### PR TITLE
feat(nuxt): add dev reviver for VNode and do not deduplicate server/client logs

### DIFF
--- a/packages/nuxt/src/app/plugins/dev-server-logs.ts
+++ b/packages/nuxt/src/app/plugins/dev-server-logs.ts
@@ -1,4 +1,4 @@
-import { consola, createConsola } from 'consola'
+import { createConsola } from 'consola'
 import type { LogObject } from 'consola'
 import { parse } from 'devalue'
 
@@ -29,32 +29,11 @@ export default defineNuxtPlugin((nuxtApp) => {
         date: true,
       },
     })
-    const hydrationLogs = new Set<string>()
-    consola.wrapConsole()
-    consola.addReporter({
-      log (logObj) {
-        try {
-          hydrationLogs.add(JSON.stringify(logObj.args))
-        } catch {
-          // silently ignore - the worst case is a user gets log twice
-        }
-      },
-    })
     nuxtApp.hook('dev:ssr-logs', (logs) => {
       for (const log of logs) {
-        // deduplicate so we don't print out things that are logged on client
-        try {
-          if (!hydrationLogs.size || !hydrationLogs.has(JSON.stringify(log.args))) {
-            logger.log(normalizeServerLog({ ...log }))
-          }
-        } catch {
-          logger.log(normalizeServerLog({ ...log }))
-        }
+        logger.log(normalizeServerLog({ ...log }))
       }
     })
-
-    nuxtApp.hooks.hook('app:suspense:resolve', () => consola.restoreAll())
-    nuxtApp.hooks.hookOnce('dev:ssr-logs', () => hydrationLogs.clear())
   }
 
   // pass SSR logs after hydration

--- a/packages/nuxt/src/app/plugins/dev-server-logs.ts
+++ b/packages/nuxt/src/app/plugins/dev-server-logs.ts
@@ -2,15 +2,17 @@ import { createConsola } from 'consola'
 import type { LogObject } from 'consola'
 import { parse } from 'devalue'
 
+import { h } from 'vue'
 import { defineNuxtPlugin } from '../nuxt'
 
 // @ts-expect-error virtual file
 import { devLogs, devRootDir } from '#build/nuxt.config.mjs'
-import { h } from 'vue'
 
-const devRevivers: Record<string, (data: any) => any> = import.meta.server ? {} : {
-  VNode: data => h(data.type, data.props),
-}
+const devRevivers: Record<string, (data: any) => any> = import.meta.server
+  ? {}
+  : {
+      VNode: data => h(data.type, data.props),
+    }
 
 export default defineNuxtPlugin((nuxtApp) => {
   if (import.meta.test) { return }

--- a/packages/nuxt/src/app/plugins/dev-server-logs.ts
+++ b/packages/nuxt/src/app/plugins/dev-server-logs.ts
@@ -6,11 +6,10 @@ import { defineNuxtPlugin } from '../nuxt'
 
 // @ts-expect-error virtual file
 import { devLogs, devRootDir } from '#build/nuxt.config.mjs'
-import { defineComponent, h } from 'vue'
+import { h } from 'vue'
 
 const devRevivers: Record<string, (data: any) => any> = import.meta.server ? {} : {
   VNode: data => h(data.type, data.props),
-  Component: data => defineComponent(data),
 }
 
 export default defineNuxtPlugin((nuxtApp) => {

--- a/packages/nuxt/src/app/plugins/dev-server-logs.ts
+++ b/packages/nuxt/src/app/plugins/dev-server-logs.ts
@@ -14,7 +14,7 @@ const devRevivers: Record<string, (data: any) => any> = import.meta.server
       VNode: data => h(data.type, data.props),
     }
 
-export default defineNuxtPlugin((nuxtApp) => {
+export default defineNuxtPlugin(async (nuxtApp) => {
   if (import.meta.test) { return }
 
   if (import.meta.server) {
@@ -37,14 +37,11 @@ export default defineNuxtPlugin((nuxtApp) => {
     })
   }
 
-  // pass SSR logs after hydration
-  nuxtApp.hooks.hook('app:suspense:resolve', async () => {
-    if (typeof window !== 'undefined') {
-      const content = document.getElementById('__NUXT_LOGS__')?.textContent
-      const logs = content ? parse(content, { ...devRevivers, ...nuxtApp._payloadRevivers }) as LogObject[] : []
-      await nuxtApp.hooks.callHook('dev:ssr-logs', logs)
-    }
-  })
+  if (typeof window !== 'undefined') {
+    const content = document.getElementById('__NUXT_LOGS__')?.textContent
+    const logs = content ? parse(content, { ...devRevivers, ...nuxtApp._payloadRevivers }) as LogObject[] : []
+    await nuxtApp.hooks.callHook('dev:ssr-logs', logs)
+  }
 })
 
 function normalizeFilenames (stack?: string) {

--- a/packages/nuxt/src/app/plugins/dev-server-logs.ts
+++ b/packages/nuxt/src/app/plugins/dev-server-logs.ts
@@ -6,6 +6,12 @@ import { defineNuxtPlugin } from '../nuxt'
 
 // @ts-expect-error virtual file
 import { devLogs, devRootDir } from '#build/nuxt.config.mjs'
+import { defineComponent, h } from 'vue'
+
+const devRevivers: Record<string, (data: any) => any> = import.meta.server ? {} : {
+  VNode: data => h(data.type, data.props),
+  Component: data => defineComponent(data),
+}
 
 export default defineNuxtPlugin((nuxtApp) => {
   if (import.meta.test) { return }
@@ -55,7 +61,7 @@ export default defineNuxtPlugin((nuxtApp) => {
   nuxtApp.hooks.hook('app:suspense:resolve', async () => {
     if (typeof window !== 'undefined') {
       const content = document.getElementById('__NUXT_LOGS__')?.textContent
-      const logs = content ? parse(content, nuxtApp._payloadRevivers) as LogObject[] : []
+      const logs = content ? parse(content, { ...devRevivers, ...nuxtApp._payloadRevivers }) as LogObject[] : []
       await nuxtApp.hooks.callHook('dev:ssr-logs', logs)
     }
   })

--- a/packages/nuxt/src/core/runtime/nitro/dev-server-logs.ts
+++ b/packages/nuxt/src/core/runtime/nitro/dev-server-logs.ts
@@ -6,11 +6,11 @@ import type { H3Event } from 'h3'
 import { withTrailingSlash } from 'ufo'
 import { getContext } from 'unctx'
 
+import { isVNode } from 'vue'
 import type { NitroApp } from '#internal/nitro/app'
 
 // @ts-expect-error virtual file
 import { rootDir } from '#internal/dev-server-logs-options'
-import { isVNode } from 'vue'
 
 const devReducers: Record<string, (data: any) => any> = {
   VNode: data => isVNode(data) ? { type: data.type, props: data.props } : undefined,

--- a/packages/nuxt/src/core/runtime/nitro/dev-server-logs.ts
+++ b/packages/nuxt/src/core/runtime/nitro/dev-server-logs.ts
@@ -14,8 +14,6 @@ import { isVNode } from 'vue'
 
 const devReducers: Record<string, (data: any) => any> = {
   VNode: data => isVNode(data) ? { type: data.type, props: data.props } : undefined,
-  Component: data => data && typeof data === 'object' && '$slots' in data ? {
-  } : undefined,
 }
 
 interface NuxtDevAsyncContext {


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/27130

### 📚 Description

Because Vue calls `console.warn` when stringifying a Vue component, it will trigger an infinite loop if consola is wrapping `console` when stringifying a Vue warning. Non-Nuxt issue/example here: https://github.com/unjs/consola/issues/298.

For now, given how common it is for Vue to warn about non-existing components (a typo is sufficient!) I think the best solution is just to remove the ability to deduplicate server/client logs, which means users may get duplicate logs.

We can revisit later if we implement loop protection upstream.

I've also added another reducer/revivers _only_ for logs, which handles VNode type. Other ideas to improve DX would be welcome.

