### PR TITLE
feat(schema): add type hints for runtime config

### DIFF
--- a/packages/schema/src/types/config.ts
+++ b/packages/schema/src/types/config.ts
@@ -29,20 +29,22 @@ type SliceLast<T extends string> = T extends `${infer A}${infer B}`
 
 type UpperSnakeCase<T extends string, State extends 'start' | 'lower' | 'upper' = 'start'> = T extends `${infer A}${infer B}`
   ? A extends Uppercase<A>
-    ? State extends 'lower' | 'upper'
-      ? B extends `${SliceLast<ExtractUpperChunk<B>>}${infer Rest}`
-        ? SliceLast<ExtractUpperChunk<B>> extends ''
-          ? `_${A}_${UpperSnakeCase<B, 'start'>}`
-          : `_${A}${SliceLast<ExtractUpperChunk<B>>}_${UpperSnakeCase<Rest, 'start'>}`
-        : B extends Uppercase<B>
-          ? `_${A}${B}`
-          : `_${A}${UpperSnakeCase<B, 'lower'>}`
-      : State extends 'start'
-        ? `${A}${UpperSnakeCase<B, 'lower'>}`
-        : never
-    : State extends 'start' | 'lower'
-      ? `${Uppercase<A>}${UpperSnakeCase<B, 'lower'>}`
-      : `_${Uppercase<A>}${UpperSnakeCase<B, 'lower'>}`
+    ? A extends `${1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 0}`
+      ? `${A}${UpperSnakeCase<B, 'lower'>}`
+      : State extends 'lower' | 'upper'
+        ? B extends `${SliceLast<ExtractUpperChunk<B>>}${infer Rest}`
+          ? SliceLast<ExtractUpperChunk<B>> extends ''
+            ? `_${A}_${UpperSnakeCase<B, 'start'>}`
+            : `_${A}${SliceLast<ExtractUpperChunk<B>>}_${UpperSnakeCase<Rest, 'start'>}`
+          : B extends Uppercase<B>
+            ? `_${A}${B}`
+            : `_${A}${UpperSnakeCase<B, 'lower'>}`
+        : State extends 'start'
+          ? `${A}${UpperSnakeCase<B, 'lower'>}`
+          : never
+      : State extends 'start' | 'lower'
+        ? `${Uppercase<A>}${UpperSnakeCase<B, 'lower'>}`
+        : `_${Uppercase<A>}${UpperSnakeCase<B, 'lower'>}`
   : Uppercase<T>
 
 const message = Symbol('message')

--- a/packages/schema/src/types/config.ts
+++ b/packages/schema/src/types/config.ts
@@ -9,10 +9,35 @@ export type { SchemaDefinition } from 'untyped'
 
 type DeepPartial<T> = T extends Function ? T : T extends Record<string, any> ? { [P in keyof T]?: DeepPartial<T[P]> } : T
 
+type UpperSnakeCase<T extends string> = T extends `${infer A}_${infer B}`
+  ? `${UpperSnakeCase<A>}_${Uppercase<B>}`
+  : T extends `${infer A}${infer B}`
+    ? A extends Uppercase<A>
+      ? B extends `${Uppercase<string>}${infer D}`
+        ? D[0] extends Lowercase<D[0]>
+          ? B extends `${infer C}${D}`
+            ? `_${A}${C}${UpperSnakeCase<D>}`
+            : never
+          : `_${A}${B}`
+        : `_${A}${UpperSnakeCase<B>}`
+      : `${Uppercase<A>}${UpperSnakeCase<B>}`
+    : Uppercase<T>
+
+const message = Symbol('message')
+export type RuntimeValue<T, B extends string> = T & { [message]?: B }
+type Overrideable<T extends Record<string, any>, Path extends string = ''> = {
+  [K in keyof T]?: K extends string
+    ? T[K] extends Record<string, any>
+      ? RuntimeValue<Overrideable<T[K], `${Path}_${UpperSnakeCase<K>}`>, `You can override this value at runtime with NUXT${Path}_${UpperSnakeCase<K>}`>
+      : RuntimeValue<T[K], `You can override this value at runtime with NUXT${Path}_${UpperSnakeCase<K>}`>
+    : never
+}
+
 /** User configuration in `nuxt.config` file */
-export interface NuxtConfig extends DeepPartial<Omit<ConfigSchema, 'vite'>> {
+export interface NuxtConfig extends DeepPartial<Omit<ConfigSchema, 'vite' | 'runtimeConfig'>> {
   // Avoid DeepPartial for vite config interface (#4772)
   vite?: ConfigSchema['vite']
+  runtimeConfig?: Overrideable<RuntimeConfig>
 
   /**
    * Experimental custom config schema

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -49,6 +49,8 @@ export default defineNuxtConfig({
     }
   },
   runtimeConfig: {
+    baseURL: '',
+    baseAPIToken: '',
     privateConfig: 'secret_key',
     public: {
       needsFallback: undefined,

--- a/test/fixtures/basic/types.ts
+++ b/test/fixtures/basic/types.ts
@@ -131,18 +131,16 @@ describe('runtimeConfig', () => {
   it('provides hints on overriding these values', () => {
     const val = defineNuxtConfig({
       runtimeConfig: {
-        privateConfig: 'secret_key',
         public: {
-          // automatically generated fallback
-          needsFallback: '',
           // @ts-expect-error
           testConfig: 'test'
-        },
-        other: 'value'
+        }
       }
     })
     expectTypeOf(val.runtimeConfig!.public!.testConfig).toEqualTypeOf<undefined | RuntimeValue<number, 'You can override this value at runtime with NUXT_PUBLIC_TEST_CONFIG'>>()
     expectTypeOf(val.runtimeConfig!.privateConfig).toEqualTypeOf<undefined | RuntimeValue<string, 'You can override this value at runtime with NUXT_PRIVATE_CONFIG'>>()
+    expectTypeOf(val.runtimeConfig!.baseURL).toEqualTypeOf<undefined | RuntimeValue<string, 'You can override this value at runtime with NUXT_BASE_URL'>>()
+    expectTypeOf(val.runtimeConfig!.baseAPIToken).toEqualTypeOf<undefined | RuntimeValue<string, 'You can override this value at runtime with NUXT_BASE_API_TOKEN'>>()
     expectTypeOf(val.runtimeConfig!.unknown).toEqualTypeOf<any>()
   })
 })

--- a/test/fixtures/basic/types.ts
+++ b/test/fixtures/basic/types.ts
@@ -1,7 +1,7 @@
 import { expectTypeOf } from 'expect-type'
 import { describe, it } from 'vitest'
 import type { Ref } from 'vue'
-import type { AppConfig } from '@nuxt/schema'
+import type { AppConfig, RuntimeValue } from '@nuxt/schema'
 
 import type { FetchError } from 'ofetch'
 import type { NavigationFailure, RouteLocationNormalizedLoaded, RouteLocationRaw, useRouter as vueUseRouter } from 'vue-router'
@@ -124,8 +124,26 @@ describe('runtimeConfig', () => {
   it('generated runtimeConfig types', () => {
     const runtimeConfig = useRuntimeConfig()
     expectTypeOf(runtimeConfig.public.testConfig).toEqualTypeOf<number>()
+    expectTypeOf(runtimeConfig.public.needsFallback).toEqualTypeOf<string>()
     expectTypeOf(runtimeConfig.privateConfig).toEqualTypeOf<string>()
     expectTypeOf(runtimeConfig.unknown).toEqualTypeOf<any>()
+  })
+  it('provides hints on overriding these values', () => {
+    const val = defineNuxtConfig({
+      runtimeConfig: {
+        privateConfig: 'secret_key',
+        public: {
+          // automatically generated fallback
+          needsFallback: '',
+          // @ts-expect-error
+          testConfig: 'test'
+        },
+        other: 'value'
+      }
+    })
+    expectTypeOf(val.runtimeConfig!.public!.testConfig).toEqualTypeOf<undefined | RuntimeValue<number, 'You can override this value at runtime with NUXT_PUBLIC_TEST_CONFIG'>>()
+    expectTypeOf(val.runtimeConfig!.privateConfig).toEqualTypeOf<undefined | RuntimeValue<string, 'You can override this value at runtime with NUXT_PRIVATE_CONFIG'>>()
+    expectTypeOf(val.runtimeConfig!.unknown).toEqualTypeOf<any>()
   })
 })
 


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/pull/18594#discussion_r1090512835

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds type hints (within nuxt.config only, not within `useRuntimeConfig`) to advise on the way to override runtime config:

<img width="836" alt="CleanShot 2023-01-31 at 22 58 22@2x" src="https://user-images.githubusercontent.com/28706372/215903089-9f071c5f-50a1-45cd-841d-173f3b5e66db.png">

I would value some testing on this and improving the algorithm to make sure we are matching `scule`. (We might also move into `scule` itself if you like @pi0, and that way we could add more type tests there.)

BTW, I initially considered using https://github.com/sindresorhus/type-fest/blob/main/source/snake-case.d.ts but there were issues with it (e.g. `baseURL` and `PascalCase` both gave incorrect results) and I thought better to take a completely different approach.

▶️ [**TypeScript playground**](https://www.typescriptlang.org/play#code/C4TwDgpgBAogHsATgQwMbAKpkogwgCwFcA7AawB4AVKCBCYgEwGcomkBLYgcwD4oBeKNVrB6zKAAMAJAG9OAMwiIoAQQC+shUqgAhNRIBQUKAH5VNOoxZYcqZEwjkVPI8dO6Loq5Nk2ldh3I2RE5eDTliRWUAJQg2fVc3dx1PMRZpCKioXHDY+MMkpLMM9Vkc2XgkNExsJQISCjzgHgTCtwAuKGIIADclRI7VAc6AchHXTu6+xAMDUEgoAGUAG3ZUCAAZe2AqVO9g0L5BYUtxDK1lUsztPQLkvbPNSO1y6+UAEVa3M3eHljGBsYzCpAVBOiVwq8VmtNttyO8WndjKNxsiur1+nNwNA-IhFsRkKQILh7I4Tl5xAduAAaJbAZCiP5QEZsZCIYAjKAAH2ZywA9gB3JScnkjQi1RCcwQs+nskZHIRM87PS7hC66L7Apm4gKOZwDLUiNI+GQARm5UAATBaAMwWgAsFoArBaAGwWgDsFoAHBaAJwWgAMXyKJquuPxhOJpPIOlpI35QsliNBnUW9MZRu8CcFwotYolqLa9yzjxk0PWWzY5EqKHQuPqZFjPBaTyyTRDxbMFdh1dr1QbRCbOhbTIBxcKxQA+rJ1DOZBGCUSSYE48zWXKUxOkuD51ce1Wdv36xLGxQRy154uoyvHE14xuOVvt50UqXrBLdc3QW1p7PwrcP6FLu-6+BKkbLjGa45km8qdjudIMtA77rrKHJAUCYbhNekGrvGibCs+E6TBiMxtGmGbIac-yPiKvK5pKQHFGBtgxs42HgUu0Z4fRsFEcBkhXp+bGtgunE3lB+EMXBdydDqMaUC4swAPTKVAABifLKMgPR8uwDDIMQ6xQHy8hQAwfKEAARsAtLzNAVkQPgOnsJZyhMPglnLAwUAALYMqg+BQMA+DQEwXG3lAhDAOwqygFA8iIHyvnrqghDLBA4yqVA+DAMAYBMO0qlcOwIXWQAdKgyXKSQABWTDKUwaUZcpVn8lZyn+ZwjWIKgymcAwtDlcATAAMQbKagY2gAtBNgYegYIzqQA8stU46Co0SckwDLsEw8jsHEUA4dxjgjPIfJ8jobLyotK1rRtW2sLt+2HR+OAQad5BLZd13Jndq3rZt20vQdR0nbe32aVdwMuEtgOPUDABaIMxa94PibhZ3Q4910AF63SMKgAAoAJJTpQy0ANIwAAcpaNrI6je1g+9SifZDIzIGA7CUHyRLEAz+OEyT5OUzT9M2htKPPWjrPHZjX1czzfMCwzVnIATPBAA).

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
