### PR TITLE
docs: add eslint setup guide

### DIFF
--- a/docs/2.guide/1.concepts/9.code-style.md
+++ b/docs/2.guide/1.concepts/9.code-style.md
@@ -25,7 +25,7 @@ The recommended approach for Nuxt is to enable eslint using [antfu/eslint-config
   bun add -D eslint @antfu/eslint-config
   ```
 
-**Add eslint.config.js to the root folder of your Nuxt app**
+**Add `eslint.config.js` to the root folder of your Nuxt app**
 
 ```js
 import antfu from '@antfu/eslint-config'

--- a/docs/2.guide/1.concepts/9.code-style.md
+++ b/docs/2.guide/1.concepts/9.code-style.md
@@ -7,25 +7,33 @@ description: "Nuxt supports ESLint out of the box"
 
 The recommended approach for Nuxt is to enable ESLint support using [`@nuxt/eslint-config`](https://github.com/nuxt/eslint-config). 
 
-**Install**
+### Install Dependencies
 
-  ```bash [yarn]
-  yarn add --dev eslint @nuxt/eslint-config
-  ```
+Install both ESLint and the Nuxt configuration as development dependencies.
 
-  ```bash [npm]
-  npm install --save-dev eslint @nuxt/eslint-config
-  ```
+::code-group
 
-  ```bash [pnpm]
-  pnpm add -D eslint @nuxt/eslint-config
-  ```
+```bash [yarn]
+yarn add --dev eslint @nuxt/eslint-config
+```
 
-  ```bash [bun]
-  bun add -D eslint @nuxt/eslint-config
-  ```
+```bash [npm]
+npm install --save-dev eslint @nuxt/eslint-config
+```
 
-**Add `.eslintrc.cjs` to the root folder of your Nuxt app**
+```bash [pnpm]
+pnpm add -D eslint @nuxt/eslint-config
+```
+
+```bash [bun]
+bun add -D eslint @nuxt/eslint-config
+```
+
+::
+
+### Configuration
+
+Add `.eslintrc.cjs` to the root folder of your Nuxt app.
 
 ```js
 module.exports = {
@@ -34,7 +42,7 @@ module.exports = {
 }
 ```
 
-## Modify package.json
+### Modify package.json
 
 Add the below to lint commands to your `package.json` script section:
 
@@ -49,7 +57,7 @@ Add the below to lint commands to your `package.json` script section:
 
 Run the lint command to check if the code style is correct or run `lint:fix` to automatically fix issues.
 
-## Configuring VSCode
+### Configuring VSCode
 
 Install the [VSCode ESLint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint).
 

--- a/docs/2.guide/1.concepts/9.code-style.md
+++ b/docs/2.guide/1.concepts/9.code-style.md
@@ -3,9 +3,9 @@ title: 'Code Style'
 description: "Nuxt 3 supports eslint out of the box"
 ---
 
-## Eslint
+## ESLint
 
-The recommended approach for Nuxt is to enable eslint using [`@nuxt/eslint-config`](https://github.com/nuxt/eslint-config). 
+The recommended approach for Nuxt is to enable ESLint support using [`@nuxt/eslint-config`](https://github.com/nuxt/eslint-config). 
 
 **Install**
 
@@ -47,11 +47,11 @@ Add the below to lint commands to your `package.json` script section:
   },
 ```
 
-Run the lint command to check if the codestyle is correct or run `lint:fix` to automatically fix issues.
+Run the lint command to check if the code style is correct or run `lint:fix` to automatically fix issues.
 
 ## Configuring VSCode
 
-Install the [VSCode eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint).
+Install the [VSCode ESLint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint).
 
 In VSCode press `ctrl+shift+p` (`cmd+shift+p` on Mac) to open the command prompt, find `Open Workspace Settings (JSON)`, add the below lines to the JSON and save:
 

--- a/docs/2.guide/1.concepts/9.code-style.md
+++ b/docs/2.guide/1.concepts/9.code-style.md
@@ -7,6 +7,12 @@ description: "Nuxt supports ESLint out of the box"
 
 The recommended approach for Nuxt is to enable ESLint support using [`@nuxt/eslint-config`](https://github.com/nuxt/eslint-config).
 
+At the moment, this configuration will not format your files; you can set up Prettier or another tool to do so.
+
+::alert{type=info}
+We're currently working to refactor the Nuxt ESLint configuration. Subscribe to [the Nuxt ESLint roadmap](https://github.com/nuxt/eslint-config/issues/303) to follow updates.]
+::
+
 ### Install Dependencies
 
 Install both ESLint and the Nuxt configuration as development dependencies.
@@ -55,7 +61,7 @@ Add the below to lint commands to your `package.json` script section:
   },
 ```
 
-Run the lint command to check if the code style is correct or run `lint:fix` to automatically fix issues.
+Run the `lint` command to check if the code style is correct or run `lint:fix` to automatically fix issues.
 
 ### Configuring VS Code
 

--- a/docs/2.guide/1.concepts/9.code-style.md
+++ b/docs/2.guide/1.concepts/9.code-style.md
@@ -1,0 +1,68 @@
+---
+title: 'Code Style'
+description: "Nuxt 3 supports eslint and prettier out of the box"
+---
+
+## Eslint
+
+The recommended approach for Nuxt is to enable eslint using [antfu/eslint-config](https://github.com/antfu/eslint-config). 
+
+**Install**
+
+  ```bash [yarn]
+  yarn add --dev eslint @antfu/eslint-config
+  ```
+
+  ```bash [npm]
+  npm install --save-dev eslint @antfu/eslint-config
+  ```
+
+  ```bash [pnpm]
+  pnpm add -D eslint @antfu/eslint-config
+  ```
+
+  ```bash [bun]
+  bun add -D eslint @antfu/eslint-config
+  ```
+
+**Add eslint.config.js to the root of your app**
+
+```js
+import antfu from '@antfu/eslint-config'
+
+export default antfu()
+```
+
+## Modify package.json
+
+Add the below to lint commands to your `package.json` script section:
+
+```json
+  "scripts": {
+    ...
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    ...
+  },
+```
+
+Run the lint command to check if the codestyle is correct or run `lint:fix` to automatically fix issues.
+
+## Configuring VSCode
+
+Install the [VSCode eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint).
+
+In VSCode press `ctrl+shift+p` (`cmd+shift+p` on Mac) to open the command prompt, find `Open Workspace Settings (JSON)`, add the below lines to the JSON and save:
+
+```json
+{
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  }
+}
+```
+
+
+You're good to go! On save, your files will be formatted. 
+

--- a/docs/2.guide/1.concepts/9.code-style.md
+++ b/docs/2.guide/1.concepts/9.code-style.md
@@ -25,7 +25,7 @@ The recommended approach for Nuxt is to enable eslint using [antfu/eslint-config
   bun add -D eslint @antfu/eslint-config
   ```
 
-**Add eslint.config.js to the root of your app**
+**Add eslint.config.js to the root folder of your Nuxt app**
 
 ```js
 import antfu from '@antfu/eslint-config'

--- a/docs/2.guide/1.concepts/9.code-style.md
+++ b/docs/2.guide/1.concepts/9.code-style.md
@@ -1,6 +1,6 @@
 ---
 title: 'Code Style'
-description: "Nuxt 3 supports eslint out of the box"
+description: "Nuxt supports ESLint out of the box"
 ---
 
 ## ESLint

--- a/docs/2.guide/1.concepts/9.code-style.md
+++ b/docs/2.guide/1.concepts/9.code-style.md
@@ -65,12 +65,11 @@ In VSCode press `ctrl+shift+p` (`cmd+shift+p` on Mac) to open the command prompt
 
 ```json
 {
-  "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   }
 }
 ```
 
-You're good to go! On save, your files will be formatted. 
+You're good to go! On save, your files will be linted and auto-fixed.
 

--- a/docs/2.guide/1.concepts/9.code-style.md
+++ b/docs/2.guide/1.concepts/9.code-style.md
@@ -1,36 +1,37 @@
 ---
 title: 'Code Style'
-description: "Nuxt 3 supports eslint and prettier out of the box"
+description: "Nuxt 3 supports eslint out of the box"
 ---
 
 ## Eslint
 
-The recommended approach for Nuxt is to enable eslint using [antfu/eslint-config](https://github.com/antfu/eslint-config). 
+The recommended approach for Nuxt is to enable eslint using [`@nuxt/eslint-config`](https://github.com/nuxt/eslint-config). 
 
 **Install**
 
   ```bash [yarn]
-  yarn add --dev eslint @antfu/eslint-config
+  yarn add --dev eslint @nuxt/eslint-config
   ```
 
   ```bash [npm]
-  npm install --save-dev eslint @antfu/eslint-config
+  npm install --save-dev eslint @nuxt/eslint-config
   ```
 
   ```bash [pnpm]
-  pnpm add -D eslint @antfu/eslint-config
+  pnpm add -D eslint @nuxt/eslint-config
   ```
 
   ```bash [bun]
-  bun add -D eslint @antfu/eslint-config
+  bun add -D eslint @nuxt/eslint-config
   ```
 
-**Add `eslint.config.js` to the root folder of your Nuxt app**
+**Add `.eslintrc.cjs` to the root folder of your Nuxt app**
 
 ```js
-import antfu from '@antfu/eslint-config'
-
-export default antfu()
+module.exports = {
+  root: true,
+  extends: ['@nuxt/eslint-config'],
+}
 ```
 
 ## Modify package.json
@@ -62,7 +63,6 @@ In VSCode press `ctrl+shift+p` (`cmd+shift+p` on Mac) to open the command prompt
   }
 }
 ```
-
 
 You're good to go! On save, your files will be formatted. 
 

--- a/docs/2.guide/1.concepts/9.code-style.md
+++ b/docs/2.guide/1.concepts/9.code-style.md
@@ -5,7 +5,7 @@ description: "Nuxt supports ESLint out of the box"
 
 ## ESLint
 
-The recommended approach for Nuxt is to enable ESLint support using [`@nuxt/eslint-config`](https://github.com/nuxt/eslint-config). 
+The recommended approach for Nuxt is to enable ESLint support using [`@nuxt/eslint-config`](https://github.com/nuxt/eslint-config).
 
 ### Install Dependencies
 
@@ -57,11 +57,11 @@ Add the below to lint commands to your `package.json` script section:
 
 Run the lint command to check if the code style is correct or run `lint:fix` to automatically fix issues.
 
-### Configuring VSCode
+### Configuring VS Code
 
-Install the [VSCode ESLint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint).
+Install the [VS Code ESLint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint).
 
-In VSCode press `ctrl+shift+p` (`cmd+shift+p` on Mac) to open the command prompt, find `Open Workspace Settings (JSON)`, add the below lines to the JSON and save:
+In VS Code press `ctrl+shift+p` (`cmd+shift+p` on Mac) to open the command prompt, find `Open Workspace Settings (JSON)`, add the below lines to the JSON and save:
 
 ```json
 {
@@ -72,4 +72,3 @@ In VSCode press `ctrl+shift+p` (`cmd+shift+p` on Mac) to open the command prompt
 ```
 
 You're good to go! On save, your files will be linted and auto-fixed.
-


### PR DESCRIPTION
I found @antfu 's eslint package to be the best approach to enable eslint in a Nuxt project and since imho its not really clear on how to set up eslint etc in Nuxt, I've documented it. So if people agree lets add it to the docs?