### PR TITLE
docs: remove step of installing deps in new nuxt project

### DIFF
--- a/docs/1.getting-started/2.installation.md
+++ b/docs/1.getting-started/2.installation.md
@@ -63,32 +63,8 @@ Or change directory into your new project from your terminal:
 cd <project-name>
 ```
 
-Install the dependencies:
+You don't need to install dependencies, they are already installed.
 
-::code-group
-
-```bash [yarn]
-yarn install
-```
-
-```bash [npm]
-npm install
-```
-
-```bash [pnpm]
-pnpm install
-```
-
-```bash [bun]
-bun install
-```
-
-::
-
-::note
-If you are using Yarn 2+ (Berry), add `nodeLinker: node-modules` to your `.yarnrc.yml` file.
-[You can follow this issue status here](https://github.com/nuxt/nuxt/issues/22861)
-::
 
 ## Development Server
 

--- a/docs/1.getting-started/2.installation.md
+++ b/docs/1.getting-started/2.installation.md
@@ -63,8 +63,6 @@ Or change directory into your new project from your terminal:
 cd <project-name>
 ```
 
-You don't need to install dependencies, they are already installed.
-
 
 ## Development Server
 

--- a/docs/1.getting-started/2.installation.md
+++ b/docs/1.getting-started/2.installation.md
@@ -63,7 +63,6 @@ Or change directory into your new project from your terminal:
 cd <project-name>
 ```
 
-
 ## Development Server
 
 Now you'll be able to start your Nuxt app in development mode:


### PR DESCRIPTION
Dependencies are installed by Nuxi init.


