### PR TITLE
docs: add advanced usage example of `useState`

### DIFF
--- a/docs/1.getting-started/7.state-management.md
+++ b/docs/1.getting-started/7.state-management.md
@@ -65,6 +65,7 @@ In this example, we use a composable that detects the user's default locale from
 
 ```ts [composables/locale.ts]
 // composables/locale.ts
+
 import type { Ref } from 'vue'
 
 export const useLocale = () => useState<string>('locale', () => useDefaultLocale().value)
@@ -106,6 +107,7 @@ export const useLocaleDate = (date: Ref<Date> | Date, locale = useLocale()) => {
 
 ```vue [app.vue]
 // app.vue
+
 <script setup>
 const locales = useLocales()
 const locale = useLocale()

--- a/docs/1.getting-started/7.state-management.md
+++ b/docs/1.getting-started/7.state-management.md
@@ -64,8 +64,6 @@ const counter = useState('counter', () => Math.round(Math.random() * 1000))
 In this example, we use a composable that detects the user's default locale from the HTTP request headers and keeps it in a `locale` state.
 
 ```ts [composables/locale.ts]
-// composables/locale.ts
-
 import type { Ref } from 'vue'
 
 export const useLocale = () => useState<string>('locale', () => useDefaultLocale().value)
@@ -106,8 +104,6 @@ export const useLocaleDate = (date: Ref<Date> | Date, locale = useLocale()) => {
 ```
 
 ```vue [app.vue]
-// app.vue
-
 <script setup>
 const locales = useLocales()
 const locale = useLocale()

--- a/docs/1.getting-started/7.state-management.md
+++ b/docs/1.getting-started/7.state-management.md
@@ -59,9 +59,72 @@ const counter = useState('counter', () => Math.round(Math.random() * 1000))
 ::ReadMore{link="/docs/api/composables/use-state"}
 ::
 
-### Advanced
+### Advanced Usage
 
 In this example, we use a composable that detects the user's default locale from the HTTP request headers and keeps it in a `locale` state.
+
+```ts [composables/locale.ts]
+// composables/locale.ts
+import type { Ref } from 'vue'
+
+export const useLocale = () => useState<string>('locale', () => useDefaultLocale().value)
+
+export const useDefaultLocale = (fallback = 'en-US') => {
+  const locale = ref(fallback)
+  if (process.server) {    
+    const reqLocale = useRequestHeaders()['accept-language']?.split(',')[0]
+    if (reqLocale) {
+      locale.value = reqLocale
+    }
+  } else if (process.client) {
+    const navLang = navigator.language
+    if (navLang) {
+      locale.value = navLang
+    }
+  }
+  return locale
+}
+
+export const useLocales = () => {
+  const locale = useLocale()
+  const locales = ref([
+    'en-US',
+    'en-GB',
+    ...
+    'ja-JP-u-ca-japanese'
+  ])
+  if (!locales.value.includes(locale.value)) {
+    locales.value.unshift(locale.value)
+  }
+  return locales
+}
+
+export const useLocaleDate = (date: Ref<Date> | Date, locale = useLocale()) => {
+  return computed(() => new Intl.DateTimeFormat(locale.value, { dateStyle: 'full' }).format(unref(date)))
+}
+```
+
+```vue [app.vue]
+// app.vue
+<script setup>
+const locales = useLocales()
+const locale = useLocale()
+const date = useLocaleDate(new Date('2016-10-26'))
+</script>
+
+<template>
+  <div>
+    <h1>Nuxt birthday</h1>
+    <p>{{ date }}</p>    
+    <label for="locale-chooser">Preview a different locale</label>
+    <select id="locale-chooser" v-model="locale">
+      <option v-for="locale of locales" :key="locale" :value="locale">
+        {{ locale }}
+      </option>
+    </select>
+  </div>
+</template>
+```
 
 ::LinkExample{link="/docs/examples/other/locale"}
 ::


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds in the documentation the same advanced example from CodesandBox. As only the basic usage example was provided but no advanced example.
This can be helpful for those that just want to kickly see some more robustic code.
Also, more examples present on the MD files can help some AIs that read docs to know about how to use it.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
