### PR TITLE
docs: better explain how environment variables work in production

### DIFF
--- a/docs/2.guide/2.directory-structure/2.env.md
+++ b/docs/2.guide/2.directory-structure/2.env.md
@@ -43,16 +43,18 @@ This design decision was made to ensure compatibility across various deployment 
 
 Since `.env` files are not used in production, you must explicitly set environment variables using the tools and methods provided by your hosting environment. Here are some common approaches:
 
-### Pass the environment variables as arguments using the terminal:
+### Pass the environment variables as arguments using the terminal
 
 ```bash [Terminal]
 DATABASE_HOST=mydatabaseconnectionstring node .output/server/index.mjs
 ```
 
 ### Shell Configuration Files
+
 You can set environment variables in shell configuration files like `.bashrc` or `.profile`.
 
 ### Cloud Service Interfaces
+
 Many cloud service providers like Vercel, Netlify, and AWS provide interfaces for setting environment variables via their dashboards, CLI tools or configuration files.
 
 ## Production Preview

--- a/docs/2.guide/2.directory-structure/2.env.md
+++ b/docs/2.guide/2.directory-structure/2.env.md
@@ -45,17 +45,15 @@ Since `.env` files are not used in production, you must explicitly set environme
 
 * Pass the environment variables as arguments using the terminal
 
-```bash [Terminal]
-DATABASE_HOST=mydatabaseconnectionstring node .output/server/index.mjs
-```
+   `$ DATABASE_HOST=mydatabaseconnectionstring node .output/server/index.mjs`
 
 * Shell Configuration Files
 
-You can set environment variables in shell configuration files like `.bashrc` or `.profile`.
+   You can set environment variables in shell configuration files like `.bashrc` or `.profile`.
 
 * Cloud Service Interfaces
 
-Many cloud service providers like Vercel, Netlify, and AWS provide interfaces for setting environment variables via their dashboards, CLI tools or configuration files.
+   Many cloud service providers like Vercel, Netlify, and AWS provide interfaces for setting environment variables via their dashboards, CLI tools or configuration files.
 
 ## Production Preview
 

--- a/docs/2.guide/2.directory-structure/2.env.md
+++ b/docs/2.guide/2.directory-structure/2.env.md
@@ -43,17 +43,17 @@ This design decision was made to ensure compatibility across various deployment 
 
 Since `.env` files are not used in production, you must explicitly set environment variables using the tools and methods provided by your hosting environment. Here are some common approaches:
 
-### Pass the environment variables as arguments using the terminal
+* Pass the environment variables as arguments using the terminal
 
 ```bash [Terminal]
 DATABASE_HOST=mydatabaseconnectionstring node .output/server/index.mjs
 ```
 
-### Shell Configuration Files
+* Shell Configuration Files
 
 You can set environment variables in shell configuration files like `.bashrc` or `.profile`.
 
-### Cloud Service Interfaces
+* Cloud Service Interfaces
 
 Many cloud service providers like Vercel, Netlify, and AWS provide interfaces for setting environment variables via their dashboards, CLI tools or configuration files.
 

--- a/docs/2.guide/2.directory-structure/2.env.md
+++ b/docs/2.guide/2.directory-structure/2.env.md
@@ -43,17 +43,13 @@ This design decision was made to ensure compatibility across various deployment 
 
 Since `.env` files are not used in production, you must explicitly set environment variables using the tools and methods provided by your hosting environment. Here are some common approaches:
 
-* Pass the environment variables as arguments using the terminal
+* You can pass the environment variables as arguments using the terminal:
 
    `$ DATABASE_HOST=mydatabaseconnectionstring node .output/server/index.mjs`
 
-* Shell Configuration Files
+* You can set environment variables in shell configuration files like `.bashrc` or `.profile`.
 
-   You can set environment variables in shell configuration files like `.bashrc` or `.profile`.
-
-* Cloud Service Interfaces
-
-   Many cloud service providers like Vercel, Netlify, and AWS provide interfaces for setting environment variables via their dashboards, CLI tools or configuration files.
+* Many cloud service providers, such as Vercel, Netlify, and AWS, provide interfaces for setting environment variables via their dashboards, CLI tools or configuration files.
 
 ## Production Preview
 

--- a/docs/2.guide/2.directory-structure/2.env.md
+++ b/docs/2.guide/2.directory-structure/2.env.md
@@ -33,11 +33,29 @@ npx nuxi dev --dotenv .env.local
 
 When updating `.env` in development mode, the Nuxt instance is automatically restarted to apply new values to the `process.env`.
 
-## Production Preview
+## Production
 
 **After your server is built**, you are responsible for setting environment variables when you run the server.
 
-Your `.env` file will not be read at this point. How you do this is different for every environment.
+Your `.env` files will not be read at this point. How you do this is different for every environment.
+
+This design decision was made to ensure compatibility across various deployment environments, some of which may not have a traditional file system available, such as serverless platforms or edge networks like Cloudflare Workers.
+
+Since `.env` files are not used in production, you must explicitly set environment variables using the tools and methods provided by your hosting environment. Here are some common approaches:
+
+### Pass the environment variables as arguments using the terminal:
+
+```bash [Terminal]
+DATABASE_HOST=mydatabaseconnectionstring node .output/server/index.mjs
+```
+
+### Shell Configuration Files
+You can set environment variables in shell configuration files like `.bashrc` or `.profile`.
+
+### Cloud Service Interfaces
+Many cloud service providers like Vercel, Netlify, and AWS provide interfaces for setting environment variables via their dashboards, CLI tools or configuration files.
+
+## Production Preview
 
 For local production preview purpose, we recommend using [`nuxi preview`](/docs/api/commands/preview) since using this command, the `.env` file will be loaded into `process.env` for convenience. Note that this command requires dependencies to be installed in the package directory.
 


### PR DESCRIPTION
### 📚 Description

We see a lot of people still being confused about why their `.env` or `.env.prod` files are not being read in production, especially people coming from Laravel or other PHP frameworks where `.env` files are being picked up automatically in production. Nuxt does it slightly differently, since it can be deployed to serverless or edge environments where a traditional filesystem isn't even available. So hopefully this will clear the confusion and explain the reasoning behind this design decision.

This PR also lists some specific ways that env variables can be set in production so people are not left wondering how to do it.