### PR TITLE
fix(vite): don't fall back to `importedModules` if ssr result exists

### DIFF
--- a/packages/vite/src/utils/warmup.ts
+++ b/packages/vite/src/utils/warmup.ts
@@ -63,7 +63,7 @@ export async function warmupViteServer (
 
     try {
       const mod = await server.moduleGraph.getModuleByUrl(url, isServer)
-      const deps = mod?.ssrTransformResult?.deps /* server */ || mod?.importedModules.size ? Array.from(mod?.importedModules /* client */).map(m => m.url) : []
+      const deps = mod?.ssrTransformResult?.deps /* server */ || (mod?.importedModules.size ? Array.from(mod?.importedModules /* client */).map(m => m.url) : [])
       await Promise.all(deps.map(m => warmup(m)))
     } catch (e) {
       logger.debug('[warmup] tracking dependencies for %s failed with: %s', url, e)


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/26312

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

A regression from https://github.com/nuxt/nuxt/pull/25647. This ensures we don't fall back to `importedModules` when `ssrTransformResult` exists.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
