### PR TITLE
refactor(schema): move `runtimeCompiler` option out of experimental

### DIFF
--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -130,7 +130,7 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
       ],
       traceInclude: [
         // force include files used in generated code from the runtime-compiler
-        ...(nuxt.options.experimental.runtimeVueCompiler && !nuxt.options.experimental.externalVue)
+        ...(nuxt.options.vue.runtimeCompiler && !nuxt.options.experimental.externalVue)
           ? [
               ...nuxt.options.modulesDir.reduce<string[]>((targets, path) => {
                 const serverRendererPath = resolve(path, 'vue/server-renderer/index.js')
@@ -150,7 +150,7 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
             vue: await resolvePath(`vue/dist/vue.cjs${nuxt.options.dev ? '' : '.prod'}.js`)
           },
       // Vue 3 mocks
-      ...nuxt.options.experimental.runtimeVueCompiler || nuxt.options.experimental.externalVue
+      ...nuxt.options.vue.runtimeCompiler || nuxt.options.experimental.externalVue
         ? {}
         : {
             'estree-walker': 'unenv/runtime/mock/proxy',
@@ -253,7 +253,7 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
   })
 
   // Enable runtime compiler client side
-  if (nuxt.options.experimental.runtimeVueCompiler) {
+  if (nuxt.options.vue.runtimeCompiler) {
     nuxt.hook('vite:extendConfig', (config, { isClient }) => {
       if (isClient) {
         if (Array.isArray(config.resolve!.alias)) {

--- a/packages/schema/src/config/app.ts
+++ b/packages/schema/src/config/app.ts
@@ -13,6 +13,13 @@ export default defineUntypedSchema({
      * @type {typeof import('@vue/compiler-core').CompilerOptions}
      */
     compilerOptions: {},
+
+    /**
+     * Include Vue compiler in runtime bundle.
+     */
+    runtimeCompiler: {
+      $resolve: async (val, get) => val ?? await get('experimental.runtimeVueCompiler') ?? false,
+    },
   },
 
   /**

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -23,12 +23,6 @@ export default defineUntypedSchema({
      */
     externalVue: true,
 
-    // TODO: move to `vue.runtimeCompiler` in v3.5
-    /**
-     * Include Vue compiler in runtime bundle.
-     */
-    runtimeVueCompiler: false,
-
     /**
      * Tree shakes contents of client-only components from server bundle.
      * @see https://github.com/nuxt/framework/pull/5750

--- a/test/fixtures/runtime-compiler/nuxt.config.ts
+++ b/test/fixtures/runtime-compiler/nuxt.config.ts
@@ -1,8 +1,10 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   experimental: {
-    runtimeVueCompiler: true,
     externalVue: false
+  },
+  vue: {
+    runtimeCompiler: true
   },
   builder: process.env.TEST_BUILDER as 'webpack' | 'vite' ?? 'vite'
 })


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This moves the `experimental.runtimeVueCompiler` option to `vue.runtimeCompiler` (with backwards compatibility). I'm not aware of any issues with the functionality and I think we're probably good to go.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
