### PR TITLE
rename progress class to prevent conflicts

### DIFF
--- a/lib/app/components/nuxt-loading.vue
+++ b/lib/app/components/nuxt-loading.vue
@@ -87,7 +87,7 @@ export default {
 }
 </script>
 
-<style scoped>
+<style>
 .nuxt-progress {
   position: fixed;
   top: 0px;

--- a/lib/app/components/nuxt-loading.vue
+++ b/lib/app/components/nuxt-loading.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="progress" :style="{
+  <div class="nuxt-progress" :style="{
     'width': percent+'%',
     'height': height,
     'background-color': canSuccess? color : failedColor,
@@ -88,7 +88,7 @@ export default {
 </script>
 
 <style scoped>
-.progress {
+.nuxt-progress {
   position: fixed;
   top: 0px;
   left: 0px;


### PR DESCRIPTION
The nuxt loading component uses the css class `progress` which is pretty generic. It was conflicting with a css framework I was using and causing style issues (top margin added by framework). 

Since this is a pretty common class name in many css frameworks (eg bootstrap), I think it would cause less issues for users if it was renamed.

Pretty trivial, but a good first PR!