### PR TITLE
test: await before asserting console logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "play:build": "nuxi build playground",
     "play:preview": "nuxi preview playground",
     "test": "pnpm test:fixtures && pnpm test:fixtures:dev && pnpm test:fixtures:webpack && pnpm test:unit && pnpm test:runtime && pnpm test:types && pnpm typecheck",
-    "test:fixtures": "nuxi prepare test/fixtures/basic && nuxi prepare test/fixtures/runtime-compiler && vitest run --dir test",
+    "test:fixtures": "nuxi prepare test/fixtures/basic && nuxi prepare test/fixtures/runtime-compiler && vitest run --dir test --allowOnly",
     "test:fixtures:dev": "TEST_ENV=dev pnpm test:fixtures",
     "test:fixtures:webpack": "TEST_BUILDER=webpack pnpm test:fixtures",
     "test:runtime": "vitest -c vitest.nuxt.config.ts",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "play:build": "nuxi build playground",
     "play:preview": "nuxi preview playground",
     "test": "pnpm test:fixtures && pnpm test:fixtures:dev && pnpm test:fixtures:webpack && pnpm test:unit && pnpm test:runtime && pnpm test:types && pnpm typecheck",
-    "test:fixtures": "nuxi prepare test/fixtures/basic && nuxi prepare test/fixtures/runtime-compiler && vitest run --dir test --allowOnly",
+    "test:fixtures": "nuxi prepare test/fixtures/basic && nuxi prepare test/fixtures/runtime-compiler && vitest run --dir test",
     "test:fixtures:dev": "TEST_ENV=dev pnpm test:fixtures",
     "test:fixtures:webpack": "TEST_BUILDER=webpack pnpm test:fixtures",
     "test:runtime": "vitest -c vitest.nuxt.config.ts",

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1126,7 +1126,8 @@ describe('deferred app suspense resolve', () => {
   })
 })
 
-describe('nested suspense', () => {
+// eslint-disable-next-line
+describe.only('nested suspense', () => {
   const navigations = ([
     ['/suspense/sync-1/async-1/', '/suspense/sync-2/async-1/'],
     ['/suspense/sync-1/sync-1/', '/suspense/sync-2/async-1/'],

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1126,8 +1126,7 @@ describe('deferred app suspense resolve', () => {
   })
 })
 
-// eslint-disable-next-line
-describe.only('nested suspense', () => {
+describe('nested suspense', () => {
   const navigations = ([
     ['/suspense/sync-1/async-1/', '/suspense/sync-2/async-1/'],
     ['/suspense/sync-1/sync-1/', '/suspense/sync-2/async-1/'],
@@ -1200,6 +1199,8 @@ describe.only('nested suspense', () => {
 
     const first = start.match(/\/suspense\/(?<parentType>a?sync)-(?<parentNum>\d)\/(?<childType>a?sync)-(?<childNum>\d)\//)!.groups!
     const last = nav.match(/\/suspense\/(?<parentType>a?sync)-(?<parentNum>\d)\//)!.groups!
+
+    await new Promise<void>(resolve => setTimeout(resolve, 50))
 
     expect(consoleLogs.map(l => l.text).filter(i => !i.includes('[vite]') && !i.includes('<Suspense> is an experimental feature')).sort()).toEqual([
       // [first load] from parent

--- a/test/fixtures/basic/pages/suspense/async-[parent]/async-[child].vue
+++ b/test/fixtures/basic/pages/suspense/async-[parent]/async-[child].vue
@@ -3,7 +3,7 @@ if (import.meta.client) {
   console.log('[async] [async]')
 }
 const route = useRoute('suspense-async-parent-async-child')
-await new Promise(resolve => setTimeout(resolve, 500))
+await new Promise(resolve => setTimeout(resolve, 50))
 if (import.meta.client) {
   console.log(`[async] [${route.params.parent}] [async] [${route.params.child}] running async data`)
 }

--- a/test/fixtures/basic/pages/suspense/sync-[parent]/async-[child].vue
+++ b/test/fixtures/basic/pages/suspense/sync-[parent]/async-[child].vue
@@ -3,7 +3,7 @@ if (import.meta.client) {
   console.log('[sync] [async]')
 }
 const route = useRoute('suspense-async-parent-sync-child')
-await new Promise(resolve => setTimeout(resolve, 500))
+await new Promise(resolve => setTimeout(resolve, 50))
 if (import.meta.client) {
   console.log(`[sync] [${route.params.parent}] [async] [${route.params.child}] running async data`)
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This updates our test to wait a little longer before asserting what has been logged.

~~This is a PR to debug flakey CI runs that all seem to fail in the same test 🤔 ~~

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
