### PR TITLE
fix(nuxt): avoid sending 404 after a redirect or early response

### DIFF
--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -168,6 +168,10 @@ export default defineNuxtPlugin(async (nuxtApp) => {
       // Clear any existing errors
       await callWithNuxt(nuxtApp, clearError)
     }
+    const event = process.server ? await callWithNuxt(nuxtApp, useRequestEvent) : undefined
+    if (event?.node.res.writableEnded) {
+      return
+    }
     if (to.matched.length === 0) {
       await callWithNuxt(nuxtApp, showError, [createError({
         statusCode: 404,
@@ -177,8 +181,7 @@ export default defineNuxtPlugin(async (nuxtApp) => {
     } else if (process.server) {
       const currentURL = to.fullPath || '/'
       if (!isEqual(currentURL, initialURL, { trailingSlash: true })) {
-        const event = await callWithNuxt(nuxtApp, useRequestEvent)
-        const options = { redirectCode: event.node.res.statusCode !== 200 ? event.node.res.statusCode || 302 : 302 }
+        const options = { redirectCode: event!.node.res.statusCode !== 200 ? event!.node.res.statusCode || 302 : 302 }
         await callWithNuxt(nuxtApp, navigateTo, [currentURL, options])
       }
     }


### PR DESCRIPTION
### 🔗 Linked issue

resolves #19557

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In some cases we have already returned a response, and we shouldn't send a 404 in these cases. For example, if we have already redirected to a different URL.

I've marked this as draft because I think this might be an opportunity to rework the redirect process so we don't need to check `writableEnded` at all.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
