### PR TITLE
options.ignore support

### DIFF
--- a/lib/builder/builder.js
+++ b/lib/builder/builder.js
@@ -274,7 +274,7 @@ module.exports = class Builder {
     if (existsSync(resolve(this.options.srcDir, 'layouts'))) {
       const layoutsFiles = await glob('layouts/**/*.{vue,js}', {
         cwd: this.options.srcDir,
-        ignore: [`layouts/**/${this.options.ignorePrefix}*.{vue,js}`]
+        ignore: this.options.ignore
       })
       let hasErrorLayout = false
       layoutsFiles.forEach(file => {
@@ -316,7 +316,7 @@ module.exports = class Builder {
       const files = {}
       ;(await glob('pages/**/*.{vue,js}', {
         cwd: this.options.srcDir,
-        ignore: [`pages/**/${this.options.ignorePrefix}*.{vue,js}`]
+        ignore: this.options.ignore
       })).forEach(f => {
         const key = f.replace(/\.(js|vue)$/, '')
         if (/\.vue$/.test(f) || !files[key]) {

--- a/lib/common/options.js
+++ b/lib/common/options.js
@@ -119,6 +119,14 @@ Options.from = function (_options) {
     options.debug = options.dev
   }
 
+  // Normalize ignore
+  options.ignore = options.ignore ? [].concat(options.ignore) : []
+
+  // Append ignorePrefix glob to ignore
+  if (typeof options.ignorePrefix === 'string') {
+    options.ignore.push(`**/${options.ignorePrefix}*.*`)
+  }
+
   // Apply mode preset
   let modePreset =
     Options.modes[options.mode || 'universal'] || Options.modes['universal']
@@ -167,6 +175,9 @@ Options.defaults = {
   nuxtAppDir: resolve(__dirname, '../app'),
   modulesDir: ['node_modules'], // ~> relative to options.rootDir
   ignorePrefix: '-',
+  ignore: [
+    '**/*.test.*'
+  ],
   extensions: [],
   build: {
     analyze: false,

--- a/test/basic.generate.test.js
+++ b/test/basic.generate.test.js
@@ -173,6 +173,12 @@ test.serial('/-ignored', async t => {
   t.true(error.response.body.includes('Cannot GET /-ignored'))
 })
 
+test.serial('/ignored.test', async t => {
+  const error = await t.throws(rp(url('/ignored.test')))
+  t.true(error.statusCode === 404)
+  t.true(error.response.body.includes('Cannot GET /ignored.test'))
+})
+
 // Close server and ask nuxt to stop listening to file changes
 test.after.always('Closing server', async t => {
   await server.close()

--- a/test/basic.ssr.test.js
+++ b/test/basic.ssr.test.js
@@ -252,10 +252,7 @@ test('Content-Security-Policy Header', async t => {
     resolveWithFullResponse: true
   })
   // Verify functionality
-  t.is(
-    headers['content-security-policy'],
-    "script-src 'self' 'sha256-BBvfKxDOoRM/gnFwke9u60HBZX3HUss/0lSI1sBRvOU='"
-  )
+  t.regex(headers['content-security-policy'], /script-src 'self' 'sha256-.*'/)
 })
 
 test('/_nuxt/server-bundle.json should return 404', async t => {

--- a/test/fixtures/basic/middleware/ignored.test.js
+++ b/test/fixtures/basic/middleware/ignored.test.js
@@ -1,0 +1,3 @@
+export default function () {
+  throw new Error('Should be ignored')
+}

--- a/test/fixtures/basic/pages/ignored.test.vue
+++ b/test/fixtures/basic/pages/ignored.test.vue
@@ -1,0 +1,13 @@
+<template lang="html">
+  <div class="error">
+    Should be ignored
+  </div>
+</template>
+
+<script>
+export default {
+}
+</script>
+
+<style lang="css">
+</style>

--- a/test/fixtures/basic/store/ignored.test.js
+++ b/test/fixtures/basic/store/ignored.test.js
@@ -1,0 +1,3 @@
+export const state = () => ({
+  error: 'Should be ignored'
+})


### PR DESCRIPTION
This PR enhances #2417 by keeping backward compatibility to support more customizable ignore patterns like `*.test` files. (#2592).

Something to mention is it is not covering `require.context` ignores (For `store` and `middleware`) but it can be considered as enough for basic support as our regexes already exclude things like `*.test.*` for store and middleware. 

For future, we may have to refactor `require.context` into glob patterns inside `builder` module. This helps many perf improvements too.