### PR TITLE
feat: make compression middleware customizable

### DIFF
--- a/lib/common/nuxt.config.js
+++ b/lib/common/nuxt.config.js
@@ -207,6 +207,7 @@ export default {
     static: {
       prefix: true
     },
+    customCompressionMiddleware: undefined,
     gzip: {
       threshold: 0
     },

--- a/lib/common/nuxt.config.js
+++ b/lib/common/nuxt.config.js
@@ -207,10 +207,7 @@ export default {
     static: {
       prefix: true
     },
-    customCompressionMiddleware: undefined,
-    gzip: {
-      threshold: 0
-    },
+    compression: undefined,
     etag: {
       weak: false
     },

--- a/lib/common/nuxt.config.js
+++ b/lib/common/nuxt.config.js
@@ -207,7 +207,7 @@ export default {
     static: {
       prefix: true
     },
-    compression: undefined,
+    compressor: undefined,
     etag: {
       weak: false
     },

--- a/lib/common/nuxt.config.js
+++ b/lib/common/nuxt.config.js
@@ -207,7 +207,9 @@ export default {
     static: {
       prefix: true
     },
-    compressor: undefined,
+    compressor: {
+      threshold: 0
+    },
     etag: {
       weak: false
     },

--- a/lib/common/options.js
+++ b/lib/common/options.js
@@ -172,7 +172,7 @@ Options.from = function (_options) {
 
   // Compression middleware
 
-  options.compressor = retrieveCompressionMiddleware(options.render)
+  options.render.compressor = options.render.gzip || options.render.compressor
 
   // Apply mode preset
   const modePreset = modes[options.mode || 'universal'] || modes.universal
@@ -213,19 +213,4 @@ Options.from = function (_options) {
   }
 
   return options
-}
-
-const retrieveCompressionMiddleware = ({ compressor, gzip }) => {
-  if (!compressor) {
-    if (gzip) {
-      consola.warn('render.gzip is deprecated and will be removed in a future version! Please switch to' +
-        ' build.render.compressor')
-      return compression(gzip)
-    }
-    return compression()
-  }
-  if (typeof compressor === 'object') {
-    return compression(compressor)
-  }
-  return compressor
 }

--- a/lib/common/options.js
+++ b/lib/common/options.js
@@ -172,7 +172,7 @@ Options.from = function (_options) {
   if (options.render.gzip) {
     consola.warn('render.gzip is deprecated and will be removed in a future version! Please switch to build.render.compressor')
     options.render.compressor = options.render.gzip
-    delte options.render.gzip
+    delete options.render.gzip
   }
 
   // Apply mode preset

--- a/lib/common/options.js
+++ b/lib/common/options.js
@@ -4,7 +4,7 @@ import fs from 'fs'
 import _ from 'lodash'
 import consola from 'consola'
 
-import compressionMiddleware from 'compression'
+import compression from 'compression'
 import { isPureObject, isUrl } from '../common/utils'
 
 import modes from './modes'
@@ -220,12 +220,12 @@ const retrieveCompressionMiddleware = ({ compressor, gzip }) => {
     if (gzip) {
       consola.warn('build.render.gzip is deprecated and will be removed in a future version! Please switch to' +
         ' build.render.compressor')
-      return compressionMiddleware(gzip)
+      return compression(gzip)
     }
-    return compressionMiddleware()
+    return compression()
   }
   if (typeof compressor === 'object') {
-    return compressionMiddleware(compressor)
+    return compression(compressor)
   }
   return compressor
 }

--- a/lib/common/options.js
+++ b/lib/common/options.js
@@ -218,7 +218,7 @@ Options.from = function (_options) {
 const retrieveCompressionMiddleware = ({ compressor, gzip }) => {
   if (!compressor) {
     if (gzip) {
-      consola.warn('build.render.gzip is deprecated and will be removed in a future version! Please switch to' +
+      consola.warn('render.gzip is deprecated and will be removed in a future version! Please switch to' +
         ' build.render.compressor')
       return compression(gzip)
     }

--- a/lib/common/options.js
+++ b/lib/common/options.js
@@ -3,8 +3,6 @@ import fs from 'fs'
 
 import _ from 'lodash'
 import consola from 'consola'
-
-import compression from 'compression'
 import { isPureObject, isUrl } from '../common/utils'
 
 import modes from './modes'
@@ -170,9 +168,11 @@ Options.from = function (_options) {
     options.ignore.push(`**/${options.ignorePrefix}*.*`)
   }
 
-  // Compression middleware
-
-  options.render.compressor = options.render.gzip || options.render.compressor
+  // Compression middleware legacy
+  if (options.render.gzip) {
+    consola.warn('render.gzip is deprecated and will be removed in a future version! Please switch to build.render.compressor')
+    options.render.compressor = options.render.gzip
+  }
 
   // Apply mode preset
   const modePreset = modes[options.mode || 'universal'] || modes.universal

--- a/lib/common/options.js
+++ b/lib/common/options.js
@@ -4,6 +4,7 @@ import fs from 'fs'
 import _ from 'lodash'
 import consola from 'consola'
 
+import compressionMiddleware from 'compression'
 import { isPureObject, isUrl } from '../common/utils'
 
 import modes from './modes'
@@ -169,6 +170,10 @@ Options.from = function (_options) {
     options.ignore.push(`**/${options.ignorePrefix}*.*`)
   }
 
+  // Compression middleware
+
+  options.compressor = retrieveCompressionMiddleware(options.render)
+
   // Apply mode preset
   const modePreset = modes[options.mode || 'universal'] || modes.universal
   _.defaultsDeep(options, modePreset)
@@ -208,4 +213,19 @@ Options.from = function (_options) {
   }
 
   return options
+}
+
+const retrieveCompressionMiddleware = ({ compressor, gzip }) => {
+  if (!compressor) {
+    if (gzip) {
+      consola.warn('build.render.gzip is deprecated and will be removed in a future version! Please switch to' +
+        ' build.render.compressor')
+      return compressionMiddleware(gzip)
+    }
+    return compressionMiddleware()
+  }
+  if (typeof compressor === 'object') {
+    return compressionMiddleware(compressor)
+  }
+  return compressor
 }

--- a/lib/common/options.js
+++ b/lib/common/options.js
@@ -172,6 +172,7 @@ Options.from = function (_options) {
   if (options.render.gzip) {
     consola.warn('render.gzip is deprecated and will be removed in a future version! Please switch to build.render.compressor')
     options.render.compressor = options.render.gzip
+    delte options.render.gzip
   }
 
   // Apply mode preset

--- a/lib/core/renderer.js
+++ b/lib/core/renderer.js
@@ -10,6 +10,7 @@ import connect from 'connect'
 import launchMiddleware from 'launch-editor-middleware'
 import consola from 'consola'
 
+import compression from 'compression'
 import { isUrl, timeout, waitFor } from '../common/utils'
 import defaults from '../common/nuxt.config'
 
@@ -202,7 +203,15 @@ export default class Renderer {
 
     // Compression middleware for production
     if (!this.options.dev) {
-      this.useMiddleware(this.options.render.compressor)
+      const compressor = this.options.render.compressor
+      if (typeof compressor === 'object') {
+        // If only setting for `compression` are provided, require the module and insert
+        const compression = this.nuxt.requireModule('compression', compressor)
+        this.useMiddleware(compression)
+      } else {
+        // Else, require own compression middleware
+        this.useMiddleware(compressor)
+      }
     }
 
     // Add webpack middleware only for development

--- a/lib/core/renderer.js
+++ b/lib/core/renderer.js
@@ -205,8 +205,8 @@ export default class Renderer {
       const compressor = this.options.render.compressor
       if (typeof compressor === 'object') {
         // If only setting for `compression` are provided, require the module and insert
-        const compression = this.nuxt.requireModule('compression', compressor)
-        this.useMiddleware(compression)
+        const compression = this.nuxt.requireModule('compression')
+        this.useMiddleware(compression(compressor))
       } else {
         // Else, require own compression middleware
         this.useMiddleware(compressor)

--- a/lib/core/renderer.js
+++ b/lib/core/renderer.js
@@ -201,9 +201,13 @@ export default class Renderer {
     // Apply setupMiddleware from modules first
     await this.nuxt.callHook('render:setupMiddleware', this.app)
 
-    // Gzip middleware for production
-    if (!this.options.dev && this.options.render.gzip) {
-      this.useMiddleware(compression(this.options.render.gzip))
+    // Compression middleware for production
+    if (!this.options.dev) {
+      if (this.options.render.customCompressionMiddleware) {
+        this.useMiddleware(this.options.render.customCompressionMiddleware)
+      } else if (this.options.render.gzip) {
+        this.useMiddleware(compression(this.options.render.gzip))
+      }
     }
 
     // Add webpack middleware only for development

--- a/lib/core/renderer.js
+++ b/lib/core/renderer.js
@@ -473,13 +473,13 @@ export const resourceMap = [
   }
 ]
 
-const retrieveCompressionMiddleware = ({ compression, gzip }) => {
-  if (!compression) {
+const retrieveCompressionMiddleware = ({ compressor, gzip }) => {
+  if (!compressor) {
     // Legacy: If options.render.gzip is present use legacy options, else default compression options will kick in.
     return compressionMiddleware(gzip)
   }
-  if (typeof compression === 'object') {
-    return compressionMiddleware(gzip)
+  if (typeof compressor === 'object') {
+    return compressionMiddleware(compressor)
   }
-  return compression
+  return compressor
 }

--- a/lib/core/renderer.js
+++ b/lib/core/renderer.js
@@ -205,7 +205,8 @@ export default class Renderer {
       const compressor = this.options.render.compressor
       if (typeof compressor === 'object') {
         // If only setting for `compression` are provided, require the module and insert
-        const compression = this.nuxt.requireModule('compression')
+        // Prefer require instead of requireModule to keep dependency in nuxt-start
+        const compression = require('compression')
         this.useMiddleware(compression(compressor))
       } else {
         // Else, require own compression middleware

--- a/lib/core/renderer.js
+++ b/lib/core/renderer.js
@@ -10,7 +10,6 @@ import connect from 'connect'
 import launchMiddleware from 'launch-editor-middleware'
 import consola from 'consola'
 
-import compression from 'compression'
 import { isUrl, timeout, waitFor } from '../common/utils'
 import defaults from '../common/nuxt.config'
 

--- a/lib/core/renderer.js
+++ b/lib/core/renderer.js
@@ -3,7 +3,7 @@ import crypto from 'crypto'
 
 import serialize from 'serialize-javascript'
 import serveStatic from 'serve-static'
-import compression from 'compression'
+import compressionMiddleware from 'compression'
 import _ from 'lodash'
 import fs from 'fs-extra'
 import { createBundleRenderer } from 'vue-server-renderer'
@@ -203,11 +203,7 @@ export default class Renderer {
 
     // Compression middleware for production
     if (!this.options.dev) {
-      if (this.options.render.customCompressionMiddleware) {
-        this.useMiddleware(this.options.render.customCompressionMiddleware)
-      } else if (this.options.render.gzip) {
-        this.useMiddleware(compression(this.options.render.gzip))
-      }
+      this.useMiddleware(retrieveCompressionMiddleware(this.options.render))
     }
 
     // Add webpack middleware only for development
@@ -476,3 +472,14 @@ export const resourceMap = [
     transform: parseTemplate
   }
 ]
+
+const retrieveCompressionMiddleware = ({ compression, gzip }) => {
+  if (!compression) {
+    // Legacy: If options.render.gzip is present use legacy options, else default compression options will kick in.
+    return compressionMiddleware(gzip)
+  }
+  if (typeof compression === 'object') {
+    return compressionMiddleware(gzip)
+  }
+  return compression
+}

--- a/lib/core/renderer.js
+++ b/lib/core/renderer.js
@@ -3,7 +3,6 @@ import crypto from 'crypto'
 
 import serialize from 'serialize-javascript'
 import serveStatic from 'serve-static'
-import compressionMiddleware from 'compression'
 import _ from 'lodash'
 import fs from 'fs-extra'
 import { createBundleRenderer } from 'vue-server-renderer'
@@ -203,7 +202,7 @@ export default class Renderer {
 
     // Compression middleware for production
     if (!this.options.dev) {
-      this.useMiddleware(retrieveCompressionMiddleware(this.options.render))
+      this.useMiddleware(this.options.render.compressor)
     }
 
     // Add webpack middleware only for development
@@ -472,18 +471,3 @@ export const resourceMap = [
     transform: parseTemplate
   }
 ]
-
-const retrieveCompressionMiddleware = ({ compressor, gzip }) => {
-  if (!compressor) {
-    if (gzip) {
-      consola.warn('build.render.gzip is deprecated and will be removed in a future version! Please switch to' +
-        ' build.render.compressor')
-      return compressionMiddleware(gzip)
-    }
-    return compressionMiddleware()
-  }
-  if (typeof compressor === 'object') {
-    return compressionMiddleware(compressor)
-  }
-  return compressor
-}

--- a/lib/core/renderer.js
+++ b/lib/core/renderer.js
@@ -475,8 +475,12 @@ export const resourceMap = [
 
 const retrieveCompressionMiddleware = ({ compressor, gzip }) => {
   if (!compressor) {
-    // Legacy: If options.render.gzip is present use legacy options, else default compression options will kick in.
-    return compressionMiddleware(gzip)
+    if (gzip) {
+      consola.warn('build.render.gzip is deprecated and will be removed in a future version! Please switch to' +
+        ' build.render.compressor')
+      return compressionMiddleware(gzip)
+    }
+    return compressionMiddleware()
   }
   if (typeof compressor === 'object') {
     return compressionMiddleware(compressor)

--- a/packages/nuxt-legacy/package.json
+++ b/packages/nuxt-legacy/package.json
@@ -50,10 +50,8 @@
   },
   "dependencies": {
     "@babel/core": "^7.0.0",
-    "@babel/polyfill": "^7.0.0",
     "@nuxtjs/babel-preset-app": "^0.5.0",
     "@nuxtjs/friendly-errors-webpack-plugin": "^2.0.2",
-    "@nuxtjs/opencollective": "^0.1.0",
     "@nuxtjs/youch": "^4.2.3",
     "babel-loader": "^8.0.0",
     "cache-loader": "^1.2.2",
@@ -82,6 +80,7 @@
     "memory-fs": "^0.4.1",
     "mini-css-extract-plugin": "^0.4.2",
     "minimist": "^1.2.0",
+    "opencollective": "^1.0.3",
     "pify": "^4.0.0",
     "postcss": "^6.0.22",
     "postcss-import": "^11.1.0",

--- a/packages/nuxt-legacy/package.json
+++ b/packages/nuxt-legacy/package.json
@@ -50,8 +50,10 @@
   },
   "dependencies": {
     "@babel/core": "^7.0.0",
+    "@babel/polyfill": "^7.0.0",
     "@nuxtjs/babel-preset-app": "^0.5.0",
     "@nuxtjs/friendly-errors-webpack-plugin": "^2.0.2",
+    "@nuxtjs/opencollective": "^0.1.0",
     "@nuxtjs/youch": "^4.2.3",
     "babel-loader": "^8.0.0",
     "cache-loader": "^1.2.2",
@@ -80,7 +82,6 @@
     "memory-fs": "^0.4.1",
     "mini-css-extract-plugin": "^0.4.2",
     "minimist": "^1.2.0",
-    "opencollective": "^1.0.3",
     "pify": "^4.0.0",
     "postcss": "^6.0.22",
     "postcss-import": "^11.1.0",

--- a/test/fixtures/with-config/nuxt.config.js
+++ b/test/fixtures/with-config/nuxt.config.js
@@ -87,7 +87,7 @@ export default {
         return ['script', 'style', 'font'].includes(type)
       }
     },
-    customCompressionMiddleware: function damn(...args) { return compression({ threshold: 9 })(...args) },
+    compressor: function damn(...args) { return compression({ threshold: 9 })(...args) },
     static: {
       maxAge: '1y'
     }

--- a/test/fixtures/with-config/nuxt.config.js
+++ b/test/fixtures/with-config/nuxt.config.js
@@ -1,4 +1,5 @@
 import path from 'path'
+import compression from 'compression'
 
 export default {
   srcDir: __dirname,
@@ -86,6 +87,7 @@ export default {
         return ['script', 'style', 'font'].includes(type)
       }
     },
+    customCompressionMiddleware: function damn(...args) { return compression({ threshold: 9 })(...args) },
     static: {
       maxAge: '1y'
     }

--- a/test/fixtures/with-config/with-config.test.js
+++ b/test/fixtures/with-config/with-config.test.js
@@ -1,13 +1,22 @@
 import consola from 'consola'
 import { buildFixture } from '../../utils/build'
 
+let customCompressionMiddlewareFunctionName
+const hooks = [
+  ['render:errorMiddleware', (app) => {
+    customCompressionMiddlewareFunctionName = app.stack[0].handle.name
+  }]
+]
+
 describe('with-config', () => {
   buildFixture('with-config', () => {
     expect(consola.warn).toHaveBeenCalledTimes(1)
+    expect(consola.fatal).toHaveBeenCalledTimes(0)
     expect(consola.warn.mock.calls[0]).toMatchObject([{
       message: 'Found 2 plugins that match the configuration, suggest to specify extension:',
       additional: expect.stringContaining('plugins/test.json'),
       badge: true
     }])
-  })
+    expect(customCompressionMiddlewareFunctionName).toBe('damn')
+  }, hooks)
 })

--- a/test/utils/build.js
+++ b/test/utils/build.js
@@ -1,10 +1,11 @@
 import { loadFixture, Nuxt, Builder } from './index'
 
-export const buildFixture = function (fixture, callback) {
+export const buildFixture = function (fixture, callback, hooks = []) {
   test(`Build ${fixture}`, async () => {
     const config = await loadFixture(fixture)
     const nuxt = new Nuxt(config)
     const buildDone = jest.fn()
+    hooks.forEach(([hook, fn]) => nuxt.hook(hook, fn))
     nuxt.hook('build:done', buildDone)
     const builder = await new Builder(nuxt).build()
     // 2: BUILD_DONE


### PR DESCRIPTION
Let user customize compression middleware

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Description

The user can now set up his own compression middleware on `render.customCompressionMiddleware` which will then be used instead of `compression`.

~Could help with~ **Likely resolves** #3117 :+1:  (have to test it on HTTPS first)

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. (PR: https://github.com/nuxt/docs/pull/749)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests passed.

