### PR TITLE
feat: automatically include env variables starting with NUXT_ENV_

### DIFF
--- a/lib/common/options.js
+++ b/lib/common/options.js
@@ -160,6 +160,10 @@ Options.from = function (_options) {
     vueConfig.performance = options.dev
   }
 
+  // merge custom env with variables
+  const eligibleEnvVariables = _.pick(process.env, Object.keys(process.env).filter(k => k.startsWith('NUXT_ENV_')))
+  Object.assign(options.env, eligibleEnvVariables)
+
   // Normalize ignore
   options.ignore = options.ignore ? [].concat(options.ignore) : []
 

--- a/test/fixtures/with-config/with-config.test.js
+++ b/test/fixtures/with-config/with-config.test.js
@@ -1,6 +1,10 @@
 import consola from 'consola'
 import { buildFixture } from '../../utils/build'
 
+beforeAll(() => {
+  process.env.NUXT_ENV_FOO = 'manniL'
+})
+
 let customCompressionMiddlewareFunctionName
 const hooks = [
   ['render:errorMiddleware', (app) => {
@@ -19,4 +23,8 @@ describe('with-config', () => {
     }])
     expect(customCompressionMiddlewareFunctionName).toBe('damn')
   }, hooks)
+})
+
+afterAll(() => {
+  delete process.env.NUXT_ENV_FOO
 })

--- a/test/unit/with-config.test.js
+++ b/test/unit/with-config.test.js
@@ -92,6 +92,7 @@ describe('with-config', () => {
     expect(html.includes('"string": "ok"')).toBe(true)
     expect(html.includes('"num2": 8.23')).toBe(true)
     expect(html.includes('"obj": {')).toBe(true)
+    expect(html).toContain('"NUXT_ENV_FOO": "manniL"')
   })
 
   test('/test/error', async () => {


### PR DESCRIPTION
If you don't want to add all `env variables` to your `nuxt.config.js` you now can prefix them with `NUXT_ENV_` to get them automatically included in the `process.env` object.

Example:
1. Build and start your app. Include the variable in the build step:
`NUXT_ENV_TEST=awesome nuxt build && nuxt start`
2. Call it in your app `process.env.NUXT_ENV_TEST //awesome`

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. (PR: https://github.com/nuxt/docs/pull/748)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests passed.

