### PR TITLE
fix(nuxt): unsub from hooks when unmounting indicator

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-loading-indicator.ts
+++ b/packages/nuxt/src/app/components/nuxt-loading-indicator.ts
@@ -54,14 +54,16 @@ export default defineComponent({
       }
     })
 
-    nuxtApp.hook('page:finish', indicator.finish)
-    nuxtApp.hook('vue:error', indicator.finish)
+    const unsubPage = nuxtApp.hook('page:finish', indicator.finish)
+    const unsubError = nuxtApp.hook('vue:error', indicator.finish)
 
     onBeforeUnmount(() => {
       const index = globalMiddleware.indexOf(indicator.start)
       if (index >= 0) {
         globalMiddleware.splice(index, 1)
       }
+      unsubPage()
+      unsubError()
       indicator.clear()
     })
 


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Spotted this unreported bug. If we ever remove loading indicator it can cause an error because we'll still be calling methods on the unmounted component.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
