### PR TITLE
fix(schema): v3 app dir backwards compatibility

### DIFF
--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -1,4 +1,5 @@
 import { existsSync, readdirSync } from 'node:fs'
+import { readdir } from 'node:fs/promises'
 import { defineUntypedSchema } from 'untyped'
 import { join, relative, resolve } from 'pathe'
 import { isDebug, isDevelopment, isTest } from 'std-env'
@@ -117,9 +118,16 @@ export default defineUntypedSchema({
       }
 
       const srcDir = resolve(rootDir, 'app')
-      const srcDirKeys = readdirSync(srcDir)
-        .filter(file => !['router.options.ts', 'spa-loading-template.html'].includes(file))
-      if (!existsSync(srcDir) || srcDirKeys.length === 0) {
+      const srcDirFiles = new Set<string>()
+      if (existsSync(srcDir)) {
+        const files = await readdir(srcDir).catch(() => [])
+        for (const file of files) {
+          if (file !== 'spa-loading-template.html' && !file.startsWith('router.options')) {
+            srcDirFiles.add(file)
+          }
+        }
+      }
+      if (srcDirFiles.size === 0) {
         for (const file of ['app.vue', 'App.vue']) {
           if (existsSync(resolve(rootDir, file))) {
             return rootDir

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync } from 'node:fs'
+import { existsSync } from 'node:fs'
 import { readdir } from 'node:fs/promises'
 import { defineUntypedSchema } from 'untyped'
 import { join, relative, resolve } from 'pathe'

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs'
+import { existsSync, readdirSync } from 'node:fs'
 import { defineUntypedSchema } from 'untyped'
 import { join, relative, resolve } from 'pathe'
 import { isDebug, isDevelopment, isTest } from 'std-env'
@@ -117,7 +117,9 @@ export default defineUntypedSchema({
       }
 
       const srcDir = resolve(rootDir, 'app')
-      if (!existsSync(srcDir)) {
+      const srcDirKeys = readdirSync(srcDir)
+        .filter(file => !['router.options.ts', 'spa-loading-template.html'].includes(file))
+      if (!existsSync(srcDir) || srcDirKeys.length === 0) {
         for (const file of ['app.vue', 'App.vue']) {
           if (existsSync(resolve(rootDir, file))) {
             return rootDir


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
https://github.com/nuxt/nuxt/issues/27527

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
Allows users to use v3 directory structure in v4 when they already have an app folder.

v3 dir structure:

- empty `app` folder
- app folder with only `router.options.ts`
- app folder with only `spa-loading-template.html` 
- app folder with either `router.options.ts` or  `spa-loading-template.html` 

v4 app dir:

- any file besides `router.options.ts` or  `spa-loading-template.html` in the app dir

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
