### PR TITLE
fix(nuxt): use URL to encode redirected URLs

### DIFF
--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -266,7 +266,7 @@ export function resolveRouteObject (to: Exclude<RouteLocationRaw, string>) {
 /**
  * @internal
  */
-export function encodeURL(location: string, isExternalHost = false) {
+export function encodeURL (location: string, isExternalHost = false) {
   const url = new URL(location, 'http://localhost')
   if (!isExternalHost) {
     return url.toString().replace(/^http:\/\/localhost\//, '/')

--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -269,7 +269,7 @@ export function resolveRouteObject (to: Exclude<RouteLocationRaw, string>) {
 export function encodeURL (location: string, isExternalHost = false) {
   const url = new URL(location, 'http://localhost')
   if (!isExternalHost) {
-    return url.toString().replace(/^http:\/\/localhost\//, '/')
+    return url.pathname + url.search + url.hash
   }
   if (location.startsWith('//')) {
     return url.toString().replace(url.protocol, '')

--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -268,5 +268,11 @@ export function resolveRouteObject (to: Exclude<RouteLocationRaw, string>) {
  */
 export function encodeURL(location: string, isExternalHost = false) {
   const url = new URL(location, 'http://localhost')
-  return isExternalHost ? url.toString() : url.toString().replace(/^http:\/\/localhost\//, '/')
+  if (!isExternalHost) {
+    return url.toString().replace(/^http:\/\/localhost\//, '/')
+  }
+  if (location.startsWith('//')) {
+    return url.toString().replace(url.protocol, '')
+  }
+  return url.toString()
 }

--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -135,7 +135,8 @@ export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: Na
     return Promise.resolve()
   }
 
-  const isExternal = options?.external || hasProtocol(toPath, { acceptRelative: true })
+  const isExternalHost = hasProtocol(toPath, { acceptRelative: true })
+  const isExternal = options?.external || isExternalHost
   if (isExternal) {
     if (!options?.external) {
       throw new Error('Navigating to an external URL is not allowed by default. Use `navigateTo(url, { external: true })`.')
@@ -166,10 +167,12 @@ export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: Na
         // TODO: consider deprecating in favour of `app:rendered` and removing
         await nuxtApp.callHook('app:redirected')
         const encodedLoc = location.replace(/"/g, '%22')
+        const encodedHeader = encodeURL(location, isExternalHost)
+
         nuxtApp.ssrContext!._renderResponse = {
           statusCode: sanitizeStatusCode(options?.redirectCode || 302, 302),
           body: `<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=${encodedLoc}"></head></html>`,
-          headers: { location: encodeURI(location) },
+          headers: { location: encodedHeader },
         }
         return response
       }
@@ -258,4 +261,12 @@ export const setPageLayout = (layout: unknown extends PageMeta['layout'] ? strin
  */
 export function resolveRouteObject (to: Exclude<RouteLocationRaw, string>) {
   return withQuery(to.path || '', to.query || {}) + (to.hash || '')
+}
+
+/**
+ * @internal
+ */
+export function encodeURL(location: string, isExternalHost = false) {
+  const url = new URL(location, 'http://localhost')
+  return isExternalHost ? url.toString() : url.toString().replace(/^http:\/\/localhost\//, '/')
 }

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1005,9 +1005,10 @@ describe('navigate', () => {
   })
 
   it('expect to redirect with encoding', async () => {
-    const { status } = await fetch('/redirect-with-encode', { redirect: 'manual' })
+    const { status, headers } = await fetch('/redirect-with-encode', { redirect: 'manual' })
 
     expect(status).toEqual(302)
+    expect(headers.get('location') || '').toEqual(encodeURI('/cœur') + '?redirected=' + encodeURIComponent('https://google.com'))
   })
 })
 

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -72,7 +72,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(rootDir, '.output-inline/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"531k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"532k"`)
 
     const modules = await analyzeSizes('node_modules/**/*', serverDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"76.2k"`)

--- a/test/fixtures/basic/pages/redirect-with-encode.vue
+++ b/test/fixtures/basic/pages/redirect-with-encode.vue
@@ -5,5 +5,5 @@
 </template>
 
 <script setup lang="ts">
-await navigateTo('/cœur')
+await navigateTo('/cœur?redirected=' + encodeURIComponent('https://google.com'))
 </script>

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -20,6 +20,7 @@ import { callOnce } from '#app/composables/once'
 import { useLoadingIndicator } from '#app/composables/loading-indicator'
 import { useRouteAnnouncer } from '#app/composables/route-announcer'
 import { encodeURL, resolveRouteObject } from '#app/composables/router'
+import { hasProtocol } from 'ufo'
 
 registerEndpoint('/api/test', defineEventHandler(event => ({
   method: event.method,
@@ -605,12 +606,15 @@ describe('routing utilities: `resolveRouteObject`', () => {
 })
 
 describe('routing utilities: `encodeURL`', () => {
+  const encode = (url: string) => {
+    const isExternal = hasProtocol(url, { acceptRelative: true })
+    return encodeURL(url, isExternal)
+  }
   it('encodeURL should correctly encode a URL', () => {
-    expect(encodeURL('https://test.com')).toMatchInlineSnapshot(`"https://test.com/"`)
-    expect(encodeURL('https://test.com', true)).toMatchInlineSnapshot(`"https://test.com/"`)
-    expect(encodeURL('//test.com', true)).toMatchInlineSnapshot(`"//test.com/"`)
-    expect(encodeURL('mailto:daniel@cœur.com')).toMatchInlineSnapshot(`"mailto:daniel@c%C5%93ur.com"`)
-    const encoded = encodeURL('/cœur?redirected=' + encodeURIComponent('https://google.com'))
+    expect(encode('https://test.com')).toMatchInlineSnapshot(`"https://test.com/"`)
+    expect(encode('//test.com')).toMatchInlineSnapshot(`"//test.com/"`)
+    expect(encode('mailto:daniel@cœur.com')).toMatchInlineSnapshot(`"mailto:daniel@c%C5%93ur.com"`)
+    const encoded = encode('/cœur?redirected=' + encodeURIComponent('https://google.com'))
     expect(new URL('/cœur', 'http://localhost').pathname).toMatchInlineSnapshot(`"/c%C5%93ur"`)
     expect(encoded).toMatchInlineSnapshot(`"/c%C5%93ur?redirected=https%3A%2F%2Fgoogle.com"`)
     expect(useRouter().resolve(encoded).query.redirected).toMatchInlineSnapshot(`"https://google.com"`)

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -19,6 +19,7 @@ import { useId } from '#app/composables/id'
 import { callOnce } from '#app/composables/once'
 import { useLoadingIndicator } from '#app/composables/loading-indicator'
 import { useRouteAnnouncer } from '#app/composables/route-announcer'
+import { encodeURL, resolveRouteObject } from '#app/composables/router'
 
 registerEndpoint('/api/test', defineEventHandler(event => ({
   method: event.method,
@@ -593,6 +594,24 @@ describe('routing utilities: `navigateTo`', () => {
     for (const [url, protocol] of urls) {
       expect(() => navigateTo(url, { external: true })).toThrowError(`Cannot navigate to a URL with '${protocol}:' protocol.`)
     }
+  })
+})
+
+describe('routing utilities: `resolveRouteObject`', () => {
+  it('resolveRouteObject should correctly resolve a route object', () => {
+    expect(resolveRouteObject({ path: '/test' })).toMatchInlineSnapshot(`"/test"`)
+    expect(resolveRouteObject({ path: '/test', hash: '#thing', query: { foo: 'bar' } })).toMatchInlineSnapshot(`"/test?foo=bar#thing"`)
+  })
+})
+
+describe('routing utilities: `encodeURL`', () => {
+  it('encodeURL should correctly encode a URL', () => {
+    expect(encodeURL('https://test.com')).toMatchInlineSnapshot(`"https://test.com/"`)
+    expect(encodeURL('//test.com')).toMatchInlineSnapshot(`"http://test.com/"`)
+    const encoded = encodeURL('/cœur?redirected=' + encodeURIComponent('https://google.com'))
+    expect(new URL('/cœur', 'http://localhost').pathname).toMatchInlineSnapshot(`"/c%C5%93ur"`)
+    expect(encoded).toMatchInlineSnapshot(`"/c%C5%93ur?redirected=https%3A%2F%2Fgoogle.com"`)
+    expect(useRouter().resolve(encoded).query.redirected).toMatchInlineSnapshot(`"https://google.com"`)
   })
 })
 

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -607,7 +607,9 @@ describe('routing utilities: `resolveRouteObject`', () => {
 describe('routing utilities: `encodeURL`', () => {
   it('encodeURL should correctly encode a URL', () => {
     expect(encodeURL('https://test.com')).toMatchInlineSnapshot(`"https://test.com/"`)
-    expect(encodeURL('//test.com')).toMatchInlineSnapshot(`"http://test.com/"`)
+    expect(encodeURL('https://test.com', true)).toMatchInlineSnapshot(`"https://test.com/"`)
+    expect(encodeURL('//test.com', true)).toMatchInlineSnapshot(`"//test.com/"`)
+    expect(encodeURL('mailto:daniel@cœur.com')).toMatchInlineSnapshot(`"mailto:daniel@c%C5%93ur.com"`)
     const encoded = encodeURL('/cœur?redirected=' + encodeURIComponent('https://google.com'))
     expect(new URL('/cœur', 'http://localhost').pathname).toMatchInlineSnapshot(`"/c%C5%93ur"`)
     expect(encoded).toMatchInlineSnapshot(`"/c%C5%93ur?redirected=https%3A%2F%2Fgoogle.com"`)

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -6,6 +6,7 @@ import { defineEventHandler } from 'h3'
 import { mount } from '@vue/test-utils'
 import { mountSuspended, registerEndpoint } from '@nuxt/test-utils/runtime'
 
+import { hasProtocol } from 'ufo'
 import * as composables from '#app/composables'
 
 import { clearNuxtData, refreshNuxtData, useAsyncData, useNuxtData } from '#app/composables/asyncData'
@@ -20,7 +21,6 @@ import { callOnce } from '#app/composables/once'
 import { useLoadingIndicator } from '#app/composables/loading-indicator'
 import { useRouteAnnouncer } from '#app/composables/route-announcer'
 import { encodeURL, resolveRouteObject } from '#app/composables/router'
-import { hasProtocol } from 'ufo'
 
 registerEndpoint('/api/test', defineEventHandler(event => ({
   method: event.method,


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/27554

### 📚 Description

This uses URL to ensure characters are ASCII-encoded as required (as well as perform other normalisation steps), without double encoding other segments of the URL.