### PR TITLE
feat(server): allow disabling `serve-static` middleware entirely

### DIFF
--- a/packages/server/src/server.js
+++ b/packages/server/src/server.js
@@ -87,13 +87,15 @@ export default class Server {
       this.useMiddleware(createTimingMiddleware(this.options.server.timing))
     }
 
-    // For serving static/ files to /
-    const staticMiddleware = serveStatic(
-      path.resolve(this.options.srcDir, this.options.dir.static),
-      this.options.render.static
-    )
-    staticMiddleware.prefix = this.options.render.static.prefix
-    this.useMiddleware(staticMiddleware)
+    if (this.options.render.static !== false) {
+      // For serving static/ files to /
+      const staticMiddleware = serveStatic(
+        path.resolve(this.options.srcDir, this.options.dir.static),
+        this.options.render.static
+      )
+      staticMiddleware.prefix = this.options.render.static.prefix
+      this.useMiddleware(staticMiddleware)
+    }
 
     // Serve .nuxt/dist/client files only for production
     // For dev they will be served with devMiddleware


### PR DESCRIPTION
## Types of changes
- [x] New feature (a non-breaking change which adds functionality)

## Description
Allows explicitly disabling `serve-static` middleware by setting `render.static` to `false`.

closes #9362

## Checklist:
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

