### PR TITLE
fix(nuxt): don't warn about `definePageMeta` in server pages

### DIFF
--- a/packages/nuxt/src/pages/runtime/composables.ts
+++ b/packages/nuxt/src/pages/runtime/composables.ts
@@ -3,6 +3,7 @@ import { getCurrentInstance } from 'vue'
 import type { RouteLocationNormalized, RouteLocationNormalizedLoaded, RouteRecordRedirectOption } from '#vue-router'
 import { useRoute } from 'vue-router'
 import type { NitroRouteConfig } from 'nitropack'
+import { useNuxtApp } from '#app/nuxt'
 import type { NuxtError } from '#app'
 
 export interface PageMeta {
@@ -58,8 +59,9 @@ export const definePageMeta = (meta: PageMeta): void => {
     const component = getCurrentInstance()?.type
     try {
       const isRouteComponent = component && useRoute().matched.some(p => Object.values(p.components || {}).includes(component))
-      if (isRouteComponent) {
-        // don't warn if it's being used in a route component
+      const isRenderingServerPage = import.meta.server && useNuxtApp().ssrContext?.islandContext
+      if (isRouteComponent || isRenderingServerPage) {
+        // don't warn if it's being used in a route component (or server page)
         return
       }
     } catch {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

closes https://github.com/nuxt/nuxt/pull/26388
resolves https://github.com/nuxt/nuxt/issues/26377

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This is a DX fix - we don't tree-shake `definePageMeta` in dev mode, but instead suppress warning if it's a page file. We hadn't updated this logic for server pages.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
