### PR TITLE
fix(nuxt): use `destr` in more places over `JSON.parse`

### DIFF
--- a/packages/nuxt/src/app/components/test-component-wrapper.ts
+++ b/packages/nuxt/src/app/components/test-component-wrapper.ts
@@ -2,6 +2,7 @@ import { parseURL } from 'ufo'
 import { defineComponent, h } from 'vue'
 import { parseQuery } from 'vue-router'
 import { resolve } from 'pathe'
+import destr from 'destr'
 // @ts-expect-error virtual file
 import { devRootDir } from '#build/nuxt.config.mjs'
 
@@ -10,7 +11,7 @@ export default (url: string) => defineComponent({
 
   async setup (props, { attrs }) {
     const query = parseQuery(parseURL(url).search)
-    const urlProps = query.props ? JSON.parse(query.props as string) : {}
+    const urlProps = query.props ? destr(query.props as string) : {}
     const path = resolve(query.path as string)
     if (!path.startsWith(devRootDir)) {
       throw new Error(`[nuxt] Cannot access path outside of project root directory: \`${path}\`.`)

--- a/packages/nuxt/src/app/components/test-component-wrapper.ts
+++ b/packages/nuxt/src/app/components/test-component-wrapper.ts
@@ -11,7 +11,7 @@ export default (url: string) => defineComponent({
 
   async setup (props, { attrs }) {
     const query = parseQuery(parseURL(url).search)
-    const urlProps = query.props ? destr(query.props as string) : {}
+    const urlProps = query.props ? destr<Record<string, any>>(query.props as string) : {}
     const path = resolve(query.path as string)
     if (!path.startsWith(devRootDir)) {
       throw new Error(`[nuxt] Cannot access path outside of project root directory: \`${path}\`.`)

--- a/packages/nuxt/src/app/composables/chunk.ts
+++ b/packages/nuxt/src/app/composables/chunk.ts
@@ -1,3 +1,4 @@
+import destr from 'destr'
 import { useNuxtApp } from '#app/nuxt'
 
 export interface ReloadNuxtAppOptions {
@@ -34,7 +35,7 @@ export function reloadNuxtApp (options: ReloadNuxtAppOptions = {}) {
 
   let handledPath: Record<string, any> = {}
   try {
-    handledPath = JSON.parse(sessionStorage.getItem('nuxt:reload') || '{}')
+    handledPath = destr(sessionStorage.getItem('nuxt:reload') || '{}')
   } catch {}
 
   if (options.force || handledPath?.path !== path || handledPath?.expires < Date.now()) {

--- a/packages/nuxt/src/app/plugins/restore-state.client.ts
+++ b/packages/nuxt/src/app/plugins/restore-state.client.ts
@@ -1,3 +1,4 @@
+import destr from 'destr'
 import { defineNuxtPlugin, useNuxtApp } from '#app/nuxt'
 
 export default defineNuxtPlugin({
@@ -9,7 +10,7 @@ export default defineNuxtPlugin({
         const state = sessionStorage.getItem('nuxt:reload:state')
         if (state) {
           sessionStorage.removeItem('nuxt:reload:state')
-          Object.assign(nuxtApp.payload.state, JSON.parse(state)?.state)
+          Object.assign(nuxtApp.payload.state, destr<Record<string, any>>(state)?.state)
         }
       } catch {}
     }

--- a/packages/nuxt/src/app/plugins/revive-payload.client.ts
+++ b/packages/nuxt/src/app/plugins/revive-payload.client.ts
@@ -1,4 +1,5 @@
 import { reactive, ref, shallowReactive, shallowRef } from 'vue'
+import destr from 'destr'
 import { definePayloadReviver, getNuxtClientPayload } from '#app/composables/payload'
 import { createError } from '#app/composables/error'
 import { defineNuxtPlugin, useNuxtApp } from '#app/nuxt'
@@ -8,8 +9,8 @@ import { componentIslands } from '#build/nuxt.config.mjs'
 
 const revivers: Record<string, (data: any) => any> = {
   NuxtError: data => createError(data),
-  EmptyShallowRef: data => shallowRef(data === '_' ? undefined : data === '0n' ? BigInt(0) : JSON.parse(data)),
-  EmptyRef: data => ref(data === '_' ? undefined : data === '0n' ? BigInt(0) : JSON.parse(data)),
+  EmptyShallowRef: data => shallowRef(data === '_' ? undefined : data === '0n' ? BigInt(0) : destr(data)),
+  EmptyRef: data => ref(data === '_' ? undefined : data === '0n' ? BigInt(0) : destr(data)),
   ShallowRef: data => shallowRef(data),
   ShallowReactive: data => shallowReactive(data),
   Ref: data => ref(data),


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This uses `destr` in more places when parsing JSON, which should be safer and faster.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
