### PR TITLE
fix(kit): handle tuple-format modules in `hasNuxtModule`

### DIFF
--- a/packages/kit/src/module/compatibility.test.ts
+++ b/packages/kit/src/module/compatibility.test.ts
@@ -12,11 +12,22 @@ describe('nuxt module compatibility', () => {
             meta: {
               name: 'nuxt-module-foo'
             }
-          })
+          }),
+          [
+            defineNuxtModule({
+              meta: {
+                name: 'module-instance-with-options'
+              }
+            }),
+            {
+              foo: 'bar'
+            }
+          ]
         ]
       }
     })
     expect(hasNuxtModule('nuxt-module-foo', nuxt)).toStrictEqual(true)
+    expect(hasNuxtModule('module-instance-with-options', nuxt)).toStrictEqual(true)
     await nuxt.close()
   })
   it('can retrieve module version from module instance', async () => {

--- a/packages/kit/src/module/compatibility.ts
+++ b/packages/kit/src/module/compatibility.ts
@@ -24,7 +24,7 @@ export function hasNuxtModule (moduleName: string, nuxt: Nuxt = useNuxt()) : boo
   // check installed modules
   return nuxt.options._installedModules.some(({ meta }) => meta.name === moduleName) ||
     // check modules to be installed
-    nuxt.options.modules.some(m => resolveNuxtModuleEntryName(m))
+    nuxt.options.modules.some(m => moduleName === resolveNuxtModuleEntryName(m))
 }
 
 /**

--- a/packages/kit/src/module/compatibility.ts
+++ b/packages/kit/src/module/compatibility.ts
@@ -4,7 +4,7 @@ import { useNuxt } from '../context'
 import { normalizeSemanticVersion } from '../compatibility'
 import { loadNuxtModuleInstance } from './install'
 
-export function resolveNuxtModuleEntryName (m: NuxtOptions['modules'][number]): string | false {
+function resolveNuxtModuleEntryName (m: NuxtOptions['modules'][number]): string | false {
   if (typeof m === 'object' && !Array.isArray(m)) {
     return (m as any as NuxtModule).name
   }

--- a/packages/kit/src/module/compatibility.ts
+++ b/packages/kit/src/module/compatibility.ts
@@ -9,7 +9,7 @@ function resolveNuxtModuleEntryName (m: NuxtOptions['modules'][number]): string 
     return (m as any as NuxtModule).name
   }
   if (Array.isArray(m)) {
-    return resolveNuxtModuleEntryName(m[0] as string)
+    return resolveNuxtModuleEntryName(m[0])
   }
   return m as string || false
 }

--- a/packages/kit/src/module/compatibility.ts
+++ b/packages/kit/src/module/compatibility.ts
@@ -19,7 +19,9 @@ export function hasNuxtModule (moduleName: string, nuxt: Nuxt = useNuxt()) : boo
             .find((m) => {
               // input may either a string, an array or a module instance
               function resolveModuleEntry (input: typeof m): boolean {
-                if (typeof input === 'object') { return (input as any as NuxtModule).name === moduleName }
+                if (typeof input === 'object' && !Array.isArray(input)) {
+                  return (input as any as NuxtModule).name === moduleName
+                }
                 return Array.isArray(input) ? resolveModuleEntry(input[0]) : input === moduleName
               }
               return resolveModuleEntry(m)

--- a/packages/kit/src/module/compatibility.ts
+++ b/packages/kit/src/module/compatibility.ts
@@ -13,20 +13,18 @@ import { loadNuxtModuleInstance } from './install'
 export function hasNuxtModule (moduleName: string, nuxt: Nuxt = useNuxt()) : boolean {
   // check installed modules
   return nuxt.options._installedModules.some(({ meta }) => meta.name === moduleName) ||
-        // check modules to be installed
-        Boolean(
-          nuxt.options.modules
-            .find((m) => {
-              // input may either a string, an array or a module instance
-              function resolveModuleEntry (input: typeof m): boolean {
-                if (typeof input === 'object' && !Array.isArray(input)) {
-                  return (input as any as NuxtModule).name === moduleName
-                }
-                return Array.isArray(input) ? resolveModuleEntry(input[0]) : input === moduleName
-              }
-              return resolveModuleEntry(m)
-            })
-        )
+    // check modules to be installed
+    nuxt.options.modules
+      .some((m) => {
+        // input may either a string, an array or a module instance
+        function resolveModuleEntry (input: typeof m): boolean {
+          if (typeof input === 'object' && !Array.isArray(input)) {
+            return (input as any as NuxtModule).name === moduleName
+          }
+          return Array.isArray(input) ? resolveModuleEntry(input[0]) : input === moduleName
+        }
+        return resolveModuleEntry(m)
+      })
 }
 
 /**

--- a/packages/kit/src/module/compatibility.ts
+++ b/packages/kit/src/module/compatibility.ts
@@ -4,7 +4,7 @@ import { useNuxt } from '../context'
 import { normalizeSemanticVersion } from '../compatibility'
 import { loadNuxtModuleInstance } from './install'
 
-export function resolveNuxtModuleEntryName(m: NuxtOptions['modules'][number]): string | false {
+export function resolveNuxtModuleEntryName (m: NuxtOptions['modules'][number]): string | false {
   if (typeof m === 'object' && !Array.isArray(m)) {
     return (m as any as NuxtModule).name
   }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

The `hasNuxtModule` function is incorrectly returning false for the following conditions:

- module with inline options
- module instance (with and without inline options)

```ts
export default defineNuxtConfig({
  modules: [
    ['my-module', { foo: 'bar' }],
   defineNuxtModule({ name: 'my-module' }),
   [defineNuxtModule({ name: 'my-module' }), { foo: 'bar' }],
  ]
})
```

Additionally, `getNuxtModuleVersion` is failing when using any of the above.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
