### PR TITLE
feat(nuxt): `useRequestHeader` utility

### DIFF
--- a/docs/3.api/2.composables/use-request-header.md
+++ b/docs/3.api/2.composables/use-request-header.md
@@ -16,7 +16,7 @@ const authorization = useRequestHeader('authorization')
 ```
 
 ::callout
-In the browser, `useRequestHeader` will return an empty string.
+In the browser, `useRequestHeader` will return `undefined`.
 ::
 
 ## Example

--- a/docs/3.api/2.composables/use-request-header.md
+++ b/docs/3.api/2.composables/use-request-header.md
@@ -11,7 +11,7 @@ links:
 You can use the built-in [`useRequestHeader`](/docs/api/composables/use-request-header) composable to access any incoming request header within your pages, components, and plugins.
 
 ```ts
-// Get the authorization request header
+// Get the cookie request header
 const cookie = useRequestHeader('cookie')
 ```
 

--- a/docs/3.api/2.composables/use-request-header.md
+++ b/docs/3.api/2.composables/use-request-header.md
@@ -8,7 +8,7 @@ links:
     size: xs
 ---
 
-You can use built-in [`useRequestHeader`](/docs/api/composables/use-request-header) composable to access any incoming request header within your pages, components, and plugins.
+You can use the built-in [`useRequestHeader`](/docs/api/composables/use-request-header) composable to access any incoming request header within your pages, components, and plugins.
 
 ```ts
 // Get the authorization request header

--- a/docs/3.api/2.composables/use-request-header.md
+++ b/docs/3.api/2.composables/use-request-header.md
@@ -25,7 +25,7 @@ We can use `useRequestHeader` to easily figure out if a user is authorized or no
 
 The example below reads the `authorization` request header to an isomorphic `$fetch` call.
 
-```vue [middleware/authorized-only.ts]
+```ts [middleware/authorized-only.ts]
 export default defineNuxtRouteMiddleware((to, from) => {
   if(!useRequestHeader('authorization')){
     return navigateTo('/not-authorized')

--- a/docs/3.api/2.composables/use-request-header.md
+++ b/docs/3.api/2.composables/use-request-header.md
@@ -12,7 +12,7 @@ You can use built-in [`useRequestHeader`](/docs/api/composables/use-request-head
 
 ```ts
 // Get the authorization request header
-const cookie = useRequestHeader('authorization')
+const cookie = useRequestHeader('cookie')
 ```
 
 ::callout

--- a/docs/3.api/2.composables/use-request-header.md
+++ b/docs/3.api/2.composables/use-request-header.md
@@ -11,8 +11,8 @@ links:
 You can use the built-in [`useRequestHeader`](/docs/api/composables/use-request-header) composable to access any incoming request header within your pages, components, and plugins.
 
 ```ts
-// Get the cookie request header
-const cookie = useRequestHeader('cookie')
+// Get the authorization request header
+const authorization = useRequestHeader('authorization')
 ```
 
 ::callout
@@ -27,7 +27,7 @@ The example below reads the `authorization` request header to find out if a pers
 
 ```ts [middleware/authorized-only.ts]
 export default defineNuxtRouteMiddleware((to, from) => {
-  if(!useRequestHeader('authorization')){
+  if (!useRequestHeader('authorization')) {
     return navigateTo('/not-authorized')
   }
 })

--- a/docs/3.api/2.composables/use-request-header.md
+++ b/docs/3.api/2.composables/use-request-header.md
@@ -1,0 +1,34 @@
+---
+title: "useRequestHeader"
+description: "Use useRequestHeader to access a certain incoming request header."
+links:
+  - label: Source
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/nuxt/blob/main/packages/nuxt/src/app/composables/ssr.ts
+    size: xs
+---
+
+You can use built-in [`useRequestHeader`](/docs/api/composables/use-request-header) composable to access any incoming request header within your pages, components, and plugins.
+
+```ts
+// Get the authorization request header
+const cookie = useRequestHeader('authorization')
+```
+
+::callout
+In the browser, `useRequestHeader` will return an empty string.
+::
+
+## Example
+
+We can use `useRequestHeader` to easily figure out if a user is authorized or not.
+
+The example below reads the `authorization` request header to an isomorphic `$fetch` call.
+
+```vue [middleware/authorized-only.ts]
+export default defineNuxtRouteMiddleware((to, from) => {
+  if(!useRequestHeader('authorization')){
+    return navigateTo('/not-authorized')
+  }
+})
+```

--- a/docs/3.api/2.composables/use-request-header.md
+++ b/docs/3.api/2.composables/use-request-header.md
@@ -23,7 +23,7 @@ In the browser, `useRequestHeader` will return an empty string.
 
 We can use `useRequestHeader` to easily figure out if a user is authorized or not.
 
-The example below reads the `authorization` request header to an isomorphic `$fetch` call.
+The example below reads the `authorization` request header to find out if a person can access a restricted resource.
 
 ```ts [middleware/authorized-only.ts]
 export default defineNuxtRouteMiddleware((to, from) => {

--- a/packages/nuxt/src/app/composables/ssr.ts
+++ b/packages/nuxt/src/app/composables/ssr.ts
@@ -1,5 +1,5 @@
 import type { H3Event } from 'h3'
-import { setResponseStatus as _setResponseStatus, appendHeader, getRequestHeaders } from 'h3'
+import { setResponseStatus as _setResponseStatus, appendHeader, getRequestHeaders, getRequestHeader } from 'h3'
 import type { NuxtApp } from '../nuxt'
 import { useNuxtApp } from '../nuxt'
 
@@ -15,6 +15,13 @@ export function useRequestHeaders (include?: any[]) {
   const headers = event ? getRequestHeaders(event) : {}
   if (!include) { return headers }
   return Object.fromEntries(include.map(key => key.toLowerCase()).filter(key => headers[key]).map(key => [key, headers[key]]))
+}
+
+export function useRequestHeader(header: string) {
+  if (import.meta.client) { return {} }
+  const event = useRequestEvent()
+  const header = event ? getRequestHeader(event, header) : ''
+  return header
 }
 
 export function useRequestFetch (): typeof global.$fetch {

--- a/packages/nuxt/src/app/composables/ssr.ts
+++ b/packages/nuxt/src/app/composables/ssr.ts
@@ -1,5 +1,5 @@
 import type { H3Event } from 'h3'
-import { setResponseStatus as _setResponseStatus, appendHeader, getRequestHeaders, getRequestHeader } from 'h3'
+import { setResponseStatus as _setResponseStatus, appendHeader, getRequestHeader, getRequestHeaders } from 'h3'
 import type { NuxtApp } from '../nuxt'
 import { useNuxtApp } from '../nuxt'
 

--- a/packages/nuxt/src/app/composables/ssr.ts
+++ b/packages/nuxt/src/app/composables/ssr.ts
@@ -17,10 +17,10 @@ export function useRequestHeaders (include?: any[]) {
   return Object.fromEntries(include.map(key => key.toLowerCase()).filter(key => headers[key]).map(key => [key, headers[key]]))
 }
 
-export function useRequestHeader(include: string) {
+export function useRequestHeader(header: string) {
   if (import.meta.client) { return undefined }
   const event = useRequestEvent()
-  return event ? getRequestHeader(event, include) : undefined
+  return event ? getRequestHeader(event, header) : undefined
 }
 
 export function useRequestFetch (): typeof global.$fetch {

--- a/packages/nuxt/src/app/composables/ssr.ts
+++ b/packages/nuxt/src/app/composables/ssr.ts
@@ -17,10 +17,10 @@ export function useRequestHeaders (include?: any[]) {
   return Object.fromEntries(include.map(key => key.toLowerCase()).filter(key => headers[key]).map(key => [key, headers[key]]))
 }
 
-export function useRequestHeader(header: string) {
+export function useRequestHeader(include: string) {
   if (import.meta.client) { return {} }
   const event = useRequestEvent()
-  const header = event ? getRequestHeader(event, header) : ''
+  const header = event ? getRequestHeader(event, include) : ''
   return header
 }
 

--- a/packages/nuxt/src/app/composables/ssr.ts
+++ b/packages/nuxt/src/app/composables/ssr.ts
@@ -18,10 +18,9 @@ export function useRequestHeaders (include?: any[]) {
 }
 
 export function useRequestHeader(include: string) {
-  if (import.meta.client) { return '' }
+  if (import.meta.client) { return undefined }
   const event = useRequestEvent()
-  const header = event ? getRequestHeader(event, include) : ''
-  return header
+  return event ? getRequestHeader(event, include) : undefined
 }
 
 export function useRequestFetch (): typeof global.$fetch {

--- a/packages/nuxt/src/app/composables/ssr.ts
+++ b/packages/nuxt/src/app/composables/ssr.ts
@@ -18,7 +18,7 @@ export function useRequestHeaders (include?: any[]) {
 }
 
 export function useRequestHeader(include: string) {
-  if (import.meta.client) { return {} }
+  if (import.meta.client) { return '' }
   const event = useRequestEvent()
   const header = event ? getRequestHeader(event, include) : ''
   return header

--- a/packages/nuxt/src/imports/presets.ts
+++ b/packages/nuxt/src/imports/presets.ts
@@ -58,7 +58,7 @@ const granularAppPresets: InlinePreset[] = [
     from: '#app/composables/cookie'
   },
   {
-    imports: ['prerenderRoutes', 'useRequestHeaders', 'useRequestEvent', 'useRequestFetch', 'setResponseStatus'],
+    imports: ['prerenderRoutes', 'useRequestHeader', 'useRequestHeaders', 'useRequestEvent', 'useRequestFetch', 'setResponseStatus'],
     from: '#app/composables/ssr'
   },
   {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
The current request header retrival process of `useRequestHeaders` is a bit unintuitive in situations that require reading headers. It doesn't make a lot of sense from a developmental standpoint as more often than not you would need only a single header, mostly for "reading" operations (I myself have a couple of such use cases, for example, authorization middleware).
This PR provides that possibility to simplify and improve DX. With this a person could simply do
```ts
const cookie = useRequestHeader('cookie')
```
That being said, I would like to reiterate and clarify that this is **not** a replacement of `getRequestHeaders`. This can be used to directly read header values when dealing with authorization related middleware for example, whereas getRequestHeaders can be used to proxy the headers and use them in API calls, due to its object return.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
