### PR TITLE
feat: optional build option to limit chunks size

### DIFF
--- a/examples/vue-chartjs/nuxt.config.js
+++ b/examples/vue-chartjs/nuxt.config.js
@@ -7,7 +7,8 @@ module.exports = {
     ]
   },
   build: {
-    vendor: ['axios', 'moment', 'chart.js', 'vue-chartjs']
+    vendor: ['axios', 'moment', 'chart.js', 'vue-chartjs'],
+    maxChunkSize: 300000
   },
   env: {
     githubToken: '42cdf9fd55abf41d24f34c0f8a4d9ada5f9e9b93'

--- a/lib/builder/webpack/client.config.js
+++ b/lib/builder/webpack/client.config.js
@@ -166,6 +166,17 @@ module.exports = function webpackClientConfig() {
       config.plugins.push(new webpack.optimize.ModuleConcatenationPlugin())
     }
 
+    // Chunks size limit
+    // https://webpack.js.org/plugins/aggressive-splitting-plugin/
+    if (this.options.build.maxChunkSize) {
+      config.plugins.push(
+        new webpack.optimize.AggressiveSplittingPlugin({
+          minSize: this.options.build.maxChunkSize,
+          maxSize: this.options.build.maxChunkSize
+        })
+      )
+    }
+
     // https://webpack.js.org/plugins/hashed-module-ids-plugin
     config.plugins.push(new webpack.HashedModuleIdsPlugin())
 

--- a/lib/common/options.js
+++ b/lib/common/options.js
@@ -184,6 +184,7 @@ Options.defaults = {
     profile: process.argv.includes('--profile'),
     dll: false,
     scopeHoisting: false,
+    maxChunkSize: false,
     extractCSS: false,
     cssSourceMap: undefined,
     ssr: undefined,


### PR DESCRIPTION
Often when people add an external vendor, they are faced with a "too big" warning from webpack perfs hint.

The following webpack plugin offer the capability to limit the size of each chunk : https://webpack.js.org/plugins/aggressive-splitting-plugin/

My proposal is to add a new optional build parameter to add a custom limit on nuxt build process.

```js
  build: {
    vendor: ['axios', 'moment', 'chart.js', 'vue-chartjs'],
    maxChunkSize: 300000 // value in octet
  },
```

---

ex. with the `examples/vue-chartjs` on `npm run build`

without limit:

```console
pages/contributors.509ed7a1ecd667cadf53.js    1.91 kB       0  [emitted]         pages/contributors
       pages/index.2fb0de0a459665463f90.js    1.79 kB       1  [emitted]         pages/index
   layouts/default.a1055a6d2a62b5ec9661.js    1.22 kB       2  [emitted]         layouts/default
            vendor.3914c893fb716952ee68.js     765 kB       3  [emitted]  [big]  vendor
               app.1216e8c163f13b4a3b1a.js    26.7 kB       4  [emitted]         app
          manifest.c5c352259037bc222559.js    1.58 kB       5  [emitted]         manifest
                                  LICENSES  843 bytes          [emitted]
 + 3 hidden assets

WARNING in asset size limit: The following asset(s) exceed the recommended size limit (300 kB).
This can impact web performance.
Assets:
  vendor.3914c893fb716952ee68.js (765 kB)
```

with 300kB limit:
```console
                                     Asset       Size  Chunks             Chunk Names
                 6.b8035634b249b67f6c95.js     127 kB       6  [emitted]
               app.890503dc54a916bd4c2f.js    26.8 kB       0  [emitted]  app
       pages/index.8394af00f47ad2c92ce8.js    1.79 kB       2  [emitted]  pages/index
   layouts/default.48a52768147345153b3b.js    1.22 kB       3  [emitted]  layouts/default
                 4.2723a779df98c6c8e1c5.js     141 kB       4  [emitted]
                 5.3dcf86b3370d0e13c489.js     140 kB       5  [emitted]
pages/contributors.51190855c2b7d384e9a2.js    1.91 kB       1  [emitted]  pages/contributors
                 7.61a55d8ea47b7acef379.js    22.9 kB       7  [emitted]
                 8.9f9d13074cf7f9a86855.js     131 kB       8  [emitted]
                 9.ee1276223ccd0cfff6a1.js     111 kB       9  [emitted]
            vendor.c92d33fd924fb5efdb1f.js    92.5 kB      10  [emitted]
          manifest.51ab9689410a36830e2e.js    1.73 kB      11  [emitted]  manifest
                                  LICENSES  843 bytes          [emitted]
 + 3 hidden assets
```

