### PR TITLE
fix(nuxt): enable suspensible behaviour for nested pages

### DIFF
--- a/packages/nuxt/src/pages/runtime/page.ts
+++ b/packages/nuxt/src/pages/runtime/page.ts
@@ -54,6 +54,7 @@ export default defineComponent({
 
           return _wrapIf(Transition, hasTransition && transitionProps,
             wrapInKeepAlive(props.keepalive ?? routeProps.route.meta.keepalive ?? (defaultKeepaliveConfig as KeepAliveProps), h(Suspense, {
+              suspensible: true,
               onPending: () => nuxtApp.callHook('page:start', routeProps.Component),
               onResolve: () => { nextTick(() => nuxtApp.callHook('page:finish', routeProps.Component).finally(done)) }
             }, { default: () => h(RouteProvider, { key, routeProps, pageKey: key, hasTransition } as {}) })

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -891,7 +891,7 @@ describe('deferred app suspense resolve', () => {
   })
 })
 
-describe.only('nested suspense', () => {
+describe('nested suspense', () => {
   const navigations = [
     ['/suspense/sync-1/async-1/', '/suspense/sync-2/async-1/'],
     ['/suspense/sync-1/sync-1/', '/suspense/sync-2/async-1/'],

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -891,6 +891,34 @@ describe('deferred app suspense resolve', () => {
   })
 })
 
+describe.only('nested suspense', () => {
+  const navigations = [
+    ['/suspense/sync-1/async-1/', '/suspense/sync-2/async-1/'],
+    ['/suspense/sync-1/sync-1/', '/suspense/sync-2/async-1/'],
+    ['/suspense/async-1/async-1/', '/suspense/async-2/async-1/'],
+    ['/suspense/async-1/sync-1/', '/suspense/async-2/async-1/']
+  ]
+
+  it.each(navigations)('should navigate from %s to %s with no white flash', async (start, nav) => {
+    const page = await createPage(start, {})
+    await page.waitForLoadState('networkidle')
+
+    const slug = nav.replace(/[/-]+/g, '-')
+    await page.click(`[href^="${nav}"]`)
+
+    const text = await page.waitForFunction(slug => document.querySelector(`#${slug}`)?.innerHTML, slug).then(r => r.evaluate(r => r))
+
+    // expect(text).toMatchInlineSnapshot()
+
+    // const parent = await page.waitForSelector(`#${slug}`, { state: 'attached' })
+
+    // const text = await parent.innerText()
+    expect(text).toContain('Async child: 2 - 1')
+
+    await page.close()
+  })
+})
+
 // Bug #6592
 describe('page key', () => {
   it('should not cause run of setup if navigation not change page key and layout', async () => {

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -906,7 +906,9 @@ describe.only('nested suspense', () => {
     const slug = nav.replace(/[/-]+/g, '-')
     await page.click(`[href^="${nav}"]`)
 
-    const text = await page.waitForFunction(slug => document.querySelector(`#${slug}`)?.innerHTML, slug).then(r => r.evaluate(r => r))
+    const text = await page.waitForFunction(slug => document.querySelector(`#${slug}`)?.innerHTML, slug)
+      // @ts-expect-error TODO: fix upstream in playwright - types for evaluate are broken
+      .then(r => r.evaluate(r => r))
 
     // expect(text).toMatchInlineSnapshot()
 

--- a/test/fixtures/basic/pages/suspense.vue
+++ b/test/fixtures/basic/pages/suspense.vue
@@ -1,0 +1,22 @@
+<script setup>
+definePageMeta({
+  // Nested <Suspense> + <Transition> is still buggy
+  pageTransition: false,
+  layoutTransition: false
+})
+const links = ['sync', 'async'].flatMap(parent => [1, 2].flatMap(p => ['sync', 'async'].flatMap(child => [1, 2].map(c => `/suspense/${parent}-${p}/${child}-${c}/`))))
+</script>
+
+<template>
+  <div>
+    This exists to test synchronous transitions between nested Suspense components.
+    <hr>
+    <NuxtLink v-for="link in links" :key="link" :to="link" style="display: block;">
+      {{ link }}
+    </NuxtLink>
+    <hr>
+    <div>
+      <NuxtPage />
+    </div>
+  </div>
+</template>

--- a/test/fixtures/basic/pages/suspense/async-[parent].vue
+++ b/test/fixtures/basic/pages/suspense/async-[parent].vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+console.log('[async]')
+const route = useRoute('suspense-async-parent')
+await useAsyncData(async () => {
+  await new Promise(resolve => setTimeout(resolve, 100))
+  console.log('[async] running async data')
+  return {}
+})
+</script>
+<template>
+  <div>
+    Async parent: {{ route.params.parent }}
+    <hr>
+    <NuxtPage />
+  </div>
+</template>

--- a/test/fixtures/basic/pages/suspense/async-[parent].vue
+++ b/test/fixtures/basic/pages/suspense/async-[parent].vue
@@ -1,14 +1,12 @@
 <script setup lang="ts">
 console.log('[async]')
 const route = useRoute('suspense-async-parent')
-await useAsyncData(async () => {
-  await new Promise(resolve => setTimeout(resolve, 100))
-  console.log('[async] running async data')
-  return {}
-})
+await new Promise(resolve => setTimeout(resolve, 100))
+console.log('[async] running async data')
 </script>
+
 <template>
-  <div>
+  <div :id="route.path.replace(/[/-]+/g, '-')">
     Async parent: {{ route.params.parent }}
     <hr>
     <NuxtPage />

--- a/test/fixtures/basic/pages/suspense/async-[parent]/async-[child].vue
+++ b/test/fixtures/basic/pages/suspense/async-[parent]/async-[child].vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+console.log('[async] [async]')
+const route = useRoute('suspense-async-parent-async-child')
+const { data } = await useAsyncData(async () => {
+  await new Promise(resolve => setTimeout(resolve, 500))
+  console.log(`[async] [${route.params.parent}] [async] [${route.params.child}] running async data`)
+  return route.params
+})
+</script>
+
+<template>
+  <div>
+    Async child: {{ route.params.parent }} - {{ route.params.child }}
+    <hr>
+    {{ data }}
+  </div>
+</template>

--- a/test/fixtures/basic/pages/suspense/async-[parent]/async-[child].vue
+++ b/test/fixtures/basic/pages/suspense/async-[parent]/async-[child].vue
@@ -1,11 +1,9 @@
 <script setup lang="ts">
 console.log('[async] [async]')
 const route = useRoute('suspense-async-parent-async-child')
-const { data } = await useAsyncData(async () => {
-  await new Promise(resolve => setTimeout(resolve, 500))
-  console.log(`[async] [${route.params.parent}] [async] [${route.params.child}] running async data`)
-  return route.params
-})
+await new Promise(resolve => setTimeout(resolve, 500))
+console.log(`[async] [${route.params.parent}] [async] [${route.params.child}] running async data`)
+const data = route.params
 </script>
 
 <template>

--- a/test/fixtures/basic/pages/suspense/async-[parent]/sync-[child].vue
+++ b/test/fixtures/basic/pages/suspense/async-[parent]/sync-[child].vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+console.log('[async] [sync]')
+const route = useRoute()
+</script>
+
+<template>
+  <div>
+    Sync child: {{ route.params.parent }} - {{ route.params.child }}
+  </div>
+</template>

--- a/test/fixtures/basic/pages/suspense/async-[parent]/sync-[child].vue
+++ b/test/fixtures/basic/pages/suspense/async-[parent]/sync-[child].vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 console.log('[async] [sync]')
-const route = useRoute()
+const route = useRoute('suspense-async-parent-sync-child')
 </script>
 
 <template>

--- a/test/fixtures/basic/pages/suspense/sync-[parent].vue
+++ b/test/fixtures/basic/pages/suspense/sync-[parent].vue
@@ -4,7 +4,7 @@ const route = useRoute('suspense-async-parent')
 </script>
 
 <template>
-  <div>
+  <div :id="route.path.replace(/[/-]+/g, '-')">
     Sync parent: {{ route.params.parent }}
     <hr>
     <NuxtPage />

--- a/test/fixtures/basic/pages/suspense/sync-[parent].vue
+++ b/test/fixtures/basic/pages/suspense/sync-[parent].vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+console.log('[sync]')
+const route = useRoute('suspense-async-parent')
+</script>
+
+<template>
+  <div>
+    Sync parent: {{ route.params.parent }}
+    <hr>
+    <NuxtPage />
+  </div>
+</template>

--- a/test/fixtures/basic/pages/suspense/sync-[parent]/async-[child].vue
+++ b/test/fixtures/basic/pages/suspense/sync-[parent]/async-[child].vue
@@ -1,11 +1,9 @@
 <script setup lang="ts">
 console.log('[sync] [async]')
 const route = useRoute('suspense-async-parent-sync-child')
-const { data } = await useAsyncData(async () => {
-  await new Promise(resolve => setTimeout(resolve, 500))
-  console.log(`[async] [${route.params.parent}] [async] [${route.params.child}] running async data`)
-  return route.params
-})
+await new Promise(resolve => setTimeout(resolve, 500))
+console.log(`[async] [${route.params.parent}] [async] [${route.params.child}] running async data`)
+const data = route.params
 </script>
 
 <template>

--- a/test/fixtures/basic/pages/suspense/sync-[parent]/async-[child].vue
+++ b/test/fixtures/basic/pages/suspense/sync-[parent]/async-[child].vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+console.log('[sync] [async]')
+const route = useRoute('suspense-async-parent-sync-child')
+const { data } = await useAsyncData(async () => {
+  await new Promise(resolve => setTimeout(resolve, 500))
+  console.log(`[async] [${route.params.parent}] [async] [${route.params.child}] running async data`)
+  return route.params
+})
+</script>
+
+<template>
+  <div>
+    Async child: {{ route.params.parent }} - {{ route.params.child }}
+    <hr>
+    {{ data }}
+  </div>
+</template>

--- a/test/fixtures/basic/pages/suspense/sync-[parent]/sync-[child].vue
+++ b/test/fixtures/basic/pages/suspense/sync-[parent]/sync-[child].vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+console.log('[sync] [sync]')
+const route = useRoute()
+</script>
+
+<template>
+  <div>
+    Sync child: {{ route.params.parent }} - {{ route.params.child }}
+  </div>
+</template>

--- a/test/fixtures/basic/pages/suspense/sync-[parent]/sync-[child].vue
+++ b/test/fixtures/basic/pages/suspense/sync-[parent]/sync-[child].vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 console.log('[sync] [sync]')
-const route = useRoute()
+const route = useRoute('suspense-sync-parent-sync-child')
 </script>
 
 <template>


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/13814
resolves https://github.com/nuxt/nuxt/issues/14860
resolves https://github.com/nuxt/nuxt/issues/18813

unblocks https://github.com/nuxt/nuxt/issues/12391

related (but not resolved) https://github.com/nuxt/nuxt/issues/14467

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR enables the new `suspensible` prop for nested pages, which resolves quite a few issues 🎉 🥳 🙌

**TODO**:
- [x] test suite
- [x] identify other issues that may be resolved by this fix

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
