### PR TITLE
feat: add exclude regex array for generated pages

### DIFF
--- a/packages/config/src/config/_common.js
+++ b/packages/config/src/config/_common.js
@@ -55,6 +55,7 @@ export default () => ({
   generate: {
     dir: 'dist',
     routes: [],
+    exclude: [],
     concurrency: 500,
     interval: 0,
     subFolders: true,

--- a/packages/generator/src/generator.js
+++ b/packages/generator/src/generator.js
@@ -4,7 +4,7 @@ import consola from 'consola'
 import fsExtra from 'fs-extra'
 import htmlMinifier from 'html-minifier'
 
-import { flatRoutes, isUrl, promisifyRoute, waitFor, isString } from '@nuxt/utils'
+import { flatRoutes, isString, isUrl, promisifyRoute, waitFor } from '@nuxt/utils'
 
 export default class Generator {
   constructor(nuxt, builder) {
@@ -83,6 +83,11 @@ export default class Generator {
       this.options.router.mode === 'hash'
         ? ['/']
         : flatRoutes(this.options.router.routes)
+
+    this.options.generate.exclude.forEach((regex) => {
+      routes = routes.filter(route => !regex.test(route))
+    })
+
     routes = this.decorateWithPayloads(routes, generateRoutes)
 
     // extendRoutes hook

--- a/packages/generator/src/generator.js
+++ b/packages/generator/src/generator.js
@@ -84,9 +84,7 @@ export default class Generator {
         ? ['/']
         : flatRoutes(this.options.router.routes)
 
-    this.options.generate.exclude.forEach((regex) => {
-      routes = routes.filter(route => !regex.test(route))
-    })
+    routes = routes.filter(route => this.options.generate.exclude.every(regex => !regex.test(route)))
 
     routes = this.decorateWithPayloads(routes, generateRoutes)
 


### PR DESCRIPTION
This PR will add a property called `generate.exclude`. It accepts an array of regular expressions and will prevent generation of routes matching them. The routes will still be accessible when `generate.fallback` is used.

## Use cases

* Having routes like `/admin` in the Nuxt app that don't need to be generated upfront but still need to be accessible
* Modules like [sitemap-module](https://github.com/nuxt-community/sitemap-module/blob/dev/src/index.js#L17) could use it as default for excluding routes in `generate` mode.

## Usage

```js
// nuxt.config.js
export default {
  // ...
  generate: {
    //...
    exclude: [/^\/admin/] // exclude every URL starting with "/admin"
  }
}
```

## Testing

Testing this feature is a bit tricky because we never test that the `generated` fallback actually loads the routes in SPA mode. We only test that it has been generated correctly [here](https://github.com/nuxt/nuxt.js/blob/fe0516978a650166bf178c0339dd7657c29e2504/test/unit/fallback.generate.test.js).

## Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

