### PR TITLE
fix(vue-app): fallback to global nuxt instance of `$root` is not available

### DIFF
--- a/packages/vue-app/template/index.js
+++ b/packages/vue-app/template/index.js
@@ -47,7 +47,7 @@ Vue.component(Nuxt.name, Nuxt)
 Object.defineProperty(Vue.prototype, '<%= globals.nuxt %>', {
   get() {
     const globalNuxt = this.$root.$options.<%= globals.nuxt %>
-    if(process.client && !globalNuxt && typeof window !== 'undefined') {
+    if (process.client && !globalNuxt && typeof window !== 'undefined') {
       return window.<%= globals.nuxt %>
     }
     return globalNuxt

--- a/packages/vue-app/template/index.js
+++ b/packages/vue-app/template/index.js
@@ -46,7 +46,7 @@ Vue.component(Nuxt.name, Nuxt)
 
 Object.defineProperty(Vue.prototype, '<%= globals.nuxt %>', {
   get() {
-    return this.$root.$options.<%= globals.nuxt %> || window.<%= globals.nuxt %>
+    return this.$root.$options.<%= globals.nuxt %> || (process.client && typeof window !== 'undefined' && window.<%= globals.nuxt %>)
   },
   configurable: true
 })

--- a/packages/vue-app/template/index.js
+++ b/packages/vue-app/template/index.js
@@ -46,7 +46,7 @@ Vue.component(Nuxt.name, Nuxt)
 
 Object.defineProperty(Vue.prototype, '<%= globals.nuxt %>', {
   get() {
-    return this.$root.$options.<%= globals.nuxt %>
+    return this.$root.$options.<%= globals.nuxt %> || window.<%= globals.nuxt %>
   },
   configurable: true
 })

--- a/packages/vue-app/template/index.js
+++ b/packages/vue-app/template/index.js
@@ -46,7 +46,11 @@ Vue.component(Nuxt.name, Nuxt)
 
 Object.defineProperty(Vue.prototype, '<%= globals.nuxt %>', {
   get() {
-    return this.$root.$options.<%= globals.nuxt %> || (process.client && typeof window !== 'undefined' && window.<%= globals.nuxt %>)
+    const globalNuxt = this.$root.$options.<%= globals.nuxt %>
+    if(process.client && !globalNuxt && typeof window !== 'undefined') {
+      return window.<%= globals.nuxt %>
+    }
+    return globalNuxt
   },
   configurable: true
 })


### PR DESCRIPTION
## Types of changes
return window.$nuxt if $root is not set
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
$nuxt was not always accessible (if $root was not set), so return the property from window object

fixes #8995

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

