### PR TITLE
fix(nuxt): await async `callWithNuxt` calls

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-root.vue
+++ b/packages/nuxt/src/app/components/nuxt-root.vue
@@ -33,7 +33,8 @@ const error = useError()
 onErrorCaptured((err, target, info) => {
   nuxtApp.hooks.callHook('vue:error', err, target, info).catch(hookError => console.error('[nuxt] Error in `vue:error` hook', hookError))
   if (process.server || (isNuxtError(err) && (err.fatal || err.unhandled))) {
-    callWithNuxt(nuxtApp, showError, [err])
+    const p = callWithNuxt(nuxtApp, showError, [err])
+    onServerPrefetch(() => p)
   }
 })
 

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -283,7 +283,7 @@ export function isNuxtPlugin (plugin: unknown) {
  * @param nuxt A Nuxt instance
  * @param setup The function to call
  */
-export function callWithNuxt<T extends (...args: any[]) => any> (nuxt: NuxtApp | _NuxtApp, setup: T, args?: Parameters<T>) {
+export function callWithNuxt<T extends (...args: any[]) => any> (nuxt: NuxtApp | _NuxtApp, setup: T, args?: Parameters<T>): Promise<ReturnType<T>> | ReturnType<T> {
   const fn = () => args ? setup(...args as Parameters<T>) : setup()
   if (process.server) {
     return nuxtAppCtx.callAsync<ReturnType<T>>(nuxt, fn)

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -283,10 +283,10 @@ export function isNuxtPlugin (plugin: unknown) {
  * @param nuxt A Nuxt instance
  * @param setup The function to call
  */
-export function callWithNuxt<T extends (...args: any[]) => any> (nuxt: NuxtApp | _NuxtApp, setup: T, args?: Parameters<T>): Promise<ReturnType<T>> | ReturnType<T> {
-  const fn = () => args ? setup(...args as Parameters<T>) : setup()
+export function callWithNuxt<T extends (...args: any[]) => any> (nuxt: NuxtApp | _NuxtApp, setup: T, args?: Parameters<T>) {
+  const fn: () => ReturnType<T> = () => args ? setup(...args as Parameters<T>) : setup()
   if (process.server) {
-    return nuxtAppCtx.callAsync<ReturnType<T>>(nuxt, fn)
+    return nuxtAppCtx.callAsync(nuxt, fn)
   } else {
     // In client side we could assume nuxt app is singleton
     nuxtAppCtx.set(nuxt)

--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -113,7 +113,7 @@ export default defineNuxtPlugin(async (nuxtApp) => {
     await router.isReady()
   } catch (error: any) {
     // We'll catch 404s here
-    callWithNuxt(nuxtApp, showError, [error])
+    await callWithNuxt(nuxtApp, showError, [error])
   }
 
   const initialLayout = useState('_layout')
@@ -171,7 +171,7 @@ export default defineNuxtPlugin(async (nuxtApp) => {
       await callWithNuxt(nuxtApp, clearError)
     }
     if (to.matched.length === 0) {
-      callWithNuxt(nuxtApp, showError, [createError({
+      await callWithNuxt(nuxtApp, showError, [createError({
         statusCode: 404,
         fatal: false,
         statusMessage: `Page not found: ${to.fullPath}`
@@ -193,7 +193,7 @@ export default defineNuxtPlugin(async (nuxtApp) => {
       })
     } catch (error: any) {
       // We'll catch middleware errors or deliberate exceptions here
-      callWithNuxt(nuxtApp, showError, [error])
+      await callWithNuxt(nuxtApp, showError, [error])
     }
   })
 

--- a/test/fixtures/basic/types.ts
+++ b/test/fixtures/basic/types.ts
@@ -5,7 +5,7 @@ import type { AppConfig } from '@nuxt/schema'
 
 import type { FetchError } from 'ofetch'
 import type { NavigationFailure, RouteLocationNormalizedLoaded, RouteLocationRaw, useRouter as vueUseRouter } from 'vue-router'
-import { isVue3 } from '#app'
+import { callWithNuxt, isVue3 } from '#app'
 import type { NavigateToOptions } from '~~/../../../packages/nuxt/dist/app/composables/router'
 import { defineNuxtConfig } from '~~/../../../packages/nuxt/config'
 import { useRouter } from '#imports'
@@ -222,5 +222,12 @@ describe('app config', () => {
 describe('extends type declarations', () => {
   it('correctly adds references to tsconfig', () => {
     expectTypeOf<import('bing').BingInterface>().toEqualTypeOf<{ foo: 'bar' }>()
+  })
+})
+
+describe('composables inference', () => {
+  it('callWithNuxt', () => {
+    const bob = callWithNuxt({} as any, () => true)
+    expectTypeOf<typeof bob>().toEqualTypeOf<boolean | Promise<boolean>>()
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/15738

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`callWithNuxt` returns a promise on server-side, so by not awaiting these instances we ran the risk of getting errors like:

```bash
Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client
```

In addition, `callWithNuxt` was previously returning `any` as its type rather than inferring it based on the input. This fixes that.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
