### PR TITLE
Move CSS imports before all component imports

### DIFF
--- a/packages/vue-app/template/App.js
+++ b/packages/vue-app/template/App.js
@@ -13,12 +13,16 @@ import { decode, parsePath, withoutBase, withoutTrailingSlash, normalizeURL } fr
   ]: []
 ] %>
 <% if (utilsImports.length) { %>import { <%= utilsImports.join(', ') %> } from './utils'<% } %>
-import NuxtError from '<%= components.ErrorPage ? components.ErrorPage : "./components/nuxt-error.vue" %>'
-<% if (loading) { %>import NuxtLoading from '<%= (typeof loading === "string" ? loading : "./components/nuxt-loading.vue") %>'<% } %>
-<% if (buildIndicator) { %>import NuxtBuildIndicator from './components/nuxt-build-indicator'<% } %>
+
+// Import CSS before importing any Vue components which might rely on overriding static CSS
+// styles applied in these files 
 <% css.forEach((c) => { %>
 import '<%= relativeToBuild(resolvePath(c.src || c, { isStyle: true })) %>'
 <% }) %>
+
+import NuxtError from '<%= components.ErrorPage ? components.ErrorPage : "./components/nuxt-error.vue" %>'
+<% if (loading) { %>import NuxtLoading from '<%= (typeof loading === "string" ? loading : "./components/nuxt-loading.vue") %>'<% } %>
+<% if (buildIndicator) { %>import NuxtBuildIndicator from './components/nuxt-build-indicator'<% } %>
 
 <% if (features.layouts) { %>
 <%= Object.keys(layouts).map((key) => {

--- a/packages/vue-app/template/index.js
+++ b/packages/vue-app/template/index.js
@@ -4,10 +4,10 @@ import Vue from 'vue'
 <% if (features.componentClientOnly) { %>import ClientOnly from 'vue-client-only'<% } %>
 <% if (features.deprecations) { %>import NoSsr from 'vue-no-ssr'<% } %>
 import { createRouter } from './router.js'
+import App from '<%= appPath %>'
 import NuxtChild from './components/nuxt-child.js'
 import NuxtError from '<%= components.ErrorPage ? components.ErrorPage : "./components/nuxt-error.vue" %>'
 import Nuxt from './components/nuxt.js'
-import App from '<%= appPath %>'
 import { setContext, getLocation, getRouteData, normalizeError } from './utils'
 <% if (store) { %>import { createStore } from './store.js'<% } %>
 


### PR DESCRIPTION
This prevents components from defining styles that depend on
the stylesheets specified in the `css` option being applied
first, for example, when utilizing the "cascading" nature of
CSS to override specific reset styles.

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
I wish I had a small reproduction example of the issue I'm running into over on https://github.com/WordPress/openverse-frontend. I tried to re-create the issue in a [Codesandbox here](https://codesandbox.io/s/eager-glade-gewem) but I couldn't get the same behavior to happen.

Potentially there is just a configuration issue with Openverse frontend that is causing this to happen in the first place. I've tested this specific change locally by modifying the files in `node_modules` in Openverse. The issue we're running into is described here: https://github.com/WordPress/openverse-frontend/pull/852#issuecomment-1036358266

Notable this doesn't seem to effect the production build at all, it's purely an issue with the development build. I suspect that something in Openverse's specific development configuration is what's preventing me from finding a minimal reproduction in that code sandbox. I know it's a big ask but if any maintainers spot something obvious in our `nuxt.config.js` for example that is causing this, happy to solve it that way.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

Locally I am getting an error when running the tests about the error page test not being able to read `data` of undefined not happening. It's not clear to me what would have caused this to fail in my changes, though the error template import in particular is the problematic one as it's the only component that gets imported before the `options.css` list that could contain CSS dependent on the configured static css assets.

I'm also not sure exactly how to add tests to cover this change, other than potentially making assertions about the output string of the vue-app template compilation.