### PR TITLE
fix(nuxt): set config on `ssrContext` in spa renderer

### DIFF
--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -124,12 +124,12 @@ const getSPARenderer = lazyCachedFunction(async () => {
     ssrContext!.payload = {
       _errors: {},
       serverRendered: false,
-      config: {
-        public: config.public,
-        app: config.app
-      },
       data: {},
       state: {}
+    }
+    ssrContext.config = {
+      public: config.public,
+      app: config.app
     }
     ssrContext!.renderMeta = ssrContext!.renderMeta ?? getStaticRenderedHead
     return Promise.resolve(result)

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -46,6 +46,7 @@ describe('route rules', () => {
     const { script, attrs } = parseData(await $fetch('/route-rules/spa'))
     expect(script.serverRendered).toEqual(false)
     expect(attrs['data-ssr']).toEqual('false')
+    await expectNoClientErrors('/route-rules/spa')
   })
 
   it('test noScript routeRules', async () => {

--- a/test/fixtures/basic/plugins/custom-type-assertion.client.ts
+++ b/test/fixtures/basic/plugins/custom-type-assertion.client.ts
@@ -1,5 +1,5 @@
 export default defineNuxtPlugin((nuxtApp) => {
-  if (nuxtApp.payload.blinkable !== '<revivified-blink>') {
+  if (nuxtApp.payload.serverRendered && nuxtApp.payload.blinkable !== '<revivified-blink>') {
     throw createError({
       message: 'Custom type in Nuxt payload was not revived correctly'
     })


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/20210

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In https://github.com/nuxt/nuxt/pull/19205 we moved runtime config out of the payload and onto `ssrContext`. This updates the SPA renderer implementation to do the same.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
