### PR TITLE
fix(nuxt): let router handle internal redirects within middleware

### DIFF
--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -6,6 +6,7 @@ import { useNuxtApp, useRuntimeConfig } from '../nuxt'
 import type { NuxtError } from './error'
 import { createError } from './error'
 import { useState } from './state'
+import { setResponseStatus } from './ssr'
 
 export const useRouter = () => {
   return useNuxtApp()?.$router as Router
@@ -97,8 +98,15 @@ export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: Na
   if (process.server) {
     const nuxtApp = useNuxtApp()
     if (nuxtApp.ssrContext && nuxtApp.ssrContext.event) {
+      // Let vue-router handle internal redirects within middleware
+      // to prevent the navigation happening after response is sent
+      if (isProcessingMiddleware() && !isExternal) {
+        setResponseStatus(options?.redirectCode || 302)
+        return to
+      }
       const redirectLocation = isExternal ? toPath : joinURL(useRuntimeConfig().app.baseURL, router.resolve(to).fullPath || '/')
-      return nuxtApp.callHook('app:redirected').then(() => sendRedirect(nuxtApp.ssrContext!.event, redirectLocation, options?.redirectCode || 302))
+      return nuxtApp.callHook('app:redirected')
+        .then(() => sendRedirect(nuxtApp.ssrContext!.event, redirectLocation, options?.redirectCode || 302))
     }
   }
 

--- a/packages/nuxt/src/app/plugins/router.ts
+++ b/packages/nuxt/src/app/plugins/router.ts
@@ -1,7 +1,7 @@
 import { reactive, h, isReadonly } from 'vue'
 import { parseURL, stringifyParsedURL, parseQuery, stringifyQuery, withoutBase, isEqual, joinURL } from 'ufo'
 import { createError } from 'h3'
-import { defineNuxtPlugin, clearError, navigateTo, showError, useRuntimeConfig, useState } from '..'
+import { defineNuxtPlugin, clearError, navigateTo, showError, useRuntimeConfig, useState, useRequestEvent } from '..'
 import { callWithNuxt } from '../nuxt'
 // @ts-ignore
 import { globalMiddleware } from '#build/middleware'
@@ -250,7 +250,9 @@ export default defineNuxtPlugin<{ route: Route, router: Router }>((nuxtApp) => {
 
     await router.replace(initialURL)
     if (!isEqual(route.fullPath, initialURL)) {
-      await callWithNuxt(nuxtApp, navigateTo, [route.fullPath])
+      const event = await callWithNuxt(nuxtApp, useRequestEvent)
+      const options = { redirectCode: event.node.res.statusCode !== 200 ? event.node.res.statusCode || 302 : 302 }
+      await callWithNuxt(nuxtApp, navigateTo, [route.fullPath, options])
     }
   })
 

--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -12,7 +12,7 @@ import {
 import { createError } from 'h3'
 import { withoutBase, isEqual } from 'ufo'
 import type NuxtPage from '../page'
-import { callWithNuxt, defineNuxtPlugin, useRuntimeConfig, showError, clearError, navigateTo, useError, useState } from '#app'
+import { callWithNuxt, defineNuxtPlugin, useRuntimeConfig, showError, clearError, navigateTo, useError, useState, useRequestEvent } from '#app'
 // @ts-ignore
 import _routes from '#build/routes'
 // @ts-ignore
@@ -179,7 +179,9 @@ export default defineNuxtPlugin(async (nuxtApp) => {
     } else if (process.server) {
       const currentURL = to.fullPath || '/'
       if (!isEqual(currentURL, initialURL)) {
-        await callWithNuxt(nuxtApp, navigateTo, [currentURL])
+        const event = await callWithNuxt(nuxtApp, useRequestEvent)
+        const options = { redirectCode: event.node.res.statusCode !== 200 ? event.node.res.statusCode || 302 : 302 }
+        await callWithNuxt(nuxtApp, navigateTo, [currentURL, options])
       }
     }
   })


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/15407, resolves https://github.com/nuxt/nuxt/issues/15738

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When we redirect within middleware, we need to tell vue router not to finish the route navigation or the page will load after all (on server side). This wasn't affecting the response but it was allowing forbidden routes to be hit on server side, and causing some unexplained errors in server logs.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
