### PR TITLE
fix(modern): wrong assets mapping in ssr client modern mode

### DIFF
--- a/packages/vue-renderer/src/renderers/modern.js
+++ b/packages/vue-renderer/src/renderers/modern.js
@@ -1,4 +1,3 @@
-import invert from 'lodash/invert'
 import { isUrl, urlJoin, safariNoModuleFix } from '@nuxt/utils'
 import SSRRenderer from './ssr'
 
@@ -17,13 +16,15 @@ export default class ModernRenderer extends SSRRenderer {
 
     const { clientManifest, modernManifest } = this.serverContext.resources
     const legacyAssets = clientManifest.assetsMapping
-    const modernAssets = invert(modernManifest.assetsMapping)
+    const modernAssets = modernManifest.assetsMapping
     const mapping = {}
 
-    for (const legacyJsFile in legacyAssets) {
-      const chunkNamesHash = legacyAssets[legacyJsFile]
-      mapping[legacyJsFile] = modernAssets[chunkNamesHash]
-    }
+    Object.keys(legacyAssets).forEach((componentHash) => {
+      const modernComponentAssets = modernAssets[componentHash] || []
+      legacyAssets[componentHash].forEach((legacyAssetName, index) => {
+        mapping[legacyAssetName] = modernComponentAssets[index]
+      })
+    })
     delete clientManifest.assetsMapping
     delete modernManifest.assetsMapping
     this._assetsMapping = mapping

--- a/packages/webpack/src/plugins/vue/client.js
+++ b/packages/webpack/src/plugins/vue/client.js
@@ -35,7 +35,11 @@ export default class VueSSRClientPlugin {
       stats.assets
         .filter(({ name }) => isJS(name))
         .forEach(({ name, chunkNames }) => {
-          assetsMapping[name] = hash(chunkNames.join('|'))
+          const componentHash = hash(chunkNames.join('|'))
+          if (!assetsMapping[componentHash]) {
+            assetsMapping[componentHash] = []
+          }
+          assetsMapping[componentHash].push(name)
         })
 
       const manifest = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

Fix https://github.com/nuxt/nuxt.js/issues/7311

When there're multiple async chunks in a component, the client modern mode is wrongly mapping, this pr is fixing this issue by using array to map between legacy and modern files.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

