### PR TITLE
fix(nuxt): allow `validate` return typing to be either error or boolean

### DIFF
--- a/packages/nuxt/src/pages/runtime/composables.ts
+++ b/packages/nuxt/src/pages/runtime/composables.ts
@@ -14,7 +14,7 @@ export interface PageMeta {
    * statusCode/statusMessage to respond immediately with an error (other matches
    * will not be checked).
    */
-  validate?: (route: RouteLocationNormalized) => boolean | Promise<boolean | Partial<NuxtError>> | Partial<NuxtError>
+  validate?: (route: RouteLocationNormalized) => boolean | Partial<NuxtError> | Promise<boolean | Partial<NuxtError>>
   /**
    * Where to redirect if the route is directly matched. The redirection happens
    * before any navigation guard and triggers a new navigation with the new

--- a/packages/nuxt/src/pages/runtime/composables.ts
+++ b/packages/nuxt/src/pages/runtime/composables.ts
@@ -14,7 +14,7 @@ export interface PageMeta {
    * statusCode/statusMessage to respond immediately with an error (other matches
    * will not be checked).
    */
-  validate?: (route: RouteLocationNormalized) => boolean | Promise<boolean> | Partial<NuxtError> | Promise<Partial<NuxtError>>
+  validate?: (route: RouteLocationNormalized) => boolean | Promise<boolean | Partial<NuxtError>> | Partial<NuxtError>
   /**
    * Where to redirect if the route is directly matched. The redirection happens
    * before any navigation guard and triggers a new navigation with the new

--- a/test/fixtures/basic-types/types.ts
+++ b/test/fixtures/basic-types/types.ts
@@ -116,6 +116,21 @@ describe('middleware', () => {
       abortNavigation(true)
     }, { global: true })
   })
+  it('handles return types of validate', () => {
+    definePageMeta({
+      validate: async () => {
+        await new Promise(resolve => setTimeout(resolve, 1000))
+        // eslint-disable-next-line
+        if (0) {
+          return createError({
+            statusCode: 404,
+            statusMessage: 'resource-type-not-found'
+          })
+        }
+        return true
+      }
+    })
+  })
 })
 
 describe('typed router integration', () => {


### PR DESCRIPTION
### 🔗 Linked issue

resolves #22319

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This is a tiny fix to `validate`'s return type to allow the union of error/boolean.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
