### PR TITLE
fix(babel-preset-app): always transpile optional chaining and nullish-coalescing for server

### DIFF
--- a/packages/babel-preset-app/package.json
+++ b/packages/babel-preset-app/package.json
@@ -14,6 +14,8 @@
     "@babel/helper-compilation-targets": "^7.10.4",
     "@babel/plugin-proposal-class-properties": "^7.10.4",
     "@babel/plugin-proposal-decorators": "^7.10.5",
+    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.4",
+    "@babel/plugin-proposal-optional-chaining": "^7.11.0",
     "@babel/plugin-transform-runtime": "^7.11.5",
     "@babel/preset-env": "^7.11.5",
     "@babel/runtime": "^7.11.2",

--- a/packages/babel-preset-app/src/index.js
+++ b/packages/babel-preset-app/src/index.js
@@ -160,8 +160,10 @@ module.exports = (api, options = {}) => {
   }])
 
   // https://github.com/nuxt/nuxt.js/issues/7722
-  plugins.push('@babel/plugin-proposal-optional-chaining')
-  plugins.push('@babel/plugin-proposal-nullish-coalescing-operator')
+  if (envName === 'server') {
+    plugins.push('@babel/plugin-proposal-optional-chaining')
+    plugins.push('@babel/plugin-proposal-nullish-coalescing-operator')
+  }
 
   return {
     sourceType: 'unambiguous',

--- a/packages/babel-preset-app/src/index.js
+++ b/packages/babel-preset-app/src/index.js
@@ -161,8 +161,8 @@ module.exports = (api, options = {}) => {
 
   // https://github.com/nuxt/nuxt.js/issues/7722
   if (envName === 'server') {
-    plugins.push('@babel/plugin-proposal-optional-chaining')
-    plugins.push('@babel/plugin-proposal-nullish-coalescing-operator')
+    plugins.push(require('@babel/plugin-proposal-optional-chaining'))
+    plugins.push(require('@babel/plugin-proposal-nullish-coalescing-operator'))
   }
 
   return {

--- a/packages/babel-preset-app/src/index.js
+++ b/packages/babel-preset-app/src/index.js
@@ -159,6 +159,10 @@ module.exports = (api, options = {}) => {
     absoluteRuntime
   }])
 
+  // https://github.com/nuxt/nuxt.js/issues/7722
+  plugins.push('@babel/plugin-proposal-optional-chaining')
+  plugins.push('@babel/plugin-proposal-nullish-coalescing-operator')
+
   return {
     sourceType: 'unambiguous',
     presets,

--- a/packages/config/src/config/build.js
+++ b/packages/config/src/config/build.js
@@ -75,10 +75,7 @@ export default () => ({
   babel: {
     configFile: false,
     babelrc: false,
-    cacheDirectory: undefined,
-    plugins: [
-      '@babel/plugin-proposal-optional-chaining'
-    ]
+    cacheDirectory: undefined
   },
   transpile: [], // Name of NPM packages to be transpiled
   postcss: {

--- a/packages/config/src/config/build.js
+++ b/packages/config/src/config/build.js
@@ -75,7 +75,10 @@ export default () => ({
   babel: {
     configFile: false,
     babelrc: false,
-    cacheDirectory: undefined
+    cacheDirectory: undefined,
+    plugins: [
+      '@babel/plugin-proposal-optional-chaining'
+    ]
   },
   transpile: [], // Name of NPM packages to be transpiled
   postcss: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description

Since node@14 supports optional chaining, `@babel/preset-env` disables transpilation for this target (we use runtime node version as target). But this makes troubles (#7722) as webpack@4 uses acorn 6.x which doesn't support this syntax (webpack/webpack#10227)

### Alternative

We could strictly set node target to 8 or 10 to avoid same happening in the future with acorn and nuxt@2

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

