### PR TITLE
fix(nuxt): server components missing parent scopeId

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-island.ts
+++ b/packages/nuxt/src/app/components/nuxt-island.ts
@@ -1,4 +1,4 @@
-import type { Component } from 'vue'
+import type { Component, PropType } from 'vue'
 import { Fragment, Teleport, computed, createStaticVNode, createVNode, defineComponent, getCurrentInstance, h, nextTick, onMounted, ref, toRaw, watch, withMemo } from 'vue'
 import { debounce } from 'perfect-debounce'
 import { hash } from 'ohash'
@@ -60,7 +60,7 @@ export default defineComponent({
       default: () => ({}),
     },
     scopeId: {
-      type: String,
+      type: String as PropType<string | undefined | null>,
       default: () => undefined,
     },
     source: {

--- a/packages/nuxt/src/app/components/nuxt-island.ts
+++ b/packages/nuxt/src/app/components/nuxt-island.ts
@@ -136,7 +136,7 @@ export default defineComponent({
       let html = ssrHTML.value
 
       if (props.scopeId) {
-        html = html.replace(/^<[^>\ ]*/, (full) => full + ' ' + props.scopeId)
+        html = html.replace(/^<[^> ]*/, full => full + ' ' + props.scopeId)
       }
 
       if (import.meta.client && !canLoadClientComponent.value) {

--- a/packages/nuxt/src/app/components/nuxt-island.ts
+++ b/packages/nuxt/src/app/components/nuxt-island.ts
@@ -59,6 +59,10 @@ export default defineComponent({
       type: Object,
       default: () => ({}),
     },
+    scopeId: {
+      type: String,
+      default: () => undefined,
+    },
     source: {
       type: String,
       default: () => undefined,
@@ -130,6 +134,10 @@ export default defineComponent({
     const html = computed(() => {
       const currentSlots = Object.keys(slots)
       let html = ssrHTML.value
+
+      if (props.scopeId) {
+        html = html.replace(/^<[^>\ ]*/, (full) => full + ' ' + props.scopeId)
+      }
 
       if (import.meta.client && !canLoadClientComponent.value) {
         for (const [key, value] of Object.entries(payloads.components || {})) {

--- a/packages/nuxt/src/components/runtime/server-component.ts
+++ b/packages/nuxt/src/components/runtime/server-component.ts
@@ -1,4 +1,4 @@
-import { defineComponent, h, ref } from 'vue'
+import { defineComponent, getCurrentInstance, h, ref } from 'vue'
 import NuxtIsland from '#app/components/nuxt-island'
 import { useRoute } from '#app/composables/router'
 import { isPrerendered } from '#app/composables/payload'
@@ -16,12 +16,18 @@ export const createServerComponent = (name: string) => {
       expose({
         refresh: () => islandRef.value?.refresh(),
       })
-
+      
+      function getIslandProps() {
+        const scopeId = getCurrentInstance()?.vnode.scopeId
+        if (scopeId) return { ...attrs, [scopeId]: '' }
+        return attrs
+      }
+      
       return () => {
         return h(NuxtIsland, {
           name,
           lazy: props.lazy,
-          props: attrs,
+          props: getIslandProps(),
           ref: islandRef,
           onError: (err) => {
             emit('error', err)

--- a/packages/nuxt/src/components/runtime/server-component.ts
+++ b/packages/nuxt/src/components/runtime/server-component.ts
@@ -18,16 +18,12 @@ export const createServerComponent = (name: string) => {
         refresh: () => islandRef.value?.refresh(),
       })
 
-      function getIslandProps () {
-        if (vm?.vnode.scopeId) { return { ...attrs, [vm.vnode.scopeId]: '' } }
-        return attrs
-      }
-
       return () => {
         return h(NuxtIsland, {
           name,
           lazy: props.lazy,
-          props: getIslandProps(),
+          props: attrs,
+          scopeId: vm?.vnode.scopeId,
           ref: islandRef,
           onError: (err) => {
             emit('error', err)

--- a/packages/nuxt/src/components/runtime/server-component.ts
+++ b/packages/nuxt/src/components/runtime/server-component.ts
@@ -16,13 +16,13 @@ export const createServerComponent = (name: string) => {
       expose({
         refresh: () => islandRef.value?.refresh(),
       })
-      
-      function getIslandProps() {
+
+      function getIslandProps () {
         const scopeId = getCurrentInstance()?.vnode.scopeId
-        if (scopeId) return { ...attrs, [scopeId]: '' }
+        if (scopeId) { return { ...attrs, [scopeId]: '' } }
         return attrs
       }
-      
+
       return () => {
         return h(NuxtIsland, {
           name,

--- a/packages/nuxt/src/components/runtime/server-component.ts
+++ b/packages/nuxt/src/components/runtime/server-component.ts
@@ -11,6 +11,7 @@ export const createServerComponent = (name: string) => {
     props: { lazy: Boolean },
     emits: ['error'],
     setup (props, { attrs, slots, expose, emit }) {
+      const vm = getCurrentInstance()
       const islandRef = ref<null | typeof NuxtIsland>(null)
 
       expose({
@@ -18,8 +19,7 @@ export const createServerComponent = (name: string) => {
       })
 
       function getIslandProps () {
-        const scopeId = getCurrentInstance()?.vnode.scopeId
-        if (scopeId) { return { ...attrs, [scopeId]: '' } }
+        if (vm?.vnode.scopeId) { return { ...attrs, [vm.vnode.scopeId]: '' } }
         return attrs
       }
 

--- a/test/nuxt/nuxt-island.test.ts
+++ b/test/nuxt/nuxt-island.test.ts
@@ -141,10 +141,10 @@ describe('runtime server component', () => {
         const vnode = h(createServerComponent('dummyName'))
         popScopeId()
         return vnode
-      }
+      },
     }))
-    
-    expect(wrapper.getComponent(NuxtIsland).props().props).toMatchObject({"data-v-654e2b21": ""})
+
+    expect(wrapper.getComponent(NuxtIsland).props().props).toMatchObject({ 'data-v-654e2b21': '' })
   })
 })
 

--- a/test/nuxt/nuxt-island.test.ts
+++ b/test/nuxt/nuxt-island.test.ts
@@ -144,7 +144,7 @@ describe('runtime server component', () => {
       },
     }))
 
-    expect(wrapper.getComponent(NuxtIsland).props().props).toMatchObject({ 'data-v-654e2b21': '' })
+    expect(wrapper.find('*').attributes()).toHaveProperty('data-v-654e2b21')
   })
 })
 

--- a/test/nuxt/nuxt-island.test.ts
+++ b/test/nuxt/nuxt-island.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach } from 'node:test'
 import { describe, expect, it, vi } from 'vitest'
-import { h, nextTick } from 'vue'
+import { defineComponent, h, nextTick, popScopeId, pushScopeId } from 'vue'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import { createServerComponent } from '../../packages/nuxt/src/components/runtime/server-component'
 import { createSimpleRemoteIslandProvider } from '../fixtures/remote-provider'
@@ -133,6 +133,19 @@ describe('runtime server component', () => {
     expect(wrapper.emitted('error')).toHaveLength(1)
     vi.mocked(fetch).mockReset()
   })
+
+  it('expect NuxtIsland to have parent scopeId', async () => {
+    const wrapper = await mountSuspended(defineComponent({
+      render () {
+        pushScopeId('data-v-654e2b21')
+        const vnode = h(createServerComponent('dummyName'))
+        popScopeId()
+        return vnode
+      }
+    }))
+    
+    expect(wrapper.getComponent(NuxtIsland).props().props).toMatchObject({"data-v-654e2b21": ""})
+  })
 })
 
 describe('client components', () => {
@@ -186,7 +199,7 @@ describe('client components', () => {
     expect(fetch).toHaveBeenCalledOnce()
 
     expect(wrapper.html()).toMatchInlineSnapshot(`
-      "<div data-island-uid="4">hello<div data-island-uid="4" data-island-component="Client-12345">
+      "<div data-island-uid="5">hello<div data-island-uid="5" data-island-component="Client-12345">
           <div>client component</div>
         </div>
       </div>
@@ -212,7 +225,7 @@ describe('client components', () => {
     await wrapper.vm.$.exposed!.refresh()
     await nextTick()
     expect(wrapper.html()).toMatchInlineSnapshot(`
-      "<div data-island-uid="4">hello<div>
+      "<div data-island-uid="5">hello<div>
           <div>fallback</div>
         </div>
       </div>"
@@ -305,7 +318,7 @@ describe('client components', () => {
     })
     expect(fetch).toHaveBeenCalledOnce()
     expect(wrapper.html()).toMatchInlineSnapshot(`
-      "<div data-island-uid="6">hello<div data-island-uid="6" data-island-component="ClientWithSlot-12345">
+      "<div data-island-uid="7">hello<div data-island-uid="7" data-island-component="ClientWithSlot-12345">
           <div class="client-component">
             <div style="display: contents" data-island-uid="" data-island-slot="default">
               <div>slot in client component</div>


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
Fixes #27429

### 📚 Description

This makes `createServerComponent` pass it's `scopeId` as a prop to `NuxtIsland`, which mimics [the way normal components behave](https://vuejs.org/api/sfc-css-features.html#child-component-root-elements).

The destructure of `attrs` might cause performance issues, but I couldn't find a much better way of doing it 🫤


<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
