### PR TITLE
fix(schema): allow type inference of arrays in runtime config

### DIFF
--- a/packages/schema/src/types/config.ts
+++ b/packages/schema/src/types/config.ts
@@ -54,7 +54,9 @@ type Overrideable<T extends Record<string, any>, Path extends string = ''> = {
     ? T[K] extends Record<string, any>
       ? RuntimeValue<Overrideable<T[K], `${Path}_${UpperSnakeCase<K>}`>, `You can override this value at runtime with NUXT${Path}_${UpperSnakeCase<K>}`>
       : RuntimeValue<T[K], `You can override this value at runtime with NUXT${Path}_${UpperSnakeCase<K>}`>
-    : never
+    : K extends number
+      ? T[K]
+      : never
 }
 
 /** User configuration in `nuxt.config` file */

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -53,6 +53,7 @@ export default defineNuxtConfig({
     baseAPIToken: '',
     privateConfig: 'secret_key',
     public: {
+      ids: [1, 2, 3],
       needsFallback: undefined,
       testConfig: 123
     }

--- a/test/fixtures/basic/types.ts
+++ b/test/fixtures/basic/types.ts
@@ -133,6 +133,7 @@ describe('runtimeConfig', () => {
     expectTypeOf(runtimeConfig.public.testConfig).toEqualTypeOf<number>()
     expectTypeOf(runtimeConfig.public.needsFallback).toEqualTypeOf<string>()
     expectTypeOf(runtimeConfig.privateConfig).toEqualTypeOf<string>()
+    expectTypeOf(runtimeConfig.public.ids).toEqualTypeOf<number[]>()
     expectTypeOf(runtimeConfig.unknown).toEqualTypeOf<any>()
   })
   it('provides hints on overriding these values', () => {
@@ -140,7 +141,8 @@ describe('runtimeConfig', () => {
       runtimeConfig: {
         public: {
           // @ts-expect-error
-          testConfig: 'test'
+          testConfig: 'test',
+          ids: [1, 2]
         }
       }
     })
@@ -148,6 +150,7 @@ describe('runtimeConfig', () => {
     expectTypeOf(val.runtimeConfig!.privateConfig).toEqualTypeOf<undefined | RuntimeValue<string, 'You can override this value at runtime with NUXT_PRIVATE_CONFIG'>>()
     expectTypeOf(val.runtimeConfig!.baseURL).toEqualTypeOf<undefined | RuntimeValue<string, 'You can override this value at runtime with NUXT_BASE_URL'>>()
     expectTypeOf(val.runtimeConfig!.baseAPIToken).toEqualTypeOf<undefined | RuntimeValue<string, 'You can override this value at runtime with NUXT_BASE_API_TOKEN'>>()
+    expectTypeOf(val.runtimeConfig!.public!.ids).toEqualTypeOf<undefined | RuntimeValue<Array<number | undefined>, 'You can override this value at runtime with NUXT_PUBLIC_IDS'>>()
     expectTypeOf(val.runtimeConfig!.unknown).toEqualTypeOf<any>()
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

resolves  #18925

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This is a fix for inferred runtime type hints in `runtimeConfig` for keys that have arrays in the runtime config.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
