### PR TITLE
fix(nuxt): pass event to `useRuntimeConfig` in Nuxt renderer

### DIFF
--- a/packages/nuxt/src/core/runtime/nitro/error.ts
+++ b/packages/nuxt/src/core/runtime/nitro/error.ts
@@ -55,7 +55,7 @@ export default <NitroErrorHandler> async function errorhandler (error: H3Error, 
 
   // HTML response (via SSR)
   const res = isRenderingError ? null : await useNitroApp().localFetch(
-    withQuery(joinURL(useRuntimeConfig().app.baseURL, '/__nuxt_error'), errorObject),
+    withQuery(joinURL(useRuntimeConfig(event).app.baseURL, '/__nuxt_error'), errorObject),
     {
       headers: { ...reqHeaders, 'x-nuxt-error': 'true' },
       redirect: 'manual'

--- a/packages/nuxt/src/core/runtime/nitro/paths.ts
+++ b/packages/nuxt/src/core/runtime/nitro/paths.ts
@@ -2,10 +2,12 @@ import { joinURL } from 'ufo'
 import { useRuntimeConfig } from '#internal/nitro'
 
 export function baseURL (): string {
+  // TODO: support passing event to `useRuntimeConfig`
   return useRuntimeConfig().app.baseURL
 }
 
 export function buildAssetsDir (): string {
+  // TODO: support passing event to `useRuntimeConfig`
   return useRuntimeConfig().app.buildAssetsDir as string
 }
 
@@ -14,6 +16,7 @@ export function buildAssetsURL (...path: string[]): string {
 }
 
 export function publicAssetsURL (...path: string[]): string {
+  // TODO: support passing event to `useRuntimeConfig`
   const app = useRuntimeConfig().app
   const publicBase = app.cdnURL as string || app.baseURL
   return path.length ? joinURL(publicBase, ...path) : publicBase

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -158,7 +158,7 @@ const getSPARenderer = lazyCachedFunction(async () => {
   const result = await renderer.renderToString({})
 
   const renderToString = (ssrContext: NuxtSSRContext) => {
-    const config = useRuntimeConfig()
+    const config = useRuntimeConfig(ssrContext.event)
     ssrContext.modules = ssrContext.modules || new Set<string>()
     ssrContext!.payload = {
       _errors: {},
@@ -288,7 +288,7 @@ export default defineRenderHandler(async (event): Promise<Partial<RenderResponse
   const ssrContext: NuxtSSRContext = {
     url,
     event,
-    runtimeConfig: useRuntimeConfig() as NuxtSSRContext['runtimeConfig'],
+    runtimeConfig: useRuntimeConfig(event) as NuxtSSRContext['runtimeConfig'],
     noSSR:
       !!(process.env.NUXT_NO_SSR) ||
       event.context.nuxt?.noSSR ||
@@ -311,7 +311,7 @@ export default defineRenderHandler(async (event): Promise<Partial<RenderResponse
 
   // Whether we are prerendering route
   const _PAYLOAD_EXTRACTION = import.meta.prerender && process.env.NUXT_PAYLOAD_EXTRACTION && !ssrContext.noSSR && !isRenderingIsland
-  const payloadURL = _PAYLOAD_EXTRACTION ? joinURL(useRuntimeConfig().app.baseURL, url, process.env.NUXT_JSON_PAYLOADS ? '_payload.json' : '_payload.js') : undefined
+  const payloadURL = _PAYLOAD_EXTRACTION ? joinURL(ssrContext.runtimeConfig.app.baseURL, url, process.env.NUXT_JSON_PAYLOADS ? '_payload.json' : '_payload.js') : undefined
   if (import.meta.prerender) {
     ssrContext.payload.prerenderedAt = Date.now()
   }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/25925

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

This attempts to address an issue with runtime config in Cloudflare. Note that this may not _fully_ resolve the issue if there are upstream issues or lack of support within Cloudflare:

> Passing `event` explicitly when possible is good idea.
> 
> Also related: [unjs/nitro#2054](https://github.com/unjs/nitro/issues/2054)
> 
> (in general, I'm afraid only safe point we can say cloudflare pages supports env universally, is when we can opt into Async Context)
> -- @pi0

However, by making this change, useRuntimeConfig() within the Vue app does not need to receive the event parameter as it will fall back to the _already resolved_ config set in this PR.

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
