### PR TITLE
fix(schema,vite): respect `vite.cacheDir` if defined

### DIFF
--- a/packages/schema/src/config/vite.ts
+++ b/packages/schema/src/config/vite.ts
@@ -110,7 +110,7 @@ export default defineUntypedSchema({
       },
     },
     cacheDir: {
-      $resolve: async (val, get) => val ?? (await get('cacheDir')),
+      $resolve: async (val, get) => val ?? resolve(await get('rootDir'), 'node_modules/.cache/vite'),
     },
   },
 })

--- a/packages/schema/src/config/vite.ts
+++ b/packages/schema/src/config/vite.ts
@@ -109,6 +109,8 @@ export default defineUntypedSchema({
         },
       },
     },
-    cacheDir: await get('cacheDir'),
+    cacheDir: {
+      $resolve: async (val, get) => val ?? (await get('cacheDir')),
+    },
   },
 })

--- a/packages/schema/src/config/vite.ts
+++ b/packages/schema/src/config/vite.ts
@@ -1,4 +1,5 @@
 import { consola } from 'consola'
+import { resolve } from 'pathe'
 import { isTest } from 'std-env'
 import { withoutLeadingSlash } from 'ufo'
 import { defineUntypedSchema } from 'untyped'
@@ -110,7 +111,7 @@ export default defineUntypedSchema({
       },
     },
     cacheDir: {
-      $resolve: async (val, get) => val ?? resolve(await get('rootDir'), 'node_modules/.cache/vite'),
+      $resolve: async (val, get) => val ?? resolve(await get('rootDir') as string, 'node_modules/.cache/vite'),
     },
   },
 })

--- a/packages/schema/src/config/vite.ts
+++ b/packages/schema/src/config/vite.ts
@@ -109,5 +109,6 @@ export default defineUntypedSchema({
         },
       },
     },
+    cacheDir: await get('cacheDir'),
   },
 })

--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -118,7 +118,7 @@ export async function buildClient (ctx: ViteBuildContext) {
         'vue',
       ],
     },
-    cacheDir: resolve(ctx.nuxt.options.rootDir, 'node_modules/.cache/vite', 'client'),
+    cacheDir: resolve(ctx.nuxt.options.rootDir, ctx.config.cacheDir ?? 'node_modules/.cache/vite', 'client'),
     build: {
       sourcemap: ctx.nuxt.options.sourcemap.client ? ctx.config.build?.sourcemap ?? ctx.nuxt.options.sourcemap.client : false,
       manifest: 'manifest.json',

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -71,7 +71,7 @@ export async function buildServer (ctx: ViteBuildContext) {
         /(nuxt|nuxt3|nuxt-nightly)\/(dist|src|app)/,
       ],
     },
-    cacheDir: resolve(ctx.nuxt.options.rootDir, 'node_modules/.cache/vite', 'server'),
+    cacheDir: resolve(ctx.nuxt.options.rootDir, ctx.config.cacheDir ?? 'node_modules/.cache/vite', 'server'),
     build: {
       // we'll display this in nitro build output
       reportCompressedSize: false,


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/27627

### 📚 Description

Vite's shared option `cacheDir` is not currently supported by `vite-builder`.  This PR allows setting it in Nuxt config `vite` object.

```
# nuxt.config.js

export default defineNuxtConfig({
  ...
  vite: {
    cacheDir: "node_modules/.cache/vite_custom"
  }
}
```

#### 🤨 Why

I am running instances of `nuxt dev` simultaneously in one directory. When they both target the same `vite.cacheDir` there are conflicts and unexpected behaviors ensue (mostly, app doesn't load).

#### 😌 QA

Modified in Playground to confirm it modified Vite's cache directory.

<img width="1003" alt="image" src="https://github.com/nuxt/nuxt/assets/3292124/0c9e2a9d-0c54-4e76-b20c-c85ebbc5691a">
