### PR TITLE
fix(vue-app): don't attach catch handler to already loaded component (fixes #5751)

### DIFF
--- a/packages/vue-app/template/components/nuxt-link.client.js
+++ b/packages/vue-app/template/components/nuxt-link.client.js
@@ -85,7 +85,10 @@ export default {
       const Components = this.getPrefetchComponents()
 
       for (const Component of Components) {
-        Component().catch(() => {})
+        const componentOrPromise = Component()
+        if (componentOrPromise instanceof Promise) {
+          componentOrPromise.catch(() => {})
+        }
         Component.__prefetched = true
       }<% if (router.linkPrefetchedClass) { %>
       this.addPrefetchedClass()<% } %>


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
Components are not necessarily lazy-loaded. If user overrides webpack
build options with `splitChunks:{layouts: false, pages: false}`, for
example, pages will be loaded already on loading app.

I was thinking of handling this in the `getPrefetchComponents` function already, to not return components that are already loaded, but I don't see a way to find that out until we call `Component()` and that would trigger prefetching in case of lazy-loaded components.

Resolves: #5751

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

