### PR TITLE
refactor: styleLoader and postcss

### DIFF
--- a/packages/webpack/src/config/utils/postcss.js
+++ b/packages/webpack/src/config/utils/postcss.js
@@ -7,6 +7,16 @@ import createResolver from 'postcss-import-resolver'
 
 import { isPureObject } from '@nuxt/common'
 
+export const orderPresets = {
+  cssnanoLast: (names) => {
+    const nanoIndex = names.indexOf('cssnano')
+    if (nanoIndex !== names.length - 1) {
+      names.push(names.splice(nanoIndex, 1)[0])
+    }
+    return names
+  }
+}
+
 export default class PostcssConfig {
   constructor(options, nuxt) {
     this.nuxt = nuxt
@@ -46,13 +56,8 @@ export default class PostcssConfig {
         'postcss-preset-env': this.preset || {},
         'cssnano': this.dev ? false : { preset: 'default' }
       },
-      order(names) {
-        const nanoIndex = names.indexOf('cssnano')
-        if (nanoIndex !== names.length - 1) {
-          names.push(names.splice(nanoIndex, 1)[0])
-        }
-        return names
-      }
+      // Array, String or Function
+      order: 'cssnanoLast'
     }
   }
 
@@ -96,6 +101,9 @@ export default class PostcssConfig {
 
   sortPlugins({ plugins, order }) {
     const names = Object.keys(plugins)
+    if (typeof order === 'string') {
+      order = orderPresets[order]
+    }
     return typeof order === 'function' ? order(names) : (order || names)
   }
 

--- a/packages/webpack/src/config/utils/postcss.js
+++ b/packages/webpack/src/config/utils/postcss.js
@@ -104,7 +104,7 @@ export default class PostcssConfig {
     if (typeof order === 'string') {
       order = orderPresets[order]
     }
-    return typeof order === 'function' ? order(names) : (order || names)
+    return typeof order === 'function' ? order(names, orderPresets) : (order || names)
   }
 
   loadPlugins(config) {

--- a/packages/webpack/src/config/utils/postcss.js
+++ b/packages/webpack/src/config/utils/postcss.js
@@ -45,6 +45,13 @@ export default class PostcssConfig {
         // https://github.com/csstools/postcss-preset-env
         'postcss-preset-env': this.preset || {},
         'cssnano': this.dev ? false : { preset: 'default' }
+      },
+      order(names) {
+        const nanoIndex = names.indexOf('cssnano')
+        if (nanoIndex !== names.length - 1) {
+          names.push(names.splice(nanoIndex, 1)[0])
+        }
+        return names
       }
     }
   }
@@ -87,11 +94,16 @@ export default class PostcssConfig {
     return config
   }
 
+  sortPlugins({ plugins, order }) {
+    const names = Object.keys(plugins)
+    return typeof order === 'function' ? order(names) : (order || names)
+  }
+
   loadPlugins(config) {
     const plugins = config.plugins
     if (isPureObject(plugins)) {
       // Map postcss plugins into instances on object mode once
-      config.plugins = Object.keys(plugins)
+      config.plugins = this.sortPlugins(config)
         .map((p) => {
           const plugin = require(p)
           const opts = plugins[p]

--- a/packages/webpack/src/config/utils/style-loader.js
+++ b/packages/webpack/src/config/utils/style-loader.js
@@ -14,7 +14,10 @@ export default class StyleLoader {
     this.assetsDir = options.dir.assets
     this.staticDir = options.dir.static
     this.rootDir = options.rootDir
-    this.loaders = options.build.loaders
+    this.loaders = {
+      css: options.build.loaders.css,
+      cssModules: options.build.loaders.cssModules
+    }
     this.extractCSS = options.build.extractCSS
     this.resources = options.build.styleResources
     this.sourceMap = Boolean(options.build.cssSourceMap)
@@ -96,8 +99,7 @@ export default class StyleLoader {
       this.styleResource(ext)
     ).filter(Boolean)
 
-    const { css: cssOptions, cssModules: cssModulesOptions } = this.loaders
-    cssOptions.importLoaders = cssModulesOptions.importLoaders = customLoaders.length
+    this.loaders.css.importLoaders = this.loaders.cssModules.importLoaders = customLoaders.length
 
     const styleLoader = this.extract() || this.vueStyle()
 
@@ -107,7 +109,7 @@ export default class StyleLoader {
         resourceQuery: /module/,
         use: this.perfLoader.css().concat(
           styleLoader,
-          this.cssModules(cssModulesOptions),
+          this.cssModules(this.loaders.cssModules),
           customLoaders
         )
       },
@@ -115,7 +117,7 @@ export default class StyleLoader {
       {
         use: this.perfLoader.css().concat(
           styleLoader,
-          this.css(cssOptions),
+          this.css(this.loaders.css),
           customLoaders
         )
       }

--- a/packages/webpack/src/config/utils/style-loader.js
+++ b/packages/webpack/src/config/utils/style-loader.js
@@ -94,7 +94,7 @@ export default class StyleLoader {
 
   apply(ext, loaders = []) {
     const customLoaders = [].concat(
-      this.postcss(loaders),
+      this.postcss(),
       this.normalize(loaders),
       this.styleResource(ext)
     ).filter(Boolean)

--- a/test/fixtures/basic/nuxt.config.js
+++ b/test/fixtures/basic/nuxt.config.js
@@ -77,7 +77,8 @@ export default {
         }
       },
       plugins: {
-        cssnano: {}
+        cssnano: {},
+        [path.resolve(__dirname, 'plugins', 'tailwind.js')]: {}
       }
     }
   }

--- a/test/fixtures/basic/plugins/tailwind.js
+++ b/test/fixtures/basic/plugins/tailwind.js
@@ -1,0 +1,6 @@
+
+const postcss = require('postcss')
+
+module.exports = postcss.plugin('nuxt-test', () => {
+  return function () {}
+})

--- a/test/unit/basic.dev.test.js
+++ b/test/unit/basic.dev.test.js
@@ -10,6 +10,7 @@ let transpile = null
 let output = null
 let loadersOptions
 let vueLoader
+let postcssLoader
 
 describe('basic dev', () => {
   beforeAll(async () => {
@@ -40,6 +41,8 @@ describe('basic dev', () => {
             output = wpOutput
             loadersOptions = loaders
             vueLoader = rules.find(loader => loader.test.test('.vue'))
+            const cssLoaders = rules.find(loader => loader.test.test('.css')).oneOf[0].use
+            postcssLoader = cssLoaders[cssLoaders.length - 1]
           }
         }
       }
@@ -80,6 +83,19 @@ describe('basic dev', () => {
     const { cssModules, vue } = loadersOptions
     expect(cssModules.localIdentName).toBe('[hash:base64:6]')
     expect(vueLoader.options).toBe(vue)
+  })
+
+  test('Config: cssnano is at then end of postcss plugins', () => {
+    const plugins = postcssLoader.options.plugins.map((plugin) => {
+      return plugin.postcssPlugin
+    })
+    expect(plugins).toEqual([
+      'postcss-import',
+      'postcss-url',
+      'postcss-preset-env',
+      'nuxt-test',
+      'cssnano'
+    ])
   })
 
   test('/stateless', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

Related to #4313, let's discuss a proper solution @Atinux @pi0 @manniL .

Introduced `order` in `postcss` object config:

```js
postcss: {
  preset: {...},
  plugins: {...},
  order(names, presets) {
    return ...
  }
}
```

`order` supports:

1. Array: the ordered plugins names, `['postcss-import', 'postcss-preset-env', 'cssnano']`
1. String: name of one order preset, 'cssnanoLast' (put `cssnanao` in last), this is the `default` value.
1. Function: parameters are `names(all plugins names)` and `presets(all predefined order presets)`, `order: (names, presets) => presets.cssnanoLast(names)`

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

