### PR TITLE
Better explanation for using tailwind with postcss-import

### DIFF
--- a/examples/tailwindcss/assets/css/tailwind.css
+++ b/examples/tailwindcss/assets/css/tailwind.css
@@ -4,42 +4,54 @@
  *
  * You can see the styles here:
  * https://github.com/tailwindcss/tailwindcss/blob/master/css/preflight.css
+ *
+ * If using `postcss-import`, you should import this line from it's own file:
+ *
+ * @import "./tailwind-preflight.css";
+ *
+ * See: https://github.com/tailwindcss/tailwindcss/issues/53#issuecomment-341413622
  */
  @tailwind preflight;
 
-  /**
-   * Here you would add any of your custom component classes; stuff that you'd
-   * want loaded *before* the utilities so that the utilities could still
-   * override them.
-   *
-   * Example:
-   *
-   * .btn { ... }
-   * .form-input { ... }
-   *
-   * Or if using a preprocessor:
-   *
-   * @import "components/buttons";
-   * @import "components/forms";
-   */
+ /**
+  * Here you would add any of your custom component classes; stuff that you'd
+  * want loaded *before* the utilities so that the utilities could still
+  * override them.
+  *
+  * Example:
+  *
+  * .btn { ... }
+  * .form-input { ... }
+  *
+  * Or if using a preprocessor or `postcss-import`:
+  *
+  * @import "components/buttons";
+  * @import "components/forms";
+  */
 
-  /**
-   * This injects all of Tailwind's utility classes, generated based on your
-   * config file.
-   */
-  @tailwind utilities;
+ /**
+  * This injects all of Tailwind's utility classes, generated based on your
+  * config file.
+  *
+  * If using `postcss-import`, you should import this line from it's own file:
+  *
+  * @import "./tailwind-utilities.css";
+  *
+  * See: https://github.com/tailwindcss/tailwindcss/issues/53#issuecomment-341413622
+  */
+ @tailwind utilities;
 
-  /**
-   * Here you would add any custom utilities you need that don't come out of the
-   * box with Tailwind.
-   *
-   * Example :
-   *
-   * .bg-pattern-graph-paper { ... }
-   * .skew-45 { ... }
-   *
-   * Or if using a preprocessor..
-   *
-   * @import "utilities/backgrond-patterns";
-   * @import "utilities/skew-transforms";
-   */
+ /**
+  * Here you would add any custom utilities you need that don't come out of the
+  * box with Tailwind.
+  *
+  * Example :
+  *
+  * .bg-pattern-graph-paper { ... }
+  * .skew-45 { ... }
+  *
+  * Or if using a preprocessor or `postcss-import`:
+  *
+  * @import "utilities/background-patterns";
+  * @import "utilities/skew-transforms";
+  */


### PR DESCRIPTION
After discussion with @adamwathan, I have added his comments about using tailwind with `postcss-import`. This PR specifies that you need to split `tailwind.css` into separate CSS files in order to use `postcss-import`. Perhaps the example would be better showing just that, but as @adamwathan says; *"the reason I think it's a bad default to include postcss-import is because you take away the choice of whether or not to inline those imports from the user. If you add that plugin, you can't do a normal CSS import that does a separate HTTP request anymore."*

Manual cherry-pick https://github.com/tailwindcss/tailwindcss/commit/ad44fae29fe9d8da189b02602558f60986bebb49

Closing #2094 