### PR TITLE
fix(schema): default devServer host to undefined

### DIFF
--- a/packages/schema/src/config/dev.ts
+++ b/packages/schema/src/config/dev.ts
@@ -25,7 +25,7 @@ export default defineUntypedSchema({
     port: process.env.NUXT_PORT || process.env.NITRO_PORT || process.env.PORT || 3000,
 
     /** Dev server listening host */
-    host: process.env.NUXT_HOST || process.env.NITRO_HOST || process.env.HOST || '',
+    host: process.env.NUXT_HOST || process.env.NITRO_HOST || process.env.HOST || undefined,
 
     /**
      * Listening dev server URL.


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/cli/pull/182

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Seems we're defaulting `devServer.host` to an empty string. I'm not entirely sure why this was originally done, but it's not required any more.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
