### PR TITLE
fix: window nuxt build by using cross-spawn

### DIFF
--- a/build/package.js
+++ b/build/package.js
@@ -1,6 +1,6 @@
 import { resolve } from 'path'
-import { spawnSync } from 'child_process'
 import EventEmitter from 'events'
+import { sync as spawnSync } from 'cross-spawn'
 import consola from 'consola'
 import { readFileSync, existsSync, readJSONSync, writeFileSync, copySync, removeSync } from 'fs-extra'
 import { builtinsMap } from './builtins'

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "babel-plugin-dynamic-import-node": "^2.0.0",
     "codecov": "^3.0.4",
     "cross-env": "^5.2.0",
+    "cross-spawn": "^6.0.5",
     "eslint": "^5.4.0",
     "eslint-config-standard": "^12.0.0",
     "eslint-config-standard-jsx": "^6.0.2",


### PR DESCRIPTION
node spawnSync have issues on windows and building fails with it with ENOENT error