### PR TITLE
fix(server): remove virtualConsole option when disabled

### DIFF
--- a/packages/server/src/jsdom.js
+++ b/packages/server/src/jsdom.js
@@ -40,9 +40,13 @@ export default async function renderAndGetWindow (
   if (options.virtualConsole) {
     if (options.virtualConsole === true) {
       options.virtualConsole = new jsdom.VirtualConsole().sendTo(consola)
+      // Throw error when window creation failed
+      options.virtualConsole.on('jsdomError', jsdomErrHandler)
     }
-    // Throw error when window creation failed
-    options.virtualConsole.on('jsdomError', jsdomErrHandler)
+  }
+  else {
+    // If we get the virtualConsole option as `false` we should delete for don't pass it to `jsdom.JSDOM.fromURL`
+    delete options.virtualConsole
   }
 
   const { window } = await jsdom.JSDOM.fromURL(url, options)

--- a/packages/server/src/jsdom.js
+++ b/packages/server/src/jsdom.js
@@ -40,9 +40,9 @@ export default async function renderAndGetWindow (
   if (options.virtualConsole) {
     if (options.virtualConsole === true) {
       options.virtualConsole = new jsdom.VirtualConsole().sendTo(consola)
-      // Throw error when window creation failed
-      options.virtualConsole.on('jsdomError', jsdomErrHandler)
     }
+    // Throw error when window creation failed
+    options.virtualConsole.on('jsdomError', jsdomErrHandler)
   } else {
     // If we get the virtualConsole option as `false` we should delete for don't pass it to `jsdom.JSDOM.fromURL`
     delete options.virtualConsole

--- a/packages/server/src/jsdom.js
+++ b/packages/server/src/jsdom.js
@@ -43,8 +43,7 @@ export default async function renderAndGetWindow (
       // Throw error when window creation failed
       options.virtualConsole.on('jsdomError', jsdomErrHandler)
     }
-  }
-  else {
+  } else {
     // If we get the virtualConsole option as `false` we should delete for don't pass it to `jsdom.JSDOM.fromURL`
     delete options.virtualConsole
   }


### PR DESCRIPTION
It's patch for [this feature](https://github.com/nuxt/nuxt.js/issues/8262)
May be it the fix not a feature

1) The `renderAndGetWindow` method can pass `virtualConsole` option as `false`
2) If we pass to `renderAndGetWindow` method our `virtualConsole` instance it will not be touched by nuxt

All unit tests are passed by `yarn test:unit`
