### PR TITLE
fix: compile error when using scrollBehavior

### DIFF
--- a/lib/app/router.js
+++ b/lib/app/router.js
@@ -24,7 +24,7 @@ uniqBy(_components, '_name').forEach((route) => { %>const <%= route._name %> = (
 <% }) %>
 
 <% if (router.scrollBehavior) { %>
-const scrollBehavior = <%= serialize(router.scrollBehavior).replace('scrollBehavior(', 'function(') %>
+const scrollBehavior = <%= serialize(router.scrollBehavior).replace('scrollBehavior(', 'function(').replace('function function', 'function') %>
 <% } else { %>
 const scrollBehavior = (to, from, savedPosition) => {
   // SavedPosition is only available for popstate navigations.


### PR DESCRIPTION
When compiling with babel as middleware the scrollBehavior function was transpiling in
incorrect way. Double function function

fixes #1516