### PR TITLE
fix(vite): resolve css files without importer id first

### DIFF
--- a/packages/vite/src/plugins/ssr-styles.ts
+++ b/packages/vite/src/plugins/ssr-styles.ts
@@ -138,8 +138,8 @@ export function ssrStylesPlugin (options: SSRStylePluginOptions): Plugin {
           const s = new MagicString(code)
           options.clientCSSMap[id] ||= new Set()
           for (const file of options.globalCSS) {
-            const resolved = await this.resolve(file, id)
-            const res = await this.resolve(file + '?inline&used', id)
+            const resolved = await this.resolve(file) ?? await this.resolve(file, id)
+            const res = await this.resolve(file + '?inline&used') ?? await this.resolve(file + '?inline&used', id)
             if (!resolved || !res) {
               if (!warnCache.has(file)) {
                 warnCache.add(file)
@@ -179,8 +179,9 @@ export function ssrStylesPlugin (options: SSRStylePluginOptions): Plugin {
       let styleCtr = 0
       const ids = options.clientCSSMap[id] || []
       for (const file of ids) {
-        const resolved = await this.resolve(file, id)
-        if (!resolved || !(await this.resolve(file + '?inline&used', id))) {
+        const resolved = await this.resolve(file) ?? await this.resolve(file, id)
+        const res = await this.resolve(file + '?inline&used') ?? await this.resolve(file + '?inline&used', id)
+        if (!resolved || !res) {
           if (!warnCache.has(file)) {
             warnCache.add(file)
             this.warn(`[nuxt] Cannot extract styles for \`${file}\`. Its styles will not be inlined when server-rendering.`)

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1154,10 +1154,10 @@ describe.skipIf(isDev() || isWebpack)('inlining component styles', () => {
     '{--global:"global";', // global css from nuxt.config
     '{--assets:"assets"}', // <script>
     '{--postcss:"postcss"}', // <style lang=postcss>
-    '{--scoped:"scoped"}' // <style lang=css>
+    '{--scoped:"scoped"}', // <style lang=css>
+    '{--server-only:"server-only"}' // server-only component not in client build
     // TODO: ideally both client/server components would have inlined css when used
     // '{--client-only:"client-only"}', // client-only component not in server build
-    // '{--server-only:"server-only"}' // server-only component not in client build
     // TODO: currently functional component not associated with ssrContext (upstream bug or perf optimization?)
     // '{--functional:"functional"}', // CSS imported ambiently in a functional component
   ]


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/21752

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`vite:resolve` struggles to resolve (in some cases) css files when passed an importer id. To cover this, we can try resolving both with/without importer rather than trying to develop a heuristic to work around this behaviour - not yet sure whether it's intentional (cc: @antfu).

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
