### PR TITLE
fix(config): compile type compatibility in css-loader v4

### DIFF
--- a/packages/cli/test/unit/__snapshots__/webpack.test.js.snap
+++ b/packages/cli/test/unit/__snapshots__/webpack.test.js.snap
@@ -135,6 +135,9 @@ exports[`webpack nuxt webpack module.rules 1`] = `
             \\"options\\": Object {
               \\"esModule\\": false,
               \\"importLoaders\\": 2,
+              \\"modules\\": Object {
+                \\"compileType\\": \\"icss\\",
+              },
               \\"sourceMap\\": false,
               \\"url\\": [Function isUrlResolvingEnabled],
             },
@@ -208,6 +211,9 @@ exports[`webpack nuxt webpack module.rules 1`] = `
             \\"options\\": Object {
               \\"esModule\\": false,
               \\"importLoaders\\": 2,
+              \\"modules\\": Object {
+                \\"compileType\\": \\"icss\\",
+              },
               \\"sourceMap\\": false,
               \\"url\\": [Function isUrlResolvingEnabled],
             },
@@ -287,6 +293,9 @@ exports[`webpack nuxt webpack module.rules 1`] = `
             \\"options\\": Object {
               \\"esModule\\": false,
               \\"importLoaders\\": 2,
+              \\"modules\\": Object {
+                \\"compileType\\": \\"icss\\",
+              },
               \\"sourceMap\\": false,
               \\"url\\": [Function isUrlResolvingEnabled],
             },
@@ -375,6 +384,9 @@ exports[`webpack nuxt webpack module.rules 1`] = `
             \\"options\\": Object {
               \\"esModule\\": false,
               \\"importLoaders\\": 2,
+              \\"modules\\": Object {
+                \\"compileType\\": \\"icss\\",
+              },
               \\"sourceMap\\": false,
               \\"url\\": [Function isUrlResolvingEnabled],
             },
@@ -463,6 +475,9 @@ exports[`webpack nuxt webpack module.rules 1`] = `
             \\"options\\": Object {
               \\"esModule\\": false,
               \\"importLoaders\\": 2,
+              \\"modules\\": Object {
+                \\"compileType\\": \\"icss\\",
+              },
               \\"sourceMap\\": false,
               \\"url\\": [Function isUrlResolvingEnabled],
             },
@@ -548,6 +563,9 @@ exports[`webpack nuxt webpack module.rules 1`] = `
             \\"options\\": Object {
               \\"esModule\\": false,
               \\"importLoaders\\": 2,
+              \\"modules\\": Object {
+                \\"compileType\\": \\"icss\\",
+              },
               \\"sourceMap\\": false,
               \\"url\\": [Function isUrlResolvingEnabled],
             },

--- a/packages/config/src/config/build.js
+++ b/packages/config/src/config/build.js
@@ -34,7 +34,12 @@ export default () => ({
         embed: 'src'
       }
     },
-    css: { esModule: false, modules: { compileType: 'icss' } },
+    css: {
+      esModule: false,
+      modules: {
+        compileType: 'icss'
+      }
+    },
     cssModules: {
       esModule: false,
       modules: {

--- a/packages/config/src/config/build.js
+++ b/packages/config/src/config/build.js
@@ -34,7 +34,7 @@ export default () => ({
         embed: 'src'
       }
     },
-    css: { esModule: false },
+    css: { esModule: false, modules: { compileType: 'icss' } },
     cssModules: {
       esModule: false,
       modules: {

--- a/packages/config/test/__snapshots__/options.test.js.snap
+++ b/packages/config/test/__snapshots__/options.test.js.snap
@@ -71,6 +71,9 @@ Object {
     "loaders": Object {
       "css": Object {
         "esModule": false,
+        "modules": Object {
+          "compileType": "icss",
+        },
         "sourceMap": false,
       },
       "cssModules": Object {

--- a/packages/config/test/config/__snapshots__/index.test.js.snap
+++ b/packages/config/test/config/__snapshots__/index.test.js.snap
@@ -55,6 +55,9 @@ Object {
     "loaders": Object {
       "css": Object {
         "esModule": false,
+        "modules": Object {
+          "compileType": "icss",
+        },
       },
       "cssModules": Object {
         "esModule": false,
@@ -441,6 +444,9 @@ Object {
     "loaders": Object {
       "css": Object {
         "esModule": false,
+        "modules": Object {
+          "compileType": "icss",
+        },
       },
       "cssModules": Object {
         "esModule": false,


### PR DESCRIPTION
set the css-loader's compileType option to icss

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
when nuxt upgrade the css-loader library to v4, it results in a break change
if you export your sass variables and import it in your vue file before, it works fine
however when the css-loader library is upgraded to v4, the css-loader's compileType option is module by default which causes the problem
for example:
in your variable.scss file
```
$primaryColor: blue;
:export{
  primaryColor: $primaryColor;
}
```
in your vue file
```
import variables from 'variable.scss'
```

before: we can get the expected value
now : the variables we get is '{}'

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

