### PR TITLE
fix(webpack): allow hmr client path to be set

### DIFF
--- a/packages/webpack/src/config/client.js
+++ b/packages/webpack/src/config/client.js
@@ -185,7 +185,7 @@ export default class WebpackClientConfig extends WebpackBaseConfig {
     } = this.buildContext
 
     const { client = {} } = hotMiddleware || {}
-    const { ansiColors, overlayStyles, path, ...options } = client
+    const { ansiColors, overlayStyles, path: pathFromOptions, ...options } = client
 
     const hotMiddlewareClientOptions = {
       reload: true,
@@ -195,7 +195,7 @@ export default class WebpackClientConfig extends WebpackBaseConfig {
       ...options,
       name: this.name
     }
-    const clientPath = path || `${router.base}/__webpack_hmr/${this.name}`
+    const clientPath = pathFromOptions || `${router.base}/__webpack_hmr/${this.name}`
 
     const hotMiddlewareClientOptionsStr =
       `${querystring.stringify(hotMiddlewareClientOptions)}&path=${clientPath}`.replace(/\/\//g, '/')

--- a/packages/webpack/src/config/client.js
+++ b/packages/webpack/src/config/client.js
@@ -185,20 +185,19 @@ export default class WebpackClientConfig extends WebpackBaseConfig {
     } = this.buildContext
 
     const { client = {} } = hotMiddleware || {}
-    const { ansiColors, overlayStyles, path: pathFromOptions, ...options } = client
+    const { ansiColors, overlayStyles, ...options } = client
 
     const hotMiddlewareClientOptions = {
       reload: true,
       timeout: 30000,
       ansiColors: JSON.stringify(ansiColors),
       overlayStyles: JSON.stringify(overlayStyles),
+      path: `${router.base}/__webpack_hmr/${this.name}`.replace(/\/\//g, '/'),
       ...options,
       name: this.name
     }
-    const clientPath = pathFromOptions || `${router.base}/__webpack_hmr/${this.name}`
 
-    const hotMiddlewareClientOptionsStr =
-      `${querystring.stringify(hotMiddlewareClientOptions)}&path=${clientPath}`.replace(/\/\//g, '/')
+    const hotMiddlewareClientOptionsStr = querystring.stringify(hotMiddlewareClientOptions)
 
     // Entry points
     config.entry = Object.assign({}, config.entry, {

--- a/packages/webpack/src/config/client.js
+++ b/packages/webpack/src/config/client.js
@@ -185,7 +185,8 @@ export default class WebpackClientConfig extends WebpackBaseConfig {
     } = this.buildContext
 
     const { client = {} } = hotMiddleware || {}
-    const { ansiColors, overlayStyles, ...options } = client
+    const { ansiColors, overlayStyles, path, ...options } = client
+
     const hotMiddlewareClientOptions = {
       reload: true,
       timeout: 30000,
@@ -194,7 +195,8 @@ export default class WebpackClientConfig extends WebpackBaseConfig {
       ...options,
       name: this.name
     }
-    const clientPath = `${router.base}/__webpack_hmr/${this.name}`
+    const clientPath = path || `${router.base}/__webpack_hmr/${this.name}`
+
     const hotMiddlewareClientOptionsStr =
       `${querystring.stringify(hotMiddlewareClientOptions)}&path=${clientPath}`.replace(/\/\//g, '/')
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

Hi,
I'm trying to set the path to the webpack hmr client in the config, but as the path is set by hand in the query string, we end with 2 paths in query string: 
```js
// nuxt.config.js

hotMiddleware: {
  client: {
    path: DEV_URL + '/__webpack_hmr/client',
  },
},
```

```js
// query string sent to client by /packages/webpack/src/config/client.js#L200:

"?reload=true&timeout=30000&ansiColors=&overlayStyles=&path=http%3A%2F%2Flocalhost%3A3000%2F__webpack_hmr%2Fclient&name=client&path=/__webpack_hmr/client"
```

The HMR client (https://github.com/webpack-contrib/webpack-hot-middleware/blob/master/client.js#L17) will parse this querystring, and set an object with two paths, and then will try to make the request to a stringified version of an array of theses two paths which will result in a 404:
>XHR GET http://localhost:3000/__webpack_hmr/client,/__webpack_hmr/client



This PR fix that by using the path set in config.

It should not be a breaking change, as nobody could have used the behavior with theses two paths.


PS: I've kept the `&path` way because of [this commit](https://github.com/nuxt/nuxt.js/pull/4796/commits/aefba48e743792547979cdc074c09cfe4d6d9569) message:
>HMR client path should not be encoded 

But actually, I see no problem with encoding it, as the client will decode it afterwards. If ok for you, I will just merge the path with the other options.

Maybe @wangxingkai can help us with that?

Thanks for your amazing work,
Mathieu.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

