### PR TITLE
fix(webpack): use default export from webpack

### DIFF
--- a/packages/webpack/src/plugins/chunk.ts
+++ b/packages/webpack/src/plugins/chunk.ts
@@ -1,12 +1,12 @@
 import type { Compiler } from 'webpack'
-import { RuntimeGlobals } from 'webpack'
+import webpack from 'webpack'
 
 const pluginName = 'ChunkErrorPlugin'
 
 const script = `
-if (typeof ${RuntimeGlobals.require} !== "undefined") {
-  var _ensureChunk = ${RuntimeGlobals.ensureChunk};
-  ${RuntimeGlobals.ensureChunk} = function (chunkId) {
+if (typeof ${webpack.RuntimeGlobals.require} !== "undefined") {
+  var _ensureChunk = ${webpack.RuntimeGlobals.ensureChunk};
+  ${webpack.RuntimeGlobals.ensureChunk} = function (chunkId) {
     return Promise.resolve(_ensureChunk(chunkId)).catch(err => {
       const e = new Event("nuxt.preloadError");
       e.payload = err;


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/19141

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This change how webpack is imported to avoid an issue with importing webpack into a node esm package.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
