### PR TITLE
fix(vite, webpack): omit magic keys when import of same name is detected

### DIFF
--- a/docs/3.api/1.composables/use-async-data.md
+++ b/docs/3.api/1.composables/use-async-data.md
@@ -80,5 +80,9 @@ const { data, pending, error, refresh } = await useAsyncData(
 )
 ```
 
+::alert{type=warning}
+`useAsyncData` is a reserved function name transformed by the compiler, so you should not name your own function `useAsyncData`.
+::
+
 ::ReadMore{link="/docs/getting-started/data-fetching"}
 ::

--- a/docs/3.api/1.composables/use-fetch.md
+++ b/docs/3.api/1.composables/use-fetch.md
@@ -122,6 +122,10 @@ const { data, pending, error, refresh } = await useFetch('/api/auth/login', {
 })
 ```
 
+::alert{type=warning}
+`useFetch` is a reserved function name transformed by the compiler, so you should not name your own function `useFetch`.
+::
+
 :ReadMore{link="/docs/getting-started/data-fetching"}
 
 ::LinkExample{link="/docs/examples/composables/use-fetch"}

--- a/docs/3.api/1.composables/use-lazy-async-data.md
+++ b/docs/3.api/1.composables/use-lazy-async-data.md
@@ -36,4 +36,8 @@ watch(count, (newCount) => {
 </script>
 ```
 
+::alert{type=warning}
+`useLazyAsyncData` is a reserved function name transformed by the compiler, so you should not name your own function `useLazyAsyncData`.
+::
+
 :ReadMore{link="/docs/getting-started/data-fetching#uselazyasyncdata"}

--- a/docs/3.api/1.composables/use-lazy-fetch.md
+++ b/docs/3.api/1.composables/use-lazy-fetch.md
@@ -40,4 +40,8 @@ watch(posts, (newPosts) => {
 </script>
 ```
 
+::alert{type=warning}
+`useLazyFetch` is a reserved function name transformed by the compiler, so you should not name your own function `useLazyFetch`.
+::
+
 :ReadMore{link="/docs/getting-started/data-fetching#uselazyfetch"}

--- a/docs/3.api/1.composables/use-state.md
+++ b/docs/3.api/1.composables/use-state.md
@@ -18,5 +18,9 @@ useState<T>(key: string, init?: () => T | Ref<T>): Ref<T>
 Because the data inside `useState` will be serialized to JSON, it is important that it does not contain anything that cannot be serialized, such as classes, functions or symbols.
 ::
 
+::alert{type=warning}
+`useState` is a reserved function name transformed by the compiler, so you should not name your own function `useState`.
+::
+
 ::ReadMore{link="/docs/getting-started/state-management"}
 ::

--- a/packages/vite/src/plugins/composable-keys.ts
+++ b/packages/vite/src/plugins/composable-keys.ts
@@ -86,11 +86,13 @@ export const composableKeysPlugin = createUnplugin((options: ComposableKeysOptio
   }
 })
 
+const NUXT_IMPORT_RE = /nuxt|#app|#imports/
+
 function detectImportNames (code: string) {
   const imports = findStaticImports(code)
   const names = new Set<string>()
   for (const i of imports) {
-    if (i.specifier.includes('nuxt')) { continue }
+    if (NUXT_IMPORT_RE.test(i.specifier)) { continue }
     const { namedImports, defaultImport, namespacedImport } = parseStaticImport(i)
     for (const name in namedImports || {}) {
       names.add(namedImports![name])

--- a/packages/vite/src/plugins/composable-keys.ts
+++ b/packages/vite/src/plugins/composable-keys.ts
@@ -7,6 +7,7 @@ import MagicString from 'magic-string'
 import { hash } from 'ohash'
 import type { CallExpression } from 'estree'
 import { parseQuery, parseURL } from 'ufo'
+import { findStaticImports, parseStaticImport } from 'mlly'
 
 export interface ComposableKeysOptions {
   sourcemap: boolean
@@ -32,6 +33,7 @@ export const composableKeysPlugin = createUnplugin((options: ComposableKeysOptio
       const { 0: script = code, index: codeIndex = 0 } = code.match(/(?<=<script[^>]*>)[\S\s.]*?(?=<\/script>)/) || { index: 0, 0: code }
       const s = new MagicString(code)
       // https://github.com/unjs/unplugin/issues/90
+      let imports: Set<string> | undefined
       let count = 0
       const relativeID = isAbsolute(id) ? relative(options.rootDir, id) : id
       walk(this.parse(script, {
@@ -43,6 +45,9 @@ export const composableKeysPlugin = createUnplugin((options: ComposableKeysOptio
           const node: CallExpression = _node as CallExpression
           const name = 'name' in node.callee && node.callee.name
           if (!name || !keyedFunctions.includes(name) || node.arguments.length >= 4) { return }
+
+          imports = imports || detectImportNames(script)
+          if (imports.has(name)) { return }
 
           switch (name) {
             case 'useState':
@@ -80,3 +85,23 @@ export const composableKeysPlugin = createUnplugin((options: ComposableKeysOptio
     }
   }
 })
+
+function detectImportNames (code: string) {
+  const imports = findStaticImports(code)
+  const names = new Set<string>()
+  for (const i of imports) {
+    console.log(i.specifier)
+    if (i.specifier.includes('nuxt')) { continue }
+    const { namedImports, defaultImport, namespacedImport } = parseStaticImport(i)
+    for (const imp of namedImports ? Object.values(namedImports) : []) {
+      names.add(imp)
+    }
+    if (defaultImport) {
+      names.add(defaultImport)
+    }
+    if (namespacedImport) {
+      names.add(namespacedImport)
+    }
+  }
+  return names
+}

--- a/packages/vite/src/plugins/composable-keys.ts
+++ b/packages/vite/src/plugins/composable-keys.ts
@@ -90,11 +90,10 @@ function detectImportNames (code: string) {
   const imports = findStaticImports(code)
   const names = new Set<string>()
   for (const i of imports) {
-    console.log(i.specifier)
     if (i.specifier.includes('nuxt')) { continue }
     const { namedImports, defaultImport, namespacedImport } = parseStaticImport(i)
-    for (const imp of namedImports ? Object.values(namedImports) : []) {
-      names.add(imp)
+    for (const name in namedImports || {}) {
+      names.add(namedImports![name])
     }
     if (defaultImport) {
       names.add(defaultImport)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

resolves #18724

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

It is possible for the user to import a function named `useFetch` (or another of our keyed composables), and in this case we should avoid injecting a key. I've also added some notes to the docs to warn against using these special function names.

**Idea**: it might be worth considering in future allowing user (or more likely, a module) to add other special function names to have keys generated for them.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

