### PR TITLE
fix(nuxt): check if `_scope` is active before calling `run` function (#26756)

### DIFF
--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -254,7 +254,12 @@ export function createNuxtApp (options: CreateOptions) {
     static: {
       data: {},
     },
-    runWithContext: (fn: any) => nuxtApp._scope.run(() => callWithNuxt(nuxtApp, fn)),
+    runWithContext (fn: any) {
+      if (nuxtApp._scope.active) {
+        return nuxtApp._scope.run(() => callWithNuxt(nuxtApp, fn))
+      }
+      return callWithNuxt(nuxtApp, fn);
+    },
     isHydrating: import.meta.client,
     deferHydration () {
       if (!nuxtApp.isHydrating) { return () => {} }

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -258,7 +258,7 @@ export function createNuxtApp (options: CreateOptions) {
       if (nuxtApp._scope.active) {
         return nuxtApp._scope.run(() => callWithNuxt(nuxtApp, fn))
       }
-      return callWithNuxt(nuxtApp, fn);
+      return callWithNuxt(nuxtApp, fn)
     },
     isHydrating: import.meta.client,
     deferHydration () {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

Resolves #26756 

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

This PR introduces an additional check in the `runWithContext` function. In some edge cases, it happens that the `run` function is called on an inactive effect scope. Which leads to a runtime warning and can lead to a runtime error:
```
TypeError: Cannot read properties of undefined (reading 'appMiddleware')
```

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
