### PR TITLE
fix(nuxi): only watch `distDir` after first build

### DIFF
--- a/packages/nuxi/src/commands/dev.ts
+++ b/packages/nuxi/src/commands/dev.ts
@@ -134,11 +134,6 @@ export default defineNuxtCommand({
 
         await currentNuxt.ready()
 
-        distWatcher = chokidar.watch(resolve(currentNuxt.options.buildDir, 'dist'), { ignoreInitial: true, depth: 0 })
-        distWatcher.on('unlinkDir', () => {
-          dLoad(true, '.nuxt/dist directory has been removed')
-        })
-
         const unsub = currentNuxt.hooks.hook('restart', async (options) => {
           unsub() // we use this instead of `hookOnce` for Nuxt Bridge support
           if (options?.hard) { return hardRestart() }
@@ -156,6 +151,12 @@ export default defineNuxtCommand({
           writeTypes(currentNuxt).catch(console.error),
           buildNuxt(currentNuxt)
         ])
+
+        distWatcher = chokidar.watch(resolve(currentNuxt.options.buildDir, 'dist'), { ignoreInitial: true, depth: 0 })
+        distWatcher.on('unlinkDir', () => {
+          dLoad(true, '.nuxt/dist directory has been removed')
+        })
+
         currentHandler = toNodeListener(currentNuxt.server.app)
         if (isRestart && args.clear !== false) {
           showBanner()


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
https://github.com/nuxt/bridge/issues/832
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
nuxt 2 seems to delete buildDir at build time.
https://github.com/nuxt/nuxt/blob/2.x/packages/builder/src/builder.js#L144

I think this problem is occurring because they are executed in the following order.
1. watch for distDir(`.nuxt/dist`)
2. delete buildDir(`.nuxt`)

reproduction
https://stackblitz.com/edit/github-3fgb91-mgegmc
It occurs when I stop the dev server once and run `npm run dev` again.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
