### PR TITLE
docs: add documentation on `nuxt2` command

### DIFF
--- a/docs/6.bridge/1.overview.md
+++ b/docs/6.bridge/1.overview.md
@@ -73,7 +73,24 @@ export default defineNuxtConfig({
 })
 ```
 
-Try running `nuxt dev` once here. You will see that the application works as before.
+### Update Commands
+
+The `nuxt` command should now be changed to the `nuxt2` command.
+
+```diff
+{
+  "scripts": {
+-   "dev": "nuxt",
++   "dev": "nuxt2",
+-   "build": "nuxt build",
++   "build": "nuxt2 build",
+-   "start": "nuxt start",
++   "start": "nuxt2 start"
+  }
+}
+```
+
+Try running `nuxt2` once here. You will see that the application works as before.
 
 (If 'bridge' is set to false, your application will operate without any changes as before.)
 

--- a/docs/6.bridge/8.nitro.md
+++ b/docs/6.bridge/8.nitro.md
@@ -20,6 +20,20 @@ export default defineNuxtConfig({
 
 You will also need to update your scripts within your `package.json` to reflect the fact that Nuxt will now produce a Nitro server as build output.
 
+### Install Nuxi
+
+Install `nuxi` as a development dependency:
+
+::code-group
+
+```bash [Yarn]
+yarn add --dev nuxi
+```
+
+```bash [npm]
+npm install -D nuxi
+```
+
 ### Nuxi
 
 Nuxt 3 introduced the new Nuxt CLI command [`nuxi`](/docs/api/commands/add). Update your scripts as follows to leverage the better support from Nuxt Bridge:
@@ -38,7 +52,7 @@ Nuxt 3 introduced the new Nuxt CLI command [`nuxi`](/docs/api/commands/add). Upd
 ```
 
 ::alert
-If `nitro: false`, use the `nuxt` command.
+If `nitro: false`, use the `nuxt2` command.
 ::
 
 ### Static Target


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
The changes to https://github.com/nuxt/bridge/pull/907 have made `nuxi` optional install and added the `nuxt2` command.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
