### PR TITLE
docs: add example of passing params to `<NuxtLink>`

### DIFF
--- a/docs/3.api/1.components/4.nuxt-link.md
+++ b/docs/3.api/1.components/4.nuxt-link.md
@@ -38,7 +38,7 @@ In this example, we pass the `id` param to link to the route `~/pages/posts/[id]
 ```
 
 ::tip
-Check out the Pages panel in Nuxt Devtools to see the route name and the params it might take.
+Check out the Pages panel in Nuxt DevTools to see the route name and the params it might take.
 ::
 
 ### Handling 404s

--- a/docs/3.api/1.components/4.nuxt-link.md
+++ b/docs/3.api/1.components/4.nuxt-link.md
@@ -25,6 +25,18 @@ In this example, we use `<NuxtLink>` component to link to another page of the ap
 </template>
 ```
 
+### Passing Params to Dynamic Routes
+
+In this example, we pass the `id` param to link to the route `~/pages/posts/[id].vue`.
+
+```vue [pages/index.vue]
+<template>
+  <NuxtLink :to={ name: 'posts-id', params: { id: 123 }>
+    Post 123
+  </NuxtLink>
+</template>
+```
+
 ### Handling 404s
 
 When using `<NuxtLink>` for `/public` directory files or when pointing to a different app on the same domain, you should use the `external` prop.

--- a/docs/3.api/1.components/4.nuxt-link.md
+++ b/docs/3.api/1.components/4.nuxt-link.md
@@ -31,11 +31,15 @@ In this example, we pass the `id` param to link to the route `~/pages/posts/[id]
 
 ```vue [pages/index.vue]
 <template>
-  <NuxtLink :to={ name: 'posts-id', params: { id: 123 }>
+  <NuxtLink :to="{ name: 'posts-id', params: { id: 123 } }">
     Post 123
   </NuxtLink>
 </template>
 ```
+
+::tip
+Check out the Pages panel in Nuxt Devtools to see the route name and the params it might take.
+::
 
 ### Handling 404s
 


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #27283

### 📚 Description

Add example to NuxtLink documentation for passing params to dynamic routes. The documentation currently lacks an example.
