### PR TITLE
feat: support global command-line build and start

### DIFF
--- a/lib/core/renderer.js
+++ b/lib/core/renderer.js
@@ -154,6 +154,7 @@ export default class Renderer {
       return
     }
 
+    const hasModules = fs.existsSync(path.resolve(this.options.rootDir, 'node_modules'))
     // Create bundle renderer for SSR
     this.bundleRenderer = createBundleRenderer(
       this.resources.serverBundle,
@@ -161,7 +162,7 @@ export default class Renderer {
         {
           clientManifest: this.resources.clientManifest,
           runInNewContext: false,
-          basedir: this.options.rootDir
+          basedir: hasModules ? this.options.rootDir : __dirname
         },
         this.options.render.bundleRenderer
       )

--- a/lib/core/renderer.js
+++ b/lib/core/renderer.js
@@ -162,6 +162,7 @@ export default class Renderer {
         {
           clientManifest: this.resources.clientManifest,
           runInNewContext: false,
+          // for globally installed nuxt command, search dependencies in global dir
           basedir: hasModules ? this.options.rootDir : __dirname
         },
         this.options.render.bundleRenderer


### PR DESCRIPTION
With this pr, user can install nuxt globally, then start or build simple repos without npm /yarn install:


```bash
npm i nuxt-edge -g
nuxt dev/build/start
```