### PR TITLE
[1/2] Do not remove optional tags

### DIFF
--- a/lib/common/nuxt.config.js
+++ b/lib/common/nuxt.config.js
@@ -112,7 +112,7 @@ export default {
       removeAttributeQuotes: false,
       removeComments: false,
       removeEmptyAttributes: true,
-      removeOptionalTags: true,
+      removeOptionalTags: false,
       removeRedundantAttributes: true,
       removeScriptTypeAttributes: false,
       removeStyleLinkTypeAttributes: false,


### PR DESCRIPTION
Mainly, `</body>` getting removed results in messing up snippet injection.

Docs: http://perfectionkills.com/experimenting-with-html-minifier/#remove_optional_tags