### PR TITLE
fix for #1234, order less greedy routes first

### DIFF
--- a/lib/common/utils.js
+++ b/lib/common/utils.js
@@ -233,7 +233,7 @@ export function createRoutes (files, srcDir) {
           let z = (_b[i].indexOf('*') > -1) ? 2 : (_b[i].indexOf(':') > -1 ? 1 : 0)
           res = y - z
           if (i === _b.length - 1 && res === 0) {
-            res = 1
+            res = -1
           }
         }
       }

--- a/lib/common/utils.js
+++ b/lib/common/utils.js
@@ -220,17 +220,21 @@ export function createRoutes (files, srcDir) {
         return 1
       }
       let res = 0
-      let _a = a.path.split('/')
-      let _b = b.path.split('/')
-      for (let i = 0; i < _a.length; i++) {
+      const _a = a.path.split('/')
+      const _b = b.path.split('/')
+      for (let i = 0; i < _a.length >= _b.length ? _a.length : _b.length; i++) {
         if (res !== 0) {
           break
         }
-        let y = (_a[i].indexOf('*') > -1) ? 2 : (_a[i].indexOf(':') > -1 ? 1 : 0)
-        let z = (_b[i].indexOf('*') > -1) ? 2 : (_b[i].indexOf(':') > -1 ? 1 : 0)
-        res = y - z
-        if (i === _b.length - 1 && res === 0) {
+        if (i >= _a.length) {
           res = 1
+        } else {
+          let y = (_a[i].indexOf('*') > -1) ? 2 : (_a[i].indexOf(':') > -1 ? 1 : 0)
+          let z = (_b[i].indexOf('*') > -1) ? 2 : (_b[i].indexOf(':') > -1 ? 1 : 0)
+          res = y - z
+          if (i === _b.length - 1 && res === 0) {
+            res = 1
+          }
         }
       }
       return res === 0 ? -1 : res


### PR DESCRIPTION
As it is possible to use dynamic route matching with nuxt, you can get into problems when you have multiple routes that match the same url. See #1234 for an example case.

The [vue-router documentation](https://router.vuejs.org/en/essentials/dynamic-matching.html) states that:
> Sometimes the same URL may be matched by multiple routes. In such a case the matching priority is determined by the order of route definition: the earlier a route is defined, the higher priority it gets

This commit changes the route sorting behaviour by making sure that less greedy routes are listed _before_ more greedy routes. In this context a less greedy route is defined as having more segments in its path (e.g. `/a/b/c` is less greedy then `/a`)