### PR TITLE
fix(utils): node v8 not support dotAll in regex

### DIFF
--- a/packages/utils/src/serialize.js
+++ b/packages/utils/src/serialize.js
@@ -14,11 +14,11 @@ export function normalizeFunctions(obj) {
     }
     if (typeof obj[key] === 'function') {
       const asString = obj[key].toString()
-      const match = asString.match(/^([^{(]+)=>\s*(.*)/s)
+      const match = asString.match(/^([^{(]+)=>\s*([\0-\uFFFF]*)/)
       if (match) {
-        const fullFunctionBody = match[2].match(/^{?(\s*return\s+)?(.*?)}?$/s)
+        const fullFunctionBody = match[2].match(/^{?(\s*return\s+)?([\0-\uFFFF]*?)}?$/)
         let functionBody = fullFunctionBody[2].trim()
-        if (fullFunctionBody[1] || !match[2].trim().match(/^\s*{/s)) {
+        if (fullFunctionBody[1] || !match[2].trim().match(/^\s*{/)) {
           functionBody = `return ${functionBody}`
         }
         // eslint-disable-next-line no-new-func


### PR DESCRIPTION
As [Node Compat Table](https://node.green/#ES2018-features--s--dotAll--flag-for-regular-expressions), `/s` is not supported until Node.js 9, so try to use `[\0-\uFFFF]` to match new line for `.`

@galvez Could please verify that current fix works fine ?

Fixes #5652 