### PR TITLE
docs: removed additional variable at 7.state-management.md

### DIFF
--- a/docs/1.getting-started/7.state-management.md
+++ b/docs/1.getting-started/7.state-management.md
@@ -192,7 +192,6 @@ const date = useLocaleDate(new Date('2016-10-26'))
 By using [auto-imported composables](/docs/guide/directory-structure/composables) we can define global type-safe states and import them across the app.
 
 ```ts twoslash [composables/states.ts]
-export const useCounter = () => useState<number>('counter', () => 0)
 export const useColor = () => useState<string>('color', () => 'pink')
 ```
 


### PR DESCRIPTION
- Removed additional example variable

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
In [Shared State](https://nuxt.com/docs/getting-started/state-management#shared-state) section, only ```useColor``` is being used in relevant example. ```useCounter``` is additional for document reader, which will increase reading time.
 
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
