### PR TITLE
fix(vue-app): re-register components construtor in HMR

### DIFF
--- a/packages/vue-app/template/client.js
+++ b/packages/vue-app/template/client.js
@@ -738,9 +738,8 @@ function hotReloadAPI(_app) {
 
   if (_app.context.isHMR) {
     const Components = getMatchedComponents(router.currentRoute)
-    const instances = getMatchedComponentsInstances(router.currentRoute)
-    instances.forEach((instance,index) => {
-      instance.constructor = Components[index]
+    Components.forEach((Component) => {
+      Component.prototype.constructor = Component
     })
   }
 }

--- a/packages/vue-app/template/client.js
+++ b/packages/vue-app/template/client.js
@@ -735,6 +735,14 @@ function hotReloadAPI(_app) {
   let $components = getNuxtChildComponents(_app.<%= globals.nuxt %>, [])
 
   $components.forEach(addHotReload.bind(_app))
+
+  if (_app.context.isHMR) {
+    const Components = getMatchedComponents(router.currentRoute)
+    const instances = getMatchedComponentsInstances(router.currentRoute)
+    instances.forEach((instance,index) => {
+      instance.constructor = Components[index]
+    })
+  }
 }
 
 function addHotReload ($component, depth) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

Fix https://github.com/nuxt/nuxt.js/issues/8501
closes https://github.com/nuxt/nuxt.js/pull/9077

We can see component instance and Component are not matching after hot reload, this pr is re-assigning correct constructor to component instance.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

