### PR TITLE
test: remove sourcemaps from minimal test

### DIFF
--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -40,10 +40,10 @@ describe.skipIf(isWindows)('minimal nuxt application', () => {
 
   it('default server bundle size', async () => {
     stats.server = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect(stats.server.totalBytes).toBeLessThan(94300)
+    expect(stats.server.totalBytes).toBeLessThan(93600)
 
     const modules = await analyzeSizes('node_modules/**/*', serverDir)
-    expect(modules.totalBytes).toBeLessThan(2717000)
+    expect(modules.totalBytes).toBeLessThan(2693900)
 
     const packages = modules.files
       .filter(m => m.endsWith('package.json'))
@@ -63,7 +63,6 @@ describe.skipIf(isWindows)('minimal nuxt application', () => {
         "@vue/runtime-dom",
         "@vue/server-renderer",
         "@vue/shared",
-        "buffer-from",
         "cookie-es",
         "defu",
         "destr",
@@ -78,7 +77,6 @@ describe.skipIf(isWindows)('minimal nuxt application', () => {
         "radix3",
         "scule",
         "source-map",
-        "source-map-support",
         "ufo",
         "uncrypto",
         "unctx",

--- a/test/fixtures/minimal/nuxt.config.ts
+++ b/test/fixtures/minimal/nuxt.config.ts
@@ -1,1 +1,3 @@
-export default defineNuxtConfig({})
+export default defineNuxtConfig({
+  sourcemap: false
+})


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We have a slight discrepancy with vite-ecosystem-ci in bundle size, and I think it might be worth removing sourcemaps from the equation, just in case they have any impact.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
