### PR TITLE
fix(nuxt): apply more import protections for nitro runtime

### DIFF
--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -17,7 +17,7 @@ import { template as defaultSpaLoadingTemplate } from '@nuxt/ui-templates/templa
 import { version as nuxtVersion } from '../../package.json'
 import { distDir } from '../dirs'
 import { toArray } from '../utils'
-import { ImportProtectionPlugin } from './plugins/import-protection'
+import { ImportProtectionPlugin, nuxtImportProtections } from './plugins/import-protection'
 
 export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
   // Resolve config
@@ -339,10 +339,7 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
   nitroConfig.rollupConfig!.plugins!.push(
     ImportProtectionPlugin.rollup({
       rootDir: nuxt.options.rootDir,
-      patterns: [
-        ...['#app', /^#build(\/|$)/]
-          .map(p => [p, 'Vue app aliases are not allowed in server routes.']) as [RegExp | string, string][]
-      ],
+      patterns: nuxtImportProtections(nuxt, true /* isNitro */),
       exclude: [/core[\\/]runtime[\\/]nitro[\\/]renderer/]
     })
   )

--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -339,7 +339,7 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
   nitroConfig.rollupConfig!.plugins!.push(
     ImportProtectionPlugin.rollup({
       rootDir: nuxt.options.rootDir,
-      patterns: nuxtImportProtections(nuxt, true /* isNitro */),
+      patterns: nuxtImportProtections(nuxt, { isNitro: true }),
       exclude: [/core[\\/]runtime[\\/]nitro[\\/]renderer/]
     })
   )

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -16,7 +16,7 @@ import importsModule from '../imports/module'
 /* eslint-enable */
 import { distDir, pkgDir } from '../dirs'
 import { version } from '../../package.json'
-import { ImportProtectionPlugin, vueAppPatterns } from './plugins/import-protection'
+import { ImportProtectionPlugin, nuxtImportProtections } from './plugins/import-protection'
 import type { UnctxTransformPluginOptions } from './plugins/unctx'
 import { UnctxTransformPlugin } from './plugins/unctx'
 import type { TreeShakeComposablesPluginOptions } from './plugins/tree-shake'
@@ -89,7 +89,7 @@ async function initNuxt (nuxt: Nuxt) {
     rootDir: nuxt.options.rootDir,
     // Exclude top-level resolutions by plugins
     exclude: [join(nuxt.options.rootDir, 'index.html')],
-    patterns: vueAppPatterns(nuxt)
+    patterns: nuxtImportProtections(nuxt)
   }
   addVitePlugin(() => ImportProtectionPlugin.vite(config))
   addWebpackPlugin(() => ImportProtectionPlugin.webpack(config))

--- a/packages/nuxt/src/core/plugins/import-protection.ts
+++ b/packages/nuxt/src/core/plugins/import-protection.ts
@@ -13,12 +13,12 @@ interface ImportProtectionOptions {
   exclude?: Array<RegExp | string>
 }
 
-export const nuxtImportProtections = (nuxt: Nuxt, isNitro?: boolean) => {
+export const nuxtImportProtections = (nuxt: Nuxt, options: { isNitro?: boolean } = {}) => {
   const patterns: ImportProtectionOptions['patterns'] = []
 
   patterns.push([
     /^(nuxt|nuxt3|nuxt-nightly)$/,
-    '`nuxt`, `nuxt3` or `nuxt-nightly` cannot be imported directly.' + (isNitro ? '' : ' Instead, import runtime Nuxt composables from `#app` or `#imports`.')
+    '`nuxt`, `nuxt3` or `nuxt-nightly` cannot be imported directly.' + (options.isNitro ? '' : ' Instead, import runtime Nuxt composables from `#app` or `#imports`.')
   ])
 
   patterns.push([
@@ -28,7 +28,7 @@ export const nuxtImportProtections = (nuxt: Nuxt, isNitro?: boolean) => {
 
   patterns.push([/(^|node_modules\/)@vue\/composition-api/])
 
-  for(const mod of nuxt.options.modules.filter(m => typeof m === 'string')) {
+  for (const mod of nuxt.options.modules.filter(m => typeof m === 'string')) {
     patterns.push([
       new RegExp(`^${escapeRE(mod as string)}$`),
       'Importing directly from module entry-points is not allowed.'
@@ -36,10 +36,10 @@ export const nuxtImportProtections = (nuxt: Nuxt, isNitro?: boolean) => {
   }
 
   for (const i of [/(^|node_modules\/)@nuxt\/kit/, /(^|node_modules\/)nuxt\/(config|kit|schema)/, 'nitropack']) {
-    patterns.push([i, 'This module cannot be imported' + (isNitro ? 'in server runtime' : ' in the Vue part of your app.')])
+    patterns.push([i, 'This module cannot be imported' + (options.isNitro ? 'in server runtime' : ' in the Vue part of your app.')])
   }
 
-  if (isNitro) {
+  if (options.isNitro) {
     for (const i of ['#app', /^#build(\/|$)/]) {
       patterns.push([i, 'Vue app aliases are not allowed in server runtime.'])
     }
@@ -47,8 +47,8 @@ export const nuxtImportProtections = (nuxt: Nuxt, isNitro?: boolean) => {
 
   patterns.push(
     [new RegExp(escapeRE(join(nuxt.options.srcDir, (nuxt.options.dir as any).server || 'server')) + '\\/(api|routes|middleware|plugins)\\/'),
-    'Importing from server is not allowed in the Vue part of your app.'
-  ])
+      'Importing from server is not allowed in the Vue part of your app.'
+    ])
 
   return patterns
 

--- a/packages/nuxt/src/core/plugins/import-protection.ts
+++ b/packages/nuxt/src/core/plugins/import-protection.ts
@@ -1,7 +1,7 @@
 import { createRequire } from 'node:module'
 import { createUnplugin } from 'unplugin'
 import { logger } from '@nuxt/kit'
-import { isAbsolute, join, relative } from 'pathe'
+import { isAbsolute, join, relative, resolve } from 'pathe'
 import escapeRE from 'escape-string-regexp'
 import type { NuxtOptions } from 'nuxt/schema'
 
@@ -46,7 +46,7 @@ export const nuxtImportProtections = (nuxt: { options: NuxtOptions }, options: {
   }
 
   patterns.push(
-    [new RegExp(escapeRE(join(nuxt.options.srcDir, nuxt.options.serverDir || 'server')) + '\\/(api|routes|middleware|plugins)\\/'),
+    [new RegExp(escapeRE(relative(nuxt.options.srcDir, resolve(nuxt.options.srcDir, nuxt.options.serverDir || 'server'))) + '\\/(api|routes|middleware|plugins)\\/'),
       'Importing from server is not allowed in the Vue part of your app.'
     ])
 

--- a/packages/nuxt/src/core/plugins/import-protection.ts
+++ b/packages/nuxt/src/core/plugins/import-protection.ts
@@ -46,7 +46,7 @@ export const nuxtImportProtections = (nuxt: Nuxt, options: { isNitro?: boolean }
   }
 
   patterns.push(
-    [new RegExp(escapeRE(join(nuxt.options.srcDir, (nuxt.options.dir as any).server || 'server')) + '\\/(api|routes|middleware|plugins)\\/'),
+    [new RegExp(escapeRE(join(nuxt.options.srcDir, nuxt.options.serverDir || 'server')) + '\\/(api|routes|middleware|plugins)\\/'),
       'Importing from server is not allowed in the Vue part of your app.'
     ])
 

--- a/packages/nuxt/src/core/plugins/import-protection.ts
+++ b/packages/nuxt/src/core/plugins/import-protection.ts
@@ -3,7 +3,7 @@ import { createUnplugin } from 'unplugin'
 import { logger } from '@nuxt/kit'
 import { isAbsolute, join, relative } from 'pathe'
 import escapeRE from 'escape-string-regexp'
-import type { Nuxt } from 'nuxt/schema'
+import type { NuxtOptions } from 'nuxt/schema'
 
 const _require = createRequire(import.meta.url)
 
@@ -13,7 +13,7 @@ interface ImportProtectionOptions {
   exclude?: Array<RegExp | string>
 }
 
-export const nuxtImportProtections = (nuxt: Nuxt, options: { isNitro?: boolean } = {}) => {
+export const nuxtImportProtections = (nuxt: { options: NuxtOptions }, options: { isNitro?: boolean } = {}) => {
   const patterns: ImportProtectionOptions['patterns'] = []
 
   patterns.push([

--- a/packages/nuxt/src/core/plugins/import-protection.ts
+++ b/packages/nuxt/src/core/plugins/import-protection.ts
@@ -35,7 +35,7 @@ export const nuxtImportProtections = (nuxt: { options: NuxtOptions }, options: {
     ])
   }
 
-  for (const i of [/(^|node_modules\/)@nuxt\/kit/, /(^|node_modules\/)nuxt\/(config|kit|schema)/, 'nitropack']) {
+  for (const i of [/(^|node_modules\/)@nuxt\/kit/, /(^|node_modules\/)nuxi/, /(^|node_modules\/)nuxt\/(config|kit|schema|test-utils)/, 'nitropack']) {
     patterns.push([i, 'This module cannot be imported' + (options.isNitro ? 'in server runtime.' : ' in the Vue part of your app.')])
   }
 

--- a/packages/nuxt/src/core/plugins/import-protection.ts
+++ b/packages/nuxt/src/core/plugins/import-protection.ts
@@ -45,10 +45,12 @@ export const nuxtImportProtections = (nuxt: { options: NuxtOptions }, options: {
     }
   }
 
-  patterns.push(
-    [new RegExp(escapeRE(relative(nuxt.options.srcDir, resolve(nuxt.options.srcDir, nuxt.options.serverDir || 'server'))) + '\\/(api|routes|middleware|plugins)\\/'),
+  if (!options.isNitro) {
+    patterns.push([
+      new RegExp(escapeRE(relative(nuxt.options.srcDir, resolve(nuxt.options.srcDir, nuxt.options.serverDir || 'server'))) + '\\/(api|routes|middleware|plugins)\\/'),
       'Importing from server is not allowed in the Vue part of your app.'
     ])
+  }
 
   return patterns
 }

--- a/packages/nuxt/src/core/plugins/import-protection.ts
+++ b/packages/nuxt/src/core/plugins/import-protection.ts
@@ -36,7 +36,7 @@ export const nuxtImportProtections = (nuxt: { options: NuxtOptions }, options: {
   }
 
   for (const i of [/(^|node_modules\/)@nuxt\/kit/, /(^|node_modules\/)nuxt\/(config|kit|schema)/, 'nitropack']) {
-    patterns.push([i, 'This module cannot be imported' + (options.isNitro ? 'in server runtime' : ' in the Vue part of your app.')])
+    patterns.push([i, 'This module cannot be imported' + (options.isNitro ? 'in server runtime.' : ' in the Vue part of your app.')])
   }
 
   if (options.isNitro) {
@@ -51,7 +51,6 @@ export const nuxtImportProtections = (nuxt: { options: NuxtOptions }, options: {
     ])
 
   return patterns
-
 }
 
 export const ImportProtectionPlugin = createUnplugin(function (options: ImportProtectionOptions) {

--- a/packages/nuxt/src/core/plugins/import-protection.ts
+++ b/packages/nuxt/src/core/plugins/import-protection.ts
@@ -35,7 +35,7 @@ export const nuxtImportProtections = (nuxt: { options: NuxtOptions }, options: {
     ])
   }
 
-  for (const i of [/(^|node_modules\/)@nuxt\/kit/, /(^|node_modules\/)nuxi/, /(^|node_modules\/)nuxt\/(config|kit|schema|test-utils)/, 'nitropack']) {
+  for (const i of [/(^|node_modules\/)@nuxt\/(kit|test-utils)/, /(^|node_modules\/)nuxi/, /(^|node_modules\/)nuxt\/(config|kit|schema)/, 'nitropack']) {
     patterns.push([i, 'This module cannot be imported' + (options.isNitro ? 'in server runtime.' : ' in the Vue part of your app.')])
   }
 

--- a/packages/nuxt/test/import-protection.test.ts
+++ b/packages/nuxt/test/import-protection.test.ts
@@ -1,6 +1,6 @@
 import { normalize } from 'pathe'
 import { describe, expect, it } from 'vitest'
-import { ImportProtectionPlugin, vueAppPatterns } from '../src/core/plugins/import-protection'
+import { ImportProtectionPlugin, nuxtImportProtections } from '../src/core/plugins/import-protection'
 
 const testsToTriggerOn = [
   ['~/nuxt.config', 'app.vue', true],
@@ -39,7 +39,7 @@ describe('import protection', () => {
 const transformWithImportProtection = (id: string, importer: string) => {
   const plugin = ImportProtectionPlugin.rollup({
     rootDir: '/root',
-    patterns: vueAppPatterns({
+    patterns: nuxtImportProtections({
       options: {
         modules: ['some-nuxt-module'],
         srcDir: 'src/',

--- a/packages/nuxt/test/import-protection.test.ts
+++ b/packages/nuxt/test/import-protection.test.ts
@@ -43,8 +43,8 @@ const transformWithImportProtection = (id: string, importer: string) => {
     patterns: nuxtImportProtections({
       options: {
         modules: ['some-nuxt-module'],
-        srcDir: 'src/',
-        serverDir: 'server'
+        srcDir: '/root/src/',
+        serverDir: '/root/src/server'
       } satisfies Partial<NuxtOptions> as NuxtOptions
     })
   })

--- a/packages/nuxt/test/import-protection.test.ts
+++ b/packages/nuxt/test/import-protection.test.ts
@@ -1,6 +1,7 @@
 import { normalize } from 'pathe'
 import { describe, expect, it } from 'vitest'
 import { ImportProtectionPlugin, nuxtImportProtections } from '../src/core/plugins/import-protection'
+import type { NuxtOptions } from '../schema'
 
 const testsToTriggerOn = [
   ['~/nuxt.config', 'app.vue', true],
@@ -43,9 +44,9 @@ const transformWithImportProtection = (id: string, importer: string) => {
       options: {
         modules: ['some-nuxt-module'],
         srcDir: 'src/',
-        dir: { server: 'server' }
-      }
-    } as any)
+        serverDir: 'server'
+      } satisfies Partial<NuxtOptions> as NuxtOptions
+    })
   })
 
   return (plugin as any).resolveId(id, importer)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

one issue https://github.com/Baroshem/nuxt-security/issues/335

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Previously we were not fully protecting nitro runtime imports for `@nuxt/kit` and other nuxt-relevant imports. This PR also refactors import protection plugin rules to be maintained in one place more easily.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
