### PR TITLE
feat(builder): support async `extendRoutes`

### DIFF
--- a/packages/builder/src/builder.js
+++ b/packages/builder/src/builder.js
@@ -414,13 +414,13 @@ export default class Builder {
     // router.extendRoutes method
     if (typeof this.options.router.extendRoutes === 'function') {
       // let the user extend the routes
-      const extendedRoutes = this.options.router.extendRoutes(
+      const extendedRoutes = await this.options.router.extendRoutes(
         templateVars.router.routes,
         r
       )
       // Only overwrite routes when something is returned for backwards compatibility
       if (extendedRoutes !== undefined) {
-        templateVars.router.routes = await extendedRoutes
+        templateVars.router.routes = extendedRoutes
       }
     }
 

--- a/packages/builder/src/builder.js
+++ b/packages/builder/src/builder.js
@@ -420,7 +420,7 @@ export default class Builder {
       )
       // Only overwrite routes when something is returned for backwards compatibility
       if (extendedRoutes !== undefined) {
-        templateVars.router.routes = extendedRoutes
+        templateVars.router.routes = await extendedRoutes
       }
     }
 


### PR DESCRIPTION
Current behaviour
its impossible to extend routes with APIs

Expected behaviour
Being able to await requests to server that are required for extendingRoutes


<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
With this simple change, we are able to extend our nuxt router with async data without need to create custom router.

In documentation is something like this:
```javascript
router: {
  extendRoutes(routes, resolve) {
    routes.push({
      name: 'PageHierarchyPage',
      path: '/test/test/',
      props: {
        id: 12,
      },
      component: resolve(__dirname, 'pages-extended/PageHierarchyPage/_.vue'),
    });
    sortRoutes(routes);
  }
}
```

But we might need something like this:
```javascript
router: {
  extendRoutes: async (routes, resolve) => {
   const dynamicRoutes = await getDynamicRoutes();
   const dynamicRoutesTransformed = dynamicRoutes.map(item => ({
     ...item,
     component: resolve(__dirname, item.component)
   }));
   routes.push(...dynamicRoutesTransformed);
   sortRoutes(routes);

   return routes;
  }
}
```

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [X] All new and existing tests are passing.

