### PR TITLE
fix(nuxt): remove isServer check on islands transform plugin

### DIFF
--- a/packages/nuxt/src/components/module.ts
+++ b/packages/nuxt/src/components/module.ts
@@ -222,7 +222,7 @@ export default defineNuxtModule<ComponentsOptions>({
         experimentalComponentIslands: nuxt.options.experimental.componentIslands
       }))
 
-      if (isServer && nuxt.options.experimental.componentIslands) {
+      if (nuxt.options.experimental.componentIslands) {
         config.plugins.push(islandsTransform.vite({
           getComponents
         }))
@@ -250,7 +250,7 @@ export default defineNuxtModule<ComponentsOptions>({
           experimentalComponentIslands: nuxt.options.experimental.componentIslands
         }))
 
-        if (nuxt.options.experimental.componentIslands && mode === 'server') {
+        if (nuxt.options.experimental.componentIslands) {
           config.plugins.push(islandsTransform.webpack({
             getComponents
           }))


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
fix https://github.com/nuxt/nuxt/pull/21844
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Hi :wave: I made a mistake on https://github.com/nuxt/nuxt/pull/21844. The `isServer` variable seems to be true only at build time so currently we have issues with client-side navigation in dev mode (not sure why this hasn't been detected by the CI).

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
