### PR TITLE
fix(kit): respect `priority` when registering components dirs

### DIFF
--- a/packages/kit/src/components.ts
+++ b/packages/kit/src/components.ts
@@ -12,6 +12,7 @@ export async function addComponentsDir (dir: ComponentsDir) {
   const nuxt = useNuxt()
   await assertNuxtCompatibility({ nuxt: '>=2.13' }, nuxt)
   nuxt.options.components = nuxt.options.components || []
+  dir.priority ||= 0
   nuxt.hook('components:dirs', (dirs) => { dirs.push(dir) })
 }
 

--- a/packages/nuxt/src/components/scan.ts
+++ b/packages/nuxt/src/components/scan.ts
@@ -121,7 +121,7 @@ export async function scanComponents (dirs: ComponentsDir[], srcDir: string): Pr
         shortPath,
         export: 'default',
         // by default, give priority to scanned components
-        priority: 1
+        priority: dir.priority ?? 1
       }
 
       if (typeof dir.extendComponent === 'function') {
@@ -135,9 +135,15 @@ export async function scanComponents (dirs: ComponentsDir[], srcDir: string): Pr
       }
 
       const existingComponent = components.find(c => c.pascalName === component.pascalName && ['all', component.mode].includes(c.mode))
+      // Ignore component if component is already defined (with same mode)
       if (existingComponent) {
-        // Ignore component if component is already defined (with same mode)
-        warnAboutDuplicateComponent(componentName, filePath, existingComponent.filePath)
+        const existingPriority = existingComponent.priority ?? 0
+        const newPriority = component.priority ?? 0
+
+        if (newPriority >= existingPriority) {
+          warnAboutDuplicateComponent(componentName, filePath, existingComponent.filePath)
+        }
+
         continue
       }
 

--- a/packages/schema/src/types/components.ts
+++ b/packages/schema/src/types/components.ts
@@ -85,6 +85,14 @@ export interface ComponentsDir extends ScanDir {
    * By default ('auto') it will set transpile: true if node_modules/ is in path.
    */
   transpile?: 'auto' | boolean
+  /**
+   * This number allows configuring the behavior of overriding Nuxt components.
+   * It will be inherited by any components within the directory.
+   *
+   * If multiple components are provided with the same name, then higher priority
+   * components will be used instead of lower priority components.
+   */
+  priority?: number
 }
 
 export interface ComponentsOptions {


### PR DESCRIPTION
### 🔗 Linked issue

resolves nuxt/nuxt#22876

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This fixes a unintended regression from https://github.com/nuxt/nuxt/pull/22709. The problem wasn't in that PR, however, it was in the fact that we were relying purely on implicit directory order to register plugins.

This PR allows modules to specify a priority for an entire directory of components - but more importantly, it defaults the behaviour of `addComponentsDir` to be the same as `addComponent` - namely, to allow overriding.

The effect of this PR does not change behaviour; it only suppresses logs when overriding a lower priority component directory, to keep this within a patch release. We can consider bigger possible changes in the next minor.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
