### PR TITLE
fix(cli): add warning for css-loader < 4.2

### DIFF
--- a/packages/cli/src/utils/dependencies.js
+++ b/packages/cli/src/utils/dependencies.js
@@ -4,6 +4,7 @@ import { getPKG } from '@nuxt/utils'
 
 const dependencies = {
   webpack: '^4.46.0',
+  'css-loader': '>=4.2.0',
   'sass-loader': '^10.1.1'
 }
 


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)

## Description
Since https://github.com/nuxt/nuxt.js/pull/9014 we now have a default schema incompatible with css-loader < 4.2, which is when the `compileType` option was introduced (see https://github.com/webpack-contrib/css-loader/pull/1150).

This PR adds a warning if the version of `css-loader` installed is less than 4.2.

closes #9117

## Checklist:
- [x] All new and existing tests are passing.

