### PR TITLE
examples(with-sockets): fix cannot read property 'app' of undefined on nuxt build

### DIFF
--- a/examples/with-sockets/io/index.js
+++ b/examples/with-sockets/io/index.js
@@ -2,23 +2,25 @@ import http from 'http'
 import socketIO from 'socket.io'
 
 export default function () {
-  const server = http.createServer(this.nuxt.renderer.app)
-  const io = socketIO(server)
+  this.nuxt.hook('render:before', (renderer) => {
+    const server = http.createServer(this.nuxt.renderer.app)
+    const io = socketIO(server)
 
-  // overwrite nuxt.server.listen()
-  this.nuxt.server.listen = (port, host) => new Promise(resolve => server.listen(port || 3000, host || 'localhost', resolve))
-  // close this server on 'close' event
-  this.nuxt.hook('close', () => new Promise(server.close))
+    // overwrite nuxt.server.listen()
+    this.nuxt.server.listen = (port, host) => new Promise(resolve => server.listen(port || 3000, host || 'localhost', resolve))
+    // close this server on 'close' event
+    this.nuxt.hook('close', () => new Promise(server.close))
 
-  // Add socket.io events
-  const messages = []
-  io.on('connection', (socket) => {
-    socket.on('last-messages', function (fn) {
-      fn(messages.slice(-50))
+    // Add socket.io events
+    const messages = []
+    io.on('connection', (socket) => {
+      socket.on('last-messages', function (fn) {
+        fn(messages.slice(-50))
+      })
+      socket.on('send-message', function (message) {
+        messages.push(message)
+        socket.broadcast.emit('new-message', message)
+      })
     })
-    socket.on('send-message', function (message) {
-      messages.push(message)
-      socket.broadcast.emit('new-message', message)
-    })
-  })
+  }
 }


### PR DESCRIPTION
The provided example works flawlessly in dev mode but when "nuxt build" is run, the build will fail with an error "Cannot read property 'app' of undefined" since the renderer is not available yet. By using the 'render:before' hook to assure that the renderer is available, it works as expected. This may not be the best solution but worked for me.

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

