### PR TITLE
feat: make extractCSS configurable

### DIFF
--- a/lib/builder/webpack/base.config.js
+++ b/lib/builder/webpack/base.config.js
@@ -105,10 +105,13 @@ export default function webpackBaseConfig(name) {
   }
 
   // CSS extraction
-  if (this.options.build.extractCSS) {
-    config.plugins.push(new ExtractTextPlugin({
-      filename: this.options.build.filenames.css
-    }))
+  const extractCSS = this.options.build.extractCSS
+  if (extractCSS) {
+    const extractOptions = Object.assign(
+      { filename: this.options.build.filenames.css },
+      typeof extractCSS === 'object' ? extractCSS : {}
+    )
+    config.plugins.push(new ExtractTextPlugin(extractOptions))
   }
 
   // Workaround for hiding Warnings about plugins without a default export (#1179)

--- a/lib/builder/webpack/vue-loader.config.js
+++ b/lib/builder/webpack/vue-loader.config.js
@@ -2,7 +2,7 @@ export default function vueLoader() {
   // https://vue-loader.vuejs.org/en
   const config = {
     postcss: this.options.build.postcss,
-    extractCSS: this.options.build.extractCSS,
+    extractCSS: !!this.options.build.extractCSS,
     cssSourceMap: this.options.build.cssSourceMap,
     preserveWhitespace: false,
     loaders: {


### PR DESCRIPTION
If extractCSS is an object, take it as the options of [extract-text-webpack-plugin](https://github.com/webpack-contrib/extract-text-webpack-plugin#options), e.g., add `allChunks: true` to extract css from all pages (webpack code split chunks ), resolve https://github.com/nuxt/nuxt.js/issues/1533.
```js
module.exports = {
  build: {
    extractCSS: {
      allChunks: true
    }
  }
}
```