### PR TITLE
docs: update $fetch documentation

### DIFF
--- a/docs/3.api/3.utils/$fetch.md
+++ b/docs/3.api/3.utils/$fetch.md
@@ -14,8 +14,12 @@ During server-side rendering, calling `$fetch` **on the server side** to fetch y
 
 ```ts
 <script setup>
-const dataTwice = await $fetch("/api/item"); // During SSR data is fetched twice, one on the server and one on the client.
-const { data } = await useAsyncData('item', () => $fetch('/api/item')); // During SSR data is fetched only on the server side and transferred to the client.
+// During SSR data is fetched twice, one on the server and one on the client.
+const dataTwice = await $fetch("/api/item")
+// During SSR data is fetched only on the server side and transferred to the client.
+const { data } = await useAsyncData('item', () => $fetch('/api/item'))
+// You can also useFetch as shortcut of useAsyncData + $fetch
+const { data } = await useFetch('/api/item')
 </script>
 ```
 

--- a/docs/3.api/3.utils/$fetch.md
+++ b/docs/3.api/3.utils/$fetch.md
@@ -7,25 +7,42 @@ description: Nuxt uses ofetch to expose globally the $fetch helper for making HT
 
 Nuxt uses [ofetch](https://github.com/unjs/ofetch) to expose globally the `$fetch` helper for making HTTP requests within your Vue app or API routes.
 
-::ReadMore{link="/docs/getting-started/data-fetching"}
-::
+During server-side rendering, calling `$fetch` to fetch your internal [API routes](/docs/guide/directory-structure/server) will directly call the relevant function (emulating the request), **saving an additional API call**.
 
-During server-side rendering, calling `$fetch` **on the server side** to fetch your internal [API routes](/docs/guide/directory-structure/server) will directly call the relevant function (emulating the request), **saving an additional API call**. However, when using server-side rendering, calling `$fetch` *on the client side* without wrapping it with `useAsyncData` causes fetching the data twice initially on the server, then again on the client, because `$fetch` does not transfer state from the server to the client. Thus, the fetch will be executed on both sides because the client has to get the data again. Use [`useFetch`](https://nuxt.com/docs/api/composables/use-fetch) or [`useAsyncData`](https://nuxt.com/docs/api/composables/use-async-data) with `$fetch` on the client side to prevent double data fetching.
+However, using `$fetch` in components without wrapping it with `useAsyncData` causes fetching the data twice: initially on the server, then again on the client-side during hydration, because `$fetch` does not transfer state from the server to the client. Thus, the fetch will be executed on both sides because the client has to get the data again.
 
-```ts
+We recommend to use [`useFetch`](https://nuxt.com/docs/api/composables/use-fetch) or [`useAsyncData`](https://nuxt.com/docs/api/composables/use-async-data) + `$fetch` to prevent double data fetching when fetching the component data.
+
+```vue
 <script setup>
 // During SSR data is fetched twice, one on the server and one on the client.
 const dataTwice = await $fetch("/api/item")
+
 // During SSR data is fetched only on the server side and transferred to the client.
 const { data } = await useAsyncData('item', () => $fetch('/api/item'))
+
 // You can also useFetch as shortcut of useAsyncData + $fetch
 const { data } = await useFetch('/api/item')
 </script>
 ```
 
-Note that `$fetch` is the preferred way to make HTTP calls in Nuxt 3 instead of [@nuxt/http](https://github.com/nuxt/http) and [@nuxtjs/axios](https://github.com/nuxt-community/axios-module) that are made for Nuxt 2.
+:ReadMore{link="/docs/getting-started/data-fetching"}
 
-During Using $fetch on client side without wrapping it with `useAsyncData` results in  `useFetch` or 
+You can use `$fetch` for any method that are executed only on client-side.
 
-::NeedContribution
-::
+```vue
+<script setup>
+function contactForm() {
+  $fetch('/api/contact', {
+    method: 'POST',
+    body: { hello: 'world '}
+  })
+}
+</script>
+
+<template>
+  <button @click="contactForm">Contact</button>
+</template>
+```
+
+`$fetch` is the preferred way to make HTTP calls in Nuxt instead of [@nuxt/http](https://github.com/nuxt/http) and [@nuxtjs/axios](https://github.com/nuxt-community/axios-module) that are made for Nuxt 2.

--- a/docs/3.api/3.utils/$fetch.md
+++ b/docs/3.api/3.utils/$fetch.md
@@ -10,9 +10,18 @@ Nuxt uses [ofetch](https://github.com/unjs/ofetch) to expose globally the `$fetc
 ::ReadMore{link="/docs/getting-started/data-fetching"}
 ::
 
-During server-side rendering, calling `$fetch` to fetch your internal [API routes](/docs/guide/directory-structure/server) will directly call the relevant function (emulating the request), **saving an additional API call**.
+During server-side rendering, calling `$fetch` **on the server side** to fetch your internal [API routes](/docs/guide/directory-structure/server) will directly call the relevant function (emulating the request), **saving an additional API call**. However, when using server-side rendering, calling `$fetch` *on the client side* without wrapping it with `useAsyncData` causes fetching the data twice initially on the server, then again on the client, because `$fetch` does not transfer state from the server to the client. Thus, the fetch will be executed on both sides because the client has to get the data again. Use [`useFetch`](https://nuxt.com/docs/api/composables/use-fetch) or [`useAsyncData`](https://nuxt.com/docs/api/composables/use-async-data) with `$fetch` on the client side to prevent double data fetching.
+
+```ts
+<script setup>
+const dataTwice = await $fetch("/api/item"); // During SSR data is fetched twice, one on the server and one on the client.
+const { data } = await useAsyncData('item', () => $fetch('/api/item')); // During SSR data is fetched only on the server side and transferred to the client.
+</script>
+```
 
 Note that `$fetch` is the preferred way to make HTTP calls in Nuxt 3 instead of [@nuxt/http](https://github.com/nuxt/http) and [@nuxtjs/axios](https://github.com/nuxt-community/axios-module) that are made for Nuxt 2.
+
+During Using $fetch on client side without wrapping it with `useAsyncData` results in  `useFetch` or 
 
 ::NeedContribution
 ::


### PR DESCRIPTION
It is confusing why data is fetched twice when using `$fetch` on the client side without wrapping it with `useAsyncData`. It is explained [here](https://github.com/nuxt/nuxt/discussions/18731#discussioncomment-4860920) clearly. This PR updates docs to add clarification.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

#18731

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

It is confusing why `$fetch` fetches data twice when used on the client side with SSR. This PR adds details about this behaviour.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have linked an issue or discussion.
- [X] I have updated the documentation accordingly.

