### PR TITLE
fix(vue-app): prevent redirection loop with uri encoded path

### DIFF
--- a/packages/vue-app/template/server.js
+++ b/packages/vue-app/template/server.js
@@ -50,7 +50,7 @@ const createNext = ssrContext => (opts) => {
     opts.path = urlJoin(routerBase, opts.path)
   }
   // Avoid loop redirect
-  if (opts.path === ssrContext.url) {
+  if (decodeURIComponent(opts.path) === ssrContext.url) {
     ssrContext.redirected = false
     return
   }

--- a/test/e2e/basic.browser.test.js
+++ b/test/e2e/basic.browser.test.js
@@ -319,6 +319,11 @@ describe('basic browser', () => {
     page.close()
   })
 
+  test('/redirection/no loop', async () => {
+    const page = await browser.page(url('/redirection/no loop'))
+    expect(await page.$text('h1')).toContain('Redirected page')
+  })
+
   // Close server and ask nuxt to stop listening to file changes
   afterAll(async () => {
     await nuxt.close()

--- a/test/fixtures/basic/pages/redirection/_slug.vue
+++ b/test/fixtures/basic/pages/redirection/_slug.vue
@@ -1,0 +1,18 @@
+<template>
+  <h1>
+    Redirected page
+  </h1>
+</template>
+
+<script>
+export default {
+  asyncData ({ redirect, route }) {
+    if (process.server) {
+      // Redirect to the same route
+      redirect(route)
+    }
+
+    return {}
+  }
+}
+</script>


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
This change decodes the requested path before comparing it with the ssrContext URL to prevent a redirect loop if the path requested has a uri-encoded string (e.g. `%20`) but the ssrContext URL (owing to redirection) has the decoded value.

Resolves: #8116

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

