### PR TITLE
fix(nuxt): await nuxt ready state before `refreshNuxtData`

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -3,6 +3,7 @@ import type { Ref, WatchSource } from 'vue'
 import type { NuxtApp } from '../nuxt'
 import { useNuxtApp } from '../nuxt'
 import { createError } from './error'
+import { onNuxtReady } from './ready'
 
 export type _Transform<Input = any, Output = any> = (input: Input) => Output
 
@@ -300,6 +301,9 @@ export async function refreshNuxtData (keys?: string | string[]): Promise<void> 
   if (process.server) {
     return Promise.resolve()
   }
+
+  await new Promise<void>(resolve => onNuxtReady(resolve))
+
   const _keys = keys ? Array.isArray(keys) ? keys : [keys] : undefined
   await useNuxtApp().hooks.callHookParallel('app:data:refresh', _keys)
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
n/a, internal mention: https://discord.com/channels/473401852243869706/1065634249174159420/1108033633870155836

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

This PRs aims at improving the DX of Nuxt utils by enforcing relevant utils to await Nuxt ready state before performing their actions. Basically, it ensures and simplifies the following kind of workflows:

```diff
// Before
- refreshNuxtData()                    // Inconsistent
- onNuxtReady(() => refreshNuxtData()) // Consistent

// After
+ refreshNuxtData()                    // Consistent
```

Indeed, some utils can have unexpected behavior when launched prior and/or during Nuxt initialization process. For example, `refreshNuxtData()`, when called from a plugin during Nuxt initialization process cannot refresh all Nuxt data properly because Nuxt data lifecycles are still in the process of being resolved. Awaiting for Nuxt to be initialized is almost mandatory if we want this util to work consistently.

**Considered utils**

So far, really, this PR only applies to `refreshNuxtData()`, I tried to consider utils alike.

- ❌ `abortNavigation`, can only be used inside route middlewares
- ❌ `clearError`, can't think of a scenario where this would make sense
- ❔ `clearNuxtData`, if there's no data to clear, there's no data to clear(?)
- ❔ `navigateTo`, maybe it applies to this one(?) not sure

That being said, if you see other utils where waiting for `onNuxtReady` seems mandatory, please voice it! Happy to update the PR.

**Doing nothing**

I've been torn a bit on whether or not we should bake in the `onNuxtReady` call. Basically: should we consider it a DX feature (having both separated) or a DX bug (what this PR fixes)

I'm leaning towards a DX bug hence this PR, but happy to reconsider it and close the PR if we settle on a DX feature (forcing explicit `onNuxtReady` calls where applicable)

Let me know if anything~

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
