### PR TITLE
fix(vite): normalise entry id for `typeCheck` plugin

### DIFF
--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -135,7 +135,7 @@ export async function buildClient (ctx: ViteBuildContext) {
   }
 
   // Add type checking client panel
-  if (ctx.nuxt.options.typescript.typeCheck && ctx.nuxt.options.dev) {
+  if (ctx.nuxt.options.typescript.typeCheck === true && ctx.nuxt.options.dev) {
     clientConfig.plugins!.push(typeCheckPlugin({ sourcemap: !!ctx.nuxt.options.sourcemap.client }))
   }
 

--- a/packages/vite/src/plugins/type-check.ts
+++ b/packages/vite/src/plugins/type-check.ts
@@ -1,7 +1,7 @@
 import MagicString from 'magic-string'
 import type { Plugin } from 'vite'
 
-const MODULE_ID_RE = /([^?]+)(?:[?].+)?/
+const QUERY_RE = /\?.+$/
 
 export function typeCheckPlugin (options: { sourcemap?: boolean } = {}): Plugin {
   let entry: string

--- a/packages/vite/src/plugins/type-check.ts
+++ b/packages/vite/src/plugins/type-check.ts
@@ -14,7 +14,7 @@ export function typeCheckPlugin (options: { sourcemap?: boolean } = {}): Plugin 
       }
     },
     transform (code, id) {
-      if (id.replace(MODULE_ID_RE, '$1') !== entry) { return }
+      if (id.replace(QUERY_RE, '') !== entry) { return }
 
       const s = new MagicString(code)
 

--- a/packages/vite/src/plugins/type-check.ts
+++ b/packages/vite/src/plugins/type-check.ts
@@ -1,6 +1,8 @@
 import MagicString from 'magic-string'
 import type { Plugin } from 'vite'
 
+const MODULE_ID_RE = /([^?]+)(?:[?].+)?/
+
 export function typeCheckPlugin (options: { sourcemap?: boolean } = {}): Plugin {
   let entry: string
   return {
@@ -12,7 +14,7 @@ export function typeCheckPlugin (options: { sourcemap?: boolean } = {}): Plugin 
       }
     },
     transform (code, id) {
-      if (id !== entry) { return }
+      if (id.replace(MODULE_ID_RE, '$1') !== entry) { return }
 
       const s = new MagicString(code)
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

resolves #24113

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Update `type-check` vite plugin to also operate on modules `id` having a query string, allowing to match app entrypoints as designed.

Update `vite` client configuration so as to not enable the `type-check` plugin when `typeCheck: 'build'` is set, which would provoke a `module not found error` since the plugin is only added to vite configuration in `development` when  `typeCheck: true`: https://github.com/nuxt/nuxt/blob/c6fc69037d6709ae4ce83f44a7eae85acc743248/packages/vite/src/vite.ts#L133-L141

Resolves #24113

### 📝 Checklist

- [X] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
