### PR TITLE
fix: update createError parameter signature to match h3 version in Nuxt.

### DIFF
--- a/docs/1.getting-started/8.error-handling.md
+++ b/docs/1.getting-started/8.error-handling.md
@@ -162,8 +162,8 @@ const { data } = await useFetch(`/api/movies/${route.params.slug}`)
 
 if (!data.value) {
   throw createError({
-    statusCode: 404,
-    statusMessage: 'Page Not Found'
+    status: 404,
+    message: 'Page Not Found'
   })
 }
 </script>

--- a/docs/2.guide/2.directory-structure/1.server.md
+++ b/docs/2.guide/2.directory-structure/1.server.md
@@ -285,8 +285,8 @@ export default defineEventHandler((event) => {
 
   if (!Number.isInteger(id)) {
     throw createError({
-      statusCode: 400,
-      statusMessage: 'ID should be an integer',
+      status: 400,
+      message: 'ID should be an integer',
     })
   }
   return 'All good'

--- a/docs/2.guide/2.directory-structure/3.error.md
+++ b/docs/2.guide/2.directory-structure/3.error.md
@@ -46,8 +46,8 @@ If you have an error with custom fields they will be lost; you should assign the
 
 ```ts
 throw createError({
-  statusCode: 404,
-  statusMessage: 'Page Not Found',
+  status: 404,
+  message: 'Page Not Found',
   data: {
     myCustomField: true
   }

--- a/docs/3.api/3.utils/create-error.md
+++ b/docs/3.api/3.utils/create-error.md
@@ -28,7 +28,7 @@ If you throw an error created with `createError`:
 const route = useRoute()
 const { data } = await useFetch(`/api/movies/${route.params.slug}`)
 if (!data.value) {
-  throw createError({ statusCode: 404, statusMessage: 'Page Not Found' })
+  throw createError({ status: 404, message: 'Page Not Found' })
 }
 </script>
 ```

--- a/docs/3.api/3.utils/define-nuxt-route-middleware.md
+++ b/docs/3.api/3.utils/define-nuxt-route-middleware.md
@@ -39,7 +39,7 @@ You can use route middleware to throw errors and show helpful error messages:
 ```ts [middleware/error.ts]
 export default defineNuxtRouteMiddleware((to) => {
   if (to.params.id === '1') {
-    throw createError({ statusCode: 404, statusMessage: 'Page Not Found' })
+    throw createError({ status: 404, message: 'Page Not Found' })
   }
 })
 ```

--- a/packages/nuxt/src/app/compat/interval.ts
+++ b/packages/nuxt/src/app/compat/interval.ts
@@ -7,7 +7,7 @@ export const setInterval = import.meta.client
   : () => {
       if (import.meta.dev) {
         throw createError({
-          statusCode: 500,
+          status: 500,
           message: intervalError,
         })
       }

--- a/packages/nuxt/src/app/components/island-renderer.ts
+++ b/packages/nuxt/src/app/components/island-renderer.ts
@@ -18,8 +18,8 @@ export default defineComponent({
 
     if (!component) {
       throw createError({
-        statusCode: 404,
-        statusMessage: `Island component not found: ${props.context.name}`,
+        status: 404,
+        message: `Island component not found: ${props.context.name}`,
       })
     }
 

--- a/packages/nuxt/src/app/components/nuxt-stubs.ts
+++ b/packages/nuxt/src/app/components/nuxt-stubs.ts
@@ -3,8 +3,8 @@ import { createError } from '../composables/error'
 function renderStubMessage (name: string) {
   throw createError({
     fatal: true,
-    statusCode: 500,
-    statusMessage: `${name} is provided by @nuxt/image. Check your console to install it or run 'npx nuxi@latest module add @nuxt/image'`,
+    status: 500,
+    message: `${name} is provided by @nuxt/image. Check your console to install it or run 'npx nuxi@latest module add @nuxt/image'`,
   })
 }
 

--- a/packages/nuxt/src/app/composables/script-stubs.ts
+++ b/packages/nuxt/src/app/composables/script-stubs.ts
@@ -6,8 +6,8 @@ function renderStubMessage (name: string) {
   if (import.meta.client) {
     throw createError({
       fatal: true,
-      statusCode: 500,
-      statusMessage: message,
+      status: 500,
+      message: message,
     })
   }
 }

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -260,8 +260,8 @@ export default defineRenderHandler(async (event): Promise<Partial<RenderResponse
 
   if (ssrError && !('__unenv__' in event.node.req) /* allow internal fetch */) {
     throw createError({
-      statusCode: 404,
-      statusMessage: 'Page Not Found: /__nuxt_error',
+      status: 404,
+      message: 'Page Not Found: /__nuxt_error',
     })
   }
 

--- a/packages/vite/src/runtime/vite-node.mjs
+++ b/packages/vite/src/runtime/vite-node.mjs
@@ -49,8 +49,9 @@ function createRunner () {
         let _err
         try {
           const { message, stack } = formatViteError(errorData, id)
+          // The createError utility in h3 has already removed statusMessage
           _err = createError({
-            statusMessage: 'Vite Error',
+            // statusMessage: 'Vite Error',
             message,
             stack,
           })
@@ -58,8 +59,9 @@ function createRunner () {
           consola.warn('Internal nuxt error while formatting vite-node error. Please report this!', formatError)
           const message = `[vite-node] [TransformError] ${errorData?.message || '-'}`
           consola.error(message, errorData)
+          // The createError utility in h3 has already removed statusMessage
           throw createError({
-            message: 'Vite Error',
+            // message: 'Vite Error',
             message,
             stack: `${message}\nat ${id}\n` + (errorData?.stack || ''),
           })

--- a/packages/vite/src/runtime/vite-node.mjs
+++ b/packages/vite/src/runtime/vite-node.mjs
@@ -59,7 +59,7 @@ function createRunner () {
           const message = `[vite-node] [TransformError] ${errorData?.message || '-'}`
           consola.error(message, errorData)
           throw createError({
-            statusMessage: 'Vite Error',
+            message: 'Vite Error',
             message,
             stack: `${message}\nat ${id}\n` + (errorData?.stack || ''),
           })

--- a/packages/vite/src/vite-node.ts
+++ b/packages/vite/src/vite-node.ts
@@ -140,10 +140,10 @@ function createViteNodeApp (ctx: ViteBuildContext, invalidates: Set<string> = ne
     return eventHandler(async (event) => {
       const moduleId = decodeURI(event.path).substring(1)
       if (moduleId === '/') {
-        throw createError({ statusCode: 400 })
+        throw createError({ status: 400 })
       }
       if (isAbsolute(moduleId) && !isFileServingAllowed(moduleId, viteServer)) {
-        throw createError({ statusCode: 403 /* Restricted */ })
+        throw createError({ status: 403 /* Restricted */ })
       }
       const module = await node.fetchModule(moduleId).catch((err) => {
         const errorData = {

--- a/test/fixtures/basic/pages/error.vue
+++ b/test/fixtures/basic/pages/error.vue
@@ -12,7 +12,7 @@ const { data, error } = await useAsyncData(() => {
 
 if (error.value) {
   useCookie('some-error').value = 'was set'
-  throw createError({ statusCode: 422, fatal: true, statusMessage: 'This is a custom error' })
+  throw createError({ status: 422, fatal: true, message: 'This is a custom error' })
 }
 
 const state = ref({ attr: 'Hello World' })

--- a/test/fixtures/basic/server/api/error.ts
+++ b/test/fixtures/basic/server/api/error.ts
@@ -1,3 +1,3 @@
 export default defineEventHandler(() => {
-  throw createError({ statusCode: 400 })
+  throw createError({ status: 400 })
 })


### PR DESCRIPTION
### 🔗 Linked issue
#25942 
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
This pull request updates the createError parameter signature to align with the h3 version used in Nuxt. The previous signature did not match, which could cause inconsistencies and potential issues when creating errors. This change ensures compatibility and improves the robustness of error handling.
ref: https://h3.unjs.io/guide/event-handler#error-handling
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
