### PR TITLE
fix: Import ErrorComponent synchronously

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-root.vue
+++ b/packages/nuxt/src/app/components/nuxt-root.vue
@@ -13,8 +13,12 @@ import { useNuxtApp } from '#app/nuxt'
 import { isNuxtError, showError, useError } from '#app/composables/error'
 import { useRoute } from '#app/composables/router'
 import AppComponent from '#build/app-component.mjs'
+import errorComponent from '#build/error-component.mjs'
 
-const ErrorComponent = defineAsyncComponent(() => import('#build/error-component.mjs').then(r => r.default || r))
+// We import ErrorComponent synchronously so that it will be pulled into the default bundle.  That way if there
+// are network issues later we will still be able to render the error.
+const ErrorComponent = errorComponent.default || errorComponent
+
 const IslandRenderer = process.server
   ? defineAsyncComponent(() => import('./island-renderer').then(r => r.default || r))
   : () => null

--- a/packages/nuxt/src/app/components/nuxt-root.vue
+++ b/packages/nuxt/src/app/components/nuxt-root.vue
@@ -13,11 +13,7 @@ import { useNuxtApp } from '#app/nuxt'
 import { isNuxtError, showError, useError } from '#app/composables/error'
 import { useRoute } from '#app/composables/router'
 import AppComponent from '#build/app-component.mjs'
-import errorComponent from '#build/error-component.mjs'
-
-// We import ErrorComponent synchronously so that it will be pulled into the default bundle.  That way if there
-// are network issues later we will still be able to render the error.
-const ErrorComponent = errorComponent.default || errorComponent
+import ErrorComponent from '#build/error-component.mjs'
 
 const IslandRenderer = process.server
   ? defineAsyncComponent(() => import('./island-renderer').then(r => r.default || r))


### PR DESCRIPTION
### 🔗 Linked issue

resolves #20996 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [X ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Importing `ErrorComponent` synchronously should result in it being included in the default bundle, which means that it will always be available later, even if there are network errors which would prevent the import of an async component.

### 📝 Checklist

- [x ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
