### PR TITLE
feat(cli): add `--quiet` option to nuxt generate command

### DIFF
--- a/packages/cli/src/commands/generate.js
+++ b/packages/cli/src/commands/generate.js
@@ -25,6 +25,18 @@ export default {
         }
       }
     },
+    quiet: {
+      alias: 'q',
+      type: 'boolean',
+      description: 'Disable output except for errors',
+      prepare(cmd, options, argv) {
+        // Silence output when using --quiet
+        options.build = options.build || {}
+        if (argv.quiet) {
+          options.build.quiet = true
+        }
+      }
+    },
     modern: {
       ...common.modern,
       description: 'Generate app in modern build (modern mode can be only client)',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
## Adding `--quiet` option for `nuxt generate` command
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
Adding `--quiet` option to the `nuxt generate` command
<!--- Why is this change required? What problem does it solve? -->
This change silence console output when using `--quiet` option with `nuxt generate`
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
Resolves: #5335

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

