### PR TITLE
feat(config): support for skipping base tag when router.base is set

### DIFF
--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -31,7 +31,11 @@ export function getNuxtConfig (_options) {
     options.router.middleware = [options.router.middleware]
   }
 
-  if (options.router && typeof options.router.base === 'string') {
+  if (typeof options.router.baseTag === 'undefined') {
+    options.router.baseTag = true
+  }
+
+  if (options.router && typeof options.router.base === 'string' && options.router.baseTag) {
     options._routerBaseSpecified = true
   }
 

--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -31,7 +31,7 @@ export function getNuxtConfig (_options) {
     options.router.middleware = [options.router.middleware]
   }
 
-  if (typeof options.router.baseTag === 'undefined') {
+  if (options.router && typeof options.router.baseTag === 'undefined') {
     options.router.baseTag = true
   }
 

--- a/packages/config/test/options.test.js
+++ b/packages/config/test/options.test.js
@@ -191,6 +191,11 @@ describe('config: options', () => {
       const { _routerBaseSpecified } = getNuxtConfig({ router: { base: '/test' } })
       expect(_routerBaseSpecified).toEqual(true)
     })
+
+    test('should not set _routerBaseSpecified when baseTag is set to false', () => {
+      const { _routerBaseSpecified } = getNuxtConfig({ router: { base: '/test', baseTag: false } })
+      expect(_routerBaseSpecified).toBeUndefined()
+    })
   })
 
   describe('config: options dir', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Resolves: https://github.com/nuxt/nuxt.js/issues/7573
There's probably a nicer way of doing this, all comments are welcome.

https://stackoverflow.com/questions/659120/url-hash-with-html-base-tag

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.


Example:
```
export default {
  router: {
    base: '/app/',
    baseTag: false,
  }
}
```

