### PR TITLE
fix(nuxt): avoid recursive ssr errors

### DIFF
--- a/packages/nuxt/src/core/runtime/nitro/error.ts
+++ b/packages/nuxt/src/core/runtime/nitro/error.ts
@@ -6,7 +6,7 @@ import { useRuntimeConfig } from '#internal/nitro'
 import { useNitroApp } from '#internal/nitro/app'
 import { isJsonRequest, normalizeError } from '#internal/nitro/utils'
 
-export default <NitroErrorHandler> async function errorhandler (error: H3Error, event) {
+export default <NitroErrorHandler>async function errorhandler(error: H3Error, event) {
   // Parse and normalize error
   const { stack, statusCode, statusMessage, message } = normalizeError(error)
 
@@ -45,14 +45,20 @@ export default <NitroErrorHandler> async function errorhandler (error: H3Error, 
     return send(event, JSON.stringify(errorObject))
   }
 
+  // Access request headers
+  const reqHeaders = getRequestHeaders(event)
+
+  // Detect to avoid recusrion in SSR rendering of errors
+  const isRenderingError = event.path.startsWith('/__nuxt_error') || !!reqHeaders['x-nuxt-error']
+
   // HTML response (via SSR)
-  const isErrorPage = event.path.startsWith('/__nuxt_error')
-  const res = !isErrorPage
-    ? await useNitroApp().localFetch(withQuery(joinURL(useRuntimeConfig().app.baseURL, '/__nuxt_error'), errorObject), {
-      headers: getRequestHeaders(event) as Record<string, string>,
+  const res = isRenderingError ? null : await useNitroApp().localFetch(
+    withQuery(joinURL(useRuntimeConfig().app.baseURL, '/__nuxt_error'), errorObject),
+    {
+      headers: { ...reqHeaders, 'x-nuxt-error': 'true' },
       redirect: 'manual'
-    }).catch(() => null)
-    : null
+    }
+  ).catch(() => null)
 
   // Fallback to static rendered error page
   if (!res) {

--- a/packages/nuxt/src/core/runtime/nitro/error.ts
+++ b/packages/nuxt/src/core/runtime/nitro/error.ts
@@ -48,7 +48,7 @@ export default <NitroErrorHandler> async function errorhandler (error: H3Error, 
   // Access request headers
   const reqHeaders = getRequestHeaders(event)
 
-  // Detect to avoid recusrion in SSR rendering of errors
+  // Detect to avoid recursion in SSR rendering of errors
   const isRenderingError = event.path.startsWith('/__nuxt_error') || !!reqHeaders['x-nuxt-error']
 
   // HTML response (via SSR)

--- a/packages/nuxt/src/core/runtime/nitro/error.ts
+++ b/packages/nuxt/src/core/runtime/nitro/error.ts
@@ -6,7 +6,7 @@ import { useRuntimeConfig } from '#internal/nitro'
 import { useNitroApp } from '#internal/nitro/app'
 import { isJsonRequest, normalizeError } from '#internal/nitro/utils'
 
-export default <NitroErrorHandler>async function errorhandler(error: H3Error, event) {
+export default <NitroErrorHandler> async function errorhandler (error: H3Error, event) {
   // Parse and normalize error
   const { stack, statusCode, statusMessage, message } = normalizeError(error)
 

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -814,6 +814,17 @@ describe('errors', () => {
         "url": "/__nuxt_error",
       }
     `)
+
+    it('should not recursively throw an error when there is an error rendering the error page', async () => {
+      const res = await $fetch('/', {
+        headers: {
+          'x-recurse': 'true',
+          accept: 'text/html'
+        }
+      })
+      expect(typeof res).toBe('string')
+      expect(res).toContain('Hello Nuxt 3!')
+    })
   })
 
   // TODO: need to create test for webpack

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -818,7 +818,7 @@ describe('errors', () => {
     it('should not recursively throw an error when there is an error rendering the error page', async () => {
       const res = await $fetch('/', {
         headers: {
-          'x-recurse': 'true',
+          'x-test-recurse-error': 'true',
           accept: 'text/html'
         }
       })

--- a/test/fixtures/basic/plugins/error.server.ts
+++ b/test/fixtures/basic/plugins/error.server.ts
@@ -1,5 +1,5 @@
 export default defineNuxtPlugin(async () => {
-  if (useRequestHeaders(['x-recurse'])['x-recurse']) {
+  if (useRequestHeaders(['x-test-recurse-error'])['x-test-recurse-error']) {
     await useRequestFetch()('/api/error').catch(() => {})
   }
 })

--- a/test/fixtures/basic/plugins/error.server.ts
+++ b/test/fixtures/basic/plugins/error.server.ts
@@ -1,0 +1,5 @@
+export default defineNuxtPlugin(async () => {
+  if (useRequestHeaders(['x-recurse'])['x-recurse']) {
+    await useRequestFetch()('/api/error').catch(() => {})
+  }
+})

--- a/test/fixtures/basic/server/api/error.ts
+++ b/test/fixtures/basic/server/api/error.ts
@@ -1,0 +1,3 @@
+export default defineEventHandler(async () => {
+  throw createError({ statusCode: 400 })
+})


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

resolves #24393

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Nitro's default error handler is set to a custom Nuxt handler that unless the incoming request is from a json client, always prefers SSR rendering. If an error happens during SSR rendering of error page by making another fetch call, we will end up with an infinity loop.

This PR fixes issue by setting a custom header to the first error rendering phase and if we see the same header in a subsequent one, we simply fallback to the static HTML one that wouldn't cause recursion.

As a much much better improvement we could (and i believe we should) skip all plugins and nuxt middleware by default when rendering error page and allow opting-in using meta as current behavior can potentially plugins to misbehave in rendering errro pages but i guess is something of a bigger discussion as this would be a breaking change.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
