### PR TITLE
fix(vue-app): add catchFetchError to throw on fetch error

### DIFF
--- a/packages/config/src/config/_app.js
+++ b/packages/config/src/config/_app.js
@@ -67,6 +67,7 @@ export default () => ({
     validate: true,
     asyncData: true,
     fetch: true,
+    catchFetchError: true,
     clientOnline: true,
     clientPrefetch: true,
     clientUseUrl: false,

--- a/packages/vue-app/template/mixins/fetch.client.js
+++ b/packages/vue-app/template/mixins/fetch.client.js
@@ -96,6 +96,7 @@ async function $_fetch() {
   let error = null
   const startTime = Date.now()
 
+  <% if (features.catchFetchError) { %>
   try {
     await this.$options.fetch.call(this)
   } catch (err) {
@@ -104,6 +105,9 @@ async function $_fetch() {
     }
     error = normalizeError(err)
   }
+  <% } else { %>
+  await this.$options.fetch.call(this)
+  <% } %>
 
   const delayLeft = this._fetchDelay - (Date.now() - startTime)
   if (delayLeft > 0) {

--- a/packages/vue-app/template/mixins/fetch.server.js
+++ b/packages/vue-app/template/mixins/fetch.server.js
@@ -7,6 +7,7 @@ async function serverPrefetch() {
   }
 
   // Call and await on $fetch
+  <% if (features.catchFetchError) { %>
   try {
     await this.$options.fetch.call(this)
   } catch (err) {
@@ -15,6 +16,9 @@ async function serverPrefetch() {
     }
     this.$fetchState.error = normalizeError(err)
   }
+  <% } else { %>
+  await this.$options.fetch.call(this)
+  <% } %>
   this.$fetchState.pending = false
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
Fixes #7742

This introduce a new key in order to control the behaviour of catching or not an error in `fetch`.

`nuxt.config.js`
```js
export default {
  features: {
    catchFetchError: false
  }
}
```

This will throw an error in development (instead of adding the error into `$fetchState.error`), can be useful when you want the same behaviour as `asyncData` by default.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

