### PR TITLE
fix: support snake case page names

### DIFF
--- a/lib/common/utils.mjs
+++ b/lib/common/utils.mjs
@@ -283,9 +283,13 @@ export const createRoutes = function createRoutes(files, srcDir, pagesDir) {
     let route = { name: '', path: '', component: r(srcDir, file) }
     let parent = routes
     keys.forEach((key, i) => {
+      // remove underscore only, if its the prefix
+      const sanatizedKey = key.indexOf('_') === 0
+        ? key.replace('_', '')
+        : key
       route.name = route.name
-        ? route.name + '-' + key.replace('_', '')
-        : key.replace('_', '')
+        ? route.name + '-' + sanatizedKey
+        : sanatizedKey
       route.name += key === '_' ? 'all' : ''
       route.chunkName = file.replace(/\.(vue|js)$/, '')
       let child = _.find(parent, { name: route.name })
@@ -297,11 +301,11 @@ export const createRoutes = function createRoutes(files, srcDir, pagesDir) {
         if (key === 'index' && i + 1 === keys.length) {
           route.path += i > 0 ? '' : '/'
         } else {
-          route.path += '/' + 
-            (key === '_' 
-              ? '*' 
-              : key.indexOf('_') === 0 
-                ? key.replace('_', ':') 
+          route.path += '/' +
+            (key === '_'
+              ? '*'
+              : key.indexOf('_') === 0
+                ? key.replace('_', ':')
                 : key)
           if (key !== '_' && key.indexOf('_') === 0) {
             route.path += '?'

--- a/lib/common/utils.mjs
+++ b/lib/common/utils.mjs
@@ -297,8 +297,13 @@ export const createRoutes = function createRoutes(files, srcDir, pagesDir) {
         if (key === 'index' && i + 1 === keys.length) {
           route.path += i > 0 ? '' : '/'
         } else {
-          route.path += '/' + (key === '_' ? '*' : key.replace('_', ':'))
-          if (key !== '_' && key.indexOf('_') !== -1) {
+          route.path += '/' + 
+            (key === '_' 
+              ? '*' 
+              : key.indexOf('_') === 0 
+                ? key.replace('_', ':') 
+                : key)
+          if (key !== '_' && key.indexOf('_') === 0) {
             route.path += '?'
           }
         }

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -198,3 +198,43 @@ describe('utils', () => {
     expect(chainedFn({}, 10)).toEqual({ foo: 11, bar: 12 })
   })
 })
+
+test('createRoutes should allow snake case routes', () => {
+  const files = [
+    'pages/_param.vue',
+    'pages/subpage/_param.vue',
+    'pages/snake_case_route.vue',
+    'pages/another_route/_id.vue'
+  ]
+  const srcDir = '/some/nuxt/app'
+  const pagesDir = 'pages'
+  const routesResult = Utils.createRoutes(files, srcDir, pagesDir)
+  const expectedResult = [
+    {
+      name: 'snake_case_route',
+      path: '/snake_case_route',
+      component: Utils.r('/some/nuxt/app/pages/snake_case_route.vue'),
+      chunkName: 'pages/snake_case_route'
+    },
+    {
+      name: 'another_route-id',
+      path: '/another_route/:id?',
+      component: Utils.r('/some/nuxt/app/pages/another_route/_id.vue'),
+      chunkName: 'pages/another_route/_id'
+    },
+    {
+      name: 'subpage-param',
+      path: '/subpage/:param?',
+      component: Utils.r('/some/nuxt/app/pages/subpage/_param.vue'),
+      chunkName: 'pages/subpage/_param'
+    },
+    {
+      name: 'param',
+      path: '/:param?',
+      component: Utils.r('/some/nuxt/app/pages/_param.vue'),
+      chunkName: 'pages/_param'
+    }
+  ]
+
+  expect(routesResult).toEqual(expectedResult)
+})


### PR DESCRIPTION
Folders or files within `pages/` should only lead to dynamic routes, if they start with an underscore.
Previously, folders like `some_folder` would lead to a route parameter `folder` being introduced.

This relates to issues #2716 #2985