### PR TITLE
docs: include example for server utilities

### DIFF
--- a/docs/2.guide/2.directory-structure/1.server.md
+++ b/docs/2.guide/2.directory-structure/1.server.md
@@ -102,6 +102,29 @@ Server routes are powered by [unjs/h3](https://github.com/unjs/h3) which comes w
 
 You can add more helpers yourself inside the `~/server/utils` directory.
 
+
+For example, you can define a custom handler utility that wraps the original handler and performs additional operations before returning the final response.
+
+**Example:**
+
+```ts [server/utils/handler.ts]
+import type { H3Event } from 'h3'
+
+export const defineMyHandler = (handler: (event: H3Event) => any) => {
+  const _handler = async (event: H3Event) => {
+    const response = await handler(event)
+
+    // mutate the response for all routes
+    const responseNew = doSome(response)
+
+    return responseNew
+  }
+
+  return defineEventHandler(_handler)
+}
+```
+
+
 ## Server Types
 
 ::alert{type="info"}

--- a/docs/2.guide/2.directory-structure/1.server.md
+++ b/docs/2.guide/2.directory-structure/1.server.md
@@ -102,7 +102,6 @@ Server routes are powered by [unjs/h3](https://github.com/unjs/h3) which comes w
 
 You can add more helpers yourself inside the `~/server/utils` directory.
 
-
 For example, you can define a custom handler utility that wraps the original handler and performs additional operations before returning the final response.
 
 **Example:**
@@ -123,7 +122,6 @@ export const defineMyHandler = (handler: (event: H3Event) => any) => {
   return defineEventHandler(_handler)
 }
 ```
-
 
 ## Server Types
 

--- a/docs/2.guide/2.directory-structure/1.server.md
+++ b/docs/2.guide/2.directory-structure/1.server.md
@@ -107,20 +107,20 @@ For example, you can define a custom handler utility that wraps the original han
 **Example:**
 
 ```ts [server/utils/handler.ts]
-import type { H3Event } from 'h3'
+import type { EventHandler } from 'h3'
 
-export const defineMyHandler = (handler: (event: H3Event) => any) => {
-  const _handler = async (event: H3Event) => {
-    const response = await handler(event)
-
-    // mutate the response for all routes
-    const responseNew = doSome(response)
-
-    return responseNew
-  }
-
-  return defineEventHandler(_handler)
-}
+export const defineWrappedResponseHandler = (handler: EventHandler) =>
+  defineEventHandler(async (event) => {
+    try {
+      // do something before the route handler
+      const response = await handler(event)
+      // do something after the route handler
+      return { response }
+    } catch (err) {
+      // Error handling
+      return { err }
+    }
+  })
 ```
 
 ## Server Types


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/21315

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I have a use case where I need to encapsulate all responses from each endpoint within an object. This can be achieved by utilizing a server utility. However, it appears that the documentation currently lacks proper explanation of this feature, and it would be beneficial to include a concise example for clarification. (Credits to [@maou-shonen](https://github.com/maou-shonen) for bringing this possibility to my attention, as discussed in this GitHub issue: https://github.com/unjs/h3/issues/397)


### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
