### PR TITLE
fix(examples): Upgrade `vue-property-decorator` in typescript examples

### DIFF
--- a/examples/typescript-vuex/package.json
+++ b/examples/typescript-vuex/package.json
@@ -5,7 +5,7 @@
     "axios": "^0.18.0",
     "nuxt-ts-edge": "latest",
     "tachyons": "^4.11.1",
-    "vue-property-decorator": "^7.2.0",
+    "vue-property-decorator": "^7.3.0",
     "vuex-class": "^0.3.1"
   },
   "scripts": {

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "nuxt-ts-edge": "latest",
-    "vue-property-decorator": "^7.2.0"
+    "vue-property-decorator": "^7.3.0"
   },
   "scripts": {
     "dev": "nuxt-ts",


### PR DESCRIPTION
Upgrade to `vue-property-decorator@7.3.0` in typescript examples.
