### PR TITLE
lint: force if braces, no lonely ifs and add store.js

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 app
+!app/store.js
 node_modules
 dist
 .nuxt

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -53,6 +53,12 @@ module.exports = {
       'ignoreReadBeforeAssign': false
     }],
 
+    // No single if in an "else" block
+    'no-lonely-if': 2,
+
+    // Force curly braces for control flow
+    curly: 2,
+
     // No async function without await
     'require-await': 2,
 

--- a/lib/app/store.js
+++ b/lib/app/store.js
@@ -23,63 +23,61 @@ if (indexFilename) {
 
 // If store is not an exported method = modules store
 if (typeof storeData !== 'function') {
-
   // Store modules
   if (!storeData.modules) {
     storeData.modules = {}
   }
 
-  for (let filename of filenames) {
+  for (const filename of filenames) {
     let name = filename.replace(/^\.\//, '').replace(/\.(<%= extensions %>)$/, '')
     if (name === 'index') continue
 
-    let namePath = name.split(/\//)
+    const namePath = name.split(/\//)
 
-    name = namePath[namePath.length-1]
+    name = namePath[namePath.length - 1]
     if (name === 'state' || name === 'getters' || name === 'actions' || name === 'mutations') {
-      let module = getModuleNamespace(storeData, namePath, true)
+      const module = getModuleNamespace(storeData, namePath, true)
       appendModule(module, filename, name)
       continue
     }
 
-    //if file is foo/index.js
-    //it should save as foo
-    let isIndex = (name === 'index')
-    if (isIndex)
+    // if file is foo/index.js
+    // it should save as foo
+    const isIndex = (name === 'index')
+    if (isIndex) {
       namePath.pop()
+    }
 
-    let module      = getModuleNamespace(storeData, namePath)
-    let fileModule  = getModule(filename)
+    const module = getModuleNamespace(storeData, namePath)
+    const fileModule = getModule(filename)
     name = namePath.pop()
     module[name] = module[name] || {}
 
-    //if file is foo.js, existing properties take priority
-    //because it's the least specific case
+    // if file is foo.js, existing properties take priority
+    // because it's the least specific case
     if (!isIndex) {
       module[name] = Object.assign({}, fileModule, module[name])
       module[name].namespaced = true
       continue
     }
 
-    //if file is foo/index.js we want to overwrite properties from foo.js
-    //but not from appended mods like foo/actions.js
-    var appendedMods = {}
+    // if file is foo/index.js we want to overwrite properties from foo.js
+    // but not from appended mods like foo/actions.js
+    const appendedMods = {}
     if (module[name].appends) {
       appendedMods.appends = module[name].appends
-      for (let append of module[name].appends)
-        appendedMods[append] = module[name][append]
+      for (const append of module[name].appends) { appendedMods[append] = module[name][append] }
     }
 
     module[name] = Object.assign({}, module[name], fileModule, appendedMods)
     module[name].namespaced = true
   }
-
 }
 
 // createStore
 export const createStore = storeData instanceof Function ? storeData : () => {
   return new Vuex.Store(Object.assign({
-    strict: (process.env.NODE_ENV !== 'production'),
+    strict: (process.env.NODE_ENV !== 'production')
   }, storeData, {
     state: storeData.state instanceof Function ? storeData.state() : {}
   }))
@@ -100,18 +98,17 @@ function getModule (filename) {
 
 function getModuleNamespace (storeData, namePath, forAppend = false) {
   if (namePath.length === 1) {
-    if (forAppend)
-      return storeData
+    if (forAppend) { return storeData }
     return storeData.modules
   }
-  let namespace = namePath.shift()
+  const namespace = namePath.shift()
   storeData.modules[namespace] = storeData.modules[namespace] || {}
   storeData.modules[namespace].namespaced = true
   storeData.modules[namespace].modules = storeData.modules[namespace].modules || {}
   return getModuleNamespace(storeData.modules[namespace], namePath, forAppend)
 }
 
-function appendModule(module, filename, name) {
+function appendModule (module, filename, name) {
   const file = files(filename)
   module.appends = module.appends || []
   module.appends.push(name)

--- a/lib/common/utils.js
+++ b/lib/common/utils.js
@@ -271,19 +271,17 @@ export const createRoutes = function createRoutes(files, srcDir, pagesDir) {
         child.children = child.children || []
         parent = child.children
         route.path = ''
+      } else if (key === 'index' && i + 1 === keys.length) {
+        route.path += i > 0 ? '' : '/'
       } else {
-        if (key === 'index' && i + 1 === keys.length) {
-          route.path += i > 0 ? '' : '/'
-        } else {
-          route.path += '/' +
+        route.path += '/' +
             (key === '_'
               ? '*'
               : key.indexOf('_') === 0
                 ? key.replace('_', ':')
                 : key)
-          if (key !== '_' && key.indexOf('_') === 0) {
-            route.path += '?'
-          }
+        if (key !== '_' && key.indexOf('_') === 0) {
+          route.path += '?'
         }
       }
     })


### PR DESCRIPTION
* Force curly braces for one-line control elements (eg. `if (true) return "A"` => `if(true) { return "A" }`

* Prohibit single `if/else` in `else` branch

f.ex.:

```js

if(true){}
else{

  if(false){}
  else{}
}
```

* unignored `lib/app/store.js`