### PR TITLE
feat(builder): allow to customize or disable minimizer plugins

### DIFF
--- a/lib/builder/webpack/client.js
+++ b/lib/builder/webpack/client.js
@@ -100,7 +100,7 @@ export default class WebpackClientConfig extends WebpackBaseConfig {
     const config = super.extendConfig(...arguments)
 
     // Add minimizer plugins
-    if (!this.options.dev && config.optimization.minimizer === undefined) {
+    if (config.optimization.minimize && config.optimization.minimizer === undefined) {
       config.optimization.minimizer = []
 
       // https://github.com/webpack-contrib/terser-webpack-plugin

--- a/lib/builder/webpack/client.js
+++ b/lib/builder/webpack/client.js
@@ -99,31 +99,36 @@ export default class WebpackClientConfig extends WebpackBaseConfig {
   extendConfig() {
     const config = super.extendConfig(...arguments)
 
-    if (!this.options.dev && !config.optimization.minimizer) {
+    // Add minimizer plugins
+    if (!this.options.dev && config.optimization.minimizer === undefined) {
       config.optimization.minimizer = []
 
       // https://github.com/webpack-contrib/terser-webpack-plugin
-      const terserJsPlugin = new TerserWebpackPlugin({
-        parallel: true,
-        cache: this.options.build.cache,
-        sourceMap: config.devtool && /source-?map/.test(config.devtool),
-        extractComments: {
-          filename: 'LICENSES'
-        },
-        terserOptions: {
-          output: {
-            comments: /^\**!|@preserve|@license|@cc_on/
-          }
-        }
-      })
-      config.optimization.minimizer.push(terserJsPlugin)
+      if (this.options.build.terser) {
+        config.optimization.minimizer.push(
+          new TerserWebpackPlugin(Object.assign({
+            parallel: true,
+            cache: this.options.build.cache,
+            sourceMap: config.devtool && /source-?map/.test(config.devtool),
+            extractComments: {
+              filename: 'LICENSES'
+            },
+            terserOptions: {
+              output: {
+                comments: /^\**!|@preserve|@license|@cc_on/
+              }
+            }
+          }, this.options.build.terser))
+        )
+      }
 
       // https://github.com/NMFR/optimize-css-assets-webpack-plugin
       // https://github.com/webpack-contrib/mini-css-extract-plugin#minimizing-for-production
       // TODO: Remove OptimizeCSSAssetsPlugin when upgrading to webpack 5
-      if (this.options.build.extractCSS) {
-        const optimizeCSSPlugin = new OptimizeCSSAssetsPlugin({})
-        config.optimization.minimizer.push(optimizeCSSPlugin)
+      if (this.options.build.optimizeCSS) {
+        config.optimization.minimizer.push(
+          new OptimizeCSSAssetsPlugin(Object.assign({}, this.options.build.optimizeCSS))
+        )
       }
     }
 

--- a/lib/common/nuxt.config.js
+++ b/lib/common/nuxt.config.js
@@ -91,6 +91,7 @@ export default {
     optimizeCSS: undefined,
     optimization: {
       runtimeChunk: 'single',
+      minimize: undefined,
       minimizer: undefined,
       splitChunks: {
         chunks: 'all',

--- a/lib/common/nuxt.config.js
+++ b/lib/common/nuxt.config.js
@@ -87,8 +87,11 @@ export default {
     },
     styleResources: {},
     plugins: [],
+    terser: {},
+    optimizeCSS: undefined,
     optimization: {
       runtimeChunk: 'single',
+      minimizer: undefined,
       splitChunks: {
         chunks: 'all',
         automaticNameDelimiter: '.',

--- a/lib/common/options.js
+++ b/lib/common/options.js
@@ -239,6 +239,11 @@ Options.from = function (_options) {
     options.build.extractCSS = false
   }
 
+  // Enable optimizeCSS only when extractCSS is enabled
+  if (options.build.optimizeCSS === undefined) {
+    options.build.optimizeCSS = options.build.extractCSS ? {} : false
+  }
+
   const loaders = options.build.loaders
   const vueLoader = loaders.vue
   if (vueLoader.productionMode === undefined) {

--- a/lib/common/options.js
+++ b/lib/common/options.js
@@ -240,8 +240,8 @@ Options.from = function (_options) {
   }
 
   // Enable minimize for production builds
-  if (options.build.minimize === undefined) {
-    options.build.minimize = options.dev
+  if (options.build.optimization.minimize === undefined) {
+    options.build.optimization.minimize = !options.dev
   }
 
   // Enable optimizeCSS only when extractCSS is enabled

--- a/lib/common/options.js
+++ b/lib/common/options.js
@@ -239,6 +239,11 @@ Options.from = function (_options) {
     options.build.extractCSS = false
   }
 
+  // Enable minimize for production builds
+  if (options.build.minimize === undefined) {
+    options.build.minimize = options.dev
+  }
+
   // Enable optimizeCSS only when extractCSS is enabled
   if (options.build.optimizeCSS === undefined) {
     options.build.optimizeCSS = options.build.extractCSS ? {} : false


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
**Background:** CSSNano is currently applied twice. Once with PostCSS loader and once with optimizeCSSAssetsPlugin. This is normally not harmful and good indeed but for incompatible CSS assets like Framework7 is problematic and currently there is not any way to disable or customize options.

This enhancement allows toggling or providing more options to both terser and optimizeCSS plugins. Also adds support for setting `false` value to `minimize` to disable them at all (for testing purposes and more webpack options compatibility)

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. (PR: nuxt/docs#805)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

