### PR TITLE
fix(nuxt): preserve (re)named imports in meta

### DIFF
--- a/packages/nuxt/src/pages/page-meta.ts
+++ b/packages/nuxt/src/pages/page-meta.ts
@@ -119,7 +119,7 @@ export const PageMetaPlugin = createUnplugin((options: PageMetaPluginOptions) =>
         const parsed = parseStaticImport(i)
         for (const name of [
           parsed.defaultImport,
-          ...Object.keys(parsed.namedImports || {}),
+          ...Object.values(parsed.namedImports || {}),
           parsed.namespacedImport
         ].filter(Boolean) as string[]) {
           importMap.set(name, i)


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/19126

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We were wrongly preserving imports with reference to the _keys_ (the name in the imported module) rather than the _values_ (the name in the local scope).

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
