### PR TITLE
fix(nuxt): align `error` param in `showError`/`createError` with H3

### DIFF
--- a/packages/nuxt/src/app/composables/error.ts
+++ b/packages/nuxt/src/app/composables/error.ts
@@ -56,7 +56,7 @@ export const isNuxtError = <DataT = unknown>(
 
 /** @since 3.0.0 */
 export const createError = <DataT = unknown>(
-    error: string | Partial<NuxtError<DataT>>
+    error: Parameters<typeof createH3Error<DataT>>[0]
 ) => {
   const nuxtError: NuxtError<DataT> = createH3Error<DataT>(error)
 

--- a/packages/nuxt/src/app/composables/error.ts
+++ b/packages/nuxt/src/app/composables/error.ts
@@ -13,10 +13,10 @@ export interface NuxtError<DataT = unknown> extends H3Error<DataT> {}
 
 /** @since 3.0.0 */
 export const showError = <DataT = unknown>(
-    error: string | Error | (Partial<NuxtError<DataT>> & {
-        status?: number;
-        statusText?: string;
-    })
+  error: string | Error | (Partial<NuxtError<DataT>> & {
+    status?: number;
+    statusText?: string;
+  })
 ) => {
   const nuxtError = createError<DataT>(error)
 
@@ -59,10 +59,10 @@ export const isNuxtError = <DataT = unknown>(
 
 /** @since 3.0.0 */
 export const createError = <DataT = unknown>(
-    error: string | Error | (Partial<NuxtError<DataT>> & {
-        status?: number;
-        statusText?: string;
-    })
+  error: string | Error | (Partial<NuxtError<DataT>> & {
+    status?: number;
+    statusText?: string;
+  })
 ) => {
   const nuxtError: NuxtError<DataT> = createH3Error<DataT>(error)
 

--- a/packages/nuxt/src/app/composables/error.ts
+++ b/packages/nuxt/src/app/composables/error.ts
@@ -13,7 +13,10 @@ export interface NuxtError<DataT = unknown> extends H3Error<DataT> {}
 
 /** @since 3.0.0 */
 export const showError = <DataT = unknown>(
-    error: Parameters<typeof createH3Error<DataT>>[0]
+    error: string | Error | (Partial<NuxtError<DataT>> & {
+        status?: number;
+        statusText?: string;
+    })
 ) => {
   const nuxtError = createError<DataT>(error)
 
@@ -56,7 +59,10 @@ export const isNuxtError = <DataT = unknown>(
 
 /** @since 3.0.0 */
 export const createError = <DataT = unknown>(
-    error: Parameters<typeof createH3Error<DataT>>[0]
+    error: string | Error | (Partial<NuxtError<DataT>> & {
+        status?: number;
+        statusText?: string;
+    })
 ) => {
   const nuxtError: NuxtError<DataT> = createH3Error<DataT>(error)
 

--- a/packages/nuxt/src/app/composables/error.ts
+++ b/packages/nuxt/src/app/composables/error.ts
@@ -13,7 +13,7 @@ export interface NuxtError<DataT = unknown> extends H3Error<DataT> {}
 
 /** @since 3.0.0 */
 export const showError = <DataT = unknown>(
-    error: string | Error | Partial<NuxtError<DataT>>
+    error: Parameters<typeof createH3Error<DataT>>[0]
 ) => {
   const nuxtError = createError<DataT>(error)
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/25942

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Aligns `error` param of Nuxt's  `showError` and `createError` with H3's. 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
