### PR TITLE
refactor(nuxt): remove `#head` alias

### DIFF
--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -38,10 +38,6 @@
       "types": "./dist/app/index.d.ts",
       "import": "./dist/app/index.js"
     },
-    "#head": {
-      "types": "./dist/head/runtime/index.d.ts",
-      "import": "./dist/head/runtime/index.js"
-    },
     "#pages": {
       "types": "./dist/pages/runtime/index.d.ts",
       "import": "./dist/pages/runtime/index.js"

--- a/packages/nuxt/src/head/module.ts
+++ b/packages/nuxt/src/head/module.ts
@@ -14,8 +14,6 @@ export default defineNuxtModule({
     // Transpile @unhead/vue
     nuxt.options.build.transpile.push('@unhead/vue')
 
-    // TODO: remove alias in v3.4
-    nuxt.options.alias['#head'] = nuxt.options.alias['#app']
     nuxt.hook('prepare:types', ({ tsConfig }) => {
       tsConfig.compilerOptions = tsConfig.compilerOptions || {}
       delete tsConfig.compilerOptions.paths['#head']

--- a/packages/nuxt/src/head/module.ts
+++ b/packages/nuxt/src/head/module.ts
@@ -14,12 +14,6 @@ export default defineNuxtModule({
     // Transpile @unhead/vue
     nuxt.options.build.transpile.push('@unhead/vue')
 
-    nuxt.hook('prepare:types', ({ tsConfig }) => {
-      tsConfig.compilerOptions = tsConfig.compilerOptions || {}
-      delete tsConfig.compilerOptions.paths['#head']
-      delete tsConfig.compilerOptions.paths['#head/*']
-    })
-
     // Register components
     const componentsPath = resolve(runtimeDir, 'components')
     for (const componentName of components) {

--- a/test/fixtures/basic/plugins/my-plugin.ts
+++ b/test/fixtures/basic/plugins/my-plugin.ts
@@ -1,6 +1,3 @@
-// @ts-expect-error
-import { useHead } from '#head'
-
 export default defineNuxtPlugin(() => {
   useHead({
     titleTemplate: '%s - Fixture'


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/pull/19548

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Following on from https://github.com/nuxt/nuxt/pull/19548 (cc: @harlan-zw), this PR removes the deprecated and untyped `#head` alias, which was unsupported in v3.3. `useHead` should be imported directly from `#imports` like other auto-imports.

### 👉 Migration

If you are importing `useHead` from `#head` you can update to import it from `#imports` instead:

```diff
- import { useHead } from '#head'
+ import { useHead } from '#imports'
```

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
