### PR TITLE
perf(nuxt): export DefineNuxtConfig interface from next/config

### DIFF
--- a/packages/nuxt/config.d.ts
+++ b/packages/nuxt/config.d.ts
@@ -2,4 +2,5 @@ import type { NuxtConfig } from 'nuxt/schema'
 import type { DefineConfig, InputConfig, UserInputConfig, ConfigLayerMeta } from 'c12'
 export { NuxtConfig } from 'nuxt/schema'
 
-export declare const defineNuxtConfig: DefineConfig<NuxtConfig, ConfigLayerMeta>
+export interface DefineNuxtConfig extends DefineConfig<NuxtConfig, ConfigLayerMeta> {}
+export declare const defineNuxtConfig: DefineNuxtConfig

--- a/packages/nuxt/types.d.ts
+++ b/packages/nuxt/types.d.ts
@@ -1,12 +1,13 @@
 /// <reference types="nitropack" />
 export * from './dist/index'
 
+import type { DefineNuxtConfig } from 'nuxt/config'
 import type { SchemaDefinition, RuntimeConfig } from 'nuxt/schema'
 import type { H3Event } from 'h3'
 import type { NuxtIslandContext, NuxtIslandResponse, NuxtRenderHTMLContext } from './dist/core/runtime/nitro/renderer'
 
 declare global {
-  const defineNuxtConfig: typeof import('nuxt/config')['defineNuxtConfig']
+  const defineNuxtConfig: DefineNuxtConfig
   const defineNuxtSchema: (schema: SchemaDefinition) => SchemaDefinition
 }
 


### PR DESCRIPTION
Improve TypeScript performance around `defineNuxtConfig`.

### 🔗 Linked issue

N/A

### ❓ Type of change

- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)

### 📚 Description

I was checking out a newly generated Nuxt app for possible TS performance improvements. Found one place — `defineNuxtConfig` function. Defining and using an interface `DefineNuxtConfig` instead of `typeof import('nuxt/config')['defineNuxtConfig']` slightly improves perf. This is not a mindblowing improvement, but it's something. 

Before:
<img width="438" alt="CleanShot 2023-07-29 at 19 40 19@2x" src="https://github.com/nuxt/nuxt/assets/9019397/445302bc-d0b9-47ec-8143-82a3ec7681b8">

After:
<img width="366" alt="CleanShot 2023-07-29 at 19 27 33@2x" src="https://github.com/nuxt/nuxt/assets/9019397/c647fadc-cfa6-4acf-bfc3-524e15556a90">

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
