### PR TITLE
Update server documentation: auto import/exports caveats

### DIFF
--- a/docs/2.guide/2.directory-structure/1.server.md
+++ b/docs/2.guide/2.directory-structure/1.server.md
@@ -502,15 +502,14 @@ export default defineNuxtConfig({
 
 Not every directory in `./server` is imported into other files.
 
-`User` is exported from this file automatically.
+`Wizard` is exported from this file automatically.
 
-```ts [./server/models/user.model.ts]
-export const User = ''
+```ts [./server/apis/wizards.get.ts]
+export const Wizard = ''
 ```
 
-`User` is not exported from this file automatically.
+`Wizard` is not exported from this file automatically.
 
-```ts [./server/Models/user.model.ts]
-export const User = ''
+```ts [./server/apis/wizards.get.ts]
+export const Wizard = ''
 ```
-

--- a/docs/2.guide/2.directory-structure/1.server.md
+++ b/docs/2.guide/2.directory-structure/1.server.md
@@ -513,3 +513,27 @@ export const Wizard = ''
 ```ts [./server/Models/wizards.model.ts]
 export const Wizard = ''
 ```
+
+### Type suggestions don't work without additional exports from utils.
+
+Types defined in `./server/models/wizard.model.ts` must be exported
+
+```ts [./server/models/wizards.model.ts]
+export type WizardType = {
+  firstName: String
+  lastName: String
+}
+```
+
+Then imported & exported from `./utils/wizard.ts` before they can be used inside of frontend code.
+
+```ts [./utils/wizard.ts]
+export type { WizardType } from '~/server/Models/wizard.model'
+```
+
+But they must also include a const export to get type suggestions.
+
+```ts [./utils/wizard.ts]
+export type { WizardType } from '~/server/Models/wizard.model'
+export const pet = 'Hedwig'
+```

--- a/docs/2.guide/2.directory-structure/1.server.md
+++ b/docs/2.guide/2.directory-structure/1.server.md
@@ -504,12 +504,12 @@ Not every directory in `./server` is imported into other files.
 
 `Wizard` is exported from this file automatically.
 
-```ts [./server/apis/wizards.get.ts]
+```ts [./server/models/wizards.model.ts]
 export const Wizard = ''
 ```
 
 `Wizard` is not exported from this file automatically.
 
-```ts [./server/apis/wizards.get.ts]
+```ts [./server/Models/wizards.model.ts]
 export const Wizard = ''
 ```

--- a/docs/2.guide/2.directory-structure/1.server.md
+++ b/docs/2.guide/2.directory-structure/1.server.md
@@ -498,7 +498,7 @@ export default defineNuxtConfig({
 
 
 
-### Cavets on Auto import/export
+### Caveats on Auto import/export
 
 Not every directory in `./server` is imported into other files.
 

--- a/docs/2.guide/2.directory-structure/1.server.md
+++ b/docs/2.guide/2.directory-structure/1.server.md
@@ -494,3 +494,23 @@ export default defineNuxtConfig({
 })
 ```
 ::
+
+
+
+
+### Cavets on Auto import/export
+
+Not every directory in `./server` is imported into other files.
+
+`User` is exported from this file automatically.
+
+```ts [./server/models/user.model.ts]
+export const User = ''
+```
+
+`User` is not exported from this file automatically.
+
+```ts [./server/Models/user.model.ts]
+export const User = ''
+```
+


### PR DESCRIPTION
### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Add additional context on what is auto imported/exported from `./server` so that future developers know the caveats of auto import/export

<img width="1035" alt="Screenshot 2023-11-15 at 10 42 58 PM" src="https://github.com/nuxt/nuxt/assets/16382165/6e541517-c5ab-415f-9dc3-0349a8b6314c">


I see builds failing in CI/CD when I change casing from `./server/models/models.model.ts` to `./server/Models/models.model.ts`

Please let me know if this shouldn't be the case.

### 📝 Checklist

- [x] I have updated the documentation accordingly.
