### PR TITLE
docs: add information on running websocket on same port as nuxt

### DIFF
--- a/docs/2.guide/3.going-further/12.websocket-servers.md
+++ b/docs/2.guide/3.going-further/12.websocket-servers.md
@@ -47,7 +47,14 @@ const proxyServer = http.createServer((req, res) => {
 
 // upgrade client connection to websocket if requested
 proxyServer.on('upgrade', (req, socket, head) => {
-  proxySocketIO.ws(req, socket, head)
+  const isSocketIo = req.url.startsWith("/socket.io")
+
+  // choose backend depending on url
+  if (isSocketIo) {
+    proxySocketIO.ws(req, socket, head)
+  } else {
+    proxyNuxt.ws(req, socket, head)
+  }
 })
 
 proxyServer.listen(4000, () => console.log("proxy is listening"))

--- a/docs/2.guide/3.going-further/12.websocket-servers.md
+++ b/docs/2.guide/3.going-further/12.websocket-servers.md
@@ -34,9 +34,13 @@ import http from 'node:http'
 const proxySocketIO = httpProxy.createProxyServer({ target: 'http://localhost:3001' });
 const proxyNuxt = httpProxy.createProxyServer({ target: 'http://localhost:3000' });
 
-const proxyServer = http.createServer((req, res) => {
+// error handlers needed, otherwise it would `throw err` on client connection resets
+proxySocketIO.on("error", (err) => console.error("proxySocketIO error:", err))
+proxyNuxt.on("error", (err) => console.error("proxyNuxt error:", err))
+
+// create http server to merge both proxies on same port
+const httpServer = http.createServer((req, res) => {
   const isSocketIo = req.url.startsWith("/socket.io")
-  
   // choose backend depending on url
   if (isSocketIo) {
     proxySocketIO.web(req, res)
@@ -46,10 +50,8 @@ const proxyServer = http.createServer((req, res) => {
 })
 
 // upgrade client connection to websocket if requested
-proxyServer.on('upgrade', (req, socket, head) => {
+httpServer.on('upgrade', (req, socket, head) => {
   const isSocketIo = req.url.startsWith("/socket.io")
-
-  // choose backend depending on url
   if (isSocketIo) {
     proxySocketIO.ws(req, socket, head)
   } else {
@@ -57,7 +59,8 @@ proxyServer.on('upgrade', (req, socket, head) => {
   }
 })
 
-proxyServer.listen(4000, () => console.log("proxy is listening"))
+// listen for incoming data
+httpServer.listen(3000, () => console.log("proxy is listening"))
 ```
 
 The socket.io server can very easily be created to listen on port `3001`.

--- a/docs/2.guide/3.going-further/12.websocket-servers.md
+++ b/docs/2.guide/3.going-further/12.websocket-servers.md
@@ -1,0 +1,108 @@
+---
+title: "Websocket servers on same port as Nuxt3"
+description: "Nuxt3 websocket servers need a workaround."
+---
+
+
+# Websocket server support in Nuxt3
+
+Nuxt3 is built upon the powerful [nitro server engine](https://nitro.unjs.io/). Which in turn utilizes the [h3 HTTP framework](https://github.com/unjs/h3).
+
+Unfortunately, due to design choices of the underlying `h3` framework, true websocket connections cannot be natively etsablished over the Nuxt3 built-in web server.
+This means that the Nuxt3 server and your websocket server need to run on different ports.
+
+# Why are Websocket servers not able to run on the same port?
+
+Simply explained, a websocket connections is a raw socket connection. In order to establish a websocket connection, the browser first sends a several traditional `HTTP GET` and `POST` request.
+Then, after making sure the server is ready for it, the connection gets `upgraded` to a socket-based connection. 
+
+Unfortunately this `upgrade` does not work with the Nuxt3 built-in webserver.
+
+# How to put Nuxt3 and websocket server on same port (socket.io example)
+
+You need to create a proxy that forwards websocket requests to the websocket server, e.g. 'http://localhost:4000/socket.io/`.
+At the same time it should forward `http://localhost:4000/` and everything else to your Nuxt3 app.
+
+Here is an example how to solve this with three files. All this code can also be put into one Nuxt3 server module if you prefer.
+
+## Example with Nuxt3 + socket.io on the same port
+
+```javascript [proxy.js]
+import httpProxy from 'http-proxy';
+import http from 'node:http'
+
+const proxySocketIO = httpProxy.createProxyServer({ target: 'http://localhost:3001' });
+const proxyNuxt = httpProxy.createProxyServer({ target: 'http://localhost:3000' });
+
+const proxyServer = http.createServer((req, res) => {
+  const isSocketIo = req.url.startsWith("/socket.io")
+  
+  // choose backend depending on url
+  if (isSocketIo) {
+    proxySocketIO.web(req, res)
+  } else {
+    proxyNuxt.web(req, res)
+  }
+})
+
+// upgrade client connection to websocket if requested
+proxyServer.on('upgrade', (req, socket, head) => {
+  proxySocketIO.ws(req, socket, head)
+})
+
+proxyServer.listen(4000, () => console.log("proxy is listening"))
+```
+
+The socket.io server can very easily be created to listen on port `3001`.
+
+```javascript [websocket-server.js]
+import { Server } from 'socket.io';
+
+const io = new Server(3001);
+
+io.on('connection', (socket) => {
+  console.log('Connection', socket.id)
+});
+
+io.on('connect', (socket) => {
+  socket.on("error", (msg) => {
+    console.log("socket error", msg)
+  })
+});
+```
+
+Your Nuxt3 will just use the default port `3000`. If you want to make `socket.io` available on the client-side you can create a small plugin.
+
+```javascript [my-nuxt-project/plugins/websocket.client.js]
+import { io } from 'socket.io-client';
+
+export default defineNuxtPlugin(async (nuxtApp) => {
+    return {
+        provide: {
+            io: io()
+        }
+    }
+});
+```
+
+Now you can use `socket.io` websockets in your templates.
+
+
+```vue [my-nuxt-project/pages/demo.vue]
+<template>
+   <h1>Socket.io and Nuxt3 Example</h1>
+</template>
+
+<script setup>
+const { $io } = useNuxtApp()
+
+onMounted(() => {
+  $io.emit("message", "new message sent");
+  $io.on("message", (message) => console.log("received backend message", message))
+})
+</script>
+```
+
+Obviously, the `proxy.js` can also be another reverse proxy such as `nginx`. But this is a handy example you can use for example in a docker-compose environment.
+
+


### PR DESCRIPTION
I have spent all day trying to figure out why proxy'ing socket.io through nuxt did not work. All the modules like `nuxt-socket-io` could not help me to achieve this. After deep diving into h3 and nitro code I noticed that h3 does not support `upgrade` requests (which makes sense from nuxt3) design perspective.

So I think we should openly document this and advise people to use a proxy in front of nuxt3 if they want to put everything on the same url / port.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

Nuxt3 and socket.io cannot be on same port, even when using proxy or various npm modules.

<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
https://github.com/nuxt/nuxt/issues/19199
https://github.com/nuxt/nuxt/issues/14786

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x] I have linked an issue or discussion.
- [x ] I have updated the documentation accordingly.

