### PR TITLE
Add hook call after route generated.

### DIFF
--- a/lib/builder/generator.js
+++ b/lib/builder/generator.js
@@ -67,6 +67,7 @@ export default class Generator {
       await Promise.all(routes.splice(0, this.options.generate.concurrency).map(async ({ route, payload }) => {
         await waitFor(n++ * this.options.generate.interval)
         await this.generateRoute({ route, payload, errors })
+        await this.applyPluginsAsync('generated-route', { generator: this, routes, route })
       }))
     }
 

--- a/lib/builder/generator.js
+++ b/lib/builder/generator.js
@@ -67,7 +67,7 @@ export default class Generator {
       await Promise.all(routes.splice(0, this.options.generate.concurrency).map(async ({ route, payload }) => {
         await waitFor(n++ * this.options.generate.interval)
         await this.generateRoute({ route, payload, errors })
-        await this.applyPluginsAsync('generated-route', { generator: this, routes, route })
+        await this.applyPluginsAsync('generated-route', { generator: this, routes, route, errors })
       }))
     }
 

--- a/lib/builder/generator.js
+++ b/lib/builder/generator.js
@@ -67,7 +67,7 @@ export default class Generator {
       await Promise.all(routes.splice(0, this.options.generate.concurrency).map(async ({ route, payload }) => {
         await waitFor(n++ * this.options.generate.interval)
         await this.generateRoute({ route, payload, errors })
-        await this.applyPluginsAsync('generated-route', { generator: this, routes, route, errors })
+        await this.nuxt.callHook('generate:routeCreated', route)
       }))
     }
 


### PR DESCRIPTION
There is no way to know when an individual route has been generated.  This PR adds the ability to know when a route is generated.

**Why?**
I have the need to generate over 30,000 static pages.  This work is distributed across a generation farm and batched out.  I have monitoring tools in place that need to know the % completion of each worker in the generation farm.  Currently we only know when generation starts and when it ends.  By adding this call after a route has been generated we know the progress of each worker.

**Example Usage**
```
  debug(`Setting ${job.data.routes.length} routes for generation.`);
  options.generate.routes = job.data.routes;

  debug('Generating...');
  const nuxt = new Nuxt(options),
        builder = new Builder(nuxt),
        generator = new Generator(nuxt, builder);

  let numGenerated = 0;

  generator.plugin('generated-route', async ({route}) => {
    numGenerated++;
    job.progress(numGenerated, job.data.routes.length, {route});
    console.log('generated-route:', numGenerated);
  });

  generator.generate()
    .then(() => {
      debug('Generate done');
      done();
      process.exit(0);
    })
    .catch((err) => {
      done();
      console.error(err); // eslint-disable-line no-console
      process.exit(1);
    });
```