### PR TITLE
refactor(nuxt): import `useNitroApp` from subpath

### DIFF
--- a/packages/nuxt/src/core/runtime/nitro/error.ts
+++ b/packages/nuxt/src/core/runtime/nitro/error.ts
@@ -2,7 +2,8 @@ import { joinURL, withQuery } from 'ufo'
 import type { NitroErrorHandler } from 'nitropack'
 import type { H3Error } from 'h3'
 import { getRequestHeaders, send, setResponseHeader, setResponseStatus } from 'h3'
-import { useNitroApp, useRuntimeConfig } from '#internal/nitro'
+import { useRuntimeConfig } from '#internal/nitro'
+import { useNitroApp } from '#internal/nitro/app'
 import { isJsonRequest, normalizeError } from '#internal/nitro/utils'
 
 export default <NitroErrorHandler> async function errorhandler (error: H3Error, event) {


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/18789#comment-2857911

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This ensures we import `useNitroApp` from correct path to avoid chunk issue with rollup.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
