### PR TITLE
fix: ensure emit triggerScroll event after scrollBehavior is called

### DIFF
--- a/lib/app/components/nuxt-child.js
+++ b/lib/app/components/nuxt-child.js
@@ -32,7 +32,10 @@ export default {
     // Add triggerScroll event on beforeEnter (fix #1376)
     let beforeEnter = listeners.beforeEnter
     listeners.beforeEnter = (el) => {
-      window.$nuxt.$emit('triggerScroll')
+      // Ensure to trigger scroll event after calling scrollBehavior
+      window.$nuxt.$nextTick(() => {
+        window.$nuxt.$emit('triggerScroll')
+      })
       if (beforeEnter) return beforeEnter.call(_parent, el)
     }
 


### PR DESCRIPTION
## Issue

I encountered a problem that scroll position is incorrect during page transition. The issue seems to be caused when we use `in-out` or default transition mode. In that case, the `scrollTrigger` event (in `beforeEnter` event of `<nuxt-child>` transition) will be emitted just after calling `scrollBehavior` hook, then Nuxt will not update scroll position.

The reproduction of this issue is put here: https://github.com/ktsn/nuxt-scroll-behavior-repro

## Nuxt version

2.0.0-25481399.feabdca

## Changes that this PR includes

In this PR, I just delayed emitting `triggerScroll` event to ensure it's emitted after `scrollBehavior`. I have no idea how I write a test case to validate such behavior. If some test case is needed, it would be appreciated if you would navigate me how I should write it 🙂 