### PR TITLE
fix(nuxt,schema): merge custom and resolved app configs

### DIFF
--- a/packages/nuxt/src/core/schema.ts
+++ b/packages/nuxt/src/core/schema.ts
@@ -142,17 +142,18 @@ export default defineNuxtModule({
         _types +
         `
 export type CustomAppConfig = Exclude<NuxtCustomSchema['appConfig'], undefined>
+type _CustomAppConfig = CustomAppConfig
 
 declare module '@nuxt/schema' {
-  interface NuxtConfig extends NuxtCustomSchema {}
-  interface NuxtOptions extends NuxtCustomSchema {}
-  interface CustomAppConfig extends CustomAppConfig {}
+  interface NuxtConfig extends Omit<NuxtCustomSchema, 'appConfig'> {}
+  interface NuxtOptions extends Omit<NuxtCustomSchema, 'appConfig'> {}
+  interface CustomAppConfig extends _CustomAppConfig {}
 }
 
 declare module 'nuxt/schema' {
-  interface NuxtConfig extends NuxtCustomSchema {}
-  interface NuxtOptions extends NuxtCustomSchema {}
-  interface CustomAppConfig extends CustomAppConfig {}
+  interface NuxtConfig extends Omit<NuxtCustomSchema, 'appConfig'> {}
+  interface NuxtOptions extends Omit<NuxtCustomSchema, 'appConfig'> {}
+  interface CustomAppConfig extends _CustomAppConfig {}
 }
 `
       const typesPath = resolve(

--- a/packages/schema/src/types/config.ts
+++ b/packages/schema/src/types/config.ts
@@ -136,7 +136,7 @@ export interface RuntimeConfig extends RuntimeConfigNamespace {
 
 // -- App Config --
 
-export interface CustomAppConfig extends Record<string, any> { }
+export interface CustomAppConfig { }
 
 export interface AppConfigInput extends CustomAppConfig {
   /** @deprecated reserved */
@@ -156,4 +156,4 @@ export interface NuxtAppConfig {
   keepalive: boolean | KeepAliveProps
 }
 
-export interface AppConfig extends CustomAppConfig { }
+export interface AppConfig { }

--- a/test/fixtures/basic/nuxt.schema.ts
+++ b/test/fixtures/basic/nuxt.schema.ts
@@ -1,6 +1,10 @@
 export default defineNuxtSchema({
   appConfig: {
-    /** This is an example app config defined in custom schema */
+    /**
+     * This is an example app config defined in custom schema
+     *
+     * @type {123 | 456}
+     */
     userConfig: 123
   }
 })

--- a/test/fixtures/basic/types.ts
+++ b/test/fixtures/basic/types.ts
@@ -241,13 +241,12 @@ describe('composables', () => {
 describe('app config', () => {
   it('merges app config as expected', () => {
     interface ExpectedMergedAppConfig {
-      fromLayer: boolean,
-      fromNuxtConfig: boolean,
+      fromLayer: boolean
+      fromNuxtConfig: boolean
       nested: {
         val: number
-      },
-      userConfig: number
-      [key: string]: any
+      }
+      userConfig: 123 | 456
     }
     expectTypeOf<AppConfig>().toEqualTypeOf<ExpectedMergedAppConfig>()
   })


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/15592

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This fixes a couple of type issues with the current config schema implementation, notably:

1. `NuxtOptions`/`NuxtConfig` were defined in conflicting ways - with two different definitions of `appConfig` - one extending CustomAppConfig and one extending the ResolvedAppConfig. In this PR we now merge the two, smartly choosing the type from CustomAppConfig but picking from ResolvedAppConfig whether or not the item is defined. We also do not include a key signature for CustomAppConfig.
2. It's possible `CustomAppConfig` was not in fact augmented previously - I've used a different type name for safety.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
