### PR TITLE
[wip] feat: add speed profiling to client build

### DIFF
--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -36,6 +36,7 @@
     "postcss-preset-env": "^6.7.0",
     "postcss-url": "^8.0.0",
     "semver": "^6.3.0",
+    "speed-measure-webpack-plugin": "^1.3.1",
     "std-env": "^2.2.1",
     "style-resources-loader": "^1.3.2",
     "terser-webpack-plugin": "^2.2.1",

--- a/packages/webpack/src/config/client.js
+++ b/packages/webpack/src/config/client.js
@@ -6,9 +6,11 @@ import BundleAnalyzer from 'webpack-bundle-analyzer'
 import OptimizeCSSAssetsPlugin from 'optimize-css-assets-webpack-plugin'
 import FriendlyErrorsWebpackPlugin from '@nuxt/friendly-errors-webpack-plugin'
 
+import SpeedMeasurePlugin from 'speed-measure-webpack-plugin'
 import CorsPlugin from '../plugins/vue/cors'
 import ModernModePlugin from '../plugins/vue/modern'
 import VueSSRClientPlugin from '../plugins/vue/client'
+
 import WebpackBaseConfig from './base'
 
 export default class WebpackClientConfig extends WebpackBaseConfig {
@@ -160,7 +162,7 @@ export default class WebpackClientConfig extends WebpackBaseConfig {
     const config = super.config()
     const {
       options: { router, buildDir },
-      buildOptions: { hotMiddleware, quiet, friendlyErrors }
+      buildOptions: { hotMiddleware, quiet, friendlyErrors, profileBuild }
     } = this.buildContext
 
     const { client = {} } = hotMiddleware || {}
@@ -201,6 +203,11 @@ export default class WebpackClientConfig extends WebpackBaseConfig {
           logLevel: 'WARNING'
         })
       )
+    }
+
+    if (profileBuild === true) {
+      const smp = new SpeedMeasurePlugin()
+      return smp.wrap(config)
     }
 
     return config


### PR DESCRIPTION
In my quest for speeding up webpack builds, I find it useful to add a plugin that can trace it. Due to the nature of said plugin, one cannot easily attach it as a user but would need to wrap the generated config. This PR does exactly that as opt-in. 

This is work in progress (docs and options missing), but I would appreciate it to be considered.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description

Add plugin to client config.


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

