### PR TITLE
perf(nuxt): share lazy component definitions

### DIFF
--- a/packages/nuxt/src/components/templates.ts
+++ b/packages/nuxt/src/components/templates.ts
@@ -27,18 +27,21 @@ const createImportMagicComments = (options: ImportMagicCommentsOptions) => {
 
 export const componentsPluginTemplate: NuxtPluginTemplate<ComponentsTemplateContext> = {
   filename: 'components.plugin.mjs',
-  getContents () {
+  getContents ({ options }) {
     return `import { defineNuxtPlugin } from '#app/nuxt'
 import { lazyGlobalComponents } from '#components'
 
 export default defineNuxtPlugin({
-  name: 'nuxt:global-components',
+  name: 'nuxt:global-components',` +
+      (options.getComponents().filter(c => c.global).length
+        ? `
   setup (nuxtApp) {
     for (const name in lazyGlobalComponents) {
       nuxtApp.vueApp.component(name, lazyGlobalComponents[name])
       nuxtApp.vueApp.component('Lazy' + name, lazyGlobalComponents[name])
     }
-  }
+  }`
+        : '') + `
 })
 `
   }

--- a/packages/nuxt/src/components/templates.ts
+++ b/packages/nuxt/src/components/templates.ts
@@ -29,14 +29,14 @@ export const componentsPluginTemplate: NuxtPluginTemplate<ComponentsTemplateCont
   filename: 'components.plugin.mjs',
   getContents () {
     return `import { defineNuxtPlugin } from '#app/nuxt'
-import { globalComponents } from '#components'
+import { lazyGlobalComponents } from '#components'
 
 export default defineNuxtPlugin({
   name: 'nuxt:global-components',
   setup (nuxtApp) {
-    for (const name in globalComponents) {
-      nuxtApp.vueApp.component(name, globalComponents[name])
-      nuxtApp.vueApp.component('Lazy' + name, globalComponents[name])
+    for (const name in lazyGlobalComponents) {
+      nuxtApp.vueApp.component(name, lazyGlobalComponents[name])
+      nuxtApp.vueApp.component('Lazy' + name, lazyGlobalComponents[name])
     }
   }
 })

--- a/packages/nuxt/src/components/templates.ts
+++ b/packages/nuxt/src/components/templates.ts
@@ -27,25 +27,16 @@ const createImportMagicComments = (options: ImportMagicCommentsOptions) => {
 
 export const componentsPluginTemplate: NuxtPluginTemplate<ComponentsTemplateContext> = {
   filename: 'components.plugin.mjs',
-  getContents ({ options }) {
-    const globalComponents = options.getComponents().filter(c => c.global === true)
-
-    return `import { defineAsyncComponent } from 'vue'
-import { defineNuxtPlugin } from '#app/nuxt'
-
-const components = ${genObjectFromRawEntries(globalComponents.map((c) => {
-  const exp = c.export === 'default' ? 'c.default || c' : `c['${c.export}']`
-  const comment = createImportMagicComments(c)
-
-  return [c.pascalName, `defineAsyncComponent(${genDynamicImport(c.filePath, { comment })}.then(c => ${exp}))`]
-}))}
+  getContents () {
+    return `import { defineNuxtPlugin } from '#app/nuxt'
+import { globalComponents } from '#components'
 
 export default defineNuxtPlugin({
   name: 'nuxt:global-components',
   setup (nuxtApp) {
-    for (const name in components) {
-      nuxtApp.vueApp.component(name, components[name])
-      nuxtApp.vueApp.component('Lazy' + name, components[name])
+    for (const name in globalComponents) {
+      nuxtApp.vueApp.component(name, globalComponents[name])
+      nuxtApp.vueApp.component('Lazy' + name, globalComponents[name])
     }
   }
 })
@@ -81,6 +72,7 @@ export const componentsTemplate: NuxtTemplate<ComponentsTemplateContext> = {
     return [
       ...imports,
       ...components,
+      `export const lazyGlobalComponents = ${genObjectFromRawEntries(options.getComponents().filter(c => c.global).map(c => [c.pascalName, `Lazy${c.pascalName}`]))}`,
       `export const componentNames = ${JSON.stringify(options.getComponents().filter(c => !c.island).map(c => c.pascalName))}`
     ].join('\n')
   }

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -48,7 +48,7 @@ describe.skipIf(isWindows || process.env.TEST_BUILDER === 'webpack' || process.e
 
   it('default server bundle size', async () => {
     stats.server = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect(roundToKilobytes(stats.server.totalBytes)).toMatchInlineSnapshot('"92.6k"')
+    expect(roundToKilobytes(stats.server.totalBytes)).toMatchInlineSnapshot('"92.4k"')
 
     const modules = await analyzeSizes('node_modules/**/*', serverDir)
     expect(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot('"2650k"')


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We were previously generating two lots of async components, one for global components directly in the plugin, and another in the `#components` chunk. This allows us to share the lazy components between chunks, and also ensures that client-only global components work correctly. (Previously we were not handling them equivalently.)

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
