### PR TITLE
perf(kit): deduplicate layers before resolving config

### DIFF
--- a/packages/kit/src/loader/config.ts
+++ b/packages/kit/src/loader/config.ts
@@ -42,10 +42,15 @@ export async function loadNuxtConfig (opts: LoadNuxtConfigOptions): Promise<Nuxt
   nuxtConfig._nuxtConfigFiles = [configFile]
 
   const _layers: ConfigLayer<NuxtConfig, ConfigLayerMeta>[] = []
+  const processedLayers = new Set<string>()
   for (const layer of layers) {
     // Resolve `rootDir` & `srcDir` of layers
     layer.config = layer.config || {}
-    layer.config.rootDir = layer.config.rootDir ?? layer.cwd
+    layer.config.rootDir = layer.config.rootDir ?? layer.cwd!
+
+    // Only process/resolve layers once
+    if (processedLayers.has(layer.config.rootDir)) { continue }
+    processedLayers.add(layer.config.rootDir)
 
     // Normalise layer directories
     layer.config = await applyDefaults(layerSchema, layer.config as NuxtConfig & Record<string, JSValue>) as unknown as NuxtConfig


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Layers may be included more than once if they are dependencies of each other.

In v3.12, we started resolving config which made this issue more evident in terms of time impact.