### PR TITLE
fix(nuxt): rename dts to avoid shadowing w/ baseUrl

### DIFF
--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -96,7 +96,7 @@ export default defineNuxtModule({
     }
 
     addTemplate({
-      filename: 'vue-router.mjs',
+      filename: 'vue-router-stub.mjs',
       // TODO: use `vue-router/auto` when we have support for page metadata
       getContents: () => 'export * from \'vue-router\';'
     })

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -75,11 +75,11 @@ export default defineNuxtModule({
 
     // adds support for #vue-router alias (used for types) with and without pages integration
     addTemplate({
-      filename: 'vue-router.d.ts',
+      filename: 'vue-router-stub.d.ts',
       getContents: () => `export * from '${useExperimentalTypedPages ? 'vue-router/auto' : 'vue-router'}'`
     })
 
-    nuxt.options.alias['#vue-router'] = join(nuxt.options.buildDir, 'vue-router')
+    nuxt.options.alias['#vue-router'] = join(nuxt.options.buildDir, 'vue-router-stub')
 
     if (!nuxt.options.pages) {
       addPlugin(resolve(distDir, 'app/plugins/router'))
@@ -451,7 +451,7 @@ export default defineNuxtModule({
     nuxt.hook('prepare:types', ({ references }) => {
       references.push({ path: resolve(nuxt.options.buildDir, 'types/middleware.d.ts') })
       references.push({ path: resolve(nuxt.options.buildDir, 'types/layouts.d.ts') })
-      references.push({ path: resolve(nuxt.options.buildDir, 'vue-router.d.ts') })
+      references.push({ path: resolve(nuxt.options.buildDir, 'vue-router-stub.d.ts') })
     })
   }
 })


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/23435

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This resolves an issue with setting baseUrl to `.nuxt` (which probably shouldn't be done anyway), where this would end up shadowing `vue-router` with `.nuxt/vue-router.d.ts`.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
