### PR TITLE
feat(nuxt): allow configuring default `<NuxtLink>` options

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -9,6 +9,9 @@ import { navigateTo, useRouter } from '../composables/router'
 import { useNuxtApp } from '../nuxt'
 import { cancelIdleCallback, requestIdleCallback } from '../compat/idle-callback'
 
+// @ts-expect-error virtual file
+import { nuxtLinkDefaults } from '#build/nuxt.config.mjs'
+
 const firstNonUndefined = <T> (...args: (T | undefined)[]) => args.find(arg => arg !== undefined)
 
 const DEFAULT_EXTERNAL_REL_ATTRIBUTE = 'noopener noreferrer'
@@ -332,7 +335,7 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
   }) as unknown as DefineComponent<NuxtLinkProps>
 }
 
-export default defineNuxtLink({ componentName: 'NuxtLink' })
+export default defineNuxtLink(nuxtLinkDefaults)
 
 // --- Prefetching utils ---
 type CallbackFn = () => void

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -347,6 +347,7 @@ export const nuxtConfigTemplate = {
       `export const remoteComponentIslands = ${ctx.nuxt.options.experimental.componentIslands === 'local+remote'}`,
       `export const devPagesDir = ${ctx.nuxt.options.dev ? JSON.stringify(ctx.nuxt.options.dir.pages) : 'null'}`,
       `export const devRootDir = ${ctx.nuxt.options.dev ? JSON.stringify(ctx.nuxt.options.rootDir) : 'null'}`,
+      `export const nuxtLinkDefaults = ${JSON.stringify(ctx.nuxt.options.experimental.defaults.nuxtLink)}`,
       `export const vueAppRootContainer = ${ctx.nuxt.options.app.rootId ? `'#${ctx.nuxt.options.app.rootId}'` : `'body > ${ctx.nuxt.options.app.rootTag}'`}`
     ].join('\n\n')
   }

--- a/packages/schema/build.config.ts
+++ b/packages/schema/build.config.ts
@@ -20,6 +20,7 @@ export default defineBuildConfig({
   ],
   externals: [
     // Type imports
+    '#app/components/nuxt-link',
     'vue-router',
     '@nuxt/telemetry',
     'vue-bundle-renderer',

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -246,6 +246,19 @@ export default defineUntypedSchema({
      * For more control, such as if you are using a custom `path` or `alias` set in the page's `definePageMeta`, you
      * should set `routeRules` directly within your `nuxt.config`.
      */
-    inlineRouteRules: false
+    inlineRouteRules: false,
+
+    /**
+     * This allows specifying the default options for core Nuxt components and composables.
+     *
+     * These options will likely be moved elsewhere in the future, such as into `app.config` or into the
+     * `app/` directory.
+     */
+    defaults: {
+      /** @type {typeof import('#app/components/nuxt-link')['NuxtLinkOptions']} */
+      nuxtLink: {
+        componentName: 'NuxtLink'
+      }
+    }
   }
 })

--- a/test/mocks/nuxt-config.ts
+++ b/test/mocks/nuxt-config.ts
@@ -1,0 +1,3 @@
+export const nuxtLinkDefaults = {
+  componentName: 'NuxtLink'
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,7 @@ import { isWindows } from 'std-env'
 export default defineConfig({
   resolve: {
     alias: {
+      '#build/nuxt.config.mjs': resolve('./test/mocks/nuxt-config'),
       '#app': resolve('./packages/nuxt/dist/app/index'),
       '@nuxt/test-utils/experimental': resolve('./packages/test-utils/src/experimental.ts'),
       '@nuxt/test-utils': resolve('./packages/test-utils/src/index.ts')


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR allows configuring NuxtLink defaults, such as trailing slash behaviour and default classes/prefetch behaviour. All of these are serialisable and initially can be set in `experimental.defaults.nuxtLink` but we will likely want to move to appConfig or `app/` directory later on.

Example:

```ts
export default defineNuxtConfig({
  experimental: {
    defaults: {
      nuxtLink: {
        activeClass: 'nuxt-link-active',
        trailingSlash: 'append'
      }
    }
  }
})
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
