### PR TITLE
fix(nuxt): call useState in setup function in `NuxtClientFallback`

### DIFF
--- a/packages/nuxt/src/app/components/client-fallback.server.ts
+++ b/packages/nuxt/src/app/components/client-fallback.server.ts
@@ -41,9 +41,10 @@ const NuxtClientFallbackServer = defineComponent({
     const vm = getCurrentInstance()
     const ssrFailed = ref(false)
     const nuxtApp = useNuxtApp()
+    const error = useState<boolean | undefined>(`${props.uid}`)
 
     onErrorCaptured((err) => {
-      useState(`${props.uid}`, () => true)
+      error.value = true
       ssrFailed.value = true
       ctx.emit('ssr-error', err)
       return false


### PR DESCRIPTION
### 🔗 Linked issue
#24135 
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Hi :wave: this PR probably fix the memory leak issue in `NuxtClientFallback` server side. 

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
