### PR TITLE
fix(nuxt): ignore schema types that eval to any

### DIFF
--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -204,15 +204,18 @@ ${app.configs.map((id: string, index: number) => `import ${`cfg${index}`} from $
 
 declare const inlineConfig = ${JSON.stringify(nuxt.options.appConfig, null, 2)}
 type ResolvedAppConfig = Defu<typeof inlineConfig, [${app.configs.map((_id: string, index: number) => `typeof cfg${index}`).join(', ')}]>
+type IsAny<T> = 0 extends 1 & T ? true : false
 
 type MergedAppConfig<Resolved extends Record<string, any>, Custom extends Record<string, any>> = {
   [K in keyof Resolved]: K extends keyof Custom
     ? Custom[K] extends Record<string, any>
-      ? Resolved[K] extends Record<string, any>
-        ? MergedAppConfig<Resolved[K], Custom[K]>
+      ? IsAny<Custom[K]> extends true
+        ? Resolved[K]
+        : Resolved[K] extends Record<string, any>
+          ? MergedAppConfig<Resolved[K], Custom[K]>
+          : Exclude<Custom[K], undefined>
         : Exclude<Custom[K], undefined>
-      : Exclude<Custom[K], undefined>
-    : Resolved[K]
+      : Resolved[K]
 }
 
 declare module 'nuxt/schema' {


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/18555#comment-1832862

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

If no custom schema is extending `appConfig` then it types out to any, which ends up erasing all other resolved types. We can avoid this by refusing to merge `any` into our resolved app config types.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
