### PR TITLE
fix(nuxt): await async payload revivers

### DIFF
--- a/packages/nuxt/src/app/composables/payload.ts
+++ b/packages/nuxt/src/app/composables/payload.ts
@@ -102,7 +102,7 @@ export async function getNuxtClientPayload () {
     return {}
   }
 
-  const inlineData = parsePayload(el.textContent || '')
+  const inlineData = await parsePayload(el.textContent || '')
 
   const externalData = el.dataset.src ? await _importPayload(el.dataset.src) : undefined
 
@@ -115,8 +115,8 @@ export async function getNuxtClientPayload () {
   return payloadCache
 }
 
-export function parsePayload (payload: string) {
-  return parse(payload, useNuxtApp()._payloadRevivers)
+export async function parsePayload (payload: string) {
+  return await parse(payload, useNuxtApp()._payloadRevivers)
 }
 
 /**


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR resolves an issue where the payload reviver was not awaited if it was an asynchronous function. This could be useful for creating more versatile payload revivers (utilizing dynamic imports), for example. However, prior to this change, the revived value on the client would be a promise instead of its resolved value.

It would probably also be a good idea to add tests for this issue. However, I noticed that `definePayloadReducer` and `definePayloadReviver` are listed in `skippedComposables` in the tests. Is there a reason why they are not tested?


<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
