### PR TITLE
ci: update fixtures to node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
         env: ['dev', 'built']
         builder: ['vite', 'webpack']
         context: ['async', 'default']
-        node: [16]
+        node: [18]
         exclude:
           - env: 'dev'
             builder: 'webpack'

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -751,12 +751,7 @@ describe('errors', () => {
 
   it('should render a HTML error page', async () => {
     const res = await fetch('/error')
-    // TODO: remove when we update CI to node v18
-    if (process.version.startsWith('v16')) {
-      expect(res.headers.get('Set-Cookie')).toBe('set-in-plugin=true; Path=/')
-    } else {
-      expect(res.headers.get('Set-Cookie')).toBe('set-in-plugin=true; Path=/, some-error=was%20set; Path=/')
-    }
+    expect(res.headers.get('Set-Cookie')).toBe('set-in-plugin=true; Path=/, some-error=was%20set; Path=/')
     expect(await res.text()).toContain('This is a custom error')
   })
 


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nodejs/release#release-schedule

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This updates our internal testing matrix to use node 18 as node 16 is now EOL.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
