### PR TITLE
feat(nuxt,schema): add `compatibilityDate` flag for future support

### DIFF
--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -390,7 +390,7 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
   // Init nitro
   const nitro = await createNitro(nitroConfig, {
     // @ts-expect-error this will be valid in a future version of Nitro
-    compatibilityDate: nuxt.options.compatibilityDate
+    compatibilityDate: nuxt.options.compatibilityDate,
   })
 
   // Trigger Nitro reload when SPA loading template changes

--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -388,7 +388,10 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
   }
 
   // Init nitro
-  const nitro = await createNitro(nitroConfig)
+  const nitro = await createNitro(nitroConfig, {
+    // @ts-expect-error this will be valid in a future version of Nitro
+    compatibilityDate: nuxt.options.compatibilityDate
+  })
 
   // Trigger Nitro reload when SPA loading template changes
   const spaLoadingTemplateFilePath = await spaLoadingTemplatePath(nuxt)

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -63,6 +63,7 @@
     "webpack-dev-middleware": "7.2.1"
   },
   "dependencies": {
+    "compatx": "^0.1.3",
     "consola": "^3.2.3",
     "defu": "^6.1.4",
     "hookable": "^5.5.3",
@@ -71,8 +72,8 @@
     "scule": "^1.3.0",
     "std-env": "^3.7.0",
     "ufo": "^1.5.3",
-    "unimport": "^3.7.2",
     "uncrypto": "^0.1.3",
+    "unimport": "^3.7.2",
     "untyped": "^1.4.2"
   },
   "engines": {

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -5,6 +5,7 @@ import { isDebug, isDevelopment, isTest } from 'std-env'
 import { defu } from 'defu'
 import { findWorkspaceDir } from 'pkg-types'
 import { randomUUID } from 'uncrypto'
+import { formatDate } from 'compatx'
 import type { RuntimeConfig } from '../types/config'
 
 export default defineUntypedSchema({
@@ -19,6 +20,18 @@ export default defineUntypedSchema({
    * @type {string | [string, typeof import('c12').SourceOptions?] | (string | [string, typeof import('c12').SourceOptions?])[]}
    */
   extends: null,
+
+  /**
+   * Specify a compatibility date for your app.
+   *
+   * This is used to control the behavior of presets in Nitro, Nuxt Image
+   * and other modules that may change behavior without a major version bump.
+   *
+   * We plan to improve the tooling around this feature in the future.
+   *
+   * @type {string | Record<string, string>}
+   */
+  compatibilityDate: formatDate(new Date()),
 
   /**
    * Extend project from a local or remote source.

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -5,7 +5,6 @@ import { isDebug, isDevelopment, isTest } from 'std-env'
 import { defu } from 'defu'
 import { findWorkspaceDir } from 'pkg-types'
 import { randomUUID } from 'uncrypto'
-import { formatDate } from 'compatx'
 import type { RuntimeConfig } from '../types/config'
 
 export default defineUntypedSchema({

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -29,9 +29,9 @@ export default defineUntypedSchema({
    *
    * We plan to improve the tooling around this feature in the future.
    *
-   * @type {string | Record<string, string>}
+   * @type {typeof import('compatx').DateString | Record<string, typeof import('compatx').DateString>}
    */
-  compatibilityDate: formatDate(new Date()),
+  compatibilityDate: undefined,
 
   /**
    * Extend project from a local or remote source.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -457,6 +457,9 @@ importers:
 
   packages/schema:
     dependencies:
+      compatx:
+        specifier: ^0.1.3
+        version: 0.1.3
       consola:
         specifier: ^3.2.3
         version: 3.2.3
@@ -3577,6 +3580,9 @@ packages:
 
   commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
+
+  compatx@0.1.3:
+    resolution: {integrity: sha512-MWspQwvBk5xeLZMetIfjOozTAtmAIICz1mtol6NbBpCSllXOO+HvWMO87B18rcFtqjfrZ0tIFOH9gNG63ep+mw==}
 
   compress-commons@6.0.2:
     resolution: {integrity: sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==}
@@ -10488,6 +10494,8 @@ snapshots:
   comment-parser@1.4.1: {}
 
   commondir@1.0.1: {}
+
+  compatx@0.1.3: {}
 
   compress-commons@6.0.2:
     dependencies:


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This adds support for `compatibilityDate` (defaulting to today's date), which should enable unlocking more features in future.

@pi0, do you think we should prompt user to add to `nuxt.config` using `magicast` immediately, or only from v4/v4-compat?

**TODO:**

- [ ] prompt user to add to `nuxt.config` using `magicast`
- [ ] print out compatibility updates in future using https://github.com/unjs/compatx