### PR TITLE
fix: set build indicator icon height for ie11

### DIFF
--- a/packages/vue-app/template/components/nuxt-build-indicator.vue
+++ b/packages/vue-app/template/components/nuxt-build-indicator.vue
@@ -136,6 +136,7 @@ svg {
   display: inline-block;
   vertical-align: baseline;
   width: 1.1em;
+  height: 1.1em;
   position: relative;
   top: 1px;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

![image](https://user-images.githubusercontent.com/19991745/82126482-c51b5900-97b5-11ea-98a6-8dc7aa91dd4a.png)


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.
