### PR TITLE
feat(nuxt,schema): add new `appId` option and improve chunk determinism

### DIFF
--- a/packages/nuxt/src/app/composables/manifest.ts
+++ b/packages/nuxt/src/app/composables/manifest.ts
@@ -1,7 +1,6 @@
 import type { MatcherExport, RouteMatcher } from 'radix3'
 import { createMatcherFromExport, createRouter as createRadixRouter, toRouteMatcher } from 'radix3'
 import { defu } from 'defu'
-import { useAppConfig } from '../config'
 import { useRuntimeConfig } from '../nuxt'
 // @ts-expect-error virtual file
 import { appManifest as isAppManifestEnabled } from '#build/nuxt.config.mjs'

--- a/packages/nuxt/src/app/composables/manifest.ts
+++ b/packages/nuxt/src/app/composables/manifest.ts
@@ -25,9 +25,7 @@ function fetchManifest () {
   if (!isAppManifestEnabled) {
     throw new Error('[nuxt] app manifest should be enabled with `experimental.appManifest`')
   }
-  // @ts-expect-error private property
-  const buildId = useAppConfig().nuxt?.buildId
-  manifest = $fetch<NuxtAppManifest>(buildAssetsURL(`builds/meta/${buildId}.json`))
+  manifest = $fetch<NuxtAppManifest>(buildAssetsURL(`builds/meta/${useRuntimeConfig().app.buildId}.json`))
   manifest.then((m) => {
     matcher = createMatcherFromExport(m.matcher)
   })

--- a/packages/nuxt/src/app/composables/payload.ts
+++ b/packages/nuxt/src/app/composables/payload.ts
@@ -3,7 +3,6 @@ import { parse } from 'devalue'
 import { useHead } from '@unhead/vue'
 import { getCurrentInstance } from 'vue'
 import { useNuxtApp, useRuntimeConfig } from '../nuxt'
-import { useAppConfig } from '../config'
 
 import { useRoute } from './router'
 import { getAppManifest, getRouteRules } from './manifest'

--- a/packages/nuxt/src/app/composables/payload.ts
+++ b/packages/nuxt/src/app/composables/payload.ts
@@ -57,8 +57,9 @@ function _getPayloadURL (url: string, opts: LoadPayloadOptions = {}) {
   if (u.host !== 'localhost' || hasProtocol(u.pathname, { acceptRelative: true })) {
     throw new Error('Payload URL must not include hostname: ' + url)
   }
-  const hash = opts.hash || (opts.fresh ? Date.now() : (useAppConfig().nuxt as any)?.buildId)
-  return joinURL(useRuntimeConfig().app.baseURL, u.pathname, filename + (hash ? `?${hash}` : ''))
+  const config = useRuntimeConfig()
+  const hash = opts.hash || (opts.fresh ? Date.now() : config.app.buildId)
+  return joinURL(config.app.baseURL, u.pathname, filename + (hash ? `?${hash}` : ''))
 }
 
 async function _importPayload (payloadURL: string) {

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -244,6 +244,7 @@ export interface CreateOptions {
 export function createNuxtApp (options: CreateOptions) {
   let hydratingCount = 0
   const nuxtApp: NuxtApp = {
+    _name: appId || 'nuxt-app',
     _scope: effectScope(),
     provide: undefined,
     globalName: 'nuxt',
@@ -378,8 +379,6 @@ export function createNuxtApp (options: CreateOptions) {
   // Expose runtime config
   const runtimeConfig = import.meta.server ? options.ssrContext!.runtimeConfig : nuxtApp.payload.config!
   nuxtApp.provide('config', runtimeConfig)
-
-  nuxtApp._name = runtimeConfig.app.id || appId || 'nuxt-app'
 
   return nuxtApp
 }

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -20,9 +20,10 @@ import type { LoadingIndicator } from '../app/composables/loading-indicator'
 import type { RouteAnnouncer } from '../app/composables/route-announcer'
 import type { ViewTransition } from './plugins/view-transitions.client'
 
-import type { NuxtAppLiterals } from '#app'
+// @ts-expect-error virtual file
+import { appId } from '#build/nuxt.config.mjs'
 
-let appId = ''
+import type { NuxtAppLiterals } from '#app'
 
 function getNuxtAppCtx (appName = appId || 'nuxt-app') {
   return getContext<NuxtApp>(appName, {
@@ -378,7 +379,7 @@ export function createNuxtApp (options: CreateOptions) {
   const runtimeConfig = import.meta.server ? options.ssrContext!.runtimeConfig : nuxtApp.payload.config!
   nuxtApp.provide('config', runtimeConfig)
 
-  appId = nuxtApp._name = runtimeConfig.app.id || 'nuxt-app'
+  nuxtApp._name = runtimeConfig.app.id || appId || 'nuxt-app'
 
   return nuxtApp
 }

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -20,9 +20,9 @@ import type { LoadingIndicator } from '../app/composables/loading-indicator'
 import type { RouteAnnouncer } from '../app/composables/route-announcer'
 import type { ViewTransition } from './plugins/view-transitions.client'
 
-let appId = ''
-
 import type { NuxtAppLiterals } from '#app'
+
+let appId = ''
 
 function getNuxtAppCtx (appName = appId || 'nuxt-app') {
   return getContext<NuxtApp>(appName, {

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -22,11 +22,8 @@ import type { ViewTransition } from './plugins/view-transitions.client'
 
 import type { NuxtAppLiterals } from '#app'
 
-// @ts-expect-error virtual import
-import { buildId } from '#build/nuxt.config.mjs'
-
 function getNuxtAppCtx (appName?: string) {
-  return getContext<NuxtApp>(appName || buildId || 'nuxt-app', {
+  return getContext<NuxtApp>(appName || 'nuxt-app', {
     asyncContext: !!__NUXT_ASYNC_CONTEXT__ && import.meta.server,
   })
 }
@@ -244,7 +241,6 @@ export interface CreateOptions {
 export function createNuxtApp (options: CreateOptions) {
   let hydratingCount = 0
   const nuxtApp: NuxtApp = {
-    name: buildId,
     _scope: effectScope(),
     provide: undefined,
     globalName: 'nuxt',
@@ -379,6 +375,8 @@ export function createNuxtApp (options: CreateOptions) {
   // Expose runtime config
   const runtimeConfig = import.meta.server ? options.ssrContext!.runtimeConfig : nuxtApp.payload.config!
   nuxtApp.provide('config', runtimeConfig)
+
+  nuxtApp.name = runtimeConfig.app.id || 'nuxt-app'
 
   return nuxtApp
 }

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -376,7 +376,7 @@ export function createNuxtApp (options: CreateOptions) {
   const runtimeConfig = import.meta.server ? options.ssrContext!.runtimeConfig : nuxtApp.payload.config!
   nuxtApp.provide('config', runtimeConfig)
 
-  nuxtApp.name = runtimeConfig.app.id || 'nuxt-app'
+  nuxtApp._name = runtimeConfig.app.id || 'nuxt-app'
 
   return nuxtApp
 }

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -20,10 +20,12 @@ import type { LoadingIndicator } from '../app/composables/loading-indicator'
 import type { RouteAnnouncer } from '../app/composables/route-announcer'
 import type { ViewTransition } from './plugins/view-transitions.client'
 
+let appId = ''
+
 import type { NuxtAppLiterals } from '#app'
 
-function getNuxtAppCtx (appName?: string) {
-  return getContext<NuxtApp>(appName || 'nuxt-app', {
+function getNuxtAppCtx (appName = appId || 'nuxt-app') {
+  return getContext<NuxtApp>(appName, {
     asyncContext: !!__NUXT_ASYNC_CONTEXT__ && import.meta.server,
   })
 }
@@ -376,7 +378,7 @@ export function createNuxtApp (options: CreateOptions) {
   const runtimeConfig = import.meta.server ? options.ssrContext!.runtimeConfig : nuxtApp.payload.config!
   nuxtApp.provide('config', runtimeConfig)
 
-  nuxtApp._name = runtimeConfig.app.id || 'nuxt-app'
+  appId = nuxtApp._name = runtimeConfig.app.id || 'nuxt-app'
 
   return nuxtApp
 }

--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -218,8 +218,7 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
 
   // Add app manifest handler and prerender configuration
   if (nuxt.options.experimental.appManifest) {
-    // @ts-expect-error untyped nuxt property
-    const buildId = nuxt.options.appConfig.nuxt!.buildId ||=
+    const buildId = nuxt.options.runtimeConfig.app.buildId ||=
       (nuxt.options.dev ? 'dev' : nuxt.options.test ? 'test' : nuxt.options.buildId)
     const buildTimestamp = Date.now()
 

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -21,7 +21,7 @@ import type { HeadEntryOptions } from '@unhead/schema'
 import type { Link, Script, Style } from '@unhead/vue'
 import { createServerHead } from '@unhead/vue'
 
-import { defineRenderHandler, getRouteRules, useAppConfig, useRuntimeConfig, useStorage } from '#internal/nitro'
+import { defineRenderHandler, getRouteRules, useRuntimeConfig, useStorage } from '#internal/nitro'
 import { useNitroApp } from '#internal/nitro/app'
 
 // @ts-expect-error virtual file
@@ -327,7 +327,7 @@ export default defineRenderHandler(async (event): Promise<Partial<RenderResponse
 
   // Whether we are prerendering route
   const _PAYLOAD_EXTRACTION = import.meta.prerender && process.env.NUXT_PAYLOAD_EXTRACTION && !ssrContext.noSSR && !isRenderingIsland
-  const payloadURL = _PAYLOAD_EXTRACTION ? joinURL(ssrContext.runtimeConfig.app.baseURL, url, process.env.NUXT_JSON_PAYLOADS ? '_payload.json' : '_payload.js') + '?' + (useAppConfig().nuxt as any)?.buildId : undefined
+  const payloadURL = _PAYLOAD_EXTRACTION ? joinURL(ssrContext.runtimeConfig.app.baseURL, url, process.env.NUXT_JSON_PAYLOADS ? '_payload.json' : '_payload.js') + '?' + ssrContext.runtimeConfig.app.buildId : undefined
   if (import.meta.prerender) {
     ssrContext.payload.prerenderedAt = Date.now()
   }

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -397,6 +397,7 @@ export const nuxtConfigTemplate: NuxtTemplate = {
       `export const fetchDefaults = ${JSON.stringify(fetchDefaults)}`,
       `export const vueAppRootContainer = ${ctx.nuxt.options.app.rootId ? `'#${ctx.nuxt.options.app.rootId}'` : `'body > ${ctx.nuxt.options.app.rootTag}'`}`,
       `export const viewTransition = ${ctx.nuxt.options.experimental.viewTransition}`,
+      `export const appId = ${JSON.stringify(ctx.nuxt.options.appId)}`,
     ].join('\n\n')
   },
 }

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -397,7 +397,6 @@ export const nuxtConfigTemplate: NuxtTemplate = {
       `export const fetchDefaults = ${JSON.stringify(fetchDefaults)}`,
       `export const vueAppRootContainer = ${ctx.nuxt.options.app.rootId ? `'#${ctx.nuxt.options.app.rootId}'` : `'body > ${ctx.nuxt.options.app.rootTag}'`}`,
       `export const viewTransition = ${ctx.nuxt.options.experimental.viewTransition}`,
-      `export const buildId = ${JSON.stringify(ctx.nuxt.options.buildId)}`,
     ].join('\n\n')
   },
 }

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -535,12 +535,11 @@ export default defineUntypedSchema({
    */
   runtimeConfig: {
     $resolve: async (val: RuntimeConfig, get): Promise<Record<string, unknown>> => {
-      const [app, appId, buildId] = await Promise.all([get('app') as Promise<Record<string, string>>, get('appId') as Promise<string>, get('buildId') as Promise<string>])
+      const [app, buildId] = await Promise.all([get('app') as Promise<Record<string, string>>, get('buildId') as Promise<string>])
       provideFallbackValues(val)
       return defu(val, {
         public: {},
         app: {
-          id: appId,
           buildId,
           baseURL: app.baseURL,
           buildAssetsDir: app.buildAssetsDir,

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -155,6 +155,13 @@ export default defineUntypedSchema({
   },
 
   /**
+   * For multi-app projects, the unique name of the Nuxt application.
+   */
+  appId: {
+    $resolve: (val: string) => val ?? 'nuxt-app',
+  },
+
+  /**
    * A unique identifier matching the build. This may contain the hash of the current state of the project.
    */
   buildId: {
@@ -528,11 +535,12 @@ export default defineUntypedSchema({
    */
   runtimeConfig: {
     $resolve: async (val: RuntimeConfig, get): Promise<Record<string, unknown>> => {
-      const app = await get('app') as Record<string, string>
+      const [app, appId] = await Promise.all([get('app') as Promise<Record<string, string>>, get('appId') as Promise<string>])
       provideFallbackValues(val)
       return defu(val, {
         public: {},
         app: {
+          id: appId,
           baseURL: app.baseURL,
           buildAssetsDir: app.buildAssetsDir,
           cdnURL: app.cdnURL,

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -535,12 +535,13 @@ export default defineUntypedSchema({
    */
   runtimeConfig: {
     $resolve: async (val: RuntimeConfig, get): Promise<Record<string, unknown>> => {
-      const [app, appId] = await Promise.all([get('app') as Promise<Record<string, string>>, get('appId') as Promise<string>])
+      const [app, appId, buildId] = await Promise.all([get('app') as Promise<Record<string, string>>, get('appId') as Promise<string>, get('buildId') as Promise<string>])
       provideFallbackValues(val)
       return defu(val, {
         public: {},
         app: {
           id: appId,
+          buildId,
           baseURL: app.baseURL,
           buildAssetsDir: app.buildAssetsDir,
           cdnURL: app.cdnURL,

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -2028,15 +2028,9 @@ describe('app config', () => {
       fromLayer: true,
       userConfig: 123,
     }
-    if (isTestingAppManifest) {
-      expectedAppConfig.nuxt.buildId = 'test'
-    }
-    expect.soft(html.replace(/"nuxt":\{"buildId":"[^"]+"\}/, '"nuxt":{"buildId":"test"}')).toContain(JSON.stringify(expectedAppConfig))
+    expect.soft(html).toContain(JSON.stringify(expectedAppConfig))
 
     const serverAppConfig = await $fetch('/api/app-config')
-    if (isTestingAppManifest) {
-      serverAppConfig.appConfig.nuxt.buildId = 'test'
-    }
     expect(serverAppConfig).toMatchObject({ appConfig: expectedAppConfig })
   })
 })
@@ -2649,23 +2643,23 @@ describe('defineNuxtComponent watch duplicate', () => {
 })
 
 describe('namespace access to useNuxtApp', () => {
-  it('should return the nuxt instance when used with correct buildId', async () => {
+  it('should return the nuxt instance when used with correct appId', async () => {
     const { page, pageErrors } = await renderPage('/namespace-nuxt-app')
 
     expect(pageErrors).toEqual([])
 
     await page.waitForFunction(() => window.useNuxtApp?.() && !window.useNuxtApp?.().isHydrating)
 
-    // Defaulting to buildId
+    // Defaulting to appId
     await page.evaluate(() => window.useNuxtApp?.())
-    // Using correct configured buildId
+    // Using correct configured appId
     // @ts-expect-error not public API yet
     await page.evaluate(() => window.useNuxtApp?.('nuxt-app-basic'))
 
     await page.close()
   })
 
-  it('should throw an error when used with wrong buildId', async () => {
+  it('should throw an error when used with wrong appId', async () => {
     const { page, pageErrors } = await renderPage('/namespace-nuxt-app')
 
     expect(pageErrors).toEqual([])
@@ -2674,7 +2668,7 @@ describe('namespace access to useNuxtApp', () => {
 
     let error: unknown
     try {
-      // Using wrong/unknown buildId
+      // Using wrong/unknown appId
       // @ts-expect-error not public API yet
       await page.evaluate(() => window.useNuxtApp?.('nuxt-app-unknown'))
     } catch (err) {

--- a/test/fixtures/basic-types/types.ts
+++ b/test/fixtures/basic-types/types.ts
@@ -534,7 +534,7 @@ describe('composables', () => {
 describe('app config', () => {
   it('merges app config as expected', () => {
     interface ExpectedMergedAppConfig {
-      nuxt: { buildId: string }
+      nuxt: {}
       fromLayer: boolean
       fromNuxtConfig: boolean
       nested: {

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -32,7 +32,7 @@ export default defineNuxtConfig({
   },
   buildDir: process.env.NITRO_BUILD_DIR,
   builder: process.env.TEST_BUILDER as 'webpack' | 'vite' ?? 'vite',
-  buildId: 'nuxt-app-basic',
+  appId: 'nuxt-app-basic',
   build: {
     transpile: [
       (ctx) => {

--- a/test/fixtures/minimal-types/types.ts
+++ b/test/fixtures/minimal-types/types.ts
@@ -51,7 +51,7 @@ describe('config typings', () => {
   it('appConfig', () => {
     expectTypeOf(useAppConfig().foo).toEqualTypeOf<unknown>()
     expectTypeOf(useAppConfig()).toEqualTypeOf<{
-      nuxt: { buildId: string }
+      nuxt: {}
       [key: string]: unknown
     }>()
   })

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -30,9 +30,7 @@ describe('app config', () => {
     const appConfig = useAppConfig()
     expect(appConfig).toMatchInlineSnapshot(`
       {
-        "nuxt": {
-          "buildId": "override",
-        },
+        "nuxt": {},
       }
     `)
     updateAppConfig({
@@ -44,7 +42,6 @@ describe('app config', () => {
       {
         "new": "value",
         "nuxt": {
-          "buildId": "override",
           "nested": 42,
         },
       }

--- a/vitest.nuxt.config.ts
+++ b/vitest.nuxt.config.ts
@@ -13,12 +13,11 @@ export default defineVitestConfig({
     environmentOptions: {
       nuxt: {
         overrides: {
-          buildId: 'nuxt-app',
           experimental: {
             appManifest: process.env.TEST_MANIFEST !== 'manifest-off',
           },
-          appConfig: {
-            nuxt: {
+          runtimeConfig: {
+            app: {
               buildId: 'override',
             },
           },


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This adds a new `appId` option and passes both `appId` and `buildId` via runtimeConfig. This means we don't have all chunk hashes changing on _every_ build. (Caused by entry file chunk hash changing with new buildId, and then every other file that imported the entry file changing because _that_ file name changed.)