### PR TITLE
feat(nuxt): warn in dev when `useRoute` is used in middleware

### DIFF
--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -17,6 +17,9 @@ export const useRouter = () => {
 }
 
 export const useRoute = (): RouteLocationNormalizedLoaded => {
+  if (process.dev && isProcessingMiddleware()) {
+    console.warn('[nuxt] Calling `useRoute` within middleware may lead to misleading results. Instead, use the (to, from) arguments passed to the middleware to access the new and old routes.')
+  }
   if (getCurrentInstance()) {
     return inject('_route', useNuxtApp()._route)
   }


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/19626#issuecomment-1493375833

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds a warning in dev mode when using `useRoute` within nuxt middleware, which will almost certainly be the wrong thing to do.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
