### PR TITLE
Remove extraneous div

### DIFF
--- a/lib/app/components/nuxt.vue
+++ b/lib/app/components/nuxt.vue
@@ -1,8 +1,6 @@
 <template>
-  <div>
-    <nuxt-child v-if="!nuxt.err"></nuxt-child>
-    <nuxt-error v-if="nuxt.err" :error="nuxt.err"></nuxt-error>
-  </div>
+  <nuxt-child v-if="!nuxt.err"></nuxt-child>
+  <nuxt-error v-else :error="nuxt.err"></nuxt-error>
 </template>
 
 <script>


### PR DESCRIPTION
Vue 2.x allows multiple root elements when only one would be rendered. Using `v-if` with `v-else` ensures that only one component will get rendered.

I think this change is important because after version 1.0 is released, I feel like changes to the DOM should be kept to a minimum.