### PR TITLE
fix(nuxt): decrement hydration count when rendering no route

### DIFF
--- a/packages/nuxt/src/pages/runtime/page.ts
+++ b/packages/nuxt/src/pages/runtime/page.ts
@@ -60,6 +60,7 @@ export default defineComponent({
             if (import.meta.client && vnode && !hasSameChildren) {
               return vnode
             }
+            done()
             return
           }
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves #23468

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

An edge case - when we have no nested route to render, on initial hydration we increment but don't decrement hydration count. This fixes that issue.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
