### PR TITLE
fix: avoid parent `dataRefresh` in nested routes

### DIFF
--- a/packages/vue-app/template/client.js
+++ b/packages/vue-app/template/client.js
@@ -422,7 +422,7 @@ async function render (to, from, next) {
       Component._dataRefresh = false
       // Check if Component need to be refreshed (call asyncData & fetch)
       // Only if its slug has changed or is watch query changes
-      if ((this._pathChanged && this._queryChanged) || Component._path !== _lastPaths[i]) {
+      if (this._pathChanged  && !_lastPaths.reduce((a, b) => a || Component._path === b, false)) {
         Component._dataRefresh = true
       } else if (!this._pathChanged && this._queryChanged) {
         const watchQuery = Component.options.watchQuery

--- a/packages/vue-app/template/client.js
+++ b/packages/vue-app/template/client.js
@@ -422,7 +422,7 @@ async function render (to, from, next) {
       Component._dataRefresh = false
       // Check if Component need to be refreshed (call asyncData & fetch)
       // Only if its slug has changed or is watch query changes
-      if (this._pathChanged  && !_lastPaths.reduce((a, b) => a || Component._path === b, false)) {
+      if (this._pathChanged && !_lastPaths.reduce((a, b) => a || Component._path === b, false)) {
         Component._dataRefresh = true
       } else if (!this._pathChanged && this._queryChanged) {
         const watchQuery = Component.options.watchQuery


### PR DESCRIPTION
in nested routes, when the route is changed, the `asyncData` of both parent and child are called when the child route has `query`. this is the case even if `watchQuery` is `false`.

this change resolved my issue.
