### PR TITLE
fix(nuxt): resolve modules from layers directories

### DIFF
--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -272,6 +272,9 @@ async function initNuxt (nuxt: Nuxt) {
     ...nuxt.options._layers.filter(i => i.cwd.includes('node_modules')).map(i => i.cwd as string),
   )
 
+  // Ensure we can resolve dependencies within layers
+  nuxt.options.modulesDir.push(...nuxt.options._layers.map(l => resolve(l.cwd, 'node_modules')))
+
   // Init user modules
   await nuxt.callHook('modules:before')
   const modulesToInstall = []


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/26479
resolves https://github.com/nuxt/nuxt/issues/23445
resolves https://github.com/nuxt/nuxt/issues/18369
resolves https://github.com/nuxt/nuxt/issues/26724
resolves https://github.com/nuxt/nuxt/issues/26065
resolves https://github.com/nuxt/nuxt/issues/12347

### 📚 Description

Thanks to @pi0 for spotting this omission! We're now adding `node_modules` directories within layers to the tree for resolving dependencies for Nuxt.

This also likely needs to be paired with force-resolving key nuxt dependencies to the latest version (e.g. vue, ufo, defu, etc.) to ensure we don't pull in wrong/duplicate versions from child layers.