### PR TITLE
fix(types): css-loader v4 type definition

### DIFF
--- a/packages/types/config/build.d.ts
+++ b/packages/types/config/build.d.ts
@@ -26,25 +26,29 @@ import { Options as WebpackDevMiddlewareOptions } from 'webpack-dev-middleware'
 import { MiddlewareOptions as WebpackHotMiddlewareOptions, ClientOptions as WebpackHotMiddlewareClientOptions } from 'webpack-hot-middleware'
 
 type CssLoaderUrlFunction = (url: string, resourcePath: string) => boolean
-type CssLoaderImportFunction = (parsedImport: string, resourcePath: string) => boolean
+type CssLoaderImportFunction = (url: string, media: string, resourcePath: string) => boolean
+
 type CssLoaderMode = 'global' | 'local' | 'pure'
 interface CssLoaderModulesOptions {
-  context?: string
-  exportLocalsConvention?: 'asIs' | 'camelCase' | 'camelCaseOnly' | 'dashes' | 'dashesOnly'
-  exportOnlyLocals?: boolean
-  getLocalIdent?: (context: string, localIdentName: string, localName: string, options: CssLoaderModulesOptions) => string
-  localIdentHashPrefix?: string
-  localIdentName?: string
-  localIdentRegExp?: string | RegExp
-  mode?: CssLoaderMode
+  compileType?: 'module' | 'icss',
+  mode?: CssLoaderMode,
+  auto?: Boolean | RegExp | ((resourcePath: string) => boolean),
+  exportGlobals?: boolean,
+  localIdentName?: string,
+  context?: string,
+  localIdentHashPrefix?: string,
+  namedExport?: boolean,
+  exportLocalsConvention?: 'asIs' | 'camelCase' | 'camelCaseOnly' | 'dashes' | 'dashesOnly',
+  exportOnlyLocals?: boolean,
 }
 
 interface CssLoaderOptions {
+  url?: boolean | CssLoaderUrlFunction
   import?: boolean | CssLoaderImportFunction
-  importLoaders?: number
   modules?: boolean | CssLoaderMode | CssLoaderModulesOptions
   sourceMap?: boolean
-  url?: boolean | CssLoaderUrlFunction
+  importLoaders?: number
+  esModule?: boolean
 }
 
 interface UrlLoaderOptions {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
I fixed the type definition for CssLoaderOptions to suit css-loader v4.

Also see:
https://github.com/webpack-contrib/css-loader/tree/v4.3.0#options

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

