### PR TITLE
feat: allow nuxt-child to pass keep-alive props to keep-alive

### DIFF
--- a/lib/app/components/nuxt-child.js
+++ b/lib/app/components/nuxt-child.js
@@ -1,7 +1,7 @@
 export default {
   name: 'nuxt-child',
   functional: true,
-  props: ['keepAlive'],
+  props: ['keepAlive', 'keepAliveProps'],
   render (h, { parent, data, props }) {
     data.nuxtChild = true
     const _parent = parent
@@ -44,7 +44,7 @@ export default {
     ]
     if (typeof props.keepAlive !== 'undefined') {
       routerView = [
-        h('keep-alive', routerView)
+        h('keep-alive', { props: props.keepAliveProps }, routerView)
       ]
     }
     return h('transition', {


### PR DESCRIPTION
Adds the ability to configure the props of keep-alive on nuxt-child.

## Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
In development, I found it impossible to configure the props of keep-alive when using nuxt-child, like ```exclude```. This PR adds a special prop to nuxt-child named keepAliveProps to allow developer to configure it.

```html
<template>
  <div>
    <nuxt-child keep-alive :keep-alive-props="{ exclude: ['modal'] }">
  </div>
</template>
```

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. (PR: https://github.com/nuxt/docs/pull/836)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

