### PR TITLE
fix(nuxt): only redirect if path is not the same as initial url

### DIFF
--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -198,7 +198,7 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
           fatal: false,
           statusMessage: `Page not found: ${to.fullPath}`
         })))
-      } else if (process.server && to.redirectedFrom) {
+      } else if (process.server && to.redirectedFrom && to.fullPath !== initialURL) {
         await nuxtApp.runWithContext(() => navigateTo(to.fullPath || '/'))
       }
     })

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -117,6 +117,11 @@ describe('pages', () => {
     expect(headers.get('location')).toEqual('/')
   })
 
+  it('allows routes to be added dynamically', async () => {
+    const html = await $fetch('/add-route-test')
+    expect(html).toContain('Hello Nuxt 3!')
+  })
+
   it('includes page metadata from pages added in pages:extend hook', async () => {
     const res = await fetch('/page-extend')
     expect(res.headers.get('x-extend')).toEqual('added in pages:extend')

--- a/test/fixtures/basic/plugins/add-route.ts
+++ b/test/fixtures/basic/plugins/add-route.ts
@@ -1,0 +1,18 @@
+export default defineNuxtPlugin((_nuxtApp) => {
+  const router = useRouter()
+
+  router.beforeEach((to) => {
+    if (to.path !== '/add-route-test') { return }
+    if (router.getRoutes().some(route => route.path === to.path)) {
+      return
+    }
+
+    router.addRoute({
+      path: to.path,
+      name: to.path,
+      component: () => import('~/pages/index.vue')
+    })
+
+    return to.path
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/20491

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

A regression was introduced in https://github.com/nuxt/nuxt/pull/20247 - namely, that it became impossible to add a new route and then redirect to it within the same request - this would become a redirection.

This adds a check that enables adding dynamic routes in this kind of way - we won't send a redirect to the same URL as the initial request.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
