### PR TITLE
_fix(webpack): remove absolute wanrning messge in css-loader

### DIFF
--- a/packages/webpack/src/utils/style-loader.js
+++ b/packages/webpack/src/utils/style-loader.js
@@ -1,5 +1,4 @@
 import path from 'path'
-import consola from 'consola'
 import ExtractCssChunksPlugin from 'extract-css-chunks-webpack-plugin'
 
 import { wrapArray } from '@nuxt/utils'

--- a/packages/webpack/src/utils/style-loader.js
+++ b/packages/webpack/src/utils/style-loader.js
@@ -36,12 +36,7 @@ export default class StyleLoader {
 
   isUrlResolvingEnabled (url, resourcePath) {
     // Ignore absolute URLs, it will be handled by serve-static.
-    if (url.startsWith('/')) {
-      consola.warn(`Please use relative path or alias path instead of absolute path ${url}`)
-      return false
-    }
-
-    return true
+    return !url.startsWith('/')
   }
 
   normalize (loaders) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

Fix https://github.com/nuxt/nuxt.js/pull/8555#issuecomment-758338689

Using absolute path like `/fonts/...` in css is a valid use case for users who don't want bundle static files into dist, this pr is removing the warning message.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

