### PR TITLE
fix(nuxt): clear cookie BroadcastChannel when scope is disposed

### DIFF
--- a/packages/nuxt/src/app/composables/cookie.ts
+++ b/packages/nuxt/src/app/composables/cookie.ts
@@ -1,5 +1,5 @@
 import type { Ref } from 'vue'
-import { getCurrentInstance, nextTick, onUnmounted, ref, watch } from 'vue'
+import { getCurrentScope, nextTick, onScopeDispose, ref, watch } from 'vue'
 import type { CookieParseOptions, CookieSerializeOptions } from 'cookie-es'
 import { parse, serialize } from 'cookie-es'
 import { deleteCookie, getCookie, getRequestHeader, setCookie } from 'h3'
@@ -35,7 +35,7 @@ export function useCookie<T = string | null | undefined> (name: string, _opts?: 
 
   if (import.meta.client) {
     const channel = typeof BroadcastChannel === 'undefined' ? null : new BroadcastChannel(`nuxt:cookies:${name}`)
-    if (getCurrentInstance()) { onUnmounted(() => { channel?.close() }) }
+    if (getCurrentScope()) { onScopeDispose(() => { channel?.close() }) }
 
     const callback = () => {
       writeClientCookie(name, cookie.value, opts as CookieSerializeOptions)


### PR DESCRIPTION
### 🔗 Linked issue

resolves #23650

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR replaces `onUnmounted` with `onScopeDispose` to ensure that `useCookie` functions correctly within the store.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
