### PR TITLE
fetch default locale from i18n.fallbackLocale in i18n example

### DIFF
--- a/examples/i18n/middleware/i18n.js
+++ b/examples/i18n/middleware/i18n.js
@@ -1,16 +1,22 @@
 export default function ({ isHMR, app, store, route, params, error, redirect }) {
+  const defaultLocale = app.i18n.fallbackLocale;
   // If middleware is called from hot module replacement, ignore it
   if (isHMR) return
   // Get locale from params
-  const locale = params.lang || 'en'
+  const locale = params.lang || defaultLocale
   if (store.state.locales.indexOf(locale) === -1) {
     return error({ message: 'This page could not be found.', statusCode: 404 })
   }
   // Set locale
   store.commit('SET_LANG', locale)
   app.i18n.locale = store.state.locale
-  // If route is /en/... -> redirect to /...
-  if (locale === 'en' && route.fullPath.indexOf('/en') === 0) {
-    return redirect(route.fullPath.replace(/^\/en/, '/'))
+  // If route is /<defaultLocale>/... -> redirect to /...
+  if (locale === defaultLocale && route.fullPath.indexOf('/'+defaultLocale) === 0) {
+
+    var toReplace = '^/'+defaultLocale
+    var re = new RegExp(toReplace); 
+    return redirect(
+      route.fullPath.replace(re, '/')
+    )
   }
 }


### PR DESCRIPTION
Not all projects have 'en' as their default locale. It would be nicer to fetch a default locale from the `fallbackLocale` set on the i18n plugin, rather than hard coding it in middleware.