### PR TITLE
perf(nuxt): allow tree-shaking empty meta from build

### DIFF
--- a/packages/nuxt/src/pages/page-meta.ts
+++ b/packages/nuxt/src/pages/page-meta.ts
@@ -16,7 +16,7 @@ export interface PageMetaPluginOptions {
 }
 
 const CODE_EMPTY = `
-const __nuxt_page_meta = {}
+const __nuxt_page_meta = null
 export default __nuxt_page_meta
 `
 
@@ -138,7 +138,7 @@ export const PageMetaPlugin = createUnplugin((options: PageMetaPluginOptions) =>
 
           const meta = node.arguments[0] as Expression & { start: number, end: number }
 
-          let contents = `const __nuxt_page_meta = ${code!.slice(meta.start, meta.end) || '{}'}\nexport default __nuxt_page_meta` + (options.dev ? CODE_HMR : '')
+          let contents = `const __nuxt_page_meta = ${code!.slice(meta.start, meta.end) || 'null'}\nexport default __nuxt_page_meta` + (options.dev ? CODE_HMR : '')
 
           function addImport (name: string | false) {
             if (name && importMap.has(name)) {

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -264,7 +264,7 @@ export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = 
         name: `${metaImportName}?.name ?? ${page.name ? JSON.stringify(page.name) : 'undefined'}`,
         path: `${metaImportName}?.path ?? ${JSON.stringify(page.path)}`,
         children: page.children ? normalizeRoutes(page.children, metaImports).routes : [],
-        meta: page.meta ? `{...(${metaImportName} || {}), ...${JSON.stringify(page.meta)}}` : metaImportName,
+        meta: page.meta ? `{...(${metaImportName} || {}), ...${JSON.stringify(page.meta)}}` : `${metaImportName} || {}`,
         alias: aliasCode,
         redirect: page.redirect ? JSON.stringify(page.redirect) : `${metaImportName}?.redirect || undefined`,
         component: genDynamicImport(file, { interopDefault: true })


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Because we output an empty object we are not able to tree-shaking empty meta objects out of the build. By setting to `null` instead, we can leverage rollup's ancient powers to bring order to the natural world.

**Before** (no minification)
```js
  {
    name: (__nuxt_page_meta$1 == null ? void 0 : __nuxt_page_meta$1.name) ?? "about",
    path: (__nuxt_page_meta$1 == null ? void 0 : __nuxt_page_meta$1.path) ?? "/about",
    children: [],
    meta: __nuxt_page_meta$1,
    alias: (__nuxt_page_meta$1 == null ? void 0 : __nuxt_page_meta$1.alias) || [],
    redirect: (__nuxt_page_meta$1 == null ? void 0 : __nuxt_page_meta$1.redirect) || void 0,
    component: () => __vitePreload(() => import("./about.js"), true ? ["./about.js","./nuxt-link.js"] : void 0, import.meta.url).then((m) => m.default || m)
  },
```


**After** (no minification)

```js
  {
    name: "about",
    path: "/about",
    children: [],
    meta: {},
    alias: [],
    redirect: void 0,
    component: () => __vitePreload(() => import("./about.js"), true ? ["./about.js","./nuxt-link.js"] : void 0, import.meta.url).then((m) => m.default || m)
  },
```

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
