### PR TITLE
fix(nuxt): throw errors when running legacy `asyncData`

### DIFF
--- a/packages/nuxt/src/app/composables/component.ts
+++ b/packages/nuxt/src/app/composables/component.ts
@@ -5,7 +5,7 @@ import type { NuxtApp } from '../nuxt'
 import { callWithNuxt, useNuxtApp } from '../nuxt'
 import { useAsyncData } from './asyncData'
 import { useRoute } from './router'
-import { createError, showError } from './error'
+import { createError } from './error'
 
 export const NuxtComponentIndicator = '__nuxt_component'
 
@@ -17,7 +17,7 @@ async function runLegacyAsyncData (res: Record<string, any> | Promise<Record<str
   const key = typeof fetchKey === 'function' ? fetchKey(() => '') : fetchKey || route.fullPath
   const { data, error } = await useAsyncData(`options:asyncdata:${key}`, () => callWithNuxt(nuxt, fn, [nuxt]))
   if (error.value) {
-    return showError(createError(error.value))
+    throw createError(error.value)
   }
   if (data.value && typeof data.value === 'object') {
     Object.assign(await res, toRefs(reactive(data.value)))

--- a/packages/nuxt/src/app/composables/component.ts
+++ b/packages/nuxt/src/app/composables/component.ts
@@ -5,7 +5,8 @@ import type { NuxtApp } from '../nuxt'
 import { callWithNuxt, useNuxtApp } from '../nuxt'
 import { useAsyncData } from './asyncData'
 import { useRoute } from './router'
-
+import { createError, showError } from "./error"
+ 
 export const NuxtComponentIndicator = '__nuxt_component'
 
 async function runLegacyAsyncData (res: Record<string, any> | Promise<Record<string, any>>, fn: (nuxtApp: NuxtApp) => Promise<Record<string, any>>) {
@@ -14,7 +15,10 @@ async function runLegacyAsyncData (res: Record<string, any> | Promise<Record<str
   const vm = getCurrentInstance()!
   const { fetchKey } = vm.proxy!.$options
   const key = typeof fetchKey === 'function' ? fetchKey(() => '') : fetchKey || route.fullPath
-  const { data } = await useAsyncData(`options:asyncdata:${key}`, () => callWithNuxt(nuxt, fn, [nuxt]))
+  const { data, error } = await useAsyncData(`options:asyncdata:${key}`, () => callWithNuxt(nuxt, fn, [nuxt]))
+  if (error.value) {
+    return showError(createError(error.value))
+  }
   if (data.value && typeof data.value === 'object') {
     Object.assign(await res, toRefs(reactive(data.value)))
   } else if (process.dev) {

--- a/packages/nuxt/src/app/composables/component.ts
+++ b/packages/nuxt/src/app/composables/component.ts
@@ -5,8 +5,8 @@ import type { NuxtApp } from '../nuxt'
 import { callWithNuxt, useNuxtApp } from '../nuxt'
 import { useAsyncData } from './asyncData'
 import { useRoute } from './router'
-import { createError, showError } from "./error"
- 
+import { createError, showError } from './error'
+
 export const NuxtComponentIndicator = '__nuxt_component'
 
 async function runLegacyAsyncData (res: Record<string, any> | Promise<Record<string, any>>, fn: (nuxtApp: NuxtApp) => Promise<Record<string, any>>) {

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -360,7 +360,6 @@ describe('pages', () => {
     const response = await fetch('/legacy-async-data-fail').then(r => r.text())
     expect(response).not.toContain('don\'t look at this')
     expect(response).toContain('OH NNNNNNOOOOOOOOOOO')
-    await page.close()
   })
 })
 

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -357,9 +357,10 @@ describe('pages', () => {
   })
 
   it('/legacy-async-data-fail', async () => {
-    const response = await $fetch('/legacy-async-data-fail').catch(error => error.data)
+    const response = await fetch('/legacy-async-data-fail').then(r => r.text())
     expect(response).not.toContain('don\'t look at this')
     expect(response).toContain('OH NNNNNNOOOOOOOOOOO')
+    await page.close()
   })
 })
 

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -357,11 +357,9 @@ describe('pages', () => {
   })
 
   it('/legacy-async-data-fail', async () => {
-    const page = await createPage('/legacy-async-data-fail') 
-    const html  = await page.content()
-    expect(html).not.toContain('don\'t look at this')
-    expect(html).toContain('This is the error page')
-    expect(html).toContain('OH NNNNNNOOOOOOOOOOO')
+    const response = await $fetch('/legacy-async-data-fail').catch(error => error.data)  
+    expect(response).not.toContain('don\'t look at this')
+    expect(response).toContain('OH NNNNNNOOOOOOOOOOO')
   })
 })
 

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -353,6 +353,15 @@ describe('pages', () => {
     await page.waitForLoadState('networkidle')
     expect(await page.locator('#async-server-component-count').innerHTML()).toContain(('1'))
     expect(await page.locator('#long-async-component-count').innerHTML()).toContain('1')
+    await page.close()
+  })
+
+  it('/legacy-async-data-fail', async () => {
+    const page = await createPage('/legacy-async-data-fail') 
+    const html  = await page.content()
+    expect(html).not.toContain('don\'t look at this')
+    expect(html).toContain('This is the error page')
+    expect(html).toContain('OH NNNNNNOOOOOOOOOOO')
   })
 })
 

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -357,8 +357,8 @@ describe('pages', () => {
   })
 
   it('/legacy-async-data-fail', async () => {
-    const page = await createPage('/legacy-async-data-fail') 
-    const html  = await page.content()
+    const page = await createPage('/legacy-async-data-fail')
+    const html = await page.content()
     expect(html).not.toContain('don\'t look at this')
     expect(html).toContain('This is the error page')
     expect(html).toContain('OH NNNNNNOOOOOOOOOOO')

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -357,7 +357,7 @@ describe('pages', () => {
   })
 
   it('/legacy-async-data-fail', async () => {
-    const response = await $fetch('/legacy-async-data-fail').catch(error => error.data)  
+    const response = await $fetch('/legacy-async-data-fail').catch(error => error.data)
     expect(response).not.toContain('don\'t look at this')
     expect(response).toContain('OH NNNNNNOOOOOOOOOOO')
   })

--- a/test/fixtures/basic/pages/legacy-async-data-fail.vue
+++ b/test/fixtures/basic/pages/legacy-async-data-fail.vue
@@ -1,0 +1,13 @@
+<template>
+    <div>
+        don't look at this
+    </div>
+</template>
+
+<script lang="ts">
+export default defineNuxtComponent({
+    asyncData() {
+        throw 'OH NNNNNNOOOOOOOOOOO'
+    }
+})
+</script>

--- a/test/fixtures/basic/pages/legacy-async-data-fail.vue
+++ b/test/fixtures/basic/pages/legacy-async-data-fail.vue
@@ -7,7 +7,7 @@
 <script lang="ts">
 export default defineNuxtComponent({
     asyncData() {
-        throw 'OH NNNNNNOOOOOOOOOOO'
+        throw new Error('OH NNNNNNOOOOOOOOOOO')
     }
 })
 </script>

--- a/test/fixtures/basic/pages/legacy-async-data-fail.vue
+++ b/test/fixtures/basic/pages/legacy-async-data-fail.vue
@@ -1,13 +1,13 @@
 <template>
-    <div>
-        don't look at this
-    </div>
+  <div>
+    don't look at this
+  </div>
 </template>
 
 <script lang="ts">
 export default defineNuxtComponent({
-    asyncData() {
-        throw new Error('OH NNNNNNOOOOOOOOOOO')
-    }
+  asyncData () {
+    throw new Error('OH NNNNNNOOOOOOOOOOO')
+  }
 })
 </script>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
resolve #19625
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Currently nothing happens when an error si thrown in the legacy `asyncData`. This PR add `showError` when an `asyncData` throws an error. 
Useful for users that are migrating from Nuxt 2 or option API users
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
