### PR TITLE
fix error when use alias for nuxt-edge

### DIFF
--- a/packages/cli/src/run.js
+++ b/packages/cli/src/run.js
@@ -1,20 +1,25 @@
 import fs from 'fs'
-import path from 'path'
 import execa from 'execa'
 import { name as pkgName } from '../package.json'
 import NuxtCommand from './command'
 import setup from './setup'
 import getCommand from './commands'
 
-function checkDuplicateNuxt() {
-  const dupPkg = pkgName === '@nuxt/cli-edge' ? 'cli' : 'cli-edge'
-  if (fs.existsSync(path.resolve(__dirname, '..', '..', dupPkg))) {
-    throw new Error('Both `nuxt` and `nuxt-edge` are installed! This is unsupported, please choose one and remove the other one from dependencies.')
+function packageExists(name) {
+  try {
+    require.resolve(name)
+    return true
+  } catch (e) {
+    return false
   }
 }
 
 export default async function run(_argv) {
-  checkDuplicateNuxt()
+  // Check for not installing both nuxt and nuxt-edge
+  const dupPkg = '@nuxt/' + (pkgName === '@nuxt/cli-edge' ? 'cli' : 'cli-edge')
+  if (packageExists(dupPkg)) {
+    throw new Error('Both `nuxt` and `nuxt-edge` dependencies are installed! This is unsupported, please choose one and remove the other one from dependencies.')
+  }
 
   // Read from process.argv
   const argv = _argv ? Array.from(_argv) : process.argv.slice(2)

--- a/packages/cli/src/run.js
+++ b/packages/cli/src/run.js
@@ -7,7 +7,7 @@ import setup from './setup'
 import getCommand from './commands'
 
 function checkDuplicateNuxt() {
-  const dupPkg = pkgName === '@nuxt/cli' ? 'cli-edge' : 'cli'
+  const dupPkg = pkgName === '@nuxt/cli-edge' ? 'cli' : 'cli-edge'
   if (fs.existsSync(path.resolve(__dirname, '..', '..', dupPkg))) {
     throw new Error('Both `nuxt` and `nuxt-edge` are installed! This is unsupported, please choose one and remove the other one from dependencies.')
   }

--- a/packages/cli/test/unit/run-edge.test.js
+++ b/packages/cli/test/unit/run-edge.test.js
@@ -1,7 +1,7 @@
 import run from '../../src/run'
 
 jest.mock('../../package.json', () => ({
-  name: 'cli-edge'
+  name: '@nuxt/cli-edge'
 }))
 
 describe('run in edge', () => {

--- a/packages/cli/test/unit/run-edge.test.js
+++ b/packages/cli/test/unit/run-edge.test.js
@@ -7,6 +7,6 @@ jest.mock('../../package.json', () => ({
 describe('run in edge', () => {
   test('throws error if nuxt and nuxt-edge are installed', async () => {
     await expect(run())
-      .rejects.toThrow('Both `nuxt` and `nuxt-edge` are installed! This is unsupported, please choose one and remove the other one from dependencies.')
+      .rejects.toThrow('Both `nuxt` and `nuxt-edge` dependencies are installed! This is unsupported, please choose one and remove the other one from dependencies.')
   })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

Fix CLI failure when use yarn alias `nuxt: "npm:nuxt-edge"`

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

