### PR TITLE
fix: allow force overriding resolve paths

### DIFF
--- a/packages/core/src/resolver.js
+++ b/packages/core/src/resolver.js
@@ -28,7 +28,7 @@ export default class Resolver {
   resolveModule (path, { paths } = {}) {
     try {
       return this._require.resolve(path, {
-        paths: [].concat(paths || [], this.options.modulesDir, global.__NUXT_PATHS__ || [], process.cwd())
+        paths: [].concat(global.__NUXT_PREPATHS__ || [], paths || [], this.options.modulesDir, global.__NUXT_PATHS__ || [], process.cwd())
       })
     } catch (error) {
       if (error.code !== 'MODULE_NOT_FOUND') {

--- a/packages/utils/src/cjs.js
+++ b/packages/utils/src/cjs.js
@@ -77,7 +77,7 @@ export function resolveModule (id, paths) {
     paths = [paths]
   }
   return _require.resolve(id, {
-    paths: [].concat(paths || [], global.__NUXT_PATHS__ || [], process.cwd())
+    paths: [].concat(...(global.__NUXT_PREPATHS__ || []), paths || [], global.__NUXT_PATHS__ || [], process.cwd())
   })
 }
 

--- a/packages/webpack/src/config/base.js
+++ b/packages/webpack/src/config/base.js
@@ -227,6 +227,7 @@ export default class WebpackBaseConfig {
     const webpackModulesDir = ['node_modules'].concat(this.buildContext.options.modulesDir)
 
     const resolvePath = [
+      ...(global.__NUXT_PREPATHS__ || []),
       this.buildContext.options.rootDir,
       __dirname,
       ...(global.__NUXT_PATHS__ || []),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description

Nuxt 2.15, introduced new `__NUXT_PATHS__` global to add more paths and by default choosing user-installed dependency. But for automation and force upgrading, we need a special path array to override rootDir. 


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

