### PR TITLE
fix: reuse serialized values in `normalizedRoutes`

### DIFF
--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -362,9 +362,9 @@ export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = 
     routes: genArrayFromRaw(routes.map((page) => {
       const route: Record<Exclude<keyof NuxtPage, 'file'>, string> & { component?: string } = Object.create(null)
       for (const [key, value] of Object.entries(page)) {
-        if (key !== 'file' && (Array.isArray(value) ? value.length : value)) {
-          route[key as Exclude<keyof NuxtPage, 'file'>] = JSON.stringify(value)
-        }
+        if (['file', 'children'].includes(key)) continue
+        if (!(Array.isArray(value) ? value.length : value)) continue
+        route[key as Exclude<keyof NuxtPage, 'file'>] = JSON.stringify(value)
       }
 
       if (page.children?.length) {

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -388,7 +388,7 @@ export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = 
       metaImports.add(genImport(`${file}?macro=true`, [{ name: 'default', as: metaImportName }]))
 
       if (overrideMeta) {
-        route.name = route.name ?? `${metaImportName}?.name ?? undefined`
+        route.name = route.name ?? `${metaImportName}?.name`
         route.path = route.path ?? `${metaImportName}?.path ?? ''`
       } else {
         route.name = `${metaImportName}?.name ?? ${page.name ? route.name : 'undefined'}`
@@ -404,7 +404,7 @@ export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = 
       route.alias = aliasFiltered.length ? `${JSON.stringify(aliasFiltered)}.concat(${aliasCode})` : aliasCode
 
       route.component = genDynamicImport(file, { interopDefault: true })
-      route.redirect = page.redirect ? route.redirect : `${metaImportName}?.redirect || undefined`
+      route.redirect = page.redirect ? route.redirect : `${metaImportName}?.redirect`
 
       return route
     }))

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -373,9 +373,6 @@ export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = 
 
       // Without a file, we can't use `definePageMeta` to extract route-level meta from the file
       if (!page.file) {
-        for (const key of ['name', 'path', 'meta', 'alias', 'redirect'] as const) {
-          if (page[key]) { route[key] = JSON.stringify(page[key]) }
-        }
         return route
       }
 

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -356,16 +356,17 @@ function prepareRoutes (routes: NuxtPage[], parent?: NuxtPage, names = new Set<s
   return routes
 }
 
+const skipSerializeValue = (val: unknown | unknown[]) => {
+  if (val === undefined) return true
+  if (Array.isArray(val)) return val.length === 0
+  return typeof val !== 'string' && !!val
+}
+
 export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = new Set(), overrideMeta = false): { imports: Set<string>, routes: string } {
   return {
     imports: metaImports,
     routes: genArrayFromRaw(routes.map((page) => {
       const route: Record<Exclude<keyof NuxtPage, 'file'>, string> & { component?: string } = Object.create(null)
-      const skipSerializeValue = (val: unknown | unknown[]) => {
-        if (val === undefined) return true
-        if (Array.isArray(val)) return val.length === 0
-        return typeof val !== 'string' && !!val
-      }
 
       for (const [key, value] of Object.entries(page)) {
         if (['file', 'children'].includes(key)) continue

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -361,9 +361,15 @@ export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = 
     imports: metaImports,
     routes: genArrayFromRaw(routes.map((page) => {
       const route: Record<Exclude<keyof NuxtPage, 'file'>, string> & { component?: string } = Object.create(null)
+      const skipSerializeValue = (val: unknown | unknown[]) => {
+        if (val === undefined) return true
+        if (Array.isArray(val)) return val.length === 0
+        return typeof val !== 'string' && !!val
+      }
+
       for (const [key, value] of Object.entries(page)) {
         if (['file', 'children'].includes(key)) continue
-        if (!(Array.isArray(value) ? value.length : value)) continue
+        if (skipSerializeValue(value)) continue
         route[key as Exclude<keyof NuxtPage, 'file'>] = JSON.stringify(value)
       }
 

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -371,7 +371,7 @@ export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = 
       for (const [key, value] of Object.entries(page)) {
         if (['file', 'children'].includes(key)) continue
         if (skipSerializeValue(value)) continue
-        route[key as Exclude<keyof NuxtPage, 'file'>] = JSON.stringify(value)
+        route[key as Exclude<keyof NuxtPage, 'file' | 'children'>] = JSON.stringify(value)
       }
 
       if (page.children?.length) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
* https://github.com/nuxt/nuxt/pull/25210
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Built on https://github.com/nuxt/nuxt/pull/25210, I haven't looked into other changes for the PR yet.

This is refactor of `normalizedRoutes` mostly for legibility with some tiny/negligible changes for perf. 

* Changes the initial loop to skip serializing `route.children` as its being overwritten in the next few lines
  * ~Should this be changed so that empty strings also get stringified? I think they are skipped as they're falsy~
  * Based on the PR history, yes they should be stringified to allow empty paths (and names?)
* Removes the second serialization loop, serialization has already occurred in the previous loop
* Rewrite of `route` assignments to reuse serialized values

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
