### PR TITLE
fix(nuxt): load layer plugins before project plugins

### DIFF
--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -126,31 +126,21 @@ async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
   }
 
   // Re-initialise plugins
-  app.plugins = nuxt.options.plugins.map(normalizePlugin)
-
-  // Track scanned plugins separately so we can apply a sorting mechanism to them
-  const scannedPlugins: [string, NuxtPlugin][] = []
-  for (const config of nuxt.options._layers.map(layer => layer.config)) {
-    for (const plugin of config.plugins || []) {
-      app.plugins.push(normalizePlugin(plugin as NuxtPlugin | string))
-    }
-
-    if (config.srcDir) {
-      const pluginDir = join(config.srcDir, config.dir?.plugins || 'plugins')
-      for (const file of await resolveFiles(pluginDir, [
-        '*.{ts,js,mjs,cjs,mts,cts}',
-        '*/index.*{ts,js,mjs,cjs,mts,cts}' // TODO: remove, only scan top-level plugins #18418
-      ])) {
-        scannedPlugins.push([file.replace(pluginDir, ''), normalizePlugin(file)])
-      }
-    }
+  app.plugins = []
+  let idx = 0
+  // Sort Plugins: layers plugins first then project plugins
+  for (const config of nuxt.options._layers.map(layer => layer.config).reverse()) {
+    app.plugins[idx++ === (nuxt.options._layers.length - 1) ? 'push' : 'unshift'](...[
+      ...(config.plugins || []),
+      ...config.srcDir
+        ? await resolveFiles(config.srcDir, [
+          `${config.dir?.plugins || 'plugins'}/*.{ts,js,mjs,cjs,mts,cts}`,
+          `${config.dir?.plugins || 'plugins'}/*/index.*{ts,js,mjs,cjs,mts,cts}` // TODO: remove, only scan top-level plugins #18418
+        ])
+        : []
+    ].map(plugin => normalizePlugin(plugin as NuxtPlugin)))
   }
-
-  // Sort scanned plugins by their names so a scanned `01.plugin.ts` will always run before finished `02.plugin.ts`
-  // and append to the plugin array
-  for (const [_name, plugin] of scannedPlugins.sort(([a], [b]) => a.localeCompare(b))) {
-    app.plugins.push(plugin)
-  }
+  app.plugins.unshift(...nuxt.options.plugins.map(normalizePlugin))
 
   // Normalize and de-duplicate plugins and middleware
   app.middleware = uniqueBy(await resolvePaths(app.middleware, 'path'), 'name')

--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -187,5 +187,9 @@ export async function annotatePlugins (nuxt: Nuxt, plugins: NuxtPlugin[]) {
     }
   }
 
-  return _plugins.sort((a, b) => (a.order ?? orderMap.default) - (b.order ?? orderMap.default))
+  return _plugins.sort((a, b) => {
+    const sortMapResult = (a.order ?? orderMap.default) - (b.order ?? orderMap.default)
+    if (sortMapResult !== 0) { return sortMapResult }
+    return a.src!.localeCompare(b.src!)
+  })
 }

--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -141,12 +141,16 @@ async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
         : []
     ].map(plugin => normalizePlugin(plugin as NuxtPlugin)))
   }
+
+  // sort scanned plugins by order and name
+  const pluginNameRegex = /\/index\.[cm]?[jt]s$/
   app.plugins.push(...plugins.sort((a, b) => {
     const sortMapResult = (a.order ?? orderMap.default) - (b.order ?? orderMap.default)
     if (sortMapResult !== 0) { return sortMapResult }
 
-    // TODO: update this when TODO in L139 is resolved
-    return basename(a.src).localeCompare(basename(b.src))
+    const aName = pluginNameRegex.test(a.src) ? basename(dirname(a.src)) : basename(a.src)
+    const bName = pluginNameRegex.test(b.src) ? basename(dirname(b.src)) : basename(b.src)
+    return aName.localeCompare(bName)
   }))
 
   // Normalize and de-duplicate plugins and middleware

--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -1,5 +1,5 @@
 import { promises as fsp, mkdirSync, writeFileSync } from 'node:fs'
-import { basename, dirname, join, resolve } from 'pathe'
+import { dirname, join, resolve } from 'pathe'
 import { defu } from 'defu'
 import { compileTemplate, findPath, normalizePlugin, normalizeTemplate, resolveAlias, resolveFiles, resolvePath, templateUtils, tryResolveModule } from '@nuxt/kit'
 import type { Nuxt, NuxtApp, NuxtPlugin, NuxtTemplate, ResolvedNuxtTemplate } from 'nuxt/schema'

--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -125,12 +125,12 @@ async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
     }))
   }
 
-  // Re-initialise plugins
-  app.plugins = []
-  let idx = 0
-  // Sort Plugins: layers plugins first then project plugins
+  // Resolve plugins, first extended layers and then base
+  app.plugins = [
+    ...nuxt.options.plugins.map(normalizePlugin)
+  ]
   for (const config of nuxt.options._layers.map(layer => layer.config).reverse()) {
-    app.plugins[idx++ === (nuxt.options._layers.length - 1) ? 'push' : 'unshift'](...[
+    app.plugins.push(...[
       ...(config.plugins || []),
       ...config.srcDir
         ? await resolveFiles(config.srcDir, [
@@ -140,7 +140,6 @@ async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
         : []
     ].map(plugin => normalizePlugin(plugin as NuxtPlugin)))
   }
-  app.plugins.unshift(...nuxt.options.plugins.map(normalizePlugin))
 
   // Normalize and de-duplicate plugins and middleware
   app.middleware = uniqueBy(await resolvePaths(app.middleware, 'path'), 'name')

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -983,6 +983,11 @@ describe('extends support', () => {
       const html = await $fetch('/foo')
       expect(html).toContain('Plugin | foo: String generated from foo plugin!')
     })
+
+    it('respects plugin ordering within layers', async () => {
+      const html = await $fetch('/plugins/ordering')
+      expect(html).toContain('catchall at plugins')
+    })
   })
 
   describe('server', () => {

--- a/test/fixtures/basic/extends/bar/plugins/09.layer-plugin-pre.ts
+++ b/test/fixtures/basic/extends/bar/plugins/09.layer-plugin-pre.ts
@@ -1,0 +1,3 @@
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.provide('layerPluginPre', 'layer-plugin')
+})

--- a/test/fixtures/basic/extends/bar/plugins/11.layer-plugin-post.ts
+++ b/test/fixtures/basic/extends/bar/plugins/11.layer-plugin-post.ts
@@ -1,0 +1,3 @@
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.provide('layerPluginPost', 'layer-plugin')
+})

--- a/test/fixtures/basic/plugins/10.layer-ordering.ts
+++ b/test/fixtures/basic/plugins/10.layer-ordering.ts
@@ -3,8 +3,8 @@ export default defineNuxtPlugin((nuxtApp) => {
     if (!nuxtApp.$layerPluginPre) {
       throw createError('layer plugin failed to run before end project plugin')
     }
-    if (nuxtApp.$layerPluginPost) {
-      throw createError('layer plugin failed to run after end project plugin')
+    if (!nuxtApp.$layerPluginPost) {
+      throw createError('layer plugin failed to run before end project plugin')
     }
   }
 })

--- a/test/fixtures/basic/plugins/10.layer-ordering.ts
+++ b/test/fixtures/basic/plugins/10.layer-ordering.ts
@@ -1,0 +1,10 @@
+export default defineNuxtPlugin((nuxtApp) => {
+  if (useRoute().path === '/plugins/ordering') {
+    if (!nuxtApp.$layerPluginPre) {
+      throw createError('layer plugin failed to run before end project plugin')
+    }
+    if (nuxtApp.$layerPluginPost) {
+      throw createError('layer plugin failed to run after end project plugin')
+    }
+  }
+})


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

closes  #22414

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Plugins are only sorted by `order`, should also be sorted by name.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
