### PR TITLE
fix(nuxt): render inlined ssr styles before stylesheets

### DIFF
--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -22,7 +22,7 @@ import type { HeadEntryOptions } from '@unhead/schema'
 import { defineRenderHandler, getRouteRules, useRuntimeConfig, useStorage } from '#internal/nitro'
 import { useNitroApp } from '#internal/nitro/app'
 
-import type { Link, Script } from '@unhead/vue'
+import type { Link, Script, Style } from '@unhead/vue'
 import { createServerHead } from '@unhead/vue'
 // @ts-expect-error virtual file
 import unheadPlugins from '#internal/unhead-plugins.mjs'
@@ -495,7 +495,7 @@ function renderHTMLDocument (html: NuxtRenderHTMLContext) {
 </html>`
 }
 
-async function renderInlineStyles (usedModules: Set<string> | string[]) {
+async function renderInlineStyles (usedModules: Set<string> | string[]): Promise<Style[]> {
   const styleMap = await getSSRStyles()
   const inlinedStyles = new Set<string>()
   for (const mod of usedModules) {
@@ -505,7 +505,7 @@ async function renderInlineStyles (usedModules: Set<string> | string[]) {
       }
     }
   }
-  return Array.from(inlinedStyles).map(style => ({ innerHTML: style }))
+  return Array.from(inlinedStyles).map(style => ({ innerHTML: style, tagPriority: 5 }))
 }
 
 function renderPayloadResponse (ssrContext: NuxtSSRContext) {

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -349,12 +349,12 @@ export default defineRenderHandler(async (event): Promise<Partial<RenderResponse
   }
 
   // 2. Styles
+  head.push({ style: inlinedStyles })
   head.push({
     link: Object.values(styles)
       .map(resource =>
         ({ rel: 'stylesheet', href: renderer.rendererContext.buildAssetsURL(resource.file) })
       ),
-    style: inlinedStyles
   }, headEntryOptions)
 
   if (!NO_SCRIPTS) {
@@ -505,7 +505,7 @@ async function renderInlineStyles (usedModules: Set<string> | string[]): Promise
       }
     }
   }
-  return Array.from(inlinedStyles).map(style => ({ innerHTML: style, tagPriority: 5 }))
+  return Array.from(inlinedStyles).map(style => ({ innerHTML: style }))
 }
 
 function renderPayloadResponse (ssrContext: NuxtSSRContext) {

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -354,7 +354,7 @@ export default defineRenderHandler(async (event): Promise<Partial<RenderResponse
     link: Object.values(styles)
       .map(resource =>
         ({ rel: 'stylesheet', href: renderer.rendererContext.buildAssetsURL(resource.file) })
-      ),
+      )
   }, headEntryOptions)
 
   if (!NO_SCRIPTS) {


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/unjs/website/pull/96#discussion_r1312789972

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When moving head rendering to unhead, we inadvertently introduced the possibility to render inline styles _after_ stylesheet links, meaning reset properties could override explicit CSS configuration.

This change aims to ensure that inline styles are rendered first, either before the default 10 priority, or before the ['SYNC_STYLES' priority](https://github.com/unjs/unhead/blob/06544acf0854b70abc2b9f005d4e1fddb207c23e/packages/unhead/src/optionalPlugins/capoPlugin.ts#L31-L34) when using `headNext`'s capo plugin.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
