### PR TITLE
docs: update examples of dynamic `pageKey`

### DIFF
--- a/docs/2.guide/2.directory-structure/1.pages.md
+++ b/docs/2.guide/2.directory-structure/1.pages.md
@@ -205,7 +205,7 @@ If you want more control over when the `<NuxtPage>` component is re-rendered (fo
 <template>
   <div>
     <h1>I am the parent view</h1>
-    <NuxtPage :page-key="someKey" />
+    <NuxtPage :page-key="route => route.fullPath" />
   </div>
 </template>
 ```

--- a/docs/3.api/2.components/2.nuxt-page.md
+++ b/docs/3.api/2.components/2.nuxt-page.md
@@ -40,7 +40,6 @@ You can also use a dynamic key based on the current route. (Don't use `$route` o
 <NuxtPage :page-key="route => route.fullPath" />
 ```
 
-
 Alternatively, `pageKey` can be passed as a `key` value via `definePageMeta` from the `<script>` section of your Vue component in the `/pages` directory.
 
 ```js

--- a/docs/3.api/2.components/2.nuxt-page.md
+++ b/docs/3.api/2.components/2.nuxt-page.md
@@ -34,6 +34,13 @@ For example, passing `static` key, `NuxtPage` component is rendered only once wh
 <NuxtPage page-key="static" />
 ```
 
+You can also use a dynamic key based on the current route. (Don't use `$route` object here as it can cause problems with how `<NuxtPage>` renders pages with `<Suspense>`.)
+
+```html
+<NuxtPage :page-key="route => route.fullPath" />
+```
+
+
 Alternatively, `pageKey` can be passed as a `key` value via `definePageMeta` from the `<script>` section of your Vue component in the `/pages` directory.
 
 ```js


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/22908

### ❓ Type of change
- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Using `$route` to define a dynamic `pageKey` for `<NuxtPage>` can cause odd errors as it's not compatible with the way we render different routes.

This updates the examples and adds a warning.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
