### PR TITLE
chore: add issue reproduction bot

### DIFF
--- a/.github/reproduire/needs-reproduction.md
+++ b/.github/reproduire/needs-reproduction.md
@@ -2,7 +2,7 @@
 
 We can't replicate the issue with the details that you provided. **Please add a reproduction so that we can investigate further.**
 
-## **Why was the \`needs-reproduction\` label added to this issue?**
+## Why was the \`needs-reproduction\` label added to this issue?
 
 For our investigation, a reproduction is vital to pinpoint the origin of the problem.
 
@@ -16,17 +16,17 @@ A public Github repository would also be acceptable.
 Please ensure that the reproduction is as **minimal** as possible.
 That implies you should **eliminate any code, files, and dependencies** that aren't directly related to the issue.
 
-## **Why was the \`needs-reproduction\` label not removed even after I included a link?**
+## Why was the \`needs-reproduction\` label not removed even after I included a link?
 
 Make sure your link refers to a codebase that's open for access (e.g., not a private repository).
 Links such as "[example.com](http://example.com/)", "n/a", "will add later", and so on are not acceptable -- we require a visible public codebase.
 Refer to the previous section for acceptable links.
 
-## **What will occur if I fail to provide a sufficient minimal reproduction?**
+## What will occur if I fail to provide a sufficient minimal reproduction?
 
 If the \`needs-reproduction\` labeled issues don't receive any substantial activity (e.g., new comments featuring a reproduction link), they will be closed by the maintainers.
 
-## **What can I do to assist if the issue matters to me but I didn't open it?**
+## What can I do to assist if the issue matters to me but I didn't open it?
 
 If you're facing the same problem, feel free to offer a minimal reproduction by following the previous instructions.
 Moreover, you can react on the initial comment of the issue.
@@ -34,17 +34,17 @@ Moreover, you can react on the initial comment of the issue.
 - Avoid commenting "I have the same issue" without providing reproduction steps or meaningful information.
 - Please refrain from posting unhelpful messages such as "+1" on an issue, use reactions on the first comment instead.
 
-## **Why isn't my issue given prompt attention even though I believe my reproduction is satisfactory?**
+## Why isn't my issue given prompt attention even though I believe my reproduction is satisfactory?
 
 Our team is regularly scanning open issues for new comments.
 Reacting on issues to indicate your interest can help us prioritize and tackle them more swiftly.
 
-## **I can provide a minimal reproduction for an issue that's already been closed.**
+## I can provide a minimal reproduction for an issue that's already been closed
 
 If you have a minimal reproduction for a closed issue, please post a comment on the issue with the reproduction link.
 We will review it and reopen the issue if it is sufficient.
 
-## **Helpful Links**
+## Helpful Links
 
 - [Nuxt Contribution Guidelines](https://nuxt.com/docs/community/reporting-bugs)
 - [The Importance of Reproductions](https://antfu.me/posts/why-reproductions-are-required)

--- a/.github/reproduire/needs-reproduction.md
+++ b/.github/reproduire/needs-reproduction.md
@@ -1,0 +1,46 @@
+# This Issue Needs A Reproduction
+
+We cannot recreate the issue with the provided information. **Please add a reproduction in order for us to be able to investigate.**
+
+## **Why was this issue marked with the \`needs-reproduction\` label?**
+
+To be able to investigate, we need access to a reproduction to identify what triggered the issue. Please provide a link to either :
+
+- a public GitHub repository
+- a [CodeSandbox](https://codesandbox.io/)
+- a [StackBlitz](https://stackblitz.com/).
+
+To make sure the issue is resolved as quickly as possible, please make sure that the reproduction is as **minimal** as possible. This means that you should **remove unnecessary code, files, and dependencies** that do not contribute to the issue.
+
+## **I added a link, why was it still marked?**
+
+Ensure the link is pointing to a codebase that is accessible (e.g. not a private repository). "[example.com](http://example.com/)", "n/a", "will add later", etc. are not acceptable links -- we need to see a public codebase. See the above section for accepted links.
+
+## **What happens if I don't provide a sufficient minimal reproduction?**
+
+Issues with the \`needs-reproduction\` label that receives no meaningful activity (e.g. new comments with a reproduction link) will be closed by the maintainers and won't be looked at.
+
+## **I did not open this issue, but it is relevant to me, what can I do to help?**
+
+Anyone experiencing the same issue is welcome to provide a minimal reproduction following the above steps. Furthermore, you can upvote the issue using a reaction on the topmost comment.
+
+- Please **do not** comment "I have the same issue" without repro steps
+- Please **do not** comment un-helpful messages such as "+1" on an issue, use reactions on the first comment instead.
+
+## **I think my reproduction is good enough, why aren't you looking into it quicker?**
+
+We constantly monitor open issues for new comments.
+
+However, sometimes we might miss one or two. We apologize, and kindly ask you to refrain from tagging core maintainers, as that will usually not result in increased priority.
+
+Upvoting issues to show your interest will help us prioritize and address them as quickly as possible.
+
+## **I have a minimal reproduction to contribute to a closed issue.**
+
+If you have a minimal reproduction for a closed issue, please write a comment on the issue with a link to the reproduction.
+We will review it and reopen the issue if it is sufficient.
+
+## **Useful Resources**
+
+- [Why reproductions are required](https://antfu.me/posts/why-reproductions-are-required)
+- [How to create a Minimal, Complete, and Verifiable example](https://stackoverflow.com/help/mcve)

--- a/.github/reproduire/needs-reproduction.md
+++ b/.github/reproduire/needs-reproduction.md
@@ -1,46 +1,51 @@
-# This Issue Needs A Reproduction
+# This Issue Needs A Valid Reproduction
 
-We cannot recreate the issue with the provided information. **Please add a reproduction in order for us to be able to investigate.**
+We can't replicate the issue with the details that you provided. **Please add a reproduction so that we can investigate further.**
 
-## **Why was this issue marked with the \`needs-reproduction\` label?**
+## **Why was the \`needs-reproduction\` label added to this issue?**
 
-To be able to investigate, we need access to a reproduction to identify what triggered the issue. Please provide a link to either :
+For our investigation, a reproduction is vital to pinpoint the origin of the problem.
 
-- a public GitHub repository
-- a [CodeSandbox](https://codesandbox.io/)
-- a [StackBlitz](https://stackblitz.com/).
+Kindly use one of the templates provided below to generate a minimal reproduction :
 
-To make sure the issue is resolved as quickly as possible, please make sure that the reproduction is as **minimal** as possible. This means that you should **remove unnecessary code, files, and dependencies** that do not contribute to the issue.
+👉 https://stackblitz.com/github/nuxt/starter/tree/v3-stackblitz
+👉 https://codesandbox.io/s/github/nuxt/starter/v3-codesandbox
 
-## **I added a link, why was it still marked?**
+A public Github repository would also be acceptable.
 
-Ensure the link is pointing to a codebase that is accessible (e.g. not a private repository). "[example.com](http://example.com/)", "n/a", "will add later", etc. are not acceptable links -- we need to see a public codebase. See the above section for accepted links.
+Please ensure that the reproduction is as **minimal** as possible.
+That implies you should **eliminate any code, files, and dependencies** that aren't directly related to the issue.
 
-## **What happens if I don't provide a sufficient minimal reproduction?**
+## **Why was the \`needs-reproduction\` label not removed even after I included a link?**
 
-Issues with the \`needs-reproduction\` label that receives no meaningful activity (e.g. new comments with a reproduction link) will be closed by the maintainers and won't be looked at.
+Make sure your link refers to a codebase that's open for access (e.g., not a private repository).
+Links such as "[example.com](http://example.com/)", "n/a", "will add later", and so on are not acceptable -- we require a visible public codebase.
+Refer to the previous section for acceptable links.
 
-## **I did not open this issue, but it is relevant to me, what can I do to help?**
+## **What will occur if I fail to provide a sufficient minimal reproduction?**
 
-Anyone experiencing the same issue is welcome to provide a minimal reproduction following the above steps. Furthermore, you can upvote the issue using a reaction on the topmost comment.
+If the \`needs-reproduction\` labeled issues don't receive any substantial activity (e.g., new comments featuring a reproduction link), they will be closed by the maintainers.
 
-- Please **do not** comment "I have the same issue" without repro steps
-- Please **do not** comment un-helpful messages such as "+1" on an issue, use reactions on the first comment instead.
+## **What can I do to assist if the issue matters to me but I didn't open it?**
 
-## **I think my reproduction is good enough, why aren't you looking into it quicker?**
+If you're facing the same problem, feel free to offer a minimal reproduction by following the previous instructions.
+Moreover, you can react on the initial comment of the issue.
 
-We constantly monitor open issues for new comments.
+- Avoid commenting "I have the same issue" without providing reproduction steps or meaningful information.
+- Please refrain from posting unhelpful messages such as "+1" on an issue, use reactions on the first comment instead.
 
-However, sometimes we might miss one or two. We apologize, and kindly ask you to refrain from tagging core maintainers, as that will usually not result in increased priority.
+## **Why isn't my issue given prompt attention even though I believe my reproduction is satisfactory?**
 
-Upvoting issues to show your interest will help us prioritize and address them as quickly as possible.
+Our team is regularly scanning open issues for new comments.
+Reacting on issues to indicate your interest can help us prioritize and tackle them more swiftly.
 
-## **I have a minimal reproduction to contribute to a closed issue.**
+## **I can provide a minimal reproduction for an issue that's already been closed.**
 
-If you have a minimal reproduction for a closed issue, please write a comment on the issue with a link to the reproduction.
+If you have a minimal reproduction for a closed issue, please post a comment on the issue with the reproduction link.
 We will review it and reopen the issue if it is sufficient.
 
-## **Useful Resources**
+## **Helpful Links**
 
-- [Why reproductions are required](https://antfu.me/posts/why-reproductions-are-required)
-- [How to create a Minimal, Complete, and Verifiable example](https://stackoverflow.com/help/mcve)
+- [Nuxt Contribution Guidelines](https://nuxt.com/docs/community/reporting-bugs)
+- [The Importance of Reproductions](https://antfu.me/posts/why-reproductions-are-required)
+- [How to Generate a Minimal, Complete, and Verifiable Example](https://stackoverflow.com/help/mcve)

--- a/.github/reproduire/needs-reproduction.md
+++ b/.github/reproduire/needs-reproduction.md
@@ -1,51 +1,32 @@
-# This Issue Needs A Valid Reproduction
+Would you be able to provide a [reproduction](https://nuxt.com/docs/community/reporting-bugs/#create-a-minimal-reproduction)? 🙏
 
-We can't replicate the issue with the details that you provided. **Please add a reproduction so that we can investigate further.**
+<details>
+<summary>More info</summary>
 
-## Why was the \`needs-reproduction\` label added to this issue?
+### Why do I need to provide a reproduction?
 
-For our investigation, a reproduction is vital to pinpoint the origin of the problem.
+Reproductions make it possible for us to triage and fix issues quickly with a relatively small team. It helps us discover the source of the problem, and also can reveal assumptions you or we might be making.
 
-Kindly use one of the templates provided below to generate a minimal reproduction :
+### What will happen?
+
+If you've provided a reproduction, we'll remove the label and try to reproduce the issue. If we can, we'll mark it as a bug and prioritise it based on its severity and how many people we think it might affect.
+
+If `needs reproduction` labeled issues don't receive any substantial activity (e.g., new comments featuring a reproduction link), we'll close them. That's not because we don't care! At any point, feel free to comment with a reproduction and we'll reopen it.
+
+### How can I create a reproduction?
+
+We have a couple of templates for starting with a minimal reproduction:
 
 👉 https://stackblitz.com/github/nuxt/starter/tree/v3-stackblitz
 👉 https://codesandbox.io/s/github/nuxt/starter/v3-codesandbox
 
-A public Github repository would also be acceptable.
+A public GitHub repository is also perfect. 👌
 
-Please ensure that the reproduction is as **minimal** as possible.
-That implies you should **eliminate any code, files, and dependencies** that aren't directly related to the issue.
+Please ensure that the reproduction is as **minimal** as possible. See more details [in our guide](https://nuxt.com/docs/community/reporting-bugs/#create-a-minimal-reproduction).
 
-## Why was the \`needs-reproduction\` label not removed even after I included a link?
+You might also find these other articles interesting and/or helpful:
 
-Make sure your link refers to a codebase that's open for access (e.g., not a private repository).
-Links such as "[example.com](http://example.com/)", "n/a", "will add later", and so on are not acceptable -- we require a visible public codebase.
-Refer to the previous section for acceptable links.
-
-## What will occur if I fail to provide a sufficient minimal reproduction?
-
-If the \`needs-reproduction\` labeled issues don't receive any substantial activity (e.g., new comments featuring a reproduction link), they will be closed by the maintainers.
-
-## What can I do to assist if the issue matters to me but I didn't open it?
-
-If you're facing the same problem, feel free to offer a minimal reproduction by following the previous instructions.
-Moreover, you can react on the initial comment of the issue.
-
-- Avoid commenting "I have the same issue" without providing reproduction steps or meaningful information.
-- Please refrain from posting unhelpful messages such as "+1" on an issue, use reactions on the first comment instead.
-
-## Why isn't my issue given prompt attention even though I believe my reproduction is satisfactory?
-
-Our team is regularly scanning open issues for new comments.
-Reacting on issues to indicate your interest can help us prioritize and tackle them more swiftly.
-
-## I can provide a minimal reproduction for an issue that's already been closed
-
-If you have a minimal reproduction for a closed issue, please post a comment on the issue with the reproduction link.
-We will review it and reopen the issue if it is sufficient.
-
-## Helpful Links
-
-- [Nuxt Contribution Guidelines](https://nuxt.com/docs/community/reporting-bugs)
 - [The Importance of Reproductions](https://antfu.me/posts/why-reproductions-are-required)
 - [How to Generate a Minimal, Complete, and Verifiable Example](https://stackoverflow.com/help/mcve)
+
+</details>

--- a/.github/workflows/reproduire-close.yml
+++ b/.github/workflows/reproduire-close.yml
@@ -14,8 +14,8 @@ jobs:
       - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8.0.0
         with:
           days-before-stale: -1 # Issues and PR will never be flagged stale automatically.
-          stale-issue-label: needs-reproduction # Label that flags an issue as stale.
-          only-labels: needs-reproduction # Only process these issues
+          stale-issue-label: 'needs reproduction' # Label that flags an issue as stale.
+          only-labels: 'needs reproduction' # Only process these issues
           days-before-issue-close: 7
           ignore-updates: true
           remove-stale-when-updated: false

--- a/.github/workflows/reproduire-close.yml
+++ b/.github/workflows/reproduire-close.yml
@@ -1,0 +1,23 @@
+name: Close incomplete issues
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '30 1 * * *' # run every day
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          days-before-stale: -1 # Issues and PR will never be flagged stale automatically.
+          stale-issue-label: needs-reproduction # Label that flags an issue as stale.
+          only-labels: needs-reproduction # Only process these issues
+          days-before-issue-close: 7
+          ignore-updates: true
+          remove-stale-when-updated: false
+          close-issue-message: This issue was closed because it was open for 7 days without a valid reproduction.
+          close-issue-label: closed-by-reproduire

--- a/.github/workflows/reproduire-close.yml
+++ b/.github/workflows/reproduire-close.yml
@@ -11,7 +11,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v8
+      - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8.0.0
         with:
           days-before-stale: -1 # Issues and PR will never be flagged stale automatically.
           stale-issue-label: needs-reproduction # Label that flags an issue as stale.

--- a/.github/workflows/reproduire-close.yml
+++ b/.github/workflows/reproduire-close.yml
@@ -20,4 +20,4 @@ jobs:
           ignore-updates: true
           remove-stale-when-updated: false
           close-issue-message: This issue was closed because it was open for 7 days without a reproduction.
-          close-issue-label: closed-by-reproduire
+          close-issue-label: closed-by-bot

--- a/.github/workflows/reproduire-close.yml
+++ b/.github/workflows/reproduire-close.yml
@@ -19,5 +19,5 @@ jobs:
           days-before-issue-close: 7
           ignore-updates: true
           remove-stale-when-updated: false
-          close-issue-message: This issue was closed because it was open for 7 days without a valid reproduction.
+          close-issue-message: This issue was closed because it was open for 7 days without a reproduction.
           close-issue-label: closed-by-reproduire

--- a/.github/workflows/reproduire.yml
+++ b/.github/workflows/reproduire.yml
@@ -10,5 +10,5 @@ jobs:
   reproduire:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: Hebilicious/reproduire@v0.0.9-mp
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - uses: Hebilicious/reproduire@4b686ae9cbb72dad60f001d278b6e3b2ce40a9ac # v0.0.9-mp

--- a/.github/workflows/reproduire.yml
+++ b/.github/workflows/reproduire.yml
@@ -1,0 +1,14 @@
+name: Reproduire
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  issues: write
+
+jobs:
+  reproduire:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: Hebilicious/reproduire@v0.0.9-mp


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This issue implements a "reproduction bot" based on [reproduire](https://github.com/Hebilicious/reproduire) that ease maintainers life by automatically commenting and closing issues labeled with `needs-reproduction`.
Many things can be configured at the maintainer discretion, please make suggestion in the reviews.

Demonstration on an example repo https://github.com/Hebilicious/nuxtpress/issues/13 (check the action runs too)

### Additional Context 

There are currently [74 open issues](https://github.com/nuxt/nuxt/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22needs+reproduction%22) with the `needs reproduction` label. 

This means that they will all be closed by the stale bot in 7 days **without** the custom reproduire message (`needs-reproduction.md`).

To write the `needs-reproduction.md` in already labeled issues, they need to be re-labelled (a rename will work). 

Either :
- rename `needs reproduction` to `needs-reproduction` (`needs-reproduction` is the default for reproduire)
- rename twice : `needs reproduction` => `temp-reproduction` => `needs reproduction` and change the configured label in the workflows to `needs reproduction`

Regardless, the custom stale message and labeled will be applied according to the configuration :

```
  close-issue-message: This issue was closed because it was open for 7 days without a valid reproduction.
  close-issue-label: closed-by-reproduire
```

By default the issues will be closed by stale with not_planned. There are more configuration options available there https://github.com/actions/stale

My suggestion is that we rename the label to `needs-reproduction` and delete the old one `needs reproduction`, to make sure that the `needs-reproduction.md` message is explicitly written in these 74 issues before they are scheduled for close.
After this we can manually trigger the `reproduire-close` workflow instead of waiting for the cron trigger.
Both of these actions will only need to be done once.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
