### PR TITLE
fix(nuxt): resolve type error in options of `useFetch`

### DIFF
--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -13,7 +13,7 @@ type AvailableRouterMethod<R extends NitroFetchRequest> = _AvailableRouterMethod
 export type FetchResult<ReqT extends NitroFetchRequest, M extends AvailableRouterMethod<ReqT>> = TypedInternalResponse<ReqT, unknown, Lowercase<M>>
 
 type ComputedOptions<T extends Record<string, any>> = {
-  [K in keyof T]: T[K] extends Function ? T[K] : T[K] extends Record<string, any> ? ComputedOptions<T[K]> | Ref<T[K]> | T[K] : Ref<T[K]> | T[K]
+  [K in keyof T]: T[K] extends Function ? T[K] : ComputedOptions<T[K]> | Ref<T[K]> | T[K]
 }
 
 interface NitroFetchOptions<R extends NitroFetchRequest, M extends AvailableRouterMethod<R> = AvailableRouterMethod<R>> extends FetchOptions {

--- a/test/fixtures/basic-types/types.ts
+++ b/test/fixtures/basic-types/types.ts
@@ -406,6 +406,17 @@ describe('composables', () => {
     expectTypeOf(test).toEqualTypeOf<string | undefined>()
   })
 
+  it('allows passing reactive values in useFetch', () => {
+    useFetch('/api/hey', {
+      headers: {
+        key: ref('test')
+      },
+      query: {
+        param: computed(() => 'thing')
+      }
+    })
+  })
+
   it('correctly types returns with key signatures', () => {
     interface TestType {
       id: string


### PR DESCRIPTION
### 🔗 Linked issue

resolves: #23626

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In the current version, the following code is working correctly and will track updates for the reactivity data. After this PR, the code will no longer display type checking errors.

```ts
// Mock vue-i18n
function useI18n () {
  return {
    locale: ref('')
  }
}

await useFetch('/api/test', {
  headers: {
    'Accept-Language': useI18n().locale.value
  }
})

await useFetch('/api/test', {
  headers: [['Accept-Language', useI18n().locale]]
})
```

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
