### PR TITLE
fix(nuxt): do not warn about missing layouts on error page

### DIFF
--- a/packages/nuxt/src/app/plugins/check-if-layout-used.ts
+++ b/packages/nuxt/src/app/plugins/check-if-layout-used.ts
@@ -1,5 +1,6 @@
 import { defineNuxtPlugin } from '../nuxt'
 import { onNuxtReady } from '../composables/ready'
+import { useError } from '../composables/error'
 
 // @ts-expect-error virtual file
 import layouts from '#build/layouts'
@@ -7,8 +8,10 @@ import layouts from '#build/layouts'
 export default defineNuxtPlugin({
   name: 'nuxt:checkIfLayoutUsed',
   setup (nuxtApp) {
+    const error = useError()
+
     function checkIfLayoutUsed () {
-      if (!nuxtApp._isNuxtLayoutUsed && Object.keys(layouts).length > 0) {
+      if (!error.value && !nuxtApp._isNuxtLayoutUsed && Object.keys(layouts).length > 0) {
         console.warn('[nuxt] Your project has layouts but the `<NuxtLayout />` component has not been used.')
       }
     }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/24912

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This should fix an over-eager check to see if layouts are being used on the error page.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
