### PR TITLE
feat: add option to push minification at the end

### DIFF
--- a/packages/webpack/src/config/utils/postcss.js
+++ b/packages/webpack/src/config/utils/postcss.js
@@ -129,6 +129,11 @@ export default class PostcssConfig {
         config = merge({}, this.defaultConfig, config)
         this.loadPlugins(config)
       }
+      if (config.options && config.options.pushCssNano) {
+        const cssnanoIndex = config.plugins.findIndex(p => p.postcssPlugin.toString() === 'cssnano')
+        const cssnanoPlugin = config.plugins.splice(cssnanoIndex, 1)
+        config.plugins.push(cssnanoPlugin[0])
+      }
       return config
     }
   }


### PR DESCRIPTION
Currently, we have no real way to control the order of the loaded postCSS plugins while saving the defaults (as they are provided as `object` to get merged with the defaults). Until Nuxt 3.0 we can't change the array behavior as well because we can't introduce breaking changes.

This leads to problems where CSS minification won't succeed as plugins are used after `cssnano` is executed.

The option `pushCssNano` will move the `cssnano` plugin to the end of the plugin array, so it'll be executed **last**

## Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

