### PR TITLE
docs: specify yarn pnp opt-out for install

### DIFF
--- a/docs/1.getting-started/2.installation.md
+++ b/docs/1.getting-started/2.installation.md
@@ -96,6 +96,11 @@ bun install
 
 ::
 
+::callout
+If you are using Yarn 2+ (Berry), add `nodeLinker: node-modules` to your `.yarnrc.yml` file.
+[You can follow this issue status here](https://github.com/nuxt/nuxt/issues/22861)
+::
+
 ## Development Server
 
 Now you'll be able to start your Nuxt app in development mode:


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

[#22861](https://github.com/nuxt/nuxt/issues/22861)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR specifies to use the `nodeLinker: node_modules` mode for Yarn Berry users in the install guide.

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
