### PR TITLE
fix(vue-app): clear idle callback

### DIFF
--- a/packages/vue-app/template/components/nuxt-link.client.js
+++ b/packages/vue-app/template/components/nuxt-link.client.js
@@ -10,6 +10,11 @@ const requestIdleCallback = window.requestIdleCallback ||
       })
     }, 1)
   }
+
+const cancelIdleCallback = window.cancelIdleCallback || function (id) {
+  clearTimeout(id)
+}
+
 const observer = window.IntersectionObserver && new window.IntersectionObserver((entries) => {
   entries.forEach(({ intersectionRatio, target: link }) => {
     if (intersectionRatio <= 0) {
@@ -35,10 +40,12 @@ export default {
   },
   mounted () {
     if (!this.noPrefetch) {
-      requestIdleCallback(this.observe, { timeout: 2e3 })
+      this.handleId = requestIdleCallback(this.observe, { timeout: 2e3 })
     }
   },
   beforeDestroy () {
+    cancelIdleCallback(this.handleId)
+
     if (this.__observed) {
       observer.unobserve(this.$el)
       delete this.$el.__prefetch

--- a/packages/vue-app/template/components/nuxt-link.client.js
+++ b/packages/vue-app/template/components/nuxt-link.client.js
@@ -85,7 +85,7 @@ export default {
       if (!this.canPrefetch()) {
         return
       }
-      // Stop obersing this link (in case of internet connection changes)
+      // Stop observing this link (in case of internet connection changes)
       observer.unobserve(this.$el)
       const Components = this.getPrefetchComponents()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

In my search for an elusive memory leak yesterday I found this potential issue. In edge cases `nuxt-link.client` could cause a memory leak when the component is destroyed before the initial idle callback has been triggered. I am not fully sure that's even technically possible (i think not), but better safe then sorry.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

