### PR TITLE
fix(nuxt): prefetch object-syntax routes with `<NuxtLink>`

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -176,7 +176,7 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
       const el = process.server ? undefined : ref<HTMLElement | null>(null)
       if (process.client) {
         checkPropConflicts(props, 'prefetch', 'noPrefetch')
-        const shouldPrefetch = props.prefetch !== false && props.noPrefetch !== true && typeof to.value === 'string' && props.target !== '_blank' && !isSlowConnection()
+        const shouldPrefetch = props.prefetch !== false && props.noPrefetch !== true && props.target !== '_blank' && !isSlowConnection()
         if (shouldPrefetch) {
           const nuxtApp = useNuxtApp()
           let idleId: number
@@ -190,7 +190,7 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
                     unobserve?.()
                     unobserve = null
                     await Promise.all([
-                      nuxtApp.hooks.callHook('link:prefetch', to.value as string).catch(() => {}),
+                      nuxtApp.hooks.callHook('link:prefetch', to.value).catch(() => {}),
                       !isExternal.value && preloadRouteComponents(to.value as string, router).catch(() => {})
                     ])
                     prefetched.value = true

--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -189,8 +189,10 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
                   unobserve = observer!.observe(el.value, async () => {
                     unobserve?.()
                     unobserve = null
+
+                    const path = typeof to.value === 'string' ? to.value : router.resolve(to.value).fullPath
                     await Promise.all([
-                      nuxtApp.hooks.callHook('link:prefetch', router.resolve(to.value).fullPath).catch(() => {}),
+                      nuxtApp.hooks.callHook('link:prefetch', path).catch(() => {}),
                       !isExternal.value && preloadRouteComponents(to.value as string, router).catch(() => {})
                     ])
                     prefetched.value = true

--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -190,7 +190,7 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
                     unobserve?.()
                     unobserve = null
                     await Promise.all([
-                      nuxtApp.hooks.callHook('link:prefetch', to.value).catch(() => {}),
+                      nuxtApp.hooks.callHook('link:prefetch', router.resolve(to.value).fullPath).catch(() => {}),
                       !isExternal.value && preloadRouteComponents(to.value as string, router).catch(() => {})
                     ])
                     prefetched.value = true

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -6,6 +6,8 @@ import { createHooks } from 'hookable'
 import { getContext } from 'unctx'
 import type { SSRContext } from 'vue-bundle-renderer/runtime'
 import type { H3Event } from 'h3'
+
+import type { RouteLocationRaw } from 'vue-router'
 // eslint-disable-next-line import/no-restricted-paths
 import type { NuxtIslandContext } from '../core/runtime/nitro/renderer'
 import type { RuntimeConfig, AppConfigInput } from 'nuxt/schema'
@@ -35,7 +37,7 @@ export interface RuntimeNuxtHooks {
   'app:error:cleared': (options: { redirect?: string }) => HookResult
   'app:chunkError': (options: { error: any }) => HookResult
   'app:data:refresh': (keys?: string[]) => HookResult
-  'link:prefetch': (link: string) => HookResult
+  'link:prefetch': (link: RouteLocationRaw) => HookResult
   'page:start': (Component?: VNode) => HookResult
   'page:finish': (Component?: VNode) => HookResult
   'page:transition:finish': (Component?: VNode) => HookResult

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -7,7 +7,6 @@ import { getContext } from 'unctx'
 import type { SSRContext } from 'vue-bundle-renderer/runtime'
 import type { H3Event } from 'h3'
 
-import type { RouteLocationRaw } from 'vue-router'
 // eslint-disable-next-line import/no-restricted-paths
 import type { NuxtIslandContext } from '../core/runtime/nitro/renderer'
 import type { RuntimeConfig, AppConfigInput } from 'nuxt/schema'
@@ -37,7 +36,7 @@ export interface RuntimeNuxtHooks {
   'app:error:cleared': (options: { redirect?: string }) => HookResult
   'app:chunkError': (options: { error: any }) => HookResult
   'app:data:refresh': (keys?: string[]) => HookResult
-  'link:prefetch': (link: RouteLocationRaw) => HookResult
+  'link:prefetch': (link: string) => HookResult
   'page:start': (Component?: VNode) => HookResult
   'page:finish': (Component?: VNode) => HookResult
   'page:transition:finish': (Component?: VNode) => HookResult

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -6,7 +6,6 @@ import { createHooks } from 'hookable'
 import { getContext } from 'unctx'
 import type { SSRContext } from 'vue-bundle-renderer/runtime'
 import type { H3Event } from 'h3'
-
 // eslint-disable-next-line import/no-restricted-paths
 import type { NuxtIslandContext } from '../core/runtime/nitro/renderer'
 import type { RuntimeConfig, AppConfigInput } from 'nuxt/schema'


### PR DESCRIPTION
### 🔗 Linked issue

- #19136

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Based on PR #19120, the `preloadRouteComponents` function now accepts a `RouteLocationRaw` type as a value. This update has also been made to `<NuxtLink>` to allow `RouteLocationRaw` as a valid value type.

This PR does not modify the type of hook `link:prefetch`, but obtains `router.resolve(to.value).fullPath` before calling the hook, because others still need string path, rash modification may cause Breaking change.

https://github.com/nuxt/nuxt/blob/7f67fcec73016dcc31b232c92d4a50db4aaef9fc/packages/nuxt/src/pages/runtime/plugins/prefetch.client.ts#L23-L40

https://github.com/nuxt/nuxt/blob/7f67fcec73016dcc31b232c92d4a50db4aaef9fc/packages/nuxt/src/app/plugins/cross-origin-prefetch.client.ts#L26-L34

https://github.com/nuxt/nuxt/blob/7f67fcec73016dcc31b232c92d4a50db4aaef9fc/packages/nuxt/src/app/plugins/payload.client.ts#L14-L18

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

