### PR TITLE
perf(nuxt): abort vue render when plugins throw error

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-root.vue
+++ b/packages/nuxt/src/app/components/nuxt-root.vue
@@ -1,7 +1,8 @@
 <template>
   <Suspense @resolve="onResolve">
+    <div v-if="abortRender" />
     <ErrorComponent
-      v-if="error"
+      v-else-if="error"
       :error="error"
     />
     <IslandRenderer
@@ -53,6 +54,8 @@ if (import.meta.dev && results && results.some(i => i && 'then' in i)) {
 
 // error handling
 const error = useError()
+// render an empty <div> when plugins have thrown an error but we're not yet rendering the error page
+const abortRender = import.meta.server && error.value && !nuxtApp.ssrContext.error
 onErrorCaptured((err, target, info) => {
   nuxtApp.hooks.callHook('vue:error', err, target, info).catch(hookError => console.error('[nuxt] Error in `vue:error` hook', hookError))
   if (import.meta.server || (isNuxtError(err) && (err.fatal || err.unhandled))) {


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/25518

### 📚 Description

It turns out that when we were throwing an error in plugins (or anywhere before the vue app started rendering) we were then rendering the error page twice - once on the initial request (which is discarded) and then again when we are intentionally rendering an error page.

A possible performance improvement might be using that initial render instead of running plugins twice. But for now, I think it's safer to keep the separated error render for consistency.