### PR TITLE
fix(nuxt): access prerender cache synchronously

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -214,9 +214,9 @@ export function useAsyncData<
   const nuxtApp = useNuxtApp()
 
   // When prerendering, share payload data automatically between requests
-  const handler = import.meta.client || !import.meta.prerender || !nuxtApp.ssrContext?._sharedPrerenderCache ? _handler : async () => {
-    const value = await nuxtApp.ssrContext!._sharedPrerenderCache!.get(key)
-    if (value) { return value as ResT }
+  const handler = import.meta.client || !import.meta.prerender || !nuxtApp.ssrContext?._sharedPrerenderCache ? _handler : () => {
+    const value = nuxtApp.ssrContext!._sharedPrerenderCache!.get(key)
+    if (value) { return value as Promise<ResT> }
 
     const promise = nuxtApp.runWithContext(_handler)
     nuxtApp.ssrContext!._sharedPrerenderCache!.set(key, promise)

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -73,7 +73,7 @@ export interface NuxtSSRContext extends SSRContext {
   _payloadReducers: Record<string, (data: any) => any>
   /** @internal */
   _sharedPrerenderCache?: {
-    get<T = unknown> (key: string): Promise<T>
+    get<T = unknown> (key: string): Promise<T> | undefined
     set<T> (key: string, value: Promise<T>): Promise<void>
   }
 }

--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -393,10 +393,12 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
     }
   })
 
+  const cacheDir = resolve(nuxt.options.buildDir, 'cache/nitro/prerender')
+  await fsp.rm(cacheDir, { recursive: true, force: true }).catch(() => {})
   nitro.options._config.storage = defu(nitro.options._config.storage, {
     'internal:nuxt:prerender': {
       driver: pathToFileURL(await resolvePath(join(distDir, 'core/runtime/nitro/cache-driver'))).href,
-      base: resolve(nuxt.options.buildDir, 'cache/nitro/prerender')
+      base: cacheDir
     }
   })
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/26142

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

There can be race conditions when awaiting the initial check whether a promise already exists in prerender cache.

Actually the `_sharedPrerenderCache` supports sync operations to verify whether the promise exists so we can convert this function to sync.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
