### PR TITLE
fix(vite): inline styles for vue components with `lang="ts"`

### DIFF
--- a/packages/vite/src/plugins/ssr-styles.ts
+++ b/packages/vite/src/plugins/ssr-styles.ts
@@ -120,6 +120,9 @@ export function ssrStylesPlugin (options: SSRStylePluginOptions): Plugin {
             // Vue files can (also) be their own entrypoints as they are tracked separately
             if (isVue(moduleId)) {
               options.clientCSSMap[moduleId].add(moduleId)
+              const parent = moduleId.replace(/\?.+$/, '')
+              options.clientCSSMap[parent] ||= new Set()
+              options.clientCSSMap[parent].add(moduleId)
             }
             // This is required to track CSS in entry chunk
             if (isEntry) {


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/26514

### 📚 Description

The issue here was that we were processing the following module IDs:

```
[
  './nuxt/nuxt/playground/pages/index.vue',
  './nuxt/nuxt/playground/components/SomeComp.vue?vue&type=script&setup=true&lang.ts',
  './nuxt/nuxt/playground/components/SomeComp.vue?vue&type=style&index=0&lang.css',
  './nuxt/nuxt/playground/pages/index.vue'
]
```

But at runtime the following ID was tracked: `./nuxt/nuxt/playground/components/SomeComp.vue`.

We can ensure this is tracked correctly by stripping the query at this point in the inline styles.
