### PR TITLE
fix(ts): fix `context.app` type

### DIFF
--- a/packages/vue-app/types/index.d.ts
+++ b/packages/vue-app/types/index.d.ts
@@ -1,4 +1,4 @@
-import Vue from 'vue'
+import Vue, { ComponentOptions } from 'vue'
 import VueRouter, { Route } from 'vue-router'
 import { Store } from 'vuex'
 import { IncomingMessage, ServerResponse } from 'http'
@@ -14,7 +14,7 @@ type Dictionary<T> = { [key: string]: T }
 type NuxtState = Dictionary<any>
 
 export interface Context {
-  app: Vue
+  app: NuxtAppOptions
   /**
    * @deprecated Use process.client instead
   */
@@ -81,7 +81,12 @@ export interface NuxtLoading extends Vue {
   start(): NuxtLoading
 }
 
+export interface NuxtAppOptions extends ComponentOptions<Vue> {
+  [key: string]: any // TBD
+}
+
 export interface NuxtApp extends Vue {
+  $options: NuxtAppOptions
   $loading: NuxtLoading
   isOffline: boolean
   isOnline: boolean


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
`context.app` was defined as a `Vue` instance, but it's not the good type, `app` being in fact Vue component options which are extended by Nuxt core but also in some few modules like [`nuxt-i18n`](https://github.com/nuxt-community/nuxt-i18n/blob/master/src/plugins/main.js#L77).

More context around this fix can be found in #5662 

The idea is just then about having a new interface `NuxtAppOptions`, which extends official Vue `ComponentOptions`. Extend options types inside this interface are still need to be defined, but for now `[key: string]: any` will prevent any TS error when accessing `context.app.someThingThatDoesntHaveTypeDefinitionYet`

I also extended `NuxtApp` interface (~ `this.$nuxt` type), so that `this.$nuxt.$options` has the extended options type.

Modules like `nuxt-i18n` should be able to extend this new interface through this way :

```ts
declare module '@nuxt/vue-app' {
  interface NuxtAppOptions {
    i18n: ...
  }
}
```

Closes #5589 
Fixes #5662

