### PR TITLE
fix(nuxt): use payload url for isPrerendered, not current route

### DIFF
--- a/packages/nuxt/src/app/composables/payload.ts
+++ b/packages/nuxt/src/app/composables/payload.ts
@@ -23,7 +23,7 @@ export function loadPayload (url: string, opts: LoadPayloadOptions = {}): Record
   if (payloadURL in cache) {
     return cache[payloadURL]
   }
-  cache[payloadURL] = isPrerendered().then((prerendered) => {
+  cache[payloadURL] = isPrerendered(url).then((prerendered) => {
     if (!prerendered) {
       cache[payloadURL] = null
       return null
@@ -78,11 +78,7 @@ async function _importPayload (payloadURL: string) {
 
 export async function isPrerendered (url = useRoute().path) {
   // Note: Alternative for server is checking x-nitro-prerender header
-  const nuxtApp = useNuxtApp()
-  if (nuxtApp.payload.prerenderedAt) {
-    return true
-  }
-  if (!appManifest) { return false }
+  if (!appManifest) { return !!useNuxtApp().payload.prerenderedAt }
   const manifest = await getAppManifest()
   if (manifest.prerendered.includes(url)) {
     return true


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This fixes two bugs in the app manifest:

1. `isPrerendered` previously would always base its value on `nuxtApp.payload.prerenderedAt`, even though we now have a more reliable way to check for any given page. we now pass in the page url to check.
2. previously we generated the manifest too early (before nitro prerendered routes) to actually include them in the manifest. Particularly review on a lifecycle point of view would be valued @pi0 :pray:

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
