### PR TITLE
Replace code that was removed by commit: 65f4a030f44f71d3dc29c64e271c…

### DIFF
--- a/lib/builder/generator.js
+++ b/lib/builder/generator.js
@@ -82,6 +82,7 @@ module.exports = class Generator {
       await Promise.all(routes.splice(0, this.options.generate.concurrency).map(async ({ route, payload }) => {
         await waitFor(n++ * this.options.generate.interval)
         await this.generateRoute({ route, payload, errors })
+        await this.nuxt.callHook('generate:routeCreated', route)
       }))
     }
 


### PR DESCRIPTION
…661b48b5410a

Original PR was approved here:
https://github.com/nuxt/nuxt.js/pull/2126

This code block was removed in this commit:
https://github.com/nuxt/nuxt.js/commit/65f4a030f44f71d3dc29c64e271c661b48b5410a#comments

I still need this code and the original reasoning still applies.  Please merge this back in.
Thanks,
David Sandor
