### PR TITLE
fix(config): typo in `unsafeInlineCompatibility` name

### DIFF
--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -241,7 +241,7 @@ export function getNuxtConfig (_options) {
       allowedSources: undefined,
       policies: undefined,
       addMeta: Boolean(options._generate),
-      unsafeInlineCompatiblity: false,
+      unsafeInlineCompatibility: false,
       reportOnly: options.debug
     })
   }

--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -244,6 +244,13 @@ export function getNuxtConfig (_options) {
       unsafeInlineCompatibility: false,
       reportOnly: options.debug
     })
+
+    // TODO: Remove this if statement in Nuxt 3, we will stop supporting this typo (more on: https://github.com/nuxt/nuxt.js/pull/6583)
+    if (options.render.csp.unsafeInlineCompatiblity) {
+      consola.warn('Using `unsafeInlineCompatiblity` is deprecated and will be removed in Nuxt 3. Use `unsafeInlineCompatibility` instead.')
+      options.render.csp.unsafeInlineCompatibility = options.render.csp.unsafeInlineCompatiblity
+      delete options.render.csp.unsafeInlineCompatiblity
+    }
   }
 
   // cssSourceMap

--- a/packages/config/test/options.test.js
+++ b/packages/config/test/options.test.js
@@ -110,6 +110,20 @@ describe('config: options', () => {
     })
   })
 
+  // TODO: Remove this test in Nuxt 3, we will stop supporting this typo (more on: https://github.com/nuxt/nuxt.js/pull/6583)
+  test('should enable csp with old typo property name, avoiding breaking changes', () => {
+    const { render: { csp } } = getNuxtConfig({ render: { csp: { allowedSources: true, test: true, unsafeInlineCompatiblity: true } } })
+    expect(csp).toEqual({
+      hashAlgorithm: 'sha256',
+      addMeta: false,
+      unsafeInlineCompatibility: true,
+      allowedSources: true,
+      policies: undefined,
+      reportOnly: false,
+      test: true
+    })
+  })
+
   test('should check unknown mode', () => {
     const { build, render } = getNuxtConfig({ mode: 'test' })
     expect(consola.warn).toHaveBeenCalledWith('Unknown mode: test. Falling back to universal')

--- a/packages/config/test/options.test.js
+++ b/packages/config/test/options.test.js
@@ -102,7 +102,7 @@ describe('config: options', () => {
     expect(csp).toEqual({
       hashAlgorithm: 'sha256',
       addMeta: false,
-      unsafeInlineCompatiblity: false,
+      unsafeInlineCompatibility: false,
       allowedSources: true,
       policies: undefined,
       reportOnly: false,

--- a/packages/vue-renderer/src/renderers/ssr.js
+++ b/packages/vue-renderer/src/renderers/ssr.js
@@ -138,7 +138,7 @@ export default class SSRRenderer extends BaseRenderer {
     if (csp) {
       // Only add the hash if 'unsafe-inline' rule isn't present to avoid conflicts (#5387)
       const containsUnsafeInlineScriptSrc = csp.policies && csp.policies['script-src'] && csp.policies['script-src'].includes(`'unsafe-inline'`)
-      if (csp.unsafeInlineCompatiblity || !containsUnsafeInlineScriptSrc) {
+      if (csp.unsafeInlineCompatibility || !containsUnsafeInlineScriptSrc) {
         const hash = crypto.createHash(csp.hashAlgorithm)
         hash.update(serializedSession)
         cspScriptSrcHashes.push(`'${csp.hashAlgorithm}-${hash.digest('base64')}'`)

--- a/test/unit/basic.ssr.csp.test.js
+++ b/test/unit/basic.ssr.csp.test.js
@@ -222,6 +222,33 @@ describe('basic ssr csp', () => {
         expect(headers[cspHeader]).toMatch(/script-src 'sha256-.*' 'self' 'unsafe-inline'$/)
       }
     )
+
+    // TODO: Remove this test in Nuxt 3, we will stop supporting this typo (more on: https://github.com/nuxt/nuxt.js/pull/6583)
+    test(
+      'Contain hash and \'unsafe-inline\' when the typo property unsafeInlineCompatiblity is enabled',
+      async () => {
+        const policies = {
+          'script-src': [`'unsafe-inline'`]
+        }
+
+        nuxt = await startCspServer({
+          unsafeInlineCompatiblity: true,
+          policies
+        })
+
+        for (let i = 0; i < 5; i++) {
+          await rp(url('/stateless'), {
+            resolveWithFullResponse: true
+          })
+        }
+
+        const { headers } = await rp(url('/stateful'), {
+          resolveWithFullResponse: true
+        })
+
+        expect(headers[cspHeader]).toMatch(/script-src 'sha256-.*' 'self' 'unsafe-inline'$/)
+      }
+    )
   })
 
   describe('debug mode', () => {
@@ -427,6 +454,33 @@ describe('basic ssr csp', () => {
 
         nuxt = await startCspServer({
           unsafeInlineCompatibility: true,
+          policies
+        })
+
+        for (let i = 0; i < 5; i++) {
+          await rp(url('/stateless'), {
+            resolveWithFullResponse: true
+          })
+        }
+
+        const { headers } = await rp(url('/stateful'), {
+          resolveWithFullResponse: true
+        })
+
+        expect(headers[cspHeader]).toMatch(/script-src 'sha256-.*' 'self' 'unsafe-inline'$/)
+      }
+    )
+
+    // TODO: Remove this test in Nuxt 3, we will stop supporting this typo (more on: https://github.com/nuxt/nuxt.js/pull/6583)
+    test(
+      'Contain hash and \'unsafe-inline\' when the typo property unsafeInlineCompatiblity is enabled',
+      async () => {
+        const policies = {
+          'script-src': [`'unsafe-inline'`]
+        }
+
+        nuxt = await startCspServer({
+          unsafeInlineCompatiblity: true,
           policies
         })
 

--- a/test/unit/basic.ssr.csp.test.js
+++ b/test/unit/basic.ssr.csp.test.js
@@ -198,14 +198,14 @@ describe('basic ssr csp', () => {
     )
 
     test(
-      'Contain hash and \'unsafe-inline\' when unsafeInlineCompatiblity is enabled',
+      'Contain hash and \'unsafe-inline\' when unsafeInlineCompatibility is enabled',
       async () => {
         const policies = {
           'script-src': [`'unsafe-inline'`]
         }
 
         nuxt = await startCspServer({
-          unsafeInlineCompatiblity: true,
+          unsafeInlineCompatibility: true,
           policies
         })
 
@@ -419,14 +419,14 @@ describe('basic ssr csp', () => {
     )
 
     test(
-      'Contain hash and \'unsafe-inline\' when unsafeInlineCompatiblity is enabled',
+      'Contain hash and \'unsafe-inline\' when unsafeInlineCompatibility is enabled',
       async () => {
         const policies = {
           'script-src': [`'unsafe-inline'`]
         }
 
         nuxt = await startCspServer({
-          unsafeInlineCompatiblity: true,
+          unsafeInlineCompatibility: true,
           policies
         })
 


### PR DESCRIPTION
Replacing all occurrences of `unsafeInlineCompatiblity` to `unsafeInlineCompatibility` (notice the missing "i" in "Compatibility".

## Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
**Edit:** Removed the [x] from "Breaking change", as it is now a non-breaking typo fix.

## Description
Just fixing a minor typo that can create confusion when typing this property (correctly) from memory. This can lead to wasted time in debugging a wrong property name.

Replacing all occurrences of `unsafeInlineCompatiblity` to `unsafeInlineCompatibility`.

**Note:** This can cause all apps using the old property name to stop working!

## Checklist:
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly. (PR: https://github.com/nuxt/docs/pull/1650)
- [X] I have added tests to cover my changes (if not applicable, please state why)
- [X] All new and existing tests are passing.

