### PR TITLE
fix(kit): revert accidental change to `addPrerenderRoutes` name

### DIFF
--- a/docs/3.api/4.advanced/2.kit.md
+++ b/docs/3.api/4.advanced/2.kit.md
@@ -88,7 +88,7 @@ description: Nuxt Kit provides composable utilities to help interacting with Nux
 - `addDevServerHandler (handler)`
 - `useNitro()` (only usable after `ready` hook)
 - `addServerPlugin`
-- `prerenderRoutes`
+- `addPrerenderRoutes`
 
 ### Resolving
 

--- a/packages/kit/src/nitro.ts
+++ b/packages/kit/src/nitro.ts
@@ -45,7 +45,7 @@ export function addServerPlugin (plugin: string) {
 /**
  * Adds routes to be prerendered
  */
-export function prerenderRoutes (routes: string | string[]) {
+export function addPrerenderRoutes (routes: string | string[]) {
   const nuxt = useNuxt()
   if (!Array.isArray(routes)) {
     routes = [routes]


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/pull/22863

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

An over-zealous search/replace in https://github.com/nuxt/nuxt/pull/22863 ended up renaming the kit utility `addPrerenderRoutes` to match the _runtime_ `prerenderRoutes` utility. This returns it to the correct name.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
