### PR TITLE
fix(nuxt): respect ignorelist when scanning auto-imports

### DIFF
--- a/packages/nuxt/src/imports/module.ts
+++ b/packages/nuxt/src/imports/module.ts
@@ -1,4 +1,4 @@
-import { addTemplate, addVitePlugin, addWebpackPlugin, defineNuxtModule, resolveAlias, tryResolveModule, updateTemplates, useNuxt } from '@nuxt/kit'
+import { addTemplate, addVitePlugin, addWebpackPlugin, defineNuxtModule, isIgnored, resolveAlias, tryResolveModule, updateTemplates, useNuxt } from '@nuxt/kit'
 import { isAbsolute, join, normalize, relative, resolve } from 'pathe'
 import type { Import, Unimport } from 'unimport'
 import { createUnimport, scanDirExports } from 'unimport'
@@ -92,7 +92,9 @@ export default defineNuxtModule<Partial<ImportsOptions>>({
         // Clear old imports
         imports.length = 0
         // Scan `composables/`
-        const composableImports = await scanDirExports(composablesDirs)
+        const composableImports = await scanDirExports(composablesDirs, {
+          fileFilter: file => !isIgnored(file)
+        })
         for (const i of composableImports) {
           i.priority = i.priority || priorities.find(([dir]) => i.from.startsWith(dir))?.[1]
         }

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -889,6 +889,13 @@ describe('composable tree shaking', () => {
   })
 })
 
+describe('ignore list', () => {
+  it('should ignore composable files in .nuxtignore', async () => {
+    const html = await $fetch('/ignore/composables')
+    expect(html).toContain('was import ignored: true')
+  })
+})
+
 describe('server tree shaking', () => {
   it('should work', async () => {
     const html = await $fetch('/client')

--- a/test/fixtures/basic/.nuxtignore
+++ b/test/fixtures/basic/.nuxtignore
@@ -1,0 +1,1 @@
+composables/ignored.*

--- a/test/fixtures/basic/composables/ignored.ts
+++ b/test/fixtures/basic/composables/ignored.ts
@@ -1,0 +1,3 @@
+export function useIgnoredImport () {
+
+}

--- a/test/fixtures/basic/pages/ignore/composables.vue
+++ b/test/fixtures/basic/pages/ignore/composables.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-const d = typeof useIgnoredImport
+const wasImportIgnored = typeof useIgnoredImport === 'undefined'
 </script>
 
 <template>
   <div>
-    was import ignored: {{ d === 'undefined' }}
+    was import ignored: {{ wasImportIgnored }}
   </div>
 </template>

--- a/test/fixtures/basic/pages/ignore/composables.vue
+++ b/test/fixtures/basic/pages/ignore/composables.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+const d = typeof useIgnoredImport
+</script>
+
+<template>
+  <div>
+    was import ignored: {{ d === 'undefined' }}
+  </div>
+</template>


### PR DESCRIPTION
### 🔗 Linked issue

resolves nuxt/nuxt#22775

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This respects the nuxt ignore list when scanning composable files.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
