### PR TITLE
fix(nuxt): throw 404 when accessing `/__nuxt_error` directly

### DIFF
--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -308,13 +308,13 @@ export default defineRenderHandler(async (event) => {
       NO_SCRIPTS
         ? undefined
         : (_PAYLOAD_EXTRACTION
-          ? process.env.NUXT_JSON_PAYLOADS
-            ? renderPayloadJsonScript({ id: '__NUXT_DATA__', ssrContext, data: splitPayload(ssrContext).initial, src: payloadURL })
-            : renderPayloadScript({ ssrContext, data: splitPayload(ssrContext).initial, src: payloadURL })
-          : process.env.NUXT_JSON_PAYLOADS
-            ? renderPayloadJsonScript({ id: '__NUXT_DATA__', ssrContext, data: ssrContext.payload })
-            : renderPayloadScript({ ssrContext, data: ssrContext.payload })
-        ),
+            ? process.env.NUXT_JSON_PAYLOADS
+              ? renderPayloadJsonScript({ id: '__NUXT_DATA__', ssrContext, data: splitPayload(ssrContext).initial, src: payloadURL })
+              : renderPayloadScript({ ssrContext, data: splitPayload(ssrContext).initial, src: payloadURL })
+            : process.env.NUXT_JSON_PAYLOADS
+              ? renderPayloadJsonScript({ id: '__NUXT_DATA__', ssrContext, data: ssrContext.payload })
+              : renderPayloadScript({ ssrContext, data: ssrContext.payload })
+          ),
       routeOptions.experimentalNoScripts ? undefined : _rendered.renderScripts(),
       // Note: bodyScripts may contain tags other than <script>
       renderedMeta.bodyScripts

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -180,7 +180,10 @@ export default defineRenderHandler(async (event) => {
   }
 
   if (ssrError && event.node.req.socket.readyState !== 'readOnly' /* direct request */) {
-    throw createError('Cannot directly render error page!')
+    throw createError({
+      statusCode: 404,
+      statusMessage: process.dev ? '[nuxt] Cannot directly render error page.' : 'Page Not Found: /__nuxt_error'
+    })
   }
 
   // Check for island component rendering

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -182,7 +182,8 @@ export default defineRenderHandler(async (event) => {
   if (ssrError && event.node.req.socket.readyState !== 'readOnly' /* direct request */) {
     throw createError({
       statusCode: 404,
-      statusMessage: process.dev ? '[nuxt] Cannot directly render error page.' : 'Page Not Found: /__nuxt_error'
+      message: process.dev ? '[nuxt] Cannot directly render error page.' : undefined,
+      statusMessage: 'Page Not Found: /__nuxt_error'
     })
   }
 
@@ -307,13 +308,13 @@ export default defineRenderHandler(async (event) => {
       NO_SCRIPTS
         ? undefined
         : (_PAYLOAD_EXTRACTION
-            ? process.env.NUXT_JSON_PAYLOADS
-              ? renderPayloadJsonScript({ id: '__NUXT_DATA__', ssrContext, data: splitPayload(ssrContext).initial, src: payloadURL })
-              : renderPayloadScript({ ssrContext, data: splitPayload(ssrContext).initial, src: payloadURL })
-            : process.env.NUXT_JSON_PAYLOADS
-              ? renderPayloadJsonScript({ id: '__NUXT_DATA__', ssrContext, data: ssrContext.payload })
-              : renderPayloadScript({ ssrContext, data: ssrContext.payload })
-          ),
+          ? process.env.NUXT_JSON_PAYLOADS
+            ? renderPayloadJsonScript({ id: '__NUXT_DATA__', ssrContext, data: splitPayload(ssrContext).initial, src: payloadURL })
+            : renderPayloadScript({ ssrContext, data: splitPayload(ssrContext).initial, src: payloadURL })
+          : process.env.NUXT_JSON_PAYLOADS
+            ? renderPayloadJsonScript({ id: '__NUXT_DATA__', ssrContext, data: ssrContext.payload })
+            : renderPayloadScript({ ssrContext, data: ssrContext.payload })
+        ),
       routeOptions.experimentalNoScripts ? undefined : _rendered.renderScripts(),
       // Note: bodyScripts may contain tags other than <script>
       renderedMeta.bodyScripts

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -182,7 +182,6 @@ export default defineRenderHandler(async (event) => {
   if (ssrError && event.node.req.socket.readyState !== 'readOnly' /* direct request */) {
     throw createError({
       statusCode: 404,
-      message: process.dev ? '[nuxt] Cannot directly render error page.' : undefined,
       statusMessage: 'Page Not Found: /__nuxt_error'
     })
   }
@@ -308,13 +307,13 @@ export default defineRenderHandler(async (event) => {
       NO_SCRIPTS
         ? undefined
         : (_PAYLOAD_EXTRACTION
-            ? process.env.NUXT_JSON_PAYLOADS
-              ? renderPayloadJsonScript({ id: '__NUXT_DATA__', ssrContext, data: splitPayload(ssrContext).initial, src: payloadURL })
-              : renderPayloadScript({ ssrContext, data: splitPayload(ssrContext).initial, src: payloadURL })
-            : process.env.NUXT_JSON_PAYLOADS
-              ? renderPayloadJsonScript({ id: '__NUXT_DATA__', ssrContext, data: ssrContext.payload })
-              : renderPayloadScript({ ssrContext, data: ssrContext.payload })
-          ),
+          ? process.env.NUXT_JSON_PAYLOADS
+            ? renderPayloadJsonScript({ id: '__NUXT_DATA__', ssrContext, data: splitPayload(ssrContext).initial, src: payloadURL })
+            : renderPayloadScript({ ssrContext, data: splitPayload(ssrContext).initial, src: payloadURL })
+          : process.env.NUXT_JSON_PAYLOADS
+            ? renderPayloadJsonScript({ id: '__NUXT_DATA__', ssrContext, data: ssrContext.payload })
+            : renderPayloadScript({ ssrContext, data: ssrContext.payload })
+        ),
       routeOptions.experimentalNoScripts ? undefined : _rendered.renderScripts(),
       // Note: bodyScripts may contain tags other than <script>
       renderedMeta.bodyScripts

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -307,13 +307,13 @@ export default defineRenderHandler(async (event) => {
       NO_SCRIPTS
         ? undefined
         : (_PAYLOAD_EXTRACTION
-          ? process.env.NUXT_JSON_PAYLOADS
-            ? renderPayloadJsonScript({ id: '__NUXT_DATA__', ssrContext, data: splitPayload(ssrContext).initial, src: payloadURL })
-            : renderPayloadScript({ ssrContext, data: splitPayload(ssrContext).initial, src: payloadURL })
-          : process.env.NUXT_JSON_PAYLOADS
-            ? renderPayloadJsonScript({ id: '__NUXT_DATA__', ssrContext, data: ssrContext.payload })
-            : renderPayloadScript({ ssrContext, data: ssrContext.payload })
-        ),
+            ? process.env.NUXT_JSON_PAYLOADS
+              ? renderPayloadJsonScript({ id: '__NUXT_DATA__', ssrContext, data: splitPayload(ssrContext).initial, src: payloadURL })
+              : renderPayloadScript({ ssrContext, data: splitPayload(ssrContext).initial, src: payloadURL })
+            : process.env.NUXT_JSON_PAYLOADS
+              ? renderPayloadJsonScript({ id: '__NUXT_DATA__', ssrContext, data: ssrContext.payload })
+              : renderPayloadScript({ ssrContext, data: ssrContext.payload })
+          ),
       routeOptions.experimentalNoScripts ? undefined : _rendered.renderScripts(),
       // Note: bodyScripts may contain tags other than <script>
       renderedMeta.bodyScripts

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -574,6 +574,21 @@ describe('errors', () => {
     expect(await res.text()).toContain('This is a custom error')
   })
 
+  it('should not allow accessing error route directly', async () => {
+    const res = await fetch('/__nuxt_error')
+    expect(res.status).toBe(404)
+    const error = await res.json()
+    delete error.stack
+    expect(error).toMatchInlineSnapshot(`
+      {
+        "message": "Page Not Found: /__nuxt_error",
+        "statusCode": 404,
+        "statusMessage": "Page Not Found: /__nuxt_error",
+        "url": "/__nuxt_error",
+      }
+    `)
+  })
+
   // TODO: need to create test for webpack
   it.runIf(!isDev() && !isWebpack)('should handle chunk loading errors', async () => {
     const { page, consoleLogs } = await renderPage('/')

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -575,7 +575,11 @@ describe('errors', () => {
   })
 
   it('should not allow accessing error route directly', async () => {
-    const res = await fetch('/__nuxt_error')
+    const res = await fetch('/__nuxt_error', {
+      headers: {
+        accept: 'application/json'
+      }
+    })
     expect(res.status).toBe(404)
     const error = await res.json()
     delete error.stack


### PR DESCRIPTION
### 🔗 Linked issue

resolves #20490

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Rather than throw a more specific error, I think it is fair that `/__nuxt_error` should return a 404.

The error is constructed in the same way as upstream 404s (but I would suggest updating both to use `message` rather than `statusMessage`).

https://github.com/nuxt/nuxt/blob/f366ab4eb89c6f270ee1a0ae6e3f64d203a146c4/packages/nuxt/src/app/plugins/router.ts#L245-L248

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
