### PR TITLE
perf(nuxt): mark define functions as side-effect free at source

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -94,7 +94,10 @@
         "varsIgnorePattern": "^_",
         "ignoreRestSiblings": true
       }
-    ]
+    ],
+    "jsdoc/check-tag-names": ["error", {
+      "definedTags": ["__NO_SIDE_EFFECTS__"]
+    }]
   },
   "settings": {
     "jsdoc": {

--- a/packages/nuxt/src/app/components/client-only.ts
+++ b/packages/nuxt/src/app/components/client-only.ts
@@ -22,6 +22,7 @@ export default defineComponent({
 
 const cache = new WeakMap()
 
+/*! @__NO_SIDE_EFFECTS__ */
 export function createClientOnly<T extends ComponentOptions> (component: T) {
   if (cache.has(component)) {
     return cache.get(component)

--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -46,6 +46,7 @@ export type NuxtLinkProps = {
   ariaCurrentValue?: string
 }
 
+/*! @__NO_SIDE_EFFECTS__ */
 export function defineNuxtLink (options: NuxtLinkOptions) {
   const componentName = options.componentName || 'NuxtLink'
 

--- a/packages/nuxt/src/app/composables/component.ts
+++ b/packages/nuxt/src/app/composables/component.ts
@@ -29,42 +29,42 @@ async function runLegacyAsyncData (res: Record<string, any> | Promise<Record<str
 
 /*! @__NO_SIDE_EFFECTS__ */
 export const defineNuxtComponent: typeof defineComponent =
- function defineNuxtComponent (...args: any[]): any {
-   const [options, key] = args
-   const { setup } = options
+  function defineNuxtComponent (...args: any[]): any {
+    const [options, key] = args
+    const { setup } = options
 
-   // Avoid wrapping if no options api is used
-   if (!setup && !options.asyncData && !options.head) {
-     return {
-       [NuxtComponentIndicator]: true,
-       ...options
-     }
-   }
+    // Avoid wrapping if no options api is used
+    if (!setup && !options.asyncData && !options.head) {
+      return {
+        [NuxtComponentIndicator]: true,
+        ...options
+      }
+    }
 
-   return {
-     [NuxtComponentIndicator]: true,
-     _fetchKeyBase: key,
-     ...options,
-     setup (props, ctx) {
-       const nuxtApp = useNuxtApp()
-       const res = setup ? Promise.resolve(nuxtApp.runWithContext(() => setup(props, ctx))).then(r => r || {}) : {}
+    return {
+      [NuxtComponentIndicator]: true,
+      _fetchKeyBase: key,
+      ...options,
+      setup (props, ctx) {
+        const nuxtApp = useNuxtApp()
+        const res = setup ? Promise.resolve(nuxtApp.runWithContext(() => setup(props, ctx))).then(r => r || {}) : {}
 
-       const promises: Promise<any>[] = []
-       if (options.asyncData) {
-         promises.push(runLegacyAsyncData(res, options.asyncData))
-       }
+        const promises: Promise<any>[] = []
+        if (options.asyncData) {
+          promises.push(runLegacyAsyncData(res, options.asyncData))
+        }
 
-       if (options.head) {
-         const nuxtApp = useNuxtApp()
-         useHead(typeof options.head === 'function' ? () => options.head(nuxtApp) : options.head)
-       }
+        if (options.head) {
+          const nuxtApp = useNuxtApp()
+          useHead(typeof options.head === 'function' ? () => options.head(nuxtApp) : options.head)
+        }
 
-       return Promise.resolve(res)
-         .then(() => Promise.all(promises))
-         .then(() => res)
-         .finally(() => {
-           promises.length = 0
-         })
-     }
-   } as DefineComponent
- }
+        return Promise.resolve(res)
+          .then(() => Promise.all(promises))
+          .then(() => res)
+          .finally(() => {
+            promises.length = 0
+          })
+      }
+    } as DefineComponent
+  }

--- a/packages/nuxt/src/app/composables/component.ts
+++ b/packages/nuxt/src/app/composables/component.ts
@@ -27,43 +27,44 @@ async function runLegacyAsyncData (res: Record<string, any> | Promise<Record<str
   }
 }
 
+/*! @__NO_SIDE_EFFECTS__ */
 export const defineNuxtComponent: typeof defineComponent =
-  function defineNuxtComponent (...args: any[]): any {
-    const [options, key] = args
-    const { setup } = options
+ function defineNuxtComponent (...args: any[]): any {
+   const [options, key] = args
+   const { setup } = options
 
-    // Avoid wrapping if no options api is used
-    if (!setup && !options.asyncData && !options.head) {
-      return {
-        [NuxtComponentIndicator]: true,
-        ...options
-      }
-    }
+   // Avoid wrapping if no options api is used
+   if (!setup && !options.asyncData && !options.head) {
+     return {
+       [NuxtComponentIndicator]: true,
+       ...options
+     }
+   }
 
-    return {
-      [NuxtComponentIndicator]: true,
-      _fetchKeyBase: key,
-      ...options,
-      setup (props, ctx) {
-        const nuxtApp = useNuxtApp()
-        const res = setup ? Promise.resolve(nuxtApp.runWithContext(() => setup(props, ctx))).then(r => r || {}) : {}
+   return {
+     [NuxtComponentIndicator]: true,
+     _fetchKeyBase: key,
+     ...options,
+     setup (props, ctx) {
+       const nuxtApp = useNuxtApp()
+       const res = setup ? Promise.resolve(nuxtApp.runWithContext(() => setup(props, ctx))).then(r => r || {}) : {}
 
-        const promises: Promise<any>[] = []
-        if (options.asyncData) {
-          promises.push(runLegacyAsyncData(res, options.asyncData))
-        }
+       const promises: Promise<any>[] = []
+       if (options.asyncData) {
+         promises.push(runLegacyAsyncData(res, options.asyncData))
+       }
 
-        if (options.head) {
-          const nuxtApp = useNuxtApp()
-          useHead(typeof options.head === 'function' ? () => options.head(nuxtApp) : options.head)
-        }
+       if (options.head) {
+         const nuxtApp = useNuxtApp()
+         useHead(typeof options.head === 'function' ? () => options.head(nuxtApp) : options.head)
+       }
 
-        return Promise.resolve(res)
-          .then(() => Promise.all(promises))
-          .then(() => res)
-          .finally(() => {
-            promises.length = 0
-          })
-      }
-    } as DefineComponent
-  }
+       return Promise.resolve(res)
+         .then(() => Promise.all(promises))
+         .then(() => res)
+         .finally(() => {
+           promises.length = 0
+         })
+     }
+   } as DefineComponent
+ }

--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -42,7 +42,10 @@ export interface RouteMiddleware {
   (to: RouteLocationNormalized, from: RouteLocationNormalized): ReturnType<NavigationGuard>
 }
 
-export const defineNuxtRouteMiddleware = (middleware: RouteMiddleware) => middleware
+/*! @__NO_SIDE_EFFECTS__ */
+export function defineNuxtRouteMiddleware (middleware: RouteMiddleware) {
+  return middleware
+}
 
 export interface AddRouteMiddlewareOptions {
   global?: boolean

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -381,10 +381,12 @@ const orderMap: Record<NonNullable<ObjectPluginInput['enforce']>, number> = {
   post: 20
 }
 
+/*! @__NO_SIDE_EFFECTS__ */
 export function definePayloadPlugin<T extends Record<string, unknown>> (plugin: Plugin<T> | ObjectPluginInput<T>) {
   return defineNuxtPlugin(plugin, { order: -40 })
 }
 
+/*! @__NO_SIDE_EFFECTS__ */
 export function defineNuxtPlugin<T extends Record<string, unknown>> (plugin: Plugin<T> | ObjectPluginInput<T>, meta?: PluginMeta): Plugin<T> {
   if (typeof plugin === 'function') { return defineNuxtPlugin({ setup: plugin }, meta) }
 
@@ -433,6 +435,7 @@ export function callWithNuxt<T extends (...args: any[]) => any> (nuxt: NuxtApp |
   }
 }
 
+/*! @__NO_SIDE_EFFECTS__ */
 /**
  * Returns the current Nuxt instance.
  */
@@ -455,6 +458,7 @@ export function useNuxtApp (): NuxtApp {
   return nuxtAppInstance
 }
 
+/*! @__NO_SIDE_EFFECTS__ */
 export function useRuntimeConfig (): RuntimeConfig {
   return useNuxtApp().$config
 }

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -45,7 +45,7 @@ describe.skipIf(isWindows || process.env.TEST_BUILDER === 'webpack' || process.e
 
   it('default server bundle size', async () => {
     stats.server = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect(roundToKilobytes(stats.server.totalBytes)).toMatchInlineSnapshot('"62.5k"')
+    expect(roundToKilobytes(stats.server.totalBytes)).toMatchInlineSnapshot('"62.6k"')
 
     const modules = await analyzeSizes('node_modules/**/*', serverDir)
     expect(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot('"2284k"')


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 📚 Description

Rollup now supports marking a function as sied-effect free:
- https://github.com/rollup/rollup/pull/5024

This PR marks the following functions as side-effect free

- `createClientOnly`
- `defineNuxtComponent`
- `defineNuxtLink`
- `definePayloadPlugin`
- `defineNuxtPlugin`
- `useNuxtApp`
- `useRuntimeConfig`

As listed here:
https://github.com/nuxt/nuxt/blob/6045beb7dc89ea0f12ada0e96f1e883d241984c5/packages/vite/src/client.ts#L80-L83

> Side note: because we are esbuild to transpile, which does not preserve comments. We need to use `/*!` to keep the controlling comment, before esbuild supports `__NO_SIDE_EFFECTS__` natively (https://github.com/evanw/esbuild/issues/3149)

A PR was also sent to Vue core to mark `defineComponent` and `defineAsyncComponent`
- https://github.com/vuejs/core/pull/8512

Once this convention gets more widely adopted, we may be able to remove the `pureAnnotationsPlugin` later.