### PR TITLE
fix(types): pin to `@types/webpack-dev-middleware` 4.1.2

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -27,7 +27,7 @@
     "@types/terser-webpack-plugin": "^4.2.1",
     "@types/webpack": "^4.41.28",
     "@types/webpack-bundle-analyzer": "^3.9.3",
-    "@types/webpack-dev-middleware": "^4.1.2",
+    "@types/webpack-dev-middleware": "4.1.2",
     "@types/webpack-hot-middleware": "^2.25.4",
     "sass-loader": "^10.1.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2584,7 +2584,7 @@
   dependencies:
     "@types/webpack" "^4"
 
-"@types/webpack-dev-middleware@^4.1.2":
+"@types/webpack-dev-middleware@4.1.2":
   version "4.1.2"
   resolved "https://registry.npmjs.org/@types/webpack-dev-middleware/-/webpack-dev-middleware-4.1.2.tgz#c683adc6a44d0b66e98f1932ab33d1c32d558142"
   integrity sha512-SxXzPCqeZ03fJ2dg3iD7cSXvqZymmS5/2GD9fANRcyWN7HYK1H3ty6q7IInXZKvPrdUqij831G3RLIeKK6aGdw==


### PR DESCRIPTION
* avoid webpack 5 being inserted in project

## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)

## Description
`@types/webpack-dev-middleware` added dependency on webpack 5 in [patch release (4.1.3)](https://unpkg.com/browse/@types/webpack-dev-middleware@4.1.3/package.json).

closes https://github.com/nuxt/nuxt.js/issues/9268

## Checklist:
- [x] All new and existing tests are passing.

