### PR TITLE
chore: add avif format as image

### DIFF
--- a/packages/cli/test/unit/__snapshots__/webpack.test.js.snap
+++ b/packages/cli/test/unit/__snapshots__/webpack.test.js.snap
@@ -565,7 +565,7 @@ exports[`webpack nuxt webpack module.rules 1`] = `
     \\"test\\": /\\\\.styl(us)?$/i,
   },
   Object {
-    \\"test\\": /\\\\.(png|jpe?g|gif|svg|webp)$/i,
+    \\"test\\": /\\\\.(png|jpe?g|gif|svg|webp|avif)$/i,
     \\"use\\": Array [
       Object {
         \\"loader\\": \\"url-loader\\",

--- a/packages/vue-renderer/src/renderers/spa.js
+++ b/packages/vue-renderer/src/renderers/spa.js
@@ -200,7 +200,7 @@ export default class SPARenderer extends BaseRenderer {
       return 'script'
     } else if (ext === 'css') {
       return 'style'
-    } else if (/jpe?g|png|svg|gif|webp|ico/.test(ext)) {
+    } else if (/jpe?g|png|svg|gif|webp|ico|avif/.test(ext)) {
       return 'image'
     } else if (/woff2?|ttf|otf|eot/.test(ext)) {
       return 'font'

--- a/packages/webpack/src/config/base.js
+++ b/packages/webpack/src/config/base.js
@@ -362,7 +362,7 @@ export default class WebpackBaseConfig {
         })
       },
       {
-        test: /\.(png|jpe?g|gif|svg|webp)$/i,
+        test: /\.(png|jpe?g|gif|svg|webp|avif)$/i,
         use: [{
           loader: 'url-loader',
           options: Object.assign(


### PR DESCRIPTION
AVIF, a new image compression format, will be supported in the next Chrome version and is supported behind a flag in FireFox ([source](https://caniuse.com/#feat=avif)). We should add it to our default webpack config so users can utilize the format!

## Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

