### PR TITLE
docs: typo on `callHook` method

### DIFF
--- a/docs/3.api/1.composables/use-nuxt-app.md
+++ b/docs/3.api/1.composables/use-nuxt-app.md
@@ -52,7 +52,7 @@ export default defineNuxtPlugin((nuxtApp) => {
 })
 ```
 
-### `callhook(name, ...args)`
+### `callHook(name, ...args)`
 
 `callHook` returns a promise when called with any of the existing hooks.
 


### PR DESCRIPTION
### 🔗 Linked issue

None

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Just a small typo I noticed while reading the documentation: `callhook` -> `callHook`

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
