### PR TITLE
fix: @babel/preset-env v7.13.0 moved utils.js

### DIFF
--- a/packages/babel-preset-app/src/polyfills-plugin.js
+++ b/packages/babel-preset-app/src/polyfills-plugin.js
@@ -12,11 +12,11 @@ module.exports = ({ types }) => {
         }
 
         const { polyfills } = state.opts
-        const { createImport } = require('@babel/preset-env/lib/polyfills/utils')
+        const { addSideEffect, getModulePath } = require('@babel/helper-module-imports')
 
         // Imports are injected in reverse order
         polyfills.slice().reverse().forEach((p) => {
-          createImport(path, p)
+          addSideEffect(path, getModulePath(p))
         })
       }
     }

--- a/packages/babel-preset-app/src/polyfills-plugin.js
+++ b/packages/babel-preset-app/src/polyfills-plugin.js
@@ -12,7 +12,7 @@ module.exports = ({ types }) => {
         }
 
         const { polyfills } = state.opts
-        const { createImport } = require('@babel/preset-env/lib/utils')
+        const { createImport } = require('@babel/preset-env/lib/polyfills/utils')
 
         // Imports are injected in reverse order
         polyfills.slice().reverse().forEach((p) => {


### PR DESCRIPTION
@babel/preset-env moved `lib/utils.js` to `lib/polyfills/utils`

I think this patch should fix it,

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Adjusted the corresponding import in @nuxt/babel-preset-app

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

