### PR TITLE
hotfix: revert to corejs@2

### DIFF
--- a/distributions/nuxt-legacy/bin/nuxt-legacy.js
+++ b/distributions/nuxt-legacy/bin/nuxt-legacy.js
@@ -1,16 +1,19 @@
 #!/usr/bin/env node
 
-require('core-js/stable')
-require('renegerator-runtime/runtime')
+require('core-js')
+require('regenerator-runtime/runtime')
 
 require('@babel/register')({
   presets: [
     [ '@babel/env', { targets: { node: 'current' } } ]
   ],
+  plugins: [
+    '@babel/plugin-syntax-dynamic-import'
+  ],
   ignore: [
     (path) => {
       // Transpile known packages
-      if (/(@nuxt|@nuxtjs)[\\/]/.test(path)) {
+      if (/(@nuxt|@nuxtjs)[\\/]|proper-lockfile|webpack|vue-app/.test(path)) {
         return false
       }
       // Ignore everything else inside node_modules

--- a/distributions/nuxt-legacy/package.json
+++ b/distributions/nuxt-legacy/package.json
@@ -60,7 +60,7 @@
     "@nuxt/loading-screen": "^0.1.2",
     "@nuxt/opencollective": "^0.2.1",
     "@nuxt/webpack": "2.5.0",
-    "core-js": "^3.0.0",
+    "core-js": "^2.6.5",
     "regenerator-runtime": "^0.13.2"
   },
   "engines": {

--- a/packages/babel-preset-app/README.md
+++ b/packages/babel-preset-app/README.md
@@ -14,7 +14,7 @@ babel: {
     ]
   }
 }
-```    
+```
 ...where `options` is an object with parameters, for example:
 ```
  const options = {
@@ -37,7 +37,7 @@ Below is a list of all available parameters:
 * **loose**, default `false` - '[@babel/preset-env](https://babeljs.io/docs/en/babel-preset-env#loose)' parameter and also sets `loose=true` for `@babel/plugin-proposal-class-properties`
 * **modern** passed by builder, either `true` or `false`
 * **modules**, default `false` - '[@babel/preset-env](https://babeljs.io/docs/en/babel-preset-env#modules)' parameter
-* **polyfills**, default `['es.array.iterator','es.promise','es.object.assign','es.promise.finally']`, more [in the corresponding repository](https://github.com/zloirock/core-js)
+* **polyfills**, default `['es6.array.iterator','es6.promise','es6.object.assign','es7.promise.finally']`, more [in the corresponding repository](https://github.com/zloirock/core-js)
 * **shippedProposals** - '[@babel/preset-env](https://babeljs.io/docs/en/babel-preset-env#shippedproposals)' parameter
 * **spec** - '[@babel/preset-env](https://babeljs.io/docs/en/babel-preset-env#spec)' parameter
 * **targets** - '[@babel/preset-env](https://babeljs.io/docs/en/babel-preset-env#targets)' parameter
@@ -61,4 +61,4 @@ babel: {
     ]
   }
 },
-```    
+```

--- a/packages/babel-preset-app/package.json
+++ b/packages/babel-preset-app/package.json
@@ -17,10 +17,8 @@
     "@babel/plugin-transform-runtime": "^7.4.0",
     "@babel/preset-env": "^7.4.2",
     "@babel/runtime": "^7.4.2",
-    "@babel/runtime-corejs3": "^7.4.2",
     "@vue/babel-preset-jsx": "^1.0.0-beta.2",
-    "core-js": "^3.0.0",
-    "core-js-compat": "^3.0.0"
+    "core-js": "^2.6.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/babel-preset-app/src/index.js
+++ b/packages/babel-preset-app/src/index.js
@@ -1,19 +1,19 @@
 const defaultPolyfills = [
   // Promise polyfill alone doesn't work in IE,
   // Needs this as well. see: #1642
-  'es.array.iterator',
+  'es6.array.iterator',
   // This is required for webpack code splitting, vuex etc.
-  'es.promise',
+  'es6.promise',
   // this is needed for object rest spread support in templates
   // as vue-template-es2015-compiler 1.8+ compiles it to Object.assign() calls.
-  'es.object.assign',
-  // #2012 es.promise replaces native Promise in FF and causes missing finally
-  'es.promise.finally'
+  'es6.object.assign',
+  // #2012 es7.promise replaces native Promise in FF and causes missing finally
+  'es7.promise.finally'
 ]
 
 function getPolyfills(targets, includes, { ignoreBrowserslistConfig, configPath }) {
   const { isPluginRequired } = require('@babel/preset-env')
-  const builtInsList = require('core-js-compat/data')
+  const builtInsList = require('@babel/preset-env/data/built-ins.json.js')
   const getTargets = require('@babel/preset-env/lib/targets-parser').default
   const builtInTargets = getTargets(targets, {
     ignoreBrowserslistConfig,
@@ -66,7 +66,7 @@ module.exports = (context, options = {}) => {
     polyfills = []
   }
 
-  const corejs = { version: 3 }
+  const corejs = { version: 2 }
 
   // Pass options along to babel-preset-env
   presets.push([

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -17,7 +17,6 @@
     "caniuse-lite": "^1.0.30000951",
     "chalk": "^2.4.2",
     "consola": "^2.5.7",
-    "core-js": "^3.0.0",
     "css-loader": "^2.1.1",
     "cssnano": "^4.1.10",
     "eventsource-polyfill": "^0.9.6",

--- a/packages/webpack/src/config/base.js
+++ b/packages/webpack/src/config/base.js
@@ -188,8 +188,7 @@ export default class WebpackBaseConfig {
       '@': path.join(srcDir),
       '@@': path.join(rootDir),
       [assetsDir]: path.join(srcDir, assetsDir),
-      [staticDir]: path.join(srcDir, staticDir),
-      'core-js': path.dirname(require.resolve('core-js/package.json'))
+      [staticDir]: path.join(srcDir, staticDir)
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -633,14 +633,6 @@
     pirates "^4.0.0"
     source-map-support "^0.5.9"
 
-"@babel/runtime-corejs3@^7.4.2":
-  version "7.4.2"
-  resolved "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.4.2.tgz#d951565aa21cc698abbd9866d54d536814e1c4d9"
-  integrity sha512-KhRhNFTBO4bxwH/X21qder3+IhvIp4Bz2qMV9exQUG60q1maoEq2ucKzRqsmMfZ0LnAOoYLE4NhLztKIiYUiJg==
-  dependencies:
-    core-js-pure "^3.0.0"
-    regenerator-runtime "^0.13.2"
-
 "@babel/runtime@^7.4.2":
   version "7.4.2"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.2.tgz#f5ab6897320f16decd855eed70b705908a313fe8"
@@ -3514,7 +3506,7 @@ core-js-compat@^3.0.0:
     core-js-pure "3.0.0"
     semver "^5.6.0"
 
-core-js-pure@3.0.0, core-js-pure@^3.0.0:
+core-js-pure@3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.0.0.tgz#a5679adb4875427c8c0488afc93e6f5b7125859b"
   integrity sha512-yPiS3fQd842RZDgo/TAKGgS0f3p2nxssF1H65DIZvZv0Od5CygP8puHXn3IQiM/39VAvgCbdaMQpresrbGgt9g==
@@ -3524,7 +3516,7 @@ core-js@3.0.0, core-js@^3.0.0:
   resolved "https://registry.npmjs.org/core-js/-/core-js-3.0.0.tgz#a8dbfa978d29bfc263bfb66c556d0ca924c28957"
   integrity sha512-WBmxlgH2122EzEJ6GH8o9L/FeoUKxxxZ6q6VUxoTlsE4EvbTWKJb447eyVxTEuq0LpXjlq/kCB2qgBvsYRkLvQ==
 
-core-js@^2.4.0:
+core-js@^2.4.0, core-js@^2.6.5:
   version "2.6.5"
   resolved "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz#44bc8d249e7fb2ff5d00e0341a7ffb94fbf67895"
   integrity sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==


### PR DESCRIPTION
Revert core-js to v2 as it is the default for current babel and forcing to v3 causes issues like #5313. Upgrading is also a breaking change for projects that have a babel.config file. So it makes sense to do it for nuxt3 or when ecosystem adopted more to v3.