### PR TITLE
fix: Error: Module did not self-register

### DIFF
--- a/lib/builder/builder.js
+++ b/lib/builder/builder.js
@@ -475,7 +475,7 @@ export default class Builder {
             /* istanbul ignore if */
             if (err) return reject(err)
             // not keep modified or deleted items in Vue.prototype
-            Object.keys(require.cache).forEach(key => delete require.cache[key])
+            Object.keys(require.cache).forEach(key => !/\.node$/.test(key) && delete require.cache[key])
           })
         )
         return


### PR DESCRIPTION
I found that if use `node-sass`, invalid all modules cache will lead to `Module build failed: Error: Module did not self-register.`, so exclude native modules.