### PR TITLE
docs: update custom route meta file name to `nuxt.d.ts`

### DIFF
--- a/docs/2.guide/2.directory-structure/1.pages.md
+++ b/docs/2.guide/2.directory-structure/1.pages.md
@@ -304,7 +304,7 @@ You may define a path matcher, if you have a more complex pattern than can be ex
 
 If you add custom metadata for your pages, you may wish to do so in a type-safe way. It is possible to augment the type of the object accepted by `definePageMeta`:
 
-```ts [index.d.ts]
+```ts [nuxt.d.ts]
 declare module '#app' {
   interface PageMeta {
     pageType?: string


### PR DESCRIPTION
### 🔗 Linked issue

None

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

With current docs, It suggest name `index.d.ts` for custom route meta however this isn't get auto included by nuxt (`.nuxt/tsconfig.json`). So, I renamed it to `nuxt.d.ts` so that it gets auto included.

If we stick to `index.d.ts` then we had to add more instructions on how to add this to tsconfig.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
