### PR TITLE
fix(nuxt): use separate alias for global components

### DIFF
--- a/packages/nuxt/src/components/module.ts
+++ b/packages/nuxt/src/components/module.ts
@@ -5,7 +5,7 @@ import type { Component, ComponentsDir, ComponentsOptions } from 'nuxt/schema'
 
 import { distDir } from '../dirs'
 import { clientFallbackAutoIdPlugin } from './client-fallback-auto-id'
-import { componentsIslandsTemplate, componentsPluginTemplate, componentsTemplate, componentsTypeTemplate } from './templates'
+import { componentsIslandsTemplate, componentsPluginTemplate, componentsTemplate, componentsTypeTemplate, lazyGlobalComponentsTemplate } from './templates'
 import { scanComponents } from './scan'
 import { loaderPlugin } from './loader'
 import { TreeShakeTemplatePlugin } from './tree-shake'
@@ -115,10 +115,10 @@ export default defineNuxtModule<ComponentsOptions>({
     addTemplate({ ...componentsTypeTemplate, options: { getComponents } })
     // components.plugin.mjs
     addPluginTemplate({ ...componentsPluginTemplate, options: { getComponents } } as any)
-    // components.server.mjs
     addTemplate({ ...componentsTemplate, filename: 'components.server.mjs', options: { getComponents, mode: 'server' } })
-    // components.client.mjs
     addTemplate({ ...componentsTemplate, filename: 'components.client.mjs', options: { getComponents, mode: 'client' } })
+    addTemplate({ ...lazyGlobalComponentsTemplate, filename: 'global-components.server.mjs', options: { getComponents, mode: 'server' } })
+    addTemplate({ ...lazyGlobalComponentsTemplate, filename: 'global-components.client.mjs', options: { getComponents, mode: 'client' } })
     // components.islands.mjs
     if (nuxt.options.experimental.componentIslands) {
       addTemplate({ ...componentsIslandsTemplate, filename: 'components.islands.mjs', options: { getComponents } })
@@ -128,12 +128,14 @@ export default defineNuxtModule<ComponentsOptions>({
 
     nuxt.hook('vite:extendConfig', (config, { isClient }) => {
       const mode = isClient ? 'client' : 'server'
-        ; (config.resolve!.alias as any)['#components'] = resolve(nuxt.options.buildDir, `components.${mode}.mjs`)
+      ;(config.resolve!.alias as any)['#components'] = resolve(nuxt.options.buildDir, `components.${mode}.mjs`)
+      ;(config.resolve!.alias as any)['#global-components'] = resolve(nuxt.options.buildDir, `global-components.${mode}.mjs`)
     })
     nuxt.hook('webpack:config', (configs) => {
       for (const config of configs) {
         const mode = config.name === 'server' ? 'server' : 'client'
-          ; (config.resolve!.alias as any)['#components'] = resolve(nuxt.options.buildDir, `components.${mode}.mjs`)
+        ;(config.resolve!.alias as any)['#components'] = resolve(nuxt.options.buildDir, `components.${mode}.mjs`)
+        ;(config.resolve!.alias as any)['#global-components'] = resolve(nuxt.options.buildDir, `global-components.${mode}.mjs`)
       }
     })
 

--- a/packages/nuxt/src/components/templates.ts
+++ b/packages/nuxt/src/components/templates.ts
@@ -1,5 +1,5 @@
 import { isAbsolute, relative } from 'pathe'
-import { genDynamicImport, genExport, genImport, genObjectFromRawEntries } from 'knitwork'
+import { genDynamicImport, genExport, genImport } from 'knitwork'
 import type { Component, Nuxt, NuxtPluginTemplate, NuxtTemplate } from 'nuxt/schema'
 
 export interface ComponentsTemplateContext {

--- a/packages/nuxt/src/components/templates.ts
+++ b/packages/nuxt/src/components/templates.ts
@@ -95,7 +95,7 @@ export const componentsTemplate: NuxtTemplate<ComponentsTemplateContext> = {
         definitions.push(genExport(c.filePath, [{ name: c.export, as: c.pascalName }]))
       }
       if (c.global) {
-        definitions.push(genExport('#global-components', [{ name: `Lazy${c.pascalName}`, as: c.pascalName }]))
+        definitions.push(genExport('#global-components', [{ name: `Lazy${c.pascalName}` }]))
       } else {
         definitions.push(`export const Lazy${c.pascalName} = /* #__PURE__ */ defineAsyncComponent(${genDynamicImport(c.filePath, { comment })}.then(c => ${isClient ? `createClientOnly(${exp})` : exp}))`)
       }


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/20439
resolves https://github.com/nuxt/nuxt/issues/20450
resolves nuxt/nuxt#20449

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

With https://github.com/nuxt/nuxt/issues/20259, it becomes more difficult for rollup to tree-shake out unused components, and side effects were persisting in the entry file. This change moves global lazy components into a separate chunk to assist with tree-shaking.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
