### PR TITLE
fix(nuxt): manually assign payload reactivity when `ssr: false`

### DIFF
--- a/packages/nuxt/src/app/composables/payload.ts
+++ b/packages/nuxt/src/app/composables/payload.ts
@@ -1,7 +1,7 @@
 import { hasProtocol, joinURL, withoutTrailingSlash } from 'ufo'
 import { parse } from 'devalue'
 import { useHead } from '@unhead/vue'
-import { getCurrentInstance, isReactive, onServerPrefetch, reactive, shallowReactive } from 'vue'
+import { getCurrentInstance, onServerPrefetch } from 'vue'
 import { useNuxtApp, useRuntimeConfig } from '../nuxt'
 import type { NuxtPayload } from '../nuxt'
 

--- a/packages/nuxt/src/app/composables/payload.ts
+++ b/packages/nuxt/src/app/composables/payload.ts
@@ -122,16 +122,6 @@ export async function getNuxtClientPayload () {
     ...window.__NUXT__,
   }
 
-  for (const key in ['_errors', 'data']) {
-    if (payloadCache?.[key] && !isReactive(payloadCache[key])) {
-      payloadCache[key] = shallowReactive(payloadCache[key])
-    }
-  }
-
-  if (payloadCache?.state && !isReactive(payloadCache.state)) {
-    payloadCache.state = reactive(payloadCache.state)
-  }
-
   return payloadCache
 }
 

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -69,7 +69,7 @@ export interface NuxtSSRContext extends SSRContext {
   /** whether we are rendering an SSR error */
   error?: boolean
   nuxt: _NuxtApp
-  payload: NuxtPayload
+  payload: Partial<NuxtPayload>
   head: VueHeadClient<MergeHead>
   /** This is used solely to render runtime config with SPA renderer. */
   config?: Pick<RuntimeConfig, 'public' | 'app'>

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -165,11 +165,7 @@ const getSPARenderer = lazyCachedFunction(async () => {
     const config = useRuntimeConfig(ssrContext.event)
     ssrContext.modules = ssrContext.modules || new Set<string>()
     ssrContext!.payload = {
-      _errors: {},
       serverRendered: false,
-      data: {},
-      state: {},
-      once: new Set<string>(),
     }
     ssrContext.config = {
       public: config.public,


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/27536

### 📚 Description

A regression from https://github.com/nuxt/nuxt/pull/27214, we were overriding a reactive payload with a non-reactive one.

In this case, we should be able to avoid serialising empty payload keys at all, in fact.