### PR TITLE
docs: add link to layers from `pages/` docs

### DIFF
--- a/docs/2.guide/2.directory-structure/1.pages.md
+++ b/docs/2.guide/2.directory-structure/1.pages.md
@@ -389,4 +389,3 @@ export default defineNuxtConfig({
 ```
 
 :ReadMore{link="/docs/guide/going-further/layers"}
-

--- a/docs/2.guide/2.directory-structure/1.pages.md
+++ b/docs/2.guide/2.directory-structure/1.pages.md
@@ -361,3 +361,33 @@ function navigate(){
 As your app gets bigger and more complex, your routing might require more flexibility. For this reason, Nuxt directly exposes the router, routes and router options for customization in different ways.
 
 :ReadMore{link="/docs/guide/going-further/custom-routing"}
+
+## Multiple pages directories
+
+By default, all your pages should be in one `pages` directory at the root of your project.
+However, you can use Layers to create groupings of your app's pages.
+
+Example:
+
+```bash
+-| nuxt.config.ts
+-| some-app/
+---| nuxt.config.ts
+---| pages
+-----| app-page.vue
+```
+
+```ts
+// some-app/nuxt.config.ts
+export default defineNuxtConfig({
+})
+
+// nuxt.config.ts
+export default defineNuxtConfig({
+  extends: ['./some-app'],
+})
+
+```
+
+:ReadMore{link="/docs/guide/going-further/layers"}
+

--- a/docs/2.guide/2.directory-structure/1.pages.md
+++ b/docs/2.guide/2.directory-structure/1.pages.md
@@ -386,7 +386,6 @@ export default defineNuxtConfig({
 export default defineNuxtConfig({
   extends: ['./some-app'],
 })
-
 ```
 
 :ReadMore{link="/docs/guide/going-further/layers"}


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)

### 📚 Description

Not sure this is the best way, but I think it would be great if Layers would be mentioned on Pages as a way to create multiple pages directories. As someone who recently tried Next.js App Dir, I was looking for ways to achieve a similar code colocation file structure, and Layers seems to be a good way to do it. However, it took me about an hour to find out about this feature, after scouring through Github issues such as #13367 and nuxt/rfcs/issues/30 .


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
