### PR TITLE
feat(schema): add `multiApp` future flag

### DIFF
--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -46,6 +46,11 @@ export default defineUntypedSchema({
      */
     compatibilityVersion: 3,
     /**
+     * This enables early access to the experimental multi-app support.
+     * @see [Nuxt Issue #21635](https://github.com/nuxt/nuxt/issues/21635)
+     */
+    multiApp: false,
+    /**
      * This enables 'Bundler' module resolution mode for TypeScript, which is the recommended setting
      * for frameworks like Nuxt and Vite.
      *


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

Related to 2nd task of multi-app support issue: #21635 

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

This PR adds a new `future` flag to `@nuxt/schema`: `multiApp`. It's disabled by default and will be used to protect breaking changes with global var `window.__NUXT__` and HTML ids `__NUXT_DATA__` and `__NUXT_LOGS__`.

See draft PR https://github.com/nuxt/nuxt/pull/27263.

This new flag can also be used to provide multi-app support with `win.__NUXT__` in [nuxt/test-utils](https://github.com/nuxt/test-utils/blob/main/src/environments/vitest/index.ts#L35)

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
