### PR TITLE
fix(schema): pin jiti until babel bug is resolved

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@nuxt/schema": "workspace:*",
     "@nuxt/vite-builder": "workspace:*",
     "@nuxt/webpack-builder": "workspace:*",
+    "jiti": "1.20.0",
     "rollup": "^4.9.5",
     "nuxt": "workspace:*",
     "vite": "5.0.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   '@nuxt/schema': workspace:*
   '@nuxt/vite-builder': workspace:*
   '@nuxt/webpack-builder': workspace:*
+  jiti: 1.20.0
   rollup: ^4.9.5
   nuxt: workspace:*
   vite: 5.0.11
@@ -89,8 +90,8 @@ importers:
         specifier: 13.2.0
         version: 13.2.0
       jiti:
-        specifier: 1.21.0
-        version: 1.21.0
+        specifier: 1.20.0
+        version: 1.20.0
       markdownlint-cli:
         specifier: 0.38.0
         version: 0.38.0
@@ -170,8 +171,8 @@ importers:
         specifier: ^5.3.0
         version: 5.3.0
       jiti:
-        specifier: ^1.21.0
-        version: 1.21.0
+        specifier: 1.20.0
+        version: 1.20.0
       knitwork:
         specifier: ^1.0.0
         version: 1.0.0
@@ -312,8 +313,8 @@ importers:
         specifier: ^5.5.3
         version: 5.5.3
       jiti:
-        specifier: ^1.21.0
-        version: 1.21.0
+        specifier: 1.20.0
+        version: 1.20.0
       klona:
         specifier: ^2.0.6
         version: 2.0.6
@@ -2033,7 +2034,7 @@ packages:
       dotenv: 16.3.1
       git-url-parse: 13.1.1
       is-docker: 3.0.0
-      jiti: 1.21.0
+      jiti: 1.20.0
       mri: 1.2.0
       nanoid: 4.0.2
       ofetch: 1.3.3
@@ -3779,7 +3780,7 @@ packages:
       defu: 6.1.4
       dotenv: 16.3.1
       giget: 1.2.1
-      jiti: 1.21.0
+      jiti: 1.20.0
       mlly: 1.5.0
       ohash: 1.1.3
       pathe: 1.1.2
@@ -6165,8 +6166,8 @@ packages:
       supports-color: 8.1.1
     dev: false
 
-  /jiti@1.21.0:
-    resolution: {integrity: sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==}
+  /jiti@1.20.0:
+    resolution: {integrity: sha512-3TV69ZbrvV6U5DfQimop50jE9Dl6J8O1ja1dvBbMba/sZ3YBEQqJ2VZRoQPVnhlzjNtU1vaXRZVrVjU4qtm8yA==}
     hasBin: true
 
   /js-beautify@1.14.9:
@@ -6355,7 +6356,7 @@ packages:
       get-port-please: 3.1.2
       h3: 1.10.0
       http-shutdown: 1.2.2
-      jiti: 1.21.0
+      jiti: 1.20.0
       mlly: 1.5.0
       node-forge: 1.3.1
       pathe: 1.1.2
@@ -6826,7 +6827,7 @@ packages:
       esbuild: 0.18.20
       fs-extra: 11.2.0
       globby: 13.2.2
-      jiti: 1.21.0
+      jiti: 1.20.0
       mlly: 1.5.0
       mri: 1.2.0
       pathe: 1.1.2
@@ -6927,7 +6928,7 @@ packages:
       hookable: 5.5.3
       httpxy: 0.1.5
       is-primitive: 3.0.1
-      jiti: 1.21.0
+      jiti: 1.20.0
       klona: 2.0.6
       knitwork: 1.0.0
       listhen: 1.5.5
@@ -7614,7 +7615,7 @@ packages:
       webpack: ^5.0.0
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.3.3)
-      jiti: 1.21.0
+      jiti: 1.20.0
       postcss: 8.4.33
       semver: 7.5.4
       webpack: 5.89.0
@@ -9127,7 +9128,7 @@ packages:
       esbuild: 0.19.11
       globby: 13.2.2
       hookable: 5.5.3
-      jiti: 1.21.0
+      jiti: 1.20.0
       magic-string: 0.30.5
       mkdist: 1.3.0(typescript@5.3.3)
       mlly: 1.5.0
@@ -9333,7 +9334,7 @@ packages:
       '@babel/standalone': 7.23.2
       '@babel/types': 7.23.4
       defu: 6.1.4
-      jiti: 1.21.0
+      jiti: 1.20.0
       mri: 1.2.0
       scule: 1.2.0
     transitivePeerDependencies:

--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,7 @@
         "main"
       ],
       "ignoreDeps": [
+        "jiti",
         "nuxt",
         "nuxt3",
         "@nuxt/kit"


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/25000
https://github.com/nuxt/nuxt.com/issues/1415

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This temporarily pins `jiti` to ensure we can generate comments from docs, until the upstream issue is resolved.

(Seems likely an issue in Babel itself, but we need to reproduce and file if possible.)

cc: @manniL, @pi0 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
