### PR TITLE
feature: override options for serving dist files

### DIFF
--- a/lib/core/renderer.js
+++ b/lib/core/renderer.js
@@ -262,10 +262,16 @@ module.exports = class Renderer {
       const distDir = resolve(this.options.buildDir, 'dist')
       this.useMiddleware({
         path: this.publicPath,
-        handler: serveStatic(distDir, {
-          index: false, // Don't serve index.html template
-          maxAge: '1y' // 1 year in production
-        })
+        handler: serveStatic(
+          distDir,
+          Object.assign(
+            {
+              index: false, // Don't serve index.html template
+              maxAge: '1y' // 1 year in production
+            },
+            this.options.render.dist
+          )
+        )
       })
     }
 


### PR DESCRIPTION
Currently, serving static dist files uses hardcoded options (no index, 1 year expire time). This PR allows to pass custom options, using exactly the same syntax as one can already pass custom options for serving static files under `static/`.

For example, this will set CORS header for dist files:

```js
// nuxt.config.js

module.exports = {
  render: {
    dist: {
      setHeaders (res, path) {
        res.setHeader('Access-Control-Allow-Origin', '*')
      },
    },
  },
}
```