### PR TITLE
docs: warn about modules with side-effects

### DIFF
--- a/docs/2.guide/1.concepts/3.rendering.md
+++ b/docs/2.guide/1.concepts/3.rendering.md
@@ -57,6 +57,10 @@ Universal rendering allows a Nuxt application to provide quick page load times w
 For more examples about writing Vue code without hydration mismatch, see [the Vue docs](https://vuejs.org/guide/scaling-up/ssr.html#hydration-mismatch).
 ::
 
+::alert{type=warning}
+When importing libraries with side-effects relying on browser API, make sure the component importing it is only called client-side. Bundlers does no treeshake imports of modules containing side-effects.
+::
+
 ### Examples
 
 Universal rendering is very versatile and can fit almost any use case, and is especially appropriate for any content-oriented websites: **blogs, marketing websites, portfolios, e-commerce sites, and marketplaces.**

--- a/docs/2.guide/1.concepts/3.rendering.md
+++ b/docs/2.guide/1.concepts/3.rendering.md
@@ -58,7 +58,7 @@ For more examples about writing Vue code without hydration mismatch, see [the Vu
 ::
 
 ::alert{type=warning}
-When importing libraries with side-effects relying on browser API, make sure the component importing it is only called client-side. Bundlers does no treeshake imports of modules containing side-effects.
+When importing a library with side-effects that relies on browser APIs, make sure the component importing it is only called client-side. Bundlers do not treeshake imports of modules containing side-effects.
 ::
 
 ### Examples

--- a/docs/2.guide/1.concepts/3.rendering.md
+++ b/docs/2.guide/1.concepts/3.rendering.md
@@ -58,7 +58,7 @@ For more examples about writing Vue code without hydration mismatch, see [the Vu
 ::
 
 ::alert{type=warning}
-When importing a library with side-effects that relies on browser APIs, make sure the component importing it is only called client-side. Bundlers do not treeshake imports of modules containing side-effects.
+When importing a library that relies on browser APIs and has side effects, make sure the component importing it is only called client-side. Bundlers do not treeshake imports of modules containing side-effects.
 ::
 
 ### Examples

--- a/docs/2.guide/1.concepts/3.rendering.md
+++ b/docs/2.guide/1.concepts/3.rendering.md
@@ -58,7 +58,7 @@ For more examples about writing Vue code without hydration mismatch, see [the Vu
 ::
 
 ::alert{type=warning}
-When importing a library that relies on browser APIs and has side effects, make sure the component importing it is only called client-side. Bundlers do not treeshake imports of modules containing side-effects.
+When importing a library that relies on browser APIs and has side effects, make sure the component importing it is only called client-side. Bundlers do not treeshake imports of modules containing side effects.
 ::
 
 ### Examples


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
resolve #19506 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Hi :wave: 
Some users reported that some of their pages fails to render due to `window` being undefined. The reason is this was caused by importing modules containing side-effects. Even if the user expect the code to work because it calls the import in a `onMounted`, the component crash at render because the import is not treeshaken in server-side.
This pr warns about importing modules with side-effects. 
Maybe can it be improved by adding an example to the error handling ? Or as mentionned by @manniL , listing a small list of modules containing side-effects (leaflet) ?  
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
