### PR TITLE
perf(nuxt): simplify generated variable names

### DIFF
--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -6,6 +6,7 @@ import escapeRE from 'escape-string-regexp'
 import { hash } from 'ohash'
 import { camelCase } from 'scule'
 import { resolvePath } from 'mlly'
+import { filename } from 'pathe/utils'
 
 export interface TemplateContext {
   nuxt: Nuxt
@@ -53,7 +54,7 @@ export const clientPluginTemplate: NuxtTemplate<TemplateContext> = {
     const imports: string[] = []
     for (const plugin of clientPlugins) {
       const path = relative(ctx.nuxt.options.rootDir, plugin.src)
-      const variable = genSafeVariableName(path).replace(/_(45|46|47)/g, '_') + '_' + hash(path)
+      const variable = genSafeVariableName(filename(plugin.src)).replace(/_(45|46|47)/g, '_') + '_' + hash(path)
       exports.push(variable)
       imports.push(genImport(plugin.src, variable))
     }
@@ -72,7 +73,7 @@ export const serverPluginTemplate: NuxtTemplate<TemplateContext> = {
     const imports: string[] = []
     for (const plugin of serverPlugins) {
       const path = relative(ctx.nuxt.options.rootDir, plugin.src)
-      const variable = genSafeVariableName(path).replace(/_(45|46|47)/g, '_') + '_' + hash(path)
+      const variable = genSafeVariableName(filename(path)).replace(/_(45|46|47)/g, '_') + '_' + hash(path)
       exports.push(variable)
       imports.push(genImport(plugin.src, variable))
     }

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -4,6 +4,8 @@ import type { NuxtPage } from '@nuxt/schema'
 import { resolveFiles, useNuxt } from '@nuxt/kit'
 import { genImport, genDynamicImport, genArrayFromRaw, genSafeVariableName } from 'knitwork'
 import escapeRE from 'escape-string-regexp'
+import { filename } from 'pathe/utils'
+import { hash } from 'ohash'
 import { uniqueBy } from '../core/utils'
 
 enum SegmentParserState {
@@ -223,12 +225,11 @@ function prepareRoutes (routes: NuxtPage[], parent?: NuxtPage) {
 }
 
 export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = new Set()): { imports: Set<string>, routes: string } {
-  const nuxt = useNuxt()
   return {
     imports: metaImports,
     routes: genArrayFromRaw(routes.map((page) => {
       const file = normalize(page.file)
-      const metaImportName = genSafeVariableName(relative(nuxt.options.rootDir, file)) + 'Meta'
+      const metaImportName = genSafeVariableName(filename(file) + hash(file)) + 'Meta'
       metaImports.add(genImport(`${file}?macro=true`, [{ name: 'default', as: metaImportName }]))
 
       let aliasCode = `${metaImportName}?.alias || []`


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

As we are already hashing the generated variable names, we can shorten the variable name considerably. For exampl, the following was a generated variable name previously:

```ts
const node_modules__pnpm_nuxt3_643_1_2_rc_0_27918017_5037dd6_node_modules_nuxt3_dist_pages_runtime_plugins_router_mjs_VvNJnoBChR = defineNuxtPlugin(/* */)
```

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
