### PR TITLE
feat(nuxi): add quiet mode support

### DIFF
--- a/packages/nuxi/src/commands/analyze.ts
+++ b/packages/nuxi/src/commands/analyze.ts
@@ -11,7 +11,7 @@ import { defineNuxtCommand } from './index'
 export default defineNuxtCommand({
   meta: {
     name: 'analyze',
-    usage: 'npx nuxi analyze [rootDir]',
+    usage: 'npx nuxi analyze [--quiet, -q] [rootDir]',
     description: 'Build nuxt and analyze production bundle (experimental)'
   },
   async invoke (args) {
@@ -28,6 +28,9 @@ export default defineNuxtCommand({
         build: {
           analyze: true
         }
+      },
+      overrides: {
+        quiet: args.quiet ?? args.q
       }
     })
 

--- a/packages/nuxi/src/commands/build.ts
+++ b/packages/nuxi/src/commands/build.ts
@@ -10,7 +10,7 @@ import { defineNuxtCommand } from './index'
 export default defineNuxtCommand({
   meta: {
     name: 'build',
-    usage: 'npx nuxi build [--prerender] [--dotenv] [rootDir]',
+    usage: 'npx nuxi build [--prerender] [--dotenv] [--quiet, -q] [rootDir]',
     description: 'Build nuxt for production deployment'
   },
   async invoke (args) {
@@ -33,6 +33,7 @@ export default defineNuxtCommand({
         }
       },
       overrides: {
+        quiet: args.quiet ?? args.q,
         _generate: args.prerender
       }
     })

--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -19,7 +19,7 @@ import { defineNuxtCommand } from './index'
 export default defineNuxtCommand({
   meta: {
     name: 'dev',
-    usage: 'npx nuxi dev [rootDir] [--dotenv] [--clipboard] [--open, -o] [--port, -p] [--host, -h] [--https] [--ssl-cert] [--ssl-key]',
+    usage: 'npx nuxi dev [rootDir] [--dotenv] [--quiet, -q] [--clipboard] [--open, -o] [--port, -p] [--host, -h] [--https] [--ssl-cert] [--ssl-key]',
     description: 'Run nuxt development server'
   },
   async invoke (args) {
@@ -75,7 +75,14 @@ export default defineNuxtCommand({
         if (currentNuxt) {
           await currentNuxt.close()
         }
-        currentNuxt = await loadNuxt({ rootDir, dev: true, ready: false })
+        currentNuxt = await loadNuxt({
+          rootDir,
+          dev: true,
+          ready: false,
+          overrides: {
+            quiet: args.quiet ?? args.q
+          }
+        })
         if (!isRestart) {
           showURL()
         }

--- a/packages/nuxi/src/commands/prepare.ts
+++ b/packages/nuxi/src/commands/prepare.ts
@@ -9,7 +9,7 @@ import { defineNuxtCommand } from './index'
 export default defineNuxtCommand({
   meta: {
     name: 'prepare',
-    usage: 'npx nuxi prepare',
+    usage: 'npx nuxi prepare [--quiet, -q] [rootDir]',
     description: 'Prepare nuxt for development/build'
   },
   async invoke (args) {
@@ -17,7 +17,13 @@ export default defineNuxtCommand({
     const rootDir = resolve(args._[0] || '.')
 
     const { loadNuxt } = await loadKit(rootDir)
-    const nuxt = await loadNuxt({ rootDir, config: { _prepare: true } })
+    const nuxt = await loadNuxt({
+      rootDir,
+      config: { _prepare: true },
+      overrides: {
+        quiet: args.quiet ?? args.q
+      }
+    })
     await clearDir(nuxt.options.buildDir)
 
     await buildNuxt(nuxt)

--- a/packages/nuxi/src/commands/typecheck.ts
+++ b/packages/nuxi/src/commands/typecheck.ts
@@ -9,7 +9,7 @@ import { defineNuxtCommand } from './index'
 export default defineNuxtCommand({
   meta: {
     name: 'typecheck',
-    usage: 'npx nuxi typecheck [rootDir]',
+    usage: 'npx nuxi typecheck [--quiet, -q] [rootDir]',
     description: 'Runs `vue-tsc` to check types throughout your app.'
   },
   async invoke (args) {
@@ -17,7 +17,13 @@ export default defineNuxtCommand({
     const rootDir = resolve(args._[0] || '.')
 
     const { loadNuxt, buildNuxt } = await loadKit(rootDir)
-    const nuxt = await loadNuxt({ rootDir, config: { _prepare: true } })
+    const nuxt = await loadNuxt({
+      rootDir,
+      config: { _prepare: true },
+      overrides: {
+        quiet: args.quiet ?? args.q
+      }
+    })
 
     // Generate types and build nuxt instance
     await writeTypes(nuxt)

--- a/packages/schema/src/config/build.ts
+++ b/packages/schema/src/config/build.ts
@@ -1,7 +1,7 @@
 import { defineUntypedSchema } from 'untyped'
 import { defu } from 'defu'
 import { join } from 'pathe'
-import { isCI, isTest, hasTTY } from 'std-env'
+import { isMinimal } from 'std-env'
 
 export default defineUntypedSchema({
   /**
@@ -49,7 +49,7 @@ export default defineUntypedSchema({
    */
   quiet: {
     $resolve: async (val, get) => {
-      return val ?? (isTest || isCI || !hasTTY)
+      return val ?? (isMinimal)
     }
   },
 

--- a/packages/schema/src/config/build.ts
+++ b/packages/schema/src/config/build.ts
@@ -1,6 +1,7 @@
 import { defineUntypedSchema } from 'untyped'
 import { defu } from 'defu'
 import { join } from 'pathe'
+import { isCI, isTest, hasTTY } from 'std-env'
 
 export default defineUntypedSchema({
   /**
@@ -36,6 +37,20 @@ export default defineUntypedSchema({
         client: await get('dev')
       })
     },
+  },
+
+  /**
+   * Whether or not to suppress non-essential logs when building Nuxt.
+   *
+   * Defaults to true when running in CI or when a TTY is not available.
+   *
+   * @type {boolean}
+   * @default {false}
+   */
+  quiet: {
+    $resolve: async (val, get) => {
+      return val ?? (isTest || isCI || !hasTTY)
+    }
   },
 
   /**

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -39,6 +39,7 @@ export async function bundle (nuxt: Nuxt) {
     entry,
     config: vite.mergeConfig(
       {
+        logLevel: nuxt.options.quiet ? 'silent' : undefined,
         resolve: {
           alias: {
             ...nuxt.options.alias,

--- a/packages/webpack/src/presets/base.ts
+++ b/packages/webpack/src/presets/base.ts
@@ -40,7 +40,7 @@ function baseConfig (ctx: WebpackConfigContext) {
     mode: ctx.isDev ? 'development' : 'production',
     cache: getCache(ctx),
     output: getOutput(ctx),
-    stats: 'none',
+    stats: ctx.nuxt.options.quiet ? 'none' : 'summary',
     ...ctx.config
   }
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

resolves #18656
resolves https://github.com/nuxt/nuxt/issues/18497

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds a basic `quiet` option that can be set in config or passed via `-q` or `--quiet` option in nuxi that will set vite logLevel to silent.

**TODO**:
- (unrelated to this PR) investigate why we have no logging in webpack at the moment

**For review**:
- consider whether to default _always_ to false (vs enabling in CI/test/without TTY)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

