### PR TITLE
refactor(csp): remove unsafe-eval in dev mode

### DIFF
--- a/packages/server/src/middleware/nuxt.js
+++ b/packages/server/src/middleware/nuxt.js
@@ -74,7 +74,7 @@ export default ({ options, nuxt, renderRoute, resources }) => async function nux
       const isReportOnly = !!options.render.csp.reportOnly
       const cspHeader = isReportOnly ? 'Content-Security-Policy-Report-Only' : 'Content-Security-Policy'
 
-      res.setHeader(cspHeader, getCspString({ cspScriptSrcHashes, allowedSources, policies, isDev: options.dev, isReportOnly }))
+      res.setHeader(cspHeader, getCspString({ cspScriptSrcHashes, allowedSources, policies, isReportOnly }))
     }
 
     // Send response
@@ -126,9 +126,9 @@ const defaultPushAssets = (preloadFiles, shouldPush, publicPath, options) => {
   return links
 }
 
-const getCspString = ({ cspScriptSrcHashes, allowedSources, policies, isDev, isReportOnly }) => {
+const getCspString = ({ cspScriptSrcHashes, allowedSources, policies, isReportOnly }) => {
   const joinedHashes = cspScriptSrcHashes.join(' ')
-  const baseCspStr = `script-src 'self'${isDev ? ' \'unsafe-eval\'' : ''} ${joinedHashes}`
+  const baseCspStr = `script-src 'self' ${joinedHashes}`
   const policyObjectAvailable = typeof policies === 'object' && policies !== null && !Array.isArray(policies)
 
   if (Array.isArray(allowedSources) && allowedSources.length) {

--- a/packages/server/test/middleware/nuxt.test.js
+++ b/packages/server/test/middleware/nuxt.test.js
@@ -265,7 +265,7 @@ describe('server: nuxtMiddleware', () => {
     expect(res.setHeader).nthCalledWith(
       1,
       'Content-Security-Policy-Report-Only',
-      "script-src 'self' 'unsafe-eval' sha256-hashes /nuxt/*.js /nuxt/images/*"
+      "script-src 'self' sha256-hashes /nuxt/*.js /nuxt/images/*"
     )
   })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

Follow up https://github.com/nuxt/nuxt.js/pull/7305 and https://github.com/nuxt/nuxt.js/pull/7454, now we won't have any eval code if csp is enabled without explicit `unsafe-eval` config, so we can remove `unsafe-eval` in dev mode now which will make csp in dev and prod more consistent.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

