### PR TITLE
feat(kit,nuxt,vite,webpack): support `-nightly` extension

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -61,5 +61,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `:rocket: Release triggered! You can now install [nuxt@npm:nuxt3@pr-${{ github.event.issue.number }}](https://www.npmjs.com/package/nuxt3/v/pr-${{ github.event.issue.number }})`
+              body: `:rocket: Release triggered! You can now install [nuxt@npm:nuxt-nightly@pr-${{ github.event.issue.number }}](https://www.npmjs.com/package/nuxt-nightly/v/pr-${{ github.event.issue.number }})`
             })

--- a/docs/2.guide/3.going-further/11.edge-channel.md
+++ b/docs/2.guide/3.going-further/11.edge-channel.md
@@ -1,23 +1,23 @@
 ---
-title: "Edge Channel"
-description: "Edge channel allows to use latest commits from the repository."
+title: "Nightly Release Channel"
+description: "The nightly release channel allows using Nuxt built directly from the latest commits to the repository."
 ---
 
-# Edge Release Channel
+# Nightly Release Channel
 
-Nuxt 3 is landing commits, improvements, and bug fixes every day. You can opt-in to test them earlier before the next release.
+Nuxt lands commits, improvements, and bug fixes every day. You can opt in to test them earlier before the next release.
 
-After each commit is merged into the `main` branch of [nuxt/nuxt](https://github.com/nuxt/nuxt) and **passing all tests**, we trigger an automated npm release using GitHub Actions publishing Nuxt 3 packages.
+After a commit is merged into the `main` branch of [nuxt/nuxt](https://github.com/nuxt/nuxt) and **passes all tests**, we trigger an automated npm release, using GitHub Actions.
 
-You can opt in to use this release channel and avoid waiting for the next release and helping Nuxt by beta testing changes.
+You can use these 'nightly' releases to beta test new features and changes.
 
-The build and publishing method and quality of edge releases are the same as stable ones. The only difference is that you should often check the GitHub repository for updates. There is a slight chance of regressions not being caught during the review process and by the automated tests. Therefore, we internally use this channel to double-check everything before each release.
+The build and publishing method and quality of these 'nightly' releases are the same as stable ones. The only difference is that you should often check the GitHub repository for updates. There is a slight chance of regressions not being caught during the review process and by the automated tests. Therefore, we internally use this channel to double-check everything before each release.
 
 :::Alert
-Features only available on the edge channel are marked with an alert in the documentation.
+Features that are only available on the nightly release channel are marked with an alert in the documentation.
 :::
 
-## Opting Into the Edge Channel
+## Opting Into the Nightly Release Channel
 
 Update `nuxt` dependency inside `package.json`:
 
@@ -25,21 +25,21 @@ Update `nuxt` dependency inside `package.json`:
 {
   "devDependencies": {
 --    "nuxt": "^3.0.0"
-++    "nuxt": "npm:nuxt3@latest"
+++    "nuxt": "npm:nuxt-nightly@latest"
   }
 }
 ```
 
 Remove lockfile (`package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, or `bun.lockb`) and reinstall dependencies.
 
-## Opting Out From the Edge Channel
+## Opting Out From the Nightly Release Channel
 
 Update `nuxt` dependency inside `package.json`:
 
 ```diff [package.json]
 {
   "devDependencies": {
---    "nuxt": "npm:nuxt3@latest"
+--    "nuxt": "npm:nuxt-nightly@latest"
 ++    "nuxt": "^3.0.0"
   }
 }
@@ -47,10 +47,10 @@ Update `nuxt` dependency inside `package.json`:
 
 Remove lockfile (`package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, or `bun.lockb`) and reinstall dependencies.
 
-## Using Latest `nuxi` CLI From Edge
+## Using Latest `nuxi` CLI From Nightly Release
 
 :::Alert
-All cli dependencies are bundled because of the building method for reducing `nuxi` package size. You can get dependency updates and CLI improvements using the edge channel.
+All cli dependencies are bundled because of the building method for reducing `nuxi` package size. You can get dependency updates and CLI improvements using the nightly release channel.
 :::
 
 You can use `npx nuxi-edge@latest [command]` to try the latest version of the nuxi CLI.

--- a/packages/kit/src/loader/nuxt.ts
+++ b/packages/kit/src/loader/nuxt.ts
@@ -26,7 +26,7 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
   // Apply dev as config override
   opts.overrides.dev = !!opts.dev
 
-  const nearestNuxtPkg = await Promise.all(['nuxt3', 'nuxt', 'nuxt-edge']
+  const nearestNuxtPkg = await Promise.all(['nuxt-nightly', 'nuxt3', 'nuxt', 'nuxt-edge']
     .map(pkg => resolvePackageJSON(pkg, { url: opts.cwd }).catch(() => null)))
     .then(r => (r.filter(Boolean) as string[]).sort((a, b) => b.length - a.length)[0])
   if (!nearestNuxtPkg) {
@@ -75,7 +75,7 @@ export async function buildNuxt (nuxt: Nuxt): Promise<any> {
 
   // Nuxt 3
   if (nuxt.options._majorVersion === 3) {
-    const { build } = await tryImportModule('nuxt3', rootDir) || await importModule('nuxt', rootDir)
+    const { build } = await tryImportModule('nuxt-nightly', rootDir) || await tryImportModule('nuxt3', rootDir) || await importModule('nuxt', rootDir)
     return build(nuxt)
   }
 

--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -155,6 +155,7 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
         ...nuxt.options.build.transpile.filter((i): i is string => typeof i === 'string'),
         'nuxt/dist',
         'nuxt3/dist',
+        'nuxt-nightly/dist',
         distDir
       ],
       traceInclude: [

--- a/packages/nuxt/src/core/plugins/import-protection.ts
+++ b/packages/nuxt/src/core/plugins/import-protection.ts
@@ -14,7 +14,7 @@ interface ImportProtectionOptions {
 }
 
 export const vueAppPatterns = (nuxt: Nuxt) => [
-  [/^(nuxt3|nuxt)$/, '`nuxt3`/`nuxt` cannot be imported directly. Instead, import runtime Nuxt composables from `#app` or `#imports`.'],
+  [/^(nuxt|nuxt3|nuxt-nightly)$/, '`nuxt`/`nuxt3`/`nuxt-nightly` cannot be imported directly. Instead, import runtime Nuxt composables from `#app` or `#imports`.'],
   [/^((|~|~~|@|@@)\/)?nuxt\.config(\.|$)/, 'Importing directly from a `nuxt.config` file is not allowed. Instead, use runtime config or a module.'],
   [/(^|node_modules\/)@vue\/composition-api/],
   ...nuxt.options.modules.filter(m => typeof m === 'string').map((m: any) =>

--- a/packages/nuxt/test/import-protection.test.ts
+++ b/packages/nuxt/test/import-protection.test.ts
@@ -11,6 +11,7 @@ const testsToTriggerOn = [
   ['.nuxt/nuxt.config', 'app.vue', false],
   ['nuxt', 'components/Component.vue', true],
   ['nuxt3', 'components/Component.vue', true],
+  ['nuxt-nightly', 'components/Component.vue', true],
   ['/root/node_modules/@vue/composition-api', 'components/Component.vue', true],
   ['@vue/composition-api', 'components/Component.vue', true],
   ['@nuxt/kit', 'components/Component.vue', true],

--- a/packages/vite/src/plugins/composable-keys.ts
+++ b/packages/vite/src/plugins/composable-keys.ts
@@ -18,7 +18,7 @@ interface ComposableKeysOptions {
 }
 
 const stringTypes = ['Literal', 'TemplateLiteral']
-const NUXT_LIB_RE = /node_modules\/nuxt3?\//
+const NUXT_LIB_RE = /node_modules\/(nuxt|nuxt3|nuxt-nightly)\//
 const SUPPORTED_EXT_RE = /\.(m?[jt]sx?|vue)/
 
 export const composableKeysPlugin = createUnplugin((options: ComposableKeysOptions) => {

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -68,7 +68,7 @@ export async function buildServer (ctx: ViteBuildContext) {
         '/__vue-jsx',
         '#app',
         /^nuxt(\/|$)/,
-        /(nuxt|nuxt3)\/(dist|src|app)/
+        /(nuxt|nuxt3|nuxt-nightly)\/(dist|src|app)/
       ]
     },
     cacheDir: resolve(ctx.nuxt.options.rootDir, 'node_modules/.cache/vite', 'server'),

--- a/packages/vite/src/vite-node.ts
+++ b/packages/vite/src/vite-node.ts
@@ -118,7 +118,7 @@ function createViteNodeApp (ctx: ViteBuildContext, invalidates: Set<string> = ne
     const node: ViteNodeServer = new ViteNodeServer(viteServer, {
       deps: {
         inline: [
-          /\/node_modules\/(.*\/)?(nuxt|nuxt3)\//,
+          /\/node_modules\/(.*\/)?(nuxt|nuxt3|nuxt-nightly)\//,
           /^#/,
           ...transpile({ isServer: true, isDev: ctx.nuxt.options.dev })
         ]

--- a/packages/webpack/src/configs/server.ts
+++ b/packages/webpack/src/configs/server.ts
@@ -47,6 +47,7 @@ function serverStandalone (ctx: WebpackConfigContext) {
     '#app',
     'nuxt',
     'nuxt3',
+    'nuxt-nightly',
     '!',
     '-!',
     '~',

--- a/scripts/bump-edge.ts
+++ b/scripts/bump-edge.ts
@@ -6,7 +6,7 @@ import { determineBumpType, loadWorkspace } from './_utils'
 const nightlyPackages = {
   nitropack: 'nitropack-edge',
   h3: 'h3-nightly',
-  nuxi: 'nuxi-edge'
+  nuxi: 'nuxi-nightly'
 }
 
 async function main () {

--- a/scripts/bump-edge.ts
+++ b/scripts/bump-edge.ts
@@ -27,7 +27,7 @@ async function main () {
         pkg.data.dependencies[name] = `npm:${nightlyName}@latest`
       }
     }
-    const newname = pkg.data.name === 'nuxt' ? 'nuxt3' : (pkg.data.name + '-edge')
+    const newname = pkg.data.name + '-nightly'
     workspace.rename(pkg.data.name, newname)
   }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/22143

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This updates the automated build process to use the `-nightly` suffix, as well as updating regexps and package patterns to recognise `nuxt-nightly`.

This means new edge/nightly release uses a consistent pattern `nuxt-nightly`, `@nuxt/kit-nightly`, etc.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
