### PR TITLE
fix(nuxt): suppress handled errors

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-root.vue
+++ b/packages/nuxt/src/app/components/nuxt-root.vue
@@ -37,6 +37,7 @@ onErrorCaptured((err, target, info) => {
   if (process.server || (isNuxtError(err) && (err.fatal || err.unhandled))) {
     const p = callWithNuxt(nuxtApp, showError, [err])
     onServerPrefetch(() => p)
+    return false // suppress error from breaking render
   }
 })
 

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -238,8 +238,9 @@ export function createNuxtApp (options: CreateOptions) {
     })
 
     // Log errors captured when running plugins, in the `app:created` and `app:beforeMount` hooks
-    // as well as when mounting the app and in the `app:mounted` hook
-    nuxtApp.hook('app:error', (...args) => { console.error('[nuxt] error caught during app initialization', ...args) })
+    // as well as when mounting the app.
+    const unreg = nuxtApp.hook('app:error', (...args) => { console.error('[nuxt] error caught during app initialization', ...args) })
+    nuxtApp.hook('app:mounted', unreg)
   }
 
   // Expose runtime config


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/15432

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This includes two fixes for error handling. First, we stop a logger listening for and logging internal errors after `app:mounted` - this was originally intended only to show errors within client-side plugins. Second, we suppress Vue errors that are already being handled with `error.vue` (as otherwise the error may stop our error page from being rendered).

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
