### PR TITLE
docs: update useFetch return values

### DIFF
--- a/docs/3.api/1.composables/use-async-data.md
+++ b/docs/3.api/1.composables/use-async-data.md
@@ -65,11 +65,11 @@ Under the hood, `lazy: false` uses `<Suspense>` to block the loading of the rout
 
 ## Return Values
 
-* **data**: the result of the asynchronous function that is passed in
-* **pending**: a boolean indicating whether the data is still being fetched
-* **refresh**/**execute**: a function that can be used to refresh the data returned by the `handler` function
-* **error**: an error object if the data fetching failed
-* **status**: a string indicating the status of the data request (`"idle"`, `"pending"`, `"success"`, `"error"`)
+* **data**: the result of the asynchronous function that is passed in.
+* **pending**: a boolean indicating whether the data is still being fetched.
+* **refresh**/**execute**: a function that can be used to refresh the data returned by the `handler` function.
+* **error**: an error object if the data fetching failed.
+* **status**: a string indicating the status of the data request (`"idle"`, `"pending"`, `"success"`, `"error"`).
 
 By default, Nuxt waits until a `refresh` is finished before it can be executed again.
 

--- a/docs/3.api/1.composables/use-fetch.md
+++ b/docs/3.api/1.composables/use-fetch.md
@@ -77,8 +77,9 @@ If you provide a function or ref as the `url` parameter, or if you provide funct
 
 * **data**: the result of the asynchronous function that is passed in.
 * **pending**: a boolean indicating whether the data is still being fetched.
-* **refresh**/**execute** : a function that can be used to refresh the data returned by the `handler` function.
+* **refresh**/**execute**: a function that can be used to refresh the data returned by the `handler` function.
 * **error**: an error object if the data fetching failed.
+* **status**: a string indicating the status of the data request (`"idle"`, `"pending"`, `"success"`, `"error"`).
 
 By default, Nuxt waits until a `refresh` is finished before it can be executed again.
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

#21045

### ❓ Type of change


- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In #21045, we have added the `status` return value to `useAsyncData`. Since `useFetch` is a wrapper around `useAsyncData`, so it has the same return values, but the [docs are not updated](https://nuxt.com/docs/api/composables/use-fetch#return-values).

![image](https://github.com/nuxt/nuxt/assets/22207414/63bd106b-4f07-43e7-bf7b-615d5ef80d6d)

This PR solves it by making the `Return Values` the same for `useFetch` and `useAsyncData`

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
