### PR TITLE
refactor(config): alias `export` to `generate`

### DIFF
--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -114,6 +114,13 @@ export function getNuxtConfig (_options) {
     options.router.base += '/'
   }
 
+  // Alias export to generate
+  // TODO: switch to export by default for nuxt3
+  if (options.export) {
+    options.generate = defu(options.export, options.generate)
+    delete options.export
+  }
+
   // Check srcDir and generate.dir existence
   const hasSrcDir = isNonEmptyString(options.srcDir)
   const hasGenerateDir = isNonEmptyString(options.generate.dir)

--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -118,8 +118,8 @@ export function getNuxtConfig (_options) {
   // TODO: switch to export by default for nuxt3
   if (options.export) {
     options.generate = defu(options.export, options.generate)
-    delete options.export
   }
+  exports.export = options.generate
 
   // Check srcDir and generate.dir existence
   const hasSrcDir = isNonEmptyString(options.srcDir)

--- a/packages/config/test/options.test.js
+++ b/packages/config/test/options.test.js
@@ -162,6 +162,11 @@ describe('config: options', () => {
     expect(fallback).toEqual('fallback.html')
   })
 
+  test('export should alias to generate', () => {
+    const { generate: { fallback } } = getNuxtConfig({ export: { fallback: 'fallback.html' } })
+    expect(fallback).toEqual('fallback.html')
+  })
+
   test('should disable parallel if extractCSS is enabled', () => {
     const { build: { parallel } } = getNuxtConfig({ build: { extractCSS: true, parallel: true } })
     expect(parallel).toEqual(false)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
As of the new `nuxt export` command, it makes sense using `export` in `nuxt.config`. This alias is a backport from Nuxt3. After defaults getting applied, we keep the same references so any modifications to each, update another one

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

