### PR TITLE
fix(nuxt): unpause DOM updates on suspense resolve

### DIFF
--- a/packages/nuxt/src/head/runtime/plugins/unhead.ts
+++ b/packages/nuxt/src/head/runtime/plugins/unhead.ts
@@ -16,14 +16,15 @@ export default defineNuxtPlugin((nuxtApp) => {
     let pauseDOMUpdates = true
     const unpauseDom = () => {
       pauseDOMUpdates = false
-      // triggers dom update
+      // trigger the debounced DOM update
       head.hooks.callHook('entries:updated', head)
     }
     head.hooks.hook('dom:beforeRender', (context) => { context.shouldRender = !pauseDOMUpdates })
     nuxtApp.hooks.hook('page:start', () => { pauseDOMUpdates = true })
     // wait for new page before unpausing dom updates (triggered after suspense resolved)
     nuxtApp.hooks.hook('page:finish', unpauseDom)
-    nuxtApp.hooks.hook('app:mounted', unpauseDom)
+    // unpause the DOM once the mount suspense is resolved
+    nuxtApp.hooks.hook('app:suspense:resolve', unpauseDom)
   }
 
   if (process.server) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
resolves https://github.com/nuxt/nuxt/issues/19680

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

We're triggering DOM updates once the app is mounted, but that doesn't mean that the suspense has resolved.

For Nuxt apps using pages that have async data, this is resulting in multiple DOM updates, one when the app mounts and one when the suspense is resolved.

Fixing it for these sites fixes the visual issue with re-mounting (title flash) but also should improve the initial blocking time performance as there are fewer DOM operations.

My understanding is that this was working correctly previously (in one of the RCs). So possible regression or I missed something when testing, both likely.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
