### PR TITLE
fix(vue-app): empty `$fetch` function for SSR  with static target

### DIFF
--- a/packages/vue-app/template/mixins/fetch.server.js
+++ b/packages/vue-app/template/mixins/fetch.server.js
@@ -41,6 +41,8 @@ export default {
       this._fetchOnServer = this.$options.fetchOnServer !== false
     }
 
+    // Added for remove vue undefined warning while ssr
+    this.$fetch = () => {} // issue #8043
     Vue.util.defineReactive(this, '$fetchState', {
       pending: true,
       error: null,

--- a/test/e2e/fetch.browser.test.js
+++ b/test/e2e/fetch.browser.test.js
@@ -76,6 +76,12 @@ describe('basic browser', () => {
     expect(await page.$text('pre')).toContain('kevinmarrec')
   })
 
+  test('ssr: /fetch-root', async () => {
+    const page = await browser.page(url('/fetch-root'))
+    expect(await page.$text('button')).toContain('has fetch')
+    page.close()
+  })
+
   test('ssr: /fetch-client', async () => {
     const page = await browser.page(url('/fetch-client'))
     expect(await page.$text('p')).toContain('Fetching...')

--- a/test/fixtures/fetch/layouts/default.vue
+++ b/test/fixtures/fetch/layouts/default.vue
@@ -32,6 +32,11 @@
         </n-link>
       </li>
       <li>
+        <n-link to="/fetch-root">
+          Fetch in root click handler
+        </n-link>
+      </li>
+      <li>
         <n-link to="/fetch-component">
           Fetch in component
         </n-link>

--- a/test/fixtures/fetch/pages/fetch-root.vue
+++ b/test/fixtures/fetch/pages/fetch-root.vue
@@ -1,0 +1,21 @@
+<template>
+  <button @click="$fetch">
+    fetch {{ foo }}
+  </button>
+</template>
+
+<script>
+export default {
+  async fetch () {
+    await new Promise(resolve => setTimeout(resolve, 100))
+
+    this.foo = this.$fetch ? 'has fetch' : 'hasn\'t fetch'
+  },
+
+  data () {
+    return {
+      foo: null
+    }
+  }
+}
+</script>


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Add empty function `$fetch` to server fetch mixin
Now while ssr `$fetch` is undefined, and vue can throw errors on it

Resolves: #8043 

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

