### PR TITLE
docs: warn about using different env variables for `runtimeConfig`

### DIFF
--- a/docs/2.guide/3.going-further/10.runtime-config.md
+++ b/docs/2.guide/3.going-further/10.runtime-config.md
@@ -67,7 +67,6 @@ It is advised to use the envrionment variables that match the structure of your 
 ```sh [.env]
 NUXT_API_SECRET=api_secret_token
 NUXT_PUBLIC_API_BASE=https://nuxtjs.org
-SOME_OTHER_VAR=true
 ```
 
 ```ts [nuxt.config.ts]

--- a/docs/2.guide/3.going-further/10.runtime-config.md
+++ b/docs/2.guide/3.going-further/10.runtime-config.md
@@ -20,7 +20,6 @@ export default defineNuxtConfig({
 })
 ```
 
-
 When adding `apiBase` to the `runtimeConfig.public`, Nuxt adds it to each page payload. We can universally access `apiBase` in both server and browser.
 
 ```ts

--- a/docs/2.guide/3.going-further/10.runtime-config.md
+++ b/docs/2.guide/3.going-further/10.runtime-config.md
@@ -58,7 +58,7 @@ There are two key requirements:
 
 ::callout{color="amber" icon="i-ph-warning-duotone"}
 Setting the default of `runtimeConfig` values to a *different environment variable* (for example setting `myVar` to `process.env.OTHER_VARIABLE`) will only work during build-time and will break on runtime.
-It is advised to use the envrionment variables that match the structure of your `runtimeConfig` object.
+It is advised to use environment variables that match the structure of your `runtimeConfig` object.
 ::
 
 #### Example

--- a/docs/2.guide/3.going-further/10.runtime-config.md
+++ b/docs/2.guide/3.going-further/10.runtime-config.md
@@ -20,6 +20,7 @@ export default defineNuxtConfig({
 })
 ```
 
+
 When adding `apiBase` to the `runtimeConfig.public`, Nuxt adds it to each page payload. We can universally access `apiBase` in both server and browser.
 
 ```ts
@@ -56,11 +57,17 @@ There are two key requirements:
 
 1. Only a specially-named environment variable can override a runtime config property. That is, an uppercase environment variable starting with `NUXT_` which uses `_` to separate keys and case changes.
 
+::callout{color="amber" icon="i-ph-warning-duotone"}
+Setting the default of `runtimeConfig` values to a *different environment variable* (for example setting `myVar` to `process.env.OTHER_VARIABLE`) will only work during build-time and will break on runtime.
+It is advised to use the envrionment variables that match the structure of your `runtimeConfig` object.
+::
+
 #### Example
 
 ```sh [.env]
 NUXT_API_SECRET=api_secret_token
 NUXT_PUBLIC_API_BASE=https://nuxtjs.org
+SOME_OTHER_VAR=true
 ```
 
 ```ts [nuxt.config.ts]

--- a/docs/2.guide/3.going-further/10.runtime-config.md
+++ b/docs/2.guide/3.going-further/10.runtime-config.md
@@ -57,7 +57,7 @@ There are two key requirements:
 1. Only a specially-named environment variable can override a runtime config property. That is, an uppercase environment variable starting with `NUXT_` which uses `_` to separate keys and case changes.
 
 ::callout{color="amber" icon="i-ph-warning-duotone"}
-Setting the default of `runtimeConfig` values to a *different environment variable* (for example setting `myVar` to `process.env.OTHER_VARIABLE`) will only work during build-time and will break on runtime.
+Setting the default of `runtimeConfig` values to *differently named environment variables* (for example setting `myVar` to `process.env.OTHER_VARIABLE`) will only work during build-time and will break on runtime.
 It is advised to use environment variables that match the structure of your `runtimeConfig` object.
 ::
 


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I've seen the pattern a few times, causing issues during runtime.

```ts
export default defineNuxtConfig({
  runtimeConfig: {
    apiSecret: process.env.SOME_OTHER_VALUE, // This will break when trying to set SOME_OTHER_VALUE during runtime
    apiKey: process.env.API_KEY.trim(), // This won't transform values when setting API_KEY during runtime
  },
})
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
