### PR TITLE
fix(nuxt): don't match partial component names with prefix

### DIFF
--- a/packages/nuxt/src/components/scan.ts
+++ b/packages/nuxt/src/components/scan.ts
@@ -130,13 +130,14 @@ export function resolveComponentName (fileName: string, prefixParts: string[]) {
    * @example AwesomeComponent -> ['Awesome', 'Component']
    */
   const fileNameParts = splitByCase(fileName)
-  const fileNamePartsContent = fileNameParts.join('').toLowerCase()
+  const fileNamePartsContent = fileNameParts.join('/').toLowerCase()
   const componentNameParts: string[] = [...prefixParts]
   let index = prefixParts.length - 1
-  const matchedSuffix:string[] = []
+  const matchedSuffix: string[] = []
   while (index >= 0) {
     matchedSuffix.unshift((prefixParts[index] || '').toLowerCase())
-    if (fileNamePartsContent.startsWith(matchedSuffix.join('')) ||
+    const matchedSuffixContent = matchedSuffix.join('/')
+    if ((fileNamePartsContent === matchedSuffixContent || fileNamePartsContent.startsWith(matchedSuffixContent + '/')) ||
       // e.g Item/Item/Item.vue -> Item
       (prefixParts[index].toLowerCase() === fileNamePartsContent &&
         prefixParts[index + 1] &&

--- a/packages/nuxt/src/components/scan.ts
+++ b/packages/nuxt/src/components/scan.ts
@@ -135,7 +135,7 @@ export function resolveComponentName (fileName: string, prefixParts: string[]) {
   let index = prefixParts.length - 1
   const matchedSuffix: string[] = []
   while (index >= 0) {
-    matchedSuffix.unshift((prefixParts[index] || '').toLowerCase())
+    matchedSuffix.unshift(...splitByCase(prefixParts[index] || '').map(p => p.toLowerCase()))
     const matchedSuffixContent = matchedSuffix.join('/')
     if ((fileNamePartsContent === matchedSuffixContent || fileNamePartsContent.startsWith(matchedSuffixContent + '/')) ||
       // e.g Item/Item/Item.vue -> Item

--- a/packages/nuxt/test/scan-components.test.ts
+++ b/packages/nuxt/test/scan-components.test.ts
@@ -257,7 +257,9 @@ const tests: Array<[string, string[], string]> = [
   ['ThingItemTest', ['Item', 'Thing', 'Foo'], 'ItemThingFooThingItemTest'],
   ['ItemIn', ['Item', 'Holder', 'Item', 'In'], 'ItemHolderItemIn'],
   ['Item', ['Item', 'Holder', 'Test'], 'ItemHolderTestItem'],
-  ['ItemHolderItem', ['Item', 'Holder', 'Item', 'Holder'], 'ItemHolderItemHolderItem']
+  ['ItemHolderItem', ['Item', 'Holder', 'Item', 'Holder'], 'ItemHolderItemHolderItem'],
+  ['Icones', ['Icon'], 'IconIcones'],
+  ['Icon', ['Icones'], 'IconesIcon']
 ]
 
 describe('components:resolveComponentName', () => {

--- a/packages/nuxt/test/scan-components.test.ts
+++ b/packages/nuxt/test/scan-components.test.ts
@@ -259,7 +259,8 @@ const tests: Array<[string, string[], string]> = [
   ['Item', ['Item', 'Holder', 'Test'], 'ItemHolderTestItem'],
   ['ItemHolderItem', ['Item', 'Holder', 'Item', 'Holder'], 'ItemHolderItemHolderItem'],
   ['Icones', ['Icon'], 'IconIcones'],
-  ['Icon', ['Icones'], 'IconesIcon']
+  ['Icon', ['Icones'], 'IconesIcon'],
+  ['IconHolder', ['IconHolder'], 'IconHolder']
 ]
 
 describe('components:resolveComponentName', () => {


### PR DESCRIPTION
### 🔗 Linked issue

resolves nuxt/nuxt#20937

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This ensures we don't match 'partial' prefixes, e.g. `Icones/Icon.vue` but fully match each segment of the prefix.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
