### PR TITLE
fix(builder): use require.resolve to get the path of babel-loader

### DIFF
--- a/packages/builder/src/webpack/base.js
+++ b/packages/builder/src/webpack/base.js
@@ -164,7 +164,7 @@ export default class WebpackBaseConfig {
           return !modulesToTranspile.some(module => module.test(file))
         },
         use: perfLoader.pool('js', {
-          loader: 'babel-loader',
+          loader: require.resolve('babel-loader'),
           options: this.getBabelOptions()
         })
       },

--- a/packages/builder/src/webpack/utils/perf-loader.js
+++ b/packages/builder/src/webpack/utils/perf-loader.js
@@ -22,7 +22,10 @@ export default class PerfLoader {
   }
 
   warmupAll() {
-    this.warmup(this.workerPools.js, ['babel-loader', '@babel/preset-env'])
+    this.warmup(this.workerPools.js, [
+      require.resolve('babel-loader'),
+      require.resolve('@babel/preset-env')
+    ])
     this.warmup(this.workerPools.css, ['css-loader'])
   }
 

--- a/test/unit/wp.config.test.js
+++ b/test/unit/wp.config.test.js
@@ -18,7 +18,10 @@ describe('webpack configuration', () => {
     perfLoader.warmup = jest.fn()
     perfLoader.warmupAll()
     expect(perfLoader.warmup).toHaveBeenCalledTimes(2)
-    expect(perfLoader.warmup).toHaveBeenCalledWith(js, ['babel-loader', '@babel/preset-env'])
+    expect(perfLoader.warmup).toHaveBeenCalledWith(js, [
+      require.resolve('babel-loader'),
+      require.resolve('@babel/preset-env')
+    ])
     expect(perfLoader.warmup).toHaveBeenCalledWith(css, ['css-loader'])
 
     const loaders = perfLoader.pool('js', { loader: 'test-perf-loader' })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Yarn sometimes tries to move packages into a subpackage. (yarn moved `babel-loader` dependency into `node_modules/@nuxt/builder-edge/node_modules/babel-loader` when upgraded a project) This break builds when resolving webpack loaders because they are being required from root package nuxt builder.

This PR is the same as a workaround for `'@nuxtjs/babel-preset-app'`/NPX. Only targetting babel loaders as they are more likely to move into the builder.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

