### PR TITLE
In renderer if ssr rendering fails, fall back to spa rendering with warning

### DIFF
--- a/lib/core/renderer.js
+++ b/lib/core/renderer.js
@@ -306,7 +306,7 @@ export default class Renderer {
     const spa = context.spa || (context.res && context.res.spa)
     const ENV = this.options.env
 
-    if (this.noSSR || spa) {
+    const spaRenderer = async () => {
       const {
         HTML_ATTRS,
         BODY_ATTRS,
@@ -341,8 +341,18 @@ export default class Renderer {
       return { html, getPreloadFiles }
     }
 
+    if (this.noSSR || spa) {
+      return spaRenderer()
+    }
+
     // Call renderToString from the bundleRenderer and generate the HTML (will update the context as well)
-    let APP = await this.bundleRenderer.renderToString(context)
+    let APP
+    try {
+      APP = await this.bundleRenderer.renderToString(context)
+    } catch(_) {
+      consola.warn(`ssrRenderer fails, fall back to spaRenderer for path ${url}.`);
+      return spaRenderer()
+    }
 
     if (!context.nuxt.serverRendered) {
       APP = '<div id="__nuxt"></div>'

--- a/lib/core/renderer.js
+++ b/lib/core/renderer.js
@@ -349,8 +349,8 @@ export default class Renderer {
     let APP
     try {
       APP = await this.bundleRenderer.renderToString(context)
-    } catch(_) {
-      consola.warn(`ssrRenderer fails, fall back to spaRenderer for path ${url}.`);
+    } catch (_) {
+      consola.warn(`ssrRenderer fails, fall back to spaRenderer for path ${url}.`)
       return spaRenderer()
     }
 


### PR DESCRIPTION
Background:
creating a module as in https://codesandbox.io/s/qkxvnmv104 to take params for general redirect.

Under universal mode generate mode,
`let APP = await this.bundleRenderer.renderToString(context)` would fail, 
as bundleRenderer comes from `{ createBundleRenderer } from 'vue-server-renderer'`, in which having assumption that the route is having a template finally .

more background:
https://github.com/nuxt-community/redirect-module/issues/3