### PR TITLE
Add linkExactActiveClass to router options

### DIFF
--- a/lib/app/router.js
+++ b/lib/app/router.js
@@ -58,6 +58,7 @@ export function createRouter () {
     mode: '<%= router.mode %>',
     base: '<%= router.base %>',
     linkActiveClass: '<%= router.linkActiveClass %>',
+    linkExactActiveClass: '<%= router.linkExactActiveClass %>',
     scrollBehavior,
     routes: [
   <%= _routes %>

--- a/lib/nuxt.js
+++ b/lib/nuxt.js
@@ -37,6 +37,7 @@ class Nuxt {
         base: '/',
         middleware: [],
         linkActiveClass: 'nuxt-link-active',
+        linkExactActiveClass: 'nuxt-link-exact-active',
         extendRoutes: null,
         scrollBehavior: null
       },


### PR DESCRIPTION
From version 2.5.0+ router-link support exact path match.
https://router.vuejs.org/en/api/options.html#linkexactactiveclass