### PR TITLE
feat(vue-app): Add n-link and n-child components shortcuts

### DIFF
--- a/examples/hello-world/pages/about.vue
+++ b/examples/hello-world/pages/about.vue
@@ -1,9 +1,7 @@
 <template>
   <div>
     <p>Hi from {{ name }}</p>
-    <NuxtLink to="/">
-      Home page
-    </NuxtLink>
+    <n-link to="/">Home page</n-link>
   </div>
 </template>
 

--- a/examples/hello-world/pages/index.vue
+++ b/examples/hello-world/pages/index.vue
@@ -1,9 +1,7 @@
 <template>
   <div>
     <h1>Welcome!</h1>
-    <NuxtLink to="/about">
-      About page
-    </NuxtLink>
+    <n-link to="/about">About Page</n-link>
   </div>
 </template>
 

--- a/packages/vue-app/template/index.js
+++ b/packages/vue-app/template/index.js
@@ -21,9 +21,11 @@ Vue.component(NoSsr.name, NoSsr)
 
 // Component: <NuxtChild>
 Vue.component(NuxtChild.name, NuxtChild)
+Vue.component('NChild', NuxtChild)
 
 // Component: <NuxtLink
 Vue.component(NuxtLink.name, NuxtLink)
+Vue.component('NLink', NuxtLink)
 
 // Component: <Nuxt>`
 Vue.component(Nuxt.name, Nuxt)


### PR DESCRIPTION
I do want the shortcuts :)

We will still support `<nuxt-link>` and `<nuxt-child/>` but I do recommend to document `<n-link>` and `<n-child/>` instead.

![screenshot 2018-12-11 at 17 40 18](https://user-images.githubusercontent.com/904724/49815394-fba4a700-fd6b-11e8-9048-0a8550b61a84.png)
