### PR TITLE
feat(types): add nuxt error type

### DIFF
--- a/packages/vue-app/types/index.d.ts
+++ b/packages/vue-app/types/index.d.ts
@@ -70,8 +70,8 @@ export interface Transition {
 
 export interface NuxtError {
   message?: string
-  statusCode?: number
   path?: string
+  statusCode?: number
 }
 
 export interface NuxtLoading extends Vue {

--- a/packages/vue-app/types/index.d.ts
+++ b/packages/vue-app/types/index.d.ts
@@ -73,6 +73,12 @@ export interface ErrorParams {
   message?: string
 }
 
+export interface NuxtError {
+  message?: string
+  statusCode?: string
+  path?: string
+}
+
 export interface NuxtLoading extends Vue {
   fail?(): NuxtLoading
   finish(): NuxtLoading

--- a/packages/vue-app/types/index.d.ts
+++ b/packages/vue-app/types/index.d.ts
@@ -39,7 +39,7 @@ export interface Context {
   res: ServerResponse
   redirect(status: number, path: string, query?: Route['query']): void
   redirect(path: string, query?: Route['query']): void
-  error(params: ErrorParams): void
+  error(params: NuxtError): void
   nuxtState: NuxtState
   beforeNuxtRender(fn: (params: { Components: VueRouter['getMatchedComponents'], nuxtState: NuxtState }) => void): void
 }
@@ -68,14 +68,9 @@ export interface Transition {
   leaveCancelled?(el: HTMLElement): void
 }
 
-export interface ErrorParams {
-  statusCode?: number
-  message?: string
-}
-
 export interface NuxtError {
   message?: string
-  statusCode?: string
+  statusCode?: number
   path?: string
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
This add type for Nuxt error with interface `NuxtError`.
With that on error layout we can now use :
```ts
import { Component, Vue, Prop } from 'nuxt-property-decorator'
import { NuxtError } from '@nuxt/vue-app'

@Component({})
export default class ErrorPage extends Vue {
  @Prop({ required: true }) readonly error!: NuxtError;
}
```

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

