### PR TITLE
perf(kit): avoid duplicate `join` operation

### DIFF
--- a/packages/kit/src/module/install.ts
+++ b/packages/kit/src/module/install.ts
@@ -70,9 +70,9 @@ export async function loadNuxtModuleInstance (nuxtModule: string | NuxtModule, n
         nuxtModule = await importModule(src, nuxt.options.modulesDir).catch(() => null) ?? requireModule(src, { paths: nuxt.options.modulesDir })
 
         // nuxt-module-builder generates a module.json with metadata including the version
-        const moduleFile=join(dirname(src), 'module.json')
-        if (existsSync(moduleFile)) {
-          buildTimeModuleMeta = JSON.parse(await fsp.readFile(moduleFile, 'utf-8'))
+        const moduleMetadataPath = join(dirname(src), 'module.json')
+        if (existsSync(moduleMetadataPath)) {
+          buildTimeModuleMeta = JSON.parse(await fsp.readFile(moduleMetadataPath, 'utf-8'))
         }
         break
       } catch (_err: unknown) {

--- a/packages/kit/src/module/install.ts
+++ b/packages/kit/src/module/install.ts
@@ -70,8 +70,9 @@ export async function loadNuxtModuleInstance (nuxtModule: string | NuxtModule, n
         nuxtModule = await importModule(src, nuxt.options.modulesDir).catch(() => null) ?? requireModule(src, { paths: nuxt.options.modulesDir })
 
         // nuxt-module-builder generates a module.json with metadata including the version
-        if (existsSync(join(dirname(src), 'module.json'))) {
-          buildTimeModuleMeta = JSON.parse(await fsp.readFile(join(dirname(src), 'module.json'), 'utf-8'))
+        const moduleFile=join(dirname(src), 'module.json')
+        if (existsSync(moduleFile)) {
+          buildTimeModuleMeta = JSON.parse(await fsp.readFile(moduleFile, 'utf-8'))
         }
         break
       } catch (_err: unknown) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
#24707

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
There is a duplicate filesystem operation in the nuxt module resolving process. This PR saves the reference to prevent the redundancy and thereby improve the performance.

NOTE: While the performance improvement here is way more miniscule, it still exists. I couldn't test it with the methods nuxt uses (I will make a benchmark with that soon) but with native fs's methods there's a ~10ms decrease in execution time, which is much more noticeable is longer iterations (**~8.38%** performance increase in 1000 iterations):
```ts
import { existsSync, promises as fsp } from "node:fs"
import { dirname, join } from "node:path"
import { fileURLToPath } from "node:url"
async function main() {
    async function test() {
        let buildTimeModuleMeta
        if (existsSync(join(dirname(fileURLToPath(import.meta.url)), 'Test2.json'))) {
            buildTimeModuleMeta = JSON.parse(await fsp.readFile(join(dirname(fileURLToPath(import.meta.url)), 'Test2.json'), 'utf-8'))
        }
    }
    async function test2() {
        let buildTimeModuleMeta
        const modB = join(dirname(fileURLToPath(import.meta.url)), 'Test2.json')
        if (existsSync(modB)) {
            buildTimeModuleMeta = JSON.parse(await fsp.readFile(modB, 'utf-8'))
        }
    }
    console.time("Current")
    for (let index = 0; index < 1000; index++) {
        await test()
    }
    console.timeEnd("Current")
    console.time("New")
    for (let index = 0; index < 1000; index++) {
        await test2()
    }
    console.timeEnd("New")
}
main()
```
```ts
//Test.json
{
"name":"test"
}
```
![image](https://github.com/nuxt/nuxt/assets/92037085/a343798e-293a-4553-9ad0-0c2dc309ef7a)

I don't know if pathe implements it differently, so I don't mind this not being merged for the time being (until I make the tests), however even my mind tells me a duplicate operation, even if insanely fast, will still take longer than saving a reference to it.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
