### PR TITLE
fix(webpack): chunk name normalization for catch-all pages and windows

### DIFF
--- a/packages/utils/src/resolve.js
+++ b/packages/utils/src/resolve.js
@@ -18,7 +18,7 @@ export const wp = function wp (p = '') {
 }
 
 export const wChunk = function wChunk (p = '') {
-  // workaround for SplitChunksPlugin that generate names starting from . for catchAll pages _.vue 
+  // workaround for SplitChunksPlugin that generate names starting from . for catchAll pages _.vue
   // consider using https://webpack.js.org/configuration/output/#outputfilename for more robust control over filename generation
   return p.replace('_', '[_]')
 }

--- a/packages/utils/src/resolve.js
+++ b/packages/utils/src/resolve.js
@@ -18,10 +18,9 @@ export const wp = function wp (p = '') {
 }
 
 export const wChunk = function wChunk (p = '') {
-  if (isWindows) {
-    return p.replace(/\//g, '_')
-  }
-  return p
+  // workaround for SplitChunksPlugin that generate names starting from . for catchAll pages _.vue 
+  // consider using https://webpack.js.org/configuration/output/#outputfilename for more robust control over filename generation
+  return p.replace('_', '[_]')
 }
 
 const reqSep = /\//g

--- a/packages/utils/test/resolve.win.test.js
+++ b/packages/utils/test/resolve.win.test.js
@@ -12,7 +12,7 @@ describe.win('util: resolve windows', () => {
   })
 
   test('should format windows path', () => {
-    expect(wChunk('nuxt/layout/test')).toEqual('nuxt_layout_test')
+    expect(wChunk('nuxt/layout/test')).toEqual('nuxt/layout/test')
   })
 
   test('should resolve alias path', () => {

--- a/test/dev/extract-css.test.js
+++ b/test/dev/extract-css.test.js
@@ -5,7 +5,6 @@ import { loadFixture, getPort, Nuxt } from '../utils'
 
 let nuxt = null
 const readFile = promisify(fs.readFile)
-const isWindows = process.platform.startsWith('win')
 
 describe('extract css', () => {
   beforeAll(async () => {
@@ -17,7 +16,7 @@ describe('extract css', () => {
   })
 
   test('Verify global.css has been extracted and minified', async () => {
-    const fileName = isWindows ? 'pages_index.css' : 'pages/index.css'
+    const fileName = 'pages/index.css'
     const extractedIndexCss = resolve(__dirname, '..', 'fixtures/extract-css/.nuxt/dist/client', fileName)
     const content = await readFile(extractedIndexCss, 'utf-8')
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
For _.vue SplitChunks will generate route starting with dot and it will lead to 404 for this chunks
Dropped window path replace to be in line with Linux, as seems to work fine on win without it

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

