### PR TITLE
refactor(nuxt): use `nuxi-ng` for edge releases

### DIFF
--- a/scripts/bump-edge.ts
+++ b/scripts/bump-edge.ts
@@ -14,7 +14,7 @@ async function main () {
   nuxtPkg.data.dependencies.nitropack = `npm:nitropack-edge@^${latestNitro}`
 
   const { version: latestNuxi } = await $fetch<{ version: string }>('https://registry.npmjs.org/nuxi-ng/latest')
-  nuxtPkg.data.dependencies.nitropack = `npm:nuxi-ng@^${latestNuxi}`
+  nuxtPkg.data.dependencies.nuxi = `npm:nuxi-ng@^${latestNuxi}`
 
   const bumpType = await determineBumpType()
 

--- a/scripts/bump-edge.ts
+++ b/scripts/bump-edge.ts
@@ -10,9 +10,11 @@ async function main () {
   const date = Math.round(Date.now() / (1000 * 60))
 
   const nuxtPkg = workspace.find('nuxt')
-  const nitroInfo = await $fetch('https://registry.npmjs.org/nitropack-edge')
-  const latestNitro = nitroInfo['dist-tags'].latest
+  const { version: latestNitro } = await $fetch<{ version: string }>('https://registry.npmjs.org/nitropack-edge/latest')
   nuxtPkg.data.dependencies.nitropack = `npm:nitropack-edge@^${latestNitro}`
+
+  const { version: latestNuxi } = await $fetch<{ version: string }>('https://registry.npmjs.org/nuxi-ng/latest')
+  nuxtPkg.data.dependencies.nitropack = `npm:nuxi-ng@^${latestNuxi}`
 
   const bumpType = await determineBumpType()
 


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

As a preparation for move to depend on https://github.com/nuxt/cli in future, this updates edge releases to use `nuxi-ng`.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
