### PR TITLE
fix(types): `NuxtOptionsHead`  can be a function

### DIFF
--- a/packages/types/config/head.d.ts
+++ b/packages/types/config/head.d.ts
@@ -6,4 +6,4 @@
 
 import { MetaInfo } from 'vue-meta'
 
-export type NuxtOptionsHead = MetaInfo
+export type NuxtOptionsHead = MetaInfo | (() => MetaInfo)


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)

## Description
`NuxtOptionsHead` can be a function too.

I don't know if it's ever meant to be a function in config file or not. It happily works in my `nuxt.config.ts`.

If this is going to be merged, I can fix the semantic issue.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

