### PR TITLE
fix(vite): disable `optimizeDeps` in ssr

### DIFF
--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -51,7 +51,7 @@ export async function buildServer (ctx: ViteBuildContext) {
       'XMLHttpRequest': 'undefined',
     },
     optimizeDeps: {
-      entries: ctx.nuxt.options.ssr ? [ctx.entry] : [],
+      noDiscovery: true,
     },
     resolve: {
       alias: {


### PR DESCRIPTION
### 🔗 Linked issue

related to #26783, but not sure if completely fixes 

### 📚 Description

We never need `optimizeDeps` in ssr, as `vite-node` externalize deps and use native node imports. This was probably a mistake. We found this out with @patak-dev during the test with Vite 6, which surfaces this issue. This might be a perf improvement as well.