### PR TITLE
fix(nuxt): defer shared asyncData promises to next tick

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -229,7 +229,7 @@ export function useAsyncData<
         const value = nuxtApp.ssrContext!._sharedPrerenderCache!.get(key)
         if (value) { return value as Promise<ResT> }
 
-        const promise = nuxtApp.runWithContext(_handler)
+        const promise = Promise.resolve().then(() => nuxtApp.runWithContext(_handler))
 
         nuxtApp.ssrContext!._sharedPrerenderCache!.set(key, promise)
         return promise

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -393,7 +393,11 @@ export default defineUntypedSchema({
      * })
      * ```
      */
-    sharedPrerenderData: false,
+    sharedPrerenderData: {
+      async $resolve (val, get) {
+        return val ?? ((await get('future') as Record<string, unknown>).compatibilityVersion === 4)
+      },
+    },
 
     /**
      * Enables CookieStore support to listen for cookie updates (if supported by the browser) and refresh `useCookie` ref values.


### PR DESCRIPTION
### 🔗 Linked issue

follow up on https://github.com/nuxt/nuxt/issues/27031

### 📚 Description

Added docs for this change in https://github.com/nuxt/nuxt/pull/27132 but didn't implement because of a bug that occurred when testing.

This PR resolves the bug (which was that synchronous calls to useAsyncData ended up unsetting the context) and enables the feature by default in v4 compatibility mode.