### PR TITLE
rename `context.serverState` to `context.nuxtState`

### DIFF
--- a/lib/app/utils.js
+++ b/lib/app/utils.js
@@ -109,7 +109,7 @@ export function getContext (context, app) {
     ctx.beforeNuxtRender = (fn) => context.beforeRenderFns.push(fn)
   }
   if (ctx.isClient && window.__NUXT__) {
-    ctx.serverState = window.__NUXT__
+    ctx.nuxtState = window.__NUXT__
   }
   return ctx
 }


### PR DESCRIPTION
[Release Note](https://github.com/nuxt/nuxt.js/releases/tag/v1.0.0-rc9) mentiond `context.nuxtState`, but it's actually named as `serverState` in rc9.