### PR TITLE
Fix the 'publicPath' parameter's mistaken reversed ternary operator result

### DIFF
--- a/lib/builder/webpack/base.js
+++ b/lib/builder/webpack/base.js
@@ -79,8 +79,8 @@ export default class WebpackBaseConfig {
       filename: this.getFileName('app'),
       chunkFilename: this.getFileName('chunk'),
       publicPath: isUrl(this.options.build.publicPath)
-        ? this.options.build.publicPath
-        : urlJoin(this.options.router.base, this.options.build.publicPath)
+        ? urlJoin(this.options.router.base, this.options.build.publicPath)
+        : this.options.build.publicPath
     }
   }
 


### PR DESCRIPTION
The 'publicPath' parameter's mistaken reversed ternary operator result, causing failure of my attempt to generate a site with relative assets path like './' using the 'generate' directive.
Now we can successfully build a real static site with relative path like './' for assets, which can be open from local system directly with browsers. All you have to do is to add settings below to your nuxt.config.js.
```
  router: {
    mode: 'hash', // I'm not sure if this one is absolutely needed. XD
  },
  build: {
    publicPath: './',
  }
```