### PR TITLE
fix(utils): remove optional params in routes ending with `index`

### DIFF
--- a/packages/utils/src/route.js
+++ b/packages/utils/src/route.js
@@ -57,7 +57,7 @@ function cleanChildrenRoutes (routes, isChild = false, routeNameSplitter = '-', 
   routes.forEach((route) => {
     route.path = isChild ? route.path.replace('/', '') : route.path
     if (route.path.includes('?')) {
-      if (route.name.endsWith('-index')) {
+      if (route.name.endsWith(`${routeNameSplitter}index`)) {
         route.path = route.path.replace(/\?$/, '')
       }
       const names = route.name.split(routeNameSplitter)

--- a/packages/utils/src/route.js
+++ b/packages/utils/src/route.js
@@ -57,6 +57,9 @@ function cleanChildrenRoutes (routes, isChild = false, routeNameSplitter = '-', 
   routes.forEach((route) => {
     route.path = isChild ? route.path.replace('/', '') : route.path
     if (route.path.includes('?')) {
+      if (route.name.endsWith('-index')) {
+        route.path = route.path.replace(/\?$/, '')
+      }
       const names = route.name.split(routeNameSplitter)
       const paths = route.path.split('/')
       if (!isChild) {


### PR DESCRIPTION
Make sure the last param of routes that end with `index` is non-optional

fix #5874

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

