### PR TITLE
perf(nuxt): don't tree-shake `useServerHead` in dev

### DIFF
--- a/packages/nuxt/src/head/module.ts
+++ b/packages/nuxt/src/head/module.ts
@@ -1,5 +1,6 @@
 import { resolve } from 'pathe'
 import { addComponent, addImportsSources, addPlugin, addTemplate, defineNuxtModule, tryResolveModule } from '@nuxt/kit'
+import { defu } from 'defu'
 import { distDir } from '../dirs'
 
 const components = ['NoScript', 'Link', 'Base', 'Title', 'Meta', 'Style', 'Head', 'Html', 'Body']
@@ -29,9 +30,11 @@ export default defineNuxtModule({
     }
 
     // allow @unhead/vue server composables to be tree-shaken from the client bundle
-    nuxt.options.optimization.treeShake.composables.client['@unhead/vue'] = [
-      'useServerHead', 'useServerSeoMeta', 'useServerHeadSafe'
-    ]
+    if (!nuxt.options.dev) {
+      nuxt.options.optimization.treeShake.composables.client['@unhead/vue'] = defu(nuxt.options.optimization.treeShake.composables.client['@unhead/vue'], [
+        'useServerHead', 'useServerSeoMeta', 'useServerHeadSafe'
+      ])
+    }
 
     addImportsSources({
       from: '@unhead/vue',

--- a/packages/nuxt/src/head/module.ts
+++ b/packages/nuxt/src/head/module.ts
@@ -31,9 +31,9 @@ export default defineNuxtModule({
 
     // allow @unhead/vue server composables to be tree-shaken from the client bundle
     if (!nuxt.options.dev) {
-      nuxt.options.optimization.treeShake.composables.client['@unhead/vue'] = defu(nuxt.options.optimization.treeShake.composables.client['@unhead/vue'], [
+      nuxt.options.optimization.treeShake.composables.client['@unhead/vue'] = [
         'useServerHead', 'useServerSeoMeta', 'useServerHeadSafe'
-      ])
+      ]
     }
 
     addImportsSources({

--- a/packages/nuxt/src/head/module.ts
+++ b/packages/nuxt/src/head/module.ts
@@ -1,6 +1,5 @@
 import { resolve } from 'pathe'
 import { addComponent, addImportsSources, addPlugin, addTemplate, defineNuxtModule, tryResolveModule } from '@nuxt/kit'
-import { defu } from 'defu'
 import { distDir } from '../dirs'
 
 const components = ['NoScript', 'Link', 'Base', 'Title', 'Meta', 'Style', 'Head', 'Html', 'Body']


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Spotted this opportunity to improve performance - we deliberately do not tree-shake any other composables in dev mode, but weren't checking before inserting `useServerHead`.

This should mean we don't need to run that vite plugin at all and it won't be initialised:

https://github.com/nuxt/nuxt/blob/3c7e68c84637d3aca9273921f8176e87e8423696/packages/nuxt/src/core/nuxt.ts#L187-L190

cc: @harlan-zw in case there's a reason we should tree-shake it in dev mode

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
