### PR TITLE
fix: remove cache-loader for external resources

### DIFF
--- a/packages/webpack/src/config/base.js
+++ b/packages/webpack/src/config/base.js
@@ -295,33 +295,33 @@ export default class WebpackBaseConfig {
       },
       {
         test: /\.(png|jpe?g|gif|svg|webp)$/i,
-        use: perfLoader.asset().concat({
+        use: {
           loader: 'url-loader',
           options: Object.assign(
             this.loaders.imgUrl,
             { name: this.getFileName('img') }
           )
-        })
+        }
       },
       {
         test: /\.(woff2?|eot|ttf|otf)(\?.*)?$/i,
-        use: perfLoader.asset().concat({
+        use: {
           loader: 'url-loader',
           options: Object.assign(
             this.loaders.fontUrl,
             { name: this.getFileName('font') }
           )
-        })
+        }
       },
       {
         test: /\.(webm|mp4|ogv)$/i,
-        use: perfLoader.asset().concat({
+        use: {
           loader: 'file-loader',
           options: Object.assign(
             this.loaders.file,
             { name: this.getFileName('video') }
           )
-        })
+        }
       }
     ]
   }

--- a/packages/webpack/src/config/base.js
+++ b/packages/webpack/src/config/base.js
@@ -295,33 +295,33 @@ export default class WebpackBaseConfig {
       },
       {
         test: /\.(png|jpe?g|gif|svg|webp)$/i,
-        use: {
+        use: [{
           loader: 'url-loader',
           options: Object.assign(
             this.loaders.imgUrl,
             { name: this.getFileName('img') }
           )
-        }
+        }]
       },
       {
         test: /\.(woff2?|eot|ttf|otf)(\?.*)?$/i,
-        use: {
+        use: [{
           loader: 'url-loader',
           options: Object.assign(
             this.loaders.fontUrl,
             { name: this.getFileName('font') }
           )
-        }
+        }]
       },
       {
         test: /\.(webm|mp4|ogv)$/i,
-        use: {
+        use: [{
           loader: 'file-loader',
           options: Object.assign(
             this.loaders.file,
             { name: this.getFileName('video') }
           )
-        }
+        }]
       }
     ]
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

Fix #4513

Disable cache-loader since it will omit url-loader/file-loader, this behaviour will lead to the fonts/images/vides which are less than 1K cannot be bundled.

And also webpack5 will be release soon, it will support cache feature internally, so it should be fine that apply current change for now.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

