### PR TITLE
fix(nuxt): pass `undefined` name when resolving trailing slash

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -113,12 +113,8 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
 
     const resolvedPath = {
       ...to,
+      name: undefined, // named routes would otherwise always override trailing slash behavior
       path: applyTrailingSlashBehavior(path, options.trailingSlash)
-    }
-
-    // named routes would otherwise always override trailing slash behavior
-    if ('name' in resolvedPath) {
-      delete resolvedPath.name
     }
 
     return resolvedPath


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/26357

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

A regression introduced in https://github.com/nuxt/nuxt/commit/ba6a4132b in an effort to fix a type issue, this PR reverts back to previous behaviour of passing an explicit `undefined` name.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
