### PR TITLE
feat(vue-renderer): Hook VueMeta  SPA / Static to modify VueMeta data while generatating

### DIFF
--- a/packages/vue-renderer/src/renderers/spa.js
+++ b/packages/vue-renderer/src/renderers/spa.js
@@ -58,7 +58,7 @@ export default class SPARenderer extends BaseRenderer {
       }
 
       // Allow the head meta passed to VueMeta to be overridden
-      await this.serverContext.nuxt.callHook('vue-renderer:spa:meta', { head, renderContext });
+      await this.serverContext.nuxt.callHook('vue-renderer:spa:meta', { head, renderContext })
 
       const m = VueMeta.generate(head || {}, this.vueMetaConfig)
 

--- a/packages/vue-renderer/src/renderers/spa.js
+++ b/packages/vue-renderer/src/renderers/spa.js
@@ -57,6 +57,9 @@ export default class SPARenderer extends BaseRenderer {
         head = cloneDeep(this.options.head)
       }
 
+      // Allow the head meta passed to VueMeta to be overridden
+      await this.serverContext.nuxt.callHook('vue-renderer:spa:meta', { head, renderContext });
+
       const m = VueMeta.generate(head || {}, this.vueMetaConfig)
 
       // HTML_ATTRS


### PR DESCRIPTION
## Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description

For SPA and static site builds, the generated HTML pages all use the meta options from `nuxt.config.js`. This is a problem for SEO (obviously) and for link sharing where the meta content of the HTML will be parsed to give a preview. While a universal or server-sided rendered app would solve this, I'd rather not have to deal with the complexities involved when there is a fairly simple solution (I only need the meta pre-rendered, nothing else).

What I'm proposing is a hook for vue-meta allowing the app to decide on a more granular level what meta to use for each route. I believe this is in-line with existing core functionality and could open up other use cases.

I would hope one day the vue-meta plugin could just work for this for static / spa built sites but I think this can be a good intermediate solution.

Example: with this code block a user can generate all their static HTML to have individual titles without any effort 

```
hooks: {
    'vue-renderer': {
      spa: {
        meta ({ head, renderContext }) {
          const urlParts = renderContext.url.split('/')
          head.title = startCase(urlParts.pop())
        }
      }
    },
  },
```

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation. - **No documentation page for `vue-renderer` hooks that I can see?**
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why) - **Wasn't sure exactly where to put these tests, wasn't a SPA generate unit test from what I could see?**
- [ ] All new and existing tests are passing.

