### PR TITLE
fix(nuxt): handle external redirects from `routeRules`

### DIFF
--- a/packages/nuxt/src/app/middleware/manifest-route-rule.ts
+++ b/packages/nuxt/src/app/middleware/manifest-route-rule.ts
@@ -1,3 +1,4 @@
+import { hasProtocol } from 'ufo'
 import { defineNuxtRouteMiddleware } from '../composables/router'
 import { getRouteRules } from '../composables/manifest'
 
@@ -5,6 +6,10 @@ export default defineNuxtRouteMiddleware(async (to) => {
   if (import.meta.server || import.meta.test) { return }
   const rules = await getRouteRules(to.path)
   if (rules.redirect) {
+    if (hasProtocol(rules.redirect, { acceptRelative: true })) {
+      window.location.href = rules.redirect
+      return false
+    }
     return rules.redirect
   }
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This resolves an issue with an external redirect.

Issue was reproducible on client side with this config:

```ts
export default defineNuxtConfig({
  routeRules: {
    "/pergel/**": {
      redirect: 'https://pergel.oku-ui.com',
    },
  },
})
```

and a page like this:

```vue
<template>
  <div>
    <NuxtLink to="/pergel">here we go!</NuxtLink>
  </div>
</template>
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
