### PR TITLE
fix(kit): don't force `config.autoImport` in `addServerImports`

### DIFF
--- a/packages/kit/src/nitro.ts
+++ b/packages/kit/src/nitro.ts
@@ -92,7 +92,7 @@ export function addServerImports (imports: Import[]) {
   nuxt.hook('nitro:config', (config) => {
     config.imports = config.imports || {}
     if (Array.isArray(config.imports.imports)) {
-      config.imports.imports = [...config.imports.imports, ...imports]
+      config.imports.imports.push(...imports)
     } else {
       config.imports.imports = [config.imports.imports, ...imports]
     }

--- a/packages/kit/src/nitro.ts
+++ b/packages/kit/src/nitro.ts
@@ -91,7 +91,6 @@ export function addServerImports (imports: Import[]) {
   const nuxt = useNuxt()
   nuxt.hook('nitro:config', (config) => {
     config.imports = config.imports || {}
-    config.imports.autoImport = true
     if (Array.isArray(config.imports.imports)) {
       config.imports.imports = [...config.imports.imports, ...imports]
     } else {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
fix https://github.com/nuxt/nuxt/pull/23288
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Hi :wave: this PR removes `config.imports.autoImport = true` from `addServerImports`
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
