### PR TITLE
feat(nuxi): support nuxt 2 and nuxt 3 edge releases in nuxi upgrade command 

### DIFF
--- a/docs/content/1.docs/3.api/5.commands/upgrade.md
+++ b/docs/content/1.docs/3.api/5.commands/upgrade.md
@@ -6,11 +6,14 @@ description: The upgrade command upgrades Nuxt 3 to the latest version.
 # `nuxi upgrade`
 
 ```{bash}
-npx nuxi upgrade [--force|-f]
+npx nuxi upgrade [--force|-f] [--channel]
 ```
 
-The `upgrade` command upgrades Nuxt 3 to the latest version.
+The `upgrade` command upgrades Nuxt to the latest version.
+
+Use `--channel` flag to switch between stable and edge package versions. Possible values are `stable` and `edge`
 
 Option        | Default          | Description
 -------------------------|-----------------|------------------
 `--force, -f` | `false` | Removes `node_modules` and lock files before upgrade.
+`--channel` | - | Switches between edge and stable release channels.

--- a/packages/nuxi/src/commands/upgrade.ts
+++ b/packages/nuxi/src/commands/upgrade.ts
@@ -1,28 +1,45 @@
 import { execSync } from 'node:child_process'
 import consola from 'consola'
 import { resolve } from 'pathe'
-import { readPackageJSON } from 'pkg-types'
 import { getPackageManager, packageManagerLocks } from '../utils/packageManagers'
 import { rmRecursive, touchFile } from '../utils/fs'
+import { createGetDepVersion, getPkg } from '../utils/packages'
 import { cleanupNuxtDirs, nuxtVersionToGitIdentifier } from '../utils/nuxt'
 import { defineNuxtCommand } from './index'
 
-async function getNuxtVersion (path: string): Promise<string|null> {
+const UNKNOWN_VERSION = '[unknown]'
+
+function getNuxtVersion (rootDir: string): string {
   try {
-    const pkg = await readPackageJSON('nuxt', { url: path })
-    if (!pkg.version) {
-      consola.warn('Cannot find any installed nuxt versions in ', path)
-    }
-    return pkg.version || null
+    const getDepVersion = createGetDepVersion(rootDir)
+    const nuxtVersion = getDepVersion('nuxt') || getDepVersion('nuxt-edge') || getDepVersion('nuxt3')
+    return nuxtVersion || UNKNOWN_VERSION
   } catch {
-    return null
+    return UNKNOWN_VERSION
+  }
+}
+
+function detectLegacyNuxt3 (rootDir: string): boolean {
+  try {
+    const legacyNuxt3 = getPkg('nuxt3', rootDir)
+    return (typeof legacyNuxt3?.version === 'string')
+  } catch {
+    return false
+  }
+}
+
+function detectNuxtEdge (nuxtVersion: string): boolean {
+  try {
+    return (/-\d{8}.[a-z0-9]{7}/).test(nuxtVersion)
+  } catch {
+    return false
   }
 }
 
 export default defineNuxtCommand({
   meta: {
     name: 'upgrade',
-    usage: 'npx nuxi upgrade [--force|-f]',
+    usage: 'npx nuxi upgrade [--force|-f] [--channel=stable|edge]',
     description: 'Upgrade nuxt'
   },
   async invoke (args) {
@@ -37,9 +54,24 @@ export default defineNuxtCommand({
     const packageManagerVersion = execSync(`${packageManager} --version`).toString('utf8').trim()
     consola.info('Package Manager:', packageManager, packageManagerVersion)
 
-    // Check currently installed nuxt version
-    const currentVersion = await getNuxtVersion(rootDir) || '[unknown]'
-    consola.info('Current nuxt version:', currentVersion)
+    // Check currently installed nuxt version and detect edge releases
+    const currentVersion = getNuxtVersion(rootDir)
+    const isLegacyNuxt3 = detectLegacyNuxt3(rootDir)
+    const isNuxtEdge = detectNuxtEdge(currentVersion)
+    // Decide to set needed nuxt version as 3
+    const isNuxt3 = currentVersion.startsWith('3') || currentVersion === UNKNOWN_VERSION
+
+    // Display information message to a user
+    if (isNuxtEdge) {
+      consola.info(`Current nuxt version: ${currentVersion}, edge release channel detected`)
+    } else {
+      consola.info(`Current nuxt version: ${currentVersion}`)
+    }
+
+    // Warn user to add alias to nuxt3 package or install stable rc version
+    if (isLegacyNuxt3) {
+      consola.warn('`nuxt3` package usage without alias is removed.\nPlease, update your code to continue working with new releases.\nSee more: https://github.com/nuxt/framework/pull/4449')
+    }
 
     // Force install
     if (args.force || args.f) {
@@ -49,15 +81,56 @@ export default defineNuxtCommand({
       await touchFile(pmLockFile)
     }
 
+    const updatedNuxtPackageName = (() => {
+      let installEdgeChannel = isNuxtEdge
+      // Switch channel only if specific flags explicitly set
+      if (args.channel === 'stable') {
+        installEdgeChannel = false
+      } else if (args.channel === 'edge') {
+        installEdgeChannel = true
+      }
+      // Nuxt 3 with 'nuxt3' package name
+      if (isLegacyNuxt3) {
+        return 'nuxt3@latest'
+      }
+      // Nuxt 3 Stable
+      if (isNuxt3 && !installEdgeChannel) {
+        return 'nuxt@3'
+      }
+      // Nuxt 3 Edge
+      if (isNuxt3 && installEdgeChannel) {
+        return 'nuxt@npm:nuxt3@latest'
+      }
+      // Nuxt 2 Stable
+      if (!isNuxt3 && !installEdgeChannel) {
+        return 'nuxt@2'
+      }
+      // Nuxt 2 Edge
+      if (!isNuxt3 && installEdgeChannel) {
+        return 'nuxt-edge'
+      }
+      return 'nuxt@3'
+    })()
+
+    // Detect switching Nuxt 2 releases
+    if ((!isNuxt3 && isNuxtEdge) && args.channel === 'stable') {
+      consola.info('Uninstalling previouus Nuxt')
+      execSync(`${packageManager} ${packageManager === 'yarn' ? 'remove' : 'uninstall'} -S nuxt-edge`, { stdio: 'inherit', cwd: rootDir })
+    }
+    if ((!isNuxt3 && !isNuxtEdge) && args.channel === 'edge') {
+      consola.info('Uninstalling previouus Nuxt')
+      execSync(`${packageManager} ${packageManager === 'yarn' ? 'remove' : 'uninstall'} -S nuxt`, { stdio: 'inherit', cwd: rootDir })
+    }
+
     // Install latest version
     consola.info('Installing latest Nuxt 3 release...')
-    execSync(`${packageManager} ${packageManager === 'yarn' ? 'add' : 'install'} -D nuxt`, { stdio: 'inherit', cwd: rootDir })
+    execSync(`${packageManager} ${packageManager === 'yarn' ? 'add' : 'install'} -D ${updatedNuxtPackageName}`, { stdio: 'inherit', cwd: rootDir })
 
     // Cleanup after upgrade
     await cleanupNuxtDirs(rootDir)
 
     // Check installed nuxt version again
-    const upgradedVersion = await getNuxtVersion(rootDir) || '[unknown]'
+    const upgradedVersion = getNuxtVersion(rootDir) || '[unknown]'
     consola.info('Upgraded nuxt version:', upgradedVersion)
 
     if (upgradedVersion === currentVersion) {

--- a/packages/nuxi/src/utils/nuxt.ts
+++ b/packages/nuxi/src/utils/nuxt.ts
@@ -28,8 +28,8 @@ export async function cleanupNuxtDirs (rootDir: string) {
 }
 
 export function nuxtVersionToGitIdentifier (version: string) {
-  // match the git identifier in the release, for example: 3.0.0-rc.8-27677607.a3a8706
-  const id = /\.([0-9a-f]{7,8})$/.exec(version)
+  // match the pattern with 8 digits and git identifier in the release and extracts only git identifier, for example: 3.0.0-rc.8-27677607.a3a8706
+  const id = (/-\d{8}.([a-z0-9]{7,8})/).exec(version)
   if (id?.[1]) {
     return id[1]
   }

--- a/packages/nuxi/src/utils/packages.ts
+++ b/packages/nuxi/src/utils/packages.ts
@@ -1,0 +1,42 @@
+
+import { createRequire } from 'node:module'
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'pathe'
+import destr from 'destr'
+import { findup } from './fs'
+
+export function createGetDepVersion (rootDir: string) {
+  const { dependencies = {}, devDependencies = {} } = findPackage(rootDir)
+  return (name: string) => getPkg(name, rootDir)?.version || dependencies[name] || devDependencies[name]
+}
+
+export function getPkg (name: string, rootDir: string) {
+  // Assume it is in {rootDir}/node_modules/${name}/package.json
+  let pkgPath = resolve(rootDir, 'node_modules', name, 'package.json')
+
+  // Try to resolve for more accuracy
+  const _require = createRequire(rootDir)
+  try { pkgPath = _require.resolve(name + '/package.json') } catch (_err) {
+    // console.log('not found:', name)
+  }
+
+  return readJSONSync(pkgPath)
+}
+
+function findPackage (rootDir: string) {
+  return findup(rootDir, (dir) => {
+    const p = resolve(dir, 'package.json')
+    if (existsSync(p)) {
+      return readJSONSync(p)
+    }
+  }) || {}
+}
+
+function readJSONSync (filePath: string) {
+  try {
+    return destr(readFileSync(filePath, 'utf-8'))
+  } catch (err) {
+    // TODO: Warn error
+    return null
+  }
+}


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

Issues to track:
https://github.com/nuxt/cli/issues/55
https://github.com/nuxt/nuxt/issues/14741
https://github.com/nuxt/cli/issues/60


This is a reopened https://github.com/nuxt/framework/pull/6998 PR, with small differences:
1. `nuxt@rc` became `nuxt@3`, because this PR was created before the first stable release
2. Resolved merge conflict in post-upgrade message

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR extends `nuxi upgrade` command usage with some new features:
1. It respects not only stable Nuxt 3RC packages (like `nuxt: "3.0.0-rc.8"`), but also Nuxt 2 (`nuxt` & `nuxt-edge`) and Nuxt 3 packages, installed as `npm:nuxt3@latest`. This might be useful for nuxt 2 bridge users and people, who wants to get edge releases of Nuxt.
3. It add extra `--channel` flag, which switches users between stable and edge releases. People in nuxt 2 can type `npx nuxi upgrade --channel="edge"` and get nuxt-edge package, which allows them to use bridge (Yes, this example also about bridge)
4. It warns people who still have `nuxt3` in their `package.json` file. It might be dangerous to find and replace all `nuxt3` imports to `nuxt` in code, so it's just a reminder to people.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

