### PR TITLE
fix(nuxt): resolve race condition regenerating auto imports

### DIFF
--- a/packages/nuxt/src/imports/module.ts
+++ b/packages/nuxt/src/imports/module.ts
@@ -87,9 +87,10 @@ export default defineNuxtModule<Partial<ImportsOptions>>({
     const priorities = nuxt.options._layers.map((layer, i) => [layer.config.srcDir, -i] as const).sort(([a], [b]) => b.length - a.length)
 
     const regenerateImports = async () => {
-      ctx.clearDynamicImports()
       await ctx.modifyDynamicImports(async (imports) => {
-        // Scan composables/
+        // clear old imports
+        imports.length = 0
+        // Scan `composables/`
         const composableImports = await scanDirExports(composablesDirs)
         for (const i of composableImports) {
           i.priority = i.priority || priorities.find(([dir]) => i.from.startsWith(dir))?.[1]
@@ -97,6 +98,7 @@ export default defineNuxtModule<Partial<ImportsOptions>>({
         imports.push(...composableImports)
         // Modules extending
         await nuxt.callHook('imports:extend', imports)
+        return imports
       })
     }
 

--- a/packages/nuxt/src/imports/module.ts
+++ b/packages/nuxt/src/imports/module.ts
@@ -88,7 +88,7 @@ export default defineNuxtModule<Partial<ImportsOptions>>({
 
     const regenerateImports = async () => {
       await ctx.modifyDynamicImports(async (imports) => {
-        // clear old imports
+        // Clear old imports
         imports.length = 0
         // Scan `composables/`
         const composableImports = await scanDirExports(composablesDirs)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

fix #22195
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This was because we cleared the registered imports first, while the regeneration is async. Causing the registry to miss those imports when new requests coming in between.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
