### PR TITLE
fix(builder): corretly detect mode of hashed plugins

### DIFF
--- a/packages/builder/src/builder.js
+++ b/packages/builder/src/builder.js
@@ -256,7 +256,7 @@ export default class Builder {
 
   normalizePlugins() {
     const modes = ['client', 'server']
-    const modePattern = new RegExp(`\\.(${modes.join('|')})(\\.\\w+)?$`)
+    const modePattern = new RegExp(`\\.(${modes.join('|')})(\\.\\w+)*$`)
     return uniqBy(
       this.options.plugins.map((p) => {
         if (typeof p === 'string') {

--- a/packages/builder/test/builder.plugin.test.js
+++ b/packages/builder/test/builder.plugin.test.js
@@ -20,6 +20,7 @@ describe('builder: builder plugins', () => {
     const nuxt = createNuxt()
     nuxt.options.plugins = [
       '/var/nuxt/plugins/test.js',
+      '/var/nuxt/.nuxt/foo-bar.plugin.client.530b6c6a.js',
       { src: '/var/nuxt/plugins/test.server', mode: 'server' },
       { src: '/var/nuxt/plugins/test.client', ssr: false }
     ]
@@ -32,6 +33,11 @@ describe('builder: builder plugins', () => {
         mode: 'all',
         name: 'nuxt_plugin_test_hash(/var/nuxt/plugins/test.js)',
         src: 'resolveAlias(/var/nuxt/plugins/test.js)'
+      },
+      {
+        mode: 'client',
+        name: 'nuxt_plugin_foobarpluginclient530b6c6a_hash(/var/nuxt/.nuxt/foo-bar.plugin.client.530b6c6a.js)',
+        src: 'resolveAlias(/var/nuxt/.nuxt/foo-bar.plugin.client.530b6c6a.js)'
       },
       {
         mode: 'server',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
`moduleContainer.addPlugin` generates a hash suffixed name if no explicit `fileName` is provided to prevent name collisions inside `.nuxt`. This PR ensures mode of file names like `mode-test.plugin.client.530b6c6a.js` is also correctly detected.

fixes #5694

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

