### PR TITLE
Add possibility to pass extra arguments to generate.routes method

### DIFF
--- a/lib/builder/generator.js
+++ b/lib/builder/generator.js
@@ -52,18 +52,17 @@ export default class Generator {
     }
   }
 
-  async initRoutes() {
+  async initRoutes(...args) {
     // Resolve config.generate.routes promises before generating the routes
     let generateRoutes = []
     if (this.options.router.mode !== 'hash') {
       try {
-        generateRoutes = await promisifyRoute(this.options.generate.routes || [])
+        generateRoutes = await promisifyRoute(this.options.generate.routes || [], ...args)
       } catch (e) {
         console.error('Could not resolve routes') // eslint-disable-line no-console
         throw e // eslint-disable-line no-unreachable
       }
     }
-
     // Generate only index.html for router.mode = 'hash'
     let routes = (this.options.router.mode === 'hash') ? ['/'] : flatRoutes(this.options.router.routes)
     routes = this.decorateWithPayloads(routes, generateRoutes)

--- a/lib/common/utils.js
+++ b/lib/common/utils.js
@@ -34,23 +34,23 @@ export function isUrl(url) {
   return (url.indexOf('http') === 0 || url.indexOf('//') === 0)
 }
 
-export function promisifyRoute(fn) {
+export function promisifyRoute(fn, ...args) {
   // If routes is an array
   if (Array.isArray(fn)) {
     return Promise.resolve(fn)
   }
   // If routes is a function expecting a callback
-  if (fn.length === 1) {
+  if (fn.length === arguments.length) {
     return new Promise((resolve, reject) => {
-      fn(function (err, routeParams) {
+      fn((err, routeParams) => {
         if (err) {
           reject(err)
         }
         resolve(routeParams)
-      })
+      }, ...args)
     })
   }
-  let promise = fn()
+  let promise = fn(...args)
   if (!promise || (!(promise instanceof Promise) && (typeof promise.then !== 'function'))) {
     promise = Promise.resolve(promise)
   }

--- a/test/generator.test.js
+++ b/test/generator.test.js
@@ -1,0 +1,76 @@
+import test from 'ava'
+import { Nuxt, Generator } from '../index.js'
+
+test('initRoutes with routes (fn => array)', async t => {
+  const array = ['/1', '/2', '/3', '/4']
+  const config = {
+    generate: {
+      routes: array
+    }
+  }
+  const nuxt = new Nuxt(config)
+  const generator = new Generator(nuxt)
+  const routes = await generator.initRoutes()
+
+  t.is(routes.length, array.length)
+  routes.map((route, index) => {
+    t.is(route.route, array[index])
+  })
+})
+
+test('initRoutes with routes (fn())', async t => {
+  const array = ['/1', '/2', '/3', '/4']
+  const config = {
+    generate: {
+      routes() {
+        return array
+      }
+    }
+  }
+  const nuxt = new Nuxt(config)
+  const generator = new Generator(nuxt)
+  const routes = await generator.initRoutes()
+
+  t.is(routes.length, array.length)
+  routes.map((route, index) => {
+    t.is(route.route, array[index])
+  })
+})
+
+test('initRoutes with routes (fn(args))', async t => {
+  const config = {
+    generate: {
+      routes(array) {
+        return array
+      }
+    }
+  }
+  const nuxt = new Nuxt(config)
+  const generator = new Generator(nuxt)
+  const array = ['/1', '/2', '/3', '/4']
+  const routes = await generator.initRoutes(array)
+
+  t.is(routes.length, array.length)
+  routes.map((route, index) => {
+    t.is(route.route, array[index])
+  })
+})
+
+test('initRoutes with routes (fn(cb, args))', async t => {
+  const config = {
+    generate: {
+      routes(cb, arg1, arg2, arg3, arg4) {
+        cb(null, [ arg1, arg2, arg3, arg4 ])
+      }
+    }
+  }
+  const nuxt = new Nuxt(config)
+  const generator = new Generator(nuxt)
+  const array = ['/1', '/2', '/3', '/4']
+  const routes = await generator.initRoutes(...array)
+
+  t.is(routes.length, array.length)
+  routes.map((route, index) => {
+    t.is(route.route, array[index])
+  })
+})

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -70,6 +70,21 @@ test('promisifyRoute (fn => promise)', t => {
     })
 })
 
+test('promisifyRoute ((fn(args) => promise))', t => {
+  const fn = function (array) {
+    return new Promise((resolve) => {
+      resolve(array)
+    })
+  }
+  const array = [1, 2, 3]
+  const promise = Utils.promisifyRoute(fn, array)
+  t.is(typeof promise, 'object')
+  return promise
+    .then((res) => {
+      t.is(res, array)
+    })
+})
+
 test('promisifyRoute (fn(cb) with error)', t => {
   const fn = function (cb) {
     cb(new Error('Error here'))
@@ -79,6 +94,19 @@ test('promisifyRoute (fn(cb) with error)', t => {
   return promise
     .catch((e) => {
       t.is(e.message, 'Error here')
+    })
+})
+
+test('promisifyRoute (fn(cb, args) with error)', t => {
+  const fn = function (cb, array) {
+    cb(new Error('Error here: ' + array.join()))
+  }
+  const array = [1, 2, 3, 4]
+  const promise = Utils.promisifyRoute(fn, array)
+  t.is(typeof promise, 'object')
+  return promise
+    .catch((e) => {
+      t.is(e.message, 'Error here: ' + array.join())
     })
 })
 
@@ -92,6 +120,21 @@ test('promisifyRoute (fn(cb) with result)', t => {
   return promise
     .then((res) => {
       t.is(res, array)
+    })
+})
+
+test('promisifyRoute (fn(cb, args) with result)', t => {
+  const fn = function (cb, array, object) {
+    cb(null, { array, object })
+  }
+  const array = [1, 2, 3, 4]
+  const object = { a: 1 }
+  const promise = Utils.promisifyRoute(fn, array, object)
+  t.is(typeof promise, 'object')
+  return promise
+    .then((res) => {
+      t.is(res.array, array)
+      t.is(res.object, object)
     })
 })
 


### PR DESCRIPTION
With this PR I am trying to merge back some features I need for nuxt-generate-cluster. Although the `options.generate.routes` method works great for retrieving dynamic routes from a remote api, it would be nice if we would have more fine-grained control about which routes the remote api should generate.

This PR adds the required changes to be able do that (its only missing an implementation for bin/nuxt-generate). Any arguments passed to the `Generator.initRoutes` method are passed to the `generator.routes` method.

Due to the line `if (fn.length === arguments.length) {` in `common/utils.js:promisifyRoute` its explicitly _not_ possible to use a 'dynamic' argument list in `generate.routes`. Eg `generate.routes(callback, ...args)` will fail and relying on `arguments` will probably fail as well.