### PR TITLE
fix(nuxt): pass transform options to component loader plugin

### DIFF
--- a/packages/nuxt/src/components/module.ts
+++ b/packages/nuxt/src/components/module.ts
@@ -202,7 +202,7 @@ export default defineNuxtModule<ComponentsOptions>({
         sourcemap: nuxt.options.sourcemap[mode],
         getComponents,
         mode,
-        transform: nuxt.options.components?.transform,
+        transform: typeof nuxt.options.components === 'object' && !Array.isArray(nuxt.options.components) ? nuxt.options.components.transform : undefined,
         experimentalComponentIslands: nuxt.options.experimental.componentIslands
       }))
     })
@@ -220,7 +220,7 @@ export default defineNuxtModule<ComponentsOptions>({
           sourcemap: nuxt.options.sourcemap[mode],
           getComponents,
           mode,
-          transform: nuxt.options.components?.transform,
+          transform: typeof nuxt.options.components === 'object' && !Array.isArray(nuxt.options.components) ? nuxt.options.components.transform : undefined,
           experimentalComponentIslands: nuxt.options.experimental.componentIslands
         }))
       })

--- a/packages/nuxt/src/components/module.ts
+++ b/packages/nuxt/src/components/module.ts
@@ -202,6 +202,7 @@ export default defineNuxtModule<ComponentsOptions>({
         sourcemap: nuxt.options.sourcemap[mode],
         getComponents,
         mode,
+        transform: nuxt.options.components?.transform,
         experimentalComponentIslands: nuxt.options.experimental.componentIslands
       }))
     })
@@ -219,6 +220,7 @@ export default defineNuxtModule<ComponentsOptions>({
           sourcemap: nuxt.options.sourcemap[mode],
           getComponents,
           mode,
+          transform: nuxt.options.components?.transform,
           experimentalComponentIslands: nuxt.options.experimental.componentIslands
         }))
       })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
resolves #19412 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

As mentioned in #19412 the component/transform options are not passed to the loaderPlugin. Therefor it is currently not possible to include/exclude components from translating "_resolveComponent(...)" to an actual "import xx from 'xx'".

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

