### PR TITLE
chore(types): add stub entrypoint to allow node resolution of `@nuxt/types`

### DIFF
--- a/packages/types/index.js
+++ b/packages/types/index.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -4,8 +4,10 @@
   "description": "Nuxt types",
   "repository": "nuxt/nuxt.js",
   "license": "MIT",
-  "types": "index",
+  "main": "index.js",
+  "types": "index.d.ts",
   "files": [
+    "index.js",
     "**/*.d.ts"
   ],
   "dependencies": {


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)

## Description
This does add new behaviour (now `require.resolve('@nuxt/types')` will output a path) but it's not breaking.

see https://github.com/microsoft/TypeScript/issues/18008#issuecomment-804299674

closes #9030

## Checklist:
- [x] All new and existing tests are passing.

