### PR TITLE
examples(vue-apollo): update to @nuxtjs/apollo 4.x

### DIFF
--- a/examples/vue-apollo/apollo/network-interfaces/default.js
+++ b/examples/vue-apollo/apollo/network-interfaces/default.js
@@ -1,5 +1,0 @@
-import { createNetworkInterface } from 'apollo-client'
-
-export default (ctx) => {
-  return createNetworkInterface({ uri: 'https://api.graph.cool/simple/v1/cj1dqiyvqqnmj0113yuqamkuu' })
-}

--- a/examples/vue-apollo/nuxt.config.js
+++ b/examples/vue-apollo/nuxt.config.js
@@ -1,8 +1,10 @@
 export default {
   modules: ['@nuxtjs/apollo'],
   apollo: {
-    networkInterfaces: {
-      default: '~/apollo/network-interfaces/default.js'
+    clientConfigs: {
+      default: {
+        httpEndpoint: 'https://api.graph.cool/simple/v1/cj1dqiyvqqnmj0113yuqamkuu'
+      }
     }
   }
 }

--- a/examples/vue-apollo/package.json
+++ b/examples/vue-apollo/package.json
@@ -1,7 +1,9 @@
 {
   "name": "example-vue-apollo",
   "dependencies": {
-    "@nuxtjs/apollo": "^2.1.1",
+    "@nuxtjs/apollo": "^4.0.0-rc.4",
+    "core-js": "^2.6.5",
+    "node-fetch": "^2.3.0",
     "nuxt": "latest"
   },
   "scripts": {


### PR DESCRIPTION
closes #5333.