### PR TITLE
feat(builder): backport --no-generate option for spa build to 1.x versions

### DIFF
--- a/bin/nuxt-build
+++ b/bin/nuxt-build
@@ -33,6 +33,7 @@ if (argv.help) {
       --analyze, -a        Launch webpack-bundle-analyzer to optimize your bundles.
       --spa                Launch in SPA mode
       --universal          Launch in Universal mode (default)
+      --no-generate        Don't generate static version for SPA mode (useful for nuxt start)
       --config-file, -c    Path to Nuxt.js config file (default: nuxt.config.js)
       --help, -h           Displays this message
   `)
@@ -65,8 +66,8 @@ const close = () => {
   process.exit(0)
 }
 
-if (options.mode !== 'spa') {
-  // -- Build for SSR app --
+if (options.mode !== 'spa' || argv.generate === false) {
+  // -- Build Only --
   builder
     .build()
     .then(() => debug('Building done'))

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "source-map": "^0.7.0",
     "style-resources-loader": "^1.0.0",
     "uglifyjs-webpack-plugin": "^1.1.8",
-    "upath": "^1.0.2",
+    "upath": "^1.1.0",
     "url-loader": "^0.6.2",
     "vue": "^2.5.17",
     "vue-loader": "^13.7.2",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "jsdom": "^11.6.2",
     "json-loader": "^0.5.7",
     "nyc": "^11.4.1",
-    "puppeteer": "^1.0.0",
+    "puppeteer": "^1.9.0",
     "request": "^2.83.0",
     "request-promise-native": "^1.0.5",
     "sinon": "^4.3.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] mini change for Nuxt command with v1.x


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
add new option `nuxt build --no-generate` for SPA mode
I saw v2.x has this option for SPA mode without generate `./dist/**` files.
my projects use `v1.4.2`, and customize an express server with TypeScript.
If I upgrade to `v2.x`, I need to refactor too many files.
(I use SPA mode, and do not need .html files. want to build faster)
So, I refer `nuxt-build` of v2.x to make this change.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

