### PR TITLE
types: fix module options type

### DIFF
--- a/packages/types/config/module.d.ts
+++ b/packages/types/config/module.d.ts
@@ -6,7 +6,7 @@
 
 import { Configuration as WebpackConfiguration } from 'webpack'
 import { NuxtOptionsLoaders } from './build'
-import { Configuration as NuxtOptions } from '.'
+import { NuxtOptions } from '.'
 
 interface ExtendFunctionContext {
   isClient: boolean


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Wrong type was used, making `options` not typed cause `Configuration` has been turned to `Record<string; any>` in **2.13.1**


## Additional notes

To merge with **[release]** to fix `@nuxt/types-edge` asap