### PR TITLE
feat(vue-app): upgrade `vue-router`  to 3.1.2

### DIFF
--- a/distributions/nuxt-start/package.json
+++ b/distributions/nuxt-start/package.json
@@ -61,7 +61,7 @@
     "vue": "^2.6.10",
     "vue-meta": "^2.2.1",
     "vue-no-ssr": "^1.1.1",
-    "vue-router": "~3.0.7",
+    "vue-router": "^3.1.2",
     "vuex": "^3.1.1"
   },
   "engines": {

--- a/packages/vue-app/package.json
+++ b/packages/vue-app/package.json
@@ -16,7 +16,7 @@
     "vue-client-only": "^2.0.0",
     "vue-meta": "^2.2.1",
     "vue-no-ssr": "^1.1.1",
-    "vue-router": "~3.0.7",
+    "vue-router": "^3.1.2",
     "vue-template-compiler": "^2.6.10",
     "vuex": "^3.1.1"
   },

--- a/renovate.json
+++ b/renovate.json
@@ -6,8 +6,7 @@
     "dev"
   ],
   "ignoreDeps": [
-    "core-js",
-    "vue-router"
+    "core-js"
   ],
   "lockFileMaintenance": {
     "enabled": true

--- a/test/unit/async-config.size-limit.test.js
+++ b/test/unit/async-config.size-limit.test.js
@@ -36,6 +36,6 @@ describe('size-limit test', () => {
     const responseSizeBytes = responseSizes.reduce((bytes, responseLength) => bytes + responseLength, 0)
     const responseSizeKilobytes = Math.ceil(responseSizeBytes / 1024)
     // Without gzip!
-    expect(responseSizeKilobytes).toBeLessThanOrEqual(196)
+    expect(responseSizeKilobytes).toBeLessThanOrEqual(200)
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -11417,10 +11417,10 @@ vue-no-ssr@^1.1.1:
   resolved "https://registry.npmjs.org/vue-no-ssr/-/vue-no-ssr-1.1.1.tgz#875f3be6fb0ae41568a837f3ac1a80eaa137b998"
   integrity sha512-ZMjqRpWabMPqPc7gIrG0Nw6vRf1+itwf0Itft7LbMXs2g3Zs/NFmevjZGN1x7K3Q95GmIjWbQZTVerxiBxI+0g==
 
-vue-router@~3.0.7:
-  version "3.0.7"
-  resolved "https://registry.npmjs.org/vue-router/-/vue-router-3.0.7.tgz#b36ca107b4acb8ff5bc4ff824584059c23fcb87b"
-  integrity sha512-utJ+QR3YlIC/6x6xq17UMXeAfxEvXA0VKD3PiSio7hBOZNusA1jXcbxZxVEfJunLp48oonjTepY8ORoIlRx/EQ==
+vue-router@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.npmjs.org/vue-router/-/vue-router-3.1.2.tgz#2e0904703545dabdd42b2b7a2e617f02f99a1969"
+  integrity sha512-WssQEHSEvIS1/CI4CO2T8LJdoK4Q9Ngox28K7FDNMTfzNTk2WS5D0dDlqYCaPG+AG4Z8wJkn1KrBc7AhspZJUQ==
 
 vue-server-renderer@^2.6.10:
   version "2.6.10"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

There is currently a known issue with new promise support (vuejs/vue-router#2862) which is when using `$router.push` and `$router.replace` a new promise will be created by default and the `reject()` callback will be passed as `onAbort` to history provider ([src](https://github.com/vuejs/vue-router/blob/d907a13c3dcd43da757fdab2ee02ac3d104eb26f/src/index.js#L157)) during redirects, vue-router calls `abort()` without any params ([src](https://github.com/vuejs/vue-router/blob/dev/src/history/base.js#L163)) this now makes an unhandled promise rejection which resolve to undefined and is a semi-breaking change. We can patch e2e tests to catch the error but still, external-redirect test is failing and if nuxt users programmatically call `$router.push()` to a route which makes redirects will have a console error about unhandled rejection.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

