### PR TITLE
fix(vite): skip warming up node builtins

### DIFF
--- a/packages/vite/src/utils/warmup.ts
+++ b/packages/vite/src/utils/warmup.ts
@@ -1,3 +1,4 @@
+import { isBuiltin } from 'node:module'
 import { logger } from '@nuxt/kit'
 import { join, normalize, relative } from 'pathe'
 import { withoutBase } from 'ufo'
@@ -39,7 +40,7 @@ export async function warmupViteServer (
     try {
       url = normaliseURL(url, server.config.base)
 
-      if (warmedUrls.has(url)) { return }
+      if (warmedUrls.has(url) || isBuiltin(url)) { return }
       const m = await server.moduleGraph.getModuleByUrl(url, isServer)
       // a module that is already compiled (and can't be warmed up anyway)
       if (m?.transformResult?.code || m?.ssrTransformResult?.code) {


### PR DESCRIPTION
resolves https://github.com/nuxt/nuxt/issues/24154

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We wrongly are trying to warm up node builtins, which ... is not ideal. It's not a fatal error but probably costs us some time.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
