### PR TITLE
fix(nuxt): remove key from `useId` type signature

### DIFF
--- a/packages/nuxt/src/app/composables/id.ts
+++ b/packages/nuxt/src/app/composables/id.ts
@@ -7,6 +7,7 @@ const ATTR_KEY = 'data-n-ids'
 /**
  * Generate an SSR-friendly unique identifier that can be passed to accessibility attributes.
  */
+export function useId (): string
 export function useId (key?: string): string {
   if (typeof key !== 'string') {
     throw new TypeError('[nuxt] [useId] key must be a string.')

--- a/test/fixtures/basic-types/types.ts
+++ b/test/fixtures/basic-types/types.ts
@@ -362,6 +362,11 @@ describe('composables', () => {
     expectTypeOf(useFetch('/test', { default: () => 500 }).data).toEqualTypeOf<Ref<unknown>>()
   })
 
+  it('prevents passing string to `useId`', () => {
+    // @ts-expect-error providing a key is not allowed
+    useId('test')
+  })
+
   it('enforces readonly cookies', () => {
     // @ts-expect-error readonly cookie
     useCookie('test', { readonly: true }).value = 'thing'


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This removes the possibility of passing a key to `useId` (at the type level) as this will probably not do what people expect (and is also not documented).

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
