### PR TITLE
fix(nuxt): prevent treeshaking hooks with composable names

### DIFF
--- a/packages/nuxt/src/core/plugins/tree-shake.ts
+++ b/packages/nuxt/src/core/plugins/tree-shake.ts
@@ -15,7 +15,10 @@ export const TreeShakeComposablesPlugin = createUnplugin((options: TreeShakeComp
    * @todo Use the options import-path to tree-shake composables in a safer way.
    */
   const composableNames = Object.values(options.composables).flat()
-  const COMPOSABLE_RE = new RegExp(`($\\s+)(${composableNames.join('|')})(?=\\()`, 'gm')
+
+  const regexp = `(^\\s*)(${composableNames.join('|')})(?=\\([^)])`
+  const COMPOSABLE_RE = new RegExp(regexp, 'm')
+  const COMPOSABLE_RE_GLOBAL = new RegExp(regexp, 'gm')
 
   return {
     name: 'nuxt:tree-shake-composables:transform',
@@ -24,11 +27,11 @@ export const TreeShakeComposablesPlugin = createUnplugin((options: TreeShakeComp
       return isVue(id, { type: ['script'] }) || isJS(id)
     },
     transform (code) {
-      if (!code.match(COMPOSABLE_RE)) { return }
+      if (!COMPOSABLE_RE.test(code)) { return }
 
       const s = new MagicString(code)
       const strippedCode = stripLiteral(code)
-      for (const match of strippedCode.matchAll(COMPOSABLE_RE) || []) {
+      for (const match of strippedCode.matchAll(COMPOSABLE_RE_GLOBAL) || []) {
         s.overwrite(match.index!, match.index! + match[0].length, `${match[1]} /*#__PURE__*/ false && ${match[2]}`)
       }
 

--- a/packages/nuxt/src/core/plugins/tree-shake.ts
+++ b/packages/nuxt/src/core/plugins/tree-shake.ts
@@ -16,7 +16,7 @@ export const TreeShakeComposablesPlugin = createUnplugin((options: TreeShakeComp
    */
   const composableNames = Object.values(options.composables).flat()
 
-  const regexp = `(^\\s*)(${composableNames.join('|')})(?=\\([^)])`
+  const regexp = `(^\\s*)(${composableNames.join('|')})(?=\\((?!\\) \\{))`
   const COMPOSABLE_RE = new RegExp(regexp, 'm')
   const COMPOSABLE_RE_GLOBAL = new RegExp(regexp, 'gm')
 

--- a/test/fixtures/basic/plugins/style.ts
+++ b/test/fixtures/basic/plugins/style.ts
@@ -1,5 +1,14 @@
 import '~/assets/plugin.css'
 
+export class OnMountedMethod {
+  public onMounted () {
+    console.log('public onMounted')
+  }
+
+  onBeforeMount () {
+    console.log('onBeforeMount')
+  }
+}
 export default defineNuxtPlugin(() => {
   //
 })


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/12374

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR:
* slightly improves perf by using a non-global regexp to test whether code should be transformed
* make regexp slightly more restrictive so that we are not tree-shaking function _names_ (e.g. `onMounted() {}`) but only calls

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
