### PR TITLE
docs(schema): add NuxtHooks interface documentation

### DIFF
--- a/docs/3.api/4.advanced/1.hooks.md
+++ b/docs/3.api/4.advanced/1.hooks.md
@@ -33,51 +33,51 @@ Hook                   | Arguments           | Environment     | Description
 
 Check the [schema source code](https://github.com/nuxt/nuxt/blob/main/packages/schema/src/types/hooks.ts#L53) for all available hooks.
 
-Hook                     | Arguments                  | Environment     | Description
--------------------------|----------------------------|-----------------|-------------
-`kit:compatibility`      | `compatibility, issues`    | Server          | Allows extending compatibility checks.
-`ready`                  | `nuxt`                     | Server          | Called after nuxt initialization, when the nuxt instance is ready to work.
-`close`                  | `nuxt`                     | Server          | Called when Nuxt instance is gracefully closing.
-`modules:before`         | -                          | Server          | Called during Nuxt initialization, before installing user modules.
-`modules:done`           | -                          | Server          | Called during Nuxt initialization, after installing user modules.
-`app:resolve`            | `app`                      | Server          | Called after resolving the `app` instance.
-`app:templates`          | `app`                      | Server          | Called during `NuxtApp` generation, to allow customizing, modifying or adding new files to the build directory (either virtually or to written to `.nuxt`).
-`app:templatesGenerated` | `app`                      | Server          | Called after templates are compiled into the [virtual file system](https://nuxt.com/docs/guide/directory-structure/nuxt#virtual-file-system) (vfs).
-`build:before`           | -                          | Server          | Called before Nuxt bundle builder.
-`build:done`             | -                          | Server          | Called after Nuxt bundle builder is complete.
-`build:manifest`         | `manifest`                 | Server          | Called during the manifest build by Vite and Webpack. This allows customizing the manifest that Nitro will use to render `<script>` and `<link>` tags in the final HTML.
-`builder:generateApp`    | `options`                  | Server          | Called before generating the app.
-`builder:watch`          | `event, path`              | Server          | Called at build time in development when the watcher spots a change to a file or directory in the project.
-`pages:extend`           | `pages`                    | Server          | Called after pages routes are resolved.
-`server:devHandler`      | `handler`                  | Server          | Called when the dev middleware is being registered on the Nitro dev server.
-`imports:sources`        | `presets`                  | Server          | Called at setup allowing modules to extend sources.
-`imports:extend`         | `imports`                  | Server          | Called at setup allowing modules to extend imports.
-`imports:context`        | `context`                  | Server          | Called when the [unimport](https://github.com/unjs/unimport) context is created.
-`imports:dirs`           | `dirs`                     | Server          | Allows extending import directories.
-`components:dirs`        | `dirs`                     | Server          | Called within `app:resolve` allowing to extend the directories that are scanned for auto-importable components.
-`components:extend`      | `components`               | Server          | Allows extending new components.
-`nitro:config`           | `nitroConfig`              | Server          | Called before initializing Nitro, allowing customization of Nitro's configuration.
-`nitro:init`             | `nitro`                    | Server          | Called after Nitro is initialized, which allows registering Nitro hooks and interacting directly with Nitro.
-`nitro:build:before`     | `nitro`                    | Server          | Called before building the nitro instance.
-`prerender:routes`       | `ctx`                      | Server          | Allows extending the routes to be prerendered.
-`build:error`            | `error`                    | Server          | Called when an error occurs at build time.
-`prepare:types`          | `options`                  | Server          | Called before nuxi writes `.nuxt/tsconfig.json` and `.nuxt/nuxt.d.ts`, allowing addition of custom references and declarations in `nuxt.d.ts`, or directly modifying the options in `tsconfig.json`
-`listen`                 | `listenerServer, listener` | Server          | Called when the dev server is loading.
-`schema:extend`          | `schemas`                  | Server          | Allows extending default schemas.
-`schema:resolved`        | `schema`                   | Server          | Allows extending resolved schema.
-`schema:beforeWrite`     | `schema`                   | Server          | Called before writing the given schema.
-`schema:written`         | -                          | Server          | Called after the schema is written.
-`vite:extend`            | `viteBuildContext`         | Server          | Allows to extend Vite default context.
-`vite:extendConfig`      | `viteInlineConfig, env`    | Server & Client | Allows to extend Vite default config.
-`vite:serverCreated`     | `viteServer, env`          | Server & Client | Called when the Vite server is created.
-`vite:compiled`          | -                          | Server & Client | Called after Vite server is compiled.
-`webpack:config`         | `webpackConfigs`           | Server          | Called before configuring the webpack compiler.
-`webpack:compile`        | `options`                  | Server          | Called right before compilation.
-`webpack:compiled`       | `options`                  | Server          | Called after resources are loaded.
-`webpack:change`         | `shortPath`                | Server          | Called on `change` on WebpackBar.
-`webpack:error`          | -                          | Server          | Called on `done` if has errors on WebpackBar.
-`webpack:done`           | -                          | Server          | Called on `allDone` on WebpackBar.
-`webpack:progress`       | `statesArray`              | Server          | Called on `progress` on WebpackBar.
+Hook                     | Arguments                  | Description
+-------------------------|----------------------------|-------------
+`kit:compatibility`      | `compatibility, issues`    | Allows extending compatibility checks.
+`ready`                  | `nuxt`                     | Called after nuxt initialization, when the nuxt instance is ready to work.
+`close`                  | `nuxt`                     | Called when Nuxt instance is gracefully closing.
+`modules:before`         | -                          | Called during Nuxt initialization, before installing user modules.
+`modules:done`           | -                          | Called during Nuxt initialization, after installing user modules.
+`app:resolve`            | `app`                      | Called after resolving the `app` instance.
+`app:templates`          | `app`                      | Called during `NuxtApp` generation, to allow customizing, modifying or adding new files to the build directory (either virtually or to written to `.nuxt`).
+`app:templatesGenerated` | `app`                      | Called after templates are compiled into the [virtual file system](https://nuxt.com/docs/guide/directory-structure/nuxt#virtual-file-system) (vfs).
+`build:before`           | -                          | Called before Nuxt bundle builder.
+`build:done`             | -                          | Called after Nuxt bundle builder is complete.
+`build:manifest`         | `manifest`                 | Called during the manifest build by Vite and Webpack. This allows customizing the manifest that Nitro will use to render `<script>` and `<link>` tags in the final HTML.
+`builder:generateApp`    | `options`                  | Called before generating the app.
+`builder:watch`          | `event, path`              | Called at build time in development when the watcher spots a change to a file or directory in the project.
+`pages:extend`           | `pages`                    | Called after pages routes are resolved.
+`server:devHandler`      | `handler`                  | Called when the dev middleware is being registered on the Nitro dev server.
+`imports:sources`        | `presets`                  | Called at setup allowing modules to extend sources.
+`imports:extend`         | `imports`                  | Called at setup allowing modules to extend imports.
+`imports:context`        | `context`                  | Called when the [unimport](https://github.com/unjs/unimport) context is created.
+`imports:dirs`           | `dirs`                     | Allows extending import directories.
+`components:dirs`        | `dirs`                     | Called within `app:resolve` allowing to extend the directories that are scanned for auto-importable components.
+`components:extend`      | `components`               | Allows extending new components.
+`nitro:config`           | `nitroConfig`              | Called before initializing Nitro, allowing customization of Nitro's configuration.
+`nitro:init`             | `nitro`                    | Called after Nitro is initialized, which allows registering Nitro hooks and interacting directly with Nitro.
+`nitro:build:before`     | `nitro`                    | Called before building the nitro instance.
+`prerender:routes`       | `ctx`                      | Allows extending the routes to be pre-rendered.
+`build:error`            | `error`                    | Called when an error occurs at build time.
+`prepare:types`          | `options`                  | Called before Nuxi writes `.nuxt/tsconfig.json` and `.nuxt/nuxt.d.ts`, allowing addition of custom references and declarations in `nuxt.d.ts`, or directly modifying the options in `tsconfig.json`
+`listen`                 | `listenerServer, listener` | Called when the dev server is loading.
+`schema:extend`          | `schemas`                  | Allows extending default schemas.
+`schema:resolved`        | `schema`                   | Allows extending resolved schema.
+`schema:beforeWrite`     | `schema`                   | Called before writing the given schema.
+`schema:written`         | -                          | Called after the schema is written.
+`vite:extend`            | `viteBuildContext`         | Allows to extend Vite default context.
+`vite:extendConfig`      | `viteInlineConfig, env`    | Allows to extend Vite default config.
+`vite:serverCreated`     | `viteServer, env`          | Called when the Vite server is created.
+`vite:compiled`          | -                          | Called after Vite server is compiled.
+`webpack:config`         | `webpackConfigs`           | Called before configuring the webpack compiler.
+`webpack:compile`        | `options`                  | Called right before compilation.
+`webpack:compiled`       | `options`                  | Called after resources are loaded.
+`webpack:change`         | `shortPath`                | Called on `change` on WebpackBar.
+`webpack:error`          | -                          | Called on `done` if has errors on WebpackBar.
+`webpack:done`           | -                          | Called on `allDone` on WebpackBar.
+`webpack:progress`       | `statesArray`              | Called on `progress` on WebpackBar.
 
 # Nitro App Hooks (runtime, server-side)
 

--- a/docs/3.api/4.advanced/1.hooks.md
+++ b/docs/3.api/4.advanced/1.hooks.md
@@ -33,7 +33,51 @@ Hook                   | Arguments           | Environment     | Description
 
 Check the [schema source code](https://github.com/nuxt/nuxt/blob/main/packages/schema/src/types/hooks.ts#L53) for all available hooks.
 
-:NeedContribution
+Hook                     | Arguments                  | Environment     | Description
+-------------------------|----------------------------|-----------------|-------------
+`kit:compatibility`      | `compatibility, issues`    | Server          | Allows extending compatibility checks.
+`ready`                  | `nuxt`                     | Server          | Called after nuxt initialization, when the nuxt instance is ready to work.
+`close`                  | `nuxt`                     | Server          | Called when Nuxt instance is gracefully closing.
+`modules:before`         | -                          | Server          | Called during nuxt initialization, before install user modules.
+`modules:done`           | -                          | Server          | Called during nuxt initialization, after install user modules.
+`app:resolve`            | `app`                      | Server          | Called after resolve the `app` instance.
+`app:templates`          | `app`                      | Server          | Called during `NuxtApp` generation, after configure user templates.
+`app:templatesGenerated` | `app`                      | Server          | Called after templates are compiled into virtual file system (vfs).
+`build:before`           | -                          | Server          | Called before Nuxt bundle builder.
+`build:done`             | -                          | Server          | Called after Nuxt bundle builder is complete.
+`build:manifest`         | `manifest`                 | Server          | Called during the manifest build by Vite and Webpack.
+`builder:generateApp`    | `options`                  | Server          | Called before generate the app.
+`builder:watch`          | `event, path`              | Server          | Called on build time when option.dev is enabled.
+`pages:extend`           | `pages`                    | Server          | Called after pages routes are resolved.
+`server:devHandler`      | `handler`                  | Server          | Called when the dev middleware is been registered on server.
+`imports:sources`        | `presets`                  | Server          | Called at setup allowing modules extending sources.
+`imports:extend`         | `imports`                  | Server          | Called at setup allowing modules extending imports.
+`imports:context`        | `context`                  | Server          | Called when the Unimport context is created.
+`imports:dirs`           | `dirs`                     | Server          | Allows extending import directories.
+`components:dirs`        | `dirs`                     | Server          | Called at app:resolve allowing to extend the directories.
+`components:extend`      | `components`               | Server          | Allows extending new components.
+`nitro:config`           | `nitroConfig`              | Server          | Called at nitro init allowing to extend the configuration.
+`nitro:init`             | `nitro`                    | Server          | Called when nitro is exposed at Nuxt instance.
+`nitro:build:before`     | `nitro`                    | Server          | Called before build the nitro instance.
+`prerender:routes`       | `ctx`                      | Server          | Allows extending the routes to be prerender.
+`build:error`            | `error`                    | Server          | Called when an error occurs at build time.
+`prepare:types`          | `options`                  | Server          | Called when nuxi is writing types.
+`listen`                 | `listenerServer, listener` | Server          | Called when the dev server is loading.
+`schema:extend`          | `schemas`                  | Server          | Allows to extend default schemas.
+`schema:resolved`        | `schema`                   | Server          | Allows to extend resolved schema.
+`schema:beforeWrite`     | `schema`                   | Server          | Called before write the given schema.
+`schema:written`         | -                          | Server          | Called after the schema is written.
+`vite:extend`            | `viteBuildContext`         | Server          | Allows to extend Vite default context.
+`vite:extendConfig`      | `viteInlineConfig, env`    | Server & Client | Allows to extend Vite default config.
+`vite:serverCreated`     | `viteServer, env`          | Server & Client | Called when the vite server is created.
+`vite:compiled`          | -                          | Server & Client | Called after vite server is compiled.
+`webpack:config`         | `webpackConfigs`           | Server          | Called before configure the webpack compiler.
+`webpack:compile`        | `options`                  | Server          | Called right before compilation.
+`webpack:compiled`       | `options`                  | Server          | Called after resources are loaded.
+`webpack:change`         | `shortPath`                | Server          | Called on `change` on WebpackBar.
+`webpack:error`          | -                          | Server          | Called on `done` if has errors on WebpackBar.
+`webpack:done`           | -                          | Server          | Called on `allDone` on WebpackBar.
+`webpack:progress`       | `statesArray`              | Server          | Called on `progress` on WebpackBar.
 
 # Nitro App Hooks (runtime, server-side)
 

--- a/docs/3.api/4.advanced/1.hooks.md
+++ b/docs/3.api/4.advanced/1.hooks.md
@@ -38,40 +38,40 @@ Hook                     | Arguments                  | Environment     | Descri
 `kit:compatibility`      | `compatibility, issues`    | Server          | Allows extending compatibility checks.
 `ready`                  | `nuxt`                     | Server          | Called after nuxt initialization, when the nuxt instance is ready to work.
 `close`                  | `nuxt`                     | Server          | Called when Nuxt instance is gracefully closing.
-`modules:before`         | -                          | Server          | Called during nuxt initialization, before install user modules.
-`modules:done`           | -                          | Server          | Called during nuxt initialization, after install user modules.
-`app:resolve`            | `app`                      | Server          | Called after resolve the `app` instance.
-`app:templates`          | `app`                      | Server          | Called during `NuxtApp` generation, after configure user templates.
-`app:templatesGenerated` | `app`                      | Server          | Called after templates are compiled into virtual file system (vfs).
+`modules:before`         | -                          | Server          | Called during Nuxt initialization, before installing user modules.
+`modules:done`           | -                          | Server          | Called during Nuxt initialization, after installing user modules.
+`app:resolve`            | `app`                      | Server          | Called after resolving the `app` instance.
+`app:templates`          | `app`                      | Server          | Called during `NuxtApp` generation, to allow customizing, modifying or adding new files to the build directory (either virtually or to written to `.nuxt`).
+`app:templatesGenerated` | `app`                      | Server          | Called after templates are compiled into the [virtual file system](https://nuxt.com/docs/guide/directory-structure/nuxt#virtual-file-system) (vfs).
 `build:before`           | -                          | Server          | Called before Nuxt bundle builder.
 `build:done`             | -                          | Server          | Called after Nuxt bundle builder is complete.
-`build:manifest`         | `manifest`                 | Server          | Called during the manifest build by Vite and Webpack.
-`builder:generateApp`    | `options`                  | Server          | Called before generate the app.
-`builder:watch`          | `event, path`              | Server          | Called on build time when option.dev is enabled.
+`build:manifest`         | `manifest`                 | Server          | Called during the manifest build by Vite and Webpack. This allows customizing the manifest that Nitro will use to render `<script>` and `<link>` tags in the final HTML.
+`builder:generateApp`    | `options`                  | Server          | Called before generating the app.
+`builder:watch`          | `event, path`              | Server          | Called at build time in development when the watcher spots a change to a file or directory in the project.
 `pages:extend`           | `pages`                    | Server          | Called after pages routes are resolved.
-`server:devHandler`      | `handler`                  | Server          | Called when the dev middleware is been registered on server.
-`imports:sources`        | `presets`                  | Server          | Called at setup allowing modules extending sources.
-`imports:extend`         | `imports`                  | Server          | Called at setup allowing modules extending imports.
-`imports:context`        | `context`                  | Server          | Called when the Unimport context is created.
+`server:devHandler`      | `handler`                  | Server          | Called when the dev middleware is being registered on the Nitro dev server.
+`imports:sources`        | `presets`                  | Server          | Called at setup allowing modules to extend sources.
+`imports:extend`         | `imports`                  | Server          | Called at setup allowing modules to extend imports.
+`imports:context`        | `context`                  | Server          | Called when the [unimport](https://github.com/unjs/unimport) context is created.
 `imports:dirs`           | `dirs`                     | Server          | Allows extending import directories.
-`components:dirs`        | `dirs`                     | Server          | Called at app:resolve allowing to extend the directories.
+`components:dirs`        | `dirs`                     | Server          | Called within `app:resolve` allowing to extend the directories that are scanned for auto-importable components.
 `components:extend`      | `components`               | Server          | Allows extending new components.
-`nitro:config`           | `nitroConfig`              | Server          | Called at nitro init allowing to extend the configuration.
-`nitro:init`             | `nitro`                    | Server          | Called when nitro is exposed at Nuxt instance.
-`nitro:build:before`     | `nitro`                    | Server          | Called before build the nitro instance.
-`prerender:routes`       | `ctx`                      | Server          | Allows extending the routes to be prerender.
+`nitro:config`           | `nitroConfig`              | Server          | Called before initializing Nitro, allowing customization of Nitro's configuration.
+`nitro:init`             | `nitro`                    | Server          | Called after Nitro is initialized, which allows registering Nitro hooks and interacting directly with Nitro.
+`nitro:build:before`     | `nitro`                    | Server          | Called before building the nitro instance.
+`prerender:routes`       | `ctx`                      | Server          | Allows extending the routes to be prerendered.
 `build:error`            | `error`                    | Server          | Called when an error occurs at build time.
-`prepare:types`          | `options`                  | Server          | Called when nuxi is writing types.
+`prepare:types`          | `options`                  | Server          | Called before nuxi writes `.nuxt/tsconfig.json` and `.nuxt/nuxt.d.ts`, allowing addition of custom references and declarations in `nuxt.d.ts`, or directly modifying the options in `tsconfig.json`
 `listen`                 | `listenerServer, listener` | Server          | Called when the dev server is loading.
-`schema:extend`          | `schemas`                  | Server          | Allows to extend default schemas.
-`schema:resolved`        | `schema`                   | Server          | Allows to extend resolved schema.
-`schema:beforeWrite`     | `schema`                   | Server          | Called before write the given schema.
+`schema:extend`          | `schemas`                  | Server          | Allows extending default schemas.
+`schema:resolved`        | `schema`                   | Server          | Allows extending resolved schema.
+`schema:beforeWrite`     | `schema`                   | Server          | Called before writing the given schema.
 `schema:written`         | -                          | Server          | Called after the schema is written.
 `vite:extend`            | `viteBuildContext`         | Server          | Allows to extend Vite default context.
 `vite:extendConfig`      | `viteInlineConfig, env`    | Server & Client | Allows to extend Vite default config.
-`vite:serverCreated`     | `viteServer, env`          | Server & Client | Called when the vite server is created.
-`vite:compiled`          | -                          | Server & Client | Called after vite server is compiled.
-`webpack:config`         | `webpackConfigs`           | Server          | Called before configure the webpack compiler.
+`vite:serverCreated`     | `viteServer, env`          | Server & Client | Called when the Vite server is created.
+`vite:compiled`          | -                          | Server & Client | Called after Vite server is compiled.
+`webpack:config`         | `webpackConfigs`           | Server          | Called before configuring the webpack compiler.
 `webpack:compile`        | `options`                  | Server          | Called right before compilation.
 `webpack:compiled`       | `options`                  | Server          | Called after resources are loaded.
 `webpack:change`         | `shortPath`                | Server          | Called on `change` on WebpackBar.

--- a/docs/3.api/4.advanced/1.hooks.md
+++ b/docs/3.api/4.advanced/1.hooks.md
@@ -36,7 +36,7 @@ Check the [schema source code](https://github.com/nuxt/nuxt/blob/main/packages/s
 Hook                     | Arguments                  | Description
 -------------------------|----------------------------|-------------
 `kit:compatibility`      | `compatibility, issues`    | Allows extending compatibility checks.
-`ready`                  | `nuxt`                     | Called after nuxt initialization, when the nuxt instance is ready to work.
+`ready`                  | `nuxt`                     | Called after Nuxt initialization, when the Nuxt instance is ready to work.
 `close`                  | `nuxt`                     | Called when Nuxt instance is gracefully closing.
 `modules:before`         | -                          | Called during Nuxt initialization, before installing user modules.
 `modules:done`           | -                          | Called during Nuxt initialization, after installing user modules.
@@ -58,7 +58,7 @@ Hook                     | Arguments                  | Description
 `components:extend`      | `components`               | Allows extending new components.
 `nitro:config`           | `nitroConfig`              | Called before initializing Nitro, allowing customization of Nitro's configuration.
 `nitro:init`             | `nitro`                    | Called after Nitro is initialized, which allows registering Nitro hooks and interacting directly with Nitro.
-`nitro:build:before`     | `nitro`                    | Called before building the nitro instance.
+`nitro:build:before`     | `nitro`                    | Called before building the Nitro instance.
 `prerender:routes`       | `ctx`                      | Allows extending the routes to be pre-rendered.
 `build:error`            | `error`                    | Called when an error occurs at build time.
 `prepare:types`          | `options`                  | Called before Nuxi writes `.nuxt/tsconfig.json` and `.nuxt/nuxt.d.ts`, allowing addition of custom references and declarations in `nuxt.d.ts`, or directly modifying the options in `tsconfig.json`

--- a/packages/schema/src/types/hooks.ts
+++ b/packages/schema/src/types/hooks.ts
@@ -53,7 +53,7 @@ export interface GenerateAppOptions {
 export interface NuxtHooks {
   // Kit
   /**
-   * Allows extending compatibility checks
+   * Allows extending compatibility checks.
    * @param compatibility Compatibility object
    * @param issues Issues to be mapped
    * @returns Promise
@@ -62,7 +62,7 @@ export interface NuxtHooks {
 
   // Nuxt
   /** 
-   * Called after nuxt initialization, when the nuxt instance is ready to work
+   * Called after Nuxt initialization, when the Nuxt instance is ready to work.
    * @param nuxt The configured Nuxt object
    * @returns Promise
    */
@@ -75,60 +75,60 @@ export interface NuxtHooks {
   'close': (nuxt: Nuxt) => HookResult
 
   /**
-   * Called during nuxt initialization, before install user modules.
+   * Called during Nuxt initialization, before installing user modules.
    * @returns Promise
    */
   'modules:before': () => HookResult
   /**
-   * Called during nuxt initialization, after install user modules
+   * Called during Nuxt initialization, after installing user modules.
    * @returns Promise
    */
   'modules:done': () => HookResult
 
   /**
-   * Called after resolve `app` instance
+   * Called after resolving the `app` instance.
    * @param app The resolved `NuxtApp` object
    * @returns Promise
    */
   'app:resolve': (app: NuxtApp) => HookResult
   /**
-   * Called during `NuxtApp` generation, after configure user templates
+   * Called during `NuxtApp` generation, to allow customizing, modifying or adding new files to the build directory (either virtually or to written to `.nuxt`).
    * @param app The configured `NuxtApp` object
    * @returns Promise
    */
   'app:templates': (app: NuxtApp) => HookResult
   /**
-   * Called after templates are compiled into virtual file system (vfs)
+   * Called after templates are compiled into the [virtual file system](https://nuxt.com/docs/guide/directory-structure/nuxt#virtual-file-system) (vfs).
    * @param app The configured `NuxtApp` object
    * @returns Promise
    */
   'app:templatesGenerated': (app: NuxtApp) => HookResult
 
   /**
-   * Called before Nuxt bundle builder
+   * Called before Nuxt bundle builder.
    * @returns Promise
    */
   'build:before': () => HookResult
   /**
-   * Called after Nuxt bundle builder is complete
+   * Called after Nuxt bundle builder is complete.
    * @returns Promise
    */
   'build:done': () => HookResult
   /**
-   * Called during the manifest build by Vite and Webpack
+   * Called during the manifest build by Vite and Webpack. This allows customizing the manifest that Nitro will use to render `<script>` and `<link>` tags in the final HTML.
    * @param manifest The manifest object to build
    * @returns Promise
    */
   'build:manifest': (manifest: Manifest) => HookResult
 
   /**
-   * Called before generate app
+   * Called before generating the app.
    * @param options GenerateAppOptions object
    * @returns Promise
    */
   'builder:generateApp': (options?: GenerateAppOptions) => HookResult
   /**
-   * Called on build time when option.dev is enabled
+   * Called at build time in development when the watcher spots a change to a file or directory in the project.
    * @param event "add" | "addDir" | "change" | "unlink" | "unlinkDir"
    * @param path the path to the watched file
    * @returns Promise
@@ -136,39 +136,39 @@ export interface NuxtHooks {
   'builder:watch': (event: WatchEvent, path: string) => HookResult
 
   /**
-   * Called after pages routes are resolved
+   * Called after pages routes are resolved.
    * @param pages Array containing resolved pages
    * @returns Promise
    */
   'pages:extend': (pages: NuxtPage[]) => HookResult
 
   /**
-   * Called when the dev middleware is been registered on server
+   * Called when the dev middleware is being registered on the Nitro dev server.
    * @param handler the Vite or Webpack event handler
    * @returns Promise
    */
   'server:devHandler': (handler: EventHandler) => HookResult
 
   /**
-   * Called at setup allowing modules extending sources
+   * Called at setup allowing modules to extend sources.
    * @param presets Array containing presets objects
    * @returns Promise
    */
   'imports:sources': (presets: ImportPresetWithDeprecation[]) => HookResult
   /**
-   * Called at setup allowing modules extending imports
+   * Called at setup allowing modules to extend imports.
    * @param imports Array containing the imports to extend
    * @returns Promise
    */
   'imports:extend': (imports: Import[]) => HookResult
   /**
-   * Called when the unimport context is created
+   * Called when the [unimport](https://github.com/unjs/unimport) context is created.
    * @param context The Unimport context
    * @returns Promise
    */
   'imports:context': (context: Unimport) => HookResult
   /**
-   * Allows extending import directories
+   * Allows extending import directories.
    * @param dirs Array containing directories as string
    * @returns Promise
    */
@@ -176,13 +176,13 @@ export interface NuxtHooks {
 
   // Components
   /**
-   * Called at app:resolve allowing to extend the directories
+   * Called within `app:resolve` allowing to extend the directories that are scanned for auto-importable components.
    * @param dirs The `dirs` option to push new items
    * @returns Promise
    */
   'components:dirs': (dirs: ComponentsOptions['dirs']) => HookResult
   /**
-   * Allows extending new components
+   * Allows extending new components.
    * @param components The `components` array to push new items
    * @returns Promise
    */
@@ -190,25 +190,25 @@ export interface NuxtHooks {
 
   // Nitropack
   /**
-   * Called at nitro init allowing to extend the configuration
+   * Called before initializing Nitro, allowing customization of Nitro's configuration.
    * @param nitroConfig The nitro config to be extended
    * @returns Promise
    */
   'nitro:config': (nitroConfig: NitroConfig) => HookResult
   /**
-   * Called when nitro is exposed at Nuxt instance
+   * Called after Nitro is initialized, which allows registering Nitro hooks and interacting directly with Nitro.
    * @param nitro The created nitro object
    * @returns Promise
    */
   'nitro:init': (nitro: Nitro) => HookResult
   /**
-   * Called before build the nitro instance
+   * Called before building the Nitro instance.
    * @param nitro The created nitro object
    * @returns Promise
    */
   'nitro:build:before': (nitro: Nitro) => HookResult
   /**
-   * Allows extending the routes to be prerender
+   * Allows extending the routes to be pre-rendered.
    * @param ctx Nuxt context
    * @returns Promise
    */
@@ -216,19 +216,19 @@ export interface NuxtHooks {
 
   // Nuxi
   /**
-   * Called when an error occurs at build time
+   * Called when an error occurs at build time.
    * @param error Error object
    * @returns Promise
    */
   'build:error': (error: Error) => HookResult
   /**
-   * Called when nuxi is writing types
+   * Called before Nuxi writes `.nuxt/tsconfig.json` and `.nuxt/nuxt.d.ts`, allowing addition of custom references and declarations in `nuxt.d.ts`, or directly modifying the options in `tsconfig.json`
    * @param options Objects containing `references`, `declarations`, `tsConfig`
    * @returns Promise
    */
   'prepare:types': (options: { references: TSReference[], declarations: string[], tsConfig: TSConfig }) => HookResult
   /**
-   * Called when the dev server is loading
+   * Called when the dev server is loading.
    * @param listenerServer The HTTP/HTTPS server object
    * @param listener The server's listener object
    * @returns Promise
@@ -237,94 +237,94 @@ export interface NuxtHooks {
 
   // Schema
   /**
-   * Allows to extend default schemas
+   * Allows extending default schemas.
    * @param schemas Schemas to be extend
    * @returns void
    */
   'schema:extend': (schemas: SchemaDefinition[]) => void
   /**
-   * Allows to extend resolved schema
+   * Allows extending resolved schema.
    * @param schema Schema object
    * @returns void
    */
   'schema:resolved': (schema: Schema) => void
   /**
-   * Called before write the given schema
+   * Called before writing the given schema.
    * @param schema Schema object
    * @returns void
    */
   'schema:beforeWrite': (schema: Schema) => void
   /**
-   * Called after the schema is written
+   * Called after the schema is written.
    * @returns void
    */
   'schema:written': () => void
 
   // Vite
   /**
-   * Allows to extend Vite default context
+   * Allows to extend Vite default context.
    * @param viteBuildContext The vite build context object
    * @returns Promise
    */
   'vite:extend': (viteBuildContext: { nuxt: Nuxt, config: ViteInlineConfig }) => HookResult
   /**
-   * Allows to extend Vite default config
+   * Allows to extend Vite default config.
    * @param viteInlineConfig The vite inline config object
    * @param env Server or client
    * @returns Promise
    */
   'vite:extendConfig': (viteInlineConfig: ViteInlineConfig, env: { isClient: boolean, isServer: boolean }) => HookResult
   /**
-   * Called when the vite server is created
+   * Called when the Vite server is created.
    * @param viteServer Vite development server
    * @param env Server or client
    * @returns Promise
    */
   'vite:serverCreated': (viteServer: ViteDevServer, env: { isClient: boolean, isServer: boolean }) => HookResult
   /**
-   * Called on server and on the client, right after vite is compiled
+   * Called after Vite server is compiled.
    * @returns Promise
    */
   'vite:compiled': () => HookResult
 
   // webpack
   /**
-   * Called before configure the webpack compiler
+   * Called before configuring the webpack compiler.
    * @param webpackConfigs Configs objects to be pushed to the compiler
    * @returns Promise
    */
   'webpack:config': (webpackConfigs: Configuration[]) => HookResult
   /**
-   * Called right before compilation
+   * Called right before compilation.
    * @param options The options to be added
    * @returns Promise
    */
   'webpack:compile': (options: { name: string, compiler: Compiler }) => HookResult
   /**
-   * Called after resources are loaded
+   * Called after resources are loaded.
    * @param options The compiler options
    * @returns Promise
    */
   'webpack:compiled': (options: { name: string, compiler: Compiler, stats: Stats }) => HookResult
 
   /**
-   * Called on `change` on WebpackBar
+   * Called on `change` on WebpackBar.
    * @param shortPath the short path
    * @returns void
    */
   'webpack:change': (shortPath: string) => void
   /**
-   * Called on `done` if has errors on WebpackBar
+   * Called on `done` if has errors on WebpackBar.
    * @returns void
    */
   'webpack:error': () => void
   /**
-   * Called on `allDone` on WebpackBar
+   * Called on `allDone` on WebpackBar.
    * @returns void
    */
   'webpack:done': () => void
   /**
-   * Called on `progress` on WebpackBar
+   * Called on `progress` on WebpackBar.
    * @param statesArray The array containing the states on progress
    * @returns void
    */

--- a/packages/schema/src/types/hooks.ts
+++ b/packages/schema/src/types/hooks.ts
@@ -47,72 +47,287 @@ export interface GenerateAppOptions {
   filter?: (template: ResolvedNuxtTemplate<any>) => boolean
 }
 
+/**
+ * The listeners to Nuxt build time events
+ */
 export interface NuxtHooks {
   // Kit
+  /**
+   * Allows extending compatibility checks
+   * @param compatibility Compatibility object
+   * @param issues Issues to be mapped
+   * @returns Promise
+   */
   'kit:compatibility': (compatibility: NuxtCompatibility, issues: NuxtCompatibilityIssues) => HookResult
 
   // Nuxt
+  /** 
+   * Called after nuxt initialization, when the nuxt instance is ready to work
+   * @param nuxt The configured Nuxt object
+   * @returns Promise
+   */
   'ready': (nuxt: Nuxt) => HookResult
+  /**
+   * Called when Nuxt instance is gracefully closing.
+   * @param nuxt The configured Nuxt object
+   * @returns Promise
+   */
   'close': (nuxt: Nuxt) => HookResult
 
+  /**
+   * Called during nuxt initialization, before install user modules.
+   * @returns Promise
+   */
   'modules:before': () => HookResult
+  /**
+   * Called during nuxt initialization, after install user modules
+   * @returns Promise
+   */
   'modules:done': () => HookResult
 
+  /**
+   * Called after resolve `app` instance
+   * @param app The resolved `NuxtApp` object
+   * @returns Promise
+   */
   'app:resolve': (app: NuxtApp) => HookResult
+  /**
+   * Called during `NuxtApp` generation, after configure user templates
+   * @param app The configured `NuxtApp` object
+   * @returns Promise
+   */
   'app:templates': (app: NuxtApp) => HookResult
+  /**
+   * Called after templates are compiled into virtual file system (vfs)
+   * @param app The configured `NuxtApp` object
+   * @returns Promise
+   */
   'app:templatesGenerated': (app: NuxtApp) => HookResult
 
+  /**
+   * Called before Nuxt bundle builder
+   * @returns Promise
+   */
   'build:before': () => HookResult
+  /**
+   * Called after Nuxt bundle builder is complete
+   * @returns Promise
+   */
   'build:done': () => HookResult
+  /**
+   * Called during the manifest build by Vite and Webpack
+   * @param manifest The manifest object to build
+   * @returns Promise
+   */
   'build:manifest': (manifest: Manifest) => HookResult
 
+  /**
+   * Called before generate app
+   * @param options GenerateAppOptions object
+   * @returns Promise
+   */
   'builder:generateApp': (options?: GenerateAppOptions) => HookResult
+  /**
+   * Called on build time when option.dev is enabled
+   * @param event "add" | "addDir" | "change" | "unlink" | "unlinkDir"
+   * @param path the path to the watched file
+   * @returns Promise
+   */
   'builder:watch': (event: WatchEvent, path: string) => HookResult
 
+  /**
+   * Called after pages routes are resolved
+   * @param pages Array containing resolved pages
+   * @returns Promise
+   */
   'pages:extend': (pages: NuxtPage[]) => HookResult
 
+  /**
+   * Called when the dev middleware is been registered on server
+   * @param handler the Vite or Webpack event handler
+   * @returns Promise
+   */
   'server:devHandler': (handler: EventHandler) => HookResult
 
+  /**
+   * Called at setup allowing modules extending sources
+   * @param presets Array containing presets objects
+   * @returns Promise
+   */
   'imports:sources': (presets: ImportPresetWithDeprecation[]) => HookResult
+  /**
+   * Called at setup allowing modules extending imports
+   * @param imports Array containing the imports to extend
+   * @returns Promise
+   */
   'imports:extend': (imports: Import[]) => HookResult
+  /**
+   * Called when the unimport context is created
+   * @param context The Unimport context
+   * @returns Promise
+   */
   'imports:context': (context: Unimport) => HookResult
+  /**
+   * Allows extending import directories
+   * @param dirs Array containing directories as string
+   * @returns Promise
+   */
   'imports:dirs': (dirs: string[]) => HookResult
 
   // Components
+  /**
+   * Called at app:resolve allowing to extend the directories
+   * @param dirs The `dirs` option to push new items
+   * @returns Promise
+   */
   'components:dirs': (dirs: ComponentsOptions['dirs']) => HookResult
+  /**
+   * Allows extending new components
+   * @param components The `components` array to push new items
+   * @returns Promise
+   */
   'components:extend': (components: Component[]) => HookResult
 
   // Nitropack
+  /**
+   * Called at nitro init allowing to extend the configuration
+   * @param nitroConfig The nitro config to be extended
+   * @returns Promise
+   */
   'nitro:config': (nitroConfig: NitroConfig) => HookResult
+  /**
+   * Called when nitro is exposed at Nuxt instance
+   * @param nitro The created nitro object
+   * @returns Promise
+   */
   'nitro:init': (nitro: Nitro) => HookResult
+  /**
+   * Called before build the nitro instance
+   * @param nitro The created nitro object
+   * @returns Promise
+   */
   'nitro:build:before': (nitro: Nitro) => HookResult
+  /**
+   * Allows extending the routes to be prerender
+   * @param ctx Nuxt context
+   * @returns Promise
+   */
   'prerender:routes': (ctx: { routes: Set<string> }) => HookResult
 
   // Nuxi
+  /**
+   * Called when an error occurs at build time
+   * @param error Error object
+   * @returns Promise
+   */
   'build:error': (error: Error) => HookResult
+  /**
+   * Called when nuxi is writing types
+   * @param options Objects containing `references`, `declarations`, `tsConfig`
+   * @returns Promise
+   */
   'prepare:types': (options: { references: TSReference[], declarations: string[], tsConfig: TSConfig }) => HookResult
+  /**
+   * Called when the dev server is loading
+   * @param listenerServer The HTTP/HTTPS server object
+   * @param listener The server's listener object
+   * @returns Promise
+   */
   'listen': (listenerServer: HttpServer | HttpsServer, listener: any) => HookResult
 
   // Schema
+  /**
+   * Allows to extend default schemas
+   * @param schemas Schemas to be extend
+   * @returns void
+   */
   'schema:extend': (schemas: SchemaDefinition[]) => void
+  /**
+   * Allows to extend resolved schema
+   * @param schema Schema object
+   * @returns void
+   */
   'schema:resolved': (schema: Schema) => void
+  /**
+   * Called before write the given schema
+   * @param schema Schema object
+   * @returns void
+   */
   'schema:beforeWrite': (schema: Schema) => void
+  /**
+   * Called after the schema is written
+   * @returns void
+   */
   'schema:written': () => void
 
   // Vite
+  /**
+   * Allows to extend Vite default context
+   * @param viteBuildContext The vite build context object
+   * @returns Promise
+   */
   'vite:extend': (viteBuildContext: { nuxt: Nuxt, config: ViteInlineConfig }) => HookResult
+  /**
+   * Allows to extend Vite default config
+   * @param viteInlineConfig The vite inline config object
+   * @param env Server or client
+   * @returns Promise
+   */
   'vite:extendConfig': (viteInlineConfig: ViteInlineConfig, env: { isClient: boolean, isServer: boolean }) => HookResult
+  /**
+   * Called when the vite server is created
+   * @param viteServer Vite development server
+   * @param env Server or client
+   * @returns Promise
+   */
   'vite:serverCreated': (viteServer: ViteDevServer, env: { isClient: boolean, isServer: boolean }) => HookResult
+  /**
+   * Called on server and on the client, right after vite is compiled
+   * @returns Promise
+   */
   'vite:compiled': () => HookResult
 
   // webpack
+  /**
+   * Called before configure the webpack compiler
+   * @param webpackConfigs Configs objects to be pushed to the compiler
+   * @returns Promise
+   */
   'webpack:config': (webpackConfigs: Configuration[]) => HookResult
+  /**
+   * Called right before compilation
+   * @param options The options to be added
+   * @returns Promise
+   */
   'webpack:compile': (options: { name: string, compiler: Compiler }) => HookResult
+  /**
+   * Called after resources are loaded
+   * @param options The compiler options
+   * @returns Promise
+   */
   'webpack:compiled': (options: { name: string, compiler: Compiler, stats: Stats }) => HookResult
 
+  /**
+   * Called on `change` on WebpackBar
+   * @param shortPath the short path
+   * @returns void
+   */
   'webpack:change': (shortPath: string) => void
+  /**
+   * Called on `done` if has errors on WebpackBar
+   * @returns void
+   */
   'webpack:error': () => void
+  /**
+   * Called on `allDone` on WebpackBar
+   * @returns void
+   */
   'webpack:done': () => void
+  /**
+   * Called on `progress` on WebpackBar
+   * @param statesArray The array containing the states on progress
+   * @returns void
+   */
   'webpack:progress': (statesArray: any[]) => void
 }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/13653

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The section [Nuxt Hooks (build time)](https://nuxt.com/docs/api/advanced/hooks#nuxt-hooks-build-time) is not yet complete on the live docs page, and it's wrongly marked as "OK" as commented [here](https://github.com/nuxt/nuxt/issues/13653#issuecomment-1397311124)

This PR adds the documentation on the interface itself and on the lifecycle hooks docs page.

This PR is important to provide information about nuxt hooks and to avoid delving into the source code to understand the hooks like I did myself.

Please make sure the description I provided for each hook is correct

Thank you

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

