### PR TITLE
chore: update to nitropack 2.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "nuxt": "workspace:*",
     "vite": "4.5.0",
     "vue": "3.3.4",
-    "magic-string": "^0.30.5"
+    "magic-string": "^0.30.5",
+    "nitropack": "npm:nitropack-nightly@2.7.0-28295301.f3f2acb"
   },
   "devDependencies": {
     "@nuxt/test-utils": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "vite": "4.5.0",
     "vue": "3.3.4",
     "magic-string": "^0.30.5",
-    "nitropack": "npm:nitropack-nightly@2.7.0-28295301.f3f2acb"
+    "nitropack": "npm:nitropack-nightly@2.7.0-28295301.f3f2acb",
+    "h3": "npm:h3-nightly"
   },
   "devDependencies": {
     "@nuxt/test-utils": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -35,9 +35,7 @@
     "nuxt": "workspace:*",
     "vite": "4.5.0",
     "vue": "3.3.4",
-    "magic-string": "^0.30.5",
-    "nitropack": "npm:nitropack-nightly@2.7.0-28295301.f3f2acb",
-    "h3": "npm:h3-nightly"
+    "magic-string": "^0.30.5"
   },
   "devDependencies": {
     "@nuxt/test-utils": "workspace:*",
@@ -61,7 +59,7 @@
     "happy-dom": "12.9.1",
     "jiti": "1.20.0",
     "markdownlint-cli": "0.37.0",
-    "nitropack": "2.6.3",
+    "nitropack": "2.7.0",
     "nuxi": "3.9.0",
     "nuxt": "workspace:*",
     "nuxt-vitest": "0.11.0",

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -45,7 +45,7 @@
     "@types/lodash-es": "4.17.10",
     "@types/semver": "7.5.3",
     "lodash-es": "4.17.21",
-    "nitropack": "2.6.3",
+    "nitropack": "2.7.0",
     "unbuild": "latest",
     "vite": "4.5.0",
     "vitest": "0.33.0",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -83,7 +83,7 @@
     "knitwork": "^1.0.0",
     "magic-string": "^0.30.5",
     "mlly": "^1.4.2",
-    "nitropack": "2.7.0",
+    "nitropack": "^2.7.0",
     "nuxi": "^3.9.0",
     "nypm": "^0.3.3",
     "ofetch": "^1.3.3",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -83,7 +83,7 @@
     "knitwork": "^1.0.0",
     "magic-string": "^0.30.5",
     "mlly": "^1.4.2",
-    "nitropack": "^2.6.3",
+    "nitropack": "2.7.0",
     "nuxi": "^3.9.0",
     "nypm": "^0.3.3",
     "ofetch": "^1.3.3",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -40,7 +40,7 @@
     "esbuild-loader": "4.0.2",
     "h3": "1.8.2",
     "ignore": "5.2.4",
-    "nitropack": "2.6.3",
+    "nitropack": "2.7.0",
     "ofetch": "1.3.3",
     "unbuild": "latest",
     "unctx": "2.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ overrides:
   vue: 3.3.4
   magic-string: ^0.30.5
   nitropack: npm:nitropack-nightly@2.7.0-28295301.f3f2acb
+  h3: npm:h3-nightly
 
 importers:
 
@@ -72,8 +73,8 @@ importers:
         specifier: 13.2.2
         version: 13.2.2
       h3:
-        specifier: 1.8.2
-        version: 1.8.2
+        specifier: npm:h3-nightly
+        version: /h3-nightly@1.9.0-1697582360.fb79f41
       happy-dom:
         specifier: 12.9.1
         version: 12.9.1
@@ -301,8 +302,8 @@ importers:
         specifier: ^13.2.2
         version: 13.2.2
       h3:
-        specifier: ^1.8.2
-        version: 1.8.2
+        specifier: npm:h3-nightly
+        version: /h3-nightly@1.9.0-1697582360.fb79f41
       hookable:
         specifier: ^5.5.3
         version: 5.5.3
@@ -483,8 +484,8 @@ importers:
         specifier: 4.0.2
         version: 4.0.2(webpack@5.89.0)
       h3:
-        specifier: 1.8.2
-        version: 1.8.2
+        specifier: npm:h3-nightly
+        version: /h3-nightly@1.9.0-1697582360.fb79f41
       ignore:
         specifier: 5.2.4
         version: 5.2.4
@@ -616,8 +617,8 @@ importers:
         specifier: ^3.1.1
         version: 3.1.1
       h3:
-        specifier: ^1.8.2
-        version: 1.8.2
+        specifier: npm:h3-nightly
+        version: /h3-nightly@1.9.0-1697582360.fb79f41
       knitwork:
         specifier: ^1.0.0
         version: 1.0.0
@@ -737,8 +738,8 @@ importers:
         specifier: ^11.1.1
         version: 11.1.1
       h3:
-        specifier: ^1.8.2
-        version: 1.8.2
+        specifier: npm:h3-nightly
+        version: /h3-nightly@1.9.0-1697582360.fb79f41
       hash-sum:
         specifier: ^2.0.0
         version: 2.0.0
@@ -2104,7 +2105,7 @@ packages:
       flatted: 3.2.9
       get-port-please: 3.1.1
       global-dirs: 3.0.1
-      h3: 1.8.2
+      h3: /h3-nightly@1.9.0-1697582360.fb79f41
       hookable: 5.5.3
       image-meta: 0.1.1
       is-installed-globally: 0.4.0
@@ -5738,18 +5739,6 @@ packages:
       uncrypto: 0.1.3
       unenv: 1.7.4
 
-  /h3@1.8.2:
-    resolution: {integrity: sha512-1Ca0orJJlCaiFY68BvzQtP2lKLk46kcLAxVM8JgYbtm2cUg6IY7pjpYgWMwUvDO9QI30N5JAukOKoT8KD3Q0PQ==}
-    dependencies:
-      cookie-es: 1.0.0
-      defu: 6.1.2
-      destr: 2.0.1
-      iron-webcrypto: 0.10.1
-      radix3: 1.1.0
-      ufo: 1.3.1
-      uncrypto: 0.1.3
-      unenv: 1.7.4
-
   /happy-dom@12.9.1:
     resolution: {integrity: sha512-UvQ3IwKn1G3iiNCdTrhijdLGqf8Vj7d3OpmYcPwlKakjFy83oYbW6TmOKDLMTVLO9whmOC1HIpS09wf/14k7cA==}
     dependencies:
@@ -6012,9 +6001,6 @@ packages:
   /ip@2.0.0:
     resolution: {integrity: sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==}
     dev: false
-
-  /iron-webcrypto@0.10.1:
-    resolution: {integrity: sha512-QGOS8MRMnj/UiOa+aMIgfyHcvkhqNUsUxb1XzskENvbo+rEfp6TOwqd1KPuDzXC4OnGHcMSVxDGRoilqB8ViqA==}
 
   /iron-webcrypto@1.0.0:
     resolution: {integrity: sha512-anOK1Mktt8U1Xi7fCM3RELTuYbnFikQY5VtrDj7kPgpejV7d43tWKhzgioO0zpkazLEL/j/iayRqnJhrGfqUsg==}
@@ -6577,7 +6563,7 @@ packages:
       consola: 3.2.3
       defu: 6.1.2
       get-port-please: 3.1.1
-      h3: 1.8.2
+      h3: /h3-nightly@1.9.0-1697582360.fb79f41
       http-shutdown: 1.2.2
       jiti: 1.20.0
       mlly: 1.4.2
@@ -9512,7 +9498,7 @@ packages:
       anymatch: 3.1.3
       chokidar: 3.5.3
       destr: 2.0.1
-      h3: 1.8.2
+      h3: /h3-nightly@1.9.0-1697582360.fb79f41
       ioredis: 5.3.2
       listhen: 1.5.5
       lru-cache: 10.0.1
@@ -9778,7 +9764,7 @@ packages:
       '@vue/test-utils': 2.4.1(vue@3.3.4)
       defu: 6.1.2
       estree-walker: 3.0.3
-      h3: 1.8.2
+      h3: /h3-nightly@1.9.0-1697582360.fb79f41
       happy-dom: 12.9.1
       local-pkg: 0.4.3
       magic-string: 0.30.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,8 +14,6 @@ overrides:
   vite: 4.5.0
   vue: 3.3.4
   magic-string: ^0.30.5
-  nitropack: npm:nitropack-nightly@2.7.0-28295301.f3f2acb
-  h3: npm:h3-nightly
 
 importers:
 
@@ -73,8 +71,8 @@ importers:
         specifier: 13.2.2
         version: 13.2.2
       h3:
-        specifier: npm:h3-nightly
-        version: /h3-nightly@1.9.0-1697582360.fb79f41
+        specifier: 1.8.2
+        version: 1.8.2
       happy-dom:
         specifier: 12.9.1
         version: 12.9.1
@@ -85,8 +83,8 @@ importers:
         specifier: 0.37.0
         version: 0.37.0
       nitropack:
-        specifier: npm:nitropack-nightly@2.7.0-28295301.f3f2acb
-        version: /nitropack-nightly@2.7.0-28295301.f3f2acb
+        specifier: 2.7.0
+        version: 2.7.0
       nuxi:
         specifier: 3.9.0
         version: 3.9.0
@@ -212,8 +210,8 @@ importers:
         specifier: 4.17.21
         version: 4.17.21
       nitropack:
-        specifier: npm:nitropack-nightly@2.7.0-28295301.f3f2acb
-        version: /nitropack-nightly@2.7.0-28295301.f3f2acb
+        specifier: 2.7.0
+        version: 2.7.0
       unbuild:
         specifier: latest
         version: 2.0.0(typescript@5.2.2)
@@ -302,8 +300,8 @@ importers:
         specifier: ^13.2.2
         version: 13.2.2
       h3:
-        specifier: npm:h3-nightly
-        version: /h3-nightly@1.9.0-1697582360.fb79f41
+        specifier: ^1.8.2
+        version: 1.8.2
       hookable:
         specifier: ^5.5.3
         version: 5.5.3
@@ -323,8 +321,8 @@ importers:
         specifier: ^1.4.2
         version: 1.4.2
       nitropack:
-        specifier: npm:nitropack-nightly@2.7.0-28295301.f3f2acb
-        version: /nitropack-nightly@2.7.0-28295301.f3f2acb
+        specifier: 2.7.0
+        version: 2.7.0
       nuxi:
         specifier: ^3.9.0
         version: 3.9.0
@@ -484,14 +482,14 @@ importers:
         specifier: 4.0.2
         version: 4.0.2(webpack@5.89.0)
       h3:
-        specifier: npm:h3-nightly
-        version: /h3-nightly@1.9.0-1697582360.fb79f41
+        specifier: 1.8.2
+        version: 1.8.2
       ignore:
         specifier: 5.2.4
         version: 5.2.4
       nitropack:
-        specifier: npm:nitropack-nightly@2.7.0-28295301.f3f2acb
-        version: /nitropack-nightly@2.7.0-28295301.f3f2acb
+        specifier: 2.7.0
+        version: 2.7.0
       ofetch:
         specifier: 1.3.3
         version: 1.3.3
@@ -617,8 +615,8 @@ importers:
         specifier: ^3.1.1
         version: 3.1.1
       h3:
-        specifier: npm:h3-nightly
-        version: /h3-nightly@1.9.0-1697582360.fb79f41
+        specifier: ^1.8.2
+        version: 1.8.2
       knitwork:
         specifier: ^1.0.0
         version: 1.0.0
@@ -738,8 +736,8 @@ importers:
         specifier: ^11.1.1
         version: 11.1.1
       h3:
-        specifier: npm:h3-nightly
-        version: /h3-nightly@1.9.0-1697582360.fb79f41
+        specifier: ^1.8.2
+        version: 1.8.2
       hash-sum:
         specifier: ^2.0.0
         version: 2.0.0
@@ -2105,14 +2103,14 @@ packages:
       flatted: 3.2.9
       get-port-please: 3.1.1
       global-dirs: 3.0.1
-      h3: /h3-nightly@1.9.0-1697582360.fb79f41
+      h3: 1.8.2
       hookable: 5.5.3
       image-meta: 0.1.1
       is-installed-globally: 0.4.0
       launch-editor: 2.6.1
       local-pkg: 0.5.0
       magicast: 0.3.0
-      nitropack: /nitropack-nightly@2.7.0-28295301.f3f2acb
+      nitropack: 2.7.0
       nuxt: link:packages/nuxt
       nypm: 0.3.3
       ofetch: 1.3.3
@@ -3825,6 +3823,23 @@ packages:
 
   /c12@1.4.2:
     resolution: {integrity: sha512-3IP/MuamSVRVw8W8+CHWAz9gKN4gd+voF2zm/Ln6D25C2RhytEZ1ABbC8MjKr4BR9rhoV1JQ7jJA158LDiTkLg==}
+    dependencies:
+      chokidar: 3.5.3
+      defu: 6.1.2
+      dotenv: 16.3.1
+      giget: 1.1.3
+      jiti: 1.20.0
+      mlly: 1.4.2
+      ohash: 1.1.3
+      pathe: 1.1.1
+      perfect-debounce: 1.0.0
+      pkg-types: 1.0.3
+      rc9: 2.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  /c12@1.5.1:
+    resolution: {integrity: sha512-BWZRJgDEveT8uI+cliCwvYSSSSvb4xKoiiu5S0jaDbKBopQLQF7E+bq9xKk1pTcG+mUa3yXuFO7bD9d8Lr9Xxg==}
     dependencies:
       chokidar: 3.5.3
       defu: 6.1.2
@@ -5727,13 +5742,13 @@ packages:
     dependencies:
       duplexer: 0.1.2
 
-  /h3-nightly@1.9.0-1697582360.fb79f41:
-    resolution: {integrity: sha512-FgS16YNHZDKyPZBcC/cOD98C9kKA2gre70fqQCK/S1I6rE5Loax9DGn8IxrhBgiSylE9GDugltvmmBJNeAfm8Q==}
+  /h3@1.8.2:
+    resolution: {integrity: sha512-1Ca0orJJlCaiFY68BvzQtP2lKLk46kcLAxVM8JgYbtm2cUg6IY7pjpYgWMwUvDO9QI30N5JAukOKoT8KD3Q0PQ==}
     dependencies:
       cookie-es: 1.0.0
       defu: 6.1.2
       destr: 2.0.1
-      iron-webcrypto: 1.0.0
+      iron-webcrypto: 0.10.1
       radix3: 1.1.0
       ufo: 1.3.1
       uncrypto: 0.1.3
@@ -6002,8 +6017,8 @@ packages:
     resolution: {integrity: sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==}
     dev: false
 
-  /iron-webcrypto@1.0.0:
-    resolution: {integrity: sha512-anOK1Mktt8U1Xi7fCM3RELTuYbnFikQY5VtrDj7kPgpejV7d43tWKhzgioO0zpkazLEL/j/iayRqnJhrGfqUsg==}
+  /iron-webcrypto@0.10.1:
+    resolution: {integrity: sha512-QGOS8MRMnj/UiOa+aMIgfyHcvkhqNUsUxb1XzskENvbo+rEfp6TOwqd1KPuDzXC4OnGHcMSVxDGRoilqB8ViqA==}
 
   /is-array-buffer@3.0.2:
     resolution: {integrity: sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==}
@@ -6563,7 +6578,7 @@ packages:
       consola: 3.2.3
       defu: 6.1.2
       get-port-please: 3.1.1
-      h3: /h3-nightly@1.9.0-1697582360.fb79f41
+      h3: 1.8.2
       http-shutdown: 1.2.2
       jiti: 1.20.0
       mlly: 1.4.2
@@ -7105,8 +7120,8 @@ packages:
   /neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
-  /nitropack-nightly@2.7.0-28295301.f3f2acb:
-    resolution: {integrity: sha512-E+LXAPg3ZIkiLf2OeWpI+DcRkC22GPStzsc5g7sQ5Wrims2YHDSizpMCwwIXC+FywSpFl1HN8wzatPB4QdjxRA==}
+  /nitropack@2.7.0:
+    resolution: {integrity: sha512-U5/Uq0k4PO3/yDM1Sao6JZc/i1DhiI2Eq/AMm92idgQ6B3NbwD0A3u9SZNIHyqEyFogOgi3qsdnRo9KWc5jgVg==}
     engines: {node: ^16.11.0 || >=17.0.0}
     hasBin: true
     peerDependencies:
@@ -7129,7 +7144,7 @@ packages:
       '@types/http-proxy': 1.17.13
       '@vercel/nft': 0.24.3
       archiver: 6.0.1
-      c12: 1.4.2
+      c12: 1.5.1
       chalk: 5.3.0
       chokidar: 3.5.3
       citty: 0.1.4
@@ -7144,7 +7159,7 @@ packages:
       fs-extra: 11.1.1
       globby: 13.2.2
       gzip-size: 7.0.0
-      h3: /h3-nightly@1.9.0-1697582360.fb79f41
+      h3: 1.8.2
       hookable: 5.5.3
       httpxy: 0.1.5
       is-primitive: 3.0.1
@@ -9498,7 +9513,7 @@ packages:
       anymatch: 3.1.3
       chokidar: 3.5.3
       destr: 2.0.1
-      h3: /h3-nightly@1.9.0-1697582360.fb79f41
+      h3: 1.8.2
       ioredis: 5.3.2
       listhen: 1.5.5
       lru-cache: 10.0.1
@@ -9764,7 +9779,7 @@ packages:
       '@vue/test-utils': 2.4.1(vue@3.3.4)
       defu: 6.1.2
       estree-walker: 3.0.3
-      h3: /h3-nightly@1.9.0-1697582360.fb79f41
+      h3: 1.8.2
       happy-dom: 12.9.1
       local-pkg: 0.4.3
       magic-string: 0.30.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -321,7 +321,7 @@ importers:
         specifier: ^1.4.2
         version: 1.4.2
       nitropack:
-        specifier: 2.7.0
+        specifier: ^2.7.0
         version: 2.7.0
       nuxi:
         specifier: ^3.9.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,7 @@ overrides:
   vite: 4.5.0
   vue: 3.3.4
   magic-string: ^0.30.5
+  nitropack: npm:nitropack-nightly@2.7.0-28295301.f3f2acb
 
 importers:
 
@@ -83,8 +84,8 @@ importers:
         specifier: 0.37.0
         version: 0.37.0
       nitropack:
-        specifier: 2.6.3
-        version: 2.6.3
+        specifier: npm:nitropack-nightly@2.7.0-28295301.f3f2acb
+        version: /nitropack-nightly@2.7.0-28295301.f3f2acb
       nuxi:
         specifier: 3.9.0
         version: 3.9.0
@@ -210,8 +211,8 @@ importers:
         specifier: 4.17.21
         version: 4.17.21
       nitropack:
-        specifier: 2.6.3
-        version: 2.6.3
+        specifier: npm:nitropack-nightly@2.7.0-28295301.f3f2acb
+        version: /nitropack-nightly@2.7.0-28295301.f3f2acb
       unbuild:
         specifier: latest
         version: 2.0.0(typescript@5.2.2)
@@ -321,8 +322,8 @@ importers:
         specifier: ^1.4.2
         version: 1.4.2
       nitropack:
-        specifier: ^2.6.3
-        version: 2.6.3
+        specifier: npm:nitropack-nightly@2.7.0-28295301.f3f2acb
+        version: /nitropack-nightly@2.7.0-28295301.f3f2acb
       nuxi:
         specifier: ^3.9.0
         version: 3.9.0
@@ -488,8 +489,8 @@ importers:
         specifier: 5.2.4
         version: 5.2.4
       nitropack:
-        specifier: 2.6.3
-        version: 2.6.3
+        specifier: npm:nitropack-nightly@2.7.0-28295301.f3f2acb
+        version: /nitropack-nightly@2.7.0-28295301.f3f2acb
       ofetch:
         specifier: 1.3.3
         version: 1.3.3
@@ -2110,7 +2111,7 @@ packages:
       launch-editor: 2.6.1
       local-pkg: 0.5.0
       magicast: 0.3.0
-      nitropack: 2.6.3
+      nitropack: /nitropack-nightly@2.7.0-28295301.f3f2acb
       nuxt: link:packages/nuxt
       nypm: 0.3.3
       ofetch: 1.3.3
@@ -2968,9 +2969,9 @@ packages:
       vue: 3.3.4
     dev: false
 
-  /@vercel/nft@0.23.1:
-    resolution: {integrity: sha512-NE0xSmGWVhgHF1OIoir71XAd0W0C1UE3nzFyhpFiMr3rVhetww7NvM1kc41trBsPG37Bh+dE5FYCTMzM/gBu0w==}
-    engines: {node: '>=14'}
+  /@vercel/nft@0.24.3:
+    resolution: {integrity: sha512-IyBdIxmFAeGZnEfMgt4QrGK7XX4lWazlQj34HEi9dw04/WeDBJ7r1yaOIO5tTf9pbfvwUFodj9b0H+NDGGoOMg==}
+    engines: {node: '>=16'}
     hasBin: true
     dependencies:
       '@mapbox/node-pre-gyp': 1.0.11
@@ -5725,6 +5726,18 @@ packages:
     dependencies:
       duplexer: 0.1.2
 
+  /h3-nightly@1.9.0-1697582360.fb79f41:
+    resolution: {integrity: sha512-FgS16YNHZDKyPZBcC/cOD98C9kKA2gre70fqQCK/S1I6rE5Loax9DGn8IxrhBgiSylE9GDugltvmmBJNeAfm8Q==}
+    dependencies:
+      cookie-es: 1.0.0
+      defu: 6.1.2
+      destr: 2.0.1
+      iron-webcrypto: 1.0.0
+      radix3: 1.1.0
+      ufo: 1.3.1
+      uncrypto: 0.1.3
+      unenv: 1.7.4
+
   /h3@1.8.2:
     resolution: {integrity: sha512-1Ca0orJJlCaiFY68BvzQtP2lKLk46kcLAxVM8JgYbtm2cUg6IY7pjpYgWMwUvDO9QI30N5JAukOKoT8KD3Q0PQ==}
     dependencies:
@@ -6002,6 +6015,9 @@ packages:
 
   /iron-webcrypto@0.10.1:
     resolution: {integrity: sha512-QGOS8MRMnj/UiOa+aMIgfyHcvkhqNUsUxb1XzskENvbo+rEfp6TOwqd1KPuDzXC4OnGHcMSVxDGRoilqB8ViqA==}
+
+  /iron-webcrypto@1.0.0:
+    resolution: {integrity: sha512-anOK1Mktt8U1Xi7fCM3RELTuYbnFikQY5VtrDj7kPgpejV7d43tWKhzgioO0zpkazLEL/j/iayRqnJhrGfqUsg==}
 
   /is-array-buffer@3.0.2:
     resolution: {integrity: sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==}
@@ -7103,8 +7119,8 @@ packages:
   /neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
-  /nitropack@2.6.3:
-    resolution: {integrity: sha512-k1GC9GiIrjAmLx48g52/38u6OfWVUAhvWtxm5G4vFUaGAt82WPVl+P5S9YXMRXgNtUnTFfzC4Vfp5TUEG0i7zQ==}
+  /nitropack-nightly@2.7.0-28295301.f3f2acb:
+    resolution: {integrity: sha512-E+LXAPg3ZIkiLf2OeWpI+DcRkC22GPStzsc5g7sQ5Wrims2YHDSizpMCwwIXC+FywSpFl1HN8wzatPB4QdjxRA==}
     engines: {node: ^16.11.0 || >=17.0.0}
     hasBin: true
     peerDependencies:
@@ -7125,7 +7141,7 @@ packages:
       '@rollup/plugin-wasm': 6.2.2(rollup@3.29.4)
       '@rollup/pluginutils': 5.0.5(rollup@3.29.4)
       '@types/http-proxy': 1.17.13
-      '@vercel/nft': 0.23.1
+      '@vercel/nft': 0.24.3
       archiver: 6.0.1
       c12: 1.4.2
       chalk: 5.3.0
@@ -7142,7 +7158,7 @@ packages:
       fs-extra: 11.1.1
       globby: 13.2.2
       gzip-size: 7.0.0
-      h3: 1.8.2
+      h3: /h3-nightly@1.9.0-1697582360.fb79f41
       hookable: 5.5.3
       httpxy: 0.1.5
       is-primitive: 3.0.1

--- a/scripts/bump-edge.ts
+++ b/scripts/bump-edge.ts
@@ -4,7 +4,7 @@ import { consola } from 'consola'
 import { determineBumpType, loadWorkspace } from './_utils'
 
 const nightlyPackages = {
-  nitropack: 'nitropack-edge',
+  nitropack: 'nitropack-nightly',
   h3: 'h3-nightly',
   nuxi: 'nuxi-nightly'
 }

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -32,7 +32,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(rootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot('"304k"')
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot('"202k"')
 
     const modules = await analyzeSizes('node_modules/**/*', serverDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot('"1826k"')
@@ -71,7 +71,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(rootDir, '.output-inline/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot('"611k"')
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot('"509k"')
 
     const modules = await analyzeSizes('node_modules/**/*', serverDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot('"71.4k"')

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -32,7 +32,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(rootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot('"202k"')
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot('"197k"')
 
     const modules = await analyzeSizes('node_modules/**/*', serverDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot('"1826k"')
@@ -71,7 +71,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(rootDir, '.output-inline/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot('"509k"')
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot('"504k"')
 
     const modules = await analyzeSizes('node_modules/**/*', serverDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot('"71.4k"')


### PR DESCRIPTION
https://github.com/unjs/nitro/releases/tag/v2.7.0

Notable: Server bundle size reduced from `304k` to `197k` / `611k` to `504k` as `node-fetch` polyfill removed!