### PR TITLE
feat(nuxt): warn when nesting nuxt links when SSR on dev

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -1,5 +1,5 @@
-import type { ComputedRef, DefineComponent, PropType } from 'vue'
-import { computed, defineComponent, h, onBeforeUnmount, onMounted, ref, resolveComponent } from 'vue'
+import type { ComputedRef, DefineComponent, InjectionKey, PropType } from 'vue'
+import { computed, defineComponent, h, inject, onBeforeUnmount, onMounted, provide, ref, resolveComponent } from 'vue'
 import type { RouteLocation, RouteLocationRaw } from '#vue-router'
 import { hasProtocol, parseQuery, parseURL, withTrailingSlash, withoutTrailingSlash } from 'ufo'
 
@@ -12,6 +12,7 @@ import { cancelIdleCallback, requestIdleCallback } from '../compat/idle-callback
 const firstNonUndefined = <T> (...args: (T | undefined)[]) => args.find(arg => arg !== undefined)
 
 const DEFAULT_EXTERNAL_REL_ATTRIBUTE = 'noopener noreferrer'
+const NuxtLinkDevKeySymbol: InjectionKey<boolean> = Symbol('nuxt-link-dev-key')
 
 export type NuxtLinkOptions = {
   componentName?: string
@@ -233,6 +234,15 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
             unobserve?.()
             unobserve = null
           })
+        }
+      }
+
+      if (import.meta.dev && import.meta.server && !props.custom) {
+        const isNuxtLinkChild = inject(NuxtLinkDevKeySymbol, false)
+        if (isNuxtLinkChild) {
+          console.log('[nuxt] [NuxtLink] You can\'t nest one <a> inside another <a>. This will cause a hydration error on client-side. You can pass the `custom` prop to take full control of the markup.')
+        } else {
+          provide(NuxtLinkDevKeySymbol, true)
         }
       }
 


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/23274#issuecomment-1723250963

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds a check for nested nuxt links. It's restricted to development and server-side only to avoid false positives within client-only components

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
