### PR TITLE
allow publicPath in dev mode and do not automatically set nuxtStatic

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -328,7 +328,7 @@ function getWebpackServerConfig () {
 function createWebpackMiddleware () {
   const clientConfig = getWebpackClientConfig.call(this)
   // setup on the fly compilation + hot-reload
-  clientConfig.entry.app = _.flatten(['webpack-hot-middleware/client?reload=true', clientConfig.entry.app])
+  clientConfig.entry.app = _.flatten([`webpack-hot-middleware/client?reload=true&path=http://${host}:${port}/__webpack_hmr`, clientConfig.entry.app])
   clientConfig.plugins.push(
     new webpack.HotModuleReplacementPlugin(),
     new webpack.NoEmitOnErrorsPlugin()

--- a/lib/build.js
+++ b/lib/build.js
@@ -83,14 +83,6 @@ export function options () {
   if (this.options.build && !Array.isArray(this.options.build.loaders)) extraDefaults.loaders = defaultsLoaders
   if (this.options.build && !Array.isArray(this.options.build.postcss)) extraDefaults.postcss = defaultsPostcss
   this.options.build = _.defaultsDeep(this.options.build, defaults, extraDefaults)
-  if (this.options.build.publicPath.indexOf('http') === 0) {
-    // activate only in production mode
-    if (this.dev) {
-      this.options.build.publicPath = defaults.publicPath
-    } else {
-      this.options.nuxtStatic = false
-    }
-  }
   // Production, create server-renderer
   if (!this.dev) {
     const serverConfig = getWebpackServerConfig.call(this)

--- a/lib/render.js
+++ b/lib/render.js
@@ -80,7 +80,7 @@ export function renderRoute (url, context = {}) {
     if (!context.nuxt.serverRendered) {
       app = '<div id="__nuxt"></div>'
     }
-    const publicPath = self.options.build.publicPath.indexOf('http') === 0 ? self.options.build.publicPath : urlJoin(self.options.router.base, self.options.build.publicPath)
+    const publicPath = self.options.build.publicPath
     const html = self.appTemplate({
       dev: self.dev, // Use to add the extracted CSS <link> in production
       baseUrl: self.options.router.base,


### PR DESCRIPTION
This refers to #25 and will allow you to use CDN's like cloudfront by setting the `build.publicPath`, it will also allow you to use nuxt with platforms like cordova because in `dev` mode you need to point to the full internal ip path like `http://${host}:${port}/_nuxt/` to run on emulators or connected devices.