### PR TITLE
fix(nuxt): allow serialising undefined refs

### DIFF
--- a/packages/nuxt/src/app/plugins/revive-payload.client.ts
+++ b/packages/nuxt/src/app/plugins/revive-payload.client.ts
@@ -5,8 +5,8 @@ import { defineNuxtPlugin } from '#app/nuxt'
 
 const revivers = {
   NuxtError: (data: any) => createError(data),
-  EmptyShallowRef: (data: any) => shallowRef(JSON.parse(data)),
-  EmptyRef: (data: any) => ref(JSON.parse(data)),
+  EmptyShallowRef: (data: any) => shallowRef(data === '_' ? undefined : JSON.parse(data)),
+  EmptyRef: (data: any) => ref(data === '_' ? undefined : JSON.parse(data)),
   ShallowRef: (data: any) => shallowRef(data),
   ShallowReactive: (data: any) => shallowReactive(data),
   Ref: (data: any) => ref(data),

--- a/packages/nuxt/src/app/plugins/revive-payload.server.ts
+++ b/packages/nuxt/src/app/plugins/revive-payload.server.ts
@@ -6,8 +6,8 @@ import { defineNuxtPlugin } from '#app/nuxt'
 
 const reducers = {
   NuxtError: (data: any) => isNuxtError(data) && data.toJSON(),
-  EmptyShallowRef: (data: any) => isRef(data) && isShallow(data) && !data.value && JSON.stringify(data.value),
-  EmptyRef: (data: any) => isRef(data) && !data.value && JSON.stringify(data.value),
+  EmptyShallowRef: (data: any) => isRef(data) && isShallow(data) && !data.value && (JSON.stringify(data.value) || '_'),
+  EmptyRef: (data: any) => isRef(data) && !data.value && (JSON.stringify(data.value) || '_'),
   ShallowRef: (data: any) => isRef(data) && isShallow(data) && data.value,
   ShallowReactive: (data: any) => isReactive(data) && isShallow(data) && toRaw(data),
   Ref: (data: any) => isRef(data) && data.value,

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -380,6 +380,7 @@ describe('rich payloads', () => {
       'Recursive objects: true',
       'Shallow reactive: true',
       'Shallow ref: true',
+      'Undefined ref: true',
       'Reactive: true',
       'Ref: true',
       'Error: true'

--- a/test/fixtures/basic/pages/json-payload.vue
+++ b/test/fixtures/basic/pages/json-payload.vue
@@ -6,6 +6,7 @@ if (process.server) {
   state.value.ref = r
   state.value.shallowReactive = shallowReactive({ nested: { ref: r } })
   state.value.shallowRef = shallowRef(false)
+  state.value.undefined = shallowRef()
   state.value.reactive = reactive({ ref: r })
   state.value.error = createError({ message: 'error' })
   state.value.date = new Date()
@@ -19,6 +20,7 @@ if (process.server) {
     Error: {{ isNuxtError(state.error) }} <hr>
     Shallow reactive: {{ isReactive(state.shallowReactive) && isShallow(state.shallowReactive) }} <br>
     Shallow ref: {{ isShallow(state.shallowRef) }} <br>
+    Undefined ref: {{ isRef(state.undefined) }} <br>
     Reactive: {{ isReactive(state.reactive) }} <br>
     Ref: {{ isRef(state.ref) }} <hr>
     Recursive objects: {{ state.ref === state.shallowReactive.nested.ref }} <br>


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/20787#issuecomment-1544192344

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This handles the case of undefined empty refs, which otherwise were not correctly being handled as `JSON.stringify` was of course not quite up to the job.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
