### PR TITLE
support named views for extendRoutes config

### DIFF
--- a/lib/app/router.js
+++ b/lib/app/router.js
@@ -2,13 +2,29 @@ import Vue from 'vue'
 import Router from 'vue-router'
 
 <% function recursiveRoutes(routes, tab, components) {
-  let res = ''
+  let res = '', resMap = ''
   routes.forEach((route, i) => {
-    route._name = '_' + hash(route.component)
-    components.push({ _name: route._name, component: route.component, name: route.name, chunkName: route.chunkName })
+    if(route.components) {
+      let _name = '_' + hash(route.components.default)
+      resMap += '\n\t\t' + tab + 'default: ' + (splitChunks.pages ? _name : `() => ${_name}.default || ${_name}`)
+      Object.keys(route.components).map(function(k){
+        _name = '_' + hash(route.components[k])
+        if (k === 'default') {
+          components.push({_name: _name, component: route.components[k], name: route.name, chunkName: route.chunkName})
+        } else {
+          components.push({_name: _name, component: route.components[k], name: route.name + '-' + k, chunkName: route.chunkNames[k]})
+          resMap += ',\n\t\t' + tab + k + ': ' + (splitChunks.pages ? _name : `() => ${_name}.default || ${_name}`)
+        }
+      });
+      route.component = false
+    } else {
+      route._name = '_' + hash(route.component)
+      components.push({_name: route._name, component: route.component, name: route.name, chunkName: route.chunkName})
+    }
     // @see: https://router.vuejs.org/api/#router-construction-options
     res += tab + '{\n'
     res += tab + '\tpath: ' + JSON.stringify(route.path)
+    res += (route.components) ? ',\n\t' + tab + 'components: {' + resMap + '\n\t' + tab + '}' : ''
     res += (route.component) ? ',\n\t' + tab + 'component: ' + (splitChunks.pages ? route._name : `() => ${route._name}.default || ${route._name}`) : ''
     res += (route.redirect) ? ',\n\t' + tab + 'redirect: ' + JSON.stringify(route.redirect) : ''
     res += (route.meta) ? ',\n\t' + tab + 'meta: ' + JSON.stringify(route.meta) : ''


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
This change have some side effect for extendRoutes config. If you want to use named views, route item must contain `chunkNames` for each named component(except `default`).
For example:
```
  router: {
    extendRoutes(routes, resolve) {
      let index = routes[0].children.findIndex(route => route.name === 'index-service-id');
      let child = routes[0].children[index];
      child.components = {
        default: child.component,
        left: resolve(__dirname, '../components/ServiceLeft.vue'),
      };
      child.chunkNames = {
        left: 'components/ServiceLeft'
      };
      routes[0].children[index] = child;
    },
  },
```
If community can help resolve chunk name from component's path, it is would be great and there is no need to hardcode chunkNames manually.

Resolves: #4100


## Checklist:
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

