### PR TITLE
fix error handler if error message is readonly

### DIFF
--- a/lib/app/client.js
+++ b/lib/app/client.js
@@ -31,12 +31,14 @@ const NUXT = window.__NUXT__ || {}
 // Setup global Vue error handler
 const defaultErrorHandler = Vue.config.errorHandler
 Vue.config.errorHandler = function (err, vm, info) {
-  err.statusCode = err.statusCode || err.name || 'Whoops!'
-  err.message = err.message || err.toString()
+  const nuxtError = {
+    statusCode: err.statusCode || err.name || 'Whoops!',
+    message: err.message || err.toString()
+  }
 
   // Show Nuxt Error Page
   if(vm && vm.$root && vm.$root.$nuxt && vm.$root.$nuxt.error && info !== 'render function') {
-    vm.$root.$nuxt.error(err)
+    vm.$root.$nuxt.error(nuxtError)
   }
 
   // Call other handler if exist
@@ -48,7 +50,7 @@ Vue.config.errorHandler = function (err, vm, info) {
   if (process.env.NODE_ENV !== 'production') {
     console.error(err)
   } else {
-    console.error(err.message)
+    console.error(err.message || nuxtError.message)
   }
 }
 <% } %>


### PR DESCRIPTION
Hi, it seems that error handler is prone to errors itself :)
This happens if it receives an exception with a readonly message as DOMException for example.

Thanks for the maintainers .