### PR TITLE
fix: ssrContext.error is not a function

### DIFF
--- a/lib/app/server.js
+++ b/lib/app/server.js
@@ -110,7 +110,7 @@ export default async ssrContext => {
   midd = midd.map((name) => {
     if (typeof name === 'function') return name
     if (typeof middleware[name] !== 'function') {
-      ssrContext.error({ statusCode: 500, message: 'Unknown middleware ' + name })
+      app.context.error({ statusCode: 500, message: 'Unknown middleware ' + name })
     }
     return middleware[name]
   })


### PR DESCRIPTION
Fix `ssrContext.error is not a function` bug