### PR TITLE
docs: remove invalid command alias

### DIFF
--- a/docs/3.api/4.commands/cleanup.md
+++ b/docs/3.api/4.commands/cleanup.md
@@ -9,7 +9,7 @@ links:
 ---
 
 ```bash [Terminal]
-npx nuxi clean|cleanup [rootDir]
+npx nuxi cleanup [rootDir]
 ```
 
 The `cleanup` command removes common generated Nuxt files and caches, including:

--- a/docs/3.api/4.commands/init.md
+++ b/docs/3.api/4.commands/init.md
@@ -9,7 +9,7 @@ links:
 ---
 
 ```bash [Terminal]
-npx nuxi init|create [--verbose|-v] [--template,-t] [dir]
+npx nuxi init [--verbose|-v] [--template,-t] [dir]
 ```
 
 The `init` command initializes a fresh Nuxt project using [unjs/giget](https://github.com/unjs/giget).

--- a/docs/3.api/4.commands/preview.md
+++ b/docs/3.api/4.commands/preview.md
@@ -9,7 +9,7 @@ links:
 ---
 
 ```bash [Terminal]
-npx nuxi preview [rootDir] [--dotenv]
+npx nuxi preview|start [rootDir] [--dotenv]
 ```
 
 The `preview` command starts a server to preview your Nuxt application after running the `build` command. The `start` command is an alias for `preview`. When running your application in production refer to the [Deployment section](/docs/getting-started/deployment).


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Commands: https://github.com/nuxt/cli/blob/main/src/commands/index.ts

Aliases for some commands are currently unavailable, removing them will make the document clearer.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
