### PR TITLE
fix(schema): don't narrow head string types to literals

### DIFF
--- a/packages/schema/src/types/config.ts
+++ b/packages/schema/src/types/config.ts
@@ -141,7 +141,7 @@ export interface AppConfigInput extends CustomAppConfig {
   server?: never
 }
 
-type Serializable<T> = T extends Function ? never : T extends Promise<infer U> ? Serializable<U> : T extends string & {} ? T :  T extends Record<string, any> ? { [K in keyof T]: Serializable<T[K]> } : T
+type Serializable<T> = T extends Function ? never : T extends Promise<infer U> ? Serializable<U> : T extends string & {} ? T : T extends Record<string, any> ? { [K in keyof T]: Serializable<T[K]> } : T
 
 export interface NuxtAppConfig {
   head: Serializable<AppHeadMetaObject>

--- a/packages/schema/src/types/config.ts
+++ b/packages/schema/src/types/config.ts
@@ -141,7 +141,7 @@ export interface AppConfigInput extends CustomAppConfig {
   server?: never
 }
 
-type Serializable<T> = T extends Function ? never : T extends Promise<infer U> ? Serializable<U> : T extends Record<string, any> ? { [K in keyof T]: Serializable<T[K]> } : T
+type Serializable<T> = T extends Function ? never : T extends Promise<infer U> ? Serializable<U> : T extends string & {} ? T :  T extends Record<string, any> ? { [K in keyof T]: Serializable<T[K]> } : T
 
 export interface NuxtAppConfig {
   head: Serializable<AppHeadMetaObject>

--- a/test/fixtures/basic-types/nuxt.config.ts
+++ b/test/fixtures/basic-types/nuxt.config.ts
@@ -25,9 +25,9 @@ export default defineNuxtConfig({
         {
           // Allows unknown property
           property: 'og:thing',
-          content: '1234567890'
-        }
-      ]
+          content: '1234567890',
+        },
+      ],
     },
     pageTransition: {
       // @ts-expect-error Functions are not allowed

--- a/test/fixtures/basic-types/nuxt.config.ts
+++ b/test/fixtures/basic-types/nuxt.config.ts
@@ -21,6 +21,13 @@ export default defineNuxtConfig({
       title: Promise.resolve('Nuxt Fixture'),
       // @ts-expect-error Functions are not allowed
       titleTemplate: title => 'test',
+      meta: [
+        {
+          // Allows unknown property
+          property: 'og:thing',
+          content: '1234567890'
+        }
+      ]
     },
     pageTransition: {
       // @ts-expect-error Functions are not allowed


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This addresses a regression in v3.12.0 from https://github.com/nuxt/nuxt/pull/27478 - we inadvertently excluded unknown strings from validity in object syntax.