### PR TITLE
fix: use case insensitive regex for webpack loader rules

### DIFF
--- a/packages/webpack/src/config/base.js
+++ b/packages/webpack/src/config/base.js
@@ -50,7 +50,7 @@ export default class WebpackBaseConfig {
 
   normalizeTranspile() {
     // include SFCs in node_modules
-    const items = [/\.vue\.js/]
+    const items = [/\.vue\.js/i]
     for (const pattern of this.options.build.transpile) {
       if (pattern instanceof RegExp) {
         items.push(pattern)
@@ -188,15 +188,15 @@ export default class WebpackBaseConfig {
 
     return [
       {
-        test: /\.vue$/,
+        test: /\.vue$/i,
         loader: 'vue-loader',
         options: this.loaders.vue
       },
       {
-        test: /\.pug$/,
+        test: /\.pug$/i,
         oneOf: [
           {
-            resourceQuery: /^\?vue/,
+            resourceQuery: /^\?vue/i,
             use: [{
               loader: 'pug-plain-loader',
               options: this.loaders.pugPlain
@@ -214,7 +214,7 @@ export default class WebpackBaseConfig {
         ]
       },
       {
-        test: /\.jsx?$/,
+        test: /\.jsx?$/i,
         exclude: (file) => {
           // not exclude files outside node_modules
           if (!/node_modules/.test(file)) {
@@ -230,12 +230,12 @@ export default class WebpackBaseConfig {
         })
       },
       {
-        test: /\.ts$/,
+        test: /\.ts$/i,
         loader: 'ts-loader',
         options: this.loaders.ts
       },
       {
-        test: /\.tsx$/,
+        test: /\.tsx$/i,
         use: [
           {
             loader: require.resolve('babel-loader'),
@@ -248,43 +248,43 @@ export default class WebpackBaseConfig {
         ]
       },
       {
-        test: /\.css$/,
+        test: /\.css$/i,
         oneOf: styleLoader.apply('css')
       },
       {
-        test: /\.p(ost)?css$/,
+        test: /\.p(ost)?css$/i,
         oneOf: styleLoader.apply('postcss')
       },
       {
-        test: /\.less$/,
+        test: /\.less$/i,
         oneOf: styleLoader.apply('less', {
           loader: 'less-loader',
           options: this.loaders.less
         })
       },
       {
-        test: /\.sass$/,
+        test: /\.sass$/i,
         oneOf: styleLoader.apply('sass', {
           loader: 'sass-loader',
           options: this.loaders.sass
         })
       },
       {
-        test: /\.scss$/,
+        test: /\.scss$/i,
         oneOf: styleLoader.apply('scss', {
           loader: 'sass-loader',
           options: this.loaders.scss
         })
       },
       {
-        test: /\.styl(us)?$/,
+        test: /\.styl(us)?$/i,
         oneOf: styleLoader.apply('stylus', {
           loader: 'stylus-loader',
           options: this.loaders.stylus
         })
       },
       {
-        test: /\.(png|jpe?g|gif|svg|webp)$/,
+        test: /\.(png|jpe?g|gif|svg|webp)$/i,
         use: perfLoader.asset().concat({
           loader: 'url-loader',
           options: Object.assign(
@@ -294,7 +294,7 @@ export default class WebpackBaseConfig {
         })
       },
       {
-        test: /\.(woff2?|eot|ttf|otf)(\?.*)?$/,
+        test: /\.(woff2?|eot|ttf|otf)(\?.*)?$/i,
         use: perfLoader.asset().concat({
           loader: 'url-loader',
           options: Object.assign(
@@ -304,7 +304,7 @@ export default class WebpackBaseConfig {
         })
       },
       {
-        test: /\.(webm|mp4|ogv)$/,
+        test: /\.(webm|mp4|ogv)$/i,
         use: perfLoader.asset().concat({
           loader: 'file-loader',
           options: Object.assign(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
currently the `url-loader` etc cannot handle file extension in all cap e.g. `PNG`, `JPEG`
[error sample](https://stackoverflow.com/questions/54102363/nuxt-and-webpack-module-parse-failed-unexpected-character-10)
This PR fixes this by making the regex test case insensitive

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

This fix seems trivial, but if new tests are needed, I don't really have an idea which case to add it into, please comment.