### PR TITLE
Fix issue with parent routes being rerendered when navigating to/from…

### DIFF
--- a/lib/app/client.js
+++ b/lib/app/client.js
@@ -364,14 +364,6 @@ function fixPrepatch (to, ___) {
 
     _lastComponentsFiles = instances.map((instance, i) => {
       if (!instance) return '';
-
-      if (_lastPaths[i] === instance.constructor._path && typeof instance.constructor.options.data === 'function') {
-        const newData = instance.constructor.options.data.call(instance)
-        for (let key in newData) {
-          Vue.set(instance.$data, key, newData[key])
-        }
-      }
-
       return instance.constructor.options.__file
     })
 


### PR DESCRIPTION
Deleting these lines fix the following issues:

[#1761](https://github.com/nuxt/nuxt.js/issues/1761)
[#1756](https://github.com/nuxt/nuxt.js/issues/1756)
and possibly [#1727](https://github.com/nuxt/nuxt.js/issues/1727)

I'm failing to see what the purpose of the deleted lines are serving. 
After removing these lines the behavior works as expected. There was a comment above this function referencing the fact that 'when navigating to a different route but same component is used, vue will not update the instance data'. 

However, even deleting these lines I cannot reproduce that behavior, it may have been something happening in older versions of vue or vue-router that have since been fixed.

Please advise.