### PR TITLE
docs: replace `@nuxt/kit` example with node built-ins

### DIFF
--- a/docs/2.guide/3.going-further/7.layers.md
+++ b/docs/2.guide/3.going-further/7.layers.md
@@ -163,11 +163,11 @@ Also when using relative paths in `nuxt.config` file of a layer, (with exception
 import { fileURLToPath } from 'url'
 import { dirname, join } from 'path'
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
+const currentDir = dirname(fileURLToPath(import.meta.url))
 
 export default defineNuxtConfig({
   css: [
-    join(__dirname, './assets/main.css')
+    join(currentDir, './assets/main.css')
   ]
 })
 ```

--- a/docs/2.guide/3.going-further/7.layers.md
+++ b/docs/2.guide/3.going-further/7.layers.md
@@ -160,13 +160,14 @@ When importing using aliases (such as `~/` and `@/`) in a layer components and c
 Also when using relative paths in `nuxt.config` file of a layer, (with exception of nested `extends`) they are resolved relative to user's project instead of the layer. As a workaround, use full resolved paths in `nuxt.config`:
 
 ```js [nuxt.config.ts]
-import { createResolver } from '@nuxt/kit'
+import { fileURLToPath } from 'url'
+import { dirname, join } from 'path'
 
-const { resolve } = createResolver(import.meta.url)
+const __dirname = dirname(fileURLToPath(import.meta.url))
 
 export default defineNuxtConfig({
   css: [
-    resolve('./assets/main.css')
+    join(__dirname, './assets/main.css')
   ]
 })
 ```


### PR DESCRIPTION
### 🔗 Linked issue

#19852 

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently the docs recommned using @nuxt/kit for path resolution which does not work.
To prevent confusion this PR adds a working path resolution example using node built-ins.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
