### PR TITLE
docs(nuxt): document the nuxtlayout fallback prop

### DIFF
--- a/docs/3.api/1.components/3.nuxt-layout.md
+++ b/docs/3.api/1.components/3.nuxt-layout.md
@@ -55,6 +55,10 @@ Please note the layout name is normalized to kebab-case, so if your layout file 
 Read more about dynamic layouts.
 ::
 
+- `fallback`: If an invalid layout is passed to the `name` prop, no layout will be rendered. Specify a `fallback` layout to be rendered in this scenario. It **must** match the name of the corresponding layout file in the [`layouts/`](/docs/guide/directory-structure/layouts) directory.
+  - **type**: `string`
+  - **default**: `null`
+
 ## Additional Props
 
 `NuxtLayout` also accepts any additional props that you may need to pass to the layout. These custom props are then made accessible as attributes.


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

N/A

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Missing prop documentation on the [`<NuxtLayout>` docs page](https://nuxt.com/docs/api/components/nuxt-layout#props).

The `<NuxtLayout>` fallback prop was added in #24777 but was not documented.

The prop can be seen here: https://github.com/nuxt/nuxt/blob/84749e0350a9f7c034f60b3968ca3da74e986a4c/packages/nuxt/src/app/components/nuxt-layout.ts#L46-L49

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
