### PR TITLE
feat(builder): support adding custom middlewares

### DIFF
--- a/packages/builder/src/builder.js
+++ b/packages/builder/src/builder.js
@@ -416,7 +416,15 @@ export default class Builder {
 
   async resolveMiddleware ({ templateVars }) {
     // -- Middleware --
-    templateVars.middleware = await this.resolveRelative(this.options.dir.middleware)
+    const middleware = await this.resolveRelative(this.options.dir.middleware)
+
+    const extRE = new RegExp(`\\.(${this.supportedExtensions.join('|')})$`)
+
+    templateVars.middleware = middleware.map(({ src }) => {
+      const name = src.replace(extRE, '')
+      const dst = this.relativeToBuild(this.options.srcDir, this.options.dir.middleware, src)
+      return { name, src, dst }
+    })
   }
 
   async resolveCustomTemplates (templateContext) {

--- a/packages/builder/test/builder.generate.test.js
+++ b/packages/builder/test/builder.generate.test.js
@@ -171,18 +171,25 @@ describe('builder: builder generate', () => {
   test('should resolve middleware', async () => {
     const nuxt = createNuxt()
     nuxt.options.store = false
+    nuxt.options.srcDir = '/var/nuxt/src'
     nuxt.options.dir = {
-      middleware: '/var/nuxt/src/middleware'
+      middleware: 'middleware'
     }
+    const middlewarePath = 'subfolder/midd.js'
     const builder = new Builder(nuxt, BundleBuilder)
     builder.resolveRelative = jest.fn(dir => [
-      { src: `${dir}/midd.js` }
+      { src: middlewarePath }
     ])
+    builder.relativeToBuild = jest.fn().mockReturnValue(middlewarePath)
 
     const templateVars = {}
     await builder.resolveMiddleware({ templateVars })
 
-    expect(templateVars.middleware).toEqual([ { src: '/var/nuxt/src/middleware/midd.js' } ])
+    expect(templateVars.middleware).toEqual([{
+      name: 'subfolder/midd',
+      src: 'subfolder/midd.js',
+      dst: 'subfolder/midd.js'
+    }])
   })
 
   test('should custom templates', async () => {

--- a/packages/vue-app/template/middleware.js
+++ b/packages/vue-app/template/middleware.js
@@ -1,8 +1,10 @@
 const middleware = {}
-<% middleware.forEach(m => {
-   const name = m.src.replace(new RegExp(`\\.(${extensions})$`), '')
+<% for (const m of middleware) {
+  const name = m.name || m.src.replace(new RegExp(`\\.(${extensions})$`), '')
+  const dst = m.dst || relativeToBuild(srcDir, dir.middleware, m.src)
 %>
-middleware['<%= name %>'] = require('<%= relativeToBuild(srcDir, dir.middleware, m.src) %>');
+middleware['<%= name %>'] = require('<%= dst %>');
 middleware['<%= name %>'] = middleware['<%= name %>'].default || middleware['<%= name %>']
-<% }) %>
+<% } %>
+
 export default middleware

--- a/packages/vue-app/template/middleware.js
+++ b/packages/vue-app/template/middleware.js
@@ -1,5 +1,6 @@
 const middleware = {}
 <% for (const m of middleware) {
+  // TODO: remove duplicate logic in v3 (see builder.resolveMiddleware)
   const name = m.name || m.src.replace(new RegExp(`\\.(${extensions})$`), '')
   const dst = m.dst || relativeToBuild(srcDir, dir.middleware, m.src)
 %>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

It seems that the middleware template in vue-app contains some business logic which should be moved to the builder class. This logic prevents me from adding a custom middleware (using the build:templates hook) in nuxt/press which has a webpack alias as path so it cant/shouldnt be resolved with `relativeToBuild`.

This pr moves that logic into the `resolveMiddleware` method of the builder class. Not sure if its needed, but to prevent a breaking change I have kept the resolve logic in the middleware template for now.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

