### PR TITLE
fix(babel): not override presets if babelrc is true

### DIFF
--- a/packages/webpack/src/config/base.js
+++ b/packages/webpack/src/config/base.js
@@ -98,7 +98,7 @@ export default class WebpackBaseConfig {
       envName
     }
 
-    if (options.configFile !== false) {
+    if (options.configFile || options.babelrc) {
       return options
     }
 
@@ -114,7 +114,7 @@ export default class WebpackBaseConfig {
       )
     }
 
-    if (!options.babelrc && !options.presets) {
+    if (!options.presets) {
       options.presets = [defaultPreset]
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

Related to https://github.com/nuxt/nuxt.js/issues/7291

If `babel.babelrc` is true, it means user will use `.babelrc` to config babel option, so we shouldn't override presets, we've ignore the override for `babel.configFile`, this pr is applying same logic to `babel.babelrc`

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

