### PR TITLE
fix(nuxt): don't `refresh` when hydrating when data is present

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -135,7 +135,7 @@ export function useAsyncData<
       (nuxt._asyncDataPromises[key] as any).cancelled = true
     }
     // Avoid fetching same key that is already fetched
-    if (opts._initial && hasCachedData()) {
+    if ((opts._initial || nuxt.isHydrating) && hasCachedData()) {
       return getCachedData()
     }
     asyncData.pending.value = true

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -135,7 +135,7 @@ export function useAsyncData<
       (nuxt._asyncDataPromises[key] as any).cancelled = true
     }
     // Avoid fetching same key that is already fetched
-    if ((opts._initial || nuxt.isHydrating) && hasCachedData()) {
+    if ((opts._initial || (nuxt.isHydrating && opts._initial !== false)) && hasCachedData()) {
       return getCachedData()
     }
     asyncData.pending.value = true

--- a/test/fixtures/basic/pages/useAsyncData/override.vue
+++ b/test/fixtures/basic/pages/useAsyncData/override.vue
@@ -22,7 +22,7 @@ if (process.client && (count !== 0 || data.value !== 1)) {
 }
 
 timeout = 0
-await refresh()
+await refresh({ _initial: false })
 
 if (process.client && (count !== 1 || data.value !== 1)) {
   throw new Error('override should execute')

--- a/test/fixtures/basic/pages/useAsyncData/override.vue
+++ b/test/fixtures/basic/pages/useAsyncData/override.vue
@@ -15,7 +15,7 @@ if (count || data.value !== 1) {
 }
 
 timeout = 100
-const p = refresh({ dedupe: true })
+const p = refresh({ dedupe: true, _initial: false })
 
 if (process.client && (count !== 0 || data.value !== 1)) {
   throw new Error('count should start at 0')


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/20900

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

It's an edge case, but when calling `execute` or `refresh` we will force refresh data on initial load of a component (ie. when hydrating), because we don't pass the `{ _initial: true }` option by default.

This PR updates behaviour to _default_ to skipping refresh of data if it exists in payload and we're hydrating. It can still be overridden by passing `{ _initial: false }`. I don't regard this as a breaking change as changing data in the payload will almost always be incorrect and cause a hydration failure.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
