### PR TITLE
docs: add more internal links

### DIFF
--- a/docs/1.getting-started/2.installation.md
+++ b/docs/1.getting-started/2.installation.md
@@ -34,7 +34,7 @@ Start with one of our starters and themes directly by opening [nuxt.new](https:/
 
 - **Volar**: Either enable [**Take Over Mode**](https://vuejs.org/guide/typescript/overview.html#volar-takeover-mode) (recommended) or add the [TypeScript Vue Plugin](https://marketplace.visualstudio.com/items?itemName=Vue.vscode-typescript-vue-plugin)
 
-If you have enabled **Take Over Mode** or installed the **TypeScript Vue Plugin (Volar)**, you can disable generating the shim for `*.vue` files in your[`nuxt.config.ts`](/docs/guide/directory-structure/nuxt.config)file:
+If you have enabled **Take Over Mode** or installed the **TypeScript Vue Plugin (Volar)**, you can disable generating the shim for `*.vue` files in your [`nuxt.config.ts`](/docs/guide/directory-structure/nuxt.config) file:
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({

--- a/docs/1.getting-started/2.installation.md
+++ b/docs/1.getting-started/2.installation.md
@@ -34,7 +34,7 @@ Start with one of our starters and themes directly by opening [nuxt.new](https:/
 
 - **Volar**: Either enable [**Take Over Mode**](https://vuejs.org/guide/typescript/overview.html#volar-takeover-mode) (recommended) or add the [TypeScript Vue Plugin](https://marketplace.visualstudio.com/items?itemName=Vue.vscode-typescript-vue-plugin)
 
-If you have enabled **Take Over Mode** or installed the **TypeScript Vue Plugin (Volar)**, you can disable generating the shim for `*.vue` files in your `nuxt.config.ts` file:
+If you have enabled **Take Over Mode** or installed the **TypeScript Vue Plugin (Volar)**, you can disable generating the shim for `*.vue` files in your[`nuxt.config.ts`](/docs/guide/directory-structure/nuxt.config)file:
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({

--- a/docs/1.getting-started/3.configuration.md
+++ b/docs/1.getting-started/3.configuration.md
@@ -9,7 +9,7 @@ By default, Nuxt is configured to cover most use cases. The [`nuxt.config.ts`](/
 
 ## Nuxt Configuration
 
-The[`nuxt.config.ts`](/docs/guide/directory-structure/nuxt.config)file is located at the root of a Nuxt project and can override or extend the application's behavior.
+The [`nuxt.config.ts`](/docs/guide/directory-structure/nuxt.config) file is located at the root of a Nuxt project and can override or extend the application's behavior.
 
 A minimal configuration file exports the `defineNuxtConfig` function containing an object with your configuration. The `defineNuxtConfig` helper is globally available without import.
 
@@ -135,7 +135,7 @@ Non primitive JS types         | ❌ No            | ✅ Yes
 
 ## External Configuration Files
 
-Nuxt uses[`nuxt.config.ts`](/docs/guide/directory-structure/nuxt.config)file as the single source of trust for configurations and skips reading external configuration files. During the course of building your project, you may have a need to configure those. The following table highlights common configurations and, where applicable, how they can be configured with Nuxt.
+Nuxt uses [`nuxt.config.ts`](/docs/guide/directory-structure/nuxt.config) file as the single source of trust for configurations and skips reading external configuration files. During the course of building your project, you may have a need to configure those. The following table highlights common configurations and, where applicable, how they can be configured with Nuxt.
 
 Name                                          | Config File               |  How To Configure
 |---------------------------------------------|---------------------------|-------------------------

--- a/docs/1.getting-started/3.configuration.md
+++ b/docs/1.getting-started/3.configuration.md
@@ -9,7 +9,7 @@ By default, Nuxt is configured to cover most use cases. The [`nuxt.config.ts`](/
 
 ## Nuxt Configuration
 
-The `nuxt.config.ts` file is located at the root of a Nuxt project and can override or extend the application's behavior.
+The[`nuxt.config.ts`](/docs/guide/directory-structure/nuxt.config)file is located at the root of a Nuxt project and can override or extend the application's behavior.
 
 A minimal configuration file exports the `defineNuxtConfig` function containing an object with your configuration. The `defineNuxtConfig` helper is globally available without import.
 
@@ -135,7 +135,7 @@ Non primitive JS types         | ❌ No            | ✅ Yes
 
 ## External Configuration Files
 
-Nuxt uses `nuxt.config.ts` file as the single source of trust for configurations and skips reading external configuration files. During the course of building your project, you may have a need to configure those. The following table highlights common configurations and, where applicable, how they can be configured with Nuxt.
+Nuxt uses[`nuxt.config.ts`](/docs/guide/directory-structure/nuxt.config)file as the single source of trust for configurations and skips reading external configuration files. During the course of building your project, you may have a need to configure those. The following table highlights common configurations and, where applicable, how they can be configured with Nuxt.
 
 Name                                          | Config File               |  How To Configure
 |---------------------------------------------|---------------------------|-------------------------

--- a/docs/1.getting-started/3.views.md
+++ b/docs/1.getting-started/3.views.md
@@ -28,7 +28,7 @@ If you are familiar with Vue, you might wonder where `main.js` is (the file that
 
 ![Components are reusable pieces of UI](/assets/docs/getting-started/views/components.svg)
 
-Most components are reusable pieces of the user interface, like buttons and menus. In Nuxt, you can create these components in the `components/` directory, and they will be automatically available across your application without having to explicitly import them.
+Most components are reusable pieces of the user interface, like buttons and menus. In Nuxt, you can create these components in the [`components/` directory](/docs/guide/directory-structure/components), and they will be automatically available across your application without having to explicitly import them.
 
 ::code-group
 
@@ -57,9 +57,9 @@ Most components are reusable pieces of the user interface, like buttons and menu
 
 ![Pages are views tied to a specific route](/assets/docs/getting-started/views/pages.svg)
 
-Pages represent views for each specific route pattern. Every file in the `pages/` directory represents a different route displaying its content.
+Pages represent views for each specific route pattern. Every file in the [`pages/` directory](/docs/guide/directory-structure/pages) represents a different route displaying its content.
 
-To use pages, create `pages/index.vue` file and add `<NuxtPage />` component to the `app.vue` (or remove `app.vue` for default entry). You can now create more pages and their corresponding routes by adding new files in the `pages/` directory.
+To use pages, create `pages/index.vue` file and add `<NuxtPage />` component to the `app.vue` (or remove `app.vue` for default entry). You can now create more pages and their corresponding routes by adding new files in the [`pages/` directory](/docs/guide/directory-structure/pages).
 
 ::code-group
 

--- a/docs/1.getting-started/4.assets.md
+++ b/docs/1.getting-started/4.assets.md
@@ -13,7 +13,7 @@ Nuxt uses two directories to handle assets like stylesheets, fonts or images.
 
 The [`public/` directory](/docs/guide/directory-structure/public) is used as a public server for static assets publicly available at a defined URL of your application.
 
-You can get a file in the `public/` directory from your application's code or from a browser by the root URL `/`.
+You can get a file in the [`public/` directory](/docs/guide/directory-structure/public) from your application's code or from a browser by the root URL `/`.
 
 ### Example
 
@@ -29,9 +29,9 @@ For example, referencing an image file in the `public/img/` directory, available
 
 Nuxt uses [Vite](https://vitejs.dev/guide/assets.html) or [webpack](https://webpack.js.org/guides/asset-management/) to build and bundle your application. The main function of these build tools is to process JavaScript files, but they can be extended through [plugins](https://vitejs.dev/plugins/) (for Vite) or [loaders](https://webpack.js.org/loaders/) (for webpack) to process other kind of assets, like stylesheets, fonts or SVG. This step transforms the original file mainly for performance or caching purposes (such as stylesheets minification or browser cache invalidation).
 
-By convention, Nuxt uses the `assets/` directory to store these files but there is no auto-scan functionality for this directory, and you can use any other name for it.
+By convention, Nuxt uses the [`assets/` directory](/docs/guide/directory-structure/assets) to store these files but there is no auto-scan functionality for this directory, and you can use any other name for it.
 
-In your application's code, you can reference a file located in the `assets/` directory by using the `~/assets/` path.
+In your application's code, you can reference a file located in the [`assets/` directory](/docs/guide/directory-structure/assets) by using the `~/assets/` path.
 
 ### Example
 
@@ -44,7 +44,7 @@ For example, referencing an image file that will be processed if a build tool is
 ```
 
 ::alert{type=info icon=💡}
-Nuxt won't serve files in the `assets/` directory at a static URL like `/assets/my-file.png`. If you need a static URL, use the [`public/` directory](#public-directory).
+Nuxt won't serve files in the [`assets/` directory](/docs/guide/directory-structure/assets) at a static URL like `/assets/my-file.png`. If you need a static URL, use the [`public/` directory](#public-directory).
 ::
 
 ### Global Styles Imports

--- a/docs/1.getting-started/4.styling.md
+++ b/docs/1.getting-started/4.styling.md
@@ -105,7 +105,7 @@ export default defineNuxtConfig({
 
 You can include external stylesheets in your application by adding a link element in the head section of your nuxt.config file. You can achieve this result using different methods. Note that local stylesheets can also be included like this.
 
-You can manipulate the head with the `app.head` property of your Nuxt configuration:
+You can manipulate the head with the [`app.head`](/docs/api/configuration/nuxt-config#head) property of your Nuxt configuration:
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({

--- a/docs/1.getting-started/4.styling.md
+++ b/docs/1.getting-started/4.styling.md
@@ -9,7 +9,7 @@ You can use CSS preprocessors, CSS frameworks, UI libraries and Nuxt modules to 
 
 ## Local Stylesheets
 
-If you're writing local stylesheets, the natural place to put them is the `assets/` directory.
+If you're writing local stylesheets, the natural place to put them is the [`assets/` directory](/docs/guide/directory-structure/assets).
 
 ### Importing Within Components
 
@@ -37,7 +37,7 @@ The stylesheets will be inlined in the HTML rendered by Nuxt.
 ### The CSS Property
 
 You can also use the `css` property in the Nuxt configuration.
-The natural place for your stylesheets is the `assets/` directory. You can then reference its path and Nuxt will include it to all the pages of your application.
+The natural place for your stylesheets is the [`assets/` directory](/docs/guide/directory-structure/assets). You can then reference its path and Nuxt will include it to all the pages of your application.
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({

--- a/docs/1.getting-started/5.routing.md
+++ b/docs/1.getting-started/5.routing.md
@@ -4,11 +4,11 @@ description: Nuxt file-system routing creates a route for every file in the page
 ---
 # Routing
 
-One core feature of Nuxt is the file system router. Every Vue file inside the `pages/` directory creates a corresponding URL (or route) that displays the contents of the file. By using dynamic imports for each page, Nuxt leverages code-splitting to ship the minimum amount of JavaScript for the requested route.
+One core feature of Nuxt is the file system router. Every Vue file inside the [`pages/` directory](/docs/guide/directory-structure/pages) creates a corresponding URL (or route) that displays the contents of the file. By using dynamic imports for each page, Nuxt leverages code-splitting to ship the minimum amount of JavaScript for the requested route.
 
 ## Pages
 
-Nuxt routing is based on [vue-router](https://router.vuejs.org/) and generates the routes from every component created in the [`pages/`](/docs/guide/directory-structure/pages) directory, based on their filename.
+Nuxt routing is based on [vue-router](https://router.vuejs.org/) and generates the routes from every component created in the [`pages/` directory](/docs/guide/directory-structure/pages), based on their filename.
 
 This file system routing uses naming conventions to create dynamic and nested routes:
 
@@ -93,8 +93,8 @@ Route middleware runs within the Vue part of your Nuxt app. Despite the similar 
 There are three kinds of route middleware:
 
 1. Anonymous (or inline) route middleware, which are defined directly in the pages where they are used.
-2. Named route middleware, which are placed in the `middleware/` directory and will be automatically loaded via asynchronous import when used on a page. (**Note**: The route middleware name is normalized to kebab-case, so `someMiddleware` becomes `some-middleware`.)
-3. Global route middleware, which are placed in the `middleware/` directory (with a `.global` suffix) and will be automatically run on every route change.
+2. Named route middleware, which are placed in the [`middleware/` directory](/docs/guide/directory-structure/middleware) and will be automatically loaded via asynchronous import when used on a page. (**Note**: The route middleware name is normalized to kebab-case, so `someMiddleware` becomes `some-middleware`.)
+3. Global route middleware, which are placed in the [`middleware/` directory](/docs/guide/directory-structure/middleware) (with a `.global` suffix) and will be automatically run on every route change.
 
 Example of an `auth` middleware protecting the `/dashboard` page:
 

--- a/docs/1.getting-started/5.seo-meta.md
+++ b/docs/1.getting-started/5.seo-meta.md
@@ -33,7 +33,7 @@ This method does not allow you to provide reactive data. We recommend to use `us
 
 Shortcuts are available to make configuration easier: `charset` and `viewport`. You can also provide any of the keys listed below in [Types](#types).
 
-## [`useHead`](/docs/api/composables/use-head) 
+## [`useHead`](/docs/api/composables/use-head)
 
 The [`useHead`](/docs/api/composables/use-head) composable function allows you to manage your head tags in a programmatic and reactive way,
 powered by [Unhead](https://unhead.harlanzw.com/).

--- a/docs/1.getting-started/5.seo-meta.md
+++ b/docs/1.getting-started/5.seo-meta.md
@@ -33,7 +33,7 @@ This method does not allow you to provide reactive data. We recommend to use `us
 
 Shortcuts are available to make configuration easier: `charset` and `viewport`. You can also provide any of the keys listed below in [Types](#types).
 
-## [`useHead`](/docs/api/composables/use-head) 
+## `useHead`
 
 The [`useHead`](/docs/api/composables/use-head) composable function allows you to manage your head tags in a programmatic and reactive way,
 powered by [Unhead](https://unhead.harlanzw.com/).

--- a/docs/1.getting-started/5.seo-meta.md
+++ b/docs/1.getting-started/5.seo-meta.md
@@ -33,9 +33,9 @@ This method does not allow you to provide reactive data. We recommend to use `us
 
 Shortcuts are available to make configuration easier: `charset` and `viewport`. You can also provide any of the keys listed below in [Types](#types).
 
-## `useHead`
+## [`useHead`](/docs/api/composables/use-head) 
 
-The `useHead` composable function allows you to manage your head tags in a programmatic and reactive way,
+The [`useHead`](/docs/api/composables/use-head) composable function allows you to manage your head tags in a programmatic and reactive way,
 powered by [Unhead](https://unhead.harlanzw.com/).
 
 As with all composables, it can only be used with a components `setup` and lifecycle hooks.
@@ -59,7 +59,7 @@ We recommend to take a look at the [`useHead`](/docs/api/composables/use-head) a
 
 ## `useSeoMeta` and `useServerSeoMeta`
 
-The `useSeoMeta` and `useServerSeoMeta` composables let you define your site's SEO meta tags as a flat object with full TypeScript support.
+The `useSeoMeta` and [`useServerSeoMeta`](/docs/api/composables/use-server-seo-meta) composables let you define your site's SEO meta tags as a flat object with full TypeScript support.
 
 This helps you avoid typos and common mistakes, such as using `name` instead of `property`.
 
@@ -108,7 +108,7 @@ const title = ref('Hello World')
 
 ## Types
 
-The below is the non-reactive types used for `useHead`, `app.head` and components.
+The below is the non-reactive types used for [`useHead`](/docs/api/composables/use-head) , [`app.head`](/docs/api/configuration/nuxt-config#head) and components.
 
 ```ts
 interface MetaObject {
@@ -196,7 +196,7 @@ If you want to use a function (for full control), then this cannot be set in you
 
 ::
 
-Now, if you set the title to `My Page` with `useHead` on another page of your site, the title would appear as 'My Page - Site Title' in the browser tab. You could also pass `null` to default to the site title.
+Now, if you set the title to `My Page` with [`useHead`](/docs/api/composables/use-head) on another page of your site, the title would appear as 'My Page - Site Title' in the browser tab. You could also pass `null` to default to the site title.
 
 ### Body Tags
 
@@ -222,7 +222,7 @@ useHead({
 
 ### With `definePageMeta`
 
-Within your [`pages/` directory](/docs/guide/directory-structure/pages), you can use `definePageMeta` along with `useHead` to set metadata based on the current route.
+Within your [`pages/` directory](/docs/guide/directory-structure/pages), you can use `definePageMeta` along with [`useHead`](/docs/api/composables/use-head) to set metadata based on the current route.
 
 For example, you can first set the current page title (this is extracted at build time via a macro, so it can't be set dynamically):
 
@@ -274,7 +274,7 @@ useHead({
 
 ### External CSS
 
-The example below shows how you might enable Google Fonts using either the `link` property of the `useHead` composable or using the `<Link>` component:
+The example below shows how you might enable Google Fonts using either the `link` property of the [`useHead`](/docs/api/composables/use-head) composable or using the `<Link>` component:
 
 ::code-group
 

--- a/docs/1.getting-started/5.seo-meta.md
+++ b/docs/1.getting-started/5.seo-meta.md
@@ -108,7 +108,7 @@ const title = ref('Hello World')
 
 ## Types
 
-The below is the non-reactive types used for [`useHead`](/docs/api/composables/use-head) , [`app.head`](/docs/api/configuration/nuxt-config#head) and components.
+Below are the non-reactive types used for [`useHead`](/docs/api/composables/use-head), [`app.head`](/docs/api/configuration/nuxt-config#head) and components.
 
 ```ts
 interface MetaObject {

--- a/docs/1.getting-started/5.seo-meta.md
+++ b/docs/1.getting-started/5.seo-meta.md
@@ -222,7 +222,7 @@ useHead({
 
 ### With `definePageMeta`
 
-Within your `pages/` directory, you can use `definePageMeta` along with `useHead` to set metadata based on the current route.
+Within your [`pages/` directory](/docs/guide/directory-structure/pages), you can use `definePageMeta` along with `useHead` to set metadata based on the current route.
 
 For example, you can first set the current page title (this is extracted at build time via a macro, so it can't be set dynamically):
 

--- a/docs/1.getting-started/6.data-fetching.md
+++ b/docs/1.getting-started/6.data-fetching.md
@@ -5,15 +5,15 @@ description: Nuxt provides composables to handle data fetching within your appli
 
 # Data fetching
 
-Nuxt comes with two composables and a built-in library to perform data-fetching in browser or server environments: `useFetch`, `useAsyncData` and `$fetch` .
+Nuxt comes with two composables and a built-in library to perform data-fetching in browser or server environments: `useFetch`, [`useAsyncData`](/docs/api/composables/use-async-data) and `$fetch` .
 
 Used together, they ensure cross-environment compatibility and efficient caching and avoid duplicate network calls.
 
-`useFetch` is the most straightforward way to handle data fetching in a component setup function.
+[`useFetch`](/docs/api/composables/use-fetch) is the most straightforward way to handle data fetching in a component setup function.
 
 On the other hand, when wanting to make a network request based on user interaction, `$fetch` is almost always the right handler to go for.
 
-If you need more fine-grained control, you can use `useAsyncData` and `$fetch` independently.
+If you need more fine-grained control, you can use [`useAsyncData`](/docs/api/composables/use-async-data) and `$fetch` independently.
 
 The two composables share a common set of options and patterns that we will detail in the last sections.
 
@@ -23,7 +23,7 @@ When using a framework like Nuxt that can perform calls and render pages on both
 
 ### Network calls duplication
 
-The `useFetch` and `useAsyncData` composables ensure that once an API call is made on the server, the data is properly forwarded to the client in the payload. This JavaScript object is accessible through [`useNuxtApp().payload`](/docs/api/composables/use-nuxt-app#payload) and is used on the client to avoid refetching the same data when the code is executed in the browser.
+The [`useFetch`](/docs/api/composables/use-fetch) and [`useAsyncData`](/docs/api/composables/use-async-data) composables ensure that once an API call is made on the server, the data is properly forwarded to the client in the payload. This JavaScript object is accessible through [`useNuxtApp().payload`](/docs/api/composables/use-nuxt-app#payload) and is used on the client to avoid refetching the same data when the code is executed in the browser.
 
 ::alert{icon=⚙️}
 Use the [Nuxt DevTools](https://devtools.nuxtjs.org) to inspect this data in the payload tab.
@@ -31,7 +31,7 @@ Use the [Nuxt DevTools](https://devtools.nuxtjs.org) to inspect this data in the
 
 ### Effective caching
 
-`useFetch` and `useAsyncData` both use a key to cache API responses and further reduce API calls. We will detail later how to invalidate this cache.
+[`useFetch`](/docs/api/composables/use-fetch) and [`useAsyncData`](/docs/api/composables/use-async-data) both use a key to cache API responses and further reduce API calls. We will detail later how to invalidate this cache.
 
 ### Suspense
 
@@ -43,7 +43,7 @@ These composables are auto-imported and can be used in `setup` functions or life
 
 ## `useFetch`
 
-`useFetch` is the most straightforward way to perform data fetching. It is a wrapper around the `useAsyncData` composable and `$fetch` utility.
+[`useFetch`](/docs/api/composables/use-fetch) is the most straightforward way to perform data fetching. It is a wrapper around the [`useAsyncData`](/docs/api/composables/use-async-data) composable and `$fetch` utility.
 
 ```vue [app.vue]
 <script setup>
@@ -75,7 +75,7 @@ The `ofetch` library is built on top of the `fetch` API and adds handy features 
 [Read the full documentation of ofetch](https://github.com/unjs/ofetch)
 ::
 
-ofetch is auto-imported by Nuxt and used by the `useFetch` composable.
+ofetch is auto-imported by Nuxt and used by the [`useFetch`](/docs/api/composables/use-fetch) composable.
 
 It can also be used in your whole application with the `$fetch` alias:
 
@@ -92,16 +92,16 @@ Beware that using only `$fetch` will not provide the benefits described in [the 
 
 ## `useAsyncData`
 
-`useFetch` receives a URL and gets that data, whereas `useAsyncData` might have more complex logic. `useFetch(url)` is nearly equivalent to `useAsyncData(url, () => $fetch(url))` - it's developer experience sugar for the most common use case.
+[`useFetch`](/docs/api/composables/use-fetch) receives a URL and gets that data, whereas [`useAsyncData`](/docs/api/composables/use-async-data) might have more complex logic. `useFetch(url)` is nearly equivalent to `useAsyncData(url, () => $fetch(url))` - it's developer experience sugar for the most common use case.
 
-There are some cases when using the `useFetch` composable is not appropriate, for example when a CMS or a third-party provide their own query layer. In this case, you can use `useAsyncData` to wrap your calls and still keep the benefits provided by the composable:
+There are some cases when using the [`useFetch`](/docs/api/composables/use-fetch) composable is not appropriate, for example when a CMS or a third-party provide their own query layer. In this case, you can use [`useAsyncData`](/docs/api/composables/use-async-data) to wrap your calls and still keep the benefits provided by the composable:
 
 ```ts
 const { data, error } = await useAsyncData('users', () => myGetFunction('users'))
 ```
 
 ::alert{icon=👉}
-The first argument of `useAsyncData` is the unique key used to cache the response of the second argument, the querying function. This argument can be ignored by directly passing the querying function. In that case, it will be auto-generated.
+The first argument of [`useAsyncData`](/docs/api/composables/use-async-data) is the unique key used to cache the response of the second argument, the querying function. This argument can be ignored by directly passing the querying function. In that case, it will be auto-generated.
 ::
 
 ::ReadMore{link="/docs/api/composables/use-async-data"}
@@ -109,7 +109,7 @@ The first argument of `useAsyncData` is the unique key used to cache the respons
 
 ## Options
 
-`useAsyncData` and `useFetch` return the same object type and accept a common set of options as their last argument. They can help you control the composables behavior, such as navigation blocking, caching or execution.
+[`useAsyncData`](/docs/api/composables/use-async-data) and [`useFetch`](/docs/api/composables/use-fetch) return the same object type and accept a common set of options as their last argument. They can help you control the composables behavior, such as navigation blocking, caching or execution.
 
 ### Lazy
 
@@ -134,7 +134,7 @@ const { pending, data: posts } = useFetch('/api/posts', {
 </script>
 ```
 
-You can alternatively use `useLazyFetch` and `useLazyAsyncData` as convenient methods to perform the same.
+You can alternatively use [`useLazyFetch`](/docs/api/composables/use-lazy-fetch) and `useLazyAsyncData` as convenient methods to perform the same.
 
 ```ts
 const { pending, data: posts } = useLazyFetch('/api/posts')
@@ -188,10 +188,10 @@ const { data: mountains } = await useFetch('/api/mountains', {
 
 #### Keys
 
-`useFetch` and `useAsyncData` use keys to prevent refetching the same data.
+[`useFetch`](/docs/api/composables/use-fetch) and [`useAsyncData`](/docs/api/composables/use-async-data) use keys to prevent refetching the same data.
 
-- `useFetch` uses the provided URL as a key. Alternatively, a `key` value can be provided in the `options` object passed as a last argument.
-- `useAsyncData` uses its first argument as a key if it is a string. If the first argument is the handler function that performs the query, then a key that is unique to the file name and line number of the instance of `useAsyncData` will be generated for you.
+- [`useFetch`](/docs/api/composables/use-fetch) uses the provided URL as a key. Alternatively, a `key` value can be provided in the `options` object passed as a last argument.
+- [`useAsyncData`](/docs/api/composables/use-async-data) uses its first argument as a key if it is a string. If the first argument is the handler function that performs the query, then a key that is unique to the file name and line number of the instance of `useAsyncData` will be generated for you.
 
 ::alert{icon=📘}
 To get the cached data by key, you can use [`useNuxtData`](/docs/api/composables/use-nuxt-data)
@@ -310,7 +310,7 @@ Using `<script setup lang="ts">` is the recommended way of declaring Vue compone
 
 ## Serialization
 
-When fetching data from the `server` directory, the response is serialized using `JSON.stringify`. However, since serialization is limited to only JavaScript primitive types, Nuxt does its best to convert the return type of `$fetch` and `useFetch` to match the actual value.
+When fetching data from the `server` directory, the response is serialized using `JSON.stringify`. However, since serialization is limited to only JavaScript primitive types, Nuxt does its best to convert the return type of `$fetch` and [`useFetch`](/docs/api/composables/use-fetch) to match the actual value.
 
 ::alert{icon=👉}
 You can learn more about `JSON.stringify` limitations [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#description).

--- a/docs/1.getting-started/7.state-management.md
+++ b/docs/1.getting-started/7.state-management.md
@@ -5,18 +5,18 @@ description: Nuxt provides powerful state management libraries and the useState 
 
 # State Management
 
-Nuxt provides the `useState` composable to create a reactive and SSR-friendly shared state across components.
+Nuxt provides the [`useState`](/docs/api/composables/use-state) composable to create a reactive and SSR-friendly shared state across components.
 
-`useState` is an SSR-friendly [`ref`](https://vuejs.org/api/reactivity-core.html#ref) replacement. Its value will be preserved after server-side rendering (during client-side hydration) and shared across all components using a unique key.
+[`useState`](/docs/api/composables/use-state) is an SSR-friendly [`ref`](https://vuejs.org/api/reactivity-core.html#ref) replacement. Its value will be preserved after server-side rendering (during client-side hydration) and shared across all components using a unique key.
 
 ::ReadMore{link="/docs/api/composables/use-state"}
 ::
 
 ::alert{icon=👉}
-`useState` only works during `setup` or [`Lifecycle Hooks`](https://vuejs.org/api/composition-api-lifecycle.html#composition-api-lifecycle-hooks).
+[`useState`](/docs/api/composables/use-state) only works during `setup` or [`Lifecycle Hooks`](https://vuejs.org/api/composition-api-lifecycle.html#composition-api-lifecycle-hooks).
 ::
 ::alert{type=warning}
-Because the data inside `useState` will be serialized to JSON, it is important that it does not contain anything that cannot be serialized, such as classes, functions or symbols.
+Because the data inside [`useState`](/docs/api/composables/use-state) will be serialized to JSON, it is important that it does not contain anything that cannot be serialized, such as classes, functions or symbols.
 ::
 
 ## Best Practices

--- a/docs/1.getting-started/9.layers.md
+++ b/docs/1.getting-started/9.layers.md
@@ -18,7 +18,7 @@ Some use cases:
 - Share standard setup across projects
 ::
 
-You can extend a layer by adding the [extends](/docs/api/configuration/nuxt-config#extends) property to the[`nuxt.config.ts`](/docs/guide/directory-structure/nuxt.config)file.
+You can extend a layer by adding the [extends](/docs/api/configuration/nuxt-config#extends) property to the [`nuxt.config.ts`](/docs/guide/directory-structure/nuxt.config) file.
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({

--- a/docs/1.getting-started/9.layers.md
+++ b/docs/1.getting-started/9.layers.md
@@ -11,14 +11,14 @@ Some use cases:
 
 ::list{type="success"}
 - Share reusable configuration presets across projects using `nuxt.config` and `app.config`
-- Create a component library using `components/` directory
-- Create utility and composable library using `composables/` and `utils/` directories
+- Create a component library using [`components/` directory](/docs/guide/directory-structure/components)
+- Create utility and composable library using [`composables/` directory](/docs/guide/directory-structure/composables) and [`utils/` directory](/docs/guide/directory-structure/utils)
 - Create [Nuxt themes](https://github.com/nuxt-themes)
 - Create Nuxt module presets
 - Share standard setup across projects
 ::
 
-You can extend a layer by adding the [extends](/docs/api/configuration/nuxt-config#extends) property to the `nuxt.config.ts` file.
+You can extend a layer by adding the [extends](/docs/api/configuration/nuxt-config#extends) property to the[`nuxt.config.ts`](/docs/guide/directory-structure/nuxt.config)file.
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({

--- a/docs/2.guide/1.concepts/2.vuejs-development.md
+++ b/docs/2.guide/1.concepts/2.vuejs-development.md
@@ -36,7 +36,7 @@ Most applications need multiple pages and a way to navigate between them. This i
 
 The `app.vue` file is the entry point, which represents the page displayed in the browser window.
 
-Inside the `<template>` of the component, we use the `<Welcome>` component created in the `components/`  directory without having to import it.
+Inside the `<template>` of the component, we use the `<Welcome>` component created in the [`components/` directory](/docs/guide/directory-structure/components) without having to import it.
 
 Try to replace the `<template>`’s content with a custom welcome message. The browser window on the right will automatically render the changes without reloading.
 
@@ -103,7 +103,7 @@ Used with the `setup` keyword in the `<script>` definition, here is the above co
 The goal of Nuxt 3 is to provide a great developer experience around the Composition API.
 
 - Use auto-imported [Reactivity functions](https://vuejs.org/api/reactivity-core.html) from Vue and Nuxt 3 [built-in composables](/docs/api/composables/use-async-data).
-- Write your own auto-imported reusable functions in the `composables/` directory.
+- Write your own auto-imported reusable functions in the [`composables/` directory](/docs/guide/directory-structure/composables).
 
 ### TypeScript Support
 

--- a/docs/2.guide/1.concepts/4.server-engine.md
+++ b/docs/2.guide/1.concepts/4.server-engine.md
@@ -24,7 +24,7 @@ Key features include:
 Check out [the h3 docs](https://github.com/unjs/h3) for more information.
 
 ::alert{type="info" icon=ℹ️}
-Learn more about the API layer in the [`server/`](/docs/guide/directory-structure/server) directory.
+Learn more about the API layer in the [`server/` directory](/docs/guide/directory-structure/server).
 ::
 
 ## Direct API Calls

--- a/docs/2.guide/1.concepts/5.modules.md
+++ b/docs/2.guide/1.concepts/5.modules.md
@@ -19,7 +19,7 @@ Best of all, Nuxt modules can be distributed in npm packages. This makes it poss
 
 ## The `modules` Property
 
-Once you have installed the modules you can then add them to your[`nuxt.config.ts`](/docs/guide/directory-structure/nuxt.config)file under the `modules` property. Module developers usually provide additional steps and details for usage.
+Once you have installed the modules you can then add them to your [`nuxt.config.ts`](/docs/guide/directory-structure/nuxt.config) file under the `modules` property. Module developers usually provide additional steps and details for usage.
 
 ```ts{}[nuxt.config.ts]
 export default defineNuxtConfig({

--- a/docs/2.guide/1.concepts/5.modules.md
+++ b/docs/2.guide/1.concepts/5.modules.md
@@ -19,7 +19,7 @@ Best of all, Nuxt modules can be distributed in npm packages. This makes it poss
 
 ## The `modules` Property
 
-Once you have installed the modules you can then add them to your `nuxt.config.ts` file under the `modules` property. Module developers usually provide additional steps and details for usage.
+Once you have installed the modules you can then add them to your[`nuxt.config.ts`](/docs/guide/directory-structure/nuxt.config)file under the `modules` property. Module developers usually provide additional steps and details for usage.
 
 ```ts{}[nuxt.config.ts]
 export default defineNuxtConfig({

--- a/docs/2.guide/2.directory-structure/0.nuxt.md
+++ b/docs/2.guide/2.directory-structure/0.nuxt.md
@@ -7,7 +7,7 @@ head.title: ".nuxt/"
 
 # .nuxt Directory
 
-Nuxt uses the `.nuxt/` directory in development to generate your Vue application.
+Nuxt uses the [`.nuxt/` directory](/docs/guide/directory-structure/nuxt) in development to generate your Vue application.
 
 ::alert{type=warning}
 You should not touch any files inside since the whole directory will be re-created when running `nuxt dev`.

--- a/docs/2.guide/2.directory-structure/0.output.md
+++ b/docs/2.guide/2.directory-structure/0.output.md
@@ -7,7 +7,7 @@ head.title: ".output/"
 
 # Output Directory
 
-Nuxt creates the `.output/` directory when building your application for production.
+Nuxt creates the [`.output/` directory](/docs/guide/directory-structure/output) when building your application for production.
 
 ::alert{type=warning}
 You should not touch any files inside since the whole directory will be re-created when running `nuxt build`.

--- a/docs/2.guide/2.directory-structure/1.assets.md
+++ b/docs/2.guide/2.directory-structure/1.assets.md
@@ -7,7 +7,7 @@ head.title: "assets/"
 
 # Assets Directory
 
-The `assets/` directory is used to add all the website's assets that the build tool (webpack or Vite) will process.
+The [`assets/` directory](/docs/guide/directory-structure/assets) is used to add all the website's assets that the build tool (webpack or Vite) will process.
 
 The directory usually contains the following types of files:
 

--- a/docs/2.guide/2.directory-structure/1.components.md
+++ b/docs/2.guide/2.directory-structure/1.components.md
@@ -7,9 +7,9 @@ head.title: "components/"
 
 # Components Directory
 
-The `components/` directory is where you put all your Vue components which can then be imported inside your pages or other components ([learn more](https://vuejs.org/guide/essentials/component-basics.html#components-basics)).
+The [`components/` directory](/docs/guide/directory-structure/components) is where you put all your Vue components which can then be imported inside your pages or other components ([learn more](https://vuejs.org/guide/essentials/component-basics.html#components-basics)).
 
-Nuxt automatically imports any components in your `components/` directory (along with components that are registered by any modules you may be using).
+Nuxt automatically imports any components in your [`components/` directory](/docs/guide/directory-structure/components) (along with components that are registered by any modules you may be using).
 
 ```bash
 | components/

--- a/docs/2.guide/2.directory-structure/1.composables.md
+++ b/docs/2.guide/2.directory-structure/1.composables.md
@@ -7,7 +7,7 @@ description: Use the composables/ directory to auto-import your Vue composables 
 
 # Composables Directory
 
-Nuxt 3 uses the `composables/` directory to automatically import your Vue composables into your application using [auto-imports](/docs/guide/concepts/auto-imports)!
+Nuxt 3 uses the [`composables/` directory](/docs/guide/directory-structure/composables) to automatically import your Vue composables into your application using [auto-imports](/docs/guide/concepts/auto-imports)!
 
 Under the hood, Nuxt auto generates the file `.nuxt/imports.d.ts` to declare the types.
 
@@ -75,7 +75,7 @@ export const useHello = () => {
 
 ## How Files Are Scanned
 
-Nuxt only scans files at the top level of the `composables/` directory, e.g.:
+Nuxt only scans files at the top level of the [`composables/` directory](/docs/guide/directory-structure/composables), e.g.:
 
 ```bash
 composables

--- a/docs/2.guide/2.directory-structure/1.content.md
+++ b/docs/2.guide/2.directory-structure/1.content.md
@@ -7,7 +7,7 @@ description: The Content module reads the content/ directory to create a file-ba
 
 # Content Directory
 
-The [Nuxt Content module](https://content.nuxtjs.org) reads the `content/` directory in your project and parses `.md`, `.yml`, `.csv` and `.json` files to create a file-based CMS for your application.
+The [Nuxt Content module](https://content.nuxtjs.org) reads the [`content/` directory](/docs/guide/directory-structure/content) in your project and parses `.md`, `.yml`, `.csv` and `.json` files to create a file-based CMS for your application.
 
 ::list{type=success}
 
@@ -55,7 +55,7 @@ export default defineNuxtConfig({
 
 ### Create Content
 
-Place your markdown files inside the `content/` directory in the root directory of your project:
+Place your markdown files inside the [`content/` directory](/docs/guide/directory-structure/content) in the root directory of your project:
 
 ```md [content/index.md]
 # Hello Content

--- a/docs/2.guide/2.directory-structure/1.layouts.md
+++ b/docs/2.guide/2.directory-structure/1.layouts.md
@@ -9,7 +9,7 @@ head.title: "layouts/"
 
 Nuxt provides a customizable layouts framework you can use throughout your application, ideal for extracting common UI or code patterns into reusable layout components.
 
-Layouts are placed in the `layouts/` directory and will be automatically loaded via asynchronous import when used. Layouts are used by adding `<NuxtLayout>` to your `app.vue`, and either setting a `layout` property as part of your page metadata (if you are using the `~/pages` integration), or by manually specifying it as a prop to `<NuxtLayout>`. (**Note**: The layout name is normalized to kebab-case, so `someLayout` becomes `some-layout`.)
+Layouts are placed in the [`layouts/` directory](/docs/guide/directory-structure/layouts) and will be automatically loaded via asynchronous import when used. Layouts are used by adding `<NuxtLayout>` to your `app.vue`, and either setting a `layout` property as part of your page metadata (if you are using the `~/pages` integration), or by manually specifying it as a prop to `<NuxtLayout>`. (**Note**: The layout name is normalized to kebab-case, so `someLayout` becomes `some-layout`.)
 
 If you only have a single layout in your application, we recommend using [app.vue](/docs/guide/directory-structure/app) instead.
 

--- a/docs/2.guide/2.directory-structure/1.middleware.md
+++ b/docs/2.guide/2.directory-structure/1.middleware.md
@@ -16,8 +16,8 @@ Route middleware run within the Vue part of your Nuxt app. Despite the similar n
 There are three kinds of route middleware:
 
 1. Anonymous (or inline) route middleware, which are defined directly in the pages where they are used.
-2. Named route middleware, which are placed in the `middleware/` directory and will be automatically loaded via asynchronous import when used on a page. (**Note**: The route middleware name is normalized to kebab-case, so `someMiddleware` becomes `some-middleware`.)
-3. Global route middleware, which are placed in the `middleware/` directory (with a `.global` suffix) and will be automatically run on every route change.
+2. Named route middleware, which are placed in the [`middleware/` directory](/docs/guide/directory-structure/middleware) and will be automatically loaded via asynchronous import when used on a page. (**Note**: The route middleware name is normalized to kebab-case, so `someMiddleware` becomes `some-middleware`.)
+3. Global route middleware, which are placed in the [`middleware/` directory](/docs/guide/directory-structure/middleware) (with a `.global` suffix) and will be automatically run on every route change.
 
 The first two kinds of route middleware can be [defined in `definePageMeta`](/docs/guide/directory-structure/pages).
 

--- a/docs/2.guide/2.directory-structure/1.modules.md
+++ b/docs/2.guide/2.directory-structure/1.modules.md
@@ -7,7 +7,7 @@ description: Use the modules/ directory to automatically register local modules 
 
 # Modules Directory
 
-Nuxt scans the `modules/` directory and loads them before starting. It is a good place to place any local modules you develop while building your application.
+Nuxt scans the [`modules/` directory](/docs/guide/directory-structure/modules) and loads them before starting. It is a good place to place any local modules you develop while building your application.
 
 The auto-registered files patterns are:
 - `modules/*/index.ts`

--- a/docs/2.guide/2.directory-structure/1.node_modules.md
+++ b/docs/2.guide/2.directory-structure/1.node_modules.md
@@ -7,4 +7,4 @@ head.title: "node_modules/"
 
 # Node modules Directory
 
-The package manager ([`npm`](https://docs.npmjs.com/cli/v7/commands/npm) or [`yarn`](https://yarnpkg.com/) or [`pnpm`](https://pnpm.io/cli/install)) creates the `node_modules/` directory to store the dependencies of your project.
+The package manager ([`npm`](https://docs.npmjs.com/cli/v7/commands/npm) or [`yarn`](https://yarnpkg.com/) or [`pnpm`](https://pnpm.io/cli/install)) creates the [`node_modules/` directory](/docs/guide/directory-structure/node_modules) to store the dependencies of your project.

--- a/docs/2.guide/2.directory-structure/1.pages.md
+++ b/docs/2.guide/2.directory-structure/1.pages.md
@@ -122,7 +122,7 @@ Navigating to `/users-admins/123` would render:
 <p>admins - 123</p>
 ```
 
-If you want to access the route using Composition API, there is a global `useRoute` function that will allow you to access the route just like `this.$route` in the Options API.
+If you want to access the route using Composition API, there is a global [`useRoute`](/docs/api/composables/use-route) function that will allow you to access the route just like `this.$route` in the Options API.
 
 ```vue
 <script setup>

--- a/docs/2.guide/2.directory-structure/1.plugins.md
+++ b/docs/2.guide/2.directory-structure/1.plugins.md
@@ -10,12 +10,12 @@ head.title: "plugins/"
 Nuxt automatically reads the files in your `plugins` directory and loads them at the creation of the Vue application. You can use `.server` or `.client` suffix in the file name to load a plugin only on the server or client side.
 
 ::alert{type=warning}
-All plugins in your `plugins/` directory are auto-registered, so you should not add them to your `nuxt.config` separately.
+All plugins in your [`plugins/` directory](/docs/guide/directory-structure/plugins) are auto-registered, so you should not add them to your `nuxt.config` separately.
 ::
 
 ## Which Files Are Registered
 
-Only files at the top level of the `plugins/` directory (or index files within any subdirectories) will be registered as plugins.
+Only files at the top level of the [`plugins/` directory](/docs/guide/directory-structure/plugins) (or index files within any subdirectories) will be registered as plugins.
 
 For example:
 

--- a/docs/2.guide/2.directory-structure/1.public.md
+++ b/docs/2.guide/2.directory-structure/1.public.md
@@ -7,8 +7,8 @@ head.title: "public/"
 
 # Public Directory
 
-The `public/` directory is directly served at the server root and contains public files that have to keep their names (e.g. `robots.txt`) _or_ likely won't change (e.g. `favicon.ico`).
+The [`public/` directory](/docs/guide/directory-structure/public) is directly served at the server root and contains public files that have to keep their names (e.g. `robots.txt`) _or_ likely won't change (e.g. `favicon.ico`).
 
 ::alert{icon=💡}
-This is known as the [`static/`](https://nuxtjs.org/docs/directory-structure/static) directory in Nuxt 2.
+This is known as the [`static/` directory](https://nuxtjs.org/docs/directory-structure/static) in Nuxt 2.
 ::

--- a/docs/2.guide/2.directory-structure/1.utils.md
+++ b/docs/2.guide/2.directory-structure/1.utils.md
@@ -7,10 +7,10 @@ description: Use the utils/ directory to auto-import your utility functions thro
 
 # Utils Directory
 
-Nuxt 3 uses the `utils/` directory to automatically import helper functions and other utilities throughout your application using [auto-imports](/docs/guide/concepts/auto-imports)!
+Nuxt 3 uses the [`utils/` directory](/docs/guide/directory-structure/utils) to automatically import helper functions and other utilities throughout your application using [auto-imports](/docs/guide/concepts/auto-imports)!
 
 ::alert{type=info}
-The main purpose of the `utils/` directory is to allow a semantic distinction between your Vue composables and other auto-imported utility functions.
+The main purpose of the [`utils/` directory](/docs/guide/directory-structure/utils) is to allow a semantic distinction between your Vue composables and other auto-imported utility functions.
 
 The way `utils/` auto-imports work and are scanned is identical to [the composables/ directory](/docs/guide/directory-structure/composables). You can see examples and more information about how they work in that section of the docs.
 ::

--- a/docs/2.guide/3.going-further/1.experimental-features.md
+++ b/docs/2.guide/3.going-further/1.experimental-features.md
@@ -69,7 +69,7 @@ Allows Nuxt app state to be restored from `sessionStorage` when reloading the pa
 
 ::alert{type=warning icon=⚠️}
 Consider carefully before enabling this as it can cause unexpected behavior,
-and consider providing explicit keys to `useState` as auto-generated keys may not match across builds.
+and consider providing explicit keys to [`useState`](/docs/api/composables/use-state) as auto-generated keys may not match across builds.
 ::
 
 ```ts [nuxt.config.ts]

--- a/docs/2.guide/3.going-further/7.layers.md
+++ b/docs/2.guide/3.going-further/7.layers.md
@@ -6,7 +6,7 @@ description: Nuxt provides a powerful system that allows you to extend the defau
 
 Nuxt layers are a powerful feature that you can use to share and reuse partial Nuxt applications within a monorepo, or from a git repository or npm package. The layers structure is almost identical to a standard Nuxt application, which makes them easy to author and maintain. ([Read More](/docs/getting-started/layers))
 
-A minimal Nuxt layer directory should contain a[`nuxt.config.ts`](/docs/guide/directory-structure/nuxt.config)file to indicate it is a layer.
+A minimal Nuxt layer directory should contain a [`nuxt.config.ts`](/docs/guide/directory-structure/nuxt.config) file to indicate it is a layer.
 
 ```ts{}[base/nuxt.config.ts]
 export default defineNuxtConfig({})
@@ -62,7 +62,7 @@ Additionally, certain other files in the layer directory will be auto-scanned an
 ::
 
 ::alert{type="info"}
-If you're interested in deepening your understanding about layers, consider examining [a fully fleshed out[`nuxt.config.ts`](/docs/guide/directory-structure/nuxt.config)file on the Docus platform](https://github.com/nuxt-themes/docus/blob/main/nuxt.config.ts).
+If you're interested in deepening your understanding about layers, consider examining [a fully fleshed out [`nuxt.config.ts`](/docs/guide/directory-structure/nuxt.config) file on the Docus platform](https://github.com/nuxt-themes/docus/blob/main/nuxt.config.ts).
 ::
 
 ## Starter Template

--- a/docs/2.guide/3.going-further/7.layers.md
+++ b/docs/2.guide/3.going-further/7.layers.md
@@ -6,7 +6,7 @@ description: Nuxt provides a powerful system that allows you to extend the defau
 
 Nuxt layers are a powerful feature that you can use to share and reuse partial Nuxt applications within a monorepo, or from a git repository or npm package. The layers structure is almost identical to a standard Nuxt application, which makes them easy to author and maintain. ([Read More](/docs/getting-started/layers))
 
-A minimal Nuxt layer directory should contain a `nuxt.config.ts` file to indicate it is a layer.
+A minimal Nuxt layer directory should contain a[`nuxt.config.ts`](/docs/guide/directory-structure/nuxt.config)file to indicate it is a layer.
 
 ```ts{}[base/nuxt.config.ts]
 export default defineNuxtConfig({})
@@ -18,7 +18,7 @@ Additionally, certain other files in the layer directory will be auto-scanned an
 - `composables/*`  - Extend the default composables
 - `pages/*`        - Extend the default pages
 - `server/*`       - Extend the default server endpoints & middleware
-- `nuxt.config.ts` - Extend the default nuxt config
+-[`nuxt.config.ts`](/docs/guide/directory-structure/nuxt.config)- Extend the default nuxt config
 - `app.config.ts`  - Extend the default app config
 
 ## Basic Example
@@ -62,7 +62,7 @@ Additionally, certain other files in the layer directory will be auto-scanned an
 ::
 
 ::alert{type="info"}
-If you're interested in deepening your understanding about layers, consider examining [a fully fleshed out `nuxt.config.ts` file on the Docus platform](https://github.com/nuxt-themes/docus/blob/main/nuxt.config.ts).
+If you're interested in deepening your understanding about layers, consider examining [a fully fleshed out[`nuxt.config.ts`](/docs/guide/directory-structure/nuxt.config)file on the Docus platform](https://github.com/nuxt-themes/docus/blob/main/nuxt.config.ts).
 ::
 
 ## Starter Template

--- a/docs/3.api/1.composables/use-async-data.md
+++ b/docs/3.api/1.composables/use-async-data.md
@@ -1,12 +1,12 @@
 ---
 description: useAsyncData provides access to data that resolves asynchronously.
 ---
-# `useAsyncData`
+# [`useAsyncData`](/docs/api/composables/use-async-data) 
 
 Within your pages, components, and plugins you can use useAsyncData to get access to data that resolves asynchronously.
 
 ::alert{type=warning}
-`useAsyncData` is a composable meant to be called directly in a setup function, plugin, or route middleware. It returns reactive composables and handles adding responses to the Nuxt payload so they can be passed from server to client without re-fetching the data on client side when the page hydrates.
+[`useAsyncData`](/docs/api/composables/use-async-data) is a composable meant to be called directly in a setup function, plugin, or route middleware. It returns reactive composables and handles adding responses to the Nuxt payload so they can be passed from server to client without re-fetching the data on client side when the page hydrates.
 ::
 
 ## Type
@@ -50,7 +50,7 @@ type AsyncDataRequestStatus = 'idle' | 'pending' | 'success' | 'error'
 
 ## Params
 
-* **key**: a unique key to ensure that data fetching can be properly de-duplicated across requests. If you do not provide a key, then a key that is unique to the file name and line number of the instance of `useAsyncData` will be generated for you.
+* **key**: a unique key to ensure that data fetching can be properly de-duplicated across requests. If you do not provide a key, then a key that is unique to the file name and line number of the instance of [`useAsyncData`](/docs/api/composables/use-async-data) will be generated for you.
 * **handler**: an asynchronous function that returns a value
 * **options**:
   * _lazy_: whether to resolve the async function after loading the route, instead of blocking client-side navigation (defaults to `false`)
@@ -74,7 +74,7 @@ Under the hood, `lazy: false` uses `<Suspense>` to block the loading of the rout
 By default, Nuxt waits until a `refresh` is finished before it can be executed again.
 
 ::alert{type=warning}
-If you have not fetched data on the server (for example, with `server: false`), then the data _will not_ be fetched until hydration completes. This means even if you await `useAsyncData` on the client side, `data` will remain `null` within `<script setup>`.
+If you have not fetched data on the server (for example, with `server: false`), then the data _will not_ be fetched until hydration completes. This means even if you await [`useAsyncData`](/docs/api/composables/use-async-data) on the client side, `data` will remain `null` within `<script setup>`.
 ::
 
 ## Example
@@ -105,7 +105,7 @@ const { data: posts } = await useAsyncData(
 ```
 
 ::alert{type=warning}
-`useAsyncData` is a reserved function name transformed by the compiler, so you should not name your own function `useAsyncData`.
+[`useAsyncData`](/docs/api/composables/use-async-data) is a reserved function name transformed by the compiler, so you should not name your own function [`useAsyncData`](/docs/api/composables/use-async-data) .
 ::
 
 ::ReadMore{link="/docs/getting-started/data-fetching"}

--- a/docs/3.api/1.composables/use-async-data.md
+++ b/docs/3.api/1.composables/use-async-data.md
@@ -1,7 +1,7 @@
 ---
 description: useAsyncData provides access to data that resolves asynchronously.
 ---
-# [`useAsyncData`](/docs/api/composables/use-async-data) 
+# [`useAsyncData`](/docs/api/composables/use-async-data)
 
 Within your pages, components, and plugins you can use useAsyncData to get access to data that resolves asynchronously.
 

--- a/docs/3.api/1.composables/use-async-data.md
+++ b/docs/3.api/1.composables/use-async-data.md
@@ -1,7 +1,7 @@
 ---
 description: useAsyncData provides access to data that resolves asynchronously.
 ---
-# [`useAsyncData`](/docs/api/composables/use-async-data) 
+# useAsyncData
 
 Within your pages, components, and plugins you can use useAsyncData to get access to data that resolves asynchronously.
 

--- a/docs/3.api/1.composables/use-fetch.md
+++ b/docs/3.api/1.composables/use-fetch.md
@@ -4,7 +4,7 @@ This composable provides a convenient wrapper around [`useAsyncData`](/docs/api/
 It automatically generates a key based on URL and fetch options, provides type hints for request url based on server routes, and infers API response type.
 
 ::alert{type=warning}
-`useFetch` is a composable meant to be called directly in a setup function, plugin, or route middleware. It returns reactive composables and handles adding responses to the Nuxt payload so they can be passed from server to client without re-fetching the data on client side when the page hydrates.
+[`useFetch`](/docs/api/composables/use-fetch) is a composable meant to be called directly in a setup function, plugin, or route middleware. It returns reactive composables and handles adding responses to the Nuxt payload so they can be passed from server to client without re-fetching the data on client side when the page hydrates.
 ::
 
 ## Type
@@ -60,8 +60,8 @@ interface AsyncDataExecuteOptions {
 All fetch options can be given a `computed` or `ref` value. These will be watched and new requests made automatically with any new values if they are updated.
 ::
 
-* **Options (from `useAsyncData`)**:
-  * `key`: a unique key to ensure that data fetching can be properly de-duplicated across requests, if not provided, it will be generated based on the static code location where `useAsyncData` is used.
+* **Options (from [`useAsyncData`](/docs/api/composables/use-async-data) )**:
+  * `key`: a unique key to ensure that data fetching can be properly de-duplicated across requests, if not provided, it will be generated based on the static code location where [`useAsyncData`](/docs/api/composables/use-async-data) is used.
   * `server`: Whether to fetch the data on the server (defaults to `true`).
   * `default`: A factory function to set the default value of the data, before the async function resolves - particularly useful with the `lazy: true` option.
   * `pick`: Only pick specified keys in this array from the `handler` function result.
@@ -70,7 +70,7 @@ All fetch options can be given a `computed` or `ref` value. These will be watche
   * `immediate`: When set to `false`, will prevent the request from firing immediately. (defaults to `true`)
 
 ::alert{type=warning}
-If you provide a function or ref as the `url` parameter, or if you provide functions as arguments to the `options` parameter, then the `useFetch` call will not match other `useFetch` calls elsewhere in your codebase, even if the options seem to be identical. If you wish to force a match, you may provide your own key in `options`.
+If you provide a function or ref as the `url` parameter, or if you provide functions as arguments to the `options` parameter, then the [`useFetch`](/docs/api/composables/use-fetch) call will not match other [`useFetch`](/docs/api/composables/use-fetch) calls elsewhere in your codebase, even if the options seem to be identical. If you wish to force a match, you may provide your own key in `options`.
 ::
 
 ## Return Values
@@ -84,7 +84,7 @@ If you provide a function or ref as the `url` parameter, or if you provide funct
 By default, Nuxt waits until a `refresh` is finished before it can be executed again.
 
 ::alert{type=warning}
-If you have not fetched data on the server (for example, with `server: false`), then the data _will not_ be fetched until hydration completes. This means even if you await `useFetch` on client-side, `data` will remain null within `<script setup>`.
+If you have not fetched data on the server (for example, with `server: false`), then the data _will not_ be fetched until hydration completes. This means even if you await [`useFetch`](/docs/api/composables/use-fetch) on client-side, `data` will remain null within `<script setup>`.
 ::
 
 ## Example
@@ -131,7 +131,7 @@ const { data, pending, error, refresh } = await useFetch('/api/auth/login', {
 ```
 
 ::alert{type=warning}
-`useFetch` is a reserved function name transformed by the compiler, so you should not name your own function `useFetch`.
+[`useFetch`](/docs/api/composables/use-fetch) is a reserved function name transformed by the compiler, so you should not name your own function `useFetch`.
 ::
 
 ::LinkExample{link="/docs/examples/advanced/use-custom-fetch-composable"}

--- a/docs/3.api/1.composables/use-head-safe.md
+++ b/docs/3.api/1.composables/use-head-safe.md
@@ -8,7 +8,7 @@ The `useHeadSafe` composable is a wrapper around the [`useHead`](/docs/api/compo
 
 ## Usage
 
-You can pass all the same values as `useHead`
+You can pass all the same values as [`useHead`](/docs/api/composables/use-head) 
 
 ```ts
 useHeadSafe({

--- a/docs/3.api/1.composables/use-head-safe.md
+++ b/docs/3.api/1.composables/use-head-safe.md
@@ -8,7 +8,7 @@ The `useHeadSafe` composable is a wrapper around the [`useHead`](/docs/api/compo
 
 ## Usage
 
-You can pass all the same values as [`useHead`](/docs/api/composables/use-head) 
+You can pass all the same values as [`useHead`](/docs/api/composables/use-head)
 
 ```ts
 useHeadSafe({

--- a/docs/3.api/1.composables/use-head.md
+++ b/docs/3.api/1.composables/use-head.md
@@ -2,7 +2,7 @@
 description: useHead customizes the head properties of individual pages of your Nuxt app.
 ---
 
-# [`useHead`](/docs/api/composables/use-head) 
+# useHead
 
 The [`useHead`](/docs/api/composables/use-head) composable function allows you to manage your head tags in a programmatic and reactive way, powered by [Unhead](https://unhead.harlanzw.com/). If the data comes from a user or other untrusted source, we recommend you check out [`useHeadSafe`](/docs/api/composables/use-head-safe)
 

--- a/docs/3.api/1.composables/use-head.md
+++ b/docs/3.api/1.composables/use-head.md
@@ -2,9 +2,9 @@
 description: useHead customizes the head properties of individual pages of your Nuxt app.
 ---
 
-# `useHead`
+# [`useHead`](/docs/api/composables/use-head) 
 
-The `useHead` composable function allows you to manage your head tags in a programmatic and reactive way, powered by [Unhead](https://unhead.harlanzw.com/). If the data comes from a user or other untrusted source, we recommend you check out [`useHeadSafe`](/docs/api/composables/use-head-safe)
+The [`useHead`](/docs/api/composables/use-head) composable function allows you to manage your head tags in a programmatic and reactive way, powered by [Unhead](https://unhead.harlanzw.com/). If the data comes from a user or other untrusted source, we recommend you check out [`useHeadSafe`](/docs/api/composables/use-head-safe)
 
 :ReadMore{link="/docs/getting-started/seo-meta"}
 
@@ -14,7 +14,7 @@ The `useHead` composable function allows you to manage your head tags in a progr
 useHead(meta: MaybeComputedRef<MetaObject>): void
 ```
 
-Below are the non-reactive types for `useHead`.
+Below are the non-reactive types for [`useHead`](/docs/api/composables/use-head) .
 
 ```ts
 interface MetaObject {
@@ -34,7 +34,7 @@ interface MetaObject {
 See [@unhead/schema](https://github.com/unjs/unhead/blob/main/packages/schema/src/schema.ts) for more detailed types.
 
 ::alert{type=info}
-The properties of `useHead` can be dynamic, accepting `ref`, `computed` and `reactive` properties. `meta` parameter can also accept a function returning an object to make the entire object reactive.
+The properties of [`useHead`](/docs/api/composables/use-head) can be dynamic, accepting `ref`, `computed` and `reactive` properties. `meta` parameter can also accept a function returning an object to make the entire object reactive.
 ::
 
 ## Parameters

--- a/docs/3.api/1.composables/use-head.md
+++ b/docs/3.api/1.composables/use-head.md
@@ -2,7 +2,7 @@
 description: useHead customizes the head properties of individual pages of your Nuxt app.
 ---
 
-# [`useHead`](/docs/api/composables/use-head) 
+# [`useHead`](/docs/api/composables/use-head)
 
 The [`useHead`](/docs/api/composables/use-head) composable function allows you to manage your head tags in a programmatic and reactive way, powered by [Unhead](https://unhead.harlanzw.com/). If the data comes from a user or other untrusted source, we recommend you check out [`useHeadSafe`](/docs/api/composables/use-head-safe)
 

--- a/docs/3.api/1.composables/use-lazy-async-data.md
+++ b/docs/3.api/1.composables/use-lazy-async-data.md
@@ -4,13 +4,13 @@ description: This wrapper around useAsyncData triggers navigation immediately.
 
 # `useLazyAsyncData`
 
-`useLazyAsyncData` provides a wrapper around `useAsyncData` that triggers navigation before the handler is resolved by setting the `lazy` option to `true`.
+`useLazyAsyncData` provides a wrapper around [`useAsyncData`](/docs/api/composables/use-async-data) that triggers navigation before the handler is resolved by setting the `lazy` option to `true`.
 
 ## Description
 
 By default, [useAsyncData](/docs/api/composables/use-async-data) blocks navigation until its async handler is resolved.
 
-> `useLazyAsyncData` has the same signature as `useAsyncData`.
+> `useLazyAsyncData` has the same signature as [`useAsyncData`](/docs/api/composables/use-async-data) .
 
 :ReadMore{link="/docs/api/composables/use-async-data"}
 

--- a/docs/3.api/1.composables/use-lazy-fetch.md
+++ b/docs/3.api/1.composables/use-lazy-fetch.md
@@ -4,13 +4,13 @@ description: This wrapper around useFetch triggers navigation immediately.
 
 # `useLazyFetch`
 
-`useLazyFetch` provides a wrapper around `useFetch` that triggers navigation before the handler is resolved by setting the `lazy` option to `true`.
+`useLazyFetch` provides a wrapper around [`useFetch`](/docs/api/composables/use-fetch) that triggers navigation before the handler is resolved by setting the `lazy` option to `true`.
 
 ## Description
 
 By default, [useFetch](/docs/api/composables/use-fetch) blocks navigation until its async handler is resolved.
 
-> `useLazyFetch` has the same signature as `useFetch`.
+> [`useLazyFetch`](/docs/api/composables/use-lazy-fetch) has the same signature as `useFetch`.
 
 :ReadMore{link="/docs/api/composables/use-fetch"}
 

--- a/docs/3.api/1.composables/use-nuxt-app.md
+++ b/docs/3.api/1.composables/use-nuxt-app.md
@@ -87,7 +87,7 @@ await nuxtApp.callHook('my-plugin:init')
 `payload` exposes data and state variables from server side to client side. The following keys will be available on the client after they have been passed from the server side:
 
 - **serverRendered** (boolean) - Indicates if response is server-side-rendered.
-- **data** (object) - When you fetch the data from an API endpoint using either `useFetch` or `useAsyncData`, resulting payload can be accessed from the `payload.data`. This data is cached and helps you prevent fetching the same data in case an identical request is made more than once.
+- **data** (object) - When you fetch the data from an API endpoint using either [`useFetch`](/docs/api/composables/use-fetch) or [`useAsyncData`](/docs/api/composables/use-async-data) , resulting payload can be accessed from the `payload.data`. This data is cached and helps you prevent fetching the same data in case an identical request is made more than once.
 
 ```vue [app.vue]
 export default defineComponent({
@@ -97,11 +97,11 @@ export default defineComponent({
 })
 ```
 
-After fetching the value of `count` using `useAsyncData` in the example above, if you access `payload.data`, you will see `{ count: 1 }` recorded there. The value of `count` is updated whenever the page count increases.
+After fetching the value of `count` using [`useAsyncData`](/docs/api/composables/use-async-data) in the example above, if you access `payload.data`, you will see `{ count: 1 }` recorded there. The value of `count` is updated whenever the page count increases.
 
 When accessing the same `payload.data` from [ssrcontext](#ssrcontext), you can access the same value on the server side as well.
 
-- **state** (object) - When you use `useState` composable in Nuxt to set shared state, this state data is accessed through `payload.state.[name-of-your-state]`.
+- **state** (object) - When you use [`useState`](/docs/api/composables/use-state) composable in Nuxt to set shared state, this state data is accessed through `payload.state.[name-of-your-state]`.
 
 ```js [plugins/my-plugin.ts]
 export const useColor = () => useState<string>('color', () => 'pink')

--- a/docs/3.api/1.composables/use-nuxt-data.md
+++ b/docs/3.api/1.composables/use-nuxt-data.md
@@ -1,6 +1,6 @@
 # `useNuxtData`
 
-`useNuxtData` gives you access to the current cached value of `useAsyncData`, `useLazyAsyncData`, `useFetch` and `useLazyFetch` with explicitly provided key.
+`useNuxtData` gives you access to the current cached value of [`useAsyncData`](/docs/api/composables/use-async-data) , `useLazyAsyncData`, [`useFetch`](/docs/api/composables/use-fetch) and [`useLazyFetch`](/docs/api/composables/use-lazy-fetch) with explicitly provided key.
 
 ## Type
 

--- a/docs/3.api/1.composables/use-request-headers.md
+++ b/docs/3.api/1.composables/use-request-headers.md
@@ -5,7 +5,7 @@ description: "Use useRequestHeaders to access the incoming request headers."
 
 # `useRequestHeaders`
 
-You can use built-in `useRequestHeaders` composable to access the incoming request headers within your pages, components, and plugins.
+You can use built-in [`useRequestHeaders`](/docs/api/composables/use-request-headers) composable to access the incoming request headers within your pages, components, and plugins.
 
 ```js
 // Get all request headers
@@ -16,12 +16,12 @@ const headers = useRequestHeaders(['cookie'])
 ```
 
 ::alert{icon=👉}
-In the browser, `useRequestHeaders` will return an empty object.
+In the browser, [`useRequestHeaders`](/docs/api/composables/use-request-headers) will return an empty object.
 ::
 
 ## Example
 
-We can use `useRequestHeaders` to access and proxy the initial request's `authorization` header to any future internal requests during SSR.
+We can use [`useRequestHeaders`](/docs/api/composables/use-request-headers) to access and proxy the initial request's `authorization` header to any future internal requests during SSR.
 
 The example below adds the `authorization` request header to an isomorphic `$fetch` call.
 

--- a/docs/3.api/1.composables/use-route.md
+++ b/docs/3.api/1.composables/use-route.md
@@ -5,13 +5,13 @@ description: The useRoute composable returns the current route.
 
 # `useRoute`
 
-The `useRoute` composable returns the current route and must be called in a `setup` function, plugin, or route middleware.
+The [`useRoute`](/docs/api/composables/use-route) composable returns the current route and must be called in a `setup` function, plugin, or route middleware.
 
 Within the template of a Vue component, you can access the route using `$route`.
 
 ## Example
 
-In the following example, we call an API via `useFetch` using a dynamic page parameter - `slug` - as part of the URL.
+In the following example, we call an API via [`useFetch`](/docs/api/composables/use-fetch) using a dynamic page parameter - `slug` - as part of the URL.
 
 ```html [~/pages/[slug].vue]
 <script setup>

--- a/docs/3.api/1.composables/use-router.md
+++ b/docs/3.api/1.composables/use-router.md
@@ -5,11 +5,11 @@ description: "The useRouter composable returns the router instance."
 
 # `useRouter`
 
-The `useRouter` composable returns the router instance and must be called in a setup function, plugin, or route middleware.
+The [`useRouter`](/docs/api/composables/use-router)  composable returns the router instance and must be called in a setup function, plugin, or route middleware.
 
 Within the template of a Vue component, you can access the router using `$router` instead.
 
-If you have a `pages/` folder, `useRouter` is identical in behavior to the one provided by `vue-router`. Feel free to read the router documentation for more information on what each method does.
+If you have a `pages/` folder, [`useRouter`](/docs/api/composables/use-router)  is identical in behavior to the one provided by `vue-router`. Feel free to read the router documentation for more information on what each method does.
 
 ::ReadMore{link="https://router.vuejs.org/api/interfaces/Router.html#Properties-currentRoute"}
 ::
@@ -63,4 +63,4 @@ However, Nuxt has a concept of **route middleware** that simplifies the implemen
 
 ## Universal Router Instance
 
-If you do not have a `pages/` folder, then `useRouter` will return a universal router instance with similar helper methods, but be aware that not all features may be supported or behave in exactly the same way as with `vue-router`.
+If you do not have a `pages/` folder, then [`useRouter`](/docs/api/composables/use-router)  will return a universal router instance with similar helper methods, but be aware that not all features may be supported or behave in exactly the same way as with `vue-router`.

--- a/docs/3.api/1.composables/use-runtime-config.md
+++ b/docs/3.api/1.composables/use-runtime-config.md
@@ -1,6 +1,6 @@
 # `useRuntimeConfig`
 
-The `useRuntimeConfig` composable is used to expose config variables within your app.
+The [`useRuntimeConfig`](/docs/api/composables/use-runtime-config) composable is used to expose config variables within your app.
 
 ## Usage
 

--- a/docs/3.api/1.composables/use-server-seo-meta.md
+++ b/docs/3.api/1.composables/use-server-seo-meta.md
@@ -4,8 +4,8 @@ description: The useServerSeoMeta composable lets you define your site's SEO met
 
 # `useServerSeoMeta`
 
-Just like [`useSeoMeta`](/docs/api/composables/use-seo-meta), `useServerSeoMeta` composable lets you define your site's SEO meta tags as a flat object with full TypeScript support.
+Just like [`useSeoMeta`](/docs/api/composables/use-seo-meta), [`useServerSeoMeta`](/docs/api/composables/use-server-seo-meta) composable lets you define your site's SEO meta tags as a flat object with full TypeScript support.
 :ReadMore{link="/docs/api/composables/use-seo-meta"}
 
-In most instances, the meta doesn't need to be reactive as robots will only scan the initial load. So we recommend using `useServerSeoMeta` as a performance-focused utility that will not do anything (or return a `head` object) on the client.
+In most instances, the meta doesn't need to be reactive as robots will only scan the initial load. So we recommend using [`useServerSeoMeta`](/docs/api/composables/use-server-seo-meta) as a performance-focused utility that will not do anything (or return a `head` object) on the client.
 Parameters are exactly the same as with [`useSeoMeta`](/docs/api/composables/use-seo-meta)

--- a/docs/3.api/1.composables/use-state.md
+++ b/docs/3.api/1.composables/use-state.md
@@ -10,16 +10,16 @@ useState<T>(init?: () => T | Ref<T>): Ref<T>
 useState<T>(key: string, init?: () => T | Ref<T>): Ref<T>
 ```
 
-* **key**: A unique key ensuring that data fetching is properly de-duplicated across requests. If you do not provide a key, then a key that is unique to the file and line number of the instance of `useState` will be generated for you.
+* **key**: A unique key ensuring that data fetching is properly de-duplicated across requests. If you do not provide a key, then a key that is unique to the file and line number of the instance of [`useState`](/docs/api/composables/use-state) will be generated for you.
 * **init**: A function that provides initial value for the state when not initiated. This function can also return a `Ref`.
 * **T**: (typescript only) Specify the type of state
 
 ::alert{type=warning}
-Because the data inside `useState` will be serialized to JSON, it is important that it does not contain anything that cannot be serialized, such as classes, functions or symbols.
+Because the data inside [`useState`](/docs/api/composables/use-state) will be serialized to JSON, it is important that it does not contain anything that cannot be serialized, such as classes, functions or symbols.
 ::
 
 ::alert{type=warning}
-`useState` is a reserved function name transformed by the compiler, so you should not name your own function `useState`.
+[`useState`](/docs/api/composables/use-state) is a reserved function name transformed by the compiler, so you should not name your own function `useState`.
 ::
 
 ::ReadMore{link="/docs/getting-started/state-management"}

--- a/docs/3.api/2.components/2.nuxt-page.md
+++ b/docs/3.api/2.components/2.nuxt-page.md
@@ -5,7 +5,7 @@ description: The NuxtPage component is required to display pages located in the 
 
 # `<NuxtPage>`
 
-`<NuxtPage>` is a built-in component that comes with Nuxt. `NuxtPage` is required to display top-level or nested pages located in the `pages/` directory.
+`<NuxtPage>` is a built-in component that comes with Nuxt. `NuxtPage` is required to display top-level or nested pages located in the [`pages/` directory](/docs/guide/directory-structure/pages).
 
 `NuxtPage` is a wrapper around [`<RouterView>`](https://router.vuejs.org/api/interfaces/RouterViewProps.html#interface-routerviewprops) component from Vue Router. `NuxtPage` component accepts same `name` and `route` props.
 

--- a/docs/3.api/3.utils/$fetch.md
+++ b/docs/3.api/3.utils/$fetch.md
@@ -9,7 +9,7 @@ Nuxt uses [ofetch](https://github.com/unjs/ofetch) to expose globally the `$fetc
 
 During server-side rendering, calling `$fetch` to fetch your internal [API routes](/docs/guide/directory-structure/server) will directly call the relevant function (emulating the request), **saving an additional API call**.
 
-However, using `$fetch` in components without wrapping it with `useAsyncData` causes fetching the data twice: initially on the server, then again on the client-side during hydration, because `$fetch` does not transfer state from the server to the client. Thus, the fetch will be executed on both sides because the client has to get the data again.
+However, using `$fetch` in components without wrapping it with [`useAsyncData`](/docs/api/composables/use-async-data) causes fetching the data twice: initially on the server, then again on the client-side during hydration, because `$fetch` does not transfer state from the server to the client. Thus, the fetch will be executed on both sides because the client has to get the data again.
 
 We recommend to use [`useFetch`](https://nuxt.com/docs/api/composables/use-fetch) or [`useAsyncData`](https://nuxt.com/docs/api/composables/use-async-data) + `$fetch` to prevent double data fetching when fetching the component data.
 

--- a/docs/3.api/3.utils/clear-nuxt-data.md
+++ b/docs/3.api/3.utils/clear-nuxt-data.md
@@ -1,6 +1,6 @@
 # `clearNuxtData`
 
-Delete cached data, error status and pending promises of `useAsyncData` and `useFetch`.
+Delete cached data, error status and pending promises of [`useAsyncData`](/docs/api/composables/use-async-data) and `useFetch`.
 
 This method is useful if you want to invalidate the data fetching for another page.
 
@@ -12,4 +12,4 @@ clearNuxtData (keys?: string | string[] | ((key: string) => boolean)): void
 
 ## Parameters
 
-* `keys`: One or an array of keys that are used in `useAsyncData` to delete their cached data. If no keys are provided, **all data** will be invalidated.
+* `keys`: One or an array of keys that are used in [`useAsyncData`](/docs/api/composables/use-async-data) to delete their cached data. If no keys are provided, **all data** will be invalidated.

--- a/docs/3.api/3.utils/clear-nuxt-state.md
+++ b/docs/3.api/3.utils/clear-nuxt-state.md
@@ -12,4 +12,4 @@ clearNuxtState (keys?: string | string[] | ((key: string) => boolean)): void
 
 ## Parameters
 
-* `keys`: One or an array of keys that are used in `useState` to delete their cached state. If no keys are provided, **all state** will be invalidated.
+* `keys`: One or an array of keys that are used in [`useState`](/docs/api/composables/use-state) to delete their cached state. If no keys are provided, **all state** will be invalidated.

--- a/docs/3.api/3.utils/define-nuxt-route-middleware.md
+++ b/docs/3.api/3.utils/define-nuxt-route-middleware.md
@@ -6,7 +6,7 @@ title: "defineNuxtRouteMiddleware"
 
 Create named route middleware using `defineNuxtRouteMiddleware` helper function.
 
-Route middleware are stored in the `middleware/` directory of your Nuxt application (unless [set otherwise](/docs/api/configuration/nuxt-config#middleware)).
+Route middleware are stored in the [`middleware/` directory](/docs/guide/directory-structure/middleware) of your Nuxt application (unless [set otherwise](/docs/api/configuration/nuxt-config#middleware)).
 
 ## Type
 

--- a/docs/3.api/3.utils/define-nuxt-route-middleware.md
+++ b/docs/3.api/3.utils/define-nuxt-route-middleware.md
@@ -46,7 +46,7 @@ The above route middleware will redirect a user to the custom error page defined
 
 ### Redirection
 
-Use `useState` in combination with `navigateTo` helper function inside the route middleware to redirect users to different routes based on their authentication status:
+Use [`useState`](/docs/api/composables/use-state) in combination with `navigateTo` helper function inside the route middleware to redirect users to different routes based on their authentication status:
 
 ```ts [middleware/auth.ts]
 export default defineNuxtRouteMiddleware((to, from) => {

--- a/docs/3.api/3.utils/define-page-meta.md
+++ b/docs/3.api/3.utils/define-page-meta.md
@@ -4,7 +4,7 @@ title: "definePageMeta"
 
 # `definePageMeta`
 
-`definePageMeta` is a compiler macro that you can use to set metadata for your **page** components located in the `pages/` directory (unless [set otherwise](/docs/api/configuration/nuxt-config#pages)). This way you can set custom metadata for each static or dynamic route of your Nuxt application.
+`definePageMeta` is a compiler macro that you can use to set metadata for your **page** components located in the [`pages/` directory](/docs/guide/directory-structure/pages) (unless [set otherwise](/docs/api/configuration/nuxt-config#pages)). This way you can set custom metadata for each static or dynamic route of your Nuxt application.
 
 ```vue [pages/some-page.vue]
 <script setup>
@@ -161,7 +161,7 @@ The example below shows how the middleware can be defined using a `function` dir
 
 ### Defining Layout
 
-You can define the layout that matches the layout's file name located (by default) in the `layouts/` directory. You can also disable the layout by setting the `layout` to `false`:
+You can define the layout that matches the layout's file name located (by default) in the [`layouts/` directory](/docs/guide/directory-structure/layouts). You can also disable the layout by setting the `layout` to `false`:
 
 ```vue [pages/some-page.vue]
 <script setup>

--- a/docs/3.api/3.utils/refresh-nuxt-data.md
+++ b/docs/3.api/3.utils/refresh-nuxt-data.md
@@ -5,7 +5,7 @@ description: refreshNuxtData refetches all data from the server and updates the 
 
 # `refreshNuxtData`
 
-`refreshNuxtData` re-fetches all data from the server and updates the page as well as invalidates the cache of `useAsyncData`, `useLazyAsyncData`, `useFetch` and `useLazyFetch`.
+`refreshNuxtData` re-fetches all data from the server and updates the page as well as invalidates the cache of [`useAsyncData`](/docs/api/composables/use-async-data) , `useLazyAsyncData`, [`useFetch`](/docs/api/composables/use-fetch) and `useLazyFetch`.
 
 ## Type
 
@@ -19,13 +19,13 @@ refreshNuxtData(keys?: string | string[])
 
     **Type**: `String | String[]`
 
-    `refreshNuxtData` accepts a single or an array of strings as `keys` that are used to fetch the data. This parameter is **optional**. All `useAsyncData` and `useFetch` are re-fetched when no `keys` are specified.
+    `refreshNuxtData` accepts a single or an array of strings as `keys` that are used to fetch the data. This parameter is **optional**. All [`useAsyncData`](/docs/api/composables/use-async-data) and [`useFetch`](/docs/api/composables/use-fetch) are re-fetched when no `keys` are specified.
 
 ## Examples
 
 ### Refresh All data
 
-This example below refreshes all data being fetched using `useAsyncData` and `useFetch` on the current page.
+This example below refreshes all data being fetched using [`useAsyncData`](/docs/api/composables/use-async-data) and [`useFetch`](/docs/api/composables/use-fetch) on the current page.
 
 ```vue [pages/some-page.vue]
 <template>

--- a/docs/6.bridge/1.overview.md
+++ b/docs/6.bridge/1.overview.md
@@ -255,7 +255,7 @@ Use of `defineNuxtRouteMiddleware` is not supported outside of the middleware di
 Nuxt Bridge does not support `definePageMeta`.
 ::
 
-## New [`useHead`](/docs/api/composables/use-head) (Optional)
+## New `useHead` (Optional)
 
 Nuxt Bridge provides a new Nuxt 3 meta API that can be accessed with a new [`useHead`](/docs/api/composables/use-head) composable.
 

--- a/docs/6.bridge/1.overview.md
+++ b/docs/6.bridge/1.overview.md
@@ -7,7 +7,7 @@ If you're starting a fresh Nuxt 3 project, please skip this section and go to [N
 ::
 
 ::alert{type=warning}
-Nuxt Bridge provides identical features to Nuxt 3 ([docs](/docs/guide/concepts/auto-imports)) but there are some limitations, notably that `useAsyncData` and `useFetch` composables are not available. Please read the rest of this page for details.
+Nuxt Bridge provides identical features to Nuxt 3 ([docs](/docs/guide/concepts/auto-imports)) but there are some limitations, notably that [`useAsyncData`](/docs/api/composables/use-async-data) and [`useFetch`](/docs/api/composables/use-fetch) composables are not available. Please read the rest of this page for details.
 ::
 
 Bridge is a forward-compatibility layer that allows you to experience many of the new Nuxt 3 features by simply installing and enabling a Nuxt module.
@@ -111,7 +111,7 @@ For all other situations, you can use the `nuxi build` command.
 
 Please make sure to avoid any CommonJS syntax such as `module.exports`, `require` or `require.resolve` in your config file. It will soon be deprecated and unsupported.
 
-You can use static `import`, dynamic `import()` and `export default` instead. Using TypeScript by renaming to `nuxt.config.ts` is also possible and recommended.
+You can use static `import`, dynamic `import()` and `export default` instead. Using TypeScript by renaming to[`nuxt.config.ts`](/docs/guide/directory-structure/nuxt.config)is also possible and recommended.
 
 ```ts [nuxt.config.js|ts]
 import { defineNuxtConfig } from '@nuxt/bridge'
@@ -226,7 +226,7 @@ export default defineNuxtPlugin(nuxtApp => {
 ```
 
 ::alert
-If you want to use the new Nuxt composables (such as `useNuxtApp` or `useRuntimeConfig`) within your plugins, you will need to use the `defineNuxtPlugin` helper for those plugins.
+If you want to use the new Nuxt composables (such as [`useNuxtApp`](/docs/api/composables/use-nuxt-app) or `useRuntimeConfig`) within your plugins, you will need to use the `defineNuxtPlugin` helper for those plugins.
 ::
 
 ::alert{type=warning}
@@ -255,9 +255,9 @@ Use of `defineNuxtRouteMiddleware` is not supported outside of the middleware di
 Nuxt Bridge does not support `definePageMeta`.
 ::
 
-## New `useHead` (Optional)
+## New [`useHead`](/docs/api/composables/use-head) (Optional)
 
-Nuxt Bridge provides a new Nuxt 3 meta API that can be accessed with a new `useHead` composable.
+Nuxt Bridge provides a new Nuxt 3 meta API that can be accessed with a new [`useHead`](/docs/api/composables/use-head) composable.
 
 ```vue
 <script setup>
@@ -279,11 +279,11 @@ export default defineNuxtConfig({
 ```
 
 ::alert
-This `useHead` composable uses `@vueuse/head` under the hood (rather than `vue-meta`) to manipulate your `<head>`. You need to add `@vueuse/head` to your package.json file for it to work properly.
+This [`useHead`](/docs/api/composables/use-head) composable uses `@vueuse/head` under the hood (rather than `vue-meta`) to manipulate your `<head>`. You need to add `@vueuse/head` to your package.json file for it to work properly.
 ::
 
 ::alert{type=warning}
-We recommend not using the native Nuxt 2 `head()` properties in addition to `useHead`, as they may conflict.
+We recommend not using the native Nuxt 2 `head()` properties in addition to [`useHead`](/docs/api/composables/use-head) , as they may conflict.
 ::
 
 For more information on how to use this composable, see [the docs](/docs/getting-started/seo-meta).

--- a/docs/6.bridge/1.overview.md
+++ b/docs/6.bridge/1.overview.md
@@ -111,7 +111,7 @@ For all other situations, you can use the `nuxi build` command.
 
 Please make sure to avoid any CommonJS syntax such as `module.exports`, `require` or `require.resolve` in your config file. It will soon be deprecated and unsupported.
 
-You can use static `import`, dynamic `import()` and `export default` instead. Using TypeScript by renaming to[`nuxt.config.ts`](/docs/guide/directory-structure/nuxt.config)is also possible and recommended.
+You can use static `import`, dynamic `import()` and `export default` instead. Using TypeScript by renaming to [`nuxt.config.ts`](/docs/guide/directory-structure/nuxt.config) is also possible and recommended.
 
 ```ts [nuxt.config.js|ts]
 import { defineNuxtConfig } from '@nuxt/bridge'

--- a/docs/6.bridge/2.bridge-composition-api.md
+++ b/docs/6.bridge/2.bridge-composition-api.md
@@ -131,7 +131,7 @@ You can read more about how to use this composable in [the Nuxt 3 docs](/docs/ap
 
 This function has been removed, and you will need to find an alternative implementation if you were using it. If you have a use case for `ssrPromise`, please let us know via a discussion.
 
-### [`useRouter`](/docs/api/composables/use-router)  and `useRoute`
+### `useRouter` and `useRoute`
 
 Nuxt Bridge provides direct replacements for these composables via [`useRouter`](/docs/api/composables/use-router)  and `useRoute`.
 

--- a/docs/6.bridge/2.bridge-composition-api.md
+++ b/docs/6.bridge/2.bridge-composition-api.md
@@ -91,7 +91,7 @@ You may wish to [migrate your plugins to Nuxt 3-style plugins](/docs/bridge/over
 
 ### `onGlobalSetup`
 
-This function has been removed, but its use cases can be met by using `useNuxtApp` or `useState` within `defineNuxtPlugin`. You can also run any custom code within the `setup()` function of a layout.
+This function has been removed, but its use cases can be met by using [`useNuxtApp`](/docs/api/composables/use-nuxt-app) or [`useState`](/docs/api/composables/use-state) within `defineNuxtPlugin`. You can also run any custom code within the `setup()` function of a layout.
 
 ```diff
 - import { onGlobalSetup } from '@nuxtjs/composition-api'
@@ -110,7 +110,7 @@ This function has been removed, but its use cases can be met by using `useNuxtAp
 
 These two functions have been replaced with a new composable that works very similarly under the hood: `useState`.
 
-The key differences are that you must provide a _key_ for this state (which Nuxt generated automatically for `ssrRef` and `shallowSsrRef`), and that it can only be called within a Nuxt 3 plugin (which is defined by `defineNuxtPlugin`) or a component instance. (In other words, you cannot use `useState` with a global/ambient context, because of the danger of shared state across requests.)
+The key differences are that you must provide a _key_ for this state (which Nuxt generated automatically for `ssrRef` and `shallowSsrRef`), and that it can only be called within a Nuxt 3 plugin (which is defined by `defineNuxtPlugin`) or a component instance. (In other words, you cannot use [`useState`](/docs/api/composables/use-state) with a global/ambient context, because of the danger of shared state across requests.)
 
 ```diff
 - import { ssrRef } from '@nuxtjs/composition-api'
@@ -131,11 +131,11 @@ You can read more about how to use this composable in [the Nuxt 3 docs](/docs/ap
 
 This function has been removed, and you will need to find an alternative implementation if you were using it. If you have a use case for `ssrPromise`, please let us know via a discussion.
 
-### `useRouter` and `useRoute`
+### [`useRouter`](/docs/api/composables/use-router)  and `useRoute`
 
-Nuxt Bridge provides direct replacements for these composables via `useRouter` and `useRoute`.
+Nuxt Bridge provides direct replacements for these composables via [`useRouter`](/docs/api/composables/use-router)  and `useRoute`.
 
-The only key difference is that `useRoute` no longer returns a computed property.
+The only key difference is that [`useRoute`](/docs/api/composables/use-route) no longer returns a computed property.
 
 ```diff
 - import { useRouter, useRoute } from '@nuxtjs/composition-api'
@@ -246,7 +246,7 @@ title.value = 'new title'
 Be careful not to use both `useNuxt2Meta()` and the Options API `head()` within the same component, as behavior may be unpredictable.
 ::
 
-Nuxt Bridge also provides a Nuxt 3-compatible meta implementation that can be accessed with the `useHead` composable.
+Nuxt Bridge also provides a Nuxt 3-compatible meta implementation that can be accessed with the [`useHead`](/docs/api/composables/use-head) composable.
 
 ```diff
 <script setup>
@@ -268,6 +268,6 @@ export default defineNuxtConfig({
 })
 ```
 
-This `useHead` composable uses `@vueuse/head` under the hood (rather than `vue-meta`) to manipulate your `<head>`. Accordingly, it is recommended not to use both the native Nuxt 2 `head()` properties as well as `useHead`, as they may conflict.
+This [`useHead`](/docs/api/composables/use-head) composable uses `@vueuse/head` under the hood (rather than `vue-meta`) to manipulate your `<head>`. Accordingly, it is recommended not to use both the native Nuxt 2 `head()` properties as well as [`useHead`](/docs/api/composables/use-head) , as they may conflict.
 
 For more information on how to use this composable, see [the Nuxt 3 docs](/docs/getting-started/seo-meta).

--- a/docs/7.migration/2.configuration.md
+++ b/docs/7.migration/2.configuration.md
@@ -94,7 +94,7 @@ If you are a module author, you can check out [more information about module com
 
 ## Directory Changes
 
-The `static/` directory (for storing static assets) has been renamed to `public/`. You can either rename your `static` directory to `public`, or keep the name by setting `dir.public` in your `nuxt.config`.
+The [`static/` directory](/docs/guide/directory-structure/static) (for storing static assets) has been renamed to `public/`. You can either rename your `static` directory to `public`, or keep the name by setting `dir.public` in your `nuxt.config`.
 
 ::ReadMore{link="/docs/guide/directory-structure/public"}
 ::

--- a/docs/7.migration/4.meta.md
+++ b/docs/7.migration/4.meta.md
@@ -3,7 +3,7 @@
 Nuxt 3 provides several different ways to manage your meta tags.
 
 1. Through your `nuxt.config`.
-2. Through the `useHead` [composable](/docs/getting-started/seo-meta)
+2. Through the [`useHead`](/docs/api/composables/use-head) [composable](/docs/getting-started/seo-meta)
 3. Through [global meta components](/docs/getting-started/seo-meta)
 
 You can customize `title`, `titleTemplate`, `base`, `script`, `noscript`, `style`, `meta`, `link`, `htmlAttrs` and `bodyAttrs`.
@@ -17,10 +17,10 @@ Nuxt currently uses [`vueuse/head`](https://github.com/vueuse/head) to manage yo
 ## Migration
 
 1. In your `nuxt.config`, rename `head` to `meta`. Consider moving this shared meta configuration into your `app.vue` instead. (Note that objects no longer have a `hid` key for deduplication.)
-1. If you need to access the component state with `head`, you should migrate to using `useHead`. You might also consider using the built-in meta-components.
+1. If you need to access the component state with `head`, you should migrate to using [`useHead`](/docs/api/composables/use-head) . You might also consider using the built-in meta-components.
 1. If you need to use the Options API, there is a `head()` method you can use when you use `defineNuxtComponent`.
 
-### Example: `useHead`
+### Example: [`useHead`](/docs/api/composables/use-head) 
 
 ::code-group
 

--- a/docs/7.migration/4.meta.md
+++ b/docs/7.migration/4.meta.md
@@ -20,7 +20,7 @@ Nuxt currently uses [`vueuse/head`](https://github.com/vueuse/head) to manage yo
 1. If you need to access the component state with `head`, you should migrate to using [`useHead`](/docs/api/composables/use-head) . You might also consider using the built-in meta-components.
 1. If you need to use the Options API, there is a `head()` method you can use when you use `defineNuxtComponent`.
 
-### Example: [`useHead`](/docs/api/composables/use-head) 
+### Example: [`useHead`](/docs/api/composables/use-head)
 
 ::code-group
 

--- a/docs/7.migration/4.meta.md
+++ b/docs/7.migration/4.meta.md
@@ -20,7 +20,7 @@ Nuxt currently uses [`vueuse/head`](https://github.com/vueuse/head) to manage yo
 1. If you need to access the component state with `head`, you should migrate to using [`useHead`](/docs/api/composables/use-head) . You might also consider using the built-in meta-components.
 1. If you need to use the Options API, there is a `head()` method you can use when you use `defineNuxtComponent`.
 
-### Example: [`useHead`](/docs/api/composables/use-head) 
+### Example: useHead
 
 ::code-group
 

--- a/docs/7.migration/6.pages-and-layouts.md
+++ b/docs/7.migration/6.pages-and-layouts.md
@@ -64,7 +64,7 @@ You will also need to change how you define the layout used by a page using the 
 
 ## Pages
 
-Nuxt 3 ships with an optional `vue-router` integration triggered by the existence of a `pages/` directory in your source directory. If you only have a single page, you may consider instead moving it to `app.vue` for a lighter build.
+Nuxt 3 ships with an optional `vue-router` integration triggered by the existence of a [`pages/` directory](/docs/guide/directory-structure/pages) in your source directory. If you only have a single page, you may consider instead moving it to `app.vue` for a lighter build.
 
 ### Dynamic Routes
 

--- a/docs/7.migration/6.pages-and-layouts.md
+++ b/docs/7.migration/6.pages-and-layouts.md
@@ -93,7 +93,7 @@ If you have been defining transitions for your page or layout directly in your c
 
 1. Rename any pages with dynamic parameters to match the new format.
 1. Update `<Nuxt>` and `<NuxtChild>` to be `<NuxtPage>`.
-1. If you're using the Composition API, you can also migrate `this.$route` and `this.$router` to use `useRoute` and `useRouter` composables.
+1. If you're using the Composition API, you can also migrate `this.$route` and `this.$router` to use [`useRoute`](/docs/api/composables/use-route) and [`useRouter`](/docs/api/composables/use-router)  composables.
 
 #### Example: Dynamic Routes
 

--- a/docs/7.migration/7.component-options.md
+++ b/docs/7.migration/7.component-options.md
@@ -21,7 +21,7 @@ You can read more [about direct API calls](/docs/guide/concepts/server-engine#di
 
 ### Using Composables
 
-Nuxt 3 provides new composables for fetching data: `useAsyncData` and `useFetch`. They each have 'lazy' variants (`useLazyAsyncData` and `useLazyFetch`), which do not block client-side navigation.
+Nuxt 3 provides new composables for fetching data: [`useAsyncData`](/docs/api/composables/use-async-data) and `useFetch`. They each have 'lazy' variants (`useLazyAsyncData` and `useLazyFetch`), which do not block client-side navigation.
 
 In Nuxt 2, you'd fetch your data in your component using a syntax similar to:
 
@@ -54,13 +54,13 @@ With Nuxt 3, you can perform this data fetching using composables in your `setup
 You can now use `post` inside of your Nuxt 3 template, or call `refresh` to update the data.
 
 ::alert{type=info}
-Despite the names, `useFetch` is not a direct replacement of the `fetch()` hook. Rather, `useAsyncData` replaces both hooks and is more customizable; it can do more than simply fetching data from an endpoint. `useFetch` is a convenience wrapper around `useAsyncData` for simply fetching data from an endpoint.
+Despite the names, [`useFetch`](/docs/api/composables/use-fetch) is not a direct replacement of the `fetch()` hook. Rather, [`useAsyncData`](/docs/api/composables/use-async-data) replaces both hooks and is more customizable; it can do more than simply fetching data from an endpoint. [`useFetch`](/docs/api/composables/use-fetch) is a convenience wrapper around [`useAsyncData`](/docs/api/composables/use-async-data) for simply fetching data from an endpoint.
 ::
 
 ### Migration
 
-1. Replace the `asyncData` hook with `useAsyncData` or `useFetch` in your page/component.
-1. Replace the `fetch` hook with `useAsyncData` or `useFetch` in your component.
+1. Replace the `asyncData` hook with [`useAsyncData`](/docs/api/composables/use-async-data) or [`useFetch`](/docs/api/composables/use-fetch) in your page/component.
+1. Replace the `fetch` hook with [`useAsyncData`](/docs/api/composables/use-async-data) or [`useFetch`](/docs/api/composables/use-fetch) in your component.
 
 ## `head`
 

--- a/docs/7.migration/8.runtime-config.md
+++ b/docs/7.migration/8.runtime-config.md
@@ -2,16 +2,16 @@
 
 If you wish to reference environment variables within your Nuxt 3 app, you will need to use runtime config.
 
-When referencing these variables within your components, you will have to use the `useRuntimeConfig` composable in your setup method (or Nuxt plugin).
+When referencing these variables within your components, you will have to use the [`useRuntimeConfig`](/docs/api/composables/use-runtime-config) composable in your setup method (or Nuxt plugin).
 
-In the `server/` portion of your app, you can use `useRuntimeConfig` without any import.
+In the `server/` portion of your app, you can use [`useRuntimeConfig`](/docs/api/composables/use-runtime-config) without any import.
 
 [Read more about runtime config](/docs/guide/going-further/runtime-config).
 
 ## Migration
 
 1. Add any environment variables that you use in your app to the `runtimeConfig` property of the `nuxt.config` file.
-1. Migrate `process.env` to `useRuntimeConfig` throughout the Vue part of your app.
+1. Migrate `process.env` to [`useRuntimeConfig`](/docs/api/composables/use-runtime-config) throughout the Vue part of your app.
 
 ## Example
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I noticed in the documentation that links to the directory structure page or composable function are specifically displayed. However, not all links use the correct format. Also, many places that should jump to the composable function page are not linked. I have modified them.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
