### PR TITLE
fix(nuxt): ensure static presets equivalent to `nuxi generate`

### DIFF
--- a/packages/nuxi/src/commands/build.ts
+++ b/packages/nuxi/src/commands/build.ts
@@ -30,6 +30,7 @@ export default defineNuxtCommand({
       overrides: {
         logLevel: args['log-level'],
         _generate: args.prerender,
+        ...(args.prerender ? { nitro: { static: true } } : {}),
         ...(options?.overrides || {})
       }
     })

--- a/packages/nuxi/src/commands/build.ts
+++ b/packages/nuxi/src/commands/build.ts
@@ -29,6 +29,7 @@ export default defineNuxtCommand({
       },
       overrides: {
         logLevel: args['log-level'],
+        // TODO: remove in 3.8
         _generate: args.prerender,
         ...(args.prerender ? { nitro: { static: true } } : {}),
         ...(options?.overrides || {})

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -1,7 +1,7 @@
 import { join, normalize, relative, resolve } from 'pathe'
 import { createDebugger, createHooks } from 'hookable'
 import type { LoadNuxtOptions } from '@nuxt/kit'
-import { addBuildPlugin, addComponent, addPlugin, addVitePlugin, addWebpackPlugin, installModule, loadNuxtConfig, logger, nuxtCtx, resolveAlias, resolveFiles, resolvePath, tryResolveModule } from '@nuxt/kit'
+import { addBuildPlugin, addComponent, addPlugin, addVitePlugin, addWebpackPlugin, installModule, loadNuxtConfig, logger, nuxtCtx, resolveAlias, resolveFiles, resolvePath, tryResolveModule, useNitro } from '@nuxt/kit'
 import type { Nuxt, NuxtHooks, NuxtOptions } from 'nuxt/schema'
 
 import escapeRE from 'escape-string-regexp'
@@ -271,15 +271,6 @@ async function initNuxt (nuxt: Nuxt) {
     })
   }
 
-  // Add prerender payload support
-  if (nuxt.options._generate && nuxt.options.experimental.payloadExtraction === undefined) {
-    console.warn('Using experimental payload extraction for full-static output. You can opt-out by setting `experimental.payloadExtraction` to `false`.')
-    nuxt.options.experimental.payloadExtraction = true
-  }
-  if (!nuxt.options.dev && nuxt.options.experimental.payloadExtraction) {
-    addPlugin(resolve(nuxt.options.appDir, 'plugins/payload.client'))
-  }
-
   // Add experimental cross-origin prefetch support using Speculation Rules API
   if (nuxt.options.experimental.crossOriginPrefetch) {
     addPlugin(resolve(nuxt.options.appDir, 'plugins/cross-origin-prefetch.client'))
@@ -380,6 +371,16 @@ async function initNuxt (nuxt: Nuxt) {
 
   // Init nitro
   await initNitro(nuxt)
+
+  // TODO: remove when app manifest support is landed in https://github.com/nuxt/nuxt/pull/21641
+  // Add prerender payload support
+  if (useNitro().options.static && nuxt.options.experimental.payloadExtraction === undefined) {
+    console.warn('Using experimental payload extraction for full-static output. You can opt-out by setting `experimental.payloadExtraction` to `false`.')
+    nuxt.options.experimental.payloadExtraction = true
+  }
+  if (!nuxt.options.dev && nuxt.options.experimental.payloadExtraction) {
+    addPlugin(resolve(nuxt.options.appDir, 'plugins/payload.client'))
+  }
 
   await nuxt.callHook('ready', nuxt)
 }

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -201,8 +201,9 @@ export default defineNuxtModule({
       })
     })
 
-    // Prerender all non-dynamic page routes when generating app
-    if (!nuxt.options.dev && nuxt.options._generate) {
+    nuxt.hook('nitro:init', (nitro) => {
+      if (nuxt.options.dev || !nitro.options.static) { return }
+      // Prerender all non-dynamic page routes when generating app
       const prerenderRoutes = new Set<string>()
       nuxt.hook('modules:done', () => {
         nuxt.hook('pages:extend', (pages) => {
@@ -230,7 +231,7 @@ export default defineNuxtModule({
         }
         nitro.options.prerender.routes = Array.from(prerenderRoutes)
       })
-    }
+    })
 
     nuxt.hook('imports:extend', (imports) => {
       imports.push(


### PR DESCRIPTION
### 🔗 Linked issue

resolves nuxt/nuxt#21254

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This finishes the second task on nuxt/nuxt#21254. Previous we enabled static nitro preset in `nuxi generate` (https://github.com/nuxt/nuxt/pull/21655), but this follows up to ensure that running `nuxi build --prerender` (or `NITRO_PRESET=static nuxi build` have the same behaviour.

From this point, we no longer use `options._generate` flag but directly access `nitro.options.static`. We can remove the internal `._generate` flag in a future minor release.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
