### PR TITLE
fix(nuxt): scroll to top in nested routes

### DIFF
--- a/packages/nuxt/src/pages/runtime/router.options.ts
+++ b/packages/nuxt/src/pages/runtime/router.options.ts
@@ -57,12 +57,13 @@ function _getHashElementScrollMarginTop (selector: string): number {
   return 0
 }
 
-function _isDifferentRoute (a: RouteLocationNormalized, b: RouteLocationNormalized): boolean {
-  const samePageComponent = a.matched[0] === b.matched[0]
+function _isDifferentRoute (from: RouteLocationNormalized, to: RouteLocationNormalized): boolean {
+  const samePageComponent = from.matched[from.matched.length - 1] === to.matched[to.matched.length - 1]
+
   if (!samePageComponent) {
     return true
   }
-  if (samePageComponent && JSON.stringify(a.params) !== JSON.stringify(b.params)) {
+  if (samePageComponent && JSON.stringify(from.params) !== JSON.stringify(to.params)) {
     return true
   }
   return false

--- a/packages/nuxt/src/pages/runtime/router.options.ts
+++ b/packages/nuxt/src/pages/runtime/router.options.ts
@@ -58,7 +58,7 @@ function _getHashElementScrollMarginTop (selector: string): number {
 }
 
 function _isDifferentRoute (from: RouteLocationNormalized, to: RouteLocationNormalized): boolean {
-  const samePageComponent = from.matched[from.matched.length - 1] === to.matched[to.matched.length - 1]
+  const samePageComponent = to.matched.every((comp, index) => comp.components?.default === from.matched[index]?.components?.default)
 
   if (!samePageComponent) {
     return true


### PR DESCRIPTION
### 🔗 Linked issue

Resolves https://github.com/nuxt/nuxt/issues/20523
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`scrollToTop` is supposed to be triggered when navigating to a different route. The current implementation compares the `from` and `to` routes against the first matched route component so when navigating within nested routes, they always use the same parent route component preventing scrolling to top to happen.

This PR fixes this by comparing using the last matched route components (0 if root navigation), supporting scrolling to top from parent and nested routes.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
