### PR TITLE
fix(vue-app): triggerScroll when transitions is disabled

### DIFF
--- a/packages/vue-app/template/client.js
+++ b/packages/vue-app/template/client.js
@@ -650,6 +650,8 @@ function fixPrepatch (to, ___) {
   const instances = getMatchedComponentsInstances(to)
   const Components = getMatchedComponents(to)
 
+  let triggerScroll = <%= features.transitions ? 'true' : 'false' %>
+
   Vue.nextTick(() => {
     instances.forEach((instance, i) => {
       if (!instance || instance._isDestroyed) {
@@ -667,12 +669,17 @@ function fixPrepatch (to, ___) {
           Vue.set(instance.$data, key, newData[key])
         }
 
-        // Ensure to trigger scroll event after calling scrollBehavior
-        window.<%= globals.nuxt %>.$nextTick(() => {
-          window.<%= globals.nuxt %>.$emit('triggerScroll')
-        })
+        triggerScroll = true
       }
     })
+
+    if (triggerScroll) {
+      // Ensure to trigger scroll event after calling scrollBehavior
+      window.<%= globals.nuxt %>.$nextTick(() => {
+        window.<%= globals.nuxt %>.$emit('triggerScroll')
+      })
+    }
+
     checkForErrors(this)
     <% if (isDev) { %>
     // Hot reloading

--- a/packages/vue-app/template/client.js
+++ b/packages/vue-app/template/client.js
@@ -650,7 +650,7 @@ function fixPrepatch (to, ___) {
   const instances = getMatchedComponentsInstances(to)
   const Components = getMatchedComponents(to)
 
-  let triggerScroll = <%= features.transitions ? 'true' : 'false' %>
+  let triggerScroll = <%= features.transitions ? 'false' : 'true' %>
 
   Vue.nextTick(() => {
     instances.forEach((instance, i) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

On a normal page change nuxt relies on the routeEnter hook of the transition to emit a triggerScroll event to resolve the scrollBehaviour: https://github.com/nuxt/nuxt.js/blob/dev/packages/vue-app/template/App.js#L65

When you set `features.transitions: false` then this event is never emitted, so scrollBehaviour is broken. This pr fixes that by always emitting triggerScroll in fixPrepatch when you've set `features.transitions = false`

The proposed change should work fine as the minifier should be able to remove the constant condition that exists when `transitions = false`

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

