### PR TITLE
~ fix asyncData parent + children pages in production build (#1248)

### DIFF
--- a/lib/app/server.js
+++ b/lib/app/server.js
@@ -171,7 +171,7 @@ export default async context => {
     if (Component.options.asyncData && typeof Component.options.asyncData === 'function') {
       let promise = promisify(Component.options.asyncData, ctx)
       promise.then(asyncDataResult => {
-        context.asyncData[Component.options.name] = asyncDataResult
+        context.asyncData[Component.cid] = asyncDataResult
         applyAsyncData(Component)
         return asyncDataResult
       })

--- a/lib/app/utils.js
+++ b/lib/app/utils.js
@@ -21,7 +21,7 @@ export function applyAsyncData (Component, asyncData = {}) {
   Component.options.data = function () {
     const data =  ComponentData.call(this)
     if(this.$ssrContext) {
-      asyncData = this.$ssrContext.asyncData[Component.options.name]
+      asyncData = this.$ssrContext.asyncData[Component.cid]
     }
     return { ...data, ...asyncData }
   }


### PR DESCRIPTION
Fixed asyncData method for a parent when Promise returns later asyncData of child page in production build.