### PR TITLE
fix(nuxi): load kit from `rootDir` when preparing project

### DIFF
--- a/packages/nuxi/src/commands/prepare.ts
+++ b/packages/nuxi/src/commands/prepare.ts
@@ -1,4 +1,3 @@
-import { buildNuxt } from '@nuxt/kit'
 import { relative, resolve } from 'pathe'
 import { consola } from 'consola'
 import { clearDir } from '../utils/fs'
@@ -16,7 +15,7 @@ export default defineNuxtCommand({
     process.env.NODE_ENV = process.env.NODE_ENV || 'production'
     const rootDir = resolve(args._[0] || '.')
 
-    const { loadNuxt } = await loadKit(rootDir)
+    const { loadNuxt, buildNuxt } = await loadKit(rootDir)
     const nuxt = await loadNuxt({
       rootDir,
       overrides: {


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We're directly importing from `@nuxt/kit` within `nuxi` despite having a `loadKit` utility which we should be using.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
