### PR TITLE
fix(vue-app): var names shadowing in chrome debugger

### DIFF
--- a/packages/vue-app/template/store.js
+++ b/packages/vue-app/template/store.js
@@ -94,10 +94,10 @@ function resolveStoreModules (moduleData, filename) {
   // If src is a known Vuex property
   if (VUEX_PROPERTIES.includes(moduleName)) {
     const property = moduleName
-    const storeModule = getStoreModule(store, namespaces, { isProperty: true })
+    const moduleStore = getStoreModule(store, namespaces, { isProperty: true })
 
     // Replace state since it's a function
-    mergeProperty(storeModule, moduleData, property)
+    mergeProperty(moduleStore, moduleData, property)
     return
   }
 

--- a/packages/vue-app/template/store.js
+++ b/packages/vue-app/template/store.js
@@ -94,10 +94,10 @@ function resolveStoreModules (moduleData, filename) {
   // If src is a known Vuex property
   if (VUEX_PROPERTIES.includes(moduleName)) {
     const property = moduleName
-    const moduleStore = getStoreModule(store, namespaces, { isProperty: true })
+    const propertyStoreModule = getStoreModule(store, namespaces, { isProperty: true })
 
     // Replace state since it's a function
-    mergeProperty(moduleStore, moduleData, property)
+    mergeProperty(propertyStoreModule, moduleData, property)
     return
   }
 


### PR DESCRIPTION
Fixes https://github.com/nuxt/nuxt.js/issues/7731 :)
Just renamed a variable in a small block so that another variable in the parent block don't shadow eachother in the Chrome debugger.

## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.
