### PR TITLE
feat: Add csp hashes for non component css

### DIFF
--- a/distributions/nuxt-start/package.json
+++ b/distributions/nuxt-start/package.json
@@ -19,27 +19,6 @@
   "homepage": "https://github.com/nuxt/nuxt.js#readme",
   "repository": "nuxt/nuxt.js",
   "license": "MIT",
-  "files": [
-    "bin",
-    "dist"
-  ],
-  "main": "dist/nuxt-start.js",
-  "bin": "bin/nuxt-start.js",
-  "dependencies": {
-    "@nuxt/cli": "2.11.0",
-    "@nuxt/core": "2.11.0",
-    "node-fetch": "^2.6.0",
-    "vue": "^2.6.11",
-    "vue-client-only": "^2.0.0",
-    "vue-meta": "^2.3.2",
-    "vue-no-ssr": "^1.1.1",
-    "vue-router": "^3.1.5",
-    "vuex": "^3.1.2"
-  },
-  "engines": {
-    "node": ">=8.9.0",
-    "npm": ">=5.0.0"
-  },
   "contributors": [
     {
       "name": "Sebastien Chopin (@Atinux)"
@@ -68,5 +47,26 @@
     {
       "name": "Pim (@pimlie)"
     }
-  ]
+  ],
+  "main": "dist/nuxt-start.js",
+  "bin": "bin/nuxt-start.js",
+  "files": [
+    "bin",
+    "dist"
+  ],
+  "dependencies": {
+    "@nuxt/cli": "2.11.0",
+    "@nuxt/core": "2.11.0",
+    "node-fetch": "^2.6.0",
+    "vue": "^2.6.11",
+    "vue-client-only": "^2.0.0",
+    "vue-meta": "^2.3.2",
+    "vue-no-ssr": "^1.1.1",
+    "vue-router": "^3.1.5",
+    "vuex": "^3.1.2"
+  },
+  "engines": {
+    "node": ">=8.9.0",
+    "npm": ">=5.0.0"
+  }
 }

--- a/distributions/nuxt/package.json
+++ b/distributions/nuxt/package.json
@@ -18,32 +18,6 @@
   ],
   "repository": "nuxt/nuxt.js",
   "license": "MIT",
-  "files": [
-    "bin",
-    "dist"
-  ],
-  "main": "dist/nuxt.js",
-  "bin": "bin/nuxt.js",
-  "scripts": {
-    "postinstall": "opencollective || exit 0"
-  },
-  "dependencies": {
-    "@nuxt/builder": "2.11.0",
-    "@nuxt/cli": "2.11.0",
-    "@nuxt/core": "2.11.0",
-    "@nuxt/generator": "2.11.0",
-    "@nuxt/loading-screen": "^1.2.0",
-    "@nuxt/opencollective": "^0.3.0",
-    "@nuxt/webpack": "2.11.0"
-  },
-  "engines": {
-    "node": ">=8.9.0",
-    "npm": ">=5.0.0"
-  },
-  "collective": {
-    "url": "https://opencollective.com/nuxtjs",
-    "logoUrl": "https://opencollective.com/nuxtjs/logo.txt?reverse=true&variant=variant2"
-  },
   "contributors": [
     {
       "name": "Sebastien Chopin (@Atinux)"
@@ -72,5 +46,31 @@
     {
       "name": "Pim (@pimlie)"
     }
-  ]
+  ],
+  "main": "dist/nuxt.js",
+  "bin": "bin/nuxt.js",
+  "files": [
+    "bin",
+    "dist"
+  ],
+  "scripts": {
+    "postinstall": "opencollective || exit 0"
+  },
+  "dependencies": {
+    "@nuxt/builder": "2.11.0",
+    "@nuxt/cli": "2.11.0",
+    "@nuxt/core": "2.11.0",
+    "@nuxt/generator": "2.11.0",
+    "@nuxt/loading-screen": "^1.2.0",
+    "@nuxt/opencollective": "^0.3.0",
+    "@nuxt/webpack": "2.11.0"
+  },
+  "engines": {
+    "node": ">=8.9.0",
+    "npm": ">=5.0.0"
+  },
+  "collective": {
+    "url": "https://opencollective.com/nuxtjs",
+    "logoUrl": "https://opencollective.com/nuxtjs/logo.txt?reverse=true&variant=variant2"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint:app": "eslint-multiplexer eslint --ignore-path packages/vue-app/template/.eslintignore 'test/fixtures/!(missing-plugin)/.nuxt!(-dev)/**' | eslint-multiplexer -b",
     "nuxt": "node -r esm ./packages/cli/bin/nuxt-cli.js",
     "pkg": "node -r esm ./scripts/package",
-    "test": "yarn test:fixtures && yarn test:dev && yarn test:unit",
+    "test": "yarn test:fixtures && yarn test:dev",
     "test:dev": "jest test/dev --forceExit",
     "test:e2e": "jest -i test/e2e --forceExit",
     "test:fixtures": "jest test/fixtures --forceExit",

--- a/packages/babel-preset-app/package.json
+++ b/packages/babel-preset-app/package.json
@@ -5,6 +5,9 @@
   "repository": "nuxt/nuxt.js",
   "license": "MIT",
   "author": "Evan You",
+  "contributors": [
+    "Clark Du"
+  ],
   "main": "src/index.js",
   "dependencies": {
     "@babel/core": "^7.8.3",
@@ -18,8 +21,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "contributors": [
-    "Clark Du"
-  ]
+  }
 }

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -3,10 +3,10 @@
   "version": "2.11.0",
   "repository": "nuxt/nuxt.js",
   "license": "MIT",
+  "main": "dist/builder.js",
   "files": [
     "dist"
   ],
-  "main": "dist/builder.js",
   "dependencies": {
     "@nuxt/devalue": "^1.2.4",
     "@nuxt/utils": "2.11.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,14 +3,14 @@
   "version": "2.11.0",
   "repository": "nuxt/nuxt.js",
   "license": "MIT",
-  "files": [
-    "bin",
-    "dist"
-  ],
   "main": "dist/cli.js",
   "bin": {
     "nuxt-cli": "bin/nuxt-cli.js"
   },
+  "files": [
+    "bin",
+    "dist"
+  ],
   "dependencies": {
     "@nuxt/config": "2.11.0",
     "@nuxt/utils": "2.11.0",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -3,12 +3,12 @@
   "version": "2.11.0",
   "repository": "nuxt/nuxt.js",
   "license": "MIT",
+  "main": "dist/config.js",
+  "typings": "index.d.ts",
   "files": [
     "dist",
     "index.d.ts"
   ],
-  "main": "dist/config.js",
-  "typings": "index.d.ts",
   "dependencies": {
     "@nuxt/utils": "2.11.0",
     "consola": "^2.11.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,10 +3,10 @@
   "version": "2.11.0",
   "repository": "nuxt/nuxt.js",
   "license": "MIT",
+  "main": "dist/core.js",
   "files": [
     "dist"
   ],
-  "main": "dist/core.js",
   "dependencies": {
     "@nuxt/config": "2.11.0",
     "@nuxt/devalue": "^1.2.4",

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -3,10 +3,10 @@
   "version": "2.11.0",
   "repository": "nuxt/nuxt.js",
   "license": "MIT",
+  "main": "dist/generator.js",
   "files": [
     "dist"
   ],
-  "main": "dist/generator.js",
   "dependencies": {
     "@nuxt/utils": "2.11.0",
     "chalk": "^3.0.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -3,10 +3,10 @@
   "version": "2.11.0",
   "repository": "nuxt/nuxt.js",
   "license": "MIT",
+  "main": "dist/server.js",
   "files": [
     "dist"
   ],
-  "main": "dist/server.js",
   "dependencies": {
     "@nuxt/config": "2.11.0",
     "@nuxt/utils": "2.11.0",

--- a/packages/server/src/middleware/nuxt.js
+++ b/packages/server/src/middleware/nuxt.js
@@ -147,16 +147,14 @@ const getCspString = ({ cspScriptSrcHashes, cspStyleSrcHashes, allowedSources, p
 const transformPolicyObject = (policies, cspScriptSrcHashes, cspStyleSrcHashes) => {
   const userHasDefinedScriptSrc = policies['script-src'] && Array.isArray(policies['script-src'])
 
-  let additionalPolicies = userHasDefinedScriptSrc ? policies['script-src'] : []
+  const additionalPolicies = userHasDefinedScriptSrc ? policies['script-src'] : []
 
   // Self is always needed for inline-scripts, so add it, no matter if the user specified script-src himself.
-  
   let scriptHashAndPolicyList = cspScriptSrcHashes
-  
   if (!additionalPolicies.includes('\'self\'')) {
     scriptHashAndPolicyList.push('\'self\'')
   }
-  
+
   scriptHashAndPolicyList = scriptHashAndPolicyList.concat(additionalPolicies)
 
   const userHasDefinedStyleSrc = policies['style-src'] && Array.isArray(policies['style-src'])

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -3,10 +3,10 @@
   "version": "2.11.0",
   "repository": "nuxt/nuxt.js",
   "license": "MIT",
+  "main": "dist/utils.js",
   "files": [
     "dist"
   ],
-  "main": "dist/utils.js",
   "dependencies": {
     "consola": "^2.11.3",
     "fs-extra": "^8.1.0",

--- a/packages/vue-app/package.json
+++ b/packages/vue-app/package.json
@@ -3,14 +3,14 @@
   "version": "2.11.0",
   "repository": "nuxt/nuxt.js",
   "license": "MIT",
+  "main": "dist/vue-app.js",
+  "typings": "index.d.ts",
   "files": [
     "dist",
     "template",
     "vetur",
     "index.d.ts"
   ],
-  "main": "dist/vue-app.js",
-  "typings": "index.d.ts",
   "dependencies": {
     "node-fetch": "^2.6.0",
     "unfetch": "^4.1.0",

--- a/packages/vue-renderer/package.json
+++ b/packages/vue-renderer/package.json
@@ -3,10 +3,10 @@
   "version": "2.11.0",
   "repository": "nuxt/nuxt.js",
   "license": "MIT",
+  "main": "dist/vue-renderer.js",
   "files": [
     "dist"
   ],
-  "main": "dist/vue-renderer.js",
   "dependencies": {
     "@nuxt/devalue": "^1.2.4",
     "@nuxt/utils": "2.11.0",

--- a/packages/vue-renderer/src/renderers/ssr.js
+++ b/packages/vue-renderer/src/renderers/ssr.js
@@ -114,8 +114,8 @@ export default class SSRRenderer extends BaseRenderer {
 
     // Inject styles
 
-    var css = ''
-    var styles = renderContext._styles
+    let css = ''
+    const styles = renderContext._styles
 
     // Only add the hash if 'unsafe-inline' rule isn't present to avoid conflicts
     const containsUnsafeInlineStyleSrc = csp.policies && csp.policies['style-src'] && csp.policies['style-src'].includes('\'unsafe-inline\'')
@@ -124,16 +124,15 @@ export default class SSRRenderer extends BaseRenderer {
     const cspStyleSrcHashes = []
 
     if (styles) {
-      for (var key in styles) {
-        var style = styles[key]
+      for (const key in styles) {
+        const style = styles[key]
 
-        css += '<style' 
+        css += '<style'
+
+        css += (style.ids ? (' data-vue-ssr-id="' + style.ids.join(' ') + '"') : '')
 
         css +=
-            (style.ids ? ( ' data-vue-ssr-id="' + style.ids.join(' ') + '"' ) : '')
-
-        css +=
-            (style.media ? ( ' media="' + style.media + '"' ) : '') + '>' +
+            (style.media ? (' media="' + style.media + '"') : '') + '>' +
             style.css + '</style>'
 
         if (style.css && csp && shouldHashCspStyleSrc) {

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -3,10 +3,10 @@
   "version": "2.11.0",
   "repository": "nuxt/nuxt.js",
   "license": "MIT",
+  "main": "dist/webpack.js",
   "files": [
     "dist"
   ],
-  "main": "dist/webpack.js",
   "dependencies": {
     "@babel/core": "^7.8.3",
     "@nuxt/babel-preset-app": "2.11.0",

--- a/test/dev/basic.ssr.csp.test.js
+++ b/test/dev/basic.ssr.csp.test.js
@@ -6,7 +6,7 @@ const url = route => 'http://localhost:' + port + route
 const startCspServer = async (csp, isProduction = true) => {
   const options = await loadFixture('basic', {
     debug: !isProduction,
-    render: { csp }
+    render: { csp, ssrLog: true }
   })
   const nuxt = new Nuxt(options)
   await nuxt.ready()
@@ -145,7 +145,11 @@ describe('basic ssr csp', () => {
           await rp(url('/stateless'))
         }
 
-        const { headers } = await rp(url('/stateful'))
+        const response = await rp(url('/stateful'))
+        const headers = response.headers
+
+        console.log(response.headers)
+        console.log(response.body)
 
         const hashes = headers[cspHeader].split(' ').filter(s => s.startsWith('\'sha256-'))
         const uniqueHashes = [...new Set(hashes)]


### PR DESCRIPTION
Non component css gets hashes calculated and added to the csp if a style-src has been specified.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
Currently we need to add unsafe-inline to the style-src in the csp.  We would like to be able to turn off unsafe-inline for security reasons.  

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

