### PR TITLE
docs: add an example of provide in object syntax plugins

### DIFF
--- a/docs/2.guide/2.directory-structure/1.plugins.md
+++ b/docs/2.guide/2.directory-structure/1.plugins.md
@@ -169,8 +169,8 @@ export default defineNuxtPlugin(() => {
 ```
 ```ts [plugins/hello-object-syntax.ts]
 export default defineNuxtPlugin({
-  name: "hello",
-  setup(nuxtApp) {
+  name: 'hello',
+  setup () {
     return {
       provide: {
         hello: (msg: string) => `Hello ${msg}!`

--- a/docs/2.guide/2.directory-structure/1.plugins.md
+++ b/docs/2.guide/2.directory-structure/1.plugins.md
@@ -155,7 +155,7 @@ Normally, Vue.js composables are bound to the current component instance while p
 
 ## Providing Helpers
 
-If you would like to provide a helper on the [`NuxtApp`](/docs/api/composables/use-nuxt-app) instance, return it from the plugin under a `provide` key. You can also use `nuxtApp.provide()` if you are using object syntax.
+If you would like to provide a helper on the [`NuxtApp`](/docs/api/composables/use-nuxt-app) instance, return it from the plugin under a `provide` key.
 
 ::code-group
 ```ts [plugins/hello.ts]
@@ -171,7 +171,11 @@ export default defineNuxtPlugin(() => {
 export default defineNuxtPlugin({
   name: "hello",
   setup(nuxtApp) {
-    nuxtApp.provide('hello', (msg: string) => `Hello ${msg}!`)
+    return {
+      provide: {
+        hello: (msg: string) => `Hello ${msg}!`
+      }
+    }
   }
 })
 ```

--- a/docs/2.guide/2.directory-structure/1.plugins.md
+++ b/docs/2.guide/2.directory-structure/1.plugins.md
@@ -155,8 +155,9 @@ Normally, Vue.js composables are bound to the current component instance while p
 
 ## Providing Helpers
 
-If you would like to provide a helper on the [`NuxtApp`](/docs/api/composables/use-nuxt-app) instance, return it from the plugin under a `provide` key.
+If you would like to provide a helper on the [`NuxtApp`](/docs/api/composables/use-nuxt-app) instance, return it from the plugin under a `provide` key. You can also use `nuxtApp.provide()` if you are using object syntax.
 
+::code-group
 ```ts [plugins/hello.ts]
 export default defineNuxtPlugin(() => {
   return {
@@ -166,6 +167,15 @@ export default defineNuxtPlugin(() => {
   }
 })
 ```
+```ts [plugins/hello-object-syntax.ts]
+export default defineNuxtPlugin({
+  name: "hello",
+  setup(nuxtApp) {
+    nuxtApp.provide('hello', (msg: string) => `Hello ${msg}!`)
+  }
+})
+```
+::
 
 You can then use the helper in your components:
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

There is no open issue for this.
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The doc has an example of `provide`. The example can't be used when the plugin uses object syntax. This adds an example for that case.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
