### PR TITLE
revert(core): call ready to prevent breaking changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,10 @@ Or you can start by using one of our starter templates:
 const { Nuxt, Builder } = require('nuxt')
 
 // Import and set nuxt.js options
-let config = require('./nuxt.config.js')
+const config = require('./nuxt.config.js')
 config.dev = (process.env.NODE_ENV !== 'production')
 
-let nuxt = new Nuxt(config)
-nuxt.ready().catch(console.error)
+const nuxt = new Nuxt(config)
 
 // Start build process (only in development)
 if (config.dev) {

--- a/packages/core/src/nuxt.js
+++ b/packages/core/src/nuxt.js
@@ -38,6 +38,11 @@ export default class Nuxt extends Hookable {
     if (this.options.server !== false) {
       this._initServer()
     }
+
+    // Call ready
+    if (this.options._ready !== false) {
+      this.ready()
+    }
   }
 
   static get version() {

--- a/packages/core/src/nuxt.js
+++ b/packages/core/src/nuxt.js
@@ -41,7 +41,9 @@ export default class Nuxt extends Hookable {
 
     // Call ready
     if (this.options._ready !== false) {
-      this.ready()
+      this.ready().catch((err) => {
+        consola.fatal(err)
+      })
     }
   }
 
@@ -51,9 +53,7 @@ export default class Nuxt extends Hookable {
 
   ready() {
     if (!this._ready) {
-      this._ready = this._init().catch((err) => {
-        consola.fatal(err)
-      })
+      this._ready = this._init()
     }
     return this._ready
   }

--- a/packages/core/test/nuxt.test.js
+++ b/packages/core/test/nuxt.test.js
@@ -14,7 +14,9 @@ jest.mock('@nuxt/utils')
 jest.mock('@nuxt/server')
 
 jest.mock('@nuxt/config', () => ({
-  getNuxtConfig: jest.fn(() => ({}))
+  getNuxtConfig: jest.fn(() => ({
+    _ready: false
+  }))
 }))
 
 describe('core: nuxt', () => {
@@ -67,10 +69,7 @@ describe('core: nuxt', () => {
     const err = new Error('nuxt ready failed')
     const nuxt = new Nuxt()
     nuxt._init = () => Promise.reject(err)
-    await nuxt.ready()
-
-    expect(consola.fatal).toBeCalledTimes(1)
-    expect(consola.fatal).toBeCalledWith(err)
+    await expect(nuxt.ready()).rejects.toThrow(err)
   })
 
   test('should return nuxt version from package.json', () => {
@@ -113,7 +112,7 @@ describe('core: nuxt', () => {
 
   test('should add object hooks', async () => {
     const hooks = {}
-    getNuxtConfig.mockReturnValueOnce({ hooks })
+    getNuxtConfig.mockReturnValueOnce({ hooks, _ready: false })
     const nuxt = new Nuxt()
 
     nuxt.addHooks = jest.fn()

--- a/packages/core/test/nuxt.test.js
+++ b/packages/core/test/nuxt.test.js
@@ -1,4 +1,3 @@
-import consola from 'consola'
 import { defineAlias } from '@nuxt/utils'
 import { getNuxtConfig } from '@nuxt/config'
 import { Server } from '@nuxt/server'

--- a/test/unit/renderer.test.js
+++ b/test/unit/renderer.test.js
@@ -16,9 +16,8 @@ describe('renderer', () => {
       dev: false,
       buildDir: '/path/to/404'
     })
-    await nuxt.ready()
-    await expect(nuxt.renderer.renderer.isReady).toBe(false)
-    expect(consola.fatal).toHaveBeenCalledWith(expect.objectContaining({
+
+    await expect(nuxt.ready()).rejects.toThrow(expect.objectContaining({
       message: expect.stringMatching(NO_BUILD_MSG)
     }))
   })
@@ -30,9 +29,8 @@ describe('renderer', () => {
       dev: false,
       buildDir: '/path/to/404'
     })
-    await nuxt.ready()
-    await expect(nuxt.renderer.renderer.isReady).toBe(false)
-    expect(consola.fatal).toHaveBeenCalledWith(expect.objectContaining({
+
+    await expect(nuxt.ready()).rejects.toThrow(expect.objectContaining({
       message: expect.stringMatching(NO_BUILD_MSG)
     }))
   })
@@ -44,9 +42,8 @@ describe('renderer', () => {
       dev: false,
       buildDir: '/path/to/404'
     })
-    await nuxt.ready()
-    await expect(nuxt.renderer.renderer.isModernReady).toBe(false)
-    expect(consola.fatal).toHaveBeenCalledWith(expect.objectContaining({
+
+    await expect(nuxt.ready()).rejects.toThrow(expect.objectContaining({
       message: expect.stringMatching(NO_MODERN_BUILD_MSG)
     }))
   })


### PR DESCRIPTION
fixes #5408.

This fixes the condition when nuxt is starting programmatically in production mode with a custom server like express that does not calls `ready()`. We shouldn't change it until 3.0 because it is a breaking change for this condition. PS: No action is required from the side of users. Calling and awaiting on `ready()` after the constructor is _still_ recommended.
