### PR TITLE
fix(vue-renderer): clone options.head before generating meta tags in spa mode

### DIFF
--- a/packages/vue-renderer/src/renderers/spa.js
+++ b/packages/vue-renderer/src/renderers/spa.js
@@ -53,7 +53,7 @@ export default class SPARenderer extends BaseRenderer {
       if (typeof this.options.head === 'function') {
         head = this.options.head()
       } else {
-        head = this.options.head
+        head = cloneDeep(this.options.head)
       }
 
       const m = VueMeta.generate(head || {}, this.vueMetaConfig)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

Resolves: #6428

vue-meta mutates the metaInfo object it receives, which could cause issues as in the linked issue.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

