### PR TITLE
ci: notify `nuxt/bridge` when composables change

### DIFF
--- a/.github/workflows/notify-nuxt-bridge.yml
+++ b/.github/workflows/notify-nuxt-bridge.yml
@@ -15,7 +15,7 @@ jobs:
       - name: repository dispatch
         uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570 #v2.1.2
         with:
-          token: ${{ secrets.ACCESS_TOKEN }}
+          token: ${{ secrets.BRIDGE_GITHUB_TOKEN }}
           repository: ${{ matrix.repo }}
           event-type: port-upstream
           client-payload: '{"url": "${{ github.event.pull_request.html_url }}"}'

--- a/.github/workflows/notify-nuxt-bridge.yml
+++ b/.github/workflows/notify-nuxt-bridge.yml
@@ -1,0 +1,21 @@
+name: bridge
+on:
+  pull_request:
+    types: [closed]
+    paths:
+      - "packages/nuxt/src/app/composables/**"
+jobs:
+  notify:
+    if: github.event.pull_request.merged == true
+    strategy:
+      matrix:
+        repo: ["nuxt/bridge"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: repository dispatch
+        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570 #v2.1.2
+        with:
+          token: ${{ secrets.ACCESS_TOKEN }}
+          repository: ${{ matrix.repo }}
+          event-type: port-upstream
+          client-payload: '{"url": "${{ github.event.pull_request.html_url }}"}'


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
The composables in nuxt/bridge are ported from nuxt 3.
So, if there are changes in nuxt 3, we need to follow the changes.
In the `workflow` being added this time, if composables are modified in Nuxt 3, a notification will be sent to nuxt/bridge.

nuxt/bridge is already set up to receive notifications.
https://github.com/nuxt/bridge/pull/1013

(I would like to discuss if this name for the workflow is appropriate.)

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### Todo
- [ ] Secrets must be prepared.
  - Need to add `contents: read & write` for nuxt bridge repo.
  - `metadata: read only` (automatically selected when selecting the contents permission)


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
