### PR TITLE
Close process when stdin is closed.

### DIFF
--- a/bin/nuxt
+++ b/bin/nuxt
@@ -23,3 +23,9 @@ if (commands.has(cmd)) {
 const bin = join(__dirname, 'nuxt-' + cmd)
 
 require(bin)
+
+// Exit if stdin is closed
+process.stdin.on('close', function() {
+  process.exit()
+})
+process.stdin.resume()


### PR DESCRIPTION
I'm using Nuxt as the builder for assets in a Phoenix application. Phoenix uses Erlang's ports mechanism to open the binary for the asset builder. This mechanism expects the binary to terminate when STDIN is closed.

Without this patch, Nuxt can be used as an asset builder. However, killing the Elixir process leaves the Nuxt process still running. With this patch, Nuxt binaries like nuxt-dev terminate correctly when the Elixir process is killed.