### PR TITLE
ci: retry flaky test when using Webpack

### DIFF
--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -615,8 +615,8 @@ describe('nuxt links', () => {
       expect(await page.evaluate(() => window.scrollY)).toBe(0)
       await page.close()
     }, 
-    // Flaky when run on windows + webpack
-    { retry: isWebpack && isWindows ? 10 : 0 }
+    // Flaky behavior when using Webpack
+    { retry: isWebpack ? 10 : 0 }
   )
 
   it('expect scroll to top on nested pages', 
@@ -643,8 +643,8 @@ describe('nuxt links', () => {
       expect(await page.evaluate(() => window.scrollY)).toBe(0)
       await page.close()
     },
-    // Flaky when run on windows + webpack
-    { retry: isWebpack && isWindows ? 10 : 0 }
+    // Flaky behavior when using Webpack
+    { retry: isWebpack ? 10 : 0 }
   )
 })
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Sorry for all the separate PRs, hopefully we gain some information about the flaky behaviour though, likely more PRs to follow. (I also check if flakiness is reduced running CI on fork)
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
