### PR TITLE
perf(nuxt): use faster approach to check cache exists

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -243,7 +243,7 @@ export function useAsyncData<
     console.warn('[nuxt] `boolean` values are deprecated for the `dedupe` option of `useAsyncData` and will be removed in the future. Use \'cancel\' or \'defer\' instead.')
   }
 
-  const hasCachedData = () => ![null, undefined].includes(options.getCachedData!(key) as any)
+  const hasCachedData = () => options.getCachedData!(key) != null
 
   // Create or use a shared asyncData entity
   if (!nuxtApp._asyncData[key] || !options.immediate) {


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently, the implementation of `hasCachedData` inside `useAsyncData` is as follows:

```ts
const hasCachedData = () => ![null, undefined].includes(options.getCachedData!(key) as any)
```

Perhaps we can tune it for better performance by simplifying the condition like this:

```ts
const hasCachedData = () => options.getCachedData!(key) != null
```

For reference, here are the benchmark test results:

```
check via `value != null` x 993,997,209 ops/sec ±0.10% (98 runs sampled)
check via `![null, undefined].includes(value)` x 74,629,930 ops/sec ±0.35% (98 runs sampled)
Fastest is check via `value != null`
```

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
