### PR TITLE
fix(nuxt): fetch island if there's no element on the vnode instance

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-island.ts
+++ b/packages/nuxt/src/app/components/nuxt-island.ts
@@ -224,9 +224,9 @@ export default defineComponent({
       watch(props, debounce(() => fetchComponent(), 100), { deep: true })
     }
 
-    if (import.meta.client && !nuxtApp.isHydrating && props.lazy) {
+    if (import.meta.client && !instance.vnode.el && props.lazy) {
       fetchComponent()
-    } else if (import.meta.server || !nuxtApp.isHydrating || !nuxtApp.payload.serverRendered) {
+    } else if (import.meta.server || !instance.vnode.el || !nuxtApp.payload.serverRendered) {
       await fetchComponent()
     } else if (selectiveClient && canLoadClientComponent.value) {
       await loadComponents(props.source, payloads.components)

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1498,8 +1498,8 @@ describe.skipIf(isDev() || isWebpack)('inlining component styles', () => {
   })
 })
 
-describe.only('server components/islands', () => {
-  it.only('/islands', async () => {
+describe('server components/islands', () => {
+  it('/islands', async () => {
     const { page } = await renderPage('/islands')
     const islandRequest = page.waitForResponse(response => response.url().includes('/__nuxt_island/') && response.status() === 200)
     await page.locator('#increase-pure-component').click()

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1498,8 +1498,8 @@ describe.skipIf(isDev() || isWebpack)('inlining component styles', () => {
   })
 })
 
-describe('server components/islands', () => {
-  it('/islands', async () => {
+describe.only('server components/islands', () => {
+  it.only('/islands', async () => {
     const { page } = await renderPage('/islands')
     const islandRequest = page.waitForResponse(response => response.url().includes('/__nuxt_island/') && response.status() === 200)
     await page.locator('#increase-pure-component').click()
@@ -1529,6 +1529,9 @@ describe('server components/islands', () => {
     // test islands mounted client side with slot
     await page.locator('#show-island').click()
     expect(await page.locator('#island-mounted-client-side').innerHTML()).toContain('Interactive testing slot post SSR')
+
+    // test islands wrapped with client-only
+    expect(await page.locator('#wrapped-client-only').innerHTML()).toContain('Was router enabled')
 
     if (!isWebpack) {
       // test client component interactivity

--- a/test/fixtures/basic/pages/islands.vue
+++ b/test/fixtures/basic/pages/islands.vue
@@ -20,14 +20,14 @@ const count = ref(0)
         name="PureComponent"
         :props="islandProps"
       />
-    <div id="wrapped-client-only"> 
-      <ClientOnly>
-        <NuxtIsland
-          name="PureComponent"
-          :props="islandProps"
-        />
-      </ClientOnly>
-    </div>
+      <div id="wrapped-client-only"> 
+        <ClientOnly>
+          <NuxtIsland
+            name="PureComponent"
+            :props="islandProps"
+          />
+        </ClientOnly>
+      </div>
     </div>
     <button
       id="increase-pure-component"

--- a/test/fixtures/basic/pages/islands.vue
+++ b/test/fixtures/basic/pages/islands.vue
@@ -20,10 +20,14 @@ const count = ref(0)
         name="PureComponent"
         :props="islandProps"
       />
-      <NuxtIsland
-        name="PureComponent"
-        :props="islandProps"
-      />
+    <div id="wrapped-client-only"> 
+      <ClientOnly>
+        <NuxtIsland
+          name="PureComponent"
+          :props="islandProps"
+        />
+      </ClientOnly>
+    </div>
     </div>
     <button
       id="increase-pure-component"


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
fix #25583 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Hi :wave: this fix an issue when combining `ClientOnly` and islands. `ClientOnly` can re-render before the hydration step finishes . 

so we need check if an element is attached on the vnode of the component insteed of verifying if nuxt is still hydrating to correctly trigger the fetch function

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
