### PR TITLE
fix(builder): apply overrides from app dir only

### DIFF
--- a/packages/builder/src/builder.js
+++ b/packages/builder/src/builder.js
@@ -444,7 +444,7 @@ export default class Builder {
 
       // Allow override templates using a file with same name in ${srcDir}/app
       const customAppFile = path.resolve(this.options.srcDir, this.options.dir.app, file)
-      const customAppFileExists = customAppFile.indexOf(appDir) === 0 && await fsExtra.exists(customAppFile)
+      const customAppFileExists = customAppFile.startsWith(appDir) && await fsExtra.exists(customAppFile)
       if (customAppFileExists) {
         src = customAppFile
       }

--- a/packages/builder/src/builder.js
+++ b/packages/builder/src/builder.js
@@ -443,16 +443,16 @@ export default class Builder {
       let src = customTemplate ? (customTemplate.src || customTemplate) : r(this.template.dir, file)
 
       // Allow override templates using a file with same name in ${srcDir}/app
-      const customPath = path.resolve(this.options.srcDir, this.options.dir.app, file)
-      const customFileExists = customPath.indexOf(appDir) === 0 && await fsExtra.exists(customPath)
-      if (customFileExists) {
-        src = customPath
+      const customAppFile = path.resolve(this.options.srcDir, this.options.dir.app, file)
+      const customAppFileExists = customAppFile.indexOf(appDir) === 0 && await fsExtra.exists(customAppFile)
+      if (customAppFileExists) {
+        src = customAppFile
       }
 
       return {
         src,
         dst: file,
-        custom: Boolean(customFileExists || customTemplate),
+        custom: Boolean(customAppFileExists || customTemplate),
         options: (customTemplate && customTemplate.options) || {}
       }
     }))

--- a/packages/builder/test/builder.generate.test.js
+++ b/packages/builder/test/builder.generate.test.js
@@ -25,8 +25,9 @@ describe('builder: builder generate', () => {
     r.mockImplementation((...args) => `r(${args.join(', ')})`)
     fs.readFile.mockImplementation((...args) => `readFile(${args.join(', ')})`)
     fs.outputFile.mockImplementation((...args) => `outputFile(${args.join(', ')})`)
-    jest.spyOn(path, 'join')
-    jest.spyOn(path, 'resolve')
+    const { join, resolve } = path
+    jest.spyOn(path, 'join').mockImplementation((...args) => join(...args).replace(/\\/g, '/'))
+    jest.spyOn(path, 'resolve').mockImplementation((...args) => resolve(...args).replace(/\\/g, '/'))
   })
 
   afterAll(() => {

--- a/packages/builder/test/builder.generate.test.js
+++ b/packages/builder/test/builder.generate.test.js
@@ -25,8 +25,8 @@ describe('builder: builder generate', () => {
     r.mockImplementation((...args) => `r(${args.join(', ')})`)
     fs.readFile.mockImplementation((...args) => `readFile(${args.join(', ')})`)
     fs.outputFile.mockImplementation((...args) => `outputFile(${args.join(', ')})`)
-    jest.spyOn(path, 'join').mockImplementation((...args) => `join(${args.join(', ')})`)
-    jest.spyOn(path, 'resolve').mockImplementation((...args) => `resolve(${args.join(', ')})`)
+    jest.spyOn(path, 'join')
+    jest.spyOn(path, 'resolve')
   })
 
   afterAll(() => {
@@ -211,7 +211,7 @@ describe('builder: builder generate', () => {
     await builder.resolveCustomTemplates(templateContext)
 
     expect(templateContext.templateFiles).toEqual([
-      { custom: true, dst: 'foo.js', src: 'r(/var/nuxt/src, app, foo.js)', options: {} },
+      { custom: true, dst: 'foo.js', src: '/var/nuxt/src/app/foo.js', options: {} },
       { custom: true, dst: 'bar.js', src: '/var/nuxt/templates/bar.js', options: {} },
       { custom: true, dst: 'baz.js', src: '/var/nuxt/templates/baz.js', options: {} },
       { custom: false, dst: 'router.js', src: 'r(/var/nuxt/templates, router.js)', options: {} },
@@ -237,12 +237,12 @@ describe('builder: builder generate', () => {
     expect(path.resolve).toBeCalledTimes(1)
     expect(path.resolve).toBeCalledWith('/var/nuxt/templates', 'views/loading', 'test_loading_indicator.html')
     expect(fs.exists).toBeCalledTimes(1)
-    expect(fs.exists).toBeCalledWith('resolve(/var/nuxt/templates, views/loading, test_loading_indicator.html)')
+    expect(fs.exists).toBeCalledWith('/var/nuxt/templates/views/loading/test_loading_indicator.html')
     expect(templateFiles).toEqual([{
       custom: false,
       dst: 'loading.html',
       options: { name: 'test_loading_indicator' },
-      src: 'resolve(/var/nuxt/templates, views/loading, test_loading_indicator.html)'
+      src: '/var/nuxt/templates/views/loading/test_loading_indicator.html'
     }])
   })
 
@@ -265,7 +265,7 @@ describe('builder: builder generate', () => {
     expect(path.resolve).toBeCalledTimes(1)
     expect(path.resolve).toBeCalledWith('/var/nuxt/templates', 'views/loading', '@/app/template.vue.html')
     expect(fs.exists).toBeCalledTimes(2)
-    expect(fs.exists).nthCalledWith(1, 'resolve(/var/nuxt/templates, views/loading, @/app/template.vue.html)')
+    expect(fs.exists).nthCalledWith(1, '/var/nuxt/templates/views/loading/@/app/template.vue.html')
     expect(fs.exists).nthCalledWith(2, 'resolveAlias(@/app/template.vue)')
     expect(templateFiles).toEqual([{
       custom: true,
@@ -294,7 +294,7 @@ describe('builder: builder generate', () => {
     expect(path.resolve).toBeCalledTimes(1)
     expect(path.resolve).toBeCalledWith('/var/nuxt/templates', 'views/loading', '@/app/empty.vue.html')
     expect(fs.exists).toBeCalledTimes(2)
-    expect(fs.exists).nthCalledWith(1, 'resolve(/var/nuxt/templates, views/loading, @/app/empty.vue.html)')
+    expect(fs.exists).nthCalledWith(1, '/var/nuxt/templates/views/loading/@/app/empty.vue.html')
     expect(fs.exists).nthCalledWith(2, 'resolveAlias(@/app/empty.vue)')
     expect(consola.error).toBeCalledTimes(1)
     expect(consola.error).toBeCalledWith('Could not fetch loading indicator: @/app/empty.vue')
@@ -436,7 +436,7 @@ describe('builder: builder generate', () => {
       expect(path.resolve).toBeCalledTimes(1)
       expect(path.resolve).toBeCalledWith('/var/nuxt/src', '/var/nuxt/src/layouts')
       expect(fs.exists).toBeCalledTimes(1)
-      expect(fs.exists).toBeCalledWith('resolve(/var/nuxt/src, /var/nuxt/src/layouts)')
+      expect(fs.exists).toBeCalledWith('/var/nuxt/src/layouts')
       expect(builder.resolveFiles).toBeCalledTimes(1)
       expect(builder.resolveFiles).toBeCalledWith('/var/nuxt/src/layouts')
       expect(builder.relativeToBuild).toBeCalledTimes(2)
@@ -503,7 +503,7 @@ describe('builder: builder generate', () => {
       expect(path.resolve).toBeCalledTimes(1)
       expect(path.resolve).toBeCalledWith('/var/nuxt/src', '/var/nuxt/src/layouts')
       expect(fs.exists).toBeCalledTimes(1)
-      expect(fs.exists).toBeCalledWith('resolve(/var/nuxt/src, /var/nuxt/src/layouts)')
+      expect(fs.exists).toBeCalledWith('/var/nuxt/src/layouts')
       expect(builder.resolveFiles).not.toBeCalled()
       expect(fs.mkdirp).not.toBeCalled()
     })

--- a/packages/builder/test/builder.generate.test.js
+++ b/packages/builder/test/builder.generate.test.js
@@ -25,9 +25,9 @@ describe('builder: builder generate', () => {
     r.mockImplementation((...args) => `r(${args.join(', ')})`)
     fs.readFile.mockImplementation((...args) => `readFile(${args.join(', ')})`)
     fs.outputFile.mockImplementation((...args) => `outputFile(${args.join(', ')})`)
-    const { join, resolve } = path
-    jest.spyOn(path, 'join').mockImplementation((...args) => join(...args).replace(/\\/g, '/'))
-    jest.spyOn(path, 'resolve').mockImplementation((...args) => resolve(...args).replace(/\\/g, '/'))
+    const { join, resolve } = path.posix
+    jest.spyOn(path, 'join').mockImplementation((...args) => join(...args))
+    jest.spyOn(path, 'resolve').mockImplementation((...args) => resolve(...args))
   })
 
   afterAll(() => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Fixes issue introduced in #6055. We should only allow overriding from `app/` dir. If a module emits an asset outside of `.nuxt` dir (like `static/sw.js`) nuxt will wrongly override `static/sw.js` to itself and watch wrong files, causing infinity rebuilds.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

