### PR TITLE
fix(vite): ignore query/hash when resolving public assets

### DIFF
--- a/packages/vite/src/plugins/public-dirs.ts
+++ b/packages/vite/src/plugins/public-dirs.ts
@@ -12,7 +12,7 @@ export const VitePublicDirsPlugin = createUnplugin(() => {
   function resolveFromPublicAssets (id: string) {
     for (const dir of nitro.options.publicAssets) {
       if (!id.startsWith(withTrailingSlash(dir.baseURL || '/'))) { continue }
-      const path = id.replace(withTrailingSlash(dir.baseURL || '/'), withTrailingSlash(dir.dir))
+      const path = id.replace(/[?#].*$/, '').replace(withTrailingSlash(dir.baseURL || '/'), withTrailingSlash(dir.dir))
       if (existsSync(path)) {
         return id
       }

--- a/test/fixtures/basic/pages/assets-custom.vue
+++ b/test/fixtures/basic/pages/assets-custom.vue
@@ -1,6 +1,7 @@
 <template>
   <div>
     <img src="/public.svg">
+    <img src="/public.svg?123">
     <img src="/custom/file.svg">
   </div>
 </template>


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/27290

### 📚 Description

We check to see if public assets exist on disk - this PR updates the implementation to ignore query/hash before doing so.