### PR TITLE
fix(vue-renderer): respect injectScripts for target:static

### DIFF
--- a/packages/vue-renderer/src/renderers/ssr.js
+++ b/packages/vue-renderer/src/renderers/ssr.js
@@ -177,7 +177,7 @@ export default class SSRRenderer extends BaseRenderer {
     const shouldHashCspScriptSrc = csp && (csp.unsafeInlineCompatibility || !containsUnsafeInlineScriptSrc)
     const inlineScripts = []
 
-    if (renderContext.staticAssetsBase) {
+    if (shouldInjectScripts && renderContext.staticAssetsBase) {
       const preloadScripts = []
       renderContext.staticAssets = []
       const { staticAssetsBase, url, nuxt, staticAssets } = renderContext

--- a/test/dev/full-static.test.js
+++ b/test/dev/full-static.test.js
@@ -14,55 +14,76 @@ let builder
 let server = null
 let generator = null
 
+const generateAndStartServer = async (overrides) => {
+  const config = await loadFixture('full-static', {
+    generate: {
+      static: false,
+      dir: '.nuxt-generate'
+    },
+    ...(overrides || {})
+  })
+  const nuxt = new Nuxt(config)
+  await nuxt.ready()
+
+  builder = new Builder(nuxt)
+  builder.build = jest.fn()
+  generator = new Generator(nuxt, builder)
+
+  await generator.generate()
+
+  const serve = serveStatic(distDir)
+  server = http.createServer((req, res) => {
+    serve(req, res, finalhandler(req, res))
+  })
+
+  port = await getPort()
+  server.listen(port)
+}
+
 describe('full-static', () => {
-  beforeAll(async () => {
-    const config = await loadFixture('full-static', {
-      generate: {
-        static: false,
-        dir: '.nuxt-generate'
-      }
-    })
-    const nuxt = new Nuxt(config)
-    await nuxt.ready()
+  describe('with scripts', () => {
+    beforeAll(async () => await generateAndStartServer())
 
-    builder = new Builder(nuxt)
-    builder.build = jest.fn()
-    generator = new Generator(nuxt, builder)
+    test('/payload (custom build.publicPath)', async () => {
+      const { body: html } = await rp(url('/payload'))
 
-    await generator.generate()
-
-    const serve = serveStatic(distDir)
-    server = http.createServer((req, res) => {
-      serve(req, res, finalhandler(req, res))
+      expect(html).toContain('<script src="https://cdn.nuxtjs.org/test/')
+      expect(html).toContain(
+        '<link rel="preload" href="https://cdn.nuxtjs.org/test/_nuxt/static/'
+      )
     })
 
-    port = await getPort()
-    server.listen(port)
-  })
+    test('/encoding/中文', async () => {
+      const { body: html } = await rp(url('/encoding/中文'))
 
-  test('/payload (custom build.publicPath)', async () => {
-    const { body: html } = await rp(url('/payload'))
+      const paths = ['encoding/中文/state.js', 'encoding/中文/payload.js']
 
-    expect(html).toContain('<script src="https://cdn.nuxtjs.org/test/')
-    expect(html).toContain(
-      '<link rel="preload" href="https://cdn.nuxtjs.org/test/_nuxt/static/'
-    )
-  })
+      paths.forEach((path) => {
+        const files = glob.sync(join(distDir, '**', path))
+        expect(html).toContain(encodeURI(path))
+        expect(files).toContainEqual(expect.stringContaining(path))
+      })
+    })
 
-  test('/encoding/中文', async () => {
-    const { body: html } = await rp(url('/encoding/中文'))
-
-    const paths = ['encoding/中文/state.js', 'encoding/中文/payload.js']
-
-    paths.forEach((path) => {
-      const files = glob.sync(join(distDir, '**', path))
-      expect(html).toContain(encodeURI(path))
-      expect(files).toContainEqual(expect.stringContaining(path))
+    // Close server and ask nuxt to stop listening to file changes
+    afterAll(async () => {
+      await server.close()
     })
   })
 
-  // Close server and ask nuxt to stop listening to file changes
-  afterAll(async () => {
-    await server.close()
+  describe('without scripts', () => {
+    beforeAll(async () => await generateAndStartServer({ render: { injectScripts: false } }))
+
+    test('should not inject scripts', async () => {
+      const { body: html } = await rp(url('/payload'))
+
+      expect(html).not.toContain('<script')
+      expect(html).not.toContain('<link')
+    })
+
+    // Close server and ask nuxt to stop listening to file changes
+    afterAll(async () => {
+      await server.close()
+    })
   })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
Fixes #8866 where `injectScripts: false` was not respected when generating full static pages.
As far as I can see this should not influence any target other than `static` since `renderContext.staticAssetsBase` in not set otherwise.

Also added a test to verify the change works. 

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing

