### PR TITLE
fix(nuxt): include all vue/js files in component transform

### DIFF
--- a/packages/nuxt/src/components/transform.ts
+++ b/packages/nuxt/src/components/transform.ts
@@ -44,16 +44,6 @@ export function createTransformPlugin (nuxt: Nuxt, getComponents: getComponentsT
 
   return createUnplugin(() => ({
     name: 'nuxt:components:imports',
-    enforce: 'post',
-    transformInclude (id) {
-      // Vue files
-      if (isVue(id, { type: ['script', 'template'] })) {
-        return true
-      }
-
-      // JavaScript files
-      return isJS(id)
-    },
     async transform (code, id) {
       // Virtual component wrapper
       if (COMPONENT_QUERY_RE.test(id)) {

--- a/packages/nuxt/src/components/transform.ts
+++ b/packages/nuxt/src/components/transform.ts
@@ -1,11 +1,10 @@
-import { isIgnored } from '@nuxt/kit'
 import type { Nuxt } from 'nuxt/schema'
 import type { Import } from 'unimport'
 import { createUnimport } from 'unimport'
 import { createUnplugin } from 'unplugin'
 import { parseURL } from 'ufo'
 import { parseQuery } from 'vue-router'
-import { normalize } from 'pathe'
+import { isJS, isVue } from '../core/utils'
 import type { getComponentsT } from './module'
 
 const COMPONENT_QUERY_RE = /[?&]nuxt_component=/
@@ -45,9 +44,15 @@ export function createTransformPlugin (nuxt: Nuxt, getComponents: getComponentsT
 
   return createUnplugin(() => ({
     name: 'nuxt:components:imports',
+    enforce: 'post',
     transformInclude (id) {
-      id = normalize(id)
-      return id.startsWith('virtual:') || id.startsWith(nuxt.options.buildDir) || !isIgnored(id)
+      // Vue files
+      if (isVue(id, { type: ['script', 'template'] })) {
+        return true
+      }
+
+      // JavaScript files
+      return isJS(id)
     },
     async transform (code, id) {
       // Virtual component wrapper

--- a/packages/nuxt/src/components/transform.ts
+++ b/packages/nuxt/src/components/transform.ts
@@ -4,7 +4,6 @@ import { createUnimport } from 'unimport'
 import { createUnplugin } from 'unplugin'
 import { parseURL } from 'ufo'
 import { parseQuery } from 'vue-router'
-import { isJS, isVue } from '../core/utils'
 import type { getComponentsT } from './module'
 
 const COMPONENT_QUERY_RE = /[?&]nuxt_component=/


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

By correcting our ignore list, we accidentally prevent files in node_modules from being transformed (such as in nuxt/content).

This is a hotfix to address the issue.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
