### PR TITLE
fix(nuxt): deduplicate `app.head` arrays

### DIFF
--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -675,7 +675,7 @@ async function checkDependencyVersion (name: string, nuxtVersion: string): Promi
 
 const RESTART_RE = /^(?:app|error|app\.config)\.(?:js|ts|mjs|jsx|tsx|vue)$/i
 
-function deduplicateArray <T = unknown>(maybeArray: T): T {
+function deduplicateArray<T = unknown> (maybeArray: T): T {
   if (!Array.isArray(maybeArray)) { return maybeArray }
 
   const fresh = []

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -7,6 +7,7 @@ import { resolvePath as _resolvePath } from 'mlly'
 import type { Nuxt, NuxtHooks, NuxtModule, NuxtOptions, RuntimeConfig } from 'nuxt/schema'
 import type { PackageJson } from 'pkg-types'
 import { readPackageJSON, resolvePackageJSON } from 'pkg-types'
+import { hash } from 'ohash'
 
 import escapeRE from 'escape-string-regexp'
 import fse from 'fs-extra'
@@ -583,6 +584,11 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
   options.appDir = options.alias['#app'] = resolve(distDir, 'app')
   options._majorVersion = 3
 
+  // De-duplicate key arrays
+  for (const key in options.app.head || {}) {
+    options.app.head[key as 'link'] = deduplicateArray(options.app.head[key as 'link'])
+  }
+
   // Nuxt DevTools only works for Vite
   if (options.builder === '@nuxt/vite-builder') {
     const isDevToolsEnabled = typeof options.devtools === 'boolean'
@@ -668,3 +674,18 @@ async function checkDependencyVersion (name: string, nuxtVersion: string): Promi
 }
 
 const RESTART_RE = /^(?:app|error|app\.config)\.(?:js|ts|mjs|jsx|tsx|vue)$/i
+
+function deduplicateArray <T = unknown>(maybeArray: T): T {
+  if (!Array.isArray(maybeArray)) { return maybeArray }
+
+  const fresh = []
+  const hashes = new Set<string>()
+  for (const item of maybeArray) {
+    const _hash = hash(item)
+    if (!hashes.has(_hash)) {
+      hashes.add(_hash)
+      fresh.push(item)
+    }
+  }
+  return fresh as T
+}

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -64,6 +64,7 @@ describe('route rules', () => {
     expect(headHtml).toContain('<meta name="description" content="Nuxt Fixture">')
     expect(headHtml).toContain('<meta charset="utf-8">')
     expect(headHtml).toContain('<meta name="viewport" content="width=1024, initial-scale=1">')
+    expect(headHtml.match(/<meta name="viewport" content="width=1024, initial-scale=1">/g)).toHaveLength(1)
 
     const { script, attrs } = parseData(headHtml)
     expect(script.serverRendered).toEqual(false)

--- a/test/fixtures/basic/extends/bar/nuxt.config.ts
+++ b/test/fixtures/basic/extends/bar/nuxt.config.ts
@@ -1,3 +1,11 @@
 export default defineNuxtConfig({
   modules: [undefined],
+  app: {
+    head: {
+      meta: [
+        { name: 'viewport', content: 'width=1024, initial-scale=1' },
+        { charset: 'utf-8' },
+      ],
+    }
+  }
 })

--- a/test/fixtures/basic/extends/bar/nuxt.config.ts
+++ b/test/fixtures/basic/extends/bar/nuxt.config.ts
@@ -6,6 +6,6 @@ export default defineNuxtConfig({
         { name: 'viewport', content: 'width=1024, initial-scale=1' },
         { charset: 'utf-8' },
       ],
-    }
-  }
+    },
+  },
 })


### PR DESCRIPTION
### 🔗 Linked issue

second issue in https://github.com/nuxt/nuxt/issues/21287

### 📚 Description

Currently with layers, we render any duplicate tags (viewport, title, favicon, etc.) which end up included more than once in any of the `app.head` arrays.

This might be the same issue as one already raised upstream (https://github.com/unjs/unhead/issues/285) but we also want to avoid including the duplicate code in the Nuxt bundle at all, rather than just deduplicating at runtime - so I think it's worth resolving in Nuxt as well.

This PR de-duplicates these arrays within `app.head`. Likely we can also de-duplicate other arrays too.