### PR TITLE
feat(vue-app): upgrade `vue-router` to 3.1.x

### DIFF
--- a/distributions/nuxt-start/package.json
+++ b/distributions/nuxt-start/package.json
@@ -62,7 +62,7 @@
     "vue-client-only": "^2.0.0",
     "vue-meta": "^2.3.1",
     "vue-no-ssr": "^1.1.1",
-    "vue-router": "~3.0.7",
+    "vue-router": "^3.1.3",
     "vuex": "^3.1.2"
   },
   "engines": {

--- a/packages/vue-app/package.json
+++ b/packages/vue-app/package.json
@@ -18,7 +18,7 @@
     "vue-client-only": "^2.0.0",
     "vue-meta": "^2.3.1",
     "vue-no-ssr": "^1.1.1",
-    "vue-router": "~3.0.7",
+    "vue-router": "^3.1.3",
     "vue-template-compiler": "^2.6.10",
     "vuex": "^3.1.2"
   },

--- a/packages/vue-app/template/router.js
+++ b/packages/vue-app/template/router.js
@@ -85,7 +85,7 @@ const _routes = recursiveRoutes(router.routes, '  ', _components, 1)
 // TODO: remove in Nuxt 3
 const emptyFn = () => {}
 const originalPush = Router.prototype.push
-Router.prototype.push = function push(location, onComplete = emptyFn, onAbort) {
+Router.prototype.push = function push (location, onComplete = emptyFn, onAbort) {
   return originalPush.call(this, location, onComplete, onAbort)
 }
 

--- a/packages/vue-app/template/router.js
+++ b/packages/vue-app/template/router.js
@@ -82,6 +82,13 @@ const _routes = recursiveRoutes(router.routes, '  ', _components, 1)
   }
 }).join('\n')%>
 
+// TODO: remove in Nuxt 3
+const emptyFn = () => {}
+const originalPush = Router.prototype.push
+Router.prototype.push = function push(location, onComplete = emptyFn, onAbort) {
+  return originalPush.call(this, location, onComplete, onAbort)
+}
+
 Vue.use(Router)
 
 export const routerOptions = {

--- a/packages/vue-renderer/package.json
+++ b/packages/vue-renderer/package.json
@@ -15,6 +15,7 @@
     "lru-cache": "^5.1.1",
     "vue": "^2.6.10",
     "vue-meta": "^2.3.1",
+    "vue-router": "^3.1.3",
     "vue-server-renderer": "^2.6.10"
   },
   "publishConfig": {

--- a/packages/vue-renderer/package.json
+++ b/packages/vue-renderer/package.json
@@ -15,7 +15,6 @@
     "lru-cache": "^5.1.1",
     "vue": "^2.6.10",
     "vue-meta": "^2.3.1",
-    "vue-router": "^3.1.3",
     "vue-server-renderer": "^2.6.10"
   },
   "publishConfig": {

--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,6 @@
   ],
   "ignoreDeps": [
     "core-js",
-    "vue-router",
     "memory-fs"
   ],
   "lockFileMaintenance": {

--- a/test/unit/unicode-base.size-limit.test.js
+++ b/test/unit/unicode-base.size-limit.test.js
@@ -21,7 +21,7 @@ describe('nuxt minimal vue-app bundle size limit', () => {
     const filter = filename => filename === 'vue-app.nuxt.js'
     const legacyResourcesSize = await getResourcesSize(distDir, 'client', { filter })
 
-    const LEGACY_JS_RESOURCES_KB_SIZE = 15.2
+    const LEGACY_JS_RESOURCES_KB_SIZE = 15.4
     expect(legacyResourcesSize.uncompressed).toBeWithinSize(LEGACY_JS_RESOURCES_KB_SIZE)
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -11978,6 +11978,11 @@ vue-no-ssr@^1.1.1:
   resolved "https://registry.npmjs.org/vue-no-ssr/-/vue-no-ssr-1.1.1.tgz#875f3be6fb0ae41568a837f3ac1a80eaa137b998"
   integrity sha512-ZMjqRpWabMPqPc7gIrG0Nw6vRf1+itwf0Itft7LbMXs2g3Zs/NFmevjZGN1x7K3Q95GmIjWbQZTVerxiBxI+0g==
 
+vue-router@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.npmjs.org/vue-router/-/vue-router-3.1.3.tgz#e6b14fabc0c0ee9fda0e2cbbda74b350e28e412b"
+  integrity sha512-8iSa4mGNXBjyuSZFCCO4fiKfvzqk+mhL0lnKuGcQtO1eoj8nq3CmbEG8FwK5QqoqwDgsjsf1GDuisDX4cdb/aQ==
+
 vue-router@~3.0.7:
   version "3.0.7"
   resolved "https://registry.npmjs.org/vue-router/-/vue-router-3.0.7.tgz#b36ca107b4acb8ff5bc4ff824584059c23fcb87b"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11983,11 +11983,6 @@ vue-router@^3.1.3:
   resolved "https://registry.npmjs.org/vue-router/-/vue-router-3.1.3.tgz#e6b14fabc0c0ee9fda0e2cbbda74b350e28e412b"
   integrity sha512-8iSa4mGNXBjyuSZFCCO4fiKfvzqk+mhL0lnKuGcQtO1eoj8nq3CmbEG8FwK5QqoqwDgsjsf1GDuisDX4cdb/aQ==
 
-vue-router@~3.0.7:
-  version "3.0.7"
-  resolved "https://registry.npmjs.org/vue-router/-/vue-router-3.0.7.tgz#b36ca107b4acb8ff5bc4ff824584059c23fcb87b"
-  integrity sha512-utJ+QR3YlIC/6x6xq17UMXeAfxEvXA0VKD3PiSio7hBOZNusA1jXcbxZxVEfJunLp48oonjTepY8ORoIlRx/EQ==
-
 vue-server-renderer@^2.6.10:
   version "2.6.10"
   resolved "https://registry.npmjs.org/vue-server-renderer/-/vue-server-renderer-2.6.10.tgz#cb2558842ead360ae2ec1f3719b75564a805b375"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

As `vue-router@3.1` has a break change for programmatic `router.push`, so this pr is adding a small wrapper for reverting the break change, let's remove the wrapper and ship it in Nuxt 3.

BTW, actually user can still use the break change(promisable push), I think it's 
very rare in current user's code and also a good way for making new feature possible.

```js
router.push('/...', false)
```

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

