### PR TITLE
fix(vue-app): scrollRestoration hasn't set

### DIFF
--- a/packages/vue-app/template/router.scrollBehavior.js
+++ b/packages/vue-app/template/router.scrollBehavior.js
@@ -2,27 +2,27 @@
 <%= isTest ? '/* eslint-disable quotes, semi, indent, comma-spacing, key-spacing, object-curly-spacing, space-before-function-paren  */' : '' %>
 export default <%= serializeFunction(router.scrollBehavior) %>
 <%= isTest ? '/* eslint-enable quotes, semi, indent, comma-spacing, key-spacing, object-curly-spacing, space-before-function-paren  */' : '' %>
-<% } else { %>import { getMatchedComponents } from './utils'
+<% } else { %>import { getMatchedComponents, setScrollRestoration } from './utils'
 
 if (process.client) {
   if ('scrollRestoration' in window.history) {
-    window.history.scrollRestoration = 'manual'
+    setScrollRestoration('manual')
 
     // reset scrollRestoration to auto when leaving page, allowing page reload
     // and back-navigation from other pages to use the browser to restore the
     // scrolling position.
     window.addEventListener('beforeunload', () => {
-      window.history.scrollRestoration = 'auto'
+      setScrollRestoration('auto')
     })
 
     // Setting scrollRestoration to manual again when returning to this page.
     window.addEventListener('load', () => {
-      window.history.scrollRestoration = 'manual'
+      setScrollRestoration('manual')
     })
   }
 }
 
-  export default function (to, from, savedPosition) {
+export default function (to, from, savedPosition) {
   // If the returned position is falsy or an empty object, will retain current scroll position
   let position = false
 

--- a/packages/vue-app/template/utils.js
+++ b/packages/vue-app/template/utils.js
@@ -667,5 +667,5 @@ export function isSamePath (p1, p2) {
 export function setScrollRestoration (newVal) {
   try {
     window.history.scrollRestoration = newVal;
-  } catch() {}
+  } catch(e) {}
 }

--- a/packages/vue-app/template/utils.js
+++ b/packages/vue-app/template/utils.js
@@ -663,3 +663,9 @@ export function stripTrailingSlash (path) {
 export function isSamePath (p1, p2) {
   return stripTrailingSlash(p1) === stripTrailingSlash(p2)
 }
+
+export function setScrollRestoration (newVal) {
+  try {
+    window.history.scrollRestoration = newVal;
+  } catch() {}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
Try catch block for setting `window.history.scrollRestoration`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
We have a lot of bug-reports with error `Cannot set property scrollRestoration of [object History] which has only a getter`, this not critical setter
For fix it, i add try/catch block, while setting this prop
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

