### PR TITLE
fix(nuxt): initialise `asyncData` errors with `null`

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -373,11 +373,11 @@ export function clearNuxtData (keys?: string | string[] | ((key: string) => bool
       nuxtApp.payload.data[key] = undefined
     }
     if (key in nuxtApp.payload._errors) {
-      nuxtApp.payload._errors[key] = undefined
+      nuxtApp.payload._errors[key] = null
     }
     if (nuxtApp._asyncData[key]) {
       nuxtApp._asyncData[key]!.data.value = undefined
-      nuxtApp._asyncData[key]!.error.value = undefined
+      nuxtApp._asyncData[key]!.error.value = null
       nuxtApp._asyncData[key]!.pending.value = false
       nuxtApp._asyncData[key]!.status.value = 'idle'
     }

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -149,7 +149,7 @@ export function useAsyncData<
     nuxt._asyncData[key] = {
       data: ref(getCachedData() ?? options.default!()),
       pending: ref(!hasCachedData()),
-      error: toRef(nuxt.payload._errors, key),
+      error: ref(nuxt.payload._errors[key] ?? null),
       status: ref('idle')
     }
   }

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -146,13 +146,16 @@ export function useAsyncData<
 
   // Create or use a shared asyncData entity
   if (!nuxt._asyncData[key] || !options.immediate) {
+    nuxt.payload._errors[key] ??= null
+
     nuxt._asyncData[key] = {
       data: ref(getCachedData() ?? options.default!()),
       pending: ref(!hasCachedData()),
-      error: ref(nuxt.payload._errors[key] ?? null),
+      error: toRef(nuxt.payload._errors, key),
       status: ref('idle')
     }
   }
+
   // TODO: Else, somehow check for conflicting keys with different defaults or fetcher
   const asyncData = { ...nuxt._asyncData[key] } as AsyncData<DataT | DefaultT, DataE>
 

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -81,7 +81,7 @@ export interface NuxtPayload {
     description: string
     data?: any
   } | null
-  _errors: Record<string, NuxtError | undefined>
+  _errors: Record<string, NuxtError | null>
   [key: string]: unknown
 }
 
@@ -104,7 +104,7 @@ interface _NuxtApp {
   _asyncData: Record<string, {
     data: Ref<any>
     pending: Ref<boolean>
-    error: Ref<any>
+    error: Ref<Error | null>
     status: Ref<AsyncDataRequestStatus>
   } | undefined>
 

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -127,7 +127,9 @@ describe('useAsyncData', () => {
 
   // https://github.com/nuxt/nuxt/issues/23411
   it('should initialize with error set to null when immediate: false', async () => {
-    const { error } = await useAsyncData(() => '', { immediate: false })
+    const { error, execute } = useAsyncData(() => ({}), { immediate: false })
+    expect(error.value).toBe(null)
+    await execute()
     expect(error.value).toBe(null)
   })
 

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -125,6 +125,12 @@ describe('useAsyncData', () => {
     expect(pending.value).toBe(false)
   })
 
+  // https://github.com/nuxt/nuxt/issues/23411
+  it('should initialize with error set to null when immediate: false', async () => {
+    const { error } = await useAsyncData(() => '', { immediate: false })
+    expect(error.value).toBe(null)
+  })
+
   it('should be accessible with useNuxtData', async () => {
     await useAsyncData('key', () => Promise.resolve('test'))
     const data = useNuxtData('key')


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

Closes #23411

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR aligns the initial values of error(s) set in `asyncData` composable and Nuxt payload with their type definitions.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
