### PR TITLE
feat: move to webpack-hot-client

### DIFF
--- a/lib/builder/builder.js
+++ b/lib/builder/builder.js
@@ -10,7 +10,7 @@ import webpack from 'webpack'
 import serialize from 'serialize-javascript'
 import MFS from 'memory-fs'
 import webpackDevMiddleware from 'webpack-dev-middleware'
-import webpackHotMiddleware from 'webpack-hot-middleware'
+import webpackHotClient from 'webpack-hot-client'
 import Glob from 'glob'
 import upath from 'upath'
 import consola from 'consola'
@@ -34,7 +34,7 @@ export default class Builder {
     this.compilers = []
     this.compilersWatching = []
     this.webpackDevMiddleware = null
-    this.webpackHotMiddleware = null
+    this.webpackHotClient = null
     this.watchers = {
       files: null,
       custom: null,
@@ -560,10 +560,27 @@ export default class Builder {
     })
   }
 
-  webpackDev(compiler) {
+  async webpackDev(compiler) {
     consola.debug('Adding webpack middleware...')
 
-    // Create webpack dev middleware
+    if (this.options.build.hotMiddleware) {
+      consola.warn('options.build.hotMiddleware is removed.')
+      consola.warn('Please migrate the options for webpack-hot-client and put it in options.build.hotClient.')
+    }
+
+    this.webpackHotClient = webpackHotClient(
+      compiler,
+      Object.assign(
+        {
+          logLevel: 'silent'
+        },
+        this.options.build.hotClient
+      )
+    )
+    await pify(cb => this.webpackHotClient.server.on('listening', cb))()
+
+    this.webpackHotClient.close = pify(this.webpackHotClient.close)
+
     this.webpackDevMiddleware = pify(
       webpackDevMiddleware(
         compiler,
@@ -581,23 +598,9 @@ export default class Builder {
 
     this.webpackDevMiddleware.close = pify(this.webpackDevMiddleware.close)
 
-    this.webpackHotMiddleware = pify(
-      webpackHotMiddleware(
-        compiler,
-        Object.assign(
-          {
-            log: false,
-            heartbeat: 10000
-          },
-          this.options.build.hotMiddleware
-        )
-      )
-    )
-
     // Inject to renderer instance
     if (this.nuxt.renderer) {
       this.nuxt.renderer.webpackDevMiddleware = this.webpackDevMiddleware
-      this.nuxt.renderer.webpackHotMiddleware = this.webpackHotMiddleware
     }
 
     // Start watching client files
@@ -673,6 +676,9 @@ export default class Builder {
     // Stop webpack middleware
     if (this.webpackDevMiddleware) {
       await this.webpackDevMiddleware.close()
+    }
+    if (this.webpackHotClient) {
+      await this.webpackHotClient.close()
     }
   }
 

--- a/lib/builder/webpack/client.js
+++ b/lib/builder/webpack/client.js
@@ -122,6 +122,11 @@ export default class WebpackClientConfig extends WebpackBaseConfig {
       app: [path.resolve(this.options.buildDir, 'client.js')]
     }
 
+    // Add error overlay for development
+    if (this.options.dev) {
+      config.entry.app.unshift('webpack-serve-overlay')
+    }
+
     // Add friendly error plugin
     if (this.options.dev && !this.options.build.quiet) {
       config.plugins.push(

--- a/lib/builder/webpack/client.js
+++ b/lib/builder/webpack/client.js
@@ -72,11 +72,6 @@ export default class WebpackClientConfig extends WebpackBaseConfig {
       new webpack.DefinePlugin(this.env())
     )
 
-    if (this.options.dev) {
-      // TODO: webpackHotUpdate is not defined: https://github.com/webpack/webpack/issues/6693
-      plugins.push(new webpack.HotModuleReplacementPlugin())
-    }
-
     // Webpack Bundle Analyzer
     // https://github.com/webpack-contrib/webpack-bundle-analyzer
     if (!this.options.dev && this.options.build.analyze) {
@@ -125,16 +120,6 @@ export default class WebpackClientConfig extends WebpackBaseConfig {
     // Entry points
     config.entry = {
       app: [path.resolve(this.options.buildDir, 'client.js')]
-    }
-
-    // Add HMR support
-    if (this.options.dev) {
-      config.entry.app.unshift(
-        // https://github.com/glenjamin/webpack-hot-middleware#config
-        `webpack-hot-middleware/client?name=client&reload=true&timeout=30000&path=${
-          this.options.router.base
-        }/__webpack_hmr`.replace(/\/\//g, '/')
-      )
     }
 
     // Add friendly error plugin

--- a/lib/common/nuxt.config.js
+++ b/lib/common/nuxt.config.js
@@ -89,7 +89,7 @@ export default {
     templates: [],
     watch: [],
     devMiddleware: {},
-    hotMiddleware: {},
+    hotClient: {},
     stats: {
       chunks: false,
       children: false,

--- a/lib/core/renderer.js
+++ b/lib/core/renderer.js
@@ -31,7 +31,6 @@ export default class Renderer {
 
     // Will be available on dev
     this.webpackDevMiddleware = null
-    this.webpackHotMiddleware = null
 
     // Create new connect instance
     this.app = connect()
@@ -211,9 +210,6 @@ export default class Renderer {
       this.useMiddleware(async (req, res, next) => {
         if (this.webpackDevMiddleware) {
           await this.webpackDevMiddleware(req, res)
-        }
-        if (this.webpackHotMiddleware) {
-          await this.webpackHotMiddleware(req, res)
         }
         next()
       })

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "webpack": "^4.17.1",
     "webpack-bundle-analyzer": "^2.13.1",
     "webpack-dev-middleware": "^3.2.0",
-    "webpack-hot-middleware": "^2.22.3",
+    "webpack-hot-client": "^4.1.1",
     "webpack-node-externals": "^1.7.2",
     "webpackbar": "^2.6.3"
   },

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "webpack-dev-middleware": "^3.2.0",
     "webpack-hot-client": "^4.1.1",
     "webpack-node-externals": "^1.7.2",
+    "webpack-serve-overlay": "^0.3.0",
     "webpackbar": "^2.6.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1012,6 +1012,10 @@ ansi-escapes@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
 
+ansi-html@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz#813584021962a9e9e6fd039f940d12f56ca7859e"
+
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
@@ -3735,6 +3739,10 @@ html-encoding-sniffer@^1.0.2:
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"
   dependencies:
     whatwg-encoding "^1.0.1"
+
+html-entities@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.2.1.tgz#0df29351f0721163515dfb9e5543e5f6eed5162f"
 
 html-minifier@^3.2.3, html-minifier@^3.5.19:
   version "3.5.20"
@@ -8470,6 +8478,13 @@ webpack-log@^2.0.0:
 webpack-node-externals@^1.7.2:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/webpack-node-externals/-/webpack-node-externals-1.7.2.tgz#6e1ee79ac67c070402ba700ef033a9b8d52ac4e3"
+
+webpack-serve-overlay@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/webpack-serve-overlay/-/webpack-serve-overlay-0.3.0.tgz#3ef21ca1dd834f3d106e028a0f8b2ca81f337517"
+  dependencies:
+    ansi-html "0.0.7"
+    html-entities "^1.2.1"
 
 webpack-sources@^1.0.1, webpack-sources@^1.1.0:
   version "1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -886,6 +886,17 @@
     "@webassemblyjs/wast-parser" "1.5.13"
     long "^3.2.0"
 
+"@webpack-contrib/schema-utils@^1.0.0-beta.0":
+  version "1.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@webpack-contrib/schema-utils/-/schema-utils-1.0.0-beta.0.tgz#bf9638c9464d177b48209e84209e23bee2eb4f65"
+  dependencies:
+    ajv "^6.1.0"
+    ajv-keywords "^3.1.0"
+    chalk "^2.3.2"
+    strip-ansi "^4.0.0"
+    text-table "^0.2.0"
+    webpack-log "^1.1.2"
+
 abab@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.0.tgz#aba0ab4c5eee2d4c79d3487d85450fb2376ebb0f"
@@ -1000,10 +1011,6 @@ ansi-escapes@^1.1.0:
 ansi-escapes@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
-
-ansi-html@0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz#813584021962a9e9e6fd039f940d12f56ca7859e"
 
 ansi-regex@^2.0.0:
   version "2.1.1"
@@ -2487,6 +2494,12 @@ cyclist@~0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
 
+d@1:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
+  dependencies:
+    es5-ext "^0.10.9"
+
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
@@ -2835,6 +2848,22 @@ es-to-primitive@^1.1.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.1"
 
+es5-ext@^0.10.35, es5-ext@^0.10.9, es5-ext@~0.10.14:
+  version "0.10.46"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.46.tgz#efd99f67c5a7ec789baa3daa7f79870388f7f572"
+  dependencies:
+    es6-iterator "~2.0.3"
+    es6-symbol "~3.1.1"
+    next-tick "1"
+
+es6-iterator@~2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
+  dependencies:
+    d "1"
+    es5-ext "^0.10.35"
+    es6-symbol "^3.1.1"
+
 es6-promise@^4.0.3:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.4.tgz#dc4221c2b16518760bd8c39a52d8f356fc00ed29"
@@ -2844,6 +2873,13 @@ es6-promisify@^5.0.0:
   resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
   dependencies:
     es6-promise "^4.0.3"
+
+es6-symbol@^3.1.1, es6-symbol@~3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.1.tgz#bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77"
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
 
 escape-html@~1.0.3:
   version "1.0.3"
@@ -3700,10 +3736,6 @@ html-encoding-sniffer@^1.0.2:
   dependencies:
     whatwg-encoding "^1.0.1"
 
-html-entities@^1.2.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.2.1.tgz#0df29351f0721163515dfb9e5543e5f6eed5162f"
-
 html-minifier@^3.2.3, html-minifier@^3.5.19:
   version "3.5.20"
   resolved "https://registry.yarnpkg.com/html-minifier/-/html-minifier-3.5.20.tgz#7b19fd3caa0cb79f7cde5ee5c3abdf8ecaa6bb14"
@@ -4129,7 +4161,7 @@ is-path-inside@^1.0.0:
   dependencies:
     path-is-inside "^1.0.1"
 
-is-plain-obj@^1.0.0:
+is-plain-obj@^1.0.0, is-plain-obj@^1.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
 
@@ -4711,7 +4743,7 @@ json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
 
-json-stringify-safe@~5.0.1:
+json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
@@ -4913,6 +4945,12 @@ lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5,
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
+log-symbols@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
+  dependencies:
+    chalk "^2.0.1"
+
 log-update@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/log-update/-/log-update-2.3.0.tgz#88328fd7d1ce7938b29283746f0b1bc126b24708"
@@ -4920,6 +4958,13 @@ log-update@^2.3.0:
     ansi-escapes "^3.0.0"
     cli-cursor "^2.0.0"
     wrap-ansi "^3.0.1"
+
+loglevelnext@^1.0.1, loglevelnext@^1.0.2:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/loglevelnext/-/loglevelnext-1.0.5.tgz#36fc4f5996d6640f539ff203ba819641680d75a2"
+  dependencies:
+    es6-symbol "^3.1.1"
+    object.assign "^4.1.0"
 
 long@4.0.0:
   version "4.0.0"
@@ -5034,6 +5079,12 @@ memory-fs@^0.4.0, memory-fs@^0.4.1, memory-fs@~0.4.1:
 merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
+
+merge-options@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/merge-options/-/merge-options-1.0.1.tgz#2a64b24457becd4e4dc608283247e94ce589aa32"
+  dependencies:
+    is-plain-obj "^1.1"
 
 merge-source-map@^1.1.0:
   version "1.1.0"
@@ -5269,6 +5320,10 @@ negotiator@0.6.1:
 neo-async@^2.5.0:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.5.2.tgz#489105ce7bc54e709d736b195f82135048c50fcc"
+
+next-tick@1:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
 
 nice-try@^1.0.4:
   version "1.0.4"
@@ -6828,7 +6883,7 @@ querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
 
-querystring@0.2.0, querystring@^0.2.0:
+querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
 
@@ -7866,7 +7921,7 @@ test-exclude@^4.2.1:
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
 
-text-table@~0.2.0:
+text-table@^0.2.0, text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
 
@@ -8202,7 +8257,7 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
 
-uuid@^3.3.2:
+uuid@^3.1.0, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
 
@@ -8383,14 +8438,27 @@ webpack-dev-middleware@^3.2.0:
     url-join "^4.0.0"
     webpack-log "^2.0.0"
 
-webpack-hot-middleware@^2.22.3:
-  version "2.22.3"
-  resolved "https://registry.yarnpkg.com/webpack-hot-middleware/-/webpack-hot-middleware-2.22.3.tgz#ae6025d57d656085c5b716b44e0bc0f796787776"
+webpack-hot-client@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/webpack-hot-client/-/webpack-hot-client-4.1.1.tgz#fc02b396749d5fd26c4f2265567e2fc1521a41ff"
   dependencies:
-    ansi-html "0.0.7"
-    html-entities "^1.2.0"
-    querystring "^0.2.0"
-    strip-ansi "^3.0.0"
+    "@webpack-contrib/schema-utils" "^1.0.0-beta.0"
+    json-stringify-safe "^5.0.1"
+    loglevelnext "^1.0.2"
+    merge-options "^1.0.1"
+    strip-ansi "^4.0.0"
+    uuid "^3.1.0"
+    webpack-log "^1.1.1"
+    ws "^4.0.0"
+
+webpack-log@^1.1.1, webpack-log@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/webpack-log/-/webpack-log-1.2.0.tgz#a4b34cda6b22b518dbb0ab32e567962d5c72a43d"
+  dependencies:
+    chalk "^2.1.0"
+    log-symbols "^2.1.0"
+    loglevelnext "^1.0.1"
+    uuid "^3.1.0"
 
 webpack-log@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
It's... a mixed story. webpack-hot-client uses WebSocket which drops support for IE 8/9, but for developers this should be pretty fine.

The corresponding config is renamed and needs new options.

The biggest issue is that webpack-hot-client does not support overlays. The maintainer is sticking with his (personal) opinion to not include that functionality: https://github.com/webpack-contrib/webpack-serve/issues/4

A basic alternative coded by the community is included as a separate commit, but it is not feature complete, such as the styling being different from the former one, and doesn't show if you refresh while having bundle error (only shows when doing HMR).