### PR TITLE
fix(lib): ensure webpack inline loaders stay prefixed

### DIFF
--- a/lib/common/utils.js
+++ b/lib/common/utils.js
@@ -153,6 +153,13 @@ export const relativeTo = function relativeTo() {
   let args = Array.prototype.slice.apply(arguments)
   let dir = args.shift()
 
+  // Keep webpack inline loader intact
+  if (args[0].indexOf('!') !== -1) {
+    const loaders = args.shift().split('!')
+
+    return loaders.concat(relativeTo(dir, loaders.pop(), ...args)).join('!')
+  }
+
   // Resolve path
   let _path = r(...args)
 

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -1,3 +1,4 @@
+import path from 'path'
 import { Utils } from '../utils'
 
 describe('utils', () => {
@@ -218,13 +219,16 @@ describe('utils', () => {
   })
 
   describe('relativeTo', () => {
+    const path1 = path.join(path.sep, 'foo', 'bar')
+    const path2 = path.join(path.sep, 'foo', 'baz')
+
     test('makes path relative to dir', () => {
-      expect(Utils.relativeTo('/foo/bar', '/foo/baz')).toBe('../baz')
+      expect(Utils.relativeTo(path1, path2)).toBe(Utils.wp(`..${path.sep}baz`))
     })
 
     test('keeps webpack inline loaders prepended', () => {
-      expect(Utils.relativeTo('/foo/bar', 'loader1!loader2!/foo/baz'))
-        .toBe('loader1!loader2!../baz')
+      expect(Utils.relativeTo(path1, `loader1!loader2!${path2}`))
+        .toBe(Utils.wp(`loader1!loader2!..${path.sep}baz`))
     })
   })
 })

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -216,6 +216,17 @@ describe('utils', () => {
     ])
     expect(routes).toMatchObject([ '/login', '/about', '', '/post' ])
   })
+
+  describe('relativeTo', () => {
+    test('makes path relative to dir', () => {
+      expect(Utils.relativeTo('/foo/bar', '/foo/baz')).toBe('../baz')
+    })
+
+    test('keeps webpack inline loaders prepended', () => {
+      expect(Utils.relativeTo('/foo/bar', 'loader1!loader2!/foo/baz'))
+        .toBe('loader1!loader2!../baz')
+    })
+  })
 })
 
 test('createRoutes should allow snake case routes', () => {


### PR DESCRIPTION
when making a component path relative

fix https://github.com/nuxt/nuxt.js/issues/3314

---

This is meant to support the discussion in https://nuxtjs.cmty.io/nuxt/nuxt.js/issues/c7042

 - ~~should we do this only if a `enableInlineLoaders` flag is true in nuxt config for backwards compatibility? (Is using `!` a common use-case nuxt supports?)~~
 - ~~The logic could also just be applied in [`router.js`](https://github.com/nuxt/nuxt.js/blob/dev/lib/app/router.js#L24) that might be less intrusive~~
 - [x] I will add tests once a solution is confirmed by a maintainer