### PR TITLE
docs: fix code block formatting for `usePreviewMode`

### DIFF
--- a/docs/3.api/2.composables/use-preview-mode.md
+++ b/docs/3.api/2.composables/use-preview-mode.md
@@ -41,7 +41,7 @@ const { enabled, state } = usePreviewMode({
 })
 ```
 
-::note{icon=👉}
+::note
 The `getState` function will append returned values to current state, so be careful not to accidentally overwrite important state.
 ::
 

--- a/docs/3.api/2.composables/use-preview-mode.md
+++ b/docs/3.api/2.composables/use-preview-mode.md
@@ -41,7 +41,7 @@ const { enabled, state } = usePreviewMode({
 })
 ```
 
-::alert{icon=👉}
+::note{icon=👉}
 The `getState` function will append returned values to current state, so be careful not to accidentally overwrite important state.
 ::
 

--- a/docs/3.api/2.composables/use-preview-mode.md
+++ b/docs/3.api/2.composables/use-preview-mode.md
@@ -24,7 +24,8 @@ export function useMyPreviewMode () {
       return !!route.query.customPreview
     }
   });
-}```
+}
+```
 
 ### Modify default state
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

N/A

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently on https://nuxt.com/docs/api/composables/use-preview-mode the code snippet is broken because badly formatted. This PR fixes this minor issue

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
