### PR TITLE
fix(nuxt): skip vue style blocks in unctx transform

### DIFF
--- a/packages/nuxt/src/core/plugins/unctx.ts
+++ b/packages/nuxt/src/core/plugins/unctx.ts
@@ -17,7 +17,7 @@ export const UnctxTransformPlugin = createUnplugin((options: UnctxTransformPlugi
     name: 'unctx:transform',
     enforce: 'post',
     transformInclude (id) {
-      return isVue(id) || isJS(id)
+      return isVue(id, { type: ['template', 'script']}) || isJS(id)
     },
     transform (code) {
       // TODO: needed for webpack - update transform in unctx/unplugin?

--- a/test/fixtures/basic/pages/styles.vue
+++ b/test/fixtures/basic/pages/styles.vue
@@ -18,6 +18,8 @@ import '~/assets/assets.css'
 </style>
 
 <style scoped>
+  /* Regression test for https: //github.com/nuxt/nuxt/issues/26057 */
+  /* definePageMeta( */
   div {
     --scoped: 'scoped';
   }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/26057

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We were wrongly applying unctx transform to style blocks as well as script/template blocks in Vue files. I think we can safely skip this.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
