### PR TITLE
docs: advise correct extension for vitest config

### DIFF
--- a/docs/1.getting-started/11.testing.md
+++ b/docs/1.getting-started/11.testing.md
@@ -59,6 +59,11 @@ We currently ship an environment for unit testing code that needs a [Nuxt](https
    })
    ```
 
+::tip
+When importing `@nuxt/test-utils` in your vitest config, It is necessary to have `type: "module"` specified in your `package.json` or rename your vitest config file appropriatly.
+> ie. `vitest.config.m{ts,js}`.
+::
+
 ### Using a Nuxt Runtime Environment
 
 By default, `@nuxt/test-utils` will not change your default Vitest environment, so you can do fine-grained opt-in and run Nuxt tests together with other unit tests.


### PR DESCRIPTION
adds `tip`
  add `type: module` to package.json || rename vitest.config filename

Resolves https://github.com/nuxt/test-utils/issues/822

adds a tip section to the setup docs