### PR TITLE
fix(nuxt): skip scanning component directories when `enabled` is set to `false`

### DIFF
--- a/packages/nuxt/src/components/scan.ts
+++ b/packages/nuxt/src/components/scan.ts
@@ -25,7 +25,7 @@ export async function scanComponents (dirs: ComponentsDir[], srcDir: string): Pr
   // All scanned paths
   const scannedPaths: string[] = []
 
-  for (const dir of dirs.filter(d => d.enabled)) {
+  for (const dir of dirs.filter(d => d.enabled !== false)) {
     // A map from resolved path to component name (used for making duplicate warning message)
     const resolvedNames = new Map<string, string>()
 

--- a/packages/nuxt/src/components/scan.ts
+++ b/packages/nuxt/src/components/scan.ts
@@ -25,7 +25,7 @@ export async function scanComponents (dirs: ComponentsDir[], srcDir: string): Pr
   // All scanned paths
   const scannedPaths: string[] = []
 
-  for (const dir of dirs) {
+  for (const dir of dirs.filter(d => d.enabled)) {
     // A map from resolved path to component name (used for making duplicate warning message)
     const resolvedNames = new Map<string, string>()
 

--- a/packages/nuxt/src/components/scan.ts
+++ b/packages/nuxt/src/components/scan.ts
@@ -25,7 +25,10 @@ export async function scanComponents (dirs: ComponentsDir[], srcDir: string): Pr
   // All scanned paths
   const scannedPaths: string[] = []
 
-  for (const dir of dirs.filter(d => d.enabled !== false)) {
+  for (const dir of dirs) {
+    if (dir.enabled === false) {
+      continue
+    }
     // A map from resolved path to component name (used for making duplicate warning message)
     const resolvedNames = new Map<string, string>()
 

--- a/packages/nuxt/test/scan-components.test.ts
+++ b/packages/nuxt/test/scan-components.test.ts
@@ -86,7 +86,7 @@ const dirs: ComponentsDir[] = [
     transpile: false,
   },
 ]
-const dirUnable = dirs.map(d=> {return {...d,enabled: false}})
+const dirUnable = dirs.map((d) => { return { ...d, enabled: false } })
 const expectedComponents = [
   {
     chunkName: 'components/isle-server',

--- a/packages/nuxt/test/scan-components.test.ts
+++ b/packages/nuxt/test/scan-components.test.ts
@@ -86,7 +86,7 @@ const dirs: ComponentsDir[] = [
     transpile: false,
   },
 ]
-
+const dirUnable = dirs.map(d=> {return {...d,enabled: false}})
 const expectedComponents = [
   {
     chunkName: 'components/isle-server',
@@ -242,4 +242,9 @@ it('components:scanComponents', async () => {
     delete c.filePath
   }
   expect(scannedComponents).deep.eq(expectedComponents)
+})
+
+it('components:scanComponents:unable', async () => {
+  const scannedComponents = await scanComponents(dirUnable, srcDir)
+  expect(scannedComponents).deep.eq([])
 })

--- a/packages/schema/src/types/components.ts
+++ b/packages/schema/src/types/components.ts
@@ -53,7 +53,7 @@ export interface ScanDir {
    */
   pathPrefix?: boolean
   /**
-   * Ignore scanning this directory if set to `true`
+   * Ignore scanning this directory if set to `false`
    */
   enabled?: boolean
   /**


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change
* [ ]  📖 Documentation (updates to the documentation, readme or JSdoc annotations)
* [ ]  🐞 Bug fix (a non-breaking change that fixes an issue)
* [x]  👌 Enhancement (improving an existing functionality like performance)
* [ ]  ✨ New feature (a non-breaking change that adds functionality)
* [ ]  🧹 Chore (updates to the build process or auxiliary tools and libraries)
* [ ]  ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
fix ineffective `ScanDir.enable` option on gen components.d.ts

### 📝 Checklist
* [ ]  I have linked an issue or discussion.
* [x]  I have added tests (if possible).
* [x]  I have updated the documentation accordingly.

