### PR TITLE
docs: introduce hint and link to environment override feature (#25812)

### DIFF
--- a/docs/1.getting-started/11.testing.md
+++ b/docs/1.getting-started/11.testing.md
@@ -373,7 +373,7 @@ registerEndpoint('/test/', {
 })
 ```
 
-> **Note**: If your requests in a component go to external API, you can use `baseURL` and then make it empty using Nuxt Environment Config (`$test`) so all your requests will go to Nitro server.
+> **Note**: If your requests in a component go to an external API, you can use `baseURL` and then make it empty using [Nuxt Environment Override Config](/docs/getting-started/configuration#environment-overrides) (`$test`) so all your requests will go to Nitro server.
 
 #### Conflict with End-To-End Testing
 


### PR DESCRIPTION
### 🔗 Linked Issue

Reference: #25812

### 📚 Description

This small quality of life improvement is aimed at helping those who are not very familiar with the Nuxt ecosystem.

Rephrasing the scenario from the issue:

A visitor stumbles upon the hint in the [testing documentation](https://nuxt.com/docs/getting-started/testing):

> Note: If your requests in a component go to external API, you can use baseURL and then make it empty using Nuxt Environment Config ($test) so all your requests will go to Nitro server.

Searching for `$test` or `Environment Config` does not yield any results, which can be a potential dead end.

As @manniL stated in the issue, it is perfectly documented in [Environment Overrides](https://nuxt.com/docs/getting-started/configuration#environment-overrides).

This PR introduces a small augmentation to the hint to make sure it is clear.

In hindsight, I understand the hint, and one might call it fussy to cross-link docs for such a small example. However, I would argue that overriding configurations at a framework level with a feature like this is not yet commonly understood by developers and therefore deserves a link like this.
