### PR TITLE
feat(webpack): export webpack's config builder classes

### DIFF
--- a/packages/webpack/src/index.js
+++ b/packages/webpack/src/index.js
@@ -1,1 +1,2 @@
 export { WebpackBundler as BundleBuilder } from './builder'
+export * from './config'


### PR DESCRIPTION
## Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
Currently there is no way to extract a webpack config from a Nuxt project, because there is no access to `WebpackClientConfig`, `WebpackServerConfig` and `WebpackModernConfig`.

Here is what I wanted to do:
```js
const { Builder } = require('@nuxt/builder');
const { Nuxt } = require('@nuxt/core');
const { WebpackClientConfig } = require('@nuxt/webpack'); // currently not exported

const nuxt = new Nuxt();
const builder = new Builder(nuxt);
console.log(new WebpackClientConfig(builder.getBundleBuilder()).config()); // webpack config
```

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

