### PR TITLE
revert: revert node-externals disabling in dev mode

### DIFF
--- a/packages/webpack/src/config/server.js
+++ b/packages/webpack/src/config/server.js
@@ -109,7 +109,7 @@ export default class WebpackServerConfig extends WebpackBaseConfig {
     // https://webpack.js.org/configuration/externals/#externals
     // https://github.com/liady/webpack-node-externals
     // https://vue-loader.vuejs.org/migrating.html#ssr-externals
-    if (!this.dev && !this.buildContext.buildOptions.standalone) {
+    if (!this.buildContext.buildOptions.standalone) {
       this.buildContext.options.modulesDir.forEach((dir) => {
         if (fs.existsSync(dir)) {
           config.externals.push(


### PR DESCRIPTION
This pr is reverting #5414 since including all `node_modules` will cause problems.

So for **fixing dev mode memory leak issue**, we suggest user using **`build.standalone: true`**.

`standalone` mode will include all `node_modules` into `server bundle file` and avoid shared Vue module in Node.js main process which leads to memory leak in dev mode.

But **one thing need to be notified** is: If all `node_modules` all bundled into `server.js` by webpack, the modules which are using Node.js globals and modules like `__dirname` won't work as be resolved successfully by webpack, so those modules need to be declared in webpack `externals`.

For example: `firebase` and its dependency `grpc` are using `__direname`, so the config would be like:

```js
// nuxt.config.js
export default {
  build: {
    standalone: true,
    extend(config, { isDev, isServer }) {
      if (isDev && isServer) {
        config.externals = [
          'grpc',
          '@firebase/app',
          '@firebase/auth',
          '@firebase/firestore',
          '@firebase/storage'
        ]
      }
    }
  }
}
```