### PR TITLE
fix: SyntaxError Unexpected token export in importing babel runtime helper

### DIFF
--- a/packages/babel-preset-app/src/index.js
+++ b/packages/babel-preset-app/src/index.js
@@ -106,7 +106,7 @@ module.exports = (context, options = {}) => {
     regenerator: useBuiltIns !== 'usage',
     corejs: useBuiltIns !== false ? false : corejs,
     helpers: useBuiltIns === 'usage',
-    useESModules: true,
+    useESModules: false,
     absoluteRuntime
   }])
 

--- a/packages/babel-preset-app/src/index.js
+++ b/packages/babel-preset-app/src/index.js
@@ -106,7 +106,7 @@ module.exports = (context, options = {}) => {
     regenerator: useBuiltIns !== 'usage',
     corejs: useBuiltIns !== false ? false : corejs,
     helpers: useBuiltIns === 'usage',
-    useESModules: false,
+    useESModules: buildTarget !== 'server',
     absoluteRuntime
   }])
 


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description

If `useESModules` option of `@babel/plugin-transform-runtime` is true, browser can not parse the `export`.

Resolves: https://github.com/nuxt/nuxt.js/issues/5400

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

