### PR TITLE
refactor(vue-renderer): remove chalk in renderer

### DIFF
--- a/packages/vue-renderer/src/renderer.js
+++ b/packages/vue-renderer/src/renderer.js
@@ -1,6 +1,5 @@
 import path from 'path'
 import fs from 'fs-extra'
-import chalk from 'chalk'
 import consola from 'consola'
 import template from 'lodash/template'
 import { isModernRequest } from '@nuxt/utils'
@@ -202,7 +201,7 @@ export default class VueRenderer {
     }
 
     options.modern = options.render.ssr ? 'server' : 'client'
-    consola.info(`Modern bundles are detected. Modern mode (${chalk.green.bold(options.modern)}) is enabled now.`)
+    consola.info(`Modern bundles are detected. Modern mode (\`${options.modern}\`) is enabled now.`)
   }
 
   createRenderer() {

--- a/test/unit/modern.server.test.js
+++ b/test/unit/modern.server.test.js
@@ -5,7 +5,7 @@ import { loadFixture, getPort, Nuxt, rp, wChunk } from '../utils'
 let nuxt, port
 const url = route => 'http://localhost:' + port + route
 const modernUA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.77 Safari/537.36'
-const modernInfo = mode => `Modern bundles are detected. Modern mode (${chalk.green.bold(mode)}) is enabled now.`
+const modernInfo = mode => `Modern bundles are detected. Modern mode (\`${mode}\`) is enabled now.`
 
 describe('modern server mode', () => {
   beforeAll(async () => {

--- a/test/unit/modern.server.test.js
+++ b/test/unit/modern.server.test.js
@@ -1,4 +1,3 @@
-import chalk from 'chalk'
 import consola from 'consola'
 import { loadFixture, getPort, Nuxt, rp, wChunk } from '../utils'
 

--- a/test/unit/modern.spa.test.js
+++ b/test/unit/modern.spa.test.js
@@ -1,4 +1,3 @@
-import chalk from 'chalk'
 import consola from 'consola'
 import { loadFixture, getPort, Nuxt, rp } from '../utils'
 

--- a/test/unit/modern.spa.test.js
+++ b/test/unit/modern.spa.test.js
@@ -5,7 +5,7 @@ import { loadFixture, getPort, Nuxt, rp } from '../utils'
 let nuxt, port, options
 const url = route => 'http://localhost:' + port + route
 const modernUA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.77 Safari/537.36'
-const modernInfo = mode => `Modern bundles are detected. Modern mode (${chalk.green.bold(mode)}) is enabled now.`
+const modernInfo = mode => `Modern bundles are detected. Modern mode (\`${mode}\`) is enabled now.`
 
 describe('modern client mode (SPA)', () => {
   beforeAll(async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

Remove warning `WARN  'chalk' is imported by packages\vue-renderer\src\renderer.js, but could not be resolved – treating it as an external dependency`

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

