### PR TITLE
feat: support `server` option in `nuxt.config.js` to set PORT and HOST

### DIFF
--- a/bin/common/utils.js
+++ b/bin/common/utils.js
@@ -44,6 +44,9 @@ exports.loadNuxtConfig = (argv) => {
     (argv.spa && 'spa') || (argv.universal && 'universal') || options.mode
 
   // Server options
+  if (!options.server) {
+    options.server = {}
+  }
   options.server.port = argv.port || options.server.port
   options.server.host = argv.hostname || options.server.host
 

--- a/bin/common/utils.js
+++ b/bin/common/utils.js
@@ -43,17 +43,23 @@ exports.loadNuxtConfig = (argv) => {
   options.mode =
     (argv.spa && 'spa') || (argv.universal && 'universal') || options.mode
 
-  return options
-}
+  // Server options
+  if (!options.server)
+    options.server = {}
+  
+  options.server.port =
+    argv.port || 
+    process.env.NUXT_PORT || 
+    process.env.PORT || 
+    process.env.npm_package_config_nuxt_port ||
+    options.server.port
 
-exports.getLatestHost = (argv) => {
-  const port =
-    argv.port || process.env.NUXT_PORT || process.env.PORT || process.env.npm_package_config_nuxt_port
-  const host =
+  options.server.host =
     argv.hostname ||
     process.env.NUXT_HOST ||
     process.env.HOST ||
-    process.env.npm_package_config_nuxt_host
+    process.env.npm_package_config_nuxt_host ||
+    options.server.host
 
-  return { port, host }
+  return options
 }

--- a/bin/common/utils.js
+++ b/bin/common/utils.js
@@ -44,23 +44,8 @@ exports.loadNuxtConfig = (argv) => {
     (argv.spa && 'spa') || (argv.universal && 'universal') || options.mode
 
   // Server options
-  if (!options.server) {
-    options.server = {}
-  }
-
-  options.server.port =
-    argv.port ||
-    process.env.NUXT_PORT ||
-    process.env.PORT ||
-    process.env.npm_package_config_nuxt_port ||
-    options.server.port
-
-  options.server.host =
-    argv.hostname ||
-    process.env.NUXT_HOST ||
-    process.env.HOST ||
-    process.env.npm_package_config_nuxt_host ||
-    options.server.host
+  options.server.port = argv.port || options.server.port
+  options.server.host = argv.hostname || options.server.host
 
   return options
 }

--- a/bin/common/utils.js
+++ b/bin/common/utils.js
@@ -44,13 +44,14 @@ exports.loadNuxtConfig = (argv) => {
     (argv.spa && 'spa') || (argv.universal && 'universal') || options.mode
 
   // Server options
-  if (!options.server)
+  if (!options.server) {
     options.server = {}
-  
+  }
+
   options.server.port =
-    argv.port || 
-    process.env.NUXT_PORT || 
-    process.env.PORT || 
+    argv.port ||
+    process.env.NUXT_PORT ||
+    process.env.PORT ||
     process.env.npm_package_config_nuxt_port ||
     options.server.port
 

--- a/bin/nuxt-dev
+++ b/bin/nuxt-dev
@@ -3,7 +3,7 @@ const parseArgs = require('minimist')
 const consola = require('consola')
 const { version } = require('../package.json')
 const { Nuxt, Builder } = require('..')
-const { loadNuxtConfig, getLatestHost } = require('./common/utils')
+const { loadNuxtConfig } = require('./common/utils')
 
 const argv = parseArgs(process.argv.slice(2), {
   alias: {
@@ -54,9 +54,6 @@ let hooked = false
 let dev = startDev()
 
 function startDev(oldInstance) {
-  // Get latest environment variables
-  const { port, host } = getLatestHost(argv)
-
   // Error handler
   const onError = (err, instance) => {
     consola.error(err)
@@ -70,6 +67,9 @@ function startDev(oldInstance) {
   } catch (err) {
     return onError(err, oldInstance)
   }
+
+  // Get latest environment variables
+  const { port, host } = options.server
 
   // Create nuxt and builder instance
   let nuxt

--- a/bin/nuxt-start
+++ b/bin/nuxt-start
@@ -4,7 +4,7 @@ const { resolve } = require('path')
 const parseArgs = require('minimist')
 const consola = require('consola')
 const { Nuxt } = require('../dist/nuxt-start')
-const { loadNuxtConfig, getLatestHost } = require('./common/utils')
+const { loadNuxtConfig } = require('./common/utils')
 
 const argv = parseArgs(process.argv.slice(2), {
   alias: {
@@ -76,7 +76,7 @@ if (nuxt.options.render.ssr === true) {
   }
 }
 
-const { port, host } = getLatestHost(argv)
+const { port, host } = options.server
 
 nuxt.listen(port, host).then(() => {
   nuxt.showReady(false)

--- a/examples/custom-port-host/README.md
+++ b/examples/custom-port-host/README.md
@@ -1,0 +1,3 @@
+# Custom PORT and HOST in `nuxt.config.js` with Nuxt.js
+
+https://nuxtjs.org/examples/custom-port-host

--- a/examples/custom-port-host/nuxt.config.js
+++ b/examples/custom-port-host/nuxt.config.js
@@ -1,0 +1,6 @@
+export default {
+  server: {
+    port: 8000,
+    host: '0.0.0.0'
+  }
+}

--- a/examples/custom-port-host/package.json
+++ b/examples/custom-port-host/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "example-custom-port-host",
+  "dependencies": {
+    "nuxt": "latest"
+  },
+  "scripts": {
+    "dev": "nuxt",
+    "build": "nuxt build",
+    "start": "nuxt start"
+  }
+}

--- a/examples/custom-port-host/pages/index.vue
+++ b/examples/custom-port-host/pages/index.vue
@@ -1,0 +1,3 @@
+<template>
+  <p>Set port and host in <code>nuxt.config.js</code>.</p>
+</template>

--- a/lib/common/nuxt.config.js
+++ b/lib/common/nuxt.config.js
@@ -15,6 +15,12 @@ export default {
   // Mode
   mode: 'universal',
 
+  // Server options
+  server: {
+    port: 3000,
+    host: '127.0.0.1'
+  },
+
   // Dirs
   buildDir: '.nuxt',
   nuxtDir,

--- a/lib/common/nuxt.config.js
+++ b/lib/common/nuxt.config.js
@@ -17,8 +17,12 @@ export default {
 
   // Server options
   server: {
-    port: 3000,
-    host: '127.0.0.1'
+    port: process.env.NUXT_PORT ||
+      process.env.PORT ||
+      process.env.npm_package_config_nuxt_port,
+    host: process.env.NUXT_HOST ||
+      process.env.HOST ||
+      process.env.npm_package_config_nuxt_host
   },
 
   // Dirs

--- a/test/fixtures/with-config/nuxt.config.js
+++ b/test/fixtures/with-config/nuxt.config.js
@@ -2,6 +2,10 @@ import path from 'path'
 
 export default {
   srcDir: __dirname,
+  server: {
+    port: 8000,
+    host: '0.0.0.0'
+  },
   router: {
     base: '/test/',
     middleware: 'noop',


### PR DESCRIPTION
Resolves #3698 

This PR adds a new option `server` for `nuxt.config.js` in order to specify PORT and HOST in the config file.
```js
// nuxt.config.js
export default {
  server: {
    port: 8000,
    host: '0.0.0.0'
  }
}
```

**Breaking change**: 
Merge the `getLatestHost(argv)` function into `loadNuxtConfig(argv)`.
`port` and `host` now is accessable in `options.server`.

```diff
- const { port, host } = getLatestHost(argv)
+ const { port, host } = options.server
```

Reasons:
- `getLatestHost(argv)` needs to read the config. It's not ideal to read the file again.
- `options.mode` is overrided by `argv` in the `loadNuxtConfig`, so override `options.server` in `loadNuxtConfig` is more consistency and simplier.