### PR TITLE
fix(webpack): modern build should wait for legacy assets

### DIFF
--- a/packages/webpack/src/plugins/vue/modern.js
+++ b/packages/webpack/src/plugins/vue/modern.js
@@ -35,15 +35,15 @@ export default class ModernModePlugin {
   }
 
   getAssets (name) {
-    const asset = this.assets[name]
-    if (!asset) {
-      return
-    }
     return new Promise((resolve) => {
-      watcher.once(name, () => {
+      const asset = this.assets[name]
+      if (asset) {
+        return resolve(asset)
+      }
+      return watcher.once(name, () => {
+        const asset = this.assets[name]
         return asset && resolve(asset)
       })
-      return asset && resolve(asset)
     })
   }
 


### PR DESCRIPTION
…odern build is ahead of legacy

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
Fix https://github.com/nuxt/nuxt.js/issues/7562 #7628

Modern build should wait for legacy build setting `assets` instead of return undefined asset if modern build is ahead of legacy build.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

