### PR TITLE
fix(nuxt): generate empty sourcemaps for wrappers

### DIFF
--- a/packages/nuxt/src/components/transform.ts
+++ b/packages/nuxt/src/components/transform.ts
@@ -53,30 +53,37 @@ export function createTransformPlugin (nuxt: Nuxt, getComponents: getComponentsT
         const mode = query.nuxt_component
         const bare = id.replace(/\?.*/, '')
         if (mode === 'async') {
-          return [
-            'import { defineAsyncComponent } from "vue"',
-            `export default defineAsyncComponent(() => import(${JSON.stringify(bare)}).then(r => r.default))`
-          ].join('\n')
+          return {
+            code: [
+              'import { defineAsyncComponent } from "vue"',
+              `export default defineAsyncComponent(() => import(${JSON.stringify(bare)}).then(r => r.default))`
+            ].join('\n'),
+            map: { mappings: '' }
+          }
         } else if (mode === 'client') {
-          return [
-            `import __component from ${JSON.stringify(bare)}`,
-            'import { createClientOnly } from "#app/components/client-only"',
-            'export default createClientOnly(__component)'
-          ].join('\n')
+          return {
+            code: [
+              `import __component from ${JSON.stringify(bare)}`,
+              'import { createClientOnly } from "#app/components/client-only"',
+              'export default createClientOnly(__component)'
+            ].join('\n'),
+            map: { mappings: '' }
+          }
         } else if (mode === 'client,async') {
-          return [
-            'import { defineAsyncComponent } from "vue"',
-            'import { createClientOnly } from "#app/components/client-only"',
-            `export default defineAsyncComponent(() => import(${JSON.stringify(bare)}).then(r => createClientOnly(r.default)))`
-          ].join('\n')
+          return {
+            code: [
+              'import { defineAsyncComponent } from "vue"',
+              'import { createClientOnly } from "#app/components/client-only"',
+              `export default defineAsyncComponent(() => import(${JSON.stringify(bare)}).then(r => createClientOnly(r.default)))`
+            ].join('\n'),
+            map: { mappings: '' }
+          }
         } else {
           throw new Error(`Unknown component mode: ${mode}, this might be an internal bug of Nuxt.`)
         }
       }
 
-      if (!code.includes('#components')) {
-        return null
-      }
+      if (!code.includes('#components')) { return }
 
       componentUnimport.modifyDynamicImports((imports) => {
         imports.length = 0
@@ -85,12 +92,11 @@ export function createTransformPlugin (nuxt: Nuxt, getComponents: getComponentsT
       })
 
       const result = await componentUnimport.injectImports(code, id, { autoImport: false, transformVirtualImports: true })
-      if (!result) {
-        return null
-      }
+      if (!result) { return }
+
       return {
         code: result.code,
-        map: nuxt.options.sourcemap
+        map: nuxt.options.sourcemap.server || nuxt.options.sourcemap.client
           ? result.s.generateMap({ hires: true })
           : undefined
       }

--- a/packages/nuxt/src/components/transform.ts
+++ b/packages/nuxt/src/components/transform.ts
@@ -58,7 +58,7 @@ export function createTransformPlugin (nuxt: Nuxt, getComponents: getComponentsT
               'import { defineAsyncComponent } from "vue"',
               `export default defineAsyncComponent(() => import(${JSON.stringify(bare)}).then(r => r.default))`
             ].join('\n'),
-            map: { mappings: '' }
+            map: null
           }
         } else if (mode === 'client') {
           return {
@@ -67,7 +67,7 @@ export function createTransformPlugin (nuxt: Nuxt, getComponents: getComponentsT
               'import { createClientOnly } from "#app/components/client-only"',
               'export default createClientOnly(__component)'
             ].join('\n'),
-            map: { mappings: '' }
+            map: null
           }
         } else if (mode === 'client,async') {
           return {
@@ -76,7 +76,7 @@ export function createTransformPlugin (nuxt: Nuxt, getComponents: getComponentsT
               'import { createClientOnly } from "#app/components/client-only"',
               `export default defineAsyncComponent(() => import(${JSON.stringify(bare)}).then(r => createClientOnly(r.default)))`
             ].join('\n'),
-            map: { mappings: '' }
+            map: null
           }
         } else {
           throw new Error(`Unknown component mode: ${mode}, this might be an internal bug of Nuxt.`)


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Without returning sourcemaps for code we've 'invented' we get the following:

```
Sourcemap is likely to be incorrect: a plugin (nuxt:components:imports) was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help
Sourcemap is likely to be incorrect: a plugin (nuxt:components:imports) was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help
Sourcemap is likely to be incorrect: a plugin (nuxt:components:imports) was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help
```

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
