### PR TITLE
fix(nuxi): only strip extensions from files

### DIFF
--- a/packages/nuxi/src/utils/prepare.ts
+++ b/packages/nuxi/src/utils/prepare.ts
@@ -75,8 +75,8 @@ export const writeTypes = async (nuxt: Nuxt) => {
     } else {
       const path = stats?.isFile()
         ? absolutePath.replace(/(?<=\w)\.\w+$/g, '') /* remove extension */
-        : absolutePath;
-      
+        : absolutePath
+
       tsConfig.compilerOptions.paths[alias] = [path]
 
       if (!absolutePath.startsWith(rootDirWithSlash)) {

--- a/packages/nuxi/src/utils/prepare.ts
+++ b/packages/nuxi/src/utils/prepare.ts
@@ -73,10 +73,14 @@ export const writeTypes = async (nuxt: Nuxt) => {
         tsConfig.include.push(`${absolutePath}/*`)
       }
     } else {
-      tsConfig.compilerOptions.paths[alias] = [absolutePath.replace(/(?<=\w)\.\w+$/g, '')] /* remove extension */
+      const path = stats?.isFile()
+        ? absolutePath.replace(/(?<=\w)\.\w+$/g, '') /* remove extension */
+        : absolutePath;
+      
+      tsConfig.compilerOptions.paths[alias] = [path]
 
       if (!absolutePath.startsWith(rootDirWithSlash)) {
-        tsConfig.include.push(absolutePath.replace(/(?<=\w)\.\w+$/g, ''))
+        tsConfig.include.push(path)
       }
     }
   }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
Fixes: https://github.com/nuxt/nuxt/issues/22344
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Currently trying to remove the extension even if it is not a file.
Fixed to remove the extension only if the file.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
