### PR TITLE
docs: resolve `preloadRouteComponents` page heading error

### DIFF
--- a/docs/3.api/3.utils/preload-route-components.md
+++ b/docs/3.api/3.utils/preload-route-components.md
@@ -4,7 +4,7 @@ title: "preloadRouteComponents"
 
 # `preloadRouteComponents`
 
-`preloadRouteComponent` allows you to manually preload individual pages in your Nuxt app.
+`preloadRouteComponents` allows you to manually preload individual pages in your Nuxt app.
 
 > Preloading routes loads the components of a given route that the user might navigate to in future. This ensures that the components are available earlier and less likely to block the navigation, improving performance.
 

--- a/docs/3.api/3.utils/preload-route-components.md
+++ b/docs/3.api/3.utils/preload-route-components.md
@@ -2,7 +2,7 @@
 title: "preloadRouteComponents"
 ---
 
-# `preloadComponents`
+# `preloadRouteComponents`
 
 `preloadRouteComponent` allows you to manually preload individual pages in your Nuxt app.
 


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<https://nuxt.com/docs/api/utils/preload-route-components>
The section heading of this page should be `preloadRouteComponents`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

