### PR TITLE
fix(vue-app): add `prefetched` class to `<nuxt-link>` after chunk loaded

### DIFF
--- a/packages/vue-app/template/components/nuxt-link.client.js
+++ b/packages/vue-app/template/components/nuxt-link.client.js
@@ -102,7 +102,7 @@ export default {
         }
         Component.__prefetched = true
       }<% if (router.linkPrefetchedClass) { %>
-        Promise.all(promises).then(() => this.addPrefetchedClass())
+        return Promise.all(promises).then(() => this.addPrefetchedClass())
       <% } %>
     }<% if (router.linkPrefetchedClass) { %>,
     addPrefetchedClass () {

--- a/packages/vue-app/template/components/nuxt-link.client.js
+++ b/packages/vue-app/template/components/nuxt-link.client.js
@@ -92,15 +92,18 @@ export default {
       // Stop observing this link (in case of internet connection changes)
       observer.unobserve(this.$el)
       const Components = this.getPrefetchComponents()
+      <% if (router.linkPrefetchedClass) { %>const promises = []<% } %>
 
       for (const Component of Components) {
         const componentOrPromise = Component()
         if (componentOrPromise instanceof Promise) {
           componentOrPromise.catch(() => {})
+          <% if (router.linkPrefetchedClass) { %>promises.push(componentOrPromise)<% } %>
         }
         Component.__prefetched = true
       }<% if (router.linkPrefetchedClass) { %>
-      this.addPrefetchedClass()<% } %>
+        Promise.all(promises).then(() => this.addPrefetchedClass())
+      <% } %>
     }<% if (router.linkPrefetchedClass) { %>,
     addPrefetchedClass () {
       if (this.prefetchedClass !== 'false') {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

Add prefetched class only when the chunk is loaded.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] All new and existing tests are passing.

