### PR TITLE
Improved default key for page with children

### DIFF
--- a/lib/app/components/nuxt.vue
+++ b/lib/app/components/nuxt.vue
@@ -50,7 +50,7 @@ export default {
     routerViewKey () {
       // If nuxtChildKey prop is given or current route has children
       if (typeof this.nuxtChildKey !== 'undefined' || this.$route.matched.length > 1) {
-        return this.nuxtChildKey || ''
+        return this.nuxtChildKey || this.$route.fullPath.split('/')[1]
       }
       return this.$route.fullPath.split('#')[0]
     }

--- a/lib/app/components/nuxt.vue
+++ b/lib/app/components/nuxt.vue
@@ -7,6 +7,7 @@
 import Vue from 'vue'
 import NuxtChild from './nuxt-child'
 import NuxtError from '<%= components.ErrorPage ? ((components.ErrorPage.includes('~') || components.ErrorPage.includes('@')) ? components.ErrorPage : "../" + components.ErrorPage) : "./nuxt-error.vue" %>'
+import { compile } from '~/.nuxt/utils'
 
 export default {
   name: 'nuxt',
@@ -50,7 +51,7 @@ export default {
     routerViewKey () {
       // If nuxtChildKey prop is given or current route has children
       if (typeof this.nuxtChildKey !== 'undefined' || this.$route.matched.length > 1) {
-        return this.nuxtChildKey || this.$route.fullPath.split('/')[1]
+        return this.nuxtChildKey || compile(this.$route.matched[0].path)(this.$route.params)
       }
       return this.$route.fullPath.split('#')[0]
     }

--- a/lib/app/components/nuxt.vue
+++ b/lib/app/components/nuxt.vue
@@ -7,7 +7,7 @@
 import Vue from 'vue'
 import NuxtChild from './nuxt-child'
 import NuxtError from '<%= components.ErrorPage ? ((components.ErrorPage.includes('~') || components.ErrorPage.includes('@')) ? components.ErrorPage : "../" + components.ErrorPage) : "./nuxt-error.vue" %>'
-import { compile } from '~/.nuxt/utils'
+import { compile } from '../utils'
 
 export default {
   name: 'nuxt',


### PR DESCRIPTION
I think this as a default key would be better if a page being loaded from the layout has children. Ideally I'd like to find the page's parent fullpath but I haven't found a good way to do that just yet. This would satisfy my needs on a basic website.

P.s. with these huge releases I know this is not top priority and isn't important enough to take attention away from all the great work going on!