### PR TITLE
fix(nuxt): handle underscores in island names

### DIFF
--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -214,7 +214,7 @@ async function getIslandContext (event: H3Event): Promise<NuxtIslandContext> {
     url = await islandPropCache!.getItem(event.path) as string
   }
   const componentParts = url.substring('/__nuxt_island'.length + 1).replace(ISLAND_SUFFIX_RE, '').split('_')
-  const hashId = componentParts.length > 1 ? componentParts.pop() : ''
+  const hashId = componentParts.length > 1 ? componentParts.pop() : undefined
   const componentName = componentParts.join('_')
 
   // TODO: Validate context

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -205,8 +205,7 @@ const sharedPrerenderCache = import.meta.prerender && process.env.NUXT_SHARED_DA
     }
   : null
 
-const ISLAND_COMPONENT_RE = /(?<componentName>[^?]*)_(?<hashId>[^_?]+)\.json\?/
-
+const ISLAND_SUFFIX_RE = /\.json(\?.*)?$/
 async function getIslandContext (event: H3Event): Promise<NuxtIslandContext> {
   // TODO: Strict validation for url
   let url = event.path || ''
@@ -214,8 +213,9 @@ async function getIslandContext (event: H3Event): Promise<NuxtIslandContext> {
     // rehydrate props from cache so we can rerender island if cache does not have it any more
     url = await islandPropCache!.getItem(event.path) as string
   }
-  url = url.substring('/__nuxt_island'.length + 1) || ''
-  const { componentName, hashId } = url.match(ISLAND_COMPONENT_RE)?.groups || {}
+  const componentParts = url.substring('/__nuxt_island'.length + 1).replace(ISLAND_SUFFIX_RE, '').split('_')
+  const hashId = componentParts.length > 1 ? componentParts.pop() : ''
+  const componentName = componentParts.join('_')
 
   // TODO: Validate context
   const context = event.method === 'GET' ? getQuery(event) : await readBody(event)

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -205,6 +205,8 @@ const sharedPrerenderCache = import.meta.prerender && process.env.NUXT_SHARED_DA
     }
   : null
 
+const ISLAND_COMPONENT_RE = /(?<componentName>[^?]*)_(?<hashId>[^_?]+)\.json\?/
+
 async function getIslandContext (event: H3Event): Promise<NuxtIslandContext> {
   // TODO: Strict validation for url
   let url = event.path || ''
@@ -213,7 +215,7 @@ async function getIslandContext (event: H3Event): Promise<NuxtIslandContext> {
     url = await islandPropCache!.getItem(event.path) as string
   }
   url = url.substring('/__nuxt_island'.length + 1) || ''
-  const [componentName, hashId] = url.split('?')[0].replace(/\.json$/, '').split('_')
+  const { componentName, hashId } = url.match(ISLAND_COMPONENT_RE)?.groups || {}
 
   // TODO: Validate context
   const context = event.method === 'GET' ? getQuery(event) : await readBody(event)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/26362

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Before we introduced island pages, it was safe to use `_` as a separator for the name + hash in island components. However, that is no longer safe as page names may well use them. This PR updates to use a regular expression rather than string manipulation based on `_`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
