### PR TITLE
fix(builder): call `watch:restart` after `watch:fileChanged` hook

### DIFF
--- a/packages/builder/src/builder.js
+++ b/packages/builder/src/builder.js
@@ -663,12 +663,12 @@ export default class Builder {
     this.createFileWatcher(
       nuxtRestartWatch,
       ['all'],
-      (event, fileName) => {
+      async (event, fileName) => {
         if (['add', 'change', 'unlink'].includes(event) === false) {
           return
         }
-        this.nuxt.callHook('watch:fileChanged', this, fileName) // Legacy
-        this.nuxt.callHook('watch:restart', { event, path: fileName })
+        await this.nuxt.callHook('watch:fileChanged', this, fileName) // Legacy
+        await this.nuxt.callHook('watch:restart', { event, path: fileName })
       },
       this.assignWatcher('restart')
     )

--- a/packages/builder/test/builder.watch.test.js
+++ b/packages/builder/test/builder.watch.test.js
@@ -244,7 +244,7 @@ describe('builder: builder watch', () => {
     expect(chokidar.on).toBeCalledWith('all', expect.any(Function))
   })
 
-  test('should trigger restarting when files changed', () => {
+  test('should trigger restarting when files changed', async () => {
     const nuxt = createNuxt()
     nuxt.options.watchers = {
       chokidar: { test: true }
@@ -259,9 +259,9 @@ describe('builder: builder watch', () => {
 
     const restartHandler = chokidar.on.mock.calls[0][1]
     const watchingFile = '/var/nuxt/src/watch/test/index.js'
-    restartHandler('add', watchingFile)
-    restartHandler('change', watchingFile)
-    restartHandler('unlink', watchingFile)
+    await restartHandler('add', watchingFile)
+    await restartHandler('change', watchingFile)
+    await restartHandler('unlink', watchingFile)
 
     expect(nuxt.callHook).toBeCalledTimes(6)
     expect(nuxt.callHook).nthCalledWith(1, 'watch:fileChanged', builder, watchingFile)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

@pi0 Should this be deprecacted ? I don't see any doc is refering it.

If there is anyone using it, this may be a slightly breaking change since there is no `builder` as param anymore.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

