### PR TITLE
fix(nuxi): use file url to start nuxi

### DIFF
--- a/packages/nuxi/src/cli-wrapper.ts
+++ b/packages/nuxi/src/cli-wrapper.ts
@@ -5,14 +5,14 @@ import { fileURLToPath } from 'node:url'
 import { fork } from 'node:child_process'
 import type { ChildProcess } from 'node:child_process'
 
-const cliEntry = fileURLToPath(new URL('../dist/cli-run.mjs', import.meta.url))
+const cliEntry = new URL('../dist/cli-run.mjs', import.meta.url)
 
 // Only enable wrapper for nuxt dev command
 if (process.argv[2] === 'dev') {
   process.env.__CLI_ARGV__ = JSON.stringify(process.argv)
   startSubprocess()
 } else {
-  import(cliEntry)
+  import(cliEntry.href)
 }
 
 function startSubprocess () {
@@ -33,7 +33,7 @@ function startSubprocess () {
   start()
 
   function start () {
-    childProc = fork(cliEntry)
+    childProc = fork(fileURLToPath(cliEntry))
     childProc.on('close', (code) => { if (code) { process.exit(code) } })
     childProc.on('message', (message) => {
       if ((message as { type: string })?.type === 'nuxt:restart') {


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/19674

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

On windows we currently cannot run nuxi@3.3.0 as it tries to import an absolute path which is not defined as a file URL.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
