### PR TITLE
fix(generator): nested route missing trailingSlash

### DIFF
--- a/packages/generator/src/generator.js
+++ b/packages/generator/src/generator.js
@@ -280,6 +280,10 @@ export default class Generator {
     let html
     const pageErrors = []
 
+    if (this.options.router && this.options.router.trailingSlash && route[route.length - 1] !== '/') {
+      route = route + '/'
+    }
+
     const setPayload = (_payload) => {
       payload = defu(_payload, payload)
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
Fixes issue #8165

I need some help finding the root of this issue. This fix just fixes the route path when generating the route, but would be good to find out where the child route is being created and adding the trailing slash there.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

