### PR TITLE
fix(babel): enable polyfilling of proposal supported by core-js

### DIFF
--- a/packages/babel-preset-app/src/index.js
+++ b/packages/babel-preset-app/src/index.js
@@ -87,6 +87,10 @@ module.exports = (api, options = {}) => {
     corejs = { version: Number(corejs) }
   }
 
+  if (corejs.proposals === undefined) {
+    corejs.proposals = true
+  }
+
   const defaultTargets = {
     server: { node: 'current' },
     client: { ie: 9 },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

Fix https://github.com/nuxt/create-nuxt-app/issues/680

We're not polyfilling proposals like Promise.allSettled, this pr is enabling it and the polyfills will be imported they are used in each file.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

