### PR TITLE
feat(nuxt): prompt to autoinstall `@nuxt/image` when it is used

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-stubs.ts
+++ b/packages/nuxt/src/app/components/nuxt-stubs.ts
@@ -1,17 +1,17 @@
-import { createError } from '#imports'
+import { createError } from '../composables/error'
 
 function renderStubMessage (name: string) {
   throw createError({
     fatal: true,
     statusCode: 500,
-    statusMessage: `<${name}> is provided by @nuxt/image. Check your console to install it or run 'npx nuxi@latest module add @nuxt/image'`
+    statusMessage: `${name} is provided by @nuxt/image. Check your console to install it or run 'npx nuxi@latest module add @nuxt/image'`
   })
 }
 
 export const NuxtImg = {
-  setup: () => renderStubMessage('NuxtImg')
+  setup: () => renderStubMessage('<NuxtImg>')
 }
 
 export const NuxtPicture = {
-  setup: () => renderStubMessage('NuxtPicture')
+  setup: () => renderStubMessage('<NuxtPicture>')
 }

--- a/packages/nuxt/src/app/components/nuxt-stubs.ts
+++ b/packages/nuxt/src/app/components/nuxt-stubs.ts
@@ -1,0 +1,17 @@
+import { createError } from '#imports'
+
+function renderStubMessage (name: string) {
+  throw createError({
+    fatal: true,
+    statusCode: 500,
+    statusMessage: `<${name}> is provided by @nuxt/image. Check your console to install it or run 'npx nuxi@latest module add @nuxt/image'`
+  })
+}
+
+export const NuxtImg = {
+  setup: () => renderStubMessage('NuxtImg')
+}
+
+export const NuxtPicture = {
+  setup: () => renderStubMessage('NuxtPicture')
+}

--- a/packages/nuxt/src/components/loader.ts
+++ b/packages/nuxt/src/components/loader.ts
@@ -46,6 +46,11 @@ export const loaderPlugin = createUnplugin((options: LoaderOptions) => {
       s.replace(/(?<=[ (])_?resolveComponent\(\s*["'](lazy-|Lazy)?([^'"]*?)["'][\s,]*[^)]*\)/g, (full: string, lazy: string, name: string) => {
         const component = findComponent(components, name, options.mode)
         if (component) {
+          // @ts-expect-error TODO: refactor to nuxi
+          if (component._internal_install) {
+            // @ts-expect-error TODO: refactor to nuxi
+            import('../core/features').then(({ installNuxtModule }) => installNuxtModule(component._internal_install))
+          }
           let identifier = map.get(component) || `__nuxt_component_${num++}`
           map.set(component, identifier)
 

--- a/packages/nuxt/src/core/features.ts
+++ b/packages/nuxt/src/core/features.ts
@@ -1,6 +1,6 @@
 import { addDependency } from 'nypm'
 import { resolvePackageJSON } from 'pkg-types'
-import { logger } from '@nuxt/kit'
+import { logger, useNuxt } from '@nuxt/kit'
 import { isCI, provider } from 'std-env'
 
 const isStackblitz = provider === 'stackblitz'
@@ -11,10 +11,7 @@ export interface EnsurePackageInstalledOptions {
   prompt?: boolean
 }
 
-export async function ensurePackageInstalled (
-  name: string,
-  options: EnsurePackageInstalledOptions
-) {
+async function promptToInstall (name: string, installCommand: () => Promise<void>, options: EnsurePackageInstalledOptions) {
   if (await resolvePackageJSON(name, { url: options.searchPaths }).catch(() => null)) {
     return true
   }
@@ -39,14 +36,30 @@ export async function ensurePackageInstalled (
 
   logger.info(`Installing ${name}...`)
   try {
-    await addDependency(name, {
-      cwd: options.rootDir,
-      dev: true
-    })
+    await installCommand()
     logger.success(`Installed ${name}`)
     return true
   } catch (err) {
     logger.error(err)
     return false
   }
+}
+
+// TODO: refactor to Nuxi
+const installPrompts = new Set<string>()
+export function installNuxtModule (name: string, options?: EnsurePackageInstalledOptions) {
+  if (installPrompts.has(name)) { return }
+  installPrompts.add(name)
+  const nuxt = useNuxt()
+  return promptToInstall(name, async () => {
+    const { runCommand } = await import('nuxi')
+    await runCommand('module', ['add', name, '--cwd', nuxt.options.rootDir])
+  }, { rootDir: nuxt.options.rootDir, searchPaths: nuxt.options.modulesDir, ...options })
+}
+
+export function ensurePackageInstalled (name: string, options: EnsurePackageInstalledOptions) {
+  return promptToInstall(name, () => addDependency(name, {
+    cwd: options.rootDir,
+    dev: true
+  }), options)
 }

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -305,6 +305,18 @@ async function initNuxt (nuxt: Nuxt) {
     }
   }
 
+  // Add stubs for <NuxtImg> and <NuxtPicture>
+  for (const name of ['NuxtImg', 'NuxtPicture']) {
+    addComponent({
+      name,
+      export: name,
+      priority: -1,
+      filePath: resolve(nuxt.options.appDir, 'components/nuxt-stubs'),
+      // @ts-expect-error TODO: refactor to nuxi
+      _internal_install: '@nuxt/image'
+    })
+  }
+
   // Add prerender payload support
   if (!nuxt.options.dev && nuxt.options.experimental.payloadExtraction) {
     addPlugin(resolve(nuxt.options.appDir, 'plugins/payload.client'))


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This is a preliminary implementation of auto-installation for `@nuxt/image`.

We plan for @pi0 to improve and possibly refactor to nuxi (providing an endpoint for a more interactive/seamless experience that doesn't rely on the CLI).

[autoinstall.mp4](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/xbfiaQHnuvLSgxHiCxpj/f30d0080-a1ea-482d-a385-4693084c1700/autoinstall.mp4)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
