### PR TITLE
fix(vue-app): duplicated router.base when using context.redirect(object)

### DIFF
--- a/packages/vue-app/template/utils.js
+++ b/packages/vue-app/template/utils.js
@@ -164,7 +164,7 @@ export async function setContext(app, context) {
         status = 302
       }
       if (pathType === 'object') {
-        path = app.router.resolve(path).href
+        path = app.router.resolve(path).route.fullPath
       }
       // "/absolute/route", "./relative/route" or "../relative/route"
       if (/(^[.]{1,2}\/)|(^\/(?!\/))/.test(path)) {


### PR DESCRIPTION
When `router.base` provided, `context.redirect(object)` leads to a path with duplicated `router.base`.

Reproduction: https://github.com/niandalu/nuxt-bug

1. Ensure `router.base` present in `nuxt.config.js`
2. Run the example above, browse `http://localhost:3000/foo`
3. Click `incorrect`, it will lead you to `/foo/foo/target` rather than `/foo/target`

## Types of changes

- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description

What I did is just changing `router.resolve().href` to `router.resove().fullName`.

`router.resolve().href` is the combination of `router.base` and `resolved.fullPath`. Also Nuxt  is prepending `router.base` to urls. So the final url generated contains duplicated `router.base`.

Although this change mutates the behavior of `context.redirect`, it should be ok:

1. For users having `router.base` blank,  same as before
2. For users having `router.base` set, original `context.redirect(object)` doesn't function correctly. So they shouldn't have `context.redirect(object)` in codebase

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [X] All new and existing tests are passing.

