### PR TITLE
fix: dont force exit when it was explicitly disabled

### DIFF
--- a/packages/cli/src/command.js
+++ b/packages/cli/src/command.js
@@ -48,9 +48,12 @@ export default class NuxtCommand {
 
     const runResolve = Promise.resolve(this.cmd.run(this))
 
-    // TODO: For v3 set timeout to 0 when force-exit === true
-    if (!this.isServer || this.argv['force-exit']) {
-      runResolve.then(() => forceExit(this.cmd.name, forceExitTimeout))
+    if (
+      this.argv['force-exit'] ||
+      // dont force exit when it was explicitly disabled by the user
+      (!this.isServer && !this.isExplicitArgument('force-exit'))
+    ) {
+      runResolve.then(() => forceExit(this.cmd.name, this.argv['force-exit'] ? 0 : forceExitTimeout))
     }
 
     return runResolve
@@ -100,6 +103,10 @@ export default class NuxtCommand {
     const { Generator } = await imports.generator()
     const builder = await this.getBuilder(nuxt)
     return new Generator(nuxt, builder)
+  }
+
+  isExplicitArgument(option) {
+    return this._argv.includes(`--${option}`) || this._argv.includes(`--no-${option}`)
   }
 
   _getMinimistOptions() {

--- a/packages/cli/src/options/common.js
+++ b/packages/cli/src/options/common.js
@@ -28,7 +28,6 @@ export default {
       }
     }
   },
-  // TODO: Change this to default: true in Nuxt 3
   'force-exit': {
     type: 'boolean',
     default: false,

--- a/packages/cli/src/options/common.js
+++ b/packages/cli/src/options/common.js
@@ -30,8 +30,10 @@ export default {
   },
   'force-exit': {
     type: 'boolean',
-    default: false,
-    description: 'Force Nuxt.js to exit after the command has finished (this option has no effect on commands which start a server)'
+    default(cmd) {
+      return ['build', 'generate'].includes(cmd.name)
+    },
+    description: 'Whether Nuxt.js should force exit after the command has finished'
   },
   version: {
     alias: 'v',

--- a/packages/cli/src/utils/index.js
+++ b/packages/cli/src/utils/index.js
@@ -140,7 +140,7 @@ export function normalizeArg(arg, defaultValue) {
 }
 
 export function forceExit(cmdName, timeout) {
-  if (timeout) {
+  if (timeout !== false) {
     const exitTimeout = setTimeout(() => {
       const msg = `The command 'nuxt ${cmdName}' finished but did not exit after ${timeout}s
 This is most likely not caused by a bug in Nuxt.js

--- a/packages/cli/src/utils/index.js
+++ b/packages/cli/src/utils/index.js
@@ -143,7 +143,7 @@ export function forceExit(cmdName, timeout) {
   if (timeout) {
     const exitTimeout = setTimeout(() => {
       const msg = `The command 'nuxt ${cmdName}' finished but did not exit after ${timeout}s
-This is most likely not caused by a bug in Nuxt.js\
+This is most likely not caused by a bug in Nuxt.js
 Make sure to cleanup all timers and listeners you or your plugins/modules start.
 Nuxt.js will now force exit
 

--- a/packages/cli/test/unit/__snapshots__/command.test.js.snap
+++ b/packages/cli/test/unit/__snapshots__/command.test.js.snap
@@ -18,10 +18,9 @@ exports[`cli/command builds help text 1`] = `
     --modern, -m       Build/Start app for 
                        modern browsers, e.g. server, client and 
                        false
-    --force-exit       Force Nuxt.js to exit 
-                       after the command has finished (this 
-                       option has no effect on commands which 
-                       start a server)
+    --force-exit       Whether Nuxt.js 
+                       should force exit after the command has 
+                       finished
     --version, -v      Display the Nuxt 
                        version
     --help, -h         Display this message

--- a/packages/cli/test/unit/build.test.js
+++ b/packages/cli/test/unit/build.test.js
@@ -74,4 +74,36 @@ describe('build', () => {
 
     expect(options.modern).toBe(true)
   })
+
+  test('build force-exits by default', async () => {
+    mockGetNuxt()
+    mockGetBuilder(Promise.resolve())
+
+    const cmd = NuxtCommand.from(build, ['build', '.'])
+    await cmd.run()
+
+    expect(utils.forceExit).toHaveBeenCalledTimes(1)
+    expect(utils.forceExit).toHaveBeenCalledWith('build', 5)
+  })
+
+  test('build can set force exit explicitly', async () => {
+    mockGetNuxt()
+    mockGetBuilder(Promise.resolve())
+
+    const cmd = NuxtCommand.from(build, ['build', '.', '--force-exit'])
+    await cmd.run()
+
+    expect(utils.forceExit).toHaveBeenCalledTimes(1)
+    expect(utils.forceExit).toHaveBeenCalledWith('build', 0)
+  })
+
+  test('build can disable force exit explicitly', async () => {
+    mockGetNuxt()
+    mockGetBuilder(Promise.resolve())
+
+    const cmd = NuxtCommand.from(build, ['build', '.', '--no-force-exit'])
+    await cmd.run()
+
+    expect(utils.forceExit).not.toHaveBeenCalled()
+  })
 })

--- a/packages/cli/test/unit/build.test.js
+++ b/packages/cli/test/unit/build.test.js
@@ -94,7 +94,7 @@ describe('build', () => {
     await cmd.run()
 
     expect(utils.forceExit).toHaveBeenCalledTimes(1)
-    expect(utils.forceExit).toHaveBeenCalledWith('build', 0)
+    expect(utils.forceExit).toHaveBeenCalledWith('build', false)
   })
 
   test('build can disable force exit explicitly', async () => {

--- a/packages/cli/test/unit/cli.test.js
+++ b/packages/cli/test/unit/cli.test.js
@@ -6,7 +6,6 @@ jest.mock('../../src/commands')
 
 describe('cli', () => {
   beforeAll(() => {
-    // TODO: Below spyOn can be removed in v3 when force-exit is default false
     jest.spyOn(utils, 'forceExit').mockImplementation(() => {})
   })
 
@@ -20,6 +19,7 @@ describe('cli', () => {
 
     await run()
     expect(mockedCommand.run).toHaveBeenCalled()
+    expect(utils.forceExit).toHaveBeenCalled()
   })
 
   test('sets NODE_ENV=development for dev', async () => {

--- a/packages/cli/test/unit/cli.test.js
+++ b/packages/cli/test/unit/cli.test.js
@@ -19,7 +19,7 @@ describe('cli', () => {
 
     await run()
     expect(mockedCommand.run).toHaveBeenCalled()
-    expect(utils.forceExit).toHaveBeenCalled()
+    expect(utils.forceExit).not.toHaveBeenCalled()
   })
 
   test('sets NODE_ENV=development for dev', async () => {

--- a/packages/cli/test/unit/dev.test.js
+++ b/packages/cli/test/unit/dev.test.js
@@ -6,7 +6,6 @@ describe('dev', () => {
 
   beforeAll(async () => {
     dev = await import('../../src/commands/dev').then(m => m.default)
-    // TODO: Below spyOn can be removed in v3 when force-exit is default false
     jest.spyOn(utils, 'forceExit').mockImplementation(() => {})
   })
 
@@ -106,5 +105,36 @@ describe('dev', () => {
     await NuxtCommand.from(dev).run()
 
     expect(consola.error).toHaveBeenCalledWith(new Error('Listen Error'))
+  })
+
+  test('dev doesnt force-exit by default', async () => {
+    mockNuxt()
+    mockBuilder()
+
+    const cmd = NuxtCommand.from(dev, ['dev', '.'])
+    await cmd.run()
+
+    expect(utils.forceExit).not.toHaveBeenCalled()
+  })
+
+  test('dev can set force exit explicitly', async () => {
+    mockNuxt()
+    mockBuilder()
+
+    const cmd = NuxtCommand.from(dev, ['dev', '.', '--force-exit'])
+    await cmd.run()
+
+    expect(utils.forceExit).toHaveBeenCalledTimes(1)
+    expect(utils.forceExit).toHaveBeenCalledWith('dev', 0)
+  })
+
+  test('dev can disable force exit explicitly', async () => {
+    mockNuxt()
+    mockBuilder()
+
+    const cmd = NuxtCommand.from(dev, ['dev', '.', '--no-force-exit'])
+    await cmd.run()
+
+    expect(utils.forceExit).not.toHaveBeenCalled()
   })
 })

--- a/packages/cli/test/unit/dev.test.js
+++ b/packages/cli/test/unit/dev.test.js
@@ -125,7 +125,7 @@ describe('dev', () => {
     await cmd.run()
 
     expect(utils.forceExit).toHaveBeenCalledTimes(1)
-    expect(utils.forceExit).toHaveBeenCalledWith('dev', 0)
+    expect(utils.forceExit).toHaveBeenCalledWith('dev', false)
   })
 
   test('dev can disable force exit explicitly', async () => {

--- a/packages/cli/test/unit/generate.test.js
+++ b/packages/cli/test/unit/generate.test.js
@@ -63,4 +63,49 @@ describe('generate', () => {
 
     expect(options.modern).toBe('client')
   })
+
+  test('generate with modern mode', async () => {
+    mockGetNuxt()
+    mockGetGenerator(Promise.resolve())
+
+    const cmd = NuxtCommand.from(generate, ['generate', '.', '--m'])
+
+    const options = await cmd.getNuxtConfig()
+
+    await cmd.run()
+
+    expect(options.modern).toBe('client')
+  })
+
+  test('generate force-exits by default', async () => {
+    mockGetNuxt()
+    mockGetGenerator(Promise.resolve())
+
+    const cmd = NuxtCommand.from(generate, ['generate', '.'])
+    await cmd.run()
+
+    expect(utils.forceExit).toHaveBeenCalledTimes(1)
+    expect(utils.forceExit).toHaveBeenCalledWith('generate', 5)
+  })
+
+  test('generate can set force exit explicitly', async () => {
+    mockGetNuxt()
+    mockGetGenerator(Promise.resolve())
+
+    const cmd = NuxtCommand.from(generate, ['generate', '.', '--force-exit'])
+    await cmd.run()
+
+    expect(utils.forceExit).toHaveBeenCalledTimes(1)
+    expect(utils.forceExit).toHaveBeenCalledWith('generate', 0)
+  })
+
+  test('generate can disable force exit explicitly', async () => {
+    mockGetNuxt()
+    mockGetGenerator(Promise.resolve())
+
+    const cmd = NuxtCommand.from(generate, ['generate', '.', '--no-force-exit'])
+    await cmd.run()
+
+    expect(utils.forceExit).not.toHaveBeenCalled()
+  })
 })

--- a/packages/cli/test/unit/generate.test.js
+++ b/packages/cli/test/unit/generate.test.js
@@ -96,7 +96,7 @@ describe('generate', () => {
     await cmd.run()
 
     expect(utils.forceExit).toHaveBeenCalledTimes(1)
-    expect(utils.forceExit).toHaveBeenCalledWith('generate', 0)
+    expect(utils.forceExit).toHaveBeenCalledWith('generate', false)
   })
 
   test('generate can disable force exit explicitly', async () => {

--- a/packages/cli/test/unit/start.test.js
+++ b/packages/cli/test/unit/start.test.js
@@ -7,7 +7,6 @@ describe('start', () => {
 
   beforeAll(async () => {
     start = await import('../../src/commands/start').then(m => m.default)
-    // TODO: Below spyOn can be removed in v3 when force-exit is default false
     jest.spyOn(utils, 'forceExit').mockImplementation(() => {})
   })
 
@@ -34,5 +33,33 @@ describe('start', () => {
     mockGetNuxtConfig()
     await NuxtCommand.from(start).run()
     expect(consola.fatal).not.toHaveBeenCalled()
+  })
+
+  test('start doesnt force-exit by default', async () => {
+    mockGetNuxtStart()
+
+    const cmd = NuxtCommand.from(start, ['start', '.'])
+    await cmd.run()
+
+    expect(utils.forceExit).not.toHaveBeenCalled()
+  })
+
+  test('start can set force exit explicitly', async () => {
+    mockGetNuxtStart()
+
+    const cmd = NuxtCommand.from(start, ['start', '.', '--force-exit'])
+    await cmd.run()
+
+    expect(utils.forceExit).toHaveBeenCalledTimes(1)
+    expect(utils.forceExit).toHaveBeenCalledWith('start', 0)
+  })
+
+  test('start can disable force exit explicitly', async () => {
+    mockGetNuxtStart()
+
+    const cmd = NuxtCommand.from(start, ['start', '.', '--no-force-exit'])
+    await cmd.run()
+
+    expect(utils.forceExit).not.toHaveBeenCalled()
   })
 })

--- a/packages/cli/test/unit/start.test.js
+++ b/packages/cli/test/unit/start.test.js
@@ -51,7 +51,7 @@ describe('start', () => {
     await cmd.run()
 
     expect(utils.forceExit).toHaveBeenCalledTimes(1)
-    expect(utils.forceExit).toHaveBeenCalledWith('start', 0)
+    expect(utils.forceExit).toHaveBeenCalledWith('start', false)
   })
 
   test('start can disable force exit explicitly', async () => {

--- a/packages/cli/test/utils/mocking.js
+++ b/packages/cli/test/utils/mocking.js
@@ -18,12 +18,12 @@ jest.mock('../../src/imports', () => {
   }
 })
 
-export const mockGetNuxt = (options, implementation) => {
+export const mockGetNuxt = (options = {}, implementation) => {
   Command.prototype.getNuxt = jest.fn().mockImplementationOnce(() => {
     return Object.assign({
       hook: jest.fn(),
       options
-    }, implementation || {})
+    }, implementation)
   })
 }
 


### PR DESCRIPTION
fix: remove slash from warning text
fix: dont force-exit when explicitly disabled
chore: add force-exit tests for command

Follow-up of: #4958 

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
As discussed on discord, some fixes and stability improvements for my pr from yesterday

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

