### PR TITLE
feat(nuxt): add scoped helper for clearing error within boundary

### DIFF
--- a/docs/1.getting-started/8.error-handling.md
+++ b/docs/1.getting-started/8.error-handling.md
@@ -155,9 +155,9 @@ If you navigate to another route, the error will be cleared automatically.
   <!-- some content -->
   <NuxtErrorBoundary @error="someErrorLogger">
     <!-- You use the default slot to render your content -->
-    <template #error="{ error }">
-      You can display the error locally here.
-      <button @click="error = null">
+    <template #error="{ error, clearError }">
+      You can display the error locally here: {{ error }}
+      <button @click="clearError">
         This will clear the error.
       </button>
     </template>

--- a/packages/nuxt/src/app/components/nuxt-error-boundary.ts
+++ b/packages/nuxt/src/app/components/nuxt-error-boundary.ts
@@ -19,6 +19,10 @@ export default defineComponent({
       }
     })
 
-    return () => error.value ? slots.error?.({ error }) : slots.default?.()
+    function clearError () {
+      error.value = null
+    }
+
+    return () => error.value ? slots.error?.({ error, clearError }) : slots.default?.()
   }
 })


### PR DESCRIPTION
### 🔗 Linked issue

resolves #20453

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds a helper to clear error within `NuxtErrorBoundary` to avoid confusing behaviour with handling `error`.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
