### PR TITLE
fix(cli): throw error with proper code for failed imports

### DIFF
--- a/packages/cli/src/imports.js
+++ b/packages/cli/src/imports.js
@@ -1,5 +1,4 @@
 import path from 'path'
-import consola from 'consola'
 
 const localNodeModules = path.resolve(process.cwd(), 'node_modules')
 

--- a/packages/cli/src/imports.js
+++ b/packages/cli/src/imports.js
@@ -5,24 +5,22 @@ const localNodeModules = path.resolve(process.cwd(), 'node_modules')
 
 // Prefer importing modules from local node_modules (for NPX and global bin)
 async function _import(modulePath) {
-  let m
-  for (const mp of [ path.resolve(localNodeModules, modulePath), modulePath ]) {
+  for (const mp of [
+    path.resolve(localNodeModules, modulePath),
+    modulePath
+  ]) {
     try {
-      m = await import(mp)
+      return await import(mp)
     } catch (e) {
       if (e.code !== 'MODULE_NOT_FOUND') {
         throw e
-      } else if (mp === modulePath) {
-        consola.fatal(
-          `Module ${modulePath} not found.\n\n`,
-          `Please install missing dependency:\n\n`,
-          `Using npm:  npm i ${modulePath}\n\n`,
-          `Using yarn: yarn add ${modulePath}`
-        )
       }
     }
   }
-  return m
+
+  const error = new Error(`Cannot import module '${modulePath}'`)
+  error.code = 'MODULE_NOT_FOUND'
+  throw error
 }
 
 export const builder = () => _import('@nuxt/builder')

--- a/packages/cli/test/unit/imports.test.js
+++ b/packages/cli/test/unit/imports.test.js
@@ -1,4 +1,3 @@
-import consola from 'consola'
 import { importModule } from '../../src/imports'
 
 describe('imports', () => {
@@ -8,15 +7,11 @@ describe('imports', () => {
   test('should import core module', async () => {
     await expect(importModule('path')).resolves.toBeDefined()
   })
-  test('should print error when module not found', async () => {
-    await expect(importModule('not-found-module')).resolves.toBeUndefined()
-    expect(consola.fatal).toHaveBeenCalled()
-    expect(consola.fatal).toHaveBeenCalledWith(
-      `Module not-found-module not found.\n\n`,
-      `Please install missing dependency:\n\n`,
-      `Using npm:  npm i not-found-module\n\n`,
-      `Using yarn: yarn add not-found-module`
-    )
+  test('should throw error with proper code when module not found', async () => {
+    await expect(importModule('not-found-module')).rejects.toMatchObject({
+      message: `Cannot import module 'not-found-module'`,
+      code: 'MODULE_NOT_FOUND'
+    })
   })
   test('should throw error when error is not module not found', async () => {
     await expect(importModule('jest/README.md')).rejects.toThrow()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
The usage of `_import` was originally expanding search path. Using `consola.fatal` disallows catching errors.

This PR fixes problem with typescript package detection by not forcing the user to install `@nuxt/typescript` when `tsconfig.json` exists in a project. ([source](https://github.com/nuxt/nuxt.js/blob/v2.6.1/packages/cli/src/utils/typescript.js#L22)) -- Thanks to @rchl for reporting this issue.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

