### PR TITLE
docs: add missing step migrating to `pinia`

### DIFF
--- a/docs/7.migration/2.configuration.md
+++ b/docs/7.migration/2.configuration.md
@@ -142,6 +142,16 @@ Install the [@pinia/nuxt](https://nuxt.com/modules/pinia) module:
 yarn add pinia @pinia/nuxt
 ```
 
+Enable the module in your nuxt configuration:
+
+```ts [nuxt.config.ts]
+import { defineNuxtConfig } from 'nuxt/config';
+
+export default defineNuxtConfig({
+  modules: ['@pinia/nuxt']
+})
+```
+
 Create a `store` folder at the root of your application:
 
 ```ts [store/index.ts]


### PR DESCRIPTION
Document pinia module registration in [nuxt config.](https://nuxt.com/docs/migration/configuration#vuex)

### 🔗 Linked issue
none

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Pinia minimal setup is documented (install, basic configuration) but misses the module registration step required in nuxt configuration file.
This pull request adds this missing step to the documentation.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
