### PR TITLE
docs: clarify that `bridge.typescript` option must be set.

### DIFF
--- a/docs/6.bridge/2.typescript.md
+++ b/docs/6.bridge/2.typescript.md
@@ -5,6 +5,19 @@
 - Remove `@nuxt/typescript-build`: Bridge enables same functionality
 - Remove `@nuxt/typescript-runtime` and `nuxt-ts`: Nuxt 2 has built-in runtime support
 
+### Set `bridge.typescript`
+
+```ts
+import { defineNuxtConfig } from '@nuxt/bridge'
+
+export default defineNuxtConfig({
+  bridge: {
+    typescript: true,
+    nitro: false // If migration to Nitro is complete, set to true
+  }
+})
+```
+
 ## Update `tsconfig.json`
 
 If you are using TypeScript, you can edit your `tsconfig.json` to benefit from auto-generated Nuxt types:

--- a/docs/6.bridge/3.bridge-composition-api.md
+++ b/docs/6.bridge/3.bridge-composition-api.md
@@ -43,7 +43,8 @@ import { defineNuxtConfig } from '@nuxt/bridge'
 
 export default defineNuxtConfig({
   bridge: {
-    capi: true
+    capi: true,
+    nitro: false // If migration to Nitro is complete, set to true
   }
 })
 ```

--- a/docs/6.bridge/6.meta.md
+++ b/docs/6.bridge/6.meta.md
@@ -12,7 +12,8 @@ If you need to use the Options API, there is a `head()` method you can use when 
 import { defineNuxtConfig } from '@nuxt/bridge'
 export default defineNuxtConfig({
   bridge: {
-    meta: true
+    meta: true,
+    nitro: false // If migration to Nitro is complete, set to true
   }
 })
 ```

--- a/lychee.toml
+++ b/lychee.toml
@@ -4,6 +4,8 @@ cache = true
 exclude_all_private = true
 # HTTP status code: 429 (Too Many Requests) will also be treated as a valid link if Lychee gets rate limited
 accept = [200, 429]
+# retry
+max_retries = 6
 # Explicitly exclude some URLs
 exclude = [
   "https://twitter.nuxt.dev/",


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Clarify that `bridge: false` does not enable typescript, so bridge.typescript must be set.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
