### PR TITLE
fix(nuxt): deduplicate global components before registration

### DIFF
--- a/packages/nuxt/src/components/templates.ts
+++ b/packages/nuxt/src/components/templates.ts
@@ -39,10 +39,12 @@ export const componentsPluginTemplate: NuxtPluginTemplate<ComponentsTemplateCont
     const globalComponents = app.components.filter(c => c.global)
     if (!globalComponents.length) { return emptyComponentsPlugin }
 
+    const components = [...new Set(globalComponents.map(n => n.pascalName))]
+
     return `import { defineNuxtPlugin } from '#app/nuxt'
-import { ${globalComponents.map(c => 'Lazy' + c.pascalName).join(', ')} } from '#components'
-const lazyGlobalComponents = [
-  ${globalComponents.map(c => `["${c.pascalName}", Lazy${c.pascalName}]`).join(',\n')}
+import { ${components.map(c => 'Lazy' + c).join(', ')} } from '#components'
+const lazynames = [
+  ${components.map(c => `["${c}", Lazy${c}]`).join(',\n')}
 ]
 
 export default defineNuxtPlugin({

--- a/packages/nuxt/src/components/templates.ts
+++ b/packages/nuxt/src/components/templates.ts
@@ -36,10 +36,15 @@ export default defineNuxtPlugin({
 export const componentsPluginTemplate: NuxtPluginTemplate<ComponentsTemplateContext> = {
   filename: 'components.plugin.mjs',
   getContents ({ app }) {
-    const globalComponents = app.components.filter(c => c.global)
-    if (!globalComponents.length) { return emptyComponentsPlugin }
+    const globalComponents = new Set<string>()
+    for (const component of app.components) {
+      if (component.global) {
+        globalComponents.add(component.pascalName)
+      }
+    }
+    if (!globalComponents.size) { return emptyComponentsPlugin }
 
-    const components = [...new Set(globalComponents.map(n => n.pascalName))]
+    const components = [...globalComponents]
 
     return `import { defineNuxtPlugin } from '#app/nuxt'
 import { ${components.map(c => 'Lazy' + c).join(', ')} } from '#components'

--- a/packages/nuxt/src/components/templates.ts
+++ b/packages/nuxt/src/components/templates.ts
@@ -43,7 +43,7 @@ export const componentsPluginTemplate: NuxtPluginTemplate<ComponentsTemplateCont
 
     return `import { defineNuxtPlugin } from '#app/nuxt'
 import { ${components.map(c => 'Lazy' + c).join(', ')} } from '#components'
-const lazynames = [
+const lazyGlobalComponents = [
   ${components.map(c => `["${c}", Lazy${c}]`).join(',\n')}
 ]
 

--- a/test/fixtures/basic/components/global/ClientGlobal.client.vue
+++ b/test/fixtures/basic/components/global/ClientGlobal.client.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    global component (client-only) registered automatically
+  </div>
+</template>


### PR DESCRIPTION
### 🔗 Linked issue

resolves #20729

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When using client/server components we create duplicate stub components for the other mode. As we were not deduplicating in the new plugin registering these components, the component ended up registered twice.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
