### PR TITLE
fix(vite): don't set explicit conditions in `shouldExternalize`

### DIFF
--- a/packages/vite/src/vite-node.ts
+++ b/packages/vite/src/vite-node.ts
@@ -132,10 +132,7 @@ function createViteNodeApp (ctx: ViteBuildContext, invalidates: Set<string> = ne
     node.shouldExternalize = async (id: string) => {
       const result = await isExternal(id)
       if (result?.external) {
-        return resolveModule(result.id, {
-          url: ctx.nuxt.options.modulesDir,
-          conditions: ['node', 'import', 'require']
-        }).catch(() => false)
+        return resolveModule(result.id, { url: ctx.nuxt.options.modulesDir }).catch(() => false)
       }
       return false
     }


### PR DESCRIPTION
### 🔗 Linked issue

resolves nuxt/nuxt#22943, resolves https://github.com/nuxt/nuxt/issues/22918

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This reverts a change to the resolution algorithm used by `vite-node` in https://github.com/nuxt/nuxt/pull/22478, which caused some regressions with resolving CJS vs ESM dependencies.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
