### PR TITLE
perf(nuxt): prevent head dom from rendering twice

### DIFF
--- a/packages/nuxt/src/head/runtime/plugins/unhead.ts
+++ b/packages/nuxt/src/head/runtime/plugins/unhead.ts
@@ -28,8 +28,7 @@ export default defineNuxtPlugin({
       // wait for new page before unpausing dom updates (triggered after suspense resolved)
       nuxtApp.hooks.hook('page:finish', () => {
         // app:suspense:resolve hook will unpause the DOM
-        if (!nuxtApp.isHydrating)
-          syncHead()
+        if (!nuxtApp.isHydrating) { syncHead() }
       })
       // unpause on error
       nuxtApp.hooks.hook('app:error', syncHead)

--- a/packages/nuxt/src/head/runtime/plugins/unhead.ts
+++ b/packages/nuxt/src/head/runtime/plugins/unhead.ts
@@ -26,7 +26,11 @@ export default defineNuxtPlugin({
       head.hooks.hook('dom:beforeRender', (context) => { context.shouldRender = !pauseDOMUpdates })
       nuxtApp.hooks.hook('page:start', () => { pauseDOMUpdates = true })
       // wait for new page before unpausing dom updates (triggered after suspense resolved)
-      nuxtApp.hooks.hook('page:finish', syncHead)
+      nuxtApp.hooks.hook('page:finish', () => {
+        // app:suspense:resolve hook will unpause the DOM
+        if (!nuxtApp.isHydrating)
+          syncHead()
+      })
       // unpause on error
       nuxtApp.hooks.hook('app:error', syncHead)
       // unpause the DOM once the mount suspense is resolved


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

With the move to immediately rendering the dom instead of debouncing it, we've introduced a regression in that the head will render to the DOM twice.

While the performance impact of this is reduced by quite a bit with Unhead 1.3, it's still not ideal and maybe adding ~5ms of extra load time.

The underlying issue is that we should wait for the suspense to resolve if we know the app is hydrating.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
