### PR TITLE
fix(nuxt): use `resolvePath` to handle edge cases for modules

### DIFF
--- a/packages/kit/src/module/install.ts
+++ b/packages/kit/src/module/install.ts
@@ -1,11 +1,11 @@
 import { lstatSync } from 'node:fs'
 import type { Nuxt, NuxtModule } from '@nuxt/schema'
-import { dirname, isAbsolute, normalize, resolve } from 'pathe'
+import { dirname, isAbsolute } from 'pathe'
 import { isNuxt2 } from '../compatibility'
 import { useNuxt } from '../context'
 import { requireModule } from '../internal/cjs'
 import { importModule } from '../internal/esm'
-import { resolveAlias } from '../resolve'
+import { resolveAlias, resolvePath } from '../resolve'
 
 /** Installs a module on a Nuxt instance. */
 export async function installModule (moduleToInstall: string | NuxtModule, _inlineOptions?: any, _nuxt?: Nuxt) {
@@ -53,11 +53,7 @@ async function normalizeModule (nuxtModule: string | NuxtModule, inlineOptions?:
 
   // Import if input is string
   if (typeof nuxtModule === 'string') {
-    let src = resolveAlias(nuxtModule)
-    if (src.match(/^\.{1,2}\//)) {
-      src = resolve(nuxt.options.rootDir, src)
-    }
-    src = normalize(src)
+    const src = await resolvePath(nuxtModule)
     try {
       // Prefer ESM resolution if possible
       nuxtModule = await importModule(src, nuxt.options.modulesDir).catch(() => null) ?? requireModule(src, { paths: nuxt.options.modulesDir })

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -80,7 +80,7 @@ export default defineNuxtConfig({
     }
   },
   modules: [
-    './modules/test/index',
+    './modules/test',
     [
       '~/modules/example',
       {


### PR DESCRIPTION
### 🔗 Linked issue

follow-up on https://github.com/nuxt/nuxt/pull/20896
resolves https://github.com/nuxt/nuxt/issues/20883

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This follows up on https://github.com/nuxt/nuxt/pull/20896 to use `resolvePath` to handle other edge cases (like implicit `/index` of a module) that occur when installing modules.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
