### PR TITLE
fix: youch with source-map in default dev case

### DIFF
--- a/lib/builder/webpack/server.config.js
+++ b/lib/builder/webpack/server.config.js
@@ -23,7 +23,7 @@ export default function webpackServerConfig() {
   config = Object.assign(config, {
     target: 'node',
     node: false,
-    devtool: this.options.dev ? config.devtool : 'source-map',
+    devtool: 'source-map',
     entry: resolve(this.options.buildDir, 'server.js'),
     output: Object.assign({}, config.output, {
       filename: 'server-bundle.js',


### PR DESCRIPTION
Through a testing in which continuously changing files under watching mode, the most influential factor of watching mode memory leak is `devtool` in `config.config.js` which has been set to `*eval-source-map`, so change `devtool` in `service.config.js` back to `source-map`, hence `maps` of `youch` is enabled in default `dev` case again.