### PR TITLE
fix(nuxt): resolve object-syntax routes with `open` in `navigateTo`

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -8,7 +8,7 @@ import type {
 } from 'vue'
 import { computed, defineComponent, h, inject, onBeforeUnmount, onMounted, provide, ref, resolveComponent } from 'vue'
 import type { RouteLocation, RouteLocationRaw, Router, RouterLink, RouterLinkProps, useLink } from '#vue-router'
-import { hasProtocol, joinURL, parseQuery, withQuery, withTrailingSlash, withoutTrailingSlash } from 'ufo'
+import { hasProtocol, joinURL, parseQuery, withTrailingSlash, withoutTrailingSlash } from 'ufo'
 import { preloadRouteComponents } from '../composables/preload'
 import { onNuxtReady } from '../composables/ready'
 import { navigateTo, resolveRouteObject, useRouter } from '../composables/router'
@@ -495,4 +495,3 @@ function isSlowConnection () {
   if (cn && (cn.saveData || /2g/.test(cn.effectiveType))) { return true }
   return false
 }
-

--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -11,7 +11,7 @@ import type { RouteLocation, RouteLocationRaw, Router, RouterLink, RouterLinkPro
 import { hasProtocol, joinURL, parseQuery, withQuery, withTrailingSlash, withoutTrailingSlash } from 'ufo'
 import { preloadRouteComponents } from '../composables/preload'
 import { onNuxtReady } from '../composables/ready'
-import { navigateTo, useRouter } from '../composables/router'
+import { navigateTo, resolveRouteObject, useRouter } from '../composables/router'
 import { useNuxtApp, useRuntimeConfig } from '../nuxt'
 import { cancelIdleCallback, requestIdleCallback } from '../compat/idle-callback'
 
@@ -496,6 +496,3 @@ function isSlowConnection () {
   return false
 }
 
-function resolveRouteObject (to: Exclude<RouteLocationRaw, string>) {
-  return withQuery(to.path || '', to.query || {}) + (to.hash ? '#' + to.hash : '')
-}

--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -1,6 +1,6 @@
 import { getCurrentInstance, hasInjectionContext, inject, onScopeDispose } from 'vue'
 import type { Ref } from 'vue'
-import type { NavigationFailure, NavigationGuard, RouteLocationNormalized, RouteLocationPathRaw, RouteLocationRaw, Router, useRoute as _useRoute, useRouter as _useRouter } from '#vue-router'
+import type { NavigationFailure, NavigationGuard, RouteLocationNormalized, RouteLocationRaw, Router, useRoute as _useRoute, useRouter as _useRouter } from '#vue-router'
 import { sanitizeStatusCode } from 'h3'
 import { hasProtocol, isScriptProtocol, joinURL, withQuery } from 'ufo'
 

--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -120,7 +120,7 @@ export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: Na
     to = '/'
   }
 
-  const toPath = typeof to === 'string' ? to : (withQuery((to as RouteLocationPathRaw).path || '/', to.query || {}) + (to.hash || ''))
+  const toPath = typeof to === 'string' ? to : 'path' in to ? resolveRouteObject(to) : useRouter().resolve(to).href
 
   // Early open handler
   if (import.meta.client && options?.open) {
@@ -251,4 +251,11 @@ export const setPageLayout = (layout: unknown extends PageMeta['layout'] ? strin
   if (!inMiddleware) {
     useRoute().meta.layout = layout as Exclude<PageMeta['layout'], Ref | false>
   }
+}
+
+/**
+ * @internal
+ */
+export function resolveRouteObject (to: Exclude<RouteLocationRaw, string>) {
+  return withQuery(to.path || '', to.query || {}) + (to.hash || '')
 }

--- a/packages/nuxt/test/nuxt-link.test.ts
+++ b/packages/nuxt/test/nuxt-link.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it, vi } from 'vitest'
-import type { RouteLocation } from 'vue-router'
+import type { RouteLocation, RouteLocationRaw } from 'vue-router'
 import type { NuxtLinkOptions, NuxtLinkProps } from '../src/app/components/nuxt-link'
 import { defineNuxtLink } from '../src/app/components/nuxt-link'
 import { useRuntimeConfig } from '../src/app/nuxt'
+import { withQuery } from 'ufo'
 
 // mocks `useRuntimeConfig()`
 vi.mock('../src/app/nuxt', () => ({
@@ -24,7 +25,10 @@ vi.mock('vue', async () => {
 })
 
 // Mocks Nuxt `useRouter()`
-vi.mock('../src/app/composables/router', () => ({
+vi.mock('../src/app/composables/router', (orig) => ({
+  resolveRouteObject (to: Exclude<RouteLocationRaw, string>) {
+    return withQuery(to.path || '', to.query || {}) + (to.hash || '')
+  },
   useRouter: () => ({
     resolve: (route: string | RouteLocation & { to?: string }): Partial<RouteLocation> & { href?: string } => {
       if (typeof route === 'string') {

--- a/packages/nuxt/test/nuxt-link.test.ts
+++ b/packages/nuxt/test/nuxt-link.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { RouteLocation, RouteLocationRaw } from 'vue-router'
+import { withQuery } from 'ufo'
 import type { NuxtLinkOptions, NuxtLinkProps } from '../src/app/components/nuxt-link'
 import { defineNuxtLink } from '../src/app/components/nuxt-link'
 import { useRuntimeConfig } from '../src/app/nuxt'
-import { withQuery } from 'ufo'
 
 // mocks `useRuntimeConfig()`
 vi.mock('../src/app/nuxt', () => ({
@@ -25,7 +25,7 @@ vi.mock('vue', async () => {
 })
 
 // Mocks Nuxt `useRouter()`
-vi.mock('../src/app/composables/router', (orig) => ({
+vi.mock('../src/app/composables/router', () => ({
   resolveRouteObject (to: Exclude<RouteLocationRaw, string>) {
     return withQuery(to.path || '', to.query || {}) + (to.hash || '')
   },


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/27676

### 📚 Description

We were wrongly assuming that object-syntax routes would be fully resolved before being passed to `navigateTo` - this adds handling for that edge case.