### PR TITLE
docs: mention when `useId` composable was introduced

### DIFF
--- a/docs/3.api/2.composables/use-id.md
+++ b/docs/3.api/2.composables/use-id.md
@@ -3,6 +3,10 @@ title: "useId"
 description: Generate an SSR-friendly unique identifier that can be passed to accessibility attributes.
 ---
 
+::important
+This composable is available since [Nuxt v3.10](/v3-10#ssr-safe-accessible-unique-id-creation).
+::
+
 `useId` generates an SSR-friendly unique identifier that can be passed to accessibility attributes.
 
 Call `useId` at the top level of your component to generate a unique string identifier:


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->


### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds a message to `useId` composable documentation saying in what Nuxt version it was introduced.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
