### PR TITLE
docs: add info about server-components async limits

### DIFF
--- a/docs/2.guide/2.directory-structure/1.components.md
+++ b/docs/2.guide/2.directory-structure/1.components.md
@@ -276,6 +276,10 @@ Now you can register server-only components with the `.server` suffix and use th
 </template>
 ```
 
+::alert{type=info}
+Please note that there is a known issue around server components: You cannot currently use async code in a server component, it will lead to hydration mismatch errors. See [#18500](https://github.com/nuxt/nuxt/issues/18500#issuecomment-1403528142). Until there is a workaround, server-components must be non-async.
+::
+
 ### Paired with a `.client` component
 
 In this case, the `.server` + `.client` components are two 'halves' of a component and can be used in advanced use cases for separate implementations of a component on server and client side.

--- a/docs/2.guide/2.directory-structure/1.components.md
+++ b/docs/2.guide/2.directory-structure/1.components.md
@@ -277,7 +277,7 @@ Now you can register server-only components with the `.server` suffix and use th
 ```
 
 ::alert{type=info}
-Please note that there is a known issue around server components: You cannot currently use async code in a server component, it will lead to hydration mismatch errors. See [#18500](https://github.com/nuxt/nuxt/issues/18500#issuecomment-1403528142). Until there is a workaround, server-components must be non-async.
+Please note that there is a known issue with using async code in a server component. It will lead to a hydration mismatch error on initial render. See [#18500](https://github.com/nuxt/nuxt/issues/18500#issuecomment-1403528142). Until there is a workaround, server-components must be synchronous.
 ::
 
 ### Paired with a `.client` component


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/18500#issuecomment-1403528142

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Due to a upstream vue issue, It's currently not possible to use async code in server components islands. To make this clear, I've added an info in this section.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

