### PR TITLE
fix(nuxt): support hoisting types of subpath imports

### DIFF
--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -102,18 +102,37 @@ async function initNuxt (nuxt: Nuxt) {
     // ignore packages that exist in `package.json` as these can be resolved by TypeScript
     if (dependencies.has(pkg) && !(pkg in nightlies)) { return [] }
 
-    // deduplicate types for nightly releases
-    if (pkg in nightlies) {
-      const nightly = nightlies[pkg as keyof typeof nightlies]
-      const path = await _resolvePath(nightly, { url: nuxt.options.modulesDir }).then(r => resolvePackageJSON(r)).catch(() => null)
-      if (path) {
-        return [[pkg, [dirname(path)]], [nightly, [dirname(path)]]]
+    let [_pkg = pkg, subpath = ''] = /^[^@]+\//.test(pkg) ? pkg.split('/') : [pkg]
+
+    if (subpath) {
+      subpath = '/' + subpath
+    }
+
+    async function resolveTypePath (path: string) {
+      try {
+        const r = await _resolvePath(path, { url: nuxt.options.modulesDir, conditions: ['types', 'import', 'require'] })
+        if (subpath) {
+          return r.replace(/(?:\.d)?\.[mc]?[jt]s$/, '')
+        }
+        const rootPath = await resolvePackageJSON(r)
+        return dirname(rootPath)
+      } catch {
+        return null
       }
     }
 
-    const path = await _resolvePath(pkg, { url: nuxt.options.modulesDir }).then(r => resolvePackageJSON(r)).catch(() => null)
+    // deduplicate types for nightly releases
+    if (_pkg in nightlies) {
+      const nightly = nightlies[pkg as keyof typeof nightlies]
+      const path = await resolveTypePath(nightly + subpath)
+      if (path) {
+        return [[pkg, [path]], [nightly + subpath, [path]]]
+      }
+    }
+
+    const path = await resolveTypePath(pkg + subpath)
     if (path) {
-      return [[pkg, [dirname(path)]]]
+      return [[pkg, [path]]]
     }
 
     return []

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -102,11 +102,8 @@ async function initNuxt (nuxt: Nuxt) {
     // ignore packages that exist in `package.json` as these can be resolved by TypeScript
     if (dependencies.has(pkg) && !(pkg in nightlies)) { return [] }
 
-    let [_pkg = pkg, subpath = ''] = /^[^@]+\//.test(pkg) ? pkg.split('/') : [pkg]
-
-    if (subpath) {
-      subpath = '/' + subpath
-    }
+    const [_pkg = pkg, _subpath] = /^[^@]+\//.test(pkg) ? pkg.split('/') : [pkg]
+    const subpath = _subpath ? '/' + _subpath : ''
 
     async function resolveTypePath (path: string) {
       try {

--- a/packages/schema/src/config/typescript.ts
+++ b/packages/schema/src/config/typescript.ts
@@ -47,6 +47,7 @@ export default defineUntypedSchema({
           '@vue/compiler-sfc',
           '@vue/runtime-dom',
           'vue-router',
+          'vue-router/auto',
           '@nuxt/schema',
           'nuxt',
         ]


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This adds support for hoisting types of paths with subpath imports, like `vue-router/auto`.... (and `nitro/types`!)