### PR TITLE
refactor(nuxi,schema): move loading template into schema

### DIFF
--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -46,7 +46,7 @@ export default defineNuxtCommand({
     let currentHandler: RequestListener | undefined
     let loadingMessage = 'Nuxt is starting...'
     const loadingHandler: RequestListener = async (_req, res) => {
-      const { loading: loadingTemplate } = await importModule('@nuxt/ui-templates', config.modulesDir)
+      const loadingTemplate = config.devServer.loadingTemplate ?? await importModule('@nuxt/ui-templates', config.modulesDir).then(r => r.loading)
       res.setHeader('Content-Type', 'text/html; charset=UTF-8')
       res.statusCode = 503 // Service Unavailable
       res.end(loadingTemplate({ loading: loadingMessage }))

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -56,7 +56,7 @@
     "@nuxt/kit": "workspace:../kit",
     "@nuxt/schema": "workspace:../schema",
     "@nuxt/telemetry": "^2.3.2",
-    "@nuxt/ui-templates": "^1.2.0",
+    "@nuxt/ui-templates": "^1.2.1",
     "@nuxt/vite-builder": "workspace:../vite",
     "@unhead/ssr": "^1.1.32",
     "@unhead/vue": "^1.1.32",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -49,6 +49,7 @@
     "webpack-dev-middleware": "6.1.1"
   },
   "dependencies": {
+    "@nuxt/ui-templates": "^1.2.0",
     "defu": "^6.1.2",
     "hookable": "^5.5.3",
     "pathe": "^1.1.1",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -49,7 +49,7 @@
     "webpack-dev-middleware": "6.1.1"
   },
   "dependencies": {
-    "@nuxt/ui-templates": "^1.2.0",
+    "@nuxt/ui-templates": "^1.2.1",
     "defu": "^6.1.2",
     "hookable": "^5.5.3",
     "pathe": "^1.1.1",

--- a/packages/schema/src/config/dev.ts
+++ b/packages/schema/src/config/dev.ts
@@ -38,7 +38,11 @@ export default defineUntypedSchema({
      */
     url: 'http://localhost:3000',
 
-    /** Template to show a loading screen */
+    /**
+     * Template to show a loading screen
+     *
+     * @type {(data: { loading?: string }) => string}
+     */
     loadingTemplate: loadingTemplate
   }
 })

--- a/packages/schema/src/config/dev.ts
+++ b/packages/schema/src/config/dev.ts
@@ -1,4 +1,5 @@
 import { defineUntypedSchema } from 'untyped'
+import { loading as loadingTemplate } from '@nuxt/ui-templates'
 
 export default defineUntypedSchema({
   devServer: {
@@ -36,5 +37,8 @@ export default defineUntypedSchema({
      * dev server with the full URL (for module and internal use).
      */
     url: 'http://localhost:3000',
+
+    /** Template to show a loading screen */
+    loadingTemplate: loadingTemplate
   }
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -347,8 +347,8 @@ importers:
         specifier: ^2.3.2
         version: 2.3.2
       '@nuxt/ui-templates':
-        specifier: ^1.2.0
-        version: 1.2.0
+        specifier: ^1.2.1
+        version: 1.2.1
       '@nuxt/vite-builder':
         specifier: workspace:*
         version: link:../vite
@@ -522,8 +522,8 @@ importers:
   packages/schema:
     dependencies:
       '@nuxt/ui-templates':
-        specifier: ^1.2.0
-        version: 1.2.0
+        specifier: ^1.2.1
+        version: 1.2.1
       defu:
         specifier: ^6.1.2
         version: 6.1.2
@@ -2078,8 +2078,8 @@ packages:
       rc9: 2.1.1
       std-env: 3.3.3
 
-  /@nuxt/ui-templates@1.2.0:
-    resolution: {integrity: sha512-MSZza7dxccNb/p7nuzGF8/m4POaFpHzVhNdR7f4xahOpH7Ja02lFeYR+rHtoHIJC0yym4qriqv0mQ+Qf/R61bQ==}
+  /@nuxt/ui-templates@1.2.1:
+    resolution: {integrity: sha512-Nt1nTkPsji/X8z/BCqUgb8uADs+kT0FZboVDwyCdMlCgjEQKrAZUlunKXGywa6ssz4/RohGmvuB1cFre6dSKXQ==}
     dev: false
 
   /@nuxtjs/eslint-config-typescript@12.0.0(eslint@8.45.0)(typescript@5.0.4):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -521,6 +521,9 @@ importers:
 
   packages/schema:
     dependencies:
+      '@nuxt/ui-templates':
+        specifier: ^1.2.0
+        version: 1.2.0
       defu:
         specifier: ^6.1.2
         version: 6.1.2


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/14353

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This change is partly necessitated by https://github.com/nuxt/nuxt/issues/14146. Rather than loading the loading ui template dynamically within nuxi, which has no declared peer dep on it, I think we can move this into schema directly, which (as a side effect) allows customising the loading template by end users.

This also means we can decouple the template from nuxi itself.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
