### PR TITLE
docs(nuxt): add cache.varies docs for multi-tenant use case

### DIFF
--- a/docs/3.api/2.composables/use-request-url.md
+++ b/docs/3.api/2.composables/use-request-url.md
@@ -10,6 +10,12 @@ links:
 
 `useRequestURL` is a helper function that returns an [URL object](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) working on both server-side and client-side.
 
+::important
+When utilizing [Hybrid Rendering](/docs/guide/concepts/rendering#hybrid-rendering) with cache strategies, all incoming request headers are dropped when handling the cached responses via the [Nitro caching layer](https://nitro.unjs.io/guide/cache) (meaning `useRequestURL` will return `localhost` for the `host`).
+
+You can define the [`cache.varies` option](https://nitro.unjs.io/guide/cache#options) to specify headers that will be considered when caching and serving the responses, such as `host` and `x-forwarded-host` for multi-tenant environments.
+::
+
 ::code-group
 
 ```vue [pages/about.vue]


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`useRequestURL` will return `localhost` for the `host` header when utilizing cache strategies, which isn't completely obvious. (It took me 3 days to figure out why my `host` headers were returning `localhost` 😅 )

The `cache.varies` option for Nitro's `routeRules` needs to be better documented to help understand the cache behavior and discarded headers, especially related to a multi-tenant implementations.

The explanation is not currently obvious when reading through the docs; however, was better explained in https://github.com/nuxt/nuxt/issues/26102#issuecomment-1980625833 by @pi0. This PR surfaces the explanation and provides docs visitors a keyword of "tenant" in the docs they can search for as a hint. 

I also created a corresponding PR for Nitro: https://github.com/unjs/nitro/pull/2241

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
