### PR TITLE
fix: apply default lock options before setting lock

### DIFF
--- a/packages/utils/src/locking.js
+++ b/packages/utils/src/locking.js
@@ -40,6 +40,7 @@ export async function lock({ id, dir, root, options }) {
     consola.fatal(`A lock with id '${id}' already exists on ${dir}`)
   }
 
+  options = getLockOptions(options)
   const release = await properlock.lock(lockPath, options)
 
   if (!release) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

As second / third time is the charm, now not only relax the lock settings but also really use them. Sorry :blush: 

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

Fixes: #5319