### PR TITLE
fix(nuxi): watch dist and register restart hook after nuxt is ready

### DIFF
--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -122,7 +122,7 @@ export default defineNuxtCommand({
         await currentNuxt.ready()
 
         const unsub = currentNuxt.hooks.hook('restart', async (options) => {
-          unsub()
+          unsub() // we use this instead of `hookOnce` for Nuxt Bridge support
           if (options?.hard && process.send) {
             await listener.close().catch(() => {})
             await currentNuxt.close().catch(() => {})

--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -101,7 +101,8 @@ export default defineNuxtCommand({
           }
         })
 
-        currentNuxt.hooks.hookOnce('restart', async (options) => {
+        // Nuxt 2 does not have `.hooks` at this point
+        currentNuxt.hooks?.hookOnce('restart', async (options) => {
           if (options?.hard && process.send) {
             await listener.close().catch(() => {})
             await currentNuxt.close().catch(() => {})

--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -105,11 +105,6 @@ export default defineNuxtCommand({
           showURL()
         }
 
-        distWatcher = chokidar.watch(resolve(currentNuxt.options.buildDir, 'dist'), { ignoreInitial: true, depth: 0 })
-        distWatcher.on('unlinkDir', () => {
-          dLoad(true, '.nuxt/dist directory has been removed')
-        })
-
         // Write manifest and also check if we need cache invalidation
         if (!isRestart) {
           const previousManifest = await loadNuxtManifest(currentNuxt.options.buildDir)
@@ -120,6 +115,11 @@ export default defineNuxtCommand({
         }
 
         await currentNuxt.ready()
+
+        distWatcher = chokidar.watch(resolve(currentNuxt.options.buildDir, 'dist'), { ignoreInitial: true, depth: 0 })
+        distWatcher.on('unlinkDir', () => {
+          dLoad(true, '.nuxt/dist directory has been removed')
+        })
 
         const unsub = currentNuxt.hooks.hook('restart', async (options) => {
           unsub() // we use this instead of `hookOnce` for Nuxt Bridge support


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently Nuxi v3.3.1 will throw an error on Bridge as it assumes that Nuxt will have a `hooks` property, but that hasn't been initialised before `ready()`. (It also doesn't have a `hookOnce` method, so this avoids using `hookOnce`.)

Finally, we avoid watching `dist` dir until Nuxt is ready. This prevents a premature restart in Bridge, with (I think) no negative consequences.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
