### PR TITLE
fix: remove md4 patch now that `webpack` has it in core

### DIFF
--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -520,17 +520,6 @@ export function getNuxtConfig (_options) {
     options.build.indicator = false
   }
 
-  // Monkey patch crypto.createHash in dev/build to upgrade hashing fnction
-  if (parseInt(process.versions.node.slice(0, 2)) > 16 && !options.buildModules.some(m => m.name === 'patchMD4')) {
-    options.buildModules.push(function patchMD4 () {
-      const crypto = require('crypto')
-      const _createHash = crypto.createHash
-      crypto.createHash = function (algorithm, options) {
-        return _createHash(algorithm === 'md4' ? 'md5' : algorithm, options)
-      }
-    })
-  }
-
   // Components Module
   if (!options._start && getPKG('@nuxt/components')) {
     options._modules.push('@nuxt/components')

--- a/packages/config/test/config/index.test.js
+++ b/packages/config/test/config/index.test.js
@@ -24,7 +24,6 @@ describe('config', () => {
       UNIX_SOCKET: '/var/run/nuxt.sock'
     }
     const config = getDefaultNuxtConfig({ env })
-    config.buildModules = config.buildModules.filter(p => p.name !== 'patchMD4')
     expect(config).toMatchSnapshot()
   })
 })

--- a/packages/config/test/options.test.js
+++ b/packages/config/test/options.test.js
@@ -34,7 +34,6 @@ describe('config: options', () => {
         }
       }
     })
-    config.buildModules = config.buildModules.filter(p => p.name !== 'patchMD4')
     expect(config).toMatchSnapshot()
 
     process.cwd.mockRestore()
@@ -298,7 +297,7 @@ describe('config: options', () => {
       const config = getNuxtConfig({ devModules: ['foo'], buildModules: ['bar'] })
       expect(consola.warn).toHaveBeenCalledWith('`devModules` has been renamed to `buildModules` and will be removed in Nuxt 3.')
       expect(config.devModules).toBe(undefined)
-      expect(config.buildModules.filter(p => p.name !== 'patchMD4')).toEqual(['bar', 'foo'])
+      expect(config.buildModules).toEqual(['bar', 'foo'])
     })
 
     test('should deprecate build.extractCSS.allChunks', () => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

https://github.com/webpack/webpack/pull/17628
https://github.com/nuxt/nuxt/pull/19108

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Now that webpack has support for md4 in latest node versions, this PR removes our monkey-patch.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
