### PR TITLE
chore: upgrade vue to 2.6.13

### DIFF
--- a/distributions/nuxt-start/package.json
+++ b/distributions/nuxt-start/package.json
@@ -34,7 +34,7 @@
     "@nuxt/utils": "2.15.6",
     "@nuxt/vue-renderer": "2.15.6",
     "node-fetch": "^2.6.1",
-    "vue": "^2.6.12",
+    "vue": "^2.6.13",
     "vue-client-only": "^2.0.0",
     "vue-meta": "^2.4.0",
     "vue-no-ssr": "^1.1.1",

--- a/packages/vue-app/package.json
+++ b/packages/vue-app/package.json
@@ -16,12 +16,12 @@
     "node-fetch": "^2.6.1",
     "ufo": "^0.7.4",
     "unfetch": "^4.2.0",
-    "vue": "^2.6.12",
+    "vue": "^2.6.13",
     "vue-client-only": "^2.0.0",
     "vue-meta": "^2.4.0",
     "vue-no-ssr": "^1.1.1",
     "vue-router": "^3.5.1",
-    "vue-template-compiler": "^2.6.12",
+    "vue-template-compiler": "^2.6.13",
     "vuex": "^3.6.2"
   },
   "publishConfig": {

--- a/packages/vue-renderer/package.json
+++ b/packages/vue-renderer/package.json
@@ -16,9 +16,9 @@
     "lodash": "^4.17.21",
     "lru-cache": "^5.1.1",
     "ufo": "^0.7.4",
-    "vue": "^2.6.12",
+    "vue": "^2.6.13",
     "vue-meta": "^2.4.0",
-    "vue-server-renderer": "^2.6.12"
+    "vue-server-renderer": "^2.6.13"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -46,7 +46,7 @@
     "url-loader": "^4.1.1",
     "vue-loader": "^15.9.7",
     "vue-style-loader": "^4.1.3",
-    "vue-template-compiler": "^2.6.12",
+    "vue-template-compiler": "^2.6.13",
     "watchpack": "^2.1.1",
     "webpack": "^4.46.0",
     "webpack-bundle-analyzer": "^4.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13416,10 +13416,10 @@ vue-router@^3.5.1:
   resolved "https://registry.npmjs.org/vue-router/-/vue-router-3.5.1.tgz#edf3cf4907952d1e0583e079237220c5ff6eb6c9"
   integrity sha512-RRQNLT8Mzr8z7eL4p7BtKvRaTSGdCbTy2+Mm5HTJvLGYSSeG9gDzNasJPP/yOYKLy+/cLG/ftrqq5fvkFwBJEw==
 
-vue-server-renderer@^2.6.12:
-  version "2.6.12"
-  resolved "https://registry.npmjs.org/vue-server-renderer/-/vue-server-renderer-2.6.12.tgz#a8cb9c49439ef205293cb41c35d0d2b0541653a5"
-  integrity sha512-3LODaOsnQx7iMFTBLjki8xSyOxhCtbZ+nQie0wWY4iOVeEtTg1a3YQAjd82WvKxrWHHTshjvLb7OXMc2/dYuxw==
+vue-server-renderer@^2.6.13:
+  version "2.6.13"
+  resolved "https://registry.npmjs.org/vue-server-renderer/-/vue-server-renderer-2.6.13.tgz#969757bb4393f53df4af29abf76f6ddd7f072ab6"
+  integrity sha512-jYcgnLjqCn/rDvBPAwADcLsl+ZA2tTM6VQnng6KSteWsunyeOIms0hJ7pR61T4tgTL40gWfkkkJY6HUgqZEUrg==
   dependencies:
     chalk "^1.1.3"
     hash-sum "^1.0.2"
@@ -13438,10 +13438,10 @@ vue-style-loader@^4.1.0, vue-style-loader@^4.1.3:
     hash-sum "^1.0.2"
     loader-utils "^1.0.2"
 
-vue-template-compiler@^2.6.12:
-  version "2.6.12"
-  resolved "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.12.tgz#947ed7196744c8a5285ebe1233fe960437fcc57e"
-  integrity sha512-OzzZ52zS41YUbkCBfdXShQTe69j1gQDZ9HIX8miuC9C3rBCk9wIRjLiZZLrmX9V+Ftq/YEyv1JaVr5Y/hNtByg==
+vue-template-compiler@^2.6.12, vue-template-compiler@^2.6.13:
+  version "2.6.13"
+  resolved "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.13.tgz#a735b8974e013ce829e7f77e08e4ee5aecbd3005"
+  integrity sha512-latKAqpUjCkovB8XppW5gnZbSdYQzkf8pavsMBZYZrQcG6lAnj0EH4Ty7jMwAwFw5Cf4mybKBHlp1UTjnLPOWw==
   dependencies:
     de-indent "^1.0.2"
     he "^1.1.0"
@@ -13451,10 +13451,10 @@ vue-template-es2015-compiler@^1.9.0:
   resolved "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz#1ee3bc9a16ecbf5118be334bb15f9c46f82f5825"
   integrity sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==
 
-vue@^2.6.12:
-  version "2.6.12"
-  resolved "https://registry.npmjs.org/vue/-/vue-2.6.12.tgz#f5ebd4fa6bd2869403e29a896aed4904456c9123"
-  integrity sha512-uhmLFETqPPNyuLLbsKz6ioJ4q7AZHzD8ZVFNATNyICSZouqP2Sz0rotWQC8UNBF6VGSCs5abnKJoStA6JbCbfg==
+vue@^2.6.13:
+  version "2.6.13"
+  resolved "https://registry.npmjs.org/vue/-/vue-2.6.13.tgz#94b2c1b31fddf1dfcc34f28ec848ba8f01ea4c5b"
+  integrity sha512-O+pAdJkce1ooYS1XyoQtpBQr9An+Oys3w39rkqxukVO3ZD1ilYJkWBGoRuadiQEm2LLJnCL2utV4TMSf52ubjw==
 
 vuex@^3.6.2:
   version "3.6.2"


### PR DESCRIPTION
## Description
https://github.com/vuejs/vue/releases/tag/v2.6.13

## Checklist:
- [x] All new and existing tests are passing.

