### PR TITLE
fix(nuxt): pass `external` prop to `navigate` fn of custom `<NuxtLink>`

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -354,13 +354,13 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
           (isAbsoluteUrl.value || hasTarget.value) ? 'noopener noreferrer' : ''
         ) || null
 
-        const navigate = () => navigateTo(href, { replace: props.replace })
-
         // https://router.vuejs.org/api/#custom
         if (props.custom) {
           if (!slots.default) {
             return null
           }
+
+          const navigate = () => navigateTo(href, { replace: props.replace, external: props.external })
 
           return slots.default({
             href,


### PR DESCRIPTION
### 🔗 Linked issue

Resolves https://github.com/nuxt/nuxt/issues/25866

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adds `external` prop to the `navigate` fn exposed in the default slot (and moves variable declaration closer to the place of usage).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
