### PR TITLE
fix(nuxt): validate no `//` in path when constructing payload url

### DIFF
--- a/packages/nuxt/src/app/composables/payload.ts
+++ b/packages/nuxt/src/app/composables/payload.ts
@@ -36,7 +36,12 @@ export function preloadPayload (url: string, opts: LoadPayloadOptions = {}) {
 
 // --- Internal ---
 
+const LOCAL_PATH_RE = /^\/[^/]/
+
 function _getPayloadURL (url: string, opts: LoadPayloadOptions = {}) {
+  if (!LOCAL_PATH_RE.test(url)) {
+    throw new Error('Payload URL must be an absolute path without hostname: ' + url)
+  }
   const u = new URL(url, 'http://localhost')
   if (u.search) {
     throw new Error('Payload URL cannot contain search params: ' + url)
@@ -45,7 +50,7 @@ function _getPayloadURL (url: string, opts: LoadPayloadOptions = {}) {
     throw new Error('Payload URL cannot contain host: ' + url)
   }
   const hash = opts.hash || (opts.fresh ? Date.now() : '')
-  return joinURL(useRuntimeConfig().app.baseURL, url, hash ? `_payload.${hash}.js` : '_payload.js')
+  return joinURL(useRuntimeConfig().app.baseURL, u.pathname, hash ? `_payload.${hash}.js` : '_payload.js')
 }
 
 async function _importPayload (payloadURL: string) {

--- a/packages/nuxt/src/app/composables/payload.ts
+++ b/packages/nuxt/src/app/composables/payload.ts
@@ -38,7 +38,7 @@ export function preloadPayload (url: string, opts: LoadPayloadOptions = {}) {
 
 function _getPayloadURL (url: string, opts: LoadPayloadOptions = {}) {
   if (!hasProtocol(url, true)) {
-    throw new Error('Payload URL must be an absolute path without hostname: ' + url)
+    throw new Error('Payload URL must not include hostname: ' + url)
   }
   const u = new URL(url, 'http://localhost')
   if (u.search) {

--- a/packages/nuxt/src/app/composables/payload.ts
+++ b/packages/nuxt/src/app/composables/payload.ts
@@ -1,4 +1,4 @@
-import { joinURL } from 'ufo'
+import { joinURL, hasProtocol } from 'ufo'
 import { useNuxtApp, useRuntimeConfig } from '../nuxt'
 import { useHead } from './head'
 
@@ -36,18 +36,13 @@ export function preloadPayload (url: string, opts: LoadPayloadOptions = {}) {
 
 // --- Internal ---
 
-const LOCAL_PATH_RE = /^\/[^/]/
-
 function _getPayloadURL (url: string, opts: LoadPayloadOptions = {}) {
-  if (!LOCAL_PATH_RE.test(url)) {
+  if (!hasProtocol(url, true)) {
     throw new Error('Payload URL must be an absolute path without hostname: ' + url)
   }
   const u = new URL(url, 'http://localhost')
   if (u.search) {
     throw new Error('Payload URL cannot contain search params: ' + url)
-  }
-  if (u.host !== 'localhost') {
-    throw new Error('Payload URL cannot contain host: ' + url)
   }
   const hash = opts.hash || (opts.fresh ? Date.now() : '')
   return joinURL(useRuntimeConfig().app.baseURL, u.pathname, hash ? `_payload.${hash}.js` : '_payload.js')

--- a/packages/nuxt/src/app/composables/payload.ts
+++ b/packages/nuxt/src/app/composables/payload.ts
@@ -45,7 +45,7 @@ function _getPayloadURL (url: string, opts: LoadPayloadOptions = {}) {
     throw new Error('Payload URL cannot contain host: ' + url)
   }
   const hash = opts.hash || (opts.fresh ? Date.now() : '')
-  return joinURL(useRuntimeConfig().app.baseURL, u.pathname, hash ? `_payload.${hash}.js` : '_payload.js')
+  return joinURL(useRuntimeConfig().app.baseURL, url, hash ? `_payload.${hash}.js` : '_payload.js')
 }
 
 async function _importPayload (payloadURL: string) {

--- a/packages/nuxt/src/app/composables/payload.ts
+++ b/packages/nuxt/src/app/composables/payload.ts
@@ -37,7 +37,7 @@ export function preloadPayload (url: string, opts: LoadPayloadOptions = {}) {
 // --- Internal ---
 
 function _getPayloadURL (url: string, opts: LoadPayloadOptions = {}) {
-  if (!hasProtocol(url, true)) {
+  if (hasProtocol(url, true)) {
     throw new Error('Payload URL must not include hostname: ' + url)
   }
   const u = new URL(url, 'http://localhost')


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

At the moment we fetch payload URLs using a parsed version of the URL, but we don't need to do this as we've already validated the path passed, and this avoids any issues with improperly constructed URLs like `//localhost//some`.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
