### PR TITLE
feat(kit): support prepend option for `addComponentsDir`

### DIFF
--- a/packages/kit/src/components.ts
+++ b/packages/kit/src/components.ts
@@ -9,12 +9,12 @@ import { logger } from './logger'
  *
  * Requires Nuxt 2.13+
  */
-export async function addComponentsDir (dir: ComponentsDir) {
+export async function addComponentsDir (dir: ComponentsDir, opts: { prepend?: boolean } = {}) {
   const nuxt = useNuxt()
   await assertNuxtCompatibility({ nuxt: '>=2.13' }, nuxt)
   nuxt.options.components = nuxt.options.components || []
   dir.priority ||= 0
-  nuxt.hook('components:dirs', (dirs) => { dirs.push(dir) })
+  nuxt.hook('components:dirs', (dirs) => { dirs[opts.prepend ? 'unshift' : 'push'](dir) })
 }
 
 export type AddComponentOptions = { name: string, filePath: string } & Partial<Exclude<Component,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Default Nuxt config for auto-import directories

```
[
  { priority: 1, path: 'D:/Test/nuxt-test/components/islands', island: true },
  { priority: 1, path: 'D:/Test/nuxt-test/components/global', global: true },
  { priority: 1, path: 'D:/Test/nuxt-test/components' },
]
```

In Nuxt [website](https://nuxt.com/docs/guide/directory-structure/components#:~:text=You%20can%20also%20selectively%20register%20some%20components%20globally%20by%20placing%20them%20in%20a%20~/components/global%20directory.&text=You%20can%20also%20selectively%20register%20some%20components%20globally%20by%20placing%20them%20in%20a%20~/components/global%20directory.&text=You%20can%20also%20selectively%20register%20some%20components%20globally%20by%20placing%20them%20in%20a%20~/components/global%20directory.) it's says

> You can also selectively register some components globally by placing them in a `~/components/global` directory.

But if I add `components.dirs[]` options in `nuxt.config.ts` default config will disposed, and in order to have **global** directory I have to define it again

```
components: {
    dirs: [
        {
          path: '~/components/ui',
          prefix: 'Ui',
          pathPrefix: false
        }
    ]
}
```

I want to add a new dir to auto-import directories, to keep the default auto-import directories I prefer using

- `"components:dirs"` hooks (nuxt.config and defineNuxtModule)
- `addComponentsDir` in setup function (defineNuxtModule)

In the hook way, I can push/unshift directories but in `addComponentsDir` way it only has the `push` method

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
