### PR TITLE
dont modify process.argv with .splice, make a copy first

### DIFF
--- a/bin/nuxt
+++ b/bin/nuxt
@@ -25,11 +25,9 @@ if (!semver.satisfies(process.version, engines.node)) {
 const defaultCommand = 'dev'
 const commands = new Set([defaultCommand, 'init', 'build', 'start', 'generate'])
 
-var cmd = process.argv[2]
+let cmd = process.argv[2]
 
-if (commands.has(cmd)) {
-  process.argv.splice(2, 1)
-} else {
+if (!commands.has(cmd)) {
   cmd = defaultCommand
 }
 

--- a/bin/nuxt-build
+++ b/bin/nuxt-build
@@ -8,7 +8,11 @@ debug.color = 2 // Force green color
 const { Nuxt, Builder, Generator, Utils } = require('..')
 const { loadNuxtConfig } = require('./common/utils')
 
-const argv = parseArgs(process.argv.slice(2), {
+const args = JSON.parse(JSON.stringify(process.argv))
+
+args.splice(2, 1)
+
+const argv = parseArgs(args.slice(2), {
   alias: {
     h: 'help',
     c: 'config-file',

--- a/bin/nuxt-dev
+++ b/bin/nuxt-dev
@@ -15,7 +15,11 @@ const {
   nuxtConfigFile
 } = require('./common/utils')
 
-const argv = parseArgs(process.argv.slice(2), {
+const args = JSON.parse(JSON.stringify(process.argv))
+
+args.splice(2, 1)
+
+const argv = parseArgs(args.slice(2), {
   alias: {
     h: 'help',
     H: 'hostname',

--- a/bin/nuxt-generate
+++ b/bin/nuxt-generate
@@ -7,7 +7,11 @@ const debug = require('debug')('nuxt:generate')
 const { Nuxt, Builder, Generator, Utils } = require('..')
 const { loadNuxtConfig } = require('./common/utils')
 
-const argv = parseArgs(process.argv.slice(2), {
+const args = JSON.parse(JSON.stringify(process.argv))
+
+args.splice(2, 1)
+
+const argv = parseArgs(args.slice(2), {
   alias: {
     h: 'help',
     c: 'config-file',

--- a/bin/nuxt-start
+++ b/bin/nuxt-start
@@ -8,7 +8,11 @@ const { resolve } = require('path')
 const { Nuxt, Utils } = require('..')
 const { loadNuxtConfig, getLatestHost } = require('./common/utils')
 
-const argv = parseArgs(process.argv.slice(2), {
+const args = JSON.parse(JSON.stringify(process.argv))
+
+args.splice(2, 1)
+
+const argv = parseArgs(args.slice(2), {
   alias: {
     h: 'help',
     H: 'hostname',


### PR DESCRIPTION
It would be nice to know with which sub-command `nuxt` was started, so modules can act accordingly (example [1] and [2]).

Unfortunately `process.argv` is modified here https://github.com/nuxt/nuxt.js/blob/dev/bin/nuxt#L31 , making it impossible to get the sub-command later in the application.

This PR will leave `process.argv` intact by creating a copy before modifying the Array with `.splice()`.

[1]: https://github.com/mustardamus/nuxt-bulma-slim/blob/master/lib/index.js#L115
[2]: https://github.com/mustardamus/teil/blob/develop/lib/nuxt-module.js#L11

