### PR TITLE
feat(vue-app): rename `transition` to `pageTransition` and deprecate it

### DIFF
--- a/examples/routes-transitions/package.json
+++ b/examples/routes-transitions/package.json
@@ -1,7 +1,6 @@
 {
   "name": "example-routes-transitions",
   "dependencies": {
-    "axios": "^0.15.3",
     "nuxt": "latest"
   },
   "scripts": {

--- a/examples/routes-transitions/pages/users.vue
+++ b/examples/routes-transitions/pages/users.vue
@@ -28,8 +28,6 @@
 </template>
 
 <script>
-import axios from 'axios'
-
 export default {
   // Watch for $route.query.page to call Component methods (asyncData, fetch, validate, layout, etc.)
   watchQuery: ['page'],
@@ -42,7 +40,8 @@ export default {
   },
   async asyncData({ query }) {
     const page = +query.page || 1
-    const { data } = await axios.get(`https://reqres.in/api/users?page=${page}`)
+    const data = await fetch(`https://reqres.in/api/users?page=${page}`).then(res => res.json())
+
     return {
       page: +data.page,
       totalPages: data.total_pages,

--- a/packages/builder/src/context/template.js
+++ b/packages/builder/src/context/template.js
@@ -37,7 +37,7 @@ export default class TemplateContext {
         typeof options.loading === 'string'
           ? builder.relativeToBuild(options.srcDir, options.loading)
           : options.loading,
-      transition: options.transition,
+      pageTransition: options.pageTransition,
       layoutTransition: options.layoutTransition,
       dir: options.dir,
       components: {

--- a/packages/builder/test/context/__snapshots__/template.test.js.snap
+++ b/packages/builder/test/context/__snapshots__/template.test.js.snap
@@ -71,18 +71,21 @@ TemplateContext {
         "test": "test message",
       },
       "mode": "test mode",
+      "pageTransition": Object {
+        "name": "test_trans",
+      },
       "router": Object {
         "route": "test",
       },
       "srcDir": "test_src_dir",
       "store": "test_store",
       "test": "test_test",
-      "transition": Object {
-        "name": "test_trans",
-      },
       "vue": Object {
         "config": "test_config",
       },
+    },
+    "pageTransition": Object {
+      "name": "test_trans",
     },
     "plugins": Array [
       "plugins",
@@ -94,9 +97,6 @@ TemplateContext {
       "testSC": true,
     },
     "store": "test_store",
-    "transition": Object {
-      "name": "test_trans",
-    },
     "uniqBy": [Function],
     "vue": Object {
       "config": "test_config",

--- a/packages/builder/test/context/template.test.js
+++ b/packages/builder/test/context/template.test.js
@@ -37,7 +37,7 @@ describe('builder: buildContext', () => {
     },
     srcDir: 'test_src_dir',
     loading: 'test-loading',
-    transition: { name: 'test_trans' },
+    pageTransition: { name: 'test_trans' },
     layoutTransition: { name: 'test_layout_trans' },
     dir: ['test_dir'],
     ErrorPage: 'test_error_page'

--- a/packages/config/src/config/_app.js
+++ b/packages/config/src/config/_app.js
@@ -42,7 +42,7 @@ export default () => ({
 
   loadingIndicator: 'default',
 
-  transition: {
+  pageTransition: {
     name: 'page',
     mode: 'out-in',
     appear: false,

--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -47,7 +47,6 @@ export function getNuxtConfig(_options) {
     options.pageTransition = { name: options.pageTransition }
   }
 
-
   if (typeof options.layoutTransition === 'string') {
     options.layoutTransition = { name: options.layoutTransition }
   }

--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -35,9 +35,18 @@ export function getNuxtConfig(_options) {
     options._routerBaseSpecified = true
   }
 
-  if (typeof options.transition === 'string') {
-    options.transition = { name: options.transition }
+  // TODO: Remove for Nuxt 3
+  // transition -> pageTransition
+  if (typeof options.transition !== 'undefined') {
+    consola.warn('`transition` property is deprecated in favor of `pageTransition` and will be removed in Nuxt 3')
+    options.pageTransition = options.transition
+    delete options.transition
   }
+
+  if (typeof options.pageTransition === 'string') {
+    options.pageTransition = { name: options.pageTransition }
+  }
+
 
   if (typeof options.layoutTransition === 'string') {
     options.layoutTransition = { name: options.layoutTransition }
@@ -275,8 +284,8 @@ export function getNuxtConfig(_options) {
   defaultsDeep(options, modePreset || options.modes.universal)
 
   // If no server-side rendering, add appear true transition
-  if (options.render.ssr === false && options.transition) {
-    options.transition.appear = true
+  if (options.render.ssr === false && options.pageTransition) {
+    options.pageTransition.appear = true
   }
 
   // We assume the SPA fallback path is 404.html (for GitHub Pages, Surge, etc.)

--- a/packages/config/test/__snapshots__/options.test.js.snap
+++ b/packages/config/test/__snapshots__/options.test.js.snap
@@ -256,6 +256,14 @@ Object {
     "/var/nuxt/node_modules",
     "/var/nuxt/test/node_modules",
   ],
+  "pageTransition": Object {
+    "appear": false,
+    "appearActiveClass": "appear-active",
+    "appearClass": "appear",
+    "appearToClass": "appear-to",
+    "mode": "out-in",
+    "name": "page",
+  },
   "plugins": Array [],
   "render": Object {
     "bundleRenderer": Object {
@@ -332,14 +340,6 @@ Object {
     "less",
   ],
   "test": true,
-  "transition": Object {
-    "appear": false,
-    "appearActiveClass": "appear-active",
-    "appearClass": "appear",
-    "appearToClass": "appear-to",
-    "mode": "out-in",
-    "name": "page",
-  },
   "vue": Object {
     "config": Object {
       "performance": false,

--- a/packages/config/test/config/__snapshots__/index.test.js.snap
+++ b/packages/config/test/config/__snapshots__/index.test.js.snap
@@ -230,6 +230,14 @@ Object {
   "modulesDir": Array [
     "node_modules",
   ],
+  "pageTransition": Object {
+    "appear": false,
+    "appearActiveClass": "appear-active",
+    "appearClass": "appear",
+    "appearToClass": "appear-to",
+    "mode": "out-in",
+    "name": "page",
+  },
   "plugins": Array [],
   "render": Object {
     "bundleRenderer": Object {
@@ -305,14 +313,6 @@ Object {
     "less",
   ],
   "test": true,
-  "transition": Object {
-    "appear": false,
-    "appearActiveClass": "appear-active",
-    "appearClass": "appear",
-    "appearToClass": "appear-to",
-    "mode": "out-in",
-    "name": "page",
-  },
   "vue": Object {
     "config": Object {
       "performance": undefined,
@@ -562,6 +562,14 @@ Object {
   "modulesDir": Array [
     "node_modules",
   ],
+  "pageTransition": Object {
+    "appear": false,
+    "appearActiveClass": "appear-active",
+    "appearClass": "appear",
+    "appearToClass": "appear-to",
+    "mode": "out-in",
+    "name": "page",
+  },
   "plugins": Array [],
   "render": Object {
     "bundleRenderer": Object {
@@ -637,14 +645,6 @@ Object {
     "less",
   ],
   "test": true,
-  "transition": Object {
-    "appear": false,
-    "appearActiveClass": "appear-active",
-    "appearClass": "appear",
-    "appearToClass": "appear-to",
-    "mode": "out-in",
-    "name": "page",
-  },
   "vue": Object {
     "config": Object {
       "performance": undefined,

--- a/packages/config/test/options.test.js
+++ b/packages/config/test/options.test.js
@@ -66,7 +66,7 @@ describe('config: options', () => {
       pageTransition: 'test-tran',
       layoutTransition: 'test-layout-tran'
     })
-    expect(transition).toMatchObject({ name: 'test-tran' })
+    expect(pageTransition).toMatchObject({ name: 'test-tran' })
     expect(layoutTransition).toMatchObject({ name: 'test-layout-tran' })
   })
 

--- a/packages/config/test/options.test.js
+++ b/packages/config/test/options.test.js
@@ -53,9 +53,17 @@ describe('config: options', () => {
     })
   })
 
-  test('should transform transition/layoutTransition to name', () => {
-    const { transition, layoutTransition } = getNuxtConfig({
-      transition: 'test-tran',
+  test('[Compatibility] should transform transition to pageTransition', () => {
+    const { pageTransition, transition } = getNuxtConfig({
+      transition: 'test-tran'
+    })
+    expect(pageTransition).toMatchObject({ name: 'test-tran' })
+    expect(transition).toBeUndefined()
+  })
+
+  test('should transform pageTransition/layoutTransition to name', () => {
+    const { pageTransition, layoutTransition } = getNuxtConfig({
+      pageTransition: 'test-tran',
       layoutTransition: 'test-layout-tran'
     })
     expect(transition).toMatchObject({ name: 'test-tran' })

--- a/packages/config/test/options.test.js
+++ b/packages/config/test/options.test.js
@@ -104,9 +104,9 @@ describe('config: options', () => {
     expect(render.ssr).toEqual(true)
   })
 
-  test('should add appear true in transition when no ssr', () => {
-    const { transition } = getNuxtConfig({ render: { ssr: false } })
-    expect(transition.appear).toEqual(true)
+  test('should add appear true in pageTransition when no ssr', () => {
+    const { pageTransition } = getNuxtConfig({ render: { ssr: false } })
+    expect(pageTransition.appear).toEqual(true)
   })
 
   test('should return 404.html as default generate.fallback', () => {

--- a/packages/vue-app/template/index.js
+++ b/packages/vue-app/template/index.js
@@ -36,7 +36,7 @@ Vue.use(Meta, {
 })
 
 const defaultTransition = <%=
-  serialize(transition)
+  serialize(pageTransition)
   .replace('beforeEnter(', 'function(').replace('enter(', 'function(').replace('afterEnter(', 'function(')
   .replace('enterCancelled(', 'function(').replace('beforeLeave(', 'function(').replace('leave(', 'function(')
   .replace('afterLeave(', 'function(').replace('leaveCancelled(', 'function(').replace('beforeAppear(', 'function(')

--- a/test/fixtures/basic/nuxt.config.js
+++ b/test/fixtures/basic/nuxt.config.js
@@ -63,7 +63,7 @@ export default {
     bad: null,
     '': true
   },
-  transition: false,
+  pageTransition: false,
   plugins: [
     '~/plugins/vuex-module',
     '~/plugins/dir-plugin',

--- a/test/fixtures/config-explicit/nuxt.config.js
+++ b/test/fixtures/config-explicit/nuxt.config.js
@@ -2,7 +2,7 @@ import path from 'path'
 
 export default {
   modulesDir: path.join(__dirname, '..', '..', '..', 'node_modules'),
-  transition: false,
+  pageTransition: false,
   vue: {
     config: {
       silent: false,

--- a/test/fixtures/spa/nuxt.config.js
+++ b/test/fixtures/spa/nuxt.config.js
@@ -1,6 +1,6 @@
 export default {
   mode: 'spa',
-  transition: false,
+  pageTransition: false,
   render: {
     http2: {
       push: true

--- a/test/fixtures/with-config/nuxt.config.js
+++ b/test/fixtures/with-config/nuxt.config.js
@@ -34,7 +34,7 @@ export default {
     }
   },
   modulesDir: [path.join(__dirname, '..', '..', '..', 'node_modules')],
-  transition: 'test',
+  pageTransition: 'test',
   layoutTransition: 'test',
   loadingIndicator: 'circle',
   extensions: 'ts',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->

Following this tweet: https://twitter.com/Atinux/status/1118789460253184000?s=19
Since we have `layoutTransition`, it makes more sense to rename `transition` to `pageTransition` in `nuxt.config.js`

I also added a warning for those using `transition` in order to rename it:
<img width="845" alt="Screenshot 2019-04-18 at 14 01 44" src="https://user-images.githubusercontent.com/904724/56360474-04f3c380-61e5-11e9-8ee9-5e6c9b067529.png">



## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

