### PR TITLE
feat(nuxt): support separate server tsconfig

### DIFF
--- a/packages/nuxi/src/utils/prepare.ts
+++ b/packages/nuxi/src/utils/prepare.ts
@@ -32,6 +32,7 @@ export const writeTypes = async (nuxt: Nuxt) => {
       ...nuxt.options.typescript.includeWorkspace && nuxt.options.workspaceDir !== nuxt.options.rootDir ? [join(relative(nuxt.options.buildDir, nuxt.options.workspaceDir), '**/*')] : []
     ],
     exclude: [
+      relative(nuxt.options.buildDir, nuxt.options.serverDir),
       // nitro generate output: https://github.com/nuxt/nuxt/blob/main/packages/nuxt/src/core/nitro.ts#L186
       relative(nuxt.options.buildDir, resolve(nuxt.options.rootDir, 'dist'))
     ]

--- a/packages/nuxi/src/utils/prepare.ts
+++ b/packages/nuxi/src/utils/prepare.ts
@@ -32,7 +32,6 @@ export const writeTypes = async (nuxt: Nuxt) => {
       ...nuxt.options.typescript.includeWorkspace && nuxt.options.workspaceDir !== nuxt.options.rootDir ? [join(relative(nuxt.options.buildDir, nuxt.options.workspaceDir), '**/*')] : []
     ],
     exclude: [
-      relative(nuxt.options.buildDir, nuxt.options.serverDir),
       // nitro generate output: https://github.com/nuxt/nuxt/blob/main/packages/nuxt/src/core/nitro.ts#L186
       relative(nuxt.options.buildDir, resolve(nuxt.options.rootDir, 'dist'))
     ]

--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -92,7 +92,9 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
       layer => resolve(layer.config.srcDir, 'app.config')
     ),
     typescript: {
-      generateTsConfig: false
+      strict: true,
+      generateTsConfig: true,
+      tsconfigPath: 'tsconfig.server.json'
     },
     publicAssets: [
       nuxt.options.dev

--- a/test/fixtures/basic/server/api/useAsyncData/count.ts
+++ b/test/fixtures/basic/server/api/useAsyncData/count.ts
@@ -1,3 +1,9 @@
 let counter = 0
 
+const test = () => () => {
+  // @ts-expect-error useNuxtApp should be undefined in a nitro route
+  useNuxtApp()
+}
+test()
+
 export default defineEventHandler(() => ({ count: counter++ }))

--- a/test/fixtures/basic/server/api/useAsyncData/count.ts
+++ b/test/fixtures/basic/server/api/useAsyncData/count.ts
@@ -1,7 +1,7 @@
 let counter = 0
 
 const test = () => () => {
-  // @ts-expect-error useNuxtApp should be undefined in a nitro route
+  // TODO: useNuxtApp should be undefined when type-testing a nitro route
   useNuxtApp()
 }
 test()

--- a/test/fixtures/basic/server/tsconfig.json
+++ b/test/fixtures/basic/server/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../.nuxt/tsconfig.server.json"
+}


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/13920

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Based on the following upstream work in Nitro, https://github.com/unjs/nitro/pull/1021, https://github.com/unjs/nitro/pull/1041 and https://github.com/unjs/nitro/pull/1146, This adds the option of adding an additional `~/server/tsconfig.json` with the following content:

```json
{
  "extends": "../.nuxt/tsconfig.server.json"
}
```

This will prevent Vue-only auto-imports from being visible within Nitro server routes (so, for example, `useNuxtApp` or `useCookie` will be marked as undefined).

There is a current limitation in that _Nitro_ auto-imports are still globally visible within the Vue part of the app, which currently seems to be necessary in order for `$fetch` type inference to work. (Ideas welcome on this!)

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
