### PR TITLE
feat(vue-app): add layout id attribute configuration

### DIFF
--- a/packages/vue-app/template/App.js
+++ b/packages/vue-app/template/App.js
@@ -45,7 +45,7 @@ export default {
     const layoutEl = h(this.layout || 'nuxt')
     const templateEl = h('div', {
       domProps: {
-        id: '__layout'
+        id: '<%= globals.layoutId %>' || '__layout'
       },
       key: this.layoutName
     }, [layoutEl])


### PR DESCRIPTION
## Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Able to rename layout id attribute ('__layout') in nuxt.config.js: globals: { layoutId: 'my-layout' }


## Checklist:
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

