### PR TITLE
perf(nuxt): set `pages` on nuxt app and deduplicate calls

### DIFF
--- a/packages/schema/src/types/nuxt.ts
+++ b/packages/schema/src/types/nuxt.ts
@@ -1,6 +1,6 @@
 import type { Hookable } from 'hookable'
 import type { Ignore } from 'ignore'
-import type { NuxtHooks, NuxtLayout, NuxtMiddleware } from './hooks'
+import type { NuxtHooks, NuxtLayout, NuxtMiddleware, NuxtPage } from './hooks'
 import type { Component } from './components'
 import type { NuxtOptions } from './config'
 
@@ -61,6 +61,7 @@ export interface NuxtApp {
   middleware: NuxtMiddleware[]
   templates: NuxtTemplate[]
   configs: string[]
+  pages?: NuxtPage[]
 }
 
 export interface Nuxt {


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This improves performance by reducing the number of times we crawl the filesystem to generate page routes. It does so by adding a new property on `app`: `app.pages`, where we can store the pages, just as we do for components, layouts, middleware, etc.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
