### PR TITLE
fix: relax lock settings

### DIFF
--- a/packages/utils/src/locking.js
+++ b/packages/utils/src/locking.js
@@ -8,8 +8,8 @@ import onExit from 'signal-exit'
 export const lockPaths = new Set()
 
 export const defaultLockOptions = {
-  stale: 15000,
-  onCompromised: err => consola.fatal(err)
+  stale: 30000,
+  onCompromised: err => consola.warn(err)
 }
 
 export function getLockOptions(options) {

--- a/packages/utils/test/locking.test.js
+++ b/packages/utils/test/locking.test.js
@@ -18,9 +18,9 @@ describe('util: locking', () => {
   beforeEach(() => jest.resetAllMocks())
   beforeEach(() => lockPaths.clear())
 
-  test('onCompromised lock is fatal error by default', () => {
+  test('onCompromised lock is warn error by default', () => {
     defaultLockOptions.onCompromised()
-    expect(consola.fatal).toHaveBeenCalledTimes(1)
+    expect(consola.warn).toHaveBeenCalledTimes(1)
   })
 
   test('can override default options', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

Relaxing the lock settings a bit should make it less likely the lock gets compromised due to cpu/io starvation.
- compromised lock is a warning now, not a fatal error
- stale timeout is twice as high, 30s now

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

