### PR TITLE
fix(nuxt): ignore `navigateTo` `open` option on server side

### DIFF
--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -135,9 +135,8 @@ export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: Na
         .join(', ')
 
       open(toPath, target, features)
+      return Promise.resolve()
     }
-
-    return Promise.resolve()
   }
 
   const isExternal = options?.external || hasProtocol(toPath, { acceptRelative: true })


### PR DESCRIPTION
### 🔗 Linked issue

resolves #26390 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR should actually ignore if the `open` option is set on the server-side rather than silently skipping the navigation request.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
