### PR TITLE
fix(nuxt): ignore fetch errors in `getLatestManifest`

### DIFF
--- a/packages/nuxt/src/app/plugins/check-outdated-build.client.ts
+++ b/packages/nuxt/src/app/plugins/check-outdated-build.client.ts
@@ -14,10 +14,14 @@ export default defineNuxtPlugin((nuxtApp) => {
     const currentManifest = await getAppManifest()
     if (timeout) { clearTimeout(timeout) }
     timeout = setTimeout(getLatestManifest, 1000 * 60 * 60)
-    const meta = await $fetch<NuxtAppManifestMeta>(buildAssetsURL('builds/latest.json') + `?${Date.now()}`)
-    if (meta.id !== currentManifest.id) {
-      // There is a newer build which we will let the user handle
-      nuxtApp.hooks.callHook('app:manifest:update', meta)
+    try {
+      const meta = await $fetch<NuxtAppManifestMeta>(buildAssetsURL('builds/latest.json') + `?${Date.now()}`)
+      if (meta.id !== currentManifest.id) {
+        // There is a newer build which we will let the user handle
+        nuxtApp.hooks.callHook('app:manifest:update', meta)
+      }
+    } catch {
+      // fail gracefully on network issue
     }
   }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fix for: 
Unhandled TypeError from production app: `Failed to fetch` in `getLatestManifest`
https://github.com/nuxt/nuxt/blob/main/packages/nuxt/src/app/plugins/check-outdated-build.client.ts#L17

In my opinion, this error should be ignored (fetch failed due to probably a network problem). The update will be detected during the next check.


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
