### PR TITLE
docs: add documentation about lost reactivity from provide

### DIFF
--- a/docs/2.guide/2.directory-structure/1.plugins.md
+++ b/docs/2.guide/2.directory-structure/1.plugins.md
@@ -202,7 +202,7 @@ Note that we highly recommend using [`composables`](/docs/guide/directory-struct
 
 ::callout{color="amber" icon="i-ph-warning-duotone"}
 **If your plugin provides reactive properties (such as `ref`, `computed`, `reactive` and the likes) they will lose their template reactivity.** :br
-This is due to how Vue works with reactive objects that aren't top-level to the template. You can read more about it [here](https://vuejs.org/guide/essentials/reactivity-fundamentals.html#caveat-when-unwrapping-in-templates).
+This is due to how Vue works with reactive objects that aren't top-level to the template. You can read more about it [in the Vue documentation](https://vuejs.org/guide/essentials/reactivity-fundamentals.html#caveat-when-unwrapping-in-templates).
 ::
 
 ## Typing Plugins

--- a/docs/2.guide/2.directory-structure/1.plugins.md
+++ b/docs/2.guide/2.directory-structure/1.plugins.md
@@ -201,7 +201,7 @@ Note that we highly recommend using [`composables`](/docs/guide/directory-struct
 ::
 
 ::callout{color="amber" icon="i-ph-warning-duotone"}
-**If your plugin provides reactive properties (`ref`/`computed`/`reactive`...) they will lose their template reactivity.**
+**If your plugin provides reactive properties (such as `ref`, `computed`, `reactive` and the likes) they will lose their template reactivity.**
 This is due to how Vue works with nested reactive objects. You can read more about it [here](https://vuejs.org/guide/essentials/reactivity-fundamentals.html#caveat-when-unwrapping-in-templates).
 ::
 

--- a/docs/2.guide/2.directory-structure/1.plugins.md
+++ b/docs/2.guide/2.directory-structure/1.plugins.md
@@ -201,8 +201,8 @@ Note that we highly recommend using [`composables`](/docs/guide/directory-struct
 ::
 
 ::callout{color="amber" icon="i-ph-warning-duotone"}
-**If your plugin provides reactive properties (such as `ref`, `computed`, `reactive` and the likes) they will lose their template reactivity.** :br
-This is due to how Vue works with reactive objects that aren't top-level to the template. You can read more about it [in the Vue documentation](https://vuejs.org/guide/essentials/reactivity-fundamentals.html#caveat-when-unwrapping-in-templates).
+**If your plugin provides a `ref` or `computed`, it will not be unwrapped in a component `<template>`.** :br
+This is due to how Vue works with refs that aren't top-level to the template. You can read more about it [in the Vue documentation](https://vuejs.org/guide/essentials/reactivity-fundamentals.html#caveat-when-unwrapping-in-templates).
 ::
 
 ## Typing Plugins

--- a/docs/2.guide/2.directory-structure/1.plugins.md
+++ b/docs/2.guide/2.directory-structure/1.plugins.md
@@ -202,7 +202,7 @@ Note that we highly recommend using [`composables`](/docs/guide/directory-struct
 
 ::callout{color="amber" icon="i-ph-warning-duotone"}
 **If your plugin provides reactive properties (such as `ref`, `computed`, `reactive` and the likes) they will lose their template reactivity.**
-This is due to how Vue works with nested reactive objects. You can read more about it [here](https://vuejs.org/guide/essentials/reactivity-fundamentals.html#caveat-when-unwrapping-in-templates).
+This is due to how Vue works with reactive objects that aren't top-level to the template. You can read more about it [here](https://vuejs.org/guide/essentials/reactivity-fundamentals.html#caveat-when-unwrapping-in-templates).
 ::
 
 ## Typing Plugins

--- a/docs/2.guide/2.directory-structure/1.plugins.md
+++ b/docs/2.guide/2.directory-structure/1.plugins.md
@@ -200,6 +200,11 @@ const { $hello } = useNuxtApp()
 Note that we highly recommend using [`composables`](/docs/guide/directory-structure/composables) instead of providing helpers to avoid polluting the global namespace and keep your main bundle entry small.
 ::
 
+::callout{color="amber" icon="i-ph-warning-duotone"}
+**If your plugin provides reactive properties (`ref`/`computed`/`reactive`...) they will lose their template reactivity.**
+This is due to how Vue works with nested reactive objects. You can read more about it [here](https://vuejs.org/guide/essentials/reactivity-fundamentals.html#caveat-when-unwrapping-in-templates).
+::
+
 ## Typing Plugins
 
 If you return your helpers from the plugin, they will be typed automatically; you'll find them typed for the return of `useNuxtApp()` and within your templates.

--- a/docs/2.guide/2.directory-structure/1.plugins.md
+++ b/docs/2.guide/2.directory-structure/1.plugins.md
@@ -201,7 +201,7 @@ Note that we highly recommend using [`composables`](/docs/guide/directory-struct
 ::
 
 ::callout{color="amber" icon="i-ph-warning-duotone"}
-**If your plugin provides reactive properties (such as `ref`, `computed`, `reactive` and the likes) they will lose their template reactivity.**
+**If your plugin provides reactive properties (such as `ref`, `computed`, `reactive` and the likes) they will lose their template reactivity.** :br
 This is due to how Vue works with reactive objects that aren't top-level to the template. You can read more about it [here](https://vuejs.org/guide/essentials/reactivity-fundamentals.html#caveat-when-unwrapping-in-templates).
 ::
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
Closes #25050
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Vue's nested reactive properties (nested in the sense that they are not top-level) lose template reactivity. It would be a good idea, as suggested in https://github.com/nuxt/nuxt/issues/25050#issuecomment-1877617625, to add this warning to the docs so that it would be clearer for newcomers who may not know how reactivity works fully.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
