### PR TITLE
refactor(nuxt): normalize NuxtLink external behavior

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -136,7 +136,7 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
         required: false
       },
       ariaCurrentValue: {
-        type: String as PropType<string>,
+        type: String as PropType<RouterLinkProps['ariaCurrentValue']>,
         default: undefined,
         required: false
       },
@@ -171,9 +171,11 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
         return typeof link.value === 'string' ? link.value : router.resolve(link.value).path
       })
       const as = computed(() => {
-        const isExternalLink = hasProtocol(href.value, { acceptRelative: true })
         const forceAnchorTag = props.external
-        return !forceAnchorTag && !isExternalLink ? 'RouterLink' : 'a'
+        if (forceAnchorTag || hasProtocol(href.value, { acceptRelative: true })) {
+          return 'a'
+        }
+        return 'RouterLink'
       })
 
       const routerLinkProps = computed(() => {
@@ -328,17 +330,13 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
 export default defineNuxtLink(nuxtLinkDefaults)
 
 // -- NuxtLink utils --
-function applyTrailingSlashBehavior (to: string, trailingSlash?: NuxtLinkOptions['trailingSlash']): string {
-  if (!trailingSlash || !to) {
-    return to
+function applyTrailingSlashBehavior (path: string, trailingSlash?: NuxtLinkOptions['trailingSlash']): string {
+  // path should always be relative here
+  if (!trailingSlash || !path) {
+    return path
   }
   const normalizeFn = trailingSlash === 'append' ? withTrailingSlash : withoutTrailingSlash
-  // Until https://github.com/unjs/ufo/issues/189 is resolved
-  const hasProtocolDifferentFromHttp = hasProtocol(to) && !to.startsWith('http')
-  if (hasProtocolDifferentFromHttp) {
-    return to
-  }
-  return normalizeFn(to, true)
+  return normalizeFn(path, true)
 }
 
 // --- Prefetching utils ---

--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -67,7 +67,6 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
     }
   }
 
-  // TODO migrate to TypeScript props
   return defineComponent({
     name: componentName,
     props: {
@@ -161,7 +160,9 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
 
       const prefetched = ref(false)
       const el = import.meta.server ? undefined : ref<HTMLElement | null>(null)
-      const elRef = import.meta.server ? undefined : (ref: any) => { el!.value = props.custom ? ref?.$el?.nextElementSibling : ref?.$el }
+      const elRef = import.meta.server ? undefined : (ref: any) => {
+        el!.value = props.custom ? ref?.$el?.nextElementSibling : ref?.$el
+      }
 
       const link = computed(() => {
         checkPropConflicts(props, 'to', 'href')
@@ -170,7 +171,7 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
       const href = computed(() => {
         return typeof link.value === 'string' ? link.value : router.resolve(link.value).path
       })
-      const isAbsoluteLink = computed(() => hasProtocol(href.value, { acceptRelative: true }))
+      const isAbsoluteLink = computed(() => hasProtocol(href.value, {acceptRelative: true}))
       const as = computed(() => {
         const forceAnchorTag = props.external
         if (forceAnchorTag || isAbsoluteLink.value) {
@@ -209,7 +210,7 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
       })
 
       const anchorProps = computed(() => {
-        const to = link.value
+        const to = href.value
         // Resolves `target` value
         const target = props.target || null
 
@@ -241,8 +242,10 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
                     unobserve = null
 
                     await Promise.all([
-                      nuxtApp.hooks.callHook('link:prefetch', href.value).catch(() => {}),
-                      as.value === 'RouterLink' && preloadRouteComponents(link.value, router).catch(() => {})
+                      nuxtApp.hooks.callHook('link:prefetch', href.value).catch(() => {
+                      }),
+                      as.value === 'RouterLink' && preloadRouteComponents(link.value, router).catch(() => {
+                      })
                     ])
                     prefetched.value = true
                   })
@@ -251,7 +254,9 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
             })
           })
           onBeforeUnmount(() => {
-            if (idleId) { cancelIdleCallback(idleId) }
+            if (idleId) {
+              cancelIdleCallback(idleId)
+            }
             unobserve?.()
             unobserve = null
           })
@@ -261,7 +266,7 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
       if (import.meta.dev && import.meta.server && !props.custom) {
         const isNuxtLinkChild = inject(NuxtLinkDevKeySymbol, false)
         if (isNuxtLinkChild) {
-          console.log('[nuxt] [NuxtLink] You can\'t nest one <a> inside another <a>. This will cause a hydration error on client-side. You can pass the `custom` prop to take full control of the markup.')
+          console.warn('[nuxt] [NuxtLink] You can\'t nest one <a> inside another <a>. This will cause a hydration error on client-side. You can pass the `custom` prop to take full control of the markup.')
         } else {
           provide(NuxtLinkDevKeySymbol, true)
         }
@@ -277,14 +282,13 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
           )
         }
 
-        if (typeof link.value === 'object') {
-          import.meta.dev && console.log('[nuxt] [NuxtLink] Providing `to` as a vue-router route is not supported with external links.', link.value)
-          return null
+        if (import.meta.dev && typeof link.value === 'object') {
+          console.warn('[nuxt] [NuxtLink] Providing `to` as a vue-router route is not supported with external links.', href.value)
         }
 
         const navigate = () => {
           if (isAbsoluteLink.value) {
-            import.meta.dev && console.log('[nuxt] [NuxtLink] Navigating to an absolute link using `navigate()` isn\'t supported', anchorProps.value.href)
+            import.meta.dev && console.warn('[nuxt] [NuxtLink] Navigating to an absolute link using `navigate()` isn\'t supported.', href.value)
             return
           }
           return navigateTo(anchorProps.value.href, {

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -526,55 +526,164 @@ describe('nuxt links', () => {
     const data: Record<string, string[]> = {}
     for (const selector of ['nuxt-link', 'router-link', 'link-with-trailing-slash', 'link-without-trailing-slash']) {
       data[selector] = []
-      for (const match of html.matchAll(new RegExp(`href="([^"]*)"[^>]*class="[^"]*\\b${selector}\\b`, 'g'))) {
-        data[selector].push(match[1])
+      // extract all anchor tags
+      for (const match of html.matchAll(new RegExp(`<a[^>]+class="[^"]*${selector}[^"]*"[^>]*>`, 'g'))) {
+        data[selector].push(match)
       }
     }
     expect(data).toMatchInlineSnapshot(`
       {
         "link-with-trailing-slash": [
-          "/",
-          "/nuxt-link/trailing-slash/",
-          "/nuxt-link/trailing-slash/",
-          "/nuxt-link/trailing-slash/?test=true&amp;thing=other/thing#thing-other",
-          "/nuxt-link/trailing-slash/?test=true&amp;thing=other/thing#thing-other",
-          "/nuxt-link/trailing-slash/",
-          "/nuxt-link/trailing-slash/?with-state=true",
-          "/nuxt-link/trailing-slash/?without-state=true",
-          "https://example.com/page.html",
+          [
+            "<a href="/" class="link-with-trailing-slash">",
+          ],
+          [
+            "<a aria-current="page" href="/nuxt-link/trailing-slash/" class="foo-active-class bar-exact-active-class link-with-trailing-slash">",
+          ],
+          [
+            "<a aria-current="page" href="/nuxt-link/trailing-slash/" class="foo-active-class bar-exact-active-class link-with-trailing-slash">",
+          ],
+          [
+            "<a aria-current="page" href="/nuxt-link/trailing-slash/?test=true&amp;thing=other/thing#thing-other" class="foo-active-class bar-exact-active-class link-with-trailing-slash">",
+          ],
+          [
+            "<a aria-current="page" href="/nuxt-link/trailing-slash/?test=true&amp;thing=other/thing#thing-other" class="foo-active-class bar-exact-active-class link-with-trailing-slash">",
+          ],
+          [
+            "<a aria-current="page" href="/nuxt-link/trailing-slash/" class="foo-active-class bar-exact-active-class link-with-trailing-slash">",
+          ],
+          [
+            "<a aria-current="page" href="/nuxt-link/trailing-slash/?with-state=true" class="foo-active-class bar-exact-active-class link-with-trailing-slash">",
+          ],
+          [
+            "<a aria-current="page" href="/nuxt-link/trailing-slash/?without-state=true" class="foo-active-class bar-exact-active-class link-with-trailing-slash">",
+          ],
+          [
+            "<a href="https://example.com/page.html" rel="noopener noreferrer" class="link-with-trailing-slash">",
+          ],
+          [
+            "<a href="/nuxt-link/https://example.com/page.html" rel="noopener noreferrer" class="link-with-trailing-slash">",
+          ],
+          [
+            "<a href="/foo" rel="noopener noreferrer" class="link-with-trailing-slash">",
+          ],
+          [
+            "<a href="/foo" rel="noopener noreferrer" class="link-with-trailing-slash">",
+          ],
         ],
         "link-without-trailing-slash": [
-          "/",
-          "/nuxt-link/trailing-slash",
-          "/nuxt-link/trailing-slash",
-          "/nuxt-link/trailing-slash?test=true&amp;thing=other/thing#thing-other",
-          "/nuxt-link/trailing-slash?test=true&amp;thing=other/thing#thing-other",
-          "/nuxt-link/trailing-slash",
-          "/nuxt-link/trailing-slash?with-state=true",
-          "/nuxt-link/trailing-slash?without-state=true",
-          "https://example.com/page.html",
+          [
+            "<a href="/" class="link-without-trailing-slash">",
+          ],
+          [
+            "<a aria-current="page" href="/nuxt-link/trailing-slash" class="foo-active-class bar-exact-active-class link-without-trailing-slash">",
+          ],
+          [
+            "<a aria-current="page" href="/nuxt-link/trailing-slash" class="foo-active-class bar-exact-active-class link-without-trailing-slash">",
+          ],
+          [
+            "<a aria-current="page" href="/nuxt-link/trailing-slash?test=true&amp;thing=other/thing#thing-other" class="foo-active-class bar-exact-active-class link-without-trailing-slash">",
+          ],
+          [
+            "<a aria-current="page" href="/nuxt-link/trailing-slash?test=true&amp;thing=other/thing#thing-other" class="foo-active-class bar-exact-active-class link-without-trailing-slash">",
+          ],
+          [
+            "<a aria-current="page" href="/nuxt-link/trailing-slash" class="foo-active-class bar-exact-active-class link-without-trailing-slash">",
+          ],
+          [
+            "<a aria-current="page" href="/nuxt-link/trailing-slash?with-state=true" class="foo-active-class bar-exact-active-class link-without-trailing-slash">",
+          ],
+          [
+            "<a aria-current="page" href="/nuxt-link/trailing-slash?without-state=true" class="foo-active-class bar-exact-active-class link-without-trailing-slash">",
+          ],
+          [
+            "<a href="https://example.com/page.html" rel="noopener noreferrer" class="link-without-trailing-slash">",
+          ],
+          [
+            "<a href="/nuxt-link/https://example.com/page.html" rel="noopener noreferrer" class="link-without-trailing-slash">",
+          ],
+          [
+            "<a href="/foo" rel="noopener noreferrer" class="link-without-trailing-slash">",
+          ],
+          [
+            "<a href="/foo" rel="noopener noreferrer" class="link-without-trailing-slash">",
+          ],
         ],
         "nuxt-link": [
-          "/",
-          "/nuxt-link/trailing-slash",
-          "/nuxt-link/trailing-slash/",
-          "/nuxt-link/trailing-slash?test=true&amp;thing=other/thing#thing-other",
-          "/nuxt-link/trailing-slash/?test=true&amp;thing=other/thing#thing-other",
-          "/nuxt-link/trailing-slash",
-          "/nuxt-link/trailing-slash?with-state=true",
-          "/nuxt-link/trailing-slash?without-state=true",
-          "https://example.com/page.html",
+          [
+            "<a href="/" class="nuxt-link">",
+          ],
+          [
+            "<a aria-current="page" href="/nuxt-link/trailing-slash" class="foo-active-class bar-exact-active-class nuxt-link">",
+          ],
+          [
+            "<a aria-current="page" href="/nuxt-link/trailing-slash/" class="foo-active-class bar-exact-active-class nuxt-link">",
+          ],
+          [
+            "<a aria-current="page" href="/nuxt-link/trailing-slash?test=true&amp;thing=other/thing#thing-other" class="foo-active-class bar-exact-active-class nuxt-link">",
+          ],
+          [
+            "<a aria-current="page" href="/nuxt-link/trailing-slash/?test=true&amp;thing=other/thing#thing-other" class="foo-active-class bar-exact-active-class nuxt-link">",
+          ],
+          [
+            "<a aria-current="page" href="/nuxt-link/trailing-slash" class="foo-active-class bar-exact-active-class nuxt-link">",
+          ],
+          [
+            "<a aria-current="page" href="/nuxt-link/trailing-slash?with-state=true" class="foo-active-class bar-exact-active-class nuxt-link">",
+          ],
+          [
+            "<a aria-current="page" href="/nuxt-link/trailing-slash?without-state=true" class="foo-active-class bar-exact-active-class nuxt-link">",
+          ],
+          [
+            "<a href="https://example.com/page.html" rel="noopener noreferrer" class="nuxt-link">",
+          ],
+          [
+            "<a href="/nuxt-link/https://example.com/page.html" rel="noopener noreferrer" class="nuxt-link">",
+          ],
+          [
+            "<a href="/foo" rel="noopener noreferrer" class="nuxt-link">",
+          ],
+          [
+            "<a href="/foo" rel="noopener noreferrer" class="nuxt-link">",
+          ],
         ],
         "router-link": [
-          "/",
-          "/nuxt-link/trailing-slash",
-          "/nuxt-link/trailing-slash/",
-          "/nuxt-link/trailing-slash?test=true&amp;thing=other/thing#thing-other",
-          "/nuxt-link/trailing-slash/?test=true&amp;thing=other/thing#thing-other",
-          "/nuxt-link/trailing-slash",
-          "/nuxt-link/trailing-slash?with-state=true",
-          "/nuxt-link/trailing-slash?without-state=true",
-          "/nuxt-link/https://example.com/page.html",
+          [
+            "<a href="/" class="router-link">",
+          ],
+          [
+            "<a aria-current="page" href="/nuxt-link/trailing-slash" class="foo-active-class bar-exact-active-class router-link">",
+          ],
+          [
+            "<a aria-current="page" href="/nuxt-link/trailing-slash/" class="foo-active-class bar-exact-active-class router-link">",
+          ],
+          [
+            "<a aria-current="page" href="/nuxt-link/trailing-slash?test=true&amp;thing=other/thing#thing-other" class="foo-active-class bar-exact-active-class router-link">",
+          ],
+          [
+            "<a aria-current="page" href="/nuxt-link/trailing-slash/?test=true&amp;thing=other/thing#thing-other" class="foo-active-class bar-exact-active-class router-link">",
+          ],
+          [
+            "<a aria-current="page" href="/nuxt-link/trailing-slash" class="foo-active-class bar-exact-active-class router-link">",
+          ],
+          [
+            "<a aria-current="page" href="/nuxt-link/trailing-slash?with-state=true" class="foo-active-class bar-exact-active-class router-link">",
+          ],
+          [
+            "<a aria-current="page" href="/nuxt-link/trailing-slash?without-state=true" class="foo-active-class bar-exact-active-class router-link">",
+          ],
+          [
+            "<a href="/nuxt-link/https://example.com/page.html" class="router-link">",
+          ],
+          [
+            "<a href="/nuxt-link/https://example.com/page.html" class="router-link" external="true">",
+          ],
+          [
+            "<a href="/foo" class="router-link" external="true">",
+          ],
+          [
+            "<a href="/foo" class="router-link" external="true">",
+          ],
         ],
       }
     `)

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -541,6 +541,7 @@ describe('nuxt links', () => {
           "/nuxt-link/trailing-slash/",
           "/nuxt-link/trailing-slash/?with-state=true",
           "/nuxt-link/trailing-slash/?without-state=true",
+          "https://example.com/page.html",
         ],
         "link-without-trailing-slash": [
           "/",
@@ -551,6 +552,7 @@ describe('nuxt links', () => {
           "/nuxt-link/trailing-slash",
           "/nuxt-link/trailing-slash?with-state=true",
           "/nuxt-link/trailing-slash?without-state=true",
+          "https://example.com/page.html",
         ],
         "nuxt-link": [
           "/",
@@ -561,6 +563,7 @@ describe('nuxt links', () => {
           "/nuxt-link/trailing-slash",
           "/nuxt-link/trailing-slash?with-state=true",
           "/nuxt-link/trailing-slash?without-state=true",
+          "https://example.com/page.html",
         ],
         "router-link": [
           "/",
@@ -571,6 +574,7 @@ describe('nuxt links', () => {
           "/nuxt-link/trailing-slash",
           "/nuxt-link/trailing-slash?with-state=true",
           "/nuxt-link/trailing-slash?without-state=true",
+          "/nuxt-link/https://example.com/page.html",
         ],
       }
     `)

--- a/test/fixtures/basic/pages/nuxt-link/trailing-slash.vue
+++ b/test/fixtures/basic/pages/nuxt-link/trailing-slash.vue
@@ -6,15 +6,22 @@ const LinkWithoutTrailingSlash = defineNuxtLink({
   trailingSlash: 'remove'
 })
 const links = [
-  '/',
-  '/nuxt-link/trailing-slash',
-  '/nuxt-link/trailing-slash/',
-  '/nuxt-link/trailing-slash?test=true&thing=other/thing#thing-other',
-  '/nuxt-link/trailing-slash/?test=true&thing=other/thing#thing-other',
-  { name: 'nuxt-link-trailing-slash' },
-  { query: { 'with-state': 'true' }, state: { foo: 'bar' } },
-  { query: { 'without-state': 'true' } },
-  'https://example.com/page.html'
+  { to: '/', },
+  { to: '/nuxt-link/trailing-slash',},
+  { to: '/nuxt-link/trailing-slash/',},
+  { to: '/nuxt-link/trailing-slash?test=true&thing=other/thing#thing-other',},
+  { to: '/nuxt-link/trailing-slash/?test=true&thing=other/thing#thing-other',},
+  { to: { name: 'nuxt-link-trailing-slash' },},
+  { to: { query: { 'with-state': 'true' }, state: { foo: 'bar' } },},
+  { to: { query: { 'without-state': 'true' } }},
+  //  Trailing slashes are applied to implicit external links
+  { to: 'https://example.com/page.html' },
+  // Explicit external links do not when using vue-router object
+  { to: { path: 'https://example.com/page.html' }, external: true },
+  //  Explicit external links (that are relative) that use vue-router object adds base and trailing slash
+  { to: { path: '/foo' }, external: true },
+  //  Explicit external for relative path trailing slashes is applied
+  { to: '/foo', external: true },
 ] as const
 
 const route = useRoute()
@@ -42,13 +49,13 @@ const windowState = computed(() => {
         :key="index"
       >
         <LinkWithTrailingSlash
-          :to="link"
+          v-bind="link"
           class="link-with-trailing-slash"
         >
           <LinkWithTrailingSlash
             v-slot="{ href }"
             custom
-            :to="link"
+            v-bind="link"
           >
             {{ href }}
           </LinkWithTrailingSlash>
@@ -63,13 +70,13 @@ const windowState = computed(() => {
         :key="index"
       >
         <LinkWithoutTrailingSlash
-          :to="link"
+          v-bind="link"
           class="link-without-trailing-slash"
         >
           <LinkWithoutTrailingSlash
             v-slot="{ href }"
             custom
-            :to="link"
+            v-bind="link"
           >
             {{ href }}
           </LinkWithoutTrailingSlash>
@@ -84,13 +91,13 @@ const windowState = computed(() => {
         :key="index"
       >
         <NuxtLink
-          :to="link"
+          v-bind="link"
           class="nuxt-link"
         >
           <NuxtLink
             v-slot="{ href }"
             custom
-            :to="link"
+            v-bind="link"
           >
             {{ href }}
           </NuxtLink>
@@ -105,13 +112,13 @@ const windowState = computed(() => {
         :key="index"
       >
         <RouterLink
-          :to="link"
+          v-bind="link"
           class="router-link"
         >
           <RouterLink
             v-slot="{ href }"
             custom
-            :to="link"
+            v-bind="link"
           >
             {{ href }}
           </RouterLink>

--- a/test/fixtures/basic/pages/nuxt-link/trailing-slash.vue
+++ b/test/fixtures/basic/pages/nuxt-link/trailing-slash.vue
@@ -13,7 +13,8 @@ const links = [
   '/nuxt-link/trailing-slash/?test=true&thing=other/thing#thing-other',
   { name: 'nuxt-link-trailing-slash' },
   { query: { 'with-state': 'true' }, state: { foo: 'bar' } },
-  { query: { 'without-state': 'true' } }
+  { query: { 'without-state': 'true' } },
+  'https://example.com/page.html'
 ] as const
 
 const route = useRoute()
@@ -28,11 +29,13 @@ const windowState = computed(() => {
 
 <template>
   <div>
+    <h2>window state</h2>
     <div data-testid="window-state">
       <ClientOnly>
         {{ windowState }}
       </ClientOnly>
     </div>
+    <h2>Links With Trailing Slash</h2>
     <ul>
       <li
         v-for="(link, index) in links"
@@ -53,6 +56,7 @@ const windowState = computed(() => {
       </li>
     </ul>
     <hr>
+    <h2>Links Without Trailing Slash</h2>
     <ul>
       <li
         v-for="(link, index) in links"
@@ -73,6 +77,7 @@ const windowState = computed(() => {
       </li>
     </ul>
     <hr>
+    <h2>Nuxt Link</h2>
     <ul>
       <li
         v-for="(link, index) in links"
@@ -93,6 +98,7 @@ const windowState = computed(() => {
       </li>
     </ul>
     <hr>
+    <h2>Router Link</h2>
     <ul>
       <li
         v-for="(link, index) in links"


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/25532

(blocking further work on https://github.com/nuxt/nuxt/pull/25435)

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

:information_source: Still thinking through this PR.

NuxtLink has some logic issues that we _should_ clean up that would solve several edge cases. We try to define what kind of logic domains we're dealing with and try and handle them more explicitly.

### Domains

**Internal relative links**

Nuxt-based relative links.

- should use `RouterLink` (vue-router)
- should have trailing slash logic applied
- should be resolved with the base URL
- should preload route components (when enabled)

```vue
<template>
  <NuxtLink to="/foo"> <!-- <RouterLink to="{ path: applyTrailingSlash('/foo')  }"> -->
</template>
```

**"External" relative links**

Used to point to non-Nuxt relative links. For example, a `/admin/` path may be hosted by a separate application, we don't want vue-router logic to apply.

- requires explicit opt-in with `external`
- should use `a` tag
- should _not_ have trailing slash logic applied (unless via an explicit prop opt-in) :warning: (?)
- should _not_ have base path applied  :warning: (?)
- should not have rel applied

```vue
<template>
  <NuxtLink to="/foo" external> <!-- <a href="/foo"> -->
</template>
```

**External absolute link**

Link to other sites.

- should use `a` tag
- should _not_ have trailing slash logic applied (unless via an explicit prop opt-in)
- should _not_ have base path applied
- should have `rel` applied

```vue
<template>
  <NuxtLink to="https://www.google.com"> <!-- <a href="www,google.com"> -->
</template>
```

**Custom Links**

When the `custom` prop is used.

- whatever child slot the user uses
- should apply logic as per the above behavior
- should work for relative/absolute links when using `navigate()` function (if explicit opt-in is provided) (!)


## New Dev Warnings

- absolute link provided as object (`{ path: 'https://example.com' }`)
- trying to navigate to absolute URL using `custom` and `navigate()` 


<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
