### PR TITLE
fix(builder): resolve aliases in `build.watch` paths

### DIFF
--- a/packages/builder/src/builder.js
+++ b/packages/builder/src/builder.js
@@ -661,7 +661,7 @@ export default class Builder {
     const customPatterns = uniq([
       ...this.options.build.watch,
       ...Object.values(omit(this.options.build.styleResources, ['options']))
-    ]).map(upath.normalizeSafe)
+    ]).map(this.nuxt.resolver.resolveAlias).map(upath.normalizeSafe)
 
     if (customPatterns.length === 0) {
       return

--- a/packages/builder/test/builder.watch.test.js
+++ b/packages/builder/test/builder.watch.test.js
@@ -178,10 +178,10 @@ describe('builder: builder watch', () => {
       middleware: '/var/nuxt/src/middleware'
     }
     nuxt.options.build.watch = [
-      '/var/nuxt/src/custom'
+      '~/custom'
     ]
     nuxt.options.build.styleResources = [
-      '/var/nuxt/src/style'
+      '~/style'
     ]
     const builder = new Builder(nuxt, BundleBuilder)
     builder.createFileWatcher = jest.fn()
@@ -189,8 +189,8 @@ describe('builder: builder watch', () => {
     builder.watchClient()
 
     const patterns = [
-      '/var/nuxt/src/custom',
-      '/var/nuxt/src/style'
+      'resolveAlias(~/custom)',
+      'resolveAlias(~/style)'
     ]
 
     expect(builder.createFileWatcher).toBeCalledTimes(3)


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)

## Description
`build.watch` currently watches relative and absolute paths but doesn't respect aliases (contra to [docs example](https://nuxtjs.org/docs/2.x/configuration-glossary/configuration-build#watch)).

This PR resolves aliases in custom watch patterns (from `build.watch` or `build.styleResources`).

closes #9045

## Checklist:
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

