### PR TITLE
docs: change `.eslintrc.js` in configuration to `eslint.config.js`

### DIFF
--- a/docs/1.getting-started/3.configuration.md
+++ b/docs/1.getting-started/3.configuration.md
@@ -149,7 +149,7 @@ Here is a list of other common config files:
 Name                                         | Config File             | How To Configure
 ---------------------------------------------|-------------------------|--------------------------
 [TypeScript](https://www.typescriptlang.org) | `tsconfig.json`         | [More Info](/docs/guide/concepts/typescript#nuxttsconfigjson)
-[ESLint](https://eslint.org)                 | `.eslintrc.js`          | [More Info](https://eslint.org/docs/latest/use/configure/configuration-files)
+[ESLint](https://eslint.org)                 | `eslint.config.js`          | [More Info](https://eslint.org/docs/latest/use/configure/configuration-files)
 [Prettier](https://prettier.io)              | `.prettierrc.json`      | [More Info](https://prettier.io/docs/en/configuration.html)
 [Stylelint](https://stylelint.io)            | `.stylelintrc.json`     | [More Info](https://stylelint.io/user-guide/configure)
 [TailwindCSS](https://tailwindcss.com)       |  `tailwind.config.js`   | [More Info](https://tailwindcss.nuxtjs.org/tailwind/config)

--- a/docs/1.getting-started/3.configuration.md
+++ b/docs/1.getting-started/3.configuration.md
@@ -149,7 +149,7 @@ Here is a list of other common config files:
 Name                                         | Config File             | How To Configure
 ---------------------------------------------|-------------------------|--------------------------
 [TypeScript](https://www.typescriptlang.org) | `tsconfig.json`         | [More Info](/docs/guide/concepts/typescript#nuxttsconfigjson)
-[ESLint](https://eslint.org)                 | `eslint.config.js`          | [More Info](https://eslint.org/docs/latest/use/configure/configuration-files)
+[ESLint](https://eslint.org)                 | `eslint.config.js`      | [More Info](https://eslint.org/docs/latest/use/configure/configuration-files)
 [Prettier](https://prettier.io)              | `.prettierrc.json`      | [More Info](https://prettier.io/docs/en/configuration.html)
 [Stylelint](https://stylelint.io)            | `.stylelintrc.json`     | [More Info](https://stylelint.io/user-guide/configure)
 [TailwindCSS](https://tailwindcss.com)       |  `tailwind.config.js`   | [More Info](https://tailwindcss.nuxtjs.org/tailwind/config)


### PR DESCRIPTION
### 📚 Description

As ESLint official has deprecated the legacy config file `.eslintrc.js` and so on, it should use `eslint.config.js` in documentation instead.