### PR TITLE
fix: throw jsdomError to avoid renderAndGetWindow hanging

### DIFF
--- a/lib/core/renderer.js
+++ b/lib/core/renderer.js
@@ -421,12 +421,18 @@ module.exports = class Renderer {
         window.scrollTo = () => {}
       }
     }
+    const jsdomErrHandler = err => { throw err }
     if (opts.virtualConsole !== false) {
-      options.virtualConsole = new jsdom.VirtualConsole().sendTo(console, { omitJSDOMErrors: true })
-      options.virtualConsole.on('jsdomError', err => { throw err })
+      options.virtualConsole = new jsdom.VirtualConsole().sendTo(console, { omitJSDOMErrors: false })
+      // throw error when window creation failed
+      options.virtualConsole.on('jsdomError', jsdomErrHandler)
     }
     url = url || 'http://localhost:3000'
     const { window } = await jsdom.JSDOM.fromURL(url, options)
+    if (opts.virtualConsole !== false) {
+      // after window initialized successfully
+      options.virtualConsole.removeListener('jsdomError', jsdomErrHandler)
+    }
     // If Nuxt could not be loaded (error from the server-side)
     const nuxtExists = window.document.body.innerHTML.includes(
       this.options.render.ssr ? 'window.__NUXT__' : '<div id="__nuxt">'

--- a/lib/core/renderer.js
+++ b/lib/core/renderer.js
@@ -422,7 +422,8 @@ module.exports = class Renderer {
       }
     }
     if (opts.virtualConsole !== false) {
-      options.virtualConsole = new jsdom.VirtualConsole().sendTo(console)
+      options.virtualConsole = new jsdom.VirtualConsole().sendTo(console, { omitJSDOMErrors: true })
+      options.virtualConsole.on('jsdomError', err => { throw err })
     }
     url = url || 'http://localhost:3000'
     const { window } = await jsdom.JSDOM.fromURL(url, options)

--- a/lib/core/renderer.js
+++ b/lib/core/renderer.js
@@ -423,16 +423,12 @@ module.exports = class Renderer {
     }
     const jsdomErrHandler = err => { throw err }
     if (opts.virtualConsole !== false) {
-      options.virtualConsole = new jsdom.VirtualConsole().sendTo(console, { omitJSDOMErrors: false })
+      options.virtualConsole = new jsdom.VirtualConsole().sendTo(console)
       // throw error when window creation failed
       options.virtualConsole.on('jsdomError', jsdomErrHandler)
     }
     url = url || 'http://localhost:3000'
     const { window } = await jsdom.JSDOM.fromURL(url, options)
-    if (opts.virtualConsole !== false) {
-      // after window initialized successfully
-      options.virtualConsole.removeListener('jsdomError', jsdomErrHandler)
-    }
     // If Nuxt could not be loaded (error from the server-side)
     const nuxtExists = window.document.body.innerHTML.includes(
       this.options.render.ssr ? 'window.__NUXT__' : '<div id="__nuxt">'
@@ -447,6 +443,10 @@ module.exports = class Renderer {
     await new Promise(resolve => {
       window._onNuxtLoaded = () => resolve(window)
     })
+    if (opts.virtualConsole !== false) {
+      // after window initialized successfully
+      options.virtualConsole.removeListener('jsdomError', jsdomErrHandler)
+    }
     // Send back window object
     return window
   }


### PR DESCRIPTION
Throw error when `jsdomError` emitted, so that tests and other codes calling `renderAndGetWindow` can get error occurred instead of being hanging.