### PR TITLE
feat(nuxt): add support for `nuxt/kit` subpath for local use

### DIFF
--- a/packages/nuxt/kit.d.ts
+++ b/packages/nuxt/kit.d.ts
@@ -1,0 +1,1 @@
+export * from '@nuxt/kit'

--- a/packages/nuxt/kit.mjs
+++ b/packages/nuxt/kit.mjs
@@ -1,0 +1,1 @@
+export * from '@nuxt/kit'

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -21,6 +21,10 @@
       "types": "./schema.d.ts",
       "import": "./schema.mjs"
     },
+    "./kit": {
+      "types": "./kit.d.ts",
+      "import": "./kit.mjs"
+    },
     "./app": "./dist/app/index.mjs",
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
### 🔗 Linked issue

resolves #12339

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds a `nuxt/kit` import for using kit utilities without adding `@nuxt/kit` as a dependency. This is useful within your own project, such as within the auto-scanned `~/modules` directory (https://github.com/nuxt/nuxt/pull/19394).

**Note:** module, layer or library authors should import from `@nuxt/kit` instead, which should be a dependency of their package.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
