### PR TITLE
match correct route when resolveComponents  in hash mode

### DIFF
--- a/lib/app/client.js
+++ b/lib/app/client.js
@@ -134,7 +134,7 @@ async function loadAsyncComponents (to, from, next) {
 
 // Get matched components
 function resolveComponents(router) {
-  const path = getLocation(router.options.base)
+  const path = getLocation(router.options.base, router.options.mode)
 
   return flatMapComponents(router.match(path), (Component, _, match, key, index) => {
     // If component already resolved

--- a/lib/app/utils.js
+++ b/lib/app/utils.js
@@ -144,8 +144,11 @@ export function promisify (fn, context) {
 }
 
 // Imported from vue-router
-export function getLocation (base) {
+export function getLocation (base, mode) {
   var path = window.location.pathname
+  if (mode === 'hash') {
+    return window.location.hash.replace(/^#\//, '')
+  }
   if (base && path.indexOf(base) === 0) {
     path = path.slice(base.length)
   }


### PR DESCRIPTION
Fix #1437 

Expected: 
When using hash mode, after refreshing  page "http://localhost:3000/#/contacts", page will be loaded successfully.

Current:
`500 Cannot read property 'layout' of undefined` happened.

Cause:
After refreshing  page, route "/" will be matched instead of "/contacts".