### PR TITLE
fix(vite): explicitly set vite manifest path

### DIFF
--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -66,7 +66,7 @@ export async function buildClient (ctx: ViteBuildContext) {
     cacheDir: resolve(ctx.nuxt.options.rootDir, 'node_modules/.cache/vite', 'client'),
     build: {
       sourcemap: ctx.nuxt.options.sourcemap.client ? ctx.config.build?.sourcemap ?? true : false,
-      manifest: resolve(ctx.nuxt.options.buildDir, 'dist/client', 'manifest.json'),
+      manifest: resolve(ctx.nuxt.options.buildDir, 'dist/client/manifest.json'),
       outDir: resolve(ctx.nuxt.options.buildDir, 'dist/client'),
       rollupOptions: {
         input: { entry: ctx.entry }

--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -66,7 +66,7 @@ export async function buildClient (ctx: ViteBuildContext) {
     cacheDir: resolve(ctx.nuxt.options.rootDir, 'node_modules/.cache/vite', 'client'),
     build: {
       sourcemap: ctx.nuxt.options.sourcemap.client ? ctx.config.build?.sourcemap ?? true : false,
-      manifest: resolve(ctx.nuxt.options.buildDir, 'dist/client/manifest.json'),
+      manifest: 'manifest.json',
       outDir: resolve(ctx.nuxt.options.buildDir, 'dist/client'),
       rollupOptions: {
         input: { entry: ctx.entry }

--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -66,7 +66,7 @@ export async function buildClient (ctx: ViteBuildContext) {
     cacheDir: resolve(ctx.nuxt.options.rootDir, 'node_modules/.cache/vite', 'client'),
     build: {
       sourcemap: ctx.nuxt.options.sourcemap.client ? ctx.config.build?.sourcemap ?? true : false,
-      manifest: true,
+      manifest: resolve(ctx.nuxt.options.buildDir, 'dist/client', 'manifest.json'),
       outDir: resolve(ctx.nuxt.options.buildDir, 'dist/client'),
       rollupOptions: {
         input: { entry: ctx.entry }


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/vitejs/vite/pull/14230

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This specifies vite `manifest.json` path for compatibility with upcoming vite v5.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
