### PR TITLE
docs: ensure we guard all `navigateTo` examples

### DIFF
--- a/docs/2.guide/2.directory-structure/1.middleware.md
+++ b/docs/2.guide/2.directory-structure/1.middleware.md
@@ -30,7 +30,9 @@ export default defineNuxtRouteMiddleware((to, from) => {
   if (to.params.id === '1') {
     return abortNavigation()
   }
-  return navigateTo('/')
+  if (to.path !== '/') {
+    return navigateTo('/')
+  }
 })
 ```
 

--- a/docs/3.api/3.utils/abort-navigation.md
+++ b/docs/3.api/3.utils/abort-navigation.md
@@ -36,7 +36,9 @@ export default defineNuxtRouteMiddleware((to, from) => {
     return abortNavigation()
   }
  
-  return navigateTo('/edit-post')
+  if (to.path !== '/edit-post') {
+    return navigateTo('/edit-post')
+  }
 })
 ```
 

--- a/docs/3.api/3.utils/define-nuxt-route-middleware.md
+++ b/docs/3.api/3.utils/define-nuxt-route-middleware.md
@@ -56,7 +56,9 @@ export default defineNuxtRouteMiddleware((to, from) => {
     return navigateTo('/login')
   }
 
-  return navigateTo('/dashboard')
+  if (to.path !== '/dashboard') {
+    return navigateTo('/dashboard')
+  }
 })
 ```
 

--- a/docs/3.api/3.utils/define-page-meta.md
+++ b/docs/3.api/3.utils/define-page-meta.md
@@ -144,7 +144,9 @@ The example below shows how the middleware can be defined using a `function` dir
             return navigateTo('/login')
         }
 
-        return navigateTo('/checkout')
+        if (to.path !== '/checkout') {
+          return navigateTo('/checkout')
+        }
       }
     ],
 

--- a/docs/3.api/3.utils/navigate-to.md
+++ b/docs/3.api/3.utils/navigate-to.md
@@ -96,8 +96,10 @@ await navigateTo({
 
 ```ts
 export default defineNuxtRouteMiddleware((to, from) => {
-  // setting the redirect code to '301 Moved Permanently'
-  return navigateTo('/search', { redirectCode: 301 })
+  if (to.path !== '/search') {
+    // setting the redirect code to '301 Moved Permanently'
+    return navigateTo('/search', { redirectCode: 301 })
+  }
 })
 ```
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves nuxt/nuxt#20676

### ❓ Type of change
- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Lots of examples in the docs didn't have an adequate guard and would result in an infinite redirect loop.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
