### PR TITLE
fix(server): avoid caching `.js` assets in development to fix HMR for safari

### DIFF
--- a/packages/server/src/server.js
+++ b/packages/server/src/server.js
@@ -114,6 +114,11 @@ export default class Server {
         if (!this.devMiddleware) {
           return next()
         }
+        // Safari over-caches JS (breaking HMR) and the seemingly only way to turn
+        // this off in dev mode is to set Vary: * header
+        if (req.url.startsWith(this.publicPath) && req.url.endsWith('.js')) {
+          res.setHeader('Vary', '*')
+        }
         this.devMiddleware(req, res, next)
       })
 

--- a/packages/server/src/server.js
+++ b/packages/server/src/server.js
@@ -116,6 +116,7 @@ export default class Server {
         }
         // Safari over-caches JS (breaking HMR) and the seemingly only way to turn
         // this off in dev mode is to set Vary: * header
+        // #3828, #9034
         if (req.url.startsWith(this.publicPath) && req.url.endsWith('.js')) {
           res.setHeader('Vary', '*')
         }


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)

## Description
This PR turns off caching for webpack-processed JS files in dev mode.

<details><summary><strong>Fixes reload loop on safari (closes #3828)</strong>.</summary>
<br>
Previously, `runtime.js` was being cached in-memory by Safari and triggering infinite HMR updates in the following situation:
* server started
* change made to file (triggering HMR)
* server restarted
* safari hard reload -> starts infinite loop (because `runtime.js` from first server is loaded from memory)

</details>

**Note**: if you have previously experienced an infinite reload loop, you will need to clear your Safari cache once using `Develop...Empty Caches` and then reload.

## Checklist:
- [x] All new and existing tests are passing.

