### PR TITLE
fix typescript examples tilde path module resolution in tsconfig

### DIFF
--- a/examples/typescript-tsx/pages/index.tsx
+++ b/examples/typescript-tsx/pages/index.tsx
@@ -1,5 +1,5 @@
 import Vue from 'vue'
-import HelloWorld from '../components/HelloWorld'
+import HelloWorld from '~/components/HelloWorld'
 
 export default Vue.extend({
   name: 'Home',

--- a/examples/typescript-tsx/tsconfig.json
+++ b/examples/typescript-tsx/tsconfig.json
@@ -3,6 +3,9 @@
   "compilerOptions": {
     "baseUrl": ".",
     "noImplicitThis": true,
-    "types": ["@types/node", "@nuxt/vue-app"]
+    "types": ["@types/node", "@nuxt/vue-app"],
+    "paths": {
+      "~/*":["./*"]
+    }
   }
 }

--- a/examples/typescript-vuex/tsconfig.json
+++ b/examples/typescript-vuex/tsconfig.json
@@ -6,6 +6,9 @@
     "types": [
       "@types/node",
       "@nuxt/vue-app-edge"
-    ]
+    ],
+    "paths": {
+      "~/*": ["./*"]
+    }
   }
 }

--- a/examples/typescript/tsconfig.json
+++ b/examples/typescript/tsconfig.json
@@ -5,6 +5,9 @@
     "types": [
       "@types/node",
       "@nuxt/vue-app-edge"
-    ]
-  },
+    ],
+    "paths": {
+      "~/*": ["./*"]
+    }
+  }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
updating `tsconfig.json` in typescript examples that properly sets tilde (~) module resolution

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
this fixes the following ts error:

<img width="610" alt="screen shot 2019-01-30 at 9 49 04 pm" src="https://user-images.githubusercontent.com/1619025/52027462-85096780-24d9-11e9-8ce2-8f27dbb7e1c8.png">



## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

