### PR TITLE
fix(nuxt): defer adding route path to preloaded record

### DIFF
--- a/packages/nuxt/src/app/composables/preload.ts
+++ b/packages/nuxt/src/app/composables/preload.ts
@@ -39,7 +39,6 @@ export async function preloadRouteComponents (to: string, router: Router & { _ro
 
   if (!router._routePreloaded) { router._routePreloaded = new Set() }
   if (router._routePreloaded.has(to)) { return }
-  router._routePreloaded.add(to)
 
   const promises = router._preloadPromises = router._preloadPromises || []
 
@@ -47,6 +46,8 @@ export async function preloadRouteComponents (to: string, router: Router & { _ro
     // Defer adding new preload requests until the existing ones have resolved
     return Promise.all(promises).then(() => preloadRouteComponents(to, router))
   }
+
+  router._routePreloaded.add(to)
 
   const components = router.resolve(to).matched
     .map(component => component.components?.default)


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently, when there are more than 5 pages that need to be preload on the screen at the same time, only the first 5 pages will be preload, but all pages will be marked as preloaded.

That's because we marked the path for preloaded too early, once it gets delayed because there are more than 5 pages waiting to be preloaded, those pages won't be prefetched.
https://github.com/nuxt/nuxt/blob/34b58d143c17c5169a6561ea538d404ea5b12ad9/packages/nuxt/src/app/composables/preload.ts#L41-L49

Maybe we can delay marking preloaded after the promise length condition.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

