### PR TITLE
feat(cli): add `--devtools` option for build and generate

### DIFF
--- a/packages/cli/src/commands/build.js
+++ b/packages/cli/src/commands/build.js
@@ -19,6 +19,18 @@ export default {
         }
       }
     },
+    devtools: {
+      type: 'boolean',
+      default: false,
+      description: 'Enable devtool.',
+      prepare(cmd, options, argv) {
+        options.vue = options.vue || {}
+        options.vue.config = options.vue.config || {}
+        if (argv.devtools) {
+          options.vue.config.devtools = true
+        }
+      }
+    },
     generate: {
       type: 'boolean',
       default: true,

--- a/packages/cli/src/commands/build.js
+++ b/packages/cli/src/commands/build.js
@@ -22,7 +22,7 @@ export default {
     devtools: {
       type: 'boolean',
       default: false,
-      description: 'Enable devtool.',
+      description: 'Enable Vue devtools',
       prepare(cmd, options, argv) {
         options.vue = options.vue || {}
         options.vue.config = options.vue.config || {}

--- a/packages/cli/src/commands/generate.js
+++ b/packages/cli/src/commands/generate.js
@@ -12,14 +12,14 @@ export default {
       default: true,
       description: 'Only generate pages for dynamic routes. Nuxt has to be built once before using this option'
     },
-    development: {
+    devtools: {
       type: 'boolean',
       default: false,
       description: 'Enable devtool.',
       prepare(cmd, options, argv) {
         options.vue = options.vue || {}
         options.vue.config = options.vue.config || {}
-        if (argv.development) {
+        if (argv.devtools) {
           options.vue.config.devtools = true
         }
       }

--- a/packages/cli/src/commands/generate.js
+++ b/packages/cli/src/commands/generate.js
@@ -15,7 +15,7 @@ export default {
     devtools: {
       type: 'boolean',
       default: false,
-      description: 'Enable devtool.',
+      description: 'Enable Vue devtools',
       prepare(cmd, options, argv) {
         options.vue = options.vue || {}
         options.vue.config = options.vue.config || {}

--- a/packages/cli/src/commands/generate.js
+++ b/packages/cli/src/commands/generate.js
@@ -12,6 +12,18 @@ export default {
       default: true,
       description: 'Only generate pages for dynamic routes. Nuxt has to be built once before using this option'
     },
+    development: {
+      type: 'boolean',
+      default: false,
+      description: 'Enable devtool.',
+      prepare(cmd, options, argv) {
+        options.vue = options.vue || {}
+        options.vue.config = options.vue.config || {}
+        if (argv.development) {
+          options.vue.config.devtools = true
+        }
+      }
+    },
     modern: {
       ...common.modern,
       description: 'Generate app in modern build (modern mode can be only client)',

--- a/packages/cli/test/unit/build.test.js
+++ b/packages/cli/test/unit/build.test.js
@@ -44,6 +44,25 @@ describe('build', () => {
     expect(process.exit).toHaveBeenCalled()
   })
 
+  test('build with devtools', async () => {
+    mockGetNuxt({
+      mode: 'universal'
+    })
+    const builder = mockGetBuilder(Promise.resolve())
+
+    const cmd = NuxtCommand.from(build)
+    const args = ['build', '.', '--devtools']
+    const argv = cmd.getArgv(args)
+    argv._ = ['.']
+
+    const options = await cmd.getNuxtConfig(argv)
+
+    await cmd.run()
+
+    expect(options.vue.config.devtools).toBe(true)
+    expect(builder).toHaveBeenCalled()
+  })
+
   test('catches error', async () => {
     mockGetNuxt({ mode: 'universal' })
     mockGetBuilder(Promise.reject(new Error('Builder Error')))

--- a/packages/cli/test/unit/generate.test.js
+++ b/packages/cli/test/unit/generate.test.js
@@ -46,6 +46,24 @@ describe('generate', () => {
     Command.prototype.getArgv = getArgv
   })
 
+  test('build with development', async () => {
+    mockGetNuxt()
+    const generator = mockGetGenerator(Promise.resolve())
+
+    const cmd = NuxtCommand.from(generate)
+    const args = ['generate', '.', '--development']
+    const argv = cmd.getArgv(args)
+    argv._ = ['.']
+
+    const options = await cmd.getNuxtConfig(argv)
+
+    await cmd.run()
+
+    expect(options.vue.config.devtools).toBe(true)
+    expect(generator).toHaveBeenCalled()
+    expect(generator.mock.calls[0][0].build).toBe(true)
+  })
+
   test('catches error', async () => {
     mockGetNuxt()
     mockGetGenerator(Promise.reject(new Error('Generator Error')))

--- a/packages/cli/test/unit/generate.test.js
+++ b/packages/cli/test/unit/generate.test.js
@@ -46,12 +46,12 @@ describe('generate', () => {
     Command.prototype.getArgv = getArgv
   })
 
-  test('build with development', async () => {
+  test('build with devtools', async () => {
     mockGetNuxt()
     const generator = mockGetGenerator(Promise.resolve())
 
     const cmd = NuxtCommand.from(generate)
-    const args = ['generate', '.', '--development']
+    const args = ['generate', '.', '--devtools']
     const argv = cmd.getArgv(args)
     argv._ = ['.']
 


### PR DESCRIPTION
## Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
This PR aimed to resolve issue #4117.

This PR adds  `devtools` option to nuxt-generate.
Whee `devtools` option is enabled, devtool is enabled and debugging is easy.

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. (PR: nuxt/docs#991)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

