### PR TITLE
fix(nuxt): produce valid css selector from `useId`

### DIFF
--- a/packages/nuxt/src/app/composables/id.ts
+++ b/packages/nuxt/src/app/composables/id.ts
@@ -3,7 +3,7 @@ import { useNuxtApp } from '../nuxt'
 import { clientOnlySymbol } from '#app/components/client-only'
 
 const ATTR_KEY = 'data-n-ids'
-const SEPARATOR = '_'
+const SEPARATOR = '-'
 
 /**
  * Generate an SSR-friendly unique identifier that can be passed to accessibility attributes.

--- a/packages/nuxt/src/app/composables/id.ts
+++ b/packages/nuxt/src/app/composables/id.ts
@@ -3,6 +3,7 @@ import { useNuxtApp } from '../nuxt'
 import { clientOnlySymbol } from '#app/components/client-only'
 
 const ATTR_KEY = 'data-n-ids'
+const SEPARATOR = '_'
 
 /**
  * Generate an SSR-friendly unique identifier that can be passed to accessibility attributes.
@@ -13,7 +14,8 @@ export function useId (key?: string): string {
     throw new TypeError('[nuxt] [useId] key must be a string.')
   }
   // TODO: implement in composable-keys
-  key = key.slice(1)
+  // Make sure key starts with a letter to be a valid selector
+  key = `n${key.slice(1)}`
   const nuxtApp = useNuxtApp()
   const instance = getCurrentInstance()
 
@@ -26,11 +28,11 @@ export function useId (key?: string): string {
   instance._nuxtIdIndex ||= {}
   instance._nuxtIdIndex[key] ||= 0
 
-  const instanceIndex = key + ':' + instance._nuxtIdIndex[key]++
+  const instanceIndex = key + SEPARATOR + instance._nuxtIdIndex[key]++
 
   if (import.meta.server) {
     const ids = JSON.parse(instance.attrs[ATTR_KEY] as string | undefined || '{}')
-    ids[instanceIndex] = key + ':' + nuxtApp._id++
+    ids[instanceIndex] = key + SEPARATOR + nuxtApp._id++
     instance.attrs[ATTR_KEY] = JSON.stringify(ids)
     return ids[instanceIndex]
   }


### PR DESCRIPTION

### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/25949

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds an `n` in front of all results from `useId` and ensures that `_` is used as separator instead of  `:`, ensuring that the result can be used as CSS selector without sanitizing.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
