### PR TITLE
feat(vue-app): add dark mode for the loadingIndicator

### DIFF
--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -238,13 +238,50 @@ export function getNuxtConfig (_options) {
       options.loadingIndicator = { name: options.loadingIndicator }
     }
 
+    const defaultColor = (options.loading && options.loading.color) || '#D3D3D3'
+    const defaultColor2 = '#F5F5F5'
+    const defaultBackground = (options.manifest && options.manifest.theme_color) || 'white'
+
+    if (isPureObject(options.loadingIndicator.color)) {
+      options.loadingIndicator = Object.assign(
+        options.loadingIndicator,
+        {
+          color: options.loadingIndicator.color.light || defaultColor,
+          colorDark: options.loadingIndicator.color.dark || defaultColor
+        }
+      )
+    }
+
+    if (isPureObject(options.loadingIndicator.color2)) {
+      options.loadingIndicator = Object.assign(
+        options.loadingIndicator,
+        {
+          color2: options.loadingIndicator.color2.light || defaultColor2,
+          color2Dark: options.loadingIndicator.color2.dark || defaultColor2
+        }
+      )
+    }
+
+    if (isPureObject(options.loadingIndicator.background)) {
+      options.loadingIndicator = Object.assign(
+        options.loadingIndicator,
+        {
+          background: options.loadingIndicator.background.light || defaultBackground,
+          backgroundDark: options.loadingIndicator.background.dark || defaultBackground
+        }
+      )
+    }
+
     // Apply defaults
     options.loadingIndicator = Object.assign(
       {
         name: 'default',
-        color: (options.loading && options.loading.color) || '#D3D3D3',
-        color2: '#F5F5F5',
-        background: (options.manifest && options.manifest.theme_color) || 'white',
+        color: defaultColor,
+        colorDark: defaultColor,
+        color2: defaultColor2,
+        color2Dark: defaultColor2,
+        background: defaultBackground,
+        backgroundDark: defaultBackground,
         dev: options.dev,
         loading: options.messages.loading
       },

--- a/packages/types/config/loading.d.ts
+++ b/packages/types/config/loading.d.ts
@@ -21,7 +21,10 @@ export interface NuxtOptionsLoading {
 
 export interface NuxtOptionsLoadingIndicator {
   background?: string
+  backgroundDark?: string
   color?: string
+  colorDark?: string
   color2?: string
+  color2Dark?: string
   name?: string
 }

--- a/packages/vue-app/template/views/loading/chasing-dots.html
+++ b/packages/vue-app/template/views/loading/chasing-dots.html
@@ -40,6 +40,16 @@ body, html, #<%= globals.id %> {
   animation-delay: -1.0s;
 }
 
+@media (prefers-color-scheme: dark) {
+  body, html, #<%= globals.id %> {
+    background: <%= options.backgroundDark %>;
+  }
+
+  .dot1, .dot2 {
+    background-color: <%= options.colorDark %>;
+  }
+}
+
 @-webkit-keyframes sk-rotate { 100% { -webkit-transform: rotate(360deg) }}
 @keyframes sk-rotate { 100% { transform: rotate(360deg); -webkit-transform: rotate(360deg) }}
 

--- a/packages/vue-app/template/views/loading/circle.html
+++ b/packages/vue-app/template/views/loading/circle.html
@@ -111,6 +111,16 @@ body, html, #<%= globals.id %> {
   -webkit-animation-delay: -0.1s;
           animation-delay: -0.1s; }
 
+@media (prefers-color-scheme: dark) {
+  body, html, #<%= globals.id %> {
+    background: <%= options.backgroundDark %>;
+  }
+
+  .sk-circle .sk-child:before {
+    background-color: <%= options.colorDark %>;
+  }
+}
+
 @-webkit-keyframes sk-circleBounceDelay {
   0%, 80%, 100% {
     -webkit-transform: scale(0);

--- a/packages/vue-app/template/views/loading/cube-grid.html
+++ b/packages/vue-app/template/views/loading/cube-grid.html
@@ -51,6 +51,16 @@ body, html, #<%= globals.id %> {
   -webkit-animation-delay: 0.2s;
           animation-delay: 0.2s; }
 
+@media (prefers-color-scheme: dark) {
+  body, html, #<%= globals.id %> {
+    background: <%= options.backgroundDark %>;
+  }
+
+  .sk-cube-grid .sk-cube {
+    background-color: <%= options.colorDark %>;
+  }
+}
+
 @-webkit-keyframes sk-cubeGridScaleDelay {
   0%, 70%, 100% {
     -webkit-transform: scale3D(1, 1, 1);

--- a/packages/vue-app/template/views/loading/default.html
+++ b/packages/vue-app/template/views/loading/default.html
@@ -73,6 +73,17 @@
   animation-duration: 5s;
 }
 
+@media (prefers-color-scheme: dark) {
+  #nuxt-loading {
+    background: <%= options.backgroundDark %>;
+  }
+
+  #nuxt-loading>div {
+    border-color: <%= options.color2Dark %>;
+    border-left-color: <%= options.colorDark %>;
+  }
+}
+
 @-webkit-keyframes nuxtLoading {
   0% {
     -webkit-transform: rotate(0deg);

--- a/packages/vue-app/template/views/loading/fading-circle.html
+++ b/packages/vue-app/template/views/loading/fading-circle.html
@@ -135,6 +135,16 @@ body, html, #<%= globals.id %> {
           animation-delay: -0.1s;
 }
 
+@media (prefers-color-scheme: dark) {
+  body, html, #<%= globals.id %> {
+    background: <%= options.backgroundDark %>;
+  }
+
+  .sk-fading-circle .sk-circle:before {
+    background-color: <%= options.colorDark %>;
+  }
+}
+
 @-webkit-keyframes sk-circleFadeDelay {
   0%, 39%, 100% { opacity: 0; }
   40% { opacity: 1; }

--- a/packages/vue-app/template/views/loading/folding-cube.html
+++ b/packages/vue-app/template/views/loading/folding-cube.html
@@ -65,6 +65,17 @@ body, html, #<%= globals.id %> {
   -webkit-animation-delay: 0.9s;
           animation-delay: 0.9s;
 }
+
+@media (prefers-color-scheme: dark) {
+  body, html, #<%= globals.id %> {
+    background: <%= options.backgroundDark %>;
+  }
+
+  .sk-folding-cube .sk-cube:before {
+    background-color: <%= options.colorDark %>;
+  }
+}
+
 @-webkit-keyframes sk-foldCubeAngle {
   0%, 10% {
     -webkit-transform: perspective(140px) rotateX(-180deg);

--- a/packages/vue-app/template/views/loading/pulse.html
+++ b/packages/vue-app/template/views/loading/pulse.html
@@ -20,6 +20,16 @@ body, html, #<%= globals.id %> {
   animation: sk-scaleout 1.0s infinite ease-in-out;
 }
 
+@media (prefers-color-scheme: dark) {
+  body, html, #<%= globals.id %> {
+    background: <%= options.backgroundDark %>;
+  }
+
+  .spinner {
+    background-color: <%= options.colorDark %>;
+  }
+}
+
 @-webkit-keyframes sk-scaleout {
   0% { -webkit-transform: scale(0) }
   100% {

--- a/packages/vue-app/template/views/loading/rectangle-bounce.html
+++ b/packages/vue-app/template/views/loading/rectangle-bounce.html
@@ -47,6 +47,16 @@ body, html, #<%= globals.id %> {
   animation-delay: -0.8s;
 }
 
+@media (prefers-color-scheme: dark) {
+  body, html, #<%= globals.id %> {
+    background: <%= options.backgroundDark %>;
+  }
+
+  .spinner > div {
+    background-color: <%= options.colorDark %>;
+  }
+}
+
 @-webkit-keyframes sk-stretchdelay {
   0%, 40%, 100% { -webkit-transform: scaleY(0.4) }
   20% { -webkit-transform: scaleY(1.0) }

--- a/packages/vue-app/template/views/loading/rotating-plane.html
+++ b/packages/vue-app/template/views/loading/rotating-plane.html
@@ -19,6 +19,16 @@ body, html, #<%= globals.id %> {
   animation: sk-rotateplane 1.2s infinite ease-in-out;
 }
 
+@media (prefers-color-scheme: dark) {
+  body, html, #<%= globals.id %> {
+    background: <%= options.backgroundDark %>;
+  }
+
+  .spinner {
+    background-color: <%= options.colorDark %>;
+  }
+}
+
 @-webkit-keyframes sk-rotateplane {
   0% { -webkit-transform: perspective(120px) }
   50% { -webkit-transform: perspective(120px) rotateY(180deg) }

--- a/packages/vue-app/template/views/loading/three-bounce.html
+++ b/packages/vue-app/template/views/loading/three-bounce.html
@@ -36,6 +36,16 @@ body, html, #<%= globals.id %> {
   animation-delay: -0.16s;
 }
 
+@media (prefers-color-scheme: dark) {
+  body, html, #<%= globals.id %> {
+    background: <%= options.backgroundDark %>;
+  }
+
+  .spinner > div {
+    background-color: <%= options.colorDark %>;
+  }
+}
+
 @-webkit-keyframes sk-bouncedelay {
   0%, 80%, 100% { -webkit-transform: scale(0) }
   40% { -webkit-transform: scale(1.0) }

--- a/packages/vue-app/template/views/loading/wandering-cubes.html
+++ b/packages/vue-app/template/views/loading/wandering-cubes.html
@@ -33,6 +33,16 @@ body, html, #<%= globals.id %> {
   animation-delay: -0.9s;
 }
 
+@media (prefers-color-scheme: dark) {
+  body, html, #<%= globals.id %> {
+    background: <%= options.backgroundDark %>;
+  }
+
+  .cube1, .cube2 {
+    background-color: <%= options.colorDark %>;
+  }
+}
+
 @-webkit-keyframes sk-cubemove {
   25% { -webkit-transform: translateX(42px) rotate(-90deg) scale(0.5) }
   50% { -webkit-transform: translateX(42px) translateY(42px) rotate(-180deg) }


### PR DESCRIPTION
Add the option to use different colors for the loadingIndicator when the user has 'prefers-color-scheme: dark' enabled. (https://github.com/nuxt/nuxt.js/issues/8580)

## Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
This update enables users to add two different color schemes for the loading indicator.

When the developer just uses strings as the for the `color`, `color2`, and `background`, nothing changes, but the developer can now also use an object with a `light` and `dark` key:

```js{}[nuxt.config.js]
export default {
  loadingIndicator: {
    name: 'circle',
    color: '#3B8070',
    background: {
      light: 'white',
      dark: 'darkgray'
    }
  }
}
```

The dark values are only used when a user has `prefers-color-scheme: dark` enabled.

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. (PR: https://github.com/nuxt/nuxtjs.org/pull/1145)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

