### PR TITLE
fix(nuxt): find parent routes by exact path match

### DIFF
--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -80,7 +80,7 @@ export async function generateRoutesFromFiles (files: string[], pagesDir: string
       route.name += (route.name && '/') + segmentName
 
       // ex: parent.vue + parent/child.vue
-      const path = getRoutePath(tokens)
+      const path = getRoutePath(tokens).replace(/\/index$/, '/')
       const child = parent.find(parentRoute => parentRoute.name === route.name && parentRoute.path === path)
 
       if (child && child.children) {

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -80,7 +80,8 @@ export async function generateRoutesFromFiles (files: string[], pagesDir: string
       route.name += (route.name && '/') + segmentName
 
       // ex: parent.vue + parent/child.vue
-      const child = parent.find(parentRoute => parentRoute.name === route.name && !parentRoute.path.endsWith('(.*)*'))
+      const path = getRoutePath(tokens)
+      const child = parent.find(parentRoute => parentRoute.name === route.name && parentRoute.path === path)
 
       if (child && child.children) {
         parent = child.children
@@ -88,7 +89,7 @@ export async function generateRoutesFromFiles (files: string[], pagesDir: string
       } else if (segmentName === 'index' && !route.path) {
         route.path += '/'
       } else if (segmentName !== 'index') {
-        route.path += getRoutePath(tokens)
+        route.path += path
       }
     }
 

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -80,7 +80,7 @@ export async function generateRoutesFromFiles (files: string[], pagesDir: string
       route.name += (route.name && '/') + segmentName
 
       // ex: parent.vue + parent/child.vue
-      const path = getRoutePath(tokens).replace(/\/index$/, '/')
+      const path = route.path + getRoutePath(tokens).replace(/\/index$/, '/')
       const child = parent.find(parentRoute => parentRoute.name === route.name && parentRoute.path === path)
 
       if (child && child.children) {
@@ -89,7 +89,7 @@ export async function generateRoutesFromFiles (files: string[], pagesDir: string
       } else if (segmentName === 'index' && !route.path) {
         route.path += '/'
       } else if (segmentName !== 'index') {
-        route.path += path
+        route.path += getRoutePath(tokens)
       }
     }
 

--- a/packages/nuxt/test/pages.test.ts
+++ b/packages/nuxt/test/pages.test.ts
@@ -331,11 +331,14 @@ describe('pages:generateRoutesFromFiles', () => {
         test.files.map(file => [file.path, 'template' in file ? file.template : ''])
       ) as Record<string, string>
 
+      let result
       try {
-        const result = await generateRoutesFromFiles(test.files.map(file => file.path), pagesDir, true, vfs)
-        expect(result).to.deep.equal(test.output)
+        result = await generateRoutesFromFiles(test.files.map(file => file.path), pagesDir, true, vfs)
       } catch (error: any) {
         expect(error.message).toEqual(test.error)
+      }
+      if (result) {
+        expect(result).toEqual(test.output)
       }
     })
   }

--- a/packages/nuxt/test/pages.test.ts
+++ b/packages/nuxt/test/pages.test.ts
@@ -350,7 +350,9 @@ describe('pages:generateRoutesFromFiles', () => {
       files: [
         { path: `${pagesDir}/param.vue` },
         { path: `${pagesDir}/param/index.vue` },
-        { path: `${pagesDir}/param/index/index.vue` }
+        { path: `${pagesDir}/param/index/index.vue` },
+        { path: `${pagesDir}/param/index/sibling.vue` },
+        { path: `${pagesDir}/param/sibling.vue` }
       ],
       output: [
         {
@@ -362,10 +364,22 @@ describe('pages:generateRoutesFromFiles', () => {
                   file: 'pages/param/index/index.vue',
                   name: 'param-index',
                   path: ''
+                },
+                {
+                  children: [],
+                  file: 'pages/param/index/sibling.vue',
+                  name: 'param-index-sibling',
+                  path: 'sibling'
                 }
               ],
               file: 'pages/param/index.vue',
               path: ''
+            },
+            {
+              children: [],
+              file: 'pages/param/sibling.vue',
+              name: 'param-sibling',
+              path: 'sibling'
             }
           ],
           file: 'pages/param.vue',

--- a/packages/nuxt/test/pages.test.ts
+++ b/packages/nuxt/test/pages.test.ts
@@ -344,6 +344,34 @@ describe('pages:generateRoutesFromFiles', () => {
           children: []
         }
       ]
+    },
+    {
+      description: 'should correctly merge nested routes',
+      files: [
+        { path: `${pagesDir}/param.vue` },
+        { path: `${pagesDir}/param/index.vue` },
+        { path: `${pagesDir}/param/index/index.vue` }
+      ],
+      output: [
+        {
+          children: [
+            {
+              children: [
+                {
+                  children: [],
+                  file: 'pages/param/index/index.vue',
+                  name: 'param-index',
+                  path: ''
+                }
+              ],
+              file: 'pages/param/index.vue',
+              path: ''
+            }
+          ],
+          file: 'pages/param.vue',
+          path: '/param'
+        }
+      ]
     }
   ]
 

--- a/packages/nuxt/test/pages.test.ts
+++ b/packages/nuxt/test/pages.test.ts
@@ -322,6 +322,28 @@ describe('pages:generateRoutesFromFiles', () => {
           children: []
         }
       ]
+    },
+    {
+      description: 'should not merge required param as a child of optional param',
+      files: [
+        { path: `${pagesDir}/[[foo]].vue` },
+        { path: `${pagesDir}/[foo].vue` }
+      ],
+      output: [
+        {
+          name: 'foo',
+          path: '/:foo?',
+          file: `${pagesDir}/[[foo]].vue`,
+          children: [
+          ]
+        },
+        {
+          name: 'foo',
+          path: '/:foo()',
+          file: `${pagesDir}/[foo].vue`,
+          children: []
+        }
+      ]
     }
   ]
 

--- a/packages/nuxt/test/pages.test.ts
+++ b/packages/nuxt/test/pages.test.ts
@@ -352,6 +352,9 @@ describe('pages:generateRoutesFromFiles', () => {
         { path: `${pagesDir}/param/index.vue` },
         { path: `${pagesDir}/param/index/index.vue` },
         { path: `${pagesDir}/param/index/sibling.vue` },
+        { path: `${pagesDir}/wrapper-expose/other.vue` },
+        { path: `${pagesDir}/wrapper-expose/other/index.vue` },
+        { path: `${pagesDir}/wrapper-expose/other/sibling.vue` },
         { path: `${pagesDir}/param/sibling.vue` }
       ],
       output: [
@@ -384,6 +387,24 @@ describe('pages:generateRoutesFromFiles', () => {
           ],
           file: 'pages/param.vue',
           path: '/param'
+        },
+        {
+          children: [
+            {
+              children: [],
+              file: 'pages/wrapper-expose/other/index.vue',
+              name: 'wrapper-expose-other',
+              path: ''
+            },
+            {
+              children: [],
+              file: 'pages/wrapper-expose/other/sibling.vue',
+              name: 'wrapper-expose-other-sibling',
+              path: 'sibling'
+            }
+          ],
+          file: 'pages/wrapper-expose/other.vue',
+          path: '/wrapper-expose/other'
         }
       ]
     }


### PR DESCRIPTION
### 🔗 Linked issue

resolves nuxt/nuxt#22977

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

It's possible to have paths that produce similarly _named_ paths but are not really the same, for example `/[[foo]].vue` and `/[foo].vue`. These should be siblings and not create a parent/child relationship in this case.

As this is a sensitive area, I would particularly value spotting any edge cases I may have overlooked.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
