### PR TITLE
fix(nuxt): don't append new route for redirect if one exists

### DIFF
--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -12,7 +12,7 @@ import type { EditableTreeNode, Options as TypedRouterOptions } from 'unplugin-v
 import type { NitroRouteConfig } from 'nitropack'
 import { defu } from 'defu'
 import { distDir } from '../dirs'
-import { normalizeRoutes, resolvePagesRoutes } from './utils'
+import { normalizeRoutes, resolvePagesRoutes, resolveRoutePaths } from './utils'
 import { extractRouteRules, getMappedPages } from './route-rules'
 import type { PageMetaPluginOptions } from './plugins/page-meta'
 import { PageMetaPlugin } from './plugins/page-meta'
@@ -371,9 +371,13 @@ export default defineNuxtModule({
       // when the app manifest is enabled.
       nuxt.hook('pages:extend', (routes) => {
         const nitro = useNitro()
+        let resolvedRoutes: string[]
         for (const path in nitro.options.routeRules) {
           const rule = nitro.options.routeRules[path]
           if (!rule.redirect) { continue }
+          resolvedRoutes ||= routes.flatMap(route => resolveRoutePaths(route))
+          // skip if there's already a route matching this path
+          if (resolvedRoutes.includes(path)) { continue }
           routes.push({
             _sync: true,
             path: path.replace(/\/[^/]*\*\*/, '/:pathMatch(.*)'),

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -539,3 +539,10 @@ export function pathToNitroGlob (path: string) {
 
   return path.replace(/\/(?:[^:/]+)?:\w+.*$/, '/**')
 }
+
+export function resolveRoutePaths (page: NuxtPage, parent = '/'): string[] {
+  return [
+    joinURL(parent, page.path),
+    ...page.children?.flatMap(child => resolveRoutePaths(child, joinURL(parent, page.path))) || []
+  ]
+}

--- a/test/fixtures/basic-types/nuxt.config.ts
+++ b/test/fixtures/basic-types/nuxt.config.ts
@@ -30,6 +30,11 @@ export default defineNuxtConfig({
       val: 1
     }
   },
+  routeRules: {
+    '/page': {
+      redirect: 'https://nuxt.com'
+    }
+  },
   modules: [
     function () {
       addTypeTemplate({

--- a/test/fixtures/basic-types/nuxt.config.ts
+++ b/test/fixtures/basic-types/nuxt.config.ts
@@ -31,8 +31,8 @@ export default defineNuxtConfig({
     }
   },
   routeRules: {
-    '/page': {
-      redirect: 'https://nuxt.com'
+    '/param': {
+      redirect: '/param/1'
     }
   },
   modules: [

--- a/test/fixtures/basic-types/pages/param.vue
+++ b/test/fixtures/basic-types/pages/param.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    <!--  -->
+  </div>
+</template>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/26363

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Previously we were always adding an additional route when there was a redirect. This wouldn't cause runtime issues but did break generation of typed paths.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
