### PR TITLE
fix(nuxt): add pages in correct hook when generating

### DIFF
--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -205,22 +205,20 @@ export default defineNuxtModule({
       if (nuxt.options.dev || !nitro.options.static) { return }
       // Prerender all non-dynamic page routes when generating app
       const prerenderRoutes = new Set<string>()
-      nuxt.hook('modules:done', () => {
-        nuxt.hook('pages:extend', (pages) => {
-          prerenderRoutes.clear()
-          const processPages = (pages: NuxtPage[], currentPath = '/') => {
-            for (const page of pages) {
-              // Add root of optional dynamic paths and catchalls
-              if (OPTIONAL_PARAM_RE.test(page.path) && !page.children?.length) { prerenderRoutes.add(currentPath) }
-              // Skip dynamic paths
-              if (page.path.includes(':')) { continue }
-              const route = joinURL(currentPath, page.path)
-              prerenderRoutes.add(route)
-              if (page.children) { processPages(page.children, route) }
-            }
+      nuxt.hook('pages:extend', (pages) => {
+        prerenderRoutes.clear()
+        const processPages = (pages: NuxtPage[], currentPath = '/') => {
+          for (const page of pages) {
+            // Add root of optional dynamic paths and catchalls
+            if (OPTIONAL_PARAM_RE.test(page.path) && !page.children?.length) { prerenderRoutes.add(currentPath) }
+            // Skip dynamic paths
+            if (page.path.includes(':')) { continue }
+            const route = joinURL(currentPath, page.path)
+            prerenderRoutes.add(route)
+            if (page.children) { processPages(page.children, route) }
           }
-          processPages(pages)
-        })
+        }
+        processPages(pages)
       })
       nuxt.hook('nitro:build:before', (nitro) => {
         for (const route of nitro.options.prerender.routes || []) {


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/22072

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When updating Nuxt to use new Nitro static flag, we kept the existing `modules:done` hook, which had already been called at this point, meaning page-produced routes were never added to prerender routes.

This updates the logic so they will be correctly added when generating, either with `nuxi build --prerender` or `nuxi generate`.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
