### PR TITLE
docs: remove superfluous await from useLazyAsync page

### DIFF
--- a/docs/3.api/2.composables/use-lazy-async-data.md
+++ b/docs/3.api/2.composables/use-lazy-async-data.md
@@ -25,7 +25,7 @@ By default, [`useAsyncData`](/docs/api/composables/use-async-data) blocks naviga
 /* Navigation will occur before fetching is complete.
   Handle pending and error states directly within your component's template
 */
-const { pending, data: count } = await useLazyAsyncData('count', () => $fetch('/api/count'))
+const { pending, data: count } = useLazyAsyncData('count', () => $fetch('/api/count'))
 
 watch(count, (newCount) => {
   // Because count might start out null, you won't have access


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/25033

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I have been investigating why multiple `useLazyAsyncData` composables inside composition setup are blocking the route change and are not "lazy". I believe the issue is with how it is documented rather than a problem with the composable itself. The documentation recommends using await on a non async function `useLazyAsyncData`. My change is to remove the `await` from the `useLazyAsyncData` documentation page

I believe the awaits make the vue component instance become undefined for any sequential `await` calls, I read [here](https://nuxt.com/docs/api/composables/use-nuxt-app) that vue should handle undefining and setting the component instance when an await is called but this seems to not be the case for these composables when wrapped in `await`.  Since the instance is undefined, `lazyAsyncData` has to revert to `asyncData` which blocks the route change because it cannot call `instance._nuxtOnBeforeMountCbs.push(initialFetch)`. This is also why one `useLazyAsyncData` with `await` works fine because the component instance is there on the first call. 

Playground with working multiple `useLazyAsyncData`: https://stackblitz.com/edit/nuxt-starter-3ojz7s?file=pages%2Findex.vue

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
