### PR TITLE
ignore *.spec.*  test files

### DIFF
--- a/lib/common/nuxt.config.js
+++ b/lib/common/nuxt.config.js
@@ -23,7 +23,8 @@ export default {
   // Ignore
   ignorePrefix: '-',
   ignore: [
-    '**/*.test.*'
+    '**/*.test.*',
+    '**/*.spec.*'
   ],
 
   extensions: [],


### PR DESCRIPTION
Add ignore for *.spec.* files in addition to *.test.*

PS the error that can happen when try to run dev without ignore and with spec js is totally  confusing and gives zero lead on what happens.
https://gist.github.com/aldarund/8542b2e477956827d9195d0f6d173a3b
Only during build there was a error printed with a proper stacktrace that was lead to my test file