### PR TITLE
fix: babelrc cannot be set to true, fix #1776

### DIFF
--- a/lib/builder/builder.js
+++ b/lib/builder/builder.js
@@ -180,10 +180,12 @@ module.exports = class Builder {
     const options = _.defaults(
       {},
       {
-        babelrc: false,
         cacheDirectory: !!this.options.dev
       },
-      this.options.build.babel
+      this.options.build.babel,
+      {
+        babelrc: false
+      }
     )
 
     if (typeof options.presets === 'function') {


### PR DESCRIPTION
According to lodash documentation:

> _.defaults
> Source objects are applied from left to right. Once a property is set, additional values of the same property are ignored.

So `babel: false` cannot to be override in `options.build.babel`.

I checked the commit records, this seems to be inadvertently introduced in a refactoring.

After this pr is merged, user can enable `.babelrc` by setting `build.babel.babelrc` to `true` in `nuxt.config.js`.