### PR TITLE
example(jest-puppeteer): fix package .json

### DIFF
--- a/examples/jest-puppeteer/package.json
+++ b/examples/jest-puppeteer/package.json
@@ -8,7 +8,7 @@
     "build": "nuxt build",
     "start": "nuxt start",
     "test": "jest -w=4",
-    "testServer": "nuxt build & nuxt start"
+    "testServer": "nuxt build && nuxt start"
   },
   "devDependencies": {
     "jest": "latest",


### PR DESCRIPTION
While adding Jest and Puppeteer to my project I noticed that the example `package.json` file contained a small bug which would causing the following error:

```
[FATAL] No build files found, please run `nuxt build` before launching `nuxt start`
```
The simple fix was to add another `&` sign between `nuxt build` and `nuxt start` 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

The change would fix the `jest-puppeteer` example folder for any future users who may want to use this as an example.


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

