### PR TITLE
fix(vue-renderer): add vary header for user-agent in modern server mode

### DIFF
--- a/packages/vue-renderer/src/renderers/modern.js
+++ b/packages/vue-renderer/src/renderers/modern.js
@@ -109,4 +109,12 @@ export default class ModernRenderer extends SSRRenderer {
       return linkTag.replace('rel="preload"', `rel="modulepreload"${cors}`).replace(legacyJsFile, modernJsFile)
     })
   }
+
+  async render(renderContext) {
+    const result = await super.render(renderContext)
+    if (this.isServerMode) {
+      renderContext.res.setHeader('Vary', 'User-Agent')
+    }
+    return result
+  }
 }

--- a/test/unit/modern.server.test.js
+++ b/test/unit/modern.server.test.js
@@ -68,6 +68,14 @@ describe('modern server mode', () => {
     ].join(', '))
   })
 
+  test('Vary header should contain User-Agent', async () => {
+    const { headers: { vary } } = await rp(url('/'), {
+      resolveWithFullResponse: true,
+      headers: { 'user-agent': modernUA }
+    })
+    expect(vary).toContain('User-Agent')
+  })
+
   // Close server and ask nuxt to stop listening to file changes
   afterAll(async () => {
     await nuxt.close()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description

When running in modern server mode, our response varies depending on user-agent. A reverse-proxy may wrongly cache the modern/legacy response and use it for others. This PR tries to prevent that.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

