### PR TITLE
Use spaces instead of tabs for consistency

### DIFF
--- a/lib/app/components/nuxt.vue
+++ b/lib/app/components/nuxt.vue
@@ -47,7 +47,7 @@ export default {
   },
   <% } %>
   components: {
-    NuxtError<%= (loading ? ',\n\t\tNuxtLoading' : '') %>
+    NuxtError<%= (loading ? ',\n    NuxtLoading' : '') %>
   }
 }
 </script>


### PR DESCRIPTION
Since the rest of the file is using spaces, I changed the tabs before `NuxtLoading` to spaces as well.