### PR TITLE
Include Vuex only when store is not empty

### DIFF
--- a/lib/common/options.js
+++ b/lib/common/options.js
@@ -1,7 +1,7 @@
 const _ = require('lodash')
 const Debug = require('debug')
 const { join, resolve } = require('path')
-const { existsSync } = require('fs')
+const { existsSync, readdirSync } = require('fs')
 const { isUrl, isPureObject } = require('../common/utils')
 
 const debug = Debug('nuxt:build')
@@ -85,7 +85,12 @@ Options.from = function (_options) {
   }
 
   // If store defined, update store options to true unless explicitly disabled
-  if (options.store !== false && existsSync(join(options.srcDir, options.dir.store))) {
+  if (
+    options.store !== false &&
+    existsSync(join(options.srcDir, options.dir.store)) &&
+    readdirSync(join(options.srcDir, options.dir.store))
+      .find(filename => filename !== 'README.md' && filename[0] !== '.')
+  ) {
     options.store = true
   }
 


### PR DESCRIPTION
Not every Nuxt project uses Vuex. By default Nuxt includes Vuex when the `store` directory is present. If you don't use Vuex and forget to remove the directory, it's still loaded and increases vendor bundle.
I suggest we check whether store is not empty (`README.md` and `.*` are ommited).
This PR is compatible with #2733.