### PR TITLE
chore(ssr): opt-out nuxt.js ssr app from Google's FLoC

### DIFF
--- a/packages/vue-renderer/src/renderers/ssr.js
+++ b/packages/vue-renderer/src/renderers/ssr.js
@@ -153,6 +153,10 @@ export default class SSRRenderer extends BaseRenderer {
       HEAD += this.renderResourceHints(renderContext)
     }
 
+    // Inject meta to disable Google's FLoC
+    if (!this.options.floc) {
+      HEAD += `<meta http-equiv="Permissions-Policy" content="interest-cohort=()"/>`
+    }
     // Inject styles
     HEAD += this.renderStyles(renderContext)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)



## Context

FLoC lets advertisers use behavioral targeting without cookies. It runs in Google’s Chrome browser and tracks a user’s online behavior. [more info](https://github.com/WICG/floc) by default your website will allow FLoC (categorizing you app users in Cohorts)

## Description

This PR is a way to opt-out of your app create by nuxt.js from being sending your user's data to this Google service. The new code check `config.nuwt.js` file for a property `floc` if it `true` will not do anything if it's `false` it will add meta-data to prevent Google chrome from sending the data to FLoC service 


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [X] All new and existing tests are passing.

