### PR TITLE
fix(nuxt): solve false warning when using `useRoute`

### DIFF
--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -85,7 +85,6 @@ const isProcessingMiddleware = () => {
       return true
     }
   } catch {
-    // Within an async middleware
     return false
   }
   return false

--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -86,7 +86,7 @@ const isProcessingMiddleware = () => {
     }
   } catch {
     // Within an async middleware
-    return true
+    return false
   }
   return false
 }


### PR DESCRIPTION
### 🔗 Linked issue

Resolve #26612

### 📚 Description

When attempting the [reproduction](https://stackblitz.com/edit/github-vmpomt?file=pages%2Findex.vue) of linked issue, it results in a warning message advising users not to utilize `useRoute` within middleware. This advice is misleading in this context.

In this PR, I tryed to update the return value in `isProcessingMiddleware()`.

Since the Nuxt 3.5.0, both asynchronous and synchronous middleware have been able to properly access the Nuxt instance. However, if `useNuxtApp()` within `isProcessingMiddleware` throws an error, it conclusively indicates that the execution is not happening within a plugin, Nuxt hook, Nuxt middleware, or Vue setup function.

Thank you for reviewing this. If there's anything I might have overlooked, please don't hesitate to let me know.

