### PR TITLE
docs: add hint for useAsyncData() in local environment

### DIFF
--- a/docs/3.api/1.composables/use-async-data.md
+++ b/docs/3.api/1.composables/use-async-data.md
@@ -9,6 +9,10 @@ Within your pages, components, and plugins you can use useAsyncData to get acces
 `useAsyncData` is a composable meant to be called directly in a setup function, plugin, or route middleware. It returns reactive composables and handles adding responses to the Nuxt payload so they can be passed from server to client without re-fetching the data on client side when the page hydrates.
 ::
 
+::alert{type=warning}
+If you are working in a local environment and want to retrieve data from a local API you should use a real IP address such as `127.0.0.1` instead of `localhost` so that `useAsyncData()` works correctly.
+::
+
 ## Type
 
 ```ts [Signature]


### PR DESCRIPTION
When working with APIs on `localhost` it seems that you have to use real IPs in order to work with `useAsyncData()` in `SSR` mode.
A small hint in the docs might help a lot as it's hard to find any information on this.
