### PR TITLE
fix(nuxt): preserve `instance.attrs` object in client-only components

### DIFF
--- a/packages/nuxt/src/app/components/client-only.ts
+++ b/packages/nuxt/src/app/components/client-only.ts
@@ -55,15 +55,18 @@ export function createClientOnly<T extends ComponentOptions> (component: T) {
   clone.setup = (props, ctx) => {
     const instance = getCurrentInstance()!
 
-    const attrs = instance.attrs
+    const attrs = { ...instance.attrs }
+
     // remove existing directives during hydration
     const directives = extractDirectives(instance)
     // prevent attrs inheritance since a staticVNode is rendered before hydration
-    instance.attrs = {}
+    for(const key in attrs) {
+      delete instance.attrs[key]
+    }
     const mounted$ = ref(false)
 
     onMounted(() => {
-      instance.attrs = attrs
+      Object.assign(instance.attrs, attrs)
       instance.vnode.dirs = directives
       mounted$.value = true
     })

--- a/test/nuxt/client.test.ts
+++ b/test/nuxt/client.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest"
+import { defineComponent, h, useAttrs, toDisplayString, ComponentOptions } from "vue"
+import { mountSuspended } from "@nuxt/test-utils/runtime"
+import { createClientOnly } from "../../packages/nuxt/src/app/components/client-only"
+
+const Client = defineComponent({
+    name: 'Client', 
+    setup() {
+        const attrs = useAttrs()
+        return () => h('div', {}, toDisplayString(attrs))
+    }
+})
+
+describe('createClient attribute inheritance', () => {
+    it('should retrieve attributes with useAttrs()', async () => {
+        const wrapper = await mountSuspended(createClientOnly(Client as ComponentOptions), {
+            attrs: {
+                id: 'client'
+            }
+        })
+
+        expect(wrapper.html()).toMatchInlineSnapshot(`
+          "<div id="client">{
+            "id": "client"
+            }</div>"
+        `)
+    })
+})

--- a/test/nuxt/client.test.ts
+++ b/test/nuxt/client.test.ts
@@ -1,28 +1,29 @@
-import { describe, it, expect } from "vitest"
-import { defineComponent, h, useAttrs, toDisplayString, ComponentOptions } from "vue"
-import { mountSuspended } from "@nuxt/test-utils/runtime"
-import { createClientOnly } from "../../packages/nuxt/src/app/components/client-only"
+import { describe, expect, it } from 'vitest'
+import type { ComponentOptions } from 'vue'
+import { defineComponent, h, toDisplayString, useAttrs } from 'vue'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { createClientOnly } from '../../packages/nuxt/src/app/components/client-only'
 
 const Client = defineComponent({
-    name: 'Client', 
-    setup() {
-        const attrs = useAttrs()
-        return () => h('div', {}, toDisplayString(attrs))
-    }
+  name: 'TestClient',
+  setup () {
+    const attrs = useAttrs()
+    return () => h('div', {}, toDisplayString(attrs))
+  }
 })
 
 describe('createClient attribute inheritance', () => {
-    it('should retrieve attributes with useAttrs()', async () => {
-        const wrapper = await mountSuspended(createClientOnly(Client as ComponentOptions), {
-            attrs: {
-                id: 'client'
-            }
-        })
-
-        expect(wrapper.html()).toMatchInlineSnapshot(`
-          "<div id="client">{
-            "id": "client"
-            }</div>"
-        `)
+  it('should retrieve attributes with useAttrs()', async () => {
+    const wrapper = await mountSuspended(createClientOnly(Client as ComponentOptions), {
+      attrs: {
+        id: 'client'
+      }
     })
+
+    expect(wrapper.html()).toMatchInlineSnapshot(`
+      "<div id="client">{
+        "id": "client"
+        }</div>"
+    `)
+  })
 })


### PR DESCRIPTION
… createClientOnly

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

fix #25140
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Hey :wave: this PR fixes the issue where `useAttrs` insn't working in `.client` components. This is because we're moving out the `attrs` object away from the component's instance. So at the time `useAttrs` is called, it retrieves the reference of an empty object.

This PR keeps the same `instance.attrs` object reference and delete the keys within it. Then use `Object.assign` on mounted hook.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
