### PR TITLE
fix(vite): strip query strings when generating style chunk filenames

### DIFF
--- a/packages/vite/src/plugins/ssr-styles.ts
+++ b/packages/vite/src/plugins/ssr-styles.ts
@@ -236,7 +236,6 @@ export function ssrStylesPlugin (options: SSRStylePluginOptions): Plugin {
   }
 }
 
-
 function filename (name: string) {
   return _filename(name.replace(/\?.+$/, ''))
 }

--- a/packages/vite/src/plugins/ssr-styles.ts
+++ b/packages/vite/src/plugins/ssr-styles.ts
@@ -2,7 +2,7 @@ import { pathToFileURL } from 'node:url'
 import type { Plugin } from 'vite'
 import { dirname, relative } from 'pathe'
 import { genImport, genObjectFromRawEntries } from 'knitwork'
-import { filename } from 'pathe/utils'
+import { filename as _filename } from 'pathe/utils'
 import { parseQuery, parseURL } from 'ufo'
 import type { Component } from '@nuxt/schema'
 import MagicString from 'magic-string'
@@ -234,4 +234,9 @@ export function ssrStylesPlugin (options: SSRStylePluginOptions): Plugin {
       }
     }
   }
+}
+
+
+function filename (name: string) {
+  return _filename(name.replace(/\?.+$/, ''))
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/25724

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Because we were passing filenames with a query string, rollup was occasionally emitting files with the `.vue` extension rather than `.js`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
