### PR TITLE
refactor(nuxt): opt-in to future `jiti.import` for schema

### DIFF
--- a/packages/nuxt/src/core/schema.ts
+++ b/packages/nuxt/src/core/schema.ts
@@ -104,7 +104,8 @@ export default defineNuxtModule({
         if (filePath && existsSync(filePath)) {
           let loadedConfig: SchemaDefinition
           try {
-            loadedConfig = _resolveSchema(filePath)
+            // TODO: fix type for second argument of `import`
+            loadedConfig = await _resolveSchema.import(filePath, {}) as SchemaDefinition
           } catch (err) {
             logger.warn(
               'Unable to load schema from',


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This opts us in to the new (async) `jiti.import` syntax. We're not using `jiti` directly at the moment (mostly via `c12`) but behaviour change will come in a future major of `jiti`.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
