### PR TITLE
Allow custom HTTP server instance from user

### DIFF
--- a/lib/common/options.js
+++ b/lib/common/options.js
@@ -225,6 +225,7 @@ Options.defaults = {
   css: [],
   modules: [],
   layouts: {},
+  serverInstance: null,
   serverMiddleware: [],
   ErrorPage: null,
   loading: {

--- a/lib/core/renderer.js
+++ b/lib/core/renderer.js
@@ -39,8 +39,16 @@ export default class Renderer extends Tapable {
     this.webpackDevMiddleware = null
     this.webpackHotMiddleware = null
 
-    // Create new connect instance
-    this.app = connect()
+    if (typeof this.options.serverInstance === 'string') {
+      // Resolve the module from rootDir
+      this.app = require(this.nuxt.resolvePath(this.options.serverInstance))()
+    } else if (this.options.serverInstance instanceof Function) {
+      // Use the instance directly
+      this.app = this.options.serverInstance
+    } else {
+      // Create new connect instance
+      this.app = connect()
+    }
 
     // Renderer runtime resources
     this.resources = {


### PR DESCRIPTION
Hello,

since we can plug my own `serverMiddleware`, I think a options for user-provided HTTP server can get more flexibility for Nuxt ヾ(\*´ω｀\*)ノ

Just add it in nuxt.config.js
```javascript
module.exports = {
  serverInstance: 'express',
}

// or

const express = require('express')

module.exports = {
  serverInstance: express()
}
```