### PR TITLE
fix(kit): don't use default export of defu

### DIFF
--- a/packages/kit/src/module/define.ts
+++ b/packages/kit/src/module/define.ts
@@ -1,5 +1,5 @@
 import { promises as fsp } from 'node:fs'
-import defu from 'defu'
+import { defu } from 'defu'
 import { applyDefaults } from 'untyped'
 import { dirname } from 'pathe'
 import type { Nuxt, NuxtModule, ModuleOptions, ModuleDefinition, NuxtOptions, ResolvedNuxtTemplate } from '@nuxt/schema'


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

For a reason that I don't really understand, I got the following error while using `loadNuxt` in an external (non-nuxt) vite server:
```
node-pre-gyp ERR!  TypeError: (0 , import_defu.default) is not a function
node-pre-gyp ERR!     at getOptions (/home/runner/work/JabRefOnline/JabRefOnline/node_modules/@nuxt/kit/dist/index.mjs:136:20)
node-pre-gyp ERR!     at normalizedModule (/home/runner/work/JabRefOnline/JabRefOnline/node_modules/@nuxt/kit/dist/index.mjs:163:28)
node-pre-gyp ERR!     at installModule (/home/runner/work/JabRefOnline/JabRefOnline/node_modules/@nuxt/kit/dist/index.mjs:352:9)
node-pre-gyp ERR!     at async initNuxt (file:///home/runner/work/JabRefOnline/JabRefOnline/node_modules/nuxt/dist/index.mjs:2044:7)
node-pre-gyp ERR!     at async loadNuxt (file:///home/runner/work/JabRefOnline/JabRefOnline/node_modules/nuxt/dist/index.mjs:2077:5)
node-pre-gyp ERR!     at loadNuxt (/home/runner/work/JabRefOnline/JabRefOnline/node_modules/@nuxt/kit/dist/index.mjs:519:19)
```
For some reason the line in the distributed file, `import defu, { defu as defu$1 } from 'defu';` results in these issues. I fixed it locally by using only the name export, and this is what this PR is doing.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

