### PR TITLE
fix(nuxt): do not override inferred type of `<NuxtPage>`

### DIFF
--- a/packages/nuxt/src/pages/runtime/page.ts
+++ b/packages/nuxt/src/pages/runtime/page.ts
@@ -1,5 +1,5 @@
 import { computed, defineComponent, h, provide, reactive, onMounted, nextTick, Suspense, Transition } from 'vue'
-import type { DefineComponent, VNode, KeepAliveProps, TransitionProps } from 'vue'
+import type { VNode, KeepAliveProps, TransitionProps } from 'vue'
 import { RouterView } from 'vue-router'
 import { defu } from 'defu'
 import type { RouteLocationNormalized, RouteLocationNormalizedLoaded, RouteLocation } from 'vue-router'
@@ -62,14 +62,7 @@ export default defineComponent({
       })
     }
   }
-}) as DefineComponent<{
-  name?: string
-  transition?: boolean | TransitionProps
-  keepalive?: boolean | KeepAliveProps
-  route?: RouteLocationNormalized
-  pageKey?: string | ((route: RouteLocationNormalizedLoaded) => string)
-  [key: string]: any
-}>
+})
 
 function _toArray (val: any) {
   return Array.isArray(val) ? val : (val ? [val] : [])

--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -11,7 +11,6 @@ import {
 } from 'vue-router'
 import { createError } from 'h3'
 import { withoutBase, isEqual } from 'ufo'
-import type NuxtPage from '../page'
 import { callWithNuxt, defineNuxtPlugin, useRuntimeConfig, showError, clearError, navigateTo, useError, useState, useRequestEvent } from '#app'
 // @ts-ignore
 import _routes from '#build/routes'
@@ -19,12 +18,6 @@ import _routes from '#build/routes'
 import routerOptions from '#build/router.options'
 // @ts-ignore
 import { globalMiddleware, namedMiddleware } from '#build/middleware'
-
-declare module '@vue/runtime-core' {
-  export interface GlobalComponents {
-    NuxtPage: typeof NuxtPage
-  }
-}
 
 // https://github.com/vuejs/router/blob/4a0cc8b9c1e642cdf47cc007fa5bbebde70afc66/packages/router/src/history/html5.ts#L37
 function createCurrentLocation (

--- a/packages/nuxt/types.d.ts
+++ b/packages/nuxt/types.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="nitropack" />
 export * from './dist/index'
 
-import type { Schema, SchemaDefinition } from '@nuxt/schema'
+import type { SchemaDefinition } from '@nuxt/schema'
 
 declare global {
   const defineNuxtConfig: typeof import('nuxt/config')['defineNuxtConfig']

--- a/test/fixtures/basic/types.ts
+++ b/test/fixtures/basic/types.ts
@@ -6,6 +6,7 @@ import type { AppConfig } from '@nuxt/schema'
 import type { FetchError } from 'ofetch'
 import type { NavigationFailure, RouteLocationNormalizedLoaded, RouteLocationRaw, useRouter as vueUseRouter } from 'vue-router'
 import { callWithNuxt, isVue3 } from '#app'
+import NuxtPage from '~~/../../../packages/nuxt/src/pages/runtime/page'
 import type { NavigateToOptions } from '~~/../../../packages/nuxt/dist/app/composables/router'
 import { defineNuxtConfig } from '~~/../../../packages/nuxt/config'
 import { useRouter } from '#imports'
@@ -152,6 +153,12 @@ describe('head', () => {
         return titleChunk ? `${titleChunk} - Site Title` : 'Site Title'
       }
     })
+  })
+})
+
+describe('components', () => {
+  it('includes types for NuxtPage', () => {
+    expectTypeOf(NuxtPage).not.toBeAny()
   })
 })
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/12395

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We were using an older format for the type of `<NuxtPage>`; this PR lets TS infer the type of the component (and removes a double type-definition via the router plugin).

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
