### PR TITLE
feat(nuxt): `trailingSlash` config & `createRouteResolver` util

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -1,6 +1,6 @@
 import type { ComputedRef, DefineComponent, InjectionKey, PropType } from 'vue'
 import type { RouteLocationRaw } from '#vue-router'
-import type { NuxtAppConfig } from "@nuxt/schema"
+import type { NuxtAppConfig } from 'nuxt/schema'
 import { computed, defineComponent, h, inject, onBeforeUnmount, onMounted, provide, ref, resolveComponent } from 'vue'
 import { hasProtocol, joinURL, parseQuery, parseURL } from 'ufo'
 import { preloadRouteComponents } from '../composables/preload'

--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -5,7 +5,7 @@ import { computed, defineComponent, h, inject, onBeforeUnmount, onMounted, provi
 import { hasProtocol, joinURL, parseQuery, parseURL } from 'ufo'
 import { preloadRouteComponents } from '../composables/preload'
 import { onNuxtReady } from '../composables/ready'
-import { createPathResolver, navigateTo, useRouter } from '../composables/router'
+import { createRouteResolver, navigateTo, useRouter } from '../composables/router'
 import { useNuxtApp, useRuntimeConfig } from '../nuxt'
 import { cancelIdleCallback, requestIdleCallback } from '../compat/idle-callback'
 
@@ -150,7 +150,7 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
       const router = useRouter()
       const config = useRuntimeConfig()
 
-      const resolvePath = createPathResolver( { trailingSlash: options?.trailingSlash })
+      const resolvePath = createRouteResolver( { trailingSlash: options?.trailingSlash })
 
       // Resolving `to` value from `to` and `href` props
       const to: ComputedRef<string | RouteLocationRaw> = computed(() => {

--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -1,11 +1,11 @@
 import type { ComputedRef, DefineComponent, InjectionKey, PropType } from 'vue'
+import type { RouteLocationRaw } from '#vue-router'
+import type { NuxtAppConfig } from "@nuxt/schema"
 import { computed, defineComponent, h, inject, onBeforeUnmount, onMounted, provide, ref, resolveComponent } from 'vue'
-import type { RouteLocation, RouteLocationRaw } from '#vue-router'
-import { hasProtocol, joinURL, parseQuery, parseURL, withTrailingSlash, withoutTrailingSlash } from 'ufo'
-
+import { hasProtocol, joinURL, parseQuery, parseURL } from 'ufo'
 import { preloadRouteComponents } from '../composables/preload'
 import { onNuxtReady } from '../composables/ready'
-import { navigateTo, useRouter } from '../composables/router'
+import { createPathResolver, navigateTo, useRouter } from '../composables/router'
 import { useNuxtApp, useRuntimeConfig } from '../nuxt'
 import { cancelIdleCallback, requestIdleCallback } from '../compat/idle-callback'
 
@@ -23,7 +23,7 @@ export type NuxtLinkOptions = {
   activeClass?: string
   exactActiveClass?: string
   prefetchedClass?: string
-  trailingSlash?: 'append' | 'remove'
+  trailingSlash?: NuxtAppConfig['trailingSlash']
 }
 
 export type NuxtLinkProps = {
@@ -59,27 +59,6 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
       console.warn(`[${componentName}] \`${main}\` and \`${sub}\` cannot be used together. \`${sub}\` will be ignored.`)
     }
   }
-  const resolveTrailingSlashBehavior = (
-    to: RouteLocationRaw,
-    resolve: (to: RouteLocationRaw) => RouteLocation & { href?: string }
-  ): RouteLocationRaw | RouteLocation => {
-    if (!to || (options.trailingSlash !== 'append' && options.trailingSlash !== 'remove')) {
-      return to
-    }
-
-    if (typeof to === 'string') {
-      return applyTrailingSlashBehavior(to, options.trailingSlash)
-    }
-
-    const path = 'path' in to ? to.path : resolve(to).path
-
-    return {
-      ...to,
-      name: undefined, // named routes would otherwise always override trailing slash behavior
-      path: applyTrailingSlashBehavior(path, options.trailingSlash)
-    }
-  }
-
   return defineComponent({
     name: componentName,
     props: {
@@ -171,19 +150,23 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
       const router = useRouter()
       const config = useRuntimeConfig()
 
+      const resolvePath = createPathResolver( { trailingSlash: options?.trailingSlash })
+
       // Resolving `to` value from `to` and `href` props
       const to: ComputedRef<string | RouteLocationRaw> = computed(() => {
         checkPropConflicts(props, 'to', 'href')
 
         const path = props.to || props.href || '' // Defaults to empty string (won't render any `href` attribute)
 
-        return resolveTrailingSlashBehavior(path, router.resolve)
+        // TODO isExternal is currently returning true for internal links that open in a new tab
+        return resolvePath(path, { external: isExternal.value })
       })
 
       // Lazily check whether to.value has a protocol
       const isProtocolURL = computed(() => typeof to.value === 'string' && hasProtocol(to.value, { acceptRelative: true }))
 
       // Resolving link type
+      // TODO separate logic of "should be router-link" and "is external link" for consistent behavior with navigateTo
       const isExternal = computed<boolean>(() => {
         // External prop is explicitly set
         if (props.external) {
@@ -286,7 +269,7 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
         const href = typeof to.value === 'object'
           ? router.resolve(to.value)?.href ?? null
           : (to.value && !props.external && !isProtocolURL.value)
-              ? resolveTrailingSlashBehavior(joinURL(config.app.baseURL, to.value), router.resolve) as string
+              ? resolvePath(joinURL(config.app.baseURL, to.value)) as string
               : to.value || null
 
         // Resolves `target` value
@@ -343,17 +326,6 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
 }
 
 export default defineNuxtLink(nuxtLinkDefaults)
-
-// -- NuxtLink utils --
-function applyTrailingSlashBehavior (to: string, trailingSlash: NuxtLinkOptions['trailingSlash']): string {
-  const normalizeFn = trailingSlash === 'append' ? withTrailingSlash : withoutTrailingSlash
-  // Until https://github.com/unjs/ufo/issues/189 is resolved
-  const hasProtocolDifferentFromHttp = hasProtocol(to) && !to.startsWith('http')
-  if (hasProtocolDifferentFromHttp) {
-    return to
-  }
-  return normalizeFn(to, true)
-}
 
 // --- Prefetching utils ---
 type CallbackFn = () => void

--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -1,8 +1,11 @@
 import { getCurrentInstance, hasInjectionContext, inject, onScopeDispose } from 'vue'
 import type { Ref } from 'vue'
 import type { NavigationFailure, NavigationGuard, RouteLocationNormalized, RouteLocationPathRaw, RouteLocationRaw, Router, useRoute as _useRoute, useRouter as _useRouter } from '#vue-router'
+import type { RouteLocation } from 'vue-router'
+import type { NuxtAppConfig } from "@nuxt/schema"
+
 import { sanitizeStatusCode } from 'h3'
-import { hasProtocol, isScriptProtocol, joinURL, parseURL, withQuery } from 'ufo'
+import { hasProtocol, isScriptProtocol, joinURL, parseURL, withTrailingSlash, withoutTrailingSlash } from 'ufo'
 
 // eslint-disable-next-line import/no-restricted-paths
 import type { PageMeta } from '../../pages/runtime/composables'
@@ -11,6 +14,9 @@ import { useNuxtApp, useRuntimeConfig } from '../nuxt'
 import { PageRouteSymbol } from '../components/injections'
 import type { NuxtError } from './error'
 import { createError, showError } from './error'
+
+// @ts-expect-error virtual file
+import { appTrailingSlash } from '#build/nuxt.config.mjs'
 
 /** @since 3.0.0 */
 export const useRouter: typeof _useRouter = () => {
@@ -35,6 +41,34 @@ export const onBeforeRouteLeave = (guard: NavigationGuard) => {
     return guard(to, from, next)
   })
   onScopeDispose(unsubscribe)
+}
+
+export const createPathResolver = (options: {
+    trailingSlash?: NuxtAppConfig['trailingSlash'],
+} = {}): RouteLocationRaw | RouteLocation => {
+  options.trailingSlash = options.trailingSlash || appTrailingSlash
+  const router = useRouter()
+  let normalizeSlashesFn = (input: string) => input
+  if (options.trailingSlash === 'append')
+    normalizeSlashesFn = withTrailingSlash
+  else if (options.trailingSlash === 'remove')
+    normalizeSlashesFn = withoutTrailingSlash
+  return (to: RouteLocationRaw, options?: { external?: boolean }) => {
+    const path = typeof to === 'object' && 'path' in to ? to.path : router.resolve(to).fullPath
+
+    const isFile = withoutTrailingSlash(path.split('/').pop())?.includes('.')
+    // Until https://github.com/unjs/ufo/issues/189 is resolved
+    const hasProtocolDifferentFromHttp = hasProtocol(to) && !to.startsWith('http')
+    if (isFile || hasProtocolDifferentFromHttp  || options.external) {
+      return to
+    }
+
+    return {
+      ...(typeof to === 'string' ? {} : to),
+      name: undefined, // named routes would otherwise always override trailing slash behavior
+      path: joinURL(useRuntimeConfig().app.baseURL, normalizeSlashesFn(path, true)),
+    }
+  }
 }
 
 /** @since 3.0.0 */
@@ -118,11 +152,13 @@ export interface NavigateToOptions {
 
 /** @since 3.0.0 */
 export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: NavigateToOptions): Promise<void | NavigationFailure | false> | false | void | RouteLocationRaw => {
-  if (!to) {
-    to = '/'
-  }
-
-  const toPath = typeof to === 'string' ? to : (withQuery((to as RouteLocationPathRaw).path || '/', to.query || {}) + (to.hash || ''))
+  // normalise to a RouteLocationNamedRaw
+  const route: RouteLocationPathRaw = typeof to === 'string' ? { path: to } : to
+  const isExternal = options?.external || hasProtocol(route.path, { acceptRelative: true })
+  const resolvePath = createPathResolver({
+    external: isExternal,
+  })
+  const resolvedPath = resolvePath(route)
 
   // Early open handler
   if (options?.open) {
@@ -134,28 +170,28 @@ export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: Na
         .map(([feature, value]) => `${feature.toLowerCase()}=${value}`)
         .join(', ')
 
-      open(toPath, target, features)
+      open(resolvedPath, target, features)
     }
 
     return Promise.resolve()
   }
 
-  const isExternal = options?.external || hasProtocol(toPath, { acceptRelative: true })
   if (isExternal) {
     if (!options?.external) {
       throw new Error('Navigating to an external URL is not allowed by default. Use `navigateTo(url, { external: true })`.')
     }
-    const protocol = parseURL(toPath).protocol
+    const protocol = parseURL(resolvedPath).protocol
     if (protocol && isScriptProtocol(protocol)) {
       throw new Error(`Cannot navigate to a URL with '${protocol}' protocol.`)
     }
   }
 
+
   const inMiddleware = isProcessingMiddleware()
 
   // Early redirect on client-side
   if (import.meta.client && !isExternal && inMiddleware) {
-    return to
+    return resolvedPath
   }
 
   const router = useRouter()
@@ -164,17 +200,14 @@ export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: Na
 
   if (import.meta.server) {
     if (nuxtApp.ssrContext) {
-      const fullPath = typeof to === 'string' || isExternal ? toPath : router.resolve(to).fullPath || '/'
-      const location = isExternal ? toPath : joinURL(useRuntimeConfig().app.baseURL, fullPath)
-
       const redirect = async function (response: any) {
         // TODO: consider deprecating in favour of `app:rendered` and removing
         await nuxtApp.callHook('app:redirected')
-        const encodedLoc = location.replace(/"/g, '%22')
+        const encodedLoc = resolvedPath.replace(/"/g, '%22')
         nuxtApp.ssrContext!._renderResponse = {
           statusCode: sanitizeStatusCode(options?.redirectCode || 302, 302),
           body: `<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=${encodedLoc}"></head></html>`,
-          headers: { location }
+          headers: { location: resolvedPath }
         }
         return response
       }
@@ -194,9 +227,9 @@ export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: Na
     // Run any cleanup steps for the current scope, like ending BroadcastChannel
     nuxtApp._scope.stop()
     if (options?.replace) {
-      location.replace(toPath)
+      location.replace(resolvedPath)
     } else {
-      location.href = toPath
+      location.href = resolvedPath
     }
     // Within in a Nuxt route middleware handler
     if (inMiddleware) {
@@ -211,11 +244,11 @@ export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: Na
     return Promise.resolve()
   }
 
-  return options?.replace ? router.replace(to) : router.push(to)
+  return options?.replace ? router.replace(resolvedPath) : router.push(resolvedPath)
 }
 
-/** 
- * This will abort navigation within a Nuxt route middleware handler. 
+/**
+ * This will abort navigation within a Nuxt route middleware handler.
  * @since 3.0.0
  */
 export const abortNavigation = (err?: string | Partial<NuxtError>) => {

--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -43,7 +43,7 @@ export const onBeforeRouteLeave = (guard: NavigationGuard) => {
   onScopeDispose(unsubscribe)
 }
 
-export const createPathResolver = (options: {
+export const createRouteResolver = (options: {
     trailingSlash?: NuxtAppConfig['trailingSlash'],
 } = {}): RouteLocationRaw | RouteLocation => {
   options.trailingSlash = options.trailingSlash || appTrailingSlash
@@ -155,7 +155,7 @@ export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: Na
   // normalise to a RouteLocationNamedRaw
   const route: RouteLocationPathRaw = typeof to === 'string' ? { path: to } : to
   const isExternal = options?.external || hasProtocol(route.path, { acceptRelative: true })
-  const resolvePath = createPathResolver({
+  const resolvePath = createRouteResolver({
     external: isExternal,
   })
   const resolvedPath = resolvePath(route)

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -9,7 +9,7 @@ import { hash } from 'ohash'
 import { transform } from 'esbuild'
 import { parse } from 'acorn'
 import type { CallExpression, ExpressionStatement, ObjectExpression, Program, Property } from 'estree'
-import type { NuxtPage } from 'nuxt/schema'
+import type { NuxtPage, NuxtAppConfig } from 'nuxt/schema'
 
 import { uniqueBy } from '../core/utils'
 import { toArray } from '../utils'
@@ -64,7 +64,7 @@ export async function resolvePagesRoutes (): Promise<NuxtPage[]> {
   return uniqueBy(allRoutes, 'path')
 }
 
-export async function generateRoutesFromFiles (files: ScannedFile[], options?: { trailingSlash?: boolean, shouldExtractBuildMeta?: boolean, vfs?: Record<string, string> }): Promise<NuxtPage[]> {
+export async function generateRoutesFromFiles (files: ScannedFile[], options: { trailingSlash?: NuxtAppConfig['trailingSlash'], shouldExtractBuildMeta?: boolean, vfs?: Record<string, string> }): Promise<NuxtPage[]> {
   const { trailingSlash, shouldExtractBuildMeta, vfs } = options
   const routes: NuxtPage[] = []
 

--- a/packages/nuxt/test/pages.test.ts
+++ b/packages/nuxt/test/pages.test.ts
@@ -473,7 +473,7 @@ describe('pages:generateRoutesFromFiles', () => {
         result = await generateRoutesFromFiles(test.files.map(file => ({
           absolutePath: file.path,
           relativePath: file.path.replace(/^(pages|layer\/pages)\//, '')
-        })), true, vfs)
+        })), { shouldExtractBuildMeta: true, vfs })
       } catch (error: any) {
         expect(error.message).toEqual(test.error)
       }

--- a/packages/schema/src/config/app.ts
+++ b/packages/schema/src/config/app.ts
@@ -126,6 +126,18 @@ export default defineUntypedSchema({
     },
 
     /**
+     * How the trailing slash on paths should be resolved.
+     *
+     * This will modify the default behavior of NuxtLink, navigateTo and
+     * vue-router paths to use the configured behavior.
+     * @example
+     * - `append` paths will look like `/foo/`
+     * - `remove` paths will look like `/foo`
+     * @type {typeof import('../src/types/config').NuxtAppConfig['trailingSlash']}
+     */
+    trailingSlash: undefined,
+
+    /**
      * Default values for layout transitions.
      *
      * This can be overridden with `definePageMeta` on an individual page.

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -297,7 +297,15 @@ export default defineUntypedSchema({
     defaults: {
       /** @type {typeof import('#app/components/nuxt-link')['NuxtLinkOptions']} */
       nuxtLink: {
-        componentName: 'NuxtLink'
+        $resolve: async (val, get) => {
+          const resolved = {
+            componentName: 'NuxtLink',
+          }
+          const { trailingSlash } = await get('app')
+          if (trailingSlash)
+            resolved.trailingSlash = trailingSlash
+          return resolved
+        }
       },
       /**
        * Options that apply to `useAsyncData` (and also therefore `useFetch`)

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -1,5 +1,4 @@
 import { defineUntypedSchema } from 'untyped'
-import {defu} from "defu";
 
 export default defineUntypedSchema({
   /**

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -1,4 +1,5 @@
 import { defineUntypedSchema } from 'untyped'
+import {defu} from "defu";
 
 export default defineUntypedSchema({
   /**
@@ -298,6 +299,7 @@ export default defineUntypedSchema({
       /** @type {typeof import('#app/components/nuxt-link')['NuxtLinkOptions']} */
       nuxtLink: {
         $resolve: async (val, get) => {
+          val = val || {}
           val.componentName = val.componentName || 'NuxtLink'
           const { trailingSlash } = await get('app')
           if (trailingSlash && !val.trailingSlash)

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -298,13 +298,11 @@ export default defineUntypedSchema({
       /** @type {typeof import('#app/components/nuxt-link')['NuxtLinkOptions']} */
       nuxtLink: {
         $resolve: async (val, get) => {
-          const resolved = {
-            componentName: 'NuxtLink',
-          }
+          val.componentName = val.componentName || 'NuxtLink'
           const { trailingSlash } = await get('app')
-          if (trailingSlash)
-            resolved.trailingSlash = trailingSlash
-          return resolved
+          if (trailingSlash && !val.trailingSlash)
+            val.trailingSlash = trailingSlash
+          return val
         }
       },
       /**

--- a/packages/schema/src/types/config.ts
+++ b/packages/schema/src/types/config.ts
@@ -141,6 +141,7 @@ export interface AppConfigInput extends CustomAppConfig {
 }
 
 export interface NuxtAppConfig {
+  trailingSlash?: 'append' | 'remove'
   head: AppHeadMetaObject
   layoutTransition: boolean | TransitionProps
   pageTransition: boolean | TransitionProps


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
https://github.com/nuxt/nuxt/issues/15462

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

There are several DX improvements we can make within the core for users who want to use appending trailing slashes in their Nuxt apps.

#### Nuxt Config

We keep existing config types from `NuxtLink`, in that end users can configure a trailing slash as either:
- `append` - add trailing slash `/foo/`
- `remove` - remove trailing slash `/foo`
- `undefined` - as is

Config is added to `app` namespace.

```ts
export default defineNuxtConfig({
  app: {
    trailingSlash: 'append',
  },
})
```

Side note: I'd prefer to have this as a `boolean` where it is always `false` or `true` but I think keeping consistent config APIs is more important.

#### Opportunities

- Setting slashes for `<NuxtLink>` and `navigateTo` paths
- Set `NuxtPage` paths to use trailing slash, which in turn generates the correct types when using `experimental.typedPages`.
- Giving modules a core config that they can use instead of rolling their own
- :warning: Redirecting non-slash URLs to slashed version (Not currently in scope of this PR)

#### createRouteResolver

In introducing new logic on how paths are resolved, we're introducing new logic to `<NuxtLink>` and `navigateTo`. To reduce the boilerplate, make testing easier, and improve core APIs, we introduce the `createRouteResolver` composable. 
This composable allows the core, module authors, and end users to resolve paths while respecting the trailing slashes and the base path.

We need to have a composable to create the resolver as we need to instantiate `useRouter()` within this function that won't be accessible async. 

```ts
const resolveRoute = createRouteResolver({ trailingSlash })
const path = computed(() => {
 return resolveRoute(props.to)
})
```

This is inspired by the logic of the [nuxt-site-config](https://github.com/harlan-zw/nuxt-site-config/blob/main/packages/site-config/src/urls.ts) module which has been battle-tested at this point.

:information_source: Looking for feedback on this.

#### Additional Notes

- Trailing slashes on file links are currently broken `<NuxtLink to="/file.pdf">` -> `href="/file.pdf/`
- The logic for handling whether links are external is currently inconsistent between `navigateTo` and `NuxtLink`
- - `NuxtLink` - any link that has a protocol or has a `target` that isn't `self` (new tab)
- - `navigateTo` - any link that has a protocol 


#### To Do

- [ ] Fix logic (hacked away at it, very likely broken)
- [ ] Tests (likely we're introducing regressions with current code).
- [ ] Documentation (will need docs for `createRouteResolver` and `app.trailingSlash`)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
