### PR TITLE
fix(webpack): disable stats output from webpack-dev-middleware

### DIFF
--- a/packages/config/src/config/build.js
+++ b/packages/config/src/config/build.js
@@ -103,7 +103,10 @@ export default () => ({
   templates: [],
 
   watch: [],
-  devMiddleware: {},
+  devMiddleware: {
+    // stats will be printed by webapckbar StateReporter
+    stats: 'none'
+  },
   hotMiddleware: {},
 
   stats: {

--- a/packages/config/test/__snapshots__/options.test.js.snap
+++ b/packages/config/test/__snapshots__/options.test.js.snap
@@ -38,7 +38,9 @@ Object {
     "cache": false,
     "corejs": "auto",
     "cssSourceMap": false,
-    "devMiddleware": Object {},
+    "devMiddleware": Object {
+      "stats": "none",
+    },
     "extractCSS": false,
     "filenames": Object {
       "app": [Function],

--- a/packages/config/test/config/__snapshots__/index.test.js.snap
+++ b/packages/config/test/config/__snapshots__/index.test.js.snap
@@ -18,7 +18,9 @@ Object {
     "cache": false,
     "corejs": "auto",
     "cssSourceMap": undefined,
-    "devMiddleware": Object {},
+    "devMiddleware": Object {
+      "stats": "none",
+    },
     "extractCSS": false,
     "filenames": Object {
       "app": [Function],
@@ -402,7 +404,9 @@ Object {
     "cache": false,
     "corejs": "auto",
     "cssSourceMap": undefined,
-    "devMiddleware": Object {},
+    "devMiddleware": Object {
+      "stats": "none",
+    },
     "extractCSS": false,
     "filenames": Object {
       "app": [Function],

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -48,7 +48,7 @@
     "vue-template-compiler": "^2.6.12",
     "webpack": "^4.46.0",
     "webpack-bundle-analyzer": "^3.9.0",
-    "webpack-dev-middleware": "^4.0.4",
+    "webpack-dev-middleware": "^4.1.0",
     "webpack-hot-middleware": "^2.25.0",
     "webpack-node-externals": "^2.5.2",
     "webpackbar": "^4.0.0"

--- a/packages/webpack/src/config/base.js
+++ b/packages/webpack/src/config/base.js
@@ -525,8 +525,6 @@ export default class WebpackBaseConfig {
         rules: this.rules()
       },
       plugins: this.plugins(),
-      // stats will be printed by webapckbar StateReporter
-      stats: 'none',
       ...this.resolve()
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13537,10 +13537,10 @@ webpack-bundle-analyzer@^3.9.0:
     opener "^1.5.1"
     ws "^6.0.0"
 
-webpack-dev-middleware@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-4.0.4.tgz#ebe1e4ad2cca8d33389f89b25d2b7ef7d621bc3f"
-  integrity sha512-6dKe7cufta6TXUwcQqFJNDoGtS3ZdlfQstPJM22V5aNT8qTVd2bWwfEC62vOQOh19eazLDczU+82FgxLHYCmlQ==
+webpack-dev-middleware@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-4.1.0.tgz#f0c1f12ff4cd855b3b5eec89ee0f69bcc5336364"
+  integrity sha512-mpa/FY+DiBu5+r5JUIyTCYWRfkWgyA3/OOE9lwfzV9S70A4vJYLsVRKj5rMFEsezBroy2FmPyQ8oBRVW8QmK1A==
   dependencies:
     colorette "^1.2.1"
     mem "^8.0.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

Latest webpack-dev-middleware has supported `stats` option, so this pr is moving `stats: 'none'` to webpack-dev-middleware.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

