### PR TITLE
fix DOMException

### DIFF
--- a/lib/app/router.js
+++ b/lib/app/router.js
@@ -53,9 +53,22 @@ const scrollBehavior = function (to, from, savedPosition) {
     window.$nuxt.$once('triggerScroll', () => {
       // coords will be used if no selector is provided,
       // or if the selector didn't match any element.
-      if (to.hash && document.querySelector(to.hash)) {
-        // scroll to anchor by returning the selector
-        position = { selector: to.hash }
+      if (to.hash) {
+        let hash = to.hash
+        // CSS.escape() is not supported with IE and Edge.
+        // But we can use the following polyfill to solve this problem.
+        // https://github.com/mathiasbynens/CSS.escape
+        if (typeof window.CSS !== 'undefined' && typeof window.CSS.escape !== 'undefined') {
+          hash = '#' + window.CSS.escape(hash.substr(1))
+        }
+        try {
+          if (document.querySelector(hash)) {
+            // scroll to anchor by returning the selector
+            position = { selector: hash }
+          }
+        } catch (e) {
+          console.warn('failed to save the scroll position. possibly this problem can be solved using a polyfill for CSS.escape().')
+        }
       }
       resolve(position)
     })

--- a/lib/app/router.js
+++ b/lib/app/router.js
@@ -56,8 +56,6 @@ const scrollBehavior = function (to, from, savedPosition) {
       if (to.hash) {
         let hash = to.hash
         // CSS.escape() is not supported with IE and Edge.
-        // But we can use the following polyfill to solve this problem.
-        // https://github.com/mathiasbynens/CSS.escape
         if (typeof window.CSS !== 'undefined' && typeof window.CSS.escape !== 'undefined') {
           hash = '#' + window.CSS.escape(hash.substr(1))
         }
@@ -67,7 +65,7 @@ const scrollBehavior = function (to, from, savedPosition) {
             position = { selector: hash }
           }
         } catch (e) {
-          console.warn('failed to save the scroll position. possibly this problem can be solved using a polyfill for CSS.escape().')
+          console.warn('Failed to save scroll position. Please add CSS.escape() polyfill (https://github.com/mathiasbynens/CSS.escape).')
         }
       }
       resolve(position)


### PR DESCRIPTION
This PR fix #2859.

`document.querySelector()` only permit a value that is valid as a CSS selector.
So we must escape the hash string before passing it to querySelector.


