### PR TITLE
feat(nuxt): add `onUpdated` and `onUnmounted` into treeshakeable composables

### DIFF
--- a/packages/schema/src/config/build.ts
+++ b/packages/schema/src/config/build.ts
@@ -165,7 +165,7 @@ export default defineUntypedSchema({
             await get('dev')
               ? {}
               : {
-                  'vue': ['onBeforeMount', 'onMounted', 'onBeforeUpdate', 'onUpdated', 'onUnmounted', 'onRenderTracked', 'onRenderTriggered', 'onActivated', 'onDeactivated', 'onBeforeUnmount'],
+                  'vue': ['onMounted', 'onUpdated', 'onUnmounted', 'onBeforeMount', 'onBeforeUpdate', 'onBeforeUnmount', 'onRenderTracked', 'onRenderTriggered', 'onActivated', 'onDeactivated'],
                   '#app': ['definePayloadReviver', 'definePageMeta'],
                 },
           ),
@@ -175,7 +175,7 @@ export default defineUntypedSchema({
             await get('dev')
               ? {}
               : {
-                  'vue': ['onServerPrefetch', 'onRenderTracked', 'onRenderTriggered'],
+                  'vue': ['onRenderTracked', 'onRenderTriggered', 'onServerPrefetch'],
                   '#app': ['definePayloadReducer', 'definePageMeta'],
                 },
           ),

--- a/packages/schema/src/config/build.ts
+++ b/packages/schema/src/config/build.ts
@@ -165,7 +165,7 @@ export default defineUntypedSchema({
             await get('dev')
               ? {}
               : {
-                  'vue': ['onBeforeMount', 'onMounted', 'onBeforeUpdate', 'onRenderTracked', 'onRenderTriggered', 'onActivated', 'onDeactivated', 'onBeforeUnmount'],
+                  'vue': ['onBeforeMount', 'onMounted', 'onBeforeUpdate', 'onUpdated', 'onUnmounted', 'onRenderTracked', 'onRenderTriggered', 'onActivated', 'onDeactivated', 'onBeforeUnmount'],
                   '#app': ['definePayloadReviver', 'definePageMeta'],
                 },
           ),


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 📚 Description

Currently, `optimization.treeShake.composables` missing some composable, such as `onUpdated` and `onUnmounted`.

https://github.com/nuxt/nuxt/blob/2c39b3ce610b946ad9397911c7ac099021651b02/packages/schema/src/config/build.ts#L163-L172

This PR adds these two composables and adjusts the sorting to match the order on the vue document.
