### PR TITLE
fix(generator): decode path with `ufo`

### DIFF
--- a/packages/generator/src/generator.js
+++ b/packages/generator/src/generator.js
@@ -6,7 +6,7 @@ import fsExtra from 'fs-extra'
 import defu from 'defu'
 import htmlMinifier from 'html-minifier'
 import { parse } from 'node-html-parser'
-import { withTrailingSlash, withoutTrailingSlash } from 'ufo'
+import { withTrailingSlash, withoutTrailingSlash, decode } from 'ufo'
 
 import { isFullStatic, flatRoutes, isString, isUrl, promisifyRoute, urlJoin, waitFor, requireModule } from '@nuxt/utils'
 
@@ -353,7 +353,7 @@ or disable the build step: \`generate({ build: false })\``)
       // Save Static Assets
       if (this.staticAssetsDir && renderContext.staticAssets) {
         for (const asset of renderContext.staticAssets) {
-          const assetPath = path.join(this.staticAssetsDir, decodeURI(asset.path))
+          const assetPath = path.join(this.staticAssetsDir, decode(asset.path))
           await fsExtra.ensureDir(path.dirname(assetPath))
           await fsExtra.writeFile(assetPath, asset.src, 'utf-8')
         }


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)

## Description
Since https://github.com/unjs/ufo/pull/32 ([line](https://github.com/unjs/ufo/commit/7a663e21d1d0e7eec21be5c4b57eae9ad81cf590#diff-c5abec12c357835942040b8ee2c0986af6b16c4e26be8e861fc05b84f0078294R94)) `&` is encoded (and is not decoded by `decodeURI`). This means that `&` in a path component is being preserved as `%26` rather than decoded:
```js
encodeURI('test & another test')
// "test%20&%20another%20test"
decodeURI('test%20%26%20another%20test')
// "test %26 another test"
```

This PR uses the `decode` function from `ufo` to ensure consistency between encoding/decoding. (url is normalised with ufo [here](https://github.com/nuxt/nuxt.js/blob/b0147772ec98568b28ae80a7e97eca3381aa6a4e/packages/vue-renderer/src/renderer.js#L280))

resolves nuxt/nuxt.js#9734

## Checklist:
- [x] All new and existing tests are passing.

