### PR TITLE
Add configurable template paths

### DIFF
--- a/lib/nuxt.js
+++ b/lib/nuxt.js
@@ -40,7 +40,11 @@ class Nuxt {
         linkActiveClass: 'nuxt-link-active',
         extendRoutes: null
       },
-      build: {}
+      build: {},
+      templates: {
+        app: resolve(__dirname, 'views', 'app.html'),
+        error: resolve(__dirname, 'views', 'error.html')
+      }
     }
     if (options.loading === true) delete options.loading
     if (typeof options.transition === 'string') options.transition = { name: options.transition }
@@ -54,10 +58,10 @@ class Nuxt {
       this.options.store = true
     }
     // Template
-    this.appTemplate = _.template(fs.readFileSync(resolve(__dirname, 'views', 'app.html'), 'utf8'), {
+    this.appTemplate = _.template(fs.readFileSync(this.options.templates.app, 'utf8'), {
       imports: { serialize }
     })
-    this.errorTemplate = _.template(fs.readFileSync(resolve(__dirname, 'views', 'error.html'), 'utf8'), {
+    this.errorTemplate = _.template(fs.readFileSync(this.options.templates.error, 'utf8'), {
       imports: {
         ansiHTML,
         encodeHtml: utils.encodeHtml


### PR DESCRIPTION
I know almost every part of the [app.html](https://github.com/nuxt/nuxt.js/blob/master/lib/views/app.html) template is configurable... But I wanted to customize the `link` element and add a `media="screen"` attribute to it ([because I'm a slave to Lighthouse](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources#implementation) 😛).

I suppose eventually more devs would like to customize these templates ([error.html](https://github.com/nuxt/nuxt.js/blob/master/lib/views/error.html) is not as configurable), so this PR adds these template paths to the options.