### PR TITLE
fix(vue-app): fix position of the build indicator when page scrolled

### DIFF
--- a/packages/vue-app/template/components/nuxt-build-indicator.vue
+++ b/packages/vue-app/template/components/nuxt-build-indicator.vue
@@ -136,7 +136,7 @@ export default {
 <style scoped>
 .nuxt__build_indicator {
   box-sizing: border-box;
-  position: absolute;
+  position: fixed;
   font-family: monospace;
   padding: 5px 10px;
   border-radius: 5px;


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
When page was scrolled, build indicator would scroll up with the page or end up completely outside of viewport. Use position: fixed to make it stick to the corner.

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

