### PR TITLE
fix(nuxt): validate

### DIFF
--- a/packages/nuxt/src/pages/runtime/validate.ts
+++ b/packages/nuxt/src/pages/runtime/validate.ts
@@ -1,11 +1,9 @@
-import { defineNuxtRouteMiddleware } from '#app'
-
+import { showError, defineNuxtRouteMiddleware } from '#app'
 export default defineNuxtRouteMiddleware(async (to) => {
-  if (!to.meta?.validate) { return }
-
-  const result = await Promise.resolve(to.meta.validate(to))
-  if (result === true) {
-    return
+  if (to.meta?.validate) {
+    const result = await Promise.resolve(to.meta.validate(to))
+    if (result === false) {
+      return showError({ statusCode: 404, message: 'This page could not be found' })
+    }
   }
-  return result
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/18567

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
In the vue file of pages, this change is made so that the validate of `definePageMeta` will function properly.

<!-- Why is this change required? What problem does it solve? -->
The current problems are considered to be the following three points.

* When the validate limit is violated, the transition from `NuxtLink` to the 404 screen is not possible.
* If the validate of `definePageMeta` is defined in the vue file of pages, the global middleware and the middleware of `definePageMeta` do not work.
* The existing `packages/nuxt/src/pages/runtime/validate.ts` process returned false if the validate limit was violated in the middleware, which caused the screen transition to fail.

This is a solution to the above problems.

<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
https://github.com/nuxt/nuxt/issues/18567

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
  - Currently, it was not working as described in the documentation, so this modification is to make it work as described in the documentation. Therefore, no checks have been made.

