### PR TITLE
refactor: remove currentRoute non-ref deprecation warning

### DIFF
--- a/packages/nuxt/src/app/plugins/router.ts
+++ b/packages/nuxt/src/app/plugins/router.ts
@@ -160,17 +160,6 @@ export default defineNuxtPlugin<{ route: Route, router: Router }>({
     }
 
     const currentRoute = computed(() => route)
-    // TODO: remove this in v3.10
-    for (const key in route) {
-      Object.defineProperty(currentRoute, key, {
-        get () {
-          if (import.meta.dev) {
-            console.warn(`\`currentRoute.${key}\` is deprecated. Use \`currentRoute.value.${key}\` instead.`)
-          }
-          return route[key as keyof Route]
-        }
-      })
-    }
 
     const router: Router = {
       currentRoute,


### PR DESCRIPTION
### 🔗 Linked issue

Related PR: https://github.com/nuxt/nuxt/pull/25026/

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR removes the warning when `currentRoute` was used as non-ref and no routing was existent. Now, currentRoute is a ref to align with behavior when "actual routing" (pages) exist. The warning should be removed in the next minor (3.10)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
