### PR TITLE
fix(config): normalize `build.indicator: true` to default value

### DIFF
--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -474,7 +474,7 @@ export function getNuxtConfig (_options) {
 
   // Indicator
   // Change boolean true to default nuxt value
-  if (typeof options.build.indicator === 'boolean' && options.build.indicator) {
+  if (options.build.indicator === true) {
     options.build.indicator = nuxtConfig.build.indicator
   }
 

--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -470,13 +470,13 @@ export function getNuxtConfig (_options) {
     options.createRequire = module => createRequire(module.filename)
   }
 
-  // ----- Builtin modules -----
-
   // Indicator
   // Change boolean true to default nuxt value
   if (options.build.indicator === true) {
     options.build.indicator = nuxtConfig.build.indicator
   }
+
+  // ----- Builtin modules -----
 
   // Loading screen
   // Force disable for production and programmatic users

--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -472,6 +472,12 @@ export function getNuxtConfig (_options) {
 
   // ----- Builtin modules -----
 
+  // Indicator
+  // Change boolean true to default nuxt value
+  if (typeof options.build.indicator === "boolean" && options.build.indicator) {
+    options.build.indicator = nuxtConfig.build.indicator
+  }
+
   // Loading screen
   // Force disable for production and programmatic users
   if (!options.dev || !options._cli || !getPKG('@nuxt/loading-screen')) {

--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -474,7 +474,7 @@ export function getNuxtConfig (_options) {
 
   // Indicator
   // Change boolean true to default nuxt value
-  if (typeof options.build.indicator === "boolean" && options.build.indicator) {
+  if (typeof options.build.indicator === 'boolean' && options.build.indicator) {
     options.build.indicator = nuxtConfig.build.indicator
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
when you set indicator to true in nuxt.config , the component nuxt-build-indicator build failed.
so when is set to true, we replace it by default value.
nuxt.config.js:
```js
build: {
   indicator: true,
   ...
}
```
output: nuxt-build-indicator.vue
```js
export default {
  ...
  computed: {
     // options is generate by template
     // options: () => (<%= JSON.stringify(buildIndicator) %>),
      options: () => (true),
      indicatorStyle () {
          const [d1, d2] = this.options.position.split('-') // error when access position in bollean
       ...
     }
  }
 ...
}
```


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

