### PR TITLE
fix(nuxt): resolve `@unhead/vue` in template code

### DIFF
--- a/packages/nuxt/src/head/module.ts
+++ b/packages/nuxt/src/head/module.ts
@@ -48,9 +48,10 @@ export default defineNuxtModule({
     })
 
     // Opt-out feature allowing dependencies using @vueuse/head to work
+    const unheadVue = await tryResolveModule('@unhead/vue', nuxt.options.modulesDir) || '@unhead/vue'
     if (nuxt.options.experimental.polyfillVueUseHead) {
       // backwards compatibility
-      nuxt.options.alias['@vueuse/head'] = await tryResolveModule('@unhead/vue', nuxt.options.modulesDir) || '@unhead/vue'
+      nuxt.options.alias['@vueuse/head'] = unheadVue
       addPlugin({ src: resolve(runtimeDir, 'plugins/vueuse-head-polyfill') })
     }
 
@@ -60,7 +61,7 @@ export default defineNuxtModule({
         if (!nuxt.options.experimental.headNext) {
           return 'export default []'
         }
-        return `import { CapoPlugin } from '@unhead/vue';
+        return `import { CapoPlugin } from ${JSON.stringify(unheadVue)};
 export default process.server ? [CapoPlugin({ track: true })] : [];`
       }
     })


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/23738

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This addresses an issue when using nuxt without shamefully hoist, by fully resolving the `@unhead/vue` import we inject.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
