### PR TITLE
Define sendResponse() only once

### DIFF
--- a/lib/core/middleware/error.js
+++ b/lib/core/middleware/error.js
@@ -15,17 +15,6 @@ export default function errorMiddleware(err, req, res, next) {
     consola.error(err)
   }
 
-  const sendResponse = (content, type = 'text/html') => {
-    // Set Headers
-    res.statusCode = err.statusCode
-    res.statusMessage = err.name
-    res.setHeader('Content-Type', type + '; charset=utf-8')
-    res.setHeader('Content-Length', Buffer.byteLength(content))
-
-    // Send Response
-    res.end(content, 'utf-8')
-  }
-
   // Check if request accepts JSON
   const hasReqHeader = (header, includes) =>
     req.headers[header] && req.headers[header].toLowerCase().includes(includes)
@@ -42,7 +31,7 @@ export default function errorMiddleware(err, req, res, next) {
       name: err.name
     }
     if (isJson) {
-      sendResponse(JSON.stringify(json, undefined, 2), 'text/json')
+      sendResponse(res, JSON.stringify(json, undefined, 2), err, 'text/json')
       return
     }
     const html = this.resources.errorTemplate(json)
@@ -60,11 +49,22 @@ export default function errorMiddleware(err, req, res, next) {
   )
   if (isJson) {
     youch.toJSON().then((json) => {
-      sendResponse(JSON.stringify(json, undefined, 2), 'text/json')
+      sendResponse(res, JSON.stringify(json, undefined, 2), err, 'text/json')
     })
   } else {
     youch.toHTML().then(html => sendResponse(html))
   }
+}
+
+function sendResponse(res, content, err, type = 'text/html') {
+  // Set Headers
+  res.statusCode = err.statusCode
+  res.statusMessage = err.name
+  res.setHeader('Content-Type', type + '; charset=utf-8')
+  res.setHeader('Content-Length', Buffer.byteLength(content))
+
+  // Send Response
+  res.end(content, 'utf-8')
 }
 
 async function readSource(frame) {


### PR DESCRIPTION
I usually don't mind little helpers functions in a block, but I felt this one was large enough to be taken out. No biggie.