### PR TITLE
fix(vue-app): use browser to handle scrolling position on page reload

### DIFF
--- a/packages/vue-app/template/router.js
+++ b/packages/vue-app/template/router.js
@@ -86,7 +86,21 @@ Vue.use(Router)
 const scrollBehavior = <%= serializeFunction(router.scrollBehavior) %>
 <% } else { %>
 if (process.client) {
-  window.history.scrollRestoration = 'manual'
+  if ('scrollRestoration' in window.history) {
+    window.history.scrollRestoration = 'manual'
+
+    // reset scrollRestoration to auto when leaving page, allowing page reload
+    // and back-navigation from other pages to use the browser to restore the
+    // scrolling position.
+    window.addEventListener('beforeunload', () => {
+      window.history.scrollRestoration = 'auto'
+    })
+
+    // Setting scrollRestoration to manual again when returning to this page.
+    window.addEventListener('load', () => {
+      window.history.scrollRestoration = 'manual'
+    })
+  }
 }
 const scrollBehavior = function (to, from, savedPosition) {
   // if the returned position is falsy or an empty object,


### PR DESCRIPTION
also for cases when returning to a nuxt site using a back button. 

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
When leaving the page, the scrollRestoration is restored to 'auto', as this will instruct the browser to memorize the scroll position. vue-router will not restore the scroll position on page reload and when navigating back from a different page. 
<!--- Why is this change required? What problem does it solve? -->
It solves the problem that the browser scrolls to the top when reloading a Nuxt page, as seen in Chrome for example with https://blog.lichter.io/.
Steps to reproduce: go to nuxt site, scroll down, press F5, browser will be at top of page and not at original scrolling position as expected.
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
Resolves #3471 

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
(this fixes a browser scrolling issue on full page reload, I assume this can't be tested automatically)
- [x] All new and existing tests are passing.

