### PR TITLE
fix(nuxt): avoid name collisions with user-crafted lazy components

### DIFF
--- a/packages/nuxt/src/components/loader.ts
+++ b/packages/nuxt/src/components/loader.ts
@@ -45,7 +45,7 @@ export const loaderPlugin = createUnplugin((options: LoaderOptions) => {
       // replace `_resolveComponent("...")` to direct import
       s.replace(/(?<=[ (])_?resolveComponent\(\s*["'](lazy-|Lazy)?([^'"]*)["'][^)]*\)/g, (full: string, lazy: string, name: string) => {
         const normalComponent = findComponent(components, name, options.mode)
-        const lazyComponent = !component && lazy ? findComponent(components, lazy + name, options.mode) : null
+        const lazyComponent = !normalComponent && lazy ? findComponent(components, lazy + name, options.mode) : null
         const component = normalComponent || lazyComponent
         if (component) {
           // @ts-expect-error TODO: refactor to nuxi

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -2644,7 +2644,9 @@ describe('import components', () => {
   })
 
   it('load user-made lazy components', () => {
-    expect(html).toContain('This is a fake lazy component that should load')
+    const { page } = await renderPage('/lazy-import-components')
+    await page.waitForLoadState('networkidle')
+    expect(await page.getByText('This is a fake lazy component that should load').all()).toHaveLength(1)
   })
 })
 

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -2642,6 +2642,10 @@ describe('import components', () => {
   it('load named component with mode server', () => {
     expect(html).toContain('named-comp-server')
   })
+
+  it('load user-made lazy components', () => {
+    expect(html).toContain('This is a fake lazy component that should load')
+  })
 })
 
 describe('lazy import components', () => {

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -2643,7 +2643,7 @@ describe('import components', () => {
     expect(html).toContain('named-comp-server')
   })
 
-  it('load user-made lazy components', () => {
+  it('load user-made lazy components', async () => {
     const { page } = await renderPage('/lazy-import-components')
     await page.waitForLoadState('networkidle')
     expect(await page.getByText('This is a fake lazy component that should load').all()).toHaveLength(1)

--- a/test/fixtures/basic/components/LazyFake.vue
+++ b/test/fixtures/basic/components/LazyFake.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    This is a fake lazy component that should load
+  </div>
+</template>

--- a/test/fixtures/basic/pages/lazy-import-components/index.vue
+++ b/test/fixtures/basic/pages/lazy-import-components/index.vue
@@ -3,5 +3,6 @@
     <LazyNCompAll message="lazy-named-comp-all" />
     <LazyNCompClient message="lazy-named-comp-client" />
     <LazyNCompServer message="lazy-named-comp-server" />
+    <LazyFake />
   </div>
 </template>


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
This PR removes name conflicts that happen with lazy prefixed components. If a developer were to create a component, (like \<LazyTest\>), using it in a template causes the "failed to resolve component" warning to show. That's because the current component loading strategy does not take into account components that could be prefixed with Lazy
<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
