### PR TITLE
fix(kit): support calling Nuxt 2 modules with module container

### DIFF
--- a/packages/kit/src/module/install.ts
+++ b/packages/kit/src/module/install.ts
@@ -1,4 +1,5 @@
 import type { Nuxt, NuxtModule } from '@nuxt/schema'
+import { isNuxt2 } from '../compatibility'
 import { useNuxt } from '../context'
 import { resolveModule, requireModule } from '../internal/cjs'
 import { importModule } from '../internal/esm'
@@ -10,7 +11,12 @@ export async function installModule (moduleToInstall: string | NuxtModule, _inli
   const { nuxtModule, inlineOptions } = await normalizeModule(moduleToInstall, _inlineOptions)
 
   // Call module
-  const res = await nuxtModule(inlineOptions, nuxt) ?? {}
+  const res = (
+    isNuxt2()
+      // @ts-expect-error Nuxt 2 `moduleContainer` is not typed
+      ? await nuxtModule.call(nuxt.moduleContainer, inlineOptions, nuxt)
+      : await nuxtModule(inlineOptions, nuxt)
+  ) ?? {}
   if (res === false /* setup aborted */) {
     return
   }

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -8,7 +8,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs"
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.mjs"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
### 🔗 Linked issue

resolves #15507

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This calls Nuxt 2 modules with the module container to support kit-defined modules installing non-kit modules

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
