### PR TITLE
[WIP] Hooks: render:routeContext and render:routeDone

### DIFF
--- a/lib/core/middleware/nuxt.js
+++ b/lib/core/middleware/nuxt.js
@@ -21,6 +21,7 @@ export default async function nuxtMiddleware(req, res, next) {
     } = result
 
     if (redirected) {
+      this.nuxt.callHook('render:routeDone', req.url, result, context)
       return html
     }
     if (error) {
@@ -33,6 +34,7 @@ export default async function nuxtMiddleware(req, res, next) {
       if (fresh(req.headers, { etag })) {
         res.statusCode = 304
         res.end()
+        this.nuxt.callHook('render:routeDone', req.url, result, context)
         return
       }
       res.setHeader('ETag', etag)
@@ -79,6 +81,7 @@ export default async function nuxtMiddleware(req, res, next) {
     res.setHeader('Content-Type', 'text/html; charset=utf-8')
     res.setHeader('Content-Length', Buffer.byteLength(html))
     res.end(html, 'utf8')
+    this.nuxt.callHook('render:routeDone', req.url, result, context)
     return html
   } catch (err) {
     /* istanbul ignore if */

--- a/lib/core/nuxt.js
+++ b/lib/core/nuxt.js
@@ -83,6 +83,7 @@ export default class Nuxt {
       return
     }
     if (name === 'render:context') {
+      name = 'render:routeContext'
       consola.warn('render:context hook has been deprecated, please use render:routeContext')
     }
     this._hooks[name] = this._hooks[name] || []

--- a/lib/core/nuxt.js
+++ b/lib/core/nuxt.js
@@ -82,6 +82,9 @@ export default class Nuxt {
     if (!name || typeof fn !== 'function') {
       return
     }
+    if (name === 'render:context') {
+      consola.warn('render:context hook has been deprecated, please use render:routeContext')
+    }
     this._hooks[name] = this._hooks[name] || []
     this._hooks[name].push(fn)
   }

--- a/lib/core/renderer.js
+++ b/lib/core/renderer.js
@@ -361,7 +361,6 @@ export default class Renderer {
       HEAD += context.renderResourceHints()
     }
 
-    await this.nuxt.callHook('render:context', context.nuxt) // DEPRECATED
     await this.nuxt.callHook('render:routeContext', context.nuxt)
 
     const serializedSession = `window.__NUXT__=${serialize(context.nuxt, {

--- a/lib/core/renderer.js
+++ b/lib/core/renderer.js
@@ -361,7 +361,8 @@ export default class Renderer {
       HEAD += context.renderResourceHints()
     }
 
-    await this.nuxt.callHook('render:context', context.nuxt)
+    await this.nuxt.callHook('render:context', context.nuxt) // DEPRECATED
+    await this.nuxt.callHook('render:routeContext', context.nuxt)
 
     const serializedSession = `window.__NUXT__=${serialize(context.nuxt, {
       isJSON: true

--- a/test/fixtures/basic/nuxt.config.js
+++ b/test/fixtures/basic/nuxt.config.js
@@ -1,5 +1,7 @@
 import path from 'path'
 
+let _nuxt
+
 export default {
   render: {
     dist: {
@@ -42,11 +44,17 @@ export default {
   modulesDir: path.join(__dirname, '..', '..', '..', 'node_modules'),
   hooks: {
     ready(nuxt) {
+      _nuxt = nuxt
       nuxt.__hook_ready_called__ = true
     },
     build: {
       done(builder) {
         builder.__hook_built_called__ = true
+      }
+    },
+    render: {
+      routeDone(url) {
+        _nuxt.__hook_render_routeDone__ = url
       }
     },
     bad: null,

--- a/test/unit/basic.dev.test.js
+++ b/test/unit/basic.dev.test.js
@@ -51,6 +51,10 @@ describe('basic dev', () => {
     expect(html.includes('<h1>My component!</h1>')).toBe(true)
   })
 
+  test('Check render:routeDone hook called', async () => {
+    expect(nuxt.__hook_render_routeDone__).toBe('/stateless')
+  })
+
   // test('/_nuxt/test.hot-update.json should returns empty html', async t => {
   //   try {
   //     await rp(url('/_nuxt/test.hot-update.json'))

--- a/test/unit/basic.dev.test.js
+++ b/test/unit/basic.dev.test.js
@@ -51,7 +51,7 @@ describe('basic dev', () => {
     expect(html.includes('<h1>My component!</h1>')).toBe(true)
   })
 
-  test('Check render:routeDone hook called', async () => {
+  test('Check render:routeDone hook called', () => {
     expect(nuxt.__hook_render_routeDone__).toBe('/stateless')
   })
 


### PR DESCRIPTION
Resolves #2880

Better consistency for `render:routeContext` so we know it's called every time a route is rendered.

- [x] Add test
- [x] Add doc for `render:routeContext`
- [x] Add doc for `render:routeDone`