### PR TITLE
fix(kit): fix `addServerImportsDir` implementation

### DIFF
--- a/docs/3.api/5.kit/11.nitro.md
+++ b/docs/3.api/5.kit/11.nitro.md
@@ -377,7 +377,7 @@ function function addServerImportsDir (dirs: string | string[], opts: { prepend?
 
 **Required**: `true`
 
-A route or an array of directories to register to be scanned by Nitro
+A directory or an array of directories to register to be scanned by Nitro
 
 ### Examples
 

--- a/docs/3.api/5.kit/11.nitro.md
+++ b/docs/3.api/5.kit/11.nitro.md
@@ -358,3 +358,40 @@ export default defineNuxtModule({
   }
 })
 ```
+
+## `addServerImportsDir`
+
+Add a directory to be scanned for auto-imports by Nitro.
+
+### Type
+
+```ts
+function function addServerImportsDir (dirs: string | string[], opts: { prepend?: boolean }): void
+```
+
+### Parameters
+
+#### `dirs`
+
+**Type**: `string | string[]`
+
+**Required**: `true`
+
+A route or an array of directories to register to be scanned by Nitro
+
+### Examples
+
+```ts
+import { defineNuxtModule, addServerImportsDir } from '@nuxt/kit'
+
+export default defineNuxtModule({
+  meta: {
+    name: 'my-module',
+    configKey: 'myModule',
+  },
+  setup(options) {
+    const resolver = createResolver(import.meta.url)
+    addServerImportsDir(resolver.resolve('./runtime/server/utils'))
+  }
+})
+```

--- a/packages/kit/src/nitro.ts
+++ b/packages/kit/src/nitro.ts
@@ -99,15 +99,13 @@ export function addServerImports (imports: Import[]) {
 }
 
 /**
- * Add directories to be scanned by Nitro
+ * Add directories to be scanned for auto-imports by Nitro
  */
 export function addServerImportsDir (dirs: string | string[], opts: { prepend?: boolean } = {}) {
   const nuxt = useNuxt()
   nuxt.hook('nitro:config', (config) => {
-    config.scanDirs = config.scanDirs || []
-
-    for (const dir of (Array.isArray(dirs) ? dirs : [dirs])) {
-      config.scanDirs[opts.prepend ? 'unshift' : 'push'](dir)
-    }
+    config.imports = config.imports || {}
+    config.imports.dirs = config.imports.dirs || []
+    config.imports.dirs[opts.prepend ? 'unshift' : 'push'](...dirs)
   })
 }

--- a/packages/kit/src/nitro.ts
+++ b/packages/kit/src/nitro.ts
@@ -103,9 +103,10 @@ export function addServerImports (imports: Import[]) {
  */
 export function addServerImportsDir (dirs: string | string[], opts: { prepend?: boolean } = {}) {
   const nuxt = useNuxt()
+  const _dirs = Array.isArray(dirs) ? dirs : [dirs]
   nuxt.hook('nitro:config', (config) => {
     config.imports = config.imports || {}
     config.imports.dirs = config.imports.dirs || []
-    config.imports.dirs[opts.prepend ? 'unshift' : 'push'](...dirs)
+    config.imports.dirs[opts.prepend ? 'unshift' : 'push'](..._dirs)
   })
 }

--- a/test/fixtures/basic/modules/auto-registered/index.ts
+++ b/test/fixtures/basic/modules/auto-registered/index.ts
@@ -21,6 +21,6 @@ export default defineNuxtModule({
       name: 'someUtils'
     }])
 
-    addServerImportsDir(resolver.resolve('./runtime/server'))
+    addServerImportsDir(resolver.resolve('./runtime/server/utils'))
   }
 })


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The implementation of `addServerImportsDir` wasn't registering auto-imports but registering them to be scanned for API routes.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
