### PR TITLE
fix(kit): handle node 14 performance behaviour

### DIFF
--- a/packages/kit/src/module/define.ts
+++ b/packages/kit/src/module/define.ts
@@ -71,8 +71,8 @@ export function defineNuxtModule<OptionsT extends ModuleOptions> (definition: Mo
     const key = `nuxt:module:${uniqueKey || (Math.round(Math.random() * 10000))}`
     const mark = performance.mark(key)
     const res = await definition.setup?.call(null as any, _options, nuxt) ?? {}
-    const perf = performance.measure(key, mark.name)
-    const setupTime = Math.round((perf.duration * 100)) / 100
+    const perf = performance.measure(key, mark?.name) // TODO: remove when Node 14 reaches EOL
+    const setupTime = perf ? Math.round((perf.duration * 100)) / 100 : 0 // TODO: remove when Node 14 reaches EOL
 
     // Measure setup time
     if (setupTime > 5000) {


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/19674

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Node 14 returns `undefined` for `performance.mark()` and `performance.measure()` which currently breaks the latest `@nuxt/kit` in Node 14. This PR ignores module setup timings on Node 14 as we will be reaching EOL shortly in April.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
