### PR TITLE
fix(vue-app): apply path-to-regexp options to tokensToFunction regexp

### DIFF
--- a/packages/vue-app/template/utils.js
+++ b/packages/vue-app/template/utils.js
@@ -280,7 +280,7 @@ export function getLocation (base, mode) {
  * @return {!function(Object=, Object=)}
  */
 export function compile (str, options) {
-  return tokensToFunction(parse(str, options))
+  return tokensToFunction(parse(str, options), options)
 }
 
 export function getQueryDiff (toQuery, fromQuery) {
@@ -449,14 +449,14 @@ function escapeGroup (group) {
 /**
  * Expose a method for transforming tokens into the path function.
  */
-function tokensToFunction (tokens) {
+function tokensToFunction (tokens, options) {
   // Compile all the tokens into regexps.
   const matches = new Array(tokens.length)
 
   // Compile all the patterns before compilation.
   for (let i = 0; i < tokens.length; i++) {
     if (typeof tokens[i] === 'object') {
-      matches[i] = new RegExp('^(?:' + tokens[i].pattern + ')$')
+      matches[i] = new RegExp('^(?:' + tokens[i].pattern + ')$', flags(options))
     }
   }
 
@@ -528,6 +528,16 @@ function tokensToFunction (tokens) {
 
     return path
   }
+}
+
+/**
+ * Get the flags for a regexp from the options.
+ *
+ * @param  {Object} options
+ * @return {string}
+ */
+function flags (options) {
+  return options && options.sensitive ? '' : 'i'
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

Route params should be matched case insensitive, this wasnt the case as the path regexp sensitive option. This was originally fixed in https://github.com/pillarjs/path-to-regexp/pull/191 but vue-router is still on path-to-regexp v1, so I've backported that fix which has now been released in https://github.com/pillarjs/path-to-regexp/releases/tag/v1.8.0

Related vue-router issue: https://github.com/vuejs/vue-router/issues/2925

Note: actually the options arent used at all as we never pass options to compile/tokensToFunction. This actually means the default behaviour changes due to this pr from being case sensitive to case insensitive

Note 2: for a full fix its probably required to wait until a vue-router release has been released that uses path-to-regexp v1.8 or v3. Although in my tests that wasnt actually necessary, not sure exactly if/when vue-router will call _tokensToFunction_ in a Nuxt.js app

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

