### PR TITLE
lint: require await in async function

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -48,13 +48,13 @@ module.exports = {
     'no-debugger': process.env.NODE_ENV === 'production' ? 2 : 0,
 
     // Prefer const over let
-    'prefer-const': ['error', {
+    'prefer-const': [2, {
       'destructuring': 'any',
       'ignoreReadBeforeAssign': false
     }],
 
     // No async function without await
-    'require-await': 'error',
+    'require-await': 2,
 
     // Do not allow console.logs etc...
     'no-console': 2,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,7 +14,7 @@ module.exports = {
     'standard-jsx',
     'plugin:import/errors',
     'plugin:import/warnings',
-    "plugin:vue/recommended"
+    'plugin:vue/recommended'
   ],
   plugins: [
     'vue',
@@ -33,7 +33,7 @@ module.exports = {
     'import/first': 2,
 
     // Other import rules
-    "import/no-mutable-exports": 2,
+    'import/no-mutable-exports': 2,
 
     // Allow unresolved imports
     'import/no-unresolved': 0,
@@ -48,10 +48,13 @@ module.exports = {
     'no-debugger': process.env.NODE_ENV === 'production' ? 2 : 0,
 
     // Prefer const over let
-    "prefer-const": ["error", {
-      "destructuring": "any",
-      "ignoreReadBeforeAssign": false
+    'prefer-const': ['error', {
+      'destructuring': 'any',
+      'ignoreReadBeforeAssign': false
     }],
+
+    // No async function without await
+    'require-await': 'error',
 
     // Do not allow console.logs etc...
     'no-console': 2,
@@ -62,8 +65,8 @@ module.exports = {
     'vue/no-parsing-error': [2, {
       'x-invalid-end-tag': false
     }],
-    "vue/max-attributes-per-line": [2, {
-      "singleline": 5,
+    'vue/max-attributes-per-line': [2, {
+      'singleline': 5,
     }]
   },
 

--- a/lib/core/module.js
+++ b/lib/core/module.js
@@ -92,7 +92,7 @@ export default class ModuleContainer {
     return this.addModule(moduleOpts, true /* require once */)
   }
 
-  async addModule(moduleOpts, requireOnce) {
+  addModule(moduleOpts, requireOnce) {
     let src
     let options
     let handler

--- a/test/fixtures/basic/pages/callback-async-data.vue
+++ b/test/fixtures/basic/pages/callback-async-data.vue
@@ -4,7 +4,7 @@
 
 <script>
 export default {
-  async asyncData(context, callback) {
+  asyncData(context, callback) {
     setTimeout(function () {
       callback(null, { name: 'Callback Nuxt.js' })
     }, 10)

--- a/test/fixtures/children/pages/patch/_id/child/_slug.vue
+++ b/test/fixtures/children/pages/patch/_id/child/_slug.vue
@@ -14,7 +14,7 @@ const countries = [
   'Czech Republic',
   'Netherlands'
 ]
-async function search(q) {
+function search(q) {
   q = String(q || '').toLowerCase()
 
   return new Promise((resolve) => {

--- a/test/fixtures/ssr/pages/asyncData.vue
+++ b/test/fixtures/ssr/pages/asyncData.vue
@@ -6,7 +6,7 @@
 import { nextId } from '@/lib/db'
 
 export default {
-  async asyncData() {
+  asyncData() {
     return {
       id: nextId()
     }

--- a/test/fixtures/ssr/pages/fetch.vue
+++ b/test/fixtures/ssr/pages/fetch.vue
@@ -6,7 +6,7 @@
 import { nextId } from '@/lib/db'
 
 export default {
-  async fetch({store}) {
+  fetch({store}) {
     // We use store just as a shared reference
     store.__id = nextId()
   }

--- a/test/unit/basic.config.defaults.test.js
+++ b/test/unit/basic.config.defaults.test.js
@@ -8,13 +8,13 @@ describe('basic config defaults', () => {
     expect(Nuxt.version).toBe(version)
   })
 
-  test('modulesDir uses /node_modules as default if not set', async () => {
+  test('modulesDir uses /node_modules as default if not set', () => {
     const options = Options.from({})
     const currentNodeModulesDir = resolve(__dirname, '..', '..', 'node_modules')
     expect(options.modulesDir.includes(currentNodeModulesDir)).toBe(true)
   })
 
-  test('vendor has been deprecated', async () => {
+  test('vendor has been deprecated', () => {
     jest.spyOn(consola, 'warn')
 
     const options = Options.from({

--- a/test/unit/basic.dev.test.js
+++ b/test/unit/basic.dev.test.js
@@ -1,4 +1,4 @@
-import { loadFixture, getPort, Nuxt, Builder, rp } from '../utils'
+import { Builder, getPort, loadFixture, Nuxt, rp } from '../utils'
 
 let port
 const url = route => 'http://localhost:' + port + route
@@ -32,7 +32,7 @@ describe('basic dev', () => {
     await nuxt.listen(port, 'localhost')
   })
 
-  test('Config: build.transpile', async () => {
+  test('Config: build.transpile', () => {
     expect(transpile('vue-test')).toBe(true)
     expect(transpile('node_modules/test.js')).toBe(false)
     expect(transpile('node_modules/vue-test')).toBe(true)

--- a/test/unit/basic.fail.generate.test.js
+++ b/test/unit/basic.fail.generate.test.js
@@ -4,7 +4,7 @@ describe('basic fail generate', () => {
   test('Fail with routes() which throw an error', async () => {
     const options = loadFixture('basic', {
       generate: {
-        async routes() {
+        routes() {
           throw new Error('Not today!')
         }
       }

--- a/test/unit/basic.generate.test.js
+++ b/test/unit/basic.generate.test.js
@@ -4,7 +4,7 @@ import { resolve } from 'path'
 import { remove } from 'fs-extra'
 import serveStatic from 'serve-static'
 import finalhandler from 'finalhandler'
-import { loadFixture, getPort, Nuxt, Generator, Builder, rp } from '../utils'
+import { Builder, Generator, getPort, loadFixture, Nuxt, rp } from '../utils'
 
 let port
 const url = route => 'http://localhost:' + port + route
@@ -16,7 +16,7 @@ let generator = null
 
 describe('basic generate', () => {
   beforeAll(async () => {
-    const config = loadFixture('basic', {generate: {dir: '.nuxt-generate'}})
+    const config = loadFixture('basic', { generate: { dir: '.nuxt-generate' } })
     const nuxt = new Nuxt(config)
     const builder = new Builder(nuxt)
     builder.build = jest.fn()
@@ -34,16 +34,16 @@ describe('basic generate', () => {
     server.listen(port)
   })
 
-  test('Check builder', async () => {
+  test('Check builder', () => {
     expect(generator.builder.isStatic).toBe(true)
     expect(generator.builder.build).toHaveBeenCalledTimes(1)
   })
 
-  test('Check ready hook called', async () => {
+  test('Check ready hook called', () => {
     expect(generator.nuxt.__hook_called__).toBe(true)
   })
 
-  test('Format errors', async () => {
+  test('Format errors', () => {
     const error = generator._formatErrors([
       { type: 'handled', route: '/h1', error: 'page not found' },
       { type: 'unhandled', route: '/h2', error: { stack: 'unhandled error stack' } }

--- a/test/unit/basic.ssr.csp.test.js
+++ b/test/unit/basic.ssr.csp.test.js
@@ -18,7 +18,7 @@ const getHeader = debug => debug ? 'content-security-policy-report-only' : 'cont
 const cspHeader = getHeader(false)
 const reportOnlyHeader = getHeader(true)
 
-const startCspDevServer = async csp => startCspServer(csp, false)
+const startCspDevServer = csp => startCspServer(csp, false)
 
 describe('basic ssr csp', () => {
   let nuxt

--- a/test/unit/error.test.js
+++ b/test/unit/error.test.js
@@ -33,7 +33,7 @@ describe('error', () => {
     })
   })
 
-  test('Error: resolvePath()', async () => {
+  test('Error: resolvePath()', () => {
     expect(() => nuxt.resolvePath()).toThrowError()
     expect(() => nuxt.resolvePath('@/pages/about.vue')).toThrowError('Cannot resolve "@/pages/about.vue"')
   })

--- a/test/unit/fallback.generate.test.js
+++ b/test/unit/fallback.generate.test.js
@@ -57,7 +57,7 @@ describe('fallback generate', () => {
     expect(existsSync(resolve(distDir, '404.html'))).toBe(false)
   })
 
-  test('generate.fallback = true is transformed to /404.html', async () => {
+  test('generate.fallback = true is transformed to /404.html', () => {
     nuxt.options.generate.fallback = true
     const options = Options.from(nuxt.options)
     expect(options.generate.fallback).toBe('404.html')

--- a/test/unit/module.test.js
+++ b/test/unit/module.test.js
@@ -31,12 +31,12 @@ describe('module', () => {
     expect(html.includes('<h1>Module Layouts</h1>')).toBe(true)
   })
 
-  test('Hooks', async () => {
+  test('Hooks', () => {
     expect(nuxt.__module_hook).toBe(1)
     expect(nuxt.__renderer_hook).toBe(2)
   })
 
-  test('Hooks - Functional', async () => {
+  test('Hooks - Functional', () => {
     expect(nuxt.__ready_called__).toBe(true)
   })
 
@@ -59,7 +59,7 @@ describe('module', () => {
     expect(nuxt.__render_context).toBeTruthy()
   })
 
-  test('AddVendor - deprecated', async () => {
+  test('AddVendor - deprecated', () => {
     jest.spyOn(consola, 'warn')
 
     nuxt.moduleContainer.addVendor('nuxt-test')


### PR DESCRIPTION
Another PR to push up our `eslint` game. If a function is declared as `async`, it **must** have an await inside.