### PR TITLE
refactor(config): move `build.crossorigin` to `render.crossorigin`

### DIFF
--- a/packages/config/src/config/build.js
+++ b/packages/config/src/config/build.js
@@ -5,7 +5,6 @@ export default () => ({
   analyze: false,
   profile: process.argv.includes('--profile'),
   extractCSS: false,
-  crossorigin: undefined,
   cssSourceMap: undefined,
   ssr: undefined,
   parallel: false,

--- a/packages/config/src/config/render.js
+++ b/packages/config/src/config/render.js
@@ -6,6 +6,7 @@ export default () => ({
     shouldPreload: (fileWithoutQuery, asType) => ['script', 'style'].includes(asType),
     runInNewContext: undefined
   },
+  crossorigin: undefined,
   resourceHints: true,
   ssr: undefined,
   ssrLog: undefined,

--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -419,6 +419,13 @@ export function getNuxtConfig (_options) {
     options.build.indicator = false
   }
 
+  // TODO: Remove this if statement in Nuxt 3
+  if (options.build.crossorigin) {
+    consola.warn('Using `build.crossorigin` is deprecated and will be removed in Nuxt 3. Please use `render.crossorigin` instead.')
+    options.render.crossorigin = options.build.crossorigin
+    delete options.build.crossorigin
+  }
+
   const { timing } = options.server
   if (timing) {
     options.server.timing = { total: true, ...timing }

--- a/packages/config/test/__snapshots__/options.test.js.snap
+++ b/packages/config/test/__snapshots__/options.test.js.snap
@@ -28,7 +28,6 @@ Object {
       "configFile": false,
     },
     "cache": false,
-    "crossorigin": undefined,
     "cssSourceMap": false,
     "devMiddleware": Object {},
     "extractCSS": false,
@@ -297,6 +296,7 @@ Object {
     "compressor": Object {
       "threshold": 0,
     },
+    "crossorigin": undefined,
     "csp": false,
     "dist": Object {
       "index": false,

--- a/packages/config/test/config/__snapshots__/index.test.js.snap
+++ b/packages/config/test/config/__snapshots__/index.test.js.snap
@@ -15,7 +15,6 @@ Object {
       "configFile": false,
     },
     "cache": false,
-    "crossorigin": undefined,
     "cssSourceMap": undefined,
     "devMiddleware": Object {},
     "extractCSS": false,
@@ -269,6 +268,7 @@ Object {
     "compressor": Object {
       "threshold": 0,
     },
+    "crossorigin": undefined,
     "csp": false,
     "dist": Object {
       "index": false,
@@ -371,7 +371,6 @@ Object {
       "configFile": false,
     },
     "cache": false,
-    "crossorigin": undefined,
     "cssSourceMap": undefined,
     "devMiddleware": Object {},
     "extractCSS": false,
@@ -625,6 +624,7 @@ Object {
     "compressor": Object {
       "threshold": 0,
     },
+    "crossorigin": undefined,
     "csp": false,
     "dist": Object {
       "index": false,

--- a/packages/config/test/options.test.js
+++ b/packages/config/test/options.test.js
@@ -277,6 +277,11 @@ describe('config: options', () => {
       getNuxtConfig({ build: { extractCSS: { allChunks: true } } })
       expect(consola.warn).toHaveBeenCalledWith('build.extractCSS.allChunks has no effect from v2.0.0. Please use build.optimization.splitChunks settings instead.')
     })
+
+    test('should deprecate build.crossorigin', () => {
+      getNuxtConfig({ build: { crossorigin: 'use-credentials' } })
+      expect(consola.warn).toHaveBeenCalledWith('Using `build.crossorigin` is deprecated and will be removed in Nuxt 3. Please use `render.crossorigin` instead.')
+    })
   })
 })
 

--- a/packages/server/src/middleware/nuxt.js
+++ b/packages/server/src/middleware/nuxt.js
@@ -112,7 +112,7 @@ const defaultPushAssets = (preloadFiles, shouldPush, publicPath, options) => {
       return
     }
 
-    const { crossorigin } = options.build
+    const { crossorigin } = options.render
     const cors = `${crossorigin ? ` crossorigin=${crossorigin};` : ''}`
     // `modulepreload` rel attribute only supports script-like `as` value
     // https://html.spec.whatwg.org/multipage/links.html#link-type-modulepreload

--- a/packages/server/test/middleware/nuxt.test.js
+++ b/packages/server/test/middleware/nuxt.test.js
@@ -207,7 +207,7 @@ describe('server: nuxtMiddleware', () => {
     }
     context.renderRoute.mockReturnValue(result)
     context.options.dev = true
-    context.options.build.crossorigin = 'use-credentials'
+    context.options.render.crossorigin = 'use-credentials'
     context.options.render.http2 = {
       push: true,
       shouldPush: jest.fn((fileWithoutQuery, asType) => asType === 'script')

--- a/packages/vue-renderer/src/renderers/spa.js
+++ b/packages/vue-renderer/src/renderers/spa.js
@@ -107,7 +107,7 @@ export default class SPARenderer extends BaseRenderer {
 
       // Preload initial resources
       if (Array.isArray(manifest.initial)) {
-        const { crossorigin } = this.options.build
+        const { crossorigin } = this.options.render
         const cors = `${crossorigin ? ` crossorigin="${crossorigin}"` : ''}`
 
         meta.preloadFiles = manifest.initial

--- a/packages/vue-renderer/src/renderers/ssr.js
+++ b/packages/vue-renderer/src/renderers/ssr.js
@@ -21,7 +21,7 @@ export default class SSRRenderer extends BaseRenderer {
 
   renderScripts (renderContext) {
     const scripts = renderContext.renderScripts()
-    const { build: { crossorigin } } = this.options
+    const { render: { crossorigin } } = this.options
     if (!crossorigin) {
       return scripts
     }
@@ -37,7 +37,7 @@ export default class SSRRenderer extends BaseRenderer {
 
   renderResourceHints (renderContext) {
     const resourceHints = renderContext.renderResourceHints()
-    const { build: { crossorigin } } = this.options
+    const { render: { crossorigin } } = this.options
     if (!crossorigin) {
       return resourceHints
     }

--- a/packages/webpack/src/config/client.js
+++ b/packages/webpack/src/config/client.js
@@ -95,7 +95,7 @@ export default class WebpackClientConfig extends WebpackBaseConfig {
 
   plugins () {
     const plugins = super.plugins()
-    const { buildOptions, options: { appTemplatePath, buildDir, modern } } = this.buildContext
+    const { buildOptions, options: { appTemplatePath, buildDir, modern, render } } = this.buildContext
 
     // Generate output HTML for SSR
     if (buildOptions.ssr) {
@@ -150,9 +150,9 @@ export default class WebpackClientConfig extends WebpackBaseConfig {
       }))
     }
 
-    if (buildOptions.crossorigin) {
+    if (render.crossorigin) {
       plugins.push(new CorsPlugin({
-        crossorigin: buildOptions.crossorigin
+        crossorigin: render.crossorigin
       }))
     }
 

--- a/test/fixtures/modern/nuxt.config.js
+++ b/test/fixtures/modern/nuxt.config.js
@@ -1,7 +1,6 @@
 export default {
   modern: true,
   build: {
-    crossorigin: 'use-credentials',
     filenames: {
       app: ({ isModern }) => {
         return `${isModern ? 'modern-' : ''}[name].js`
@@ -12,6 +11,7 @@ export default {
     }
   },
   render: {
+    crossorigin: 'use-credentials',
     http2: {
       push: true
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

Issue is raised by @pimlie 
In order to make the configuration have a clearer namespace, this pr is moving `build.crossorigin` to `render.crossorigin` as `crossorigin` is more used by `renderer`.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

