### PR TITLE
feat(nuxt): add chokidar watcher debug timing

### DIFF
--- a/packages/nuxt/src/core/builder.ts
+++ b/packages/nuxt/src/core/builder.ts
@@ -44,6 +44,10 @@ export async function build (nuxt: Nuxt) {
 }
 
 function watch (nuxt: Nuxt) {
+  if (nuxt.options.debug) {
+    console.time('[nuxt] builder:chokidar:watch')
+  }
+
   const watcher = chokidar.watch(nuxt.options._layers.map(i => i.config.srcDir as string).filter(Boolean), {
     ...nuxt.options.watchers.chokidar,
     cwd: nuxt.options.srcDir,
@@ -54,6 +58,10 @@ function watch (nuxt: Nuxt) {
       'node_modules'
     ]
   })
+
+  if (nuxt.options.debug) {
+    watcher.on('ready', () => console.timeEnd('[nuxt] builder:chokidar:watch'))
+  }
 
   watcher.on('all', (event, path) => nuxt.callHook('builder:watch', event, normalize(path)))
   nuxt.hook('close', () => watcher.close())


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I have noticed that chokidar take a lot of time during initialization (can take more than 30sec). I'm adding measurement here, so we can have a reference for further optimization.

Chokidar will recursively discover all subdirectories/files (`node_modules` / `.git` / ...), regardless `ignored` option (which is used only to filter events send).

I think it's a wanted behavior, to ensure consistency 
https://github.com/paulmillr/chokidar/blob/0f163b89f3ae76607900aa48fec9fa3fdefd7ca1/lib/fsevents-handler.js#L455-L457

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
