### PR TITLE
fix(nuxt): handle external navigation to api routes

### DIFF
--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -90,7 +90,7 @@ export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: Na
   }
 
   const toPath = typeof to === 'string' ? to : ((to as RouteLocationPathRaw).path || '/')
-  const isExternal = hasProtocol(toPath, { acceptRelative: true })
+  const isExternal = options?.external || hasProtocol(toPath, { acceptRelative: true })
   if (isExternal && !options?.external) {
     throw new Error('Navigating to external URL is not allowed by default. Use `navigateTo (url, { external: true })`.')
   }

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -528,6 +528,12 @@ describe('navigate external', () => {
 
     expect(headers.get('location')).toEqual('https://example.com/')
   })
+
+  it('should redirect to api endpoint', async () => {
+    const { headers } = await fetch('/navigate-to-api', { redirect: 'manual' })
+
+    expect(headers.get('location')).toEqual('/api/test')
+  })
 })
 
 describe('middlewares', () => {

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -26,7 +26,7 @@ describe.skipIf(isWindows)('minimal nuxt application', () => {
 
   it('default client bundle size', async () => {
     stats.client = await analyzeSizes('**/*.js', publicDir)
-    expect(stats.client.totalBytes).toBeLessThan(106500)
+    expect(stats.client.totalBytes).toBeLessThan(106600)
     expect(stats.client.files.map(f => f.replace(/\..*\.js/, '.js'))).toMatchInlineSnapshot(`
       [
         "_nuxt/_plugin-vue_export-helper.js",

--- a/test/fixtures/basic/pages/navigate-to-api.vue
+++ b/test/fixtures/basic/pages/navigate-to-api.vue
@@ -1,0 +1,7 @@
+<template>
+  <div>You should not see me</div>
+</template>
+
+<script setup>
+await navigateTo('/api/test', { external: true })
+</script>


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/18875

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This respects the value of user options if they have set `external: true` (maybe useful for redirecting to an API route or other path not known by vue-router).

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
