### PR TITLE
perf(nuxt): verbatim module syntax + restrict type discovery

### DIFF
--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -134,9 +134,8 @@ export async function writeTypes (nuxt: Nuxt) {
       strict: nuxt.options.typescript?.strict ?? true,
       noImplicitThis: true,
       esModuleInterop: true,
-      // TODO: enable by default in v3.8
-      // types: [],
-      // verbatimModuleSyntax: true,
+      types: [],
+      verbatimModuleSyntax: true,
       allowJs: true,
       noEmit: true,
       resolveJsonModule: true,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue



### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This avoids 'auto-discovery' or inclusion of all `@types/` packages installed. It also enables `verbatimModuleSyntax`, which is important for `<script setup>` (see https://github.com/vuejs/tsconfig/blob/main/tsconfig.json#L30-L33).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
