### PR TITLE
feat: passing props to route components on extendRoutes

### DIFF
--- a/lib/app/router.js
+++ b/lib/app/router.js
@@ -9,6 +9,7 @@ import Router from 'vue-router'
     res += tab + '{\n'
     res += tab + '\tpath: ' + JSON.stringify(route.path)
     res += (route.component) ? ',\n\t' + tab + 'component: ' + (splitChunks.pages ? route._name : `() => ${route._name}.default || ${route._name}`) : ''
+    res += (route.props) ? ',\n\t' + tab + 'props: ' + JSON.stringify(route.props) : ''
     res += (route.redirect) ? ',\n\t' + tab + 'redirect: ' + JSON.stringify(route.redirect) : ''
     res += (route.name) ? ',\n\t' + tab + 'name: ' + JSON.stringify(route.name) : ''
     res += (route.children) ? ',\n\t' + tab + 'children: [\n' + recursiveRoutes(routes[i].children, tab + '\t\t', components) + '\n\t' + tab + ']' : ''

--- a/test/fixtures/with-config/components/test.vue
+++ b/test/fixtures/with-config/components/test.vue
@@ -1,0 +1,9 @@
+<template>
+  <h1>Hello {{ name }}!</h1>
+</template>
+
+<script>
+  export default {
+    props: ['name']
+  }
+</script>

--- a/test/fixtures/with-config/nuxt.config.js
+++ b/test/fixtures/with-config/nuxt.config.js
@@ -16,6 +16,14 @@ export default {
         {
           path: '/redirect/about-bis',
           redirect: '/about-bis'
+        },
+        {
+          name: 'hello-world',
+          path: '/hello-world',
+          component: '~/components/test.vue',
+          props: {
+            name: 'world'
+          }
         }
       ]
     }

--- a/test/unit/with-config.test.js
+++ b/test/unit/with-config.test.js
@@ -170,6 +170,17 @@ describe('with-config', () => {
     expect(html.includes('<h1>About page</h1>')).toBe(true)
   })
 
+  test('/test/hello-world (added with extendRoutes)', async () => {
+    // const logSpy = await interceptLog()
+    const window = await nuxt.renderAndGetWindow(url('/test/hello-world'))
+    // expect(logSpy.calledOnce).toBe(true)
+    // expect(logSpy.args[0][0]).toBe('Test plugin!')
+    // release()
+
+    const html = window.document.body.innerHTML
+    expect(html.includes('<h1>Hello world!</h1>')).toBe(true)
+  })
+
   test('Check /test/test.txt with custom serve-static options', async () => {
     const { headers } = await rp(url('/test/test.txt'), {
       resolveWithFullResponse: true


### PR DESCRIPTION
Missing part on vue-router support with `extendRoutes`: https://router.vuejs.org/en/essentials/passing-props.html

According the following mention from the doc: https://nuxtjs.org/api/configuration-router/#extendroutes

> The schema of the route should respect the vue-router schema.

Related to https://github.com/nuxt/nuxt.js/issues/1591