### PR TITLE
make use of runInNewContext: false

### DIFF
--- a/lib/app/client.js
+++ b/lib/app/client.js
@@ -2,12 +2,14 @@
 
 import Vue from 'vue'
 import middleware from './middleware'
-import { app, router<%= (store ? ', store' : '') %>, NuxtError } from './index'
+import { createApp, NuxtError } from './index'
 import { applyAsyncData, getMatchedComponents, getMatchedComponentsInstances, flatMapComponents, getContext, promiseSeries, promisify, getLocation, compile } from './utils'
 const noopData = () => { return {} }
 const noopFetch = () => {}
 let _lastPaths = []
 let _lastComponentsFiles = []
+
+const { app, router<%= (store ? ', store' : '') %> } = createApp()
 
 function mapTransitions(Components, to, from) {
   return Components.map((Component) => {

--- a/lib/app/index.js
+++ b/lib/app/index.js
@@ -2,8 +2,8 @@
 
 import Vue from 'vue'
 import Meta from 'vue-meta'
-import router from './router.js'
-<% if (store) { %>import store from './store.js'<% } %>
+import { createRouter } from './router.js'
+<% if (store) { %>import { createStore } from './store.js'<% } %>
 import NuxtChild from './components/nuxt-child.js'
 import NuxtLink from './components/nuxt-link.js'
 import NuxtError from '<%= components.ErrorPage ? components.ErrorPage : "./components/nuxt-error.vue" %>'
@@ -25,86 +25,95 @@ Vue.use(Meta, {
   tagIDKeyName: 'hid' // the property name that vue-meta uses to determine whether to overwrite or append a tag
 })
 
-if (process.browser) {
-  <% if (store) { %>
-  // Replace store state before calling plugins
-  if (window.__NUXT__ && window.__NUXT__.state) {
-    store.replaceState(window.__NUXT__.state)
-  }
-  <% } %>
-  // window.onNuxtReady(() => console.log('Ready')) hook
-  // Useful for jsdom testing or plugins (https://github.com/tmpvar/jsdom#dealing-with-asynchronous-script-loading)
-  window._nuxtReadyCbs = []
-  window.onNuxtReady = function (cb) {
-    window._nuxtReadyCbs.push(cb)
-  }
-}
-
-// root instance
-// here we inject the router and store to all child components,
-// making them available everywhere as `this.$router` and `this.$store`.
 const defaultTransition = <%=
-serialize(transition)
-.replace('beforeEnter(', 'function(').replace('enter(', 'function(').replace('afterEnter(', 'function(')
-.replace('enterCancelled(', 'function(').replace('beforeLeave(', 'function(').replace('leave(', 'function(')
-.replace('afterLeave(', 'function(').replace('leaveCancelled(', 'function(')
-%>
-let app = {
-  router,
-  <%= (store ? 'store,' : '') %>
-  _nuxt: {
-    defaultTransition: defaultTransition,
-    transitions: [ defaultTransition ],
-    setTransitions (transitions) {
-      if (!Array.isArray(transitions)) {
-        transitions = [ transitions ]
-      }
-      transitions = transitions.map((transition) => {
-        if (!transition) {
-          transition = defaultTransition
-        } else if (typeof transition === 'string') {
-          transition = Object.assign({}, defaultTransition, { name: transition })
-        } else {
-          transition = Object.assign({}, defaultTransition, transition)
-        }
-        return transition
-      })
-      this.$options._nuxt.transitions = transitions
-      return transitions
-    },
-    err: null,
-    dateErr: null,
-    error (err) {
-      err = err || null
-      if (typeof err === 'string') {
-        err = { statusCode: 500, message: err }
-      }
-      this.$options._nuxt.dateErr = Date.now()
-      this.$options._nuxt.err = err;
-      return err
+  serialize(transition)
+  .replace('beforeEnter(', 'function(').replace('enter(', 'function(').replace('afterEnter(', 'function(')
+  .replace('enterCancelled(', 'function(').replace('beforeLeave(', 'function(').replace('leave(', 'function(')
+  .replace('afterLeave(', 'function(').replace('leaveCancelled(', 'function(')
+  %>
+
+export { NuxtError }
+
+export function createApp (ssrContext) {
+  const store = createStore()
+  const router = createRouter()
+
+  if (process.browser) {
+    <% if (store) { %>
+    // Replace store state before calling plugins
+    if (window.__NUXT__ && window.__NUXT__.state) {
+      store.replaceState(window.__NUXT__.state)
     }
-  },
-  ...App
-}
+    <% } %>
+    // window.onNuxtReady(() => console.log('Ready')) hook
+    // Useful for jsdom testing or plugins (https://github.com/tmpvar/jsdom#dealing-with-asynchronous-script-loading)
+    window._nuxtReadyCbs = []
+    window.onNuxtReady = function (cb) {
+      window._nuxtReadyCbs.push(cb)
+    }
+  }
+
+  // root instance
+  // here we inject the router and store to all child components,
+  // making them available everywhere as `this.$router` and `this.$store`.
+  let app = {
+    router,
+    <%= (store ? 'store,' : '') %>
+    ssrContext,
+    _nuxt: {
+      defaultTransition: defaultTransition,
+      transitions: [ defaultTransition ],
+      setTransitions (transitions) {
+        if (!Array.isArray(transitions)) {
+          transitions = [ transitions ]
+        }
+        transitions = transitions.map((transition) => {
+          if (!transition) {
+            transition = defaultTransition
+          } else if (typeof transition === 'string') {
+            transition = Object.assign({}, defaultTransition, { name: transition })
+          } else {
+            transition = Object.assign({}, defaultTransition, transition)
+          }
+          return transition
+        })
+        this.$options._nuxt.transitions = transitions
+        return transitions
+      },
+      err: null,
+      dateErr: null,
+      error (err) {
+        err = err || null
+        if (typeof err === 'string') {
+          err = { statusCode: 500, message: err }
+        }
+        this.$options._nuxt.dateErr = Date.now()
+        this.$options._nuxt.err = err;
+        return err
+      }
+    },
+    ...App
+  }
 
 
-// Includes & Inject external plugins
-<% plugins.forEach(function (plugin) {
-if (plugin.ssr) { %>
-<%= (plugin.injectAs ? 'let ' + plugin.injectAs + ' = ' : '') %>require('<%= plugin.src %>')
-<% if (plugin.injectAs) { %>
-<%= plugin.injectAs + ' = ' + plugin.injectAs + '.default || ' + plugin.injectAs %>
-app['<%= plugin.injectAs %>'] = <%= plugin.injectAs %>
-<% }
-} else { %>
-if (process.browser) {
+  // Includes & Inject external plugins
+  <% plugins.forEach(function (plugin) {
+  if (plugin.ssr) { %>
   <%= (plugin.injectAs ? 'let ' + plugin.injectAs + ' = ' : '') %>require('<%= plugin.src %>')
   <% if (plugin.injectAs) { %>
   <%= plugin.injectAs + ' = ' + plugin.injectAs + '.default || ' + plugin.injectAs %>
   app['<%= plugin.injectAs %>'] = <%= plugin.injectAs %>
-  <% } %>
-}
-<% }
-}) %>
+  <% }
+  } else { %>
+  if (process.browser) {
+    <%= (plugin.injectAs ? 'let ' + plugin.injectAs + ' = ' : '') %>require('<%= plugin.src %>')
+    <% if (plugin.injectAs) { %>
+    <%= plugin.injectAs + ' = ' + plugin.injectAs + '.default || ' + plugin.injectAs %>
+    app['<%= plugin.injectAs %>'] = <%= plugin.injectAs %>
+    <% } %>
+  }
+  <% }
+  }) %>
 
-export { app, router<%= (store ? ', store' : '') %>, NuxtError }
+  return { app, router<%= (store ? ', store' : '') %> }
+}

--- a/lib/app/router.js
+++ b/lib/app/router.js
@@ -53,12 +53,14 @@ const scrollBehavior = (to, from, savedPosition) => {
 }
 <% } %>
 
-export default new Router({
-  mode: '<%= router.mode %>',
-  base: '<%= router.base %>',
-  linkActiveClass: '<%= router.linkActiveClass %>',
-  scrollBehavior,
-  routes: [
-<%= _routes %>
-  ]
-})
+export function createRouter () {
+  return new Router({
+    mode: '<%= router.mode %>',
+    base: '<%= router.base %>',
+    linkActiveClass: '<%= router.linkActiveClass %>',
+    scrollBehavior,
+    routes: [
+  <%= _routes %>
+    ]
+  })
+}

--- a/lib/app/server.js
+++ b/lib/app/server.js
@@ -7,11 +7,10 @@ import Vue from 'vue'
 import { stringify } from 'querystring'
 import { omit } from 'lodash'
 import middleware from './middleware'
-import { app, router<%= (store ? ', store' : '') %>, NuxtError } from './index'
+import { createApp, NuxtError } from './index'
 import { applyAsyncData, getMatchedComponents, getContext, promiseSeries, promisify, urlJoin } from './utils'
 
 const isDev = <%= isDev %>
-const _app = new Vue(app)
 
 // This exported function will be called by `bundleRenderer`.
 // This is where we perform data-prefetching to determine the
@@ -19,6 +18,8 @@ const _app = new Vue(app)
 // Since data fetching is async, this function is expected to
 // return a Promise that resolves to the app instance.
 export default context => {
+  const { app, router<%= (store ? ', store' : '') %> } = createApp(context)
+  const _app = new Vue(app)
   // Add store to the context
   <%= (store ? 'context.store = store' : '') %>
   // Nuxt object

--- a/lib/app/store.js
+++ b/lib/app/store.js
@@ -30,8 +30,11 @@ let storeData = {}
 if (filenames.indexOf('./index.js') !== -1) {
   let mainModule = getModule('./index.js')
   if (mainModule.commit) {
-    store = mainModule
+    console.error('[nuxt.js] store/index.js should export raw store options instead of an instance.')
   } else {
+    if (mainModule.state && typeof mainModule.state !== 'function') {
+      console.error('[nuxt.js] store state should be a function.')
+    }
     storeData = mainModule
   }
 }
@@ -49,8 +52,13 @@ if (store == null) {
     name = namePath.pop()
     module[name] = getModule(filename)
     module[name].namespaced = true
+
+    if (typeof module[name].state !== 'function') {
+      console.error('[nuxt.js] store module state should be a function.')
+    }
   }
-  store = new Vuex.Store(storeData)
 }
 
-export default store
+export function createStore () {
+  return new Vuex.Store(storeData)
+}

--- a/lib/build.js
+++ b/lib/build.js
@@ -464,7 +464,8 @@ function createRenderer (bundle) {
     }))
   }
   this.renderer = createBundleRenderer(bundle, {
-    cache: cacheConfig
+    cache: cacheConfig,
+    runInNewContext: false
   })
   this.renderToString = pify(this.renderer.renderToString)
   this.renderToStream = this.renderer.renderToStream


### PR DESCRIPTION
This PR contains changes necessary to make use of the new `runInNewContext: false` option introduced in 2.3.

The changes are implemented and tested on top of https://github.com/nuxt/nuxt.js/pull/633 and should be merged after it. (This is probably why CI is broken, this is mainly submitted to show the diffs, I can re-submit after #633 is merged as well)

**This introduces breaking changes.** Most notably the user will have to avoid global singletons in their code as explained [here](https://ssr.vuejs.org/en/structure.html). Also, in [store.js](https://github.com/yyx990803/nuxt.js/blob/context/lib/app/store.js#L33) we have to add a few warnings to require user store and modules to use functions for `state`.

It's possible to maintain backwards compat by making this whole thing behind a config option, but I think this really should be the new default.

Perf comparison for an out-of-the-box Nuxt app using `vue init nuxt/starter` with `ab -n 1000`:

### Before

```
Concurrency Level:      1
Time taken for tests:   10.904 seconds
Complete requests:      1000
Failed requests:        0
Total transferred:      4531000 bytes
HTML transferred:       4371000 bytes
Requests per second:    91.71 [#/sec] (mean)
Time per request:       10.904 [ms] (mean)
Time per request:       10.904 [ms] (mean, across all concurrent requests)
Transfer rate:          405.81 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.1      0       1
Processing:     6   11   6.5      9      92
Waiting:        6   11   6.4      9      91
Total:          6   11   6.5      9      92

Percentage of the requests served within a certain time (ms)
  50%      9
  66%     10
  75%     10
  80%     11
  90%     13
  95%     23
  98%     32
  99%     35
 100%     92 (longest request)
```

### After

```
Concurrency Level:      1
Time taken for tests:   2.126 seconds
Complete requests:      1000
Failed requests:        0
Total transferred:      4531000 bytes
HTML transferred:       4371000 bytes
Requests per second:    470.41 [#/sec] (mean)
Time per request:       2.126 [ms] (mean)
Time per request:       2.126 [ms] (mean, across all concurrent requests)
Transfer rate:          2081.49 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.1      0       1
Processing:     1    2   1.8      1      17
Waiting:        1    2   1.8      1      17
Total:          1    2   1.8      1      17

Percentage of the requests served within a certain time (ms)
  50%      1
  66%      2
  75%      2
  80%      2
  90%      3
  95%      5
  98%      9
  99%     13
 100%     17 (longest request)
```