### PR TITLE
fix(schema): pass correct jsx config for esbuild-loader

### DIFF
--- a/packages/schema/src/config/webpack.ts
+++ b/packages/schema/src/config/webpack.ts
@@ -157,7 +157,11 @@ export default defineUntypedSchema({
        * See https://github.com/esbuild-kit/esbuild-loader
        * @type {Omit<typeof import('esbuild-loader')['LoaderOptions'], 'loader'>}
        */
-      esbuild: {},
+      esbuild: {
+        jsxFactory: 'h',
+        jsxFragment: 'Fragment',
+        tsconfigRaw: '{}',
+      },
 
       /**
        * See: https://github.com/webpack-contrib/file-loader#options


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/23844

### 📚 Description

This ports esbuild configuration to webpack from vite:

https://github.com/nuxt/nuxt/blob/f209158352b09d1986aa320e29ff36353b91c358/packages/schema/src/config/vite.ts#L83-L87

Note that this does not enable support for auto-importing components used within JSX/TSX files in webpack; that is a separate issue. (For now, a workaround is to import them from `#components`.)