### PR TITLE
Generator refactoring

### DIFF
--- a/bin/nuxt-build
+++ b/bin/nuxt-build
@@ -80,6 +80,38 @@ if (options.mode !== 'spa') {
       process.exit(1)
     })
 } else {
+  const s = Date.now()
+
+  nuxt.hook('generate:distRemoved', function() {
+    debug('Destination folder cleaned')
+  })
+
+  nuxt.hook('generate:distCopied', function() {
+    debug('Static & build files copied')
+  })
+
+  nuxt.hook('generate:page', function(page) {
+    debug('Generate file: ' + page.path)
+  })
+
+  nuxt.hook('generate:done', function(generator, errors) {
+    const duration = Math.round((Date.now() - s) / 100) / 10
+
+    debug(`HTML Files generated in ${duration}s`)
+
+    if (errors.length) {
+      const report = errors.map(({ type, route, error }) => {
+        /* istanbul ignore if */
+        if (type === 'unhandled') {
+          return `Route: '${route}'\n${error.stack}`
+        } else {
+          return `Route: '${route}' thrown an error: \n` + JSON.stringify(error)
+        }
+      })
+      console.error('==== Error report ==== \n' + report.join('\n\n')) // eslint-disable-line no-console
+    }
+  })
+
   // Disable minify to get exact results of nuxt start
   nuxt.options.generate.minify = false
   // Generate on spa mode

--- a/bin/nuxt-generate
+++ b/bin/nuxt-generate
@@ -85,7 +85,7 @@ nuxt.hook('generate:page', function(page) {
   debug('Generate file: ' + page.path)
 })
 
-nuxt.hook('generate:done', function(errors) {
+nuxt.hook('generate:done', function(generator, errors) {
   const duration = Math.round((Date.now() - s) / 100) / 10
 
   debug(`HTML Files generated in ${duration}s`)

--- a/bin/nuxt-generate
+++ b/bin/nuxt-generate
@@ -71,8 +71,40 @@ const generateOptions = {
   build: argv['build']
 }
 
+const s = Date.now()
+
+nuxt.hook('generate:distRemoved', function() {
+  debug('Destination folder cleaned')
+})
+
+nuxt.hook('generate:distCopied', function() {
+  debug('Static & build files copied')
+})
+
+nuxt.hook('generate:page', function(page) {
+  debug('Generate file: ' + page.path)
+})
+
+nuxt.hook('generate:done', function(errors) {
+  const duration = Math.round((Date.now() - s) / 100) / 10
+
+  debug(`HTML Files generated in ${duration}s`)
+
+  if (errors.length) {
+    const report = errors.map(({ type, route, error }) => {
+      /* istanbul ignore if */
+      if (type === 'unhandled') {
+        return `Route: '${route}'\n${error.stack}`
+      } else {
+        return `Route: '${route}' thrown an error: \n` + JSON.stringify(error)
+      }
+    })
+    console.error('==== Error report ==== \n' + report.join('\n\n')) // eslint-disable-line no-console
+  }
+})
+
 generator.generate(generateOptions)
-  .then(() => {
+  .then(({ errors }) => {
     debug('Generate done')
     process.exit(0)
   })

--- a/bin/nuxt-generate
+++ b/bin/nuxt-generate
@@ -104,7 +104,7 @@ nuxt.hook('generate:done', function(errors) {
 })
 
 generator.generate(generateOptions)
-  .then(({ errors }) => {
+  .then(() => {
     debug('Generate done')
     process.exit(0)
   })

--- a/lib/builder/generator.js
+++ b/lib/builder/generator.js
@@ -21,14 +21,27 @@ export default class Generator {
   }
 
   async generate({ build = true, init = true } = {}) {
+    const s = Date.now()
+
+    await this.initiate({ build, init })
+
+    const routes = await this.initRoutes()
+
+    const errors = await this.generateRoutes(routes)
+    await this.afterGenerate()
+
+    const duration = Math.round((Date.now() - s) / 100) / 10
+    this.printReport(duration, errors)
+
+    return { duration, errors }
+  }
+
+  async initiate({ build = true, init = true } = {}) {
     // Wait for nuxt be ready
     await this.nuxt.ready()
 
     // Call before hook
     await this.nuxt.callHook('generate:before', this, this.options.generate)
-
-    const s = Date.now()
-    let errors = []
 
     // Add flag to set process.static
     this.builder.forGenerate()
@@ -42,7 +55,9 @@ export default class Generator {
     if (init) {
       await this.initDist()
     }
+  }
 
+  async initRoutes() {
     // Resolve config.generate.routes promises before generating the routes
     let generateRoutes = []
     if (this.options.router.mode !== 'hash') {
@@ -61,16 +76,25 @@ export default class Generator {
     // extendRoutes hook
     await this.nuxt.callHook('generate:extendRoutes', routes)
 
+    return routes
+  }
+
+  async generateRoutes(routes) {
+    let errors = []
+
     // Start generate process
     while (routes.length) {
       let n = 0
       await Promise.all(routes.splice(0, this.options.generate.concurrency).map(async ({ route, payload }) => {
         await waitFor(n++ * this.options.generate.interval)
         await this.generateRoute({ route, payload, errors })
-        await this.nuxt.callHook('generate:routeCreated', route)
       }))
     }
 
+    return errors
+  }
+
+  async afterGenerate() {
     const indexPath = join(this.distPath, 'index.html')
     if (existsSync(indexPath)) {
       // Copy /index.html to /200.html for surge SPA
@@ -80,8 +104,9 @@ export default class Generator {
         await copy(indexPath, _200Path)
       }
     }
+  }
 
-    const duration = Math.round((Date.now() - s) / 100) / 10
+  async printReport(duration, errors) {
     debug(`HTML Files generated in ${duration}s`)
 
     // done hook
@@ -98,8 +123,6 @@ export default class Generator {
       })
       console.error('==== Error report ==== \n' + report.join('\n\n')) // eslint-disable-line no-console
     }
-
-    return { duration, errors }
   }
 
   async initDist() {

--- a/lib/builder/generator.js
+++ b/lib/builder/generator.js
@@ -3,9 +3,6 @@ import _ from 'lodash'
 import { resolve, join, dirname, sep } from 'path'
 import { minify } from 'html-minifier'
 import { isUrl, promisifyRoute, waitFor, flatRoutes } from 'utils'
-import Debug from 'debug'
-
-const debug = Debug('nuxt:generate')
 
 export default class Generator {
   constructor(nuxt, builder) {
@@ -21,8 +18,6 @@ export default class Generator {
   }
 
   async generate({ build = true, init = true } = {}) {
-    const s = Date.now()
-
     await this.initiate({ build, init })
 
     const routes = await this.initRoutes()
@@ -30,10 +25,10 @@ export default class Generator {
     const errors = await this.generateRoutes(routes)
     await this.afterGenerate()
 
-    const duration = Math.round((Date.now() - s) / 100) / 10
-    this.printReport(duration, errors)
+    // done hook
+    await this.nuxt.callHook('generate:done', this, errors)
 
-    return { duration, errors }
+    return { errors }
   }
 
   async initiate({ build = true, init = true } = {}) {
@@ -106,29 +101,11 @@ export default class Generator {
     }
   }
 
-  async printReport(duration, errors) {
-    debug(`HTML Files generated in ${duration}s`)
-
-    // done hook
-    await this.nuxt.callHook('generate:done', this, errors)
-
-    if (errors.length) {
-      const report = errors.map(({ type, route, error }) => {
-        /* istanbul ignore if */
-        if (type === 'unhandled') {
-          return `Route: '${route}'\n${error.stack}`
-        } else {
-          return `Route: '${route}' thrown an error: \n` + JSON.stringify(error)
-        }
-      })
-      console.error('==== Error report ==== \n' + report.join('\n\n')) // eslint-disable-line no-console
-    }
-  }
-
   async initDist() {
     // Clean destination folder
     await remove(this.distPath)
-    debug('Destination folder cleaned')
+
+    await this.nuxt.callHook('generate:distRemoved', this)
 
     // Copy static and built files
     /* istanbul ignore if */
@@ -156,7 +133,7 @@ export default class Generator {
       }
     })
 
-    debug('Static & build files copied')
+    await this.nuxt.callHook('generate:distCopied', this)
   }
 
   decorateWithPayloads(routes, generateRoutes) {
@@ -222,7 +199,6 @@ export default class Generator {
     const page = { route, path, html }
     await this.nuxt.callHook('generate:page', page)
 
-    debug('Generate file: ' + page.path)
     page.path = join(this.distPath, page.path)
 
     // Make sure the sub folders are created

--- a/lib/builder/generator.js
+++ b/lib/builder/generator.js
@@ -14,7 +14,7 @@ export default class Generator {
     this.builder = builder
 
     // Set variables
-    this.generateRoutes = resolve(this.options.srcDir, 'static')
+    this.staticRoutes = resolve(this.options.srcDir, 'static')
     this.srcBuiltPath = resolve(this.options.buildDir, 'dist')
     this.distPath = resolve(this.options.rootDir, this.options.generate.dir)
     this.distNuxtPath = join(this.distPath, (isUrl(this.options.build.publicPath) ? '' : this.options.build.publicPath))
@@ -109,8 +109,8 @@ export default class Generator {
 
     // Copy static and built files
     /* istanbul ignore if */
-    if (existsSync(this.generateRoutes)) {
-      await copy(this.generateRoutes, this.distPath)
+    if (existsSync(this.staticRoutes)) {
+      await copy(this.staticRoutes, this.distPath)
     }
     await copy(this.srcBuiltPath, this.distNuxtPath)
 

--- a/lib/builder/generator.js
+++ b/lib/builder/generator.js
@@ -182,16 +182,21 @@ export default class Generator {
 
   async generateRoute({ route, payload = {}, errors = [] }) {
     let html
+    let pageErrors = []
 
     try {
       const res = await this.nuxt.renderer.renderRoute(route, { _generate: true, payload })
       html = res.html
       if (res.error) {
-        errors.push({ type: 'handled', route, error: res.error })
+        pageErrors.push({ type: 'handled', route, error: res.error })
       }
     } catch (err) {
       /* istanbul ignore next */
-      return errors.push({ type: 'unhandled', route, error: err })
+      pageErrors.push({ type: 'unhandled', route, error: err })
+
+      await this.nuxt.callHook('generate:routeFailed', { route, errors: pageErrors })
+
+      return false
     }
 
     if (this.options.generate.minify) {
@@ -199,7 +204,7 @@ export default class Generator {
         html = minify(html, this.options.generate.minify)
       } catch (err) /* istanbul ignore next */ {
         const minifyErr = new Error(`HTML minification failed. Make sure the route generates valid HTML. Failed HTML:\n ${html}`)
-        errors.push({ type: 'unhandled', route, error: minifyErr })
+        pageErrors.push({ type: 'unhandled', route, error: minifyErr })
       }
     }
 
@@ -223,6 +228,12 @@ export default class Generator {
     // Make sure the sub folders are created
     await mkdirp(dirname(page.path))
     await writeFile(page.path, page.html, 'utf8')
+
+    await this.nuxt.callHook('generate:routeCreated', { route, path: page.path, errors: pageErrors })
+
+    if (pageErrors.length) {
+      Array.prototype.push.apply(errors, pageErrors)
+    }
 
     return true
   }

--- a/lib/builder/generator.js
+++ b/lib/builder/generator.js
@@ -159,7 +159,7 @@ export default class Generator {
 
   async generateRoute({ route, payload = {}, errors = [] }) {
     let html
-    let pageErrors = []
+    const pageErrors = []
 
     try {
       const res = await this.nuxt.renderer.renderRoute(route, { _generate: true, payload })
@@ -170,6 +170,7 @@ export default class Generator {
     } catch (err) {
       /* istanbul ignore next */
       pageErrors.push({ type: 'unhandled', route, error: err })
+      Array.prototype.push.apply(errors, pageErrors)
 
       await this.nuxt.callHook('generate:routeFailed', { route, errors: pageErrors })
 

--- a/test/children.patch.test.js
+++ b/test/children.patch.test.js
@@ -111,7 +111,7 @@ test('Search a country', async t => {
 
   await page.type('[data-test-search-input]', 'gu')
 
-  await Utils.waitFor(100)
+  await Utils.waitFor(250)
   const newCountries = await page.$$text('[data-test-search-result]')
   t.is(newCountries.length, 1)
   t.deepEqual(newCountries, ['Guinea'])

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -63,7 +63,6 @@ test('bin/nuxt-start', async t => {
   const html = await rp(url('/users/1'))
   t.true(html.includes('<h1>User: 1</h1>'))
 
-  await Utils.waitFor(1000)
   nuxtStart.kill()
 
   // Wait max 10s for the process to be killed

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,0 +1,96 @@
+import test from 'ava'
+import { resolve } from 'path'
+import rp from 'request-promise-native'
+import { Utils } from '../index.js'
+import { promisify } from 'util'
+import { exec, spawn } from 'child_process'
+
+const execify = promisify(exec)
+const rootDir = resolve(__dirname, 'fixtures/basic')
+
+const port = 4011
+const url = (route) => 'http://localhost:' + port + route
+
+test('bin/nuxt-build', async t => {
+  const binBuild = resolve(__dirname, '..', 'bin', 'nuxt-build')
+
+  const { error, stdout, stderr } = await execify(`${binBuild} ${rootDir}`)
+
+  t.is(error, undefined)
+  t.true(stdout.includes('server-bundle.json'))
+  t.true(stderr.includes('Building done'))
+})
+
+test('bin/nuxt-start', async t => {
+  const binStart = resolve(__dirname, '..', 'bin', 'nuxt-start')
+
+  let stdout = ''
+  let stderr = ''
+  let error
+  let exitCode
+
+  const env = process.env
+  env.PORT = port
+
+  const nuxtStart = spawn(binStart, [rootDir], { env: env })
+
+  nuxtStart.stdout.on('data', (data) => {
+    stdout += data
+  })
+
+  nuxtStart.stderr.on('data', (data) => {
+    stderr += data
+  })
+
+  nuxtStart.on('error', (err) => {
+    error = err
+  })
+
+  nuxtStart.on('close', (code) => {
+    exitCode = code
+  })
+
+  // Give the process max 10s to start
+  let iterator = 0
+  while (!stdout.includes('OPEN') && iterator < 40) {
+    await Utils.waitFor(250)
+    iterator++
+  }
+
+  t.is(error, undefined)
+  t.true(stdout.includes('OPEN'))
+
+  const html = await rp(url('/users/1'))
+  t.true(html.includes('<h1>User: 1</h1>'))
+
+  await Utils.waitFor(1000)
+  nuxtStart.kill()
+
+  // Wait max 10s for the process to be killed
+  iterator = 0
+  while (exitCode === undefined && iterator < 40) { // eslint-disable-line no-unmodified-loop-condition
+    await Utils.waitFor(250)
+    iterator++
+  }
+
+  if (iterator >= 40) {
+    t.log(`WARN: we were unable to automatically kill the child process with pid: ${nuxtStart.pid}`)
+  }
+
+  t.is(stderr, '')
+  t.is(exitCode, null)
+})
+
+test('bin/nuxt-generate', async t => {
+  const binGenerate = resolve(__dirname, '..', 'bin', 'nuxt-generate')
+
+  const { error, stdout, stderr } = await execify(`${binGenerate} ${rootDir}`)
+
+  t.is(error, undefined)
+  t.true(stdout.includes('server-bundle.json'))
+  t.true(stderr.includes('Destination folder cleaned'))
+  t.true(stderr.includes('Static & build files copied'))
+  t.true(stderr.includes('Generate file: /users/1/index.html'))
+  t.true(stderr.includes('Error report'))
+  t.true(stderr.includes('Generate done'))
+})

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,5 +1,5 @@
 import test from 'ava'
-import { resolve } from 'path'
+import { resolve, sep } from 'path'
 import rp from 'request-promise-native'
 import { Utils } from '../index.js'
 import pify from 'pify'
@@ -87,7 +87,7 @@ test('bin/nuxt-generate', async t => {
   t.true(stdout.includes('server-bundle.json'))
   t.true(stderr.includes('Destination folder cleaned'))
   t.true(stderr.includes('Static & build files copied'))
-  t.true(stderr.includes('Generate file: /users/1/index.html'))
+  t.true(stderr.includes(`Generate file: ${sep}users${sep}1${sep}index.html`))
   t.true(stderr.includes('Error report'))
   t.true(stderr.includes('Generate done'))
 })

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -14,7 +14,7 @@ const url = (route) => 'http://localhost:' + port + route
 test('bin/nuxt-build', async t => {
   const binBuild = resolve(__dirname, '..', 'bin', 'nuxt-build')
 
-  const [ stdout, stderr ] = await execify(`${binBuild} ${rootDir}`)
+  const [ stdout, stderr ] = await execify(`node ${binBuild} ${rootDir}`)
 
   t.true(stdout.includes('server-bundle.json'))
   t.true(stderr.includes('Building done'))
@@ -31,7 +31,7 @@ test('bin/nuxt-start', async t => {
   const env = process.env
   env.PORT = port
 
-  const nuxtStart = spawn(binStart, [rootDir], { env: env })
+  const nuxtStart = spawn('node', [binStart, rootDir], { env: env })
 
   nuxtStart.stdout.on('data', (data) => {
     stdout += data
@@ -82,7 +82,7 @@ test('bin/nuxt-start', async t => {
 test('bin/nuxt-generate', async t => {
   const binGenerate = resolve(__dirname, '..', 'bin', 'nuxt-generate')
 
-  const [ stdout, stderr ] = await execify(`${binGenerate} ${rootDir}`)
+  const [ stdout, stderr ] = await execify(`node ${binGenerate} ${rootDir}`)
 
   t.true(stdout.includes('server-bundle.json'))
   t.true(stderr.includes('Destination folder cleaned'))

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -2,10 +2,10 @@ import test from 'ava'
 import { resolve } from 'path'
 import rp from 'request-promise-native'
 import { Utils } from '../index.js'
-import { promisify } from 'util'
+import pify from 'pify'
 import { exec, spawn } from 'child_process'
 
-const execify = promisify(exec)
+const execify = pify(exec, { multiArgs: true })
 const rootDir = resolve(__dirname, 'fixtures/basic')
 
 const port = 4011
@@ -14,9 +14,8 @@ const url = (route) => 'http://localhost:' + port + route
 test('bin/nuxt-build', async t => {
   const binBuild = resolve(__dirname, '..', 'bin', 'nuxt-build')
 
-  const { error, stdout, stderr } = await execify(`${binBuild} ${rootDir}`)
+  const [ stdout, stderr ] = await execify(`${binBuild} ${rootDir}`)
 
-  t.is(error, undefined)
   t.true(stdout.includes('server-bundle.json'))
   t.true(stderr.includes('Building done'))
 })
@@ -83,9 +82,8 @@ test('bin/nuxt-start', async t => {
 test('bin/nuxt-generate', async t => {
   const binGenerate = resolve(__dirname, '..', 'bin', 'nuxt-generate')
 
-  const { error, stdout, stderr } = await execify(`${binGenerate} ${rootDir}`)
+  const [ stdout, stderr ] = await execify(`${binGenerate} ${rootDir}`)
 
-  t.is(error, undefined)
   t.true(stdout.includes('server-bundle.json'))
   t.true(stderr.includes('Destination folder cleaned'))
   t.true(stderr.includes('Static & build files copied'))


### PR DESCRIPTION
With this PR I am trying to merge back some features I need for nuxt-generate-cluster so I wont need to maintain my own `lib/builder/generator.js`. One major feature is still missing (being able to pass custom variables to the `options.generate.routes` method) but I will create a separate PR for that.

The list of changes are:
- Split generator logic in to separate methods
- Separate the business logic from the presentation layer: make the Generator class a silent library class that doesn't communicate with the user itself (eg removed debug call's from generator.js)
- Added/moved hooks
  - `generate:distRemoved` has been added to log the `Destination folder cleaned` statement
  - `generate:distCopied` has been added to log the `Static & build files copied` statement
  - `generate:routeFailed` has been added for when an unhandled exception occurred during `renderRoute`
  - `generate:routeCreated` has been moved to the generateRoute method so we can include the path
- To be able to log errors during page rendering they are kept separately until all hooks have been called

--edit--
The build fails due to an error unrelated to this PR. The test might still fail for Node v6 as I copied the reporting method to nuxt-generate which still uses string literals and arrow functions.