### PR TITLE
chore: use puppeteer-core

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,8 +147,6 @@ jobs:
 
   test-types:
     <<: *defaults
-    docker:
-      - image: circleci/node:latest-browsers
     steps:
       - checkout
       - attach_workspace:

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "node-fetch": "^2.3.0",
     "pug": "^2.0.3",
     "pug-plain-loader": "^1.0.0",
-    "puppeteer": "~1.11.0",
+    "puppeteer-core": "^1.12.1",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.5",
     "rimraf": "^2.6.3",
@@ -80,7 +80,8 @@
     "tslint": "^5.12.1",
     "typescript": "^3.3.1",
     "vue-jest": "^3.0.2",
-    "vue-property-decorator": "^7.3.0"
+    "vue-property-decorator": "^7.3.0",
+    "which": "^1.3.1"
   },
   "repository": {
     "type": "git",

--- a/test/utils/browser.js
+++ b/test/utils/browser.js
@@ -1,17 +1,24 @@
-import puppeteer from 'puppeteer'
+import puppeteer from 'puppeteer-core'
+import which from 'which'
 
 export default class Browser {
   async start(options = {}) {
     // https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#puppeteerlaunchoptions
-    this.browser = await puppeteer.launch(
-      Object.assign(
-        {
-          args: ['--no-sandbox', '--disable-setuid-sandbox'],
-          executablePath: process.env.PUPPETEER_EXECUTABLE_PATH
-        },
-        options
-      )
-    )
+    const _opts = {
+      args: [
+        '--no-sandbox',
+        '--disable-setuid-sandbox'
+      ],
+      executablePath: process.env.PUPPETEER_EXECUTABLE_PATH,
+      ...options
+    }
+
+    if (!_opts.executablePath) {
+      const resolve = cmd => which.sync(cmd, { nothrow: true })
+      _opts.executablePath = resolve('google-chrome') || resolve('chromium')
+    }
+
+    this.browser = await puppeteer.launch(_opts)
   }
 
   async close() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9231,10 +9231,10 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-puppeteer@~1.11.0:
-  version "1.11.0"
-  resolved "https://registry.npmjs.org/puppeteer/-/puppeteer-1.11.0.tgz#63cdbe12b07275cd6e0b94bce41f3fcb20305770"
-  integrity sha512-iG4iMOHixc2EpzqRV+pv7o3GgmU2dNYEMkvKwSaQO/vMZURakwSOn/EYJ6OIRFYOque1qorzIBvrytPIQB3YzQ==
+puppeteer-core@^1.12.1:
+  version "1.12.1"
+  resolved "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-1.12.1.tgz#aec39d9c199ceff6ddd4da00e0733bb73fce4156"
+  integrity sha512-arGXPRe1dkX3+tOh1GMQ0Ny3CoOCRurkHAW4AZEBIBMX/LdY6ReFqRTT9YSV3d9zzxiIat9kJc3v9h9nkxAu3g==
   dependencies:
     debug "^4.1.0"
     extract-zip "^1.6.6"


### PR DESCRIPTION
- Use `puppeteer-core` instead of `puppeteer` and update to latest.
- `puppeteer` package always downloads google chrome (~200MB) and even if we use cache it is passed to all CI steps unnecessarily.
- We use `circleci/node:latest-browsers` which has chrome pre-installed
- Faster local repository installs time and instead auto-detect locally installed chrome/chromium path
- Prevent breaking change of puppeteer 1.12.1 by using chrome-stable of circle CI image

Before: (took 07:02)

![image](https://user-images.githubusercontent.com/5158436/52163669-72ba4400-26fa-11e9-9562-42a5c9b6ffed.png)

After: (took 06:04)

![image](https://user-images.githubusercontent.com/5158436/52163673-7948bb80-26fa-11e9-88f2-c3cd71493315.png)
