### PR TITLE
fix(resolver): resolve dir if no index found #4568

### DIFF
--- a/packages/core/src/resolver.js
+++ b/packages/core/src/resolver.js
@@ -91,7 +91,7 @@ export default class Resolver {
       }
     }
 
-    // If there's no index.[ext] we just return the dierctory path
+    // If there's no index.[ext] we just return the directory path
     if (isDirectory) {
       return resolvedPath
     }

--- a/packages/core/src/resolver.js
+++ b/packages/core/src/resolver.js
@@ -82,11 +82,11 @@ export default class Resolver {
 
     // Check if any resolvedPath.[ext] or resolvedPath/index.[ext] exists
     for (const ext of this.options.extensions) {
-      if (fs.existsSync(resolvedPath + '.' + ext)) {
+      if (!isDirectory && fs.existsSync(resolvedPath + '.' + ext)) {
         return resolvedPath + '.' + ext
       }
 
-      if (fs.existsSync(resolvedPath + '/index.' + ext)) {
+      if (isDirectory && fs.existsSync(resolvedPath + '/index.' + ext)) {
         return resolvedPath + '/index.' + ext
       }
     }

--- a/packages/core/src/resolver.js
+++ b/packages/core/src/resolver.js
@@ -69,9 +69,15 @@ export default class Resolver {
       resolvedPath = path
     }
 
+    let isDirectory
+
     // Check if resolvedPath exits and is not a directory
-    if (fs.existsSync(resolvedPath) && !fs.lstatSync(resolvedPath).isDirectory()) {
-      return resolvedPath
+    if (fs.existsSync(resolvedPath)) {
+      isDirectory = fs.lstatSync(resolvedPath).isDirectory()
+
+      if (!isDirectory) {
+        return resolvedPath
+      }
     }
 
     // Check if any resolvedPath.[ext] or resolvedPath/index.[ext] exists
@@ -83,6 +89,11 @@ export default class Resolver {
       if (fs.existsSync(resolvedPath + '/index.' + ext)) {
         return resolvedPath + '/index.' + ext
       }
+    }
+
+    // If there's no index.[ext] we just return the dierctory path
+    if (isDirectory) {
+      return resolvedPath
     }
 
     // Give up


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
The previous behaviour was to return `resolvedPath` if the file exists
(even if it's a dir). After this change we first check for index files
in the dir, if there's not we still return the `resolvedPath` for the dir.
This fixes #4568


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

