### PR TITLE
test: add jest roots for less greedy test search

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,8 +6,8 @@ module.exports = {
   forceExit: true,
 
   roots: [
-    "<rootDir>/packages",
-    "<rootDir>/test"
+    '<rootDir>/packages',
+    '<rootDir>/test'
   ],
 
   // https://github.com/facebook/jest/pull/6747 fix warning here

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,11 @@ module.exports = {
 
   forceExit: true,
 
+  roots: [
+    "<rootDir>/packages",
+    "<rootDir>/test"
+  ],
+
   // https://github.com/facebook/jest/pull/6747 fix warning here
   // But its performance overhead is pretty bad (30+%).
   // detectOpenHandles: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

This should save at least 1 second on running tests. By default jest searches for modules/tests on `<rootDir>`. That is normally pretty ok, but (at least on linux) jest uses the following command to saerch for modules: `find <rootDir> -type f -iname *.snap -o -iname *.js -o iname *.json`

This is pretty greedy and also searched all examples, all node_modules dirs (main and from examples). So it will find _a lot_ of files, on my machine that takes about 1 second. On circleci that will probably be multiple seconds because find is quite i/o intensive (thats also how I noticed this command was being run because it was showing on iotop for some time).

Also it appears that the time it takes for the find command to run does not count for the total run time that jest reports. Eg if you run the tests like this `time yarn test` then the time reported by jest and by the time command should be closer to each other now.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

