### PR TITLE
docs: add callouts for `readValidatedBody` and `getValidatedQuery`

### DIFF
--- a/docs/2.guide/2.directory-structure/1.server.md
+++ b/docs/2.guide/2.directory-structure/1.server.md
@@ -231,7 +231,7 @@ export default defineEventHandler(async (event) => {
 ```
 
 ::callout{icon="i-ph-lightbulb" color="green" to="https://unjs.io/blog/2023-08-15-h3-towards-the-edge-of-the-web#runtime-type-safe-request-utils"}
-Alternatively, use `readValidatedBody` with schema validators such as Zod for runtime and type safety.
+Alternatively, use `readValidatedBody` with a schema validator such as Zod for runtime and type safety.
 ::
 
 You can now universally call this API using:
@@ -264,7 +264,7 @@ export default defineEventHandler((event) => {
 ```
 
 ::callout{icon="i-ph-lightbulb" color="green" to="https://unjs.io/blog/2023-08-15-h3-towards-the-edge-of-the-web#runtime-type-safe-request-utils"}
-Alternatively, use `getValidatedQuery` with schema validators such as Zod for runtime and type safety.
+Alternatively, use `getValidatedQuery` with a schema validator such as Zod for runtime and type safety.
 ::
 
 ### Error Handling

--- a/docs/2.guide/2.directory-structure/1.server.md
+++ b/docs/2.guide/2.directory-structure/1.server.md
@@ -230,6 +230,10 @@ export default defineEventHandler(async (event) => {
 })
 ```
 
+::callout{icon="i-ph-lightbulb" color="green" to="https://unjs.io/blog/2023-08-15-h3-towards-the-edge-of-the-web#runtime-type-safe-request-utils"}
+Alternatively, use `readValidatedBody` with schema validators such as Zod for runtime and type safety.
+::
+
 You can now universally call this API using:
 
 ```vue [app.vue]
@@ -258,6 +262,10 @@ export default defineEventHandler((event) => {
   return { a: query.foo, b: query.baz }
 })
 ```
+
+::callout{icon="i-ph-lightbulb" color="green" to="https://unjs.io/blog/2023-08-15-h3-towards-the-edge-of-the-web#runtime-type-safe-request-utils"}
+Alternatively, use `getValidatedQuery` with schema validators such as Zod for runtime and type safety.
+::
 
 ### Error Handling
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

#24429 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

As discussed in #24429, the documentation is currently lacking examples of validating `body` and `query` on the server side. This PR adds initial mentions of the functions to the docs. 

I also intend to add some examples, however this will take more time and I can open a subsequent PR for those.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
