### PR TITLE
docs: fix testing config file name typo

### DIFF
--- a/docs/1.getting-started/11.testing.md
+++ b/docs/1.getting-started/11.testing.md
@@ -49,7 +49,7 @@ We currently ship an environment for unit testing code that needs a [Nuxt](https
    })
    ```
 
-2. Create a `vitest.config.ts` with the following content:
+2. Create a `vitest.config.mts` with the following content:
 
    ```ts twoslash
    import { defineVitestConfig } from '@nuxt/test-utils/config'
@@ -77,7 +77,7 @@ You can opt in to a Nuxt environment by adding `.nuxt.` to the test file's name 
 You can alternatively set `environment: 'nuxt'` in your Vitest configuration to enable the Nuxt environment for **all tests**.
 
 ```ts twoslash
-// vitest.config.ts
+// vitest.config.mts
 import { fileURLToPath } from 'node:url'
 import { defineVitestConfig } from '@nuxt/test-utils/config'
 
@@ -127,7 +127,7 @@ Default `true`, creates a dummy class without any functionality for the Intersec
 
 Default `false`, uses [`fake-indexeddb`](https://github.com/dumbmatter/fakeIndexedDB) to create a functional mock of the IndexedDB API
 
-These can be configured in the `environmentOptions` section of your `vitest.config.ts` file:
+These can be configured in the `environmentOptions` section of your `vitest.config.mts` file:
 
 ```ts twoslash
 import { defineVitestConfig } from '@nuxt/test-utils/config'


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/test-utils/issues/704

### 📚 Description

Change vitest config file extention to .mts in documentation.
This stops you getting the following error when running vitest `[ERROR] "@nuxt/test-utils/config" resolved to an ESM file` 

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
