### PR TITLE
fix(nuxt): respect layer order for other layer plugins

### DIFF
--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -126,9 +126,7 @@ async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
   }
 
   // Resolve plugins, first extended layers and then base
-  app.plugins = [
-    ...nuxt.options.plugins.map(normalizePlugin)
-  ]
+  app.plugins = []
   for (const config of nuxt.options._layers.map(layer => layer.config).reverse()) {
     app.plugins.push(...[
       ...(config.plugins || []),
@@ -139,6 +137,14 @@ async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
         ])
         : []
     ].map(plugin => normalizePlugin(plugin as NuxtPlugin)))
+  }
+
+  // Add back plugins not specified in layers or user config
+  for (const p of nuxt.options.plugins) {
+    const plugin = normalizePlugin(p)
+    if (!app.plugins.some(p => p.src === plugin.src)) {
+      app.plugins.unshift(plugin)
+    }
   }
 
   // Normalize and de-duplicate plugins and middleware


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/23123

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This builds on work done by @userquin in https://github.com/nuxt/nuxt/pull/22889 to ensure that other plugins specified directly in nuxt config by layers are loaded in sequence matching layer order.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
