### PR TITLE
feat(nuxt): enable `appManifest` by default

### DIFF
--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -269,6 +269,7 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
       }
 
       const manifest = {
+        version: 1,
         id: buildId,
         timestamp: buildTimestamp,
         matcher: exportMatcher(routeRulesMatcher),
@@ -277,6 +278,7 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
 
       await fsp.mkdir(join(tempDir, 'meta'), { recursive: true })
       await fsp.writeFile(join(tempDir, 'latest.json'), JSON.stringify({
+        version: 1,
         id: buildId,
         timestamp: buildTimestamp
       }))

--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -269,7 +269,6 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
       }
 
       const manifest = {
-        version: 1,
         id: buildId,
         timestamp: buildTimestamp,
         matcher: exportMatcher(routeRulesMatcher),
@@ -278,7 +277,6 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
 
       await fsp.mkdir(join(tempDir, 'meta'), { recursive: true })
       await fsp.writeFile(join(tempDir, 'latest.json'), JSON.stringify({
-        version: 1,
         id: buildId,
         timestamp: buildTimestamp
       }))

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -20,7 +20,7 @@ export default defineUntypedSchema({
      */
     reactivityTransform: false,
 
-    // TODO: Remove in v3.8 when nitro has support for mocking traced dependencies
+    // TODO: Remove when nitro has support for mocking traced dependencies
     // https://github.com/unjs/nitro/issues/1118
     /**
      * Externalize `vue`, `@vue/*` and `vue-router` when building.
@@ -210,8 +210,7 @@ export default defineUntypedSchema({
     /**
      * Use app manifests to respect route rules on client-side.
      */
-    // TODO: enable by default in v3.8
-    appManifest: false,
+    appManifest: true,
 
     // This is enabled when `experimental.payloadExtraction` is set to `true`.
     // appManifest: {

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -11,7 +11,7 @@ import type { NuxtIslandResponse } from '../packages/nuxt/src/core/runtime/nitro
 import { expectNoClientErrors, expectWithPolling, gotoPath, isRenderingJson, parseData, parsePayload, renderPage } from './utils'
 
 const isWebpack = process.env.TEST_BUILDER === 'webpack'
-const isTestingAppManifest = process.env.TEST_MANIFEST === 'manifest-on'
+const isTestingAppManifest = process.env.TEST_MANIFEST !== 'manifest-off'
 
 await setup({
   rootDir: fileURLToPath(new URL('./fixtures/basic', import.meta.url)),

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -19,7 +19,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
   for (const outputDir of ['.output', '.output-inline']) {
     it('default client bundle size', async () => {
       const clientStats = await analyzeSizes('**/*.js', join(rootDir, outputDir, 'public'))
-      expect.soft(roundToKilobytes(clientStats.totalBytes)).toMatchInlineSnapshot('"97.3k"')
+      expect.soft(roundToKilobytes(clientStats.totalBytes)).toMatchInlineSnapshot('"99.1k"')
       expect(clientStats.files.map(f => f.replace(/\..*\.js/, '.js'))).toMatchInlineSnapshot(`
         [
           "_nuxt/entry.js",
@@ -32,7 +32,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(rootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot('"300k"')
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot('"304k"')
 
     const modules = await analyzeSizes('node_modules/**/*', serverDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot('"1822k"')
@@ -71,7 +71,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(rootDir, '.output-inline/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot('"607k"')
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot('"611k"')
 
     const modules = await analyzeSizes('node_modules/**/*', serverDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot('"71.4k"')

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -195,8 +195,6 @@ export default defineNuxtConfig({
     reactivityTransform: true,
     treeshakeClientOnly: true,
     asyncContext: process.env.TEST_CONTEXT === 'async',
-    // TODO: remove this in v3.8
-    payloadExtraction: true,
     appManifest: process.env.TEST_MANIFEST === 'manifest-on',
     headNext: true,
     inlineRouteRules: true

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -195,7 +195,7 @@ export default defineNuxtConfig({
     reactivityTransform: true,
     treeshakeClientOnly: true,
     asyncContext: process.env.TEST_CONTEXT === 'async',
-    appManifest: process.env.TEST_MANIFEST === 'manifest-on',
+    appManifest: process.env.TEST_MANIFEST !== 'manifest-off',
     headNext: true,
     inlineRouteRules: true
   },

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -233,7 +233,7 @@ describe('url', () => {
   })
 })
 
-describe.skipIf(process.env.TEST_MANIFEST !== 'manifest-on')('app manifests', () => {
+describe.skipIf(process.env.TEST_MANIFEST === 'manifest-off')('app manifests', () => {
   it('getAppManifest', async () => {
     const manifest = await getAppManifest()
     delete manifest.timestamp

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -21,10 +21,12 @@ vi.mock('#app/compat/idle-callback', () => ({
 
 const timestamp = Date.now()
 registerEndpoint('/_nuxt/builds/latest.json', defineEventHandler(() => ({
+  version: 1,
   id: 'test',
   timestamp
 })))
 registerEndpoint('/_nuxt/builds/meta/test.json', defineEventHandler(() => ({
+  version: 1,
   id: 'test',
   timestamp,
   matcher: { static: { '/': null, '/pre': null }, wildcard: { '/pre': { prerender: true } }, dynamic: {} },

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -255,7 +255,6 @@ describe.skipIf(process.env.TEST_MANIFEST === 'manifest-off')('app manifests', (
         "prerendered": [
           "/specific-prerendered",
         ],
-        "version": 1,
       }
     `)
   })

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -257,6 +257,7 @@ describe.skipIf(process.env.TEST_MANIFEST === 'manifest-off')('app manifests', (
         "prerendered": [
           "/specific-prerendered",
         ],
+        "version": 1,
       }
     `)
   })

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -21,12 +21,10 @@ vi.mock('#app/compat/idle-callback', () => ({
 
 const timestamp = Date.now()
 registerEndpoint('/_nuxt/builds/latest.json', defineEventHandler(() => ({
-  version: 1,
   id: 'test',
   timestamp
 })))
 registerEndpoint('/_nuxt/builds/meta/test.json', defineEventHandler(() => ({
-  version: 1,
   id: 'test',
   timestamp,
   matcher: { static: { '/': null, '/pre': null }, wildcard: { '/pre': { prerender: true } }, dynamic: {} },


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

https://github.com/nuxt/nuxt/pull/21641

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This follows up on https://github.com/nuxt/nuxt/pull/21641 to enable app manifests and client-side routeRules by default. This can be disabled by setting `experimental.appManifest` to false.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
