### PR TITLE
ci: retry flaky test when running in Windows with Webpack

### DIFF
--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -591,29 +591,33 @@ describe('nuxt links', () => {
     await page.close()
   })
 
-  it('expect scroll to top on routes with same component', async () => {
-    // #22402
-    const page = await createPage('/big-page-1', {
-      viewport: {
-        width: 1000,
-        height: 1000
-      }
-    })
-    await page.waitForFunction(() => window.useNuxtApp?.()._route.fullPath === '/big-page-1')
+  it('expect scroll to top on routes with same component', 
+    async () => {
+      // #22402
+      const page = await createPage('/big-page-1', {
+        viewport: {
+          width: 1000,
+          height: 1000
+        }
+      })
+      await page.waitForFunction(() => window.useNuxtApp?.()._route.fullPath === '/big-page-1')
 
-    await page.locator('#big-page-2').scrollIntoViewIfNeeded()
-    expect(await page.evaluate(() => window.scrollY)).toBeGreaterThan(0)
-    await page.locator('#big-page-2').click()
-    await page.waitForFunction(path => window.useNuxtApp?.()._route.fullPath === path, `/big-page-2`)
-    expect(await page.evaluate(() => window.scrollY)).toBe(0)
+      await page.locator('#big-page-2').scrollIntoViewIfNeeded()
+      expect(await page.evaluate(() => window.scrollY)).toBeGreaterThan(0)
+      await page.locator('#big-page-2').click()
+      await page.waitForFunction(path => window.useNuxtApp?.()._route.fullPath === path, `/big-page-2`)
+      expect(await page.evaluate(() => window.scrollY)).toBe(0)
 
-    await page.locator('#big-page-1').scrollIntoViewIfNeeded()
-    expect(await page.evaluate(() => window.scrollY)).toBeGreaterThan(0)
-    await page.locator('#big-page-1').click()
-    await page.waitForFunction(path => window.useNuxtApp?.()._route.fullPath === path, `/big-page-1`)
-    expect(await page.evaluate(() => window.scrollY)).toBe(0)
-    await page.close()
-  })
+      await page.locator('#big-page-1').scrollIntoViewIfNeeded()
+      expect(await page.evaluate(() => window.scrollY)).toBeGreaterThan(0)
+      await page.locator('#big-page-1').click()
+      await page.waitForFunction(path => window.useNuxtApp?.()._route.fullPath === path, `/big-page-1`)
+      expect(await page.evaluate(() => window.scrollY)).toBe(0)
+      await page.close()
+    }, 
+    // Flaky when run on windows + webpack
+    { retry: isWebpack && isWindows ? 10 : 0 }
+  )
 
   it('expect scroll to top on nested pages', async () => {
     // #20523


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Since we know that it is flaky and it does succeed after retries, this is preferable over triggering the retry manually. This possibly needs to include the following test "expect scroll to top on nested pages" as well, but I haven't tested its flakiness.

While retries are not ideal, it's better/faster than rerunning the entire job. Hopefully we can find the source of its flakiness someday or someone manages to provide a reproduction with the issue.

Besides this scroll to top test, `test/basic.test.ts > component islands > test client-side navigation` may be the last remaining flaky test.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
