### PR TITLE
fix(nuxt): prevent initial scroll jump when loading page

### DIFF
--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -78,13 +78,25 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
           startPosition = savedPosition
           return
         }
-        // reset scroll behavior to initial value
-        router.options.scrollBehavior = routerOptions.scrollBehavior
-        return routerOptions.scrollBehavior?.(to, START_LOCATION, startPosition || savedPosition)
+        if (routerOptions.scrollBehavior) {
+          // reset scroll behavior to initial value
+          router.options.scrollBehavior = routerOptions.scrollBehavior
+          if ('scrollRestoration' in window.history) {
+            const unsub = router.beforeEach(() => {
+              unsub()
+              window.history.scrollRestoration = 'manual'
+            })
+          }
+          return routerOptions.scrollBehavior(to, START_LOCATION, startPosition || savedPosition)
+        }
       },
       history,
       routes
     })
+
+    if (import.meta.client && 'scrollRestoration' in window.history) {
+      window.history.scrollRestoration = 'auto'
+    }
     nuxtApp.vueApp.use(router)
 
     const previousRoute = shallowRef(router.currentRoute.value)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/19664
resolves https://github.com/nuxt/nuxt/issues/25030
resolves https://github.com/nuxt/nuxt/issues/22487

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When performing an initial load of a page, there are _two_ navigation events that happen, first when the router plugin initialises, and then after all plugins run (to give a chance for plugins to register middleware).

This causes a jump of the scroll to the top and then after all plugins run, it restores the scroll position. However, this is unaesthetic and a bad user experience.

Rather than adjusting the scrollBehavior itself, we can set `window.history.scrollRestoration` to `auto` until these first two navigations have taken place.

https://github.com/vuejs/router/blob/main/packages/router/src/router.ts#L378-L381

This supersedes some of https://github.com/nuxt/nuxt/pull/24960 but by no means all. (cc: @bernhardberger)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
