### PR TITLE
fix(nuxt): prevent fallthrough attributes on custom `NuxtLink`

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -211,20 +211,29 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
 
       return () => {
         if (!isExternal.value) {
+          const routerLinkProps: Record<string, any> = {
+            ref: process.server ? undefined : (ref: any) => { el!.value = ref?.$el },
+            to: to.value,
+            activeClass: props.activeClass || options.activeClass,
+            exactActiveClass: props.exactActiveClass || options.exactActiveClass,
+            replace: props.replace,
+            ariaCurrentValue: props.ariaCurrentValue,
+            custom: props.custom
+          }
+
+          // `custom` API cannot support fallthrough attributes as the slot
+          // may render fragment or text root nodes (#14897, #19375)
+          if (!props.custom) {
+            if (prefetched.value) {
+              routerLinkProps.class = props.prefetchedClass || options.prefetchedClass
+            }
+            routerLinkProps.rel = props.rel
+          }
+
           // Internal link
           return h(
             resolveComponent('RouterLink'),
-            {
-              ref: process.server ? undefined : (ref: any) => { el!.value = ref?.$el },
-              to: to.value,
-              ...((prefetched.value && !props.custom) ? { class: props.prefetchedClass || options.prefetchedClass } : {}),
-              activeClass: props.activeClass || options.activeClass,
-              exactActiveClass: props.exactActiveClass || options.exactActiveClass,
-              replace: props.replace,
-              ariaCurrentValue: props.ariaCurrentValue,
-              custom: props.custom,
-              rel: props.rel
-            },
+            routerLinkProps,
             slots.default
           )
         }

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -40,7 +40,7 @@ describe.skipIf(isWindows)('minimal nuxt application', () => {
 
   it('default server bundle size', async () => {
     stats.server = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect(stats.server.totalBytes).toBeLessThan(92900)
+    expect(stats.server.totalBytes).toBeLessThan(93000)
 
     const modules = await analyzeSizes('node_modules/**/*', serverDir)
     expect(modules.totalBytes).toBeLessThan(2722000)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
Resolves: #19375

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
In #19309 we enabled the forwarding of the `rel` prop of `NuxtLink` as an attribute to internal links.

This resurfaced an issue we faced in the past (#14897) where the `custom` API of `NuxtLink` (from `RouterLink`) cannot handle such fallthrough attributes[^1]. This seems to happen because Vue slot API cannot assume that the slot content strictly is a VNode (as it could also be a fragment or text node), so it has to consider all cases.[^2]

I think this is not really an upstream issue (`vue-router` actually tries to let those attribute fallthrough as it's Vue default behavior, causing the warning) but a limitation of the slot API (again, it cannot just assume it will be a VNode).

Given those considerations we (mainly) have two choices:
1. Forcing users to forward fallthrough attributes manually using `v-bind="$attrs"` systematically when using the `custom` API
2. Not forwarding any additional attribute to the component when the `custom` API is used

I think n°2 makes more sense. Should someone use the `custom` API, it makes more sense for them to just apply those extra attributes on their slot content themselves rather than providing them to the link component which might eventually apply them to their slotted template. This comes with the tradeoff of not being able to programmatically define attributes to be applied on our end (like the prefetching class)[^3]

---

This PR also refactors the way `RouterLink` props are defined to be more readable (otherwise we would have multiple inline ternaries when defining the object).

The type of `routerLinkProps` is `Record<string, any>`, defined after Vue's internal `RawProps` type which is not exported by Vue (with reasons I assume)
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

[^1]: Vue documentation on fallthrough attributes behavior: https://vuejs.org/guide/components/attrs.html
[^2]: For reference, this also happens with `RouterLink` directly: https://stackblitz.com/edit/github-stiici-ukvew6
[^3]: `vue-router` seems to be doing the same tradeoff, albeit booleans used to define active classes and such are exposed to the slot: https://github.com/vuejs/router/blob/6b7b25a74e89f1dde534bf86d19cfcdbce25092b/packages/router/src/RouterLink.ts#L214-L230