### PR TITLE
Bump Nuxt and Vuetify versions in "with-vuetify"-example

### DIFF
--- a/examples/with-vuetify/README.md
+++ b/examples/with-vuetify/README.md
@@ -2,5 +2,3 @@
 
 https://nuxtjs.org/examples/with-vuetify<br>
 https://vuetifyjs.com/
-
-*NOTE: Some Vuetify components needs Vue v2.2.x (or later) to work properly (Nuxt currently uses v2.1.x)*

--- a/examples/with-vuetify/package.json
+++ b/examples/with-vuetify/package.json
@@ -1,8 +1,8 @@
 {
   "name": "with-vuetify",
   "dependencies": {
-    "nuxt": "latest",
-    "vuetify": "^0.9.1"
+    "nuxt": "0.10",
+    "vuetify": "0.9.4"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/with-vuetify/pages/index.vue
+++ b/examples/with-vuetify/pages/index.vue
@@ -7,7 +7,7 @@
     <main>
       <v-sidebar left fixed drawer v-model="sidebar">
         <v-list>
-          <v-list-item v-for="i in 3">
+          <v-list-item v-for="i in 3" :key="i">
             <v-list-tile>
               <v-list-tile-title>Item {{ i }}</v-list-tile-title>
             </v-list-tile>
@@ -30,7 +30,7 @@
 
 <script>
   export default {
-    data() {
+    asyncData() {
       return {
         sidebar: false
       }


### PR DESCRIPTION
Vuetify-components should now work properly (as Nuxt now uses Vue v2.2+)