### PR TITLE
feat: mode for plugin

### DIFF
--- a/packages/builder/src/builder.js
+++ b/packages/builder/src/builder.js
@@ -114,7 +114,6 @@ export default class Builder {
         // TODO: remove deprecated check in Nuxt 3
         if (p.ssr === false) {
           p.mode = 'client'
-          consola.warn(`ssr in plugin options has been deprecated, please use mode instead`)
         } else if (!['client', 'server'].includes(p.mode)) {
           p.mode = 'all'
         }

--- a/packages/builder/src/builder.js
+++ b/packages/builder/src/builder.js
@@ -116,7 +116,7 @@ export default class Builder {
         } else if (p.mode === undefined) {
           p.mode = 'all'
         } else if (!['client', 'server'].includes(p.mode)) {
-          consola.warn(`Invalid plugin mode (server/client/all): '${p.mode}'. Falling back to 'all'.`)
+          consola.warn(`Invalid plugin mode (server/client/all): '${p.mode}'. Falling back to 'all'`)
           p.mode = 'all'
         }
 

--- a/packages/builder/src/builder.js
+++ b/packages/builder/src/builder.js
@@ -111,13 +111,12 @@ export default class Builder {
           ''
         )
 
-        // TODO: remove deprecated check in Nuxt 3
         if (p.ssr === false) {
           p.mode = 'client'
         } else if (p.mode === undefined) {
           p.mode = 'all'
         } else if (!['client', 'server'].includes(p.mode)) {
-          consola.warn(`Invalid plugin mode (server/client): ${p.mode}. Falling back to default`)
+          consola.warn(`Invalid plugin mode (server/client/all): '${p.mode}'. Falling back to 'all'.`)
           p.mode = 'all'
         }
 

--- a/packages/builder/src/builder.js
+++ b/packages/builder/src/builder.js
@@ -222,6 +222,8 @@ export default class Builder {
     // Generate routes and interpret the template files
     await this.generateRoutesAndFiles()
 
+    await this.resolvePlugins()
+
     // Start bundle build: webpack, rollup, parcel...
     await this.bundleBuilder.build()
 
@@ -239,8 +241,6 @@ export default class Builder {
 
     // Plugins
     this.plugins = Array.from(this.normalizePlugins())
-
-    await this.resolvePlugins()
 
     // -- Templates --
     let templatesFiles = Array.from(this.template.templatesFiles)

--- a/packages/builder/src/builder.js
+++ b/packages/builder/src/builder.js
@@ -114,7 +114,10 @@ export default class Builder {
         // TODO: remove deprecated check in Nuxt 3
         if (p.ssr === false) {
           p.mode = 'client'
+        } else if (p.mode === undefined) {
+          p.mode = 'all'
         } else if (!['client', 'server'].includes(p.mode)) {
+          consola.warn(`Invalid plugin mode (server/client): ${p.mode}. Falling back to default`)
           p.mode = 'all'
         }
 

--- a/packages/core/src/module.js
+++ b/packages/core/src/module.js
@@ -63,7 +63,9 @@ export default class ModuleContainer {
     // Add to nuxt plugins
     this.options.plugins.unshift({
       src: path.join(this.options.buildDir, dst),
-      ssr: template.ssr
+      // TODO: remove deprecated option in Nuxt 3
+      ssr: template.ssr,
+      mode: template.mode
     })
   }
 

--- a/packages/vue-app/template/index.js
+++ b/packages/vue-app/template/index.js
@@ -12,7 +12,7 @@ import { setContext, getLocation, getRouteData, normalizeError } from './utils'
 
 /* Plugins */
 <%= isTest ? '/* eslint-disable camelcase */' : '' %>
-<% plugins.forEach((plugin) => { %>import <%= plugin.name %> from '<%= plugin.name %>' // Source: <%= relativeToBuild(plugin.src) %><%= (plugin.ssr===false) ? ' (ssr: false)' : '' %>
+<% plugins.forEach((plugin) => { %>import <%= plugin.name %> from '<%= plugin.name %>' // Source: <%= plugin.src %> (mode: '<%= plugin.mode %>')
 <% }) %>
 <%= isTest ? '/* eslint-enable camelcase */' : '' %>
 
@@ -168,11 +168,18 @@ async function createApp(ssrContext) {
 
   // Plugin execution
   <%= isTest ? '/* eslint-disable camelcase */' : '' %>
-  <% plugins.filter(p => p.ssr).forEach((plugin) => { %>
+  <% plugins.filter(p => p.mode === 'all').forEach((plugin) => { %>
   if (typeof <%= plugin.name %> === 'function') await <%= plugin.name %>(app.context, inject)<% }) %>
-  <% if (plugins.filter(p => !p.ssr).length) { %>
+
+  <% if (plugins.filter(p => p.mode === 'client').length) { %>
   if (process.client) {
-    <% plugins.filter((p) => !p.ssr).forEach((plugin) => { %>
+    <% plugins.filter(p => p.mode === 'client').forEach((plugin) => { %>
+    if (typeof <%= plugin.name %> === 'function') await <%= plugin.name %>(app.context, inject)<% }) %>
+  }<% } %>
+
+  <% if (plugins.filter(p => p.mode === 'server').length) { %>
+  if (process.server) {
+    <% plugins.filter(p => p.mode === 'server').forEach((plugin) => { %>
     if (typeof <%= plugin.name %> === 'function') await <%= plugin.name %>(app.context, inject)<% }) %>
   }<% } %>
   <%= isTest ? '/* eslint-enable camelcase */' : '' %>

--- a/packages/vue-app/template/index.js
+++ b/packages/vue-app/template/index.js
@@ -12,7 +12,7 @@ import { setContext, getLocation, getRouteData, normalizeError } from './utils'
 
 /* Plugins */
 <%= isTest ? '/* eslint-disable camelcase */' : '' %>
-<% plugins.forEach((plugin) => { %>import <%= plugin.name %> from '<%= plugin.name %>' // Source: <%= plugin.src %> (mode: '<%= plugin.mode %>')
+<% plugins.forEach((plugin) => { %>import <%= plugin.name %> from '<%= plugin.name %>' // Source: <%= relativeToBuild(plugin.src) %> (mode: '<%= plugin.mode %>')
 <% }) %>
 <%= isTest ? '/* eslint-enable camelcase */' : '' %>
 

--- a/packages/webpack/src/builder.js
+++ b/packages/webpack/src/builder.js
@@ -63,18 +63,17 @@ export class WebpackBundler {
     for (const p of this.context.plugins) {
       // Client config
       if (!clientConfig.resolve.alias[p.name]) {
-        clientConfig.resolve.alias[p.name] = p.src
+        clientConfig.resolve.alias[p.name] = p.mode === 'server' ? './empty.js' : p.src
       }
 
       // Server config
       if (serverConfig && !serverConfig.resolve.alias[p.name]) {
-        // Alias to noop for ssr:false plugins
-        serverConfig.resolve.alias[p.name] = p.ssr ? p.src : './empty.js'
+        serverConfig.resolve.alias[p.name] = p.mode === 'client' ? './empty.js' : p.src
       }
 
       // Modern config
       if (modernConfig && !modernConfig.resolve.alias[p.name]) {
-        modernConfig.resolve.alias[p.name] = p.src
+        modernConfig.resolve.alias[p.name] = p.mode === 'client' ? './empty.js' : p.src
       }
     }
 

--- a/test/fixtures/with-config/nuxt.config.js
+++ b/test/fixtures/with-config/nuxt.config.js
@@ -37,7 +37,7 @@ export default {
   extensions: 'ts',
   plugins: [
     '~/plugins/test',
-    '~/plugins/test.plugin',
+    { src: '~/plugins/test.plugin', mode: 'abc' },
     '~/plugins/test.client',
     '~/plugins/test.server',
     { src: '~/plugins/only-client.js', ssr: false }

--- a/test/fixtures/with-config/nuxt.config.js
+++ b/test/fixtures/with-config/nuxt.config.js
@@ -38,6 +38,8 @@ export default {
   plugins: [
     '~/plugins/test',
     '~/plugins/test.plugin',
+    '~/plugins/test.client',
+    '~/plugins/test.server',
     { src: '~/plugins/only-client.js', ssr: false }
   ],
   loading: '~/components/loading',

--- a/test/fixtures/with-config/plugins/test.client.js
+++ b/test/fixtures/with-config/plugins/test.client.js
@@ -1,1 +1,1 @@
-window.__test_plugin_client = true
+window.__test_plugin_client = 'test_plugin_client'

--- a/test/fixtures/with-config/plugins/test.client.js
+++ b/test/fixtures/with-config/plugins/test.client.js
@@ -1,0 +1,1 @@
+window.__test_plugin_client = true

--- a/test/fixtures/with-config/plugins/test.server.js
+++ b/test/fixtures/with-config/plugins/test.server.js
@@ -1,1 +1,1 @@
-global.__test_plugin_server = true
+global.__test_plugin_server = 'test_plugin_server'

--- a/test/fixtures/with-config/plugins/test.server.js
+++ b/test/fixtures/with-config/plugins/test.server.js
@@ -1,0 +1,1 @@
+global.__test_plugin_server = true

--- a/test/fixtures/with-config/with-config.test.js
+++ b/test/fixtures/with-config/with-config.test.js
@@ -14,11 +14,14 @@ const hooks = [
 
 describe('with-config', () => {
   buildFixture('with-config', () => {
-    expect(consola.warn).toHaveBeenCalledTimes(4)
+    expect(consola.warn).toHaveBeenCalledTimes(5)
     expect(consola.fatal).toHaveBeenCalledTimes(0)
     expect(consola.warn.mock.calls).toMatchObject([
       [
         'Unknown mode: unknown. Falling back to universal'
+      ],
+      [
+        'ssr in plugin options has been deprecated, please use mode instead'
       ],
       [{
         message: 'Found 2 plugins that match the configuration, suggest to specify extension:',

--- a/test/fixtures/with-config/with-config.test.js
+++ b/test/fixtures/with-config/with-config.test.js
@@ -14,11 +14,14 @@ const hooks = [
 
 describe('with-config', () => {
   buildFixture('with-config', () => {
-    expect(consola.warn).toHaveBeenCalledTimes(4)
+    expect(consola.warn).toHaveBeenCalledTimes(5)
     expect(consola.fatal).toHaveBeenCalledTimes(0)
     expect(consola.warn.mock.calls).toMatchObject([
       [
         'Unknown mode: unknown. Falling back to universal'
+      ],
+      [
+        'Invalid plugin mode (server/client): abc. Falling back to default'
       ],
       [{
         message: 'Found 2 plugins that match the configuration, suggest to specify extension:',

--- a/test/fixtures/with-config/with-config.test.js
+++ b/test/fixtures/with-config/with-config.test.js
@@ -21,7 +21,7 @@ describe('with-config', () => {
         'Unknown mode: unknown. Falling back to universal'
       ],
       [
-        'Invalid plugin mode (server/client): abc. Falling back to default'
+        `Invalid plugin mode (server/client/all): 'abc'. Falling back to 'all'`
       ],
       [{
         message: 'Found 2 plugins that match the configuration, suggest to specify extension:',

--- a/test/fixtures/with-config/with-config.test.js
+++ b/test/fixtures/with-config/with-config.test.js
@@ -14,14 +14,11 @@ const hooks = [
 
 describe('with-config', () => {
   buildFixture('with-config', () => {
-    expect(consola.warn).toHaveBeenCalledTimes(5)
+    expect(consola.warn).toHaveBeenCalledTimes(4)
     expect(consola.fatal).toHaveBeenCalledTimes(0)
     expect(consola.warn.mock.calls).toMatchObject([
       [
         'Unknown mode: unknown. Falling back to universal'
-      ],
-      [
-        'ssr in plugin options has been deprecated, please use mode instead'
       ],
       [{
         message: 'Found 2 plugins that match the configuration, suggest to specify extension:',

--- a/test/unit/with-config.test.js
+++ b/test/unit/with-config.test.js
@@ -91,6 +91,8 @@ describe('with-config', () => {
 
     expect(window.__test_plugin).toBe(true)
     expect(window.__test_plugin_ext).toBe(true)
+    expect(window.__test_plugin_client).toBe(true)
+    expect(window.__test_plugin_server).toBe(false)
   })
 
   test('/test/about (custom layout)', async () => {

--- a/test/unit/with-config.test.js
+++ b/test/unit/with-config.test.js
@@ -91,8 +91,8 @@ describe('with-config', () => {
 
     expect(window.__test_plugin).toBe(true)
     expect(window.__test_plugin_ext).toBe(true)
-    expect(window.__test_plugin_client).toBe(true)
-    expect(window.__test_plugin_server).toBe(false)
+    expect(window.__test_plugin_client).toBe('test_plugin_client')
+    expect(window.__test_plugin_server).toBeUndefined()
   })
 
   test('/test/about (custom layout)', async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

The idea is from @Atinux , use `.server.js` or `.client.js` to automatically detect server/client side plugin.

1. introduce `mode: 'client|server'` in plugin options
2. deprecate `ssr` in plugin options and use `mode: 'client|server'` instead, for now auto adapt `ssr: false` to `mode: 'client'` and show deprecating log.
3. apply `server/client` plugin on file ext like: `server.js` or `client.js` (**specified options has higher priority**)

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

