### PR TITLE
fix(nuxt): ignore prefix if `clearNuxtState` called w/o keys

### DIFF
--- a/packages/nuxt/src/app/composables/state.ts
+++ b/packages/nuxt/src/app/composables/state.ts
@@ -42,6 +42,8 @@ export function clearNuxtState (
 ): void {
   const nuxtApp = useNuxtApp()
   const _allKeys = Object.keys(nuxtApp.payload.state)
+    .map(key => key.substring(useStateKeyPrefix.length))
+
   const _keys: string[] = !keys
     ? _allKeys
     : typeof keys === 'function'

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -214,12 +214,50 @@ describe('useState', () => {
     useState('key', () => 'value')
     expect(Object.entries(useNuxtApp().payload.state)).toContainEqual(['$skey', 'value'])
   })
+})
 
-  it.todo('clearNuxtState', () => {
-    const state = useState(() => 'test')
+describe('clearNuxtState', () => {
+  it('clears state in payload for single key', () => {
+    const key = 'clearNuxtState-test'
+    const state = useState(key, () => 'test')
     expect(state.value).toBe('test')
+    clearNuxtState(key)
+    expect(state.value).toBeUndefined()
+  })
+
+  it('clears state in payload for array of keys', () => {
+    const key1 = 'clearNuxtState-test'
+    const key2 = 'clearNuxtState-test2'
+    const state1 = useState(key1, () => 'test')
+    const state2 = useState(key2, () => 'test')
+    expect(state1.value).toBe('test')
+    expect(state2.value).toBe('test')
+    clearNuxtState([key1, 'other'])
+    expect(state1.value).toBeUndefined()
+    expect(state2.value).toBe('test')
+    clearNuxtState([key1, key2])
+    expect(state1.value).toBeUndefined()
+    expect(state2.value).toBeUndefined()
+  })
+
+  it('clears state in payload for function', () => {
+    const key = 'clearNuxtState-test'
+    const state = useState(key, () => 'test')
+    expect(state.value).toBe('test')
+    clearNuxtState(() => false)
+    expect(state.value).toBe('test')
+    clearNuxtState(k => k === key)
+    expect(state.value).toBeUndefined()
+  })
+
+  it('clears all state when no key is provided', () => {
+    const state1 = useState('clearNuxtState-test', () => 'test')
+    const state2 = useState('clearNuxtState-test2', () => 'test')
+    expect(state1.value).toBe('test')
+    expect(state2.value).toBe('test')
     clearNuxtState()
-    expect.soft(state.value).toBeUndefined()
+    expect(state1.value).toBeUndefined()
+    expect(state2.value).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves #23482.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

This fixes `clearNuxtState` behavior when called with a function or with no arguments. Internally, `useState` prefixes all keys. When `clearNuxtState` is called with a callback, it should not be needed to provide the prefix on keys from the calling side (this is an implementation detail). Also, when called without argument, all keys should be reset. The current behavior resets none, because all prefixed keys are prefixed again and then removed (which matches none).

I added mulitple tests as a separate `describe` to make sure all functionality is tested.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
