### PR TITLE
fix(nuxt): inline global css with `ssr: false` route rule

### DIFF
--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -126,6 +126,7 @@ const getSPARenderer = lazyCachedFunction(async () => {
 
   const renderToString = (ssrContext: NuxtSSRContext) => {
     const config = useRuntimeConfig()
+    ssrContext.modules = ssrContext.modules || new Set<string>()
     ssrContext!.payload = {
       path: ssrContext.url,
       _errors: {},

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1201,6 +1201,17 @@ describe.skipIf(isDev() || isWebpack)('inlining component styles', () => {
     }
   })
 
+  it('should inline global css when accessing a page with `ssr: false` override via route rules', async () => {
+    const globalCSS = [
+      '{--plugin:"plugin"}', // CSS imported ambiently in JS/TS
+      '{--global:"global";' // global css from nuxt.config
+    ]
+    const html = await $fetch('/route-rules/spa')
+    for (const style of globalCSS) {
+      expect(html).toContain(style)
+    }
+  })
+
   it('should not include inlined CSS in generated CSS file', async () => {
     const html: string = await $fetch('/styles')
     const cssFiles = new Set([...html.matchAll(/<link [^>]*href="([^"]*\.css)">/g)].map(m => m[1]))

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -35,7 +35,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
 
   it('default server bundle size', async () => {
     stats.server = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect.soft(roundToKilobytes(stats.server.totalBytes)).toMatchInlineSnapshot('"63.9k"')
+    expect.soft(roundToKilobytes(stats.server.totalBytes)).toMatchInlineSnapshot('"64.0k"')
 
     const modules = await analyzeSizes('node_modules/**/*', serverDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot('"2328k"')


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/21748
resolves https://github.com/nuxt/nuxt/issues/21760

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

With https://github.com/nuxt/nuxt/pull/21573, we now no longer emit global CSS in an entry.css file but instead inline it based on usage. This won't work with SPA mode by default as there is no usage tracking (even though we do explicitly add the entry file id to a modules set if it exists).

This fix ensures we have a `modules` set on ssrContext in which to inject the 'entry' module that is our source for inlining CSS.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
