### PR TITLE
v3.4.0

### DIFF
--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxt/kit",
-  "version": "3.3.3",
+  "version": "3.4.0",
   "repository": "nuxt/nuxt",
   "license": "MIT",
   "type": "module",

--- a/packages/nuxi/package.json
+++ b/packages/nuxi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxi",
-  "version": "3.3.3",
+  "version": "3.4.0",
   "repository": "nuxt/nuxt",
   "license": "MIT",
   "type": "module",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt",
-  "version": "3.3.3",
+  "version": "3.4.0",
   "repository": "nuxt/nuxt",
   "license": "MIT",
   "type": "module",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxt/schema",
-  "version": "3.3.3",
+  "version": "3.4.0",
   "repository": "nuxt/nuxt",
   "license": "MIT",
   "type": "module",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxt/test-utils",
-  "version": "3.3.3",
+  "version": "3.4.0",
   "repository": "nuxt/nuxt",
   "license": "MIT",
   "type": "module",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxt/vite-builder",
-  "version": "3.3.3",
+  "version": "3.4.0",
   "repository": "nuxt/nuxt",
   "license": "MIT",
   "type": "module",

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxt/webpack-builder",
-  "version": "3.3.3",
+  "version": "3.4.0",
   "repository": "nuxt/nuxt",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
> **3.4.0** is a minor (feature) release for Nuxt 3 bringing exciting new features, including support for the View Transitions API, transferring rich JavaScript payloads from server to client - and much more.
>
> **Timetable**: today.

<!--

## 👀 Highlights

### 🪄 View Transitions API Support

https://user-images.githubusercontent.com/904724/231222082-6bd4aeae-3026-407e-b3be-658df6305748.mp4

<br>

You can see a demo on https://nuxt-view-transitions.surge.sh

You may have noticed that Chromium-based browsers now ship a new web platform API: the [**View Transitions API**](https://developer.chrome.com/docs/web-platform/view-transitions/). This is an exciting new ability for native browser transitions which (among other things) have the ability to transition between unrelated elements on different pages.

Nuxt now ships with an experimental implementation, which will be under active development during the v3.4 release cycle. See the known issues in the [linked PR](https://github.com/nuxt/nuxt/pull/20092).

```ts
export default defineNuxtConfig({
  experimental: {
    viewTransition: true
  }
})
```

### ✨ Payload Enhancements

We've merged a **[significant change to how Nuxt handles payloads](https://github.com/nuxt/nuxt/pull/19205)** (under an experimental flag). Payloads are used to send data from the server to the client when doing server-side rendering and avoid double data-fetching during the hydration phase.

```ts [nuxt.config.ts]
export default defineNuxtConfig({
  experimental: {
    renderJsonPayloads: true
  }
})
```

With this new option enabled, this now means that **various rich JS types are supported out-of-the-box**: regular expressions, dates, Map and Set and BigInt as well as NuxtError - and Vue-specific objects like `ref`, `reactive`, `shallowRef` and `shallowReactive`.

You can find [an example](https://github.com/nuxt/nuxt/blob/main/test/fixtures/basic/pages/json-payload.vue) in our test suite.

This is all possible due to [Rich-Harris/devalue#58](https://github.com/Rich-Harris/devalue/pull/58). For a long time, Nuxt has been using our own fork of devalue owing to issues serialising Errors and other non-POJO objects, but we now have transitioned back to the original.

You can even register your own custom types with a new object-syntax Nuxt plugin:

```ts [plugins/custom-payload-type.ts]
export default definePayloadPlugin(() => {
  definePayloadReducer('BlinkingText', data => data === '<original-blink>' && '_')
  definePayloadReviver('BlinkingText', () => '<revivified-blink>')
})
```

You can read more about how this works [here](https://github.com/rich-harris/devalue#custom-types).

**Note**: this only affects payloads of the Nuxt app, that is, data stored within `useState`, returned from `useAsyncData` or manually injected via `nuxtApp.payload`. It does not affect data fetched from Nitro server routes via `$fetch` or `useFetch` although this is one area I am keen to explore further.

Preliminary testing shows a significant speed-up: **25% faster in total server response time** for a very minimal app with a large JSON payload, but I'd urge you to run your own tests and share the results with us.

As mentioned, we're merging this behind a flag so we can test this broadly and gather feedback on the new approach. The most significant potential change is that the payload is now no longer available on `window.__NUXT__` immediately. Instead, we now need to initialise the Nuxt app to parse the payload so any code that accesses `__NUXT__` will need to be run in a plugin or later in the Nuxt app lifecycle. Please feel free to raise an issue if you foresee or encounter issues in your projects.

### 🎁 Object-syntax Nuxt plugins

We now support object-syntax Nuxt plugins for better control over plugin _order_ and easier registration of hooks.

```ts [plugins/my-plugin.ts]
export default defineNuxtPlugin({
  name: 'my-plugin',
  enforce: 'pre', // or 'post'
  async setup (nuxtApp) {
    // this is the equivalent of a normal functional plugin
  },
  hooks: {
    // You can directly register Nuxt app hooks here
    'app:created'() {
      const nuxtApp = useNuxtApp()
      // 
    }
  }
})
```

In future we plan to enable build optimizations based on the metadata you pass in your Nuxt plugins.

### 🛠️ Easier Devtools Configuration

It's even easier to enable Nuxt DevTools in your project: just set `devtools: true` in your `nuxt.config` file to enable devtools.

```js [nuxt.config.ts]
export default defineNuxtConfig({
  devtools: true
})
```

If it's not already installed, Nuxt will prompt to install it locally. This means you no longer need to have Nuxt DevTools enabled globally.

**Note**: the DevTools is still experimental and under active development, so do be prepared for occasional unexpected behaviour, and please report issues directly to https://github.com/nuxt/devtools 🙏 

### 📚 Layers Improvements

We now support [transforming `~`/`~~`/`@`/`@@` aliases within layers](https://github.com/nuxt/nuxt/pull/19986), meaning you now no longer need to use relative paths when importing within layers.

This should mean it is much easier to use a 'normal' Nuxt project as a [layer](https://nuxt.com/docs/getting-started/layers#layers) without needing to specially write it as one.

### 🧸 Better Context Transforms

We [now transform certain keys](https://github.com/nuxt/nuxt/pull/20182) of `definePageMeta` and `defineNuxtComponent` which means you should have fewer issues with a missing Nuxt instance. This includes support accessing the Nuxt instance after an `await` within `asyncData` and `setup` functions for those still using the Options API. And you no longer need to wrap `middleware` and `validate` with `defineNuxtRouteMiddleware` when using async functions.

### ♻️ Ecosystem Updates

As usual, this release will pull in upstream improvements, including the new [Consola v3](https://github.com/unjs/consola) and [Nitropack v2.3.3](https://github.com/unjs/nitro) (a new minor is expected shortly).

### 🚨 'Breaking fixes'

We've also taken the opportunity to do some cleanup in this minor release.

1. Previously it was possible to pass the `x-nuxt-no-ssr` header (undocumented) to force SPA rendering. We've now disabled this behaviour by default but you can get it back by setting `experimental.respectNoSSRHeader` to true. Alternatively, you can set `event.context.nuxt.noSSR` on the server to force SPA rendering.
2. We've [removed the (deprecated) `#head` alias](https://github.com/nuxt/nuxt/pull/20111) and also disabled the [polyfill for `@vueuse/head` behaviour](https://github.com/nuxt/nuxt/pull/20131) by default. (It can still be enabled with `experimental.polyfillVueUseHead`.)
3. We've [removed the (deprecated) `experimental.viteNode` option](https://github.com/nuxt/nuxt/pull/20112). It can be configured instead with `vite.devBundler`.
4. We've [deprecated accessing public runtime config without the `public` key](https://github.com/nuxt/nuxt/pull/20082). This was an undocument compatibility measure with Nuxt 2 and we plan to remove it entirely in v3.5.
5. To fix a bug with our vue-router integration, we now generate a slightly different path matching syntax. If you were relying on the exact path generated, have a look at https://github.com/nuxt/nuxt/pull/19902 for more information.

### ✅ Upgrading

As usual, our recommendation for upgrading is to run:

```sh
nuxi upgrade --force
```

This will refresh your lockfile as well, and ensures that you pull in updates from other dependencies that Nuxt relies on, particularly in the unjs ecosystem.

With Nuxt v3.4.0, we now advise that you explicitly install the `@types/node` version that matches your Node version.

-->

## 👉 Changelog

[compare changes](https://github.com/nuxt/nuxt/compare/v3.3.3...v3.4.0)


### 🚀 Enhancements

  - **nuxt:** Warn in dev when `useRoute` is used in middleware ([#20050](https://github.com/nuxt/nuxt/pull/20050))
  - **nuxt:** Support disabling `watch` with `useFetch` ([#19823](https://github.com/nuxt/nuxt/pull/19823))
  - **nuxt:** Support `~`/`~~`/`@`/`@@` aliases within layers ([#19986](https://github.com/nuxt/nuxt/pull/19986))
  - **nuxt:** Respect custom `dir.pages` in page placeholder ([#20079](https://github.com/nuxt/nuxt/pull/20079))
  - **nuxt:** Support vue runtime compiler ([#4762](https://github.com/nuxt/framework/pull/4762))
  - **test-utils:** Allow mounting single component for testing ([#5723](https://github.com/nuxt/nuxt/pull/5723))
  - **nuxt:** Experimental option for rich json payloads ([#19205](https://github.com/nuxt/nuxt/pull/19205))
  - **nuxt:** Prompt to install `devtools` when it's enabled ([#20126](https://github.com/nuxt/nuxt/pull/20126))
  - Upgrade to consola v3.x prerelease ([#20141](https://github.com/nuxt/nuxt/pull/20141))
  - **nuxt:** Add experimental View Transitions API support ([#20092](https://github.com/nuxt/nuxt/pull/20092))
  - **nuxt:** Support async transform of object properties ([#20182](https://github.com/nuxt/nuxt/pull/20182))
  - **nuxt:** Support object-syntax plugins ([#20003](https://github.com/nuxt/nuxt/pull/20003))
  - **nuxt:** Add `experimentalNoScripts` route rule ([#19805](https://github.com/nuxt/nuxt/pull/19805))
  - **nuxt:** Add chokidar watcher debug timing ([#20176](https://github.com/nuxt/nuxt/pull/20176))

### 🔥 Performance

  - **head:** Disable `@vueuse/head` polyfill by default ([#20131](https://github.com/nuxt/nuxt/pull/20131))

### 🩹 Fixes

  - **nuxt:** End route param tokens manually ([#19902](https://github.com/nuxt/nuxt/pull/19902))
  - **nuxt:** Disable `x-nuxt-no-ssr` header by default ([#20024](https://github.com/nuxt/nuxt/pull/20024))
  - **kit:** Support calling Nuxt 2 modules with module container ([#20023](https://github.com/nuxt/nuxt/pull/20023))
  - **nuxt:** Add types for globally injected `$config` object ([#20081](https://github.com/nuxt/nuxt/pull/20081))
  - **nuxt:** Throw error on protocol relative path in `useFetch` ([#20052](https://github.com/nuxt/nuxt/pull/20052))
  - **nuxt:** Add `@types/node` as a peerDependency ([#20025](https://github.com/nuxt/nuxt/pull/20025))
  - **nuxt:** Test all custom app config keys for `any` ([#20105](https://github.com/nuxt/nuxt/pull/20105))
  - **nuxt:** Add key to `.client` component placeholders ([#20093](https://github.com/nuxt/nuxt/pull/20093))
  - **nuxt:** Add `undefined` type for `useCookie` return value ([4f0b3c722](https://github.com/nuxt/nuxt/commit/4f0b3c722))
  - **nuxt:** Deprecate old (pre-rc) runtimeConfig ([#20082](https://github.com/nuxt/nuxt/pull/20082))
  - **cli:** Preview nitro build with custom dir config ([#18882](https://github.com/nuxt/nuxt/pull/18882))
  - **nuxt:** Default nitro autoImports to `imports.autoImport` ([#20180](https://github.com/nuxt/nuxt/pull/20180))
  - **nuxi, vite:** Suppress sourcemap + native fetch warnings ([#20198](https://github.com/nuxt/nuxt/pull/20198))
  - **schema:** Allow `ignorePrefix` to be changed ([#20202](https://github.com/nuxt/nuxt/pull/20202))

### 💅 Refactors

  - **schema:** Clean up `experimental` options ([#20112](https://github.com/nuxt/nuxt/pull/20112))
  - **nuxt:** Remove `#head` alias ([#20111](https://github.com/nuxt/nuxt/pull/20111))

### 📖 Documentation

  - Add interop default to dynamic vue import example ([8908aa7c5](https://github.com/nuxt/nuxt/commit/8908aa7c5))
  - Add short note about custom `imports` configuration ([#20073](https://github.com/nuxt/nuxt/pull/20073))
  - Re-enable docs linting and update docs ([#20084](https://github.com/nuxt/nuxt/pull/20084))
  - Fix type of `headers` option for `useFetch` ([#20148](https://github.com/nuxt/nuxt/pull/20148))
  - Fix typo in `@pinia/nuxt` module name ([#20199](https://github.com/nuxt/nuxt/pull/20199))
  - Add import to server-side cookies example ([#20197](https://github.com/nuxt/nuxt/pull/20197))

### 🏡 Chore

  - Loosen nitro version constraint ([79ad5ac9b](https://github.com/nuxt/nuxt/commit/79ad5ac9b))
  - Exclude new subpath from lint reordering ([b8cdef69c](https://github.com/nuxt/nuxt/commit/b8cdef69c))
  - Use workspace ref ([b33b84d57](https://github.com/nuxt/nuxt/commit/b33b84d57))
  - Use `overrides` ([4a6f85277](https://github.com/nuxt/nuxt/commit/4a6f85277))
  - Correctly nest `overrides` ([a15a9b66f](https://github.com/nuxt/nuxt/commit/a15a9b66f))
  - Remove `JITI_ESM_RESOLVE` ([#20172](https://github.com/nuxt/nuxt/pull/20172))
  - Upgrade to consola v3 ([#20194](https://github.com/nuxt/nuxt/pull/20194))

### ✅ Tests

  - Use kb size snapshot ([#20083](https://github.com/nuxt/nuxt/pull/20083))
  - Update bundle size snapshot ([d265abbad](https://github.com/nuxt/nuxt/commit/d265abbad))

### 🎨 Styles

  - Lint ([f1baa0355](https://github.com/nuxt/nuxt/commit/f1baa0355))
  - Enable `sort-imports` eslint rule ([#20133](https://github.com/nuxt/nuxt/pull/20133))

### 🤖 CI

  - Enable autofix for pr linting ([#20085](https://github.com/nuxt/nuxt/pull/20085))
  - Use autofix to update bundle size ([#20088](https://github.com/nuxt/nuxt/pull/20088))
  - Stub project before linting ([13b853622](https://github.com/nuxt/nuxt/commit/13b853622))
  - Lint before stubbing ([857e9cb3d](https://github.com/nuxt/nuxt/commit/857e9cb3d))
  - Stub project before linting ([b329ed781](https://github.com/nuxt/nuxt/commit/b329ed781))
  - Use `head_ref` for dependency deduping ([ae5df72c5](https://github.com/nuxt/nuxt/commit/ae5df72c5))

### ❤️  Contributors

- Daniel Roe (@danielroe)
- Sacha Stafyniak (@stafyniaksacha)
- Julien Huang (@huang-julien)
- Harlan Wilton (@harlan-zw)
- Nolan (@ncphillips)
- Jeremy Graziani (@AcelisWeaven)
- JT Smith (@rizen)
- Anthony Fu (@antfu)
- Xjccc (@xjccc)
- Pooya Parsa (@pi0)
- Cany748 (@cany748)
- Aleksandar Trpkovski (@Suv4o)
- Paul Melero (@gangsthub)
