### PR TITLE
build(ui-templates): directly copy templates on build

### DIFF
--- a/packages/nuxt/.gitignore
+++ b/packages/nuxt/.gitignore
@@ -1,0 +1,6 @@
+src/app/components/error-404.vue
+src/app/components/error-500.vue
+src/app/components/error-dev.vue
+src/app/components/welcome.vue
+src/core/runtime/nitro/error-500.ts
+src/core/runtime/nitro/error-dev.ts

--- a/packages/nuxt/src/app/components/error-404.vue
+++ b/packages/nuxt/src/app/components/error-404.vue
@@ -1,1 +1,0 @@
-../../../../ui-templates/dist/templates/error-404.vue

--- a/packages/nuxt/src/app/components/error-500.vue
+++ b/packages/nuxt/src/app/components/error-500.vue
@@ -1,1 +1,0 @@
-../../../../ui-templates/dist/templates/error-500.vue

--- a/packages/nuxt/src/app/components/error-dev.vue
+++ b/packages/nuxt/src/app/components/error-dev.vue
@@ -1,1 +1,0 @@
-../../../../ui-templates/dist/templates/error-dev.vue

--- a/packages/nuxt/src/app/components/welcome.vue
+++ b/packages/nuxt/src/app/components/welcome.vue
@@ -1,1 +1,0 @@
-../../../../ui-templates/dist/templates/welcome.vue

--- a/packages/nuxt/src/core/runtime/nitro/error-500.ts
+++ b/packages/nuxt/src/core/runtime/nitro/error-500.ts
@@ -1,1 +1,0 @@
-../../../../../ui-templates/dist/templates/error-500.ts

--- a/packages/nuxt/src/core/runtime/nitro/error-dev.ts
+++ b/packages/nuxt/src/core/runtime/nitro/error-dev.ts
@@ -1,1 +1,0 @@
-../../../../../ui-templates/dist/templates/error-dev.ts

--- a/packages/ui-templates/lib/render.ts
+++ b/packages/ui-templates/lib/render.ts
@@ -1,5 +1,6 @@
 import { fileURLToPath } from 'node:url'
 import { readFileSync, rmdirSync, unlinkSync, writeFileSync } from 'node:fs'
+import { copyFile } from 'node:fs/promises'
 import { basename, dirname, join, resolve } from 'pathe'
 import type { Plugin } from 'vite'
 // @ts-expect-error https://github.com/GoogleChromeLabs/critters/pull/151
@@ -166,6 +167,15 @@ export const RenderPlugin = () => {
         // Remove original html file
         unlinkSync(fileName)
         rmdirSync(dirname(fileName))
+      }
+
+      // we manually copy files across rather than using symbolic links for better windows support
+      const nuxtRoot = r('../nuxt')
+      for (const file of ['error-404.vue', 'error-500.vue', 'error-dev.vue', 'welcome.vue']) {
+        await copyFile(r(`dist/templates/${file}`), join(nuxtRoot, 'src/app/components', file))
+      }
+      for (const file of ['error-500.ts', 'error-dev.ts']) {
+        await copyFile(r(`dist/templates/${file}`), join(nuxtRoot, 'src/core/runtime/nitro', file))
       }
     },
   }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This removes symbolic links to `ui-templates` in order to improve experience for developing with this repository on Windows machines.