### PR TITLE
fix(nuxt): do not redirect when `vue-router` normalises url

### DIFF
--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -8,7 +8,7 @@ import {
   createWebHistory
 } from 'vue-router'
 import { createError } from 'h3'
-import { isEqual, withoutBase } from 'ufo'
+import { withoutBase } from 'ufo'
 
 import type { PageMeta, Plugin, RouteMiddleware } from '../../../app/index'
 import { callWithNuxt, defineNuxtPlugin, useRuntimeConfig } from '#app/nuxt'
@@ -178,11 +178,10 @@ export default defineNuxtPlugin({
           statusMessage: `Page not found: ${to.fullPath}`
         })])
       } else if (process.server) {
-        const currentURL = to.fullPath || '/'
-        if (!isEqual(currentURL, initialURL, { trailingSlash: true })) {
+        if (to.redirectedFrom) {
           const event = await callWithNuxt(nuxtApp, useRequestEvent)
           const options = { redirectCode: event.node.res.statusCode !== 200 ? event.node.res.statusCode || 302 : 302 }
-          await callWithNuxt(nuxtApp, navigateTo, [currentURL, options])
+          await callWithNuxt(nuxtApp, navigateTo, [to.fullPath, options])
         }
       }
     })

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -130,6 +130,11 @@ describe('pages', () => {
     await page.close()
   })
 
+  it('returns 500 when there is an infinite redirect', async () => {
+    const { status } = await fetch('/redirect-infinite', { redirect: 'manual' })
+    expect(status).toEqual(500)
+  })
+
   it('render 404', async () => {
     const html = await $fetch('/not-found')
 

--- a/test/fixtures/basic/middleware/redirect.global.ts
+++ b/test/fixtures/basic/middleware/redirect.global.ts
@@ -9,6 +9,10 @@ export default defineNuxtRouteMiddleware(async (to) => {
     await new Promise(resolve => setTimeout(resolve, 100))
     return navigateTo(to.path.slice('/redirect/'.length - 1))
   }
+  if (to.path === '/redirect-infinite') {
+    // the path will be the same in this new route and vue-router should send a 500 response
+    return navigateTo('/redirect-infinite?test=true')
+  }
   const pluginPath = nuxtApp.$path()
   if (process.server && !/redirect|navigate/.test(pluginPath) && to.path !== pluginPath) {
     throw new Error('plugin did not run before middleware')


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/14316

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

vue router normalises `/?asd=1231%20` to `/?asd=1231+` but this isn't actually a redirect performed by middleware. We can respect `to.redirectedFrom` to tell us whether there's been an _explicit_ redirection rather than just vue-router normalising things for us.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
