### PR TITLE
types: fix module and typescript compatibility and add missing crawler definition

### DIFF
--- a/packages/types/config/generate.d.ts
+++ b/packages/types/config/generate.d.ts
@@ -10,6 +10,7 @@ type NuxtOptionsGenerateRoutesFunctionWithCallback = (callback: (err: Error, rou
 
 export interface NuxtOptionsGenerate {
   concurrency?: number
+  crawler?: boolean
   devtools?: boolean
   dir?: string
   exclude?: RegExp[]

--- a/packages/types/config/index.d.ts
+++ b/packages/types/config/index.d.ts
@@ -22,7 +22,9 @@ import { NuxtOptionsWatchers } from './watchers'
 export { Module } from './module'
 export { ServerMiddleware } from './server-middleware'
 
-export interface NuxtOptions extends Record<string, any> {
+export interface Configuration extends Record<string, any> {}
+
+export interface NuxtOptions extends Configuration {
   build: NuxtOptionsBuild
   buildDir: string
   buildModules: NuxtOptionsModule[]
@@ -65,7 +67,4 @@ export interface NuxtOptions extends Record<string, any> {
   watchers: NuxtOptionsWatchers
 }
 
-// Modules can either extend `Configuration` or `NuxtConfig`
-// Users should use `NuxtConfig` over `Configuration` in their configuration file
-export interface Configuration extends Partial<NuxtOptions> {}
-export interface NuxtConfig extends Configuration {}
+export type NuxtConfig = Partial<NuxtOptions>

--- a/packages/types/config/index.d.ts
+++ b/packages/types/config/index.d.ts
@@ -13,7 +13,7 @@ import { NuxtOptionsModule } from './module'
 import { NuxtOptionsPlugin } from './plugin'
 import { NuxtOptionsRender } from './render'
 import { NuxtOptionsRouter } from './router'
-import { NuxtConfigurationRuntimeConfig } from './runtime'
+import { NuxtOptionsRuntimeConfig } from './runtime'
 import { NuxtOptionsServer } from './server'
 import { NuxtOptionsServerMiddleware } from './server-middleware'
 import { NuxtOptionsVueConfiguration } from './vue-configuration'
@@ -51,8 +51,8 @@ export interface NuxtOptions extends Record<string, any> {
   modules: NuxtOptionsModule[]
   modulesDir: string[]
   plugins: NuxtOptionsPlugin[]
-  privateRuntimeConfig?: NuxtConfigurationRuntimeConfig
-  publicRuntimeConfig?: NuxtConfigurationRuntimeConfig
+  privateRuntimeConfig: NuxtOptionsRuntimeConfig
+  publicRuntimeConfig: NuxtOptionsRuntimeConfig
   render: NuxtOptionsRender
   rootDir: string
   router: NuxtOptionsRouter
@@ -65,9 +65,7 @@ export interface NuxtOptions extends Record<string, any> {
   watchers: NuxtOptionsWatchers
 }
 
-export type NuxtConfig = Partial<NuxtOptions>
-
-/**
- * @deprecated Use NuxtConfig instead
-*/
-export type Configuration = NuxtConfig // Legacy alias
+// Modules can either extend `Configuration` or `NuxtConfig`
+// Users should use `NuxtConfig` over `Configuration` in their configuration file
+export interface Configuration extends Partial<NuxtOptions> {}
+export interface NuxtConfig extends Configuration {}

--- a/packages/types/config/index.d.ts
+++ b/packages/types/config/index.d.ts
@@ -22,6 +22,9 @@ import { NuxtOptionsWatchers } from './watchers'
 export { Module } from './module'
 export { ServerMiddleware } from './server-middleware'
 
+/**	
+ * @deprecated Use NuxtConfig instead
+*/
 export interface Configuration extends Record<string, any> {}
 
 export interface NuxtOptions extends Configuration {

--- a/packages/types/config/runtime.d.ts
+++ b/packages/types/config/runtime.d.ts
@@ -1,5 +1,5 @@
 /**
-* NuxtConfigurationRuntimeConfig
+* NuxtOptionsRuntimeConfig
 * NuxtRuntimeConfig interface can be extended by users to enable intellisense on $config
 */
 
@@ -7,4 +7,4 @@ export interface NuxtRuntimeConfig {
   [key: string]: any
 }
 
-export type NuxtConfigurationRuntimeConfig = NuxtRuntimeConfig | ((env: typeof process.env) => NuxtRuntimeConfig)
+export type NuxtOptionsRuntimeConfig = NuxtRuntimeConfig | ((env: typeof process.env) => NuxtRuntimeConfig)

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -1,4 +1,9 @@
 import './process'
 
-export * from './app'
-export * from './config'
+/**
+ * Note: `export * from './app'` does not work well with TypeScript < 3.9
+ * TODO: When 3.9 considered stable with Nuxt, require it and use `export *`
+ */
+
+export { Context, Middleware, NuxtAppOptions, NuxtError, Plugin, Transition } from './app'
+export { Configuration, Module, NuxtConfig, NuxtOptions, ServerMiddleware } from './config'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description

- `Configuration` needs to be an interface to be extended by modules types and be compatible with old/current modules.
- `NuxtOptions` should now be extended by new modules instead of `Configuration`
  - It is extending `Configuration` to support modules still using it 
  - `NuxtConfig` is the right import to do over `Configuration` in configuration files, and it inherits `Configuration` through `NuxtOptions`.
- Add missing `crawler` config (fixes #7585)
- Do not use `export *` as of issues with typescript < [3.9](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-9.html#export--is-always-retained)

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

