### PR TITLE
v2.16.2

### DIFF
--- a/distributions/nuxt-start/package.json
+++ b/distributions/nuxt-start/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-start",
-  "version": "2.16.1",
+  "version": "2.16.2",
   "description": "Starts Nuxt Application in production mode",
   "keywords": [
     "nuxt",
@@ -26,13 +26,13 @@
     "dist"
   ],
   "dependencies": {
-    "@nuxt/cli": "2.16.1",
-    "@nuxt/config": "2.16.1",
-    "@nuxt/core": "2.16.1",
-    "@nuxt/server": "2.16.1",
+    "@nuxt/cli": "2.16.2",
+    "@nuxt/config": "2.16.2",
+    "@nuxt/core": "2.16.2",
+    "@nuxt/server": "2.16.2",
     "@nuxt/telemetry": "^1.4.1",
-    "@nuxt/utils": "2.16.1",
-    "@nuxt/vue-renderer": "2.16.1",
+    "@nuxt/utils": "2.16.2",
+    "@nuxt/vue-renderer": "2.16.2",
     "node-fetch-native": "^1.0.2",
     "vue": "^2.7.10",
     "vue-client-only": "^2.1.0",

--- a/distributions/nuxt/package.json
+++ b/distributions/nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt",
-  "version": "2.16.1",
+  "version": "2.16.2",
   "description": "A minimalistic framework for server-rendered Vue.js applications (inspired by Next.js)",
   "keywords": [
     "nuxt",
@@ -31,21 +31,21 @@
     "postinstall": "opencollective || exit 0"
   },
   "dependencies": {
-    "@nuxt/babel-preset-app": "2.16.1",
-    "@nuxt/builder": "2.16.1",
-    "@nuxt/cli": "2.16.1",
+    "@nuxt/babel-preset-app": "2.16.2",
+    "@nuxt/builder": "2.16.2",
+    "@nuxt/cli": "2.16.2",
     "@nuxt/components": "^2.2.1",
-    "@nuxt/config": "2.16.1",
-    "@nuxt/core": "2.16.1",
-    "@nuxt/generator": "2.16.1",
+    "@nuxt/config": "2.16.2",
+    "@nuxt/core": "2.16.2",
+    "@nuxt/generator": "2.16.2",
     "@nuxt/loading-screen": "^2.0.4",
     "@nuxt/opencollective": "^0.3.3",
-    "@nuxt/server": "2.16.1",
+    "@nuxt/server": "2.16.2",
     "@nuxt/telemetry": "^1.4.1",
-    "@nuxt/utils": "2.16.1",
-    "@nuxt/vue-app": "2.16.1",
-    "@nuxt/vue-renderer": "2.16.1",
-    "@nuxt/webpack": "2.16.1"
+    "@nuxt/utils": "2.16.2",
+    "@nuxt/vue-app": "2.16.2",
+    "@nuxt/vue-renderer": "2.16.2",
+    "@nuxt/webpack": "2.16.2"
   },
   "collective": {
     "url": "https://opencollective.com/nuxtjs",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.16.1",
+  "version": "2.16.2",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "conventionalCommits": true,

--- a/packages/babel-preset-app/package.json
+++ b/packages/babel-preset-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxt/babel-preset-app",
-  "version": "2.16.1",
+  "version": "2.16.2",
   "description": "babel-preset-app for nuxt",
   "repository": "nuxt/nuxt.js",
   "license": "MIT",

--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxt/builder",
-  "version": "2.16.1",
+  "version": "2.16.2",
   "repository": "nuxt/nuxt.js",
   "license": "MIT",
   "main": "dist/builder.js",
@@ -9,9 +9,9 @@
   ],
   "dependencies": {
     "@nuxt/devalue": "^2.0.0",
-    "@nuxt/utils": "2.16.1",
-    "@nuxt/vue-app": "2.16.1",
-    "@nuxt/webpack": "2.16.1",
+    "@nuxt/utils": "2.16.2",
+    "@nuxt/vue-app": "2.16.2",
+    "@nuxt/webpack": "2.16.2",
     "chalk": "^4.1.2",
     "chokidar": "^3.5.3",
     "consola": "^2.15.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxt/cli",
-  "version": "2.16.1",
+  "version": "2.16.2",
   "repository": "nuxt/nuxt.js",
   "license": "MIT",
   "main": "dist/cli.js",
@@ -12,8 +12,8 @@
     "dist"
   ],
   "dependencies": {
-    "@nuxt/config": "2.16.1",
-    "@nuxt/utils": "2.16.1",
+    "@nuxt/config": "2.16.2",
+    "@nuxt/utils": "2.16.2",
     "boxen": "^5.1.2",
     "chalk": "^4.1.2",
     "compression": "^1.7.4",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxt/config",
-  "version": "2.16.1",
+  "version": "2.16.2",
   "repository": "nuxt/nuxt.js",
   "license": "MIT",
   "main": "dist/config.js",
@@ -10,7 +10,7 @@
     "index.d.ts"
   ],
   "dependencies": {
-    "@nuxt/utils": "2.16.1",
+    "@nuxt/utils": "2.16.2",
     "consola": "^2.15.3",
     "defu": "^6.1.2",
     "destr": "^1.2.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxt/core",
-  "version": "2.16.1",
+  "version": "2.16.2",
   "repository": "nuxt/nuxt.js",
   "license": "MIT",
   "main": "dist/core.js",
@@ -8,9 +8,9 @@
     "dist"
   ],
   "dependencies": {
-    "@nuxt/config": "2.16.1",
-    "@nuxt/server": "2.16.1",
-    "@nuxt/utils": "2.16.1",
+    "@nuxt/config": "2.16.2",
+    "@nuxt/server": "2.16.2",
+    "@nuxt/utils": "2.16.2",
     "consola": "^2.15.3",
     "fs-extra": "^10.1.0",
     "hable": "^3.0.0",

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxt/generator",
-  "version": "2.16.1",
+  "version": "2.16.2",
   "repository": "nuxt/nuxt.js",
   "license": "MIT",
   "main": "dist/generator.js",
@@ -8,7 +8,7 @@
     "dist"
   ],
   "dependencies": {
-    "@nuxt/utils": "2.16.1",
+    "@nuxt/utils": "2.16.2",
     "chalk": "^4.1.2",
     "consola": "^2.15.3",
     "defu": "^6.1.2",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxt/server",
-  "version": "2.16.1",
+  "version": "2.16.2",
   "repository": "nuxt/nuxt.js",
   "license": "MIT",
   "main": "dist/server.js",
@@ -8,8 +8,8 @@
     "dist"
   ],
   "dependencies": {
-    "@nuxt/utils": "2.16.1",
-    "@nuxt/vue-renderer": "2.16.1",
+    "@nuxt/utils": "2.16.2",
+    "@nuxt/vue-renderer": "2.16.2",
     "@nuxtjs/youch": "^4.2.3",
     "compression": "^1.7.4",
     "connect": "^3.7.0",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxt/types",
-  "version": "2.16.1",
+  "version": "2.16.2",
   "description": "Nuxt types",
   "repository": "nuxt/nuxt.js",
   "license": "MIT",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxt/utils",
-  "version": "2.16.1",
+  "version": "2.16.2",
   "repository": "nuxt/nuxt.js",
   "license": "MIT",
   "main": "dist/utils.js",

--- a/packages/vue-app/package.json
+++ b/packages/vue-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxt/vue-app",
-  "version": "2.16.1",
+  "version": "2.16.2",
   "repository": "nuxt/nuxt.js",
   "license": "MIT",
   "main": "dist/vue-app.js",

--- a/packages/vue-renderer/package.json
+++ b/packages/vue-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxt/vue-renderer",
-  "version": "2.16.1",
+  "version": "2.16.2",
   "repository": "nuxt/nuxt.js",
   "license": "MIT",
   "main": "dist/vue-renderer.js",
@@ -9,7 +9,7 @@
   ],
   "dependencies": {
     "@nuxt/devalue": "^2.0.0",
-    "@nuxt/utils": "2.16.1",
+    "@nuxt/utils": "2.16.2",
     "consola": "^2.15.3",
     "defu": "^6.1.2",
     "fs-extra": "^10.1.0",

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxt/webpack",
-  "version": "2.16.1",
+  "version": "2.16.2",
   "repository": "nuxt/nuxt.js",
   "license": "MIT",
   "main": "dist/webpack.js",
@@ -9,9 +9,9 @@
   ],
   "dependencies": {
     "@babel/core": "^7.21.0",
-    "@nuxt/babel-preset-app": "2.16.1",
+    "@nuxt/babel-preset-app": "2.16.2",
     "@nuxt/friendly-errors-webpack-plugin": "^2.5.2",
-    "@nuxt/utils": "2.16.1",
+    "@nuxt/utils": "2.16.2",
     "babel-loader": "^8.3.0",
     "cache-loader": "^4.1.0",
     "caniuse-lite": "^1.0.30001458",


### PR DESCRIPTION
> **2.16.2** is a patch release with bug fixes and performance improvements.
>
> **Timetable**: this week

## 👉 Changelog

[compare changes](https://github.com/nuxt/nuxt/compare/v2.16.1...v2.16.2)


### 🚀 Enhancements

  - **types:** Add basic types for Nuxt interface (#9772)

### 🩹 Fixes

  - **vue-renderer:** Insert `charset` before `title` (#18998)
  - **types:** Remove non-existent properties from context (#19021)
  - Add minimum node 14.18 version constraint (#19112)
  - **config:** Upgrade md4 -> md5 on node > 16 (#19108)
  - **vue-app:** Handle promise rejection from `asyncData` (#18585)

### 🏡 Chore

  - Update tag name (15787a2e5)
  - Fix version merge (49ea657a4)
  - Add `@types/jest` (d48efa6cf)

### ❤️  Contributors

- Rafał Chłodnicki ([@rchl](http://github.com/rchl))
- Daniel Roe ([@danielroe ](https://github.com/danielroe/))
- Pooya Parsa ([@pi0](https://github.com/pi0))
- Harlan Wilton ([@harlan-zw](http://github.com/harlan-zw))


