### PR TITLE
fix: index.d.ts for plugins (#app → nuxt/app)

### DIFF
--- a/docs/2.guide/2.directory-structure/1.plugins.md
+++ b/docs/2.guide/2.directory-structure/1.plugins.md
@@ -216,7 +216,7 @@ If you need to use a provided helper _within_ another plugin, you can call [`use
 For advanced use-cases, you can declare the type of injected properties like this:
 
 ```ts [index.d.ts]
-declare module '#app' {
+declare module 'nuxt/app' {
   interface NuxtApp {
     $hello (msg: string): string
   }


### PR DESCRIPTION
### 📚 Description

I tried to manually type my plugin (I'm making a custom $fetch) because *.ts is linted by non-Nuxt-aware tslint/tsserver/etc instead of volar and therefore (I assume) can't simply infer types from the defineNuxtPlugin call.

I banged my head against the wall for a good while until I realized `#app` should actually read `nuxt/app`. :-)