### PR TITLE
feat: add styleExtensions

### DIFF
--- a/packages/config/src/config/_common.js
+++ b/packages/config/src/config/_common.js
@@ -42,6 +42,7 @@ export default () => ({
     store: 'store'
   },
   extensions: [],
+  styleExtensions: [],
 
   // Ignores
   ignorePrefix: '-',

--- a/packages/config/src/config/_common.js
+++ b/packages/config/src/config/_common.js
@@ -42,7 +42,7 @@ export default () => ({
     store: 'store'
   },
   extensions: [],
-  styleExtensions: [],
+  styleExtensions: ['css', 'pcss', 'postcss', 'styl', 'stylus', 'scss', 'sass', 'less'],
 
   // Ignores
   ignorePrefix: '-',

--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -43,6 +43,21 @@ export function getNuxtConfig(_options) {
     options.extensions = [options.extensions]
   }
 
+  const styleExtensionDefaults = ['css', 'pcss', 'postcss', 'styl', 'stylus', 'scss', 'sass', 'less']
+
+  if (!options.styleExtensions) {
+    options.styleExtensions = styleExtensionDefaults
+  }
+
+  if (typeof options.styleExtensions === 'function') {
+    // Execute functions with defaults passed in as first argument
+    options.styleExtensions = options.styleExtensions(styleExtensionDefaults)
+  }
+
+  if (typeof options.styleExtensions === 'string') {
+    options.styleExtensions = [options.styleExtensions]
+  }
+
   options.globalName = (isNonEmptyString(options.globalName) && /^[a-zA-Z]+$/.test(options.globalName))
     ? options.globalName.toLowerCase()
     : `nuxt`

--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -43,21 +43,6 @@ export function getNuxtConfig(_options) {
     options.extensions = [options.extensions]
   }
 
-  const styleExtensionDefaults = ['css', 'pcss', 'postcss', 'styl', 'stylus', 'scss', 'sass', 'less']
-
-  if (!options.styleExtensions) {
-    options.styleExtensions = styleExtensionDefaults
-  }
-
-  if (typeof options.styleExtensions === 'function') {
-    // Execute functions with defaults passed in as first argument
-    options.styleExtensions = options.styleExtensions(styleExtensionDefaults)
-  }
-
-  if (typeof options.styleExtensions === 'string') {
-    options.styleExtensions = [options.styleExtensions]
-  }
-
   options.globalName = (isNonEmptyString(options.globalName) && /^[a-zA-Z]+$/.test(options.globalName))
     ? options.globalName.toLowerCase()
     : `nuxt`

--- a/packages/core/src/resolver.js
+++ b/packages/core/src/resolver.js
@@ -46,7 +46,7 @@ export default class Resolver {
     return resolve(this.options.srcDir, path)
   }
 
-  resolvePath(path, { alias, module } = {}) {
+  resolvePath(path, { alias, module, isStyle } = {}) {
     // Fast return in case of path exists
     if (fs.existsSync(path)) {
       return path
@@ -80,8 +80,10 @@ export default class Resolver {
       }
     }
 
+    const extensions = isStyle ? this.options.styleExtensions : this.options.extensions
+
     // Check if any resolvedPath.[ext] or resolvedPath/index.[ext] exists
-    for (const ext of this.options.extensions) {
+    for (const ext of extensions) {
       if (!isDirectory && fs.existsSync(resolvedPath + '.' + ext)) {
         return resolvedPath + '.' + ext
       }

--- a/packages/vue-app/template/App.js
+++ b/packages/vue-app/template/App.js
@@ -1,7 +1,7 @@
 import Vue from 'vue'
 <% if (loading) { %>import NuxtLoading from '<%= (typeof loading === "string" ? loading : "./components/nuxt-loading.vue") %>'<% } %>
 <% css.forEach((c) => { %>
-import '<%= relativeToBuild(resolvePath(c.src || c)) %>'
+import '<%= relativeToBuild(resolvePath(c.src || c, { isStyle: true })) %>'
 <% }) %>
 
 <%= Object.keys(layouts).map((key) => {

--- a/test/fixtures/with-config/nuxt.config.js
+++ b/test/fixtures/with-config/nuxt.config.js
@@ -80,7 +80,8 @@ export default {
       })
     }
   },
-  css: [{ src: '~/assets/app.pcss' }],
+  css: [{ src: '~/assets/app' }],
+  styleExtensions: currentExtensions => currentExtensions.filter(e => e === 'pcss'),
   render: {
     csp: true,
     http2: {

--- a/test/fixtures/with-config/nuxt.config.js
+++ b/test/fixtures/with-config/nuxt.config.js
@@ -81,7 +81,6 @@ export default {
     }
   },
   css: [{ src: '~/assets/app' }],
-  styleExtensions: currentExtensions => currentExtensions.filter(e => e === 'pcss'),
   render: {
     csp: true,
     http2: {


### PR DESCRIPTION
In your `css` array, you have to write the corresponding extension when providing your stylesheets. While transitioning from SCSS to PostCSS in several projects, I thought: "Why not completely omitting the extension as we do it for JS resolves :thinking:?"

There we go! 

## Types of changes
- [x] New feature (a non-breaking change which adds functionality)

## Checklist:
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

