### PR TITLE
fix(vite): normalize path emitted by vite watcher

### DIFF
--- a/packages/vite/src/vite-node.ts
+++ b/packages/vite/src/vite-node.ts
@@ -2,7 +2,7 @@ import { pathToFileURL } from 'node:url'
 import { createApp, createError, defineEventHandler, defineLazyEventHandler, eventHandler, toNodeListener } from 'h3'
 import { ViteNodeServer } from 'vite-node/server'
 import fse from 'fs-extra'
-import { resolve } from 'pathe'
+import { resolve, normalize } from 'pathe'
 import { addDevServerHandler } from '@nuxt/kit'
 import type { ModuleNode, Plugin as VitePlugin } from 'vite'
 import { normalizeViteManifest } from 'vue-bundle-renderer'
@@ -59,7 +59,7 @@ export function viteNodePlugin (ctx: ViteBuildContext): VitePlugin {
       })
 
       server.watcher.on('all', (event, file) => {
-        markInvalidates(server.moduleGraph.getModulesByFile(file))
+        markInvalidates(server.moduleGraph.getModulesByFile(normalize(file)))
         // Invalidate all virtual modules when a file is added or removed
         if (event === 'add' || event === 'unlink') {
           invalidateVirtualModules()


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

fix #18635

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This might be considered a bug of Vite, the path comes from the watcher containing backslash on windows, while Vite's getModulesByFile does not handle that.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

