### PR TITLE
fix(nuxt): skip vue render when redirecting

### DIFF
--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -115,7 +115,7 @@ export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: Na
       const fullPath = typeof to === 'string' || isExternal ? toPath : router.resolve(to).fullPath || '/'
       const location = isExternal ? toPath : joinURL(useRuntimeConfig().app.baseURL, fullPath)
 
-      async function redirect () {
+      async function redirect (response: any) {
         // TODO: consider deprecating in favour of `app:rendered` and removing
         await nuxtApp.callHook('app:redirected')
         const encodedLoc = location.replace(/"/g, '%22')
@@ -124,16 +124,16 @@ export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: Na
           body: `<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=${encodedLoc}"></head></html>`,
           headers: { location }
         }
-        return inMiddleware ? /* abort route navigation */ false : undefined
+        return response
       }
 
       // We wait to perform the redirect last in case any other middleware will intercept the redirect
       // and redirect somewhere else instead.
       if (!isExternal && inMiddleware) {
-        router.afterEach(final => (final.fullPath === fullPath) ? redirect() : undefined)
+        router.afterEach(final => final.fullPath === fullPath ? redirect(false) : undefined)
         return to
       }
-      return redirect()
+      return redirect(!inMiddleware ? undefined : /* abort route navigation */ false)
     }
   }
 

--- a/packages/nuxt/src/app/entry.ts
+++ b/packages/nuxt/src/app/entry.ts
@@ -41,6 +41,7 @@ if (process.server) {
       await nuxt.hooks.callHook('app:error', err)
       nuxt.payload.error = (nuxt.payload.error || err) as any
     }
+    if (ssrContext?._renderResponse) { throw new Error('skipping render') }
 
     return vueApp
   }

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -246,6 +246,9 @@ export default defineRenderHandler(async (event): Promise<Partial<RenderResponse
   }
 
   const _rendered = await renderer.renderToString(ssrContext).catch(async (error) => {
+    // We use error to bypass full render if we have an early response we can make
+    if (ssrContext._renderResponse) { return }
+
     // Use explicitly thrown error in preference to subsequent rendering errors
     const _err = (!ssrError && ssrContext.payload?.error) || error
     await ssrContext.nuxt?.hooks.callHook('app:error', _err)

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -247,7 +247,7 @@ export default defineRenderHandler(async (event): Promise<Partial<RenderResponse
 
   const _rendered = await renderer.renderToString(ssrContext).catch(async (error) => {
     // We use error to bypass full render if we have an early response we can make
-    if (ssrContext._renderResponse) { return {} as ReturnType<typeof renderer['renderToString']> }
+    if (ssrContext._renderResponse && error.message === 'skipping render') { return {} as ReturnType<typeof renderer['renderToString']> }
 
     // Use explicitly thrown error in preference to subsequent rendering errors
     const _err = (!ssrError && ssrContext.payload?.error) || error

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -247,7 +247,7 @@ export default defineRenderHandler(async (event): Promise<Partial<RenderResponse
 
   const _rendered = await renderer.renderToString(ssrContext).catch(async (error) => {
     // We use error to bypass full render if we have an early response we can make
-    if (ssrContext._renderResponse) { return }
+    if (ssrContext._renderResponse) { return {} as ReturnType<typeof renderer['renderToString']> }
 
     // Use explicitly thrown error in preference to subsequent rendering errors
     const _err = (!ssrError && ssrContext.payload?.error) || error

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -627,7 +627,7 @@ describe('navigate', () => {
   it('should not run setup function in path redirected to', async () => {
     const { headers, status } = await fetch('/navigate-to-error', { redirect: 'manual' })
 
-    expect(headers.get('location')).toEqual('/navigate-to-error')
+    expect(headers.get('location')).toEqual('/setup-should-not-run')
     expect(status).toEqual(302)
   })
 

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -624,6 +624,13 @@ describe('navigate', () => {
     expect(status).toEqual(302)
   })
 
+  it('should not run setup function in path redirected to', async () => {
+    const { headers, status } = await fetch('/navigate-to-error', { redirect: 'manual' })
+
+    expect(headers.get('location')).toEqual('/navigate-to-error')
+    expect(status).toEqual(302)
+  })
+
   it('supports directly aborting navigation on SSR', async () => {
     const { status } = await fetch('/navigate-to-false', { redirect: 'manual' })
 

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -45,7 +45,7 @@ describe.skipIf(isWindows || process.env.TEST_BUILDER === 'webpack' || process.e
 
   it('default server bundle size', async () => {
     stats.server = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect(roundToKilobytes(stats.server.totalBytes)).toMatchInlineSnapshot('"62.4k"')
+    expect(roundToKilobytes(stats.server.totalBytes)).toMatchInlineSnapshot('"62.6k"')
 
     const modules = await analyzeSizes('node_modules/**/*', serverDir)
     expect(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot('"2284k"')

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -45,7 +45,7 @@ describe.skipIf(isWindows || process.env.TEST_BUILDER === 'webpack' || process.e
 
   it('default server bundle size', async () => {
     stats.server = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect(roundToKilobytes(stats.server.totalBytes)).toMatchInlineSnapshot('"62.6k"')
+    expect(roundToKilobytes(stats.server.totalBytes)).toMatchInlineSnapshot('"62.7k"')
 
     const modules = await analyzeSizes('node_modules/**/*', serverDir)
     expect(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot('"2284k"')

--- a/test/fixtures/basic/pages/navigate-to-error.vue
+++ b/test/fixtures/basic/pages/navigate-to-error.vue
@@ -1,0 +1,14 @@
+<template>
+  <div>You should not see me</div>
+</template>
+
+<script setup>
+definePageMeta({
+  alias: ['/setup-should-not-run'],
+  middleware: to => to.path === '/navigate-to-error' ? navigateTo('/setup-should-not-run') : undefined
+})
+console.log('running setup')
+useNuxtApp().hook('app:rendered', () => {
+  throw new Error('this should not run')
+})
+</script>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/20696

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When we have an early response (for example, redirection), we can completely skip rendering the html for the page; we're not going to send it back. We can abort the rendering process with a targeted thrown/handled error.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
