### PR TITLE
fix(builder): only listen for file changes for supported extensions

### DIFF
--- a/packages/builder/test/builder.generate.test.js
+++ b/packages/builder/test/builder.generate.test.js
@@ -76,7 +76,7 @@ describe('builder: builder generate', () => {
     ])
     expect(builder.resolveCustomTemplates).toBeCalledTimes(1)
     expect(builder.resolveLoadingIndicator).toBeCalledTimes(1)
-    expect(builder.options.build.watch).toEqual(['/var/nuxt/src/template'])
+    expect(builder.options.build.watch).toEqual(['/var/nuxt/src/template/**/*.{vue,js,ts,tsx}'])
     expect(builder.compileTemplates).toBeCalledTimes(1)
     expect(consola.success).toBeCalledTimes(1)
     expect(consola.success).toBeCalledWith('Nuxt files generated')

--- a/packages/builder/test/builder.watch.test.js
+++ b/packages/builder/test/builder.watch.test.js
@@ -42,25 +42,24 @@ describe('builder: builder watch', () => {
 
     const patterns = [
       '/var/nuxt/src/layouts',
-      '/var/nuxt/src/middleware',
-      '/var/nuxt/src/layouts/*.{vue,js,ts,tsx}',
-      '/var/nuxt/src/layouts/**/*.{vue,js,ts,tsx}'
+      '/var/nuxt/src/middleware'
     ]
 
-    expect(r).toBeCalledTimes(4)
-    expect(r).nthCalledWith(1, '/var/nuxt/src', '/var/nuxt/src/layouts')
-    expect(r).nthCalledWith(2, '/var/nuxt/src', '/var/nuxt/src/middleware')
-    expect(r).nthCalledWith(3, '/var/nuxt/src', '/var/nuxt/src/layouts/*.{vue,js,ts,tsx}')
-    expect(r).nthCalledWith(4, '/var/nuxt/src', '/var/nuxt/src/layouts/**/*.{vue,js,ts,tsx}')
+    const globbedPatterns = [
+      '/var/nuxt/src/layouts/**/*.{vue,js,ts,tsx}',
+      '/var/nuxt/src/middleware/**/*.{vue,js,ts,tsx}'
+    ]
 
-    expect(upath.normalizeSafe).toBeCalledTimes(4)
-    expect(upath.normalizeSafe).nthCalledWith(1, '/var/nuxt/src/layouts', 0, patterns)
-    expect(upath.normalizeSafe).nthCalledWith(2, '/var/nuxt/src/middleware', 1, patterns)
-    expect(upath.normalizeSafe).nthCalledWith(3, '/var/nuxt/src/layouts/*.{vue,js,ts,tsx}', 2, patterns)
-    expect(upath.normalizeSafe).nthCalledWith(4, '/var/nuxt/src/layouts/**/*.{vue,js,ts,tsx}', 3, patterns)
+    expect(r).toBeCalledTimes(2)
+    expect(r).nthCalledWith(1, '/var/nuxt/src', patterns[0])
+    expect(r).nthCalledWith(2, '/var/nuxt/src', patterns[1])
+
+    expect(upath.normalizeSafe).toBeCalledTimes(2)
+    expect(upath.normalizeSafe).nthCalledWith(1, globbedPatterns[0], 0, patterns)
+    expect(upath.normalizeSafe).nthCalledWith(2, globbedPatterns[1], 1, patterns)
 
     expect(builder.createFileWatcher).toBeCalledTimes(1)
-    expect(builder.createFileWatcher).toBeCalledWith(patterns, ['add', 'unlink'], expect.any(Function), expect.any(Function))
+    expect(builder.createFileWatcher).toBeCalledWith(globbedPatterns, ['add', 'unlink'], expect.any(Function), expect.any(Function))
     expect(builder.assignWatcher).toBeCalledTimes(1)
   })
 
@@ -83,8 +82,8 @@ describe('builder: builder watch', () => {
 
     builder.watchClient()
 
-    expect(r).toBeCalledTimes(5)
-    expect(r).nthCalledWith(5, '/var/nuxt/src', '/var/nuxt/src/store')
+    expect(r).toBeCalledTimes(3)
+    expect(r).nthCalledWith(3, '/var/nuxt/src', '/var/nuxt/src/store')
   })
 
   test('should NOT watch pages files on client if _defaultPage=true', () => {
@@ -108,7 +107,7 @@ describe('builder: builder watch', () => {
 
     builder.watchClient()
 
-    expect(r).toBeCalledTimes(4)
+    expect(r).toBeCalledTimes(2)
   })
   test('should watch pages files', () => {
     const nuxt = createNuxt()
@@ -130,10 +129,11 @@ describe('builder: builder watch', () => {
 
     builder.watchClient()
 
-    expect(r).toBeCalledTimes(7)
-    expect(r).nthCalledWith(5, '/var/nuxt/src', '/var/nuxt/src/pages')
-    expect(r).nthCalledWith(6, '/var/nuxt/src', '/var/nuxt/src/pages/*.{vue,js,ts,tsx}')
-    expect(r).nthCalledWith(7, '/var/nuxt/src', '/var/nuxt/src/pages/**/*.{vue,js,ts,tsx}')
+    expect(r).toBeCalledTimes(3)
+    expect(r).nthCalledWith(3, '/var/nuxt/src', '/var/nuxt/src/pages')
+
+    expect(upath.normalizeSafe).toBeCalledTimes(3)
+    expect(upath.normalizeSafe).nthCalledWith(3, '/var/nuxt/src/pages/**/*.{vue,js,ts,tsx}', 2, expect.any(Array))
   })
 
   test('should invoke generateRoutesAndFiles on file refresh', () => {

--- a/packages/config/src/config/_common.js
+++ b/packages/config/src/config/_common.js
@@ -66,7 +66,7 @@ export default () => ({
   // Watch
   watch: [],
   watchers: {
-    rewatchOnRawEvents: env.linux ? ['rename'] : undefined,
+    rewatchOnRawEvents: undefined,
     webpack: {},
     chokidar: {
       ignoreInitial: true

--- a/packages/config/test/__snapshots__/options.test.js.snap
+++ b/packages/config/test/__snapshots__/options.test.js.snap
@@ -363,9 +363,7 @@ Object {
     "chokidar": Object {
       "ignoreInitial": true,
     },
-    "rewatchOnRawEvents": Array [
-      "rename",
-    ],
+    "rewatchOnRawEvents": undefined,
     "webpack": Object {},
   },
 }

--- a/packages/config/test/config/__snapshots__/index.test.js.snap
+++ b/packages/config/test/config/__snapshots__/index.test.js.snap
@@ -327,9 +327,7 @@ Object {
     "chokidar": Object {
       "ignoreInitial": true,
     },
-    "rewatchOnRawEvents": Array [
-      "rename",
-    ],
+    "rewatchOnRawEvents": undefined,
     "webpack": Object {},
   },
 }
@@ -662,9 +660,7 @@ Object {
     "chokidar": Object {
       "ignoreInitial": true,
     },
-    "rewatchOnRawEvents": Array [
-      "rename",
-    ],
+    "rewatchOnRawEvents": undefined,
     "webpack": Object {},
   },
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

- the patterns used for listening to file changes contained some duplicates, removed those
- the workaround for recreating the watcher on raw events on linux is not needed anymore due to fixed in chokidar (left the code in for now, it just isnt used by default anymore as the config is empty)
- made all patterns less greedy by always only listening for supported file extensions

Eg listening on a directory without the supported file extensions could be prone to unnecessary reloads due to file changes which are not used by Nuxt. Eg `*.swp`, `*~` or `*.bak` files used by editors

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

