### PR TITLE
fix(cli): handle `generate.cache.ignore` as a function in `ensureBuild`

### DIFF
--- a/packages/cli/src/utils/generate.js
+++ b/packages/cli/src/utils/generate.js
@@ -43,7 +43,7 @@ export async function ensureBuild (cmd) {
 
   // Extend ignore
   const { generate } = options
-  if (generate.cache.ignore === 'function') {
+  if (typeof generate.cache.ignore === 'function') {
     generate.cache.ignore = generate.cache.ignore(ignore)
   } else if (Array.isArray(generate.cache.ignore)) {
     generate.cache.ignore = generate.cache.ignore.concat(ignore)
@@ -52,9 +52,9 @@ export async function ensureBuild (cmd) {
 
   // Take a snapshot of current project
   const snapshotOptions = {
-    rootDir: nuxt.options.rootDir,
-    ignore: nuxt.options.generate.cache.ignore.map(upath.normalize),
-    globbyOptions: nuxt.options.generate.cache.globbyOptions
+    rootDir: options.rootDir,
+    ignore: generate.cache.ignore.map(upath.normalize),
+    globbyOptions: generate.cache.globbyOptions
   }
 
   const currentBuildSnapshot = await snapshot(snapshotOptions)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
Fixes an issue where `generate.cache.ignore` didn't work if it was a function.
With the folowing Nuxt config:
```
generate: {
    cache: {
        ignore(excludedFiles) {
            return excludedFiles.concat('docker');
        }
    }
}
```
we get this error:
```
 FATAL  nuxt.options.generate.cache.ignore.map is not a function                                                                       12:14:18

  at ensureBuild (node_modules/@nuxt/cli/dist/cli-generate.js:162:48)
  at async Object.run (node_modules/@nuxt/cli/dist/cli-generate.js:356:7)
  at async NuxtCommand.run (node_modules/@nuxt/cli/dist/cli-index.js:2811:7)


   ╭─────────────────────────────────────────────────────────────────────────╮
   │                                                                         │
   │   ✖ Nuxt Fatal Error                                                    │
   │                                                                         │
   │   TypeError: nuxt.options.generate.cache.ignore.map is not a function   │
   │                                                                         │
   ╰─────────────────────────────────────────────────────────────────────────╯
```

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

