### PR TITLE
refactor: resolve exact route prior to index

### DIFF
--- a/lib/common/utils.js
+++ b/lib/common/utils.js
@@ -290,11 +290,19 @@ exports.createRoutes = function createRoutes(files, srcDir) {
     // Order Routes path
     parent.push(route)
     parent.sort((a, b) => {
-      if (!a.path.length || a.path === '/') {
+      if (!a.path.length) {
         return -1
       }
-      if (!b.path.length || b.path === '/') {
+      if (!b.path.length) {
         return 1
+      }
+      // Order: /static, /index, /:dynamic
+      // Match exact route before index: /login before /index/_slug
+      if (a.path === '/') {
+        return /^\/(:|\*)/.test(b.path) ? -1 : 1
+      }
+      if (b.path === '/') {
+        return /^\/(:|\*)/.test(a.path) ? 1 : -1
       }
       let i = 0
       let res = 0

--- a/test/dynamic-routes.test.js
+++ b/test/dynamic-routes.test.js
@@ -37,46 +37,43 @@ test('Check .nuxt/router.js', t => {
       routerFile.lastIndexOf(']') + 1
     )
     let routes = eval('( ' + routerFile + ')') // eslint-disable-line no-eval
-    // pages/index.vue
-    t.is(routes[0].path, '/')
-    t.is(routes[0].name, 'index')
     // pages/test/index.vue
-    t.is(routes[1].path, '/test')
-    t.is(routes[1].name, 'test')
+    t.is(routes[0].path, '/test')
+    t.is(routes[0].name, 'test')
     // pages/posts.vue
-    t.is(routes[2].path, '/posts')
-    t.is(routes[2].name, 'posts')
-    t.is(routes[2].children.length, 1)
+    t.is(routes[1].path, '/posts')
+    t.is(routes[1].name, 'posts')
+    t.is(routes[1].children.length, 1)
     // pages/posts/_id.vue
-    t.is(routes[2].children[0].path, ':id?')
-    t.is(routes[2].children[0].name, 'posts-id')
+    t.is(routes[1].children[0].path, ':id?')
+    t.is(routes[1].children[0].name, 'posts-id')
     // pages/parent.vue
-    t.is(routes[3].path, '/parent')
-    t.falsy(routes[3].name) // parent route has no name
+    t.is(routes[2].path, '/parent')
+    t.falsy(routes[2].name) // parent route has no name
     // pages/parent/*.vue
-    t.is(routes[3].children.length, 3) // parent has 3 children
-    t.deepEqual(routes[3].children.map(r => r.path), ['', 'teub', 'child'])
-    t.deepEqual(routes[3].children.map(r => r.name), [
+    t.is(routes[2].children.length, 3) // parent has 3 children
+    t.deepEqual(routes[2].children.map(r => r.path), ['', 'teub', 'child'])
+    t.deepEqual(routes[2].children.map(r => r.name), [
       'parent',
       'parent-teub',
       'parent-child'
     ])
     // pages/test/projects/index.vue
-    t.is(routes[4].path, '/test/projects')
-    t.is(routes[4].name, 'test-projects')
+    t.is(routes[3].path, '/test/projects')
+    t.is(routes[3].name, 'test-projects')
     // pages/test/users.vue
-    t.is(routes[5].path, '/test/users')
-    t.falsy(routes[5].name) // parent route has no name
+    t.is(routes[4].path, '/test/users')
+    t.falsy(routes[4].name) // parent route has no name
     // pages/test/users/*.vue
-    t.is(routes[5].children.length, 5) // parent has 5 children
-    t.deepEqual(routes[5].children.map(r => r.path), [
+    t.is(routes[4].children.length, 5) // parent has 5 children
+    t.deepEqual(routes[4].children.map(r => r.path), [
       '',
       'projects',
       'projects/:category',
       ':id',
       ':index/teub'
     ])
-    t.deepEqual(routes[5].children.map(r => r.name), [
+    t.deepEqual(routes[4].children.map(r => r.name), [
       'test-users',
       'test-users-projects',
       'test-users-projects-category',
@@ -84,20 +81,25 @@ test('Check .nuxt/router.js', t => {
       'test-users-index-teub'
     ])
     // pages/test/songs/toto.vue
-    t.is(routes[6].path, '/test/songs/toto')
-    t.is(routes[6].name, 'test-songs-toto')
+    t.is(routes[5].path, '/test/songs/toto')
+    t.is(routes[5].name, 'test-songs-toto')
+    // pages/test/projects/_category.vue
+    t.is(routes[6].path, '/test/projects/:category')
+    t.is(routes[6].name, 'test-projects-category')
     // pages/test/songs/_id.vue
     t.is(routes[7].path, '/test/songs/:id?')
     t.is(routes[7].name, 'test-songs-id')
-    // pages/test/projects/_category.vue
-    t.is(routes[8].path, '/test/projects/:category')
-    t.is(routes[8].name, 'test-projects-category')
     // pages/users/_id.vue
-    t.is(routes[9].path, '/users/:id?')
-    t.is(routes[9].name, 'users-id')
+    t.is(routes[8].path, '/users/:id?')
+    t.is(routes[8].name, 'users-id')
     // pages/test/_.vue
-    t.is(routes[10].path, '/test/*')
-    t.is(routes[10].name, 'test-all')
+    t.is(routes[9].path, '/test/*')
+    t.is(routes[9].name, 'test-all')
+
+    // pages/index.vue
+    t.is(routes[10].path, '/')
+    t.is(routes[10].name, 'index')
+
     // pages/_slug.vue
     t.is(routes[11].path, '/:slug')
     t.is(routes[11].name, 'slug')


### PR DESCRIPTION
#### Resolve #2662 

In routes generation, put `/index` after exact route like `/login` and before dynamic ones like '/:slug', so that `/login` will have higher priority than `/index/_slug`.