### PR TITLE
fix(ssr): segmentation fault (SIGSEGV) in Node.js 13.2

### DIFF
--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -401,7 +401,7 @@ export function getNuxtConfig (_options) {
   // Use runInNewContext for dev mode by default
   const { bundleRenderer } = options.render
   if (typeof bundleRenderer.runInNewContext === 'undefined') {
-    bundleRenderer.runInNewContext = options.dev
+    bundleRenderer.runInNewContext = options.dev ? true : 'once'
   }
 
   // Add loading screen

--- a/packages/config/test/__snapshots__/options.test.js.snap
+++ b/packages/config/test/__snapshots__/options.test.js.snap
@@ -292,7 +292,7 @@ Object {
   "plugins": Array [],
   "render": Object {
     "bundleRenderer": Object {
-      "runInNewContext": false,
+      "runInNewContext": "once",
       "shouldPrefetch": [Function],
       "shouldPreload": [Function],
     },

--- a/test/unit/basic.ssr.csp.test.js
+++ b/test/unit/basic.ssr.csp.test.js
@@ -22,7 +22,7 @@ const reportOnlyHeader = getHeader(true)
 
 const startCspDevServer = csp => startCspServer(csp, false)
 
-describe.skip('basic ssr csp', () => {
+describe('basic ssr csp', () => {
   let nuxt
 
   afterEach(async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

Relate to https://github.com/nuxt/nuxt.js/pull/6740 , we found `segmentation fault` in ssr with Node.js 13.2.0.

This error happens when server is started frequently and in same Node.js context, throught my investigation, it'e related to the shared contenxt between ssr render and Node server, so this pr is to change `runInNewContext` to `once` in prod.

This change might be kind of breaking change, but as we're using `runInNewContext : false` in `dev` mode, so if there is any issue caused by running in new context, the issue should have been found in dev, so it should be somehow safe change.
