### PR TITLE
fix(nuxt): sync `setResponseStatus` signature with h3

### DIFF
--- a/docs/3.api/3.utils/set-response-status.md
+++ b/docs/3.api/3.utils/set-response-status.md
@@ -10,11 +10,13 @@ Nuxt provides composables and utilities for first-class server-side-rendering su
 `setResponseStatus` can only be called within component setup functions, plugins, and route middleware.
 
 ```js
+const event = useRequestEvent()
+
 // Set the status code to 404 for a custom 404 page
-setResponseStatus(404)
+setResponseStatus(event, 404)
 
 // Set the status message as well
-setResponseStatus(404, 'Page Not Found')
+setResponseStatus(event, 404, 'Page Not Found')
 ```
 
 ::alert{icon=👉}

--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -111,7 +111,7 @@ export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: Na
       // Let vue-router handle internal redirects within middleware
       // to prevent the navigation happening after response is sent
       if (isProcessingMiddleware() && !isExternal) {
-        setResponseStatus(options?.redirectCode || 302)
+        setResponseStatus(nuxtApp.ssrContext.event, options?.redirectCode || 302)
         return to
       }
       const redirectLocation = isExternal ? toPath : joinURL(useRuntimeConfig().app.baseURL, router.resolve(to).fullPath || '/')

--- a/packages/nuxt/src/app/composables/ssr.ts
+++ b/packages/nuxt/src/app/composables/ssr.ts
@@ -25,7 +25,13 @@ export function useRequestFetch (): typeof global.$fetch {
   return event?.$fetch as typeof globalThis.$fetch || globalThis.$fetch
 }
 
-export function setResponseStatus (code: number, message?: string) {
+export function setResponseStatus (event: H3Event, code?: number, message?: string): void
+/** @deprecated Pass `event` as first option. */
+export function setResponseStatus (code: number, message?: string): void
+export function setResponseStatus (arg1: H3Event | number | undefined, arg2?: number | string, arg3?: string) {
   if (process.client) { return }
-  _setResponseStatus(useRequestEvent(), code, message)
+  if (arg1 && typeof arg1 !== 'number') {
+    return _setResponseStatus(arg1, arg2 as number | undefined, arg3)
+  }
+  return _setResponseStatus(useRequestEvent(), arg1, arg2 as string | undefined)
 }


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/19867

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We have two composables named `setResponseStatus` - one in Nuxt and one in Nitro (from h3). This PR equalises the signatures and deprecates the version without `event` as first parameter.

This will mean both that the types are (more) correct within Nitro routes.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
