### PR TITLE
docs: remove outdated recommendation

### DIFF
--- a/docs/1.getting-started/5.seo-meta.md
+++ b/docs/1.getting-started/5.seo-meta.md
@@ -128,8 +128,6 @@ See [@unhead/schema](https://github.com/unjs/unhead/blob/main/packages/schema/sr
 
 Reactivity is supported on all properties, by providing a computed value, a getter, or a reactive object.
 
-It's recommended to use getters (`() => value`) over computed (`computed(() => value)`).
-
 ::code-group
 
   ```vue twoslash [useHead]


### PR DESCRIPTION
### 🔗 Linked issue

None

### 📚 Description

According to @harlan-zw this is an outdated recommendation thus no longer needed in the docs. 

See here for more info:
https://x.com/harlan_zw/status/1803031530157261181
