### PR TITLE
fix(types): `build.html.minify` can be false

### DIFF
--- a/packages/types/config/build.d.ts
+++ b/packages/types/config/build.d.ts
@@ -154,7 +154,7 @@ export interface NuxtOptionsBuild {
   friendlyErrors?: boolean
   hardSource?: boolean
   hotMiddleware?: WebpackHotMiddlewareOptions & { client?: WebpackHotMiddlewareClientOptions }
-  html?: { minify: HtmlMinifierOptions }
+  html?: { minify: HtmlMinifierOptions | boolean }
   indicator?: boolean
   loaders?: NuxtOptionsLoaders
   loadingScreen?: boolean | any

--- a/packages/types/config/build.d.ts
+++ b/packages/types/config/build.d.ts
@@ -154,7 +154,7 @@ export interface NuxtOptionsBuild {
   friendlyErrors?: boolean
   hardSource?: boolean
   hotMiddleware?: WebpackHotMiddlewareOptions & { client?: WebpackHotMiddlewareClientOptions }
-  html?: { minify: HtmlMinifierOptions | boolean }
+  html?: { minify: false | HtmlMinifierOptions }
   indicator?: boolean
   loaders?: NuxtOptionsLoaders
   loadingScreen?: boolean | any


### PR DESCRIPTION
 <!--- Provide a general summary of your changes in the title above -->

## Types of changes

Types

## Description

The `build.html.minify` option isn't typed correctly.

 It's passed to:
-  the `html-webpack-plugin` which allows for a boolean option OR an object, see: https://github.com/jantimon/html-webpack-plugin#minification
- generator::minifyHtml which checks if it's not false before minifying

Because it's also used in the generate code, if it was typed to be able to use `'auto'` or `true` it may cause some issues, so we only type the false. Guessing this discrepancy will be solved in Nuxt3.


## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why) - no logic changes
- [] All new and existing tests are passing. - tests are throwing a lot of weird unrelated errors, maybe environment-dependent

