### PR TITLE
fix(builder): await for renderer to load resources

### DIFF
--- a/packages/vue-renderer/src/renderer.js
+++ b/packages/vue-renderer/src/renderer.js
@@ -140,7 +140,7 @@ export default class VueRenderer {
     // Try once to load SSR resources from fs
     await this.loadResources(fs)
 
-    // Without using `nuxt start` (Programmatic, Tests and Generate)
+    // Without using `nuxt start` (programmatic, tests and generate)
     if (!this.context.options._start) {
       this.context.nuxt.hook('build:resources', () => this.loadResources(fs))
       return

--- a/packages/webpack/src/builder.js
+++ b/packages/webpack/src/builder.js
@@ -173,6 +173,9 @@ export class WebpackBundler {
       // Actual error will be printed by webpack
       throw new Error('Nuxt Build Error')
     }
+
+    // Await for renderer to load resources (programmatic, tests and generate)
+    await nuxt.callHook('build:resources')
   }
 
   async webpackDev(compiler) {


### PR DESCRIPTION
This is how nuxt module tests are written:

```js
// BeforeAll
nuxt = new Nuxt(config)
await nuxt.ready()
await new Builder(nuxt).build()
await nuxt.listen(3000)

// Tests
// Fetch http://localhost:300/...
```

With async-fs (#5186) we silently broke this because after awaiting `build()` we don't wait on renderer to load resources from fs and immediately requesting to the server causes tests failing. 

We didn't await because it is a webpack hook: https://github.com/nuxt/nuxt.js/blob/dev/packages/webpack/src/builder.js#L130

With this PR, for production build a `build:resources` hook will be emitted and awaited on `build()`. This prevents breaking tests.
