### PR TITLE
fix(utils): flatRoutes regex for nested routes with trailing slash enabled

### DIFF
--- a/packages/utils/src/route.js
+++ b/packages/utils/src/route.js
@@ -15,7 +15,7 @@ export const flatRoutes = function flatRoutes (router, fileName = '', routes = [
       }
       return flatRoutes(r.children, fileName + r.path + '/', routes)
     }
-    fileName = fileName.replace(/^\/+$/, '/')
+    fileName = fileName.replace(/\/+/g, '/')
     routes.push(
       (r.path === '' && fileName[fileName.length - 1] === '/'
         ? fileName.slice(0, -1)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
Nested routes with `trailingSlash: true` nuxt config is getting double forward slash paths.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
Resolves: #6783 

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [] All new and existing tests are passing.

