### PR TITLE
fix(nuxt): provide more helpful error when instance unavailable

### DIFF
--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -441,7 +441,11 @@ export function useNuxtApp () {
   if (!nuxtAppInstance) {
     const vm = getCurrentInstance()
     if (!vm) {
-      throw new Error('nuxt instance unavailable')
+      if (process.dev) {
+        throw new Error('[nuxt] A composable that requires access to the Nuxt instance was called outside of a plugin, Nuxt hook, Nuxt middleware, or Vue setup function. This is probably not a Nuxt bug. Find out more at `https://nuxt.com/docs/guide/concepts/auto-imports#using-vue-and-nuxt-composables`.')
+      } else {
+        throw new Error('[nuxt] instance unavailable')
+      }
     }
     return vm.appContext.app.$nuxt as NuxtApp
   }


### PR DESCRIPTION
### 🔗 Linked issue

resolves nuxt/nuxt#13975

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This seeks to improve the error message that is logged when the Nuxt instance is unavailable. Suggestions to make this better are definitely welcome! And maybe we need to give this section its own page?

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
