### PR TITLE
Minor consistency tweaks

### DIFF
--- a/lib/app/App.js
+++ b/lib/app/App.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 <% if (loading) { %>import NuxtLoading from '<%= (typeof loading === "string" ? loading : "./components/nuxt-loading.vue") %>'<% } %>
-<% css.forEach(function (c) { %>
+<% css.forEach((c) => { %>
 import '<%= relativeToBuild(resolvePath(c.src || c)) %>'
 <% }) %>
 

--- a/lib/app/client.js
+++ b/lib/app/client.js
@@ -35,7 +35,7 @@ Object.assign(Vue.config, <%= serialize(vue.config) %>)
 <% if (debug || mode === 'spa') { %>
 // Setup global Vue error handler
 const defaultErrorHandler = Vue.config.errorHandler
-Vue.config.errorHandler = function (err, vm, info) {
+Vue.config.errorHandler = (err, vm, info) => {
   const nuxtError = {
     statusCode: err.statusCode || err.name || 'Whoops!',
     message: err.message || err.toString()
@@ -489,7 +489,7 @@ function nuxtReady (_app) {
     window._onNuxtLoaded(_app)
   }
   // Add router hooks
-  router.afterEach(function (to, from) {
+  router.afterEach((to, from) => {
     // Wait for fixPrepatch + $data updates
     Vue.nextTick(() => _app.$nuxt.$emit('routeChanged', to, from))
   })

--- a/lib/app/utils.js
+++ b/lib/app/utils.js
@@ -6,7 +6,7 @@ const noopData = () => ({})
 // Useful for jsdom testing or plugins (https://github.com/tmpvar/jsdom#dealing-with-asynchronous-script-loading)
 if (process.browser) {
   window._nuxtReadyCbs = []
-  window.onNuxtReady = function (cb) {
+  window.onNuxtReady = (cb) => {
     window._nuxtReadyCbs.push(cb)
   }
 }
@@ -58,8 +58,8 @@ export function sanitizeComponent(Component) {
 }
 
 export function getMatchedComponents(route, matches = false) {
-  return [].concat.apply([], route.matched.map(function (m, index) {
-    return Object.keys(m.components).map(function (key) {
+  return Array.prototype.concat.apply([], route.matched.map((m, index) => {
+    return Object.keys(m.components).map((key) => {
       matches && matches.push(index)
       return m.components[key]
     })
@@ -67,8 +67,8 @@ export function getMatchedComponents(route, matches = false) {
 }
 
 export function getMatchedComponentsInstances(route, matches = false) {
-  return [].concat.apply([], route.matched.map(function (m, index) {
-    return Object.keys(m.instances).map(function (key) {
+  return Array.prototype.concat.apply([], route.matched.map((m, index) => {
+    return Object.keys(m.instances).map((key) => {
       matches && matches.push(index)
       return m.instances[key]
     })
@@ -76,8 +76,8 @@ export function getMatchedComponentsInstances(route, matches = false) {
 }
 
 export function flatMapComponents(route, fn) {
-  return Array.prototype.concat.apply([], route.matched.map(function (m, index) {
-    return Object.keys(m.components).reduce(function (promises, key) {
+  return Array.prototype.concat.apply([], route.matched.map((m, index) => {
+    return Object.keys(m.components).reduce((promises, key) => {
       if (m.components[key]) {
         promises.push(fn(m.components[key], m.instances[key], m, key, index))
       } else {
@@ -130,9 +130,12 @@ export async function setContext(app, context) {
     // Only set once
     if (context.req) app.context.req = context.req
     if (context.res) app.context.res = context.res
-    app.context.redirect = function (status, path, query) {
-      if (!status) return
-      app.context._redirected = true // Used in middleware
+    app.context.redirect = (status, path, query) => {
+      if (!status) {
+        return
+      }
+      // Used in middleware
+      app.context._redirected = true
       // if only 1 or 2 arguments: redirect('/') or redirect('/', { foo: 'bar' })
       let pathType = typeof path
       if (typeof status !== 'number' && (pathType === 'undefined' || pathType === 'object')) {
@@ -176,10 +179,14 @@ export async function setContext(app, context) {
   app.context._redirected = false
   app.context._errored = false
   app.context.isHMR = !!context.isHMR
-  if (context.route) app.context.route = await getRouteData(context.route)
+  if (context.route) {
+    app.context.route = await getRouteData(context.route)
+  }
   app.context.params = app.context.route.params || {}
   app.context.query = app.context.route.query || {}
-  if (context.from) app.context.from = await getRouteData(context.from)
+  if (context.from) {
+    app.context.from = await getRouteData(context.from)
+  }
 }
 
 export function middlewareSeries(promises, appContext) {
@@ -227,7 +234,7 @@ export function getLocation(base, mode) {
 }
 
 export function urlJoin() {
-  return [].slice.call(arguments).join('/').replace(/\/+/g, '/')
+  return Array.prototype.slice.call(arguments).join('/').replace(/\/+/g, '/')
 }
 
 // Imported from path-to-regexp
@@ -352,7 +359,7 @@ function parse(str, options) {
  * @return {string}
  */
 function encodeURIComponentPretty(str) {
-  return encodeURI(str).replace(/[\/?#]/g, function (c) {
+  return encodeURI(str).replace(/[\/?#]/g, (c) => {
     return '%' + c.charCodeAt(0).toString(16).toUpperCase()
   })
 }
@@ -364,7 +371,7 @@ function encodeURIComponentPretty(str) {
  * @return {string}
  */
 function encodeAsterisk(str) {
-  return encodeURI(str).replace(/[?#]/g, function (c) {
+  return encodeURI(str).replace(/[?#]/g, (c) => {
     return '%' + c.charCodeAt(0).toString(16).toUpperCase()
   })
 }


### PR DESCRIPTION
@Atinux @clarkdo just a few places `function` seemed to be uselessly used (and in files where `() =>` was _also_ used)... changed and ran the tests, ditto! No biggie :)

Just my daily [pomodoro](https://en.wikipedia.org/wiki/Pomodoro_Technique) studying Nuxt.

Also noticed a few places where `[].concat` and `Array.prototype.concat` were used for the same purpose. Just thought it was cleaner to standardize on referencing the actual prototype method.