### PR TITLE
fix(nuxt): make `onNuxtReady` safe to run on server-side

### DIFF
--- a/docs/3.api/3.utils/on-nuxt-ready.md
+++ b/docs/3.api/3.utils/on-nuxt-ready.md
@@ -17,3 +17,7 @@ export default defineNuxtPlugin(() => {
 ```
 
 It is 'safe' to run even after your app has initialized. In this case, then the code will be registered to run in the next idle callback.
+
+::alert
+`onNuxtReady` only runs on the client-side.
+::

--- a/packages/nuxt/src/app/compat/idle-callback.ts
+++ b/packages/nuxt/src/app/compat/idle-callback.ts
@@ -1,7 +1,7 @@
 // Polyfills for Safari support
 // https://caniuse.com/requestidlecallback
 export const requestIdleCallback: Window['requestIdleCallback'] = process.server
-  ? undefined as any
+  ? (() => {}) as any
   : (globalThis.requestIdleCallback || ((cb) => {
       const start = Date.now()
       const idleDeadline = {
@@ -12,5 +12,5 @@ export const requestIdleCallback: Window['requestIdleCallback'] = process.server
     }))
 
 export const cancelIdleCallback: Window['cancelIdleCallback'] = process.server
-  ? null as any
+  ? (() => {}) as any
   : (globalThis.cancelIdleCallback || ((id) => { clearTimeout(id) }))

--- a/packages/nuxt/src/app/composables/ready.ts
+++ b/packages/nuxt/src/app/composables/ready.ts
@@ -2,6 +2,8 @@ import { useNuxtApp } from '../nuxt'
 import { requestIdleCallback } from '../compat/idle-callback'
 
 export const onNuxtReady = (callback: () => any) => {
+  if (process.server) { return }
+
   const nuxtApp = useNuxtApp()
   if (nuxtApp.isHydrating) {
     nuxtApp.hooks.hookOnce('app:suspense:resolve', () => { requestIdleCallback(callback) })


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/18696

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

As we didn't provide a stub for `requestIdleCallback` on server, `onNuxtReady` wasn't safe to call in SSR. This PR changes that, making the behaviour explicit: `onNuxtReady` will not call the callback at all on server side.

It also adds stub functions for idle callback support on server.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
