### PR TITLE
chore(examples): use `2.x` version of nuxt instead of latest

### DIFF
--- a/examples/async-component-injection/package.json
+++ b/examples/async-component-injection/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-async-components-injection",
   "dependencies": {
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/async-data/package.json
+++ b/examples/async-data/package.json
@@ -2,7 +2,7 @@
   "name": "example-async-data",
   "dependencies": {
     "axios": "^0.19.0",
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/auth-jwt/package.json
+++ b/examples/auth-jwt/package.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "cookieparser": "^0.1.0",
     "js-cookie": "^2.2.0",
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/auth-routes/package.json
+++ b/examples/auth-routes/package.json
@@ -5,7 +5,7 @@
     "body-parser": "^1.17.2",
     "express": "^4.15.3",
     "express-session": "^1.15.3",
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/axios/package.json
+++ b/examples/axios/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@nuxtjs/axios": "^5.0.0",
     "@nuxtjs/proxy": "^1.1.2",
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/cached-components/package.json
+++ b/examples/cached-components/package.json
@@ -2,7 +2,7 @@
   "name": "example-cached-components",
   "dependencies": {
     "lru-cache": "^4.0.2",
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/coffeescript/package.json
+++ b/examples/coffeescript/package.json
@@ -11,7 +11,7 @@
     "post-update": "yarn upgrade --latest"
   },
   "dependencies": {
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "devDependencies": {
     "coffee-loader": "^0.8.0",

--- a/examples/custom-build/package.json
+++ b/examples/custom-build/package.json
@@ -2,7 +2,7 @@
   "name": "example-custom-build",
   "description": "",
   "dependencies": {
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/custom-layouts/package.json
+++ b/examples/custom-layouts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-custom-layouts",
   "dependencies": {
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/custom-loading/package.json
+++ b/examples/custom-loading/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-custom-loading",
   "dependencies": {
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/custom-page-loading/package.json
+++ b/examples/custom-page-loading/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-custom-page-loading",
   "dependencies": {
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/custom-port-host/package.json
+++ b/examples/custom-port-host/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-custom-port-host",
   "dependencies": {
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/custom-routes/package.json
+++ b/examples/custom-routes/package.json
@@ -2,7 +2,7 @@
   "name": "example-custom-routes",
   "dependencies": {
     "axios": "^0.19.0",
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/custom-server/package.json
+++ b/examples/custom-server/package.json
@@ -2,7 +2,7 @@
   "name": "example-custom-server",
   "dependencies": {
     "express": "^4.15.3",
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "scripts": {
     "dev": "node server.js",

--- a/examples/custom-template/package.json
+++ b/examples/custom-template/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-custom-template",
   "dependencies": {
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/docker-build/package.json
+++ b/examples/docker-build/package.json
@@ -10,6 +10,6 @@
     "nuxt-start": "latest"
   },
   "devDependencies": {
-    "nuxt": "latest"
+    "nuxt": "2.x"
   }
 }

--- a/examples/dynamic-components/package.json
+++ b/examples/dynamic-components/package.json
@@ -2,7 +2,7 @@
   "name": "example-dynamic-components",
   "dependencies": {
     "chart.js": "^2.7.3",
-    "nuxt": "latest",
+    "nuxt": "2.x",
     "vue-chartjs": "^3.4.2"
   },
   "scripts": {

--- a/examples/dynamic-layouts/package.json
+++ b/examples/dynamic-layouts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-dynamic-layouts",
   "dependencies": {
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/global-css/package.json
+++ b/examples/global-css/package.json
@@ -2,7 +2,7 @@
   "name": "example-global-css",
   "dependencies": {
     "bulma": "^0.5.1",
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-hello-world",
   "dependencies": {
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/i18n/package.json
+++ b/examples/i18n/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-i18n",
   "dependencies": {
-    "nuxt": "latest",
+    "nuxt": "2.x",
     "vue-i18n": "^7.3.2"
   },
   "scripts": {

--- a/examples/jest-puppeteer/package.json
+++ b/examples/jest-puppeteer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-jest-puppeteer",
   "dependencies": {
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/jest-vtu-example/package.json
+++ b/examples/jest-vtu-example/package.json
@@ -9,7 +9,7 @@
     "post-update": "yarn upgrade --latest"
   },
   "dependencies": {
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "devDependencies": {
     "@babel/core": "^7.3.4",

--- a/examples/jsx/package.json
+++ b/examples/jsx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-jsx",
   "dependencies": {
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/layout-transitions/package.json
+++ b/examples/layout-transitions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-layout-transitions",
   "dependencies": {
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/markdownit/package.json
+++ b/examples/markdownit/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@nuxtjs/markdownit": "^1.1.2",
-    "nuxt": "latest",
+    "nuxt": "2.x",
     "pug": "^2.0.0-rc.4"
   },
   "scripts": {

--- a/examples/meta-info/package.json
+++ b/examples/meta-info/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-meta-info",
   "dependencies": {
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/middleware/package.json
+++ b/examples/middleware/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-middleware",
   "dependencies": {
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/minimal-features/package.json
+++ b/examples/minimal-features/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-minimal-features",
   "dependencies": {
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/named-views/package.json
+++ b/examples/named-views/package.json
@@ -1,7 +1,7 @@
 {
   "name": "my-app",
   "dependencies": {
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/nested-components/package.json
+++ b/examples/nested-components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-nested-components",
   "dependencies": {
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/nested-routes/package.json
+++ b/examples/nested-routes/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-nested-routes",
   "dependencies": {
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/new-fetch/package.json
+++ b/examples/new-fetch/package.json
@@ -6,7 +6,7 @@
     "vue-content-placeholders": "^0.2.1"
   },
   "devDependencies": {
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/no-ssr/package.json
+++ b/examples/no-ssr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-no-ssr",
   "dependencies": {
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/nuxt-prefetch/package.json
+++ b/examples/nuxt-prefetch/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-nuxt-prefetch",
   "dependencies": {
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/plugins-vendor/package.json
+++ b/examples/plugins-vendor/package.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "axios": "^0.19.0",
     "mini-toastr": "^0.6.5",
-    "nuxt": "latest",
+    "nuxt": "2.x",
     "vue-notifications": "^0.8.0"
   },
   "scripts": {

--- a/examples/programmatic/package.json
+++ b/examples/programmatic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-programmatic",
   "dependencies": {
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "scripts": {
     "dev": "node scripts/dev",

--- a/examples/pug-stylus-coffee/package.json
+++ b/examples/pug-stylus-coffee/package.json
@@ -12,7 +12,7 @@
     "post-update": "yarn upgrade --latest"
   },
   "dependencies": {
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "devDependencies": {
     "coffee-loader": "^0.8.0",

--- a/examples/pug/package.json
+++ b/examples/pug/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-pug",
   "dependencies": {
-    "nuxt": "latest",
+    "nuxt": "2.x",
     "pug": "^2.0.3",
     "pug-plain-loader": "^1.0.0"
   },

--- a/examples/routes-meta/package.json
+++ b/examples/routes-meta/package.json
@@ -1,7 +1,7 @@
 {
   "name": "examples-routes-meta",
   "dependencies": {
-    "nuxt": "latest",
+    "nuxt": "2.x",
     "wingcss": "^1.0.0-beta"
   },
   "scripts": {

--- a/examples/routes-transitions/package.json
+++ b/examples/routes-transitions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-routes-transitions",
   "dependencies": {
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/scroll-behavior/package.json
+++ b/examples/scroll-behavior/package.json
@@ -2,7 +2,7 @@
   "name": "example-scroll-behavior",
   "dependencies": {
     "@nuxtjs/axios": "^5.3.6",
-    "nuxt": "latest",
+    "nuxt": "2.x",
     "vue-router": "https://github.com/homerjam/vue-router#dist"
   },
   "scripts": {

--- a/examples/spa/package.json
+++ b/examples/spa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-spa",
   "dependencies": {
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/static-images/package.json
+++ b/examples/static-images/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-static-images",
   "dependencies": {
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/storybook/package.json
+++ b/examples/storybook/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "chart.js": "^2.7.1",
-    "nuxt": "latest",
+    "nuxt": "2.x",
     "vue-chartjs": "^3.1.1",
     "vuetify": "1.2.6"
   },

--- a/examples/style-resources/package.json
+++ b/examples/style-resources/package.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "less": "^2.7.3",
     "less-loader": "^4.0.5",
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/styled-vue/package.json
+++ b/examples/styled-vue/package.json
@@ -2,7 +2,7 @@
   "name": "example-styled-vue",
   "version": "1.0.0",
   "dependencies": {
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/tailwindcss/package.json
+++ b/examples/tailwindcss/package.json
@@ -8,7 +8,7 @@
     "post-update": "yarn upgrade --latest"
   },
   "dependencies": {
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "devDependencies": {
     "autoprefixer": "^7.1.6",

--- a/examples/uikit/package.json
+++ b/examples/uikit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-uikit",
   "dependencies": {
-    "nuxt": "latest",
+    "nuxt": "2.x",
     "uikit": "^3.0.0-beta.30",
     "jquery": "^3.2.1"
   },

--- a/examples/vue-apollo/package.json
+++ b/examples/vue-apollo/package.json
@@ -4,7 +4,7 @@
     "@nuxtjs/apollo": "^4.0.0-rc.4",
     "core-js": "^2.6.5",
     "node-fetch": "^2.3.0",
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/vue-chartjs/package.json
+++ b/examples/vue-chartjs/package.json
@@ -4,7 +4,7 @@
     "@nuxt/http": "^0.4.0",
     "chart.js": "^2.9.3",
     "moment": "^2.24.0",
-    "nuxt": "latest",
+    "nuxt": "2.x",
     "vue-chartjs": "^3.5.0"
   },
   "scripts": {

--- a/examples/vue-class-component/package.json
+++ b/examples/vue-class-component/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-vue-class-component",
   "dependencies": {
-    "nuxt": "latest",
+    "nuxt": "2.x",
     "nuxt-class-component": "latest"
   },
   "scripts": {

--- a/examples/vuex-persistedstate/package.json
+++ b/examples/vuex-persistedstate/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-persisted-state",
   "dependencies": {
-    "nuxt": "latest",
+    "nuxt": "2.x",
     "vuex-persistedstate": "^2.0.0"
   },
   "scripts": {

--- a/examples/vuex-store/package.json
+++ b/examples/vuex-store/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-vuex-store",
   "dependencies": {
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/web-worker/package.json
+++ b/examples/web-worker/package.json
@@ -12,7 +12,7 @@
     "post-update": "yarn upgrade --latest"
   },
   "dependencies": {
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "devDependencies": {
     "babel-eslint": "^8.2.6",

--- a/examples/with-amp/package.json
+++ b/examples/with-amp/package.json
@@ -2,7 +2,7 @@
   "name": "example-with-amp",
   "version": "1.0.0",
   "dependencies": {
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/with-ava/package.json
+++ b/examples/with-ava/package.json
@@ -12,6 +12,6 @@
     "jsdom": "^11.0.0"
   },
   "dependencies": {
-    "nuxt": "latest"
+    "nuxt": "2.x"
   }
 }

--- a/examples/with-buefy/package.json
+++ b/examples/with-buefy/package.json
@@ -10,7 +10,7 @@
     "post-update": "yarn upgrade --latest"
   },
   "dependencies": {
-    "nuxt": "latest",
+    "nuxt": "2.x",
     "nuxt-buefy": "latest"
   }
 }

--- a/examples/with-cookies/package.json
+++ b/examples/with-cookies/package.json
@@ -3,12 +3,12 @@
   "dependencies": {
     "cookie": "^0.3.1",
     "js-cookie": "^2.1.4",
-    "nuxt": "latest",
-    "post-update": "yarn upgrade --latest"
+    "nuxt": "2.x"
   },
   "scripts": {
     "dev": "nuxt",
     "build": "nuxt build",
-    "start": "nuxt start"
+    "start": "nuxt start",
+    "post-update": "yarn upgrade --latest"
   }
 }

--- a/examples/with-element-ui/package.json
+++ b/examples/with-element-ui/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "dependencies": {
     "element-ui": "^2.6.3",
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/with-feathers/package.json
+++ b/examples/with-feathers/package.json
@@ -33,7 +33,7 @@
     "feathers-rest": "^1.6.0",
     "feathers-socketio": "^1.4.2",
     "nedb": "^1.8.0",
-    "nuxt": "latest",
+    "nuxt": "2.x",
     "passport": "^0.3.2",
     "winston": "^2.3.0"
   },

--- a/examples/with-firebase/package.json
+++ b/examples/with-firebase/package.json
@@ -16,6 +16,6 @@
   "license": "MIT",
   "dependencies": {
     "axios": "^0.19.0",
-    "nuxt": "latest"
+    "nuxt": "2.x"
   }
 }

--- a/examples/with-keep-alive/package.json
+++ b/examples/with-keep-alive/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-with-keep-alive",
   "dependencies": {
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/with-museui/package.json
+++ b/examples/with-museui/package.json
@@ -1,13 +1,13 @@
 {
 	"name": "example-with-museui",
 	"dependencies": {
-		"nuxt": "latest",
+		"nuxt": "2.x",
 		"muse-ui": "latest"
 	},
 	"scripts": {
 		"dev": "nuxt",
 		"build": "nuxt build",
 		"start": "nuxt start",
-    "post-update": "yarn upgrade --latest"
+		"post-update": "yarn upgrade --latest"
 	}
 }

--- a/examples/with-purgecss/package.json
+++ b/examples/with-purgecss/package.json
@@ -8,7 +8,7 @@
     "post-update": "yarn upgrade --latest"
   },
   "dependencies": {
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "devDependencies": {
     "glob-all": "^3.1.0",

--- a/examples/with-sockets/package.json
+++ b/examples/with-sockets/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "express": "^4.14.0",
-    "nuxt": "latest",
+    "nuxt": "2.x",
     "socket.io": "^1.7.2",
     "socket.io-client": "^1.7.2"
   },

--- a/examples/with-tape/package.json
+++ b/examples/with-tape/package.json
@@ -5,10 +5,10 @@
 		"build": "nuxt build",
 		"start": "nuxt start",
 		"test": "tape ./test/**/*.js -r ./test/setup.js | tap-spec",
-    "post-update": "yarn upgrade --latest"
+		"post-update": "yarn upgrade --latest"
 	},
 	"devDependencies": {
-    "@vue/test-utils": "^1.0.0",
+		"@vue/test-utils": "^1.0.0",
 		"browser-env": "^3.2.1",
 		"require-extension-hooks": "^0.3.2",
 		"require-extension-hooks-babel": "^0.1.1",
@@ -17,6 +17,6 @@
 		"tape": "^4.8.0"
 	},
 	"dependencies": {
-		"nuxt": "latest"
+		"nuxt": "2.x"
 	}
 }

--- a/examples/with-vue-material/package.json
+++ b/examples/with-vue-material/package.json
@@ -2,7 +2,7 @@
   "name": "example-with-vue-material",
   "version": "1.0.0",
   "dependencies": {
-    "nuxt": "latest",
+    "nuxt": "2.x",
     "vue": "~2.4.4",
     "vue-material": "beta"
   },

--- a/examples/with-vuetify/package.json
+++ b/examples/with-vuetify/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-with-vuetify",
   "dependencies": {
-    "nuxt": "latest"
+    "nuxt": "2.x"
   },
   "scripts": {
     "dev": "nuxt",

--- a/examples/with-vuikit/package.json
+++ b/examples/with-vuikit/package.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "@vuikit/icons": "latest",
     "@vuikit/theme": "latest",
-    "nuxt": "latest",
+    "nuxt": "2.x",
     "vuikit": "latest"
   },
   "scripts": {

--- a/examples/with-vux/package.json
+++ b/examples/with-vux/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "dependencies": {
-    "nuxt": "latest",
+    "nuxt": "2.x",
     "vux": "^2.8.0"
   },
   "scripts": {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Updated examples to use 2.x version of Nuxt dependency instead of `latest` (Nuxt 3).
Of course I haven't verified that all of them work still.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
