### PR TITLE
test: remove separate test for baseurl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         module: ['bundler', 'node']
-        base: ['with-base-url', 'without-base-url']
 
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
@@ -135,7 +134,6 @@ jobs:
         run: pnpm test:types
         env:
           MODULE_RESOLUTION: ${{ matrix.module }}
-          TS_BASE_URL: ${{ matrix.base }}
 
   lint:
     # autofix workflow will be triggered instead for PRs

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -19,7 +19,7 @@ export default defineUntypedSchema({
      */
     reactivityTransform: false,
 
-    // TODO: Remove in v3.6 when nitro has support for mocking traced dependencies
+    // TODO: Remove in v3.8 when nitro has support for mocking traced dependencies
     // https://github.com/unjs/nitro/issues/1118
     /**
      * Externalize `vue`, `@vue/*` and `vue-router` when building.

--- a/test/fixtures/basic-types/nuxt.config.ts
+++ b/test/fixtures/basic-types/nuxt.config.ts
@@ -28,14 +28,6 @@ export default defineNuxtConfig({
     }
   },
   modules: [
-    function (_, nuxt) {
-      // TODO: remove in v3.7
-      if (process.env.TS_BASE_URL === 'without-base-url') {
-        nuxt.hook('prepare:types', ({ tsConfig }) => {
-          delete tsConfig.compilerOptions!.baseUrl
-        })
-      }
-    },
     function () {
       addTypeTemplate({
         filename: 'test.d.ts',


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

With https://github.com/nuxt/nuxt/pull/22410, we can now remove the extra test for using Nuxt without `baseUrl`.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
