### PR TITLE
fix(babel-preset-app): TypeError when import cjs in webpack building

### DIFF
--- a/packages/babel-preset-app/src/index.js
+++ b/packages/babel-preset-app/src/index.js
@@ -145,6 +145,7 @@ module.exports = (api, options = {}) => {
   }])
 
   return {
+    sourceType: 'unambiguous',
     presets,
     plugins
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

Fix https://github.com/nuxt-community/tailwindcss-module/issues/62#issuecomment-584411263

As we've turning off babel module transformation and let webpack process modules, so we'd better use `sourceType: 'unambiguous'` for allowing cjs files are not in strict mode.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

