### PR TITLE
fix(cli): handle error in full static mode with `--fail-on-error`

### DIFF
--- a/packages/cli/src/utils/generate.js
+++ b/packages/cli/src/utils/generate.js
@@ -12,8 +12,11 @@ export async function generate (cmd) {
   const generator = await cmd.getGenerator(nuxt)
 
   await nuxt.server.listen(0)
-  await generator.generate({ build: false })
+  const { errors } = await generator.generate({ build: false })
   await nuxt.close()
+  if (cmd.argv['fail-on-error'] && errors.length > 0) {
+    throw new Error('Error generating pages, exiting with non-zero code')
+  }
 }
 
 export async function ensureBuild (cmd) {


### PR DESCRIPTION
Fixed a bug that command error does not occur even if parameter [--fail-on-error] is added in full static mode.


## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Resolves: [#7947](https://github.com/nuxt/nuxt.js/issues/7947)


## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

