### PR TITLE
fix(kit): don't mutate existing component entries when overriding

### DIFF
--- a/packages/kit/src/components.ts
+++ b/packages/kit/src/components.ts
@@ -52,8 +52,9 @@ export async function addComponent (opts: AddComponentOptions) {
   }
 
   nuxt.hook('components:extend', (components: Component[]) => {
-    const existingComponent = components.find(c => (c.pascalName === component.pascalName || c.kebabName === component.kebabName) && c.mode === component.mode)
-    if (existingComponent) {
+    const existingComponentIndex = components.findIndex(c => (c.pascalName === component.pascalName || c.kebabName === component.kebabName) && c.mode === component.mode)
+    if (existingComponentIndex !== -1) {
+      const existingComponent = components[existingComponentIndex]
       const existingPriority = existingComponent.priority ?? 0
       const newPriority = component.priority ?? 0
 
@@ -65,7 +66,7 @@ export async function addComponent (opts: AddComponentOptions) {
         const name = existingComponent.pascalName || existingComponent.kebabName
         logger.warn(`Overriding ${name} component. You can specify a \`priority\` option when calling \`addComponent\` to avoid this warning.`)
       }
-      Object.assign(existingComponent, component)
+      components.splice(existingComponentIndex, 1, component)
     } else {
       components.push(component)
     }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/25787

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Previously, using `Object.assign`, we were mutating other components added with `addComponent`, when overriding with a higher priority component. This change ensures that we just swap our new component into the components array rather than mutating any existing data.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
