### PR TITLE
chore(ci): use Node.js lts instead of latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ executors:
         type: boolean
         default: false
     docker:
-      - image: circleci/node:latest<<# parameters.browsers >>-browsers<</ parameters.browsers >>
+      - image: circleci/node:lts<<# parameters.browsers >>-browsers<</ parameters.browsers >>
     working_directory: ~/project
     environment:
       NODE_ENV: test

--- a/test/unit/basic.ssr.csp.test.js
+++ b/test/unit/basic.ssr.csp.test.js
@@ -22,7 +22,7 @@ const reportOnlyHeader = getHeader(true)
 
 const startCspDevServer = csp => startCspServer(csp, false)
 
-describe.skip('basic ssr csp', () => {
+describe('basic ssr csp', () => {
   let nuxt
 
   afterEach(async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

Follow up https://github.com/nuxt/nuxt.js/pull/6746, as we're not going ship `runInNewContext: false` as @pi0 suggestion, this pr is chaning CI node tag to LTS

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

