### PR TITLE
docs: improve testing component examples 

### DIFF
--- a/docs/1.getting-started/11.testing.md
+++ b/docs/1.getting-started/11.testing.md
@@ -160,20 +160,27 @@ export default defineVitestConfig({
 `mountSuspended` allows you to mount any Vue component within the Nuxt environment, allowing async setup and access to injections from your Nuxt plugins. For example:
 
 ```ts twoslash
-import type { Component } from 'vue'
 import { it, expect } from 'vitest'
-declare const SomeComponent: Component
-declare const App: Component
 // ---cut---
 // tests/components/SomeComponents.nuxt.spec.ts
 import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { SomeComponent } from '#components'
 
 it('can mount some component', async () => {
     const component = await mountSuspended(SomeComponent)
     expect(component.text()).toMatchInlineSnapshot(
-        'This is an auto-imported component'
+        '"This is an auto-imported component"'
     )
 })
+
+```
+
+```ts twoslash
+import { it, expect } from 'vitest'
+// ---cut---
+// tests/components/SomeComponents.nuxt.spec.ts
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import App from '~/app.vue'
 
 // tests/App.nuxt.spec.ts
 it('can also mount an app', async () => {
@@ -199,13 +206,11 @@ The passed in component will be rendered inside a `<div id="test-wrapper"></div>
 Examples:
 
 ```ts twoslash
-import type { Component } from 'vue'
 import { it, expect } from 'vitest'
-declare const SomeComponent: Component
-declare const App: Component
 // ---cut---
 // tests/components/SomeComponents.nuxt.spec.ts
 import { renderSuspended } from '@nuxt/test-utils/runtime'
+import { SomeComponent } from '#components'
 import { screen } from '@testing-library/vue'
 
 it('can render some component', async () => {
@@ -215,13 +220,11 @@ it('can render some component', async () => {
 ```
 
 ```ts twoslash
-import type { Component } from 'vue'
 import { it, expect } from 'vitest'
-declare const SomeComponent: Component
-declare const App: Component
 // ---cut---
 // tests/App.nuxt.spec.ts
 import { renderSuspended } from '@nuxt/test-utils/runtime'
+import App from '~/app.vue'
 
 it('can also render an app', async () => {
   const html = await renderSuspended(App, { route: '/test' })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #27120.

Thanks @danielroe for the pointer on the import shortcut.

I made a PR with some related tweaks - hopefully improvements.

- I removed the declaration of the Components and the associated Component type import since they are no longer necessary.
- I split the first example in two since the comments indicate they are separate files.
- I used the @ directory alias to do the app import (`import App from '@/app.vue'`) but maybe there is another way?