### PR TITLE
fix(webpack): use lodash `cloneDeep` again

### DIFF
--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -35,7 +35,7 @@
     "fs-extra": "^11.1.1",
     "h3": "^1.8.2",
     "hash-sum": "^2.0.0",
-    "klona": "^2.0.6",
+    "lodash-es": "4.17.21",
     "magic-string": "^0.30.5",
     "memfs": "^4.6.0",
     "mini-css-extract-plugin": "^2.7.6",

--- a/packages/webpack/src/configs/server.ts
+++ b/packages/webpack/src/configs/server.ts
@@ -3,7 +3,7 @@ import webpack from 'webpack'
 import ForkTSCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin'
 import { logger } from '@nuxt/kit'
 import type { WebpackConfigContext } from '../utils/config'
-import { applyPresets, getWebpackConfig } from '../utils/config'
+import { applyPresets } from '../utils/config'
 import { nuxt } from '../presets/nuxt'
 import { node } from '../presets/node'
 
@@ -20,8 +20,6 @@ export function server (ctx: WebpackConfigContext) {
     serverPreset,
     serverPlugins
   ])
-
-  return getWebpackConfig(ctx)
 }
 
 function serverPreset (ctx: WebpackConfigContext) {

--- a/packages/webpack/src/utils/config.ts
+++ b/packages/webpack/src/utils/config.ts
@@ -1,7 +1,7 @@
 import type { Configuration } from 'webpack'
 import type { Nuxt, NuxtOptions } from '@nuxt/schema'
 import { logger } from '@nuxt/kit'
-import { klona } from 'klona'
+import { cloneDeep } from 'lodash-es'
 
 export interface WebpackConfigContext {
   nuxt: Nuxt
@@ -68,5 +68,5 @@ export function fileName (ctx: WebpackConfigContext, key: string) {
 
 export function getWebpackConfig (ctx: WebpackConfigContext): Configuration {
   // Clone to avoid leaking config between Client and Server
-  return klona(ctx.config)
+  return cloneDeep(ctx.config)
 }

--- a/packages/webpack/src/utils/config.ts
+++ b/packages/webpack/src/utils/config.ts
@@ -68,5 +68,6 @@ export function fileName (ctx: WebpackConfigContext, key: string) {
 
 export function getWebpackConfig (ctx: WebpackConfigContext): Configuration {
   // Clone to avoid leaking config between Client and Server
+  // TODO: rewrite webpack implementation to avoid necessity for this
   return cloneDeep(ctx.config)
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -744,9 +744,9 @@ importers:
       hash-sum:
         specifier: ^2.0.0
         version: 2.0.0
-      klona:
-        specifier: ^2.0.6
-        version: 2.0.6
+      lodash-es:
+        specifier: 4.17.21
+        version: 4.17.21
       magic-string:
         specifier: ^0.30.5
         version: 0.30.5
@@ -1120,6 +1120,7 @@ packages:
   /@babel/highlight@7.22.20:
     resolution: {integrity: sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==}
     engines: {node: '>=6.9.0'}
+    requiresBuild: true
     dependencies:
       '@babel/helper-validator-identifier': 7.22.20
       chalk: 2.4.2
@@ -6408,6 +6409,7 @@ packages:
 
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+    requiresBuild: true
 
   /js-yaml@3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
@@ -6627,7 +6629,6 @@ packages:
 
   /lodash-es@4.17.21:
     resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
-    dev: true
 
   /lodash.clonedeep@4.5.0:
     resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/23843

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This is a hotfix reverting part of https://github.com/nuxt/nuxt/pull/23692 to use `cloneDeep` for now instead of `klona`. (The webpack implementation here could likely be rewritten to avoid the need.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
