### PR TITLE
ci: use correct SHA calculation for release-pr action

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -29,10 +29,24 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Get PR Info
+        id: pr
+        env:
+          PR_NUMBER: ${{ github.event.issue.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          COMMENT_AT: ${{ github.event.comment.created_at }}
+        run: |
+          pr="$(gh api -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/${GH_REPO}/pulls/${PR_NUMBER})"
+          head_sha="$(echo "$pr" | jq -r .head.sha)"
+          updated_at="$(echo "$pr" | jq -r .updated_at)"
+
+          if [[ $(date -d $updated_at) > $(date -d $COMMENT_AT) ]]; exit 1; fi
+          
+          echo "head_sha=$head_sha" >> $GITHUB_OUTPUT
+      - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.issue.pull_request.head.sha }}
-          fetch-depth: 0
+          ref: ${{ steps.pr.outputs.head_sha }}
 
       - run: corepack enable
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -44,9 +44,10 @@ jobs:
           if [[ $(date -d $updated_at) > $(date -d $COMMENT_AT) ]]; exit 1; fi
           
           echo "head_sha=$head_sha" >> $GITHUB_OUTPUT
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           ref: ${{ steps.pr.outputs.head_sha }}
+          fetch-depth: 1
 
       - run: corepack enable
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2


### PR DESCRIPTION
`${{ github.event.issue.pull_request.head.sha }}` does not exist (My bad!).

This PR updates the logic to correctly calculate the SHA.