### PR TITLE
fix(nuxt): exclude 'body' when making `GET` request  with `useFetch`

### DIFF
--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -39,7 +39,9 @@ export function useFetch<
   DefaultT = null,
 > (
   request: Ref<ReqT> | ReqT | (() => ReqT),
-  opts?: UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, ReqT, Method>
+  opts?: Method extends 'get'
+    ? Omit<UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, ReqT, Method>, 'body'>
+    : UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, ReqT, Method>
 ): AsyncData<PickFrom<DataT, PickKeys> | DefaultT, ErrorT | null>
 export function useFetch<
   ResT = void,

--- a/test/fixtures/basic-types/types.ts
+++ b/test/fixtures/basic-types/types.ts
@@ -83,6 +83,17 @@ describe('API routes', () => {
     expectTypeOf(useLazyFetch('/error').error).toEqualTypeOf<Ref<FetchError | null>>()
     expectTypeOf(useLazyFetch<any, string>('/error').error).toEqualTypeOf<Ref<string | null>>()
   })
+  
+  it('excludes body when using GET request with useFetch', () => {
+    // @ts-expect-error Body cannot be passed to GET request
+    useFetch('/api/other', { body: {} })
+    // TODO: enable when fixed upstream https://github.com/unjs/nitro/pull/1247
+    // TODO: @ts-expect-error Body cannot be passed to GET request
+    // useFetch('/api/other', { method: 'GET', body: {} })
+    // @ts-expect-error Body cannot be passed to GET request
+    useFetch('/api/other', { method: 'get', body: {} })
+    useFetch('/api/other', { method: 'post', body: {} })
+  })
 })
 
 describe('aliases', () => {

--- a/test/fixtures/basic-types/types.ts
+++ b/test/fixtures/basic-types/types.ts
@@ -83,7 +83,7 @@ describe('API routes', () => {
     expectTypeOf(useLazyFetch('/error').error).toEqualTypeOf<Ref<FetchError | null>>()
     expectTypeOf(useLazyFetch<any, string>('/error').error).toEqualTypeOf<Ref<string | null>>()
   })
-  
+
   it('excludes body when using GET request with useFetch', () => {
     // @ts-expect-error Body cannot be passed to GET request
     useFetch('/api/other', { body: {} })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/20667

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This excludes a `body` when performing GET requests. Might be worth waiting until v3.6 release to have more time to test. Might also be worth moving upstream to `ofetch` instead of within Nuxt.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
