### PR TITLE
ci: fix potential GitHub Actions smells

### DIFF
--- a/.github/workflows/reproduire-close.yml
+++ b/.github/workflows/reproduire-close.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   stale:
     runs-on: ubuntu-latest
-    if: ${{github.event_name == 'workflow_dispatch' || github.repository == 'nuxt/nuxt.js'}}
+    if: ${{github.event_name == 'workflow_dispatch' || github.repository == 'nuxt/nuxt'}}
     steps:
       - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
         with:

--- a/.github/workflows/reproduire-close.yml
+++ b/.github/workflows/reproduire-close.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    if: ${{github.event_name == 'workflow_dispatch' || github.repository == 'nuxt/nuxt.js'}}
     steps:
       - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
         with:

--- a/.github/workflows/reproduire-close.yml
+++ b/.github/workflows/reproduire-close.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   stale:
     runs-on: ubuntu-latest
-    if: ${{github.event_name == 'workflow_dispatch' || github.repository == 'nuxt/nuxt'}}
+    if: github.event_name == 'workflow_dispatch' || github.repository == 'nuxt/nuxt'
     steps:
       - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
         with:

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -28,7 +28,7 @@ jobs:
       id-token: write
       contents: read
       actions: read
-    if: ${{github.event_name == 'push' || github.repository == 'nuxt/nuxt'}}
+    if: github.event_name == 'push' || github.repository == 'nuxt/nuxt'
 
     steps:
       - name: "Checkout code"
@@ -60,7 +60,7 @@ jobs:
       # format to the repository Actions tab.
       - name: "Upload artifact"
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
-        if: ${{github.repository == 'nuxt/nuxt' && success()}}
+        if: github.repository == 'nuxt/nuxt' && success()
         with:
           name: SARIF file
           path: results.sarif
@@ -69,6 +69,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
         uses: github/codeql-action/upload-sarif@d39d31e687223d841ef683f52467bd88e9b21c14 # v3.25.3
-        if: ${{github.repository == 'nuxt/nuxt' && success()}}
+        if: github.repository == 'nuxt/nuxt' && success()
         with:
           sarif_file: results.sarif

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -28,6 +28,7 @@ jobs:
       id-token: write
       contents: read
       actions: read
+    if: ${{github.event_name == 'push' || github.repository == 'nuxt/nuxt.js'}}
 
     steps:
       - name: "Checkout code"
@@ -58,7 +59,8 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.1
+        if: ${{github.repository == 'nuxt/nuxt.js' && success()}}
         with:
           name: SARIF file
           path: results.sarif
@@ -66,6 +68,7 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@8f596b4ae3cb3c588a5c46780b86dd53fef16c52 # v3.25.2
+        uses: github/codeql-action/upload-sarif@8f596b4ae3cb3c588a5c46780b86dd53fef16c52 # v3.24.9
+        if: ${{github.repository == 'nuxt/nuxt.js' && success()}}
         with:
           sarif_file: results.sarif

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -59,7 +59,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.1
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         if: ${{github.repository == 'nuxt/nuxt.js' && success()}}
         with:
           name: SARIF file
@@ -68,7 +68,7 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@8f596b4ae3cb3c588a5c46780b86dd53fef16c52 # v3.24.9
+        uses: github/codeql-action/upload-sarif@8f596b4ae3cb3c588a5c46780b86dd53fef16c52 # v3.25.2
         if: ${{github.repository == 'nuxt/nuxt.js' && success()}}
         with:
           sarif_file: results.sarif

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -28,7 +28,7 @@ jobs:
       id-token: write
       contents: read
       actions: read
-    if: ${{github.event_name == 'push' || github.repository == 'nuxt/nuxt.js'}}
+    if: ${{github.event_name == 'push' || github.repository == 'nuxt/nuxt'}}
 
     steps:
       - name: "Checkout code"
@@ -60,7 +60,7 @@ jobs:
       # format to the repository Actions tab.
       - name: "Upload artifact"
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
-        if: ${{github.repository == 'nuxt/nuxt.js' && success()}}
+        if: ${{github.repository == 'nuxt/nuxt' && success()}}
         with:
           name: SARIF file
           path: results.sarif
@@ -69,6 +69,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
         uses: github/codeql-action/upload-sarif@8f596b4ae3cb3c588a5c46780b86dd53fef16c52 # v3.25.2
-        if: ${{github.repository == 'nuxt/nuxt.js' && success()}}
+        if: ${{github.repository == 'nuxt/nuxt' && success()}}
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
Hey! 🙂
I want to contribute the following changes to your workflow:

- Use 'if' for upload-artifact action
- Avoid uploading artifacts on forks
- Avoid executing  scheduled workflows on forks

(These changes are part of a research Study at TU Delft looking at GitHub Action Smells. [Find out more](https://ceddy4395.github.io/research/gha-smells.html))

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
