### PR TITLE
Support other implementations of Promises inside nuxtServerInit (currently only HTML5 Promises works correctly)

### DIFF
--- a/lib/app/client.js
+++ b/lib/app/client.js
@@ -166,7 +166,7 @@ function render (to, from, next) {
       }
       if (Component.options.fetch) {
         var p = Component.options.fetch(context)
-        if (!(p instanceof Promise)) { p = Promise.resolve(p) }
+        if (!p || (!(p instanceof Promise) && (typeof p.then !== 'function'))) { p = Promise.resolve(p) }
         <%= (loading ? 'p.then(() => this.$loading.increase && this.$loading.increase(30))' : '') %>
         promises.push(p)
       }
@@ -318,7 +318,7 @@ function addHotReload ($component, depth) {
       // Call fetch()
       Component.options.fetch = Component.options.fetch || noopFetch
       let pFetch = Component.options.fetch(context)
-      if (!(pFetch instanceof Promise)) { pFetch = Promise.resolve(pFetch) }
+      if (!pFetch || (!(pFetch instanceof Promise) && (typeof pFetch.then !== 'function'))) { pFetch = Promise.resolve(pFetch) }
       <%= (loading ? 'pFetch.then(() => this.$loading.increase && this.$loading.increase(30))' : '') %>
       promises.push(pFetch)
       return Promise.all(promises)

--- a/lib/app/server.js
+++ b/lib/app/server.js
@@ -81,7 +81,7 @@ export default context => {
     // nuxtServerInit
     <% if (store) { %>
       let promise = (store._actions && store._actions.nuxtServerInit ? store.dispatch('nuxtServerInit', omit(getContext(context), 'redirect', 'error')) : null)
-      if (!(promise instanceof Promise)) promise = Promise.resolve()
+      if (!promise || (!(promise instanceof Promise) && (promise && typeof promise.then !== 'function'))) promise = Promise.resolve()
     <% } else { %>
       let promise = Promise.resolve()
     <% } %>

--- a/lib/app/server.js
+++ b/lib/app/server.js
@@ -81,7 +81,7 @@ export default context => {
     // nuxtServerInit
     <% if (store) { %>
       let promise = (store._actions && store._actions.nuxtServerInit ? store.dispatch('nuxtServerInit', omit(getContext(context), 'redirect', 'error')) : null)
-      if (!promise || (!(promise instanceof Promise) && (promise && typeof promise.then !== 'function'))) promise = Promise.resolve()
+      if (!promise || (!(promise instanceof Promise) && (typeof promise.then !== 'function'))) promise = Promise.resolve()
     <% } else { %>
       let promise = Promise.resolve()
     <% } %>

--- a/lib/app/utils.js
+++ b/lib/app/utils.js
@@ -84,7 +84,7 @@ export function promisify (fn, context) {
   } else {
     promise = fn(context)
   }
-  if (!(promise instanceof Promise)) {
+  if (!promise || (!(promise instanceof Promise) && (typeof promise.then !== 'function')))
     promise = Promise.resolve(promise)
   }
   return promise

--- a/lib/app/utils.js
+++ b/lib/app/utils.js
@@ -84,7 +84,7 @@ export function promisify (fn, context) {
   } else {
     promise = fn(context)
   }
-  if (!promise || (!(promise instanceof Promise) && (typeof promise.then !== 'function')))
+  if (!promise || (!(promise instanceof Promise) && (typeof promise.then !== 'function'))) {
     promise = Promise.resolve(promise)
   }
   return promise

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -52,7 +52,7 @@ export function promisifyRoute (fn) {
     })
   }
   let promise = fn()
-  if (!promise || (!(promise instanceof Promise) && (typeof promise.then !== 'function')))
+  if (!promise || (!(promise instanceof Promise) && (typeof promise.then !== 'function'))) {
     promise = Promise.resolve(promise)
   }
   return promise

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -52,7 +52,7 @@ export function promisifyRoute (fn) {
     })
   }
   let promise = fn()
-  if (!(promise instanceof Promise)) {
+  if (!promise || (!(promise instanceof Promise) && (typeof promise.then !== 'function')))
     promise = Promise.resolve(promise)
   }
   return promise


### PR DESCRIPTION
Fix for using for exapmle Axios promises in nuxtServerInit() without wrapping it to HTML5 Promise