### PR TITLE
fix(nuxt): respect query/hash for external routes in `navigateTo`

### DIFF
--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -2,7 +2,7 @@ import { getCurrentInstance, hasInjectionContext, inject, onUnmounted } from 'vu
 import type { Ref } from 'vue'
 import type { NavigationFailure, NavigationGuard, RouteLocationNormalized, RouteLocationPathRaw, RouteLocationRaw, Router, useRoute as _useRoute, useRouter as _useRouter } from '#vue-router'
 import { sanitizeStatusCode } from 'h3'
-import { hasProtocol, joinURL, parseURL } from 'ufo'
+import { hasProtocol, joinURL, parseURL, withQuery } from 'ufo'
 
 import { useNuxtApp, useRuntimeConfig } from '../nuxt'
 import type { NuxtError } from './error'
@@ -113,7 +113,7 @@ export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: Na
     to = '/'
   }
 
-  const toPath = typeof to === 'string' ? to : ((to as RouteLocationPathRaw).path || '/')
+  const toPath = typeof to === 'string' ? to : (withQuery((to as RouteLocationPathRaw).path || '/', to.query || {}) + (to.hash || ''))
 
   // Early open handler
   if (options?.open) {

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -732,7 +732,7 @@ describe('navigate external', () => {
   it('should redirect to example.com', async () => {
     const { headers } = await fetch('/navigate-to-external/', { redirect: 'manual' })
 
-    expect(headers.get('location')).toEqual('https://example.com/')
+    expect(headers.get('location')).toEqual('https://example.com/?redirect=false#test')
   })
 
   it('should redirect to api endpoint', async () => {

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -25,7 +25,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
 
   it('default client bundle size', async () => {
     stats.client = await analyzeSizes('**/*.js', publicDir)
-    expect(roundToKilobytes(stats.client.totalBytes)).toMatchInlineSnapshot('"98.5k"')
+    expect(roundToKilobytes(stats.client.totalBytes)).toMatchInlineSnapshot('"98.6k"')
     expect(stats.client.files.map(f => f.replace(/\..*\.js/, '.js'))).toMatchInlineSnapshot(`
       [
         "_nuxt/entry.js",

--- a/test/fixtures/basic/pages/navigate-to-external.vue
+++ b/test/fixtures/basic/pages/navigate-to-external.vue
@@ -8,5 +8,5 @@ if (useRoute().path === '/navigate-to-external') {
     throw new Error('this should not run')
   })
 }
-await navigateTo('https://example.com/', { external: true, replace: true })
+await navigateTo({ path: 'https://example.com/', query: { redirect: false }, hash: '#test' }, { external: true, replace: true })
 </script>


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/21499

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds support for `query` and `hash` when an object syntax external path is passed to `naviageTo`

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
