### PR TITLE
fix: serialize config head fn shorthand correctly

### DIFF
--- a/packages/vue-app/template/App.js
+++ b/packages/vue-app/template/App.js
@@ -18,7 +18,7 @@ const layouts = { <%= Object.keys(layouts).map(key => `"_${key}": _${hash(key)}`
 
 export default {
   <%= isTest ? '/* eslint-disable quotes, semi, indent, comma-spacing, key-spacing, object-curly-spacing, object-property-newline, arrow-parens */' : '' %>
-  head: <%= serialize(head).replace(/:\w+\(/gm, ':function(') %>,
+  head: <%= serialize(head).replace(/:\w+\(/gm, ':function(').replace('head(', 'function(') %>,
   <%= isTest ? '/* eslint-enable quotes, semi, indent, comma-spacing, key-spacing, object-curly-spacing, object-property-newline, arrow-parens */' : '' %>
   render(h, props) {
     <% if (loading) { %>const loadingEl = h('nuxt-loading', { ref: 'loading' })<% } %>

--- a/test/fixtures/basic/nuxt.config.js
+++ b/test/fixtures/basic/nuxt.config.js
@@ -36,9 +36,11 @@ export default {
     interval: 200,
     subFolders: true
   },
-  head: {
-    titleTemplate: (titleChunk) => {
-      return titleChunk ? `${titleChunk} - Nuxt.js` : 'Nuxt.js'
+  head() {
+    return {
+      titleTemplate: (titleChunk) => {
+        return titleChunk ? `${titleChunk} - Nuxt.js` : 'Nuxt.js'
+      }
     }
   },
   modulesDir: path.join(__dirname, '..', '..', '..', 'node_modules'),


### PR DESCRIPTION
Applied a similar fix as in https://github.com/nuxt/nuxt.js/blob/dev/packages/vue-app/template/index.js#L41 for the `nuxt.config.js` head property (if a function shorthand is used there).

## Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

