### PR TITLE
docs: add instruction on how to use other modules in a module

### DIFF
--- a/docs/2.guide/3.going-further/3.modules.md
+++ b/docs/2.guide/3.going-further/3.modules.md
@@ -425,7 +425,7 @@ export default defineNuxtModule<ModuleOptions>({
     // We can inject our css file which includes tailwind's directives
     nuxt.options.css.push(resolve('./runtime/assets/styles.css'))
 
-    installModule('@nuxtjs/tailwindcss', {
+    await installModule('@nuxtjs/tailwindcss', {
       // module configuration
       exposeConfig: true,
       config: {

--- a/docs/2.guide/3.going-further/3.modules.md
+++ b/docs/2.guide/3.going-further/3.modules.md
@@ -390,6 +390,7 @@ export default defineNuxtModule({
   }
 })
 ```
+
 And a more advanced one, exposing a folder of assets through [Nitro](/docs/guide/concepts/server-engine)'s `publicAssets` option:
 
 ```js

--- a/docs/2.guide/3.going-further/3.modules.md
+++ b/docs/2.guide/3.going-further/3.modules.md
@@ -415,7 +415,7 @@ export default defineNuxtModule({
 
 If your module depends on other modules, you can add them by using `installModule`. For example, suppose you want to use `tailwindcss` framework in your module, you can add it as below:
 
-```js
+```ts
 import { defineNuxtModule, createResolver, installModule } from '@nuxt/kit'
 
 export default defineNuxtModule<ModuleOptions>({  
@@ -423,10 +423,10 @@ export default defineNuxtModule<ModuleOptions>({
     const { resolve } = createResolver(import.meta.url)
 
     // We can inject our css file which includes tailwind's directives
-    nuxt.options.css.push(resolve( './runtime/assets/styles.css'))
+    nuxt.options.css.push(resolve('./runtime/assets/styles.css'))
 
     installModule('@nuxtjs/tailwindcss', {
-      // module configurations
+      // module configuration
       exposeConfig: true,
       config: {
         darkMode: 'class',

--- a/docs/2.guide/3.going-further/3.modules.md
+++ b/docs/2.guide/3.going-further/3.modules.md
@@ -390,6 +390,25 @@ export default defineNuxtModule({
   }
 })
 ```
+And a more advanced one, exposing a folder of assets through [Nitro](/docs/guide/concepts/server-engine)'s `publicAssets` option:
+
+```js
+import { defineNuxtModule, createResolver } from '@nuxt/kit'
+
+export default defineNuxtModule({
+  setup (options, nuxt) {
+    const { resolve } = createResolver(import.meta.url)
+
+    nuxt.hook('nitro:config', async (nitroConfig) => {
+      nitroConfig.publicAssets ||= []
+      nitroConfig.publicAssets.push({
+        dir: resolve('./runtime/public'),
+        maxAge: 60 * 60 * 24 * 365 // 1 year
+      })
+    })
+  }
+})
+```
 
 #### Using other modules in your module
 
@@ -417,26 +436,6 @@ export default defineNuxtModule<ModuleOptions>({
           ],
         }
       }
-    })
-  }
-})
-```
-
-And a more advanced one, exposing a folder of assets through [Nitro](/docs/guide/concepts/server-engine)'s `publicAssets` option:
-
-```js
-import { defineNuxtModule, createResolver } from '@nuxt/kit'
-
-export default defineNuxtModule({
-  setup (options, nuxt) {
-    const { resolve } = createResolver(import.meta.url)
-
-    nuxt.hook('nitro:config', async (nitroConfig) => {
-      nitroConfig.publicAssets ||= []
-      nitroConfig.publicAssets.push({
-        dir: resolve('./runtime/public'),
-        maxAge: 60 * 60 * 24 * 365 // 1 year
-      })
     })
   }
 })

--- a/docs/2.guide/3.going-further/3.modules.md
+++ b/docs/2.guide/3.going-further/3.modules.md
@@ -391,6 +391,35 @@ export default defineNuxtModule({
 })
 ```
 
+#### Using other modules in your module
+If your module depends on other modules, you can add them by using `installModule`. For example, suppose you want to use `tailwindcss` framework in your module, you can add it as below:
+```js
+import { defineNuxtModule, createResolver, installModule } from '@nuxt/kit'
+
+export default defineNuxtModule<ModuleOptions>({  
+  setup (options, nuxt) {
+    const { resolve } = createResolver(import.meta.url)
+
+    // We can inject our css file which includes tailwind's directives
+    nuxt.options.css.push(resolve( './runtime/assets/styles.css'))
+
+    installModule('@nuxtjs/tailwindcss', {
+      // module configurations
+      exposeConfig: true,
+      config: {
+        darkMode: 'class',
+        content: {
+          files: [
+            resolve('./runtime/components/**/*.{vue,mjs,ts}'),
+            resolve('./runtime/*.{mjs,js,ts}')
+          ],
+        }
+      }
+    })
+  }
+})
+```
+
 And a more advanced one, exposing a folder of assets through [Nitro](/docs/guide/concepts/server-engine)'s `publicAssets` option:
 
 ```js

--- a/docs/2.guide/3.going-further/3.modules.md
+++ b/docs/2.guide/3.going-further/3.modules.md
@@ -411,9 +411,9 @@ export default defineNuxtModule({
 })
 ```
 
-#### Using other modules in your module
+#### Using Other Modules in Your Module
 
-If your module depends on other modules, you can add them by using `installModule`. For example, suppose you want to use `tailwindcss` framework in your module, you can add it as below:
+If your module depends on other modules, you can add them by using Nuxt Kit's `installModule` utility. For example, if you wanted to use Nuxt Tailwind in your module, you could add it as below:
 
 ```ts
 import { defineNuxtModule, createResolver, installModule } from '@nuxt/kit'
@@ -422,7 +422,7 @@ export default defineNuxtModule<ModuleOptions>({
   async setup (options, nuxt) {
     const { resolve } = createResolver(import.meta.url)
 
-    // We can inject our css file which includes tailwind's directives
+    // We can inject our CSS file which includes Tailwind's directives
     nuxt.options.css.push(resolve('./runtime/assets/styles.css'))
 
     await installModule('@nuxtjs/tailwindcss', {
@@ -434,7 +434,7 @@ export default defineNuxtModule<ModuleOptions>({
           files: [
             resolve('./runtime/components/**/*.{vue,mjs,ts}'),
             resolve('./runtime/*.{mjs,js,ts}')
-          ],
+          ]
         }
       }
     })

--- a/docs/2.guide/3.going-further/3.modules.md
+++ b/docs/2.guide/3.going-further/3.modules.md
@@ -419,7 +419,7 @@ If your module depends on other modules, you can add them by using `installModul
 import { defineNuxtModule, createResolver, installModule } from '@nuxt/kit'
 
 export default defineNuxtModule<ModuleOptions>({  
-  setup (options, nuxt) {
+  async setup (options, nuxt) {
     const { resolve } = createResolver(import.meta.url)
 
     // We can inject our css file which includes tailwind's directives

--- a/docs/2.guide/3.going-further/3.modules.md
+++ b/docs/2.guide/3.going-further/3.modules.md
@@ -392,7 +392,9 @@ export default defineNuxtModule({
 ```
 
 #### Using other modules in your module
+
 If your module depends on other modules, you can add them by using `installModule`. For example, suppose you want to use `tailwindcss` framework in your module, you can add it as below:
+
 ```js
 import { defineNuxtModule, createResolver, installModule } from '@nuxt/kit'
 


### PR DESCRIPTION
I have searched for this guide for three days but couldn't find it. Even I opened a discussion (#22020) but haven't received an answer. Finally, I have just discovered how to do it, and I think it is worth documenting.