### PR TITLE
fix(nuxt): improved plugin annotating warnings

### DIFF
--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -205,9 +205,9 @@ export async function annotatePlugins (nuxt: Nuxt, plugins: NuxtPlugin[]) {
         ...await extractMetadata(code),
         ...plugin
       })
-    } catch (e: Error) {
+    } catch (e) {
       const relativePluginSrc = relative(nuxt.options.rootDir, plugin.src)
-      if (e.message === 'Invalid plugin metadata') {
+      if ((e as Error).message === 'Invalid plugin metadata') {
         logger.warn(`Failed to parse static properties from plugin \`${relativePluginSrc}\`, falling back to non-optimized runtime meta. Learn more: https://nuxt.com/docs/guide/directory-structure/plugins#object-syntax-plugins`)
       } else {
         logger.warn(`Failed to parse static properties from plugin \`${relativePluginSrc}\`.`, e)

--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -205,7 +205,7 @@ export async function annotatePlugins (nuxt: Nuxt, plugins: NuxtPlugin[]) {
         ...await extractMetadata(code),
         ...plugin
       })
-    } catch (e) {
+    } catch (e: Error) {
       const relativePluginSrc = relative(nuxt.options.rootDir, plugin.src)
       if (e.message === 'Invalid plugin metadata') {
         logger.warn(`Failed to parse static properties from plugin \`${relativePluginSrc}\`, falling back to non-optimized runtime meta. Learn more: https://nuxt.com/docs/guide/directory-structure/plugins#object-syntax-plugins`)

--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -209,6 +209,7 @@ export async function annotatePlugins (nuxt: Nuxt, plugins: NuxtPlugin[]) {
           } else {
             logger.warn(`Failed to parse static properties from plugin \`${relativePluginSrc}\`.`, e)
           }
+          return {}
         }),
       ...plugin
     })

--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -199,18 +199,21 @@ function resolvePaths<Item extends Record<string, any>> (items: Item[], key: { [
 export async function annotatePlugins (nuxt: Nuxt, plugins: NuxtPlugin[]) {
   const _plugins: Array<NuxtPlugin & Omit<PluginMeta, 'enforce'>> = []
   for (const plugin of plugins) {
-    const code = plugin.src in nuxt.vfs ? nuxt.vfs[plugin.src] : await fsp.readFile(plugin.src!, 'utf-8')
-    const meta = await extractMetadata(code)
-      .catch((e) => {
-        const relativePluginSrc = relative(nuxt.options.rootDir, plugin.src)
-        if (e.message === 'Invalid plugin metadata') {
-          logger.warn(`Failed to parse static properties from plugin \`${relativePluginSrc}\`, falling back to non-optimized runtime meta. Learn more: https://nuxt.com/docs/guide/directory-structure/plugins#object-syntax-plugins`)
-        } else {
-          logger.warn(`Failed to parse static properties from plugin \`${relativePluginSrc}\`.`, e)
-        }
+    try {
+      const code = plugin.src in nuxt.vfs ? nuxt.vfs[plugin.src] : await fsp.readFile(plugin.src!, 'utf-8')
+      _plugins.push({
+        ...await extractMetadata(code),
+        ...plugin
       })
-    // assign meta to the plugin
-    _plugins.push(meta ? Object.assign(plugin, meta) : plugin)
+    } catch (e) {
+      const relativePluginSrc = relative(nuxt.options.rootDir, plugin.src)
+      if (e.message === 'Invalid plugin metadata') {
+        logger.warn(`Failed to parse static properties from plugin \`${relativePluginSrc}\`, falling back to non-optimized runtime meta. Learn more: https://nuxt.com/docs/guide/directory-structure/plugins#object-syntax-plugins`)
+      } else {
+        logger.warn(`Failed to parse static properties from plugin \`${relativePluginSrc}\`.`, e)
+      }
+      _plugins.push(plugin)
+    }
   }
 
   return _plugins.sort((a, b) => (a.order ?? orderMap.default) - (b.order ?? orderMap.default))

--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -199,16 +199,19 @@ function resolvePaths<Item extends Record<string, any>> (items: Item[], key: { [
 export async function annotatePlugins (nuxt: Nuxt, plugins: NuxtPlugin[]) {
   const _plugins: Array<NuxtPlugin & Omit<PluginMeta, 'enforce'>> = []
   for (const plugin of plugins) {
-    try {
-      const code = plugin.src in nuxt.vfs ? nuxt.vfs[plugin.src] : await fsp.readFile(plugin.src!, 'utf-8')
-      _plugins.push({
-        ...await extractMetadata(code),
-        ...plugin
-      })
-    } catch (e) {
-      logger.warn(`Could not resolve \`${plugin.src}\`.`)
-      _plugins.push(plugin)
-    }
+    const code = plugin.src in nuxt.vfs ? nuxt.vfs[plugin.src] : await fsp.readFile(plugin.src!, 'utf-8')
+    _plugins.push({
+      ...await extractMetadata(code)
+        .catch((e) => {
+          const relativePluginSrc = relative(nuxt.options.rootDir, plugin.src)
+          if (e.message === 'Invalid plugin metadata') {
+            logger.warn(`Failed to parse static properties from plugin \`${relativePluginSrc}\`, falling back to non-optimized runtime meta. Learn more: https://nuxt.com/docs/guide/directory-structure/plugins#object-syntax-plugins`)
+          } else {
+            logger.warn(`Failed to parse static properties from plugin \`${relativePluginSrc}\`.`, e)
+          }
+        }),
+      ...plugin
+    })
   }
 
   return _plugins.sort((a, b) => (a.order ?? orderMap.default) - (b.order ?? orderMap.default))

--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -209,7 +209,7 @@ export async function annotatePlugins (nuxt: Nuxt, plugins: NuxtPlugin[]) {
           } else {
             logger.warn(`Failed to parse static properties from plugin \`${relativePluginSrc}\`.`, e)
           }
-          return {}
+          return {} as Omit<PluginMeta, 'enforce'>
         }),
       ...plugin
     })

--- a/packages/nuxt/src/core/plugins/plugin-metadata.ts
+++ b/packages/nuxt/src/core/plugins/plugin-metadata.ts
@@ -47,8 +47,6 @@ export async function extractMetadata (code: string) {
   if (metaCache[code]) {
     return metaCache[code]
   }
-  // avoid re-parsing failed plugin code, initial error will bubble up
-  metaCache[code] = {}
   const js = await transform(code, { loader: 'ts' })
   walk(parse(js.code, {
     sourceType: 'module',

--- a/packages/nuxt/src/core/plugins/plugin-metadata.ts
+++ b/packages/nuxt/src/core/plugins/plugin-metadata.ts
@@ -47,6 +47,8 @@ export async function extractMetadata (code: string) {
   if (metaCache[code]) {
     return metaCache[code]
   }
+  // avoid re-parsing failed plugin code, initial error will bubble up
+  metaCache[code] = {}
   const js = await transform(code, { loader: 'ts' })
   walk(parse(js.code, {
     sourceType: 'module',


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I had a valid use case for needing runtime meta data for a plugin, when making it, a cryptic warning was being thrown 3 times. 

```sh
WARN  Could not resolve /home/harlan/packages/nuxt-seo/src/runtime/nuxt/plugin/defaults.ts.
WARN  Could not resolve /home/harlan/packages/nuxt-seo/src/runtime/nuxt/plugin/defaults.ts.
WARN  Could not resolve /home/harlan/packages/nuxt-seo/src/runtime/nuxt/plugin/defaults.ts.
```

I honestly had no idea what it was meant to mean and could only debug it by looking through the Nuxt source.

This PR aims to make this warning easier to interpret.

New warnings:

```sh
WARN  Failed to parse static properties from plugin plugins/sample.ts, falling back to non-optimized runtime meta. Learn more: https://nuxt.com/docs/guide/directory-structure/plugins#object-syntax-plugins
```

OR

```sh
WARN  Failed to extract meta data from plugin ../../../src/runtime/nuxt/plugin/defaultsWaitI18n. ENOENT: no such file or directory, open '/home/harlan/packages/nuxt-seo/src/runtime/nuxt/plugin/defaultsWaitI18n'
```

Note: I did try and change it to only throw once by making sure we don't annotate code blocks that have already been parsed but ran into too many errors from the test suite. Not too sure what went wrong.



<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
