### PR TITLE
i18n example middleware fix

### DIFF
--- a/examples/i18n/middleware/i18n.js
+++ b/examples/i18n/middleware/i18n.js
@@ -12,7 +12,7 @@ export default function ({ isHMR, app, store, route, params, error, redirect }) 
   app.i18n.locale = store.state.locale
   // If route is /<defaultLocale>/... -> redirect to /...
   if (locale === defaultLocale && route.fullPath.indexOf('/' + defaultLocale) === 0) {
-    const toReplace = '^/' + defaultLocale
+    const toReplace = '^/' + defaultLocale + (route.fullPath.indexOf('/' + defaultLocale + '/') === 0 ? '/' : '')
     const re = new RegExp(toReplace)
     return redirect(
       route.fullPath.replace(re, '/')


### PR DESCRIPTION
Today I was implementing an i18n according to this example in one of my projects. Unfortunately, current example fails if (for example) our `defaultLocale` is `en` and our url is `example.com/en/` or `example.com/en/news`: middleware redirects into `example.com//` and `example.con//news` respectively.

I've fixed the example (not sure if it is the most elegant way to do it though), so it replaces `/en/` with `/`.