### PR TITLE
perf(nuxt): don't update manifest in dev mode

### DIFF
--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -152,6 +152,7 @@ export default defineNuxtModule({
 
     // Do not prefetch page chunks
     nuxt.hook('build:manifest', async (manifest) => {
+      if (nuxt.options.dev) { return }
       const pages = await resolvePagesRoutes()
       await nuxt.callHook('pages:extend', pages)
 


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Checking devtools results, we were needlessly processing the dev build manifest to remove prefetches, which was adding an extra 10ms to dev startup. This removes that overhead in dev mode.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
