### PR TITLE
fix(vue-app): respect `scroll-margin-top` when navigating with hash

### DIFF
--- a/packages/vue-app/template/router.scrollBehavior.js
+++ b/packages/vue-app/template/router.scrollBehavior.js
@@ -66,9 +66,15 @@ export default function (to, from, savedPosition) {
           hash = '#' + window.CSS.escape(hash.substr(1))
         }
         try {
-          if (document.querySelector(hash)) {
+          const el = document.querySelector(hash)
+          if (el) {
             // scroll to anchor by returning the selector
             position = { selector: hash }
+            // Respect any scroll-margin-top set in CSS when scrolling to anchor
+            const y = Number(getComputedStyle(el)['scroll-margin-top']?.replace('px', ''))
+            if (y) {
+              position.offset = { y }
+            }
           }
         } catch (e) {
           <%= isTest ? '// eslint-disable-next-line no-console' : '' %>


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)

## Description

This PR checks whether there is a `scroll-margin-top` and uses that value as offset when scrolling to the element when navigating via hash navigation, e.g. `<NuxtLink to="/about#heading-3">About</NuxtLink>`.

closes #9135

## Checklist:
- [x] All new and existing tests are passing.

