### PR TITLE
fix(nuxt): don't generate separate chunk for stubs

### DIFF
--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -364,6 +364,7 @@ export default defineNuxtModule({
           const rule = nitro.options.routeRules[path]
           if (!rule.redirect) { continue }
           routes.push({
+            _sync: true,
             path: path.replace(/\/[^/]*\*\*/, '/:pathMatch(.*)'),
             file: resolve(runtimeDir, 'component-stub')
           })

--- a/packages/schema/src/types/hooks.ts
+++ b/packages/schema/src/types/hooks.ts
@@ -44,6 +44,8 @@ export type NuxtPage = {
    * @default 'all'
    */
   mode?: 'client' | 'server' | 'all'
+  /** @internal */
+  _sync?: boolean
 }
 
 export type NuxtMiddleware = {


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The dynamic import of the stub page is an extra (tiny) file we can remove entirely.

Discovered here: https://github.com/nuxt/nuxt.new/pull/168 in https://github.com/nuxt/nuxt.new/actions/runs/8303502245/job/22727724314?pr=168.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
