### PR TITLE
fix(vue-app): use mixin to provide `this.$nuxt` #8068

### DIFF
--- a/packages/vue-app/template/server.js
+++ b/packages/vue-app/template/server.js
@@ -24,6 +24,14 @@ if (!Vue.__nuxt__fetch__mixin__) {
 }
 <% } %>
 
+Vue.mixin({
+  beforeCreate() {
+    if(Vue.prototype.<%= globals.nuxt %>) {
+      this.<%= globals.nuxt %> = Vue.prototype.<%= globals.nuxt %>
+    }
+  }
+})
+
 // Component: <NuxtLink>
 Vue.component(NuxtLink.name, NuxtLink)
 <% if (features.componentAliases) { %>Vue.component('NLink', NuxtLink)<% } %>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

closes #7696

Continue work on #8068 (author @danielroe)

### TODO:

- [ ] Use `defineProperty` with a getter
- [ ] Test

