### PR TITLE
fix(schema): handle dev/test `buildId` in schema

### DIFF
--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -218,8 +218,7 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
 
   // Add app manifest handler and prerender configuration
   if (nuxt.options.experimental.appManifest) {
-    const buildId = nuxt.options.runtimeConfig.app.buildId ||=
-      (nuxt.options.dev ? 'dev' : nuxt.options.test ? 'test' : nuxt.options.buildId)
+    const buildId = nuxt.options.runtimeConfig.app.buildId ||= nuxt.options.buildId
     const buildTimestamp = Date.now()
 
     const manifestPrefix = joinURL(nuxt.options.app.buildAssetsDir, 'builds')

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -166,7 +166,7 @@ export default defineUntypedSchema({
    */
   buildId: {
     $resolve: async (val: string | undefined, get): Promise<string> => {
-      if (typeof val === 'string') return val
+      if (typeof val === 'string') { return val }
 
       const [isDev, isTest] = await Promise.all([get('dev') as Promise<boolean>, get('test') as Promise<boolean>])
       return isDev ? 'dev' : isTest ? 'test' : randomUUID()

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -165,7 +165,12 @@ export default defineUntypedSchema({
    * A unique identifier matching the build. This may contain the hash of the current state of the project.
    */
   buildId: {
-    $resolve: (val: string) => val ?? randomUUID(),
+    $resolve: async (val: string | undefined, get): Promise<string> => {
+      if (typeof val === 'string') return val
+
+      const [isDev, isTest] = await Promise.all([get('dev') as Promise<boolean>, get('test') as Promise<boolean>])
+      return isDev ? 'dev' : isTest ? 'test' : randomUUID()
+    },
   },
 
   /**

--- a/vitest.nuxt.config.ts
+++ b/vitest.nuxt.config.ts
@@ -13,13 +13,9 @@ export default defineVitestConfig({
     environmentOptions: {
       nuxt: {
         overrides: {
+          buildId: 'override',
           experimental: {
             appManifest: process.env.TEST_MANIFEST !== 'manifest-off',
-          },
-          runtimeConfig: {
-            app: {
-              buildId: 'override',
-            },
           },
         },
       },


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This addresses a regression in testing with https://github.com/nuxt/nuxt/pull/27258 that prevented overriding `buildId` in test/dev mode.