### PR TITLE
fix(schema): correctly set default cssnano config

### DIFF
--- a/packages/schema/src/config/postcss.ts
+++ b/packages/schema/src/config/postcss.ts
@@ -6,7 +6,7 @@ export default defineUntypedSchema({
      * Options for configuring PostCSS plugins.
      *
      * https://postcss.org/
-     * @type {Record<string, any>}
+     * @type {Record<string, any> & { autoprefixer?: any; cssnano?: any }}
      */
     plugins: {
       /**
@@ -14,14 +14,19 @@ export default defineUntypedSchema({
        */
       autoprefixer: {},
 
+      /**
+       * https://cssnano.co/docs/config-file/#configuration-options
+       */
       cssnano: {
-        $resolve: async (val, get) => val ?? (!(await get('dev')) && {
-          preset: ['default', {
-            // Keep quotes in font values to prevent from HEX conversion
-            // https://github.com/nuxt/nuxt/issues/6306
-            minifyFontValues: { removeQuotes: false }
-          }]
-        })
+        $resolve: async (val, get) => {
+          if (val || val === false) {
+            return val
+          }
+          if (await get('dev')) {
+            return false
+          }
+          return {}
+        }
       }
     }
   }

--- a/packages/schema/src/config/postcss.ts
+++ b/packages/schema/src/config/postcss.ts
@@ -15,7 +15,7 @@ export default defineUntypedSchema({
       autoprefixer: {},
 
       cssnano: {
-        $resolve: async (val, get) => val ?? !(await get('dev') && {
+        $resolve: async (val, get) => val ?? (!(await get('dev')) && {
           preset: ['default', {
             // Keep quotes in font values to prevent from HEX conversion
             // https://github.com/nuxt/nuxt/issues/6306


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Spotted when looking into postcss - seems we had wrong parens and weren't passing the default options through, only a boolean `true`.

I looked into the config (which we weren't respecting) and couldn't reproduce the bug it links, so I think we can remove it.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
