### PR TITLE
docs: fix typos

### DIFF
--- a/docs/2.guide/1.concepts/3.rendering.md
+++ b/docs/2.guide/1.concepts/3.rendering.md
@@ -1,5 +1,5 @@
 ---
-description: "Nuxt supports different rendering modes, univeral rendering, client-side rendering but also offers hybrid-rendering and the possibility to render on CDN Edge Servers."
+description: "Nuxt supports different rendering modes, universal rendering, client-side rendering but also offers hybrid-rendering and the possibility to render on CDN Edge Servers."
 ---
 
 # Rendering Modes

--- a/docs/2.guide/3.going-further/3.modules.md
+++ b/docs/2.guide/3.going-further/3.modules.md
@@ -280,7 +280,7 @@ export default defineNuxtModule({
 })
 ```
 
-Note that we use [`defu`](https://github.com/unjs/defu) to extend the public runtime configuration the user can provides instead of overwritting it.
+Note that we use [`defu`](https://github.com/unjs/defu) to extend the public runtime configuration the user can provides instead of overwriting it.
 
 You can then access your module options in a plugin, component, the application like any other runtime configuration:
 

--- a/docs/6.bridge/1.overview.md
+++ b/docs/6.bridge/1.overview.md
@@ -144,7 +144,7 @@ You may also need to add `@vue/runtime-dom` as a devDependency if you are strugg
 Keep in mind that all options extended from `./.nuxt/tsconfig.json` will be overwritten by the options defined in your `tsconfig.json`.
 Overwriting options such as `"compilerOptions.paths"` with your own configuration will lead TypeScript to not factor in the module resolutions from `./.nuxt/tsconfig.json`. This can lead to module resolutions such as `#imports` not being recognized.
 
-In case you need to extend options provided by `./.nuxt/tsconfig.json` further, you can use the `alias` property withing your `nuxt.config`. `nuxi` will pick them up and extend `./.nuxt/tsconfig.json` accordingly.
+In case you need to extend options provided by `./.nuxt/tsconfig.json` further, you can use the `alias` property within your `nuxt.config`. `nuxi` will pick them up and extend `./.nuxt/tsconfig.json` accordingly.
 ::
 
 ## Update Runtime Config


### PR DESCRIPTION
Hey :wave:,

This PR will fix :

1 typo in `docs/2.guide/1.concepts/3.rendering.md`
1 typo in `docs/2.guide/3.going-further/3.modules.md`
1 typo in `docs/6.bridge/1.overview.md`


Best!