### PR TITLE
fix(imports): toggle nitro autoImports with `imports.autoImport`

### DIFF
--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -37,6 +37,7 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
     dev: nuxt.options.dev,
     buildDir: nuxt.options.buildDir,
     imports: {
+      autoImports: nuxt.options.imports.autoImport,
       imports: [
         {
           as: '__buildAssetsURL',


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

When developing a Nuxt module using the provided starter, the auto imports are disabled with the `.nuxtrc` [file](https://github.com/nuxt/starter/blob/module/.nuxtrc). This is helpful because when a module is published, the auto imports won't work, allowing module authors to find import issues before publishing.

However, this config would seem to imply that all auto imports are disabled. This isn't the case as nitro auto imports still work. 

```ts
export default defineEventHandler((_event) => {
  return 'Hello!'
})
```

The above would work while in development but fail once deployed.

I've tested the fix in this PR and it seems to work correctly, however, one issue is that the type doesn't seem to be available, I'm not sure why that is. It seems purposefully excluded from the config types. Though within Nitro this config is parsed directly to the rollup plugin which uses this. Maybe a Nitro or an Unplugin PR is also needed?

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
