### PR TITLE
Fix incorrect Cache-Busting for CSS

### DIFF
--- a/lib/common/options.js
+++ b/lib/common/options.js
@@ -153,7 +153,7 @@ Options.defaults = {
     ssr: undefined,
     publicPath: '/_nuxt/',
     filenames: {
-      css: 'common.[chunkhash].css',
+      css: 'common.[contenthash].css',
       manifest: 'manifest.[hash].js',
       vendor: 'vendor.bundle.[chunkhash].js',
       app: 'nuxt.bundle.[chunkhash].js',


### PR DESCRIPTION
Chunkhash do not work with css content.

See https://medium.com/@okonetchnikov/long-term-caching-of-static-assets-with-webpack-1ecb139adb95#.f9aon6s3b