### PR TITLE
add generate html template config

### DIFF
--- a/lib/builder/generator.js
+++ b/lib/builder/generator.js
@@ -132,6 +132,19 @@ export default class Generator extends Tapable {
     return _.values(routeMap)
   }
 
+  buildHtmlFilePath (route) {
+    const { html = {} } = this.options.generate
+    let {
+      useRouteName = false,
+      fileName = 'index',
+      extension = 'html'
+    } = html
+    extension = extension ? `.${extension}` : ''
+    const name = useRouteName ? (route === '/' ? 'index' : '') : fileName
+    const path = useRouteName ? `${route}${name}${extension}` : join(route, sep, `${name}${extension}`)// /about -> /about/index.html
+    return (route === '/404') ? `/404${extension}` : path // /404 -> /404.html
+  }
+
   async generateRoute ({route, payload = {}, errors = []}) {
     let html
 
@@ -154,9 +167,7 @@ export default class Generator extends Tapable {
         errors.push({ type: 'unhandled', route, error: minifyErr })
       }
     }
-
-    let path = join(route, sep, 'index.html') // /about -> /about/index.html
-    path = (path === '/404/index.html') ? '/404.html' : path // /404 -> /404.html
+    let path = this.buildHtmlFilePath(route)
     debug('Generate file: ' + path)
     path = join(this.distPath, path)
 

--- a/lib/common/options.js
+++ b/lib/common/options.js
@@ -151,9 +151,9 @@ Options.defaults = {
       useShortDoctype: true
     },
     html: {
-      useRouteName: false,  // if set ture, will use the last route path as html file name, but replace route `/` with `/index`.
-      fileName: 'index',    // the html template file name, default 'index'.
-      extension: 'html'     // the html template extension type, default `html`. also can be set 'php' or jsp' or others.
+      useRouteName: false, // if set ture, will use the last route path as html file name, but replace route `/` with `/index`.
+      fileName: 'index', // the html template file name, default 'index'.
+      extension: 'html' // the html template extension type, default `html`. also can be set 'php' or jsp' or others.
     }
   },
   env: {},

--- a/lib/common/options.js
+++ b/lib/common/options.js
@@ -149,6 +149,11 @@ Options.defaults = {
       sortClassName: true,
       trimCustomFragments: true,
       useShortDoctype: true
+    },
+    html: {
+      useRouteName: false,  // if set ture, will use the last route path as html file name, but replace route `/` with `/index`.
+      fileName: 'index',    // the html template file name, default 'index'.
+      extension: 'html'     // the html template extension type, default `html`. also can be set 'php' or jsp' or others.
     }
   },
   env: {},


### PR DESCRIPTION
### At present，"nuxt generate" only can generate static template with html file type，and immutable name:  "index".

### I add some config, supportting user to set templates name and extension.

### the genarate config like this:

``` javascript
generate: {
    html: {
      useRouteName: false,  // if set ture, will use the last route path as html file name, but replace route `/` with `/index`.
      fileName: 'index',    // the html template file name, default 'index'.
      extension: 'html'     // the html template extension type, default `html`. also can be set 'php' or jsp' or others.
    }
}
```
### if don't set any config, will use default config，as same as old version

