### PR TITLE
fix(vue-app): not strip trailing slash for redirect external domain

### DIFF
--- a/packages/vue-app/template/utils.js
+++ b/packages/vue-app/template/utils.js
@@ -598,7 +598,7 @@ function formatUrl (url, query) {
 
   let path = parts.join('/')
   if (path === '' && parts.length === 1) {
-    path = '/'
+    result += '/'
   }
 
   let hash
@@ -607,7 +607,7 @@ function formatUrl (url, query) {
     [path, hash] = parts
   }
 
-  result += path && path !== '/' ? '/' + path : ''
+  result += path ? '/' + path : ''
 
   if (query && JSON.stringify(query) !== '{}') {
     result += (url.split('?').length === 2 ? '&' : '?') + formatQuery(query)

--- a/packages/vue-app/template/utils.js
+++ b/packages/vue-app/template/utils.js
@@ -607,7 +607,7 @@ function formatUrl (url, query) {
     [path, hash] = parts
   }
 
-  result += path ? '/' + path : ''
+  result += path && path !== '/' ? '/' + path : ''
 
   if (query && JSON.stringify(query) !== '{}') {
     result += (url.split('?').length === 2 ? '&' : '?') + formatQuery(query)

--- a/packages/vue-app/template/utils.js
+++ b/packages/vue-app/template/utils.js
@@ -597,6 +597,10 @@ function formatUrl (url, query) {
   let result = (protocol ? protocol + '://' : '//') + parts.shift()
 
   let path = parts.join('/')
+  if (path === '') {
+    return result + (parts.length === 1 ? '/' : '')
+  }
+
   let hash
   parts = path.split('#')
   if (parts.length === 2) {

--- a/packages/vue-app/template/utils.js
+++ b/packages/vue-app/template/utils.js
@@ -597,8 +597,8 @@ function formatUrl (url, query) {
   let result = (protocol ? protocol + '://' : '//') + parts.shift()
 
   let path = parts.join('/')
-  if (path === '') {
-    return result + (parts.length === 1 ? '/' : '')
+  if (path === '' && parts.length === 1) {
+    path = '/'
   }
 
   let hash

--- a/test/e2e/basic.browser.test.js
+++ b/test/e2e/basic.browser.test.js
@@ -261,7 +261,7 @@ describe('basic browser', () => {
     await page.nuxt.navigate('/redirect-external', false)
 
     await page.waitForFunction(
-      () => window.location.href === 'https://nuxtjs.org/'
+      () => window.location.href === 'https://nuxtjs.org/api/'
     )
     page.close()
   })

--- a/test/fixtures/basic/pages/redirect-external-no-slash.vue
+++ b/test/fixtures/basic/pages/redirect-external-no-slash.vue
@@ -5,7 +5,7 @@
 <script>
 export default {
   middleware ({ redirect }) {
-    return redirect('https://nuxtjs.org/api/')
+    return redirect('https://nuxtjs.org/api')
   }
 }
 </script>

--- a/test/fixtures/basic/pages/redirect-external-root.vue
+++ b/test/fixtures/basic/pages/redirect-external-root.vue
@@ -5,7 +5,7 @@
 <script>
 export default {
   middleware ({ redirect }) {
-    return redirect('https://nuxtjs.org/api/')
+    return redirect('https://nuxtjs.org/')
   }
 }
 </script>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

Add test for https://github.com/nuxt/nuxt.js/pull/7475

When redirect to external domain, not strip trailing slash.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

