### PR TITLE
fix(route): error when redirect to different route in router guards

### DIFF
--- a/lib/app/index.js
+++ b/lib/app/index.js
@@ -8,7 +8,7 @@ import NuxtLink from './components/nuxt-link.js'
 import NuxtError from '<%= components.ErrorPage ? components.ErrorPage : "./components/nuxt-error.vue" %>'
 import Nuxt from './components/nuxt.js'
 import App from '<%= appPath %>'
-import { setContext, getLocation } from './utils'
+import { setContext, getLocation, getRouteData } from './utils'
 <% if (store) { %>import { createStore } from './store.js'<% } %>
 
 /* Plugins */
@@ -167,7 +167,20 @@ async function createApp (ssrContext) {
   // If server-side, wait for async component to be resolved first
   if (process.server && ssrContext && ssrContext.url) {
     await new Promise((resolve, reject) => {
-      router.push(ssrContext.url, resolve, reject)
+      router.push(ssrContext.url, resolve, () => {
+        let initSSR = true
+        // navigated to a different route in router guard
+        router.afterEach(async (to, from, next) => {
+          if (initSSR) {
+            ssrContext.url = to.fullPath
+            app.context.route = await getRouteData(to)
+            app.context.params = to.params || {}
+            app.context.query = to.query || {}
+          }
+          initSSR = false
+          resolve()
+        })
+      })
     })
   }
 

--- a/lib/app/index.js
+++ b/lib/app/index.js
@@ -168,16 +168,13 @@ async function createApp (ssrContext) {
   if (process.server && ssrContext && ssrContext.url) {
     await new Promise((resolve, reject) => {
       router.push(ssrContext.url, resolve, () => {
-        let initSSR = true
         // navigated to a different route in router guard
-        router.afterEach(async (to, from, next) => {
-          if (initSSR) {
-            ssrContext.url = to.fullPath
-            app.context.route = await getRouteData(to)
-            app.context.params = to.params || {}
-            app.context.query = to.query || {}
-          }
-          initSSR = false
+        const unregister = router.afterEach(async (to, from, next) => {
+          ssrContext.url = to.fullPath
+          app.context.route = await getRouteData(to)
+          app.context.params = to.params || {}
+          app.context.query = to.query || {}
+          unregister()
           resolve()
         })
       })

--- a/lib/app/utils.js
+++ b/lib/app/utils.js
@@ -85,7 +85,7 @@ export function resolveRouteComponents(route) {
   )
 }
 
-async function getRouteData(route) {
+export async function getRouteData(route) {
   // Make sure the components are resolved (code-splitting)
   await resolveRouteComponents(route)
   // Send back a copy of route with meta based on Component definition

--- a/test/basic.csr.test.js
+++ b/test/basic.csr.test.js
@@ -179,6 +179,12 @@ test('/fn-midd?please=true', async t => {
   t.true(h1.includes('Date:'))
 })
 
+test('/router-guard', async t => {
+  await page.nuxt.navigate('/router-guard')
+
+  t.is(await page.$text('p'), 'Nuxt.js')
+})
+
 // Close server and ask nuxt to stop listening to file changes
 test.after('Closing server and nuxt.js', t => {
   nuxt.close()

--- a/test/basic.ssr.test.js
+++ b/test/basic.ssr.test.js
@@ -239,6 +239,12 @@ test('/fn-midd?please=true', async t => {
   t.true(html.includes('<h1>Date:'))
 })
 
+test('/router-guard', async t => {
+  const { html } = await nuxt.renderRoute('/router-guard')
+  t.true(html.includes('<p>Nuxt.js</p>'))
+  t.false(html.includes('Router Guard'))
+})
+
 // Close server and ask nuxt to stop listening to file changes
 test.after('Closing server and nuxt.js', t => {
   nuxt.close()

--- a/test/fixtures/basic/pages/router-guard.vue
+++ b/test/fixtures/basic/pages/router-guard.vue
@@ -1,0 +1,11 @@
+<template>
+  <div>Router Guard</div>
+</template>
+
+<script>
+export default {
+  beforeRouteEnter(to, from, next) {
+    next({path: '/async-data'})
+  }
+}
+</script>


### PR DESCRIPTION
### Fix #2289 

In `navigation guards` for `vue-router`(such as: `beforeRouteEnter`), if called `next('..')` or `next({ path: '...' })`, it should redirect to a different route.

But currently, it has an error occurred: **Error: Cannot read property 'serverRendered' of undefined Show all frames_**

The error is due to third param(`onAbort`) of `router.push` should not be `reject`, it will quit the `renderString` unexpectedly.

Use `router.afterEach` inside `onAbort` may be not elegant, the reason is that we need to replace `context.route` and `ssrContext.url` after `router.push`[(_sources_)](https://github.com/vuejs/vue-router/blob/dev/src/history/base.js#L151) of `NavigationGuard->next`.