### PR TITLE
fix(nuxt): pass nuxt + workspace paths when importing builder

### DIFF
--- a/packages/nuxt/src/core/builder.ts
+++ b/packages/nuxt/src/core/builder.ts
@@ -61,7 +61,7 @@ function watch (nuxt: Nuxt) {
 async function bundle (nuxt: Nuxt) {
   try {
     const { bundle } = typeof nuxt.options.builder === 'string'
-      ? await importModule(nuxt.options.builder, { paths: [import.meta.url, nuxt.options.rootDir, nuxt.options.workspaceDir] })
+      ? await importModule(nuxt.options.builder, { paths: [nuxt.options.rootDir, nuxt.options.workspaceDir, import.meta.url] })
       : nuxt.options.builder
 
     return bundle(nuxt)

--- a/packages/nuxt/src/core/builder.ts
+++ b/packages/nuxt/src/core/builder.ts
@@ -61,7 +61,7 @@ function watch (nuxt: Nuxt) {
 async function bundle (nuxt: Nuxt) {
   try {
     const { bundle } = typeof nuxt.options.builder === 'string'
-      ? await importModule(nuxt.options.builder, { paths: nuxt.options.rootDir })
+      ? await importModule(nuxt.options.builder, { paths: [import.meta.url, nuxt.options.rootDir, nuxt.options.workspaceDir] })
       : nuxt.options.builder
 
     return bundle(nuxt)


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/14441

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This passes the path of `nuxt` and the workspace dir as a basis from which to resolve the builder, which can help if the builder dependency is not hoisted (probably only in the case of `@nuxt/vite-builder`).

We are probably due to refactor away from this `importModule` util but this can be considered a hotfix until then.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
