### PR TITLE
fix(nuxt): useId() causing hydration-error when using value multiple times

### DIFF
--- a/packages/nuxt/src/app/composables/id.ts
+++ b/packages/nuxt/src/app/composables/id.ts
@@ -54,5 +54,5 @@ export function useId (key?: string): string {
   }
 
   // pure client-side ids, avoiding potential collision with server-side ids
-  return key + '_' + nuxtApp._id++
+  return key + SEPARATOR + nuxtApp._id++
 }


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When using the value of `useId()` multiple times a hydration-error happens.

```vue
<script setup lang="ts">
const id = useId()
</script>

<template>
  <div :id="id">
    text
  </div>
  <div :id="id">
    text
  </div>
</template>
```

```
warn [Vue warn]: Hydration text content mismatch on 
<div id="id" data-v-inspector="playground/app.vue:6:3"> 
  - rendered on server: nE3KxD8SGyR-0
  - expected on client: nE3KxD8SGyR_0 
  at <App key=3 > 
  at <NuxtRoot>
```

this only occurs when using the ID multiple times.
working example:

```vue
<script setup lang="ts">
const id = useId()
</script>

<template>
  <div :id="id">
    text
  </div>
</template>
```

note:
I do not really understand the code so there might be a reason why a different separator is used.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
