### PR TITLE
fix(nuxt): show error page after fatal `abortNavigation`

### DIFF
--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -10,6 +10,7 @@ import { createError, showError } from './error'
 import { useState } from './state'
 
 import type { PageMeta } from '#app'
+import { isNuxtError } from '#app'
 
 export const useRouter: typeof _useRouter = () => {
   return useNuxtApp()?.$router as Router
@@ -158,7 +159,7 @@ export const abortNavigation = (err?: string | Partial<NuxtError>) => {
 
   if (!err) { return false }
 
-  if (typeof err === 'object' && err.fatal) {
+  if (isNuxtError(err) && err.fatal) {
     const nuxtApp = useNuxtApp()
     nuxtApp.runWithContext(() => showError(err))
   }

--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -6,7 +6,7 @@ import { hasProtocol, joinURL, parseURL } from 'ufo'
 
 import { useNuxtApp, useRuntimeConfig } from '../nuxt'
 import type { NuxtError } from './error'
-import { createError, isNuxtError, showError } from './error'
+import { createError, showError } from './error'
 import { useState } from './state'
 
 import type { PageMeta } from '#app'
@@ -158,12 +158,13 @@ export const abortNavigation = (err?: string | Partial<NuxtError>) => {
 
   if (!err) { return false }
 
-  if (isNuxtError(err) && err.fatal) {
-    const nuxtApp = useNuxtApp()
-    nuxtApp.runWithContext(() => showError(err))
+  err = createError(err)
+
+  if (err.fatal) {
+    useNuxtApp().runWithContext(() => showError(err as NuxtError))
   }
 
-  throw createError(err)
+  throw err
 }
 
 export const setPageLayout = (layout: string) => {

--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -6,7 +6,7 @@ import { hasProtocol, joinURL, parseURL } from 'ufo'
 
 import { useNuxtApp, useRuntimeConfig } from '../nuxt'
 import type { NuxtError } from './error'
-import { createError } from './error'
+import { createError, showError } from './error'
 import { useState } from './state'
 
 import type { PageMeta } from '#app'
@@ -155,10 +155,15 @@ export const abortNavigation = (err?: string | Partial<NuxtError>) => {
   if (process.dev && !isProcessingMiddleware()) {
     throw new Error('abortNavigation() is only usable inside a route middleware handler.')
   }
-  if (err) {
-    throw createError(err)
+
+  if (!err) { return false }
+
+  if (typeof err === 'object' && err.fatal) {
+    const nuxtApp = useNuxtApp()
+    nuxtApp.runWithContext(() => showError(err))
   }
-  return false
+
+  throw createError(err)
 }
 
 export const setPageLayout = (layout: string) => {

--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -6,11 +6,10 @@ import { hasProtocol, joinURL, parseURL } from 'ufo'
 
 import { useNuxtApp, useRuntimeConfig } from '../nuxt'
 import type { NuxtError } from './error'
-import { createError, showError } from './error'
+import { createError, isNuxtError, showError } from './error'
 import { useState } from './state'
 
 import type { PageMeta } from '#app'
-import { isNuxtError } from '#app'
 
 export const useRouter: typeof _useRouter = () => {
   return useNuxtApp()?.$router as Router

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -710,6 +710,14 @@ describe('middlewares', () => {
     expect(res.status).toEqual(401)
   })
 
+  it('should allow aborting navigation fatally on client-side', async () => {
+    const html = await $fetch('/middleware-abort')
+    expect(html).not.toContain('This is the error page')
+    const page = await createPage('/middleware-abort')
+    await page.waitForLoadState('networkidle')
+    expect(await page.innerHTML('body')).toContain('This is the error page')
+  })
+
   it('should inject auth', async () => {
     const html = await $fetch('/auth')
 

--- a/test/fixtures/basic/pages/middleware-abort.vue
+++ b/test/fixtures/basic/pages/middleware-abort.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+definePageMeta({
+  middleware: () => {
+    if (process.server || useNuxtApp().isHydrating) { return }
+    return abortNavigation({
+      fatal: true
+    })
+  }
+})
+const router = useRouter()
+onNuxtReady(() => router.push({ path: '/middleware-abort', force: true }))
+</script>
+
+<template>
+  <div>
+    <!--  -->
+  </div>
+</template>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
resolves #15053

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Show error page if `fatal: true` option was passed to `abortNavigation`

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
