### PR TITLE
docs: fix auto-import differences for composables and components folder

### DIFF
--- a/docs/2.guide/1.concepts/1.auto-imports.md
+++ b/docs/2.guide/1.concepts/1.auto-imports.md
@@ -113,7 +113,7 @@ Nuxt exposes every auto-import with the `#imports` alias that can be used to mak
 
 ### Disabling Auto-imports
 
-If you want to disable auto-importing of composables and utilities, you can set `imports.autoImport` to `false` in your `nuxt.config.ts`.
+If you want to disable auto-importing composables and utilities, you can set `imports.autoImport` to `false` in the `nuxt.config` file.
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({

--- a/docs/2.guide/1.concepts/1.auto-imports.md
+++ b/docs/2.guide/1.concepts/1.auto-imports.md
@@ -4,7 +4,7 @@ description: "Nuxt auto-imports helper functions, composables and Vue APIs."
 
 # Auto imports
 
-### Composables and Helper Functions
+## Composables and Helper Functions
 
 Nuxt auto-imports helper functions, composables and Vue APIs to use across your application without explicitly importing them. Based on the directory structure, every Nuxt application can also use auto-imports for its own components, composables and plugins. Components, composables or plugins can use these functions.
 

--- a/docs/2.guide/1.concepts/1.auto-imports.md
+++ b/docs/2.guide/1.concepts/1.auto-imports.md
@@ -2,7 +2,7 @@
 description: "Nuxt auto-imports helper functions, composables and Vue APIs."
 ---
 
-# Auto imports
+# Auto-imports
 
 ## Composables and Helper Functions
 

--- a/docs/2.guide/1.concepts/1.auto-imports.md
+++ b/docs/2.guide/1.concepts/1.auto-imports.md
@@ -4,6 +4,8 @@ description: "Nuxt auto-imports helper functions, composables and Vue APIs."
 
 # Auto imports
 
+### Composables and Helper Functions
+
 Nuxt auto-imports helper functions, composables and Vue APIs to use across your application without explicitly importing them. Based on the directory structure, every Nuxt application can also use auto-imports for its own components, composables and plugins. Components, composables or plugins can use these functions.
 
 Contrary to a classic global declaration, Nuxt preserves typings and IDEs completions and hints, and only includes what is actually used in your production code.
@@ -21,9 +23,9 @@ In the [server directory](/docs/guide/directory-structure/server), we auto impor
 You can also auto-import functions exported from custom folders or third-party packages by configuring the [`imports` section](/docs/api/configuration/nuxt-config#imports) of your `nuxt.config` file.
 ::
 
-## Built-in Auto-imports
+### Built-in Auto-imports
 
-### Nuxt Auto-imports
+#### Nuxt Auto-imports
 
 Nuxt auto-imports functions and composables to perform [data fetching](/docs/getting-started/data-fetching), get access to the [app context](/docs/api/composables/use-nuxt-app) and [runtime config](/docs/guide/going-further/runtime-config), manage [state](/docs/getting-started/state-management) or define components and plugins.
 
@@ -34,7 +36,7 @@ Nuxt auto-imports functions and composables to perform [data fetching](/docs/get
 </script>
 ```
 
-### Vue Auto-imports
+#### Vue Auto-imports
 
 Vue 3 exposes Reactivity APIs like `ref` or `computed`, as well as lifecycle hooks and helpers that are auto-imported by Nuxt.
 
@@ -46,7 +48,7 @@ Vue 3 exposes Reactivity APIs like `ref` or `computed`, as well as lifecycle hoo
 </script>
 ```
 
-### Using Vue and Nuxt composables
+#### Using Vue and Nuxt composables
 
 <!-- TODO: move to separate page with https://github.com/nuxt/nuxt/issues/14723 and add more information -->
 
@@ -63,7 +65,7 @@ See the full explanation in this [comment](https://github.com/nuxt/nuxt/issues/1
 ::NeedContribution
 ::
 
-#### Example
+##### Example
 
 **Example:** Breaking code:
 
@@ -88,7 +90,7 @@ export const useMyComposable = () => {
 }
 ```
 
-## Directory-based Auto-imports
+### Directory-based Auto-imports
 
 Nuxt directly auto-imports files created in defined directories:
 
@@ -96,7 +98,7 @@ Nuxt directly auto-imports files created in defined directories:
 - `composables/` for [Vue composables](/docs/guide/directory-structure/composables).
 - `utils/` for helper functions and other utilities.
 
-## Explicit Imports
+### Explicit Imports
 
 Nuxt exposes every auto-import with the `#imports` alias that can be used to make the import explicit if needed:
 
@@ -109,21 +111,32 @@ Nuxt exposes every auto-import with the `#imports` alias that can be used to mak
 </script>
 ```
 
-## Disable Auto-imports
+### Disabling Auto-imports
 
-In case you want to disable auto-imports, you can set `imports.autoImport` to `false` in your `nuxt.config.ts`. By default, this configuration disables auto-imports for the composables folder.
+If you want to disable auto-importing of composables and utilities, you can set `imports.autoImport` to `false` in your `nuxt.config.ts`.
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   imports: {
     autoImport: false
   }
+})
+```
+
+This will disable auto imports completely but it's still possible to use [Explicit Imports](#explicit-imports) from `#imports`.
+
+## Auto-imported Components
+
+Nuxt also automatically imports components from your `~/components` directory, although this is configured separately from auto-importing of composables and utility functions.
+
+:ReadMore{link="/docs/guide/directory-structure/components"}
+
+To disable auto-importing of components from your own `~/components` directory, you can set `components.dirs` to an empty array (though note that this will not affect components added by modules).
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
   components: {
     dirs: []
   }
 })
 ```
-
-To disable auto-imports for the components folder, you can add the `components.dirs` configuration with an empty array as shown above.
-
-This will disable implicit auto imports completely but it's still possible to use [Explicit Imports](#explicit-imports).

--- a/docs/2.guide/1.concepts/1.auto-imports.md
+++ b/docs/2.guide/1.concepts/1.auto-imports.md
@@ -111,14 +111,19 @@ Nuxt exposes every auto-import with the `#imports` alias that can be used to mak
 
 ## Disable Auto-imports
 
-In case you want to disable auto-imports, you can set `imports.autoImport` to `false` in your `nuxt.config.ts`.
+In case you want to disable auto-imports, you can set `imports.autoImport` to `false` in your `nuxt.config.ts`. By default, this configuration disables auto-imports for the composables folder.
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   imports: {
     autoImport: false
   }
+  components: {
+    dirs: []
+  }
 })
 ```
+
+To disable auto-imports for the components folder, you can add the `components.dirs` configuration with an empty array as shown above.
 
 This will disable implicit auto imports completely but it's still possible to use [Explicit Imports](#explicit-imports).

--- a/docs/2.guide/1.concepts/1.auto-imports.md
+++ b/docs/2.guide/1.concepts/1.auto-imports.md
@@ -123,15 +123,15 @@ export default defineNuxtConfig({
 })
 ```
 
-This will disable auto imports completely but it's still possible to use [Explicit Imports](#explicit-imports) from `#imports`.
+This will disable auto-imports completely but it's still possible to use [explicit imports](#explicit-imports) from `#imports`.
 
 ## Auto-imported Components
 
-Nuxt also automatically imports components from your `~/components` directory, although this is configured separately from auto-importing of composables and utility functions.
+Nuxt also automatically imports components from your `~/components` directory, although this is configured separately from auto-importing composables and utility functions.
 
 :ReadMore{link="/docs/guide/directory-structure/components"}
 
-To disable auto-importing of components from your own `~/components` directory, you can set `components.dirs` to an empty array (though note that this will not affect components added by modules).
+To disable auto-importing components from your own `~/components` directory, you can set `components.dirs` to an empty array (though note that this will not affect components added by modules).
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
#22056

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently the documentation is not explaining about the differences to disable auto-import for the `composables` and `components` folder. Added the information based on @danielroe comments (Thanks for the explanation 😄).

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
