### PR TITLE
fix(vite): inline styles for imports used only on server

### DIFF
--- a/packages/vite/src/plugins/ssr-styles.ts
+++ b/packages/vite/src/plugins/ssr-styles.ts
@@ -163,8 +163,6 @@ export function ssrStylesPlugin (options: SSRStylePluginOptions): Plugin {
 
       const { pathname, search } = parseURL(decodeURIComponent(pathToFileURL(id).href))
 
-      if (!(id in options.clientCSSMap) && !islands.some(c => c.filePath === pathname)) { return }
-
       const query = parseQuery(search)
       if (query.macro || query.nuxt_component) { return }
 

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1386,6 +1386,7 @@ describe.skipIf(isDev() || isWebpack)('inlining component styles', () => {
     '{--assets:"assets"}', // <script>
     '{--postcss:"postcss"}', // <style lang=postcss>
     '{--scoped:"scoped"}', // <style lang=css>
+    '{--server-only-child:"server-only-child"}', // child of a server-only component
     '{--server-only:"server-only"}' // server-only component not in client build
     // TODO: ideally both client/server components would have inlined css when used
     // '{--client-only:"client-only"}', // client-only component not in server build

--- a/test/fixtures/basic/components/ServerOnlyComponent.server.vue
+++ b/test/fixtures/basic/components/ServerOnlyComponent.server.vue
@@ -5,6 +5,7 @@ prerenderRoutes(['/some/url/from/server-only/component'])
 <template>
   <div>
     server-only component
+    <ServerOnlyComponentChild />
   </div>
 </template>
 

--- a/test/fixtures/basic/components/ServerOnlyComponentChild.vue
+++ b/test/fixtures/basic/components/ServerOnlyComponentChild.vue
@@ -1,0 +1,11 @@
+<template>
+  <div>
+    server-only component child (non-server-only)
+  </div>
+</template>
+
+<style>
+:root {
+  --server-only-child: 'server-only-child';
+}
+</style>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/24480
resolves https://github.com/nuxt/nuxt/issues/25330

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Not quite sure why, but we were previously not extracting styles for components that didn't have a counterpart in the client build. This change avoids the early return, but needs some extra testing to see what I was thinking in https://github.com/nuxt/nuxt/pull/21573 🤔 

It also needs a simple test.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
