### PR TITLE
add: print warning when using build.extractCSS.allChunks

### DIFF
--- a/lib/common/options.js
+++ b/lib/common/options.js
@@ -241,7 +241,6 @@ Options.from = function (_options) {
   // build.extractCSS.allChunks has no effect
   if (typeof options.build.extractCSS.allChunks !== 'undefined') {
     consola.warn('build.extractCSS.allChunks has no effect from v2.0.0. Please use build.splitChunks settings instead.')
-    options.build.extractCSS = false
   }
 
   // TODO: remove when mini-css-extract-plugin supports HMR

--- a/lib/common/options.js
+++ b/lib/common/options.js
@@ -238,6 +238,12 @@ Options.from = function (_options) {
     consola.warn('vendor has been deprecated due to webpack4 optimization')
   }
 
+  // build.extractCSS.allChunks has no effect
+  if (typeof options.build.extractCSS.allChunks !== 'undefined') {
+    consola.warn('build.extractCSS.allChunks has no effect from v2.0.0. Please use build.splitChunks settings instead.')
+    options.build.extractCSS = false
+  }
+
   // TODO: remove when mini-css-extract-plugin supports HMR
   if (options.dev) {
     options.build.extractCSS = false

--- a/lib/common/options.js
+++ b/lib/common/options.js
@@ -240,7 +240,7 @@ Options.from = function (_options) {
 
   // build.extractCSS.allChunks has no effect
   if (typeof options.build.extractCSS.allChunks !== 'undefined') {
-    consola.warn('build.extractCSS.allChunks has no effect from v2.0.0. Please use build.splitChunks settings instead.')
+    consola.warn('build.extractCSS.allChunks has no effect from v2.0.0. Please use build.optimization.splitChunks settings instead.')
   }
 
   // TODO: remove when mini-css-extract-plugin supports HMR


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
Resolve: #4094 

I have a question.
When build.extractCSS.allChunks is set, what should be the default value?

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.


