### PR TITLE
fix(nuxt): add router.options files in definite order

### DIFF
--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -38,10 +38,10 @@ export default defineNuxtModule({
       // Add default options
       context.files.push({ path: resolve(runtimeDir, 'router.options'), optional: true })
 
-      await Promise.all(nuxt.options._layers.map(async layer => {
+      for (const layer of nuxt.options._layers) {
         const path = await findPath(resolve(layer.config.srcDir, 'app/router.options'))
         if (path) { context.files.push({ path }) }
-      }))
+      }
 
       await nuxt.callHook('pages:routerOptions', context)
       return context.files


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue



### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In debugging https://github.com/nuxt/nuxt/actions/runs/7628326647/job/20779171448?pr=25395, realised that we in fact were resolving `app/router.options` files in a non-reproducible order (since https://github.com/nuxt/nuxt/pull/24922).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
