### PR TITLE
feat(server): add config option to define etag hash function

### DIFF
--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -219,6 +219,18 @@ export function getNuxtConfig (_options) {
     options.debug = options.dev
   }
 
+  // Validate that etag.hash is a function, if not unset it
+  if (options.render.etag) {
+    const { hash } = options.render.etag
+    if (hash) {
+      const isFn = typeof hash === 'function'
+      if (options.dev && !isFn) {
+        options.render.etag.hash = undefined
+        consola.warn(`render.etag.hash should be a function, received ${typeof hash} instead`)
+      }
+    }
+  }
+
   // Apply default hash to CSP option
   if (options.render.csp) {
     options.render.csp = defaults({}, options.render.csp, {

--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -224,9 +224,12 @@ export function getNuxtConfig (_options) {
     const { hash } = options.render.etag
     if (hash) {
       const isFn = typeof hash === 'function'
-      if (options.dev && !isFn) {
+      if (!isFn) {
         options.render.etag.hash = undefined
-        consola.warn(`render.etag.hash should be a function, received ${typeof hash} instead`)
+
+        if (options.dev) {
+          consola.warn(`render.etag.hash should be a function, received ${typeof hash} instead`)
+        }
       }
     }
   }

--- a/packages/config/test/options.test.js
+++ b/packages/config/test/options.test.js
@@ -87,6 +87,16 @@ describe('config: options', () => {
     expect(store).toEqual(true)
   })
 
+  test('should unset and warn when etag.hash not a function', () => {
+    const { render: { etag } } = getNuxtConfig({ render: { etag: { hash: true } } })
+    expect(etag).toMatchObject({ hash: undefined })
+    expect(consola.warn).not.toHaveBeenCalledWith('render.etag.hash should be a function, received boolean instead')
+
+    const { render: { etag: etagDev } } = getNuxtConfig({ dev: true, render: { etag: { hash: true } } })
+    expect(etagDev).toMatchObject({ hash: undefined })
+    expect(consola.warn).toHaveBeenCalledWith('render.etag.hash should be a function, received boolean instead')
+  })
+
   test('should enable csp', () => {
     const { render: { csp } } = getNuxtConfig({ render: { csp: { allowedSources: true, test: true } } })
     expect(csp).toEqual({

--- a/packages/server/src/middleware/nuxt.js
+++ b/packages/server/src/middleware/nuxt.js
@@ -38,10 +38,8 @@ export default ({ options, nuxt, renderRoute, resources }) => async function nux
 
     // Add ETag header
     if (!error && options.render.etag) {
-      const etagArg = { value: undefined }
-      await nuxt.callHook('render:generateETag', html, etagArg)
-
-      const etag = etagArg.value || generateETag(html, options.render.etag)
+      const { hash } = options.render.etag
+      const etag = (hash && hash(html)) || generateETag(html, options.render.etag)
       if (fresh(req.headers, { etag })) {
         res.statusCode = 304
         res.end()

--- a/packages/server/src/middleware/nuxt.js
+++ b/packages/server/src/middleware/nuxt.js
@@ -38,7 +38,10 @@ export default ({ options, nuxt, renderRoute, resources }) => async function nux
 
     // Add ETag header
     if (!error && options.render.etag) {
-      const etag = generateETag(html, options.render.etag)
+      const etagArg = { value: undefined }
+      await nuxt.callHook('render:generateETag', html, etagArg)
+
+      const etag = etagArg.value || generateETag(html, options.render.etag)
       if (fresh(req.headers, { etag })) {
         res.statusCode = 304
         res.end()

--- a/packages/server/src/middleware/nuxt.js
+++ b/packages/server/src/middleware/nuxt.js
@@ -39,7 +39,7 @@ export default ({ options, nuxt, renderRoute, resources }) => async function nux
     // Add ETag header
     if (!error && options.render.etag) {
       const { hash } = options.render.etag
-      const etag = (hash && hash(html)) || generateETag(html, options.render.etag)
+      const etag = hash ? hash(html, options.render.etag) : generateETag(html, options.render.etag)
       if (fresh(req.headers, { etag })) {
         res.statusCode = 304
         res.end()

--- a/packages/server/test/middleware/nuxt.test.js
+++ b/packages/server/test/middleware/nuxt.test.js
@@ -119,20 +119,17 @@ describe('server: nuxtMiddleware', () => {
 
   test('should set etag after rendering through hook', async () => {
     const context = createContext()
-    context.nuxt.callHook.mockImplementation((name, html, etagArg) => {
-      if (name === 'render:generateETag') {
-        etagArg.value = 'etag-hook'
-      }
-    })
+    const hash = jest.fn(() => 'etag-hook')
+    context.options.render.etag = { hash }
+
     const result = { html: 'rendered html' }
     context.renderRoute.mockReturnValue(result)
-    context.options.render.etag = true
     const nuxtMiddleware = createNuxtMiddleware(context)
     const { req, res, next } = createServerContext()
 
     await nuxtMiddleware(req, res, next)
 
-    expect(context.nuxt.callHook).toBeCalledWith('render:generateETag', 'rendered html', { value: expect.anything() })
+    expect(hash).toBeCalledWith('rendered html')
     expect(res.setHeader).nthCalledWith(1, 'ETag', 'etag-hook')
   })
 

--- a/packages/server/test/middleware/nuxt.test.js
+++ b/packages/server/test/middleware/nuxt.test.js
@@ -129,7 +129,7 @@ describe('server: nuxtMiddleware', () => {
 
     await nuxtMiddleware(req, res, next)
 
-    expect(hash).toBeCalledWith('rendered html')
+    expect(hash).toBeCalledWith('rendered html', expect.any(Object))
     expect(res.setHeader).nthCalledWith(1, 'ETag', 'etag-hook')
   })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

While looking into some benchmarks, @aldarund found out that generating the etag could snoop up a lot of processing time (especially with large html, ie `extractCss: false`). Further investigation found that the etag module uses `SHA1` for generating a hash of the full html body.

This pr introduces a new config option `render.etag.hash` which users can use to implement their own etag hash function. Ie for etags it should often be fine to use a non-cryptographic hash function like murmurhash, which is multiple times faster with larger html body sizes.

Note: the `render.etag.weak` option is ignored when using the hook, user is responsible for implementing that.

Example  for using [murmurhash-native](https://github.com/royaltm/node-murmurhash-native) instead:
```js
// nuxt.config.js
import { murmurHash128 } from 'murmurhash-native'

export default {
  render: {
    etag: {
      hash: html => murmurHash128(html)
    }
  }
}
```

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

