### PR TITLE
fix(utils): flat routes if child routes have absolute paths

### DIFF
--- a/packages/utils/src/route.js
+++ b/packages/utils/src/route.js
@@ -13,14 +13,19 @@ export const flatRoutes = function flatRoutes (router, fileName = '', routes = [
       if (fileName === '' && r.path === '/') {
         routes.push('/')
       }
+
       return flatRoutes(r.children, fileName + r.path + '/', routes)
     }
     fileName = fileName.replace(/\/+/g, '/')
-    routes.push(
-      (r.path === '' && fileName[fileName.length - 1] === '/'
-        ? fileName.slice(0, -1)
-        : fileName) + r.path
-    )
+
+    // if child path is already absolute, do not make any concatenations
+    if (r.path && r.path.startsWith('/')) {
+      routes.push(r.path)
+    } else if (r.path === '' && fileName[fileName.length - 1] === '/') {
+      routes.push(fileName.slice(0, -1) + r.path)
+    } else {
+      routes.push(fileName + r.path)
+    }
   })
   return routes
 }

--- a/packages/utils/test/route.test.js
+++ b/packages/utils/test/route.test.js
@@ -40,6 +40,37 @@ describe('util: route', () => {
     expect(routes).toEqual(['/', '/foo/bar', '/foo/baz'])
   })
 
+  test('should flat absolute routes', () => {
+    const routes = flatRoutes([
+      {
+        name: 'foo',
+        path: '/foo',
+        children: [
+          { name: 'foo-bar', path: '/foo/bar' },
+          { name: 'foo-baz', path: '/foo/baz' }
+        ]
+      }
+    ])
+
+    expect(routes).toEqual(['/foo/bar', '/foo/baz'])
+  })
+
+  test('should flat absolute routes with empty path', () => {
+    const routes = flatRoutes([
+      {
+        name: 'foo',
+        path: '/foo',
+        children: [
+          { name: 'foo-root', path: '' },
+          { name: 'foo-bar', path: '/foo/bar' },
+          { name: 'foo-baz', path: '/foo/baz' }
+        ]
+      }
+    ])
+
+    expect(routes).toEqual(['/foo', '/foo/bar', '/foo/baz'])
+  })
+
   describe('util: route guard', () => {
     test('should guard parent dir', () => {
       expect(() => {


### PR DESCRIPTION
Fixed `flatRoutes` function to work properly if children routes have absolute paths.
This was working fine in 2.12, it did break in 2.13.

## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
I am using `nuxt.js` along with `nuxt-18n`. I use SEO-friendly, localized routes.
For this to work, you have to configure pages to have absolute paths.

Here is a snapshot of my config:
![image](https://user-images.githubusercontent.com/2473784/85711657-c6f70700-b6e7-11ea-935b-921cb1b42e59.png)

However, it does not work well:
![image](https://user-images.githubusercontent.com/2473784/85711707-d4ac8c80-b6e7-11ea-832e-d8aa94ceb4b9.png)

Routes are not properly concatenated. When I look into `router.js` generated file, it looks fine:
![image](https://user-images.githubusercontent.com/2473784/85711777-e726c600-b6e7-11ea-8323-f6afaddd3622.png)

The reason behind this is, that `flatRoutes` function concatenates parent path and child path, even if child path is absolute.

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

