### PR TITLE
feat: respect beforeEnter for route if set

### DIFF
--- a/lib/app/router.js
+++ b/lib/app/router.js
@@ -12,6 +12,7 @@ import Router from 'vue-router'
     res += (route.redirect) ? ',\n\t' + tab + 'redirect: ' + JSON.stringify(route.redirect) : ''
     res += (route.meta) ? ',\n\t' + tab + 'meta: ' + JSON.stringify(route.meta) : ''
     res += (route.name) ? ',\n\t' + tab + 'name: ' + JSON.stringify(route.name) : ''
+    res += (route.beforeEnter) ? ',\n\t' + tab + 'beforeEnter: ' + serialize(route.beforeEnter) : ''
     res += (route.children) ? ',\n\t' + tab + 'children: [\n' + recursiveRoutes(routes[i].children, tab + '\t\t', components) + '\n\t' + tab + ']' : ''
     res += '\n' + tab + '}' + (i + 1 === routes.length ? '' : ',\n')
   })

--- a/test/fixtures/basic/nuxt.config.js
+++ b/test/fixtures/basic/nuxt.config.js
@@ -6,6 +6,15 @@ export default {
       maxAge: ((60 * 60 * 24 * 365) * 2)
     }
   },
+  router: {
+    extendRoutes(routes, resolve) {
+      return [{
+        path: '/before-enter',
+        name: 'before-enter',
+        beforeEnter: (to, from, next) => { next('/') }
+      }, ...routes]
+    }
+  },
   generate: {
     routes: [
       // TODO: generate with {build: false} does not scans pages!

--- a/test/unit/basic.ssr.test.js
+++ b/test/unit/basic.ssr.test.js
@@ -101,6 +101,11 @@ describe('basic ssr', () => {
     expect(html.includes('<h1>I am valid</h1>')).toBe(true)
   })
 
+  test('/before-enter', async () => {
+    const { html } = await nuxt.renderRoute('/before-enter')
+    expect(html.includes('<h1>Index page</h1>')).toBe(true)
+  })
+
   test('/redirect', async () => {
     const { html, redirected } = await nuxt.renderRoute('/redirect')
     expect(html.includes('<div id="__nuxt"></div>')).toBe(true)


### PR DESCRIPTION
The `vue-router` enables the possibility to set a per-route guard called [`beforeEnter`](https://router.vuejs.org/guide/advanced/navigation-guards.html#per-route-guard).

With this PR, the guard will be respected and added to the router.

Resolves #3722