### PR TITLE
fix(server): treat https: null as https: undefined

### DIFF
--- a/packages/server/src/listener.js
+++ b/packages/server/src/listener.js
@@ -63,7 +63,7 @@ export default class Listener {
 
     // Initialize underlying http(s) server
     const protocol = this.https ? https : http
-    const protocolOpts = typeof this.https === 'object' ? [this.https] : []
+    const protocolOpts = this.https ? [this.https] : []
     this._server = protocol.createServer.apply(protocol, protocolOpts.concat(this.app))
 
     // Call server.listen


### PR DESCRIPTION
Fix situation when null passed to server.https and it will go to protocol HTTP options as null and will lead to unexpected behaviour ( for it was hanging requests when appinsight-js is on )