### PR TITLE
fix(webpack): can't resolve absolute url in css

### DIFF
--- a/packages/cli/test/unit/__snapshots__/webpack.test.js.snap
+++ b/packages/cli/test/unit/__snapshots__/webpack.test.js.snap
@@ -104,6 +104,7 @@ exports[`webpack nuxt webpack module.rules 1`] = `
                 \\"localIdentName\\": \\"[local]_[hash:base64:5]\\",
               },
               \\"sourceMap\\": false,
+              \\"url\\": [Function isUrlResolvingEnabled],
             },
           },
           Object {
@@ -135,6 +136,7 @@ exports[`webpack nuxt webpack module.rules 1`] = `
               \\"esModule\\": false,
               \\"importLoaders\\": 2,
               \\"sourceMap\\": false,
+              \\"url\\": [Function isUrlResolvingEnabled],
             },
           },
           Object {
@@ -175,6 +177,7 @@ exports[`webpack nuxt webpack module.rules 1`] = `
                 \\"localIdentName\\": \\"[local]_[hash:base64:5]\\",
               },
               \\"sourceMap\\": false,
+              \\"url\\": [Function isUrlResolvingEnabled],
             },
           },
           Object {
@@ -206,6 +209,7 @@ exports[`webpack nuxt webpack module.rules 1`] = `
               \\"esModule\\": false,
               \\"importLoaders\\": 2,
               \\"sourceMap\\": false,
+              \\"url\\": [Function isUrlResolvingEnabled],
             },
           },
           Object {
@@ -246,6 +250,7 @@ exports[`webpack nuxt webpack module.rules 1`] = `
                 \\"localIdentName\\": \\"[local]_[hash:base64:5]\\",
               },
               \\"sourceMap\\": false,
+              \\"url\\": [Function isUrlResolvingEnabled],
             },
           },
           Object {
@@ -283,6 +288,7 @@ exports[`webpack nuxt webpack module.rules 1`] = `
               \\"esModule\\": false,
               \\"importLoaders\\": 2,
               \\"sourceMap\\": false,
+              \\"url\\": [Function isUrlResolvingEnabled],
             },
           },
           Object {
@@ -329,6 +335,7 @@ exports[`webpack nuxt webpack module.rules 1`] = `
                 \\"localIdentName\\": \\"[local]_[hash:base64:5]\\",
               },
               \\"sourceMap\\": false,
+              \\"url\\": [Function isUrlResolvingEnabled],
             },
           },
           Object {
@@ -369,6 +376,7 @@ exports[`webpack nuxt webpack module.rules 1`] = `
               \\"esModule\\": false,
               \\"importLoaders\\": 2,
               \\"sourceMap\\": false,
+              \\"url\\": [Function isUrlResolvingEnabled],
             },
           },
           Object {
@@ -418,6 +426,7 @@ exports[`webpack nuxt webpack module.rules 1`] = `
                 \\"localIdentName\\": \\"[local]_[hash:base64:5]\\",
               },
               \\"sourceMap\\": false,
+              \\"url\\": [Function isUrlResolvingEnabled],
             },
           },
           Object {
@@ -455,6 +464,7 @@ exports[`webpack nuxt webpack module.rules 1`] = `
               \\"esModule\\": false,
               \\"importLoaders\\": 2,
               \\"sourceMap\\": false,
+              \\"url\\": [Function isUrlResolvingEnabled],
             },
           },
           Object {
@@ -501,6 +511,7 @@ exports[`webpack nuxt webpack module.rules 1`] = `
                 \\"localIdentName\\": \\"[local]_[hash:base64:5]\\",
               },
               \\"sourceMap\\": false,
+              \\"url\\": [Function isUrlResolvingEnabled],
             },
           },
           Object {
@@ -538,6 +549,7 @@ exports[`webpack nuxt webpack module.rules 1`] = `
               \\"esModule\\": false,
               \\"importLoaders\\": 2,
               \\"sourceMap\\": false,
+              \\"url\\": [Function isUrlResolvingEnabled],
             },
           },
           Object {

--- a/packages/webpack/src/utils/style-loader.js
+++ b/packages/webpack/src/utils/style-loader.js
@@ -1,4 +1,5 @@
 import path from 'path'
+import consola from 'consola'
 import ExtractCssChunksPlugin from 'extract-css-chunks-webpack-plugin'
 
 import { wrapArray } from '@nuxt/utils'
@@ -23,6 +24,16 @@ export default class StyleLoader {
 
   get exportOnlyLocals () {
     return Boolean(this.isServer && this.extractCSS)
+  }
+
+  isUrlResolvingEnabled (url, resourcePath) {
+    // Ignore absolute URLs, it will be handled by serve-static.
+    if (url.startsWith('/')) {
+      consola.warn(`Please use relative path or alias path instead of absolute path ${url}`)
+      return false
+    }
+
+    return true
   }
 
   normalize (loaders) {
@@ -70,6 +81,10 @@ export default class StyleLoader {
 
   css (options) {
     const cssLoader = { loader: this.resolveModule('css-loader'), options }
+
+    if (!options.url) {
+      options.url = this.isUrlResolvingEnabled
+    }
 
     if (this.exportOnlyLocals) {
       options.modules = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

Fix https://github.com/nuxt/nuxt.js/issues/8508

Latest css-loder won't resolve absolute url now, but we'll see can't resolve pth error from webpack, this pr will ignore absolute path (will cover by serve-static or cdn path) and print a warning message.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

