### PR TITLE
fix(core): stable route sorting

### DIFF
--- a/packages/common/src/utils.js
+++ b/packages/common/src/utils.js
@@ -290,11 +290,20 @@ const sortRoutes = function sortRoutes(routes) {
       res = y - z
       // If a.length >= b.length
       if (i === _b.length - 1 && res === 0) {
-        // sort alphabetically unless * found
-        res = _a[i] === '*' ? -1 : a.path.localeCompare(b.path)
+        // unless * found sort by level, then alphabetically
+        res = _a[i] === '*' ? -1 : (
+          _a.length === _b.length ? a.path.localeCompare(b.path) : (_a.length - _b.length)
+        )
       }
     }
-    return res === 0 ? (_a[i - 1] === '*' && _b[i] ? 1 : -1) : res
+
+    if (res === 0) {
+      // unless * found sort by level, then alphabetically
+      res = _a[i - 1] === '*' && _b[i] ? 1 : (
+        _a.length === _b.length ? a.path.localeCompare(b.path) : (_a.length - _b.length)
+      )
+    }
+    return res
   })
 
   routes.forEach((route) => {

--- a/test/unit/dynamic-routes.test.js
+++ b/test/unit/dynamic-routes.test.js
@@ -20,8 +20,16 @@ describe('dynamic routes', () => {
       )
       const routes = eval('( ' + routerFile + ')') // eslint-disable-line no-eval
       // pages/test/index.vue
-      expect(routes[0].path).toBe('/test')
-      expect(routes[0].name).toBe('test')
+      expect(routes[0].path).toBe('/parent')
+      expect(routes[0].name).toBeFalsy() // parent route has no name
+      // pages/parent/*.vue
+      expect(routes[0].children.length).toBe(3) // parent has 3 children
+      expect(routes[0].children.map(r => r.path)).toEqual(['', 'child', 'teub'])
+      expect(routes[0].children.map(r => r.name)).toEqual([
+        'parent',
+        'parent-child',
+        'parent-teub'
+      ])
       // pages/posts.vue
       expect(routes[1].path).toBe('/posts')
       expect(routes[1].name).toBe('posts')
@@ -30,16 +38,8 @@ describe('dynamic routes', () => {
       expect(routes[1].children[0].path).toBe(':id?')
       expect(routes[1].children[0].name).toBe('posts-id')
       // pages/parent.vue
-      expect(routes[2].path).toBe('/parent')
-      expect(routes[2].name).toBeFalsy() // parent route has no name
-      // pages/parent/*.vue
-      expect(routes[2].children.length).toBe(3) // parent has 3 children
-      expect(routes[2].children.map(r => r.path)).toEqual(['', 'teub', 'child'])
-      expect(routes[2].children.map(r => r.name)).toEqual([
-        'parent',
-        'parent-teub',
-        'parent-child'
-      ])
+      expect(routes[2].path).toBe('/test')
+      expect(routes[2].name).toBe('test')
       // pages/test/projects/index.vue
       expect(routes[3].path).toBe('/test/projects')
       expect(routes[3].name).toBe('test-projects')

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -303,16 +303,16 @@ test('createRoutes should allow snake case routes', () => {
   const routesResult = Utils.createRoutes(files, srcDir, pagesDir)
   const expectedResult = [
     {
-      name: 'snake_case_route',
-      path: '/snake_case_route',
-      component: Utils.r('/some/nuxt/app/pages/snake_case_route.vue'),
-      chunkName: 'pages/snake_case_route'
-    },
-    {
       name: 'another_route-id',
       path: '/another_route/:id?',
       component: Utils.r('/some/nuxt/app/pages/another_route/_id.vue'),
       chunkName: 'pages/another_route/_id'
+    },
+    {
+      name: 'snake_case_route',
+      path: '/snake_case_route',
+      component: Utils.r('/some/nuxt/app/pages/snake_case_route.vue'),
+      chunkName: 'pages/snake_case_route'
     },
     {
       name: 'subpage-param',

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -303,16 +303,16 @@ test('createRoutes should allow snake case routes', () => {
   const routesResult = Utils.createRoutes(files, srcDir, pagesDir)
   const expectedResult = [
     {
-      name: 'another_route-id',
-      path: '/another_route/:id?',
-      component: Utils.r('/some/nuxt/app/pages/another_route/_id.vue'),
-      chunkName: 'pages/another_route/_id'
-    },
-    {
       name: 'snake_case_route',
       path: '/snake_case_route',
       component: Utils.r('/some/nuxt/app/pages/snake_case_route.vue'),
       chunkName: 'pages/snake_case_route'
+    },
+    {
+      name: 'another_route-id',
+      path: '/another_route/:id?',
+      component: Utils.r('/some/nuxt/app/pages/another_route/_id.vue'),
+      chunkName: 'pages/another_route/_id'
     },
     {
       name: 'subpage-param',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

This PR fixes route sorting in Node v11 (fix #4188).

The problem was caused because the route sorting in Nuxt was inherently unstable due to default ordering to be dictated by the order in which elements where compared. This caused issues in v11 because quicksort compares `arr[0]` with `arr[1]` but timsort does `arr[0]` with `arr[arr.length - 1]`. 
E.g. if you look at the `dynamic-routes` test then with quicksort it compared `parent` to `test` but in timsort it compared `test` to `parent`. As the default behaviour of route sorting was to return `1`, this meant that if there was no 'special' case `a` was always sorted after `b` regardless of its actual value (hence the inherently unstable). This PR changes this behaviour to alphabetically sort a and b (with `localeCompare`) if there is no 'special' case.

I have also moved route sorting outside the forEach loop, there is no need to sort the routes array on every intermediate step and it probably saves a little bit of time to only sort it once.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

