### PR TITLE
feat(nuxt): await custom `routes` function in `router.options`

### DIFF
--- a/packages/nuxt/src/pages/build.d.ts
+++ b/packages/nuxt/src/pages/build.d.ts
@@ -1,5 +1,6 @@
 declare module '#build/router.options' {
   import type { RouterOptions } from '@nuxt/schema'
+
   const _default: RouterOptions
   export default _default
 }

--- a/packages/nuxt/src/pages/build.d.ts
+++ b/packages/nuxt/src/pages/build.d.ts
@@ -1,0 +1,5 @@
+declare module '#build/router.options' {
+  import type { RouterOptions } from '@nuxt/schema'
+  const _default: RouterOptions
+  export default _default
+}

--- a/packages/nuxt/src/pages/runtime/plugins/prerender.server.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/prerender.server.ts
@@ -5,7 +5,6 @@ import { defineNuxtPlugin } from '#app/nuxt'
 import { prerenderRoutes } from '#app/composables/ssr'
 // @ts-expect-error virtual file
 import _routes from '#build/routes'
-// @ts-expect-error virtual file
 import routerOptions from '#build/router.options'
 
 let routes: string[]

--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -66,7 +66,7 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
       : createMemoryHistory(routerBase)
     )
 
-    const routes = await routerOptions.routes?.(_routes) ?? _routes
+    const routes = routerOptions.routes ? await routerOptions.routes(_routes) ?? _routes : _routes
 
     let startPosition: Parameters<RouterScrollBehavior>[2] | null
 

--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -24,7 +24,6 @@ import { navigateTo } from '#app/composables/router'
 import { appManifest as isAppManifestEnabled } from '#build/nuxt.config.mjs'
 // @ts-expect-error virtual file
 import _routes from '#build/routes'
-// @ts-expect-error virtual file
 import routerOptions from '#build/router.options'
 // @ts-expect-error virtual file
 import { globalMiddleware, namedMiddleware } from '#build/middleware'
@@ -67,7 +66,7 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
       : createMemoryHistory(routerBase)
     )
 
-    const routes = routerOptions.routes?.(_routes) ?? _routes
+    const routes = await routerOptions.routes?.(_routes) ?? _routes
 
     let startPosition: Parameters<RouterScrollBehavior>[2] | null
 

--- a/packages/schema/src/types/router.ts
+++ b/packages/schema/src/types/router.ts
@@ -2,7 +2,7 @@ import type { RouterHistory, RouterOptions as _RouterOptions } from 'vue-router'
 
 export type RouterOptions = Partial<Omit<_RouterOptions, 'history' | 'routes'>> & {
   history?: (baseURL?: string) => RouterHistory
-  routes?: (_routes: _RouterOptions['routes']) => _RouterOptions['routes']
+  routes?: (_routes: _RouterOptions['routes']) => _RouterOptions['routes'] | Promise<_RouterOptions['routes']>
   hashMode?: boolean
   scrollBehaviorType?: 'smooth' | 'auto'
 }


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/23678

### 📚 Description

This allows awaiting the `routes()` function from `router.options.ts` to allow routes to be added before the router initialises.