### PR TITLE
fix(utils): Router config `trailingSlash` causes error with dynamic nuxt-child routes

### DIFF
--- a/packages/utils/src/route.js
+++ b/packages/utils/src/route.js
@@ -56,11 +56,7 @@ function cleanChildrenRoutes (routes, isChild = false, routeNameSplitter = '-', 
     route.path = isChild ? route.path.replace('/', '') : route.path
     if (route.path.includes('?')) {
       if (route.name.endsWith(`${routeNameSplitter}index`)) {
-        if (trailingSlash) {
-          route.path = route.path.replace(/\?\/$/, '/')
-        } else {
-          route.path = route.path.replace(/\?$/, '')
-        }
+        route.path = route.path.replace(/\?\/?$/, trailingSlash ? '/' : '')
       }
       const names = route.name.replace(regExpParentRouteName, '').split(routeNameSplitter)
       const paths = route.path.split('/')

--- a/packages/utils/src/route.js
+++ b/packages/utils/src/route.js
@@ -56,7 +56,11 @@ function cleanChildrenRoutes (routes, isChild = false, routeNameSplitter = '-', 
     route.path = isChild ? route.path.replace('/', '') : route.path
     if (route.path.includes('?')) {
       if (route.name.endsWith(`${routeNameSplitter}index`)) {
-        route.path = route.path.replace(/\?$/, '')
+        if (trailingSlash) {
+          route.path = route.path.replace(/\?\/$/, '/')
+        } else {
+          route.path = route.path.replace(/\?$/, '')
+        }
       }
       const names = route.name.replace(regExpParentRouteName, '').split(routeNameSplitter)
       const paths = route.path.split('/')


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
fix #9472 
This bug existed because `trailingSlash = true` not been considered in a specific condition and exists regex missed it!

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

