### PR TITLE
fix(vue-app): properly catch component loading error (#5687)

### DIFF
--- a/packages/vue-app/template/components/nuxt-link.client.js
+++ b/packages/vue-app/template/components/nuxt-link.client.js
@@ -85,10 +85,7 @@ export default {
       const Components = this.getPrefetchComponents()
 
       for (const Component of Components) {
-        try {
-          Component()
-          Component.__prefetched = true
-        } catch (e) {}
+        Component().then(() => Component.__prefetched = true).catch(() => {})
       }<% if (router.linkPrefetchedClass) { %>
       this.addPrefetchedClass()<% } %>
     }<% if (router.linkPrefetchedClass) { %>,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
Component prefetching from nuxt-link's was using try/catch to catch loading error but as the call to load the component returns a promise, in practice actual loading error wasn't caught.
That triggered majority of errors that are reported to Sentry in my production site.
Such errors can trigger fairly easily by canceling loading of a page or navigating to different URL while loading is in progress. We shouldn't care about those failing and shouldn't report them to console/sentry.
Resolves: #5687

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
Honestly I didn't have time to look into it and also I didn't find existing tests for prefetch failure. So investigating how to create new test would require me to spend a lot more time.
- [ ] All new and existing tests are passing.
Yes apart from `Address `/Users/xxx/workspace/github/nuxt.js/test/fixtures/sockets/nuxt.socket` is already in use` which seems unrelated.

