### PR TITLE
docs: add info `~/server/utils` directory in `~/utils` page

### DIFF
--- a/docs/2.guide/2.directory-structure/1.utils.md
+++ b/docs/2.guide/2.directory-structure/1.utils.md
@@ -16,5 +16,5 @@ The way `utils/` auto-imports work and are scanned is identical to [the composab
 ::
 
 ::alert{type=info}
-In the [server directory](/docs/guide/directory-structure/server), we auto import exported functions and variables from `server/utils/`.
+These utils are only available within the Vue part of your app. Within the [server directory](/docs/guide/directory-structure/server#server-utilities), we auto import exported functions and variables from `~/server/utils` instead.
 ::

--- a/docs/2.guide/2.directory-structure/1.utils.md
+++ b/docs/2.guide/2.directory-structure/1.utils.md
@@ -14,3 +14,7 @@ The main purpose of the `utils/` directory is to allow a semantic distinction be
 
 The way `utils/` auto-imports work and are scanned is identical to [the composables/ directory](/docs/guide/directory-structure/composables). You can see examples and more information about how they work in that section of the docs.
 ::
+
+::alert{type=info}
+In the [server directory](/docs/guide/directory-structure/server), we auto import exported functions and variables from `server/utils/`.
+::


### PR DESCRIPTION


<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I didn't know that `/server/utils` exist and assumed that the server uses `/utils` too. Added info alert to avoid such misconceptions.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
