### PR TITLE
feat: make babel-loader exclude configurable

### DIFF
--- a/lib/builder/webpack/base.js
+++ b/lib/builder/webpack/base.js
@@ -40,6 +40,7 @@ export default class WebpackBaseConfig {
       ]
     }
 
+    delete options.exclude
     return options
   }
 
@@ -139,10 +140,7 @@ export default class WebpackBaseConfig {
       },
       {
         test: /\.jsx?$/,
-        exclude: file => (
-          /node_modules/.test(file) &&
-          !/\.vue\.js/.test(file)
-        ),
+        exclude: this.options.build.babel.exclude,
         use: perfLoader.pool('js', {
           loader: 'babel-loader',
           options: this.getBabelOptions()

--- a/lib/builder/webpack/base.js
+++ b/lib/builder/webpack/base.js
@@ -40,7 +40,6 @@ export default class WebpackBaseConfig {
       ]
     }
 
-    delete options.exclude
     return options
   }
 
@@ -140,7 +139,25 @@ export default class WebpackBaseConfig {
       },
       {
         test: /\.jsx?$/,
-        exclude: this.options.build.babel.exclude,
+        exclude: file => {
+          // not exclude files outside node_modules
+          if (/node_modules/.test(file)) {
+            let transpile = this.options.build.transpile || []
+            // transpile supports string like 'vue-lib'
+            if (!Array.isArray(transpile)) {
+              transpile = [transpile]
+            }
+            // include SFCs in node_modules
+            transpile.push(/\.vue\.js/)
+            for (let pkg of transpile) {
+              // item in transpile can be string or regex object
+              if (new RegExp(pkg).test(file)) {
+                return false
+              }
+            }
+            return true
+          }
+        },
         use: perfLoader.pool('js', {
           loader: 'babel-loader',
           options: this.getBabelOptions()

--- a/lib/builder/webpack/base.js
+++ b/lib/builder/webpack/base.js
@@ -142,14 +142,7 @@ export default class WebpackBaseConfig {
         exclude: file => {
           // not exclude files outside node_modules
           if (/node_modules/.test(file)) {
-            let transpile = this.options.build.transpile || []
-            // transpile supports string like 'vue-lib'
-            if (!Array.isArray(transpile)) {
-              transpile = [transpile]
-            }
-            // include SFCs in node_modules
-            transpile.push(/\.vue\.js/)
-            for (let pkg of transpile) {
+            for (let pkg of this.options.build.transpile) {
               // item in transpile can be string or regex object
               if (new RegExp(pkg).test(file)) {
                 return false

--- a/lib/common/nuxt.config.js
+++ b/lib/common/nuxt.config.js
@@ -61,7 +61,11 @@ export default {
     },
     babel: {
       babelrc: false,
-      cacheDirectory: undefined
+      cacheDirectory: undefined,
+      exclude: file => (
+        /node_modules/.test(file) &&
+        !/\.vue\.js/.test(file)
+      )
     },
     vueLoader: {},
     postcss: {},

--- a/lib/common/nuxt.config.js
+++ b/lib/common/nuxt.config.js
@@ -61,12 +61,9 @@ export default {
     },
     babel: {
       babelrc: false,
-      cacheDirectory: undefined,
-      exclude: file => (
-        /node_modules/.test(file) &&
-        !/\.vue\.js/.test(file)
-      )
+      cacheDirectory: undefined
     },
+    transpile: [], // Name of NPM packages to be transpiled
     vueLoader: {},
     postcss: {},
     templates: [],

--- a/lib/common/options.js
+++ b/lib/common/options.js
@@ -187,5 +187,9 @@ Options.from = function (_options) {
   if (options.dev) {
     options.build.extractCSS = false
   }
+
+  // include SFCs in node_modules
+  options.build.transpile = [/\.vue\.js/].concat(options.build.transpile || [])
+
   return options
 }

--- a/test/fixtures/with-config/nuxt.config.js
+++ b/test/fixtures/with-config/nuxt.config.js
@@ -62,6 +62,7 @@ export default {
         return null // Coverage: Return null, so defaults will be used.
       }
     },
+    transpile: 'vue-test',
     extend(config, options) {
       return Object.assign({}, config, {
         devtool: 'nosources-source-map'

--- a/test/unit/basic.dev.test.js
+++ b/test/unit/basic.dev.test.js
@@ -4,6 +4,7 @@ let port
 const url = route => 'http://localhost:' + port + route
 
 let nuxt = null
+let transpile = null
 
 describe('basic dev', () => {
   beforeAll(async () => {
@@ -12,23 +13,31 @@ describe('basic dev', () => {
       debug: true,
       buildDir: '.nuxt-dev',
       build: {
-        stats: 'none'
+        stats: 'none',
+        transpile: [
+          '\\vue.test\\.js',
+          /vue-test/
+        ],
+        extend({ module: { rules } }, { isClient }) {
+          if (isClient) {
+            const babelLoader = rules.find(loader => loader.test.test('.jsx'))
+            transpile = babelLoader.exclude
+          }
+        }
       }
     })
     nuxt = new Nuxt(config)
-    new Builder(nuxt).build()
+    await new Builder(nuxt).build()
     port = await getPort()
     await nuxt.listen(port, 'localhost')
   })
 
-  // TODO: enable test when style-loader.js:60 was resolved
-  // test.serial('/extractCSS', async t => {
-  //   const window = await nuxt.renderAndGetWindow(url('/extractCSS'))
-  //   const html = window.document.head.innerHTML
-  //   t.true(html.includes('vendor.css'))
-  //   t.true(!html.includes('30px'))
-  //   t.is(window.getComputedStyle(window.document.body).getPropertyValue('font-size'), '30px')
-  // })
+  test('Config: build.transpile', async () => {
+    expect(transpile('vue-test')).toBeUndefined()
+    expect(transpile('node_modules/test.js')).toBe(true)
+    expect(transpile('node_modules/vue-test')).toBe(false)
+    expect(transpile('node_modules/test.vue.js')).toBe(false)
+  })
 
   test('/stateless', async () => {
     const window = await nuxt.renderAndGetWindow(url('/stateless'))

--- a/test/unit/basic.dev.test.js
+++ b/test/unit/basic.dev.test.js
@@ -15,7 +15,7 @@ describe('basic dev', () => {
       build: {
         stats: 'none',
         transpile: [
-          '\\vue.test\\.js',
+          'vue\\.test\\.js',
           /vue-test/
         ],
         extend({ module: { rules } }, { isClient }) {
@@ -36,6 +36,7 @@ describe('basic dev', () => {
     expect(transpile('vue-test')).toBeUndefined()
     expect(transpile('node_modules/test.js')).toBe(true)
     expect(transpile('node_modules/vue-test')).toBe(false)
+    expect(transpile('node_modules/vue.test.js')).toBe(false)
     expect(transpile('node_modules/test.vue.js')).toBe(false)
   })
 


### PR DESCRIPTION
Just simply expose the rule `exclude` to users, so this config supports multiple ways (string, RegExp, function, array, object)  https://webpack.js.org/configuration/module/#condition 
