### PR TITLE
fix(nuxt): add dedupe option to useFetch composable

### DIFF
--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -126,6 +126,7 @@ export function useFetch<
     immediate,
     getCachedData,
     deep,
+    dedupe,
     ...fetchOptions
   } = opts
 
@@ -144,6 +145,7 @@ export function useFetch<
     immediate,
     getCachedData,
     deep,
+    dedupe,
     watch: watch === false ? [] : [_fetchOptions, _request, ...(watch || [])]
   }
 


### PR DESCRIPTION
### 🔗 Linked issue

/

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This update ensures that the dedupe parameter is correctly passed to the useAsyncData composable from the useFetch options. The change aligns the behavior with the documentation, ensuring that the dedupe functionality functions as described. Developers can now expect the dedupe feature to work as intended, as documented, within the data fetching process.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
