### PR TITLE
fix(nuxt): don't override options signature with schema

### DIFF
--- a/packages/nuxt/src/core/schema.ts
+++ b/packages/nuxt/src/core/schema.ts
@@ -129,7 +129,8 @@ export default defineNuxtModule({
       const _types = generateTypes(schema, {
         addExport: true,
         interfaceName: 'NuxtCustomSchema',
-        partial: true
+        partial: true,
+        allowExtraKeys: false
       })
       const types =
         _types +


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

A regression from introducing schema was overriding the basic signature of the `NuxtOptions` interface when there was no defined schema.

However, I would also consider fixing upstream in untyped - or maybe defaulting to `[key: string]: unknown`? (cc: @pi0)

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
