### PR TITLE
fix(dev-watching): mixins not removed after function changed or deleted

### DIFF
--- a/lib/builder/builder.js
+++ b/lib/builder/builder.js
@@ -459,6 +459,9 @@ export default class Builder {
           compiler.watch(this.options.watchers.webpack, (err) => {
             /* istanbul ignore if */
             if (err) return reject(err)
+            // not keep modified or deleted items in Vue.prototype
+            delete require.cache[require.resolve('vue')]
+            delete require.cache[require.resolve('vue-router')]
           })
         )
         return


### PR DESCRIPTION
fix #2282