### PR TITLE
fix(nuxt): load plugin that depends on loaded and unloaded plugins

### DIFF
--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -368,8 +368,9 @@ export async function applyPlugins (nuxtApp: NuxtApp, plugins: Array<Plugin & Ob
   let promiseDepth = 0
 
   async function executePlugin (plugin: Plugin & ObjectPlugin<any>) {
-    if (plugin.dependsOn && !plugin.dependsOn.every(name => resolvedPlugins.includes(name))) {
-      unresolvedPlugins.push([new Set(plugin.dependsOn), plugin])
+    const unresolvedPluginsForThisPlugin = plugin.dependsOn?.filter(name => !resolvedPlugins.includes(name)) ?? []
+    if (unresolvedPluginsForThisPlugin.length > 0) {
+      unresolvedPlugins.push([new Set(unresolvedPluginsForThisPlugin), plugin])
     } else {
       const promise = applyPlugin(nuxtApp, plugin).then(async () => {
         if (plugin._name) {

--- a/test/nuxt/plugin.test.ts
+++ b/test/nuxt/plugin.test.ts
@@ -249,19 +249,19 @@ describe('plugin dependsOn', () => {
     const nuxtApp = useNuxtApp()
     const sequence: string[] = []
     const plugins = [
-      pluginFactory('A', undefined, sequence),
-      pluginFactory('B', ['A', 'C'], sequence),
-      pluginFactory('C', undefined, sequence)
+      pluginFactory('A', undefined, sequence, false),
+      pluginFactory('B', ['A', 'C'], sequence, false),
+      pluginFactory('C', undefined, sequence, false),
     ]
     await applyPlugins(nuxtApp, plugins)
 
     expect(sequence).toMatchObject([
       'start A',
-      'start C',
       'end A',
+      'start C',
       'end C',
       'start B',
-      'end B'
+      'end B',
     ])
   })
 })

--- a/test/nuxt/plugin.test.ts
+++ b/test/nuxt/plugin.test.ts
@@ -244,4 +244,24 @@ describe('plugin dependsOn', () => {
       'end B'
     ])
   })
+
+  it('expect B to execute after A, C when B depends on A and C', async () => {
+    const nuxtApp = useNuxtApp()
+    const sequence: string[] = []
+    const plugins = [
+      pluginFactory('A', undefined, sequence),
+      pluginFactory('B', ['A', 'C'], sequence),
+      pluginFactory('C', undefined, sequence)
+    ]
+    await applyPlugins(nuxtApp, plugins)
+
+    expect(sequence).toMatchObject([
+      'start A',
+      'start C',
+      'end A',
+      'end C',
+      'start B',
+      'end B'
+    ])
+  })
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

#25305

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Resolves #25305 

Originally, when a plugin is loaded, if there is any unresolved plugin depended by the plugin all its dependencies including the ones already resolved are marked as resolve needed.
Thus even when all its unresolved plugin are resolved, it is not loaded because it still has plugins that are by mistake considered unresolved but actually have already been resolved.

I made change to the code so that only unresolved plugins are marked as resolve needed when a plugin is loaded.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
