### PR TITLE
fix(server): set `unsafe-eval` CSP in dev mode with custom CSP policies

### DIFF
--- a/packages/server/src/middleware/nuxt.js
+++ b/packages/server/src/middleware/nuxt.js
@@ -134,20 +134,24 @@ const getCspString = ({ cspScriptSrcHashes, allowedSources, policies, isDev, isR
   }
 
   if (policyObjectAvailable) {
-    const transformedPolicyObject = transformPolicyObject(policies, cspScriptSrcHashes)
+    const transformedPolicyObject = transformPolicyObject(policies, cspScriptSrcHashes, isDev)
     return Object.entries(transformedPolicyObject).map(([k, v]) => `${k} ${Array.isArray(v) ? v.join(' ') : v}`).join('; ')
   }
 
   return baseCspStr
 }
 
-const transformPolicyObject = (policies, cspScriptSrcHashes) => {
+const transformPolicyObject = (policies, cspScriptSrcHashes, isDev) => {
   const userHasDefinedScriptSrc = policies['script-src'] && Array.isArray(policies['script-src'])
 
   const additionalPolicies = userHasDefinedScriptSrc ? policies['script-src'] : []
 
   // Self is always needed for inline-scripts, so add it, no matter if the user specified script-src himself.
   const hashAndPolicyList = cspScriptSrcHashes.concat('\'self\'', additionalPolicies)
+  
+  if (isDev) {
+    hashAndPolicyList.push('\'unsafe-eval\'')
+  }
 
   return { ...policies, 'script-src': hashAndPolicyList }
 }

--- a/packages/server/src/middleware/nuxt.js
+++ b/packages/server/src/middleware/nuxt.js
@@ -148,7 +148,7 @@ const transformPolicyObject = (policies, cspScriptSrcHashes, isDev) => {
 
   // Self is always needed for inline-scripts, so add it, no matter if the user specified script-src himself.
   const hashAndPolicyList = cspScriptSrcHashes.concat('\'self\'', additionalPolicies)
-  
+
   if (isDev) {
     hashAndPolicyList.push('\'unsafe-eval\'')
   }

--- a/packages/server/test/middleware/nuxt.test.js
+++ b/packages/server/test/middleware/nuxt.test.js
@@ -289,7 +289,7 @@ describe('server: nuxtMiddleware', () => {
     expect(res.setHeader).nthCalledWith(
       1,
       'Content-Security-Policy',
-      "script-src sha256-hashes 'self' /nuxt.js /test.js; report-uri /report"
+      "script-src sha256-hashes 'self' /nuxt.js /test.js 'unsafe-eval'; report-uri /report"
     )
   })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

This could relate to #7451. When the `render.csp.policies` config is an object, `unsafe-eval` is not added to the CSP header in development mode, like it is when an array or nothing is provided.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes
- [X] All new and existing tests are passing.

