### PR TITLE
fix(nuxt): reuse intermediate setup state in `<ClientOnly>`

### DIFF
--- a/packages/nuxt/src/app/components/client-only.ts
+++ b/packages/nuxt/src/app/components/client-only.ts
@@ -1,4 +1,4 @@
-import { createElementBlock, createElementVNode, createStaticVNode, defineComponent, getCurrentInstance, h, onMounted, ref } from 'vue'
+import { cloneVNode, createElementBlock, createElementVNode, createStaticVNode, defineComponent, getCurrentInstance, h, onMounted, ref } from 'vue'
 import type { ComponentInternalInstance, ComponentOptions } from 'vue'
 import { getFragmentHTML } from './utils'
 
@@ -37,7 +37,7 @@ export function createClientOnly<T extends ComponentOptions> (component: T) {
       if ($setup.mounted$ ?? ctx.mounted$) {
         const res = component.render?.bind(ctx)(ctx, cache, $props, $setup, $data, $options)
         return (res.children === null || typeof res.children === 'string')
-          ? createElementVNode(res.type, res.props, res.children, res.patchFlag, res.dynamicProps, res.shapeFlag)
+          ? cloneVNode(res)
           : h(res)
       } else {
         const fragment = getFragmentHTML(ctx._.vnode.el ?? null) ?? ['<div></div>']
@@ -79,7 +79,7 @@ export function createClientOnly<T extends ComponentOptions> (component: T) {
           if (mounted$.value) {
             const res = setupState(...args)
             return (res.children === null || typeof res.children === 'string')
-              ? createElementVNode(res.type, res.props, res.children, res.patchFlag, res.dynamicProps, res.shapeFlag)
+              ? cloneVNode(res)
               : h(res)
           } else {
             const fragment = getFragmentHTML(instance?.vnode.el ?? null) ?? ['<div></div>']

--- a/packages/nuxt/src/app/components/client-only.ts
+++ b/packages/nuxt/src/app/components/client-only.ts
@@ -1,4 +1,4 @@
-import { cloneVNode, createElementBlock, createElementVNode, createStaticVNode, defineComponent, getCurrentInstance, h, onMounted, ref } from 'vue'
+import { cloneVNode, createElementBlock, createStaticVNode, defineComponent, getCurrentInstance, h, onMounted, ref } from 'vue'
 import type { ComponentInternalInstance, ComponentOptions } from 'vue'
 import { getFragmentHTML } from './utils'
 

--- a/test/fixtures/basic/components/ClientWrapped.client.vue
+++ b/test/fixtures/basic/components/ClientWrapped.client.vue
@@ -4,11 +4,11 @@ function exposedFunc () {
 }
 
 defineExpose({ exposedFunc })
-
+const $hello = ref('hello')
 await new Promise(resolve => setTimeout(resolve, 300))
 
 onMounted(() => {
-  console.log('mounted')
+  console.log('mounted', $hello.value)
 })
 </script>
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/22435

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This resolves an extraneous warning from Vue about properties accessed in setup functions within client-only components that start with `$`. By avoiding spreading the setup state, we preserve the getter that indicates it's a script setup return and avoid a warning from Vue.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
