### PR TITLE
fix: prevented data-v filter added in #23095 from impacting styles

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-island.ts
+++ b/packages/nuxt/src/app/components/nuxt-island.ts
@@ -50,7 +50,8 @@ export default defineComponent({
     const error = ref<unknown>(null)
     const config = useRuntimeConfig()
     const nuxtApp = useNuxtApp()
-    const hashId = computed(() => hash([props.name, props.props, props.context, props.source]))
+    const propsForHash = props.props ? Object.fromEntries(Object.entries(props.props).filter(([key]) => !key.startsWith('data-v-'))) : {}
+    const hashId = computed(() => hash([props.name, propsForHash, props.context, props.source]))
     const instance = getCurrentInstance()!
     const event = useRequestEvent()
     // TODO: remove use of `$fetch.raw` when nitro 503 issues on windows dev server are resolved

--- a/packages/nuxt/src/app/components/nuxt-island.ts
+++ b/packages/nuxt/src/app/components/nuxt-island.ts
@@ -50,8 +50,8 @@ export default defineComponent({
     const error = ref<unknown>(null)
     const config = useRuntimeConfig()
     const nuxtApp = useNuxtApp()
-    const propsForHash = props.props ? Object.fromEntries(Object.entries(props.props).filter(([key]) => !key.startsWith('data-v-'))) : {}
-    const hashId = computed(() => hash([props.name, propsForHash, props.context, props.source]))
+    const propsForHash = computed(() => props.props ? Object.fromEntries(Object.entries(props.props).filter(([key]) => !key.startsWith('data-v-'))) : {})
+    const hashId = computed(() => hash([props.name, propsForHash.value, props.context, props.source]))
     const instance = getCurrentInstance()!
     const event = useRequestEvent()
     // TODO: remove use of `$fetch.raw` when nitro 503 issues on windows dev server are resolved

--- a/packages/nuxt/src/app/components/nuxt-island.ts
+++ b/packages/nuxt/src/app/components/nuxt-island.ts
@@ -50,8 +50,8 @@ export default defineComponent({
     const error = ref<unknown>(null)
     const config = useRuntimeConfig()
     const nuxtApp = useNuxtApp()
-    const propsForHash = computed(() => props.props ? Object.fromEntries(Object.entries(props.props).filter(([key]) => !key.startsWith('data-v-'))) : {})
-    const hashId = computed(() => hash([props.name, propsForHash.value, props.context, props.source]))
+    const filteredProps = computed(() => props.props ? Object.fromEntries(Object.entries(props.props).filter(([key]) => !key.startsWith('data-v-'))) : {})
+    const hashId = computed(() => hash([props.name, filteredProps.value, props.context, props.source]))
     const instance = getCurrentInstance()!
     const event = useRequestEvent()
     // TODO: remove use of `$fetch.raw` when nitro 503 issues on windows dev server are resolved

--- a/packages/nuxt/src/components/runtime/server-component.ts
+++ b/packages/nuxt/src/components/runtime/server-component.ts
@@ -11,8 +11,7 @@ export const createServerComponent = (name: string) => {
         return h(NuxtIsland, {
           name,
           lazy: props.lazy,
-          // #23051 - remove data-v attributes
-          props: Object.fromEntries(Object.entries(attrs).filter(([key]) => !key.startsWith('data-v-')))
+          props: attrs
         }, slots)
       }
     }

--- a/test/nuxt/nuxt-island.test.ts
+++ b/test/nuxt/nuxt-island.test.ts
@@ -31,9 +31,9 @@ describe('runtime server component', () => {
     expect(h).toHaveBeenCalledOnce()
     if (!vi.mocked(h).mock.lastCall) { throw new Error('no last call') }
     expect(vi.mocked(h).mock.lastCall![1]?.props).toBeTypeOf('object')
-    expect(Object.keys(vi.mocked(h).mock.lastCall![1]?.props)).not.toContain('data-v-123')
     expect(vi.mocked(h).mock.lastCall![1]?.props).toMatchInlineSnapshot(`
       {
+        "data-v-123": '',
         "test": 1,
       }
     `)

--- a/test/nuxt/nuxt-island.test.ts
+++ b/test/nuxt/nuxt-island.test.ts
@@ -33,7 +33,7 @@ describe('runtime server component', () => {
     expect(vi.mocked(h).mock.lastCall![1]?.props).toBeTypeOf('object')
     expect(vi.mocked(h).mock.lastCall![1]?.props).toMatchInlineSnapshot(`
       {
-        "data-v-123": '',
+        "data-v-123": "",
         "test": 1,
       }
     `)


### PR DESCRIPTION

### 🔗 Linked issue

Fix #23385

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fixes #23385
The data-v attribute is only removed for the hash function.
Please validate, this is my first PR 😉

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
