### PR TITLE
fix(ts): improve tsconfig.json compatibility

### DIFF
--- a/examples/pm2-typescript/tsconfig.json
+++ b/examples/pm2-typescript/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@nuxt/typescript",
+  "extends": "./node_modules/@nuxt/typescript/tsconfig",
   "compilerOptions": {
     "baseUrl": ".",
     "types": [

--- a/examples/typescript-tsx/tsconfig.json
+++ b/examples/typescript-tsx/tsconfig.json
@@ -1,8 +1,11 @@
 {
-  "extends": "@nuxt/typescript",
+  "extends": "./node_modules/@nuxt/typescript/tsconfig",
   "compilerOptions": {
     "baseUrl": ".",
     "noImplicitThis": true,
-    "types": ["@types/node", "@nuxt/vue-app"]
+    "types": [
+      "@types/node",
+      "@nuxt/vue-app"
+    ]
   }
 }

--- a/examples/typescript-vuex/tsconfig.json
+++ b/examples/typescript-vuex/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@nuxt/typescript",
+  "extends": "./node_modules/@nuxt/typescript/tsconfig",
   "compilerOptions": {
     "baseUrl": ".",
     "noImplicitAny": false,

--- a/examples/typescript/tsconfig.json
+++ b/examples/typescript/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@nuxt/typescript",
+  "extends": "./node_modules/@nuxt/typescript/tsconfig",
   "compilerOptions": {
     "baseUrl": ".",
     "types": [

--- a/packages/typescript/src/index.js
+++ b/packages/typescript/src/index.js
@@ -6,7 +6,7 @@ import { existsSync, writeJSON } from 'fs-extra'
 import { register } from 'ts-node'
 
 async function generateTsConfig(tsConfigPath) {
-  const configToExtend = '@nuxt/typescript'
+  const configToExtend = './node_modules/@nuxt/typescript/tsconfig'
   await writeJSON(tsConfigPath, {
     extends: configToExtend,
     compilerOptions: {
@@ -17,7 +17,7 @@ async function generateTsConfig(tsConfigPath) {
       ]
     }
   }, { spaces: 2 })
-  consola.info(`Extending ${chalk.bold.blue(`node_modules/${configToExtend}/tsconfig.json`)}`)
+  consola.info(`Extending ${chalk.bold.blue(`${configToExtend}.json`)}`)
   consola.success(`Generated successfully at ${chalk.bold.green(tsConfigPath)}`)
 }
 

--- a/packages/typescript/test/setup.test.js
+++ b/packages/typescript/test/setup.test.js
@@ -21,7 +21,7 @@ describe('typescript setup', () => {
   test('tsconfig.json has been generated if missing', async () => {
     expect(await exists(tsConfigPath)).toBe(true)
     expect(await readJSON(tsConfigPath)).toEqual({
-      extends: '@nuxt/typescript',
+      extends: './node_modules/@nuxt/typescript/tsconfig',
       compilerOptions: {
         baseUrl: '.',
         types: [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

It became possible to resolve a Node.js package for the `"extends"` field since TypeScript v3.2 (`tsconfig.json` inheritance via Node.js packages](https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript#tsconfigjson-inheritance-via-nodejs-packages)). But vetur 's langserver is running under TypeScript v3.2 ([package.json#L40](https://github.com/vuejs/vetur/blob/v0.16.2/server/package.json#L40). Therefore, when using vetur it will not be resolved correctly.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

