### PR TITLE
fix(types): add missing `redirect` overload to `Context` interface

### DIFF
--- a/packages/types/app/index.d.ts
+++ b/packages/types/app/index.d.ts
@@ -47,6 +47,7 @@ export interface Context {
   redirect(status: number, path: string, query?: Route['query']): void
   redirect(path: string, query?: Route['query']): void
   redirect(location: Location): void
+  redirect(status: number, location: Location): void
   ssrContext?: {
     req: Context['req']
     res: Context['res']


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
Passing a Location object into the context's `redirect` function is already allowed, but not together with an HTTP status code. However, the redirect function actually allows that:

https://github.com/nuxt/nuxt.js/blob/b64ee2c8eff08ab16591127ac3b71deb1cc01c8d/packages/vue-app/template/utils.js#L196-L211

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

