### PR TITLE
refactor(core): use `require.resolve` instead of `Module` internals

### DIFF
--- a/packages/core/src/resolver.js
+++ b/packages/core/src/resolver.js
@@ -1,4 +1,3 @@
-import Module from 'module'
 import { resolve, join } from 'path'
 import fs from 'fs-extra'
 import consola from 'consola'
@@ -23,7 +22,7 @@ export default class Resolver {
 
   resolveModule(path) {
     try {
-      return Module._resolveFilename(path, {
+      return require.resolve(path, {
         paths: this.options.modulesDir
       })
     } catch (error) {

--- a/packages/core/src/resolver.js
+++ b/packages/core/src/resolver.js
@@ -28,13 +28,10 @@ export default class Resolver {
         paths: this.options.modulesDir
       })
     } catch (error) {
-      if (error.code === 'MODULE_NOT_FOUND') {
-        return undefined
-      } else {
+      if (error.code !== 'MODULE_NOT_FOUND') {
         // TODO: remove after https://github.com/facebook/jest/pull/8487 released
-        if (process.env.NODE_ENV === 'test' &&
-          error.message.startsWith('Cannot resolve module')) {
-          return undefined
+        if (process.env.NODE_ENV === 'test' && error.message.startsWith('Cannot resolve module')) {
+          return
         }
         throw error
       }

--- a/packages/core/src/resolver.js
+++ b/packages/core/src/resolver.js
@@ -6,7 +6,7 @@ import esm from 'esm'
 import { startsWithRootAlias, startsWithSrcAlias } from '@nuxt/utils'
 
 export default class Resolver {
-  constructor(nuxt) {
+  constructor(nuxt, moduleResolver) {
     this.nuxt = nuxt
     this.options = this.nuxt.options
 
@@ -18,11 +18,14 @@ export default class Resolver {
 
     // ESM Loader
     this.esm = esm(module)
+
+    // module resolver
+    this.moduleResolver = moduleResolver || require.resolve
   }
 
   resolveModule(path) {
     try {
-      return require.resolve(path, {
+      return this.moduleResolver(path, {
         paths: this.options.modulesDir
       })
     } catch (error) {

--- a/packages/core/src/resolver.js
+++ b/packages/core/src/resolver.js
@@ -1,3 +1,4 @@
+import Module from 'module'
 import { resolve, join } from 'path'
 import fs from 'fs-extra'
 import consola from 'consola'
@@ -26,7 +27,7 @@ export default class Resolver {
         paths: this.options.modulesDir
       })
     } catch (error) {
-      if (error.code === 'MODULE_NOT_FOUND') {
+      if (error.code === "MODULE_NOT_FOUND" || error.message.includes('Cannot resolve module')) {
         return undefined
       } else {
         throw error

--- a/packages/core/src/resolver.js
+++ b/packages/core/src/resolver.js
@@ -1,4 +1,3 @@
-import Module from 'module'
 import { resolve, join } from 'path'
 import fs from 'fs-extra'
 import consola from 'consola'
@@ -27,7 +26,7 @@ export default class Resolver {
         paths: this.options.modulesDir
       })
     } catch (error) {
-      if (error.code === "MODULE_NOT_FOUND" || error.message.includes('Cannot resolve module')) {
+      if (error.code === 'MODULE_NOT_FOUND' || error.message.includes('Cannot resolve module')) {
         return undefined
       } else {
         throw error

--- a/packages/core/test/resolver.test.js
+++ b/packages/core/test/resolver.test.js
@@ -1,4 +1,3 @@
-import Module from 'module'
 import path from 'path'
 import esm from 'esm'
 import fs from 'fs-extra'
@@ -7,7 +6,6 @@ import { startsWithRootAlias, startsWithSrcAlias } from '@nuxt/utils'
 
 import Resolver from '../src/resolver'
 
-jest.mock('module')
 jest.mock('path')
 jest.mock('esm', () => jest.fn(() => jest.fn()))
 jest.mock('fs-extra')
@@ -33,42 +31,45 @@ describe('core: resolver', () => {
     expect(esm).toBeCalledTimes(1)
   })
 
-  test('should call _resolveFilename in resolveModule', () => {
-    const resolver = new Resolver({
-      options: { modulesDir: '/var/nuxt/node_modules' }
-    })
-    Module._resolveFilename = jest.fn(() => '/var/nuxt/resolver/module')
+  test('should call require.resolve in resolveModule', () => {
+    require.resolve = jest.fn(() => '/var/nuxt/resolver/module');
+    const resolver = new Resolver(
+      {
+        options: { modulesDir: '/var/nuxt/node_modules' }
+      },
+      require.resolve,
+    )
 
     const modulePath = resolver.resolveModule('/var/nuxt/resolver')
 
     expect(modulePath).toEqual('/var/nuxt/resolver/module')
-    expect(Module._resolveFilename).toBeCalledTimes(1)
-    expect(Module._resolveFilename).toBeCalledWith('/var/nuxt/resolver', { paths: '/var/nuxt/node_modules' })
+    expect(require.resolve).toBeCalledTimes(1)
+    expect(require.resolve).toBeCalledWith('/var/nuxt/resolver', { paths: '/var/nuxt/node_modules' })
   })
 
   test('should return undefined when module is not found', () => {
-    const resolver = new Resolver({
-      options: { modulesDir: '/var/nuxt/node_modules' }
-    })
-    Module._resolveFilename = jest.fn(() => {
+    require.resolve = jest.fn(() => {
       const err = new Error()
       err.code = 'MODULE_NOT_FOUND'
       throw err
-    })
+    });
+    const resolver = new Resolver({
+      options: { modulesDir: '/var/nuxt/node_modules' }
+    }, require.resolve)
 
     const modulePath = resolver.resolveModule('/var/nuxt/resolver')
 
     expect(modulePath).toBeUndefined()
-    expect(Module._resolveFilename).toBeCalledTimes(1)
+    expect(require.resolve).toBeCalledTimes(1)
   })
 
-  test('should throw error when _resolveFilename failed', () => {
-    const resolver = new Resolver({
-      options: { modulesDir: '/var/nuxt/node_modules' }
-    })
-    Module._resolveFilename = jest.fn(() => {
+  test('should throw error when require.resolve failed', () => {
+    require.resolve = jest.fn(() => {
       throw new Error('resolve failed')
     })
+    const resolver = new Resolver({
+      options: { modulesDir: '/var/nuxt/node_modules' }
+    }, require.resolve)
 
     expect(() => resolver.resolveModule('/var/nuxt/resolver')).toThrow('resolve failed')
   })

--- a/packages/core/test/resolver.test.js
+++ b/packages/core/test/resolver.test.js
@@ -32,44 +32,39 @@ describe('core: resolver', () => {
   })
 
   test('should call require.resolve in resolveModule', () => {
-    require.resolve = jest.fn(() => '/var/nuxt/resolver/module')
-    const resolver = new Resolver(
-      {
-        options: { modulesDir: '/var/nuxt/node_modules' }
-      },
-      require.resolve
-    )
+    const resolver = new Resolver({
+      options: { modulesDir: '/var/nuxt/node_modules' }
+    })
+    const resolve = resolver._resolve = jest.fn(() => '/var/nuxt/resolver/module')
 
     const modulePath = resolver.resolveModule('/var/nuxt/resolver')
 
     expect(modulePath).toEqual('/var/nuxt/resolver/module')
-    expect(require.resolve).toBeCalledTimes(1)
-    expect(require.resolve).toBeCalledWith('/var/nuxt/resolver', { paths: '/var/nuxt/node_modules' })
+    expect(resolve).toBeCalledTimes(1)
+    expect(resolve).toBeCalledWith('/var/nuxt/resolver', { paths: '/var/nuxt/node_modules' })
   })
 
   test('should return undefined when module is not found', () => {
-    require.resolve = jest.fn(() => {
+    const resolver = new Resolver({
+      options: { modulesDir: '/var/nuxt/node_modules' }
+    })
+    const resolve = resolver._resolve = jest.fn(() => {
       const err = new Error()
       err.code = 'MODULE_NOT_FOUND'
       throw err
     })
-    const resolver = new Resolver({
-      options: { modulesDir: '/var/nuxt/node_modules' }
-    }, require.resolve)
 
     const modulePath = resolver.resolveModule('/var/nuxt/resolver')
 
     expect(modulePath).toBeUndefined()
-    expect(require.resolve).toBeCalledTimes(1)
+    expect(resolve).toBeCalledTimes(1)
   })
 
   test('should throw error when require.resolve failed', () => {
-    require.resolve = jest.fn(() => {
-      throw new Error('resolve failed')
-    })
     const resolver = new Resolver({
       options: { modulesDir: '/var/nuxt/node_modules' }
-    }, require.resolve)
+    })
+    resolver._resolve = jest.fn(() => { throw new Error('resolve failed') })
 
     expect(() => resolver.resolveModule('/var/nuxt/resolver')).toThrow('resolve failed')
   })

--- a/packages/core/test/resolver.test.js
+++ b/packages/core/test/resolver.test.js
@@ -32,12 +32,12 @@ describe('core: resolver', () => {
   })
 
   test('should call require.resolve in resolveModule', () => {
-    require.resolve = jest.fn(() => '/var/nuxt/resolver/module');
+    require.resolve = jest.fn(() => '/var/nuxt/resolver/module')
     const resolver = new Resolver(
       {
         options: { modulesDir: '/var/nuxt/node_modules' }
       },
-      require.resolve,
+      require.resolve
     )
 
     const modulePath = resolver.resolveModule('/var/nuxt/resolver')
@@ -52,7 +52,7 @@ describe('core: resolver', () => {
       const err = new Error()
       err.code = 'MODULE_NOT_FOUND'
       throw err
-    });
+    })
     const resolver = new Resolver({
       options: { modulesDir: '/var/nuxt/node_modules' }
     }, require.resolve)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Is there any reason to not use require.resolve but rather a private module function? We use [Bazel](https://bazel.build/) as our build tool to call nuxt and it implements a custom module resolution. Using this private method currently does not work, but using `require.resolve` does. Would be great to get this in if there is no specific reason to use this private method.


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

