### PR TITLE
docs: corrected json syntax in 7.esm.md

### DIFF
--- a/docs/2.guide/1.concepts/7.esm.md
+++ b/docs/2.guide/1.concepts/7.esm.md
@@ -52,7 +52,7 @@ So in Nuxt 2, the bundler (webpack) would pull in the CJS file ('main') for the 
 
 However, in recent Node.js LTS releases, it is now possible to [use native ESM module](https://nodejs.org/api/esm.html) within Node.js. That means that Node.js itself can process JavaScript using ESM syntax, although it doesn't do it by default. The two most common ways to enable ESM syntax are:
 
-- set `type: 'module'` within your `package.json` and keep using `.js` extension
+- set `"type": "module"` within your `package.json` and keep using `.js` extension
 - use the `.mjs` file extensions (recommended)
 
 This is what we do for Nuxt Nitro; we output a `.output/server/index.mjs` file. That tells Node.js to treat this file as a native ES module.
@@ -67,7 +67,7 @@ Node supports the following kinds of imports (see [docs](https://nodejs.org/api/
 
 1. files ending in `.mjs` - these are expected to use ESM syntax
 1. files ending in `.cjs` - these are expected to use CJS syntax
-1. files ending in `.js` - these are expected to use CJS syntax unless their `package.json` has `type: 'module'`
+1. files ending in `.js` - these are expected to use CJS syntax unless their `package.json` has `"type": "module"`
 
 ### What Kinds of Problems Can There Be?
 
@@ -211,7 +211,7 @@ The good news is that it's relatively simple to fix issues of ESM compatibility.
 
 1. **You can opt to make your entire library ESM-only**.
 
-   This would mean setting `type: 'module'` in your `package.json` and ensuring that your built library uses ESM syntax. However, you may face issues with your dependencies - and this approach means your library can _only_ be consumed in an ESM context.
+   This would mean setting `"type": "module"` in your `package.json` and ensuring that your built library uses ESM syntax. However, you may face issues with your dependencies - and this approach means your library can _only_ be consumed in an ESM context.
 
 ### Migration
 


### PR DESCRIPTION
It should be `"type": "module"` and not `type: 'module'`

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
