### PR TITLE
test: fix error messages in dev/error test

### DIFF
--- a/test/dev/error.test.js
+++ b/test/dev/error.test.js
@@ -21,9 +21,8 @@ describe('error', () => {
   })
 
   test('/ should display an error', async () => {
-    await expect(nuxt.server.renderRoute('/error')).rejects.toMatchObject({
-      message: expect.stringContaining('not_defined is not defined')
-    })
+    await expect(nuxt.server.renderRoute('/error'))
+      .rejects.toThrow('not_defined is not defined')
   })
 
   test('/404 should display an error too', async () => {
@@ -38,7 +37,8 @@ describe('error', () => {
 
   test('Error: resolvePath()', () => {
     expect(() => nuxt.resolver.resolvePath()).toThrowError()
-    expect(() => nuxt.resolver.resolvePath('@/pages/not-found.vue')).toThrowError('Cannot resolve "@/pages/not-found.vue"')
+    expect(() => nuxt.resolver.resolvePath('@/pages/not-found.vue'))
+      .toThrow('Cannot resolve "@/pages/not-found.vue"')
   })
 
   test('Error: callHook()', async () => {
@@ -58,21 +58,18 @@ describe('error', () => {
   })
 
   test('/info should display an error', async () => {
-    await expect(nuxt.server.renderRoute('/info')).rejects.toMatchObject({
-      message: expect.stringContaining('Cannot read property \'title\' of undefined')
-    })
+    await expect(nuxt.server.renderRoute('/info'))
+      .rejects.toThrow('Cannot read properties of undefined (reading \'title\')')
   })
 
   test('/about should work', async () => {
-    await expect(nuxt.server.renderRoute('/about')).resolves.toMatchObject({
-      html: expect.stringContaining('About')
-    })
+    const { html } = await nuxt.server.renderRoute('/about')
+    expect(html).toContain('<h1>About</h1>')
   })
 
   test('/error-square should display an error', async () => {
-    await expect(nuxt.server.renderRoute('/squared')).rejects.toMatchObject({
-      message: expect.stringContaining('Cannot read property \'data\' of undefined')
-    })
+    await expect(nuxt.server.renderRoute('/squared'))
+      .rejects.toThrow('Cannot read properties of undefined (reading \'data\')')
   })
 
   // Close server and ask nuxt to stop listening to file changes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
While I was messing up with the code base, two tests of error messages in `dev/error.test.js` started to fail. It was strange, because these are related with `renderRoute`,  I did not touch anything even close to `renderRoute`. Better to take a look.

To check what is going on:
1. I copied the `error` fixture to separate location
2. took sample of the code from `renderRoute` [documentation](https://nuxtjs.org/docs/2.x/internals-glossary/nuxt-render-route)
3. and I was playing with it (without involving Jest or anything else)

Running this playground code I could see that expected:
`'Cannot read property 'title' of undefined'`
was throwing as:
`'Cannot read properties of undefined (reading 'title')'`

Back to testing. Bellow is what I see while running the test with commented out `consola.wrapConsole()` line (are the message documented in the tests wrong? or what is happening here?):

<img width="708" alt="Screenshot 2021-09-09 at 12 00 34" src="https://user-images.githubusercontent.com/72159681/132656349-4503050d-54db-4142-bf57-0bc980be3678.png">

Can’t explain the reasons. This PR is an attempt to fix the failing test or at least to understand what went wrong on my side.

The main fix are these two tests: '/info should display an error', '/error-square should display an error'. The rest are just a refactor for better readability and consistent style.

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.
