### PR TITLE
fix(vue-app): call ssrContext.unsetMutationObserver only if it exists

### DIFF
--- a/packages/vue-app/template/server.js
+++ b/packages/vue-app/template/server.js
@@ -134,7 +134,10 @@ export default async (ssrContext) => {
 
       <% if (isFullStatic && store) { %>
       // Stop recording store mutations
-      ssrContext.unsetMutationObserver && ssrContext.unsetMutationObserver()
+      // unsetMutationObserver is only set after all router middleware are evaluated
+      if (ssrContext.unsetMutationObserver) {
+        ssrContext.unsetMutationObserver()
+      }
       <% } %>
     }
   }

--- a/packages/vue-app/template/server.js
+++ b/packages/vue-app/template/server.js
@@ -134,7 +134,7 @@ export default async (ssrContext) => {
 
       <% if (isFullStatic && store) { %>
       // Stop recording store mutations
-      ssrContext.unsetMutationObserver()
+      ssrContext.unsetMutationObserver && ssrContext.unsetMutationObserver()
       <% } %>
     }
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Resolves: #10131
`ssrContext.unsetMutationObserver` is set after router middleware are evaluated. This causes a problem because if a middleware calls `error`, then the app calls `renderErrorPage` which in turns calls `ssrContext.unsetMutationObserver()` in the `beforeRender` function, causing an error.

[https://github.com/nuxt/nuxt.js/blob/dev/packages/vue-app/template/server.js#L137](https://github.com/nuxt/nuxt.js/blob/dev/packages/vue-app/template/server.js#L137)
[https://github.com/nuxt/nuxt.js/blob/dev/packages/vue-app/template/server.js#L209](https://github.com/nuxt/nuxt.js/blob/dev/packages/vue-app/template/server.js#209)
[https://github.com/nuxt/nuxt.js/blob/dev/packages/vue-app/template/server.js#L216](https://github.com/nuxt/nuxt.js/blob/dev/packages/vue-app/template/server.js#L216)


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

