### PR TITLE
fix(types): export interface for `NuxtConfig` instead of type

### DIFF
--- a/packages/types/config/index.d.ts
+++ b/packages/types/config/index.d.ts
@@ -74,4 +74,4 @@ export interface NuxtOptions extends Configuration {
   watchers: NuxtOptionsWatchers
 }
 
-export type NuxtConfig = Partial<NuxtOptions>
+export interface NuxtConfig extends Partial<NuxtOptions> {}


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)

## Description
* Seems accidentally changed in https://github.com/nuxt/nuxt.js/pull/8630
* Context: https://github.com/nuxt-community/module-template/pull/65#issuecomment-705654456, https://github.com/nuxt/nuxt.js/pull/8169
* allows it to be extended rather than overwritten

## Checklist:
- [x] All new and existing tests are passing.

