### PR TITLE
POC of orchestrated components (multi-app)

### DIFF
--- a/examples/orchestrated-apps/app.html
+++ b/examples/orchestrated-apps/app.html
@@ -1,0 +1,12 @@
+{% if (!orchestrated) { %}<!DOCTYPE html>
+<html {{ HTML_ATTRS }}>
+    <head {{ HEAD_ATTRS }}>
+        {{ HEAD }}
+    </head>
+    <body {{ BODY_ATTRS }}>
+        {{ APP }}
+    </body>
+</html>
+{% } else { %}
+{{ APP }}
+{% } %}

--- a/examples/orchestrated-apps/components/FooterComponent.vue
+++ b/examples/orchestrated-apps/components/FooterComponent.vue
@@ -1,0 +1,15 @@
+<template>
+  <footer>
+    <h2>This is the footer</h2>
+    <p>count: {{ $store.state.counter }}</p>
+    <button @click="$store.commit('increment')">
+      Increment
+    </button>
+  </footer>
+</template>
+
+<style scoped>
+footer {
+  background-color: #eee;
+}
+</style>

--- a/examples/orchestrated-apps/components/HeaderComponent.vue
+++ b/examples/orchestrated-apps/components/HeaderComponent.vue
@@ -1,0 +1,15 @@
+<template>
+  <header>
+    <h2>This is the header</h2>
+    <p>count: {{ $store.state.counter }}</p>
+    <button @click="$store.commit('increment')">
+      Increment
+    </button>
+  </header>
+</template>
+
+<style scoped>
+header {
+  background-color: #eee;
+}
+</style>

--- a/examples/orchestrated-apps/layouts/default.vue
+++ b/examples/orchestrated-apps/layouts/default.vue
@@ -1,0 +1,7 @@
+<template>
+  <div>
+    <HeaderComponent />
+    <Nuxt />
+    <FooterComponent />
+  </div>
+</template>

--- a/examples/orchestrated-apps/layouts/orchestrated.vue
+++ b/examples/orchestrated-apps/layouts/orchestrated.vue
@@ -1,0 +1,3 @@
+<template>
+  <Nuxt />
+</template>

--- a/examples/orchestrated-apps/nuxt.config.js
+++ b/examples/orchestrated-apps/nuxt.config.js
@@ -1,0 +1,19 @@
+export default {
+  components: true,
+  features: {
+    store: true,
+    layouts: true,
+    meta: false,
+    middleware: false,
+    transitions: false,
+    deprecations: false,
+    validate: false,
+    asyncData: false,
+    fetch: false,
+    clientOnline: false,
+    clientPrefetch: false,
+    clientUseUrl: false,
+    componentAliases: false,
+    componentClientOnly: false
+  }
+}

--- a/examples/orchestrated-apps/nuxt.config.js
+++ b/examples/orchestrated-apps/nuxt.config.js
@@ -1,5 +1,29 @@
 export default {
   components: true,
+  plugins: [
+    '~/plugins/orchestrated.server'
+  ],
+  hooks: {
+    'vue-renderer': {
+      ssr: {
+        context (renderContext) {
+          // Disable style/script injection based on query params parsed
+          // in plugins/orchestrated.server.js
+          if (renderContext.excludeStyles) {
+            renderContext.renderStyles = () => '<!-- styles disabled -->'
+          }
+          if (renderContext.excludeScripts) {
+            renderContext.renderResourceHints = () => '<!-- resource hints disabled -->'
+            renderContext.renderScripts = () => '<!-- scripts disabled -->'
+          }
+        },
+        templateParams (templateParams, renderContext) {
+          // Provide template flag for orchestrated scenarios
+          templateParams.orchestrated = renderContext.orchestrated
+        }
+      }
+    }
+  },
   features: {
     store: true,
     layouts: true,

--- a/examples/orchestrated-apps/package.json
+++ b/examples/orchestrated-apps/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "nuxt-micro-apps",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "nuxt",
+    "build": "nuxt build",
+    "start": "nuxt start",
+    "generate": "nuxt generate"
+  },
+  "dependencies": {
+    "core-js": "^3.6.5",
+    "nuxt": "2.14.12"
+  },
+  "devDependencies": {}
+}

--- a/examples/orchestrated-apps/package.json
+++ b/examples/orchestrated-apps/package.json
@@ -9,7 +9,9 @@
     "generate": "nuxt generate"
   },
   "dependencies": {
+    "axios": "0.21.1",
     "core-js": "^3.6.5",
+    "express": "4.17.1",
     "nuxt": "2.14.12"
   },
   "devDependencies": {}

--- a/examples/orchestrated-apps/pages/index.vue
+++ b/examples/orchestrated-apps/pages/index.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="container">
+    This is the homepage
+  </div>
+</template>

--- a/examples/orchestrated-apps/pages/orchestrated/_component.vue
+++ b/examples/orchestrated-apps/pages/orchestrated/_component.vue
@@ -1,0 +1,22 @@
+<script>
+import FooterComponent from '~/components/FooterComponent.vue'
+import HeaderComponent from '~/components/HeaderComponent.vue'
+
+const componentMap = {
+  footer: FooterComponent,
+  header: HeaderComponent
+}
+export default {
+  layout: 'orchestrated',
+  render (h) {
+    const component = process.server
+      ? this.$route.params.component
+      : this.$root.$options.orchestrated
+    return h(componentMap[component], {
+      attrs: {
+        'data-orchestrated-app': component
+      }
+    })
+  }
+}
+</script>

--- a/examples/orchestrated-apps/plugins/orchestrated.server.js
+++ b/examples/orchestrated-apps/plugins/orchestrated.server.js
@@ -1,0 +1,8 @@
+export default function orchestratedAppPlugin (ctx) {
+  if (ctx.route.name !== 'orchestrated-component') {
+    return
+  }
+  ctx.ssrContext.orchestrated = ctx.route.params.component
+  ctx.ssrContext.excludeStyles = ctx.route.query.excludeStyles === '1'
+  ctx.ssrContext.excludeScripts = ctx.route.query.excludeScripts === '1'
+}

--- a/examples/orchestrated-apps/server.js
+++ b/examples/orchestrated-apps/server.js
@@ -1,0 +1,80 @@
+/* eslint-disable no-console */
+
+const http = require('http')
+const express = require('express')
+const axios = require('axios')
+
+const nuxtBaseUrl = 'http://localhost:3000'
+
+const app = express()
+
+function proxyRequestToNuxt (req, logger) {
+  return new Promise((resolve, reject) => {
+    const proxyUrl = `${nuxtBaseUrl}${req.url}`
+    console.debug(`Proxying ${req.url} to ${proxyUrl}`)
+    const proxyRequest = http.get(proxyUrl, { headers: req.headers }, (res) => {
+      const { statusCode, headers } = res
+      let buffer = Buffer.alloc(0)
+      res.on('error', e => reject(e))
+      // eslint-disable-next-line no-return-assign
+      res.on('data', chunk => buffer = Buffer.concat([buffer, chunk]))
+      res.on('end', () => resolve({ statusCode, headers, buffer }))
+    })
+    proxyRequest.on('error', e => reject(e))
+    proxyRequest.end()
+  })
+}
+
+async function proxyHandler (req, res) {
+  try {
+    const response = await proxyRequestToNuxt(req, res.locals.logger)
+    res.set(response.headers)
+    res.status(response.statusCode).send(response.buffer)
+  } catch (e) {
+    if (e && e.response) {
+      res.set(e.response.headers)
+      res.status(e.response.statusCode).send(e.response.buffer)
+    } else {
+      console.error(e)
+      throw new Error('Error proxying response')
+    }
+  }
+}
+
+function renderTemplate (headerHtml, footerHtml) {
+  return `
+<!DOCTYPE html>
+<html>
+  <head>
+      <title>Sample App</title>
+  </head>
+  <body>
+    ${headerHtml}
+    <main>
+      <p>This is the body of the page</p>
+    </main>
+    ${footerHtml}
+  </body>
+</html>`
+}
+
+// These don't seem to handle the long polling aspect
+// app.get('/__webpack_hmr/*', proxyHandler);
+app.get('/_nuxt/*', proxyHandler)
+// app.get('/_loading/*', proxyHandler);
+
+app.get('/', async (req, res) => {
+  const headerHtml = await axios.get('http://localhost:3000/orchestrated/header')
+  const footerHtml = await axios.get('http://localhost:3000/orchestrated/footer', {
+    query: {
+      excludeStyles: 1,
+      excludeScripts: 1
+    }
+  })
+  const html = renderTemplate(headerHtml.data, footerHtml.data)
+  res.send(html)
+})
+
+const server = app.listen(3001, () => {
+  console.info(`Server listening at http://localhost:${server.address().port}/`)
+})

--- a/examples/orchestrated-apps/store/index.js
+++ b/examples/orchestrated-apps/store/index.js
@@ -1,0 +1,9 @@
+export const state = () => ({
+  counter: 0
+})
+
+export const mutations = {
+  increment (state) {
+    state.counter++
+  }
+}

--- a/packages/vue-app/template/client.js
+++ b/packages/vue-app/template/client.js
@@ -117,7 +117,23 @@ Vue.config.$nuxt.<%= globals.nuxt %> = true
 const errorHandler = Vue.config.errorHandler || console.error
 
 // Create and mount App
-createApp(null, NUXT.config).then(mountApp).catch(errorHandler)
+NUXT.config.orchestratedEls = Array.from(document.querySelectorAll('[data-orchestrated-app'));
+if (NUXT.config.orchestratedEls.length > 1) {
+  NUXT.config.orchestrated = true;
+  NUXT.config.orchestratedEls.reduce(
+    (acc, el) => acc
+      .then(() => createApp(null, NUXT.config))
+      .then((app) => {
+        app.app.orchestrated = el.dataset.orchestratedApp;
+        NUXT.config.existingStore = NUXT.config.existingStore || app.store;
+        return mountApp(app, el);
+      })
+      .catch(errorHandler),
+    Promise.resolve(),
+  );
+} else {
+  createApp(null, NUXT.config).then(mountApp).catch(errorHandler);
+}
 
 <% if (features.transitions) { %>
 function componentOption (component, key, ...args) {
@@ -833,7 +849,7 @@ function addHotReload ($component, depth) {
 }
 <% } %>
 
-async function mountApp (__app) {
+async function mountApp (__app, el) {
   // Set global variables
   app = __app.app
   router = __app.router
@@ -861,7 +877,7 @@ async function mountApp (__app) {
 
   // Mounts Vue app to DOM element
   const mount = () => {
-    _app.$mount('#<%= globals.id %>')
+    _app.$mount(el || '#<%= globals.id %>')
 
     // Add afterEach router hooks
     router.afterEach(normalizeComponents)

--- a/packages/vue-app/template/index.js
+++ b/packages/vue-app/template/index.js
@@ -91,7 +91,7 @@ async function createApp(ssrContext, config = {}) {
   const router = await createRouter(ssrContext, config)
 
   <% if (store) { %>
-  const store = createStore(ssrContext)
+  const store = config.existingStore || createStore(ssrContext)
   // Add this.$router into store actions/mutations
   store.$router = router
     <% if (mode === 'universal') { %>

--- a/packages/vue-app/template/router.js
+++ b/packages/vue-app/template/router.js
@@ -110,6 +110,12 @@ function decodeObj(obj) {
 }
 
 export function createRouter (ssrContext, config) {
+  if (config.orchestrated) {
+    routerOptions.routes = [{
+      ...routerOptions.routes.find(r => r.name === "orchestrated-component"),
+      path: '*',
+    }];
+  }
   const base = (config.app && config.app.basePath) || routerOptions.base
   const router = new Router({ ...routerOptions, base  })
 


### PR DESCRIPTION
This is a quick POC based on [this comment](https://github.com/nuxt/rfcs/issues/30#issuecomment-744647345) in https://github.com/nuxt/rfcs/issues/30.  I initially looked into doing this with a module but didn't think I would have the right ability to hook in and make changes to the templates without providing custom templates (which would quickly become out of sync with general nuxt upgrades).  However, if I missed something and this could be done via a sustainable module approach, I'd be happy to try to convert it over.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
The implementation here provides 2 new related features:

* The ability to orchestrate Nuxt server-rendered components into a different application in which Nuxt/Vue may not be in control of the full page or routing - and thus would not want a full `html`/`head`/`body` structure in the SSR'd HTML
* The ability to instantiate _multiple_ Vue/Nuxt apps on a single page

The specific example implementation here is the use-case that my team is currently doing with our own `vue-server-renderer` build.  We're looking to migrate to Nuxt but this seems to be the only thing standing in our way.  We are able to get most of the way there with plugins, a custom `app.html`, etc - but the main thing we cannot get past is the `_app.$mount('#__nuxt')` aspect which sets a global limitation of a single app per-page.  Beyond that, there introduce some minor changes to the router and the ability to share a Vuex instance across the apps.

In addition to this type use-case of "plugging" Nuxt/Vue components into existing SSR apps, I think these new features could also potentially have use-cases in the micro-frontend landscape, but I haven't spent too much time thinking through those.

This addresses I think a slightly different issue that what is posed in https://github.com/nuxt/rfcs/issues/30, but looking for confirmation on that and happy to open a new RFC for discussion.

### Testing Steps
* Checkout this branch
* Tab #1: `yarn nuxt examples/orchestrated-apps/`
* Tab #2: `cd examples/orchestrated-apps && npm install && node server.js`
* http://localhost:3000/ - Loads the normal Nuxt app, rendering header/homepage/footer content
* http://localhost:3001/ - Loads the Express non-Nuxt app with the orchestrated Nuxt header/footer

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

(I haven't looked at tests or documentation yet, but I will if this gains any traction)