### PR TITLE
fix(nuxt): access resolved `scrollBehaviorType`

### DIFF
--- a/packages/nuxt/src/pages/runtime/router.options.ts
+++ b/packages/nuxt/src/pages/runtime/router.options.ts
@@ -2,6 +2,7 @@ import type { RouteLocationNormalized, RouterScrollBehavior } from '#vue-router'
 import { nextTick } from 'vue'
 import type { RouterConfig } from 'nuxt/schema'
 import { useNuxtApp } from '#app/nuxt'
+import { useRouter } from '#app/composables/router'
 // @ts-expect-error virtual file
 import { appPageTransition as defaultPageTransition } from '#build/nuxt.config.mjs'
 
@@ -12,7 +13,8 @@ type ScrollPosition = Awaited<ReturnType<RouterScrollBehavior>>
 export default <RouterConfig> {
   scrollBehavior (to, from, savedPosition) {
     const nuxtApp = useNuxtApp()
-    const behavior = this.scrollBehaviorType ?? 'auto'
+    // @ts-expect-error untyped, nuxt-injected option
+    const behavior = useRouter().options?.scrollBehaviorType ?? 'auto'
 
     // By default when the returned position is falsy or an empty object, vue-router will retain the current scroll position
     // savedPosition is only available for popstate navigations (back button)


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/pull/21948
https://github.com/nuxt/ecosystem-ci/actions/runs/5618792731/job/15224930143

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We are accessing `this.scrollBehaviorType` but this is not accessible if the user has provided their own router config. Instead we can access it from the resolved router options.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
