### PR TITLE
feat(kit): load `/module` or `/nuxt` module subpath if it exists

### DIFF
--- a/packages/kit/src/module/install.ts
+++ b/packages/kit/src/module/install.ts
@@ -61,19 +61,30 @@ export async function loadNuxtModuleInstance (nuxtModule: string | NuxtModule, n
   let buildTimeModuleMeta: ModuleMeta = {}
   // Import if input is string
   if (typeof nuxtModule === 'string') {
-    const src = await resolvePath(nuxtModule)
-    try {
+    const paths = [join(nuxtModule, 'module'), nuxtModule]
+    let error: unknown
+    for (const path of paths) {
+      const src = await resolvePath(path)
       // Prefer ESM resolution if possible
-      nuxtModule = await importModule(src, nuxt.options.modulesDir).catch(() => null) ?? requireModule(src, { paths: nuxt.options.modulesDir })
-    } catch (error: unknown) {
+      try {
+        nuxtModule = await importModule(src, nuxt.options.modulesDir).catch(() => null) ?? requireModule(src, { paths: nuxt.options.modulesDir })
+
+        // nuxt-module-builder generates a module.json with metadata including the version
+        if (existsSync(join(dirname(src), 'module.json'))) {
+          buildTimeModuleMeta = JSON.parse(await fsp.readFile(join(dirname(src), 'module.json'), 'utf-8'))
+        }
+        break
+      } catch (_err: unknown) {
+        error = _err
+        continue
+      }
+    }
+    if (!nuxtModule && error) {
       logger.error(`Error while requiring module \`${nuxtModule}\`: ${error}`)
       throw error
     }
-    // nuxt-module-builder generates a module.json with metadata including the version
-    if (existsSync(join(dirname(src), 'module.json'))) {
-      buildTimeModuleMeta = JSON.parse(await fsp.readFile(join(dirname(src), 'module.json'), 'utf-8'))
-    }
   }
+
 
   // Throw error if input is not a function
   if (typeof nuxtModule !== 'function') {

--- a/packages/kit/src/module/install.ts
+++ b/packages/kit/src/module/install.ts
@@ -61,7 +61,7 @@ export async function loadNuxtModuleInstance (nuxtModule: string | NuxtModule, n
   let buildTimeModuleMeta: ModuleMeta = {}
   // Import if input is string
   if (typeof nuxtModule === 'string') {
-    const paths = [join(nuxtModule, 'module'), nuxtModule]
+    const paths = [join(nuxtModule, 'nuxt'), join(nuxtModule, 'module'), nuxtModule]
     let error: unknown
     for (const path of paths) {
       const src = await resolvePath(path)

--- a/packages/kit/src/module/install.ts
+++ b/packages/kit/src/module/install.ts
@@ -85,7 +85,6 @@ export async function loadNuxtModuleInstance (nuxtModule: string | NuxtModule, n
     }
   }
 
-
   // Throw error if input is not a function
   if (typeof nuxtModule !== 'function') {
     throw new TypeError('Nuxt module should be a function: ' + nuxtModule)

--- a/test/fixtures/basic/modules/subpath/index.ts
+++ b/test/fixtures/basic/modules/subpath/index.ts
@@ -1,0 +1,1 @@
+export const someUtil = () => {}

--- a/test/fixtures/basic/modules/subpath/module.ts
+++ b/test/fixtures/basic/modules/subpath/module.ts
@@ -1,0 +1,5 @@
+import { defineNuxtModule } from 'nuxt/kit'
+
+export default defineNuxtModule({
+  meta: { name: 'subpath' },
+})

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -80,6 +80,7 @@ export default defineNuxtConfig({
     }
   },
   modules: [
+    '~/modules/subpath',
     './modules/test',
     '~/modules/example',
     function (_, nuxt) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds support for detecting a `/module` subpath and loading it where it exists.

This would mean a project that is primarily a library can ship a Nuxt module as `/module` and support adding just the root library name to `modules: []`.

#### Example

```diff
  export default defineNuxtConfig({
    modules: [
-    'some-library/module'
+    'some-library'
    ]
  })
```

(We can, for example, use this straight away for `@nuxt/test-utils/module`.)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
