### PR TITLE
feat(modern): remove inlined safari fix in csp mode

### DIFF
--- a/packages/webpack/src/config/client.js
+++ b/packages/webpack/src/config/client.js
@@ -144,9 +144,17 @@ export default class WebpackClientConfig extends WebpackBaseConfig {
     }
 
     if (modern) {
+      let noUnsafeInline = false
+      const { csp } = this.buildContext.options.render
+      if (csp) {
+        const { policies = {} } = csp
+        const scriptPolicy = policies['script-src'] || policies['default-src'] || []
+        noUnsafeInline = !scriptPolicy.includes('\'unsafe-inline\'')
+      }
       plugins.push(new ModernModePlugin({
         targetDir: path.resolve(buildDir, 'dist', 'client'),
-        isModernBuild: this.isModern
+        isModernBuild: this.isModern,
+        noUnsafeInline
       }))
     }
 

--- a/packages/webpack/src/config/client.js
+++ b/packages/webpack/src/config/client.js
@@ -23,6 +23,14 @@ export default class WebpackClientConfig extends WebpackBaseConfig {
     return this.dev ? 'cheap-module-eval-source-map' : false
   }
 
+  getCspScriptPolicy () {
+    const { csp } = this.buildContext.options.render
+    if (csp) {
+      const { policies = {} } = csp
+      return policies['script-src'] || policies['default-src'] || []
+    }
+  }
+
   getFileName (...args) {
     if (this.buildContext.buildOptions.analyze) {
       const [key] = args
@@ -144,13 +152,8 @@ export default class WebpackClientConfig extends WebpackBaseConfig {
     }
 
     if (modern) {
-      let noUnsafeInline = false
-      const { csp } = this.buildContext.options.render
-      if (csp) {
-        const { policies = {} } = csp
-        const scriptPolicy = policies['script-src'] || policies['default-src'] || []
-        noUnsafeInline = !scriptPolicy.includes('\'unsafe-inline\'')
-      }
+      const scriptPolicy = this.getCspScriptPolicy()
+      const noUnsafeInline = scriptPolicy && !scriptPolicy.includes('\'unsafe-inline\'')
       plugins.push(new ModernModePlugin({
         targetDir: path.resolve(buildDir, 'dist', 'client'),
         isModernBuild: this.isModern,

--- a/test/dev/modern.spa.test.js
+++ b/test/dev/modern.spa.test.js
@@ -54,6 +54,11 @@ describe('modern client mode (SPA)', () => {
     expect(response).toContain('<link rel="modulepreload" crossorigin="use-credentials" href="/_nuxt/modern-commons.app.js" as="script">')
   })
 
+  test('should contain safari nomodule fix', async () => {
+    const { body: response } = await rp(url('/'), { headers: { 'user-agent': modernUA } })
+    expect(response).toContain('src="/_nuxt/safari-nomodule-fix.js" crossorigin="use-credentials"')
+  })
+
   test('should contain modern http2 pushed resources', async () => {
     const { headers: { link } } = await rp(url('/'), { headers: { 'user-agent': modernUA } })
     expect(link).toEqual([

--- a/test/fixtures/modern/nuxt.config.js
+++ b/test/fixtures/modern/nuxt.config.js
@@ -11,6 +11,7 @@ export default {
     }
   },
   render: {
+    csp: true,
     crossorigin: 'use-credentials',
     http2: {
       push: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
Idea is from https://github.com/vuejs/vue-cli/pull/2741
Related issue: https://github.com/nuxt/nuxt.js/issues/4876

If `csp` is enabled without `unsafe-inline`, let's inject safari no-module fix as an external script.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

