### PR TITLE
server(hook): Ability to execute a function before starting the server

### DIFF
--- a/packages/server/src/server.js
+++ b/packages/server/src/server.js
@@ -18,6 +18,9 @@ export default class Server {
     this.nuxt = nuxt
     this.options = nuxt.options
 
+    // Before server init
+    this.nuxt.callHook('server:prepare', null)
+
     this.globals = determineGlobals(nuxt.options.globalName, nuxt.options.globals)
 
     this.publicPath = isUrl(this.options.build.publicPath)

--- a/packages/server/test/server.test.js
+++ b/packages/server/test/server.test.js
@@ -146,9 +146,10 @@ describe('server: server', () => {
 
     await server.ready()
 
-    expect(server.nuxt.callHook).toBeCalledTimes(2)
-    expect(server.nuxt.callHook).nthCalledWith(1, 'render:before', server, server.options.render)
-    expect(server.nuxt.callHook).nthCalledWith(2, 'render:done', server)
+    expect(server.nuxt.callHook).toBeCalledTimes(3)
+    expect(server.nuxt.callHook).nthCalledWith(1, 'server:prepare', null)
+    expect(server.nuxt.callHook).nthCalledWith(2, 'render:before', server, server.options.render)
+    expect(server.nuxt.callHook).nthCalledWith(3, 'render:done', server)
     expect(ServerContext).toBeCalledTimes(1)
     expect(ServerContext).toBeCalledWith(server)
     expect(VueRenderer).toBeCalledTimes(1)
@@ -169,9 +170,10 @@ describe('server: server', () => {
 
     await server.setupMiddleware()
 
-    expect(server.nuxt.callHook).toBeCalledTimes(2)
-    expect(server.nuxt.callHook).nthCalledWith(1, 'render:setupMiddleware', server.app)
-    expect(server.nuxt.callHook).nthCalledWith(2, 'render:errorMiddleware', server.app)
+    expect(server.nuxt.callHook).toBeCalledTimes(3)
+    expect(server.nuxt.callHook).nthCalledWith(1, 'server:prepare', null)
+    expect(server.nuxt.callHook).nthCalledWith(2, 'render:setupMiddleware', server.app)
+    expect(server.nuxt.callHook).nthCalledWith(3, 'render:errorMiddleware', server.app)
 
     expect(server.useMiddleware).toBeCalledTimes(4)
     expect(serveStatic).toBeCalledTimes(2)
@@ -478,8 +480,9 @@ describe('server: server', () => {
     })
     expect(listener.listen).toBeCalledTimes(1)
     expect(server.listeners).toEqual([listener])
-    expect(server.nuxt.callHook).toBeCalledTimes(1)
-    expect(server.nuxt.callHook).toBeCalledWith('listen', listener.server, listener)
+    expect(server.nuxt.callHook).toBeCalledTimes(2)
+    expect(server.nuxt.callHook).nthCalledWith(1, 'server:prepare', null)
+    expect(server.nuxt.callHook).nthCalledWith(2,'listen', listener.server, listener)
   })
 
   test('should listen server via options.server', async () => {


### PR DESCRIPTION
In some use cases, we need to initialize our server with some tools, before even starting the app. The best example is the monitoring. In order to be sure everything is tracked, it has to be the first thing done on the app. 

The problem here, is that I really want to stick as close as possible to the "native" nuxt implementation using the nuxt commands (nuxt dev, nuxt start etc.). Using the server with an express wrapper is not a good option in my opinion because I would create several ways of doing 1 thing (express middleware, nuxt middleware etc.), highly emphasised by the size of the team which could lead to inconsistencies. 

Let me give you an example, it might be easier to follow : ) *Datadog*

https://docs.datadoghq.com/tracing/setup/nodejs/#quickstart

This APM library needs to be (as it is explained) the first library loaded, before the server. 

## Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
I believe, simply adding a hook on the Server would do the trick (correct me if I'm wrong). That way this is flexible enough to implement anything we want here.

I'm open to suggestions if you believe I didn't look at the right place :) 

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.