### PR TITLE
fix(nuxt): don't render unknown components with placeholder

### DIFF
--- a/packages/nuxt/src/components/loader.ts
+++ b/packages/nuxt/src/components/loader.ts
@@ -133,12 +133,14 @@ function findComponent (components: Component[], name: string, mode: LoaderOptio
   const component = components.find(component => id === component.pascalName && ['all', mode, undefined].includes(component.mode))
   if (component) { return component }
 
+  const otherModeComponent = components.find(component => id === component.pascalName)
+
   // Render client-only components on the server with <ServerPlaceholder> (a simple div)
-  if (mode === 'server' && !component && components.some(c => id === c.pascalName)) {
+  if (mode === 'server' && otherModeComponent) {
     return components.find(c => c.pascalName === 'ServerPlaceholder')
   }
 
   // Return the other-mode component in all other cases - we'll handle createClientOnly
   // and createServerComponent above
-  return components.find(component => id === component.pascalName)
+  return otherModeComponent
 }

--- a/packages/nuxt/src/components/loader.ts
+++ b/packages/nuxt/src/components/loader.ts
@@ -134,7 +134,7 @@ function findComponent (components: Component[], name: string, mode: LoaderOptio
   if (component) { return component }
 
   // Render client-only components on the server with <ServerPlaceholder> (a simple div)
-  if (mode === 'server' && !component) {
+  if (mode === 'server' && !component && components.some(c => id === c.pascalName)) {
     return components.find(c => c.pascalName === 'ServerPlaceholder')
   }
 

--- a/test/fixtures/basic/pages/index.vue
+++ b/test/fixtures/basic/pages/index.vue
@@ -16,6 +16,7 @@
     </NuxtLink>
     <NestedSugarCounter :multiplier="2" />
     <CustomComponent />
+    <Spin>Test</Spin>
     <component :is="`test${'-'.toString()}global`" />
     <component :is="`with${'-'.toString()}suffix`" />
     <ClientWrapped ref="clientRef" style="color: red;" class="client-only" />

--- a/test/fixtures/basic/plugins/register.ts
+++ b/test/fixtures/basic/plugins/register.ts
@@ -1,0 +1,13 @@
+import { defineComponent, h } from 'vue'
+
+const Spin = defineComponent({
+  setup (props, { slots }) {
+    return () => {
+      return h('div', slots.default?.())
+    }
+  }
+})
+
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.vueApp.component('Spin', Spin)
+})


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/18491
resolves https://github.com/nuxt/nuxt/issues/12341

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

A regression of https://github.com/nuxt/framework/pull/9972 was to load `<ServerPlaceholder>` for _all_ unknown components rather than confirming that there was in fact a client-only component corresponding to them.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
