### PR TITLE
fix(nuxi): ignore error if nitro is not enabled on bridge

### DIFF
--- a/packages/nuxi/package.json
+++ b/packages/nuxi/package.json
@@ -41,6 +41,7 @@
     "listhen": "1.3.0",
     "mlly": "1.4.0",
     "mri": "1.2.0",
+    "nitropack": "^2.5.2",
     "ohash": "1.1.3",
     "pathe": "1.1.1",
     "perfect-debounce": "1.0.0",

--- a/packages/nuxi/src/commands/build.ts
+++ b/packages/nuxi/src/commands/build.ts
@@ -1,5 +1,6 @@
 import { relative, resolve } from 'pathe'
 import { consola } from 'consola'
+import type { Nitro } from 'nitropack'
 
 // we are deliberately inlining this code as a backup in case user has `@nuxt/schema<3.7`
 import { writeTypes as writeTypesLegacy } from '../../../kit/src/template'
@@ -38,8 +39,12 @@ export default defineNuxtCommand({
       }
     })
 
-    // Use ? for backward compatibility for Nuxt <= RC.10
-    const nitro = useNitro?.()
+    let nitro: Nitro | undefined
+    // In Bridge, if nitro is not enabled, useNitro will throw an error
+    try {
+      // Use ? for backward compatibility for Nuxt <= RC.10
+      nitro = useNitro?.()
+    } catch {}
 
     await clearBuildDir(nuxt.options.buildDir)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -316,6 +316,9 @@ importers:
       mri:
         specifier: 1.2.0
         version: 1.2.0
+      nitropack:
+        specifier: ^2.5.2
+        version: 2.5.2
       ohash:
         specifier: 1.1.3
         version: 1.1.3


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/bridge/issues/566

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This ignores the error we throw about nitro not being initialised if called in a Bridge context where nitro is not enabled.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
