### PR TITLE
refactor(cli): call setup hook in run command with more args

### DIFF
--- a/packages/cli/src/command.js
+++ b/packages/cli/src/command.js
@@ -1,4 +1,5 @@
 
+import path from 'path'
 import consola from 'consola'
 import minimist from 'minimist'
 import Hookable from 'hable'
@@ -35,6 +36,12 @@ export default class NuxtCommand extends Hookable {
   }
 
   async run () {
+    await this.callHook('setup', {
+      argv: this._argv,
+      cmd: this.cmd,
+      rootDir: path.resolve(this.argv._[0] || '.')
+    })
+
     if (this.argv.help) {
       this.showHelp()
       return

--- a/packages/cli/src/run.js
+++ b/packages/cli/src/run.js
@@ -36,12 +36,6 @@ export default async function run (_argv, hooks = {}) {
   // Check for dev
   const dev = argv[0] === 'dev'
 
-  // Call setup hook
-  if (typeof hooks.setup === 'function') {
-    await hooks.setup({ cmd, dev, argv })
-    delete hooks.setup
-  }
-
   // Setup env
   setup({ dev })
 

--- a/packages/cli/test/unit/hooks.test.js
+++ b/packages/cli/test/unit/hooks.test.js
@@ -1,3 +1,4 @@
+import path from 'path'
 import { NuxtCommand } from '../utils'
 
 describe('dev', () => {
@@ -8,6 +9,34 @@ describe('dev', () => {
   })
 
   afterEach(() => jest.clearAllMocks())
+
+  test('setup hook', async () => {
+    const hooks = {
+      setup: jest.fn()
+    }
+
+    await NuxtCommand.run(dev, [], hooks)
+
+    expect(hooks.setup).toHaveBeenCalledWith({
+      argv: [],
+      cmd: dev,
+      rootDir: path.resolve('.')
+    })
+  })
+
+  test('setup hook (custom CLI options & rootDir)', async () => {
+    const hooks = {
+      setup: jest.fn()
+    }
+
+    await NuxtCommand.run(dev, ['-p', '3001', 'path/to/project'], hooks)
+
+    expect(hooks.setup).toHaveBeenCalledWith({
+      argv: ['-p', '3001', 'path/to/project'],
+      cmd: dev,
+      rootDir: path.resolve('path/to/project')
+    })
+  })
 
   test('config hook', async () => {
     const hooks = {

--- a/packages/cli/test/unit/run.test.js
+++ b/packages/cli/test/unit/run.test.js
@@ -29,15 +29,6 @@ describe('run', () => {
     expect(NuxtCommand.run).toHaveBeenCalledWith(expect.anything(), ['--foo'], {})
   })
 
-  test('setup hook', async () => {
-    const setup = jest.fn()
-    await run(['--foo'], { setup })
-    expect(setup).toHaveBeenCalledWith(expect.objectContaining({
-      argv: ['dev', '--foo'],
-      dev: true
-    }))
-  })
-
   test('all hooks passed to NuxtCommand', async () => {
     const hooks = { foo: jest.fn() }
     await run([], hooks)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
It's overall a fix (where the setup hook is called) that will make TypeScript Runtime shine by not relying anymore on `process.argv` to find the `rootDir` which was not optimal (glitchy and not secure regarding new potential CLI Options).

See : https://github.com/nuxt/typescript/pull/97

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

