### PR TITLE
fix(vue-app): use nuxt globalName correctly in nuxt-link and fetch mixin

### DIFF
--- a/packages/vue-app/template/components/nuxt-link.client.js
+++ b/packages/vue-app/template/components/nuxt-link.client.js
@@ -111,8 +111,8 @@ export default {
       // Preload the data only if not in preview mode
       if (!this.$root.isPreview) {
         const { href } = this.$router.resolve(this.to, this.$route, this.append)
-        if (this.$nuxt)
-          this.$nuxt.fetchPayload(href).catch(() => {})
+        if (this.<%= globals.nuxt %>)
+          this.<%= globals.nuxt %>.fetchPayload(href).catch(() => {})
       }
       <% } %>
       <% if (router.linkPrefetchedClass) { %>

--- a/packages/vue-app/template/mixins/fetch.client.js
+++ b/packages/vue-app/template/mixins/fetch.client.js
@@ -60,12 +60,12 @@ function createdFullStatic() {
   if (typeof this.$options.fetchOnServer === 'function') {
     fetchedOnServer = this.$options.fetchOnServer.call(this) !== false
   }
-  if (!fetchedOnServer || this.$nuxt.isPreview || !this.$nuxt._pagePayload) {
+  if (!fetchedOnServer || this.<%= globals.nuxt %>.isPreview || !this.<%= globals.nuxt %>._pagePayload) {
     return
   }
   this._hydrated = true
-  this._fetchKey = this.$nuxt._payloadFetchIndex++
-  const data = this.$nuxt._pagePayload.fetch[this._fetchKey]
+  this._fetchKey = this.<%= globals.nuxt %>._payloadFetchIndex++
+  const data = this.<%= globals.nuxt %>._pagePayload.fetch[this._fetchKey]
 
   // If fetch error
   if (data && data._error) {


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
**History**: `this.$nuxt` accidentally crept in in the static target PR (https://github.com/nuxt/nuxt.js/pull/6159). This caused an error which was solved by testing for `this.$nuxt` rather than using `globalName` (https://github.com/nuxt/nuxt.js/pull/7766) as is done elsewhere in the component (see https://github.com/nuxt/nuxt.js/pull/4743)

This PR reverts to using `globalName`.

Resolves #8118

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

