### PR TITLE
feat(cli): use cjs dist stub in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "coverage": "codecov",
     "lint": "eslint --ext .js,.mjs,.vue .",
     "lint:app": "eslint-multiplexer eslint --ignore-path packages/app/template/.eslintignore 'test/fixtures/!(missing-plugin)/.nuxt!(-dev)/**' | eslint-multiplexer -b",
-    "nuxt": "./packages/cli/bin/nuxt.js",
+    "nuxt": "node -r esm ./packages/cli/bin/nuxt.js",
     "test": "yarn test:fixtures && yarn test:unit",
     "test:fixtures": "jest test/fixtures",
     "test:e2e": "jest -i test/e2e",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "coverage": "codecov",
     "lint": "eslint --ext .js,.mjs,.vue .",
     "lint:app": "eslint-multiplexer eslint --ignore-path packages/app/template/.eslintignore 'test/fixtures/!(missing-plugin)/.nuxt!(-dev)/**' | eslint-multiplexer -b",
-    "nuxt": "node -r esm ./packages/cli/bin/nuxt.js",
+    "nuxt": "./packages/cli/bin/nuxt.js",
     "test": "yarn test:fixtures && yarn test:unit",
     "test:fixtures": "jest test/fixtures",
     "test:e2e": "jest -i test/e2e",

--- a/scripts/dev
+++ b/scripts/dev
@@ -5,6 +5,26 @@ import consola from 'consola'
 
 import Package from './package.js'
 
+const useCjs = new Set([
+  '@nuxt/cli'
+])
+
+const stub = {
+  es: `export * from '../src/index'`,
+  cjs: `const esm = require('esm')
+
+const _require = esm(module, {
+  cache: false,
+  cjs: {
+    cache: true,
+    vars: true,
+    namedExports: true
+  }
+})
+
+module.exports = _require('../src/index')
+`}
+
 async function main() {
   // Read package at current directory
   const rootPackage = new Package()
@@ -18,7 +38,7 @@ async function main() {
     consola.info(pkg.pkg.main)
     const distMain = pkg.resolvePath(pkg.pkg.main)
     await fs.mkdirp(path.dirname(distMain))
-    await fs.writeFile(distMain, `export * from '../src/index'`)
+    await fs.writeFile(distMain, useCjs.has(pkg.pkg.name) ? stub.cjs : stub.es)
   }
 }
 

--- a/test/unit/cli.test.js
+++ b/test/unit/cli.test.js
@@ -9,7 +9,7 @@ const rootDir = resolve(__dirname, '..', 'fixtures/cli')
 const url = route => 'http://localhost:' + port + route
 
 const nuxtBin = resolve(__dirname, '../../packages/cli/bin/nuxt.js')
-const spawnNuxt = (command, opts) => spawn('node', ['-r', 'esm', nuxtBin, command, rootDir], opts)
+const spawnNuxt = (command, opts) => spawn('node', [nuxtBin, command, rootDir], opts)
 
 const close = async (nuxtInt) => {
   nuxtInt.kill('SIGKILL')

--- a/test/unit/cli.test.js
+++ b/test/unit/cli.test.js
@@ -9,7 +9,7 @@ const rootDir = resolve(__dirname, '..', 'fixtures/cli')
 const url = route => 'http://localhost:' + port + route
 
 const nuxtBin = resolve(__dirname, '../../packages/cli/bin/nuxt.js')
-const spawnNuxt = (command, opts) => spawn('node', [nuxtBin, command, rootDir], opts)
+const spawnNuxt = (command, opts) => spawn(nuxtBin, [command, rootDir], opts)
 
 const close = async (nuxtInt) => {
   nuxtInt.kill('SIGKILL')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

As discussed on discord, the cli package could use a cjs stub so we dont have to use `-r esm` all the time. The other packages dont need this because they dont provide a point of entry
and are thus not directly invoked during development. They are either called through the cli or through jest when testing (and jest didnt seem to like all the esm stubs).

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

