### PR TITLE
fix(nuxt,schema): use `std-env` to detect whether app is being tested

### DIFF
--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -215,7 +215,7 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
   if (nuxt.options.experimental.appManifest) {
     // @ts-expect-error untyped nuxt property
     const buildId = nuxt.options.appConfig.nuxt!.buildId ||=
-      (nuxt.options.test ? 'test' : nuxt.options.dev ? 'dev' : randomUUID())
+      (nuxt.options.dev ? 'dev' : nuxt.options.test ? 'test' : randomUUID())
     const buildTimestamp = Date.now()
 
     const manifestPrefix = joinURL(nuxt.options.app.buildAssetsDir, 'builds')

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -1,6 +1,6 @@
 import { defineUntypedSchema } from 'untyped'
 import { join, relative, resolve } from 'pathe'
-import { isDebug, isDevelopment } from 'std-env'
+import { isDebug, isDevelopment, isTest } from 'std-env'
 import { defu } from 'defu'
 import { findWorkspaceDir } from 'pkg-types'
 import type { RuntimeConfig } from '../types/config'
@@ -158,7 +158,7 @@ export default defineUntypedSchema({
   /**
    * Whether your app is being unit tested.
    */
-  test: Boolean(isDevelopment),
+  test: Boolean(isTest),
 
   /**
    * Set to `true` to enable debug mode.


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/23829

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

As `nuxt.options.test` defaults to true in dev mode this updates buildId to test for it first.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
