### PR TITLE
feat(nuxt): auto-install optional features on StackBlitz

### DIFF
--- a/packages/nuxt/src/core/features.ts
+++ b/packages/nuxt/src/core/features.ts
@@ -1,9 +1,17 @@
 import { addDependency } from 'nypm'
 import { resolvePackageJSON } from 'pkg-types'
 import { logger } from '@nuxt/kit'
-import { isCI } from 'std-env'
+import { isCI, provider } from 'std-env'
 
-export async function ensurePackageInstalled (rootDir: string, name: string, searchPaths?: string[]) {
+const isStackblitz = provider === 'stackblitz'
+
+export async function ensurePackageInstalled (
+  rootDir: string,
+  name: string,
+  searchPaths?: string[],
+  // In StackBlitz we install packages automatically by default
+  prompt = !isStackblitz
+) {
   if (await resolvePackageJSON(name, { url: searchPaths }).catch(() => null)) {
     return true
   }
@@ -13,14 +21,16 @@ export async function ensurePackageInstalled (rootDir: string, name: string, sea
     return false
   }
 
-  const confirm = await logger.prompt(`Do you want to install ${name} package?`, {
-    type: 'confirm',
-    name: 'confirm',
-    initial: true
-  })
+  if (!prompt) {
+    const confirm = await logger.prompt(`Do you want to install ${name} package?`, {
+      type: 'confirm',
+      name: 'confirm',
+      initial: true
+    })
 
-  if (!confirm) {
-    return false
+    if (!confirm) {
+      return false
+    }
   }
 
   logger.info(`Installing ${name}...`)

--- a/packages/nuxt/src/core/features.ts
+++ b/packages/nuxt/src/core/features.ts
@@ -15,14 +15,7 @@ export async function ensurePackageInstalled (
   name: string,
   options: EnsurePackageInstalledOptions
 ) {
-  const {
-    rootDir,
-    searchPaths,
-    // In StackBlitz we install packages automatically by default
-    prompt = !isStackblitz
-  } = options
-
-  if (await resolvePackageJSON(name, { url: searchPaths }).catch(() => null)) {
+  if (await resolvePackageJSON(name, { url: options.searchPaths }).catch(() => null)) {
     return true
   }
 
@@ -31,7 +24,8 @@ export async function ensurePackageInstalled (
     return false
   }
 
-  if (!prompt) {
+  // In StackBlitz we install packages automatically by default
+  if (options.prompt === true || (options.prompt !== false && !isStackblitz)) {
     const confirm = await logger.prompt(`Do you want to install ${name} package?`, {
       type: 'confirm',
       name: 'confirm',
@@ -46,7 +40,7 @@ export async function ensurePackageInstalled (
   logger.info(`Installing ${name}...`)
   try {
     await addDependency(name, {
-      cwd: rootDir,
+      cwd: options.rootDir,
       dev: true
     })
     logger.success(`Installed ${name}`)

--- a/packages/nuxt/src/core/features.ts
+++ b/packages/nuxt/src/core/features.ts
@@ -5,13 +5,23 @@ import { isCI, provider } from 'std-env'
 
 const isStackblitz = provider === 'stackblitz'
 
+export interface EnsurePackageInstalledOptions {
+  rootDir: string
+  searchPaths?: string[]
+  prompt?: boolean
+}
+
 export async function ensurePackageInstalled (
-  rootDir: string,
   name: string,
-  searchPaths?: string[],
-  // In StackBlitz we install packages automatically by default
-  prompt = !isStackblitz
+  options: EnsurePackageInstalledOptions
 ) {
+  const {
+    rootDir,
+    searchPaths,
+    // In StackBlitz we install packages automatically by default
+    prompt = !isStackblitz
+  } = options
+
   if (await resolvePackageJSON(name, { url: searchPaths }).catch(() => null)) {
     return true
   }

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -497,3 +497,5 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
 
   return nuxt
 }
+
+const RESTART_RE = /^(app|error|app\.config)\.(js|ts|mjs|jsx|tsx|vue)$/i

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -443,7 +443,10 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
 
   // Nuxt DevTools is currently opt-in
   if (options.devtools === true || (options.devtools && options.devtools.enabled !== false)) {
-    if (await import('./features').then(r => r.ensurePackageInstalled(options.rootDir, '@nuxt/devtools', options.modulesDir))) {
+    if (await import('./features').then(r => r.ensurePackageInstalled('@nuxt/devtools', {
+      rootDir: options.rootDir,
+      searchPaths: options.modulesDir
+    }))) {
       options._modules.push('@nuxt/devtools')
     } else {
       logger.warn('Failed to install `@nuxt/devtools`, please install it manually, or disable `devtools` in `nuxt.config`')
@@ -452,7 +455,10 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
 
   // Nuxt Webpack Builder is currently opt-in
   if (options.builder === '@nuxt/webpack-builder') {
-    if (!await import('./features').then(r => r.ensurePackageInstalled(options.rootDir, '@nuxt/webpack-builder', options.modulesDir))) {
+    if (!await import('./features').then(r => r.ensurePackageInstalled('@nuxt/webpack-builder', {
+      rootDir: options.rootDir,
+      searchPaths: options.modulesDir
+    }))) {
       logger.warn('Failed to install `@nuxt/webpack-builder`, please install it manually, or change the `builder` option to vite in `nuxt.config`')
     }
   }
@@ -491,5 +497,3 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
 
   return nuxt
 }
-
-const RESTART_RE = /^(app|error|app\.config)\.(js|ts|mjs|jsx|tsx|vue)$/i


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In StackBlitz we could assume the envoriment is isolated and safe, we could install optional deps when enabled automatically to provide better overall experience when opening playgrounds.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
