### PR TITLE
chore(vue-app): improve missing inject value error message

### DIFF
--- a/packages/vue-app/template/index.js
+++ b/packages/vue-app/template/index.js
@@ -168,7 +168,7 @@ async function createApp (ssrContext) {
       throw new Error('inject(key, value) has no key provided')
     }
     if (value === undefined) {
-      throw new Error('inject(key, value) has no value provided')
+      throw new Error(`inject('${key}', value) has no value provided`)
     }
 
     key = '$' + key

--- a/test/dev/basic.plugins.test.js
+++ b/test/dev/basic.plugins.test.js
@@ -22,7 +22,7 @@ describe('with-config', () => {
 
   test('inject fails if value is undefined', async () => {
     // inject('injectedProperty', undefined)
-    await expect(nuxt.renderRoute('/?injectValue=undefined')).rejects.toThrowError('inject(key, value) has no value provided')
+    await expect(nuxt.renderRoute('/?injectValue=undefined')).rejects.toThrowError('inject(\'injectedProperty\', value) has no value provided')
   })
 
   test('inject succeeds if value is defined but evaluates to false', async () => {


### PR DESCRIPTION
Currently when `inject(key, value)` is missing a value, the error message is:

```js
      throw new Error('inject(key, value) has no value provided')
```

This changes it to the following in order to facilitate debugging:

```js
      throw new Error(`inject('${key}', value) has no value provided`)
```