### PR TITLE
fix(nuxt): use original escapes/quotes in page re-exports

### DIFF
--- a/test/fixtures/basic/components/global/NonAsçii.vue
+++ b/test/fixtures/basic/components/global/NonAsçii.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    global component registered automatically
+  </div>
+</template>

--- a/test/fixtures/basic/components/global/NonAsçii.vue
+++ b/test/fixtures/basic/components/global/NonAsçii.vue
@@ -1,5 +1,0 @@
-<template>
-  <div>
-    global component registered automatically
-  </div>
-</template>

--- a/test/fixtures/basic/pages/non-ascii/ç.vue
+++ b/test/fixtures/basic/pages/non-ascii/ç.vue
@@ -1,0 +1,8 @@
+<script setup lang="ts">
+</script>
+
+<template>
+  <div>
+    <!--  -->
+  </div>
+</template>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/15113

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When parsing imports using `findStaticImports` we can end up with a string which has unicode escapes. When this happens, calling `JSON.stringify` on it ends up double-escaping the previous escapes.

I felt the best way to resolve in this particular case was to avoid re-stringifying but other ideas are welcome.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
