### PR TITLE
fix(nuxt): skip browser cache when fetching latest manifest

### DIFF
--- a/packages/nuxt/src/app/plugins/check-outdated-build.client.ts
+++ b/packages/nuxt/src/app/plugins/check-outdated-build.client.ts
@@ -14,7 +14,7 @@ export default defineNuxtPlugin((nuxtApp) => {
     const currentManifest = await getAppManifest()
     if (timeout) { clearTimeout(timeout) }
     timeout = setTimeout(getLatestManifest, 1000 * 60 * 60)
-    const meta = await $fetch<NuxtAppManifestMeta>(buildAssetsURL('builds/latest.json'))
+    const meta = await $fetch<NuxtAppManifestMeta>(buildAssetsURL('builds/latest.json') + '?rnd=' + Date.now())
     if (meta.id !== currentManifest.id) {
       // There is a newer build which we will let the user handle
       nuxtApp.hooks.callHook('app:manifest:update', meta)

--- a/packages/nuxt/src/app/plugins/check-outdated-build.client.ts
+++ b/packages/nuxt/src/app/plugins/check-outdated-build.client.ts
@@ -14,7 +14,7 @@ export default defineNuxtPlugin((nuxtApp) => {
     const currentManifest = await getAppManifest()
     if (timeout) { clearTimeout(timeout) }
     timeout = setTimeout(getLatestManifest, 1000 * 60 * 60)
-    const meta = await $fetch<NuxtAppManifestMeta>(buildAssetsURL('builds/latest.json') + '?rnd=' + Date.now())
+    const meta = await $fetch<NuxtAppManifestMeta>(buildAssetsURL('builds/latest.json') + `?${Date.now()}`)
     if (meta.id !== currentManifest.id) {
       // There is a newer build which we will let the user handle
       nuxtApp.hooks.callHook('app:manifest:update', meta)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Small fix for bypassing browser cache when fetching the latest manifest. Without this, the browser may keep returning old data.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
