### PR TITLE
refactor(cli,schema): add `bundler` module resolution flag

### DIFF
--- a/packages/nuxi/src/utils/prepare.ts
+++ b/packages/nuxi/src/utils/prepare.ts
@@ -14,9 +14,9 @@ export const writeTypes = async (nuxt: Nuxt) => {
       jsx: 'preserve',
       target: 'ESNext',
       module: 'ESNext',
-      moduleResolution: 'Node',
+      moduleResolution: nuxt.options.experimental.typescriptBundlerResolution ? 'Bundler' : 'Node',
       skipLibCheck: true,
-      strict: nuxt.options.typescript?.strict ?? false,
+      strict: nuxt.options.typescript?.strict ?? true,
       allowJs: true,
       // TODO: remove by default in 3.7
       baseUrl: nuxt.options.srcDir,

--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -37,6 +37,7 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
     console.warn(`[nuxt] Could not load custom \`spaLoadingTemplate\` path as it does not exist: \`${spaLoadingTemplate}\`.`)
   }
 
+  // @ts-expect-error `typescriptBundlerResolution` coming in next nitro version
   const nitroConfig: NitroConfig = defu(_nitroConfig, {
     debug: nuxt.options.debug,
     rootDir: nuxt.options.rootDir,
@@ -44,6 +45,10 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
     srcDir: nuxt.options.serverDir,
     dev: nuxt.options.dev,
     buildDir: nuxt.options.buildDir,
+    experimental: {
+      // @ts-expect-error `typescriptBundlerResolution` coming in next nitro version
+      typescriptBundlerResolution: nuxt.options.experimental.typescriptBundlerResolution
+    },
     imports: {
       autoImport: nuxt.options.imports.autoImport as boolean,
       imports: [

--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -47,7 +47,7 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
     buildDir: nuxt.options.buildDir,
     experimental: {
       // @ts-expect-error `typescriptBundlerResolution` coming in next nitro version
-      typescriptBundlerResolution: nuxt.options.experimental.typescriptBundlerResolution
+      typescriptBundlerResolution: nuxt.options.experimental.typescriptBundlerResolution || nuxt.options.typescript?.tsConfig?.compilerOptions?.moduleResolution?.toLowercase() === 'bundler' || _nitroConfig.typescript?.tsConfig?.compilerOptions?.moduleResolution?.toLowercase() === 'bundler'
     },
     imports: {
       autoImport: nuxt.options.imports.autoImport as boolean,

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -157,7 +157,16 @@ export default defineUntypedSchema({
      *
      * See https://github.com/microsoft/TypeScript/pull/51669
      */
-    typescriptBundlerResolution: false,
+    typescriptBundlerResolution: {
+      async $resolve (val, get) {
+        if (typeof val === 'boolean') { return val }
+        const setting = await get('typescript.tsConfig.compilerOptions.moduleResolution')
+        if (setting) {
+          return setting.toLowerCase() === 'bundler'
+        }
+        return false
+      }
+    },
 
     /**
      * Whether or not to add a compatibility layer for modules, plugins or user code relying on the old

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -12,8 +12,8 @@ export default defineUntypedSchema({
     /**
      * Enable Vue's reactivity transform
      * @see https://vuejs.org/guide/extras/reactivity-transform.html
-     * 
-     * Warning: Reactivity transform feature has been marked as deprecated in Vue 3.3 and is planned to be 
+     *
+     * Warning: Reactivity transform feature has been marked as deprecated in Vue 3.3 and is planned to be
      * removed from core in Vue 3.4.
      * @see https://github.com/vuejs/rfcs/discussions/369#discussioncomment-5059028
      */
@@ -107,7 +107,7 @@ export default defineUntypedSchema({
 
     /**
      * When this option is enabled (by default) payload of pages generated with `nuxt generate` are extracted
-     * 
+     *
      * @type {boolean | undefined}
      */
     payloadExtraction: undefined,
@@ -146,6 +146,18 @@ export default defineUntypedSchema({
      * @see https://github.com/nuxt/nuxt/issues/15592
      */
     configSchema: true,
+
+    /**
+     * This enables 'Bundler' module resolution mode for TypeScript, which is the recommended setting
+     * for frameworks like Nuxt and Vite.
+     *
+     * It improves type support when using modern libraries with `exports`.
+     *
+     * This is only not enabled by default because it could be a breaking change for some projects.
+     *
+     * See https://github.com/microsoft/TypeScript/pull/51669
+     */
+    typescriptBundlerResolution: false,
 
     /**
      * Whether or not to add a compatibility layer for modules, plugins or user code relying on the old

--- a/packages/schema/src/config/typescript.ts
+++ b/packages/schema/src/config/typescript.ts
@@ -46,7 +46,7 @@ export default defineUntypedSchema({
 
     /**
      * You can extend generated `.nuxt/tsconfig.json` using this option.
-     * @type {typeof import('pkg-types')['readPackageJSON']}
+     * @type {typeof import('pkg-types')['TSConfig']}
      */
     tsConfig: {},
 

--- a/test/fixtures/basic-types/nuxt.config.ts
+++ b/test/fixtures/basic-types/nuxt.config.ts
@@ -2,15 +2,8 @@ import { addTypeTemplate } from 'nuxt/kit'
 
 export default defineNuxtConfig({
   experimental: {
-    typedPages: true
-  },
-  typescript: {
-    strict: true,
-    tsConfig: {
-      compilerOptions: {
-        moduleResolution: process.env.MODULE_RESOLUTION
-      }
-    }
+    typedPages: true,
+    typescriptBundlerResolution: process.env.MODULE_RESOLUTION === 'bundler'
   },
   buildDir: process.env.NITRO_BUILD_DIR,
   builder: process.env.TEST_BUILDER as 'webpack' | 'vite' ?? 'vite',


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/unjs/nitro/pull/1384, https://github.com/nuxt/nuxt/pull/20629, 

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds a corresponding 'bundler' module resolution option for nuxt, which also sets the nitro option by default.

**This is now the recommended setting.** New projects are recommended to start with this turned on, and in a future minor release of Nuxt it will become the default setting.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
