### PR TITLE
docs: added a note about server dynamic routes limitation

### DIFF
--- a/docs/2.guide/2.directory-structure/1.server.md
+++ b/docs/2.guide/2.directory-structure/1.server.md
@@ -56,6 +56,11 @@ export default defineEventHandler(() => 'Hello World!')
 
 Given the example above, the `/hello` route will be accessible at <http://localhost:3000/hello>.
 
+::alert{type=info icon=💡}
+Note that currently server routes do not support the full functionality of dynamic routes as [pages](https://nuxt.com/docs/guide/directory-structure/pages#dynamic-routes) do. 
+::
+
+
 ## Server Middleware
 
 Nuxt will automatically read in any file in the `~/server/middleware` to create server middleware for your project.

--- a/docs/2.guide/2.directory-structure/1.server.md
+++ b/docs/2.guide/2.directory-structure/1.server.md
@@ -57,9 +57,8 @@ export default defineEventHandler(() => 'Hello World!')
 Given the example above, the `/hello` route will be accessible at <http://localhost:3000/hello>.
 
 ::alert{type=info icon=💡}
-Note that currently server routes do not support the full functionality of dynamic routes as [pages](https://nuxt.com/docs/guide/directory-structure/pages#dynamic-routes) do. 
+Note that currently server routes do not support the full functionality of dynamic routes as [pages](https://nuxt.com/docs/guide/directory-structure/pages#dynamic-routes) do.
 ::
-
 
 ## Server Middleware
 


### PR DESCRIPTION
Added a note that currently server routes do not support the full functionality of dynamic routes as `pages` do.

### 🔗 Linked issue

I updated the documentation as @danielroe suggested on this issue [#21781](https://github.com/nuxt/nuxt/issues/21781)