### PR TITLE
fix(webpack): explicitly pass outputFileSystem to webpackDevMiddleware

### DIFF
--- a/packages/webpack/src/builder.js
+++ b/packages/webpack/src/builder.js
@@ -176,6 +176,7 @@ export class WebpackBundler {
           stats: false,
           logLevel: 'silent',
           watchOptions: this.buildContext.options.watchers.webpack,
+          fs: compiler.outputFileSystem,
           ...buildOptions.devMiddleware
         })
     )


### PR DESCRIPTION
Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
I got hit by https://github.com/nuxt/typescript/issues/145 a couple of days ago, and together with @crutch12 we were able to determine the reason.

It is not triggered in particular by `lerna`, `@nuxt/typescript`, and can also be reproduced with yarn.

The culprit happens to be in the interaction between `@nuxt/webpack`, `webpack-dev-middleware` and `memory-fs`, and how the package manager (e.g. npm or yarn) decides to dedupe them on disk.

In particular, `webpack-dev-middleware@3.7.2` performs a check `compiler.outputFileSystem instanceof MemoryFileSystem`: https://github.com/webpack/webpack-dev-middleware/blob/v3.7.2/lib/fs.js#L112

1. When `@nuxt/webpack` and `webpack-dev-middleware` happen to "share" the deduped `memory-fs` (i.e. it is hoisted to a top of node_modules), then the check passes, and everything is snazzy.
2. When `memory-fs` happens to be "inlined" (i.e. another version of `memory-fs` is hoisted to the top of node_modules), then the check fails, and `webpack-dev-middleware` creates it's own instance of MemoryFileSystem to write to, and the original AsyncMFS created by `@nuxt/webpack` never gets populated with compiled files.

Reproduction is quite easy, you just have to have top level `memory-fs` dependency of a different version than the one used by `@nuxt/webpack` and `webpack-dev-middleware`:

```sh
# Start from empty folder
npm i nuxt@2.13.1 memory-fs@0.5.0
npx nuxt
# Open browser and see the error
```

A solution we were able to find is to explicitly pass file system instance through `webpack-dev-middleware` options instead of relying on it to extract the file system instance from the compiler instance.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

