### PR TITLE
feat(generator): ability to customize non-root page extensions

### DIFF
--- a/packages/config/src/config/generate.js
+++ b/packages/config/src/config/generate.js
@@ -18,5 +18,6 @@ export default () => ({
     versionBase: undefined, // Default: "_nuxt/static/{version}""
     dir: 'static',
     version: undefined // Default: "{timeStampSec}"
-  }
+  },
+  nonRootPageExtension: undefined // Default: '.html'
 })

--- a/packages/config/test/__snapshots__/options.test.js.snap
+++ b/packages/config/test/__snapshots__/options.test.js.snap
@@ -205,6 +205,7 @@ Object {
     "exclude": Array [],
     "fallback": "200.html",
     "interval": 0,
+    "nonRootPageExtension": undefined,
     "routes": Array [],
     "staticAssets": Object {
       "base": "/_nuxt/static",

--- a/packages/config/test/config/__snapshots__/index.test.js.snap
+++ b/packages/config/test/config/__snapshots__/index.test.js.snap
@@ -184,6 +184,7 @@ Object {
     "exclude": Array [],
     "fallback": "200.html",
     "interval": 0,
+    "nonRootPageExtension": undefined,
     "routes": Array [],
     "staticAssets": Object {
       "base": undefined,
@@ -560,6 +561,7 @@ Object {
     "exclude": Array [],
     "fallback": "200.html",
     "interval": 0,
+    "nonRootPageExtension": undefined,
     "routes": Array [],
     "staticAssets": Object {
       "base": undefined,

--- a/packages/generator/src/generator.js
+++ b/packages/generator/src/generator.js
@@ -359,7 +359,8 @@ export default class Generator {
       fileName = fileName === '/404/index.html' ? '/404.html' : fileName // /404 -> /404.html
     } else {
       const normalizedRoute = route.replace(/\/$/, '')
-      fileName = route.length > 1 ? path.join(path.sep, normalizedRoute + '.html') : path.join(path.sep, 'index.html')
+      const extension = (typeof this.options.generate.nonRootPageExtension === 'undefined') ? '.html' : this.options.generate.nonRootPageExtension
+      fileName = route.length > 1 ? path.join(path.sep, normalizedRoute + extension) : path.join(path.sep, 'index.html')
     }
 
     // Call hook to let user update the path & html


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
This PR adds a new parameter to the `generate` config section, called `nonRootPageExtension`. When specified and `subfolders` is set to false, it allows setting the extension of all the files, except index.html and 404.html. For example, setting it to an empty string would result in generating the files without any extension, as requested in issue #8212


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. (PR: 872 in the nuxtjs.org repo)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

