### PR TITLE
Support extract manifest file from vendor.js

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -52,7 +52,8 @@ const defaults = {
   filenames: {
     css: 'style.css',
     vendor: 'vendor.bundle.js',
-    app: 'nuxt.bundle.js'
+    app: 'nuxt.bundle.js',
+    manifest: 'manifest.js'
   },
   vendor: [],
   loaders: [],

--- a/lib/render.js
+++ b/lib/render.js
@@ -3,6 +3,10 @@
 const debug = require('debug')('nuxt:render')
 import co from 'co'
 import { urlJoin, getContext } from './utils'
+import fs from 'fs-extra'
+import { resolve, join } from 'path'
+
+var manifestObject
 // force blue color
 debug.color = 4
 
@@ -64,6 +68,25 @@ export function render (req, res) {
   })
 }
 
+function getGeneratedAssetPath(srcPath) {
+  let lastPart, filename
+  if (srcPath.indexOf('/') !== -1) {
+    let parts = srcPath.split('/')
+    lastPart = parts[parts.length - 1]
+  } else {
+    lastPart = srcPath
+  }
+  filename = lastPart.replace(/\[.+\]/, '').replace('..', '.')
+
+  if (typeof manifestObject === 'undefined') {
+    let path = this.options.rootDir
+    let manifestPath = resolve(this.dir, '.nuxt', 'dist', 'manifest.json')
+    manifestObject = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  }
+
+  return manifestObject[filename]
+}
+
 export function renderRoute (url, context = {}) {
   debug(`Rendering url ${url}`)
   // Add url and isSever to the context
@@ -76,16 +99,17 @@ export function renderRoute (url, context = {}) {
     if (!context.nuxt.serverRendered) {
       app = '<div id="__nuxt"></div>'
     }
+
     const html = self.appTemplate({
       dev: self.dev, // Use to add the extracted CSS <link> in production
       baseUrl: self.options.router.base,
       APP: app,
       context: context,
       files: {
-        css: urlJoin(self.options.router.base, '/_nuxt/', self.options.build.filenames.css),
-        vendor: urlJoin(self.options.router.base, '/_nuxt/', self.options.build.filenames.vendor),
-        app: urlJoin(self.options.router.base, '/_nuxt/', self.options.build.filenames.app),
-        manifest: self.options.extractManifest ? urlJoin(self.options.router.base, '/_nuxt/', self.options.build.filenames.manifest) : undefined
+        css: urlJoin(self.options.router.base, '/_nuxt/', getGeneratedAssetPath.call(self, self.options.build.filenames.css)),
+        vendor: urlJoin(self.options.router.base, '/_nuxt/', getGeneratedAssetPath.call(self, self.options.build.filenames.vendor)),
+        app: urlJoin(self.options.router.base, '/_nuxt/', getGeneratedAssetPath.call(self, self.options.build.filenames.app)),
+        manifest: self.options.extractManifest ? urlJoin(self.options.router.base, '/_nuxt/', getGeneratedAssetPath.call(self, self.options.build.filenames.manifest)) : undefined
       }
     })
     return {

--- a/lib/render.js
+++ b/lib/render.js
@@ -84,7 +84,8 @@ export function renderRoute (url, context = {}) {
       files: {
         css: urlJoin(self.options.router.base, '/_nuxt/', self.options.build.filenames.css),
         vendor: urlJoin(self.options.router.base, '/_nuxt/', self.options.build.filenames.vendor),
-        app: urlJoin(self.options.router.base, '/_nuxt/', self.options.build.filenames.app)
+        app: urlJoin(self.options.router.base, '/_nuxt/', self.options.build.filenames.app),
+        manifest: self.options.extractManifest ? urlJoin(self.options.router.base, '/_nuxt/', self.options.build.filenames.manifest) : undefined
       }
     })
     return {

--- a/lib/views/app.html
+++ b/lib/views/app.html
@@ -13,6 +13,7 @@
   <body <%= m.bodyAttrs.text() %>>
     <%= APP %>
     <script type="text/javascript" defer>window.__NUXT__=<%= serialize(context.nuxt, { isJSON: true }) %></script>
+    <% if (files.manifest) { %><script src="<%= files.manifest %>" defer></script><% } %>
     <script src="<%= files.vendor %>" defer></script>
     <script src="<%= files.app %>" defer></script>
   </body>

--- a/lib/webpack/client.config.js
+++ b/lib/webpack/client.config.js
@@ -92,13 +92,6 @@ export default function () {
       isClient: true
     })
   }
-  
-  const self = this;
-  config.plugins.some(function(item, index) {
-    if (item.constructor.name == 'CommonsChunkPlugin' && item.chunkNames != 'vendor') {
-      self.options.extractManifest = true;
-    }
-  });
 
   // Webpack Bundle Analyzer
   if (!this.dev && this.options.build.analyze) {

--- a/lib/webpack/client.config.js
+++ b/lib/webpack/client.config.js
@@ -53,6 +53,13 @@ export default function () {
     })
   ])
 
+  if (this.options.extractManifest) {
+    config.plugins.push(new webpack.optimize.CommonsChunkPlugin({
+      name: 'manifest',
+      filename: this.options.build.filenames.manifest
+    }))
+  }
+
   // client bundle progress bar
   config.plugins.push(
     new ProgressBarPlugin()
@@ -85,6 +92,14 @@ export default function () {
       isClient: true
     })
   }
+  
+  const self = this;
+  config.plugins.some(function(item, index) {
+    if (item.constructor.name == 'CommonsChunkPlugin' && item.chunkNames != 'vendor') {
+      self.options.extractManifest = true;
+    }
+  });
+
   // Webpack Bundle Analyzer
   if (!this.dev && this.options.build.analyze) {
     let options = {}

--- a/lib/webpack/client.config.js
+++ b/lib/webpack/client.config.js
@@ -5,6 +5,7 @@ import webpack from 'webpack'
 import ExtractTextPlugin from 'extract-text-webpack-plugin'
 import ProgressBarPlugin from 'progress-bar-webpack-plugin'
 import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer'
+import ManifestPlugin from 'webpack-manifest-plugin'
 import base from './base.config.js'
 import { resolve } from 'path'
 /*
@@ -52,13 +53,19 @@ export default function () {
       filename: this.options.build.filenames.vendor
     })
   ])
-
+  // Extract manifest chunk for better caching
   if (this.options.extractManifest) {
     config.plugins.push(new webpack.optimize.CommonsChunkPlugin({
       name: 'manifest',
       filename: this.options.build.filenames.manifest
     }))
   }
+
+  config.plugins.push(
+    new ManifestPlugin({
+      writeToFileEmit: true
+    })
+  )
 
   // client bundle progress bar
   config.plugins.push(

--- a/package.json
+++ b/package.json
@@ -91,7 +91,8 @@
     "webpack": "^2.2.1",
     "webpack-bundle-analyzer": "^2.2.3",
     "webpack-dev-middleware": "^1.10.0",
-    "webpack-hot-middleware": "^2.16.1"
+    "webpack-hot-middleware": "^2.16.1",
+    "webpack-manifest-plugin": "^1.1.0"
   },
   "devDependencies": {
     "ava": "^0.18.1",


### PR DESCRIPTION
Support extract manifest.js from vendor.js to make vendor.js be cached longer. Users only need to add `extractManifest: true` to the nuxt.config.js file, and if they want to customize the file name, they can add  `filenames : { manifest: 'common.js' }`