### PR TITLE
feat(vue-renderer): pass `renderContext` to `vue-renderer:ssr:templateParams` hook

### DIFF
--- a/packages/vue-renderer/src/renderers/ssr.js
+++ b/packages/vue-renderer/src/renderers/ssr.js
@@ -210,7 +210,7 @@ export default class SSRRenderer extends BaseRenderer {
     }
 
     // Call ssr:templateParams hook
-    await this.serverContext.nuxt.callHook('vue-renderer:ssr:templateParams', templateParams)
+    await this.serverContext.nuxt.callHook('vue-renderer:ssr:templateParams', templateParams, renderContext)
 
     // Render with SSR template
     const html = this.renderTemplate(this.serverContext.resources.ssrTemplate, templateParams)


### PR DESCRIPTION
Only `templateParams` is passed to `vue-renderer:ssr:templateParams` hook. This PR updates the vue-renderer to pass `renderContext` as well.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
Resolves: #7163

By passing `renderContext`, we can have a chance to modify the HTML with the renderContext before the actual render happens. Details in #7163

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

Should I update the doc in this PR or should I send a separate PR for the doc?

Unfortunately `vue-renderer` has no test at all. It probably takes some work to make tests work including mocking and separating stuff. So I didn't add any test case. I hope it's okay.