### PR TITLE
types: add cross-origin property to `NuxtOptionsRender`

### DIFF
--- a/packages/types/config/render.d.ts
+++ b/packages/types/config/render.d.ts
@@ -50,6 +50,7 @@ export interface NuxtOptionsRender {
   bundleRenderer?: BundleRendererOptions
   compressor?: CompressionOptions | NuxtOptionsServerMiddleware | false
   csp?: boolean | CspOptions
+  crossorigin?: "anonymous" | "use-credentials" | ""
   dist?: ServeStaticOptions
   etag?: NuxtEtagOptions | false
   fallback?: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

I found a missing property `crossorigin` in `NuxtOptionsRender` Type. This PR fixes it.
According to [the MDN page](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin), this property is enumerated.

Now, this property is in [the official document](https://nuxtjs.org/api/configuration-render/#crossorigin) and available. 

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

