### PR TITLE
feat: improve custom-server example

### DIFF
--- a/examples/custom-server/package.json
+++ b/examples/custom-server/package.json
@@ -1,8 +1,9 @@
 {
   "name": "nuxt-custom-server",
   "dependencies": {
+    "chalk": "^2.2.0",
     "express": "^4.15.3",
-    "nuxt": "^1.0.0-rc3"
+    "nuxt": "latest"
   },
   "scripts": {
     "dev": "node server.js",

--- a/examples/custom-server/server.js
+++ b/examples/custom-server/server.js
@@ -1,5 +1,6 @@
 const app = require('express')()
 const { Nuxt, Builder } = require('nuxt')
+const chalk = require('chalk')
 
 const host = process.env.HOST || '127.0.0.1'
 const port = process.env.PORT || 3000
@@ -21,4 +22,4 @@ app.use(nuxt.render)
 
 // Start express server
 app.listen(port, host)
-console.log('Server listening on ' + host + ':' + port)
+console.log('\n' + chalk.bgGreen.black(' OPEN ') + chalk.green(` http://${host}:${port}`))


### PR DESCRIPTION
`Open message` will be show before building completed, how you think to put below codes into `server.js` ?
```js
nuxt.showOpen = () => {
    console.log('\n' + chalk.bgGreen.black(' OPEN ') + chalk.green(` http://${_host}:${port}\n`))
}
```