### PR TITLE
feat(cli): catch build errors with `cli:buildError` hook

### DIFF
--- a/packages/cli/src/commands/dev.js
+++ b/packages/cli/src/commands/dev.js
@@ -27,16 +27,25 @@ export default {
   },
 
   async startDev (cmd, argv) {
+    let nuxt
     try {
-      const nuxt = await this._startDev(cmd, argv)
-
-      return nuxt
+      nuxt = await this._listenDev(cmd, argv)
     } catch (error) {
+      consola.fatal(error)
+      return
+    }
+
+    try {
+      await this._buildDev(cmd, argv, nuxt)
+    } catch (error) {
+      await nuxt.callHook('cli:buildError', error)
       consola.error(error)
     }
+
+    return nuxt
   },
 
-  async _startDev (cmd, argv) {
+  async _listenDev (cmd, argv) {
     const config = await cmd.getNuxtConfig({ dev: true, _build: true })
     const nuxt = await cmd.getNuxt(config)
 
@@ -60,6 +69,11 @@ export default {
       await Promise.all(openerPromises)
     }
 
+    // Return instance
+    return nuxt
+  },
+
+  async _buildDev (cmd, argv, nuxt) {
     // Create builder instance
     const builder = await cmd.getBuilder(nuxt)
 

--- a/packages/cli/test/unit/dev.test.js
+++ b/packages/cli/test/unit/dev.test.js
@@ -41,7 +41,7 @@ describe('dev', () => {
     expect(consola.error).not.toHaveBeenCalled()
   })
 
-  test('catches build error', async () => {
+  test('catches build error and calls hook', async () => {
     const Nuxt = mockNuxt()
     const Builder = mockBuilder()
 
@@ -55,6 +55,7 @@ describe('dev', () => {
     await Nuxt.fileRestartHook(builder)
 
     expect(Nuxt.prototype.close).toHaveBeenCalled()
+    expect(Nuxt.prototype.callHook).toHaveBeenCalledWith('cli:buildError', expect.any(Error))
     expect(consola.error).toHaveBeenCalledWith(new Error('Build Error'))
   })
 
@@ -88,7 +89,7 @@ describe('dev', () => {
     builder.nuxt = new Nuxt()
     await Nuxt.fileRestartHook(builder)
 
-    expect(consola.error).toHaveBeenCalledWith(new Error('Config Error'))
+    expect(consola.fatal).toHaveBeenCalledWith(new Error('Config Error'))
     // expect(Builder.prototype.watchRestart).toHaveBeenCalledTimes(1)
   })
 
@@ -104,7 +105,7 @@ describe('dev', () => {
 
     await NuxtCommand.from(dev).run()
 
-    expect(consola.error).toHaveBeenCalledWith(new Error('Listen Error'))
+    expect(consola.fatal).toHaveBeenCalledWith(new Error('Listen Error'))
   })
 
   test('dev doesnt force-exit by default', async () => {

--- a/packages/cli/test/utils/mocking.js
+++ b/packages/cli/test/utils/mocking.js
@@ -83,6 +83,7 @@ export const mockNuxt = (implementation) => {
       }
     },
     options: {},
+    callHook: jest.fn(),
     clearHook: jest.fn(),
     clearHooks: jest.fn(),
     close: jest.fn(),


### PR DESCRIPTION
refactor: errors during initiating/listening nuxt are non-recoverable thus should be fatal. Also some errors during the build are non-recoverable but not sure if thats _some_ or _all_, so dont make those fatal for now

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

When you were developing your app and eg added a plugin but made a typo, then the re-build of Nuxt would fail but the loading screen would not reflect that. The build error was only visible on the console, which can be confusing if you are not used to looking at the console for errors.

This pr changes that (together with https://github.com/nuxt/loading-screen/pull/45) to capture build errors in dev mode and print a stracktrace of them on the loading screen.

![image](https://user-images.githubusercontent.com/1067403/65815267-ce878f00-e1ed-11e9-9857-3ab700191361.png)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

