### PR TITLE
fix(kit): set tsConfig moduleDetection to 'force'

### DIFF
--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -129,6 +129,7 @@ export async function _generateTypes (nuxt: Nuxt) {
       jsxImportSource: 'vue',
       target: 'ESNext',
       module: 'ESNext',
+      moduleDetection: 'force',
       moduleResolution: nuxt.options.future?.typescriptBundlerResolution || (nuxt.options.experimental as any)?.typescriptBundlerResolution ? 'Bundler' : 'Node',
       skipLibCheck: true,
       isolatedModules: true,


### PR DESCRIPTION
The issue lies in [typescript-eslint/typescript-eslint](https://github.com/typescript-eslint/typescript-eslint) and has been described in [this issue](https://github.com/typescript-eslint/typescript-eslint/issues/6337#issuecomment-2039271142).
The fix should come from that repository but is not easy to tackle. This PR provides an alternative solution for Nuxt repositories

### 📚 Description
When using `typescript-eslint` in a Vue project and enabling the following rules
```js
  rules: {
    '@typescript-eslint/no-unsafe-assignment': 'error',
    '@typescript-eslint/no-unsafe-call': 'error',
    '@typescript-eslint/no-unsafe-member-access': 'error',
    '@typescript-eslint/no-unsafe-return': 'error',
  }
```
an error occur with props declaration in `script setup` components.

As explained by a maintainer of `typescript-eslint` in [this comment](https://github.com/typescript-eslint/typescript-eslint/issues/6337#issuecomment-1500890265), because `script setup` components have no exports they can sometime be treated as `scripts` by TypeScript instead of `modules` and as such every variables declared inside them are considered global variables.

What this means is that when declaring 2 components with a `props` variable, the first one is considered a global variable and its type is used by `typescript-eslint` to define the second one.
The above mentioned are then being raised in the second Component because the types are not recognized properly.

For example
```html
<!-- Bar.vue -->
<script setup lang="ts">
  const props = defineProps<{
    bars: string[]
  }
</script>

<!-- Foo.vue -->
<script setup lang="ts">
  const props = defineProps<{
    foos: (() => null)[]
  } // `typescript-eslint` uses Bar's props's type despite declaring this one
  
  const noUnsafeAssignment = props.foos // triggers an error because props.foos is treated as `any`
  const noUnsafeMemberAccess = props.foos.length // triggers an error because we're calling `length` on a `any` property
  const noUnsafeReturn = () => props.foos // triggers an error because we're returning a `any` property
  
  props.foos.forEach(foo => {
    const noUnsafeCall = foo() // triggers an error because we're calling a `any` property
  }
</script>
```

### 🔎 Solution
Setting the TypeScript [moduleDetection](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#control-over-module-detection) to `"force"` "solves" this issue because then TypeScript does not consider those Vue components as `scripts` anymore but is forced to treat them as `modules` despite having neither imports nor exports.
This means the variables are not treated as globals anymore.

This change should not have any undesired impact considering Nuxt is shipped as `"type": "module"` by default in Nuxt 3 and Vite also has disabled support for `CommonJS`.
