### PR TITLE
refactor: enable css thread pool

### DIFF
--- a/lib/builder/webpack/utils/perf-loader.js
+++ b/lib/builder/webpack/utils/perf-loader.js
@@ -53,10 +53,6 @@ export default class PerfLoader {
   }
 
   poolOneOf(poolName, oneOfRules) {
-    // disable css thread pool since vue-style-loader needs options like: target
-    if (poolName === 'css' && !this.options.build.extractCSS) {
-      return oneOfRules
-    }
     return oneOfRules.map(rule => Object.assign({}, rule, {
       use: this.pool(poolName, rule.use)
     }))

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "server-destroy": "^1.0.1",
     "std-env": "^1.3.0",
     "style-resources-loader": "^1.1.0",
-    "thread-loader": "^1.1.5",
+    "thread-loader": "^1.2.0",
     "time-fix-plugin": "^2.0.3",
     "uglifyjs-webpack-plugin": "^1.2.7",
     "upath": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7156,9 +7156,9 @@ text-table@^0.2.0, text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
 
-thread-loader@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/thread-loader/-/thread-loader-1.1.5.tgz#7f9d6701f773734fff1832586779021ab8571917"
+thread-loader@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/thread-loader/-/thread-loader-1.2.0.tgz#35dedb23cf294afbbce6c45c1339b950ed17e7a4"
   dependencies:
     async "^2.3.0"
     loader-runner "^2.3.0"


### PR DESCRIPTION
`vue-style-loader` with `thread-loader` issue has been fixed via https://github.com/webpack-contrib/thread-loader/pull/25