### PR TITLE
fix(nuxi,schema): support `devServer.https: true`

### DIFF
--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -62,8 +62,8 @@ export default defineNuxtCommand({
       hostname: args.host || args.h || process.env.NUXT_HOST || config.devServer.host,
       https: (args.https !== false && (args.https || config.devServer.https))
         ? {
-            cert: args['ssl-cert'] || (config.devServer.https && config.devServer.https.cert) || undefined,
-            key: args['ssl-key'] || (config.devServer.https && config.devServer.https.key) || undefined
+            cert: args['ssl-cert'] || (typeof config.devServer.https !== 'boolean' && config.devServer.https.cert) || undefined,
+            key: args['ssl-key'] || (typeof config.devServer.https !== 'boolean' && config.devServer.https.key) || undefined
           }
         : false
     })

--- a/packages/schema/src/config/dev.ts
+++ b/packages/schema/src/config/dev.ts
@@ -18,7 +18,7 @@ export default defineUntypedSchema({
      * ```
      *
      *
-     * @type {false | { key: string; cert: string }}
+     * @type {boolean | { key: string; cert: string }}
      *
      */
     https: false,


### PR DESCRIPTION
### 🔗 Linked issue

nuxt/nuxt#20435

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds support for setting `devServer.https` to `true` (rather than just an empty object) to enable SSL from within the `nuxt.config`.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
