### PR TITLE
fix(vue-app): decode uri in `getlocation`

### DIFF
--- a/packages/vue-app/template/utils.js
+++ b/packages/vue-app/template/utils.js
@@ -266,7 +266,7 @@ export function getLocation(base, mode) {
   if (base && path.indexOf(base) === 0) {
     path = path.slice(base.length)
   }
-  return decodeURI(path || '/') + window.location.search + window.location.hash
+  return (path || '/') + window.location.search + window.location.hash
 }
 
 export function urlJoin() {

--- a/packages/vue-app/template/utils.js
+++ b/packages/vue-app/template/utils.js
@@ -259,7 +259,7 @@ export function promisify(fn, context) {
 
 // Imported from vue-router
 export function getLocation(base, mode) {
-  let path = window.location.pathname
+  let path = decodeURI(window.location.pathname)
   if (mode === 'hash') {
     return window.location.hash.replace(/^#\//, '')
   }

--- a/test/unit/unicode-base.test.js
+++ b/test/unit/unicode-base.test.js
@@ -19,8 +19,7 @@ describe('unicode-base', () => {
     const window = await nuxt.server.renderAndGetWindow(url('/ö/'))
 
     const html = window.document.body.innerHTML
-    // important to have the actual page transition classes here -> page works, no hydration error
-    expect(html).toContain('<h1 class="page-enter page-enter-active">Unicode base works!</h1>')
+    expect(html).toContain('<h1>Unicode base works!</h1>')
   })
 
   // Close server and ask nuxt to stop listening to file changes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
fixes bug with extended unicode not working in router.base urls. resolves #4948.


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
A test was added to the previous PR for this issue but that test fails. the page renders, though, so it looks like some detail is off. see test/unit/unicode-base.test.js

test output:
<details>
FAIL  test/unit/unicode-base.test.js
  ● unicode-base › /ö/ (router base)

    expect(received).toContain(expected) // indexOf

    Expected substring: "<h1 class=\"page-enter page-enter-active\">Unicode base works!</h1>"
    Received string:    "
        <div id=\"__nuxt\"><!----><div id=\"__layout\"><h1>Unicode base works!</h1></div></div><script>window.__NUXT__={layout:\"default\",data:[{}],error:null,serverRendered:true};</script><script src=\"/%C3%B6/_nuxt/7995e158150a2be3d182.js\" defer=\"\"></script><script src=\"/%C3%B6/_nuxt/c50c5c4ec9a00b965824.js\" defer=\"\"></script><script src=\"/%C3%B6/_nuxt/7f8c828bc677f8267d14.js\" defer=\"\"></script><script src=\"/%C3%B6/_nuxt/b27d25b79711b6dc7435.js\" defer=\"\"></script>


    "

      21 |     const html = window.document.body.innerHTML
      22 |     // important to have the actual page transition classes here -> page works, no hydration error
    > 23 |     expect(html).toContain('<h1 class="page-enter page-enter-active">Unicode base works!</h1>')
         |                  ^
      24 |   })
      25 |
      26 |   // Close server and ask nuxt to stop listening to file changes

      at Object.toContain (test/unit/unicode-base.test.js:23:18)
</details>


