### PR TITLE
fix(nuxt): correctly move v-if from slot to wrapper component

### DIFF
--- a/packages/nuxt/src/components/islandsTransform.ts
+++ b/packages/nuxt/src/components/islandsTransform.ts
@@ -106,7 +106,7 @@ export const islandsTransform = createUnplugin((options: ServerOnlyComponentTran
             s.appendLeft(startingIndex + loc[0].start, `<NuxtTeleportSsrSlot${vIf ? ` v-if="${vIf}"` : ''} name="${slotName}" :props="${bindings}">`)
             // remove v-if from first tag
             if (vIf) {
-              s.overwrite(startingIndex + loc[0].start,  startingIndex + loc[0].end, code.slice( startingIndex + loc[0].start,  startingIndex + loc[0].end).replace(`v-if="${vIf}"`, ''))
+              s.overwrite(startingIndex + loc[0].start, startingIndex + loc[0].end, code.slice(startingIndex + loc[0].start, startingIndex + loc[0].end).replace(`v-if="${vIf}"`, ''))
             }
             s.appendRight(startingIndex + loc[1].end, '</NuxtTeleportSsrSlot>')
           } else if (options.selectiveClient && ('nuxt-client' in node.attributes || ':nuxt-client' in node.attributes)) {

--- a/packages/nuxt/src/components/islandsTransform.ts
+++ b/packages/nuxt/src/components/islandsTransform.ts
@@ -98,10 +98,12 @@ export const islandsTransform = createUnplugin((options: ServerOnlyComponentTran
               attributes._bind = attributes['v-bind']
               delete attributes['v-bind']
             }
+            const vIf = attributes['v-if']
+            delete attributes['v-if']
             const bindings = getPropsToString(attributes, vfor)
 
             // add the wrapper
-            s.appendLeft(startingIndex + loc[0].start, `<NuxtTeleportSsrSlot name="${slotName}" :props="${bindings}">`)
+            s.appendLeft(startingIndex + loc[0].start, `<NuxtTeleportSsrSlot${vIf ? ` v-if="${vIf}"` : ''} name="${slotName}" :props="${bindings}">`)
             s.appendRight(startingIndex + loc[1].end, '</NuxtTeleportSsrSlot>')
           } else if (options.selectiveClient && ('nuxt-client' in node.attributes || ':nuxt-client' in node.attributes)) {
             hasNuxtClient = true

--- a/packages/nuxt/src/components/islandsTransform.ts
+++ b/packages/nuxt/src/components/islandsTransform.ts
@@ -81,9 +81,9 @@ export const islandsTransform = createUnplugin((options: ServerOnlyComponentTran
             const { attributes, children, loc } = node
 
             const slotName = attributes.name ?? 'default'
-            let vfor: [string, string] | undefined
+            let vfor:  string | undefined
             if (attributes['v-for']) {
-              vfor = attributes['v-for'].split(' in ').map((v: string) => v.trim()) as [string, string]
+              vfor = attributes['v-for']
             }
             delete attributes['v-for']
 
@@ -92,7 +92,7 @@ export const islandsTransform = createUnplugin((options: ServerOnlyComponentTran
               attributes._bind = extractAttributes(attributes, ['v-bind'])['v-bind']
             }
             const teleportAttributes = extractAttributes(attributes, ['v-if', 'v-else-if', 'v-else'])
-            const bindings = getPropsToString(attributes, vfor)
+            const bindings = getPropsToString(attributes, vfor?.split(' in ').map((v: string) => v.trim()) as [string, string])
             // add the wrapper
             s.appendLeft(startingIndex + loc[0].start, `<NuxtTeleportSsrSlot${attributeToString(teleportAttributes)} name="${slotName}" :props="${bindings}">`)
 
@@ -100,7 +100,8 @@ export const islandsTransform = createUnplugin((options: ServerOnlyComponentTran
               // pass slot fallback to NuxtTeleportSsrSlot fallback
               const attrString = attributeToString(attributes)
               const slice = code.slice(startingIndex + loc[0].end, startingIndex + loc[1].start).replaceAll(/:?key="[^"]"/g, '')
-              s.overwrite(startingIndex + loc[0].start, startingIndex + loc[1].end, `<slot${attrString.replaceAll(EXTRACTED_ATTRS_RE, '')}/><template #fallback>${attributes['v-for'] ? wrapWithVForDiv(slice, attributes['v-for']) : slice}</template>`)
+              debugger
+              s.overwrite(startingIndex + loc[0].start, startingIndex + loc[1].end, `<slot${attrString.replaceAll(EXTRACTED_ATTRS_RE, '')}/><template #fallback>${vfor ? wrapWithVForDiv(slice, vfor) : slice}</template>`)
             } else {
               s.overwrite(startingIndex + loc[0].start, startingIndex + loc[0].end, code.slice(startingIndex + loc[0].start, startingIndex + loc[0].end).replaceAll(EXTRACTED_ATTRS_RE, ''))
             }

--- a/packages/nuxt/src/components/islandsTransform.ts
+++ b/packages/nuxt/src/components/islandsTransform.ts
@@ -81,7 +81,7 @@ export const islandsTransform = createUnplugin((options: ServerOnlyComponentTran
             const { attributes, children, loc } = node
 
             const slotName = attributes.name ?? 'default'
-            let vfor:  string | undefined
+            let vfor: string | undefined
             if (attributes['v-for']) {
               vfor = attributes['v-for']
             }
@@ -100,7 +100,6 @@ export const islandsTransform = createUnplugin((options: ServerOnlyComponentTran
               // pass slot fallback to NuxtTeleportSsrSlot fallback
               const attrString = attributeToString(attributes)
               const slice = code.slice(startingIndex + loc[0].end, startingIndex + loc[1].start).replaceAll(/:?key="[^"]"/g, '')
-              debugger
               s.overwrite(startingIndex + loc[0].start, startingIndex + loc[1].end, `<slot${attrString.replaceAll(EXTRACTED_ATTRS_RE, '')}/><template #fallback>${vfor ? wrapWithVForDiv(slice, vfor) : slice}</template>`)
             } else {
               s.overwrite(startingIndex + loc[0].start, startingIndex + loc[0].end, code.slice(startingIndex + loc[0].start, startingIndex + loc[0].end).replaceAll(EXTRACTED_ATTRS_RE, ''))

--- a/packages/nuxt/src/components/islandsTransform.ts
+++ b/packages/nuxt/src/components/islandsTransform.ts
@@ -149,7 +149,7 @@ function extractAttributes (attributes: Record<string, string>, names: string[])
   return extracted
 }
 
-function attributeToString(attributes: Record<string, string>) {
+function attributeToString (attributes: Record<string, string>) {
   return Object.entries(attributes).map(([name, value]) => value ? ` ${name}="${value}"` : ` ${name}`).join('')
 }
 

--- a/packages/nuxt/src/components/islandsTransform.ts
+++ b/packages/nuxt/src/components/islandsTransform.ts
@@ -95,7 +95,7 @@ export const islandsTransform = createUnplugin((options: ServerOnlyComponentTran
             const bindings = getPropsToString(attributes, vfor)
             // add the wrapper
             s.appendLeft(startingIndex + loc[0].start, `<NuxtTeleportSsrSlot${attributeToString(teleportAttributes)} name="${slotName}" :props="${bindings}">`)
-            
+
             if (children.length) {
               // pass slot fallback to NuxtTeleportSsrSlot fallback
               const attrString = attributeToString(attributes)
@@ -138,7 +138,7 @@ export const islandsTransform = createUnplugin((options: ServerOnlyComponentTran
 /**
  * extract attributes from a node
  */
-function extractAttributes(attributes: Record<string, string>, names: string[]) {
+function extractAttributes (attributes: Record<string, string>, names: string[]) {
   const extracted:Record<string, string> = {}
   for (const name of names) {
     if (name in attributes) {
@@ -149,7 +149,7 @@ function extractAttributes(attributes: Record<string, string>, names: string[]) 
   return extracted
 }
 
-function attributeToString(attributes: Record<string, string>) {
+function attributeToString (attributes: Record<string, string>) {
   return Object.entries(attributes).map(([name, value]) => value ? ` ${name}="${value}"` : ` ${name}`).join()
 }
 

--- a/packages/nuxt/src/components/islandsTransform.ts
+++ b/packages/nuxt/src/components/islandsTransform.ts
@@ -150,7 +150,7 @@ function extractAttributes(attributes: Record<string, string>, names: string[]) 
 }
 
 function attributeToString(attributes: Record<string, string>) {
-  return Object.entries(attributes).map(([name, value]) => value ? ` ${name}="${value}"` : ` ${name}`).join()
+  return Object.entries(attributes).map(([name, value]) => value ? ` ${name}="${value}"` : ` ${name}`).join('')
 }
 
 function isBinding (attr: string): boolean {

--- a/packages/nuxt/src/components/islandsTransform.ts
+++ b/packages/nuxt/src/components/islandsTransform.ts
@@ -104,6 +104,10 @@ export const islandsTransform = createUnplugin((options: ServerOnlyComponentTran
 
             // add the wrapper
             s.appendLeft(startingIndex + loc[0].start, `<NuxtTeleportSsrSlot${vIf ? ` v-if="${vIf}"` : ''} name="${slotName}" :props="${bindings}">`)
+            // remove v-if from first tag
+            if (vIf) {
+              s.overwrite(startingIndex + loc[0].start,  startingIndex + loc[0].end, code.slice( startingIndex + loc[0].start,  startingIndex + loc[0].end).replace(`v-if="${vIf}"`, ''))
+            }
             s.appendRight(startingIndex + loc[1].end, '</NuxtTeleportSsrSlot>')
           } else if (options.selectiveClient && ('nuxt-client' in node.attributes || ':nuxt-client' in node.attributes)) {
             hasNuxtClient = true

--- a/packages/nuxt/src/components/islandsTransform.ts
+++ b/packages/nuxt/src/components/islandsTransform.ts
@@ -159,7 +159,7 @@ function isBinding (attr: string): boolean {
 
 function getPropsToString (bindings: Record<string, string>, vfor?: [string, string]): string {
   if (Object.keys(bindings).length === 0) { return 'undefined' }
-  const content = Object.entries(bindings).filter(b => b[0] && b[0] !== '_bind').map(([name, value]) => isBinding(name) ? `${name.slice(1)}: ${value}` : `${name}: \`${value}\``).join(',')
+  const content = Object.entries(bindings).filter(b => b[0] && b[0] !== '_bind').map(([name, value]) => isBinding(name) ? `[\`${name.slice(1)}\`]: ${value}` : `[\`${name}\`]: \`${value}\``).join(',')
   const data = bindings._bind ? `mergeProps(${bindings._bind}, { ${content} })` : `{ ${content} }`
   if (!vfor) {
     return `[${data}]`

--- a/packages/nuxt/test/islandTransform.test.ts
+++ b/packages/nuxt/test/islandTransform.test.ts
@@ -65,8 +65,8 @@ describe('islandTransform - server and island components', () => {
               <div>
                 <NuxtTeleportSsrSlot name="default" :props="undefined"><slot /></NuxtTeleportSsrSlot>
 
-                <NuxtTeleportSsrSlot name="named" :props="[{ some-data: someData }]"><slot name="named" :some-data="someData" /></NuxtTeleportSsrSlot>
-                <NuxtTeleportSsrSlot name="other" :props="[{ some-data: someData }]"><slot
+                <NuxtTeleportSsrSlot name="named" :props="[{ [\`some-data\`]: someData }]"><slot name="named" :some-data="someData" /></NuxtTeleportSsrSlot>
+                <NuxtTeleportSsrSlot name="other" :props="[{ [\`some-data\`]: someData }]"><slot
                   name="other"
                   :some-data="someData"
                 /></NuxtTeleportSsrSlot>
@@ -99,7 +99,7 @@ describe('islandTransform - server and island components', () => {
       expect(normalizeLineEndings(result)).toMatchInlineSnapshot(`
         "<template>
               <div>
-                <NuxtTeleportSsrSlot name="default" :props="[{ some-data: someData }]"><slot :some-data="someData"/><template #fallback>
+                <NuxtTeleportSsrSlot name="default" :props="[{ [\`some-data\`]: someData }]"><slot :some-data="someData"/><template #fallback>
                   <div>fallback</div>
                 </template></NuxtTeleportSsrSlot>
               </div>

--- a/packages/nuxt/test/islandTransform.test.ts
+++ b/packages/nuxt/test/islandTransform.test.ts
@@ -183,6 +183,29 @@ describe('islandTransform - server and island components', () => {
             "
       `)
     })
+
+    it('expect v-if to be set in teleport component wrapper', async () => {
+      const result = await viteTransform(`<script setup lang="ts">
+      const foo = true;
+      </script>
+      <template>
+        <slot v-if="foo" />
+      </template>
+      `, 'WithVif.vue', false, true)
+
+      expect(normalizeLineEndings(result)).toMatchInlineSnapshot(`
+        "<script setup lang="ts">
+        import { vforToArray as __vforToArray } from '#app/components/utils'
+        import NuxtTeleportIslandComponent from '#app/components/nuxt-teleport-island-component'
+        import NuxtTeleportSsrSlot from '#app/components/nuxt-teleport-island-slot'
+              const foo = true;
+              </script>
+              <template>
+                <NuxtTeleportSsrSlot v-if="foo" name="default" :props="undefined"><slot v-if="foo" /></NuxtTeleportSsrSlot>
+              </template>
+              "
+      `)
+    })
   })
 
   describe('nuxt-client', () => {

--- a/packages/nuxt/test/islandTransform.test.ts
+++ b/packages/nuxt/test/islandTransform.test.ts
@@ -201,7 +201,7 @@ describe('islandTransform - server and island components', () => {
               const foo = true;
               </script>
               <template>
-                <NuxtTeleportSsrSlot v-if="foo" name="default" :props="undefined"><slot v-if="foo" /></NuxtTeleportSsrSlot>
+                <NuxtTeleportSsrSlot v-if="foo" name="default" :props="undefined"><slot  /></NuxtTeleportSsrSlot>
               </template>
               "
       `)

--- a/packages/nuxt/test/islandTransform.test.ts
+++ b/packages/nuxt/test/islandTransform.test.ts
@@ -99,7 +99,7 @@ describe('islandTransform - server and island components', () => {
       expect(normalizeLineEndings(result)).toMatchInlineSnapshot(`
         "<template>
               <div>
-                <NuxtTeleportSsrSlot name="default" :props="[{ some-data: someData }]"><slot :some-data="someData"  /><template #fallback>
+                <NuxtTeleportSsrSlot name="default" :props="[{ some-data: someData }]"><slot :some-data="someData"/><template #fallback>
                   <div>fallback</div>
                 </template></NuxtTeleportSsrSlot>
               </div>
@@ -158,7 +158,7 @@ describe('islandTransform - server and island components', () => {
                     <p>message: {{ message }}</p>
                     <p>Below is the slot I want to be hydrated on the client</p>
                     <div>
-                      <NuxtTeleportSsrSlot name="default" :props="undefined"><slot  /><template #fallback>
+                      <NuxtTeleportSsrSlot name="default" :props="undefined"><slot/><template #fallback>
                         This is the default content of the slot, I should not see this after
                         the client loading has completed.
                       </template></NuxtTeleportSsrSlot>
@@ -184,12 +184,14 @@ describe('islandTransform - server and island components', () => {
       `)
     })
 
-    it('expect v-if to be set in teleport component wrapper', async () => {
+    it('expect v-if/v-else/v-else-if to be set in teleport component wrapper', async () => {
       const result = await viteTransform(`<script setup lang="ts">
       const foo = true;
       </script>
       <template>
-        <slot v-if="foo" />
+      <slot v-if="foo" />
+      <slot v-else-if="test" />
+      <slot v-else />
       </template>
       `, 'WithVif.vue', false, true)
 
@@ -201,7 +203,9 @@ describe('islandTransform - server and island components', () => {
               const foo = true;
               </script>
               <template>
-                <NuxtTeleportSsrSlot v-if="foo" name="default" :props="undefined"><slot  /></NuxtTeleportSsrSlot>
+              <NuxtTeleportSsrSlot v-if="foo" name="default" :props="undefined"><slot  /></NuxtTeleportSsrSlot>
+              <NuxtTeleportSsrSlot v-else-if="test" name="default" :props="undefined"><slot  /></NuxtTeleportSsrSlot>
+              <NuxtTeleportSsrSlot v-else name="default" :props="undefined"><slot  /></NuxtTeleportSsrSlot>
               </template>
               "
       `)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

fix #26361 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Hi :wave: this fix a bug where v-if are not correctly moved from the slot to the wrapper component

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
