### PR TITLE
docs: add example of auto-importing components from npm package

### DIFF
--- a/docs/2.guide/2.directory-structure/1.components.md
+++ b/docs/2.guide/2.directory-structure/1.components.md
@@ -166,6 +166,38 @@ export default defineNuxtConfig({
 })
 ```
 
+## NPM Packages
+
+If you want to auto-import components from an npm package, you can use [`addComponent`](/docs/api/kit/components#addcomponent) in a Nuxt hook to register them.
+
+::code-group
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  hooks: {
+    'modules:done': async () => {
+        // import { MyComponent } from 'my-npm-package'
+        await addComponent({
+          name: 'MyAutoImportedComponent',
+          export: 'MyComponent',
+          filePath: 'my-npm-package',
+        })
+      },
+  }
+})
+```
+
+```vue [app.vue]
+<template>
+  <div>
+    <!--  the component uses the name we specified and is auto-imported  -->
+    <MyAutoImportedComponent />
+  </div>
+</template>
+```
+
+::
+
 ::callout
 Any nested directories need to be added first as they are scanned in order.
 ::

--- a/docs/2.guide/2.directory-structure/1.components.md
+++ b/docs/2.guide/2.directory-structure/1.components.md
@@ -166,7 +166,7 @@ export default defineNuxtConfig({
 })
 ```
 
-## NPM Packages
+## npm Packages
 
 If you want to auto-import components from an npm package, you can use [`addComponent`](/docs/api/kit/components#addcomponent) in a [local module](/docs/guide/directory-structure/modules) to register them.
 

--- a/docs/2.guide/2.directory-structure/1.components.md
+++ b/docs/2.guide/2.directory-structure/1.components.md
@@ -168,7 +168,7 @@ export default defineNuxtConfig({
 
 ## NPM Packages
 
-If you want to auto-import components from an npm package, you can use [`addComponent`](/docs/api/kit/components#addcomponent) in a local module to register them.
+If you want to auto-import components from an npm package, you can use [`addComponent`](/docs/api/kit/components#addcomponent) in a [local module](/docs/guide/directory-structure/modules) to register them.
 
 ::code-group
 

--- a/docs/2.guide/2.directory-structure/1.components.md
+++ b/docs/2.guide/2.directory-structure/1.components.md
@@ -168,22 +168,22 @@ export default defineNuxtConfig({
 
 ## NPM Packages
 
-If you want to auto-import components from an npm package, you can use [`addComponent`](/docs/api/kit/components#addcomponent) in a Nuxt hook to register them.
+If you want to auto-import components from an npm package, you can use [`addComponent`](/docs/api/kit/components#addcomponent) in a local module to register them.
 
 ::code-group
 
-```ts [nuxt.config.ts]
-export default defineNuxtConfig({
-  hooks: {
-    'modules:done': async () => {
-        // import { MyComponent as MyAutoImportedComponent } from 'my-npm-package'
-        await addComponent({
-          name: 'MyAutoImportedComponent',
-          export: 'MyComponent',
-          filePath: 'my-npm-package',
-        })
-      },
-  }
+```ts [~/modules/register-component.ts]
+import { addComponent, defineNuxtModule } from '@nuxt/kit'
+
+export default defineNuxtModule({
+  setup() {
+    // import { MyComponent as MyAutoImportedComponent } from 'my-npm-package'
+    addComponent({
+      name: 'MyAutoImportedComponent',
+      export: 'MyComponent',
+      filePath: 'my-npm-package',
+    })
+  },
 })
 ```
 

--- a/docs/2.guide/2.directory-structure/1.components.md
+++ b/docs/2.guide/2.directory-structure/1.components.md
@@ -176,7 +176,7 @@ If you want to auto-import components from an npm package, you can use [`addComp
 export default defineNuxtConfig({
   hooks: {
     'modules:done': async () => {
-        // import { MyComponent } from 'my-npm-package'
+        // import { MyComponent as MyAutoImportedComponent } from 'my-npm-package'
         await addComponent({
           name: 'MyAutoImportedComponent',
           export: 'MyComponent',


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Provides guidance on auto-importing components from npm packages that are not available as Nuxt modules with pre-configured auto-imports.
I added code examples for using the `addComponent` function within a Nuxt hook to manually register these components for auto-imports.

This is something I found myself needing in the last few days and wasn't able to find it anywhere in the docs.


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
