### PR TITLE
refactor(config,vue-app): change back to app namespace

### DIFF
--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -455,7 +455,7 @@ export function getNuxtConfig (_options) {
   const isRelativePublicPath = isRelative(options.build.publicPath)
 
   options.app = defu(options.app, {
-    basePath: options.router.base,
+    baseURL: options.router.base,
     buildAssetsPath: isRelativePublicPath ? options.build.publicPath : useCDN ? '/' : joinURL(options.router.base, options.build.publicPath),
     cdnURL: useCDN ? options.build.publicPath : null
   })

--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -456,12 +456,13 @@ export function getNuxtConfig (_options) {
 
   options.app = defu(options.app, {
     basePath: options.router.base,
-    assetsPath: isRelativePublicPath ? options.build.publicPath : useCDN ? '/' : joinURL(options.router.base, options.build.publicPath),
+    buildAssetsPath: isRelativePublicPath ? options.build.publicPath : useCDN ? '/' : joinURL(options.router.base, options.build.publicPath),
     cdnURL: useCDN ? options.build.publicPath : null
   })
   // Expose app config to $config._app
   options.publicRuntimeConfig = options.publicRuntimeConfig || {}
-  options.publicRuntimeConfig._app = options.app
+  Object.assign(options.app, options.publicRuntimeConfig.app)
+  options.publicRuntimeConfig.app = options.app
 
   // Generate staticAssets
   const { staticAssets } = options.generate
@@ -469,7 +470,7 @@ export function getNuxtConfig (_options) {
     staticAssets.version = String(Math.round(Date.now() / 1000))
   }
   if (!staticAssets.base) {
-    staticAssets.base = joinURL(options.app.assetsPath, staticAssets.dir)
+    staticAssets.base = joinURL(options.app.buildAssetsPath, staticAssets.dir)
   }
   if (!staticAssets.versionBase) {
     staticAssets.versionBase = joinURL(staticAssets.base, staticAssets.version)

--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -459,7 +459,7 @@ export function getNuxtConfig (_options) {
     buildAssetsPath: isRelativePublicPath ? options.build.publicPath : useCDN ? '/' : joinURL(options.router.base, options.build.publicPath),
     cdnURL: useCDN ? options.build.publicPath : null
   })
-  // Expose app config to $config._app
+  // Expose app config to $config.app
   options.publicRuntimeConfig = options.publicRuntimeConfig || {}
   Object.assign(options.app, options.publicRuntimeConfig.app)
   options.publicRuntimeConfig.app = options.app

--- a/packages/config/test/__snapshots__/options.test.js.snap
+++ b/packages/config/test/__snapshots__/options.test.js.snap
@@ -20,7 +20,7 @@ Object {
     "~~": "/var/nuxt/test",
   },
   "app": Object {
-    "basePath": "/",
+    "baseURL": "/",
     "buildAssetsPath": "/_nuxt/",
     "cdnURL": null,
   },
@@ -325,7 +325,7 @@ Object {
   "privateRuntimeConfig": Object {},
   "publicRuntimeConfig": Object {
     "app": Object {
-      "basePath": "/",
+      "baseURL": "/",
       "buildAssetsPath": "/_nuxt/",
       "cdnURL": null,
     },

--- a/packages/config/test/__snapshots__/options.test.js.snap
+++ b/packages/config/test/__snapshots__/options.test.js.snap
@@ -20,8 +20,8 @@ Object {
     "~~": "/var/nuxt/test",
   },
   "app": Object {
-    "buildAssetsPath": "/_nuxt/",
     "basePath": "/",
+    "buildAssetsPath": "/_nuxt/",
     "cdnURL": null,
   },
   "appTemplatePath": "/var/nuxt/test/.nuxt/views/app.template.html",
@@ -324,9 +324,9 @@ Object {
   "plugins": Array [],
   "privateRuntimeConfig": Object {},
   "publicRuntimeConfig": Object {
-    "_app": Object {
-      "buildAssetsPath": "/_nuxt/",
+    "app": Object {
       "basePath": "/",
+      "buildAssetsPath": "/_nuxt/",
       "cdnURL": null,
     },
   },

--- a/packages/config/test/__snapshots__/options.test.js.snap
+++ b/packages/config/test/__snapshots__/options.test.js.snap
@@ -20,7 +20,7 @@ Object {
     "~~": "/var/nuxt/test",
   },
   "app": Object {
-    "assetsPath": "/_nuxt/",
+    "buildAssetsPath": "/_nuxt/",
     "basePath": "/",
     "cdnURL": null,
   },
@@ -325,7 +325,7 @@ Object {
   "privateRuntimeConfig": Object {},
   "publicRuntimeConfig": Object {
     "_app": Object {
-      "assetsPath": "/_nuxt/",
+      "buildAssetsPath": "/_nuxt/",
       "basePath": "/",
       "cdnURL": null,
     },

--- a/packages/vue-app/template/client.js
+++ b/packages/vue-app/template/client.js
@@ -50,7 +50,7 @@ const NUXT = window.<%= globals.context %> || {}
 
 const $config = NUXT.config || {}
 if ($config._app) {
-  __webpack_public_path__ = urlJoin($config._app.cdnURL, $config._app.assetsPath)
+  __webpack_public_path__ = urlJoin($config.app.cdnURL, $config.app.buildAssetsPath)
 }
 
 Object.assign(Vue.config, <%= serialize(vue.config) %>)<%= isTest ? '// eslint-disable-line' : '' %>

--- a/packages/vue-app/template/client.js
+++ b/packages/vue-app/template/client.js
@@ -49,7 +49,7 @@ let router
 const NUXT = window.<%= globals.context %> || {}
 
 const $config = NUXT.config || {}
-if ($config._app) {
+if ($config.app) {
   __webpack_public_path__ = urlJoin($config.app.cdnURL, $config.app.buildAssetsPath)
 }
 

--- a/packages/vue-app/template/router.js
+++ b/packages/vue-app/template/router.js
@@ -102,7 +102,7 @@ export const routerOptions = {
 }
 
 export function createRouter (ssrContext, config) {
-  const base = (config._app && config._app.basePath) || routerOptions.base
+  const base = (config.app && config.app.basePath) || routerOptions.base
   const router = new Router({ ...routerOptions, base  })
 
   // TODO: remove in Nuxt 3

--- a/packages/vue-app/template/router.js
+++ b/packages/vue-app/template/router.js
@@ -102,7 +102,7 @@ export const routerOptions = {
 }
 
 export function createRouter (ssrContext, config) {
-  const base = (config.app && config.app.basePath) || routerOptions.base
+  const base = (config.app && config.app.baseURL) || routerOptions.base
   const router = new Router({ ...routerOptions, base  })
 
   // TODO: remove in Nuxt 3

--- a/packages/vue-app/template/server.js
+++ b/packages/vue-app/template/server.js
@@ -59,7 +59,7 @@ const createNext = ssrContext => (opts) => {
   }
   let fullPath = withQuery(opts.path, opts.query)
   const $config = ssrContext.nuxt.config || {}
-  const routerBase = ($config.app && $config.app.basePath) || '<%= router.base %>'
+  const routerBase = ($config.app && $config.app.baseURL) || '<%= router.base %>'
   if (!fullPath.startsWith('http') && (routerBase !== '/' && !fullPath.startsWith(routerBase))) {
     fullPath = joinURL(routerBase, fullPath)
   }

--- a/packages/vue-app/template/server.js
+++ b/packages/vue-app/template/server.js
@@ -59,7 +59,7 @@ const createNext = ssrContext => (opts) => {
   }
   let fullPath = withQuery(opts.path, opts.query)
   const $config = ssrContext.nuxt.config || {}
-  const routerBase = ($config._app && $config._app.basePath) || '<%= router.base %>'
+  const routerBase = ($config.app && $config.app.basePath) || '<%= router.base %>'
   if (!fullPath.startsWith('http') && (routerBase !== '/' && !fullPath.startsWith(routerBase))) {
     fullPath = joinURL(routerBase, fullPath)
   }
@@ -102,7 +102,7 @@ export default async (ssrContext) => {
   // Public runtime config
   ssrContext.nuxt.config = ssrContext.runtimeConfig.public
   if (ssrContext.nuxt.config._app) {
-    __webpack_public_path__ = joinURL(ssrContext.nuxt.config._app.cdnURL, ssrContext.nuxt.config._app.assetsPath)
+    __webpack_public_path__ = joinURL(ssrContext.nuxt.config.app.cdnURL, ssrContext.nuxt.config.app.buildAssetsPath)
   }
   // Create the app definition and the instance (created for each request)
   const { app, router<%= (store ? ', store' : '') %> } = await createApp(ssrContext, ssrContext.runtimeConfig.private)

--- a/packages/vue-app/template/server.js
+++ b/packages/vue-app/template/server.js
@@ -101,7 +101,7 @@ export default async (ssrContext) => {
   <% } %>
   // Public runtime config
   ssrContext.nuxt.config = ssrContext.runtimeConfig.public
-  if (ssrContext.nuxt.config._app) {
+  if (ssrContext.nuxt.config.app) {
     __webpack_public_path__ = joinURL(ssrContext.nuxt.config.app.cdnURL, ssrContext.nuxt.config.app.buildAssetsPath)
   }
   // Create the app definition and the instance (created for each request)

--- a/packages/vue-renderer/src/renderer.js
+++ b/packages/vue-renderer/src/renderer.js
@@ -312,7 +312,7 @@ export default class VueRenderer {
   }
 
   get resourceMap () {
-    const publicPath = urlJoin(this.options.app.cdnURL, this.options.app.assetsPath)
+    const publicPath = urlJoin(this.options.app.cdnURL, this.options.app.buildAssetsPath)
     return {
       clientManifest: {
         fileName: 'client.manifest.json',

--- a/test/dev/basic.dynamic.test.js
+++ b/test/dev/basic.dynamic.test.js
@@ -55,9 +55,9 @@ describe('basic ssr', () => {
 
     expect(window.document.body.innerHTML).toContain('<h1>Index page</h1>')
 
-    expect(window.__NUXT__.config._app.basePath).toBe('/path/')
-    expect(window.__NUXT__.config._app.cdnURL).toBe('https://cdn.nuxtjs.org/')
-    expect(window.__NUXT__.config._app.assetsPath).toBe('/')
+    expect(window.__NUXT__.config.app.basePath).toBe('/path/')
+    expect(window.__NUXT__.config.app.cdnURL).toBe('https://cdn.nuxtjs.org/')
+    expect(window.__NUXT__.config.app.buildAssetsPath).toBe('/')
 
     expect(fetchCount).toBeGreaterThan(0)
   })

--- a/test/dev/basic.dynamic.test.js
+++ b/test/dev/basic.dynamic.test.js
@@ -55,7 +55,7 @@ describe('basic ssr', () => {
 
     expect(window.document.body.innerHTML).toContain('<h1>Index page</h1>')
 
-    expect(window.__NUXT__.config.app.basePath).toBe('/path/')
+    expect(window.__NUXT__.config.app.baseURL).toBe('/path/')
     expect(window.__NUXT__.config.app.cdnURL).toBe('https://cdn.nuxtjs.org/')
     expect(window.__NUXT__.config.app.buildAssetsPath).toBe('/')
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


## Description
For parity with Nuxt 3, this changes the _names_ (but not the behaviour) of `app.assetsPath` -> `app.buildAssetsPath` and `publicRuntimeConfig._app` -> `publicRuntimeConfig.app`.

Nuxt should merge the app config with any existing properties in `publicRuntimeConfig.app` to minimise the impact, but still this should be recognised as a breaking change.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [x] All new and existing tests are passing.

