### PR TITLE
test: disable terser/minify by default

### DIFF
--- a/test/fixtures/async-config/nuxt.config.js
+++ b/test/fixtures/async-config/nuxt.config.js
@@ -1,6 +1,9 @@
 const createData = async () => {
   await new Promise(resolve => setTimeout(resolve, 500))
   return {
+    build: {
+      terser: true
+    },
     head: {
       title: 'Async Config!'
     }

--- a/test/fixtures/async-config/nuxt.config.js
+++ b/test/fixtures/async-config/nuxt.config.js
@@ -2,6 +2,7 @@ const createData = async () => {
   await new Promise(resolve => setTimeout(resolve, 500))
   return {
     build: {
+      // without terser enabled the size-limit unit test fails
       terser: true
     },
     head: {

--- a/test/fixtures/modern/nuxt.config.js
+++ b/test/fixtures/modern/nuxt.config.js
@@ -1,6 +1,7 @@
 export default {
   modern: true,
   build: {
+    terser: true,
     crossorigin: 'use-credentials',
     filenames: {
       app: ({ isModern }) => {

--- a/test/fixtures/modern/nuxt.config.js
+++ b/test/fixtures/modern/nuxt.config.js
@@ -1,7 +1,6 @@
 export default {
   modern: true,
   build: {
-    terser: true,
     crossorigin: 'use-credentials',
     filenames: {
       app: ({ isModern }) => {

--- a/test/unit/modern.server.test.js
+++ b/test/unit/modern.server.test.js
@@ -35,12 +35,12 @@ describe('modern server mode', () => {
 
   test('should include es6 syntax in modern resources', async () => {
     const response = await rp(url(`/_nuxt/modern-${wChunk('pages/index.js')}`))
-    expect(response).toContain('arrow:()=>"build test"')
+    expect(response).toContain('arrow: () => {')
   })
 
   test('should not include es6 syntax in normal resources', async () => {
     const response = await rp(url(`/_nuxt/${wChunk('pages/index.js')}`))
-    expect(response).toContain('arrow:function(){return"build test"}')
+    expect(response).toContain('arrow: function arrow() {')
   })
 
   test('should contain legacy http2 pushed resources', async () => {

--- a/test/utils/nuxt.js
+++ b/test/utils/nuxt.js
@@ -33,5 +33,14 @@ export const loadFixture = async function (fixture, overrides) {
   config.dev = false
   config.test = true
 
+  // disable terser to speed-up fixture builds
+  if (config.build) {
+    if (!config.build.hasOwnProperty('terser')) {
+      config.build.terser = false
+    }
+  } else {
+    config.build = { terser: false }
+  }
+
   return defaultsDeep({}, overrides, config)
 }

--- a/test/utils/nuxt.js
+++ b/test/utils/nuxt.js
@@ -35,7 +35,7 @@ export const loadFixture = async function (fixture, overrides) {
 
   // disable terser to speed-up fixture builds
   if (config.build) {
-    if (!config.build.hasOwnProperty('terser')) {
+    if (!config.build.terser) {
       config.build.terser = false
     }
   } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

We have probably all wasted hours of our time waiting for terser to run on the test fixtures. Thats completely useless in most cases because we dont have any need for it.

This PR speeds up the building of the fixtures with ~40 seconds for me (from 100-110s to 65s)

On CircleCI, the nighty build from last night:
![image](https://user-images.githubusercontent.com/1067403/63635080-84474700-c65e-11e9-8fac-d89bfaff3d6d.png)

This pr:
![image](https://user-images.githubusercontent.com/1067403/63635084-92956300-c65e-11e9-9948-f7ab689b7850.png)


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing. **YES AND MUCH QUICKER**

