### PR TITLE
fix(nuxt): don't mark redirected routes as prerendered

### DIFF
--- a/packages/nuxt/src/app/composables/payload.ts
+++ b/packages/nuxt/src/app/composables/payload.ts
@@ -88,7 +88,7 @@ export async function isPrerendered (url = useRoute().path) {
     return true
   }
   const rules = await getRouteRules(url)
-  return !!rules.prerender
+  return !!rules.prerender && !rules.redirect
 }
 
 let payloadCache: any = null

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -19,7 +19,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
   for (const outputDir of ['.output', '.output-inline']) {
     it('default client bundle size', async () => {
       const clientStats = await analyzeSizes('**/*.js', join(rootDir, outputDir, 'public'))
-      expect.soft(roundToKilobytes(clientStats.totalBytes)).toMatchInlineSnapshot('"99.1k"')
+      expect.soft(roundToKilobytes(clientStats.totalBytes)).toMatchInlineSnapshot('"99.2k"')
       expect(clientStats.files.map(f => f.replace(/\..*\.js/, '.js'))).toMatchInlineSnapshot(`
         [
           "_nuxt/entry.js",

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -349,5 +349,6 @@ describe.skipIf(process.env.TEST_MANIFEST === 'manifest-off')('app manifests', (
     expect(await isPrerendered('/prerendered/test')).toBeTruthy()
     expect(await isPrerendered('/test')).toBeFalsy()
     expect(await isPrerendered('/pre/test')).toBeFalsy()
+    expect(await isPrerendered('/pre/thing')).toBeTruthy()
   })
 })

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -331,7 +331,6 @@ describe.skipIf(process.env.TEST_MANIFEST === 'manifest-off')('app manifests', (
     `)
   })
   it('getRouteRules', async () => {
-    const rules = await getRouteRules('/')
     expect(await getRouteRules('/')).toMatchInlineSnapshot('{}')
     expect(await getRouteRules('/pre')).toMatchInlineSnapshot(`
       {

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -27,7 +27,15 @@ registerEndpoint('/_nuxt/builds/latest.json', defineEventHandler(() => ({
 registerEndpoint('/_nuxt/builds/meta/override.json', defineEventHandler(() => ({
   id: 'override',
   timestamp,
-  matcher: { static: { '/': null, '/pre': null }, wildcard: { '/pre': { prerender: true } }, dynamic: {} },
+  matcher: {
+    static: {
+      '/': null,
+      '/pre': null,
+      '/pre/test': { redirect: true }
+    },
+    wildcard: { '/pre': { prerender: true } },
+    dynamic: {}
+  },
   prerendered: ['/specific-prerendered']
 })))
 
@@ -306,6 +314,9 @@ describe.skipIf(process.env.TEST_MANIFEST === 'manifest-off')('app manifests', (
           "static": {
             "/": null,
             "/pre": null,
+            "/pre/test": {
+              "redirect": true,
+            },
           },
           "wildcard": {
             "/pre": {
@@ -321,11 +332,23 @@ describe.skipIf(process.env.TEST_MANIFEST === 'manifest-off')('app manifests', (
   })
   it('getRouteRules', async () => {
     const rules = await getRouteRules('/')
-    expect(rules).toMatchInlineSnapshot('{}')
+    expect(await getRouteRules('/')).toMatchInlineSnapshot('{}')
+    expect(await getRouteRules('/pre')).toMatchInlineSnapshot(`
+      {
+        "prerender": true,
+      }
+    `)
+    expect(await getRouteRules('/pre/test')).toMatchInlineSnapshot(`
+      {
+        "prerender": true,
+        "redirect": true,
+      }
+    `)
   })
   it('isPrerendered', async () => {
     expect(await isPrerendered('/specific-prerendered')).toBeTruthy()
     expect(await isPrerendered('/prerendered/test')).toBeTruthy()
     expect(await isPrerendered('/test')).toBeFalsy()
+    expect(await isPrerendered('/pre/test')).toBeFalsy()
   })
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

If a  route rule will redirect a route, we shouldn't treat that route as prerendered (and therefore try to fetch a payload for it)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
