### PR TITLE
fix(vite): respect `isCustomElement` config for jsx transform

### DIFF
--- a/packages/schema/build.config.ts
+++ b/packages/schema/build.config.ts
@@ -30,6 +30,7 @@ export default defineBuildConfig({
     'rollup-plugin-visualizer',
     'vite',
     '@vitejs/plugin-vue',
+    '@vitejs/plugin-vue-jsx',
     'mini-css-extract-plugin',
     'terser-webpack-plugin',
     'css-minimizer-webpack-plugin',

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -18,6 +18,7 @@
     "@types/semver": "^7.3.13",
     "@unhead/schema": "^1.0.21",
     "@vitejs/plugin-vue": "^4.0.0",
+    "@vitejs/plugin-vue-jsx": "^3.0.0",
     "nitropack": "^2.2.1",
     "unbuild": "latest",
     "vite": "~4.1.1"

--- a/packages/schema/src/config/vite.ts
+++ b/packages/schema/src/config/vite.ts
@@ -44,8 +44,11 @@ export default defineUntypedSchema({
       }
     },
     vueJsx: {
-      isCustomElement: {
-        $resolve: async (val, get) => val ?? (await get('vue')).compilerOptions?.isCustomElement
+      $resolve: async (val, get) => {
+        return {
+          isCustomElement: (await get('vue')).compilerOptions?.isCustomElement,
+          ...(val || {})
+        }
       }
     },
     optimizeDeps: {

--- a/packages/schema/src/config/vite.ts
+++ b/packages/schema/src/config/vite.ts
@@ -43,6 +43,11 @@ export default defineUntypedSchema({
         }
       }
     },
+    vueJsx: {
+      isCustomElement: {
+        $resolve: async (val, get) => val ?? (await get('vue')).compilerOptions?.isCustomElement
+      }
+    },
     optimizeDeps: {
       exclude: {
         $resolve: async (val, get) => [

--- a/packages/schema/src/types/config.ts
+++ b/packages/schema/src/types/config.ts
@@ -2,6 +2,7 @@ import type { KeepAliveProps, TransitionProps } from 'vue'
 import type { ConfigSchema } from '../../schema/config'
 import type { ServerOptions as ViteServerOptions, UserConfig as ViteUserConfig } from 'vite'
 import type { Options as VuePluginOptions } from '@vitejs/plugin-vue'
+import type { Options as VueJsxPluginOptions } from '@vitejs/plugin-vue-jsx'
 import type { AppHeadMetaObject } from './meta'
 import type { Nuxt } from './nuxt'
 import type { SchemaDefinition } from 'untyped'
@@ -95,9 +96,15 @@ export interface NuxtOptions extends Omit<ConfigSchema, 'builder'> {
 export interface ViteConfig extends ViteUserConfig {
   /**
    * Options passed to @vitejs/plugin-vue
-   * @see https://github.com/vitejs/vite/tree/main/packages/plugin-vue
+   * @see https://github.com/vitejs/vite-plugin-vue/tree/main/packages/plugin-vue
    */
   vue?: VuePluginOptions
+
+  /**
+   * Options passed to @vitejs/plugin-vue-jsx
+   * @see https://github.com/vitejs/vite-plugin-vue/tree/main/packages/plugin-vue-jsx
+   */
+  vueJsx?: VueJsxPluginOptions
 
   /**
    * Bundler for dev time server-side rendering.

--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -60,7 +60,7 @@ export async function buildClient (ctx: ViteBuildContext) {
     plugins: [
       cacheDirPlugin(ctx.nuxt.options.rootDir, 'client'),
       vuePlugin(ctx.config.vue),
-      viteJsxPlugin(),
+      viteJsxPlugin(ctx.config.vueJsx),
       devStyleSSRPlugin({
         srcDir: ctx.nuxt.options.srcDir,
         buildAssetsURL: joinURL(ctx.nuxt.options.app.baseURL, ctx.nuxt.options.app.buildAssetsDir)

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -110,7 +110,7 @@ export async function buildServer (ctx: ViteBuildContext) {
     plugins: [
       cacheDirPlugin(ctx.nuxt.options.rootDir, 'server'),
       vuePlugin(ctx.config.vue),
-      viteJsxPlugin()
+      viteJsxPlugin(ctx.config.vueJsx)
     ]
   } as ViteOptions)
 

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -3,7 +3,8 @@ import { join, resolve } from 'pathe'
 import type { Nuxt } from '@nuxt/schema'
 import type { InlineConfig, SSROptions } from 'vite'
 import { logger, isIgnored, resolvePath, addVitePlugin } from '@nuxt/kit'
-import type { Options } from '@vitejs/plugin-vue'
+import type { Options as VueOptions } from '@vitejs/plugin-vue'
+import type { Options as VueJsxOptions } from '@vitejs/plugin-vue-jsx'
 import replace from '@rollup/plugin-replace'
 import { sanitizeFilePath } from 'mlly'
 import { withoutLeadingSlash } from 'ufo'
@@ -17,7 +18,8 @@ import { resolveCSSOptions } from './css'
 import { composableKeysPlugin } from './plugins/composable-keys'
 
 export interface ViteOptions extends InlineConfig {
-  vue?: Options
+  vue?: VueOptions
+  vueJsx?: VueJsxOptions
   ssr?: SSROptions
   devBundler?: 'vite-node' | 'legacy'
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -512,6 +512,7 @@ importers:
       '@types/semver': ^7.3.13
       '@unhead/schema': ^1.0.21
       '@vitejs/plugin-vue': ^4.0.0
+      '@vitejs/plugin-vue-jsx': ^3.0.0
       c12: ^1.1.0
       create-require: ^1.1.1
       defu: ^6.1.2
@@ -547,6 +548,7 @@ importers:
       '@types/semver': 7.3.13
       '@unhead/schema': 1.0.21
       '@vitejs/plugin-vue': 4.0.0_vite@4.1.1
+      '@vitejs/plugin-vue-jsx': 3.0.0_vite@4.1.1
       nitropack: 2.2.1
       unbuild: 1.1.1
       vite: 4.1.1
@@ -848,7 +850,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.20.7
-    dev: false
 
   /@babel/helper-compilation-targets/7.20.7_@babel+core@7.20.12:
     resolution: {integrity: sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==}
@@ -880,7 +881,6 @@ packages:
       '@babel/helper-split-export-declaration': 7.18.6
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@babel/helper-environment-visitor/7.18.9:
     resolution: {integrity: sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==}
@@ -904,7 +904,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.20.7
-    dev: false
 
   /@babel/helper-module-imports/7.18.6:
     resolution: {integrity: sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==}
@@ -932,12 +931,10 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.20.7
-    dev: false
 
   /@babel/helper-plugin-utils/7.20.2:
     resolution: {integrity: sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==}
     engines: {node: '>=6.9.0'}
-    dev: false
 
   /@babel/helper-replace-supers/7.20.7:
     resolution: {integrity: sha512-vujDMtB6LVfNW13jhlCrp48QNslK6JXi7lQG736HVbHz/mbf4Dc7tIRh1Xf5C0rF7BP8iiSxGMCmY6Ci1ven3A==}
@@ -951,7 +948,6 @@ packages:
       '@babel/types': 7.20.7
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@babel/helper-simple-access/7.20.2:
     resolution: {integrity: sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==}
@@ -964,7 +960,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.20.7
-    dev: false
 
   /@babel/helper-split-export-declaration/7.18.6:
     resolution: {integrity: sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==}
@@ -1017,7 +1012,6 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
-    dev: false
 
   /@babel/plugin-syntax-typescript/7.20.0_@babel+core@7.20.12:
     resolution: {integrity: sha512-rd9TkG+u1CExzS4SM1BlMEhMXwFLKVjOAFFCDx9PbX5ycJWDoWMcwdJH9RhkPu1dOgn5TrxLot/Gx6lWFuAUNQ==}
@@ -1027,7 +1021,6 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
-    dev: false
 
   /@babel/plugin-transform-typescript/7.20.13_@babel+core@7.20.12:
     resolution: {integrity: sha512-O7I/THxarGcDZxkgWKMUrk7NK1/WbHAg3Xx86gqS6x9MTrNL6AwIluuZ96ms4xeDe6AVx6rjHbWHP7x26EPQBA==}
@@ -1041,7 +1034,6 @@ packages:
       '@babel/plugin-syntax-typescript': 7.20.0_@babel+core@7.20.12
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@babel/standalone/7.20.15:
     resolution: {integrity: sha512-B3LmZ1NHlTb2eFEaw8rftZc730Wh9MlmsH8ubb6IjsNoIk9+SQ2aAA0nrm/1806+PftPRAACPClmKTu8PG7Tew==}
@@ -2748,6 +2740,21 @@ packages:
       - encoding
       - supports-color
 
+  /@vitejs/plugin-vue-jsx/3.0.0_vite@4.1.1:
+    resolution: {integrity: sha512-vurkuzgac5SYuxd2HUZqAFAWGTF10diKBwJNbCvnWijNZfXd+7jMtqjPFbGt7idOJUn584fP1Ar9j/GN2jQ3Ew==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.0.0
+      vue: ^3.0.0
+    dependencies:
+      '@babel/core': 7.20.12
+      '@babel/plugin-transform-typescript': 7.20.13_@babel+core@7.20.12
+      '@vue/babel-plugin-jsx': 1.1.1_@babel+core@7.20.12
+      vite: 4.1.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@vitejs/plugin-vue-jsx/3.0.0_vite@4.1.1+vue@3.2.47:
     resolution: {integrity: sha512-vurkuzgac5SYuxd2HUZqAFAWGTF10diKBwJNbCvnWijNZfXd+7jMtqjPFbGt7idOJUn584fP1Ar9j/GN2jQ3Ew==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -2890,7 +2897,6 @@ packages:
 
   /@vue/babel-helper-vue-transform-on/1.0.2:
     resolution: {integrity: sha512-hz4R8tS5jMn8lDq6iD+yWL6XNB699pGIVLk7WSJnn1dbpjaazsjZQkieJoRX6gW5zpYSCFqQ7jUquPNY65tQYA==}
-    dev: false
 
   /@vue/babel-plugin-jsx/1.1.1_@babel+core@7.20.12:
     resolution: {integrity: sha512-j2uVfZjnB5+zkcbc/zsOc0fSNGCMMjaEXP52wdwdIfn0qjFfEYpYZBFKFg+HHnQeJCVrjOeO0YxgaL7DMrym9w==}
@@ -2907,7 +2913,6 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
-    dev: false
 
   /@vue/compiler-core/3.2.47:
     resolution: {integrity: sha512-p4D7FDnQb7+YJmO2iPEv0SQNeNzcbHdGByJDsT4lynf63AFkOTFN07HsiRSvjGo0QrxR/o3d0hUyNCUnBU2Tig==}
@@ -3592,7 +3597,6 @@ packages:
   /camelcase/6.3.0:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
-    dev: false
 
   /caniuse-api/3.0.0:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
@@ -5564,7 +5568,6 @@ packages:
   /html-tags/3.2.0:
     resolution: {integrity: sha512-vy7ClnArOZwCnqZgvv+ddgHgJiAFXe3Ge9ML5/mBctVJoUoYPCdxVucOywjDARn6CVoh3dRSFdPHy2sX80L0Wg==}
     engines: {node: '>=8'}
-    dev: false
 
   /htmlparser2/3.10.1:
     resolution: {integrity: sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==}
@@ -8097,7 +8100,6 @@ packages:
 
   /svg-tags/1.0.0:
     resolution: {integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==}
-    dev: false
 
   /svgo/2.8.0:
     resolution: {integrity: sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==}

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -76,6 +76,15 @@ describe('pages', () => {
     await expectNoClientErrors('/')
   })
 
+  // TODO: support jsx with webpack
+  it.runIf(!isWebpack)('supports jsx', async () => {
+    const html = await $fetch('/')
+
+    // should import JSX/TSX components with custom elements
+    expect(html).toContain('TSX component')
+    expect(html).toContain('<custom-component>custom</custom-component>')
+  })
+
   it('respects aliases in page metadata', async () => {
     const html = await $fetch('/some-alias')
     expect(html).toContain('Hello Nuxt 3!')

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -78,7 +78,7 @@ describe('pages', () => {
 
   // TODO: support jsx with webpack
   it.runIf(!isWebpack)('supports jsx', async () => {
-    const html = await $fetch('/')
+    const html = await $fetch('/jsx')
 
     // should import JSX/TSX components with custom elements
     expect(html).toContain('TSX component')

--- a/test/fixtures/basic/components/Tsx.tsx
+++ b/test/fixtures/basic/components/Tsx.tsx
@@ -1,0 +1,8 @@
+export default defineComponent({
+  render () {
+    return <div>
+      TSX component
+      <custom-component>custom</custom-component>
+    </div>
+  }
+})

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -148,6 +148,13 @@ export default defineNuxtConfig({
       })
     }
   },
+  vue: {
+    compilerOptions: {
+      isCustomElement: (tag) => {
+        return tag === 'custom-component'
+      }
+    }
+  },
   experimental: {
     inlineSSRStyles: id => !!id && !id.includes('assets.vue'),
     componentIslands: true,

--- a/test/fixtures/basic/pages/jsx.vue
+++ b/test/fixtures/basic/pages/jsx.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    <Tsx />
+  </div>
+</template>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
resolves #19024 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adds ability to configure `@vitejs/plugin-vue-jsx` via the nuxt config. This config will live at config path `vite.vueJsx`. 

Without this, it is impossible to silence console warnings pertaining to custom elements usage in JSX. However opening up this config is more generally useful for configuring other aspects of `@vitejs/plugin-vue-jsx`.

To simplify the common use case, `vue.comilerOptions.isCustomElement` is used as a smart default for `vite.vueJsx.isCustomElement`.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

