### PR TITLE
chore: remove reference to "experimental" `defineModel`

### DIFF
--- a/docs/1.getting-started/3.configuration.md
+++ b/docs/1.getting-started/3.configuration.md
@@ -199,12 +199,11 @@ export default defineNuxtConfig({
 
 ### Enabling Experimental Vue Features
 
-You may need to enable experimental features in Vue, such as `defineModel` or `propsDestructure`. Nuxt provides an easy way to do that in `nuxt.config.ts`, no matter which builder you are using:
+You may need to enable experimental features in Vue, such as `propsDestructure`. Nuxt provides an easy way to do that in `nuxt.config.ts`, no matter which builder you are using:
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   vue: {
-    defineModel: true,
     propsDestructure: true
   }
 })

--- a/packages/schema/src/config/app.ts
+++ b/packages/schema/src/config/app.ts
@@ -28,13 +28,6 @@ export default defineUntypedSchema({
      * @type {boolean}
      */
     propsDestructure: false,
-
-    /**
-     * Vue Experimental: Enable macro `defineModel`
-     * @see [Vue RFC#503](https://github.com/vuejs/rfcs/discussions/503)
-     * @type {boolean}
-     */
-    defineModel: false
   },
 
   /**

--- a/packages/schema/src/config/vite.ts
+++ b/packages/schema/src/config/vite.ts
@@ -55,9 +55,6 @@ export default defineUntypedSchema({
       script: {
         propsDestructure: {
           $resolve: async (val, get) => val ?? Boolean((await get('vue')).propsDestructure)
-        },
-        defineModel: {
-          $resolve: async (val, get) => val ?? Boolean((await get('vue')).defineModel)
         }
       }
     },

--- a/packages/schema/src/config/webpack.ts
+++ b/packages/schema/src/config/webpack.ts
@@ -205,7 +205,6 @@ export default defineUntypedSchema({
         },
         compilerOptions: { $resolve: async (val, get) => val ?? (await get('vue.compilerOptions')) },
         propsDestructure: { $resolve: async (val, get) => val ?? Boolean(await get('vue.propsDestructure')) },
-        defineModel: { $resolve: async (val, get) => val ?? Boolean(await get('vue.defineModel')) }
       },
 
       css: {


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/25302

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

As `defineModel` is stable now, we can remove (or alternatively deprrecate) the configuration option for it, as well as remove the docs reference.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
