### PR TITLE
fix(test-utils): pass along error if server can't start

### DIFF
--- a/packages/test-utils/src/server.ts
+++ b/packages/test-utils/src/server.ts
@@ -28,6 +28,7 @@ export async function startServer () {
       }
     })
     await waitForPort(port, { retries: 32 })
+    let lastError
     for (let i = 0; i < 50; i++) {
       await new Promise(resolve => setTimeout(resolve, 100))
       try {
@@ -35,10 +36,12 @@ export async function startServer () {
         if (!res.includes('__NUXT_LOADING__')) {
           return
         }
-      } catch {}
+      } catch (e) {
+        lastError = e
+      }
     }
     ctx.serverProcess.kill()
-    throw new Error('Timeout waiting for dev server!')
+    throw lastError || new Error('Timeout waiting for dev server!')
   } else {
     ctx.serverProcess = execa('node', [
       resolve(ctx.nuxt!.options.nitro.output!.dir!, 'server/index.mjs')


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

If there is an issue starting the dev server, I think it's useful to surface the underlying issue. In a recent PR (https://github.com/nuxt/nuxt/pull/22214) the issue was actually vite throwing an error rather than the server being not ready.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
