### PR TITLE
chore(readme): add nuxt.ready() for middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ let config = require('./nuxt.config.js')
 config.dev = (process.env.NODE_ENV !== 'production')
 
 let nuxt = new Nuxt(config)
+await nuxt.ready()
 
 // Start build process (only in development)
 if (config.dev) {

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ let config = require('./nuxt.config.js')
 config.dev = (process.env.NODE_ENV !== 'production')
 
 let nuxt = new Nuxt(config)
-await nuxt.ready()
+nuxt.ready()
 
 // Start build process (only in development)
 if (config.dev) {

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ let config = require('./nuxt.config.js')
 config.dev = (process.env.NODE_ENV !== 'production')
 
 let nuxt = new Nuxt(config)
-nuxt.ready()
+nuxt.ready().catch(console.error)
 
 // Start build process (only in development)
 if (config.dev) {


### PR DESCRIPTION
Starting on 2.5.0, it is now required to call `nuxt.ready()`. 