### PR TITLE
chore(ci): enable 2.x pr ci for hotfix purpose

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,11 +9,13 @@ on:
   pull_request:
     branches:
       - dev
+      - 2.x
       - next
 
 jobs:
   setup:
     runs-on: ${{ matrix.os }}
+    if: github.event_name == 'push' || !(github.base_ref == '2.x' && github.head_ref == 'dev')
 
     strategy:
       matrix:


### PR DESCRIPTION
- Enable pull request ci building on 2.x branch for hotfix purpose.
- Exclude  pull request ci building on 2.x branch from dev branch (release pr, ci building is push type)