### PR TITLE
Fix class component checks for extended components

### DIFF
--- a/lib/app/server.js
+++ b/lib/app/server.js
@@ -79,7 +79,7 @@ export default async context => {
   let Components = []
   try {
     Components = await Promise.all(getMatchedComponents(router.match(context.url)).map(Component => {
-      if (typeof Component !== 'function' || Component.super === Vue) {
+      if (typeof Component !== 'function' || Component.cid) {
         return sanitizeComponent(Component)
       }
       return Component().then(Component => sanitizeComponent(Component))


### PR DESCRIPTION
PR #765 works great for class component which directly extends `Vue`, but Vue Components which extends another class components will not work, like
```jsx
@Component({
  name: 'Layout',
})
class Layout extends Vue {
  render () { return this.renderContent() }
}

@Component({
  name: 'page',
  layout: 'empty',
})
export class Page extends Layout {
  renderContent () { return <span>Content</span> }
}
```

Using `Page` in Nuxt would raise an error, and changes checking `super` to checking `cid` fixes this.