### PR TITLE
Typo fix, const must be renamed clientCompiler

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -386,8 +386,8 @@ function webpackWatchAndUpdate () {
 function webpackRunClient () {
   return new Promise((resolve, reject) => {
     const clientConfig = getWebpackClientConfig.call(this)
-    const serverCompiler = webpack(clientConfig)
-    serverCompiler.run((err, stats) => {
+    const clientCompiler = webpack(clientConfig)
+    clientCompiler.run((err, stats) => {
       if (err) return reject(err)
       console.log('[nuxt:build:client]\n', stats.toString(webpackStats)) // eslint-disable-line no-console
       if (stats.hasErrors()) return reject('Webpack build exited with errors')


### PR DESCRIPTION
From orignal issue: Variable name misused #409