### PR TITLE
fix(webpack): allow transpiling package in nested `node_modules`

### DIFF
--- a/packages/webpack/src/config/base.js
+++ b/packages/webpack/src/config/base.js
@@ -316,7 +316,7 @@ export default class WebpackBaseConfig {
       {
         test: /\.m?jsx?$/i,
         exclude: (file) => {
-          file = file.split('node_modules', 2)[1]
+          file = file.split(/node_modules(.*)/)[1]
 
           // not exclude files outside node_modules
           if (!file) {


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
When I need to transpile `[PROJECT_PATH]/node_modules/lowlight/node_modules/highlight.js/...` but not transpile `/lowlight/` itself, it is imposible, because split only return text between `node_modules` ( `/lowlight/` in this example)

this change leave full path after first `node_modules`, not only path between 2 `node_modules` ( `/lowlight/node_modules/highlight.js/...` in this example)


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.