### PR TITLE
types: add missing `loadingScreen` type definition 

### DIFF
--- a/packages/types/config/build.d.ts
+++ b/packages/types/config/build.d.ts
@@ -157,6 +157,7 @@ export interface NuxtOptionsBuild {
   html?: { minify: HtmlMinifierOptions }
   indicator?: boolean
   loaders?: NuxtOptionsLoaders
+  loadingScreen?: false | {}
   optimization?: WebpackOptions.Optimization
   optimizeCSS?: OptimizeCssAssetsWebpackPluginOptions | boolean
   parallel?: boolean

--- a/packages/types/config/build.d.ts
+++ b/packages/types/config/build.d.ts
@@ -157,7 +157,7 @@ export interface NuxtOptionsBuild {
   html?: { minify: HtmlMinifierOptions }
   indicator?: boolean
   loaders?: NuxtOptionsLoaders
-  loadingScreen?: false | {}
+  loadingScreen?: boolean | any
   optimization?: WebpackOptions.Optimization
   optimizeCSS?: OptimizeCssAssetsWebpackPluginOptions | boolean
   parallel?: boolean


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
This PR adds the missing type definition for `loadingScreen` as mentioned in #6272. The feature was implemented but that made type definition incompatible (if you decide to overwrite this setting).


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
  - https://github.com/nuxt/nuxtjs.org/pull/1153
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.
