### PR TITLE
fix: prevent matching native statements in serializeFunction

### DIFF
--- a/packages/common/src/utils.js
+++ b/packages/common/src/utils.js
@@ -463,10 +463,10 @@ export function defineAlias(src, target, prop, opts = {}) {
 export function serializeFunction(func) {
   let open = false
   return serialize(func)
-    .replace(/^(\s*):(\w+)\(/gm, (_, spaces) => {
+    .replace(serializeFunction.assignmentRE, (_, spaces) => {
       return `${spaces}:function(`
     })
-    .replace(/^(\s*)(?!(if)|(for)|(while)|(switch))(\w+)\s*\((.*?)\)\s*\{/gm, (_, spaces, name, args) => {
+    .replace(serializeFunction.internalFunctionRE, (_, spaces, name, args) => {
       if (open) {
         return `${spaces}${name}:function(${args}) {`
       } else {
@@ -476,3 +476,6 @@ export function serializeFunction(func) {
     })
     .replace(`${func.name}(`, 'function(')
 }
+
+serializeFunction.internalFunctionRE = /^(\s*)(?!(?:if)|(?:for)|(?:while)|(?:switch))(\w+)\s*\((.*?)\)\s*\{/gm
+serializeFunction.assignmentRE = /^(\s*):(\w+)\(/gm

--- a/packages/common/src/utils.js
+++ b/packages/common/src/utils.js
@@ -463,10 +463,10 @@ export function defineAlias(src, target, prop, opts = {}) {
 export function serializeFunction(func) {
   let open = false
   return serialize(func)
-    .replace(/^(\s*):(\w+)\(/gm, (_, spaces) => {
+    .replace(/^(\s*):(?!(?:if|for|while|switch)\s*\()\w+)\(/gm, (_, spaces) => {
       return `${spaces}:function(`
     })
-    .replace(/^(\s*)(\w+)\s*\((.*?)\)\s*\{/gm, (_, spaces, name, args) => {
+    .replace(/^(\s*)(?!(if)|(for)|(while)|(switch))(\w+)\s*\((.*?)\)\s*\{/gm, (_, spaces, name, args) => {
       if (open) {
         return `${spaces}${name}:function(${args}) {`
       } else {

--- a/packages/common/src/utils.js
+++ b/packages/common/src/utils.js
@@ -463,7 +463,7 @@ export function defineAlias(src, target, prop, opts = {}) {
 export function serializeFunction(func) {
   let open = false
   return serialize(func)
-    .replace(/^(\s*):(?!(?:if|for|while|switch)\s*\()\w+)\(/gm, (_, spaces) => {
+    .replace(/^(\s*):(\w+)\(/gm, (_, spaces) => {
       return `${spaces}:function(`
     })
     .replace(/^(\s*)(?!(if)|(for)|(while)|(switch))(\w+)\s*\((.*?)\)\s*\{/gm, (_, spaces, name, args) => {


### PR DESCRIPTION
As reported in https://github.com/nuxt/nuxt.js/commit/25d26ba42f97fa738592df4f85e692a557ffa1bf#r31725441, `serializeFunction()` introduce a bug where it's matching native JS statements.