### PR TITLE
feat(webpack): extendable functional babel.presets and babel envName

### DIFF
--- a/packages/webpack/src/config/base.js
+++ b/packages/webpack/src/config/base.js
@@ -1,7 +1,6 @@
 import path from 'path'
 import consola from 'consola'
 import TimeFixPlugin from 'time-fix-plugin'
-import clone from 'lodash/clone'
 import cloneDeep from 'lodash/cloneDeep'
 import escapeRegExp from 'lodash/escapeRegExp'
 import VueLoader from 'vue-loader'
@@ -70,21 +69,28 @@ export default class WebpackBaseConfig {
   }
 
   getBabelOptions() {
-    const options = clone(this.buildContext.buildOptions.babel)
+    const options = {
+      ...this.buildContext.buildOptions.babel,
+      envName: this.name
+    }
+
+    if (options.configFile !== false) {
+      return options
+    }
+
+    const defaultPreset = [
+      require.resolve('@nuxt/babel-preset-app'),
+      {
+        buildTarget: this.isServer ? 'server' : 'client'
+      }
+    ]
 
     if (typeof options.presets === 'function') {
-      options.presets = options.presets({ isServer: this.isServer })
+      options.presets = options.presets({ isServer: this.isServer }, defaultPreset)
     }
 
     if (!options.babelrc && !options.presets) {
-      options.presets = [
-        [
-          require.resolve('@nuxt/babel-preset-app'),
-          {
-            buildTarget: this.isServer ? 'server' : 'client'
-          }
-        ]
-      ]
+      options.presets = defaultPreset
     }
 
     return options

--- a/packages/webpack/src/config/base.js
+++ b/packages/webpack/src/config/base.js
@@ -90,7 +90,7 @@ export default class WebpackBaseConfig {
     }
 
     if (!options.babelrc && !options.presets) {
-      options.presets = defaultPreset
+      options.presets = [ defaultPreset ]
     }
 
     return options

--- a/packages/webpack/src/config/modern.js
+++ b/packages/webpack/src/config/modern.js
@@ -1,4 +1,3 @@
-import clone from 'lodash/clone'
 import WebpackClientConfig from './client'
 
 export default class WebpackModernConfig extends WebpackClientConfig {
@@ -15,17 +14,17 @@ export default class WebpackModernConfig extends WebpackClientConfig {
   }
 
   getBabelOptions() {
-    const options = clone(this.buildContext.buildOptions.babel)
-
-    options.presets = [
-      [
-        require.resolve('@nuxt/babel-preset-app'),
-        {
-          modern: true
-        }
+    return {
+      ...this.buildContext.buildOptions.babel,
+      envName: this.name,
+      presets: [
+        [
+          require.resolve('@nuxt/babel-preset-app'),
+          {
+            modern: true
+          }
+        ]
       ]
-    ]
-
-    return options
+    }
   }
 }


### PR DESCRIPTION
<details>
<summary>Hide Comment</summary>

## What's current situation

Current babel config in Nuxt.js is kind of complex and limited:

1. `build.babel.presets` supports `Function`, `Array` which may be confusing
2. Hard to apply customized config
3. Change options for `@nuxt/babel-preset-app` needs more useless code (via functional babel.presets)

## What's in this pr

This pr suggests using `babel.config.js` in `rootDir` which aligns to [`babel default behaviour`](https://babeljs.io/docs/en/configuration#babelconfigjs), user can easily config babel like:

```js
// babel.config.js
module.exports = function (api) {
  return {
    presets: [
      require.resolve('@nuxt/babel-preset-app'),
      {
        buildTarget: api.env('client') ? 'client' : 'server'
      }
    ],
	plugins: [...]
  }
}
```

For more complex scenario, it's also easier which is not possible in current Nuxt.js:

```js
// babel.config.js
module.exports = function (api) {
  const env = api.env()
  api.cache.using(() => env)

  const presets = []
  const plugins = []

  if (env === 'server') {
    // set server presets/plugins
  } else if (env === 'client') {
    // set client presets/plugins
  } else if (env === 'modern') {
    // set modern presets/plugins
  }

  return { presets, plugins }
}

```

## What's next (Nuxt.js v3)

I suggest that we remove `build.babel` and use native babel config way, actually `babel-loader` has already been using [`babel options`](https://babeljs.io/docs/en/options) as options of loader instead of self-defined options.

The current default preset config can be kept as default value when no babel config file found.

</details>

After discussion with @pi0 , we think keeping good DX and avoiding conflicts are very important.

So I have changed the pr:

1. Support api like `build.extend` for functional `presets`:

> `preset` is @nuxt/babel-preset-app
> `options` are [here](https://github.com/nuxt/nuxt.js/tree/dev/packages/babel-preset-app#options)

```js
// nuxt.config.js
export default {
  build: {
    babel: {
      presets({ isServer }, [preset, options]) {
        // change options directly
        options.targets = ...
        options.corejs = ...

        // or return whole preset list

        return [
          [
            preset, {
              buildTarget: ...,
              corejs: ...,
              ...,
              ...options
          }],
          [
            ...
          ]
        ]
      }
    }
  }
}
```

2. Add envName for users are using `configFile`

⚠️ **NOTE**⚠️ : `configFile` is not suggested to be used only if you know what you're doing

```js
// nuxt.config.js
export default {
  build: {
    babel: {
      configFile: path.resolve(rootDir, 'babel.config.js')
    }
  }
}

// babel.config.js
module.exports = function (api) {
  const env = api.env()
  api.cache.using(() => env)

  const presets = []
  const plugins = []

  if (env === 'server') {
    // set server presets/plugins
  } else if (env === 'client') {
    // set client presets/plugins
  } else if (env === 'modern') {
    // set modern presets/plugins
  }

  return { presets, plugins }
}

```