### PR TITLE
fix(vue-app): nuxt-link prefetch error on fallback page

### DIFF
--- a/packages/vue-app/template/components/nuxt-link.client.js
+++ b/packages/vue-app/template/components/nuxt-link.client.js
@@ -111,7 +111,8 @@ export default {
       // Preload the data only if not in preview mode
       if (!this.$root.isPreview) {
         const { href } = this.$router.resolve(this.to, this.$route, this.append)
-        this.$nuxt.fetchPayload(href).catch(() => {})
+        if (this.$nuxt)
+          this.$nuxt.fetchPayload(href).catch(() => {})
       }
       <% } %>
       <% if (router.linkPrefetchedClass) { %>


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
This will suppress unnecessary error on 404 fallback pages in full static builds.
<details>
<summary>Example error this will solve</summary>

```
VM149 app.b6b9056.modern.js:1 Uncaught TypeError: Cannot read property 'fetchPayload' of undefined
    at f.prefetchLink (VM149 app.b6b9056.modern.js:1)
    at VM149 app.b6b9056.modern.js:1
    at Array.forEach (<anonymous>)
    at IntersectionObserver.l (VM149 app.b6b9056.modern.js:1)
```
</details>


## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

