### PR TITLE
fix(postcss): default to preset-env and cssnano last

### DIFF
--- a/packages/webpack/src/utils/postcss.js
+++ b/packages/webpack/src/utils/postcss.js
@@ -9,12 +9,22 @@ import createResolver from 'postcss-import-resolver'
 import { isPureObject } from '@nuxt/utils'
 
 export const orderPresets = {
-  cssnanoLast: (names) => {
+  cssnanoLast(names) {
     const nanoIndex = names.indexOf('cssnano')
     if (nanoIndex !== names.length - 1) {
       names.push(names.splice(nanoIndex, 1)[0])
     }
     return names
+  },
+  presetEnvLast(names) {
+    const nanoIndex = names.indexOf('postcss-preset-env')
+    if (nanoIndex !== names.length - 1) {
+      names.push(names.splice(nanoIndex, 1)[0])
+    }
+    return names
+  },
+  presetEnvAndCssnanoLast(names) {
+    return this.cssnanoLast(this.presetEnvLast(names))
   }
 }
 
@@ -53,7 +63,7 @@ export default class PostcssConfig {
         'cssnano': dev ? false : { preset: 'default' }
       },
       // Array, String or Function
-      order: 'cssnanoLast'
+      order: 'presetEnvAndCssnanoLast'
     }
   }
 

--- a/packages/webpack/src/utils/postcss.js
+++ b/packages/webpack/src/utils/postcss.js
@@ -24,7 +24,7 @@ export const orderPresets = {
     return names
   },
   presetEnvAndCssnanoLast(names) {
-    return this.cssnanoLast(this.presetEnvLast(names))
+    return orderPresets.cssnanoLast(orderPresets.presetEnvLast(names))
   }
 }
 

--- a/test/unit/basic.dev.test.js
+++ b/test/unit/basic.dev.test.js
@@ -90,15 +90,15 @@ describe('basic dev', () => {
     expect(vueLoader.options).toEqual(vue)
   })
 
-  test('Config: cssnano is at then end of postcss plugins', () => {
+  test('Config: preset-env and cssnano are at then end of postcss plugins', () => {
     const plugins = postcssLoader.options.plugins.map((plugin) => {
       return plugin.postcssPlugin
     })
     expect(plugins).toEqual([
       'postcss-import',
       'postcss-url',
-      'postcss-preset-env',
       'nuxt-test',
+      'postcss-preset-env',
       'cssnano'
     ])
   })


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)


## Description

Currently, `cssnano` is moved at the end of the Postcss plugin chain. This totally makes sense. However, as Nuxt includes `postcss-preset-env` by default which contains `autoprefixer`, it should come second last to apply prefixing to all previous plugin outputs (e.g. `tailwindcss`).


## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

