### PR TITLE
Git ignore yarn-error.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ package-lock.json
 # Logs
 *.log
 npm-debug.log*
+yarn-error.log*
 
 # Other
 .nuxt*


### PR DESCRIPTION
Looks like this file is used here:
 
https://github.com/nuxt/nuxt.js/blob/ef7a42649dcee7e65886b2db1a329deecd93aff2/scripts/make-start#L75 

as new projects starter, so I assume it's the only place it's supposed to be added. Can't find any other anyway.