### PR TITLE
docs: fix component library example in docs

### DIFF
--- a/docs/2.guide/2.directory-structure/1.components.md
+++ b/docs/2.guide/2.directory-structure/1.components.md
@@ -427,7 +427,7 @@ export default defineNuxtModule({
       const { resolve } = createResolver(import.meta.url)
       // Add ./components dir to the list
       dirs.push({
-        path: fileURLToPath(resolve('./components')),
+        path: resolve('./components'),
         prefix: 'awesome'
       })
     }


### PR DESCRIPTION
### 🔗 Linked issue

resolves [#21301](https://github.com/nuxt/nuxt/issues/21301)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently, nuxt has the below example in `/guide/concepts/directory-structure/components`:

```ts
import { defineNuxtModule, createResolver } from '@nuxt/kit'

export default defineNuxtModule({
  hooks: {
    'components:dirs': (dirs) => {
      const { resolve } = createResolver(import.meta.url)
      // Add ./components dir to the list
      dirs.push({
        path: fileURLToPath(resolve('./components')),
        prefix: 'awesome'
      })
    }
  }
})
```

This example is not valid as mentioned in [#21301](https://github.com/nuxt/nuxt/issues/21301). We can directly use `resolve()` like this:

```ts
import { defineNuxtModule, createResolver } from '@nuxt/kit'

export default defineNuxtModule({
  hooks: {
    'components:dirs': (dirs) => {
      const { resolve } = createResolver(import.meta.url)
      // Add ./components dir to the list
      dirs.push({
        path: resolve('./components'),
        prefix: 'awesome'
      })
    }
  }
})
```

### 📝 Checklist

- [x ] I have linked an issue or discussion.
- [x ] I have updated the documentation accordingly.
