### PR TITLE
chore: mark `@nuxt/test-utils` package as external group

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,6 +24,16 @@
     "jsdoc/require-returns": "off",
     "jsdoc/require-param-type": "off",
     "no-redeclare": "off",
+    "import/order": [
+      "error", {
+        "pathGroups": [
+          {
+            "pattern": "@nuxt/test-utils",
+            "group": "external"
+          }
+        ]
+      }
+    ],
     "import/no-restricted-paths": [
       "error",
       {

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from 'vitest'
 import { joinURL, withQuery } from 'ufo'
 import { isCI, isWindows } from 'std-env'
 import { normalize } from 'pathe'
-// eslint-disable-next-line import/order
 import { setup, fetch, $fetch, startServer, isDev, createPage, url } from '@nuxt/test-utils'
 
 import type { NuxtIslandResponse } from '../packages/nuxt/src/core/runtime/nitro/renderer'

--- a/test/hmr.test.ts
+++ b/test/hmr.test.ts
@@ -3,7 +3,6 @@ import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import { isWindows } from 'std-env'
 import { join } from 'pathe'
-// eslint-disable-next-line import/order
 import { setup, $fetch } from '@nuxt/test-utils'
 
 import { expectWithPolling, renderPage } from './utils'


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Move @nuxt/test-utils to external package so that we don't need eslint-disable on it.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

