### PR TITLE
fix: useRouter() fallback to useRouter() from 'vue-router'

### DIFF
--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -13,7 +13,7 @@ import type { PageMeta } from '#app'
 import { PageRouteSymbol } from '#app/components/injections'
 
 export const useRouter: typeof _useRouter = () => {
-  return useNuxtApp()?.$router as Router
+  return useNuxtApp()?.$router ?? _useRouter() as Router
 }
 
 export const useRoute: typeof _useRoute = () => {


### PR DESCRIPTION

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ x ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ x ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

useRouter should fall-back to `useRouter` from `vue-router`, as that will be cases where it is not defined

Maybe this is not a usual case for normal Nuxt Project, but when i was implementing Nuxt framework project in Storybook this occurs i fixed by a workaround which set the $router manually before registering plugins 



