### PR TITLE
fix(resolver) allow directories with index.[ext] files to be resolved as modules

### DIFF
--- a/packages/core/src/resolver.js
+++ b/packages/core/src/resolver.js
@@ -69,15 +69,19 @@ export default class Resolver {
       resolvedPath = path
     }
 
-    // Check if resolvedPath exits
-    if (fs.existsSync(resolvedPath)) {
+    // Check if resolvedPath exits and is not a directory
+    if (fs.existsSync(resolvedPath) && !fs.lstatSync(resolvedPath).isDirectory()) {
       return resolvedPath
     }
 
-    // Check if any resolvedPath.[ext] exists
+    // Check if any resolvedPath.[ext] or resolvedPath/index.[ext] exists
     for (const ext of this.options.extensions) {
       if (fs.existsSync(resolvedPath + '.' + ext)) {
         return resolvedPath + '.' + ext
+      }
+
+      if (fs.existsSync(resolvedPath + '/index.' + ext)) {
+        return resolvedPath + '/index.' + ext
       }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
Currently if I have modules in my project like this
```
~
| - modules
  | - my-module
    | - index.js
```
I can have this in my `nuxt.config.js`
```
{
  modules: [
    '~/modules/my-module',
  ]
}
```

and it works fine. However if you use any other extension (including extensions listed in `extensions` in config) it will not work. This effects me because I'm using TS, it will work if you use `~/modules/my-module/index.ts` or `~/modules/my-module/index` however since it works for .js files it feels like this is a bug.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

