### PR TITLE
fix(vue-app): don't throw if we can't read `sessionStorage`

### DIFF
--- a/packages/vue-app/template/utils.js
+++ b/packages/vue-app/template/utils.js
@@ -157,12 +157,15 @@ export function resolveRouteComponents (route, fn) {
             window.sessionStorage
           ) {
             const timeNow = Date.now()
-            const previousReloadTime = parseInt(window.sessionStorage.getItem('nuxt-reload'))
-
-            // check for previous reload time not to reload infinitely
-            if (!previousReloadTime || previousReloadTime + 60000 < timeNow) {
-              window.sessionStorage.setItem('nuxt-reload', timeNow)
-              window.location.reload(true /* skip cache */)
+            try {
+              const previousReloadTime = parseInt(window.sessionStorage.getItem('nuxt-reload'))
+              // check for previous reload time not to reload infinitely
+              if (!previousReloadTime || previousReloadTime + 60000 < timeNow) {
+                window.sessionStorage.setItem('nuxt-reload', timeNow)
+                window.location.reload(true /* skip cache */)
+              }
+            } catch {
+              // don't throw an error if we have issues reading sessionStorage
             }
           }
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/10279

### 📚 Description

In [some situations](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage#securityerror) session storage will throw an error. We can prevent and ignore that error, just as we do in Nuxt 3.