### PR TITLE
fix(nuxt): add missing type for `head` in `defineNuxtComponent`

### DIFF
--- a/packages/nuxt/src/app/types/augments.d.ts
+++ b/packages/nuxt/src/app/types/augments.d.ts
@@ -1,3 +1,4 @@
+import type { UseHeadInput } from "@unhead/vue";
 import type { NuxtApp, useNuxtApp } from '../nuxt'
 
 interface NuxtStaticBuildFlags {
@@ -31,5 +32,8 @@ declare module 'vue' {
   }
   interface ComponentInternalInstance {
     _nuxtOnBeforeMountCbs: Function[]
+  }
+  interface ComponentCustomOptions {
+    head?(nuxtApp: NuxtApp): UseHeadInput
   }
 }

--- a/packages/nuxt/src/app/types/augments.d.ts
+++ b/packages/nuxt/src/app/types/augments.d.ts
@@ -34,6 +34,10 @@ declare module 'vue' {
     _nuxtOnBeforeMountCbs: Function[]
   }
   interface ComponentCustomOptions {
+    /**
+     * Available exclusively for `defineNuxtComponent`.
+     * It will not be executed when using `defineComponent`.
+     */
     head?(nuxtApp: NuxtApp): UseHeadInput
   }
 }

--- a/test/fixtures/basic-types/types.ts
+++ b/test/fixtures/basic-types/types.ts
@@ -329,6 +329,25 @@ describe('head', () => {
       }
     })
   })
+  it('types head for defineNuxtComponent', () => {
+    defineNuxtComponent({
+      head(nuxtApp) {
+        expectTypeOf(nuxtApp).not.toBeAny()
+        return {
+          title: 'Site Title'
+        }
+      }
+    })
+
+    defineNuxtComponent({
+      // @ts-expect-error wrong return type for head function
+      head() {
+        return {
+          'test': true
+        }
+      }
+    })
+  })
 })
 
 describe('components', () => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

#24811

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Fixes missing type definition for `head` function in the `defineNuxtComponent`

Resolves #24811
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
