### PR TITLE
add an option to prevent nuxt error handler execution

### DIFF
--- a/lib/app/client.js
+++ b/lib/app/client.js
@@ -37,14 +37,21 @@ Vue.config.errorHandler = function (err, vm, info) {
     message: err.message || err.toString()
   }
 
+  // Call other handler if exist
+  let handled = null
+  if (typeof defaultErrorHandler === 'function') {
+    handled = defaultErrorHandler(...arguments)
+  }
+  if(handled === true){
+    return handled
+  }
+
   // Show Nuxt Error Page
   if(vm && vm.$root && vm.$root.$nuxt && vm.$root.$nuxt.error && info !== 'render function') {
     vm.$root.$nuxt.error(nuxtError)
   }
-
-  // Call other handler if exist
   if (typeof defaultErrorHandler === 'function') {
-    return defaultErrorHandler(...arguments)
+    return handled
   }
 
   // Log to console


### PR DESCRIPTION
add an option to prevent nuxt error handler execution from custom error handler
custom error handler can return `true` to prevent default nuxt error handler 