### PR TITLE
fix(nuxt): handle multi-line slots in islands

### DIFF
--- a/packages/nuxt/src/components/islandsTransform.ts
+++ b/packages/nuxt/src/components/islandsTransform.ts
@@ -97,7 +97,7 @@ function isBinding (attr: string): boolean {
 
 function getBindings (bindings: Record<string, string>, vfor?: [string, string]): string {
   if (Object.keys(bindings).length === 0) { return '' }
-  const content = Object.entries(bindings).filter(b => b[0] !== '_bind').map(([name, value]) => isBinding(name) ? `${name.slice(1)}: ${value}` : `${name}: \`${value}\``).join(',')
+  const content = Object.entries(bindings).filter(b => b[0] && b[0] !== '_bind').map(([name, value]) => isBinding(name) ? `${name.slice(1)}: ${value}` : `${name}: \`${value}\``).join(',')
   const data = bindings._bind ? `mergeProps(${bindings._bind}, { ${content} })` : `{ ${content} }`
   if (!vfor) {
     return `:nuxt-ssr-slot-data="JSON.stringify([${data}])"`

--- a/packages/nuxt/test/islandTransform.test.ts
+++ b/packages/nuxt/test/islandTransform.test.ts
@@ -34,11 +34,15 @@ describe('islandTransform - server and island components', () => {
         <slot />
 
         <slot name="named" :some-data="someData" />
+        <slot
+          name="other"
+          :some-data="someData"
+        />
       </div>
       </template>
       <script setup lang="ts">
       const someData = 'some data'
-      
+
       </script>`
       , 'hello.server.vue')
 
@@ -48,12 +52,13 @@ describe('islandTransform - server and island components', () => {
                 <div style=\\"display: contents;\\" nuxt-ssr-slot-name=\\"default\\" />
 
                 <div style=\\"display: contents;\\" nuxt-ssr-slot-name=\\"named\\" :nuxt-ssr-slot-data=\\"JSON.stringify([{ some-data: someData }])\\"/>
+                <div style=\\"display: contents;\\" nuxt-ssr-slot-name=\\"other\\" :nuxt-ssr-slot-data=\\"JSON.stringify([{ some-data: someData }])\\"/>
               </div>
               </template>
               <script setup lang=\\"ts\\">
         import { vforToArray as __vforToArray } from '#app/components/utils'
               const someData = 'some data'
-              
+
               </script>"
       `)
     })
@@ -68,7 +73,7 @@ describe('islandTransform - server and island components', () => {
       </template>
       <script setup lang="ts">
       const someData = 'some data'
-      
+
       </script>`
       , 'hello.server.vue')
 
@@ -83,7 +88,7 @@ describe('islandTransform - server and island components', () => {
               <script setup lang=\\"ts\\">
         import { vforToArray as __vforToArray } from '#app/components/utils'
               const someData = 'some data'
-              
+
               </script>"
       `)
     })
@@ -109,13 +114,13 @@ describe('islandTransform - server and island components', () => {
         </UCard>
       </div>
     </template>
-    
+
     <script setup lang="ts">
     export interface Props {
       count?: number;
     }
     const props = withDefaults(defineProps<Props>(), { count: 0 });
-    
+
     const message = "Hello World";
     </script>
     `
@@ -142,14 +147,14 @@ describe('islandTransform - server and island components', () => {
                 </UCard>
               </div>
             </template>
-            
+
             <script setup lang=\\"ts\\">
         import { vforToArray as __vforToArray } from '#app/components/utils'
             export interface Props {
               count?: number;
             }
             const props = withDefaults(defineProps<Props>(), { count: 0 });
-            
+
             const message = \\"Hello World\\";
             </script>
             "


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/pull/24209

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This fixes an issue parsing multiline slots, where an 'undefined' attribute ended up producing code like this:

```vue
<div style=\"display: contents;\" nuxt-ssr-slot-name=\"other\" :nuxt-ssr-slot-data=\"JSON.stringify([{ : ``,some-data: someData }])\"/>
```

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
