### PR TITLE
fix(vue-renderer): apply `nomodule` to legacy chunks

### DIFF
--- a/packages/vue-renderer/src/renderers/modern.js
+++ b/packages/vue-renderer/src/renderers/modern.js
@@ -48,7 +48,7 @@ export default class ModernRenderer extends SSRRenderer {
     const scripts = super.renderScripts(renderContext)
 
     if (this.isServerMode) {
-      return scripts.replace('<script', `<script nomodule`)
+      return scripts
     }
 
     const scriptPattern = /<script[^>]*?src="([^"]*?)" defer><\/script>/g
@@ -57,7 +57,7 @@ export default class ModernRenderer extends SSRRenderer {
       const legacyJsFile = jsFile.replace(this.publicPath, '')
       const modernJsFile = this.assetsMapping[legacyJsFile]
       if (!modernJsFile) {
-        return scriptTag
+        return scriptTag.replace('<script', `<script nomodule`)
       }
       const moduleTag = scriptTag
         .replace('<script', `<script type="module"`)


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
An earlier PR (#7919) accidentally added `nomodule` to the runtime chunk rather than just legacy ones. This fixes that issue and should still work with #7918 (but this should be tested - I don't have a repro).

closes #7927

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

