### PR TITLE
fix(nuxt): don't encode location header

### DIFF
--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -169,7 +169,8 @@ export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: Na
         nuxtApp.ssrContext!._renderResponse = {
           statusCode: sanitizeStatusCode(options?.redirectCode || 302, 302),
           body: `<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=${encodedLoc}"></head></html>`,
-          headers: { location: encodeURI(location) },
+          // do not encode as this would break some modules and some environments
+          headers: { location },
         }
         return response
       }

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -937,12 +937,6 @@ describe('navigate', () => {
 
     expect(status).toEqual(404)
   })
-
-  it('expect to redirect with encoding', async () => {
-    const { status } = await fetch('/redirect-with-encode', { redirect: 'manual' })
-
-    expect(status).toEqual(302)
-  })
 })
 
 describe('preserves current instance', () => {

--- a/test/fixtures/basic/pages/redirect-with-encode.vue
+++ b/test/fixtures/basic/pages/redirect-with-encode.vue
@@ -1,9 +1,0 @@
-<template>
-  <div>
-    oh no !
-  </div>
-</template>
-
-<script setup lang="ts">
-await navigateTo('/cœur')
-</script>


### PR DESCRIPTION
### 🔗 Linked issue
fix #26882
fix #26888 
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Hi :wave: this PR reverts a change. It remove the `encodeURI` for the location header.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
