### PR TITLE
fix(vite): enable css sourcemaps in dev based on `sourcemap`

### DIFF
--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -30,6 +30,9 @@ export async function buildClient (ctx: ViteBuildContext) {
         return { runtime: `globalThis.__publicAssetsURL(${JSON.stringify(filename)})` }
       }
     },
+    css: {
+      devSourcemap: ctx.nuxt.options.sourcemap.client
+    },
     define: {
       'process.server': false,
       'process.client': true,

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -34,6 +34,9 @@ export async function buildServer (ctx: ViteBuildContext) {
         }
       }
     },
+    css: {
+      devSourcemap: ctx.nuxt.options.sourcemap.server
+    },
     define: {
       'process.server': true,
       'process.client': false,


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/18377

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This enables CSS sourcemaps in dev mode, respecting top-level `sourcemap` option. This will mean it is enabled by default in dev mode, as webpack css sourcemaps also are (https://github.com/nuxt/nuxt.js/blob/265db5051510dcf8abf5d5c4563f0f68baf7c23b/packages/schema/src/config/webpack.ts#L96-L98).

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
