### PR TITLE
fix(nuxt): don't add an extra `baseURL` on server `useRequestURL`

### DIFF
--- a/packages/nuxt/src/app/composables/url.ts
+++ b/packages/nuxt/src/app/composables/url.ts
@@ -1,14 +1,10 @@
 import { getRequestURL } from 'h3'
-import { joinURL } from 'ufo'
-import { useRuntimeConfig } from '../nuxt'
 import { useRequestEvent } from './ssr'
 
 /** @since 3.5.0 */
 export function useRequestURL () {
   if (import.meta.server) {
-    const url = getRequestURL(useRequestEvent()!)
-    url.pathname = joinURL(useRuntimeConfig().app.baseURL, url.pathname)
-    return url
+    return getRequestURL(useRequestEvent()!)
   }
   return new URL(window.location.href)
 }

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -593,7 +593,7 @@ describe('nuxt links', () => {
     await page.close()
   })
 
-  it('expect scroll to top on routes with same component', 
+  it('expect scroll to top on routes with same component',
     async () => {
       // #22402
       const page = await createPage('/big-page-1', {
@@ -616,12 +616,12 @@ describe('nuxt links', () => {
       await page.waitForFunction(path => window.useNuxtApp?.()._route.fullPath === path, `/big-page-1`)
       expect(await page.evaluate(() => window.scrollY)).toBe(0)
       await page.close()
-    }, 
+    },
     // Flaky behavior when using Webpack
     { retry: isWebpack ? 10 : 0 }
   )
 
-  it('expect scroll to top on nested pages', 
+  it('expect scroll to top on nested pages',
     async () => {
       // #20523
       const page = await createPage('/nested/foo/test', {
@@ -1722,6 +1722,8 @@ describe.skipIf(isDev())('dynamic paths', () => {
         (isWebpack && url === '/public.svg')
       ).toBeTruthy()
     }
+
+    expect(await $fetch('/foo/url')).toContain('path: /foo/url')
   })
 
   it('should allow setting relative baseURL', async () => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/25763

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I suspect this was triggered by an upstream change after `useRequestURL` was introduced, but currently `event.path` returns full URL so we do not have to add `baseURL` if app is running with a custom baseURL.

cc: @pi0 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
