### PR TITLE
fix(nuxt): allow modules to disable `appManifest` without crashing

### DIFF
--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -94,7 +94,6 @@ async function initNuxt (nuxt: Nuxt) {
   addVitePlugin(() => ImportProtectionPlugin.vite(config))
   addWebpackPlugin(() => ImportProtectionPlugin.webpack(config))
 
-
   // add resolver for modules used in virtual files
   addVitePlugin(() => resolveDeepImportsPlugin(nuxt))
 

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -391,7 +391,6 @@ async function initNuxt (nuxt: Nuxt) {
   }
 
    await nuxt.callHook('modules:done')
-  // otherwise the app will crash (#24672)
   if (nuxt.options.experimental.appManifest) {
     addRouteMiddleware({
       name: 'manifest-route-rule',

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -391,7 +391,6 @@ async function initNuxt (nuxt: Nuxt) {
   }
 
    await nuxt.callHook('modules:done')
-  // register the app manifest middleware now to allow user modules to disable it
   // otherwise the app will crash (#24672)
   if (nuxt.options.experimental.appManifest) {
     addRouteMiddleware({

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -94,15 +94,6 @@ async function initNuxt (nuxt: Nuxt) {
   addVitePlugin(() => ImportProtectionPlugin.vite(config))
   addWebpackPlugin(() => ImportProtectionPlugin.webpack(config))
 
-  if (nuxt.options.experimental.appManifest) {
-    addRouteMiddleware({
-      name: 'manifest-route-rule',
-      path: resolve(nuxt.options.appDir, 'middleware/manifest-route-rule'),
-      global: true
-    })
-
-    addPlugin(resolve(nuxt.options.appDir, 'plugins/check-outdated-build.client'))
-  }
 
   // add resolver for modules used in virtual files
   addVitePlugin(() => resolveDeepImportsPlugin(nuxt))
@@ -397,6 +388,18 @@ async function initNuxt (nuxt: Nuxt) {
     } else {
       await installModule(m, {})
     }
+  }
+
+  // register the app manifest middleware now to allow user modules to disable it
+  // otherwise the app will crash (#24672)
+  if (nuxt.options.experimental.appManifest) {
+    addRouteMiddleware({
+      name: 'manifest-route-rule',
+      path: resolve(nuxt.options.appDir, 'middleware/manifest-route-rule'),
+      global: true
+    })
+
+    addPlugin(resolve(nuxt.options.appDir, 'plugins/check-outdated-build.client'))
   }
 
   await nuxt.callHook('modules:done')

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -390,7 +390,7 @@ async function initNuxt (nuxt: Nuxt) {
     }
   }
 
-   await nuxt.callHook('modules:done')
+  await nuxt.callHook('modules:done')
   if (nuxt.options.experimental.appManifest) {
     addRouteMiddleware({
       name: 'manifest-route-rule',

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -390,6 +390,7 @@ async function initNuxt (nuxt: Nuxt) {
   }
 
   await nuxt.callHook('modules:done')
+
   if (nuxt.options.experimental.appManifest) {
     addRouteMiddleware({
       name: 'manifest-route-rule',

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -401,7 +401,6 @@ async function initNuxt (nuxt: Nuxt) {
 
     addPlugin(resolve(nuxt.options.appDir, 'plugins/check-outdated-build.client'))
   }
-
   await nuxt.callHook('modules:done')
 
   nuxt.hooks.hook('builder:watch', (event, relativePath) => {

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -390,6 +390,7 @@ async function initNuxt (nuxt: Nuxt) {
     }
   }
 
+   await nuxt.callHook('modules:done')
   // register the app manifest middleware now to allow user modules to disable it
   // otherwise the app will crash (#24672)
   if (nuxt.options.experimental.appManifest) {

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -400,7 +400,6 @@ async function initNuxt (nuxt: Nuxt) {
 
     addPlugin(resolve(nuxt.options.appDir, 'plugins/check-outdated-build.client'))
   }
-  await nuxt.callHook('modules:done')
 
   nuxt.hooks.hook('builder:watch', (event, relativePath) => {
     const path = resolve(nuxt.options.srcDir, relativePath)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
- #24672

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Resolves #24672

`nuxt.options.experimental.appManifest` is set to true by default, and can be set to `false` by users if they want to opt out of the app manifest generation feature. However, a user module trying to disable `appManifest` would break completely the user app because of the ordering in `initNuxt` (located in [packages/nuxt/src/core/nuxt.ts](https://github.com/nuxt/nuxt/blob/7a32eaf873c16980d304ce8ace0a125dce8567c0/packages/nuxt/src/core/nuxt.ts)). 

Before this PR, the `manifest-route-rule` middleware was added before any user module could have the opportunity to set `nuxt.options.experimental.appManifest` to `false`. However, the middleware throws an error if it is registered and `appManifest` is not equal to `true`.

As a result, when a user module tried to override the Nuxt config to set `nuxt.options.experimental.appManifest` to `false`, the middleware was still registered in the app but was throwing on every route with a 500 error, thus broking the app.

This is why this PR moves the addition of the `manifest-route-rule` middleware after the registration of user hooks : this way, the config can be altered by the user modules before the middleware is added.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
