### PR TITLE
fix(nuxt): don't call `timeEnd` unless we're debugging

### DIFF
--- a/packages/nuxt/src/core/builder.ts
+++ b/packages/nuxt/src/core/builder.ts
@@ -75,7 +75,9 @@ async function watch (nuxt: Nuxt) {
           ]
         })
         watcher.then((subscription) => {
-          console.timeEnd('[nuxt] builder:parcel:watch')
+          if (nuxt.options.debug) {
+            console.timeEnd('[nuxt] builder:parcel:watch')
+          }
           nuxt.hook('close', () => subscription.unsubscribe())
         })
       }


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We need to apply debug condition to both `time` and `timeEnd`

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
