### PR TITLE
fix: reorder the types field in package.json

### DIFF
--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -13,9 +13,9 @@
   "exports": {
     ".": "./dist/index.mjs",
     "./config": {
+      "types": "./config.d.ts",
       "import": "./config.mjs",
-      "require": "./config.cjs",
-      "types": "./config.d.ts"
+      "require": "./config.cjs"
     },
     "./app": "./dist/app/index.mjs",
     "./package.json": "./package.json"


### PR DESCRIPTION


<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
According to the typescript documentation: Entry-point for TypeScript resolution must occur first.

Same as Vue repo: https://github.com/vuejs/core/commit/957722c4185ea87aabc711f6f8997e528dd3ba1b `fix(build): ensure type exports is first`
>Reference:  
> https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

