### PR TITLE
chore: update root monorepo node engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   },
   "packageManager": "pnpm@9.1.0",
   "engines": {
-    "node": "^14.18.0 || >=16.10.0"
+    "node": "^16.10.0 || >=18.0.0"
   },
   "version": ""
 }


### PR DESCRIPTION
### 🔗 Linked issue

related nuxt/cli#356 , #23821, https://github.com/nuxt/nuxt/pull/23821#pullrequestreview-1689862898

### 📚 Description

Update the minimum required node version to match `version` in [nuxt/cli/package.json](https://github.com/nuxt/cli/blob/b9868fedcb4545b9f84372005801ba86d4ff1b46/package.json#L89-L91).

I also try to match the minimum node version mentioned in the [documentation](https://nuxt.com/docs/getting-started/installation#prerequisites).

### 🗒️ Note

All GitHub Actions workflows were `node-version: 20` (nuxt2 only `node-version: 18`).
Therefore, we believe that there will be no impact on existing workflow.