### PR TITLE
Fix class component typeerror when using nuxt1.0.0-alpha

### DIFF
--- a/lib/app/server.js
+++ b/lib/app/server.js
@@ -52,7 +52,7 @@ export default async (context) => {
   let Components = []
   let promises = getMatchedComponents(router.match(context.url)).map((Component) => {
     return new Promise((resolve, reject) => {
-      if (typeof Component !== 'function') return resolve(sanitizeComponent(Component))
+      if (typeof Component !== 'function' || Component.super === Vue) return resolve(sanitizeComponent(Component))
       const _resolve = (Component) => resolve(sanitizeComponent(Component))
       Component().then(_resolve).catch(reject)
     })


### PR DESCRIPTION
 Nuxt 1.0.0 introduced Vue 2.3.x, but when using vue-class-component to declare component, it will throw exception: `TypeError: Cannot read property '_init' of undefined.`

The reason is :
1. In Nuxt lib/app/server.js, if Component defined in router is not function, it will be treated as a promise.
2. Component declared in Router at first is a promise (a webpack import), but the import was resolved in advance due to [change in vue-router 2.5.x] (https://github.com/vuejs/vue-router/commit/d763544cde7a21a87ef7d557458f92f43360dd34)