### PR TITLE
fix(nuxi): restart nuxt when `distDir` is unlinked

### DIFF
--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -158,6 +158,11 @@ export default defineNuxtCommand({
 
     await load(false)
 
+    const distWatcher = chokidar.watch(resolve(rootDir, '.nuxt/dist'), { ignoreInitial: true })
+    distWatcher.on('unlinkDir', () => {
+      dLoad(true, '.nuxt/dist directory has been removed')
+    })
+
     return 'wait' as const
   }
 })

--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -86,7 +86,7 @@ export default defineNuxtCommand({
           showURL()
         }
 
-        distWatcher = chokidar.watch(resolve(currentNuxt.options.buildDir, 'dist'), { ignoreInitial: true })
+        distWatcher = chokidar.watch(resolve(currentNuxt.options.buildDir, 'dist'), { ignoreInitial: true, depth: 0 })
         distWatcher.on('unlinkDir', () => {
           dLoad(true, '.nuxt/dist directory has been removed')
         })

--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -78,7 +78,7 @@ export default defineNuxtCommand({
           await currentNuxt.close()
         }
         if (distWatcher) {
-          distWatcher.close()
+          await distWatcher.close()
         }
 
         currentNuxt = await loadNuxt({ rootDir, dev: true, ready: false })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
resolve https://github.com/nuxt/nuxt/issues/15069
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Hi :wave: 
this adds a watcher on `.nuxt/dist`. The dev server would reload nuxt by itself if the `dist` directory has been removed. 
This would avoid to manually restart the server.

Use case: 
- Start dev server 
- "Oh i forgot to add another package"
- `npm install another-package` in another terminal 
- `postinstall` is run with `nuxi prepare`, clear buildDir
- dev server break :cry:                                         -- dev server restart 👍 
- `ctrl` + C, ⬆️ , `enter`, wait for server to restart --- nuxt ready

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

