### PR TITLE
types: add `enablePreview` to context

### DIFF
--- a/packages/types/app/index.d.ts
+++ b/packages/types/app/index.d.ts
@@ -87,7 +87,7 @@ export interface Context {
   error(params: NuxtError): void
   nuxtState: NuxtState
   beforeNuxtRender(fn: (params: { Components: VueRouter['getMatchedComponents'], nuxtState: NuxtState }) => void): void
-  enablePreview(): Function | undefined
+  enablePreview?: (previewData?: Record<string, any>) => void
   $preview?: Object
 }
 

--- a/packages/types/app/index.d.ts
+++ b/packages/types/app/index.d.ts
@@ -87,7 +87,8 @@ export interface Context {
   error(params: NuxtError): void
   nuxtState: NuxtState
   beforeNuxtRender(fn: (params: { Components: VueRouter['getMatchedComponents'], nuxtState: NuxtState }) => void): void
-  enablePreview(): void
+  enablePreview(): Function | undefined
+  $preview?: Object
 }
 
 // eslint-disable-next-line @typescript-eslint/ban-types

--- a/packages/types/app/index.d.ts
+++ b/packages/types/app/index.d.ts
@@ -88,7 +88,7 @@ export interface Context {
   nuxtState: NuxtState
   beforeNuxtRender(fn: (params: { Components: VueRouter['getMatchedComponents'], nuxtState: NuxtState }) => void): void
   enablePreview?: (previewData?: Record<string, any>) => void
-  $preview?: Object
+  $preview?: Record<string, any>
 }
 
 // eslint-disable-next-line @typescript-eslint/ban-types

--- a/packages/types/app/index.d.ts
+++ b/packages/types/app/index.d.ts
@@ -87,6 +87,7 @@ export interface Context {
   error(params: NuxtError): void
   nuxtState: NuxtState
   beforeNuxtRender(fn: (params: { Components: VueRouter['getMatchedComponents'], nuxtState: NuxtState }) => void): void
+  enablePreview(): void
 }
 
 // eslint-disable-next-line @typescript-eslint/ban-types


### PR DESCRIPTION
Somehow the [`enablePreview`](https://nuxtjs.org/docs/2.x/features/live-preview/) function was missing in the Context type.
As it is only available in plugins, I'm not sure if there is a better way to add it. Open for feedback here!