### PR TITLE
v2.16.0

### DIFF
--- a/distributions/nuxt-start/package.json
+++ b/distributions/nuxt-start/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-start",
-  "version": "2.15.8",
+  "version": "2.16.0",
   "description": "Starts Nuxt Application in production mode",
   "keywords": [
     "nuxt",
@@ -26,13 +26,13 @@
     "dist"
   ],
   "dependencies": {
-    "@nuxt/cli": "2.15.8",
-    "@nuxt/config": "2.15.8",
-    "@nuxt/core": "2.15.8",
-    "@nuxt/server": "2.15.8",
+    "@nuxt/cli": "2.16.0",
+    "@nuxt/config": "2.16.0",
+    "@nuxt/core": "2.16.0",
+    "@nuxt/server": "2.16.0",
     "@nuxt/telemetry": "^1.4.1",
-    "@nuxt/utils": "2.15.8",
-    "@nuxt/vue-renderer": "2.15.8",
+    "@nuxt/utils": "2.16.0",
+    "@nuxt/vue-renderer": "2.16.0",
     "node-fetch-native": "^1.0.1",
     "vue": "^2.7.10",
     "vue-client-only": "^2.1.0",

--- a/distributions/nuxt/package.json
+++ b/distributions/nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt",
-  "version": "2.15.8",
+  "version": "2.16.0",
   "description": "A minimalistic framework for server-rendered Vue.js applications (inspired by Next.js)",
   "keywords": [
     "nuxt",
@@ -31,21 +31,21 @@
     "postinstall": "opencollective || exit 0"
   },
   "dependencies": {
-    "@nuxt/babel-preset-app": "2.15.8",
-    "@nuxt/builder": "2.15.8",
-    "@nuxt/cli": "2.15.8",
+    "@nuxt/babel-preset-app": "2.16.0",
+    "@nuxt/builder": "2.16.0",
+    "@nuxt/cli": "2.16.0",
     "@nuxt/components": "^2.2.1",
-    "@nuxt/config": "2.15.8",
-    "@nuxt/core": "2.15.8",
-    "@nuxt/generator": "2.15.8",
+    "@nuxt/config": "2.16.0",
+    "@nuxt/core": "2.16.0",
+    "@nuxt/generator": "2.16.0",
     "@nuxt/loading-screen": "^2.0.4",
     "@nuxt/opencollective": "^0.3.3",
-    "@nuxt/server": "2.15.8",
+    "@nuxt/server": "2.16.0",
     "@nuxt/telemetry": "^1.4.1",
-    "@nuxt/utils": "2.15.8",
-    "@nuxt/vue-app": "2.15.8",
-    "@nuxt/vue-renderer": "2.15.8",
-    "@nuxt/webpack": "2.15.8"
+    "@nuxt/utils": "2.16.0",
+    "@nuxt/vue-app": "2.16.0",
+    "@nuxt/vue-renderer": "2.16.0",
+    "@nuxt/webpack": "2.16.0"
   },
   "collective": {
     "url": "https://opencollective.com/nuxtjs",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.15.8",
+  "version": "2.16.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "conventionalCommits": true,

--- a/packages/babel-preset-app/package.json
+++ b/packages/babel-preset-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxt/babel-preset-app",
-  "version": "2.15.8",
+  "version": "2.16.0",
   "description": "babel-preset-app for nuxt",
   "repository": "nuxt/nuxt.js",
   "license": "MIT",

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxt/builder",
-  "version": "2.15.8",
+  "version": "2.16.0",
   "repository": "nuxt/nuxt.js",
   "license": "MIT",
   "main": "dist/builder.js",
@@ -9,9 +9,9 @@
   ],
   "dependencies": {
     "@nuxt/devalue": "^2.0.0",
-    "@nuxt/utils": "2.15.8",
-    "@nuxt/vue-app": "2.15.8",
-    "@nuxt/webpack": "2.15.8",
+    "@nuxt/utils": "2.16.0",
+    "@nuxt/vue-app": "2.16.0",
+    "@nuxt/webpack": "2.16.0",
     "chalk": "^4.1.2",
     "chokidar": "^3.5.3",
     "consola": "^2.15.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxt/cli",
-  "version": "2.15.8",
+  "version": "2.16.0",
   "repository": "nuxt/nuxt.js",
   "license": "MIT",
   "main": "dist/cli.js",
@@ -12,8 +12,8 @@
     "dist"
   ],
   "dependencies": {
-    "@nuxt/config": "2.15.8",
-    "@nuxt/utils": "2.15.8",
+    "@nuxt/config": "2.16.0",
+    "@nuxt/utils": "2.16.0",
     "boxen": "^5.1.2",
     "chalk": "^4.1.2",
     "compression": "^1.7.4",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxt/config",
-  "version": "2.15.8",
+  "version": "2.16.0",
   "repository": "nuxt/nuxt.js",
   "license": "MIT",
   "main": "dist/config.js",
@@ -10,7 +10,7 @@
     "index.d.ts"
   ],
   "dependencies": {
-    "@nuxt/utils": "2.15.8",
+    "@nuxt/utils": "2.16.0",
     "consola": "^2.15.3",
     "defu": "^6.1.2",
     "destr": "^1.2.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxt/core",
-  "version": "2.15.8",
+  "version": "2.16.0",
   "repository": "nuxt/nuxt.js",
   "license": "MIT",
   "main": "dist/core.js",
@@ -8,9 +8,9 @@
     "dist"
   ],
   "dependencies": {
-    "@nuxt/config": "2.15.8",
-    "@nuxt/server": "2.15.8",
-    "@nuxt/utils": "2.15.8",
+    "@nuxt/config": "2.16.0",
+    "@nuxt/server": "2.16.0",
+    "@nuxt/utils": "2.16.0",
     "consola": "^2.15.3",
     "fs-extra": "^10.1.0",
     "hable": "^3.0.0",

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxt/generator",
-  "version": "2.15.8",
+  "version": "2.16.0",
   "repository": "nuxt/nuxt.js",
   "license": "MIT",
   "main": "dist/generator.js",
@@ -8,7 +8,7 @@
     "dist"
   ],
   "dependencies": {
-    "@nuxt/utils": "2.15.8",
+    "@nuxt/utils": "2.16.0",
     "chalk": "^4.1.2",
     "consola": "^2.15.3",
     "defu": "^6.1.2",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxt/server",
-  "version": "2.15.8",
+  "version": "2.16.0",
   "repository": "nuxt/nuxt.js",
   "license": "MIT",
   "main": "dist/server.js",
@@ -8,8 +8,8 @@
     "dist"
   ],
   "dependencies": {
-    "@nuxt/utils": "2.15.8",
-    "@nuxt/vue-renderer": "2.15.8",
+    "@nuxt/utils": "2.16.0",
+    "@nuxt/vue-renderer": "2.16.0",
     "@nuxtjs/youch": "^4.2.3",
     "compression": "^1.7.4",
     "connect": "^3.7.0",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxt/types",
-  "version": "2.15.8",
+  "version": "2.16.0",
   "description": "Nuxt types",
   "repository": "nuxt/nuxt.js",
   "license": "MIT",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxt/utils",
-  "version": "2.15.8",
+  "version": "2.16.0",
   "repository": "nuxt/nuxt.js",
   "license": "MIT",
   "main": "dist/utils.js",

--- a/packages/vue-app/package.json
+++ b/packages/vue-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxt/vue-app",
-  "version": "2.15.8",
+  "version": "2.16.0",
   "repository": "nuxt/nuxt.js",
   "license": "MIT",
   "main": "dist/vue-app.js",

--- a/packages/vue-renderer/package.json
+++ b/packages/vue-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxt/vue-renderer",
-  "version": "2.15.8",
+  "version": "2.16.0",
   "repository": "nuxt/nuxt.js",
   "license": "MIT",
   "main": "dist/vue-renderer.js",
@@ -9,7 +9,7 @@
   ],
   "dependencies": {
     "@nuxt/devalue": "^2.0.0",
-    "@nuxt/utils": "2.15.8",
+    "@nuxt/utils": "2.16.0",
     "consola": "^2.15.3",
     "defu": "^6.1.2",
     "fs-extra": "^10.1.0",

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxt/webpack",
-  "version": "2.15.8",
+  "version": "2.16.0",
   "repository": "nuxt/nuxt.js",
   "license": "MIT",
   "main": "dist/webpack.js",
@@ -9,9 +9,9 @@
   ],
   "dependencies": {
     "@babel/core": "^7.20.12",
-    "@nuxt/babel-preset-app": "2.15.8",
+    "@nuxt/babel-preset-app": "2.16.0",
     "@nuxt/friendly-errors-webpack-plugin": "^2.5.2",
-    "@nuxt/utils": "2.15.8",
+    "@nuxt/utils": "2.16.0",
     "babel-loader": "^8.3.0",
     "cache-loader": "^4.1.0",
     "caniuse-lite": "^1.0.30001450",


### PR DESCRIPTION
> Nuxt 2.16.0 is the first minor release since Feb 15, 2021. The focus is mostly on releasing the latest fixes and enhancements that have been present in `nuxt-edge` for some time.
>
> **Timetable**: later this week.

## ✨ Highlights

* upgrade to [PostCSS 8](https://github.com/nuxt/nuxt/pull/9671)
* default to [`core-js` v3](https://github.com/nuxt/nuxt/pull/9987)
* ... full details below

## ⚠️ Breaking changes

* **In this PR we only support Node 14+**. This is mostly an issue for dependencies, which we need to keep updated for security reasons. Going forward until [its own EOL](https://nuxt.com/vision-2023#migrating-to-nuxt-3), Nuxt 2 will only officially support Node versions that have not reached [their EOL](https://github.com/nodejs/release#release-schedule).
* **New postcss options format**. See https://github.com/nuxt/nuxt/pull/9671 for full details.
* **Dependency upgrades**. A number of dependencies have dropped support for earlier node versions. [`dotenv`](https://github.com/nuxt/nuxt/pull/18364) has changed how it parses `.env` files in a number of edge cases. [`glob`](https://github.com/nuxt/nuxt/pull/18370) now requires `/` instead of `\` on windows machines. There may also be other changes that affect your usage, so please do upgrade with care.
* **Vue 2.7 upgrade**. Although you can use Vue 2.7 with any release of Nuxt 2, 2.16.0 for the first time includes it as a dependency, which means that you may well encounter some issues associated with upgrading Vue 2.6 -> Vue 2.7.

   This may be a good time to consider using the composition API utilities provided by https://github.com/nuxt/bridge instead, which mirror Nuxt 3's more precisely than `@nuxtjs/composition-api`. (You can opt-in to _just_ these utilities by disabling the other bridge modules individually.)

## Changelog

[compare changes](https://github.com/nuxt/nuxt/compare/v2.15.8...v2.16.0)


### 🚀 Enhancements

  - **config:** Support `nuxtrc` in dist directory (#9280)
  - **generator:** Add ignoreEnv generate option during ensureBuild(cmd) (#8955)
  - **server:** Allow disabling `serve-static` middleware (#9365)
  - **types:** Add `asyncData` return types to component instance type (#9239)
  - **vue-app:** `context.beforeSerialize` method (#9332)
  - **vue-app:** Pass `store` to `createRouter` (#9629)
  - Default to `core-js` version 3 (#9987)
  - **webpack:** ⚠️  Update postcss to v8 (#9671)

### 🩹 Fixes

  - **vue-app:** Respect `scroll-margin-top` when navigating with hash (#9187)
  - **webpack:** Use `javascript/auto` for js rule (#9180)
  - **server:** Unregister error event listener (#9245)
  - **babel-preset-app:** Respect explicit options.targets for modern preset (#9337)
  - **types:** Add nuxt.config alias type (#9424)
  - **vue-app:** Check whether route exists within nuxt app before replacing (#9431)
  - **vue-renderer:** Decode route path for `payload.js` (#9494)
  - **vue-app:** Don't normalise route path if it's valid (#9460)
  - **vue-app:** Redirect to external url replaces current history entry (#9500)
  - **utils:** `trailingSlash` causes error with dynamic nuxt-child routes (#9505)
  - **types:** Add `onNuxtLoaded` and `onNuxtReady` types (#9510)
  - **vue-app:** Re-register components construtor in HMR (#9539)
  - **types:** Add typing for `build.stats` options (#9555)
  - **babel:** Loose option for babel private-property-in-object (#9631)
  - **vue-app:** Serialize route meta to allow functions (#9634)
  - **vue-app:** `null` check for `$root` access (#9150)
  - **generator:** Allow passing `builder` to `getGenerator` (#9574)
  - **generator:** Throw an error when Builder is missing (#9663)
  - **vue-app:** Use correct `$config` for finding basePath (#9706)
  - **vue-renderer:** Ensure custom build indicator preserves some whitespace (#9705)
  - 'npm run test' fails because the last command lacks 'yarn' (#9761)
  - **generator:** Decode path with `ufo` (#9739)
  - **cli:** Ensure nuxt instance is closed when skipping build (3e9d7e3e7)
  - Nuxt-child-key in web-types.json (#9792)
  - **types:** Return type of $fetch (#9854)
  - **deps:** Update `ua-parser-js` to 1.x (#9979)
  - **deps:** Update `ya-parser-js` to latest `0.7.x` (#9979)
  - **vue-app:** Call ssrContext.unsetMutationObserver only if it exists (#10132)
  - **webpack:** Allow files with `.cjs` extension to be transpiled (#10340)
  - **vue-app:** Preview mode fetch (#10489)
  - **webpack:** Resolve `.wasm` extension with lower priority (#10676)
  - **vue-app:** Clear hide timeout when calling `clear()` (#10086)

### 📦 Build

  - Use 7 digit edge hashes (0501a424b)
  - Upgrade to rollup v3 (#18686)

### 🌊 Types

  - Add `prefetchPayloads` to router options (#9715)

### 🏡 Chore

  - **release:** V2.15.6 (a53fd32d6)
  - **pkg:** Build for es2019 target (#9328)
  - **types:** Add types for new `false` option for `render.static` (#9372)
  - Update error tests (d4e5998f9)
  - **test:** Revert jest and babel-jest to 26 (#9377)
  - Ignore audit 1754,1755 (39f785967)
  - Fix vetur extension syntax for GitPod (#9572)
  - Ignore globby > 12 upgrade as needs native esm (e0968a3ad)
  - Update rollup plugins (5614399b4)
  - Fix code formatting (17bbb21b5)
  - **utils:** Improve `stripWhitespace` utility (#9668)
  - Update license year to present (#9682)
  - Add separate file with security disclosure info (#9738)
  - Update logo (#9796)
  - **doc:** Fix link to contribution guide (#9815)
  - **test:** Fix external redirect link (#9816)
  - Update funding.yml (1f8513720)
  - Update lockfile (76143601f)
  - Update audit list (6f73c36ae)
  - Update lockfile and audit (1878b26f9)
  - Update issue template with nuxt 3 (#9948)
  - Enable blank issues (54542c1b0)
  - **radme:** Fix browserstack and saucelabs icons (#10068)
  - Update dependencies (#10510)
  - Update repo (773d292b5)
  - Ignore vue and vuex major updates (bafc814ef)
  - Update README.md (#10831)
  - Update pull request template (0db7e7b39)
  - Update issue templates (f36fb9cd0)
  - Rename 2.x bug template (ba966cf9e)
  - Move nuxt 2 report to bottom (ce7b1a939)
  - Bump `ua-parser-js` version (1cedad5fc)
  - Bump test/dev dependencies (#18672)
  - Upgrade unjs dependencies (#18670)
  - Use named export from `defu` (#18679)

### ✅ Tests

  - Update async size test (23e2018a1)
  - Update size limit tests (4f11d3c1a)

### 🤖 CI

  - Update test branch condition (331a2d724)
  - Update workflows (9677fbe53)

#### ⚠️  Breaking Changes

  - **webpack:** ⚠️  Update postcss to v8 (#9671)

### ❤️  Contributors

- Xin Du (Clark) <clark.duxin@gmail.com>
- Daniel Roe <daniel@roe.dev>
- Arik 
- Bot08 
- Pooya Parsa <pooya@pi0.io>
- Yuyao Nie <nieyuyao0826@hotmail.com>
- Sébastien Chopin <seb@nuxtjs.com>
- Clément Ollivier <clement.o2p@gmail.com>
- Michiel Doesburg 
- Rafał Chłodnicki <rchl2k@gmail.com>
- Abdfn 
- K-utsumi 
- Matteo Rigon <matteo.rigon7@gmail.com>
- Mehmet 
- Thibault Vlacich <thibault.vlacich@gmail.com>
- Jon-ht <jonathan.huteau15@gmail.com>
- Ahmadou Waly NDIAYE <ahmadouwalyndiaye@gmail.com>
- Daniil Okhlopkov 
- Aewshyae 
- Michał Kędrzyński <kedrzu@gmail.com>
- Mrazauskas 
- Loick Le Digabel <loick.ledigabel@gmail.com>
- Payel Karmakar 
- SlayerOfTheBad 
- Ofer Shaal <ofer@3paces.com>
- Mohammad Saleh Fadaei 
- Andrew Luca <thendrluca@gmail.com>
- David Ovčačík <david.ovcacik@gmail.com>
- Carbotaniuman 
- William L'Archeveque <william.larcheveque@gmail.com>
- Matthieu Sieben



> Remake of https://github.com/nuxt/nuxt.js/pull/9660, https://github.com/nuxt/nuxt/pull/10907