### PR TITLE
Lock @babel/preset-env version to avoid breakage

### DIFF
--- a/packages/babel-preset-app/package.json
+++ b/packages/babel-preset-app/package.json
@@ -18,7 +18,7 @@
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.12.13",
     "@babel/plugin-proposal-optional-chaining": "^7.12.17",
     "@babel/plugin-transform-runtime": "^7.12.17",
-    "@babel/preset-env": "^7.12.17",
+    "@babel/preset-env": "~7.12.17",
     "@babel/runtime": "^7.12.18",
     "@vue/babel-preset-jsx": "^1.2.4",
     "core-js": "^2.6.5",


### PR DESCRIPTION
@babel/preset-env has removed utils.js in version 7.13.0, which is required by polyfills-plugin.js (https://github.com/nuxt/nuxt.js/blob/dev/packages/babel-preset-app/src/polyfills-plugin.js). This fix locks the dependency to 7.12.x.

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

@babel/preset-env has removed utils.js in version 7.13.0, which is required by polyfills-plugin.js (https://github.com/nuxt/nuxt.js/blob/dev/packages/babel-preset-app/src/polyfills-plugin.js). This fix locks the dependency to 7.12.x.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

