### PR TITLE
feat: allow `lang="postcss"` in Vue SFCs

### DIFF
--- a/packages/webpack/src/config/base.js
+++ b/packages/webpack/src/config/base.js
@@ -195,7 +195,7 @@ export default class WebpackBaseConfig {
         })
       },
       {
-        test: /\.css$/,
+        test: /\.(post)?css$/,
         oneOf: styleLoader.apply('css')
       },
       {

--- a/packages/webpack/src/config/base.js
+++ b/packages/webpack/src/config/base.js
@@ -195,8 +195,12 @@ export default class WebpackBaseConfig {
         })
       },
       {
-        test: /\.(post)?css$/,
+        test: /\.css$/,
         oneOf: styleLoader.apply('css')
+      },
+      {
+        test: /\.postcss$/,
+        oneOf: styleLoader.apply('postcss')
       },
       {
         test: /\.less$/,

--- a/test/fixtures/basic/pages/postcss.vue
+++ b/test/fixtures/basic/pages/postcss.vue
@@ -1,0 +1,15 @@
+<template>
+  <div class="red">
+    This is red
+  </div>
+</template>
+
+<style lang="postcss">
+@custom-selector :--red div.red;
+:--red {
+  background-color: blue;
+}
+.red {
+  color: red;
+}
+</style>

--- a/test/unit/basic.ssr.test.js
+++ b/test/unit/basic.ssr.test.js
@@ -44,6 +44,19 @@ describe('basic ssr', () => {
     const window = await nuxt.server.renderAndGetWindow(url('/css'))
 
     const headHtml = window.document.head.innerHTML
+    expect(headHtml).toContain('color:red')
+
+    const element = window.document.querySelector('.red')
+    expect(element).not.toBe(null)
+    expect(element.textContent).toContain('This is red')
+    expect(element.className).toBe('red')
+    // t.is(window.getComputedStyle(element).color, 'red')
+  })
+
+  test('/postcss', async () => {
+    const window = await nuxt.server.renderAndGetWindow(url('/css'))
+
+    const headHtml = window.document.head.innerHTML
     expect(headHtml).toContain('background-color:#00f')
 
     // const element = window.document.querySelector('div.red')


### PR DESCRIPTION
Support style tag with `lang="postcss"` attribute (and treat it the same way as normal style tag) in Vue SFCs.

~Not sure if we should classify it as bugfix or~ feature

Resolves: https://github.com/nuxt/nuxt.js/issues/4061

## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

