### PR TITLE
fix(schema): update webpack `transformAssetUrls` + pass `hoistStatic` to vite plugin

### DIFF
--- a/packages/schema/build.config.ts
+++ b/packages/schema/build.config.ts
@@ -56,6 +56,7 @@ export default defineBuildConfig({
     '@vue/language-core',
     // Implicit
     '@vue/compiler-core',
+    '@vue/compiler-sfc',
     '@vue/shared',
     'untyped'
   ]

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -42,6 +42,7 @@
     "@vitejs/plugin-vue": "5.0.4",
     "@vitejs/plugin-vue-jsx": "3.1.0",
     "@vue/compiler-core": "3.4.21",
+    "@vue/compiler-sfc": "^3.4.21",
     "@vue/language-core": "2.0.7",
     "c12": "1.10.0",
     "esbuild-loader": "4.1.0",

--- a/packages/schema/src/config/app.ts
+++ b/packages/schema/src/config/app.ts
@@ -6,18 +6,16 @@ import type { AppHeadMetaObject } from '../types/head'
 export default defineUntypedSchema({
   /**
    * Vue.js config
-   * @type {typeof import('../src/types/config').VueConfig}
    */
   vue: {
-    template: {
-      transformAssetUrls: {
-        video: ['src', 'poster'],
-        source: ['src'],
-        img: ['src'],
-        image: ['xlink:href', 'href'],
-        use: ['xlink:href', 'href']
-      }
-    } satisfies import('@vitejs/plugin-vue').Options['template'],
+    /** @type {typeof import('@vue/compiler-sfc').AssetURLTagConfig} */
+    transformAssetUrls: {
+      video: ['src', 'poster'],
+      source: ['src'],
+      img: ['src'],
+      image: ['xlink:href', 'href'],
+      use: ['xlink:href', 'href']
+    },
     /**
      * Options for the Vue compiler that will be passed at build time.
      * @see [documentation](https://vuejs.org/api/application.html#app-config-compileroptions)

--- a/packages/schema/src/config/app.ts
+++ b/packages/schema/src/config/app.ts
@@ -6,6 +6,7 @@ import type { AppHeadMetaObject } from '../types/head'
 export default defineUntypedSchema({
   /**
    * Vue.js config
+   * @type {typeof import('../src/types/config').VueConfig}
    */
   vue: {
     template: {
@@ -16,7 +17,7 @@ export default defineUntypedSchema({
         image: ['xlink:href', 'href'],
         use: ['xlink:href', 'href']
       }
-    },
+    } satisfies import('@vitejs/plugin-vue').Options['template'],
     /**
      * Options for the Vue compiler that will be passed at build time.
      * @see [documentation](https://vuejs.org/api/application.html#app-config-compileroptions)

--- a/packages/schema/src/config/app.ts
+++ b/packages/schema/src/config/app.ts
@@ -8,6 +8,15 @@ export default defineUntypedSchema({
    * Vue.js config
    */
   vue: {
+    template: {
+      transformAssetUrls: {
+        video: ['src', 'poster'],
+        source: ['src'],
+        img: ['src'],
+        image: ['xlink:href', 'href'],
+        use: ['xlink:href', 'href']
+      }
+    },
     /**
      * Options for the Vue compiler that will be passed at build time.
      * @see [documentation](https://vuejs.org/api/application.html#app-config-compileroptions)

--- a/packages/schema/src/config/typescript.ts
+++ b/packages/schema/src/config/typescript.ts
@@ -43,6 +43,7 @@ export default defineUntypedSchema({
           '@unhead/vue',
           'vue',
           '@vue/runtime-core',
+          '@vue/compiler-sfc',
           '@vue/runtime-dom',
           'vue-router',
           '@nuxt/schema',

--- a/packages/schema/src/config/vite.ts
+++ b/packages/schema/src/config/vite.ts
@@ -49,11 +49,17 @@ export default defineUntypedSchema({
       template: {
         compilerOptions: {
           $resolve: async (val, get) => val ?? (await get('vue') as Record<string, any>).compilerOptions
+        },
+        transformAssetUrls: {
+          $resolve: async (val, get) => val ?? (await get('vue') as Record<string, any>).transformAssetUrls
         }
       },
       script: {
         propsDestructure: {
           $resolve: async (val, get) => val ?? Boolean((await get('vue') as Record<string, any>).propsDestructure)
+        },
+        hoistStatic: {
+          $resolve: async (val, get) => val ?? (await get('vue') as Record<string, any>).compilerOptions?.hoistStatic
         }
       }
     },

--- a/packages/schema/src/config/webpack.ts
+++ b/packages/schema/src/config/webpack.ts
@@ -1,5 +1,6 @@
 import { defu } from 'defu'
 import { defineUntypedSchema } from 'untyped'
+import type { VueLoaderOptions } from 'vue-loader'
 
 export default defineUntypedSchema({
   webpack: {
@@ -200,14 +201,15 @@ export default defineUntypedSchema({
        */
       vue: {
         transformAssetUrls: {
-          video: 'src',
-          source: 'src',
-          object: 'src',
-          embed: 'src'
+          $resolve: async (val, get) => (val ?? (await get('vue.transformAssetUrls'))) as VueLoaderOptions['transformAssetUrls']
         },
-        compilerOptions: { $resolve: async (val, get) => val ?? (await get('vue.compilerOptions')) },
-        propsDestructure: { $resolve: async (val, get) => val ?? Boolean(await get('vue.propsDestructure')) }
-      },
+        compilerOptions: {
+          $resolve: async (val, get) => (val ?? (await get('vue.compilerOptions'))) as VueLoaderOptions['compilerOptions']
+        },
+        propsDestructure: {
+          $resolve: async (val, get) => Boolean(val ?? await get('vue.propsDestructure'))
+        }
+      } satisfies { [K in keyof VueLoaderOptions]: { $resolve: (val: unknown, get: (id: string) => Promise<unknown>) => Promise<VueLoaderOptions[K]> } },
 
       css: {
         importLoaders: 0,

--- a/packages/schema/src/config/webpack.ts
+++ b/packages/schema/src/config/webpack.ts
@@ -201,7 +201,7 @@ export default defineUntypedSchema({
        */
       vue: {
         transformAssetUrls: {
-          $resolve: async (val, get) => (val ?? (await get('vue.template.transformAssetUrls'))) as VueLoaderOptions['transformAssetUrls']
+          $resolve: async (val, get) => (val ?? (await get('vue.transformAssetUrls'))) as VueLoaderOptions['transformAssetUrls']
         },
         compilerOptions: {
           $resolve: async (val, get) => (val ?? (await get('vue.compilerOptions'))) as VueLoaderOptions['compilerOptions']

--- a/packages/schema/src/config/webpack.ts
+++ b/packages/schema/src/config/webpack.ts
@@ -201,7 +201,7 @@ export default defineUntypedSchema({
        */
       vue: {
         transformAssetUrls: {
-          $resolve: async (val, get) => (val ?? (await get('vue.transformAssetUrls'))) as VueLoaderOptions['transformAssetUrls']
+          $resolve: async (val, get) => (val ?? (await get('vue.template.transformAssetUrls'))) as VueLoaderOptions['transformAssetUrls']
         },
         compilerOptions: {
           $resolve: async (val, get) => (val ?? (await get('vue.compilerOptions'))) as VueLoaderOptions['compilerOptions']

--- a/packages/schema/src/types/config.ts
+++ b/packages/schema/src/types/config.ts
@@ -1,7 +1,6 @@
 import type { KeepAliveProps, TransitionProps } from 'vue'
 import type { ServerOptions as ViteServerOptions, UserConfig as ViteUserConfig } from 'vite'
 import type { Options as VuePluginOptions } from '@vitejs/plugin-vue'
-import type { CompilerOptions as VueCompilerOptions } from '@vue/compiler-core'
 import type { Options as VueJsxPluginOptions } from '@vitejs/plugin-vue-jsx'
 import type { SchemaDefinition } from 'untyped'
 import type { NitroRuntimeConfig, NitroRuntimeConfigApp } from 'nitropack'
@@ -84,12 +83,6 @@ export interface NuxtOptions extends Omit<ConfigSchema, 'builder' | 'webpack'> {
   }
   _layers: NuxtConfigLayer[]
   $schema: SchemaDefinition
-}
-
-export interface VueConfig extends VuePluginOptions {
-  compilerOptions?: VueCompilerOptions
-  runtimeCompiler?: boolean
-  propsDestructure?: boolean
 }
 
 export interface ViteConfig extends Omit<ViteUserConfig, 'publicDir'> {

--- a/packages/schema/src/types/config.ts
+++ b/packages/schema/src/types/config.ts
@@ -1,6 +1,7 @@
 import type { KeepAliveProps, TransitionProps } from 'vue'
 import type { ServerOptions as ViteServerOptions, UserConfig as ViteUserConfig } from 'vite'
 import type { Options as VuePluginOptions } from '@vitejs/plugin-vue'
+import type { CompilerOptions as VueCompilerOptions } from '@vue/compiler-core'
 import type { Options as VueJsxPluginOptions } from '@vitejs/plugin-vue-jsx'
 import type { SchemaDefinition } from 'untyped'
 import type { NitroRuntimeConfig, NitroRuntimeConfigApp } from 'nitropack'
@@ -70,7 +71,7 @@ export type NuxtConfigLayer = ConfigLayer<NuxtConfig & {
 }>
 
 export interface NuxtBuilder {
-    bundle: (nuxt: Nuxt) => Promise<void>
+  bundle: (nuxt: Nuxt) => Promise<void>
 }
 
 // Normalized Nuxt options available as `nuxt.options.*`
@@ -83,6 +84,12 @@ export interface NuxtOptions extends Omit<ConfigSchema, 'builder' | 'webpack'> {
   }
   _layers: NuxtConfigLayer[]
   $schema: SchemaDefinition
+}
+
+export interface VueConfig extends VuePluginOptions {
+  compilerOptions?: VueCompilerOptions
+  runtimeCompiler?: boolean
+  propsDestructure?: boolean
 }
 
 export interface ViteConfig extends Omit<ViteUserConfig, 'publicDir'> {

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -112,17 +112,6 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
           }),
           virtual(nuxt.vfs)
         ],
-        vue: {
-          template: {
-            transformAssetUrls: {
-              video: ['src', 'poster'],
-              source: ['src'],
-              img: ['src'],
-              image: ['xlink:href', 'href'],
-              use: ['xlink:href', 'href']
-            }
-          }
-        },
         server: {
           watch: { ignored: isIgnored },
           fs: {

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -4,13 +4,11 @@ import { dirname, join, normalize, resolve } from 'pathe'
 import type { Nuxt, NuxtBuilder, ViteConfig } from '@nuxt/schema'
 import { addVitePlugin, isIgnored, logger, resolvePath } from '@nuxt/kit'
 import replace from '@rollup/plugin-replace'
-import type { Options as VuePluginOptions } from '@vitejs/plugin-vue'
 import { sanitizeFilePath } from 'mlly'
 import { withoutLeadingSlash } from 'ufo'
 import { filename } from 'pathe/utils'
 import { resolveTSConfig } from 'pkg-types'
 
-import { defu } from 'defu'
 import { buildClient } from './client'
 import { buildServer } from './server'
 import virtual from './plugins/virtual'
@@ -124,19 +122,6 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
       viteConfig
     )
   }
-
-  // Normalise vue configuration for vite-plugin-vue
-  const { compilerOptions, propsDestructure, ...vueConfig } = ctx.nuxt.options.vue || {}
-  ctx.config.vue = defu(ctx.config.vue, vueConfig satisfies VuePluginOptions, {
-    template: {
-      compilerOptions
-    },
-    isProduction: !ctx.nuxt.options.dev,
-    script: {
-      propsDestructure,
-      hoistStatic: compilerOptions?.hoistStatic
-    }
-  } satisfies VuePluginOptions) as VuePluginOptions
 
   // In build mode we explicitly override any vite options that vite is relying on
   // to detect whether to inject production or development code (such as HMR code)

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -133,8 +133,8 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
     },
     isProduction: !ctx.nuxt.options.dev,
     script: {
-      propsDestructure: propsDestructure as boolean,
-      hoistStatic: compilerOptions?.hoistStatic || undefined
+      propsDestructure,
+      hoistStatic: compilerOptions?.hoistStatic
     }
   } satisfies VuePluginOptions) as VuePluginOptions
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -493,6 +493,9 @@ importers:
       '@vue/compiler-core':
         specifier: 3.4.21
         version: 3.4.21
+      '@vue/compiler-sfc':
+        specifier: ^3.4.21
+        version: 3.4.21
       '@vue/language-core':
         specifier: 2.0.7
         version: 2.0.7(typescript@5.4.3)
@@ -534,7 +537,7 @@ importers:
         version: 2.0.0
       vue-loader:
         specifier: 17.4.2
-        version: 17.4.2(vue@3.4.21)(webpack@5.91.0)
+        version: 17.4.2(@vue/compiler-sfc@3.4.21)(vue@3.4.21)(webpack@5.91.0)
       vue-router:
         specifier: 4.3.0
         version: 4.3.0(vue@3.4.21)
@@ -781,7 +784,7 @@ importers:
         version: 2.0.0
       vue-loader:
         specifier: ^17.4.2
-        version: 17.4.2(vue@3.4.21)(webpack@5.91.0)
+        version: 17.4.2(@vue/compiler-sfc@3.4.21)(vue@3.4.21)(webpack@5.91.0)
       webpack:
         specifier: ^5.91.0
         version: 5.91.0
@@ -11993,7 +11996,7 @@ packages:
       - supports-color
     dev: true
 
-  /vue-loader@17.4.2(vue@3.4.21)(webpack@5.91.0):
+  /vue-loader@17.4.2(@vue/compiler-sfc@3.4.21)(vue@3.4.21)(webpack@5.91.0):
     resolution: {integrity: sha512-yTKOA4R/VN4jqjw4y5HrynFL8AK0Z3/Jt7eOJXEitsm0GMRHDBjCfCiuTiLP7OESvsZYo2pATCWhDqxC5ZrM6w==}
     peerDependencies:
       '@vue/compiler-sfc': '*'
@@ -12005,6 +12008,7 @@ packages:
       vue:
         optional: true
     dependencies:
+      '@vue/compiler-sfc': 3.4.21
       chalk: 4.1.2
       hash-sum: 2.0.0
       vue: 3.4.21(typescript@5.4.3)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

Spotted while investigating https://github.com/nuxt/nuxt/issues/26449

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR updates the webpack `transformAssetUrls` config to be consistent with vite, and also passes `hoistStatic` explicitly to vite-plugin-vue's script options.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
