### PR TITLE
Add `generate:page` hook for `with-amp` example for SPA mode

### DIFF
--- a/examples/with-amp/nuxt.config.js
+++ b/examples/with-amp/nuxt.config.js
@@ -6,7 +6,7 @@ const modifyHtml = (html) => {
   // Add AMP script before </head>
   const ampScript = '<script async src="https://cdn.ampproject.org/v0.js"></script>'
   html = html.replace('</head>', ampScript + '</head>')
-  return html;
+  return html
 }
 module.exports = {
   head: {

--- a/examples/with-amp/nuxt.config.js
+++ b/examples/with-amp/nuxt.config.js
@@ -1,3 +1,13 @@
+const modifyHtml = (html) => {
+  // Add amp-custom tag to added CSS
+  html = html.replace(/<style data-vue-ssr/g, '<style amp-custom data-vue-ssr')
+  // Remove every script tag from generated HTML
+  html = html.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
+  // Add AMP script before </head>
+  const ampScript = '<script async src="https://cdn.ampproject.org/v0.js"></script>'
+  html = html.replace('</head>', ampScript + '</head>')
+  return html;
+}
 module.exports = {
   head: {
     meta: [
@@ -16,18 +26,13 @@ module.exports = {
     resourceHints: false
   },
   hooks: {
+    // This hook is called before generatic static html files for SPA mode
+    'generate:page': (page) => {
+      page.html = modifyHtml(page.html)
+    },
     // This hook is called before rendering the html to the browser
-    'render:route': (url, result) => {
-      let html = result.html
-      // Add amp-custom tag to added CSS
-      html = html.replace(/<style data-vue-ssr/g, '<style amp-custom data-vue-ssr')
-      // Remove every script tag from generated HTML
-      html = html.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
-      // Add AMP script before </head>
-      const ampScript = '<script async src="https://cdn.ampproject.org/v0.js"></script>'
-      html = html.replace('</head>', ampScript + '</head>')
-      // Update result html
-      result.html = html
+    'render:route': (url, page) => {
+      page.html = modifyHtml(page.html)
     }
   }
 }

--- a/examples/with-amp/package.json
+++ b/examples/with-amp/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "nuxt",
     "build": "nuxt build",
-    "start": "nuxt start"
+    "start": "nuxt start",
+    "generate": "nuxt generate"
   }
 }


### PR DESCRIPTION
Current version is not working while generating static html files with `nuxt generate` command. I modified `nuxt.config.js` and added necassary hook. 

Fixes: https://github.com/nuxt/nuxt.js/issues/2661