### PR TITLE
fix(cli): add back flags for generate and add _export flag

### DIFF
--- a/packages/cli/src/commands/export.js
+++ b/packages/cli/src/commands/export.js
@@ -21,7 +21,8 @@ export default {
     const config = await cmd.getNuxtConfig({
       dev: false,
       target: TARGETS.static,
-      _build: cmd.argv.build
+      _build: false,
+      _export: true
     })
     const nuxt = await cmd.getNuxt(config)
 

--- a/packages/cli/src/commands/export.js
+++ b/packages/cli/src/commands/export.js
@@ -21,7 +21,6 @@ export default {
     const config = await cmd.getNuxtConfig({
       dev: false,
       target: TARGETS.static,
-      _build: false,
       _export: true
     })
     const nuxt = await cmd.getNuxt(config)

--- a/packages/cli/src/commands/generate.js
+++ b/packages/cli/src/commands/generate.js
@@ -56,7 +56,8 @@ export default {
   async run (cmd) {
     const config = await cmd.getNuxtConfig({
       dev: false,
-      _build: cmd.argv.build
+      _build: cmd.argv.build,
+      _generate: true
     })
 
     if (config.target === TARGETS.static) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
It was a breaking change to remove `_generate` flag when running `nuxt generate`, add it back + add `_export` flag in `nuxt export`

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

