### PR TITLE
fix(nuxt): `NuxtLink` no default rel for relative external links

### DIFF
--- a/docs/3.api/1.components/4.nuxt-link.md
+++ b/docs/3.api/1.components/4.nuxt-link.md
@@ -34,7 +34,7 @@ In this example, we use `<NuxtLink>` component to link to a website.
   <NuxtLink to="https://nuxtjs.org">
     Nuxt website
   </NuxtLink>
-  <!-- <a href="https://nuxtjs.org" rel="noopener noreferrer">...</a> -->
+  <!-- <a href="https://nuxtjs.org" rel="noreferrer">...</a> -->
 </template>
 ```
 
@@ -47,7 +47,7 @@ In this example, we use `<NuxtLink>` with `target`, `rel`, and `noRel` props.
   <NuxtLink to="https://twitter.com/nuxt_js" target="_blank">
     Nuxt Twitter
   </NuxtLink>
-  <!-- <a href="https://twitter.com/nuxt_js" target="_blank" rel="noopener noreferrer">...</a> -->
+  <!-- <a href="https://twitter.com/nuxt_js" target="_blank" rel="noreferrer">...</a> -->
 
   <NuxtLink to="https://discord.nuxtjs.org" target="_blank" rel="noopener">
     Nuxt Discord
@@ -62,7 +62,7 @@ In this example, we use `<NuxtLink>` with `target`, `rel`, and `noRel` props.
   <NuxtLink to="/contact" target="_blank">
     Contact page opens in another tab
   </NuxtLink>
-  <!-- <a href="/contact" target="_blank" rel="noopener noreferrer">...</a> -->
+  <!-- <a href="/contact" target="_blank" rel="noreferrer">...</a> -->
 </template>
 ```
 
@@ -113,7 +113,7 @@ defineNuxtLink({
 ```
 
 - `componentName`: A name for the defined `<NuxtLink>` component.
-- `externalRelAttribute`: A default `rel` attribute value applied on external links. Defaults to `"noopener noreferrer"`. Set it to `""` to disable
+- `externalRelAttribute`: A default `rel` attribute value applied on external links. Defaults to `"noreferrer"`. Set it to `""` to disable
 - `activeClass`: A default class to apply on active links. Works the same as [Vue Router's `linkActiveClass` option](https://router.vuejs.org/api/interfaces/RouterOptions.html#Properties-linkActiveClass). Defaults to Vue Router's default (`"router-link-active"`)
 - `exactActiveClass`: A default class to apply on exact active links. Works the same as [Vue Router's `linkExactActiveClass` option](https://router.vuejs.org/api/interfaces/RouterOptions.html#Properties-linkExactActiveClass). Defaults to Vue Router's default (`"router-link-exact-active"`)
 - `prefetchedClass`: A default class to apply to links that have been prefetched.

--- a/docs/3.api/1.components/4.nuxt-link.md
+++ b/docs/3.api/1.components/4.nuxt-link.md
@@ -34,11 +34,11 @@ In this example, we use `<NuxtLink>` component to link to a website.
   <NuxtLink to="https://nuxtjs.org">
     Nuxt website
   </NuxtLink>
-  <!-- <a href="https://nuxtjs.org" rel="noreferrer">...</a> -->
+  <!-- <a href="https://nuxtjs.org" rel="noopener noreferrer">...</a> -->
 </template>
 ```
 
-## Best Practice Rel
+## `target` and `rel` Attributes
 
 A `rel` attribute of `noopener noreferrer` is applied by default to absolute links and links that open in new tabs.
 - `noopener` solves a [security bug](https://mathiasbynens.github.io/rel-noopener/) in older browsers.

--- a/docs/3.api/1.components/4.nuxt-link.md
+++ b/docs/3.api/1.components/4.nuxt-link.md
@@ -53,7 +53,7 @@ When you need to overwrite this behavior you can use the `rel` and `noRel` props
   <NuxtLink to="https://twitter.com/nuxt_js" target="_blank">
     Nuxt Twitter
   </NuxtLink>
-  <!-- <a href="https://twitter.com/nuxt_js" target="_blank" rel="noreferrer">...</a> -->
+  <!-- <a href="https://twitter.com/nuxt_js" target="_blank" rel="noopener noreferrer">...</a> -->
 
   <NuxtLink to="https://discord.nuxtjs.org" target="_blank" rel="noopener">
     Nuxt Discord
@@ -68,7 +68,7 @@ When you need to overwrite this behavior you can use the `rel` and `noRel` props
   <NuxtLink to="/contact" target="_blank">
     Contact page opens in another tab
   </NuxtLink>
-  <!-- <a href="/contact" target="_blank" rel="noreferrer">...</a> -->
+  <!-- <a href="/contact" target="_blank" rel="noopener noreferrer">...</a> -->
 </template>
 ```
 
@@ -119,7 +119,7 @@ defineNuxtLink({
 ```
 
 - `componentName`: A name for the defined `<NuxtLink>` component.
-- `externalRelAttribute`: A default `rel` attribute value applied on external links. Defaults to `"noreferrer"`. Set it to `""` to disable
+- `externalRelAttribute`: A default `rel` attribute value applied on external links. Defaults to `"noopener noreferrer"`. Set it to `""` to disable
 - `activeClass`: A default class to apply on active links. Works the same as [Vue Router's `linkActiveClass` option](https://router.vuejs.org/api/interfaces/RouterOptions.html#Properties-linkActiveClass). Defaults to Vue Router's default (`"router-link-active"`)
 - `exactActiveClass`: A default class to apply on exact active links. Works the same as [Vue Router's `linkExactActiveClass` option](https://router.vuejs.org/api/interfaces/RouterOptions.html#Properties-linkExactActiveClass). Defaults to Vue Router's default (`"router-link-exact-active"`)
 - `prefetchedClass`: A default class to apply to links that have been prefetched.

--- a/docs/3.api/1.components/4.nuxt-link.md
+++ b/docs/3.api/1.components/4.nuxt-link.md
@@ -38,9 +38,15 @@ In this example, we use `<NuxtLink>` component to link to a website.
 </template>
 ```
 
-## `target` and `rel` Attributes
+## Best Practice Rel
 
-In this example, we use `<NuxtLink>` with `target`, `rel`, and `noRel` props.
+A `rel` attribute of `noopener noreferrer` is applied by default to absolute links and links that open in new tabs.
+- `noopener` solves a [security bug](https://mathiasbynens.github.io/rel-noopener/) in older browsers.
+- `noreferrer` improves privacy for your users by not sending the `Referer` header to the linked site.
+
+These defaults have no negative impact on SEO and are considered [best practice](https://developer.chrome.com/docs/lighthouse/best-practices/external-anchors-use-rel-noopener).
+
+When you need to overwrite this behavior you can use the `rel` and `noRel` props.
 
 ```vue [app.vue]
 <template>

--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -14,7 +14,7 @@ import { nuxtLinkDefaults } from '#build/nuxt.config.mjs'
 
 const firstNonUndefined = <T> (...args: (T | undefined)[]) => args.find(arg => arg !== undefined)
 
-const DEFAULT_EXTERNAL_REL_ATTRIBUTE = 'noopener noreferrer'
+const DEFAULT_EXTERNAL_REL_ATTRIBUTE = 'noreferrer'
 const NuxtLinkDevKeySymbol: InjectionKey<boolean> = Symbol('nuxt-link-dev-key')
 
 export type NuxtLinkOptions = {
@@ -181,7 +181,7 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
       })
 
       // Lazily check whether to.value has a protocol
-      const isProtocolURL = computed(() => typeof to.value === 'string' && hasProtocol(to.value, { acceptRelative: true }))
+      const isAbsoluteUrl = computed(() => typeof to.value === 'string' && hasProtocol(to.value, { acceptRelative: true }))
 
       // Resolving link type
       const isExternal = computed<boolean>(() => {
@@ -200,7 +200,7 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
           return false
         }
 
-        return to.value === '' || isProtocolURL.value
+        return to.value === '' || isAbsoluteUrl.value
       })
 
       // Prefetching
@@ -285,7 +285,7 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
         // converts `""` to `null` to prevent the attribute from being added as empty (`href=""`)
         const href = typeof to.value === 'object'
           ? router.resolve(to.value)?.href ?? null
-          : (to.value && !props.external && !isProtocolURL.value)
+          : (to.value && !props.external && !isAbsoluteUrl.value)
               ? resolveTrailingSlashBehavior(joinURL(config.app.baseURL, to.value), router.resolve) as string
               : to.value || null
 
@@ -297,7 +297,7 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
         const rel = (props.noRel)
           ? null
           // converts `""` to `null` to prevent the attribute from being added as empty (`rel=""`)
-          : firstNonUndefined<string | null>(props.rel, options.externalRelAttribute, href ? DEFAULT_EXTERNAL_REL_ATTRIBUTE : '') || null
+          : firstNonUndefined<string | null>(props.rel, ...(isAbsoluteUrl.value ? [options.externalRelAttribute, href ? DEFAULT_EXTERNAL_REL_ATTRIBUTE : ''] : [])) || null
 
         const navigate = () => navigateTo(href, { replace: props.replace })
 

--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -297,7 +297,7 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
         checkPropConflicts(props, 'noRel', 'rel')
         const rel = firstNonUndefined<string | null>(
           // converts `""` to `null` to prevent the attribute from being added as empty (`rel=""`)
-          props.noRel ? '' : undefined, props.rel,
+          props.noRel ? '' : props.rel,
           options.externalRelAttribute,
           /*
           * A fallback rel of `noopener noreferrer` is applied for external links or links that open in a new tab.

--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -300,7 +300,7 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
           props.noRel ? '' : undefined, props.rel,
           options.externalRelAttribute,
           /*
-          * A fallback rel of `noreferrer` is applied for external links or links that open in a new tab.
+          * A fallback rel of `noopener noreferrer` is applied for external links or links that open in a new tab.
           * This solves a reverse tabnapping security flaw in browsers pre-2021 as well as improving privacy.
           */
           (isAbsoluteUrl.value || hasTarget.value) ? 'noopener noreferrer' : ''

--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -293,18 +293,18 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
         // Resolves `target` value
         const target = props.target || null
 
-        /*
-         * A fallback rel of `noreferrer` is applied for external links or links that open in a new tab.
-         * This solves a reverse tabnapping security flaw in browsers pre-2021 as well as improving privacy.
-         */
-        const fallbackRel = (isAbsoluteUrl.value || hasTarget.value) ?
-          [options.externalRelAttribute, href ? 'noreferrer' : ''] : []
         // Resolves `rel`
         checkPropConflicts(props, 'noRel', 'rel')
-        const rel = (props.noRel)
-          ? null
+        const rel = firstNonUndefined<string | null>(
           // converts `""` to `null` to prevent the attribute from being added as empty (`rel=""`)
-          : firstNonUndefined<string | null>(props.rel, ...fallbackRel) || null
+          props.noRel ? '' : undefined, props.rel,
+          options.externalRelAttribute,
+          /*
+          * A fallback rel of `noreferrer` is applied for external links or links that open in a new tab.
+          * This solves a reverse tabnapping security flaw in browsers pre-2021 as well as improving privacy.
+          */
+          (isAbsoluteUrl.value || hasTarget.value) ? 'noopener noreferrer' : ''
+        ) || null
 
         const navigate = () => navigateTo(href, { replace: props.replace })
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

Relates to https://github.com/nuxt/nuxt/issues/25532
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The default `rel` tag we apply to `external` NuxtLink's is quite interesting, here are some details about it if you don't know:
- We have used it because this security issue: https://mathiasbynens.github.io/rel-noopener/
- The [noreferrer](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/noreferrer) will automatically apply `noopener`, providing both are not required. I'd just use `noreferrer` but it's probably worth keeping consistency with larger sites in this case (i.e GitHub / Twitter still uses both).
- The [noopener](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/noopener) has been applied by default when using `target="_blank"` in browsers since 2021, so providing all together will not be necessary at some point.  

Anyway to the point of this PR, it's to fix an edge case where it's applied when not needed and document this logic.

```vue
<template>
  <NuxtLink to="/foo" external> <!--- <a href="/foo" rel="noopener noreferrer"> -->
</template>
```

Wasn't sure whether to support relative links that open in a separate window context for extra security, interested to hear others' thoughts (i.e you're hosting an untrusted app on your domain).

```vue
<template>
  <NuxtLink to="/naughty-app" external target="_blank"> <!--- <a to="/naughty-app" rel="noopener noreferrer"> -->
</template>
```

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
