### PR TITLE
fix: invalid all require.cache in watching

### DIFF
--- a/lib/builder/builder.js
+++ b/lib/builder/builder.js
@@ -460,8 +460,7 @@ export default class Builder {
             /* istanbul ignore if */
             if (err) return reject(err)
             // not keep modified or deleted items in Vue.prototype
-            delete require.cache[require.resolve('vue')]
-            delete require.cache[require.resolve('vue-router')]
+            Object.keys(require.cache).forEach(key => delete require.cache[key])
           })
         )
         return


### PR DESCRIPTION
I found if some lib depends on `vue` or `vue-router`, `require.cache` cannot remove completely #2288 , so it's better to remove all caches.