### PR TITLE
added sourcemaps support to scss-loader and css-loader

### DIFF
--- a/lib/webpack/helpers.js
+++ b/lib/webpack/helpers.js
@@ -7,9 +7,9 @@ export function extractStyles () {
 export function styleLoader (ext, loader = []) {
   if (extractStyles.call(this)) {
     return ExtractTextPlugin.extract({
-      use: ['css-loader?minimize'].concat(loader),
-      fallback: 'vue-style-loader'
+      use: ['css-loader?minify&sourceMap'].concat(loader),
+      fallback: 'vue-style-loader?sourceMap'
     })
   }
-  return ['vue-style-loader', 'css-loader'].concat(loader)
+  return ['vue-style-loader?sourceMap', 'css-loader?sourceMap'].concat(loader)
 }

--- a/lib/webpack/vue-loader.config.js
+++ b/lib/webpack/vue-loader.config.js
@@ -18,7 +18,7 @@ export default function ({ isClient }) {
       'css': styleLoader.call(this, 'css'),
       'less': styleLoader.call(this, 'less', 'less-loader'),
       'sass': styleLoader.call(this, 'sass', 'sass-loader?indentedSyntax'),
-      'scss': styleLoader.call(this, 'sass', 'sass-loader'),
+      'scss': styleLoader.call(this, 'sass', 'sass-loader?sourceMap'),
       'stylus': styleLoader.call(this, 'stylus', 'stylus-loader'),
       'styl': styleLoader.call(this, 'stylus', 'stylus-loader')
     },


### PR DESCRIPTION
I'll be the first to admit I know nothing about webpack, but randomly pasting in `?sourceMap` worked pretty well -- the Chrome Inspector now shows me which Bootstrap sass source file generated the css  for a particular html element. Very cool. 

This might be needed for stylus and less as well. 