### PR TITLE
docs: add one necessary comma to the code block in the documentation

### DIFF
--- a/docs/2.guide/3.going-further/8.custom-routing.md
+++ b/docs/2.guide/3.going-further/8.custom-routing.md
@@ -105,7 +105,7 @@ export default defineNuxtConfig({
       const resolver = createResolver(import.meta.url)
       // add a route
       files.push({
-        path: resolver.resolve('./runtime/app/router-options')
+        path: resolver.resolve('./runtime/app/router-options'),
         optional: true
       })
     }


### PR DESCRIPTION
🔗 Linked issue
No issue, just a minor addition to the documentation.

❓ Type of change
- [X]  📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ]  🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ]  👌 Enhancement (improving an existing functionality like performance)
- [ ]  ✨ New feature (a non-breaking change that adds functionality)
- [ ]  🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ]  ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

📚 Description
Add one necessary comma to the code block in the documentation where it has to be to work fine after copying