### PR TITLE
feat: add plugin resolved hook and util

### DIFF
--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -48,6 +48,7 @@ export interface RuntimeNuxtHooks {
   'app:chunkError': (options: { error: any }) => HookResult
   'app:data:refresh': (keys?: string[]) => HookResult
   'app:manifest:update': (meta?: NuxtAppManifestMeta) => HookResult
+  'app:plugin:resolved': (name: NuxtAppLiterals['pluginName']) => HookResult
   'dev:ssr-logs': (logs: LogObject[]) => void | Promise<void>
   'link:prefetch': (link: string) => HookResult
   'page:start': (Component?: VNode) => HookResult
@@ -111,6 +112,7 @@ interface _NuxtApp {
   callHook: _NuxtApp['hooks']['callHook']
 
   runWithContext: <T extends () => any>(fn: T) => ReturnType<T> | Promise<Awaited<ReturnType<T>>>
+  runAfterPlugin: <T extends () => any>(pluginName: NuxtAppLiterals['pluginName'], fn: T) => ReturnType<T> | Promise<Awaited<ReturnType<T>>>
 
   [key: string]: unknown
 
@@ -166,6 +168,9 @@ interface _NuxtApp {
   _routeAnnouncer?: RouteAnnouncer
   /** @internal */
   _routeAnnouncerDeps?: number
+
+  /** @internal */
+  _resolvedPlugins: string[]
 
   // Nuxt injections
   $config: RuntimeConfig
@@ -271,6 +276,9 @@ export function createNuxtApp (options: CreateOptions) {
       }
       return callWithNuxt(nuxtApp, fn)
     },
+    runAfterPlugin (plugin: NuxtAppLiterals['pluginName'], fn: () => void) {
+      return runAfterPlugin(plugin, fn)
+    },
     isHydrating: import.meta.client,
     deferHydration () {
       if (!nuxtApp.isHydrating) { return () => {} }
@@ -293,6 +301,7 @@ export function createNuxtApp (options: CreateOptions) {
     _asyncDataPromises: {},
     _asyncData: shallowReactive({}),
     _payloadRevivers: {},
+    _resolvedPlugins: [],
     ...options,
   } as any as NuxtApp
 
@@ -408,20 +417,21 @@ export async function applyPlugin (nuxtApp: NuxtApp, plugin: Plugin & ObjectPlug
 
 /** @since 3.0.0 */
 export async function applyPlugins (nuxtApp: NuxtApp, plugins: Array<Plugin & ObjectPlugin<any>>) {
-  const resolvedPlugins: string[] = []
+  nuxtApp._resolvedPlugins = []
+
   const unresolvedPlugins: [Set<string>, Plugin & ObjectPlugin<any>][] = []
   const parallels: Promise<any>[] = []
   const errors: Error[] = []
   let promiseDepth = 0
 
   async function executePlugin (plugin: Plugin & ObjectPlugin<any>) {
-    const unresolvedPluginsForThisPlugin = plugin.dependsOn?.filter(name => plugins.some(p => p._name === name) && !resolvedPlugins.includes(name)) ?? []
+    const unresolvedPluginsForThisPlugin = plugin.dependsOn?.filter(name => plugins.some(p => p._name === name) && !nuxtApp._resolvedPlugins.includes(name)) ?? []
     if (unresolvedPluginsForThisPlugin.length > 0) {
       unresolvedPlugins.push([new Set(unresolvedPluginsForThisPlugin), plugin])
     } else {
       const promise = applyPlugin(nuxtApp, plugin).then(async () => {
         if (plugin._name) {
-          resolvedPlugins.push(plugin._name)
+          nuxtApp._resolvedPlugins.push(plugin._name)
           await Promise.all(unresolvedPlugins.map(async ([dependsOn, unexecutedPlugin]) => {
             if (dependsOn.has(plugin._name!)) {
               dependsOn.delete(plugin._name!)
@@ -431,6 +441,8 @@ export async function applyPlugins (nuxtApp: NuxtApp, plugins: Array<Plugin & Ob
               }
             }
           }))
+
+          nuxtApp.hooks.callHook('app:plugin:resolved', plugin._name)
         }
       })
 
@@ -496,6 +508,23 @@ export function callWithNuxt<T extends (...args: any[]) => any> (nuxt: NuxtApp |
     nuxtAppCtx.set(nuxt as NuxtApp)
     return nuxt.vueApp.runWithContext(fn)
   }
+}
+
+/** @since 3.13.0 */
+export function runAfterPlugin<T extends (...args: any[]) => any> (pluginName: NuxtAppLiterals['pluginName'], callback: T, nuxt?: NuxtApp | _NuxtApp) {
+  const nuxtApp = nuxt || useNuxtApp()
+
+  if (nuxtApp._resolvedPlugins.includes(pluginName)) {
+    callback()
+    return
+  }
+
+  const unhook = nuxtApp.hook('app:plugin:resolved', (name) => {
+    if (pluginName === name) {
+      unhook()
+      callback()
+    }
+  })
 }
 
 /* @__NO_SIDE_EFFECTS__ */

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -19,7 +19,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
   for (const outputDir of ['.output', '.output-inline']) {
     it('default client bundle size', async () => {
       const clientStats = await analyzeSizes('**/*.js', join(rootDir, outputDir, 'public'))
-      expect.soft(roundToKilobytes(clientStats.totalBytes)).toMatchInlineSnapshot(`"105k"`)
+      expect.soft(roundToKilobytes(clientStats.totalBytes)).toMatchInlineSnapshot(`"106k"`)
       expect(clientStats.files.map(f => f.replace(/\..*\.js/, '.js'))).toMatchInlineSnapshot(`
         [
           "_nuxt/entry.js",
@@ -72,7 +72,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(rootDir, '.output-inline/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"528k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"529k"`)
 
     const modules = await analyzeSizes('node_modules/**/*', serverDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"76.2k"`)

--- a/test/nuxt/plugin.test.ts
+++ b/test/nuxt/plugin.test.ts
@@ -313,4 +313,66 @@ describe('plugin hooks', () => {
       'listen B',
     ])
   })
+
+  it('it runs after plugin', async () => {
+    const nuxtApp = useNuxtApp()
+
+    const sequence: string[] = []
+    const plugins = [
+      defineNuxtPlugin({
+        name: 'A',
+        setup () {
+          sequence.push('start A')
+        },
+      }),
+      defineNuxtPlugin({
+        name: 'B',
+        setup (nuxt) {
+          nuxt.runAfterPlugin('A', () => {
+            sequence.push('after A')
+          })
+        },
+      }),
+    ]
+
+    await applyPlugins(nuxtApp, plugins)
+    expect(sequence).toMatchObject([
+      'start A',
+      'after A',
+    ])
+  })
+
+  it('it registers callback before execution', async () => {
+    const nuxtApp = useNuxtApp()
+
+    const sequence: string[] = []
+    const plugins = [
+      defineNuxtPlugin({
+        name: 'A',
+        setup (nuxt) {
+          sequence.push('start A')
+          nuxt.runAfterPlugin('B', () => {
+            sequence.push('after B')
+          })
+        },
+      }),
+      defineNuxtPlugin({
+        name: 'B',
+        dependsOn: ['A'],
+        setup () {
+          sequence.push('start B')
+        },
+      }),
+    ]
+
+    await applyPlugins(nuxtApp, plugins)
+
+    expect(nuxtApp._resolvedPlugins).toMatchObject(['A', 'B'])
+
+    expect(sequence).toMatchObject([
+      'start A',
+      'start B',
+      'after B',
+    ])
+  })
 })


### PR DESCRIPTION
### 🔗 Linked issue

resolves #27618

### 📚 Description

This PR adds a new nuxt hook called `app:plugin:resolved`. It also moves keeping track of the resolved plugins into the nuxt app instance. Finally, it adds a function to `NuxtApp` that allows a user to run a callback whenever a certain plugin is been resolved.

