### PR TITLE
fix(nuxt): avoid hooks being mutated whilst called

### DIFF
--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -190,7 +190,7 @@ export function createNuxtApp (options: CreateOptions) {
 
   if (process.server) {
     async function contextCaller (hooks: HookCallback[], args: any[]) {
-      for (const hook of hooks) {
+      for (const hook of [...hooks]) {
         await nuxtAppCtx.call(nuxtApp, () => hook(...args))
       }
     }


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/19967

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

With a custom context caller, we were in danger of the hooks array being mutated (by single-use hooks registered with `hookOnce`) and thereby accidentally skipping some hooks.

We might consider also iterating with a different array method, changing behaviour upstream in hookable or just documentating that the hook array is mutable - wdyt @pi0?

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
