### PR TITLE
Add possiblity to mute webpack in non-dev modes

### DIFF
--- a/lib/builder/builder.js
+++ b/lib/builder/builder.js
@@ -39,17 +39,7 @@ module.exports = class Builder {
     this.customFilesWatcher = null
 
     // Mute stats on dev
-    this.webpackStats = this.options.dev ? false : {
-      chunks: false,
-      children: false,
-      modules: false,
-      colors: true,
-      excludeAssets: [
-        /.map$/,
-        /index\..+\.html$/,
-        /vue-ssr-client-manifest.json/
-      ]
-    }
+    this.webpackStats = this.options.dev ? false : this.options.build.stats
 
     // Helper to resolve build paths
     this.relativeToBuild = (...args) => relativeTo(this.options.buildDir, ...args)

--- a/lib/builder/webpack/client.config.js
+++ b/lib/builder/webpack/client.config.js
@@ -106,8 +106,11 @@ module.exports = function webpackClientConfig() {
     }))
   }
 
+  const shouldClearConsole = this.options.build.stats !== false &&
+                             this.options.build.stats !== 'errors-only'
+
   // Add friendly error plugin
-  config.plugins.push(new FriendlyErrorsWebpackPlugin())
+  config.plugins.push(new FriendlyErrorsWebpackPlugin({ clearConsole: shouldClearConsole }))
 
   // --------------------------------------
   // Dev specific config

--- a/lib/common/options.js
+++ b/lib/common/options.js
@@ -228,7 +228,18 @@ Options.defaults = {
     templates: [],
     watch: [],
     devMiddleware: {},
-    hotMiddleware: {}
+    hotMiddleware: {},
+    stats: {
+      chunks: false,
+      children: false,
+      modules: false,
+      colors: true,
+      excludeAssets: [
+        /.map$/,
+        /index\..+\.html$/,
+        /vue-ssr-client-manifest.json/
+      ]
+    }
   },
   generate: {
     dir: 'dist',


### PR DESCRIPTION
In a previous discussion about the console helper for the nuxt tests, @pi0 suggested to just silence webpack instead of capturing and ignoring the output. This PR adds the possiblity to do that easily by setting `nuxt.options.build.stats = false`.

The default config for webpackStats which is used in `builder.js` is moved to `options.js`. Also `FriendlyErrorsWebpackPlugin` will now only clear the console when webpack is expected to output something.

