### PR TITLE
docs: replace `process.*` with `import.meta.*`

### DIFF
--- a/docs/1.getting-started/7.state-management.md
+++ b/docs/1.getting-started/7.state-management.md
@@ -130,12 +130,12 @@ export const useLocale = () => {
 
 export const useDefaultLocale = (fallback = 'en-US') => {
   const locale = ref(fallback)
-  if (process.server) {
+  if (import.meta.server) {
     const reqLocale = useRequestHeaders()['accept-language']?.split(',')[0]
     if (reqLocale) {
       locale.value = reqLocale
     }
-  } else if (process.client) {
+  } else if (import.meta.client) {
     const navLang = navigator.language
     if (navLang) {
       locale.value = navLang

--- a/docs/2.guide/2.directory-structure/1.middleware.md
+++ b/docs/2.guide/2.directory-structure/1.middleware.md
@@ -125,12 +125,12 @@ However, if you want to avoid this behaviour you can do so:
 ```ts twoslash [middleware/example.ts]
 export default defineNuxtRouteMiddleware(to => {
   // skip middleware on server
-  if (process.server) return
+  if (import.meta.server) return
   // skip middleware on client side entirely
-  if (process.client) return
+  if (import.meta.client) return
   // or only skip middleware on initial client load
   const nuxtApp = useNuxtApp()
-  if (process.client && nuxtApp.isHydrating && nuxtApp.payload.serverRendered) return
+  if (import.meta.client && nuxtApp.isHydrating && nuxtApp.payload.serverRendered) return
 })
 ```
 

--- a/docs/2.guide/2.directory-structure/1.plugins.md
+++ b/docs/2.guide/2.directory-structure/1.plugins.md
@@ -78,7 +78,7 @@ export default defineNuxtPlugin({
 
 ::note
 If you are using the object-syntax, the properties may be statically analyzed in future to produce a more optimized build. So you should not define them at runtime. :br
-For example, setting `enforce: process.server ? 'pre' : 'post'` would defeat any future optimization Nuxt is able to do for your plugins.
+For example, setting `enforce: import.meta.server ? 'pre' : 'post'` would defeat any future optimization Nuxt is able to do for your plugins.
 ::
 
 ## Registration Order

--- a/docs/2.guide/3.going-further/10.runtime-config.md
+++ b/docs/2.guide/3.going-further/10.runtime-config.md
@@ -98,7 +98,7 @@ The behavior is different between the client-side and server-side:
 const config = useRuntimeConfig()
 
 console.log('Runtime config:', config)
-if (process.server) {
+if (import.meta.server) {
   console.log('API secret:', config.apiSecret)
 }
 </script>

--- a/docs/2.guide/3.going-further/8.custom-routing.md
+++ b/docs/2.guide/3.going-further/8.custom-routing.md
@@ -172,6 +172,6 @@ import { createMemoryHistory } from 'vue-router'
 
 export default <RouterConfig> {
   // https://router.vuejs.org/api/interfaces/routeroptions.html
-  history: base => process.client ? createMemoryHistory(base) : null /* default */
+  history: base => import.meta.client ? createMemoryHistory(base) : null /* default */
 }
 ```

--- a/docs/3.api/2.composables/use-nuxt-app.md
+++ b/docs/3.api/2.composables/use-nuxt-app.md
@@ -51,7 +51,7 @@ export default defineNuxtPlugin((nuxtApp) => {
   })
   nuxtApp.hook('vue:error', (..._args) => {
     console.log('vue:error')
-    // if (process.client) {
+    // if (import.meta.client) {
     //   console.log(..._args)
     // }
   })
@@ -120,7 +120,7 @@ Nuxt exposes the following properties through `ssrContext`:
   export const useColor = () => useState<string>('color', () => 'pink')
 
   export default defineNuxtPlugin((nuxtApp) => {
-    if (process.server) {
+    if (import.meta.server) {
       const color = useColor()
     }
   })
@@ -159,7 +159,7 @@ export default defineComponent({
   setup (_props, { slots, emit }) {
     const nuxtApp = useNuxtApp()
     onErrorCaptured((err) => {
-      if (process.client && !nuxtApp.isHydrating) {
+      if (import.meta.client && !nuxtApp.isHydrating) {
         // ...
       }
     })

--- a/docs/3.api/5.kit/10.templates.md
+++ b/docs/3.api/5.kit/10.templates.md
@@ -117,7 +117,7 @@ import { defineNuxtPlugin } from '#imports'
 import metaConfig from '#build/meta.config.mjs'
 
 export default defineNuxtPlugin((nuxtApp) => {
-  const createHead = process.server ? createServerHead : createClientHead
+  const createHead = import.meta.server ? createServerHead : createClientHead
   const head = createHead()
   head.push(metaConfig.globalMeta)
 

--- a/docs/3.api/5.kit/9.plugins.md
+++ b/docs/3.api/5.kit/9.plugins.md
@@ -251,7 +251,7 @@ export default defineNuxtPlugin((nuxtApp) => {
   nuxtApp.vueApp.use(VueFire, { firebaseApp })
 
   <% if(options.ssr) { %>
-  if (process.server) {
+  if (import.meta.server) {
     nuxtApp.payload.vuefire = useSSRInitialState(undefined, firebaseApp)
   } else if (nuxtApp.payload?.vuefire) {
     useSSRInitialState(nuxtApp.payload.vuefire, firebaseApp)

--- a/test/fixtures/basic/pages/preview/index.vue
+++ b/test/fixtures/basic/pages/preview/index.vue
@@ -4,7 +4,7 @@ const { enabled: isPreview } = usePreviewMode()
 const { data } = await useAsyncData(async () => {
   await new Promise(resolve => setTimeout(resolve, 200))
 
-  const fetchedOnClient = process.client
+  const fetchedOnClient = import.meta.client
 
   console.log(fetchedOnClient)
 


### PR DESCRIPTION
### 🔗 Linked issue

Context: https://github.com/nuxt/nuxt/issues/25323

### 📚 Description

This PR updates `process.client` to `import.meta.client` and `process.server` to `import.meta.server`.
