### PR TITLE
feat(cli): add internal `_generate` and `_build` flags

### DIFF
--- a/packages/cli/src/commands/build.js
+++ b/packages/cli/src/commands/build.js
@@ -61,7 +61,7 @@ export default {
     }
   },
   async run(cmd) {
-    const config = await cmd.getNuxtConfig({ dev: false })
+    const config = await cmd.getNuxtConfig({ dev: false, _build: true })
     const nuxt = await cmd.getNuxt(config)
 
     if (cmd.argv.lock) {

--- a/packages/cli/src/commands/dev.js
+++ b/packages/cli/src/commands/dev.js
@@ -35,7 +35,7 @@ export default {
   },
 
   async _startDev(cmd, argv) {
-    const config = await cmd.getNuxtConfig({ dev: true })
+    const config = await cmd.getNuxtConfig({ dev: true, _build: true })
     const nuxt = await cmd.getNuxt(config)
 
     // Setup hooks

--- a/packages/cli/src/commands/generate.js
+++ b/packages/cli/src/commands/generate.js
@@ -53,7 +53,7 @@ export default {
     }
   },
   async run(cmd) {
-    const config = await cmd.getNuxtConfig({ dev: false })
+    const config = await cmd.getNuxtConfig({ dev: false, _generate: true, _build: cmd.argv.build })
 
     // Disable analyze if set by the nuxt config
     if (!config.build) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
Previously we had internal flag `options._start`, this PR also adds `options._build` and `options._generate` when running CLI commands so 1) options.js 2) modules can predict if a builder or generator is supposed to be started with the current instance. (Useful for #5354.)

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

