### PR TITLE
feat(vite): add `node_modules` and buildDir to `x_google_ignoreList`

### DIFF
--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -63,6 +63,9 @@ export async function bundle (nuxt: Nuxt) {
           copyPublicDir: false,
           rollupOptions: {
             output: {
+              sourcemapIgnoreList: (relativeSourcePath) => {
+                return relativeSourcePath.includes('/node_modules/') || relativeSourcePath.includes(ctx.nuxt.options.buildDir)
+              },
               sanitizeFileName: sanitizeFilePath,
               // https://github.com/vitejs/vite/tree/main/packages/vite/src/node/build.ts#L464-L478
               assetFileNames: nuxt.options.dev


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Rollup now supports (https://github.com/rollup/rollup/pull/4848) adding certain files to the [`x_google_ignoreList` source map extension](https://developer.chrome.com/blog/devtools-better-angular-debugging/#the-x_google_ignorelist-source-map-extension). We can opt-in to this to provide a better default experience on Chrome.

| Before | After |
| - | - |
| <img width="529" alt="CleanShot 2023-02-23 at 15 17 10@2x" src="https://user-images.githubusercontent.com/28706372/220933126-56d9a0e5-e846-4958-a40a-e528a48bcb32.png"> | <img width="534" alt="CleanShot 2023-02-23 at 15 16 18@2x" src="https://user-images.githubusercontent.com/28706372/220932932-932f193b-59a6-4385-8796-a62dcfd59c20.png"> |

**Limitations**: This is a specific enhancement only for vite. More significantly, at the moment this is only processed in the rollup/vite production build rather than in development, which is a bit of a pain. ~~I've marked this as draft to investigate further. It might require an upstream vite enhancement.~~ This will need to be enabled upstream in vite first before being configurable here.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
