### PR TITLE
fix(server): process browser version with non semver versions

### DIFF
--- a/packages/server/src/middleware/modern.js
+++ b/packages/server/src/middleware/modern.js
@@ -17,6 +17,9 @@ const isModernBrowser = (ua) => {
   }
   const { browser } = UAParser(ua)
   const browserVersion = semver.coerce(browser.version)
+  if (!browserVersion) {
+    return false
+  }
   return modernBrowsers[browser.name] && semver.gte(browserVersion, modernBrowsers[browser.name])
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
With user agent like `Opera/12.80 (Windows NT 5.1; U; en) Presto/2.10.289 Version/12.02`
version will be 12.02 and semver.coerse will give a null as a result. And later it will lead to exception at comparing.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

