### PR TITLE
fix(nuxt): handle injecting multiple entry ids for styles

### DIFF
--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -66,7 +66,10 @@ const getClientManifest: () => Promise<Manifest> = () => import('#build/dist/ser
   .then(r => r.default || r)
   .then(r => typeof r === 'function' ? r() : r) as Promise<ClientManifest>
 
-const getEntryIds: () => Promise<string[]> = () => getClientManifest().then(r => Object.values(r).filter(r => r.isEntry).map(r => r.src!))
+const getEntryIds: () => Promise<string[]> = () => getClientManifest().then(r => Object.values(r).filter(r =>
+  // @ts-expect-error internal key set by CSS inlining configuration
+  r._globalCSS
+).map(r => r.src!))
 
 // @ts-expect-error virtual file
 const getStaticRenderedHead = (): Promise<NuxtMeta> => import('#head-static').then(r => r.default || r)

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -66,7 +66,7 @@ const getClientManifest: () => Promise<Manifest> = () => import('#build/dist/ser
   .then(r => r.default || r)
   .then(r => typeof r === 'function' ? r() : r) as Promise<ClientManifest>
 
-const getEntryId: () => Promise<string> = () => getClientManifest().then(r => Object.values(r).find(r => r.isEntry)!.src!)
+const getEntryIds: () => Promise<string[]> = () => getClientManifest().then(r => Object.values(r).filter(r => r.isEntry).map(r => r.src!))
 
 // @ts-expect-error virtual file
 const getStaticRenderedHead = (): Promise<NuxtMeta> => import('#head-static').then(r => r.default || r)
@@ -289,11 +289,11 @@ export default defineRenderHandler(async (event): Promise<Partial<RenderResponse
   const renderedMeta = await ssrContext.renderMeta?.() ?? {}
 
   if (process.env.NUXT_INLINE_STYLES && !islandContext) {
-    const entryId = await getEntryId()
-    if (ssrContext.modules) {
-      ssrContext.modules.add(entryId)
-    } else if (ssrContext._registeredComponents) {
-      ssrContext._registeredComponents.add(entryId)
+    const source = ssrContext.modules ?? ssrContext._registeredComponents
+    if (source) {
+      for (const id of await getEntryIds()) {
+        source.add(id)
+      }
     }
   }
 

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -166,6 +166,10 @@ export async function bundle (nuxt: Nuxt) {
       for (const key in manifest) {
         const entry = manifest[key]
         const shouldRemoveCSS = chunksWithInlinedCSS.has(key) && !entry.isEntry
+        if (chunksWithInlinedCSS.has(key)) {
+          // @ts-expect-error internal key
+          entry._globalCSS = true
+        }
         if (shouldRemoveCSS && entry.css) {
           entry.css = []
         }

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -166,7 +166,7 @@ export async function bundle (nuxt: Nuxt) {
       for (const key in manifest) {
         const entry = manifest[key]
         const shouldRemoveCSS = chunksWithInlinedCSS.has(key) && !entry.isEntry
-        if (chunksWithInlinedCSS.has(key)) {
+        if (entry.isEntry && chunksWithInlinedCSS.has(key)) {
           // @ts-expect-error internal key
           entry._globalCSS = true
         }


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/21840

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

If another module adds a second entrypoint, we might not be able to identify the right entry id at runtime. This instead adds all entrypoint ids that are associated with global CSS.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
