### PR TITLE
fix(vue-app): use correct `$config` for finding basePath

### DIFF
--- a/packages/vue-app/template/server.js
+++ b/packages/vue-app/template/server.js
@@ -58,7 +58,7 @@ const createNext = ssrContext => (opts) => {
     return
   }
   let fullPath = withQuery(opts.path, opts.query)
-  const $config = ssrContext.runtimeConfig || {}
+  const $config = ssrContext.nuxt.config || {}
   const routerBase = ($config._app && $config._app.basePath) || '<%= router.base %>'
   if (!fullPath.startsWith('http') && (routerBase !== '/' && !fullPath.startsWith(routerBase))) {
     fullPath = joinURL(routerBase, fullPath)


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)

## Description
`runtimeConfig` within `ssrContext` is still divided into `public` and `private`.

**Context**: issue introduced in https://github.com/nuxt/nuxt.js/pull/8520
**Resolves** https://github.com/nuxt/nuxt.js/issues/9625

## Checklist:
- [x] All new and existing tests are passing.

