### PR TITLE
fix(nuxt): scroll to top on page navigation when scroll-behavior: smo…

### DIFF
--- a/packages/nuxt/src/pages/runtime/router.options.ts
+++ b/packages/nuxt/src/pages/runtime/router.options.ts
@@ -1,5 +1,4 @@
 import type { RouteLocationNormalized, RouterScrollBehavior } from '#vue-router'
-import { nextTick } from 'vue'
 import type { RouterConfig } from 'nuxt/schema'
 import { useNuxtApp } from '#app/nuxt'
 import { isChangingPage } from '#app/components/utils'
@@ -36,6 +35,8 @@ export default <RouterConfig> {
       if (to.hash) {
         return { el: to.hash, top: _getHashElementScrollMarginTop(to.hash), behavior }
       }
+      // The route isn't changing so keep current scroll position
+      return false;
     }
 
     // Wait for `page:transition:finish` or `page:finish` depending on if transitions are enabled or not
@@ -43,7 +44,7 @@ export default <RouterConfig> {
     const hookToWait = (hasTransition(from) && hasTransition(to)) ? 'page:transition:finish' : 'page:finish'
     return new Promise((resolve) => {
       nuxtApp.hooks.hookOnce(hookToWait, async () => {
-        await nextTick()
+        await new Promise((resolve) => setTimeout(resolve, 0));
         if (to.hash) {
           position = { el: to.hash, top: _getHashElementScrollMarginTop(to.hash), behavior }
         }

--- a/packages/nuxt/src/pages/runtime/router.options.ts
+++ b/packages/nuxt/src/pages/runtime/router.options.ts
@@ -36,7 +36,7 @@ export default <RouterConfig> {
         return { el: to.hash, top: _getHashElementScrollMarginTop(to.hash), behavior }
       }
       // The route isn't changing so keep current scroll position
-      return false;
+      return false
     }
 
     // Wait for `page:transition:finish` or `page:finish` depending on if transitions are enabled or not
@@ -44,7 +44,7 @@ export default <RouterConfig> {
     const hookToWait = (hasTransition(from) && hasTransition(to)) ? 'page:transition:finish' : 'page:finish'
     return new Promise((resolve) => {
       nuxtApp.hooks.hookOnce(hookToWait, async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
+        await new Promise(resolve => setTimeout(resolve, 0))
         if (to.hash) {
           position = { el: to.hash, top: _getHashElementScrollMarginTop(to.hash), behavior }
         }


### PR DESCRIPTION
### 🔗 Linked issue

fixes #25816 
fixes #19239 

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In Firefox, if you have `scroll-behavior: smooth` style set on `html`, navigation between pages doesn't scroll to top ([reproduction](https://stackblitz.com/edit/nuxt-starter-4f9fpe?file=app.vue)). The root cause of the problem is that awaiting `nextTick` in [router.options.ts](https://github.com/nuxt/nuxt/blob/599081eda20bf374923cd076e9a5e02828ca9fc2/packages/nuxt/src/pages/runtime/router.options.ts#L46) doesn't work in that case. It's not clear to me why since the [nextTick implementation](https://github.com/vuejs/core/blob/272ab9fbdcb1af0535108b9f888e80d612f9171d/packages/runtime-core/src/scheduler.ts#L46-L58) doesn't seem to be doing anything too strange. That said, replacing `await nextTick` with awaiting a `setTimeout` fixes things. This happens to be related to something being addressed in a [currently open PR](https://github.com/nuxt/nuxt/pull/24960#pullrequestreview-1807867839) where both myself and @bernhardberger found that a `setTimeout` was necessary.

I'll admit I'm not particularly familiar with why `nextTick` is specifically being called here, but as far as I can tell replacing it the way I did fully resolves #25816.

In addition, I fixed a slight missed edge case, if you click on the same link 20 times in a row that all link to the same page, the next time you click on another link, the 20 `hookOnce`s that you created are all resolved at the same time returning undefined. It doesn't seem to cause any issues, but there's no reason to enter line 45+ if we're not going to scroll anyways when you click the same link.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
