### PR TITLE
fix(webpack): remove legacy support for `build.extend`

### DIFF
--- a/packages/webpack/src/utils/config.ts
+++ b/packages/webpack/src/utils/config.ts
@@ -57,27 +57,6 @@ export function fileName (ctx: WebpackConfigContext, key: string) {
 }
 
 export function getWebpackConfig (ctx: WebpackConfigContext): Configuration {
-  // @ts-expect-error TODO: remove support for `build.extend` in v3.6
-  const { extend } = ctx.options.build
-  if (typeof extend === 'function') {
-    logger.warn('[nuxt] The `build.extend` and `webpack.build.extend` properties have been deprecated in Nuxt 3 for some time and will be removed in a future minor release. Instead, you can extend webpack config using the `webpack:config` hook.')
-
-    const extendedConfig = extend.call(
-      {},
-      ctx.config,
-      { loaders: [], ...ctx }
-    ) || ctx.config
-
-    const pragma = /@|#/
-    const { devtool } = extendedConfig
-    if (typeof devtool === 'string' && pragma.test(devtool)) {
-      extendedConfig.devtool = devtool.replace(pragma, '')
-      logger.warn(`devtool has been normalized to ${extendedConfig.devtool} as webpack documented value`)
-    }
-
-    return extendedConfig
-  }
-
   // Clone deep avoid leaking config between Client and Server
   return cloneDeep(ctx.config)
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

https://github.com/nuxt/nuxt/pull/20605

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This removes legacy and never-documented support for `build.extend` function when using the webpack builder.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
