### PR TITLE
chore: warn on unknown mode

### DIFF
--- a/packages/cli/src/utils/index.js
+++ b/packages/cli/src/utils/index.js
@@ -56,10 +56,6 @@ export async function loadNuxtConfig(argv) {
   options.mode =
     (argv.spa && 'spa') || (argv.universal && 'universal') || options.mode
 
-  if (options.mode && !['spa', 'universal'].includes(options.mode)) {
-    consola.warn(`Unknown mode: ${options.mode}`)
-  }
-
   // Server options
   options.server = defaultsDeep({
     port: argv.port || undefined,

--- a/packages/cli/src/utils/index.js
+++ b/packages/cli/src/utils/index.js
@@ -56,7 +56,7 @@ export async function loadNuxtConfig(argv) {
   options.mode =
     (argv.spa && 'spa') || (argv.universal && 'universal') || options.mode
 
-  if (!['spa', 'universal'].includes(options.mode.toLowerCase())) {
+  if (options.mode && !['spa', 'universal'].includes(options.mode)) {
     consola.warn(`Unknown mode: ${options.mode}`)
   }
 

--- a/packages/cli/src/utils/index.js
+++ b/packages/cli/src/utils/index.js
@@ -56,6 +56,10 @@ export async function loadNuxtConfig(argv) {
   options.mode =
     (argv.spa && 'spa') || (argv.universal && 'universal') || options.mode
 
+  if (!['spa', 'universal'].includes(options.mode.toLowerCase())) {
+    consola.warn(`Unknown mode: ${options.mode}`)
+  }
+
   // Server options
   options.server = defaultsDeep({
     port: argv.port || undefined,

--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -238,11 +238,10 @@ export function getNuxtConfig(_options) {
   // Apply mode preset
   const modePreset = options.modes[options.mode || 'universal']
 
-  if (modePreset) {
-    defaultsDeep(options, modePreset)
-  } else {
-    consola.warn(`Unknown mode: ${options.mode}`)
+  if (!modePreset) {
+    consola.warn(`Unknown mode: ${options.mode}. Falling back to universal`)
   }
+  defaultsDeep(options, modePreset || options.modes.universal)
 
   if (options.modern === true) {
     options.modern = 'server'

--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -236,7 +236,7 @@ export function getNuxtConfig(_options) {
   }
 
   // Apply mode preset
-  const modePreset = options.modes[options.mode || 'universal'] || {}
+  const modePreset = options.modes[options.mode || 'universal']
 
   if (modePreset) {
     defaultsDeep(options, modePreset)  

--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -239,6 +239,10 @@ export function getNuxtConfig(_options) {
   const modePreset = options.modes[options.mode || 'universal']
   defaultsDeep(options, modePreset)
 
+  if (!modePreset || !['spa', 'universal'].includes(options.mode)) {
+    consola.warn(`Unknown mode: ${options.mode}`)
+  }
+
   if (options.modern === true) {
     options.modern = 'server'
   }

--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -236,10 +236,11 @@ export function getNuxtConfig(_options) {
   }
 
   // Apply mode preset
-  const modePreset = options.modes[options.mode || 'universal']
-  defaultsDeep(options, modePreset)
+  const modePreset = options.modes[options.mode || 'universal'] || {}
 
-  if (!modePreset || !['spa', 'universal'].includes(options.mode)) {
+  if (modePreset) {
+    defaultsDeep(options, modePreset)  
+  } else {
     consola.warn(`Unknown mode: ${options.mode}`)
   }
 

--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -239,7 +239,7 @@ export function getNuxtConfig(_options) {
   const modePreset = options.modes[options.mode || 'universal']
 
   if (modePreset) {
-    defaultsDeep(options, modePreset)  
+    defaultsDeep(options, modePreset)
   } else {
     consola.warn(`Unknown mode: ${options.mode}`)
   }

--- a/test/fixtures/with-config/nuxt.config.js
+++ b/test/fixtures/with-config/nuxt.config.js
@@ -2,6 +2,7 @@ import path from 'path'
 import compression from 'compression'
 
 export default {
+  mode: 'unknown',
   srcDir: __dirname,
   server: {
     port: 8000,

--- a/test/fixtures/with-config/with-config.test.js
+++ b/test/fixtures/with-config/with-config.test.js
@@ -14,7 +14,7 @@ const hooks = [
 
 describe('with-config', () => {
   buildFixture('with-config', () => {
-    expect(consola.warn).toHaveBeenCalledTimes(3)
+    expect(consola.warn).toHaveBeenCalledTimes(4)
     expect(consola.fatal).toHaveBeenCalledTimes(0)
     expect(consola.warn.mock.calls).toMatchObject([
       [

--- a/test/fixtures/with-config/with-config.test.js
+++ b/test/fixtures/with-config/with-config.test.js
@@ -17,6 +17,9 @@ describe('with-config', () => {
     expect(consola.warn).toHaveBeenCalledTimes(3)
     expect(consola.fatal).toHaveBeenCalledTimes(0)
     expect(consola.warn.mock.calls).toMatchObject([
+      [
+        'Unknown mode: unknown'
+      ],
       [{
         message: 'Found 2 plugins that match the configuration, suggest to specify extension:',
         additional: expect.stringContaining('plugins/test.json')

--- a/test/fixtures/with-config/with-config.test.js
+++ b/test/fixtures/with-config/with-config.test.js
@@ -18,7 +18,7 @@ describe('with-config', () => {
     expect(consola.fatal).toHaveBeenCalledTimes(0)
     expect(consola.warn.mock.calls).toMatchObject([
       [
-        'Unknown mode: unknown'
+        'Unknown mode: unknown. Falling back to universal'
       ],
       [{
         message: 'Found 2 plugins that match the configuration, suggest to specify extension:',


### PR DESCRIPTION
Warn if mode is neither `spa` nor `universal`.

## Types of changes
- [x] Warning
