### PR TITLE
fix(nuxt): unregister hooks the moment `close` is called

### DIFF
--- a/packages/nuxt/src/core/builder.ts
+++ b/packages/nuxt/src/core/builder.ts
@@ -46,10 +46,12 @@ export async function build (nuxt: Nuxt) {
   if (!nuxt.options._prepare) {
     await Promise.all([checkForExternalConfigurationFiles(), bundle(nuxt)])
     await nuxt.callHook('build:done')
-  }
 
-  if (!nuxt.options.dev) {
-    await nuxt.callHook('close', nuxt)
+    if (!nuxt.options.dev) {
+      await nuxt.callHook('close', nuxt)
+    }
+  } else {
+    nuxt.hook('prepare:types', () => nuxt.close())
   }
 }
 

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -54,7 +54,7 @@ export function createNuxt (options: NuxtOptions): Nuxt {
     apps: {},
   }
 
-  hooks.hookOnce('close', hooks.removeAllHooks)
+  hooks.hookOnce('close', () => { hooks.removeAllHooks() })
 
   return nuxt
 }

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -49,13 +49,12 @@ export function createNuxt (options: NuxtOptions): Nuxt {
     addHooks: hooks.addHooks,
     hook: hooks.hook,
     ready: () => initNuxt(nuxt),
-    close: async () => {
-      await hooks.callHook('close', nuxt)
-      hooks.removeAllHooks()
-    },
+    close: () => hooks.callHook('close', nuxt),
     vfs: {},
     apps: {},
   }
+
+  hooks.hookOnce('close', hooks.removeAllHooks)
 
   return nuxt
 }


### PR DESCRIPTION
### 🔗 Linked issue

related to https://github.com/nuxt/nuxt/pull/27571

### 📚 Description

Occasionally users may have noticed race conditions when restarting Nuxt because of a file rename/move. A warning might show up, like this:

```
WARN  'manifest-route-rule' middleware already exists at '/packages/nuxt/src/app/middleware/manifest-route-rule.ts'. You can set override: true to replace it.
```

This was because the old Nuxt hooks were still responding - so calling `app:resolve` was triggering adding route middleware from the _old_ Nuxt as well as the new one.

This resolves the issue by preventing any hooks from being called, from the moment the `close` hook is called. (Existing close hooks are still honoured as `hookable` takes a snapshot of the hooks the moment it's called.