### PR TITLE
fix(vue-renderer): clone spa meta to prevent cache modification

### DIFF
--- a/packages/vue-renderer/src/renderers/spa.js
+++ b/packages/vue-renderer/src/renderers/spa.js
@@ -1,4 +1,5 @@
 import { extname } from 'path'
+import cloneDeep from 'lodash/cloneDeep'
 import Vue from 'vue'
 import VueMeta from 'vue-meta'
 import { createRenderer } from 'vue-server-renderer'
@@ -43,7 +44,9 @@ export default class SPARenderer extends BaseRenderer {
     let meta = this.cache.get(cacheKey)
 
     if (meta) {
-      return meta
+      // Return a copy of the content, so that future
+      // modifications do not effect the data in cache
+      return cloneDeep(meta)
     }
 
     meta = {
@@ -149,7 +152,9 @@ export default class SPARenderer extends BaseRenderer {
     // Set meta tags inside cache
     this.cache.set(cacheKey, content)
 
-    return content
+    // Return a copy of the content, so that future
+    // modifications do not effect the data in cache
+    return cloneDeep(content)
   }
 
   static normalizeFile(file) {

--- a/test/fixtures/spa/nuxt.config.js
+++ b/test/fixtures/spa/nuxt.config.js
@@ -1,3 +1,10 @@
+function modifyHtml(html) {
+  return html.replace(
+    '</body>',
+    `<!-- extra html from render:route hook added at ${Date.now()}--></body>`
+  )
+}
+
 export default {
   mode: 'spa',
   pageTransition: false,
@@ -18,7 +25,10 @@ export default {
   router: {
     middleware: 'middleware'
   },
-  plugins: [
-    '~/plugins/error.js'
-  ]
+  plugins: ['~/plugins/error.js'],
+  hooks: {
+    'render:route': (url, page, { req, res }) => {
+      page.html = modifyHtml(page.html)
+    }
+  }
 }

--- a/test/unit/spa.test.js
+++ b/test/unit/spa.test.js
@@ -138,6 +138,22 @@ describe('spa', () => {
     consola.log.mockClear()
   })
 
+  test('render:route hook does not corrupt the cache', async () => {
+    const window1 = await nuxt.server.renderAndGetWindow(url('/'))
+    const html1 = window1.document.body.innerHTML
+    expect(html1).toContain('extra html from render:route hook')
+    expect(html1.match(/render:route/g).length).toBe(1)
+
+    window1.close()
+
+    const window2 = await nuxt.server.renderAndGetWindow(url('/'))
+    const html2 = window2.document.body.innerHTML
+    expect(html2).toContain('extra html from render:route hook')
+    expect(html2.match(/render:route/g).length).toBe(1)
+
+    window2.close()
+  })
+
   // Close server and ask nuxt to stop listening to file changes
   afterAll(async () => {
     await nuxt.close()


### PR DESCRIPTION
This ensures that post-processing of the result object does not cause cache corruption.

When transforming the response in SPA mode via `render:route` hook, setting `result.html` changes the data in cache, which is not ideal. 

Fixes https://github.com/nuxt/nuxt.js/issues/5962

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

