### PR TITLE
docs: warn directives must be registered on both server/client

### DIFF
--- a/docs/2.guide/2.directory-structure/1.plugins.md
+++ b/docs/2.guide/2.directory-structure/1.plugins.md
@@ -223,4 +223,8 @@ export default defineNuxtPlugin((nuxtApp) => {
 })
 ```
 
+::alert{type=warning}
+If you register a Vue directive, you _must_ register it on both client and server side unless you are only using it when rendering one side. If the directive only makes sense from a client side, you can always move it to `~/plugins/my-directive.client.ts` and provide a 'stub' directive for the server in `~/plugins/my-directive.server.ts`.
+::
+
 :ReadMore{link="https://vuejs.org/guide/reusability/custom-directives.html"}


### PR DESCRIPTION
### 🔗 Linked issue

resolves nuxt/nuxt#14568

### ❓ Type of change
- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds a warning to the docs that directives need to be registered on both client/server

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
