### PR TITLE
fix(nuxt): include external layers in `tsconfig.json` scope

### DIFF
--- a/packages/nuxi/src/utils/prepare.ts
+++ b/packages/nuxi/src/utils/prepare.ts
@@ -30,8 +30,8 @@ export const writeTypes = async (nuxt: Nuxt) => {
       './nuxt.d.ts',
       join(relative(nuxt.options.buildDir, nuxt.options.rootDir), '**/*'),
       ...nuxt.options.srcDir !== nuxt.options.rootDir ? [join(relative(nuxt.options.buildDir, nuxt.options.srcDir), '**/*')] : [],
-      ...nuxt.options.typescript.includeWorkspace && nuxt.options.workspaceDir !== nuxt.options.rootDir ? [join(relative(nuxt.options.buildDir, nuxt.options.workspaceDir), '**/*')] : [],
-      ...nuxt.options._layers.reduce((paths: string[], layer) => { if (layer.config.srcDir && layer.config.srcDir !== nuxt.options.rootDir) { paths.push(join(layer.config.srcDir, '**/*')) } return paths }, [])
+      ...nuxt.options._layers.filter(layer => !(layer.config.srcDir ?? layer.cwd).startsWith(nuxt.options.rootDir)).map(layer => join(relative(nuxt.options.buildDir, layer.config.srcDir ?? layer.cwd), '**/*')),
+      ...nuxt.options.typescript.includeWorkspace && nuxt.options.workspaceDir !== nuxt.options.rootDir ? [join(relative(nuxt.options.buildDir, nuxt.options.workspaceDir), '**/*')] : []
     ],
     exclude: [
       // nitro generate output: https://github.com/nuxt/nuxt/blob/main/packages/nuxt/src/core/nitro.ts#L186

--- a/packages/nuxi/src/utils/prepare.ts
+++ b/packages/nuxi/src/utils/prepare.ts
@@ -30,7 +30,8 @@ export const writeTypes = async (nuxt: Nuxt) => {
       './nuxt.d.ts',
       join(relative(nuxt.options.buildDir, nuxt.options.rootDir), '**/*'),
       ...nuxt.options.srcDir !== nuxt.options.rootDir ? [join(relative(nuxt.options.buildDir, nuxt.options.srcDir), '**/*')] : [],
-      ...nuxt.options.typescript.includeWorkspace && nuxt.options.workspaceDir !== nuxt.options.rootDir ? [join(relative(nuxt.options.buildDir, nuxt.options.workspaceDir), '**/*')] : []
+      ...nuxt.options.typescript.includeWorkspace && nuxt.options.workspaceDir !== nuxt.options.rootDir ? [join(relative(nuxt.options.buildDir, nuxt.options.workspaceDir), '**/*')] : [],
+      ...nuxt.options._layers.reduce((paths: string[], layer) => { if (layer.config.srcDir && layer.config.srcDir !== nuxt.options.rootDir) { paths.push(join(layer.config.srcDir, '**/*')) } return paths }, [])
     ],
     exclude: [
       // nitro generate output: https://github.com/nuxt/nuxt/blob/main/packages/nuxt/src/core/nitro.ts#L186


### PR DESCRIPTION
### 🔗 Linked issue

#21877

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

_Not sure which type(s) apply._

### 📚 Description

<!-- Describe your changes in detail -->
Volar 1.8.2 introduced a [breaking change](https://github.com/vuejs/language-tools/blob/master/CHANGELOG.md#182-2023627) regarding the way it handles `tsconfig`.

Until this PR, we needed to manually add our layer(s) paths to the `include` section, that'd override the default one, on our project `tsconfig` to get support for things like autocompletion. Something like:
```json
"include": [
    ".nuxt/nuxt.d.ts",
    "**/*",
    "<path to layer files>"
],
```

What this PR does is check `nuxt.options._layers` for paths that are different than `nuxt.options.rootDir` and add them, with a trailing `**/*` to the `include` array, next to `./nuxt.d.ts` and all the other ones.

There's probably a better way to do it, but it works for now.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

I don't think documentation should mention it, as it's transparent for the user like the rest of the `tsconfig` file.
