### PR TITLE
fix(nuxt): don't use local fetch with an external `baseURL`

### DIFF
--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -140,9 +140,15 @@ export function useFetch<
     controller?.abort?.()
     controller = typeof AbortController !== 'undefined' ? new AbortController() : {} as AbortController
 
-    const isLocalFetch = typeof _request.value === 'string' && _request.value.startsWith('/') && (!unref(opts.baseURL) || unref(opts.baseURL)!.startsWith('/'))
+    let _$fetch = opts.$fetch || globalThis.$fetch
+
     // Use fetch with request context and headers for server direct API calls
-    const _$fetch = opts.$fetch || ((import.meta.server && isLocalFetch) ? useRequestFetch() : globalThis.$fetch)
+    if (import.meta.server && !opts.$fetch) {
+      const isLocalFetch = typeof _request.value === 'string' && _request.value.startsWith('/') && (!unref(opts.baseURL) || unref(opts.baseURL)!.startsWith('/'))
+      if (isLocalFetch) {
+        _$fetch = useRequestFetch()
+      }
+    }
 
     return _$fetch(_request.value, { signal: controller.signal, ..._fetchOptions } as any) as Promise<_ResT>
   }, _asyncDataOptions)

--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -140,12 +140,9 @@ export function useFetch<
     controller?.abort?.()
     controller = typeof AbortController !== 'undefined' ? new AbortController() : {} as AbortController
 
-    const isLocalFetch = typeof _request.value === 'string' && _request.value.startsWith('/')
-    let _$fetch = opts.$fetch || globalThis.$fetch
+    const isLocalFetch = typeof _request.value === 'string' && _request.value.startsWith('/') && (!unref(opts.baseURL) || unref(opts.baseURL)!.startsWith('/'))
     // Use fetch with request context and headers for server direct API calls
-    if (import.meta.server && !opts.$fetch && isLocalFetch) {
-      _$fetch = useRequestFetch()
-    }
+    const _$fetch = opts.$fetch || ((import.meta.server && isLocalFetch) ? useRequestFetch() : globalThis.$fetch)
 
     return _$fetch(_request.value, { signal: controller.signal, ..._fetchOptions } as any) as Promise<_ResT>
   }, _asyncDataOptions)


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/23880

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This updates the test for `isLocalFetch` to only match if there is no provided baseURL or the baseURL starts with `/`.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
