### PR TITLE
feat(nuxt): auto-register layers in `layers/` directory

### DIFF
--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -10,7 +10,7 @@ import { readPackageJSON, resolvePackageJSON } from 'pkg-types'
 
 import escapeRE from 'escape-string-regexp'
 import fse from 'fs-extra'
-import { withoutLeadingSlash } from 'ufo'
+import { withTrailingSlash, withoutLeadingSlash } from 'ufo'
 
 import defu from 'defu'
 import pagesModule from '../pages/module'
@@ -70,6 +70,17 @@ async function initNuxt (nuxt: Nuxt) {
       nuxt.hooks.addHooks(config.hooks)
     }
   }
+
+  // Restart Nuxt when layer directories are added or removed
+  const layersDir = withTrailingSlash(resolve(nuxt.options.rootDir, 'layers'))
+  nuxt.hook('builder:watch', (event, relativePath) => {
+    const path = resolve(nuxt.options.srcDir, relativePath)
+    if (event === 'addDir' || event === 'unlinkDir') {
+      if (path.startsWith(layersDir)) {
+        return nuxt.callHook('restart', { hard: true })
+      }
+    }
+  })
 
   // Set nuxt instance for useNuxt
   nuxtCtx.set(nuxt)

--- a/test/fixtures/basic/layers/bar/nuxt.config.ts
+++ b/test/fixtures/basic/layers/bar/nuxt.config.ts
@@ -1,0 +1,8 @@
+export default defineNuxtConfig({
+  modules: [
+    function (_options, nuxt) {
+      // @ts-expect-error not valid nuxt option
+      nuxt.options.__installed_layer = true
+    }
+  ],
+})

--- a/test/fixtures/basic/layers/bar/nuxt.config.ts
+++ b/test/fixtures/basic/layers/bar/nuxt.config.ts
@@ -3,6 +3,6 @@ export default defineNuxtConfig({
     function (_options, nuxt) {
       // @ts-expect-error not valid nuxt option
       nuxt.options.__installed_layer = true
-    }
+    },
   ],
 })

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -92,6 +92,14 @@ export default defineNuxtConfig({
     },
   },
   modules: [
+    function (_options, nuxt) {
+      nuxt.hook('modules:done', () => {
+        // @ts-expect-error not valid nuxt option
+        if (!nuxt.options.__installed_layer) {
+          throw new Error('layer in layers/ directory was not auto-registered')
+        }
+      })
+    },
     '~/modules/subpath',
     './modules/test',
     '~/modules/example',


### PR DESCRIPTION
### 🔗 Linked issue

follow up on https://github.com/nuxt/nuxt/issues/26444

### 📚 Description

This auto-registers layers located in a top-level `~~/layers` directory. To avoid collisions with user layer configuration, it adds a new internal `_extends` key to nuxt options, and then instructs `c12` to read from that. This seems like a more straightforward/correct way than attempting to add an auto-registration feature to `c12` itself.

Would love your thoughts particularly @pi0 with regard to c12 approach.