### PR TITLE
Revert cc74126 which caused duplicate hook call

### DIFF
--- a/lib/builder/generator.js
+++ b/lib/builder/generator.js
@@ -82,7 +82,6 @@ module.exports = class Generator {
       await Promise.all(routes.splice(0, this.options.generate.concurrency).map(async ({ route, payload }) => {
         await waitFor(n++ * this.options.generate.interval)
         await this.generateRoute({ route, payload, errors })
-        await this.nuxt.callHook('generate:routeCreated', route)
       }))
     }
 


### PR DESCRIPTION
Ref: #2379 

The generate:routeCreated hook still existed but probably not in the expected place.