### PR TITLE
fix(nuxt): transform `#components` imports into direct component imports

### DIFF
--- a/packages/nuxt/src/components/module.ts
+++ b/packages/nuxt/src/components/module.ts
@@ -120,7 +120,7 @@ export default defineNuxtModule<ComponentsOptions>({
     addTemplate({ ...componentsTemplate, filename: 'components.server.mjs', options: { getComponents, mode: 'server' } })
     // components.client.mjs
     addTemplate({ ...componentsTemplate, filename: 'components.client.mjs', options: { getComponents, mode: 'client' } })
-    // components-names.mjs
+    // component-names.mjs
     addTemplate({ ...componentNamesTemplate, options: { getComponents, mode: 'all' } })
     // components.islands.mjs
     if (nuxt.options.experimental.componentIslands) {

--- a/packages/nuxt/src/components/module.ts
+++ b/packages/nuxt/src/components/module.ts
@@ -5,7 +5,7 @@ import type { Component, ComponentsDir, ComponentsOptions } from 'nuxt/schema'
 
 import { distDir } from '../dirs'
 import { clientFallbackAutoIdPlugin } from './client-fallback-auto-id'
-import { componentNamesTemplate, componentsIslandsTemplate, componentsPluginTemplate, componentsTemplate, componentsTypeTemplate } from './templates'
+import { componentNamesTemplate, componentsIslandsTemplate, componentsPluginTemplate, componentsTypeTemplate } from './templates'
 import { scanComponents } from './scan'
 import { loaderPlugin } from './loader'
 import { TreeShakeTemplatePlugin } from './tree-shake'
@@ -116,10 +116,6 @@ export default defineNuxtModule<ComponentsOptions>({
     addTemplate({ ...componentsTypeTemplate, options: { getComponents } })
     // components.plugin.mjs
     addPluginTemplate({ ...componentsPluginTemplate, options: { getComponents } } as any)
-    // components.server.mjs
-    addTemplate({ ...componentsTemplate, filename: 'components.server.mjs', options: { getComponents, mode: 'server' } })
-    // components.client.mjs
-    addTemplate({ ...componentsTemplate, filename: 'components.client.mjs', options: { getComponents, mode: 'client' } })
     // component-names.mjs
     addTemplate({ ...componentNamesTemplate, options: { getComponents, mode: 'all' } })
     // components.islands.mjs
@@ -137,17 +133,6 @@ export default defineNuxtModule<ComponentsOptions>({
 
     addWebpackPlugin(unpluginServer.webpack(), { server: true, client: false })
     addWebpackPlugin(unpluginClient.webpack(), { server: false, client: true })
-
-    nuxt.hook('vite:extendConfig', (config, { isClient }) => {
-      const mode = isClient ? 'client' : 'server'
-        ; (config.resolve!.alias as any)['#components-global'] = resolve(nuxt.options.buildDir, `components.${mode}.mjs`)
-    })
-    nuxt.hook('webpack:config', (configs) => {
-      for (const config of configs) {
-        const mode = config.name === 'server' ? 'server' : 'client'
-          ; (config.resolve!.alias as any)['#components-global'] = resolve(nuxt.options.buildDir, `components.${mode}.mjs`)
-      }
-    })
 
     // Do not prefetch global components chunks
     nuxt.hook('build:manifest', (manifest) => {

--- a/packages/nuxt/src/components/module.ts
+++ b/packages/nuxt/src/components/module.ts
@@ -5,7 +5,7 @@ import type { Component, ComponentsDir, ComponentsOptions } from 'nuxt/schema'
 
 import { distDir } from '../dirs'
 import { clientFallbackAutoIdPlugin } from './client-fallback-auto-id'
-import { componentsIslandsTemplate, componentsPluginTemplate, componentsTemplate, componentsTypeTemplate } from './templates'
+import { componentNamesTemplate, componentsIslandsTemplate, componentsPluginTemplate, componentsTemplate, componentsTypeTemplate } from './templates'
 import { scanComponents } from './scan'
 import { loaderPlugin } from './loader'
 import { TreeShakeTemplatePlugin } from './tree-shake'
@@ -120,6 +120,8 @@ export default defineNuxtModule<ComponentsOptions>({
     addTemplate({ ...componentsTemplate, filename: 'components.server.mjs', options: { getComponents, mode: 'server' } })
     // components.client.mjs
     addTemplate({ ...componentsTemplate, filename: 'components.client.mjs', options: { getComponents, mode: 'client' } })
+    // components-names.mjs
+    addTemplate({ ...componentNamesTemplate, options: { getComponents, mode: 'all' } })
     // components.islands.mjs
     if (nuxt.options.experimental.componentIslands) {
       addTemplate({ ...componentsIslandsTemplate, filename: 'components.islands.mjs', options: { getComponents } })

--- a/packages/nuxt/src/components/templates.ts
+++ b/packages/nuxt/src/components/templates.ts
@@ -1,5 +1,5 @@
 import { isAbsolute, relative } from 'pathe'
-import { genDynamicImport, genExport, genImport, genObjectFromRawEntries } from 'knitwork'
+import { genDynamicImport } from 'knitwork'
 import type { Component, Nuxt, NuxtPluginTemplate, NuxtTemplate } from 'nuxt/schema'
 
 export interface ComponentsTemplateContext {
@@ -25,24 +25,33 @@ const createImportMagicComments = (options: ImportMagicCommentsOptions) => {
   ].filter(Boolean).join(', ')
 }
 
+const emptyComponentsPlugin = `
+import { defineNuxtPlugin } from '#app/nuxt'
+export default defineNuxtPlugin({
+  name: 'nuxt:global-components',
+})
+`
+
 export const componentsPluginTemplate: NuxtPluginTemplate<ComponentsTemplateContext> = {
   filename: 'components.plugin.mjs',
   getContents ({ options }) {
-    const enableGlobal = options.getComponents().filter(c => c.global).length > 0
+    const globalComponents = options.getComponents().filter(c => c.global)
+    if (!globalComponents.length) { return emptyComponentsPlugin }
+
     return `import { defineNuxtPlugin } from '#app/nuxt'
-${enableGlobal ? 'import { lazyGlobalComponents } from \'#components-global\'' : ''}
+import { ${globalComponents.map(c => 'Lazy' + c.pascalName).join(', ')} } from '#components'
+const lazyGlobalComponents = [
+  ${globalComponents.map(c => `["${c.pascalName}", Lazy${c.pascalName}]`).join(',\n')}
+]
 
 export default defineNuxtPlugin({
-  name: 'nuxt:global-components',` +
-      (enableGlobal
-        ? `
+  name: 'nuxt:global-components',
   setup (nuxtApp) {
-    for (const name in lazyGlobalComponents) {
-      nuxtApp.vueApp.component(name, lazyGlobalComponents[name])
-      nuxtApp.vueApp.component('Lazy' + name, lazyGlobalComponents[name])
+    for (const [name, component] of lazyGlobalComponents) {
+      nuxtApp.vueApp.component(name, component)
+      nuxtApp.vueApp.component('Lazy' + name, component)
     }
-  }`
-        : '') + `
+  }
 })
 `
   }
@@ -52,40 +61,6 @@ export const componentNamesTemplate: NuxtPluginTemplate<ComponentsTemplateContex
   filename: 'component-names.mjs',
   getContents ({ options }) {
     return `export const componentNames = ${JSON.stringify(options.getComponents().filter(c => !c.island).map(c => c.pascalName))}`
-  }
-}
-
-export const componentsTemplate: NuxtTemplate<ComponentsTemplateContext> = {
-  // components.[server|client].mjs'
-  getContents ({ options }) {
-    const imports = new Set<string>()
-    imports.add('import { defineAsyncComponent } from \'vue\'')
-
-    let num = 0
-    const components = options.getComponents(options.mode).filter(c => !c.island).flatMap((c) => {
-      const exp = c.export === 'default' ? 'c.default || c' : `c['${c.export}']`
-      const comment = createImportMagicComments(c)
-
-      const isClient = c.mode === 'client'
-      const definitions = []
-      if (isClient) {
-        num++
-        const identifier = `__nuxt_component_${num}`
-        imports.add(genImport('#app/components/client-only', [{ name: 'createClientOnly' }]))
-        imports.add(genImport(c.filePath, [{ name: c.export, as: identifier }]))
-        definitions.push(`export const ${c.pascalName} = /* #__PURE__ */ createClientOnly(${identifier})`)
-      } else {
-        definitions.push(genExport(c.filePath, [{ name: c.export, as: c.pascalName }]))
-      }
-      definitions.push(`export const Lazy${c.pascalName} = /* #__PURE__ */ defineAsyncComponent(${genDynamicImport(c.filePath, { comment })}.then(c => ${isClient ? `createClientOnly(${exp})` : exp}))`)
-      return definitions
-    })
-    return [
-      ...imports,
-      ...components,
-      `export const lazyGlobalComponents = ${genObjectFromRawEntries(options.getComponents().filter(c => c.global).map(c => [c.pascalName, `Lazy${c.pascalName}`]))}`,
-      `export const componentNames = ${JSON.stringify(options.getComponents().filter(c => !c.island).map(c => c.pascalName))}`
-    ].join('\n')
   }
 }
 

--- a/packages/nuxt/src/components/templates.ts
+++ b/packages/nuxt/src/components/templates.ts
@@ -28,12 +28,13 @@ const createImportMagicComments = (options: ImportMagicCommentsOptions) => {
 export const componentsPluginTemplate: NuxtPluginTemplate<ComponentsTemplateContext> = {
   filename: 'components.plugin.mjs',
   getContents ({ options }) {
+    const enableGlobal = options.getComponents().filter(c => c.global).length > 0
     return `import { defineNuxtPlugin } from '#app/nuxt'
-import { lazyGlobalComponents } from '#components'
+${enableGlobal ? 'import { lazyGlobalComponents } from \'#components-global\'' : ''}
 
 export default defineNuxtPlugin({
   name: 'nuxt:global-components',` +
-      (options.getComponents().filter(c => c.global).length
+      (enableGlobal
         ? `
   setup (nuxtApp) {
     for (const name in lazyGlobalComponents) {

--- a/packages/nuxt/src/components/templates.ts
+++ b/packages/nuxt/src/components/templates.ts
@@ -49,7 +49,7 @@ export default defineNuxtPlugin({
 }
 
 export const componentNamesTemplate: NuxtPluginTemplate<ComponentsTemplateContext> = {
-  filename: 'components-names.mjs',
+  filename: 'component-names.mjs',
   getContents ({ options }) {
     return `export const componentNames = ${JSON.stringify(options.getComponents().filter(c => !c.island).map(c => c.pascalName))}`
   }

--- a/packages/nuxt/src/components/templates.ts
+++ b/packages/nuxt/src/components/templates.ts
@@ -48,6 +48,13 @@ export default defineNuxtPlugin({
   }
 }
 
+export const componentNamesTemplate: NuxtPluginTemplate<ComponentsTemplateContext> = {
+  filename: 'components-names.mjs',
+  getContents ({ options }) {
+    return `export const componentNames = ${JSON.stringify(options.getComponents().filter(c => !c.island).map(c => c.pascalName))}`
+  }
+}
+
 export const componentsTemplate: NuxtTemplate<ComponentsTemplateContext> = {
   // components.[server|client].mjs'
   getContents ({ options }) {

--- a/packages/nuxt/src/components/transform.ts
+++ b/packages/nuxt/src/components/transform.ts
@@ -9,7 +9,12 @@ import type { getComponentsT } from './module'
 
 export function createTransformPlugin (nuxt: Nuxt, getComponents: getComponentsT, mode: 'client' | 'server' | 'all') {
   const componentUnimport = createUnimport({
-    imports: [],
+    imports: [
+      {
+        name: 'componentNames',
+        from: '#build/components-names'
+      }
+    ],
     virtualImports: ['#components']
   })
 

--- a/packages/nuxt/src/components/transform.ts
+++ b/packages/nuxt/src/components/transform.ts
@@ -1,0 +1,90 @@
+import { isIgnored } from '@nuxt/kit'
+import type { Nuxt } from 'nuxt/schema'
+import type { Import } from 'unimport'
+import { createUnimport } from 'unimport'
+import { createUnplugin } from 'unplugin'
+import { parseURL } from 'ufo'
+import { parseQuery } from 'vue-router'
+import type { getComponentsT } from './module'
+
+export function createTransformPlugin (nuxt: Nuxt, getComponents: getComponentsT, mode: 'client' | 'server' | 'all') {
+  const componentUnimport = createUnimport({
+    imports: [],
+    virtualImports: ['#components']
+  })
+
+  function getComponentsImports (): Import[] {
+    const components = getComponents(mode)
+    return components.flatMap((c): Import[] => {
+      return [
+        {
+          as: c.pascalName,
+          from: c.filePath + (c.mode === 'client' ? '?component=client' : ''),
+          name: 'default'
+        },
+        {
+          as: 'Lazy' + c.pascalName,
+          from: c.filePath + '?component=' + [c.mode === 'client' ? 'client' : '', 'async'].filter(Boolean).join(','),
+          name: 'default'
+        }
+      ]
+    })
+  }
+
+  return createUnplugin(() => ({
+    name: 'nuxt:components:imports',
+    transformInclude (id) {
+      return !isIgnored(id)
+    },
+    async transform (code, id) {
+      // Virtual component wrapper
+      if (id.includes('?component')) {
+        const { search } = parseURL(id)
+        const query = parseQuery(search)
+        const mode = query.component
+        const bare = id.replace(/\?.*/, '')
+        if (mode === 'async') {
+          return [
+            'import { defineAsyncComponent } from "vue"',
+            `export default defineAsyncComponent(() => import(${JSON.stringify(bare)}).then(r => r.default))`
+          ].join('\n')
+        } else if (mode === 'client') {
+          return [
+            `import __component from ${JSON.stringify(bare)}`,
+            'import { createClientOnly } from "#app/components/client-only"',
+            'export default createClientOnly(__component)'
+          ].join('\n')
+        } else if (mode === 'client,async') {
+          return [
+            'import { defineAsyncComponent } from "vue"',
+            'import { createClientOnly } from "#app/components/client-only"',
+            `export default defineAsyncComponent(() => import(${JSON.stringify(bare)}).then(r => createClientOnly(r.default)))`
+          ].join('\n')
+        } else {
+          throw new Error(`Unknown component mode: ${mode}, this might be an internal bug of Nuxt.`)
+        }
+      }
+
+      if (!code.includes('#components')) {
+        return null
+      }
+
+      componentUnimport.modifyDynamicImports((imports) => {
+        imports.length = 0
+        imports.push(...getComponentsImports())
+        return imports
+      })
+
+      const result = await componentUnimport.injectImports(code, id, { autoImport: false, transformVirtualImports: true })
+      if (!result) {
+        return null
+      }
+      return {
+        code: result.code,
+        map: nuxt.options.sourcemap
+          ? result.s.generateMap({ hires: true })
+          : undefined
+      }
+    }
+  }))
+}

--- a/packages/nuxt/src/components/transform.ts
+++ b/packages/nuxt/src/components/transform.ts
@@ -12,7 +12,7 @@ export function createTransformPlugin (nuxt: Nuxt, getComponents: getComponentsT
     imports: [
       {
         name: 'componentNames',
-        from: '#build/components-names'
+        from: '#build/component-names'
       }
     ],
     virtualImports: ['#components']

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -34,7 +34,7 @@ describe.skipIf(isWindows || process.env.TEST_BUILDER === 'webpack' || process.e
 
   it('default client bundle size', async () => {
     stats.client = await analyzeSizes('**/*.js', publicDir)
-    expect(roundToKilobytes(stats.client.totalBytes)).toMatchInlineSnapshot('"94.4k"')
+    expect(roundToKilobytes(stats.client.totalBytes)).toMatchInlineSnapshot('"94.3k"')
     expect(stats.client.files.map(f => f.replace(/\..*\.js/, '.js'))).toMatchInlineSnapshot(`
       [
         "_nuxt/entry.js",
@@ -45,10 +45,10 @@ describe.skipIf(isWindows || process.env.TEST_BUILDER === 'webpack' || process.e
 
   it('default server bundle size', async () => {
     stats.server = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect(roundToKilobytes(stats.server.totalBytes)).toMatchInlineSnapshot('"67.2k"')
+    expect(roundToKilobytes(stats.server.totalBytes)).toMatchInlineSnapshot('"66.8k"')
 
     const modules = await analyzeSizes('node_modules/**/*', serverDir)
-    expect(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot('"2657k"')
+    expect(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot('"2654k"')
 
     const packages = modules.files
       .filter(m => m.endsWith('package.json'))
@@ -76,7 +76,6 @@ describe.skipIf(isWindows || process.env.TEST_BUILDER === 'webpack' || process.e
         "h3",
         "hookable",
         "iron-webcrypto",
-        "klona",
         "node-fetch-native",
         "ofetch",
         "ohash",

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -45,7 +45,7 @@ describe.skipIf(isWindows || process.env.TEST_BUILDER === 'webpack' || process.e
 
   it('default server bundle size', async () => {
     stats.server = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect(roundToKilobytes(stats.server.totalBytes)).toMatchInlineSnapshot('"67.3k"')
+    expect(roundToKilobytes(stats.server.totalBytes)).toMatchInlineSnapshot('"66.8k"')
 
     const modules = await analyzeSizes('node_modules/**/*', serverDir)
     expect(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot('"2654k"')


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

closes #20492 (as a better fix)

resolves https://github.com/nuxt/nuxt/issues/20439
resolves https://github.com/nuxt/nuxt/issues/20450
resolves nuxt/nuxt#20449

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

With https://github.com/nuxt/nuxt/issues/20259, it becomes more difficult for rollup to tree-shake out unused components, and side effects were persisting in the entry file. This change transforms imports from `#components` into individual imports of each component, meaning that there should be no possibility of side-effects from unused components.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
