### PR TITLE
feat: make optimization and splitChunks configurable

### DIFF
--- a/bin/nuxt-build
+++ b/bin/nuxt-build
@@ -33,6 +33,7 @@ if (argv.help) {
       --analyze, -a        Launch webpack-bundle-analyzer to optimize your bundles.
       --spa                Launch in SPA mode
       --universal          Launch in Universal mode (default)
+      --generate           Generate static version after build
       --config-file, -c    Path to Nuxt.js config file (default: nuxt.config.js)
       --help, -h           Displays this message
   `)
@@ -65,14 +66,14 @@ const close = () => {
   process.exit(0)
 }
 
-if (options.mode !== 'spa') {
-  // -- Build for SSR app --
+if (!argv.generate) {
+  // -- Build only --
   builder
     .build()
     .then(() => close())
     .catch(Utils.fatalError)
 } else {
-  // -- Build for SPA app --
+  // -- Build and generate --
   const s = Date.now()
 
   nuxt.hook('generate:distRemoved', () => debug('Destination folder cleaned'))
@@ -91,9 +92,6 @@ if (options.mode !== 'spa') {
       console.log('\n' + errors.toString())
     }
   })
-
-  // Disable minify to get exact results of nuxt start
-  nuxt.options.generate.minify = false
 
   // Generate dist for SPA static deployment
   new Generator(nuxt, builder).generate({ build: true }).then(() => {

--- a/lib/app/App.js
+++ b/lib/app/App.js
@@ -5,7 +5,7 @@ import '<%= relativeToBuild(resolvePath(c.src || c)) %>'
 <% }) %>
 
 <%= Object.keys(layouts).map(key => {
-  if (splitPages) {
+  if (splitChunks.layouts) {
     return `const _${hash(key)} = () => import('${layouts[key]}'  /* webpackChunkName: "${wChunk('layouts/' + key)}" */).then(m => m.default || m)`
   } else {
     return `import _${hash(key)} from '${layouts[key]}'`
@@ -14,7 +14,7 @@ import '<%= relativeToBuild(resolvePath(c.src || c)) %>'
 
 const layouts = { <%= Object.keys(layouts).map(key => `"_${key}": _${hash(key)}`).join(',') %> }
 
-<% if (splitPages) { %>let resolvedLayouts = {}<% } %>
+<% if (splitChunks.layouts) { %>let resolvedLayouts = {}<% } %>
 
 export default {
   head: <%= serialize(head).replace('head(', 'function(').replace('titleTemplate(', 'function(') %>,
@@ -78,7 +78,7 @@ export default {
       }
     },
     <% } %>
-    <% if (splitPages) { %>
+    <% if (splitChunks.layouts) { %>
     setLayout (layout) {
       if (!layout || !resolvedLayouts['_' + layout]) layout = 'default'
       this.layoutName = layout

--- a/lib/app/App.js
+++ b/lib/app/App.js
@@ -112,6 +112,7 @@ export default {
       return this.layout
     },
     loadLayout(layout) {
+      if (!layout || !layouts['_' + layout]) layout = 'default'
       return Promise.resolve(layouts['_' + layout])
     }
     <% } %>

--- a/lib/app/router.js
+++ b/lib/app/router.js
@@ -8,7 +8,7 @@ import Router from 'vue-router'
     components.push({ _name: route._name, component: route.component, name: route.name, chunkName: route.chunkName })
     res += tab + '{\n'
     res += tab + '\tpath: ' + JSON.stringify(route.path)
-    res += (route.component) ? ',\n\t' + tab + 'component: ' + (splitPages ? route._name : `() => ${route._name}.default || ${route._name}`) : ''
+    res += (route.component) ? ',\n\t' + tab + 'component: ' + (splitChunks.pages ? route._name : `() => ${route._name}.default || ${route._name}`) : ''
     res += (route.redirect) ? ',\n\t' + tab + 'redirect: ' + JSON.stringify(route.redirect) : ''
     res += (route.name) ? ',\n\t' + tab + 'name: ' + JSON.stringify(route.name) : ''
     res += (route.children) ? ',\n\t' + tab + 'children: [\n' + recursiveRoutes(routes[i].children, tab + '\t\t', components) + '\n\t' + tab + ']' : ''
@@ -24,7 +24,7 @@ const _routes = recursiveRoutes(router.routes, '\t\t', _components)
   const chunkName = wChunk(route.chunkName)
   const name = route._name
 
-  if (splitPages) {
+  if (splitChunks.pages) {
     return `const ${name} = () => import('${path}' /* webpackChunkName: "${chunkName}" */).then(m => m.default || m)`
   } else {
     return `import ${name} from '${path}'`

--- a/lib/builder/builder.mjs
+++ b/lib/builder/builder.mjs
@@ -211,7 +211,7 @@ export default class Builder {
         .map(ext => ext.replace(/^\./, ''))
         .join('|'),
       messages: this.options.messages,
-      splitPages: this.options.build.splitPages,
+      splitChunks: this.options.build.splitChunks,
       uniqBy: _.uniqBy,
       isDev: this.options.dev,
       debug: this.options.debug,

--- a/lib/builder/webpack/client.config.mjs
+++ b/lib/builder/webpack/client.config.mjs
@@ -6,6 +6,7 @@ import webpack from 'webpack'
 import HTMLPlugin from 'html-webpack-plugin'
 import StylishPlugin from 'webpack-stylish'
 import BundleAnalyzer from 'webpack-bundle-analyzer'
+import HtmlWebpackInlineSourcePlugin from 'html-webpack-inline-source-plugin'
 
 import Debug from 'debug'
 import base from './base.config'
@@ -42,6 +43,7 @@ export default function webpackClientConfig() {
       filename: 'index.spa.html',
       template: this.options.appTemplatePath,
       inject: true,
+      inlineSource: /runtime.*\.js$/,
       chunksSortMode: 'dependency'
     })
   )
@@ -56,6 +58,10 @@ export default function webpackClientConfig() {
       })
     )
   }
+
+  // Enhances html-webpack-plugin functionality by adding the inlineSource option.
+  // https://github.com/DustinJackson/html-webpack-inline-source-plugin
+  config.plugins.push(new HtmlWebpackInlineSourcePlugin())
 
   // Generate vue-ssr-client-manifest
   config.plugins.push(

--- a/lib/builder/webpack/client.config.mjs
+++ b/lib/builder/webpack/client.config.mjs
@@ -61,7 +61,9 @@ export default function webpackClientConfig() {
 
   // Enhances html-webpack-plugin functionality by adding the inlineSource option.
   // https://github.com/DustinJackson/html-webpack-inline-source-plugin
-  config.plugins.push(new HtmlWebpackInlineSourcePlugin())
+  if (!this.options.dev) {
+    config.plugins.push(new HtmlWebpackInlineSourcePlugin())
+  }
 
   // Generate vue-ssr-client-manifest
   config.plugins.push(

--- a/lib/builder/webpack/client.config.mjs
+++ b/lib/builder/webpack/client.config.mjs
@@ -78,48 +78,59 @@ export default function webpackClientConfig() {
     )
   )
 
-  // Optimization
-  config.optimization.splitChunks = {
-    chunks: 'all',
-    // TODO: remove spa after https://github.com/jantimon/html-webpack-plugin/issues/878 solved
-    name: this.options.dev || this.options.mode === 'spa',
+  // -- Optimization --
+  config.optimization = this.options.build.optimization
 
-    // Explicit cache groups
-    cacheGroups: {
-      // Vue.js core modules
-      vue: {
-        test: /node_modules\/(vue|vue-loader|vue-router|vuex|vue-meta)\//,
-        chunks: 'initial',
-        name: 'vue',
-        priority: 10,
-        enforce: true
-      },
-      // Common modules which are usually included in projects
-      common: {
-        test: /node_modules\/(core-js|babel-runtime|lodash|es6-promise|moment|axios|webpack|setimediate|timers-browserify|process)\//,
-        chunks: 'initial',
-        name: 'common',
-        priority: 9
-      },
-      // Generated templates
-      main: {
-        test: /\.nuxt\//,
-        chunks: 'initial',
-        name: 'main',
-        priority: 8
-      },
-      // Other vendors inside node_modules
-      vendor: {
-        test: /node_modules\//,
-        chunks: 'initial',
-        name: 'vendor',
-        priority: 8
-      }
+  // TODO: remove spa check after https://github.com/jantimon/html-webpack-plugin/issues/878 solved
+  if (this.options.dev || this.options.mode === 'spa') {
+    config.optimization.splitChunks.name = true
+  }
+
+  // ... Explicit cache groups
+
+  // Vue.js core modules
+  if (this.options.build.splitChunks.vue) {
+    config.optimization.splitChunks.cacheGroups.vue = {
+      test: /node_modules\/(vue|vue-loader|vue-router|vuex|vue-meta)\//,
+      chunks: 'initial',
+      name: 'vue',
+      priority: 10,
+      enforce: true
+    }
+  }
+
+  // Common modules which are usually included in projects
+  if (this.options.build.splitChunks.common) {
+    config.optimization.splitChunks.cacheGroups.common = {
+      test: /node_modules\/(core-js|babel-runtime|lodash|es6-promise|moment|axios|webpack|setimediate|timers-browserify|process)\//,
+      chunks: 'initial',
+      name: 'common',
+      priority: 9
+    }
+  }
+
+  // Generated templates
+  if (this.options.build.splitChunks.main) {
+    config.optimization.splitChunks.cacheGroups.main = {
+      test: /\.nuxt\//,
+      chunks: 'initial',
+      name: 'main',
+      priority: 8
+    }
+  }
+
+  // Other vendors inside node_modules
+  if (this.options.build.splitChunks.vendor) {
+    config.optimization.splitChunks.cacheGroups.vendor = {
+      test: /node_modules\//,
+      chunks: 'initial',
+      name: 'vendor',
+      priority: 8
     }
   }
 
   // Create additional runtime chunk for cache boosting
-  config.optimization.runtimeChunk = true
+  config.optimization.runtimeChunk = this.options.build.splitChunks.runtime
 
   // --------------------------------------
   // Dev specific config

--- a/lib/common/nuxt.config.js
+++ b/lib/common/nuxt.config.js
@@ -150,7 +150,7 @@ export default {
     bundleRenderer: {
       shouldPrefetch: () => false
     },
-    resourceHints: true,
+    resourceHints: undefined,
     ssr: undefined,
     http2: {
       push: false,

--- a/lib/common/nuxt.config.js
+++ b/lib/common/nuxt.config.js
@@ -112,7 +112,7 @@ export default {
     duration: 5000,
     rtl: false
   },
-  loadingIndicator: {},
+  loadingIndicator: false,
   transition: {
     name: 'page',
     mode: 'out-in',

--- a/lib/common/nuxt.config.js
+++ b/lib/common/nuxt.config.js
@@ -18,7 +18,6 @@ export default {
   build: {
     analyze: false,
     profile: process.argv.includes('--profile'),
-    splitPages: true,
     maxChunkSize: false,
     extractCSS: false,
     cssSourceMap: undefined,
@@ -31,6 +30,20 @@ export default {
     },
     styleResources: {},
     plugins: [],
+    optimization: {
+      splitChunks: {
+        chunks: 'all',
+        name: false,
+        cacheGroups: {}
+      }
+    },
+    splitChunks: {
+      pages: true,
+      vendor: true,
+      commons: true,
+      runtime: true,
+      layouts: true
+    },
     babel: {
       babelrc: false
     },

--- a/lib/common/nuxt.config.js
+++ b/lib/common/nuxt.config.js
@@ -147,7 +147,9 @@ export default {
     fallback: false
   },
   render: {
-    bundleRenderer: {},
+    bundleRenderer: {
+      shouldPrefetch: () => false
+    },
     resourceHints: true,
     ssr: undefined,
     http2: {

--- a/lib/common/nuxt.config.js
+++ b/lib/common/nuxt.config.js
@@ -42,7 +42,7 @@ export default {
       vendor: true,
       commons: true,
       runtime: true,
-      layouts: true
+      layouts: false
     },
     babel: {
       babelrc: false

--- a/lib/common/options.mjs
+++ b/lib/common/options.mjs
@@ -141,6 +141,11 @@ Options.from = function (_options) {
     options.debug = options.dev
   }
 
+  // Resource hints
+  if (options.render.resourceHints === undefined) {
+    options.render.resourceHints = !options.dev
+  }
+
   // Normalize ignore
   options.ignore = options.ignore ? [].concat(options.ignore) : []
 

--- a/lib/common/options.mjs
+++ b/lib/common/options.mjs
@@ -103,25 +103,28 @@ Options.from = function (_options) {
     options.store = true
   }
 
-  // Normalize loadingIndicator
-  if (!isPureObject(options.loadingIndicator)) {
-    options.loadingIndicator = { name: options.loadingIndicator }
+  // SPA loadingIndicator
+  if (options.loadingIndicator) {
+    // Normalize loadingIndicator
+    if (!isPureObject(options.loadingIndicator)) {
+      options.loadingIndicator = { name: options.loadingIndicator }
+    }
+
+    // Apply defaults
+    options.loadingIndicator = Object.assign(
+      {
+        name: 'pulse',
+        color: '#dbe1ec',
+        background: 'white'
+      },
+      options.loadingIndicator
+    )
   }
 
   // Apply default hash to CSP option
   if (options.render.csp === true) {
     options.render.csp = { hashAlgorithm: 'sha256' }
   }
-
-  // Apply defaults to loadingIndicator
-  options.loadingIndicator = Object.assign(
-    {
-      name: 'pulse',
-      color: '#dbe1ec',
-      background: 'white'
-    },
-    options.loadingIndicator
-  )
 
   // cssSourceMap
   if (options.build.cssSourceMap === undefined) {

--- a/lib/core/meta.mjs
+++ b/lib/core/meta.mjs
@@ -43,12 +43,16 @@ export default class MetaRenderer {
       HEAD: '',
       BODY_SCRIPTS: ''
     }
+
     // Get vue-meta context
     const m = await this.getMeta(url)
+
     // HTML_ATTRS
     meta.HTML_ATTRS = m.htmlAttrs.text()
+
     // BODY_ATTRS
     meta.BODY_ATTRS = m.bodyAttrs.text()
+
     // HEAD tags
     meta.HEAD =
       m.meta.text() +
@@ -57,28 +61,40 @@ export default class MetaRenderer {
       m.style.text() +
       m.script.text() +
       m.noscript.text()
+
     // BODY_SCRIPTS
     meta.BODY_SCRIPTS = m.script.text({ body: true }) + m.noscript.text({ body: true })
+
     // Resources Hints
+
     meta.resourceHints = ''
-    // Resource Hints
+
     const clientManifest = this.renderer.resources.clientManifest
+
+    const shouldPreload = this.options.render.bundleRenderer.shouldPreload || (() => true)
+    const shouldPrefetch = this.options.render.bundleRenderer.shouldPrefetch || (() => true)
+
     if (this.options.render.resourceHints && clientManifest) {
       const publicPath = clientManifest.publicPath || '/_nuxt/'
-      // Pre-Load initial resources
+
+      // Preload initial resources
       if (Array.isArray(clientManifest.initial)) {
         meta.resourceHints += clientManifest.initial
+          .filter(file => shouldPreload(file))
           .map(
             r => `<link rel="preload" href="${publicPath}${r}" as="script" />`
           )
           .join('')
       }
+
       // Pre-Fetch async resources
       if (Array.isArray(clientManifest.async)) {
         meta.resourceHints += clientManifest.async
+          .filter(file => shouldPrefetch(file))
           .map(r => `<link rel="prefetch" href="${publicPath}${r}" />`)
           .join('')
       }
+
       // Add them to HEAD
       if (meta.resourceHints) {
         meta.HEAD += meta.resourceHints
@@ -87,12 +103,14 @@ export default class MetaRenderer {
 
     // Emulate getPreloadFiles from vue-server-renderer (works for JS chunks only)
     meta.getPreloadFiles = () =>
-      clientManifest.initial.map(r => ({
-        file: r,
-        fileWithoutQuery: r,
-        asType: 'script',
-        extension: 'js'
-      }))
+      clientManifest.initial
+        .filter(file => shouldPreload(file))
+        .map(r => ({
+          file: r,
+          fileWithoutQuery: r,
+          asType: 'script',
+          extension: 'js'
+        }))
 
     // Set meta tags inside cache
     this.cache.set(url, meta)

--- a/lib/core/meta.mjs
+++ b/lib/core/meta.mjs
@@ -74,20 +74,22 @@ export default class MetaRenderer {
     const shouldPreload = this.options.render.bundleRenderer.shouldPreload || (() => true)
     const shouldPrefetch = this.options.render.bundleRenderer.shouldPrefetch || (() => true)
 
+    const runtimeRegex = /runtime.*\.js$/
+
     if (this.options.render.resourceHints && clientManifest) {
       const publicPath = clientManifest.publicPath || '/_nuxt/'
 
       // Preload initial resources
       if (Array.isArray(clientManifest.initial)) {
         meta.resourceHints += clientManifest.initial
-          .filter(file => shouldPreload(file))
+          .filter(file => shouldPreload(file) && !(runtimeRegex.test(file)))
           .map(
             r => `<link rel="preload" href="${publicPath}${r}" as="script" />`
           )
           .join('')
       }
 
-      // Pre-Fetch async resources
+      // Prefetch async resources
       if (Array.isArray(clientManifest.async)) {
         meta.resourceHints += clientManifest.async
           .filter(file => shouldPrefetch(file))
@@ -104,7 +106,7 @@ export default class MetaRenderer {
     // Emulate getPreloadFiles from vue-server-renderer (works for JS chunks only)
     meta.getPreloadFiles = () =>
       clientManifest.initial
-        .filter(file => shouldPreload(file))
+        .filter(file => shouldPreload(file) && !(runtimeRegex.test(file)))
         .map(r => ({
           file: r,
           fileWithoutQuery: r,

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "glob": "^7.1.2",
     "hash-sum": "^1.0.2",
     "html-minifier": "^3.5.11",
+    "html-webpack-inline-source-plugin": "^0.0.10",
     "html-webpack-plugin": "^3.0.6",
     "launch-editor-middleware": "^2.2.1",
     "lodash": "^4.17.5",

--- a/test/utils/browser.js
+++ b/test/utils/browser.js
@@ -6,7 +6,8 @@ export default class Browser {
     this.browser = await puppeteer.launch(
       Object.assign(
         {
-          args: ['--no-sandbox', '--disable-setuid-sandbox']
+          args: ['--no-sandbox', '--disable-setuid-sandbox'],
+          executablePath: process.env.PUPPETEER_EXECUTABLE_PATH
         },
         options
       )

--- a/yarn.lock
+++ b/yarn.lock
@@ -2445,6 +2445,12 @@ eslint-plugin-standard@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-standard/-/eslint-plugin-standard-3.0.1.tgz#34d0c915b45edc6f010393c7eef3823b08565cf2"
 
+eslint-plugin-vue@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-vue/-/eslint-plugin-vue-4.3.0.tgz#478c6267269dbaa20f6e8b2cfae7a0ccc98c1d72"
+  dependencies:
+    vue-eslint-parser "^2.0.3"
+
 eslint-scope@^3.7.1, eslint-scope@~3.7.1:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
@@ -3338,6 +3344,14 @@ html-minifier@^3.5.11:
 html-tags@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-2.0.0.tgz#10b30a386085f43cede353cc8fa7cb0deeea668b"
+
+html-webpack-inline-source-plugin@^0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/html-webpack-inline-source-plugin/-/html-webpack-inline-source-plugin-0.0.10.tgz#89bd5f761e4f16902aa76a44476eb52831c9f7f0"
+  dependencies:
+    escape-string-regexp "^1.0.5"
+    slash "^1.0.0"
+    source-map-url "^0.4.0"
 
 html-webpack-plugin@^3.0.6:
   version "3.0.6"
@@ -7394,6 +7408,17 @@ vm-browserify@0.0.4:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-0.0.4.tgz#5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73"
   dependencies:
     indexof "0.0.1"
+
+vue-eslint-parser@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/vue-eslint-parser/-/vue-eslint-parser-2.0.3.tgz#c268c96c6d94cfe3d938a5f7593959b0ca3360d1"
+  dependencies:
+    debug "^3.1.0"
+    eslint-scope "^3.7.1"
+    eslint-visitor-keys "^1.0.0"
+    espree "^3.5.2"
+    esquery "^1.0.0"
+    lodash "^4.17.4"
 
 vue-hot-reload-api@^2.2.0:
   version "2.3.0"


### PR DESCRIPTION
As a continuation to previous works on `splitPages`, this PR makes both `optimization` (webpack 4 option) and `splitChunks` fully customizable.

We can disable all splitting features using this option in `nuxt.config.js`:

```js
build: {
    optimization: {
      splitChunks: {
        chunks: 'async',
      }
    },
    splitChunks: {
      pages: false,
      vendor: false,
      commons: false,
      runtime: false,
      layouts: false
    },
}
```

### Other improvements with this PR

- Splitting for layout chunks disabled by default for performance
- `shouldPrefetch` is falsy by default to improve TTL
- `resourcHints` are disabled for dev mode

### SPA Improvements

- Support `render.shouldPrefetch` and `render.shouldPreload`
- Disabled `loadingIndicator` to improve TTL
- Runtime chunk is inlined only for production