### PR TITLE
feat(cli): early return on static generation by error count

### DIFF
--- a/packages/cli/src/commands/generate.js
+++ b/packages/cli/src/commands/generate.js
@@ -111,7 +111,7 @@ export default {
     const { errors } = await generator.generate({
       init: true,
       build: cmd.argv.build,
-      failOnError: cmd.argv['fail-on-error']
+      maxErrors: cmd.argv['max-errors']
     })
 
     await nuxt.close()

--- a/packages/cli/src/commands/generate.js
+++ b/packages/cli/src/commands/generate.js
@@ -110,7 +110,8 @@ export default {
 
     const { errors } = await generator.generate({
       init: true,
-      build: cmd.argv.build
+      build: cmd.argv.build,
+      failOnError: cmd.argv['fail-on-error']
     })
 
     await nuxt.close()

--- a/packages/cli/src/utils/generate.js
+++ b/packages/cli/src/utils/generate.js
@@ -12,7 +12,7 @@ export async function generate (cmd) {
   const generator = await cmd.getGenerator(nuxt)
 
   await nuxt.server.listen(0)
-  const { errors } = await generator.generate({ build: false })
+  const { errors } = await generator.generate({ build: false, failOnError: cmd.argv['fail-on-error'] })
   await nuxt.close()
   if (cmd.argv['fail-on-error'] && errors.length > 0) {
     throw new Error('Error generating pages, exiting with non-zero code')

--- a/packages/cli/src/utils/generate.js
+++ b/packages/cli/src/utils/generate.js
@@ -12,7 +12,7 @@ export async function generate (cmd) {
   const generator = await cmd.getGenerator(nuxt)
 
   await nuxt.server.listen(0)
-  const { errors } = await generator.generate({ build: false, failOnError: cmd.argv['fail-on-error'] })
+  const { errors } = await generator.generate({ build: false, maxErrors: cmd.argv['max-errors'] })
   await nuxt.close()
   if (cmd.argv['fail-on-error'] && errors.length > 0) {
     throw new Error('Error generating pages, exiting with non-zero code')

--- a/packages/cli/test/unit/__snapshots__/webpack.test.js.snap
+++ b/packages/cli/test/unit/__snapshots__/webpack.test.js.snap
@@ -361,6 +361,10 @@ exports[`webpack nuxt webpack module.rules 1`] = `
                       },
                       Object {
                         "Declaration": [Function Declaration],
+                        "postcssPlugin": "postcss-exponential-functions",
+                      },
+                      Object {
+                        "Declaration": [Function Declaration],
                         "postcssPlugin": "postcss-clamp",
                       },
                       Object {
@@ -379,6 +383,7 @@ exports[`webpack nuxt webpack module.rules 1`] = `
                         "browsers": undefined,
                         "info": [Function info],
                         "options": Object {
+                          "env": undefined,
                           "overrideBrowserslist": undefined,
                         },
                         "postcssPlugin": "autoprefixer",
@@ -514,7 +519,7 @@ exports[`webpack nuxt webpack module.rules 1`] = `
                         "postcssPlugin": "cssnano-util-raw-cache",
                       },
                     ],
-                    "version": "8.4.25",
+                    "version": "8.4.27",
                   },
                 ],
               },
@@ -796,6 +801,10 @@ exports[`webpack nuxt webpack module.rules 1`] = `
                       },
                       Object {
                         "Declaration": [Function Declaration],
+                        "postcssPlugin": "postcss-exponential-functions",
+                      },
+                      Object {
+                        "Declaration": [Function Declaration],
                         "postcssPlugin": "postcss-clamp",
                       },
                       Object {
@@ -814,6 +823,7 @@ exports[`webpack nuxt webpack module.rules 1`] = `
                         "browsers": undefined,
                         "info": [Function info],
                         "options": Object {
+                          "env": undefined,
                           "overrideBrowserslist": undefined,
                         },
                         "postcssPlugin": "autoprefixer",
@@ -949,7 +959,7 @@ exports[`webpack nuxt webpack module.rules 1`] = `
                         "postcssPlugin": "cssnano-util-raw-cache",
                       },
                     ],
-                    "version": "8.4.25",
+                    "version": "8.4.27",
                   },
                 ],
               },
@@ -1237,6 +1247,10 @@ exports[`webpack nuxt webpack module.rules 1`] = `
                       },
                       Object {
                         "Declaration": [Function Declaration],
+                        "postcssPlugin": "postcss-exponential-functions",
+                      },
+                      Object {
+                        "Declaration": [Function Declaration],
                         "postcssPlugin": "postcss-clamp",
                       },
                       Object {
@@ -1255,6 +1269,7 @@ exports[`webpack nuxt webpack module.rules 1`] = `
                         "browsers": undefined,
                         "info": [Function info],
                         "options": Object {
+                          "env": undefined,
                           "overrideBrowserslist": undefined,
                         },
                         "postcssPlugin": "autoprefixer",
@@ -1390,7 +1405,7 @@ exports[`webpack nuxt webpack module.rules 1`] = `
                         "postcssPlugin": "cssnano-util-raw-cache",
                       },
                     ],
-                    "version": "8.4.25",
+                    "version": "8.4.27",
                   },
                 ],
               },
@@ -1672,6 +1687,10 @@ exports[`webpack nuxt webpack module.rules 1`] = `
                       },
                       Object {
                         "Declaration": [Function Declaration],
+                        "postcssPlugin": "postcss-exponential-functions",
+                      },
+                      Object {
+                        "Declaration": [Function Declaration],
                         "postcssPlugin": "postcss-clamp",
                       },
                       Object {
@@ -1690,6 +1709,7 @@ exports[`webpack nuxt webpack module.rules 1`] = `
                         "browsers": undefined,
                         "info": [Function info],
                         "options": Object {
+                          "env": undefined,
                           "overrideBrowserslist": undefined,
                         },
                         "postcssPlugin": "autoprefixer",
@@ -1825,7 +1845,7 @@ exports[`webpack nuxt webpack module.rules 1`] = `
                         "postcssPlugin": "cssnano-util-raw-cache",
                       },
                     ],
-                    "version": "8.4.25",
+                    "version": "8.4.27",
                   },
                 ],
               },
@@ -2113,6 +2133,10 @@ exports[`webpack nuxt webpack module.rules 1`] = `
                       },
                       Object {
                         "Declaration": [Function Declaration],
+                        "postcssPlugin": "postcss-exponential-functions",
+                      },
+                      Object {
+                        "Declaration": [Function Declaration],
                         "postcssPlugin": "postcss-clamp",
                       },
                       Object {
@@ -2131,6 +2155,7 @@ exports[`webpack nuxt webpack module.rules 1`] = `
                         "browsers": undefined,
                         "info": [Function info],
                         "options": Object {
+                          "env": undefined,
                           "overrideBrowserslist": undefined,
                         },
                         "postcssPlugin": "autoprefixer",
@@ -2266,7 +2291,7 @@ exports[`webpack nuxt webpack module.rules 1`] = `
                         "postcssPlugin": "cssnano-util-raw-cache",
                       },
                     ],
-                    "version": "8.4.25",
+                    "version": "8.4.27",
                   },
                 ],
               },
@@ -2554,6 +2579,10 @@ exports[`webpack nuxt webpack module.rules 1`] = `
                       },
                       Object {
                         "Declaration": [Function Declaration],
+                        "postcssPlugin": "postcss-exponential-functions",
+                      },
+                      Object {
+                        "Declaration": [Function Declaration],
                         "postcssPlugin": "postcss-clamp",
                       },
                       Object {
@@ -2572,6 +2601,7 @@ exports[`webpack nuxt webpack module.rules 1`] = `
                         "browsers": undefined,
                         "info": [Function info],
                         "options": Object {
+                          "env": undefined,
                           "overrideBrowserslist": undefined,
                         },
                         "postcssPlugin": "autoprefixer",
@@ -2707,7 +2737,7 @@ exports[`webpack nuxt webpack module.rules 1`] = `
                         "postcssPlugin": "cssnano-util-raw-cache",
                       },
                     ],
-                    "version": "8.4.25",
+                    "version": "8.4.27",
                   },
                 ],
               },
@@ -3001,6 +3031,10 @@ exports[`webpack nuxt webpack module.rules 1`] = `
                       },
                       Object {
                         "Declaration": [Function Declaration],
+                        "postcssPlugin": "postcss-exponential-functions",
+                      },
+                      Object {
+                        "Declaration": [Function Declaration],
                         "postcssPlugin": "postcss-clamp",
                       },
                       Object {
@@ -3019,6 +3053,7 @@ exports[`webpack nuxt webpack module.rules 1`] = `
                         "browsers": undefined,
                         "info": [Function info],
                         "options": Object {
+                          "env": undefined,
                           "overrideBrowserslist": undefined,
                         },
                         "postcssPlugin": "autoprefixer",
@@ -3154,7 +3189,7 @@ exports[`webpack nuxt webpack module.rules 1`] = `
                         "postcssPlugin": "cssnano-util-raw-cache",
                       },
                     ],
-                    "version": "8.4.25",
+                    "version": "8.4.27",
                   },
                 ],
               },
@@ -3445,6 +3480,10 @@ exports[`webpack nuxt webpack module.rules 1`] = `
                       },
                       Object {
                         "Declaration": [Function Declaration],
+                        "postcssPlugin": "postcss-exponential-functions",
+                      },
+                      Object {
+                        "Declaration": [Function Declaration],
                         "postcssPlugin": "postcss-clamp",
                       },
                       Object {
@@ -3463,6 +3502,7 @@ exports[`webpack nuxt webpack module.rules 1`] = `
                         "browsers": undefined,
                         "info": [Function info],
                         "options": Object {
+                          "env": undefined,
                           "overrideBrowserslist": undefined,
                         },
                         "postcssPlugin": "autoprefixer",
@@ -3598,7 +3638,7 @@ exports[`webpack nuxt webpack module.rules 1`] = `
                         "postcssPlugin": "cssnano-util-raw-cache",
                       },
                     ],
-                    "version": "8.4.25",
+                    "version": "8.4.27",
                   },
                 ],
               },
@@ -3895,6 +3935,10 @@ exports[`webpack nuxt webpack module.rules 1`] = `
                       },
                       Object {
                         "Declaration": [Function Declaration],
+                        "postcssPlugin": "postcss-exponential-functions",
+                      },
+                      Object {
+                        "Declaration": [Function Declaration],
                         "postcssPlugin": "postcss-clamp",
                       },
                       Object {
@@ -3913,6 +3957,7 @@ exports[`webpack nuxt webpack module.rules 1`] = `
                         "browsers": undefined,
                         "info": [Function info],
                         "options": Object {
+                          "env": undefined,
                           "overrideBrowserslist": undefined,
                         },
                         "postcssPlugin": "autoprefixer",
@@ -4048,7 +4093,7 @@ exports[`webpack nuxt webpack module.rules 1`] = `
                         "postcssPlugin": "cssnano-util-raw-cache",
                       },
                     ],
-                    "version": "8.4.25",
+                    "version": "8.4.27",
                   },
                 ],
               },
@@ -4336,6 +4381,10 @@ exports[`webpack nuxt webpack module.rules 1`] = `
                       },
                       Object {
                         "Declaration": [Function Declaration],
+                        "postcssPlugin": "postcss-exponential-functions",
+                      },
+                      Object {
+                        "Declaration": [Function Declaration],
                         "postcssPlugin": "postcss-clamp",
                       },
                       Object {
@@ -4354,6 +4403,7 @@ exports[`webpack nuxt webpack module.rules 1`] = `
                         "browsers": undefined,
                         "info": [Function info],
                         "options": Object {
+                          "env": undefined,
                           "overrideBrowserslist": undefined,
                         },
                         "postcssPlugin": "autoprefixer",
@@ -4489,7 +4539,7 @@ exports[`webpack nuxt webpack module.rules 1`] = `
                         "postcssPlugin": "cssnano-util-raw-cache",
                       },
                     ],
-                    "version": "8.4.25",
+                    "version": "8.4.27",
                   },
                 ],
               },
@@ -4783,6 +4833,10 @@ exports[`webpack nuxt webpack module.rules 1`] = `
                       },
                       Object {
                         "Declaration": [Function Declaration],
+                        "postcssPlugin": "postcss-exponential-functions",
+                      },
+                      Object {
+                        "Declaration": [Function Declaration],
                         "postcssPlugin": "postcss-clamp",
                       },
                       Object {
@@ -4801,6 +4855,7 @@ exports[`webpack nuxt webpack module.rules 1`] = `
                         "browsers": undefined,
                         "info": [Function info],
                         "options": Object {
+                          "env": undefined,
                           "overrideBrowserslist": undefined,
                         },
                         "postcssPlugin": "autoprefixer",
@@ -4936,7 +4991,7 @@ exports[`webpack nuxt webpack module.rules 1`] = `
                         "postcssPlugin": "cssnano-util-raw-cache",
                       },
                     ],
-                    "version": "8.4.25",
+                    "version": "8.4.27",
                   },
                 ],
               },
@@ -5224,6 +5279,10 @@ exports[`webpack nuxt webpack module.rules 1`] = `
                       },
                       Object {
                         "Declaration": [Function Declaration],
+                        "postcssPlugin": "postcss-exponential-functions",
+                      },
+                      Object {
+                        "Declaration": [Function Declaration],
                         "postcssPlugin": "postcss-clamp",
                       },
                       Object {
@@ -5242,6 +5301,7 @@ exports[`webpack nuxt webpack module.rules 1`] = `
                         "browsers": undefined,
                         "info": [Function info],
                         "options": Object {
+                          "env": undefined,
                           "overrideBrowserslist": undefined,
                         },
                         "postcssPlugin": "autoprefixer",
@@ -5377,7 +5437,7 @@ exports[`webpack nuxt webpack module.rules 1`] = `
                         "postcssPlugin": "cssnano-util-raw-cache",
                       },
                     ],
-                    "version": "8.4.25",
+                    "version": "8.4.27",
                   },
                 ],
               },

--- a/packages/generator/src/generator.js
+++ b/packages/generator/src/generator.js
@@ -47,7 +47,7 @@ export default class Generator {
     }
   }
 
-  async generate ({ build = true, init = true } = {}) {
+  async generate ({ build = true, init = true, failOnError = false } = {}) {
     consola.debug('Initializing generator...')
     await this.initiate({ build, init })
 
@@ -55,7 +55,7 @@ export default class Generator {
     const routes = await this.initRoutes()
 
     consola.info('Generating pages' + (this.isFullStatic ? ' with full static mode' : ''))
-    const errors = await this.generateRoutes(routes)
+    const errors = await this.generateRoutes(routes, failOnError)
 
     await this.afterGenerate()
 
@@ -168,7 +168,7 @@ or disable the build step: \`generate({ build: false })\``)
     return requireModule(path.join(this.options.buildDir, 'routes.json'))
   }
 
-  async generateRoutes (routes) {
+  async generateRoutes (routes, failOnError = false) {
     const errors = []
 
     this.routes = []
@@ -184,6 +184,9 @@ or disable the build step: \`generate({ build: false })\``)
     // Start generate process
     while (this.routes.length) {
       let n = 0
+      if (typeof failOnError === 'number' && errors.length >= failOnError) {
+        return errors
+      }
       await Promise.all(
         this.routes
           .splice(0, this.options.generate.concurrency)

--- a/packages/generator/src/generator.js
+++ b/packages/generator/src/generator.js
@@ -47,7 +47,7 @@ export default class Generator {
     }
   }
 
-  async generate ({ build = true, init = true, failOnError = false } = {}) {
+  async generate ({ build = true, init = true, maxErrors = undefined } = {}) {
     consola.debug('Initializing generator...')
     await this.initiate({ build, init })
 
@@ -55,7 +55,7 @@ export default class Generator {
     const routes = await this.initRoutes()
 
     consola.info('Generating pages' + (this.isFullStatic ? ' with full static mode' : ''))
-    const errors = await this.generateRoutes(routes, failOnError)
+    const errors = await this.generateRoutes(routes, maxErrors)
 
     await this.afterGenerate()
 
@@ -168,7 +168,7 @@ or disable the build step: \`generate({ build: false })\``)
     return requireModule(path.join(this.options.buildDir, 'routes.json'))
   }
 
-  async generateRoutes (routes, failOnError = false) {
+  async generateRoutes (routes, maxErrors = undefined) {
     const errors = []
     // Improve string representation for errors
     // TODO: Use consola for more consistency
@@ -187,7 +187,7 @@ or disable the build step: \`generate({ build: false })\``)
     // Start generate process
     while (this.routes.length) {
       let n = 0
-      if (typeof failOnError === 'number' && errors.length >= failOnError) {
+      if (typeof maxErrors === 'number' && errors.length >= maxErrors) {
         return errors
       }
       await Promise.all(

--- a/packages/generator/src/generator.js
+++ b/packages/generator/src/generator.js
@@ -170,6 +170,9 @@ or disable the build step: \`generate({ build: false })\``)
 
   async generateRoutes (routes, failOnError = false) {
     const errors = []
+    // Improve string representation for errors
+    // TODO: Use consola for more consistency
+    errors.toString = () => this._formatErrors(errors)
 
     this.routes = []
     this.generatedRoutes = new Set()
@@ -196,11 +199,6 @@ or disable the build step: \`generate({ build: false })\``)
           })
       )
     }
-
-    // Improve string representation for errors
-    // TODO: Use consola for more consistency
-    errors.toString = () => this._formatErrors(errors)
-
     return errors
   }
 

--- a/packages/generator/test/generator.gen.test.js
+++ b/packages/generator/test/generator.gen.test.js
@@ -42,7 +42,7 @@ describe('generator: generate routes', () => {
     expect(consola.info).toBeCalledTimes(1)
     expect(consola.info).toBeCalledWith('Generating pages')
     expect(generator.generateRoutes).toBeCalledTimes(1)
-    expect(generator.generateRoutes).toBeCalledWith(routes)
+    expect(generator.generateRoutes).toBeCalledWith(routes, false)
     expect(generator.afterGenerate).toBeCalledTimes(1)
     expect(nuxt.callHook).toBeCalledWith('generate:done', generator, errors)
   })

--- a/packages/generator/test/generator.gen.test.js
+++ b/packages/generator/test/generator.gen.test.js
@@ -42,7 +42,7 @@ describe('generator: generate routes', () => {
     expect(consola.info).toBeCalledTimes(1)
     expect(consola.info).toBeCalledWith('Generating pages')
     expect(generator.generateRoutes).toBeCalledTimes(1)
-    expect(generator.generateRoutes).toBeCalledWith(routes)
+    expect(generator.generateRoutes).toBeCalledWith(routes, undefined)
     expect(generator.afterGenerate).toBeCalledTimes(1)
     expect(nuxt.callHook).toBeCalledWith('generate:done', generator, errors)
   })

--- a/packages/generator/test/generator.gen.test.js
+++ b/packages/generator/test/generator.gen.test.js
@@ -42,7 +42,7 @@ describe('generator: generate routes', () => {
     expect(consola.info).toBeCalledTimes(1)
     expect(consola.info).toBeCalledWith('Generating pages')
     expect(generator.generateRoutes).toBeCalledTimes(1)
-    expect(generator.generateRoutes).toBeCalledWith(routes, false)
+    expect(generator.generateRoutes).toBeCalledWith(routes)
     expect(generator.afterGenerate).toBeCalledTimes(1)
     expect(nuxt.callHook).toBeCalledWith('generate:done', generator, errors)
   })


### PR DESCRIPTION
improve https://github.com/nuxt/nuxt.js/pull/9762 by [review](https://github.com/nuxt/nuxt.js/pull/9762#pullrequestreview-746625291)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
The command `nuxt generate --fail-on-error` returns error after all routes generation has completed even with 10,000+ routes.
However even if only 1 error occurs with any other generation succeeded the command will fail.
Thus, the command need to the way to exit early when the first error occurs.

In detail I have changed to return after the concurrency occurs specified counts of error.

This change will save the time of user.(Resolves: #9704)

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation. ()
- [x] I have updated the documentation accordingly. (PR: https://github.com/nuxt/docs/pull/2135)
- [x] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

