### PR TITLE
allow router mode to be set in config

### DIFF
--- a/lib/app/router.js
+++ b/lib/app/router.js
@@ -54,7 +54,7 @@ const scrollBehavior = (to, from, savedPosition) => {
 <% } %>
 
 export default new Router({
-  mode: 'history',
+  mode: '<%= router.mode %>',
   base: '<%= router.base %>',
   linkActiveClass: '<%= router.linkActiveClass %>',
   scrollBehavior,

--- a/lib/build.js
+++ b/lib/build.js
@@ -172,6 +172,7 @@ function * generateRoutesAndFiles () {
     uniqBy: _.uniqBy,
     isDev: this.dev,
     router: {
+      mode: this.options.router.mode,
       base: this.options.router.base,
       middleware: this.options.router.middleware,
       linkActiveClass: this.options.router.linkActiveClass,

--- a/lib/nuxt.js
+++ b/lib/nuxt.js
@@ -36,6 +36,7 @@ class Nuxt {
         mode: 'out-in'
       },
       router: {
+        mode: 'history',
         base: '/',
         middleware: [],
         linkActiveClass: 'nuxt-link-active',


### PR DESCRIPTION
This enables you to set `router.mode` to `null`, which will make `generate` work with `cordova` as it doesn't support history mode.