### PR TITLE
refactor: ad-hoc modules

### DIFF
--- a/packages/config/src/config/_app.js
+++ b/packages/config/src/config/_app.js
@@ -26,9 +26,6 @@ export default () => ({
 
   css: [],
 
-  modules: [],
-  buildModules: [],
-
   layouts: {},
 
   ErrorPage: null,

--- a/packages/config/src/config/_common.js
+++ b/packages/config/src/config/_common.js
@@ -20,6 +20,11 @@ export default () => ({
   mode: MODES.universal,
   modern: undefined,
 
+  // Modules
+  modules: [],
+  buildModules: [],
+  _modules: [],
+
   globalName: undefined,
   globals: {
     id: globalName => `__${globalName}`,

--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -469,7 +469,7 @@ export function getNuxtConfig (_options) {
   }
 
   // Components Module
-  if (!options._start && getPKG('@nuxt/telemetry')) {
+  if (!options._start && getPKG('@nuxt/components')) {
     options._modules.push('@nuxt/components')
   }
 

--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -458,10 +458,10 @@ export function getNuxtConfig (_options) {
 
   // Loading screen
   // Force disable for production and programmatic users
-  if (!options.dev || !options._cli) {
+  if (!options.dev || !options._cli || !getPKG('@nuxt/loading-screen')) {
     options.build.loadingScreen = false
   }
-  if (options.build.loadingScreen && getPKG('@nuxt/loading-screen')) {
+  if (options.build.loadingScreen) {
     options._modules.push(['@nuxt/loading-screen', options.build.loadingScreen])
   } else {
     // When loadingScreen is disabled we should also disable build indicator

--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -461,7 +461,7 @@ export function getNuxtConfig (_options) {
   if (!options.dev || !options._cli) {
     options.build.loadingScreen = false
   }
-  if (options.build.loadingScreen) {
+  if (options.build.loadingScreen && getPKG('@nuxt/loading-screen')) {
     options._modules.push(['@nuxt/loading-screen', options.build.loadingScreen])
   } else {
     // When loadingScreen is disabled we should also disable build indicator
@@ -469,7 +469,7 @@ export function getNuxtConfig (_options) {
   }
 
   // Components Module
-  if (options.dev && options.components) {
+  if (!options._start && getPKG('@nuxt/telemetry')) {
     options._modules.push('@nuxt/components')
   }
 

--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -424,21 +424,6 @@ export function getNuxtConfig (_options) {
     bundleRenderer.runInNewContext = options.dev
   }
 
-  // Loading screen
-  // disable for production and programmatic users
-  if (!options.dev || !options._cli) {
-    options.build.loadingScreen = false
-  }
-  // Add loading-screen module
-  if (options.build.loadingScreen) {
-    options.buildModules.push(['@nuxt/loading-screen', options.build.loadingScreen])
-  }
-
-  // When loadingScreen is disabled we should also disable build indicator
-  if (!options.build.loadingScreen) {
-    options.build.indicator = false
-  }
-
   // TODO: Remove this if statement in Nuxt 3
   if (options.build.crossorigin) {
     consola.warn('Using `build.crossorigin` is deprecated and will be removed in Nuxt 3. Please use `render.crossorigin` instead.')
@@ -456,11 +441,6 @@ export function getNuxtConfig (_options) {
       .map(([path, handler]) => ({ path, handler }))
   }
 
-  // Components module
-  if (options.components) {
-    options.buildModules.push('@nuxt/components')
-  }
-
   // Generate staticAssets
   const { staticAssets } = options.generate
   if (!staticAssets.version) {
@@ -474,6 +454,25 @@ export function getNuxtConfig (_options) {
     staticAssets.versionBase = urlJoin(staticAssets.base, staticAssets.version)
   }
 
+  // ----- Builtin modules -----
+
+  // Loading screen
+  // Force disable for production and programmatic users
+  if (!options.dev || !options._cli) {
+    options.build.loadingScreen = false
+  }
+  if (options.build.loadingScreen) {
+    options._modules.push(['@nuxt/loading-screen', options.build.loadingScreen])
+  } else {
+    // When loadingScreen is disabled we should also disable build indicator
+    options.build.indicator = false
+  }
+
+  // Components Module
+  if (options.dev && options.components) {
+    options._modules.push('@nuxt/components')
+  }
+
   // Nuxt Telemetry
   if (
     options.telemetry !== false &&
@@ -481,11 +480,7 @@ export function getNuxtConfig (_options) {
     !destr(process.env.NUXT_TELEMETRY_DISABLED) &&
     getPKG('@nuxt/telemetry')
   ) {
-    // TODO: Remove before 2.13 in favor of checking .nuxrc for first run message
-    if (typeof options.telemetry === 'undefined') {
-      consola.warn('Experimental `@nuxt/telemetry` enabled. You can disable this message by explicitly setting `telemetry: false` or `telemetry: true` in `nuxt.config`')
-    }
-    options.modules.push('@nuxt/telemetry')
+    options._modules.push('@nuxt/telemetry')
   }
 
   return options

--- a/packages/config/test/__snapshots__/options.test.js.snap
+++ b/packages/config/test/__snapshots__/options.test.js.snap
@@ -4,6 +4,7 @@ exports[`config: options should return default nuxt config 1`] = `
 Object {
   "ErrorPage": null,
   "__normalized__": true,
+  "_modules": Array [],
   "_nuxtConfigFile": "/var/nuxt/test/nuxt.config.js",
   "_nuxtConfigFiles": Array [
     "/var/nuxt/test/nuxt.config.js",

--- a/packages/config/test/__snapshots__/options.test.js.snap
+++ b/packages/config/test/__snapshots__/options.test.js.snap
@@ -4,7 +4,9 @@ exports[`config: options should return default nuxt config 1`] = `
 Object {
   "ErrorPage": null,
   "__normalized__": true,
-  "_modules": Array [],
+  "_modules": Array [
+    "@nuxt/components",
+  ],
   "_nuxtConfigFile": "/var/nuxt/test/nuxt.config.js",
   "_nuxtConfigFiles": Array [
     "/var/nuxt/test/nuxt.config.js",

--- a/packages/config/test/config/__snapshots__/index.test.js.snap
+++ b/packages/config/test/config/__snapshots__/index.test.js.snap
@@ -3,6 +3,7 @@
 exports[`config should return default nuxt configurations 1`] = `
 Object {
   "ErrorPage": null,
+  "_modules": Array [],
   "_nuxtConfigFile": undefined,
   "alias": Object {},
   "build": Object {
@@ -371,6 +372,7 @@ Object {
 exports[`config should return nuxt configurations with custom env 1`] = `
 Object {
   "ErrorPage": null,
+  "_modules": Array [],
   "_nuxtConfigFile": undefined,
   "alias": Object {},
   "build": Object {

--- a/packages/config/test/options.test.js
+++ b/packages/config/test/options.test.js
@@ -16,7 +16,8 @@ jest.mock('std-env', () => ({
 
 jest.mock('@nuxt/utils', () => ({
   ...jest.requireActual('@nuxt/utils'),
-  getMainModule: () => ({ paths: ['/var/nuxt/node_modules'] })
+  getMainModule: () => ({ paths: ['/var/nuxt/node_modules'] }),
+  getPKG: () => ({ name: 'fake' })
 }))
 
 describe('config: options', () => {

--- a/packages/core/src/module.js
+++ b/packages/core/src/module.js
@@ -31,7 +31,7 @@ export default class ModuleContainer {
     // Load every module in sequence
     await sequence(this.options.modules, this.addModule)
 
-    // Load built-in module last so we ensure hooks are already registred and no override happens
+    // Load ah-hoc modules last
     await sequence(this.options._modules, this.addModule)
 
     // Call done hook

--- a/packages/core/test/module.test.js
+++ b/packages/core/test/module.test.js
@@ -19,7 +19,8 @@ jest.mock('@nuxt/utils', () => ({
 
 const defaultOptions = {
   modules: [],
-  buildModules: []
+  buildModules: [],
+  _modules: []
 }
 
 describe('core: module', () => {

--- a/packages/utils/src/cjs.js
+++ b/packages/utils/src/cjs.js
@@ -1,3 +1,5 @@
+import { join } from 'path'
+
 export function isExternalDependency (id) {
   return /[/\\]node_modules[/\\]/.test(id)
 }
@@ -61,5 +63,5 @@ export function tryRequire (id) {
 }
 
 export function getPKG (id) {
-  return tryRequire(id + '/package.json')
+  return tryRequire(join(id, 'package.json'))
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
As we are introducing more and more ad-hoc modules ([nuxt/screens](https://github.com/nuxt/screens), [nuxt/components](https://github.com/nuxt/components), [nuxt/telemetry](https://github.com/nuxt/telemetry)), it makes sense to make an internal array to keep them. This helps to:
- Make debugging easier
- Ensure all hooks are registred before their entrypoint
- No overriding happens when developing these modules themself when nuxt adds them (this requires we expose `meta` field from modules

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

