### PR TITLE
fix(nuxt): compatible route object for custom external routes

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -250,25 +250,17 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
             return null
           }
 
-          const props = {
+          return slots.default({
             href,
             navigate,
-            rel,
-            target,
-            isExternal: isExternal.value,
-            isActive: false,
-            isExactActive: false
-          }
-
-          Object.defineProperty(props, 'route', {
-            get () {
+            get route () {
               if (!href) { return undefined }
 
               const url = parseURL(href)
               return {
                 path: url.pathname,
                 fullPath: url.pathname,
-                query: parseQuery(url.search),
+                get query () { return parseQuery(url.search) },
                 hash: url.hash,
                 // stub properties for compat with vue-router
                 params: {},
@@ -278,10 +270,13 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
                 meta: {},
                 href
               }
-            }
+            },
+            rel,
+            target,
+            isExternal: isExternal.value,
+            isActive: false,
+            isExactActive: false
           })
-
-          return slots.default(props)
         }
 
         return h('a', { ref: el, href, rel, target }, slots.default?.())

--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -1,7 +1,7 @@
 import type { PropType, DefineComponent, ComputedRef } from 'vue'
 import { defineComponent, h, ref, resolveComponent, computed, onMounted, onBeforeUnmount } from 'vue'
 import type { RouteLocationRaw } from 'vue-router'
-import { hasProtocol } from 'ufo'
+import { hasProtocol, parseQuery, parseURL } from 'ufo'
 
 import { preloadRouteComponents } from '../composables/preload'
 import { onNuxtReady } from '../composables/ready'
@@ -249,10 +249,25 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
           if (!slots.default) {
             return null
           }
+          const url = href && parseURL(href)
           return slots.default({
             href,
             navigate,
-            route: router.resolve(href!),
+            route: url
+              ? {
+                  path: url.pathname,
+                  fullPath: url.pathname,
+                  query: parseQuery(url.search),
+                  hash: url.hash,
+                  // stub properties for compat with vue-router
+                  params: {},
+                  name: undefined,
+                  matched: [],
+                  redirectedFrom: undefined,
+                  meta: {},
+                  href
+                }
+              : undefined,
             rel,
             target,
             isExternal: isExternal.value,

--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -249,31 +249,39 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
           if (!slots.default) {
             return null
           }
-          const url = href && parseURL(href)
-          return slots.default({
+
+          const props = {
             href,
             navigate,
-            route: url
-              ? {
-                  path: url.pathname,
-                  fullPath: url.pathname,
-                  query: parseQuery(url.search),
-                  hash: url.hash,
-                  // stub properties for compat with vue-router
-                  params: {},
-                  name: undefined,
-                  matched: [],
-                  redirectedFrom: undefined,
-                  meta: {},
-                  href
-                }
-              : undefined,
             rel,
             target,
             isExternal: isExternal.value,
             isActive: false,
             isExactActive: false
+          }
+
+          Object.defineProperty(props, 'route', {
+            get () {
+              if (!href) { return undefined }
+
+              const url = parseURL(href)
+              return {
+                path: url.pathname,
+                fullPath: url.pathname,
+                query: parseQuery(url.search),
+                hash: url.hash,
+                // stub properties for compat with vue-router
+                params: {},
+                name: undefined,
+                matched: [],
+                redirectedFrom: undefined,
+                meta: {},
+                href
+              }
+            }
           })
+
+          return slots.default(props)
         }
 
         return h('a', { ref: el, href, rel, target }, slots.default?.())

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -40,7 +40,7 @@ describe.skipIf(isWindows)('minimal nuxt application', () => {
 
   it('default server bundle size', async () => {
     stats.server = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect(stats.server.totalBytes).toBeLessThan(92100)
+    expect(stats.server.totalBytes).toBeLessThan(92500)
 
     const modules = await analyzeSizes('node_modules/**/*', serverDir)
     expect(modules.totalBytes).toBeLessThan(2710200)

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -40,7 +40,7 @@ describe.skipIf(isWindows)('minimal nuxt application', () => {
 
   it('default server bundle size', async () => {
     stats.server = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect(stats.server.totalBytes).toBeLessThan(92800)
+    expect(stats.server.totalBytes).toBeLessThan(92700)
 
     const modules = await analyzeSizes('node_modules/**/*', serverDir)
     expect(modules.totalBytes).toBeLessThan(2710200)

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -40,7 +40,7 @@ describe.skipIf(isWindows)('minimal nuxt application', () => {
 
   it('default server bundle size', async () => {
     stats.server = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect(stats.server.totalBytes).toBeLessThan(92500)
+    expect(stats.server.totalBytes).toBeLessThan(92800)
 
     const modules = await analyzeSizes('node_modules/**/*', serverDir)
     expect(modules.totalBytes).toBeLessThan(2710200)


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/19259

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We were calling `router.resolve()` on known external routes. We can either completely omit this route or we can parse it as we are doing in the universal router plugin. (I've chosen the latter as it's a non-breaking change if someone is already using the universal router + custom external links, but other thoughts welcome.)

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
