### PR TITLE
fix(nuxt): do not check for layout/page usage if `<ClientOnly>` present

### DIFF
--- a/packages/nuxt/src/app/components/client-only.ts
+++ b/packages/nuxt/src/app/components/client-only.ts
@@ -1,5 +1,6 @@
 import { cloneVNode, createElementBlock, createStaticVNode, defineComponent, getCurrentInstance, h, onMounted, provide, ref } from 'vue'
 import type { ComponentInternalInstance, ComponentOptions, InjectionKey } from 'vue'
+import { useNuxtApp } from '../nuxt'
 import { getFragmentHTML } from './utils'
 
 export const clientOnlySymbol: InjectionKey<boolean> = Symbol.for('nuxt:client-only')
@@ -12,6 +13,12 @@ export default defineComponent({
   setup (_, { slots, attrs }) {
     const mounted = ref(false)
     onMounted(() => { mounted.value = true })
+    // Bail out of checking for pages/layouts as they might be included under `<ClientOnly>` 🤷‍♂️
+    if (import.meta.dev) {
+      const nuxtApp = useNuxtApp()
+      nuxtApp._isNuxtPageUsed = true
+      nuxtApp._isNuxtLayoutUsed = true
+    }
     provide(clientOnlySymbol, true)
     return (props: any) => {
       if (mounted.value) { return slots.default?.() }
@@ -63,7 +70,7 @@ export function createClientOnly<T extends ComponentOptions> (component: T) {
     // remove existing directives during hydration
     const directives = extractDirectives(instance)
     // prevent attrs inheritance since a staticVNode is rendered before hydration
-    for(const key in attrs) {
+    for (const key in attrs) {
       delete instance.attrs[key]
     }
     const mounted$ = ref(false)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/25196

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This suppresses warnings about `<NuxtPage>` or `<NuxtLayout>` not being used when `<ClientOnly>` is present in a page. This might suppress some genuine cases but it's mainly meant to help users avoid footguns, so it's probably worth erring on the side of avoiding the friction of false positives.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
