### PR TITLE
fix(vue-app): remove trailing slash in vue-router non-strict mode

### DIFF
--- a/packages/vue-app/template/components/nuxt.js
+++ b/packages/vue-app/template/components/nuxt.js
@@ -41,7 +41,8 @@ export default {
         return this.nuxtChildKey || compile(this.$route.matched[0].path)(this.$route.params)
       }
 
-      const Component = this.$route.matched[0] && this.$route.matched[0].components.default
+      const matchedRoute = this.$route.matched[0]
+      const Component = matchedRoute && matchedRoute.components.default
       if (Component && Component.options) {
         const { key, watchQuery } = Component.options
 
@@ -64,7 +65,8 @@ export default {
         }
       }
 
-      return this.$route.path
+      const strict = /\/$/.test(matchedRoute.path)
+      return strict ? this.$route.path : this.$route.path.replace(/\/$/, '')
     }
   },
   beforeCreate() {

--- a/packages/vue-app/template/components/nuxt.js
+++ b/packages/vue-app/template/components/nuxt.js
@@ -41,7 +41,7 @@ export default {
         return this.nuxtChildKey || compile(this.$route.matched[0].path)(this.$route.params)
       }
 
-      const matchedRoute = this.$route.matched[0]
+      const [matchedRoute] = this.$route.matched
       const Component = matchedRoute && matchedRoute.components.default
       if (Component && Component.options) {
         const { key, watchQuery } = Component.options


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

Fix #5593 

According to https://github.com/vuejs/vue-router/blob/dev/src/create-route-map.js#L167 , `vue-router` will remove the trailing slash in non strict mode.

Imagine we have routes like and there is `NuxtChild` and `NuxtLink to='/test/post/1'` in `pages/test.vue`:

In non-strict mode, after we click link, the `route.matched[0]` is always `{ path: '/test', ... }`

```js
{
  path: "/test",
  name: "test",
  children: [{
    path: "post/:slug"
  }]
}
``` 


When we access `http://localhost:3000/test`, `routerViewKey` is always `/test` before and after clicking link.

But if we access `http://localhost:3000/test/`, the `routerViewKey` is `/test/` from [`this.route.path`](https://github.com/nuxt/nuxt.js/blob/dev/packages/vue-app/template/components/nuxt.js#L67). After clicking link, the `routerViewKey` is `/test` from [`this.$route.matched[0].path`](https://github.com/nuxt/nuxt.js/blob/dev/packages/vue-app/template/components/nuxt.js#L41), so `test.vue` will be destroyed and recreated which is incorrect.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

