### PR TITLE
feat: Progress indication when generating routes

### DIFF
--- a/packages/generator/src/generator.js
+++ b/packages/generator/src/generator.js
@@ -1,92 +1,80 @@
-/*!
- * @nuxt/generator v2.12.2 (c) 2016-2020
+import path from 'path'
+import Chalk from 'chalk'
+import consola from 'consola'
+import fsExtra from 'fs-extra'
+import htmlMinifier from 'html-minifier'
 
- * - All the amazing contributors
- * Released under the MIT License.
- * Website: https://nuxtjs.org
-*/
-'use strict';
+import { flatRoutes, isString, isUrl, promisifyRoute, waitFor } from '@nuxt/utils'
 
-Object.defineProperty(exports, '__esModule', { value: true });
-
-function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
-
-const path = _interopDefault(require('path'));
-const Chalk = _interopDefault(require('chalk'));
-const consola = _interopDefault(require('consola'));
-const fsExtra = _interopDefault(require('fs-extra'));
-const htmlMinifier = _interopDefault(require('html-minifier'));
-const utils = require('@nuxt/utils');
-
-class Generator {
+export default class Generator {
   constructor (nuxt, builder) {
-    this.nuxt = nuxt;
-    this.options = nuxt.options;
-    this.builder = builder;
+    this.nuxt = nuxt
+    this.options = nuxt.options
+    this.builder = builder
 
     // Set variables
-    this.staticRoutes = path.resolve(this.options.srcDir, this.options.dir.static);
-    this.srcBuiltPath = path.resolve(this.options.buildDir, 'dist', 'client');
-    this.distPath = this.options.generate.dir;
+    this.staticRoutes = path.resolve(this.options.srcDir, this.options.dir.static)
+    this.srcBuiltPath = path.resolve(this.options.buildDir, 'dist', 'client')
+    this.distPath = this.options.generate.dir
     this.distNuxtPath = path.join(
       this.distPath,
-      utils.isUrl(this.options.build.publicPath) ? '' : this.options.build.publicPath
-    );
+      isUrl(this.options.build.publicPath) ? '' : this.options.build.publicPath
+    )
   }
 
   async generate ({ build = true, init = true } = {}) {
-    consola.debug('Initializing generator...');
+    consola.debug('Initializing generator...')
 
-    await this.initiate({ build, init });
+    await this.initiate({ build, init })
 
-    consola.debug('Preparing routes for generate...');
+    consola.debug('Preparing routes for generate...')
 
-    const routes = await this.initRoutes();
+    const routes = await this.initRoutes()
 
-    consola.info('Generating pages');
+    consola.info('Generating pages')
 
-    const errors = await this.generateRoutes(routes);
+    const errors = await this.generateRoutes(routes)
 
-    await this.afterGenerate();
+    await this.afterGenerate()
 
     // Done hook
-    await this.nuxt.callHook('generate:done', this, errors);
+    await this.nuxt.callHook('generate:done', this, errors)
 
     return { errors }
   }
 
   async initiate ({ build = true, init = true } = {}) {
     // Wait for nuxt be ready
-    await this.nuxt.ready();
+    await this.nuxt.ready()
 
     // Call before hook
-    await this.nuxt.callHook('generate:before', this, this.options.generate);
+    await this.nuxt.callHook('generate:before', this, this.options.generate)
 
     if (build) {
       // Add flag to set process.static
-      this.builder.forGenerate();
+      this.builder.forGenerate()
 
       // Start build process
-      await this.builder.build();
+      await this.builder.build()
     }
 
     // Initialize dist directory
     if (init) {
-      await this.initDist();
+      await this.initDist()
     }
   }
 
   async initRoutes (...args) {
     // Resolve config.generate.routes promises before generating the routes
-    let generateRoutes = [];
+    let generateRoutes = []
     if (this.options.router.mode !== 'hash') {
       try {
-        generateRoutes = await utils.promisifyRoute(
+        generateRoutes = await promisifyRoute(
           this.options.generate.routes || [],
           ...args
-        );
+        )
       } catch (e) {
-        consola.error('Could not resolve routes');
+        consola.error('Could not resolve routes')
         throw e // eslint-disable-line no-unreachable
       }
     }
@@ -94,40 +82,40 @@ class Generator {
     let routes =
       this.options.router.mode === 'hash'
         ? ['/']
-        : utils.flatRoutes(this.options.router.routes);
+        : flatRoutes(this.options.router.routes)
 
-    routes = routes.filter(route => this.options.generate.exclude.every(regex => !regex.test(route)));
+    routes = routes.filter(route => this.options.generate.exclude.every(regex => !regex.test(route)))
 
-    routes = this.decorateWithPayloads(routes, generateRoutes);
+    routes = this.decorateWithPayloads(routes, generateRoutes)
 
     // extendRoutes hook
-    await this.nuxt.callHook('generate:extendRoutes', routes);
+    await this.nuxt.callHook('generate:extendRoutes', routes)
 
     return routes
   }
 
   async generateRoutes (routes) {
-		const errors = [];
-		const routesLength = routes.length;
-		let routeIndex = 0;
+    const errors = []
+    const routesTotal = routes.length;
+    let currentRoute = 0;
 
     // Start generate process
     while (routes.length) {
-			let n = 0;
+      let n = 0
       await Promise.all(
         routes
           .splice(0, this.options.generate.concurrency)
           .map(async ({ route, payload }) => {
-						await utils.waitFor(n++ * this.options.generate.interval);
-						routeIndex++;
-						await this.generateRoute({ route, payload, errors }, routeIndex, routesLength);
+            await waitFor(n++ * this.options.generate.interval)
+            currentRoute++
+            await this.generateRoute({ route, payload, errors }, currentRoute, routesTotal)
           })
-      );
+      )
     }
 
     // Improve string representation for errors
     // TODO: Use consola for more consistency
-    errors.toString = () => this._formatErrors(errors);
+    errors.toString = () => this._formatErrors(errors)
 
     return errors
   }
@@ -135,15 +123,15 @@ class Generator {
   _formatErrors (errors) {
     return errors
       .map(({ type, route, error }) => {
-        const isHandled = type === 'handled';
-        const color = isHandled ? 'yellow' : 'red';
+        const isHandled = type === 'handled'
+        const color = isHandled ? 'yellow' : 'red'
 
-        let line = Chalk[color](` ${route}\n\n`);
+        let line = Chalk[color](` ${route}\n\n`)
 
         if (isHandled) {
-          line += Chalk.grey(JSON.stringify(error, undefined, 2) + '\n');
+          line += Chalk.grey(JSON.stringify(error, undefined, 2) + '\n')
         } else {
-          line += Chalk.grey(error.stack || error.message || `${error}`);
+          line += Chalk.grey(error.stack || error.message || `${error}`)
         }
 
         return line
@@ -152,151 +140,151 @@ class Generator {
   }
 
   async afterGenerate () {
-    const { fallback } = this.options.generate;
+    const { fallback } = this.options.generate
 
     // Disable SPA fallback if value isn't a non-empty string
     if (typeof fallback !== 'string' || !fallback) {
       return
     }
 
-    const fallbackPath = path.join(this.distPath, fallback);
+    const fallbackPath = path.join(this.distPath, fallback)
 
     // Prevent conflicts
     if (await fsExtra.exists(fallbackPath)) {
-      consola.warn(`SPA fallback was configured, but the configured path (${fallbackPath}) already exists.`);
+      consola.warn(`SPA fallback was configured, but the configured path (${fallbackPath}) already exists.`)
       return
     }
 
     // Render and write the SPA template to the fallback path
-    let { html } = await this.nuxt.server.renderRoute('/', { spa: true });
+    let { html } = await this.nuxt.server.renderRoute('/', { spa: true })
 
     try {
-      html = this.minifyHtml(html);
+      html = this.minifyHtml(html)
     } catch (error) {
-      consola.warn('HTML minification failed for SPA fallback');
+      consola.warn('HTML minification failed for SPA fallback')
     }
 
-    await fsExtra.writeFile(fallbackPath, html, 'utf8');
+    await fsExtra.writeFile(fallbackPath, html, 'utf8')
   }
 
   async initDist () {
     // Clean destination folder
-    await fsExtra.remove(this.distPath);
+    await fsExtra.remove(this.distPath)
 
-    await this.nuxt.callHook('generate:distRemoved', this);
+    await this.nuxt.callHook('generate:distRemoved', this)
 
     // Copy static and built files
     if (await fsExtra.exists(this.staticRoutes)) {
-      await fsExtra.copy(this.staticRoutes, this.distPath);
+      await fsExtra.copy(this.staticRoutes, this.distPath)
     }
-    await fsExtra.copy(this.srcBuiltPath, this.distNuxtPath);
+    await fsExtra.copy(this.srcBuiltPath, this.distNuxtPath)
 
     // Add .nojekyll file to let GitHub Pages add the _nuxt/ folder
     // https://help.github.com/articles/files-that-start-with-an-underscore-are-missing/
-    const nojekyllPath = path.resolve(this.distPath, '.nojekyll');
-    fsExtra.writeFile(nojekyllPath, '');
+    const nojekyllPath = path.resolve(this.distPath, '.nojekyll')
+    fsExtra.writeFile(nojekyllPath, '')
 
-    await this.nuxt.callHook('generate:distCopied', this);
+    await this.nuxt.callHook('generate:distCopied', this)
   }
 
   decorateWithPayloads (routes, generateRoutes) {
-    const routeMap = {};
+    const routeMap = {}
     // Fill routeMap for known routes
     routes.forEach((route) => {
-      routeMap[route] = { route, payload: null };
-    });
+      routeMap[route] = { route, payload: null }
+    })
     // Fill routeMap with given generate.routes
     generateRoutes.forEach((route) => {
       // route is either a string or like { route : '/my_route/1', payload: {} }
-      const path = utils.isString(route) ? route : route.route;
+      const path = isString(route) ? route : route.route
       routeMap[path] = {
         route: path,
         payload: route.payload || null
-      };
-    });
+      }
+    })
     return Object.values(routeMap)
   }
 
-  async generateRoute ({ route, payload = {}, errors = [] }, currentRouteIndex = 1, totalRoutes = 1) {
-    let html;
-    const pageErrors = [];
+  async generateRoute ({ route, payload = {}, errors = [] }, currentRoute = 1, totalRoutes = 1) {
+    let html
+    const pageErrors = []
 
     try {
       const res = await this.nuxt.server.renderRoute(route, {
         _generate: true,
         payload
       })
-      ;({ html } = res);
+      ;({ html } = res)
       if (res.error) {
-        pageErrors.push({ type: 'handled', route, error: res.error });
+        pageErrors.push({ type: 'handled', route, error: res.error })
       }
     } catch (err) {
-      pageErrors.push({ type: 'unhandled', route, error: err });
-      errors.push(...pageErrors);
+      pageErrors.push({ type: 'unhandled', route, error: err })
+      errors.push(...pageErrors)
 
       await this.nuxt.callHook('generate:routeFailed', {
         route,
         errors: pageErrors
-      });
-      consola.error(this._formatErrors(pageErrors));
+      })
+      consola.error(this._formatErrors(pageErrors))
 
       return false
     }
 
     try {
-      html = this.minifyHtml(html);
+      html = this.minifyHtml(html)
     } catch (err) {
       const minifyErr = new Error(
         `HTML minification failed. Make sure the route generates valid HTML. Failed HTML:\n ${html}`
-      );
-      pageErrors.push({ type: 'unhandled', route, error: minifyErr });
+      )
+      pageErrors.push({ type: 'unhandled', route, error: minifyErr })
     }
 
-    let fileName;
+    let fileName
 
     if (this.options.generate.subFolders) {
-      fileName = path.join(route, path.sep, 'index.html'); // /about -> /about/index.html
-      fileName = fileName === '/404/index.html' ? '/404.html' : fileName; // /404 -> /404.html
+      fileName = path.join(route, path.sep, 'index.html') // /about -> /about/index.html
+      fileName = fileName === '/404/index.html' ? '/404.html' : fileName // /404 -> /404.html
     } else {
-      const normalizedRoute = route.replace(/\/$/, '');
-      fileName = route.length > 1 ? path.join(path.sep, normalizedRoute + '.html') : path.join(path.sep, 'index.html');
+      const normalizedRoute = route.replace(/\/$/, '')
+      fileName = route.length > 1 ? path.join(path.sep, normalizedRoute + '.html') : path.join(path.sep, 'index.html')
     }
 
     // Call hook to let user update the path & html
-    const page = { route, path: fileName, html };
-    await this.nuxt.callHook('generate:page', page);
+    const page = { route, path: fileName, html }
+    await this.nuxt.callHook('generate:page', page)
 
-    page.path = path.join(this.distPath, page.path);
+    page.path = path.join(this.distPath, page.path)
 
     // Make sure the sub folders are created
-    await fsExtra.mkdirp(path.dirname(page.path));
-    await fsExtra.writeFile(page.path, page.html, 'utf8');
+    await fsExtra.mkdirp(path.dirname(page.path))
+    await fsExtra.writeFile(page.path, page.html, 'utf8')
 
     await this.nuxt.callHook('generate:routeCreated', {
       route,
       path: page.path,
       errors: pageErrors
-    });
+    })
 
     if (pageErrors.length) {
-      consola.error('Error generating ' + route);
-      errors.push(...pageErrors);
+      consola.error('(' + currentRoute + '/' + totalRoutes + ') Error generating ' + route)
+      errors.push(...pageErrors)
     } else {
-      consola.success('(' + currentRouteIndex + '/' + totalRoutes + ') Generated ' + route);
+      consola.success('(' + currentRoute + '/' + totalRoutes + ') Generated ' + route)
     }
 
     return true
   }
 
   minifyHtml (html) {
-    let minificationOptions = this.options.build.html.minify;
+    let minificationOptions = this.options.build.html.minify
 
     // Legacy: Override minification options with generate.minify if present
     // TODO: Remove in Nuxt version 3
     if (typeof this.options.generate.minify !== 'undefined') {
-      minificationOptions = this.options.generate.minify;
+      minificationOptions = this.options.generate.minify
       consola.warn('generate.minify has been deprecated and will be removed in the next major version.' +
-        ' Use build.html.minify instead!');
+        ' Use build.html.minify instead!')
     }
 
     if (!minificationOptions) {
@@ -306,10 +294,3 @@ class Generator {
     return htmlMinifier.minify(html, minificationOptions)
   }
 }
-
-function getGenerator (nuxt) {
-  return new Generator(nuxt)
-}
-
-exports.Generator = Generator;
-exports.getGenerator = getGenerator;

--- a/packages/generator/src/generator.js
+++ b/packages/generator/src/generator.js
@@ -1,80 +1,92 @@
-import path from 'path'
-import Chalk from 'chalk'
-import consola from 'consola'
-import fsExtra from 'fs-extra'
-import htmlMinifier from 'html-minifier'
+/*!
+ * @nuxt/generator v2.12.2 (c) 2016-2020
 
-import { flatRoutes, isString, isUrl, promisifyRoute, waitFor } from '@nuxt/utils'
+ * - All the amazing contributors
+ * Released under the MIT License.
+ * Website: https://nuxtjs.org
+*/
+'use strict';
 
-export default class Generator {
+Object.defineProperty(exports, '__esModule', { value: true });
+
+function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
+
+const path = _interopDefault(require('path'));
+const Chalk = _interopDefault(require('chalk'));
+const consola = _interopDefault(require('consola'));
+const fsExtra = _interopDefault(require('fs-extra'));
+const htmlMinifier = _interopDefault(require('html-minifier'));
+const utils = require('@nuxt/utils');
+
+class Generator {
   constructor (nuxt, builder) {
-    this.nuxt = nuxt
-    this.options = nuxt.options
-    this.builder = builder
+    this.nuxt = nuxt;
+    this.options = nuxt.options;
+    this.builder = builder;
 
     // Set variables
-    this.staticRoutes = path.resolve(this.options.srcDir, this.options.dir.static)
-    this.srcBuiltPath = path.resolve(this.options.buildDir, 'dist', 'client')
-    this.distPath = this.options.generate.dir
+    this.staticRoutes = path.resolve(this.options.srcDir, this.options.dir.static);
+    this.srcBuiltPath = path.resolve(this.options.buildDir, 'dist', 'client');
+    this.distPath = this.options.generate.dir;
     this.distNuxtPath = path.join(
       this.distPath,
-      isUrl(this.options.build.publicPath) ? '' : this.options.build.publicPath
-    )
+      utils.isUrl(this.options.build.publicPath) ? '' : this.options.build.publicPath
+    );
   }
 
   async generate ({ build = true, init = true } = {}) {
-    consola.debug('Initializing generator...')
+    consola.debug('Initializing generator...');
 
-    await this.initiate({ build, init })
+    await this.initiate({ build, init });
 
-    consola.debug('Preparing routes for generate...')
+    consola.debug('Preparing routes for generate...');
 
-    const routes = await this.initRoutes()
+    const routes = await this.initRoutes();
 
-    consola.info('Generating pages')
+    consola.info('Generating pages');
 
-    const errors = await this.generateRoutes(routes)
+    const errors = await this.generateRoutes(routes);
 
-    await this.afterGenerate()
+    await this.afterGenerate();
 
     // Done hook
-    await this.nuxt.callHook('generate:done', this, errors)
+    await this.nuxt.callHook('generate:done', this, errors);
 
     return { errors }
   }
 
   async initiate ({ build = true, init = true } = {}) {
     // Wait for nuxt be ready
-    await this.nuxt.ready()
+    await this.nuxt.ready();
 
     // Call before hook
-    await this.nuxt.callHook('generate:before', this, this.options.generate)
+    await this.nuxt.callHook('generate:before', this, this.options.generate);
 
     if (build) {
       // Add flag to set process.static
-      this.builder.forGenerate()
+      this.builder.forGenerate();
 
       // Start build process
-      await this.builder.build()
+      await this.builder.build();
     }
 
     // Initialize dist directory
     if (init) {
-      await this.initDist()
+      await this.initDist();
     }
   }
 
   async initRoutes (...args) {
     // Resolve config.generate.routes promises before generating the routes
-    let generateRoutes = []
+    let generateRoutes = [];
     if (this.options.router.mode !== 'hash') {
       try {
-        generateRoutes = await promisifyRoute(
+        generateRoutes = await utils.promisifyRoute(
           this.options.generate.routes || [],
           ...args
-        )
+        );
       } catch (e) {
-        consola.error('Could not resolve routes')
+        consola.error('Could not resolve routes');
         throw e // eslint-disable-line no-unreachable
       }
     }
@@ -82,37 +94,40 @@ export default class Generator {
     let routes =
       this.options.router.mode === 'hash'
         ? ['/']
-        : flatRoutes(this.options.router.routes)
+        : utils.flatRoutes(this.options.router.routes);
 
-    routes = routes.filter(route => this.options.generate.exclude.every(regex => !regex.test(route)))
+    routes = routes.filter(route => this.options.generate.exclude.every(regex => !regex.test(route)));
 
-    routes = this.decorateWithPayloads(routes, generateRoutes)
+    routes = this.decorateWithPayloads(routes, generateRoutes);
 
     // extendRoutes hook
-    await this.nuxt.callHook('generate:extendRoutes', routes)
+    await this.nuxt.callHook('generate:extendRoutes', routes);
 
     return routes
   }
 
   async generateRoutes (routes) {
-    const errors = []
+		const errors = [];
+		const routesLength = routes.length;
+		let routeIndex = 0;
 
     // Start generate process
     while (routes.length) {
-      let n = 0
+			let n = 0;
       await Promise.all(
         routes
           .splice(0, this.options.generate.concurrency)
           .map(async ({ route, payload }) => {
-            await waitFor(n++ * this.options.generate.interval)
-            await this.generateRoute({ route, payload, errors })
+						await utils.waitFor(n++ * this.options.generate.interval);
+						routeIndex++;
+						await this.generateRoute({ route, payload, errors }, routeIndex, routesLength);
           })
-      )
+      );
     }
 
     // Improve string representation for errors
     // TODO: Use consola for more consistency
-    errors.toString = () => this._formatErrors(errors)
+    errors.toString = () => this._formatErrors(errors);
 
     return errors
   }
@@ -120,15 +135,15 @@ export default class Generator {
   _formatErrors (errors) {
     return errors
       .map(({ type, route, error }) => {
-        const isHandled = type === 'handled'
-        const color = isHandled ? 'yellow' : 'red'
+        const isHandled = type === 'handled';
+        const color = isHandled ? 'yellow' : 'red';
 
-        let line = Chalk[color](` ${route}\n\n`)
+        let line = Chalk[color](` ${route}\n\n`);
 
         if (isHandled) {
-          line += Chalk.grey(JSON.stringify(error, undefined, 2) + '\n')
+          line += Chalk.grey(JSON.stringify(error, undefined, 2) + '\n');
         } else {
-          line += Chalk.grey(error.stack || error.message || `${error}`)
+          line += Chalk.grey(error.stack || error.message || `${error}`);
         }
 
         return line
@@ -137,151 +152,151 @@ export default class Generator {
   }
 
   async afterGenerate () {
-    const { fallback } = this.options.generate
+    const { fallback } = this.options.generate;
 
     // Disable SPA fallback if value isn't a non-empty string
     if (typeof fallback !== 'string' || !fallback) {
       return
     }
 
-    const fallbackPath = path.join(this.distPath, fallback)
+    const fallbackPath = path.join(this.distPath, fallback);
 
     // Prevent conflicts
     if (await fsExtra.exists(fallbackPath)) {
-      consola.warn(`SPA fallback was configured, but the configured path (${fallbackPath}) already exists.`)
+      consola.warn(`SPA fallback was configured, but the configured path (${fallbackPath}) already exists.`);
       return
     }
 
     // Render and write the SPA template to the fallback path
-    let { html } = await this.nuxt.server.renderRoute('/', { spa: true })
+    let { html } = await this.nuxt.server.renderRoute('/', { spa: true });
 
     try {
-      html = this.minifyHtml(html)
+      html = this.minifyHtml(html);
     } catch (error) {
-      consola.warn('HTML minification failed for SPA fallback')
+      consola.warn('HTML minification failed for SPA fallback');
     }
 
-    await fsExtra.writeFile(fallbackPath, html, 'utf8')
+    await fsExtra.writeFile(fallbackPath, html, 'utf8');
   }
 
   async initDist () {
     // Clean destination folder
-    await fsExtra.remove(this.distPath)
+    await fsExtra.remove(this.distPath);
 
-    await this.nuxt.callHook('generate:distRemoved', this)
+    await this.nuxt.callHook('generate:distRemoved', this);
 
     // Copy static and built files
     if (await fsExtra.exists(this.staticRoutes)) {
-      await fsExtra.copy(this.staticRoutes, this.distPath)
+      await fsExtra.copy(this.staticRoutes, this.distPath);
     }
-    await fsExtra.copy(this.srcBuiltPath, this.distNuxtPath)
+    await fsExtra.copy(this.srcBuiltPath, this.distNuxtPath);
 
     // Add .nojekyll file to let GitHub Pages add the _nuxt/ folder
     // https://help.github.com/articles/files-that-start-with-an-underscore-are-missing/
-    const nojekyllPath = path.resolve(this.distPath, '.nojekyll')
-    fsExtra.writeFile(nojekyllPath, '')
+    const nojekyllPath = path.resolve(this.distPath, '.nojekyll');
+    fsExtra.writeFile(nojekyllPath, '');
 
-    await this.nuxt.callHook('generate:distCopied', this)
+    await this.nuxt.callHook('generate:distCopied', this);
   }
 
   decorateWithPayloads (routes, generateRoutes) {
-    const routeMap = {}
+    const routeMap = {};
     // Fill routeMap for known routes
     routes.forEach((route) => {
-      routeMap[route] = { route, payload: null }
-    })
+      routeMap[route] = { route, payload: null };
+    });
     // Fill routeMap with given generate.routes
     generateRoutes.forEach((route) => {
       // route is either a string or like { route : '/my_route/1', payload: {} }
-      const path = isString(route) ? route : route.route
+      const path = utils.isString(route) ? route : route.route;
       routeMap[path] = {
         route: path,
         payload: route.payload || null
-      }
-    })
+      };
+    });
     return Object.values(routeMap)
   }
 
-  async generateRoute ({ route, payload = {}, errors = [] }) {
-    let html
-    const pageErrors = []
+  async generateRoute ({ route, payload = {}, errors = [] }, currentRouteIndex = 1, totalRoutes = 1) {
+    let html;
+    const pageErrors = [];
 
     try {
       const res = await this.nuxt.server.renderRoute(route, {
         _generate: true,
         payload
       })
-      ;({ html } = res)
+      ;({ html } = res);
       if (res.error) {
-        pageErrors.push({ type: 'handled', route, error: res.error })
+        pageErrors.push({ type: 'handled', route, error: res.error });
       }
     } catch (err) {
-      pageErrors.push({ type: 'unhandled', route, error: err })
-      errors.push(...pageErrors)
+      pageErrors.push({ type: 'unhandled', route, error: err });
+      errors.push(...pageErrors);
 
       await this.nuxt.callHook('generate:routeFailed', {
         route,
         errors: pageErrors
-      })
-      consola.error(this._formatErrors(pageErrors))
+      });
+      consola.error(this._formatErrors(pageErrors));
 
       return false
     }
 
     try {
-      html = this.minifyHtml(html)
+      html = this.minifyHtml(html);
     } catch (err) {
       const minifyErr = new Error(
         `HTML minification failed. Make sure the route generates valid HTML. Failed HTML:\n ${html}`
-      )
-      pageErrors.push({ type: 'unhandled', route, error: minifyErr })
+      );
+      pageErrors.push({ type: 'unhandled', route, error: minifyErr });
     }
 
-    let fileName
+    let fileName;
 
     if (this.options.generate.subFolders) {
-      fileName = path.join(route, path.sep, 'index.html') // /about -> /about/index.html
-      fileName = fileName === '/404/index.html' ? '/404.html' : fileName // /404 -> /404.html
+      fileName = path.join(route, path.sep, 'index.html'); // /about -> /about/index.html
+      fileName = fileName === '/404/index.html' ? '/404.html' : fileName; // /404 -> /404.html
     } else {
-      const normalizedRoute = route.replace(/\/$/, '')
-      fileName = route.length > 1 ? path.join(path.sep, normalizedRoute + '.html') : path.join(path.sep, 'index.html')
+      const normalizedRoute = route.replace(/\/$/, '');
+      fileName = route.length > 1 ? path.join(path.sep, normalizedRoute + '.html') : path.join(path.sep, 'index.html');
     }
 
     // Call hook to let user update the path & html
-    const page = { route, path: fileName, html }
-    await this.nuxt.callHook('generate:page', page)
+    const page = { route, path: fileName, html };
+    await this.nuxt.callHook('generate:page', page);
 
-    page.path = path.join(this.distPath, page.path)
+    page.path = path.join(this.distPath, page.path);
 
     // Make sure the sub folders are created
-    await fsExtra.mkdirp(path.dirname(page.path))
-    await fsExtra.writeFile(page.path, page.html, 'utf8')
+    await fsExtra.mkdirp(path.dirname(page.path));
+    await fsExtra.writeFile(page.path, page.html, 'utf8');
 
     await this.nuxt.callHook('generate:routeCreated', {
       route,
       path: page.path,
       errors: pageErrors
-    })
+    });
 
     if (pageErrors.length) {
-      consola.error('Error generating ' + route)
-      errors.push(...pageErrors)
+      consola.error('Error generating ' + route);
+      errors.push(...pageErrors);
     } else {
-      consola.success('Generated ' + route)
+      consola.success('(' + currentRouteIndex + '/' + totalRoutes + ') Generated ' + route);
     }
 
     return true
   }
 
   minifyHtml (html) {
-    let minificationOptions = this.options.build.html.minify
+    let minificationOptions = this.options.build.html.minify;
 
     // Legacy: Override minification options with generate.minify if present
     // TODO: Remove in Nuxt version 3
     if (typeof this.options.generate.minify !== 'undefined') {
-      minificationOptions = this.options.generate.minify
+      minificationOptions = this.options.generate.minify;
       consola.warn('generate.minify has been deprecated and will be removed in the next major version.' +
-        ' Use build.html.minify instead!')
+        ' Use build.html.minify instead!');
     }
 
     if (!minificationOptions) {
@@ -291,3 +306,10 @@ export default class Generator {
     return htmlMinifier.minify(html, minificationOptions)
   }
 }
+
+function getGenerator (nuxt) {
+  return new Generator(nuxt)
+}
+
+exports.Generator = Generator;
+exports.getGenerator = getGenerator;

--- a/packages/generator/src/generator.js
+++ b/packages/generator/src/generator.js
@@ -96,8 +96,8 @@ export default class Generator {
 
   async generateRoutes (routes) {
     const errors = []
-    const routesTotal = routes.length;
-    let currentRoute = 0;
+    const routesTotal = routes.length
+    let currentRoute = 0
 
     // Start generate process
     while (routes.length) {


### PR DESCRIPTION
Adds a progress indication to the console when generating routes (e.g. `(2/3) Generated /about-us`)

![nuxt generate progress](https://user-images.githubusercontent.com/3786627/80711907-6b4a3c00-8af1-11ea-885b-dc8cb1286bbb.gif)

## Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
As described in this issue: https://github.com/nuxt/nuxt.js/issues/7038 it would be handy with a little progress indication when generating routes.

I generate around 3000 routes for an e-commerce site, and it takes anywhere between 600-3000 seconds (currently investigating why) and it would be quite helpful for my impatience to have some kind of idea where in the process we are.

This pull request will add a simple indication when generating routes, like so:

    (1/3) Generated /home
    (2/3) Generate /about-us
    (3/3) Generated /contact

I would have loved to implement it using https://github.com/nuxt/webpackbar, however, lack of knowledge of how to implement it made me refrain from doing it (the webpackbar could use a little improvement in the documentation ;))

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

Not sure how to run the testsuite yet. Doubt this change would have an effect.