### PR TITLE
chore: add chore to type of change in pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,6 +17,7 @@ Please carefully read the contribution docs before creating a pull request
 - [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
 - [ ] 👌 Enhancement (improving an existing functionality like performance)
 - [ ] ✨ New feature (a non-breaking change that adds functionality)
+- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
 - [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
 
 ### 📚 Description
@@ -33,4 +34,3 @@ Please carefully read the contribution docs before creating a pull request
 
 - [ ] I have linked an issue or discussion.
 - [ ] I have updated the documentation accordingly.
-


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

I think we can have a `chore` type for prs like changing ci, lint and other build tools.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

