### PR TITLE
best practices: add try/catch to async examples

### DIFF
--- a/examples/async-data/pages/posts/_id.vue
+++ b/examples/async-data/pages/posts/_id.vue
@@ -13,8 +13,12 @@ import axios from 'axios'
 export default {
   async asyncData({ params }) {
     // We can use async/await ES6 feature
-    let { data } = await axios.get(`https://jsonplaceholder.typicode.com/posts/${params.id}`)
-    return { post: data }
+    try {
+      let { data } = await axios.get(`https://jsonplaceholder.typicode.com/posts/${params.id}`)
+      return { post: data }
+    } catch (e) {
+      throw Error(e)
+    }
   },
   head() {
     return {

--- a/examples/axios/pages/index.vue
+++ b/examples/axios/pages/index.vue
@@ -10,8 +10,12 @@
 export default {
 
   async asyncData({ app }) {
-    const { data: { message: dog } } = await app.$axios.get('/dog')
-    return { dog }
+    try {
+      const { data: { message: dog } } = await app.$axios.get('/dog')
+      return { dog }
+    } catch (e) {
+      throw Error(e)
+    }
   }
 }
 </script>

--- a/examples/custom-routes/pages/index.vue
+++ b/examples/custom-routes/pages/index.vue
@@ -14,8 +14,12 @@ import axios from 'axios'
 
 export default {
   async asyncData() {
-    const { data } = await axios.get('https://jsonplaceholder.typicode.com/users')
-    return { users: data }
+    try {
+      const { data } = await axios.get('https://jsonplaceholder.typicode.com/users')
+      return { users: data }
+    } catch (e) {
+      throw Error(e)
+    }
   }
 }
 </script>

--- a/examples/with-firebase/pages/index.vue
+++ b/examples/with-firebase/pages/index.vue
@@ -32,8 +32,12 @@ import axios from '~/plugins/axios'
 
 export default {
   async asyncData() {
-    const { data: users } = await axios.get('users.json')
-    return { users }
+    try {
+      const { data: users } = await axios.get('users.json')
+      return { users }
+    } catch (e) {
+      throw Error(e)
+    }
   }
 }
 </script>

--- a/examples/with-firebase/pages/users/_key.vue
+++ b/examples/with-firebase/pages/users/_key.vue
@@ -16,8 +16,12 @@ import axios from '~/plugins/axios'
 export default {
   async asyncData({ route }) {
     const { key } = route.params
-    const { data: user } = await axios.get(`users/${key}.json`)
-    return { user }
+    try {
+      const { data: user } = await axios.get(`users/${key}.json`)
+      return { user }
+    } catch (e) {
+      throw Error(e)
+    }
   }
 }
 </script>


### PR DESCRIPTION
Hey guys,

I was checking the examples and noticed some does not try/catch blocks for async/await.

Since most newcomers will copy/paste the code and eventually send to production I think it's a good idea to at least give them a better chance of success providing a smaller error surface.

What do you guys think?
 
PS. First PR let me know if I need to do something else or more places to change :)