### PR TITLE
fix(webpack): update hmr option for `extract-css-chunks-webpack-plugin`

### DIFF
--- a/packages/webpack/src/utils/style-loader.js
+++ b/packages/webpack/src/utils/style-loader.js
@@ -112,7 +112,7 @@ export default class StyleLoader {
           // TODO: https://github.com/faceyspacey/extract-css-chunks-webpack-plugin/issues/132
           // https://github.com/faceyspacey/extract-css-chunks-webpack-plugin/issues/161#issuecomment-500162574
           reloadAll: isDev,
-          hot: isDev
+          hmr: isDev
         }
       }
     }


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)

## Description

Looks like `extract-css-chunks-webpack-plugin` changed options format in https://github.com/faceyspacey/extract-css-chunks-webpack-plugin/commit/9daf720d11e671353d42d31fd05908ecae22af08.

closes #5390

## Checklist:
- [x] All new and existing tests are passing.

