### PR TITLE
fix(schema): use `rootDir` rather than `process.cwd` for `modulesDir`

### DIFF
--- a/packages/schema/build.config.ts
+++ b/packages/schema/build.config.ts
@@ -9,6 +9,8 @@ export default defineBuildConfig({
       name: 'config',
       builder: 'untyped',
       defaults: {
+        srcDir: '/<srcDir>/',
+        workspaceDir: '/<workspaceDir>/',
         rootDir: '/<rootDir>/',
         vite: {
           base: '/'

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -137,8 +137,8 @@ export default defineUntypedSchema({
     $resolve: async (val: string[] | undefined, get): Promise<string[]> => {
       const rootDir = await get('rootDir') as string
       return [
-        ...await Promise.all((val || []).map(async (dir: string) => resolve(rootDir, dir))),
-        resolve(process.cwd(), 'node_modules')
+        ...(val || []).map((dir: string) => resolve(rootDir, dir)),
+        resolve(rootDir, 'node_modules')
       ]
     }
   },

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -136,10 +136,10 @@ export default defineUntypedSchema({
     $default: ['node_modules'],
     $resolve: async (val: string[] | undefined, get): Promise<string[]> => {
       const rootDir = await get('rootDir') as string
-      return [
+      return [...new Set([
         ...(val || []).map((dir: string) => resolve(rootDir, dir)),
         resolve(rootDir, 'node_modules')
-      ]
+      ])]
     }
   },
 

--- a/packages/schema/src/config/vite.ts
+++ b/packages/schema/src/config/vite.ts
@@ -92,14 +92,14 @@ export default defineUntypedSchema({
         allow: {
           $resolve: async (val: string[] | undefined, get) => {
             const [buildDir, srcDir, rootDir, workspaceDir, modulesDir] = await Promise.all([get('buildDir'), get('srcDir'), get('rootDir'), get('workspaceDir'), get('modulesDir')]) as [string, string, string, string, string]
-            return [
+            return [...new Set([
               buildDir,
               srcDir,
               rootDir,
               workspaceDir,
               ...(modulesDir),
               ...val ?? []
-            ]
+            ])]
           }
         }
       }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/25408

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This addresses a number of schema issues.

1. It adds a minor perf improvement by deduplicating `fs.allow` and `modulesDir` arrays.
2. It adds `<srcDir>` and `<workspaceDir>` aliases to clean up generated documentation
3. It does not add `process.cwd()` to modulesDir but instead rootDir (which defaults to `process.cwd()` if no value is provided). This is the most significant change and means that Nuxt's behaviour will change when running `nuxi some/directory`. It will no longer pull in the `node_modules` from the directory _where_ you are running nuxi but will instead pull in the `node_modules` from the Nuxt project you are running, which seems to be the better behaviour.

I wonder if the 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
