### PR TITLE
Fix: server side redirect with basePath at runtime

### DIFF
--- a/packages/vue-app/template/server.js
+++ b/packages/vue-app/template/server.js
@@ -58,7 +58,7 @@ const createNext = ssrContext => (opts) => {
     return
   }
   let fullPath = withQuery(opts.path, opts.query)
-  const $config = ssrContext.nuxt.config || {}
+  const $config = ssrContext.nuxt.config.public || {}
   const routerBase = ($config._app && $config._app.basePath) || '<%= router.base %>'
   if (!fullPath.startsWith('http') && (routerBase !== '/' && !fullPath.startsWith(routerBase))) {
     fullPath = joinURL(routerBase, fullPath)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #1337" -->
In `createNext` function `ssrContext.nuxt.config` has only `public` and `private` keys for client and server side runtime variables but this function for now is trying to read runtimeConfig directly from config object. 
This causes this variable: `const routerBase = ($config._app && $config._app.basePath) || '<%= router.base %>'` to always be `'<%= router.base %>'` which is statically embedded during the build. If we try to change `router: { basePath: }` in `nuxt.config.js` after build it will not be reflected in `next` function - nuxt context `redirect()` function uses this function to handle server side redirects.
To reproduce this bug:
1. Create redirect e.g. in plugin to redirect `/test` path to `/success` with redirect() context function
2. Build app with e.g. `router: { basePath: '/en/' }`
3. Change this setting to e.g. `/pl/`
4. Open `/pl/test` - you will land on `/en/success` instead of `/pl/success`
This change fixes above error. 

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (PR: #)
- [ ] I have added tests to cover my changes (if not applicable, please state why)
I can't find any tests for this file or functionality
- [x] All new and existing tests are passing.

