### PR TITLE
fix(vite): expand `fs.allow` dirs to include app files

### DIFF
--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -33,12 +33,14 @@ export async function bundle (nuxt: Nuxt) {
     nuxt.options.appDir,
     nuxt.options.workspaceDir,
     ...nuxt.options._layers.map(l => l.config.rootDir),
-    ...nuxt.apps.default?.components.map(c => dirname(c.filePath)),
-    ...nuxt.apps.default?.plugins.map(p => dirname(p.src)),
-    ...nuxt.apps.default?.middleware.map(m => dirname(m.path)),
-    ...Object.values(nuxt.apps.default?.layouts || {}).map(l => dirname(l.file)),
-    dirname(nuxt.apps.default.rootComponent!),
-    dirname(nuxt.apps.default.errorComponent!)
+    ...Object.values(nuxt.apps).flatMap(app => [
+      ...app.components.map(c => dirname(c.filePath)),
+      ...app.plugins.map(p => dirname(p.src)),
+      ...app.middleware.map(m => dirname(m.path)),
+      ...Object.values(app.layouts || {}).map(l => dirname(l.file)),
+      dirname(nuxt.apps.default.rootComponent!),
+      dirname(nuxt.apps.default.errorComponent!)
+    ])
   ].filter(d => d && existsSync(d))
 
   for (const dir of allowDirs) {

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -106,7 +106,7 @@ export async function bundle (nuxt: Nuxt) {
         server: {
           watch: { ignored: isIgnored },
           fs: {
-            allow: allowDirs
+            allow: [...new Set(allowDirs)]
           }
         }
       } satisfies ViteConfig,


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/14295

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds the directories from app dependencies (like component folders) directly into the vite allow list to avoid potential issues. It's of course totally possible for a user to do this themselves but it can add friction. wdyt @antfu?

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
