### PR TITLE
docs: add link to pages documentation to routing

### DIFF
--- a/docs/1.getting-started/5.routing.md
+++ b/docs/1.getting-started/5.routing.md
@@ -38,15 +38,7 @@ pages/
 
 ::
 
-To display pages, use the `<NuxtPage />` tag:
-
-```vue [app.vue]
-<template>
-  <div>
-    <NuxtPage />
-  </div>
-</template>
-```
+:ReadMore{link="/docs/guide/directory-structure/pages"}
 
 ## Navigation
 

--- a/docs/1.getting-started/5.routing.md
+++ b/docs/1.getting-started/5.routing.md
@@ -38,6 +38,16 @@ pages/
 
 ::
 
+To display pages, use the `<NuxtPage />` tag:
+
+```vue [app.vue]
+<template>
+  <div>
+    <NuxtPage />
+  </div>
+</template>
+```
+
 ## Navigation
 
 The `<NuxtLink>` component links pages between them. It renders an `<a>` tag with the `href` attribute set to the route of the page. Once the application is hydrated, page transitions are performed in JavaScript by updating the browser URL. This prevents full-page refreshes and allows for animated transitions.


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Exemplify how to display pages with the router, so developers can get up to speed quicker.

It would be handy to have the code example in the `Routing` section as well, now I only came across it "accidentally" on the `Transitions` page (it took me a while to figure out how to display routes, being totally new to Nuxt).

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

