### PR TITLE
fix(vite): ensure `__publicAssetsURL` set before loading assets

### DIFF
--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -13,6 +13,7 @@ import { defineEventHandler } from 'h3'
 import { cacheDirPlugin } from './plugins/cache-dir'
 import type { ViteBuildContext, ViteOptions } from './vite'
 import { devStyleSSRPlugin } from './plugins/dev-ssr-css'
+import { runtimePathsPlugin } from './plugins/paths'
 import { viteNodePlugin } from './vite-node'
 
 export async function buildClient (ctx: ViteBuildContext) {
@@ -63,6 +64,9 @@ export async function buildClient (ctx: ViteBuildContext) {
       devStyleSSRPlugin({
         srcDir: ctx.nuxt.options.srcDir,
         buildAssetsURL: joinURL(ctx.nuxt.options.app.baseURL, ctx.nuxt.options.app.buildAssetsDir)
+      }),
+      runtimePathsPlugin({
+        sourcemap: ctx.nuxt.options.sourcemap.client
       }),
       viteNodePlugin(ctx)
     ],

--- a/packages/vite/src/plugins/paths.ts
+++ b/packages/vite/src/plugins/paths.ts
@@ -1,0 +1,27 @@
+import MagicString from 'magic-string'
+import type { Plugin } from 'vite'
+
+export interface RuntimePathsOptions {
+  sourcemap?: boolean
+}
+
+export function runtimePathsPlugin (options: RuntimePathsOptions): Plugin {
+  return {
+    name: 'nuxt:runtime-paths-dep',
+    enforce: 'post',
+    transform (code, id) {
+      if (code.includes('__VITE_ASSET__') || code.includes('__VITE_PUBLIC_ASSET__')) {
+        const s = new MagicString(code)
+        // Register dependency on paths.mjs, which sets globalThis.__publicAssetsURL
+        s.prepend('import "#build/paths.mjs";')
+
+        return {
+          code: s.toString(),
+          map: options.sourcemap
+            ? s.generateMap({ source: id, includeContent: true })
+            : undefined
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

With upgrade of vite/rollup, we now sometimes output separate chunks for assets which reference globally registered `__publicAssetsURL` function. But it's possible via race condition for this to be executed before the function is set (typically within entry - it's a side-effect of `#build/paths.mjs`). This PR ensures that this implicit dependency is made explicit.

Here's an example of the diff for a generated chunk for a logo url.

```diff
- const o=""+globalThis.__publicAssetsURL("logo.svg");export{o as _};
+ import"./entry.68b62826.js";const o=""+globalThis.__publicAssetsURL("logo.svg");export{o as _};
```

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
