### PR TITLE
docs: correct grammar in `typescript.shim` JSDoc

### DIFF
--- a/packages/schema/src/config/typescript.ts
+++ b/packages/schema/src/config/typescript.ts
@@ -80,7 +80,7 @@ export default defineUntypedSchema({
      * We recommend instead letting the [official Vue extension](https://marketplace.visualstudio.com/items?itemName=Vue.volar)
      * generate accurate types for your components.
      *
-     * Note that if you may wish to set this to `true` if you are using other libraries, such as ESLint,
+     * Note that you may wish to set this to `true` if you are using other libraries, such as ESLint,
      * that are unable to understand the type of `.vue` files.
      */
     shim: false


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/pull/26607

### 📚 Description

Corrects grammar in https://github.com/nuxt/nuxt/pull/26607.