### PR TITLE
fix (postcss): enable autoprefixer when no custom build.postcss is set

### DIFF
--- a/lib/core/options.js
+++ b/lib/core/options.js
@@ -107,7 +107,7 @@ export const defaultOptions = {
     vendor: [],
     plugins: [],
     babel: {},
-    postcss: [],
+    postcss: undefined,
     templates: [],
     watch: [],
     devMiddleware: {},


### PR DESCRIPTION
Before: default value of `build.postcss` is `[]`, therefore `autoprefixer` cannot be added as a default due to https://github.com/nuxt/nuxt.js/blob/dev/lib/builder/webpack/base.config.js#L21.

After: set `build.postcss` to be `undefined`, so `autoprefixer` could be added successfully.