### PR TITLE
fix: csp SHA hashes accumulate when using custom script-src rules

### DIFF
--- a/packages/server/src/middleware/nuxt.js
+++ b/packages/server/src/middleware/nuxt.js
@@ -141,14 +141,9 @@ const transformPolicyObject = (policies, cspScriptSrcHashSet) => {
   const hashAndPolicySet = cspScriptSrcHashSet
   hashAndPolicySet.add(`'self'`)
 
-  if (!userHasDefinedScriptSrc) {
-    policies['script-src'] = Array.from(hashAndPolicySet)
-    return policies
+  if (userHasDefinedScriptSrc) {
+    new Set(policies['script-src']).forEach(src => hashAndPolicySet.add(src))
   }
 
-  new Set(policies['script-src']).forEach(src => hashAndPolicySet.add(src))
-
-  policies['script-src'] = Array.from(hashAndPolicySet)
-
-  return policies
+  return { ...policies, 'script-src': Array.from(hashAndPolicySet) }
 }

--- a/packages/vue-renderer/src/renderer.js
+++ b/packages/vue-renderer/src/renderer.js
@@ -365,12 +365,12 @@ export default class VueRenderer {
 
     const serializedSession = `window.${this.context.globals.context}=${devalue(context.nuxt)};`
 
-    const cspScriptSrcHashSet = new Set()
+    const cspScriptSrcHashes = []
     if (this.context.options.render.csp) {
       const { hashAlgorithm } = this.context.options.render.csp
       const hash = crypto.createHash(hashAlgorithm)
       hash.update(serializedSession)
-      cspScriptSrcHashSet.add(`'${hashAlgorithm}-${hash.digest('base64')}'`)
+      cspScriptSrcHashes.push(`'${hashAlgorithm}-${hash.digest('base64')}'`)
     }
 
     APP += `<script>${serializedSession}</script>`
@@ -390,7 +390,7 @@ export default class VueRenderer {
 
     return {
       html,
-      cspScriptSrcHashSet,
+      cspScriptSrcHashes,
       getPreloadFiles: this.getPreloadFiles.bind(this, context),
       error: context.nuxt.error,
       redirected: context.redirected


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Fixes https://github.com/nuxt/nuxt.js/issues/4201

Currently when user defined a `script-src` list for CSP, the `transformPolicyObject()` would modify the CSP config object for EVERY unique SHA hash generated by nuxt. This will bloat up the CSP header until it exceed limit.

This patch fixes it by returning a new object when transforming the csp policy object.

Also the original use of `Set` seems unnecessary, not sure.

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

