### PR TITLE
Fixed: Cannot read properties of undefined (reading 'keyedComposables')

### DIFF
--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -74,7 +74,7 @@ export async function bundle (nuxt: Nuxt) {
           composableKeysPlugin.vite({
             sourcemap: nuxt.options.sourcemap.server || nuxt.options.sourcemap.client,
             rootDir: nuxt.options.rootDir,
-            composables: nuxt.options.optimization.keyedComposables
+            composables: nuxt?.options?.optimization?.keyedComposables ?? []
           }),
           replace({
             ...Object.fromEntries([';', '(', '{', '}', ' ', '\t', '\n'].map(d => [`${d}global.`, `${d}globalThis.`])),


### PR DESCRIPTION

Fixed Cannot read properties of undefined (reading 'keyedComposables') During build

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)


### 📚 Description
Fixed Cannot read properties of undefined (reading 'keyedComposables') error During build on nuxt 3.0.0-rc.7

