### PR TITLE
fix(nuxt): trigger immediate DOM update on `page:finish`

### DIFF
--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -60,6 +60,7 @@
     "@nuxt/vite-builder": "workspace:../vite",
     "@unhead/ssr": "^1.2.2",
     "@unhead/vue": "^1.2.2",
+    "@unhead/dom": "^1.2.2",
     "@vue/shared": "^3.3.4",
     "acorn": "8.10.0",
     "c12": "^1.4.2",

--- a/packages/nuxt/src/head/runtime/plugins/unhead.ts
+++ b/packages/nuxt/src/head/runtime/plugins/unhead.ts
@@ -1,5 +1,6 @@
 import { createHead as createClientHead } from '@unhead/vue'
 import { defineNuxtPlugin } from '#app/nuxt'
+import { renderDOMHead } from '@unhead/dom'
 
 export default defineNuxtPlugin({
   name: 'nuxt:head',
@@ -11,17 +12,16 @@ export default defineNuxtPlugin({
     if (import.meta.client) {
       // pause dom updates until page is ready and between page transitions
       let pauseDOMUpdates = true
-      const unpauseDom = () => {
+      const syncHead = async () => {
         pauseDOMUpdates = false
-        // trigger the debounced DOM update
-        head.hooks.callHook('entries:updated', head)
+        await renderDOMHead(head)
       }
       head.hooks.hook('dom:beforeRender', (context) => { context.shouldRender = !pauseDOMUpdates })
       nuxtApp.hooks.hook('page:start', () => { pauseDOMUpdates = true })
       // wait for new page before unpausing dom updates (triggered after suspense resolved)
-      nuxtApp.hooks.hook('page:finish', unpauseDom)
+      nuxtApp.hooks.hook('page:finish', syncHead)
       // unpause the DOM once the mount suspense is resolved
-      nuxtApp.hooks.hook('app:suspense:resolve', unpauseDom)
+      nuxtApp.hooks.hook('app:suspense:resolve', syncHead)
     }
   }
 })

--- a/packages/nuxt/src/head/runtime/plugins/unhead.ts
+++ b/packages/nuxt/src/head/runtime/plugins/unhead.ts
@@ -1,6 +1,6 @@
 import { createHead as createClientHead } from '@unhead/vue'
-import { defineNuxtPlugin } from '#app/nuxt'
 import { renderDOMHead } from '@unhead/dom'
+import { defineNuxtPlugin } from '#app/nuxt'
 
 export default defineNuxtPlugin({
   name: 'nuxt:head',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -364,6 +364,9 @@ importers:
       '@types/node':
         specifier: ^14.18.0 || >=16.10.0
         version: 18.17.4
+      '@unhead/dom':
+        specifier: ^1.2.2
+        version: 1.2.2
       '@unhead/ssr':
         specifier: ^1.2.2
         version: 1.2.2
@@ -7189,7 +7192,7 @@ packages:
       graceful-fs: 4.2.11
 
   /jstransformer@1.0.0:
-    resolution: {integrity: sha512-C9YK3Rf8q6VAPDCCU9fnqo3mAfOH6vUGnMcP4AQAYIEpWtfGLpwOTmZ+igtdK5y+VvI2n3CyYSzy4Qh34eq24A==}
+    resolution: {integrity: sha1-7Yvwkh4vPx7U1cGkT2hwntJHIsM=}
     dependencies:
       is-promise: 2.2.2
       promise: 7.3.1
@@ -10320,7 +10323,7 @@ packages:
     engines: {node: '>=0.6'}
 
   /token-stream@1.0.0:
-    resolution: {integrity: sha512-VSsyNPPW74RpHwR8Fc21uubwHY7wMDeJLys2IX5zJNih+OnAnaifKHo+1LHT7DAdloQ7apeaaWg8l7qnf/TnEg==}
+    resolution: {integrity: sha1-zCAOqyYT9BZtJ/+a/HylbUnfbrQ=}
     dev: false
 
   /totalist@1.1.0:


### PR DESCRIPTION

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
#22334, #22560


### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

When updating the DOM from head changes, we batch the changes, this reduces DOM thrashing. We use this batching when the page is finishing which is causing the linked issue.

However, we can just update the head immediately.

One issue with this solution though is the `page:finish` is now delayed, on average this is ~10ms for a few DOM updates (if needed), so maybe worth considering if this change is worth it.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
