### PR TITLE
fix(cli): remove warning if postcss 8 is installed

### DIFF
--- a/packages/cli/src/utils/dependencies.js
+++ b/packages/cli/src/utils/dependencies.js
@@ -3,7 +3,6 @@ import { satisfies } from 'semver'
 import { getPKG } from '@nuxt/utils'
 
 const dependencies = {
-  postcss: '^7.0.32',
   webpack: '^4.46.0',
   'sass-loader': '^10.1.1'
 }


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)

## Description
We now have support for PostCSS 8 and do not need to warn users. (Related: https://github.com/nuxt/nuxt.js/issues/8087)

(**Note**: the recommended way to enable PostCSS 8 is via https://github.com/nuxt/postcss8.)

## Checklist:
- [x] All new and existing tests are passing.

