### PR TITLE
fix(vue-app): reuse page component on watchQuery

### DIFF
--- a/packages/vue-app/template/client.js
+++ b/packages/vue-app/template/client.js
@@ -506,6 +506,11 @@ function fixPrepatch(to, ___) {
         for (const key in newData) {
           Vue.set(instance.$data, key, newData[key])
         }
+
+        // Ensure to trigger scroll event after calling scrollBehavior
+        window.<%= globals.nuxt %>.$nextTick(() => {
+          window.<%= globals.nuxt %>.$emit('triggerScroll')
+        })
       }
     })
     showNextPage.call(this, to)

--- a/packages/vue-app/template/components/nuxt.js
+++ b/packages/vue-app/template/components/nuxt.js
@@ -43,11 +43,12 @@ export default {
 
       const [matchedRoute] = this.$route.matched
       const Component = matchedRoute && matchedRoute.components.default
-      if (Component && Component.options) {
-        const { key } = Component.options
 
-        if (key) {
-          return (typeof key === 'function' ? key(this.$route) : key)
+      if (Component && Component.options) {
+        const { options } = Component
+
+        if (options.key) {
+          return (typeof options.key === 'function' ? options.key(this.$route) : options.key)
         }
       }
 

--- a/packages/vue-app/template/components/nuxt.js
+++ b/packages/vue-app/template/components/nuxt.js
@@ -43,24 +43,10 @@ export default {
 
       const Component = this.$route.matched[0] && this.$route.matched[0].components.default
       if (Component && Component.options) {
-        const { key, watchQuery } = Component.options
+        const { key } = Component.options
 
         if (key) {
           return (typeof key === 'function' ? key(this.$route) : key)
-        }
-
-        if (watchQuery) {
-          if (watchQuery.length) {
-            const pickedQuery = {}
-            for (const queryKey of watchQuery) {
-              pickedQuery[queryKey] = this.$route.query[queryKey]
-            }
-            return this.$router.resolve({
-              path: this.$route.path,
-              query: pickedQuery
-            }).href
-          }
-          return this.$route.fullPath
         }
       }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

Related issue and pull request:
- Resolves: #5738  #5759 
- Related: #5516 

I've submitted the pull request #5516 and it's about making `watchQuery` considered on creating a route key. However, by the change, page components are no more reused but recreated for every query route specified in `watchQuery` (#5738). The pull request was actually a breaking change.

The main goal of the original pull request was to make scroll restoration work with query route. Disabling component reuse is unexpected side-effect. Thus I'd like to revert the original change, with still enabling scroll restoration in a different way. So, here is this pull request.

This pull request restores the original `routerViewKey` behaviour (`$route.path`) so that page components are reused. Instead, I added `$emit('triggerScroll')` in `fixPrepatch`, which is called only when `navigating on a different route but the same component is used` according to the function's comment. I tested the change out on example pages and it worked well. [The original test cases on scroll behaviour](https://github.com/nuxt/nuxt.js/blob/dev/test/e2e/basic.browser.test.js#L144-L181) pass too.

Because of this change the documentation about `routerViewKey` should be updated (`watchQuery` no more affects the key). I'll update it and upload a pull request on docs after this pull request is reviewed.

Thanks in advance!

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. (PR: https://github.com/nuxt/docs/pull/1395)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
  + There is already tests for the behaviour: https://github.com/nuxt/nuxt.js/blob/dev/test/e2e/basic.browser.test.js#L144-L181
- [x] All new and existing tests are passing.