### PR TITLE
fix(nuxt): improve warning for invalid children of `<Title>`

### DIFF
--- a/packages/nuxt/src/head/runtime/components.ts
+++ b/packages/nuxt/src/head/runtime/components.ts
@@ -149,12 +149,20 @@ export const Title = defineComponent({
   name: 'Title',
   inheritAttrs: false,
   setup: setupForUseMeta((_, { slots }) => {
-    const title = slots.default?.()?.[0]?.children || null
-    if (process.dev && title && typeof title !== 'string') {
-      console.error('<Title> can only take a string in its default slot.')
+    if (process.dev) {
+      const defaultSlot = slots.default?.() ?? null
+
+      if (defaultSlot && (defaultSlot.length > 1 || typeof defaultSlot[0].children !== 'string')) {
+        console.error('<Title> can take only one string in its default slot.')
+      }
+
+      return {
+        title: defaultSlot?.[0]?.children || null
+      }
     }
+
     return {
-      title
+      title: slots.default?.()?.[0]?.children || null
     }
   })
 })

--- a/packages/nuxt/src/head/runtime/components.ts
+++ b/packages/nuxt/src/head/runtime/components.ts
@@ -150,7 +150,7 @@ export const Title = defineComponent({
   inheritAttrs: false,
   setup: setupForUseMeta((_, { slots }) => {
     if (process.dev) {
-      const defaultSlot = slots.default?.() ?? null
+      const defaultSlot = slots.default?.()
 
       if (defaultSlot && (defaultSlot.length > 1 || typeof defaultSlot[0].children !== 'string')) {
         console.error('<Title> can take only one string in its default slot.')


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

Resolves #19716

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

I improved a logic to detect wrong usage of `Title` component.

I tested the following usages in playground:

```vue
<Title>Valid</Title>
<Title>{{ 'valid' }}</Title>
<Title>{{ 'valid' }} {{ 'valid' }}</Title>
<Title><p>valid</p></Title>
```

```vue
<!-- Error -->
<Title>
  error due to more than
  <p>2 nodes</p>
</Title>
<Title>
  <!-- Comment is also a vnode -->
  so this is 2nd node
</Title>
```

We could use VNode's `type` property to detect redundant `p` tag and/or preceding comment tag,
but I think it's not a good idea to rely on undocumented APIs.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

I couldn't find the corresponding part of documentation.
If you let me know, I will modify it too.