### PR TITLE
fix(webpack): transpile ufo

### DIFF
--- a/packages/webpack/src/config/base.js
+++ b/packages/webpack/src/config/base.js
@@ -73,7 +73,7 @@ export default class WebpackBaseConfig {
     return [
       /\.vue\.js/i, // include SFCs in node_modules
       /consola\/src/,
-      /@nuxt[/\\]ufo/, // exports modern syntax for browser field
+      /ufo/, // exports modern syntax for browser field
       ...this.normalizeTranspile({ pathNormalize: true })
     ]
   }


### PR DESCRIPTION
Add `ufo` module, instead of `@nuxt/ufo`, to the default target of transpile.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
There is a commit https://github.com/nuxt/nuxt.js/commit/7529d65d75a1f943817cd5683e21335d48891b6b that migrates from `@nuxt/ufo` to `ufo`. However, it seems migration of the configuration of transpiling was not included.
Since `ufo` will not be transpiled by default, user's nuxt.js app will be broken on old browsers such as IE.

Resolves: #8838, #8839

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.