### PR TITLE
 perf(vite): use stub entry in vite server build when `ssr: false `

### DIFF
--- a/packages/nuxt/src/app/entry-spa.ts
+++ b/packages/nuxt/src/app/entry-spa.ts
@@ -1,0 +1,1 @@
+export default () => {}

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -82,7 +82,7 @@ export async function buildServer (ctx: ViteBuildContext) {
     build: {
       sourcemap: ctx.nuxt.options.sourcemap.server ? ctx.config.build?.sourcemap ?? true : false,
       outDir: resolve(ctx.nuxt.options.buildDir, 'dist/server'),
-      ssr: ctx.nuxt.options.ssr ?? true,
+      ssr: true,
       rollupOptions: {
         input: ctx.entry,
         external: ['#internal/nitro', ...ctx.nuxt.options.experimental.externalVue ? ['vue', 'vue-router'] : []],

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -2,7 +2,7 @@ import { resolve } from 'pathe'
 import * as vite from 'vite'
 import vuePlugin from '@vitejs/plugin-vue'
 import viteJsxPlugin from '@vitejs/plugin-vue-jsx'
-import { logger, resolveModule } from '@nuxt/kit'
+import { logger, resolveModule, resolvePath } from '@nuxt/kit'
 import { joinURL, withoutLeadingSlash, withTrailingSlash } from 'ufo'
 import type { ViteBuildContext, ViteOptions } from './vite'
 import { cacheDirPlugin } from './plugins/cache-dir'
@@ -14,8 +14,9 @@ import { transpile } from './utils/transpile'
 export async function buildServer (ctx: ViteBuildContext) {
   const _resolve = (id: string) => resolveModule(id, { paths: ctx.nuxt.options.modulesDir })
   const helper = ctx.nuxt.options.nitro.imports !== false ? '' : 'globalThis.'
+  const entry = ctx.nuxt.options.ssr ? ctx.entry : await resolvePath(resolve(ctx.nuxt.options.appDir, 'entry-spa'))
   const serverConfig: vite.InlineConfig = vite.mergeConfig(ctx.config, {
-    entry: ctx.entry,
+    entry,
     base: ctx.nuxt.options.dev
       ? joinURL(ctx.nuxt.options.app.baseURL.replace(/^\.\//, '/') || '/', ctx.nuxt.options.app.buildAssetsDir)
       : undefined,
@@ -47,7 +48,7 @@ export async function buildServer (ctx: ViteBuildContext) {
       'typeof XMLHttpRequest': '"undefined"'
     },
     optimizeDeps: {
-      entries: [ctx.entry]
+      entries: ctx.nuxt.options.ssr ? [ctx.entry] : []
     },
     resolve: {
       alias: {
@@ -84,7 +85,7 @@ export async function buildServer (ctx: ViteBuildContext) {
       outDir: resolve(ctx.nuxt.options.buildDir, 'dist/server'),
       ssr: true,
       rollupOptions: {
-        input: ctx.entry,
+        input: entry,
         external: ['#internal/nitro', ...ctx.nuxt.options.experimental.externalVue ? ['vue', 'vue-router'] : []],
         output: {
           entryFileNames: 'server.mjs',


### PR DESCRIPTION
### 🔗 Linked issue

resolves #12544

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR skips the vite server build (partially) by mocking the entry file when `ssr: false`. I've not skipped the build entirely as we do have some hook dependencies (like client renderer creation) that we care about.

This should significantly improve performance for SPA projects and fix bugs like the one linked (which was caused by trying to resolve a server plugin's imports with browser APIs as `vite.build.ssr` was set to false).

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
