### PR TITLE
fix(nuxt): close top-level watcher on nuxt 'close'

### DIFF
--- a/packages/nuxt/src/core/builder.ts
+++ b/packages/nuxt/src/core/builder.ts
@@ -136,6 +136,7 @@ function createGranularWatcher () {
         console.timeEnd('[nuxt] builder:chokidar:watch')
       }
     })
+    nuxt.hook('close', () => watcher?.close())
   }
 }
 

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -50,7 +50,7 @@ export function createNuxt (options: NuxtOptions): Nuxt {
     hook: hooks.hook,
     ready: () => initNuxt(nuxt),
     close: async () => {
-      await Promise.resolve(hooks.callHook('close', nuxt))
+      await hooks.callHook('close', nuxt)
       hooks.removeAllHooks()
     },
     vfs: {},

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -49,7 +49,10 @@ export function createNuxt (options: NuxtOptions): Nuxt {
     addHooks: hooks.addHooks,
     hook: hooks.hook,
     ready: () => initNuxt(nuxt),
-    close: () => Promise.resolve(hooks.callHook('close', nuxt)),
+    close: async () => {
+      await Promise.resolve(hooks.callHook('close', nuxt))
+      hooks.removeAllHooks()
+    },
     vfs: {},
     apps: {},
   }


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/27570

### 📚 Description

Helpful catch - we were not closing out the top level watcher when restarting Nuxt, meaning these watchers would accumulate.

In addition, this PR removes all hooks to avoid them being called post-close event. (Difficult to know as it does make it more unlikely to catch bugs in modules, but it seems like the right thing to do.)

cc: @pi0 in case you think differently - happy to revert this last bit if so