### PR TITLE
feat(vue-app): allow customizing build indicator

### DIFF
--- a/packages/config/src/config/build.js
+++ b/packages/config/src/config/build.js
@@ -3,7 +3,11 @@ import env from 'std-env'
 export default () => ({
   quiet: Boolean(env.ci || env.test),
   analyze: false,
-  indicator: true,
+  indicator: {
+    position: 'bottom-right',
+    backgroundColor: '#2E495E',
+    color: '#00C48D'
+  },
   profile: process.argv.includes('--profile'),
   extractCSS: false,
   crossorigin: undefined,

--- a/packages/config/test/__snapshots__/options.test.js.snap
+++ b/packages/config/test/__snapshots__/options.test.js.snap
@@ -54,7 +54,11 @@ Object {
         "useShortDoctype": true,
       },
     },
-    "indicator": true,
+    "indicator": Object {
+      "backgroundColor": "#2E495E",
+      "color": "#00C48D",
+      "position": "bottom-right",
+    },
     "loaders": Object {
       "css": Object {
         "sourceMap": false,

--- a/packages/config/test/config/__snapshots__/index.test.js.snap
+++ b/packages/config/test/config/__snapshots__/index.test.js.snap
@@ -41,7 +41,11 @@ Object {
         "useShortDoctype": true,
       },
     },
-    "indicator": true,
+    "indicator": Object {
+      "backgroundColor": "#2E495E",
+      "color": "#00C48D",
+      "position": "bottom-right",
+    },
     "loaders": Object {
       "css": Object {},
       "cssModules": Object {
@@ -375,7 +379,11 @@ Object {
         "useShortDoctype": true,
       },
     },
-    "indicator": true,
+    "indicator": Object {
+      "backgroundColor": "#2E495E",
+      "color": "#00C48D",
+      "position": "bottom-right",
+    },
     "loaders": Object {
       "css": Object {},
       "cssModules": Object {

--- a/packages/vue-app/template/components/nuxt-build-indicator.vue
+++ b/packages/vue-app/template/components/nuxt-build-indicator.vue
@@ -1,6 +1,6 @@
 <template>
   <transition appear>
-    <div class="nuxt__build_indicator" v-if="building">
+    <div class="nuxt__build_indicator" :style="indicatorStyle" v-if="building">
       <svg viewBox="0 0 96 72" version="1" xmlns="http://www.w3.org/2000/svg">
         <g fill="none" fill-rule="evenodd">
           <path d="M6 66h23l1-3 21-37L40 6 6 66zM79 66h11L62 17l-5 9 22 37v3zM54 31L35 66h38z"/>
@@ -40,6 +40,16 @@ export default {
       const _path = '<%= router.base %>_loading/ws'
       const _protocol = location.protocol === 'https:' ? 'wss' : 'ws'
       return `${_protocol}://${location.hostname}:${location.port}${_path}`
+    },
+    options: () => (<%= JSON.stringify(buildIndicator) %>),
+    indicatorStyle() {
+      const [ d1, d2 ] = this.options.position.split('-')
+      return {
+        [d1]: '20px',
+        [d2]: '20px',
+        'background-color': this.options.backgroundColor,
+        color: this.options.color,
+      }
     }
   },
   watch: {
@@ -128,13 +138,9 @@ export default {
   box-sizing: border-box;
   position: absolute;
   font-family: monospace;
-  bottom: 20px;
-  right: 20px;
-  background-color: #2E495E;
   padding: 5px 10px;
   border-radius: 5px;
   box-shadow: 1px 1px 2px 0px rgba(0,0,0,0.2);
-  color: #00C48D;
   width: 84px;
   z-index: 2147483647;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
```js
export default {
  build: {
    indicator: {
      position: 'top-right',
      backgroundColor: 'black',
      color: 'white'
    }
  }
}
```
![image](https://user-images.githubusercontent.com/5158436/58711125-11b62a80-83d3-11e9-8dea-9f238887553c.png)


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

