### PR TITLE
fix(nuxt): add client flag for animationframe api

### DIFF
--- a/packages/nuxt/src/app/composables/loading-indicator.ts
+++ b/packages/nuxt/src/app/composables/loading-indicator.ts
@@ -79,7 +79,9 @@ function createLoadingIndicator (opts: Partial<LoadingIndicatorOpts> = {}) {
 
   function clear () {
     clearTimeout(_throttle)
-    cancelAnimationFrame(rafId)
+    if (import.meta.client) {
+      cancelAnimationFrame(rafId)
+    }
     _throttle = null
   }
 
@@ -93,7 +95,9 @@ function createLoadingIndicator (opts: Partial<LoadingIndicatorOpts> = {}) {
       startTimeStamp ??= timeStamp
       const elapsed = timeStamp - startTimeStamp
       progress.value = Math.max(0, Math.min(100, getProgress(duration, elapsed)))
-      rafId = requestAnimationFrame(step)
+      if (import.meta.client) {
+        rafId = requestAnimationFrame(step)
+      }
     }
 
     if (import.meta.client) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

fix #25560

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Hey :wave: this PR move the animation frame functions within `useLoadingIndicator` behind a import.meta.client flag.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
