### PR TITLE
fix: inject scrollBehavior in a more tolerant way

### DIFF
--- a/lib/app/router.js
+++ b/lib/app/router.js
@@ -35,7 +35,7 @@ const _routes = recursiveRoutes(router.routes, '\t\t', _components)
 Vue.use(Router)
 
 <% if (router.scrollBehavior) { %>
-const scrollBehavior = <%= serialize(router.scrollBehavior).replace('scrollBehavior(', 'function(').replace('function function', 'function') %>
+const scrollBehavior = <%= serialize(router.scrollBehavior).replace(/scrollBehavior\s*\(/, 'function(').replace('function function', 'function') %>
 <% } else { %>
 if (process.client) {
   window.history.scrollRestoration = 'manual'


### PR DESCRIPTION
Currently we cannot define `scrollBehavior` like:

```js
scrollBehavior () { // ← we can have space before the parenthesis
  // ...
}
```

Fixed this by using a `RegExp` to be more tolerant.