### PR TITLE
feat(postcss): support postcss v8 with explict postcss installation

### DIFF
--- a/packages/cli/test/unit/__snapshots__/webpack.test.js.snap
+++ b/packages/cli/test/unit/__snapshots__/webpack.test.js.snap
@@ -109,13 +109,15 @@ exports[`webpack nuxt webpack module.rules 1`] = `
           Object {
             \\"loader\\": \\"<nuxtDir>/node_modules/postcss-loader/src/index.js\\",
             \\"options\\": Object {
-              \\"order\\": \\"presetEnvAndCssnanoLast\\",
-              \\"plugins\\": Array [
-                [Function anonymous],
-                [Function anonymous],
-                [Function anonymous],
-                [Function anonymous],
-              ],
+              \\"execute\\": undefined,
+              \\"postcssOptions\\": Object {
+                \\"plugins\\": Array [
+                  [Function anonymous],
+                  [Function anonymous],
+                  [Function anonymous],
+                  [Function anonymous],
+                ],
+              },
               \\"sourceMap\\": false,
             },
           },
@@ -140,13 +142,15 @@ exports[`webpack nuxt webpack module.rules 1`] = `
           Object {
             \\"loader\\": \\"<nuxtDir>/node_modules/postcss-loader/src/index.js\\",
             \\"options\\": Object {
-              \\"order\\": \\"presetEnvAndCssnanoLast\\",
-              \\"plugins\\": Array [
-                [Function anonymous],
-                [Function anonymous],
-                [Function anonymous],
-                [Function anonymous],
-              ],
+              \\"execute\\": undefined,
+              \\"postcssOptions\\": Object {
+                \\"plugins\\": Array [
+                  [Function anonymous],
+                  [Function anonymous],
+                  [Function anonymous],
+                  [Function anonymous],
+                ],
+              },
               \\"sourceMap\\": false,
             },
           },
@@ -180,13 +184,15 @@ exports[`webpack nuxt webpack module.rules 1`] = `
           Object {
             \\"loader\\": \\"<nuxtDir>/node_modules/postcss-loader/src/index.js\\",
             \\"options\\": Object {
-              \\"order\\": \\"presetEnvAndCssnanoLast\\",
-              \\"plugins\\": Array [
-                [Function anonymous],
-                [Function anonymous],
-                [Function anonymous],
-                [Function anonymous],
-              ],
+              \\"execute\\": undefined,
+              \\"postcssOptions\\": Object {
+                \\"plugins\\": Array [
+                  [Function anonymous],
+                  [Function anonymous],
+                  [Function anonymous],
+                  [Function anonymous],
+                ],
+              },
               \\"sourceMap\\": false,
             },
           },
@@ -211,13 +217,15 @@ exports[`webpack nuxt webpack module.rules 1`] = `
           Object {
             \\"loader\\": \\"<nuxtDir>/node_modules/postcss-loader/src/index.js\\",
             \\"options\\": Object {
-              \\"order\\": \\"presetEnvAndCssnanoLast\\",
-              \\"plugins\\": Array [
-                [Function anonymous],
-                [Function anonymous],
-                [Function anonymous],
-                [Function anonymous],
-              ],
+              \\"execute\\": undefined,
+              \\"postcssOptions\\": Object {
+                \\"plugins\\": Array [
+                  [Function anonymous],
+                  [Function anonymous],
+                  [Function anonymous],
+                  [Function anonymous],
+                ],
+              },
               \\"sourceMap\\": false,
             },
           },
@@ -251,13 +259,15 @@ exports[`webpack nuxt webpack module.rules 1`] = `
           Object {
             \\"loader\\": \\"<nuxtDir>/node_modules/postcss-loader/src/index.js\\",
             \\"options\\": Object {
-              \\"order\\": \\"presetEnvAndCssnanoLast\\",
-              \\"plugins\\": Array [
-                [Function anonymous],
-                [Function anonymous],
-                [Function anonymous],
-                [Function anonymous],
-              ],
+              \\"execute\\": undefined,
+              \\"postcssOptions\\": Object {
+                \\"plugins\\": Array [
+                  [Function anonymous],
+                  [Function anonymous],
+                  [Function anonymous],
+                  [Function anonymous],
+                ],
+              },
               \\"sourceMap\\": false,
             },
           },
@@ -288,13 +298,15 @@ exports[`webpack nuxt webpack module.rules 1`] = `
           Object {
             \\"loader\\": \\"<nuxtDir>/node_modules/postcss-loader/src/index.js\\",
             \\"options\\": Object {
-              \\"order\\": \\"presetEnvAndCssnanoLast\\",
-              \\"plugins\\": Array [
-                [Function anonymous],
-                [Function anonymous],
-                [Function anonymous],
-                [Function anonymous],
-              ],
+              \\"execute\\": undefined,
+              \\"postcssOptions\\": Object {
+                \\"plugins\\": Array [
+                  [Function anonymous],
+                  [Function anonymous],
+                  [Function anonymous],
+                  [Function anonymous],
+                ],
+              },
               \\"sourceMap\\": false,
             },
           },
@@ -334,13 +346,15 @@ exports[`webpack nuxt webpack module.rules 1`] = `
           Object {
             \\"loader\\": \\"<nuxtDir>/node_modules/postcss-loader/src/index.js\\",
             \\"options\\": Object {
-              \\"order\\": \\"presetEnvAndCssnanoLast\\",
-              \\"plugins\\": Array [
-                [Function anonymous],
-                [Function anonymous],
-                [Function anonymous],
-                [Function anonymous],
-              ],
+              \\"execute\\": undefined,
+              \\"postcssOptions\\": Object {
+                \\"plugins\\": Array [
+                  [Function anonymous],
+                  [Function anonymous],
+                  [Function anonymous],
+                  [Function anonymous],
+                ],
+              },
               \\"sourceMap\\": false,
             },
           },
@@ -374,13 +388,15 @@ exports[`webpack nuxt webpack module.rules 1`] = `
           Object {
             \\"loader\\": \\"<nuxtDir>/node_modules/postcss-loader/src/index.js\\",
             \\"options\\": Object {
-              \\"order\\": \\"presetEnvAndCssnanoLast\\",
-              \\"plugins\\": Array [
-                [Function anonymous],
-                [Function anonymous],
-                [Function anonymous],
-                [Function anonymous],
-              ],
+              \\"execute\\": undefined,
+              \\"postcssOptions\\": Object {
+                \\"plugins\\": Array [
+                  [Function anonymous],
+                  [Function anonymous],
+                  [Function anonymous],
+                  [Function anonymous],
+                ],
+              },
               \\"sourceMap\\": false,
             },
           },
@@ -423,13 +439,15 @@ exports[`webpack nuxt webpack module.rules 1`] = `
           Object {
             \\"loader\\": \\"<nuxtDir>/node_modules/postcss-loader/src/index.js\\",
             \\"options\\": Object {
-              \\"order\\": \\"presetEnvAndCssnanoLast\\",
-              \\"plugins\\": Array [
-                [Function anonymous],
-                [Function anonymous],
-                [Function anonymous],
-                [Function anonymous],
-              ],
+              \\"execute\\": undefined,
+              \\"postcssOptions\\": Object {
+                \\"plugins\\": Array [
+                  [Function anonymous],
+                  [Function anonymous],
+                  [Function anonymous],
+                  [Function anonymous],
+                ],
+              },
               \\"sourceMap\\": false,
             },
           },
@@ -460,13 +478,15 @@ exports[`webpack nuxt webpack module.rules 1`] = `
           Object {
             \\"loader\\": \\"<nuxtDir>/node_modules/postcss-loader/src/index.js\\",
             \\"options\\": Object {
-              \\"order\\": \\"presetEnvAndCssnanoLast\\",
-              \\"plugins\\": Array [
-                [Function anonymous],
-                [Function anonymous],
-                [Function anonymous],
-                [Function anonymous],
-              ],
+              \\"execute\\": undefined,
+              \\"postcssOptions\\": Object {
+                \\"plugins\\": Array [
+                  [Function anonymous],
+                  [Function anonymous],
+                  [Function anonymous],
+                  [Function anonymous],
+                ],
+              },
               \\"sourceMap\\": false,
             },
           },
@@ -506,13 +526,15 @@ exports[`webpack nuxt webpack module.rules 1`] = `
           Object {
             \\"loader\\": \\"<nuxtDir>/node_modules/postcss-loader/src/index.js\\",
             \\"options\\": Object {
-              \\"order\\": \\"presetEnvAndCssnanoLast\\",
-              \\"plugins\\": Array [
-                [Function anonymous],
-                [Function anonymous],
-                [Function anonymous],
-                [Function anonymous],
-              ],
+              \\"execute\\": undefined,
+              \\"postcssOptions\\": Object {
+                \\"plugins\\": Array [
+                  [Function anonymous],
+                  [Function anonymous],
+                  [Function anonymous],
+                  [Function anonymous],
+                ],
+              },
               \\"sourceMap\\": false,
             },
           },
@@ -543,13 +565,15 @@ exports[`webpack nuxt webpack module.rules 1`] = `
           Object {
             \\"loader\\": \\"<nuxtDir>/node_modules/postcss-loader/src/index.js\\",
             \\"options\\": Object {
-              \\"order\\": \\"presetEnvAndCssnanoLast\\",
-              \\"plugins\\": Array [
-                [Function anonymous],
-                [Function anonymous],
-                [Function anonymous],
-                [Function anonymous],
-              ],
+              \\"execute\\": undefined,
+              \\"postcssOptions\\": Object {
+                \\"plugins\\": Array [
+                  [Function anonymous],
+                  [Function anonymous],
+                  [Function anonymous],
+                  [Function anonymous],
+                ],
+              },
               \\"sourceMap\\": false,
             },
           },

--- a/packages/cli/test/unit/__snapshots__/webpack.test.js.snap
+++ b/packages/cli/test/unit/__snapshots__/webpack.test.js.snap
@@ -109,15 +109,13 @@ exports[`webpack nuxt webpack module.rules 1`] = `
           Object {
             \\"loader\\": \\"<nuxtDir>/node_modules/postcss-loader/src/index.js\\",
             \\"options\\": Object {
-              \\"execute\\": undefined,
-              \\"postcssOptions\\": Object {
-                \\"plugins\\": Array [
-                  [Function anonymous],
-                  [Function anonymous],
-                  [Function anonymous],
-                  [Function anonymous],
-                ],
-              },
+              \\"order\\": \\"presetEnvAndCssnanoLast\\",
+              \\"plugins\\": Array [
+                [Function anonymous],
+                [Function anonymous],
+                [Function anonymous],
+                [Function anonymous],
+              ],
               \\"sourceMap\\": false,
             },
           },
@@ -142,15 +140,13 @@ exports[`webpack nuxt webpack module.rules 1`] = `
           Object {
             \\"loader\\": \\"<nuxtDir>/node_modules/postcss-loader/src/index.js\\",
             \\"options\\": Object {
-              \\"execute\\": undefined,
-              \\"postcssOptions\\": Object {
-                \\"plugins\\": Array [
-                  [Function anonymous],
-                  [Function anonymous],
-                  [Function anonymous],
-                  [Function anonymous],
-                ],
-              },
+              \\"order\\": \\"presetEnvAndCssnanoLast\\",
+              \\"plugins\\": Array [
+                [Function anonymous],
+                [Function anonymous],
+                [Function anonymous],
+                [Function anonymous],
+              ],
               \\"sourceMap\\": false,
             },
           },
@@ -184,15 +180,13 @@ exports[`webpack nuxt webpack module.rules 1`] = `
           Object {
             \\"loader\\": \\"<nuxtDir>/node_modules/postcss-loader/src/index.js\\",
             \\"options\\": Object {
-              \\"execute\\": undefined,
-              \\"postcssOptions\\": Object {
-                \\"plugins\\": Array [
-                  [Function anonymous],
-                  [Function anonymous],
-                  [Function anonymous],
-                  [Function anonymous],
-                ],
-              },
+              \\"order\\": \\"presetEnvAndCssnanoLast\\",
+              \\"plugins\\": Array [
+                [Function anonymous],
+                [Function anonymous],
+                [Function anonymous],
+                [Function anonymous],
+              ],
               \\"sourceMap\\": false,
             },
           },
@@ -217,15 +211,13 @@ exports[`webpack nuxt webpack module.rules 1`] = `
           Object {
             \\"loader\\": \\"<nuxtDir>/node_modules/postcss-loader/src/index.js\\",
             \\"options\\": Object {
-              \\"execute\\": undefined,
-              \\"postcssOptions\\": Object {
-                \\"plugins\\": Array [
-                  [Function anonymous],
-                  [Function anonymous],
-                  [Function anonymous],
-                  [Function anonymous],
-                ],
-              },
+              \\"order\\": \\"presetEnvAndCssnanoLast\\",
+              \\"plugins\\": Array [
+                [Function anonymous],
+                [Function anonymous],
+                [Function anonymous],
+                [Function anonymous],
+              ],
               \\"sourceMap\\": false,
             },
           },
@@ -259,15 +251,13 @@ exports[`webpack nuxt webpack module.rules 1`] = `
           Object {
             \\"loader\\": \\"<nuxtDir>/node_modules/postcss-loader/src/index.js\\",
             \\"options\\": Object {
-              \\"execute\\": undefined,
-              \\"postcssOptions\\": Object {
-                \\"plugins\\": Array [
-                  [Function anonymous],
-                  [Function anonymous],
-                  [Function anonymous],
-                  [Function anonymous],
-                ],
-              },
+              \\"order\\": \\"presetEnvAndCssnanoLast\\",
+              \\"plugins\\": Array [
+                [Function anonymous],
+                [Function anonymous],
+                [Function anonymous],
+                [Function anonymous],
+              ],
               \\"sourceMap\\": false,
             },
           },
@@ -298,15 +288,13 @@ exports[`webpack nuxt webpack module.rules 1`] = `
           Object {
             \\"loader\\": \\"<nuxtDir>/node_modules/postcss-loader/src/index.js\\",
             \\"options\\": Object {
-              \\"execute\\": undefined,
-              \\"postcssOptions\\": Object {
-                \\"plugins\\": Array [
-                  [Function anonymous],
-                  [Function anonymous],
-                  [Function anonymous],
-                  [Function anonymous],
-                ],
-              },
+              \\"order\\": \\"presetEnvAndCssnanoLast\\",
+              \\"plugins\\": Array [
+                [Function anonymous],
+                [Function anonymous],
+                [Function anonymous],
+                [Function anonymous],
+              ],
               \\"sourceMap\\": false,
             },
           },
@@ -346,15 +334,13 @@ exports[`webpack nuxt webpack module.rules 1`] = `
           Object {
             \\"loader\\": \\"<nuxtDir>/node_modules/postcss-loader/src/index.js\\",
             \\"options\\": Object {
-              \\"execute\\": undefined,
-              \\"postcssOptions\\": Object {
-                \\"plugins\\": Array [
-                  [Function anonymous],
-                  [Function anonymous],
-                  [Function anonymous],
-                  [Function anonymous],
-                ],
-              },
+              \\"order\\": \\"presetEnvAndCssnanoLast\\",
+              \\"plugins\\": Array [
+                [Function anonymous],
+                [Function anonymous],
+                [Function anonymous],
+                [Function anonymous],
+              ],
               \\"sourceMap\\": false,
             },
           },
@@ -388,15 +374,13 @@ exports[`webpack nuxt webpack module.rules 1`] = `
           Object {
             \\"loader\\": \\"<nuxtDir>/node_modules/postcss-loader/src/index.js\\",
             \\"options\\": Object {
-              \\"execute\\": undefined,
-              \\"postcssOptions\\": Object {
-                \\"plugins\\": Array [
-                  [Function anonymous],
-                  [Function anonymous],
-                  [Function anonymous],
-                  [Function anonymous],
-                ],
-              },
+              \\"order\\": \\"presetEnvAndCssnanoLast\\",
+              \\"plugins\\": Array [
+                [Function anonymous],
+                [Function anonymous],
+                [Function anonymous],
+                [Function anonymous],
+              ],
               \\"sourceMap\\": false,
             },
           },
@@ -439,15 +423,13 @@ exports[`webpack nuxt webpack module.rules 1`] = `
           Object {
             \\"loader\\": \\"<nuxtDir>/node_modules/postcss-loader/src/index.js\\",
             \\"options\\": Object {
-              \\"execute\\": undefined,
-              \\"postcssOptions\\": Object {
-                \\"plugins\\": Array [
-                  [Function anonymous],
-                  [Function anonymous],
-                  [Function anonymous],
-                  [Function anonymous],
-                ],
-              },
+              \\"order\\": \\"presetEnvAndCssnanoLast\\",
+              \\"plugins\\": Array [
+                [Function anonymous],
+                [Function anonymous],
+                [Function anonymous],
+                [Function anonymous],
+              ],
               \\"sourceMap\\": false,
             },
           },
@@ -478,15 +460,13 @@ exports[`webpack nuxt webpack module.rules 1`] = `
           Object {
             \\"loader\\": \\"<nuxtDir>/node_modules/postcss-loader/src/index.js\\",
             \\"options\\": Object {
-              \\"execute\\": undefined,
-              \\"postcssOptions\\": Object {
-                \\"plugins\\": Array [
-                  [Function anonymous],
-                  [Function anonymous],
-                  [Function anonymous],
-                  [Function anonymous],
-                ],
-              },
+              \\"order\\": \\"presetEnvAndCssnanoLast\\",
+              \\"plugins\\": Array [
+                [Function anonymous],
+                [Function anonymous],
+                [Function anonymous],
+                [Function anonymous],
+              ],
               \\"sourceMap\\": false,
             },
           },
@@ -526,15 +506,13 @@ exports[`webpack nuxt webpack module.rules 1`] = `
           Object {
             \\"loader\\": \\"<nuxtDir>/node_modules/postcss-loader/src/index.js\\",
             \\"options\\": Object {
-              \\"execute\\": undefined,
-              \\"postcssOptions\\": Object {
-                \\"plugins\\": Array [
-                  [Function anonymous],
-                  [Function anonymous],
-                  [Function anonymous],
-                  [Function anonymous],
-                ],
-              },
+              \\"order\\": \\"presetEnvAndCssnanoLast\\",
+              \\"plugins\\": Array [
+                [Function anonymous],
+                [Function anonymous],
+                [Function anonymous],
+                [Function anonymous],
+              ],
               \\"sourceMap\\": false,
             },
           },
@@ -565,15 +543,13 @@ exports[`webpack nuxt webpack module.rules 1`] = `
           Object {
             \\"loader\\": \\"<nuxtDir>/node_modules/postcss-loader/src/index.js\\",
             \\"options\\": Object {
-              \\"execute\\": undefined,
-              \\"postcssOptions\\": Object {
-                \\"plugins\\": Array [
-                  [Function anonymous],
-                  [Function anonymous],
-                  [Function anonymous],
-                  [Function anonymous],
-                ],
-              },
+              \\"order\\": \\"presetEnvAndCssnanoLast\\",
+              \\"plugins\\": Array [
+                [Function anonymous],
+                [Function anonymous],
+                [Function anonymous],
+                [Function anonymous],
+              ],
               \\"sourceMap\\": false,
             },
           },

--- a/packages/webpack/src/utils/postcss-v8.js
+++ b/packages/webpack/src/utils/postcss-v8.js
@@ -1,0 +1,208 @@
+import fs from 'fs'
+import path from 'path'
+import consola from 'consola'
+import { defaults, merge, cloneDeep } from 'lodash'
+import createResolver from 'postcss-import-resolver'
+
+import { isPureObject } from '@nuxt/utils'
+
+export const orderPresets = {
+  cssnanoLast (names) {
+    const nanoIndex = names.indexOf('cssnano')
+    if (nanoIndex !== names.length - 1) {
+      names.push(names.splice(nanoIndex, 1)[0])
+    }
+    return names
+  },
+  presetEnvLast (names) {
+    const nanoIndex = names.indexOf('postcss-preset-env')
+    if (nanoIndex !== names.length - 1) {
+      names.push(names.splice(nanoIndex, 1)[0])
+    }
+    return names
+  },
+  presetEnvAndCssnanoLast (names) {
+    return orderPresets.cssnanoLast(orderPresets.presetEnvLast(names))
+  }
+}
+
+function postcssConfigFileWarning () {
+  if (postcssConfigFileWarning.executed) {
+    return
+  }
+  consola.warn('Please use `build.postcss` in your nuxt.config.js instead of an external config file. Support for such files will be removed in Nuxt 3 as they remove all defaults set by Nuxt and can cause severe problems with features like alias resolving inside your CSS.')
+  postcssConfigFileWarning.executed = true
+}
+
+export default class PostcssConfig {
+  constructor (buildContext) {
+    this.buildContext = buildContext
+  }
+
+  get cssSourceMap () {
+    return this.buildContext.buildOptions.cssSourceMap
+  }
+
+  get postcssOptions () {
+    return this.buildContext.buildOptions.postcss
+  }
+
+  get postcssImportAlias () {
+    const alias = { ...this.buildContext.options.alias }
+
+    for (const key in alias) {
+      if (key.startsWith('~')) {
+        continue
+      }
+      const newKey = '~' + key
+      if (!alias[newKey]) {
+        alias[newKey] = alias[key]
+      }
+    }
+
+    return alias
+  }
+
+  get defaultPostcssOptions () {
+    const { dev, srcDir, rootDir, modulesDir } = this.buildContext.options
+    return {
+      plugins: {
+        // https://github.com/postcss/postcss-import
+        'postcss-import': {
+          resolve: createResolver({
+            alias: this.postcssImportAlias,
+            modules: [srcDir, rootDir, ...modulesDir]
+          })
+        },
+
+        // https://github.com/postcss/postcss-url
+        'postcss-url': {},
+
+        // https://github.com/csstools/postcss-preset-env
+        // TODO: enable when https://github.com/csstools/postcss-preset-env/issues/191 gets closed
+        // 'postcss-preset-env': this.preset || {},
+        cssnano: dev
+          ? false
+          : {
+            preset: ['default', {
+              // Keep quotes in font values to prevent from HEX conversion
+              // https://github.com/nuxt/nuxt.js/issues/6306
+              minifyFontValues: { removeQuotes: false }
+            }]
+          }
+      },
+      // Array, String or Function
+      order: 'presetEnvAndCssnanoLast'
+    }
+  }
+
+  searchConfigFile () {
+    // Search for postCSS config file and use it if exists
+    // https://github.com/michael-ciniawsky/postcss-load-config
+    // TODO: Remove in Nuxt 3
+    const { srcDir, rootDir } = this.buildContext.options
+    for (const dir of [srcDir, rootDir]) {
+      for (const file of [
+        'postcss.config.js',
+        '.postcssrc.js',
+        '.postcssrc',
+        '.postcssrc.json',
+        '.postcssrc.yaml'
+      ]) {
+        const configFile = path.resolve(dir, file)
+        if (fs.existsSync(configFile)) {
+          postcssConfigFileWarning()
+          return configFile
+        }
+      }
+    }
+  }
+
+  configFromFile () {
+    const loaderConfig = (this.postcssOptions && this.postcssOptions.config) || {}
+    loaderConfig.path = loaderConfig.path || this.searchConfigFile()
+
+    if (loaderConfig.path) {
+      return {
+        config: loaderConfig
+      }
+    }
+  }
+
+  normalize (postcssOptions) {
+    // TODO: Remove in Nuxt 3
+    if (Array.isArray(postcssOptions)) {
+      consola.warn('Using an Array as `build.postcss` will be deprecated in Nuxt 3. Please switch to the object' +
+        ' declaration')
+      postcssOptions = { plugins: postcssOptions }
+    }
+    return postcssOptions
+  }
+
+  sortPlugins ({ plugins, order }) {
+    const names = Object.keys(plugins)
+    if (typeof order === 'string') {
+      order = orderPresets[order]
+    }
+    return typeof order === 'function' ? order(names, orderPresets) : (order || names)
+  }
+
+  loadPlugins (postcssOptions) {
+    const { plugins } = postcssOptions
+    if (isPureObject(plugins)) {
+      // Map postcss plugins into instances on object mode once
+      postcssOptions.plugins = this.sortPlugins(postcssOptions)
+        .map((p) => {
+          const plugin = this.buildContext.nuxt.resolver.requireModule(p, { paths: [__dirname] })
+          const opts = plugins[p]
+          if (opts === false) {
+            return false // Disabled
+          }
+          return plugin(opts)
+        })
+        .filter(Boolean)
+    }
+  }
+
+  config () {
+    /* istanbul ignore if */
+    if (!this.postcssOptions) {
+      return false
+    }
+
+    let postcssOptions = this.configFromFile()
+    if (postcssOptions) {
+      return {
+        postcssOptions,
+        sourceMap: this.cssSourceMap
+      }
+    }
+
+    postcssOptions = this.normalize(cloneDeep(this.postcssOptions))
+
+    // Apply default plugins
+    if (isPureObject(postcssOptions)) {
+      if (postcssOptions.preset) {
+        this.preset = postcssOptions.preset
+        delete postcssOptions.preset
+      }
+      if (Array.isArray(postcssOptions.plugins)) {
+        defaults(postcssOptions, this.defaultPostcssOptions)
+      } else {
+        // Keep the order of default plugins
+        postcssOptions = merge({}, this.defaultPostcssOptions, postcssOptions)
+        this.loadPlugins(postcssOptions)
+      }
+
+      const { execute } = postcssOptions
+      delete postcssOptions.execute
+      delete postcssOptions.order
+
+      return {
+        execute,
+        postcssOptions,
+        sourceMap: this.cssSourceMap
+      }
+    }
+  }
+}

--- a/packages/webpack/src/utils/style-loader.js
+++ b/packages/webpack/src/utils/style-loader.js
@@ -13,11 +13,11 @@ export default class StyleLoader {
     this.perfLoader = perfLoader
     this.resolveModule = resolveModule
 
-    const { postcss } = buildContext.options.build
-    if (postcss) {
-      const { version } = postcss
-      delete postcss.version
-      if (version === 8) {
+    const { postcss: postcssOptions } = buildContext.options.build
+    if (postcssOptions) {
+      const postcss = require(resolveModule('postcss'))
+      // postcss >= v8
+      if (!postcss.vendor) {
         this.postcssConfig = new PostcssV8Config(buildContext)
       } else {
         this.postcssConfig = new PostcssConfig(buildContext)

--- a/packages/webpack/src/utils/style-loader.js
+++ b/packages/webpack/src/utils/style-loader.js
@@ -4,6 +4,7 @@ import ExtractCssChunksPlugin from 'extract-css-chunks-webpack-plugin'
 import { wrapArray } from '@nuxt/utils'
 
 import PostcssConfig from './postcss'
+import PostcssV8Config from './postcss-v8'
 
 export default class StyleLoader {
   constructor (buildContext, { isServer, perfLoader, resolveModule }) {
@@ -12,8 +13,15 @@ export default class StyleLoader {
     this.perfLoader = perfLoader
     this.resolveModule = resolveModule
 
-    if (buildContext.options.build.postcss) {
-      this.postcssConfig = new PostcssConfig(buildContext)
+    const { postcss } = buildContext.options.build.postcss
+    if (postcss) {
+      const { version } = postcss
+      delete postcss.version
+      if (version === 8) {
+        this.postcssConfig = new PostcssV8Config(buildContext)
+      } else {
+        this.postcssConfig = new PostcssConfig(buildContext)
+      }
     }
   }
 

--- a/packages/webpack/src/utils/style-loader.js
+++ b/packages/webpack/src/utils/style-loader.js
@@ -13,7 +13,7 @@ export default class StyleLoader {
     this.perfLoader = perfLoader
     this.resolveModule = resolveModule
 
-    const { postcss } = buildContext.options.build.postcss
+    const { postcss } = buildContext.options.build
     if (postcss) {
       const { version } = postcss
       delete postcss.version


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

As we can't [fully migrated to postcss 8](https://github.com/nuxt/nuxt.js/pull/8408) until [postcss-preset-env supports v8](https://github.com/csstools/postcss-preset-env/issues/191)

This pr is for supporting postcss config in nuxt if user installs postcss packages explicitly, required packages:

**NOTE: postcss-preset-env is disabled in v8 config as it doesn't support postcss v8 for now.**

```sh
yarn add --dev css-loader@^5.0.0 postcss@^8.1.10 postcss-import@^13.0.0 postcss-loader@^4.1.0 postcss-url@^10.1.1
# or
npm i --save-dev css-loader@^5.0.0 postcss@^8.1.10 postcss-import@^13.0.0 postcss-loader@^4.1.0 postcss-url@^10.1.1
```

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

