### PR TITLE
misc: add user-defined chokidar files to watch

### DIFF
--- a/bin/nuxt-dev
+++ b/bin/nuxt-dev
@@ -59,9 +59,9 @@ defaultsDeep(nuxtConfig, { watchers: { chokidar: { ignoreInitial: true } } })
 let dev = startDev()
 let needToRestart = false
 
-// Start watching for nuxt.config.js changes
+// Start watching for nuxt.config.js (and user defined file) changes
 chokidar
-  .watch(nuxtConfigFile(argv), nuxtConfig.watchers.chokidar)
+  .watch((nuxtConfig.watch || []).concat(nuxtConfigFile(argv)), nuxtConfig.watchers.chokidar)
   .on('all', () => {
     consola.debug('[nuxt.config.js] changed')
     needToRestart = true


### PR DESCRIPTION
This allows us to (optionally) add user-defined files to watch with chokidar in nuxt.config.js.