### PR TITLE
fix(nuxt): stop tracking suspense resolution if error in page/layout

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-layout.ts
+++ b/packages/nuxt/src/app/components/nuxt-layout.ts
@@ -5,7 +5,7 @@ import type { RouteLocationNormalizedLoaded } from 'vue-router'
 // eslint-disable-next-line import/no-restricted-paths
 import type { PageMeta } from '../../pages/runtime/composables'
 
-import { useRoute } from '../composables/router'
+import { useRoute, useRouter } from '../composables/router'
 import { useNuxtApp } from '../nuxt'
 import { _wrapIf } from './utils'
 import { LayoutMetaSymbol, PageRouteSymbol } from './injections'
@@ -71,6 +71,10 @@ export default defineComponent({
     context.expose({ layoutRef })
 
     const done = nuxtApp.deferHydration()
+    if (import.meta.client && nuxtApp.isHydrating) {
+      const removeErrorHook = nuxtApp.hooks.hookOnce('app:error', done)
+      useRouter().beforeEach(removeErrorHook)
+    }
 
     if (import.meta.dev) {
       nuxtApp._isNuxtLayoutUsed = true
@@ -97,7 +101,7 @@ export default defineComponent({
     }
   }
 }) as unknown as DefineComponent<{
-  name?: (unknown extends PageMeta['layout'] ? MaybeRef<string | false> : PageMeta['layout']) | undefined;
+  name?: (unknown extends PageMeta['layout'] ? MaybeRef<string | false> : PageMeta['layout']) | undefined
 }>
 
 const LayoutProvider = defineComponent({

--- a/packages/nuxt/src/app/components/nuxt-root.vue
+++ b/packages/nuxt/src/app/components/nuxt-root.vue
@@ -20,7 +20,7 @@
 import { defineAsyncComponent, onErrorCaptured, onServerPrefetch, provide } from 'vue'
 import { useNuxtApp } from '../nuxt'
 import { isNuxtError, showError, useError } from '../composables/error'
-import { useRoute } from '../composables/router'
+import { useRoute, useRouter } from '../composables/router'
 import { PageRouteSymbol } from '../components/injections'
 import AppComponent from '#build/app-component.mjs'
 import ErrorComponent from '#build/error-component.mjs'
@@ -31,6 +31,10 @@ const IslandRenderer = import.meta.server
 
 const nuxtApp = useNuxtApp()
 const onResolve = nuxtApp.deferHydration()
+if (import.meta.client && nuxtApp.isHydrating) {
+  const removeErrorHook = nuxtApp.hooks.hookOnce('app:error', onResolve)
+  useRouter().beforeEach(removeErrorHook)
+}
 
 const url = import.meta.server ? nuxtApp.ssrContext.url : window.location.pathname
 const SingleRenderer = import.meta.test && import.meta.dev && import.meta.server && url.startsWith('/__nuxt_component_test__/') && defineAsyncComponent(() => import('#build/test-component-wrapper.mjs')

--- a/packages/nuxt/src/pages/runtime/page.ts
+++ b/packages/nuxt/src/pages/runtime/page.ts
@@ -9,6 +9,7 @@ import type { RouterViewSlotProps } from './utils'
 import { generateRouteKey, wrapInKeepAlive } from './utils'
 import { RouteProvider } from '#app/components/route-provider'
 import { useNuxtApp } from '#app/nuxt'
+import { useRouter } from '#app/composables/router'
 import { _wrapIf } from '#app/components/utils'
 import { LayoutMetaSymbol, PageRouteSymbol } from '#app/components/injections'
 // @ts-expect-error virtual file
@@ -49,6 +50,10 @@ export default defineComponent({
     let vnode: VNode
 
     const done = nuxtApp.deferHydration()
+    if (import.meta.client && nuxtApp.isHydrating) {
+      const removeErrorHook = nuxtApp.hooks.hookOnce('app:error', done)
+      useRouter().beforeEach(removeErrorHook)
+    }
 
     if (props.pageKey) {
       watch(() => props.pageKey, (next, prev) => {
@@ -151,12 +156,12 @@ function haveParentRoutesRendered (fork: RouteLocationNormalizedLoaded | null, n
   return newRoute.matched.slice(0, index)
     .some(
       (c, i) => c.components?.default !== fork.matched[i]?.components?.default) ||
-        (Component && generateRouteKey({ route: newRoute, Component }) !== generateRouteKey({ route: fork, Component }))
+    (Component && generateRouteKey({ route: newRoute, Component }) !== generateRouteKey({ route: fork, Component }))
 }
 
 function hasChildrenRoutes (fork: RouteLocationNormalizedLoaded | null, newRoute: RouteLocationNormalizedLoaded, Component?: VNode) {
   if (!fork) { return false }
 
   const index = newRoute.matched.findIndex(m => m.components?.default === Component?.type)
-  return index < newRoute.matched.length -1
+  return index < newRoute.matched.length - 1
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/22683

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

If an error was thrown in a page or layout, before Nuxt finished hydrating, Nuxt would never unset `isHydrating`, meaning a number of things wouldn't work as expected, including clearing the error before navigation. For example, clicking header link to home on https://unstorage.unjs.io/404.

This PR adds a hook to decrement the hydration count when `app:error` is called in the initial hydration phase of the app.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
