### PR TITLE
fix(nuxt): deprecate boolean values for `dedupe`

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -236,7 +236,7 @@ export function useAsyncData<
   options.dedupe = options.dedupe ?? 'cancel'
 
   if (import.meta.dev && typeof options.dedupe === 'boolean') {
-    console.warn('`boolean` values are deprecated for the `dedupe` option of useAsyncData and will be removed in the future. Use "cancel" or "defer" instead.')
+    console.warn('[nuxt] `boolean` values are deprecated for the `dedupe` option of `useAsyncData` and will be removed in the future. Use 'cancel' or 'defer' instead.')
   }
 
   const hasCachedData = () => ![null, undefined].includes(options.getCachedData!(key) as any)

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -235,7 +235,7 @@ export function useAsyncData<
   options.deep = options.deep ?? asyncDataDefaults.deep
   options.dedupe = options.dedupe ?? 'cancel'
 
-  if(import.meta.dev && typeof options.dedupe === 'boolean') {
+  if (import.meta.dev && typeof options.dedupe === 'boolean') {
     console.warn('`boolean` values are deprecated for the `dedupe` option of useAsyncData and will be removed in the future. Use "cancel" or "defer" instead.')
   }
 

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -236,7 +236,7 @@ export function useAsyncData<
   options.dedupe = options.dedupe ?? 'cancel'
 
   if (import.meta.dev && typeof options.dedupe === 'boolean') {
-    console.warn('[nuxt] `boolean` values are deprecated for the `dedupe` option of `useAsyncData` and will be removed in the future. Use 'cancel' or 'defer' instead.')
+    console.warn('[nuxt] `boolean` values are deprecated for the `dedupe` option of `useAsyncData` and will be removed in the future. Use \'cancel\' or \'defer\' instead.')
   }
 
   const hasCachedData = () => ![null, undefined].includes(options.getCachedData!(key) as any)

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -92,7 +92,7 @@ export interface AsyncDataOptions<
 
 export interface AsyncDataExecuteOptions {
   _initial?: boolean
-  // TODO: deprecate boolean option in future minor
+  // TODO: remove boolean option in Nuxt 4
   /**
    * Force a refresh, even if there is already a pending request. Previous requests will
    * not be cancelled, but their result will not affect the data/pending state - and any
@@ -115,7 +115,7 @@ export interface _AsyncData<DataT, ErrorT> {
 
 export type AsyncData<Data, Error> = _AsyncData<Data, Error> & Promise<_AsyncData<Data, Error>>
 
-// TODO: deprecate boolean option in future minor
+// TODO: remove boolean option in Nuxt 4
 const isDefer = (dedupe?: boolean | 'cancel' | 'defer') => dedupe === 'defer' || dedupe === false
 
 /**
@@ -234,6 +234,10 @@ export function useAsyncData<
   options.immediate = options.immediate ?? true
   options.deep = options.deep ?? asyncDataDefaults.deep
   options.dedupe = options.dedupe ?? 'cancel'
+
+  if(import.meta.dev && typeof options.dedupe === 'boolean') {
+    console.warn('`boolean` values are deprecated for the `dedupe` option of useAsyncData and will be removed in the future. Use "cancel" or "defer" instead.')
+  }
 
   const hasCachedData = () => ![null, undefined].includes(options.getCachedData!(key) as any)
 


### PR DESCRIPTION
### 🔗 Linked issue

Non, only code comments + https://github.com/nuxt/nuxt/pull/24564

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR deprecates boolean values for the `useAsyncData` `dedupe` option. In the future, the boolean option will be fully removed, only allowing `cancel` or `defer`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
