### PR TITLE
fix(nuxt): warn when scanning layout/middleware without name

### DIFF
--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -1,5 +1,5 @@
 import { promises as fsp, mkdirSync, writeFileSync } from 'node:fs'
-import { dirname, join, resolve } from 'pathe'
+import { dirname, join, relative, resolve } from 'pathe'
 import { defu } from 'defu'
 import { compileTemplate, findPath, logger, normalizePlugin, normalizeTemplate, resolveAlias, resolveFiles, resolvePath, templateUtils, tryResolveModule } from '@nuxt/kit'
 import type { Nuxt, NuxtApp, NuxtPlugin, NuxtTemplate, ResolvedNuxtTemplate } from 'nuxt/schema'
@@ -117,6 +117,11 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
     const layoutFiles = await resolveFiles(config.srcDir, `${layoutDir}/**/*{${nuxt.options.extensions.join(',')}}`)
     for (const file of layoutFiles) {
       const name = getNameFromPath(file, resolve(config.srcDir, layoutDir))
+      if (!name) {
+        // Ignore files like `~/layouts/index.vue` which end up not having a name at all
+        logger.warn(`No layout name could not be resolved for \`~/${relative(nuxt.options.srcDir, file)}\`. Bear in mind that \`index\` is ignored for the purpose of creating a layout name.`)
+        continue
+      }
       app.layouts[name] = app.layouts[name] || { name, file }
     }
   }

--- a/packages/nuxt/test/app.test.ts
+++ b/packages/nuxt/test/app.test.ts
@@ -80,16 +80,34 @@ describe('resolveApp', () => {
     `)
   })
 
-  it('resolves layouts correctly', async () => {
+  it('resolves layouts and middleware correctly', async () => {
     const app = await getResolvedApp([
+      'middleware/index.ts',
+      'middleware/auth/index.ts',
+      'middleware/other.ts',
       'layouts/index.vue',
       'layouts/default/index.vue',
+      'layouts/other.vue',
     ])
+    // Middleware are not resolved in a nested manner
+    expect(app.middleware.filter(m => m.path.startsWith('<rootDir>'))).toMatchInlineSnapshot(`
+      [
+        {
+          "global": false,
+          "name": "other",
+          "path": "<rootDir>/middleware/other.ts",
+        },
+      ]
+    `)
     expect(app.layouts).toMatchInlineSnapshot(`
       {
         "default": {
           "file": "<rootDir>/layouts/default/index.vue",
           "name": "default",
+        },
+        "other": {
+          "file": "<rootDir>/layouts/other.vue",
+          "name": "other",
         },
       }
     `)

--- a/packages/nuxt/test/app.test.ts
+++ b/packages/nuxt/test/app.test.ts
@@ -80,6 +80,21 @@ describe('resolveApp', () => {
     `)
   })
 
+  it('resolves layouts correctly', async () => {
+    const app = await getResolvedApp([
+      'layouts/index.vue',
+      'layouts/default/index.vue',
+    ])
+    expect(app.layouts).toMatchInlineSnapshot(`
+      {
+        "default": {
+          "file": "<rootDir>/layouts/default/index.vue",
+          "name": "default",
+        },
+      }
+    `)
+  })
+
   it('resolves layer plugins in correct order', async () => {
     const app = await getResolvedApp([
       // layer 1


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/24988

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds a warning a layout that does not resolve to a name is detected, like `~/layouts/index.vue`

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
