### PR TITLE
refactor: change function calls when arity is one

### DIFF
--- a/bin/nuxt
+++ b/bin/nuxt
@@ -4,9 +4,7 @@ const { join } = require('path')
 const consola = require('consola')
 
 // Global error handler
-process.on('unhandledRejection', _error => {
-  consola.error(_error)
-})
+process.on('unhandledRejection', consola.error)
 
 // Exit process on fatal errors
 consola.add({
@@ -21,7 +19,7 @@ consola.add({
 const defaultCommand = 'dev'
 const commands = new Set([defaultCommand, 'init', 'build', 'start', 'generate'])
 
-var cmd = process.argv[2]
+let cmd = process.argv[2]
 
 if (commands.has(cmd)) {
   process.argv.splice(2, 1)

--- a/bin/nuxt-build
+++ b/bin/nuxt-build
@@ -51,7 +51,7 @@ const nuxt = new Nuxt(options)
 const builder = new Builder(nuxt)
 
 // Setup hooks
-nuxt.hook('error', (_err) => consola.fatal(_err))
+nuxt.hook('error', consola.fatal)
 
 // Close function
 const close = () => {
@@ -68,12 +68,12 @@ if (options.mode !== 'spa' || argv.generate === false) {
   // Build only
   builder
     .build()
-    .then(() => close())
-    .catch(error => consola.fatal(error))
+    .then(close)
+    .catch(consola.fatal)
 } else {
   // Build + Generate for static deployment
   new Generator(nuxt, builder)
     .generate({ build: true })
-    .then(() => close())
-    .catch(error => consola.fatal(error))
+    .then(close)
+    .catch(consola.fatal)
 }

--- a/bin/nuxt-dev
+++ b/bin/nuxt-dev
@@ -115,7 +115,7 @@ function startDev(oldInstance) {
         }
       })
       // Start build
-      .then(() => builder.build())
+      .then(builder.build)
       // Close old nuxt after successful build
       .then(
         () =>

--- a/bin/nuxt-generate
+++ b/bin/nuxt-generate
@@ -53,4 +53,4 @@ generator
   .then(() => {
     process.exit(0)
   })
-  .catch(error => consola.fatal(error))
+  .catch(consola.fatal)

--- a/bin/nuxt-start
+++ b/bin/nuxt-start
@@ -52,7 +52,7 @@ options.dev = false
 const nuxt = new Nuxt(options)
 
 // Setup hooks
-nuxt.hook('error', (_err) => consola.fatal(_err))
+nuxt.hook('error', consola.fatal)
 
 // Check if project is built for production
 const distDir = resolve(

--- a/examples/storybook/.storybook/config.js
+++ b/examples/storybook/.storybook/config.js
@@ -15,7 +15,7 @@ Vue.component('my-button', MyButton)
 const req = require.context('../stories', true, /.story.js$/)
 
 function loadStories() {
-  req.keys().forEach((filename) => req(filename))
+  req.keys().forEach(req)
 }
 
 configure(loadStories, module)

--- a/examples/vue-chartjs/pages/contributors.vue
+++ b/examples/vue-chartjs/pages/contributors.vue
@@ -9,9 +9,9 @@ import DoughnutChart from '~/components/doughnut-chart'
 import axios from 'axios'
 
 function getRandomColor() {
-  var letters = '0123456789ABCDEF'
-  var color = '#'
-  for (var i = 0; i < 6; i++) {
+  const letters = '0123456789ABCDEF'
+  let color = '#'
+  for (let i = 0; i < 6; i++) {
     color += letters[Math.floor(Math.random() * 16)]
   }
   return color
@@ -26,8 +26,8 @@ export default {
         datasets: [
           {
             label: 'Nuxt.js Contributors',
-            backgroundColor: res.data.map(() => getRandomColor()),
-            data: res.data.map((stat) => 1)
+            backgroundColor: res.data.map(getRandomColor),
+            data: res.data.map(() => 1)
           }
         ]
       }

--- a/examples/with-feathers/test/app.test.js
+++ b/examples/with-feathers/test/app.test.js
@@ -5,7 +5,7 @@ import app from '../src/app'
 describe('Feathers application tests', function () {
   before(function (done) {
     this.server = app.listen(3030)
-    this.server.once('listening', () => done())
+    this.server.once('listening', done)
   })
 
   after(function (done) {

--- a/examples/with-sockets/io/index.js
+++ b/examples/with-sockets/io/index.js
@@ -8,7 +8,7 @@ export default function () {
   // overwrite nuxt.listen()
   this.nuxt.listen = (port, host) => new Promise((resolve) => server.listen(port || 3000, host || 'localhost', resolve))
   // close this server on 'close' event
-  this.nuxt.hook('close', () => new Promise((resolve) => server.close(resolve)))
+  this.nuxt.hook('close', () => new Promise(server.close))
 
   // Add socket.io events
   let messages = []

--- a/lib/app/utils.js
+++ b/lib/app/utils.js
@@ -155,7 +155,7 @@ export async function setContext(app, context) {
         }
       }
     }
-    if (process.server) app.context.beforeNuxtRender = (fn) => context.beforeRenderFns.push(fn)
+    if (process.server) app.context.beforeNuxtRender = fn => context.beforeRenderFns.push(fn)
     if (process.client) app.context.nuxtState = window.__NUXT__
   }
   // Dynamic keys

--- a/lib/builder/builder.js
+++ b/lib/builder/builder.js
@@ -47,7 +47,7 @@ export default class Builder {
 
     // Stop watching on nuxt.close()
     if (this.options.dev) {
-      this.nuxt.hook('close', () => this.unwatch())
+      this.nuxt.hook('close', this.unwatch)
     }
 
     // Initialize shared FS and Cache
@@ -57,7 +57,7 @@ export default class Builder {
 
     // if(!this.options.dev) {
     // TODO: enable again when unsafe concern resolved.(common/options.js:42)
-    // this.nuxt.hook('build:done', () => this.generateConfig())
+    // this.nuxt.hook('build:done', this.generateConfig)
     // }
   }
 
@@ -595,7 +595,7 @@ export default class Builder {
         r(src, `${this.options.dir.pages}/**/*.{vue,js}`)
       )
     }
-    patterns = _.map(patterns, p => upath.normalizeSafe(p))
+    patterns = _.map(patterns, upath.normalizeSafe)
 
     const options = Object.assign({}, this.options.watchers.chokidar, {
       ignoreInitial: true
@@ -614,9 +614,7 @@ export default class Builder {
       this.options.build.watch,
       ..._.values(_.omit(this.options.build.styleResources, ['options']))
     )
-    customPatterns = _.map(_.uniq(customPatterns), p =>
-      upath.normalizeSafe(p)
-    )
+    customPatterns = _.map(_.uniq(customPatterns), upath.normalizeSafe)
     this.customFilesWatcher = chokidar
       .watch(customPatterns, options)
       .on('change', refreshFiles)

--- a/lib/builder/webpack/plugins/vue/util.js
+++ b/lib/builder/webpack/plugins/vue/util.js
@@ -31,6 +31,6 @@ export const onEmit = (compiler, name, hook) => {
   }
 }
 
-export const isJS = (file) => /\.js(\?[^.]+)?$/.test(file)
+export const isJS = file => /\.js(\?[^.]+)?$/.test(file)
 
-export const isCSS = (file) => /\.css(\?[^.]+)?$/.test(file)
+export const isCSS = file => /\.css(\?[^.]+)?$/.test(file)

--- a/lib/common/options.js
+++ b/lib/common/options.js
@@ -65,7 +65,7 @@ Options.from = function (_options) {
   options.modulesDir = []
     .concat(options.modulesDir)
     .concat(path.join(options.nuxtDir, 'node_modules'))
-    .filter(dir => hasValue(dir))
+    .filter(hasValue)
     .map(dir => path.resolve(options.rootDir, dir))
 
   // Sanitize extensions

--- a/lib/common/utils.js
+++ b/lib/common/utils.js
@@ -82,7 +82,7 @@ export const sequence = function sequence(tasks, fn) {
 }
 
 export const parallel = function parallel(tasks, fn) {
-  return Promise.all(tasks.map(task => fn(task)))
+  return Promise.all(tasks.map(fn))
 }
 
 export const chainFn = function chainFn(base, fn) {


### PR DESCRIPTION
When a function only takes one parameter (f.ex. `(string) => capitalize(string)`), you can replace it with `capitalize` completely, achieving a point-free function call and a less verbose code.

Where applicable (function only takes one parameter and is no built-in function), I've changed the calls.