### PR TITLE
feat(schema,vite): allow `$client` and `$server` vite env overrides

### DIFF
--- a/packages/schema/src/config/vite.ts
+++ b/packages/schema/src/config/vite.ts
@@ -10,7 +10,7 @@ export default defineUntypedSchema({
    * See https://vitejs.dev/config for more information.
    * Please note that not all vite options are supported in Nuxt.
    *
-   * @type {typeof import('../src/types/config').ViteConfig}
+   * @type {typeof import('../src/types/config').ViteConfig & { $client?: typeof import('../src/types/config').ViteConfig, $server?: typeof import('../src/types/config').ViteConfig }}
    */
   vite: {
     root: {

--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -20,7 +20,7 @@ import { viteNodePlugin } from './vite-node'
 import { createViteLogger } from './utils/logger'
 
 export async function buildClient (ctx: ViteBuildContext) {
-  const clientConfig: ViteConfig = vite.mergeConfig(ctx.config, {
+  const clientConfig: ViteConfig = vite.mergeConfig(ctx.config, vite.mergeConfig({
     configFile: false,
     base: ctx.nuxt.options.dev
       ? joinURL(ctx.nuxt.options.app.baseURL.replace(/^\.\//, '/') || '/', ctx.nuxt.options.app.buildAssetsDir)
@@ -82,7 +82,7 @@ export async function buildClient (ctx: ViteBuildContext) {
     server: {
       middlewareMode: true
     }
-  } satisfies vite.InlineConfig)
+  } satisfies vite.InlineConfig, ctx.nuxt.options.vite.$client || {}))
 
   clientConfig.customLogger = createViteLogger(clientConfig)
 

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -16,7 +16,7 @@ export async function buildServer (ctx: ViteBuildContext) {
   const helper = ctx.nuxt.options.nitro.imports !== false ? '' : 'globalThis.'
   const entry = ctx.nuxt.options.ssr ? ctx.entry : await resolvePath(resolve(ctx.nuxt.options.appDir, 'entry-spa'))
   const nitroDependencies = await tryResolveModule('nitropack/package.json', ctx.nuxt.options.modulesDir).then(r => import(r!)).then(r => Object.keys(r.dependencies || {})).catch(() => [])
-  const serverConfig: ViteConfig = vite.mergeConfig(ctx.config, {
+  const serverConfig: ViteConfig = vite.mergeConfig(ctx.config, vite.mergeConfig({
     configFile: false,
     base: ctx.nuxt.options.dev
       ? joinURL(ctx.nuxt.options.app.baseURL.replace(/^\.\//, '/') || '/', ctx.nuxt.options.app.buildAssetsDir)
@@ -100,7 +100,7 @@ export async function buildServer (ctx: ViteBuildContext) {
         functions: ['defineComponent', 'defineAsyncComponent', 'defineNuxtLink', 'createClientOnly', 'defineNuxtPlugin', 'defineNuxtRouteMiddleware', 'defineNuxtComponent', 'useRuntimeConfig']
       })
     ]
-  } satisfies vite.InlineConfig)
+  } satisfies vite.InlineConfig, ctx.nuxt.options.vite.$server || {}))
 
   serverConfig.customLogger = createViteLogger(serverConfig)
 

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -56,6 +56,8 @@ export async function bundle (nuxt: Nuxt) {
     allowDirs = allowDirs.filter(d => !d.startsWith(dir) || d === dir)
   }
 
+  const { $client, $server, ...viteConfig } = nuxt.options.vite
+
   const ctx: ViteBuildContext = {
     nuxt,
     entry,
@@ -121,7 +123,7 @@ export async function bundle (nuxt: Nuxt) {
           }
         }
       } satisfies ViteConfig,
-      nuxt.options.vite
+      viteConfig
     )
   }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/13499#issuecomment-1643476119

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This allows configuring client/server configuration for vite directly in the Nuxt config, without needing to do so in a hook. This is pure convenience, but avoids issues where setting a vite configuration for the _client_ ends up having negative implications for the server configuration, as in the linked issue above.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
