### PR TITLE
fix(nuxt): prioritise vue app context when available

### DIFF
--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -435,7 +435,7 @@ export function callWithNuxt<T extends (...args: any[]) => any> (nuxt: NuxtApp |
 /**
  * Returns the current Nuxt instance.
  */
-export function useNuxtApp () {
+export function useNuxtApp (): NuxtApp {
   let nuxtAppInstance
   if (hasInjectionContext()) {
     nuxtAppInstance = getCurrentInstance()?.appContext.app.$nuxt

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-use-before-define */
-import { getCurrentInstance, reactive } from 'vue'
+import { getCurrentInstance, hasInjectionContext, reactive } from 'vue'
 import type { App, Ref, VNode, onErrorCaptured } from 'vue'
 import type { RouteLocationNormalizedLoaded } from '#vue-router'
 import type { HookCallback, Hookable } from 'hookable'
@@ -436,18 +436,19 @@ export function callWithNuxt<T extends (...args: any[]) => any> (nuxt: NuxtApp |
  * Returns the current Nuxt instance.
  */
 export function useNuxtApp () {
-  const nuxtAppInstance = nuxtAppCtx.tryUse()
+  let nuxtAppInstance
+  if (hasInjectionContext()) {
+    nuxtAppInstance = getCurrentInstance()?.appContext.app.$nuxt
+  }
+
+  nuxtAppInstance = nuxtAppInstance || nuxtAppCtx.tryUse()
 
   if (!nuxtAppInstance) {
-    const vm = getCurrentInstance()
-    if (!vm) {
-      if (process.dev) {
-        throw new Error('[nuxt] A composable that requires access to the Nuxt instance was called outside of a plugin, Nuxt hook, Nuxt middleware, or Vue setup function. This is probably not a Nuxt bug. Find out more at `https://nuxt.com/docs/guide/concepts/auto-imports#using-vue-and-nuxt-composables`.')
-      } else {
-        throw new Error('[nuxt] instance unavailable')
-      }
+    if (process.dev) {
+      throw new Error('[nuxt] A composable that requires access to the Nuxt instance was called outside of a plugin, Nuxt hook, Nuxt middleware, or Vue setup function. This is probably not a Nuxt bug. Find out more at `https://nuxt.com/docs/guide/concepts/auto-imports#using-vue-and-nuxt-composables`.')
+    } else {
+      throw new Error('[nuxt] instance unavailable')
     }
-    return vm.appContext.app.$nuxt as NuxtApp
   }
 
   return nuxtAppInstance

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -600,8 +600,7 @@ describe('preserves current instance', () => {
   it('should not return getCurrentInstance when there\'s an error in data', async () => {
     await fetch('/instance/error')
     const html = await $fetch('/instance/next-request')
-    // TODO: this needs to be fixed upstream in Vue: https://github.com/vuejs/core/issues/7733, https://github.com/vuejs/core/pull/7743
-    expect(html).not.toContain('This should be false: false')
+    expect(html).toContain('This should be false: false')
   })
   it('should not lose current nuxt app after await in vue component', async () => {
     const requests = await Promise.all(Array.from({ length: 100 }).map(() => $fetch('/instance/next-request')))

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -596,6 +596,21 @@ describe('navigate', () => {
   })
 })
 
+describe('preserves current instance', () => {
+  it('should not return getCurrentInstance when there\'s an error in data', async () => {
+    await fetch('/instance/error')
+    const html = await $fetch('/instance/next-request')
+    // TODO: this needs to be fixed upstream in Vue: https://github.com/vuejs/core/issues/7733, https://github.com/vuejs/core/pull/7743
+    expect(html).not.toContain('This should be false: false')
+  })
+  it('should not lose current nuxt app after await in vue component', async () => {
+    const requests = await Promise.all(Array.from({ length: 100 }).map(() => $fetch('/instance/next-request')))
+    for (const html of requests) {
+      expect(html).toContain('This should be true: true')
+    }
+  })
+})
+
 describe('errors', () => {
   it('should render a JSON error page', async () => {
     const res = await fetch('/error', {

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -604,7 +604,7 @@ describe('preserves current instance', () => {
     expect(html).toContain('This should be false: false')
   })
   it('should not lose current nuxt app after await in vue component', async () => {
-    const requests = await Promise.all(Array.from({ length: 100 }).map(() => $fetch('/instance/next-request')))
+    const requests = await Promise.all(Array.from({ length: isWindows ? 4 : 100 }).map(() => $fetch('/instance/next-request')))
     for (const html of requests) {
       expect(html).toContain('This should be true: true')
     }

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -598,13 +598,14 @@ describe('navigate', () => {
 
 describe('preserves current instance', () => {
   // TODO: reenable when https://github.com/vuejs/core/issues/7733 is resolved
-  it.todo('should not return getCurrentInstance when there\'s an error in data', async () => {
+  it('should not return getCurrentInstance when there\'s an error in data', async () => {
     await fetch('/instance/error')
     const html = await $fetch('/instance/next-request')
     expect(html).toContain('This should be false: false')
   })
-  it('should not lose current nuxt app after await in vue component', async () => {
-    const requests = await Promise.all(Array.from({ length: isWindows ? 4 : 100 }).map(() => $fetch('/instance/next-request')))
+  // TODO: re-enable when https://github.com/nuxt/nuxt/issues/15164 is resolved
+  it.skipIf(isWindows)('should not lose current nuxt app after await in vue component', async () => {
+    const requests = await Promise.all(Array.from({ length: 100 }).map(() => $fetch('/instance/next-request')))
     for (const html of requests) {
       expect(html).toContain('This should be true: true')
     }

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -597,7 +597,8 @@ describe('navigate', () => {
 })
 
 describe('preserves current instance', () => {
-  it('should not return getCurrentInstance when there\'s an error in data', async () => {
+  // TODO: reenable when https://github.com/vuejs/core/issues/7733 is resolved
+  it.todo('should not return getCurrentInstance when there\'s an error in data', async () => {
     await fetch('/instance/error')
     const html = await $fetch('/instance/next-request')
     expect(html).toContain('This should be false: false')

--- a/test/fixtures/basic/pages/instance/error.vue
+++ b/test/fixtures/basic/pages/instance/error.vue
@@ -1,0 +1,13 @@
+<script lang="ts">
+export default defineComponent({
+  data () {
+    throw new Error('💀')
+  }
+})
+</script>
+
+<template>
+  <div>
+    This should not display.
+  </div>
+</template>

--- a/test/fixtures/basic/pages/instance/next-request.vue
+++ b/test/fixtures/basic/pages/instance/next-request.vue
@@ -1,0 +1,14 @@
+<script setup>
+const nuxtApp = useNuxtApp()
+await new Promise(resolve => setTimeout(resolve, 150))
+const isSameApp = nuxtApp === useNuxtApp()
+if (!isSameApp) {
+  throw new Error('💀')
+}
+</script>
+<template>
+  <div>
+    This should be false: {{ $wasVueAppInstanceWronglyPreserved }}
+    This should be true: {{ isSameApp }}
+  </div>
+</template>

--- a/test/fixtures/basic/plugins/context-error.ts
+++ b/test/fixtures/basic/plugins/context-error.ts
@@ -1,0 +1,9 @@
+export default defineNuxtPlugin(() => {
+  // this should be undefined
+  const vueApp = getCurrentInstance()
+  return {
+    provide: {
+      wasVueAppInstanceWronglyPreserved: !!vueApp
+    }
+  }
+})


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/20741
related https://github.com/nuxt/nuxt/pull/19624#issuecomment-1465838519
proper fix will need to come https://github.com/vuejs/core/pull/7743

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Now that we have access to `hasInjectionContext` we can ensure we only check for current vue instance when we are within a component (or `getCurrentInstance` should fail).

TODO:
- [x] confirm that https://github.com/vuejs/core/issues/7733 doesn't cause request to be shared when using this strategy

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
