### PR TITLE
chore(vue-app): suppress deprecated warning for production

### DIFF
--- a/packages/vue-app/template/store.js
+++ b/packages/vue-app/template/store.js
@@ -14,9 +14,10 @@ void (function updateModules() {
   <% return true }}) %>
 
   // If store is an exported method = classic mode (deprecated)
+  <% if (isDev) { %>
   if (typeof store === 'function') {
     return log.warn('Classic mode for store/ is deprecated and will be removed in Nuxt 3.')
-  }
+  }<% } %>
 
   // Enforce store modules
   store.modules = store.modules || {}


### PR DESCRIPTION
## Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Fixes #5136 
We should not need this warning in the production build.

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.
