### PR TITLE
fix(nuxt): only warn for `useId` if there is no readable attribute

### DIFF
--- a/packages/nuxt/src/app/composables/id.ts
+++ b/packages/nuxt/src/app/composables/id.ts
@@ -19,7 +19,7 @@ export function useId (key?: string): string {
 
   if (!instance) {
     // TODO: support auto-incrementing ID for plugins if there is need?
-    throw new TypeError('[nuxt] `useId` must be called within a component.')
+    throw new TypeError('[nuxt] `useId` must be called within a component setup function.')
   }
 
   nuxtApp._id ||= 0
@@ -29,9 +29,6 @@ export function useId (key?: string): string {
   const instanceIndex = key + ':' + instance._nuxtIdIndex[key]++
 
   if (import.meta.server) {
-    if (import.meta.dev && instance.vnode.type && typeof instance.vnode.type === 'object' && 'inheritAttrs' in instance.vnode.type && instance.vnode.type.inheritAttrs === false) {
-      console.warn('[nuxt] `useId` is not compatible with components that have `inheritAttrs: false`.')
-    }
     const ids = JSON.parse(instance.attrs[ATTR_KEY] as string | undefined || '{}')
     ids[instanceIndex] = key + ':' + nuxtApp._id++
     instance.attrs[ATTR_KEY] = JSON.stringify(ids)
@@ -47,6 +44,10 @@ export function useId (key?: string): string {
     const ids = JSON.parse(el?.getAttribute?.(ATTR_KEY) || '{}')
     if (ids[instanceIndex]) {
       return ids[instanceIndex]
+    }
+
+    if (import.meta.dev && instance.vnode.type && typeof instance.vnode.type === 'object' && 'inheritAttrs' in instance.vnode.type && instance.vnode.type.inheritAttrs === false) {
+      console.warn('[nuxt] `useId` might not work correctly with components that have `inheritAttrs: false`.')
     }
   }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

related: https://github.com/nuxt/nuxt/issues/25755
resolves https://github.com/nuxt/nuxt/issues/25717#issuecomment-1938266384

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In some cases (such as headless ui or `@nuxt/ui`), `inheritAttrs` might be false but attrs are still bound to the root element. In this case the warning is misleading.

This PR only gives a console warning if there is no matching attribute _on hydration_. (So there should be no warning if the component binds attributes to root element.)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
