### PR TITLE
fix(vue-app): don't remove req/res/query unless in full static mode

### DIFF
--- a/packages/vue-app/template/server.js
+++ b/packages/vue-app/template/server.js
@@ -80,9 +80,11 @@ export default async (ssrContext) => {
   <% } %>
 
   // Remove query from url is static target
-  if (process.static && ssrContext.url) {
+  <% if (isFullStatic) { %>
+  if (ssrContext.url) {
     ssrContext.url = ssrContext.url.split('?')[0]
   }
+  <% } %>
   // Public runtime config
   ssrContext.nuxt.config = ssrContext.runtimeConfig.public
   // Create the app definition and the instance (created for each request)

--- a/packages/vue-app/template/utils.js
+++ b/packages/vue-app/template/utils.js
@@ -184,12 +184,14 @@ export async function setContext (app, context) {
       env: <%= JSON.stringify(env) %><%= isTest ? '// eslint-disable-line' : '' %>
     }
     // Only set once
-    if (!process.static && context.req) {
+    <% if (!isFullStatic) { %>
+    if (context.req) {
       app.context.req = context.req
     }
-    if (!process.static && context.res) {
+    if (context.res) {
       app.context.res = context.res
     }
+    <% } %>
     if (context.ssrContext) {
       app.context.ssrContext = context.ssrContext
     }


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)

## Description
In full static mode, we remove any query parameters from the URL before parsing with router. But this isn't necessarily desirable if generating files in legacy universal mode. This PR lets users with legacy universal mode access req/res/query objects within the server build.

closes #7965

## Checklist:
<!-- - [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why) -->
- [x] All new and existing tests are passing.

