### PR TITLE
chore: faster ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ jobs:
           at: ~/project
       - run:
           name: Build Fixtures
-          command: yarn test:fixtures -i --coverage && yarn coverage
+          command: yarn test:fixtures --coverage && yarn coverage
       - persist_to_workspace:
           root: ~/project
           paths:
@@ -131,7 +131,7 @@ jobs:
           at: ~/project
       - run:
           name: Unit Tests
-          command: yarn test:unit -w=2 --coverage && yarn coverage
+          command: yarn test:unit --coverage && yarn coverage
 
   test-e2e:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ jobs:
           at: ~/project
       - run:
           name: Build Fixtures
-          command: yarn test:fixtures --coverage && yarn coverage
+          command: yarn test:fixtures -w2 --coverage && yarn coverage
       - persist_to_workspace:
           root: ~/project
           paths:
@@ -131,7 +131,7 @@ jobs:
           at: ~/project
       - run:
           name: Unit Tests
-          command: yarn test:unit --coverage && yarn coverage
+          command: yarn test:unit -w2 --coverage && yarn coverage
 
   test-e2e:
     <<: *defaults


### PR DESCRIPTION
Currently, CircleCI uses run-in-band to prevent previous inconsistencies. This makes build step too long (~5min) let's try if it is better now :)

### results 

- `-i` => `~5min`
- Without worker limit => ENNOMEM