### PR TITLE
feat(ssr): add non async split chunk to preload scripts

### DIFF
--- a/packages/webpack/src/plugins/vue/client.js
+++ b/packages/webpack/src/plugins/vue/client.js
@@ -62,7 +62,7 @@ export default class VueSSRClientPlugin {
           const filesSet = new Set(chunk.files.map(fileToIndex))
 
           for (const chunkName of chunk.names) {
-            if (entrypoints[chunkName]) {
+            if (!entrypoints[chunkName]) {
               const chunkGroup = namedChunkGroups[chunkName]
               if (chunkGroup) {
                 for (const asset of chunkGroup.assets) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

Fix https://github.com/nuxt/nuxt.js/issues/7360.

preload files don't have split chunks in component for now, this pr is including assets within same chunk group into ssr manifest (none async chunks), so that ssr renderer can get those split chunks from mapping of component-hash and assets-index.

### Before
![image](https://user-images.githubusercontent.com/4312154/82152130-37904580-9857-11ea-9480-d076be9ffa48.png)
### After
![image](https://user-images.githubusercontent.com/4312154/82152159-555daa80-9857-11ea-9bda-82fe50b95c68.png)



## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

