### PR TITLE
docs: clarify bridge needs `nitro` to use `runtimeConfig`

### DIFF
--- a/docs/6.bridge/7.runtime-config.md
+++ b/docs/6.bridge/7.runtime-config.md
@@ -1,5 +1,9 @@
 # Runtime Config
 
+::alert{type=warning}
+When using `runtimeConfig` option, [nitro](/docs/bridge/nitro) must have been configured.
+::
+
 ## Update Runtime Config
 
 Nuxt 3 approaches runtime config differently than Nuxt 2, using a new combined `runtimeConfig` option.


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
`runtimeConfig` option must be nitro enabled.
So I added an explanation.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
