### PR TITLE
feat(nuxt): add `strategy: parallel` option for asyncData

### DIFF
--- a/packages/nuxt/src/app/components/route-provider.ts
+++ b/packages/nuxt/src/app/components/route-provider.ts
@@ -62,7 +62,8 @@ export const RouteProvider = defineComponent({
 const ResolvePendingPromises = defineComponent({
   async setup () {
     const nuxtApp = useNuxtApp()
-    await Promise.all(Object.values(nuxtApp._asyncDataPromises).filter(p => p?.strategy !== 'lazy'))
+    const promises = Object.values(nuxtApp._asyncDataPromises).filter(p => p?.strategy !== 'lazy')
+    await (Promise.allSettled?.(promises) ?? Promise.all(promises).catch(() => {}))
   },
   render: () => null
 })

--- a/packages/nuxt/src/app/components/route-provider.ts
+++ b/packages/nuxt/src/app/components/route-provider.ts
@@ -2,6 +2,7 @@ import { defineComponent, h, nextTick, onMounted, provide, shallowReactive } fro
 import type { Ref, VNode } from 'vue'
 import type { RouteLocation, RouteLocationNormalizedLoaded } from '#vue-router'
 import { PageRouteSymbol } from '#app/components/injections'
+import { useNuxtApp } from '#app/nuxt'
 
 export const RouteProvider = defineComponent({
   name: 'RouteProvider',
@@ -50,10 +51,18 @@ export const RouteProvider = defineComponent({
     return () => {
       if (process.dev && process.client) {
         vnode = h(props.vnode, { ref: props.vnodeRef })
-        return vnode
+        return [vnode, h(ResolvePendingPromises)]
       }
 
-      return h(props.vnode, { ref: props.vnodeRef })
+      return [h(props.vnode, { ref: props.vnodeRef }), h(ResolvePendingPromises)]
     }
   }
+})
+
+const ResolvePendingPromises = defineComponent({
+  async setup () {
+    const nuxtApp = useNuxtApp()
+    await Promise.all(Object.values(nuxtApp._asyncDataPromises).filter(p => p?.strategy !== 'lazy'))
+  },
+  render: () => null
 })

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -215,7 +215,7 @@ export function useAsyncData<
         }
         delete nuxt._asyncDataPromises[key]
       })
-    nuxt._asyncDataPromises[key] = promise
+    nuxt._asyncDataPromises[key] = Object.assign(promise, { strategy: options.strategy })
     return nuxt._asyncDataPromises[key]
   }
 

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -31,6 +31,8 @@ export type KeyOfRes<Transform extends _Transform> = KeysOf<ReturnType<Transform
 
 export type MultiWatchSources = (WatchSource<unknown> | object)[]
 
+export type AsyncDataStrategy = 'lazy' | 'parallel' | 'blocking'
+
 export interface AsyncDataOptions<
   ResT,
   DataT = ResT,
@@ -40,7 +42,7 @@ export interface AsyncDataOptions<
   server?: boolean
   /** @deprecated Use strategy: 'lazy' */
   lazy?: boolean
-  strategy?: 'lazy' | 'parallel' | 'blocking'
+  strategy?: AsyncDataStrategy
   default?: () => DefaultT | Ref<DefaultT>
   transform?: _Transform<ResT, DataT>
   pick?: PickKeys

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -278,7 +278,7 @@ export function useAsyncData<
 
   // Allow directly awaiting on asyncData
   const asyncDataPromise = Promise.resolve(nuxt._asyncDataPromises[key]).then(() => asyncData) as AsyncData<ResT, DataE>
-  Object.assign(asyncDataPromise, asyncData)
+  Object.assign(options.strategy === 'blocking' ? asyncDataPromise : Promise.resolve(asyncData), asyncData)
 
   return asyncDataPromise as AsyncData<PickFrom<DataT, PickKeys>, DataE>
 }

--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -99,6 +99,7 @@ export function useFetch<
     pick,
     watch,
     immediate,
+    strategy,
     ...fetchOptions
   } = opts
 
@@ -110,6 +111,7 @@ export function useFetch<
   const _asyncDataOptions: AsyncDataOptions<_ResT, DataT, PickKeys, DefaultT> = {
     server,
     lazy,
+    strategy,
     default: defaultFn,
     transform,
     pick,
@@ -180,7 +182,7 @@ export function useLazyFetch<
 
   return useFetch<ResT, ErrorT, ReqT, Method, _ResT, DataT, PickKeys, DefaultT>(request, {
     ...opts,
-    lazy: true
+    strategy: 'lazy'
   },
   // @ts-expect-error we pass an extra argument with the resolved auto-key to prevent another from being injected
   autoKey)

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -14,7 +14,7 @@ import type { RenderResponse } from 'nitropack'
 import type { NuxtIslandContext } from '../core/runtime/nitro/renderer'
 import type { RouteMiddleware } from '../../app'
 import type { NuxtError } from '../app/composables/error'
-import type { AsyncDataRequestStatus } from '../app/composables/asyncData'
+import type { AsyncDataOptions, AsyncDataRequestStatus } from '../app/composables/asyncData'
 
 const nuxtAppCtx = /* #__PURE__ */ getContext<NuxtApp>('nuxt-app')
 
@@ -103,7 +103,7 @@ interface _NuxtApp {
   [key: string]: unknown
 
   /** @internal */
-  _asyncDataPromises: Record<string, Promise<any> & { strategy?: 'lazy' | 'blocking' | 'parallel' } | undefined>
+  _asyncDataPromises: Record<string, Promise<any> & { strategy?: AsyncDataOptions<any>['strategy'] } | undefined>
   /** @internal */
   _asyncData: Record<string, {
     data: Ref<any>

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -103,7 +103,7 @@ interface _NuxtApp {
   [key: string]: unknown
 
   /** @internal */
-  _asyncDataPromises: Record<string, Promise<any> | undefined>
+  _asyncDataPromises: Record<string, Promise<any> & { strategy?: 'lazy' | 'blocking' | 'parallel' } | undefined>
   /** @internal */
   _asyncData: Record<string, {
     data: Ref<any>

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -14,7 +14,7 @@ import type { RenderResponse } from 'nitropack'
 import type { NuxtIslandContext } from '../core/runtime/nitro/renderer'
 import type { RouteMiddleware } from '../../app'
 import type { NuxtError } from '../app/composables/error'
-import type { AsyncDataOptions, AsyncDataRequestStatus } from '../app/composables/asyncData'
+import type { AsyncDataRequestStatus, AsyncDataStrategy } from '../app/composables/asyncData'
 
 const nuxtAppCtx = /* #__PURE__ */ getContext<NuxtApp>('nuxt-app')
 
@@ -103,7 +103,7 @@ interface _NuxtApp {
   [key: string]: unknown
 
   /** @internal */
-  _asyncDataPromises: Record<string, Promise<any> & { strategy?: AsyncDataOptions<any>['strategy'] } | undefined>
+  _asyncDataPromises: Record<string, Promise<any> & { strategy?: AsyncDataStrategy } | undefined>
   /** @internal */
   _asyncData: Record<string, {
     data: Ref<any>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/12391

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds a new `strategy` option for useAsyncData + useFetch, which can be set to `blocking` (current default behaviour), `lazy` (same as `lazy: true` which I have deprecated in favour of explicit `strategy: lazy`) and a new `parallel` option, which will ensure the promise is resolved before changing the route, but allows it to be run in parallel with other data fetching requests.

In order for parallel strategy to work, the `useAsyncData` composable should not be awaited.

This PR also changes behaviour when `useAsyncData` with current default strategy is not awaited - it will ensure it is awaited before the route changes. I regard this as a bug fix.

**TODO**:

- [ ] add tests to cover new strategy/option

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
