### PR TITLE
test: add forceExit argv

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,10 +58,10 @@
     "prebuild": "yarn clean",
     "security": "nsp check || true",
     "test": "yarn test:fixtures && yarn test:unit",
-    "test:fixtures": "jest --maxWorkers=4 --coverage -e test/fixtures",
-    "test:e2e": "jest --maxWorkers=1 test/e2e",
+    "test:fixtures": "jest --maxWorkers=4 --coverage -e test/fixtures --forceExit",
+    "test:e2e": "jest --maxWorkers=1 test/e2e --forceExit",
     "test:lint": "yarn lint && yarn security",
-    "test:unit": "jest --maxWorkers=4 --coverage -e test/unit"
+    "test:unit": "jest --maxWorkers=4 --coverage -e test/unit --forceExit"
   },
   "engines": {
     "node": ">=8.0.0",


### PR DESCRIPTION
- OS: MAC os 10.12
- node version: 8.11
- sub system: test

When I run `yarn test`, sometimes will appear the following questions:
![image](https://user-images.githubusercontent.com/5475069/38975572-effaed32-43e0-11e8-8627-765f5c297915.png)
The nuxt server do not quit for a long time. Normally, this test case only need 30 seconds or so.  

I'm not sure if this is a bug, but I think it will be better to add `--forceExit` in jest.