### PR TITLE
feat(nuxt): make `<NuxtPage>` exposes default slots

### DIFF
--- a/packages/nuxt/src/pages/runtime/page.ts
+++ b/packages/nuxt/src/pages/runtime/page.ts
@@ -1,4 +1,4 @@
-import { Suspense, Transition, defineComponent, h, inject, nextTick, ref, watch } from 'vue'
+import { Fragment, Suspense, Transition, defineComponent, h, inject, nextTick, ref, watch } from 'vue'
 import type { KeepAliveProps, TransitionProps, VNode } from 'vue'
 import { RouterView } from '#vue-router'
 import { defu } from 'defu'
@@ -37,7 +37,7 @@ export default defineComponent({
       default: null,
     },
   },
-  setup (props, { attrs, expose }) {
+  setup (props, { attrs, slots, expose }) {
     const nuxtApp = useNuxtApp()
     const pageRef = ref()
     const forkRoute = inject(PageRouteSymbol, null)
@@ -120,7 +120,7 @@ export default defineComponent({
               default: () => {
                 const providerVNode = h(RouteProvider, {
                   key: key || undefined,
-                  vnode: routeProps.Component,
+                  vnode: slots.default ? h(Fragment, undefined, slots.default(routeProps)) : routeProps.Component,
                   route: routeProps.route,
                   renderKey: key || undefined,
                   trackRootNodes: hasTransition,


### PR DESCRIPTION
### 🔗 Linked issue

Resolve #26998 

### 📚 Description

After this PR, we can use `<NuxtPage>` more like `<RouterView>` like bellow:

```html
<NuxtPage v-slot="{ Component: component }">
  <Component :is="component" />
</NuxtPage>
```

The code above is equivalent to using `<NuxtPage />` without the slot, but the slot provides extra flexibility when we want to work with other features.
