### PR TITLE
chore(ci): fetch full history and tags for releasing nuxt-edge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -319,6 +319,9 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@master
+        with:
+          ref: 'refs/heads/dev'
+          fetch-depth: 0 # All history
 
       - name: restore workspace cache
         uses: actions/cache@v2
@@ -329,6 +332,9 @@ jobs:
             distributions/*/node_modules
             packages/*/dist
           key: ${{ matrix.os }}-node-v${{ matrix.node }}-nuxt-${{ github.sha }}
+
+      - name: fetch tags
+        run: git fetch --depth=1 origin "+refs/tags/*:refs/tags/*"
 
       - uses: actions/setup-node@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -323,6 +323,9 @@ jobs:
           ref: 'refs/heads/dev'
           fetch-depth: 0 # All history
 
+      - name: fetch tags
+        run: git fetch --depth=1 origin "+refs/tags/*:refs/tags/*"
+
       - name: restore workspace cache
         uses: actions/cache@v2
         with:
@@ -332,9 +335,6 @@ jobs:
             distributions/*/node_modules
             packages/*/dist
           key: ${{ matrix.os }}-node-v${{ matrix.node }}-nuxt-${{ github.sha }}
-
-      - name: fetch tags
-        run: git fetch --depth=1 origin "+refs/tags/*:refs/tags/*"
 
       - uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
Let's try this and see nuxt-edge version.
