### PR TITLE
fix(vue-app): Followup for fix for handle prefetch error (#5687)

### DIFF
--- a/packages/vue-app/template/components/nuxt-link.client.js
+++ b/packages/vue-app/template/components/nuxt-link.client.js
@@ -85,7 +85,8 @@ export default {
       const Components = this.getPrefetchComponents()
 
       for (const Component of Components) {
-        Component().then(() => Component.__prefetched = true).catch(() => {})
+        Component().catch(() => {})
+        Component.__prefetched = true
       }<% if (router.linkPrefetchedClass) { %>
       this.addPrefetchedClass()<% } %>
     }<% if (router.linkPrefetchedClass) { %>,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
After more investigation I've came to conclusion that keeping previous
behavior of marking component as prefetched before we know if it
loaded/failed, is the right thing to do. That's because otherwise, when
processing many nuxt-links within a page, that code will trigger multiple
times, with same component list and trigger loading of them multiple
times (which might be optimized by webpack code anyway but still...).
Resolves: #5687 

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

