### PR TITLE
Check if layout var is set before looking for middleware

### DIFF
--- a/lib/app/server.js
+++ b/lib/app/server.js
@@ -123,9 +123,9 @@ export default async ssrContext => {
   ** Set layout
   */
   let layout = Components.length ? Components[0].options.layout : NuxtError.layout
-  if (typeof layout === 'function') layout = layout(app.context)
+  if (typeof layout === 'function') { layout = layout(_app.context) }
+  _app.setLayout(layout)
   await _app.loadLayout(layout)
-  layout = _app.setLayout(layout)
   // ...Set layout to __NUXT__
   ssrContext.nuxt.layout = _app.layoutName
 
@@ -133,7 +133,7 @@ export default async ssrContext => {
   ** Call middleware (layout + pages)
   */
   midd = []
-  if (layout.middleware) midd = midd.concat(layout.middleware)
+  if (layout && layout.middleware) midd = midd.concat(layout.middleware)
   Components.forEach((Component) => {
     if (Component.options.middleware) {
       midd = midd.concat(Component.options.middleware)


### PR DESCRIPTION
added conditional check for layout object in order for third party middleware to surface errors. Regarding Issue #2427 