### PR TITLE
try to resolve node_modules before alias logic

### DIFF
--- a/lib/core/nuxt.js
+++ b/lib/core/nuxt.js
@@ -183,6 +183,8 @@ module.exports = class Nuxt {
   resolveAlias(path) {
     const modulePath = this.resolveModule(path)
 
+    // Try to resolve it as if it were a regular node_module
+    // Package first. Fixes issue with @<org> scoped packages
     if (modulePath != null) {
       return modulePath
     }
@@ -217,6 +219,7 @@ module.exports = class Nuxt {
   resolvePath(path) {
     const modulePath = this.resolveModule(path)
 
+    // Try to resolve path as a node_module package first
     if (modulePath != null) {
       return modulePath
     }

--- a/lib/core/nuxt.js
+++ b/lib/core/nuxt.js
@@ -181,6 +181,12 @@ module.exports = class Nuxt {
   }
 
   resolveAlias(path) {
+    const modulePath = this.resolveModule(path)
+
+    if (modulePath != null) {
+      return modulePath
+    }
+
     if (path.indexOf('@@') === 0 || path.indexOf('~~') === 0) {
       return join(this.options.rootDir, path.substr(2))
     }
@@ -192,22 +198,30 @@ module.exports = class Nuxt {
     return resolve(this.options.srcDir, path)
   }
 
-  resolvePath(path) {
-    // Try to resolve using NPM resolve path first
+  resolveModule(path) {
     try {
       const resolvedPath = Module._resolveFilename(path, {
         paths: this.options.modulesDir
       })
+
       return resolvedPath
     } catch (error) {
       if (error.code === 'MODULE_NOT_FOUND') {
-        // Continue to try other methods
+        return null
       } else {
         throw error
       }
     }
+  }
 
-    let _path = this.resolveAlias(path)
+  resolvePath(path) {
+    const modulePath = this.resolveModule(path)
+
+    if (modulePath != null) {
+      return modulePath
+    }
+
+    const _path = this.resolveAlias(path)
 
     if (existsSync(_path)) {
       return _path


### PR DESCRIPTION
This updates the `resolveAlias` function to try resolving `node_modules` before it's custom logic. Fixes issues with `@<organization>/<package>` for plugins, but I suspect there are more places.