### PR TITLE
fix(nuxt): make slot response fallback property undefineable

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-island.ts
+++ b/packages/nuxt/src/app/components/nuxt-island.ts
@@ -134,7 +134,7 @@ export default defineComponent({
 
       return html.replaceAll(SLOT_FALLBACK_RE, (full, slotName) => {
         if (!currentSlots.includes(slotName)) {
-          return full + payloadSlots[slotName]?.fallback || ''
+          return full + (payloadSlots[slotName]?.fallback || '')
         }
         return full
       })

--- a/packages/nuxt/src/app/components/nuxt-island.ts
+++ b/packages/nuxt/src/app/components/nuxt-island.ts
@@ -134,7 +134,7 @@ export default defineComponent({
 
       return html.replaceAll(SLOT_FALLBACK_RE, (full, slotName) => {
         if (!currentSlots.includes(slotName)) {
-          return full + payloadSlots[slotName]?.fallback ?? ''
+          return full + payloadSlots[slotName]?.fallback || ''
         }
         return full
       })

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -64,7 +64,7 @@ export interface NuxtIslandContext {
 
 export interface NuxtIslandSlotResponse {
   props: Array<unknown>
-  fallback: string
+  fallback?: string
 }
 export interface NuxtIslandClientResponse {
   html: string
@@ -626,7 +626,7 @@ function getSlotIslandResponse (ssrContext: NuxtSSRContext): NuxtIslandResponse[
   for (const slot in ssrContext.islandContext.slots) {
     response[slot] = {
       ...ssrContext.islandContext.slots[slot],
-      fallback: ssrContext.teleports?.[`island-fallback=${slot}`] || ''
+      fallback: ssrContext.teleports?.[`island-fallback=${slot}`]
     }
   }
   return response

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1825,7 +1825,6 @@ describe('component islands', () => {
         "html": "<div data-island-uid><div> count is above 2 </div><!--[--><div style="display: contents;" data-island-uid data-island-slot="default"></div><!--]--> that was very long ... <div id="long-async-component-count">3</div>  <!--[--><div style="display: contents;" data-island-uid data-island-slot="test"></div><!--]--><p>hello world !!!</p><!--[--><div style="display: contents;" data-island-uid data-island-slot="hello"></div><!--teleport start--><!--teleport end--><!--]--><!--[--><div style="display: contents;" data-island-uid data-island-slot="fallback"></div><!--teleport start--><!--teleport end--><!--]--></div>",
         "slots": {
           "default": {
-            "fallback": "",
             "props": [],
           },
           "fallback": {
@@ -1854,7 +1853,6 @@ describe('component islands', () => {
             ],
           },
           "test": {
-            "fallback": "",
             "props": [
               {
                 "count": 3,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Hey :wave: this PR makes the fallback field for slots in the NuxtIslandResponse undefined by default.

Before that, there was a nullish operator which was triggering esbuild warning when building (in dev).

I think it's better to move the nullish operator to an OR (||) and make the field undefineable instead

PS: is there a way to detect that in the CI ?

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
