### PR TITLE
fix(schema): add types to warn of non-serializable values

### DIFF
--- a/packages/schema/src/types/config.ts
+++ b/packages/schema/src/types/config.ts
@@ -64,7 +64,7 @@ type Overrideable<T extends Record<string, any>, Path extends string = ''> = {
 export interface NuxtConfig extends DeepPartial<Omit<ConfigSchema, 'vite' | 'runtimeConfig'>> {
   // Avoid DeepPartial for vite config interface (#4772)
   vite?: ConfigSchema['vite']
-  runtimeConfig?: Overrideable<RuntimeConfig>
+  runtimeConfig?: Overrideable<RuntimeConfigInput>
 
   /**
    * Experimental custom config schema
@@ -125,26 +125,28 @@ export interface ViteConfig extends ViteUserConfig {
   server?: Omit<ViteServerOptions, 'port' | 'host'>
 }
 
-// add warning to try prevent non-JSON-serialisable types from being set
-type JsonSerializable = null | boolean | number | string | JsonSerializable[] | { [key: string]: JsonSerializable }
+// add warning to try prevent non-serializable types from being set
+type SerializableValues =  null | boolean | number | string | SerializableValues[] | { [key: string]: SerializableValues } | undefined | Function
 
 // -- Runtime Config --
 
 type RuntimeConfigNamespace = Record<string, any>
 
-export interface PublicRuntimeConfig extends RuntimeConfigNamespace {
-  [key: string]: JsonSerializable
+export interface RuntimeConfigInput {
+  public: PublicRuntimeConfig
+
+  [key: string]: SerializableValues
 }
 
+export interface PublicRuntimeConfig extends RuntimeConfigNamespace {}
+
 export interface RuntimeConfig extends RuntimeConfigNamespace {
-  [key: string]: JsonSerializable
   public: PublicRuntimeConfig
 }
 
 // -- App Config --
 
 export interface CustomAppConfig {
-  [key: string]: JsonSerializable | undefined
 }
 
 export interface AppConfigInput extends CustomAppConfig {
@@ -156,6 +158,8 @@ export interface AppConfigInput extends CustomAppConfig {
   nitro?: never
   /** @deprecated reserved */
   server?: never
+
+  [key: string]: SerializableValues
 }
 
 export interface NuxtAppConfig {
@@ -166,5 +170,5 @@ export interface NuxtAppConfig {
 }
 
 export interface AppConfig {
-  [key: string]: JsonSerializable
+  [key: string]: unknown
 }

--- a/packages/schema/src/types/config.ts
+++ b/packages/schema/src/types/config.ts
@@ -125,21 +125,26 @@ export interface ViteConfig extends ViteUserConfig {
   server?: Omit<ViteServerOptions, 'port' | 'host'>
 }
 
+// add warning to try prevent non-JSON-serialisable types from being set
+type JsonSerializable = null | boolean | number | string | JsonSerializable[] | { [key: string]: JsonSerializable }
 
 // -- Runtime Config --
 
 type RuntimeConfigNamespace = Record<string, any>
 
-export interface PublicRuntimeConfig extends RuntimeConfigNamespace { }
+export interface PublicRuntimeConfig extends RuntimeConfigNamespace {
+  [key: string]: JsonSerializable
+}
 
 export interface RuntimeConfig extends RuntimeConfigNamespace {
+  [key: string]: JsonSerializable
   public: PublicRuntimeConfig
 }
 
 // -- App Config --
 
 export interface CustomAppConfig {
-  [key: string]: unknown
+  [key: string]: JsonSerializable | undefined
 }
 
 export interface AppConfigInput extends CustomAppConfig {
@@ -161,5 +166,5 @@ export interface NuxtAppConfig {
 }
 
 export interface AppConfig {
-  [key: string]: unknown
+  [key: string]: JsonSerializable
 }


### PR DESCRIPTION
### 🔗 Linked issue

#13992 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Add types to warn of non-serializable values for runtimeConfig and defineAppConfig.

This will give warnings for inputs like:

```ts
export default defineAppConfig({
  navigation: new Map()
})
```
or

```ts
export default defineNuxtConfig({
  runtimeConfig: {
    myConfig: new Set(['a', 'b', 'c'])
  }
})
```

Related to: https://github.com/nuxt/nuxt/issues/13992#issuecomment-1455932131

### 📝 Checklist

- [X] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
