### PR TITLE
feat(schema): support setting `hidden` sourcemaps

### DIFF
--- a/packages/nuxt/src/components/module.ts
+++ b/packages/nuxt/src/components/module.ts
@@ -208,16 +208,16 @@ export default defineNuxtModule<ComponentsOptions>({
       config.plugins = config.plugins || []
       if (nuxt.options.experimental.treeshakeClientOnly && isServer) {
         config.plugins.push(TreeShakeTemplatePlugin.vite({
-          sourcemap: nuxt.options.sourcemap[mode],
+          sourcemap: !!nuxt.options.sourcemap[mode],
           getComponents
         }))
       }
       config.plugins.push(clientFallbackAutoIdPlugin.vite({
-        sourcemap: nuxt.options.sourcemap[mode],
+        sourcemap: !!nuxt.options.sourcemap[mode],
         rootDir: nuxt.options.rootDir
       }))
       config.plugins.push(loaderPlugin.vite({
-        sourcemap: nuxt.options.sourcemap[mode],
+        sourcemap: !!nuxt.options.sourcemap[mode],
         getComponents,
         mode,
         transform: typeof nuxt.options.components === 'object' && !Array.isArray(nuxt.options.components) ? nuxt.options.components.transform : undefined,
@@ -252,16 +252,16 @@ export default defineNuxtModule<ComponentsOptions>({
         config.plugins = config.plugins || []
         if (nuxt.options.experimental.treeshakeClientOnly && mode === 'server') {
           config.plugins.push(TreeShakeTemplatePlugin.webpack({
-            sourcemap: nuxt.options.sourcemap[mode],
+            sourcemap: !!nuxt.options.sourcemap[mode],
             getComponents
           }))
         }
         config.plugins.push(clientFallbackAutoIdPlugin.webpack({
-          sourcemap: nuxt.options.sourcemap[mode],
+          sourcemap: !!nuxt.options.sourcemap[mode],
           rootDir: nuxt.options.rootDir
         }))
         config.plugins.push(loaderPlugin.webpack({
-          sourcemap: nuxt.options.sourcemap[mode],
+          sourcemap: !!nuxt.options.sourcemap[mode],
           getComponents,
           mode,
           transform: typeof nuxt.options.components === 'object' && !Array.isArray(nuxt.options.components) ? nuxt.options.components.transform : undefined,

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -94,14 +94,14 @@ async function initNuxt (nuxt: Nuxt) {
   if (nuxt.options.experimental.localLayerAliases) {
     // Add layer aliasing support for ~, ~~, @ and @@ aliases
     addVitePlugin(() => LayerAliasingPlugin.vite({
-      sourcemap: nuxt.options.sourcemap.server || nuxt.options.sourcemap.client,
+      sourcemap: !!nuxt.options.sourcemap.server || !!nuxt.options.sourcemap.client,
       dev: nuxt.options.dev,
       root: nuxt.options.srcDir,
       // skip top-level layer (user's project) as the aliases will already be correctly resolved
       layers: nuxt.options._layers.slice(1)
     }))
     addWebpackPlugin(() => LayerAliasingPlugin.webpack({
-      sourcemap: nuxt.options.sourcemap.server || nuxt.options.sourcemap.client,
+      sourcemap: !!nuxt.options.sourcemap.server || !!nuxt.options.sourcemap.client,
       dev: nuxt.options.dev,
       root: nuxt.options.srcDir,
       // skip top-level layer (user's project) as the aliases will already be correctly resolved
@@ -113,7 +113,7 @@ async function initNuxt (nuxt: Nuxt) {
   nuxt.hook('modules:done', () => {
     // Add unctx transform
     const options = {
-      sourcemap: nuxt.options.sourcemap.server || nuxt.options.sourcemap.client,
+      sourcemap: !!nuxt.options.sourcemap.server || !!nuxt.options.sourcemap.client,
       transformerOptions: nuxt.options.optimization.asyncTransforms
     }
     addVitePlugin(() => UnctxTransformPlugin.vite(options))
@@ -121,7 +121,7 @@ async function initNuxt (nuxt: Nuxt) {
 
     // Add composable tree-shaking optimisations
     const serverTreeShakeOptions: TreeShakeComposablesPluginOptions = {
-      sourcemap: nuxt.options.sourcemap.server,
+      sourcemap: !!nuxt.options.sourcemap.server,
       composables: nuxt.options.optimization.treeShake.composables.server
     }
     if (Object.keys(serverTreeShakeOptions.composables).length) {
@@ -129,7 +129,7 @@ async function initNuxt (nuxt: Nuxt) {
       addWebpackPlugin(() => TreeShakeComposablesPlugin.webpack(serverTreeShakeOptions), { client: false })
     }
     const clientTreeShakeOptions: TreeShakeComposablesPluginOptions = {
-      sourcemap: nuxt.options.sourcemap.client,
+      sourcemap: !!nuxt.options.sourcemap.client,
       composables: nuxt.options.optimization.treeShake.composables.client
     }
     if (Object.keys(clientTreeShakeOptions.composables).length) {
@@ -140,8 +140,8 @@ async function initNuxt (nuxt: Nuxt) {
 
   if (!nuxt.options.dev) {
     // DevOnly component tree-shaking - build time only
-    addVitePlugin(() => DevOnlyPlugin.vite({ sourcemap: nuxt.options.sourcemap.server || nuxt.options.sourcemap.client }))
-    addWebpackPlugin(() => DevOnlyPlugin.webpack({ sourcemap: nuxt.options.sourcemap.server || nuxt.options.sourcemap.client }))
+    addVitePlugin(() => DevOnlyPlugin.vite({ sourcemap: !!nuxt.options.sourcemap.server || !!nuxt.options.sourcemap.client }))
+    addWebpackPlugin(() => DevOnlyPlugin.webpack({ sourcemap: !!nuxt.options.sourcemap.server || !!nuxt.options.sourcemap.client }))
   }
 
   // Transform initial composable call within `<script setup>` to preserve context

--- a/packages/nuxt/src/imports/module.ts
+++ b/packages/nuxt/src/imports/module.ts
@@ -82,8 +82,8 @@ export default defineNuxtModule<Partial<ImportsOptions>>({
     nuxt.options.alias['#imports'] = join(nuxt.options.buildDir, 'imports')
 
     // Transform to inject imports in production mode
-    addVitePlugin(() => TransformPlugin.vite({ ctx, options, sourcemap: nuxt.options.sourcemap.server || nuxt.options.sourcemap.client }))
-    addWebpackPlugin(() => TransformPlugin.webpack({ ctx, options, sourcemap: nuxt.options.sourcemap.server || nuxt.options.sourcemap.client }))
+    addVitePlugin(() => TransformPlugin.vite({ ctx, options, sourcemap: !!nuxt.options.sourcemap.server || !!nuxt.options.sourcemap.client }))
+    addWebpackPlugin(() => TransformPlugin.webpack({ ctx, options, sourcemap: !!nuxt.options.sourcemap.server || !!nuxt.options.sourcemap.client }))
 
     const priorities = nuxt.options._layers.map((layer, i) => [layer.config.srcDir, -i] as const).sort(([a], [b]) => b.length - a.length)
 

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -308,7 +308,7 @@ export default defineNuxtModule({
     // Extract macros from pages
     const pageMetaOptions: PageMetaPluginOptions = {
       dev: nuxt.options.dev,
-      sourcemap: nuxt.options.sourcemap.server || nuxt.options.sourcemap.client
+      sourcemap: !!nuxt.options.sourcemap.server || !!nuxt.options.sourcemap.client
     }
     nuxt.hook('modules:done', () => {
       addVitePlugin(() => PageMetaPlugin.vite(pageMetaOptions))

--- a/packages/schema/src/config/build.ts
+++ b/packages/schema/src/config/build.ts
@@ -25,7 +25,7 @@ export default defineUntypedSchema({
   /**
    * Whether to generate sourcemaps.
    *
-   * @type {boolean | { server?: boolean, client?: boolean }}
+   * @type {boolean | { server?: boolean | 'hidden', client?: boolean | 'hidden' }}
    */
   sourcemap: {
     $resolve: async (val, get) => {

--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -35,7 +35,7 @@ export async function buildClient (ctx: ViteBuildContext) {
       }
     },
     css: {
-      devSourcemap: ctx.nuxt.options.sourcemap.client
+      devSourcemap: !!ctx.nuxt.options.sourcemap.client
     },
     define: {
       'process.env.NODE_ENV': JSON.stringify(ctx.config.mode),
@@ -78,11 +78,11 @@ export async function buildClient (ctx: ViteBuildContext) {
         buildAssetsURL: joinURL(ctx.nuxt.options.app.baseURL, ctx.nuxt.options.app.buildAssetsDir)
       }),
       runtimePathsPlugin({
-        sourcemap: ctx.nuxt.options.sourcemap.client
+        sourcemap: !!ctx.nuxt.options.sourcemap.client
       }),
       viteNodePlugin(ctx),
       pureAnnotationsPlugin.vite({
-        sourcemap: ctx.nuxt.options.sourcemap.client,
+        sourcemap: !!ctx.nuxt.options.sourcemap.client,
         functions: ['defineComponent', 'defineAsyncComponent', 'defineNuxtLink', 'createClientOnly', 'defineNuxtPlugin', 'defineNuxtRouteMiddleware', 'defineNuxtComponent', 'useRuntimeConfig', 'defineRouteRules']
       })
     ],
@@ -102,7 +102,7 @@ export async function buildClient (ctx: ViteBuildContext) {
 
   // Emit chunk errors if the user has opted in to `experimental.emitRouteChunkError`
   if (ctx.nuxt.options.experimental.emitRouteChunkError) {
-    clientConfig.plugins!.push(chunkErrorPlugin({ sourcemap: ctx.nuxt.options.sourcemap.client }))
+    clientConfig.plugins!.push(chunkErrorPlugin({ sourcemap: !!ctx.nuxt.options.sourcemap.client }))
   }
 
   // We want to respect users' own rollup output options
@@ -135,7 +135,7 @@ export async function buildClient (ctx: ViteBuildContext) {
 
   // Add type checking client panel
   if (ctx.nuxt.options.typescript.typeCheck && ctx.nuxt.options.dev) {
-    clientConfig.plugins!.push(typeCheckPlugin({ sourcemap: ctx.nuxt.options.sourcemap.client }))
+    clientConfig.plugins!.push(typeCheckPlugin({ sourcemap: !!ctx.nuxt.options.sourcemap.client }))
   }
 
   await ctx.nuxt.callHook('vite:extendConfig', clientConfig, { isClient: true, isServer: false })

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -37,7 +37,7 @@ export async function buildServer (ctx: ViteBuildContext) {
       }
     },
     css: {
-      devSourcemap: ctx.nuxt.options.sourcemap.server
+      devSourcemap: !!ctx.nuxt.options.sourcemap.server
     },
     define: {
       'process.server': true,
@@ -106,7 +106,7 @@ export async function buildServer (ctx: ViteBuildContext) {
     },
     plugins: [
       pureAnnotationsPlugin.vite({
-        sourcemap: ctx.nuxt.options.sourcemap.server,
+        sourcemap: !!ctx.nuxt.options.sourcemap.server,
         functions: ['defineComponent', 'defineAsyncComponent', 'defineNuxtLink', 'createClientOnly', 'defineNuxtPlugin', 'defineNuxtRouteMiddleware', 'defineNuxtComponent', 'useRuntimeConfig', 'defineRouteRules']
       })
     ]

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -99,7 +99,7 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
         },
         plugins: [
           composableKeysPlugin.vite({
-            sourcemap: nuxt.options.sourcemap.server || nuxt.options.sourcemap.client,
+            sourcemap: !!nuxt.options.sourcemap.server || !!nuxt.options.sourcemap.client,
             rootDir: nuxt.options.rootDir,
             composables: nuxt.options.optimization.keyedComposables
           }),

--- a/packages/webpack/src/configs/client.ts
+++ b/packages/webpack/src/configs/client.ts
@@ -30,12 +30,14 @@ function clientDevtool (ctx: WebpackConfigContext) {
     return
   }
 
+  const prefix = ctx.nuxt.options.sourcemap.client === 'hidden' ? 'hidden-' : ''
+
   if (!ctx.isDev) {
-    ctx.config.devtool = 'source-map'
+    ctx.config.devtool = prefix + 'source-map'
     return
   }
 
-  ctx.config.devtool = 'eval-cheap-module-source-map'
+  ctx.config.devtool = prefix + 'eval-cheap-module-source-map'
 }
 
 function clientPerformance (ctx: WebpackConfigContext) {

--- a/packages/webpack/src/configs/server.ts
+++ b/packages/webpack/src/configs/server.ts
@@ -27,7 +27,12 @@ export function server (ctx: WebpackConfigContext) {
 function serverPreset (ctx: WebpackConfigContext) {
   ctx.config.output!.filename = 'server.mjs'
 
-  ctx.config.devtool = ctx.nuxt.options.sourcemap.server ? ctx.isDev ? 'cheap-module-source-map' : 'source-map' : false
+  if (ctx.nuxt.options.sourcemap.server) {
+    const prefix = ctx.nuxt.options.sourcemap.server === 'hidden' ? 'hidden-' : ''
+    ctx.config.devtool = prefix + ctx.isDev ? 'cheap-module-source-map' : 'source-map'
+  } else {
+    ctx.config.devtool = false
+  }
 
   ctx.config.optimization = {
     splitChunks: false,

--- a/packages/webpack/src/webpack.ts
+++ b/packages/webpack/src/webpack.ts
@@ -39,14 +39,14 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
 
   for (const config of webpackConfigs) {
     config.plugins!.push(DynamicBasePlugin.webpack({
-      sourcemap: nuxt.options.sourcemap[config.name as 'client' | 'server']
+      sourcemap: !!nuxt.options.sourcemap[config.name as 'client' | 'server']
     }))
     // Emit chunk errors if the user has opted in to `experimental.emitRouteChunkError`
     if (config.name === 'client' && nuxt.options.experimental.emitRouteChunkError) {
       config.plugins!.push(new ChunkErrorPlugin())
     }
     config.plugins!.push(composableKeysPlugin.webpack({
-      sourcemap: nuxt.options.sourcemap[config.name as 'client' | 'server'],
+      sourcemap: !!nuxt.options.sourcemap[config.name as 'client' | 'server'],
       rootDir: nuxt.options.rootDir,
       composables: nuxt.options.optimization.keyedComposables
     }))


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/19253

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We now support setting `hidden` as a possible option for sourcemaps since this is now supported in Nitro. Vite already supported it and we now also set [appropriate sourcemap settings](https://webpack.js.org/configuration/devtool/) in webpack.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
