### PR TITLE
fix(vue-app): only add leave listener when none provided or w/o done callback

### DIFF
--- a/packages/vue-app/template/components/nuxt-child.js
+++ b/packages/vue-app/template/components/nuxt-child.js
@@ -56,12 +56,17 @@ export default {
     // make sure that leave is called asynchronous (fix #5703)
     if (transition.css === false) {
       const leave = listeners.leave
-      listeners.leave = (el, done) => {
-        if (leave) {
-          leave.call(_parent, el)
-        }
 
-        _parent.$nextTick(done)
+      // only add leave listener when user didnt provide one
+      // or when it misses the done argument
+      if (!leave || leave.length < 2) {
+        listeners.leave = (el, done) => {
+          if (leave) {
+            leave.call(_parent, el)
+          }
+
+          _parent.$nextTick(done)
+        }
       }
     }
 


### PR DESCRIPTION
Resolves: #6263

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

It shouldnt be necessary to also add `_parent.$nextTick(done)` when the user already provided a done callback.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

