### PR TITLE
fix(nuxt): allow island renders without `/` route

### DIFF
--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -186,7 +186,7 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
       if (process.server && failure?.type === 4 /* ErrorTypes.NAVIGATION_ABORTED */) {
         return
       }
-      if (to.matched.length === 0) {
+      if (to.matched.length === 0 && (!process.server || !nuxtApp.ssrContext?.islandContext)) {
         await nuxtApp.runWithContext(() => showError(createError({
           statusCode: 404,
           fatal: false,


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Previously we were throwing a 404 if the root `~/pages/index.vue` path didn't exist - server components would silently fail to render. 😬

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
