### PR TITLE
`waitFor` - Remove unnecessary async

### DIFF
--- a/lib/common/utils.js
+++ b/lib/common/utils.js
@@ -49,7 +49,7 @@ exports.setAnsiColors = function setAnsiColors(ansiHTML) {
   })
 }
 
-exports.waitFor = async function waitFor(ms) {
+exports.waitFor = function waitFor(ms) {
   return new Promise(resolve => setTimeout(resolve, ms || 0))
 }
 


### PR DESCRIPTION
Doing so will allow people to avoid having to bablify `utils`. This might be useful for people who may want to run nuxt 1.0 in environments where only older versions of node are available, such as on AWS Lambda. This PR may hence be helpful for phlogisticfugu/perfect-paca#5