### PR TITLE
fix(generator, builder): empty build and dist directories instead of remove

### DIFF
--- a/packages/builder/src/builder.js
+++ b/packages/builder/src/builder.js
@@ -153,8 +153,8 @@ export default class Builder {
 
     consola.debug(`App root: ${this.options.srcDir}`)
 
-    // Create .nuxt/, .nuxt/components and .nuxt/dist folders
-    await fsExtra.remove(r(this.options.buildDir))
+    // Create or empty .nuxt/, .nuxt/components and .nuxt/dist folders
+    await fsExtra.emptyDir(r(this.options.buildDir))
     const buildDirs = [r(this.options.buildDir, 'components')]
     if (!this.options.dev) {
       buildDirs.push(
@@ -162,7 +162,7 @@ export default class Builder {
         r(this.options.buildDir, 'dist', 'server')
       )
     }
-    await Promise.all(buildDirs.map(dir => fsExtra.mkdirp(dir)))
+    await Promise.all(buildDirs.map(dir => fsExtra.emptyDir(dir)))
 
     // Call ready hook
     await this.nuxt.callHook('builder:prepared', this, this.options.build)

--- a/packages/builder/test/builder.build.test.js
+++ b/packages/builder/test/builder.build.test.js
@@ -18,6 +18,7 @@ jest.mock('@nuxt/webpack')
 describe('builder: builder build', () => {
   beforeAll(() => {
     jest.spyOn(path, 'join').mockImplementation((...args) => `join(${args.join(', ')})`)
+    r.mockImplementation((...args) => `r(${args.join(', ')})`)
   })
 
   afterAll(() => {
@@ -44,8 +45,6 @@ describe('builder: builder build', () => {
     builder.generateRoutesAndFiles = jest.fn()
     builder.resolvePlugins = jest.fn()
 
-    r.mockImplementation((dir, src) => `r(${dir})`)
-
     const buildReturn = await builder.build()
 
     expect(consola.info).toBeCalledTimes(3)
@@ -60,12 +59,11 @@ describe('builder: builder build', () => {
     expect(consola.success).toBeCalledWith('Builder initialized')
     expect(consola.debug).toBeCalledTimes(1)
     expect(consola.debug).toBeCalledWith('App root: /var/nuxt/src')
-    expect(fsExtra.remove).toBeCalledTimes(1)
-    expect(fsExtra.remove).toBeCalledWith('r(/var/nuxt/build)')
-    expect(fsExtra.mkdirp).toBeCalledTimes(3)
-    expect(fsExtra.mkdirp).nthCalledWith(1, 'r(/var/nuxt/build)')
-    expect(fsExtra.mkdirp).nthCalledWith(2, 'r(/var/nuxt/build)')
-    expect(fsExtra.mkdirp).nthCalledWith(3, 'r(/var/nuxt/build)')
+    expect(fsExtra.emptyDir).toBeCalledTimes(4)
+    expect(fsExtra.emptyDir).nthCalledWith(1, 'r(/var/nuxt/build)')
+    expect(fsExtra.emptyDir).nthCalledWith(2, 'r(/var/nuxt/build, components)')
+    expect(fsExtra.emptyDir).nthCalledWith(3, 'r(/var/nuxt/build, dist, client)')
+    expect(fsExtra.emptyDir).nthCalledWith(4, 'r(/var/nuxt/build, dist, server)')
     expect(r).toBeCalledTimes(4)
     expect(r).nthCalledWith(1, '/var/nuxt/build')
     expect(r).nthCalledWith(2, '/var/nuxt/build', 'components')
@@ -132,8 +130,9 @@ describe('builder: builder build', () => {
     expect(consola.info).toBeCalledTimes(2)
     expect(consola.info).nthCalledWith(1, 'Preparing project for development')
     expect(consola.info).nthCalledWith(2, 'Initial build may take a while')
-    expect(fsExtra.mkdirp).toBeCalledTimes(1)
-    expect(fsExtra.mkdirp).toBeCalledWith('r(/var/nuxt/build)')
+    expect(fsExtra.emptyDir).toBeCalledTimes(2)
+    expect(fsExtra.emptyDir).nthCalledWith(1, 'r(/var/nuxt/build)')
+    expect(fsExtra.emptyDir).nthCalledWith(2, 'r(/var/nuxt/build, components)')
     expect(r).toBeCalledTimes(2)
     expect(r).nthCalledWith(1, '/var/nuxt/build')
     expect(r).nthCalledWith(2, '/var/nuxt/build', 'components')

--- a/packages/generator/src/generator.js
+++ b/packages/generator/src/generator.js
@@ -219,7 +219,7 @@ export default class Generator {
 
   async initDist () {
     // Clean destination folder
-    await fsExtra.remove(this.distPath)
+    await fsExtra.emptyDir(this.distPath)
 
     consola.info(`Generating output directory: ${path.basename(this.distPath)}/`)
     await this.nuxt.callHook('generate:distRemoved', this)

--- a/packages/generator/test/generator.init.test.js
+++ b/packages/generator/test/generator.init.test.js
@@ -182,8 +182,8 @@ describe('generator: initialize', () => {
 
     await generator.initDist()
 
-    expect(fsExtra.remove).toBeCalledTimes(1)
-    expect(fsExtra.remove).toBeCalledWith(generator.distPath)
+    expect(fsExtra.emptyDir).toBeCalledTimes(1)
+    expect(fsExtra.emptyDir).toBeCalledWith(generator.distPath)
     expect(nuxt.callHook).toBeCalledTimes(2)
     expect(nuxt.callHook).nthCalledWith(1, 'generate:distRemoved', generator)
     expect(fsExtra.exists).toBeCalledTimes(1)


### PR DESCRIPTION
fixes #5344

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Instead of removing and recreating the **dist** and **build** directories they are emptied.
In case they do not exists they are still created by the emptyDir function.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.