### PR TITLE
Fix HTML script tag in core/renderer to pass W3C validation 

### DIFF
--- a/lib/core/renderer.js
+++ b/lib/core/renderer.js
@@ -375,7 +375,7 @@ module.exports = class Renderer {
       )
     }
 
-    APP += `<script type="text/javascript">${serializedSession}</script>`
+    APP += `<script>${serializedSession}</script>`
     APP += context.renderScripts()
     APP += m.script.text({ body: true })
     APP += m.noscript.text({ body: true })


### PR DESCRIPTION
Hello,

I found an unnecessary script tag attribute in core/renderer.js that prevent a nuxt project to pass W3C validation.

Thank you for your really nice job, nuxt is amazing ;)