### PR TITLE
feat(webpack,cli): standalone build mode

### DIFF
--- a/packages/cli/src/commands/build.js
+++ b/packages/cli/src/commands/build.js
@@ -33,7 +33,7 @@ export default {
     generate: {
       type: 'boolean',
       default: true,
-      description: 'Don\'t generate static version for SPA mode (useful for nuxt start)'
+      description: 'Don\'t generate static version for SPA mode (useful for nuxt-start)'
     },
     quiet: {
       alias: 'q',
@@ -44,6 +44,16 @@ export default {
         options.build = options.build || {}
         if (argv.quiet) {
           options.build.quiet = !!argv.quiet
+        }
+      }
+    },
+    standalone: {
+      type: 'boolean',
+      default: false,
+      description: 'Bundle all server dependencies (useful for nuxt-start)',
+      prepare(cmd, options, argv) {
+        if (argv.standalone) {
+          options.build.standalone = true
         }
       }
     }

--- a/packages/cli/src/commands/build.js
+++ b/packages/cli/src/commands/build.js
@@ -33,7 +33,7 @@ export default {
     generate: {
       type: 'boolean',
       default: true,
-      description: 'Don\'t generate static version for SPA mode (useful for nuxt-start)'
+      description: 'Don\'t generate static version for SPA mode (useful for nuxt start)'
     },
     quiet: {
       alias: 'q',

--- a/packages/config/src/config/build.js
+++ b/packages/config/src/config/build.js
@@ -10,6 +10,7 @@ export default () => ({
   ssr: undefined,
   parallel: false,
   cache: false,
+  standalone: false,
   publicPath: '/_nuxt/',
   filenames: {
     // { isDev, isClient, isServer }

--- a/packages/webpack/src/config/server.js
+++ b/packages/webpack/src/config/server.js
@@ -86,16 +86,18 @@ export default class WebpackServerConfig extends WebpackBaseConfig {
     // https://webpack.js.org/configuration/externals/#externals
     // https://github.com/liady/webpack-node-externals
     // https://vue-loader.vuejs.org/migrating.html#ssr-externals
-    this.options.modulesDir.forEach((dir) => {
-      if (fs.existsSync(dir)) {
-        config.externals.push(
-          nodeExternals({
-            whitelist: this.whitelist,
-            modulesDir: dir
-          })
-        )
-      }
-    })
+    if (!this.options.build.standalone && !this.options.dev) {
+      this.options.modulesDir.forEach((dir) => {
+        if (fs.existsSync(dir)) {
+          config.externals.push(
+            nodeExternals({
+              whitelist: this.whitelist,
+              modulesDir: dir
+            })
+          )
+        }
+      })
+    }
 
     return config
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
This PR implements @clarkdo idea (https://github.com/nuxt/nuxt.js/pull/4645#issuecomment-450365285) for standalone build mode and resolves #4645.

The `build.standalone` option is turned off by default to prevent any behaviour/breaking changes.

## Benchmarks

- Tested on bare-bone hello-world
- Cold start time is measured using the production build of nuxt. From reading config until `nuxt.ready()`
- Built on windows (Yeah I'm using windows again :P)

Normal build: 
- Size of `server.js`: `22 Kib`
- Cost of dependencies (`vue`, `vue-router`,  `lodash` (/omit), `vue-no-ssr`, `debug`): `7.4M`
- Cold start: `306.385ms`
- Memory usage: `29.9` MB (RSS: `106 MB`) 

Standalone build:
- Size of `server.js`:  `145 Kib`
- cold start: `306.550ms`
- Memory usage: `28.6 MB` (RSS: `106 MB`)

Results prove that there should be no big runtime diffs with the standalone mode. Still, we need to benchmark nuxt against real-world projects to decide on the default value.

## Remarks

- This is strange what dependency adds `lodash/omit` to the server bundle. Standalone build tree shakes only needed parts but should be still addressed
- We need to announce users to use `nuxt build --standalone` when they need to use it with `nuxt-start`. 
  - Alternative: For now we can add dependencies again to the `nuxt-start` distribution but it makes package bigger again

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

