### PR TITLE
fix: set build indicator icon height for ie11

### DIFF
--- a/packages/vue-app/template/components/nuxt-build-indicator.vue
+++ b/packages/vue-app/template/components/nuxt-build-indicator.vue
@@ -136,7 +136,7 @@ svg {
   display: inline-block;
   vertical-align: baseline;
   width: 1.1em;
-  height: 1.1em;
+  height: 0.825em;
   position: relative;
   top: 1px;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
Related #7377 

Before
![image](https://user-images.githubusercontent.com/19991745/82133107-5f988e00-97f0-11ea-9312-65aa06eec228.png)

After
![image](https://user-images.githubusercontent.com/19991745/82133103-4e4f8180-97f0-11ea-953d-81dbd8eadf6b.png)

/cc @pi0 
## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

