### PR TITLE
fix(vue-app): don't normalise route path if it's valid

### DIFF
--- a/packages/vue-app/template/index.js
+++ b/packages/vue-app/template/index.js
@@ -270,12 +270,14 @@ async function createApp(ssrContext, config = {}) {
 
   // Wait for async component to be resolved first
   await new Promise((resolve, reject) => {
-    const { route } = router.resolve(app.context.route.fullPath)
-    // Ignore 404s rather than blindly replacing URL
-    if (!route.matched.length && process.client) {
-      return resolve()
+    // Ignore 404s rather than blindly replacing URL in browser
+    if (process.client) {
+      const { route } = router.resolve(app.context.route.fullPath)
+      if (!route.matched.length) {
+        return resolve()
+      }
     }
-    router.replace(route, resolve, (err) => {
+    router.replace(app.context.route.fullPath, resolve, (err) => {
       // https://github.com/vuejs/vue-router/blob/v3.4.3/src/util/errors.js
       if (!err._isRouter) return reject(err)
       if (err.type !== 2 /* NavigationFailureType.redirected */) return resolve()


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)

## Description
After https://github.com/nuxt/nuxt.js/pull/9431 we were using the normalised path (which might, for example, lack a trailing slash if `trailingSlash: true` weren't set). This PR reverts that behaviour whilst keeping the fix, at the expense of a double implicit call to `router.resolve`.

Closes #9442

## Checklist:
- [x] All new and existing tests are passing.

