### PR TITLE
ci: limit nuxt2 nightly build to nuxt org

### DIFF
--- a/.github/workflows/nuxt2-edge.yml
+++ b/.github/workflows/nuxt2-edge.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   nightly:
+    if: github.repository_owner == 'nuxt'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Issue

`nuxt2-nightly` runs on forks of the `nuxt/nuxt` repository every night (and also fails - `A branch or tag with the name '2.x' could not be found`) and sending out an alert of fork owners, such as myself & over email at midnight, about the CI run. 😅 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Added condition to `nightly` job.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

