### PR TITLE
fix(nuxt): handle relative baseURL in nitro runtime config

### DIFF
--- a/packages/nuxt/src/app/composables/manifest.ts
+++ b/packages/nuxt/src/app/composables/manifest.ts
@@ -1,10 +1,11 @@
-import { joinURL } from 'ufo'
 import type { MatcherExport, RouteMatcher } from 'radix3'
 import { createMatcherFromExport } from 'radix3'
 import { defu } from 'defu'
-import { useAppConfig, useRuntimeConfig } from '#app'
+import { useAppConfig } from '#app'
 // @ts-expect-error virtual file
 import { appManifest as isAppManifestEnabled } from '#build/nuxt.config.mjs'
+// @ts-expect-error virtual file
+import { buildAssetsURL } from '#build/paths.mjs'
 
 export interface NuxtAppManifestMeta {
   id: string
@@ -23,10 +24,9 @@ function fetchManifest () {
   if (!isAppManifestEnabled) {
     throw new Error('[nuxt] app manifest should be enabled with `experimental.appManifest`')
   }
-  const config = useRuntimeConfig()
   // @ts-expect-error private property
   const buildId = useAppConfig().nuxt?.buildId
-  manifest = $fetch<NuxtAppManifest>(joinURL(config.app.cdnURL || config.app.baseURL, config.app.buildAssetsDir, `builds/meta/${buildId}.json`))
+  manifest = $fetch<NuxtAppManifest>(buildAssetsURL(`builds/meta/${buildId}.json`))
   manifest.then((m) => {
     matcher = createMatcherFromExport(m.matcher)
   })

--- a/packages/nuxt/src/app/plugins/check-outdated-build.client.ts
+++ b/packages/nuxt/src/app/plugins/check-outdated-build.client.ts
@@ -1,18 +1,18 @@
-import { joinURL } from 'ufo'
 import type { NuxtAppManifestMeta } from '#app'
-import { defineNuxtPlugin, getAppManifest, onNuxtReady, useRuntimeConfig } from '#app'
+import { defineNuxtPlugin, getAppManifest, onNuxtReady } from '#app'
+// @ts-expect-error virtual file
+import { buildAssetsURL } from '#build/paths.mjs'
 
 export default defineNuxtPlugin((nuxtApp) => {
   if (import.meta.test) { return }
 
   let timeout: NodeJS.Timeout
-  const config = useRuntimeConfig()
 
   async function getLatestManifest () {
     const currentManifest = await getAppManifest()
     if (timeout) { clearTimeout(timeout) }
     timeout = setTimeout(getLatestManifest, 1000 * 60 * 60)
-    const meta = await $fetch<NuxtAppManifestMeta>(joinURL(config.app.cdnURL || config.app.baseURL, config.app.buildAssetsDir, 'builds/latest.json'))
+    const meta = await $fetch<NuxtAppManifestMeta>(buildAssetsURL('builds/latest.json'))
     if (meta.id !== currentManifest.id) {
       // There is a newer build which we will let the user handle
       nuxtApp.hooks.callHook('app:manifest:update', meta)

--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -11,7 +11,7 @@ import escapeRE from 'escape-string-regexp'
 import { defu } from 'defu'
 import fsExtra from 'fs-extra'
 import { dynamicEventHandler } from 'h3'
-import type { Nuxt } from 'nuxt/schema'
+import type { Nuxt, RuntimeConfig } from 'nuxt/schema'
 // @ts-expect-error TODO: add legacy type support for subpath imports
 import { template as defaultSpaLoadingTemplate } from '@nuxt/ui-templates/templates/spa-loading-icon.mjs'
 
@@ -99,6 +99,12 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
     },
     runtimeConfig: {
       ...nuxt.options.runtimeConfig,
+      app: {
+        ...nuxt.options.runtimeConfig.app,
+        baseURL: nuxt.options.runtimeConfig.app.baseURL.startsWith('./')
+          ? nuxt.options.runtimeConfig.app.baseURL.slice(1)
+          : nuxt.options.runtimeConfig.app.baseURL
+      } satisfies RuntimeConfig['app'],
       nitro: {
         envPrefix: 'NUXT_',
         ...nuxt.options.runtimeConfig.nitro

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -19,7 +19,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
   for (const outputDir of ['.output', '.output-inline']) {
     it('default client bundle size', async () => {
       const clientStats = await analyzeSizes('**/*.js', join(rootDir, outputDir, 'public'))
-      expect.soft(roundToKilobytes(clientStats.totalBytes)).toMatchInlineSnapshot('"99.3k"')
+      expect.soft(roundToKilobytes(clientStats.totalBytes)).toMatchInlineSnapshot('"99.2k"')
       expect(clientStats.files.map(f => f.replace(/\..*\.js/, '.js'))).toMatchInlineSnapshot(`
         [
           "_nuxt/entry.js",


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/23831

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Nitro currently doesn't handle or support being passed a relative baseURL. I think it also doesn't particularly make sense for Nitro. So this change simply makes the url absolute instead.

I also ship an improvement in the manifest handling, to use the path utils we already have for giving us the build asset dir rather than reimplementing. However, this change wasn't needed to fix the bug; it's merely an optimisation I discovered in the process of resolving the bug..

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
