### PR TITLE
feat(nuxt): allow fallback production content in `<DevOnly>`

### DIFF
--- a/docs/2.guide/2.directory-structure/1.components.md
+++ b/docs/2.guide/2.directory-structure/1.components.md
@@ -336,6 +336,11 @@ The content will not be included in production builds and tree-shaken.
     <DevOnly>
       <!-- this component will only be rendered during development -->
       <LazyDebugBar />
+
+      <!-- if you ever require to have a replacement during production -->
+      <template #fallback>
+        <div><!-- empty div for flex.justify-between --></div>
+      </template>
     </DevOnly>
   </div>
 </template>

--- a/packages/nuxt/src/app/components/dev-only.ts
+++ b/packages/nuxt/src/app/components/dev-only.ts
@@ -6,6 +6,6 @@ export default defineComponent({
     if (process.dev) {
       return () => props.slots.default?.()
     }
-    return () => null
+    return () => props.slots.fallback
   }
 })

--- a/packages/nuxt/src/app/components/dev-only.ts
+++ b/packages/nuxt/src/app/components/dev-only.ts
@@ -6,6 +6,6 @@ export default defineComponent({
     if (process.dev) {
       return () => props.slots.default?.()
     }
-    return () => props.slots.fallback
+    return () => props.slots.fallback?.()
   }
 })

--- a/packages/nuxt/src/core/plugins/dev-only.ts
+++ b/packages/nuxt/src/core/plugins/dev-only.ts
@@ -9,7 +9,7 @@ interface DevOnlyPluginOptions {
 }
 
 export const DevOnlyPlugin = createUnplugin((options: DevOnlyPluginOptions) => {
-  const DEVONLY_COMP_RE = /<(dev-only|DevOnly)>[\s\S]*?<\/(dev-only|DevOnly)>/g
+  const DEVONLY_COMP_RE = /<(?:dev-only|DevOnly)>[^<]*(?:<template\s+#fallback>(?<fallback>[\s\S]*?)<\/template>)?[\s\S]*?<\/(?:dev-only|DevOnly)>/g
 
   return {
     name: 'nuxt:server-devonly:transform',
@@ -29,7 +29,7 @@ export const DevOnlyPlugin = createUnplugin((options: DevOnlyPluginOptions) => {
       const s = new MagicString(code)
       const strippedCode = stripLiteral(code)
       for (const match of strippedCode.matchAll(DEVONLY_COMP_RE) || []) {
-        s.remove(match.index!, match.index! + match[0].length)
+        s.overwrite(match.index!, match.index! + match[0].length, match.groups?.fallback || '')
       }
 
       if (s.hasChanged()) {

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -83,6 +83,8 @@ describe('pages', () => {
     expect(html).toContain('Composable | star: auto imported from ~/composables/nested/bar.ts via star export')
     // should import components
     expect(html).toContain('This is a custom component with a named export.')
+    // should remove dev-only and replace with any fallback content
+    expect(html).toContain('Some prod-only info')
     // should apply attributes to client-only components
     expect(html).toContain('<div style="color:red;" class="client-only"></div>')
     // should render server-only components

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -84,7 +84,7 @@ describe('pages', () => {
     // should import components
     expect(html).toContain('This is a custom component with a named export.')
     // should remove dev-only and replace with any fallback content
-    expect(html).toContain('Some prod-only info')
+    expect(html).toContain(isDev() ? 'Some dev-only info' : 'Some prod-only info')
     // should apply attributes to client-only components
     expect(html).toContain('<div style="color:red;" class="client-only"></div>')
     // should render server-only components

--- a/test/fixtures/basic/pages/index.vue
+++ b/test/fixtures/basic/pages/index.vue
@@ -11,6 +11,14 @@
     <div>Composable | star: {{ useNestedBar() }}</div>
     <DevOnly>Some dev-only info</DevOnly>
     <div><DevOnly>Some dev-only info</DevOnly></div>
+    <div>
+      <DevOnly>
+        Some dev-only info
+        <template #fallback>
+          Some prod-only info
+        </template>
+      </DevOnly>
+    </div>
     <div>Path: {{ $route.fullPath }}</div>
     <NuxtLink to="/">
       Link


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

This is a (silly little) PR that's motivated by some use-cases/scenarios where usage of the handy DevOnly causes some design changes in my app during build and so usage requires extra consideration. For example,

```html
<div class="flex justify-between">
  <span>1</span>
  <span>2</span>

  <!-- here I *could* wrap DevOnly in span but it may affect what I put inside the component -->
  <span><DevOnly></DevOnly></span>
  <!-- and where do I put 3 if I don't want both fighting for space in span during dev -->

</div>

<!-- more realistic example -->
<div class="flex justify-between">
  <span>Search</span>
  <span>Branding</span>

  <Menu />
  <DevOnly>
    <DevMenu /> <!-- custom component as superset of Menu -->
  </DevOnly>
</div>
```

In such cases, especially where I have `flex` class, when `DevOnly` is removed, it causes block of three to change into two across the screen. This could allow fallback usage if ever required by devs.

```html
<div class="flex justify-between">
  <span>1</span>
  <span>2</span>
  <DevOnly>
    <Button />
    <template #fallback><span>3</span></template>
  </DevOnly>
</div>

<div class="flex justify-between">
  <span>Search</span>
  <span>Branding</span>
  <DevOnly>
    <DevMenu />
    <template #fallback><Menu /></template>
  </DevOnly>
</div>
```

Could test it out in the repository playground:

`playground/app.vue`

```html
<script setup lang="ts">
</script>

<template>
  <!-- Edit this file to play around with Nuxt but never commit changes! -->
  <div>
    Nuxt 3 Playground
    <DevOnly>Some dev-only info</DevOnly>
    <div><DevOnly>Some dev-only info</DevOnly></div>
    <div>
      <DevOnly>
        Some dev-only info
        <template #fallback>
          Some prod-only info
        </template>
      </DevOnly>
    </div>
  </div>
</template>

<style scoped>

</style>
```

and run `pnpm play:build && pnpm play:preview`

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
