### PR TITLE
refactor(vite): use rollup types re-exported from vite

### DIFF
--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -3,12 +3,11 @@ import { join, resolve } from 'pathe'
 import * as vite from 'vite'
 import vuePlugin from '@vitejs/plugin-vue'
 import viteJsxPlugin from '@vitejs/plugin-vue-jsx'
-import type { ServerOptions } from 'vite'
+import type { ServerOptions, BuildOptions } from 'vite'
 import { logger } from '@nuxt/kit'
 import { getPort } from 'get-port-please'
 import { joinURL, withoutLeadingSlash } from 'ufo'
 import { defu } from 'defu'
-import type { OutputOptions } from 'rollup'
 import { defineEventHandler } from 'h3'
 import type { ViteConfig } from '@nuxt/schema'
 import { cacheDirPlugin } from './plugins/cache-dir'
@@ -99,7 +98,7 @@ export async function buildClient (ctx: ViteBuildContext) {
     output: {
       chunkFileNames: ctx.nuxt.options.dev ? undefined : withoutLeadingSlash(join(ctx.nuxt.options.app.buildAssetsDir, '[name].[hash].js')),
       entryFileNames: ctx.nuxt.options.dev ? 'entry.js' : withoutLeadingSlash(join(ctx.nuxt.options.app.buildAssetsDir, '[name].[hash].js'))
-    } as OutputOptions
+    } satisfies NonNullable<BuildOptions['rollupOptions']>['output']
   }) as any
 
   if (clientConfig.server && clientConfig.server.hmr !== false) {

--- a/packages/vite/src/plugins/virtual.ts
+++ b/packages/vite/src/plugins/virtual.ts
@@ -1,5 +1,5 @@
 import { dirname, isAbsolute, join, resolve } from 'pathe'
-import type { Plugin } from 'rollup'
+import type { Plugin } from 'vite'
 
 const PREFIX = 'virtual:nuxt:'
 


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This moves to use rollup types re-exported directly from vite to prevent internal type conflicts when multiple versions of `rollup` are installed (in ecosystem-ci tests and in renovate PRs).

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
