### PR TITLE
fix: syntax error in generator.js

### DIFF
--- a/lib/builder/generator.js
+++ b/lib/builder/generator.js
@@ -74,7 +74,7 @@ export default class Generator extends Tapable {
     }
 
     const indexPath = join(this.distPath, 'index.html')
-    if (existsSync(indexPath) {
+    if (existsSync(indexPath)) {
       // Copy /index.html to /200.html for surge SPA
       // https://surge.sh/help/adding-a-200-page-for-client-side-routing
       const _200Path = join(this.distPath, '200.html')


### PR DESCRIPTION
Fix error caused by https://github.com/nuxt/nuxt.js/pull/1937
@Atinux @pi0 