### PR TITLE
fix(nuxt): disallow `write: false` for type templates

### DIFF
--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -1,7 +1,7 @@
 import { existsSync, promises as fsp } from 'node:fs'
 import { basename, isAbsolute, join, parse, relative, resolve } from 'pathe'
 import hash from 'hash-sum'
-import type { Nuxt, NuxtTemplate, ResolvedNuxtTemplate, TSReference } from '@nuxt/schema'
+import type { Nuxt, NuxtTemplate, NuxtTypeTemplate, ResolvedNuxtTemplate, TSReference } from '@nuxt/schema'
 import { withTrailingSlash } from 'ufo'
 import { defu } from 'defu'
 import type { TSConfig } from 'pkg-types'
@@ -34,7 +34,7 @@ export function addTemplate (_template: NuxtTemplate<any> | string) {
  * Renders given types using lodash template during build into the project buildDir
  * and register them as types.
  */
-export function addTypeTemplate (_template: NuxtTemplate<any>) {
+export function addTypeTemplate (_template: NuxtTypeTemplate<any>) {
   const nuxt = useNuxt()
 
   const template = addTemplate(_template)

--- a/packages/schema/src/types/nuxt.ts
+++ b/packages/schema/src/types/nuxt.ts
@@ -18,7 +18,11 @@ export interface NuxtPlugin {
   order?: number
 }
 
-export interface NuxtTemplate<Options = Record<string, any>> {
+// Internal type for simpler NuxtTemplate interface extension
+
+type TemplateDefaultOptions = Record<string, any>
+
+export interface NuxtTemplate<Options = TemplateDefaultOptions> {
   /** resolved output file path (generated) */
   dst?: string
   /** The target filename once the template is copied into the Nuxt buildDir */
@@ -33,17 +37,17 @@ export interface NuxtTemplate<Options = Record<string, any>> {
   write?: boolean
 }
 
-export interface ResolvedNuxtTemplate<Options = Record<string, any>> extends NuxtTemplate<Options> {
+export interface ResolvedNuxtTemplate<Options = TemplateDefaultOptions> extends NuxtTemplate<Options> {
   filename: string
   dst: string
 }
 
-export interface NuxtTypeTemplate<Options = Record<string, any>> extends Omit<NuxtTemplate<Options>, 'write'> {
+export interface NuxtTypeTemplate<Options = TemplateDefaultOptions> extends Omit<NuxtTemplate<Options>, 'write'> {
   write?: true
 }
 
 type _TemplatePlugin<Options> = Omit<NuxtPlugin, 'src'> & NuxtTemplate<Options>
-export interface NuxtPluginTemplate<Options = Record<string, any>> extends _TemplatePlugin<Options> { }
+export interface NuxtPluginTemplate<Options = TemplateDefaultOptions> extends _TemplatePlugin<Options> { }
 
 export interface NuxtApp {
   mainComponent?: string | null

--- a/packages/schema/src/types/nuxt.ts
+++ b/packages/schema/src/types/nuxt.ts
@@ -38,7 +38,9 @@ export interface ResolvedNuxtTemplate<Options = Record<string, any>> extends Nux
   dst: string
 }
 
-export type NuxtTypeTemplate<Options = Record<string, any>> = Omit<NuxtTemplate<Options>, 'write'>
+export interface NuxtTypeTemplate<Options = Record<string, any>> extends Omit<NuxtTemplate<Options>, 'write'> {
+  write?: true
+}
 
 type _TemplatePlugin<Options> = Omit<NuxtPlugin, 'src'> & NuxtTemplate<Options>
 export interface NuxtPluginTemplate<Options = Record<string, any>> extends _TemplatePlugin<Options> { }

--- a/packages/schema/src/types/nuxt.ts
+++ b/packages/schema/src/types/nuxt.ts
@@ -38,6 +38,8 @@ export interface ResolvedNuxtTemplate<Options = Record<string, any>> extends Nux
   dst: string
 }
 
+export type NuxtTypeTemplate<Options = Record<string, any>> = Omit<NuxtTemplate<Options>, 'write'>
+
 type _TemplatePlugin<Options> = Omit<NuxtPlugin, 'src'> & NuxtTemplate<Options>
 export interface NuxtPluginTemplate<Options = Record<string, any>> extends _TemplatePlugin<Options> { }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

As stated in https://github.com/nuxt/nuxt/blob/4e05650cde31ca73be4d14b1f0d23c7854008749/packages/kit/src/template.ts#L89-L92 `.d.ts` files always be written to the filesystem. This pull request introduces the NuxtTypeTemplate interface, where the write parameter for the addTypeTemplate function is omitted.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
