### PR TITLE
fix: dev tools detection of custom global name

### DIFF
--- a/packages/vue-app/template/App.js
+++ b/packages/vue-app/template/App.js
@@ -60,7 +60,7 @@ export default {
     if (typeof window !== 'undefined') {
       window.<%= globals.nuxt %> = this
       <% if (globals.nuxt !== '$nuxt') { %>
-      window.$nuxt = this
+      window.$nuxt = { $root: { constructor: this.$root.constructor } }
       <% } %>
     }
     // Add $nuxt.error()

--- a/packages/vue-app/template/App.js
+++ b/packages/vue-app/template/App.js
@@ -60,7 +60,7 @@ export default {
     if (typeof window !== 'undefined') {
       window.<%= globals.nuxt %> = this
       <% if (globals.nuxt !== '$nuxt') { %>
-      window.$nuxt = true
+      window.$nuxt = this
       <% } %>
     }
     // Add $nuxt.error()


### PR DESCRIPTION
See #4296 -- apparently we need to maintain the reference to the Vue object.