### PR TITLE
fix(schema): exclude non-serialisable types from `app` options

### DIFF
--- a/packages/schema/src/types/config.ts
+++ b/packages/schema/src/types/config.ts
@@ -141,12 +141,14 @@ export interface AppConfigInput extends CustomAppConfig {
   server?: never
 }
 
+type Serializable<T> = T extends Function ? never : T extends Promise<infer U> ? Serializable<U> : T extends Record<string, any> ? { [K in keyof T]: Serializable<T[K]> } : T
+
 export interface NuxtAppConfig {
-  head: AppHeadMetaObject
-  layoutTransition: boolean | TransitionProps
-  pageTransition: boolean | TransitionProps
+  head: Serializable<AppHeadMetaObject>
+  layoutTransition: boolean | Serializable<TransitionProps>
+  pageTransition: boolean | Serializable<TransitionProps>
   viewTransition?: boolean | 'always'
-  keepalive: boolean | KeepAliveProps
+  keepalive: boolean | Serializable<KeepAliveProps>
 }
 
 export interface AppConfig {

--- a/test/fixtures/basic-types/nuxt.config.ts
+++ b/test/fixtures/basic-types/nuxt.config.ts
@@ -15,6 +15,18 @@ export default defineNuxtConfig({
   extends: [
     './extends/node_modules/foo',
   ],
+  app: {
+    head: {
+      // @ts-expect-error Promises are not allowed
+      title: Promise.resolve('Nuxt Fixture'),
+      // @ts-expect-error Functions are not allowed
+      titleTemplate: (title) => 'test'
+    },
+    pageTransition: {
+      // @ts-expect-error Functions are not allowed
+      onBeforeEnter: el => console.log(el),
+    }
+  },
   runtimeConfig: {
     baseURL: '',
     baseAPIToken: '',

--- a/test/fixtures/basic-types/nuxt.config.ts
+++ b/test/fixtures/basic-types/nuxt.config.ts
@@ -20,12 +20,12 @@ export default defineNuxtConfig({
       // @ts-expect-error Promises are not allowed
       title: Promise.resolve('Nuxt Fixture'),
       // @ts-expect-error Functions are not allowed
-      titleTemplate: (title) => 'test'
+      titleTemplate: title => 'test',
     },
     pageTransition: {
       // @ts-expect-error Functions are not allowed
       onBeforeEnter: el => console.log(el),
-    }
+    },
   },
   runtimeConfig: {
     baseURL: '',

--- a/test/fixtures/basic-types/types.ts
+++ b/test/fixtures/basic-types/types.ts
@@ -320,6 +320,7 @@ describe('runtimeConfig', () => {
 
 describe('head', () => {
   it('correctly types nuxt.config options', () => {
+    // @ts-expect-error invalid head option
     defineNuxtConfig({ app: { head: { titleTemplate: () => 'test' } } })
     defineNuxtConfig({
       app: {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This improves type safety in nuxt `app` option. We don't support functions or promises, despite these being permitted in the types for `app.head` and `app.pageTransition`/`app.layoutTransition`.

This should improve DX.