### PR TITLE
fix(nuxt): return type directly if not picking asyncData

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -11,14 +11,16 @@ export type PickFrom<T, K extends Array<string>> = T extends Array<any>
   : T extends Record<string, any>
   ? keyof T extends K[number]
     ? T // Exact same keys as the target, skip Pick
-    : Pick<T, K[number]>
+    : K[number] extends never
+      ? T
+      : Pick<T, K[number]>
   : T
 
 export type KeysOf<T> = Array<
   T extends T // Include all keys of union types, not just common keys
   ? keyof T extends string
     ? keyof T
-    : string
+    : never
   : never
 >
 

--- a/test/fixtures/basic/types.ts
+++ b/test/fixtures/basic/types.ts
@@ -259,6 +259,21 @@ describe('composables', () => {
     expectTypeOf(useFetch('/api/hey', { default: () => 'bar', transform: v => v.foo }).data).toEqualTypeOf<Ref<string | null>>()
     expectTypeOf(useLazyFetch('/api/hey', { default: () => 'bar', transform: v => v.foo }).data).toEqualTypeOf<Ref<string | null>>()
   })
+
+  it('correctly types returns with key signatures', () => {
+    interface TestType {
+      id: string
+      content: string[]
+      [x: string]: any
+    }
+
+    const testFetch = () => Promise.resolve({}) as Promise<TestType>
+
+    const { data: notTypedData } = useAsyncData('test', testFetch)
+    expectTypeOf(notTypedData.value!.id).toEqualTypeOf<string>()
+    expectTypeOf(notTypedData.value!.content).toEqualTypeOf<string[]>()
+    expectTypeOf(notTypedData.value!.untypedKey).toEqualTypeOf<any>()
+  })
 })
 
 describe('app config', () => {


### PR DESCRIPTION
### 🔗 Linked issue

resolves nuxt/nuxt#14440

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This fixes an issue with `Pick`, which was being applied indiscriminately to the return types of `useAsyncData` and `useFetch`. When no option is provided, we were defaulting PickKeys to `string`, which would result in returning all the keys (expected) or, in some cases, completely losing types. In this PR, we default it to `never` and thus can skip Pick entirely if there are no string keys to pick from.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
