### PR TITLE
Add "resourcesLoaded" plugin for Renderer

### DIFF
--- a/lib/core/renderer.js
+++ b/lib/core/renderer.js
@@ -108,6 +108,9 @@ export default class Renderer extends Tapable {
       this.resources.loadingHTML = ''
     }
 
+    // Call resourcesLoaded plugin
+    await this.applyPluginsAsync('resourcesLoaded', this.resources)
+
     if (updated.length > 0) {
       // debug('Updated', updated.join(', '), isServer)
       this.createRenderer()


### PR DESCRIPTION
Provide the ability to modify resources before use. eg: set runtime publicPath
```js
__webpack_require__.p = window.__NUXT__ && window.__NUXT__.publicPath || `${defaultPublicPath}`
```
```js
const publicPath = `${runtimePublicPath}`

nuxt.renderer.plugin('resourcesLoaded', function (resources) {
  resources.clientManifest.publicPath = publicPath

  const serverBundle = resources.serverBundle.files['server-bundle.js']
  resources.serverBundle.files['server-bundle.js'] = serverBundle.replace(/__webpack_require__\.p = "[^"]+"/, `__webpack_require__.p = "${publicPath}"`)
})

nuxt.renderer.plugin('ready', function (renderer) {
  const originRenderToString = renderer.bundleRenderer.renderToString
  renderer.bundleRenderer.renderToString = function (context) {
    return originRenderToString.apply(this, arguments).then((d) => {
      context.nuxt.publicPath = publicPath
      return d
    })
  }
})
```