### PR TITLE
fix(babel-preset-app): respect explicit options.targets for modern preset

### DIFF
--- a/packages/babel-preset-app/src/index.js
+++ b/packages/babel-preset-app/src/index.js
@@ -97,12 +97,7 @@ module.exports = (api, options = {}) => {
     modern: { esmodules: true }
   }
 
-  let { targets = defaultTargets[envName] } = options
-
-  // modern mode can only be { esmodules: true }
-  if (envName === 'modern') {
-    targets = defaultTargets.modern
-  }
+  const { targets = defaultTargets[envName] } = options
 
   const polyfills = []
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Fix https://github.com/nuxt/nuxt.js/issues/9315

We used to limit targets of modern preset can only be `{esModules: true}` for not breaking matching between browsers which support `<script type="module">` and corresponding modern syntax, but it makes sense that let users specify a more modern targets manually if they know exactly what is the target browsers.

@pi0 Do you think we need to add a cli info message here about overrding default modern preset targets may break browsers which support `<script type="module">` but not implement more modern ecma syntax yet ?

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

