### PR TITLE
ci: test on node 20.5 rather than 20.6

### DIFF
--- a/.github/workflows/autofix-docs.yml
+++ b/.github/workflows/autofix-docs.yml
@@ -21,7 +21,7 @@ jobs:
       - run: corepack enable
       - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 20
+          node-version: 20.5
           cache: "pnpm"
 
       - name: Install dependencies

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -17,7 +17,7 @@ jobs:
       - run: corepack enable
       - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 20
+          node-version: 20.5
           cache: "pnpm"
 
       - name: Install dependencies

--- a/.github/workflows/changelogensets.yml
+++ b/.github/workflows/changelogensets.yml
@@ -26,7 +26,7 @@ jobs:
       - run: corepack enable
       - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 20
+          node-version: 20.5
           cache: "pnpm"
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - run: corepack enable
       - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 20
+          node-version: 20.5
           cache: "pnpm"
 
       - name: Install dependencies
@@ -79,7 +79,7 @@ jobs:
       - run: corepack enable
       - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 20
+          node-version: 20.5
           cache: "pnpm"
 
       - name: Install dependencies
@@ -118,7 +118,7 @@ jobs:
       - run: corepack enable
       - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 20
+          node-version: 20.5
           cache: "pnpm"
 
       - name: Install dependencies
@@ -146,7 +146,7 @@ jobs:
       - run: corepack enable
       - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 20
+          node-version: 20.5
           cache: "pnpm"
 
       - name: Install dependencies
@@ -256,7 +256,7 @@ jobs:
       - run: corepack enable
       - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 20
+          node-version: 20.5
           cache: "pnpm"
 
       - name: Install dependencies
@@ -295,7 +295,7 @@ jobs:
       - run: corepack enable
       - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 20
+          node-version: 20.5
           cache: "pnpm"
 
       - name: Install dependencies

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
       - run: corepack enable
       - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 20
+          node-version: 20.5
           cache: "pnpm"
 
       - name: Install dependencies

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -37,7 +37,7 @@ jobs:
       - run: corepack enable
       - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
-          node-version: 20
+          node-version: 20.5
           cache: "pnpm"
 
       - name: Install dependencies


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/23020
https://github.com/nodejs/node/issues/49497

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This runs our CI on node 20.5 to avoid breakage in node 20.6 (example failed run: https://github.com/nuxt/nuxt/actions/runs/6096011429/job/16540685059?pr=23040).

Upstream solution has already been merged but I imagine it will likely take a while to filter back down to GHA runners, even after a hotfix release.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
