### PR TITLE
chore: depend on `h3-nightly` on edge releases

### DIFF
--- a/scripts/bump-edge.ts
+++ b/scripts/bump-edge.ts
@@ -3,6 +3,12 @@ import { $fetch } from 'ofetch'
 import { inc } from 'semver'
 import { determineBumpType, loadWorkspace } from './_utils'
 
+const nightlyPackages = {
+  nitropack: 'nitropack-edge',
+  h3: 'h3-nightly',
+  nuxi: 'nuxi-ng'
+}
+
 async function main () {
   const workspace = await loadWorkspace(process.cwd())
 
@@ -10,11 +16,10 @@ async function main () {
   const date = Math.round(Date.now() / (1000 * 60))
 
   const nuxtPkg = workspace.find('nuxt')
-  const { version: latestNitro } = await $fetch<{ version: string }>('https://registry.npmjs.org/nitropack-edge/latest')
-  nuxtPkg.data.dependencies.nitropack = `npm:nitropack-edge@^${latestNitro}`
-
-  const { version: latestNuxi } = await $fetch<{ version: string }>('https://registry.npmjs.org/nuxi-ng/latest')
-  nuxtPkg.data.dependencies.nuxi = `npm:nuxi-ng@^${latestNuxi}`
+  for (const [pkg, name] of Object.entries(nightlyPackages)) {
+    const { version: latest } = await $fetch<{ version: string }>(`https://registry.npmjs.org/${name}/latest`)
+    nuxtPkg.data.dependencies[pkg] = `npm:${name}@^${latest}`
+  }
 
   const bumpType = await determineBumpType()
 

--- a/scripts/bump-edge.ts
+++ b/scripts/bump-edge.ts
@@ -32,9 +32,6 @@ async function main () {
       if (name in pkg.data.dependencies) {
         pkg.data.dependencies[name] = version
       }
-      if (name in pkg.data.devDependencies) {
-        pkg.data.dependencies[name] = version
-      }
     }
     const newname = pkg.data.name === 'nuxt' ? 'nuxt3' : (pkg.data.name + '-edge')
     workspace.rename(pkg.data.name, newname)


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This also pins h3 on edge releases.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
