### PR TITLE
fix(vite): emit assets referenced in inline css

### DIFF
--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1180,6 +1180,13 @@ describe.skipIf(isDev() || isWebpack)('inlining component styles', () => {
     }
   })
 
+  it('should emit assets referenced in inlined CSS', async () => {
+    // @ts-expect-error ssssh! untyped secret property
+    const publicDir = useTestContext().nuxt._nitro.options.output.publicDir
+    const files = await readdir(join(publicDir, '_nuxt')).catch(() => [])
+    expect(files.map(m => m.replace(/\.\w+(\.\w+)$/, '$1'))).toContain('css-only-asset.svg')
+  })
+
   it('should not include inlined CSS in generated CSS file', async () => {
     const html: string = await $fetch('/styles')
     const cssFiles = new Set([...html.matchAll(/<link [^>]*href="([^"]*\.css)">/g)].map(m => m[1]))

--- a/test/fixtures/basic/assets/css-only-asset.svg
+++ b/test/fixtures/basic/assets/css-only-asset.svg
@@ -1,0 +1,7 @@
+<svg viewBox="0 0 221 65" fill="none" xmlns="http://www.w3.org/2000/svg" class="h-8">
+  <defs>
+    <clipPath id="a">
+      <path fill="#fff" d="M0 0h221v65H0z"></path>
+    </clipPath>
+  </defs>
+</svg>

--- a/test/fixtures/basic/assets/global.css
+++ b/test/fixtures/basic/assets/global.css
@@ -1,4 +1,4 @@
 :root {
   --global: 'global';
-  --asset: url('~/assets/logo.svg');
+  --asset: url('~/assets/css-only-asset.svg');
 }


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/21784

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

By resolving CSS files to empty modules, we were entirely skipping the processing of them, meaning no assets included in CSS files were being emitted in the _client_ build.

This change takes the more lightweight approach of disabling side effects (namely CSS) but not entirely disabling the processing of those assets.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
