### PR TITLE
refactor: log nuxtServerInit error for better error tracing

### DIFF
--- a/lib/app/server.js
+++ b/lib/app/server.js
@@ -91,7 +91,12 @@ export default async ssrContext => {
   ** Dispatch store nuxtServerInit
   */
   if (store._actions && store._actions.nuxtServerInit) {
-    await store.dispatch('nuxtServerInit', app.context)
+    try {
+      await store.dispatch('nuxtServerInit', app.context)
+    } catch (err) {
+      debug('error occurred when calling nuxtServerInit: ', e.message)
+      throw err
+    }
   }
   // ...If there is a redirect or an error, stop the process
   if (ssrContext.redirected) return noopApp()


### PR DESCRIPTION
If `nuxtServerInit` has error when uses `nuxt generate`,  console only outputs `Error: ENOENT: no such file or directory, lstat 'dist/index.html'`.

There has been bunch of issues related to it.(https://github.com/nuxt/nuxt.js/issues/1943, https://github.com/nuxt/nuxt.js/issues/2068), it's difficult to locate the error cause.