### PR TITLE
docs: fix typo in layout description

### DIFF
--- a/docs/2.guide/2.directory-structure/1.layouts.md
+++ b/docs/2.guide/2.directory-structure/1.layouts.md
@@ -22,7 +22,7 @@ Layouts are enabled by adding [`<NuxtLayout>`](/docs/api/components/nuxt-layout)
 ```
 
 To use a layout:
-- Set a `layout` property in your page with [definePageMeta](/docs/api/utils/define-page-meta)
+- Set a `layout` property in your page with [definePageMeta](/docs/api/utils/define-page-meta).
 - Set the `name` prop of `<NuxtLayout>`.
 
 ::callout{color="blue" icon="i-ph-info-duotone"}

--- a/docs/2.guide/2.directory-structure/1.layouts.md
+++ b/docs/2.guide/2.directory-structure/1.layouts.md
@@ -22,7 +22,7 @@ Layouts are enabled by adding [`<NuxtLayout>`](/docs/api/components/nuxt-layout)
 ```
 
 To use a layout:
-- Set a `layout` property in your with with [definePageMeta](/docs/api/utils/define-page-meta)
+- Set a `layout` property in your page with [definePageMeta](/docs/api/utils/define-page-meta)
 - Set the `name` prop of `<NuxtLayout>`.
 
 ::callout{color="blue" icon="i-ph-info-duotone"}


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Documentation regarding setting layouts on the [directory structure guide](https://nuxt.com/docs/guide/directory-structure/layouts) has a malformed sentence. 
Old: "Set a layout property in your **with with**..."
New: "Set a layout property in your **page with**..."

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
