### PR TITLE
chore(postcss): deprecate config support

### DIFF
--- a/packages/webpack/src/utils/postcss.js
+++ b/packages/webpack/src/utils/postcss.js
@@ -34,7 +34,7 @@ const postcssConfigFileWarning = (() => {
     if (executed) {
       return
     }
-    consola.warn(`Please use \`build.postcss\` in your nuxt.config.js instead of an external config file. Support for such files will be removed in Nuxt 3.`)
+    consola.warn(`Please use \`build.postcss\` in your nuxt.config.js instead of an external config file. Support for such files will be removed in Nuxt 3 as they remove all defaults set by Nuxt and can cause severe problems with features like alias resolving inside your CSS.`)
     executed = true
   }
 })()

--- a/packages/webpack/src/utils/postcss.js
+++ b/packages/webpack/src/utils/postcss.js
@@ -28,6 +28,17 @@ export const orderPresets = {
   }
 }
 
+const postcssConfigFileWarning = (() => {
+  let executed
+  return () => {
+    if (executed) {
+      return
+    }
+    consola.warn(`Please use \`build.postcss\` in your nuxt.config.js instead of an external config file. Support for such files will be removed in Nuxt 3.`)
+    executed = true
+  }
+})()
+
 export default class PostcssConfig {
   constructor(buildContext) {
     this.buildContext = buildContext
@@ -82,7 +93,7 @@ export default class PostcssConfig {
       ]) {
         const configFile = path.resolve(dir, file)
         if (fs.existsSync(configFile)) {
-          consola.warn(`Please use \`build.postcss\` in your nuxt.config.js instead of a${file} file. Support for such files will be removed in Nuxt 3.`)
+          postcssConfigFileWarning()
           return configFile
         }
       }

--- a/packages/webpack/src/utils/postcss.js
+++ b/packages/webpack/src/utils/postcss.js
@@ -28,16 +28,13 @@ export const orderPresets = {
   }
 }
 
-const postcssConfigFileWarning = (() => {
-  let executed
-  return () => {
-    if (executed) {
-      return
-    }
-    consola.warn(`Please use \`build.postcss\` in your nuxt.config.js instead of an external config file. Support for such files will be removed in Nuxt 3 as they remove all defaults set by Nuxt and can cause severe problems with features like alias resolving inside your CSS.`)
-    executed = true
+function postcssConfigFileWarning() {
+  if (postcssConfigFileWarning.executed) {
+    return
   }
-})()
+  consola.warn('Please use `build.postcss` in your nuxt.config.js instead of an external config file. Support for such files will be removed in Nuxt 3 as they remove all defaults set by Nuxt and can cause severe problems with features like alias resolving inside your CSS.')
+  postcssConfigFileWarning.executed = true
+}
 
 export default class PostcssConfig {
   constructor(buildContext) {

--- a/packages/webpack/src/utils/postcss.js
+++ b/packages/webpack/src/utils/postcss.js
@@ -70,6 +70,7 @@ export default class PostcssConfig {
   searchConfigFile() {
     // Search for postCSS config file and use it if exists
     // https://github.com/michael-ciniawsky/postcss-load-config
+    // TODO: Remove in Nuxt 3
     const { srcDir, rootDir } = this.buildContext.options
     for (const dir of [ srcDir, rootDir ]) {
       for (const file of [
@@ -81,6 +82,7 @@ export default class PostcssConfig {
       ]) {
         const configFile = path.resolve(dir, file)
         if (fs.existsSync(configFile)) {
+          consola.warn(`Please use \`build.postcss\` in your nuxt.config.js instead of a${file} file. Support for such files will be removed in Nuxt 3.`)
           return configFile
         }
       }

--- a/test/fixtures/with-config/with-config.test.js
+++ b/test/fixtures/with-config/with-config.test.js
@@ -14,26 +14,18 @@ const hooks = [
 
 describe('with-config', () => {
   buildFixture('with-config', () => {
-    expect(consola.warn).toHaveBeenCalledTimes(5)
+    expect(consola.warn).toHaveBeenCalledTimes(6)
     expect(consola.fatal).toHaveBeenCalledTimes(0)
     expect(consola.warn.mock.calls).toMatchObject([
-      [
-        'Unknown mode: unknown. Falling back to universal'
-      ],
-      [
-        `Invalid plugin mode (server/client/all): 'abc'. Falling back to 'all'`
-      ],
+      ['Unknown mode: unknown. Falling back to universal'],
+      ['Invalid plugin mode (server/client/all): \'abc\'. Falling back to \'all\''],
       [{
-        message: 'Found 2 plugins that match the configuration, suggest to specify extension:',
-        additional: expect.stringContaining('plugins/test.json')
+        'additional': '',
+        'message': 'Found 2 plugins that match the configuration, suggest to specify extension:'
       }],
-      [
-        'Using styleResources without the nuxt-style-resources-module is not suggested and can lead to severe performance issues.',
-        'Please use https://github.com/nuxt-community/style-resources-module'
-      ],
-      [
-        'Notice: Please do not deploy bundles built with analyze mode, it\'s only for analyzing purpose.'
-      ]
+      ['Please use `build.postcss` in your nuxt.config.js instead of an external config file. Support for such files will be removed in Nuxt 3.'],
+      ['Using styleResources without the nuxt-style-resources-module is not suggested and can lead to severe performance issues.', 'Please use https://github.com/nuxt-community/style-resources-module'],
+      ['Notice: Please do not deploy bundles built with analyze mode, it\'s only for analyzing purpose.']
     ])
     expect(customCompressionMiddlewareFunctionName).toBe('damn')
   }, hooks)

--- a/test/fixtures/with-config/with-config.test.js
+++ b/test/fixtures/with-config/with-config.test.js
@@ -20,7 +20,7 @@ describe('with-config', () => {
       ['Unknown mode: unknown. Falling back to universal'],
       ['Invalid plugin mode (server/client/all): \'abc\'. Falling back to \'all\''],
       [{
-        'additional': '',
+        'additional': expect.stringContaining('plugins/test.json'),
         'message': 'Found 2 plugins that match the configuration, suggest to specify extension:'
       }],
       ['Please use `build.postcss` in your nuxt.config.js instead of an external config file. Support for such files will be removed in Nuxt 3.'],

--- a/test/fixtures/with-config/with-config.test.js
+++ b/test/fixtures/with-config/with-config.test.js
@@ -23,7 +23,7 @@ describe('with-config', () => {
         'additional': expect.stringContaining('plugins/test.json'),
         'message': 'Found 2 plugins that match the configuration, suggest to specify extension:'
       }],
-      ['Please use `build.postcss` in your nuxt.config.js instead of an external config file. Support for such files will be removed in Nuxt 3.'],
+      ['Please use `build.postcss` in your nuxt.config.js instead of an external config file. Support for such files will be removed in Nuxt 3 as they remove all defaults set by Nuxt and can cause severe problems with features like alias resolving inside your CSS.'],
       ['Using styleResources without the nuxt-style-resources-module is not suggested and can lead to severe performance issues.', 'Please use https://github.com/nuxt-community/style-resources-module'],
       ['Notice: Please do not deploy bundles built with analyze mode, it\'s only for analyzing purpose.']
     ])


### PR DESCRIPTION


## Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Feature deprecation


## Description

Using a `postcss.config.js` or a similar file will not apply any of the default plugins coming with Nuxt which could lead to severe issues (like not resolving aliases).

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

