### PR TITLE
fix: disable "analyze" for nuxt generate

### DIFF
--- a/packages/cli/src/commands/generate.js
+++ b/packages/cli/src/commands/generate.js
@@ -38,6 +38,9 @@ export default {
     const config = await cmd.getNuxtConfig({ dev: false })
 
     // Disable analyze if set by the nuxt config
+    if (!config.build) {
+      config.build = {}
+    }
     config.build.analyze = false
 
     const nuxt = await cmd.getNuxt(config)

--- a/packages/cli/src/commands/generate.js
+++ b/packages/cli/src/commands/generate.js
@@ -36,6 +36,10 @@ export default {
   },
   async run(cmd) {
     const config = await cmd.getNuxtConfig({ dev: false })
+
+    // Disable analyze if set by the nuxt config
+    config.build.analyze = false
+
     const nuxt = await cmd.getNuxt(config)
     const generator = await cmd.getGenerator(nuxt)
 


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description

Analyzing builds should only happen on `nuxt build` as you shouldn't use the bundle for prod/deployment anyway. I suggest to set `build.analyze` to false when using `nuxt generate`

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

