### PR TITLE
fix(cli): server should not be initialized in nuxt build

### DIFF
--- a/packages/cli/src/commands/build.js
+++ b/packages/cli/src/commands/build.js
@@ -61,7 +61,7 @@ export default {
     }
   },
   async run (cmd) {
-    const config = await cmd.getNuxtConfig({ dev: false, _build: true })
+    const config = await cmd.getNuxtConfig({ dev: false, server: false, _build: true })
     const nuxt = await cmd.getNuxt(config)
 
     if (cmd.argv.lock) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

As `server.js` and `vue-renderer` are also be created in building, so `server.ready` and `loaderResources` will be executed which should only be executed in `dev` or `start`, this pr is for avoiding calling server ready and incorrect options change (like modern mode detect) which is only for server rendering.

@pi0 I removed `_build` in `dev` since it should be only for `build`. And I didn't see any where is using it, if there is any concern, I can add another filed in `build`. 

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

