### PR TITLE
chore: increase stale operations per run

### DIFF
--- a/.github/workflows/reproduire-close.yml
+++ b/.github/workflows/reproduire-close.yml
@@ -21,3 +21,4 @@ jobs:
           remove-stale-when-updated: false
           close-issue-message: This issue was closed because it was open for 7 days without a reproduction.
           close-issue-label: closed-by-bot
+          operations-per-run: 100 #default 30


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Looking at the first [workflow run ](https://github.com/nuxt/nuxt/actions/runs/5768106334), it looks like the bot successfully closed [3 issues ](https://github.com/nuxt/nuxt/issues?q=is%3Aissue+sort%3Aupdated-desc+label%3Aclosed-by-bot+is%3Aclosed).
There's room to increase the amount of [operations per run](https://github.com/actions/stale#operations-per-run) as there is a lot of issues to go through.

```bash
Statistics:
Processed items: 74
├── Processed issues: 55
└── Processed PRs   : 19
Closed issues: 3
Added issues labels: 3
Added issues comments: 3
Fetched items: 100
Fetched items events: 10
Fetched items comments: 10
Operations performed: 30
```

We could also try to run the bot more frequently.

I'm wary of being rate limited for all the other worfklows if we increase this number too much though...

Does nuxt has a github entreprise account ? Otherwise it looks like we are rate limited to [1000 request/hour](https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limits-for-requests-from-github-actions); therefore increasing to 100 should be safe (assuming 1 operation = 1request)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
