### PR TITLE
feat(webpack, schema): add webpack experiments configuration

### DIFF
--- a/packages/schema/src/config/webpack.ts
+++ b/packages/schema/src/config/webpack.ts
@@ -290,5 +290,13 @@ export default defineUntypedSchema({
      * @type {Array<(warn: typeof import('webpack').WebpackError) => boolean>}
      */
     warningIgnoreFilters: [],
+
+    /**
+     * Configure [webpack experiments](https://webpack.js.org/configuration/experiments/)
+     * @type {false | typeof import('webpack').Configuration['experiments']}
+     */
+    experiments: {
+      $resolve: async (val, get) => val ?? (await get('experiments'))
+    }
   }
 })

--- a/packages/schema/src/config/webpack.ts
+++ b/packages/schema/src/config/webpack.ts
@@ -295,8 +295,6 @@ export default defineUntypedSchema({
      * Configure [webpack experiments](https://webpack.js.org/configuration/experiments/)
      * @type {false | typeof import('webpack').Configuration['experiments']}
      */
-    experiments: {
-      $resolve: async (val, get) => val ?? (await get('experiments'))
-    }
+    experiments: {}
   }
 })

--- a/packages/webpack/src/presets/base.ts
+++ b/packages/webpack/src/presets/base.ts
@@ -39,7 +39,9 @@ function baseConfig (ctx: WebpackConfigContext) {
       ...options.webpack.optimization,
       minimizer: []
     },
-    experiments: {},
+    experiments: {
+      ...options.webpack.experiments
+    },
     mode: ctx.isDev ? 'development' : 'production',
     cache: getCache(ctx),
     output: getOutput(ctx),


### PR DESCRIPTION
### 🔗 Linked issue

#20647 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [X] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Add the ability to set up webpack experiments configuration in nuxt.config

```ts
 webpack: {
    experiments: {
        asyncWebAssembly: true,
        buildHttp: true,
        layers: true,
        lazyCompilation: true,
        outputModule: true,
        syncWebAssembly: true,
        topLevelAwait: true,
    }
  }
 ```

Resolves #20647 

### 📝 Checklist

- [X] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
