### PR TITLE
fix: generate pages/index/**

### DIFF
--- a/lib/common/utils.js
+++ b/lib/common/utils.js
@@ -150,8 +150,12 @@ export function flatRoutes(router, path = '', routes = []) {
     if (!r.path.includes(':') && !r.path.includes('*')) {
       /* istanbul ignore if */
       if (r.children) {
+        if (path === '' && r.path === '/') {
+          routes.push('/')
+        }
         flatRoutes(r.children, path + r.path + '/', routes)
       } else {
+        path = path.replace(/^\/+$/, '/')
         routes.push((r.path === '' && path[path.length - 1] === '/' ? path.slice(0, -1) : path) + r.path)
       }
     }


### PR DESCRIPTION
### Fix #2296

When there is existing nested component in `pages/index/`, remove duplicate `/` in route path and push a route for generating root `index.html`