### PR TITLE
feat: default to `core-js` version 3

### DIFF
--- a/packages/babel-preset-app/package.json
+++ b/packages/babel-preset-app/package.json
@@ -23,7 +23,7 @@
     "@babel/preset-env": "^7.15.8",
     "@babel/runtime": "^7.15.4",
     "@vue/babel-preset-jsx": "^1.2.4",
-    "core-js": "^2.6.5",
+    "core-js": "^3.19.0",
     "core-js-compat": "^3.19.0",
     "regenerator-runtime": "^0.13.9"
   },

--- a/packages/cli/test/unit/__snapshots__/webpack.test.js.snap
+++ b/packages/cli/test/unit/__snapshots__/webpack.test.js.snap
@@ -76,7 +76,7 @@ exports[`webpack nuxt webpack module.rules 1`] = `
               \\"<nuxtDir>/packages/babel-preset-app/src/index.js\\",
               Object {
                 \\"corejs\\": Object {
-                  \\"version\\": 2,
+                  \\"version\\": 3,
                 },
               },
             ],
@@ -689,7 +689,7 @@ exports[`webpack nuxt webpack module.rules test=.jsx 1`] = `
             \\"<nuxtDir>/packages/babel-preset-app/src/index.js\\",
             Object {
               \\"corejs\\": Object {
-                \\"version\\": 2,
+                \\"version\\": 3,
               },
             },
           ],

--- a/packages/webpack/src/config/base.js
+++ b/packages/webpack/src/config/base.js
@@ -125,7 +125,7 @@ export default class WebpackBaseConfig {
       try {
         corejsVersion = Number.parseInt(requireModule('core-js/package.json', rootDir).version.split('.')[0])
       } catch (_err) {
-        corejsVersion = 2
+        corejsVersion = 3
       }
     } else {
       corejsVersion = Number.parseInt(corejsVersion)
@@ -133,7 +133,7 @@ export default class WebpackBaseConfig {
 
     if (![2, 3].includes(corejsVersion)) {
       consola.warn(`Invalid corejs version ${corejsVersion}! Please set "build.corejs" to either "auto", 2 or 3.`)
-      corejsVersion = 2
+      corejsVersion = 3
     }
 
     const defaultPreset = [this.resolveModule('@nuxt/babel-preset-app'), {

--- a/test/dev/async-config.size-limit.test.js
+++ b/test/dev/async-config.size-limit.test.js
@@ -20,26 +20,26 @@ describe('nuxt basic resources size limit', () => {
   it('should stay within the size limit range in legacy mode', async () => {
     const legacyResourcesSize = await getResourcesSize(distDir, 'client', { gzip: true, brotli: true })
 
-    const LEGACY_JS_RESOURCES_KB_SIZE = 217
+    const LEGACY_JS_RESOURCES_KB_SIZE = 240
     expect(legacyResourcesSize.uncompressed).toBeWithinSize(LEGACY_JS_RESOURCES_KB_SIZE)
 
-    const LEGACY_JS_RESOURCES_GZIP_KB_SIZE = 75
+    const LEGACY_JS_RESOURCES_GZIP_KB_SIZE = 83
     expect(legacyResourcesSize.gzip).toBeWithinSize(LEGACY_JS_RESOURCES_GZIP_KB_SIZE)
 
-    const LEGACY_JS_RESOURCES_BROTLI_KB_SIZE = 64
+    const LEGACY_JS_RESOURCES_BROTLI_KB_SIZE = 72
     expect(legacyResourcesSize.brotli).toBeWithinSize(LEGACY_JS_RESOURCES_BROTLI_KB_SIZE)
   })
 
   it('should stay within the size limit range in modern mode', async () => {
     const modernResourcesSize = await getResourcesSize(distDir, 'modern', { gzip: true, brotli: true })
 
-    const MODERN_JS_RESOURCES_KB_SIZE = 180
+    const MODERN_JS_RESOURCES_KB_SIZE = 210
     expect(modernResourcesSize.uncompressed).toBeWithinSize(MODERN_JS_RESOURCES_KB_SIZE)
 
-    const MODERN_JS_RESOURCES_GZIP_KB_SIZE = 64
+    const MODERN_JS_RESOURCES_GZIP_KB_SIZE = 73
     expect(modernResourcesSize.gzip).toBeWithinSize(MODERN_JS_RESOURCES_GZIP_KB_SIZE)
 
-    const MODERN_JS_RESOURCES_BROTLI_KB_SIZE = 58
+    const MODERN_JS_RESOURCES_BROTLI_KB_SIZE = 64
     expect(modernResourcesSize.brotli).toBeWithinSize(MODERN_JS_RESOURCES_BROTLI_KB_SIZE)
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -4618,10 +4618,10 @@ core-js-compat@^3.16.0, core-js-compat@^3.16.2, core-js-compat@^3.19.0:
     browserslist "^4.17.5"
     semver "7.0.0"
 
-core-js@^2.6.5:
-  version "2.6.12"
-  resolved "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
-  integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
+core-js@^3.19.0:
+  version "3.19.0"
+  resolved "https://registry.npmjs.org/core-js/-/core-js-3.19.0.tgz#9e40098a9bc326c7e81b486abbd5e12b9d275176"
+  integrity sha512-L1TpFRWXZ76vH1yLM+z6KssLZrP8Z6GxxW4auoCj+XiViOzNPJCAuTIkn03BGdFe6Z5clX5t64wRIRypsZQrUg==
 
 core-util-is@1.0.2:
   version "1.0.2"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


## Description

This PR upgrades the Nuxt `core-js` dependency to v3. Users can still opt-in to old `core-js@2` version if they want by installing the package at root-level, although this is not advised.

```
warning core-js@2.6.12: core-js@<3.3 is no longer maintained and not
recommended for usage due to the number of issues. Because of the V8
engine whims, feature detection in old core-js versions could cause
a slowdown up to 100x even if nothing is polyfilled. Please, upgrade
your dependencies to the actual version of core-js.
```

closes https://github.com/nuxt/nuxt.js/issues/9851

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

