### PR TITLE
feat: bind serverMiddleware to nuxt instance

### DIFF
--- a/packages/server/src/server.js
+++ b/packages/server/src/server.js
@@ -273,7 +273,7 @@ export default class Server {
 
   useMiddleware (middleware) {
     const { route, handle } = this.resolveMiddleware(middleware)
-    this.app.use(route, handle)
+    this.app.use(route, handle.bind(this.nuxt))
   }
 
   replaceMiddleware (query, middleware) {

--- a/packages/server/test/server.test.js
+++ b/packages/server/test/server.test.js
@@ -343,7 +343,7 @@ describe('server: server', () => {
 
     expect(nuxt.resolver.requireModule).not.toBeCalled()
     expect(server.app.use).toBeCalledTimes(1)
-    expect(server.app.use).toBeCalledWith(nuxt.options.router.base, handler)
+    expect(server.app.use).toBeCalledWith(nuxt.options.router.base, handler.bind(nuxt))
   })
 
   test('should use function module middleware', () => {
@@ -358,7 +358,7 @@ describe('server: server', () => {
     expect(nuxt.resolver.requireModule).toBeCalledTimes(1)
     expect(nuxt.resolver.requireModule).toBeCalledWith('test-middleware')
     expect(server.app.use).toBeCalledTimes(1)
-    expect(server.app.use).toBeCalledWith(nuxt.options.router.base, handler)
+    expect(server.app.use).toBeCalledWith(nuxt.options.router.base, handler.bind(nuxt))
   })
 
   test('should use object module middleware', () => {
@@ -377,7 +377,7 @@ describe('server: server', () => {
     expect(nuxt.resolver.requireModule).toBeCalledTimes(1)
     expect(nuxt.resolver.requireModule).toBeCalledWith('test-middleware')
     expect(server.app.use).toBeCalledTimes(1)
-    expect(server.app.use).toBeCalledWith('/middleware', handler)
+    expect(server.app.use).toBeCalledWith('/middleware', handler.bind(nuxt))
   })
 
   test('should show error when module require failed', () => {


### PR DESCRIPTION
Bind the server middleware functions to the nuxt instance. Ideally I wished this was [the server context](https://nuxtjs.org/api/context/) object because I wanted to load some runtime configuration options, but I couldn't find it. This is at least a little stop gap that makes it easier to access lower level options.

## Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Solves the issue of not being able to access nuxt or any lower level settings in server middleware functions.


## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

