### PR TITLE
feat(vite): replace browser globals with `undefined` on server

### DIFF
--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -5,7 +5,6 @@ import viteJsxPlugin from '@vitejs/plugin-vue-jsx'
 import { logger, resolvePath, tryResolveModule } from '@nuxt/kit'
 import { joinURL, withTrailingSlash, withoutLeadingSlash } from 'ufo'
 import type { ViteConfig } from '@nuxt/schema'
-import replace from '@rollup/plugin-replace'
 import type { ViteBuildContext } from './vite'
 import { createViteLogger } from './utils/logger'
 import { initViteNodeServer } from './vite-node'
@@ -44,7 +43,12 @@ export async function buildServer (ctx: ViteBuildContext) {
       'process.browser': false,
       'import.meta.server': true,
       'import.meta.client': false,
-      'import.meta.browser': false
+      'import.meta.browser': false,
+      'window': 'undefined',
+      'document': 'undefined',
+      'navigator': 'undefined',
+      'location': 'undefined',
+      'XMLHttpRequest': 'undefined'
     },
     optimizeDeps: {
       entries: ctx.nuxt.options.ssr ? [ctx.entry] : []
@@ -96,19 +100,6 @@ export async function buildServer (ctx: ViteBuildContext) {
       preTransformRequests: false,
       hmr: false
     },
-    plugins: [
-      // @ts-expect-error types not compatible yet in `@rollup/plugin-replace`
-      replace({
-        values: {
-          'typeof window': '"undefined"',
-          'typeof document': '"undefined"',
-          'typeof navigator': '"undefined"',
-          'typeof location': '"undefined"',
-          'typeof XMLHttpRequest': '"undefined"'
-        },
-        preventAssignment: true
-      })
-    ]
   } satisfies vite.InlineConfig, ctx.nuxt.options.vite.$server || {}))
 
   if (!ctx.nuxt.options.dev) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

related https://github.com/nuxt/nuxt/pull/24182

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

With Vite 5 improvements on `define`, we can now define `window`, `document` when used on server, meaning an even wider range of code can be tree shaken (e.g. `if (typeof document === 'undefined')` but also `if (document)`. 

It should also be more accurate to use `define` rather than `replace` as it won't replace non-code (e.g. string literals).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
