### PR TITLE
chore(cli): rename setup hook to run:before

### DIFF
--- a/packages/cli/src/command.js
+++ b/packages/cli/src/command.js
@@ -36,7 +36,7 @@ export default class NuxtCommand extends Hookable {
   }
 
   async run () {
-    await this.callHook('setup', {
+    await this.callHook('run:before', {
       argv: this._argv,
       cmd: this.cmd,
       rootDir: path.resolve(this.argv._[0] || '.')

--- a/packages/cli/test/unit/hooks.test.js
+++ b/packages/cli/test/unit/hooks.test.js
@@ -10,28 +10,28 @@ describe('dev', () => {
 
   afterEach(() => jest.clearAllMocks())
 
-  test('setup hook', async () => {
+  test('run:before hook', async () => {
     const hooks = {
-      setup: jest.fn()
+      'run:before': jest.fn()
     }
 
     await NuxtCommand.run(dev, [], hooks)
 
-    expect(hooks.setup).toHaveBeenCalledWith({
+    expect(hooks['run:before']).toHaveBeenCalledWith({
       argv: [],
       cmd: dev,
       rootDir: path.resolve('.')
     })
   })
 
-  test('setup hook (custom CLI options & rootDir)', async () => {
+  test('run:before hook (custom CLI options & rootDir)', async () => {
     const hooks = {
-      setup: jest.fn()
+      'run:before': jest.fn()
     }
 
     await NuxtCommand.run(dev, ['-p', '3001', 'path/to/project'], hooks)
 
-    expect(hooks.setup).toHaveBeenCalledWith({
+    expect(hooks['run:before']).toHaveBeenCalledWith({
       argv: ['-p', '3001', 'path/to/project'],
       cmd: dev,
       rootDir: path.resolve('path/to/project')


### PR DESCRIPTION
## Description
Rename `setup` CLI hook to `run:before` to better fit the context where it's called.

## Checklist:
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

