### PR TITLE
fix: fallback should always be a string

### DIFF
--- a/lib/builder/generator.js
+++ b/lib/builder/generator.js
@@ -141,8 +141,8 @@ export default class Generator {
   async afterGenerate() {
     const { fallback } = this.options.generate
 
-    // Disable SPA fallback if value isn't true or a string
-    if (fallback !== true && typeof fallback !== 'string') return
+    // Disable SPA fallback if value isn't a non-empty string
+    if (typeof fallback !== 'string' || !fallback) return
 
     const fallbackPath = path.join(this.distPath, fallback)
 

--- a/test/unit/fallback.generate.test.js
+++ b/test/unit/fallback.generate.test.js
@@ -57,6 +57,23 @@ describe('fallback generate', () => {
     expect(existsSync(resolve(distDir, '404.html'))).toBe(false)
   })
 
+  test('nuxt re-generating with generate.fallback = \'\'', async () => {
+    nuxt.options.generate.fallback = ''
+    await expect(generator.generate({ build: false })).resolves.toBeTruthy()
+  })
+
+  test('empty string creates no fallback', async () => {
+    await expect(rp(url('/200.html'))).rejects.toMatchObject({
+      statusCode: 404,
+      response: {
+        body: expect.stringContaining('Cannot GET /200.html')
+      }
+    })
+
+    expect(existsSync(resolve(distDir, '200.html'))).toBe(false)
+    expect(existsSync(resolve(distDir, '404.html'))).toBe(false)
+  })
+
   test('generate.fallback = true is transformed to /404.html', () => {
     nuxt.options.generate.fallback = true
     const options = Options.from(nuxt.options)
@@ -70,6 +87,15 @@ describe('fallback generate', () => {
       await expect(generator.generate({ build: false })).resolves.toBeTruthy()
     }
   )
+
+  test('spa-fallback.html was created', async () => {
+    const html = await rp(url('/spa-fallback.html'))
+    expect(html.includes('<h1>Index page</h1>')).toBe(false)
+    expect(html.includes('data-server-rendered')).toBe(false)
+    expect(existsSync(resolve(distDir, 'spa-fallback.html'))).toBe(true)
+    expect(existsSync(resolve(distDir, '200.html'))).toBe(false)
+    expect(existsSync(resolve(distDir, '404.html'))).toBe(false)
+  })
 
   // Close server and ask nuxt to stop listening to file changes
   afterAll(async () => {


### PR DESCRIPTION
The SPA fallback option should always be a string, if in the user configuration it was specified as boolean true it should have been replaced by the default string value (currently 404.html) in lib/common/options.js

Added test on empty string fallback option

Added missing test for custom fallback option spa-fallback.html