### PR TITLE
fix(vue-app): fix regression with `scrollToTop`

### DIFF
--- a/packages/vue-app/template/router.scrollBehavior.js
+++ b/packages/vue-app/template/router.scrollBehavior.js
@@ -22,7 +22,11 @@ if (process.client) {
   }
 }
 
-export default function (to, from, savedPosition) {
+  export default function (to, from, savedPosition) {
+  if (from === to) {
+    return
+  }
+
   // if the returned position is falsy or an empty object,
   // will retain current scroll position.
   let position = false

--- a/packages/vue-app/template/router.scrollBehavior.js
+++ b/packages/vue-app/template/router.scrollBehavior.js
@@ -23,24 +23,24 @@ if (process.client) {
 }
 
   export default function (to, from, savedPosition) {
-  if (from === to) {
-    return
-  }
+  const isInitialLoad = to === from
 
-  // if the returned position is falsy or an empty object,
-  // will retain current scroll position.
+    if (isInitialLoad) {
+      return
+    }
+
+  // If the returned position is falsy or an empty object, will retain current scroll position
   let position = false
 
-  // if no children detected and scrollToTop is not explicitly disabled
   const Pages = getMatchedComponents(to)
+
+  // Scroll to the top of the page if...
   if (
-    Pages.length < 2 &&
-    Pages.every(Page => Page.options.scrollToTop !== false)
+      // One of the children set `scrollToTop`
+      Pages.some(Page => Page.options.scrollToTop) ||
+      // scrollToTop set in only page without children
+      (Pages.length < 2 && Pages.every(Page => Page.options.scrollToTop !== false))
   ) {
-    // scroll to the top of the page
-    position = { x: 0, y: 0 }
-  } else if (Pages.some(Page => Page.options.scrollToTop)) {
-    // if one of the children has scrollToTop option set to true
     position = { x: 0, y: 0 }
   }
 

--- a/packages/vue-app/template/router.scrollBehavior.js
+++ b/packages/vue-app/template/router.scrollBehavior.js
@@ -46,7 +46,7 @@ if (process.client) {
   const nuxt = window.<%= globals.nuxt %>
 
   if (
-    // Page hash changes
+    // Route hash changes
     (to.path === from.path && to.hash !== from.hash) ||
     // Initial load (vuejs/vue-router#3199)
     to === from

--- a/packages/vue-app/template/router.scrollBehavior.js
+++ b/packages/vue-app/template/router.scrollBehavior.js
@@ -25,9 +25,9 @@ if (process.client) {
   export default function (to, from, savedPosition) {
   const isInitialLoad = to === from
 
-    if (isInitialLoad) {
-      return
-    }
+  if (isInitialLoad) {
+    return
+  }
 
   // If the returned position is falsy or an empty object, will retain current scroll position
   let position = false

--- a/packages/vue-app/template/router.scrollBehavior.js
+++ b/packages/vue-app/template/router.scrollBehavior.js
@@ -48,7 +48,7 @@ if (process.client) {
   if (
     // Page hash changes
     (to.path === from.path && to.hash !== from.hash) ||
-    // InitialLoad (introduced by vuejs/vue-router#3199)
+    // Initial load (vuejs/vue-router#3199)
     to === from
   ) {
     nuxt.$nextTick(() => nuxt.$emit('triggerScroll'))

--- a/packages/vue-app/template/router.scrollBehavior.js
+++ b/packages/vue-app/template/router.scrollBehavior.js
@@ -23,12 +23,6 @@ if (process.client) {
 }
 
   export default function (to, from, savedPosition) {
-  const isInitialLoad = to === from
-
-  if (isInitialLoad) {
-    return
-  }
-
   // If the returned position is falsy or an empty object, will retain current scroll position
   let position = false
 
@@ -51,8 +45,12 @@ if (process.client) {
 
   const nuxt = window.<%= globals.nuxt %>
 
-  // triggerScroll is only fired when a new component is loaded
-  if (to.path === from.path && to.hash !== from.hash) {
+  if (
+    // Page hash changes
+    (to.path === from.path && to.hash !== from.hash) ||
+    // InitialLoad (introduced by vuejs/vue-router#3199)
+    to === from
+  ) {
     nuxt.$nextTick(() => nuxt.$emit('triggerScroll'))
   }
 

--- a/test/dev/unicode-base.size-limit.test.js
+++ b/test/dev/unicode-base.size-limit.test.js
@@ -20,7 +20,7 @@ describe('nuxt minimal vue-app bundle size limit', () => {
   it('should stay within the size limit range', async () => {
     const filter = filename => filename === 'vue-app.nuxt.js'
     const legacyResourcesSize = await getResourcesSize(distDir, 'client', { filter })
-    const LEGACY_JS_RESOURCES_KB_SIZE = 16.5
+    const LEGACY_JS_RESOURCES_KB_SIZE = 16.6
     expect(legacyResourcesSize.uncompressed).toBeWithinSize(LEGACY_JS_RESOURCES_KB_SIZE)
   })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
`vue-router@3.4.0` landed with vuejs/vue-router#3199 which is breaking `scrollToTop: false` as we need to call `triggerScroll` event on first page too otherwise it will be delayed until next navigation which causes jumping to top (or saved position of previous page)

PR also introducing some code refactors

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

