### PR TITLE
fix(nuxt): pass path to `jiti` and not file URL

### DIFF
--- a/packages/nuxt/src/core/schema.ts
+++ b/packages/nuxt/src/core/schema.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs'
 import { mkdir, writeFile } from 'node:fs/promises'
-import { pathToFileURL } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import { dirname, resolve } from 'pathe'
 import chokidar from 'chokidar'
 import { interopDefault } from 'mlly'
@@ -26,7 +26,7 @@ export default defineNuxtModule({
     const resolver = createResolver(import.meta.url)
 
     // Initialize untyped/jiti loader
-    const _resolveSchema = jiti(dirname(import.meta.url), {
+    const _resolveSchema = jiti(dirname(fileURLToPath(import.meta.url)), {
       esmResolve: true,
       interopDefault: true,
       cache: false,


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/test-utils/pull/848

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Discovered in https://github.com/nuxt/test-utils/pull/848, we were passing fileURL via dirname -> jiti, which was yielding an invalid path of `file:\\\D:\...\...` on windows machines. Not sure of the cause at the moment, but it seems like we probably should be passing a file path rather than URL anyway.

cc: @pi0

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
