### PR TITLE
fix(kit): apply preferred options for esbuild transpilation

### DIFF
--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -121,6 +121,8 @@ export async function writeTypes (nuxt: Nuxt) {
       module: 'ESNext',
       moduleResolution: nuxt.options.experimental?.typescriptBundlerResolution ? 'Bundler' : 'Node',
       skipLibCheck: true,
+      isolatedModules: true,
+      useDefineForClassFields: true,
       strict: nuxt.options.typescript?.strict ?? true,
       allowJs: true,
       noEmit: true,


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In line with [Vite recommendations](https://vitejs.dev/guide/features.html#typescript-compiler-options), this sets correct values for `isolatedModules` and `useDefineForClassFields`. You can see more about the rationale in the link.

As always, generated tsconfig compiler options can be customised within your `nuxt.config` if you need to:

```ts
export default defineNuxtConfig({
  typescript: {
    tsConfig: {
      compilerOptions: {
        isolatedModules: false,
        useDefineForClassFields: false
      }
    }
  }
})
```

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
