### PR TITLE
feat(schema): enable rich json payloads by default

### DIFF
--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -93,9 +93,8 @@ export default defineUntypedSchema({
      */
     noScripts: false,
 
-    // TODO: enable by default in v3.5
     /** Render JSON payloads with support for revivifying complex types. */
-    renderJsonPayloads: false,
+    renderJsonPayloads: true,
 
     /**
      * Disable vue server renderer endpoint within nitro.

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -34,7 +34,7 @@ describe.skipIf(isWindows || process.env.TEST_BUILDER === 'webpack' || process.e
 
   it('default client bundle size', async () => {
     stats.client = await analyzeSizes('**/*.js', publicDir)
-    expect(roundToKilobytes(stats.client.totalBytes)).toMatchInlineSnapshot('"94.2k"')
+    expect(roundToKilobytes(stats.client.totalBytes)).toMatchInlineSnapshot('"96.6k"')
     expect(stats.client.files.map(f => f.replace(/\..*\.js/, '.js'))).toMatchInlineSnapshot(`
       [
         "_nuxt/entry.js",
@@ -45,7 +45,7 @@ describe.skipIf(isWindows || process.env.TEST_BUILDER === 'webpack' || process.e
 
   it('default server bundle size', async () => {
     stats.server = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect(roundToKilobytes(stats.server.totalBytes)).toMatchInlineSnapshot('"67.7k"')
+    expect(roundToKilobytes(stats.server.totalBytes)).toMatchInlineSnapshot('"61.7k"')
 
     const modules = await analyzeSizes('node_modules/**/*', serverDir)
     expect(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot('"2658k"')


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/pull/19205

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This is a follow-up from https://github.com/nuxt/nuxt/pull/19205. We now enable rich JSON payload rendering by default. If this causes any issues in your projects, please do raise an issue to let us know (and, as a temporary workaround, you can set `experimental.renderJsonPayloads` to false):

```ts
export default defineNuxtConfig({
  experimental: {
    renderJsonPayloads: false
  }
})
```

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
