### PR TITLE
fix(cli): rebuild if `process.env` changes in `nuxt.config`

### DIFF
--- a/test/fixtures/full-static/nuxt.config.js
+++ b/test/fixtures/full-static/nuxt.config.js
@@ -11,6 +11,12 @@ export default {
   build: {
     publicPath: '/test/_nuxt/'
   },
+  foo: {
+    shell: process.env.SHELL
+  },
+  env: {
+    x: 123
+  },
   hooks: {
     export: {
       before ({ setPayload }) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
Fixes #8199 using two methods:
 - Adding `config.env` in snapshot for quick diff
 - Static analyzes of `process.env.*` usage in `nuxt.config` and also include in snapshot

**NOTE:** Downside is that it may cause rebuilds if `runtimeConfig` is using `process.env` directly. Workaround would be using `foo: 'FOO'` syntax.

![ThanksPic](https://source.unsplash.com/xulIYVIbYIc/640x959)

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

