### PR TITLE
fix(kit): provide name to `performance.mark()`

### DIFF
--- a/packages/kit/src/module/define.ts
+++ b/packages/kit/src/module/define.ts
@@ -68,9 +68,10 @@ export function defineNuxtModule<OptionsT extends ModuleOptions> (definition: Mo
     }
 
     // Call setup
-    const mark = performance.mark()
+    const key = `nuxt:module:${uniqueKey || (Math.round(Math.random() * 10000))}`
+    const mark = performance.mark(key)
     const res = await definition.setup?.call(null as any, _options, nuxt) ?? {}
-    const perf = performance.measure(`nuxt:module:${uniqueKey || (Math.round(Math.random() * 10000))}`, mark.name)
+    const perf = performance.measure(key, mark.name)
     const setupTime = Math.round((perf.duration * 100)) / 100
 
     // Measure setup time


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/19682

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This works around a change in Node 19 (https://github.com/nodejs/node/issues/47097) whereby a name must be supplied to `performance.mark()`.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
