### PR TITLE
[webpack] include project `node_modules` dir

### DIFF
--- a/lib/build/webpack/base.config.js
+++ b/lib/build/webpack/base.config.js
@@ -2,7 +2,7 @@
 
 const vueLoaderConfig = require('./vue-loader.config')
 const { defaults } = require('lodash')
-const { join } = require('path')
+const { join, resolve } = require('path')
 const { urlJoin } = require('../../utils')
 
 /*
@@ -14,7 +14,8 @@ const { urlJoin } = require('../../utils')
 |--------------------------------------------------------------------------
 */
 module.exports = function () {
-  const nodeModulesDir = join(__dirname, '..', '..', '..', 'node_modules')
+  const nodeModulesDir = resolve(__dirname, '..', '..', '..', 'node_modules')
+  const projectNodeModulesDir = resolve(nodeModulesDir, '..', '..', '..', 'node_modules')
   let config = {
     devtool: 'source-map',
     entry: {
@@ -39,12 +40,14 @@ module.exports = function () {
       },
       modules: [
         nodeModulesDir,
+        projectNodeModulesDir,
         join(this.dir, 'node_modules')
       ]
     },
     resolveLoader: {
       modules: [
         nodeModulesDir,
+        projectNodeModulesDir,
         join(this.dir, 'node_modules')
       ]
     },


### PR DESCRIPTION
In case of using nuxt inside a subdirectory of project, only two paths are included in webpack resolve path:
(Assuming nuxt project lives inside `path/to/ui` and using it as main `{project}` middleware)

- `{project}/path/to/ui/node_modules`
- `{project}/node_modules/nuxt/node_modules`

This PR also adds this to path:

- `{project}/node_modules`

We REALLY need this or we are forced to making syslinks inside submodule :)) (who likes this ugly way?:?)

**PS** the reason switching to full paths for resolver is that it makes debugging easier stripping lots of `../../../`s :))