### PR TITLE
fix(vite): remove `postcss-url` and duplicate `postcss-import`

### DIFF
--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -60,7 +60,6 @@
     "hookable": "^5.5.3",
     "pathe": "^1.1.1",
     "pkg-types": "^1.0.3",
-    "postcss-import-resolver": "^2.0.0",
     "std-env": "^3.4.3",
     "ufo": "^1.3.1",
     "unimport": "^3.4.0",

--- a/packages/schema/src/config/postcss.ts
+++ b/packages/schema/src/config/postcss.ts
@@ -1,5 +1,3 @@
-import { defu } from 'defu'
-import createResolver from 'postcss-import-resolver'
 import { defineUntypedSchema } from 'untyped'
 
 export default defineUntypedSchema({
@@ -11,29 +9,6 @@ export default defineUntypedSchema({
      * @type {Record<string, any>}
      */
     plugins: {
-      /**
-       * https://github.com/postcss/postcss-import
-       */
-      'postcss-import': {
-        $resolve: async (val, get) => val !== false
-          ? defu(val || {}, {
-            resolve: createResolver({
-              alias: { ...(await get('alias')) },
-              modules: [
-                await get('srcDir'),
-                await get('rootDir'),
-                ...(await get('modulesDir'))
-              ]
-            })
-          })
-          : val
-      },
-
-      /**
-       * https://github.com/postcss/postcss-url
-       */
-      'postcss-url': {},
-
       /**
        * https://github.com/postcss/autoprefixer
        */

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -51,8 +51,6 @@
     "perfect-debounce": "^1.0.0",
     "pkg-types": "^1.0.3",
     "postcss": "^8.4.31",
-    "postcss-import": "^15.1.0",
-    "postcss-url": "^10.1.3",
     "rollup-plugin-visualizer": "^5.9.2",
     "std-env": "^3.4.3",
     "strip-literal": "^1.3.0",

--- a/packages/vite/src/css.ts
+++ b/packages/vite/src/css.ts
@@ -10,11 +10,10 @@ export function resolveCSSOptions (nuxt: Nuxt): ViteConfig['css'] {
     }
   }
 
-  const vitePlugins = ['postcss-import', 'postcss-url']
   const lastPlugins = ['autoprefixer', 'cssnano']
   css.postcss.plugins = Object.entries(nuxt.options.postcss.plugins)
     .sort((a, b) => lastPlugins.indexOf(a[0]) - lastPlugins.indexOf(b[0]))
-    .filter(([name, opts]) => !vitePlugins.includes(name) && opts)
+    .filter(([, opts]) => opts)
     .map(([name, opts]) => {
       const plugin = requireModule(name, {
         paths: [

--- a/packages/vite/src/css.ts
+++ b/packages/vite/src/css.ts
@@ -10,10 +10,11 @@ export function resolveCSSOptions (nuxt: Nuxt): ViteConfig['css'] {
     }
   }
 
+  const vitePlugins = ['postcss-import', 'postcss-url']
   const lastPlugins = ['autoprefixer', 'cssnano']
   css.postcss.plugins = Object.entries(nuxt.options.postcss.plugins)
     .sort((a, b) => lastPlugins.indexOf(a[0]) - lastPlugins.indexOf(b[0]))
-    .filter(([, opts]) => opts)
+    .filter(([name, opts]) => !vitePlugins.includes(name) && opts)
     .map(([name, opts]) => {
       const plugin = requireModule(name, {
         paths: [

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -45,6 +45,7 @@
     "pify": "^6.1.0",
     "postcss": "^8.4.31",
     "postcss-import": "^15.1.0",
+    "postcss-import-resolver": "^2.0.0",
     "postcss-loader": "^7.3.3",
     "postcss-url": "^10.1.3",
     "pug-plain-loader": "^1.1.0",

--- a/packages/webpack/src/utils/postcss.ts
+++ b/packages/webpack/src/utils/postcss.ts
@@ -1,3 +1,4 @@
+import createResolver from 'postcss-import-resolver'
 import { createCommonJS } from 'mlly'
 import { requireModule } from '@nuxt/kit'
 import type { Nuxt } from '@nuxt/schema'
@@ -25,7 +26,7 @@ const orderPresets = {
   }
 }
 
-export const getPostcssConfig = (nuxt: Nuxt) => {
+export const getPostcssConfig = async async async async (nuxt: Nuxt) => {
   function sortPlugins ({ plugins, order }: any) {
     const names = Object.keys(plugins)
     if (typeof order === 'string') {
@@ -39,6 +40,22 @@ export const getPostcssConfig = (nuxt: Nuxt) => {
   }
 
   const postcssOptions = defu({}, nuxt.options.postcss, {
+    plugins: {
+      /**
+       * https://github.com/postcss/postcss-import
+       */
+      'postcss-import': {
+        resolve: createResolver({
+          alias: { ...nuxt.options.alias },
+          modules: nuxt.options.modulesDir
+        })
+      },
+
+      /**
+       * https://github.com/postcss/postcss-url
+       */
+      'postcss-url': {}
+    },
     sourceMap: nuxt.options.webpack.cssSourceMap,
     // Array, String or Function
     order: 'autoprefixerAndCssnanoLast'

--- a/packages/webpack/src/utils/postcss.ts
+++ b/packages/webpack/src/utils/postcss.ts
@@ -26,7 +26,7 @@ const orderPresets = {
   }
 }
 
-export const getPostcssConfig = async async async async (nuxt: Nuxt) => {
+export const getPostcssConfig = (nuxt: Nuxt) => {
   function sortPlugins ({ plugins, order }: any) {
     const names = Object.keys(plugins)
     if (typeof order === 'string') {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -438,9 +438,6 @@ importers:
       pkg-types:
         specifier: ^1.0.3
         version: 1.0.3
-      postcss-import-resolver:
-        specifier: ^2.0.0
-        version: 2.0.0
       std-env:
         specifier: ^3.4.3
         version: 3.4.3
@@ -774,6 +771,9 @@ importers:
       postcss-import:
         specifier: ^15.1.0
         version: 15.1.0(postcss@8.4.31)
+      postcss-import-resolver:
+        specifier: ^2.0.0
+        version: 2.0.0
       postcss-loader:
         specifier: ^7.3.3
         version: 7.3.3(postcss@8.4.31)(typescript@5.2.2)(webpack@5.89.0)
@@ -853,6 +853,9 @@ importers:
 
   playground:
     dependencies:
+      '@fontsource/lora':
+        specifier: ^5.0.8
+        version: 5.0.8
       nuxt:
         specifier: workspace:*
         version: link:../packages/nuxt
@@ -1748,6 +1751,10 @@ packages:
   /@fastify/busboy@2.0.0:
     resolution: {integrity: sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==}
     engines: {node: '>=14'}
+
+  /@fontsource/lora@5.0.8:
+    resolution: {integrity: sha512-lJBsGmaOCr5INZwxz29TVTrIuZPTYcd3lkwnpoTclb86KsYpyU7chDVUQvf3CW/+hdX3fi1z7GvUz/kJIDyiZA==}
+    dev: false
 
   /@humanwhocodes/config-array@0.11.13:
     resolution: {integrity: sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -853,9 +853,6 @@ importers:
 
   playground:
     dependencies:
-      '@fontsource/lora':
-        specifier: ^5.0.8
-        version: 5.0.8
       nuxt:
         specifier: workspace:*
         version: link:../packages/nuxt
@@ -1751,10 +1748,6 @@ packages:
   /@fastify/busboy@2.0.0:
     resolution: {integrity: sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==}
     engines: {node: '>=14'}
-
-  /@fontsource/lora@5.0.8:
-    resolution: {integrity: sha512-lJBsGmaOCr5INZwxz29TVTrIuZPTYcd3lkwnpoTclb86KsYpyU7chDVUQvf3CW/+hdX3fi1z7GvUz/kJIDyiZA==}
-    dev: false
 
   /@humanwhocodes/config-array@0.11.13:
     resolution: {integrity: sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -641,12 +641,6 @@ importers:
       postcss:
         specifier: ^8.4.31
         version: 8.4.31
-      postcss-import:
-        specifier: ^15.1.0
-        version: 15.1.0(postcss@8.4.31)
-      postcss-url:
-        specifier: ^10.1.3
-        version: 10.1.3(postcss@8.4.31)
       rollup-plugin-visualizer:
         specifier: ^5.9.2
         version: 5.9.2(rollup@3.29.4)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/15765

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This was a fun deep-dive.

Investigating the linked issue, I found that we are adding `postcss-import` - _and so is vite_. In addition, I believe the key features `postcss-url` (which was causing the bug) are in fact already covered by Vite's list of features:

> Vite improves @import resolving for Sass and Less so that Vite aliases are also respected. In addition, relative url() references inside imported Sass/Less files that are in different directories from the root file are also automatically rebased to ensure correctness.
> https://vitejs.dev/guide/features.html#css-pre-processors

Accordingly, this PR removes both plugins (or rather, doesn't add them).

I suspect removing these two plugins will improve our performance as well as fix the bug. I would also consider we reconsider whether to include `cssnano` or defer to vite's esbuild/lightningcss minificiation step in future (cc: antfu).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
