### PR TITLE
fix(nuxt): only log boot errors on client-side

### DIFF
--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -197,11 +197,11 @@ export function createNuxtApp (options: CreateOptions) {
     window.addEventListener('nuxt.preloadError', (event) => {
       nuxtApp.callHook('app:chunkError', { error: (event as Event & { payload: Error }).payload })
     })
-  }
 
-  // Log errors captured when running plugins, in the `app:created` and `app:beforeMount` hooks
-  // as well as when mounting the app and in the `app:mounted` hook
-  nuxtApp.hook('app:error', (...args) => { console.error('[nuxt] error caught during app initialization', ...args) })
+    // Log errors captured when running plugins, in the `app:created` and `app:beforeMount` hooks
+    // as well as when mounting the app and in the `app:mounted` hook
+    nuxtApp.hook('app:error', (...args) => { console.error('[nuxt] error caught during app initialization', ...args) })
+  }
 
   // Expose runtime config
   const runtimeConfig = process.server


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/pull/19187#issuecomment-1459936385

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

With https://github.com/nuxt/nuxt/pull/19187, we were logging all errors caught in `app:created`. But on the server we actually handle these and they shouldn't be logged in addition. Instead, we should restrict these logs to client-side.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
