### PR TITLE
fix(webpack): deepClone before calling extendConfig

### DIFF
--- a/packages/webpack/src/config/base.js
+++ b/packages/webpack/src/config/base.js
@@ -361,9 +361,7 @@ export default class WebpackBaseConfig {
       plugins: this.plugins()
     }
 
-    const extendedConfig = this.extendConfig(config)
-
     // Clone deep avoid leaking config between Client and Server
-    return cloneDeep(extendedConfig)
+    return this.extendConfig(cloneDeep(config))
   }
 }

--- a/test/unit/basic.dev.test.js
+++ b/test/unit/basic.dev.test.js
@@ -87,7 +87,7 @@ describe('basic dev', () => {
     )
     const { cssModules, vue } = loadersOptions
     expect(cssModules.localIdentName).toBe('[hash:base64:6]')
-    expect(vueLoader.options).toBe(vue)
+    expect(vueLoader.options).toEqual(vue)
   })
 
   test('Config: cssnano is at then end of postcss plugins', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
I've found this bug when working on #4439. In [`client/extendConfig`](https://github.com/nuxt/nuxt.js/blob/dev/packages/webpack/src/config/client.js#L116) we directly mutate things like `config.optimization.minimize` just before cloning config. This was hidden because it is internally used for client and modern that share a same minimizer. 

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

