### PR TITLE
fix(nuxt): use starting index when transforming islands

### DIFF
--- a/packages/nuxt/src/components/islandsTransform.ts
+++ b/packages/nuxt/src/components/islandsTransform.ts
@@ -11,6 +11,8 @@ interface ServerOnlyComponentTransformPluginOptions {
 }
 
 const SCRIPT_RE = /<script[^>]*>/g
+const HAS_SLOT_RE = /<slot[ \/]/
+const TEMPLATE_RE = /<template>([\s\S]*)<\/template>/
 
 export const islandsTransform = createUnplugin((options: ServerOnlyComponentTransformPluginOptions) => {
   return {
@@ -27,8 +29,8 @@ export const islandsTransform = createUnplugin((options: ServerOnlyComponentTran
       return islands.some(c => c.filePath === pathname)
     },
     async transform (code, id) {
-      if (!code.includes('<slot ')) { return }
-      const template = code.match(/<template>([\s\S]*)<\/template>/)
+      if (!HAS_SLOT_RE.test(code)) { return }
+      const template = code.match(TEMPLATE_RE)
       if (!template) { return }
       const startingIndex = template.index || 0
       const s = new MagicString(code)

--- a/packages/nuxt/src/components/islandsTransform.ts
+++ b/packages/nuxt/src/components/islandsTransform.ts
@@ -11,7 +11,7 @@ interface ServerOnlyComponentTransformPluginOptions {
 }
 
 const SCRIPT_RE = /<script[^>]*>/g
-const HAS_SLOT_RE = /<slot[ \/]/
+const HAS_SLOT_RE = /<slot[ /]/
 const TEMPLATE_RE = /<template>([\s\S]*)<\/template>/
 
 export const islandsTransform = createUnplugin((options: ServerOnlyComponentTransformPluginOptions) => {

--- a/test/fixtures/basic/components/ServerOnlyComponent.server.vue
+++ b/test/fixtures/basic/components/ServerOnlyComponent.server.vue
@@ -1,14 +1,14 @@
-<template>
-  <div>
-    server-only component
-  </div>
-</template>
-
 <script setup>
 import { appendResponseHeader } from 'h3'
 
 appendResponseHeader(useRequestEvent(), 'x-nitro-prerender', '/some/url/from/server-only/component')
 </script>
+
+<template>
+  <div>
+    server-only component
+  </div>
+</template>
 
 <style>
 :root {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When manipulating the code, we need to start from the index of `<template>` or we will end up overwriting other blocks and producing invalid SFCs.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
