### PR TITLE
feat(nuxt): allow customising fallback layout

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-layout.ts
+++ b/packages/nuxt/src/app/components/nuxt-layout.ts
@@ -42,6 +42,10 @@ export default defineComponent({
     name: {
       type: [String, Boolean, Object] as unknown as () => unknown extends PageMeta['layout'] ? MaybeRef<string | false> : PageMeta['layout'],
       default: null
+    },
+    fallback: {
+      type: [String, Object] as unknown as () => unknown extends PageMeta['layout'] ? MaybeRef<string> : PageMeta['layout'],
+      default: null
     }
   },
   setup (props, context) {
@@ -50,7 +54,18 @@ export default defineComponent({
     const injectedRoute = inject(PageRouteSymbol)
     const route = injectedRoute === useRoute() ? useVueRouterRoute() : injectedRoute
 
-    const layout = computed(() => unref(props.name) ?? route.meta.layout as string ?? 'default')
+    const layout = computed(() => {
+      let layout = unref(props.name) ?? route.meta.layout as string ?? 'default'
+      if (layout && !(layout in layouts) && layout !== 'default') {
+        if (import.meta.dev) {
+          console.warn(`Invalid layout \`${layout}\` selected.`)
+        }
+        if (props.fallback) {
+          layout = unref(props.fallback)
+        }
+      }
+      return layout
+    })
 
     const layoutRef = ref()
     context.expose({ layoutRef })
@@ -63,10 +78,6 @@ export default defineComponent({
 
     return () => {
       const hasLayout = layout.value && layout.value in layouts
-      if (import.meta.dev && layout.value && !hasLayout && layout.value !== 'default') {
-        console.warn(`Invalid layout \`${layout.value}\` selected.`)
-      }
-
       const transitionProps = route.meta.layoutTransition ?? defaultLayoutTransition
 
       // We avoid rendering layout transition if there is no layout to render

--- a/packages/nuxt/src/app/components/nuxt-layout.ts
+++ b/packages/nuxt/src/app/components/nuxt-layout.ts
@@ -56,8 +56,8 @@ export default defineComponent({
 
     const layout = computed(() => {
       let layout = unref(props.name) ?? route.meta.layout as string ?? 'default'
-      if (layout && !(layout in layouts) && layout !== 'default') {
-        if (import.meta.dev) {
+      if (layout && !(layout in layouts)) {
+        if (import.meta.dev && layout !== 'default') {
           console.warn(`Invalid layout \`${layout}\` selected.`)
         }
         if (props.fallback) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/15570

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently if an invalid layout is selected, no layout is rendered. This change allows passing a `fallback` prop to `<NuxtLayout>` to provide a layout that will be rendered in this case. For example:

```vue
<NuxtLayout fallback="default">
  <NuxtPage />
</NuxtLayout>
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
