### PR TITLE
docs: mention options api equivalent for `head()`

### DIFF
--- a/docs/7.migration/4.meta.md
+++ b/docs/7.migration/4.meta.md
@@ -113,7 +113,7 @@ export default {
 // if using options API `head` method you must use `defineNuxtComponent`
 export default defineNuxtComponent({
   head (nuxtApp) {
-    // head receives the nuxt app but cannot access the component instance
+    // `head` receives the nuxt app but cannot access the component instance
     return {
       meta: [{
         name: 'description',

--- a/docs/7.migration/4.meta.md
+++ b/docs/7.migration/4.meta.md
@@ -18,6 +18,7 @@ Nuxt currently uses [`vueuse/head`](https://github.com/vueuse/head) to manage yo
 
 1. In your `nuxt.config`, rename `head` to `meta`. Consider moving this shared meta configuration into your `app.vue` instead. (Note that objects no longer have a `hid` key for deduplication.)
 1. If you need to access the component state with `head`, you should migrate to using `useHead`. You might also consider using the built-in meta-components.
+1. If you need to use the Options API, there is a `head()` method you can use when you use `defineNuxtComponent`.
 
 ### Example: `useHead`
 
@@ -104,3 +105,22 @@ export default {
 1. Make sure you use capital letters for these component names to distinguish them from native HTML elements (`<Title>` rather than `<title>`).
 1. You can place these components anywhere in your template for your page.
 ::
+
+### Example: Options API
+
+```vue [Nuxt 3 (Options API)]
+<script>
+// if using options API `head` method you must use `defineNuxtComponent`
+export default defineNuxtComponent({
+  head (nuxtApp) {
+    // head receives the nuxt app but cannot access the component instance
+    return {
+      meta: [{
+        name: 'description',
+        content: 'This is my page description.'
+      }]
+    }
+  }
+})
+</script>
+```


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/15743

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds a comment in the migration guide regarding Options API equivalent for setting head data.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
