### PR TITLE
fix(webpack): always resolve core-js to v3

### DIFF
--- a/distributions/nuxt-legacy/package.json
+++ b/distributions/nuxt-legacy/package.json
@@ -60,7 +60,7 @@
     "@nuxt/loading-screen": "^0.1.2",
     "@nuxt/opencollective": "^0.2.1",
     "@nuxt/webpack": "2.4.5",
-    "core-js": "3",
+    "core-js": "^3.0.0",
     "regenerator-runtime": "^0.13.2"
   },
   "engines": {

--- a/packages/babel-preset-app/package.json
+++ b/packages/babel-preset-app/package.json
@@ -19,7 +19,8 @@
     "@babel/runtime": "^7.4.0",
     "@babel/runtime-corejs3": "^7.4.0",
     "@vue/babel-preset-jsx": "^1.0.0-beta.2",
-    "core-js": "3"
+    "core-js": "^3.0.0",
+    "core-js-compat": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -17,6 +17,7 @@
     "caniuse-lite": "^1.0.30000951",
     "chalk": "^2.4.2",
     "consola": "^2.5.7",
+    "core-js": "^3.0.0",
     "css-loader": "^2.1.1",
     "cssnano": "^4.1.10",
     "eventsource-polyfill": "^0.9.6",

--- a/packages/webpack/src/config/base.js
+++ b/packages/webpack/src/config/base.js
@@ -188,7 +188,8 @@ export default class WebpackBaseConfig {
       '@': path.join(srcDir),
       '@@': path.join(rootDir),
       [assetsDir]: path.join(srcDir, assetsDir),
-      [staticDir]: path.join(srcDir, staticDir)
+      [staticDir]: path.join(srcDir, staticDir),
+      'core-js': path.dirname(require.resolve('core-js/package.json'))
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3519,7 +3519,7 @@ core-js-pure@3.0.0, core-js-pure@^3.0.0:
   resolved "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.0.0.tgz#a5679adb4875427c8c0488afc93e6f5b7125859b"
   integrity sha512-yPiS3fQd842RZDgo/TAKGgS0f3p2nxssF1H65DIZvZv0Od5CygP8puHXn3IQiM/39VAvgCbdaMQpresrbGgt9g==
 
-core-js@3, core-js@3.0.0, core-js@^3.0.0:
+core-js@3.0.0, core-js@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/core-js/-/core-js-3.0.0.tgz#a8dbfa978d29bfc263bfb66c556d0ca924c28957"
   integrity sha512-WBmxlgH2122EzEJ6GH8o9L/FeoUKxxxZ6q6VUxoTlsE4EvbTWKJb447eyVxTEuq0LpXjlq/kCB2qgBvsYRkLvQ==


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description

`@babel/polyfill` translates : `var b = new Map();` into `import "core-js/modules/es6.map"; var b = new Map();` thus webpack tries to require `node_modules/core-js`. In case of package-manager hoists `core-js@2` in `node_modules` and moves `core-js@3` to `node_modules/@nuxt/babel-preset-app/node_modules` we will get into trouble. This PR forces webapck to correctly resolve from correct version of `core-js`. 

Fixes nuxt-community/pwa-module#170

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

