### PR TITLE
[feature] multiple nuxt apps in project

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -112,10 +112,10 @@ export async function build () {
   debug(`App root: ${this.srcDir}`)
   debug('Generating .nuxt/ files...')
   // Create .nuxt/, .nuxt/components and .nuxt/dist folders
-  await remove(r(this.dir, '.nuxt'))
-  await mkdirp(r(this.dir, '.nuxt/components'))
+  await remove(r(this.buildDir))
+  await mkdirp(r(this.buildDir, 'components'))
   if (!this.dev) {
-    await mkdirp(r(this.dir, '.nuxt/dist'))
+    await mkdirp(r(this.buildDir, 'dist'))
   }
   // Generate routes and interpret the template files
   await generateRoutesAndFiles.call(this)
@@ -139,7 +139,7 @@ async function buildFiles () {
 }
 
 function addAppTemplate () {
-  let templatePath = resolve(this.dir, '.nuxt', 'dist', 'index.html')
+  let templatePath = resolve(this.buildDir, 'dist', 'index.html')
   if (fs.existsSync(templatePath)) {
     this.appTemplate = _.template(fs.readFileSync(templatePath, 'utf8'), {
       interpolate: /{{([\s\S]+?)}}/g
@@ -209,7 +209,7 @@ async function generateRoutesAndFiles () {
   }
   // If no default layout, create its folder and add the default folder
   if (!templateVars.layouts.default) {
-    await mkdirp(r(this.dir, '.nuxt/layouts'))
+    await mkdirp(r(this.buildDir, 'layouts'))
     templatesFiles.push('layouts/default.vue')
     templateVars.layouts.default = r(__dirname, 'app', 'layouts', 'default.vue')
   }
@@ -284,7 +284,7 @@ async function generateRoutesAndFiles () {
       src,
       dst
     }))
-    const path = r(this.dir, '.nuxt', dst)
+    const path = r(this.buildDir, dst)
     // Ensure parent dir exits
     await mkdirp(dirname(path))
     // Write file

--- a/lib/build.js
+++ b/lib/build.js
@@ -110,7 +110,7 @@ export async function build () {
     }
   }
   debug(`App root: ${this.srcDir}`)
-  debug('Generating .nuxt/ files...')
+  debug(`Generating .nuxt/${this.options.build.buildNamespace ? (this.options.build.buildNamespace + '/') : ''} files...`)
   // Create .nuxt/, .nuxt/components and .nuxt/dist folders
   await remove(r(this.buildDir))
   await mkdirp(r(this.buildDir, 'components'))

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -46,7 +46,7 @@ export default async function () {
   */
   this.options.generate = _.defaultsDeep(this.options.generate, defaults)
   var srcStaticPath = resolve(this.srcDir, 'static')
-  var srcBuiltPath = resolve(this.dir, '.nuxt', 'dist')
+  var srcBuiltPath = resolve(this.buildDir, 'dist')
   var distPath = resolve(this.dir, this.options.generate.dir)
   var distNuxtPath = join(distPath, (isUrl(this.options.build.publicPath) ? '' : this.options.build.publicPath))
   /*

--- a/lib/nuxt.js
+++ b/lib/nuxt.js
@@ -62,7 +62,9 @@ class Nuxt {
         webpack: {},
         chokidar: {}
       },
-      build: {}
+      build: {
+        buildNamespace: null
+      }
     }
     // Sanitization
     if (options.loading === true) delete options.loading
@@ -77,7 +79,8 @@ class Nuxt {
     // Explicit srcDir, rootDir and buildDir
     this.dir = (typeof options.rootDir === 'string' && options.rootDir ? options.rootDir : process.cwd())
     this.srcDir = (typeof options.srcDir === 'string' && options.srcDir ? resolve(this.dir, options.srcDir) : this.dir)
-    this.buildDir = resolve(this.dir, '.nuxt')
+    this.buildDir = (typeof options.build.buildNamespace === 'string' && options.build.buildNamespace)
+                    ? resolve(this.dir, '.nuxt', options.build.buildNamespace) : resolve(this.dir, '.nuxt')
     options.rootDir = this.dir
     options.srcDir = this.srcDir
     options.buildDir = this.buildDir

--- a/lib/nuxt.js
+++ b/lib/nuxt.js
@@ -74,11 +74,13 @@ class Nuxt {
     this.options = _.defaultsDeep(options, defaults)
     // Env variables
     this.dev = this.options.dev
-    // Explicit srcDir and rootDir
+    // Explicit srcDir, rootDir and buildDir
     this.dir = (typeof options.rootDir === 'string' && options.rootDir ? options.rootDir : process.cwd())
     this.srcDir = (typeof options.srcDir === 'string' && options.srcDir ? resolve(this.dir, options.srcDir) : this.dir)
+    this.buildDir = resolve(this.dir, '.nuxt')
     options.rootDir = this.dir
     options.srcDir = this.srcDir
+    options.buildDir = this.buildDir
     // If store defined, update store options to true
     if (fs.existsSync(join(this.srcDir, 'store'))) {
       this.options.store = true
@@ -93,7 +95,7 @@ class Nuxt {
     // For serving static/ files to /
     this.serveStatic = pify(serveStatic(resolve(this.srcDir, 'static'), this.options.render.static))
     // For serving .nuxt/dist/ files (only when build.publicPath is not an URL)
-    this.serveStaticNuxt = pify(serveStatic(resolve(this.dir, '.nuxt', 'dist'), {
+    this.serveStaticNuxt = pify(serveStatic(resolve(this.buildDir, 'dist'), {
       maxAge: (this.dev ? 0 : '1y') // 1 year in production
     }))
     // gzip middleware for production

--- a/lib/webpack/base.config.js
+++ b/lib/webpack/base.config.js
@@ -40,8 +40,8 @@ export default function ({ isClient, isServer }) {
         'assets': join(this.srcDir, 'assets'), // use in template with <img src="~assets/nuxt.png" />
         '~assets': join(this.srcDir, 'assets'),
         '~plugins': join(this.srcDir, 'plugins'),
-        '~store': join(this.dir, '.nuxt/store'),
-        '~router': join(this.dir, '.nuxt/router'),
+        '~store': join(this.buildDir, 'store'),
+        '~router': join(this.buildDir, 'router'),
         '~pages': join(this.srcDir, 'pages'),
         '~components': join(this.srcDir, 'components')
       },

--- a/lib/webpack/client.config.js
+++ b/lib/webpack/client.config.js
@@ -25,7 +25,7 @@ export default function () {
   let config = base.call(this, { isClient: true })
 
   // Entry
-  config.entry.app = resolve(this.dir, '.nuxt', 'client.js')
+  config.entry.app = resolve(this.buildDir, 'client.js')
 
   // Add vendors
   if (this.options.store) {
@@ -34,7 +34,7 @@ export default function () {
   config.entry.vendor = config.entry.vendor.concat(this.options.build.vendor)
 
   // Output
-  config.output.path = resolve(this.dir, '.nuxt', 'dist')
+  config.output.path = resolve(this.buildDir, 'dist')
   config.output.filename = this.options.build.filenames.app
 
   // env object defined in nuxt.config.js

--- a/lib/webpack/server.config.js
+++ b/lib/webpack/server.config.js
@@ -24,9 +24,9 @@ export default function () {
   config = Object.assign(config, {
     target: 'node',
     devtool: (this.dev ? 'source-map' : false),
-    entry: resolve(this.dir, '.nuxt', 'server.js'),
+    entry: resolve(this.buildDir, 'server.js'),
     output: Object.assign({}, config.output, {
-      path: resolve(this.dir, '.nuxt', 'dist'),
+      path: resolve(this.buildDir, 'dist'),
       filename: 'server-bundle.js',
       libraryTarget: 'commonjs2'
     }),


### PR DESCRIPTION
The pull request aims to allows to nuxt lovers to create multiple nuxt apps in same project; for example, separate backend and frontend.

First, it defines a buildDir property for nuxt to dry the `'.nuxt'` across the code.
Then, it defines a config option in `build.buildNamespace` which creates a sub-directory inside `.nuxt/` to be used by `nuxt build`.
 
**PS**: The feature should be backward compatible, yet you may want to take it into account while developing  [modules](https://github.com/nuxt/nuxt.js/blob/dev/lib/module.js#L55).

Cheers!