### PR TITLE
refactor(schema): use `CompatibilityDateSpec` for `compatibilityDate` type

### DIFF
--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -28,7 +28,7 @@ export default defineUntypedSchema({
    *
    * We plan to improve the tooling around this feature in the future.
    *
-   * @type {typeof import('compatx').DateString | Record<string, typeof import('compatx').DateString>}
+   * @type {typeof import('compatx').CompatibilityDateSpec>}
    */
   compatibilityDate: undefined,
 

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -28,7 +28,7 @@ export default defineUntypedSchema({
    *
    * We plan to improve the tooling around this feature in the future.
    *
-   * @type {typeof import('compatx').CompatibilityDateSpec>}
+   * @type {typeof import('compatx').CompatibilityDateSpec}
    */
   compatibilityDate: undefined,
 

--- a/test/fixtures/basic/modules/page-extend/index.ts
+++ b/test/fixtures/basic/modules/page-extend/index.ts
@@ -16,9 +16,15 @@ export default defineNuxtModule({
       }, {
         path: '/big-page-1',
         file: resolver.resolve('./pages/big-page.vue'),
+        meta: {
+          layout: false,
+        },
       }, {
         path: '/big-page-2',
         file: resolver.resolve('./pages/big-page.vue'),
+        meta: {
+          layout: false,
+        },
       })
     })
   },


### PR DESCRIPTION
Context: https://github.com/nuxt/nuxt/pull/27512

Adds stricter type hints for default and known platform keys sharable with nitro
