### PR TITLE
fix(kit): match commit hashes of other lengths

### DIFF
--- a/packages/kit/src/compatibility.ts
+++ b/packages/kit/src/compatibility.ts
@@ -12,7 +12,7 @@ export async function checkNuxtCompatibility (constraints: NuxtCompatibility, nu
   if (constraints.nuxt) {
     const nuxtVersion = getNuxtVersion(nuxt)
     const nuxtSemanticVersion = nuxtVersion
-      .replace(/-[0-9]+\.[0-9a-f]{7,8}/, '') // Remove edge prefix
+      .replace(/-[0-9]+\.[0-9a-f]+/, '') // Remove edge prefix
     if (!satisfies(nuxtSemanticVersion, constraints.nuxt, { includePrerelease: true })) {
       issues.push({
         name: 'nuxt',


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Current edge release version string is 9 characters long (`3.3.0-27965694.71225e50c`), and I'm not sure we need to be validating the length of the hash.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
