### PR TITLE
fix(nuxt): mark `useRequestHeaders` keys as optional

### DIFF
--- a/packages/nuxt/src/app/composables/ssr.ts
+++ b/packages/nuxt/src/app/composables/ssr.ts
@@ -5,7 +5,7 @@ import type { NuxtApp } from '../nuxt'
 import { useNuxtApp } from '../nuxt'
 
 export function useRequestHeaders<K extends string = string> (include: K[]): { [key in Lowercase<K>]?: string }
-export function useRequestHeaders (): Readonly<Record<string, string | undefined>>
+export function useRequestHeaders (): Readonly<Record<string, string>>
 export function useRequestHeaders (include?: any[]) {
   if (process.client) { return {} }
   const headers = useNuxtApp().ssrContext?.event.node.req.headers ?? {}

--- a/packages/nuxt/src/app/composables/ssr.ts
+++ b/packages/nuxt/src/app/composables/ssr.ts
@@ -4,7 +4,7 @@ import { setResponseStatus as _setResponseStatus } from 'h3'
 import type { NuxtApp } from '../nuxt'
 import { useNuxtApp } from '../nuxt'
 
-export function useRequestHeaders<K extends string = string> (include: K[]): Record<Lowercase<K>, string | undefined>
+export function useRequestHeaders<K extends string = string> (include: K[]): { [key in Lowercase<K>]?: string }
 export function useRequestHeaders (): Readonly<Record<string, string | undefined>>
 export function useRequestHeaders (include?: any[]) {
   if (process.client) { return {} }

--- a/test/fixtures/basic/types.ts
+++ b/test/fixtures/basic/types.ts
@@ -259,6 +259,15 @@ describe('composables', () => {
     expectTypeOf(useFetch('/api/hey', { default: () => 'bar', transform: v => v.foo }).data).toEqualTypeOf<Ref<string | null>>()
     expectTypeOf(useLazyFetch('/api/hey', { default: () => 'bar', transform: v => v.foo }).data).toEqualTypeOf<Ref<string | null>>()
   })
+
+  it('uses types compatible between useRequestHeaders and useFetch', () => {
+    useFetch('/api/hey', {
+      headers: useRequestHeaders()
+    })
+    useFetch('/api/hey', {
+      headers: useRequestHeaders(['test'])
+    })
+  })
 })
 
 describe('app config', () => {

--- a/test/fixtures/basic/types.ts
+++ b/test/fixtures/basic/types.ts
@@ -267,6 +267,8 @@ describe('composables', () => {
     useFetch('/api/hey', {
       headers: useRequestHeaders(['test'])
     })
+    const { test } = useRequestHeaders(['test'])
+    expectTypeOf(test).toEqualTypeOf<string | undefined>()
   })
 })
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves nuxt/nuxt#14920

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This marks selected keys in `useRequestHeaders` as optional rather than explicitly set to `undefined`, and therefore compatible with the type of `HeadersInit`.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
