### PR TITLE
fix(config): let webpack merge postcss plugins

### DIFF
--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -440,10 +440,8 @@ export function getNuxtConfig (_options) {
     delete options.build.crossorigin
   }
 
-  if (options.build.postcss.plugins) {
+  if (options.build.postcss?.plugins) {
     consola.warn('`postcss.plugins` option has been moved to `postcss.postcssOptions.plugins` for aligning `postcss-loader` format.')
-    options.build.postcss.postcssOptions.plugins = options.build.postcss.plugins
-    delete options.build.postcss.plugins
   }
 
   if (options.buildModules && options.buildModules.includes('@nuxt/postcss8')) {

--- a/packages/webpack/src/utils/postcss.js
+++ b/packages/webpack/src/utils/postcss.js
@@ -195,12 +195,15 @@ export default class PostcssConfig {
     // Apply default plugins
     if (isPureObject(postcssOptions)) {
       const postcssLoaderOptions = this.postcssLoaderOptions
-      if (postcssLoaderOptions.plugins && !postcssOptions.plugins) {
-        postcssOptions.plugins = postcssLoaderOptions.plugins
+      if (postcssLoaderOptions.plugins) {
+        if (!postcssOptions.plugins || isPureObject(postcssOptions.plugins)) {
+          postcssOptions.plugins = { ...postcssLoaderOptions.plugins || {}, ...postcssOptions.plugins || {} }
+        }
         delete postcssLoaderOptions.plugins
       }
-      if (postcssLoaderOptions.order && !postcssOptions.order) {
-        postcssOptions.order = postcssLoaderOptions.order
+      if ('order' in postcssLoaderOptions) {
+        // Prioritise correct config value
+        postcssOptions.order = postcssOptions.order || postcssLoaderOptions.order
         delete postcssLoaderOptions.order
       }
 

--- a/test/fixtures/basic/nuxt.config.js
+++ b/test/fixtures/basic/nuxt.config.js
@@ -95,9 +95,12 @@ export default {
           'custom-selectors': true
         }
       },
+      // deliberately invalid config to test normalization
+      plugins: {
+        cssnano: {}
+      },
       postcssOptions: {
         plugins: {
-          cssnano: {},
           [path.resolve(__dirname, 'plugins', 'tailwind.js')]: {}
         }
       }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/18814
resolves https://github.com/nuxt/nuxt/issues/18798

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently we normalize postcss options at config stage, but modules may modify them later, leaving the options in an impossible situation. This PR defers normalizing them until just before passing them to the webpack loader.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

