### PR TITLE
fix(vite): add css to manifest without `cssCodeSplit`

### DIFF
--- a/packages/vite/src/manifest.ts
+++ b/packages/vite/src/manifest.ts
@@ -1,5 +1,5 @@
 import fse from 'fs-extra'
-import { resolve } from 'pathe'
+import { relative, resolve } from 'pathe'
 import { withTrailingSlash, withoutLeadingSlash } from 'ufo'
 import escapeRE from 'escape-string-regexp'
 import { normalizeViteManifest } from 'vue-bundle-renderer'
@@ -46,6 +46,15 @@ export async function writeManifest (ctx: ViteBuildContext, css: string[] = []) 
   }
 
   await fse.mkdirp(serverDist)
+
+  if (ctx.config.build?.cssCodeSplit === false) {
+    const entryCSS = Object.values(clientManifest as Record<string, { file?: string }>).find(val => (val).file?.endsWith('.css'))?.file
+    if (entryCSS) {
+      const key = relative(ctx.config.root!, ctx.entry)
+      clientManifest[key].css ||= []
+      clientManifest[key].css!.push(entryCSS)
+    }
+  }
 
   const manifest = normalizeViteManifest(clientManifest)
   await ctx.nuxt.callHook('build:manifest', manifest)


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/21353

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

If users explicitly disable [`vite.build.cssCodeSplit`](https://vitejs.dev/config/build-options.html#build-csscodesplit) then there will be no CSS dependencies in the client manifest.

Assuming this isn't a vite bug we need to fix upstream (cc: @antfu) we need to add this to our client manifest so we will render a link to the CSS file in the HTML.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
