### PR TITLE
fix(nuxt): wrap `currentRoute` in a `Ref` when not using `vue-router`

### DIFF
--- a/packages/nuxt/src/app/plugins/router.ts
+++ b/packages/nuxt/src/app/plugins/router.ts
@@ -1,4 +1,5 @@
-import { defineComponent, h, isReadonly, reactive } from 'vue'
+import type { Ref } from 'vue'
+import { computed, defineComponent, h, isReadonly, reactive } from 'vue'
 import { isEqual, joinURL, parseQuery, parseURL, stringifyParsedURL, stringifyQuery, withoutBase } from 'ufo'
 import { createError } from 'h3'
 import { defineNuxtPlugin, useRuntimeConfig } from '../nuxt'
@@ -71,7 +72,7 @@ interface RouterHooks {
 }
 
 interface Router {
-  currentRoute: Route
+  currentRoute: Ref<Route>
   isReady: () => Promise<void>
   options: {}
   install: () => Promise<void>
@@ -159,7 +160,7 @@ export default defineNuxtPlugin<{ route: Route, router: Router }>({
     }
 
     const router: Router = {
-      currentRoute: route,
+      currentRoute: computed(() => route),
       isReady: () => Promise.resolve(),
       // These options provide a similar API to vue-router but have no effect
       options: {},

--- a/packages/nuxt/src/app/plugins/router.ts
+++ b/packages/nuxt/src/app/plugins/router.ts
@@ -159,8 +159,21 @@ export default defineNuxtPlugin<{ route: Route, router: Router }>({
       }
     }
 
+    const currentRoute = computed(() => route)
+    // TODO: remove this in v3.10
+    for (const key in route) {
+      Object.defineProperty(currentRoute, key, {
+        get () {
+          if (import.meta.dev) {
+            console.warn(`'route.${key}' is deprecated. Use 'route.value.${key}' instead.`)
+          }
+          return route[key as keyof Route]
+        }
+      })
+    }
+
     const router: Router = {
-      currentRoute: computed(() => route),
+      currentRoute,
       isReady: () => Promise.resolve(),
       // These options provide a similar API to vue-router but have no effect
       options: {},

--- a/packages/nuxt/src/app/plugins/router.ts
+++ b/packages/nuxt/src/app/plugins/router.ts
@@ -165,7 +165,7 @@ export default defineNuxtPlugin<{ route: Route, router: Router }>({
       Object.defineProperty(currentRoute, key, {
         get () {
           if (import.meta.dev) {
-            console.warn(`'route.${key}' is deprecated. Use 'route.value.${key}' instead.`)
+            console.warn(`\`currentRoute.${key}\` is deprecated. Use \`currentRoute.value.${key}\` instead.`)
           }
           return route[key as keyof Route]
         }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/24798

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This updates `useRouter().currentRoute` to be a `Ref`. This was a mistake in the original implementation but I've added a deprecation for now; we can finish the fix in v3.10 by removing direct access to these properties.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
