### PR TITLE
fix(ts): Add missing `loading` property to Component options

### DIFF
--- a/packages/vue-app/types/vue.d.ts
+++ b/packages/vue-app/types/vue.d.ts
@@ -14,6 +14,7 @@ declare module "vue/types/options" {
     head?: MetaInfo | (() => MetaInfo);
     key?: string | ((to: Route) => string);
     layout?: string | ((ctx: Context) => string);
+    loading?: boolean;
     middleware?: Middleware | Middleware[];
     scrollToTop?: boolean;
     transition?: string | Transition | ((to: Route, from: Route) => string);

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -48,6 +48,10 @@ options.head = () => metaInfo
 options.layout = 'foo'
 options.layout = (context) => 'foo'
 
+// loading
+
+options.loading = true
+
 // middleware
 
 const middlewares: types.Middleware[] = [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
See :
https://nuxtjs.org/examples/custom-page-loading => `about.vue`
https://github.com/nuxt/nuxt.js/blob/dev/packages/vue-app/template/client.js#L388

This PR add missing typedefs and is also linked to missing documentation of the `loading` property in pages/components.

## Todo
- [x] Fix
- [x] Documentation (https://github.com/nuxt/docs/pull/1111)

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. (PR: https://github.com/nuxt/docs/pull/1111)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

