### PR TITLE
refactor: load all modules with esm

### DIFF
--- a/lib/core/module.js
+++ b/lib/core/module.js
@@ -112,9 +112,7 @@ export default class ModuleContainer {
 
     // Resolve handler
     if (!handler) {
-      // If module is internal (src starts with '.' or alias '@' '~'), support esm
-      const isInnerModule = /^[.@~]/.test(src)
-      handler = this.nuxt.requireModule(src, { esm: isInnerModule })
+      handler = this.nuxt.requireModule(src)
     }
 
     // Validate handler


### PR DESCRIPTION
1. previous change cannot distinguish scoped node modules.
2. use nuxt.resolveAlias may solve it, but it's more expensive.
3. our current esm config is 100% CJS support, so no need to seprate the require and import.