### PR TITLE
feat(nuxt): add `page:view-transition:start` hook

### DIFF
--- a/docs/3.api/6.advanced/1.hooks.md
+++ b/docs/3.api/6.advanced/1.hooks.md
@@ -28,6 +28,7 @@ Hook                   | Arguments           | Environment     | Description
 `page:loading:start`   | -                   | Client          | Called when the `setup()` of the new page is running.
 `page:loading:end`     | -                   | Client          | Called after `page:finish`
 `page:transition:finish`| `pageComponent?`    | Client          | After page transition [onAfterLeave](https://vuejs.org/guide/built-ins/transition.html#javascript-hooks) event.
+`page:view-transition:start` | `transition`        | Client          | Called after document.startViewTransition is called by the [experimental nuxt plugin](https://nuxt.com/docs/getting-started/transitions#view-transitions-api-experimental).
 
 ## Nuxt Hooks (build time)
 

--- a/docs/3.api/6.advanced/1.hooks.md
+++ b/docs/3.api/6.advanced/1.hooks.md
@@ -28,7 +28,7 @@ Hook                   | Arguments           | Environment     | Description
 `page:loading:start`   | -                   | Client          | Called when the `setup()` of the new page is running.
 `page:loading:end`     | -                   | Client          | Called after `page:finish`
 `page:transition:finish`| `pageComponent?`    | Client          | After page transition [onAfterLeave](https://vuejs.org/guide/built-ins/transition.html#javascript-hooks) event.
-`page:view-transition:start` | `transition`        | Client          | Called after document.startViewTransition is called by the [experimental nuxt plugin](https://nuxt.com/docs/getting-started/transitions#view-transitions-api-experimental).
+`page:view-transition:start` | `transition`        | Client          | Called after `document.startViewTransition` is called when [experimental viewTransition support is enabled](https://nuxt.com/docs/getting-started/transitions#view-transitions-api-experimental).
 
 ## Nuxt Hooks (build time)
 

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -18,6 +18,7 @@ import type { NuxtError } from '../app/composables/error'
 import type { AsyncDataRequestStatus } from '../app/composables/asyncData'
 import type { NuxtAppManifestMeta } from '../app/composables/manifest'
 import type { LoadingIndicator } from '../app/composables/loading-indicator'
+import type { ViewTransition } from './plugins/view-transitions.client'
 
 import type { NuxtAppLiterals } from '#app'
 

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -45,6 +45,7 @@ export interface RuntimeNuxtHooks {
   'page:finish': (Component?: VNode) => HookResult
   'page:transition:start': () => HookResult
   'page:transition:finish': (Component?: VNode) => HookResult
+  'page:view-transition:start': (transition: ViewTransition) => HookResult
   'page:loading:start': () => HookResult
   'page:loading:end': () => HookResult
   'vue:setup': () => void

--- a/packages/nuxt/src/app/plugins/view-transitions.client.ts
+++ b/packages/nuxt/src/app/plugins/view-transitions.client.ts
@@ -14,7 +14,7 @@ export default defineNuxtPlugin((nuxtApp) => {
 
   const router = useRouter()
 
-  router.beforeResolve((to, from) => {
+  router.beforeResolve(async (to, from) => {
     const viewTransitionMode = to.meta.viewTransition ?? defaultViewTransition
     const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
     const prefersNoTransition = prefersReducedMotion && viewTransitionMode !== 'always'
@@ -35,7 +35,7 @@ export default defineNuxtPlugin((nuxtApp) => {
       changeRoute()
       return promise
     })
-    nuxtApp.callHook('page:view-transition:start', transition)
+    await nuxtApp.callHook('page:view-transition:start', transition)
 
     transition.finished.then(() => {
       abortTransition = undefined

--- a/packages/nuxt/src/app/plugins/view-transitions.client.ts
+++ b/packages/nuxt/src/app/plugins/view-transitions.client.ts
@@ -56,13 +56,13 @@ export default defineNuxtPlugin((nuxtApp) => {
   })
 })
 
-declare global {
-  interface ViewTransition {
-    ready: Promise<void>
-    finished: Promise<void>
-    updateCallbackDone: Promise<void>
-  }
+export interface ViewTransition {
+  ready: Promise<void>
+  finished: Promise<void>
+  updateCallbackDone: Promise<void>
+}
 
+declare global {
   interface Document {
     startViewTransition?: (callback: () => Promise<void> | void) => ViewTransition
   }

--- a/packages/nuxt/src/app/plugins/view-transitions.client.ts
+++ b/packages/nuxt/src/app/plugins/view-transitions.client.ts
@@ -35,6 +35,7 @@ export default defineNuxtPlugin((nuxtApp) => {
       changeRoute()
       return promise
     })
+    nuxtApp.callHook('page:view-transition:start', transition)
 
     transition.finished.then(() => {
       abortTransition = undefined
@@ -56,11 +57,13 @@ export default defineNuxtPlugin((nuxtApp) => {
 })
 
 declare global {
+  interface ViewTransition {
+    ready: Promise<void>
+    finished: Promise<void>
+    updateCallbackDone: Promise<void>
+  }
+
   interface Document {
-    startViewTransition?: (callback: () => Promise<void> | void) => {
-      finished: Promise<void>
-      updateCallbackDone: Promise<void>
-      ready: Promise<void>
-    }
+    startViewTransition?: (callback: () => Promise<void> | void) => ViewTransition
   }
 }

--- a/packages/nuxt/src/app/plugins/view-transitions.client.ts
+++ b/packages/nuxt/src/app/plugins/view-transitions.client.ts
@@ -35,12 +35,13 @@ export default defineNuxtPlugin((nuxtApp) => {
       changeRoute()
       return promise
     })
-    await nuxtApp.callHook('page:view-transition:start', transition)
 
     transition.finished.then(() => {
       abortTransition = undefined
       finishTransition = undefined
     })
+
+    await nuxtApp.callHook('page:view-transition:start', transition)
 
     return ready
   })


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/26044

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
This is a small PR that introduces a new client lifecycle hook, which is called right after a [ViewTransition object](https://developer.mozilla.org/en-US/docs/Web/API/ViewTransition) is created by the [experimental view transition plugin](https://nuxt.com/docs/getting-started/transitions#view-transitions-api-experimental).

<!-- Why is this change required? What problem does it solve? -->
Using this hook an app can obtain the transition object.

<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Resolves #26044

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
