### PR TITLE
docs: fix variable name

### DIFF
--- a/docs/1.getting-started/6.data-fetching.md
+++ b/docs/1.getting-started/6.data-fetching.md
@@ -227,7 +227,7 @@ Combined with the `lazy` option, this can be useful for data that is not needed 
 const articles = await useFetch('/api/article')
 
 /* This call will only be performed on the client */
-const { pending, data: posts } = useFetch('/api/comments', {
+const { pending, data: comments } = useFetch('/api/comments', {
   lazy: true,
   server: false
 })


### PR DESCRIPTION
### 🔗 Linked issue

none

### 📚 Description

The api endpoint is called comments. The data variable name should match that. 
