### PR TITLE
docs: fix accessing custom props from child pages

### DIFF
--- a/docs/3.api/2.components/2.nuxt-page.md
+++ b/docs/3.api/2.components/2.nuxt-page.md
@@ -71,7 +71,7 @@ In addition, `NuxtPage` also accepts custom props that you may need to pass furt
 <NuxtPage :foobar="123" />
 ```
 
-For example, in above example, value of `foobar` will be available using `$attrs.foobar`.
+For example, in the above example, the value of `foobar` will be available using `$attrs.foobar` in the template or `useAttrs().foobar` in `<script setup>`.
 
 ::ReadMore{link="/docs/guide/directory-structure/app"}
 ::

--- a/docs/3.api/2.components/2.nuxt-page.md
+++ b/docs/3.api/2.components/2.nuxt-page.md
@@ -71,7 +71,7 @@ In addition, `NuxtPage` also accepts custom props that you may need to pass furt
 <NuxtPage :foobar="123" />
 ```
 
-For example, in above example, value of `foobar` will be available using `attrs.foobar`.
+For example, in above example, value of `foobar` will be available using `$attrs.foobar`.
 
 ::ReadMore{link="/docs/guide/directory-structure/app"}
 ::


### PR DESCRIPTION
To call custom props from child pages, it requires $attrs

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
resolves https://github.com/nuxt/nuxt/issues/21976

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
