### PR TITLE
resolve server listen details with server.address()

### DIFF
--- a/lib/core/nuxt.js
+++ b/lib/core/nuxt.js
@@ -134,7 +134,7 @@ export default class Nuxt {
             ? 'localhost'
             : connection.address
           const realPort = server.address().port
-          
+
           const listenURL = chalk.underline.blue(`http://${realHost}:${realPort}`)
           this.readyMessage = `Listening on ${listenURL}`
 

--- a/lib/core/nuxt.js
+++ b/lib/core/nuxt.js
@@ -129,7 +129,13 @@ export default class Nuxt {
             return reject(err)
           }
 
-          const listenURL = chalk.underline.blue(`http://${host}:${port}`)
+          const connection = server.address()
+          const realHost = (['127.0.0.1', '0.0.0.0'].includes(connection.address))
+            ? 'localhost'
+            : connection.address
+          const realPort = server.address().port
+          
+          const listenURL = chalk.underline.blue(`http://${realHost}:${realPort}`)
           this.readyMessage = `Listening on ${listenURL}`
 
           // Close server on nuxt close
@@ -149,7 +155,7 @@ export default class Nuxt {
               })
           )
 
-          this.callHook('listen', server, { port, host }).then(resolve)
+          this.callHook('listen', server, { port: realPort, host: realHost }).then(resolve)
         }
       )
 

--- a/lib/core/nuxt.js
+++ b/lib/core/nuxt.js
@@ -129,13 +129,12 @@ export default class Nuxt {
             return reject(err)
           }
 
-          const connection = server.address()
-          const realHost = (['127.0.0.1', '0.0.0.0'].includes(connection.address))
-            ? 'localhost'
-            : connection.address
-          const realPort = server.address().port
+          let { host, port } = server.address()
+          if (['127.0.0.1', '0.0.0.0'].includes(host)) {
+            host = 'localhost'
+          }
 
-          const listenURL = chalk.underline.blue(`http://${realHost}:${realPort}`)
+          const listenURL = chalk.underline.blue(`http://${host}:${port}`)
           this.readyMessage = `Listening on ${listenURL}`
 
           // Close server on nuxt close
@@ -155,7 +154,7 @@ export default class Nuxt {
               })
           )
 
-          this.callHook('listen', server, { port: realPort, host: realHost }).then(resolve)
+          this.callHook('listen', server, { port, host }).then(resolve)
         }
       )
 

--- a/lib/core/nuxt.js
+++ b/lib/core/nuxt.js
@@ -129,7 +129,7 @@ export default class Nuxt {
             return reject(err)
           }
 
-          let { host, port } = server.address()
+          ({ host, port } = server.address())
           if (['127.0.0.1', '0.0.0.0'].includes(host)) {
             host = 'localhost'
           }


### PR DESCRIPTION
This should work (made right on GitHub without testing :grin:).

### Issue:
When using port 0, linux assigns a random unused port to the server. Right now this will be outputted as `localhost:0` and you will have no clue what the actual port is. Usually this happens when doing some CI testing and you want to avoid port collisions.

### Fix:
This uses the `server.address()` method to resolve the real host and port the server is listening on.

### Node docs:
https://nodejs.org/api/net.html#net_server_address