### PR TITLE
fix(nuxt): mock hookable methods on nuxt 2

### DIFF
--- a/packages/kit/src/loader/nuxt.ts
+++ b/packages/kit/src/loader/nuxt.ts
@@ -57,11 +57,11 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
   // Mock new hookable methods
   nuxt.removeHook ||= nuxt.clearHook.bind(nuxt)
   nuxt.removeAllHooks ||= nuxt.clearHooks.bind(nuxt)
-  nuxt.hookOnce ||= (name: string, fn: (...args: any[]) => any) => {
+  nuxt.hookOnce ||= (name: string, fn: (...args: any[]) => any, ...hookArgs: any[]) => {
     const unsub = nuxt.hook(name, (...args: any[]) => {
       unsub()
       return fn(...args)
-    })
+    }, ...hookArgs)
     return unsub
   }
   // https://github.com/nuxt/nuxt/tree/main/packages/kit/src/module/define.ts#L111-L113

--- a/packages/kit/src/loader/nuxt.ts
+++ b/packages/kit/src/loader/nuxt.ts
@@ -55,9 +55,9 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
   })
 
   // Mock new hookable methods
-  nuxt.removeHook = nuxt.clearHook.bind(nuxt)
-  nuxt.removeAllHooks = nuxt.clearHooks.bind(nuxt)
-  nuxt.hookOnce = (name: string, fn: (...args: any[]) => any) => {
+  nuxt.removeHook ||= nuxt.clearHook.bind(nuxt)
+  nuxt.removeAllHooks ||= nuxt.clearHooks.bind(nuxt)
+  nuxt.hookOnce ||= (name: string, fn: (...args: any[]) => any) => {
     const unsub = nuxt.hook(name, (...args: any[]) => {
       unsub()
       return fn(...args)
@@ -65,7 +65,7 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
     return unsub
   }
   // https://github.com/nuxt/nuxt/tree/main/packages/kit/src/module/define.ts#L111-L113
-  nuxt.hooks = nuxt
+  nuxt.hooks ||= nuxt
 
   return nuxt as Nuxt
 }

--- a/packages/kit/src/loader/nuxt.ts
+++ b/packages/kit/src/loader/nuxt.ts
@@ -54,6 +54,17 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
     envConfig: opts.dotenv // TODO: Backward format conversion
   })
 
+  // Mock new hookable methods
+  nuxt.removeHook = nuxt.clearHook.bind(nuxt)
+  nuxt.removeAllHooks = nuxt.clearHooks.bind(nuxt)
+  nuxt.hookOnce = (name: string, fn: (...args: any[]) => any) => {
+    const unsub = nuxt.hook(name, (...args: any[]) => {
+      unsub()
+      return fn(...args)
+    })
+    return unsub
+  }
+
   return nuxt as Nuxt
 }
 

--- a/packages/kit/src/loader/nuxt.ts
+++ b/packages/kit/src/loader/nuxt.ts
@@ -64,6 +64,8 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
     })
     return unsub
   }
+  // https://github.com/nuxt/nuxt/tree/main/packages/kit/src/module/define.ts#L111-L113
+  nuxt.hooks = nuxt
 
   return nuxt as Nuxt
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

related https://github.com/nuxt/bridge/pull/921
closes https://github.com/nuxt/cli/pull/230

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This polyfills some hook methods relied on by nuxi/bridge so they are available from the moment nuxt is loaded, rather than after `ready()` is called.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
