### PR TITLE
Add support for a generate done function

### DIFF
--- a/lib/generate.js
+++ b/lib/generate.js
@@ -158,4 +158,10 @@ export default async function () {
     })
     console.error('==== Error report ==== \n' + report.join('\n\n')) // eslint-disable-line no-console
   }
+  /*
+  ** Call done callback function if existing
+  */
+  if (typeof this.options.generate.done === 'function') {
+    this.options.generate.done(errors)
+  }
 }

--- a/test/basic.generate.done.test.js
+++ b/test/basic.generate.done.test.js
@@ -1,0 +1,38 @@
+import test from 'ava'
+import { resolve } from 'path'
+
+test('Calls done function', async t => {
+  let generateDone = false
+  const Nuxt = require('../')
+  const options = {
+    rootDir: resolve(__dirname, 'fixtures/basic'),
+    dev: false,
+    generate: {
+      done: function () {
+        generateDone = true
+      }
+    }
+  }
+  const nuxt = new Nuxt(options)
+  await nuxt.generate()
+  t.is(generateDone, true)
+})
+
+test('Calls done function with errors in errorcase', async t => {
+  let generateErrors
+  const Nuxt = require('../')
+  const options = {
+    rootDir: resolve(__dirname, 'fixtures/error'),
+    dev: false,
+    generate: {
+      done: function (errors) {
+        generateErrors = errors
+      }
+    }
+  }
+  const nuxt = new Nuxt(options)
+  await nuxt.generate()
+  t.is(generateErrors.length, 1)
+  t.is(generateErrors[0].type, 'unhandled')
+  t.is(generateErrors[0].route, '/')
+})


### PR DESCRIPTION
Implements #855 

Adds support for a generate done function. The function receives the array of generation errors.

Example usecase: An app, where we want to close firebase websockets after generation is done:
```
  generate: {
    done: function (errors) {
        process.__Firebase__.goOffline()
    }
  }
```
