### PR TITLE
fix(nuxt): dedupe payload cache by payload url

### DIFF
--- a/packages/nuxt/src/app/composables/payload.ts
+++ b/packages/nuxt/src/app/composables/payload.ts
@@ -12,17 +12,17 @@ export function loadPayload (url: string, opts: LoadPayloadOptions = {}) {
   const payloadURL = _getPayloadURL(url, opts)
   const nuxtApp = useNuxtApp()
   const cache = nuxtApp._payloadCache = nuxtApp._payloadCache || {}
-  if (cache[url]) {
-    return cache[url]
+  if (cache[payloadURL]) {
+    return cache[payloadURL]
   }
-  cache[url] = _importPayload(payloadURL).then((payload) => {
+  cache[payloadURL] = _importPayload(payloadURL).then((payload) => {
     if (!payload) {
-      delete cache[url]
+      delete cache[payloadURL]
       return null
     }
     return payload
   })
-  return cache[url]
+  return cache[payloadURL]
 }
 
 export function preloadPayload (url: string, opts: LoadPayloadOptions = {}) {


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/19478

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

At the moment, we will re-fetch a payload for different URLs even if the payload URL is the same. This change uses the payload URL as the cache key to dedupe these requests.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
