### PR TITLE
fix(nuxt): remove `$` from generated id in `useId`

### DIFF
--- a/packages/nuxt/src/app/composables/id.ts
+++ b/packages/nuxt/src/app/composables/id.ts
@@ -11,6 +11,7 @@ export function useId (key?: string): string {
   if (typeof key !== 'string') {
     throw new TypeError('[nuxt] [useId] key must be a string.')
   }
+  // TODO: implement in composable-keys
   key = key.slice(1)
   const nuxtApp = useNuxtApp()
   const instance = getCurrentInstance()

--- a/packages/nuxt/src/app/composables/id.ts
+++ b/packages/nuxt/src/app/composables/id.ts
@@ -11,6 +11,7 @@ export function useId (key?: string): string {
   if (typeof key !== 'string') {
     throw new TypeError('[nuxt] [useId] key must be a string.')
   }
+  key = key.slice(1)
   const nuxtApp = useNuxtApp()
   const instance = getCurrentInstance()
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/25572

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This is a quick hotfix to remove generated `$` from key provided to `useId`.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
