### PR TITLE
fix(babel-preset-app): allow to specify `corejs.version` as string

### DIFF
--- a/packages/babel-preset-app/src/index.js
+++ b/packages/babel-preset-app/src/index.js
@@ -15,8 +15,16 @@ const coreJsMeta = {
   }
 }
 
+function getMajorVersion (version) {
+  if (typeof version === 'number') {
+    return Math.floor(version)
+  } else {
+    return Number(version.split('.')[0])
+  }
+}
+
 function getDefaultPolyfills (corejs) {
-  const { prefixes: { es6, es7 } } = coreJsMeta[corejs.version]
+  const { prefixes: { es6, es7 } } = coreJsMeta[getMajorVersion(corejs.version)]
   return [
     // Promise polyfill alone doesn't work in IE,
     // Needs this as well. see: #1642
@@ -33,7 +41,7 @@ function getDefaultPolyfills (corejs) {
 
 function getPolyfills (targets, includes, { ignoreBrowserslistConfig, configPath, corejs }) {
   const { default: getTargets, isRequired } = require('@babel/helper-compilation-targets')
-  const builtInsList = require(coreJsMeta[corejs.version].builtIns)
+  const builtInsList = require(coreJsMeta[getMajorVersion(corejs.version)].builtIns)
   const builtInTargets = getTargets(targets, {
     ignoreBrowserslistConfig,
     configPath


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
According to the [`core-js` documentation](https://github.com/zloirock/core-js#babelpreset-env), it's recommended to specify used minor `core-js` version:
> **Warning!** Recommended to specify used minor `core-js` version, like `corejs: '3.6'`, instead of `corejs: 3`, since with `corejs: 3` will not be injected modules which were added in minor `core-js` releases.

More examples in their documentation: 
> By default, `@babel/preset-env` with `useBuiltIns: 'usage'` option only polyfills stable features, but you can enable polyfilling of proposals by `proposals` option, as `corejs: { version: '3.6', proposals: true }`.

However, with the current implementation of `babel-preset-app`, only integers can be set as they are used as the key of `coreJsMeta`. This PR enables users to specify minor `core-js` versions by handling minor version string/number. 


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
  > `babel-preset-app` doesn't have any tests...
- [ ] All new and existing tests are passing.

