### PR TITLE
v3.4.2

### DIFF
--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxt/kit",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "repository": "nuxt/nuxt",
   "license": "MIT",
   "type": "module",

--- a/packages/nuxi/package.json
+++ b/packages/nuxi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxi",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "repository": "nuxt/nuxt",
   "license": "MIT",
   "type": "module",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "repository": "nuxt/nuxt",
   "license": "MIT",
   "type": "module",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxt/schema",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "repository": "nuxt/nuxt",
   "license": "MIT",
   "type": "module",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxt/test-utils",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "repository": "nuxt/nuxt",
   "license": "MIT",
   "type": "module",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxt/vite-builder",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "repository": "nuxt/nuxt",
   "license": "MIT",
   "type": "module",

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxt/webpack-builder",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "repository": "nuxt/nuxt",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
> 3.4.2 is a patch release with the latest bug fixes and performance improvements.
>
> **Timetable**: Thursday.


## 👉 Changelog

[compare changes](https://github.com/nuxt/nuxt/compare/v3.4.1...main)


### 🔥 Performance

  - **nuxt:** Share lazy component definitions ([#20259](https://github.com/nuxt/nuxt/pull/20259))
  - Remove unused deps and add implicit deps ([#20356](https://github.com/nuxt/nuxt/pull/20356))
  - Allow using `@parcel/watcher` for dev watcher ([#20179](https://github.com/nuxt/nuxt/pull/20179))

### 🩹 Fixes

  - **vite:** Set different cache dirs for client/server ([#20276](https://github.com/nuxt/nuxt/pull/20276))
  - **nuxt:** Generate hi-res sourcemaps ([#20280](https://github.com/nuxt/nuxt/pull/20280))
  - **nuxt:** Return type directly if not picking asyncData ([#20288](https://github.com/nuxt/nuxt/pull/20288))
  - **nuxt:** Provide more helpful error when instance unavailable ([#20289](https://github.com/nuxt/nuxt/pull/20289))
  - **nuxt:** Mark `useRequestHeaders` keys as optional ([#20286](https://github.com/nuxt/nuxt/pull/20286))
  - **vite:** Avoid serving arbitrary file in vite-node middleware ([#20345](https://github.com/nuxt/nuxt/pull/20345))
  - **nuxt:** Swap preloads for json/js payloads ([#20375](https://github.com/nuxt/nuxt/pull/20375))
  - **nuxt:** Handle pages with no content and log warning ([#20373](https://github.com/nuxt/nuxt/pull/20373))
  - **test-utils:** Import jest functions from `@jest/globals` ([#20360](https://github.com/nuxt/nuxt/pull/20360))
  - **core,kit:** Ensure module transpilation paths are dirs ([#20396](https://github.com/nuxt/nuxt/pull/20396))
  - **schema:** Rely on installed telemetry types ([#19640](https://github.com/nuxt/nuxt/pull/19640))
  - **cli:** Load kit from `rootDir` when preparing project ([#20401](https://github.com/nuxt/nuxt/pull/20401))

### 💅 Refactors

  - **nuxt:** Rework and use `isJS` and `isVue` utilities consistently ([#20344](https://github.com/nuxt/nuxt/pull/20344))

### 📖 Documentation

  - Update links on hooks page ([#20296](https://github.com/nuxt/nuxt/pull/20296))
  - Add brief information on debugging a nuxt app ([#20282](https://github.com/nuxt/nuxt/pull/20282))
  - Fix vue-tsc link ([#20350](https://github.com/nuxt/nuxt/pull/20350))
  - Update lint command for the documentation ([#20399](https://github.com/nuxt/nuxt/pull/20399))

### 🏡 Chore

  - **deps:** Update all non-major dependencies (main) ([#20253](https://github.com/nuxt/nuxt/pull/20253))
  - Remove `@ts-ignore` and fix some issues ([#20273](https://github.com/nuxt/nuxt/pull/20273))
  - **deps:** Update all non-major dependencies (main) ([#20305](https://github.com/nuxt/nuxt/pull/20305))
  - **deps:** Update all non-major dependencies (main) ([#20313](https://github.com/nuxt/nuxt/pull/20313))
  - **deps:** Update devdependency eslint-plugin-jsdoc to ^41.1.2 (main) ([#20320](https://github.com/nuxt/nuxt/pull/20320))
  - **deps:** Update dependency c12 to ^1.3.0 (main) ([#20328](https://github.com/nuxt/nuxt/pull/20328))
  - **deps:** Update all non-major dependencies (main) ([#20337](https://github.com/nuxt/nuxt/pull/20337))
  - **deps:** Update all non-major dependencies (main) ([#20364](https://github.com/nuxt/nuxt/pull/20364))
  - **deps:** Update all non-major dependencies (main) ([#20395](https://github.com/nuxt/nuxt/pull/20395))
  - **deps:** Update all non-major dependencies (main) ([#20400](https://github.com/nuxt/nuxt/pull/20400))

### 🤖 CI

  - Don't run ci for release branches ([f550976f7](https://github.com/nuxt/nuxt/commit/f550976f7))

### ❤️  Contributors

- Daniel Roe <daniel@roe.dev>
- Harlan Wilton ([@harlan-zw](http://github.com/harlan-zw))
- Preet Mishra ([@preetmishra](http://github.com/preetmishra))
- Lehoczky Zoltán ([@Lehoczky](http://github.com/Lehoczky))
- BD103 
- Anthony Fu <anthonyfu117@hotmail.com>