### PR TITLE
feat(nuxt): add `watch` option and refactor dev server restarting

### DIFF
--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -1,6 +1,6 @@
 import type { AddressInfo } from 'node:net'
 import type { RequestListener } from 'node:http'
-import { resolve, relative, normalize } from 'pathe'
+import { resolve, relative } from 'pathe'
 import chokidar from 'chokidar'
 import { debounce } from 'perfect-debounce'
 import type { Nuxt } from '@nuxt/schema'

--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -1,6 +1,5 @@
 import type { AddressInfo } from 'node:net'
 import type { RequestListener } from 'node:http'
-import { existsSync, readdirSync } from 'node:fs'
 import { resolve, relative, normalize } from 'pathe'
 import chokidar from 'chokidar'
 import { debounce } from 'perfect-debounce'

--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -170,33 +170,6 @@ export default defineNuxtCommand({
       if (file.match(/(nuxt\.config\.(js|ts|mjs|cjs)|\.nuxtignore|\.env|\.nuxtrc)$/)) {
         dLoad(true, `${relativePath} updated`)
       }
-
-      const isDirChange = ['addDir', 'unlinkDir'].includes(event)
-      const isFileChange = ['add', 'unlink'].includes(event)
-      const pagesDir = resolve(currentNuxt.options.srcDir, currentNuxt.options.dir.pages)
-      const reloadDirs = ['components', 'composables', 'utils'].map(d => resolve(currentNuxt.options.srcDir, d))
-
-      if (isDirChange) {
-        if (reloadDirs.includes(file)) {
-          return dLoad(true, `Directory \`${relativePath}/\` ${event === 'addDir' ? 'created' : 'removed'}`)
-        }
-      }
-
-      if (isFileChange) {
-        if (file.match(/(app|error|app\.config)\.(js|ts|mjs|jsx|tsx|vue)$/)) {
-          return dLoad(true, `\`${relativePath}\` ${event === 'add' ? 'created' : 'removed'}`)
-        }
-      }
-
-      if (file.startsWith(pagesDir)) {
-        const hasPages = existsSync(pagesDir) ? readdirSync(pagesDir).length > 0 : false
-        if (currentNuxt && !currentNuxt.options.pages && hasPages) {
-          return dLoad(true, 'Pages enabled')
-        }
-        if (currentNuxt && currentNuxt.options.pages && !hasPages) {
-          return dLoad(true, 'Pages disabled')
-        }
-      }
     })
 
     await load(false)

--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -159,15 +159,11 @@ export default defineNuxtCommand({
     // Watch for config changes
     // TODO: Watcher service, modules, and requireTree
     const dLoad = debounce(load)
-    const watcher = chokidar.watch([rootDir], { ignoreInitial: true, depth: 1 })
-    watcher.on('all', (event, _file) => {
-      if (!currentNuxt) { return }
-      const file = normalize(_file)
-      const buildDir = withTrailingSlash(normalize(currentNuxt.options.buildDir))
-      if (file.startsWith(buildDir)) { return }
-      const relativePath = relative(rootDir, file)
-      if (file.match(/(nuxt\.config\.(js|ts|mjs|cjs)|\.nuxtignore|\.env|\.nuxtrc)$/)) {
-        dLoad(true, `${relativePath} updated`)
+    const watcher = chokidar.watch([rootDir], { ignoreInitial: true, depth: 0 })
+    watcher.on('all', (_event, _file) => {
+      const file = relative(rootDir, _file)
+      if (file.match(/^(nuxt\.config\.(js|ts|mjs|cjs)|\.nuxtignore|\.env|\.nuxtrc)$/)) {
+        dLoad(true, `${file} updated`)
       }
     })
 

--- a/packages/nuxt/src/components/module.ts
+++ b/packages/nuxt/src/components/module.ts
@@ -147,6 +147,17 @@ export default defineNuxtModule<ComponentsOptions>({
       }
     })
 
+    // Restart dev server when component directories are added/removed
+    nuxt.hook('builder:watch', (event, path) => {
+      const isDirChange = ['addDir', 'unlinkDir'].includes(event)
+      const fullPath = resolve(nuxt.options.srcDir, path)
+
+      if (isDirChange && componentDirs.some(dir => dir.path === fullPath)) {
+        console.info(`Directory \`${path}/\` ${event === 'addDir' ? 'created' : 'removed'}`)
+        return nuxt.callHook('restart')
+      }
+    })
+
     // Scan components and add to plugin
     nuxt.hook('app:templates', async () => {
       const newComponents = await scanComponents(componentDirs, nuxt.options.srcDir!)

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -1,4 +1,3 @@
-import { existsSync, readdirSync } from 'node:fs'
 import { join, normalize, relative, resolve } from 'pathe'
 import { createHooks, createDebugger } from 'hookable'
 import type { LoadNuxtOptions } from '@nuxt/kit'

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -1,3 +1,4 @@
+import { existsSync, readdirSync } from 'node:fs'
 import { join, normalize, relative, resolve } from 'pathe'
 import { createHooks, createDebugger } from 'hookable'
 import type { LoadNuxtOptions } from '@nuxt/kit'
@@ -161,10 +162,6 @@ async function initNuxt (nuxt: Nuxt) {
   // Register user and then ad-hoc modules
   modulesToInstall.push(...nuxt.options.modules, ...nuxt.options._modules)
 
-  nuxt.hooks.hookOnce('builder:watch', (event, path) => {
-    if (watchedPaths.has(path)) { nuxt.callHook('restart', { hard: true }) }
-  })
-
   // Add <NuxtWelcome>
   addComponent({
     name: 'NuxtWelcome',
@@ -267,6 +264,29 @@ async function initNuxt (nuxt: Nuxt) {
   }
 
   await nuxt.callHook('modules:done')
+
+  nuxt.hooks.hook('builder:watch', (event, path) => {
+    // Local module patterns
+    if (watchedPaths.has(path)) {
+      return nuxt.callHook('restart', { hard: true })
+    }
+
+    // User provided patterns
+    for (const pattern of nuxt.options.watch) {
+      if (typeof pattern === 'string') {
+        if (pattern === path) { return nuxt.callHook('restart') }
+        continue
+      }
+      if (pattern.test(path)) { return nuxt.callHook('restart') }
+    }
+
+    // Core Nuxt files: app.vue, error.vue and app.config.ts
+    const isFileChange = ['add', 'unlink'].includes(event)
+    if (isFileChange && path.match(/^(app|error|app\.config)\.(js|ts|mjs|jsx|tsx|vue)$/i)) {
+      console.info(`\`${path}\` ${event === 'add' ? 'created' : 'removed'}`)
+      return nuxt.callHook('restart')
+    }
+  })
 
   // Normalize windows transpile paths added by modules
   nuxt.options.build.transpile = nuxt.options.build.transpile.map(t => typeof t === 'string' ? normalize(t) : t)

--- a/packages/nuxt/src/imports/module.ts
+++ b/packages/nuxt/src/imports/module.ts
@@ -61,6 +61,17 @@ export default defineNuxtModule<Partial<ImportsOptions>>({
     await nuxt.callHook('imports:dirs', composablesDirs)
     composablesDirs = composablesDirs.map(dir => normalize(dir))
 
+    // Restart nuxt when composable directories are added/removed
+    nuxt.hook('builder:watch', (event, path) => {
+      const isDirChange = ['addDir', 'unlinkDir'].includes(event)
+      const fullPath = resolve(nuxt.options.srcDir, path)
+
+      if (isDirChange && composablesDirs.includes(fullPath)) {
+        console.info(`Directory \`${path}/\` ${event === 'addDir' ? 'created' : 'removed'}`)
+        return nuxt.callHook('restart')
+      }
+    })
+
     // Support for importing from '#imports'
     addTemplate({
       filename: 'imports.mjs',

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -346,6 +346,18 @@ export default defineUntypedSchema({
   },
 
   /**
+   * The watch property lets you define patterns that will restart the Nuxt dev server when changed.
+   *
+   * It is an array of strings or regular expressions, which will be matched against the file path
+   * relative to the project `srcDir`.
+   *
+   * @type {Array<string | RegExp>}
+   */
+  watch: {
+    $resolve: val => [].concat(val).filter((b: unknown) => typeof b === 'string' || b instanceof RegExp),
+  },
+
+  /**
    * The watchers property lets you overwrite watchers configuration in your `nuxt.config`.
    */
   watchers: {


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This provides a number of improvements to the dev server restarting behaviour:

1. it allows configuring the files that cause a server restart (with either string/RegExp - more complex patterns can be handled with `builder:watch` hook
2. it fixes implementation detail where we were only listening in dev server to rootDir changes, but we were trying to match against srcDir - this would have worked unless there was a custom srcDir (an undetected bug?)
3. it now offers more precise matching in pages module to detect changes and trigger restart
4. we now support restarting on actual component/composables/utils directories that are used rather than hard-coded values

What's more, because we're moving the logic into the ad-hoc modules that actually care about this, it should mean we integrate better with upcoming nuxi-ng, but definitely cc: @pi0 in case you foresee any issues here.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
