### PR TITLE
fix(example): "`head` property in component must be a function"

### DIFF
--- a/examples/meta-info/pages/index.vue
+++ b/examples/meta-info/pages/index.vue
@@ -1,30 +1,32 @@
 <template>
   <div class="container">
     <h1>Home page 🚀</h1>
-    <NuxtLink to="/about">
-      About page
-    </NuxtLink>
+    <NuxtLink to="/about">About page</NuxtLink>
   </div>
 </template>
 
 <script>
 export default {
-  head: {
-    title: 'Home page 🚀',
-    meta: [
-      { hid: 'description', name: 'description', content: 'Home page description' }
-    ],
-    noscript: [
-      { innerHTML: 'Body No Scripts', body: true }
-    ],
-    script: [
-      { src: '/head.js' },
-      // Supported since 1.0
-      { src: '/body.js', body: true },
-      { src: '/defer.js', defer: '' }
-    ]
+  head() {
+    return {
+      title: "Home page 🚀",
+      meta: [
+        {
+          hid: "description",
+          name: "description",
+          content: "Home page description"
+        }
+      ],
+      noscript: [{ innerHTML: "Body No Scripts", body: true }],
+      script: [
+        { src: "/head.js" },
+        // Supported since 1.0
+        { src: "/body.js", body: true },
+        { src: "/defer.js", defer: "" }
+      ]
+    };
   }
-}
+};
 </script>
 
 <style>


### PR DESCRIPTION
Fix example "SEO HTML Head"

The codestyle for ``head`` of [nuxt examples: SEO HTML Head](https://nuxtjs.org/examples/seo-html-head/) and [nuxt api: API: The head Method](https://nuxtjs.org/api/pages-head/) differ.
Further on `Nuxt.js @ v2.12.x` I got the obove mentioned error.