### PR TITLE
chore: replace links with speaking equivalents

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -3,7 +3,9 @@
 
 Please use the following link to create a new issue:
 
-👉 https://cmty.app/nuxt/issues/new?repo=nuxt.js
+- 🚨 Bug report - http://bug.nuxt.xyz/ 
+- 🙋 Feature request - http://feature.nuxt.xyz/ 
+- ❗️ All other issues - http://cmty.nuxt.xyz/ 
 
-If your issue was not created using the app above, it will be closed immediately.
+If your issue was not created using the app above, **it will be closed immediately**.
 -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,9 @@ First of all, thank you for considering to contribute to Nuxt.js! :heart:
 ## Reporting Issues
 
 A great way to contribute to the project is to send a detailed report when you encounter an issue.
-To make things easier for contributors and maintainers, we use [CMTY](https://cmty.app/nuxt/issues/new?repo=nuxt.js).
+To make things easier for contributors and maintainers, we use [CMTY](http://cmty.nuxt.xyz).
 
-Please make sure to include a reproduction repository or [CodeSandBox](https://codesandbox.io/s/github/nuxt/codesandbox-nuxt/tree/master/)
+Please make sure to include a reproduction repository or [CodeSandBox](http://template.nuxt.xyz)
 so that bugs can be reproduced without great efforts. The better a bug can be reproduced, the faster we can start fixing it!
 
 ## Pull Requests
@@ -15,8 +15,8 @@ so that bugs can be reproduced without great efforts. The better a bug can be re
 We'd love to see your pull requests, even if it's just to fix a typo!
 
 However, any significant improvement should be associated to an existing
-[feature request](https://cmty.app/nuxt/issues/feature-request?repo=nuxt.js)
-or [bug report](https://cmty.app/nuxt/issues/bug-report?repo=nuxt.js).
+[feature request](http://feature.nuxt.xyz/)
+or [bug report](http://bug.nuxt.xyz/).
 
 ### Getting started
 

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
   <a href="https://www.npmjs.com/package/nuxt"><img src="https://badgen.net/npm/dm/nuxt" alt="Downloads"></a>
   <a href="https://www.npmjs.com/package/nuxt"><img src="https://badgen.net/npm/v/nuxt" alt="Version"></a>
   <a href="https://www.npmjs.com/package/nuxt"><img src="https://badgen.net/npm/license/nuxt" alt="License"></a>
-  <a href="https://discord.gg/VApZF5W"><img src="https://badgen.net/badge/Discord/join-us/7289DA" alt="Discord"></a>
+  <a href="http://discord.nuxt.xyz"><img src="https://badgen.net/badge/Discord/join-us/7289DA" alt="Discord"></a>
  </p>
  <p align="center">
   <a href="#partners" alt="Partner on Open Collective"><img src="https://opencollective.com/nuxtjs/tiers/partner/badge.svg" /></a>
   <a href="#sponsors" alt="Sponsors on Open Collective"><img src="https://opencollective.com/nuxtjs/tiers/sponsors/badge.svg" /></a>
   <a href="#backers" alt="Backers on Open Collective"><img src="https://opencollective.com/nuxtjs/tiers/backers/badge.svg" /></a>
-  <a href="https://opencollective.com/nuxtjs"><img src="https://img.shields.io/badge/Support%20us-Open%20Collective-41B883.svg" alt="Support us"></a>
+  <a href="http://oc.nuxt.xyz/"><img src="https://img.shields.io/badge/Support%20us-Open%20Collective-41B883.svg" alt="Support us"></a>
 
 </p>
 
@@ -23,10 +23,10 @@
 - 📘 Documentation: [https://nuxtjs.org](https://nuxtjs.org)
 - 👥 Community: [cmty.app/nuxt](https://cmty.app/nuxt)
 - 🎬 Video: [1 minute demo](https://www.youtube.com/watch?v=kmf-p-pTi40)
-- 🐦 Twitter: [@nuxt_js](https://twitter.com/nuxt_js)
-- 💬 Chat: [Discord](https://discord.gg/VApZF5W)
+- 🐦 Twitter: [@nuxt_js](http://twitter.nuxt.xyz)
+- 💬 Chat: [Discord](http://discord.nuxt.xyz)
 - 📦 [Nuxt.js Modules](https://github.com/nuxt-community/modules)
-- 👉 [Play with Nuxt.js online](https://glitch.com/edit/#!/nuxt-hello-world)
+- 👉 [Play with Nuxt.js online](http://template.nuxt.xyz)
 
 ## Features
 


### PR DESCRIPTION
Replace links that are frequently used with `nuxt.xyz` subdomains that redirect to the destination. 

Example: `https://codesandbox.io/s/github/nuxt/codesandbox-nuxt/tree/master/` ~> `http://template.nuxt.xyz/`