### PR TITLE
chore: lint vue-app templates

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
       'vue/component-name-in-template-casing': ['warn', 'kebab-case']
     }
   }, {
-    files: [ 'test/fixtures/*/.nuxt*/**/+(App|index|server|client).js' ],
+    files: [ 'test/fixtures/*/.nuxt*/**/+(App|index|server|client|nuxt).js' ],
     rules: {
       'import/order': 'off'
     }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "consola": "^2.10.1",
     "cross-spawn": "^7.0.0",
     "eslint": "^6.3.0",
-    "eslint-multiplexer": "^1.0.4",
+    "eslint-multiplexer": "^2.0.0",
     "esm": "^3.2.25",
     "execa": "^2.0.4",
     "express": "^4.17.1",

--- a/packages/vue-app/template/App.js
+++ b/packages/vue-app/template/App.js
@@ -28,11 +28,11 @@ const layouts = { <%= Object.keys(layouts).map(key => `"_${key}": _${hash(key)}`
 
 export default {
   <% if (features.meta) { %>
-  <%= isTest ? '/* eslint-disable quotes, semi, indent, comma-spacing, key-spacing, object-curly-spacing, space-before-function-paren  */' : '' %>
+  <%= isTest ? '/* eslint-disable quotes, semi, indent, comma-spacing, key-spacing, object-curly-spacing, space-before-function-paren, object-shorthand  */' : '' %>
   head: <%= serializeFunction(head) %>,
-  <%= isTest ? '/* eslint-enable quotes, semi, indent, comma-spacing, key-spacing, object-curly-spacing, space-before-function-paren */' : '' %>
+  <%= isTest ? '/* eslint-enable quotes, semi, indent, comma-spacing, key-spacing, object-curly-spacing, space-before-function-paren, object-shorthand */' : '' %>
   <% } %>
-  render(h, props) {
+  render (h, props) {
     <% if (loading) { %>const loadingEl = h('NuxtLoading', { ref: 'loading' })<% } %>
     <% if (features.layouts) { %>
     const layoutEl = h(this.layout || 'nuxt')
@@ -53,7 +53,7 @@ export default {
         mode: '<%= layoutTransition.mode %>'
       },
       on: {
-        beforeEnter(el) {
+        beforeEnter (el) {
           // Ensure to trigger scroll event after calling scrollBehavior
           window.<%= globals.nuxt %>.$nextTick(() => {
             window.<%= globals.nuxt %>.$emit('triggerScroll')
@@ -84,10 +84,10 @@ export default {
     <% } %>
   }),
   <% } %>
-  beforeCreate() {
+  beforeCreate () {
     Vue.util.defineReactive(this, 'nuxt', this.$options.nuxt)
   },
-  created() {
+  created () {
     // Add this.$nuxt in child instances
     Vue.prototype.<%= globals.nuxt %> = this
     // add to window so we can listen when ready
@@ -106,7 +106,7 @@ export default {
     this.context = this.$options.context
   },
   <% if (loading) { %>
-  mounted() {
+  mounted () {
     this.$loading = this.$refs.loading
   },
   watch: {
@@ -115,14 +115,15 @@ export default {
   <% } %>
   <% if (features.clientOnline) { %>
   computed: {
-    isOffline() {
+    isOffline () {
       return !this.isOnline
     }
   },
   <% } %>
   methods: {
+    <%= isTest ? '/* eslint-disable comma-dangle */' : '' %>
     <% if (features.clientOnline) { %>
-    refreshOnlineStatus() {
+    refreshOnlineStatus () {
       if (process.client) {
         if (typeof window.navigator.onLine === 'undefined') {
           // If the browser doesn't support connection status reports
@@ -135,7 +136,7 @@ export default {
       }
     },
     <% } %>
-    async refresh() {
+    async refresh () {
       <% if (features.asyncData || features.fetch) { %>
       const pages = getMatchedComponentsInstances(this.$route)
 
@@ -144,7 +145,7 @@ export default {
       }
       <% if (loading) { %>this.$loading.start()<% } %>
 
-      const promises = pages.map(async (page) => {
+      const promises = pages.map((page) => {
         const p = []
 
         <% if (features.fetch) { %>
@@ -177,26 +178,34 @@ export default {
       <% } %>
     },
     <% if (loading) { %>
-    errorChanged() {
+    errorChanged () {
       if (this.nuxt.err && this.$loading) {
-        if (this.$loading.fail) this.$loading.fail()
-        if (this.$loading.finish) this.$loading.finish()
+        if (this.$loading.fail) {
+          this.$loading.fail()
+        }
+        if (this.$loading.finish) {
+          this.$loading.finish()
+        }
       }
     },
     <% } %>
     <% if (features.layouts) { %>
     <% if (splitChunks.layouts) { %>
-    setLayout(layout) {
+    setLayout (layout) {
       <% if (debug) { %>
-      if(layout && typeof layout !== 'string') throw new Error('[nuxt] Avoid using non-string value as layout property.')
+      if(layout && typeof layout !== 'string') {
+        throw new Error('[nuxt] Avoid using non-string value as layout property.')
+      }
       <% } %>
-      if (!layout || !resolvedLayouts['_' + layout]) layout = 'default'
+      if (!layout || !resolvedLayouts['_' + layout]) {
+        layout = 'default'
+      }
       this.layoutName = layout
       let _layout = '_' + layout
       this.layout = resolvedLayouts[_layout]
       return this.layout
     },
-    loadLayout(layout) {
+    loadLayout (layout) {
       const undef = !layout
       const nonexistent = !(layouts['_' + layout] || resolvedLayouts['_' + layout])
       let _layout = '_' + ((undef || nonexistent) ? 'default' : layout)
@@ -216,9 +225,11 @@ export default {
         })
     }
     <% } else { %>
-    setLayout(layout) {
+    setLayout (layout) {
       <% if (debug) { %>
-      if(layout && typeof layout !== 'string') throw new Error('[nuxt] Avoid using non-string value as layout property.')
+      if(layout && typeof layout !== 'string') {
+        throw new Error('[nuxt] Avoid using non-string value as layout property.')
+      }
       <% } %>
       if (!layout || !layouts['_' + layout]) {
         layout = 'default'
@@ -227,7 +238,7 @@ export default {
       this.layout = layouts['_' + layout]
       return this.layout
     },
-    loadLayout(layout) {
+    loadLayout (layout) {
       if (!layout || !layouts['_' + layout]) {
         layout = 'default'
       }
@@ -241,4 +252,5 @@ export default {
     NuxtLoading
   }
   <% } %>
+  <%= isTest ? '/* eslint-enable comma-dangle */' : '' %>
 }

--- a/packages/vue-app/template/components/nuxt-build-indicator.vue
+++ b/packages/vue-app/template/components/nuxt-build-indicator.vue
@@ -1,12 +1,12 @@
 <template>
   <transition appear>
-    <div class="nuxt__build_indicator" :style="indicatorStyle" v-if="building">
+    <div v-if="building" class="nuxt__build_indicator" :style="indicatorStyle">
       <svg viewBox="0 0 96 72" version="1" xmlns="http://www.w3.org/2000/svg">
         <g fill="none" fill-rule="evenodd">
-          <path d="M6 66h23l1-3 21-37L40 6 6 66zM79 66h11L62 17l-5 9 22 37v3zM54 31L35 66h38z"/>
-          <path d="M29 69v-1-2H6L40 6l11 20 3-6L44 3s-2-3-4-3-3 1-5 3L1 63c0 1-2 3 0 6 0 1 2 2 5 2h28c-3 0-4-1-5-2z" fill="#00C58E"/>
-          <path d="M95 63L67 14c0-1-2-3-5-3-1 0-3 0-4 3l-4 6 3 6 5-9 28 49H79a5 5 0 0 1 0 3c-2 2-5 2-5 2h16c1 0 4 0 5-2 1-1 2-3 0-6z" fill="#00C58E"/>
-          <path d="M79 69v-1-2-3L57 26l-3-6-3 6-21 37-1 3a5 5 0 0 0 0 3c1 1 2 2 5 2h40s3 0 5-2zM54 31l19 35H35l19-35z" fill="#FFF" fill-rule="nonzero"/>
+          <path d="M6 66h23l1-3 21-37L40 6 6 66zM79 66h11L62 17l-5 9 22 37v3zM54 31L35 66h38z" />
+          <path d="M29 69v-1-2H6L40 6l11 20 3-6L44 3s-2-3-4-3-3 1-5 3L1 63c0 1-2 3 0 6 0 1 2 2 5 2h28c-3 0-4-1-5-2z" fill="#00C58E" />
+          <path d="M95 63L67 14c0-1-2-3-5-3-1 0-3 0-4 3l-4 6 3 6 5-9 28 49H79a5 5 0 0 1 0 3c-2 2-5 2-5 2h16c1 0 4 0 5-2 1-1 2-3 0-6z" fill="#00C58E" />
+          <path d="M79 69v-1-2-3L57 26l-3-6-3 6-21 37-1 3a5 5 0 0 0 0 3c1 1 2 2 5 2h40s3 0 5-2zM54 31l19 35H35l19-35z" fill="#FFF" fill-rule="nonzero" />
         </g>
       </svg>
       {{ animatedProgress }}%
@@ -16,39 +16,29 @@
 
 <script>
 export default {
-  name: 'nuxt-build-indicator',
-  data() {
+  name: 'NuxtBuildIndicator',
+  data () {
     return {
       building: false,
       progress: 0,
       animatedProgress: 0,
-      reconnectAttempts: 0,
+      reconnectAttempts: 0
     }
-  },
-  mounted() {
-    if (typeof EventSource === undefined) {
-      return // Unsupported
-    }
-    this.sseConnect()
-  },
-  beforeDestroy() {
-    this.sseClose()
-    clearInterval(this._progressAnimation)
   },
   computed: {
     options: () => (<%= JSON.stringify(buildIndicator) %>),
-    indicatorStyle() {
+    indicatorStyle () {
       const [ d1, d2 ] = this.options.position.split('-')
       return {
         [d1]: '20px',
         [d2]: '20px',
         'background-color': this.options.backgroundColor,
-        color: this.options.color,
+        color: this.options.color
       }
     }
   },
   watch: {
-    progress(val, oldVal) {
+    progress (val, oldVal) {
       // Average progress may decrease but ignore it!
       if (val < oldVal) {
         return
@@ -71,18 +61,30 @@ export default {
       }, 50)
     }
   },
+  mounted () {
+    if (EventSource === undefined) {
+      return // Unsupported
+    }
+    this.sseConnect()
+  },
+  beforeDestroy () {
+    this.sseClose()
+    clearInterval(this._progressAnimation)
+  },
   methods: {
-    sseConnect() {
+    sseConnect () {
       if (this._connecting) {
         return
       }
       this._connecting = true
       this.sse = new EventSource('<%= router.base %>_loading/sse')
-      this.sse.addEventListener('message', (event) => this.onSseMessage(event))
+      this.sse.addEventListener('message', event => this.onSseMessage(event))
     },
-    onSseMessage(message) {
+    onSseMessage (message) {
       const data = JSON.parse(message.data)
-      if (!data.states) return
+      if (!data.states) {
+        return
+      }
 
       this.progress = Math.round(data.states.reduce((p, s) => p + s.progress, 0) / data.states.length)
 
@@ -98,7 +100,7 @@ export default {
       }
     },
 
-    sseClose() {
+    sseClose () {
       if (this.sse) {
         this.sse.close()
         delete this.sse

--- a/packages/vue-app/template/components/nuxt-child.js
+++ b/packages/vue-app/template/components/nuxt-child.js
@@ -13,7 +13,7 @@ export default {
       default: undefined
     }
   },
-  render(h, { parent, data, props }) {
+  render (h, { parent, data, props }) {
     <% if (features.transitions) { %>
     data.nuxtChild = true
     const _parent = parent

--- a/packages/vue-app/template/components/nuxt-error.vue
+++ b/packages/vue-app/template/components/nuxt-error.vue
@@ -29,7 +29,7 @@ export default {
       default: null
     }
   },
-  head() {
+  head () {
     return {
       title: this.message,
       meta: [
@@ -41,10 +41,10 @@ export default {
     }
   },
   computed: {
-    statusCode() {
+    statusCode () {
       return (this.error && this.error.statusCode) || 500
     },
-    message() {
+    message () {
       return this.error.message || `<%= messages.client_error %>`
     }
   }

--- a/packages/vue-app/template/components/nuxt-link.client.js
+++ b/packages/vue-app/template/components/nuxt-link.client.js
@@ -6,9 +6,7 @@ const requestIdleCallback = window.requestIdleCallback ||
     return setTimeout(function () {
       cb({
         didTimeout: false,
-        timeRemaining: function () {
-          return Math.max(0, 50 - (Date.now() - start))
-        }
+        timeRemaining: () => Math.max(0, 50 - (Date.now() - start))
       })
     }, 1)
   }
@@ -35,19 +33,19 @@ export default {
       default: '<%= router.linkPrefetchedClass %>'
     }<% } %>
   },
-  mounted() {
+  mounted () {
     if (!this.noPrefetch) {
       requestIdleCallback(this.observe, { timeout: 2e3 })
     }
   },
-  beforeDestroy() {
+  beforeDestroy () {
     if (this.__observed) {
       observer.unobserve(this.$el)
       delete this.$el.__prefetch
     }
   },
   methods: {
-    observe() {
+    observe () {
       // If no IntersectionObserver, avoid prefetching
       if (!observer) {
         return
@@ -61,22 +59,22 @@ export default {
         this.addPrefetchedClass()
       }<% } %>
     },
-    shouldPrefetch() {
+    shouldPrefetch () {
       return this.getPrefetchComponents().length > 0
     },
-    canPrefetch() {
+    canPrefetch () {
       const conn = navigator.connection
       const hasBadConnection = this.<%= globals.nuxt %>.isOffline || (conn && ((conn.effectiveType || '').includes('2g') || conn.saveData))
 
       return !hasBadConnection
     },
-    getPrefetchComponents() {
+    getPrefetchComponents () {
       const ref = this.$router.resolve(this.to, this.$route, this.append)
       const Components = ref.resolved.matched.map(r => r.components.default)
 
       return Components.filter(Component => typeof Component === 'function' && !Component.options && !Component.__prefetched)
     },
-    prefetch() {
+    prefetch () {
       if (!this.canPrefetch()) {
         return
       }
@@ -93,7 +91,7 @@ export default {
       }<% if (router.linkPrefetchedClass) { %>
       this.addPrefetchedClass()<% } %>
     }<% if (router.linkPrefetchedClass) { %>,
-    addPrefetchedClass() {
+    addPrefetchedClass () {
       if (this.prefetchedClass !== 'false') {
         this.$el.className = (this.$el.className + ' ' + this.prefetchedClass).trim()
       }

--- a/packages/vue-app/template/components/nuxt-loading.vue
+++ b/packages/vue-app/template/components/nuxt-loading.vue
@@ -1,7 +1,7 @@
 <script>
 export default {
   name: 'NuxtLoading',
-  data() {
+  data () {
     return {
       percent: 0,
       show: false,
@@ -15,7 +15,7 @@ export default {
     }
   },
   computed: {
-    left() {
+    left () {
       if (!this.continuous && !this.rtl) {
         return false
       }
@@ -24,16 +24,16 @@ export default {
         : (!this.reversed ? '0px' : 'auto')
     }
   },
-  beforeDestroy() {
+  beforeDestroy () {
     this.clear()
   },
   methods: {
-    clear() {
+    clear () {
       clearInterval(this._timer)
       clearTimeout(this._throttle)
       this._timer = null
     },
-    start() {
+    start () {
       this.clear()
       this.percent = 0
       this.reversed = false
@@ -47,37 +47,37 @@ export default {
       }
       return this
     },
-    set(num) {
+    set (num) {
       this.show = true
       this.canSucceed = true
       this.percent = Math.min(100, Math.max(0, Math.floor(num)))
       return this
     },
-    get() {
+    get () {
       return this.percent
     },
-    increase(num) {
+    increase (num) {
       this.percent = Math.min(100, Math.floor(this.percent + num))
       return this
     },
-    decrease(num) {
+    decrease (num) {
       this.percent = Math.max(0, Math.floor(this.percent - num))
       return this
     },
-    pause() {
+    pause () {
       clearInterval(this._timer)
       return this
     },
-    resume() {
+    resume () {
       this.startTimer()
       return this
     },
-    finish() {
+    finish () {
       this.percent = this.reversed ? 0 : 100
       this.hide()
       return this
     },
-    hide() {
+    hide () {
       this.clear()
       setTimeout(() => {
         this.show = false
@@ -88,11 +88,11 @@ export default {
       }, 500)
       return this
     },
-    fail() {
+    fail () {
       this.canSucceed = false
       return this
     },
-    startTimer() {
+    startTimer () {
       if (!this.show) {
         this.show = true
       }
@@ -133,7 +133,7 @@ export default {
       }, 100)
     }
   },
-  render(h) {
+  render (h) {
     let el = h(false)
     if (this.show) {
       el = h('div', {

--- a/packages/vue-app/template/components/nuxt.js
+++ b/packages/vue-app/template/components/nuxt.js
@@ -44,7 +44,7 @@ export default {
     }
   },
   computed: {
-    routerViewKey() {
+    routerViewKey () {
       // If nuxtChildKey prop is given or current route has children
       if (typeof this.nuxtChildKey !== 'undefined' || this.$route.matched.length > 1) {
         return this.nuxtChildKey || compile(this.$route.matched[0].path)(this.$route.params)
@@ -70,10 +70,10 @@ export default {
       return strict ? this.$route.path : this.$route.path.replace(/\/$/, '')
     }
   },
-  beforeCreate() {
+  beforeCreate () {
     Vue.util.defineReactive(this, 'nuxt', this.$root.$options.nuxt)
   },
-  render(h) {
+  render (h) {
     // if there is no error
     if (!this.nuxt.err) {
       // Directly return nuxt child

--- a/packages/vue-app/template/index.js
+++ b/packages/vue-app/template/index.js
@@ -24,9 +24,10 @@ Vue.component(ClientOnly.name, ClientOnly)
 // TODO: Remove in Nuxt 3: <NoSsr>
 Vue.component(NoSsr.name, {
   ...NoSsr,
-  render(h, ctx) {
+  render (h, ctx) {
     if (process.client && !NoSsr._warned) {
       NoSsr._warned = true
+      <%= isTest ? '// eslint-disable-next-line no-console' : '' %>
       console.warn(`<no-ssr> has been deprecated and will be removed in Nuxt 3, please use <client-only> instead`)
     }
     return NoSsr.render(h, ctx)
@@ -62,7 +63,7 @@ const defaultTransition = <%=
 %><%= isTest ? '// eslint-disable-line' : '' %>
 <% } %>
 
-async function createApp(ssrContext) {
+async function createApp (ssrContext) {
   const router = await createRouter(ssrContext)
 
   <% if (store) { %>
@@ -87,7 +88,7 @@ async function createApp(ssrContext) {
       <% if (features.transitions) { %>
       defaultTransition,
       transitions: [ defaultTransition ],
-      setTransitions(transitions) {
+      setTransitions (transitions) {
         if (!Array.isArray(transitions)) {
           transitions = [ transitions ]
         }
@@ -107,7 +108,7 @@ async function createApp(ssrContext) {
       <% } %>
       err: null,
       dateErr: null,
-      error(err) {
+      error (err) {
         err = err || null
         app.context._errored = Boolean(err)
         err = err ? normalizeError(err) : null
@@ -115,7 +116,9 @@ async function createApp(ssrContext) {
         nuxt.dateErr = Date.now()
         nuxt.err = err
         // Used in src/server.js
-        if (ssrContext) ssrContext.nuxt.error = err
+        if (ssrContext) {
+          ssrContext.nuxt.error = err
+        }
         return err
       }
     },
@@ -150,8 +153,13 @@ async function createApp(ssrContext) {
 
   <% if (plugins.length) { %>
   const inject = function (key, value) {
-    if (!key) throw new Error('inject(key, value) has no key provided')
-    if (typeof value === 'undefined') throw new Error('inject(key, value) has no value provided')
+    if (!key) {
+      throw new Error('inject(key, value) has no key provided')
+    }
+    if (value === undefined) {
+      throw new Error('inject(key, value) has no value provided')
+    }
+
     key = '$' + key
     // Add into app
     app[key] = value
@@ -161,13 +169,15 @@ async function createApp(ssrContext) {
     <% } %>
     // Check if plugin not already installed
     const installKey = '__<%= globals.pluginPrefix %>_' + key + '_installed__'
-    if (Vue[installKey]) return
+    if (Vue[installKey]) {
+      return
+    }
     Vue[installKey] = true
     // Call Vue.use() to install the plugin into vm
     Vue.use(() => {
       if (!Vue.prototype.hasOwnProperty(key)) {
         Object.defineProperty(Vue.prototype, key, {
-          get() {
+          get () {
             return this.$root.$options[key]
           }
         })

--- a/packages/vue-app/template/middleware.js
+++ b/packages/vue-app/template/middleware.js
@@ -1,11 +1,12 @@
 const middleware = {}
+<%= isTest ? '/* eslint-disable dot-notation */' : '' %>
 <% for (const m of middleware) {
   // TODO: remove duplicate logic in v3 (see builder.resolveMiddleware)
   const name = m.name || m.src.replace(new RegExp(`\\.(${extensions})$`), '')
   const dst = m.dst || relativeToBuild(srcDir, dir.middleware, m.src)
 %>
-middleware['<%= name %>'] = require('<%= dst %>');
+middleware['<%= name %>'] = require('<%= dst %>')
 middleware['<%= name %>'] = middleware['<%= name %>'].default || middleware['<%= name %>']
 <% } %>
-
+<%= isTest ? '/* eslint-enable dot-notation */' : '' %>
 export default middleware

--- a/packages/vue-app/template/router.js
+++ b/packages/vue-app/template/router.js
@@ -68,7 +68,7 @@ import scrollBehavior from './router.scrollBehavior.js'
   return res
 }
 const _components = []
-const _routes = recursiveRoutes(router.routes, '  ', _components, 2)
+const _routes = recursiveRoutes(router.routes, '  ', _components, 1)
 %><%= uniqBy(_components, '_name').map((route) => {
   if (!route.component) return ''
   const path = relativeToBuild(route.component)
@@ -98,6 +98,6 @@ export const routerOptions = {
   fallback: <%= router.fallback %>
 }
 
-export function createRouter() {
+export function createRouter () {
   return new Router(routerOptions)
 }

--- a/packages/vue-app/template/router.scrollBehavior.js
+++ b/packages/vue-app/template/router.scrollBehavior.js
@@ -1,5 +1,7 @@
 <% if (router.scrollBehavior) { %>
+<%= isTest ? '/* eslint-disable quotes, semi, indent, comma-spacing, key-spacing, object-curly-spacing, space-before-function-paren  */' : '' %>
 export default <%= serializeFunction(router.scrollBehavior) %>
+<%= isTest ? '/* eslint-enable quotes, semi, indent, comma-spacing, key-spacing, object-curly-spacing, space-before-function-paren  */' : '' %>
 <% } else { %>import { getMatchedComponents } from './utils'
 
 if (process.client) {
@@ -67,6 +69,7 @@ export default function (to, from, savedPosition) {
             position = { selector: hash }
           }
         } catch (e) {
+          <%= isTest ? '// eslint-disable-next-line no-console' : '' %>
           console.warn('Failed to save scroll position. Please add CSS.escape() polyfill (https://github.com/mathiasbynens/CSS.escape).')
         }
       }

--- a/packages/vue-app/template/server.js
+++ b/packages/vue-app/template/server.js
@@ -5,11 +5,11 @@ import Vue from 'vue'
 import {
   <% if (features.asyncData) { %>applyAsyncData,<% } %>
   <% if (features.middleware) { %>middlewareSeries,<% } %>
+  <% if (features.middleware && features.layouts) { %>sanitizeComponent,<% } %>
   getMatchedComponents,
-  promisify,
-  sanitizeComponent
+  promisify
 } from './utils.js'
-import { createApp, NuxtError } from './index.js'
+import { createApp<% if (features.layouts) { %>, NuxtError<% } %> } from './index.js'
 import NuxtLink from './components/nuxt-link.server.js' // should be included after ./index.js
 
 // Component: <NuxtLink>
@@ -20,7 +20,7 @@ Vue.component(NuxtLink.name, NuxtLink)
 
 const noopApp = () => new Vue({ render: h => h('div') })
 
-function urlJoin() {
+function urlJoin () {
   return Array.prototype.slice.call(arguments).join('/').replace(/\/+/g, '/')
 }
 
@@ -114,13 +114,17 @@ export default async (ssrContext) => {
     try {
       await store.dispatch('nuxtServerInit', app.context)
     } catch (err) {
-      console.debug('Error occurred when calling nuxtServerInit: ', err.message)
+      console.debug('Error occurred when calling nuxtServerInit: ', err.message)<%= isTest ? '// eslint-disable-line no-console' : '' %>
       throw err
     }
   }
   // ...If there is a redirect or an error, stop the process
-  if (ssrContext.redirected) return noopApp()
-  if (ssrContext.nuxt.error) return renderErrorPage()
+  if (ssrContext.redirected) {
+    return noopApp()
+  }
+  if (ssrContext.nuxt.error) {
+    return renderErrorPage()
+  }
   <% } %>
 
   <% if (features.middleware) { %>
@@ -129,7 +133,9 @@ export default async (ssrContext) => {
   */
   let midd = <%= serialize(router.middleware).replace('middleware(', 'function(') %><%= isTest ? '// eslint-disable-line' : '' %>
   midd = midd.map((name) => {
-    if (typeof name === 'function') return name
+    if (typeof name === 'function') {
+      return name
+    }
     if (typeof middleware[name] !== 'function') {
       app.context.error({ statusCode: 500, message: 'Unknown middleware ' + name })
     }
@@ -137,8 +143,12 @@ export default async (ssrContext) => {
   })
   await middlewareSeries(midd, app.context)
   // ...If there is a redirect or an error, stop the process
-  if (ssrContext.redirected) return noopApp()
-  if (ssrContext.nuxt.error) return renderErrorPage()
+  if (ssrContext.redirected) {
+    return noopApp()
+  }
+  if (ssrContext.nuxt.error) {
+    return renderErrorPage()
+  }
   <% } %>
 
   <% if (features.layouts) { %>
@@ -146,9 +156,13 @@ export default async (ssrContext) => {
   ** Set layout
   */
   let layout = Components.length ? Components[0].options.layout : NuxtError.layout
-  if (typeof layout === 'function') layout = layout(app.context)
+  if (typeof layout === 'function') {
+    layout = layout(app.context)
+  }
   await _app.loadLayout(layout)
-  if (ssrContext.nuxt.error) return renderErrorPage()
+  if (ssrContext.nuxt.error) {
+    return renderErrorPage()
+  }
   layout = _app.setLayout(layout)
   ssrContext.nuxt.layout = _app.layoutName
   <% } %>
@@ -170,7 +184,9 @@ export default async (ssrContext) => {
     }
   })
   midd = midd.map((name) => {
-    if (typeof name === 'function') return name
+    if (typeof name === 'function') {
+      return name
+    }
     if (typeof middleware[name] !== 'function') {
       app.context.error({ statusCode: 500, message: 'Unknown middleware ' + name })
     }
@@ -178,8 +194,12 @@ export default async (ssrContext) => {
   })
   await middlewareSeries(midd, app.context)
   // ...If there is a redirect or an error, stop the process
-  if (ssrContext.redirected) return noopApp()
-  if (ssrContext.nuxt.error) return renderErrorPage()
+  if (ssrContext.redirected) {
+    return noopApp()
+  }
+  if (ssrContext.nuxt.error) {
+    return renderErrorPage()
+  }
   <% } %>
 
   <% if (features.validate) { %>
@@ -211,14 +231,18 @@ export default async (ssrContext) => {
   // ...If .validate() returned false
   if (!isValid) {
     // Don't server-render the page in generate mode
-    if (ssrContext._generate) ssrContext.nuxt.serverRendered = false
+    if (ssrContext._generate) {
+      ssrContext.nuxt.serverRendered = false
+    }
     // Render a 404 error page
     return render404Page()
   }
   <% } %>
 
   // If no Components found, returns 404
-  if (!Components.length) return render404Page()
+  if (!Components.length) {
+    return render404Page()
+  }
 
   <% if (features.asyncData || features.fetch) { %>
   // Call asyncData & fetch hooks on components matched by the route.
@@ -252,15 +276,19 @@ export default async (ssrContext) => {
     return Promise.all(promises)
   }))
 
-  <% if (debug) { %>if (process.env.DEBUG && asyncDatas.length)console.debug('Data fetching ' + ssrContext.url + ': ' + (Date.now() - s) + 'ms')<% } %>
+  <% if (debug) { %>if (process.env.DEBUG && asyncDatas.length) console.debug('Data fetching ' + ssrContext.url + ': ' + (Date.now() - s) + 'ms')<% } %>
 
   // datas are the first row of each
   ssrContext.nuxt.data = asyncDatas.map(r => r[0] || {})
   <% } %>
 
   // ...If there is a redirect or an error, stop the process
-  if (ssrContext.redirected) return noopApp()
-  if (ssrContext.nuxt.error) return renderErrorPage()
+  if (ssrContext.redirected) {
+    return noopApp()
+  }
+  if (ssrContext.nuxt.error) {
+    return renderErrorPage()
+  }
 
   // Call beforeNuxtRender methods & add store state
   await beforeRender()

--- a/packages/vue-app/template/store.js
+++ b/packages/vue-app/template/store.js
@@ -3,6 +3,11 @@ import Vuex from 'vuex'
 
 Vue.use(Vuex)
 
+<%
+const willResolveStoreModules = storeModules.some(s => s.src.indexOf('index.') !== 0)
+if (willResolveStoreModules) { %>
+const VUEX_PROPERTIES = ['state', 'getters', 'actions', 'mutations']
+<% } %>
 let store = {}
 
 void (function updateModules () {
@@ -73,9 +78,7 @@ function normalizeModule (moduleData, filePath) {
   return moduleData
 }
 
-<% if (storeModules.some(s => s.src.indexOf('index.') !== 0)) { %>
-const VUEX_PROPERTIES = ['state', 'getters', 'actions', 'mutations']
-
+<% if (willResolveStoreModules) { %>
 function resolveStoreModules (moduleData, filename) {
   moduleData = moduleData.default || moduleData
   // Remove store src + extension (./foo/index.js -> foo/index)

--- a/packages/vue-app/template/store.js
+++ b/packages/vue-app/template/store.js
@@ -3,10 +3,9 @@ import Vuex from 'vuex'
 
 Vue.use(Vuex)
 
-const VUEX_PROPERTIES = ['state', 'getters', 'actions', 'mutations']
 let store = {}
 
-void (function updateModules() {
+void (function updateModules () {
   <% storeModules.some(s => {
     if(s.src.indexOf('index.') === 0) { %>
   store = normalizeRoot(require('<%= relativeToBuild(srcDir, dir.store, s.src) %>'), '<%= dir.store %>/<%= s.src %>')
@@ -15,6 +14,7 @@ void (function updateModules() {
   // If store is an exported method = classic mode (deprecated)
   <% if (isDev) { %>
   if (typeof store === 'function') {
+    <%= isTest ? '// eslint-disable-next-line no-console' : '' %>
     return console.warn('Classic mode for store/ is deprecated and will be removed in Nuxt 3.')
   }<% } %>
 
@@ -47,7 +47,36 @@ export const createStore = store instanceof Function ? store : () => {
   }, store))
 }
 
-function resolveStoreModules(moduleData, filename) {
+function normalizeRoot (moduleData, filePath) {
+  moduleData = moduleData.default || moduleData
+
+  if (moduleData.commit) {
+    throw new Error(`[nuxt] ${filePath} should export a method that returns a Vuex instance.`)
+  }
+
+  if (typeof moduleData !== 'function') {
+    // Avoid TypeError: setting a property that has only a getter when overwriting top level keys
+    moduleData = Object.assign({}, moduleData)
+  }
+  return normalizeModule(moduleData, filePath)
+}
+
+function normalizeModule (moduleData, filePath) {
+  if (moduleData.state && typeof moduleData.state !== 'function') {
+    <%= isTest ? '// eslint-disable-next-line no-console' : '' %>
+    console.warn(`'state' should be a method that returns an object in ${filePath}`)
+
+    const state = Object.assign({}, moduleData.state)
+    // Avoid TypeError: setting a property that has only a getter when overwriting top level keys
+    moduleData = Object.assign({}, moduleData, { state: () => state })
+  }
+  return moduleData
+}
+
+<% if (storeModules.some(s => s.src.indexOf('index.') !== 0)) { %>
+const VUEX_PROPERTIES = ['state', 'getters', 'actions', 'mutations']
+
+function resolveStoreModules (moduleData, filename) {
   moduleData = moduleData.default || moduleData
   // Remove store src + extension (./foo/index.js -> foo/index)
   const namespace = filename.replace(/\.(<%= extensions %>)$/, '')
@@ -87,22 +116,9 @@ function resolveStoreModules(moduleData, filename) {
   }
 }
 
-function normalizeRoot(moduleData, filePath) {
-  moduleData = moduleData.default || moduleData
-
-  if (moduleData.commit) {
-    throw new Error(`[nuxt] ${filePath} should export a method that returns a Vuex instance.`)
-  }
-
+function normalizeState (moduleData, filePath) {
   if (typeof moduleData !== 'function') {
-    // Avoid TypeError: setting a property that has only a getter when overwriting top level keys
-    moduleData = Object.assign({}, moduleData)
-  }
-  return normalizeModule(moduleData, filePath)
-}
-
-function normalizeState(moduleData, filePath) {
-  if (typeof moduleData !== 'function') {
+    <%= isTest ? '// eslint-disable-next-line no-console' : '' %>
     console.warn(`${filePath} should export a method that returns an object`)
     const state = Object.assign({}, moduleData)
     return () => state
@@ -110,17 +126,7 @@ function normalizeState(moduleData, filePath) {
   return normalizeModule(moduleData, filePath)
 }
 
-function normalizeModule(moduleData, filePath) {
-  if (moduleData.state && typeof moduleData.state !== 'function') {
-    console.warn(`'state' should be a method that returns an object in ${filePath}`)
-    const state = Object.assign({}, moduleData.state)
-    // Avoid TypeError: setting a property that has only a getter when overwriting top level keys
-    moduleData = Object.assign({}, moduleData, { state: () => state })
-  }
-  return moduleData
-}
-
-function getStoreModule(storeModule, namespaces, { isProperty = false } = {}) {
+function getStoreModule (storeModule, namespaces, { isProperty = false } = {}) {
   // If ./mutations.js
   if (!namespaces.length || (isProperty && namespaces.length === 1)) {
     return storeModule
@@ -135,8 +141,10 @@ function getStoreModule(storeModule, namespaces, { isProperty = false } = {}) {
   return getStoreModule(storeModule.modules[namespace], namespaces, { isProperty })
 }
 
-function mergeProperty(storeModule, moduleData, property) {
-  if (!moduleData) return
+function mergeProperty (storeModule, moduleData, property) {
+  if (!moduleData) {
+    return
+  }
 
   if (property === 'state') {
     storeModule.state = moduleData || storeModule.state
@@ -144,3 +152,4 @@ function mergeProperty(storeModule, moduleData, property) {
     storeModule[property] = Object.assign({}, storeModule[property], moduleData)
   }
 }
+<% } %>

--- a/packages/vue-app/template/utils.js
+++ b/packages/vue-app/template/utils.js
@@ -9,20 +9,20 @@ if (process.client) {
   }
 }
 
-export function empty() {}
+export function empty () {}
 
-export function globalHandleError(error) {
+export function globalHandleError (error) {
   if (Vue.config.errorHandler) {
     Vue.config.errorHandler(error)
   }
 }
 
-export function interopDefault(promise) {
+export function interopDefault (promise) {
   return promise.then(m => m.default || m)
 }
 
 <% if (features.asyncData) { %>
-export function applyAsyncData(Component, asyncData) {
+export function applyAsyncData (Component, asyncData) {
   if (
     // For SSR, we once all this function without second param to just apply asyncData
     // Prevent doing this for each SSR request
@@ -50,7 +50,7 @@ export function applyAsyncData(Component, asyncData) {
 }
 <% } %>
 
-export function sanitizeComponent(Component) {
+export function sanitizeComponent (Component) {
   // If Component already sanitized
   if (Component.options && Component._Ctor === Component) {
     return Component
@@ -69,7 +69,7 @@ export function sanitizeComponent(Component) {
   return Component
 }
 
-export function getMatchedComponents(route, matches = false, prop = 'components') {
+export function getMatchedComponents (route, matches = false, prop = 'components') {
   return Array.prototype.concat.apply([], route.matched.map((m, index) => {
     return Object.keys(m[prop]).map((key) => {
       matches && matches.push(index)
@@ -78,11 +78,11 @@ export function getMatchedComponents(route, matches = false, prop = 'components'
   }))
 }
 
-export function getMatchedComponentsInstances(route, matches = false) {
+export function getMatchedComponentsInstances (route, matches = false) {
   return getMatchedComponents(route, matches, 'instances')
 }
 
-export function flatMapComponents(route, fn) {
+export function flatMapComponents (route, fn) {
   return Array.prototype.concat.apply([], route.matched.map((m, index) => {
     return Object.keys(m.components).reduce((promises, key) => {
       if (m.components[key]) {
@@ -95,7 +95,7 @@ export function flatMapComponents(route, fn) {
   }))
 }
 
-export function resolveRouteComponents(route, fn) {
+export function resolveRouteComponents (route, fn) {
   return Promise.all(
     flatMapComponents(route, async (Component, instance, match, key) => {
       // If component is a function, resolve it
@@ -108,7 +108,7 @@ export function resolveRouteComponents(route, fn) {
   )
 }
 
-export async function getRouteData(route) {
+export async function getRouteData (route) {
   if (!route) {
     return
   }
@@ -123,7 +123,7 @@ export async function getRouteData(route) {
   }
 }
 
-export async function setContext(app, context) {
+export async function setContext (app, context) {
   // If context not defined, create it
   if (!app.context) {
     app.context = {
@@ -217,7 +217,7 @@ export async function setContext(app, context) {
   app.context.query = app.context.route.query || {}
 }
 <% if (features.middleware) { %>
-export function middlewareSeries(promises, appContext) {
+export function middlewareSeries (promises, appContext) {
   if (!promises.length || appContext._redirected || appContext._errored) {
     return Promise.resolve()
   }
@@ -227,7 +227,7 @@ export function middlewareSeries(promises, appContext) {
     })
 }
 <% } %>
-export function promisify(fn, context) {
+export function promisify (fn, context) {
   <% if (features.deprecations) { %>
   let promise
   if (fn.length === 2) {
@@ -250,7 +250,7 @@ export function promisify(fn, context) {
     promise = fn(context)
   }
   <% } else { %>
-    const promise = fn(context)
+  const promise = fn(context)
   <% } %>
   if (promise && promise instanceof Promise && typeof promise.then === 'function') {
     return promise
@@ -259,7 +259,7 @@ export function promisify(fn, context) {
 }
 
 // Imported from vue-router
-export function getLocation(base, mode) {
+export function getLocation (base, mode) {
   let path = decodeURI(window.location.pathname)
   if (mode === 'hash') {
     return window.location.hash.replace(/^#\//, '')
@@ -279,11 +279,11 @@ export function getLocation(base, mode) {
  * @param  {Object=}            options
  * @return {!function(Object=, Object=)}
  */
-export function compile(str, options) {
+export function compile (str, options) {
   return tokensToFunction(parse(str, options))
 }
 
-export function getQueryDiff(toQuery, fromQuery) {
+export function getQueryDiff (toQuery, fromQuery) {
   const diff = {}
   const queries = { ...toQuery, ...fromQuery }
   for (const k in queries) {
@@ -294,7 +294,7 @@ export function getQueryDiff(toQuery, fromQuery) {
   return diff
 }
 
-export function normalizeError(err) {
+export function normalizeError (err) {
   let message
   if (!(err.message || typeof err === 'string')) {
     try {
@@ -337,7 +337,7 @@ const PATH_REGEXP = new RegExp([
  * @param  {Object=} options
  * @return {!Array}
  */
-function parse(str, options) {
+function parse (str, options) {
   const tokens = []
   let key = 0
   let index = 0
@@ -409,7 +409,7 @@ function parse(str, options) {
  * @param  {string}
  * @return {string}
  */
-function encodeURIComponentPretty(str, slashAllowed) {
+function encodeURIComponentPretty (str, slashAllowed) {
   const re = slashAllowed ? /[?#]/g : /[/?#]/g
   return encodeURI(str).replace(re, (c) => {
     return '%' + c.charCodeAt(0).toString(16).toUpperCase()
@@ -422,7 +422,7 @@ function encodeURIComponentPretty(str, slashAllowed) {
  * @param  {string}
  * @return {string}
  */
-function encodeAsterisk(str) {
+function encodeAsterisk (str) {
   return encodeURIComponentPretty(str, true)
 }
 
@@ -432,7 +432,7 @@ function encodeAsterisk(str) {
  * @param  {string} str
  * @return {string}
  */
-function escapeString(str) {
+function escapeString (str) {
   return str.replace(/([.+*?=^!:${}()[\]|/\\])/g, '\\$1')
 }
 
@@ -442,14 +442,14 @@ function escapeString(str) {
  * @param  {string} group
  * @return {string}
  */
-function escapeGroup(group) {
+function escapeGroup (group) {
   return group.replace(/([=!:$/()])/g, '\\$1')
 }
 
 /**
  * Expose a method for transforming tokens into the path function.
  */
-function tokensToFunction(tokens) {
+function tokensToFunction (tokens) {
   // Compile all the tokens into regexps.
   const matches = new Array(tokens.length)
 
@@ -537,7 +537,7 @@ function tokensToFunction(tokens) {
  * @param  {string} query
  * @return {string}
  */
-function formatUrl(url, query) {
+function formatUrl (url, query) {
   <% if (features.clientUseUrl) { %>
   url = new URL(url, top.location.href)
   for (const key in query) {
@@ -592,7 +592,7 @@ function formatUrl(url, query) {
  * @param  {object} query
  * @return {string}
  */
-function formatQuery(query) {
+function formatQuery (query) {
   return Object.keys(query).sort().map((key) => {
     const val = query[key]
     if (val == null) {

--- a/packages/vue-app/template/views/loading/default.html
+++ b/packages/vue-app/template/views/loading/default.html
@@ -98,7 +98,9 @@
 <script>
 window.addEventListener('error', function () {
   var e = document.getElementById('nuxt-loading');
-  if (e) e.className += ' error';
+  if (e) {
+    e.className += ' error';
+  }
 });
 </script>
 

--- a/test/unit/unicode-base.size-limit.test.js
+++ b/test/unit/unicode-base.size-limit.test.js
@@ -21,7 +21,7 @@ describe('nuxt minimal vue-app bundle size limit', () => {
     const filter = filename => filename === 'vue-app.nuxt.js'
     const legacyResourcesSize = await getResourcesSize(distDir, 'client', { filter })
 
-    const LEGACY_JS_RESOURCES_KB_SIZE = 15.8
+    const LEGACY_JS_RESOURCES_KB_SIZE = 15.2
     expect(legacyResourcesSize.uncompressed).toBeWithinSize(LEGACY_JS_RESOURCES_KB_SIZE)
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -4615,10 +4615,10 @@ eslint-module-utils@^2.4.0:
     debug "^2.6.8"
     pkg-dir "^2.0.0"
 
-eslint-multiplexer@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.npmjs.org/eslint-multiplexer/-/eslint-multiplexer-1.0.4.tgz#4dde202fa2c9edc2ee802ab4b8fdb02a49b6d596"
-  integrity sha512-KdakcevBFb6n4VQBRY7u+wFqyREzz1QYJRuuPNHUcK5hN1XOikJIEC5Qf+28ZRIvHkoxiw/CW//LNAAyQzxaiQ==
+eslint-multiplexer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/eslint-multiplexer/-/eslint-multiplexer-2.0.0.tgz#34d00218f5027b417b89a4add81f1536d4197a7d"
+  integrity sha512-hZA86lQ6d3srMwVlEjYVsX24mk/AImm4zL0r0AR8jNsJYoznQT7O2xgeaT6gNsLIxzRP79VkpeMVRxu4+GRWOA==
   dependencies:
     cross-spawn "^6.0.5"
     minimist "^1.2.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

Maybe we should start looking for a more constructive way of composing the templates. Especially now with the `feature` flags the amount of configurable code paths is becoming almost unmaintainable and makes the templates quite unreadable. Eg I'm quite sure that certain methods from `utils.js` could actually still be removed for certain feature flag combinations.

Not sure how we could solve that except maybe by splitting the template compilation in to two steps, first generate templates based on the enabled features then compile with the configured options.

This pr also upgrades eslint-multiplexer to v2.0.0 which makes #6291 obsolete. Creating a new pr is easier then trying to fix this within the renovate pr.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

