### PR TITLE
Don't set `babelOptions.presets` if babelrc = true

### DIFF
--- a/lib/builder/builder.js
+++ b/lib/builder/builder.js
@@ -120,12 +120,14 @@ export default class Builder extends Tapable {
 
     // Babel options
     this.babelOptions = _.defaults(this.options.build.babel, {
-      presets: [
-        require.resolve('babel-preset-vue-app')
-      ],
       babelrc: false,
       cacheDirectory: !!this.options.dev
     })
+    if (!this.babelOptions.babelrc && !this.babelOptions.presets) {
+      this.babelOptions.presets = [
+        require.resolve('babel-preset-vue-app')
+      ]
+    }
 
     // Map postcss plugins into instances on object mode once
     if (isPureObject(this.options.build.postcss)) {


### PR DESCRIPTION
Currently when using nuxt with `babelrc = true`, nuxt will change `babelOptions.presets` which overides the presets defined in `babelrc` file.