### PR TITLE
feat(store): allow a function named 'initialState' to define the state

### DIFF
--- a/lib/app/store.js
+++ b/lib/app/store.js
@@ -76,7 +76,11 @@ export const createStore = storeData instanceof Function ? storeData : () => {
   return new Vuex.Store(Object.assign({
     strict: (process.env.NODE_ENV !== 'production')
   }, storeData, {
-    state: storeData.state instanceof Function ? storeData.state() : {}
+    state: storeData.state instanceof Function 
+      ? storeData.state() 
+      : storeData.initialState instanceof Function 
+        ? storeData.initialState() 
+        : {}
   }))
 }
 
@@ -87,8 +91,8 @@ function getModule (filename) {
   if (module.commit) {
     throw new Error('[nuxt] <%= dir.store %>/' + filename.replace('./', '') + ' should export a method which returns a Vuex instance.')
   }
-  if (module.state && typeof module.state !== 'function') {
-    throw new Error('[nuxt] state should be a function in <%= dir.store %>/' + filename.replace('./', ''))
+  if ((module.state && typeof module.state !== 'function') || (module.initialState && typeof module.initialState !== 'function')) {
+    throw new Error('[nuxt] state should be a function named `state` or `initialState in <%= dir.store %>/' + filename.replace('./', ''))
   }
   return module
 }

--- a/lib/app/store.js
+++ b/lib/app/store.js
@@ -92,7 +92,7 @@ function getModule (filename) {
     throw new Error('[nuxt] <%= dir.store %>/' + filename.replace('./', '') + ' should export a method which returns a Vuex instance.')
   }
   if ((module.state && typeof module.state !== 'function') || (module.initialState && typeof module.initialState !== 'function')) {
-    throw new Error('[nuxt] state should be a function named `state` or `initialState in <%= dir.store %>/' + filename.replace('./', ''))
+    throw new Error('[nuxt] state should be a function named `state` or `initialState` in <%= dir.store %>/' + filename.replace('./', ''))
   }
   return module
 }

--- a/test/fixtures/store-initial-state-export/pages/index.vue
+++ b/test/fixtures/store-initial-state-export/pages/index.vue
@@ -1,0 +1,19 @@
+<template>
+  <div>
+    <h1>{{ counter }}</h1>
+    <button id="changeState" @click="increment">Increment</button>
+  </div>
+</template>
+
+<script>
+import { mapState, mapActions } from 'vuex'
+
+export default {
+  computed: {
+    ...mapState(['counter'])
+  },
+  methods: {
+    ...mapActions(['increment'])
+  }
+}
+</script>

--- a/test/fixtures/store-initial-state-export/store-initial-state-export.test.js
+++ b/test/fixtures/store-initial-state-export/store-initial-state-export.test.js
@@ -1,0 +1,3 @@
+import { buildFixture } from '../../utils/build'
+
+buildFixture('store-initial-state-export')

--- a/test/fixtures/store-initial-state-export/store/index.js
+++ b/test/fixtures/store-initial-state-export/store/index.js
@@ -1,0 +1,15 @@
+export const initialState = () => ({
+  counter: 0
+})
+
+export const mutations = {
+  increment(state) {
+    state.counter += 1
+  }
+}
+
+export const actions = {
+  increment({ commit }) {
+    commit('increment')
+  }
+}

--- a/test/unit/store-initial-state-export.test.js
+++ b/test/unit/store-initial-state-export.test.js
@@ -1,0 +1,36 @@
+import Browser from '../utils/browser'
+import { loadFixture, getPort, Nuxt } from '../utils'
+
+let port
+const browser = new Browser()
+const url = route => 'http://localhost:' + port + route
+
+let nuxt = null
+let page = null
+
+describe('store initialState export', () => {
+  beforeAll(async () => {
+    const config = await loadFixture('store-initial-state-export')
+    nuxt = new Nuxt(config)
+    port = await getPort()
+    await nuxt.listen(port, 'localhost')
+
+    await browser.start()
+    page = await browser.page(url('/'))
+  })
+
+  test('initial value is present in the h1 element', async () => {
+    expect(await page.$text('h1')).toBe('0')
+  })
+
+  test('after state change, the mutated value is present in the h1 element', async () => {
+    await page.click('#changeState')
+    expect(await page.$text('h1')).toBe('1')
+  })
+
+  afterAll(async () => {
+    await page.close()
+    await browser.close()
+    await nuxt.close()
+  })
+})


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
When using the Vuex store in the modules mode, the changes in this PR will allow the state to be defined by a function named 'initialState' instead of 'state' - this resolves #3995.
The existing functionality stays unaltered: Nuxt will first search for a function named 'state', then, if not found, search for the new 'initialState'.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

