### PR TITLE
fix(ts): fix default `tsconfig.json`

### DIFF
--- a/examples/typescript-vuex/tsconfig.json
+++ b/examples/typescript-vuex/tsconfig.json
@@ -1,7 +1,10 @@
 {
   "extends": "@nuxt/typescript-edge",
   "compilerOptions": {
-    "baseUrl": ".",
-    "noImplicitAny": false
+    "noImplicitAny": false,
+    "types": [
+      "@types/node",
+      "@nuxt/vue-app-edge"
+    ]
   }
 }

--- a/examples/typescript/tsconfig.json
+++ b/examples/typescript/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "extends": "@nuxt/typescript-edge",
   "compilerOptions": {
-    "baseUrl": "."
-  }
+    "types": [
+      "@types/node",
+      "@nuxt/vue-app-edge"
+    ]
+  },
 }

--- a/packages/typescript/package.js
+++ b/packages/typescript/package.js
@@ -1,19 +1,3 @@
-import { readJSON, writeJSON } from 'fs-extra'
-
 export default {
-  build: true,
-  hooks: {
-    async 'build:done'(pkg) {
-      if (pkg.options.suffix && pkg.options.linkedDependencies) {
-        const tsconfig = await readJSON(pkg.resolvePath('tsconfig.json'))
-
-        tsconfig.compilerOptions.types = tsconfig.compilerOptions.types.map((type) => {
-          const suffix = pkg.options.linkedDependencies.includes(type) ? pkg.options.suffix : ''
-          return type + suffix
-        })
-
-        await writeJSON(pkg.resolvePath('tsconfig.json'), tsconfig, { spaces: 2 })
-      }
-    }
-  }
+  build: true
 }

--- a/packages/typescript/src/config-generation.js
+++ b/packages/typescript/src/config-generation.js
@@ -22,7 +22,10 @@ export async function generateTsConfigIfMissing(rootDir) {
       await writeJSON(tsConfigPath, {
         extends: configToExtend,
         compilerOptions: {
-          baseUrl: '.'
+          types: [
+            '@types/node',
+            '@nuxt/vue-app'
+          ]
         }
       }, { spaces: 2 })
       consola.info(`Extending ${chalk.bold.blue(`node_modules/${configToExtend}/tsconfig.json`)}`)

--- a/packages/typescript/tsconfig.json
+++ b/packages/typescript/tsconfig.json
@@ -8,7 +8,6 @@
       "dom"
     ],
     "esModuleInterop": true,
-    "resolveJsonModule": true,
     "experimentalDecorators": true,
     "jsx": "preserve",
     "sourceMap": true,
@@ -25,10 +24,6 @@
       "@/*": [
         "./*"
       ]
-    },
-    "types": [
-      "@types/node",
-      "@nuxt/vue-app"
-    ]
+    }
   }
 }

--- a/test/unit/typescript.modern.test.js
+++ b/test/unit/typescript.modern.test.js
@@ -12,7 +12,7 @@ describe('typescript modern', () => {
     await new Builder(nuxt, BundleBuilder).build()
   })
 
-  test('fork-ts-checker-webpack-plugin', () => {
+  test('check types only once', () => {
     expect(ForkTsCheckerWebpackPlugin).toHaveBeenCalledTimes(1)
   })
 

--- a/test/unit/typescript.setup.test.js
+++ b/test/unit/typescript.setup.test.js
@@ -22,7 +22,10 @@ describe('typescript setup', () => {
     expect(await readJSON(tsConfigPath)).toEqual({
       extends: '@nuxt/typescript',
       compilerOptions: {
-        baseUrl: '.'
+        types: [
+          '@types/node',
+          '@nuxt/vue-app'
+        ]
       }
     })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
>(**default** refers to `@nuxt/typescript/tsconfig.json`)
(**final** refers to generated `end-user-project/tsconfig.json`)

The following PR does the following fixes and improvements:
- Remove `baseUrl` in **final** `tsconfig.json` as it's only required for our testing suites
- Remove `resolveJsonModule` as , after little thoughts, we should not force it to users
- Move `types` property from **default** to **final** `tsconfig.json` as there is an issue if end-user wants to add other types in the array (It overrides the whole array if set after extending **default** `tsconfig.json`)
- Remove logic in `packages/typescript/package.js` as it's no longer needed
- Update TypeScript examples to match the above changes
- Update `test/unit/typescript.setup.js` to match the above changes
- Rename a test name in `test/unit/typescript.modern.js` just for better understanding

## Checklist
- [x] I have updated tests to cover my changes
- [ ] All updated and existing tests are passing

