### PR TITLE
fix(kit): avoid adding already installed modules to internal `_installedModules`

### DIFF
--- a/packages/kit/src/module/define.ts
+++ b/packages/kit/src/module/define.ts
@@ -41,8 +41,7 @@ export function defineNuxtModule<OptionsT extends ModuleOptions> (definition: Mo
     if (uniqueKey) {
       nuxt.options._requiredModules = nuxt.options._requiredModules || {}
       if (nuxt.options._requiredModules[uniqueKey]) {
-        // TODO: Notify user if inline options is provided since will be ignored!
-        return
+        return false
       }
       nuxt.options._requiredModules[uniqueKey] = true
     }

--- a/packages/kit/src/module/install.ts
+++ b/packages/kit/src/module/install.ts
@@ -9,7 +9,10 @@ export async function installModule (moduleToInstall: string | NuxtModule, _inli
   const { nuxtModule, inlineOptions } = await normalizeModule(moduleToInstall, _inlineOptions)
 
   // Call module
-  await nuxtModule(inlineOptions, nuxt)
+  const res = await nuxtModule(inlineOptions, nuxt)
+  if (res === false /* setup aborted */) {
+    return
+  }
 
   if (typeof moduleToInstall === 'string') {
     nuxt.options.build.transpile.push(moduleToInstall)

--- a/packages/schema/src/types/module.ts
+++ b/packages/schema/src/types/module.ts
@@ -38,7 +38,7 @@ export interface ModuleDefinition<T extends ModuleOptions = ModuleOptions> {
 /** Nuxt modules are always a simple function. */
 type Awaitable<T> = T | Promise<T>
 export interface NuxtModule<T extends ModuleOptions = ModuleOptions> {
-  (this: void, inlineOptions: T, nuxt: Nuxt): Awaitable<void|false>
+  (this: void, inlineOptions: T, nuxt: Nuxt): Awaitable<void | false>
   getOptions?: (inlineOptions?: T, nuxt?: Nuxt) => Promise<T>
   getMeta?: () => Promise<ModuleMeta>
 }

--- a/packages/schema/src/types/module.ts
+++ b/packages/schema/src/types/module.ts
@@ -36,8 +36,9 @@ export interface ModuleDefinition<T extends ModuleOptions = ModuleOptions> {
 }
 
 /** Nuxt modules are always a simple function. */
+type Awaitable<T> = T | Promise<T>
 export interface NuxtModule<T extends ModuleOptions = ModuleOptions> {
-  (this: void, inlineOptions: T, nuxt: Nuxt): void | Promise<void>
+  (this: void, inlineOptions: T, nuxt: Nuxt): Awaitable<void|false>
   getOptions?: (inlineOptions?: T, nuxt?: Nuxt) => Promise<T>
   getMeta?: () => Promise<ModuleMeta>
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

Reproductions:
- https://stackblitz.com/edit/github-g1pkrv?file=nuxt.config.ts
- https://github.com/Atinux/content-wind/tree/devtools

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In situations that same module is added twice (it can be result of merging layers mainly), kit already smartly deduplicates and avoids second install of module using unique key stored in `nuxt.options._requiredModules`. However the newer `nuxt.options._installedModules` containing meta, ignores this fact since setup was not signaling it's result.

This fixes issues both for toolings depending on new `_installedModules` API and also our generated types


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

