### PR TITLE
test: add route-provider e2e test

### DIFF
--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1291,6 +1291,17 @@ describe('page key', () => {
   })
 })
 
+describe('route provider', () => {
+  it('should preserve current route when navigation is suspended', async () => {
+    const { page } = await renderPage('/route-provider/foo')
+    await page.click('[href="/route-provider/bar"]')
+    expect(await page.getByTestId('foo').innerText()).toMatchInlineSnapshot('"foo: /route-provider/foo - /route-provider/foo"')
+    expect(await page.getByTestId('bar').innerText()).toMatchInlineSnapshot('"bar: /route-provider/bar - /route-provider/bar"')
+
+    await page.close()
+  })
+})
+
 // Bug #6592
 describe('layout change not load page twice', () => {
   const cases = {

--- a/test/fixtures/basic/pages/route-provider/index.vue
+++ b/test/fixtures/basic/pages/route-provider/index.vue
@@ -1,0 +1,11 @@
+<template>
+  <div>
+    <NuxtPage />
+    <NuxtLink to="/route-provider/foo">
+      foo
+    </NuxtLink>
+    <NuxtLink to="/route-provider/bar">
+      bar
+    </NuxtLink>
+  </div>
+</template>

--- a/test/fixtures/basic/pages/route-provider/index/bar.vue
+++ b/test/fixtures/basic/pages/route-provider/index/bar.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+const route = useRoute()
+await new Promise(resolve => setTimeout(resolve, 100))
+</script>
+
+<template>
+  <div data-testid="bar">
+    bar: {{ $route.path }} - {{ route.path }}
+  </div>
+</template>
+
+<style scoped>
+
+</style>

--- a/test/fixtures/basic/pages/route-provider/index/foo.vue
+++ b/test/fixtures/basic/pages/route-provider/index/foo.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+const route = useRoute()
+await new Promise(resolve => setTimeout(resolve, 100))
+</script>
+
+<template>
+  <div data-testid="foo">
+    foo: {{ $route.path }} - {{ route.path }}
+  </div>
+</template>
+
+<style scoped>
+
+</style>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

https://github.com/nuxt/nuxt/pull/24024

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds a test for correct behaviour when navigating between routes with suspense - the existing route should be maintained.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
