### PR TITLE
docs: add domEnvironment option to example

### DIFF
--- a/docs/1.getting-started/11.testing.md
+++ b/docs/1.getting-started/11.testing.md
@@ -88,6 +88,7 @@ export default defineVitestConfig({
     // environmentOptions: {
     //   nuxt: {
     //     rootDir: fileURLToPath(new URL('./playground', import.meta.url)),
+    //     domEnvironment: 'happy-dom', // 'happy-dom' (default) or 'jsdom'
     //     overrides: {
     //       // other Nuxt config you want to pass
     //     }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

No issue, just a minor addition to the documentation.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The [Testing Guide](https://nuxt.com/docs/getting-started/testing) mentions that it is possible to choose between happy-dom and jsdom, but it did not mention how. Since I was using jsdom before and happy-dom was not installed, all my tests failed. I had to go through the source code to discover the `domEnvironment` option to fix this.

Maybe I'm missing something, but it feels like the Testing Guide could in general use a bit more detail here and there.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
