### PR TITLE
Remove inaccurate and misleading "memory usage" in dev CLI output

### DIFF
--- a/packages/cli/src/utils/index.js
+++ b/packages/cli/src/utils/index.js
@@ -6,7 +6,6 @@ import defaultsDeep from 'lodash/defaultsDeep'
 import { getDefaultNuxtConfig } from '@nuxt/config'
 import boxen from 'boxen'
 import chalk from 'chalk'
-import prettyBytes from 'pretty-bytes'
 import env from 'std-env'
 
 const _require = esm(module, {
@@ -94,10 +93,6 @@ export function showBanner(nuxt) {
 
   // Running mode
   lines.push(`Running in ${nuxt.options.dev ? chalk.bold.blue('development') : chalk.bold.green('production')} mode (${chalk.bold(nuxt.options.mode)})`)
-
-  // https://nodejs.org/api/process.html#process_process_memoryusage
-  const { heapUsed, rss } = process.memoryUsage()
-  lines.push(`Memory usage: ${chalk.bold(prettyBytes(heapUsed))} (RSS: ${prettyBytes(rss)})`)
 
   // Listeners
   lines.push('')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

After introducing the new DX feature - the "building project" page - the memory usage is printed **before** the app start. Whereas previously the memory usage was printed **after** the app start.

![image](https://user-images.githubusercontent.com/1622575/55924868-ddce4c80-5c4e-11e9-9944-f37f9b9ed694.png)

On the picture above the 58MB is quite inaccurate. Actual memory usage is around 300-500MB.

**Suggestion - do not print memory usage at all.**

Hence the PR.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

