### PR TITLE
refactor: obselete AggressiveSplittingPlugin

### DIFF
--- a/examples/vue-chartjs/nuxt.config.js
+++ b/examples/vue-chartjs/nuxt.config.js
@@ -6,9 +6,6 @@ export default {
       { name: 'viewport', content: 'width=device-width, initial-scale=1' }
     ]
   },
-  build: {
-    maxChunkSize: 300000
-  },
   env: {
     githubToken: '42cdf9fd55abf41d24f34c0f8a4d9ada5f9e9b93'
   }

--- a/lib/builder/webpack/client.js
+++ b/lib/builder/webpack/client.js
@@ -57,17 +57,6 @@ export default class WebpackClientConfig extends WebpackBaseConfig {
       plugins.push(new webpack.HotModuleReplacementPlugin())
     }
 
-    // Chunks size limit
-    // https://webpack.js.org/plugins/aggressive-splitting-plugin/
-    if (!this.options.dev && this.options.build.maxChunkSize) {
-      plugins.push(
-        new webpack.optimize.AggressiveSplittingPlugin({
-          minSize: this.options.build.maxChunkSize,
-          maxSize: this.options.build.maxChunkSize
-        })
-      )
-    }
-
     // Webpack Bundle Analyzer
     // https://github.com/webpack-contrib/webpack-bundle-analyzer
     if (!this.options.dev && this.options.build.analyze) {
@@ -105,7 +94,7 @@ export default class WebpackClientConfig extends WebpackBaseConfig {
         test: /node_modules[\\/](vue|vue-loader|vue-router|vuex|vue-meta|core-js|babel-runtime|es6-promise|axios|webpack|setimmediate|timers-browserify|process|regenerator-runtime|cookie|js-cookie|is-buffer|dotprop|nuxt\.js)[\\/]/,
         chunks: 'all',
         priority: 10,
-        name: 'commons'
+        name: true
       }
     }
 

--- a/lib/common/nuxt.config.js
+++ b/lib/common/nuxt.config.js
@@ -31,7 +31,6 @@ export default {
   build: {
     analyze: false,
     profile: process.argv.includes('--profile'),
-    maxChunkSize: false,
     extractCSS: false,
     cssSourceMap: undefined,
     ssr: undefined,

--- a/test/fixtures/with-config/nuxt.config.js
+++ b/test/fixtures/with-config/nuxt.config.js
@@ -45,7 +45,6 @@ export default {
   },
   build: {
     publicPath: '/orion/',
-    maxChunkSize: 300000,
     cssSourceMap: true,
     parallel: true,
     analyze: {


### PR DESCRIPTION
Webpack has obseleted AggressiveSplittingPlugin. https://github.com/webpack/webpack/pull/7651

Users can use `optimization.splitChunks.maxSize` instead.