### PR TITLE
fix(nuxt): ensure prerendered components are treated as islands

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-island.ts
+++ b/packages/nuxt/src/app/components/nuxt-island.ts
@@ -79,6 +79,7 @@ export default defineComponent({
       }
       // TODO: Validate response
       const result = await $fetch<NuxtIslandResponse>(url, {
+        responseType: 'json',
         params: {
           ...props.context,
           props: props.props ? JSON.stringify(props.props) : undefined

--- a/packages/nuxt/src/app/plugins/revive-payload.client.ts
+++ b/packages/nuxt/src/app/plugins/revive-payload.client.ts
@@ -20,7 +20,10 @@ if (componentIslands) {
   revivers.Island = ({ key, params }: any) => {
     const nuxtApp = useNuxtApp()
     if (!nuxtApp.isHydrating) {
-      nuxtApp.payload.data[key] = nuxtApp.payload.data[key] || $fetch(`/__nuxt_island/${key}`, params ? { params } : {}).then((r) => {
+      nuxtApp.payload.data[key] = nuxtApp.payload.data[key] || $fetch(`/__nuxt_island/${key}`, {
+        responseType: 'json',
+        ...params ? { params } : {}
+      }).then((r) => {
         nuxtApp.payload.data[key] = r
         return r
       })


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/pull/21461

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This fixes a regression with prerendered islands where they were not being treated as JSON but text. This way we ensure we treat the response as JSON.

### 📝 Checklist

- [s] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
