### PR TITLE
feat: Overwrite store.registerModule

### DIFF
--- a/lib/app/index.js
+++ b/lib/app/index.js
@@ -49,6 +49,11 @@ async function createApp (ssrContext) {
   const store = createStore(ssrContext)
   // Add this.$router into store actions/mutations
   store.$router = router
+    <% if (mode === 'universal') { %>
+    // Fix SSR caveat https://github.com/nuxt/nuxt.js/issues/3757#issuecomment-414689141
+    const registerModule = store.registerModule
+    store.registerModule = (path, rawModule, options) => registerModule.call(store, path, rawModule, Object.assign({ preserveState: process.browser }, options))
+    <% } %>
   <% } %>
 
   // Create Root instance

--- a/test/e2e/basic.browser.test.js
+++ b/test/e2e/basic.browser.test.js
@@ -50,6 +50,11 @@ describe('basic browser', () => {
     expect(await page.$text('h1')).toBe('My component!')
   })
 
+  test('/store-module', async () => {
+    await page.nuxt.navigate('/store-module')
+    expect(await page.$text('h1')).toBe('mutated')
+  })
+
   test('/css', async () => {
     await page.nuxt.navigate('/css')
 

--- a/test/fixtures/basic/nuxt.config.js
+++ b/test/fixtures/basic/nuxt.config.js
@@ -31,7 +31,7 @@ export default {
       '/async-data',
       '/validate',
       '/redirect',
-
+      '/store-module',
       '/users/1',
       '/users/2',
       { route: '/users/3', payload: { id: 3000 } }

--- a/test/fixtures/basic/nuxt.config.js
+++ b/test/fixtures/basic/nuxt.config.js
@@ -8,6 +8,9 @@ export default {
       maxAge: ((60 * 60 * 24 * 365) * 2)
     }
   },
+  plugins: [
+    '~/plugins/vuex-module'
+  ],
   router: {
     extendRoutes(routes, resolve) {
       return [{

--- a/test/fixtures/basic/pages/store-module.vue
+++ b/test/fixtures/basic/pages/store-module.vue
@@ -1,0 +1,11 @@
+<template>
+  <h1>{{ $store.state.simpleModule.mutateMe }}</h1>
+</template>
+
+<script>
+export default {
+  fetch({ store }) {
+    store.dispatch('simpleModule/mutate')
+  }
+}
+</script>

--- a/test/fixtures/basic/plugins/vuex-module.js
+++ b/test/fixtures/basic/plugins/vuex-module.js
@@ -1,0 +1,18 @@
+export default function ({ store }) {
+  store.registerModule('simpleModule', {
+    namespaced: true,
+    state: () => ({
+      mutateMe: 'not mutated'
+    }),
+    actions: {
+      mutate({ commit }) {
+        commit('mutate')
+      }
+    },
+    mutations: {
+      mutate(state) {
+        state.mutateMe = 'mutated'
+      }
+    }
+  })
+}

--- a/test/unit/basic.generate.test.js
+++ b/test/unit/basic.generate.test.js
@@ -61,6 +61,12 @@ describe('basic generate', () => {
     expect(html.includes('<h1>My component!</h1>')).toBe(true)
   })
 
+  test('/store-module', async () => {
+    const window = await generator.nuxt.renderAndGetWindow(url('/store-module'))
+    const html = window.document.body.innerHTML
+    expect(html.includes('<h1>mutated</h1>')).toBe(true)
+  })
+
   test('/css', async () => {
     const window = await generator.nuxt.renderAndGetWindow(url('/css'))
 

--- a/test/unit/basic.ssr.test.js
+++ b/test/unit/basic.ssr.test.js
@@ -19,6 +19,11 @@ describe('basic ssr', () => {
     expect(html.includes('<h1>My component!</h1>')).toBe(true)
   })
 
+  test('/store-module', async () => {
+    const { html } = await nuxt.renderRoute('/store-module')
+    expect(html.includes('<h1>mutated</h1>')).toBe(true)
+  })
+
   /*
   ** Example of testing via dom checking
   */


### PR DESCRIPTION
Make `store.registerModule` works seamlessly with server-side rendering.

Related to https://github.com/nuxt/nuxt.js/issues/3757#issuecomment-414689141

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->



## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests passed.

