### PR TITLE
fix(nitro): ensure ssr error `statusCode` is a number

### DIFF
--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -85,7 +85,7 @@ interface _NuxtApp {
     rendered?: Function
     error?: Error | {
       url: string
-      statusCode: string
+      statusCode: number
       statusMessage: string
       message: string
       description: string

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -157,6 +157,17 @@ async function getIslandContext (event: H3Event): Promise<NuxtIslandContext> {
   return ctx
 }
 
+const normalizeSsrError = (ssrErrorQuery: ReturnType<typeof getQuery>) => {
+  const { statusCode, ...ssrErrorStringProps } = ssrErrorQuery
+  const ssrError = ssrErrorStringProps as unknown as Exclude<NuxtApp['payload']['error'], Error>
+
+  if (ssrError && typeof statusCode === 'string') {
+    ssrError.statusCode = parseInt(statusCode)
+  }
+
+  return ssrError
+}
+
 const PAYLOAD_CACHE = (process.env.NUXT_PAYLOAD_EXTRACTION && process.env.prerender) ? new Map() : null // TODO: Use LRU cache
 const PAYLOAD_URL_RE = /\/_payload(\.[a-zA-Z0-9]+)?.js(\?.*)?$/
 
@@ -167,7 +178,7 @@ export default defineRenderHandler(async (event) => {
 
   // Whether we're rendering an error page
   const ssrError = event.node.req.url?.startsWith('/__nuxt_error')
-    ? getQuery(event) as Exclude<NuxtApp['payload']['error'], Error>
+    ? normalizeSsrError(getQuery(event))
     : null
   if (ssrError && event.node.req.socket.readyState !== 'readOnly' /* direct request */) {
     throw createError('Cannot directly render error page!')

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -40,7 +40,7 @@ describe.skipIf(isWindows)('minimal nuxt application', () => {
 
   it('default server bundle size', async () => {
     stats.server = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect(stats.server.totalBytes).toBeLessThan(90000)
+    expect(stats.server.totalBytes).toBeLessThan(90200)
 
     const modules = await analyzeSizes('node_modules/**/*', serverDir)
     expect(modules.totalBytes).toBeLessThan(2700000)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Fix https://github.com/nuxt/nuxt/issues/18992.

For keeping consistent type on ssr error, statusCode should be number, so this pr is normalizing the string value from the error getting by querystring.

