### PR TITLE
docs: clarify nuxi start command usage

### DIFF
--- a/docs/3.api/5.commands/preview.md
+++ b/docs/3.api/5.commands/preview.md
@@ -9,7 +9,7 @@ description: The preview command starts a server to preview your application aft
 npx nuxi preview [rootDir] [--dotenv]
 ```
 
-The `preview` command starts a server to preview your Nuxt application after running the `build` command.
+The `preview` command starts a server to preview your Nuxt application after running the `build` command. The `start` command is an alias for `preview`. When running your application in production refer to the [Deployment section](/docs/getting-started/deployment).
 
 Option        | Default          | Description
 -------------------------|-----------------|------------------


### PR DESCRIPTION
### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`nuxi start` command isn't easily understandable to be an alias for the `preview` command and might get misunderstood as the command to run the nuxt application in production. The difference between the two is fairly small but unnecessarily loading the `.env` file should be avoided.

`npx nuxi start --help` gives this info about the `start` command
```
> Usage: npx nuxi preview|start [--dotenv] [rootDir]

⋮ Launches nitro server for local testing after nuxi build.

Use npx nuxi [command] --help to see help for each command
```

Also linked the Deployment section of the docs so it's clear where to look for instructions on deploying your application after previewing it

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
