### PR TITLE
fix(nuxt,vite): strip virtual prefixes before converting to url

### DIFF
--- a/packages/nuxt/src/components/islandsTransform.ts
+++ b/packages/nuxt/src/components/islandsTransform.ts
@@ -1,10 +1,8 @@
-import { pathToFileURL } from 'node:url'
 import type { Component } from '@nuxt/schema'
-import { parseURL } from 'ufo'
 import { createUnplugin } from 'unplugin'
 import MagicString from 'magic-string'
 import { ELEMENT_NODE, parse, walk } from 'ultrahtml'
-import { isVue } from '../core/utils'
+import { isVue, parseId } from '../core/utils'
 
 interface ServerOnlyComponentTransformPluginOptions {
     getComponents: () => Component[]
@@ -25,7 +23,7 @@ export const islandsTransform = createUnplugin((options: ServerOnlyComponentTran
       const islands = components.filter(component =>
         component.island || (component.mode === 'server' && !components.some(c => c.pascalName === component.pascalName && c.mode === 'client'))
       )
-      const { pathname } = parseURL(decodeURIComponent(pathToFileURL(id).href))
+      const { pathname } = parseId(id)
       return islands.some(c => c.filePath === pathname)
     },
     async transform (code, id) {

--- a/packages/nuxt/src/components/tree-shake.ts
+++ b/packages/nuxt/src/components/tree-shake.ts
@@ -1,5 +1,3 @@
-import { pathToFileURL } from 'node:url'
-import { parseURL } from 'ufo'
 import MagicString from 'magic-string'
 import { walk } from 'estree-walker'
 import type { AssignmentProperty, CallExpression, Identifier, Literal, MemberExpression, Node, ObjectExpression, Pattern, Program, Property, ReturnStatement, VariableDeclaration } from 'estree'
@@ -7,6 +5,7 @@ import { createUnplugin } from 'unplugin'
 import type { Component } from '@nuxt/schema'
 import { resolve } from 'pathe'
 import { distDir } from '../dirs'
+import { parseId } from '../core/utils'
 
 interface TreeShakeTemplatePluginOptions {
   sourcemap?: boolean
@@ -26,7 +25,7 @@ export const TreeShakeTemplatePlugin = createUnplugin((options: TreeShakeTemplat
     name: 'nuxt:tree-shake-template',
     enforce: 'post',
     transformInclude (id) {
-      const { pathname } = parseURL(decodeURIComponent(pathToFileURL(id).href))
+      const { pathname } = parseId(id)
       return pathname.endsWith('.vue')
     },
     transform (code) {

--- a/packages/nuxt/src/core/utils/plugins.ts
+++ b/packages/nuxt/src/core/utils/plugins.ts
@@ -1,9 +1,15 @@
 import { pathToFileURL } from 'node:url'
+import { isAbsolute } from 'pathe'
 import { parseQuery, parseURL } from 'ufo'
+
+export function parseId (id: string) {
+  id = id.replace(/^(virtual:nuxt:|virtual:)/, '')
+  return parseURL(decodeURIComponent(isAbsolute(id) ? pathToFileURL(id).href : id))
+}
 
 export function isVue (id: string, opts: { type?: Array<'template' | 'script' | 'style'> } = {}) {
   // Bare `.vue` file (in Vite)
-  const { search } = parseURL(decodeURIComponent(pathToFileURL(id).href))
+  const { search } = parseId(id)
   if (id.endsWith('.vue') && !search) {
     return true
   }
@@ -38,6 +44,6 @@ const JS_RE = /\.((c|m)?j|t)sx?$/
 
 export function isJS (id: string) {
   // JavaScript files
-  const { pathname } = parseURL(decodeURIComponent(pathToFileURL(id).href))
+  const { pathname } = parseId(id)
   return JS_RE.test(pathname)
 }

--- a/packages/nuxt/src/pages/plugins/page-meta.ts
+++ b/packages/nuxt/src/pages/plugins/page-meta.ts
@@ -9,6 +9,7 @@ import { walk } from 'estree-walker'
 import MagicString from 'magic-string'
 import { isAbsolute } from 'pathe'
 import { logger } from '@nuxt/kit'
+import { parseId } from '../../core/utils'
 
 export interface PageMetaPluginOptions {
   dev?: boolean
@@ -90,7 +91,7 @@ export const PageMetaPlugin = createUnplugin((options: PageMetaPluginOptions) =>
       if (!hasMacro && !code.includes('export { default }') && !code.includes('__nuxt_page_meta')) {
         if (!code) {
           s.append(CODE_EMPTY + (options.dev ? CODE_HMR : ''))
-          const { pathname } = parseURL(decodeURIComponent(pathToFileURL(id).href))
+          const { pathname } = parseId(id)
           logger.error(`The file \`${pathname}\` is not a valid page as it has no content.`)
         } else {
           s.overwrite(0, code.length, CODE_EMPTY + (options.dev ? CODE_HMR : ''))

--- a/packages/nuxt/src/pages/plugins/page-meta.ts
+++ b/packages/nuxt/src/pages/plugins/page-meta.ts
@@ -182,6 +182,7 @@ function rewriteQuery (id: string) {
 }
 
 function parseMacroQuery (id: string) {
+  id = id.replace(/^(virtual:nuxt:|virtual:)/, '')
   const { search } = parseURL(decodeURIComponent(isAbsolute(id) ? pathToFileURL(id).href : id).replace(/\?macro=true$/, ''))
   const query = parseQuery(search)
   if (id.includes('?macro=true')) {

--- a/packages/vite/src/plugins/composable-keys.ts
+++ b/packages/vite/src/plugins/composable-keys.ts
@@ -1,4 +1,3 @@
-import { pathToFileURL } from 'node:url'
 import { createUnplugin } from 'unplugin'
 import { isAbsolute, relative } from 'pathe'
 import type { Node } from 'estree-walker'
@@ -9,7 +8,7 @@ import type { CallExpression, Pattern } from 'estree'
 import { parseQuery, parseURL } from 'ufo'
 import escapeRE from 'escape-string-regexp'
 import { findStaticImports, parseStaticImport } from 'mlly'
-import { matchWithStringOrRegex } from '../utils'
+import { matchWithStringOrRegex, parseId } from '../utils'
 
 interface ComposableKeysOptions {
   sourcemap: boolean
@@ -32,7 +31,7 @@ export const composableKeysPlugin = createUnplugin((options: ComposableKeysOptio
     name: 'nuxt:composable-keys',
     enforce: 'post',
     transformInclude (id) {
-      const { pathname, search } = parseURL(decodeURIComponent(pathToFileURL(id).href))
+      const { pathname, search } = parseId(id)
       return !NUXT_LIB_RE.test(pathname) && SUPPORTED_EXT_RE.test(pathname) && parseQuery(search).type !== 'style' && !parseQuery(search).macro
     },
     transform (code, id) {

--- a/packages/vite/src/plugins/paths.ts
+++ b/packages/vite/src/plugins/paths.ts
@@ -1,8 +1,8 @@
 import { pathToFileURL } from 'node:url'
 import MagicString from 'magic-string'
-import { parseQuery, parseURL } from 'ufo'
+import { parseQuery } from 'ufo'
 import type { Plugin } from 'vite'
-import { isCSS } from '../utils'
+import { isCSS, parseId } from '../utils'
 
 interface RuntimePathsOptions {
   sourcemap?: boolean
@@ -15,7 +15,7 @@ export function runtimePathsPlugin (options: RuntimePathsOptions): Plugin {
     name: 'nuxt:runtime-paths-dep',
     enforce: 'post',
     transform (code, id) {
-      const { pathname, search } = parseURL(decodeURIComponent(pathToFileURL(id).href))
+      const { pathname, search } = parseId(id)
 
       // skip import into css files
       if (isCSS(pathname)) { return }

--- a/packages/vite/src/plugins/paths.ts
+++ b/packages/vite/src/plugins/paths.ts
@@ -1,4 +1,3 @@
-import { pathToFileURL } from 'node:url'
 import MagicString from 'magic-string'
 import { parseQuery } from 'ufo'
 import type { Plugin } from 'vite'

--- a/packages/vite/src/plugins/ssr-styles.ts
+++ b/packages/vite/src/plugins/ssr-styles.ts
@@ -1,14 +1,13 @@
-import { pathToFileURL } from 'node:url'
 import type { Plugin } from 'vite'
 import { dirname, relative } from 'pathe'
 import { genImport, genObjectFromRawEntries } from 'knitwork'
 import { filename } from 'pathe/utils'
-import { parseQuery, parseURL } from 'ufo'
+import { parseQuery } from 'ufo'
 import type { Component } from '@nuxt/schema'
 import MagicString from 'magic-string'
 import { findStaticImports } from 'mlly'
 
-import { isCSS } from '../utils'
+import { isCSS, parseId } from '../utils'
 
 interface SSRStylePluginOptions {
   srcDir: string
@@ -161,7 +160,7 @@ export function ssrStylesPlugin (options: SSRStylePluginOptions): Plugin {
         return
       }
 
-      const { pathname, search } = parseURL(decodeURIComponent(pathToFileURL(id).href))
+      const { pathname, search } = parseId(id)
 
       if (!(id in options.clientCSSMap) && !islands.some(c => c.filePath === pathname)) { return }
 

--- a/packages/vite/src/utils/index.ts
+++ b/packages/vite/src/utils/index.ts
@@ -1,4 +1,7 @@
+import { pathToFileURL } from 'node:url'
 import { hash } from 'ohash'
+import { isAbsolute } from 'pathe'
+import { parseURL } from 'ufo'
 
 export function uniq<T> (arr: T[]): T[] {
   return Array.from(new Set(arr))
@@ -23,4 +26,9 @@ export function matchWithStringOrRegex (value: string, matcher: string | RegExp)
   }
 
   return false
+}
+
+export function parseId (id: string) {
+  id = id.replace(/^(virtual:nuxt:|virtual:)/, '')
+  return parseURL(decodeURIComponent(isAbsolute(id) ? pathToFileURL(id).href : id))
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/24103

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This addresses an issue surfacing in Node 20 that it will now warn (and ultimately throw in a future version) if we are passing it invalid URLs.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
