### PR TITLE
docs: fix typo

### DIFF
--- a/docs/2.guide/2.directory-structure/3.nuxt-config.md
+++ b/docs/2.guide/2.directory-structure/3.nuxt-config.md
@@ -33,7 +33,7 @@ Discover all the available options in the **Nuxt configuration** documentation.
 
 To ensure your configuration is up to date, Nuxt will make a full restart when detecting changes in the main configuration file, the [`.env`](/docs/guide/directory-structure/env), [`.nuxtignore`](/docs/guide/directory-structure/nuxtignore) and `.nuxtrc` dotfiles.
 
-The `.nuxtrc` file is a file that can be used to configure Nuxt with a fla syntax, it is based on [`unjs/rc9`](https://github.com/unjs/rc9).
+The `.nuxtrc` file is a file that can be used to configure Nuxt with a flat syntax, it is based on [`unjs/rc9`](https://github.com/unjs/rc9).
 
 ``` [.nuxtrc]
 ssr=false

--- a/docs/2.guide/2.directory-structure/3.nuxt-config.md
+++ b/docs/2.guide/2.directory-structure/3.nuxt-config.md
@@ -33,7 +33,7 @@ Discover all the available options in the **Nuxt configuration** documentation.
 
 To ensure your configuration is up to date, Nuxt will make a full restart when detecting changes in the main configuration file, the [`.env`](/docs/guide/directory-structure/env), [`.nuxtignore`](/docs/guide/directory-structure/nuxtignore) and `.nuxtrc` dotfiles.
 
-The `.nuxtrc` file is a file that can be used to configure Nuxt with a flat syntax, it is based on [`unjs/rc9`](https://github.com/unjs/rc9).
+The `.nuxtrc` file can be used to configure Nuxt with a flat syntax. It is based on [`unjs/rc9`](https://github.com/unjs/rc9).
 
 ``` [.nuxtrc]
 ssr=false


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt.com/issues/1555

### 📚 Description

This pr fixes a typo in the directory structure/nuxt.config section of the docs.
