### PR TITLE
fix(vite): invalidate templates by `dst` not `src`

### DIFF
--- a/packages/vite/src/vite-node.ts
+++ b/packages/vite/src/vite-node.ts
@@ -48,7 +48,7 @@ export function viteNodePlugin (ctx: ViteBuildContext): VitePlugin {
           markInvalidates(server.moduleGraph.getModulesByFile(typeof plugin === 'string' ? plugin : plugin.src))
         }
         for (const template of ctx.nuxt.options.build.templates) {
-          markInvalidates(server.moduleGraph.getModulesByFile(template?.src as string))
+          markInvalidates(server.moduleGraph.getModulesByFile(template.dst))
         }
       }
 

--- a/packages/vite/src/vite-node.ts
+++ b/packages/vite/src/vite-node.ts
@@ -48,7 +48,7 @@ export function viteNodePlugin (ctx: ViteBuildContext): VitePlugin {
           markInvalidates(server.moduleGraph.getModulesByFile(typeof plugin === 'string' ? plugin : plugin.src))
         }
         for (const template of ctx.nuxt.options.build.templates) {
-          markInvalidates(server.moduleGraph.getModulesByFile(template.dst))
+          markInvalidates(server.moduleGraph.getModulesByFile(template.dst!))
         }
       }
 


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We were previously invalidating templates by their _source_ but in fact it's the `dst` that will actually be part of the build. In most cases, the file that needs to be valid is actually prefixed with `virtual:nuxt:` but we already cover that earlier:

https://github.com/nuxt/nuxt/blob/ff842347bcec23bbe7a50e25c4a8583d5565a91f/packages/vite/src/vite-node.ts#L42-L46

I'm not sure this has actually caused any issues, but 🤷‍♂️ 

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
