### PR TITLE
fix(nuxt): resolve `defu`/`h3` paths in type templates

### DIFF
--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -8,6 +8,9 @@ import { hash } from 'ohash'
 import { camelCase } from 'scule'
 import { filename } from 'pathe/utils'
 import type { NuxtTemplate } from 'nuxt/schema'
+import { tryResolveModule } from '@nuxt/kit'
+
+
 import { annotatePlugins, checkForCircularDependencies } from './app'
 
 export const vueShim: NuxtTemplate = {
@@ -221,12 +224,13 @@ export const middlewareTemplate: NuxtTemplate = {
 
 export const nitroSchemaTemplate: NuxtTemplate = {
   filename: 'types/nitro-nuxt.d.ts',
-  getContents: () => {
+  async getContents ({ nuxt }) {
+    const localH3 = await tryResolveModule('h3', nuxt.options.modulesDir) || 'h3'
     return /* typescript */`
 /// <reference path="./schema.d.ts" />
 
 import type { RuntimeConfig } from 'nuxt/schema'
-import type { H3Event } from 'h3'
+import type { H3Event } from '${localH3}'
 import type { NuxtIslandContext, NuxtIslandResponse, NuxtRenderHTMLContext } from 'nuxt/dist/core/runtime/nitro/renderer'
 
 declare module 'nitropack' {
@@ -261,10 +265,11 @@ export const useRuntimeConfig = () => window?.__NUXT__?.config || {}
 
 export const appConfigDeclarationTemplate: NuxtTemplate = {
   filename: 'types/app.config.d.ts',
-  getContents: ({ app, nuxt }) => {
+  async getContents ({ app, nuxt }) {
+    const localDefu = await tryResolveModule('defu', nuxt.options.modulesDir) || 'defu'
     return `
 import type { CustomAppConfig } from 'nuxt/schema'
-import type { Defu } from 'defu'
+import type { Defu } from '${localDefu}'
 ${app.configs.map((id: string, index: number) => `import ${`cfg${index}`} from ${JSON.stringify(id.replace(/(?<=\w)\.\w+$/g, ''))}`).join('\n')}
 
 declare const inlineConfig = ${JSON.stringify(nuxt.options.appConfig, null, 2)}
@@ -298,10 +303,11 @@ declare module '@nuxt/schema' {
 export const appConfigTemplate: NuxtTemplate = {
   filename: 'app.config.mjs',
   write: true,
-  getContents ({ app, nuxt }) {
+  async getContents ({ app, nuxt }) {
+    const localDefu = await tryResolveModule('defu', nuxt.options.modulesDir) || 'defu'
     return `
 import { updateAppConfig } from '#app/config'
-import { defuFn } from 'defu'
+import { defuFn } from '${localDefu}'
 
 const inlineConfig = ${JSON.stringify(nuxt.options.appConfig, null, 2)}
 

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -10,7 +10,6 @@ import { filename } from 'pathe/utils'
 import type { NuxtTemplate } from 'nuxt/schema'
 import { tryResolveModule } from '@nuxt/kit'
 
-
 import { annotatePlugins, checkForCircularDependencies } from './app'
 
 export const vueShim: NuxtTemplate = {

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -479,7 +479,7 @@ export default defineNuxtModule({
       getContents: ({ nuxt, app }: { nuxt: Nuxt, app: NuxtApp }) => {
         const composablesFile = relative(join(nuxt.options.buildDir, 'types'), resolve(runtimeDir, 'composables'))
         return [
-          'import { ComputedRef, MaybeRef } from \'vue\'',
+          'import type { ComputedRef, MaybeRef } from \'vue\'',
           `export type LayoutKey = ${Object.keys(app.layouts).map(name => genString(name)).join(' | ') || 'string'}`,
           `declare module ${genString(composablesFile)} {`,
           '  interface PageMeta {',
@@ -499,7 +499,7 @@ export default defineNuxtModule({
           const runtimeDir = resolve(distDir, 'pages/runtime')
           const composablesFile = relative(join(nuxt.options.buildDir, 'types'), resolve(runtimeDir, 'composables'))
           return [
-            'import { ComputedRef, MaybeRef } from \'vue\'',
+            'import type { ComputedRef, MaybeRef } from \'vue\'',
             `declare module ${genString(composablesFile)} {`,
             '  interface PageMeta {',
             `    viewTransition?: boolean | 'always'`,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This should fix types when importing directly from `#build/app.config` and also the declared app config from `types/app.config.d.ts`.

Related: https://github.com/nuxt/nuxt/issues/23984

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
