### PR TITLE
Feature: watch `options.build.styleResources` as default in dev mode

### DIFF
--- a/lib/builder/builder.js
+++ b/lib/builder/builder.js
@@ -668,11 +668,15 @@ module.exports = class Builder {
       .on('unlink', refreshFiles)
 
     // Watch for custom provided files
-    const watchFiles = _.map(_.uniq(this.options.build.watch), p =>
+    let customPatterns = _.concat(
+      this.options.build.watch,
+      ..._.values(_.omit(this.options.build.styleResources, ['options']))
+    )
+    customPatterns = _.map(_.uniq(customPatterns), p =>
       upath.normalizeSafe(p)
     )
     this.customFilesWatcher = chokidar
-      .watch(watchFiles, options)
+      .watch(customPatterns, options)
       .on('change', refreshFiles)
   }
 


### PR DESCRIPTION
Implement https://github.com/nuxt/nuxt.js/issues/2583

`options.build.styleResources` can say almost will be modified during development (often be used to setup variables), why not watch then in default (๑ơ ω ơ)?

`imports` from them was also covered.

I also changed the var name `watchFiles -> customPatterns` which seems more similar to the naming of codes above.