### PR TITLE
fix(nuxt): prefix server component ids to avoid collisions

### DIFF
--- a/packages/nuxt/src/components/runtime/server-component.ts
+++ b/packages/nuxt/src/components/runtime/server-component.ts
@@ -18,7 +18,7 @@ const SLOT_FALLBACK_RE = /<div nuxt-slot-fallback-start="([^"]*)"[^>]*><\/div>((
 const SSR_UID_RE = /nuxt-ssr-component-uid="([^"]*)"/
 
 let id = 0
-const getId = process.client ? () => (id++).toString() : randomUUID
+const getId = process.client ? () => (id--).toString() : randomUUID
 
 export const createServerComponent = (name: string) => {
   return defineComponent({
@@ -123,7 +123,7 @@ const NuxtServerComponent = defineComponent({
     })
     const availableSlots = computed(() => {
       return [...res.data.value!.html.matchAll(SLOTNAME_RE)].map(m => m[1])
-    })
+    }) 
 
     const html = computed(() => {
       const currentSlots = Object.keys(slots)

--- a/packages/nuxt/src/components/runtime/server-component.ts
+++ b/packages/nuxt/src/components/runtime/server-component.ts
@@ -123,7 +123,7 @@ const NuxtServerComponent = defineComponent({
     })
     const availableSlots = computed(() => {
       return [...res.data.value!.html.matchAll(SLOTNAME_RE)].map(m => m[1])
-    }) 
+    })
 
     const html = computed(() => {
       const currentSlots = Object.keys(slots)

--- a/packages/nuxt/src/components/runtime/server-component.ts
+++ b/packages/nuxt/src/components/runtime/server-component.ts
@@ -18,7 +18,7 @@ const SLOT_FALLBACK_RE = /<div nuxt-slot-fallback-start="([^"]*)"[^>]*><\/div>((
 const SSR_UID_RE = /nuxt-ssr-component-uid="([^"]*)"/
 
 let id = 0
-const getId = process.client ? () => (id--).toString() : randomUUID
+const getId = process.client ? () => 's' + (id--) : randomUUID
 
 export const createServerComponent = (name: string) => {
   return defineComponent({


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
resolve https://github.com/nuxt/nuxt/issues/21471
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Hi :wave:

this is a VERY small workaround :joy:  to avoid server components and island component having the same id 
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
