### PR TITLE
fix(nuxt): don't overwrite scope in runWithContext if scope already exists

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -378,9 +378,7 @@ export function useAsyncData<
     const hasScope = getCurrentScope()
     if (options.watch) {
       const unsub = watch(options.watch, () => asyncData.refresh())
-      if (instance) {
-        onUnmounted(unsub)
-      } else if (hasScope) {
+      if (hasScope) {
         onScopeDispose(unsub)
       }
     }
@@ -389,9 +387,7 @@ export function useAsyncData<
         await asyncData.refresh()
       }
     })
-    if (instance) {
-      onUnmounted(off)
-    } else if (hasScope) {
+    if (hasScope) {
       onScopeDispose(off)
     }
   }

--- a/packages/nuxt/src/app/composables/component.ts
+++ b/packages/nuxt/src/app/composables/component.ts
@@ -48,7 +48,6 @@ export const defineNuxtComponent: typeof defineComponent =
       ...options,
       setup (props, ctx) {
         const nuxtApp = useNuxtApp()
-
         const res = setup ? Promise.resolve(nuxtApp.runWithContext(() => setup(props, ctx))).then(r => r || {}) : {}
 
         const promises: Promise<any>[] = []

--- a/packages/nuxt/src/app/composables/component.ts
+++ b/packages/nuxt/src/app/composables/component.ts
@@ -1,4 +1,4 @@
-import { getCurrentInstance, getCurrentScope, reactive, toRefs } from 'vue'
+import { getCurrentInstance, reactive, toRefs } from 'vue'
 import type { DefineComponent, defineComponent } from 'vue'
 import { useHead } from '@unhead/vue'
 import type { NuxtApp } from '../nuxt'
@@ -48,9 +48,8 @@ export const defineNuxtComponent: typeof defineComponent =
       ...options,
       setup (props, ctx) {
         const nuxtApp = useNuxtApp()
-        const scope = getCurrentScope()
 
-        const res = setup ? Promise.resolve(nuxtApp.runWithContext(() => setup(props, ctx), scope)).then(r => r || {}) : {}
+        const res = setup ? Promise.resolve(nuxtApp.runWithContext(() => setup(props, ctx))).then(r => r || {}) : {}
 
         const promises: Promise<any>[] = []
         if (options.asyncData) {

--- a/packages/nuxt/src/app/composables/component.ts
+++ b/packages/nuxt/src/app/composables/component.ts
@@ -48,7 +48,16 @@ export const defineNuxtComponent: typeof defineComponent =
       ...options,
       setup (props, ctx) {
         const nuxtApp = useNuxtApp()
-        const res = setup ? Promise.resolve(nuxtApp.runWithContext(() => setup(props, ctx))).then(r => r || {}) : {}
+
+        let res: Promise<any> | {} = {}
+
+        if (setup) {
+          if (import.meta.client) {
+            res = Promise.resolve(setup(props, ctx)).then(r => r || {})
+          } else {
+            res = Promise.resolve(nuxtApp.runWithContext(() => setup(props, ctx))).then(r => r || {})
+          }
+        }
 
         const promises: Promise<any>[] = []
         if (options.asyncData) {

--- a/packages/nuxt/src/app/composables/component.ts
+++ b/packages/nuxt/src/app/composables/component.ts
@@ -1,4 +1,4 @@
-import { getCurrentInstance, reactive, toRefs } from 'vue'
+import { getCurrentInstance, getCurrentScope, reactive, toRefs } from 'vue'
 import type { DefineComponent, defineComponent } from 'vue'
 import { useHead } from '@unhead/vue'
 import type { NuxtApp } from '../nuxt'
@@ -48,16 +48,9 @@ export const defineNuxtComponent: typeof defineComponent =
       ...options,
       setup (props, ctx) {
         const nuxtApp = useNuxtApp()
+        const scope = getCurrentScope()
 
-        let res: Promise<any> | {} = {}
-
-        if (setup) {
-          if (import.meta.client) {
-            res = Promise.resolve(setup(props, ctx)).then(r => r || {})
-          } else {
-            res = Promise.resolve(nuxtApp.runWithContext(() => setup(props, ctx))).then(r => r || {})
-          }
-        }
+        const res = setup ? Promise.resolve(nuxtApp.runWithContext(() => setup(props, ctx), scope)).then(r => r || {}) : {}
 
         const promises: Promise<any>[] = []
         if (options.asyncData) {

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -101,7 +101,7 @@ interface _NuxtApp {
   hook: _NuxtApp['hooks']['hook']
   callHook: _NuxtApp['hooks']['callHook']
 
-  runWithContext: <T extends () => any>(fn: T, scope?: EffectScope) => ReturnType<T> | Promise<Awaited<ReturnType<T>>>
+  runWithContext: <T extends () => any>(fn: T) => ReturnType<T> | Promise<Awaited<ReturnType<T>>>
 
   [key: string]: unknown
 
@@ -254,9 +254,9 @@ export function createNuxtApp (options: CreateOptions) {
     static: {
       data: {},
     },
-    runWithContext (fn: any, scope = nuxtApp._scope) {
-      if (scope.active && !getCurrentScope()) {
-        return scope.run(() => callWithNuxt(nuxtApp, fn))
+    runWithContext (fn: any) {
+      if (nuxtApp._scope.active && !(getCurrentScope() || getCurrentInstance())) {
+        return nuxtApp._scope.run(() => callWithNuxt(nuxtApp, fn))
       }
       return callWithNuxt(nuxtApp, fn)
     },

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -255,7 +255,7 @@ export function createNuxtApp (options: CreateOptions) {
       data: {},
     },
     runWithContext (fn: any) {
-      if (nuxtApp._scope.active && !(getCurrentScope() || getCurrentInstance())) {
+      if (nuxtApp._scope.active && !getCurrentScope()) {
         return nuxtApp._scope.run(() => callWithNuxt(nuxtApp, fn))
       }
       return callWithNuxt(nuxtApp, fn)

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -1,4 +1,4 @@
-import { effectScope, getCurrentInstance, hasInjectionContext, reactive } from 'vue'
+import { effectScope, getCurrentInstance, getCurrentScope, hasInjectionContext, reactive } from 'vue'
 import type { App, EffectScope, Ref, VNode, onErrorCaptured } from 'vue'
 import type { RouteLocationNormalizedLoaded } from '#vue-router'
 import type { HookCallback, Hookable } from 'hookable'
@@ -101,7 +101,7 @@ interface _NuxtApp {
   hook: _NuxtApp['hooks']['hook']
   callHook: _NuxtApp['hooks']['callHook']
 
-  runWithContext: <T extends () => any>(fn: T) => ReturnType<T> | Promise<Awaited<ReturnType<T>>>
+  runWithContext: <T extends () => any>(fn: T, scope?: EffectScope) => ReturnType<T> | Promise<Awaited<ReturnType<T>>>
 
   [key: string]: unknown
 
@@ -254,9 +254,9 @@ export function createNuxtApp (options: CreateOptions) {
     static: {
       data: {},
     },
-    runWithContext (fn: any) {
-      if (nuxtApp._scope.active) {
-        return nuxtApp._scope.run(() => callWithNuxt(nuxtApp, fn))
+    runWithContext (fn: any, scope = nuxtApp._scope) {
+      if (scope.active && !getCurrentScope()) {
+        return scope.run(() => callWithNuxt(nuxtApp, fn))
       }
       return callWithNuxt(nuxtApp, fn)
     },

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -2605,3 +2605,13 @@ describe('lazy import components', () => {
     expect(html).toContain('lazy-named-comp-server')
   })
 })
+
+describe('defineNuxtComponent watch duplicate', () => {
+  it('test after navigation duplicate', async () => {
+    const { page } = await renderPage('/define-nuxt-component')
+    await page.getByTestId('define-nuxt-component-bar').click()
+    await page.getByTestId('define-nuxt-component-state').click()
+    await page.getByTestId('define-nuxt-component-foo').click()
+    expect(await page.getByTestId('define-nuxt-component-state').first().innerText()).toBe('2')
+  })
+})

--- a/test/fixtures/basic/pages/define-nuxt-component/index.vue
+++ b/test/fixtures/basic/pages/define-nuxt-component/index.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 export default defineNuxtComponent({
   name: 'DefineNuxtComponentTest',
-  setup() {
+  setup () {
     const router = useRouter()
 
     return {
@@ -13,7 +13,17 @@ export default defineNuxtComponent({
 
 <template>
   <div>
-    <div data-testid="define-nuxt-component-bar" @click="router.push('/define-nuxt-component/nested/bar')">Open bar</div>
-    <div data-testid="define-nuxt-component-foo" @click="router.push('/define-nuxt-component/nested/foo')">Open foo</div>
+    <div
+      data-testid="define-nuxt-component-bar"
+      @click="router.push('/define-nuxt-component/nested/bar')"
+    >
+      Open bar
+    </div>
+    <div
+      data-testid="define-nuxt-component-foo"
+      @click="router.push('/define-nuxt-component/nested/foo')"
+    >
+      Open foo
+    </div>
   </div>
 </template>

--- a/test/fixtures/basic/pages/define-nuxt-component/index.vue
+++ b/test/fixtures/basic/pages/define-nuxt-component/index.vue
@@ -1,0 +1,19 @@
+<script lang="ts">
+export default defineNuxtComponent({
+  name: 'DefineNuxtComponentTest',
+  setup() {
+    const router = useRouter()
+
+    return {
+      router,
+    }
+  },
+})
+</script>
+
+<template>
+  <div>
+    <div data-testid="define-nuxt-component-bar" @click="router.push('/define-nuxt-component/nested/bar')">Open bar</div>
+    <div data-testid="define-nuxt-component-foo" @click="router.push('/define-nuxt-component/nested/foo')">Open foo</div>
+  </div>
+</template>

--- a/test/fixtures/basic/pages/define-nuxt-component/nested/[foo].vue
+++ b/test/fixtures/basic/pages/define-nuxt-component/nested/[foo].vue
@@ -1,14 +1,14 @@
 <script lang="ts">
 export default defineNuxtComponent({
   name: 'DefineNuxtComponentTest',
-  setup() {
+  setup () {
     const state = useState('define-nuxt-component-counter', () => 0)
     const watcher = useState('define-nuxt-component-watcher', () => 0)
     const router = useRouter()
 
-    //Should trigger once per page on state change
+    // Should trigger once per page on state change
     watch(state, () => {
-        watcher.value++
+      watcher.value++
     })
 
     state.value++
@@ -24,6 +24,11 @@ export default defineNuxtComponent({
 
 <template>
   <div>
-    <div data-testid="define-nuxt-component-state" @click="router.push('/define-nuxt-component')">{{ watcher }}</div>
+    <div
+      data-testid="define-nuxt-component-state"
+      @click="router.push('/define-nuxt-component')"
+    >
+      {{ watcher }}
+    </div>
   </div>
 </template>

--- a/test/fixtures/basic/pages/define-nuxt-component/nested/[foo].vue
+++ b/test/fixtures/basic/pages/define-nuxt-component/nested/[foo].vue
@@ -1,0 +1,29 @@
+<script lang="ts">
+export default defineNuxtComponent({
+  name: 'DefineNuxtComponentTest',
+  setup() {
+    const state = useState('define-nuxt-component-counter', () => 0)
+    const watcher = useState('define-nuxt-component-watcher', () => 0)
+    const router = useRouter()
+
+    //Should trigger once per page on state change
+    watch(state, () => {
+        watcher.value++
+    })
+
+    state.value++
+
+    return {
+      state,
+      watcher,
+      router,
+    }
+  },
+})
+</script>
+
+<template>
+  <div>
+    <div data-testid="define-nuxt-component-state" @click="router.push('/define-nuxt-component')">{{ watcher }}</div>
+  </div>
+</template>


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #25029

### 📚 Description

This issue can cause significant problems for anybody using root watch on CSR with defineNuxtComponent.

Turns out the issue is runWithContext callback for setup. I don't think that removing that completely is needed since on SSR it's a good feature if you're using asyncContext.

So I've decided to simply remove this callback on client since there context is standalone. 

Fun fact: getCurrentInstance is *not* undefined there, so it could also possibly be upstream vue bug, but I'm not sure about it.