### PR TITLE
fix(config): merge `app` namespace rather than overriding

### DIFF
--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -461,7 +461,7 @@ export function getNuxtConfig (_options) {
   })
   // Expose app config to $config.app
   options.publicRuntimeConfig = options.publicRuntimeConfig || {}
-  options.publicRuntimeConfig.app = options.app
+  options.publicRuntimeConfig.app = defu(options.publicRuntimeConfig.app, options.app)
 
   // Generate staticAssets
   const { staticAssets } = options.generate


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)

## Description
Note that `app` should be a reserved namespace in any case so this may be an abundance of caution.

closes #8991

## Checklist:
- [x] All new and existing tests are passing.

