### PR TITLE
docs: update pr template to include jsdoc annotations

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,7 @@ Please carefully read the contribution docs before creating a pull request
 
 <!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
 
-- [ ] 📖 Documentation (updates to the documentation or readme)
+- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
 - [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
 - [ ] 👌 Enhancement (improving an existing functionality like performance)
 - [ ] ✨ New feature (a non-breaking change that adds functionality)


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Add JSdoc annotations to types of changes that go under `docs:`