### PR TITLE
fix(generator): avoid duplicate slashes for routes ending with hash

### DIFF
--- a/packages/generator/src/generator.js
+++ b/packages/generator/src/generator.js
@@ -303,6 +303,7 @@ export default class Generator {
             .trim()
 
           const route = decodeURI(sanitizedHref + possibleTrailingSlash)
+            .replace(/\/+/g, '/')
 
           if (route.startsWith('/') && !path.extname(route) && this.shouldGenerateRoute(route) && !this.generatedRoutes.has(route)) {
             this.generatedRoutes.add(route)

--- a/packages/generator/src/generator.js
+++ b/packages/generator/src/generator.js
@@ -297,13 +297,12 @@ export default class Generator {
         parse(html).querySelectorAll('a').map((el) => {
           const sanitizedHref = (el.getAttribute('href') || '')
             .replace(this.options.router.base, '/')
-            .replace(/\/+$/, '')
             .split('?')[0]
             .split('#')[0]
+            .replace(/\/+$/, '')
             .trim()
 
           const route = decodeURI(sanitizedHref + possibleTrailingSlash)
-            .replace(/\/+/g, '/')
 
           if (route.startsWith('/') && !path.extname(route) && this.shouldGenerateRoute(route) && !this.generatedRoutes.has(route)) {
             this.generatedRoutes.add(route)

--- a/test/fixtures/full-static/layouts/default.vue
+++ b/test/fixtures/full-static/layouts/default.vue
@@ -10,7 +10,7 @@
       <NLink to="/pagination/1">
         Pagination
       </NLink>
-      <NLink to="/dynamic/foo bar#hash">
+      <NLink to="/dynamic/foo bar/#hash">
         Dynamic route 1
       </NLink>
       <NLink to="/dynamic/foo%20bar">

--- a/test/fixtures/full-static/nuxt.config.js
+++ b/test/fixtures/full-static/nuxt.config.js
@@ -6,7 +6,8 @@ export default {
     }
   },
   router: {
-    // base: '/test'
+    // base: '/test',
+    trailingSlash: true
   },
   hooks: {
     export: {


### PR DESCRIPTION
Using links like `/foo/#bar` cause error in generating static pages. This happens because crawler adds a trailing slash to every route. We need to make sure the is no duplicate slashes in route.

close #7772
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

