### PR TITLE
perf(ts): transpileOnly when using `nuxt-ts start`

### DIFF
--- a/packages/typescript/src/index.js
+++ b/packages/typescript/src/index.js
@@ -47,6 +47,7 @@ export async function setup(tsConfigPath) {
     project: tsConfigPath,
     compilerOptions: {
       module: 'commonjs'
-    }
+    },
+    transpileOnly: process.argv[2] === 'start'
   })
 }

--- a/packages/typescript/test/setup.test.js
+++ b/packages/typescript/test/setup.test.js
@@ -38,7 +38,8 @@ describe('typescript setup', () => {
       project: tsConfigPath,
       compilerOptions: {
         module: 'commonjs'
-      }
+      },
+      transpileOnly: false
     })
   })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] Performance (a non-breaking change which improves performance)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Knowing Runtime TypeScript are already type checked during `nuxt-ts build`, type checking is not needed during `nuxt-ts start`.

By using `ts-node` `transpileOnly` option for the `nuxt-ts start` command, it results in a faster startup & lower base RAM usage.

### Some stats around my own production server (VPS)
| transpileOnly | Startup time | Memory usage | 📊
|---------|---|---|---|
| false     | ~10s | 120MB | 👎 |
|   **true**      | **~3s** | **70MB** | 👍 |

## Checklist
- [x] I have updated tests to cover my changes
- [x] All updated and existing tests are passing.

