### PR TITLE
Fix route redirect

### DIFF
--- a/lib/app/router.js
+++ b/lib/app/router.js
@@ -11,7 +11,8 @@ function recursiveRoutes(routes, tab, components) {
     components.push({ _name: route._name, component: route.component, name: route.name, chunkName: route.chunkName })
     res += tab + '{\n'
     res += tab + '\tpath: ' + JSON.stringify(route.path) + ',\n'
-    res += tab + '\tcomponent: ' + route._name
+    if (route.component) res += tab + '\tcomponent: ' + route._name
+    if (route.redirect) res += tab + '\tredirect: ' + JSON.stringify(route.redirect)
     res += (route.name) ? ',\n\t' + tab + 'name: ' + JSON.stringify(route.name) : ''
     res += (route.children) ? ',\n\t' + tab + 'children: [\n' + recursiveRoutes(routes[i].children, tab + '\t\t', components) + '\n\t' + tab + ']' : ''
     res += '\n' + tab + '}' + (i + 1 === routes.length ? '' : ',\n')
@@ -20,8 +21,8 @@ function recursiveRoutes(routes, tab, components) {
 }
 const _components = []
 const _routes = recursiveRoutes(router.routes, '\t\t', _components)
-uniqBy(_components, '_name').forEach((route) => { %>const <%= route._name %> = () => import('<%= relativeToBuild(route.component) %>' /* webpackChunkName: "<%= wChunk(route.chunkName) %>" */).then(m => m.default || m)
-<% }) %>
+uniqBy(_components, '_name').forEach((route) => { if (route.component) { %>const <%= route._name %> = () => import('<%= relativeToBuild(route.component) %>' /* webpackChunkName: "<%= wChunk(route.chunkName) %>" */).then(m => m.default || m)
+<% } }) %>
 
 <% if (router.scrollBehavior) { %>
 const scrollBehavior = <%= serialize(router.scrollBehavior).replace('scrollBehavior(', 'function(').replace('function function', 'function') %>


### PR DESCRIPTION
If you extend the routes via `router.extendRoutes` or override  `build.createRoutes` and add a new route with just the `path` and `redirect` it will still try to import the route component and fail.

This checks if `route.component` or `route.redirect` exists. 