### PR TITLE
fix(test-utils): allow overriding nitro options

### DIFF
--- a/packages/test-utils/src/nuxt.ts
+++ b/packages/test-utils/src/nuxt.ts
@@ -1,7 +1,9 @@
 import { existsSync, promises as fsp } from 'node:fs'
 import { resolve } from 'node:path'
+import { defu } from 'defu'
 import * as _kit from '@nuxt/kit'
 import { useTestContext } from './context'
+
 
 // @ts-ignore type cast
 // eslint-disable-next-line
@@ -43,7 +45,7 @@ export async function loadFixture () {
   if (!ctx.options.dev) {
     const randomId = Math.random().toString(36).slice(2, 8)
     const buildDir = resolve(ctx.options.rootDir, '.nuxt', randomId)
-    Object.assign(ctx.options.nuxtConfig, {
+    ctx.options.nuxtConfig = defu(ctx.options.nuxtConfig, {
       buildDir,
       nitro: {
         output: {

--- a/packages/test-utils/src/nuxt.ts
+++ b/packages/test-utils/src/nuxt.ts
@@ -4,7 +4,6 @@ import { defu } from 'defu'
 import * as _kit from '@nuxt/kit'
 import { useTestContext } from './context'
 
-
 // @ts-ignore type cast
 // eslint-disable-next-line
 const kit: typeof _kit = _kit.default || _kit


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Allow overriding nitro config for testing. Previously we were overriding them all.

Example usage:

```ts
  await setup({
    nuxtConfig: {
      nitro: {
        storage: {
          data: { driver: "memory" },
        },
      },
    },
  });
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
