### PR TITLE
fix(vue-app): always import error layout, either internal or custom

### DIFF
--- a/packages/vue-app/template/App.js
+++ b/packages/vue-app/template/App.js
@@ -12,7 +12,7 @@ import Vue from 'vue'
   ]: []
 ] %>
 <% if (utilsImports.length) { %>import { <%= utilsImports.join(', ') %> } from './utils'<% } %>
-<% if (features.layouts && components.ErrorPage) { %>import NuxtError from '<%= components.ErrorPage %>'<% } %>
+import NuxtError from '<%= components.ErrorPage ? components.ErrorPage : "./components/nuxt-error.vue" %>'
 <% if (loading) { %>import NuxtLoading from '<%= (typeof loading === "string" ? loading : "./components/nuxt-loading.vue") %>'<% } %>
 <% if (buildIndicator) { %>import NuxtBuildIndicator from './components/nuxt-build-indicator'<% } %>
 <% css.forEach((c) => { %>


### PR DESCRIPTION
closes #8066

## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

The client template needs access to NuxtError and we can follow the pattern of App.js - thanks https://github.com/nuxt/nuxt.js/issues/8066#issuecomment-691556167 for a helpful diagnosis of the issue.

For reference:
* https://github.com/nuxt/nuxt.js/pull/6479 (original source of NuxtError import)
* https://github.com/nuxt/nuxt.js/pull/8016 (PR introducing regression that this fixes)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

