### PR TITLE
chore: remove redundant eslint-plugin-regexp

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,7 +5,6 @@ import noOnlyTests from 'eslint-plugin-no-only-tests'
 import typegen from 'eslint-typegen'
 // @ts-expect-error missing types
 import perfectionist from 'eslint-plugin-perfectionist'
-import regex from 'eslint-plugin-regexp'
 
 export default createConfigForNuxt({
   features: {
@@ -217,9 +216,6 @@ export default createConfigForNuxt({
         'vue/multi-word-component-names': 'off',
       },
     },
-
-    // @ts-ignore types misaligned
-    regex.configs['flat/recommended'],
   )
 
   // Generate type definitions for the eslint config

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "eslint": "9.2.0",
     "eslint-plugin-no-only-tests": "3.1.0",
     "eslint-plugin-perfectionist": "2.10.0",
-    "eslint-plugin-regexp": "2.5.0",
     "eslint-typegen": "0.2.4",
     "execa": "9.1.0",
     "fs-extra": "11.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,9 +77,6 @@ importers:
       eslint-plugin-perfectionist:
         specifier: 2.10.0
         version: 2.10.0(eslint@9.2.0)(typescript@5.4.5)(vue-eslint-parser@9.4.2(eslint@9.2.0))
-      eslint-plugin-regexp:
-        specifier: 2.5.0
-        version: 2.5.0(eslint@9.2.0)
       eslint-typegen:
         specifier: 0.2.4
         version: 0.2.4(eslint@9.2.0)


### PR DESCRIPTION
It's now part of the `@nuxt/eslint-config`, we don't need add it manually anymore