### PR TITLE
feat(vite): unpin vite from minor

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -57,7 +57,7 @@
     "strip-literal": "^1.0.1",
     "ufo": "^1.1.2",
     "unplugin": "^1.3.2",
-    "vite": "~4.3.9",
+    "vite": "^4.3.9",
     "vite-node": "^0.33.0",
     "vite-plugin-checker": "^0.6.1",
     "vue-bundle-renderer": "^1.0.3"


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This unpins `vite` from minor versions as it is now safe to rely on `vite.experimental.renderBuiltUrl` across new 4.x minors.

cc: @patak-dev

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
