### PR TITLE
fix(nuxt): provide default data type values in nuxt/app dir

### DIFF
--- a/packages/nuxt/index.d.ts
+++ b/packages/nuxt/index.d.ts
@@ -19,10 +19,4 @@ declare global {
   }
 }
 
-declare module '#app/defaults' {
-  type DefaultAsyncDataErrorValue = undefined
-  type DefaultAsyncDataValue = undefined
-  type DefaultErrorValue = undefined
-}
-
 export {}

--- a/packages/nuxt/src/app/defaults.js
+++ b/packages/nuxt/src/app/defaults.js
@@ -1,2 +1,0 @@
-// TODO: temporary module for backwards compatibility
-export {}

--- a/packages/nuxt/src/app/defaults.ts
+++ b/packages/nuxt/src/app/defaults.ts
@@ -1,7 +1,7 @@
 // TODO: temporary module for backwards compatibility
 
-export type DefaultAsyncDataErrorValue = undefined
-export type DefaultAsyncDataValue = undefined
-export type DefaultErrorValue = undefined
+export type DefaultAsyncDataErrorValue = null
+export type DefaultAsyncDataValue = null
+export type DefaultErrorValue = null
 
 export {}

--- a/packages/nuxt/src/app/defaults.ts
+++ b/packages/nuxt/src/app/defaults.ts
@@ -1,0 +1,7 @@
+// TODO: temporary module for backwards compatibility
+
+export type DefaultAsyncDataErrorValue = undefined
+export type DefaultAsyncDataValue = undefined
+export type DefaultErrorValue = undefined
+
+export {}


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/ecosystem-ci/actions/runs/9185601389/job/25259855681

### 📚 Description

This moves the types for `#app/defaults` into a file, which means that `@nuxt/module-builder` can resolve them.