### PR TITLE
fix(vite): suppress warning about unresolved public assets

### DIFF
--- a/packages/vite/src/plugins/public-dirs.ts
+++ b/packages/vite/src/plugins/public-dirs.ts
@@ -7,17 +7,7 @@ import { dirname, relative } from 'pathe'
 const PREFIX = 'virtual:public?'
 
 export const VitePublicDirsPlugin = createUnplugin(() => {
-  const nitro = useNitro()
-
-  function resolveFromPublicAssets (id: string) {
-    for (const dir of nitro.options.publicAssets) {
-      if (!id.startsWith(withTrailingSlash(dir.baseURL || '/'))) { continue }
-      const path = id.replace(/[?#].*$/, '').replace(withTrailingSlash(dir.baseURL || '/'), withTrailingSlash(dir.dir))
-      if (existsSync(path)) {
-        return id
-      }
-    }
-  }
+  const { resolveFromPublicAssets } = useResolveFromPublicAssets()
 
   return {
     name: 'nuxt:vite-public-dir-resolution',
@@ -62,3 +52,19 @@ export const VitePublicDirsPlugin = createUnplugin(() => {
     },
   }
 })
+
+export function useResolveFromPublicAssets () {
+  const nitro = useNitro()
+
+  function resolveFromPublicAssets (id: string) {
+    for (const dir of nitro.options.publicAssets) {
+      if (!id.startsWith(withTrailingSlash(dir.baseURL || '/'))) { continue }
+      const path = id.replace(/[?#].*$/, '').replace(withTrailingSlash(dir.baseURL || '/'), withTrailingSlash(dir.dir))
+      if (existsSync(path)) {
+        return id
+      }
+    }
+  }
+
+  return { resolveFromPublicAssets }
+}

--- a/packages/vite/src/plugins/public-dirs.ts
+++ b/packages/vite/src/plugins/public-dirs.ts
@@ -6,8 +6,9 @@ import { dirname, relative } from 'pathe'
 import MagicString from 'magic-string'
 
 const PREFIX = 'virtual:public?'
+const CSS_URL_RE = /url\((\/[^)]+)\)/g
 
-export const VitePublicDirsPlugin = createUnplugin(() => {
+export const VitePublicDirsPlugin = createUnplugin((options: { sourcemap?: boolean }) => {
   const { resolveFromPublicAssets } = useResolveFromPublicAssets()
 
   return {
@@ -88,5 +89,3 @@ export function useResolveFromPublicAssets () {
 
   return { resolveFromPublicAssets }
 }
-
-const CSS_URL_RE = /url\((\/[^)]+)\)/g

--- a/packages/vite/src/utils/logger.ts
+++ b/packages/vite/src/utils/logger.ts
@@ -35,7 +35,7 @@ export function createViteLogger (config: vite.InlineConfig): vite.Logger {
       // Hide sourcemap warnings related to node_modules
       if (msg.startsWith('Sourcemap') && msg.includes('node_modules')) { return }
       // Hide warnings about externals produced by https://github.com/vitejs/vite/blob/v5.2.11/packages/vite/src/node/plugins/css.ts#L350-L355
-      if (msg.includes("didn't resolve at build time, it will remain unchanged to be resolved at runtime")) {
+      if (msg.includes('didn\'t resolve at build time, it will remain unchanged to be resolved at runtime')) {
         const id = msg.trim().match(/^([^ ]+) referenced in/m)?.[1]
         if (id && resolveFromPublicAssets(id)) { return }
       }

--- a/packages/vite/src/utils/logger.ts
+++ b/packages/vite/src/utils/logger.ts
@@ -3,6 +3,7 @@ import { logger } from '@nuxt/kit'
 import { hasTTY, isCI } from 'std-env'
 import clear from 'clear'
 import type { NuxtOptions } from '@nuxt/schema'
+import { useResolveFromPublicAssets } from '../plugins/public-dirs'
 
 let duplicateCount = 0
 let lastType: vite.LogType | null = null
@@ -26,6 +27,8 @@ export function createViteLogger (config: vite.InlineConfig): vite.Logger {
   const canClearScreen = hasTTY && !isCI && config.clearScreen
   const clearScreen = canClearScreen ? clear : () => {}
 
+  const { resolveFromPublicAssets } = useResolveFromPublicAssets()
+
   function output (type: vite.LogType, msg: string, options: vite.LogErrorOptions = {}) {
     if (typeof msg === 'string' && !process.env.DEBUG) {
       // TODO: resolve upstream in Vite
@@ -34,7 +37,7 @@ export function createViteLogger (config: vite.InlineConfig): vite.Logger {
       // Hide warnings about externals produced by https://github.com/vitejs/vite/blob/v5.2.11/packages/vite/src/node/plugins/css.ts#L350-L355
       if (msg.includes("didn't resolve at build time, it will remain unchanged to be resolved at runtime")) {
         const id = msg.trim().match(/^([^ ]+) referenced in/m)?.[1]
-        if (id?.startsWith('/')) { return }
+        if (id && resolveFromPublicAssets(id)) { return }
       }
     }
 

--- a/packages/vite/src/utils/logger.ts
+++ b/packages/vite/src/utils/logger.ts
@@ -31,6 +31,11 @@ export function createViteLogger (config: vite.InlineConfig): vite.Logger {
       // TODO: resolve upstream in Vite
       // Hide sourcemap warnings related to node_modules
       if (msg.startsWith('Sourcemap') && msg.includes('node_modules')) { return }
+      // Hide warnings about externals produced by https://github.com/vitejs/vite/blob/v5.2.11/packages/vite/src/node/plugins/css.ts#L350-L355
+      if (msg.includes("didn't resolve at build time, it will remain unchanged to be resolved at runtime")) {
+        const id = msg.trim().match(/^([^ ]+) referenced in/m)?.[1]
+        if (id?.startsWith('/')) { return }
+      }
     }
 
     const sameAsLast = lastType === type && lastMsg === msg


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/26379
closes https://github.com/nuxt/nuxt/pull/26551

### 📚 Description

We now take full control of rendering public assets (https://github.com/nuxt/nuxt/pull/26163). But it is not possible to configure whether vite warns about public assets without providing a custom `external` function to rollup, which would mean taking _complete_ control of externals, which we wouldn't want.

https://github.com/vitejs/vite/blob/v5.2.11/packages/vite/src/node/plugins/css.ts#L350-L355

So this obscures the (harmless) warning when it matches a public asset. It will still warn if a nonexistent public asset or other pattern is passed.