### PR TITLE
feat(nuxt): allow generating metadata for nuxt components

### DIFF
--- a/docs/3.api/5.kit/5.components.md
+++ b/docs/3.api/5.kit/5.components.md
@@ -41,6 +41,11 @@ interface ComponentsDir {
   transpile?: 'auto' | boolean
 }
 
+// You can augment this interface (exported from `@nuxt/schema`) if needed
+interface ComponentMeta {
+  [key: string]: unknown
+}
+
 interface Component {
   pascalName: string
   kebabName: string
@@ -54,6 +59,7 @@ interface Component {
   island?: boolean
   mode?: 'client' | 'server' | 'all'
   priority?: number
+  meta?: ComponentMeta
 }
 ```
 

--- a/packages/kit/src/components.ts
+++ b/packages/kit/src/components.ts
@@ -48,6 +48,7 @@ export async function addComponent (opts: AddComponentOptions) {
     mode: 'all',
     shortPath: opts.filePath,
     priority: 0,
+    meta: {},
     ...opts
   }
 

--- a/packages/nuxt/src/components/module.ts
+++ b/packages/nuxt/src/components/module.ts
@@ -5,7 +5,7 @@ import type { Component, ComponentsDir, ComponentsOptions } from 'nuxt/schema'
 
 import { distDir } from '../dirs'
 import { clientFallbackAutoIdPlugin } from './client-fallback-auto-id'
-import { componentNamesTemplate, componentsIslandsTemplate, componentsPluginTemplate, componentsTypeTemplate } from './templates'
+import { componentNamesTemplate, componentsIslandsTemplate, componentsMetadataTemplate, componentsPluginTemplate, componentsTypeTemplate } from './templates'
 import { scanComponents } from './scan'
 import { loaderPlugin } from './loader'
 import { TreeShakeTemplatePlugin } from './tree-shake'
@@ -125,6 +125,10 @@ export default defineNuxtModule<ComponentsOptions>({
       addTemplate({ ...componentsIslandsTemplate, filename: 'components.islands.mjs' })
     } else {
       addTemplate({ filename: 'components.islands.mjs', getContents: () => 'export const islandComponents = {}' })
+    }
+
+    if (componentOptions.generateMetadata) {
+      addTemplate(componentsMetadataTemplate)
     }
 
     const unpluginServer = createTransformPlugin(nuxt, getComponents, 'server')

--- a/packages/nuxt/src/components/templates.ts
+++ b/packages/nuxt/src/components/templates.ts
@@ -124,3 +124,9 @@ export const componentNames: string[]
 `
   }
 }
+
+export const componentsMetadataTemplate: NuxtTemplate = {
+  filename: 'components.json',
+  write: true,
+  getContents: ({ app }) => JSON.stringify(app.components, null, 2)
+}

--- a/packages/schema/src/types/components.ts
+++ b/packages/schema/src/types/components.ts
@@ -1,3 +1,7 @@
+export interface ComponentMeta {
+  [key: string]: unknown
+}
+
 export interface Component {
   pascalName: string
   kebabName: string
@@ -9,6 +13,7 @@ export interface Component {
   preload: boolean
   global?: boolean | 'sync'
   island?: boolean
+  meta?: ComponentMeta
   mode?: 'client' | 'server' | 'all'
   /**
    * This number allows configuring the behavior of overriding Nuxt components.

--- a/packages/schema/src/types/components.ts
+++ b/packages/schema/src/types/components.ts
@@ -114,6 +114,11 @@ export interface ComponentsOptions {
    * @default false
    */
   global?: boolean
+  /**
+   * Whether to write metadata to the build directory with information about the components that
+   * are auto-registered in your app.
+   */
+  generateMetadata?: boolean
   loader?: boolean
 
   transform?: {


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/15015

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds a new option: `components.generateMetadata` which writes `~/.nuxt/components.json` which could be consumed by other integrations to get information about the auto-imported components in your app.

The original use case of this (eslint) will likely be implemented differently so it may be worth reconsidering this and/or closing the PR. What do you think @antfu?

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
