### PR TITLE
feat(webpack): Expose webpack base config class

### DIFF
--- a/packages/webpack/src/index.js
+++ b/packages/webpack/src/index.js
@@ -1,1 +1,2 @@
 export { WebpackBundler as BundleBuilder } from './builder'
+export { WebpackBaseConfig } from './config/base'

--- a/packages/webpack/src/index.js
+++ b/packages/webpack/src/index.js
@@ -1,2 +1,2 @@
 export { WebpackBundler as BundleBuilder } from './builder'
-export { WebpackBaseConfig } from './config/base'
+export { default as WebpackBaseConfig } from './config/base'


### PR DESCRIPTION
Expose webpack base config class.

## Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Add an export of the [`WebpackBaseConfig`](https://github.com/nuxt/nuxt.js/blob/dev/packages/webpack/src/config/base.js) class.

It could be useful for some advanced modules to be able to extend this class for independent webpack build using Nuxt base config:
I'm making a module which hooks Nuxt to add another webpack build with NetlifyCMS, but sharing some source files with Nuxt project (for previews). I would like to have the same base configuration so Nuxt project files can be imported with the same rules, plugins, etc...

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.
