### PR TITLE
types: expose `Inject` type

### DIFF
--- a/packages/types/app/index.d.ts
+++ b/packages/types/app/index.d.ts
@@ -50,7 +50,8 @@ export interface Context {
 }
 
 export type Middleware = string | ((ctx: Context, cb: Function) => Promise<void> | void)
-export type Plugin = (ctx: Context, inject: (key: string, value: any) => void) => Promise<void> | void
+export type Inject = (key: string, value: any) => void
+export type Plugin = (ctx: Context, inject: Inject) => Promise<void> | void
 
 export interface Transition {
   name?: string


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

When using Typescript, I usually declare my Nuxt plugins as so:

```
import { Context, Plugin } from '@nuxt/types'
const MyPlugin: Plugin = (ctx: Context, inject: (key: string, value: any) => void) => {})

export default MyPlugin
```

I have to define the `inject` function type myself. I think it would be better to actually export the existing type!
This way, if the type changes one day, I won't have to change the definition in all my plugins.

Now it looks like:
```
import { Context, Plugin, Inject } from '@nuxt/types'
const MyPlugin: Plugin = (ctx: Context, inject: Inject) => {})

export default MyPlugin
```

What do you think?

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

