### PR TITLE
perf(core): skip esm for node_modules and non .js files

### DIFF
--- a/packages/core/src/module.js
+++ b/packages/core/src/module.js
@@ -143,7 +143,7 @@ export default class ModuleContainer {
 
     // Resolve handler
     if (!handler) {
-      handler = this.nuxt.resolver.requireModule(src)
+      handler = this.nuxt.resolver.requireModule(src, { useESM: true })
     }
 
     // Validate handler

--- a/packages/core/src/module.js
+++ b/packages/core/src/module.js
@@ -152,7 +152,10 @@ export default class ModuleContainer {
     }
 
     // Resolve module meta
-    const key = (handler.meta && handler.meta.name) || handler.name || src
+    let key = (handler.meta && handler.meta.name) || handler.name
+    if (!key || key === 'default') {
+      key = src
+    }
 
     // Update requiredModules
     if (typeof key === 'string') {

--- a/packages/core/src/resolver.js
+++ b/packages/core/src/resolver.js
@@ -136,8 +136,8 @@ export default class Resolver {
     }
 
     // Disable esm for ts files by default
-    if (useESM === undefined && /.ts$/.test(resolvedPath)) {
-      useESM = false
+    if (useESM === undefined) {
+      useESM = /.(js|mjs)$/.test(resolvedPath) && !/node_modules/.test(resolvedPath)
     }
 
     // Try to require

--- a/packages/core/src/resolver.js
+++ b/packages/core/src/resolver.js
@@ -143,9 +143,9 @@ export default class Resolver {
     // Try to require
     try {
       if (useESM) {
-        requiredModule = require(resolvedPath)
-      } else {
         requiredModule = this.esm(resolvedPath)
+      } else {
+        requiredModule = require(resolvedPath)
       }
     } catch (e) {
       lastError = e

--- a/packages/core/src/resolver.js
+++ b/packages/core/src/resolver.js
@@ -135,14 +135,14 @@ export default class Resolver {
       lastError = e
     }
 
-    // Disable esm for ts files by default
+    // By default use esm only for js,mjs files outside of node_modules
     if (useESM === undefined) {
       useESM = /.(js|mjs)$/.test(resolvedPath) && !/node_modules/.test(resolvedPath)
     }
 
     // Try to require
     try {
-      if (useESM === false) {
+      if (useESM) {
         requiredModule = require(resolvedPath)
       } else {
         requiredModule = this.esm(resolvedPath)

--- a/packages/core/test/module.test.js
+++ b/packages/core/test/module.test.js
@@ -330,7 +330,7 @@ describe('core: module', () => {
     const result = await module.addModule('moduleTest')
 
     expect(requireModule).toBeCalledTimes(1)
-    expect(requireModule).toBeCalledWith('moduleTest')
+    expect(requireModule).toBeCalledWith('moduleTest', { useESM: true })
     expect(module.requiredModules).toEqual({
       moduleTest: {
         handler: expect.any(Function),
@@ -379,7 +379,7 @@ describe('core: module', () => {
     const result = await module.addModule(['moduleTest', { test: true }])
 
     expect(requireModule).toBeCalledTimes(1)
-    expect(requireModule).toBeCalledWith('moduleTest')
+    expect(requireModule).toBeCalledWith('moduleTest', { useESM: true })
     expect(module.requiredModules).toEqual({
       moduleTest: {
         handler: expect.any(Function),

--- a/packages/core/test/resolver.test.js
+++ b/packages/core/test/resolver.test.js
@@ -403,7 +403,7 @@ describe('core: resolver', () => {
       resolver.resolvePath = jest.fn(() => 'path')
       resolver.esm = jest.fn(() => ({ default: 'resolved module' }))
 
-      const resolvedModule = resolver.requireModule('path', { esm: false })
+      const resolvedModule = resolver.requireModule('path', { useESM: false })
 
       expect(resolvedModule).toBe(path)
     })
@@ -460,7 +460,7 @@ describe('core: resolver', () => {
       resolver.resolvePath = jest.fn()
       resolver.esm = jest.fn()
 
-      resolver.requireModule('/var/nuxt/resolver/file', { esm: true })
+      resolver.requireModule('/var/nuxt/resolver/file', { useESM: true })
       const warnMsg = 'Using esm is deprecated and will be removed in Nuxt 3. Use `useESM` instead.'
       expect(consola.warn).toBeCalledTimes(1)
       expect(consola.warn).toBeCalledWith(warnMsg)

--- a/packages/core/test/resolver.test.js
+++ b/packages/core/test/resolver.test.js
@@ -352,7 +352,7 @@ describe('core: resolver', () => {
       })
       fs.existsSync = jest.fn(() => true)
 
-      resolver.resolvePath('/var/nuxt/resolver/file', { module: true })
+      resolver.resolvePath('/var/nuxt/resolver/file.js', { module: true })
       const warnMsg = 'Using module is deprecated and will be removed in Nuxt 3. Use `isModule` instead.'
       expect(consola.warn).toBeCalledTimes(1)
       expect(consola.warn).toBeCalledWith(warnMsg)
@@ -364,10 +364,10 @@ describe('core: resolver', () => {
       const resolver = new Resolver({
         options: {}
       })
-      resolver.resolvePath = jest.fn()
+      resolver.resolvePath = x => x
       resolver.esm = jest.fn(() => ({ default: 'resolved module' }))
 
-      const resolvedModule = resolver.requireModule('/var/nuxt/resolver/module')
+      const resolvedModule = resolver.requireModule('/var/nuxt/resolver/module.js')
 
       expect(resolvedModule).toEqual('resolved module')
     })
@@ -376,10 +376,10 @@ describe('core: resolver', () => {
       const resolver = new Resolver({
         options: {}
       })
-      resolver.resolvePath = jest.fn()
+      resolver.resolvePath = x => x
       resolver.esm = jest.fn(() => 'resolved module')
 
-      const resolvedModule = resolver.requireModule('/var/nuxt/resolver/module')
+      const resolvedModule = resolver.requireModule('/var/nuxt/resolver/module.js')
 
       expect(resolvedModule).toEqual('resolved module')
     })
@@ -388,10 +388,10 @@ describe('core: resolver', () => {
       const resolver = new Resolver({
         options: {}
       })
-      resolver.resolvePath = jest.fn()
+      resolver.resolvePath = x => x
       resolver.esm = jest.fn(() => ({ default: 'resolved module' }))
 
-      const resolvedModule = resolver.requireModule('/var/nuxt/resolver/module', { interopDefault: false })
+      const resolvedModule = resolver.requireModule('/var/nuxt/resolver/module.js', { interopDefault: false })
 
       expect(resolvedModule).toEqual({ default: 'resolved module' })
     })
@@ -427,7 +427,7 @@ describe('core: resolver', () => {
       resolver.resolvePath = jest.fn(() => { throw new Error('resolve failed') })
       resolver.esm = jest.fn(() => undefined)
 
-      expect(() => resolver.requireModule('/var/nuxt/resolver/module')).toThrow('resolve failed')
+      expect(() => resolver.requireModule('/var/nuxt/resolver/module.js')).toThrow('resolve failed')
     })
 
     test('should throw last error', () => {
@@ -437,17 +437,17 @@ describe('core: resolver', () => {
       resolver.resolvePath = jest.fn(() => { throw new Error('resolve failed') })
       resolver.esm = jest.fn(() => { throw new Error('resolve esm failed') })
 
-      expect(() => resolver.requireModule('/var/nuxt/resolver/module')).toThrow('resolve esm failed')
+      expect(() => resolver.requireModule('/var/nuxt/resolver/module.js')).toThrow('resolve esm failed')
     })
 
     test('should display deprecated alias options', () => {
       const resolver = new Resolver({
         options: {}
       })
-      resolver.resolvePath = jest.fn()
+      resolver.resolvePath = x => x
       resolver.esm = jest.fn()
 
-      resolver.requireModule('/var/nuxt/resolver/file', { alias: true })
+      resolver.requireModule('/var/nuxt/resolver/file.js', { alias: true })
       const warnMsg = 'Using alias is deprecated and will be removed in Nuxt 3. Use `isAlias` instead.'
       expect(consola.warn).toBeCalledTimes(1)
       expect(consola.warn).toBeCalledWith(warnMsg)
@@ -460,7 +460,7 @@ describe('core: resolver', () => {
       resolver.resolvePath = jest.fn()
       resolver.esm = jest.fn()
 
-      resolver.requireModule('/var/nuxt/resolver/file', { useESM: true })
+      resolver.requireModule('/var/nuxt/resolver/file.js', { esm: true })
       const warnMsg = 'Using esm is deprecated and will be removed in Nuxt 3. Use `useESM` instead.'
       expect(consola.warn).toBeCalledTimes(1)
       expect(consola.warn).toBeCalledWith(warnMsg)

--- a/test/fixtures/typescript/modules/module.ts
+++ b/test/fixtures/typescript/modules/module.ts
@@ -1,1 +1,3 @@
-export default () => {}
+export default function testTSModule() {
+
+}

--- a/test/unit/typescript.test.js
+++ b/test/unit/typescript.test.js
@@ -40,7 +40,7 @@ describe('typescript', () => {
   })
 
   test('TS module successfully required', () => {
-    expect(nuxt.moduleContainer.requiredModules).toHaveProperty('~/modules/module')
+    expect(nuxt.moduleContainer.requiredModules.testTSModule).toBeDefined()
   })
 
   // Close server and ask nuxt to stop listening to file changes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
Skip using `esm` for files inside `node_modules` and only use for `.js`/`.mjs` files (resolved first!). `useESM` set to `true` for modules to prevent breaking changes on 2.x.

Also fixes #5203.

Currently startup of nuxt dev requires these:

```
/node_modules/node-fetch/package.json
/node_modules/unfetch/package.json
/node_modules/vue/package.json
/node_modules/vue-meta/package.json
/node_modules/vue-no-ssr/package.json
/node_modules/vue-router/package.json
/node_modules/vue-template-compiler/package.json
/node_modules/vuex/package.json
/node_modules/postcss-import/index.js
/node_modules/postcss-url/src/index.js
/node_modules/postcss-preset-env/index.js
/node_modules/cssnano/dist/index.js
/node_modules/postcss-import/index.js
/node_modules/postcss-url/src/index.js
/node_modules/postcss-preset-env/index.js
/node_modules/cssnano/dist/index.js
/node_modules/postcss-import/index.js
/node_modules/postcss-url/src/index.js
/node_modules/postcss-preset-env/index.js
/node_modules/cssnano/dist/index.js
/node_modules/postcss-import/index.js
/node_modules/postcss-url/src/index.js
/node_modules/postcss-preset-env/index.js
/node_modules/cssnano/dist/index.js
/node_modules/postcss-import/index.js
/node_modules/postcss-url/src/index.js
/node_modules/postcss-preset-env/index.js
/node_modules/cssnano/dist/index.js
/node_modules/postcss-import/index.js
/node_modules/postcss-url/src/index.js
/node_modules/postcss-preset-env/index.js
/node_modules/cssnano/dist/index.js
/node_modules/postcss-import/index.js
/node_modules/postcss-url/src/index.js
/node_modules/postcss-preset-env/index.js
/node_modules/cssnano/dist/index.js
/node_modules/postcss-import/index.js
/node_modules/postcss-url/src/index.js
/node_modules/postcss-preset-env/index.js
/node_modules/cssnano/dist/index.js
/node_modules/postcss-import/index.js
/node_modules/postcss-url/src/index.js
/node_modules/postcss-preset-env/index.js
/node_modules/cssnano/dist/index.js
/node_modules/postcss-import/index.js
/node_modules/postcss-url/src/index.js
/node_modules/postcss-preset-env/index.js
/node_modules/cssnano/dist/index.js
/node_modules/postcss-import/index.js
/node_modules/postcss-url/src/index.js
/node_modules/postcss-preset-env/index.js
/node_modules/cssnano/dist/index.js
/node_modules/postcss-import/index.js
/node_modules/postcss-url/src/index.js
/node_modules/postcss-preset-env/index.js
/node_modules/cssnano/dist/index.js
```

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

