### PR TITLE
feat: Add option 'apollo' to Vue component options api

### DIFF
--- a/packages/types/app/vue.d.ts
+++ b/packages/types/app/vue.d.ts
@@ -24,6 +24,13 @@ declare module 'vue/types/options' {
     validate?(ctx: Context): Promise<boolean> | boolean
     watchQuery?: boolean | string[] | ((newQuery: Route['query'], oldQuery: Route['query']) => boolean)
     meta?: { [key: string]: any }
+    apollo?: {
+      [key: string]: {
+        query: any
+        prefetch: boolean
+        variables(): { [key: string]: any }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Add the apollo option to allow use of the nuxtjs/apollo module with the Options API

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

