### PR TITLE
docs: add `name` param to `PageMeta` interface description

### DIFF
--- a/docs/3.api/3.utils/define-page-meta.md
+++ b/docs/3.api/3.utils/define-page-meta.md
@@ -25,6 +25,7 @@ definePageMeta(meta: PageMeta) => void
 interface PageMeta {
   validate?: (route: RouteLocationNormalized) => boolean | Promise<boolean> | Partial<NuxtError> | Promise<Partial<NuxtError>>
   redirect?: RouteRecordRedirectOption
+  name?: string
   path?: string
   alias?: string | string[]
   pageTransition?: boolean | TransitionProps
@@ -45,6 +46,12 @@ interface PageMeta {
 - **Type**: `PageMeta`
 
   An object accepting the following page metadata:
+
+  **`name`**
+
+  - **Type**: `string`
+
+    You may define a name for this page's route. By default, name is generated based on path inside the [`pages/` directory](/docs/guide/directory-structure/pages).
 
   **`path`**
 


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Add missing `name` param to PageMeta interface description

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
