### PR TITLE
Fix legacy gzip warning

### DIFF
--- a/lib/common/options.js
+++ b/lib/common/options.js
@@ -174,7 +174,7 @@ Options.from = function (_options) {
 
   // Compression middleware legacy
   if (options.render.gzip) {
-    consola.warn('render.gzip is deprecated and will be removed in a future version! Please switch to build.render.compressor')
+    consola.warn('render.gzip is deprecated and will be removed in a future version! Please switch to render.compressor')
     options.render.compressor = options.render.gzip
     delete options.render.gzip
   }


### PR DESCRIPTION
Fix legacy gzip warning. Thanks to @liam-potter for pointing that out!

Related PR: #3863 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] All new and existing tests passed.

