### PR TITLE
fix(types): import `Location` from `vue-router`

### DIFF
--- a/packages/types/app/index.d.ts
+++ b/packages/types/app/index.d.ts
@@ -1,7 +1,7 @@
 import type { ServerResponse } from 'http'
 import type { IncomingMessage, NextFunction } from 'connect'
 import type Vue from 'vue'
-import type { Route } from 'vue-router'
+import type { Location, Route } from 'vue-router'
 import type { Store } from 'vuex'
 import VueRouter from 'vue-router'
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Fixed `vue-router`'s `Location` type was not imported and global `Location` type was used for `redirect` argument type.

https://github.com/nuxt/nuxt/blob/2.x/packages/types/app/index.d.ts#L60-L61

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

