### PR TITLE
allow returning false on routeParams to prevent generating route file

### DIFF
--- a/lib/generate.js
+++ b/lib/generate.js
@@ -69,18 +69,22 @@ export default function () {
     ** Generate html files from routes
     */
     let routes = []
+    const routeKeys = Object.keys(this.options.generate.routeParams || {})
+
     this.routes.forEach((route) => {
-      if (route.includes(':') || route.includes('*')) {
+      if (route.includes(':') || route.includes('*') || routeKeys.includes(route)) {
         const routeParams = this.options.generate.routeParams[route]
-        if (!routeParams) {
+
+        if (routeParams === undefined) {
           console.error(`Could not generate the dynamic route ${route}, please add the mapping params in nuxt.config.js (generate.routeParams).`) // eslint-disable-line no-console
           return process.exit(1)
+        } else if (routeParams) {
+          route = route + '?'
+          const toPath = pathToRegexp.compile(route)
+          routes = routes.concat(routeParams.map((params) => {
+            return toPath(params)
+          }))
         }
-        route = route + '?'
-        const toPath = pathToRegexp.compile(route)
-        routes = routes.concat(routeParams.map((params) => {
-          return toPath(params)
-        }))
       } else {
         routes.push(route)
       }


### PR DESCRIPTION
i.e.

```
{
  generate: {
    routeParams: {
      '/about': () => { return false }
    }
  }
}
```

will make it so `/dist/about/index.html` won't be generated. 