### PR TITLE
docs: sync `useAsyncData` and `useFetch` types

### DIFF
--- a/docs/3.api/1.composables/use-async-data.md
+++ b/docs/3.api/1.composables/use-async-data.md
@@ -28,19 +28,17 @@ type AsyncDataOptions<DataT> = {
   immediate?: boolean
 }
 
-interface RefreshOptions {
-  dedupe?: boolean
-}
-
 type AsyncData<DataT, ErrorT> = {
   data: Ref<DataT | null>
   pending: Ref<boolean>
-  execute: () => Promise<void>
-  refresh: (opts?: RefreshOptions) => Promise<void>
+  refresh: (opts?: AsyncDataExecuteOptions) => Promise<void>
+  execute: (opts?: AsyncDataExecuteOptions) => Promise<void>
   error: Ref<ErrorT | null>
+};
+
+interface AsyncDataExecuteOptions {
+  dedupe?: boolean
 }
-
-
 ```
 
 ## Params

--- a/docs/3.api/1.composables/use-fetch.md
+++ b/docs/3.api/1.composables/use-fetch.md
@@ -29,12 +29,16 @@ type UseFetchOptions = {
   watch?: WatchSource[]
 }
 
-type AsyncData<DataT> = {
-  data: Ref<DataT>
+type AsyncData<DataT, ErrorT> = {
+  data: Ref<DataT | null>
   pending: Ref<boolean>
-  refresh: (opts?: { dedupe?: boolean }) => Promise<void>
-  execute: () => Promise<void>
-  error: Ref<Error | boolean>
+  refresh: (opts?: AsyncDataExecuteOptions) => Promise<void>
+  execute: (opts?: AsyncDataExecuteOptions) => Promise<void>
+  error: Ref<ErrorT | null>
+}
+
+interface AsyncDataExecuteOptions {
+  dedupe?: boolean
 }
 ```
 


### PR DESCRIPTION
Synchronize `type AsyncData` with `asyncData.d.ts`

### 🔗 Linked issue

none

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I opened discussion [#20885](https://github.com/nuxt/nuxt/discussions/20885). It was questions of data-fetching.
I decided to dig into that so I checked the codes and found that in [useFetch](https://nuxt.com/docs/api/composables/use-fetch#type) and [useAsyncData](https://nuxt.com/docs/api/composables/use-async-data#type) docs, type definition is different from `asyncData.d.ts`. `type AsyncData` in `useFetch` docs is even wrong.
```ts
type AsyncData<DataT> = {  // where is Error generic?
  data: Ref<DataT>
  pending: Ref<boolean>
  refresh: (opts?: { dedupe?: boolean }) => Promise<void>
  execute: () => Promise<void>
  error: Ref<Error | boolean>
}
```
There is a property in `AsyncDataExecuteOptions` which is `_initial` but I didn't added it since I couldn't find anything relative that in `Nuxt` docs.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
