### PR TITLE
fix(nuxt): only remove one item from middleware

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-loading-indicator.ts
+++ b/packages/nuxt/src/app/components/nuxt-loading-indicator.ts
@@ -45,7 +45,10 @@ export default defineComponent({
     nuxtApp.hook('page:finish', indicator.finish)
     nuxtApp.hook('vue:error', indicator.finish)
     onBeforeUnmount(() => {
-      globalMiddleware.splice(globalMiddleware.indexOf(indicator.start, 1))
+      const index = globalMiddleware.indexOf(indicator.start)
+      if (index >= 0) {
+        globalMiddleware.splice(index, 1)
+      }
       indicator.clear()
     })
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/21701

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

An embarassing one - a misaligned bracket meant we were removing _all_ middleware when `<NuxtLoadingIndicator>` was present. I've also added an extra test to ensure the added middleware is still present

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
