### PR TITLE
feat(nuxt): allow experimental `global: 'sync'` components

### DIFF
--- a/packages/nuxt/src/components/templates.ts
+++ b/packages/nuxt/src/components/templates.ts
@@ -49,7 +49,6 @@ export const componentsPluginTemplate: NuxtPluginTemplate<ComponentsTemplateCont
 
     const lazyComponents = [...lazyGlobalComponents]
     const syncComponents = [...syncGlobalComponents]
-    console.log({ lazyComponents, syncComponents })
 
     return `import { defineNuxtPlugin } from '#app/nuxt'
 import { ${[...lazyComponents.map(c => 'Lazy' + c), ...syncComponents].join(', ')} } from '#components'

--- a/packages/nuxt/src/components/templates.ts
+++ b/packages/nuxt/src/components/templates.ts
@@ -36,20 +36,26 @@ export default defineNuxtPlugin({
 export const componentsPluginTemplate: NuxtPluginTemplate<ComponentsTemplateContext> = {
   filename: 'components.plugin.mjs',
   getContents ({ app }) {
-    const globalComponents = new Set<string>()
+    const lazyGlobalComponents = new Set<string>()
+    const syncGlobalComponents = new Set<string>()
     for (const component of app.components) {
-      if (component.global) {
-        globalComponents.add(component.pascalName)
+      if (component.global === 'sync') {
+        syncGlobalComponents.add(component.pascalName)
+      } else if (component.global) {
+        lazyGlobalComponents.add(component.pascalName)
       }
     }
-    if (!globalComponents.size) { return emptyComponentsPlugin }
+    if (!lazyGlobalComponents.size && !syncGlobalComponents.size) { return emptyComponentsPlugin }
 
-    const components = [...globalComponents]
+    const lazyComponents = [...lazyGlobalComponents]
+    const syncComponents = [...syncGlobalComponents]
+    console.log({ lazyComponents, syncComponents })
 
     return `import { defineNuxtPlugin } from '#app/nuxt'
-import { ${components.map(c => 'Lazy' + c).join(', ')} } from '#components'
+import { ${[...lazyComponents.map(c => 'Lazy' + c), ...syncComponents].join(', ')} } from '#components'
 const lazyGlobalComponents = [
-  ${components.map(c => `["${c}", Lazy${c}]`).join(',\n')}
+  ${lazyComponents.map(c => `["${c}", Lazy${c}]`).join(',\n')},
+  ${syncComponents.map(c => `["${c}", ${c}]`).join(',\n')}
 ]
 
 export default defineNuxtPlugin({

--- a/packages/schema/src/types/components.ts
+++ b/packages/schema/src/types/components.ts
@@ -7,7 +7,7 @@ export interface Component {
   chunkName: string
   prefetch: boolean
   preload: boolean
-  global?: boolean
+  global?: boolean | 'sync'
   island?: boolean
   mode?: 'client' | 'server' | 'all'
   /**

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -94,6 +94,7 @@ describe('pages', () => {
     // should register global components automatically
     expect(html).toContain('global component registered automatically')
     expect(html).toContain('global component via suffix')
+    expect(html).toContain('This is a synchronously registered global component')
 
     await expectNoClientErrors('/')
   })

--- a/test/fixtures/basic/components/GlobalSync.vue
+++ b/test/fixtures/basic/components/GlobalSync.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    This is a synchronously registered global component
+  </div>
+</template>

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -146,6 +146,13 @@ export default defineNuxtConfig({
         filePath: '~/other-components-folder/named-export'
       })
     },
+    'components:extend' (components) {
+      for (const comp of components) {
+        if (comp.pascalName === 'GlobalSync') {
+          comp.global = 'sync'
+        }
+      }
+    },
     'vite:extendConfig' (config) {
       config.plugins!.push({
         name: 'nuxt:server',

--- a/test/fixtures/basic/pages/index.vue
+++ b/test/fixtures/basic/pages/index.vue
@@ -44,6 +44,7 @@
     </NuxtLink>
     <NestedSugarCounter :multiplier="2" />
     <CustomComponent />
+    <component :is="`global${'-'.toString()}sync`" />
     <Spin>Test</Spin>
     <component :is="`test${'-'.toString()}global`" />
     <component :is="`with${'-'.toString()}suffix`" />


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In general, we want to discourage global components because it will inflate bundle size. Libraries or users could go and register all components of a ui library as global as an easy choice, with the downside of hugely inflating bundle size.

So, we would prefer if people use auto import so only what they need is required (and can be bundle-split appropriate).

When global components _are_ used, we register them as async components and the chunks only get fetched when used.

However, there is a significant downside when these components are small and used frequently as this approach produces many small chunks. One option is to provide a custom chunk handler to rollup, though this can only really be done by an end user and not by an integration.

This PR provides an escape hatch for edge cases (like `@nuxt/content`) which want to register components globally and _synchronously_ in the main bundle.

**Note**: Within `nuxt/content`, I would advise using this this an experiment only. I would prefer to see compilation of markdown into vue (or server components, or partial compilation of just the tags) so auto-import/bundle-splitting can be used rather than increasing the _entry_ bundle size. For a large site using `nuxt/content`, if all components used in content across all pages are registered synchronously, I would expect to see very poor initial load performance scores.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
