### PR TITLE
fix(types): bring types from `less` into namespace

### DIFF
--- a/packages/types/config/build.d.ts
+++ b/packages/types/config/build.d.ts
@@ -3,6 +3,7 @@
  * Documentation: https://nuxtjs.org/api/configuration-build
  */
 
+import 'less'
 import type { IncomingMessage, ServerResponse } from 'http'
 import type { TransformOptions, PluginItem } from '@babel/core'
 import type { Options as AutoprefixerOptions } from 'autoprefixer'

--- a/packages/types/config/build.d.ts
+++ b/packages/types/config/build.d.ts
@@ -1,9 +1,9 @@
+/// <reference types="less" />
 /**
  * NuxtOptionsBuild
  * Documentation: https://nuxtjs.org/api/configuration-build
  */
 
-import 'less'
 import type { IncomingMessage, ServerResponse } from 'http'
 import type { TransformOptions, PluginItem } from '@babel/core'
 import type { Options as AutoprefixerOptions } from 'autoprefixer'


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The `Less` namespace is referenced in this file and the `@types/less` is one of the dependencies of `@nuxt/types` but `less` is not imported anywhere within the `@nuxt/types` package which causes the following error when running `tsc` in projects using `@nuxt/types`:

```
../../packages/types/config/build.d.ts:68:10 - error TS2503: Cannot find namespace 'Less'.

68   less?: Less.Options
            ~~~~
```

Projects can work around it by including `less` in `types` in `tsconfig.json` but they shouldn't need to.


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
