### PR TITLE
feat(server): add custom HTTP headers into error response

### DIFF
--- a/packages/server/src/middleware/error.js
+++ b/packages/server/src/middleware/error.js
@@ -11,7 +11,7 @@ export default ({ resources, options }) => async function errorMiddleware (err, 
     statusCode: err.statusCode || 500,
     message: err.message || 'Nuxt Server Error',
     name: !err.name || err.name === 'Error' ? 'NuxtServerError' : err.name,
-    headers: err.headers || {}
+    headers: err.headers
   }
 
   const sendResponse = (content, type = 'text/html') => {
@@ -21,9 +21,13 @@ export default ({ resources, options }) => async function errorMiddleware (err, 
     res.setHeader('Content-Type', type + '; charset=utf-8')
     res.setHeader('Content-Length', Buffer.byteLength(content))
     res.setHeader('Cache-Control', 'no-cache, no-store, max-age=0, must-revalidate')
-    Object.entries(error.headers).forEach(([name, value]) => {
-      res.setHeader(name, value)
-    })
+
+    // Error headers
+    if (error.headers) {
+      for (const name in error.headers) {
+        res.setHeader(name, error.headers[name])
+      }
+    }
 
     // Send Response
     res.end(content, 'utf-8')

--- a/packages/server/src/middleware/error.js
+++ b/packages/server/src/middleware/error.js
@@ -10,7 +10,8 @@ export default ({ resources, options }) => async function errorMiddleware (err, 
   const error = {
     statusCode: err.statusCode || 500,
     message: err.message || 'Nuxt Server Error',
-    name: !err.name || err.name === 'Error' ? 'NuxtServerError' : err.name
+    name: !err.name || err.name === 'Error' ? 'NuxtServerError' : err.name,
+    headers: err.headers || {}
   }
 
   const sendResponse = (content, type = 'text/html') => {
@@ -20,6 +21,9 @@ export default ({ resources, options }) => async function errorMiddleware (err, 
     res.setHeader('Content-Type', type + '; charset=utf-8')
     res.setHeader('Content-Length', Buffer.byteLength(content))
     res.setHeader('Cache-Control', 'no-cache, no-store, max-age=0, must-revalidate')
+    Object.entries(error.headers).forEach(([name, value]) => {
+      res.setHeader(name, value)
+    })
 
     // Send Response
     res.end(content, 'utf-8')

--- a/packages/server/test/middleware/error.test.js
+++ b/packages/server/test/middleware/error.test.js
@@ -49,6 +49,7 @@ describe('server: errorMiddleware', () => {
     const params = createParams()
     const errorMiddleware = createErrorMiddleware(params)
     const error = new Error()
+    error.headers = { 'Custom-Header': 'test' }
     const ctx = createServerContext()
 
     await errorMiddleware(error, ctx.req, ctx.res, ctx.next)
@@ -56,10 +57,11 @@ describe('server: errorMiddleware', () => {
     expect(consola.error).toBeCalledWith(error)
     expect(ctx.res.statusCode).toEqual(500)
     expect(ctx.res.statusMessage).toEqual('NuxtServerError')
-    expect(ctx.res.setHeader).toBeCalledTimes(3)
+    expect(ctx.res.setHeader).toBeCalledTimes(4)
     expect(ctx.res.setHeader).nthCalledWith(1, 'Content-Type', 'text/html; charset=utf-8')
     expect(ctx.res.setHeader).nthCalledWith(2, 'Content-Length', Buffer.byteLength('error template'))
     expect(ctx.res.setHeader).nthCalledWith(3, 'Cache-Control', 'no-cache, no-store, max-age=0, must-revalidate')
+    expect(ctx.res.setHeader).nthCalledWith(4, 'Custom-Header', 'test')
     expect(params.resources.errorTemplate).toBeCalledTimes(1)
     expect(params.resources.errorTemplate).toBeCalledWith({
       status: 500,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
This PR add the capability to set a list of custom HTTP header on Error middleware when `throw error`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
Resolves: #7213

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

