### PR TITLE
feat: browserslist config file support

### DIFF
--- a/packages/babel-preset-app/src/index.js
+++ b/packages/babel-preset-app/src/index.js
@@ -56,6 +56,17 @@ function getPolyfills (targets, includes, { ignoreBrowserslistConfig, configPath
   ))
 }
 
+function getTargetsFromBrowserslistRc (browserslistEnv = 'client') {
+  const { default: getTargets } = require('@babel/helper-compilation-targets')
+  const targets = getTargets(undefined, { browserslistEnv })
+
+  if (Object.keys(targets).length !== 0) {
+    return targets
+  } else {
+    return undefined
+  }
+}
+
 module.exports = (api, options = {}) => {
   const presets = []
   const plugins = []
@@ -70,7 +81,7 @@ module.exports = (api, options = {}) => {
     useBuiltIns = 'usage',
     modules = false,
     spec,
-    ignoreBrowserslistConfig = envName === 'modern',
+    ignoreBrowserslistConfig,
     configPath,
     include,
     exclude,
@@ -95,6 +106,10 @@ module.exports = (api, options = {}) => {
     server: { node: 'current' },
     client: { ie: 9 },
     modern: { esmodules: true }
+  }
+
+  if (envName !== 'server' && !options.targets) {
+    options.targets = getTargetsFromBrowserslistRc(envName)
   }
 
   const { targets = defaultTargets[envName] } = options


### PR DESCRIPTION
Add browserslist config file support

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
Resolves: #9337
After supporting modern browsers config in the Nuxt, there were two things that must be worked on it too:
1. Retrieve targets browsers from browserslist config file (.browserlistrc): With this RP, now the Nuxt users can configure their target browsers from a separate file. (that is used by other packages like Autoprifixer, etc too)
2. Target browsers detection on the server, which I reported in #9337 and I think @clarkdo working on it currently

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

