### PR TITLE
perf(nuxt): avoid double path lookup when generating imports

### DIFF
--- a/packages/nuxt/src/imports/module.ts
+++ b/packages/nuxt/src/imports/module.ts
@@ -153,7 +153,11 @@ function addDeclarationTemplates (ctx: Unimport, options: Partial<ImportsOptions
         return
       }
       let path = resolveAlias(from)
-      if (!isAbsolute(path)) {
+      if (isAbsolute(path)) {
+        path = relative(join(nuxt.options.buildDir, 'types'), path)
+        
+      }
+      else {
         path = await tryResolveModule(from, nuxt.options.modulesDir).then(async (r) => {
           if (!r) { return r }
 
@@ -162,9 +166,6 @@ function addDeclarationTemplates (ctx: Unimport, options: Partial<ImportsOptions
           const subpath = await lookupNodeModuleSubpath(r)
           return join(dir, name, subpath || '')
         }) ?? path
-      }
-      else {
-        path = relative(join(nuxt.options.buildDir, 'types'), path)
       }
 
       path = stripExtension(path)

--- a/packages/nuxt/src/imports/module.ts
+++ b/packages/nuxt/src/imports/module.ts
@@ -155,19 +155,16 @@ function addDeclarationTemplates (ctx: Unimport, options: Partial<ImportsOptions
       let path = resolveAlias(from)
       if (isAbsolute(path)) {
         path = relative(join(nuxt.options.buildDir, 'types'), path)
-        
       }
       else {
         path = await tryResolveModule(from, nuxt.options.modulesDir).then(async (r) => {
           if (!r) { return r }
-
           const { dir, name } = parseNodeModulePath(r)
           if (!dir || !name) { return r }
           const subpath = await lookupNodeModuleSubpath(r)
           return join(dir, name, subpath || '')
         }) ?? path
       }
-
       path = stripExtension(path)
       resolvedImportPathMap.set(from, path)
     }))

--- a/packages/nuxt/src/imports/module.ts
+++ b/packages/nuxt/src/imports/module.ts
@@ -163,7 +163,7 @@ function addDeclarationTemplates (ctx: Unimport, options: Partial<ImportsOptions
           return join(dir, name, subpath || '')
         }) ?? path
       }
-      if (isAbsolute(path)) {
+      else {
         path = relative(join(nuxt.options.buildDir, 'types'), path)
       }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
By using `else` we can avoid a double path lookup when checking if it's absolute, and we won't need to explicitly make another if statement as the return value is a boolean.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
