### PR TITLE
feat: store and replay vuex mutations for static target

### DIFF
--- a/packages/vue-app/template/server.js
+++ b/packages/vue-app/template/server.js
@@ -93,6 +93,12 @@ export default async (ssrContext) => {
   ssrContext.asyncData = {}
   <% } %>
 
+  <% if (isFullStatic && store) { %>
+  // Record store mutations for full-static
+  ssrContext.nuxt.mutations = []
+  store.subscribe(m => { ssrContext.nuxt.mutations.push([m.type, m.payload]) })
+  <% } %>
+
   const beforeRender = async () => {
     // Call beforeNuxtRender() methods
     await Promise.all(ssrContext.beforeRenderFns.map(fn => promisify(fn, { Components, nuxtState: ssrContext.nuxt })))

--- a/packages/vue-app/template/server.js
+++ b/packages/vue-app/template/server.js
@@ -93,12 +93,6 @@ export default async (ssrContext) => {
   ssrContext.asyncData = {}
   <% } %>
 
-  <% if (isFullStatic && store) { %>
-  // Record store mutations for full-static
-  ssrContext.nuxt.mutations = []
-  const unsubscribe = store.subscribe(m => { ssrContext.nuxt.mutations.push([m.type, m.payload]) })
-  <% } %>
-
   const beforeRender = async () => {
     // Call beforeNuxtRender() methods
     await Promise.all(ssrContext.beforeRenderFns.map(fn => promisify(fn, { Components, nuxtState: ssrContext.nuxt })))
@@ -108,7 +102,7 @@ export default async (ssrContext) => {
       ssrContext.nuxt.state = store.state
       <% if (isFullStatic && store) { %>
       // Stop recording store mutations
-      unsubscribe()
+      ssrContext.unsetMutationObserver()
       <% } %>
     }
     <% } %>
@@ -183,6 +177,12 @@ export default async (ssrContext) => {
   if (ssrContext.nuxt.error) {
     return renderErrorPage()
   }
+  <% } %>
+
+  <% if (isFullStatic && store) { %>
+  // Record store mutations for full-static after nuxtServerInit and Middleware
+  ssrContext.nuxt.mutations =[]
+  ssrContext.unsetMutationObserver = store.subscribe(m => { ssrContext.nuxt.mutations.push([m.type, m.payload]) })
   <% } %>
 
   <% if (features.layouts) { %>

--- a/packages/vue-app/template/server.js
+++ b/packages/vue-app/template/server.js
@@ -96,7 +96,7 @@ export default async (ssrContext) => {
   <% if (isFullStatic && store) { %>
   // Record store mutations for full-static
   ssrContext.nuxt.mutations = []
-  store.subscribe(m => { ssrContext.nuxt.mutations.push([m.type, m.payload]) })
+  const unsubscribe = store.subscribe(m => { ssrContext.nuxt.mutations.push([m.type, m.payload]) })
   <% } %>
 
   const beforeRender = async () => {
@@ -106,6 +106,10 @@ export default async (ssrContext) => {
     ssrContext.rendered = () => {
       // Add the state from the vuex store
       ssrContext.nuxt.state = store.state
+      <% if (isFullStatic && store) { %>
+      // Stop recording store mutations
+      unsubscribe()
+      <% } %>
     }
     <% } %>
   }

--- a/packages/vue-renderer/src/renderers/ssr.js
+++ b/packages/vue-renderer/src/renderers/ssr.js
@@ -163,7 +163,7 @@ export default class SSRRenderer extends BaseRenderer {
       const preloadScripts = []
       renderContext.staticAssets = []
       const { staticAssetsBase, url, nuxt, staticAssets } = renderContext
-      const { data, fetch, ...state } = nuxt
+      const { data, fetch, mutations, ...state } = nuxt
 
       // Initial state
       const nuxtStaticScript = `window.__NUXT_STATIC__='${staticAssetsBase}';`
@@ -186,7 +186,7 @@ export default class SSRRenderer extends BaseRenderer {
       const payloadPath = urlJoin(url, 'payload.js')
       const payloadUrl = urlJoin(staticAssetsBase, payloadPath)
       const routePath = (url.replace(/\/+$/, '') || '/').split('?')[0] // remove trailing slah and query params
-      const payloadScript = `__NUXT_JSONP__("${routePath}", ${devalue({ data, fetch })});`
+      const payloadScript = `__NUXT_JSONP__("${routePath}", ${devalue({ data, fetch, mutations })});`
       staticAssets.push({ path: payloadPath, src: payloadScript })
       preloadScripts.push(payloadUrl)
 

--- a/test/fixtures/full-static/full-static.test.js
+++ b/test/fixtures/full-static/full-static.test.js
@@ -1,0 +1,3 @@
+import { buildFixture } from '../../utils/build'
+
+buildFixture('full-static')

--- a/test/fixtures/full-static/layouts/default.vue
+++ b/test/fixtures/full-static/layouts/default.vue
@@ -1,0 +1,21 @@
+<template>
+  <div>
+    <NLink to="/">
+      Home
+    </NLink>
+    <NLink to="/store">
+      Store
+    </NLink>
+    <NLink to="/pagination/1">
+      Pagination
+    </NLink>
+    <br>
+    <Nuxt />
+  </div>
+</template>
+
+<style scoped>
+a {
+  margin: 0 1em;
+}
+</style>

--- a/test/fixtures/full-static/nuxt.config.js
+++ b/test/fixtures/full-static/nuxt.config.js
@@ -1,0 +1,3 @@
+export default {
+  target: 'static'
+}

--- a/test/fixtures/full-static/pages/index.vue
+++ b/test/fixtures/full-static/pages/index.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    <h1>Full Static Playground!</h1>
+  </div>
+</template>

--- a/test/fixtures/full-static/pages/pagination/_i.vue
+++ b/test/fixtures/full-static/pages/pagination/_i.vue
@@ -1,0 +1,21 @@
+<template>
+  <div>
+    <NLink v-if="i>0" :to="`./${i-1}`">
+      Previous
+    </NLink>
+    Page {{ i }}
+    <NLink v-if="i<5" :to="`./${i+1}`">
+      Next
+    </NLink>
+  </div>
+</template>
+
+<script>
+export default {
+  computed: {
+    i () {
+      return parseInt(this.$route.params.i) || 0
+    }
+  }
+}
+</script>

--- a/test/fixtures/full-static/pages/store.vue
+++ b/test/fixtures/full-static/pages/store.vue
@@ -1,0 +1,18 @@
+<template>
+  <div>
+    <h3>Welcome {{ $store.state.auth.user.name }}!</h3>
+    <br>
+    You visited this page <strong>{{ $store.state.counter }}</strong> times.
+  </div>
+</template>
+
+<script>
+export default {
+  fetch () {
+    this.$store.commit('COUNT')
+  },
+  async asyncData ({ store }) {
+    await store.dispatch('auth/FETCH_USER')
+  }
+}
+</script>

--- a/test/fixtures/full-static/store/auth.js
+++ b/test/fixtures/full-static/store/auth.js
@@ -1,0 +1,17 @@
+export const state = () => ({
+  user: null
+})
+
+export const mutations = {
+  SET_USER (state, user) {
+    state.user = user
+  }
+}
+
+export const actions = {
+  FETCH_USER ({ commit }) {
+    commit('SET_USER', {
+      name: (process.client ? 'C' : 'S') + ' Æ A-' + (10 + Math.round(Math.random() * 10))
+    })
+  }
+}

--- a/test/fixtures/full-static/store/index.js
+++ b/test/fixtures/full-static/store/index.js
@@ -1,0 +1,9 @@
+export const state = () => ({
+  counter: 0
+})
+
+export const mutations = {
+  COUNT (state) {
+    state.counter += 1
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
This PR, records, and replays store mutations during client-side-navigation for the new full static target in order to allow updating (store) state with `asyncData()` and `fetch()`

Try locally:

```bash
yarn nuxt build test/fixtures/full-static
yarn nuxt export test/fixtures/full-static
yarn nuxt serve test/fixtures/full-static
```

Navigate to http://localhost:3000 and click on store link for testing CSR state restore.

You should see:

![image](https://user-images.githubusercontent.com/5158436/81606251-033e0480-93d3-11ea-8bdb-37c3d8f35461.png)

PS: This is the first use case of store mutations I've ever seen :D

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

