### PR TITLE
Adding support for CSP script-src safe inline, for SSR state transfer

### DIFF
--- a/lib/common/options.js
+++ b/lib/common/options.js
@@ -34,9 +34,6 @@ Options.from = function (_options) {
   if (typeof options.extensions === 'string') {
     options.extensions = [ options.extensions ]
   }
-  if (options.render.csp === true) {
-    options.render.csp = { hashAlgorithm: 'sha256' }
-  }
 
   const hasValue = v => typeof v === 'string' && v
   options.rootDir = hasValue(options.rootDir) ? options.rootDir : process.cwd()
@@ -89,6 +86,11 @@ Options.from = function (_options) {
   // Normalize loadingIndicator
   if (!isPureObject(options.loadingIndicator)) {
     options.loadingIndicator = { name: options.loadingIndicator }
+  }
+  
+  // Apply default hash to CSP option
+  if (options.render.csp === true) {
+    options.render.csp = { hashAlgorithm: 'sha256' }
   }
 
   // Apply defaults to loadingIndicator

--- a/lib/common/options.js
+++ b/lib/common/options.js
@@ -87,7 +87,7 @@ Options.from = function (_options) {
   if (!isPureObject(options.loadingIndicator)) {
     options.loadingIndicator = { name: options.loadingIndicator }
   }
-  
+
   // Apply default hash to CSP option
   if (options.render.csp === true) {
     options.render.csp = { hashAlgorithm: 'sha256' }

--- a/lib/common/options.js
+++ b/lib/common/options.js
@@ -34,6 +34,9 @@ Options.from = function (_options) {
   if (typeof options.extensions === 'string') {
     options.extensions = [ options.extensions ]
   }
+  if (options.render.csp === true) {
+    options.render.csp = { hashAlgorithm: 'sha256' }
+  }
 
   const hasValue = v => typeof v === 'string' && v
   options.rootDir = hasValue(options.rootDir) ? options.rootDir : process.cwd()
@@ -278,7 +281,8 @@ Options.defaults = {
     },
     etag: {
       weak: false
-    }
+    },
+    csp: undefined
   },
   watchers: {
     webpack: {

--- a/lib/core/middleware/nuxt.js
+++ b/lib/core/middleware/nuxt.js
@@ -11,7 +11,7 @@ module.exports = async function nuxtMiddleware(req, res, next) {
   try {
     const result = await this.renderRoute(req.url, context)
     await this.nuxt.callHook('render:route', req.url, result)
-    const { html, error, redirected, getPreloadFiles } = result
+    const { html, cspScriptSrcHashes, error, redirected, getPreloadFiles } = result
 
     if (redirected) {
       return html
@@ -59,6 +59,10 @@ module.exports = async function nuxtMiddleware(req, res, next) {
       // https://preloadFilesblog.cloudflare.com/http-2-server-push-with-multiple-assets-per-link-header
       // https://www.w3.org/Protocols/9707-link-header.html
       res.setHeader('Link', pushAssets.join(','))
+    }
+
+    if (this.options.render.csp) {
+      res.setHeader('Content-Security-Policy', `script-src 'self' ${(cspScriptSrcHashes || []).join(' ')}`)
     }
 
     // Send response

--- a/lib/core/renderer.js
+++ b/lib/core/renderer.js
@@ -9,6 +9,7 @@ const { createBundleRenderer } = require('vue-server-renderer')
 const Debug = require('debug')
 const connect = require('connect')
 const launchMiddleware = require('launch-editor-middleware')
+const crypto = require('crypto')
 
 const { setAnsiColors, isUrl, waitFor } = require('../common/utils')
 const { Options } = require('../common')
@@ -315,7 +316,15 @@ module.exports = class Renderer {
       HEAD += context.renderResourceHints()
     }
 
-    APP += `<script type="text/javascript">window.__NUXT__=${serialize(context.nuxt, { isJSON: true })};</script>`
+    let serializedSession = `window.__NUXT__=${serialize(context.nuxt, { isJSON: true })};`
+    let cspScriptSrcHashes = []
+    if (this.options.render.csp) {
+      let hash = crypto.createHash(this.options.render.csp.hashAlgorithm)
+      hash.update(serializedSession)
+      cspScriptSrcHashes.push(`'${this.options.render.csp.hashAlgorithm}-${hash.digest('base64')}'`)
+    }
+
+    APP += `<script type="text/javascript">${serializedSession}</script>`
     APP += context.renderScripts()
     APP += m.script.text({ body: true })
 
@@ -331,6 +340,7 @@ module.exports = class Renderer {
 
     return {
       html,
+      cspScriptSrcHashes,
       getPreloadFiles: context.getPreloadFiles,
       error: context.nuxt.error,
       redirected: context.redirected

--- a/test/basic.ssr.test.js
+++ b/test/basic.ssr.test.js
@@ -22,6 +22,9 @@ test.serial('Init Nuxt.js', async t => {
     },
     build: {
       stats: false
+    },
+    render: {
+      csp: true
     }
   }
 
@@ -226,6 +229,12 @@ test('ETag Header', async t => {
   // Verify functionality
   const error = await t.throws(rp(url('/stateless'), { headers: { 'If-None-Match': etag } }))
   t.is(error.statusCode, 304)
+})
+
+test('Content-Security-Policy Header', async t => {
+  const { headers } = await rp(url('/stateless'), { resolveWithFullResponse: true })
+  // Verify functionality
+  t.is(headers['content-security-policy'], "script-src 'self' 'sha256-BBvfKxDOoRM/gnFwke9u60HBZX3HUss/0lSI1sBRvOU='")
 })
 
 test('/_nuxt/server-bundle.json should return 404', async t => {


### PR DESCRIPTION
VueJS is fully CSP compliant (script-wise) when using runtime-only builds [1].

Nuxt appears to follow suit, with the single exception that a strict locked-down CSP policy should not allow inline scripts. SSR state transfer relies on inline scripts in a non-avoidable way. The CSP spec allows for inline scripts to be whitelisted by nonce or checksum.

There appears to be an issue open on this topic already: #2422

My solution allows a user to opt in to CSP script compliance by setting the `options.render.csp` variable to either `true` or an object containing the key `hashAlgorithm`. The `hashAlgorithm` may be `sha256`, `sha384` or `sha512` per the CSP spec [2] and these three hash algorithms should also be supported in most builds of Node (it is technically dependent on the version of OpenSSL on the platform, but these are three very common algorithms [3]). The default value is `sha256` if the user just sets the option to true.

[1] https://vuejs.org/v2/guide/installation.html#CSP-environments
[2] https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src
[3] https://nodejs.org/api/crypto.html#crypto_class_hash
  