### PR TITLE
docs: update outdated strict checks section

### DIFF
--- a/docs/2.guide/1.concepts/8.typescript.md
+++ b/docs/2.guide/1.concepts/8.typescript.md
@@ -76,18 +76,18 @@ Overwriting options such as `"compilerOptions.paths"` with your own configuratio
 In case you need to extend options provided by `./.nuxt/tsconfig.json` further, you can use the [`alias` property](/docs/api/nuxt-config#alias) within your `nuxt.config`. `nuxi` will pick them up and extend `./.nuxt/tsconfig.json` accordingly.
 ::
 
-## Stricter Checks
+## Strict Checks
 
-TypeScript comes with certain checks to give you more safety and analysis of your program.
+TypeScript comes with certain checks to give you more safety and analysis of your program. 
 
-Once you’ve converted your codebase to TypeScript and felt familiar with it, you can start enabling these checks for greater safety ([read more](https://www.typescriptlang.org/docs/handbook/migrating-from-javascript.html#getting-stricter-checks)).
+[Strict checks](https://www.typescriptlang.org/docs/handbook/migrating-from-javascript.html#getting-stricter-checks) are enabled by default in Nuxt 3 to give you a greater type safety.
 
-In order to enable strict type checking, you have to update `nuxt.config`:
+If you are currently converting your codebase to TypeScript, you may want to temporarely disable strict checks by setting `strict` to `false` in your `nuxt.config`:
 
 ```ts twoslash [nuxt.config.ts]
 export default defineNuxtConfig({
   typescript: {
-    strict: true
+    strict: false
   }
 })
 ```

--- a/docs/2.guide/1.concepts/8.typescript.md
+++ b/docs/2.guide/1.concepts/8.typescript.md
@@ -78,7 +78,7 @@ In case you need to extend options provided by `./.nuxt/tsconfig.json` further, 
 
 ## Strict Checks
 
-TypeScript comes with certain checks to give you more safety and analysis of your program. 
+TypeScript comes with certain checks to give you more safety and analysis of your program.
 
 [Strict checks](https://www.typescriptlang.org/docs/handbook/migrating-from-javascript.html#getting-stricter-checks) are enabled by default in Nuxt 3 to give you a greater type safety.
 

--- a/docs/2.guide/1.concepts/8.typescript.md
+++ b/docs/2.guide/1.concepts/8.typescript.md
@@ -80,9 +80,9 @@ In case you need to extend options provided by `./.nuxt/tsconfig.json` further, 
 
 TypeScript comes with certain checks to give you more safety and analysis of your program.
 
-[Strict checks](https://www.typescriptlang.org/docs/handbook/migrating-from-javascript.html#getting-stricter-checks) are enabled by default in Nuxt 3 to give you a greater type safety.
+[Strict checks](https://www.typescriptlang.org/docs/handbook/migrating-from-javascript.html#getting-stricter-checks) are enabled by default in Nuxt 3 to give you greater type safety.
 
-If you are currently converting your codebase to TypeScript, you may want to temporarely disable strict checks by setting `strict` to `false` in your `nuxt.config`:
+If you are currently converting your codebase to TypeScript, you may want to temporarily disable strict checks by setting `strict` to `false` in your `nuxt.config`:
 
 ```ts twoslash [nuxt.config.ts]
 export default defineNuxtConfig({


### PR DESCRIPTION
### 📚 Description

I noticed this outdated strict checks section in the concepts docs. It points out that you have to manually set `strict` to `true` to enable them. But it's already `true` by default. 

Maybe we could either remove the section completely, change it like proposed in this PR or add the minimum version of nuxt where strict was set to `true` by default (not sure when this was).
