### PR TITLE
feat: add tests to check for changed files

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
     "get-port": "^4.0.0",
     "jest": "^23.6.0",
     "jsdom": "^12.0.0",
+    "klaw-sync": "^5.0.0",
     "pug": "^2.0.3",
     "pug-plain-loader": "^1.0.0",
     "puppeteer": "^1.8.0",

--- a/test/unit/basic.generate.test.js
+++ b/test/unit/basic.generate.test.js
@@ -62,7 +62,7 @@ describe('basic generate', () => {
     let changedFileFound = false
     const paths = listPaths(generator.nuxt.options.rootDir, pathsBefore)
     paths.map((item) => {
-      console.log(changedFileName, item.path)
+      console.log(changedFileName, item.path) // eslint-disable-line no-console
       if (item.path === changedFileName) {
         changedFileFound = true
       } else {

--- a/test/unit/basic.generate.test.js
+++ b/test/unit/basic.generate.test.js
@@ -62,6 +62,7 @@ describe('basic generate', () => {
     let changedFileFound = false
     const paths = listPaths(generator.nuxt.options.rootDir, pathsBefore)
     paths.map((item) => {
+      console.log(changedFileName, item.path)
       if (item.path === changedFileName) {
         changedFileFound = true
       } else {

--- a/test/unit/basic.generate.test.js
+++ b/test/unit/basic.generate.test.js
@@ -61,7 +61,7 @@ describe('basic generate', () => {
 
     let changedFileFound = false
     const paths = listPaths(generator.nuxt.options.rootDir, pathsBefore)
-    paths.map((item) => {
+    paths.forEach((item) => {
       if (item.path === changedFileName) {
         changedFileFound = true
       } else {

--- a/test/unit/basic.generate.test.js
+++ b/test/unit/basic.generate.test.js
@@ -1,10 +1,10 @@
 import { existsSync, writeFile } from 'fs'
 import http from 'http'
-import { resolve, sep } from 'path'
+import { resolve } from 'path'
 import { remove } from 'fs-extra'
 import serveStatic from 'serve-static'
 import finalhandler from 'finalhandler'
-import { Builder, Generator, getPort, loadFixture, Nuxt, rp, listPaths } from '../utils'
+import { Builder, Generator, getPort, loadFixture, Nuxt, rp, listPaths, equalOrStartsWith } from '../utils'
 
 let port
 const url = route => 'http://localhost:' + port + route
@@ -54,18 +54,18 @@ describe('basic generate', () => {
   })
 
   test('Check changed files', () => {
-    // When generating Nuxt we only expect files to changed
-    // within the nuxt.options.generate.dir
-    const generateDirMatch =
-      new RegExp(`^${generator.nuxt.options.generate.dir}(${sep}|$)`)
-    let changedFileFound = false
+    // When generating Nuxt we only expect files to change
+    // within nuxt.options.generate.dir, but also allow other
+    // .nuxt dirs for when tests are runInBand
+    const allowChangesDir = resolve(generator.nuxt.options.generate.dir, '..', '.nuxt')
 
+    let changedFileFound = false
     const paths = listPaths(generator.nuxt.options.rootDir, pathsBefore)
     paths.map((item) => {
       if (item.path === changedFileName) {
         changedFileFound = true
       } else {
-        expect(item.path).toMatch(generateDirMatch)
+        expect(equalOrStartsWith(allowChangesDir, item.path)).toBe(true)
       }
     })
     expect(changedFileFound).toBe(true)

--- a/test/unit/basic.generate.test.js
+++ b/test/unit/basic.generate.test.js
@@ -1,4 +1,4 @@
-import { existsSync, writeFile } from 'fs'
+import { existsSync, writeFileSync } from 'fs'
 import http from 'http'
 import { resolve } from 'path'
 import { remove } from 'fs-extra'
@@ -26,7 +26,7 @@ describe('basic generate', () => {
     // Make sure our check for changed files is really working
     changedFileName = resolve(nuxt.options.generate.dir, '..', '.nuxt-generate-changed')
     nuxt.hook('generate:done', () => {
-      writeFile(changedFileName, '')
+      writeFileSync(changedFileName, '')
     })
 
     const builder = new Builder(nuxt)
@@ -62,7 +62,6 @@ describe('basic generate', () => {
     let changedFileFound = false
     const paths = listPaths(generator.nuxt.options.rootDir, pathsBefore)
     paths.map((item) => {
-      console.log(changedFileName, item.path) // eslint-disable-line no-console
       if (item.path === changedFileName) {
         changedFileFound = true
       } else {

--- a/test/unit/generator.test.js
+++ b/test/unit/generator.test.js
@@ -13,7 +13,7 @@ describe('generator', () => {
     const routes = await generator.initRoutes()
 
     expect(routes.length).toBe(array.length)
-    routes.map((route, index) => {
+    routes.forEach((route, index) => {
       expect(route.route).toBe(array[index])
     })
   })
@@ -32,7 +32,7 @@ describe('generator', () => {
     const routes = await generator.initRoutes()
 
     expect(routes.length).toBe(array.length)
-    routes.map((route, index) => {
+    routes.forEach((route, index) => {
       expect(route.route).toBe(array[index])
     })
   })
@@ -51,7 +51,7 @@ describe('generator', () => {
     const routes = await generator.initRoutes(array)
 
     expect(routes.length).toBe(array.length)
-    routes.map((route, index) => {
+    routes.forEach((route, index) => {
       expect(route.route).toBe(array[index])
     })
   })
@@ -70,7 +70,7 @@ describe('generator', () => {
     const routes = await generator.initRoutes(...array)
 
     expect(routes.length).toBe(array.length)
-    routes.map((route, index) => {
+    routes.forEach((route, index) => {
       expect(route.route).toBe(array[index])
     })
   })

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -1,5 +1,5 @@
 import path from 'path'
-import { Utils, waitUntil, isAppveyor } from '../utils'
+import { Utils, waitUntil } from '../utils'
 
 describe('utils', () => {
   test('encodeHtml', () => {
@@ -17,14 +17,14 @@ describe('utils', () => {
   })
 
   test('waitFor', async () => {
+    const delay = 100
     const s = process.hrtime()
-    await Utils.waitFor(100)
+    await Utils.waitFor(delay)
     const t = process.hrtime(s)
-    let waitedFor = (t[0] * 1e9 + t[1]) / 1e6
-    if (isAppveyor) {
-      waitedFor = Math.round(waitedFor)
-    }
-    expect(waitedFor).not.toBeLessThan(100)
+    // Node.js makes no guarantees about the exact timing of when callbacks will fire
+    // HTML5 specifies a minimum delay of 4ms for timeouts
+    // although arbitrary, use this value to determine our lower limit
+    expect((t[0] * 1e9 + t[1]) / 1e6).not.toBeLessThan(delay - 4)
     await Utils.waitFor()
   })
 

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -1,5 +1,5 @@
 import path from 'path'
-import { Utils, waitUntil } from '../utils'
+import { Utils, waitUntil, isAppveyor } from '../utils'
 
 describe('utils', () => {
   test('encodeHtml', () => {
@@ -20,7 +20,11 @@ describe('utils', () => {
     const s = process.hrtime()
     await Utils.waitFor(100)
     const t = process.hrtime(s)
-    expect(t[0] * 1e9 + t[1]).not.toBeLessThan(100 * 1e6)
+    let waitedFor = (t[0] * 1e9 + t[1]) / 1e6
+    if (isAppveyor) {
+      waitedFor = Math.round(waitedFor)
+    }
+    expect(waitedFor).not.toBeLessThan(100)
     await Utils.waitFor()
   })
 

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -16,10 +16,11 @@ describe('utils', () => {
     expect(ctx.res.b).toBe(2)
   })
 
-  test.skip.appveyor('waitFor', async () => {
-    const s = Date.now()
+  test('waitFor', async () => {
+    const s = process.hrtime()
     await Utils.waitFor(100)
-    expect(Date.now() - s >= 100).toBe(true)
+    const t = process.hrtime(s)
+    expect(t[0] * 1e9 + t[1] >= 100 * 1e6).toBe(true)
     await Utils.waitFor()
   })
 

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -20,7 +20,7 @@ describe('utils', () => {
     const s = process.hrtime()
     await Utils.waitFor(100)
     const t = process.hrtime(s)
-    expect(t[0] * 1e9 + t[1] >= 100 * 1e6).toBe(true)
+    expect(t[0] * 1e9 + t[1]).not.toBeLessThan(100 * 1e6)
     await Utils.waitFor()
   })
 

--- a/test/utils/build.js
+++ b/test/utils/build.js
@@ -32,7 +32,7 @@ export const buildFixture = function (fixture, callback, hooks = []) {
     // within the nuxt.options.buildDir
     Object.keys(pathsBefore).forEach((key) => {
       const paths = listPaths(nuxt.options[`${key}Dir`], pathsBefore[key])
-      paths.map((item) => {
+      paths.forEach((item) => {
         expect(equalOrStartsWith(nuxt.options.buildDir, item.path)).toBe(true)
       })
     })

--- a/test/utils/build.js
+++ b/test/utils/build.js
@@ -1,5 +1,4 @@
-import { sep } from 'path'
-import { loadFixture, Nuxt, Builder, listPaths } from './index'
+import { loadFixture, Nuxt, Builder, listPaths, equalOrStartsWith } from './index'
 
 export const buildFixture = function (fixture, callback, hooks = []) {
   const pathsBefore = {}
@@ -31,12 +30,10 @@ export const buildFixture = function (fixture, callback, hooks = []) {
 
     // When building Nuxt we only expect files to changed
     // within the nuxt.options.buildDir
-    const buildDirMatch = new RegExp(`^${nuxt.options.buildDir}(${sep}|$)`)
-
     Object.keys(pathsBefore).forEach((key) => {
       const paths = listPaths(nuxt.options[`${key}Dir`], pathsBefore[key])
       paths.map((item) => {
-        expect(item.path).toMatch(buildDirMatch)
+        expect(equalOrStartsWith(nuxt.options.buildDir, item.path)).toBe(true)
       })
     })
   })

--- a/test/utils/build.js
+++ b/test/utils/build.js
@@ -1,9 +1,19 @@
-import { loadFixture, Nuxt, Builder } from './index'
+import { sep } from 'path'
+import { loadFixture, Nuxt, Builder, listPaths } from './index'
 
 export const buildFixture = function (fixture, callback, hooks = []) {
+  const pathsBefore = {}
+  let nuxt
+
   test(`Build ${fixture}`, async () => {
     const config = await loadFixture(fixture)
-    const nuxt = new Nuxt(config)
+    nuxt = new Nuxt(config)
+
+    pathsBefore.root = listPaths(nuxt.options.rootDir)
+    if (nuxt.options.rootDir !== nuxt.options.srcDir) {
+      pathsBefore.src = listPaths(nuxt.options.srcDir)
+    }
+
     const buildDone = jest.fn()
     hooks.forEach(([hook, fn]) => nuxt.hook(hook, fn))
     nuxt.hook('build:done', buildDone)
@@ -15,4 +25,19 @@ export const buildFixture = function (fixture, callback, hooks = []) {
       callback(builder)
     }
   }, 120000)
+
+  test('Check changed files', () => {
+    expect.hasAssertions()
+
+    // When building Nuxt we only expect files to changed
+    // within the nuxt.options.buildDir
+    const buildDirMatch = new RegExp(`^${nuxt.options.buildDir}(${sep}|$)`)
+
+    Object.keys(pathsBefore).forEach((key) => {
+      const paths = listPaths(nuxt.options[`${key}Dir`], pathsBefore[key])
+      paths.map((item) => {
+        expect(item.path).toMatch(buildDirMatch)
+      })
+    })
+  })
 }

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -1,8 +1,9 @@
 import path from 'path'
 import fs from 'fs'
+import klawSync from 'klaw-sync'
 
 import _getPort from 'get-port'
-import { defaultsDeep } from 'lodash'
+import { defaultsDeep, find } from 'lodash'
 import _rp from 'request-promise-native'
 import pkg from '../../package.json'
 import _Nuxt from '../../lib/index.js'
@@ -50,4 +51,20 @@ export const waitUntil = async function waitUntil(condition, duration = 20, inte
     return true
   }
   return false
+}
+
+export const listPaths = function listPaths(dir, pathsBefore = [], options = {}) {
+  if (Array.isArray(pathsBefore) && pathsBefore.length) {
+    // only return files that didn't exist before building
+    // and files that have been changed
+    options.filter = (item) => {
+      const foundItem = find(pathsBefore, (itemBefore) => {
+        return item.path === itemBefore.path
+      })
+      return typeof foundItem === 'undefined' ||
+        item.stats.mtimeMs !== foundItem.stats.mtimeMs
+    }
+  }
+
+  return klawSync(dir, options)
 }

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -18,8 +18,6 @@ export const Options = _Nuxt.Options
 export const Builder = _Nuxt.Builder
 export const Generator = _Nuxt.Generator
 
-export const isAppveyor = !!process.env.APPVEYOR
-
 export const loadFixture = async function (fixture, overrides) {
   const rootDir = path.resolve(__dirname, '..', 'fixtures', fixture)
   const configFile = path.resolve(rootDir, 'nuxt.config.js')

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -18,6 +18,8 @@ export const Options = _Nuxt.Options
 export const Builder = _Nuxt.Builder
 export const Generator = _Nuxt.Generator
 
+export const isAppveyor = !!process.env.APPVEYOR
+
 export const loadFixture = async function (fixture, overrides) {
   const rootDir = path.resolve(__dirname, '..', 'fixtures', fixture)
   const configFile = path.resolve(rootDir, 'nuxt.config.js')

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -68,3 +68,7 @@ export const listPaths = function listPaths(dir, pathsBefore = [], options = {})
 
   return klawSync(dir, options)
 }
+
+export const equalOrStartsWith = function equalOrStartsWith(string1, string2) {
+  return string1 === string2 || string2.startsWith(string1)
+}

--- a/test/utils/setup.js
+++ b/test/utils/setup.js
@@ -1,5 +1,4 @@
-import { isAppveyor } from '.'
-
+const isAppveyor = !!process.env.APPVEYOR
 describe.skip.appveyor = isAppveyor ? describe.skip : describe
 test.skip.appveyor = isAppveyor ? test.skip : test
 

--- a/test/utils/setup.js
+++ b/test/utils/setup.js
@@ -1,5 +1,5 @@
+import { isAppveyor } from '.'
 
-const isAppveyor = !!process.env.APPVEYOR
 describe.skip.appveyor = isAppveyor ? describe.skip : describe
 test.skip.appveyor = isAppveyor ? test.skip : test
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4611,6 +4611,12 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.2"
   resolved "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
 
+klaw-sync@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/klaw-sync/-/klaw-sync-5.0.0.tgz#b8db1249f96a82751c311ee8a626a319db119904"
+  dependencies:
+    graceful-fs "^4.1.11"
+
 kleur@^2.0.1:
   version "2.0.2"
   resolved "https://registry.npmjs.org/kleur/-/kleur-2.0.2.tgz#b704f4944d95e255d038f0cb05fb8a602c55a300"


### PR DESCRIPTION
As discussed in #3869

Make sure that if we are building or generating only files in buildDir and generate.dir are changed. If files in another location would also be changed due to a new config option, those locations should be guarded in `lib/common/options.js` so you cant set them lower then rootDir or srcDir.

## Checklist:
- [x] All new and existing tests passed.

