### PR TITLE
fix(cli): normalize win32 paths for `nuxt generate` cache snapshots

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -33,6 +33,7 @@
     "pretty-bytes": "^5.3.0",
     "serve-static": "^1.14.1",
     "std-env": "^2.2.1",
+    "upath": "^1.2.0",
     "wrap-ansi": "^6.2.0"
   },
   "publishConfig": {

--- a/packages/cli/src/utils/generate.js
+++ b/packages/cli/src/utils/generate.js
@@ -1,4 +1,5 @@
 import path, { relative } from 'path'
+import upath from 'upath'
 import fs from 'fs-extra'
 import crc32 from 'crc/lib/crc32'
 import consola from 'consola'
@@ -48,7 +49,7 @@ export async function ensureBuild (cmd) {
   // Take a snapshot of current project
   const snapshotOptions = {
     rootDir: nuxt.options.rootDir,
-    ignore: nuxt.options.generate.cache.ignore,
+    ignore: nuxt.options.generate.cache.ignore.map(upath.normalize),
     globbyOptions: nuxt.options.generate.cache.globbyOptions
   }
 


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
Added [upath](https://www.npmjs.com/package/upath) (which is already used in @nuxtjs/builder) for enforce posix patterns to be given to the `nuxt generate` [`snapshot` function](https://github.com/nuxt/nuxt.js/blob/dev/packages/cli/src/utils/generate.js#L142).
<!--- Why is this change required? What problem does it solve? -->
Globby was receiving OS specific paths for it's [ignore option](https://github.com/nuxt/nuxt.js/blob/dev/packages/cli/src/utils/generate.js#L142) while only accepting posix paths resulting to cache failing on win32 platform.
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
Resolves: #7792 (all details there)

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing. _(see message below)_

