### PR TITLE
fix(vite): use `''` key for root scope in variable collector

### DIFF
--- a/packages/vite/src/plugins/composable-keys.ts
+++ b/packages/vite/src/plugins/composable-keys.ts
@@ -141,14 +141,26 @@ export const composableKeysPlugin = createUnplugin((options: ComposableKeysOptio
   }
 })
 
+/*
+* track scopes with unique keys. for example
+* ```js
+* // root scope, marked as ''
+* function a () { // '0'
+*   function b () {} // '0-0'
+*   function c () {} // '0-1'
+* }
+* function d () {} // '1'
+* // ''
+* ```
+* */
 class ScopeTracker {
+  // the top of the stack is not a part of current key, it is used for next level
   scopeIndexStack: number[]
   curScopeKey: string
 
   constructor () {
-    // top level
     this.scopeIndexStack = [0]
-    this.curScopeKey = '0'
+    this.curScopeKey = ''
   }
 
   getKey () {
@@ -173,8 +185,7 @@ class ScopedVarsCollector {
 
   constructor () {
     this.all = new Map()
-    // top level
-    this.curScopeKey = '0'
+    this.curScopeKey = ''
   }
 
   refresh (scopeKey: string) {
@@ -192,7 +203,7 @@ class ScopedVarsCollector {
 
   hasVar (scopeKey: string, name: string) {
     const indices = scopeKey.split('-').map(Number)
-    for (let i = indices.length; i > 0; i--) {
+    for (let i = indices.length; i >= 0; i--) {
       if (this.all.get(indices.slice(0, i).join('-'))?.has(name)) {
         return true
       }

--- a/test/fixtures/basic/other-composables-folder/local.ts
+++ b/test/fixtures/basic/other-composables-folder/local.ts
@@ -1,0 +1,5 @@
+function useAsyncData (s?: any) { return s }
+
+export const ShouldNotBeKeyed = (() => {
+  return useAsyncData()
+})()

--- a/test/fixtures/basic/pages/keyed-composables/local.vue
+++ b/test/fixtures/basic/pages/keyed-composables/local.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { ShouldNotBeKeyed } from '~/other-composables-folder/local'
+
 function localScopedComposables () {
   const _assert = (key?: string) => key ?? 'was not keyed'
 
@@ -39,11 +41,15 @@ function localScopedComposables () {
     })()]
   }
 
+  function fromNonComponentFile () {
+    return [_assert(ShouldNotBeKeyed)]
+  }
+
   function useCustomKeyedComposable (arg?: string) {
     return _assert(arg)
   }
 
-  return [...basic(), ...hoisting(), ...complex(), ...deeperScope(), useCustomKeyedComposable()]
+  return [...basic(), ...hoisting(), ...complex(), ...deeperScope(), ...fromNonComponentFile(), useCustomKeyedComposable()]
 }
 const skippedLocalScopedComposables = localScopedComposables().every(res => res === 'was not keyed')
 </script>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

The key of the root scope should be an empty string instead of '0'. I didn't notice this mistake because all setup script code will be put in a nested scope, so I introduced a test case to verify if it can correctly analyze the normal code.

Besides this, I think these code need to be refactored and have independent tests, but currently I don't have good ideas of that.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
