### PR TITLE
fix(cli): prevent caching when disabled

### DIFF
--- a/packages/cli/src/utils/generate.js
+++ b/packages/cli/src/utils/generate.js
@@ -24,6 +24,7 @@ export async function ensureBuild (cmd) {
     const builder = await cmd.getBuilder(nuxt)
     await builder.build()
     await nuxt.close()
+    return
   }
 
   // Default build ignore files


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
I'm not that familiar with Nuxt internals so far (working on it ^^) but [`ensureBuild` function](https://github.com/nuxt/nuxt.js/blob/dev/packages/cli/src/utils/generate.js#L23-L27) doesn't exit after build when [`options.generate.cache`](https://nuxtjs.org/guides/configuration-glossary/configuration-generate#cache) is set to `false` so I made the function returns when needed.
<!--- Why is this change required? What problem does it solve? -->
When explicitly disabling cache (i.e. with `options.generate.cache = false`) Nuxt will attempt to build twice because `ensureBuild` doesn't return after [`await nuxt.close()` statement](https://github.com/nuxt/nuxt.js/blob/dev/packages/cli/src/utils/generate.js#L26), and eventually leading to a fatal because globby ends up receiving an undefined argument:
```bash
8:23:55 PM: [fatal] Cannot read property 'concat' of undefined
8:23:55 PM:   at generateGlobTasks (node_modules/globby/index.js:64:31)
8:23:55 PM:   at module.exports (node_modules/globby/index.js:115:20)
8:23:55 PM:   at snapshot (node_modules/@nuxt/cli/dist/cli-generate.js:236:23)
8:23:55 PM:   at ensureBuild (node_modules/@nuxt/cli/dist/cli-generate.js:154:38)
```

I'm not 100% confident on that one but you'll tell me~ 🙂

P.S. skipped the issue part because it looks minime to me, hope you don't mind~ (and I want it shipped with `2.14.1` haha)
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

