### PR TITLE
fix(nuxt): call `app:error` in SSR before rendering error page

### DIFF
--- a/docs/1.getting-started/8.error-handling.md
+++ b/docs/1.getting-started/8.error-handling.md
@@ -41,6 +41,7 @@ This includes:
 
 * running Nuxt plugins
 * processing `app:created` and `app:beforeMount` hooks
+* rendering your Vue app to HTML (on the server)
 * mounting the app (on client-side), though you should handle this case with `onErrorCaptured` or with `vue:error`
 * processing the `app:mounted` hook
 

--- a/packages/nuxt/src/app/composables/cookie.ts
+++ b/packages/nuxt/src/app/composables/cookie.ts
@@ -48,11 +48,12 @@ export function useCookie <T = string | null | undefined> (name: string, _opts?:
       }
     }
     const unhook = nuxtApp.hooks.hookOnce('app:rendered', writeFinalCookieValue)
-    nuxtApp.hooks.hookOnce('app:redirected', () => {
-      // don't write cookie subsequently when app:rendered is called
-      unhook()
+    const writeAndUnhook = () => {
+      unhook() // don't write cookie subsequently when app:rendered is called
       return writeFinalCookieValue()
-    })
+    }
+    nuxtApp.hooks.hookOnce('app:error', writeAndUnhook)
+    nuxtApp.hooks.hookOnce('app:redirected', writeAndUnhook)
   }
 
   return cookie as CookieRef<T>

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -245,9 +245,9 @@ export default defineRenderHandler(async (event) => {
   }
 
   const _rendered = await renderer.renderToString(ssrContext).catch(async (error) => {
+    // Use explicitly thrown error in preference to subsequent rendering errors
     const _err = (!ssrError && ssrContext.payload?.error) || error
     await ssrContext.nuxt?.hooks.callHook('app:error', _err)
-    // Use explicitly thrown error in preference to subsequent rendering errors
     throw _err
   })
   await ssrContext.nuxt?.hooks.callHook('app:rendered', { ssrContext })

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -244,9 +244,11 @@ export default defineRenderHandler(async (event) => {
     writeEarlyHints(event, link)
   }
 
-  const _rendered = await renderer.renderToString(ssrContext).catch((error) => {
+  const _rendered = await renderer.renderToString(ssrContext).catch(async (error) => {
+    const _err = (!ssrError && ssrContext.payload?.error) || error
+    await ssrContext.nuxt?.hooks.callHook('app:error', _err)
     // Use explicitly thrown error in preference to subsequent rendering errors
-    throw (!ssrError && ssrContext.payload?.error) || error
+    throw _err
   })
   await ssrContext.nuxt?.hooks.callHook('app:rendered', { ssrContext })
 

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -571,6 +571,7 @@ describe('errors', () => {
 
   it('should render a HTML error page', async () => {
     const res = await fetch('/error')
+    expect(res.headers.get('Set-Cookie')).toBe('some-error=was%20set; Path=/')
     expect(await res.text()).toContain('This is a custom error')
   })
 

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -45,7 +45,7 @@ describe.skipIf(isWindows || process.env.TEST_BUILDER === 'webpack' || process.e
 
   it('default server bundle size', async () => {
     stats.server = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect(roundToKilobytes(stats.server.totalBytes)).toMatchInlineSnapshot('"67.2k"')
+    expect(roundToKilobytes(stats.server.totalBytes)).toMatchInlineSnapshot('"67.3k"')
 
     const modules = await analyzeSizes('node_modules/**/*', serverDir)
     expect(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot('"2657k"')

--- a/test/fixtures/basic/pages/error.vue
+++ b/test/fixtures/basic/pages/error.vue
@@ -11,6 +11,7 @@ const { data, error } = await useAsyncData(() => {
 }, { server: true })
 
 if (error.value) {
+  useCookie('some-error').value = 'was set'
   throw createError({ statusCode: 422, fatal: true, statusMessage: 'This is a custom error' })
 }
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves nuxt/nuxt#20183
resolves https://github.com/nuxt/nuxt/issues/20113

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR calls `app:error` when there's an error rendering to string and we'll directly return an error page. (Previously, it _only_ caught fatal errors in Nuxt plugins.) That allows us to hook into this for setting cookies, for example, as well as to provide some consistency when handling errors with hooks registered in nuxt plugins, and so on.

The one downside is that fatal errors in Nuxt plugins will now result in _two_ calls to `app:error`.

Alternatively, we could call `app:rendered` here - or add another hook (`app:render:error`?).

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
