### PR TITLE
fix(nuxt): fix inconsistent `pages/*` file scanning order

### DIFF
--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -51,7 +51,9 @@ export async function resolvePagesRoutes (): Promise<NuxtPage[]> {
     const files = await resolveFiles(dir, `**/*{${nuxt.options.extensions.join(',')}}`)
     scannedFiles.push(...files.map(file => ({ relativePath: relative(dir, file), absolutePath: file })))
   }
-  scannedFiles.sort((a, b) => a.relativePath.localeCompare(b.relativePath))
+
+  // sort scanned files using en-US locale to make the result consistent across different system locales
+  scannedFiles.sort((a, b) => a.relativePath.localeCompare(b.relativePath, 'en-US'))
 
   const allRoutes = await generateRoutesFromFiles(uniqueBy(scannedFiles, 'relativePath'), nuxt.options.experimental.typedPages, nuxt.vfs)
 


### PR DESCRIPTION
### 🔗 Linked issue
#25193 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fixed inconsistent `pages/*` file scanning order on different system locales by explicitly specifying `en-US` as the locale for sorting.
According to #25193, the pages scanning logic seems to be rely on the fact that `users.vue` always come before `users/index.vue`. This is true on `en-US`, but in that case (`th-TH`), the `users/index.vue` come first, making the nested routes feature unusable.

Resolves #25193

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
