### PR TITLE
fix: small typo in docs

### DIFF
--- a/docs/1.getting-started/3.configuration.md
+++ b/docs/1.getting-started/3.configuration.md
@@ -135,7 +135,7 @@ Non primitive JS types         | ❌ No            | ✅ Yes
 
 ## External Configuration Files
 
-Nuxt uses [`nuxt.config.ts`](/docs/guide/directory-structure/nuxt-config) file as the single source of trust for configurations and skips reading external configuration files. During the course of building your project, you may have a need to configure those. The following table highlights common configurations and, where applicable, how they can be configured with Nuxt.
+Nuxt uses [`nuxt.config.ts`](/docs/guide/directory-structure/nuxt-config) file as the single source of truth for configurations and skips reading external configuration files. During the course of building your project, you may have a need to configure those. The following table highlights common configurations and, where applicable, how they can be configured with Nuxt.
 
 Name                                         | Config File               |  How To Configure
 ---------------------------------------------|---------------------------|-------------------------


### PR DESCRIPTION
### 🔗 Linked issue

No issue, this is just a small typo 

### 📚 Description

Docs state that "Nuxt uses [nuxt.config.ts](https://nuxt.com/docs/guide/directory-structure/nuxt-config) file as the single source of trust", this is probably a typo, meaning to use the expression "single source of truth".