### PR TITLE
[Feature][SEO] Allow strict and case sensitive paths

### DIFF
--- a/lib/app/router.js
+++ b/lib/app/router.js
@@ -12,6 +12,7 @@ import Router from 'vue-router'
     res += (route.redirect) ? ',\n\t' + tab + 'redirect: ' + JSON.stringify(route.redirect) : ''
     res += (route.meta) ? ',\n\t' + tab + 'meta: ' + JSON.stringify(route.meta) : ''
     res += (route.name) ? ',\n\t' + tab + 'name: ' + JSON.stringify(route.name) : ''
+    res += (route.pathToRegexpOptions) ? ',\n\t' + tab + 'pathToRegexpOptions: ' + JSON.stringify(route.pathToRegexpOptions) : ''
     res += (route.children) ? ',\n\t' + tab + 'children: [\n' + recursiveRoutes(routes[i].children, tab + '\t\t', components) + '\n\t' + tab + ']' : ''
     res += '\n' + tab + '}' + (i + 1 === routes.length ? '' : ',\n')
   })

--- a/lib/builder/builder.js
+++ b/lib/builder/builder.js
@@ -268,7 +268,8 @@ export default class Builder {
       templateVars.router.routes = createRoutes(
         Object.values(files),
         this.options.srcDir,
-        this.options.dir.pages
+        this.options.dir.pages,
+        this.options.router.routesOptions
       )
     } else {
       templateVars.router.routes = this.options.build.createRoutes(

--- a/lib/common/nuxt.config.js
+++ b/lib/common/nuxt.config.js
@@ -164,7 +164,11 @@ export default {
     scrollBehavior: null,
     parseQuery: false,
     stringifyQuery: false,
-    fallback: false
+    fallback: false,
+    routesOptions: {
+      pathToRegexpOptions: undefined,
+      trailingSlash: false
+    }
   },
   render: {
     bundleRenderer: {

--- a/lib/common/utils.js
+++ b/lib/common/utils.js
@@ -245,8 +245,13 @@ function cleanChildrenRoutes(routes, isChild = false) {
   return routes
 }
 
-export const createRoutes = function createRoutes(files, srcDir, pagesDir, { pathToRegexpOptions = undefined, trailingSlash = false } = {}) {
-  let routes = []
+export const createRoutes = function (
+  files,
+  srcDir,
+  pagesDir,
+  { pathToRegexpOptions = undefined, trailingSlash = false } = {}
+) {
+  const routes = []
   files.forEach(file => {
     let keys = file
       .replace(RegExp(`^${pagesDir}`), '')

--- a/lib/common/utils.js
+++ b/lib/common/utils.js
@@ -245,7 +245,7 @@ function cleanChildrenRoutes(routes, isChild = false) {
   return routes
 }
 
-export const createRoutes = function createRoutes(files, srcDir, pagesDir) {
+export const createRoutes = function createRoutes(files, srcDir, pagesDir, { pathToRegexpOptions = undefined, trailingSlash = false } = {}) {
   let routes = []
   files.forEach(file => {
     let keys = file
@@ -287,6 +287,16 @@ export const createRoutes = function createRoutes(files, srcDir, pagesDir) {
         }
       }
     })
+
+    if (pathToRegexpOptions) {
+      route.pathToRegexpOptions = pathToRegexpOptions
+    }
+
+    // Add final trailing slash to path on index.vue files inside pages subfolders
+    if (trailingSlash && /-index$/.test(route.name)) {
+      route.path += '/'
+    }
+
     // Order Routes path
     parent.push(route)
     parent.sort((a, b) => {


### PR DESCRIPTION
Actually nuxt.js have a duplicated content issue on generated routes, you can access to same page on diferent url's variations like: '/news', '/news/', '/News', '/NeWS/', etc etc...

This is bad practice for SEO and it's penalized by search engines, with this modification nuxt.js allow set strict and case sensitive routes with some options on nuxt.config.js inside router section:

```
  router: {
    routesOptions: {
      pathToRegexpOptions: {strict: true, sensitive: true},
      trailingSlash: true
    }
  }
```

## Example scenario

Files:

```
pages/
 |-index.vue
 |-contact.vue
 |-blog/
 |   |-index.vue
 |   |-_slug.vue
 |-otherpages/
    |-index.vue
    |-one.vue
    |-two.vue
```
Generated routes urls (should match exactly, any diference on path didnt meet the route, except the fourth url that it's dinamic but still working only without final slash):

```
/
/contact
/blog/
/blog/somedinamicslug
/otherpages/
/otherpages/one
/otherpages/two
```

