### PR TITLE
docs: add info for `nuxi devtools` command

### DIFF
--- a/docs/3.api/5.commands/devtools.md
+++ b/docs/3.api/5.commands/devtools.md
@@ -1,0 +1,19 @@
+---
+title: "nuxi devtools"
+description: The devtools command allows you to enable or disable Nuxt Devtools on a per-project basis.
+---
+
+# `nuxi devtools`
+
+```{bash}
+npx nuxi devtools enable|disable [rootDir]
+```
+
+Running `nuxi devtools enable` will install the Nuxt DevTools globally, and also enable it within the particular project you are using. It is saved as a preference in your user-level `.nuxtrc`. If you want to remove devtools support for a particular project, you can run `nuxi devtools disable`.
+
+Option        | Default          | Description
+-------------------------|-----------------|------------------
+`rootDir` | `.` | The root directory of the app you want to enable devtools for.
+
+::ReadMore{link="https://github.com/nuxt/devtools"}
+::


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/pull/18864

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds basic documentation for `nuxi devtools`. This command won't work until we release `@nuxt/devtools`, which is aimed for same time as 3.2.0.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
