### PR TITLE
fix(ts): prevent checking types twice in modern mode & use consola as logger

### DIFF
--- a/packages/webpack/src/config/client.js
+++ b/packages/webpack/src/config/client.js
@@ -136,7 +136,7 @@ export default class WebpackClientConfig extends WebpackBaseConfig {
 
     // TypeScript type checker
     // Only performs once per client compilation and only if `ts-loader` checker is not used (transpileOnly: true)
-    if (this.loaders.ts.transpileOnly && this.options.build.useForkTsChecker) {
+    if (!this.isModern && this.loaders.ts.transpileOnly && this.options.build.useForkTsChecker) {
       const forkTsCheckerResolvedPath = this.nuxt.resolver.resolveModule('fork-ts-checker-webpack-plugin')
       if (forkTsCheckerResolvedPath) {
         const ForkTsCheckerWebpackPlugin = require(forkTsCheckerResolvedPath)
@@ -145,7 +145,8 @@ export default class WebpackClientConfig extends WebpackBaseConfig {
           tsconfig: path.resolve(this.options.rootDir, 'tsconfig.json'),
           // https://github.com/Realytics/fork-ts-checker-webpack-plugin#options - tslint: boolean | string - So we set it false if file not found
           tslint: (tslintPath => fs.existsSync(tslintPath) && tslintPath)(path.resolve(this.options.rootDir, 'tslint.json')),
-          formatter: 'codeframe'
+          formatter: 'codeframe',
+          logger: consola
         }, this.options.build.useForkTsChecker)))
       } else {
         consola.warn('You need to install `fork-ts-checker-webpack-plugin` as devDependency to enable TypeScript type checking !')
@@ -171,7 +172,7 @@ export default class WebpackClientConfig extends WebpackBaseConfig {
         // https://github.com/glenjamin/webpack-hot-middleware#config
         `webpack-hot-middleware/client?name=${this.name}&reload=true&timeout=30000&path=${
           this.options.router.base
-        }/__webpack_hmr/${this.name}`.replace(/\/\//g, '/')
+          }/__webpack_hmr/${this.name}`.replace(/\/\//g, '/')
       )
     }
 

--- a/packages/webpack/src/config/client.js
+++ b/packages/webpack/src/config/client.js
@@ -172,7 +172,7 @@ export default class WebpackClientConfig extends WebpackBaseConfig {
         // https://github.com/glenjamin/webpack-hot-middleware#config
         `webpack-hot-middleware/client?name=${this.name}&reload=true&timeout=30000&path=${
           this.options.router.base
-          }/__webpack_hmr/${this.name}`.replace(/\/\//g, '/')
+        }/__webpack_hmr/${this.name}`.replace(/\/\//g, '/')
       )
     }
 

--- a/test/unit/typescript.modern.test.js
+++ b/test/unit/typescript.modern.test.js
@@ -1,0 +1,25 @@
+import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin'
+import { loadFixture, Nuxt, Builder, BundleBuilder } from '../utils'
+
+jest.mock('fork-ts-checker-webpack-plugin')
+
+describe('typescript modern', () => {
+  let nuxt
+
+  beforeAll(async () => {
+    process.env.NUXT_TS = 'true'
+    const options = await loadFixture('typescript')
+    nuxt = new Nuxt(Object.assign(options, { modern: true }))
+    await new Builder(nuxt, BundleBuilder).build()
+    delete process.env.NUXT_TS
+  })
+
+  test('fork-ts-checker-webpack-plugin', () => {
+    expect(ForkTsCheckerWebpackPlugin).toHaveBeenCalledTimes(1)
+  })
+
+  // Close server and ask nuxt to stop listening to file changes
+  afterAll(async () => {
+    await nuxt.close()
+  })
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
In modern mode (`modern: true`), types were checking twice, once for the default client and once for the modern mode client. Only first check is needed.

- [x] Prevent checking types twice in modern mode (+ unit test)
- [x] Use `consola` as default logger for `fork-ts-checker-webpack-plugin`

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

