### PR TITLE
fix(vue-app): nuxt-child-key in web-types.json

### DIFF
--- a/packages/vue-app/web-types/web-types.json
+++ b/packages/vue-app/web-types/web-types.json
@@ -14,7 +14,7 @@
           "doc-url": "https://nuxtjs.org/api/components-nuxt",
           "attributes": [
             {
-              "name": "next-child-key",
+              "name": "nuxt-child-key",
               "value": {
                 "kind": "expression",
                 "type": "string"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

This is just a typo in a property of `Nuxt` component

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

PhpStorm is able to provide autocompletion thanks to `web-types.json` file. There is one property with a typo

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

