### PR TITLE
fix(nuxt): flag async data promise as cancelled only if defined

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -543,7 +543,10 @@ function clearNuxtDataByKey (nuxtApp: NuxtApp, key: string): void {
   }
 
   if (key in nuxtApp._asyncDataPromises) {
-    (nuxtApp._asyncDataPromises[key] as any).cancelled = true
+    if (nuxtApp._asyncDataPromises[key]) {
+      (nuxtApp._asyncDataPromises[key] as any).cancelled = true
+    }
+
     nuxtApp._asyncDataPromises[key] = undefined
   }
 }


### PR DESCRIPTION
### 🔗 Linked issue

### 📚 Description

When flagging an async data promise as cancelled, we weren't checking whether it is defined but only for the existence of the key, which throws an error.
