### PR TITLE
Custom transition for specific NuxtChild

### DIFF
--- a/packages/vue-app/template/components/nuxt-child.js
+++ b/packages/vue-app/template/components/nuxt-child.js
@@ -7,6 +7,7 @@ export default {
       type: String,
       default: ''
     },
+    transition: Object,
     keepAlive: Boolean,
     keepAliveProps: {
       type: Object,
@@ -29,7 +30,7 @@ export default {
       parent = parent.$parent
     }
     data.nuxtChildDepth = depth
-    const transition = transitions[depth] || defaultTransition
+    const transition = props.transition || transitions[depth] || defaultTransition
     const transitionProps = {}
     transitionsKeys.forEach((key) => {
       if (typeof transition[key] !== 'undefined') {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->

Hello friends.
I'm playing with named views in Nuxt (2.18) - i would like to attach a specific transition only to one view.

So far i could not find a way to give any <NuxtChild> a specific transition.
Looking at the source code it apparently always inherit either parent's or global transition.

Above is a simple change i made that allowed me to pass a transition object to my NuxtChild.

```html
<div id="page">
    <nav id="navigation">
        <NuxtChild name="left" :transition="{name:'nav'}"/>
    </nav>
      
    <main>
        <NuxtChild/>
    </main>
</div>
```

Do you think this is worth pursuing with this change ?
Or maybe there is a native solution to this.

Thank you, good day

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

