### PR TITLE
feat(kit): allow vite and webpack plugins to be prepended

### DIFF
--- a/packages/kit/src/build.ts
+++ b/packages/kit/src/build.ts
@@ -32,7 +32,14 @@ export interface ExtendConfigOptions {
 export interface ExtendWebpackConfigOptions extends ExtendConfigOptions {
 }
 
-export interface ExtendViteConfigOptions extends ExtendConfigOptions {}
+export interface ExtendViteConfigOptions extends ExtendConfigOptions {
+  /**
+   * Prepends the plugin to the array with `unshit()` instead of `push()`. In practice this shouldn't be necessary, but
+   * it's needed by unplugin-vue-router until vue exposes an API to parse files.
+   * @internal
+   */
+  prepend?: boolean
+}
 
 /**
  * Extend webpack config
@@ -119,11 +126,12 @@ export function addWebpackPlugin (plugin: WebpackPluginInstance | WebpackPluginI
  */
 export function addVitePlugin (plugin: VitePlugin | VitePlugin[], options?: ExtendViteConfigOptions) {
   extendViteConfig((config) => {
+    const method: 'push' | 'unshift' = options?.prepend ? 'unshift' : 'push'
     config.plugins = config.plugins || []
     if (Array.isArray(plugin)) {
-      config.plugins.push(...plugin)
+      config.plugins[method](...plugin)
     } else {
-      config.plugins.push(plugin)
+      config.plugins[method](plugin)
     }
   }, options)
 }

--- a/packages/kit/src/build.ts
+++ b/packages/kit/src/build.ts
@@ -30,13 +30,15 @@ export interface ExtendConfigOptions {
 }
 
 export interface ExtendWebpackConfigOptions extends ExtendConfigOptions {
+  /**
+   * Prepends the plugin to the array with `unshit()` instead of `push()`.
+   */
+  prepend?: boolean
 }
 
 export interface ExtendViteConfigOptions extends ExtendConfigOptions {
   /**
-   * Prepends the plugin to the array with `unshit()` instead of `push()`. In practice this shouldn't be necessary, but
-   * it's needed by unplugin-vue-router until vue exposes an API to parse files.
-   * @internal
+   * Prepends the plugin to the array with `unshit()` instead of `push()`.
    */
   prepend?: boolean
 }
@@ -111,12 +113,13 @@ export function extendViteConfig (
  * Append webpack plugin to the config.
  */
 export function addWebpackPlugin (plugin: WebpackPluginInstance | WebpackPluginInstance[], options?: ExtendWebpackConfigOptions) {
+  const method: 'push' | 'unshift' = options?.prepend ? 'unshift' : 'push'
   extendWebpackConfig((config) => {
     config.plugins = config.plugins || []
     if (Array.isArray(plugin)) {
-      config.plugins.push(...plugin)
+      config.plugins[method](...plugin)
     } else {
-      config.plugins.push(plugin)
+      config.plugins[method](plugin)
     }
   }, options)
 }
@@ -125,8 +128,8 @@ export function addWebpackPlugin (plugin: WebpackPluginInstance | WebpackPluginI
  * Append Vite plugin to the config.
  */
 export function addVitePlugin (plugin: VitePlugin | VitePlugin[], options?: ExtendViteConfigOptions) {
+  const method: 'push' | 'unshift' = options?.prepend ? 'unshift' : 'push'
   extendViteConfig((config) => {
-    const method: 'push' | 'unshift' = options?.prepend ? 'unshift' : 'push'
     config.plugins = config.plugins || []
     if (Array.isArray(plugin)) {
       config.plugins[method](...plugin)

--- a/packages/kit/src/build.ts
+++ b/packages/kit/src/build.ts
@@ -27,21 +27,15 @@ export interface ExtendConfigOptions {
    * @default true
    */
   client?: boolean
-}
-
-export interface ExtendWebpackConfigOptions extends ExtendConfigOptions {
   /**
    * Prepends the plugin to the array with `unshit()` instead of `push()`.
    */
   prepend?: boolean
 }
 
-export interface ExtendViteConfigOptions extends ExtendConfigOptions {
-  /**
-   * Prepends the plugin to the array with `unshit()` instead of `push()`.
-   */
-  prepend?: boolean
-}
+export interface ExtendWebpackConfigOptions extends ExtendConfigOptions {}
+
+export interface ExtendViteConfigOptions extends ExtendConfigOptions {}
 
 /**
  * Extend webpack config


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/pull/20367/files

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds a `prepend` option to `addWebpackPlugin` and `addVitePlugin` to allow plugins to be prepended to the start of the plugins list.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
