### PR TITLE
fix: add types for `build.corejs` option and use number

### DIFF
--- a/packages/cli/test/unit/__snapshots__/webpack.test.js.snap
+++ b/packages/cli/test/unit/__snapshots__/webpack.test.js.snap
@@ -75,7 +75,7 @@ exports[`webpack nuxt webpack module.rules 1`] = `
               \\"<nuxtDir>/packages/babel-preset-app/src/index.js\\",
               Object {
                 \\"corejs\\": Object {
-                  \\"version\\": \\"2\\",
+                  \\"version\\": 2,
                 },
               },
             ],
@@ -654,7 +654,7 @@ exports[`webpack nuxt webpack module.rules test=.jsx 1`] = `
             \\"<nuxtDir>/packages/babel-preset-app/src/index.js\\",
             Object {
               \\"corejs\\": Object {
-                \\"version\\": \\"2\\",
+                \\"version\\": 2,
               },
             },
           ],

--- a/packages/types/config/build.d.ts
+++ b/packages/types/config/build.d.ts
@@ -137,6 +137,7 @@ export interface NuxtOptionsBuild {
   analyze?: BundleAnalyzerPlugin.Options | boolean
   babel?: NuxtBabelOptions
   cache?: boolean
+  corejs?: 'auto' | 2 | 3
   crossorigin?: string
   cssSourceMap?: boolean
   devMiddleware?: WebpackDevMiddlewareOptions

--- a/packages/webpack/src/config/base.js
+++ b/packages/webpack/src/config/base.js
@@ -120,15 +120,15 @@ export default class WebpackBaseConfig {
     let corejsVersion = corejs
     if (corejsVersion === 'auto') {
       try {
-        corejsVersion = createRequire(rootDir)('core-js/package.json').version.split('.')[0]
+        corejsVersion = Number.parseInt(createRequire(rootDir)('core-js/package.json').version.split('.')[0])
       } catch (_err) {
-        corejsVersion = '2'
+        corejsVersion = 2
       }
     }
 
-    if (corejsVersion !== '2' && corejsVersion !== '3') {
-      consola.warn(`Invalid corejs version ${JSON.stringify(corejsVersion)}! Please set "build.corejs" to either "2" or "3".`)
-      corejsVersion = '2'
+    if (![2, 3].includes(corejsVersion)) {
+      consola.warn(`Invalid corejs version ${corejsVersion}! Please set "build.corejs" to either "auto", 2 or 3.`)
+      corejsVersion = 2
     }
 
     const defaultPreset = [require.resolve('@nuxt/babel-preset-app'), {


### PR DESCRIPTION
Match the documentation https://github.com/nuxt/nuxtjs.org/commit/9301152105f89255813a46c1d5c00286c731df0c

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
A follow-up to comments raised in https://github.com/nuxt/nuxt.js/pull/7785
Correct the check that checks user-provided value for `build.corejs`.
It now matches documentation at https://github.com/nuxt/nuxtjs.org/commit/9301152105f89255813a46c1d5c00286c731df0c

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

