### PR TITLE
fix(vite): respect `devServer.host` for `hmr`

### DIFF
--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -123,7 +123,8 @@ export async function buildClient (ctx: ViteBuildContext) {
       https: ctx.nuxt.options.devServer.https,
       hmr: {
         protocol: ctx.nuxt.options.devServer.https ? 'wss' : 'ws',
-        port: hmrPort
+        port: hmrPort,
+        host: ctx.nuxt.options.devServer.host
       }
     })
   }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When the browser points to `127.0.0.1` (the new default for nuxi in windows), vite HMR port should also listen to `127.0.0.1`. Defaulting to `""` leads to VSCode listening WSL2 on `localhost` which (surprisingly) mismatches in browser URL!

This PR fixes the issue by respecting the host that is set by nuxi. (which is currently always `127.0.01`)

<img width="1470" alt="image" src="https://github.com/nuxt/nuxt/assets/5158436/ae247e51-a9eb-4db5-a376-978f847b6763">


### Alternatives

This is not the best solution since causes HMR only working on localhost. Something we were working around previously by (unsafely) listening to all interfaces.

I am thinking we might use main server HMR port for upgrade events on vite path (as a feature)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
