### PR TITLE
fix(nuxt, vite): do not use cjs utils to resolve/alias vue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ dist
 .vercel
 .netlify
 .output
+.output-*
 .gen
 
 # Junit reports

--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -2,7 +2,7 @@ import { existsSync, promises as fsp, readFileSync } from 'node:fs'
 import { join, relative, resolve } from 'pathe'
 import { build, copyPublicAssets, createDevServer, createNitro, prepare, prerender, scanHandlers, writeTypes } from 'nitropack'
 import type { Nitro, NitroConfig } from 'nitropack'
-import { logger, resolvePath } from '@nuxt/kit'
+import { logger } from '@nuxt/kit'
 import escapeRE from 'escape-string-regexp'
 import { defu } from 'defu'
 import fsExtra from 'fs-extra'
@@ -165,13 +165,6 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
       ]
     },
     alias: {
-      ...nuxt.options.experimental.externalVue
-        ? {}
-        : {
-            'vue/compiler-sfc': 'vue/compiler-sfc',
-            'vue/server-renderer': 'vue/server-renderer',
-            vue: await resolvePath(`vue/dist/vue.cjs${nuxt.options.dev ? '' : '.prod'}.js`)
-          },
       // Vue 3 mocks
       ...nuxt.options.vue.runtimeCompiler || nuxt.options.experimental.externalVue
         ? {}

--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -58,7 +58,6 @@ export async function buildClient (ctx: ViteBuildContext) {
         // runtime compiler
         '@vue/compiler-sfc', '@vue/compiler-dom', '@vue/compiler-core', '@vue/compiler-ssr'
       ]
-
     },
     cacheDir: resolve(ctx.nuxt.options.rootDir, 'node_modules/.cache/vite', 'client'),
     build: {

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -2,7 +2,7 @@ import { resolve } from 'pathe'
 import * as vite from 'vite'
 import vuePlugin from '@vitejs/plugin-vue'
 import viteJsxPlugin from '@vitejs/plugin-vue-jsx'
-import { logger, resolveModule, resolvePath } from '@nuxt/kit'
+import { logger, resolvePath } from '@nuxt/kit'
 import { joinURL, withTrailingSlash, withoutLeadingSlash } from 'ufo'
 import type { ViteConfig } from '@nuxt/schema'
 import type { ViteBuildContext } from './vite'
@@ -13,7 +13,6 @@ import { writeManifest } from './manifest'
 import { transpile } from './utils/transpile'
 
 export async function buildServer (ctx: ViteBuildContext) {
-  const _resolve = (id: string) => resolveModule(id, { paths: ctx.nuxt.options.modulesDir })
   const helper = ctx.nuxt.options.nitro.imports !== false ? '' : 'globalThis.'
   const entry = ctx.nuxt.options.ssr ? ctx.entry : await resolvePath(resolve(ctx.nuxt.options.appDir, 'entry-spa'))
   const serverConfig: ViteConfig = vite.mergeConfig(ctx.config, {
@@ -53,17 +52,7 @@ export async function buildServer (ctx: ViteBuildContext) {
     },
     resolve: {
       alias: {
-        '#build/plugins': resolve(ctx.nuxt.options.buildDir, 'plugins/server'),
-        ...ctx.nuxt.options.experimental.externalVue || ctx.nuxt.options.dev
-          ? {}
-          : {
-              '@vue/reactivity': _resolve(`@vue/reactivity/dist/reactivity.cjs${ctx.nuxt.options.dev ? '' : '.prod'}.js`),
-              '@vue/shared': _resolve(`@vue/shared/dist/shared.cjs${ctx.nuxt.options.dev ? '' : '.prod'}.js`),
-              'vue-router': _resolve(`vue-router/dist/vue-router.cjs${ctx.nuxt.options.dev ? '' : '.prod'}.js`),
-              'vue/server-renderer': _resolve('vue/server-renderer'),
-              'vue/compiler-sfc': _resolve('vue/compiler-sfc'),
-              vue: _resolve(`vue/dist/vue.cjs${ctx.nuxt.options.dev ? '' : '.prod'}.js`)
-            }
+        '#build/plugins': resolve(ctx.nuxt.options.buildDir, 'plugins/server')
       }
     },
     ssr: {

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -56,9 +56,7 @@ export async function buildServer (ctx: ViteBuildContext) {
       }
     },
     ssr: {
-      external: ctx.nuxt.options.experimental.externalVue
-        ? ['#internal/nitro', '#internal/nitro/utils', 'vue', 'vue-router']
-        : ['#internal/nitro', '#internal/nitro/utils'],
+      external: ['#internal/nitro', '#internal/nitro/utils'],
       noExternal: [
         ...transpile({ isServer: true, isDev: ctx.nuxt.options.dev }),
         // TODO: Use externality for production (rollup) build
@@ -77,7 +75,7 @@ export async function buildServer (ctx: ViteBuildContext) {
       ssr: true,
       rollupOptions: {
         input: { server: entry },
-        external: ['#internal/nitro', ...ctx.nuxt.options.experimental.externalVue ? ['vue', 'vue-router'] : []],
+        external: ['#internal/nitro'],
         output: {
           entryFileNames: '[name].mjs',
           format: 'module',

--- a/test/fixtures/minimal/nuxt.config.ts
+++ b/test/fixtures/minimal/nuxt.config.ts
@@ -1,3 +1,14 @@
+import { fileURLToPath } from 'node:url'
+
+const testWithInlineVue = process.env.EXTERNAL_VUE === 'false'
+
 export default defineNuxtConfig({
+  experimental: {
+    externalVue: !testWithInlineVue
+  },
+  buildDir: testWithInlineVue ? '.nuxt-inline' : '.nuxt',
+  nitro: {
+    output: { dir: fileURLToPath(new URL(testWithInlineVue ? './.output-inline' : './.output', import.meta.url)) }
+  },
   sourcemap: false
 })


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/14146

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Vite and Nitro correctly resolve vue dependencies, and it is far better to defer resolution to the bundlers than override it ourselves, particularly with support for non-hoist:

You can test with this plugin:

<details>
<summary>Details</summary>

```ts
const logger = {
  name: 'log',
  writeBundle (_options, bundle) {
    for (const file in bundle) {
      const chunk = bundle[file]
      if (chunk.type === 'asset') { continue }
      const resolvedVueFiles = chunk?.moduleIds.filter(i => i.includes('vue'))
      if (resolvedVueFiles?.length) {
        console.log(resolvedVueFiles)
      }
    }
  }
}

export default defineNuxtConfig({
  experimental: {
    // you can try with and without
    externalVue: false
  },
  nitro: {
    rollupConfig: {
      plugins: [logger]
    }
  },
  vite: {
    plugins: [logger]
  }
})
```

</details>

(In my testing, before this PR, with `externalVue: false` vue was actually being bundled twice in nitro bundle.)

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
