### PR TITLE
fix(build):  change hash filename to query hash filename for ChunkLoa…

### DIFF
--- a/packages/config/src/config/build.js
+++ b/packages/config/src/config/build.js
@@ -14,12 +14,12 @@ export default () => ({
   serverURLPolyfill: 'url',
   filenames: {
     // { isDev, isClient, isServer }
-    app: ({ isDev, isModern }) => isDev ? `[name]${isModern ? '.modern' : ''}.js` : `[contenthash:7]${isModern ? '.modern' : ''}.js`,
-    chunk: ({ isDev, isModern }) => isDev ? `[name]${isModern ? '.modern' : ''}.js` : `[contenthash:7]${isModern ? '.modern' : ''}.js`,
-    css: ({ isDev }) => isDev ? '[name].css' : 'css/[contenthash:7].css',
-    img: ({ isDev }) => isDev ? '[path][name].[ext]' : 'img/[name].[contenthash:7].[ext]',
-    font: ({ isDev }) => isDev ? '[path][name].[ext]' : 'fonts/[name].[contenthash:7].[ext]',
-    video: ({ isDev }) => isDev ? '[path][name].[ext]' : 'videos/[name].[contenthash:7].[ext]'
+    app: ({ isDev, isModern }) => isDev ? `[name]${isModern ? '.modern' : ''}.js` : `[name]${isModern ? '.modern' : ''}.js?[contenthash:7]`,
+    chunk: ({ isDev, isModern }) => isDev ? `[name]${isModern ? '.modern' : ''}.js` : `[name]${isModern ? '.modern' : ''}.js?[contenthash:7]`,
+    css: ({ isDev }) => isDev ? '[name].css' : 'css/[name].css?[contenthash:7]',
+    img: ({ isDev }) => isDev ? '[path][name].[ext]' : 'img/[name].[ext]?[contenthash:7]',
+    font: ({ isDev }) => isDev ? '[path][name].[ext]' : 'fonts/[name].[ext]?[contenthash:7]',
+    video: ({ isDev }) => isDev ? '[path][name].[ext]' : 'videos/[name].[ext]?[contenthash:7]'
   },
   loaders: {
     file: { esModule: false },

--- a/packages/config/test/config/build.test.js
+++ b/packages/config/test/config/build.test.js
@@ -15,18 +15,18 @@ describe('config: build', () => {
   test('should return prod filenames', () => {
     const { filenames } = buildConfig()
     const env = { isDev: false }
-    expect(filenames.app(env)).toEqual('[contenthash:7].js')
-    expect(filenames.chunk(env)).toEqual('[contenthash:7].js')
-    expect(filenames.css(env)).toEqual('css/[contenthash:7].css')
-    expect(filenames.img(env)).toEqual('img/[name].[contenthash:7].[ext]')
-    expect(filenames.font(env)).toEqual('fonts/[name].[contenthash:7].[ext]')
-    expect(filenames.video(env)).toEqual('videos/[name].[contenthash:7].[ext]')
+    expect(filenames.app(env)).toEqual('[name].js?[contenthash:7]')
+    expect(filenames.chunk(env)).toEqual('[name].js?[contenthash:7]')
+    expect(filenames.css(env)).toEqual('css/[name].css?[contenthash:7]')
+    expect(filenames.img(env)).toEqual('img/[name].[ext]?[contenthash:7]')
+    expect(filenames.font(env)).toEqual('fonts/[name].[ext]?[contenthash:7]')
+    expect(filenames.video(env)).toEqual('videos/[name].[ext]?[contenthash:7]')
   })
 
   test('should return modern filenames', () => {
     const { filenames } = buildConfig()
     const env = { isDev: true, isModern: true }
-    expect(filenames.app(env)).toEqual('[name].modern.js')
-    expect(filenames.chunk(env)).toEqual('[name].modern.js')
+    expect(filenames.app(env)).toEqual('[name].modern.js?[contenthash:7]')
+    expect(filenames.chunk(env)).toEqual('[name].modern.js?[contenthash:7]')
   })
 })


### PR DESCRIPTION
I think it's better to change the naming format of the generated files of build to prevent ChunkLoadError.

```
# example error
ChunkLoadError: Loading chunk 269 failed
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


## Description
With the current file naming, the file itself is recognized as a new file, which causes a 404 error for existing users (users who are staying), which in turn causes a ChunkLoadError.
The file name itself is not changed, I think we'd better adding the query hash to end of file name without changing the file name itself.

Also, Currently, when using multiple containers and building in each container, created hash file naming in each container.
When that cases, Sometimes it connects to a different container, 404 file error when using load balancers.

Therefore, we need to generate the same file name in every build, and I think the way to update the cache with the query hash value at the end file name is better.


## Checklist:
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

