### PR TITLE
fix: Make all Promise rejections in asyncData/fetch handled

### DIFF
--- a/lib/app/client.js
+++ b/lib/app/client.js
@@ -14,7 +14,9 @@ import {
   getLocation,
   compile,
   getQueryDiff,
-  globalHandleError
+  globalHandleError,
+  allPromisesHandled,
+  compactMultipleErrors
 } from './utils'
 
 const noopData = () => { return {} }
@@ -320,7 +322,7 @@ async function render (to, from, next) {
     }
 
     // Call asyncData & fetch hooks on components matched by the route.
-    await Promise.all(Components.map((Component, i) => {
+    await allPromisesHandled(Components.map((Component, i) => {
       // Check if only children route changed
       Component._path = compile(to.matched[matches[i]].path)(to.params)
       Component._dataRefresh = false
@@ -384,8 +386,28 @@ async function render (to, from, next) {
           promises.push(p)
       }
 
-      return Promise.all(promises)
-    }))
+      return allPromisesHandled(promises).catch(async (errors) => 
+        Promise.reject(
+          Object.assign(compactMultipleErrors(
+            errors, 
+            `AsyncData Error${errors.length>1?'s':''} (${Component.options.name})`,
+            ' && '
+          ), {
+            component: Component
+          })
+        )
+      )
+    })).catch(async (errors) => 
+      Promise.reject(
+        errors.length === 1 ? 
+          errors[0] :
+          compactMultipleErrors(
+            errors, 
+            `Multiple Components AsyncData Error`,
+            '\n;\n'
+          )
+      )
+    )
 
     // If not redirected
     if (!nextCalled) {
@@ -591,7 +613,7 @@ function addHotReload ($component, depth) {
       if (!pFetch || (!(pFetch instanceof Promise) && (typeof pFetch.then !== 'function'))) { pFetch = Promise.resolve(pFetch) }
       <%= (loading ? 'pFetch.then(() => this.$loading.increase && this.$loading.increase(30))' : '') %>
       promises.push(pFetch)
-      return Promise.all(promises)
+      return allPromisesHandled(promises)
     })
     .then(() => {
       <%= (loading ? 'this.$loading.finish && this.$loading.finish()' : '') %>
@@ -609,7 +631,7 @@ async function mountApp(__app) {
   <% if (store) { %>store = __app.store <% } %>
 
   // Resolve route components
-  const Components = await Promise.all(resolveComponents(router))
+  const Components = await allPromisesHandled(resolveComponents(router))
 
   // Create Vue instance
   const _app = new Vue(app)

--- a/lib/app/client.js
+++ b/lib/app/client.js
@@ -388,13 +388,15 @@ async function render (to, from, next) {
 
       return allPromisesHandled(promises).catch(async (errors) => 
         Promise.reject(
-          Object.assign(compactMultipleErrors(
-            errors, 
-            `AsyncData Error${errors.length>1?'s':''} (${Component.options.name})`,
-            ' && '
-          ), {
-            component: Component
-          })
+          errors.length === 1 ?
+            errors[0] :
+            Object.assign(compactMultipleErrors(
+              errors, 
+              `AsyncData Error${errors.length>1?'s':''} (${Component.options.name})`,
+              ' && '
+            ), {
+              component: Component
+            })
         )
       )
     })).catch(async (errors) => 

--- a/lib/app/server.js
+++ b/lib/app/server.js
@@ -3,7 +3,7 @@ import { stringify } from 'querystring'
 import omit from 'lodash/omit'
 import middleware from './middleware'
 import { createApp, NuxtError } from './index'
-import { applyAsyncData, sanitizeComponent, getMatchedComponents, getContext, middlewareSeries, promisify, urlJoin } from './utils'
+import { applyAsyncData, sanitizeComponent, getMatchedComponents, getContext, middlewareSeries, promisify, urlJoin, allPromisesHandled, compactMultipleErrors } from './utils'
 
 const debug = require('debug')('nuxt:render')
 debug.color = 4 // force blue color
@@ -59,7 +59,7 @@ export default async (ssrContext) => {
 
   const beforeRender = async () => {
     // Call beforeNuxtRender() methods
-    await Promise.all(ssrContext.beforeRenderFns.map((fn) => promisify(fn, { Components, nuxtState: ssrContext.nuxt })))
+    await allPromisesHandled(ssrContext.beforeRenderFns.map((fn) => promisify(fn, { Components, nuxtState: ssrContext.nuxt })))
     <% if (store) { %>
     // Add the state from the vuex store
     ssrContext.nuxt.state = store.state
@@ -187,13 +187,13 @@ export default async (ssrContext) => {
   if (!Components.length) return render404Page()
 
   // Call asyncData & fetch hooks on components matched by the route.
-  let asyncDatas = await Promise.all(Components.map((Component) => {
+  let asyncDatas = await allPromisesHandled(Components.map((Component) => {
     let promises = []
 
     // Call asyncData(context)
     if (Component.options.asyncData && typeof Component.options.asyncData === 'function') {
       let promise = promisify(Component.options.asyncData, app.context)
-      promise.then((asyncDataResult) => {
+      promise = promise.then((asyncDataResult) => {
         ssrContext.asyncData[Component.cid] = asyncDataResult
         applyAsyncData(Component)
         return asyncDataResult
@@ -211,8 +211,30 @@ export default async (ssrContext) => {
       promises.push(null)
     }
 
-    return Promise.all(promises)
-  }))
+    return allPromisesHandled(promises).catch(async (errors) => 
+      Promise.reject(
+        errors.length === 1 ?
+          errors[0] :
+          Object.assign(compactMultipleErrors(
+            errors, 
+            `AsyncData Error${errors.length>1?'s':''} (${Component.options.name})`,
+            ' && '
+          ), {
+            component: Component
+          })
+      )
+    )
+  })).catch(async (errors) => 
+    Promise.reject(
+      errors.length === 1 ? 
+        errors[0] :
+        compactMultipleErrors(
+          errors, 
+          `Multiple Components AsyncData Error`,
+          '\n;\n'
+        )
+    )
+  )
 
   <% if (isDev) { %>if (asyncDatas.length) debug('Data fetching ' + ssrContext.url + ': ' + (Date.now() - s) + 'ms')<% } %>
 

--- a/lib/app/utils.js
+++ b/lib/app/utils.js
@@ -19,6 +19,67 @@ export function globalHandleError(error) {
   }
 }
 
+// Takes an array of errors and assigns a message and stack to it to make it error-like:
+export function compactMultipleErrors(errors, messagePrefix = 'Multiple Errors', errorJoiner = '\n + \n'){
+  if (!Array.isArray(errors)) {
+    throw new TypeError('Supplied errors is not an array');
+  }
+  
+  return Object.assign(errors, {
+    message: `${messagePrefix}:\n${
+      errors
+        .map(error => 
+          (typeof error === 'object' && error !== null && 'message' in error) ? 
+            error.message : 
+            String(error)
+        )
+        .reduce((messages, error) => {
+          messages.push(error)
+          return messages
+        }, [])
+        .join(errorJoiner)
+    }`,
+    stack: errors.find(error => error.stack).stack
+  })
+}
+
+// Like Promise.all, but leaves no rejection/error unhandled by collecting them into an array
+//   and rejecting it at the end:
+export async function allPromisesHandled(promises = []){
+  // Ensure supplied list of promises is an array.
+  if (!Array.isArray(promises)) {
+    throw new TypeError('Supplied promises is not an Array')
+  }
+
+  // Array to collect promise errors
+  const errors = []
+
+  // Reduce all promises to a chain of promises resulting in an array of all promise results.
+  return await promises.reduce((chain, promise) => 
+    // With the chain of previous promise results,
+    chain.then(async results => {
+      // push next result when its ready onto the results array:
+      results.push(
+        // Convert the promise (or thenable) to a built-in Promise,
+        //   and catch its error if it throws one, appending it
+        //   to the errors array.
+        await Promise.resolve(promise).catch(error => {
+          errors.push(error)
+        })
+      )
+      return results
+    }),
+    // Initial promise chain is empty:
+    Promise.resolve([])
+  ).then(results => 
+    // If there was any errors, reject with them.
+    errors.length > 0 
+      ? Promise.reject(compactMultipleErrors(errors)) 
+      // Otherwise resolve with results.
+      : results
+  )
+}
+
 export function applyAsyncData(Component, asyncData) {
   const ComponentData = Component.options.data || noopData
   // Prevent calling this method for each request on SSR context
@@ -89,7 +150,7 @@ export function flatMapComponents(route, fn) {
 }
 
 export function resolveRouteComponents(route) {
-  return Promise.all(
+  return allPromisesHandled(
     flatMapComponents(route, async (Component, _, match, key) => {
       // If component is a function, resolve it
       if (typeof Component === 'function' && !Component.options) {

--- a/test/fixtures/error/pages/async-data-rejection.vue
+++ b/test/fixtures/error/pages/async-data-rejection.vue
@@ -1,0 +1,13 @@
+<template>
+  <p>Error page because of asyncData rejection</p>
+</template>
+
+<script>
+export default {
+  asyncData() {
+    return new Promise((resolve, reject) => {
+      reject(new Error('Generic AsyncData Error'))
+    })
+  }
+}
+</script>

--- a/test/unit/error.test.js
+++ b/test/unit/error.test.js
@@ -27,6 +27,25 @@ describe('error', () => {
     expect(error.message.includes('This page could not be found')).toBe(true)
   })
 
+  test('/async-data-rejection should not result in an unhandled rejection', async () => {
+    const unhandledRejectionHook = jest.fn()
+
+    process.on('unhandledRejection', unhandledRejectionHook)
+
+    await expect(nuxt.renderRoute('/async-data-rejection')).rejects.toMatchObject({
+      message: expect.stringContaining('Generic AsyncData Error')
+    })
+
+    // Important: Circa jest version: 23.6.0, the process never emits unhandledRejection,
+    //   even when it should, rendering this expectation completely meaningless. It's still
+    //   a valid test though--it's a bug for the people working on jest to work out.
+    // Ref: https://github.com/facebook/jest/issues/5620
+    //    > The `unhandledRejection` handler is not testable anymore. (#5620)
+    expect(unhandledRejectionHook).toHaveBeenCalledTimes(0)
+
+    process.removeListener('unhandledRejection', unhandledRejectionHook)
+  })
+
   test('/ with renderAndGetWindow()', async () => {
     await expect(nuxt.renderAndGetWindow(url('/'))).rejects.toMatchObject({
       statusCode: 500


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Replaces several calls to `Promise.all` with a wrapper that does the same thing as before, but now accumulates the rejection errors from each of the promises and throws them as an array of errors after all of the supplied promises have resolved or rejected.

This change leaves it to application authors who use `nuxt.renderRoute(path, { req, res })`, `lib/core/middleware/nuxt`, etc... to choose to handle any promise errors that occur inside of a page Component's `asyncData` or `fetch` methods. Before this change, calls to `asyncData` or `fetch` that resulted in a promise rejection or error that would be considered unhandled, **regardless of whether or not there was only one rejection in the promises provided to** `Promise.all`; an `"unhandledRejection"` would be emitted at the process level.

```js
// Results in a caught rejection and also in an "unhandledRejection" event:

await Promise.all([ Promise.reject(12345) ]).catch((error) => error) 
// => 12345 (uncaught: 12345)

await Promise.all([ Promise.reject(1), Promise.reject(2) ]).catch((error) => error) 
// => 1 (uncaught: 1) (uncaught: 2)
```
```js
import { allPromisesHandled } from "lib/app/utils";
// Results in a caught rejection and no "unhandledRejection" event:

await allPromisesHandled([ Promise.reject(12345) ]).catch((errors) => errors) 
// => [ 12345 ]

await allPromisesHandled([ Promise.reject(1), Promise.reject(2) ]).catch((errors) => errors) 
// => [ 1, 2 ]
```
&mdash; [*See `allPromisesHandled` in `lib/app/utils.js`*](https://github.com/scryptonite/nuxt.js/blob/08541707a9f9327091d7980c5c5f2f8fcbacdc08/lib/app/utils.js#L46-L81)

In my application(s), I listen for the process `"unhandledRejection"` event and log the error/promise before shutting down. I wanted to be able to properly handle the promise rejection and also leave my listener for `"unhandledRejection"` in case somewhere in my codebase creates a promise without anticipating and handling its rejection.

Possible side-effects that I've thought of (but I don't think they'll be an issue):
  - A render waiting on a page Component with both an `asyncData` and `fetch`, where one rejects immediately(or at least before the other) will take longer than it did before. `Promise.all` could be thought of as a *'race to any rejection or for all to resolve'*, where `allPromiseHandled` will *'wait for all to reject or resolve'* before resolving or rejecting itself. (I.e. *eager vs patient rejection*)
  - The error thrown by a rejected promise collection is now sometimes an `Array` (if there is only one error involved, that is thrown instead of an array for asyncData/fetch rejections), which may be confusing to some theoretical existing error handling code outside of nuxt's codebase. In some places, I've made the resulting array itself error-like, using a function I made function named [`compactMultipleErrors` in `lib/app/utils.js`](https://github.com/scryptonite/nuxt.js/blob/08541707a9f9327091d7980c5c5f2f8fcbacdc08/lib/app/utils.js#L22-L44); It assigns a `message` and `stack` property to the array. (`message`: based on concatenations of the error messages within, `stack`: first truthy `stack` property in the errors array)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
  - Funny enough, I ran into a jest-related issue while writing a test to cover this change (as in, the test doesn't work properly with a current version of jest: `23.6.0`). See facebook/jest#5620
- [x] All new and existing tests passed.

