### PR TITLE
fix(vue-app): check plugin key on `Vue.prototype` instead of `Vue`

### DIFF
--- a/packages/vue-app/template/index.js
+++ b/packages/vue-app/template/index.js
@@ -189,7 +189,7 @@ async function createApp(ssrContext, config = {}) {
     Vue[installKey] = true
     // Call Vue.use() to install the plugin into vm
     Vue.use(() => {
-      if (!Object.prototype.hasOwnProperty.call(Vue, key)) {
+      if (!Object.prototype.hasOwnProperty.call(Vue.prototype, key)) {
         Object.defineProperty(Vue.prototype, key, {
           get () {
             return this.$root.$options[key]


### PR DESCRIPTION
Fix for an obscure bug that got introduced in https://github.com/nuxt/nuxt.js/commit/e8aca9eb117851047e82e94948ff8b4bcb464b1a. 
Triggered when you `inject` something under a key, that was already used by other library. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
Example (using https://github.com/stalniy/casl/tree/master/packages/casl-vue):
```js
// plugins/casl.js
import Vue from 'vue';
import { Ability, abilitiesPlugin } from '@casl/vue';
export default function(context, inject) {
   const ability = new Ability(...);
   Vue.use(abilitiesPlugin, { ability }); // defines $ability and $can on Vue.prototype
   inject('ability', ability); // error: Can not redefine '$ability'
}
```

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

