### PR TITLE
docs: add callout for `getValidatedRouterParams`

### DIFF
--- a/docs/2.guide/2.directory-structure/1.server.md
+++ b/docs/2.guide/2.directory-structure/1.server.md
@@ -158,6 +158,10 @@ export default defineEventHandler((event) => {
 })
 ```
 
+::callout{icon="i-ph-lightbulb" color="green"}
+Alternatively, use `getValidatedRouterParams` with a schema validator such as Zod for runtime and type safety.
+::
+
 You can now universally call this API on `/api/hello/nuxt` and get `Hello, nuxt!`.
 
 ### Matching HTTP Method


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

#24429

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

As suggested in [this comment](https://github.com/nuxt/nuxt/issues/24429#issuecomment-1824850624), add a callout for `getValidatedRouterParams` in the appropriate section. 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
