### PR TITLE
Resolve Promise when got VueComponent

### DIFF
--- a/lib/app/App.vue
+++ b/lib/app/App.vue
@@ -42,7 +42,7 @@ export default {
     loadLayout (layout) {
       if (!layout || !layouts['_' + layout]) layout = 'default'
       let _layout = '_' + layout
-      if (typeof layouts[_layout] !== 'function') {
+      if (typeof layouts[_layout] !== 'function' || layouts[_layout].name === 'VueComponent') {
         return Promise.resolve(layouts[_layout])
       }
       return layouts[_layout]()


### PR DESCRIPTION
fix this: https://github.com/nuxt/nuxt.js/issues/800

In the case of a layout file written in JavaScript, loadLayout get a Object.
However, in the case of TypeScript, loadLayout get a VueComponent (it is function).

I checked vue-class-component and nuxt-class-component.
