### PR TITLE
fix(vue-app): always finish transition.leave asynchronously

### DIFF
--- a/packages/vue-app/template/components/nuxt-child.js
+++ b/packages/vue-app/template/components/nuxt-child.js
@@ -60,7 +60,8 @@ export default {
         if (leave) {
           leave.call(_parent, el)
         }
-        return _parent.$nextTick(done)
+
+        _parent.$nextTick(done)
       }
     }
 

--- a/packages/vue-app/template/components/nuxt-child.js
+++ b/packages/vue-app/template/components/nuxt-child.js
@@ -51,18 +51,25 @@ export default {
       if (beforeEnter) return beforeEnter.call(_parent, el)
     }
 
-    let routerView = [
-      h('router-view', data)
-    ]
-    if (props.keepAlive) {
-      routerView = [
-        h('keep-alive', { props: props.keepAliveProps }, routerView)
-      ]
+    // make sure that leave is called asynchronous (fix #5703)
+    if (transition.css === false) {
+      const leave = listeners.leave
+      listeners.leave = (el, done) => {
+        if (leave) leave.call(_parent, el)
+        return _parent.$nextTick(done)
+      }
     }
+
+    let routerView = h('routerView', data)
+
+    if (props.keepAlive) {
+      routerView = h('keep-alive', { props: props.keepAliveProps }, [routerView])
+    }
+
     return h('transition', {
       props: transitionProps,
       on: listeners
-    }, routerView)
+    }, [routerView])
   }
 }
 

--- a/packages/vue-app/template/components/nuxt-child.js
+++ b/packages/vue-app/template/components/nuxt-child.js
@@ -48,14 +48,18 @@ export default {
       window.<%= globals.nuxt %>.$nextTick(() => {
         window.<%= globals.nuxt %>.$emit('triggerScroll')
       })
-      if (beforeEnter) return beforeEnter.call(_parent, el)
+      if (beforeEnter) {
+        return beforeEnter.call(_parent, el)
+      }
     }
 
     // make sure that leave is called asynchronous (fix #5703)
     if (transition.css === false) {
       const leave = listeners.leave
       listeners.leave = (el, done) => {
-        if (leave) leave.call(_parent, el)
+        if (leave) {
+          leave.call(_parent, el)
+        }
         return _parent.$nextTick(done)
       }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
Fix: #5703

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

When `transition.css = false` and no leave listener with a callback/done argument is provided, the leave transition callback is called [synchronously](https://github.com/vuejs/vue/blob/4de4649d9637262a9b007720b59f80ac72a5620c/src/platforms/web/runtime/modules/transition.js#L277).

This causes a problem when switching layouts in Nuxt. Eg given page A with layout A and page B with layout B the following roughly happens (thus with `transition.css = false`):
1. when page A is loaded the component tree is: Layout A -> Nuxt -> NuxtChild -> Transition -> RouterView -> Page A
2. next user clicks link to page B
3. Client app loads page component B and determines it needs layout B
4. layout B is preloaded (App.loadLayout)
5. router.next() is called
6. leave transition for Page A is called
7. leave transition immediately finishes (synchronously)
8. Page B is loaded within Layout A
9. router.afterEach calls Client.fixPrepatch
10. Client.showNextPage is called
11. Layout B is loaded (App.setLayout)
12. Page B is loaded

By calling the leave callback in step 6/7 asynchronous (as would happen when eg transition.css is not false), all subsequent steps are called before the leave callback is called which means that Layout B will already be loaded and Page B is never loaded in Layout A.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

