### PR TITLE
fix(cli): respect `router.trailingSlash` when serving static files

### DIFF
--- a/packages/cli/src/utils/serve.js
+++ b/packages/cli/src/utils/serve.js
@@ -30,7 +30,8 @@ export async function serve (cmd) {
   app.use(
     options.router.base,
     serveStatic(options.generate.dir, {
-      extensions: ['html']
+      extensions: ['html'],
+      redirect: !!options.router.trailingSlash
     })
   )
   if (options.generate.fallback) {

--- a/packages/server/src/server.js
+++ b/packages/server/src/server.js
@@ -92,7 +92,10 @@ export default class Server {
     // For serving static/ files to /
     const staticMiddleware = serveStatic(
       path.resolve(this.options.srcDir, this.options.dir.static),
-      this.options.render.static
+      {
+        redirect: !!this.options.router.trailingSlash,
+        ...this.options.render.static
+      }
     )
     staticMiddleware.prefix = this.options.render.static.prefix
     this.useMiddleware(staticMiddleware)

--- a/packages/server/src/server.js
+++ b/packages/server/src/server.js
@@ -92,10 +92,7 @@ export default class Server {
     // For serving static/ files to /
     const staticMiddleware = serveStatic(
       path.resolve(this.options.srcDir, this.options.dir.static),
-      {
-        redirect: !!this.options.router.trailingSlash,
-        ...this.options.render.static
-      }
+      this.options.render.static
     )
     staticMiddleware.prefix = this.options.render.static.prefix
     this.useMiddleware(staticMiddleware)


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)


## Description
`serve-static` defaults to *redirect* directories to `trailingSlash` ([see docs](https://github.com/expressjs/serve-static#redirect)). This PR respects the user's choice (defaulting not to redirect).

This does change behaviour because it will no longer redirect by default (i.e. if `trailingSlash` is undefined), but this will almost certainly only be true on the local machine as it's unlikely users will serve their static sites in production with `nuxt start`

closes #8350

## Checklist:
<!--- [ ] My change requires a change to the documentation. -->
<!---- [ ] I have updated the documentation accordingly. (PR: #) -->
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

