### PR TITLE
chore: run CI using Node 16

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,6 +7,12 @@ on:
 jobs:
   nightly:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node: [14, 16]
+
     steps:
       - uses: actions/checkout@v2
         with:
@@ -16,7 +22,7 @@ jobs:
         run: git fetch --depth=1 origin "+refs/tags/*:refs/tags/*"
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: ${{ matrix.node }}
           registry-url: 'https://registry.npmjs.org'
       - name: install
         run: yarn --check-files --frozen-lockfile --non-interactive

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         # os: [ubuntu-latest, macos-latest, windows-latest]
         os: [ubuntu-latest]
-        node: [12, 14]
+        node: [12, 14, 16]
 
     steps:
       - uses: actions/setup-node@v2
@@ -63,7 +63,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [14]
+        node: [14, 16]
 
     steps:
       - uses: actions/setup-node@v2
@@ -96,7 +96,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [14]
+        node: [14, 16]
 
     steps:
       - uses: actions/setup-node@v2
@@ -127,7 +127,7 @@ jobs:
       matrix:
         # os: [ubuntu-latest, macos-latest, windows-latest]
         os: [ubuntu-latest]
-        node: [12, 14]
+        node: [12, 14, 16]
 
     steps:
       - uses: actions/setup-node@v2
@@ -164,7 +164,7 @@ jobs:
       matrix:
         # os: [ubuntu-latest, macos-latest, windows-latest]
         os: [ubuntu-latest]
-        node: [12, 14]
+        node: [12, 14, 16]
 
     env:
       NODE_OPTIONS: "--max_old_space_size=4096"
@@ -203,7 +203,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [14]
+        node: [14, 16]
 
     steps:
       - uses: actions/setup-node@v2
@@ -240,7 +240,7 @@ jobs:
       matrix:
         # os: [ubuntu-latest, macos-latest, windows-latest]
         os: [ubuntu-latest]
-        node: [12, 14]
+        node: [12, 14, 16]
 
     steps:
       - uses: actions/setup-node@v2
@@ -277,7 +277,7 @@ jobs:
       matrix:
         # os: [ubuntu-latest, macos-latest, windows-latest]
         os: [ubuntu-latest]
-        node: [12, 14]
+        node: [12, 14, 16]
 
     steps:
       - uses: actions/setup-node@v2
@@ -313,7 +313,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [14]
+        node: [14, 16]
 
     steps:
       - name: checkout

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        node: [14]
+        node: [14, 16]
 
     steps:
       - uses: actions/setup-node@v2
@@ -58,7 +58,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        node: [14]
+        node: [14, 16]
 
     env:
       NODE_OPTIONS: "--max_old_space_size=4096"
@@ -92,7 +92,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        node: [14]
+        node: [14, 16]
 
     env:
       NODE_OPTIONS: "--max_old_space_size=4096"
@@ -131,7 +131,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        node: [14]
+        node: [14, 16]
 
     env:
       NODE_OPTIONS: "--max_old_space_size=4096"


### PR DESCRIPTION
The [Installation](https://nuxtjs.org/docs/get-started/installation) guide suggests having "the latest LTS version installed". However, Nuxt.js isn't currently tested against Node 16.x, which is the current LTS.

This PR changes CI scripts to run all tests and linter not only using Node 12 and/or 14 but also Node 16.