### PR TITLE
docs: add instructions for Bun package manager

### DIFF
--- a/docs/1.getting-started/2.installation.md
+++ b/docs/1.getting-started/2.installation.md
@@ -88,6 +88,10 @@ npm install
 pnpm install
 ```
 
+```bash [bun]
+bun install
+```
+
 ::
 
 ## Development Server
@@ -106,6 +110,10 @@ npm run dev -- -o
 
 ```bash [pnpm]
 pnpm dev -o
+```
+
+```bash [pnpm]
+bun run dev -o
 ```
 
 ::

--- a/docs/2.guide/2.directory-structure/1.node_modules.md
+++ b/docs/2.guide/2.directory-structure/1.node_modules.md
@@ -7,4 +7,4 @@ head.title: "node_modules/"
 
 # Node modules Directory
 
-The package manager ([`npm`](https://docs.npmjs.com/cli/v7/commands/npm) or [`yarn`](https://yarnpkg.com/) or [`pnpm`](https://pnpm.io/cli/install)) creates the [`node_modules/` directory](/docs/guide/directory-structure/node_modules) to store the dependencies of your project.
+The package manager ([`npm`](https://docs.npmjs.com/cli/v7/commands/npm) or [`yarn`](https://yarnpkg.com/) or [`pnpm`](https://pnpm.io/cli/install) or [`bun`](https://bun.sh/package-manager))  creates the [`node_modules/` directory](/docs/guide/directory-structure/node_modules) to store the dependencies of your project.

--- a/docs/2.guide/3.going-further/11.edge-channel.md
+++ b/docs/2.guide/3.going-further/11.edge-channel.md
@@ -30,7 +30,7 @@ Update `nuxt` dependency inside `package.json`:
 }
 ```
 
-Remove lockfile (`package-lock.json`, `yarn.lock`, or `pnpm-lock.yaml`) and reinstall dependencies.
+Remove lockfile (`package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, or `bun.lockb`) and reinstall dependencies.
 
 ## Opting Out From the Edge Channel
 
@@ -45,7 +45,7 @@ Update `nuxt` dependency inside `package.json`:
 }
 ```
 
-Remove lockfile (`package-lock.json`, `yarn.lock`, or `pnpm-lock.yaml`) and reinstall dependencies.
+Remove lockfile (`package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, or `bun.lockb`) and reinstall dependencies.
 
 ## Using Latest `nuxi` CLI From Edge
 

--- a/docs/5.community/4.contribution.md
+++ b/docs/5.community/4.contribution.md
@@ -157,7 +157,7 @@ We recommend using [VS Code](https://code.visualstudio.com/) along with the [ESL
 
 #### No Prettier
 
-Since ESLint is already configured to format the code, there is no need to duplicate the functionality with Prettier. To format the code, you can run `yarn lint --fix` or `pnpm lint --fix` or referring the [ESLint section](#use-eslint) for IDE Setup.
+Since ESLint is already configured to format the code, there is no need to duplicate the functionality with Prettier. To format the code, you can run `yarn lint --fix`, `pnpm lint --fix`, or `bun run lint --fix` or referring the [ESLint section](#use-eslint) for IDE Setup.
 
 If you have Prettier installed in your editor, we recommend you disable it when working on the project to avoid conflict.
 


### PR DESCRIPTION

### ❓ Type of change
Add instructions for `bun` package manager where relevant. 
- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)

