### PR TITLE
fix(nuxt): detect nested pages with `/index` segments

### DIFF
--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -85,7 +85,7 @@ export async function generateRoutesFromFiles (files: ScannedFile[], shouldExtra
       route.name += (route.name && '/') + segmentName
 
       // ex: parent.vue + parent/child.vue
-      const path = withLeadingSlash(joinURL(route.path, getRoutePath(tokens).replace(/\/index$/, '')))
+      const path = withLeadingSlash(joinURL(route.path, getRoutePath(tokens).replace(/\/index$/, '/')))
       const child = parent.find(parentRoute => parentRoute.name === route.name && parentRoute.path === path)
 
       if (child && child.children) {

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs'
 import { extname, normalize, relative, resolve } from 'pathe'
-import { encodePath } from 'ufo'
+import { encodePath, joinURL, withLeadingSlash } from 'ufo'
 import { logger, resolveFiles, useNuxt } from '@nuxt/kit'
 import { genArrayFromRaw, genDynamicImport, genImport, genSafeVariableName } from 'knitwork'
 import escapeRE from 'escape-string-regexp'
@@ -85,7 +85,7 @@ export async function generateRoutesFromFiles (files: ScannedFile[], shouldExtra
       route.name += (route.name && '/') + segmentName
 
       // ex: parent.vue + parent/child.vue
-      const path = route.path + getRoutePath(tokens).replace(/\/index$/, '/')
+      const path = withLeadingSlash(joinURL(route.path, getRoutePath(tokens).replace(/\/index$/, '')))
       const child = parent.find(parentRoute => parentRoute.name === route.name && parentRoute.path === path)
 
       if (child && child.children) {

--- a/packages/nuxt/test/pages.test.ts
+++ b/packages/nuxt/test/pages.test.ts
@@ -437,6 +437,28 @@ describe('pages:generateRoutesFromFiles', () => {
           path: '/wrapper-expose/other'
         }
       ]
+    },
+    {
+      description: 'should handle trailing slashes with index routes',
+      files: [
+        { path: `${pagesDir}/index/index.vue` },
+        { path: `${pagesDir}/index/index/all.vue` }
+      ],
+      output: [
+        {
+          children: [
+            {
+              children: [],
+              file: `${pagesDir}/index/index/all.vue`,
+              name: 'index-index-all',
+              path: 'all'
+            }
+          ],
+          file: `${pagesDir}/index/index.vue`,
+          name: 'index',
+          path: '/'
+        }
+      ]
     }
   ]
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/23219


### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This addresses an unintended regression with index routes not properly being detected as parent routes when nesting pages.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
