### PR TITLE
fix: add serialize-javascript to common package

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -8,7 +8,8 @@
   ],
   "main": "dist/common.js",
   "dependencies": {
-    "consola": "^2.3.0"
+    "consola": "^2.3.0",
+    "serialize-javascript": "^1.5.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
As reported by @kevinmarrec -- apparently this should be here, please shed a light @pi0 @clarkdo if I'm mistaken :)