### PR TITLE
fix(nuxt): don't incl overridden layer pages as nested children

### DIFF
--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -52,7 +52,7 @@ export async function resolvePagesRoutes (): Promise<NuxtPage[]> {
   }
   scannedFiles.sort((a, b) => a.relativePath.localeCompare(b.relativePath))
 
-  const allRoutes = await generateRoutesFromFiles(scannedFiles, nuxt.options.experimental.typedPages, nuxt.vfs)
+  const allRoutes = await generateRoutesFromFiles(uniqueBy(scannedFiles, 'relativePath'), nuxt.options.experimental.typedPages, nuxt.vfs)
 
   return uniqueBy(allRoutes, 'path')
 }

--- a/test/fixtures/basic/extends/node_modules/foo/pages/override.vue
+++ b/test/fixtures/basic/extends/node_modules/foo/pages/override.vue
@@ -1,3 +1,8 @@
 <template>
   <div>This page should be overriden by bar</div>
 </template>
+
+<script setup lang="ts">
+import invalidImport from '234897f'
+console.log(invalidImport)
+</script>


### PR DESCRIPTION
### 🔗 Linked issue

resolves #23216

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

With https://github.com/nuxt/nuxt/pull/23134, we inadvertently kept overridden layer pages as 'children' of the overriding page. This PR ensures we deduplicate by exact relative path first.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
