### PR TITLE
Align nuxt-start package.json with main package.json

### DIFF
--- a/start/package.json
+++ b/start/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-start",
-  "version": "1.0.0-rc11",
+  "version": "1.0.0",
   "description": "runtime-only build for nuxt",
   "contributors": [
     {
@@ -42,8 +42,8 @@
     "nuxt-start": "./bin/nuxt-start"
   },
   "engines": {
-    "node": ">=6.11",
-    "npm": ">=3.10.0"
+    "node": ">=8.0.0",
+    "npm": ">=5.0.0"
   },
   "dependencies": {
     "source-map-support": "^0.5.0",
@@ -59,13 +59,13 @@
     "fresh": "^0.5.2",
     "serve-static": "^1.13.1",
     "compression": "^1.7.1",
-    "fs-extra": "^4.0.2",
-    "vue-server-renderer": "^2.5.6",
-    "@nuxtjs/youch": "^3.1.0",
+    "fs-extra": "^5.0.0",
+    "vue-server-renderer": "^2.5.13",
+    "@nuxtjs/youch": "^4.2.3",
     "source-map": "^0.6.1",
     "connect": "^3.6.5",
-    "vue": "^2.5.6",
-    "vue-meta": "^1.3.1",
+    "vue": "^2.5.13",
+    "vue-meta": "^1.4.2",
     "lru-cache": "^4.1.1",
     "server-destroy": "^1.0.1",
     "open-in-editor": "^2.2.0"


### PR DESCRIPTION
Hello Nuxt.js team,

First of all thank you for your hard work. This is a great framework!
I saw that the `package.json` of `nuxt-start` is misaligned with main `package.json`.
This PR update package version to 1.0.0, engines configuration and packages versions in accordance with main `package.json`.

Thanks!
