### PR TITLE
feat: use runInNewContext: true for nuxt dev

### DIFF
--- a/packages/config/src/config/render.js
+++ b/packages/config/src/config/render.js
@@ -3,7 +3,8 @@
 export default () => ({
   bundleRenderer: {
     shouldPrefetch: () => false,
-    shouldPreload: (fileWithoutQuery, asType) => ['script', 'style'].includes(asType)
+    shouldPreload: (fileWithoutQuery, asType) => ['script', 'style'].includes(asType),
+    runInNewContext: undefined
   },
   resourceHints: true,
   ssr: undefined,

--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -341,5 +341,11 @@ export function getNuxtConfig(_options) {
     consola.level = 0
   }
 
+  // Use runInNewContext for dev mode by default
+  const { bundleRenderer } = options.render
+  if (typeof bundleRenderer.runInNewContext === 'undefined') {
+    bundleRenderer.runInNewContext = options.dev
+  }
+
   return options
 }

--- a/packages/vue-renderer/src/renderer.js
+++ b/packages/vue-renderer/src/renderer.js
@@ -244,7 +244,6 @@ export default class VueRenderer {
     const hasModules = fs.existsSync(path.resolve(this.context.options.rootDir, 'node_modules'))
 
     const rendererOptions = {
-      runInNewContext: false,
       clientManifest: this.context.resources.clientManifest,
       // for globally installed nuxt command, search dependencies in global dir
       basedir: hasModules ? this.context.options.rootDir : __dirname,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
(Originally suggested by @Atinux)

For several reasons there are different kinds of shared state and memory leaks in development mode. This PR also fixes another important problem that when we globally register vue plugins with `Vue.use()` they will be remaining even when removed from the code. `runInNewContext` is highly recommanded to be disabled for production mode but for development time number of req/second rarely hits 5, it should be worthy.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

