### PR TITLE
chore(vue-app): use serializeFunction when appropriate

### DIFF
--- a/packages/vue-app/template/router.js
+++ b/packages/vue-app/template/router.js
@@ -112,8 +112,8 @@ export function createRouter() {
     <%= isTest ? '/* eslint-disable quotes */' : '' %>
     routes: [<%= _routes %>],
     <%= isTest ? '/* eslint-enable quotes */' : '' %>
-    <% if (router.parseQuery) { %>parseQuery: <%= serialize(router.parseQuery).replace('parseQuery(', 'function(') %>,<% } %>
-    <% if (router.stringifyQuery) { %>stringifyQuery: <%= serialize(router.stringifyQuery).replace('stringifyQuery(', 'function(') %>,<% } %>
+    <% if (router.parseQuery) { %>parseQuery: <%= serializeFunction(router.parseQuery) %>,<% } %>
+    <% if (router.stringifyQuery) { %>stringifyQuery: <%= serializeFunction(router.stringifyQuery) %>,<% } %>
     fallback: <%= router.fallback %>
   })
 }

--- a/packages/vue-app/template/router.js
+++ b/packages/vue-app/template/router.js
@@ -49,7 +49,7 @@ const _routes = recursiveRoutes(router.routes, '  ', _components, 2)
 Vue.use(Router)
 
 <% if (router.scrollBehavior) { %>
-const scrollBehavior = <%= serialize(router.scrollBehavior).replace(/scrollBehavior\s*\(/, 'function(').replace('function function', 'function') %>
+const scrollBehavior = <%= serializeFunction(router.scrollBehavior) %>
 <% } else { %>
 if (process.client) {
   window.history.scrollRestoration = 'manual'


### PR DESCRIPTION
Following https://github.com/nuxt/nuxt.js/pull/4558, noticed a few other places than make use of `serializeFunction`.