### PR TITLE
Feature generate scraper

### DIFF
--- a/bin/nuxt-generate
+++ b/bin/nuxt-generate
@@ -34,7 +34,6 @@ if (argv.help) {
       $ nuxt generate <dir>
     Options
       --spa              Launch in SPA mode
-      --spa              Launch in SPA mode
       --universal        Launch in Universal mode (default)
       --config-file, -c  Path to Nuxt.js config file (default: nuxt.config.js)
       --help, -h         Displays this message

--- a/lib/builder/generator.js
+++ b/lib/builder/generator.js
@@ -178,7 +178,7 @@ export default class Generator {
     return _.values(routeMap)
   }
 
-  async generateRoute({ route, payload = {}, errors = [] }) {
+  async generateRoute({ route, payload, errors = [] }) {
     let html
     const pageErrors = []
 

--- a/lib/builder/generator.js
+++ b/lib/builder/generator.js
@@ -3,6 +3,7 @@ import _ from 'lodash'
 import { resolve, join, dirname, sep } from 'path'
 import { minify } from 'html-minifier'
 import { isUrl, promisifyRoute, waitFor, flatRoutes } from 'utils'
+const {JSDOM} = require('jsdom')
 
 export default class Generator {
   constructor(nuxt, builder) {
@@ -75,17 +76,38 @@ export default class Generator {
 
   async generateRoutes(routes) {
     let errors = []
+    let seenRoutes = new Set(_.map(routes, 'route'))
 
     // Start generate process
     while (routes.length) {
       let n = 0
       await Promise.all(routes.splice(0, this.options.generate.concurrency).map(async ({ route, payload }) => {
         await waitFor(n++ * this.options.generate.interval)
-        await this.generateRoute({ route, payload, errors })
+        let html = await this.generateRoute({ route, payload, errors })
+        if (this.options.generate.scrape) {
+          var scrapedHrefs = this.scrapeLinks(html)
+          for (let href of scrapedHrefs) {
+            if (!seenRoutes.has(href)) {
+              routes.push({route: href})
+              seenRoutes.add(href)
+            }
+          }
+        }
       }))
     }
 
     return errors
+  }
+  scrapeLinks(html) {
+    let dom = new JSDOM(html)
+    let newRoutes = []
+    for (let node of dom.window.document.querySelectorAll('a')) {
+      let href = decodeURIComponent(node.getAttribute('href'))
+      if (!(href.startsWith('http://') || href.startsWith('https://'))) {
+        newRoutes.push(href)
+      }
+    }
+    return newRoutes
   }
 
   async afterGenerate() {
@@ -211,6 +233,6 @@ export default class Generator {
       Array.prototype.push.apply(errors, pageErrors)
     }
 
-    return true
+    return html
   }
 }


### PR DESCRIPTION
This PR implements a scraper for the generate command. If `generate.scrape` is truthy in the config each generated route will have their `a[href]` tags scraped, and any found `href` will be scheduled for rendering. 

The purpose of this feature is to avoid having to re-implement the same filtering logic in your `config.generate.routes` as in your actual vue files. 