### PR TITLE
feat: Process transpile path

### DIFF
--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -2,6 +2,7 @@ import path from 'path'
 import fs from 'fs'
 import defaultsDeep from 'lodash/defaultsDeep'
 import defaults from 'lodash/defaults'
+import escapeRegExp from 'lodash/escapeRegExp'
 import pick from 'lodash/pick'
 import isObject from 'lodash/isObject'
 import consola from 'consola'
@@ -320,7 +321,12 @@ export function getNuxtConfig(_options) {
 
   // include SFCs in node_modules
   options.build.transpile = [].concat(options.build.transpile || [])
-    .map(module => module instanceof RegExp ? module : new RegExp(module))
+    .map(module => (module instanceof RegExp)
+      ? module
+      : new RegExp(
+        escapeRegExp(path.join(module))
+      )
+    )
 
   if (options.build.quiet === true) {
     consola.level = 0

--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -324,7 +324,7 @@ export function getNuxtConfig(_options) {
     .map(module => (module instanceof RegExp)
       ? module
       : new RegExp(
-        escapeRegExp(path.join(module))
+        escapeRegExp(path.normalize(module))
       )
     )
 

--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -324,7 +324,11 @@ export function getNuxtConfig(_options) {
     .map(module => (module instanceof RegExp)
       ? module
       : new RegExp(
-        escapeRegExp(path.normalize(module))
+        escapeRegExp(
+          path.normalize(
+            module.replace(/\\/g, '/')
+          )
+        )
       )
     )
 

--- a/test/unit/basic.dev.test.js
+++ b/test/unit/basic.dev.test.js
@@ -62,11 +62,11 @@ describe('basic dev', () => {
 
   test('Config: build.transpile', () => {
     expect(transpile('vue-test')).toBe(true)
-    expect(transpile(path.join('node_modules/test.js'))).toBe(false)
-    expect(transpile(path.join('node_modules/vue-test'))).toBe(true)
-    expect(transpile(path.join('node_modules/vue.test.js'))).toBe(true)
-    expect(transpile(path.join('node_modules/test.vue.js'))).toBe(true)
-    expect(transpile(path.join('node_modules/@scoped/packageA/src/index.js'))).toBe(true)
+    expect(transpile(path.normalize('node_modules/test.js'))).toBe(false)
+    expect(transpile(path.normalize('node_modules/vue-test'))).toBe(true)
+    expect(transpile(path.normalize('node_modules/vue.test.js'))).toBe(true)
+    expect(transpile(path.normalize('node_modules/test.vue.js'))).toBe(true)
+    expect(transpile(path.normalize('node_modules/@scoped/packageA/src/index.js'))).toBe(true)
   })
 
   test('Config: build.filenames', () => {

--- a/test/unit/basic.dev.test.js
+++ b/test/unit/basic.dev.test.js
@@ -28,7 +28,7 @@ describe('basic dev', () => {
         },
         transpile: [
           '@scoped/packageA',
-          'vue\\.test\\.js',
+          'vue.test.js',
           /vue-test/
         ],
         loaders: {

--- a/test/unit/basic.dev.test.js
+++ b/test/unit/basic.dev.test.js
@@ -1,3 +1,4 @@
+import path from 'path'
 import consola from 'consola'
 import { Builder, BundleBuilder, getPort, loadFixture, Nuxt, rp } from '../utils'
 
@@ -60,10 +61,10 @@ describe('basic dev', () => {
 
   test('Config: build.transpile', () => {
     expect(transpile('vue-test')).toBe(true)
-    expect(transpile('node_modules/test.js')).toBe(false)
-    expect(transpile('node_modules/vue-test')).toBe(true)
-    expect(transpile('node_modules/vue.test.js')).toBe(true)
-    expect(transpile('node_modules/test.vue.js')).toBe(true)
+    expect(transpile(path.join('node_modules/test.js'))).toBe(false)
+    expect(transpile(path.join('node_modules/vue-test'))).toBe(true)
+    expect(transpile(path.join('node_modules/vue.test.js'))).toBe(true)
+    expect(transpile(path.join('node_modules/test.vue.js'))).toBe(true)
   })
 
   test('Config: build.filenames', () => {

--- a/test/unit/basic.dev.test.js
+++ b/test/unit/basic.dev.test.js
@@ -27,6 +27,7 @@ describe('basic dev', () => {
           chunk: 'test-[name].[contenthash].js'
         },
         transpile: [
+          '@scoped/packageA',
           'vue\\.test\\.js',
           /vue-test/
         ],
@@ -65,6 +66,7 @@ describe('basic dev', () => {
     expect(transpile(path.join('node_modules/vue-test'))).toBe(true)
     expect(transpile(path.join('node_modules/vue.test.js'))).toBe(true)
     expect(transpile(path.join('node_modules/test.vue.js'))).toBe(true)
+    expect(transpile(path.join('node_modules/@scoped/packageA/src/index.js'))).toBe(true)
   })
 
   test('Config: build.filenames', () => {

--- a/test/unit/basic.dev.test.js
+++ b/test/unit/basic.dev.test.js
@@ -28,6 +28,7 @@ describe('basic dev', () => {
         },
         transpile: [
           '@scoped/packageA',
+          '@scoped\\packageB',
           'vue.test.js',
           /vue-test/
         ],
@@ -67,6 +68,7 @@ describe('basic dev', () => {
     expect(transpile(path.normalize('node_modules/vue.test.js'))).toBe(true)
     expect(transpile(path.normalize('node_modules/test.vue.js'))).toBe(true)
     expect(transpile(path.normalize('node_modules/@scoped/packageA/src/index.js'))).toBe(true)
+    expect(transpile(path.normalize('node_modules/@scoped/packageB/src/index.js'))).toBe(true)
   })
 
   test('Config: build.filenames', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
This PR aimed to resolve issue #4334 by processing the plain string entry of `options.build.transpile`.

The processing includes:
1. convert given path to os friendly file path (using path.normalize)
2. sanitize string for RegExp (using lodash escapeRegExp)
3. convert the sanitized string to RegExp (original)
4. use this RegExp for testing (original)

However, doing this conflict with one of the test case that uses escaped RegExp string as entry. 
**input**: `'vue\\.test\\.js'`
**test**: `node_modules/vue.test.js`
This will no longer work (thus breaking change) because we will now be expecting user to write plain string instead.

Unfortunally this test is also depended on the OS as it uses `path.normalize` which its behaviour is depended on OS.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

