### PR TITLE
fix(nuxt): respect custom export in component transform

### DIFF
--- a/packages/nuxt/src/components/transform.ts
+++ b/packages/nuxt/src/components/transform.ts
@@ -36,12 +36,12 @@ export function createTransformPlugin (nuxt: Nuxt, getComponents: getComponentsT
         {
           as: c.pascalName,
           from: withMode(mode),
-          name: 'default'
+          name: c.export || 'default'
         },
         {
           as: 'Lazy' + c.pascalName,
           from: withMode([mode, 'async'].filter(Boolean).join(',')),
-          name: 'default'
+          name: c.export || 'default'
         }
       ]
     })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

https://github.com/Tresjs/nuxt/pull/44#issuecomment-1740730192

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Discovered when looking into https://github.com/Tresjs/nuxt/pull/44 - we were not correctly handling non-default exports for components, leading to an error like `Component is missing template or render function.` when using components that had named exports.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
