### PR TITLE
docs: add not about vue-tsc

### DIFF
--- a/docs/2.guide/1.concepts/8.typescript.md
+++ b/docs/2.guide/1.concepts/8.typescript.md
@@ -1,3 +1,4 @@
+
 ---
 title: 'TypeScript'
 description: "Nuxt 3 is fully typed and provides helpful shortcuts to ensure you have access to accurate type information when you are coding."
@@ -9,22 +10,25 @@ By default, Nuxt doesn't check types when you run [`nuxi dev`](/docs/api/command
 
 To enable type-checking at build or development time, install `vue-tsc` and `typescript` as development dependency:
 
+> Please note that currently only the latest major version 1 of vue-tsc
+> is compatible
+
 ::code-group
 
   ```bash [yarn]
-  yarn add --dev vue-tsc typescript
+  yarn add --dev vue-tsc@^1 typescript
   ```
 
   ```bash [npm]
-  npm install --save-dev vue-tsc typescript
+  npm install --save-dev vue-tsc@^1 typescript
   ```
 
   ```bash [pnpm]
-  pnpm add -D vue-tsc typescript
+  pnpm add -D vue-tsc@^1 typescript
   ```
 
   ```bash [bun]
-  bun add -D vue-tsc typescript
+  bun add -D vue-tsc@^1 typescript
   ```
 
 ::


### PR DESCRIPTION
Added a note about vue-tsc, since nuxt3 doesn't work with vue-tsc version 2, I lost a lot of time searching for a solution, I hope this little note helps others and saves a lot of time.