### PR TITLE
fix(vue-app): `redirect` no longer strips trailing slash from URL

### DIFF
--- a/packages/vue-app/template/utils.js
+++ b/packages/vue-app/template/utils.js
@@ -596,7 +596,7 @@ function formatUrl (url, query) {
   let parts = url.split('/')
   let result = (protocol ? protocol + '://' : '//') + parts.shift()
 
-  let path = parts.filter(Boolean).join('/')
+  let path = parts.join('/')
   let hash
   parts = path.split('#')
   if (parts.length === 2) {


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
When calling `redirect('...')` with an external (non-relative) URL,
and when that URL has a trailing slash, Nuxt will remove the trailing
slash before performing the redirect. This breaks when the external URL
requires that trailing slash!

The cause of this is simple. Nuxt was filtering empty components
form the URL's path. This is over-paranoid and (in this case) was
causing a bug where the trailing slash was being removed (because
there was an empty component path after that trailing slash, which
was being filtered out before re-joining the path back together.

The fix is simple. Don't filter empty components from the path.
This type of paranoid URL cleaning should not be the responsibility
of the `redirect()` function.

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.
