### PR TITLE
fix(nuxt): do not embed error path in payload

### DIFF
--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -266,7 +266,7 @@ export function createNuxtApp (options: CreateOptions) {
       // Expose payload types
       nuxtApp.ssrContext._payloadReducers = {}
       // Expose current path
-      nuxtApp.payload.path = nuxtApp.ssrContext.event.path
+      nuxtApp.payload.path = nuxtApp.ssrContext.url
     }
     // Expose to server renderer to create payload
     nuxtApp.ssrContext = nuxtApp.ssrContext || {} as any

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -127,7 +127,7 @@ const getSPARenderer = lazyCachedFunction(async () => {
   const renderToString = (ssrContext: NuxtSSRContext) => {
     const config = useRuntimeConfig()
     ssrContext!.payload = {
-      path: ssrContext.event.path,
+      path: ssrContext.url,
       _errors: {},
       serverRendered: false,
       data: {},


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When rendering the error page, we wrongly set the server-side error page (with encoded error) as payload path, which means on client we then _redirect_ to this URL and throw a page not found.

This PR changes it so we respect the normalised URL:

https://github.com/nuxt/nuxt/blob/bf86b42ba0d5608e3cbf94fa6b7cdc9178abee9a/packages/nuxt/src/core/runtime/nitro/renderer.ts#L206

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
