### PR TITLE
Fix: commons.js file getting generated in dist/node_modules

### DIFF
--- a/packages/webpack/src/config/client.js
+++ b/packages/webpack/src/config/client.js
@@ -66,7 +66,7 @@ export default class WebpackClientConfig extends WebpackBaseConfig {
       cacheGroups.commons = {
         test: /node_modules[\\/](vue|vue-loader|vue-router|vuex|vue-meta|core-js|@babel\/runtime|axios|webpack|setimmediate|timers-browserify|process|regenerator-runtime|cookie|js-cookie|is-buffer|dotprop|nuxt\.js)[\\/]/,
         chunks: 'all',
-        name: 'node_modules/commons',
+        name: true,
         priority: 10
       }
     }


### PR DESCRIPTION
Fixes -  https://github.com/nuxt/nuxt.js/issues/7901
Summary - 
In Nuxt version 2.14.1, When generating static files using "nuxt generate" the common.js file is created in 'dist/_nuxt/node_modules/' while in Nuxt version 2.14.0 it gets created in 'dist/_nuxt/commons' folder.  
The problem with commons.js file getting generated in node_modules is when pushing the dist folder to GitHub for hosting it does push the commons.js file as the node_modules are by default in .gitignore.  
This PR fixes the above issue and commons.js file will gett generated in `dist/_nuxt/commons` folder.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Resolves: #7901 


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

