### PR TITLE
docs: add cache option to useFetch params

### DIFF
--- a/docs/3.api/2.composables/use-fetch.md
+++ b/docs/3.api/2.composables/use-fetch.md
@@ -87,6 +87,8 @@ Watch the video from Alexander Lichter to avoid using `useFetch` the wrong way!
   - `headers`: Request headers.
   - `baseURL`: Base URL for the request.
   - `timeout`: Milliseconds to automatically abort request
+  - `cache`: Handles cache control according to [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/fetch#cache)
+    - You can pass boolean to disable the cache or you can pass one of the following values: `default`, `no-store`, `reload`, `no-cache`, `force-cache`, and `only-if-cached`.
 
 ::note
 All fetch options can be given a `computed` or `ref` value. These will be watched and new requests made automatically with any new values if they are updated.


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #27080

### 📚 Description

Added `cache` param to `useFetch`composable documentation.
