### PR TITLE
Use original process.env.NODE_ENV with build

### DIFF
--- a/lib/builder/webpack/client.config.js
+++ b/lib/builder/webpack/client.config.js
@@ -86,7 +86,7 @@ module.exports = function webpackClientConfig() {
   // Define Env
   config.plugins.push(
     new webpack.DefinePlugin(Object.assign(env, {
-      'process.env.NODE_ENV': JSON.stringify(env.NODE_ENV || (this.options.dev ? 'development' : 'production')),
+      'process.env.NODE_ENV': JSON.stringify(env['process.env.NODE_ENV'] || (this.options.dev ? 'development' : 'production')),
       'process.env.VUE_ENV': JSON.stringify('client'),
       'process.mode': JSON.stringify(this.options.mode),
       'process.browser': true,

--- a/lib/builder/webpack/server.config.js
+++ b/lib/builder/webpack/server.config.js
@@ -41,7 +41,7 @@ module.exports = function webpackServerConfig() {
         filename: 'server-bundle.json'
       }),
       new webpack.DefinePlugin(Object.assign(env, {
-        'process.env.NODE_ENV': JSON.stringify(env.NODE_ENV || (this.options.dev ? 'development' : 'production')),
+        'process.env.NODE_ENV': JSON.stringify(env['process.env.NODE_ENV'] || (this.options.dev ? 'development' : 'production')),
         'process.env.VUE_ENV': JSON.stringify('server'),
         'process.mode': JSON.stringify(this.options.mode),
         'process.browser': false,


### PR DESCRIPTION
env.NODE_ENV is always undefined.