### PR TITLE
fix: Allow listening on number 0 port

### DIFF
--- a/packages/server/src/server.js
+++ b/packages/server/src/server.js
@@ -225,7 +225,7 @@ export default class Server {
   async listen(port, host, socket) {
     // Create a new listener
     const listener = new Listener({
-      port: port || this.options.server.port,
+      port: isNaN(parseInt(port)) ? this.options.server.port : port,
       host: host || this.options.server.host,
       socket: socket || this.options.server.socket,
       https: this.options.server.https,

--- a/test/unit/server.listen.test.js
+++ b/test/unit/server.listen.test.js
@@ -41,4 +41,33 @@ describe('server listen', () => {
 
     await nuxt.close()
   })
+
+  test('should skip the use of default port when listening on port 0', async () => {
+    // Stub process.env.PORT
+    const stubDetails = {
+      originalValue: process.env.PORT,
+      hasProperty: 'PORT' in process.env
+    }
+    const DEFAULT_PORT = '2999'
+    process.env.PORT = DEFAULT_PORT
+
+    // Setup test
+    const nuxt = new Nuxt({ ...config, dev: true })
+    const listen = () => nuxt.server.listen(0, 'localhost') // Use port 0 to let allow host to randomly assign a free PORT
+    const toString = (x = '') => `${x}`
+
+    // Nuxt server should not be listening on the DEFAULT_PORT
+    await listen()
+    expect(toString(nuxt.server.listeners[0].port)).not.toBe(DEFAULT_PORT)
+
+    // Reset stub for process.env.PORT
+    if (stubDetails.hasProperty) {
+      process.env.PORT = stubDetails.originalValue
+    } else {
+      delete process.env.PORT
+    }
+
+    // Finalize test
+    await nuxt.close()
+  })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
### Why is this change required?
This PR allow the server to listen on port number `0`. In some machine, port `0` let the host machine dynamically generate a unused port for an application.

https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers#Well-known_ports
> In programming APIs (not in communication between hosts), requests a system-allocated (dynamic) port[5]
>  ["Linux/net/ipv4/inet_connection_sock.c". LXR. Retrieved 2015-01-17.](https://elixir.bootlin.com/linux/v3.18/source/net/ipv4/inet_connection_sock.c#L89)

### What problem does it solve?
When a number `0` is supplied to `nuxt.server.listen` as port, it will be treated as FALSEY. This caused the default server port (3000) to be used instead.

```js
const listener = new Listener({
      port: port || this.options.server.port,
```

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

```
 PASS  test/unit/server.listen.test.js
  server listen
    √ should throw error when listening on same port (prod) (179ms)
    √ should assign a random port when listening on same port (dev) (12ms)
    √ should skip the use of default port when listening on port 0 (5ms)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        4.558s, estimated 5s
```

