### PR TITLE
feat: add generate:addRoutes and a max call count for hooks

### DIFF
--- a/lib/builder/generator.js
+++ b/lib/builder/generator.js
@@ -109,6 +109,8 @@ export default class Generator {
             await this.generateRoute({ route, payload, errors })
           })
       )
+      await this.nuxt.callHook('generate:addRoutes', routes)
+      routes = this.decorateWithPayloads([], routes)
     }
 
     // Improve string representation for errors

--- a/lib/core/nuxt.js
+++ b/lib/core/nuxt.js
@@ -78,12 +78,28 @@ export default class Nuxt {
     return this
   }
 
-  hook(name, fn) {
+  hook(name, fn, maxCallCount = 0) {
     if (!name || typeof fn !== 'function') {
       return
     }
     this._hooks[name] = this._hooks[name] || []
-    this._hooks[name].push(fn)
+
+    if (maxCallCount >= 1) {
+      const fnWrap = (...args) => {
+        fn(...args, ++fnWrap.callCount)
+        if (fnWrap.callCount >= maxCallCount) {
+          this._hooks[name] = this._hooks[name].filter(item => item !== fnWrap)
+        }
+      }
+      fnWrap.callCount = 0
+      this._hooks[name].push(fnWrap)
+    } else {
+      this._hooks[name].push(fn)
+    }
+  }
+
+  hookOnce(name, fn) {
+    this.hook(name, fn, 1)
   }
 
   async callHook(name, ...args) {


### PR DESCRIPTION
With these changes it should be possible to implement a scraper as requested in #2281. See the test case for an example how to use this.

As I believe a common/recognisable interface benefits the users I used Nuxt's hooks system to add the routes, but that means we need to be able to call a hook only once. Otherwise every iteration of the `generate.concurrency` loop would be adding the same routes over and over again.

De-duplication can be implement by:
- hooking into `generate:extendRoutes` to store a unique routes list
- before adding the route in your `generate:addRoutes` hook check if its already listed in your routes list

The only downside to this implementation afaik is that we call `decorateWithPayloads` on every iteration. Maybe we could add an observer on the routes array in the future and only call `decorateWithPayloads` when routes has really changed.