### PR TITLE
fix(vue-renderer): read `target` from class instead of `serverContext`

### DIFF
--- a/packages/vue-renderer/src/renderer.js
+++ b/packages/vue-renderer/src/renderer.js
@@ -276,7 +276,7 @@ export default class VueRenderer {
     // Add url to the renderContext
     renderContext.url = url
     // Add target to the renderContext
-    renderContext.target = this.serverContext.options.target
+    renderContext.target = this.options.target
 
     const { req = {}, res = {} } = renderContext
 

--- a/packages/vue-renderer/src/renderer.js
+++ b/packages/vue-renderer/src/renderer.js
@@ -276,7 +276,7 @@ export default class VueRenderer {
     // Add url to the renderContext
     renderContext.url = url
     // Add target to the renderContext
-    renderContext.target = this.serverContext.nuxt.options.target
+    renderContext.target = this.serverContext.options.target
 
     const { req = {}, res = {} } = renderContext
 


### PR DESCRIPTION
The `renderRoute` method assumes that `this.serverContext.nuxt.options` is a valid path, but that does not seem like a good assumption AFAICT. We could defensively check for its existence, but I think the correct thing to do here, is to use `this.options` instead.

I'm not sure how this was working before, but I hit this particular problem while trying to use `nuxt-lambda` which creates a minimal `serverContext` that doesn't include `serverContext.nuxt.options`. See: https://github.com/pimlie/nuxt-lambda/blob/master/src/renderer.js#L8-L21 -- I freely admit that the bug could lie there. I tried to find some authoratative documentation on `serverContext` but was unsuccessful.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Presently `renderRouter` assumes that `serverContext` has a `nuxt.options.target` field. This seems at odds with other areas within the code that need to access `target` and get it directly from `serverContext.options`. To remain consistent and remove (what I think is) an errant path, we should update the assignment of `serverContext.target` using `this.options.target` instead of `this.serverContext.nuxt.options.target`

## Checklist:
I tried to run the tests locally but failed hard. Could not get jest to work.
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.
