### PR TITLE
fix(webpack): fallback for empty chunk name

### DIFF
--- a/packages/webpack/src/config/client.js
+++ b/packages/webpack/src/config/client.js
@@ -74,24 +74,29 @@ export default class WebpackClientConfig extends WebpackBaseConfig {
 
     if (!this.dev && cacheGroups.default && cacheGroups.default.name === undefined) {
       cacheGroups.default.name = (_module, chunks) => {
-        // Use compact name for concatinated modules
-        let compactName = chunks
-          .filter(c => c.name)
+        // Map chunks to names
+        const names = chunks
           .map(c => c.name)
+          .filter(Boolean)
           .sort()
           .map(name => name.replace(/[/\\]/g, '.').replace(/_/g, '').replace('pages.', ''))
-          .join('~')
 
         // Fixes https://github.com/nuxt/nuxt.js/issues/7665
         // TODO: We need a reproduction for this case (test/fixtures/shared-chunk)
-        if (!compactName) {
-          compactName = 'default'
+        if (!names.length) {
+          return 'commons/default'
         }
 
+        // Single chunk is not common
+        if (names.length === 1) {
+          return names[0]
+        }
+
+        // Use compact name for concatinated modules
+        let compactName = names.join('~')
         if (compactName.length > 32) {
           compactName = hash(compactName)
         }
-
         return 'commons/' + compactName
       }
     }

--- a/packages/webpack/src/config/client.js
+++ b/packages/webpack/src/config/client.js
@@ -77,9 +77,13 @@ export default class WebpackClientConfig extends WebpackBaseConfig {
         // Map chunks to names
         const names = chunks
           .map(c => c.name)
+          .map(name => name
+            .replace(/[/\\]/g, '.')
+            .replace(/_/g, '')
+            .replace('pages.', '')
+          )
           .filter(Boolean)
           .sort()
-          .map(name => name.replace(/[/\\]/g, '.').replace(/_/g, '').replace('pages.', ''))
 
         // Fixes https://github.com/nuxt/nuxt.js/issues/7665
         // TODO: We need a reproduction for this case (test/fixtures/shared-chunk)

--- a/packages/webpack/src/config/client.js
+++ b/packages/webpack/src/config/client.js
@@ -76,7 +76,7 @@ export default class WebpackClientConfig extends WebpackBaseConfig {
       cacheGroups.default.name = (_module, chunks) => {
         // Map chunks to names
         const names = chunks
-          .map(c => c.name)
+          .map(c => c.name || '')
           .map(name => name
             .replace(/[/\\]/g, '.')
             .replace(/_/g, '')

--- a/packages/webpack/src/config/client.js
+++ b/packages/webpack/src/config/client.js
@@ -84,7 +84,7 @@ export default class WebpackClientConfig extends WebpackBaseConfig {
           .map(c => c.name)
           .sort()
           .map(name => name.replace(/[/\\]/g, '.').replace(/_/g, '').replace('pages.', ''))
-          .join('~')
+          .join('~') || 'default'
 
         if (compactName.length > 32) {
           compactName = hash(compactName)

--- a/packages/webpack/src/config/client.js
+++ b/packages/webpack/src/config/client.js
@@ -74,10 +74,6 @@ export default class WebpackClientConfig extends WebpackBaseConfig {
 
     if (!this.dev && cacheGroups.default && cacheGroups.default.name === undefined) {
       cacheGroups.default.name = (_module, chunks) => {
-        // Use default name for single chunks
-        if (chunks.length === 1) {
-          return chunks[0].name || ''
-        }
         // Use compact name for concatinated modules
         let compactName = chunks
           .filter(c => c.name)

--- a/packages/webpack/src/config/client.js
+++ b/packages/webpack/src/config/client.js
@@ -84,7 +84,13 @@ export default class WebpackClientConfig extends WebpackBaseConfig {
           .map(c => c.name)
           .sort()
           .map(name => name.replace(/[/\\]/g, '.').replace(/_/g, '').replace('pages.', ''))
-          .join('~') || 'default'
+          .join('~')
+
+        // Fixes https://github.com/nuxt/nuxt.js/issues/7665
+        // TODO: We need a reproduction for this case (test/fixtures/shared-chunk)
+        if (!compactName) {
+          compactName = 'default'
+        }
 
         if (compactName.length > 32) {
           compactName = hash(compactName)

--- a/test/fixtures/shared-chunk/components/lazy.vue
+++ b/test/fixtures/shared-chunk/components/lazy.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    Lazy Components
+  </div>
+</template>

--- a/test/fixtures/shared-chunk/nuxt.config.js
+++ b/test/fixtures/shared-chunk/nuxt.config.js
@@ -1,3 +1,4 @@
 export default {
-  components: true
+  components: true,
+  modern: true
 }

--- a/test/fixtures/shared-chunk/pages/index.vue
+++ b/test/fixtures/shared-chunk/pages/index.vue
@@ -1,5 +1,14 @@
 <template>
   <div>
+    <MyLazyComponent />
     <SharedVendor />
   </div>
 </template>
+
+<script>
+export default {
+  components: {
+    MyLazyComponent: () => import('~/components/lazy.vue')
+  }
+}
+</script>


### PR DESCRIPTION
fixes #7665

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
if all chunks have no name, it results to an empty compactName. Due to #7639 this results into file paths like /common/.xxx.js. As files with a dot at the beginnign are not served, this is a problem ;-)  


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

