### PR TITLE
fix(utils): include routes with children for generation

### DIFF
--- a/packages/utils/src/route.js
+++ b/packages/utils/src/route.js
@@ -9,22 +9,19 @@ export const flatRoutes = function flatRoutes (router, fileName = '', routes = [
     if ([':', '*'].some(c => r.path.includes(c))) {
       return
     }
-    if (r.children) {
-      if (fileName === '' && r.path === '/') {
-        routes.push('/')
-      }
-
-      return flatRoutes(r.children, fileName + r.path + '/', routes)
-    }
-    fileName = fileName.replace(/\/+/g, '/')
+    fileName = (fileName + r.path + '/').replace(/\/+/g, '/')
 
     // if child path is already absolute, do not make any concatenations
     if (r.path && r.path.startsWith('/')) {
       routes.push(r.path)
     } else if (r.path === '' && fileName[fileName.length - 1] === '/') {
-      routes.push(fileName.slice(0, -1) + r.path)
+      routes.push(fileName.slice(0, -1))
     } else {
-      routes.push(fileName + r.path)
+      routes.push(fileName)
+    }
+
+    if (r.children) {
+      return flatRoutes(r.children, fileName, routes)
     }
   })
   return routes

--- a/packages/utils/src/route.js
+++ b/packages/utils/src/route.js
@@ -5,7 +5,8 @@ import consola from 'consola'
 import { r } from './resolve'
 
 const getRouteChildrens = function (route) {
-  if (route.children.some(child => child.path === '')) {
+  const routeHasChildWithEmptyPath = route.children.some(child => child.path === '')
+  if (routeHasChildWithEmptyPath) {
     return route.children
   }
   return [
@@ -23,7 +24,7 @@ export const flatRoutes = function flatRoutes (router, fileName = '', routes = [
     if ([':', '*'].some(c => r.path.includes(c))) {
       return
     }
-    const route = (fileName + r.path + '/').replace(/\/+/g, '/')
+    const route = `${fileName}${r.path}/`.replace(/\/+/g, '/')
     if (r.children) {
       return flatRoutes(getRouteChildrens(r), route, routes)
     }
@@ -31,7 +32,7 @@ export const flatRoutes = function flatRoutes (router, fileName = '', routes = [
     // if child path is already absolute, do not make any concatenations
     if (r.path && r.path.startsWith('/')) {
       routes.push(r.path)
-    } else if (route[route.length - 1] === '/') {
+    } else if (route !== '/' && route[route.length - 1] === '/') {
       routes.push(route.slice(0, -1))
     } else {
       routes.push(route)

--- a/packages/utils/src/route.js
+++ b/packages/utils/src/route.js
@@ -23,18 +23,18 @@ export const flatRoutes = function flatRoutes (router, fileName = '', routes = [
     if ([':', '*'].some(c => r.path.includes(c))) {
       return
     }
+    const route = (fileName + r.path + '/').replace(/\/+/g, '/')
     if (r.children) {
-      return flatRoutes(getRouteChildrens(r), fileName + r.path + '/', routes)
+      return flatRoutes(getRouteChildrens(r), route, routes)
     }
-    fileName = fileName.replace(/\/+/g, '/')
 
     // if child path is already absolute, do not make any concatenations
     if (r.path && r.path.startsWith('/')) {
       routes.push(r.path)
-    } else if (r.path === '' && fileName[fileName.length - 1] === '/') {
-      routes.push(fileName.slice(0, -1))
+    } else if (route[route.length - 1] === '/') {
+      routes.push(route.slice(0, -1))
     } else {
-      routes.push(fileName + r.path)
+      routes.push(route)
     }
   })
   return routes

--- a/packages/utils/src/route.js
+++ b/packages/utils/src/route.js
@@ -4,9 +4,9 @@ import consola from 'consola'
 
 import { r } from './resolve'
 
-const getRouteChildrens = function (route) {
-  const routeHasChildWithEmptyPath = route.children.some(child => child.path === '')
-  if (routeHasChildWithEmptyPath) {
+const routeChildren = function (route) {
+  const hasChildWithEmptyPath = route.children.some(child => child.path === '')
+  if (hasChildWithEmptyPath) {
     return route.children
   }
   return [
@@ -26,7 +26,7 @@ export const flatRoutes = function flatRoutes (router, fileName = '', routes = [
     }
     const route = `${fileName}${r.path}/`.replace(/\/+/g, '/')
     if (r.children) {
-      return flatRoutes(getRouteChildrens(r), route, routes)
+      return flatRoutes(routeChildren(r), route, routes)
     }
 
     // if child path is already absolute, do not make any concatenations

--- a/packages/utils/src/route.js
+++ b/packages/utils/src/route.js
@@ -4,12 +4,29 @@ import consola from 'consola'
 
 import { r } from './resolve'
 
+const getRouteChildrens = function (route) {
+  if (route.children.some(child => child.path === '')) {
+    return route.children
+  }
+  return [
+    // Add default child to render parent page
+    {
+      ...route,
+      children: undefined
+    },
+    ...route.children
+  ]
+}
+
 export const flatRoutes = function flatRoutes (router, fileName = '', routes = []) {
   router.forEach((r) => {
     if ([':', '*'].some(c => r.path.includes(c))) {
       return
     }
-    fileName = (fileName + r.path + '/').replace(/\/+/g, '/')
+    if (r.children) {
+      return flatRoutes(getRouteChildrens(r), fileName + r.path + '/', routes)
+    }
+    fileName = fileName.replace(/\/+/g, '/')
 
     // if child path is already absolute, do not make any concatenations
     if (r.path && r.path.startsWith('/')) {
@@ -17,11 +34,7 @@ export const flatRoutes = function flatRoutes (router, fileName = '', routes = [
     } else if (r.path === '' && fileName[fileName.length - 1] === '/') {
       routes.push(fileName.slice(0, -1))
     } else {
-      routes.push(fileName)
-    }
-
-    if (r.children) {
-      return flatRoutes(r.children, fileName, routes)
+      routes.push(fileName + r.path)
     }
   })
   return routes

--- a/packages/utils/test/route.test.js
+++ b/packages/utils/test/route.test.js
@@ -14,7 +14,7 @@ describe('util: route', () => {
         ]
       }
     ])
-    expect(routes).toEqual(['/login', '/about', '', '/post'])
+    expect(routes).toEqual(['/login', '/about', '/', '/post'])
   })
 
   test('should ignore route with * and :', () => {

--- a/packages/utils/test/route.test.js
+++ b/packages/utils/test/route.test.js
@@ -52,7 +52,7 @@ describe('util: route', () => {
       }
     ])
 
-    expect(routes).toEqual(['/foo/bar', '/foo/baz'])
+    expect(routes).toEqual(['/foo', '/foo/bar', '/foo/baz'])
   })
 
   test('should flat absolute routes with empty path', () => {


### PR DESCRIPTION
`flatRoutes` function was skip all parent routes that have children. Parent routes was not generates in static generation, to  Take a look at #4562 to find more about the issue.
close #4562 & #4982

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

