### PR TITLE
docs: update Nuxt 4 scheduled release date

### DIFF
--- a/docs/5.community/6.roadmap.md
+++ b/docs/5.community/6.roadmap.md
@@ -63,7 +63,7 @@ Each active version has its own nightly releases which are generated automatical
 
 Release                                 |                                                                                                  | Initial release | End Of Life  | Docs
 ----------------------------------------|---------------------------------------------------------------------------------------------------|-----------------|--------------|-------
-**4.x** (scheduled)                     |                                                                                           | 2024 Q1         |              | &nbsp;
+**4.x** (scheduled)                     |                                                                                           | 2024 Q2         |              | &nbsp;
 **3.x** (stable)           | <a href="https://npmjs.com/package/nuxt"><img alt="Nuxt latest 3.x version" src="https://flat.badgen.net/npm/v/nuxt?label="></a>            | 2022-11-16      | TBA          | [nuxt.com](/docs)
 **2.x** (maintenance)      | <a href="https://www.npmjs.com/package/nuxt?activeTab=versions"><img alt="Nuxt 2.x version" src="https://flat.badgen.net/npm/v/nuxt/2x?label="></a>         | 2018-09-21      | 2024-06-30   | [v2.nuxt.com](https://v2.nuxt.com/docs)
 **1.x** (unsupported)      | <a href="https://www.npmjs.com/package/nuxt?activeTab=versions"><img alt="Nuxt 1.x version" src="https://flat.badgen.net/npm/v/nuxt/1x?label="></a>         | 2018-01-08      | 2019-09-21 | &nbsp;


### PR DESCRIPTION


### 🔗 Linked issue

N/A

### 📚 Description

Unless the nuxt team has the ability to travel in the past, someone has to update the planned release date 🙂.

Not sure if `Q2` is right though 
