### PR TITLE
fix(nuxt): extract all-literal page meta 

### DIFF
--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -257,9 +257,19 @@ export async function getRouteMeta (contents: string, absolutePath: string): Pro
       }
 
       const extraneousMetaKeys = pageMetaArgument.properties
-        .filter(property => property.type === 'Property' && property.key.type === 'Identifier' && !(extractionKeys as unknown as string[]).includes(property.key.name))
-        // @ts-expect-error inferred types have been filtered out
-        .map(property => property.key.name)
+        .filter((property) => {
+          if (property.type !== 'Property') {
+            return false
+          }
+          const isIdentifierOrLiteral = property.key.type === 'Literal' || property.key.type === 'Identifier'
+          if (!isIdentifierOrLiteral) {
+            return false
+          }
+          const name = property.key.type === 'Identifier' ? property.key.name : String(property.value)
+          return !(extractionKeys as unknown as string[]).includes(name)
+        })
+        // @ts-expect-error inferred types have been filtered out - Remove with TS 5.5
+        .map((property: Property) => property.key.type === 'Identifier' ? property.key.name : String(property.value))
 
       if (extraneousMetaKeys.length) {
         dynamicProperties.add('meta')

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -256,23 +256,19 @@ export async function getRouteMeta (contents: string, absolutePath: string): Pro
         extractedMeta[key] = property.value.value
       }
 
-      const extraneousMetaKeys = pageMetaArgument.properties
-        .filter((property) => {
-          if (property.type !== 'Property') {
-            return false
-          }
-          const isIdentifierOrLiteral = property.key.type === 'Literal' || property.key.type === 'Identifier'
-          if (!isIdentifierOrLiteral) {
-            return false
-          }
-          const name = property.key.type === 'Identifier' ? property.key.name : String(property.value)
-          return !(extractionKeys as unknown as string[]).includes(name)
-        })
-        // @ts-expect-error inferred types have been filtered out - Remove with TS 5.5
-        .map((property: Property) => property.key.type === 'Identifier' ? property.key.name : String(property.value))
-
-      if (extraneousMetaKeys.length) {
-        dynamicProperties.add('meta')
+      for (const property of pageMetaArgument.properties) {
+        if (property.type !== 'Property') {
+          continue
+        }
+        const isIdentifierOrLiteral = property.key.type === 'Literal' || property.key.type === 'Identifier'
+        if (!isIdentifierOrLiteral) {
+          continue
+        }
+        const name = property.key.type === 'Identifier' ? property.key.name : String(property.value)
+        if (!(extractionKeys as unknown as string[]).includes(name)) {
+          dynamicProperties.add('meta')
+          break
+        }
       }
 
       if (dynamicProperties.size) {

--- a/packages/nuxt/test/page-metadata.test.ts
+++ b/packages/nuxt/test/page-metadata.test.ts
@@ -75,6 +75,28 @@ describe('page metadata', () => {
       }
     `)
   })
+
+  it('should extract serialisable metadata all quoted', async () => {
+    const meta = await getRouteMeta(`
+    <script setup>
+    definePageMeta({
+      "otherValue": {
+        foo: 'bar',
+      },
+    })
+    </script>
+    `, filePath)
+
+    expect(meta).toMatchInlineSnapshot(`
+      {
+        "meta": {
+          "__nuxt_dynamic_meta_key": Set {
+            "meta",
+          },
+        }
+      }
+    `)
+  })
 })
 
 describe('normalizeRoutes', () => {

--- a/packages/nuxt/test/page-metadata.test.ts
+++ b/packages/nuxt/test/page-metadata.test.ts
@@ -93,7 +93,7 @@ describe('page metadata', () => {
           "__nuxt_dynamic_meta_key": Set {
             "meta",
           },
-        }
+        },
       }
     `)
   })


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/27815

### 📚 Description

This PR ensures that objects in `definePageMeta` using only literals as keys (e.g. `{ 'a': 1 }`) still will be extracted correctly.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
