### PR TITLE
fix(nuxt): more accurate asyncData deduplication

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -236,7 +236,13 @@ export function useAsyncData<
 
   // Used to get default values
   const getDefault = () => asyncDataDefaults.value
-  const getDefaultCachedData = () => nuxtApp.isHydrating ? nuxtApp.payload.data[key] : nuxtApp.static.data[key]
+  const getDefaultCachedData = () => {
+    if (nuxtApp.isHydrating) {
+      return Object.hasOwn(nuxtApp.payload.data ?? {}, key) ? nuxtApp.payload.data[key] : null
+    } else {
+      return Object.hasOwn(nuxtApp.static.data ?? {}, key) ? nuxtApp.static.data[key] : null
+    }
+  }
 
   // Apply defaults
   options.server = options.server ?? true


### PR DESCRIPTION
### 🔗 Linked issue

#27594 

### 📚 Description

This MR handles more accurate asyncData client deduplication check for the cases when `useAsyncData` return falsy values