### PR TITLE
fix(module): protect `clearRequireCache` against infinite recursion

### DIFF
--- a/packages/utils/src/cjs.js
+++ b/packages/utils/src/cjs.js
@@ -20,13 +20,12 @@ export function clearRequireCache (id) {
     entry.parent.children = entry.parent.children.filter(e => e.id !== id)
   }
 
-  delete require.cache[id]; // needs to be cleared before children, to protect against circular deps (which are totally fine for typescript)
-  
+  // Needs to be cleared before children, to protect against circular deps (#7966)
+  delete require.cache[id] 
+
   for (const child of entry.children) {
     clearRequireCache(child.id)
   }
-
-  
 }
 
 export function scanRequireTree (id, files = new Set()) {

--- a/packages/utils/src/cjs.js
+++ b/packages/utils/src/cjs.js
@@ -20,11 +20,13 @@ export function clearRequireCache (id) {
     entry.parent.children = entry.parent.children.filter(e => e.id !== id)
   }
 
+  delete require.cache[id]; // needs to be cleared before children, to protect against circular deps (which are totally fine for typescript)
+  
   for (const child of entry.children) {
     clearRequireCache(child.id)
   }
 
-  delete require.cache[id]
+  
 }
 
 export function scanRequireTree (id, files = new Set()) {

--- a/packages/utils/src/cjs.js
+++ b/packages/utils/src/cjs.js
@@ -21,7 +21,7 @@ export function clearRequireCache (id) {
   }
 
   // Needs to be cleared before children, to protect against circular deps (#7966)
-  delete require.cache[id] 
+  delete require.cache[id]
 
   for (const child of entry.children) {
     clearRequireCache(child.id)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
This is a very small change, fixing a recently introduced bug when using nuxt-ts : recursive function clearRequireCache was not protected against infinite recursion when dealing with code containing circular reference between modules.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

