### PR TITLE
fix(nuxt): warn if `inheritAttrs: false` is set when using `useId`

### DIFF
--- a/packages/nuxt/src/app/composables/id.ts
+++ b/packages/nuxt/src/app/composables/id.ts
@@ -26,7 +26,7 @@ export function useId (key?: string): string {
   const instanceIndex = key + ':' + instance._nuxtIdIndex[key]++
 
   if (import.meta.server) {
-    if (!import.meta.dev && instance.vnode.type && typeof instance.vnode.type === 'object' && 'inheritAttrs' in instance.vnode.type && instance.vnode.type.inheritAttrs === false) {
+    if (import.meta.dev && instance.vnode.type && typeof instance.vnode.type === 'object' && 'inheritAttrs' in instance.vnode.type && instance.vnode.type.inheritAttrs === false) {
       console.warn('[nuxt] `useId` is not compatible with components that have `inheritAttrs: false`.')
     }
     const ids = JSON.parse(instance.attrs[ATTR_KEY] as string | undefined || '{}')

--- a/packages/nuxt/src/app/composables/id.ts
+++ b/packages/nuxt/src/app/composables/id.ts
@@ -26,6 +26,9 @@ export function useId (key?: string): string {
   const instanceIndex = key + ':' + instance._nuxtIdIndex[key]++
 
   if (import.meta.server) {
+    if (!import.meta.dev && instance.vnode.type && typeof instance.vnode.type === 'object' && 'inheritAttrs' in instance.vnode.type && instance.vnode.type.inheritAttrs === false) {
+      console.warn('[nuxt] `useId` is not compatible with components that have `inheritAttrs: false`.')
+    }
     const ids = JSON.parse(instance.attrs[ATTR_KEY] as string | undefined || '{}')
     ids[instanceIndex] = key + ':' + nuxtApp._id++
     instance.attrs[ATTR_KEY] = JSON.stringify(ids)


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/25605

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds a warning when `inheritAttrs: false` is set in a component where we are using `useId`. This is not compatible with our current implementation.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
