### PR TITLE
fix(nuxt): skip payload extraction for island context

### DIFF
--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -199,7 +199,7 @@ export default defineRenderHandler(async (event): Promise<Partial<RenderResponse
   let url = ssrError?.url as string || islandContext?.url || event.node.req.url!
 
   // Whether we are rendering payload route
-  const isRenderingPayload = PAYLOAD_URL_RE.test(url)
+  const isRenderingPayload = PAYLOAD_URL_RE.test(url) && !islandContext
   if (isRenderingPayload) {
     url = url.substring(0, url.lastIndexOf('/')) || '/'
     event.node.req.url = url
@@ -229,7 +229,7 @@ export default defineRenderHandler(async (event): Promise<Partial<RenderResponse
   }
 
   // Whether we are prerendering route
-  const _PAYLOAD_EXTRACTION = process.env.prerender && process.env.NUXT_PAYLOAD_EXTRACTION && !ssrContext.noSSR
+  const _PAYLOAD_EXTRACTION = process.env.prerender && process.env.NUXT_PAYLOAD_EXTRACTION && !ssrContext.noSSR && !islandContext
   const payloadURL = _PAYLOAD_EXTRACTION ? joinURL(useRuntimeConfig().app.baseURL, url, process.env.NUXT_JSON_PAYLOADS ? '_payload.json' : '_payload.js') : undefined
   if (process.env.prerender) {
     ssrContext.payload.prerenderedAt = Date.now()


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

https://github.com/harlan-zw/nuxt-og-image/issues/35

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

When prerendering a Nuxt app that uses Nuxt Islands components, the home page payload will be reset whenever an Island component is rendered.

The consequence of this for prerendered static Nuxt apps is that any data fetching required for the home page won't work, potentially breaking the page.

### Reproduction

https://stackblitz.com/edit/nuxt-starter-iqevpt?file=pages/z.vue

- `nuxi generate`
- `cat .output/public/_payload.js` (you'll see `export default {data:{},prerenderedAt:1682833083825}` which is not correct)
-  `npx sirv-cli .output/public/`, you'll see the posts can't load

The expected output for the payload is:

```ts
export default {data:{T6SB1FMcRf:[{title:"10 Tips for Writing Clean JavaScript Code",slug:"10-tips-for-writing-clean-javascript-code"},{title:"How to Build a Responsive Website with Bootstrap 5",slug:"how-to-build-a-responsive-website-with-bootstrap-5"},{title:"Introduction to Machine Learning with Python",slug:"introduction-to-machine-learning-with-python"}]},prerenderedAt:1682833610711}
```

### Issue / Solution

The issue seems to be related to the island context being given the `/` path and allowed to generate payloads. By ignoring payload extraction for island components we can get around this issue. 

An alternative solution may be to change the given path, but not sure if this will have unexpected consequences.

There may be a better solution than these two so please advise.


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
