### PR TITLE
fix(nuxt): handle auto-importing named components

### DIFF
--- a/packages/nuxt/test/components-transform.test.ts
+++ b/packages/nuxt/test/components-transform.test.ts
@@ -39,6 +39,10 @@ describe('components:transform', () => {
       "import { createServerComponent } from "/Users/daniel/code/nuxt/nuxt/packages/nuxt/src/components/runtime/server-component"
       export default createServerComponent("Foo")"
     `)
+    expect(await transform('', '/Foo.vue?nuxt_component=server&nuxt_component_name=Foo&nuxt_component_export=Foo')).toMatchInlineSnapshot(`
+      "import { createServerComponent } from "/Users/daniel/code/nuxt/nuxt/packages/nuxt/src/components/runtime/server-component"
+      export const Foo = createServerComponent("Foo")"
+    `)
   })
 
   it('should correctly resolve client-only components', async () => {
@@ -62,6 +66,11 @@ describe('components:transform', () => {
       "import { defineAsyncComponent } from "vue"
       import { createClientOnly } from "#app/components/client-only"
       export default defineAsyncComponent(() => import("/Foo.vue").then(r => createClientOnly(r["default"] || r.default || r)))"
+    `)
+    expect(await transform('', '/Foo.vue?nuxt_component=client,async&nuxt_component_name=Foo&nuxt_component_export=Foo')).toMatchInlineSnapshot(`
+      "import { defineAsyncComponent } from "vue"
+      import { createClientOnly } from "#app/components/client-only"
+      export const Foo = defineAsyncComponent(() => import("/Foo.vue").then(r => createClientOnly(r["Foo"] || r.default || r)))"
     `)
   })
 })

--- a/packages/nuxt/test/components-transform.test.ts
+++ b/packages/nuxt/test/components-transform.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+import type { Component, Nuxt } from '@nuxt/schema'
+import { kebabCase } from 'scule'
+
+import { createTransformPlugin } from '../src/components/transform'
+
+describe('components:transform', () => {
+  it('should transform #components imports', async () => {
+    const transform = createTransformer([
+      createComponent('Foo'),
+      createComponent('Bar', { export: 'Bar' })
+    ])
+
+    const code = await transform('import { Foo, Bar } from \'#components\'', '/app.vue')
+    expect(code).toMatchInlineSnapshot(`
+      "import Foo from '/Foo.vue';
+      import { Bar } from '/Bar.vue';
+      "
+    `)
+  })
+
+  it('should correctly resolve server-only components', async () => {
+    const transform = createTransformer([
+      createComponent('Foo', { mode: 'server' })
+    ])
+
+    const code = await transform('import { Foo, LazyFoo } from \'#components\'', '/app.vue')
+    expect(code).toMatchInlineSnapshot(`
+      "import Foo from '/Foo.vue?nuxt_component=server&nuxt_component_name=Foo&nuxt_component_export=default';
+      import LazyFoo from '/Foo.vue?nuxt_component=server,async&nuxt_component_name=Foo&nuxt_component_export=default';
+      "
+    `)
+
+    expect(await transform('', '/Foo.vue?nuxt_component=server&nuxt_component_name=Foo&nuxt_component_export=default')).toMatchInlineSnapshot(`
+      "import { createServerComponent } from "/Users/daniel/code/nuxt/nuxt/packages/nuxt/src/components/runtime/server-component"
+      export default createServerComponent("Foo")"
+    `)
+    expect(await transform('', '/Foo.vue?nuxt_component=server,async&nuxt_component_name=Foo&nuxt_component_export=default')).toMatchInlineSnapshot(`
+      "import { createServerComponent } from "/Users/daniel/code/nuxt/nuxt/packages/nuxt/src/components/runtime/server-component"
+      export default createServerComponent("Foo")"
+    `)
+  })
+
+  it('should correctly resolve client-only components', async () => {
+    const transform = createTransformer([
+      createComponent('Foo', { mode: 'client' })
+    ])
+
+    const code = await transform('import { Foo, LazyFoo } from \'#components\'', '/app.vue')
+    expect(code).toMatchInlineSnapshot(`
+      "import Foo from '/Foo.vue?nuxt_component=client&nuxt_component_name=Foo&nuxt_component_export=default';
+      import LazyFoo from '/Foo.vue?nuxt_component=client,async&nuxt_component_name=Foo&nuxt_component_export=default';
+      "
+    `)
+
+    expect(await transform('', '/Foo.vue?nuxt_component=client&nuxt_component_name=Foo&nuxt_component_export=default')).toMatchInlineSnapshot(`
+      "import { default as __component } from "/Foo.vue";
+      import { createClientOnly } from "#app/components/client-only"
+      export default createClientOnly(__component)"
+    `)
+    expect(await transform('', '/Foo.vue?nuxt_component=client,async&nuxt_component_name=Foo&nuxt_component_export=default')).toMatchInlineSnapshot(`
+      "import { defineAsyncComponent } from "vue"
+      import { createClientOnly } from "#app/components/client-only"
+      export default defineAsyncComponent(() => import("/Foo.vue").then(r => createClientOnly(r["default"] || r.default || r)))"
+    `)
+  })
+})
+
+function createTransformer (components: Component[], mode: 'client' | 'server' | 'all' = 'all') {
+  const stubNuxt = {
+    options: {
+      buildDir: '/',
+      sourcemap: {
+        server: false,
+        client: false
+      }
+    }
+  } as Nuxt
+  const plugin = createTransformPlugin(stubNuxt, () => components, mode).vite()
+
+  return async (code: string, id: string) => {
+    const result = await (plugin as any).transform!(code, id)
+    return typeof result === 'string' ? result : result?.code
+  }
+}
+
+function createComponent (pascalName: string, options: Partial<Component> = {}) {
+  return {
+    filePath: `/${pascalName}.vue`,
+    pascalName,
+    export: 'default',
+    chunkName: `components/${pascalName.toLowerCase()}`,
+    kebabName: kebabCase(pascalName),
+    mode: 'all',
+    prefetch: false,
+    preload: false,
+    shortPath: `components/${pascalName}.vue`,
+    ...options
+  } satisfies Component
+}

--- a/packages/nuxt/test/components-transform.test.ts
+++ b/packages/nuxt/test/components-transform.test.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import type { Component, Nuxt } from '@nuxt/schema'
 import { kebabCase } from 'scule'
@@ -32,15 +33,15 @@ describe('components:transform', () => {
     `)
 
     expect(await transform('', '/Foo.vue?nuxt_component=server&nuxt_component_name=Foo&nuxt_component_export=default')).toMatchInlineSnapshot(`
-      "import { createServerComponent } from "/Users/daniel/code/nuxt/nuxt/packages/nuxt/src/components/runtime/server-component"
+      "import { createServerComponent } from "<repo>/nuxt/src/components/runtime/server-component"
       export default createServerComponent("Foo")"
     `)
     expect(await transform('', '/Foo.vue?nuxt_component=server,async&nuxt_component_name=Foo&nuxt_component_export=default')).toMatchInlineSnapshot(`
-      "import { createServerComponent } from "/Users/daniel/code/nuxt/nuxt/packages/nuxt/src/components/runtime/server-component"
+      "import { createServerComponent } from "<repo>/nuxt/src/components/runtime/server-component"
       export default createServerComponent("Foo")"
     `)
     expect(await transform('', '/Foo.vue?nuxt_component=server&nuxt_component_name=Foo&nuxt_component_export=Foo')).toMatchInlineSnapshot(`
-      "import { createServerComponent } from "/Users/daniel/code/nuxt/nuxt/packages/nuxt/src/components/runtime/server-component"
+      "import { createServerComponent } from "<repo>/nuxt/src/components/runtime/server-component"
       export const Foo = createServerComponent("Foo")"
     `)
   })
@@ -75,6 +76,8 @@ describe('components:transform', () => {
   })
 })
 
+const rootDir = fileURLToPath(new URL('../..', import.meta.url))
+
 function createTransformer (components: Component[], mode: 'client' | 'server' | 'all' = 'all') {
   const stubNuxt = {
     options: {
@@ -89,7 +92,7 @@ function createTransformer (components: Component[], mode: 'client' | 'server' |
 
   return async (code: string, id: string) => {
     const result = await (plugin as any).transform!(code, id)
-    return typeof result === 'string' ? result : result?.code
+    return (typeof result === 'string' ? result : result?.code)?.replaceAll(rootDir, '<repo>/')
   }
 }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/26471
https://github.com/nuxt/nuxt/pull/23715

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This improves our handling of components with named exports, ensuring that our generated wrappers also correctly have the desired named export, as well as adding some snapshot tests that confirm all is working as expected.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
