### PR TITLE
fix(vite): don't warm up css deps and normalise urls correctly

### DIFF
--- a/packages/vite/src/utils/warmup.ts
+++ b/packages/vite/src/utils/warmup.ts
@@ -39,6 +39,11 @@ export async function warmupViteServer (
     url = normaliseURL(url, server.config.base)
 
     if (warmedUrls.has(url)) { return }
+    const m = await server.moduleGraph.getModuleByUrl(url, isServer)
+    // a module that is already compiled (and can't be warmed up anyway)
+    if (m?.transformResult?.code) {
+      return
+    }
     warmedUrls.add(url)
     try {
       await server.transformRequest(url, { ssr: isServer })

--- a/packages/vite/src/utils/warmup.ts
+++ b/packages/vite/src/utils/warmup.ts
@@ -15,6 +15,18 @@ function fileToUrl (file: string, root: string) {
   return '/' + normalize(url)
 }
 
+function normaliseURL (url: string, base: string) {
+  // remove any base url
+  url = withoutBase(url, base)
+  // unwrap record
+  if (url.startsWith('/@id/')) {
+    url = url.slice('/@id/'.length).replace('__x00__', '\0')
+  }
+  // strip query
+  url = url.replace(/(\?|&)import=?(?:&|$)/, '').replace(/[?&]$/, '')
+  return url
+}
+
 // TODO: use built-in warmup logic when we update to vite 5
 export async function warmupViteServer (
   server: ViteDevServer,
@@ -24,14 +36,8 @@ export async function warmupViteServer (
   const warmedUrls = new Set<String>()
 
   const warmup = async (url: string) => {
-    // remove any base url
-    url = withoutBase(url, server.config.base)
-    // unwrap record
-    if (url.startsWith('/@id/')) {
-      url = url.slice('/@id/'.length).replace('__x00__', '\0')
-    }
-    // strip query
-    url = url.replace(/(\?|&)import=?(?:&|$)/, '').replace(/[?&]$/, '')
+    url = normaliseURL(url, server.config.base)
+
     if (warmedUrls.has(url)) { return }
     warmedUrls.add(url)
     try {

--- a/packages/vite/src/utils/warmup.ts
+++ b/packages/vite/src/utils/warmup.ts
@@ -41,7 +41,7 @@ export async function warmupViteServer (
     if (warmedUrls.has(url)) { return }
     const m = await server.moduleGraph.getModuleByUrl(url, isServer)
     // a module that is already compiled (and can't be warmed up anyway)
-    if (m?.transformResult?.code) {
+    if (m?.transformResult?.code || m?.ssrTransformResult?.code) {
       return
     }
     warmedUrls.add(url)

--- a/packages/vite/src/utils/warmup.ts
+++ b/packages/vite/src/utils/warmup.ts
@@ -13,6 +13,7 @@ function fileToUrl (file: string, root: string) {
   return '/' + normalize(url)
 }
 
+// TODO: use built-in warmup logic when we update to vite 5
 export async function warmupViteServer (
   server: ViteDevServer,
   entries: string[],

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -192,11 +192,7 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
       }
     })
 
-    if (
-      nuxt.options.vite.warmupEntry !== false &&
-      // https://github.com/nuxt/nuxt/issues/14898
-      !(env.isServer && ctx.nuxt.options.vite.devBundler !== 'legacy')
-    ) {
+    if (nuxt.options.vite.warmupEntry !== false) {
       const start = Date.now()
       warmupViteServer(server, [ctx.entry], env.isServer)
         .then(() => logger.info(`Vite ${env.isClient ? 'client' : 'server'} warmed up in ${Date.now() - start}ms`))

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -198,7 +198,7 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
       !(env.isServer && ctx.nuxt.options.vite.devBundler !== 'legacy')
     ) {
       const start = Date.now()
-      warmupViteServer(server, [join('/@fs/', ctx.entry)], env.isServer)
+      warmupViteServer(server, [ctx.entry], env.isServer)
         .then(() => logger.info(`Vite ${env.isClient ? 'client' : 'server'} warmed up in ${Date.now() - start}ms`))
         .catch(logger.error)
     }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/20533
resolves https://github.com/nuxt/nuxt/issues/14898

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

It seems we are over-warming up vite, and in particular warming up lots of Sass files has a significant performance cost in some projects, which is not actually needed.

~~This PR ensures we align our warmup logic with the upcoming warmup option in Vite 5 (https://github.com/vitejs/vite/pull/14291).~~

This PR skips warming up CSS dependencies as these are duplicate (ie. they are already included in the output of the first CSS dep). It also applies same logic for normalising URLs as Vite does itself, e.g.:

https://github.com/vitejs/vite/blob/e4c801c552edc4a60659720b89777e29eb93db6b/packages/vite/src/node/plugins/importAnalysis.ts#L604

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
