### PR TITLE
docs: note that `useCookie` does not share state

### DIFF
--- a/docs/3.api/1.composables/use-cookie.md
+++ b/docs/3.api/1.composables/use-cookie.md
@@ -18,6 +18,10 @@ const cookie = useCookie(name, options)
 `useCookie` ref will automatically serialize and deserialize cookie value to JSON.
 ::
 
+::alert{icon=⚠️}
+Multiple invocations of `useCookie` with the same name are not synced. [You can utilise `useState()` to sync them as a workaround](https://github.com/nuxt/nuxt/issues/13020#issuecomment-1505548242).
+::
+
 ## Example
 
 The example below creates a cookie called `counter`. If the cookie doesn't exist, it is initially set to a random value. Whenever we update the `counter` variable, the cookie will be updated accordingly.


### PR DESCRIPTION
### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds a note in the `useCookie` documentation, detailing that multiple invocations of `useCookie` are not kept in-sync. This is a common expectation of `useCookie`, as it's how `useState` and other functions like `useLocalStorage` behave. However there is no mention of this implementation detail in the documentation as current.

I've also added a link to a GitHub thread (https://github.com/nuxt/nuxt/issues/13020) that displays a workaround. Going to this thread will allow people to stay up-to-date with any developments around supporting this feature out of the box.

### 📝 Checklist

- [x] I have linked an issue or discussion (https://github.com/nuxt/nuxt/issues/13020)
- [x] I have updated the documentation accordingly.
