### PR TITLE
fix(vue-app): scroll to top on route changes only

### DIFF
--- a/packages/vue-app/template/router.scrollBehavior.js
+++ b/packages/vue-app/template/router.scrollBehavior.js
@@ -31,9 +31,11 @@ export default function (to, from, savedPosition) {
   // Scroll to the top of the page if...
   if (
       // One of the children set `scrollToTop`
-      Pages.some(Page => Page.options.scrollToTop) ||
+      (Pages.some(Page => Page.options.scrollToTop) ||
       // scrollToTop set in only page without children
-      (Pages.length < 2 && Pages.every(Page => Page.options.scrollToTop !== false))
+      (Pages.length < 2 && Pages.every(Page => Page.options.scrollToTop !== false))) &&
+      // route changes
+      to !== from
   ) {
     position = { x: 0, y: 0 }
   }


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
This change fixes the default scroll behavior by only scrolling to the top of page when the route changes.
Resolves #8553.

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

