### PR TITLE
fix(nuxt): allow overriding components + only warn if clash

### DIFF
--- a/packages/nuxt/src/components/scan.ts
+++ b/packages/nuxt/src/components/scan.ts
@@ -140,7 +140,12 @@ export async function scanComponents (dirs: ComponentsDir[], srcDir: string): Pr
         const existingPriority = existingComponent.priority ?? 0
         const newPriority = component.priority ?? 0
 
-        if (newPriority >= existingPriority) {
+        // Replace component if priority is higher
+        if (newPriority > existingPriority) {
+          components.splice(components.indexOf(existingComponent), 1, component)
+        }
+        // Warn if a user-defined (or prioritised) component conflicts with a previously scanned component
+        if (newPriority > 0 && newPriority === existingPriority) {
           warnAboutDuplicateComponent(componentName, filePath, existingComponent.filePath)
         }
 


### PR DESCRIPTION
### 🔗 Linked issue

nuxt/content#2302, https://github.com/nuxt-themes/docus/issues/972#issuecomment-1714411410

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This is yet another tweak to the duplicate component warning. We:

1. allow overriding components if a newly scanned component has a higher priority. No warning is needed here; this is by design. (This does result in a behaviour change but I don't think it should affect most users as we already prioritised user content over layers, and that is also what the priority system does.)
2. warn only if components are the **same priority** _and_ are not layer components (which are designed to be overridden), namely have a priority of 1+

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
