### PR TITLE
Fix HMR http request timeout issue under node 8

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -451,7 +451,8 @@ function createWebpackMiddleware () {
     watchOptions: this.options.watchers.webpack
   }))
   this.webpackHotMiddleware = pify(require('webpack-hot-middleware')(clientCompiler, {
-    log: () => {}
+    log: () => {},
+    heartbeat: 2500
   }))
   clientCompiler.plugin('done', () => {
     const fs = this.webpackDevMiddleware.fileSystem


### PR DESCRIPTION
To prevent ERR_INCOMPLETE_CHUNKED_ENCODING on js console.
The fix is to add a heartbeat less than 5 secs.
see https://github.com/zeit/next.js/pull/2166/commits/2359b3f9b2087935c0b1372d0fe55eac4ec3d830