### PR TITLE
v3.3.3

### DIFF
--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxt/kit",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "repository": "nuxt/nuxt",
   "license": "MIT",
   "type": "module",

--- a/packages/nuxi/package.json
+++ b/packages/nuxi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxi",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "repository": "nuxt/nuxt",
   "license": "MIT",
   "type": "module",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "repository": "nuxt/nuxt",
   "license": "MIT",
   "type": "module",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxt/schema",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "repository": "nuxt/nuxt",
   "license": "MIT",
   "type": "module",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxt/test-utils",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "repository": "nuxt/nuxt",
   "license": "MIT",
   "type": "module",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxt/vite-builder",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "repository": "nuxt/nuxt",
   "license": "MIT",
   "type": "module",

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxt/webpack-builder",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "repository": "nuxt/nuxt",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
> **3.3.3** is your regularly scheduled bugfix/patch release.
>
> **Timetable**: today.

## 👉 Changelog

[compare changes](https://github.com/nuxt/nuxt/compare/v3.3.2...v3.3.3)

### 🩹 Fixes

  - **schema:** Prefer src to rootDir aliases ([#19937](https://github.com/nuxt/nuxt/pull/19937))
  - **nuxt:** Don't override options signature with schema ([#19934](https://github.com/nuxt/nuxt/pull/19934))
  - **vite:** Allow extending vue config per-environment ([#19968](https://github.com/nuxt/nuxt/pull/19968))
  - **nuxt:** Store payloads in cache without trailing slash ([#19992](https://github.com/nuxt/nuxt/pull/19992))
  - **webpack:** Transpile rest of nuxt runtime directories ([#19936](https://github.com/nuxt/nuxt/pull/19936))
  - **nuxt:** Suppress handled errors ([#20002](https://github.com/nuxt/nuxt/pull/20002))
  - **vite:** Remove separate rollup dependency ([#20013](https://github.com/nuxt/nuxt/pull/20013))
  - **nuxt:** Sync `setResponseStatus` signature with h3 ([#19987](https://github.com/nuxt/nuxt/pull/19987))
  - **schema:** Add export condition for nuxt2 support ([1fd491f1a](https://github.com/nuxt/nuxt/commit/1fd491f1a))

### 💅 Refactors

  - **vite:** Use rollup types re-exported from vite ([#20011](https://github.com/nuxt/nuxt/pull/20011))

### 📖 Documentation

  - Fix `pages:extend` example ([72724076b](https://github.com/nuxt/nuxt/commit/72724076b))
  - Remove unused function call ([#20021](https://github.com/nuxt/nuxt/pull/20021))
  - Add explanation for middleware execution order ([#20029](https://github.com/nuxt/nuxt/pull/20029))
  - Fix a couple of typos ([b083493ec](https://github.com/nuxt/nuxt/commit/b083493ec))

### 🏡 Chore

  - Remove unneeded types packages ([e60cb2698](https://github.com/nuxt/nuxt/commit/e60cb2698))
  - Use pnpm workspace protocol internally ([#19962](https://github.com/nuxt/nuxt/pull/19962))
  - Bump version of `mkdist` to `1.2.0` ([a96451d2d](https://github.com/nuxt/nuxt/commit/a96451d2d))
  - Fix fixture package.json files ([8c2ca23c5](https://github.com/nuxt/nuxt/commit/8c2ca23c5))
  - Fix typo in code comment ([2f8e991b9](https://github.com/nuxt/nuxt/commit/2f8e991b9))

### ✅ Tests

  - Skip bundle size test in ecosystem-ci suites ([434e2013e](https://github.com/nuxt/nuxt/commit/434e2013e))
  - Bump bundle size test by 100 bytes ([5785908ec](https://github.com/nuxt/nuxt/commit/5785908ec))

### 🤖 CI

  - Run docs linting step on node 18 ([1ae5b2c58](https://github.com/nuxt/nuxt/commit/1ae5b2c58))

### ❤️  Contributors

- Daniel Roe (@danielroe)
- Ben Hong (@bencodezen)
- Julien Le Coupanec (@LeCoupa)
- David Mignot (@idflood)


