### PR TITLE
fix: keepAliveProps broken in <nuxt-child>

### DIFF
--- a/packages/vue-app/template/components/nuxt-child.js
+++ b/packages/vue-app/template/components/nuxt-child.js
@@ -7,7 +7,8 @@ export default {
       type: String,
       default: ''
     },
-    keepAlive: Boolean
+    keepAlive: Boolean,
+    keepAliveProps: Object
   },
   render(h, { parent, data, props }) {
     data.nuxtChild = true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

The `keepAliveProps` prop support is broken during 2.3.0 because the prop is not declared in <nuxt-child>.

Related doc: https://nuxtjs.org/api/components-nuxt-child
Related pr: https://github.com/nuxt/nuxt.js/pull/4067

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

