### PR TITLE
chore: avoid inlining deps in vitest

### DIFF
--- a/packages/nuxt/test/treeshake-client.test.ts
+++ b/packages/nuxt/test/treeshake-client.test.ts
@@ -9,12 +9,6 @@ import _vuePlugin from '@vitejs/plugin-vue'
 import { TreeShakeTemplatePlugin } from '../src/components/tree-shake'
 import { fixtureDir, normalizeLineEndings } from './utils'
 
-vi.mock('node:crypto', () => ({
-  update: vi.fn().mockReturnThis(),
-  digest: vi.fn().mockReturnValue('one-hash-to-rule-them-all'),
-  createHash: vi.fn().mockReturnThis()
-}))
-
 // mock due to differences of results between windows and linux
 vi.spyOn(path, 'relative').mockImplementation((from: string, to: string) => {
   if (to.includes('SomeComponent')) {
@@ -90,7 +84,7 @@ async function SFCCompile (name: string, source: string, options: Options, ssr =
   return typeof result === 'string' ? result : result?.code
 }
 
-const stateToTest: {name: string, options: Partial<Options & {devServer: {config: {server: any}}}> }[] = [
+const stateToTest: { name: string, options: Partial<Options & { devServer: { config: { server: any } } }> }[] = [
   {
     name: 'prod',
     options: {
@@ -188,7 +182,7 @@ describe('treeshake client only in ssr', () => {
         expect(treeshaken).not.toContain('ssrRenderComponent(_unref(HelloWorld')
         expect(treeshaken).toContain('ssrRenderComponent(_unref(Glob')
       }
-      expect(treeshaken).toMatchSnapshot()
+      expect(treeshaken.replace(/data-v-[\d\w]{8}/g, 'data-v-one-hash').replace(/scoped=[\d\w]{8}/g, 'scoped=one-hash')).toMatchSnapshot()
     })
   }
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,11 +14,6 @@ export default defineConfig({
   test: {
     globalSetup: 'test/setup.ts',
     testTimeout: isWindows ? 60000 : 10000,
-    deps: {
-      experimentalOptimizer: {
-        enabled: true
-      }
-    },
     // Excluded plugin because it should throw an error when accidentally loaded via Nuxt
     exclude: [...configDefaults.exclude, '**/this-should-not-load.spec.js'],
     maxThreads: process.env.TEST_ENV === 'dev' ? 1 : undefined,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,7 +14,11 @@ export default defineConfig({
   test: {
     globalSetup: 'test/setup.ts',
     testTimeout: isWindows ? 60000 : 10000,
-    deps: { inline: ['@vitejs/plugin-vue'] },
+    deps: {
+      experimentalOptimizer: {
+        enabled: true
+      }
+    },
     // Excluded plugin because it should throw an error when accidentally loaded via Nuxt
     exclude: [...configDefaults.exclude, '**/this-should-not-load.spec.js'],
     maxThreads: process.env.TEST_ENV === 'dev' ? 1 : undefined,


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/vitest-dev/vitest/issues/2806#issuecomment-1572506412

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This switches our internal vitest config to use the new `deps.experimentalOptimizer` in vitest. (cc: @antfu)

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
