### PR TITLE
fix: route without `file` normalizes to `{}`

### DIFF
--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -377,6 +377,12 @@ function prepareRoutes (routes: NuxtPage[], parent?: NuxtPage, names = new Set<s
   return routes
 }
 
+function serializeRouteValue (value: any, filtered?: any[]) {
+  if (filtered?.length === 0) return undefined
+  if (value === undefined) return undefined
+  return JSON.stringify(value)
+}
+
 type NormalizedRoute = Partial<Record<Exclude<keyof NuxtPage, 'file'>, string>> & { component?: string }
 type NormalizedRouteKeys = (keyof NormalizedRoute)[]
 export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = new Set(), overrideMeta = false): { imports: Set<string>, routes: string } {
@@ -388,14 +394,14 @@ export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = 
         .filter(([key, value]) => key !== DYNAMIC_META_KEY && value !== undefined)
         .map(([_, value]) => value)
       const aliasFiltered = toArray(page.alias).filter(Boolean)
-      
-      const route: NormalizedRoute = Object.create({
-        path: page.path !== undefined ? JSON.stringify(page.path) : undefined,
-        name: page.name !== undefined ? JSON.stringify(page.name) : undefined,
-        meta: metaFiltered.length ? JSON.stringify(metaFiltered) : undefined,
-        alias: aliasFiltered.length ? JSON.stringify(aliasFiltered) : undefined,
-        redirect: page.redirect ? JSON.stringify(page.redirect) : undefined,
-      })
+
+      const route: NormalizedRoute = {
+        path: serializeRouteValue(page.path),
+        name: serializeRouteValue(page.name),
+        meta: serializeRouteValue(page.meta, metaFiltered),
+        alias: serializeRouteValue(page.alias, aliasFiltered),
+        redirect: serializeRouteValue(page.redirect),
+      }
 
       if (page.children?.length) {
         route.children = normalizeRoutes(page.children, metaImports, overrideMeta).routes

--- a/packages/nuxt/test/__snapshots__/pages-override-meta-disabled.test.ts.snap
+++ b/packages/nuxt/test/__snapshots__/pages-override-meta-disabled.test.ts.snap
@@ -1,4 +1,13 @@
 {
+  "route without file": [
+    {
+      "alias": "["sweet-home"]",
+      "meta": "{"hello":"world"}",
+      "name": ""home"",
+      "path": ""/"",
+      "redirect": undefined,
+    },
+  ],
   "should allow pages with `:` in their path": [
     {
       "alias": "mockMeta?.alias || []",

--- a/packages/nuxt/test/__snapshots__/pages-override-meta-enabled.test.ts.snap
+++ b/packages/nuxt/test/__snapshots__/pages-override-meta-enabled.test.ts.snap
@@ -1,4 +1,13 @@
 {
+  "route without file": [
+    {
+      "alias": "["sweet-home"]",
+      "meta": "{"hello":"world"}",
+      "name": ""home"",
+      "path": ""/"",
+      "redirect": undefined,
+    },
+  ],
   "should allow pages with `:` in their path": [
     {
       "component": "() => import("pages/test:name.vue").then(m => m.default || m)",
@@ -58,6 +67,7 @@
     {
       "alias": "["sweet-home"]",
       "component": "() => import("pages/index.vue").then(m => m.default || m)",
+      "meta": "mockMeta || {}",
       "name": ""home"",
       "path": ""/"",
       "redirect": ""/"",


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
* https://github.com/nuxt/nuxt/pull/25210
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Added a single test to test a route without `file`, I'm not sure why returning route made with `Object.create` resolved to `{}`. Also the serialization of `meta` was incorrect, it was using `metaFiltered` which is an array of values and not the original `meta` object.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
