### PR TITLE
fix(babel): loose option for babel private-property-in-object

### DIFF
--- a/packages/babel-preset-app/src/index.js
+++ b/packages/babel-preset-app/src/index.js
@@ -137,7 +137,8 @@ module.exports = (api, options = {}) => {
         // but webpack 4 doesn't support the syntax when target supports and babel transpilation is skipped
         // https://github.com/webpack/webpack/issues/9708
         '@babel/plugin-proposal-class-properties',
-        '@babel/plugin-proposal-private-methods'
+        '@babel/plugin-proposal-private-methods',
+        '@babel/plugin-proposal-private-property-in-object'
       ],
       shippedProposals,
       forceAllTransforms
@@ -156,7 +157,8 @@ module.exports = (api, options = {}) => {
     }],
     // class-properties and private-methods need same loose value
     [require('@babel/plugin-proposal-class-properties'), { loose: true }],
-    [require('@babel/plugin-proposal-private-methods'), { loose: true }]
+    [require('@babel/plugin-proposal-private-methods'), { loose: true }],
+    [require('@babel/plugin-proposal-private-property-in-object'), { loose: true }]
   )
 
   // Transform runtime, but only for helpers


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->


Issue https://github.com/nuxt/nuxt.js/issues/9224#issuecomment-893224842

Similar fix to https://github.com/nuxt/nuxt.js/pull/9232.

`@babel/plugin-proposal-private-methods` has been added to @babel/preset-env now, but the syntax is not supported by webpack 4, so this pr is excluding it from preset-env and setting loose option as a seprate plugin.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

