### PR TITLE
fix(nuxt): provide typescript aliases for core packages

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-island.ts
+++ b/packages/nuxt/src/app/components/nuxt-island.ts
@@ -9,8 +9,7 @@ import { joinURL, withQuery } from 'ufo'
 import type { FetchResponse } from 'ofetch'
 import { join } from 'pathe'
 
-// eslint-disable-next-line import/no-restricted-paths
-import type { NuxtIslandResponse } from '../../core/runtime/nitro/renderer'
+import type { NuxtIslandResponse } from '../types'
 import { useNuxtApp, useRuntimeConfig } from '../nuxt'
 import { prerenderRoutes, useRequestEvent } from '../composables/ssr'
 import { getFragmentHTML } from './utils'

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -11,8 +11,7 @@ import type { AppConfig, AppConfigInput, RuntimeConfig } from 'nuxt/schema'
 import type { RenderResponse } from 'nitropack'
 import type { MergeHead, VueHeadClient } from '@unhead/vue'
 
-// eslint-disable-next-line import/no-restricted-paths
-import type { NuxtIslandContext } from '../core/runtime/nitro/renderer'
+import type { NuxtIslandContext } from '../app/types'
 import type { RouteMiddleware } from '../app/composables/router'
 import type { NuxtError } from '../app/composables/error'
 import type { AsyncDataRequestStatus } from '../app/composables/asyncData'

--- a/packages/nuxt/src/app/types.ts
+++ b/packages/nuxt/src/app/types.ts
@@ -4,3 +4,6 @@ export type { PageMeta } from '../pages/runtime/index'
 export interface NuxtAppLiterals {
   [key: string]: string
 }
+
+// eslint-disable-next-line import/no-restricted-paths
+export type { NuxtIslandContext, NuxtIslandResponse, NuxtRenderHTMLContext } from '../core/runtime/nitro/renderer'

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -8,7 +8,6 @@ import { hash } from 'ohash'
 import { camelCase } from 'scule'
 import { filename } from 'pathe/utils'
 import type { NuxtTemplate } from 'nuxt/schema'
-import { tryResolveModule } from '@nuxt/kit'
 
 import { annotatePlugins, checkForCircularDependencies } from './app'
 
@@ -223,14 +222,13 @@ export const middlewareTemplate: NuxtTemplate = {
 
 export const nitroSchemaTemplate: NuxtTemplate = {
   filename: 'types/nitro-nuxt.d.ts',
-  async getContents ({ nuxt }) {
-    const localH3 = await tryResolveModule('h3', nuxt.options.modulesDir) || 'h3'
+  getContents () {
     return /* typescript */`
 /// <reference path="./schema.d.ts" />
 
 import type { RuntimeConfig } from 'nuxt/schema'
-import type { H3Event } from '${localH3}'
-import type { NuxtIslandContext, NuxtIslandResponse, NuxtRenderHTMLContext } from 'nuxt/dist/core/runtime/nitro/renderer'
+import type { H3Event } from 'h3'
+import type { NuxtIslandContext, NuxtIslandResponse, NuxtRenderHTMLContext } from 'nuxt/app'
 
 declare module 'nitropack' {
   interface NitroRuntimeConfigApp {
@@ -264,11 +262,10 @@ export const useRuntimeConfig = () => window?.__NUXT__?.config || {}
 
 export const appConfigDeclarationTemplate: NuxtTemplate = {
   filename: 'types/app.config.d.ts',
-  async getContents ({ app, nuxt }) {
-    const localDefu = await tryResolveModule('defu', nuxt.options.modulesDir) || 'defu'
+  getContents ({ app, nuxt }) {
     return `
 import type { CustomAppConfig } from 'nuxt/schema'
-import type { Defu } from '${localDefu}'
+import type { Defu } from 'defu'
 ${app.configs.map((id: string, index: number) => `import ${`cfg${index}`} from ${JSON.stringify(id.replace(/(?<=\w)\.\w+$/g, ''))}`).join('\n')}
 
 declare const inlineConfig = ${JSON.stringify(nuxt.options.appConfig, null, 2)}
@@ -302,11 +299,10 @@ declare module '@nuxt/schema' {
 export const appConfigTemplate: NuxtTemplate = {
   filename: 'app.config.mjs',
   write: true,
-  async getContents ({ app, nuxt }) {
-    const localDefu = await tryResolveModule('defu', nuxt.options.modulesDir) || 'defu'
+  getContents ({ app, nuxt }) {
     return `
 import { updateAppConfig } from '#app/config'
-import { defuFn } from '${localDefu}'
+import { defuFn } from 'defu'
 
 const inlineConfig = ${JSON.stringify(nuxt.options.appConfig, null, 2)}
 

--- a/packages/nuxt/types.d.mts
+++ b/packages/nuxt/types.d.mts
@@ -4,7 +4,7 @@ export * from './dist/index.js'
 import type { DefineNuxtConfig } from 'nuxt/config'
 import type { RuntimeConfig, SchemaDefinition } from 'nuxt/schema'
 import type { H3Event } from 'h3'
-import type { NuxtIslandContext, NuxtIslandResponse, NuxtRenderHTMLContext } from './dist/core/runtime/nitro/renderer.js'
+import type { NuxtIslandContext, NuxtIslandResponse, NuxtRenderHTMLContext } from './dist/app/types.js'
 
 declare global {
   const defineNuxtConfig: DefineNuxtConfig

--- a/packages/nuxt/types.d.ts
+++ b/packages/nuxt/types.d.ts
@@ -4,7 +4,7 @@ export * from './dist/index'
 import type { DefineNuxtConfig } from 'nuxt/config'
 import type { RuntimeConfig, SchemaDefinition } from 'nuxt/schema'
 import type { H3Event } from 'h3'
-import type { NuxtIslandContext, NuxtIslandResponse, NuxtRenderHTMLContext } from './dist/core/runtime/nitro/renderer'
+import type { NuxtIslandContext, NuxtIslandResponse, NuxtRenderHTMLContext } from './dist/app/types'
 
 declare global {
   const defineNuxtConfig: DefineNuxtConfig

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -7,8 +7,9 @@ import { join, normalize } from 'pathe'
 import { $fetch, createPage, fetch, isDev, setup, startServer, url, useTestContext } from '@nuxt/test-utils/e2e'
 import { $fetchComponent } from '@nuxt/test-utils/experimental'
 
-import type { NuxtIslandResponse } from '../packages/nuxt/src/core/runtime/nitro/renderer'
 import { expectNoClientErrors, expectWithPolling, gotoPath, isRenderingJson, parseData, parsePayload, renderPage } from './utils'
+
+import type { NuxtIslandResponse } from '#app'
 
 const isWebpack = process.env.TEST_BUILDER === 'webpack'
 const isTestingAppManifest = process.env.TEST_MANIFEST !== 'manifest-off'


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This resolves the deep directories of a number of key packages to enable full type safety when used with `shamefully-hoist=false`. It also refactors the existing implementation of this to make it more performant (by just doing it once rather than in the templates which run many times).

We also export some renderer types from `#app` so they will work when used with new TS bundler resolution.

With this, the following bugs are resolved with `shamefully-hoist=false`:

* nitro runtime hooks are properly extended
* key renderer types (like HTMLContext) now work
* app config is correctly merged/typed
* internal API types now flow through correclty

Later on we might want to do this automatically for dependencies added to auto imports, or make this list extensible.

cc: @pi0 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
