### PR TITLE
fix: remove consola.debug for hooks

### DIFF
--- a/packages/core/src/hookable.js
+++ b/packages/core/src/hookable.js
@@ -30,7 +30,7 @@ export default class Hookable {
     if (!this._hooks[name]) {
       return
     }
-    
+
     try {
       await sequence(this._hooks[name], fn => fn(...args))
     } catch (err) {

--- a/packages/core/src/hookable.js
+++ b/packages/core/src/hookable.js
@@ -30,7 +30,7 @@ export default class Hookable {
     if (!this._hooks[name]) {
       return
     }
-    consola.debug(`Call ${name} hooks (${this._hooks[name].length})`)
+    
     try {
       await sequence(this._hooks[name], fn => fn(...args))
     } catch (err) {

--- a/packages/core/test/hookable.test.js
+++ b/packages/core/test/hookable.test.js
@@ -64,7 +64,6 @@ describe('core: hookable', () => {
 
     await hook.callHook('test:hook')
 
-    expect(consola.debug).toBeCalledWith('Call test:hook hooks (1)')
     expect(consola.log).toBeCalledWith('test:hook called')
   })
 


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Starting on Nuxt 2.5.x with the loading screen, this line causes spamming with bundler:progress calls.
The consequence to this is delaying the build time from seconds to minutes. I think it's an oversight.

## Checklist:
- [ ] **not applicable** My change requires a change to the documentation.
- [ ] **not applicable** I have updated the documentation accordingly. (PR: #)
- [ ] **not applicable** I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.