### PR TITLE
Support ES6 modules in Nuxt config

### DIFF
--- a/bin/nuxt-build
+++ b/bin/nuxt-build
@@ -3,6 +3,7 @@
 // Show logs
 process.env.DEBUG = process.env.DEBUG || 'nuxt:*'
 
+require('babel-register');
 const fs = require('fs')
 const parseArgs = require('minimist')
 const { Nuxt, Builder, Generator } = require('../')

--- a/bin/nuxt-build
+++ b/bin/nuxt-build
@@ -3,7 +3,7 @@
 // Show logs
 process.env.DEBUG = process.env.DEBUG || 'nuxt:*'
 
-require('babel-register');
+require('babel-register')
 const fs = require('fs')
 const parseArgs = require('minimist')
 const { Nuxt, Builder, Generator } = require('../')

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "babel-plugin-array-includes": "^2.0.3",
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-plugin-istanbul": "^4.1.5",
+    "babel-register": "^6.26.0",
     "codecov": "^2.3.0",
     "copy-webpack-plugin": "^4.1.1",
     "cross-env": "^5.0.5",


### PR DESCRIPTION
When requiring modules in `nuxt.config.js`, the build task crashes if the required modules contain ES6 features.

To reproduce this, you could create a simple module in the project's root: 
```js
// module.js

import { has } from 'lodash';

export default {}
```

Then import this module in `nuxt.config.js`:
```js
// nuxt.config.js

const test = require(__dirname + '/module.js');
```

Running `yarn dev` should work properly but running `yarn build` fails with following error:
```
yarn run v1.2.1
$ nuxt build && backpack build
/path/to/nuxt/app/module.js:3
import { has } from 'lodash';
^^^^^^

SyntaxError: Unexpected token import
```

I don't know if requiring `babel-register` is the proper way to fix this but it works in my case.