### PR TITLE
feat(nuxt.config.js): support chunkFileName in config

### DIFF
--- a/lib/builder/webpack/base.config.js
+++ b/lib/builder/webpack/base.config.js
@@ -35,6 +35,7 @@ export default function webpackBaseConfig ({ isClient, isServer }) {
     output: {
       path: resolve(this.options.buildDir, 'dist'),
       filename: this.options.build.filenames.app,
+      chunkFilename: this.options.build.filenames.chunk,
       publicPath: (isUrl(this.options.build.publicPath)
         ? this.options.build.publicPath
         : urlJoin(this.options.router.base, this.options.build.publicPath))

--- a/lib/builder/webpack/client.config.js
+++ b/lib/builder/webpack/client.config.js
@@ -122,6 +122,7 @@ export default function webpackClientConfig () {
     // Add HMR support
     config.entry.app = ['webpack-hot-middleware/client?name=$client&reload=true', config.entry.app]
     config.output.filename = '[name].js'
+    config.output.chunkFilename = '[id].js'
     config.plugins.push(
       new webpack.HotModuleReplacementPlugin(),
       new webpack.NoEmitOnErrorsPlugin()

--- a/lib/common/options.js
+++ b/lib/common/options.js
@@ -102,7 +102,8 @@ Options.defaults = {
       css: 'common.[chunkhash].css',
       manifest: 'manifest.[hash].js',
       vendor: 'vendor.bundle.[chunkhash].js',
-      app: 'nuxt.bundle.[chunkhash].js'
+      app: 'nuxt.bundle.[chunkhash].js',
+      chunk: '[id].nuxt.bundle.[chunkhash].js'
     },
     vendor: [],
     plugins: [],


### PR DESCRIPTION
* add `chunk` in `nuxt.config.js` to config webpack chunk file name
 ```js
build: {
    filenames: {
      app: 'app.[chunkhash].js',
      // this is the new introduced config
      chunk: 'chunk[id].[chunkhash].js'
    }
}
```