### PR TITLE
fix(nuxt): preserve hyphens in component/layout kebab names

### DIFF
--- a/packages/nuxt/src/core/utils/names.ts
+++ b/packages/nuxt/src/core/utils/names.ts
@@ -1,5 +1,5 @@
 import { basename, dirname, extname, normalize } from 'pathe'
-import { kebabCase, pascalCase, splitByCase } from 'scule'
+import { kebabCase, splitByCase } from 'scule'
 import { withTrailingSlash } from 'ufo'
 
 export function getNameFromPath (path: string, relativeTo?: string) {

--- a/packages/nuxt/src/core/utils/names.ts
+++ b/packages/nuxt/src/core/utils/names.ts
@@ -8,14 +8,15 @@ export function getNameFromPath (path: string, relativeTo?: string) {
     : basename(path)
   const prefixParts = splitByCase(dirname(relativePath))
   const fileName = basename(relativePath, extname(relativePath))
-  return kebabCase(resolveComponentName(fileName.toLowerCase() === 'index' ? '' : fileName, prefixParts)).replace(/["']/g, '')
+  const segments = resolveComponentNameSegments(fileName.toLowerCase() === 'index' ? '' : fileName, prefixParts).filter(Boolean)
+  return kebabCase(segments).replace(/["']/g, '')
 }
 
 export function hasSuffix (path: string, suffix: string) {
   return basename(path).replace(extname(path), '').endsWith(suffix)
 }
 
-export function resolveComponentName (fileName: string, prefixParts: string[]) {
+export function resolveComponentNameSegments (fileName: string, prefixParts: string[]) {
   /**
    * Array of fileName parts splitted by case, / or -
    * @example third-component -> ['third', 'component']
@@ -38,6 +39,5 @@ export function resolveComponentName (fileName: string, prefixParts: string[]) {
     }
     index--
   }
-
-  return pascalCase(componentNameParts) + pascalCase(fileNameParts)
+  return [...componentNameParts, ...fileNameParts]
 }

--- a/packages/nuxt/test/naming.test.ts
+++ b/packages/nuxt/test/naming.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { pascalCase } from 'scule'
+import { getNameFromPath, resolveComponentNameSegments } from '../src/core/utils'
+
+describe('getNameFromPath', () => {
+  const cases: Record<string, string> = {
+    'base.vue': 'base',
+    'base/base.vue': 'base',
+    'base/base-layout.vue': 'base-layout',
+    'base-1-layout': 'base-1-layout'
+  }
+  it.each(Object.keys(cases))('correctly deduplicates segments - %s', (filename) => {
+    expect(getNameFromPath(filename)).toEqual(cases[filename])
+  })
+})
+
+const tests: Array<[string, string[], string]> = [
+  ['WithClientOnlySetup', ['Client'], 'ClientWithClientOnlySetup'],
+  ['ItemHolderItem', ['Item', 'Holder', 'Item'], 'ItemHolderItem'],
+  ['Item', ['Item'], 'Item'],
+  ['Item', ['Item', 'Item'], 'Item'],
+  ['ItemTest', ['Item', 'Test'], 'ItemTest'],
+  ['ThingItemTest', ['Item', 'Thing'], 'ItemThingItemTest'],
+  ['Item', ['Thing', 'Item'], 'ThingItem'],
+  ['Item', ['Item', 'Holder', 'Item'], 'ItemHolderItem'],
+  ['ItemHolder', ['Item', 'Holder', 'Item'], 'ItemHolderItemHolder'],
+  ['ThingItemTest', ['Item', 'Thing', 'Foo'], 'ItemThingFooThingItemTest'],
+  ['ItemIn', ['Item', 'Holder', 'Item', 'In'], 'ItemHolderItemIn'],
+  ['Item', ['Item', 'Holder', 'Test'], 'ItemHolderTestItem'],
+  ['ItemHolderItem', ['Item', 'Holder', 'Item', 'Holder'], 'ItemHolderItemHolderItem'],
+  ['Icones', ['Icon'], 'IconIcones'],
+  ['Icon', ['Icones'], 'IconesIcon'],
+  ['IconHolder', ['IconHolder'], 'IconHolder'],
+  ['GameList', ['Desktop', 'ShareGame', 'Review', 'Detail'], 'DesktopShareGameReviewDetailGameList'],
+  ['base-1-layout', [], 'Base1Layout']
+]
+
+describe('components:resolveComponentNameSegments', () => {
+  it.each(tests)('resolves %s with prefix parts %s and filename %s', (fileName, prefixParts: string[], result) => {
+    expect(pascalCase(resolveComponentNameSegments(fileName, prefixParts))).toBe(result)
+  })
+})

--- a/packages/nuxt/test/scan-components.test.ts
+++ b/packages/nuxt/test/scan-components.test.ts
@@ -1,9 +1,8 @@
 import { resolve } from 'node:path'
-import { describe, expect, it, vi } from 'vitest'
+import { expect, it, vi } from 'vitest'
 import type { ComponentsDir } from 'nuxt/schema'
 
 import { scanComponents } from '../src/components/scan'
-import { resolveComponentName } from '../src/core/utils'
 
 const fixtureDir = resolve(__dirname, 'fixture')
 const rFixture = (...p: string[]) => resolve(fixtureDir, ...p)
@@ -243,30 +242,4 @@ it('components:scanComponents', async () => {
     delete c.filePath
   }
   expect(scannedComponents).deep.eq(expectedComponents)
-})
-
-const tests: Array<[string, string[], string]> = [
-  ['WithClientOnlySetup', ['Client'], 'ClientWithClientOnlySetup'],
-  ['ItemHolderItem', ['Item', 'Holder', 'Item'], 'ItemHolderItem'],
-  ['Item', ['Item'], 'Item'],
-  ['Item', ['Item', 'Item'], 'Item'],
-  ['ItemTest', ['Item', 'Test'], 'ItemTest'],
-  ['ThingItemTest', ['Item', 'Thing'], 'ItemThingItemTest'],
-  ['Item', ['Thing', 'Item'], 'ThingItem'],
-  ['Item', ['Item', 'Holder', 'Item'], 'ItemHolderItem'],
-  ['ItemHolder', ['Item', 'Holder', 'Item'], 'ItemHolderItemHolder'],
-  ['ThingItemTest', ['Item', 'Thing', 'Foo'], 'ItemThingFooThingItemTest'],
-  ['ItemIn', ['Item', 'Holder', 'Item', 'In'], 'ItemHolderItemIn'],
-  ['Item', ['Item', 'Holder', 'Test'], 'ItemHolderTestItem'],
-  ['ItemHolderItem', ['Item', 'Holder', 'Item', 'Holder'], 'ItemHolderItemHolderItem'],
-  ['Icones', ['Icon'], 'IconIcones'],
-  ['Icon', ['Icones'], 'IconesIcon'],
-  ['IconHolder', ['IconHolder'], 'IconHolder'],
-  ['GameList', ['Desktop', 'ShareGame', 'Review', 'Detail'], 'DesktopShareGameReviewDetailGameList']
-]
-
-describe('components:resolveComponentName', () => {
-  it.each(tests)('resolves %s with prefix parts %s and filename %s', (fileName, prefixParts: string[], result) => {
-    expect(resolveComponentName(fileName, prefixParts)).toBe(result)
-  })
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This fixes a regression in https://github.com/nuxt/nuxt/pull/20190 where hyphen data was missing because we converted kebab -> pascal -> kebab, e.g. `base-1-thing` -> `Base1Thing` -> `base1-thing`. This preserves the initial segments to revert that change.

Because of the value of keeping things consistent, I've also applied the change to the component resolver. This should only affect kebab-casing with numbers, but although it is a behaviour change I think it is a fix (so `test-1-file.vue` can be used as `<test-1-file>` rather than requiring `<test1-file>`).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
