### PR TITLE
docs(nuxt): remove misleading .ts for resolve

### DIFF
--- a/docs/2.guide/3.going-further/3.modules.md
+++ b/docs/2.guide/3.going-further/3.modules.md
@@ -396,7 +396,7 @@ export default defineNuxtModule({
 
     addServerHandler({
       route: '/api/hello',
-      handler: resolver.resolve('./runtime/server/api/hello/index.get.ts')
+      handler: resolver.resolve('./runtime/server/api/hello/index.get')
     })
   }
 })
@@ -413,7 +413,7 @@ export default defineNuxtModule({
 
     addServerHandler({
       route: '/api/hello/:name',
-      handler: resolver.resolve('./runtime/server/api/hello/[name].get.ts')
+      handler: resolver.resolve('./runtime/server/api/hello/[name].get')
     })
   }
 })


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/20998

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

From [Daniel's comment](https://github.com/nuxt/nuxt/issues/20998#issuecomment-1556899413):

> You should not add the .ts extension as this will not be present when you build your module.

### 📝 Checklist


- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
