### PR TITLE
fix(webpack): transpile app directory

### DIFF
--- a/packages/webpack/src/presets/base.ts
+++ b/packages/webpack/src/presets/base.ts
@@ -158,7 +158,8 @@ export function baseTranspile (ctx: WebpackConfigContext) {
   const transpile = [
     /\.vue\.js/i, // include SFCs in node_modules
     /consola\/src/,
-    /vue-demi/
+    /vue-demi/,
+    /(^|\/)nuxt\/(dist\/)?app($|\/)/
   ]
 
   for (let pattern of options.build.transpile) {


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/19689
resolves https://github.com/nuxt/nuxt/issues/15583

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

It seems we are not always transpiling the nuxt app directory in webpack. This adds a transpile pattern to ensure it is being transpiled, similar to our vite implementation:

https://github.com/nuxt/nuxt/blob/624314600de6ceea7834e9afe14429bb4146c822/packages/vite/src/server.ts#L74-L83

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
