### PR TITLE
docs: update and shorten server example

### DIFF
--- a/docs/2.guide/2.directory-structure/1.server.md
+++ b/docs/2.guide/2.directory-structure/1.server.md
@@ -1,13 +1,14 @@
 ---
 navigation.icon: IconDirectory
 title: server
-head.title: 'server/'
+head.title: "server/"
 description: The server/ directory is used to register API and server handlers to your application.
 ---
 
 # Server Directory
 
 Nuxt automatically scans files inside these directories to register API and server handlers with HMR support:
+
 - `~/server/api`
 - `~/server/routes`
 - `~/server/middleware`
@@ -21,16 +22,16 @@ The handler can directly return JSON data, a `Promise` or use `event.node.res.en
 ```ts [server/api/hello.ts]
 export default defineEventHandler((event) => {
   return {
-    hello: 'world'
-  }
-})
+    hello: "world",
+  };
+});
 ```
 
 You can now universally call this API in your pages and components:
 
 ```vue [pages/index.vue]
 <script setup lang="ts">
-const { data } = await useFetch('/api/hello')
+const { data } = await useFetch("/api/hello");
 </script>
 
 <template>
@@ -51,7 +52,7 @@ To add server routes without `/api` prefix, put them into `~/server/routes` dire
 **Example:**
 
 ```ts [server/routes/hello.ts]
-export default defineEventHandler(() => 'Hello World!')
+export default defineEventHandler(() => "Hello World!");
 ```
 
 Given the example above, the `/hello` route will be accessible at <http://localhost:3000/hello>.
@@ -74,14 +75,14 @@ Middleware handlers should not return anything (nor close or respond to the requ
 
 ```ts [server/middleware/log.ts]
 export default defineEventHandler((event) => {
-  console.log('New request: ' + getRequestURL(event))
-})
+  console.log("New request: " + getRequestURL(event));
+});
 ```
 
 ```ts [server/middleware/auth.ts]
 export default defineEventHandler((event) => {
-  event.context.auth = { user: 123 }
-})
+  event.context.auth = { user: 123 };
+});
 ```
 
 ## Server Plugins
@@ -92,8 +93,8 @@ Nuxt will automatically read any files in the `~/server/plugins` directory and r
 
 ```ts [server/plugins/nitroPlugin.ts]
 export default defineNitroPlugin((nitroApp) => {
-  console.log('Nitro plugin', nitroApp)
-})
+  console.log("Nitro plugin", nitroApp);
+});
 ```
 
 :ReadMore{link="https://nitro.unjs.io/guide/plugins" title="Nitro Plugins"}
@@ -111,20 +112,20 @@ For example, you can define a custom handler utility that wraps the original han
 **Example:**
 
 ```ts [server/utils/handler.ts]
-import type { EventHandler } from 'h3'
+import type { EventHandler } from "h3";
 
 export const defineWrappedResponseHandler = (handler: EventHandler) =>
   defineEventHandler(async (event) => {
     try {
       // do something before the route handler
-      const response = await handler(event)
+      const response = await handler(event);
       // do something after the route handler
-      return { response }
+      return { response };
     } catch (err) {
       // Error handling
-      return { err }
+      return { err };
     }
-  })
+  });
 ```
 
 ## Server Types
@@ -151,8 +152,11 @@ Server routes can use dynamic parameters within brackets in the file name like `
 
 **Example:**
 
-```ts [server/api/hello/[name\\].ts]
-export default defineEventHandler((event) => `Hello, ${event.context.params.name}!`)
+```ts [server/api/hello/[name].ts]
+export default defineEventHandler((event) => {
+  const { name } = event.context.params;
+  return { `Hello, ${name}!` }
+}
 ```
 
 You can now universally call this API using `await $fetch('/api/hello/nuxt')` and get `Hello, nuxt!`.
@@ -162,11 +166,11 @@ You can now universally call this API using `await $fetch('/api/hello/nuxt')` an
 Handle file names can be suffixed with `.get`, `.post`, `.put`, `.delete`, ... to match request's [HTTP Method](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods).
 
 ```ts [server/api/test.get.ts]
-export default defineEventHandler(() => 'Test get handler')
+export default defineEventHandler(() => "Test get handler");
 ```
 
 ```ts [server/api/test.post.ts]
-export default defineEventHandler(() => 'Test post handler')
+export default defineEventHandler(() => "Test post handler");
 ```
 
 Given the example above, fetching `/test` with:
@@ -181,21 +185,21 @@ Catch-all routes are helpful for fallback route handling. For example, creating 
 
 **Examples:**
 
-```ts [server/api/foo/[...\\].ts]
-export default defineEventHandler(() => `Default foo handler`)
+```ts [server/api/foo/[...].ts]
+export default defineEventHandler(() => `Default foo handler`);
 ```
 
-```ts [server/api/[...\\].ts]
-export default defineEventHandler(() => `Default api handler`)
+```ts [server/api/[...].ts]
+export default defineEventHandler(() => `Default api handler`);
 ```
 
 ### Handling Requests with Body
 
 ```ts [server/api/submit.post.ts]
 export default defineEventHandler(async (event) => {
-    const body = await readBody(event)
-    return { body }
-})
+  const body = await readBody(event);
+  return { body };
+});
 ```
 
 You can now universally call this API using `$fetch('/api/submit', { method: 'post', body: { test: 123 } })`.
@@ -210,9 +214,9 @@ Sample query `/api/query?param1=a&param2=b`
 
 ```ts [server/api/query.get.ts]
 export default defineEventHandler((event) => {
-  const query = getQuery(event)
-  return { a: query.param1, b: query.param2 }
-})
+  const query = getQuery(event);
+  return { a: query.param1, b: query.param2 };
+});
 ```
 
 ### Error handling
@@ -221,17 +225,17 @@ If no errors are thrown, a status code of `200 OK` will be returned. Any uncaugh
 
 To return other error codes, throw an exception with `createError`
 
-```ts [server/api/validation/[id\\].ts]
+```ts [server/api/validation/[id].ts]
 export default defineEventHandler((event) => {
-  const id = parseInt(event.context.params.id) as number
+  const id = parseInt(event.context.params.id) as number;
   if (!Number.isInteger(id)) {
     throw createError({
       statusCode: 400,
-      statusMessage: 'ID should be an integer',
-    })
+      statusMessage: "ID should be an integer",
+    });
   }
-  return 'All good'
-})
+  return "All good";
+});
 ```
 
 ### Returning other status codes
@@ -240,29 +244,28 @@ To return other status codes, you can use the `setResponseStatus` utility.
 
 For example, to return `202 Accepted`
 
-```ts [server/api/validation/[id\\].ts]
+```ts [server/api/validation/[id].ts]
 export default defineEventHandler((event) => {
-  setResponseStatus(event, 202)
-})
+  setResponseStatus(event, 202);
+});
 ```
 
 ### Accessing Runtime Config
 
 ```ts [server/api/foo.ts]
-
 export default defineEventHandler((event) => {
-  const config = useRuntimeConfig()
-  return { key: config.KEY }
-})
+  const config = useRuntimeConfig();
+  return { key: config.KEY };
+});
 ```
 
 ### Accessing Request Cookies
 
 ```ts
 export default defineEventHandler((event) => {
-  const cookies = parseCookies(event)
-  return { cookies }
-})
+  const cookies = parseCookies(event);
+  return { cookies };
+});
 ```
 
 ## Advanced Usage Examples
@@ -278,20 +281,23 @@ This is an advanced option. Custom config can affect production deployments, as 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   // https://nitro.unjs.io/config
-  nitro: {}
-})
+  nitro: {},
+});
 ```
 
 ### Using a Nested Router
 
-```ts [server/api/hello/[...slug\\].ts]
-import { createRouter, defineEventHandler, useBase } from 'h3'
+```ts [server/api/hello/[...slug].ts]
+import { createRouter, defineEventHandler, useBase } from "h3";
 
-const router = createRouter()
+const router = createRouter();
 
-router.get('/test', defineEventHandler(() => 'Hello World'))
+router.get(
+  "/test",
+  defineEventHandler(() => "Hello World")
+);
 
-export default useBase('/api/hello', router.handler)
+export default useBase("/api/hello", router.handler);
 ```
 
 ### Sending Streams (Experimental)
@@ -299,28 +305,28 @@ export default useBase('/api/hello', router.handler)
 **Note:** This is an experimental feature and is only available within Node.js environments.
 
 ```ts [server/api/foo.get.ts]
-import fs from 'node:fs'
-import { sendStream } from 'h3'
+import fs from "node:fs";
+import { sendStream } from "h3";
 
 export default defineEventHandler((event) => {
-  return sendStream(event, fs.createReadStream('/path/to/file'))
-})
+  return sendStream(event, fs.createReadStream("/path/to/file"));
+});
 ```
 
 ### Sending Redirect
 
 ```ts [server/api/foo.get.ts]
 export default defineEventHandler((event) => {
-  return sendRedirect(event, '/path/redirect/to', 302)
-})
+  return sendRedirect(event, "/path/redirect/to", 302);
+});
 ```
 
 ### Return a Legacy Handler or Middleware
 
 ```ts [server/api/legacy.ts]
 export default fromNodeMiddleware((req, res) => {
-  res.end('Legacy handler')
-})
+  res.end("Legacy handler");
+});
 ```
 
 ::alert{type=warning}
@@ -329,9 +335,9 @@ Legacy support is possible using [unjs/h3](https://github.com/unjs/h3), but it i
 
 ```ts [server/middleware/legacy.ts]
 export default fromNodeMiddleware((req, res, next) => {
-  console.log('Legacy middleware')
-  next()
-})
+  console.log("Legacy middleware");
+  next();
+});
 ```
 
 ::alert{type=warning}
@@ -350,19 +356,19 @@ Using `nitro.storage`:
 export default defineNuxtConfig({
   nitro: {
     storage: {
-      'redis': {
-        driver: 'redis',
+      redis: {
+        driver: "redis",
         /* redis connector options */
         port: 6379, // Redis port
         host: "127.0.0.1", // Redis host
         username: "", // needs Redis >= 6
         password: "",
         db: 0, // Defaults to 0
-        tls: {} // tls/ssl
-      }
-    }
-  }
-})
+        tls: {}, // tls/ssl
+      },
+    },
+  },
+});
 ```
 
 Alternatively, using server plugins:
@@ -370,34 +376,35 @@ Alternatively, using server plugins:
 ::code-group
 
 ```ts [server/plugins/storage.ts]
-import redisDriver from 'unstorage/drivers/redis'
+import redisDriver from "unstorage/drivers/redis";
 
 export default defineNitroPlugin(() => {
-  const storage = useStorage()
+  const storage = useStorage();
 
   // Dynamically pass in credentials from runtime configuration, or other sources
   const driver = redisDriver({
-      base: 'redis',
-      host: useRuntimeConfig().redis.host,
-      port: useRuntimeConfig().redis.port,
-      /* other redis connector options */
-    })
+    base: "redis",
+    host: useRuntimeConfig().redis.host,
+    port: useRuntimeConfig().redis.port,
+    /* other redis connector options */
+  });
 
   // Mount driver
-  storage.mount('redis', driver)
-})
+  storage.mount("redis", driver);
+});
 ```
 
-``` ts [nuxt.config.ts]
+```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   runtimeConfig: {
-    redis: { // Default values
-      host: '',
+    redis: {
+      // Default values
+      host: "",
       port: 0,
       /* other redis connector options */
-    }
-  }
-})
+    },
+  },
+});
 ```
 
 ::
@@ -406,30 +413,30 @@ Create a new file in `server/api/test.post.ts`:
 
 ```ts [server/api/test.post.ts]
 export default defineEventHandler(async (event) => {
-  const body = await readBody(event)
-  await useStorage().setItem('redis:test', body)
-  return 'Data is set'
-})
+  const body = await readBody(event);
+  await useStorage().setItem("redis:test", body);
+  return "Data is set";
+});
 ```
 
 Create a new file in `server/api/test.get.ts`:
 
 ```ts [server/api/test.get.ts]
 export default defineEventHandler(async (event) => {
-  const data = await useStorage().getItem('redis:test')
-  return data
-})
+  const data = await useStorage().getItem("redis:test");
+  return data;
+});
 ```
 
 Create a new file in `app.vue`:
 
 ```vue [app.vue]
 <script setup lang="ts">
-  const { data: resDataSuccess } = await useFetch('/api/test', {
-      method: 'post',
-      body: { text: 'Nuxt is Awesome!' }
-  })
-  const { data: resData } = await useFetch('/api/test')
+const { data: resDataSuccess } = await useFetch("/api/test", {
+  method: "post",
+  body: { text: "Nuxt is Awesome!" },
+});
+const { data: resData } = await useFetch("/api/test");
 </script>
 
 <template>

--- a/docs/2.guide/2.directory-structure/1.server.md
+++ b/docs/2.guide/2.directory-structure/1.server.md
@@ -153,8 +153,8 @@ Server routes can use dynamic parameters within brackets in the file name like `
 
 ```ts [server/api/hello/[name\\].ts]
 export default defineEventHandler((event) => {
-  const { name } = event.context.params
-  return { `Hello, ${name}!` }
+  const name = getRouterParam(event, 'name')
+  return `Hello, ${name}!`
 })
 ```
 

--- a/docs/2.guide/2.directory-structure/1.server.md
+++ b/docs/2.guide/2.directory-structure/1.server.md
@@ -1,14 +1,13 @@
 ---
 navigation.icon: IconDirectory
 title: server
-head.title: "server/"
+head.title: 'server/'
 description: The server/ directory is used to register API and server handlers to your application.
 ---
 
 # Server Directory
 
 Nuxt automatically scans files inside these directories to register API and server handlers with HMR support:
-
 - `~/server/api`
 - `~/server/routes`
 - `~/server/middleware`
@@ -22,16 +21,16 @@ The handler can directly return JSON data, a `Promise` or use `event.node.res.en
 ```ts [server/api/hello.ts]
 export default defineEventHandler((event) => {
   return {
-    hello: "world",
-  };
-});
+    hello: 'world'
+  }
+})
 ```
 
 You can now universally call this API in your pages and components:
 
 ```vue [pages/index.vue]
 <script setup lang="ts">
-const { data } = await useFetch("/api/hello");
+const { data } = await useFetch('/api/hello')
 </script>
 
 <template>
@@ -52,7 +51,7 @@ To add server routes without `/api` prefix, put them into `~/server/routes` dire
 **Example:**
 
 ```ts [server/routes/hello.ts]
-export default defineEventHandler(() => "Hello World!");
+export default defineEventHandler(() => 'Hello World!')
 ```
 
 Given the example above, the `/hello` route will be accessible at <http://localhost:3000/hello>.
@@ -75,14 +74,14 @@ Middleware handlers should not return anything (nor close or respond to the requ
 
 ```ts [server/middleware/log.ts]
 export default defineEventHandler((event) => {
-  console.log("New request: " + getRequestURL(event));
-});
+  console.log('New request: ' + getRequestURL(event))
+})
 ```
 
 ```ts [server/middleware/auth.ts]
 export default defineEventHandler((event) => {
-  event.context.auth = { user: 123 };
-});
+  event.context.auth = { user: 123 }
+})
 ```
 
 ## Server Plugins
@@ -93,8 +92,8 @@ Nuxt will automatically read any files in the `~/server/plugins` directory and r
 
 ```ts [server/plugins/nitroPlugin.ts]
 export default defineNitroPlugin((nitroApp) => {
-  console.log("Nitro plugin", nitroApp);
-});
+  console.log('Nitro plugin', nitroApp)
+})
 ```
 
 :ReadMore{link="https://nitro.unjs.io/guide/plugins" title="Nitro Plugins"}
@@ -112,20 +111,20 @@ For example, you can define a custom handler utility that wraps the original han
 **Example:**
 
 ```ts [server/utils/handler.ts]
-import type { EventHandler } from "h3";
+import type { EventHandler } from 'h3'
 
 export const defineWrappedResponseHandler = (handler: EventHandler) =>
   defineEventHandler(async (event) => {
     try {
       // do something before the route handler
-      const response = await handler(event);
+      const response = await handler(event)
       // do something after the route handler
-      return { response };
+      return { response }
     } catch (err) {
       // Error handling
-      return { err };
+      return { err }
     }
-  });
+  })
 ```
 
 ## Server Types
@@ -152,9 +151,9 @@ Server routes can use dynamic parameters within brackets in the file name like `
 
 **Example:**
 
-```ts [server/api/hello/[name].ts]
+```ts [server/api/hello/[name\\].ts]
 export default defineEventHandler((event) => {
-  const { name } = event.context.params;
+  const { name } = event.context.params
   return { `Hello, ${name}!` }
 }
 ```
@@ -166,11 +165,11 @@ You can now universally call this API using `await $fetch('/api/hello/nuxt')` an
 Handle file names can be suffixed with `.get`, `.post`, `.put`, `.delete`, ... to match request's [HTTP Method](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods).
 
 ```ts [server/api/test.get.ts]
-export default defineEventHandler(() => "Test get handler");
+export default defineEventHandler(() => 'Test get handler')
 ```
 
 ```ts [server/api/test.post.ts]
-export default defineEventHandler(() => "Test post handler");
+export default defineEventHandler(() => 'Test post handler')
 ```
 
 Given the example above, fetching `/test` with:
@@ -185,21 +184,21 @@ Catch-all routes are helpful for fallback route handling. For example, creating 
 
 **Examples:**
 
-```ts [server/api/foo/[...].ts]
-export default defineEventHandler(() => `Default foo handler`);
+```ts [server/api/foo/[...\\].ts]
+export default defineEventHandler(() => `Default foo handler`)
 ```
 
-```ts [server/api/[...].ts]
-export default defineEventHandler(() => `Default api handler`);
+```ts [server/api/[...\\].ts]
+export default defineEventHandler(() => `Default api handler`)
 ```
 
 ### Handling Requests with Body
 
 ```ts [server/api/submit.post.ts]
 export default defineEventHandler(async (event) => {
-  const body = await readBody(event);
-  return { body };
-});
+    const body = await readBody(event)
+    return { body }
+})
 ```
 
 You can now universally call this API using `$fetch('/api/submit', { method: 'post', body: { test: 123 } })`.
@@ -214,9 +213,9 @@ Sample query `/api/query?param1=a&param2=b`
 
 ```ts [server/api/query.get.ts]
 export default defineEventHandler((event) => {
-  const query = getQuery(event);
-  return { a: query.param1, b: query.param2 };
-});
+  const query = getQuery(event)
+  return { a: query.param1, b: query.param2 }
+})
 ```
 
 ### Error handling
@@ -225,17 +224,17 @@ If no errors are thrown, a status code of `200 OK` will be returned. Any uncaugh
 
 To return other error codes, throw an exception with `createError`
 
-```ts [server/api/validation/[id].ts]
+```ts [server/api/validation/[id\\].ts]
 export default defineEventHandler((event) => {
-  const id = parseInt(event.context.params.id) as number;
+  const id = parseInt(event.context.params.id) as number
   if (!Number.isInteger(id)) {
     throw createError({
       statusCode: 400,
-      statusMessage: "ID should be an integer",
-    });
+      statusMessage: 'ID should be an integer',
+    })
   }
-  return "All good";
-});
+  return 'All good'
+})
 ```
 
 ### Returning other status codes
@@ -244,28 +243,29 @@ To return other status codes, you can use the `setResponseStatus` utility.
 
 For example, to return `202 Accepted`
 
-```ts [server/api/validation/[id].ts]
+```ts [server/api/validation/[id\\].ts]
 export default defineEventHandler((event) => {
-  setResponseStatus(event, 202);
-});
+  setResponseStatus(event, 202)
+})
 ```
 
 ### Accessing Runtime Config
 
 ```ts [server/api/foo.ts]
+
 export default defineEventHandler((event) => {
-  const config = useRuntimeConfig();
-  return { key: config.KEY };
-});
+  const config = useRuntimeConfig()
+  return { key: config.KEY }
+})
 ```
 
 ### Accessing Request Cookies
 
 ```ts
 export default defineEventHandler((event) => {
-  const cookies = parseCookies(event);
-  return { cookies };
-});
+  const cookies = parseCookies(event)
+  return { cookies }
+})
 ```
 
 ## Advanced Usage Examples
@@ -281,23 +281,20 @@ This is an advanced option. Custom config can affect production deployments, as 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   // https://nitro.unjs.io/config
-  nitro: {},
-});
+  nitro: {}
+})
 ```
 
 ### Using a Nested Router
 
-```ts [server/api/hello/[...slug].ts]
-import { createRouter, defineEventHandler, useBase } from "h3";
+```ts [server/api/hello/[...slug\\].ts]
+import { createRouter, defineEventHandler, useBase } from 'h3'
 
-const router = createRouter();
+const router = createRouter()
 
-router.get(
-  "/test",
-  defineEventHandler(() => "Hello World")
-);
+router.get('/test', defineEventHandler(() => 'Hello World'))
 
-export default useBase("/api/hello", router.handler);
+export default useBase('/api/hello', router.handler)
 ```
 
 ### Sending Streams (Experimental)
@@ -305,28 +302,28 @@ export default useBase("/api/hello", router.handler);
 **Note:** This is an experimental feature and is only available within Node.js environments.
 
 ```ts [server/api/foo.get.ts]
-import fs from "node:fs";
-import { sendStream } from "h3";
+import fs from 'node:fs'
+import { sendStream } from 'h3'
 
 export default defineEventHandler((event) => {
-  return sendStream(event, fs.createReadStream("/path/to/file"));
-});
+  return sendStream(event, fs.createReadStream('/path/to/file'))
+})
 ```
 
 ### Sending Redirect
 
 ```ts [server/api/foo.get.ts]
 export default defineEventHandler((event) => {
-  return sendRedirect(event, "/path/redirect/to", 302);
-});
+  return sendRedirect(event, '/path/redirect/to', 302)
+})
 ```
 
 ### Return a Legacy Handler or Middleware
 
 ```ts [server/api/legacy.ts]
 export default fromNodeMiddleware((req, res) => {
-  res.end("Legacy handler");
-});
+  res.end('Legacy handler')
+})
 ```
 
 ::alert{type=warning}
@@ -335,9 +332,9 @@ Legacy support is possible using [unjs/h3](https://github.com/unjs/h3), but it i
 
 ```ts [server/middleware/legacy.ts]
 export default fromNodeMiddleware((req, res, next) => {
-  console.log("Legacy middleware");
-  next();
-});
+  console.log('Legacy middleware')
+  next()
+})
 ```
 
 ::alert{type=warning}
@@ -356,19 +353,19 @@ Using `nitro.storage`:
 export default defineNuxtConfig({
   nitro: {
     storage: {
-      redis: {
-        driver: "redis",
+      'redis': {
+        driver: 'redis',
         /* redis connector options */
         port: 6379, // Redis port
         host: "127.0.0.1", // Redis host
         username: "", // needs Redis >= 6
         password: "",
         db: 0, // Defaults to 0
-        tls: {}, // tls/ssl
-      },
-    },
-  },
-});
+        tls: {} // tls/ssl
+      }
+    }
+  }
+})
 ```
 
 Alternatively, using server plugins:
@@ -376,35 +373,34 @@ Alternatively, using server plugins:
 ::code-group
 
 ```ts [server/plugins/storage.ts]
-import redisDriver from "unstorage/drivers/redis";
+import redisDriver from 'unstorage/drivers/redis'
 
 export default defineNitroPlugin(() => {
-  const storage = useStorage();
+  const storage = useStorage()
 
   // Dynamically pass in credentials from runtime configuration, or other sources
   const driver = redisDriver({
-    base: "redis",
-    host: useRuntimeConfig().redis.host,
-    port: useRuntimeConfig().redis.port,
-    /* other redis connector options */
-  });
+      base: 'redis',
+      host: useRuntimeConfig().redis.host,
+      port: useRuntimeConfig().redis.port,
+      /* other redis connector options */
+    })
 
   // Mount driver
-  storage.mount("redis", driver);
-});
+  storage.mount('redis', driver)
+})
 ```
 
-```ts [nuxt.config.ts]
+``` ts [nuxt.config.ts]
 export default defineNuxtConfig({
   runtimeConfig: {
-    redis: {
-      // Default values
-      host: "",
+    redis: { // Default values
+      host: '',
       port: 0,
       /* other redis connector options */
-    },
-  },
-});
+    }
+  }
+})
 ```
 
 ::
@@ -413,30 +409,30 @@ Create a new file in `server/api/test.post.ts`:
 
 ```ts [server/api/test.post.ts]
 export default defineEventHandler(async (event) => {
-  const body = await readBody(event);
-  await useStorage().setItem("redis:test", body);
-  return "Data is set";
-});
+  const body = await readBody(event)
+  await useStorage().setItem('redis:test', body)
+  return 'Data is set'
+})
 ```
 
 Create a new file in `server/api/test.get.ts`:
 
 ```ts [server/api/test.get.ts]
 export default defineEventHandler(async (event) => {
-  const data = await useStorage().getItem("redis:test");
-  return data;
-});
+  const data = await useStorage().getItem('redis:test')
+  return data
+})
 ```
 
 Create a new file in `app.vue`:
 
 ```vue [app.vue]
 <script setup lang="ts">
-const { data: resDataSuccess } = await useFetch("/api/test", {
-  method: "post",
-  body: { text: "Nuxt is Awesome!" },
-});
-const { data: resData } = await useFetch("/api/test");
+  const { data: resDataSuccess } = await useFetch('/api/test', {
+      method: 'post',
+      body: { text: 'Nuxt is Awesome!' }
+  })
+  const { data: resData } = await useFetch('/api/test')
 </script>
 
 <template>

--- a/docs/2.guide/2.directory-structure/1.server.md
+++ b/docs/2.guide/2.directory-structure/1.server.md
@@ -155,7 +155,7 @@ Server routes can use dynamic parameters within brackets in the file name like `
 export default defineEventHandler((event) => {
   const { name } = event.context.params
   return { `Hello, ${name}!` }
-}
+})
 ```
 
 You can now universally call this API using `await $fetch('/api/hello/nuxt')` and get `Hello, nuxt!`.


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->


### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
Here the single line ```export default defineEventHandler((event) => `Hello, ${event.context.params.name}!`)``` is long. That is why the full code becomes blur in the doc. 
![blur](https://github.com/nuxt/nuxt/assets/47961062/d6eef4df-0b6a-4c19-ac3a-29c7441369e0)
It is not readable and we cannot see the full code by default in the doc. Making it two lines removes the blur issue.
<!-- Why is this change required? What problem does it solve? -->
I think it is required because by default the line becomes blur in the doc. we cannot see the entire line because of long single line of code. That is why we can make it readable.

<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
