### PR TITLE
refactor(kit): use esm utils for `resolvePath`

### DIFF
--- a/packages/kit/src/internal/cjs.ts
+++ b/packages/kit/src/internal/cjs.ts
@@ -95,18 +95,6 @@ export function resolveModule (id: string, opts: ResolveModuleOptions = {}) {
 }
 
 /** @deprecated Do not use CJS utils */
-export function tryResolveModule (path: string, opts: ResolveModuleOptions = {}): string | null {
-  try {
-    return resolveModule(path, opts)
-  } catch (error: any) {
-    if (error?.code !== 'MODULE_NOT_FOUND') {
-      throw error
-    }
-  }
-  return null
-}
-
-/** @deprecated Do not use CJS utils */
 export function requireModule (id: string, opts: RequireModuleOptions = {}) {
   // Resolve id
   const resolvedPath = resolveModule(id, opts)

--- a/packages/kit/src/resolve.ts
+++ b/packages/kit/src/resolve.ts
@@ -2,9 +2,9 @@ import { existsSync, promises as fsp } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { basename, dirname, isAbsolute, join, normalize, resolve } from 'pathe'
 import { globby } from 'globby'
+import { resolvePath as _resolvePath } from 'mlly'
 import { resolveAlias as _resolveAlias } from 'pathe/utils'
 import { tryUseNuxt } from './context'
-import { tryResolveModule } from './internal/cjs'
 import { isIgnored } from './ignore'
 
 export interface ResolvePathOptions {
@@ -71,7 +71,7 @@ export async function resolvePath (path: string, opts: ResolvePathOptions = {}):
   }
 
   // Try to resolve as module id
-  const resolveModulePath = tryResolveModule(_path, { paths: [cwd, ...modulesDir] })
+  const resolveModulePath = await _resolvePath(_path, { url: [cwd, ...modulesDir] }).catch(() => null)
   if (resolveModulePath) {
     return resolveModulePath
   }


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This should be a minor change, swapping out ESM utils (from `mlly`) instead of a deprecated internal CJS utility for the kit `resolvePath` utility.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
