### PR TITLE
perf(builder): use fs-extra for parallel tasks

### DIFF
--- a/lib/builder/builder.js
+++ b/lib/builder/builder.js
@@ -133,11 +133,14 @@ export default class Builder {
 
     // Create .nuxt/, .nuxt/components and .nuxt/dist folders
     await fsExtra.remove(r(this.options.buildDir))
-    await fsExtra.mkdirp(r(this.options.buildDir, 'components'))
+    const buildDirs = [r(this.options.buildDir, 'components')]
     if (!this.options.dev) {
-      await fsExtra.mkdirp(r(this.options.buildDir, 'dist', 'client'))
-      await fsExtra.mkdirp(r(this.options.buildDir, 'dist', 'server'))
+      buildDirs.push(
+        r(this.options.buildDir, 'dist', 'client'),
+        r(this.options.buildDir, 'dist', 'server')
+      )
     }
+    await Promise.all(buildDirs.map(dir => fsExtra.mkdirp(dir)))
 
     // Generate routes and interpret the template files
     await this.generateRoutesAndFiles()
@@ -420,10 +423,8 @@ export default class Builder {
           throw new Error(`Could not compile template ${src}: ${err.message}`)
         }
         const _path = r(this.options.buildDir, dst)
-        // Ensure parent dir exits
-        await fsExtra.mkdirp(path.dirname(_path))
-        // Write file
-        await fsExtra.writeFile(_path, content, 'utf8')
+        // Ensure parent dir exits and write file
+        await fsExtra.outputFile(_path, content, 'utf8')
       })
     )
 


### PR DESCRIPTION
Potentially `fsExtra.outputFile` could be used in more places