### PR TITLE
fix(generator): no copying built files when publicPath is an url

### DIFF
--- a/packages/generator/src/generator.js
+++ b/packages/generator/src/generator.js
@@ -167,6 +167,7 @@ export default class Generator {
   async initDist () {
     // Clean destination folder
     await fsExtra.remove(this.distPath)
+    await fsExtra.mkdirp(this.distPath)
 
     await this.nuxt.callHook('generate:distRemoved', this)
 
@@ -174,7 +175,9 @@ export default class Generator {
     if (await fsExtra.exists(this.staticRoutes)) {
       await fsExtra.copy(this.staticRoutes, this.distPath)
     }
-    await fsExtra.copy(this.srcBuiltPath, this.distNuxtPath)
+    if (!isUrl(this.options.build.publicPath)) {
+      await fsExtra.copy(this.srcBuiltPath, this.distNuxtPath)
+    }
 
     // Add .nojekyll file to let GitHub Pages add the _nuxt/ folder
     // https://help.github.com/articles/files-that-start-with-an-underscore-are-missing/


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
This is a small change so I didn't create an issue for it first. This is also technically a small breaking change, but the old behavior was never documented.

I have already described the intention in the git commit message, but here it is again:

> When build.publicPath is an url, there is no point in copying over built css and js files, since they should be uploaded to CDN separately and already lives in a separate documented path.

In my case, since I have to upload `.nuxt/dist/client` to the CDN, I have to filter out the built js files in the dist folder, which is uploaded separately (I think this should be the case pretty generally when you use a CDN). And having to perform an extra step to remove these files first feels like a waste.

I don't have a strong opinion on this, if any nuxt team member has an objection, feel free to close the PR.

BTW, I'd like to send two more PRs, but I'm not sure if they will be accepted. So I'll just ask them here if that's ok.

1. Creating `.nojekyll` should be optional, maybe `generate.nojekyll: bool` and default to true?
2. There shouldn't be a `__layout` element in the generated html (there are a few issues asking for this), and technical wise, it only contains one child element, and not as the __nuxt element which might contain several thus is mandatory.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

Not sure how to test this, the generator test doesn't have any test that actually generates files.
