### PR TITLE
perf(webpack): prefer using `contenthash`

### DIFF
--- a/examples/custom-build/nuxt.config.js
+++ b/examples/custom-build/nuxt.config.js
@@ -1,9 +1,9 @@
 export default {
   build: {
     filenames: {
-      css: 'styles.[chunkhash].css', // default: common.[chunkhash].css
-      manifest: 'manifest.[hash].js', // default: manifest.[hash].js
-      app: 'app.[chunkhash].js' // default: nuxt.bundle.[chunkhash].js
+      css: 'styles.[contenthash].css', // default: common.[contenthash].css
+      manifest: 'manifest.[contenthash].js', // default: manifest.[contenthash].js
+      app: 'app.[contenthash].js' // default: nuxt.bundle.[contenthash].js
     },
     extend (config, { isDev }) {
       if (isDev) {

--- a/packages/config/src/config/build.js
+++ b/packages/config/src/config/build.js
@@ -19,12 +19,12 @@ export default () => ({
   publicPath: '/_nuxt/',
   filenames: {
     // { isDev, isClient, isServer }
-    app: ({ isDev, isModern }) => isDev ? `${isModern ? 'modern-' : ''}[name].js` : '[chunkhash].js',
-    chunk: ({ isDev, isModern }) => isDev ? `${isModern ? 'modern-' : ''}[name].js` : '[chunkhash].js',
+    app: ({ isDev, isModern }) => isDev ? `${isModern ? 'modern-' : ''}[name].js` : '[contenthash].js',
+    chunk: ({ isDev, isModern }) => isDev ? `${isModern ? 'modern-' : ''}[name].js` : '[contenthash].js',
     css: ({ isDev }) => isDev ? '[name].css' : '[contenthash].css',
-    img: ({ isDev }) => isDev ? '[path][name].[ext]' : 'img/[hash:7].[ext]',
-    font: ({ isDev }) => isDev ? '[path][name].[ext]' : 'fonts/[hash:7].[ext]',
-    video: ({ isDev }) => isDev ? '[path][name].[ext]' : 'videos/[hash:7].[ext]'
+    img: ({ isDev }) => isDev ? '[path][name].[ext]' : 'img/[contenthash:7].[ext]',
+    font: ({ isDev }) => isDev ? '[path][name].[ext]' : 'fonts/[contenthash:7].[ext]',
+    video: ({ isDev }) => isDev ? '[path][name].[ext]' : 'videos/[contenthash:7].[ext]'
   },
   loaders: {
     file: {},

--- a/packages/config/test/config/build.test.js
+++ b/packages/config/test/config/build.test.js
@@ -15,12 +15,12 @@ describe('config: build', () => {
   test('should return prod filenames', () => {
     const { filenames } = buildConfig()
     const env = { isDev: false }
-    expect(filenames.app(env)).toEqual('[chunkhash].js')
-    expect(filenames.chunk(env)).toEqual('[chunkhash].js')
+    expect(filenames.app(env)).toEqual('[contenthash].js')
+    expect(filenames.chunk(env)).toEqual('[contenthash].js')
     expect(filenames.css(env)).toEqual('[contenthash].css')
-    expect(filenames.img(env)).toEqual('img/[hash:7].[ext]')
-    expect(filenames.font(env)).toEqual('fonts/[hash:7].[ext]')
-    expect(filenames.video(env)).toEqual('videos/[hash:7].[ext]')
+    expect(filenames.img(env)).toEqual('img/[contenthash:7].[ext]')
+    expect(filenames.font(env)).toEqual('fonts/[contenthash:7].[ext]')
+    expect(filenames.video(env)).toEqual('videos/[contenthash:7].[ext]')
   })
 
   test('should return modern filenames', () => {


### PR DESCRIPTION
## Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
`[contenthash]` is a better way of identifying a file if the contents don't change. See issues: https://github.com/webpack/webpack.js.org/issues/2096 and https://github.com/webpack/webpack/issues/7138.

This should mean that assets (like images or fonts) that are unlikely to change between deploys can be cached more efficiently.

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. PR: https://github.com/nuxt/docs/pull/1710
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

