### PR TITLE
docs: clarify that app config is not available (yet) in nitro

### DIFF
--- a/docs/2.guide/2.directory-structure/3.app-config.md
+++ b/docs/2.guide/2.directory-structure/3.app-config.md
@@ -38,7 +38,7 @@ export default defineAppConfig({
 When adding `theme` to the `app.config`, Nuxt uses Vite or webpack to bundle the code. We can universally access `theme` both when server-rendering the page and in the browser using [useAppConfig](/docs/api/composables/use-app-config) composable.
 
 ::alert{type=info}
-Access from the `server` in this context refers to server-side rendering, not Nitro or the [server directory](/docs/guide/directory-structure/server). Nitro support is [coming soon](https://github.com/unjs/nitro/issues/728).
+Support for accessing `useAppConfig()` in Nitro and `server` directory is [coming soon](https://github.com/nuxt/nuxt/issues/14670).
 ::
 
 ```js

--- a/docs/2.guide/2.directory-structure/3.app-config.md
+++ b/docs/2.guide/2.directory-structure/3.app-config.md
@@ -35,7 +35,7 @@ export default defineAppConfig({
 })
 ```
 
-When adding `theme` to the `app.config`, Nuxt uses Vite or webpack to bundle the code. We can universally access `theme` in both server-side rendering and client-side using [useAppConfig](/docs/api/composables/use-app-config) composable.
+When adding `theme` to the `app.config`, Nuxt uses Vite or webpack to bundle the code. We can universally access `theme` both when server-rendering the page and in the browser using [useAppConfig](/docs/api/composables/use-app-config) composable.
 
 ::alert{type=info}
 Access from the `server` in this context refers to server-side rendering, not Nitro or the [server directory](/docs/guide/directory-structure/server). Nitro support is [coming soon](https://github.com/unjs/nitro/issues/728).

--- a/docs/2.guide/2.directory-structure/3.app-config.md
+++ b/docs/2.guide/2.directory-structure/3.app-config.md
@@ -38,7 +38,7 @@ export default defineAppConfig({
 When adding `theme` to the `app.config`, Nuxt uses Vite or webpack to bundle the code. We can universally access `theme` in both server and browser using [useAppConfig](/docs/api/composables/use-app-config) composable.
 
 ::alert{type=info}
-Access from the `server` in this context refers to server-side rendering, not Nitro or the [server directory](/docs/guide/directory-structure/server).
+Access from the `server` in this context refers to server-side rendering, not Nitro or the [server directory](/docs/guide/directory-structure/server). Nitro support is [coming soon](https://github.com/unjs/nitro/issues/728).
 ::
 
 ```js

--- a/docs/2.guide/2.directory-structure/3.app-config.md
+++ b/docs/2.guide/2.directory-structure/3.app-config.md
@@ -37,6 +37,10 @@ export default defineAppConfig({
 
 When adding `theme` to the `app.config`, Nuxt uses Vite or webpack to bundle the code. We can universally access `theme` in both server and browser using [useAppConfig](/docs/api/composables/use-app-config) composable.
 
+::alert{type=info}
+Access from the `server` in this context refers to server-side rendering, not Nitro or the [server directory](/docs/guide/directory-structure/server).
+::
+
 ```js
 const appConfig = useAppConfig()
 

--- a/docs/2.guide/2.directory-structure/3.app-config.md
+++ b/docs/2.guide/2.directory-structure/3.app-config.md
@@ -35,7 +35,7 @@ export default defineAppConfig({
 })
 ```
 
-When adding `theme` to the `app.config`, Nuxt uses Vite or webpack to bundle the code. We can universally access `theme` in both server and browser using [useAppConfig](/docs/api/composables/use-app-config) composable.
+When adding `theme` to the `app.config`, Nuxt uses Vite or webpack to bundle the code. We can universally access `theme` in both server-side rendering and client-side using [useAppConfig](/docs/api/composables/use-app-config) composable.
 
 ::alert{type=info}
 Access from the `server` in this context refers to server-side rendering, not Nitro or the [server directory](/docs/guide/directory-structure/server). Nitro support is [coming soon](https://github.com/unjs/nitro/issues/728).


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

Discussion:  #19180

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Provide clarity on use of `useAppConfig()` in `server/api/`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

