### PR TITLE
fix(nuxt): decode page paths to be prerendered

### DIFF
--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -234,7 +234,7 @@ export default defineNuxtModule({
             // Skip dynamic paths
             if (page.path.includes(':')) { continue }
             const route = joinURL(currentPath, page.path)
-            prerenderRoutes.add(route)
+            prerenderRoutes.add(decodeURIComponent(route))
             if (page.children) { processPages(page.children, route) }
           }
         }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/22660

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We encode paths when creating vue-router paths. This is expected. But we were also passing fully encoded paths to nitro to fetch, meaning we got double encoded paths.

![CleanShot 2023-11-16 at 15 26 38](https://github.com/nuxt/nuxt/assets/28706372/382972dc-acb5-402b-9351-96b5482d77cc)

(We also need to merge https://github.com/unjs/nitro/pull/1914 to ensure that Nitro decodes paths scanned from rendered HTML.)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
