### PR TITLE
chore(utils): improve `stripWhitespace` utility

### DIFF
--- a/packages/utils/src/lang.js
+++ b/packages/utils/src/lang.js
@@ -29,7 +29,8 @@ const WHITESPACE_REPLACEMENTS = [
   [/{\n{2,}/g, '{\n'], // strip start padding from blocks
   [/\n{2,}([ \t\f\r]*})/g, '\n$1'], // strip end padding from blocks
   [/\n{3,}/g, '\n\n'], // strip multiple blank lines (1 allowed)
-  [/\n{2,}$/g, '\n'] // strip blank lines EOF (0 allowed)
+  [/^\n+/, ''], // strip blank lines at the beginning of a string
+  [/\n{2,}$/, '\n'] // strip blank lines at the end of a string
 ]
 
 export const stripWhitespace = function stripWhitespace (string) {

--- a/packages/utils/test/lang.test.js
+++ b/packages/utils/test/lang.test.js
@@ -36,12 +36,12 @@ describe('util: lang', () => {
   })
 
   test('should strip white spaces in given argument', () => {
-    expect(stripWhitespace('foo')).toEqual('foo')
-    expect(stripWhitespace('foo\t\r\f\n')).toEqual('foo\n')
-    expect(stripWhitespace('foo{\n\n\n')).toEqual('foo{\n')
-    expect(stripWhitespace('\n\n\n\f\r\f}')).toEqual('\n\f\r\f}')
+    expect(stripWhitespace('foo\t\r \f\nbar')).toEqual('foo\nbar')
+    expect(stripWhitespace('foo{\n\n\nbar')).toEqual('foo{\nbar')
+    expect(stripWhitespace('foo\n\n\n\t \r\f}')).toEqual('foo\n\t \r\f}')
     expect(stripWhitespace('foo\n\n\nbar')).toEqual('foo\n\nbar')
-    expect(stripWhitespace('foo\n\n\n')).toEqual('foo\n')
+    expect(stripWhitespace('\n\nfoo\n')).toEqual('foo\n')
+    expect(stripWhitespace('foo\n\n')).toEqual('foo\n')
   })
 
   test('should encode html', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
This is a minor fix. I was playing with plugin templates and found that `stripWhitespace` utility is not removing empty lines if these appear at the beginning of a file. For instance, empty lines will be left if a template begins like this one:

```js
<% if (options.debug) { %>
import { debug } from '<%= options.import.path %>'
<% } %>
// rest of the file
```

A regexp was added to remove empty lines if they appear at the beginning of a file. `g`, global search flag seemed to be unnecessary, because globally there is just one beginning (or end) of a string. Or I missed something important? `g` is not included in the new regexp. For consistency I removed it in the regexp which was targeting the end of a string. (Alternatively `g` flag could be added to both.)

#### Test

After the change, the `expect` with `'\n\n\n\f\r\f}'` string was failing. I improved this and other tests by adding `foo` before (or `bar` after) `\n` as if these samples are taken from the middle of a string. Also after `strip multiple blank lines` regexp there must be only double `\n\n`s left in the string, so two last `expect`s simply checks double `\n\n`s.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

