### PR TITLE
perf(nuxt): add tree-shaken `useServerSeoMeta` composable

### DIFF
--- a/docs/content/1.docs/1.getting-started/5.seo-meta.md
+++ b/docs/content/1.docs/1.getting-started/5.seo-meta.md
@@ -76,6 +76,8 @@ The `useSeoMeta` composable lets you define your site's SEO meta tags as a flat 
 
 This helps you avoid typos and common mistakes, such as using `name` instead of `property`.
 
+In most instances, the meta does not need to be reactive as robots will only scan the initial load, and so `useSeoMeta` will only do anything (or return a `head` object) on the server, not on the client.
+
 ### Example
 
 #### Simple
@@ -106,21 +108,6 @@ useSeoMeta({
   description: () => data.value?.description,
   ogDescription: () => data.value?.description,
 })
-</script>
-```
-
-### Client-side Optimization
-
-In most instances, the meta does not need to be reactive as robots will only scan the initial load.
-
-The composable itself is ~2kB, so you may consider only using it on the server and having it be tree-shaken from the client bundle.
-
-```vue{}[app.vue]
-<script setup lang="ts">
-// only run on the server or in development mode
-if (process.dev || process.server) {
-  useSeoMeta({ description: () => myDescription.value })
-}
 </script>
 ```
 

--- a/docs/content/1.docs/1.getting-started/5.seo-meta.md
+++ b/docs/content/1.docs/1.getting-started/5.seo-meta.md
@@ -70,13 +70,13 @@ useHead({
 ::ReadMore{link="/docs/api/composables/use-head"}
 ::
 
-## Composable: `useSeoMeta`
+## Composable: `useSeoMeta` and `useServerSeoMeta`
 
-The `useSeoMeta` composable lets you define your site's SEO meta tags as a flat object with full TypeScript support.
+The `useSeoMeta` and `useServerSeoMeta` composables let you define your site's SEO meta tags as a flat object with full TypeScript support.
 
 This helps you avoid typos and common mistakes, such as using `name` instead of `property`.
 
-In most instances, the meta does not need to be reactive as robots will only scan the initial load, and so `useSeoMeta` will only do anything (or return a `head` object) on the server, not on the client.
+In most instances, the meta does not need to be reactive as robots will only scan the initial load. So we recommend using `useServerSeoMeta` as a performance-focused utility that will not do anything (or return a `head` object) on the client.
 
 ### Example
 
@@ -84,7 +84,7 @@ In most instances, the meta does not need to be reactive as robots will only sca
 
 ```vue{}[app.vue]
 <script setup lang="ts">
-useSeoMeta({
+useServerSeoMeta({
   title: 'My Amazing Site',
   ogTitle: 'My Amazing Site',
   description: 'This is my amazing site, let me tell you all about it.',
@@ -103,7 +103,7 @@ use the computed getter syntax, the same as `useHead`.
 ```vue{}[app.vue]
 <script setup lang="ts">
 const data = useFetch(() => $fetch('/api/example'))
-useSeoMeta({
+useServerSeoMeta({
   ogTitle: () => `${data.value?.title} - My Site`,
   description: () => data.value?.description,
   ogDescription: () => data.value?.description,

--- a/packages/nuxt/src/head/module.ts
+++ b/packages/nuxt/src/head/module.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'pathe'
-import { addComponent, addImportsSources, addPlugin, defineNuxtModule } from '@nuxt/kit'
+import { addComponent, addPlugin, defineNuxtModule } from '@nuxt/kit'
 import { distDir } from '../dirs'
 
 const components = ['NoScript', 'Link', 'Base', 'Title', 'Meta', 'Style', 'Head', 'Html', 'Body']

--- a/packages/nuxt/src/head/module.ts
+++ b/packages/nuxt/src/head/module.ts
@@ -17,13 +17,6 @@ export default defineNuxtModule({
     // Add #head alias
     nuxt.options.alias['#head'] = runtimeDir
 
-    addImportsSources({
-      from: '@vueuse/head',
-      imports: [
-        'useSeoMeta'
-      ]
-    })
-
     // Register components
     const componentsPath = resolve(runtimeDir, 'components')
     for (const componentName of components) {

--- a/packages/nuxt/src/head/runtime/composables.ts
+++ b/packages/nuxt/src/head/runtime/composables.ts
@@ -24,8 +24,7 @@ export function useHead<T extends HeadAugmentations> (input: UseHeadInput<T>, op
  * This function will have no effect (and will return nothing) if called on the client.
  */
 export const useSeoMeta: typeof _useSeoMeta = (meta) => {
-  // SEO meta is
-  if (process.server || process.dev) {
+  if (process.server) {
     return _useSeoMeta(meta)
   }
 }

--- a/packages/nuxt/src/head/runtime/composables.ts
+++ b/packages/nuxt/src/head/runtime/composables.ts
@@ -1,5 +1,6 @@
 import type { HeadEntryOptions, UseHeadInput, ActiveHeadEntry } from '@vueuse/head'
 import type { HeadAugmentations } from '@nuxt/schema'
+import { useSeoMeta as _useSeoMeta } from '@vueuse/head'
 import { useNuxtApp } from '#app'
 
 /**
@@ -11,4 +12,20 @@ import { useNuxtApp } from '#app'
  */
 export function useHead<T extends HeadAugmentations> (input: UseHeadInput<T>, options?: HeadEntryOptions): ActiveHeadEntry<UseHeadInput<T>> | void {
   return useNuxtApp()._useHead(input, options)
+}
+
+/**
+ * The `useSeoMeta` composable lets you define your site's SEO meta tags
+ * as a flat object with full TypeScript support.
+ *
+ * This helps you avoid typos and common mistakes, such as using `name`
+ * instead of `property`.
+ *
+ * This function will have no effect (and will return nothing) if called on the client.
+ */
+export const useSeoMeta: typeof _useSeoMeta = (meta) => {
+  // SEO meta is
+  if (process.server || process.dev) {
+    return _useSeoMeta(meta)
+  }
 }

--- a/packages/nuxt/src/head/runtime/composables.ts
+++ b/packages/nuxt/src/head/runtime/composables.ts
@@ -21,9 +21,18 @@ export function useHead<T extends HeadAugmentations> (input: UseHeadInput<T>, op
  * This helps you avoid typos and common mistakes, such as using `name`
  * instead of `property`.
  *
- * This function will have no effect (and will return nothing) if called on the client.
+ * It is advised to use `useServerSeoMeta` unless you _need_ client-side
+ * rendering of your SEO meta tags.
  */
 export const useSeoMeta: typeof _useSeoMeta = (meta) => {
+  return _useSeoMeta(meta)
+}
+
+/**
+ * The `useServerSeoMeta` composable is identical to `useSeoMeta` except that
+ * it will have no effect (and will return nothing) if called on the client.
+ */
+export const useServerSeoMeta: typeof _useSeoMeta = (meta) => {
   if (process.server) {
     return _useSeoMeta(meta)
   }

--- a/packages/nuxt/src/imports/presets.ts
+++ b/packages/nuxt/src/imports/presets.ts
@@ -7,7 +7,8 @@ const commonPresets: InlinePreset[] = [
     from: '#head',
     imports: [
       'useHead',
-      'useSeoMeta'
+      'useSeoMeta',
+      'useServerSeoMeta'
     ]
   }),
   // vue-demi (mocked)

--- a/packages/nuxt/src/imports/presets.ts
+++ b/packages/nuxt/src/imports/presets.ts
@@ -6,7 +6,8 @@ const commonPresets: InlinePreset[] = [
   defineUnimportPreset({
     from: '#head',
     imports: [
-      'useHead'
+      'useHead',
+      'useSeoMeta'
     ]
   }),
   // vue-demi (mocked)


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/pull/18441

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR automatically excludes the `useSeoMeta` composable from the client-side bundle.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
