### PR TITLE
docs: migrate transition class names and style prop

### DIFF
--- a/docs/7.migration/6.pages-and-layouts.md
+++ b/docs/7.migration/6.pages-and-layouts.md
@@ -85,7 +85,7 @@ See [more about migrating Nuxt component hooks](/docs/migration/component-option
 
 ### Page and Layout Transitions
 
-If you have been defining transitions for your page or layout directly in your component options, you will now need to use `definePageMeta` to set the transition.
+If you have been defining transitions for your page or layout directly in your component options, you will now need to use `definePageMeta` to set the transition. Since Vue 3, [-enter and -leave CSS classes have been renamed](https://v3-migration.vuejs.org/breaking-changes/transition.html). The `style` prop from `<Nuxt>` no longer applies to transition when used on `<slot>`, so move the styles to your `-active` class.
 
 [Read more about `pages/`](/docs/guide/directory-structure/pages).
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

If developers have defined their own transition, for example by copying a `slide-fade` example from https://v2.vuejs.org/v2/guide/transitions.html#CSS-Transitions, `-enter` is replaced by `-enter-from` and `-leave` by `-leave-from` as per new examples at https://vuejs.org/guide/built-ins/transition.html#css-based-transitions. I've linked the Vue 3 migration page.

Moreover, there is a change to the behavior of `style` prop of the page slot referenced in layout (for example, I've had to use a `width: 100%` workaround to avoid the disappearing page being smaller during the transition).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
