### PR TITLE
feat: implement `force` option for refreshing and `triggeredBy` for `getCachedData`

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -138,7 +138,7 @@ export function useAsyncData<
   DataT = ResT,
   PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
   DefaultT = null,
-> (
+>(
   handler: (ctx?: NuxtApp) => Promise<ResT>,
   options?: AsyncDataOptions<ResT, DataT, PickKeys, DefaultT>
 ): AsyncData<PickFrom<DataT, PickKeys> | DefaultT, (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>) | null>
@@ -154,7 +154,7 @@ export function useAsyncData<
   DataT = ResT,
   PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
   DefaultT = DataT,
-> (
+>(
   handler: (ctx?: NuxtApp) => Promise<ResT>,
   options?: AsyncDataOptions<ResT, DataT, PickKeys, DefaultT>
 ): AsyncData<PickFrom<DataT, PickKeys> | DefaultT, (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>) | null>
@@ -171,7 +171,7 @@ export function useAsyncData<
   DataT = ResT,
   PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
   DefaultT = null,
-> (
+>(
   key: string,
   handler: (ctx?: NuxtApp) => Promise<ResT>,
   options?: AsyncDataOptions<ResT, DataT, PickKeys, DefaultT>
@@ -189,7 +189,7 @@ export function useAsyncData<
   DataT = ResT,
   PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
   DefaultT = DataT,
-> (
+>(
   key: string,
   handler: (ctx?: NuxtApp) => Promise<ResT>,
   options?: AsyncDataOptions<ResT, DataT, PickKeys, DefaultT>
@@ -200,7 +200,7 @@ export function useAsyncData<
   DataT = ResT,
   PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
   DefaultT = null,
-> (...args: any[]): AsyncData<PickFrom<DataT, PickKeys>, (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>) | null> {
+>(...args: any[]): AsyncData<PickFrom<DataT, PickKeys>, (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>) | null> {
   const autoKey = typeof args[args.length - 1] === 'string' ? args.pop() : undefined
   if (typeof args[0] !== 'string') { args.unshift(autoKey) }
 
@@ -274,9 +274,17 @@ export function useAsyncData<
       (nuxtApp._asyncDataPromises[key] as any).cancelled = true
     }
     // Avoid fetching same key that is already fetched
-    if (!opts.force && hasCachedData(opts._triggeredBy)) {
+    if(opts._triggeredBy === 'initial' && !opts.force && nuxtApp.isHydrating && hasCachedData(opts._triggeredBy)) {
       return Promise.resolve(options.getCachedData!(key, opts._triggeredBy))
     }
+
+    // If cache changed based on the triggeredBy, set new data result
+    if (!opts.force && hasCachedData(opts._triggeredBy)) {
+      const result = options.getCachedData!(key, opts._triggeredBy)
+      asyncData.data.value = result
+      return Promise.resolve(result)
+    }
+
     asyncData.pending.value = true
     asyncData.status.value = 'pending'
     // TODO: Cancel previous promise
@@ -325,7 +333,7 @@ export function useAsyncData<
     return nuxtApp._asyncDataPromises[key]!
   }
 
-  const initialFetch = () => asyncData.refresh({ _triggeredBy: 'refresh:manual' })
+  const initialFetch = () => asyncData.refresh({ _triggeredBy: 'initial' })
 
   const fetchOnServer = options.server !== false && nuxtApp.payload.serverRendered
 
@@ -372,7 +380,7 @@ export function useAsyncData<
       initialFetch()
     }
     if (options.watch) {
-      watch(options.watch, () => asyncData.refresh({ _triggeredBy: 'watch'}))
+      watch(options.watch, () => asyncData.refresh({ _triggeredBy: 'watch' }))
     }
     const off = nuxtApp.hook('app:data:refresh', async (keys, force) => {
       if (!keys || keys.includes(key)) {
@@ -397,7 +405,7 @@ export function useLazyAsyncData<
   DataT = ResT,
   PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
   DefaultT = null,
-> (
+>(
   handler: (ctx?: NuxtApp) => Promise<ResT>,
   options?: Omit<AsyncDataOptions<ResT, DataT, PickKeys, DefaultT>, 'lazy'>
 ): AsyncData<PickFrom<DataT, PickKeys> | DefaultT, DataE | null>
@@ -407,7 +415,7 @@ export function useLazyAsyncData<
   DataT = ResT,
   PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
   DefaultT = DataT,
-> (
+>(
   handler: (ctx?: NuxtApp) => Promise<ResT>,
   options?: Omit<AsyncDataOptions<ResT, DataT, PickKeys, DefaultT>, 'lazy'>
 ): AsyncData<PickFrom<DataT, PickKeys> | DefaultT, DataE | null>
@@ -417,7 +425,7 @@ export function useLazyAsyncData<
   DataT = ResT,
   PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
   DefaultT = null,
-> (
+>(
   key: string,
   handler: (ctx?: NuxtApp) => Promise<ResT>,
   options?: Omit<AsyncDataOptions<ResT, DataT, PickKeys, DefaultT>, 'lazy'>
@@ -428,7 +436,7 @@ export function useLazyAsyncData<
   DataT = ResT,
   PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
   DefaultT = DataT,
-> (
+>(
   key: string,
   handler: (ctx?: NuxtApp) => Promise<ResT>,
   options?: Omit<AsyncDataOptions<ResT, DataT, PickKeys, DefaultT>, 'lazy'>
@@ -440,7 +448,7 @@ export function useLazyAsyncData<
   DataT = ResT,
   PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
   DefaultT = null,
-> (...args: any[]): AsyncData<PickFrom<DataT, PickKeys> | DefaultT, DataE | null> {
+>(...args: any[]): AsyncData<PickFrom<DataT, PickKeys> | DefaultT, DataE | null> {
   const autoKey = typeof args[args.length - 1] === 'string' ? args.pop() : undefined
   if (typeof args[0] !== 'string') { args.unshift(autoKey) }
   const [key, handler, options = {}] = args as [string, (ctx?: NuxtApp) => Promise<ResT>, AsyncDataOptions<ResT, DataT, PickKeys, DefaultT>]
@@ -455,7 +463,7 @@ export function useLazyAsyncData<
 }
 
 /** @since 3.1.0 */
-export function useNuxtData<DataT = any> (key: string): { data: Ref<DataT | null> } {
+export function useNuxtData<DataT = any>(key: string): { data: Ref<DataT | null> } {
   const nuxtApp = useNuxtApp()
 
   // Initialize value when key is not already set
@@ -469,7 +477,7 @@ export function useNuxtData<DataT = any> (key: string): { data: Ref<DataT | null
 }
 
 /** @since 3.0.0 */
-export async function refreshNuxtData (keys?: string | string[], force?: boolean): Promise<void> {
+export async function refreshNuxtData(keys?: string | string[], force?: boolean): Promise<void> {
   if (import.meta.server) {
     return Promise.resolve()
   }
@@ -481,7 +489,7 @@ export async function refreshNuxtData (keys?: string | string[], force?: boolean
 }
 
 /** @since 3.0.0 */
-export function clearNuxtData (keys?: string | string[] | ((key: string) => boolean)): void {
+export function clearNuxtData(keys?: string | string[] | ((key: string) => boolean)): void {
   const nuxtApp = useNuxtApp()
   const _allKeys = Object.keys(nuxtApp.payload.data)
   const _keys: string[] = !keys
@@ -509,7 +517,7 @@ export function clearNuxtData (keys?: string | string[] | ((key: string) => bool
   }
 }
 
-function pick (obj: Record<string, any>, keys: string[]) {
+function pick(obj: Record<string, any>, keys: string[]) {
   const newObj = {}
   for (const key of keys) {
     (newObj as any)[key] = obj[key]

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -103,12 +103,12 @@ export interface AsyncDataExecuteOptions {
    * Instead of using `boolean` values, use `cancel` for `true` and `defer` for `false`.
    * Boolean values will be removed in a future release.
    */
-  dedupe?: boolean | 'cancel' | 'defer',
+  dedupe?: boolean | 'cancel' | 'defer'
   /**
    * Do not use potentially cached data from getCachedData and perform a new request
    * @default false
    */
-  force?: boolean,
+  force?: boolean
 }
 
 export interface _AsyncData<DataT, ErrorT> {
@@ -138,7 +138,7 @@ export function useAsyncData<
   DataT = ResT,
   PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
   DefaultT = null,
->(
+> (
   handler: (ctx?: NuxtApp) => Promise<ResT>,
   options?: AsyncDataOptions<ResT, DataT, PickKeys, DefaultT>
 ): AsyncData<PickFrom<DataT, PickKeys> | DefaultT, (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>) | null>
@@ -154,7 +154,7 @@ export function useAsyncData<
   DataT = ResT,
   PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
   DefaultT = DataT,
->(
+> (
   handler: (ctx?: NuxtApp) => Promise<ResT>,
   options?: AsyncDataOptions<ResT, DataT, PickKeys, DefaultT>
 ): AsyncData<PickFrom<DataT, PickKeys> | DefaultT, (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>) | null>
@@ -171,7 +171,7 @@ export function useAsyncData<
   DataT = ResT,
   PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
   DefaultT = null,
->(
+> (
   key: string,
   handler: (ctx?: NuxtApp) => Promise<ResT>,
   options?: AsyncDataOptions<ResT, DataT, PickKeys, DefaultT>
@@ -189,7 +189,7 @@ export function useAsyncData<
   DataT = ResT,
   PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
   DefaultT = DataT,
->(
+> (
   key: string,
   handler: (ctx?: NuxtApp) => Promise<ResT>,
   options?: AsyncDataOptions<ResT, DataT, PickKeys, DefaultT>
@@ -200,7 +200,7 @@ export function useAsyncData<
   DataT = ResT,
   PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
   DefaultT = null,
->(...args: any[]): AsyncData<PickFrom<DataT, PickKeys>, (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>) | null> {
+> (...args: any[]): AsyncData<PickFrom<DataT, PickKeys>, (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>) | null> {
   const autoKey = typeof args[args.length - 1] === 'string' ? args.pop() : undefined
   if (typeof args[0] !== 'string') { args.unshift(autoKey) }
 
@@ -405,7 +405,7 @@ export function useLazyAsyncData<
   DataT = ResT,
   PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
   DefaultT = null,
->(
+> (
   handler: (ctx?: NuxtApp) => Promise<ResT>,
   options?: Omit<AsyncDataOptions<ResT, DataT, PickKeys, DefaultT>, 'lazy'>
 ): AsyncData<PickFrom<DataT, PickKeys> | DefaultT, DataE | null>
@@ -415,7 +415,7 @@ export function useLazyAsyncData<
   DataT = ResT,
   PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
   DefaultT = DataT,
->(
+> (
   handler: (ctx?: NuxtApp) => Promise<ResT>,
   options?: Omit<AsyncDataOptions<ResT, DataT, PickKeys, DefaultT>, 'lazy'>
 ): AsyncData<PickFrom<DataT, PickKeys> | DefaultT, DataE | null>
@@ -425,7 +425,7 @@ export function useLazyAsyncData<
   DataT = ResT,
   PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
   DefaultT = null,
->(
+> (
   key: string,
   handler: (ctx?: NuxtApp) => Promise<ResT>,
   options?: Omit<AsyncDataOptions<ResT, DataT, PickKeys, DefaultT>, 'lazy'>
@@ -436,7 +436,7 @@ export function useLazyAsyncData<
   DataT = ResT,
   PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
   DefaultT = DataT,
->(
+> (
   key: string,
   handler: (ctx?: NuxtApp) => Promise<ResT>,
   options?: Omit<AsyncDataOptions<ResT, DataT, PickKeys, DefaultT>, 'lazy'>
@@ -448,7 +448,7 @@ export function useLazyAsyncData<
   DataT = ResT,
   PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
   DefaultT = null,
->(...args: any[]): AsyncData<PickFrom<DataT, PickKeys> | DefaultT, DataE | null> {
+> (...args: any[]): AsyncData<PickFrom<DataT, PickKeys> | DefaultT, DataE | null> {
   const autoKey = typeof args[args.length - 1] === 'string' ? args.pop() : undefined
   if (typeof args[0] !== 'string') { args.unshift(autoKey) }
   const [key, handler, options = {}] = args as [string, (ctx?: NuxtApp) => Promise<ResT>, AsyncDataOptions<ResT, DataT, PickKeys, DefaultT>]
@@ -463,7 +463,7 @@ export function useLazyAsyncData<
 }
 
 /** @since 3.1.0 */
-export function useNuxtData<DataT = any>(key: string): { data: Ref<DataT | null> } {
+export function useNuxtData<DataT = any> (key: string): { data: Ref<DataT | null> } {
   const nuxtApp = useNuxtApp()
 
   // Initialize value when key is not already set
@@ -477,7 +477,7 @@ export function useNuxtData<DataT = any>(key: string): { data: Ref<DataT | null>
 }
 
 /** @since 3.0.0 */
-export async function refreshNuxtData(keys?: string | string[], force?: boolean): Promise<void> {
+export async function refreshNuxtData (keys?: string | string[], force?: boolean): Promise<void> {
   if (import.meta.server) {
     return Promise.resolve()
   }
@@ -489,7 +489,7 @@ export async function refreshNuxtData(keys?: string | string[], force?: boolean)
 }
 
 /** @since 3.0.0 */
-export function clearNuxtData(keys?: string | string[] | ((key: string) => boolean)): void {
+export function clearNuxtData (keys?: string | string[] | ((key: string) => boolean)): void {
   const nuxtApp = useNuxtApp()
   const _allKeys = Object.keys(nuxtApp.payload.data)
   const _keys: string[] = !keys
@@ -517,7 +517,7 @@ export function clearNuxtData(keys?: string | string[] | ((key: string) => boole
   }
 }
 
-function pick(obj: Record<string, any>, keys: string[]) {
+function pick (obj: Record<string, any>, keys: string[]) {
   const newObj = {}
   for (const key of keys) {
     (newObj as any)[key] = obj[key]

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -38,7 +38,7 @@ export interface RuntimeNuxtHooks {
   'app:error': (err: any) => HookResult
   'app:error:cleared': (options: { redirect?: string }) => HookResult
   'app:chunkError': (options: { error: any }) => HookResult
-  'app:data:refresh': (keys?: string[]) => HookResult
+  'app:data:refresh': (keys?: string[], force?: boolean) => HookResult
   'app:manifest:update': (meta?: NuxtAppManifestMeta) => HookResult
   'link:prefetch': (link: string) => HookResult
   'page:start': (Component?: VNode) => HookResult

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -1,13 +1,31 @@
-<script setup lang="ts">
+<script setup>
+const page = ref(0)
+const nuxt = useNuxtApp()
+const { data, refresh } = await useFetch('https://icanhazdadjoke.com/', {
+  query: { page }, // "fed" into watch array for asyncData under the hood
+  getCachedData: (key) => {
+    return nuxt.payload.data[key] || nuxt.static.data[key]
+  },
+  headers: {
+    Accept: 'application/json',
+  },
+})
 </script>
 
 <template>
-  <!-- Edit this file to play around with Nuxt but never commit changes! -->
   <div>
-    Nuxt 3 Playground
+    <button @click="refresh()">
+      New Joke (refresh, default)
+    </button>
+    <button @click="refresh({ force: true })">
+      New Joke (refresh, force)
+    </button>
+    <button @click="page++">
+      New Joke (update query value + 1)
+    </button>
+    <button @click="page--">
+      New Joke (update query value - 1)
+    </button>
+    {{ data.joke }}
   </div>
 </template>
-
-<style scoped>
-
-</style>

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -1,31 +1,13 @@
-<script setup>
-const page = ref(0)
-const nuxt = useNuxtApp()
-const { data, refresh } = await useFetch('https://icanhazdadjoke.com/', {
-  query: { page }, // "fed" into watch array for asyncData under the hood
-  getCachedData: (key) => {
-    return nuxt.payload.data[key] || nuxt.static.data[key]
-  },
-  headers: {
-    Accept: 'application/json',
-  },
-})
+<script setup lang="ts">
 </script>
 
 <template>
+  <!-- Edit this file to play around with Nuxt but never commit changes! -->
   <div>
-    <button @click="refresh()">
-      New Joke (refresh, default)
-    </button>
-    <button @click="refresh({ force: true })">
-      New Joke (refresh, force)
-    </button>
-    <button @click="page++">
-      New Joke (update query value + 1)
-    </button>
-    <button @click="page--">
-      New Joke (update query value - 1)
-    </button>
-    {{ data.joke }}
+    Nuxt 3 Playground
   </div>
 </template>
+
+<style scoped>
+
+</style>

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -1,13 +1,20 @@
 <script setup lang="ts">
+const { data, refresh } = await useAsyncData('key', () => Promise.resolve('something'), {
+  getCachedData: (_, triggeredBy) => {
+    if(triggeredBy === 'refresh:manual') {
+      return 1
+    }
+    return 0
+  }
+})
 </script>
 
 <template>
   <!-- Edit this file to play around with Nuxt but never commit changes! -->
   <div>
-    Nuxt 3 Playground
+    {{ data }}
+    <button @click="refresh()" />
   </div>
 </template>
 
-<style scoped>
-
-</style>
+<style scoped></style>

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,3 +1,9 @@
 export default defineNuxtConfig({
-
+  routeRules: {
+    '/': {
+      headers: {
+        'My-Header': 'My-Value'
+      }
+    }
+  }
 })

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,9 +1,3 @@
 export default defineNuxtConfig({
-  routeRules: {
-    '/': {
-      headers: {
-        'My-Header': 'My-Value'
-      }
-    }
-  }
+
 })

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -239,19 +239,16 @@ describe('useAsyncData', () => {
   })
 
   it('will use cache on refresh by default', async () => {
-    let called = 0
-    const fn = () => called++
-    const { data, refresh } = await useAsyncData(() => 'other value', { getCachedData: () => fn() })
-    expect(data.value).toBe(0)
+    const { data, refresh } = await useAsyncData(() => 'other value', { getCachedData: () => 'cached' })
+    expect(data.value).toBe('cached')
     await refresh()
-    expect(data.value).toBe(0)
+    expect(data.value).toBe('cached')
   })
 
   it('will not use cache with force option', async () => {
     let called = 0
     const fn = () => called++
     const { data, refresh } = await useAsyncData(() => 'other value', { getCachedData: () => fn() })
-    expect(data.value).toBe(0)
     await refresh({ force: true })
     expect(data.value).toBe('other value')
   })
@@ -262,16 +259,18 @@ describe('useAsyncData', () => {
   })
 
   it('getCachedData should receive triggeredBy on manual refresh', async () => {
-    const { data, refresh } = await useAsyncData(() => '', { getCachedData: (_, triggeredBy) => triggeredBy })
+    const { data, refresh } = await useAsyncData(() => '', {
+      getCachedData: (_, triggeredBy) => triggeredBy
+    })
     await refresh()
     expect(data.value).toBe('refresh:manual')
   })
 
   it('getCachedData should receive triggeredBy on watch', async () => {
     const number = ref(0)
-    const { data } = await useAsyncData(() => '', { getCachedData: (_, triggeredBy) => triggeredBy })
+    const { data } = await useAsyncData(() => '', { getCachedData: (_, triggeredBy) => triggeredBy, watch: [number] })
     number.value = 1
-    // TODO: Maybe setTimeout or similar
+    await new Promise(resolve => setTimeout(resolve, 1))
     expect(data.value).toBe('watch')
   })
 

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -412,7 +412,7 @@ describe('useHydration', () => {
   it('should hydrate value from payload', async () => {
     let val: any
     const nuxtApp = useNuxtApp()
-    useHydration('key', () => { }, (fromPayload) => { val = fromPayload })
+    useHydration('key', () => {}, (fromPayload) => { val = fromPayload })
     await nuxtApp.hooks.callHook('app:created', nuxtApp.vueApp)
     expect(val).toMatchInlineSnapshot('undefined')
 
@@ -483,7 +483,7 @@ describe('useId', () => {
     const vals = new Set<string>()
     for (let index = 0; index < 100; index++) {
       mount(defineComponent({
-        setup() {
+        setup () {
           const id = useId()
           vals.add(id)
           return () => h('div', id)
@@ -495,7 +495,7 @@ describe('useId', () => {
 
   it('generates unique ids per-component', () => {
     const component = defineComponent({
-      setup() {
+      setup () {
         const id = useId()
         return () => h('div', id)
       }


### PR DESCRIPTION
### 🔗 Linked issue

Resolves https://github.com/nuxt/nuxt/issues/24332.

And linking https://github.com/nuxt/nuxt/issues/24271 for prep work

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds a `force` option to to `refresh` function (from `useAsyncData`) and a force option to `refreshNuxtData`. It allows to bypass a possibly existing `getCachedData` function and forces to refetch.

As `force` cannot be set when watching params, e.g. through `useFetch` or manually in `useAsyncData`, `getCachedData` now receives the "context" that triggered the function and requests the cached data, allowing more granular results.

Happy for feedback on the implementation.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
