### PR TITLE
fix(server): Setup Nuxt middleware only in dev or start

### DIFF
--- a/packages/server/src/server.js
+++ b/packages/server/src/server.js
@@ -59,8 +59,10 @@ export default class Server {
     this.renderer = new VueRenderer(this.serverContext)
     await this.renderer.ready()
 
-    // Setup nuxt middleware
-    await this.setupMiddleware()
+    // Setup nuxt middleware (only with nuxt dev && nuxt start)
+    if (this.options.dev || this.options._start) {
+      await this.setupMiddleware()
+    }
 
     // Call done hook
     await this.nuxt.callHook('render:done', this)

--- a/test/fixtures/with-config/with-config.test.js
+++ b/test/fixtures/with-config/with-config.test.js
@@ -5,13 +5,6 @@ beforeAll(() => {
   process.env.NUXT_ENV_FOO = 'manniL'
 })
 
-let customCompressionMiddlewareFunctionName
-const hooks = [
-  ['render:errorMiddleware', (app) => {
-    customCompressionMiddlewareFunctionName = app.stack[0].handle.name
-  }]
-]
-
 describe('with-config', () => {
   buildFixture('with-config', () => {
     expect(consola.warn).toHaveBeenCalledTimes(6)
@@ -27,9 +20,7 @@ describe('with-config', () => {
       ['Using styleResources without the @nuxtjs/style-resources is not suggested and can lead to severe performance issues.', 'Please use https://github.com/nuxt-community/style-resources-module'],
       ['Notice: Please do not deploy bundles built with analyze mode, it\'s only for analyzing purpose.']
     ])
-    // setupMiddleware() is not called on build only
-    // expect(customCompressionMiddlewareFunctionName).toBe('damn')
-  }, hooks)
+  })
 })
 
 afterAll(() => {

--- a/test/fixtures/with-config/with-config.test.js
+++ b/test/fixtures/with-config/with-config.test.js
@@ -27,7 +27,8 @@ describe('with-config', () => {
       ['Using styleResources without the @nuxtjs/style-resources is not suggested and can lead to severe performance issues.', 'Please use https://github.com/nuxt-community/style-resources-module'],
       ['Notice: Please do not deploy bundles built with analyze mode, it\'s only for analyzing purpose.']
     ])
-    expect(customCompressionMiddlewareFunctionName).toBe('damn')
+    // setupMiddleware() is not called on build only
+    // expect(customCompressionMiddlewareFunctionName).toBe('damn')
   }, hooks)
 })
 

--- a/test/fixtures/with-config/with-config.test.js
+++ b/test/fixtures/with-config/with-config.test.js
@@ -5,6 +5,13 @@ beforeAll(() => {
   process.env.NUXT_ENV_FOO = 'manniL'
 })
 
+let customCompressionMiddlewareFunctionName
+const hooks = [
+  ['render:errorMiddleware', (app) => {
+    customCompressionMiddlewareFunctionName = app.stack[0].handle.name
+  }]
+]
+
 describe('with-config', () => {
   buildFixture('with-config', () => {
     expect(consola.warn).toHaveBeenCalledTimes(6)
@@ -20,7 +27,8 @@ describe('with-config', () => {
       ['Using styleResources without the @nuxtjs/style-resources is not suggested and can lead to severe performance issues.', 'Please use https://github.com/nuxt-community/style-resources-module'],
       ['Notice: Please do not deploy bundles built with analyze mode, it\'s only for analyzing purpose.']
     ])
-  })
+    expect(customCompressionMiddlewareFunctionName).toBe('damn')
+  }, hooks)
 })
 
 afterAll(() => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

This should fixes issues like https://github.com/nuxt/nuxt.js/issues/5669
It should as well avoid useless operations when not needed.

**Warning:** The breaking change will be related to programmatically usage (since they don't provide `_start`), so it may not the best solution. But what I see from https://nuxtjs.org/api/nuxt, it seems it's not up to date.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

