### PR TITLE
perf(webpack): use `futureEmitAssets`

### DIFF
--- a/packages/webpack/src/config/base.js
+++ b/packages/webpack/src/config/base.js
@@ -122,6 +122,7 @@ export default class WebpackBaseConfig {
     return {
       path: path.resolve(this.options.buildDir, 'dist', this.isServer ? 'server' : 'client'),
       filename: this.getFileName('app'),
+      futureEmitAssets: true,
       chunkFilename: this.getFileName('chunk'),
       publicPath: isUrl(this.options.build.publicPath)
         ? this.options.build.publicPath

--- a/packages/webpack/src/config/base.js
+++ b/packages/webpack/src/config/base.js
@@ -122,7 +122,7 @@ export default class WebpackBaseConfig {
     return {
       path: path.resolve(this.options.buildDir, 'dist', this.isServer ? 'server' : 'client'),
       filename: this.getFileName('app'),
-      futureEmitAssets: true,
+      futureEmitAssets: true, // TODO: Remove when using webpack 5
       chunkFilename: this.getFileName('chunk'),
       publicPath: isUrl(this.options.build.publicPath)
         ? this.options.build.publicPath


### PR DESCRIPTION
Implement https://github.com/webpack/webpack/pull/8642

## Types of changes
- [x] New feature (a non-breaking change which adds functionality)


## Description

> New option `output.futureEmitAssets` allows to opt-in to the new way of emitting assets which allows to free memory of Sources with the trade-off of disallowing reading asset content after emitting

~~Maybe~~ we should make that configurable ~~though 🤔~~ when problems arise

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

