### PR TITLE
docs: remove misleading reference to `useFetch`

### DIFF
--- a/docs/1.getting-started/6.data-fetching.md
+++ b/docs/1.getting-started/6.data-fetching.md
@@ -122,7 +122,7 @@ const { data, error } = await useAsyncData(`user:${id}`, () => {
 </script>
 ```
 
-The `useAsyncData` composable is a great way to wrap and wait for multiple `useFetch` to be done, and then retrieve the results of each.
+The `useAsyncData` composable is a great way to wrap and wait for multiple `$fetch` to be done, and then retrieve the results of each.
 
 ```vue
 <script setup lang="ts">

--- a/docs/1.getting-started/6.data-fetching.md
+++ b/docs/1.getting-started/6.data-fetching.md
@@ -122,7 +122,7 @@ const { data, error } = await useAsyncData(`user:${id}`, () => {
 </script>
 ```
 
-The `useAsyncData` composable is a great way to wrap and wait for multiple `$fetch` to be done, and then retrieve the results of each.
+The `useAsyncData` composable is a great way to wrap and wait for multiple `$fetch` requests to be done, and then retrieve the results of each.
 
 ```vue
 <script setup lang="ts">

--- a/docs/1.getting-started/6.data-fetching.md
+++ b/docs/1.getting-started/6.data-fetching.md
@@ -122,7 +122,7 @@ const { data, error } = await useAsyncData(`user:${id}`, () => {
 </script>
 ```
 
-The `useAsyncData` composable is a great way to wrap and wait for multiple `$fetch` requests to be done, and then retrieve the results of each.
+The `useAsyncData` composable is a great way to wrap and wait for multiple `$fetch` requests to be completed, and then process the results.
 
 ```vue
 <script setup lang="ts">


### PR DESCRIPTION
It seems to be referring `$fetch` instead of `useFetch` based on the example code below.

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Reading the whole page from the start, it mentioned `useAsyncData` can be combined with `$fetch` to provide fine-grained control. Also the code below the changed line uses `$fetch` rather than `useFetch`. So I think it should be `$fetch` here?

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
