### PR TITLE
fix(kit): add legacy entrypoints for pre v3.3 usage

### DIFF
--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -4,13 +4,12 @@
   "repository": "nuxt/nuxt",
   "license": "MIT",
   "type": "module",
-  "main": "./dist/index.mjs",
-  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs"
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -4,6 +4,8 @@
   "repository": "nuxt/nuxt",
   "license": "MIT",
   "type": "module",
+  "main": "./dist/index.mjs",
+  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/19717

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In various cases users on projects pre-3.3 who are consuming a 3.3 kit may receive an error message (because previously we were using cjs resolve utilities to resolve kit.

For example: https://github.com/nuxt/nuxt.new/pull/55.

This adds backward compatibility for those previous projects.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
