### PR TITLE
refactor: functional filename should be called from webpack

### DIFF
--- a/lib/builder/webpack/base.js
+++ b/lib/builder/webpack/base.js
@@ -44,23 +44,25 @@ export default class WebpackBaseConfig {
   }
 
   getFileName(name) {
-    let fileName = this.options.build.filenames[name]
+    const fileName = this.options.build.filenames[name]
 
     if (typeof fileName === 'function') {
-      fileName = fileName(name)
+      return name => this.normalizeFileName(fileName(name))
+    } else {
+      return this.normalizeFileName(fileName)
     }
+  }
 
+  normalizeFileName(fileName) {
     // Don't use hashes when watching
     // https://github.com/webpack/webpack/issues/1914#issuecomment-174171709
     if (this.options.dev) {
       fileName = fileName.replace(/\[(chunkhash|contenthash|hash)(?::(\d+))?\]\./g, '')
     }
-
     // Don't use [name] for production assets
     if (!this.options.dev && this.options.build.optimization.splitChunks.name !== true) {
       fileName = fileName.replace(/\[name\]\./g, '')
     }
-
     return fileName
   }
 

--- a/test/unit/basic.dev.test.js
+++ b/test/unit/basic.dev.test.js
@@ -6,7 +6,7 @@ const url = route => 'http://localhost:' + port + route
 let nuxt = null
 let builder = null
 let transpile = null
-let appFileName = null
+let output = null
 
 describe('basic dev', () => {
   beforeAll(async () => {
@@ -18,17 +18,18 @@ describe('basic dev', () => {
         filenames: {
           app: () => {
             return 'test-app.[contenthash].js'
-          }
+          },
+          chunk: 'test-[name].[contenthash].js'
         },
         transpile: [
           'vue\\.test\\.js',
           /vue-test/
         ],
-        extend({ module: { rules }, output: { filename } }, { isClient }) {
+        extend({ module: { rules }, output: wpOutput }, { isClient }) {
           if (isClient) {
             const babelLoader = rules.find(loader => loader.test.test('.jsx'))
             transpile = file => !babelLoader.exclude(file)
-            appFileName = filename
+            output = wpOutput
           }
         }
       }
@@ -52,8 +53,10 @@ describe('basic dev', () => {
     expect(transpile('node_modules/test.vue.js')).toBe(true)
   })
 
-  test('Config: build.filenames as function', () => {
-    expect(appFileName).toBe('test-app.js')
+  test('Config: build.filenames', () => {
+    expect(typeof output.filename).toBe('function')
+    expect(output.filename()).toBe('test-app.js')
+    expect(output.chunkFilename).toBe('test-[name].js')
   })
 
   test('/stateless', async () => {


### PR DESCRIPTION
@Atinux Improvement for #3787
