### PR TITLE
fix(vue-app): enforce default css when used with frameworks

### DIFF
--- a/packages/vue-app/template/components/nuxt-build-indicator.vue
+++ b/packages/vue-app/template/components/nuxt-build-indicator.vue
@@ -119,6 +119,7 @@ export default {
   width: 88px;
   z-index: 2147483647;
   font-size: 16px;
+  line-height: 1.2rem;
 }
 .v-enter-active, .v-leave-active {
   transition-delay: 0.2s;
@@ -130,6 +131,8 @@ export default {
   transform: translateY(20px);
 }
 svg {
+  display: inline-block;
+  vertical-align: baseline;
   width: 1.1em;
   position: relative;
   top: 1px;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
When used with TailwindCSS, `svg` is set as `display: block;` so the percent is displayed at the bottom of the logo for build-indicator.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] All new and existing tests are passing.

