### PR TITLE
fix(nuxt): restrict access to single renderer outside of test/rootDir

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-root.vue
+++ b/packages/nuxt/src/app/components/nuxt-root.vue
@@ -23,7 +23,7 @@ const nuxtApp = useNuxtApp()
 const onResolve = nuxtApp.deferHydration()
 
 const url = process.server ? nuxtApp.ssrContext.url : window.location.pathname
-const SingleRenderer = process.dev && process.server && url.startsWith('/__nuxt_component_test__/') && defineAsyncComponent(() => import('#build/test-component-wrapper.mjs')
+const SingleRenderer = process.test && process.dev && process.server && url.startsWith('/__nuxt_component_test__/') && /* #__PURE__ */ defineAsyncComponent(() => import('#build/test-component-wrapper.mjs')
   .then(r => r.default(process.server ? url : window.location.href)))
 
 // Inject default route (outside of pages) as active route

--- a/packages/nuxt/src/app/components/test-component-wrapper.ts
+++ b/packages/nuxt/src/app/components/test-component-wrapper.ts
@@ -1,13 +1,20 @@
 import { parseURL } from 'ufo'
 import { defineComponent, h } from 'vue'
 import { parseQuery } from 'vue-router'
+import { resolve } from 'pathe'
+// @ts-expect-error virtual file
+import { devRootDir } from '#build/nuxt.config.mjs'
 
-export default (url:string) => defineComponent({
+export default (url: string) => defineComponent({
   name: 'NuxtTestComponentWrapper',
 
   async setup (props, { attrs }) {
     const query = parseQuery(parseURL(url).search)
     const urlProps = query.props ? JSON.parse(query.props as string) : {}
+    const path = resolve(query.path as string)
+    if (!path.startsWith(devRootDir)) {
+      throw new Error(`[nuxt] Cannot access path outside of project root directory: \`${path}\`.`)
+    }
     const comp = await import(/* @vite-ignore */ query.path as string).then(r => r.default)
     return () => [
       h('div', 'Component Test Wrapper for ' + query.path),

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -299,7 +299,8 @@ export const nuxtConfigTemplate = {
     return [
       ...Object.entries(ctx.nuxt.options.app).map(([k, v]) => `export const ${camelCase('app-' + k)} = ${JSON.stringify(v)}`),
       `export const renderJsonPayloads = ${!!ctx.nuxt.options.experimental.renderJsonPayloads}`,
-      `export const devPagesDir = ${ctx.nuxt.options.dev ? JSON.stringify(ctx.nuxt.options.dir.pages) : 'null'}`
+      `export const devPagesDir = ${ctx.nuxt.options.dev ? JSON.stringify(ctx.nuxt.options.dir.pages) : 'null'}`,
+      `export const devRootDir = ${ctx.nuxt.options.dev ? JSON.stringify(ctx.nuxt.options.rootDir) : 'null'}`
     ].join('\n\n')
   }
 }

--- a/packages/schema/src/config/vite.ts
+++ b/packages/schema/src/config/vite.ts
@@ -1,4 +1,5 @@
 import { resolve } from 'pathe'
+import { isTest } from 'std-env'
 import { withoutLeadingSlash } from 'ufo'
 import { defineUntypedSchema } from 'untyped'
 
@@ -21,6 +22,7 @@ export default defineUntypedSchema({
     define: {
       $resolve: async (val, get) => ({
         'process.dev': await get('dev'),
+        'process.test': isTest,
         ...val || {}
       })
     },

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -45,6 +45,7 @@
     "postcss-import": "^15.1.0",
     "postcss-loader": "^7.2.4",
     "postcss-url": "^10.1.3",
+    "std-env": "^3.3.2",
     "time-fix-plugin": "^2.0.7",
     "ufo": "^1.1.1",
     "unplugin": "^1.3.1",

--- a/packages/webpack/src/presets/base.ts
+++ b/packages/webpack/src/presets/base.ts
@@ -10,6 +10,7 @@ import FriendlyErrorsWebpackPlugin from '@nuxt/friendly-errors-webpack-plugin'
 import escapeRegExp from 'escape-string-regexp'
 import { joinURL } from 'ufo'
 import type { NuxtOptions } from '@nuxt/schema'
+import { isTest } from 'std-env'
 import type { WarningFilter } from '../plugins/warning-ignore'
 import WarningIgnorePlugin from '../plugins/warning-ignore'
 import type { WebpackConfigContext } from '../utils/config'
@@ -233,6 +234,7 @@ function getEnv (ctx: WebpackConfigContext) {
     'process.env.NODE_ENV': JSON.stringify(ctx.config.mode),
     'process.mode': JSON.stringify(ctx.config.mode),
     'process.dev': options.dev,
+    'process.test': isTest,
     __NUXT_VERSION__: JSON.stringify(ctx.nuxt._version),
     'process.env.VUE_ENV': JSON.stringify(ctx.name),
     'process.browser': ctx.isClient,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1044,6 +1044,9 @@ importers:
       postcss-url:
         specifier: ^10.1.3
         version: 10.1.3(postcss@8.4.23)
+      std-env:
+        specifier: ^3.3.2
+        version: 3.3.2
       time-fix-plugin:
         specifier: ^2.0.7
         version: 2.0.7(webpack@5.80.0)


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In dev mode, it was possible to import arbitrary paths via the `/__nuxt_component_test__` endpoint. That is a problem because if you click a crafted URL you could execute JS on someone's dev server. This change restricts that to test mode only (also adding `process.test`) which does not listen to a public hostname. In addition, we also ensure that any imports are located within the project `rootDir`.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
