### PR TITLE
perf(nuxt): increase static asset maxAge to 1yr

### DIFF
--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -86,7 +86,7 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
         ? { dir: resolve(nuxt.options.buildDir, 'dist/client') }
         : {
             dir: join(nuxt.options.buildDir, 'dist/client', nuxt.options.app.buildAssetsDir),
-            maxAge: 30 * 24 * 60 * 60,
+            maxAge: 31536000 /* 1 year */,
             baseURL: nuxt.options.app.buildAssetsDir
           },
       ...nuxt.options._layers


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

With new Nitro support for cache rules we cache static assets for 30 days. This falls afoul of the Lighthouse recommended length - see https://developer.chrome.com/docs/lighthouse/performance/uses-long-cache-ttl.

Until the next release, you can opt-in to this behaviour by adding this to your `nuxt.config`:

```ts
export default defineNuxtConfig({
  nitro: {
    publicAssets: [
      {
        baseURL: '/_nuxt',
        maxAge: 31536000,
        dir: '~/.nuxt/dist/client/_nuxt',
      },
    ],
  }
})
```

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
