### PR TITLE
fix(nuxt): control nitro log level with nuxt options

### DIFF
--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -19,11 +19,11 @@ import { distDir } from '../dirs'
 import { toArray } from '../utils'
 import { ImportProtectionPlugin } from './plugins/import-protection'
 
-const logLevelMapReverse: Record<NuxtOptions['logLevel'], NitroConfig['logLevel']> = {
+const logLevelMapReverse = {
   silent: 0,
   info: 3,
   verbose: 3
-}
+} satisfies Record<NuxtOptions['logLevel'], NitroConfig['logLevel']>
 
 export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
   // Resolve config

--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -11,13 +11,19 @@ import escapeRE from 'escape-string-regexp'
 import { defu } from 'defu'
 import fsExtra from 'fs-extra'
 import { dynamicEventHandler } from 'h3'
-import type { Nuxt, RuntimeConfig } from 'nuxt/schema'
+import type { Nuxt, NuxtOptions, RuntimeConfig } from 'nuxt/schema'
 // @ts-expect-error TODO: add legacy type support for subpath imports
 import { template as defaultSpaLoadingTemplate } from '@nuxt/ui-templates/templates/spa-loading-icon.mjs'
 import { version as nuxtVersion } from '../../package.json'
 import { distDir } from '../dirs'
 import { toArray } from '../utils'
 import { ImportProtectionPlugin } from './plugins/import-protection'
+
+export const logLevelMapReverse: Record<NuxtOptions['logLevel'], NitroConfig['logLevel']> = {
+  silent: 0,
+  info: 3,
+  verbose: 3
+}
 
 export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
   // Resolve config
@@ -218,7 +224,8 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
     rollupConfig: {
       output: {},
       plugins: []
-    }
+    },
+    logLevel: logLevelMapReverse[nuxt.options.logLevel],
   } satisfies NitroConfig)
 
   // Resolve user-provided paths

--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -19,7 +19,7 @@ import { distDir } from '../dirs'
 import { toArray } from '../utils'
 import { ImportProtectionPlugin } from './plugins/import-protection'
 
-export const logLevelMapReverse: Record<NuxtOptions['logLevel'], NitroConfig['logLevel']> = {
+const logLevelMapReverse: Record<NuxtOptions['logLevel'], NitroConfig['logLevel']> = {
   silent: 0,
   info: 3,
   verbose: 3


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently, the `log-level` argument does not affect Nitro build logging, leading to confusion. This PR updates Nitro's configuration to include the `log-level` argument, enhancing consistency in log levels.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
