### PR TITLE
Added an nuxt.config.js option srcDir

### DIFF
--- a/lib/build/index.js
+++ b/lib/build/index.js
@@ -88,18 +88,19 @@ exports.options = function () {
 }
 
 exports.build = function * () {
+  console.log(this.srcDir)
   /*
   ** Check if pages dir exists and warn if not
   */
-  if (!fs.existsSync(join(this.dir, 'pages'))) {
-    if (fs.existsSync(join(this.dir, '..', 'pages'))) {
+  if (!fs.existsSync(join(this.srcDir, 'pages'))) {
+    if (fs.existsSync(join(this.srcDir, '..', 'pages'))) {
       console.error('> No `pages` directory found. Did you mean to run `nuxt` in the parent (`../`) directory?')
     } else {
       console.error('> Couldn\'t find a `pages` directory. Please create one under the project root')
     }
     process.exit(1)
   }
-  debug(`App root: ${this.dir}`)
+  debug(`App root: ${this.srcDir}`)
   debug('Generating .nuxt/ files...')
   /*
   ** Create .nuxt/, .nuxt/components and .nuxt/dist folders
@@ -114,7 +115,7 @@ exports.build = function * () {
     if (route.component.slice(-4) !== '.vue') {
       route.component = route.component + '.vue'
     }
-    route.component = r(this.dir, route.component)
+    route.component = r(this.srcDir, route.component)
   })
   // Generate routes and interpret the template files
   yield generateRoutesAndFiles.call(this)
@@ -141,13 +142,13 @@ function * generateRoutesAndFiles () {
   /*
   ** Generate routes based on files
   */
-  const files = yield glob('pages/**/*.vue', { cwd: this.dir })
+  const files = yield glob('pages/**/*.vue', { cwd: this.srcDir })
   let routes = []
   files.forEach((file) => {
     let path = file.replace(/^pages/, '').replace(/index\.vue$/, '/').replace(/\.vue$/, '').replace(/\/{2,}/g, '/')
     let name = file.replace(/^pages/, '').replace(/\.vue$/, '').replace(/\/{2,}/g, '/').split('/').slice(1).join('-')
     if (basename(path)[0] === '_') return
-    routes.push({ path: path, component: r(this.dir, file), name: name })
+    routes.push({ path: path, component: r(this.srcDir, file), name: name })
   })
   // Concat pages routes and custom routes in this.routes
   this.routes = routes.concat(this.options.router.routes)
@@ -177,9 +178,9 @@ function * generateRoutesAndFiles () {
     head: this.options.head,
     store: this.options.store,
     css: this.options.css,
-    plugins: this.options.plugins.map((p) => r(this.dir, p)),
+    plugins: this.options.plugins.map((p) => r(this.srcDir, p)),
     appPath: './App.vue',
-    loading: (typeof this.options.loading === 'string' ? r(this.dir, this.options.loading) : this.options.loading),
+    loading: (typeof this.options.loading === 'string' ? r(this.srcDir, this.options.loading) : this.options.loading),
     transition: this.options.transition,
     components: {
       Loading: r(__dirname, '..', 'app', 'components', 'nuxt-loading.vue'),
@@ -199,16 +200,16 @@ function * generateRoutesAndFiles () {
     return r
   })
   if (files.includes('pages/_app.vue')) {
-    templateVars.appPath = r(this.dir, 'pages/_app.vue')
+    templateVars.appPath = r(this.srcDir, 'pages/_app.vue')
   }
-  if (fs.existsSync(join(this.dir, 'layouts', 'app.vue'))) {
-    templateVars.appPath = r(this.dir, 'layouts/app.vue')
+  if (fs.existsSync(join(this.srcDir, 'layouts', 'app.vue'))) {
+    templateVars.appPath = r(this.srcDir, 'layouts/app.vue')
   }
   if (files.includes('pages/_error.vue')) {
-    templateVars.components.ErrorPage = r(this.dir, 'pages/_error.vue')
+    templateVars.components.ErrorPage = r(this.srcDir, 'pages/_error.vue')
   }
-  if (fs.existsSync(join(this.dir, 'layouts', 'error.vue'))) {
-    templateVars.appPath = r(this.dir, 'layouts/error.vue')
+  if (fs.existsSync(join(this.srcDir, 'layouts', 'error.vue'))) {
+    templateVars.appPath = r(this.srcDir, 'layouts/error.vue')
   }
   let moveTemplates = templatesFiles.map((file) => {
     return readFile(r(__dirname, '..', 'app', file), 'utf8')
@@ -316,7 +317,7 @@ function createRenderer (bundle) {
 }
 
 function watchPages () {
-  const patterns = [ r(this.dir, 'pages/*.vue'), r(this.dir, 'pages/**/*.vue') ]
+  const patterns = [ r(this.srcDir, 'pages/*.vue'), r(this.srcDir, 'pages/**/*.vue') ]
   const options = {
     // ignored: '**/_*.vue',
     ignoreInitial: true

--- a/lib/build/index.js
+++ b/lib/build/index.js
@@ -88,7 +88,6 @@ exports.options = function () {
 }
 
 exports.build = function * () {
-  console.log(this.srcDir)
   /*
   ** Check if pages dir exists and warn if not
   */

--- a/lib/build/webpack/base.config.js
+++ b/lib/build/webpack/base.config.js
@@ -26,16 +26,16 @@ module.exports = function () {
     resolve: {
       // Disable for now
       alias: {
-        '~': join(this.dir),
-        'static': join(this.dir, 'static'), // use in template with <img src="~static/nuxt.png" />
-        '~static': join(this.dir, 'static'),
-        'assets': join(this.dir, 'assets'), // use in template with <img src="~static/nuxt.png" />
-        '~assets': join(this.dir, 'assets'),
-        '~plugins': join(this.dir, 'plugins'),
-        '~store': join(this.dir, 'store'),
+        '~': join(this.srcDir),
+        'static': join(this.srcDir, 'static'), // use in template with <img src="~static/nuxt.png" />
+        '~static': join(this.srcDir, 'static'),
+        'assets': join(this.srcDir, 'assets'), // use in template with <img src="~static/nuxt.png" />
+        '~assets': join(this.srcDir, 'assets'),
+        '~plugins': join(this.srcDir, 'plugins'),
+        '~store': join(this.srcDir, 'store'),
         '~router': join(this.dir, '.nuxt/router'),
-        '~pages': join(this.dir, 'pages'),
-        '~components': join(this.dir, 'components')
+        '~pages': join(this.srcDir, 'pages'),
+        '~components': join(this.srcDir, 'components')
       },
       modules: [
         nodeModulesDir,

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -33,7 +33,7 @@ module.exports = function () {
   */
   this.options.generate = _.defaultsDeep(this.options.generate, defaults)
   var self = this
-  var srcStaticPath = resolve(this.dir, 'static')
+  var srcStaticPath = resolve(this.srcDir, 'static')
   var srcBuiltPath = resolve(this.dir, '.nuxt', 'dist')
   var distPath = resolve(this.dir, this.options.generate.dir)
   var distNuxtPath = resolve(distPath, '_nuxt')

--- a/lib/nuxt.js
+++ b/lib/nuxt.js
@@ -51,7 +51,7 @@ class Nuxt {
     // Env variables
     this.dev = this.options.dev
     this.dir = (typeof options.rootDir === 'string' && options.rootDir ? options.rootDir : process.cwd())
-    this.srcDir = (typeof options.srcDir === 'string' && options.srcDir ? options.srcDir : process.cwd())
+    this.srcDir = (typeof options.srcDir === 'string' && options.srcDir ? options.srcDir : this.dir)
     // If store defined, update store options to true
     if (fs.existsSync(join(this.srcDir, 'store', 'index.js'))) {
       this.options.store = true

--- a/lib/nuxt.js
+++ b/lib/nuxt.js
@@ -51,8 +51,9 @@ class Nuxt {
     // Env variables
     this.dev = this.options.dev
     this.dir = (typeof options.rootDir === 'string' && options.rootDir ? options.rootDir : process.cwd())
+    this.srcDir = (typeof options.srcDir === 'string' && options.srcDir ? options.srcDir : process.cwd())
     // If store defined, update store options to true
-    if (fs.existsSync(join(this.dir, 'store', 'index.js'))) {
+    if (fs.existsSync(join(this.srcDir, 'store', 'index.js'))) {
       this.options.store = true
     }
     // Template
@@ -65,7 +66,7 @@ class Nuxt {
     // renderer used by Vue.js (via createBundleRenderer)
     this.renderer = null
     // For serving static/ files to /
-    this.serveStatic = pify(serveStatic(resolve(this.dir, 'static')))
+    this.serveStatic = pify(serveStatic(resolve(this.srcDir, 'static')))
     // For serving .nuxt/dist/ files
     this._nuxtRegexp = /^\/_nuxt\//
     this.serveStaticNuxt = pify(serveStatic(resolve(this.dir, '.nuxt', 'dist')))


### PR DESCRIPTION
Solution for #43.  Added an option so that you can have your files located somewhere other the root of your project.

```javascript
const { resolve } = require('path')

module.exports = {
  srcDir: resolve('./src'),
  head: {
    title: 'nuxt',
    meta: [
      { charset: 'utf-8' },
      { name: 'viewport', content: 'width=device-width, initial-scale=1' },
      { hid: 'description', content: "Nuxt.js project" }
    ],
    link: [
      { rel: 'icon', type: 'image/x-icon', href: 'favicon.ico' }
    ]
  },
  css: ['~assets/main.css']
}
```

Now you can move all your files to a src folder:

![](http://image.prntscr.com/image/4892e40783794383a5975ddbc233063c.png)
![](http://image.prntscr.com/image/ab2f363692904530acb01ed78b96672a.png)