### PR TITLE
feat: custom pushAssets function to control http2 push headers

### DIFF
--- a/packages/core/src/middleware/nuxt.js
+++ b/packages/core/src/middleware/nuxt.js
@@ -44,30 +44,18 @@ export default async function nuxtMiddleware(req, res, next) {
     if (!error && this.options.render.http2.push) {
       // Parse resourceHints to extract HTTP.2 prefetch/push headers
       // https://w3c.github.io/preload/#server-push-http-2
-      const pushAssets = []
       const preloadFiles = getPreloadFiles()
-      const { shouldPush } = this.options.render.http2
+      const { shouldPush, pushAssets } = this.options.render.http2
       const { publicPath } = this.resources.clientManifest
 
-      preloadFiles.forEach(({ file, asType, fileWithoutQuery }) => {
-        // By default, we only preload scripts or css
-        /* istanbul ignore if */
-        if (!shouldPush && asType !== 'script' && asType !== 'style') {
-          return
-        }
-
-        // User wants to explicitly control what to preload
-        if (shouldPush && !shouldPush(fileWithoutQuery, asType)) {
-          return
-        }
-
-        pushAssets.push(`<${publicPath}${file}>; rel=preload; as=${asType}`)
-      })
+      const links = pushAssets ? pushAssets(req, res, publicPath, preloadFiles) : defaultPushAssets(preloadFiles, shouldPush, publicPath, this.options.dev)
 
       // Pass with single Link header
       // https://blog.cloudflare.com/http-2-server-push-with-multiple-assets-per-link-header
       // https://www.w3.org/Protocols/9707-link-header.html
-      res.setHeader('Link', pushAssets.join(','))
+      if (links.length > 0) {
+        res.setHeader('Link', links.join(', '))
+      }
     }
 
     if (this.options.render.csp) {
@@ -92,6 +80,29 @@ export default async function nuxtMiddleware(req, res, next) {
 
     next(err)
   }
+}
+
+const defaultPushAssets = (preloadFiles, shouldPush, publicPath, isDev) => {
+  if (shouldPush && isDev) {
+    consola.warn('http2.shouldPush is deprecated. User http2.pushAssets function')
+  }
+
+  const links = []
+  preloadFiles.forEach(({ file, asType, fileWithoutQuery }) => {
+    // By default, we only preload scripts or css
+    /* istanbul ignore if */
+    if (!shouldPush && asType !== 'script' && asType !== 'style') {
+      return
+    }
+
+    // User wants to explicitly control what to preload
+    if (shouldPush && !shouldPush(fileWithoutQuery, asType)) {
+      return
+    }
+
+    links.push(`<${publicPath}${file}>; rel=preload; as=${asType}`)
+  })
+  return links
 }
 
 const getCspString = ({ cspScriptSrcHashSet, allowedSources, policies, isDev }) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
Resolves: #4011 

Adds `pushAssets(req, res, publicPath, preloadFiles)` option to `http2`.
Function returns array of links. Now we can conditionally decide which assets we want to push.

Undocumented filter function `shouldPush` was marked as `deprecated`

## Checklist:
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

