### PR TITLE
Replace background-color to background in loadingIndicator

### DIFF
--- a/lib/app/views/loading/chasing-dots.html
+++ b/lib/app/views/loading/chasing-dots.html
@@ -1,6 +1,6 @@
 <style>
 body, html, #__nuxt {
-  background-color: <%= options.background %>;
+  background: <%= options.background %>;
   width: 100%;
   height: 100%;
   display: flex;

--- a/lib/app/views/loading/circle.html
+++ b/lib/app/views/loading/circle.html
@@ -1,6 +1,6 @@
 <style>
 body, html, #__nuxt {
-  background-color: <%= options.background %>;
+  background: <%= options.background %>;
   width: 100%;
   height: 100%;
   display: flex;

--- a/lib/app/views/loading/cube-grid.html
+++ b/lib/app/views/loading/cube-grid.html
@@ -1,6 +1,6 @@
 <style>
 body, html, #__nuxt {
-  background-color: <%= options.background %>;
+  background: <%= options.background %>;
   width: 100%;
   height: 100%;
   display: flex;

--- a/lib/app/views/loading/fading-circle.html
+++ b/lib/app/views/loading/fading-circle.html
@@ -1,6 +1,6 @@
 <style>
 body, html, #__nuxt {
-  background-color: <%= options.background %>;
+  background: <%= options.background %>;
   width: 100%;
   height: 100%;
   display: flex;

--- a/lib/app/views/loading/folding-cube.html
+++ b/lib/app/views/loading/folding-cube.html
@@ -1,6 +1,6 @@
 <style>
 body, html, #__nuxt {
-  background-color: <%= options.background %>;
+  background: <%= options.background %>;
   width: 100%;
   height: 100%;
   display: flex;

--- a/lib/app/views/loading/nuxt.html
+++ b/lib/app/views/loading/nuxt.html
@@ -1,6 +1,6 @@
 <style>
 body, html, #__nuxt {
-  background-color: <%= options.background %>;
+  background: <%= options.background %>;
   width: 100%;
   height: 100%;
   display: flex;

--- a/lib/app/views/loading/pulse.html
+++ b/lib/app/views/loading/pulse.html
@@ -1,6 +1,6 @@
 <style>
 body, html, #__nuxt {
-  background-color: <%= options.background %>;
+  background: <%= options.background %>;
   width: 100%;
   height: 100%;
   display: flex;

--- a/lib/app/views/loading/rectangle-bounce.html
+++ b/lib/app/views/loading/rectangle-bounce.html
@@ -1,6 +1,6 @@
 <style>
 body, html, #__nuxt {
-  background-color: <%= options.background %>;
+  background: <%= options.background %>;
   width: 100%;
   height: 100%;
   display: flex;

--- a/lib/app/views/loading/rotating-plane.html
+++ b/lib/app/views/loading/rotating-plane.html
@@ -1,6 +1,6 @@
 <style>
 body, html, #__nuxt {
-  background-color: <%= options.background %>;
+  background: <%= options.background %>;
   width: 100%;
   height: 100%;
   display: flex;

--- a/lib/app/views/loading/three-bounce.html
+++ b/lib/app/views/loading/three-bounce.html
@@ -1,6 +1,6 @@
 <style>
 body, html, #__nuxt {
-  background-color: <%= options.background %>;
+  background: <%= options.background %>;
   width: 100%;
   height: 100%;
   display: flex;

--- a/lib/app/views/loading/wandering-cubes.html
+++ b/lib/app/views/loading/wandering-cubes.html
@@ -1,6 +1,6 @@
 <style>
 body, html, #__nuxt {
-  background-color: <%= options.background %>;
+  background: <%= options.background %>;
   width: 100%;
   height: 100%;
   display: flex;


### PR DESCRIPTION
## About

Replace `background-color` property to `background` property in loading templates.
This will allow you to use images and gradients on the background.

## Refs

resolve #3649 