### PR TITLE
fix(kit): resolve relative module paths when installing

### DIFF
--- a/packages/kit/src/module/install.ts
+++ b/packages/kit/src/module/install.ts
@@ -1,6 +1,6 @@
 import { lstatSync } from 'node:fs'
 import type { Nuxt, NuxtModule } from '@nuxt/schema'
-import { dirname, isAbsolute, normalize } from 'pathe'
+import { dirname, isAbsolute, normalize, resolve } from 'pathe'
 import { isNuxt2 } from '../compatibility'
 import { useNuxt } from '../context'
 import { requireModule } from '../internal/cjs'
@@ -53,7 +53,11 @@ async function normalizeModule (nuxtModule: string | NuxtModule, inlineOptions?:
 
   // Import if input is string
   if (typeof nuxtModule === 'string') {
-    const src = normalize(resolveAlias(nuxtModule))
+    let src = resolveAlias(nuxtModule)
+    if (src.match(/^\.{1,2}\//)) {
+      src = resolve(nuxt.options.rootDir, src)
+    }
+    src = normalize(src)
     try {
       // Prefer ESM resolution if possible
       nuxtModule = await importModule(src, nuxt.options.modulesDir).catch(() => null) ?? requireModule(src, { paths: nuxt.options.modulesDir })

--- a/test/fixtures/basic/modules/test/index.ts
+++ b/test/fixtures/basic/modules/test/index.ts
@@ -1,0 +1,7 @@
+import { defineNuxtModule } from 'nuxt/kit'
+
+export default defineNuxtModule({
+  meta: {
+    name: 'test'
+  }
+})

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -80,6 +80,7 @@ export default defineNuxtConfig({
     }
   },
   modules: [
+    './modules/test/index',
     [
       '~/modules/example',
       {


### PR DESCRIPTION
### 🔗 Linked issue

partly resolves nuxt/nuxt#20883

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Regression introduced in https://github.com/nuxt/nuxt/pull/20757. We need to normalise module relative paths.

There's still an issue where loading an implicit index (e.g. `~/modules/test` for `~/modules/test/index`) fails owing to jiti trying to read the directory, but I think that's consistent with the ESM ecosystem. (cc: @pi0)

<details><summary>Details</summary>
<p>

```
 ERROR  Error while requiring module ./modules/test/: Error: EISDIR: illegal operation on a directory, read                                                             22:35:47


 ERROR  Cannot restart nuxt:  EISDIR: illegal operation on a directory, read                                                                                            22:35:47

  at Object.readSync (node:fs:757:3)
  at tryReadSync (node:fs:438:20)
  at readFileSync (node:fs:484:19)
  at jiti (node_modules/.pnpm/jiti@1.18.2/node_modules/jiti/dist/jiti.js:1:244019)
  at requireModule (packages/kit/src/internal/cjs.ts:108:26)
  at normalizeModule (packages/kit/src/module/install.ts:63:125)
  at async installModule (packages/kit/src/module/install.ts:13:41)
  at async initNuxt (packages/nuxt/src/core/nuxt.ts:339:7)
  at async load (packages/nuxi/src/commands/dev.ts:132:9)
  at async _applyPromised (node_modules/.pnpm/perfect-debounce@1.0.0/node_modules/perfect-debounce/dist/index.cjs:56:10)
```

</p>
</details> 

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
