### PR TITLE
refactor: inline staticAssetsBase in state chunk for full-static

### DIFF
--- a/packages/vue-app/template/App.js
+++ b/packages/vue-app/template/App.js
@@ -305,7 +305,7 @@ export default {
     async fetchPayload(route) {
       route = (route.replace(/\/+$/, '') || '/').split('?')[0]
       try {
-        const src = urlJoin(window.__NUXT_STATIC__, route, 'payload.js')
+        const src = urlJoin(window.<%= globals.context %>.staticAssetsBase, route, 'payload.js')
         const payload = await window.__NUXT_IMPORT__(route, src)
         this.setPagePayload(payload)
         return payload

--- a/packages/vue-app/template/client.js
+++ b/packages/vue-app/template/client.js
@@ -805,7 +805,7 @@ async function mountApp (__app) {
 
   <% if (isFullStatic) { %>
   // Load page chunk
-  if (!NUXT.data && !NUXT.spa) {
+  if (!NUXT.data && NUXT.serverRendered) {
     try {
       const payload = await _app.fetchPayload(_app.context.route.path)
       Object.assign(NUXT, payload)

--- a/packages/vue-renderer/src/renderers/spa.js
+++ b/packages/vue-renderer/src/renderers/spa.js
@@ -152,12 +152,9 @@ export default class SPARenderer extends BaseRenderer {
     // Serialize state (runtime config)
     let APP = `${meta.BODY_SCRIPTS_PREPEND}<div id="${this.serverContext.globals.id}">${this.serverContext.resources.loadingHTML}</div>${meta.BODY_SCRIPTS}`
 
-    if (renderContext.staticAssetsBase) {
-      APP += `<script>window.__NUXT_STATIC__='${renderContext.staticAssetsBase}'</script>`
-    }
     APP += `<script>window.${this.serverContext.globals.context}=${devalue({
       config: renderContext.runtimeConfig.public,
-      spa: true
+      staticAssetsBase: renderContext.staticAssetsBase
     })}</script>`
 
     // Prepare template params

--- a/packages/vue-renderer/src/renderers/ssr.js
+++ b/packages/vue-renderer/src/renderers/ssr.js
@@ -182,7 +182,7 @@ export default class SSRRenderer extends BaseRenderer {
         APP += `<script defer src="${staticAssetsBase}${statePath}"></script>`
         preloadScripts.push(stateUrl)
       } else {
-        APP += `<script defer>${stateScript}</script>`
+        APP += `<script>${stateScript}</script>`
       }
 
       // Page level payload.js (async loaded for CSR)

--- a/packages/vue-renderer/src/renderers/ssr.js
+++ b/packages/vue-renderer/src/renderers/ssr.js
@@ -168,20 +168,21 @@ export default class SSRRenderer extends BaseRenderer {
       const { data, fetch, mutations, ...state } = nuxt
 
       // Initial state
-      const nuxtStaticScript = `window.__NUXT_STATIC__='${staticAssetsBase}';`
-      const stateScript = `window.${this.serverContext.globals.context}=${devalue(state)};`
+      const stateScript = `window.${this.serverContext.globals.context}=${devalue({
+        staticAssetsBase,
+        ...state
+      })};`
 
       // Make chunk for initial state > 10 KB
       const stateScriptKb = (stateScript.length * 4 /* utf8 */) / 100
-      if (stateScriptKb > 10) {
+      if (stateScriptKb > 1) {
         const statePath = urlJoin(url, 'state.js')
         const stateUrl = urlJoin(staticAssetsBase, statePath)
         staticAssets.push({ path: statePath, src: stateScript })
-        APP += `<script defer>${nuxtStaticScript}</script>`
         APP += `<script defer src="${staticAssetsBase}${statePath}"></script>`
         preloadScripts.push(stateUrl)
       } else {
-        APP += `<script defer>${nuxtStaticScript}${stateScript}</script>`
+        APP += `<script defer>${stateScript}</script>`
       }
 
       // Page level payload.js (async loaded for CSR)

--- a/packages/vue-renderer/src/renderers/ssr.js
+++ b/packages/vue-renderer/src/renderers/ssr.js
@@ -175,7 +175,7 @@ export default class SSRRenderer extends BaseRenderer {
 
       // Make chunk for initial state > 10 KB
       const stateScriptKb = (stateScript.length * 4 /* utf8 */) / 100
-      if (stateScriptKb > 1) {
+      if (stateScriptKb > 10) {
         const statePath = urlJoin(url, 'state.js')
         const stateUrl = urlJoin(staticAssetsBase, statePath)
         staticAssets.push({ path: statePath, src: stateScript })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
- Use `serverRendered` instead of `spa`
- Inline `staticAssetsBase` into `state` chunk to avoid additional script block. This also adds `globalName` compatibility back.
- Remove unnecessary `defer` attribute from inline script

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

