### PR TITLE
fix: Vue.component('RouterLink') is undefined in vue-router 3.0.0

### DIFF
--- a/packages/vue-app/template/router.js
+++ b/packages/vue-app/template/router.js
@@ -81,6 +81,12 @@ const _routes = recursiveRoutes(router.routes, '  ', _components, 2)
 }).join('\n')%>
 
 Vue.use(Router)
+// router-view was changed to RouterView in vue-router 3.0.2
+// Fix: Vue.component('RouterLink') is undefined in vue-router 3.0.0
+if (!Vue.component('RouterLink')) {
+  Vue.options.components['RouterView'] = Vue.component('router-view')
+  Vue.options.components['RouterLink'] = Vue.component('router-link')
+}
 
 <% if (router.scrollBehavior) { %>
 const scrollBehavior = <%= serializeFunction(router.scrollBehavior) %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] All new and existing tests are passing.

