### PR TITLE
perf(vue-renderer):  don't serialize session when `injectScripts` is false

### DIFF
--- a/packages/vue-renderer/src/renderers/ssr.js
+++ b/packages/vue-renderer/src/renderers/ssr.js
@@ -130,7 +130,7 @@ export default class SSRRenderer extends BaseRenderer {
     // Only add the hash if 'unsafe-inline' rule isn't present to avoid conflicts (#5387)
     const containsUnsafeInlineScriptSrc = csp.policies && csp.policies['script-src'] && csp.policies['script-src'].includes('\'unsafe-inline\'')
     const shouldHashCspScriptSrc = csp && (csp.unsafeInlineCompatibility || !containsUnsafeInlineScriptSrc)
-    let serializedSession = '';
+    let serializedSession = ''
 
     // Serialize state
     if (shouldInjectScripts || shouldHashCspScriptSrc) {

--- a/packages/vue-renderer/src/renderers/ssr.js
+++ b/packages/vue-renderer/src/renderers/ssr.js
@@ -126,19 +126,26 @@ export default class SSRRenderer extends BaseRenderer {
       }
     }
 
+    const { csp } = this.options.render
+    // Only add the hash if 'unsafe-inline' rule isn't present to avoid conflicts (#5387)
+    const containsUnsafeInlineScriptSrc = csp.policies && csp.policies['script-src'] && csp.policies['script-src'].includes('\'unsafe-inline\'')
+    const shouldHashCspScriptSrc = csp && (csp.unsafeInlineCompatibility || !containsUnsafeInlineScriptSrc)
+    let serializedSession = '';
+
     // Serialize state
-    const serializedSession = `window.${this.serverContext.globals.context}=${devalue(renderContext.nuxt)};`
+    if (shouldInjectScripts || shouldHashCspScriptSrc) {
+      // Only serialized session if need inject scripts or csp hash
+      serializedSession = `window.${this.serverContext.globals.context}=${devalue(renderContext.nuxt)};`
+    }
+
     if (shouldInjectScripts) {
       APP += `<script>${serializedSession}</script>`
     }
 
     // Calculate CSP hashes
-    const { csp } = this.options.render
     const cspScriptSrcHashes = []
     if (csp) {
-      // Only add the hash if 'unsafe-inline' rule isn't present to avoid conflicts (#5387)
-      const containsUnsafeInlineScriptSrc = csp.policies && csp.policies['script-src'] && csp.policies['script-src'].includes('\'unsafe-inline\'')
-      if (csp.unsafeInlineCompatibility || !containsUnsafeInlineScriptSrc) {
+      if (shouldHashCspScriptSrc) {
         const hash = crypto.createHash(csp.hashAlgorithm)
         hash.update(serializedSession)
         cspScriptSrcHashes.push(`'${csp.hashAlgorithm}-${hash.digest('base64')}'`)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

`serializedSession` is always computed even though not use the result. it use too much cpu in some render options.
now, `serializedSession` will be computed only when this result needed. 

before: 
![image](https://user-images.githubusercontent.com/15642931/71764692-09ecd480-2f26-11ea-9abf-a1b358c93d6e.png)

after: 
![image](https://user-images.githubusercontent.com/15642931/71764706-2721a300-2f26-11ea-8e32-e785a1827ad1.png)



## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

