### PR TITLE
feat(types): support nuxt types for `defineComponent`

### DIFF
--- a/packages/types/app/vue.d.ts
+++ b/packages/types/app/vue.d.ts
@@ -6,7 +6,12 @@ import type Vue from 'vue'
 import type { MetaInfo } from 'vue-meta'
 import type { Route } from 'vue-router'
 import type { RecordPropsDefinition, ComponentOptions } from 'vue/types/options'
-import type { ComponentOptionsMixin } from 'vue/types/v3-component-options'
+import type { Data, HasDefined } from 'vue/types/common'
+import type { ComponentOptionsMixin, ComputedOptions, ComponentOptionsBase, MethodOptions } from 'vue/types/v3-component-options'
+import type { ComponentPropsOptions, ExtractDefaultPropTypes, ExtractPropTypes } from 'vue/types/v3-component-props'
+import type { CreateComponentPublicInstance } from 'vue/types/v3-component-public-instance'
+import type { DefineComponent } from 'vue/types/v3-define-component'
+import type { EmitsOptions } from 'vue/types/v3-setup-context'
 import type { CombinedVueInstance } from 'vue/types/vue'
 import type { NuxtRuntimeConfig } from '../config/runtime'
 import type { Context, Middleware, Transition, NuxtApp } from './index'
@@ -16,12 +21,150 @@ type DefaultData<V> = object | ((this: V) => object)
 type DefaultProps = Record<string, any>
 type DefaultMethods<V> = { [key: string]: (this: V, ...args: any[]) => any }
 type DefaultComputed = { [key: string]: any }
-type DefaultAsyncData<V> = ((this: V, context: Context) => Promise<object | void> | object | void)
+type DefaultAsyncData = ((context: Context) => Promise<object | void> | object | void)
+
+declare module 'vue/types' {
+  /**
+   * overload 1: object format with no props
+   */
+  export function defineComponent<
+    RawBindings,
+    D = {},
+    C extends ComputedOptions = {},
+    M extends MethodOptions = {},
+    Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
+    Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
+    Emits extends EmitsOptions = {},
+    EmitsNames extends string = string,
+    AsyncData extends DefaultAsyncData = DefaultAsyncData,
+  >(
+    options: { functional?: never } & ComponentOptionsWithoutPropsAndAsyncData<
+      {},
+      RawBindings,
+      D,
+      C,
+      M,
+      Mixin,
+      Extends,
+      Emits,
+      EmitsNames,
+      AsyncData
+    >
+  ): DefineComponent<
+    {},
+    RawBindings,
+    Merged<D, Awaited<ReturnType<AsyncData>>>,
+    C,
+    M,
+    Mixin,
+    Extends,
+    Emits
+  >
+
+  /**
+   * overload 2: object format with array props declaration
+   * props inferred as `{ [key in PropNames]?: any }`
+   *
+   * return type is for Vetur and TSX support
+   */
+  export function defineComponent<
+    PropNames extends string,
+    RawBindings = {},
+    D = {},
+    C extends ComputedOptions = {},
+    M extends MethodOptions = {},
+    Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
+    Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
+    Emits extends EmitsOptions = {},
+    EmitsNames extends string = string,
+    PropsOptions extends ComponentPropsOptions = ComponentPropsOptions,
+    AsyncData extends DefaultAsyncData = DefaultAsyncData,
+  >(
+    options: { functional?: never } & ComponentOptionsWithArrayPropsAndAsyncData<
+      PropNames,
+      RawBindings,
+      D,
+      C,
+      M,
+      Mixin,
+      Extends,
+      Emits,
+      EmitsNames,
+      Readonly<{ [key in PropNames]?: any }>,
+      AsyncData
+    >
+  ): DefineComponent<
+    Readonly<{ [key in PropNames]?: any }>,
+    RawBindings,
+    Merged<D, Awaited<ReturnType<AsyncData>>>,
+    C,
+    M,
+    Mixin,
+    Extends,
+    Emits
+  >
+
+  /**
+   * overload 3: object format with object props declaration
+   *
+   * see `ExtractPropTypes` in './componentProps.ts'
+   */
+  export function defineComponent<
+    Props,
+    RawBindings = {},
+    D = {},
+    C extends ComputedOptions = {},
+    M extends MethodOptions = {},
+    Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
+    Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
+    Emits extends EmitsOptions = {},
+    EmitsNames extends string = string,
+    PropsOptions extends ComponentPropsOptions = ComponentPropsOptions,
+    AsyncData extends DefaultAsyncData = DefaultAsyncData,
+  >(
+    options: HasDefined<Props> extends true
+      ? { functional?: never } & ComponentOptionsWithPropsAndAsyncData<
+          PropsOptions,
+          RawBindings,
+          D,
+          C,
+          M,
+          Mixin,
+          Extends,
+          Emits,
+          EmitsNames,
+          Props,
+          ExtractDefaultPropTypes<PropsOptions>,
+          AsyncData
+        >
+      : { functional?: never } & ComponentOptionsWithPropsAndAsyncData<
+          PropsOptions,
+          RawBindings,
+          D,
+          C,
+          M,
+          Mixin,
+          Extends,
+          Emits,
+          EmitsNames,
+          ExtractPropTypes<PropsOptions>,
+          AsyncData
+        >
+  ): DefineComponent<
+    PropsOptions,
+    RawBindings,
+    Merged<D, Awaited<ReturnType<AsyncData>>>,
+    C,
+    M,
+    Mixin,
+    Extends,
+    Emits
+  >
+}
 
 declare module 'vue/types/options' {
   interface ComponentOptions<
     V extends Vue,
-    /* eslint-disable no-unused-vars,@typescript-eslint/no-unused-vars */
     Data = DefaultData<V>,
     Methods = DefaultMethods<V>,
     Computed = DefaultComputed,
@@ -30,10 +173,8 @@ declare module 'vue/types/options' {
     RawBindings = {},
     Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
     Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
-    /* eslint-enable no-unused-vars,@typescript-eslint/no-unused-vars */
-    AsyncData = DefaultAsyncData<V>
+    AsyncData = DefaultAsyncData
   > {
-    // eslint-disable-next-line @typescript-eslint/ban-types
     asyncData?: AsyncData
     fetch?(ctx: Context): Promise<void> | void
     fetchKey?: string | ((getKey: (id: string) => number) => string)
@@ -67,7 +208,7 @@ type ThisTypedComponentOptionsWithArrayPropsAndAsyncData<
   SetupBindings,
   Mixin extends ComponentOptionsMixin,
   Extends extends ComponentOptionsMixin,
-  AsyncData extends DefaultAsyncData<V> = DefaultAsyncData<V>
+  AsyncData extends DefaultAsyncData = DefaultAsyncData
 > = object &
   ComponentOptions<
     V,
@@ -102,7 +243,7 @@ export type ThisTypedComponentOptionsWithRecordPropsAndAsyncData<
   SetupBindings,
   Mixin extends ComponentOptionsMixin,
   Extends extends ComponentOptionsMixin,
-  AsyncData extends DefaultAsyncData<V>
+  AsyncData extends DefaultAsyncData
 > = object &
   ComponentOptions<
     V,
@@ -151,7 +292,7 @@ declare module 'vue/types/vue' {
       SetupBindings = {},
       Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
       Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
-      AsyncData extends DefaultAsyncData<V> = DefaultAsyncData<V>
+      AsyncData extends DefaultAsyncData = DefaultAsyncData
     >(
       options?: ThisTypedComponentOptionsWithArrayPropsAndAsyncData<
         V,
@@ -184,7 +325,7 @@ declare module 'vue/types/vue' {
       SetupBindings = {},
       Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
       Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
-      AsyncData extends DefaultAsyncData<V> = DefaultAsyncData<V>
+      AsyncData extends DefaultAsyncData = DefaultAsyncData
     >(
       options?: ThisTypedComponentOptionsWithRecordPropsAndAsyncData<
         V,
@@ -209,3 +350,120 @@ declare module 'vue/types/vue' {
       >
   }
 }
+
+export type ComponentOptionsWithPropsAndAsyncData<
+  PropsOptions = ComponentPropsOptions,
+  RawBindings = Data,
+  D = Data,
+  C extends ComputedOptions = {},
+  M extends MethodOptions = {},
+  Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
+  Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
+  Emits extends EmitsOptions = {},
+  EmitsNames extends string = string,
+  Props = ExtractPropTypes<PropsOptions>,
+  Defaults = ExtractDefaultPropTypes<PropsOptions>,
+  AsyncData extends DefaultAsyncData = DefaultAsyncData,
+> = ComponentOptionsBase<
+  Props,
+  RawBindings,
+  D,
+  C,
+  M,
+  Mixin,
+  Extends,
+  Emits,
+  EmitsNames,
+  Defaults
+> & {
+  props?: PropsOptions,
+  asyncData: AsyncData,
+} & ThisType<
+    CreateComponentPublicInstance<
+      Props,
+      RawBindings,
+      Merged<D, Awaited<ReturnType<AsyncData>>>,
+      C,
+      M,
+      Mixin,
+      Extends,
+      Emits
+    >
+  >
+
+export type ComponentOptionsWithArrayPropsAndAsyncData<
+  PropNames extends string = string,
+  RawBindings = Data,
+  D = Data,
+  C extends ComputedOptions = {},
+  M extends MethodOptions = {},
+  Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
+  Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
+  Emits extends EmitsOptions = {},
+  EmitsNames extends string = string,
+  Props = Readonly<{ [key in PropNames]?: any }>,
+  AsyncData extends DefaultAsyncData = DefaultAsyncData,
+> = ComponentOptionsBase<
+  Props,
+  RawBindings,
+  D,
+  C,
+  M,
+  Mixin,
+  Extends,
+  Emits,
+  EmitsNames,
+  {}
+> & {
+  props?: PropNames[],
+  asyncData: AsyncData,
+} & ThisType<
+    CreateComponentPublicInstance<
+      Props,
+      RawBindings,
+      Merged<D, Awaited<ReturnType<AsyncData>>>,
+      C,
+      M,
+      Mixin,
+      Extends,
+      Emits
+    >
+  >
+
+export type ComponentOptionsWithoutPropsAndAsyncData<
+  Props = {},
+  RawBindings = Data,
+  D = Data,
+  C extends ComputedOptions = {},
+  M extends MethodOptions = {},
+  Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
+  Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
+  Emits extends EmitsOptions = {},
+  EmitsNames extends string = string,
+  AsyncData extends DefaultAsyncData = DefaultAsyncData,
+> = ComponentOptionsBase<
+  Props,
+  RawBindings,
+  D,
+  C,
+  M,
+  Mixin,
+  Extends,
+  Emits,
+  EmitsNames,
+  {}
+> & {
+  props?: undefined,
+  asyncData: AsyncData,
+} & ThisType<
+    CreateComponentPublicInstance<
+      Props,
+      RawBindings,
+      Merged<D, Awaited<ReturnType<AsyncData>>>,
+      C,
+      M,
+      Mixin,
+      Extends,
+      Emits
+    >
+  >

--- a/packages/types/app/vue.d.ts
+++ b/packages/types/app/vue.d.ts
@@ -38,7 +38,7 @@ declare module 'vue/types' {
     EmitsNames extends string = string,
     AsyncData extends DefaultAsyncData = DefaultAsyncData,
   >(
-    options: { functional?: never } & ComponentOptionsWithoutPropsAndAsyncData<
+    options: { functional?: never } & ComponentOptionsWithoutPropsAndWithAsyncData<
       {},
       RawBindings,
       D,
@@ -430,7 +430,7 @@ export type ComponentOptionsWithArrayPropsAndAsyncData<
     >
   >
 
-export type ComponentOptionsWithoutPropsAndAsyncData<
+export type ComponentOptionsWithoutPropsAndWithAsyncData<
   Props = {},
   RawBindings = Data,
   D = Data,

--- a/packages/types/app/vue.d.ts
+++ b/packages/types/app/vue.d.ts
@@ -21,7 +21,7 @@ type DefaultData<V> = object | ((this: V) => object)
 type DefaultProps = Record<string, any>
 type DefaultMethods<V> = { [key: string]: (this: V, ...args: any[]) => any }
 type DefaultComputed = { [key: string]: any }
-type DefaultAsyncData = ((context: Context) => Promise<object | void> | object | void)
+type DefaultAsyncData = ((this: never, context: Context) => Promise<object | void> | object | void)
 
 declare module 'vue/types' {
   /**

--- a/packages/types/test/vue.ts
+++ b/packages/types/test/vue.ts
@@ -2,8 +2,9 @@
  * Test extended type definitions of Vue interfaces
  * @nuxt/types/app/vue.d.ts
  */
+/* eslint-disable vue/one-component-per-file */
 
-import Vue from 'vue'
+import Vue, { defineComponent } from 'vue'
 import type { Middleware } from '..'
 
 const options: Vue.ComponentOptions<Vue> = {}
@@ -110,3 +111,169 @@ vm.$nuxt.$loading.start()
 
 vm.$nuxt.isOffline = true
 vm.$nuxt.isOnline = true
+
+// component options - defineComponent
+
+defineComponent({
+  name: 'WithNoProps',
+  asyncData (context) {
+    return {
+      asyncDataProperty: context.base
+    }
+  },
+  data () {
+    return {
+      normalDataProperty: 123
+    }
+  },
+  computed: {
+    dataPropertyGetter (): number {
+      return this.normalDataProperty
+    },
+    asyncPropertyGetter (): string {
+      return this.asyncDataProperty
+    }
+  }
+})
+
+defineComponent({
+  name: 'WithObjectProps',
+  props: {
+    boolProperty: {
+      type: Boolean,
+      required: true
+    }
+  },
+  asyncData (context) {
+    return {
+      asyncDataProperty: context.base
+    }
+  },
+  data () {
+    return {
+      normalDataProperty: 123
+    }
+  },
+  computed: {
+    boolPropertyGetter (): boolean {
+      return this.boolProperty
+    },
+    dataPropertyGetter (): number {
+      return this.normalDataProperty
+    },
+    asyncPropertyGetter (): string {
+      return this.asyncDataProperty
+    }
+  }
+})
+
+defineComponent({
+  name: 'WithArrayProps',
+  // eslint-disable-next-line vue/require-prop-types
+  props: ['boolProperty'],
+  asyncData (context) {
+    return {
+      asyncDataProperty: context.base
+    }
+  },
+  data () {
+    return {
+      normalDataProperty: 123
+    }
+  },
+  computed: {
+    boolPropertyGetter (): boolean {
+      // Typed as "any"
+      return this.boolProperty
+    },
+    dataPropertyGetter (): number {
+      return this.normalDataProperty
+    },
+    asyncPropertyGetter (): string {
+      return this.asyncDataProperty
+    }
+  }
+})
+
+// component options - Vue.extend
+
+Vue.extend({
+  name: 'WithNoProps',
+  asyncData (context) {
+    return {
+      asyncDataProperty: context.base
+    }
+  },
+  data () {
+    return {
+      normalDataProperty: 123
+    }
+  },
+  computed: {
+    dataPropertyGetter (): number {
+      return this.normalDataProperty
+    },
+    asyncPropertyGetter (): string {
+      return this.asyncDataProperty
+    }
+  }
+})
+
+Vue.extend({
+  name: 'WithObjectProps',
+  props: {
+    boolProperty: {
+      type: Boolean,
+      required: true
+    }
+  },
+  asyncData (context) {
+    return {
+      asyncDataProperty: context.base
+    }
+  },
+  data () {
+    return {
+      normalDataProperty: 123
+    }
+  },
+  computed: {
+    boolPropertyGetter (): boolean {
+      return this.boolProperty
+    },
+    dataPropertyGetter (): number {
+      return this.normalDataProperty
+    },
+    asyncPropertyGetter (): string {
+      return this.asyncDataProperty
+    }
+  }
+})
+
+Vue.extend({
+  name: 'WithArrayProps',
+  // eslint-disable-next-line vue/require-prop-types
+  props: ['boolProperty'],
+  asyncData (context) {
+    return {
+      asyncDataProperty: context.base
+    }
+  },
+  data () {
+    return {
+      normalDataProperty: 123
+    }
+  },
+  computed: {
+    boolPropertyGetter (): boolean {
+      // Typed as "any"
+      return this.boolProperty
+    },
+    dataPropertyGetter (): number {
+      return this.normalDataProperty
+    },
+    asyncPropertyGetter (): string {
+      return this.asyncDataProperty
+    }
+  }
+})


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Support `asyncData` types in components exported using `defineComponent` function.

The existing code only handled `Vue.extend` which is no longer recommended in Vue 2.7 and also Volar defaults to `defineComponent` so the `asyncData` types didn't work properly in that case by default (unless manually wrapped with `Vue.extend`).

This adds new overloads for `defineFunction` that are slightly modified to support `asyncData` option, including inferring types both in the script tag and in the template. The [original Vue 2.7 types](https://github.com/vuejs/vue/blob/a9ca2d85193e435e668ba25ace481bfb176b0c6e/types/v3-define-component.d.ts#L23-L201) have 5 overloads of `defineComponent`. I've added variants of first 3, skipping functional component cases. Since functional components don't have state, I think `asyncData` doesn't apply to those but maybe I'm wrong? Haven't investigated that.

Also added tests for both the `definedComponent` and `Vue.extend` cases.
This is equivalent to testing types within the "script" tag in the Vue SFC component. I haven't quite figured out how to test the "template" part but this is better than nothing.

To better visualize what modifications were done to the original overloads I've created this diff that shows a diff between the original and the "augmented with asyncData" types:

<details>
<summary>defineComponent Diff</summary>

```diff
--- /vue.d.ts	Sat Mar 18 13:20:40 2023
+++ /vue.d.ts	Sat Mar 18 13:23:59 2023
@@ -9,9 +9,10 @@
   Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
   Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
   Emits extends EmitsOptions = {},
-  EmitsNames extends string = string
+  EmitsNames extends string = string,
+  AsyncData extends DefaultAsyncData = DefaultAsyncData,
 >(
-  options: { functional?: never } & ComponentOptionsWithoutProps<
+  options: { functional?: never } & ComponentOptionsWithoutPropsAndAsyncData<
     {},
     RawBindings,
     D,
@@ -20,10 +21,19 @@
     Mixin,
     Extends,
     Emits,
-    EmitsNames
-  >
-): DefineComponent<{}, RawBindings, D, C, M, Mixin, Extends, Emits>
-
+    EmitsNames,
+    AsyncData
+  >
+): DefineComponent<
+  {},
+  RawBindings,
+  Merged<D, Awaited<ReturnType<AsyncData>>>,
+  C,
+  M,
+  Mixin,
+  Extends,
+  Emits
+>
 
 /**
  * overload 2: object format with array props declaration
@@ -41,9 +51,10 @@
   Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
   Emits extends EmitsOptions = {},
   EmitsNames extends string = string,
-  PropsOptions extends ComponentPropsOptions = ComponentPropsOptions
+  PropsOptions extends ComponentPropsOptions = ComponentPropsOptions,
+  AsyncData extends DefaultAsyncData = DefaultAsyncData,
 >(
-  options: { functional?: never } & ComponentOptionsWithArrayProps<
+  options: { functional?: never } & ComponentOptionsWithArrayPropsAndAsyncData<
     PropNames,
     RawBindings,
     D,
@@ -52,19 +63,20 @@
     Mixin,
     Extends,
     Emits,
-    EmitsNames
+    EmitsNames,
+    Readonly<{ [key in PropNames]?: any }>,
+    AsyncData
   >
 ): DefineComponent<
   Readonly<{ [key in PropNames]?: any }>,
   RawBindings,
-  D,
+  Merged<D, Awaited<ReturnType<AsyncData>>>,
   C,
   M,
   Mixin,
   Extends,
   Emits
 >
-
 
 /**
  * overload 3: object format with object props declaration
@@ -81,10 +93,11 @@
   Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
   Emits extends EmitsOptions = {},
   EmitsNames extends string = string,
-  PropsOptions extends ComponentPropsOptions = ComponentPropsOptions
+  PropsOptions extends ComponentPropsOptions = ComponentPropsOptions,
+  AsyncData extends DefaultAsyncData = DefaultAsyncData,
 >(
   options: HasDefined<Props> extends true
-    ? { functional?: never } & ComponentOptionsWithProps<
+    ? { functional?: never } & ComponentOptionsWithPropsAndAsyncData<
         PropsOptions,
         RawBindings,
         D,
@@ -94,9 +107,11 @@
         Extends,
         Emits,
         EmitsNames,
-        Props
+        Props,
+        ExtractDefaultPropTypes<PropsOptions>,
+        AsyncData
       >
-    : { functional?: never } & ComponentOptionsWithProps<
+    : { functional?: never } & ComponentOptionsWithPropsAndAsyncData<
         PropsOptions,
         RawBindings,
         D,
@@ -105,11 +120,22 @@
         Mixin,
         Extends,
         Emits,
-        EmitsNames
+        EmitsNames,
+        ExtractPropTypes<PropsOptions>,
+        AsyncData
       >
-): DefineComponent<PropsOptions, RawBindings, D, C, M, Mixin, Extends, Emits>
-
-export type ComponentOptionsWithProps<
+): DefineComponent<
+  PropsOptions,
+  RawBindings,
+  Merged<D, Awaited<ReturnType<AsyncData>>>,
+  C,
+  M,
+  Mixin,
+  Extends,
+  Emits
+>
+
+export type ComponentOptionsWithPropsAndAsyncData<
   PropsOptions = ComponentPropsOptions,
   RawBindings = Data,
   D = Data,
@@ -120,7 +146,8 @@
   Emits extends EmitsOptions = {},
   EmitsNames extends string = string,
   Props = ExtractPropTypes<PropsOptions>,
-  Defaults = ExtractDefaultPropTypes<PropsOptions>
+  Defaults = ExtractDefaultPropTypes<PropsOptions>,
+  AsyncData extends DefaultAsyncData = DefaultAsyncData,
 > = ComponentOptionsBase<
   Props,
   RawBindings,
@@ -133,12 +160,13 @@
   EmitsNames,
   Defaults
 > & {
-  props?: PropsOptions
+  props?: PropsOptions,
+  asyncData: AsyncData,
 } & ThisType<
     CreateComponentPublicInstance<
       Props,
       RawBindings,
-      D,
+      Merged<D, Awaited<ReturnType<AsyncData>>>,
       C,
       M,
       Mixin,
@@ -147,7 +175,7 @@
     >
   >
 
-export type ComponentOptionsWithArrayProps<
+export type ComponentOptionsWithArrayPropsAndAsyncData<
   PropNames extends string = string,
   RawBindings = Data,
   D = Data,
@@ -157,7 +185,8 @@
   Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
   Emits extends EmitsOptions = {},
   EmitsNames extends string = string,
-  Props = Readonly<{ [key in PropNames]?: any }>
+  Props = Readonly<{ [key in PropNames]?: any }>,
+  AsyncData extends DefaultAsyncData = DefaultAsyncData,
 > = ComponentOptionsBase<
   Props,
   RawBindings,
@@ -170,12 +199,13 @@
   EmitsNames,
   {}
 > & {
-  props?: PropNames[]
+  props?: PropNames[],
+  asyncData: AsyncData,
 } & ThisType<
     CreateComponentPublicInstance<
       Props,
       RawBindings,
-      D,
+      Merged<D, Awaited<ReturnType<AsyncData>>>,
       C,
       M,
       Mixin,
@@ -184,7 +214,7 @@
     >
   >
 
-export type ComponentOptionsWithoutProps<
+export type ComponentOptionsWithoutPropsAndAsyncData<
   Props = {},
   RawBindings = Data,
   D = Data,
@@ -193,7 +223,8 @@
   Mixin extends ComponentOptionsMixin = ComponentOptionsMixin,
   Extends extends ComponentOptionsMixin = ComponentOptionsMixin,
   Emits extends EmitsOptions = {},
-  EmitsNames extends string = string
+  EmitsNames extends string = string,
+  AsyncData extends DefaultAsyncData = DefaultAsyncData,
 > = ComponentOptionsBase<
   Props,
   RawBindings,
@@ -206,12 +237,13 @@
   EmitsNames,
   {}
 > & {
-  props?: undefined
+  props?: undefined,
+  asyncData: AsyncData,
 } & ThisType<
     CreateComponentPublicInstance<
       Props,
       RawBindings,
-      D,
+      Merged<D, Awaited<ReturnType<AsyncData>>>,
       C,
       M,
       Mixin,
```

</details>

Oh, and I've also changed `asyncData` to not have `Vue` instance as `this` as that's not accurate. `this` is `undefined` in `asyncData`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
