### PR TITLE
feat: Detect custom srcDir when initial TypeScript mode and Add root aliases

### DIFF
--- a/packages/cli/src/command.js
+++ b/packages/cli/src/command.js
@@ -97,12 +97,14 @@ export default class NuxtCommand {
     // Flag to indicate nuxt is running with CLI (not programmatic)
     extraOptions._cli = true
 
+    const config = await loadNuxtConfig(this.argv)
+
     // Typescript support
     extraOptions._typescript = await detectTypeScript(rootDir, {
-      transpileOnly: this.cmd.name === 'start'
+      transpileOnly: this.cmd.name === 'start',
+      srcDir: config ? config.srcDir || null : null
     })
 
-    const config = await loadNuxtConfig(this.argv)
     const options = Object.assign(config, extraOptions)
 
     for (const name of Object.keys(this.cmd.options)) {

--- a/packages/cli/src/utils/typescript.js
+++ b/packages/cli/src/utils/typescript.js
@@ -61,7 +61,7 @@ export async function detectTypeScript(rootDir, options = {}) {
   // If exists do additional setup
   if (nuxtTypeScript) {
     typescript.build = true
-    await nuxtTypeScript.setupDefaults(typescript.tsConfigPath)
+    await nuxtTypeScript.setupDefaults({ tsConfigPath: typescript.tsConfigPath, srcDir: options.srcDir })
   }
 
   return typescript

--- a/packages/typescript/src/index.js
+++ b/packages/typescript/src/index.js
@@ -1,6 +1,24 @@
 import { exists, readFile, writeJSON } from 'fs-extra'
 import consola from 'consola'
 
+function createPaths(srcDir) {
+  const path = srcDir ? `${srcDir}/` : ''
+  return {
+    [`~/${path}*`]: [
+      `./${path}*`
+    ],
+    [`@/${path}*`]: [
+      `./${path}*`
+    ],
+    [`~~/${path}*`]: [
+      './*'
+    ],
+    [`@@/${path}*`]: [
+      './*'
+    ]
+  }
+}
+
 export const defaultTsJsonConfig = {
   compilerOptions: {
     target: 'esnext',
@@ -19,14 +37,7 @@ export const defaultTsJsonConfig = {
     noImplicitAny: false,
     noEmit: true,
     baseUrl: '.',
-    paths: {
-      '~/*': [
-        './*'
-      ],
-      '@/*': [
-        './*'
-      ]
-    },
+    paths: createPaths(null),
     types: [
       '@types/node',
       '@nuxt/vue-app'
@@ -34,7 +45,7 @@ export const defaultTsJsonConfig = {
   }
 }
 
-export async function setupDefaults(tsConfigPath) {
+export async function setupDefaults({ tsConfigPath, srcDir }) {
   let contents = ''
 
   if (await exists(tsConfigPath)) {
@@ -43,6 +54,15 @@ export async function setupDefaults(tsConfigPath) {
 
   if (!contents || contents === '{}') {
     consola.info(`Generating ${tsConfigPath.replace(process.cwd(), '')}`)
-    await writeJSON(tsConfigPath, defaultTsJsonConfig, { spaces: 2 })
+    await writeJSON(
+      tsConfigPath,
+      {
+        ...defaultTsJsonConfig,
+        ...{
+          paths: createPaths(srcDir)
+        }
+      },
+      { spaces: 2 }
+    )
   }
 }

--- a/packages/typescript/src/index.js
+++ b/packages/typescript/src/index.js
@@ -58,8 +58,11 @@ export async function setupDefaults({ tsConfigPath, srcDir }) {
       tsConfigPath,
       {
         ...defaultTsJsonConfig,
-        ...{
-          paths: createPaths(srcDir)
+        compilerOptions: {
+          ...defaultTsJsonConfig.compilerOptions,
+          ...{
+            paths: createPaths(srcDir)
+          }
         }
       },
       { spaces: 2 }

--- a/packages/typescript/test/setup.test.js
+++ b/packages/typescript/test/setup.test.js
@@ -12,7 +12,7 @@ describe('typescript setup', () => {
   })
 
   test('Create tsconfig.json with defaults', async () => {
-    await setupDefaults(tsConfigPath)
+    await setupDefaults({ tsConfigPath })
     expect(await readJSON(tsConfigPath)).toEqual(defaultTsJsonConfig)
   })
 
@@ -20,7 +20,7 @@ describe('typescript setup', () => {
     const fooJSON = '{ "foo": 123 }'
     await writeFile(tsConfigPath, fooJSON, 'utf-8')
 
-    await setupDefaults(tsConfigPath)
+    await setupDefaults({ tsConfigPath })
 
     expect(await readFile(tsConfigPath, 'utf-8')).toEqual(fooJSON)
   })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
It appears that tsconfig's autogeneration logic doesn't support `~~/`, `@@/`, or customized `srcDir`.
This PR adds their support.
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

