### PR TITLE
Remove reference to npm scripts as they no longer exist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 1. [Fork](https://help.github.com/articles/fork-a-repo/) this repository to your own GitHub account and then [clone](https://help.github.com/articles/cloning-a-repository/) it to your local device.
 2. Install the dependencies: `npm install`.
 3. Run `npm link` to link the local repo to NPM.
-4. Run `npm run build` to build or `npm run watch` to build and watch for code changes.
+4. Run `nuxt build` to build or `nuxt` to build and watch for code changes.
 5. Then npm link this repo inside any example app with `npm link nuxt`.
 6. Then you can run your example app with the local version of Nuxt.js (You may need to re-run the example app as you change server side code in the Nuxt.js repository).
 


### PR DESCRIPTION
Looks like these were removed [here](https://github.com/nuxt/nuxt.js/commit/9b8cbed51236d32372706be7c2381df032c3dd88#diff-b9cfc7f2cdf78a7f4b91a753d10865a2L53)