### PR TITLE
export server resourceMap

### DIFF
--- a/lib/core/renderer.js
+++ b/lib/core/renderer.js
@@ -449,7 +449,7 @@ const parseTemplate = templateStr =>
     interpolate: /{{([\s\S]+?)}}/g
   })
 
-const resourceMap = [
+export const resourceMap = [
   {
     key: 'clientManifest',
     fileName: 'vue-ssr-client-manifest.json',


### PR DESCRIPTION
This is a very helpful list of ssr files that _should not_ be available to the client. It's useful to other nuxt users and should be public.

## Use case:

I have a gulp task that builds all the nuxt files and then uploads the dist folder to S3. Right now I have a hard coded list of these files that should be excluded.

```js
/**
 * gulp/nuxt.js
 * Builds all the nuxt v3 assets
 */

import gulp from 'gulp'
import { Nuxt, Builder } from 'nuxt'
import path from 'path'

const nuxtConfig = require('../nuxt.config.js')

gulp.task('nuxt:build', async () => {
  const base = path.resolve(__dirname, '../.nuxt/dist')
  const src = [
    path.resolve(__dirname, '../.nuxt/dist/**/*'),
    // Prevent SSR files from being served for added security
    '!**/vue-ssr-client-manifest.json',
    '!**/server-bundle.json',
    '!**/index.ssr.html',
    '!**/index.spa.html',
  ]
  const dest = path.resolve(__dirname, '../public/assets/v3')

  const nuxt = new Nuxt(Object.assign({}, nuxtConfig, {
    dev: false, // Never watch files
  }))
  const builder = new Builder(nuxt)

  // Actually build the files with nuxt
  await builder.build()

  // And then copy them over to the public assets folder
  return gulp.src(src, { base })
    .pipe(gulp.dest(dest))
})
```

