### PR TITLE
fix(nuxt): render a div when client-only hydrates w/o element

### DIFF
--- a/packages/nuxt/src/app/components/client-only.ts
+++ b/packages/nuxt/src/app/components/client-only.ts
@@ -41,7 +41,7 @@ export function createClientOnly<T extends ComponentOptions> (component: T) {
           : h(res)
       } else {
         const fragment = getFragmentHTML(ctx._.vnode.el ?? null)
-        return process.client ? createStaticVNode(fragment.join(''), fragment.length) : h('div', ctx.$attrs ?? ctx._.attrs)
+        return process.client ? createStaticVNode(fragment.join('') || '<div></div>', fragment.length) : h('div', ctx.$attrs ?? ctx._.attrs)
       }
     }
   } else if (clone.template) {
@@ -80,7 +80,7 @@ export function createClientOnly<T extends ComponentOptions> (component: T) {
                   : h(res)
               } else {
                 const fragment = getFragmentHTML(instance?.vnode.el ?? null)
-                return process.client ? createStaticVNode(fragment.join(''), fragment.length) : h('div', ctx.attrs)
+                return process.client ? createStaticVNode(fragment.join('') || '<div></div>', fragment.length) : h('div', ctx.attrs)
               }
             }
       })

--- a/packages/nuxt/src/app/components/client-only.ts
+++ b/packages/nuxt/src/app/components/client-only.ts
@@ -40,8 +40,8 @@ export function createClientOnly<T extends ComponentOptions> (component: T) {
           ? createElementVNode(res.type, res.props, res.children, res.patchFlag, res.dynamicProps, res.shapeFlag)
           : h(res)
       } else {
-        const fragment = getFragmentHTML(ctx._.vnode.el ?? null)
-        return process.client ? createStaticVNode(fragment.join('') || '<div></div>', fragment.length) : h('div', ctx.$attrs ?? ctx._.attrs)
+        const fragment = getFragmentHTML(ctx._.vnode.el ?? null) ?? ['<div></div>']
+        return process.client ? createStaticVNode(fragment.join(''), fragment.length) : h('div', ctx.$attrs ?? ctx._.attrs)
       }
     }
   } else if (clone.template) {
@@ -79,8 +79,8 @@ export function createClientOnly<T extends ComponentOptions> (component: T) {
                   ? createElementVNode(res.type, res.props, res.children, res.patchFlag, res.dynamicProps, res.shapeFlag)
                   : h(res)
               } else {
-                const fragment = getFragmentHTML(instance?.vnode.el ?? null)
-                return process.client ? createStaticVNode(fragment.join('') || '<div></div>', fragment.length) : h('div', ctx.attrs)
+                const fragment = getFragmentHTML(instance?.vnode.el ?? null) ?? ['<div></div>']
+                return process.client ? createStaticVNode(fragment.join(''), fragment.length) : h('div', ctx.attrs)
               }
             }
       })

--- a/packages/nuxt/src/app/components/nuxt-island.ts
+++ b/packages/nuxt/src/app/components/nuxt-island.ts
@@ -73,10 +73,10 @@ export default defineComponent({
 
     const ssrHTML = ref<string>('')
     if (import.meta.client) {
-      const renderedHTML = getFragmentHTML(instance.vnode?.el ?? null).join('')
+      const renderedHTML = getFragmentHTML(instance.vnode?.el ?? null)?.join('') ?? ''
       if (renderedHTML && nuxtApp.isHydrating) {
         setPayload(`${props.name}_${hashId.value}`, {
-          html: getFragmentHTML(instance.vnode?.el ?? null, true).join(''),
+          html: getFragmentHTML(instance.vnode?.el ?? null, true)?.join('') ?? '',
           state: {},
           head: {
             link: [],

--- a/packages/nuxt/src/app/components/utils.ts
+++ b/packages/nuxt/src/app/components/utils.ts
@@ -104,7 +104,7 @@ export function vforToArray (source: any): any[] {
  * @param withoutSlots purge all slots from the HTML string retrieved
  * @returns {string[]} An array of string which represent the content of each element. Use `.join('')` to retrieve a component vnode.el HTML
  */
-export function getFragmentHTML (element: RendererNode | null, withoutSlots = false): string[] {
+export function getFragmentHTML (element: RendererNode | null, withoutSlots = false): string[] | null {
   if (element) {
     if (element.nodeName === '#comment' && element.nodeValue === '[') {
       return getFragmentChildren(element, [], withoutSlots)
@@ -116,7 +116,7 @@ export function getFragmentHTML (element: RendererNode | null, withoutSlots = fa
     }
     return [element.outerHTML]
   }
-  return []
+  return null
 }
 
 function getFragmentChildren (element: RendererNode | null, blocks: string[] = [], withoutSlots = false) {

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -83,7 +83,7 @@ describe('modules', () => {
   })
 })
 
-describe('pages', () => {
+describe.only('pages', () => {
   it('render index', async () => {
     const html = await $fetch('/')
 
@@ -362,6 +362,12 @@ describe('pages', () => {
 
     expect(pageErrors).toEqual([])
     await page.close()
+    // don't expect any errors or warning on client-side navigation
+    const { page: page2, consoleLogs: consoleLogs2 } = await renderPage('/')
+    await page2.locator('#to-client-only-components').click()
+    // force wait for a few ticks
+    await page2.waitForTimeout(50)
+    expect(consoleLogs2.some(log => log.type === 'error' || log.type === 'warning')).toBeFalsy()
   })
 
   it('/wrapper-expose/layout', async () => {

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -83,7 +83,7 @@ describe('modules', () => {
   })
 })
 
-describe.only('pages', () => {
+describe('pages', () => {
   it('render index', async () => {
     const html = await $fetch('/')
 

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -368,6 +368,7 @@ describe('pages', () => {
     // force wait for a few ticks
     await page2.waitForTimeout(50)
     expect(consoleLogs2.some(log => log.type === 'error' || log.type === 'warning')).toBeFalsy()
+    await page2.close()
   })
 
   it('/wrapper-expose/layout', async () => {

--- a/test/fixtures/basic/pages/index.vue
+++ b/test/fixtures/basic/pages/index.vue
@@ -32,6 +32,9 @@
     <NuxtLink to="/chunk-error" :prefetch="false">
       Chunk error
     </NuxtLink>
+    <NuxtLink id="to-client-only-components" to="/client-only-components">
+      createClientOnly()
+    </NuxtLink>
     <NuxtLink id="middleware-abort-non-fatal" to="/middleware-abort-non-fatal" :prefetch="false">
       Middleware abort navigation
     </NuxtLink>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

fix #23876 

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Hi :wave: 
This PR makes the component cloned from `createClientOnly` render a `<div></div>` if there's no element attached to it's instance.
 
The issue does not happens on hydration because an element is already attached to the component instance on hydration.


<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
