### PR TITLE
fix(cli): apply default value for NODE_ENV environment variable

### DIFF
--- a/bin/nuxt-build
+++ b/bin/nuxt-build
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+process.env.NODE_ENV = process.env.NODE_ENV || 'production'
+
 const parseArgs = require('minimist')
 const consola = require('consola')
 const { Nuxt, Builder, Generator } = require('..')

--- a/bin/nuxt-dev
+++ b/bin/nuxt-dev
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+process.env.NODE_ENV = process.env.NODE_ENV || 'development'
+
 const parseArgs = require('minimist')
 const consola = require('consola')
 const { version } = require('../package.json')

--- a/bin/nuxt-generate
+++ b/bin/nuxt-generate
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+process.env.NODE_ENV = process.env.NODE_ENV || 'production'
+
 const parseArgs = require('minimist')
 const consola = require('consola')
 const { Nuxt, Builder, Generator } = require('..')

--- a/bin/nuxt-start
+++ b/bin/nuxt-start
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+process.env.NODE_ENV = process.env.NODE_ENV || 'production'
+
 const fs = require('fs')
 const { resolve } = require('path')
 const parseArgs = require('minimist')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
Related to #4002. Some tools (Including the current version of `vue-loader`) implicitly use `process.env.NODE_ENV` to align their options. This change only sets the best value for `NODE_ENV` if not already set so it won't break anything. 

- The reason for including before any `require()` is that some modules may need this env during evaluation.
- The reason for not refactoring this logic inside `bin/nuxt` is binaries portability. (nuxt-start directly is being called) 

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests pass.

