### PR TITLE
refactor(nuxt): remove `process.*` usage in nuxt vue app

### DIFF
--- a/packages/nuxt/index.d.ts
+++ b/packages/nuxt/index.d.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-var */
 declare global {
   var __NUXT_VERSION__: string
+  var __NUXT_ASYNC_CONTEXT__: boolean
   var __NUXT_PREPATHS__: string[] | string | undefined
   var __NUXT_PATHS__: string[] | string | undefined
 

--- a/packages/nuxt/src/app/components/client-only.ts
+++ b/packages/nuxt/src/app/components/client-only.ts
@@ -41,7 +41,7 @@ export function createClientOnly<T extends ComponentOptions> (component: T) {
           : h(res)
       } else {
         const fragment = getFragmentHTML(ctx._.vnode.el ?? null) ?? ['<div></div>']
-        return process.client ? createStaticVNode(fragment.join(''), fragment.length) : h('div', ctx.$attrs ?? ctx._.attrs)
+        return import.meta.client ? createStaticVNode(fragment.join(''), fragment.length) : h('div', ctx.$attrs ?? ctx._.attrs)
       }
     }
   } else if (clone.template) {
@@ -80,7 +80,7 @@ export function createClientOnly<T extends ComponentOptions> (component: T) {
                   : h(res)
               } else {
                 const fragment = getFragmentHTML(instance?.vnode.el ?? null) ?? ['<div></div>']
-                return process.client ? createStaticVNode(fragment.join(''), fragment.length) : h('div', ctx.attrs)
+                return import.meta.client ? createStaticVNode(fragment.join(''), fragment.length) : h('div', ctx.attrs)
               }
             }
       })

--- a/packages/nuxt/src/app/composables/ssr.ts
+++ b/packages/nuxt/src/app/composables/ssr.ts
@@ -36,7 +36,7 @@ export function setResponseStatus (arg1: H3Event | number | undefined, arg2?: nu
 }
 
 export function prerenderRoutes (path: string | string[]) {
-  if (!process.server || !process.env.prerender) { return }
+  if (!import.meta.server || !import.meta.prerender) { return }
 
   const paths = Array.isArray(path) ? path : [path]
   appendHeader(useRequestEvent(), 'x-nitro-prerender', paths.map(p => encodeURIComponent(p)).join(', '))

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -19,7 +19,7 @@ import type { AsyncDataRequestStatus } from '../app/composables/asyncData'
 import type { NuxtAppManifestMeta } from '../app/composables/manifest'
 
 const nuxtAppCtx = /*@__PURE__*/ getContext<NuxtApp>('nuxt-app', {
-  asyncContext: !!process.env.NUXT_ASYNC_CONTEXT && process.server
+  asyncContext: !!__NUXT_ASYNC_CONTEXT__ && process.server
 })
 
 type HookResult = Promise<void> | void

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -19,7 +19,7 @@ import type { AsyncDataRequestStatus } from '../app/composables/asyncData'
 import type { NuxtAppManifestMeta } from '../app/composables/manifest'
 
 const nuxtAppCtx = /*@__PURE__*/ getContext<NuxtApp>('nuxt-app', {
-  asyncContext: !!__NUXT_ASYNC_CONTEXT__ && process.server
+  asyncContext: !!__NUXT_ASYNC_CONTEXT__ && import.meta.server
 })
 
 type HookResult = Promise<void> | void

--- a/packages/nuxt/src/app/plugins/payload.client.ts
+++ b/packages/nuxt/src/app/plugins/payload.client.ts
@@ -11,7 +11,7 @@ export default defineNuxtPlugin({
   name: 'nuxt:payload',
   setup (nuxtApp) {
     // TODO: Support dev
-    if (process.dev) { return }
+    if (import.meta.dev) { return }
 
     // Load payload after middleware & once final route is resolved
     useRouter().beforeResolve(async (to, from) => {

--- a/packages/nuxt/src/head/module.ts
+++ b/packages/nuxt/src/head/module.ts
@@ -62,7 +62,7 @@ export default defineNuxtModule({
           return 'export default []'
         }
         return `import { CapoPlugin } from ${JSON.stringify(unheadVue)};
-export default process.server ? [CapoPlugin({ track: true })] : [];`
+export default import.meta.server ? [CapoPlugin({ track: true })] : [];`
       }
     })
 

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -77,7 +77,7 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
         css: resolveCSSOptions(nuxt),
         define: {
           __NUXT_VERSION__: JSON.stringify(nuxt._version),
-          'process.env.NUXT_ASYNC_CONTEXT': nuxt.options.experimental.asyncContext
+          __NUXT_ASYNC_CONTEXT__: nuxt.options.experimental.asyncContext
         },
         build: {
           copyPublicDir: false,

--- a/packages/webpack/src/presets/base.ts
+++ b/packages/webpack/src/presets/base.ts
@@ -217,8 +217,8 @@ function getEnv (ctx: WebpackConfigContext) {
   const _env: Record<string, string | boolean> = {
     'process.env.NODE_ENV': JSON.stringify(ctx.config.mode),
     __NUXT_VERSION__: JSON.stringify(ctx.nuxt._version),
+     __NUXT_ASYNC_CONTEXT__: ctx.options.experimental.asyncContext,
     'process.env.VUE_ENV': JSON.stringify(ctx.name),
-    'process.env.NUXT_ASYNC_CONTEXT': ctx.options.experimental.asyncContext,
     'process.dev': ctx.options.dev,
     'process.test': isTest,
     'process.browser': ctx.isClient,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,9 +11,6 @@ export default defineConfig({
       '#app': resolve('./packages/nuxt/dist/app')
     }
   },
-  define: {
-    'process.env.NUXT_ASYNC_CONTEXT': 'false'
-  },
   test: {
     globalSetup: './test/setup.ts',
     setupFiles: ['./test/setup-env.ts'],


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

related https://github.com/nuxt/nuxt/pull/24182, https://github.com/nuxt/nuxt/pull/24711

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This moves to using `import.meta.*` in preference to `process` within the core nuxt app. (And, in particular, move away from `process.env.NUXT_ASYNC_CONTEXT` which can have unexpected treatment by vite.)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
