### PR TITLE
(generate) dont assume /index.html exists when copying to 200.html

### DIFF
--- a/lib/builder/generator.js
+++ b/lib/builder/generator.js
@@ -73,11 +73,14 @@ export default class Generator extends Tapable {
       }))
     }
 
-    // Copy /index.html to /200.html for surge SPA
-    // https://surge.sh/help/adding-a-200-page-for-client-side-routing
-    const _200Path = join(this.distPath, '200.html')
-    if (!existsSync(_200Path)) {
-      await copy(join(this.distPath, 'index.html'), _200Path)
+    const indexPath = join(this.distPath, 'index.html')
+    if (existsSync(indexPath) {
+      // Copy /index.html to /200.html for surge SPA
+      // https://surge.sh/help/adding-a-200-page-for-client-side-routing
+      const _200Path = join(this.distPath, '200.html')
+      if (!existsSync(_200Path)) {
+        await copy(indexPath, _200Path)
+      }
     }
 
     const duration = Math.round((Date.now() - s) / 100) / 10


### PR DESCRIPTION
It may be an edge-case but users might not have a `/index.html` in their project. So only copy it to `200.html` if an index file exists.