### PR TITLE
feat(nuxi): allow passing overrides to other nuxi commands

### DIFF
--- a/packages/nuxi/src/commands/analyze.ts
+++ b/packages/nuxi/src/commands/analyze.ts
@@ -3,6 +3,7 @@ import { join, resolve } from 'pathe'
 import { createApp, eventHandler, lazyEventHandler, toNodeListener } from 'h3'
 import { listen } from 'listhen'
 import type { NuxtAnalyzeMeta } from '@nuxt/schema'
+import { defu } from 'defu'
 import { loadKit } from '../utils/kit'
 import { clearDir } from '../utils/fs'
 import { overrideEnv } from '../utils/env'
@@ -14,7 +15,7 @@ export default defineNuxtCommand({
     usage: 'npx nuxi analyze [--log-level] [--name] [--no-serve] [rootDir]',
     description: 'Build nuxt and analyze production bundle (experimental)'
   },
-  async invoke (args) {
+  async invoke (args, options = {}) {
     overrideEnv('production')
 
     const name = args.name || 'default'
@@ -31,7 +32,7 @@ export default defineNuxtCommand({
 
     const nuxt = await loadNuxt({
       rootDir,
-      overrides: {
+      overrides: defu(options.overrides, {
         build: {
           analyze: true
         },
@@ -43,7 +44,7 @@ export default defineNuxtCommand({
           }
         },
         logLevel: args['log-level']
-      }
+      })
     })
 
     analyzeDir = nuxt.options.analyzeDir

--- a/packages/nuxi/src/commands/build-module.ts
+++ b/packages/nuxi/src/commands/build-module.ts
@@ -18,7 +18,8 @@ export default defineNuxtCommand({
     const hasLocal = await tryResolveModule(`${MODULE_BUILDER_PKG}/package.json`, rootDir)
 
     const execArgs = Object.entries({
-      '--stub': args.stub
+      '--stub': args.stub,
+      '--prepare': args.prepare
     }).filter(([, value]) => value).map(([key]) => key)
 
     let cmd = 'nuxt-module-build'

--- a/packages/nuxi/src/commands/build.ts
+++ b/packages/nuxi/src/commands/build.ts
@@ -13,7 +13,7 @@ export default defineNuxtCommand({
     usage: 'npx nuxi build [--prerender] [--dotenv] [--log-level] [rootDir]',
     description: 'Build nuxt for production deployment'
   },
-  async invoke (args) {
+  async invoke (args, options = {}) {
     overrideEnv('production')
 
     const rootDir = resolve(args._[0] || '.')
@@ -29,7 +29,8 @@ export default defineNuxtCommand({
       },
       overrides: {
         logLevel: args['log-level'],
-        _generate: args.prerender
+        _generate: args.prerender,
+        ...(options?.overrides || {})
       }
     })
 

--- a/packages/nuxi/src/commands/generate.ts
+++ b/packages/nuxi/src/commands/generate.ts
@@ -7,8 +7,8 @@ export default defineNuxtCommand({
     usage: 'npx nuxi generate [rootDir] [--dotenv]',
     description: 'Build Nuxt and prerender static routes'
   },
-  async invoke (args) {
+  async invoke (args, options = {}) {
     args.prerender = true
-    await buildCommand.invoke(args)
+    await buildCommand.invoke(args, options)
   }
 })

--- a/packages/nuxi/src/commands/prepare.ts
+++ b/packages/nuxi/src/commands/prepare.ts
@@ -11,7 +11,7 @@ export default defineNuxtCommand({
     usage: 'npx nuxi prepare [--log-level] [rootDir]',
     description: 'Prepare nuxt for development/build'
   },
-  async invoke (args) {
+  async invoke (args, options = {}) {
     process.env.NODE_ENV = process.env.NODE_ENV || 'production'
     const rootDir = resolve(args._[0] || '.')
 
@@ -20,7 +20,8 @@ export default defineNuxtCommand({
       rootDir,
       overrides: {
         _prepare: true,
-        logLevel: args['log-level']
+        logLevel: args['log-level'],
+        ...(options.overrides || {})
       }
     })
     await clearBuildDir(nuxt.options.buildDir)

--- a/packages/nuxi/src/commands/preview.ts
+++ b/packages/nuxi/src/commands/preview.ts
@@ -14,11 +14,11 @@ export default defineNuxtCommand({
     usage: 'npx nuxi preview|start [--dotenv] [rootDir]',
     description: 'Launches nitro server for local testing after `nuxi build`.'
   },
-  async invoke (args) {
+  async invoke (args, options = {}) {
     process.env.NODE_ENV = process.env.NODE_ENV || 'production'
     const rootDir = resolve(args._[0] || '.')
     const { loadNuxtConfig } = await loadKit(rootDir)
-    const config = await loadNuxtConfig({ cwd: rootDir })
+    const config = await loadNuxtConfig({ cwd: rootDir, overrides: options?.overrides || {} })
 
     const resolvedOutputDir = resolve(config.srcDir || rootDir, config.nitro.srcDir || 'server', config.nitro.output?.dir || '.output', 'nitro.json')
     const defaultOutput = resolve(rootDir, '.output', 'nitro.json') // for backwards compatibility

--- a/packages/nuxi/src/commands/test.ts
+++ b/packages/nuxi/src/commands/test.ts
@@ -7,14 +7,15 @@ export default defineNuxtCommand({
     usage: 'npx nuxi test [--dev] [--watch] [rootDir]',
     description: 'Run tests'
   },
-  async invoke (args) {
+  async invoke (args, options = {}) {
     process.env.NODE_ENV = process.env.NODE_ENV || 'test'
     const rootDir = resolve(args._[0] || '.')
     const { runTests } = await importTestUtils()
     await runTests({
       rootDir,
       dev: !!args.dev,
-      watch: !!args.watch
+      watch: !!args.watch,
+      ...(options || {})
     })
 
     if (args.watch) {

--- a/packages/nuxi/src/commands/typecheck.ts
+++ b/packages/nuxi/src/commands/typecheck.ts
@@ -12,7 +12,7 @@ export default defineNuxtCommand({
     usage: 'npx nuxi typecheck [--log-level] [rootDir]',
     description: 'Runs `vue-tsc` to check types throughout your app.'
   },
-  async invoke (args) {
+  async invoke (args, options = {}) {
     process.env.NODE_ENV = process.env.NODE_ENV || 'production'
     const rootDir = resolve(args._[0] || '.')
 
@@ -21,7 +21,8 @@ export default defineNuxtCommand({
       rootDir,
       overrides: {
         _prepare: true,
-        logLevel: args['log-level']
+        logLevel: args['log-level'],
+        ...(options?.overrides || {})
       }
     })
 


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/pull/20748#issuecomment-1542082791

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In order to support `nuxt/module-builder` having a `prepare` command (and invoking nuxi prepare programmatically under the hood), we can allow overriding options for the nuxt instance loaded by `nuxi prepare`.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
