### PR TITLE
Fix for excluding builder instance when not building nuxt

### DIFF
--- a/lib/builder/generator.js
+++ b/lib/builder/generator.js
@@ -38,11 +38,11 @@ export default class Generator {
     // Call before hook
     await this.nuxt.callHook('generate:before', this, this.options.generate)
 
-    // Add flag to set process.static
-    this.builder.forGenerate()
-
-    // Start build process
     if (build) {
+      // Add flag to set process.static
+      this.builder.forGenerate()
+
+      // Start build process
       await this.builder.build()
     }
 


### PR DESCRIPTION
The initiate method will fail with `a property of undefined error` if you have initiated the generator without a nuxt builder instance because you dont want to (re)build nuxt anyway.