### PR TITLE
fix(vite): remove separate rollup dependency

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -49,7 +49,6 @@
     "postcss": "^8.4.21",
     "postcss-import": "^15.1.0",
     "postcss-url": "^10.1.3",
-    "rollup": "^3.20.2",
     "rollup-plugin-visualizer": "^5.9.0",
     "std-env": "^3.3.2",
     "strip-literal": "^1.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -848,9 +848,6 @@ importers:
       postcss-url:
         specifier: ^10.1.3
         version: 10.1.3(postcss@8.4.21)
-      rollup:
-        specifier: ^3.20.2
-        version: 3.20.2
       rollup-plugin-visualizer:
         specifier: ^5.9.0
         version: 5.9.0(rollup@3.20.2)


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This removes an explicit `rollup` dependency to reduce the risk of rollup version mismatches, as vite and nitropack provide their own dependency ranges.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
