### PR TITLE
fix(core): Provide the correct name of routeContext hook

### DIFF
--- a/packages/core/src/nuxt.js
+++ b/packages/core/src/nuxt.js
@@ -26,7 +26,7 @@ export default class Nuxt extends Hookable {
     // Deprecated hooks
     this.deprecateHooks({
       'render:context': 'render:routeContext',
-      'render:routeContext': 'vue-renderer:afterRender',
+      'render:routeContext': 'vue-renderer:ssr:context',
       showReady: 'webpack:done' // Workaround to deprecate showReady
     })
 

--- a/packages/core/test/nuxt.test.js
+++ b/packages/core/test/nuxt.test.js
@@ -38,7 +38,7 @@ describe('core: nuxt', () => {
 
     expect(nuxt._deprecatedHooks).toEqual({
       'render:context': 'render:routeContext',
-      'render:routeContext': 'vue-renderer:afterRender',
+      'render:routeContext': 'vue-renderer:ssr:context',
       showReady: 'webpack:done'
     })
 


### PR DESCRIPTION
New name of hook is `vue-renderer:ssr:context`

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (a non-breaking change which fixes an issue)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

This corrects deprecation message and also links to correct documentation (PR: 1832)
No tests are required

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My change requires a change to the documentation.
- [x ] I have updated the documentation accordingly. (PR: 1832)

