### PR TITLE
Preserve route meta data

### DIFF
--- a/lib/app/router.js
+++ b/lib/app/router.js
@@ -14,6 +14,7 @@ function recursiveRoutes(routes, tab, components) {
     res += tab + '\tcomponent: ' + route._name
     res += (route.name) ? ',\n\t' + tab + 'name: ' + JSON.stringify(route.name) : ''
     res += (route.children) ? ',\n\t' + tab + 'children: [\n' + recursiveRoutes(routes[i].children, tab + '\t\t', components) + '\n\t' + tab + ']' : ''
+    res += (route.meta) ? ',\n\t' + tab + 'meta: ' + JSON.stringify(route.meta) : ''
     res += '\n' + tab + '}' + (i + 1 === routes.length ? '' : ',\n')
   })
   return res


### PR DESCRIPTION
Modules or `config.router.extendRoutes()` might add route meta (https://router.vuejs.org/en/advanced/meta.html). This meta data should be preserved when generation the router config.

It would also be a nice to have to configure `routeMeta` on the page components and merge those into the router config. But I haven't yet found a way to do this.