### PR TITLE
feat(nuxt): add path to `error.data` when throwing 404 errors

### DIFF
--- a/packages/nuxt/src/app/plugins/router.ts
+++ b/packages/nuxt/src/app/plugins/router.ts
@@ -246,7 +246,10 @@ export default defineNuxtPlugin<{ route: Route, router: Router }>({
               if (result === false || result instanceof Error) {
                 const error = result || createError({
                   statusCode: 404,
-                  statusMessage: `Page Not Found: ${initialURL}`
+                  statusMessage: `Page Not Found: ${initialURL}`,
+                  data: {
+                    to
+                  }
                 })
                 delete nuxtApp._processingMiddleware
                 return nuxtApp.runWithContext(() => showError(error))

--- a/packages/nuxt/src/app/plugins/router.ts
+++ b/packages/nuxt/src/app/plugins/router.ts
@@ -248,7 +248,7 @@ export default defineNuxtPlugin<{ route: Route, router: Router }>({
                   statusCode: 404,
                   statusMessage: `Page Not Found: ${initialURL}`,
                   data: {
-                    path: to.fullPath
+                    path: initialURL
                   }
                 })
                 delete nuxtApp._processingMiddleware

--- a/packages/nuxt/src/app/plugins/router.ts
+++ b/packages/nuxt/src/app/plugins/router.ts
@@ -248,7 +248,7 @@ export default defineNuxtPlugin<{ route: Route, router: Router }>({
                   statusCode: 404,
                   statusMessage: `Page Not Found: ${initialURL}`,
                   data: {
-                    to
+                    path: to.fullPath
                   }
                 })
                 delete nuxtApp._processingMiddleware

--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -211,7 +211,7 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
           fatal: false,
           statusMessage: `Page not found: ${to.fullPath}`,
           data: {
-            to
+            path: to.fullPath
           }
         })))
       } else if (import.meta.server && to.redirectedFrom && to.fullPath !== initialURL) {

--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -209,7 +209,10 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
         await nuxtApp.runWithContext(() => showError(createError({
           statusCode: 404,
           fatal: false,
-          statusMessage: `Page not found: ${to.fullPath}`
+          statusMessage: `Page not found: ${to.fullPath}`,
+          data: {
+            to
+          }
         })))
       } else if (import.meta.server && to.redirectedFrom && to.fullPath !== initialURL) {
         await nuxtApp.runWithContext(() => navigateTo(to.fullPath || '/'))

--- a/packages/nuxt/src/pages/runtime/validate.ts
+++ b/packages/nuxt/src/pages/runtime/validate.ts
@@ -20,7 +20,7 @@ export default defineNuxtRouteMiddleware(async (to) => {
     statusCode: 404,
     statusMessage: `Page Not Found: ${to.fullPath}`,
     data: {
-      to
+      path: to.fullPath
     }
   })
   const unsub = router.beforeResolve((final) => {

--- a/packages/nuxt/src/pages/runtime/validate.ts
+++ b/packages/nuxt/src/pages/runtime/validate.ts
@@ -15,9 +15,13 @@ export default defineNuxtRouteMiddleware(async (to) => {
   if (import.meta.server) {
     return result
   }
+
   const error = createError({
     statusCode: 404,
-    statusMessage: `Page Not Found: ${to.fullPath}`
+    statusMessage: `Page Not Found: ${to.fullPath}`,
+    data: {
+      to
+    }
   })
   const unsub = router.beforeResolve((final) => {
     unsub()

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -155,6 +155,7 @@ describe('pages', () => {
 
     await page.getByText('should throw a 404 error').click()
     expect(await page.getByRole('heading').textContent()).toMatchInlineSnapshot('"Page Not Found: /forbidden"')
+    expect(await page.getByTestId('path').textContent()).toMatchInlineSnapshot('" Path: /forbidden"')
 
     await gotoPath(page, '/navigate-to-forbidden')
     await page.getByText('should be caught by catchall').click()

--- a/test/fixtures/basic/error.vue
+++ b/test/fixtures/basic/error.vue
@@ -3,6 +3,12 @@
     <div>
       <h1>{{ error?.message }}</h1>
       This is the error page 😱
+      <div
+        v-if="error?.data?.path"
+        data-testid="path"
+      >
+        Path: {{ error.data.path }}
+      </div>
     </div>
   </div>
 </template>


### PR DESCRIPTION
### 🔗 Linked issue

Resolves https://github.com/nuxt/nuxt/issues/24543

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When having an error thrown by a `false` value from `validate`, no info about the route can be obtained.
Same issue when Nuxt's `router.ts` creates a `404` error.

This PR adds the `fullPath` info from the `to` route as `error.data` in these cases as `path` key.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
