### PR TITLE
feat(builder): optional typescript support

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,10 @@ module.exports = {
   root: true,
   parserOptions: {
     parser: 'babel-eslint',
-    sourceType: 'module'
+    sourceType: 'module',
+    ecmaFeatures: {
+      legacyDecorators: true
+    }
   },
   extends: [
     '@nuxtjs'

--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
     "rollup-plugin-replace": "^2.1.0",
     "sort-package-json": "^1.17.0",
     "typescript": "^3.2.2",
-    "vue-jest": "^3.0.2"
+    "vue-jest": "^3.0.2",
+    "vue-property-decorator": "^7.2.0"
   },
   "repository": {
     "type": "git",

--- a/packages/babel-preset-app/package.json
+++ b/packages/babel-preset-app/package.json
@@ -17,6 +17,7 @@
     "@babel/plugin-syntax-jsx": "^7.2.0",
     "@babel/plugin-transform-runtime": "^7.2.0",
     "@babel/preset-env": "^7.2.0",
+    "@babel/preset-typescript": "^7.1.0",
     "@babel/runtime": "^7.2.0",
     "babel-helper-vue-jsx-merge-props": "^2.0.3",
     "babel-plugin-transform-vue-jsx": "^4.0.1"

--- a/packages/babel-preset-app/src/index.js
+++ b/packages/babel-preset-app/src/index.js
@@ -92,6 +92,11 @@ module.exports = (context, options = {}) => {
     }
   ])
 
+  // TypeScript preset
+  if (options.typescript) {
+    presets.push(require('@babel/preset-typescript'))
+  }
+
   plugins.push(
     require('@babel/plugin-syntax-dynamic-import'),
     [require('@babel/plugin-proposal-decorators'), {

--- a/packages/builder/src/builder.js
+++ b/packages/builder/src/builder.js
@@ -277,7 +277,7 @@ export default class Builder {
       layoutsFiles.forEach((file) => {
         const name = file
           .replace(new RegExp(`^${this.options.dir.layouts}/`), '')
-          .replace(new RegExp(`\\.(${this.supportedExtensions.join('|')})$`, ''))
+          .replace(new RegExp(`\\.(${this.supportedExtensions.join('|')})$`), '')
         if (name === 'error') {
           if (!templateVars.components.ErrorPage) {
             templateVars.components.ErrorPage = this.relativeToBuild(
@@ -317,7 +317,7 @@ export default class Builder {
         cwd: this.options.srcDir,
         ignore: this.options.ignore
       })).forEach((f) => {
-        const key = f.replace(new RegExp(`\\.(${this.supportedExtensions.join('|')})$`, ''))
+        const key = f.replace(new RegExp(`\\.(${this.supportedExtensions.join('|')})$`), '')
         if (/\.vue$/.test(f) || !files[key]) {
           files[key] = f.replace(/(['"])/g, '\\$1')
         }

--- a/packages/builder/src/builder.js
+++ b/packages/builder/src/builder.js
@@ -46,7 +46,7 @@ export default class Builder {
 
     this.supportedExtensions = ['vue', 'js']
     if (this.options.build.typescript) {
-      this.supportedExtensions = this.supportedExtensions.concat(['ts', 'tsx'])
+      this.supportedExtensions.push('ts', 'tsx')
     }
 
     // Helper to resolve build paths
@@ -326,7 +326,7 @@ export default class Builder {
         Object.values(files),
         this.options.srcDir,
         this.options.dir.pages,
-        this.options.build.typescript
+        this.supportedExtensions
       )
     } else { // If user defined a custom method to create routes
       templateVars.router.routes = this.options.build.createRoutes(
@@ -508,20 +508,19 @@ export default class Builder {
 
   watchClient() {
     const src = this.options.srcDir
+    let rGlob = (dir) => ['*', '**/*'].map(glob => r(src, `${dir}/${glob}.{${this.supportedExtensions.join(',')}}`))
 
     let patterns = [
       r(src, this.options.dir.layouts),
       r(src, this.options.dir.store),
       r(src, this.options.dir.middleware),
-      r(src, `${this.options.dir.layouts}/*.{${this.supportedExtensions.join(',')}}`),
-      r(src, `${this.options.dir.layouts}/**/*.{${this.supportedExtensions.join(',')}}`)
+      ...rGlob(this.options.dir.layouts)
     ]
 
     if (this._nuxtPages) {
       patterns.push(
         r(src, this.options.dir.pages),
-        r(src, `${this.options.dir.pages}/*.{${this.supportedExtensions.join(',')}}`),
-        r(src, `${this.options.dir.pages}/**/*.{${this.supportedExtensions.join(',')}}`)
+        ...rGlob(this.options.dir.pages)
       )
     }
 

--- a/packages/builder/src/builder.js
+++ b/packages/builder/src/builder.js
@@ -508,7 +508,7 @@ export default class Builder {
 
   watchClient() {
     const src = this.options.srcDir
-    let rGlob = (dir) => ['*', '**/*'].map(glob => r(src, `${dir}/${glob}.{${this.supportedExtensions.join(',')}}`))
+    const rGlob = dir => ['*', '**/*'].map(glob => r(src, `${dir}/${glob}.{${this.supportedExtensions.join(',')}}`))
 
     let patterns = [
       r(src, this.options.dir.layouts),

--- a/packages/builder/src/builder.js
+++ b/packages/builder/src/builder.js
@@ -44,6 +44,11 @@ export default class Builder {
       restart: null
     }
 
+    this.supportedExtensions = ['vue', 'js']
+    if (this.options.typescript) {
+      this.supportedExtensions = this.supportedExtensions.concat(['ts', 'tsx'])
+    }
+
     // Helper to resolve build paths
     this.relativeToBuild = (...args) =>
       relativeTo(this.options.buildDir, ...args)
@@ -265,14 +270,14 @@ export default class Builder {
 
     // -- Layouts --
     if (fsExtra.existsSync(path.resolve(this.options.srcDir, this.options.dir.layouts))) {
-      const layoutsFiles = await glob(`${this.options.dir.layouts}/**/*.{vue,js}`, {
+      const layoutsFiles = await glob(`${this.options.dir.layouts}/**/*.{${this.supportedExtensions.join(',')}}`, {
         cwd: this.options.srcDir,
         ignore: this.options.ignore
       })
       layoutsFiles.forEach((file) => {
         const name = file
           .replace(new RegExp(`^${this.options.dir.layouts}/`), '')
-          .replace(/\.(vue|js)$/, '')
+          .replace(new RegExp(`\\.(${this.supportedExtensions.join('|')})$`, ''))
         if (name === 'error') {
           if (!templateVars.components.ErrorPage) {
             templateVars.components.ErrorPage = this.relativeToBuild(
@@ -308,11 +313,11 @@ export default class Builder {
     } else if (this._nuxtPages) {
       // Use nuxt.js createRoutes bases on pages/
       const files = {}
-        ; (await glob(`${this.options.dir.pages}/**/*.{vue,js}`, {
+        ; (await glob(`${this.options.dir.pages}/**/*.{${this.supportedExtensions.join(',')}}`, {
         cwd: this.options.srcDir,
         ignore: this.options.ignore
       })).forEach((f) => {
-        const key = f.replace(/\.(js|vue)$/, '')
+        const key = f.replace(new RegExp(`\\.(${this.supportedExtensions.join('|')})$`, ''))
         if (/\.vue$/.test(f) || !files[key]) {
           files[key] = f.replace(/(['"])/g, '\\$1')
         }
@@ -320,7 +325,8 @@ export default class Builder {
       templateVars.router.routes = createRoutes(
         Object.values(files),
         this.options.srcDir,
-        this.options.dir.pages
+        this.options.dir.pages,
+        this.options.typescript
       )
     } else { // If user defined a custom method to create routes
       templateVars.router.routes = this.options.build.createRoutes(
@@ -507,15 +513,15 @@ export default class Builder {
       r(src, this.options.dir.layouts),
       r(src, this.options.dir.store),
       r(src, this.options.dir.middleware),
-      r(src, `${this.options.dir.layouts}/*.{vue,js}`),
-      r(src, `${this.options.dir.layouts}/**/*.{vue,js}`)
+      r(src, `${this.options.dir.layouts}/*.{${this.supportedExtensions.join(',')}}`),
+      r(src, `${this.options.dir.layouts}/**/*.{${this.supportedExtensions.join(',')}}`)
     ]
 
     if (this._nuxtPages) {
       patterns.push(
         r(src, this.options.dir.pages),
-        r(src, `${this.options.dir.pages}/*.{vue,js}`),
-        r(src, `${this.options.dir.pages}/**/*.{vue,js}`)
+        r(src, `${this.options.dir.pages}/*.{${this.supportedExtensions.join(',')}}`),
+        r(src, `${this.options.dir.pages}/**/*.{${this.supportedExtensions.join(',')}}`)
       )
     }
 

--- a/packages/builder/src/builder.js
+++ b/packages/builder/src/builder.js
@@ -45,7 +45,7 @@ export default class Builder {
     }
 
     this.supportedExtensions = ['vue', 'js']
-    if (this.options.typescript) {
+    if (this.options.build.typescript) {
       this.supportedExtensions = this.supportedExtensions.concat(['ts', 'tsx'])
     }
 
@@ -326,7 +326,7 @@ export default class Builder {
         Object.values(files),
         this.options.srcDir,
         this.options.dir.pages,
-        this.options.typescript
+        this.options.build.typescript
       )
     } else { // If user defined a custom method to create routes
       templateVars.router.routes = this.options.build.createRoutes(

--- a/packages/common/src/utils.js
+++ b/packages/common/src/utils.js
@@ -315,11 +315,7 @@ const sortRoutes = function sortRoutes(routes) {
   return routes
 }
 
-export const createRoutes = function createRoutes(files, srcDir, pagesDir, typescript = false) {
-  let supportedExtensions = ['vue', 'js']
-  if (typescript) {
-    supportedExtensions = supportedExtensions.concat(['ts', 'tsx'])
-  }
+export const createRoutes = function createRoutes(files, srcDir, pagesDir, supportedExtensions = ['vue', 'js']) {
   const routes = []
   files.forEach((file) => {
     const keys = file

--- a/packages/common/src/utils.js
+++ b/packages/common/src/utils.js
@@ -315,12 +315,16 @@ const sortRoutes = function sortRoutes(routes) {
   return routes
 }
 
-export const createRoutes = function createRoutes(files, srcDir, pagesDir) {
+export const createRoutes = function createRoutes(files, srcDir, pagesDir, typescript = false) {
+  let supportedExtensions = ['vue', 'js']
+  if (typescript) {
+    supportedExtensions = supportedExtensions.concat(['ts', 'tsx'])
+  }
   const routes = []
   files.forEach((file) => {
     const keys = file
-      .replace(RegExp(`^${pagesDir}`), '')
-      .replace(/\.(vue|js)$/, '')
+      .replace(new RegExp(`^${pagesDir}`), '')
+      .replace(new RegExp(`\\.(${supportedExtensions.join('|')})$`), '')
       .replace(/\/{2,}/g, '/')
       .split('/')
       .slice(1)
@@ -334,7 +338,7 @@ export const createRoutes = function createRoutes(files, srcDir, pagesDir) {
         ? route.name + '-' + sanitizedKey
         : sanitizedKey
       route.name += key === '_' ? 'all' : ''
-      route.chunkName = file.replace(/\.(vue|js)$/, '')
+      route.chunkName = file.replace(new RegExp(`\\.(${supportedExtensions.join('|')})$`), '')
       const child = parent.find(parentRoute => parentRoute.name === route.name)
 
       if (child) {

--- a/packages/config/src/config/build.js
+++ b/packages/config/src/config/build.js
@@ -5,6 +5,7 @@ export default () => ({
   analyze: false,
   profile: process.argv.includes('--profile'),
   extractCSS: false,
+  typescript: false,
   crossorigin: undefined,
   cssSourceMap: undefined,
   ssr: undefined,

--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -119,7 +119,7 @@ export function getNuxtConfig(_options) {
   )
 
   const mandatoryExtensions = ['js', 'mjs']
-  if (options.typescript) {
+  if (options.build.typescript) {
     mandatoryExtensions.push('ts')
   }
 

--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -119,6 +119,9 @@ export function getNuxtConfig(_options) {
   )
 
   const mandatoryExtensions = ['js', 'mjs']
+  if (options.typescript) {
+    mandatoryExtensions.push('ts')
+  }
 
   options.extensions = mandatoryExtensions
     .filter(ext => !options.extensions.includes(ext))

--- a/packages/webpack/src/config/base.js
+++ b/packages/webpack/src/config/base.js
@@ -76,7 +76,7 @@ export default class WebpackBaseConfig {
           require.resolve('@nuxt/babel-preset-app'),
           {
             buildTarget: this.isServer ? 'server' : 'client',
-            typescript: this.options.typescript
+            typescript: this.options.build.typescript
           }
         ]
       ]
@@ -216,7 +216,7 @@ export default class WebpackBaseConfig {
         ]
       },
       {
-        test: this.options.typescript ? /\.(j|t)sx?$/ : /\.jsx?$/,
+        test: this.options.build.typescript ? /\.(j|t)sx?$/ : /\.jsx?$/,
         exclude: (file) => {
           // not exclude files outside node_modules
           if (!/node_modules/.test(file)) {
@@ -378,7 +378,7 @@ export default class WebpackBaseConfig {
     // Prioritize nested node_modules in webpack search path (#2558)
     const webpackModulesDir = ['node_modules'].concat(this.options.modulesDir)
     let extensionsToResolve = ['.wasm', '.mjs', '.js', '.json', '.vue', '.jsx']
-    if (this.options.typescript) {
+    if (this.options.build.typescript) {
       extensionsToResolve = extensionsToResolve.concat(['.ts', '.tsx'])
     }
 

--- a/packages/webpack/src/config/base.js
+++ b/packages/webpack/src/config/base.js
@@ -75,7 +75,8 @@ export default class WebpackBaseConfig {
         [
           require.resolve('@nuxt/babel-preset-app'),
           {
-            buildTarget: this.isServer ? 'server' : 'client'
+            buildTarget: this.isServer ? 'server' : 'client',
+            typescript: this.options.typescript
           }
         ]
       ]
@@ -215,7 +216,7 @@ export default class WebpackBaseConfig {
         ]
       },
       {
-        test: /\.jsx?$/,
+        test: this.options.typescript ? /\.(j|t)sx?$/ : /\.jsx?$/,
         exclude: (file) => {
           // not exclude files outside node_modules
           if (!/node_modules/.test(file)) {
@@ -376,6 +377,10 @@ export default class WebpackBaseConfig {
   config() {
     // Prioritize nested node_modules in webpack search path (#2558)
     const webpackModulesDir = ['node_modules'].concat(this.options.modulesDir)
+    let extensionsToResolve = ['.wasm', '.mjs', '.js', '.json', '.vue', '.jsx']
+    if (this.options.typescript) {
+      extensionsToResolve = extensionsToResolve.concat(['.ts', '.tsx'])
+    }
 
     const config = {
       name: this.name,
@@ -388,7 +393,7 @@ export default class WebpackBaseConfig {
         hints: this.options.dev ? false : 'warning'
       },
       resolve: {
-        extensions: ['.wasm', '.mjs', '.js', '.json', '.vue', '.jsx'],
+        extensions: extensionsToResolve,
         alias: this.alias(),
         modules: webpackModulesDir
       },

--- a/test/fixtures/typescript/@types/process.d.ts
+++ b/test/fixtures/typescript/@types/process.d.ts
@@ -1,0 +1,8 @@
+declare namespace NodeJS {
+  interface Process {
+    browser: boolean
+    client: boolean
+    server: boolean
+    static: boolean
+  }
+}

--- a/test/fixtures/typescript/@types/shims-tsx.d.ts
+++ b/test/fixtures/typescript/@types/shims-tsx.d.ts
@@ -1,0 +1,11 @@
+import Vue, { VNode } from 'vue'
+
+declare global {
+  namespace JSX {
+    interface Element extends VNode {}
+    interface ElementClass extends Vue {}
+    interface IntrinsicElements {
+      [elemName: string]: any
+    }
+  }
+}

--- a/test/fixtures/typescript/layouts/default.vue
+++ b/test/fixtures/typescript/layouts/default.vue
@@ -1,14 +1,13 @@
 <template>
-  <div>{{ message }}</div>
+  <Nuxt />
 </template>
 
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator'
 
 @Component({
-  name: 'Index'
+  name: 'DefaultLayout',
+  middleware: 'test'
 })
-export default class extends Vue {
-  message = 'Index Page'
-}
+export default class extends Vue {}
 </script>

--- a/test/fixtures/typescript/middleware/middleware.ts
+++ b/test/fixtures/typescript/middleware/middleware.ts
@@ -1,0 +1,1 @@
+export default () => {}

--- a/test/fixtures/typescript/middleware/test.ts
+++ b/test/fixtures/typescript/middleware/test.ts
@@ -1,4 +1,0 @@
-export default () => {
-  const messageFromMiddleware: string = 'Message from a TS middleware !'
-  console.log(`[${process.server ? 'Server' : 'Client'}]`, messageFromMiddleware)
-}

--- a/test/fixtures/typescript/middleware/test.ts
+++ b/test/fixtures/typescript/middleware/test.ts
@@ -1,0 +1,4 @@
+export default () => {
+  const messageFromMiddleware: string = 'Message from a TS middleware !'
+  console.log(`[${process.server ? 'Server' : 'Client'}]`, messageFromMiddleware)
+}

--- a/test/fixtures/typescript/nuxt.config.js
+++ b/test/fixtures/typescript/nuxt.config.js
@@ -1,5 +1,3 @@
-import { resolve } from 'path'
-
 export default {
   plugins: [
     '~/plugins/plugin.ts'

--- a/test/fixtures/typescript/nuxt.config.js
+++ b/test/fixtures/typescript/nuxt.config.js
@@ -1,0 +1,9 @@
+import { resolve } from 'path'
+
+export default {
+  typescript: true,
+  srcDir: resolve(__dirname),
+  plugins: [
+    '~/plugins/test.ts'
+  ]
+}

--- a/test/fixtures/typescript/nuxt.config.js
+++ b/test/fixtures/typescript/nuxt.config.js
@@ -1,9 +1,11 @@
 import { resolve } from 'path'
 
 export default {
-  typescript: true,
   srcDir: resolve(__dirname),
   plugins: [
     '~/plugins/test.ts'
-  ]
+  ],
+  build: {
+    typescript: true
+  }
 }

--- a/test/fixtures/typescript/nuxt.config.js
+++ b/test/fixtures/typescript/nuxt.config.js
@@ -1,9 +1,8 @@
 import { resolve } from 'path'
 
 export default {
-  srcDir: resolve(__dirname),
   plugins: [
-    '~/plugins/test.ts'
+    '~/plugins/plugin.ts'
   ],
   build: {
     typescript: true

--- a/test/fixtures/typescript/pages/about.ts
+++ b/test/fixtures/typescript/pages/about.ts
@@ -1,0 +1,8 @@
+import Vue from 'vue'
+
+export default Vue.extend({
+  name: 'About',
+  render (h) {
+    return h('div', 'About Page')
+  }
+})

--- a/test/fixtures/typescript/pages/contact.tsx
+++ b/test/fixtures/typescript/pages/contact.tsx
@@ -1,0 +1,13 @@
+import Vue from 'vue'
+
+export default Vue.extend({
+  name: 'Contact',
+  data () {
+    return {
+      message: 'Contact Page'
+    }
+  },
+  render () {
+    return <div>{this.message}</div>
+  }
+})

--- a/test/fixtures/typescript/pages/index.vue
+++ b/test/fixtures/typescript/pages/index.vue
@@ -1,0 +1,16 @@
+<template>
+  <div>
+    {{ message }}
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator'
+
+@Component({
+  middleware: 'test'
+})
+export default class PageIndex extends Vue {
+  message = 'Index Page'
+}
+</script>

--- a/test/fixtures/typescript/plugins/plugin.ts
+++ b/test/fixtures/typescript/plugins/plugin.ts
@@ -1,0 +1,1 @@
+export default () => {}

--- a/test/fixtures/typescript/plugins/test.ts
+++ b/test/fixtures/typescript/plugins/test.ts
@@ -1,4 +1,0 @@
-export default () => {
-  const messageFromPlugin: string = 'Message from a TS plugin !'
-  console.log(`[${process.server ? 'Server' : 'Client'}]`, messageFromPlugin)
-}

--- a/test/fixtures/typescript/plugins/test.ts
+++ b/test/fixtures/typescript/plugins/test.ts
@@ -1,0 +1,4 @@
+export default () => {
+  const messageFromPlugin: string = 'Message from a TS plugin !'
+  console.log(`[${process.server ? 'Server' : 'Client'}]`, messageFromPlugin)
+}

--- a/test/fixtures/typescript/tsconfig.json
+++ b/test/fixtures/typescript/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "lib": ["esnext", "esnext.asynciterable", "dom"],
+    "esModuleInterop": true,
+    "experimentalDecorators": true,
+    "allowJs": true,
+    "jsx": "preserve",
+    "sourceMap": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "noEmit": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["./*"]
+    }
+  }
+}

--- a/test/fixtures/typescript/typescript.test.js
+++ b/test/fixtures/typescript/typescript.test.js
@@ -1,0 +1,3 @@
+import { buildFixture } from '../../utils/build'
+
+buildFixture('typescript')

--- a/test/unit/typescript.test.js
+++ b/test/unit/typescript.test.js
@@ -1,0 +1,32 @@
+import { loadFixture, getPort, Nuxt } from '../utils'
+
+let nuxt = null
+
+describe('typescript', () => {
+  beforeAll(async () => {
+    const options = await loadFixture('typescript')
+    nuxt = new Nuxt(options)
+    const port = await getPort()
+    await nuxt.server.listen(port, '0.0.0.0')
+  })
+
+  test('/', async () => {
+    const { html } = await nuxt.server.renderRoute('/')
+    expect(html).toContain('<div>Index Page</div>')
+  })
+
+  test('/about', async () => {
+    const { html } = await nuxt.server.renderRoute('/about')
+    expect(html).toContain('<div>About Page</div>')
+  })
+
+  test('/contact', async () => {
+    const { html } = await nuxt.server.renderRoute('/contact')
+    expect(html).toContain('<div>Contact Page</div>')
+  })
+
+  // Close server and ask nuxt to stop listening to file changes
+  afterAll(async () => {
+    await nuxt.close()
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -354,6 +354,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/plugin-syntax-typescript@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.2.0.tgz#55d240536bd314dcbbec70fd949c5cabaed1de29"
+  integrity sha512-WhKr6yu6yGpGcNMVgIBuI9MkredpVc7Y3YR4UzEZmDztHoL6wV56YBHLhWnjO1EvId1B32HrD3DRFc+zSoKI1g==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
 "@babel/plugin-transform-arrow-functions@^7.2.0":
   version "7.2.0"
   resolved "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz#9aeafbe4d6ffc6563bf8f8372091628f00779550"
@@ -570,6 +577,14 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/plugin-transform-typescript@^7.1.0":
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.2.0.tgz#bce7c06300434de6a860ae8acf6a442ef74a99d1"
+  integrity sha512-EnI7i2/gJ7ZNr2MuyvN2Hu+BHJENlxWte5XygPvfj/MbvtOkWor9zcnHpMMQL2YYaaCcqtIvJUyJ7QVfoGs7ew==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-typescript" "^7.2.0"
+
 "@babel/plugin-transform-unicode-regex@^7.2.0":
   version "7.2.0"
   resolved "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.2.0.tgz#4eb8db16f972f8abb5062c161b8b115546ade08b"
@@ -633,6 +648,14 @@
     invariant "^2.2.2"
     js-levenshtein "^1.1.3"
     semver "^5.3.0"
+
+"@babel/preset-typescript@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.1.0.tgz#49ad6e2084ff0bfb5f1f7fb3b5e76c434d442c7f"
+  integrity sha512-LYveByuF9AOM8WrsNne5+N79k1YxjNB6gmpCQsnuSBAcV8QUeB+ZUxQzL7Rz7HksPbahymKkq2qBR+o36ggFZA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-transform-typescript" "^7.1.0"
 
 "@babel/register@^7.0.0":
   version "7.0.0"
@@ -11037,6 +11060,11 @@ void-elements@^2.0.1:
   resolved "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
   integrity sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=
 
+vue-class-component@^6.2.0:
+  version "6.3.2"
+  resolved "https://registry.npmjs.org/vue-class-component/-/vue-class-component-6.3.2.tgz#e6037e84d1df2af3bde4f455e50ca1b9eec02be6"
+  integrity sha512-cH208IoM+jgZyEf/g7mnFyofwPDJTM/QvBNhYMjqGB8fCsRyTf68rH2ISw/G20tJv+5mIThQ3upKwoL4jLTr1A==
+
 vue-eslint-parser@^4.0.2:
   version "4.0.2"
   resolved "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-4.0.2.tgz#7d10ec5b67d9b2ef240cac0f0e8b2f03773d810e"
@@ -11094,6 +11122,13 @@ vue-no-ssr@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/vue-no-ssr/-/vue-no-ssr-1.1.0.tgz#b323807112f676324d9d7cfde85d7831ced11dd9"
   integrity sha512-prJ9czuPrVu0GhUZKTS/epFfM15QjLuG6wt61g0nyixPXk0g6eY7wNF4RKIqJsxomOiuSYTv3Zo8A43Vi93xfw==
+
+vue-property-decorator@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/vue-property-decorator/-/vue-property-decorator-7.2.0.tgz#8e6b0f4dcc630c357135f76366ba7bd91f1db015"
+  integrity sha512-sCI6NVM3tEDg+mpZrQlgkddtxd9LbFWetue8D+nqO3agfSLz0KoC/UIi2P1l5E0TDhcUeIXS9rasuP2HWg+L4w==
+  dependencies:
+    vue-class-component "^6.2.0"
 
 vue-router@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## ⚠ Warning ⚠ (EDIT AFTER MERGE)

➡ Please be aware of #4563 , which will likely make this merged PR outdated. ⬅

## Description

What if Typescript Support what just about setting a boolean variable to `true` ? 😎

### Prequel

This PR is highly inspired by #4406 made by @chanlito, so special thanks to him.

His current PR state alters Nuxt packages even for non-TS projects, and will also break projects using their own TypeScript module, that's why I implemented a new way to provide the TS support.

Existing TS projects will be able to either keep their own implementation of TypeScript support *OR* use this built-in **optional** one.

### I. Usage 👨‍💻👩‍💻

```js
// nuxt.config.js
export default {
  build: {
    typescript: true // 🚀
  }
}
```

### II. How it works behind the scenes ? ⚙

When the `typescript` option is set to true, and only if is set true, it alters the following Nuxt internal packages :

✏ Config (**@nuxt/config**)  
*Accept `.ts(x)` files for plugins and middleware*

✏ Builder (**@nuxt/builder**) & Common(**@nuxt/common**)  
*Watch & Use `.ts(x)` files to generate routes (layouts & pages)*

✏ Webpack (**@nuxt/webpack**)  
*Resolve `.ts(x)` files through Babel, passing the typescript option value to the Nuxt babel preset*

✏ Babel (**@nuxt/babel-preset-app**)  
*Retrieve the typescript option from the preset options to use the [@babel/preset-typescript](https://www.npmjs.com/package/@babel/preset-typescript) Babel TypeScript preset.*

✏ CLI (**@nuxt/cli**) [*Suggestion not implemented yet*]  
*Warning or Error if `tsconfig.json` not found in the source folder, using the `srcDir` config option*

### III. What about the documentation ? 📖

I suggest a **Typescript** section in the documentation *OR* a **How to use Typescript ?** in the FAQ.

I will (or at least propose to) take the lead on it if my proposal is accepted and submit a PR regarding this documentation. This latter will talk about type definitions as well (#4164).

### IV. What about a Nuxt TS project example ? 📁

An example highly similar to the one in #4406 will be proposed in a different PR if this proposal is accepted.

### V. What about tests ? 🛠

A test fixture and an unit test are linked in the PR.

**NOTE :** Nuxt TS community is growing, we already have a bunch of developers who will be ready to test this support using `nuxt-edge` if this proposal gets accepted and merged 😇

@chanlito @hartmut-co-uk @husayt @ksnyde @NickBolles

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

