### PR TITLE
fixed modulesDir is not initialized with correct default value

### DIFF
--- a/lib/common/options.js
+++ b/lib/common/options.js
@@ -43,12 +43,12 @@ Options.from = function (_options) {
   options.cacheDir = resolve(options.rootDir, options.cacheDir)
 
   // Normalize modulesDir
+  /* istanbul ignore if */
+  if (!options.modulesDir) {
+    options.modulesDir = ['node_modules']
+  }
   if (!Array.isArray(options.modulesDir)) {
     options.modulesDir = [options.modulesDir]
-  }
-  /* istanbul ignore if */
-  if (!options.modulesDir.length) {
-    options.modulesDir = ['node_modules']
   }
   options.modulesDir = options.modulesDir.filter(dir => hasValue(dir)).map(dir => resolve(options.rootDir, dir))
 

--- a/test/basic.config.defaults.test.js
+++ b/test/basic.config.defaults.test.js
@@ -1,0 +1,9 @@
+import test from 'ava'
+import { resolve } from 'path'
+import { Options } from '../index'
+
+test('modulesDir uses /node_modules as default if not set', async t => {
+  const options = Options.from({})
+  const currentNodeModulesDir = resolve(__dirname, '..', 'node_modules')
+  t.true(options.modulesDir.includes(currentNodeModulesDir))
+})


### PR DESCRIPTION
When `modulesDir` is not defined, a `dependencies were not found` error is thrown.

When the `modulesDir` property is not set in the nuxt.config.js `node_modules` should be used as a default.
Currently if it is not set `!Array.isArray()` is true, which means `modulesDir` becomes `[undefined]`.
The second `if`, which should set the default value is therefore never executed since the array now has 1 element.