### PR TITLE
fix(cli): don't early return when a dependency isn't installed

### DIFF
--- a/packages/cli/src/utils/dependencies.js
+++ b/packages/cli/src/utils/dependencies.js
@@ -20,7 +20,7 @@ export function checkDependencies () {
   for (const name in dependencies) {
     const installedVersion = getInstalledVersion(name)
     if (!installedVersion) {
-      return // Ignore to avoid false-positive warnings
+      continue // Ignore to avoid false-positive warnings
     }
     const expectedRange = dependencies[name]
     if (!satisfies(installedVersion, expectedRange)) {


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)

## Description
refactoring in PR (https://github.com/nuxt/nuxt.js/pull/8792) left a `return` that should be a `continue` 

## Checklist:
- [x] All new and existing tests are passing.

