### PR TITLE
docs: update module execution order in guides and modules jsdocs

### DIFF
--- a/docs/2.guide/2.directory-structure/1.modules.md
+++ b/docs/2.guide/2.directory-structure/1.modules.md
@@ -46,7 +46,11 @@ export default defineEventHandler(() => {
 
 When starting Nuxt, the `hello` module will be registered and the `/api/hello` route will be available.
 
-Local modules are registered in alphabetical order. You can change the order by adding a number to the front of each directory name:
+Modules are executed in the following sequence:
+- First, the modules defined in [`nuxt.config.ts`](/docs/api/nuxt-config#modules-1) are loaded.
+- Then, modules found in the `modules/` directory are executed, and they load in alphabetical order.
+
+You can change the order of local module by adding a number to the front of each directory name:
 
 ```bash [Directory structure]
 modules/

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -236,7 +236,7 @@ export default defineUntypedSchema({
    *
    * Nuxt tries to resolve each item in the modules array using node require path
    * (in `node_modules`) and then will be resolved from project `srcDir` if `~` alias is used.
-   * @note Modules are executed sequentially so the order is important. First, the modules defined in `nuxt.config.ts` are loaded. Then, modules found in the `modules/` 
+   * @note Modules are executed sequentially so the order is important. First, the modules defined in `nuxt.config.ts` are loaded. Then, modules found in the `modules/`
    * directory are executed, and they load in alphabetical order.
    * @example
    * ```js

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -236,7 +236,8 @@ export default defineUntypedSchema({
    *
    * Nuxt tries to resolve each item in the modules array using node require path
    * (in `node_modules`) and then will be resolved from project `srcDir` if `~` alias is used.
-   * @note Modules are executed sequentially so the order is important.
+   * @note Modules are executed sequentially so the order is important. First, the modules defined in `nuxt.config.ts` are loaded. Then, modules found in the `modules/` 
+   * directory are executed, and they load in alphabetical order.
    * @example
    * ```js
    * modules: [


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #26813

### 📚 Description

This PR updates docs and modules description with modules execution order.
