### PR TITLE
test(nuxt): add `BaseTransitionPropsValidators` to auto-import exclude list

### DIFF
--- a/packages/nuxt/test/auto-imports.test.ts
+++ b/packages/nuxt/test/auto-imports.test.ts
@@ -100,6 +100,7 @@ const excludedVueHelpers = [
   'toDisplayString',
   'toHandlerKey',
   'BaseTransition',
+  'BaseTransitionPropsValidators',
   'Comment',
   'Fragment',
   'KeepAlive',


### PR DESCRIPTION
This new export is added in 3.3.0-alpha and is needed to fix a tree-shaking issue.