### PR TITLE
feat(nuxt): respect custom `dir.pages` in page placeholder

### DIFF
--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -278,7 +278,10 @@ export const publicPathTemplate: NuxtTemplate = {
 export const nuxtConfigTemplate = {
   filename: 'nuxt.config.mjs',
   getContents: (ctx: TemplateContext) => {
-    return Object.entries(ctx.nuxt.options.app).map(([k, v]) => `export const ${camelCase('app-' + k)} = ${JSON.stringify(v)}`).join('\n\n')
+    return [
+      ...Object.entries(ctx.nuxt.options.app).map(([k, v]) => `export const ${camelCase('app-' + k)} = ${JSON.stringify(v)}`),
+      `export const devPagesDir = ${ctx.nuxt.options.dev ? JSON.stringify(ctx.nuxt.options.dir.pages) : 'null'}`
+    ].join('\n\n')
   }
 }
 

--- a/packages/nuxt/src/pages/runtime/page-placeholder.ts
+++ b/packages/nuxt/src/pages/runtime/page-placeholder.ts
@@ -1,10 +1,12 @@
 import { defineComponent } from 'vue'
+// @ts-expect-error virtual file
+import { devPagesDir } from '#build/nuxt.config.mjs'
 
 export default defineComponent({
   name: 'NuxtPage',
   setup (_, props) {
     if (process.dev) {
-      console.warn('Create a Vue component in the `pages/` directory to enable `<NuxtPage>`')
+      console.warn(`Create a Vue component in the \`${devPagesDir}/\` directory to enable \`<NuxtPage>\``)
     }
     return () => props.slots.default?.()
   }


### PR DESCRIPTION
### 🔗 Linked issue

resolves #20064

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This respects any custom `dir.pages` set in nuxt.config when advising the user to use a custom pages directory. I've confirmed this is tree-shaken out of the build, even if the stub placeholder for `<NuxtPage>` is somehow included. In future we could use other `dev`-prefixed variables as a convention for passing data to runtime for better messages.

Alternatively, this may become obsolete once we improve our error message framework: https://github.com/nuxt/nuxt/discussions/19890.

Either way, this is an internal property and I think safe to merge.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
