### PR TITLE
docs: update VS Code settings

### DIFF
--- a/docs/5.community/4.contribution.md
+++ b/docs/5.community/4.contribution.md
@@ -139,7 +139,7 @@ Under projects with configuration as shown below, Corepack will install `v7.5.0`
 
 We use [ESLint](https://eslint.org) for both linting and formatting with [`@nuxt/eslint-config`](https://github.com/nuxt/eslint-config).
 
-#### IDE Setup
+##### IDE Setup
 
 We recommend using [VS Code](https://code.visualstudio.com) along with the [ESLint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint). If you would like, you can enable auto-fix and formatting when you save the code you are editing:
 

--- a/docs/5.community/4.contribution.md
+++ b/docs/5.community/4.contribution.md
@@ -139,15 +139,15 @@ Under projects with configuration as shown below, Corepack will install `v7.5.0`
 
 We use [ESLint](https://eslint.org) for both linting and formatting with [`@nuxt/eslint-config`](https://github.com/nuxt/eslint-config).
 
-##### IDE Setup
+#### IDE Setup
 
 We recommend using [VS Code](https://code.visualstudio.com) along with the [ESLint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint). If you would like, you can enable auto-fix and formatting when you save the code you are editing:
 
 ```json [settings.json]
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll": false,
-    "source.fixAll.eslint": true
+    "source.fixAll": "never",
+    "source.fixAll.eslint": "explicit"
   }
 }
 ```


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The 'Code Actions on Save and Auto' specification was changed in the 2023.11 VSCode update.
  
  - [November 2023 (version 1.85)](https://code.visualstudio.com/updates/v1_85#_code-actions-on-save-and-auto)

The changes are quoted below.

> The setting value updates are as follows, with the previous boolean values to be deprecated in favor of the string equivalent.
>
> The options are:
>
> - explicit - Triggers Code Actions when explicitly saved. Same as true.
> - always - Triggers Code Actions when explicitly saved and on Auto Saves from window or focus changes.
> - never - Never triggers Code Actions on save. Same as false.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
