### PR TITLE
perf(nuxt): allow hmr for server components in dev mode

### DIFF
--- a/packages/nuxt/src/components/module.ts
+++ b/packages/nuxt/src/components/module.ts
@@ -1,5 +1,5 @@
 import { statSync } from 'node:fs'
-import { relative, resolve } from 'pathe'
+import { normalize, relative, resolve } from 'pathe'
 import { addPluginTemplate, addTemplate, addVitePlugin, addWebpackPlugin, defineNuxtModule, resolveAlias, updateTemplates } from '@nuxt/kit'
 import type { Component, ComponentsDir, ComponentsOptions } from 'nuxt/schema'
 
@@ -232,7 +232,8 @@ export default defineNuxtModule<ComponentsOptions>({
           name: 'nuxt-server-component-hmr',
           handleHotUpdate (ctx) {
             const components = getComponents()
-            const comp = components.find(c => c.filePath === ctx.file)
+            const filePath = normalize(ctx.file)
+            const comp = components.find(c => c.filePath === filePath)
             if (comp?.mode === 'server') {
               ctx.server.ws.send({
                 event: `nuxt-server-component:${comp.pascalName}`,

--- a/packages/nuxt/src/components/module.ts
+++ b/packages/nuxt/src/components/module.ts
@@ -227,6 +227,21 @@ export default defineNuxtModule<ComponentsOptions>({
           getComponents
         }))
       }
+      if (!isServer && nuxt.options.experimental.componentIslands) {
+        config.plugins.push({
+          name: 'nuxt-server-component-hmr',
+          handleHotUpdate (ctx) {
+            const components = getComponents()
+            const comp = components.find(c => c.filePath === ctx.file)
+            if (comp?.mode === 'server') {
+              ctx.server.ws.send({
+                event: `nuxt-server-component:${comp.pascalName}`,
+                type: 'custom'
+              })
+            }
+          },
+        })
+      }
     })
     nuxt.hook('webpack:config', (configs) => {
       configs.forEach((config) => {

--- a/packages/nuxt/src/components/module.ts
+++ b/packages/nuxt/src/components/module.ts
@@ -239,7 +239,7 @@ export default defineNuxtModule<ComponentsOptions>({
                 type: 'custom'
               })
             }
-          },
+          }
         })
       }
     })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds support for HMR in server components when in development - automatically refetching server components when they change on the server.

![CleanShot 2023-07-03 at 15 54 03](https://github.com/nuxt/nuxt/assets/28706372/9ea1997a-ed01-43f9-9df4-6226151575ce)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
