### PR TITLE
Show all ipv4 addresses when server is running on unspecified address

### DIFF
--- a/lib/core/nuxt.js
+++ b/lib/core/nuxt.js
@@ -120,7 +120,28 @@ export default class Nuxt {
 
         const _host = host === '0.0.0.0' ? 'localhost' : host
         // eslint-disable-next-line no-console
-        console.log('\n' + chalk.bgGreen.black(' OPEN ') + chalk.green(` http://${_host}:${port}\n`))
+        console.log('\n' + chalk.bgGreen.black(' OPEN ') + chalk.green(` http://${_host}:${port}`))
+
+        if (host === '0.0.0.0') {
+          const ifaces = require('os').networkInterfaces()
+
+          Object.keys(ifaces).forEach((ifName) => {
+            let ifAliasNum = 0
+            let ifAlias = ''
+            ifaces[ifName].forEach((iface, index) => {
+              if (iface.family === 'IPv4' && iface.internal === false) {
+                if (ifAliasNum > 0) {
+                  ifAlias = `:${ifAliasNum}`
+                }
+                // eslint-disable-next-line no-console
+                console.log(chalk.bgGreen.black(` OPEN (${ifName}${ifAlias}) `) + chalk.green(` http://${iface.address}:${port}`))
+                ifAliasNum++
+              }
+            })
+          })
+        }
+        // eslint-disable-next-line no-console
+        console.log('\n')
 
         // Close server on nuxt close
         this.hook('close', () => new Promise((resolve, reject) => {


### PR DESCRIPTION
Ref: https://github.com/nuxt/nuxt.js/issues/2180

It can be confusing that if you run the server with a unspecified address it will always show that its running on localhost. This pr changes that behaviour by listing all ipv4 address the server is listening on.

Example output:
![image](https://user-images.githubusercontent.com/1067403/33072778-0e96940c-cec1-11e7-941f-4cec3de4568a.png)
