### PR TITLE
fix(config): fix `extendRoutes` method type

### DIFF
--- a/packages/config/types/router.d.ts
+++ b/packages/config/types/router.d.ts
@@ -12,7 +12,7 @@ type Component = ComponentOptions<Vue> | typeof Vue | AsyncComponent;
 
 export interface NuxtRouteConfig extends RouteConfig {
   chunkNames: { [key: string]: string }
-  component: Component | string,
+  component: RouteConfig['component'] | string
   children?: NuxtRouteConfig[]
 }
 

--- a/packages/config/types/router.d.ts
+++ b/packages/config/types/router.d.ts
@@ -10,7 +10,7 @@ import { RouterOptions, RouteConfig } from 'vue-router'
 export interface NuxtRouteConfig extends RouteConfig {
   chunkNames: { [key: string]: string },
   component: string,
-  children?: NuxtRouteConfig[],
+  children?: NuxtRouteConfig[]
 }
 
 export interface NuxtConfigurationRouter extends RouterOptions {

--- a/packages/config/types/router.d.ts
+++ b/packages/config/types/router.d.ts
@@ -9,7 +9,7 @@ import { RouterOptions, RouteConfig } from 'vue-router'
 
 export interface NuxtRouteConfig extends RouteConfig {
   chunkNames: { [key: string]: string }
-  component: RouteConfig['component'] | string
+  component?: RouteConfig['component'] | string
   children?: NuxtRouteConfig[]
 }
 

--- a/packages/config/types/router.d.ts
+++ b/packages/config/types/router.d.ts
@@ -6,10 +6,13 @@
  */
 
 import { RouterOptions, RouteConfig } from 'vue-router'
+import Vue, { ComponentOptions, AsyncComponent } from 'vue'
+
+type Component = ComponentOptions<Vue> | typeof Vue | AsyncComponent;
 
 export interface NuxtRouteConfig extends RouteConfig {
   chunkNames: { [key: string]: string },
-  component: string,
+  component: Component | string,
   children?: NuxtRouteConfig[]
 }
 

--- a/packages/config/types/router.d.ts
+++ b/packages/config/types/router.d.ts
@@ -6,9 +6,6 @@
  */
 
 import { RouterOptions, RouteConfig } from 'vue-router'
-import Vue, { ComponentOptions, AsyncComponent } from 'vue'
-
-type Component = ComponentOptions<Vue> | typeof Vue | AsyncComponent;
 
 export interface NuxtRouteConfig extends RouteConfig {
   chunkNames: { [key: string]: string }

--- a/packages/config/types/router.d.ts
+++ b/packages/config/types/router.d.ts
@@ -10,6 +10,7 @@ import { RouterOptions, RouteConfig } from 'vue-router'
 export interface NuxtRouteConfig extends RouteConfig {
   chunkNames: { [key: string]: string },
   component: string,
+  children?: NuxtRouteConfig[],
 }
 
 export interface NuxtConfigurationRouter extends RouterOptions {

--- a/packages/config/types/router.d.ts
+++ b/packages/config/types/router.d.ts
@@ -8,7 +8,8 @@
 import { RouterOptions, RouteConfig } from 'vue-router'
 
 export interface NuxtRouteConfig extends RouteConfig {
-  chunkNames: { [key: string]: string }
+  chunkNames: { [key: string]: string },
+  component: string,
 }
 
 export interface NuxtConfigurationRouter extends RouterOptions {

--- a/packages/config/types/router.d.ts
+++ b/packages/config/types/router.d.ts
@@ -11,7 +11,7 @@ import Vue, { ComponentOptions, AsyncComponent } from 'vue'
 type Component = ComponentOptions<Vue> | typeof Vue | AsyncComponent;
 
 export interface NuxtRouteConfig extends RouteConfig {
-  chunkNames: { [key: string]: string },
+  chunkNames: { [key: string]: string }
   component: Component | string,
   children?: NuxtRouteConfig[]
 }


### PR DESCRIPTION
Add ts declaration missing `component` and `children` fields for Route in `route.extendRoutes` method.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Fix typescript declaration

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

