### PR TITLE
fix(vue-renderer): use `modulepreload` for modern mode spa generate

### DIFF
--- a/packages/vue-renderer/src/spa-meta.js
+++ b/packages/vue-renderer/src/spa-meta.js
@@ -30,8 +30,9 @@ export default class SPAMetaRenderer {
     return vm.$meta().inject()
   }
 
-  async render({ url = '/', req = {} }) {
-    const cacheKey = `${req.modernMode ? 'modern:' : 'legacy:'}${url}`
+  async render({ url = '/', req = {}, _generate }) {
+    const modern = req.modernMode || _generate
+    const cacheKey = `${modern ? 'modern:' : 'legacy:'}${url}`
     let meta = this.cache.get(cacheKey)
 
     if (meta) {
@@ -75,7 +76,7 @@ export default class SPAMetaRenderer {
     meta.resourceHints = ''
 
     const { resources: { modernManifest, clientManifest } } = this.renderer.context
-    const manifest = req.modernMode ? modernManifest : clientManifest
+    const manifest = modern ? modernManifest : clientManifest
 
     const { shouldPreload, shouldPrefetch } = this.options.render.bundleRenderer
 
@@ -90,7 +91,7 @@ export default class SPAMetaRenderer {
         meta.preloadFiles = manifest.initial
           .map(SPAMetaRenderer.normalizeFile)
           .filter(({ fileWithoutQuery, asType }) => shouldPreload(fileWithoutQuery, asType))
-          .map(file => ({ ...file, modern: req.modernMode }))
+          .map(file => ({ ...file, modern }))
 
         meta.resourceHints += meta.preloadFiles
           .map(({ file, extension, fileWithoutQuery, asType, modern }) => {

--- a/packages/vue-renderer/src/spa-meta.js
+++ b/packages/vue-renderer/src/spa-meta.js
@@ -31,7 +31,7 @@ export default class SPAMetaRenderer {
   }
 
   async render({ url = '/', req = {}, _generate }) {
-    const modern = req.modernMode || _generate
+    const modern = req.modernMode || (this.options.modern && _generate)
     const cacheKey = `${modern ? 'modern:' : 'legacy:'}${url}`
     let meta = this.cache.get(cacheKey)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

Fix #5486

In generate, use `modulepreload` modern resources instead of `preload` legacy resources for avoiding downloading both `modern` and `legacy` resources.

@pi0 I'm using `_generate` in context, not sure if it's a stable flag, please review 😄  

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

