### PR TITLE
Feature Request: Store directory structure changes

### DIFF
--- a/lib/app/store.js
+++ b/lib/app/store.js
@@ -36,9 +36,7 @@ if (typeof storeData !== 'function') {
     let namePath = name.split(/\//)
 
     name = namePath[namePath.length-1]
-    console.log(namePath)
     if (name === 'state' || name === 'getters' || name === 'actions' || name === 'mutations') {
-
       let module = getModuleNamespace(storeData, namePath, true)
       appendModule(module, filename, name)
       continue

--- a/lib/app/store.js
+++ b/lib/app/store.js
@@ -34,10 +34,21 @@ if (typeof storeData !== 'function') {
     if (name === 'index') continue
 
     let namePath = name.split(/\//)
+
+    name = namePath[namePath.length-1]
+    console.log(namePath)
+    if (name === 'state' || name === 'getters' || name === 'actions' || name === 'mutations') {
+
+      let module = getModuleNamespace(storeData, namePath, true)
+      appendModule(module, filename, name)
+      continue
+    }
+
     let module = getModuleNamespace(storeData, namePath)
 
     name = namePath.pop()
-    module[name] = getModule(filename)
+    module[name] = module[name] || {}
+    module[name] = Object.assign(module[name], getModule(filename))
     module[name].namespaced = true
   }
 
@@ -65,13 +76,20 @@ function getModule (filename) {
   return module
 }
 
-function getModuleNamespace (storeData, namePath) {
+function getModuleNamespace (storeData, namePath, forAppend = false) {
   if (namePath.length === 1) {
+    if (forAppend)
+      return storeData
     return storeData.modules
   }
   let namespace = namePath.shift()
   storeData.modules[namespace] = storeData.modules[namespace] || {}
   storeData.modules[namespace].namespaced = true
   storeData.modules[namespace].modules = storeData.modules[namespace].modules || {}
-  return getModuleNamespace(storeData.modules[namespace], namePath)
+  return getModuleNamespace(storeData.modules[namespace], namePath, forAppend)
+}
+
+function appendModule(module, filename, name) {
+  const file = files(filename)
+  module[name] = file.default || file
 }

--- a/lib/app/store.js
+++ b/lib/app/store.js
@@ -45,6 +45,9 @@ if (typeof storeData !== 'function') {
     let module = getModuleNamespace(storeData, namePath)
 
     name = namePath.pop()
+
+    //use Object.assign to deal with cases where there's a 'myModule.js' and
+    //a 'myModule' folder containing state/getters/actions/mutations
     module[name] = module[name] || {}
     module[name] = Object.assign(module[name], getModule(filename))
     module[name].namespaced = true

--- a/lib/app/store.js
+++ b/lib/app/store.js
@@ -44,18 +44,29 @@ if (typeof storeData !== 'function') {
 
     //if file is user/index.js
     //it should save as user
-    if (name === 'index')
+    var isIndex = (name === 'index')
+    if (isIndex)
       namePath.pop()
 
     let module = getModuleNamespace(storeData, namePath)
-
     name = namePath.pop()
-
-    //use Object.assign to deal with cases where there's a 'myModule.js' and
-    //a 'myModule' folder containing state/getters/actions/mutations
     module[name] = module[name] || {}
-    module[name] = Object.assign(module[name], getModule(filename))
-    module[name].namespaced = true
+    var fileModule = getModule(filename)
+
+    if (!isIndex) {
+      module[name] = Object.assign({}, fileModule, module[name])
+      module[name].namespaced = true
+      continue
+    }
+
+    var appendedMods = []
+    if (module[name].appends) {
+      fileModule.appends = module[name].appends
+      for (let append of module[name].appends) {
+        appendedMods[append] = module[name][append]
+      }
+    }
+    module[name] = Object.assign(module[name], fileModule, appendedMods)
   }
 
 }
@@ -97,5 +108,7 @@ function getModuleNamespace (storeData, namePath, forAppend = false) {
 
 function appendModule(module, filename, name) {
   const file = files(filename)
+  module.appends = module.appends || []
+  module.appends.push(name)
   module[name] = file.default || file
 }

--- a/lib/app/store.js
+++ b/lib/app/store.js
@@ -42,29 +42,32 @@ if (typeof storeData !== 'function') {
       continue
     }
 
-    //if file is user/index.js
-    //it should save as user
-    var isIndex = (name === 'index')
+    //if file is foo/index.js
+    //it should save as foo
+    let isIndex = (name === 'index')
     if (isIndex)
       namePath.pop()
 
-    let module = getModuleNamespace(storeData, namePath)
+    let module      = getModuleNamespace(storeData, namePath)
+    let fileModule  = getModule(filename)
     name = namePath.pop()
     module[name] = module[name] || {}
-    var fileModule = getModule(filename)
 
+    //if file is foo.js, existing properties take priority
+    //because it's the least specific case
     if (!isIndex) {
       module[name] = Object.assign({}, fileModule, module[name])
       module[name].namespaced = true
       continue
     }
 
+    //if file is foo/index.js we want to overwrite properties from foo.js
+    //but not from appended mods like foo/actions.js
     var appendedMods = []
     if (module[name].appends) {
       fileModule.appends = module[name].appends
-      for (let append of module[name].appends) {
+      for (let append of module[name].appends)
         appendedMods[append] = module[name][append]
-      }
     }
     module[name] = Object.assign(module[name], fileModule, appendedMods)
   }

--- a/lib/app/store.js
+++ b/lib/app/store.js
@@ -63,13 +63,15 @@ if (typeof storeData !== 'function') {
 
     //if file is foo/index.js we want to overwrite properties from foo.js
     //but not from appended mods like foo/actions.js
-    var appendedMods = []
+    var appendedMods = {}
     if (module[name].appends) {
-      fileModule.appends = module[name].appends
+      appendedMods.appends = module[name].appends
       for (let append of module[name].appends)
         appendedMods[append] = module[name][append]
     }
-    module[name] = Object.assign(module[name], fileModule, appendedMods)
+
+    module[name] = Object.assign({}, module[name], fileModule, appendedMods)
+    module[name].namespaced = true
   }
 
 }

--- a/lib/app/store.js
+++ b/lib/app/store.js
@@ -42,6 +42,11 @@ if (typeof storeData !== 'function') {
       continue
     }
 
+    //if file is user/index.js
+    //it should save as user
+    if (name === 'index')
+      namePath.pop()
+
     let module = getModuleNamespace(storeData, namePath)
 
     name = namePath.pop()

--- a/test/basic.csr.test.js
+++ b/test/basic.csr.test.js
@@ -81,6 +81,7 @@ test.serial('/store', async t => {
   t.is(await page.$text('h1'), 'Vuex Nested Modules')
   t.is(await page.$text('p'), '1')
   t.is(await page.$text('h2'), '4')
+  t.is(await page.$text('h3'), '10')
 })
 
 test.serial('/head', async t => {

--- a/test/basic.csr.test.js
+++ b/test/basic.csr.test.js
@@ -80,6 +80,7 @@ test.serial('/store', async t => {
 
   t.is(await page.$text('h1'), 'Vuex Nested Modules')
   t.is(await page.$text('p'), '1')
+  t.is(await page.$text('h2'), '4')
 })
 
 test.serial('/head', async t => {

--- a/test/fixtures/basic/pages/store.vue
+++ b/test/fixtures/basic/pages/store.vue
@@ -5,6 +5,8 @@
     <p>{{ $store.state.counter }}</p>
     <br>
     <h2>{{ getVal }}</h2>
+    <br>
+    <h3>{{ getBabVal }}</h3>
   </div>
 </template>
 
@@ -14,7 +16,8 @@ import { mapGetters } from 'vuex'
 export default {
   computed: {
     ...mapGetters('foo/bar', ['baz']),
-    ...mapGetters('foo/blarg', ['getVal'])
+    ...mapGetters('foo/blarg', ['getVal']),
+    ...mapGetters('bab', ['getBabVal'])
   }
 }
 </script>

--- a/test/fixtures/basic/pages/store.vue
+++ b/test/fixtures/basic/pages/store.vue
@@ -3,6 +3,8 @@
     <h1>{{ baz }}</h1>
     <br>
     <p>{{ $store.state.counter }}</p>
+    <br>
+    <h2>{{ getVal }}</h2>
   </div>
 </template>
 
@@ -10,6 +12,9 @@
 import { mapGetters } from 'vuex'
 
 export default {
-  computed: mapGetters('foo/bar', ['baz'])
+  computed: {
+    ...mapGetters('foo/bar', ['baz']),
+    ...mapGetters('foo/blarg', ['getVal'])
+  }
 }
 </script>

--- a/test/fixtures/basic/store/bab/index.js
+++ b/test/fixtures/basic/store/bab/index.js
@@ -1,0 +1,9 @@
+export const state = () => ({
+  babVal: 10
+})
+
+export const getters = {
+  getBabVal(state) {
+    return state.babVal
+  }
+}

--- a/test/fixtures/basic/store/foo/blarg.js
+++ b/test/fixtures/basic/store/foo/blarg.js
@@ -1,0 +1,3 @@
+export const state = () => ({
+  val: 1
+})

--- a/test/fixtures/basic/store/foo/blarg.js
+++ b/test/fixtures/basic/store/foo/blarg.js
@@ -1,3 +1,9 @@
 export const state = () => ({
   val: 1
 })
+
+export const getters = {
+  getVal(state) {
+    return 100
+  }
+}

--- a/test/fixtures/basic/store/foo/blarg/getters.js
+++ b/test/fixtures/basic/store/foo/blarg/getters.js
@@ -1,0 +1,5 @@
+export default {
+  getVal(state) {
+    return state.val
+  }
+}

--- a/test/fixtures/basic/store/foo/blarg/index.js
+++ b/test/fixtures/basic/store/foo/blarg/index.js
@@ -1,0 +1,3 @@
+export const state = () => ({
+  val: 2
+})

--- a/test/fixtures/basic/store/foo/blarg/index.js
+++ b/test/fixtures/basic/store/foo/blarg/index.js
@@ -1,3 +1,9 @@
 export const state = () => ({
   val: 2
 })
+
+export const getters = {
+  getVal(state) {
+    return 99
+  }
+}

--- a/test/fixtures/basic/store/foo/blarg/state.js
+++ b/test/fixtures/basic/store/foo/blarg/state.js
@@ -1,0 +1,3 @@
+export default () => ({
+  val: 4
+})


### PR DESCRIPTION
This is similar to issue #1576.

I thought it would be really useful to allow an alternative directory structure for the Vuex store. I've changed it so that you can break up a module into state/getters/actions/mutations files like this. Also allows using `module/index.js`.

```
store
  state.js
  actions.js
  mutations.js
  getters.js
  module1/
    state.js
    actions.js
    nested-module/
      state.js
  module2/
    index.js
    getters.js
```

But it's still compatible with the existing directory structure (unless you have files named state.js, actions.js, etc). And you can mix and match.

```
store
  index.js
  module1.js
  module1/
    nested-module.js
  module2/
    state.js
    actions.js
```

Also, this is my first PR ever, so I apologize if I did this all wrong.