### PR TITLE
fix(vue-app): fix exception on property access of undefined object

### DIFF
--- a/packages/vue-app/template/components/nuxt.js
+++ b/packages/vue-app/template/components/nuxt.js
@@ -42,7 +42,12 @@ export default {
       }
 
       const [matchedRoute] = this.$route.matched
-      const Component = matchedRoute && matchedRoute.components.default
+
+      if (!matchedRoute) {
+        return this.$route.path
+      }
+
+      const Component = matchedRoute.components.default
 
       if (Component && Component.options) {
         const { options } = Component


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
After PR #5746, which has added code to remove trailing slash
in non-strict mode, I've gotten exception reported through Sentry due to
trying to get proper 'path' of undefined 'matchedRoute' object.

I don't know how it happens but it's clear error as code above checks
for null `matchedRoute` but not the code that checks for trailing slash.

Made the logic so that non-replaced path is returned when no route
matches. Same as before original fix.

Follow-up fix to #5593

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

