### PR TITLE
fix(nuxt): cookie timeoutLength after expiration

### DIFF
--- a/packages/nuxt/src/app/composables/cookie.ts
+++ b/packages/nuxt/src/app/composables/cookie.ts
@@ -198,6 +198,7 @@ function cookieRef<T> (value: T | undefined, delay: number, shouldWatch: boolean
     if (shouldWatch) { unsubscribe = watch(internalRef, trigger) }
 
     function createExpirationTimeout () {
+      elapsed = 0
       clearTimeout(timeout)
       const timeRemaining = delay - elapsed
       const timeoutLength = timeRemaining < MAX_TIMEOUT_DELAY ? timeRemaining : MAX_TIMEOUT_DELAY


### PR DESCRIPTION
### 🔗 Linked issue

resolves #26765 

### 📚 Description
When setting maxAge/expires setTimeout calling with 0 after expiration. Must reset elapsed 

