### PR TITLE
fix(nuxt): bind `createClientOnly` render function to ctx

### DIFF
--- a/packages/nuxt/src/app/components/client-only.ts
+++ b/packages/nuxt/src/app/components/client-only.ts
@@ -34,7 +34,7 @@ export function createClientOnly<T extends ComponentOptions> (component: T) {
     // override the component render (non script setup component)
     clone.render = (ctx: any, ...args: any[]) => {
       if (ctx.mounted$) {
-        const res = component.render!(ctx, ...args)
+        const res = component.render?.bind(ctx)(ctx, ...args)
         return (res.children === null || typeof res.children === 'string')
           ? createElementVNode(res.type, res.props, res.children, res.patchFlag, res.dynamicProps, res.shapeFlag)
           : h(res)

--- a/test/fixtures/basic/components/client/Binding.client.ts
+++ b/test/fixtures/basic/components/client/Binding.client.ts
@@ -1,0 +1,11 @@
+export default defineComponent({
+  name: 'Foo',
+  methods: {
+    getMessage () {
+      return 'Hello world'
+    }
+  },
+  render () {
+    return h('div', {}, this.getMessage())
+  }
+})

--- a/test/fixtures/basic/pages/client-only-components.vue
+++ b/test/fixtures/basic/pages/client-only-components.vue
@@ -1,5 +1,6 @@
 <template>
   <div>
+    <ClientBinding />
     <ClientScript ref="clientScript" class="client-only-script" foo="bar" />
     <ClientSetupScript
       ref="clientSetupScript"


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
fix https://github.com/nuxt/nuxt/issues/22280
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Hi :wave: 
This PR bind the render function to the ctx so the render function can have an access to the option API methods
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
