### PR TITLE
fix(vue-app): don't fetch payload on first spa fallback render

### DIFF
--- a/packages/vue-app/template/client.js
+++ b/packages/vue-app/template/client.js
@@ -274,8 +274,10 @@ async function render (to, from, next) {
     return next()
   }
   // Handle first render on SPA mode
+  let spaFallback = false
   if (to === from) {
     _lastPaths = []
+    spaFallback = true
   } else {
     const fromMatches = []
     _lastPaths = getMatchedComponents(from, fromMatches).map((Component, i) => {
@@ -488,7 +490,7 @@ async function render (to, from, next) {
         <% if (isFullStatic) { %>
           let promise
 
-          if (this.isPreview) {
+          if (this.isPreview || spaFallback) {
             promise = promisify(Component.options.asyncData, app.context)
           } else {
               promise = this.fetchPayload(to.path)
@@ -522,7 +524,7 @@ async function render (to, from, next) {
 
       <% if (features.fetch) { %>
         <% if (isFullStatic) { %>
-        if (!this.isPreview) {
+        if (!this.isPreview && !spaFallback) {
           // Catching the error here for letting the SPA fallback and normal fetch behaviour
           promises.push(this.fetchPayload(to.path).catch(err => null))
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
Fixes #7648 (un-necessary payload fetch on spa fallback)

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] All new and existing tests are passing.

