### PR TITLE
fix(nuxt): handle tsx code when extracting page meta + route rules

### DIFF
--- a/packages/nuxt/src/pages/route-rules.ts
+++ b/packages/nuxt/src/pages/route-rules.ts
@@ -18,11 +18,12 @@ export async function extractRouteRules (code: string): Promise<NitroRouteConfig
   }
   if (!ROUTE_RULE_RE.test(code)) { return null }
 
-  code = extractScriptContent(code) || code
+  const script = extractScriptContent(code)
+  code = script?.code || code
 
   let rule: NitroRouteConfig | null = null
 
-  const js = await transform(code, { loader: 'ts' })
+  const js = await transform(code, { loader: script?.loader || 'ts' })
   walk(parse(js.code, {
     sourceType: 'module',
     ecmaVersion: 'latest',

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -154,12 +154,15 @@ export async function augmentPages (routes: NuxtPage[], vfs: Record<string, stri
   return augmentedPages
 }
 
-const SFC_SCRIPT_RE = /<script[^>]*>([\s\S]*?)<\/script[^>]*>/i
+const SFC_SCRIPT_RE = /<script(?<attrs>[^>]*)>(?<content>[\s\S]*?)<\/script[^>]*>/i
 export function extractScriptContent (html: string) {
-  const match = html.match(SFC_SCRIPT_RE)
+  const groups = html.match(SFC_SCRIPT_RE)?.groups || {}
 
-  if (match && match[1]) {
-    return match[1].trim()
+  if (groups.content) {
+    return {
+      loader: groups.attrs.includes('tsx') ? 'tsx' : 'ts',
+      code: groups.content.trim()
+    } as const
   }
 
   return null
@@ -185,12 +188,12 @@ async function getRouteMeta (contents: string, absolutePath: string): Promise<Pa
     return {}
   }
 
-  if (!PAGE_META_RE.test(script)) {
+  if (!PAGE_META_RE.test(script.code)) {
     metaCache[absolutePath] = {}
     return {}
   }
 
-  const js = await transform(script, { loader: 'ts' })
+  const js = await transform(script.code, { loader: script.loader })
   const ast = parse(js.code, {
     sourceType: 'module',
     ecmaVersion: 'latest',

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -161,7 +161,7 @@ export function extractScriptContent (html: string) {
   if (groups.content) {
     return {
       loader: groups.attrs.includes('tsx') ? 'tsx' : 'ts',
-      code: groups.content.trim()
+      code: groups.content.trim(),
     } as const
   }
 

--- a/test/fixtures/basic/pages/tsx-page-meta.vue
+++ b/test/fixtures/basic/pages/tsx-page-meta.vue
@@ -1,0 +1,8 @@
+<template>
+  <PageContent />
+</template>
+<script setup lang="tsx">
+definePageMeta({})
+defineRouteRules({})
+const PageContent = () => (<div>Home Page</div>)
+</script>

--- a/test/fixtures/basic/pages/tsx-page-meta.vue
+++ b/test/fixtures/basic/pages/tsx-page-meta.vue
@@ -1,6 +1,7 @@
 <template>
   <PageContent />
 </template>
+
 <script setup lang="tsx">
 definePageMeta({})
 defineRouteRules({})


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/27581

### 📚 Description

This handles `<script lang="tsx">` cases for extracting route rules + page meta from pages.