### PR TITLE
feat(packaging): rollup build improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,10 @@
   },
   "devDependencies": {
     "babel-eslint": "^8.2.1",
+    "babel-jest": "^23.0.1",
     "babel-plugin-external-helpers": "^6.22.0",
+    "babel-polyfill": "^6.26.0",
+    "babel-preset-env": "^1.7.0",
     "codecov": "^3.0.2",
     "cross-env": "^5.1.6",
     "eslint": "^4.19.1",

--- a/scripts/rollup/rollup.config.js
+++ b/scripts/rollup/rollup.config.js
@@ -14,6 +14,7 @@ export default ({ name, input, plugins = [], options }) => defaultsDeep({}, opti
     nodeResolve({
       modulesOnly: true,
       preferBuiltins: true,
+      only: ['./'],
       extensions: ['.mjs', '.js']
     }),
     commonjs(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1071,7 +1071,15 @@ babel-polyfill@6.23.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-preset-env@^1.6.0:
+babel-polyfill@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
+  dependencies:
+    babel-runtime "^6.26.0"
+    core-js "^2.5.0"
+    regenerator-runtime "^0.10.5"
+
+babel-preset-env@^1.6.0, babel-preset-env@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/babel-preset-env/-/babel-preset-env-1.7.0.tgz#dea79fa4ebeb883cd35dab07e260c1c9c04df77a"
   dependencies:
@@ -6361,7 +6369,7 @@ regenerate@^1.2.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
 
-regenerator-runtime@^0.10.0:
+regenerator-runtime@^0.10.0, regenerator-runtime@^0.10.5:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
 


### PR DESCRIPTION
Each commit is self explanatory. With these changes the built artefacts can be used with pnpm, which does not use a flat node_modules tree.