### PR TITLE
fix(vue-renderer): fix csp policy when using hash + custom `script-src` policy.

### DIFF
--- a/packages/vue-renderer/src/renderers/ssr.js
+++ b/packages/vue-renderer/src/renderers/ssr.js
@@ -243,7 +243,7 @@ export default class SSRRenderer extends BaseRenderer {
     }
 
     // Calculate CSP hashes
-    const cspScriptSrcHashes = []
+    const cspScriptSrcHashes = csp.policies && csp.policies['script-src'] ? csp.policies['script-src'] : []
     if (csp) {
       if (shouldHashCspScriptSrc) {
         for (const script of inlineScripts) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
Nuxt's CSP support currently generates a hash for inline scripts. Unfortunately, if you specify a custom `script-src` policy, it will override the hash - so they don't work together.

This change makes sure both approaches are compatible by adding the generated tags to any custom script-src policy.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests are passing.