### PR TITLE
fix(options): vendor backward compability with nuxt 1.x

### DIFF
--- a/lib/common/options.js
+++ b/lib/common/options.js
@@ -182,6 +182,11 @@ Options.from = function (_options) {
     options.build.stats = false
   }
 
+  // Vendor backward compability with nuxt 1.x
+  if (!options.build.vendor) {
+    options.build.vendor = []
+  }
+
   // TODO: remove when mini-css-extract-plugin supports HMR
   if (options.dev) {
     options.build.extractCSS = false


### PR DESCRIPTION
Re-add `build.vendor` in options to backward compatibility with nuxt 1.x