### PR TITLE
fix(nuxt,schema,vite,webpack): analyze w/o overriding config

### DIFF
--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -78,11 +78,13 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
     esbuild: {
       options: { exclude: excludePattern }
     },
-    analyze: nuxt.options.build.analyze && (nuxt.options.build.analyze === true || nuxt.options.build.analyze.enabled) && {
-      template: 'treemap',
-      projectRoot: nuxt.options.rootDir,
-      filename: join(nuxt.options.analyzeDir, '{name}.html')
-    },
+    analyze: nuxt.options.build.analyze && (nuxt.options.build.analyze === true || nuxt.options.build.analyze.enabled)
+      ? {
+          template: 'treemap',
+          projectRoot: nuxt.options.rootDir,
+          filename: join(nuxt.options.analyzeDir, '{name}.html')
+        }
+      : false,
     scanDirs: nuxt.options._layers.map(layer => (layer.config.serverDir || layer.config.srcDir) && resolve(layer.cwd, layer.config.serverDir || resolve(layer.config.srcDir, 'server'))).filter(Boolean),
     renderer: resolve(distDir, 'core/runtime/nitro/renderer'),
     errorHandler: resolve(distDir, 'core/runtime/nitro/error'),

--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -78,7 +78,7 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
     esbuild: {
       options: { exclude: excludePattern }
     },
-    analyze: nuxt.options.build.analyze && {
+    analyze: nuxt.options.build.analyze && (nuxt.options.build.analyze === true || nuxt.options.build.analyze.enabled) && {
       template: 'treemap',
       projectRoot: nuxt.options.rootDir,
       filename: join(nuxt.options.analyzeDir, '{name}.html')

--- a/packages/schema/src/config/build.ts
+++ b/packages/schema/src/config/build.ts
@@ -97,7 +97,7 @@ export default defineUntypedSchema({
     templates: [],
 
     /**
-     * Nuxt uses `webpack-bundle-analyzer` to visualize your bundles and how to optimize them.
+     * Nuxt allows visualizing your bundles and how to optimize them.
      *
      * Set to `true` to enable bundle analysis, or pass an object with options: [for webpack](https://github.com/webpack-contrib/webpack-bundle-analyzer#options-for-plugin) or [for vite](https://github.com/btd/rollup-plugin-visualizer#options).
      * @example
@@ -106,7 +106,7 @@ export default defineUntypedSchema({
      *   analyzerMode: 'static'
      * }
      * ```
-     * @type {boolean | typeof import('webpack-bundle-analyzer').BundleAnalyzerPlugin.Options | typeof import('rollup-plugin-visualizer').PluginVisualizerOptions}
+     * @type {boolean | ((0 extends 1 & typeof import('webpack-bundle-analyzer').BundleAnalyzerPlugin.Options ? {} : typeof import('webpack-bundle-analyzer').BundleAnalyzerPlugin.Options) | typeof import('rollup-plugin-visualizer').PluginVisualizerOptions)}
      */
     analyze: {
       $resolve: async (val, get) => {

--- a/packages/schema/src/config/build.ts
+++ b/packages/schema/src/config/build.ts
@@ -106,20 +106,17 @@ export default defineUntypedSchema({
      *   analyzerMode: 'static'
      * }
      * ```
-     * @type {boolean | ((0 extends 1 & typeof import('webpack-bundle-analyzer').BundleAnalyzerPlugin.Options ? {} : typeof import('webpack-bundle-analyzer').BundleAnalyzerPlugin.Options) | typeof import('rollup-plugin-visualizer').PluginVisualizerOptions)}
+     * @type {boolean | { enabled?: boolean } & ((0 extends 1 & typeof import('webpack-bundle-analyzer').BundleAnalyzerPlugin.Options ? {} : typeof import('webpack-bundle-analyzer').BundleAnalyzerPlugin.Options) | typeof import('rollup-plugin-visualizer').PluginVisualizerOptions)}
      */
     analyze: {
       $resolve: async (val, get) => {
-        if (val !== true) {
-          return val ?? false
-        }
         const rootDir = await get('rootDir')
         const analyzeDir = await get('analyzeDir')
-        return {
+        return defu(typeof val === 'boolean' ? { enabled: val } : val, {
           template: 'treemap',
           projectRoot: rootDir,
           filename: join(analyzeDir, '{name}.html')
-        }
+        })
       }
     }
   },

--- a/packages/schema/src/config/webpack.ts
+++ b/packages/schema/src/config/webpack.ts
@@ -1,4 +1,4 @@
-import { join } from 'pathe'
+import defu from 'defu'
 import { defineUntypedSchema } from 'untyped'
 
 export default defineUntypedSchema({
@@ -13,20 +13,11 @@ export default defineUntypedSchema({
      *   analyzerMode: 'static'
      * }
      * ```
-     * @type {boolean | typeof import('webpack-bundle-analyzer').BundleAnalyzerPlugin.Options}
+     * @type {boolean | { enabled?: boolean } & typeof import('webpack-bundle-analyzer').BundleAnalyzerPlugin.Options}
      */
     analyze: {
       $resolve: async (val, get) => {
-        if (val !== true) {
-          return val ?? false
-        }
-        const rootDir = await get('rootDir')
-        const analyzeDir = await get('analyzeDir')
-        return {
-          template: 'treemap',
-          projectRoot: rootDir,
-          filename: join(analyzeDir, '{name}.html')
-        }
+        return defu(val, await get('build.analyze'))
       }
     },
 

--- a/packages/schema/src/config/webpack.ts
+++ b/packages/schema/src/config/webpack.ts
@@ -1,4 +1,4 @@
-import defu from 'defu'
+import { defu } from 'defu'
 import { defineUntypedSchema } from 'untyped'
 
 export default defineUntypedSchema({

--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -129,7 +129,7 @@ export async function buildClient (ctx: ViteBuildContext) {
   }
 
   // Add analyze plugin if needed
-  if (ctx.nuxt.options.build.analyze) {
+  if (ctx.nuxt.options.build.analyze && (ctx.nuxt.options.build.analyze === true || ctx.nuxt.options.build.analyze.enabled)) {
     clientConfig.plugins!.push(...await import('./plugins/analyze').then(r => r.analyzePlugin(ctx)))
   }
 

--- a/packages/vite/src/plugins/analyze.ts
+++ b/packages/vite/src/plugins/analyze.ts
@@ -1,10 +1,13 @@
 import type { Plugin } from 'vite'
 import { transform } from 'esbuild'
 import { visualizer } from 'rollup-plugin-visualizer'
+import defu from 'defu'
+import type { NuxtOptions } from 'nuxt/schema'
 import type { ViteBuildContext } from '../vite'
 
 export function analyzePlugin (ctx: ViteBuildContext): Plugin[] {
-  if (typeof ctx.nuxt.options.build.analyze === 'boolean') { return [] }
+  const analyzeOptions = defu({}, ctx.nuxt.options.build.analyze) as Exclude<NuxtOptions['build']['analyze'], boolean>
+  if (!analyzeOptions.enabled) { return [] }
 
   return [
     {
@@ -22,8 +25,8 @@ export function analyzePlugin (ctx: ViteBuildContext): Plugin[] {
       }
     },
     visualizer({
-      ...ctx.nuxt.options.build.analyze,
-      filename: 'filename' in ctx.nuxt.options.build.analyze ? ctx.nuxt.options.build.analyze.filename!.replace('{name}', 'client') : undefined,
+      ...analyzeOptions,
+      filename: 'filename' in analyzeOptions ? analyzeOptions.filename!.replace('{name}', 'client') : undefined,
       title: 'Client bundle stats',
       gzipSize: true
     })

--- a/packages/webpack/src/configs/client.ts
+++ b/packages/webpack/src/configs/client.ts
@@ -83,7 +83,7 @@ function clientOptimization (_ctx: WebpackConfigContext) {
 function clientPlugins (ctx: WebpackConfigContext) {
   // webpack Bundle Analyzer
   // https://github.com/webpack-contrib/webpack-bundle-analyzer
-  if (!ctx.isDev && ctx.name === 'client' && ctx.userConfig.analyze) {
+  if (!ctx.isDev && ctx.name === 'client' && ctx.userConfig.analyze && (ctx.userConfig.analyze === true || ctx.userConfig.analyze.enabled)) {
     const statsDir = resolve(ctx.options.analyzeDir)
 
     ctx.config.plugins!.push(new BundleAnalyzerPlugin({


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This resolves two issues:

1. we now have correct types (that is, not `any`) for `build.analyze`
2. we now respect user-passed `build.analyze` options and do not enable analysis just by having these options set in config (once nuxi is updated)

#### Example

```ts
export default defineNuxtConfig({
  build: {
    analyze: {
      template: 'sunburst'
    }
  },
})
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
