### PR TITLE
chore: add `sass` to dependencies

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -28,7 +28,8 @@
     "@types/terser-webpack-plugin": "4.2.1",
     "@types/webpack": "^4.41.35",
     "@types/webpack-bundle-analyzer": "3.9.5",
-    "@types/webpack-hot-middleware": "2.25.5"
+    "@types/webpack-hot-middleware": "2.25.5",
+    "sass": "1.69.5"
   },
   "engines": {
     "node": "^14.18.0 || >=16.10.0"


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Running `tsc` on a project that does not have `sass` installed will result in an error.
I don't want to get type errors if `sass` is not installed.

```log
node_modules/@nuxt/types/lib/sass-loader/interfaces.d.ts:1:23 - error TS2307: Cannot find module 'sass' or its corresponding type declarations.

1 import * as Sass from 'sass'
                        ~~~~~~


Found 1 error in node_modules/@nuxt/types/lib/sass-loader/interfaces.d.ts:1
```

I wanted to solve this problem without adding a package, but it was difficult.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
