### PR TITLE
fix(generator): throw an error when Builder is missing

### DIFF
--- a/packages/generator/src/generator.js
+++ b/packages/generator/src/generator.js
@@ -84,6 +84,12 @@ export default class Generator {
     await this.nuxt.callHook('export:before', this)
 
     if (build) {
+      if (!this.builder) {
+        throw new Error(
+          `Could not generate. Make sure a Builder instance is pass to the constructor of Generator class \
+or disable the build step: \`generate({ build: false })\``)
+      }
+
       // Add flag to set process.static
       this.builder.forGenerate()
 

--- a/packages/generator/src/generator.js
+++ b/packages/generator/src/generator.js
@@ -86,7 +86,7 @@ export default class Generator {
     if (build) {
       if (!this.builder) {
         throw new Error(
-          `Could not generate. Make sure a Builder instance is pass to the constructor of Generator class \
+          `Could not generate. Make sure a Builder instance is passed to the constructor of Generator class or `getGenerator` function \
 or disable the build step: \`generate({ build: false })\``)
       }
 

--- a/packages/generator/test/generator.init.test.js
+++ b/packages/generator/test/generator.init.test.js
@@ -98,6 +98,13 @@ describe('generator: initialize', () => {
     expect(generator.initDist).not.toBeCalled()
   })
 
+  test('should throw error when build is not disabled, but Builder instance is omitted', async () => {
+    const nuxt = createNuxt()
+    const generator = new Generator(nuxt)
+
+    await expect(generator.initiate()).rejects.toThrow('Could not generate')
+  })
+
   test('should init routes with generate.routes and routes.json', async () => {
     const nuxt = createNuxt()
     nuxt.options = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
As it was noted in #9574: currently Generator throws `TypeError: Cannot read property 'forGenerate' of undefined...` when Builder instance is missing.

The aim of this PR is to throw more useful error message.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

