### PR TITLE
perf(schema): use parallel promises

### DIFF
--- a/packages/schema/src/config/build.ts
+++ b/packages/schema/src/config/build.ts
@@ -110,8 +110,7 @@ export default defineUntypedSchema({
      */
     analyze: {
       $resolve: async (val, get) => {
-        const rootDir = await get('rootDir')
-        const analyzeDir = await get('analyzeDir')
+        const [rootDir, analyzeDir] = await Promise.all([get('rootDir'), get('analyzeDir')])
         return defu(typeof val === 'boolean' ? { enabled: val } : val, {
           template: 'treemap',
           projectRoot: rootDir,

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -136,10 +136,9 @@ export default defineUntypedSchema({
     $default: ['node_modules'],
     $resolve: async (val, get) => {
       const rootDir = await get('rootDir')
-      const currentDir = process.cwd()
       return [
         ...await Promise.all(val.map(async (dir: string) => resolve(rootDir, dir))),
-        resolve(currentDir, 'node_modules')
+        resolve(process.cwd(), 'node_modules')
       ]
     }
   },

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -313,7 +313,7 @@ export default defineUntypedSchema({
    */
   alias: {
     $resolve: async (val, get) => {
-      const [srcDir, rootDir, dirAssets, dirPublic] = await Promise.all(get('srcDir'), get('rootDir'), get('dir.assets'), get('dir.public'))
+      const [srcDir, rootDir, dirAssets, dirPublic] = await Promise.all([get('srcDir'), get('rootDir'), get('dir.assets'), get('dir.public')])
       return {
         '~': srcDir,
         '@': srcDir,
@@ -353,7 +353,7 @@ export default defineUntypedSchema({
    */
   ignore: {
     $resolve: async (val, get) => {
-      const[rootDir, ignorePrefix] = await Promise.all(get('rootDir'), get('ignorePrefix'))
+      const[rootDir, ignorePrefix] = await Promise.all([get('rootDir'), get('ignorePrefix')])
       return [
         '**/*.stories.{js,cts,mts,ts,jsx,tsx}', // ignore storybook files
         '**/*.{spec,test}.{js,cts,mts,ts,jsx,tsx}', // ignore tests

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -134,10 +134,14 @@ export default defineUntypedSchema({
    */
   modulesDir: {
     $default: ['node_modules'],
-    $resolve: async (val, get) => [
-      ...await Promise.all(val.map(async (dir: string) => resolve(await get('rootDir'), dir))),
-      resolve(process.cwd(), 'node_modules')
-    ]
+    $resolve: async (val, get) => {
+      const rootDir = await get('rootDir')
+      const currentDir = process.cwd()
+      return [
+        ...await Promise.all(val.map(async (dir: string) => resolve(rootDir, dir))),
+        resolve(currentDir, 'node_modules')
+      ]
+    }
   },
 
   /**
@@ -309,10 +313,7 @@ export default defineUntypedSchema({
    */
   alias: {
     $resolve: async (val, get) => {
-      const srcDir = await get('srcDir')
-      const rootDir = await get('rootDir')
-      const dirAssets = await get('dir.assets')
-      const dirPublic = await get('dir.public')
+      const [srcDir, rootDir, dirAssets, dirPublic] = await Promise.all(get('srcDir'), get('rootDir'), get('dir.assets'), get('dir.public'))
       return {
         '~': srcDir,
         '@': srcDir,
@@ -352,8 +353,7 @@ export default defineUntypedSchema({
    */
   ignore: {
     $resolve: async (val, get) => {
-      const rootDir = await get('rootDir')
-      const ignorePrefix = await get('ignorePrefix')
+      const[rootDir, ignorePrefix] = await Promise.all(get('rootDir'), get('ignorePrefix'))
       return [
         '**/*.stories.{js,cts,mts,ts,jsx,tsx}', // ignore storybook files
         '**/*.{spec,test}.{js,cts,mts,ts,jsx,tsx}', // ignore tests

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -353,14 +353,14 @@ export default defineUntypedSchema({
    */
   ignore: {
     $resolve: async (val, get) => {
-      const [rootDir, ignorePrefix] = await Promise.all([get('rootDir'), get('ignorePrefix')])
+      const [rootDir, ignorePrefix, analyzeDir, buildDir] = await Promise.all([get('rootDir'), get('ignorePrefix'), get('analyzeDir'), get('buildDir')])
       return [
         '**/*.stories.{js,cts,mts,ts,jsx,tsx}', // ignore storybook files
         '**/*.{spec,test}.{js,cts,mts,ts,jsx,tsx}', // ignore tests
         '**/*.d.{cts,mts,ts}', // ignore type declarations
         '**/.{pnpm-store,vercel,netlify,output,git,cache,data}',
-        relative(rootDir, await get('analyzeDir')),
-        relative(rootDir, await get('buildDir')),
+        relative(rootDir, analyzeDir),
+        relative(rootDir, buildDir),
         ignorePrefix && `**/${ignorePrefix}*.*`
       ].concat(val).filter(Boolean)
     }

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -353,7 +353,7 @@ export default defineUntypedSchema({
    */
   ignore: {
     $resolve: async (val, get) => {
-      const[rootDir, ignorePrefix] = await Promise.all([get('rootDir'), get('ignorePrefix')])
+      const [rootDir, ignorePrefix] = await Promise.all([get('rootDir'), get('ignorePrefix')])
       return [
         '**/*.stories.{js,cts,mts,ts,jsx,tsx}', // ignore storybook files
         '**/*.{spec,test}.{js,cts,mts,ts,jsx,tsx}', // ignore tests

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -313,14 +313,14 @@ export default defineUntypedSchema({
    */
   alias: {
     $resolve: async (val, get) => {
-      const [srcDir, rootDir, dirAssets, dirPublic] = await Promise.all([get('srcDir'), get('rootDir'), get('dir.assets'), get('dir.public')])
+      const [srcDir, rootDir, assetsDir, publicDir] = await Promise.all([get('srcDir'), get('rootDir'), get('dir.assets'), get('dir.public')])
       return {
         '~': srcDir,
         '@': srcDir,
         '~~': rootDir,
         '@@': rootDir,
-        [dirAssets]: join(srcDir, dirAssets),
-        [dirPublic]: join(srcDir, dirPublic),
+        [assetsDir]: join(srcDir, assetsDir),
+        [publicDir]: join(srcDir, publicDir),
         ...val
       }
     }

--- a/packages/schema/src/config/vite.ts
+++ b/packages/schema/src/config/vite.ts
@@ -39,7 +39,7 @@ export default defineUntypedSchema({
         if (val) {
           consola.warn('Directly configuring the `vite.publicDir` option is not supported. Instead, set `dir.public`. You can read more in `https://nuxt.com/docs/api/nuxt-config#public`.')
         }
-        return val ?? await Promise.all([get('srcDir'), get('dir')]).then([srcDir, dir] => resolve(srcDir, dir.public))
+        return val ?? await Promise.all([get('srcDir'), get('dir')]).then(([srcDir, dir]) => resolve(srcDir, dir.public))
       }
     },
     vue: {

--- a/packages/schema/src/config/vite.ts
+++ b/packages/schema/src/config/vite.ts
@@ -39,8 +39,7 @@ export default defineUntypedSchema({
         if (val) {
           consola.warn('Directly configuring the `vite.publicDir` option is not supported. Instead, set `dir.public`. You can read more in `https://nuxt.com/docs/api/nuxt-config#public`.')
         }
-        const [srcDir, dir] = await Promise.all([get('srcDir'), get('dir')])
-        return val ?? resolve(srcDir, dir.public)
+        return val ?? await Promise.all([get('srcDir'), get('dir')]).then([srcDir, dir] => resolve(srcDir, dir.public))
       }
     },
     vue: {

--- a/packages/schema/src/config/vite.ts
+++ b/packages/schema/src/config/vite.ts
@@ -39,7 +39,8 @@ export default defineUntypedSchema({
         if (val) {
           consola.warn('Directly configuring the `vite.publicDir` option is not supported. Instead, set `dir.public`. You can read more in `https://nuxt.com/docs/api/nuxt-config#public`.')
         }
-        return val ?? resolve((await get('srcDir')), (await get('dir')).public)
+        const [srcDir, dir] = await Promise.all([get('srcDir'), get('dir')])
+        return val ?? resolve(srcDir, dir.public)
       }
     },
     vue: {
@@ -92,14 +93,17 @@ export default defineUntypedSchema({
     server: {
       fs: {
         allow: {
-          $resolve: async (val, get) => [
-            await get('buildDir'),
-            await get('srcDir'),
-            await get('rootDir'),
-            await get('workspaceDir'),
-            ...(await get('modulesDir')),
-            ...val ?? []
-          ]
+          $resolve: async (val, get) => {
+            const [buildDir, srcDir, rootDir, workspaceDir, modulesDir] = await Promise.all([get('buildDir'), get('srcDir'), get('rootDir'), get('workspaceDir'), get('modulesDir')])
+              [
+                buildDir,
+                srcDir,
+                rootDir,
+                workspaceDir,
+                ...(modulesDir),
+                ...val ?? []
+              ]
+          }
         }
       }
     }

--- a/packages/schema/src/config/vite.ts
+++ b/packages/schema/src/config/vite.ts
@@ -94,14 +94,14 @@ export default defineUntypedSchema({
         allow: {
           $resolve: async (val, get) => {
             const [buildDir, srcDir, rootDir, workspaceDir, modulesDir] = await Promise.all([get('buildDir'), get('srcDir'), get('rootDir'), get('workspaceDir'), get('modulesDir')])
-            return  [
-                buildDir,
-                srcDir,
-                rootDir,
-                workspaceDir,
-                ...(modulesDir),
-                ...val ?? []
-              ]
+            return [
+              buildDir,
+              srcDir,
+              rootDir,
+              workspaceDir,
+              ...(modulesDir),
+              ...val ?? []
+            ]
           }
         }
       }

--- a/packages/schema/src/config/vite.ts
+++ b/packages/schema/src/config/vite.ts
@@ -94,7 +94,7 @@ export default defineUntypedSchema({
         allow: {
           $resolve: async (val, get) => {
             const [buildDir, srcDir, rootDir, workspaceDir, modulesDir] = await Promise.all([get('buildDir'), get('srcDir'), get('rootDir'), get('workspaceDir'), get('modulesDir')])
-              [
+            return  [
                 buildDir,
                 srcDir,
                 rootDir,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
#24734 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Following the linked PR, @pi0 brought to my attention that we can use parallel promises, and indeed the benchmark shows a significant **~30%** improvement in performance, so all credits of this PR are to him.
```ts
async function main(){
async function get(name:string){
    return 42;
  }
  console.time("current")
  for (let index = 0; index < 1000000; index++) {
   const a = await get('a')
   const b = await get('b')
   const c = await get('c')
   const d = await get('d')
    
  }
console.timeEnd("current")
console.time("PR")
for (let index = 0; index < 1000000; index++) {
    const [a,b,c,d]=await Promise.all([get('a'), get('b'), get('c'), get('d')])
    
  }
  console.timeEnd("PR")
}
main()
```
![image](https://github.com/nuxt/nuxt/assets/92037085/666c3b65-ac6d-4704-81b3-7cd32fc6bf61)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
