### PR TITLE
expand route meta with meta from matched routes

### DIFF
--- a/lib/app/utils.js
+++ b/lib/app/utils.js
@@ -93,9 +93,9 @@ export async function getRouteData(route) {
   // Send back a copy of route with meta based on Component definition
   return {
     ...route,
-    meta: getMatchedComponents(route).map((Component) => {
-      return Component.options.meta || {}
-    })
+    meta: getMatchedComponents(route).reduce((meta, Component) => {
+      return Object.assign(meta, Component.options.meta)
+    }, route.meta)
   }
 }
 

--- a/test/basic.csr.test.js
+++ b/test/basic.csr.test.js
@@ -186,7 +186,7 @@ test.serial('/meta', async t => {
   await page.nuxt.navigate('/meta')
 
   const state = await page.nuxt.storeState()
-  t.deepEqual(state.meta, [{ works: true }])
+  t.deepEqual(state.meta, { works: true })
 })
 
 test.serial('/fn-midd', async t => {

--- a/test/basic.ssr.test.js
+++ b/test/basic.ssr.test.js
@@ -279,7 +279,7 @@ test('/_nuxt/ should return 404', async t => {
 
 test('/meta', async t => {
   const { html } = await nuxt.renderRoute('/meta')
-  t.true(html.includes('"meta":[{"works":true}]'))
+  t.true(html.includes('"meta":{"works":true}'))
 })
 
 test('/fn-midd', async t => {


### PR DESCRIPTION
$route.meta should be an object in order to be consistent with vue-router, and contain meta from matched routes. (not to be confused with vue-meta)

https://router.vuejs.org/en/advanced/meta.html
https://github.com/nuxt/nuxt.js/issues/2552