### PR TITLE
fix(nuxt): ignore falsy modules

### DIFF
--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -276,6 +276,9 @@ async function initNuxt (nuxt: Nuxt) {
   }
 
   for (const m of modulesToInstall) {
+    if (!m) {
+      continue
+    }
     if (Array.isArray(m)) {
       await installModule(m[0], m[1])
     } else {

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -276,9 +276,6 @@ async function initNuxt (nuxt: Nuxt) {
   }
 
   for (const m of modulesToInstall) {
-    if (!m) {
-      continue
-    }
     if (Array.isArray(m)) {
       await installModule(m[0], m[1])
     } else {

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -132,7 +132,7 @@ export const schemaTemplate: NuxtTemplate<TemplateContext> = {
       ...modules.map(([configKey, importName]) =>
         `    [${configKey}]?: typeof ${genDynamicImport(importName, { wrapper: false })}.default extends NuxtModule<infer O> ? Partial<O> : Record<string, any>`
       ),
-      modules.length > 0 ? `    modules?: (NuxtModule | string | [NuxtModule | string, Record<string, any>] | ${modules.map(([configKey, importName]) => `[${genString(importName)}, Exclude<NuxtConfig[${configKey}], boolean>]`).join(' | ')})[],` : '',
+      modules.length > 0 ? `    modules?: (undefined | null | false | NuxtModule | string | [NuxtModule | string, Record<string, any>] | ${modules.map(([configKey, importName]) => `[${genString(importName)}, Exclude<NuxtConfig[${configKey}], boolean>]`).join(' | ')})[],` : '',
       '  }',
       generateTypes(await resolveSchema(Object.fromEntries(Object.entries(nuxt.options.runtimeConfig).filter(([key]) => key !== 'public'))),
         {

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -194,7 +194,7 @@ export default defineUntypedSchema({
    *   function () {}
    * ]
    * ```
-   * @type {(typeof import('../src/types/module').NuxtModule | string | [typeof import('../src/types/module').NuxtModule | string, Record<string, any>])[]}
+   * @type {(typeof import('../src/types/module').NuxtModule | string | [typeof import('../src/types/module').NuxtModule | string, Record<string, any>] | undefined | null | false)[]}
    */
   modules: [],
 

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -196,7 +196,9 @@ export default defineUntypedSchema({
    * ```
    * @type {(typeof import('../src/types/module').NuxtModule | string | [typeof import('../src/types/module').NuxtModule | string, Record<string, any>] | undefined | null | false)[]}
    */
-  modules: [],
+  modules: {
+    $resolve: val => [].concat(val).filter(Boolean)
+  },
 
   /**
    * Customize default directory structure used by Nuxt.

--- a/test/fixtures/basic/extends/bar/nuxt.config.ts
+++ b/test/fixtures/basic/extends/bar/nuxt.config.ts
@@ -1,1 +1,3 @@
-export default defineNuxtConfig({})
+export default defineNuxtConfig({
+  modules: [undefined]
+})

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -137,7 +137,7 @@ export default defineNuxtConfig({
       nuxt.options.optimization.treeShake.composables.client[nuxt.options.rootDir] = ['useServerOnlyComposable']
     },
     // To test falsy module values
-    undefined,
+    undefined
   ],
   vite: {
     logLevel: 'silent'

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -135,7 +135,9 @@ export default defineNuxtConfig({
     function (_, nuxt) {
       nuxt.options.optimization.treeShake.composables.server[nuxt.options.rootDir] = ['useClientOnlyComposable', 'setTitleToPink']
       nuxt.options.optimization.treeShake.composables.client[nuxt.options.rootDir] = ['useServerOnlyComposable']
-    }
+    },
+    // To test falsy module values
+    undefined,
   ],
   vite: {
     logLevel: 'silent'


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This allows user to enable some modules conditionally, say:

```ts
export default defineNuxtConfig({
  modules: [
    '@vueuse/nuxt'
    process.env.CI ? undefined : '@nuxt/devtools',
  ],
})
```

Currently it will error out with:

```
[error] Nuxt module should be a function: undefined
```

The current workaround is:

```ts
export default defineNuxtConfig({
  modules: [
    '@vueuse/nuxt'
    ...(process.env.CI ? [] : ['@nuxt/devtools']),
  ],
})
```

Which I think it's not idle.


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
