### PR TITLE
perf(vue-renderer): early return `render` when redirect happens 

### DIFF
--- a/packages/vue-renderer/src/renderers/ssr.js
+++ b/packages/vue-renderer/src/renderers/ssr.js
@@ -83,6 +83,14 @@ export default class SSRRenderer extends BaseRenderer {
       APP = `<div id="${this.serverContext.globals.id}"></div>`
     }
 
+    if (renderContext.redirected && !renderContext._generate) {
+      return {
+        html: APP,
+        error: renderContext.nuxt.error,
+        redirected: renderContext.redirected
+      }
+    }
+
     let HEAD = ''
 
     // Inject head meta

--- a/test/dev/basic.ssr.test.js
+++ b/test/dev/basic.ssr.test.js
@@ -155,6 +155,7 @@ describe('basic ssr', () => {
   test('/redirect', async () => {
     const { html, redirected } = await nuxt.server.renderRoute('/redirect')
     expect(html).toContain('<div id="__nuxt"></div>')
+    expect(html).not.toContain('window.__NUXT__')
     expect(redirected.path === '/').toBe(true)
     expect(redirected.status === 302).toBe(true)
   })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

In pure ssr mode (ie not nuxt-generate) its not needed to return a full nuxt app on redirecting. A header with Location and empty body is plenty enough.

While debugging a redirect issue yesterday I was confused by this for a long time because I wasnt expecting the full body to be present so was thinking that it had already rendered the next page. 

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

