### PR TITLE
fix(kit): avoid falling back to normalized path for `loadNuxtModuleInstance`

### DIFF
--- a/packages/kit/src/module/install.ts
+++ b/packages/kit/src/module/install.ts
@@ -84,7 +84,7 @@ export async function loadNuxtModuleInstance (nuxtModule: string | NuxtModule, n
     let error: unknown
     for (const path of paths) {
       try {
-        const src = await resolvePath(path)
+        const src = await resolvePath(path, { fallbackToOriginal: true })
         // Prefer ESM resolution if possible
         nuxtModule = await importModule(src, nuxt.options.modulesDir).catch(() => null) ?? requireModule(src, { paths: nuxt.options.modulesDir })
 

--- a/packages/kit/src/resolve.ts
+++ b/packages/kit/src/resolve.ts
@@ -23,6 +23,13 @@ export interface ResolvePathOptions {
    * @default false
    */
   virtual?: boolean
+
+  /**
+   * Whether to fallback to the original path if the resolved path does not exist instead of returning the normalized input path.
+   *
+   * @default false
+   */
+  fallbackToOriginal?: boolean
 }
 
 /**

--- a/packages/kit/src/resolve.ts
+++ b/packages/kit/src/resolve.ts
@@ -106,7 +106,7 @@ export async function resolvePath (path: string, opts: ResolvePathOptions = {}):
   }
 
   // Return normalized input
-  return path
+  return opts.fallbackToOriginal ? _path : path
 }
 
 /**


### PR DESCRIPTION
Discovered while investigating #27479

When installing nuxt modules, we use `kit.resolvePath` utility first to resolve aliases, etc.

If they cannot be resolved for any reason (this way happening in unit tests silently), the util returns the normalized value (which is `${cwd}/path`).

Returned value can be something like `/source/to/nuxt/@nuxt/telemetry` which is obviously invalid and was being passed to the `import()` which was obviously always failing even when the module is a valid ESM module and then fallback to `jiti` (via `kit.requireModule`)

Jiti's ESM resolver (bundled mlly) was somehow (yet i don't know how) fixing this situation but with latest bundled ESM resolve algorithm, it won't be effective and revealed this..