### PR TITLE
chore(examples): rebase on latest stable nuxt version

### DIFF
--- a/examples/async-component-injection/package.json
+++ b/examples/async-component-injection/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-async-components-injection",
   "dependencies": {
-    "nuxt-edge": "latest"
+    "nuxt": "latest"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/async-data/package.json
+++ b/examples/async-data/package.json
@@ -2,7 +2,7 @@
   "name": "example-async-data",
   "dependencies": {
     "axios": "latest",
-    "nuxt-edge": "latest"
+    "nuxt": "latest"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/auth-jwt/package.json
+++ b/examples/auth-jwt/package.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "cookieparser": "^0.1.0",
     "js-cookie": "^2.2.0",
-    "nuxt-edge": "latest"
+    "nuxt": "latest"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/auth-routes/package.json
+++ b/examples/auth-routes/package.json
@@ -5,7 +5,7 @@
     "body-parser": "^1.17.2",
     "express": "^4.15.3",
     "express-session": "^1.15.3",
-    "nuxt-edge": "latest"
+    "nuxt": "latest"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/axios/package.json
+++ b/examples/axios/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@nuxtjs/axios": "^5.0.0",
     "@nuxtjs/proxy": "^1.1.2",
-    "nuxt-edge": "latest"
+    "nuxt": "latest"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/cached-components/package.json
+++ b/examples/cached-components/package.json
@@ -2,7 +2,7 @@
   "name": "example-cached-components",
   "dependencies": {
     "lru-cache": "^4.0.2",
-    "nuxt-edge": "latest"
+    "nuxt": "latest"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/coffeescript/package.json
+++ b/examples/coffeescript/package.json
@@ -11,7 +11,7 @@
     "post-update": "yarn upgrade --latest"
   },
   "dependencies": {
-    "nuxt-edge": "latest"
+    "nuxt": "latest"
   },
   "devDependencies": {
     "coffee-loader": "^0.8.0",

--- a/examples/custom-build/package.json
+++ b/examples/custom-build/package.json
@@ -2,7 +2,7 @@
   "name": "example-custom-build",
   "description": "",
   "dependencies": {
-    "nuxt-edge": "latest"
+    "nuxt": "latest"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/custom-layouts/package.json
+++ b/examples/custom-layouts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-custom-layouts",
   "dependencies": {
-    "nuxt-edge": "latest"
+    "nuxt": "latest"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/custom-loading/package.json
+++ b/examples/custom-loading/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-custom-loading",
   "dependencies": {
-    "nuxt-edge": "latest"
+    "nuxt": "latest"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/custom-page-loading/package.json
+++ b/examples/custom-page-loading/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-custom-page-loading",
   "dependencies": {
-    "nuxt-edge": "latest"
+    "nuxt": "latest"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/custom-port-host/package.json
+++ b/examples/custom-port-host/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-custom-port-host",
   "dependencies": {
-    "nuxt-edge": "latest"
+    "nuxt": "latest"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/custom-routes/package.json
+++ b/examples/custom-routes/package.json
@@ -2,7 +2,7 @@
   "name": "example-custom-routes",
   "dependencies": {
     "axios": "latest",
-    "nuxt-edge": "latest"
+    "nuxt": "latest"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/custom-server/package.json
+++ b/examples/custom-server/package.json
@@ -2,7 +2,7 @@
   "name": "example-custom-server",
   "dependencies": {
     "express": "^4.15.3",
-    "nuxt-edge": "latest"
+    "nuxt": "latest"
   },
   "scripts": {
     "dev": "node server.js",

--- a/examples/dynamic-components/package.json
+++ b/examples/dynamic-components/package.json
@@ -2,7 +2,7 @@
   "name": "example-dynamic-components",
   "dependencies": {
     "chart.js": "^2.7.0",
-    "nuxt-edge": "latest",
+    "nuxt": "latest",
     "vue-chartjs": "^2.8.7"
   },
   "scripts": {

--- a/examples/dynamic-layouts/package.json
+++ b/examples/dynamic-layouts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-dynamic-layouts",
   "dependencies": {
-    "nuxt-edge": "latest"
+    "nuxt": "latest"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/global-css/package.json
+++ b/examples/global-css/package.json
@@ -2,7 +2,7 @@
   "name": "example-global-css",
   "dependencies": {
     "bulma": "^0.5.1",
-    "nuxt-edge": "latest"
+    "nuxt": "latest"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-hello-world",
   "dependencies": {
-    "nuxt-edge": "latest"
+    "nuxt": "latest"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/i18n/package.json
+++ b/examples/i18n/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-i18n",
   "dependencies": {
-    "nuxt-edge": "latest",
+    "nuxt": "latest",
     "vue-i18n": "^7.3.2"
   },
   "scripts": {

--- a/examples/jest-vtu-example/package.json
+++ b/examples/jest-vtu-example/package.json
@@ -9,7 +9,7 @@
     "post-update": "yarn upgrade --latest"
   },
   "dependencies": {
-    "nuxt-edge": "latest"
+    "nuxt": "latest"
   },
   "devDependencies": {
     "@babel/core": "^7.1.2",

--- a/examples/jsx/package.json
+++ b/examples/jsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-jsx",
   "dependencies": {
-    "nuxt-edge": "latest"
+    "nuxt": "latest"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/layout-transitions/package.json
+++ b/examples/layout-transitions/package.json
@@ -2,7 +2,7 @@
   "name": "example-layout-transitions",
   "dependencies": {
     "axios": "^0.15.3",
-    "nuxt-edge": "latest"
+    "nuxt": "latest"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/markdownit/package.json
+++ b/examples/markdownit/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@nuxtjs/markdownit": "^1.1.2",
-    "nuxt-edge": "latest",
+    "nuxt": "latest",
     "pug": "^2.0.0-rc.4"
   },
   "scripts": {

--- a/examples/meta-info/package.json
+++ b/examples/meta-info/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-meta-info",
   "dependencies": {
-    "nuxt-edge": "latest"
+    "nuxt": "latest"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/middleware/package.json
+++ b/examples/middleware/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-middleware",
   "dependencies": {
-    "nuxt-edge": "latest"
+    "nuxt": "latest"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/nested-components/package.json
+++ b/examples/nested-components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-nested-components",
   "dependencies": {
-    "nuxt-edge": "latest"
+    "nuxt": "latest"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/nested-routes/package.json
+++ b/examples/nested-routes/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-nested-routes",
   "dependencies": {
-    "nuxt-edge": "latest"
+    "nuxt": "latest"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/no-ssr/package.json
+++ b/examples/no-ssr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-no-ssr",
   "dependencies": {
-    "nuxt-edge": "latest"
+    "nuxt": "latest"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/nuxt-prefetch/package.json
+++ b/examples/nuxt-prefetch/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-nuxt-prefetch",
   "dependencies": {
-    "nuxt-edge": "latest"
+    "nuxt": "latest"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/plugins-vendor/package.json
+++ b/examples/plugins-vendor/package.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "axios": "^0.16.2",
     "mini-toastr": "^0.6.5",
-    "nuxt-edge": "latest",
+    "nuxt": "latest",
     "vue-notifications": "^0.8.0"
   },
   "scripts": {

--- a/examples/pug/package.json
+++ b/examples/pug/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-pug",
   "dependencies": {
-    "nuxt-edge": "latest",
+    "nuxt": "latest",
     "pug": "^2.0.3",
     "pug-loader": "^2.4.0"
   },

--- a/examples/routes-meta/package.json
+++ b/examples/routes-meta/package.json
@@ -1,7 +1,7 @@
 {
   "name": "examples-routes-meta",
   "dependencies": {
-    "nuxt-edge": "latest",
+    "nuxt": "latest",
     "wingcss": "^1.0.0-beta"
   },
   "scripts": {

--- a/examples/routes-transitions/package.json
+++ b/examples/routes-transitions/package.json
@@ -2,7 +2,7 @@
   "name": "example-routes-transitions",
   "dependencies": {
     "axios": "^0.15.3",
-    "nuxt-edge": "latest"
+    "nuxt": "latest"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/scroll-behavior/package.json
+++ b/examples/scroll-behavior/package.json
@@ -2,7 +2,7 @@
   "name": "example-scroll-behavior",
   "dependencies": {
     "@nuxtjs/axios": "^5.3.6",
-    "nuxt-edge": "latest",
+    "nuxt": "latest",
     "vue-router": "https://github.com/homerjam/vue-router#dist"
   },
   "scripts": {

--- a/examples/spa/package.json
+++ b/examples/spa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-spa",
   "dependencies": {
-    "nuxt-edge": "latest"
+    "nuxt": "latest"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/static-images/package.json
+++ b/examples/static-images/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-static-images",
   "dependencies": {
-    "nuxt-edge": "latest"
+    "nuxt": "latest"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/storybook/package.json
+++ b/examples/storybook/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "chart.js": "^2.7.1",
-    "nuxt-edge": "latest",
+    "nuxt": "latest",
     "vue-chartjs": "^3.1.1",
     "vuetify": "1.2.6"
   },

--- a/examples/style-resources/package.json
+++ b/examples/style-resources/package.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "less": "^2.7.3",
     "less-loader": "^4.0.5",
-    "nuxt-edge": "latest"
+    "nuxt": "latest"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/styled-vue/package.json
+++ b/examples/styled-vue/package.json
@@ -2,7 +2,7 @@
   "name": "example-styled-vue",
   "version": "1.0.0",
   "dependencies": {
-    "nuxt-edge": "latest"
+    "nuxt": "latest"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/tailwindcss/package.json
+++ b/examples/tailwindcss/package.json
@@ -8,7 +8,7 @@
     "post-update": "yarn upgrade --latest"
   },
   "dependencies": {
-    "nuxt-edge": "latest"
+    "nuxt": "latest"
   },
   "devDependencies": {
     "autoprefixer": "^7.1.6",

--- a/examples/typescript-vuex/package.json
+++ b/examples/typescript-vuex/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "axios": "^0.18.0",
-    "nuxt-ts-edge": "latest",
+    "nuxt-ts": "latest",
     "tachyons": "^4.11.1",
     "vue-property-decorator": "^7.3.0",
     "vuex-class": "^0.3.1"

--- a/examples/typescript-vuex/tsconfig.json
+++ b/examples/typescript-vuex/tsconfig.json
@@ -1,11 +1,11 @@
 {
-  "extends": "@nuxt/typescript-edge",
+  "extends": "@nuxt/typescript",
   "compilerOptions": {
     "baseUrl": ".",
     "noImplicitAny": false,
     "types": [
       "@types/node",
-      "@nuxt/vue-app-edge"
+      "@nuxt/vue-app"
     ]
   }
 }

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -2,7 +2,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "nuxt-ts-edge": "latest",
+    "nuxt-ts": "latest",
     "vue-property-decorator": "^7.3.0"
   },
   "scripts": {

--- a/examples/typescript/tsconfig.json
+++ b/examples/typescript/tsconfig.json
@@ -1,10 +1,10 @@
 {
-  "extends": "@nuxt/typescript-edge",
+  "extends": "@nuxt/typescript",
   "compilerOptions": {
     "baseUrl": ".",
     "types": [
       "@types/node",
-      "@nuxt/vue-app-edge"
+      "@nuxt/vue-app"
     ]
   },
 }

--- a/examples/uikit/package.json
+++ b/examples/uikit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-uikit",
   "dependencies": {
-    "nuxt-edge": "latest",
+    "nuxt": "latest",
     "uikit": "^3.0.0-beta.30",
     "jquery": "^3.2.1"
   },

--- a/examples/vue-apollo/package.json
+++ b/examples/vue-apollo/package.json
@@ -2,7 +2,7 @@
   "name": "example-vue-apollo",
   "dependencies": {
     "@nuxtjs/apollo": "^2.1.1",
-    "nuxt-edge": "latest"
+    "nuxt": "latest"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/vue-chartjs/package.json
+++ b/examples/vue-chartjs/package.json
@@ -4,7 +4,7 @@
     "axios": "^0.16.2",
     "chart.js": "^2.7.1",
     "moment": "^2.18.1",
-    "nuxt-edge": "latest",
+    "nuxt": "latest",
     "vue-chartjs": "^3.1.0"
   },
   "scripts": {

--- a/examples/vue-class-component/package.json
+++ b/examples/vue-class-component/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-vue-class-component",
   "dependencies": {
-    "nuxt-edge": "latest",
+    "nuxt": "latest",
     "nuxt-class-component": "latest"
   },
   "scripts": {

--- a/examples/vuex-persistedstate/package.json
+++ b/examples/vuex-persistedstate/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-persisted-state",
   "dependencies": {
-    "nuxt-edge": "latest",
+    "nuxt": "latest",
     "vuex-persistedstate": "^2.0.0"
   },
   "scripts": {

--- a/examples/vuex-store-modules/package.json
+++ b/examples/vuex-store-modules/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-vuex-store-modules",
   "dependencies": {
-    "nuxt-edge": "latest"
+    "nuxt": "latest"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/vuex-store/package.json
+++ b/examples/vuex-store/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-vuex-store",
   "dependencies": {
-    "nuxt-edge": "latest"
+    "nuxt": "latest"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/web-worker/package.json
+++ b/examples/web-worker/package.json
@@ -12,7 +12,7 @@
     "post-update": "yarn upgrade --latest"
   },
   "dependencies": {
-    "nuxt-edge": "latest"
+    "nuxt": "latest"
   },
   "devDependencies": {
     "babel-eslint": "^8.2.6",

--- a/examples/with-amp/package.json
+++ b/examples/with-amp/package.json
@@ -2,7 +2,7 @@
   "name": "example-with-amp",
   "version": "1.0.0",
   "dependencies": {
-    "nuxt-edge": "latest"
+    "nuxt": "latest"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/with-ava/package.json
+++ b/examples/with-ava/package.json
@@ -12,6 +12,6 @@
     "jsdom": "^11.0.0"
   },
   "dependencies": {
-    "nuxt-edge": "latest"
+    "nuxt": "latest"
   }
 }

--- a/examples/with-buefy/package.json
+++ b/examples/with-buefy/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "buefy": "^0.5.4",
-    "nuxt-edge": "latest",
+    "nuxt": "latest",
     "vue": "~2.4.4"
   },
   "devDependencies": {

--- a/examples/with-cookies/package.json
+++ b/examples/with-cookies/package.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "cookie": "^0.3.1",
     "js-cookie": "^2.1.4",
-    "nuxt-edge": "latest",
+    "nuxt": "latest",
     "post-update": "yarn upgrade --latest"
   },
   "scripts": {

--- a/examples/with-element-ui/package.json
+++ b/examples/with-element-ui/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "dependencies": {
     "element-ui": "^2",
-    "nuxt-edge": "latest",
+    "nuxt": "latest",
     "post-update": "yarn upgrade --latest"
   },
   "scripts": {

--- a/examples/with-feathers/package.json
+++ b/examples/with-feathers/package.json
@@ -33,7 +33,7 @@
     "feathers-rest": "^1.6.0",
     "feathers-socketio": "^1.4.2",
     "nedb": "^1.8.0",
-    "nuxt-edge": "latest",
+    "nuxt": "latest",
     "passport": "^0.3.2",
     "winston": "^2.3.0"
   },

--- a/examples/with-firebase/package.json
+++ b/examples/with-firebase/package.json
@@ -16,6 +16,6 @@
   "license": "MIT",
   "dependencies": {
     "axios": "^0.15.3",
-    "nuxt-edge": "latest"
+    "nuxt": "latest"
   }
 }

--- a/examples/with-keep-alive/package.json
+++ b/examples/with-keep-alive/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-with-keep-alive",
   "dependencies": {
-    "nuxt-edge": "latest"
+    "nuxt": "latest"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/with-museui/package.json
+++ b/examples/with-museui/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "example-with-museui",
 	"dependencies": {
-		"nuxt-edge": "latest",
+		"nuxt": "latest",
 		"muse-ui": "latest"
 	},
 	"scripts": {

--- a/examples/with-purgecss/package.json
+++ b/examples/with-purgecss/package.json
@@ -8,7 +8,7 @@
     "post-update": "yarn upgrade --latest"
   },
   "dependencies": {
-    "nuxt-edge": "latest"
+    "nuxt": "latest"
   },
   "devDependencies": {
     "glob-all": "^3.1.0",

--- a/examples/with-sockets/package.json
+++ b/examples/with-sockets/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "express": "^4.14.0",
-    "nuxt-edge": "latest",
+    "nuxt": "latest",
     "socket.io": "^1.7.2",
     "socket.io-client": "^1.7.2"
   },

--- a/examples/with-tape/package.json
+++ b/examples/with-tape/package.json
@@ -17,6 +17,6 @@
 		"vue-test-utils": "^1.0.0-beta.2"
 	},
 	"dependencies": {
-		"nuxt-edge": "latest"
+		"nuxt": "latest"
 	}
 }

--- a/examples/with-vue-material/package.json
+++ b/examples/with-vue-material/package.json
@@ -2,7 +2,7 @@
   "name": "example-with-vue-material",
   "version": "1.0.0",
   "dependencies": {
-    "nuxt-edge": "latest",
+    "nuxt": "latest",
     "vue": "~2.4.4",
     "vue-material": "beta"
   },

--- a/examples/with-vuetify/package.json
+++ b/examples/with-vuetify/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-with-vuetify",
   "dependencies": {
-    "nuxt-edge": "latest",
+    "nuxt": "latest",
     "vuetify": "latest",
     "vuetify-loader": "latest"
   },

--- a/examples/with-vuikit/package.json
+++ b/examples/with-vuikit/package.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "@vuikit/icons": "latest",
     "@vuikit/theme": "latest",
-    "nuxt-edge": "latest",
+    "nuxt": "latest",
     "vuikit": "latest"
   },
   "scripts": {

--- a/examples/with-vux/package.json
+++ b/examples/with-vux/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "dependencies": {
-    "nuxt-edge": "latest",
+    "nuxt": "latest",
     "vux": "^2.8.0"
   },
   "scripts": {


### PR DESCRIPTION
Examples should reflect the *current stable* Nuxt version (instead of bleeding edge builds)