### PR TITLE
fix: allow quotes in messages

### DIFF
--- a/lib/app/client.js
+++ b/lib/app/client.js
@@ -243,7 +243,7 @@ async function render (to, from, next) {
     await callMiddleware.call(this, Components, app.context, layout)
     if (nextCalled) return
     // Show error page
-    app.context.error({ statusCode: 404, message: '<%= messages.error_404 %>' })
+    app.context.error({ statusCode: 404, message: `<%= messages.error_404 %>` })
     return next()
   }
 
@@ -285,7 +285,7 @@ async function render (to, from, next) {
     })
     // ...If .validate() returned false
     if (!isValid) {
-      this.error({ statusCode: 404, message: '<%= messages.error_404 %>' })
+      this.error({ statusCode: 404, message: `<%= messages.error_404 %>` })
       return next()
     }
 

--- a/lib/app/components/nuxt-error.vue
+++ b/lib/app/components/nuxt-error.vue
@@ -38,7 +38,7 @@ export default {
       return (this.error && this.error.statusCode) || 500
     },
     message () {
-      return this.error.message || '<%= messages.client_error %>'
+      return this.error.message || `<%= messages.client_error %>`
     }
   }
 }

--- a/lib/app/server.js
+++ b/lib/app/server.js
@@ -75,7 +75,7 @@ export default async ssrContext => {
     return _app
   }
   const render404Page = () => {
-    app.context.error({ statusCode: 404, path: ssrContext.url, message: '<%= messages.error_404 %>' })
+    app.context.error({ statusCode: 404, path: ssrContext.url, message: `<%= messages.error_404 %>` })
     return renderErrorPage()
   }
 


### PR DESCRIPTION
Fix #3523

This change also brings in some tricky behaviour, it exposed a door to access the server runtime:

```js
// nuxt.config.js
module.exports = {
  messages: {
    error_404: 'Current layout is: ${ssrContext.nuxt.layout}'
  }
}
```

@Atinux @pi0 Do you think it's a vulnerability ?