### PR TITLE
fix(test-utils): prevent orphaned processes and use baseURL when loading

### DIFF
--- a/packages/test-utils/src/server.ts
+++ b/packages/test-utils/src/server.ts
@@ -30,12 +30,13 @@ export async function startServer () {
     for (let i = 0; i < 50; i++) {
       await new Promise(resolve => setTimeout(resolve, 100))
       try {
-        const res = await $fetch('/')
+        const res = await $fetch(ctx.nuxt!.options.app.baseURL)
         if (!res.includes('__NUXT_LOADING__')) {
           return
         }
       } catch {}
     }
+    ctx.serverProcess.kill()
     throw new Error('Timeout waiting for dev server!')
   } else {
     ctx.serverProcess = execa('node', [


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

resolves #12385

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This fixes two unrelated issues:

* when setup failed we were not killing the server, which meant we could collect quite a few orphaned node processes when there was an error in this case (as there was in the case of the reported bug, and how I noticed the issue)
* when we have a custom `baseURL`, we will never resolve fetching `/` - we needed to update this to the url actually served by the app

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

