### PR TITLE
fix(nuxt): improved typing support for app config

### DIFF
--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -222,15 +222,17 @@ declare const inlineConfig = ${JSON.stringify(nuxt.options.appConfig, null, 2)}
 type ResolvedAppConfig = Defu<typeof inlineConfig, [${app.configs.map((_id: string, index: number) => `typeof cfg${index}`).join(', ')}]>
 type IsAny<T> = 0 extends 1 & T ? true : false
 
-type MergedAppConfig<Resolved extends Record<string, any>, Custom extends Record<string, any>> = {
-  [K in keyof Resolved]: K extends keyof Custom
-    ? IsAny<Custom[K]> extends true
+type MergedAppConfig<Resolved extends Record<string, unknown>, Custom extends Record<string, unknown>> = {
+  [K in keyof (Resolved & Custom)]: K extends keyof Custom
+    ? unknown extends Custom[K]
       ? Resolved[K]
-      : Custom[K] extends Record<string, any>
-        ? Resolved[K] extends Record<string, any>
-          ? MergedAppConfig<Resolved[K], Custom[K]>
-          : Exclude<Custom[K], undefined>
-        : Exclude<Custom[K], undefined>
+      : IsAny<Custom[K]> extends true
+        ? Resolved[K]
+        : Custom[K] extends Record<string, any>
+            ? Resolved[K] extends Record<string, any>
+              ? MergedAppConfig<Resolved[K], Custom[K]>
+              : Exclude<Custom[K], undefined>
+            : Exclude<Custom[K], undefined>
     : Resolved[K]
 }
 

--- a/packages/schema/src/types/config.ts
+++ b/packages/schema/src/types/config.ts
@@ -138,7 +138,9 @@ export interface RuntimeConfig extends RuntimeConfigNamespace {
 
 // -- App Config --
 
-export interface CustomAppConfig { }
+export interface CustomAppConfig {
+  [key: string]: unknown
+}
 
 export interface AppConfigInput extends CustomAppConfig {
   /** @deprecated reserved */
@@ -158,4 +160,6 @@ export interface NuxtAppConfig {
   keepalive: boolean | KeepAliveProps
 }
 
-export interface AppConfig { }
+export interface AppConfig {
+  [key: string]: unknown
+}

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -145,6 +145,20 @@ export default defineNuxtConfig({
   },
   telemetry: false, // for testing telemetry types - it is auto-disabled in tests
   hooks: {
+    'schema:extend' (schemas) {
+      schemas.push({
+        appConfig: {
+          someThing: {
+            value: {
+              $default: 'default',
+              $schema: {
+                tsType: 'string | false'
+              }
+            }
+          }
+        }
+      })
+    },
     'prepare:types' ({ tsConfig }) {
       tsConfig.include = tsConfig.include!.filter(i => i !== '../../../../**/*')
     },

--- a/test/fixtures/basic/types.ts
+++ b/test/fixtures/basic/types.ts
@@ -295,6 +295,10 @@ describe('app config', () => {
         val: number
       }
       userConfig: 123 | 456
+      someThing?: {
+        value?: string | false,
+      }
+      [key: string]: unknown
     }
     expectTypeOf<AppConfig>().toEqualTypeOf<ExpectedMergedAppConfig>()
   })


### PR DESCRIPTION
### 🔗 Linked issue

closes https://github.com/nuxt/nuxt/pull/20440

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR bundles a few type fixes for app config:

1. First, it ensures that even keys that are not actually present in `appConfig` are represented in its types. This might affect modules that use custom schema. (resolves https://github.com/nuxt-modules/icon/issues/62)
2. Second, it ensures that keys can be set in `defineAppConfig` that are _not_ present on `AppConfigInput` (resolves https://github.com/nuxt-modules/icon/issues/72).

I've added a test to cover both.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
