### PR TITLE
Update package.json

### DIFF
--- a/examples/auth-routes/package.json
+++ b/examples/auth-routes/package.json
@@ -3,6 +3,7 @@
   "description": "",
   "dependencies": {
     "body-parser": "^1.15.2",
+    "cross-env": "^3.1.3",
     "express": "^4.14.0",
     "express-session": "^1.14.2",
     "nuxt": "latest",
@@ -11,6 +12,6 @@
   "scripts": {
     "dev": "node server.js",
     "build": "nuxt build",
-    "start": "NODE_ENV=production node server.js"
+    "start": "cross-env NODE_ENV=production & node server.js"
   }
 }


### PR DESCRIPTION
On the auth-routes example the start script sets the node environment with NODE_ENV, which is not a recognised command on Windows. The work around is to use the cross-env package or to have two separate scripts, one for Windows and one for Unix based systems. I figured using the cross-env package is much more friendly and will save confusion, tested on both Windows and Mac.