### PR TITLE
docs: clarify `server: false` doesn't await on initial load

### DIFF
--- a/docs/1.getting-started/6.data-fetching.md
+++ b/docs/1.getting-started/6.data-fetching.md
@@ -149,11 +149,9 @@ const { pending, data: posts } = useLazyFetch('/api/posts')
 
 ### Client-only fetching
 
-By default, data fetching composables will perform their asynchronous function on both client and server environments. Set the `server` option to `false` to only perform the call on the client-side. On initial load, the data will not be fetched before hydration is complete so you have to handle a pending state.
+By default, data fetching composables will perform their asynchronous function on both client and server environments. Set the `server` option to `false` to only perform the call on the client-side. On initial load, the data will not be fetched before hydration is complete so you have to handle a pending state, though on subsequent client-side navigation the data will be awaited before loading the page.
 
-On the client-side navigation the data will be loaded before.
-
-Combined with the `lazy` option, this can be useful for data that are not needed on the first render (for example, non-SEO sensitive data).
+Combined with the `lazy` option, this can be useful for data that is not needed on the first render (for example, non-SEO sensitive data).
 
 ```ts
 /* This call will only be performed on the client */

--- a/docs/1.getting-started/6.data-fetching.md
+++ b/docs/1.getting-started/6.data-fetching.md
@@ -149,7 +149,11 @@ const { pending, data: posts } = useLazyFetch('/api/posts')
 
 ### Client-only fetching
 
-By default, data fetching composables will perform their asynchronous function on both client and server environments. Set the `server` option to `false` to only perform the call on the client-side. Combined with the `lazy` option, this can be useful for data that are not needed on the first render (for example, non-SEO sensitive data).
+By default, data fetching composables will perform their asynchronous function on both client and server environments. Set the `server` option to `false` to only perform the call on the client-side. On initial load, the data will not be fetched before hydration is complete so you have to handle a pending state.
+
+On the client-side navigation the data will be loaded before.
+
+Combined with the `lazy` option, this can be useful for data that are not needed on the first render (for example, non-SEO sensitive data).
 
 ```ts
 /* This call will only be performed on the client */
@@ -158,6 +162,7 @@ const { pending, data: posts } = useFetch('/api/comments', {
   server: false
 })
 ```
+The `useFetch` composable is meant to be invoked in setup method or called directly at the top level of a function in lifecycle hooks, otherwise you should use `$fetch` method.
 
 ### Minimize payload size
 

--- a/docs/1.getting-started/6.data-fetching.md
+++ b/docs/1.getting-started/6.data-fetching.md
@@ -162,6 +162,7 @@ const { pending, data: posts } = useFetch('/api/comments', {
   server: false
 })
 ```
+
 The `useFetch` composable is meant to be invoked in setup method or called directly at the top level of a function in lifecycle hooks, otherwise you should use `$fetch` method.
 
 ### Minimize payload size


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
fixes: #13805 - on initial client side load with server:false, useFetch does not await data fetching
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When the server is set to false, the data is not fetched before hydration is completed or it cause a hydration error.
This means a pending state has to be handled.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
