### PR TITLE
fix(vue-app): do not preserve state when registering client-side dynamic module

### DIFF
--- a/packages/vue-app/template/index.js
+++ b/packages/vue-app/template/index.js
@@ -78,9 +78,12 @@ const defaultTransition = <%=
 const originalRegisterModule = Vuex.Store.prototype.registerModule
 
 function registerModule (path, rawModule, options = {}) {
-  return originalRegisterModule.call(
-    this, path, rawModule, { preserveState: process.client && path in this.state, ...options }
+  const preserveState = process.client && (
+    Array.isArray(path)
+      ? path.reduce((namespacedState, path) => namespacedState && namespacedState[path], this.state)
+      : path in this.state
   )
+  return originalRegisterModule.call(this, path, rawModule, { preserveState, ...options })
 }
 <% } %>
 

--- a/packages/vue-app/template/index.js
+++ b/packages/vue-app/template/index.js
@@ -76,10 +76,11 @@ const defaultTransition = <%=
 
 <% if (store) { %>
 const originalRegisterModule = Vuex.Store.prototype.registerModule
-const baseStoreOptions = { preserveState: process.client }
 
 function registerModule (path, rawModule, options = {}) {
-  return originalRegisterModule.call(this, path, rawModule, { ...baseStoreOptions, ...options })
+  return originalRegisterModule.call(
+    this, path, rawModule, { preserveState: process.client && path in this.state, ...options }
+  )
 }
 <% } %>
 

--- a/packages/vue-app/template/index.js
+++ b/packages/vue-app/template/index.js
@@ -80,7 +80,7 @@ const originalRegisterModule = Vuex.Store.prototype.registerModule
 function registerModule (path, rawModule, options = {}) {
   const preserveState = process.client && (
     Array.isArray(path)
-      ? path.reduce((namespacedState, path) => namespacedState && namespacedState[path], this.state)
+      ? !!path.reduce((namespacedState, path) => namespacedState && namespacedState[path], this.state)
       : path in this.state
   )
   return originalRegisterModule.call(this, path, rawModule, { preserveState, ...options })

--- a/test/e2e/basic.browser.test.js
+++ b/test/e2e/basic.browser.test.js
@@ -55,6 +55,7 @@ describe('basic browser', () => {
   test('/store-module', async () => {
     await page.nuxt.navigate('/store-module')
     expect(await page.$text('h1')).toBe('mutated')
+    expect(await page.evaluate(() => window.__NUXT__.state.clientsideModule.initialised)).toBeTruthy()
   })
 
   test('/css', async () => {

--- a/test/fixtures/basic/plugins/vuex-module.js
+++ b/test/fixtures/basic/plugins/vuex-module.js
@@ -15,4 +15,13 @@ export default function ({ store }) {
       }
     }
   })
+
+  if (process.server) { return }
+
+  store.registerModule('clientsideModule', {
+    namespaced: true,
+    state: () => ({
+      initialised: true
+    })
+  })
 }


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)

## Description
This PR changes the default `preserveState: true` (on client-side `store.registerModule`) to instead be true only if there is in fact state to preserve, which allows for registering dynamic store modules on the client-side without having to pass `preserveState: false` explicitly.

**HT** to @Timkor for the suggestion.

closes #8445
closes #7046

## Checklist:
- [x] My change requires a change to the documentation.
<!-- - [ ] I have updated the documentation accordingly. (PR: #) -->
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

