### PR TITLE
docs: updated unreachable docus url in documentation

### DIFF
--- a/docs/5.community/5.framework-contribution.md
+++ b/docs/5.community/5.framework-contribution.md
@@ -134,7 +134,7 @@ git checkout -b my-new-branch
 
 ### Set Up Documentation Website in Local Environment
 
-We are using [Docus](https://nuxtlabs.com/docus) for documentation.
+We are using [Docus](https://docus.dev) for documentation.
 
 - Run `pnpm build:stub` once in the root directory
 - Go into the docs directory: `cd docs`


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Updated the documentation where docus external url was giving 404 error.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

