### PR TITLE
chore(script): 'npm run test' fails because the last command lacks 'yarn'

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "ls-lint": "npx @ls-lint/ls-lint",
     "nuxt": "jiti ./packages/cli/bin/nuxt-cli.js",
     "pkg": "jiti ./scripts/pkg.js",
-    "test": "yarn test:fixtures && yarn test:dev && yarn test:unit && test:types",
+    "test": "yarn test:fixtures && yarn test:dev && yarn test:unit && yarn test:types",
     "test:dev": "jest test/dev --forceExit --runInBand",
     "test:e2e": "jest -i test/e2e --forceExit",
     "test:fixtures": "jest test/fixtures --forceExit",


### PR DESCRIPTION

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
the npm script "test" fails because the last command `test:types` lacks `yarn`.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

