### PR TITLE
chore: add `baseUrl: "."` to .nuxt/tsconfig.json

### DIFF
--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -124,6 +124,7 @@ export async function _generateTypes (nuxt: Nuxt) {
 
   const tsConfig: TSConfig = defu(nuxt.options.typescript?.tsConfig, {
     compilerOptions: {
+      baseUrl: '.',
       forceConsistentCasingInFileNames: true,
       jsx: 'preserve',
       jsxImportSource: 'vue',


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/radix-vue/shadcn-vue/issues/291#issuecomment-1901788144

### 📚 Description

This PR will add default `"baseUrl": "."` to **.nuxt/tsconfig.json**

Will update description for context please check shadcn-vue issue

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
