### PR TITLE
fix(nuxt): ensure plugins retain original order

### DIFF
--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -143,7 +143,7 @@ async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
   }
 
   // Add back plugins not specified in layers or user config
-  for (const p of nuxt.options.plugins) {
+  for (const p of [...nuxt.options.plugins].reverse()) {
     const plugin = normalizePlugin(p)
     if (!app.plugins.some(p => p.src === plugin.src)) {
       app.plugins.unshift(plugin)


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/23166, resolves https://github.com/nuxt/nuxt/issues/23163

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This fixes a regression in https://github.com/nuxt/nuxt/pull/23148 to ensure we respect the original plugin order when restoring original plugins to the array.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
