### PR TITLE
fix(vue-app): force chidren to be required if default child is present

### DIFF
--- a/packages/utils/src/route.js
+++ b/packages/utils/src/route.js
@@ -87,6 +87,13 @@ function cleanChildrenRoutes (routes, isChild = false, routeNameSplitter = '-', 
         if (trailingSlash === false) {
           defaultChildRoute.name = route.name
         }
+        route.children.forEach((child) => {
+          if (child.path !== indexRoutePath) {
+            const parts = child.path.split('/')
+            parts[1] = parts[1].endsWith('?') ? parts[1].substr(0, parts[1].length - 1) : parts[1]
+            child.path = parts.join('/')
+          }
+        })
         delete route.name
       }
       route.children = cleanChildrenRoutes(route.children, true, routeNameSplitter, trailingSlash, routeName)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
This is a fix for #7823  

Assume these pages:  
```
- parent
  - index.vue
  - _slug.vue
- parent.vue
```

In the parent-child routes, if the parent has an `index` child, all other child routes with optional params should be treated as required to ensure the `index` child does load on `/parent`


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

