### PR TITLE
fix(test-utils): export from core playwright package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,8 +214,7 @@ jobs:
             ${{ runner.os }}-playwright-bin-v1-
 
       - name: Install Playwright
-        # does not need to explicitly set chromium after https://github.com/microsoft/playwright/issues/14862 is solved
-        run: pnpm playwright install chromium
+        run: pnpm playwright-core install chromium
 
       - name: Restore dist cache
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "nuxt-vitest": "0.8.7",
     "ofetch": "1.1.1",
     "pathe": "1.1.1",
-    "playwright": "1.35.1",
+    "playwright-core": "1.35.1",
     "rimraf": "5.0.1",
     "semver": "7.5.3",
     "std-env": "3.3.3",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -40,7 +40,7 @@
   },
   "peerDependencies": {
     "@jest/globals": "^29.5.0",
-    "playwright": "^1.34.3",
+    "playwright-core": "^1.34.3",
     "vitest": "^0.30.0 || ^0.31.0 || ^0.32.0 || ^0.33.0",
     "vue": "^3.3.4"
   },
@@ -48,7 +48,7 @@
     "@jest/globals": {
       "optional": true
     },
-    "playwright": {
+    "playwright-core": {
       "optional": true
     },
     "vitest": {

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@jest/globals": "29.6.0",
-    "playwright": "1.35.1",
+    "playwright-core": "1.35.1",
     "unbuild": "latest",
     "vitest": "0.33.0"
   },

--- a/packages/test-utils/src/browser.ts
+++ b/packages/test-utils/src/browser.ts
@@ -1,20 +1,20 @@
-import type { Browser, BrowserContextOptions } from 'playwright'
+import type { Browser, BrowserContextOptions } from 'playwright-core'
 import { useTestContext } from './context'
 import { url } from './server'
 
 export async function createBrowser () {
   const ctx = useTestContext()
 
-  let playwright: typeof import('playwright')
+  let playwright: typeof import('playwright-core')
   try {
     // Workaround for https://github.com/nuxt/nuxt/issues/13441
     // TODO: Remove when upstream issue resolved
-    playwright = await import(String('playwright'))
+    playwright = await import(String('playwright-core'))
   } catch {
     /* istanbul ignore next */
     throw new Error(`
-      The dependency 'playwright' not found.
-      Please run 'yarn add --dev playwright' or 'npm install --save-dev playwright'
+      The dependency 'playwright-core' not found.
+      Please run 'yarn add --dev playwright-core' or 'npm install --save-dev playwright-core'
     `)
   }
 

--- a/packages/test-utils/src/types.ts
+++ b/packages/test-utils/src/types.ts
@@ -1,6 +1,6 @@
 import type { Nuxt, NuxtConfig } from '@nuxt/schema'
 import type { ExecaChildProcess } from 'execa'
-import type { Browser, LaunchOptions } from 'playwright'
+import type { Browser, LaunchOptions } from 'playwright-core'
 
 export type TestRunner = 'vitest' | 'jest'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,7 +107,7 @@ importers:
       pathe:
         specifier: 1.1.1
         version: 1.1.1
-      playwright:
+      playwright-core:
         specifier: 1.35.1
         version: 1.35.1
       rimraf:
@@ -636,6 +636,9 @@ importers:
       pathe:
         specifier: ^1.1.1
         version: 1.1.1
+      playwright:
+        specifier: ^1.34.3
+        version: 1.35.1
       ufo:
         specifier: ^1.1.2
         version: 1.1.2
@@ -646,7 +649,7 @@ importers:
       '@jest/globals':
         specifier: 29.6.0
         version: 29.6.0
-      playwright:
+      playwright-core:
         specifier: 1.35.1
         version: 1.35.1
       unbuild:
@@ -7147,7 +7150,6 @@ packages:
     resolution: {integrity: sha512-pNXb6CQ7OqmGDRspEjlxE49w+4YtR6a3X6mT1hZXeJHWmsEz7SunmvZeiG/+y1yyMZdHnnn73WKYdtV1er0Xyg==}
     engines: {node: '>=16'}
     hasBin: true
-    dev: true
 
   /playwright@1.35.1:
     resolution: {integrity: sha512-NbwBeGJLu5m7VGM0+xtlmLAH9VUfWwYOhUi/lSEDyGg46r1CA9RWlvoc5yywxR9AzQb0mOCm7bWtOXV7/w43ZA==}
@@ -7156,7 +7158,6 @@ packages:
     requiresBuild: true
     dependencies:
       playwright-core: 1.35.1
-    dev: true
 
   /pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,7 +130,7 @@ importers:
         version: 4.3.9(@types/node@18.16.19)
       vitest:
         specifier: 0.33.0
-        version: 0.33.0(playwright@1.35.1)
+        version: 0.33.0
       vitest-environment-nuxt:
         specifier: 0.8.7
         version: 0.8.7(vitest@0.33.0)(vue-router@4.2.4)(vue@3.3.4)
@@ -224,7 +224,7 @@ importers:
         version: 4.3.9(@types/node@18.16.19)
       vitest:
         specifier: 0.33.0
-        version: 0.33.0(playwright@1.35.1)
+        version: 0.33.0
       webpack:
         specifier: 5.88.1
         version: 5.88.1
@@ -514,7 +514,7 @@ importers:
         version: 4.3.9(@types/node@18.16.19)
       vitest:
         specifier: 0.33.0
-        version: 0.33.0(playwright@1.35.1)
+        version: 0.33.0
 
   packages/schema:
     dependencies:
@@ -636,9 +636,6 @@ importers:
       pathe:
         specifier: ^1.1.1
         version: 1.1.1
-      playwright:
-        specifier: ^1.34.3
-        version: 1.35.1
       ufo:
         specifier: ^1.1.2
         version: 1.1.2
@@ -657,7 +654,7 @@ importers:
         version: 1.2.1
       vitest:
         specifier: 0.33.0
-        version: 0.33.0(playwright@1.35.1)
+        version: 0.33.0
 
   packages/vite:
     dependencies:
@@ -979,7 +976,7 @@ importers:
         version: 1.1.1
       vitest:
         specifier: latest
-        version: 0.33.0(playwright@1.35.1)
+        version: 0.33.0
       vue:
         specifier: 3.3.4
         version: 3.3.4
@@ -6863,7 +6860,7 @@ packages:
       perfect-debounce: 1.0.0
       std-env: 3.3.3
       vite: 4.3.9(@types/node@18.16.19)
-      vitest: 0.33.0(playwright@1.35.1)
+      vitest: 0.33.0
       vitest-environment-nuxt: 0.8.7(vitest@0.33.0)(vue-router@4.2.4)(vue@3.3.4)
     transitivePeerDependencies:
       - '@vue/compiler-dom'
@@ -7150,14 +7147,7 @@ packages:
     resolution: {integrity: sha512-pNXb6CQ7OqmGDRspEjlxE49w+4YtR6a3X6mT1hZXeJHWmsEz7SunmvZeiG/+y1yyMZdHnnn73WKYdtV1er0Xyg==}
     engines: {node: '>=16'}
     hasBin: true
-
-  /playwright@1.35.1:
-    resolution: {integrity: sha512-NbwBeGJLu5m7VGM0+xtlmLAH9VUfWwYOhUi/lSEDyGg46r1CA9RWlvoc5yywxR9AzQb0mOCm7bWtOXV7/w43ZA==}
-    engines: {node: '>=16'}
-    hasBin: true
-    requiresBuild: true
-    dependencies:
-      playwright-core: 1.35.1
+    dev: true
 
   /pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
@@ -8979,7 +8969,7 @@ packages:
       magic-string: 0.30.1
       ofetch: 1.1.1
       unenv: 1.5.1
-      vitest: 0.33.0(playwright@1.35.1)
+      vitest: 0.33.0
       vue: 3.3.4
       vue-router: 4.2.4(vue@3.3.4)
     transitivePeerDependencies:
@@ -8987,7 +8977,7 @@ packages:
       - '@vue/server-renderer'
     dev: true
 
-  /vitest@0.33.0(playwright@1.35.1):
+  /vitest@0.33.0:
     resolution: {integrity: sha512-1CxaugJ50xskkQ0e969R/hW47za4YXDUfWJDxip1hwbnhUjYolpfUn2AMOulqG/Dtd9WYAtkHmM/m3yKVrEejQ==}
     engines: {node: '>=v14.18.0'}
     hasBin: true
@@ -9035,7 +9025,6 @@ packages:
       magic-string: 0.30.1
       pathe: 1.1.1
       picocolors: 1.0.0
-      playwright: 1.35.1
       std-env: 3.3.3
       strip-literal: 1.0.1
       tinybench: 2.5.0

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,6 +1,6 @@
 import { Script, createContext } from 'node:vm'
 import { expect } from 'vitest'
-import type { Page } from 'playwright'
+import type { Page } from 'playwright-core'
 import { parse } from 'devalue'
 import { reactive, ref, shallowReactive, shallowRef } from 'vue'
 import { createError } from 'h3'


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Playwright recently deprecated having both `playwright` and `@playwright/test` installed, which means that users with just `@playwright/test` dependency - who _cannot_ install `playwright` any more - nuxt test utils will fail to work.

Instead, we can import the core (browserless) playwright implementation from `playwright-core`.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
