### PR TITLE
fix(nuxi): allow nuxt.config and module setup to use `process.dev`

### DIFF
--- a/packages/nuxi/src/utils/env.ts
+++ b/packages/nuxi/src/utils/env.ts
@@ -5,4 +5,5 @@ export const overrideEnv = (targetEnv: string) => {
   }
 
   process.env.NODE_ENV = targetEnv
+  process.dev = targetEnv === 'development'
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
-

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

To check whether Nuxt is running in development, you can use the `process.dev` flag. 

This works as expected at runtime. However, when using the same flag at build time, the result will be undefined (see https://stackblitz.com/edit/nuxt-starter-jev4hu?file=nuxt.config.ts).

The recommendation is to use `nuxt.options.dev`, but for consistency, we should override this environment variable when we set the `NODE_ENV` as well.

This isn't exactly a bug, just something that has just caught me out.


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
