### PR TITLE
fix(nuxt): proxy headers to islands + returned prerender hints

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-island.ts
+++ b/packages/nuxt/src/app/components/nuxt-island.ts
@@ -86,9 +86,11 @@ export default defineComponent({
         props: props.props ? JSON.stringify(props.props) : undefined
       }))
       const result = await r.json() as NuxtIslandResponse
-      if (process.server) {
-        for (const [header, value] of r.headers) {
-          appendResponseHeader(event, header, value)
+      // TODO: support passing on more headers
+      if (process.server && process.env.prerender) {
+        const hints = r.headers.get('x-nitro-prerender')
+        if (hints) {
+          appendResponseHeader(event, 'x-nitro-prerender', hints)
         }
       }
       nuxtApp.payload.data[key] = {

--- a/packages/nuxt/src/app/components/nuxt-island.ts
+++ b/packages/nuxt/src/app/components/nuxt-island.ts
@@ -4,8 +4,9 @@ import { hash } from 'ohash'
 import { appendResponseHeader } from 'h3'
 import { useHead } from '@unhead/vue'
 import { randomUUID } from 'uncrypto'
-
 import { withQuery } from 'ufo'
+
+// eslint-disable-next-line import/no-restricted-paths
 import type { NuxtIslandResponse } from '../../core/runtime/nitro/renderer'
 import { getFragmentHTML, getSlotProps } from './utils'
 import { useNuxtApp } from '#app/nuxt'

--- a/packages/nuxt/src/app/components/nuxt-island.ts
+++ b/packages/nuxt/src/app/components/nuxt-island.ts
@@ -9,7 +9,7 @@ import { withQuery } from 'ufo'
 import type { NuxtIslandResponse } from '../../core/runtime/nitro/renderer'
 import { getFragmentHTML, getSlotProps } from './utils'
 import { useNuxtApp } from '#app/nuxt'
-import { useRequestEvent, useRequestFetch } from '#app/composables/ssr'
+import { useRequestEvent } from '#app/composables/ssr'
 
 const pKey = '_islandPromises'
 const SSR_UID_RE = /nuxt-ssr-component-uid="([^"]*)"/

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -367,7 +367,7 @@ export default defineRenderHandler(async (event): Promise<Partial<RenderResponse
 
     await nitroApp.hooks.callHook('render:island', islandResponse, { event, islandContext })
 
-    const response: RenderResponse = {
+    const response = {
       body: JSON.stringify(islandResponse, null, 2),
       statusCode: event.node.res.statusCode,
       statusMessage: event.node.res.statusMessage,
@@ -375,7 +375,7 @@ export default defineRenderHandler(async (event): Promise<Partial<RenderResponse
         'content-type': 'application/json;charset=utf-8',
         'x-powered-by': 'Nuxt'
       }
-    }
+    } satisfies RenderResponse
     if (process.env.prerender) {
       ISLAND_CACHE!.set(`/__nuxt_island/${islandContext!.name}_${islandContext!.id}`, response)
     }
@@ -383,7 +383,7 @@ export default defineRenderHandler(async (event): Promise<Partial<RenderResponse
   }
 
   // Construct HTML response
-  const response: RenderResponse = {
+  const response = {
     body: renderHTMLDocument(htmlContext),
     statusCode: event.node.res.statusCode,
     statusMessage: event.node.res.statusMessage,
@@ -391,7 +391,7 @@ export default defineRenderHandler(async (event): Promise<Partial<RenderResponse
       'content-type': 'text/html;charset=utf-8',
       'x-powered-by': 'Nuxt'
     }
-  }
+  } satisfies RenderResponse
 
   return response
 })
@@ -456,7 +456,7 @@ async function renderInlineStyles (usedModules: Set<string> | string[]) {
 }
 
 function renderPayloadResponse (ssrContext: NuxtSSRContext) {
-  return <RenderResponse> {
+  return {
     body: process.env.NUXT_JSON_PAYLOADS
       ? stringify(splitPayload(ssrContext).payload, ssrContext._payloadReducers)
       : `export default ${devalue(splitPayload(ssrContext).payload)}`,
@@ -466,7 +466,7 @@ function renderPayloadResponse (ssrContext: NuxtSSRContext) {
       'content-type': process.env.NUXT_JSON_PAYLOADS ? 'application/json;charset=utf-8' : 'text/javascript;charset=utf-8',
       'x-powered-by': 'Nuxt'
     }
-  }
+  } satisfies RenderResponse
 }
 
 function renderPayloadJsonScript (opts: { id: string, ssrContext: NuxtSSRContext, data?: any, src?: string }) {

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -67,7 +67,8 @@ describe('modules', () => {
 
 describe('pages', () => {
   it('render index', async () => {
-    const html = await $fetch('/')
+    const res = await fetch('/')
+    const html = await res.text()
 
     // Snapshot
     // expect(html).toMatchInlineSnapshot()
@@ -90,6 +91,8 @@ describe('pages', () => {
     expect(html).toContain('<div style="color:red;" class="client-only"></div>')
     // should render server-only components
     expect(html.replace(/ nuxt-ssr-component-uid="[^"]*"/, '')).toContain('<div class="server-only" style="background-color:gray;"> server-only component </div>')
+    // should include headers set by server-only components
+    expect(res.headers.get('x-server')).toBe('Hello from ServerOnlyComponent.server.vue')
     // should register global components automatically
     expect(html).toContain('global component registered automatically')
     expect(html).toContain('global component via suffix')

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1251,7 +1251,11 @@ describe('server components/islands', () => {
   it.skipIf(isDev)('should allow server-only components to set prerender hints', async () => {
     // @ts-expect-error ssssh! untyped secret property
     const publicDir = useTestContext().nuxt._nitro.options.output.publicDir
-    expect(await readdir(join(publicDir, 'some', 'url', 'from', 'server-only', 'component')).catch(() => [])).toContain('_payload.json')
+    expect(await readdir(join(publicDir, 'some', 'url', 'from', 'server-only', 'component')).catch(() => [])).toContain(
+      isRenderingJson
+        ? '_payload.json'
+        : '_payload.js'
+    )
   })
 })
 

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -68,6 +68,7 @@ describe('modules', () => {
 
 describe('pages', () => {
   it('render index', async () => {
+    // @ts-expect-error ssssh! untyped secret property
     const publicDir = useTestContext().nuxt._nitro.options.output.publicDir
     const html = await $fetch('/')
 

--- a/test/fixtures/basic/components/ServerOnlyComponent.server.vue
+++ b/test/fixtures/basic/components/ServerOnlyComponent.server.vue
@@ -7,7 +7,7 @@
 <script setup>
 import { appendResponseHeader } from 'h3'
 
-appendResponseHeader(useRequestEvent(), 'x-server', 'Hello from ServerOnlyComponent.server.vue')
+appendResponseHeader(useRequestEvent(), 'x-nitro-prerender', '/some/url/from/server-only/component')
 </script>
 
 <style>

--- a/test/fixtures/basic/components/ServerOnlyComponent.server.vue
+++ b/test/fixtures/basic/components/ServerOnlyComponent.server.vue
@@ -4,6 +4,12 @@
   </div>
 </template>
 
+<script setup>
+import { appendResponseHeader } from 'h3'
+
+appendResponseHeader(useRequestEvent(), 'x-server', 'Hello from ServerOnlyComponent.server.vue')
+</script>
+
 <style>
 :root {
   --server-only: 'server-only';


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When using server components, currently they are unable to hint to Nitro to prerender resources. For example, a `<nuxt-img>` rendered in a server component will not output a statically generated image at the end of the build.

I think it makes sense to proxy both event context (e.g. auth headers) _to_ islands as well as to set any headers on the response. (Honestly, I thought event fetch did the latter piece anyway, but it seems I am mistaken: cc: @pi0.)

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
