### PR TITLE
Added errorMiddleware hook.

### DIFF
--- a/lib/core/renderer.js
+++ b/lib/core/renderer.js
@@ -280,6 +280,11 @@ module.exports = class Renderer {
     // Error middleware for errors that occurred in middleware that declared above
     // Middleware should exactly take 4 arguments
     // https://github.com/senchalabs/connect#error-middleware
+
+    // Apply errorMiddleware from modules first
+    await this.nuxt.callHook('render:errorMiddleware', this.app)
+
+    // Apply errorMiddleware from Nuxt
     this.useMiddleware(errorMiddleware.bind(this))
   }
 


### PR DESCRIPTION
Hi! The upgrade to version v1.0.0 unfortunately broke the [Sentry module](https://github.com/nuxt-community/sentry-module), which was pointed out by @steffen1249 [here](https://github.com/nuxt-community/sentry-module/issues/9).

This PR allows modules to inject error middleware, before calling NuxtJS's. The Sentry module is already [waiting](https://github.com/nuxt-community/sentry-module/commit/67f3f301e6b2726914fb149babd6ebf9da3e2f11) for this PR :).