### PR TITLE
fix(nuxt): correctly remove extension from path in `hasSuffix` util

### DIFF
--- a/packages/nuxt/src/core/utils/names.ts
+++ b/packages/nuxt/src/core/utils/names.ts
@@ -13,7 +13,7 @@ export function getNameFromPath (path: string, relativeTo?: string) {
 }
 
 export function hasSuffix (path: string, suffix: string) {
-  return basename(path).replace(extname(path), '').endsWith(suffix)
+  return basename(path, extname(path)).endsWith(suffix)
 }
 
 export function resolveComponentNameSegments (fileName: string, prefixParts: string[]) {


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/26721

### 📚 Description

Leverages built-in extension removal in `basename` method instead of incorrectly replacing first occurence of an extension in the last segment of middleware file path.