### PR TITLE
fix(nuxt): escape colons in page paths

### DIFF
--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -289,7 +289,3 @@ export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = 
     }))
   }
 }
-
-function escapeSegment (segment: string) {
-  return segment.replace(/:/g, '\\:')
-}

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -104,7 +104,7 @@ function getRoutePath (tokens: SegmentToken[]): string {
           ? `:${token.value}()`
           : token.type === SegmentTokenType.catchall
             ? `:${token.value}(.*)*`
-            : encodePath(token.value))
+            : encodePath(token.value).replace(/:/g, '\\:'))
     )
   }, '/')
 }
@@ -288,4 +288,8 @@ export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = 
       return route
     }))
   }
+}
+
+function escapeSegment (segment: string) {
+  return segment.replace(/:/g, '\\:')
 }

--- a/packages/nuxt/test/pages.test.ts
+++ b/packages/nuxt/test/pages.test.ts
@@ -279,6 +279,20 @@ describe('pages:generateRoutesFromFiles', () => {
           children: []
         }
       ]
+    },
+    {
+      description: 'should allow pages with `:` in their path',
+      files: [
+        `${pagesDir}/test:name.vue`
+      ],
+      output: [
+        {
+          name: 'test:name',
+          path: '/test\\:name',
+          file: `${pagesDir}/test:name.vue`,
+          children: []
+        }
+      ]
     }
   ]
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves #21582

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR encodes `:` in page paths to avoid accidentally creating dynamic params.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
