### PR TITLE
fix(nuxt): ensure middleware is processed when returning `true`

### DIFF
--- a/packages/nuxt/src/app/plugins/router.ts
+++ b/packages/nuxt/src/app/plugins/router.ts
@@ -58,7 +58,7 @@ function getRouteFromPath (fullPath: string | Partial<Route>) {
   }
 }
 
-type RouteGuardReturn = void | Error | string | false
+type RouteGuardReturn = void | Error | string | boolean
 
 interface RouteGuard {
   (to: Route, from: Route): RouteGuardReturn | Promise<RouteGuardReturn>
@@ -130,7 +130,7 @@ export default defineNuxtPlugin<{ route: Route, router: Router }>({
           // Cancel navigation
           if (result === false || result instanceof Error) { return }
           // Redirect
-          if (result) { return handleNavigation(result, true) }
+          if (typeof result === 'string' && result.length) { return handleNavigation(result, true) }
         }
 
         for (const handler of hooks['resolve:before']) {
@@ -250,6 +250,7 @@ export default defineNuxtPlugin<{ route: Route, router: Router }>({
                 return nuxtApp.runWithContext(() => showError(error))
               }
             }
+            if (result === true) { continue }
             if (result || result === false) { return result }
           }
         }

--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -179,6 +179,7 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
             }
           }
 
+          if (result === true) { continue }
           if (result || result === false) {
             return result
           }

--- a/test/fixtures/basic/middleware/abort.global.ts
+++ b/test/fixtures/basic/middleware/abort.global.ts
@@ -4,4 +4,5 @@ export default defineNuxtRouteMiddleware((to) => {
       statusCode: 401
     })
   }
+  return true
 })


### PR DESCRIPTION
### 🔗 Linked issue

Resolve #22898

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When switching routes, all middleware should run to completion unless there is a middleware redirection or an error occurs. However, currently, if we return `true` in one of the middleware, the loop will terminate without continuing.

As shown below, when `return true` is encountered, the loop exits at line 183, even though there are other unexecuted middlewares afterward:
https://github.com/nuxt/nuxt/blob/aa0ea8bf2d71b59344a773bcebd776f89f4cdafd/packages/nuxt/src/pages/runtime/plugins/router.ts#L182-L184

Therefore, I added a check in the previous code. If `result` is `true`, it allows the loop to continue, executing the next middleware.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
