### PR TITLE
fix(vue-renderer): decode route path for `payload.js`

### DIFF
--- a/packages/vue-renderer/src/renderers/ssr.js
+++ b/packages/vue-renderer/src/renderers/ssr.js
@@ -210,7 +210,7 @@ export default class SSRRenderer extends BaseRenderer {
         // Page level payload.js (async loaded for CSR)
         const payloadPath = urlJoin(url, 'payload.js')
         const payloadUrl = urlJoin(staticAssetsBase, payloadPath)
-        const routePath = withoutTrailingSlash(decode(parsePath(url).pathname));
+        const routePath = withoutTrailingSlash(decode(parsePath(url).pathname))
         const payloadScript = `__NUXT_JSONP__("${routePath}", ${devalue({ data, fetch, mutations })});`
         staticAssets.push({ path: payloadPath, src: payloadScript })
         preloadScripts.push(payloadUrl)

--- a/packages/vue-renderer/src/renderers/ssr.js
+++ b/packages/vue-renderer/src/renderers/ssr.js
@@ -4,7 +4,7 @@ import { format } from 'util'
 import fs from 'fs-extra'
 import consola from 'consola'
 import { TARGETS, urlJoin } from '@nuxt/utils'
-import { parsePath, withoutTrailingSlash } from 'ufo'
+import { decode, parsePath, withoutTrailingSlash } from 'ufo'
 import devalue from '@nuxt/devalue'
 import { createBundleRenderer } from 'vue-server-renderer'
 import BaseRenderer from './base'
@@ -210,7 +210,7 @@ export default class SSRRenderer extends BaseRenderer {
         // Page level payload.js (async loaded for CSR)
         const payloadPath = urlJoin(url, 'payload.js')
         const payloadUrl = urlJoin(staticAssetsBase, payloadPath)
-        const routePath = withoutTrailingSlash(parsePath(url).pathname)
+        const routePath = withoutTrailingSlash(decode(parsePath(url).pathname));
         const payloadScript = `__NUXT_JSONP__("${routePath}", ${devalue({ data, fetch, mutations })});`
         staticAssets.push({ path: payloadPath, src: payloadScript })
         preloadScripts.push(payloadUrl)


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)

## Description
Previously the `payload.js` for a non-ascii route contained something like:
```js
__NUXT_JSONP__("/anv%C3%A4ndarhandledning", {data:[{slug:"användarhandledning"}],fetch:{},mutations:void 0});
```

With this fix we decode the `routePath` for the payload so we get instead:
```js
__NUXT_JSONP__("/användarhandledning", {data:[{slug:"användarhandledning"}],fetch:{},mutations:void 0});
```

This way we find the payload correctly (decoded payloads match):
* https://github.com/nuxt/nuxt.js/blob/9d33456e69a3bc74734461fa2eb866d2ceac490f/packages/vue-app/template/App.js#L321
* https://github.com/nuxt/nuxt.js/blob/9d33456e69a3bc74734461fa2eb866d2ceac490f/packages/vue-app/template/App.js#L331
 
resolves #9011, resolves #9297, resolves #9425

## Checklist:
- [x] All new and existing tests are passing.

