### PR TITLE
fix(webpack): prevent terser mangling html/vue reserved tags

### DIFF
--- a/packages/webpack/src/config/base.js
+++ b/packages/webpack/src/config/base.js
@@ -17,6 +17,8 @@ import PerfLoader from '../utils/perf-loader'
 import StyleLoader from '../utils/style-loader'
 import WarnFixPlugin from '../plugins/warnfix'
 
+import { vueReservedTags } from '../utils/reserved-tags'
+
 export default class WebpackBaseConfig {
   constructor(builder, options) {
     this.name = options.name
@@ -156,6 +158,9 @@ export default class WebpackBaseConfig {
             },
             output: {
               comments: /^\**!|@preserve|@license|@cc_on/
+            },
+            mangle: {
+              reserved: vueReservedTags
             }
           }
         }, this.options.build.terser))

--- a/packages/webpack/src/config/base.js
+++ b/packages/webpack/src/config/base.js
@@ -17,7 +17,7 @@ import PerfLoader from '../utils/perf-loader'
 import StyleLoader from '../utils/style-loader'
 import WarnFixPlugin from '../plugins/warnfix'
 
-import { vueReservedTags } from '../utils/reserved-tags'
+import { reservedVueTags } from '../utils/reserved-tags'
 
 export default class WebpackBaseConfig {
   constructor(builder, options) {
@@ -160,7 +160,7 @@ export default class WebpackBaseConfig {
               comments: /^\**!|@preserve|@license|@cc_on/
             },
             mangle: {
-              reserved: vueReservedTags
+              reserved: reservedVueTags
             }
           }
         }, this.options.build.terser))

--- a/packages/webpack/src/utils/index.js
+++ b/packages/webpack/src/utils/index.js
@@ -1,0 +1,3 @@
+export { default as PerfLoader } from './perf-loader'
+export { default as StyleLoader } from './style-loader'
+export { reservedVueTags } from './reserved-tags'

--- a/packages/webpack/src/utils/reserved-tags.js
+++ b/packages/webpack/src/utils/reserved-tags.js
@@ -1,23 +1,23 @@
-export const htmlTags = (
-  'html,body,base,head,link,meta,style,title,' +
-  'address,article,aside,footer,header,h1,h2,h3,h4,h5,h6,hgroup,nav,section,' +
-  'div,dd,dl,dt,figcaption,figure,picture,hr,img,li,main,ol,p,pre,ul,' +
-  'a,b,abbr,bdi,bdo,br,cite,code,data,dfn,em,i,kbd,mark,q,rp,rt,rtc,ruby,' +
-  's,samp,small,span,strong,sub,sup,time,u,var,wbr,area,audio,map,track,video,' +
-  'embed,object,param,source,canvas,script,noscript,del,ins,' +
-  'caption,col,colgroup,table,thead,tbody,td,th,tr,' +
-  'button,datalist,fieldset,form,input,label,legend,meter,optgroup,option,' +
-  'output,progress,select,textarea,' +
-  'details,dialog,menu,menuitem,summary,' +
-  'content,element,shadow,template,blockquote,iframe,tfoot'
-).split(',')
-
-export const svgTags = (
-  'svg,animate,circle,clippath,cursor,defs,desc,ellipse,filter,font-face,' +
-  'foreignObject,g,glyph,image,line,marker,mask,missing-glyph,path,pattern,' +
-  'polygon,polyline,rect,switch,symbol,text,textpath,tspan,use,view'
-).split(',')
-
-export const vueBuiltInTags = ['slot', 'component']
-
-export const vueReservedTags = [...htmlTags, ...svgTags, ...vueBuiltInTags]
+export const reservedVueTags = [
+  // HTML tags
+  'html', 'body', 'base', 'head', 'link', 'meta', 'style', 'title', 'address',
+  'article', 'aside', 'footer', 'header', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+  'hgroup', 'nav', 'section', 'div', 'dd', 'dl', 'dt', 'figcaption', 'figure',
+  'picture', 'hr', 'img', 'li', 'main', 'ol', 'p', 'pre', 'ul', 'a', 'b', 'abbr',
+  'bdi', 'bdo', 'br', 'cite', 'code', 'data', 'dfn', 'em', 'i', 'kbd', 'mark',
+  'q', 'rp', 'rt', 'rtc', 'ruby', 's', 'samp', 'small', 'span', 'strong', 'sub',
+  'sup', 'time', 'u', 'var', 'wbr', 'area', 'audio', 'map', 'track', 'video',
+  'embed', 'object', 'param', 'source', 'canvas', 'script', 'noscript', 'del',
+  'ins', 'caption', 'col', 'colgroup', 'table', 'thead', 'tbody', 'td', 'th', 'tr',
+  'button', 'datalist', 'fieldset', 'form', 'input', 'label', 'legend', 'meter',
+  'optgroup', 'option', 'output', 'progress', 'select', 'textarea', 'details',
+  'dialog', 'menu', 'menuitem', 'summary', 'content', 'element', 'shadow', 'template',
+  'blockquote', 'iframe', 'tfoot',
+  // SVG tags
+  'svg', 'animate', 'circle', 'clippath', 'cursor', 'defs', 'desc', 'ellipse', 'filter',
+  'font-face', 'foreignObject', 'g', 'glyph', 'image', 'line', 'marker', 'mask',
+  'missing-glyph', 'path', 'pattern', 'polygon', 'polyline', 'rect', 'switch', 'symbol',
+  'text', 'textpath', 'tspan', 'use', 'view',
+  // Vue built-in tags
+  'slot', 'component'
+]

--- a/packages/webpack/src/utils/reserved-tags.js
+++ b/packages/webpack/src/utils/reserved-tags.js
@@ -1,0 +1,23 @@
+export const htmlTags = (
+  'html,body,base,head,link,meta,style,title,' +
+  'address,article,aside,footer,header,h1,h2,h3,h4,h5,h6,hgroup,nav,section,' +
+  'div,dd,dl,dt,figcaption,figure,picture,hr,img,li,main,ol,p,pre,ul,' +
+  'a,b,abbr,bdi,bdo,br,cite,code,data,dfn,em,i,kbd,mark,q,rp,rt,rtc,ruby,' +
+  's,samp,small,span,strong,sub,sup,time,u,var,wbr,area,audio,map,track,video,' +
+  'embed,object,param,source,canvas,script,noscript,del,ins,' +
+  'caption,col,colgroup,table,thead,tbody,td,th,tr,' +
+  'button,datalist,fieldset,form,input,label,legend,meter,optgroup,option,' +
+  'output,progress,select,textarea,' +
+  'details,dialog,menu,menuitem,summary,' +
+  'content,element,shadow,template,blockquote,iframe,tfoot'
+).split(',')
+
+export const svgTags = (
+  'svg,animate,circle,clippath,cursor,defs,desc,ellipse,filter,font-face,' +
+  'foreignObject,g,glyph,image,line,marker,mask,missing-glyph,path,pattern,' +
+  'polygon,polyline,rect,switch,symbol,text,textpath,tspan,use,view'
+).split(',')
+
+export const vueBuiltInTags = ['slot', 'component']
+
+export const vueReservedTags = [...htmlTags, ...svgTags, ...vueBuiltInTags]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
By default, `terser` (the webpack plugin that minify code) mangles names.
https://github.com/terser-js/terser#minify-options

It can happen that variables get mangled to things like `g`, `i`, `b` and in rare cases generate Vue runtime warnings cause these are reserved html tags.

> The warnings for the TypeScript unit test are one of these rare cases (https://circleci.com/gh/nuxt/nuxt.js/24001)

This PR prevents a bunch of reserved tags from being mangled by `terser`, no more warnings :)

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

