### PR TITLE
fix: remove trailing comma in tsconfig

### DIFF
--- a/examples/typescript/tsconfig.json
+++ b/examples/typescript/tsconfig.json
@@ -6,5 +6,5 @@
       "@types/node",
       "@nuxt/vue-app"
     ]
-  },
+  }
 }


### PR DESCRIPTION
IDE highlighted comma like "JSON standard does not allow trailing comma", i am just removed it.

## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Just typo fixing


## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

