### PR TITLE
Adding the ability to send back to the client with middleware

### DIFF
--- a/lib/app/server.js
+++ b/lib/app/server.js
@@ -98,6 +98,7 @@ export default async (context) => {
   if (!context.nuxt.error) {
     await middlewareSeries(midd, ctx)
   }
+  if (context.res.headersSent) return
   if (context.redirected) return _noopApp
   // Set layout
   let layout = Components.length ? Components[0].options.layout : NuxtError.layout

--- a/lib/app/server.js
+++ b/lib/app/server.js
@@ -98,7 +98,7 @@ export default async (context) => {
   if (!context.nuxt.error) {
     await middlewareSeries(midd, ctx)
   }
-  if (context.res.headersSent) return
+  if (context.res && context.res.headersSent) return
   if (context.redirected) return _noopApp
   // Set layout
   let layout = Components.length ? Components[0].options.layout : NuxtError.layout

--- a/lib/app/utils.js
+++ b/lib/app/utils.js
@@ -104,7 +104,7 @@ export function middlewareSeries (promises, context) {
   }
   return promisify(promises[0], context)
   .then(() => {
-    if (context.res.headersSent) return
+    if (context.res && context.res.headersSent) return
     return middlewareSeries(promises.slice(1), context)
   })
 }

--- a/lib/app/utils.js
+++ b/lib/app/utils.js
@@ -104,6 +104,7 @@ export function middlewareSeries (promises, context) {
   }
   return promisify(promises[0], context)
   .then(() => {
+    if (context.res.headersSent) return
     return middlewareSeries(promises.slice(1), context)
   })
 }


### PR DESCRIPTION
When using nuxt, if you were to send a response back to the client, nuxt would continue to call the following middlewares and put the request through the router. Now, once the response has been sent, it will cease to send the request through more middleware or the router.

This makes the creation of API middleware possible.