### PR TITLE
fix(schema): mark schema as free of side effects

### DIFF
--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "type": "module",
   "types": "./dist/index.d.ts",
+  "sideEffects": false,
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/cli/issues/83

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Discovered when removing `@nuxt/schema` from externals, it seems rollup inlines various dependencies of `@nuxt/schema` even when just importing types. We can work around this by marking it as side-effect free, which also happens to be the case.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
