### PR TITLE
fix(nuxt): prevent losing pages routes on prerender

### DIFF
--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -293,8 +293,8 @@ export default defineNuxtModule({
             if (route === '/') { continue }
             prerenderRoutes.add(route)
           }
-          nitro.options.prerender.routes = Array.from(prerenderRoutes)
         }
+        nitro.options.prerender.routes = Array.from(prerenderRoutes)
       })
     })
 


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I have a static site with several normal pages + a few thousand dynamic ones which are prerendered by inserting their routes in nitro `prerender:routes` hook like that:

```js
"prerender:routes"(routes) {
    const pages = getPages();
    if (pages.length) {
      for (const route of pages) {
        routes.add(route);
      }
    }
  },
```

After updating to Nuxt 3.11.0, I noticed an unexpected change in the generated build where all static pages, except for index.html, were missing, though all dynamic pages were still present. Upon investigation, it appeared that the `routes` parameter, which previously contained all static routes (`Set(63) { '/about', '/uk/about', ...}`) in Nuxt 3.10, was reduced to only `Set(1) { '/' }` in Nuxt 3.11.0.

This issue seems to stem from the changes made in https://github.com/nuxt/nuxt/commit/ff1bb56e3f90472ff7aae69b214e21197c78400b, and this PR addresses the problem.

P.S. This is my first contribution to this project. I was unsure whether a separate issue should be created for this trivial fix. Apologies if this was an oversight.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
