### PR TITLE
docs: warn about using `useRequestHeaders` in `useFetch`

### DIFF
--- a/docs/1.getting-started/6.data-fetching.md
+++ b/docs/1.getting-started/6.data-fetching.md
@@ -371,9 +371,13 @@ The example below adds the request headers to an isomorphic `$fetch` call to ens
 <script setup lang="ts">
 const headers = useRequestHeaders(['cookie'])
 
-const { data } = await useFetch('/api/me', { headers })
+const { data } = await useAsyncData(() => $fetch('/api/me', { headers }))
 </script>
 ```
+
+::callout
+We are not using `useFetch` here as `headers` would then form part of the automatically generated key, causing this result to mismatch between client and server.
+::
 
 ::callout
 Be very careful before proxying headers to an external API and just include headers that you need. Not all headers are safe to be bypassed and might introduce unwanted behavior. Here is a list of common headers that are NOT to be proxied:

--- a/docs/3.api/2.composables/use-request-headers.md
+++ b/docs/3.api/2.composables/use-request-headers.md
@@ -30,8 +30,13 @@ The example below adds the `authorization` request header to an isomorphic `$fet
 
 ```vue [pages/some-page.vue]
 <script setup lang="ts">
-const { data } = await useFetch('/api/confidential', {
-  headers: useRequestHeaders(['authorization'])
-})
+const headers = useRequestHeaders(['authorization'])
+const { data } = await useAsyncData(() => $fetch('/api/confidential', {
+  headers
+}))
 </script>
 ```
+
+::callout
+We are not using `useFetch` here as `headers` would then form part of the automatically generated key, causing this result to mismatch between client and server.
+::


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/23900

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This updates documentation to avoid using `useRequestHeaders` in `useFetch` calls, following https://github.com/nuxt/nuxt/pull/23462.

We could also consider reverting that change.

Thoughts welcome. 🙏 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
