### PR TITLE
fix: warn when using array postcss configuration

### DIFF
--- a/packages/webpack/src/utils/postcss.js
+++ b/packages/webpack/src/utils/postcss.js
@@ -1,5 +1,6 @@
 import fs from 'fs'
 import path from 'path'
+import consola from 'consola'
 import defaults from 'lodash/defaults'
 import merge from 'lodash/merge'
 import cloneDeep from 'lodash/cloneDeep'
@@ -93,7 +94,10 @@ export default class PostcssConfig {
   }
 
   normalize(config) {
+    // TODO: Remove in Nuxt 3
     if (Array.isArray(config)) {
+      consola.warn('Using an Array as `build.postcss` will be deprecated in Nuxt 3. Please switch to the object' +
+        ' declaration')
       config = { plugins: config }
     }
     return config


### PR DESCRIPTION
Warn users when using an array as postcss configuration (legacy). Docs are already up to date for that

## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.