### PR TITLE
chore: upgrade unjs dependencies

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -16,9 +16,9 @@
     "destr": "^1.2.2",
     "dotenv": "^16.0.3",
     "lodash": "^4.17.21",
-    "rc9": "^1.2.4",
+    "rc9": "^2.0.1",
     "std-env": "^3.3.1",
-    "ufo": "^0.8.6"
+    "ufo": "^1.0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -16,7 +16,7 @@
     "fs-extra": "^10.1.0",
     "html-minifier": "^4.0.0",
     "node-html-parser": "^6.1.4",
-    "ufo": "^0.8.6"
+    "ufo": "^1.0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -24,7 +24,7 @@
     "serve-placeholder": "^1.2.4",
     "serve-static": "^1.15.0",
     "server-destroy": "^1.0.1",
-    "ufo": "^0.8.6"
+    "ufo": "^1.0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -19,7 +19,7 @@
     "serialize-javascript": "^6.0.1",
     "signal-exit": "^3.0.7",
     "ua-parser-js": "^1.0.33",
-    "ufo": "^0.8.6"
+    "ufo": "^1.0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/vue-app/package.json
+++ b/packages/vue-app/package.json
@@ -14,7 +14,7 @@
   ],
   "dependencies": {
     "node-fetch-native": "^1.0.1",
-    "ufo": "^0.8.6",
+    "ufo": "^1.0.1",
     "unfetch": "^4.2.0",
     "vue": "^2.7.10",
     "vue-client-only": "^2.1.0",

--- a/packages/vue-renderer/package.json
+++ b/packages/vue-renderer/package.json
@@ -15,7 +15,7 @@
     "fs-extra": "^10.1.0",
     "lodash": "^4.17.21",
     "lru-cache": "^5.1.1",
-    "ufo": "^0.8.6",
+    "ufo": "^1.0.1",
     "vue": "^2.7.10",
     "vue-meta": "^2.4.0",
     "vue-server-renderer": "^2.7.14"

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -42,7 +42,7 @@
     "terser-webpack-plugin": "^4.2.3",
     "thread-loader": "^3.0.4",
     "time-fix-plugin": "^2.0.7",
-    "ufo": "^0.8.6",
+    "ufo": "^1.0.1",
     "url-loader": "^4.1.1",
     "vue-loader": "^15.10.1",
     "vue-style-loader": "^4.1.3",

--- a/test/dev/async-config.size-limit.test.js
+++ b/test/dev/async-config.size-limit.test.js
@@ -26,7 +26,7 @@ describe('nuxt basic resources size limit', () => {
     const LEGACY_JS_RESOURCES_GZIP_KB_SIZE = 88
     expect(legacyResourcesSize.gzip).toBeWithinSize(LEGACY_JS_RESOURCES_GZIP_KB_SIZE)
 
-    const LEGACY_JS_RESOURCES_BROTLI_KB_SIZE = 72
+    const LEGACY_JS_RESOURCES_BROTLI_KB_SIZE = 73
     expect(legacyResourcesSize.brotli).toBeWithinSize(LEGACY_JS_RESOURCES_BROTLI_KB_SIZE)
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12218,7 +12218,7 @@ raw-body@2.5.1:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-rc9@^1.2.0, rc9@^1.2.4:
+rc9@^1.2.0:
   version "1.2.4"
   resolved "https://registry.npmjs.org/rc9/-/rc9-1.2.4.tgz#a625f5ec63a54eebd66114eb9c6ce9a6c54dfac8"
   integrity sha512-YD1oJO9LUzMdmr2sAsVlwQVtEoDCmvuyDwmSWrg2GKFprl3BckP5cmw9rHPunei0lV6Xl4E5t2esT+0trY1xfQ==
@@ -12226,6 +12226,15 @@ rc9@^1.2.0, rc9@^1.2.4:
     defu "^6.0.0"
     destr "^1.1.1"
     flat "^5.0.0"
+
+rc9@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/rc9/-/rc9-2.0.1.tgz#51e0f556759ee434e20ed29ca506b4ce97e7c6c0"
+  integrity sha512-9EfjLgNmzP9255YX8bGnILQcmdtOXKtUlFTu8bOZPJVtaUDZ2imswcUdpK51tMjTRQyB7r5RebNijrzuyGXcVA==
+  dependencies:
+    defu "^6.1.2"
+    destr "^1.2.2"
+    flat "^5.0.2"
 
 react-is@^18.0.0:
   version "18.2.0"
@@ -14015,10 +14024,10 @@ ua-parser-js@^1.0.33:
   resolved "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.33.tgz#f21f01233e90e7ed0f059ceab46eb190ff17f8f4"
   integrity sha512-RqshF7TPTE0XLYAqmjlu5cLLuGdKrNu9O1KLA/qp39QtbZwuzwv1dT46DZSopoUMsYgXpB3Cv8a03FI8b74oFQ==
 
-ufo@^0.8.6:
-  version "0.8.6"
-  resolved "https://registry.npmjs.org/ufo/-/ufo-0.8.6.tgz#c0ec89bc0e0c9fa59a683680feb0f28b55ec323b"
-  integrity sha512-fk6CmUgwKCfX79EzcDQQpSCMxrHstvbLswFChHS0Vump+kFkw7nJBfTZoC1j0bOGoY9I7R3n2DGek5ajbcYnOw==
+ufo@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/ufo/-/ufo-1.0.1.tgz#64ed43b530706bda2e4892f911f568cf4cf67d29"
+  integrity sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==
 
 uglify-js@^3.1.4, uglify-js@^3.5.1:
   version "3.17.4"


### PR DESCRIPTION
### 📚 Description

This bumps ufo + rc9 dependencies. When we release next patch of v1 nuxt/telemetry, we will then lose the previous rc9 dep.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

