### PR TITLE
fix(webpack): add `node-fetch-native` to externals list

### DIFF
--- a/packages/webpack/src/config/server.js
+++ b/packages/webpack/src/config/server.js
@@ -9,6 +9,8 @@ import WebpackBaseConfig from './base'
 
 const nativeFileExtensions = [
   '.json',
+  '.cjs',
+  '.mjs',
   '.js'
 ]
 
@@ -123,7 +125,7 @@ export default class WebpackServerConfig extends WebpackBaseConfig {
         maxEntrypointSize: Infinity,
         maxAssetSize: Infinity
       },
-      externals: [].concat(config.externals || [])
+      externals: ['node-fetch-native'].concat(config.externals || [])
     })
 
     // https://webpack.js.org/configuration/externals/#externals


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/10751

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds `node-fetch-native` to the externals list when building. It also marks cjs and mjs as allowable native file extensions to allow avoiding bundling these files.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
