### PR TITLE
fix(nuxt): updateAppConfig does not convert arrays into objects

### DIFF
--- a/packages/nuxt/src/app/config.ts
+++ b/packages/nuxt/src/app/config.ts
@@ -27,7 +27,8 @@ function deepAssign (obj: any, newObj: any) {
   for (const key in newObj) {
     const val = newObj[key]
     if (val !== null && typeof val === 'object') {
-      obj[key] = obj[key] || {}
+      const defaultVal = Array.isArray(val) ? [] : {}
+      obj[key] = obj[key] || defaultVal
       deepAssign(obj[key], val)
     } else {
       obj[key] = val


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->resolves #25715

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
When I try to update the appConfig using updateAppConfig and add a new property with an array value, I get an object instead of an array. 
Example:
```js
defineAppConfig({
  foo: bar 
})

updateAppConfig({
  test: [1,2]
})
```
Expected config:
```js
{ 
  foo:bar,
  test: [1,2] 
}
```

But got:
```js
{ 
  foo:bar, 
  test: { 
    '0': 1,
    '1': 2
  }
}
```
<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
