### PR TITLE
perf: await routeData promises in parallel

### DIFF
--- a/packages/vue-app/template/utils.js
+++ b/packages/vue-app/template/utils.js
@@ -191,14 +191,8 @@ export async function setContext(app, context) {
       app.context.nuxtState = window.<%= globals.context %>
     }
   }
-  // Dynamic keys
-  app.context.next = context.next
-  app.context._redirected = false
-  app.context._errored = false
-  app.context.isHMR = !!context.isHMR
-  app.context.params = app.context.route.params || {}
-  app.context.query = app.context.route.query || {}
 
+  // Dynamic keys
   const [currentRouteData, fromRouteData] = await Promise.all([
     getRouteData(context.route),
     getRouteData(context.from)
@@ -211,6 +205,13 @@ export async function setContext(app, context) {
   if (context.from) {
     app.context.from = fromRouteData
   }
+
+  app.context.next = context.next
+  app.context._redirected = false
+  app.context._errored = false
+  app.context.isHMR = !!context.isHMR
+  app.context.params = app.context.route.params || {}
+  app.context.query = app.context.route.query || {}
 }
 
 export function middlewareSeries(promises, appContext) {

--- a/packages/vue-app/template/utils.js
+++ b/packages/vue-app/template/utils.js
@@ -106,6 +106,9 @@ export function resolveRouteComponents(route) {
 }
 
 export async function getRouteData(route) {
+  if (!route) {
+    return
+  }
   // Make sure the components are resolved (code-splitting)
   await resolveRouteComponents(route)
   // Send back a copy of route with meta based on Component definition
@@ -193,13 +196,20 @@ export async function setContext(app, context) {
   app.context._redirected = false
   app.context._errored = false
   app.context.isHMR = !!context.isHMR
-  if (context.route) {
-    app.context.route = await getRouteData(context.route)
-  }
   app.context.params = app.context.route.params || {}
   app.context.query = app.context.route.query || {}
+
+  const [currentRouteData, fromRouteData] = await Promise.all([
+    getRouteData(context.route),
+    getRouteData(context.from)
+  ])
+
+  if (context.route) {
+    app.context.route = currentRouteData
+  }
+
   if (context.from) {
-    app.context.from = await getRouteData(context.from)
+    app.context.from = fromRouteData
   }
 }
 


### PR DESCRIPTION
Not sure if it makes a huge difference but running promises without dependencies in parallel here (and early return if the given arg is falsy) should work.
## Types of changes
- [x] Refactor

## Description


## Checklist:
- [ ] All new and existing tests are passing.

