### PR TITLE
fix(cli): re-enable `serve-static` redirect

### DIFF
--- a/packages/cli/src/utils/serve.js
+++ b/packages/cli/src/utils/serve.js
@@ -31,8 +31,7 @@ export async function serve (cmd) {
   app.use(
     options.router.base,
     serveStatic(options.generate.dir, {
-      extensions: ['html'],
-      redirect: !!options.router.trailingSlash
+      extensions: ['html']
     })
   )
   if (options.generate.fallback) {


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)

## Description
now that we ignore trailing slash in full static payloads, we can re-enable redirecting to trailing slash in `serve-static` middleware after `nuxt generate && nuxt start`

closes #8684

## Checklist:
- [x] All new and existing tests are passing.

