### PR TITLE
docs: removing deprecated coming soon banner

### DIFF
--- a/docs/2.guide/2.directory-structure/3.app-config.md
+++ b/docs/2.guide/2.directory-structure/3.app-config.md
@@ -37,11 +37,6 @@ export default defineAppConfig({
 
 When adding `theme` to the `app.config`, Nuxt uses Vite or webpack to bundle the code. We can universally access `theme` both when server-rendering the page and in the browser using [useAppConfig](/docs/api/composables/use-app-config) composable.
 
-::alert{type=info}
-<!-- TODO: Remove banner when releasing Nuxt on stable channel -->
-Support for accessing `useAppConfig()` in Nitro and `server` directory is [coming soon](https://github.com/nuxt/nuxt/pull/19489) and available on [edge-channel](https://nuxt.com/docs/guide/going-further/edge-channel).
-::
-
 ```js
 const appConfig = useAppConfig()
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves #19816

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Removing deprecated banner stating that work on supporting `useAppConfig` in server envs, is on progress.
Resolves #19816

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
