### PR TITLE
refactor(examples/with-ava): replace 'nuxt.renderAndGetWindow' -> 'JS…

### DIFF
--- a/examples/with-ava/test/index.test.js
+++ b/examples/with-ava/test/index.test.js
@@ -1,17 +1,21 @@
-import { resolve } from 'path'
-
 import test from 'ava'
+import { resolve } from 'path'
 import { Nuxt, Builder } from 'nuxt'
+import { JSDOM } from 'jsdom'
 
 // We keep the nuxt and server instance
 // So we can close them at the end of the test
 let nuxt = null
 
 // Init Nuxt.js and create a server listening on localhost:4000
-beforeAll(async () => {
+test.before(async () => {
   const rootDir = resolve(__dirname, '..')
   let config = {}
-  try { config = require(resolve(rootDir, 'nuxt.config.js')) } catch (e) {}
+  try {
+    config = require(resolve(rootDir, 'nuxt.config.js'))
+  } catch (e) {
+    console.log(e)
+  }
   config.rootDir = rootDir // project folder
   config.dev = false // production build
   nuxt = new Nuxt(config)
@@ -21,14 +25,16 @@ beforeAll(async () => {
 
 // Example of testing only generated html
 test('Route / exits and render HTML', async t => {
-  let context = {}
+  const context = {}
   const { html } = await nuxt.renderRoute('/', context)
   t.true(html.includes('<h1 class="red">Hello world!</h1>'))
 })
 
 // Example of testing via dom checking
 test('Route / exits and render HTML with CSS applied', async t => {
-  const window = await nuxt.renderAndGetWindow('http://localhost:4000/')
+  const context = {}
+  const { html } = await nuxt.renderRoute('/', context)
+  const { window } = new JSDOM(html).window
   const element = window.document.querySelector('.red')
   t.not(element, null)
   t.is(element.textContent, 'Hello world!')

--- a/examples/with-ava/test/index.test.js
+++ b/examples/with-ava/test/index.test.js
@@ -1,7 +1,7 @@
-import test from 'ava'
 import { resolve } from 'path'
 import { Nuxt, Builder } from 'nuxt'
 import { JSDOM } from 'jsdom'
+import test from 'ava'
 
 // We keep the nuxt and server instance
 // So we can close them at the end of the test
@@ -14,7 +14,6 @@ test.before(async () => {
   try {
     config = require(resolve(rootDir, 'nuxt.config.js'))
   } catch (e) {
-    console.log(e)
   }
   config.rootDir = rootDir // project folder
   config.dev = false // production build


### PR DESCRIPTION
…DOM'

detail:

'beforeAll' no longer support
change to 'test.before'

renderAndGetWindow
const window = await nuxt.renderAndGetWindow('http://localhost:4000/')
does not return 'window'.

if url change to real server return window
but test server just return html.

so change to JSDOM way.