### PR TITLE
fix(nuxt): store payloads in cache without trailing slash

### DIFF
--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -197,6 +197,7 @@ export default defineRenderHandler(async (event) => {
   const isRenderingPayload = PAYLOAD_URL_RE.test(url)
   if (isRenderingPayload) {
     url = url.substring(0, url.lastIndexOf('/')) || '/'
+    url += !url.endsWith("/") ? "/" : "";
     event.node.req.url = url
     if (process.env.prerender && PAYLOAD_CACHE!.has(url)) {
       return PAYLOAD_CACHE!.get(url)

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -5,7 +5,7 @@ import type { H3Event } from 'h3'
 import { appendHeader, getQuery, writeEarlyHints, readBody, createError } from 'h3'
 import devalue from '@nuxt/devalue'
 import destr from 'destr'
-import { joinURL } from 'ufo'
+import { joinURL, withoutTrailingSlash } from 'ufo'
 import { renderToString as _renderToString } from 'vue/server-renderer'
 import { hash } from 'ohash'
 
@@ -197,7 +197,6 @@ export default defineRenderHandler(async (event) => {
   const isRenderingPayload = PAYLOAD_URL_RE.test(url)
   if (isRenderingPayload) {
     url = url.substring(0, url.lastIndexOf('/')) || '/'
-    url += !url.endsWith("/") ? "/" : "";
     event.node.req.url = url
     if (process.env.prerender && PAYLOAD_CACHE!.has(url)) {
       return PAYLOAD_CACHE!.get(url)
@@ -263,7 +262,7 @@ export default defineRenderHandler(async (event) => {
     // Hint nitro to prerender payload for this route
     appendHeader(event, 'x-nitro-prerender', joinURL(url, '_payload.js'))
     // Use same ssr context to generate payload for this route
-    PAYLOAD_CACHE!.set(url, renderPayloadResponse(ssrContext))
+    PAYLOAD_CACHE!.set(withoutTrailingSlash(url), renderPayloadResponse(ssrContext))
   }
 
   // Render meta


### PR DESCRIPTION
### 🔗 Linked issue

#19989

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This normalise url by ensuring there is a trailing slash before adding the data to the PAYLOAD_CACHE.

This resolve an issue where the content was loaded twice, once for page and a second time for payload extraction. This happened when links had trailing slashes in content.

Resolves #19989

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
