### PR TITLE
docs(nuxt): remove hanging word in modules docs

### DIFF
--- a/docs/2.guide/3.going-further/3.modules.md
+++ b/docs/2.guide/3.going-further/3.modules.md
@@ -542,7 +542,7 @@ export default defineNuxtModule({
 
 You might also want to add a type declaration to the user's project (for example, to augment a Nuxt interface
 or provide a global type of your own). For this, Nuxt provides the `addTypeTemplate` utility that both
-writes a template to the disk and adds a reference to it in the generated `nuxt.d.ts` file that.
+writes a template to the disk and adds a reference to it in the generated `nuxt.d.ts` file.
 
 If your module should augment types handled by Nuxt, you can use `addTypeTemplate` to perform this operation:
 


### PR DESCRIPTION
Remove hanging word in modules docs

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
