### PR TITLE
feat(module): support src as a function in addModule

### DIFF
--- a/packages/core/src/module.js
+++ b/packages/core/src/module.js
@@ -115,8 +115,8 @@ export default class ModuleContainer {
     let options
     let handler
 
-    // Type 1: String
-    if (typeof moduleOpts === 'string') {
+    // Type 1: String or Function
+    if (typeof moduleOpts === 'string' || typeof moduleOpts === 'function') {
       src = moduleOpts
     } else if (Array.isArray(moduleOpts)) {
       // Type 2: Babel style array
@@ -124,6 +124,11 @@ export default class ModuleContainer {
     } else if (typeof moduleOpts === 'object') {
       // Type 3: Pure object
       ({ src, options, handler } = moduleOpts)
+    }
+
+    // Define handler if src is a function
+    if (typeof src === 'function') {
+      handler = src
     }
 
     // Resolve handler

--- a/packages/core/test/module.test.js
+++ b/packages/core/test/module.test.js
@@ -309,6 +309,31 @@ describe('core: module', () => {
     expect(result).toEqual({ src: 'moduleTest', options: {} })
   })
 
+  test('should add function module', async () => {
+    const module = new ModuleContainer({
+      resolver: { requireModule },
+      options: {}
+    })
+
+    const functionModule = function (options) {
+      return Promise.resolve(options)
+    }
+
+    functionModule.meta = { name: 'moduleTest' }
+
+    const result = await module.addModule(functionModule)
+
+    expect(requireModule).not.toBeCalled()
+    expect(module.requiredModules).toEqual({
+      moduleTest: {
+        handler: expect.any(Function),
+        options: undefined,
+        src: functionModule
+      }
+    })
+    expect(result).toEqual({ })
+  })
+
   test('should add array module', async () => {
     const module = new ModuleContainer({
       resolver: { requireModule },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
While developing a module I came across a problem in its coverage.

If you are analyzing the modules such as [pwa](https://github.com/nuxt-community/pwa-module), [moment-module](https://github.com/nuxt-community/moment-module), [nuxt-i18n](https://github.com/nuxt-community/nuxt-i18n) the coverage is made on top of the `test` folder and not the `lib` or `src`, this is why nuxt solves the module using `esm` by default, so the module is not is covered.

Today to test the modules we created a `nuxt.config.js` like this:
```js
modules: [
  '@@'
]
```
and this has no coverage.

With this correction we can create like this:
```js
modules: [
  require('../../')
]
```
and this has coverage

If we want to create the module using ESM and with coverage we have to add new configurations in `jest` and `babel`:

```json
  "babel": {
    "presets": [
      [
        "env",
        {
          "modules": false
        }
      ]
    ],
    "env": {
      "test": {
        "presets": [
          [
            "env",
            {
              "targets": {
                "node": "current"
              }
            }
          ]
        ]
      }
    }
  },
  "jest": {
    "testEnvironment": "node",
    "collectCoverage": true,
    "collectCoverageFrom": [
      "lib/**/*.js"
    ],
    "transform": {
      "^.+\\.js$": "babel-jest"
    }
  }
```
and add the dependencies `babel-jest` and `babel-preset-env`

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

