### PR TITLE
Use `nuxt.build()` instead of promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,13 +84,10 @@ const options = {
 }
 
 // Launch nuxt build with given options
-new Nuxt(options)
-.then((nuxt) => {
-  // You can use nuxt.render(req, res) or nuxt.renderRoute(route, context)
-})
-.catch((error) {
-  // If an error appended while building the project
-})
+// TODO: you can wrap below inside try/catch to catch any errors.
+let nuxt = new Nuxt(options).build();
+// You can use nuxt.render(req, res) or nuxt.renderRoute(route, context)
+
 ```
 
 


### PR DESCRIPTION
In latest nuxt release, `generate.js` constructor returns this instead of a promise also[ Nuxt() does not call build() anymore](https://github.com/nuxt/nuxt.js/commit/43f51c402a945caa8e28e8fbd8f8cfd8c995f8ff).
This pr updates docs for correct programmatically usage.