### PR TITLE
fix(nuxt): conditionally use `tsx` parser

### DIFF
--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -204,13 +204,15 @@ function resolvePaths<Item extends Record<string, any>> (items: Item[], key: { [
   }))
 }
 
+const IS_TSX = /\.[jt]sx$/
+
 export async function annotatePlugins (nuxt: Nuxt, plugins: NuxtPlugin[]) {
   const _plugins: Array<NuxtPlugin & Omit<PluginMeta, 'enforce'>> = []
   for (const plugin of plugins) {
     try {
       const code = plugin.src in nuxt.vfs ? nuxt.vfs[plugin.src] : await fsp.readFile(plugin.src!, 'utf-8')
       _plugins.push({
-        ...await extractMetadata(code),
+        ...await extractMetadata(code, IS_TSX.test(plugin.src) ? 'tsx' : 'ts'),
         ...plugin
       })
     } catch (e) {

--- a/packages/nuxt/src/core/plugins/plugin-metadata.ts
+++ b/packages/nuxt/src/core/plugins/plugin-metadata.ts
@@ -42,12 +42,12 @@ export const orderMap: Record<NonNullable<ObjectPlugin['enforce']>, number> = {
 }
 
 const metaCache: Record<string, Omit<PluginMeta, 'enforce'>> = {}
-export async function extractMetadata (code: string) {
+export async function extractMetadata (code: string, loader = 'ts' as 'ts' | 'tsx') {
   let meta: PluginMeta = {}
   if (metaCache[code]) {
     return metaCache[code]
   }
-  const js = await transform(code, { loader: 'tsx' })
+  const js = await transform(code, { loader })
   walk(parse(js.code, {
     sourceType: 'module',
     ecmaVersion: 'latest'

--- a/packages/nuxt/test/plugin-metadata.test.ts
+++ b/packages/nuxt/test/plugin-metadata.test.ts
@@ -21,7 +21,7 @@ describe('plugin-metadata', () => {
         'export default defineNuxtPlugin({',
         ...obj.map(([key, value]) => `${key}: ${typeof value === 'function' ? value.toString().replace('"[JSX]"', '() => <span>JSX</span>') : JSON.stringify(value)},`),
         '})'
-      ].join('\n'))
+      ].join('\n'), 'tsx')
 
       expect(meta).toMatchInlineSnapshot(`
         {


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/26310

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This avoids using tsx parser unless file path matches tsx/jsx.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
