### PR TITLE
docs: updated .gitignore in directory structure

### DIFF
--- a/docs/2.guide/2.directory-structure/2.gitignore.md
+++ b/docs/2.guide/2.directory-structure/2.gitignore.md
@@ -14,7 +14,11 @@ We recommend having a `.gitignore` file that has **at least** the following entr
 ```bash [.gitignore]
 # Nuxt dev/build outputs
 .output
+.data
 .nuxt
+.nitro
+.cache
+dist
 
 # Node dependencies
 node_modules
@@ -27,6 +31,7 @@ logs
 .DS_Store
 
 # Local env files
+.env
 .env.*
 !.env.example
 ```


### PR DESCRIPTION
### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)

### 📚 Description

Updated minimum recommended `.gitignore` to include entries for Nuxt dev/build outputs (matches nuxi generated file).

Most significantly **.env** has also been added, which is generated by nuxi but omitted from the docs. In it's current state the actual ".env" will not be ignored and added to source control - with potential to share secret credentials etc.

### 📝 Checklist

- [x] I have updated the documentation accordingly.
