### PR TITLE
Configurable 'key' attribute/property for transitions

### DIFF
--- a/lib/app/components/nuxt.vue
+++ b/lib/app/components/nuxt.vue
@@ -1,6 +1,6 @@
 <template>
   <nuxt-error v-if="nuxt.err" :error="nuxt.err"></nuxt-error>
-  <nuxt-child v-else></nuxt-child>
+  <nuxt-child :key="routerViewKey" v-else></nuxt-child>
 </template>
 
 <script>
@@ -10,6 +10,7 @@ import NuxtError from '<%= components.ErrorPage ? ((components.ErrorPage.include
 
 export default {
   name: 'nuxt',
+  props: ['routerViewKey'],
   beforeCreate () {
     Vue.util.defineReactive(this, 'nuxt', this.$root.$options._nuxt)
   },


### PR DESCRIPTION
The vue-router component can have a 'key' property which means it's easier to configure transitions between routes with slugs.

With this change in a layout template you can use
```html
<nuxt :routerViewKey="routerViewKey" />
```
And the following for example
```js
    computed: {
      routerViewKey () {
        if (this.$route.name === 'service') {
          return this.$route.name
        } else {
          return this.$route.fullPath
        }
      }
    }
```
This would implement the functionality that @myst729 mentioned here https://github.com/vuejs/vue-router/issues/474 for vue-router - some routes can just switch, but some you may want to transition as though it's a complete new page to an end-user

This is a possible resolution to issue raised here https://github.com/nuxt/nuxt.js/issues/1021