### PR TITLE
fix: add option to rewatch on path after raw fs event

### DIFF
--- a/packages/config/src/config/_common.js
+++ b/packages/config/src/config/_common.js
@@ -64,6 +64,7 @@ export default () => ({
   // Watch
   watch: [],
   watchers: {
+    rewatchOnRawEvents: env.linux ? ['rename'] : undefined,
     webpack: {},
     chokidar: {
       ignoreInitial: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

This pr improves watching for file changes on linux in dev mode. Node on linux watches on inodes rather than paths, which means if you move a file you are watching an inode with a different name then intended (or no name at all when the file is removed).

Chokidar has a ~bug~ feature that if you pass a path to a non-existing fie it will listen on the folder instead. Due to this the implementation in the first commit was fine at first, but when you started moving files the number of events triggered for the same file grew enormously. The implementation in the second commit prevents this behaviour. There didnt seem to be a real performance difference between the two commits, the time it took for both implementations was somewhere between 0.1 to 0.4ms on my system (both not really consistent).

Due to that ~bug~ feature in chokidar it also has the side effect that every change in the folder (of the missing file) triggers a refresh. Unfortunately this is also not mitigable by comparing to `customPatterns`. But once another file exists with the name we are looking for that stops (with the second implementation).

Currently only implemented for `watcher.custom`, although the same issue applies to `watcher.files`

Not sure if and where I should add tests for this

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

