### PR TITLE
docs: add nuxt-link defaults config in nuxt.config

### DIFF
--- a/docs/3.api/1.components/4.nuxt-link.md
+++ b/docs/3.api/1.components/4.nuxt-link.md
@@ -88,6 +88,33 @@ Defaults can be overwritten, see [overwriting defaults](#overwriting-defaults) i
 
 ## Overwriting Defaults
 
+### By Nuxt Config
+
+You can overwrite `<NuxtLink>` defaults by [`nuxt.config`](https://nuxt.com/docs/api/nuxt-config#defaults)
+
+::callout{color="amber" icon="i-ph-warning-duotone"}
+These options will likely be moved elsewhere in the future, such as into `app.config` or into the `app/` directory.
+::
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  experimental: {
+    defaults: {
+      nuxtLink: {
+        componentName?: string;
+        externalRelAttribute?: string;
+        activeClass?: string;
+        exactActiveClass?: string;
+        prefetchedClass?: string;
+        trailingSlash?: 'append' | 'remove'
+      }
+    }
+  }
+})
+```
+
+### Recommended
+
 You can overwrite `<NuxtLink>` defaults by creating your own link component using `defineNuxtLink`.
 
 ```js [components/MyNuxtLink.ts]

--- a/docs/3.api/1.components/4.nuxt-link.md
+++ b/docs/3.api/1.components/4.nuxt-link.md
@@ -88,9 +88,9 @@ Defaults can be overwritten, see [overwriting defaults](#overwriting-defaults) i
 
 ## Overwriting Defaults
 
-### By Nuxt Config
+### In Nuxt Config
 
-You can overwrite `<NuxtLink>` defaults by [`nuxt.config`](https://nuxt.com/docs/api/nuxt-config#defaults)
+You can overwrite some `<NuxtLink>` defaults in your [`nuxt.config`](https://nuxt.com/docs/api/nuxt-config#defaults)
 
 ::callout{color="amber" icon="i-ph-warning-duotone"}
 These options will likely be moved elsewhere in the future, such as into `app.config` or into the `app/` directory.
@@ -101,19 +101,20 @@ export default defineNuxtConfig({
   experimental: {
     defaults: {
       nuxtLink: {
-        componentName?: string;
-        externalRelAttribute?: string;
-        activeClass?: string;
-        exactActiveClass?: string;
-        prefetchedClass?: string;
-        trailingSlash?: 'append' | 'remove'
+        // default values
+        componentName: 'NuxtLink',
+        externalRelAttribute: 'noopener noreferrer',
+        activeClass: 'router-link-active',
+        exactActiveClass: 'router-link-exact-active',
+        prefetchedClass: undefined, // can be any valid string class name
+        trailingSlash: undefined // can be 'append' or 'remove'
       }
     }
   }
 })
 ```
 
-### Recommended
+### Custom Link Component
 
 You can overwrite `<NuxtLink>` defaults by creating your own link component using `defineNuxtLink`.
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

none

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Set `nuxt-link` defaults by `nuxt.config` is one way, and its not in the docs.

However its will be changed in the future.

So, using `defineNuxtLink` is the reccomended way?

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
