### PR TITLE
docs: accessing custom props for `NuxtLayout`

### DIFF
--- a/docs/3.api/2.components/3.nuxt-layout.md
+++ b/docs/3.api/2.components/3.nuxt-layout.md
@@ -46,7 +46,7 @@ Please note the layout name is normalized to kebab-case, so if your layout file 
   </NuxtLayout>
 </template>
 ```
-## Custom Props/Layout attrs
+## Passing additional props
 
 `NuxtLayout` also accepts custom props that you may need to pass to the layout. These custom props are accessible via `attrs` in the Nuxt app.
 

--- a/docs/3.api/2.components/3.nuxt-layout.md
+++ b/docs/3.api/2.components/3.nuxt-layout.md
@@ -46,6 +46,7 @@ Please note the layout name is normalized to kebab-case, so if your layout file 
   </NuxtLayout>
 </template>
 ```
+
 ## Passing Additional Props
 
 `NuxtLayout` also accepts custom props that you may need to pass to the layout. These custom props are accessible via `attrs` in the Nuxt app.

--- a/docs/3.api/2.components/3.nuxt-layout.md
+++ b/docs/3.api/2.components/3.nuxt-layout.md
@@ -46,7 +46,7 @@ Please note the layout name is normalized to kebab-case, so if your layout file 
   </NuxtLayout>
 </template>
 ```
-## Passing additional props
+## Passing Additional Props
 
 `NuxtLayout` also accepts custom props that you may need to pass to the layout. These custom props are accessible via `attrs` in the Nuxt app.
 

--- a/docs/3.api/2.components/3.nuxt-layout.md
+++ b/docs/3.api/2.components/3.nuxt-layout.md
@@ -46,6 +46,25 @@ Please note the layout name is normalized to kebab-case, so if your layout file 
   </NuxtLayout>
 </template>
 ```
+## Custom Props/Layout attrs
+
+`NuxtLayout` also accepts custom props that you may need to pass to the layout. These custom props are accessible via `attrs` in the Nuxt app.
+
+```vue[pages/some-page.vue]
+<div>
+  <NuxtLayout name="custom" title="I am a custom layout">
+  </NuxtLayout>
+</div>
+```
+
+In the above example, the value of `title` will be available using `$attrs.title` in the template or `useAttrs().title` in `<script setup>` at custom.vue.
+
+```vue[layouts/custom.vue]
+<script setup lang="ts">
+  const layoutCustomProps = useAttrs()
+  console.log(layoutCustomProps.title)//I am a custom layout
+</script>
+```
 
 ## Layout and Transition
 

--- a/docs/3.api/2.components/3.nuxt-layout.md
+++ b/docs/3.api/2.components/3.nuxt-layout.md
@@ -49,7 +49,7 @@ Please note the layout name is normalized to kebab-case, so if your layout file 
 
 ## Passing Additional Props
 
-`NuxtLayout` also accepts custom props that you may need to pass to the layout. These custom props are accessible via `attrs` in the Nuxt app.
+`NuxtLayout` also accepts any additional props that you may need to pass to the layout. These custom props are then made accessible as attributes.
 
 ```vue[pages/some-page.vue]
 <div>

--- a/docs/3.api/2.components/3.nuxt-layout.md
+++ b/docs/3.api/2.components/3.nuxt-layout.md
@@ -62,7 +62,7 @@ In the above example, the value of `title` will be available using `$attrs.title
 ```vue[layouts/custom.vue]
 <script setup lang="ts">
   const layoutCustomProps = useAttrs()
-  console.log(layoutCustomProps.title)//I am a custom layout
+  console.log(layoutCustomProps.title) // I am a custom layout
 </script>
 ```
 


### PR DESCRIPTION
I documented how one can access props passed to a NuxtLayout, in the layout

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
