### PR TITLE
fix(webpack): extract css breaks hmr and source-maps

### DIFF
--- a/packages/webpack/src/utils/style-loader.js
+++ b/packages/webpack/src/utils/style-loader.js
@@ -88,7 +88,9 @@ export default class StyleLoader {
         loader: ExtractCssChunksPlugin.loader,
         options: {
           // TODO: https://github.com/faceyspacey/extract-css-chunks-webpack-plugin/issues/132
-          reloadAll: true
+          // https://github.com/faceyspacey/extract-css-chunks-webpack-plugin/issues/161#issuecomment-500162574
+          reloadAll: true,
+          hot: true
         }
       }
     }


### PR DESCRIPTION
Resolves #5386 #5390 

## Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)

## Description

Related: https://github.com/faceyspacey/extract-css-chunks-webpack-plugin/issues/161

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

