### PR TITLE
fix(ts): prevent `ts-node` to register twice

### DIFF
--- a/packages/cli/src/utils/typescript.js
+++ b/packages/cli/src/utils/typescript.js
@@ -2,7 +2,14 @@ import path from 'path'
 import fs from 'fs-extra'
 import * as imports from '../imports'
 
+let _guard = false
+export const setGuard = (val) => { _guard = val }
+
 async function registerTSNode({ tsConfigPath, options }) {
+  if (_guard) {
+    return
+  }
+
   const { register } = await imports.tsNode()
 
   // https://github.com/TypeStrong/ts-node
@@ -13,6 +20,8 @@ async function registerTSNode({ tsConfigPath, options }) {
     },
     ...options
   })
+
+  _guard = true
 }
 
 async function getNuxtTypeScript() {

--- a/packages/cli/test/unit/typescript.test.js
+++ b/packages/cli/test/unit/typescript.test.js
@@ -1,7 +1,7 @@
 import { resolve } from 'path'
 import { mkdirp, writeFile, remove } from 'fs-extra'
 import { register } from 'ts-node'
-import { detectTypeScript } from '../../src/utils/typescript'
+import { detectTypeScript, setGuard } from '../../src/utils/typescript'
 
 jest.mock('ts-node')
 
@@ -16,8 +16,12 @@ describe('Typescript Support', () => {
     await writeFile(tsConfigPath, '{}', 'utf-8')
   })
 
-  test('detectTypeScript detects and registers runtime', async () => {
+  beforeEach(() => {
     register.mockReset()
+    setGuard(false)
+  })
+
+  test('detectTypeScript detects and registers runtime', async () => {
     await detectTypeScript(rootDir)
     expect(register).toHaveBeenCalledTimes(1)
     expect(register).toHaveBeenCalledWith({
@@ -28,8 +32,13 @@ describe('Typescript Support', () => {
     })
   })
 
+  test('multiple detectTypeScript calls registers runtime only once', async () => {
+    await detectTypeScript(rootDir)
+    await detectTypeScript(rootDir)
+    expect(register).toHaveBeenCalledTimes(1)
+  })
+
   test('detectTypeScript skips rootDir without tsconfig.json', async () => {
-    register.mockReset()
     await detectTypeScript(rootDir2)
     expect(register).toHaveBeenCalledTimes(0)
   })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
This add a guard to prevent `ts-node` registration to happen more than once.
We had a similar guard few Nuxt versions ago but it seems to have been unintentionally removed with last refactors.

Fixes https://github.com/nuxt/nuxt.js/issues/5626

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

