### PR TITLE
test: mock enquirer in typescript tests

### DIFF
--- a/packages/typescript/test/setup.test.js
+++ b/packages/typescript/test/setup.test.js
@@ -1,9 +1,13 @@
 import { resolve } from 'path'
+import enquirer from 'enquirer' // eslint-disable-line no-unused-vars
 import { exists, mkdirp, readJSON, remove } from 'fs-extra'
 import { register } from 'ts-node'
 import { setup as setupTypeScript } from '@nuxt/typescript'
 
 jest.mock('ts-node')
+jest.mock('enquirer', () => ({
+  prompt: jest.fn(() => ({ confirmGeneration: true }))
+}))
 
 describe('typescript setup', () => {
   const rootDir = 'tmp'

--- a/packages/typescript/test/setup.test.js
+++ b/packages/typescript/test/setup.test.js
@@ -1,5 +1,4 @@
 import { resolve } from 'path'
-import enquirer from 'enquirer' // eslint-disable-line no-unused-vars
 import { exists, mkdirp, readJSON, remove } from 'fs-extra'
 import { register } from 'ts-node'
 import { setup as setupTypeScript } from '@nuxt/typescript'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

This resolves an issue with enquirer during testing (see here: https://github.com/enquirer/enquirer/issues/116)

Although the enquirer team are working on that issue, I think its still better to just completely mock enquirer in our tests. Unfortunately we cant use auto mocking here, due to some export magic in enquirer the prompt fn is not available in the automock

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

