### PR TITLE
fix(nuxi, vite): suppress sourcemap + native fetch warnings

### DIFF
--- a/packages/nuxi/src/cli.ts
+++ b/packages/nuxi/src/cli.ts
@@ -54,6 +54,7 @@ const wrapReporter = (reporter: ConsolaReporter) => ({
       if (msg.startsWith('[Vue Router warn]: No match found for location with path')) {
         return
       }
+      // TODO: resolve upstream in Vite
       // Hide sourcemap warnings related to node_modules
       if (msg.startsWith('Sourcemap') && msg.includes('node_modules')) {
         return

--- a/packages/nuxi/src/cli.ts
+++ b/packages/nuxi/src/cli.ts
@@ -54,6 +54,10 @@ const wrapReporter = (reporter: ConsolaReporter) => ({
       if (msg.startsWith('[Vue Router warn]: No match found for location with path')) {
         return
       }
+      // Suppress warning about native Node.js fetch
+      if (msg.includes('ExperimentalWarning: The Fetch API is an experimental feature')) {
+        return
+      }
       // TODO: resolve upstream in Vite
       // Hide sourcemap warnings related to node_modules
       if (msg.startsWith('Sourcemap') && msg.includes('node_modules')) {

--- a/packages/vite/src/utils/logger.ts
+++ b/packages/vite/src/utils/logger.ts
@@ -27,6 +27,12 @@ export function createViteLogger (config: vite.InlineConfig): vite.Logger {
   const clearScreen = canClearScreen ? clear : () => {}
 
   function output (type: vite.LogType, msg: string, options: vite.LogErrorOptions = {}) {
+    if (typeof msg === 'string' && !process.env.DEBUG) {
+      // TODO: resolve upstream in Vite
+      // Hide sourcemap warnings related to node_modules
+      if (msg.startsWith('Sourcemap') && msg.includes('node_modules')) { return }
+    }
+
     const sameAsLast = lastType === type && lastMsg === msg
     if (sameAsLast) {
       duplicateCount += 1


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We're no longer suppressing sourcemap warnings as expected - not entirely sure of cause but it might be consola v3 upgrade (cc: @pi0). This applies the same fix in CLI to our custom vite logger.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
