### PR TITLE
feat: add subFolders option for generate

### DIFF
--- a/lib/builder/generator.js
+++ b/lib/builder/generator.js
@@ -179,8 +179,15 @@ export default class Generator {
       }
     }
 
-    let path = join(route, sep, 'index.html') // /about -> /about/index.html
-    path = (path === '/404/index.html') ? '/404.html' : path // /404 -> /404.html
+    let path
+
+    if (this.options.generate.subFolders) {
+      path = join(route, sep, 'index.html') // /about -> /about/index.html
+      path = path === '/404/index.html' ? '/404.html' : path // /404 -> /404.html
+    } else {
+      path =
+        route.length > 1 ? join(sep, route + '.html') : join(sep, 'index.html')
+    }
 
     // Call hook to let user update the path & html
     const page = { route, path, html }

--- a/lib/common/options.js
+++ b/lib/common/options.js
@@ -208,6 +208,7 @@ Options.defaults = {
     routes: [],
     concurrency: 500,
     interval: 0,
+    subFolders: true,
     minify: {
       collapseBooleanAttributes: true,
       collapseWhitespace: false,

--- a/test/basic.generate.nosubfolders.test.js
+++ b/test/basic.generate.nosubfolders.test.js
@@ -1,0 +1,135 @@
+import test from 'ava'
+import { resolve } from 'path'
+import http from 'http'
+import serveStatic from 'serve-static'
+import finalhandler from 'finalhandler'
+import rp from 'request-promise-native'
+import { Nuxt, Builder, Generator } from '../index.js'
+
+const port = 4002
+const url = (route) => 'http://localhost:' + port + route
+
+let nuxt = null
+let server = null
+
+// Init nuxt.js and create server listening on localhost:4000
+test.before('Init Nuxt.js', async t => {
+  const rootDir = resolve(__dirname, 'fixtures/basic')
+  let config = require(resolve(rootDir, 'nuxt.config.js'))
+  config.rootDir = rootDir
+  config.dev = false
+  config.generate.subFolders = false
+
+  nuxt = new Nuxt(config)
+  const builder = new Builder(nuxt)
+  const generator = new Generator(nuxt, builder)
+  try {
+    await generator.generate() // throw an error (of /validate route)
+  } catch (err) {
+  }
+
+  const serve = serveStatic(resolve(__dirname, 'fixtures/basic/dist'), { extensions: ['html'] })
+  server = http.createServer((req, res) => {
+    serve(req, res, finalhandler(req, res))
+  })
+  server.listen(port)
+})
+
+test('Check ready hook called', async t => {
+  t.true(nuxt.__hook_called__)
+})
+
+test('/stateless', async t => {
+  const window = await nuxt.renderAndGetWindow(url('/stateless'))
+  const html = window.document.body.innerHTML
+  t.true(html.includes('<h1>My component!</h1>'))
+})
+
+test('/css', async t => {
+  const window = await nuxt.renderAndGetWindow(url('/css'))
+  const element = window.document.querySelector('.red')
+  t.not(element, null)
+  t.is(element.textContent, 'This is red')
+  t.is(element.className, 'red')
+  t.is(window.getComputedStyle(element).color, 'red')
+})
+
+test('/stateful', async t => {
+  const window = await nuxt.renderAndGetWindow(url('/stateful'))
+  const html = window.document.body.innerHTML
+  t.true(html.includes('<div><p>The answer is 42</p></div>'))
+})
+
+test('/head', async t => {
+  const window = await nuxt.renderAndGetWindow(url('/head'))
+  const html = window.document.body.innerHTML
+  const metas = window.document.getElementsByTagName('meta')
+  t.is(window.document.title, 'My title')
+  t.is(metas[0].getAttribute('content'), 'my meta')
+  t.true(html.includes('<div><h1>I can haz meta tags</h1></div>'))
+})
+
+test('/async-data', async t => {
+  const window = await nuxt.renderAndGetWindow(url('/async-data'))
+  const html = window.document.body.innerHTML
+  t.true(html.includes('<p>Nuxt.js</p>'))
+})
+
+test('/users/1', async t => {
+  const html = await rp(url('/users/1'))
+  t.true(html.includes('<h1>User: 1</h1>'))
+})
+
+test('/users/2', async t => {
+  const html = await rp(url('/users/2'))
+  t.true(html.includes('<h1>User: 2</h1>'))
+})
+
+test('/users/3 (payload given)', async t => {
+  const html = await rp(url('/users/3'))
+  t.true(html.includes('<h1>User: 3000</h1>'))
+})
+
+test('/users/4 -> Not found', async t => {
+  try {
+    await rp(url('/users/4'))
+  } catch (error) {
+    t.true(error.statusCode === 404)
+    t.true(error.response.body.includes('Cannot GET /users/4'))
+  }
+})
+
+test('/validate should not be server-rendered', async t => {
+  const html = await rp(url('/validate'))
+  t.true(html.includes('<div id="__nuxt"></div>'))
+  t.true(html.includes('serverRendered:!1'))
+})
+
+test('/validate -> should display a 404', async t => {
+  const window = await nuxt.renderAndGetWindow(url('/validate'))
+  const html = window.document.body.innerHTML
+  t.true(html.includes('This page could not be found'))
+})
+
+test('/validate?valid=true', async t => {
+  const window = await nuxt.renderAndGetWindow(url('/validate?valid=true'))
+  const html = window.document.body.innerHTML
+  t.true(html.includes('I am valid</h1>'))
+})
+
+test('/redirect should not be server-rendered', async t => {
+  const html = await rp(url('/redirect'))
+  t.true(html.includes('<div id="__nuxt"></div>'))
+  t.true(html.includes('serverRendered:!1'))
+})
+
+test('/redirect -> check redirected source', async t => {
+  const window = await nuxt.renderAndGetWindow(url('/redirect'))
+  const html = window.document.body.innerHTML
+  t.true(html.includes('<h1>Index page</h1>'))
+})
+
+// Close server and ask nuxt to stop listening to file changes
+test.after('Closing server', t => {
+  server.close()
+})

--- a/test/fixtures/basic/nuxt.config.js
+++ b/test/fixtures/basic/nuxt.config.js
@@ -5,7 +5,8 @@ module.exports = {
       '/users/2',
       { route: '/users/3', payload: { id: 3000 } }
     ],
-    interval: 200
+    interval: 200,
+    subFolders: true
   },
   hooks: {
     ready(nuxt) {


### PR DESCRIPTION
Hi there,

First of all, thank you for this awesome project & all the effort you are putting together to make Nuxt.js awesome!

I faced a little issue using `nuxt generate` as it creates a directory for every route & write an index.html inside it.

```bash
index.html
/about/index.html
/contact/index.html
```

However, most CDN (& or static hosting) do URL normalization to enforce consistent URL patterns (e.g Netlify).

Quoted from Netlify documentation:

```
When “Pretty URLs” is enabled under processing settings for your site, Netlify will enforce consistent URL patterns.

A link to /about.html will be rewritten to /about in your HTML files and Netlify will enforce a redirect from /about/ to /about

A link to /about/index.html will be rewritten to /about/ and Netlify will redirect from /about to /about/
```

With that said, the current generate does not suit the following scenario:

Let's say I have the following routes:

```
- /
- /about
- /contact
```

1. My webapp loads on `/` (e.g: https://example.com)
2. I navigate to a route using CSR (e.g https://example.com/about)
3. I refresh & been redirected to https://example.com/about/

Which means, if Google crawls `/about`, it will face a 301 redirection to `/about/` (using Netlify for example).

Adding the `subFolders` option to `generate` fixes this problem.

Any thoughts/restrictions?

Fixes
-----
- [x] #721

Todo
-----
- [x] Tests
- [x] Add documentation under [Configuration / Generate](https://nuxtjs.org/api/configuration-generate)