### PR TITLE
feat(nuxt): allow auto-registration of plugins with .jsx or .tsx extensions

### DIFF
--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -150,8 +150,8 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
       ...(config.plugins || []),
       ...config.srcDir
         ? await resolveFiles(config.srcDir, [
-          `${pluginDir}/*.{ts,js,mjs,cjs,mts,cts}`,
-          `${pluginDir}/*/index.*{ts,js,mjs,cjs,mts,cts}` // TODO: remove, only scan top-level plugins #18418
+          `${pluginDir}/*.{ts,js,mjs,cjs,mts,cts,jsx,tsx}`,
+          `${pluginDir}/*/index.*{ts,js,mjs,cjs,mts,cts,jsx,tsx}` // TODO: remove, only scan top-level plugins #18418
         ])
         : []
     ].map(plugin => normalizePlugin(plugin as NuxtPlugin)))

--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -150,8 +150,8 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
       ...(config.plugins || []),
       ...config.srcDir
         ? await resolveFiles(config.srcDir, [
-          `${pluginDir}/*.{ts,js,mjs,cjs,mts,cts,jsx,tsx}`,
-          `${pluginDir}/*/index.*{ts,js,mjs,cjs,mts,cts,jsx,tsx}` // TODO: remove, only scan top-level plugins #18418
+          `${pluginDir}/*{${nuxt.options.extensions.join(',')}}`,
+          `${pluginDir}/*/index{${nuxt.options.extensions.join(',')}}` // TODO: remove, only scan top-level plugins #18418
         ])
         : []
     ].map(plugin => normalizePlugin(plugin as NuxtPlugin)))

--- a/packages/nuxt/src/core/plugins/plugin-metadata.ts
+++ b/packages/nuxt/src/core/plugins/plugin-metadata.ts
@@ -47,7 +47,7 @@ export async function extractMetadata (code: string) {
   if (metaCache[code]) {
     return metaCache[code]
   }
-  const js = await transform(code, { loader: 'ts' })
+  const js = await transform(code, { loader: 'tsx' })
   walk(parse(js.code, {
     sourceType: 'module',
     ecmaVersion: 'latest'

--- a/packages/nuxt/test/plugin-metadata.test.ts
+++ b/packages/nuxt/test/plugin-metadata.test.ts
@@ -10,8 +10,7 @@ describe('plugin-metadata', () => {
       name: 'test',
       enforce: 'post',
       hooks: { 'app:mounted': () => {} },
-      // @ts-expect-error JSX not configured in workspace
-      setup: () => { return { provide: { jsx: () => <span>JSX</span> } } },
+      setup: () => { return { provide: { jsx: '[JSX]' } } },
       order: 1
     })
 
@@ -20,7 +19,7 @@ describe('plugin-metadata', () => {
 
       const meta = await extractMetadata([
         'export default defineNuxtPlugin({',
-        ...obj.map(([key, value]) => `${key}: ${typeof value === 'function' ? value.toString() : JSON.stringify(value)},`),
+        ...obj.map(([key, value]) => `${key}: ${typeof value === 'function' ? value.toString().replace('"[JSX]"', '() => <span>JSX</span>') : JSON.stringify(value)},`),
         '})'
       ].join('\n'))
 

--- a/packages/nuxt/test/plugin-metadata.test.ts
+++ b/packages/nuxt/test/plugin-metadata.test.ts
@@ -9,8 +9,8 @@ describe('plugin-metadata', () => {
     const properties = Object.entries({
       name: 'test',
       enforce: 'post',
-      hooks: { 'app:mounted': () => {} },
-      setup: () => {},
+      hooks: { 'app:mounted': () => { } },
+      setup: () => { return { provide: { jsx: '[JSX]' } } },
       order: 1
     })
 
@@ -19,7 +19,7 @@ describe('plugin-metadata', () => {
 
       const meta = await extractMetadata([
         'export default defineNuxtPlugin({',
-        ...obj.map(([key, value]) => `${key}: ${typeof value === 'function' ? value.toString() : JSON.stringify(value)},`),
+        ...obj.map(([key, value]) => `${key}: ${typeof value === 'function' ? value.toString().replace('"[JSX]"', '() => <span>JSX</span>') : JSON.stringify(value)},`),
         '})'
       ].join('\n'))
 

--- a/packages/nuxt/test/plugin-metadata.test.tsx
+++ b/packages/nuxt/test/plugin-metadata.test.tsx
@@ -10,7 +10,8 @@ describe('plugin-metadata', () => {
       name: 'test',
       enforce: 'post',
       hooks: { 'app:mounted': () => { } },
-      setup: () => { return { provide: { jsx: '[JSX]' } } },
+      // @ts-expect-error JSX not configured in workspace
+      setup: () => { return { provide: { jsx: () => <span>JSX</span> } } },
       order: 1
     })
 
@@ -19,7 +20,7 @@ describe('plugin-metadata', () => {
 
       const meta = await extractMetadata([
         'export default defineNuxtPlugin({',
-        ...obj.map(([key, value]) => `${key}: ${typeof value === 'function' ? value.toString().replace('"[JSX]"', '() => <span>JSX</span>') : JSON.stringify(value)},`),
+        ...obj.map(([key, value]) => `${key}: ${typeof value === 'function' ? value.toString() : JSON.stringify(value)},`),
         '})'
       ].join('\n'))
 

--- a/packages/nuxt/test/plugin-metadata.test.tsx
+++ b/packages/nuxt/test/plugin-metadata.test.tsx
@@ -9,7 +9,7 @@ describe('plugin-metadata', () => {
     const properties = Object.entries({
       name: 'test',
       enforce: 'post',
-      hooks: { 'app:mounted': () => { } },
+      hooks: { 'app:mounted': () => {} },
       // @ts-expect-error JSX not configured in workspace
       setup: () => { return { provide: { jsx: () => <span>JSX</span> } } },
       order: 1


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

This PR adds `.jsx` and `.tsx` to the list of extensions that are automatically resolved in the `plugins` directory. 

Additionally, in order to avoid the meta data analysis from throwing an error (and therefore a `WARN  Failed to parse static properties from plugin xxxxx`), I switched the esbuild transform loader from `ts` to `tsx`.

The plugin metadata test has been updated in a not-very-elegant way, but I though it was better than changing the test to `.tsx` "just" for 3 words.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
