### PR TITLE
chore(deps): Fix dependencies order in some package.json's

### DIFF
--- a/distributions/nuxt-legacy/package.json
+++ b/distributions/nuxt-legacy/package.json
@@ -53,8 +53,8 @@
     "@nuxt/common": "2.3.4",
     "@nuxt/core": "2.3.4",
     "@nuxt/generator": "2.3.4",
-    "@nuxt/webpack": "2.3.4",
-    "@nuxt/opencollective": "^0.2.1"
+    "@nuxt/opencollective": "^0.2.1",
+    "@nuxt/webpack": "2.3.4"
   },
   "engines": {
     "node": ">=6.0.0",

--- a/distributions/nuxt/package.json
+++ b/distributions/nuxt/package.json
@@ -53,8 +53,8 @@
     "@nuxt/common": "2.3.4",
     "@nuxt/core": "2.3.4",
     "@nuxt/generator": "2.3.4",
-    "@nuxt/webpack": "2.3.4",
-    "@nuxt/opencollective": "^0.2.1"
+    "@nuxt/opencollective": "^0.2.1",
+    "@nuxt/webpack": "2.3.4"
   },
   "engines": {
     "node": ">=8.0.0",

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -9,8 +9,8 @@
   "main": "dist/builder.js",
   "dependencies": {
     "@nuxt/common": "2.3.4",
-    "@nuxt/vue-app": "2.3.4",
     "@nuxt/devalue": "^1.2.0",
+    "@nuxt/vue-app": "2.3.4",
     "chokidar": "^2.0.4",
     "consola": "^2.3.0",
     "fs-extra": "^7.0.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,9 +10,9 @@
   "dependencies": {
     "@nuxt/common": "2.3.4",
     "@nuxt/config": "2.3.4",
+    "@nuxt/devalue": "^1.2.0",
     "@nuxt/server": "2.3.4",
     "@nuxt/vue-renderer": "2.3.4",
-    "@nuxt/devalue": "^1.2.0",
     "consola": "^2.3.0",
     "debug": "^4.1.0",
     "esm": "^3.0.84",


### PR DESCRIPTION
# Description

`yarn build` is automatically creating these changes since https://github.com/nuxt/nuxt.js/commit/8b366fd216ce3aeafd0db2925f6555d96311999a

This PR fixes the (alphabetical) order of the dependencies which are now using `@nuxt/{dep}` instead of `@nuxtjs/{dep}`.

Idea suggested by @pi0 : CI Pipeline build should fail if version controlled file has been changed during the build.