### PR TITLE
fix(nuxt): use `test`/`dev` as manifest buildId when appropriate

### DIFF
--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -213,7 +213,7 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
   // Add app manifest handler and prerender configuration
   if (nuxt.options.experimental.appManifest) {
     // @ts-expect-error untyped nuxt property
-    const buildId = nuxt.options.appConfig.nuxt!.buildId ||= randomUUID()
+    const buildId = nuxt.options.appConfig.nuxt!.buildId ||= (nuxt.options.test ? 'test' : randomUUID())
     const buildTimestamp = Date.now()
 
     const manifestPrefix = joinURL(nuxt.options.app.buildAssetsDir, 'builds')

--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -213,7 +213,8 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
   // Add app manifest handler and prerender configuration
   if (nuxt.options.experimental.appManifest) {
     // @ts-expect-error untyped nuxt property
-    const buildId = nuxt.options.appConfig.nuxt!.buildId ||= (nuxt.options.test ? 'test' : randomUUID())
+    const buildId = nuxt.options.appConfig.nuxt!.buildId ||=
+      (nuxt.options.test ? 'test' : nuxt.options.dev ? 'dev' : randomUUID())
     const buildTimestamp = Date.now()
 
     const manifestPrefix = joinURL(nuxt.options.app.buildAssetsDir, 'builds')

--- a/vitest.nuxt.config.ts
+++ b/vitest.nuxt.config.ts
@@ -7,17 +7,6 @@ export default defineVitestConfig({
   },
   test: {
     dir: './test/nuxt',
-    environment: 'nuxt',
-    environmentOptions: {
-      nuxt: {
-        overrides: {
-          appConfig: {
-            nuxt: {
-              buildId: 'test'
-            }
-          }
-        }
-      }
-    }
+    environment: 'nuxt'
   }
 })


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

With new app manifest enabled, we can potentially have a source of unreliable test data in that we have a constantly changing buildId which is difficult to mock (see https://github.com/danielroe/nuxt-vitest/pull/354).

This PR defaults the buildId (unless user overrides) to `test` when running in e2e/unit test environments.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
