### PR TITLE
feat(builder): validate vue-app dependencies and suggest fix

### DIFF
--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -18,6 +18,7 @@
     "hash-sum": "^1.0.2",
     "lodash": "^4.17.11",
     "pify": "^4.0.1",
+    "semver": "^5.6.0",
     "serialize-javascript": "^1.6.1",
     "upath": "^1.1.0"
   },

--- a/packages/builder/src/builder.js
+++ b/packages/builder/src/builder.js
@@ -207,9 +207,11 @@ export default class Builder {
     }
 
     // Validate template
-    await this.validateTemplate().catch((error) => {
-      consola.fatal(error)
-    })
+    try {
+      this.validateTemplate()
+    } catch (err) {
+      consola.fatal(err)
+    }
 
     consola.success('Builder initialized')
 
@@ -243,7 +245,7 @@ export default class Builder {
     return this
   }
 
-  async validateTemplate() {
+  validateTemplate() {
     // Validate template dependencies
     const templateDependencies = this.template.dependencies
     const dpendencyFixes = []

--- a/packages/builder/src/builder.js
+++ b/packages/builder/src/builder.js
@@ -7,6 +7,7 @@ import hash from 'hash-sum'
 import pify from 'pify'
 import serialize from 'serialize-javascript'
 import upath from 'upath'
+import semver from 'semver'
 
 import debounce from 'lodash/debounce'
 import omit from 'lodash/omit'
@@ -75,7 +76,7 @@ export default class Builder {
     // Resolve template
     this.template = this.options.build.template || '@nuxt/vue-app'
     if (typeof this.template === 'string') {
-      this.template = this.nuxt.resolver.requireModule(this.template)
+      this.template = this.nuxt.resolver.requireModule(this.template).template
     }
 
     // if(!this.options.dev) {
@@ -205,6 +206,11 @@ export default class Builder {
       }
     }
 
+    // Validate template
+    await this.validateTemplate().catch((error) => {
+      consola.fatal(error)
+    })
+
     consola.success('Builder initialized')
 
     consola.debug(`App root: ${this.options.srcDir}`)
@@ -237,6 +243,43 @@ export default class Builder {
     return this
   }
 
+  async validateTemplate() {
+    // Validate template dependencies
+    const templateDependencies = this.template.dependencies
+    const dpendencyFixes = []
+    for (const depName in templateDependencies) {
+      const depVersion = templateDependencies[depName]
+      const requiredVersion = `${depName}@${depVersion}`
+
+      // Load installed version
+      const pkg = this.nuxt.resolver.requireModule(path.join(depName, 'package.json'))
+      if (pkg) {
+        const validVersion = semver.satisfies(pkg.version, depVersion)
+        if (!validVersion) {
+          consola.warn(`${requiredVersion} is required but ${depName}@${pkg.version} is installed!`)
+          dpendencyFixes.push(requiredVersion)
+        }
+      } else {
+        consola.warn(`${depName}@${depVersion} is required but not installed!`)
+        dpendencyFixes.push(requiredVersion)
+      }
+    }
+
+    // Suggest dependency fixes (TODO: automate me)
+    if (dpendencyFixes.length) {
+      consola.error(
+        `Please install missing dependencies:\n`,
+        '\n',
+        `Using yarn:\n`,
+        `yarn add ${dpendencyFixes.join(' ')}\n`,
+        '\n',
+        `Using npm:\n`,
+        `npm i ${dpendencyFixes.join(' ')}\n`
+      )
+      throw new Error('Missing Template Dependencies')
+    }
+  }
+
   async generateRoutesAndFiles() {
     consola.debug(`Generating nuxt files`)
 
@@ -244,7 +287,7 @@ export default class Builder {
     this.plugins = Array.from(this.normalizePlugins())
 
     // -- Templates --
-    let templatesFiles = Array.from(this.template.templatesFiles)
+    let templatesFiles = Array.from(this.template.files)
 
     const templateVars = {
       options: this.options,
@@ -325,7 +368,7 @@ export default class Builder {
     if (this._defaultPage) {
       templateVars.router.routes = createRoutes(
         ['index.vue'],
-        this.template.templatesDir + '/pages',
+        this.template.dir + '/pages',
         '',
         this.options.router.routeNameSplitter
       )

--- a/packages/builder/src/builder.js
+++ b/packages/builder/src/builder.js
@@ -441,7 +441,7 @@ export default class Builder {
         const customFileExists = fsExtra.existsSync(customPath)
 
         return {
-          src: customFileExists ? customPath : r(this.template.templatesDir, file),
+          src: customFileExists ? customPath : r(this.template.dir, file),
           dst: file,
           custom: customFileExists
         }
@@ -466,7 +466,7 @@ export default class Builder {
     // -- Loading indicator --
     if (this.options.loadingIndicator.name) {
       const indicatorPath1 = path.resolve(
-        this.template.templatesDir,
+        this.template.dir,
         'views/loading',
         this.options.loadingIndicator.name + '.html'
       )

--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -253,14 +253,6 @@ export function getNuxtConfig(_options) {
     delete options.render.gzip
   }
 
-  if (options.nuxtAppDir) {
-    consola.warn('nuxtAppDir is deprecated and will be removed in a future version! Please switch to build.template')
-    options.build.template = {
-      templatesDir: options.nuxtAppDir
-    }
-    delete options.nuxtAppDir
-  }
-
   // Apply mode preset
   const modePreset = options.modes[options.mode || 'universal']
 

--- a/packages/vue-app/src/index.js
+++ b/packages/vue-app/src/index.js
@@ -1,26 +1,26 @@
 import path from 'path'
-import pkg from '../package.json'
+import { dependencies } from '../package.json'
 
-export const meta = pkg
-
-export const templatesDir = path.join(__dirname, '..', 'template')
-
-export const templatesFiles = [
-  'App.js',
-  'client.js',
-  'index.js',
-  'middleware.js',
-  'router.js',
-  'server.js',
-  'utils.js',
-  'empty.js',
-  'components/nuxt-error.vue',
-  'components/nuxt-loading.vue',
-  'components/nuxt-child.js',
-  'components/nuxt-link.server.js',
-  'components/nuxt-link.client.js',
-  'components/nuxt.js',
-  'components/no-ssr.js',
-  'views/app.template.html',
-  'views/error.html'
-]
+export const template = {
+  dependencies,
+  dir: path.join(__dirname, '..', 'template'),
+  files: [
+    'App.js',
+    'client.js',
+    'index.js',
+    'middleware.js',
+    'router.js',
+    'server.js',
+    'utils.js',
+    'empty.js',
+    'components/nuxt-error.vue',
+    'components/nuxt-loading.vue',
+    'components/nuxt-child.js',
+    'components/nuxt-link.server.js',
+    'components/nuxt-link.client.js',
+    'components/nuxt.js',
+    'components/no-ssr.js',
+    'views/app.template.html',
+    'views/error.html'
+  ]
+}

--- a/packages/vue-app/template/router.js
+++ b/packages/vue-app/template/router.js
@@ -81,12 +81,6 @@ const _routes = recursiveRoutes(router.routes, '  ', _components, 2)
 }).join('\n')%>
 
 Vue.use(Router)
-// router-view was changed to RouterView in vue-router 3.0.2
-// Fix: Vue.component('RouterLink') is undefined in vue-router 3.0.0
-if (!Vue.component('RouterLink')) {
-  Vue.options.components['RouterView'] = Vue.component('router-view')
-  Vue.options.components['RouterLink'] = Vue.component('router-link')
-}
 
 <% if (router.scrollBehavior) { %>
 const scrollBehavior = <%= serializeFunction(router.scrollBehavior) %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
**Background:** Nuxt requires all peer like dependencies as a dependency for easier usage. Sometimes this causes unwanted behaviors when users explicitly add a specific version in their `package.json` which is incompatible with nuxt.

This could also help to resolve popular `Vue packages version mismatch` error (#198, #669, #1084, #1414, #1851, #2079, #2406, #3454) and also regressions like #4668 that `vue-router@^3.0.2` is required by Nuxt and has fixes but users may encounter problems if anyhow they are still using `vue-router@3.0.0`.

Example error:
![image](https://user-images.githubusercontent.com/5158436/50593651-613d0c80-0eae-11e9-89b4-396c5f64d31d.png)


## Future improvements

- Automate dependency installs

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

