### PR TITLE
fix(build): disable loading `babel.config.js` by default

### DIFF
--- a/packages/config/src/config/build.js
+++ b/packages/config/src/config/build.js
@@ -79,6 +79,7 @@ export default () => ({
     commons: true
   },
   babel: {
+    configFile: false,
     babelrc: false,
     cacheDirectory: undefined
   },

--- a/packages/config/test/__snapshots__/options.test.js.snap
+++ b/packages/config/test/__snapshots__/options.test.js.snap
@@ -12,6 +12,7 @@ Object {
     "babel": Object {
       "babelrc": false,
       "cacheDirectory": false,
+      "configFile": false,
     },
     "cache": false,
     "crossorigin": undefined,

--- a/packages/config/test/config/__snapshots__/index.test.js.snap
+++ b/packages/config/test/config/__snapshots__/index.test.js.snap
@@ -9,6 +9,7 @@ Object {
     "babel": Object {
       "babelrc": false,
       "cacheDirectory": undefined,
+      "configFile": false,
     },
     "cache": false,
     "crossorigin": undefined,
@@ -340,6 +341,7 @@ Object {
     "babel": Object {
       "babelrc": false,
       "cacheDirectory": undefined,
+      "configFile": false,
     },
     "cache": false,
     "crossorigin": undefined,

--- a/packages/config/test/options.test.js
+++ b/packages/config/test/options.test.js
@@ -189,9 +189,10 @@ describe('config: options', () => {
       })
       expect(consola.warn).toHaveBeenCalledWith('@nuxtjs/babel-preset-app has been deprecated, please use @nuxt/babel-preset-app.')
       expect(babel).toEqual({
-        'babelrc': false,
-        'cacheDirectory': false,
-        'presets': ['@nuxt/babel-preset-app']
+        configFile: false,
+        babelrc: false,
+        cacheDirectory: false,
+        presets: ['@nuxt/babel-preset-app']
       })
     })
 
@@ -200,9 +201,10 @@ describe('config: options', () => {
         build: { babel: { presets: [['@nuxt/babel-preset-app', { test: true }]] } }
       })
       expect(babel).toEqual({
-        'babelrc': false,
-        'cacheDirectory': false,
-        'presets': [['@nuxt/babel-preset-app', { test: true }]]
+        configFile: false,
+        babelrc: false,
+        cacheDirectory: false,
+        presets: [['@nuxt/babel-preset-app', { test: true }]]
       })
     })
   })


### PR DESCRIPTION
If it's reasonable and qualified to be a hotfix, please change base to `2.x`