### PR TITLE
feat(server): support csp report-uri

### DIFF
--- a/test/dev/basic.ssr.csp.test.js
+++ b/test/dev/basic.ssr.csp.test.js
@@ -129,6 +129,26 @@ describe('basic ssr csp', () => {
     )
 
     test(
+      'Contain report-uri in Content-Security-Policy-Report-Only header, when explicitly asked for CSRP, allowedSources, csp.report-url',
+      async () => {
+        const cspOption = {
+          allowedSources: ['https://example.com', 'https://example.io'],
+          reportOnly: true,
+          policies: {
+            'report-uri': '/csp_report_uri'
+          }
+        }
+        nuxt = await startCspDevServer(cspOption)
+        const { headers } = await rp(url('/stateless'))
+
+        expect(headers[reportOnlyHeader]).toMatch(/^script-src 'self' 'sha256-.*'/)
+        expect(headers[reportOnlyHeader]).toContain('https://example.com')
+        expect(headers[reportOnlyHeader]).toContain('https://example.io')
+        expect(headers[reportOnlyHeader]).toContain('report-uri /csp_report_uri')
+      }
+    )
+
+    test(
       'Contain only unique hashes in header when csp.policies is set',
       async () => {
         const policies = {
@@ -299,6 +319,26 @@ describe('basic ssr csp', () => {
         expect(headers[reportOnlyHeader]).toMatch(/script-src 'sha256-(.*)?' 'self'/)
         expect(headers[reportOnlyHeader]).toContain('https://example.com')
         expect(headers[reportOnlyHeader]).toContain('https://example.io')
+      }
+    )
+
+    test(
+      'Contain report-uri in Content-Security-Policy-Report-Only header, when explicitly asked for CSRP, allowedSources, csp.report-url',
+      async () => {
+        const cspOption = {
+          allowedSources: ['https://example.com', 'https://example.io'],
+          reportOnly: true,
+          policies: {
+            'report-uri': '/csp_report_uri'
+          }
+        }
+        nuxt = await startCspDevServer(cspOption)
+        const { headers } = await rp(url('/stateless'))
+
+        expect(headers[reportOnlyHeader]).toMatch(/^script-src 'self' 'sha256-.*'/)
+        expect(headers[reportOnlyHeader]).toContain('https://example.com')
+        expect(headers[reportOnlyHeader]).toContain('https://example.io')
+        expect(headers[reportOnlyHeader]).toContain('report-uri /csp_report_uri')
       }
     )
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
Now, we cannot set report-uri when setting alloweSources option.
I enable to set report-uri in Content-Security-Policy-Repor-Only header, even if allowedSources is set.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

