### PR TITLE
docs: add closing blocks for `ReadMore` components

### DIFF
--- a/docs/2.guide/3.going-further/1.experimental-features.md
+++ b/docs/2.guide/3.going-further/1.experimental-features.md
@@ -29,6 +29,7 @@ export defineNuxtConfig({ experimental: { reactivityTransform: true } })
 ```
 
 ::ReadMore{link="docs/getting-started/configuration#enabling-experimental-vue-features"}
+::
 
 ## externalVue
 
@@ -143,6 +144,7 @@ export defineNuxtConfig({ experimental: { viewTransition: true } })
 ```
 
 ::ReadMore{link="docs/getting-started/transitions#view-transitions-api-experimental"}
+::
 
 ## writeEarlyHints
 
@@ -161,6 +163,7 @@ export defineNuxtConfig({ experimental: { componentIslands: true } })
 ```
 
 ::ReadMore{link="docs/guide/directory-structure/components#server-components"}
+::
 
 You can follow the server components roadmap on [GitHub](https://github.com/nuxt/nuxt/issues/19772).
 


### PR DESCRIPTION
Fix Experimental Features page not loading completely due to ReadMore sections that were not closed.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

#22540

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fix the ReadMore syntax on the Experimental Features page to match other uses of ReadMore like in [this example on the State Management page](https://github.com/nuxt/nuxt/blob/c5437e648a2923a9190c725ed00c2b25d91c1a82/docs/1.getting-started/7.state-management.md?plain=1#L12).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
