### PR TITLE
refactor(vue-renderer): improve ready status error

### DIFF
--- a/packages/vue-renderer/src/renderer.js
+++ b/packages/vue-renderer/src/renderer.js
@@ -462,7 +462,7 @@ export default class VueRenderer {
           case 'created':
             throw new Error('Renderer is not initialized! `nuxt.ready()` should be called.')
           case 'loading':
-            throw new Error(`Renderer is initializing.`)
+            throw new Error(`Renderer is loading.`)
           case 'error':
             throw this._error
           case 'ready':

--- a/packages/vue-renderer/src/renderer.js
+++ b/packages/vue-renderer/src/renderer.js
@@ -126,9 +126,10 @@ export default class VueRenderer {
 
   ready() {
     if (!this._readyPromise) {
-      this._state = 'loading'
+      this._state = 'initializing'
       this._readyPromise = this._ready()
         .then(() => {
+          this._state = 'ready'
           return this
         })
         .catch((error) => {
@@ -142,8 +143,6 @@ export default class VueRenderer {
   }
 
   async _ready() {
-    this._state = 'loading'
-
     // Resolve dist path
     this.distPath = path.resolve(this.context.options.buildDir, 'dist', 'server')
 
@@ -225,10 +224,6 @@ export default class VueRenderer {
 
       // Create new renderer
       this.createRenderer()
-    }
-
-    if (this.isReady) {
-      this._state = 'ready'
     }
 
     return this.context.nuxt.callHook('render:resourcesLoaded', this.context.resources)
@@ -460,13 +455,13 @@ export default class VueRenderer {
       if (!this.context.options.dev) {
         switch (this._state) {
           case 'created':
-            throw new Error('Renderer is not initialized! `nuxt.ready()` should be called.')
-          case 'loading':
-            throw new Error(`Renderer is loading.`)
+            throw new Error('Renderer is not initialized! Please ensure `nuxt.ready()` is called and awaited.')
+          case 'initializing':
+            throw new Error(`Renderer is initializing.`)
           case 'error':
             throw this._error
           case 'ready':
-            throw new Error(`Renderer resources unavailable! Please check ${this.distPath} existence.`)
+            throw new Error(`Renderer is initialized but not all resources are unavailable! Please check ${this.distPath} existence.`)
           default:
             throw new Error('Renderer is in unknown state!')
         }

--- a/packages/vue-renderer/src/renderer.js
+++ b/packages/vue-renderer/src/renderer.js
@@ -460,15 +460,15 @@ export default class VueRenderer {
       if (!this.context.options.dev) {
         switch (this._state) {
           case 'created':
-            throw new Error('Nuxt is not initialized! `nuxt.ready()` should be called.')
+            throw new Error('Renderer is not initialized! `nuxt.ready()` should be called.')
           case 'loading':
-            await this.ready()
-            return this.renderRoute(url, context)
+            throw new Error(`Renderer is initializing.`)
           case 'error':
             throw this._error
           case 'ready':
+            throw new Error(`Renderer resource unavailable! Please check ${this.distPath} existence.`)
           default:
-            throw new Error(`SSR renderer is not initialized! Please check ${this.distPath} existence.`)
+            throw new Error('Renderer is in unknown state!')
         }
       }
       // Tell nuxt middleware to render UI

--- a/packages/vue-renderer/src/renderer.js
+++ b/packages/vue-renderer/src/renderer.js
@@ -455,13 +455,13 @@ export default class VueRenderer {
       if (!this.context.options.dev) {
         switch (this._state) {
           case 'created':
-            throw new Error('Renderer is not initialized! Please ensure `nuxt.ready()` is called and awaited.')
+            throw new Error('Renderer ready() is not called! Please ensure `nuxt.ready()` is called and awaited.')
           case 'loading':
             throw new Error(`Renderer is loading.`)
           case 'error':
             throw this._error
           case 'ready':
-            throw new Error(`Renderer is initialized but not all resources are unavailable! Please check ${this.distPath} existence.`)
+            throw new Error(`Renderer is loaded but not all resources are unavailable! Please check ${this.distPath} existence.`)
           default:
             throw new Error('Renderer is in unknown state!')
         }

--- a/packages/vue-renderer/src/renderer.js
+++ b/packages/vue-renderer/src/renderer.js
@@ -126,7 +126,7 @@ export default class VueRenderer {
 
   ready() {
     if (!this._readyPromise) {
-      this._state = 'initializing'
+      this._state = 'loading'
       this._readyPromise = this._ready()
         .then(() => {
           this._state = 'ready'
@@ -456,8 +456,8 @@ export default class VueRenderer {
         switch (this._state) {
           case 'created':
             throw new Error('Renderer is not initialized! Please ensure `nuxt.ready()` is called and awaited.')
-          case 'initializing':
-            throw new Error(`Renderer is initializing.`)
+          case 'loading':
+            throw new Error(`Renderer is loading.`)
           case 'error':
             throw this._error
           case 'ready':

--- a/packages/vue-renderer/src/renderer.js
+++ b/packages/vue-renderer/src/renderer.js
@@ -129,7 +129,6 @@ export default class VueRenderer {
       this._state = 'loading'
       this._readyPromise = this._ready()
         .then(() => {
-          this._state = 'ready'
           return this
         })
         .catch((error) => {
@@ -143,10 +142,7 @@ export default class VueRenderer {
   }
 
   async _ready() {
-    if (this._readyCalled) {
-      return this
-    }
-    this._readyCalled = true
+    this._state = 'loading'
 
     // Resolve dist path
     this.distPath = path.resolve(this.context.options.buildDir, 'dist', 'server')
@@ -178,8 +174,6 @@ export default class VueRenderer {
         `No build files found in ${this.distPath}.\nUse either \`nuxt build\` or \`builder.build()\` or start nuxt in development mode.`
       )
     }
-
-    return this
   }
 
   async loadResources(_fs) {
@@ -208,7 +202,6 @@ export default class VueRenderer {
 
       // Skip unavailable resources
       if (!resource) {
-        consola.debug('Resource not available:', resourceName)
         continue
       }
 
@@ -234,8 +227,9 @@ export default class VueRenderer {
       this.createRenderer()
     }
 
-    // Call resourcesLoaded hook
-    consola.debug('Resources loaded:', updated.join(','))
+    if (this.isReady) {
+      this._state = 'ready'
+    }
 
     return this.context.nuxt.callHook('render:resourcesLoaded', this.context.resources)
   }

--- a/packages/vue-renderer/src/renderer.js
+++ b/packages/vue-renderer/src/renderer.js
@@ -33,6 +33,10 @@ export default class VueRenderer {
       spaTemplate: undefined,
       errorTemplate: this.parseTemplate('Nuxt.js Internal Server Error')
     })
+
+    // Default status
+    this._status = 'created'
+    this._error = null
   }
 
   get assetsMapping() {

--- a/packages/vue-renderer/src/renderer.js
+++ b/packages/vue-renderer/src/renderer.js
@@ -466,7 +466,7 @@ export default class VueRenderer {
           case 'error':
             throw this._error
           case 'ready':
-            throw new Error(`Renderer resource unavailable! Please check ${this.distPath} existence.`)
+            throw new Error(`Renderer resources unavailable! Please check ${this.distPath} existence.`)
           default:
             throw new Error('Renderer is in unknown state!')
         }

--- a/packages/vue-renderer/src/renderer.js
+++ b/packages/vue-renderer/src/renderer.js
@@ -35,7 +35,7 @@ export default class VueRenderer {
     })
 
     // Default status
-    this._status = 'created'
+    this._state = 'created'
     this._error = null
   }
 
@@ -126,14 +126,14 @@ export default class VueRenderer {
 
   ready() {
     if (!this._readyPromise) {
-      this._status = 'loading'
+      this._state = 'loading'
       this._readyPromise = this._ready()
         .then(() => {
-          this._status = 'ready'
+          this._state = 'ready'
           return this
         })
         .catch((error) => {
-          this._status = 'error'
+          this._state = 'error'
           this._error = error
           throw error
         })
@@ -464,7 +464,7 @@ export default class VueRenderer {
     if (!this.isReady) {
       // Production
       if (!this.context.options.dev) {
-        switch (this._status) {
+        switch (this._state) {
           case 'created':
             throw new Error('Nuxt is not initialized! `nuxt.ready()` should be called.')
           case 'loading':


### PR DESCRIPTION
With this PR, vue-renderer has 4 possible states: (`this._state`) and better errors for each one.

- `created`
- `loading` (while ready() promise is active)
- `error`
- `ready`

This PR also resolves race-conditions by preventing calling `ready()` more than once (It returns same promise) and removes extra debug messages about resource not available