### PR TITLE
fix(vite): let rollup know that public assets are handled as externals

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -47,6 +47,7 @@
     "externality": "^1.0.2",
     "fs-extra": "^11.2.0",
     "get-port-please": "^3.1.2",
+    "globby": "^14.0.1",
     "h3": "^1.11.1",
     "knitwork": "^1.0.0",
     "magic-string": "^0.30.8",

--- a/packages/vite/src/plugins/public-dirs.ts
+++ b/packages/vite/src/plugins/public-dirs.ts
@@ -1,10 +1,31 @@
 import { existsSync } from 'node:fs'
-import { useNitro } from '@nuxt/kit'
+import { useNitro, useNuxt } from '@nuxt/kit'
 import { createUnplugin } from 'unplugin'
-import { withLeadingSlash, withTrailingSlash } from 'ufo'
+import { joinURL, withLeadingSlash, withTrailingSlash } from 'ufo'
 import { dirname, relative } from 'pathe'
+import { globby } from 'globby'
 
 const PREFIX = 'virtual:public?'
+
+export async function listPublicAssets () {
+  const nitro = useNitro()
+  const nuxt = useNuxt()
+  const publicFiles = new Set<string>()
+  for (const dir of nitro.options.publicAssets) {
+    const files = await globby('**/*', {
+      cwd: dir.dir,
+      absolute: false,
+      ignore: [
+        ...nuxt.options.ignore,
+        'node_modules'
+      ]
+    })
+    for (const file of files) {
+      publicFiles.add(joinURL(dir.baseURL || '/', file))
+    }
+  }
+  return [...publicFiles]
+}
 
 export const VitePublicDirsPlugin = createUnplugin(() => {
   const nitro = useNitro()

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -17,7 +17,7 @@ import { resolveCSSOptions } from './css'
 import { composableKeysPlugin } from './plugins/composable-keys'
 import { logLevelMap } from './utils/logger'
 import { ssrStylesPlugin } from './plugins/ssr-styles'
-import { VitePublicDirsPlugin } from './plugins/public-dirs'
+import { VitePublicDirsPlugin, listPublicAssets } from './plugins/public-dirs'
 
 export interface ViteBuildContext {
   nuxt: Nuxt
@@ -83,6 +83,7 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
         build: {
           copyPublicDir: false,
           rollupOptions: {
+            external: nuxt.options.dev ? [] : await listPublicAssets(),
             output: {
               sourcemapIgnoreList: (relativeSourcePath) => {
                 return relativeSourcePath.includes('node_modules') || relativeSourcePath.includes(ctx.nuxt.options.buildDir)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -592,6 +592,9 @@ importers:
       get-port-please:
         specifier: ^3.1.2
         version: 3.1.2
+      globby:
+        specifier: ^14.0.1
+        version: 14.0.1
       h3:
         specifier: ^1.11.1
         version: 1.11.1


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/26379

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This suppresses the warning vite was throwing when using public assets in CSS, by letting rollup know that these assets can be resolved as externals.

We could also consider simply suppressing logs about these particular assets, if you're worried about any negative performance costs.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
