### PR TITLE
fix(vue-app): layout in error.vue not work for Vue.extend component

### DIFF
--- a/packages/vue-app/template/App.js
+++ b/packages/vue-app/template/App.js
@@ -37,12 +37,15 @@ export default {
     <% if (loading) { %>const loadingEl = h('NuxtLoading', { ref: 'loading' })<% } %>
     <% if (features.layouts) { %>
     <% if (components.ErrorPage) { %>
-    if (this.nuxt.err && NuxtError.layout) {
-      this.setLayout(
-        typeof NuxtError.layout === 'function'
-          ? NuxtError.layout(this.context)
-          : NuxtError.layout
-      )
+    if (this.nuxt.err && NuxtError) {
+      const errorLayout = (NuxtError.options || NuxtError).layout
+      if (errorLayout) {
+        this.setLayout(
+          typeof errorLayout === 'function'
+            ? errorLayout.call(NuxtError, this.context)
+            : errorLayout
+        )
+      }
     }
     <% } %>
     const layoutEl = h(this.layout || 'nuxt')

--- a/packages/vue-app/template/client.js
+++ b/packages/vue-app/template/client.js
@@ -315,10 +315,11 @@ async function render (to, from, next) {
 
     <% if (features.layouts) { %>
     // Load layout for error page
+    const errorLayout = (NuxtError.options || NuxtError).layout
     const layout = await this.loadLayout(
-      typeof NuxtError.layout === 'function'
-        ? NuxtError.layout(app.context)
-        : NuxtError.layout
+      typeof errorLayout === 'function'
+        ? errorLayout.call(NuxtError, app.context)
+        : errorLayout
     )
     <% } %>
 
@@ -523,7 +524,7 @@ async function render (to, from, next) {
 
     <% if (features.layouts) { %>
     // Load error layout
-    let layout = NuxtError.layout
+    let errorLayout = (NuxtError.options || NuxtError).layout
     if (typeof layout === 'function') {
       layout = layout(app.context)
     }
@@ -558,7 +559,7 @@ function showNextPage (to) {
   <% if (features.layouts) { %>
   // Set layout
   let layout = this.$options.nuxt.err
-    ? NuxtError.layout
+    ? (NuxtError.options || NuxtError).layout
     : to.matched[0].components.default.options.layout
 
   if (typeof layout === 'function') {

--- a/packages/vue-app/template/client.js
+++ b/packages/vue-app/template/client.js
@@ -524,7 +524,7 @@ async function render (to, from, next) {
 
     <% if (features.layouts) { %>
     // Load error layout
-    let errorLayout = (NuxtError.options || NuxtError).layout
+    let layout = (NuxtError.options || NuxtError).layout
     if (typeof layout === 'function') {
       layout = layout(app.context)
     }

--- a/packages/vue-app/template/server.js
+++ b/packages/vue-app/template/server.js
@@ -89,7 +89,7 @@ export default async (ssrContext) => {
     <% if (features.layouts) { %>
     // Load layout for error page
     const layout = (NuxtError.options || NuxtError).layout
-    const errLayout = typeof layout=== 'function' ? layout.call(NuxtError, app.context) : layout
+    const errLayout = typeof layout === 'function' ? layout.call(NuxtError, app.context) : layout
     ssrContext.nuxt.layout = errLayout || 'default'
     await _app.loadLayout(errLayout)
     _app.setLayout(errLayout)

--- a/packages/vue-app/template/server.js
+++ b/packages/vue-app/template/server.js
@@ -88,7 +88,8 @@ export default async (ssrContext) => {
   const renderErrorPage = async () => {
     <% if (features.layouts) { %>
     // Load layout for error page
-    const errLayout = (typeof NuxtError.layout === 'function' ? NuxtError.layout(app.context) : NuxtError.layout)
+    const layout = (NuxtError.options || NuxtError).layout
+    const errLayout = typeof layout=== 'function' ? layout.call(NuxtError, app.context) : layout
     ssrContext.nuxt.layout = errLayout || 'default'
     await _app.loadLayout(errLayout)
     _app.setLayout(errLayout)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
Fix https://github.com/nuxt/nuxt.js/issues/6651
Reported from Discord from @aldarund , when component is from `Vue.extend`, the `layout` on `error.vue` doesn't, this is because `layout` is `component.options.layout` but not `component.layout`.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

