### PR TITLE
chore(nuxt): move ui-templates to workspace link

### DIFF
--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -117,7 +117,7 @@
     "vue-router": "^4.3.2"
   },
   "devDependencies": {
-    "@nuxt/ui-templates": "link:../ui-templates",
+    "@nuxt/ui-templates": "workspace:*",
     "@parcel/watcher": "2.4.1",
     "@types/estree": "1.0.5",
     "@types/fs-extra": "11.0.4",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -117,7 +117,7 @@
     "vue-router": "^4.3.2"
   },
   "devDependencies": {
-    "@nuxt/ui-templates": "1.3.3",
+    "@nuxt/ui-templates": "link:../ui-templates",
     "@parcel/watcher": "2.4.1",
     "@types/estree": "1.0.5",
     "@types/fs-extra": "11.0.4",

--- a/packages/nuxt/src/core/runtime/nitro/error-500.ts
+++ b/packages/nuxt/src/core/runtime/nitro/error-500.ts
@@ -1,1 +1,1 @@
-../../../../../ui-templates/dist/templates/error-500.ts
+export * from '@nuxt/ui-templates/dist/templates/error-500'

--- a/packages/nuxt/src/core/runtime/nitro/error-500.ts
+++ b/packages/nuxt/src/core/runtime/nitro/error-500.ts
@@ -1,1 +1,1 @@
-export * from '@nuxt/ui-templates/dist/templates/error-500'
+export * from '../../../../../ui-templates/dist/templates/error-dev'

--- a/packages/nuxt/src/core/runtime/nitro/error-dev.ts
+++ b/packages/nuxt/src/core/runtime/nitro/error-dev.ts
@@ -1,1 +1,1 @@
-../../../../../ui-templates/dist/templates/error-dev.ts
+export * from '@nuxt/ui-templates/dist/templates/error-dev'

--- a/packages/nuxt/src/core/runtime/nitro/error-dev.ts
+++ b/packages/nuxt/src/core/runtime/nitro/error-dev.ts
@@ -1,1 +1,1 @@
-export * from '@nuxt/ui-templates/dist/templates/error-dev'
+export * from '../../../../../ui-templates/dist/templates/error-dev'


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

Hey :wave: 

This PR moves symlinks to workspace link with `workspace*` and re-export what was symlinked.... because this doesn't work on windows :(
<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
