### PR TITLE
Initial work on a fully validating AMP example.

### DIFF
--- a/examples/amp/README.md
+++ b/examples/amp/README.md
@@ -1,0 +1,3 @@
+# AMP Hello World with Nuxt.js
+
+https://nuxtjs.org/examples

--- a/examples/amp/app.html
+++ b/examples/amp/app.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html ⚡ {{ HTML_ATTRS }}>
+  <head>
+    {{ HEAD }}
+    <script src="https://cdn.ampproject.org/v0.js" async></script>
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  </head>
+  <body {{ BODY_ATTRS }}>
+    {{ APP }}
+  </body>
+</html>

--- a/examples/amp/components/Byline.vue
+++ b/examples/amp/components/Byline.vue
@@ -1,0 +1,11 @@
+<template>
+  <div class="byline">
+    {{author}}
+  </div>
+</template>
+
+<script>
+export default {
+  props: [ 'author' ]
+}
+</script>

--- a/examples/amp/nuxt.config.js
+++ b/examples/amp/nuxt.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  head: {
+    meta: [
+      { charset: 'utf-8' },
+      { name: 'viewport', content: 'width=device-width,minimum-scale=1' }
+    ]
+  },
+  mode: 'ssr',
+  render: {
+    resourceHints: false
+  },
+  loading: false
+}

--- a/examples/amp/package.json
+++ b/examples/amp/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "amp-nuxt",
+  "dependencies": {
+    "nuxt": "../../"
+  },
+  "scripts": {
+    "dev": "nuxt",
+    "build": "nuxt build",
+    "start": "nuxt start"
+  }
+}

--- a/examples/amp/pages/about.vue
+++ b/examples/amp/pages/about.vue
@@ -1,0 +1,21 @@
+<template>
+  <div>
+    <p>Hi from {{ name }}</p>
+    <nuxt-link to="/">Home page</nuxt-link>
+  </div>
+</template>
+
+<script>
+export default {
+  asyncData ({ isStatic, isServer }) {
+    return {
+      name: isStatic ? 'static' : (isServer ? 'server' : 'client')
+    }
+  },
+  head: {
+    link: [
+      { rel: 'canonical', href: 'http://localhost:3000/?html' }
+    ]
+  }
+}
+</script>

--- a/examples/amp/pages/index.vue
+++ b/examples/amp/pages/index.vue
@@ -1,0 +1,19 @@
+<template>
+  <div>
+    <h1>Welcome!</h1>
+    <nuxt-link to="/about">About page</nuxt-link>
+    <byline author="Pete Johanson"></byline>
+  </div>
+</template>
+
+<script>
+import Byline from '~/components/Byline'
+export default {
+  components: { Byline },
+  head: {
+    link: [
+      { rel: 'canonical', href: 'http://localhost:3000/?html' }
+    ]
+  }
+}
+</script>

--- a/lib/core/renderer.js
+++ b/lib/core/renderer.js
@@ -533,7 +533,7 @@ export default class Renderer extends Tapable {
       HEAD += resourceHints
     }
 
-    if (this.options.mode != 'ssr') {
+    if (this.options.mode !== 'ssr') {
       APP += `<script type="text/javascript">window.__NUXT__=${serialize(context.nuxt, { isJSON: true })};</script>`
       APP += context.renderScripts()
     }

--- a/lib/core/renderer.js
+++ b/lib/core/renderer.js
@@ -532,8 +532,11 @@ export default class Renderer extends Tapable {
       resourceHints = context.renderResourceHints()
       HEAD += resourceHints
     }
-    APP += `<script type="text/javascript">window.__NUXT__=${serialize(context.nuxt, { isJSON: true })};</script>`
-    APP += context.renderScripts()
+
+    if (this.options.mode != 'ssr') {
+      APP += `<script type="text/javascript">window.__NUXT__=${serialize(context.nuxt, { isJSON: true })};</script>`
+      APP += context.renderScripts()
+    }
 
     HEAD += context.renderStyles()
 


### PR DESCRIPTION
* Requires one change to include a new mode option of 'ssr' which does
  *only* SSR, no universal app (i.e. no inserted script tags).
* AMP example that has required head elements, style/noscript tags, etc.
  to pass validation.
* Fixes nuxt/nuxt.js#878


Notes:

The most controversial/needs-discussion change required to fully pass the AMP validator was the addition of a new `mode` value for `nuxt.config.js` of `ssr`, which when detected prevents the insertion of any `<script>` tags into the body of the rendered page.

In order to allow re-using the exact same Nuxt.js routes for both AMP and non-AMP uses, it may be more useful to have that calculation performed during SSR (e.g. passing a query flag to the URL "http://mysites/dogs?amp=true", etc). I'm new to the Nuxt.js codebase, and didn't see an *obvious* way to support that in `lib/core/renderer.js` so I'm happy to dive into that if folks would like.

Thanks, and happy #hacktoberfest!