### PR TITLE
Warn on `npm install nuxt` when using an untargeted version of node or npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,10 @@
     "precommit": "npm run lint",
     "prepublish": "npm run build"
   },
+  "engines": {
+    "node": ">=4.3.0 <5.0.0 || >=5.10",
+    "npm": ">=3.0.0"
+  },
   "dependencies": {
     "ansi-html": "^0.0.7",
     "autoprefixer": "^6.7.2",


### PR DESCRIPTION
I borrowed the node engines string from webpack's `package.json` because a warning for that is already thrown at those versions when installing nuxt. In my testing, nuxt appeared to work with a simple example down to v4.0.0 of node so feel free to change the string to ">4.0.0".

Anything below npm@3.0.0 failed for me, so I set an engines string for that as well. 