### PR TITLE
fix(nuxt): watch custom `cookieRef` values deeply

### DIFF
--- a/packages/nuxt/src/app/composables/cookie.ts
+++ b/packages/nuxt/src/app/composables/cookie.ts
@@ -123,9 +123,9 @@ export function useCookie<T = string | null | undefined> (name: string, _opts?: 
   return cookie as CookieRef<T>
 }
 /** @since 3.10.0 */
-export function refreshCookie(name: string) {
+export function refreshCookie (name: string) {
   if (store || typeof BroadcastChannel === 'undefined') return
-  
+
   new BroadcastChannel(`nuxt:cookies:${name}`)?.postMessage({ refresh: true })
 }
 
@@ -176,12 +176,19 @@ const MAX_TIMEOUT_DELAY = 2_147_483_647
 // custom ref that will update the value to undefined if the cookie expires
 function cookieRef<T> (value: T | undefined, delay: number) {
   let timeout: NodeJS.Timeout
+  let unsubscribe: (() => void) | undefined
   let elapsed = 0
+  const internalRef = ref(value)
   if (getCurrentScope()) {
-    onScopeDispose(() => { clearTimeout(timeout) })
+    onScopeDispose(() => {
+      unsubscribe?.()
+      clearTimeout(timeout)
+    })
   }
 
   return customRef((track, trigger) => {
+    unsubscribe = watch(internalRef, trigger)
+
     function createExpirationTimeout () {
       clearTimeout(timeout)
       const timeRemaining = delay - elapsed
@@ -190,7 +197,7 @@ function cookieRef<T> (value: T | undefined, delay: number) {
         elapsed += timeoutLength
         if (elapsed < delay) { return createExpirationTimeout() }
 
-        value = undefined
+        internalRef.value = undefined
         trigger()
       }, timeoutLength)
     }
@@ -198,12 +205,12 @@ function cookieRef<T> (value: T | undefined, delay: number) {
     return {
       get () {
         track()
-        return value
+        return internalRef.value
       },
       set (newValue) {
         createExpirationTimeout()
 
-        value = newValue
+        internalRef.value = newValue
         trigger()
       }
     }

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -97,6 +97,7 @@ describe('composables', () => {
       'useRequestFetch',
       'isPrerendered',
       'useRequestHeaders',
+      'useCookie',
       'clearNuxtState',
       'useState',
       'useRequestURL',
@@ -121,7 +122,6 @@ describe('composables', () => {
       'preloadRouteComponents',
       'reloadNuxtApp',
       'refreshCookie',
-      'useCookie',
       'useFetch',
       'useHead',
       'useLazyFetch',
@@ -628,6 +628,33 @@ describe('defineNuxtComponent', () => {
   it.todo('should support Options API head')
 })
 
+describe('useCookie', () => {
+  it('should watch custom cookie refs', () => {
+    const user = useCookie('userInfo', {
+      default: () => ({ score: -1 }),
+      maxAge: 60 * 60,
+    })
+    const computedVal = computed(() => user.value.score)
+    expect(computedVal.value).toBe(-1)
+    user.value.score++
+    expect(computedVal.value).toBe(0)
+  })
+
+  it('should not watch custom cookie refs when shallow', () => {
+    for (const value of ['shallow', false] as const) {
+      const user = useCookie('shallowUserInfo', {
+        default: () => ({ score: -1 }),
+        maxAge: 60 * 60,
+        watch: value
+      })
+      const computedVal = computed(() => user.value.score)
+      expect(computedVal.value).toBe(-1)
+      user.value.score++
+      expect(computedVal.value).toBe(-1)
+    }
+  })
+})
+
 describe('callOnce', () => {
   it('should only call composable once', async () => {
     const fn = vi.fn()
@@ -643,7 +670,7 @@ describe('callOnce', () => {
     await Promise.all([execute(), execute(), execute()])
     expect(fn).toHaveBeenCalledTimes(1)
 
-    const fnSync = vi.fn().mockImplementation(() => { })
+    const fnSync = vi.fn().mockImplementation(() => {})
     const executeSync = () => callOnce(fnSync)
     await Promise.all([executeSync(), executeSync(), executeSync()])
     expect(fnSync).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/24856

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

With objects within cookies, we need to wrap them in a ref in order to benefit from reactivity when changing their contents. This has the slight overhead of a double-ref but seems safe otherwise.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
