### PR TITLE
External script support for CSP

### DIFF
--- a/lib/common/options.js
+++ b/lib/common/options.js
@@ -305,7 +305,9 @@ Options.defaults = {
     etag: {
       weak: false
     },
-    csp: undefined
+    csp: {
+      allowedSouces: []
+    }
   },
   watchers: {
     webpack: {

--- a/lib/core/middleware/nuxt.js
+++ b/lib/core/middleware/nuxt.js
@@ -68,9 +68,13 @@ module.exports = async function nuxtMiddleware(req, res, next) {
     }
 
     if (this.options.render.csp) {
+      let allowSources = cspScriptSrcHashes
+      if (this.options.render.csp.allowDomains) {
+        allowSources = cspScriptSrcHashes.concat(this.options.render.csp.allowDomains)
+      }
       res.setHeader(
         'Content-Security-Policy',
-        `script-src 'self' ${(cspScriptSrcHashes || []).join(' ')}`
+        `script-src 'self' ${(allowSources || []).join(' ')}`
       )
     }
 

--- a/lib/core/middleware/nuxt.js
+++ b/lib/core/middleware/nuxt.js
@@ -67,14 +67,11 @@ module.exports = async function nuxtMiddleware(req, res, next) {
       res.setHeader('Link', pushAssets.join(','))
     }
 
-    if (this.options.render.csp) {
-      let allowSources = cspScriptSrcHashes
-      if (this.options.render.csp.allowDomains) {
-        allowSources = cspScriptSrcHashes.concat(this.options.render.csp.allowDomains)
-      }
+    if (this.options.render.csp.hashAlgorithm) {
+      let allowedSources = cspScriptSrcHashes.concat(this.options.render.csp.allowedSources)
       res.setHeader(
         'Content-Security-Policy',
-        `script-src 'self' ${(allowSources || []).join(' ')}`
+        `script-src 'self' ${(allowedSources || []).join(' ')}`
       )
     }
 

--- a/lib/core/renderer.js
+++ b/lib/core/renderer.js
@@ -361,7 +361,7 @@ module.exports = class Renderer {
       isJSON: true
     })};`
     let cspScriptSrcHashes = []
-    if (this.options.render.csp) {
+    if (this.options.render.csp.hashAlgorithm) {
       let hash = crypto.createHash(this.options.render.csp.hashAlgorithm)
       hash.update(serializedSession)
       cspScriptSrcHashes.push(

--- a/test/basic.ssr.test.js
+++ b/test/basic.ssr.test.js
@@ -24,7 +24,10 @@ test.serial('Init Nuxt.js', async t => {
       stats: false
     },
     render: {
-      csp: true
+      csp: {
+        hashAlgorithm: 'sha256',
+        allowDomains: ['https://example.com', 'https://example.io']
+      }
     }
   }
 
@@ -256,6 +259,8 @@ test('Content-Security-Policy Header', async t => {
   })
   // Verify functionality
   t.regex(headers['content-security-policy'], /script-src 'self' 'sha256-.*'/)
+  t.true(headers['content-security-policy'].includes('https://example.com'))
+  t.true(headers['content-security-policy'].includes('https://example.io'))
 })
 
 test('/_nuxt/server-bundle.json should return 404', async t => {

--- a/test/basic.ssr.test.js
+++ b/test/basic.ssr.test.js
@@ -26,7 +26,7 @@ test.serial('Init Nuxt.js', async t => {
     render: {
       csp: {
         hashAlgorithm: 'sha256',
-        allowDomains: ['https://example.com', 'https://example.io']
+        allowedSources: ['https://example.com', 'https://example.io']
       }
     }
   }


### PR DESCRIPTION
refs : https://github.com/nuxt/nuxt.js/issues/2606

This PR is Changed to allow external scripts for content security policy

e.g.) `script-src  'self' sha256-xKS1DGTF21G4Kpdsfaadsx3b+dw= https://example.com`