### PR TITLE
perf(nuxt): invalidate `getRouteMeta` cache on page contents change

### DIFF
--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -135,18 +135,25 @@ export function extractScriptContent (html: string) {
 const PAGE_META_RE = /(definePageMeta\([\s\S]*?\))/
 const DYNAMIC_META_KEY = '__nuxt_dynamic_meta_key' as const
 
+const pageContentsCache: Record<string, string> = {}
 const metaCache: Record<string, Partial<Record<keyof NuxtPage, any>>> = {}
-async function getRouteMeta (contents: string, absolutePath?: string): Promise<Partial<Record<keyof NuxtPage, any>>> {
-  if (contents in metaCache) { return metaCache[contents] }
+async function getRouteMeta (contents: string, absolutePath: string): Promise<Partial<Record<keyof NuxtPage, any>>> {
+  // set/update pageContentsCache, invalidate metaCache on cache mismatch
+  if (!(absolutePath in pageContentsCache) || pageContentsCache[absolutePath] !== contents) { 
+    pageContentsCache[absolutePath] = contents 
+    delete metaCache[absolutePath]
+  }
+
+  if (absolutePath in metaCache) { return metaCache[absolutePath] }
 
   const script = extractScriptContent(contents)
   if (!script) {
-    metaCache[contents] = {}
+    metaCache[absolutePath] = {}
     return {}
   }
 
   if (!PAGE_META_RE.test(script)) {
-    metaCache[contents] = {}
+    metaCache[absolutePath] = {}
     return {}
   }
 
@@ -158,7 +165,7 @@ async function getRouteMeta (contents: string, absolutePath?: string): Promise<P
   }) as unknown as Program
   const pageMetaAST = ast.body.find(node => node.type === 'ExpressionStatement' && node.expression.type === 'CallExpression' && node.expression.callee.type === 'Identifier' && node.expression.callee.name === 'definePageMeta')
   if (!pageMetaAST) {
-    metaCache[contents] = {}
+    metaCache[absolutePath] = {}
     return {}
   }
 
@@ -221,7 +228,7 @@ async function getRouteMeta (contents: string, absolutePath?: string): Promise<P
     extractedMeta.meta[DYNAMIC_META_KEY] = dynamicProperties
   }
 
-  metaCache[contents] = extractedMeta
+  metaCache[absolutePath] = extractedMeta
   return extractedMeta
 }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Instead of using file contents as key, we cache the contents separately using `absolutePath` as key. While I'm not sure if there is much performance gained by not using large strings as keys, using the contents as key will add an entry on every file change, so with the current implementation the cache will keep on growing during development as old entries won't be removed. 

(changed PR title to better communicate the change)
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
