### PR TITLE
feat(vue-renderer): add csp option for csp v1 compatibility

### DIFF
--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -220,6 +220,7 @@ export function getNuxtConfig(_options) {
       allowedSources: undefined,
       policies: undefined,
       addMeta: Boolean(options._generate),
+      unsafeInlineCompatiblity: false,
       reportOnly: options.debug
     })
   }

--- a/packages/config/test/options.test.js
+++ b/packages/config/test/options.test.js
@@ -92,6 +92,7 @@ describe('config: options', () => {
     expect(csp).toEqual({
       hashAlgorithm: 'sha256',
       addMeta: false,
+      unsafeInlineCompatiblity: false,
       allowedSources: true,
       policies: undefined,
       reportOnly: false,

--- a/packages/vue-renderer/src/renderers/ssr.js
+++ b/packages/vue-renderer/src/renderers/ssr.js
@@ -121,7 +121,7 @@ export default class SSRRenderer extends BaseRenderer {
     if (csp) {
       // Only add the hash if 'unsafe-inline' rule isn't present to avoid conflicts (#5387)
       const containsUnsafeInlineScriptSrc = csp.policies && csp.policies['script-src'] && csp.policies['script-src'].includes(`'unsafe-inline'`)
-      if (!containsUnsafeInlineScriptSrc) {
+      if (csp.unsafeInlineCompatiblity || !containsUnsafeInlineScriptSrc) {
         const hash = crypto.createHash(csp.hashAlgorithm)
         hash.update(serializedSession)
         cspScriptSrcHashes.push(`'${csp.hashAlgorithm}-${hash.digest('base64')}'`)

--- a/test/unit/basic.ssr.csp.test.js
+++ b/test/unit/basic.ssr.csp.test.js
@@ -196,7 +196,34 @@ describe('basic ssr csp', () => {
         expect(headers[cspHeader]).toMatch(/script-src 'self' 'unsafe-inline'$/)
       }
     )
+
+    test(
+      'Contain hash and \'unsafe-inline\' when unsafeInlineCompatiblity is enabled',
+      async () => {
+        const policies = {
+          'script-src': [`'unsafe-inline'`]
+        }
+
+        nuxt = await startCspServer({
+          unsafeInlineCompatiblity: true,
+          policies
+        })
+
+        for (let i = 0; i < 5; i++) {
+          await rp(url('/stateless'), {
+            resolveWithFullResponse: true
+          })
+        }
+
+        const { headers } = await rp(url('/stateful'), {
+          resolveWithFullResponse: true
+        })
+
+        expect(headers[cspHeader]).toMatch(/script-src 'sha256-.*' 'self' 'unsafe-inline'$/)
+      }
+    )
   })
+
   describe('debug mode', () => {
     test(
       'Not contain Content-Security-Policy-Report-Only header, when csp is false',
@@ -388,6 +415,32 @@ describe('basic ssr csp', () => {
         })
 
         expect(headers[reportOnlyHeader]).toMatch(/script-src 'self' 'unsafe-inline'$/)
+      }
+    )
+
+    test(
+      'Contain hash and \'unsafe-inline\' when unsafeInlineCompatiblity is enabled',
+      async () => {
+        const policies = {
+          'script-src': [`'unsafe-inline'`]
+        }
+
+        nuxt = await startCspServer({
+          unsafeInlineCompatiblity: true,
+          policies
+        })
+
+        for (let i = 0; i < 5; i++) {
+          await rp(url('/stateless'), {
+            resolveWithFullResponse: true
+          })
+        }
+
+        const { headers } = await rp(url('/stateful'), {
+          resolveWithFullResponse: true
+        })
+
+        expect(headers[cspHeader]).toMatch(/script-src 'sha256-.*' 'self' 'unsafe-inline'$/)
       }
     )
   })


### PR DESCRIPTION
Fixes CSP compatibility mentioned in https://github.com/nuxt/nuxt.js/issues/5627

## Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Add a csp option `unsafeInlineCompatiblity` which allows `'unsafe-inline'` and hash based rules to appear together.
Not sure if the option name can be shorter.
Resolves: #5627 

## Checklist:
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

