### PR TITLE
docs: Add alt to logo image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img align="center" src="./.github/logo.svg"/></p><br/>
+<p align="center"><img alt="Nuxt" align="center" src="./.github/logo.svg"/></p><br/>
 <p align="center">
   <a href="https://github.com/nuxt/nuxt.js/actions?query=branch%3Adev+event%3Apush"><img src="https://github.com/nuxt/nuxt.js/workflows/test/badge.svg?branch=dev&event=push" alt="Tests Status"></a>
   <a href="https://github.com/nuxt/nuxt.js/actions?query=branch%3Adev+event%3Apush"><img src="https://github.com/nuxt/nuxt.js/workflows/windows/badge.svg?branch=dev&event=push" alt="Windows Status"></a>


### PR DESCRIPTION
The image has the text `NuxtJS`, but there is no `NuxtJS` notation in the entire document or elsewhere.
So, I set `Nuxt`.

PS: I just wanted to know the correct notation for Nuxt.