### PR TITLE
[edge] minify: true => fix gap between inline-block labels

### DIFF
--- a/lib/builder/webpack/client.js
+++ b/lib/builder/webpack/client.js
@@ -32,6 +32,7 @@ export default class WebpackClientConfig extends WebpackBaseConfig {
         new HTMLPlugin({
           filename: 'index.ssr.html',
           template: this.options.appTemplatePath,
+          minify: true,
           inject: false // Resources will be injected using bundleRenderer
         })
       )
@@ -41,6 +42,7 @@ export default class WebpackClientConfig extends WebpackBaseConfig {
       new HTMLPlugin({
         filename: 'index.spa.html',
         template: this.options.appTemplatePath,
+        minify: true,
         inject: true,
         chunksSortMode: 'dependency'
       }),


### PR DESCRIPTION
etc.
```css
.a, .b {
 display: inline-block;
}
.a {
 width: 50px;
}
.b {
 width: calc(100% - 50px);
}
```
```html
<div class="a">a</div>
<div class="b">b</div>
```

If not minify html, gaps appear between inline-block labels. v1.4.0 does not have this issue.

Anyone have a better idea for this without using flexbox layout?

https://css-tricks.com/fighting-the-space-between-inline-block-elements/#comment-166547