### PR TITLE
fix(webpack): resolve loaders to absolute paths

### DIFF
--- a/packages/webpack/src/configs/client.ts
+++ b/packages/webpack/src/configs/client.ts
@@ -1,8 +1,9 @@
 import querystring from 'node:querystring'
+import { pathToFileURL } from 'node:url'
 import { resolve } from 'pathe'
 import webpack from 'webpack'
 import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer'
-import { logger } from '@nuxt/kit'
+import { logger, tryResolveModule } from '@nuxt/kit'
 import { joinURL } from 'ufo'
 import ForkTSCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin'
 
@@ -46,7 +47,7 @@ function clientPerformance (ctx: WebpackConfigContext) {
   }
 }
 
-function clientHMR (ctx: WebpackConfigContext) {
+async function clientHMR (ctx: WebpackConfigContext) {
   if (!ctx.isDev) {
     return
   }
@@ -65,9 +66,10 @@ function clientHMR (ctx: WebpackConfigContext) {
 
   // Add HMR support
   const app = (ctx.config.entry as any).app as any
+  const hotMiddlewarePath = await tryResolveModule('webpack-hot-middleware/client', import.meta.url) || 'webpack-hot-middleware/client'
   app.unshift(
     // https://github.com/glenjamin/webpack-hot-middleware#config
-    `webpack-hot-middleware/client?${hotMiddlewareClientOptionsStr}`
+    `${pathToFileURL(hotMiddlewarePath)}?${hotMiddlewareClientOptionsStr}`
   )
 
   ctx.config.plugins = ctx.config.plugins || []

--- a/packages/webpack/src/configs/client.ts
+++ b/packages/webpack/src/configs/client.ts
@@ -10,11 +10,11 @@ import type { WebpackConfigContext } from '../utils/config'
 import { applyPresets } from '../utils/config'
 import { nuxt } from '../presets/nuxt'
 
-export function client (ctx: WebpackConfigContext) {
+export async function client (ctx: WebpackConfigContext) {
   ctx.name = 'client'
   ctx.isClient = true
 
-  applyPresets(ctx, [
+  await applyPresets(ctx, [
     nuxt,
     clientPlugins,
     clientOptimization,

--- a/packages/webpack/src/configs/server.ts
+++ b/packages/webpack/src/configs/server.ts
@@ -9,11 +9,11 @@ import { node } from '../presets/node'
 
 const assetPattern = /\.(css|s[ca]ss|png|jpe?g|gif|svg|woff2?|eot|ttf|otf|webp|webm|mp4|ogv)(\?.*)?$/i
 
-export function server (ctx: WebpackConfigContext) {
+export async function server (ctx: WebpackConfigContext) {
   ctx.name = 'server'
   ctx.isServer = true
 
-  applyPresets(ctx, [
+  await applyPresets(ctx, [
     nuxt,
     node,
     serverStandalone,

--- a/packages/webpack/src/presets/assets.ts
+++ b/packages/webpack/src/presets/assets.ts
@@ -1,12 +1,13 @@
+import { tryResolveModule } from '@nuxt/kit'
 import type { WebpackConfigContext } from '../utils/config'
 import { fileName } from '../utils/config'
 
-export function assets (ctx: WebpackConfigContext) {
+export async function assets (ctx: WebpackConfigContext) {
   ctx.config.module!.rules!.push(
     {
       test: /\.(png|jpe?g|gif|svg|webp)$/i,
       use: [{
-        loader: 'url-loader',
+        loader: await tryResolveModule('url-loader', import.meta.url) ?? 'url-loader',
         options: {
           ...ctx.userConfig.loaders.imgUrl,
           name: fileName(ctx, 'img')
@@ -16,7 +17,7 @@ export function assets (ctx: WebpackConfigContext) {
     {
       test: /\.(woff2?|eot|ttf|otf)(\?.*)?$/i,
       use: [{
-        loader: 'url-loader',
+        loader: await tryResolveModule('url-loader', import.meta.url) ?? 'url-loader',
         options: {
           ...ctx.userConfig.loaders.fontUrl,
           name: fileName(ctx, 'font')
@@ -26,7 +27,7 @@ export function assets (ctx: WebpackConfigContext) {
     {
       test: /\.(webm|mp4|ogv)$/i,
       use: [{
-        loader: 'file-loader',
+        loader: await tryResolveModule('file-loader', import.meta.url) ?? 'file-loader',
         options: {
           ...ctx.userConfig.loaders.file,
           name: fileName(ctx, 'video')

--- a/packages/webpack/src/presets/base.ts
+++ b/packages/webpack/src/presets/base.ts
@@ -16,8 +16,8 @@ import WarningIgnorePlugin from '../plugins/warning-ignore'
 import type { WebpackConfigContext } from '../utils/config'
 import { applyPresets, fileName } from '../utils/config'
 
-export function base (ctx: WebpackConfigContext) {
-  applyPresets(ctx, [
+export async function base (ctx: WebpackConfigContext) {
+  await applyPresets(ctx, [
     baseAlias,
     baseConfig,
     basePlugins,

--- a/packages/webpack/src/presets/base.ts
+++ b/packages/webpack/src/presets/base.ts
@@ -133,6 +133,8 @@ function baseResolve (ctx: WebpackConfigContext) {
   // TODO: this might be refactored as default modulesDir?
   const webpackModulesDir = ['node_modules'].concat(ctx.options.modulesDir)
 
+  // console.log({webpackModulesDir})
+
   ctx.config.resolve = {
     extensions: ['.wasm', '.mjs', '.js', '.ts', '.json', '.vue', '.jsx', '.tsx'],
     alias: ctx.alias,
@@ -142,7 +144,7 @@ function baseResolve (ctx: WebpackConfigContext) {
   }
 
   ctx.config.resolveLoader = {
-    modules: webpackModulesDir,
+    // modules: webpackModulesDir,
     ...ctx.config.resolveLoader
   }
 }

--- a/packages/webpack/src/presets/base.ts
+++ b/packages/webpack/src/presets/base.ts
@@ -133,8 +133,6 @@ function baseResolve (ctx: WebpackConfigContext) {
   // TODO: this might be refactored as default modulesDir?
   const webpackModulesDir = ['node_modules'].concat(ctx.options.modulesDir)
 
-  // console.log({webpackModulesDir})
-
   ctx.config.resolve = {
     extensions: ['.wasm', '.mjs', '.js', '.ts', '.json', '.vue', '.jsx', '.tsx'],
     alias: ctx.alias,
@@ -144,7 +142,7 @@ function baseResolve (ctx: WebpackConfigContext) {
   }
 
   ctx.config.resolveLoader = {
-    // modules: webpackModulesDir,
+    modules: webpackModulesDir,
     ...ctx.config.resolveLoader
   }
 }

--- a/packages/webpack/src/presets/esbuild.ts
+++ b/packages/webpack/src/presets/esbuild.ts
@@ -1,7 +1,8 @@
 import { EsbuildPlugin } from 'esbuild-loader'
+import { tryResolveModule } from '@nuxt/kit'
 import type { WebpackConfigContext } from '../utils/config'
 
-export function esbuild (ctx: WebpackConfigContext) {
+export async function esbuild (ctx: WebpackConfigContext) {
   // https://esbuild.github.io/getting-started/#bundling-for-the-browser
   // https://gs.statcounter.com/browser-version-market-share
   // https://nodejs.org/en/
@@ -13,7 +14,7 @@ export function esbuild (ctx: WebpackConfigContext) {
   ctx.config.module!.rules!.push(
     {
       test: /\.m?[jt]s$/i,
-      loader: 'esbuild-loader',
+      loader: await tryResolveModule('esbuild-loader', import.meta.url) ?? 'esbuild-loader',
       exclude: (file) => {
         // Not exclude files outside node_modules
         file = file.split('node_modules', 2)[1]
@@ -32,7 +33,7 @@ export function esbuild (ctx: WebpackConfigContext) {
     },
     {
       test: /\.m?[jt]sx$/,
-      loader: 'esbuild-loader',
+      loader: await tryResolveModule('esbuild-loader', import.meta.url) ?? 'esbuild-loader',
       options: {
         target,
         ...ctx.nuxt.options.webpack.loaders.esbuild,

--- a/packages/webpack/src/presets/nuxt.ts
+++ b/packages/webpack/src/presets/nuxt.ts
@@ -8,8 +8,8 @@ import { pug } from './pug'
 import { style } from './style'
 import { vue } from './vue'
 
-export function nuxt (ctx: WebpackConfigContext) {
-  applyPresets(ctx, [
+export async function nuxt (ctx: WebpackConfigContext) {
+  await applyPresets(ctx, [
     base,
     assets,
     esbuild,

--- a/packages/webpack/src/presets/pug.ts
+++ b/packages/webpack/src/presets/pug.ts
@@ -1,13 +1,14 @@
+import { tryResolveModule } from '@nuxt/kit'
 import type { WebpackConfigContext } from '../utils/config'
 
-export function pug (ctx: WebpackConfigContext) {
+export async function pug (ctx: WebpackConfigContext) {
   ctx.config.module!.rules!.push({
     test: /\.pug$/i,
     oneOf: [
       {
         resourceQuery: /^\?vue/i,
         use: [{
-          loader: 'pug-plain-loader',
+          loader: await tryResolveModule('pug-plain-loader', import.meta.url) ?? 'pug-plain-loader',
           options: ctx.userConfig.loaders.pugPlain
         }]
       },
@@ -15,7 +16,7 @@ export function pug (ctx: WebpackConfigContext) {
         use: [
           'raw-loader',
           {
-            loader: 'pug-plain-loader',
+            loader: await tryResolveModule('pug-plain-loader', import.meta.url) ?? 'pug-plain-loader',
             options: ctx.userConfig.loaders.pugPlain
           }
         ]

--- a/packages/webpack/src/presets/style.ts
+++ b/packages/webpack/src/presets/style.ts
@@ -4,8 +4,8 @@ import type { WebpackConfigContext } from '../utils/config'
 import { applyPresets, fileName } from '../utils/config'
 import { getPostcssConfig } from '../utils/postcss'
 
-export function style (ctx: WebpackConfigContext) {
-  applyPresets(ctx, [
+export async function style (ctx: WebpackConfigContext) {
+  await applyPresets(ctx, [
     loaders,
     extractCSS,
     minimizer

--- a/packages/webpack/src/presets/vue.ts
+++ b/packages/webpack/src/presets/vue.ts
@@ -1,17 +1,18 @@
 import { resolve } from 'pathe'
 import VueLoaderPlugin from 'vue-loader/dist/pluginWebpack5.js'
 import webpack from 'webpack'
+import { tryResolveModule } from '@nuxt/kit'
 import VueSSRClientPlugin from '../plugins/vue/client'
 import VueSSRServerPlugin from '../plugins/vue/server'
 import type { WebpackConfigContext } from '../utils/config'
 
-export function vue (ctx: WebpackConfigContext) {
+export async function vue (ctx: WebpackConfigContext) {
   // @ts-expect-error de-default vue-loader
   ctx.config.plugins!.push(new (VueLoaderPlugin.default || VueLoaderPlugin)())
 
   ctx.config.module!.rules!.push({
     test: /\.vue$/i,
-    loader: 'vue-loader',
+    loader: await tryResolveModule('vue-loader', import.meta.url) ?? 'vue-loader',
     options: {
       reactivityTransform: ctx.nuxt.options.experimental.reactivityTransform,
       ...ctx.userConfig.loaders.vue

--- a/packages/webpack/src/utils/config.ts
+++ b/packages/webpack/src/utils/config.ts
@@ -36,15 +36,15 @@ export function createWebpackConfigContext (nuxt: Nuxt): WebpackConfigContext {
   }
 }
 
-export function applyPresets (ctx: WebpackConfigContext, presets: WebpackConfigPresetItem | WebpackConfigPresetItem[]) {
+export async function applyPresets (ctx: WebpackConfigContext, presets: WebpackConfigPresetItem | WebpackConfigPresetItem[]) {
   if (!Array.isArray(presets)) {
     presets = [presets]
   }
   for (const preset of presets) {
     if (Array.isArray(preset)) {
-      preset[0](ctx, preset[1])
+      await preset[0](ctx, preset[1])
     } else {
-      preset(ctx)
+      await preset(ctx)
     }
   }
 }

--- a/packages/webpack/src/webpack.ts
+++ b/packages/webpack/src/webpack.ts
@@ -25,12 +25,12 @@ import { applyPresets, createWebpackConfigContext, getWebpackConfig } from './ut
 export async function bundle (nuxt: Nuxt) {
   registerVirtualModules()
 
-  const webpackConfigs = [client, ...nuxt.options.ssr ? [server] : []].map((preset) => {
+  const webpackConfigs = await Promise.all([client, ...nuxt.options.ssr ? [server] : []].map(async (preset) => {
     const ctx = createWebpackConfigContext(nuxt)
     ctx.userConfig = defu(nuxt.options.webpack[`$${preset.name as 'client' | 'server'}`], ctx.userConfig)
-    applyPresets(ctx, preset)
+    await applyPresets(ctx, preset)
     return getWebpackConfig(ctx)
-  })
+  }))
 
   await nuxt.callHook('webpack:config', webpackConfigs)
 

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -130,7 +130,7 @@ export default defineNuxtConfig({
       // in order to test bigint serialisation we need to set target to a more modern one
       for (const config of configs) {
         const esbuildRules = config.module!.rules!.filter(
-          rule => typeof rule === 'object' && rule && 'loader' in rule && rule.loader === 'esbuild-loader'
+          rule => typeof rule === 'object' && rule && 'loader' in rule && rule.loader?.includes('esbuild-loader')
         )
         for (const rule of esbuildRules) {
           if (typeof rule === 'object' && typeof rule.options === 'object') {


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/14146

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When using webpack builder without shamefully-hoist, we can't resolve the loaders nuxt uses.

This PR updates loaders to be absolute paths.

I'd be open for this to be behind a flag if we think it might break existing integrations that expect loaders to be unresolved package names. (Or other solution ideas!)

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
