### PR TITLE
fix(types): don't pin webpack types to exact version

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -23,7 +23,7 @@
     "@types/pug": "2.0.6",
     "@types/serve-static": "1.15.2",
     "@types/terser-webpack-plugin": "4.2.1",
-    "@types/webpack": "4.41.33",
+    "@types/webpack": "^4.41.33",
     "@types/webpack-bundle-analyzer": "3.9.5",
     "@types/webpack-hot-middleware": "2.25.5"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2834,10 +2834,10 @@
     "@types/source-list-map" "*"
     source-map "^0.7.3"
 
-"@types/webpack@4.41.33", "@types/webpack@^4", "@types/webpack@^4.41.8":
-  version "4.41.33"
-  resolved "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.33.tgz#16164845a5be6a306bcbe554a8e67f9cac215ffc"
-  integrity sha512-PPajH64Ft2vWevkerISMtnZ8rTs4YmRbs+23c402J0INmxDKCrhZNvwZYtzx96gY2wAtXdrK1BS2fiC8MlLr3g==
+"@types/webpack@^4", "@types/webpack@^4.41.33", "@types/webpack@^4.41.8":
+  version "4.41.34"
+  resolved "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.34.tgz#8cf616be84b39c8fb26f9459d4470a5514df2477"
+  integrity sha512-CN2aOGrR3zbMc2v+cKqzaClYP1ldkpPOgtdNvgX+RmlWCSWxHxpzz6WSCVQZRkF8D60ROlkRzAoEpgjWQ+bd2g==
   dependencies:
     "@types/node" "*"
     "@types/tapable" "^1"


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Since the current convention in `@nuxt/types` is to pin all dependencies to exact versions, I'm pretty sure this is not an acceptable solution but I wanted to raise an issue with the current approach.

The `@types/webpack` is pinned to `4.41.33`. Since `4.41.34` is now the latest version, if I do `yarn upgrade` in my project, this will introduce both `4.41.33` and `4.41.34` and then the shim that extends `webpack` from `@nuxt/types/shims.d.ts` will stop working. A code like:

```ts
import '@nuxt/types'
import { MultiStats, AssetInfo } from 'webpack'
```

should show that `MultiStats` that the shim is supposed to introduce is not present.

It works if only `4.41.33` is installed in the project.

I'm not sure what to do with this problem. Clearly there was a reason for going with exact versions but as evident here, this is also not a good solution. Ideally a range should be allowed and as long as packages follow semver, it should not cause issues (but clearly did in the past).

@danielroe 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
