### PR TITLE
docs: add external parameter behavior navigateTo

### DIFF
--- a/docs/3.api/3.utils/navigate-to.md
+++ b/docs/3.api/3.utils/navigate-to.md
@@ -52,6 +52,18 @@ export default defineNuxtRouteMiddleware((to, from) => {
 
 ### External URL
 
+The `external` parameter in `navigateTo` influences how navigating to URLs is handled:
+
+- **Without `external: true`**:
+  - Internal URLs navigate as expected.
+  - External URLs throw an error.
+
+- **With `external: true`**:
+  - Internal URLs navigate with a full-page reload.
+  - External URLs navigate as expected.
+
+#### Example
+
 ```vue
 <script setup lang="ts">
 // will throw an error;


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #20856

### 📚 Description

Adds external URL behavior section to `navigateTo` docs page.