### PR TITLE
Add better support for pug

### DIFF
--- a/lib/builder/webpack/vue-loader.config.js
+++ b/lib/builder/webpack/vue-loader.config.js
@@ -22,7 +22,7 @@ export default function ({ isClient }) {
     },
     template: {
       // for pug, see https://github.com/vuejs/vue-loader/issues/55
-      doctype: "html"
+      doctype: 'html'
     },
     preserveWhitespace: false,
     extractCSS: extractStyles.call(this)

--- a/lib/builder/webpack/vue-loader.config.js
+++ b/lib/builder/webpack/vue-loader.config.js
@@ -20,6 +20,10 @@ export default function ({ isClient }) {
       'stylus': styleLoader.call(this, 'stylus', 'stylus-loader'),
       'styl': styleLoader.call(this, 'stylus', 'stylus-loader')
     },
+    template: {
+      // for pug, see https://github.com/vuejs/vue-loader/issues/55
+      doctype: "html"
+    },
     preserveWhitespace: false,
     extractCSS: extractStyles.call(this)
   }


### PR DESCRIPTION
When using `lang="pug"`, passing Boolean `true` as prop and using directives will case errors.

See: 
https://github.com/vuejs/vue-loader/issues/693
https://github.com/vuejs/vue-loader/issues/55

For example:

```html
<template lang="pug">
foo(
  bar
  v-baz-directive
)
</template>
```

This will be rendered as
`<foo bar="bar" v-baz-directive="v-baz-directive">`
and cause errors such as `bar expected Boolean but got String` and `v`/`baz`/`directive` not defined.