### PR TITLE
fix(vite): don't skip loading styles in hydration phase

### DIFF
--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -143,8 +143,6 @@ export function createNuxtApp (options: CreateOptions) {
 
         if (hydratingCount === 0) {
           nuxtApp.isHydrating = false
-          // @ts-expect-error private flag
-          globalThis.__hydrated = true
           return nuxtApp.callHook('app:suspense:resolve')
         }
       }

--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -1,39 +1,28 @@
 import type { IncomingMessage, ServerResponse } from 'node:http'
-import { join, relative, resolve } from 'pathe'
+import { join, resolve } from 'pathe'
 import * as vite from 'vite'
 import vuePlugin from '@vitejs/plugin-vue'
 import viteJsxPlugin from '@vitejs/plugin-vue-jsx'
 import type { ServerOptions } from 'vite'
 import { logger } from '@nuxt/kit'
 import { getPort } from 'get-port-please'
-import { joinURL, withoutLeadingSlash, withoutTrailingSlash } from 'ufo'
+import { joinURL, withoutLeadingSlash } from 'ufo'
 import defu from 'defu'
 import type { OutputOptions } from 'rollup'
 import { defineEventHandler } from 'h3'
-import { genString } from 'knitwork'
 import { cacheDirPlugin } from './plugins/cache-dir'
 import type { ViteBuildContext, ViteOptions } from './vite'
 import { devStyleSSRPlugin } from './plugins/dev-ssr-css'
 import { viteNodePlugin } from './vite-node'
 
 export async function buildClient (ctx: ViteBuildContext) {
-  const buildAssetsDir = withoutLeadingSlash(
-    withoutTrailingSlash(ctx.nuxt.options.app.buildAssetsDir)
-  )
-  const relativeToBuildAssetsDir = (filename: string) => './' + relative(buildAssetsDir, filename)
   const clientConfig: vite.InlineConfig = vite.mergeConfig(ctx.config, {
     entry: ctx.entry,
     base: ctx.nuxt.options.dev
       ? joinURL(ctx.nuxt.options.app.baseURL.replace(/^\.\//, '/') || '/', ctx.nuxt.options.app.buildAssetsDir)
       : './',
     experimental: {
-      renderBuiltUrl: (filename, { type, hostType, hostId }) => {
-        // When rendering inline styles, we can skip loading CSS chunk that matches the current page
-        if (ctx.nuxt.options.experimental.inlineSSRStyles && hostType === 'js' && filename.endsWith('.css')) {
-          return {
-            runtime: `!globalThis.__hydrated ? ${genString(relativeToBuildAssetsDir(hostId))} : ${genString(relativeToBuildAssetsDir(filename))}`
-          }
-        }
+      renderBuiltUrl: (filename, { type, hostType }) => {
         if (hostType !== 'js' || type === 'asset') {
           // In CSS we only use relative paths until we craft a clever runtime CSS hack
           return { relative: true }


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The [previous PR](https://github.com/nuxt/framework/pull/9475) to prevent injecting an extra stylesheet didn't take into account client-side only styles that weren't inlined in SSR. This reverts that change pending a better implementation.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
