### PR TITLE
docs: fix typo

### DIFF
--- a/docs/7.migration/7.component-options.md
+++ b/docs/7.migration/7.component-options.md
@@ -125,7 +125,7 @@ The validate hook in Nuxt 3 only accepts a single argument, the `route`. Just as
 + definePageMeta({
 +   validate: async (route) => {
 +     const nuxtApp = useNuxtApp()
-+     return /^\d+$/.test(params.id)
++     return /^\d+$/.test(route.params.id)
 +   }
 + })
   </script>


### PR DESCRIPTION
The current code in the `validate` example gives:

```[Vue Router warn]: uncaught error during route navigation: ReferenceError: params is not defined```

params should be accessed via route.params.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

