### PR TITLE
fix(vite): only mark nitro deps as externals when building

### DIFF
--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -15,7 +15,6 @@ import { transpile } from './utils/transpile'
 export async function buildServer (ctx: ViteBuildContext) {
   const helper = ctx.nuxt.options.nitro.imports !== false ? '' : 'globalThis.'
   const entry = ctx.nuxt.options.ssr ? ctx.entry : await resolvePath(resolve(ctx.nuxt.options.appDir, 'entry-spa'))
-  const nitroDependencies = await tryResolveModule('nitropack/package.json', ctx.nuxt.options.modulesDir).then(r => import(r!)).then(r => Object.keys(r.dependencies || {})).catch(() => [])
   const serverConfig: ViteConfig = vite.mergeConfig(ctx.config, vite.mergeConfig({
     configFile: false,
     base: ctx.nuxt.options.dev
@@ -63,10 +62,6 @@ export async function buildServer (ctx: ViteBuildContext) {
     ssr: {
       external: [
         '#internal/nitro', '#internal/nitro/utils',
-        // explicit dependencies we use in our ssr renderer - these can be inlined (if necessary) in the nitro build
-        'unhead', '@unhead/ssr', '@unhead/vue', 'unctx', 'h3', 'devalue', '@nuxt/devalue', 'radix3', 'unstorage', 'hookable',
-        // dependencies we might share with nitro - these can be inlined (if necessary) in the nitro build
-        ...nitroDependencies
       ],
       noExternal: [
         ...transpile({ isServer: true, isDev: ctx.nuxt.options.dev }),
@@ -111,6 +106,17 @@ export async function buildServer (ctx: ViteBuildContext) {
       })
     ]
   } satisfies vite.InlineConfig, ctx.nuxt.options.vite.$server || {}))
+
+  if (!ctx.nuxt.options.dev) {
+    const nitroDependencies = await tryResolveModule('nitropack/package.json', ctx.nuxt.options.modulesDir)
+      .then(r => import(r!)).then(r => Object.keys(r.dependencies || {})).catch(() => [])
+    serverConfig.ssr!.external!.push(
+      // explicit dependencies we use in our ssr renderer - these can be inlined (if necessary) in the nitro build
+      'unhead', '@unhead/ssr', 'unctx', 'h3', 'devalue', '@nuxt/devalue', 'radix3', 'unstorage', 'hookable',
+      // dependencies we might share with nitro - these can be inlined (if necessary) in the nitro build
+      ...nitroDependencies
+    )
+  }
 
   serverConfig.customLogger = createViteLogger(serverConfig)
 

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -61,7 +61,7 @@ export async function buildServer (ctx: ViteBuildContext) {
     },
     ssr: {
       external: [
-        '#internal/nitro', '#internal/nitro/utils',
+        '#internal/nitro', '#internal/nitro/utils'
       ],
       noExternal: [
         ...transpile({ isServer: true, isDev: ctx.nuxt.options.dev }),


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/14146

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When we added nitro deps to externals list, this broke _dev_ mode with vite-node when used without shamefully-hoist.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
