### PR TITLE
fix(vue-app): add id attribute to `noopApp`

### DIFF
--- a/packages/vue-app/template/server.js
+++ b/packages/vue-app/template/server.js
@@ -31,7 +31,7 @@ Vue.component(NuxtLink.name, NuxtLink)
 
 <% if (fetch.server) { %>if (!global.fetch) { global.fetch = fetch }<% } %>
 
-const noopApp = () => new Vue({ render: h => h('div') })
+const noopApp = () => new Vue({ render: h => h('div', { domProps: { id: '<%= globals.id %>' } }) })
 
 function urlJoin () {
   return Array.prototype.slice.call(arguments).join('/').replace(/\/+/g, '/')

--- a/test/dev/basic.ssr.test.js
+++ b/test/dev/basic.ssr.test.js
@@ -183,21 +183,21 @@ describe('basic ssr', () => {
       const { html } = await nuxt.server.renderRoute('/redirect-external', renderContext)
       expect(_status).toBe(302)
       expect(_headers.Location).toBe('https://nuxtjs.org/docs/2.x/features/data-fetching/')
-      expect(html).toContain('<div data-server-rendered="true"></div>')
+      expect(html).toContain('<div data-server-rendered="true" id="__nuxt"></div>')
     })
 
     test('/redirect -> external link without trailing slash', async () => {
       const { html } = await nuxt.server.renderRoute('/redirect-external-no-slash', renderContext)
       expect(_status).toBe(302)
       expect(_headers.Location).toBe('https://nuxtjs.org/docs/2.x/features/data-fetching')
-      expect(html).toContain('<div data-server-rendered="true"></div>')
+      expect(html).toContain('<div data-server-rendered="true" id="__nuxt"></div>')
     })
 
     test('/redirect -> external link with root domain url', async () => {
       const { html } = await nuxt.server.renderRoute('/redirect-external-root', renderContext)
       expect(_status).toBe(302)
       expect(_headers.Location).toBe('https://nuxtjs.org/')
-      expect(html).toContain('<div data-server-rendered="true"></div>')
+      expect(html).toContain('<div data-server-rendered="true" id="__nuxt"></div>')
     })
   })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
Add `id` attribute to `noopApp` Vue instance.  
If a route face redirection during its rendering process, `noopApp` will render on the server side [server.js#L182](https://github.com/nuxt/nuxt.js/blob/dev/packages/vue-app/template/server.js#L182). Since the `noopApp` does not contains `id` attribute, This cause an error during client side rendering/hydration.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

