### PR TITLE
fix(vite): ignore layer `tsconfig.json` when resolving vue prop types

### DIFF
--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -5,7 +5,7 @@ import type { Nuxt, NuxtBuilder, ViteConfig } from '@nuxt/schema'
 import { addVitePlugin, isIgnored, logger, resolvePath } from '@nuxt/kit'
 import replace from '@rollup/plugin-replace'
 import { sanitizeFilePath } from 'mlly'
-import { withoutLeadingSlash, withTrailingSlash } from 'ufo'
+import { withTrailingSlash, withoutLeadingSlash } from 'ufo'
 import { filename } from 'pathe/utils'
 import { resolveTSConfig } from 'pkg-types'
 import defu from 'defu'
@@ -140,7 +140,7 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
   ctx.config.vue = defu(ctx.config.vue, {
     script: {
       fs: {
-        fileExists(file) {
+        fileExists (file) {
           if (file.endsWith('/tsconfig.json') && layerPrefixes.some(l => file.startsWith(l))) {
             return false
           }
@@ -148,8 +148,8 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
         },
         readFile: file => readFileSync(file, 'utf-8'),
         realpath: file => realpathSync(file),
-      }
-    }
+      },
+    },
   } satisfies VuePluginOptions)
 
   if (nuxt.options.dev) {


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/26449

### 📚 Description

There are two issues here:

1. Vue's resolution algorithm. This PR exists to resolve that issue; we can force it to resolve the `tsconfig.json` of the parent project.

2. `tsconfck` (used in vite) expects to find a valid `tsconfig.json` for any file that is not in `node_modules/`.

   https://github.com/vitejs/vite/blob/6f77b2b22012ad1b810f4ec0511609ead35363dd/packages/vite/src/node/plugins/esbuild.ts#L451-L476

   Because the layer is outside of `node_modules/`, vite throws an error. I think we have to require that layers in your source directory have valid TS configs in this case. 

@ineshbose The reproduction you provided still has an issue with point 2 above, so this doesn't totally resolve it, but from your comment in https://github.com/nuxt/cli/pull/309 I think you were referring to a bigger picture. Could you provide a reproduction or test this fix on that situation and let me know whether it resolves things for you?