### PR TITLE
perf(nuxt,schema): do not watch `buildDir` and `node_modules`

### DIFF
--- a/packages/nuxt/src/components/module.ts
+++ b/packages/nuxt/src/components/module.ts
@@ -98,7 +98,7 @@ export default defineNuxtModule<ComponentsOptions>({
           pattern: dirOptions.pattern || `**/*.{${extensions.join(',')},}`,
           ignore: [
             '**/*{M,.m,-m}ixin.{js,ts,jsx,tsx}', // ignore mixins
-            '**/*.d.ts', // .d.ts files
+            '**/*.d.{cts,mts,ts}', // .d.ts files
             ...(dirOptions.ignore || [])
           ],
           transpile: (transpile === 'auto' ? dirPath.includes('node_modules') : transpile)

--- a/packages/nuxt/src/components/transform.ts
+++ b/packages/nuxt/src/components/transform.ts
@@ -1,10 +1,10 @@
-import { isIgnored } from '@nuxt/kit'
 import type { Nuxt } from 'nuxt/schema'
 import type { Import } from 'unimport'
 import { createUnimport } from 'unimport'
 import { createUnplugin } from 'unplugin'
 import { parseURL } from 'ufo'
 import { parseQuery } from 'vue-router'
+import { isJS, isVue } from '../core/utils'
 import type { getComponentsT } from './module'
 
 const COMPONENT_QUERY_RE = /[?&]nuxt_component=/
@@ -45,7 +45,7 @@ export function createTransformPlugin (nuxt: Nuxt, getComponents: getComponentsT
   return createUnplugin(() => ({
     name: 'nuxt:components:imports',
     transformInclude (id) {
-      return !isIgnored(id)
+      return isVue(id) || isJS(id)
     },
     async transform (code, id) {
       // Virtual component wrapper

--- a/packages/nuxt/src/components/transform.ts
+++ b/packages/nuxt/src/components/transform.ts
@@ -5,6 +5,7 @@ import { createUnimport } from 'unimport'
 import { createUnplugin } from 'unplugin'
 import { parseURL } from 'ufo'
 import { parseQuery } from 'vue-router'
+import { normalize } from 'pathe'
 import type { getComponentsT } from './module'
 
 const COMPONENT_QUERY_RE = /[?&]nuxt_component=/
@@ -45,7 +46,7 @@ export function createTransformPlugin (nuxt: Nuxt, getComponents: getComponentsT
   return createUnplugin(() => ({
     name: 'nuxt:components:imports',
     transformInclude (id) {
-      return !isIgnored(id) || id.includes(nuxt.options.buildDir)
+      return !isIgnored(id) || normalize(id).startsWith(nuxt.options.buildDir)
     },
     async transform (code, id) {
       // Virtual component wrapper

--- a/packages/nuxt/src/components/transform.ts
+++ b/packages/nuxt/src/components/transform.ts
@@ -1,10 +1,10 @@
+import { isIgnored } from '@nuxt/kit'
 import type { Nuxt } from 'nuxt/schema'
 import type { Import } from 'unimport'
 import { createUnimport } from 'unimport'
 import { createUnplugin } from 'unplugin'
 import { parseURL } from 'ufo'
 import { parseQuery } from 'vue-router'
-import { isJS, isVue } from '../core/utils'
 import type { getComponentsT } from './module'
 
 const COMPONENT_QUERY_RE = /[?&]nuxt_component=/
@@ -45,7 +45,7 @@ export function createTransformPlugin (nuxt: Nuxt, getComponents: getComponentsT
   return createUnplugin(() => ({
     name: 'nuxt:components:imports',
     transformInclude (id) {
-      return isVue(id) || isJS(id)
+      return !isIgnored(id) || id.includes(nuxt.options.buildDir)
     },
     async transform (code, id) {
       // Virtual component wrapper

--- a/packages/nuxt/src/components/transform.ts
+++ b/packages/nuxt/src/components/transform.ts
@@ -46,7 +46,8 @@ export function createTransformPlugin (nuxt: Nuxt, getComponents: getComponentsT
   return createUnplugin(() => ({
     name: 'nuxt:components:imports',
     transformInclude (id) {
-      return !isIgnored(id) || normalize(id).startsWith(nuxt.options.buildDir)
+      id = normalize(id)
+      return id.startsWith('virtual:') || id.startsWith(nuxt.options.buildDir) || !isIgnored(id)
     },
     async transform (code, id) {
       // Virtual component wrapper

--- a/packages/nuxt/src/core/builder.ts
+++ b/packages/nuxt/src/core/builder.ts
@@ -76,7 +76,6 @@ function createWatcher () {
     ignoreInitial: true,
     ignored: [
       isIgnored,
-      '.nuxt',
       'node_modules'
     ]
   })

--- a/packages/nuxt/src/core/builder.ts
+++ b/packages/nuxt/src/core/builder.ts
@@ -103,7 +103,7 @@ function createGranularWatcher () {
   }
   for (const dir of pathsToWatch) {
     pending++
-    const watcher = chokidar.watch(dir, { ...nuxt.options.watchers.chokidar, ignoreInitial: false, depth: 0, ignored: [isIgnored] })
+    const watcher = chokidar.watch(dir, { ...nuxt.options.watchers.chokidar, ignoreInitial: false, depth: 0, ignored: [isIgnored, '**/node_modules'] })
     const watchers: Record<string, FSWatcher> = {}
 
     watcher.on('all', (event, path) => {

--- a/packages/nuxt/src/core/builder.ts
+++ b/packages/nuxt/src/core/builder.ts
@@ -81,7 +81,7 @@ function createWatcher () {
   })
 
   watcher.on('all', (event, path) => nuxt.callHook('builder:watch', event, normalize(path)))
-  nuxt.hook('close', () => watcher.close())
+  nuxt.hook('close', () => watcher?.close())
 }
 
 function createGranularWatcher () {
@@ -112,13 +112,13 @@ function createGranularWatcher () {
         nuxt.callHook('builder:watch', event, path)
       }
       if (event === 'unlinkDir' && path in watchers) {
-        watchers[path].close()
+        watchers[path]?.close()
         delete watchers[path]
       }
       if (event === 'addDir' && path !== dir && !ignoredDirs.has(path) && !pathsToWatch.includes(path) && !(path in watchers) && !isIgnored(path)) {
         watchers[path] = chokidar.watch(path, { ...nuxt.options.watchers.chokidar, ignored: [isIgnored] })
         watchers[path].on('all', (event, path) => nuxt.callHook('builder:watch', event, normalize(path)))
-        nuxt.hook('close', () => watchers[path].close())
+        nuxt.hook('close', () => watchers[path]?.close())
       }
     })
     watcher.on('ready', () => {

--- a/packages/nuxt/src/core/builder.ts
+++ b/packages/nuxt/src/core/builder.ts
@@ -149,7 +149,6 @@ async function createParcelWatcher () {
       }, {
         ignore: [
           ...nuxt.options.ignore,
-          '.nuxt',
           'node_modules'
         ]
       })

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -355,9 +355,9 @@ export default defineUntypedSchema({
       '**/*.stories.{js,ts,jsx,tsx}', // ignore storybook files
       '**/*.{spec,test}.{js,ts,jsx,tsx}', // ignore tests
       '**/*.d.ts', // ignore type declarations
-      '.output',
-      '.git',
-      '.cache',
+      '**/.output',
+      '**/.git',
+      '**/.cache',
       relative(await get('rootDir'), await get('analyzeDir')),
       relative(await get('rootDir'), await get('buildDir')),
       await get('ignorePrefix') && `**/${await get('ignorePrefix')}*.*`

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -352,15 +352,11 @@ export default defineUntypedSchema({
    */
   ignore: {
     $resolve: async (val, get) => [
-      '**/*.stories.{js,ts,jsx,tsx}', // ignore storybook files
-      '**/*.{spec,test}.{js,ts,jsx,tsx}', // ignore tests
-      '**/*.d.ts', // ignore type declarations
+      '**/*.stories.{js,cts,mts,ts,jsx,tsx}', // ignore storybook files
+      '**/*.{spec,test}.{js,cts,mts,ts,jsx,tsx}', // ignore tests
+      '**/*.d.{cts,mts,ts}', // ignore type declarations
+      '**/.{vercel,netlify,output,git,cache}',
       '**/dist',
-      '**/.vercel',
-      '**/.netlify',
-      '**/.output',
-      '**/.git',
-      '**/.cache',
       relative(await get('rootDir'), await get('analyzeDir')),
       relative(await get('rootDir'), await get('buildDir')),
       await get('ignorePrefix') && `**/${await get('ignorePrefix')}*.*`

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -355,7 +355,7 @@ export default defineUntypedSchema({
       '**/*.stories.{js,cts,mts,ts,jsx,tsx}', // ignore storybook files
       '**/*.{spec,test}.{js,cts,mts,ts,jsx,tsx}', // ignore tests
       '**/*.d.{cts,mts,ts}', // ignore type declarations
-      '**/.{vercel,netlify,output,git,cache}',
+      '**/.{vercel,netlify,output,git,cache,data}',
       '**/dist',
       relative(await get('rootDir'), await get('analyzeDir')),
       relative(await get('rootDir'), await get('buildDir')),

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -355,6 +355,9 @@ export default defineUntypedSchema({
       '**/*.stories.{js,ts,jsx,tsx}', // ignore storybook files
       '**/*.{spec,test}.{js,ts,jsx,tsx}', // ignore tests
       '**/*.d.ts', // ignore type declarations
+      '**/dist',
+      '**/.vercel',
+      '**/.netlify',
       '**/.output',
       '**/.git',
       '**/.cache',

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -1,5 +1,5 @@
 import { defineUntypedSchema } from 'untyped'
-import { join, resolve } from 'pathe'
+import { join, relative, resolve } from 'pathe'
 import { isDebug, isDevelopment } from 'std-env'
 import { defu } from 'defu'
 import { findWorkspaceDir } from 'pkg-types'
@@ -358,8 +358,8 @@ export default defineUntypedSchema({
       '.output',
       '.git',
       '.cache',
-      await get('analyzeDir'),
-      await get('buildDir'),
+      relative(await get('rootDir'), await get('analyzeDir')),
+      relative(await get('rootDir'), await get('buildDir')),
       await get('ignorePrefix') && `**/${await get('ignorePrefix')}*.*`
     ].concat(val).filter(Boolean)
   },

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,6 +1,7 @@
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
 import fs from 'fs-extra'
+import { execaCommand } from 'execa'
 
 const dir = dirname(fileURLToPath(import.meta.url))
 const fixtureDir = join(dir, 'fixtures')
@@ -13,6 +14,7 @@ export async function setup () {
   await fs.copy(fixtureDir, tempDir, {
     filter: src => !src.includes('.nuxt') && !src.includes('.cache')
   })
+  await execaCommand(`pnpm nuxi prepare ${tempDir}`)
 }
 
 export async function teardown () {

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -10,7 +10,9 @@ export async function setup () {
   if (fs.existsSync(tempDir)) {
     await fs.remove(tempDir)
   }
-  await fs.copy(fixtureDir, tempDir)
+  await fs.copy(fixtureDir, tempDir, {
+    filter: src => !src.includes('.nuxt') && !src.includes('.cache')
+  })
 }
 
 export async function teardown () {

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,7 +1,6 @@
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
 import fs from 'fs-extra'
-import { execaCommand } from 'execa'
 
 const dir = dirname(fileURLToPath(import.meta.url))
 const fixtureDir = join(dir, 'fixtures')
@@ -12,9 +11,8 @@ export async function setup () {
     await fs.remove(tempDir)
   }
   await fs.copy(fixtureDir, tempDir, {
-    filter: src => !src.includes('.nuxt') && !src.includes('.cache')
+    filter: src => !src.includes('.cache')
   })
-  await execaCommand(`pnpm nuxi prepare ${tempDir}`)
 }
 
 export async function teardown () {


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/unjs/nitro/issues/1458, https://github.com/nuxt/nuxt/discussions/20213

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This follows up some earlier fixes to the watching implementation for Nuxt, which will particularly affect Linux and Windows machines. There are two issues fixed here as well as a third potential issue:

1. we were adding `.nuxt` and `.nuxt/analyze` in their absolute form which were ignored, meaning we were watching the build directory 😱
2. we were not ignoring `node_modules` within layers, only at the top level 😱
3. we have also added additional output directories like `.vercel`, `.netlify` and `dist`, as well as excluding `.output`, `.git` and `.cache` even when these are within subdirectories. (There has been no explicit report that this fixes, but I think it should be safe and improve performance.)

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
