### PR TITLE
fix(nuxt): add script block if there's none before island transformation

### DIFF
--- a/packages/nuxt/src/components/islandsTransform.ts
+++ b/packages/nuxt/src/components/islandsTransform.ts
@@ -58,7 +58,7 @@ export const islandsTransform = createUnplugin((options: ServerOnlyComponentTran
       const startingIndex = template.index || 0
       const s = new MagicString(code)
 
-      if(!code.match(SCRIPT_RE)) {
+      if (!code.match(SCRIPT_RE)) {
         s.prepend('<script setup>' + IMPORT_CODE + '</script>')
       } else {
         s.replace(SCRIPT_RE, (full) => {

--- a/packages/nuxt/src/components/islandsTransform.ts
+++ b/packages/nuxt/src/components/islandsTransform.ts
@@ -33,6 +33,7 @@ const SCRIPT_RE = /<script[^>]*>/g
 const HAS_SLOT_OR_CLIENT_RE = /(<slot[^>]*>)|(nuxt-client)/
 const TEMPLATE_RE = /<template>([\s\S]*)<\/template>/
 const NUXTCLIENT_ATTR_RE = /\snuxt-client(="[^"]*")?/g
+const IMPORT_CODE = '\nimport { vforToArray as __vforToArray } from \'#app/components/utils\'' + '\nimport NuxtTeleportSsrClient from \'#app/components/nuxt-teleport-ssr-client\''
 
 export const islandsTransform = createUnplugin((options: ServerOnlyComponentTransformPluginOptions, meta) => {
   const isVite = meta.framework === 'vite'
@@ -57,9 +58,15 @@ export const islandsTransform = createUnplugin((options: ServerOnlyComponentTran
       const startingIndex = template.index || 0
       const s = new MagicString(code)
 
-      s.replace(SCRIPT_RE, (full) => {
-        return full + '\nimport { vforToArray as __vforToArray } from \'#app/components/utils\'' + '\nimport NuxtTeleportSsrClient from \'#app/components/nuxt-teleport-ssr-client\''
-      })
+      if(!code.match(SCRIPT_RE)) {
+        console.log(id)
+        s.prepend('<script setup>' + IMPORT_CODE + '</script>')
+      } else {
+        s.replace(SCRIPT_RE, (full) => {
+          return full + IMPORT_CODE 
+        })
+      }
+
 
       let hasNuxtClient = false
 

--- a/packages/nuxt/src/components/islandsTransform.ts
+++ b/packages/nuxt/src/components/islandsTransform.ts
@@ -59,7 +59,6 @@ export const islandsTransform = createUnplugin((options: ServerOnlyComponentTran
       const s = new MagicString(code)
 
       if(!code.match(SCRIPT_RE)) {
-        console.log(id)
         s.prepend('<script setup>' + IMPORT_CODE + '</script>')
       } else {
         s.replace(SCRIPT_RE, (full) => {

--- a/packages/nuxt/test/islandTransform.test.ts
+++ b/packages/nuxt/test/islandTransform.test.ts
@@ -317,6 +317,31 @@ describe('islandTransform - server and island components', () => {
                 "
         `)
       })
+
+      it('should add import if there is no scripts in the SFC', async () => {
+        const result = await viteTransform(`<template>
+        <div>
+          <HelloWorld />
+          <HelloWorld nuxt-client />
+        </div>
+      </template>
+      
+      `, 'hello.server.vue', false, true)
+
+      expect(result).toMatchInlineSnapshot(`
+        "<script setup>
+        import { vforToArray as __vforToArray } from '#app/components/utils'
+        import NuxtTeleportSsrClient from '#app/components/nuxt-teleport-ssr-client'</script><template>
+                <div>
+                  <HelloWorld />
+                  <NuxtTeleportSsrClient to="HelloWorld-CyH3UXLuYA"  :nuxt-client="true"><HelloWorld /></NuxtTeleportSsrClient>
+                </div>
+              </template>
+              
+              "
+      `)
+      expect(result).toContain(`import NuxtTeleportSsrClient from '#app/components/nuxt-teleport-ssr-client'`)
+      })
     })
 
     describe('webpack', () => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

fix #25147

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Hi :wave: 
This PR fix #25147 because in the example, there's no `<script>` block so the SFC will be missing imports when transformed by `islandTransform` plugin

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
