### PR TITLE
fix(nuxt): don't set slots content within the payload

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-island.ts
+++ b/packages/nuxt/src/app/components/nuxt-island.ts
@@ -60,21 +60,17 @@ export default defineComponent({
       }
     }
 
-    const ssrHTML = ref('<div></div>')
-    if (process.client) {
-      const renderedHTML = getFragmentHTML(instance.vnode?.el ?? null).join('')
-      if (renderedHTML) {
-        ssrHTML.value = renderedHTML
-        setPayload(`${props.name}_${hashId.value}`, {
-          html: renderedHTML,
-          state: {},
-          head: {
-            link: [],
-            style: []
-          }
-        })
-      }
-      ssrHTML.value = renderedHTML
+    const ssrHTML = ref(process.client ? getFragmentHTML(instance.vnode?.el ?? null).join('') ?? '<div></div>' : '<div></div>')
+
+    if (process.client && ssrHTML.value) {
+      setPayload(`${props.name}_${hashId.value}`, {
+        html: getFragmentHTML(instance.vnode?.el ?? null, true).join(''),
+        state: {},
+        head: {
+          link: [],
+          style: []
+        }
+      })
     }
     const slotProps = computed(() => getSlotProps(ssrHTML.value))
     const uid = ref<string>(ssrHTML.value.match(SSR_UID_RE)?.[1] ?? randomUUID())

--- a/packages/nuxt/src/app/components/utils.ts
+++ b/packages/nuxt/src/app/components/utils.ts
@@ -99,25 +99,42 @@ export function vforToArray (source: any): any[] {
   return []
 }
 
-export function getFragmentHTML (element: RendererNode | null) {
+/**
+ * Retrieve the HTML content from an element
+ * Handles `<!--[-->` Fragment elements
+ *
+ * @param element the element to retrieve the HTML
+ * @param withoutSlots purge all slots from the HTML string retrieved
+ * @returns {string[]} An array of string which represent the content of each element. Use `.join('')` to retrieve a component vnode.el HTML
+ */
+export function getFragmentHTML (element: RendererNode | null, withoutSlots = false) {
   if (element) {
     if (element.nodeName === '#comment' && element.nodeValue === '[') {
-      return getFragmentChildren(element)
+      return getFragmentChildren(element, [], withoutSlots)
+    }
+    if (withoutSlots) {
+      const clone = element.cloneNode(true)
+      clone.querySelectorAll('[nuxt-ssr-slot-name]').forEach((n: Element) => { n.innerHTML = '' })
+      return [clone.outerHTML]
     }
     return [element.outerHTML]
   }
   return []
 }
 
-function getFragmentChildren (element: RendererNode | null, blocks: string[] = []) {
+function getFragmentChildren (element: RendererNode | null, blocks: string[] = [], withoutSlots = false) {
   if (element && element.nodeName) {
     if (isEndFragment(element)) {
       return blocks
     } else if (!isStartFragment(element)) {
-      blocks.push(element.outerHTML)
+      const clone = element.cloneNode(true) as Element
+      if (withoutSlots) {
+        clone.querySelectorAll('[nuxt-ssr-slot-name]').forEach((n) => { n.innerHTML = '' })
+      }
+      blocks.push(clone.outerHTML)
     }
 
-    getFragmentChildren(element.nextSibling, blocks)
+    getFragmentChildren(element.nextSibling, blocks, withoutSlots)
   }
   return blocks
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

this fix an HMR + re-render issue with the PR. 
`setPayload` client side was including slots content to the payload thus causing a duplication of slots with one being static

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
