### PR TITLE
fix(nuxt): don't print layout warning if page is not ssr

### DIFF
--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -142,7 +142,7 @@ export const setPageLayout = (layout: string) => {
     useState('_layout').value = layout
   }
   const nuxtApp = useNuxtApp()
-  if (process.dev && nuxtApp.isHydrating && useState('_layout').value !== layout) {
+  if (process.dev && nuxtApp.isHydrating && nuxtApp.payload.serverRendered && useState('_layout').value !== layout) {
     console.warn('[warn] [nuxt] `setPageLayout` should not be called to change the layout during hydration as this will cause hydration errors.')
   }
   const inMiddleware = isProcessingMiddleware()


### PR DESCRIPTION
### 🔗 Linked issue

resolves #19428

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We can ignore the warning from `setPageLayout` if the page isn't SSRed as there is no danger of a hydration mismatch.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
