### PR TITLE
perf(nuxt): avoid watching nested paths

### DIFF
--- a/packages/nuxt/src/core/builder.ts
+++ b/packages/nuxt/src/core/builder.ts
@@ -116,7 +116,7 @@ function createGranularWatcher () {
         watchers[path].close()
         delete watchers[path]
       }
-      if (event === 'addDir' && path !== dir && !ignoredDirs.has(path) && !(path in watchers) && !isIgnored(path)) {
+      if (event === 'addDir' && path !== dir && !ignoredDirs.has(path) && !pathsToWatch.includes(path) && !(path in watchers) && !isIgnored(path)) {
         watchers[path] = chokidar.watch(path, { ...nuxt.options.watchers.chokidar, ignored: [isIgnored] })
         watchers[path].on('all', (event, path) => nuxt.callHook('builder:watch', event, normalize(path)))
         nuxt.hook('close', () => watchers[path].close())

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -357,6 +357,7 @@ export default defineUntypedSchema({
       '**/*.d.ts', // ignore type declarations
       '.output',
       '.git',
+      '.cache',
       await get('analyzeDir'),
       await get('buildDir'),
       await get('ignorePrefix') && `**/${await get('ignorePrefix')}*.*`


### PR DESCRIPTION
### 🔗 Linked issue

resolves nuxt/nuxt#20596

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This handles an edge case, specifically when cloning a layer with a demo project located _within_ it (like https://github.com/Atinux/content-wind/tree/main/.demo). Currently this means we don't properly benefit from the granular watcher pattern and exclude `node_modules`, `.git` and `.cache` folders within the subfolder.

Before watching a subfolder, this PR first checks whether it is a layer and if so skips creating the additional watcher.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
