### PR TITLE
fix(nuxt): merge and apply layer hooks

### DIFF
--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -51,7 +51,11 @@ export function createNuxt (options: NuxtOptions): Nuxt {
 
 async function initNuxt (nuxt: Nuxt) {
   // Register user hooks
-  nuxt.hooks.addHooks(nuxt.options.hooks)
+  for (const config of nuxt.options._layers.map(layer => layer.config).reverse()) {
+    if (config.hooks) {
+      nuxt.hooks.addHooks(config.hooks)
+    }
+  }
 
   // Set nuxt instance for useNuxt
   nuxtCtx.set(nuxt)

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -51,12 +51,7 @@ export function createNuxt (options: NuxtOptions): Nuxt {
 
 async function initNuxt (nuxt: Nuxt) {
   // Register user hooks
-  let hooks: NuxtConfig['hooks'] = {}
-  for (const config of nuxt.options._layers.map(layer => layer.config).reverse()) {
-    if (config.hooks) {
-      mergeHooks(hooks, config.hooks)
-    }
-  }
+  const hooks: NuxtConfig['hooks'] = mergeHooks(nuxt.options._layers.map(layer => layer.config.hooks).reverse()) || {}
   nuxt.hooks.addHooks(hooks)
 
   // Set nuxt instance for useNuxt

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -1,8 +1,8 @@
 import { join, normalize, relative, resolve } from 'pathe'
-import { createDebugger, createHooks, mergeHooks } from 'hookable'
+import { createDebugger, createHooks } from 'hookable'
 import type { LoadNuxtOptions } from '@nuxt/kit'
 import { addBuildPlugin, addComponent, addPlugin, addRouteMiddleware, addVitePlugin, addWebpackPlugin, installModule, loadNuxtConfig, logger, nuxtCtx, resolveAlias, resolveFiles, resolvePath, tryResolveModule, useNitro } from '@nuxt/kit'
-import type { Nuxt, NuxtConfig, NuxtHooks, NuxtOptions } from 'nuxt/schema'
+import type { Nuxt, NuxtHooks, NuxtOptions } from 'nuxt/schema'
 
 import escapeRE from 'escape-string-regexp'
 import fse from 'fs-extra'
@@ -51,8 +51,11 @@ export function createNuxt (options: NuxtOptions): Nuxt {
 
 async function initNuxt (nuxt: Nuxt) {
   // Register user hooks
-  const hooks: NuxtConfig['hooks'] = mergeHooks(nuxt.options._layers.map(layer => layer.config.hooks).reverse()) || {}
-  nuxt.hooks.addHooks(hooks)
+  for (const config of nuxt.options._layers.map(layer => layer.config).reverse()) {
+    if (config.hooks) {
+      nuxt.hooks.addHooks(config.hooks)
+    }
+  }
 
   // Set nuxt instance for useNuxt
   nuxtCtx.set(nuxt)

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -1,8 +1,8 @@
 import { join, normalize, relative, resolve } from 'pathe'
-import { createDebugger, createHooks } from 'hookable'
+import { createDebugger, createHooks, mergeHooks } from 'hookable'
 import type { LoadNuxtOptions } from '@nuxt/kit'
 import { addBuildPlugin, addComponent, addPlugin, addRouteMiddleware, addVitePlugin, addWebpackPlugin, installModule, loadNuxtConfig, logger, nuxtCtx, resolveAlias, resolveFiles, resolvePath, tryResolveModule, useNitro } from '@nuxt/kit'
-import type { Nuxt, NuxtHooks, NuxtOptions } from 'nuxt/schema'
+import type { Nuxt, NuxtConfig, NuxtHooks, NuxtOptions } from 'nuxt/schema'
 
 import escapeRE from 'escape-string-regexp'
 import fse from 'fs-extra'
@@ -51,11 +51,13 @@ export function createNuxt (options: NuxtOptions): Nuxt {
 
 async function initNuxt (nuxt: Nuxt) {
   // Register user hooks
+  let hooks: NuxtConfig['hooks'] = {}
   for (const config of nuxt.options._layers.map(layer => layer.config).reverse()) {
     if (config.hooks) {
-      nuxt.hooks.addHooks(config.hooks)
+      mergeHooks(hooks, config.hooks)
     }
   }
+  nuxt.hooks.addHooks(hooks)
 
   // Set nuxt instance for useNuxt
   nuxtCtx.set(nuxt)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/13367

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Rather than relying on `c12` to merge hooks, this simply iterates over layers to ensure all layer hooks are merged/respected in the final hookable instance.

We reverse the layer order to ensure that final user hooks run last, with layer hooks being added first.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
