### PR TITLE
docs: add JetBrains IDEs debug configuration

### DIFF
--- a/docs/2.guide/3.going-further/9.debugging.md
+++ b/docs/2.guide/3.going-further/9.debugging.md
@@ -67,6 +67,7 @@ You can also debug your Nuxt app in JetBrains IDEs such as IntelliJ IDEA, WebSto
 1. Create a new file in your project root directory and name it `nuxt.run.xml`.
 
 2. Open the `nuxt.run.xml` file and paste the following debug configuration:
+
 ```xml
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="client: chrome" type="JavascriptDebugType" uri="http://localhost:3000" useFirstLineBreakpoints="true">

--- a/docs/2.guide/3.going-further/9.debugging.md
+++ b/docs/2.guide/3.going-further/9.debugging.md
@@ -60,6 +60,31 @@ You may need to update the config below with a path to your web browser. For mor
 }
 ```
 
+### Example JetBrains IDEs Debug Configuration
+
+You can also debug your Nuxt app in JetBrains IDEs such as IntelliJ IDEA, WebStorm, or PhpStorm.
+
+1. Create a new file in your project root directory and name it `nuxt.run.xml`.
+
+2. Open the `nuxt.run.xml` file and paste the following debug configuration:
+```xml
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="client: chrome" type="JavascriptDebugType" uri="http://localhost:3000" useFirstLineBreakpoints="true">
+    <method v="2" />
+  </configuration>
+
+  <configuration default="false" name="server: nuxt" type="NodeJSConfigurationType" application-parameters="dev" path-to-js-file="$PROJECT_DIR$/node_modules/nuxi/bin/nuxi.mjs" working-dir="$PROJECT_DIR$">
+    <method v="2" />
+  </configuration>
+
+  <configuration default="false" name="fullstack: nuxt" type="CompoundRunConfigurationType">
+    <toRun name="client: chrome" type="JavascriptDebugType" />
+    <toRun name="server: nuxt" type="NodeJSConfigurationType" />
+    <method v="2" />
+  </configuration>
+</component>
+```
+
 ### Other IDEs
 
 If you have another IDE and would like to contribute sample configuration, feel free to [open a PR](https://github.com/nuxt/nuxt/edit/main/docs/2.guide/3.going-further/9.debugging.md)!


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Added documentation for configuring debugging in JetBrains IDEs, including IntelliJ IDEA, WebStorm, and PhpStorm. The commit includes an example `nuxt.run.xml` file with the necessary debug configurations for client and server debugging. This update enhances the documentation for developers using JetBrains IDEs for Nuxt app development.


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
