### PR TITLE
chore: bump edge version based on commits

### DIFF
--- a/scripts/bump-edge.ts
+++ b/scripts/bump-edge.ts
@@ -1,6 +1,8 @@
 import { execSync } from 'node:child_process'
 import { $fetch } from 'ofetch'
 import { inc } from 'semver'
+import { getGitDiff, determineSemverChange, loadChangelogConfig, parseCommits } from 'changelogen'
+import { execaSync } from 'execa'
 import { loadWorkspace } from './_utils'
 
 async function main () {
@@ -14,9 +16,16 @@ async function main () {
   const latestNitro = nitroInfo['dist-tags'].latest
   nuxtPkg.data.dependencies.nitropack = `npm:nitropack-edge@^${latestNitro}`
 
+  const config = await loadChangelogConfig(process.cwd())
+
+  const latestTag = execaSync('git', ['describe', '--tags', '--abbrev=0']).stdout
+  console.log({ latestTag })
+
+  const commits = await getGitDiff(latestTag)
+  const bumpType = determineSemverChange(parseCommits(commits, config), config)
+
   for (const pkg of workspace.packages.filter(p => !p.data.private)) {
-    // TODO: Set release type based on changelog after 3.0.0
-    const newVersion = inc(pkg.data.version, 'prerelease', 'rc')
+    const newVersion = inc(pkg.data.version, bumpType || 'prerelease')
     workspace.setVersion(pkg.data.name, `${newVersion}-${date}.${commit}`)
     const newname = pkg.data.name === 'nuxt' ? 'nuxt3' : (pkg.data.name + '-edge')
     workspace.rename(pkg.data.name, newname)

--- a/scripts/bump-edge.ts
+++ b/scripts/bump-edge.ts
@@ -19,7 +19,6 @@ async function main () {
   const config = await loadChangelogConfig(process.cwd())
 
   const latestTag = execaSync('git', ['describe', '--tags', '--abbrev=0']).stdout
-  console.log({ latestTag })
 
   const commits = await getGitDiff(latestTag)
   const bumpType = determineSemverChange(parseCommits(commits, config), config)


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change

- [x] 🧹 Chore
- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This uses the latest git commits to tell us what kind of bump to make in the nightly versions. For example, this would bump us to `3.3.0-27962919.2db04d7db` at the moment.

When https://github.com/unjs/changelogen/pull/69 merges, we can refactor to use that utility rather than directly calling `git`.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
