### PR TITLE
docs: add `index.vue` to page routing example

### DIFF
--- a/docs/1.getting-started/5.routing.md
+++ b/docs/1.getting-started/5.routing.md
@@ -17,6 +17,7 @@ This file system routing uses naming conventions to create dynamic and nested ro
 ```text [pages/ directory]
 pages/
 --| about.vue
+--| index.vue
 --| posts/
 ----| [id].vue
 ```
@@ -27,6 +28,10 @@ pages/
     {
       "path": "/about",
       "component": "pages/about.vue"
+    },
+    {
+      "path": "/",
+      "component": "pages/index.vue"
     },
     {
       "path": "/posts/:id",


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Not adding `index.vue` while using `<NuxtPage>` results in `Page not found: /` and is required for nuxt to work as mentioned [here](https://nuxt.com/docs/getting-started/views#pages). This ensures a nuxt app following the example is actually runnable

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
