### PR TITLE
fix: Lock defu version to 6.1.0

### DIFF
--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -11,7 +11,7 @@
     "@nuxt/utils": "2.15.6",
     "chalk": "^4.1.2",
     "consola": "^2.15.3",
-    "defu": "^6.1.0",
+    "defu": "6.1.0",
     "devalue": "^2.0.1",
     "fs-extra": "^10.1.0",
     "html-minifier": "^4.0.0",


### PR DESCRIPTION
Lock dependency of defu to 6.1.0 as 6.1.1 is breaking nuxt generator FATAL defu is not a function when running nuxt generate

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Lock dependency of defu to 6.1.0 as 6.1.1 is avoid nuxt generator from running
FATAL defu is not a function will be shown when running nuxt generate
nuxt generate cannot be completed because of that

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
- [ ] All new and existing tests are passing.

