### PR TITLE
fix(nuxt): add `__VUE_PROD_HYDRATION_MISMATCH_DETAILS__`

### DIFF
--- a/packages/nuxt/test/auto-imports.test.ts
+++ b/packages/nuxt/test/auto-imports.test.ts
@@ -162,6 +162,7 @@ const excludedVueHelpers = [
   'Transition',
   'TransitionGroup',
   'VueElement',
+  'ErrorTypeStrings',
   'createApp',
   'createSSRApp',
   'defineCustomElement',

--- a/packages/schema/src/config/vite.ts
+++ b/packages/schema/src/config/vite.ts
@@ -21,10 +21,11 @@ export default defineUntypedSchema({
     },
     define: {
       $resolve: async (val, get) => {
-        const dev = await get('dev')
+        const [isDev, isDebug] = await Promise.all([get('dev'), get('debug')])
         return {
-          'process.dev': dev,
-          'import.meta.dev': dev,
+          __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: isDebug,
+          'process.dev': isDev,
+          'import.meta.dev': isDev,
           'process.test': isTest,
           'import.meta.test': isTest,
           ...val


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This extracts two fixes from https://github.com/nuxt/nuxt/pull/23998 to allow a future upgrade to Vue 3.4 with fewer changes in future (and also allow vue ecosystem CI to pass). (It enables prod hydration debugging when `debug` is on, though this can be overridden.)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
