### PR TITLE
fix(nuxt): handle unset spa-loading fallback

### DIFF
--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -420,6 +420,10 @@ function spaLoadingTemplate (nuxt: Nuxt) {
     return defaultSpaLoadingTemplate({})
   }
 
+  if (nuxt.options.spaLoadingTemplate === null) {
+    return ''
+  }
+
   console.warn(`[nuxt] Could not load custom \`spaLoadingTemplate\` path as it does not exist: \`${nuxt.options.spaLoadingTemplate}\`.`)
   return ''
 }

--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -420,10 +420,9 @@ function spaLoadingTemplate (nuxt: Nuxt) {
     return defaultSpaLoadingTemplate({})
   }
 
-  if (nuxt.options.spaLoadingTemplate === null) {
-    return ''
+  if (nuxt.options.spaLoadingTemplate) {
+    console.warn(`[nuxt] Could not load custom \`spaLoadingTemplate\` path as it does not exist: \`${nuxt.options.spaLoadingTemplate}\`.`)
   }
 
-  console.warn(`[nuxt] Could not load custom \`spaLoadingTemplate\` path as it does not exist: \`${nuxt.options.spaLoadingTemplate}\`.`)
   return ''
 }

--- a/packages/schema/src/config/app.ts
+++ b/packages/schema/src/config/app.ts
@@ -243,7 +243,7 @@ export default defineUntypedSchema({
    * @type {string | boolean}
    */
   spaLoadingTemplate: {
-    $resolve: async (val, get) => typeof val === 'string' ? resolve(await get('srcDir'), val) : val
+    $resolve: async (val, get) => typeof val === 'string' ? resolve(await get('srcDir'), val) : val ?? null
   },
 
   /**


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/pull/23048

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Unintended regression after merging https://github.com/nuxt/nuxt/pull/23048, 'undefined' result normalises through to `{}` in untyped. Also we were always warning even if it was unset.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
