### PR TITLE
fix(ts): deprecate `isClient`, `isServer`, `isStatic`

### DIFF
--- a/packages/vue-app/types/index.d.ts
+++ b/packages/vue-app/types/index.d.ts
@@ -14,8 +14,17 @@ type NuxtState = Dictionary<any>;
 
 export interface Context {
   app: Vue;
+  /**
+   * @deprecated Use process.client instead
+   */
   isClient: boolean;
+  /**
+   * @deprecated Use process.server instead
+   */
   isServer: boolean;
+  /**
+   * @deprecated Use process.static instead
+   */
   isStatic: boolean;
   isDev: boolean;
   isHMR: boolean;


### PR DESCRIPTION
## Description
This follows the documentation on the [context page](https://nuxtjs.org/api/context) and is supported by tslint.

I found this necessary as the current types were inconsistent with the documentation.

## Checklist:
- [x] I have updated the documentation accordingly.
