### PR TITLE
fix: require babel-preset-vue-app directly

### DIFF
--- a/lib/builder/webpack/base.js
+++ b/lib/builder/webpack/base.js
@@ -32,7 +32,7 @@ export default class WebpackBaseConfig {
     if (!options.babelrc && !options.presets) {
       options.presets = [
         [
-          this.builder.nuxt.resolvePath('babel-preset-vue-app'),
+          require.resolve('babel-preset-vue-app'),
           {
             targets: this.isServer ? { node: 'current' } : { ie: 9, uglify: true }
           }


### PR DESCRIPTION
This avoids requiring a dependency on the user side. Another compatibility change for pnpm.