### PR TITLE
chore: add Node.js 10, remove Node.js 9

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@
 environment:
   matrix:
     - nodejs_version: "8"
-    - nodejs_version: "9"
+    - nodejs_version: "10"
 
 cache:
   - "%LOCALAPPDATA%\\Yarn"


### PR DESCRIPTION
10 is the current stable branch and 8 the current LTS branch.