### PR TITLE
feat(nuxt): add `open` option in `navigateTo` helper

### DIFF
--- a/docs/3.api/3.utils/navigate-to.md
+++ b/docs/3.api/3.utils/navigate-to.md
@@ -120,7 +120,7 @@ An object accepting the following properties:
   
       **Type**: `boolean`
 
-    Refer to the [documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/ope) for more detailed information on the **windowFeatures** properties.
+    Refer to the [documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/open) for more detailed information on the **windowFeatures** properties.
 
 ## Examples
 

--- a/docs/3.api/3.utils/navigate-to.md
+++ b/docs/3.api/3.utils/navigate-to.md
@@ -72,29 +72,55 @@ An object accepting the following properties:
 
 - `open` (optional)
 
-  **Type**: `WindowOpenOptions`
+  **Type**: `OpenOptions`
 
   Allows navigating to the URL using the [open()](https://developer.mozilla.org/en-US/docs/Web/API/Window/open) method of the window. This option is only applicable on the client side and will be ignored on the server side.
-  
-  ```ts
-  interface WindowOpenFeatures {
-    width?: number;
-    innerWidth?: number;
-    height?: number;
-    innerHeight?: number;
-    left?: number;
-    screenX?: number;
-    top?: number;
-    screenY?: number;
-    noopener?: boolean;
-    noreferrer?: boolean;
-  }
 
-  interface WindowOpenOptions {
-    target: '_self' | '_blank' | '_parent' | '_top';
-    windowFeatures?: WindowOpenFeatures;
-  }
-  ```
+  An object accepting the following properties:
+
+  - `target`
+
+    **Type**: `string`
+
+    **Default**: `'_blank'`
+
+    A string, without whitespace, specifying the name of the browsing context the resource is being loaded into.
+
+  - `windowFeatures` (optional)
+
+    **Type**: `OpenWindowFeatures`
+
+    An object accepting the following properties:
+    
+    - `popup` (optional)
+      
+      **Type**: `boolean`
+
+    - `width` or `innerWidth` (optional)
+      
+      **Type**: `number`
+
+    - `height` or `innerHeight` (optional)
+      
+      **Type**: `number`
+
+    - `left` or `screenX` (optional)
+      
+      **Type**: `number`
+
+    - `top` or `screenY` (optional)
+      
+      **Type**: `number`
+  
+    - `noopener` (optional)
+      
+      **Type**: `boolean`
+
+    - `noreferrer` (optional)
+  
+      **Type**: `boolean`
+    
+    Refer to the [documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/ope) for more detailed information on the **windowFeatures** properties.
 
 ## Examples
 

--- a/docs/3.api/3.utils/navigate-to.md
+++ b/docs/3.api/3.utils/navigate-to.md
@@ -18,7 +18,7 @@ interface NavigateToOptions {
   replace?: boolean
   redirectCode?: number
   external?: boolean,
-  open?: WindowOpenOptions
+  open?: OpenOptions
 }
 ```
 

--- a/docs/3.api/3.utils/navigate-to.md
+++ b/docs/3.api/3.utils/navigate-to.md
@@ -17,7 +17,7 @@ navigateTo(to: RouteLocationRaw | undefined | null, options?: NavigateToOptions)
 interface NavigateToOptions {
   replace?: boolean
   redirectCode?: number
-  external?: boolean,
+  external?: boolean
   open?: OpenOptions
 }
 ```

--- a/docs/3.api/3.utils/navigate-to.md
+++ b/docs/3.api/3.utils/navigate-to.md
@@ -91,35 +91,35 @@ An object accepting the following properties:
     **Type**: `OpenWindowFeatures`
 
     An object accepting the following properties:
-    
+
     - `popup` (optional)
-      
+
       **Type**: `boolean`
 
     - `width` or `innerWidth` (optional)
-      
+
       **Type**: `number`
 
     - `height` or `innerHeight` (optional)
-      
+
       **Type**: `number`
 
     - `left` or `screenX` (optional)
-      
+
       **Type**: `number`
 
     - `top` or `screenY` (optional)
-      
+
       **Type**: `number`
   
     - `noopener` (optional)
-      
+
       **Type**: `boolean`
 
     - `noreferrer` (optional)
   
       **Type**: `boolean`
-    
+
     Refer to the [documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/ope) for more detailed information on the **windowFeatures** properties.
 
 ## Examples

--- a/docs/3.api/3.utils/navigate-to.md
+++ b/docs/3.api/3.utils/navigate-to.md
@@ -17,7 +17,8 @@ navigateTo(to: RouteLocationRaw | undefined | null, options?: NavigateToOptions)
 interface NavigateToOptions {
   replace?: boolean
   redirectCode?: number
-  external?: boolean
+  external?: boolean,
+  open?: WindowOpenOptions
 }
 ```
 
@@ -69,6 +70,32 @@ An object accepting the following properties:
 
   Allows navigating to an external URL when set to `true`. Otherwise, `navigateTo` will throw an error, as external navigation is not allowed by default.
 
+- `open` (optional)
+
+  **Type**: `WindowOpenOptions`
+
+  Allows navigating to the URL using the [open()](https://developer.mozilla.org/en-US/docs/Web/API/Window/open) method of the window. This option is only applicable on the client side and will be ignored on the server side.
+  
+  ```ts
+  interface WindowOpenFeatures {
+    width?: number;
+    innerWidth?: number;
+    height?: number;
+    innerHeight?: number;
+    left?: number;
+    screenX?: number;
+    top?: number;
+    screenY?: number;
+    noopener?: boolean;
+    noreferrer?: boolean;
+  }
+
+  interface WindowOpenOptions {
+    target: '_self' | '_blank' | '_parent' | '_top';
+    windowFeatures?: WindowOpenFeatures;
+  }
+  ```
+
 ## Examples
 
 ### Navigating Within a Vue Component
@@ -117,6 +144,23 @@ await navigateTo('https://nuxt.com')
 // will redirect successfully with the 'external' parameter set to 'true'
 await navigateTo('https://nuxt.com', {
   external: true
+})
+</script>
+```
+
+### Navigating using open()
+
+```vue
+<script setup>
+// will open 'https://nuxt.com' in a new tab
+await navigateTo('https://nuxt.com', {  
+  open: {
+    target: '_blank'
+    windowFeatures: {
+      width: 500,
+      height: 500
+    }
+  }
 })
 </script>
 ```

--- a/docs/3.api/3.utils/navigate-to.md
+++ b/docs/3.api/3.utils/navigate-to.md
@@ -155,7 +155,7 @@ await navigateTo('https://nuxt.com', {
 // will open 'https://nuxt.com' in a new tab
 await navigateTo('https://nuxt.com', {  
   open: {
-    target: '_blank'
+    target: '_blank',
     windowFeatures: {
       width: 500,
       height: 500

--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -99,10 +99,10 @@ export type OpenOptions = {
 }
 
 export interface NavigateToOptions {
-  replace?: boolean;
-  redirectCode?: number;
-  external?: boolean;
-  open?: OpenOptions;
+  replace?: boolean
+  redirectCode?: number,
+  external?: boolean,
+  open?: OpenOptions
 }
 
 export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: NavigateToOptions): Promise<void | NavigationFailure | false> | false | void | RouteLocationRaw => {

--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -100,8 +100,8 @@ export type OpenOptions = {
 
 export interface NavigateToOptions {
   replace?: boolean
-  redirectCode?: number,
-  external?: boolean,
+  redirectCode?: number
+  external?: boolean
   open?: OpenOptions
 }
 

--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -119,11 +119,7 @@ export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: Na
 
       const features = Object.entries(windowFeatures)
         .filter(([_, value]) => value !== undefined)
-        .map(([feature, value]) => {
-          const formattedValue = typeof value === 'boolean' ? (value ? 'true' : 'false') : value
-
-          return `${feature.toLowerCase()}=${formattedValue}`
-        })
+        .map(([feature, value]) => `${feature.toLowerCase()}=${value}`)
         .join(', ')
 
       open(toPath, target, features)

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -45,7 +45,7 @@ describe.skipIf(isWindows || process.env.TEST_BUILDER === 'webpack' || process.e
 
   it('default server bundle size', async () => {
     stats.server = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect(roundToKilobytes(stats.server.totalBytes)).toMatchInlineSnapshot('"62.5k"')
+    expect(roundToKilobytes(stats.server.totalBytes)).toMatchInlineSnapshot('"62.6k"')
 
     const modules = await analyzeSizes('node_modules/**/*', serverDir)
     expect(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot('"2284k"')

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -34,7 +34,7 @@ describe.skipIf(isWindows || process.env.TEST_BUILDER === 'webpack' || process.e
 
   it('default client bundle size', async () => {
     stats.client = await analyzeSizes('**/*.js', publicDir)
-    expect(roundToKilobytes(stats.client.totalBytes)).toMatchInlineSnapshot('"97.7k"')
+    expect(roundToKilobytes(stats.client.totalBytes)).toMatchInlineSnapshot('"98.0k"')
     expect(stats.client.files.map(f => f.replace(/\..*\.js/, '.js'))).toMatchInlineSnapshot(`
       [
         "_nuxt/entry.js",


### PR DESCRIPTION
### 🔗 Linked issue

#20625 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

1. Extend the _NavigateToOptions_ interface to include a new optional object parameter, `open`. 
This parameter, when set, will instruct the navigateTo function to open the URL using window.open method.

2. Modify the _navigateTo_ function to handle the `open` option. This option is only applicable on the client side and will be ignored on the server side.

Resolves #20625 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
