### PR TITLE
fix(generator): respect `options.router.trailingSlash` for crawler

### DIFF
--- a/packages/generator/src/generator.js
+++ b/packages/generator/src/generator.js
@@ -299,13 +299,15 @@ export default class Generator {
 
       // If crawler activated and called from generateRoutes()
       if (this.options.generate.crawler && this.options.render.ssr) {
-        const trailingSlashReplacement = this.options.router.trailingSlash ? '/' : ''
+        const possibleTrailingSlash = this.options.router.trailingSlash ? '/' : ''
         parse(html).querySelectorAll('a').map((el) => {
-          const href = (el.getAttribute('href') || '')
-            .replace(/\/+$/, trailingSlashReplacement)
+          const sanitizedHref = (el.getAttribute('href') || '')
+            .replace(/\/+$/, '')
             .split('?')[0]
             .split('#')[0]
             .trim()
+
+          const href = sanitizedHref + possibleTrailingSlash
 
           if (href.startsWith('/') && !path.extname(href) && this.shouldGenerateRoute(href) && !this.generatedRoutes.has(href)) {
             this.generatedRoutes.add(href) // add the route to the tracked list

--- a/packages/generator/src/generator.js
+++ b/packages/generator/src/generator.js
@@ -299,8 +299,13 @@ export default class Generator {
 
       // If crawler activated and called from generateRoutes()
       if (this.options.generate.crawler && this.options.render.ssr) {
+        const trailingSlashReplacement = this.options.router.trailingSlash ? '/' : ''
         parse(html).querySelectorAll('a').map((el) => {
-          const href = (el.getAttribute('href') || '').replace(/\/+$/, '').split('?')[0].split('#')[0].trim()
+          const href = (el.getAttribute('href') || '')
+            .replace(/\/+$/, trailingSlashReplacement)
+            .split('?')[0]
+            .split('#')[0]
+            .trim()
 
           if (href.startsWith('/') && !path.extname(href) && this.shouldGenerateRoute(href) && !this.generatedRoutes.has(href)) {
             this.generatedRoutes.add(href) // add the route to the tracked list


### PR DESCRIPTION

## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)

## Description
When crawling and enforcing a trailing slash, all pages will be crawled twice because the trailing slash is skipped. This also leads to massive errors because pages without trailing slashes can't be generated (as they throw a 404 when enforcing a trailing slash)
