### PR TITLE
fix(nuxt): only fetch payloads for prerendered routes

### DIFF
--- a/packages/nuxt/src/app/composables/payload.ts
+++ b/packages/nuxt/src/app/composables/payload.ts
@@ -9,6 +9,8 @@ interface LoadPayloadOptions {
 
 export function loadPayload (url: string, opts: LoadPayloadOptions = {}) {
   if (process.server) { return null }
+  if (!_hasPayload(url)) { return null }
+
   const payloadURL = _getPayloadURL(url, opts)
   const nuxtApp = useNuxtApp()
   const cache = nuxtApp._payloadCache = nuxtApp._payloadCache || {}
@@ -26,6 +28,8 @@ export function loadPayload (url: string, opts: LoadPayloadOptions = {}) {
 }
 
 export function preloadPayload (url: string, opts: LoadPayloadOptions = {}) {
+  if (!_hasPayload(url)) { return }
+
   const payloadURL = _getPayloadURL(url, opts)
   useHead({
     link: [
@@ -43,6 +47,11 @@ function _getPayloadURL (url: string, opts: LoadPayloadOptions = {}) {
   }
   const hash = opts.hash || (opts.fresh ? Date.now() : '')
   return joinURL(parsed.pathname, hash ? `_payload.${hash}.js` : '_payload.js')
+}
+
+function _hasPayload (url: string) {
+  const nuxtApp = useNuxtApp()
+  return nuxtApp._manifest.static.some(route => typeof route === 'string' ? route === url : route.test(url))
 }
 
 async function _importPayload (payloadURL: string) {

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -55,6 +55,10 @@ export interface NuxtSSRContext extends SSRContext {
   renderMeta?: () => Promise<NuxtMeta> | NuxtMeta
 }
 
+export interface RouteManifest {
+  static: Array<string | RegExp>
+}
+
 interface _NuxtApp {
   vueApp: App<Element>
   globalName: string
@@ -71,6 +75,8 @@ interface _NuxtApp {
     pending: Ref<boolean>
     error: Ref<any>
   } | undefined>,
+
+  _manifest: RouteManifest
 
   ssrContext?: NuxtSSRContext
   payload: {

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -174,7 +174,7 @@ async function initNuxt (nuxt: Nuxt) {
   })
 
   // Add prerender payload support
-  if (!nuxt.options.dev && nuxt.options.experimental.payloadExtraction) {
+  if (nuxt.options.experimental.payloadExtraction) {
     addPlugin(resolve(nuxt.options.appDir, 'plugins/payload.client'))
   }
 

--- a/packages/nuxt/src/core/runtime/nitro/manifest.ts
+++ b/packages/nuxt/src/core/runtime/nitro/manifest.ts
@@ -1,0 +1,8 @@
+import { defineCachedEventHandler } from '#internal/nitro'
+
+export default defineCachedEventHandler(() => {
+  return {
+    // TODO: support route rules for payload extraction
+    static: ['/**']
+  }
+})

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -196,6 +196,7 @@ export default defineRenderHandler(async (event) => {
     head: normalizeChunks([
       renderedMeta.headTags,
       _PAYLOAD_EXTRACTION ? `<link rel="modulepreload" href="${payloadURL}">` : null,
+      process.env.NUXT_PAYLOAD_EXTRACTION ? '<link rel="preload" href="/manifest.json" as="fetch" crossorigin>' : null,
       _rendered.renderResourceHints(),
       _rendered.renderStyles(),
       inlinedStyles,

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -78,6 +78,8 @@ export default defineUntypedSchema({
     /**
      * When this option is enabled (by default) payload of pages generated with `nuxt generate` are extracted
      */
-    payloadExtraction: true,
+    payloadExtraction: {
+      $resolve: async (val, get) => val ?? !(await get('dev'))
+    },
   }
 })

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -493,7 +493,7 @@ describe.runIf(process.env.NUXT_TEST_DEV)('detecting invalid root nodes', () => 
 describe.skipIf(process.env.NUXT_TEST_DEV)('dynamic paths', () => {
   it('should work with no overrides', async () => {
     const html: string = await $fetch('/assets')
-    for (const match of html.matchAll(/(href|src)="(.*?)"|url\(([^)]*?)\)/g)) {
+    for (const match of html.matchAll(/<(?!link)[^>]*(href|src)="(.*?)"|url\(([^)]*?)\)/g)) {
       const url = match[2] || match[3]
       expect(url.startsWith('/_nuxt/') || url === '/public.svg').toBeTruthy()
     }
@@ -523,7 +523,7 @@ describe.skipIf(process.env.NUXT_TEST_DEV)('dynamic paths', () => {
     await startServer()
 
     const html = await $fetch('/foo/assets')
-    for (const match of html.matchAll(/(href|src)="(.*?)"|url\(([^)]*?)\)/g)) {
+    for (const match of html.matchAll(/<(?!link)[^>]*(href|src)="(.*?)"|url\(([^)]*?)\)/g)) {
       const url = match[2] || match[3]
       expect(
         url.startsWith('/foo/_other/') ||
@@ -540,7 +540,7 @@ describe.skipIf(process.env.NUXT_TEST_DEV)('dynamic paths', () => {
     await startServer()
 
     const html = await $fetch('/assets')
-    for (const match of html.matchAll(/(href|src)="(.*?)"|url\(([^)]*?)\)/g)) {
+    for (const match of html.matchAll(/<(?!link)[^>]*(href|src)="(.*?)"|url\(([^)]*?)\)/g)) {
       const url = match[2] || match[3]
       expect(
         url.startsWith('./_nuxt/') ||
@@ -568,7 +568,7 @@ describe.skipIf(process.env.NUXT_TEST_DEV)('dynamic paths', () => {
     await startServer()
 
     const html = await $fetch('/foo/assets')
-    for (const match of html.matchAll(/(href|src)="(.*?)"|url\(([^)]*?)\)/g)) {
+    for (const match of html.matchAll(/<(?!link)[^>]*(href|src)="(.*?)"|url\(([^)]*?)\)/g)) {
       const url = match[2] || match[3]
       expect(
         url.startsWith('https://example.com/_cdn/') ||


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

https://github.com/nuxt/nuxt.js/issues/14507

resolves https://github.com/nuxt/nuxt.js/issues/15024

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds support for an app manifest (at `/manifest.json`) which contains, at the moment, simply a list of routes for which there are corresponding payloads. With the implementation of [route rules](https://github.com/nuxt/framework/discussions/560) this manifest can be extended/modified. In addition, it can be extended with a build hash to allow version change detection.

With this PR:
 * we **will not fetch** payloads for pages that were not prerendered (they would give a 404)
 * will **will fetch** all payloads if there is an SSR/hybrid app
 * we can fetch payloads in development mode if `experimental.payloadExtraction` is set by the user to `true` (there are more edge cases, such as CORS, with client-side fetching, so I felt it was better to set default to false in dev mode so user handles them properly, in case they are not prerendering all their pages).
 * support for _hybrid_ payload extraction (e.g. _some but not all_ routes have SSR payloads) is deferred to implementation of [route rules](https://github.com/nuxt/framework/discussions/560)

(**Note**, @pi0, I'm also happy to go ahead and implement route rules, but thought we could adopt this approach for now and modify it at that point.)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

