### PR TITLE
docs: remove irregular spaces

### DIFF
--- a/docs/2.guide/2.directory-structure/1.components.md
+++ b/docs/2.guide/2.directory-structure/1.components.md
@@ -1,13 +1,13 @@
 ---
 navigation.icon: IconDirectory
 title: "components"
-description: "The components/ directory is where you put all your Vue components."
+description: "The components/ directory is where you put all your Vue components."
 head.title: "components/"
 ---
 
 # Components Directory
 
-The `components/` directory is where you put all your Vue components which can then be imported inside your pages or other components ([learn more](https://vuejs.org/guide/essentials/component-basics.html#components-basics)).
+The `components/` directory is where you put all your Vue components which can then be imported inside your pages or other components ([learn more](https://vuejs.org/guide/essentials/component-basics.html#components-basics)).
 
 Nuxt automatically imports any components in your `components/` directory (along with components that are registered by any modules you may be using).
 

--- a/docs/2.guide/2.directory-structure/1.pages.md
+++ b/docs/2.guide/2.directory-structure/1.pages.md
@@ -182,7 +182,7 @@ This file tree will generate these routes:
 ]
 ```
 
-To display the `child.vue` component, you have to insert the `<NuxtPage>` component inside `pages/parent.vue`:
+To display the `child.vue` component, you have to insert the `<NuxtPage>` component inside `pages/parent.vue`:
 
 ```html{}[pages/parent.vue]
 <template>
@@ -317,7 +317,7 @@ export {}
 
 ## Navigation
 
-To navigate between pages of your app, you should use the [`<NuxtLink>`](/docs/api/components/nuxt-link) component.
+To navigate between pages of your app, you should use the [`<NuxtLink>`](/docs/api/components/nuxt-link) component.
 
 This component is included with Nuxt and therefore you don't have to import it as you do with other components.
 

--- a/docs/2.guide/2.directory-structure/1.public.md
+++ b/docs/2.guide/2.directory-structure/1.public.md
@@ -7,7 +7,7 @@ head.title: "public/"
 
 # Public Directory
 
-The `public/` directory is directly served at the server root and contains public files that have to keep their names (e.g. `robots.txt`) _or_ likely won't change (e.g. `favicon.ico`).
+The `public/` directory is directly served at the server root and contains public files that have to keep their names (e.g. `robots.txt`) _or_ likely won't change (e.g. `favicon.ico`).
 
 ::alert{icon=💡}
 This is known as the [`static/`](https://nuxtjs.org/docs/directory-structure/static) directory in Nuxt 2.

--- a/docs/2.guide/2.directory-structure/3.package.md
+++ b/docs/2.guide/2.directory-structure/3.package.md
@@ -2,9 +2,9 @@
 navigation.icon: IconFile
 title: package.json
 head.title: package.json
-description: The package.json file contains all the dependencies and scripts for your application.
+description: The package.json file contains all the dependencies and scripts for your application.
 ---
 
 # Package.json File
 
-The `package.json` file contains all the dependencies and scripts for your application ([learn more](https://docs.npmjs.com/cli/v7/configuring-npm/package-json)).
+The `package.json` file contains all the dependencies and scripts for your application ([learn more](https://docs.npmjs.com/cli/v7/configuring-npm/package-json)).

--- a/docs/3.api/1.composables/use-nuxt-app.md
+++ b/docs/3.api/1.composables/use-nuxt-app.md
@@ -14,7 +14,7 @@ You can use `useNuxtApp()` within composables, plugins and components.
 
 ### `provide (name, value)`
 
-`nuxtApp` is a runtime context that you can extend using [Nuxt plugins](/docs/guide/directory-structure/plugins). Use the `provide` function to create Nuxt plugins to make values and helper methods available in your Nuxt application across all composables and components.
+`nuxtApp` is a runtime context that you can extend using [Nuxt plugins](/docs/guide/directory-structure/plugins). Use the `provide` function to create Nuxt plugins to make values and helper methods available in your Nuxt application across all composables and components.
 
 `provide` function accepts `name` and `value` parameters.
 
@@ -70,7 +70,7 @@ await nuxtApp.callHook('my-plugin:init')
 
 - [**component()**](https://vuejs.org/api/application.html#app-component) - Registers a global component if passing both a name string and a component definition, or retrieves an already registered one if only the name is passed.
 - [**directive()**](https://vuejs.org/api/application.html#app-directive) - Registers a global custom directive if passing both a name string and a directive definition, or retrieves an already registered one if only the name is passed[(example)](/docs/guide/directory-structure/plugins#vue-directives).
-- [**use()**](https://vuejs.org/api/application.html#app-use) - Installs a **[Vue.js Plugin](https://vuejs.org/guide/reusability/plugins.html)** [(example)](/docs/guide/directory-structure/plugins#vue-plugins).
+- [**use()**](https://vuejs.org/api/application.html#app-use) - Installs a **[Vue.js Plugin](https://vuejs.org/guide/reusability/plugins.html)** [(example)](/docs/guide/directory-structure/plugins#vue-plugins).
 
 :ReadMore{link="https://vuejs.org/api/application.html#application-api"}
 

--- a/docs/3.api/2.components/2.nuxt-page.md
+++ b/docs/3.api/2.components/2.nuxt-page.md
@@ -11,7 +11,7 @@ description: The NuxtPage component is required to display pages located in the 
 
 - **name:** type: `string`
 
-`name` helps `RouterView` render the component with the corresponding name in the matched route record's components option.
+`name` helps `RouterView` render the component with the corresponding name in the matched route record's components option.
 
 - **route:** type: `RouteLocationNormalized`
 

--- a/docs/3.api/3.utils/abort-navigation.md
+++ b/docs/3.api/3.utils/abort-navigation.md
@@ -22,7 +22,7 @@ abortNavigation(err?: Error | string): false
 
 - **Type**: [`Error`](https://developer.mozilla.org/pl/docs/Web/JavaScript/Reference/Global_Objects/Error) | `string`
 
-  Optional error to be thrown by `abortNavigation`.
+  Optional error to be thrown by `abortNavigation`.
 
 ## Examples
 

--- a/docs/3.api/3.utils/define-nuxt-route-middleware.md
+++ b/docs/3.api/3.utils/define-nuxt-route-middleware.md
@@ -26,7 +26,7 @@ interface RouteMiddleware {
 
 A function that takes two Vue Router's route location objects as parameters: the next route `to` as the first, and the current route `from` as the second.
 
-Learn more about available properties of `RouteLocationNormalized` in the **[Vue Router docs](https://router.vuejs.org/api/interfaces/RouteLocationNormalized.html)**.
+Learn more about available properties of `RouteLocationNormalized` in the **[Vue Router docs](https://router.vuejs.org/api/interfaces/RouteLocationNormalized.html)**.
 
 ## Examples
 

--- a/docs/3.api/3.utils/update-app-config.md
+++ b/docs/3.api/3.utils/update-app-config.md
@@ -5,7 +5,7 @@ Updates [app config](/docs/guide/directory-structure/app-config) using deep assi
 **Usage:**
 
 ```js
-const appConfig = useAppConfig() // { foo: 'bar' }
+const appConfig = useAppConfig() // { foo: 'bar' }
 
 const newAppConfig = { foo: 'baz' }
 

--- a/docs/6.bridge/1.overview.md
+++ b/docs/6.bridge/1.overview.md
@@ -12,7 +12,7 @@ Nuxt Bridge provides identical features to Nuxt 3 ([docs](/docs/guide/concepts/a
 
 Bridge is a forward-compatibility layer that allows you to experience many of the new Nuxt 3 features by simply installing and enabling a Nuxt module.
 
-Using Nuxt Bridge, you can make sure your project is (almost) ready for Nuxt 3 and have the best developer experience without needing a major rewrite or risk breaking changes.
+Using Nuxt Bridge, you can make sure your project is (almost) ready for Nuxt 3 and have the best developer experience without needing a major rewrite or risk breaking changes.
 
 ## Upgrade Nuxt 2
 


### PR DESCRIPTION
for some reason I found we have many 0xA0 spaces instead of 0x20. I guess they are not intentional.