### PR TITLE
feat(modern): auto detect modern mode

### DIFF
--- a/packages/config/src/config/_common.js
+++ b/packages/config/src/config/_common.js
@@ -12,7 +12,7 @@ export default () => ({
 
   // Mode
   mode: 'universal',
-  modern: false,
+  modern: undefined,
 
   // Globals
   globalName: `nuxt`,

--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -253,10 +253,6 @@ export function getNuxtConfig(_options) {
   }
   defaultsDeep(options, modePreset || options.modes.universal)
 
-  if (options.modern === true) {
-    options.modern = 'server'
-  }
-
   // If no server-side rendering, add appear true transition
   /* istanbul ignore if */
   if (options.render.ssr === false && options.transition) {

--- a/packages/server/src/middleware/modern.js
+++ b/packages/server/src/middleware/modern.js
@@ -1,3 +1,5 @@
+import chalk from 'chalk'
+import consola from 'consola'
 import { ModernBrowsers } from '@nuxt/common'
 import { matchesUA } from 'browserslist-useragent'
 
@@ -11,12 +13,33 @@ const isModernBrowser = (ua) => {
   })
 }
 
-export default function (req, res, next) {
-  const { socket = {}, headers } = req
-  if (socket.modernMode === undefined) {
-    const ua = headers && headers['user-agent']
-    socket.modernMode = isModernBrowser(ua)
+let detected = false
+
+const detectModernBuild = ({ options, resources }) => {
+  if (detected === false && ![false, 'client', 'server'].includes(options.modern)) {
+    detected = true
+    if (resources.modernManifest) {
+      options.modern = options.render.ssr ? 'server' : 'client'
+      consola.info(`Modern bundles are detected. Modern mode (${chalk.green.bold(options.modern)}) is enabled now.`)
+    } else {
+      options.modern = false
+    }
   }
-  req.modernMode = socket.modernMode
+}
+
+const detectModernBrowser = (req, options) => {
+  if (options.modern === 'server') {
+    const { socket = {}, headers } = req
+    if (socket.modernMode === undefined) {
+      const ua = headers && headers['user-agent']
+      socket.modernMode = isModernBrowser(ua)
+    }
+    req.modernMode = socket.modernMode
+  }
+}
+
+export default ({ context }) => (req, res, next) => {
+  detectModernBuild(context)
+  detectModernBrowser(req, context.options)
   next()
 }

--- a/packages/server/src/server.js
+++ b/packages/server/src/server.js
@@ -10,7 +10,7 @@ import renderAndGetWindow from './jsdom'
 import nuxtMiddleware from './middleware/nuxt'
 import errorMiddleware from './middleware/error'
 import Listener from './listener'
-import modernMiddleware from './middleware/modern'
+import createModernMiddleware from './middleware/modern'
 
 export default class Server {
   constructor(nuxt) {
@@ -79,12 +79,13 @@ export default class Server {
       }
     }
 
-    if (this.options.modern === 'server') {
-      this.useMiddleware(modernMiddleware)
-    }
+    const modernMiddleware = createModernMiddleware({
+      context: this.renderer.context
+    })
 
     // Add webpack middleware support only for development
     if (this.options.dev) {
+      this.useMiddleware(modernMiddleware)
       this.useMiddleware(async (req, res, next) => {
         const name = req.modernMode ? 'modern' : 'client'
         if (this.devMiddleware[name]) {
@@ -124,6 +125,7 @@ export default class Server {
           this.options.render.dist
         )
       })
+      this.useMiddleware(modernMiddleware)
     }
 
     // Add user provided middleware

--- a/packages/vue-renderer/src/renderer.js
+++ b/packages/vue-renderer/src/renderer.js
@@ -223,7 +223,8 @@ export default class VueRenderer {
       rendererOptions
     )
 
-    if (this.context.options.modern === 'server') {
+    if (this.context.resources.modernManifest &&
+      !['client', false].includes(this.context.options.modern)) {
       this.renderer.modern = createBundleRenderer(
         this.context.resources.serverBundle,
         {

--- a/test/unit/modern.server.test.js
+++ b/test/unit/modern.server.test.js
@@ -1,15 +1,23 @@
+import chalk from 'chalk'
+import consola from 'consola'
 import { loadFixture, getPort, Nuxt, rp, wChunk } from '../utils'
 
 let nuxt, port
 const url = route => 'http://localhost:' + port + route
 const modernUA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.77 Safari/537.36'
+const modernInfo = mode => `Modern bundles are detected. Modern mode (${chalk.green.bold(mode)}) is enabled now.`
 
 describe('modern server mode', () => {
   beforeAll(async () => {
-    const options = await loadFixture('modern', { modern: 'server' })
+    const options = await loadFixture('modern')
     nuxt = new Nuxt(options)
     port = await getPort()
     await nuxt.server.listen(port, 'localhost')
+  })
+
+  test('should detect server modern mode', async () => {
+    await nuxt.server.renderAndGetWindow(url('/'))
+    expect(consola.info).toHaveBeenCalledWith(modernInfo('server'))
   })
 
   test('should use legacy resources by default', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

If user doesn't specify `modern` in `command` and `nuxt.config.js`, a middleware will detect by if there is modern built asset in dist:
1. ssr: server
1. spa: client
1. no modern assets: false

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

