### PR TITLE
fix(webpack): dont push to compilersWatching in callback

### DIFF
--- a/packages/builder/src/builder.js
+++ b/packages/builder/src/builder.js
@@ -157,6 +157,9 @@ export default class Builder {
     // Generate routes and interpret the template files
     await this.generateRoutesAndFiles()
 
+    // Add vue-app template dir to watchers
+    this.options.build.watch.push(this.globPathWithExtensions(this.template.dir))
+
     await this.resolvePlugins()
 
     // Start bundle build: webpack, rollup, parcel...
@@ -243,9 +246,6 @@ export default class Builder {
     await this.resolveCustomTemplates(templateContext)
 
     await this.resolveLoadingIndicator(templateContext)
-
-    // Add vue-app template dir to watchers
-    this.options.build.watch.push(this.globPathWithExtensions(this.template.dir))
 
     await this.compileTemplates(templateContext)
 

--- a/packages/builder/test/__utils__/index.js
+++ b/packages/builder/test/__utils__/index.js
@@ -2,7 +2,9 @@ export const createNuxt = () => ({
   options: {
     globalName: 'global_name',
     globals: [],
-    build: {},
+    build: {
+      watch: []
+    },
     router: {},
     dir: {
       app: 'app'

--- a/packages/builder/test/builder.build.test.js
+++ b/packages/builder/test/builder.build.test.js
@@ -33,6 +33,7 @@ describe('builder: builder build', () => {
     nuxt.options.srcDir = '/var/nuxt/src'
     nuxt.options.buildDir = '/var/nuxt/build'
     nuxt.options.dir = { pages: '/var/nuxt/src/pages' }
+    nuxt.options.build.template = { dir: '/var/nuxt/src/template' }
     nuxt.options.build.createRoutes = jest.fn()
 
     const bundleBuilder = { build: jest.fn() }
@@ -70,6 +71,7 @@ describe('builder: builder build', () => {
     expect(r).nthCalledWith(3, '/var/nuxt/build', 'dist', 'client')
     expect(r).nthCalledWith(4, '/var/nuxt/build', 'dist', 'server')
     expect(builder.generateRoutesAndFiles).toBeCalledTimes(1)
+    expect(nuxt.options.build.watch).toEqual(['/var/nuxt/src/template/**/*.{vue,js}'])
     expect(builder.resolvePlugins).toBeCalledTimes(1)
     expect(bundleBuilder.build).toBeCalledTimes(1)
     expect(builder._buildStatus).toEqual(2)

--- a/packages/builder/test/builder.generate.test.js
+++ b/packages/builder/test/builder.generate.test.js
@@ -82,7 +82,7 @@ describe('builder: builder generate', () => {
     expect(builder.addOptionalTemplates).toBeCalledTimes(1)
     expect(builder.resolveCustomTemplates).toBeCalledTimes(1)
     expect(builder.resolveLoadingIndicator).toBeCalledTimes(1)
-    expect(builder.options.build.watch).toEqual(['/var/nuxt/src/template/**/*.{vue,js}'])
+    expect(builder.options.build.watch).toEqual([])
     expect(builder.compileTemplates).toBeCalledTimes(1)
     expect(consola.success).toBeCalledTimes(1)
     expect(consola.success).toBeCalledWith('Nuxt files generated')
@@ -237,6 +237,7 @@ describe('builder: builder generate', () => {
     const nuxt = createNuxt()
     nuxt.options.srcDir = '/var/nuxt/src'
     nuxt.options.build = {
+      watch: [],
       template: { dir: '/var/nuxt/templates' },
       templates: [
         '/var/nuxt/templates/foo.js',
@@ -275,6 +276,7 @@ describe('builder: builder generate', () => {
       name: 'test_loading_indicator'
     }
     nuxt.options.build = {
+      watch: [],
       template: { dir: '/var/nuxt/templates' }
     }
     const builder = new Builder(nuxt, BundleBuilder)
@@ -301,6 +303,7 @@ describe('builder: builder generate', () => {
       name: '@/app/template.vue'
     }
     nuxt.options.build = {
+      watch: [],
       template: { dir: '/var/nuxt/templates' }
     }
     const builder = new Builder(nuxt, BundleBuilder)
@@ -330,6 +333,7 @@ describe('builder: builder generate', () => {
       name: '@/app/empty.vue'
     }
     nuxt.options.build = {
+      watch: [],
       template: { dir: '/var/nuxt/templates' }
     }
     const builder = new Builder(nuxt, BundleBuilder)
@@ -599,6 +603,7 @@ describe('builder: builder generate', () => {
       const nuxt = createNuxt()
       nuxt.options.srcDir = '/var/nuxt/src'
       nuxt.options.build = {
+        watch: [],
         createRoutes: jest.fn(),
         template: { dir: '/var/nuxt/templates' }
       }
@@ -642,6 +647,7 @@ describe('builder: builder generate', () => {
         pages: '/var/nuxt/pages'
       }
       nuxt.options.build = {
+        watch: [],
         createRoutes: jest.fn()
       }
       nuxt.options.router = {

--- a/packages/webpack/src/builder.js
+++ b/packages/webpack/src/builder.js
@@ -136,10 +136,11 @@ export class WebpackBundler {
           if (err) {
             return reject(err)
           }
-          watching.close = pify(watching.close)
-          this.compilersWatching.push(watching)
           resolve()
         })
+
+        watching.close = pify(watching.close)
+        this.compilersWatching.push(watching)
       })
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

Possible fix for #6442 (but probably not)

The issue in webpack has been around for 10 months, but only until pause/resume was added in `v2.9.2` it started showing issues as on every server watcher callback the watcher instance was again added to the `compilersWatching` array.

## Unresolved issue

For me webpack doesnt properly reload after I add a new file:
- start hello-world example in dev mode
- add `pages/test1.vue`
- `grep -ir test1 examples/hello-world/.nuxt/`
```
.nuxt/router.js:const _24ea789e = () => interopDefault(import('../pages/test1.vue' /* webpackChunkName: "pages/test1" */))
.nuxt/router.js:    path: "/test1",
.nuxt/router.js:    name: "test1"
```
- `touch examples/hello-world/.nuxt/router.js`
- works:
```
...
.nuxt/dist/server/client.manifest.json:    "pages/test1.js"
...
```
Tried to fix this, but `router.js` _is_ properly updated before `resumeWatch` is called. Tried timeouts, nextTick, override resumeWatch by calling invalidate manually but nothing seemed to work. 

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

