### PR TITLE
fix: access to pages with non ascii filenames

### DIFF
--- a/lib/common/utils.js
+++ b/lib/common/utils.js
@@ -279,7 +279,7 @@ export const createRoutes = function createRoutes(files, srcDir, pagesDir) {
               ? '*'
               : key.indexOf('_') === 0
                 ? key.replace('_', ':')
-                : key)
+                : encodeURIComponent(key))
         if (key !== '_' && key.indexOf('_') === 0) {
           route.path += '?'
         }

--- a/lib/common/utils.js
+++ b/lib/common/utils.js
@@ -279,7 +279,7 @@ export const createRoutes = function createRoutes(files, srcDir, pagesDir) {
               ? '*'
               : key.indexOf('_') === 0
                 ? key.replace('_', ':')
-                : encodeURIComponent(key))
+                : key)
         if (key !== '_' && key.indexOf('_') === 0) {
           route.path += '?'
         }

--- a/lib/core/middleware/nuxt.js
+++ b/lib/core/middleware/nuxt.js
@@ -7,11 +7,12 @@ import { getContext } from '../../common/utils'
 export default async function nuxtMiddleware(req, res, next) {
   // Get context
   const context = getContext(req, res)
+  const url = decodeURIComponent(req.url)
 
   res.statusCode = 200
   try {
-    const result = await this.renderRoute(req.url, context)
-    await this.nuxt.callHook('render:route', req.url, result, context)
+    const result = await this.renderRoute(url, context)
+    await this.nuxt.callHook('render:route', url, result, context)
     const {
       html,
       cspScriptSrcHashSet,
@@ -21,7 +22,7 @@ export default async function nuxtMiddleware(req, res, next) {
     } = result
 
     if (redirected) {
-      this.nuxt.callHook('render:routeDone', req.url, result, context)
+      this.nuxt.callHook('render:routeDone', url, result, context)
       return html
     }
     if (error) {
@@ -34,7 +35,7 @@ export default async function nuxtMiddleware(req, res, next) {
       if (fresh(req.headers, { etag })) {
         res.statusCode = 304
         res.end()
-        this.nuxt.callHook('render:routeDone', req.url, result, context)
+        this.nuxt.callHook('render:routeDone', url, result, context)
         return
       }
       res.setHeader('ETag', etag)
@@ -81,7 +82,7 @@ export default async function nuxtMiddleware(req, res, next) {
     res.setHeader('Content-Type', 'text/html; charset=utf-8')
     res.setHeader('Content-Length', Buffer.byteLength(html))
     res.end(html, 'utf8')
-    this.nuxt.callHook('render:routeDone', req.url, result, context)
+    this.nuxt.callHook('render:routeDone', url, result, context)
     return html
   } catch (err) {
     /* istanbul ignore if */

--- a/test/fixtures/spa/pages/тест雨.vue
+++ b/test/fixtures/spa/pages/тест雨.vue
@@ -1,0 +1,12 @@
+<template>
+  <div>Hello SPA!</div>
+</template>
+
+<script>
+export default {
+  mounted() {
+    window.indexMounted = (+window.indexMounted) + 1
+    console.log('mounted') // eslint-disable-line no-console
+  }
+}
+</script>

--- a/test/unit/spa.test.js
+++ b/test/unit/spa.test.js
@@ -27,6 +27,14 @@ describe('spa', () => {
     consola.log.mockClear()
   })
 
+  test('/тест雨 (test non ascii route)', async () => {
+    const { html } = await renderRoute('/тест雨')
+    expect(html).toMatch('Hello SPA!')
+    expect(consola.log).not.toHaveBeenCalledWith('created')
+    expect(consola.log).toHaveBeenCalledWith('mounted')
+    consola.log.mockClear()
+  })
+
   test('/custom (custom layout)', async () => {
     const { html } = await renderRoute('/custom')
     expect(html).toMatch('Custom layout')


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
Resolves: #2888 #3211

Blocked by: https://github.com/vuejs/vue-router/pull/2375

Waiting for vue-router release > 3.0.1 before we can merge this

As a workaround  dynamic url with slug can be used e.g. `mypage/_slug.vue`. In this case any url `mypage/*` even if it contains non ascii chars will be rendered.

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests passed.

