### PR TITLE
fix(nuxt): respect `false` to disable spa loading template

### DIFF
--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -31,11 +31,9 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
     ? [new RegExp(`node_modules\\/(?!${excludePaths.join('|')})`)]
     : [/node_modules/]
 
-  const spaLoadingTemplatePath = nuxt.options.spaLoadingTemplate ?? resolve(nuxt.options.srcDir, 'app/spa-loading-template.html')
-  if (spaLoadingTemplatePath !== false && !existsSync(spaLoadingTemplatePath)) {
-    if (nuxt.options.spaLoadingTemplate) {
-      console.warn(`[nuxt] Could not load custom \`spaLoadingTemplate\` path as it does not exist: \`${spaLoadingTemplatePath}\`.`)
-    }
+  const spaLoadingTemplate = nuxt.options.spaLoadingTemplate ?? resolve(nuxt.options.srcDir, 'app/spa-loading-template.html')
+  if (spaLoadingTemplate && nuxt.options.spaLoadingTemplate && !existsSync(spaLoadingTemplate)) {
+    console.warn(`[nuxt] Could not load custom \`spaLoadingTemplate\` path as it does not exist: \`${spaLoadingTemplate}\`.`)
   }
 
   const nitroConfig: NitroConfig = defu(_nitroConfig, {
@@ -88,11 +86,11 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
       '#internal/nuxt.config.mjs': () => nuxt.vfs['#build/nuxt.config'],
       '#spa-template': () => {
         try {
-          if (spaLoadingTemplatePath) {
-            return `export const template = ${JSON.stringify(readFileSync(spaLoadingTemplatePath, 'utf-8'))}`
+          if (spaLoadingTemplate) {
+            return `export const template = ${JSON.stringify(readFileSync(spaLoadingTemplate, 'utf-8'))}`
           }
         } catch {}
-        return `export const template = ${JSON.stringify(defaultSpaLoadingTemplate({}))}`
+        return `export const template = ${JSON.stringify(spaLoadingTemplate === false ? '' : defaultSpaLoadingTemplate({}))}`
       }
     },
     routeRules: {

--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -85,12 +85,11 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
     virtual: {
       '#internal/nuxt.config.mjs': () => nuxt.vfs['#build/nuxt.config'],
       '#spa-template': () => {
+        if (!spaLoadingTemplate) { return 'export const template = ""' }
         try {
-          if (spaLoadingTemplate) {
-            return `export const template = ${JSON.stringify(readFileSync(spaLoadingTemplate, 'utf-8'))}`
-          }
+          return `export const template = ${JSON.stringify(readFileSync(spaLoadingTemplate, 'utf-8'))}`
         } catch {}
-        return `export const template = ${JSON.stringify(spaLoadingTemplate === false ? '' : defaultSpaLoadingTemplate({}))}`
+        return `export const template = ${JSON.stringify(defaultSpaLoadingTemplate({}))}`
       }
     },
     routeRules: {


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/21721#issuecomment-1604967828
resolves https://github.com/nuxt/nuxt/issues/21745

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This fixes a regression in the SPA loading template whereby setting it to `false` did not disable it.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
