### PR TITLE
fix: escape quotes in page file names

### DIFF
--- a/lib/builder/builder.js
+++ b/lib/builder/builder.js
@@ -314,7 +314,7 @@ module.exports = class Builder {
       })).forEach(f => {
         const key = f.replace(/\.(js|vue)$/, '')
         if (/\.vue$/.test(f) || !files[key]) {
-          files[key] = f
+          files[key] = f.replace(/(['|"])/g, '\\$1')
         }
       })
       templateVars.router.routes = createRoutes(


### PR DESCRIPTION
This commit seeks to fix a possible security issue described in #2991.