### PR TITLE
fix(nuxt): stop loading indicator on vue errors

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-error-boundary.ts
+++ b/packages/nuxt/src/app/components/nuxt-error-boundary.ts
@@ -11,9 +11,10 @@ export default defineComponent({
     const error = ref<Error | null>(null)
     const nuxtApp = useNuxtApp()
 
-    onErrorCaptured((err) => {
+    onErrorCaptured((err, target, info) => {
       if (process.client && !nuxtApp.isHydrating) {
         emit('error', err)
+        nuxtApp.hooks.callHook('vue:error', err, target, info)
         error.value = err
         return false
       }

--- a/packages/nuxt/src/app/components/nuxt-loading-indicator.ts
+++ b/packages/nuxt/src/app/components/nuxt-loading-indicator.ts
@@ -32,6 +32,7 @@ export default defineComponent({
     const nuxtApp = useNuxtApp()
     nuxtApp.hook('page:start', indicator.start)
     nuxtApp.hook('page:finish', indicator.finish)
+    nuxtApp.hook('vue:error', indicator.finish)
     onBeforeUnmount(indicator.clear)
 
     return () => h('div', {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
#15788
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
- Stop loading indicator when there is an error while navigating
- Call **vue:error** hook from `NuxtErrorBoundary` to signal that there was an error

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
