### PR TITLE
chore: increase stale bot limit to 300

### DIFF
--- a/.github/workflows/reproduire-close.yml
+++ b/.github/workflows/reproduire-close.yml
@@ -21,4 +21,4 @@ jobs:
           remove-stale-when-updated: false
           close-issue-message: This issue was closed because it was open for 7 days without a reproduction.
           close-issue-label: closed-by-bot
-          operations-per-run: 100 #default 30
+          operations-per-run: 300 #default 30


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

So far : 

18 issues have been closed by the `reproduire-close` workflow : https://github.com/nuxt/nuxt/issues?q=is%3Aissue+sort%3Aupdated-desc+label%3Aclosed-by-bot+is%3Aclosed 🎉 

Looking at the latest run, https://github.com/nuxt/nuxt/actions/runs/5791807546/job/15697183387, 366 items were processed.
Increasing by 3x means we should be able to process every item in one run, without hitting the rate limit (which should be 1000 operations)

Any suggestions to improve the bot would be welcome 🙏🏽 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
