### PR TITLE
refactor: move internal app runtime config to `_app` namespace

### DIFF
--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -459,9 +459,9 @@ export function getNuxtConfig (_options) {
     assetsPath: isRelativePublicPath ? options.build.publicPath : useCDN ? '/' : joinURL(options.router.base, options.build.publicPath),
     cdnURL: useCDN ? options.build.publicPath : null
   })
-  // Expose app config to $config.app
+  // Expose app config to $config._app
   options.publicRuntimeConfig = options.publicRuntimeConfig || {}
-  options.publicRuntimeConfig.app = defu(options.publicRuntimeConfig.app, options.app)
+  options.publicRuntimeConfig._app = options.app
 
   // Generate staticAssets
   const { staticAssets } = options.generate

--- a/packages/config/test/__snapshots__/options.test.js.snap
+++ b/packages/config/test/__snapshots__/options.test.js.snap
@@ -323,7 +323,7 @@ Object {
   "plugins": Array [],
   "privateRuntimeConfig": Object {},
   "publicRuntimeConfig": Object {
-    "app": Object {
+    "_app": Object {
       "assetsPath": "/_nuxt/",
       "basePath": "/",
       "cdnURL": null,

--- a/packages/types/config/runtime.d.ts
+++ b/packages/types/config/runtime.d.ts
@@ -4,7 +4,12 @@
 */
 
 export interface NuxtRuntimeConfig {
-  [key: string]: any
+  [key: string]: any;
+  /**
+   * This is used internally by Nuxt for dynamic configuration and should not be used.
+   * @internal
+   */
+  _app?: never;
 }
 
 export type NuxtOptionsRuntimeConfig = NuxtRuntimeConfig | ((env: typeof process.env) => NuxtRuntimeConfig)

--- a/packages/vue-app/template/client.js
+++ b/packages/vue-app/template/client.js
@@ -49,8 +49,8 @@ let router
 const NUXT = window.<%= globals.context %> || {}
 
 const $config = NUXT.config || {}
-if ($config.app) {
-  __webpack_public_path__ = urlJoin($config.app.cdnURL, $config.app.assetsPath)
+if ($config._app) {
+  __webpack_public_path__ = urlJoin($config._app.cdnURL, $config._app.assetsPath)
 }
 
 Object.assign(Vue.config, <%= serialize(vue.config) %>)<%= isTest ? '// eslint-disable-line' : '' %>

--- a/packages/vue-app/template/router.js
+++ b/packages/vue-app/template/router.js
@@ -102,7 +102,7 @@ export const routerOptions = {
 }
 
 export function createRouter (ssrContext, config) {
-  const base = (config.app && config.app.basePath) || routerOptions.base
+  const base = (config._app && config._app.basePath) || routerOptions.base
   const router = new Router({ ...routerOptions, base  })
 
   // TODO: remove in Nuxt 3

--- a/packages/vue-app/template/server.js
+++ b/packages/vue-app/template/server.js
@@ -59,7 +59,7 @@ const createNext = ssrContext => (opts) => {
   }
   let fullPath = withQuery(opts.path, opts.query)
   const $config = ssrContext.runtimeConfig || {}
-  const routerBase = ($config.app && $config.app.basePath) || '<%= router.base %>'
+  const routerBase = ($config._app && $config._app.basePath) || '<%= router.base %>'
   if (!fullPath.startsWith('http') && (routerBase !== '/' && !fullPath.startsWith(routerBase))) {
     fullPath = joinURL(routerBase, fullPath)
   }
@@ -99,8 +99,8 @@ export default async (ssrContext) => {
   <% } %>
   // Public runtime config
   ssrContext.nuxt.config = ssrContext.runtimeConfig.public
-  if (ssrContext.nuxt.config.app) {
-    __webpack_public_path__ = joinURL(ssrContext.nuxt.config.app.cdnURL, ssrContext.nuxt.config.app.assetsPath)
+  if (ssrContext.nuxt.config._app) {
+    __webpack_public_path__ = joinURL(ssrContext.nuxt.config._app.cdnURL, ssrContext.nuxt.config._app.assetsPath)
   }
   // Create the app definition and the instance (created for each request)
   const { app, router<%= (store ? ', store' : '') %> } = await createApp(ssrContext, ssrContext.runtimeConfig.private)

--- a/test/dev/basic.dynamic.test.js
+++ b/test/dev/basic.dynamic.test.js
@@ -55,9 +55,9 @@ describe('basic ssr', () => {
 
     expect(window.document.body.innerHTML).toContain('<h1>Index page</h1>')
 
-    expect(window.__NUXT__.config.app.basePath).toBe('/path/')
-    expect(window.__NUXT__.config.app.cdnURL).toBe('https://cdn.nuxtjs.org/')
-    expect(window.__NUXT__.config.app.assetsPath).toBe('/')
+    expect(window.__NUXT__.config._app.basePath).toBe('/path/')
+    expect(window.__NUXT__.config._app.cdnURL).toBe('https://cdn.nuxtjs.org/')
+    expect(window.__NUXT__.config._app.assetsPath).toBe('/')
 
     expect(fetchCount).toBeGreaterThan(0)
   })


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)

## Description
move internal runtime config to `_app`  from `app` - and add notification that this is reserved via TS types/IDE autocomplete

History: #8759, #9039

closes #9074

## Checklist:
- [x] All new and existing tests are passing.

