### PR TITLE
fix(vite): use `isBuiltin` polyfill for greater node support

### DIFF
--- a/packages/vite/src/utils/warmup.ts
+++ b/packages/vite/src/utils/warmup.ts
@@ -29,9 +29,9 @@ function normaliseURL (url: string, base: string) {
 }
 
 // TODO: remove when we drop support for node 18
-const builtinSet = new Set(builtinModules)
+const builtins = new Set(builtinModules)
 function isBuiltin (id: string) {
-  return id.startsWith('node:') || builtinSet.has(id)
+  return id.startsWith('node:') || builtins.has(id)
 }
 
 // TODO: use built-in warmup logic when we update to vite 5

--- a/packages/vite/src/utils/warmup.ts
+++ b/packages/vite/src/utils/warmup.ts
@@ -28,6 +28,7 @@ function normaliseURL (url: string, base: string) {
   return url
 }
 
+// TODO: remove when we drop support for node 18
 const builtinSet = new Set(builtinModules)
 function isBuiltin (id: string) {
   return id.startsWith('node:') || builtinSet.has(id)

--- a/packages/vite/src/utils/warmup.ts
+++ b/packages/vite/src/utils/warmup.ts
@@ -1,4 +1,4 @@
-import { isBuiltin } from 'node:module'
+import { builtinModules } from 'node:module'
 import { logger } from '@nuxt/kit'
 import { join, normalize, relative } from 'pathe'
 import { withoutBase } from 'ufo'
@@ -26,6 +26,11 @@ function normaliseURL (url: string, base: string) {
   // strip query
   url = url.replace(/(\?|&)import=?(?:&|$)/, '').replace(/[?&]$/, '')
   return url
+}
+
+const builtinSet = new Set(builtinModules)
+function isBuiltin (id: string) {
+  return id.startsWith('node:') || builtinSet.has(id)
 }
 
 // TODO: use built-in warmup logic when we update to vite 5


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/24402

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This uses a simple polyfill of `isBuiltin` that we can keep until node 18 is no longer supported.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
