### PR TITLE
fix(nuxt): handle vite preload-helper id with extension

### DIFF
--- a/packages/vite/src/plugins/chunk-error.ts
+++ b/packages/vite/src/plugins/chunk-error.ts
@@ -3,6 +3,7 @@ import type { Plugin } from 'vite'
 
 const vitePreloadHelperId = '\0vite/preload-helper'
 
+// TODO: remove this function when we upgrade to vite 5
 export function chunkErrorPlugin (options: { sourcemap?: boolean }): Plugin {
   return {
     name: 'nuxt:chunk-error',

--- a/packages/vite/src/plugins/chunk-error.ts
+++ b/packages/vite/src/plugins/chunk-error.ts
@@ -1,11 +1,14 @@
 import MagicString from 'magic-string'
 import type { Plugin } from 'vite'
 
+const vitePreloadHelperId = '\0vite/preload-helper'
+
 export function chunkErrorPlugin (options: { sourcemap?: boolean }): Plugin {
   return {
     name: 'nuxt:chunk-error',
     transform (code, id) {
-      if (id !== '\0vite/preload-helper' || code.includes('nuxt.preloadError')) { return }
+      // Vite 5 has an id with extension
+      if (!(id === vitePreloadHelperId || id === `${vitePreloadHelperId}.js`) || code.includes('nuxt.preloadError')) { return }
 
       const s = new MagicString(code)
       s.replace(/__vitePreload/g, '___vitePreload')


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Vite 5 will change the id of preload-helper (https://github.com/vitejs/vite/pull/14231).
This PR makes the `chunkErrorPlugin` to handle that id as well.

Perhaps the chunkErrorPlugin can be completely removed as https://github.com/vitejs/vite/pull/12084 is now merged. Feel free to close this PR if you're going to do that 👍 

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
