### PR TITLE
fix: Relative publicPath if router.base set

### DIFF
--- a/lib/builder/webpack/base.js
+++ b/lib/builder/webpack/base.js
@@ -93,7 +93,7 @@ export default class WebpackBaseConfig {
         ? this.options.build.publicPath
         : urlJoin(
           this.options.router.base,
-          this.options.router.base !== '/'
+          (this.options.router.base !== '/' && this.options.build.publicPath === '/_nuxt/')
             ? `.${this.options.build.publicPath}`
             : this.options.build.publicPath
         )

--- a/lib/builder/webpack/base.js
+++ b/lib/builder/webpack/base.js
@@ -91,7 +91,12 @@ export default class WebpackBaseConfig {
       chunkFilename: this.getFileName('chunk'),
       publicPath: isUrl(this.options.build.publicPath)
         ? this.options.build.publicPath
-        : urlJoin(this.options.router.base, this.options.build.publicPath)
+        : urlJoin(
+          this.options.router.base,
+          this.options.router.base.length > 1
+            ? `.${this.options.build.publicPath}`
+            : this.options.build.publicPath
+        )
     }
   }
 

--- a/lib/builder/webpack/base.js
+++ b/lib/builder/webpack/base.js
@@ -93,7 +93,7 @@ export default class WebpackBaseConfig {
         ? this.options.build.publicPath
         : urlJoin(
           this.options.router.base,
-          this.options.router.base.length > 1
+          this.options.router.base !== '/'
             ? `.${this.options.build.publicPath}`
             : this.options.build.publicPath
         )


### PR DESCRIPTION
As seen in https://github.com/nuxt/nuxt.js/issues/1947, people can get stuck sorting this out.

Perhaps this is a sensible change, ensuring a relative path in `urlJoin()` in case `router.base` differs from `'/'`, but i'll let you be the judge of that.