### PR TITLE
fix(nuxt): fix default injection type for plugins

### DIFF
--- a/packages/nuxt/src/app/composables/error.ts
+++ b/packages/nuxt/src/app/composables/error.ts
@@ -2,6 +2,7 @@ import type { H3Error } from 'h3'
 import { createError as _createError } from 'h3'
 import { toRef } from 'vue'
 import { useNuxtApp } from '../nuxt'
+import { useRouter } from './router'
 
 export const useError = () => toRef(useNuxtApp().payload, 'error')
 
@@ -27,7 +28,7 @@ export const clearError = async (options: { redirect?: string } = {}) => {
   const error = useError()
   nuxtApp.callHook('app:error:cleared', options)
   if (options.redirect) {
-    await nuxtApp.$router.replace(options.redirect)
+    await useRouter().replace(options.redirect)
   }
   error.value = null
 }

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-use-before-define */
 import { getCurrentInstance, reactive } from 'vue'
 import type { App, onErrorCaptured, VNode, Ref } from 'vue'
-import type { RouteLocationNormalizedLoaded, Router } from 'vue-router'
+import type { RouteLocationNormalizedLoaded } from 'vue-router'
 import type { Hookable } from 'hookable'
 import { createHooks } from 'hookable'
 import { getContext } from 'unctx'
@@ -101,7 +101,6 @@ interface _NuxtApp {
 
   // Nuxt injections
   $config: RuntimeConfig
-  $router: Router
 
   isHydrating?: boolean
   deferHydration: () => () => void | Promise<void>
@@ -133,7 +132,7 @@ interface _NuxtApp {
 export interface NuxtApp extends _NuxtApp {}
 
 export const NuxtPluginIndicator = '__nuxt_plugin'
-export interface Plugin<Injections extends Record<string, any> = Record<string, any>> {
+export interface Plugin<Injections extends Record<string, unknown> = Record<string, unknown>> {
   (nuxt: _NuxtApp): Promise<void> | Promise<{ provide?: Injections }> | void | { provide?: Injections }
   [NuxtPluginIndicator]?: true
 }
@@ -313,7 +312,7 @@ export function normalizePlugins (_plugins: Plugin[]) {
   return plugins as Plugin[]
 }
 
-export function defineNuxtPlugin<T extends Record<string, any>> (plugin: Plugin<T>) {
+export function defineNuxtPlugin<T extends Record<string, unknown>> (plugin: Plugin<T>) {
   plugin[NuxtPluginIndicator] = true
   return plugin
 }

--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -1,8 +1,6 @@
 import { computed, isReadonly, reactive, shallowRef } from 'vue'
 import type { Ref } from 'vue'
-import type {
-  RouteLocation
-} from 'vue-router'
+import type { RouteLocation, Router } from 'vue-router'
 import {
   createRouter,
   createWebHistory,
@@ -12,7 +10,7 @@ import {
 import { createError } from 'h3'
 import { withoutBase, isEqual } from 'ufo'
 
-import type { PageMeta, RouteMiddleware } from '#app'
+import type { PageMeta, RouteMiddleware, Plugin } from '../../../app/index'
 import { callWithNuxt, defineNuxtPlugin, useRuntimeConfig } from '#app/nuxt'
 import { showError, clearError, useError } from '#app/composables/error'
 import { useRequestEvent } from '#app/composables/ssr'
@@ -200,4 +198,4 @@ export default defineNuxtPlugin(async (nuxtApp) => {
   })
 
   return { provide: { router } }
-})
+}) as Plugin<{ router: Router }>

--- a/test/fixtures/basic/types.ts
+++ b/test/fixtures/basic/types.ts
@@ -3,7 +3,7 @@ import { describe, it } from 'vitest'
 import type { Ref } from 'vue'
 import type { AppConfig, RuntimeValue } from '@nuxt/schema'
 import type { FetchError } from 'ofetch'
-import type { NavigationFailure, RouteLocationNormalizedLoaded, RouteLocationRaw, useRouter as vueUseRouter } from 'vue-router'
+import type { NavigationFailure, RouteLocationNormalizedLoaded, RouteLocationRaw, useRouter as vueUseRouter, Router } from 'vue-router'
 
 import { defineNuxtConfig } from 'nuxt/config'
 import { callWithNuxt, isVue3 } from '#app'
@@ -130,9 +130,11 @@ describe('modules', () => {
 describe('nuxtApp', () => {
   it('types injections provided by plugins', () => {
     expectTypeOf(useNuxtApp().$asyncPlugin).toEqualTypeOf<() => string>()
+    expectTypeOf(useNuxtApp().$router).toEqualTypeOf<Router>()
   })
   it('marks unknown injections as unknown', () => {
     expectTypeOf(useNuxtApp().doesNotExist).toEqualTypeOf<unknown>()
+    expectTypeOf(useNuxtApp().$random).toEqualTypeOf<unknown>()
   })
 })
 


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We were previously typing plugins' provides as `Record<string, any>` which mean that all `$`-prefixed properties of NuxtApp were also typed as any, depriving us of type-safety here. This change updates the default plugin provide type and adds a couple of regression tests.

It also fixes an issue with the `router.d.ts` generated from the pages module which was wrongly typed as `any` previously.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
