### PR TITLE
feat: add route separator

### DIFF
--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -199,10 +199,11 @@ function parseSegment (segment: string) {
 }
 
 function prepareRoutes (routes: NuxtPage[], routeNameSeparator: string, parent?: NuxtPage) {
+  const separatorWithIndex = new RegExp(`${escapeRE(routeNameSeparator)}index$`)
   for (const route of routes) {
-    // Remove <routeNameSeparator>index
     if (route.name) {
-      route.name = route.name.replace(new RegExp(`${escapeRE(routeNameSeparator)}index$`), '')
+      // Remove <routeNameSeparator>index
+      route.name = route.name.replace(separatorWithIndex, '')
     }
 
     // Remove leading / if children route

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -38,14 +38,14 @@ export async function resolvePagesRoutes (): Promise<NuxtPage[]> {
       const files = await resolveFiles(dir, `**/*{${nuxt.options.extensions.join(',')}}`)
       // Sort to make sure parent are listed first
       files.sort()
-      return generateRoutesFromFiles(files, dir)
+      return generateRoutesFromFiles(files, dir, nuxt.options.router.routeSeparator)
     })
   )).flat()
 
   return uniqueBy(allRoutes, 'path')
 }
 
-export function generateRoutesFromFiles (files: string[], pagesDir: string): NuxtPage[] {
+export function generateRoutesFromFiles (files: string[], pagesDir: string, routeSeparator = '-'): NuxtPage[] {
   const routes: NuxtPage[] = []
 
   for (const file of files) {
@@ -70,7 +70,7 @@ export function generateRoutesFromFiles (files: string[], pagesDir: string): Nux
       const segmentName = tokens.map(({ value }) => value).join('')
 
       // ex: parent/[slug].vue -> parent-slug
-      route.name += (route.name && '-') + segmentName
+      route.name += (route.name && routeSeparator) + segmentName
 
       // ex: parent.vue + parent/child.vue
       const child = parent.find(parentRoute => parentRoute.name === route.name && !parentRoute.path.endsWith('(.*)*'))

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -70,7 +70,6 @@ export function generateRoutesFromFiles (files: string[], pagesDir: string, rout
       const segmentName = tokens.map(({ value }) => value).join('')
 
       // ex: parent/[slug].vue -> parent-slug
-      console.log((route.name && routeSeparator) + segmentName)
       route.name += (route.name && routeSeparator) + segmentName
 
       // ex: parent.vue + parent/child.vue

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -38,14 +38,14 @@ export async function resolvePagesRoutes (): Promise<NuxtPage[]> {
       const files = await resolveFiles(dir, `**/*{${nuxt.options.extensions.join(',')}}`)
       // Sort to make sure parent are listed first
       files.sort()
-      return generateRoutesFromFiles(files, dir, nuxt.options.router.routeSeparator)
+      return generateRoutesFromFiles(files, dir, nuxt.options.router.routeNameSeparator)
     })
   )).flat()
 
   return uniqueBy(allRoutes, 'path')
 }
 
-export function generateRoutesFromFiles (files: string[], pagesDir: string, routeSeparator = '-'): NuxtPage[] {
+export function generateRoutesFromFiles (files: string[], pagesDir: string, routeNameSeparator = '-'): NuxtPage[] {
   const routes: NuxtPage[] = []
 
   for (const file of files) {
@@ -70,7 +70,7 @@ export function generateRoutesFromFiles (files: string[], pagesDir: string, rout
       const segmentName = tokens.map(({ value }) => value).join('')
 
       // ex: parent/[slug].vue -> parent-slug
-      route.name += (route.name && routeSeparator) + segmentName
+      route.name += (route.name && routeNameSeparator) + segmentName
 
       // ex: parent.vue + parent/child.vue
       const child = parent.find(parentRoute => parentRoute.name === route.name && !parentRoute.path.endsWith('(.*)*'))
@@ -88,7 +88,7 @@ export function generateRoutesFromFiles (files: string[], pagesDir: string, rout
     parent.push(route)
   }
 
-  return prepareRoutes(routes, routeSeparator)
+  return prepareRoutes(routes, routeNameSeparator)
 }
 
 function getRoutePath (tokens: SegmentToken[]): string {
@@ -198,11 +198,11 @@ function parseSegment (segment: string) {
   return tokens
 }
 
-function prepareRoutes (routes: NuxtPage[], routeSeparator: string, parent?: NuxtPage) {
+function prepareRoutes (routes: NuxtPage[], routeNameSeparator: string, parent?: NuxtPage) {
   for (const route of routes) {
-    // Remove <routeSeparator>index
+    // Remove <routeNameSeparator>index
     if (route.name) {
-      route.name = route.name.replace(new RegExp(`${escapeRE(routeSeparator)}index$`), '')
+      route.name = route.name.replace(new RegExp(`${escapeRE(routeNameSeparator)}index$`), '')
     }
 
     // Remove leading / if children route
@@ -211,7 +211,7 @@ function prepareRoutes (routes: NuxtPage[], routeSeparator: string, parent?: Nux
     }
 
     if (route.children?.length) {
-      route.children = prepareRoutes(route.children, routeSeparator, route)
+      route.children = prepareRoutes(route.children, routeNameSeparator, route)
     }
 
     if (route.children?.find(childRoute => childRoute.path === '')) {

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -70,6 +70,7 @@ export function generateRoutesFromFiles (files: string[], pagesDir: string, rout
       const segmentName = tokens.map(({ value }) => value).join('')
 
       // ex: parent/[slug].vue -> parent-slug
+      console.log((route.name && routeSeparator) + segmentName)
       route.name += (route.name && routeSeparator) + segmentName
 
       // ex: parent.vue + parent/child.vue
@@ -88,7 +89,7 @@ export function generateRoutesFromFiles (files: string[], pagesDir: string, rout
     parent.push(route)
   }
 
-  return prepareRoutes(routes)
+  return prepareRoutes(routes, routeSeparator)
 }
 
 function getRoutePath (tokens: SegmentToken[]): string {
@@ -198,11 +199,11 @@ function parseSegment (segment: string) {
   return tokens
 }
 
-function prepareRoutes (routes: NuxtPage[], parent?: NuxtPage) {
+function prepareRoutes (routes: NuxtPage[], routeSeparator: string, parent?: NuxtPage) {
   for (const route of routes) {
-    // Remove -index
+    // Remove <routeSeparator>index
     if (route.name) {
-      route.name = route.name.replace(/-index$/, '')
+      route.name = route.name.replace(new RegExp(`${escapeRE(routeSeparator)}index$`), '')
     }
 
     // Remove leading / if children route
@@ -211,7 +212,7 @@ function prepareRoutes (routes: NuxtPage[], parent?: NuxtPage) {
     }
 
     if (route.children?.length) {
-      route.children = prepareRoutes(route.children, route)
+      route.children = prepareRoutes(route.children, routeSeparator, route)
     }
 
     if (route.children?.find(childRoute => childRoute.path === '')) {

--- a/packages/nuxt/test/pages.test.ts
+++ b/packages/nuxt/test/pages.test.ts
@@ -257,7 +257,7 @@ describe('pages:generateRoutesFromFiles', () => {
   for (const test of tests) {
     it(test.description, async () => {
       if (test.error) {
-        expect(() => generateRoutesFromFiles(test.files, pagesDir)).to.throws(test.error)
+        expect(() => generateRoutesFromFiles(test.files, pagesDir, '.')).to.throws(test.error)
       } else {
         expect(await generateRoutesFromFiles(test.files, pagesDir, '.')).to.deep.equal(test.output)
       }

--- a/packages/nuxt/test/pages.test.ts
+++ b/packages/nuxt/test/pages.test.ts
@@ -84,7 +84,7 @@ describe('pages:generateRoutesFromFiles', () => {
       ],
       output: [
         {
-          name: 'stories-id',
+          name: 'stories.id',
           path: '/stories/:id',
           file: `${pagesDir}/stories/[id].vue`,
           children: []

--- a/packages/nuxt/test/pages.test.ts
+++ b/packages/nuxt/test/pages.test.ts
@@ -26,7 +26,7 @@ describe('pages:generateRoutesFromFiles', () => {
           children: []
         },
         {
-          name: 'parent-child',
+          name: 'parent.child',
           path: '/parent/child',
           file: `${pagesDir}/parent/child/index.vue`,
           children: []
@@ -46,7 +46,7 @@ describe('pages:generateRoutesFromFiles', () => {
           file: `${pagesDir}/parent.vue`,
           children: [
             {
-              name: 'parent-child',
+              name: 'parent.child',
               path: 'child',
               file: `${pagesDir}/parent/child.vue`,
               children: []
@@ -69,7 +69,7 @@ describe('pages:generateRoutesFromFiles', () => {
           children: []
         },
         {
-          name: 'stories-id',
+          name: 'stories.id',
           path: '/stories/:id',
           file: `${pagesDir}/stories/[id].vue`,
           children: []
@@ -168,19 +168,19 @@ describe('pages:generateRoutesFromFiles', () => {
           path: '/:bar'
         },
         {
-          name: 'nonopt-slug',
+          name: 'nonopt.slug',
           path: '/nonopt/:slug',
           file: `${pagesDir}/nonopt/[slug].vue`,
           children: []
         },
         {
-          name: 'opt-slug',
+          name: 'opt.slug',
           path: '/opt/:slug?',
           file: `${pagesDir}/opt/[[slug]].vue`,
           children: []
         },
         {
-          name: 'sub-route-slug',
+          name: 'sub.route-slug',
           path: '/:sub?/route-:slug',
           file: `${pagesDir}/[[sub]]/route-[slug].vue`,
           children: []
@@ -259,7 +259,7 @@ describe('pages:generateRoutesFromFiles', () => {
       if (test.error) {
         expect(() => generateRoutesFromFiles(test.files, pagesDir)).to.throws(test.error)
       } else {
-        expect(await generateRoutesFromFiles(test.files, pagesDir)).to.deep.equal(test.output)
+        expect(await generateRoutesFromFiles(test.files, pagesDir, '.')).to.deep.equal(test.output)
       }
     })
   }

--- a/packages/schema/src/config/router.ts
+++ b/packages/schema/src/config/router.ts
@@ -14,6 +14,10 @@ export default defineUntypedSchema({
      *
      */
     options: {},
+    /**
+     * The string used as separator between nested routes.
+     * `parent/[slug].vue` will be converted to `parent-slug` where `'-'` is the separator by default.
+     */
     routeSeparator: '-',
   }
 })

--- a/packages/schema/src/config/router.ts
+++ b/packages/schema/src/config/router.ts
@@ -18,6 +18,6 @@ export default defineUntypedSchema({
      * The string used as separator between nested routes.
      * `parent/[slug].vue` will be converted to `parent-slug` where `'-'` is the separator by default.
      */
-    routeSeparator: '-',
+    routeNameSeparator: '-',
   }
 })

--- a/packages/schema/src/config/router.ts
+++ b/packages/schema/src/config/router.ts
@@ -13,6 +13,7 @@ export default defineUntypedSchema({
      * @type {import('../src/types/router').RouterConfigSerializable}
      *
      */
-    options: {}
+    options: {},
+    routeSeparator: '-',
   }
 })


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/18457

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR introduces an optional config option called `router.routeSeparator` which will work similarly to the `routeNameSplitter` options from Nuxt 2.

(Happy to add docs if the decision to add it has been made if more than the one's added are necessary)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

