### PR TITLE
fix(webpack): allow transpilation of .cjs files

### DIFF
--- a/packages/webpack/src/config/base.js
+++ b/packages/webpack/src/config/base.js
@@ -329,7 +329,7 @@ export default class WebpackBaseConfig {
         ]
       },
       {
-        test: /\.m?jsx?$/i,
+        test: /\.[mc]?jsx?$/i,
         type: 'javascript/auto',
         exclude: (file) => {
           file = file.split(/node_modules(.*)/)[1]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

When trying to transpile a file from `node_modules` through the `build.transpile` property, files ending with `.cjs` were previously ignored.

This PR fixes it.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

