### PR TITLE
fix(vue-app): static payload fetching bugfixes

### DIFF
--- a/packages/vue-app/template/App.js
+++ b/packages/vue-app/template/App.js
@@ -324,22 +324,22 @@ export default {
       this._pagePayload = payload
       this._fetchCounters = {}
     },
-    async fetchPayload(route) {
+    async fetchPayload(route, prefetch) {
       <% if (nuxtOptions.generate.manifest) { %>
       const manifest = await this.fetchStaticManifest()
       const path = this.getRoutePath(route)
       if (!manifest.routes.includes(path)) {
-        this.setPagePayload(false)
+        if (!prefetch) { this.setPagePayload(false) }
         throw new Error(`Route ${path} is not pre-rendered`)
       }
       <% } %>
       const src = urlJoin(this.getStaticAssetsPath(route), 'payload.js')
       try {
         const payload = await window.__NUXT_IMPORT__(decodeURI(route), encodeURI(src))
-        this.setPagePayload(payload)
+        if (!prefetch) { this.setPagePayload(payload) }
         return payload
       } catch (err) {
-        this.setPagePayload(false)
+        if (!prefetch) { this.setPagePayload(false) }
         throw err
       }
     }

--- a/packages/vue-app/template/client.js
+++ b/packages/vue-app/template/client.js
@@ -21,7 +21,9 @@ import {
 import { createApp<% if (features.layouts) { %>, NuxtError<% } %> } from './index.js'
 <% if (features.fetch) { %>import fetchMixin from './mixins/fetch.client'<% } %>
 import NuxtLink from './components/nuxt-link.<%= features.clientPrefetch ? "client" : "server" %>.js' // should be included after ./index.js
-<% if (isFullStatic) { %>import './jsonp'<% } %>
+<% if (isFullStatic) { %>import { installJsonp } from './jsonp'<% } %>
+
+<% if (isFullStatic) { %>installJsonp()<% } %>
 
 <% if (features.fetch) { %>
 // Fetch mixin

--- a/packages/vue-app/template/components/nuxt-link.client.js
+++ b/packages/vue-app/template/components/nuxt-link.client.js
@@ -112,7 +112,7 @@ export default {
       if (!this.$root.isPreview) {
         const { href } = this.$router.resolve(this.to, this.$route, this.append)
         if (this.<%= globals.nuxt %>)
-          this.<%= globals.nuxt %>.fetchPayload(href).catch(() => {})
+          this.<%= globals.nuxt %>.fetchPayload(href, true).catch(() => {})
       }
       <% } %>
       <% if (router.linkPrefetchedClass) { %>

--- a/packages/vue-app/template/jsonp.js
+++ b/packages/vue-app/template/jsonp.js
@@ -75,6 +75,9 @@ function importChunk(chunkId, src) {
   return promise
 }
 
-window.__NUXT_JSONP__ = function (chunkId, exports) { chunks[chunkId] = exports }
-window.__NUXT_JSONP_CACHE__ = chunks
-window.__NUXT_IMPORT__ = importChunk
+export function installJsonp() {
+  window.__NUXT_JSONP__ = function (chunkId, exports) { chunks[chunkId] = exports }
+  window.__NUXT_JSONP_CACHE__ = chunks
+  window.__NUXT_IMPORT__ = importChunk
+}
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description

- Fix regression with webpack in `nuxt-edge` as `window.__NUXT_IMPORT__` gets undefined
  - There are two theories either webpack is wrongly tree-shaking top level window setters or using an internal other than `globalThis` for that condition either way exlicit `install` call seems fixing issue (also makes jsonp.js sideeffect-less)
-  Fix issue that _pagePayload is overwritten by payload prefetches (reported by @StephanGerbeth via https://github.com/nuxt/image/pull/136)

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

