### PR TITLE
feat(webpack): allow babel plugins to be defined by function

### DIFF
--- a/packages/types/config/build.d.ts
+++ b/packages/types/config/build.d.ts
@@ -85,12 +85,13 @@ interface NuxtBabelPresetEnv {
   envName: 'client' | 'modern' | 'server'
 }
 
-interface NuxtBabelOptions extends Pick<TransformOptions, Exclude<keyof TransformOptions, 'presets'>> {
+interface NuxtBabelOptions extends Pick<TransformOptions, Exclude<keyof TransformOptions, 'presets' | 'plugins'>> {
   cacheCompression?: boolean
   cacheDirectory?: boolean
   cacheIdentifier?: string
   customize?: string | null
   presets?: ((env: NuxtBabelPresetEnv & NuxtWebpackEnv, defaultPreset: [string, object]) => PluginItem[] | void) | PluginItem[] | null
+  plugins?: ((env: NuxtBabelPresetEnv & NuxtWebpackEnv) => NonNullable<TransformOptions['plugins']>) | TransformOptions['plugins']
 }
 
 interface Warning {

--- a/packages/webpack/src/config/base.js
+++ b/packages/webpack/src/config/base.js
@@ -105,6 +105,15 @@ export default class WebpackBaseConfig {
       return options
     }
 
+    if (typeof options.plugins === 'function') {
+      options.plugins = options.plugins(
+        {
+          envName,
+          ...this.nuxtEnv
+        }
+      )
+    }
+
     const defaultPreset = [require.resolve('@nuxt/babel-preset-app'), {}]
 
     if (typeof options.presets === 'function') {

--- a/packages/webpack/test/index.test.js
+++ b/packages/webpack/test/index.test.js
@@ -17,7 +17,7 @@ describe('webpack: babel', () => {
   test('should allow defining plugins with an array', () => {
     expect(getConfigWithPlugins(['myPlugin']).getBabelOptions().plugins).toEqual(['myPlugin'])
   })
-  test('should allow defining plugins with  function', () => {
+  test('should allow defining plugins with a function', () => {
     expect(getConfigWithPlugins(({ isDev }) => [`myPlugin-${isDev}`]).getBabelOptions().plugins).toEqual(['myPlugin-false'])
   })
 })

--- a/packages/webpack/test/index.test.js
+++ b/packages/webpack/test/index.test.js
@@ -1,0 +1,23 @@
+import WebpackBaseConfig from '../src/config/base'
+
+describe('webpack: babel', () => {
+  const getConfigWithPlugins = plugins =>
+    new WebpackBaseConfig({
+      buildContext: {
+        options: {
+          dev: false
+        },
+        buildOptions: {
+          babel: {
+            plugins
+          }
+        }
+      }
+    })
+  test('should allow defining plugins with an array', () => {
+    expect(getConfigWithPlugins(['myPlugin']).getBabelOptions().plugins).toEqual(['myPlugin'])
+  })
+  test('should allow defining plugins with  function', () => {
+    expect(getConfigWithPlugins(({ isDev }) => [`myPlugin-${isDev}`]).getBabelOptions().plugins).toEqual(['myPlugin-false'])
+  })
+})


### PR DESCRIPTION
This PR allows `build.babel.plugins` to be a function that receives context and returns Babel plugins.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
With the [new format for `babel-polyfills`](https://github.com/babel/babel-polyfills/blob/master/docs/migration.md) it may be important to pass targets to Babel plugins, which will likely vary by `isModern`.

So, in line with the current `presets` configuration, it would be appropriate for `plugins` to take a function.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.


