### PR TITLE
fix(config): remove runtimeConfig string fallback

### DIFF
--- a/packages/config/src/load.js
+++ b/packages/config/src/load.js
@@ -137,7 +137,7 @@ function loadEnv (envConfig, rootDir = process.cwd()) {
 function expand (target, source = {}, parse = v => v) {
   function getValue (key) {
     // Source value 'wins' over target value
-    return source[key] !== undefined ? source[key] : (target[key] || '')
+    return source[key] !== undefined ? source[key] : target[key]
   }
 
   function interpolate (value) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Follows #7420 

Since we check for `string` type in `interpolate` function, there is no need to fallback to empty string value `''`.

It fixes the issue where `false` was transformed to `''`.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

