### PR TITLE
fix(inject): Throw error only if value is undefined

### DIFF
--- a/packages/app/template/index.js
+++ b/packages/app/template/index.js
@@ -130,7 +130,7 @@ async function createApp(ssrContext) {
   <% if (plugins.length) { %>
   const inject = function (key, value) {
     if (!key) throw new Error('inject(key, value) has no key provided')
-    if (!value) throw new Error('inject(key, value) has no value provided')
+    if (typeof value === 'undefined') throw new Error('inject(key, value) has no value provided')
     key = '$' + key
     // Add into app
     app[key] = value

--- a/test/fixtures/basic/nuxt.config.js
+++ b/test/fixtures/basic/nuxt.config.js
@@ -63,7 +63,8 @@ export default {
   transition: false,
   plugins: [
     '~/plugins/vuex-module',
-    '~/plugins/dir-plugin'
+    '~/plugins/dir-plugin',
+    '~/plugins/inject'
   ],
   build: {
     scopeHoisting: true,

--- a/test/fixtures/basic/plugins/inject.js
+++ b/test/fixtures/basic/plugins/inject.js
@@ -1,0 +1,16 @@
+export default ({ route, params }, inject) => {
+  const { injectValue } = route.query
+  if (typeof injectValue === 'undefined') {
+    return
+  }
+  const key = 'injectedProperty'
+  const map = {
+    'undefined': undefined,
+    'null': null,
+    'false': false,
+    '0': 0,
+    'empty': ''
+  }
+  const value = map[injectValue]
+  inject(key, value)
+}

--- a/test/unit/basic.plugins.test.js
+++ b/test/unit/basic.plugins.test.js
@@ -18,6 +18,22 @@ describe('with-config', () => {
     expect(window.__test_plugin).toBe(true)
   })
 
+  test('inject fails if value is undefined', async () => {
+    // inject('injectedProperty', undefined)
+    await expect(nuxt.renderRoute('/?injectValue=undefined')).rejects.toThrowError('inject(key, value) has no value provided')
+  })
+
+  test('inject succeeds if value is defined but evaluates to false', async () => {
+    // inject('injectedProperty', null)
+    await expect(nuxt.renderRoute('/?injectValue=null')).resolves.not.toThrowError()
+    // inject('injectedProperty', false)
+    await expect(nuxt.renderRoute('/?injectValue=false')).resolves.not.toThrowError()
+    // inject('injectedProperty', 0)
+    await expect(nuxt.renderRoute('/?injectValue=0')).resolves.not.toThrowError()
+    // inject('injectedProperty', '')
+    await expect(nuxt.renderRoute('/?injectValue=empty')).resolves.not.toThrowError()
+  })
+
   // Close server and ask nuxt to stop listening to file changes
   afterAll(async () => {
     await nuxt.close()


### PR DESCRIPTION
## Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description

This change prevents the `inject()` method from throwing an error if provided value is defined but evaluates to `false`. It can be useful to inject a boolean or other "falsy" value.


## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

I've been trying to add some tests for the `inject()` method but having trouble with my Nuxt setup at the moment.