### PR TITLE
docs: fix usePreviewMode code and note

### DIFF
--- a/docs/3.api/2.composables/use-preview-mode.md
+++ b/docs/3.api/2.composables/use-preview-mode.md
@@ -24,7 +24,8 @@ export function useMyPreviewMode () {
       return !!route.query.customPreview
     }
   });
-}```
+}
+```
 
 ### Modify default state
 
@@ -40,7 +41,7 @@ const { enabled, state } = usePreviewMode({
 })
 ```
 
-::alert{icon=👉}
+::note
 The `getState` function will append returned values to current state, so be careful not to accidentally overwrite important state.
 ::
 


### PR DESCRIPTION
### 🔗 Linked issue

none

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

correctly closes code block and uses new `note` block, as it currently looks a bit weird...

![image](https://github.com/nuxt/nuxt/assets/56201308/ab75492f-f305-4b66-a282-718910c278ec)

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
