### PR TITLE
feat(nuxt-ts): typescript support improvements

### DIFF
--- a/examples/typescript-vuex/tsconfig.json
+++ b/examples/typescript-vuex/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "esnext",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["es2015", "dom"],
+    "lib": ["esnext", "esnext.asynciterable", "dom"],
     "esModuleInterop": true,
     "experimentalDecorators": true,
     "allowJs": true,

--- a/examples/typescript/tsconfig.json
+++ b/examples/typescript/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "esnext",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["es2015", "dom"],
+    "lib": ["esnext", "esnext.asynciterable", "dom"],
     "esModuleInterop": true,
     "experimentalDecorators": true,
     "allowJs": true,

--- a/packages/cli/src/utils/index.js
+++ b/packages/cli/src/utils/index.js
@@ -9,7 +9,7 @@ import chalk from 'chalk'
 import prettyBytes from 'pretty-bytes'
 import env from 'std-env'
 
-export const requireModule = esm(module, {
+export const requireModule = process.env.NUXT_TS ? require : esm(module, {
   cache: false,
   cjs: {
     cache: true,

--- a/packages/webpack/src/config/base.js
+++ b/packages/webpack/src/config/base.js
@@ -185,6 +185,10 @@ export default class WebpackBaseConfig {
       this.nuxt,
       { isServer: this.isServer, perfLoader }
     )
+    const babelLoader = {
+      loader: require.resolve('babel-loader'),
+      options: this.getBabelOptions()
+    }
 
     return [
       {
@@ -224,23 +228,22 @@ export default class WebpackBaseConfig {
           // item in transpile can be string or regex object
           return !this.modulesToTranspile.some(module => module.test(file))
         },
-        use: perfLoader.js().concat({
-          loader: require.resolve('babel-loader'),
-          options: this.getBabelOptions()
-        })
+        use: perfLoader.js().concat(babelLoader)
       },
       {
         test: /\.ts$/i,
-        loader: 'ts-loader',
-        options: this.loaders.ts
+        use: [
+          babelLoader,
+          {
+            loader: 'ts-loader',
+            options: this.loaders.ts
+          }
+        ]
       },
       {
         test: /\.tsx$/i,
         use: [
-          {
-            loader: require.resolve('babel-loader'),
-            options: this.getBabelOptions()
-          },
+          babelLoader,
           {
             loader: 'ts-loader',
             options: this.loaders.tsx

--- a/test/fixtures/typescript/tsconfig.json
+++ b/test/fixtures/typescript/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "esnext",
     "module": "esnext",
     "moduleResolution": "node",
     "lib": ["esnext", "esnext.asynciterable", "dom"],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
- Improvement : Let babel transpile TypeScript output for `.ts` files (was already done for `.tsx`)
You know don't have to worry about which ECMAScript version is targeted in your `tsconfig.json`
Targeting `esnext` is now recommended so that TypeScript only transpile TypeScript to `esnext` JS and let Babel take the relay.

- Fix : `nuxt.config.ts` was required with `esm` instead of `ts-node` through `require`


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

