### PR TITLE
fix(babel-preset-app): avoid rely on preset-env utils

### DIFF
--- a/packages/babel-preset-app/package.json
+++ b/packages/babel-preset-app/package.json
@@ -13,6 +13,7 @@
     "@babel/compat-data": "^7.12.13",
     "@babel/core": "^7.12.17",
     "@babel/helper-compilation-targets": "^7.12.17",
+    "@babel/helper-module-imports": "^7.12.13",
     "@babel/plugin-proposal-class-properties": "^7.12.13",
     "@babel/plugin-proposal-decorators": "^7.12.13",
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.12.13",

--- a/packages/babel-preset-app/src/polyfills-plugin.js
+++ b/packages/babel-preset-app/src/polyfills-plugin.js
@@ -1,4 +1,18 @@
 // Add polyfill imports to the first file encountered.
+const { addSideEffect } = require('@babel/helper-module-imports')
+
+const modulePathMap = {
+  'regenerator-runtime': 'regenerator-runtime/runtime.js'
+}
+
+function getModulePath (mod) {
+  return modulePathMap[mod] || 'core-js/modules/' + mod + '.js'
+}
+
+function createImport (path, mod) {
+  return addSideEffect(path, getModulePath(mod))
+}
+
 module.exports = ({ types }) => {
   let entryFile
   return {
@@ -12,7 +26,6 @@ module.exports = ({ types }) => {
         }
 
         const { polyfills } = state.opts
-        const { createImport } = require('@babel/preset-env/lib/utils')
 
         // Imports are injected in reverse order
         polyfills.slice().reverse().forEach((p) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
Refactored to avoid depending on `@babel/preset-env` internals.
<!--- Why is this change required? What problem does it solve? -->
Closes https://github.com/nuxt/nuxt.js/pull/8881

<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

