### PR TITLE
fix(nuxt): handle serialising empty bigint

### DIFF
--- a/packages/nuxt/src/app/plugins/revive-payload.client.ts
+++ b/packages/nuxt/src/app/plugins/revive-payload.client.ts
@@ -5,8 +5,8 @@ import { defineNuxtPlugin } from '#app/nuxt'
 
 const revivers = {
   NuxtError: (data: any) => createError(data),
-  EmptyShallowRef: (data: any) => shallowRef(data === '_' ? undefined : JSON.parse(data)),
-  EmptyRef: (data: any) => ref(data === '_' ? undefined : JSON.parse(data)),
+  EmptyShallowRef: (data: any) => shallowRef(data === '_' ? undefined : data.slice(-1) === 'n' ? BigInt(data.slice(-1)) : JSON.parse(data)),
+  EmptyRef: (data: any) => ref(data === '_' ? undefined : data.slice(-1) === 'n' ? BigInt(data.slice(-1)) : JSON.parse(data)),
   ShallowRef: (data: any) => shallowRef(data),
   ShallowReactive: (data: any) => shallowReactive(data),
   Ref: (data: any) => ref(data),

--- a/packages/nuxt/src/app/plugins/revive-payload.client.ts
+++ b/packages/nuxt/src/app/plugins/revive-payload.client.ts
@@ -5,8 +5,8 @@ import { defineNuxtPlugin } from '#app/nuxt'
 
 const revivers = {
   NuxtError: (data: any) => createError(data),
-  EmptyShallowRef: (data: any) => shallowRef(data === '_' ? undefined : data.slice(-1) === 'n' ? BigInt(data.slice(0, -1)) : JSON.parse(data)),
-  EmptyRef: (data: any) => ref(data === '_' ? undefined : data.slice(-1) === 'n' ? BigInt(data.slice(0, -1)) : JSON.parse(data)),
+  EmptyShallowRef: (data: any) => shallowRef(data === '_' ? undefined : data === '0n' ? 0n : JSON.parse(data)),
+  EmptyRef: (data: any) => ref(data === '_' ? undefined : data === '0n' ? 0n : JSON.parse(data)),
   ShallowRef: (data: any) => shallowRef(data),
   ShallowReactive: (data: any) => shallowReactive(data),
   Ref: (data: any) => ref(data),

--- a/packages/nuxt/src/app/plugins/revive-payload.client.ts
+++ b/packages/nuxt/src/app/plugins/revive-payload.client.ts
@@ -5,8 +5,8 @@ import { defineNuxtPlugin } from '#app/nuxt'
 
 const revivers = {
   NuxtError: (data: any) => createError(data),
-  EmptyShallowRef: (data: any) => shallowRef(data === '_' ? undefined : data.slice(-1) === 'n' ? BigInt(data.slice(-1)) : JSON.parse(data)),
-  EmptyRef: (data: any) => ref(data === '_' ? undefined : data.slice(-1) === 'n' ? BigInt(data.slice(-1)) : JSON.parse(data)),
+  EmptyShallowRef: (data: any) => shallowRef(data === '_' ? undefined : data.slice(-1) === 'n' ? BigInt(data.slice(0, -1)) : JSON.parse(data)),
+  EmptyRef: (data: any) => ref(data === '_' ? undefined : data.slice(-1) === 'n' ? BigInt(data.slice(0, -1)) : JSON.parse(data)),
   ShallowRef: (data: any) => shallowRef(data),
   ShallowReactive: (data: any) => shallowReactive(data),
   Ref: (data: any) => ref(data),

--- a/packages/nuxt/src/app/plugins/revive-payload.server.ts
+++ b/packages/nuxt/src/app/plugins/revive-payload.server.ts
@@ -6,8 +6,8 @@ import { defineNuxtPlugin } from '#app/nuxt'
 
 const reducers = {
   NuxtError: (data: any) => isNuxtError(data) && data.toJSON(),
-  EmptyShallowRef: (data: any) => isRef(data) && isShallow(data) && !data.value && (JSON.stringify(data.value) || '_'),
-  EmptyRef: (data: any) => isRef(data) && !data.value && (JSON.stringify(data.value) || '_'),
+  EmptyShallowRef: (data: any) => isRef(data) && isShallow(data) && !data.value && (typeof data.value === 'bigint' ? data.value + 'n' : (JSON.stringify(data.value) || '_')),
+  EmptyRef: (data: any) => isRef(data) && !data.value && (typeof data.value === 'bigint' ? data.value + 'n' : (JSON.stringify(data.value) || '_')),
   ShallowRef: (data: any) => isRef(data) && isShallow(data) && data.value,
   ShallowReactive: (data: any) => isReactive(data) && isShallow(data) && toRaw(data),
   Ref: (data: any) => isRef(data) && data.value,

--- a/packages/nuxt/src/app/plugins/revive-payload.server.ts
+++ b/packages/nuxt/src/app/plugins/revive-payload.server.ts
@@ -6,8 +6,8 @@ import { defineNuxtPlugin } from '#app/nuxt'
 
 const reducers = {
   NuxtError: (data: any) => isNuxtError(data) && data.toJSON(),
-  EmptyShallowRef: (data: any) => isRef(data) && isShallow(data) && !data.value && (typeof data.value === 'bigint' ? data.value + 'n' : (JSON.stringify(data.value) || '_')),
-  EmptyRef: (data: any) => isRef(data) && !data.value && (typeof data.value === 'bigint' ? data.value + 'n' : (JSON.stringify(data.value) || '_')),
+  EmptyShallowRef: (data: any) => isRef(data) && isShallow(data) && !data.value && (typeof data.value === 'bigint' ? '0n' : (JSON.stringify(data.value) || '_')),
+  EmptyRef: (data: any) => isRef(data) && !data.value && (typeof data.value === 'bigint' ? '0n' : (JSON.stringify(data.value) || '_')),
   ShallowRef: (data: any) => isRef(data) && isShallow(data) && data.value,
   ShallowReactive: (data: any) => isReactive(data) && isShallow(data) && toRaw(data),
   Ref: (data: any) => isRef(data) && data.value,

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -34,7 +34,7 @@ describe.skipIf(isWindows || process.env.TEST_BUILDER === 'webpack' || process.e
 
   it('default client bundle size', async () => {
     stats.client = await analyzeSizes('**/*.js', publicDir)
-    expect(roundToKilobytes(stats.client.totalBytes)).toMatchInlineSnapshot('"97.8k"')
+    expect(roundToKilobytes(stats.client.totalBytes)).toMatchInlineSnapshot('"97.7k"')
     expect(stats.client.files.map(f => f.replace(/\..*\.js/, '.js'))).toMatchInlineSnapshot(`
       [
         "_nuxt/entry.js",
@@ -45,7 +45,7 @@ describe.skipIf(isWindows || process.env.TEST_BUILDER === 'webpack' || process.e
 
   it('default server bundle size', async () => {
     stats.server = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect(roundToKilobytes(stats.server.totalBytes)).toMatchInlineSnapshot('"62.5k"')
+    expect(roundToKilobytes(stats.server.totalBytes)).toMatchInlineSnapshot('"62.4k"')
 
     const modules = await analyzeSizes('node_modules/**/*', serverDir)
     expect(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot('"2284k"')

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -34,7 +34,7 @@ describe.skipIf(isWindows || process.env.TEST_BUILDER === 'webpack' || process.e
 
   it('default client bundle size', async () => {
     stats.client = await analyzeSizes('**/*.js', publicDir)
-    expect(roundToKilobytes(stats.client.totalBytes)).toMatchInlineSnapshot('"97.7k"')
+    expect(roundToKilobytes(stats.client.totalBytes)).toMatchInlineSnapshot('"97.8k"')
     expect(stats.client.files.map(f => f.replace(/\..*\.js/, '.js'))).toMatchInlineSnapshot(`
       [
         "_nuxt/entry.js",
@@ -45,7 +45,7 @@ describe.skipIf(isWindows || process.env.TEST_BUILDER === 'webpack' || process.e
 
   it('default server bundle size', async () => {
     stats.server = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect(roundToKilobytes(stats.server.totalBytes)).toMatchInlineSnapshot('"62.4k"')
+    expect(roundToKilobytes(stats.server.totalBytes)).toMatchInlineSnapshot('"62.5k"')
 
     const modules = await analyzeSizes('node_modules/**/*', serverDir)
     expect(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot('"2284k"')

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -128,6 +128,19 @@ export default defineNuxtConfig({
   },
   telemetry: false, // for testing telemetry types - it is auto-disabled in tests
   hooks: {
+    'webpack:config' (configs) {
+      // in order to test bigint serialisation we need to set target to a more modern one
+      for (const config of configs) {
+        const esbuildRules = config.module!.rules!.filter(
+          rule => typeof rule === 'object' && rule && 'loader' in rule && rule.loader === 'esbuild-loader'
+        )
+        for (const rule of esbuildRules) {
+          if (typeof rule === 'object' && typeof rule.options === 'object') {
+            rule.options.target = 'es2022'
+          }
+        }
+      }
+    },
     'modules:done' () {
       addComponent({
         name: 'CustomComponent',

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -40,6 +40,12 @@ export default defineNuxtConfig({
     './extends/node_modules/foo'
   ],
   nitro: {
+    esbuild: {
+      options: {
+        // in order to test bigint serialisation
+        target: 'es2022'
+      }
+    },
     routeRules: {
       '/route-rules/spa': { ssr: false },
       '/no-scripts': { experimentalNoScripts: true }

--- a/test/fixtures/basic/pages/json-payload.vue
+++ b/test/fixtures/basic/pages/json-payload.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 const state = useState(() => shallowRef({} as Record<string, any>))
+const nonDisplayedState = useState(() => shallowRef({} as Record<string, any>))
 
 if (process.server) {
   const r = ref('')
@@ -10,6 +11,8 @@ if (process.server) {
   state.value.reactive = reactive({ ref: r })
   state.value.error = createError({ message: 'error' })
   state.value.date = new Date()
+  nonDisplayedState.value.bigint = 0n
+  nonDisplayedState.value.bigintRef = ref(0n)
 }
 </script>
 
@@ -17,10 +20,12 @@ if (process.server) {
   <div>
     <pre>{{ state }}</pre>
     Date: {{ state.date instanceof Date }} <br>
+    BigInt: {{ nonDisplayedState.bigint === 0n }} <br>
     Error: {{ isNuxtError(state.error) }} <hr>
     Shallow reactive: {{ isReactive(state.shallowReactive) && isShallow(state.shallowReactive) }} <br>
     Shallow ref: {{ isShallow(state.shallowRef) }} <br>
     Undefined ref: {{ isRef(state.undefined) }} <br>
+    BigInt ref: {{ isRef(nonDisplayedState.bigintRef) && typeof nonDisplayedState.bigintRef.value === 'bigint' }} <br>
     Reactive: {{ isReactive(state.reactive) }} <br>
     Ref: {{ isRef(state.ref) }} <hr>
     Recursive objects: {{ state.ref === state.shallowReactive.nested.ref }} <br>


### PR DESCRIPTION
### 🔗 Linked issue

vuejs/pinia#2236

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We have an edge case for serialising `ref(0n)` which is falsy. This adds a test for bigints and updates the test fixture.

Note that there are a number of other edge cases with bigint, including not being able to _display_ them in vue components and also Nitro/webpack esbuild targets need to be updated to support them.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
