### PR TITLE
feat(generate) return non-zero code or page error (#4991)

### DIFF
--- a/packages/cli/src/commands/generate.js
+++ b/packages/cli/src/commands/generate.js
@@ -71,12 +71,12 @@ export default {
 
     const generator = await cmd.getGenerator(nuxt)
 
-    const errors = await generator.generate({
+    const generateResult = await generator.generate({
       init: true,
       build: cmd.argv.build
     })
 
-    if (cmd.argv['fail-on-error'] && errors.errors.length > 0) {
+    if (cmd.argv['fail-on-error'] && generateResult.errors.length > 0) {
       throw new Error('Error generating pages, exiting with non-zero code')
     }
   }

--- a/packages/cli/src/commands/generate.js
+++ b/packages/cli/src/commands/generate.js
@@ -34,7 +34,7 @@ export default {
         }
       }
     },
-    'fail-on-page-error': {
+    'fail-on-error': {
       type: 'boolean',
       default: false,
       description: 'Exit with non-zero status code if there are errors when generating pages'
@@ -76,7 +76,7 @@ export default {
       build: cmd.argv.build
     })
 
-    if (cmd.argv['fail-on-page-error'] && errors.errors.length > 0) {
+    if (cmd.argv['fail-on-error'] && errors.errors.length > 0) {
       throw new Error('Error generating pages, exiting with non-zero code')
     }
   }

--- a/packages/cli/src/commands/generate.js
+++ b/packages/cli/src/commands/generate.js
@@ -33,6 +33,11 @@ export default {
           options.modern = 'client'
         }
       }
+    },
+    'fail-on-page-error': {
+      type: 'boolean',
+      default: false,
+      description: 'Exit with non-zero status code if there are errors when generating pages'
     }
   },
   async run(cmd) {
@@ -66,9 +71,13 @@ export default {
 
     const generator = await cmd.getGenerator(nuxt)
 
-    await generator.generate({
+    const errors = await generator.generate({
       init: true,
       build: cmd.argv.build
     })
+
+    if (cmd.argv['fail-on-page-error'] && errors && errors.errors && errors.errors.length > 0) {
+      throw new Error('Error generating pages, exiting with non-zero code')
+    }
   }
 }

--- a/packages/cli/src/commands/generate.js
+++ b/packages/cli/src/commands/generate.js
@@ -71,12 +71,12 @@ export default {
 
     const generator = await cmd.getGenerator(nuxt)
 
-    const generateResult = await generator.generate({
+    const { errors } = await generator.generate({
       init: true,
       build: cmd.argv.build
     })
 
-    if (cmd.argv['fail-on-error'] && generateResult.errors.length > 0) {
+    if (cmd.argv['fail-on-error'] && errors.length > 0) {
       throw new Error('Error generating pages, exiting with non-zero code')
     }
   }

--- a/packages/cli/src/commands/generate.js
+++ b/packages/cli/src/commands/generate.js
@@ -76,7 +76,7 @@ export default {
       build: cmd.argv.build
     })
 
-    if (cmd.argv['fail-on-page-error'] && errors && errors.errors && errors.errors.length > 0) {
+    if (cmd.argv['fail-on-page-error'] && errors.errors.length > 0) {
       throw new Error('Error generating pages, exiting with non-zero code')
     }
   }

--- a/packages/cli/test/unit/generate.test.js
+++ b/packages/cli/test/unit/generate.test.js
@@ -113,6 +113,7 @@ describe('generate', () => {
 
     mockGetGenerator(async () => {
       await buildDone()
+      return { errors: [] }
     })
 
     const cmd = NuxtCommand.from(generate, ['generate', '.'])

--- a/packages/cli/test/unit/generate.test.js
+++ b/packages/cli/test/unit/generate.test.js
@@ -135,15 +135,15 @@ describe('generate', () => {
     expect(createLock).not.toHaveBeenCalled()
   })
 
-  test('throw an error when fail-on-page-error enabled and page errors', async () => {
+  test('throw an error when fail-on-error enabled and page errors', async () => {
     mockGetNuxt()
     mockGetGenerator(() => ({ errors: [{ type: 'dummy' }] }))
 
-    const cmd = NuxtCommand.from(generate, ['generate', '.', '--fail-on-page-error'])
+    const cmd = NuxtCommand.from(generate, ['generate', '.', '--fail-on-error'])
     await expect(cmd.run()).rejects
   })
 
-  test('do not throw an error when fail-on-page-error disabled and page errors', async () => {
+  test('do not throw an error when fail-on-error disabled and page errors', async () => {
     mockGetNuxt()
     mockGetGenerator(() => ({ errors: [{ type: 'dummy' }] }))
 
@@ -151,11 +151,11 @@ describe('generate', () => {
     await cmd.run()
   })
 
-  test('do not throw an error when fail-on-page-error enabled and no page errors', async () => {
+  test('do not throw an error when fail-on-error enabled and no page errors', async () => {
     mockGetNuxt()
     mockGetGenerator()
 
-    const cmd = NuxtCommand.from(generate, ['generate', '.', '--fail-on-page-error'])
+    const cmd = NuxtCommand.from(generate, ['generate', '.', '--fail-on-error'])
     await cmd.run()
   })
 })

--- a/packages/cli/test/unit/generate.test.js
+++ b/packages/cli/test/unit/generate.test.js
@@ -134,4 +134,28 @@ describe('generate', () => {
 
     expect(createLock).not.toHaveBeenCalled()
   })
+
+  test('throw an error when fail-on-page-error enabled and page errors', async () => {
+    mockGetNuxt()
+    mockGetGenerator(() => ({ errors: [{ type: 'dummy' }] }))
+
+    const cmd = NuxtCommand.from(generate, ['generate', '.', '--fail-on-page-error'])
+    await expect(cmd.run()).rejects
+  })
+
+  test('do not throw an error when fail-on-page-error disabled and page errors', async () => {
+    mockGetNuxt()
+    mockGetGenerator(() => ({ errors: [{ type: 'dummy' }] }))
+
+    const cmd = NuxtCommand.from(generate, ['generate', '.'])
+    await cmd.run()
+  })
+
+  test('do not throw an error when fail-on-page-error enabled and no page errors', async () => {
+    mockGetNuxt()
+    mockGetGenerator()
+
+    const cmd = NuxtCommand.from(generate, ['generate', '.', '--fail-on-page-error'])
+    await cmd.run()
+  })
 })

--- a/packages/cli/test/utils/mocking.js
+++ b/packages/cli/test/utils/mocking.js
@@ -39,6 +39,8 @@ export const mockGetGenerator = (ret) => {
   const generate = jest.fn()
   if (ret) {
     generate.mockImplementationOnce(ret)
+  } else {
+    generate.mockImplementationOnce(() => ({ errors: [] }))
   }
 
   Command.prototype.getGenerator = jest.fn().mockImplementationOnce(() => ({ generate }))


### PR DESCRIPTION
Introduce --fail-on-page-error option that will cause nuxt generate to return non-zero status code when it encounters a page generation error. This is useful to let CI know that something went wrong.

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
Resolves: #4991 
This PR is a result of the discussion under this ticket and the fact that nuxt-generate-cluster implements similar feature: see https://github.com/nuxt-community/nuxt-generate-cluster/pull/17.

This feature allows `nuxt generate` to return non-zero status code in case of page generation error. This is useful to let CI know that something went wrong, otherwise such issues might get unnoticed for a long time. 

In order to avoid changing existing behavior and introducing a breaking change I am proposing to add a parameter `--fail-on-page-error`. Only if this parameter is present the error status code will be returned.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

Note - I am not sure if it requires documentation update and where I should update it, but I am happy to do it if needed. For the moment I have added a option description which will be available when running `nuxt generate --help`.
