### PR TITLE
fix: fail in case of missing core-js dependency

### DIFF
--- a/packages/builder/src/builder.js
+++ b/packages/builder/src/builder.js
@@ -222,7 +222,7 @@ export default class Builder {
         'Using npm:\n',
         `npm i ${dependencyFixes.join(' ')}\n`
       )
-      throw new Error('Missing Template Dependencies')
+      throw new Error('Missing App Dependencies')
     }
   }
 

--- a/packages/builder/test/builder.build.test.js
+++ b/packages/builder/test/builder.build.test.js
@@ -263,7 +263,7 @@ describe('builder: builder build', () => {
       .mockReturnValueOnce({ version: 'alpha' })
       .mockReturnValueOnce(undefined)
 
-    expect(() => builder.validateTemplate()).toThrow('Missing Template Dependencies')
+    expect(() => builder.validateTemplate()).toThrow('Missing App Dependencies')
 
     expect(nuxt.resolver.requireModule).toBeCalledTimes(2)
     expect(nuxt.resolver.requireModule).nthCalledWith(1, 'join(vue, package.json)')

--- a/packages/vue-app/package.json
+++ b/packages/vue-app/package.json
@@ -12,6 +12,7 @@
   "main": "dist/vue-app.js",
   "typings": "types/index.d.ts",
   "dependencies": {
+    "core-js": "^2.6.5",
     "node-fetch": "^2.3.0",
     "unfetch": "^4.1.0",
     "vue": "^2.6.10",


### PR DESCRIPTION
Fail to build if hoisted `core-js` version mismatch happens and provide instructions:

![image](https://user-images.githubusercontent.com/5158436/54826450-77987e80-4ccd-11e9-94b6-29d94696dc00.png)

* This condition allows any version matching 2.x.x.