### PR TITLE
fix(nuxt): on `callOnce` only run once callbacks with falsy return values

### DIFF
--- a/packages/nuxt/src/app/composables/once.ts
+++ b/packages/nuxt/src/app/composables/once.ts
@@ -24,9 +24,9 @@ export async function callOnce (...args: any): Promise<void> {
   if (nuxtApp.payload.once.has(_key)) {
     return
   }
+  nuxtApp.payload.once.add(_key)
   nuxtApp._once = nuxtApp._once || {}
   nuxtApp._once[_key] = nuxtApp._once[_key] || fn()
   await nuxtApp._once[_key]
-  nuxtApp.payload.once.add(_key)
   delete nuxtApp._once[_key]
 }

--- a/packages/nuxt/src/app/composables/once.ts
+++ b/packages/nuxt/src/app/composables/once.ts
@@ -24,9 +24,9 @@ export async function callOnce (...args: any): Promise<void> {
   if (nuxtApp.payload.once.has(_key)) {
     return
   }
-  nuxtApp.payload.once.add(_key)
   nuxtApp._once = nuxtApp._once || {}
   nuxtApp._once[_key] = nuxtApp._once[_key] || fn() || true
   await nuxtApp._once[_key]
+  nuxtApp.payload.once.add(_key)
   delete nuxtApp._once[_key]
 }

--- a/packages/nuxt/src/app/composables/once.ts
+++ b/packages/nuxt/src/app/composables/once.ts
@@ -26,7 +26,7 @@ export async function callOnce (...args: any): Promise<void> {
   }
   nuxtApp.payload.once.add(_key)
   nuxtApp._once = nuxtApp._once || {}
-  nuxtApp._once[_key] = nuxtApp._once[_key] || fn()
+  nuxtApp._once[_key] = nuxtApp._once[_key] || fn() || true
   await nuxtApp._once[_key]
   delete nuxtApp._once[_key]
 }

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -595,6 +595,11 @@ describe('callOnce', () => {
     const execute = () => callOnce(fn)
     await Promise.all([execute(), execute(), execute()])
     expect(fn).toHaveBeenCalledTimes(1)
+    
+    const fnSync = vi.fn().mockImplementation(() => { })
+    const executeSync = () => callOnce(fnSync)
+    await Promise.all([executeSync(), executeSync(), executeSync()])
+    expect(fnSync).toHaveBeenCalledTimes(1)
   })
 
   it('should use key to dedupe', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

resolves #25419 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR is just a suggestion to solve the related issue in code instead of on documentation. 

When registering a callback with falsy return value (undefined), it gets triggered multiple times by `callOnce` (same key). As explained in issue, the callback should return a truthy value in order to handle the evaluation below correctly. For better DX, I think the return value should be irrelevant to the logic. 

https://github.com/nuxt/nuxt/blob/44fcacba846a6cdf33e1475fc8413f6ae49d1fe4/packages/nuxt/src/app/composables/once.ts#L28



The proposed solution is to add the key in `payload.once` before the evaluation. Plus this makes sure that if the callback throws an error it will not get called again.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
