### PR TITLE
perf: cache nuxt config during static site generation

### DIFF
--- a/packages/cli/src/command.js
+++ b/packages/cli/src/command.js
@@ -100,7 +100,7 @@ export default class NuxtCommand extends Hookable {
     return this._parsedArgv
   }
 
-  async getNuxtConfig (extraOptions = {}) {
+  async getNuxtConfig (extraOptions = {}, loadOptions = {}) {
     // Flag to indicate nuxt is running with CLI (not programmatic)
     extraOptions._cli = true
 
@@ -109,7 +109,7 @@ export default class NuxtCommand extends Hookable {
       dev: !!extraOptions.dev
     }
 
-    const config = await loadNuxtConfig(this.argv, context)
+    const config = await loadNuxtConfig(this.argv, context, loadOptions)
     const options = Object.assign(config, extraOptions)
 
     for (const name of Object.keys(this.cmd.options)) {

--- a/packages/cli/src/utils/config.js
+++ b/packages/cli/src/utils/config.js
@@ -2,11 +2,12 @@ import path from 'path'
 import { defu } from 'defu'
 import { loadNuxtConfig as _loadNuxtConfig, getDefaultNuxtConfig } from '@nuxt/config'
 
-export async function loadNuxtConfig (argv, configContext) {
+export async function loadNuxtConfig (argv, configContext, loadOptions = {}) {
   const rootDir = path.resolve(argv._[0] || '.')
   const configFile = argv['config-file']
 
   // Load config
+  const { shouldClearRequireCache = true } = loadOptions
   const options = await _loadNuxtConfig({
     rootDir,
     configFile,
@@ -14,7 +15,8 @@ export async function loadNuxtConfig (argv, configContext) {
     envConfig: {
       dotenv: argv.dotenv === 'false' ? false : argv.dotenv,
       env: argv.processenv ? process.env : {}
-    }
+    },
+    shouldClearRequireCache
   })
 
   if (argv.spa === true) {

--- a/packages/cli/src/utils/generate.js
+++ b/packages/cli/src/utils/generate.js
@@ -128,7 +128,7 @@ export async function ensureBuild (cmd) {
 }
 
 async function getNuxt (args, cmd) {
-  const config = await cmd.getNuxtConfig({ dev: false, ...args })
+  const config = await cmd.getNuxtConfig({ dev: false, ...args }, { shouldClearRequireCache: false })
 
   if (config.target === TARGETS.static) {
     config._export = true

--- a/packages/cli/test/unit/command.test.js
+++ b/packages/cli/test/unit/command.test.js
@@ -81,7 +81,7 @@ describe('cli/command', () => {
       env: expect.objectContaining({
         NODE_ENV: 'test'
       })
-    })
+    }, {})
 
     loadConfigSpy.mockRestore()
   })

--- a/packages/config/src/load.js
+++ b/packages/config/src/load.js
@@ -13,7 +13,8 @@ export async function loadNuxtConfig ({
   envConfig = {},
   configFile = defaultNuxtConfigFile,
   configContext = {},
-  configOverrides = {}
+  configOverrides = {},
+  shouldClearRequireCache = true
 } = {}) {
   rootDir = path.resolve(rootDir)
 
@@ -51,8 +52,9 @@ export async function loadNuxtConfig ({
   }
 
   if (configFile) {
-    // Clear cache
-    clearRequireCache(configFile)
+    if (shouldClearRequireCache) {
+      clearRequireCache(configFile)
+    }
     options = _require(configFile) || {}
     if (options.default) {
       options = options.default

--- a/test/fixtures/full-static/nuxt.config.js
+++ b/test/fixtures/full-static/nuxt.config.js
@@ -1,10 +1,5 @@
 export default {
   target: 'static',
-  export: {
-    payload: {
-      config: true
-    }
-  },
   router: {
     // base: '/test',
   },
@@ -18,7 +13,7 @@ export default {
     x: 123
   },
   hooks: {
-    export: {
+    generate: {
       before ({ setPayload }) {
         setPayload({ shared: true })
       },


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

Resolves #10098

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The issue is that [getNuxtConfig()]() is being called 3 times during generation: [here](https://github.com/nuxt/nuxt/blob/853439ddf945b6ee358d5912e6e5a68009633c27/packages/cli/src/commands/generate.js#L64) and [here](https://github.com/nuxt/nuxt/blob/853439ddf945b6ee358d5912e6e5a68009633c27/packages/cli/src/utils/generate.js#L123) twice (once by [ensureBuild](https://github.com/nuxt/nuxt/blob/853439ddf945b6ee358d5912e6e5a68009633c27/packages/cli/src/utils/generate.js#L22) and [generate](https://github.com/nuxt/nuxt/blob/853439ddf945b6ee358d5912e6e5a68009633c27/packages/cli/src/utils/generate.js#L10)).

First, I thought about passing the config as a parameter to `ensureBuild` and `generate` so they don't have to load it again:

```js
const config = await cmd.getNuxtConfig({ dev: false })

...

// Full static
if (config.target === TARGETS.static) {
      await ensureBuild(cmd, config)
      await generate(cmd, config)
      return
}
```

But both functions are heavily mutating the config, so this lead to bugs. I didn't want to install a lib to deep copy this object, so the next best thing that came to my mind is to create an option to not clear the `require` cache. It's not the prettiest solution, because the boolean flag needs to be passed through multiple functions, but so far, this is the easiest fix I can think of. 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
