### PR TITLE
fix(nuxt): deprecate `process.*` flags

### DIFF
--- a/packages/nuxt/src/app/types/augments.d.ts
+++ b/packages/nuxt/src/app/types/augments.d.ts
@@ -1,20 +1,29 @@
 import type { UseHeadInput } from '@unhead/vue'
 import type { NuxtApp, useNuxtApp } from '../nuxt'
 
-interface NuxtStaticBuildFlags {
-  browser: boolean
-  client: boolean
-  dev: boolean
-  server: boolean
-  test: boolean
-}
-
 declare global {
   namespace NodeJS {
-    interface Process extends NuxtStaticBuildFlags {}
+    interface Process {
+      /** @deprecated Use `import.meta.browser` instead. This may be removed in Nuxt v5 or a future major version. */
+      browser: boolean
+      /** @deprecated Use `import.meta.client` instead. This may be removed in Nuxt v5 or a future major version. */
+      client: boolean
+      /** @deprecated Use `import.meta.dev` instead. This may be removed in Nuxt v5 or a future major version. */
+      dev: boolean
+      /** @deprecated Use `import.meta.server` instead. This may be removed in Nuxt v5 or a future major version. */
+      server: boolean
+      /** @deprecated Use `import.meta.test` instead. This may be removed in Nuxt v5 or a future major version. */
+      test: boolean
+    }
   }
 
-  interface ImportMeta extends NuxtStaticBuildFlags {}
+  interface ImportMeta extends NuxtStaticBuildFlags {
+    browser: boolean
+    client: boolean
+    dev: boolean
+    server: boolean
+    test: boolean
+  }
 
   interface Window {
     __NUXT__?: Record<string, any>


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/26474

### 📚 Description

This deprecates `process.client`/`process.server` and starts the process of working towards fully using `import.meta.*` in Nuxt v5.
