### PR TITLE
refactor(config): rename `devModules` to `buildModules`

### DIFF
--- a/packages/config/src/config/_app.js
+++ b/packages/config/src/config/_app.js
@@ -23,7 +23,7 @@ export default () => ({
   css: [],
 
   modules: [],
-  devModules: [],
+  buildModules: [],
 
   layouts: {},
 

--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -376,7 +376,7 @@ export function getNuxtConfig (_options) {
 
   // Add loading screen
   if (options.dev) {
-    options.devModules.push('@nuxt/loading-screen')
+    options.buildModules.push('@nuxt/loading-screen')
     // Disable build indicator for programmatic users
     if (!options._cli) {
       options.build.indicator = false

--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -338,7 +338,7 @@ export function getNuxtConfig (_options) {
 
   // devModules has been renamed to buildModules
   if (typeof options.devModules !== 'undefined') {
-    consola.warn('`devModules` has been renamed to `buildModules` and will be removed in nuxt 3.')
+    consola.warn('`devModules` has been renamed to `buildModules` and will be removed in Nuxt 3.')
     options.buildModules.push(...options.devModules)
     delete options.devModules
   }

--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -336,7 +336,7 @@ export function getNuxtConfig (_options) {
     consola.warn('build.extractCSS.allChunks has no effect from v2.0.0. Please use build.optimization.splitChunks settings instead.')
   }
 
-  // devModules renamed to buildModules
+  // devModules has been renamed to buildModules
   if (typeof options.devModules !== 'undefined') {
     consola.warn('`devModules` has been renamed to `buildModules` and will be removed in nuxt 3.')
     options.buildModules.push(...options.devModules)

--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -338,7 +338,7 @@ export function getNuxtConfig (_options) {
 
   // devModules renamed to buildModules
   if (typeof options.devModules !== 'undefined') {
-    consola.warn('`devModules` has been renamed to `buildModules`')
+    consola.warn('`devModules` has been renamed to `buildModules` and will be removed in nuxt 3.')
     options.buildModules.push(...options.devModules)
     delete options.devModules
   }

--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -336,6 +336,13 @@ export function getNuxtConfig (_options) {
     consola.warn('build.extractCSS.allChunks has no effect from v2.0.0. Please use build.optimization.splitChunks settings instead.')
   }
 
+  // devModules renamed to buildModules
+  if (typeof options.devModules !== 'undefined') {
+    consola.warn('`devModules` has been renamed to `buildModules`')
+    options.buildModules.push(...options.devModules)
+    delete options.devModules
+  }
+
   // Enable minimize for production builds
   if (options.build.optimization.minimize === undefined) {
     options.build.optimization.minimize = !options.dev

--- a/packages/config/test/__snapshots__/options.test.js.snap
+++ b/packages/config/test/__snapshots__/options.test.js.snap
@@ -143,13 +143,13 @@ Object {
     "watch": Array [],
   },
   "buildDir": "/var/nuxt/test/.nuxt",
+  "buildModules": Array [],
   "cli": Object {
     "badgeMessages": Array [],
   },
   "css": Array [],
   "debug": false,
   "dev": false,
-  "buildModules": Array [],
   "dir": Object {
     "app": "app",
     "assets": "assets",

--- a/packages/config/test/__snapshots__/options.test.js.snap
+++ b/packages/config/test/__snapshots__/options.test.js.snap
@@ -149,7 +149,7 @@ Object {
   "css": Array [],
   "debug": false,
   "dev": false,
-  "devModules": Array [],
+  "buildModules": Array [],
   "dir": Object {
     "app": "app",
     "assets": "assets",

--- a/packages/config/test/config/__snapshots__/index.test.js.snap
+++ b/packages/config/test/config/__snapshots__/index.test.js.snap
@@ -129,7 +129,7 @@ Object {
   "css": Array [],
   "debug": undefined,
   "dev": false,
-  "devModules": Array [],
+  "buildModules": Array [],
   "dir": Object {
     "app": "app",
     "assets": "assets",
@@ -456,7 +456,7 @@ Object {
   "css": Array [],
   "debug": undefined,
   "dev": false,
-  "devModules": Array [],
+  "buildModules": Array [],
   "dir": Object {
     "app": "app",
     "assets": "assets",

--- a/packages/config/test/config/__snapshots__/index.test.js.snap
+++ b/packages/config/test/config/__snapshots__/index.test.js.snap
@@ -123,13 +123,13 @@ Object {
     "watch": Array [],
   },
   "buildDir": ".nuxt",
+  "buildModules": Array [],
   "cli": Object {
     "badgeMessages": Array [],
   },
   "css": Array [],
   "debug": undefined,
   "dev": false,
-  "buildModules": Array [],
   "dir": Object {
     "app": "app",
     "assets": "assets",
@@ -450,13 +450,13 @@ Object {
     "watch": Array [],
   },
   "buildDir": ".nuxt",
+  "buildModules": Array [],
   "cli": Object {
     "badgeMessages": Array [],
   },
   "css": Array [],
   "debug": undefined,
   "dev": false,
-  "buildModules": Array [],
   "dir": Object {
     "app": "app",
     "assets": "assets",

--- a/packages/config/test/options.test.js
+++ b/packages/config/test/options.test.js
@@ -232,6 +232,13 @@ describe('config: options', () => {
       expect(consola.warn).toHaveBeenCalledWith('vendor has been deprecated due to webpack4 optimization')
     })
 
+    test('should deprecate devModules', () => {
+      const config = getNuxtConfig({ devModules: ['foo'], buildModules: ['bar'] })
+      expect(consola.warn).toHaveBeenCalledWith('`devModules` has been renamed to `buildModules`')
+      expect(config.devModules).toBe(undefined)
+      expect(config.buildModules).toEqual(['bar', 'foo'])
+    })
+
     test('should deprecate build.extractCSS.allChunks', () => {
       getNuxtConfig({ build: { extractCSS: { allChunks: true } } })
       expect(consola.warn).toHaveBeenCalledWith('build.extractCSS.allChunks has no effect from v2.0.0. Please use build.optimization.splitChunks settings instead.')

--- a/packages/config/test/options.test.js
+++ b/packages/config/test/options.test.js
@@ -234,7 +234,7 @@ describe('config: options', () => {
 
     test('should deprecate devModules', () => {
       const config = getNuxtConfig({ devModules: ['foo'], buildModules: ['bar'] })
-      expect(consola.warn).toHaveBeenCalledWith('`devModules` has been renamed to `buildModules` and will be removed in nuxt 3.')
+      expect(consola.warn).toHaveBeenCalledWith('`devModules` has been renamed to `buildModules` and will be removed in Nuxt 3.')
       expect(config.devModules).toBe(undefined)
       expect(config.buildModules).toEqual(['bar', 'foo'])
     })

--- a/packages/config/test/options.test.js
+++ b/packages/config/test/options.test.js
@@ -234,7 +234,7 @@ describe('config: options', () => {
 
     test('should deprecate devModules', () => {
       const config = getNuxtConfig({ devModules: ['foo'], buildModules: ['bar'] })
-      expect(consola.warn).toHaveBeenCalledWith('`devModules` has been renamed to `buildModules`')
+      expect(consola.warn).toHaveBeenCalledWith('`devModules` has been renamed to `buildModules` and will be removed in nuxt 3.')
       expect(config.devModules).toBe(undefined)
       expect(config.buildModules).toEqual(['bar', 'foo'])
     })

--- a/packages/core/src/module.js
+++ b/packages/core/src/module.js
@@ -16,9 +16,9 @@ export default class ModuleContainer {
     // Call before hook
     await this.nuxt.callHook('modules:before', this, this.options.modules)
 
-    if (this.options.devModules && !this.options._start) {
+    if (this.options.buildModules && !this.options._start) {
       // Load every devModule in sequence
-      await sequence(this.options.devModules, this.addModule.bind(this))
+      await sequence(this.options.buildModules, this.addModule.bind(this))
     }
 
     // Load every module in sequence
@@ -136,8 +136,8 @@ export default class ModuleContainer {
       handler = src
     }
 
-    // Prevent adding devModules-listed entries in production
-    if (this.options.devModules.includes(handler) && this.options._start) {
+    // Prevent adding buildModules-listed entries in production
+    if (this.options.buildModules.includes(handler) && this.options._start) {
       return
     }
 

--- a/packages/core/test/module.test.js
+++ b/packages/core/test/module.test.js
@@ -19,7 +19,7 @@ jest.mock('@nuxt/utils', () => ({
 
 const defaultOptions = {
   modules: [],
-  devModules: []
+  buildModules: []
 }
 
 describe('core: module', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description

`devModules`, initially introduced by #5102 to have a way to only include some modules during dev/build time and removing from production dependencies at runtime. It was named after `devDependencies` section in `package.json` as such modules should not be installed for production environment at all. However the original name is proven to be little confusing and making users thinking it is only for development time. New `buildModules` name tries to make it more clear.
However `devModules` was not documented, backward compatibility with deprecation massage is added to support `devModules` until 3.x.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

