### PR TITLE
fix(nuxt): test all custom app config keys for `any`

### DIFF
--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -219,14 +219,14 @@ type IsAny<T> = 0 extends 1 & T ? true : false
 
 type MergedAppConfig<Resolved extends Record<string, any>, Custom extends Record<string, any>> = {
   [K in keyof Resolved]: K extends keyof Custom
-    ? Custom[K] extends Record<string, any>
-      ? IsAny<Custom[K]> extends true
-        ? Resolved[K]
-        : Resolved[K] extends Record<string, any>
+    ? IsAny<Custom[K]> extends true
+      ? Resolved[K]
+      : Custom[K] extends Record<string, any>
+        ? Resolved[K] extends Record<string, any>
           ? MergedAppConfig<Resolved[K], Custom[K]>
           : Exclude<Custom[K], undefined>
         : Exclude<Custom[K], undefined>
-      : Resolved[K]
+    : Resolved[K]
 }
 
 declare module 'nuxt/schema' {


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/20103

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This fixes a bug with custom schema whereby we were still merging `any` into our AppConfig types, but only if there was no custom app config defined. (Follow on from https://github.com/nuxt/nuxt/pull/19835.)

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
