### PR TITLE
chore(deps): update sass-loader to v10.2.0

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -29,7 +29,7 @@
     "@types/webpack-bundle-analyzer": "3.9.3",
     "@types/webpack-dev-middleware": "4.1.2",
     "@types/webpack-hot-middleware": "2.25.5",
-    "sass-loader": "10.1.1"
+    "sass-loader": "10.2.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Adds support for node-sass v6, which `nuxt-cookie-control` requires.

## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

