### PR TITLE
fix(nuxt): generate hi-res sourcemaps

### DIFF
--- a/packages/nuxt/src/components/client-fallback-auto-id.ts
+++ b/packages/nuxt/src/components/client-fallback-auto-id.ts
@@ -44,7 +44,7 @@ export const clientFallbackAutoIdPlugin = createUnplugin((options: LoaderOptions
         return {
           code: s.toString(),
           map: options.sourcemap
-            ? s.generateMap({ source: id, includeContent: true })
+            ? s.generateMap({ hires: true })
             : undefined
         }
       }

--- a/packages/nuxt/src/components/loader.ts
+++ b/packages/nuxt/src/components/loader.ts
@@ -33,7 +33,7 @@ export const loaderPlugin = createUnplugin((options: LoaderOptions) => {
       }
       return isVueTemplate(id)
     },
-    transform (code, id) {
+    transform (code) {
       const components = options.getComponents()
 
       let num = 0
@@ -92,7 +92,7 @@ export const loaderPlugin = createUnplugin((options: LoaderOptions) => {
         return {
           code: s.toString(),
           map: options.sourcemap
-            ? s.generateMap({ source: id, includeContent: true })
+            ? s.generateMap({ hires: true })
             : undefined
         }
       }

--- a/packages/nuxt/src/components/tree-shake.ts
+++ b/packages/nuxt/src/components/tree-shake.ts
@@ -29,7 +29,7 @@ export const TreeShakeTemplatePlugin = createUnplugin((options: TreeShakeTemplat
       const { pathname } = parseURL(decodeURIComponent(pathToFileURL(id).href))
       return pathname.endsWith('.vue')
     },
-    transform (code, id) {
+    transform (code) {
       const components = options.getComponents()
 
       if (!regexpMap.has(components)) {
@@ -106,7 +106,7 @@ export const TreeShakeTemplatePlugin = createUnplugin((options: TreeShakeTemplat
         return {
           code: s.toString(),
           map: options.sourcemap
-            ? s.generateMap({ source: id, includeContent: true })
+            ? s.generateMap({ hires: true })
             : undefined
         }
       }
@@ -192,7 +192,7 @@ function removeImportDeclaration (ast: Program, importName: string, magicString:
  * ImportDeclarations and VariableDeclarations are ignored
  * return the name of the component if is not called
  */
-function isComponentNotCalledInSetup (codeAst: Node, name: string): string|void {
+function isComponentNotCalledInSetup (codeAst: Node, name: string): string | void {
   if (name) {
     let found = false
     walk(codeAst, {

--- a/packages/nuxt/src/core/plugins/dev-only.ts
+++ b/packages/nuxt/src/core/plugins/dev-only.ts
@@ -23,7 +23,7 @@ export const DevOnlyPlugin = createUnplugin((options: DevOnlyPluginOptions) => {
         return true
       }
     },
-    transform (code, id) {
+    transform (code) {
       if (!code.match(DEVONLY_COMP_RE)) { return }
 
       const s = new MagicString(code)
@@ -36,7 +36,7 @@ export const DevOnlyPlugin = createUnplugin((options: DevOnlyPluginOptions) => {
         return {
           code: s.toString(),
           map: options.sourcemap
-            ? s.generateMap({ source: id, includeContent: true })
+            ? s.generateMap({ hires: true })
             : undefined
         }
       }

--- a/packages/nuxt/src/core/plugins/layer-aliasing.ts
+++ b/packages/nuxt/src/core/plugins/layer-aliasing.ts
@@ -60,7 +60,7 @@ export const LayerAliasingPlugin = createUnplugin((options: LayerAliasingOptions
       if (s.hasChanged()) {
         return {
           code: s.toString(),
-          map: options.sourcemap ? s.generateMap({ source: id, includeContent: true }) : undefined
+          map: options.sourcemap ? s.generateMap({ hires: true }) : undefined
         }
       }
     }

--- a/packages/nuxt/src/core/plugins/tree-shake.ts
+++ b/packages/nuxt/src/core/plugins/tree-shake.ts
@@ -35,7 +35,7 @@ export const TreeShakeComposablesPlugin = createUnplugin((options: TreeShakeComp
         return true
       }
     },
-    transform (code, id) {
+    transform (code) {
       if (!code.match(COMPOSABLE_RE)) { return }
 
       const s = new MagicString(code)
@@ -48,7 +48,7 @@ export const TreeShakeComposablesPlugin = createUnplugin((options: TreeShakeComp
         return {
           code: s.toString(),
           map: options.sourcemap
-            ? s.generateMap({ source: id, includeContent: true })
+            ? s.generateMap({ hires: true })
             : undefined
         }
       }

--- a/packages/nuxt/src/core/plugins/unctx.ts
+++ b/packages/nuxt/src/core/plugins/unctx.ts
@@ -34,7 +34,7 @@ export const UnctxTransformPlugin = createUnplugin((options: UnctxTransformPlugi
         return true
       }
     },
-    transform (code, id) {
+    transform (code) {
       // TODO: needed for webpack - update transform in unctx/unplugin?
       if (code.startsWith(TRANSFORM_MARKER) || !transformer.shouldTransform(code)) { return }
       const result = transformer.transform(code)
@@ -42,7 +42,7 @@ export const UnctxTransformPlugin = createUnplugin((options: UnctxTransformPlugi
         return {
           code: TRANSFORM_MARKER + result.code,
           map: options.sourcemap
-            ? result.magicString.generateMap({ source: id, includeContent: true })
+            ? result.magicString.generateMap({ hires: true })
             : undefined
         }
       }

--- a/packages/nuxt/src/imports/transform.ts
+++ b/packages/nuxt/src/imports/transform.ts
@@ -49,7 +49,7 @@ export const TransformPlugin = createUnplugin(({ ctx, options, sourcemap }: { ct
         return {
           code: s.toString(),
           map: sourcemap
-            ? s.generateMap({ source: id, includeContent: true })
+            ? s.generateMap({ hires: true })
             : undefined
         }
       }

--- a/packages/nuxt/src/pages/page-meta.ts
+++ b/packages/nuxt/src/pages/page-meta.ts
@@ -58,7 +58,7 @@ export const PageMetaPlugin = createUnplugin((options: PageMetaPluginOptions) =>
           return {
             code: s.toString(),
             map: options.sourcemap
-              ? s.generateMap({ source: id, includeContent: true })
+              ? s.generateMap({ hires: true })
               : undefined
           }
         }

--- a/packages/vite/src/plugins/chunk-error.ts
+++ b/packages/vite/src/plugins/chunk-error.ts
@@ -21,7 +21,7 @@ export const __vitePreload = (...args) => ___vitePreload(...args).catch(err => {
       return {
         code: s.toString(),
         map: options.sourcemap
-          ? s.generateMap({ source: id, includeContent: true })
+          ? s.generateMap({ hires: true })
           : undefined
       }
     }

--- a/packages/vite/src/plugins/composable-keys.ts
+++ b/packages/vite/src/plugins/composable-keys.ts
@@ -86,7 +86,7 @@ export const composableKeysPlugin = createUnplugin((options: ComposableKeysOptio
         return {
           code: s.toString(),
           map: options.sourcemap
-            ? s.generateMap({ source: id, includeContent: true })
+            ? s.generateMap({ hires: true })
             : undefined
         }
       }

--- a/packages/vite/src/plugins/paths.ts
+++ b/packages/vite/src/plugins/paths.ts
@@ -34,7 +34,7 @@ export function runtimePathsPlugin (options: RuntimePathsOptions): Plugin {
         return {
           code: s.toString(),
           map: options.sourcemap
-            ? s.generateMap({ source: id, includeContent: true })
+            ? s.generateMap({ hires: true })
             : undefined
         }
       }

--- a/packages/vite/src/plugins/pure-annotations.ts
+++ b/packages/vite/src/plugins/pure-annotations.ts
@@ -29,7 +29,7 @@ export const pureAnnotationsPlugin = createUnplugin((options: PureAnnotationsOpt
         return true
       }
     },
-    transform (code, id) {
+    transform (code) {
       if (!FUNCTION_RE_SINGLE.test(code)) { return }
 
       const s = new MagicString(code)
@@ -43,7 +43,7 @@ export const pureAnnotationsPlugin = createUnplugin((options: PureAnnotationsOpt
         return {
           code: s.toString(),
           map: options.sourcemap
-            ? s.generateMap({ source: id, includeContent: true })
+            ? s.generateMap({ hires: true })
             : undefined
         }
       }

--- a/packages/webpack/src/plugins/dynamic-base.ts
+++ b/packages/webpack/src/plugins/dynamic-base.ts
@@ -25,7 +25,7 @@ export const DynamicBasePlugin = createUnplugin((options: DynamicBasePluginOptio
       return {
         code: s.toString(),
         map: options.sourcemap
-          ? s.generateMap({ source: id, includeContent: true })
+          ? s.generateMap({ hires: true })
           : undefined
       }
     }


### PR DESCRIPTION
### 🔗 Linked issue

resolves #8730
resolves #13674

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In general in the vite ecosystem generating hires sourcemaps seems to be the norm ([search](https://github.com/search?q=generatemap+org%3Avitejs&type=code)).

It seems to be faster _and_ more accurate when viewed in browser DevTools, and also significantly improves debugging in SSR. However I'd value your thoughts particularly @antfu.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
