### PR TITLE
 fix: duplicate style in extractCSS 

### DIFF
--- a/packages/webpack/src/utils/style-loader.js
+++ b/packages/webpack/src/utils/style-loader.js
@@ -1,5 +1,5 @@
 import path from 'path'
-import ExtractCssChunks from 'extract-css-chunks-webpack-plugin'
+import ExtractCssChunksPlugin from 'extract-css-chunks-webpack-plugin'
 
 import { wrapArray } from '@nuxt/common'
 
@@ -81,7 +81,7 @@ export default class StyleLoader {
 
   extract() {
     if (this.extractCSS) {
-      return ExtractCssChunks.loader
+      return ExtractCssChunksPlugin.loader
     }
   }
 

--- a/test/unit/extract-css.test.js
+++ b/test/unit/extract-css.test.js
@@ -14,7 +14,7 @@ describe('extract css', () => {
     await nuxt.server.listen(await getPort(), '0.0.0.0')
   })
 
-  test.skip('Verify global.css has been extracted and minified', async () => {
+  test('Verify global.css has been extracted and minified', async () => {
     const fileName = isWindows ? 'pages_index.css' : 'pages/index.css'
     const extractedIndexCss = resolve(__dirname, '..', 'fixtures/extract-css/.nuxt/dist/client', fileName)
     const content = await readFile(extractedIndexCss, 'utf-8')
@@ -29,5 +29,7 @@ describe('extract css', () => {
   test('/about should contain module style', async () => {
     const { html } = await nuxt.server.renderRoute('/about')
     expect(html).toMatch(/<h1 class="test_[a-zA-Z0-9]{5}">\s*I'm BLUE\s*<\/h1>/)
+    // no duplicate inlined style
+    expect(html).not.toContain('{color:#00f}')
   })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
Fix #4173
1. Set `exportOnlyLocals` for css-loader of cssModules
1. Ignore `vue-style-loader` in server build when extractCSS enabled for avoiding inject duplicate style.
1. Refactor `style-loader` slightly

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

