### PR TITLE
fix(webpack): clone `config.entry`

### DIFF
--- a/packages/webpack/src/config/client.js
+++ b/packages/webpack/src/config/client.js
@@ -182,9 +182,9 @@ export default class WebpackClientConfig extends WebpackBaseConfig {
       `${querystring.stringify(hotMiddlewareClientOptions)}&path=${clientPath}`.replace(/\/\//g, '/')
 
     // Entry points
-    config.entry = {
+    config.entry = Object.assign({}, config.entry, {
       app: [path.resolve(buildDir, 'client.js')]
-    }
+    })
 
     // Add HMR support
     if (this.dev) {

--- a/packages/webpack/src/config/server.js
+++ b/packages/webpack/src/config/server.js
@@ -69,9 +69,9 @@ export default class WebpackServerConfig extends WebpackBaseConfig {
     Object.assign(config, {
       target: 'node',
       node: false,
-      entry: {
+      entry: Object.assign({}, config.entry, {
         app: [path.resolve(this.buildContext.options.buildDir, 'server.js')]
-      },
+      }),
       output: Object.assign({}, config.output, {
         filename: 'server.js',
         libraryTarget: 'commonjs2'


### PR DESCRIPTION
## Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
Assign to webpack config entry instead of overwriting.
Allow custom entries to be specified in `build.extend`.
Resolves: #4849

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests are passing.
