### PR TITLE
Set proper maxAge headers for /static files

### DIFF
--- a/lib/nuxt.js
+++ b/lib/nuxt.js
@@ -90,7 +90,9 @@ class Nuxt {
     // renderer used by Vue.js (via createBundleRenderer)
     this.renderer = null
     // For serving static/ files to /
-    this.serveStatic = pify(serveStatic(resolve(this.srcDir, 'static')))
+    this.serveStatic = pify(serveStatic(resolve(this.srcDir, 'static'), {
+      maxAge: (this.dev ? 0 : '1y') // 1 year in production
+    }))
     // For serving .nuxt/dist/ files (only when build.publicPath is not an URL)
     this.serveStaticNuxt = pify(serveStatic(resolve(this.dir, '.nuxt', 'dist'), {
       maxAge: (this.dev ? 0 : '1y') // 1 year in production


### PR DESCRIPTION
Files in the /static dir seem to not have the proper expire headers. They serve as "max-age=0". 

The user's browser does a request to static files on each page load, which is not best practice. Also, services like CloudFlare won't pick up on those files and so you miss their CDN capabilities.

This PR fixes that.