### PR TITLE
fix(nuxt): disable `x-nuxt-no-ssr` header by default

### DIFF
--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -189,6 +189,15 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
     }
   }
 
+  // Add backward-compatible middleware to respect `x-nuxt-no-ssr` header
+  if (nuxt.options.experimental.respectNoSSRHeader) {
+    nitroConfig.handlers = nitroConfig.handlers || []
+    nitroConfig.handlers.push({
+      handler: resolve(distDir, 'core/runtime/nitro/no-ssr'),
+      middleware: true
+    })
+  }
+
   // Register nuxt protection patterns
   nitroConfig.rollupConfig!.plugins = await nitroConfig.rollupConfig!.plugins || []
   nitroConfig.rollupConfig!.plugins = Array.isArray(nitroConfig.rollupConfig!.plugins) ? nitroConfig.rollupConfig!.plugins : [nitroConfig.rollupConfig!.plugins]

--- a/packages/nuxt/src/core/runtime/nitro/no-ssr.ts
+++ b/packages/nuxt/src/core/runtime/nitro/no-ssr.ts
@@ -1,6 +1,6 @@
 import { defineEventHandler, getRequestHeader } from 'h3'
 
-export default defineEventHandler(async event => {
+export default defineEventHandler((event) => {
   if (getRequestHeader(event, 'x-nuxt-no-ssr') === 'true') {
     event.context.nuxt = event.context.nuxt || {}
     event.context.nuxt.noSSR = true

--- a/packages/nuxt/src/core/runtime/nitro/no-ssr.ts
+++ b/packages/nuxt/src/core/runtime/nitro/no-ssr.ts
@@ -1,7 +1,7 @@
 import { defineEventHandler, getRequestHeader } from 'h3'
 
 export default defineEventHandler((event) => {
-  if (getRequestHeader(event, 'x-nuxt-no-ssr') === 'true') {
+  if (getRequestHeader(event, 'x-nuxt-no-ssr')) {
     event.context.nuxt = event.context.nuxt || {}
     event.context.nuxt.noSSR = true
   }

--- a/packages/nuxt/src/core/runtime/nitro/no-ssr.ts
+++ b/packages/nuxt/src/core/runtime/nitro/no-ssr.ts
@@ -1,0 +1,8 @@
+import { defineEventHandler, getRequestHeader } from 'h3'
+
+export default defineEventHandler(async event => {
+  if (getRequestHeader(event, 'x-nuxt-no-ssr') === 'true') {
+    event.context.nuxt = event.context.nuxt || {}
+    event.context.nuxt.noSSR = true
+  }
+})

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -295,9 +295,9 @@ export default defineRenderHandler(async (event) => {
       process.env.NUXT_NO_SCRIPTS
         ? undefined
         : (_PAYLOAD_EXTRACTION
-          ? `<script type="module">import p from "${payloadURL}";window.__NUXT__={...p,...(${devalue(splitPayload(ssrContext).initial)})}</script>`
-          : `<script>window.__NUXT__=${devalue(ssrContext.payload)}</script>`
-        ),
+            ? `<script type="module">import p from "${payloadURL}";window.__NUXT__={...p,...(${devalue(splitPayload(ssrContext).initial)})}</script>`
+            : `<script>window.__NUXT__=${devalue(ssrContext.payload)}</script>`
+          ),
       _rendered.renderScripts(),
       // Note: bodyScripts may contain tags other than <script>
       renderedMeta.bodyScripts

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -213,7 +213,7 @@ export default defineRenderHandler(async (event) => {
     runtimeConfig: useRuntimeConfig() as NuxtSSRContext['runtimeConfig'],
     noSSR:
       !!(process.env.NUXT_NO_SSR) ||
-      !!(event.node.req.headers['x-nuxt-no-ssr']) ||
+      event.context.nuxt?.noSSR ||
       routeOptions.ssr === false ||
       (process.env.prerender ? PRERENDER_NO_SSR_ROUTES.has(url) : false),
     error: !!ssrError,
@@ -295,9 +295,9 @@ export default defineRenderHandler(async (event) => {
       process.env.NUXT_NO_SCRIPTS
         ? undefined
         : (_PAYLOAD_EXTRACTION
-            ? `<script type="module">import p from "${payloadURL}";window.__NUXT__={...p,...(${devalue(splitPayload(ssrContext).initial)})}</script>`
-            : `<script>window.__NUXT__=${devalue(ssrContext.payload)}</script>`
-          ),
+          ? `<script type="module">import p from "${payloadURL}";window.__NUXT__={...p,...(${devalue(splitPayload(ssrContext).initial)})}</script>`
+          : `<script>window.__NUXT__=${devalue(ssrContext.payload)}</script>`
+        ),
       _rendered.renderScripts(),
       // Note: bodyScripts may contain tags other than <script>
       renderedMeta.bodyScripts

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -160,8 +160,7 @@ export default defineUntypedSchema({
      */
     polyfillVueUseHead: true,
 
-    // TODO: set to false by default in next minor release
     /** Allow disabling Nuxt SSR responses by setting the `x-nuxt-no-ssr` header. */
-    respectNoSSRHeader: true,
+    respectNoSSRHeader: false,
   }
 })

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -158,6 +158,10 @@ export default defineUntypedSchema({
      *
      * This can be disabled for most Nuxt sites to reduce the client-side bundle by ~0.5kb.
      */
-    polyfillVueUseHead: true
+    polyfillVueUseHead: true,
+
+    // TODO: set to false by default in next minor release
+    /** Allow disabling Nuxt SSR responses by setting the `x-nuxt-no-ssr` header. */
+    respectNoSSRHeader: true,
   }
 })

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -40,7 +40,7 @@ describe.skipIf(isWindows || process.env.ECOSYSTEM_CI)('minimal nuxt application
 
   it('default server bundle size', async () => {
     stats.server = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect(stats.server.totalBytes).toBeLessThan(93300)
+    expect(stats.server.totalBytes).toBeLessThan(93600)
 
     const modules = await analyzeSizes('node_modules/**/*', serverDir)
     expect(modules.totalBytes).toBeLessThan(2694900)

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -40,7 +40,7 @@ describe.skipIf(isWindows || process.env.ECOSYSTEM_CI)('minimal nuxt application
 
   it('default server bundle size', async () => {
     stats.server = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect(stats.server.totalBytes).toBeLessThan(93600)
+    expect(stats.server.totalBytes).toBeLessThan(93300)
 
     const modules = await analyzeSizes('node_modules/**/*', serverDir)
     expect(modules.totalBytes).toBeLessThan(2694900)

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -184,6 +184,8 @@ export default defineNuxtConfig({
     }
   },
   experimental: {
+    // TODO: this will be false by default in next minor release
+    // respectNoSSRHeader: true,
     clientFallback: true,
     restoreState: true,
     inlineSSRStyles: id => !!id && !id.includes('assets.vue'),

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -184,8 +184,7 @@ export default defineNuxtConfig({
     }
   },
   experimental: {
-    // TODO: this will be false by default in next minor release
-    // respectNoSSRHeader: true,
+    respectNoSSRHeader: true,
     clientFallback: true,
     restoreState: true,
     inlineSSRStyles: id => !!id && !id.includes('assets.vue'),


### PR DESCRIPTION
### 🔗 Linked issue

resolves #15667

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We have an undocumented header for disabling SSR responses, `x-nuxt-no-ssr`. I think it would be better not to have this enabled by default as it allows third-parties to control the behaviour of the Nuxt renderer.

I think we can consider this a non-breaking change if clearly signposted in release notes.

### 👉 Migration

If you were using the `x-nuxt-no-ssr` flag, you can turn on the previous behaviour with:

```ts
export default defineNuxtConfig({
  experimental: {
    respectNoSSRHeader: true
  }
})
```

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
