### PR TITLE
fix(nuxt): prefer using currentInstance if available in `useNuxtApp`

### DIFF
--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -315,17 +315,14 @@ export function callWithNuxt<T extends (...args: any[]) => any> (nuxt: NuxtApp |
  * Returns the current Nuxt instance.
  */
 export function useNuxtApp () {
+  const vm = getCurrentInstance()
+  if (vm) { return vm.appContext.app.$nuxt as NuxtApp }
   const nuxtAppInstance = nuxtAppCtx.tryUse()
 
   if (!nuxtAppInstance) {
-    const vm = getCurrentInstance()
-    if (!vm) {
-      throw new Error('nuxt instance unavailable')
-    }
-    return vm.appContext.app.$nuxt as NuxtApp
+    throw new Error('nuxt instance unavailable')
   }
-
-  return nuxtAppInstance
+  return nuxtAppInstance as NuxtApp
 }
 
 export function useRuntimeConfig (): RuntimeConfig {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
resolve https://github.com/nuxt/nuxt/issues/19623
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
hi :wave: this is a workaround for https://github.com/nuxt/nuxt/issues/19623

when using `useNuxtApp` there is a small risk of CRSP with sync server components. However this risk gets higher with async components.
This keeps the current implementation,_ it just prefer using the current instance of the component if it is available.

Needed for https://github.com/nuxt/nuxt/pull/19605
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
