### PR TITLE
fix(nuxt): add types for globally injected `$config` object

### DIFF
--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -379,9 +379,3 @@ function defineGetter<K extends string | number | symbol, V> (obj: Record<K, V>,
 export function defineAppConfig<C extends AppConfigInput> (config: C): C {
   return config
 }
-
-declare module 'vue' {
-  interface ComponentCustomProperties {
-    $config: RuntimeConfig
-  }
-}

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -379,3 +379,9 @@ function defineGetter<K extends string | number | symbol, V> (obj: Record<K, V>,
 export function defineAppConfig<C extends AppConfigInput> (config: C): C {
   return config
 }
+
+declare module 'vue' {
+  interface ComponentCustomProperties {
+    $config: RuntimeConfig
+  }
+}

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -130,7 +130,7 @@ export const schemaTemplate: NuxtTemplate<TemplateContext> = {
     const modules = moduleInfo.map(meta => [genString(meta.configKey), getImportName(meta.importName)])
 
     return [
-      "import { NuxtModule } from 'nuxt/schema'",
+      "import { NuxtModule, RuntimeConfig } from 'nuxt/schema'",
       "declare module 'nuxt/schema' {",
       '  interface NuxtConfig {',
       ...modules.map(([configKey, importName]) =>
@@ -154,7 +154,18 @@ export const schemaTemplate: NuxtTemplate<TemplateContext> = {
           allowExtraKeys: false,
           indentation: 2
         }),
-      '}'
+      '}',
+      `declare module 'vue' {
+        interface ComponentCustomProperties {
+          $config: RuntimeConfig
+        }
+      }`,
+      // TODO: remove when webstorm has support for augumenting 'vue' directly
+      `declare module '@vue/runtime-dom' {
+        interface ComponentCustomProperties {
+          $config: RuntimeConfig
+        }
+      }`
     ].join('\n')
   }
 }

--- a/test/fixtures/basic/types.ts
+++ b/test/fixtures/basic/types.ts
@@ -146,6 +146,13 @@ describe('runtimeConfig', () => {
     expectTypeOf(runtimeConfig.privateConfig).toEqualTypeOf<string>()
     expectTypeOf(runtimeConfig.public.ids).toEqualTypeOf<number[]>()
     expectTypeOf(runtimeConfig.unknown).toEqualTypeOf<any>()
+
+    const injectedConfig = useNuxtApp().$config
+    expectTypeOf(injectedConfig.public.testConfig).toEqualTypeOf<number>()
+    expectTypeOf(injectedConfig.public.needsFallback).toEqualTypeOf<string>()
+    expectTypeOf(injectedConfig.privateConfig).toEqualTypeOf<string>()
+    expectTypeOf(injectedConfig.public.ids).toEqualTypeOf<number[]>()
+    expectTypeOf(injectedConfig.unknown).toEqualTypeOf<any>()
   })
   it('provides hints on overriding these values', () => {
     const val = defineNuxtConfig({


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/20069

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds types for the injected `$config` by including them in the generated schema types.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
