### PR TITLE
fix(vue-renderer): ensure custom build indicator preserves some whitespace

### DIFF
--- a/packages/vue-renderer/src/renderer.js
+++ b/packages/vue-renderer/src/renderer.js
@@ -153,7 +153,8 @@ export default class VueRenderer {
 
     if (await fs.exists(loadingHTMLPath)) {
       this.serverContext.resources.loadingHTML = await fs.readFile(loadingHTMLPath, 'utf8')
-      this.serverContext.resources.loadingHTML = this.serverContext.resources.loadingHTML.replace(/\r|\n|[\t\s]{3,}/g, '')
+      this.serverContext.resources.loadingHTML =
+        this.serverContext.resources.loadingHTML.replace(/\r|\n/g, ' ').replace(/[\t\s]+/g, ' ')
     } else {
       this.serverContext.resources.loadingHTML = ''
     }


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)

## Description
Previously the custom whitespace removal util could end up removing all whitespace entirely, leaving code like:
```html
<imgsrc="https://nuxtjs.org/logos/nuxt.svg"alt="Nuxt Logo"draggable="false"oncontextmenu="return false;"  />
```

[**Reproduction**](https://codesandbox.io/s/nuxt-customloadingindicator-bug-i79yf)

This change ensures that at least a space remains after this minification.

resolves https://github.com/nuxt/nuxt.js/issues/9695

## Checklist:
- [x] All new and existing tests are passing.

