### PR TITLE
Fix router generation for page names containing @/~

### DIFF
--- a/lib/app/components/nuxt.js
+++ b/lib/app/components/nuxt.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 import NuxtChild from './nuxt-child'
-import NuxtError from '<%= components.ErrorPage ? ((components.ErrorPage.includes('~') || components.ErrorPage.includes('@')) ? components.ErrorPage : "../" + components.ErrorPage) : "./nuxt-error.vue" %>'
+import NuxtError from '<%= components.ErrorPage ? ((components.ErrorPage.indexOf('~') === 0 || components.ErrorPage.indexOf('@') === 0) ? components.ErrorPage : "../" + components.ErrorPage) : "./nuxt-error.vue" %>'
 import { compile } from '../utils'
 
 export default {

--- a/lib/common/utils.js
+++ b/lib/common/utils.js
@@ -118,7 +118,7 @@ export function r() {
   let args = Array.prototype.slice.apply(arguments)
   let lastArg = _.last(args)
 
-  if (lastArg.includes('@') || lastArg.includes('~')) {
+  if (lastArg.indexOf('@') === 0 || lastArg.indexOf('~') === 0) {
     return wp(lastArg)
   }
 
@@ -133,7 +133,7 @@ export function relativeTo() {
   let path = r(...args)
 
   // Check if path is an alias
-  if (path.includes('@') || path.includes('~')) {
+  if (path.indexOf('@') === 0 || path.indexOf('~') === 0) {
     return path
   }
 


### PR DESCRIPTION
The generated router currently generates incorrect module paths for pages containing `@` or `~` (the `srcDir` aliases).

* Generated module path of normal page: `${srcDir}/pages/users/me.vue` (OK)
* Generated module path of affected page: `pages/users/@me.vue` (module not found error)

It seems that `resolvePath()` only applies the `@`/`~` aliases if a path starts with either alias ([lib/core/nuxt.js:188](https://github.com/nuxt/nuxt.js/blob/06ae3868fe381d2a4771793754600a12689aa4c6/lib/core/nuxt.js#L188)).

However, the other path related functions in the library check if the characters are anywhere in the path string ([lib/common/utils.js:121](https://github.com/nuxt/nuxt.js/blob/06ae3868fe381d2a4771793754600a12689aa4c6/lib/common/utils.js#L121), [lib/common/utils.js:136](https://github.com/nuxt/nuxt.js/blob/06ae3868fe381d2a4771793754600a12689aa4c6/lib/common/utils.js#L136), [lib/app/components/nuxt.js:3](https://github.com/nuxt/nuxt.js/blob/06ae3868fe381d2a4771793754600a12689aa4c6/lib/app/components/nuxt.js#L3)). This doesn't seem to make sense, since `pages/users/@me` should be a normal path, and `~/pages/users/@me` should be rooted in `srcDir`.