### PR TITLE
[Feature: generate] optimize rendering step in generate

### DIFF
--- a/lib/app/utils.js
+++ b/lib/app/utils.js
@@ -61,7 +61,7 @@ export function getContext (context, app) {
     app: app,
     <%= (store ? 'store: context.store,' : '') %>
     route: (context.to ? context.to : context.route),
-    routePayload : context.routePayload,
+    generatePayload : context.generatePayload,
     error: context.error,
     base: '<%= router.base %>',
     env: <%= JSON.stringify(env) %>

--- a/lib/app/utils.js
+++ b/lib/app/utils.js
@@ -61,6 +61,7 @@ export function getContext (context, app) {
     app: app,
     <%= (store ? 'store: context.store,' : '') %>
     route: (context.to ? context.to : context.route),
+    routePayload : context.routePayload,
     error: context.error,
     base: '<%= router.base %>',
     env: <%= JSON.stringify(env) %>

--- a/lib/app/utils.js
+++ b/lib/app/utils.js
@@ -61,7 +61,7 @@ export function getContext (context, app) {
     app: app,
     <%= (store ? 'store: context.store,' : '') %>
     route: (context.to ? context.to : context.route),
-    generatePayload : context.generatePayload,
+    payload : context.payload,
     error: context.error,
     base: '<%= router.base %>',
     env: <%= JSON.stringify(env) %>

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -103,7 +103,7 @@ export default async function () {
       await waitFor(n++ * this.options.generate.interval)
       let html
       try {
-        const res = await this.renderRoute(route, { _generate: true, generatePayload: payload })
+        const res = await this.renderRoute(route, { _generate: true, payload })
         html = res.html
         if (res.error) {
           errors.push({ type: 'handled', route, error: res.error })

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -78,26 +78,30 @@ export default async function () {
       process.exit(1)
       throw e // eslint-disable-line no-unreachable
     }
-    /*
-    ** Generate html files from routes
-    */
-    generateRoutes.forEach((route) => {
-      if (this.routes.indexOf(route) < 0) {
-        this.routes.push(route)
+  }
+  function decorateWithPayloads (routes) {
+    let routeMap = _(routes).map((route) => {
+      return [route, {route, routePayload: {}}]
+    }).fromPairs().value()
+    generateRoutes.forEach(({route, routePayload}) => {
+      if (!routeMap[route]) {
+        routeMap[route] = {route, routePayload}
       }
     })
+    return _.values(routeMap)
   }
   /*
   ** Generate only index.html for router.mode = 'hash'
   */
-  let routes = (this.options.router.mode === 'hash') ? ['/'] : this.routes
+  let routes = (this.options.router.mode === 'hash') ? [{route: '/'}] : decorateWithPayloads(this.routes)
+
   while (routes.length) {
     let n = 0
-    await Promise.all(routes.splice(0, 500).map(async (route) => {
+    await Promise.all(routes.splice(0, 500).map(async ({route, routePayload}) => {
       await waitFor(n++ * this.options.generate.interval)
       let html
       try {
-        const res = await this.renderRoute(route, { _generate: true })
+        const res = await this.renderRoute(route, { _generate: true, routePayload })
         html = res.html
         if (res.error) {
           errors.push({ type: 'handled', route, error: res.error })

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -81,11 +81,13 @@ export default async function () {
   }
   function decorateWithPayloads (routes) {
     let routeMap = _(routes).map((route) => {
-      return [route, {route, routePayload: {}}]
+      return [route, {route, payload: {}}]
     }).fromPairs().value()
-    generateRoutes.forEach(({route, routePayload}) => {
+    generateRoutes.forEach((route) => {
+      // route argument is either a string or like {route : "/my_route/1"}
+      route = _.isString(route) ? route : route.route
       if (!routeMap[route]) {
-        routeMap[route] = {route, routePayload}
+        routeMap[route] = {route, payload: route.payload}
       }
     })
     return _.values(routeMap)
@@ -97,11 +99,11 @@ export default async function () {
 
   while (routes.length) {
     let n = 0
-    await Promise.all(routes.splice(0, 500).map(async ({route, routePayload}) => {
+    await Promise.all(routes.splice(0, 500).map(async ({route, payload}) => {
       await waitFor(n++ * this.options.generate.interval)
       let html
       try {
-        const res = await this.renderRoute(route, { _generate: true, routePayload })
+        const res = await this.renderRoute(route, { _generate: true, generatePayload: payload })
         html = res.html
         if (res.error) {
           errors.push({ type: 'handled', route, error: res.error })

--- a/test/fixtures/basic/nuxt.config.js
+++ b/test/fixtures/basic/nuxt.config.js
@@ -1,9 +1,9 @@
 module.exports = {
   generate: {
     routes: [
-      {route: '/users/1'},
-      {route: '/users/2'},
-      {route: '/users/3'}
+      '/users/1',
+      '/users/2',
+      '/users/3'
     ],
     interval: 200
   }

--- a/test/fixtures/basic/nuxt.config.js
+++ b/test/fixtures/basic/nuxt.config.js
@@ -1,9 +1,9 @@
 module.exports = {
   generate: {
     routes: [
-      '/users/1',
-      '/users/2',
-      '/users/3'
+      {route: '/users/1'},
+      {route: '/users/2'},
+      {route: '/users/3'}
     ],
     interval: 200
   }


### PR DESCRIPTION
Added support for rendering dynamic routes using data cached by generate.routes in the config file. Rather than just generating dynamic routes as such:
```js
routes : ['/route/1'...]
```
You should do this:
```js
routes : [
   {route : "/route/1", payload : { data : ...}
]
```

routePayload is then injected into the context of _id.vue, enabling that component to skip over its asynchronous query to the server and render the view immediately. This means you can skip the generate.interval approach to avoid flooding the server, since only one query is made per dynamic route. This also makes the rendering step synchronous. 

Note that I implemented this feature backwards-incompatible. 

Example asyncData in route/_id.vue. We can see that because we have the routePayload we don't need to fetch from the backend. 
```js
async asyncData ({ params, error, payload }) {
            if (payload) {
                return { article : payload}
            }
            try{
                var article = await backend.getArticle(params.id)
            }
            catch(err) {
                error({ message: "Artikeln kunde inte hittas.", statusCode: 404 })
            }
            return { article }
}
```