### PR TITLE
fix: use "import.meta.url" for internal require

### DIFF
--- a/packages/nuxi/src/utils/cjs.ts
+++ b/packages/nuxi/src/utils/cjs.ts
@@ -15,7 +15,7 @@ export function getModulePaths (paths?: string | string[]): string[] {
     .filter(Boolean) as string[]
 }
 
-const _require = createRequire(process.cwd())
+const _require = createRequire(import.meta.url)
 
 export function resolveModule (id: string, paths?: string | string[]) {
   return normalize(_require.resolve(id, { paths: getModulePaths(paths) }))


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

There's no related issue currently open in this repo. Given the scope of this change, I propose to treat this pull request as both the issue report and the proposed resolution. 

This change, however, may partially address #14146, since using `import.meta.url` will create a proper parent module context when requiring modules, which will let Node lookup 4th party dependencies from the PNPM store. 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

I don't have enough context of Nuxt to assert whether this change is breaking or not. The intention behind this change is to keep whichever internal intention there was behind this `createRequire()` call. From the consumer's standpoint, this shouldn't be a breaking change, so I'm marking it as a bug fix. 

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

The internal usage of `Module.createRequire()` in `cjs.ts` is incorrect. Per [Node.js documentation](https://nodejs.org/api/module.html#modulecreaterequirefilename), the `filename` argument must be a _file name_. Passing `process.cwd()` does not yield a file name but a _directory path_. Providing incorrect value may affect the module resolution as the parent module filename will be incorrect. 

To respect the Node specification, I propose to use `import.meta.url` instead, which would point to the current module of `cjs.ts`. 

I suspect that the intention here is to create a `require()` that would always resolve modules from the project's root level (thus the CWD). If that's the case, we should still consider using a proper filename, such as a reference to `package.json` perhaps. 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

