### PR TITLE
fix(vite): remove @vue/ scoped libraries from resolutions

### DIFF
--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -52,11 +52,7 @@ export async function buildClient (ctx: ViteBuildContext) {
         '#internal/nitro': resolve(ctx.nuxt.options.buildDir, 'nitro.client.mjs')
       },
       dedupe: [
-        'vue',
-        // basic reactivity
-        '@vue/reactivity', '@vue/runtime-core', '@vue/runtime-dom', '@vue/shared',
-        // runtime compiler
-        '@vue/compiler-sfc', '@vue/compiler-dom', '@vue/compiler-core', '@vue/compiler-ssr'
+        'vue'
       ]
     },
     cacheDir: resolve(ctx.nuxt.options.rootDir, 'node_modules/.cache/vite', 'client'),

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -15,7 +15,7 @@ import { transpile } from './utils/transpile'
 export async function buildServer (ctx: ViteBuildContext) {
   const helper = ctx.nuxt.options.nitro.imports !== false ? '' : 'globalThis.'
   const entry = ctx.nuxt.options.ssr ? ctx.entry : await resolvePath(resolve(ctx.nuxt.options.appDir, 'entry-spa'))
-  const nitroDependencies = await tryResolveModule('nitropack/package.json').then(r => import(r!)).then(r => Object.keys(r.dependencies || {})).catch(() => [])
+  const nitroDependencies = await tryResolveModule('nitropack/package.json', ctx.nuxt.options.modulesDir).then(r => import(r!)).then(r => Object.keys(r.dependencies || {})).catch(() => [])
   const serverConfig: ViteConfig = vite.mergeConfig(ctx.config, {
     configFile: false,
     base: ctx.nuxt.options.dev

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -2,7 +2,7 @@ import { resolve } from 'pathe'
 import * as vite from 'vite'
 import vuePlugin from '@vitejs/plugin-vue'
 import viteJsxPlugin from '@vitejs/plugin-vue-jsx'
-import { logger, resolvePath } from '@nuxt/kit'
+import { logger, resolvePath, tryImportModule } from '@nuxt/kit'
 import { joinURL, withTrailingSlash, withoutLeadingSlash } from 'ufo'
 import type { ViteConfig } from '@nuxt/schema'
 import type { ViteBuildContext } from './vite'
@@ -15,7 +15,7 @@ import { transpile } from './utils/transpile'
 export async function buildServer (ctx: ViteBuildContext) {
   const helper = ctx.nuxt.options.nitro.imports !== false ? '' : 'globalThis.'
   const entry = ctx.nuxt.options.ssr ? ctx.entry : await resolvePath(resolve(ctx.nuxt.options.appDir, 'entry-spa'))
-  const nitroDependencies = await import('nitropack/package.json').then(r => Object.keys(r.dependencies)).catch(() => [])
+  const nitroDependencies = await tryImportModule('nitropack/package.json').then(r => Object.keys(r.dependencies)) || []
   const serverConfig: ViteConfig = vite.mergeConfig(ctx.config, {
     configFile: false,
     base: ctx.nuxt.options.dev

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -2,7 +2,7 @@ import { resolve } from 'pathe'
 import * as vite from 'vite'
 import vuePlugin from '@vitejs/plugin-vue'
 import viteJsxPlugin from '@vitejs/plugin-vue-jsx'
-import { logger, resolvePath, tryImportModule } from '@nuxt/kit'
+import { logger, resolvePath, tryResolveModule } from '@nuxt/kit'
 import { joinURL, withTrailingSlash, withoutLeadingSlash } from 'ufo'
 import type { ViteConfig } from '@nuxt/schema'
 import type { ViteBuildContext } from './vite'
@@ -15,7 +15,7 @@ import { transpile } from './utils/transpile'
 export async function buildServer (ctx: ViteBuildContext) {
   const helper = ctx.nuxt.options.nitro.imports !== false ? '' : 'globalThis.'
   const entry = ctx.nuxt.options.ssr ? ctx.entry : await resolvePath(resolve(ctx.nuxt.options.appDir, 'entry-spa'))
-  const nitroDependencies = await tryImportModule('nitropack/package.json').then(r => Object.keys(r.dependencies)) || []
+  const nitroDependencies = await tryResolveModule('nitropack/package.json').then(r => import(r!)).then(r => Object.keys(r.dependencies || {})).catch(() => [])
   const serverConfig: ViteConfig = vite.mergeConfig(ctx.config, {
     configFile: false,
     base: ctx.nuxt.options.dev

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -15,6 +15,7 @@ import { transpile } from './utils/transpile'
 export async function buildServer (ctx: ViteBuildContext) {
   const helper = ctx.nuxt.options.nitro.imports !== false ? '' : 'globalThis.'
   const entry = ctx.nuxt.options.ssr ? ctx.entry : await resolvePath(resolve(ctx.nuxt.options.appDir, 'entry-spa'))
+  const nitroDependencies = await import('nitropack/package.json').then(r => Object.keys(r.dependencies)).catch(() => [])
   const serverConfig: ViteConfig = vite.mergeConfig(ctx.config, {
     configFile: false,
     base: ctx.nuxt.options.dev
@@ -56,12 +57,9 @@ export async function buildServer (ctx: ViteBuildContext) {
       }
     },
     ssr: {
-      external: ['#internal/nitro', '#internal/nitro/utils'],
+      external: ['#internal/nitro', '#internal/nitro/utils', ...nitroDependencies],
       noExternal: [
         ...transpile({ isServer: true, isDev: ctx.nuxt.options.dev }),
-        // TODO: Use externality for production (rollup) build
-        /\/esm\/.*\.js$/,
-        /\.(es|esm|esm-browser|esm-bundler).js$/,
         '/__vue-jsx',
         '#app',
         /^nuxt(\/|$)/,

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -76,7 +76,7 @@ export async function bundle (nuxt: Nuxt) {
           }
         },
         optimizeDeps: {
-          include: ['vue', '@vue/reactivity', '@vue/runtime-core', '@vue/runtime-dom', '@vue/shared'],
+          include: ['vue'],
           exclude: ['nuxt/app']
         },
         css: resolveCSSOptions(nuxt),


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

reverts #20829
https://github.com/nuxt/nuxt/issues/14146#issuecomment-1603993453

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Technically any packages in `optimizeDeps.include` and `dedupe` need to be resolvable from the dependencies of the root `package.json`. So the current setup is incompatible with disabling shamefully-hoist. By removing these packages, we make it possible not to have to to install all the `@vue` scoped libraries.

In addition, this PR also adds nitro dependencies to the `external` array so that nitro can better handle resolving them as part of its build process (possibly deduping them with them being used in server routes).

When https://github.com/unjs/nitro/pull/1388 is merged, we can then move the `transpile` call from vite/webpack server builds directly into nitro options.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
