### PR TITLE
fix(vite): remove dev styles injected via absolute path

### DIFF
--- a/packages/vite/src/plugins/dev-ssr-css.ts
+++ b/packages/vite/src/plugins/dev-ssr-css.ts
@@ -23,8 +23,8 @@ export function devStyleSSRPlugin (options: DevStyleSSRPluginOptions): Plugin {
       }
 
       // When dev `<style>` is injected, remove the `<link>` styles from manifest
-      const selector = joinURL(options.buildAssetsURL, moduleId)
-      return code + `\ndocument.querySelectorAll(\`link[href="${selector}"]\`).forEach(i=>i.remove())`
+      const selectors = [joinURL(options.buildAssetsURL, moduleId), joinURL(options.buildAssetsURL, '@fs', moduleId)]
+      return code + selectors.map(selector => `\ndocument.querySelectorAll(\`link[href="${selector}"]\`).forEach(i=>i.remove())`).join('')
     }
   }
 }


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/22710

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We have an SSR-styles plugin that removes explicit stylesheets when developing. However, this was not removing them when they include an optional `@fs` param in the path (which seems triggered when path to CSS isn't the same as the path to root, such as with a custom `srcDir` or in a monorepo). This updates the code so we remove these stylesheets too.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
