### PR TITLE
feat: add http/2.0 support through https (spdy)

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -24,6 +24,7 @@
     "serve-placeholder": "^1.2.3",
     "serve-static": "^1.14.1",
     "server-destroy": "^1.0.1",
+    "spdy": "^4.0.2",
     "ufo": "^0.7.2"
   },
   "publishConfig": {

--- a/packages/server/src/listener.js
+++ b/packages/server/src/listener.js
@@ -1,5 +1,5 @@
 import http from 'http'
-import https from 'https'
+import https from 'spdy'
 import enableDestroy from 'server-destroy'
 import ip from 'ip'
 import consola from 'consola'


### PR DESCRIPTION
## Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Add http/2.0 support with `sdpy` module instead of `https`. Will only work through https as browser like Firefox and Google chrome implemented http/2.0 only for https.

This is a must have for google lighthouse performance test!


## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing. => I haven't been able to test as the test seems broken but not by my changes.

