### PR TITLE
fix(nuxt): add module declarations for virtual files

### DIFF
--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -129,6 +129,8 @@ async function initNuxt (nuxt: Nuxt) {
     if (nuxt.options.typescript.shim) {
       opts.references.push({ path: resolve(nuxt.options.buildDir, 'types/vue-shim.d.ts') })
     }
+    // Add shims for `#build/*` imports that do not already have matching types
+    opts.references.push({ path: resolve(nuxt.options.buildDir, 'types/build.d.ts') })
     // Add module augmentations directly to NuxtConfig
     opts.references.push({ path: resolve(nuxt.options.buildDir, 'types/schema.d.ts') })
     opts.references.push({ path: resolve(nuxt.options.buildDir, 'types/app.config.d.ts') })

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -414,6 +414,7 @@ export const nuxtConfigTemplate: NuxtTemplate = {
   },
 }
 
+const TYPE_FILENAME_RE = /\.([cm])?[jt]s$/
 export const buildTypeTemplate: NuxtTemplate = {
   filename: 'types/build.d.ts',
   getContents ({ app }) {
@@ -424,12 +425,11 @@ export const buildTypeTemplate: NuxtTemplate = {
         continue
       }
 
-      const typeFilenames = [
-        file.filename.replace(/\.([cm])?[jt]s$/, '.d.$1ts'),
-        file.filename.replace(/\.([cm])?[jt]s$/, '.d.ts'),
-      ]
-      if (app.templates.some(f => f.filename && typeFilenames.includes(f.filename))) {
-        continue
+      if (TYPE_FILENAME_RE.test(file.filename)) {
+        const typeFilenames = new Set([file.filename.replace(TYPE_FILENAME_RE, '.d.$1ts'), file.filename.replace(TYPE_FILENAME_RE, '.d.ts')])
+        if (app.templates.some(f => f.filename && typeFilenames.has(f.filename))) {
+          continue
+        }
       }
 
       if (!file.filename.endsWith('.d.ts')) {

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -415,13 +415,14 @@ export const nuxtConfigTemplate: NuxtTemplate = {
 }
 
 const TYPE_FILENAME_RE = /\.([cm])?[jt]s$/
+const DECLARATION_RE = /\.d\.[cm]?ts$/
 export const buildTypeTemplate: NuxtTemplate = {
   filename: 'types/build.d.ts',
   getContents ({ app }) {
     let declarations = ''
 
     for (const file of app.templates) {
-      if (file.write || !file.filename || file.filename.endsWith('.d.ts')) {
+      if (file.write || !file.filename || DECLARATION_RE.test(file.filename)) {
         continue
       }
 

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -413,3 +413,30 @@ export const nuxtConfigTemplate: NuxtTemplate = {
     ].join('\n\n')
   },
 }
+
+export const buildTypeTemplate: NuxtTemplate = {
+  filename: 'types/build.d.ts',
+  getContents({ app }) {
+    let declarations = ''
+
+    for (const file of app.templates) {
+      if (file.write || !file.filename || file.filename.endsWith('.d.ts')) {
+        continue
+      }
+
+      const typeFilenames = [
+        file.filename.replace(/\.([cm])?[jt]s$/, '.d.$1ts'),
+        file.filename.replace(/\.([cm])?[jt]s$/, '.d.ts')
+      ]
+      if (app.templates.some(f => f.filename && typeFilenames.includes(f.filename))) {
+        continue
+      }
+
+      if (!file.filename.endsWith('.d.ts')) {
+        declarations += 'declare module ' + JSON.stringify(join('#build', file.filename)) + ';\n'
+      }
+    }
+
+    return declarations
+  }
+}

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -416,7 +416,7 @@ export const nuxtConfigTemplate: NuxtTemplate = {
 
 export const buildTypeTemplate: NuxtTemplate = {
   filename: 'types/build.d.ts',
-  getContents({ app }) {
+  getContents ({ app }) {
     let declarations = ''
 
     for (const file of app.templates) {
@@ -426,7 +426,7 @@ export const buildTypeTemplate: NuxtTemplate = {
 
       const typeFilenames = [
         file.filename.replace(/\.([cm])?[jt]s$/, '.d.$1ts'),
-        file.filename.replace(/\.([cm])?[jt]s$/, '.d.ts')
+        file.filename.replace(/\.([cm])?[jt]s$/, '.d.ts'),
       ]
       if (app.templates.some(f => f.filename && typeFilenames.includes(f.filename))) {
         continue
@@ -438,5 +438,5 @@ export const buildTypeTemplate: NuxtTemplate = {
     }
 
     return declarations
-  }
+  },
 }

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -432,9 +432,7 @@ export const buildTypeTemplate: NuxtTemplate = {
         }
       }
 
-      if (!file.filename.endsWith('.d.ts')) {
-        declarations += 'declare module ' + JSON.stringify(join('#build', file.filename)) + ';\n'
-      }
+      declarations += 'declare module ' + JSON.stringify(join('#build', file.filename)) + ';\n'
     }
 
     return declarations


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/22421
resolves https://github.com/danielroe/nuxt-time/issues/252

### 📚 Description

This PR suppresses type warnings for imports from `#build/*` by generating a `types/build.d.ts` file.

This should mean that module authors can safely import from these paths (as they will be written to disk in their case) and consumers of the modules will not have type errors. 🤞 

Because of the potential surface area of type issues this needs wider testing (e.g. ecosystem-ci + some targeted testing of modules).