### PR TITLE
perf(nuxt): avoid duplicate iterations over layers

### DIFF
--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -107,8 +107,9 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
   }
 
   // Resolve layouts/ from all config layers
+  const layerConfigs = nuxt.options._layers.map(layer => layer.config)
   app.layouts = {}
-  for (const config of nuxt.options._layers.map(layer => layer.config)) {
+  for (const config of layerConfigs) {
     const layoutDir = (config.rootDir === nuxt.options.rootDir ? nuxt.options : config).dir?.layouts || 'layouts'
     const layoutFiles = await resolveFiles(config.srcDir, `${layoutDir}/**/*{${nuxt.options.extensions.join(',')}}`)
     for (const file of layoutFiles) {
@@ -119,7 +120,7 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
 
   // Resolve middleware/ from all config layers, layers first
   app.middleware = []
-  for (const config of nuxt.options._layers.map(layer => layer.config).reverse()) {
+  for (const config of layerConfigs.reverse()) {
     const middlewareDir = (config.rootDir === nuxt.options.rootDir ? nuxt.options : config).dir?.middleware || 'middleware'
     const middlewareFiles = await resolveFiles(config.srcDir, `${middlewareDir}/*{${nuxt.options.extensions.join(',')}}`)
     app.middleware.push(...middlewareFiles.map((file) => {
@@ -130,7 +131,7 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
 
   // Resolve plugins, first extended layers and then base
   app.plugins = []
-  for (const config of nuxt.options._layers.map(layer => layer.config).reverse()) {
+  for (const config of layerConfigs.reverse()) {
     const pluginDir = (config.rootDir === nuxt.options.rootDir ? nuxt.options : config).dir?.plugins || 'plugins'
     app.plugins.push(...[
       ...(config.plugins || []),
@@ -157,7 +158,7 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
 
   // Resolve app.config
   app.configs = []
-  for (const config of nuxt.options._layers.map(layer => layer.config)) {
+  for (const config of layerConfigs) {
     const appConfigPath = await findPath(resolve(config.srcDir, 'app.config'))
     if (appConfigPath) {
       app.configs.push(appConfigPath)

--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -108,6 +108,7 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
 
   // Resolve layouts/ from all config layers
   const layerConfigs = nuxt.options._layers.map(layer => layer.config)
+  const reversedConfigs = layerConfigs.slice().reverse()
   app.layouts = {}
   for (const config of layerConfigs) {
     const layoutDir = (config.rootDir === nuxt.options.rootDir ? nuxt.options : config).dir?.layouts || 'layouts'
@@ -120,7 +121,7 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
 
   // Resolve middleware/ from all config layers, layers first
   app.middleware = []
-  for (const config of layerConfigs.reverse()) {
+  for (const config of reversedConfigs) {
     const middlewareDir = (config.rootDir === nuxt.options.rootDir ? nuxt.options : config).dir?.middleware || 'middleware'
     const middlewareFiles = await resolveFiles(config.srcDir, `${middlewareDir}/*{${nuxt.options.extensions.join(',')}}`)
     app.middleware.push(...middlewareFiles.map((file) => {
@@ -131,7 +132,7 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
 
   // Resolve plugins, first extended layers and then base
   app.plugins = []
-  for (const config of layerConfigs.reverse()) {
+  for (const config of reversedConfigs) {
     const pluginDir = (config.rootDir === nuxt.options.rootDir ? nuxt.options : config).dir?.plugins || 'plugins'
     app.plugins.push(...[
       ...(config.plugins || []),

--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -108,7 +108,6 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
 
   // Resolve layouts/ from all config layers
   const layerConfigs = nuxt.options._layers.map(layer => layer.config)
-  const reversedConfigs=layerConfigs.reverse()
   app.layouts = {}
   for (const config of layerConfigs) {
     const layoutDir = (config.rootDir === nuxt.options.rootDir ? nuxt.options : config).dir?.layouts || 'layouts'
@@ -121,7 +120,7 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
 
   // Resolve middleware/ from all config layers, layers first
   app.middleware = []
-  for (const config of reversedConfigs) {
+  for (const config of layerConfigs.reverse()) {
     const middlewareDir = (config.rootDir === nuxt.options.rootDir ? nuxt.options : config).dir?.middleware || 'middleware'
     const middlewareFiles = await resolveFiles(config.srcDir, `${middlewareDir}/*{${nuxt.options.extensions.join(',')}}`)
     app.middleware.push(...middlewareFiles.map((file) => {
@@ -132,7 +131,7 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
 
   // Resolve plugins, first extended layers and then base
   app.plugins = []
-  for (const config of reversedConfigs) {
+  for (const config of layerConfigs.reverse()) {
     const pluginDir = (config.rootDir === nuxt.options.rootDir ? nuxt.options : config).dir?.plugins || 'plugins'
     app.plugins.push(...[
       ...(config.plugins || []),

--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -108,6 +108,7 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
 
   // Resolve layouts/ from all config layers
   const layerConfigs = nuxt.options._layers.map(layer => layer.config)
+  const reversedConfigs=layerConfigs.reverse()
   app.layouts = {}
   for (const config of layerConfigs) {
     const layoutDir = (config.rootDir === nuxt.options.rootDir ? nuxt.options : config).dir?.layouts || 'layouts'
@@ -120,7 +121,7 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
 
   // Resolve middleware/ from all config layers, layers first
   app.middleware = []
-  for (const config of layerConfigs.reverse()) {
+  for (const config of reversedConfigs) {
     const middlewareDir = (config.rootDir === nuxt.options.rootDir ? nuxt.options : config).dir?.middleware || 'middleware'
     const middlewareFiles = await resolveFiles(config.srcDir, `${middlewareDir}/*{${nuxt.options.extensions.join(',')}}`)
     app.middleware.push(...middlewareFiles.map((file) => {
@@ -131,7 +132,7 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
 
   // Resolve plugins, first extended layers and then base
   app.plugins = []
-  for (const config of layerConfigs.reverse()) {
+  for (const config of reversedConfigs) {
     const pluginDir = (config.rootDir === nuxt.options.rootDir ? nuxt.options : config).dir?.plugins || 'plugins'
     app.plugins.push(...[
       ...(config.plugins || []),


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
This PR saves the mapped configs (and their reversed counterpart) to avoid the repetitive operations when generating the app, resulting in a **~81.7%** increase in performance.
Benchmark results (offline, from host PC):
```ts
const nuxt={
    options:{
        _layers:[
            {config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true},{config:true}
        ]
    }
}
console.time("regular")
for (let index = 0; index < 100000; index++) {
    for(const config of nuxt.options._layers.map(layer => layer.config)){

    }
}
console.timeEnd("regular")
const layerConfigs=nuxt.options._layers.map(layer => layer.config)
console.time("PR")
for (let index = 0; index < 100000; index++) {
    for(const config of layerConfigs){}
}
console.timeEnd("PR")
```

![image](https://github.com/nuxt/nuxt/assets/92037085/e9ac28dc-3985-44d5-a658-b5443eb898af)


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
