### PR TITLE
chore(stale): ignore feature request issues

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -4,6 +4,7 @@ daysUntilClose: 7
 staleLabel: stale
 exemptLabels:
   - "cmty:feature-request"
+  - "feature-request
   - "WIP"
   - "pending"
   - "discussion"


### PR DESCRIPTION
Due to recent label changes, `feature-request` issues are being marked as stale. I've adapted the bot config to avoid that