### PR TITLE
docs: fix `srcDir` description mentioning deprecated `static/` directory

### DIFF
--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -79,7 +79,7 @@ export default defineUntypedSchema({
    * ------| middleware/
    * ------| pages/
    * ------| plugins/
-   * ------| static/
+   * ------| public/
    * ------| store/
    * ------| server/
    * ------| app.config.ts


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
No issues found.

### 📚 Description

The docs for `srcDir` in Nuxt config mentions a `static/` directory, which was renamed in Nuxt 3.
I got confused, but I did verify that by default, `<srcDir>/public` works and `<srcDir>/static` doesn't.

I tried running `nuxt.com` locally to verify that my PR fixes the docs, but I couldn't, so I apologize if I'm missing any steps to apply the JSDoc update.

Links:
- Docs mentioning deprecated `static/` directory: [`srcDir` in Nuxt Configuration](https://nuxt.com/docs/api/nuxt-config#srcdir)

  ![Screenshot 2024-04-17 at 2 00 16](https://github.com/nuxt/nuxt/assets/45890038/2b4e5504-03fd-40f7-8bc4-ce3ea355eb31)

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
