### PR TITLE
refactor(nuxt): simplify `runtimeConfig` initialization of client side

### DIFF
--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -338,7 +338,7 @@ export function createNuxtApp (options: CreateOptions) {
   }
 
   // Expose runtime config
-  const runtimeConfig = import.meta.server ? options.ssrContext!.runtimeConfig : reactive(nuxtApp.payload.config!)
+  const runtimeConfig = import.meta.server ? options.ssrContext!.runtimeConfig : nuxtApp.payload.config!
   nuxtApp.provide('config', runtimeConfig)
 
   return nuxtApp


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently, when we initialize `nuxtApp.$config` on the client side, we use `reactive(nuxtApp.payload.config!)`.

https://github.com/nuxt/nuxt/blob/50c92fbe6cfb5ce4d5bd51ffdbc7f6da2b1ddf65/packages/nuxt/src/app/nuxt.ts#L340-L342

However, `nuxtApp.payload` is set to `reactive` during initialization, meaning `nuxtApp.payload.config` is already a reactive object on the client side, so it does not need to be processed with `reactive` again.

https://github.com/nuxt/nuxt/blob/50c92fbe6cfb5ce4d5bd51ffdbc7f6da2b1ddf65/packages/nuxt/src/app/nuxt.ts#L241-L247

Thank you for reviewing this. If there's anything I might have overlooked, please don't hesitate to let me know.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
