### PR TITLE
chore: warn when styleResources is used without the community module

### DIFF
--- a/packages/webpack/src/builder.js
+++ b/packages/webpack/src/builder.js
@@ -77,8 +77,10 @@ export class WebpackBundler {
     // Check styleResource existence
     const styleResources = this.context.options.build.styleResources
     if (styleResources && Object.keys(styleResources).length) {
-      consola.warn('Using styleResources without the nuxt-style-resources-module is not suggested and can lead to severe performance issues')
-      consola.warn('Please use https://github.com/nuxt-community/style-resources-module')
+      consola.warn(
+        'Using styleResources without the nuxt-style-resources-module is not suggested and can lead to severe performance issues.',
+        'Please use https://github.com/nuxt-community/style-resources-module'
+      )
     }
     Object.keys(styleResources).forEach(async (ext) => {
       await Promise.all(wrapArray(styleResources[ext]).map(async (p) => {

--- a/packages/webpack/src/builder.js
+++ b/packages/webpack/src/builder.js
@@ -76,6 +76,10 @@ export class WebpackBundler {
 
     // Check styleResource existence
     const styleResources = this.context.options.build.styleResources
+    if (styleResources && Object.keys(styleResources).length) {
+      consola.warn('Using styleResources without the nuxt-style-resources-module is not suggested and can lead to severe performance issues')
+      consola.warn('Please use https://github.com/nuxt-community/style-resources-module')
+    }
     Object.keys(styleResources).forEach(async (ext) => {
       await Promise.all(wrapArray(styleResources[ext]).map(async (p) => {
         const styleResourceFiles = await glob(path.resolve(this.context.options.rootDir, p))

--- a/test/fixtures/with-config/with-config.test.js
+++ b/test/fixtures/with-config/with-config.test.js
@@ -22,6 +22,12 @@ describe('with-config', () => {
         additional: expect.stringContaining('plugins/test.json')
       }],
       [
+        'Using styleResources without the nuxt-style-resources-module is not suggested and can lead to severe performance issues'
+      ],
+      [
+        'Please use https://github.com/nuxt-community/style-resources-module'
+      ],
+      [
         'Notice: Please do not deploy bundles built with analyze mode, it\'s only for analyzing purpose.'
       ]
     ])

--- a/test/fixtures/with-config/with-config.test.js
+++ b/test/fixtures/with-config/with-config.test.js
@@ -14,7 +14,7 @@ const hooks = [
 
 describe('with-config', () => {
   buildFixture('with-config', () => {
-    expect(consola.warn).toHaveBeenCalledTimes(2)
+    expect(consola.warn).toHaveBeenCalledTimes(4)
     expect(consola.fatal).toHaveBeenCalledTimes(0)
     expect(consola.warn.mock.calls).toMatchObject([
       [{

--- a/test/fixtures/with-config/with-config.test.js
+++ b/test/fixtures/with-config/with-config.test.js
@@ -14,7 +14,7 @@ const hooks = [
 
 describe('with-config', () => {
   buildFixture('with-config', () => {
-    expect(consola.warn).toHaveBeenCalledTimes(4)
+    expect(consola.warn).toHaveBeenCalledTimes(3)
     expect(consola.fatal).toHaveBeenCalledTimes(0)
     expect(consola.warn.mock.calls).toMatchObject([
       [{
@@ -22,9 +22,7 @@ describe('with-config', () => {
         additional: expect.stringContaining('plugins/test.json')
       }],
       [
-        'Using styleResources without the nuxt-style-resources-module is not suggested and can lead to severe performance issues'
-      ],
-      [
+        'Using styleResources without the nuxt-style-resources-module is not suggested and can lead to severe performance issues.',
         'Please use https://github.com/nuxt-community/style-resources-module'
       ],
       [


### PR DESCRIPTION
related: #3994 

As `style-resources-loader` causes huge performance problems and we cannot easily replace or remove it as it'd be a breaking change, we should put out a warning and a reference to the drop-in replacement (https://github.com/nuxt-community/style-resources-module).

The module will set `build.styleResources` to an empty object if used, so this warning will only pop up if you are not using the module.

## Types of changes
- [x] Warning
