### PR TITLE
docs: add missing imports for nitro examples

### DIFF
--- a/docs/3.api/5.kit/11.nitro.md
+++ b/docs/3.api/5.kit/11.nitro.md
@@ -382,7 +382,7 @@ A directory or an array of directories to register to be scanned by Nitro
 ### Examples
 
 ```ts
-import { defineNuxtModule, addServerImportsDir } from '@nuxt/kit'
+import { defineNuxtModule, createResolver, addServerImportsDir } from '@nuxt/kit'
 
 export default defineNuxtModule({
   meta: {
@@ -420,7 +420,7 @@ A directory or an array of directories to register to be scanned for by Nitro as
 ### Examples
 
 ```ts
-import { defineNuxtModule, addServerScanDir } from '@nuxt/kit'
+import { defineNuxtModule, createResolver, addServerScanDir } from '@nuxt/kit'
 export default defineNuxtModule({
   meta: {
     name: 'my-module',


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

There is no open issue for this.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds missing imports to the examples of the `addServerImportsDir` and `addServerScanDir` utilities.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
