### PR TITLE
fix(nuxt): register override hooks separately

### DIFF
--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -509,6 +509,11 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
 
   const nuxt = createNuxt(options)
 
+  // We register hooks layer-by-layer so any overrides need to be registered separately
+  if (opts.overrides?.hooks) {
+    nuxt.hooks.addHooks(opts.overrides.hooks)
+  }
+
   if (nuxt.options.debug) {
     createDebugger(nuxt.hooks, { tag: 'nuxt' })
   }

--- a/packages/nuxt/test/load-nuxt.test.ts
+++ b/packages/nuxt/test/load-nuxt.test.ts
@@ -1,0 +1,26 @@
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { normalize } from 'pathe'
+import { withoutTrailingSlash } from 'ufo'
+import { loadNuxt } from '../src'
+
+const repoRoot = withoutTrailingSlash(normalize(fileURLToPath(new URL('../../../', import.meta.url))))
+
+describe('loadNuxt', () => {
+  it('respects hook overrides', async () => {
+    let hookRan = false
+    const nuxt = await loadNuxt({
+      cwd: repoRoot,
+      ready: true,
+      overrides: {
+        hooks: {
+          ready() {
+            hookRan = true
+          }
+        }
+      }
+    })
+    await nuxt.close()
+    expect(hookRan).toBe(true)
+  })
+})


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue



### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In consequence of https://github.com/nuxt/nuxt/pull/24639, we were no longer respecting `overrides`. This PR separately adds any override hooks.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
