### PR TITLE
fix(nuxi): read `devServer` options from nuxt config

### DIFF
--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -46,7 +46,10 @@ export default defineNuxtCommand({
 
     const { loadNuxt, loadNuxtConfig, buildNuxt } = await loadKit(rootDir)
 
-    const config = await loadNuxtConfig({})
+    const config = await loadNuxtConfig({
+      cwd: rootDir,
+      overrides: { dev: true }
+    })
 
     const listener = await listen(serverHandler, {
       showURL: false,

--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -44,19 +44,23 @@ export default defineNuxtCommand({
 
     await setupDotenv({ cwd: rootDir, fileName: args.dotenv })
 
+    const { loadNuxt, loadNuxtConfig, buildNuxt } = await loadKit(rootDir)
+
+    const config = await loadNuxtConfig({})
+
     const listener = await listen(serverHandler, {
       showURL: false,
       clipboard: args.clipboard,
       open: args.open || args.o,
-      port: args.port || args.p || process.env.NUXT_PORT,
-      hostname: args.host || args.h || process.env.NUXT_HOST,
-      https: args.https && {
-        cert: args['ssl-cert'],
-        key: args['ssl-key']
-      }
+      port: args.port || args.p || process.env.NUXT_PORT || config.devServer.port,
+      hostname: args.host || args.h || process.env.NUXT_HOST || config.devServer.host,
+      https: (args.https !== false && (args.https || config.devServer.https))
+        ? {
+            cert: args['ssl-cert'] || (config.devServer.https && config.devServer.https.cert) || undefined,
+            key: args['ssl-key'] || (config.devServer.https && config.devServer.https.key) || undefined
+          }
+        : false
     })
-
-    const { loadNuxt, buildNuxt } = await loadKit(rootDir)
 
     let currentNuxt: Nuxt
     const showURL = () => {

--- a/packages/schema/src/config/dev.ts
+++ b/packages/schema/src/config/dev.ts
@@ -28,10 +28,13 @@ export default defineUntypedSchema({
     port: process.env.NUXT_PORT || process.env.NITRO_PORT || process.env.PORT || 3000,
 
     /** Dev server listening host */
-    host: process.env.NUXT_HOST || process.env.NITRO_HOST || process.env.HOST || 'localhost',
+    host: process.env.NUXT_HOST || process.env.NITRO_HOST || process.env.HOST || '',
 
     /**
-     * Listening dev server url
+     * Listening dev server URL.
+     *
+     * This should not be set directly as it will always be overridden by the
+     * dev server with the full URL (for module and internal use).
      */
     url: 'http://localhost:3000',
   }


### PR DESCRIPTION
### 🔗 Linked issue

Related issue #15710 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
nuxi has been updated to read `devServer` options from the Nuxt config.
The default for `devServer.host` and `devServer.url` has been changed in schema to avoid issues.
<!-- Why is this change required? What problem does it solve? -->
The changes are required as nuxi currently does not read any `devServer` options from the nuxt config.
This is a problem as it means we cannot dynamically change, for example, the HTTPS certificate and private key.

To support the change, schema has been updated to set the default for `devServer.host` to `0.0.0.0`, and `devServer.url` to `http://0.0.0.0:3000`. If this wasn't changed, the default Nuxt host setting would override listhens default settings when the user has not specified any host option, and potentially break existing developers setups.

Current documentation is misleading, stating that the `devServer` configuration options work, when in reality they are never read at all. This would save a lot of developers from wasting time figuring out why the options don't work, as I did.
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Resolves #15710 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

Unsure about updating the documentation, I believe it gets automatically updated as I could not find the relating file.
