### PR TITLE
pass 'this nuxt' context in extend webpack config

### DIFF
--- a/lib/webpack/client.config.js
+++ b/lib/webpack/client.config.js
@@ -105,7 +105,7 @@ export default function () {
   }
   // Extend config
   if (typeof this.options.build.extend === 'function') {
-    this.options.build.extend(config, {
+    this.options.build.extend.call(this, config, {
       dev: this.dev,
       isClient: true
     })


### PR DESCRIPTION
// nuxt.config
```
build: {
    extend (config, {dev, isClient}) {
      // get this context here
      config.resolve.alias['~services'] = join(this.srcDir, 'services');
    },
}
```