### PR TITLE
docs: fix plugins docs

### DIFF
--- a/docs/2.guide/2.directory-structure/1.plugins.md
+++ b/docs/2.guide/2.directory-structure/1.plugins.md
@@ -117,7 +117,7 @@ export default defineNuxtPlugin({
 
 ### Plugins With Dependencies
 
-If a plugin needs to await a parallel plugin before it runs, you can add the plugin's name to the `dependsOn` array.
+If a plugin needs to wait for another plugin before it runs, you can add the plugin's name to the `dependsOn` array.
 
 ```ts twoslash [plugins/depending-on-my-plugin.ts]
 export default defineNuxtPlugin({


### PR DESCRIPTION
### 📚 Description

Improved description of plugins with dependencies. 
The Docs say that "If a plugin needs to await a parallel plugin", it can use `dependsOn`. But it is confusing, because `dependsOn` also works with sync plugins with `parallel: false`.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
