### PR TITLE
fix(ts): wrong export used in render.d.ts

### DIFF
--- a/packages/config/types/render.d.ts
+++ b/packages/config/types/render.d.ts
@@ -11,11 +11,11 @@ import { CompressionOptions } from 'compression'
 import { Options as EtagOptions } from 'etag'
 import { ServeStaticOptions } from 'serve-static'
 import { BundleRendererOptions } from 'vue-server-renderer'
-import { NuxtConfigurationServerMiddleware } from './index'
+import { ServerMiddleware } from './index'
 
 export interface NuxtConfigurationRender {
   bundleRenderer?: BundleRendererOptions
-  compressor?: CompressionOptions | NuxtConfigurationServerMiddleware
+  compressor?: CompressionOptions | ServerMiddleware
   csp?: any // TBD
   dist?: ServeStaticOptions
   etag?: EtagOptions | false

--- a/packages/config/types/render.d.ts
+++ b/packages/config/types/render.d.ts
@@ -11,7 +11,7 @@ import { CompressionOptions } from 'compression'
 import { Options as EtagOptions } from 'etag'
 import { ServeStaticOptions } from 'serve-static'
 import { BundleRendererOptions } from 'vue-server-renderer'
-import { ServerMiddleware } from './index'
+import { NuxtConfigurationServerMiddleware } from './server-middleware'
 
 export interface NuxtConfigurationRender {
   bundleRenderer?: BundleRendererOptions

--- a/packages/config/types/render.d.ts
+++ b/packages/config/types/render.d.ts
@@ -15,7 +15,7 @@ import { NuxtConfigurationServerMiddleware } from './server-middleware'
 
 export interface NuxtConfigurationRender {
   bundleRenderer?: BundleRendererOptions
-  compressor?: CompressionOptions | ServerMiddleware
+  compressor?: CompressionOptions | NuxtConfigurationServerMiddleware
   csp?: any // TBD
   dist?: ServeStaticOptions
   etag?: EtagOptions | false


### PR DESCRIPTION
Hey all 👋 

In the current version of `@nuxt/config`, [we try to get `NuxtConfigurationServerMiddleware` from `./index.d.ts`](https://github.com/nuxt/nuxt.js/blob/dev/packages/config/types/render.d.ts#L14) in `render.d.ts`. This export doesn't exist.

[It has been renamed to `ServerMiddleware`](https://github.com/nuxt/nuxt.js/blob/dev/packages/config/types/index.d.ts#L89).

**NOTE:** It's currently impossible to build a Nuxt application using TS because the compiler throw an error.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)