### PR TITLE
fix(vue-renderer): call `render:resourcesLoaded` hook before `createRenderer`

### DIFF
--- a/packages/vue-renderer/src/renderer.js
+++ b/packages/vue-renderer/src/renderer.js
@@ -128,13 +128,13 @@ export default class VueRenderer {
     // Load templates
     await this.loadTemplates()
 
+    await this.serverContext.nuxt.callHook('render:resourcesLoaded', this.serverContext.resources)
+
     // Detect if any resource updated
     if (updated.length > 0) {
       // Create new renderer
       this.createRenderer()
     }
-
-    return this.serverContext.nuxt.callHook('render:resourcesLoaded', this.serverContext.resources)
   }
 
   async loadTemplates () {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

Resloves #5960, move hook before renderers creation, provide possibility to change resources at runtime.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

