### PR TITLE
fix(nuxt): store augmented pages with route path

### DIFF
--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -140,19 +140,19 @@ export function generateRoutesFromFiles (files: ScannedFile[], options: Generate
   return prepareRoutes(routes)
 }
 
-export async function augmentPages (routes: NuxtPage[], vfs: Record<string, string>, augmentedPages = new Set<string>()) {
+export async function augmentPages (routes: NuxtPage[], vfs: Record<string, string>, augmentedPagesWithPaths = new Set<string>()) {
   for (const route of routes) {
-    if (route.file && !augmentedPages.has(route.file)) {
+    if (route.file && !augmentedPagesWithPaths.has(route.file)) {
       const fileContent = route.file in vfs ? vfs[route.file] : fs.readFileSync(await resolvePath(route.file), 'utf-8')
       Object.assign(route, await getRouteMeta(fileContent, route.file))
-      augmentedPages.add(route.file)
+      augmentedPagesWithPaths.add(`${route.file}_${route.path}`)
     }
 
     if (route.children && route.children.length > 0) {
       await augmentPages(route.children, vfs)
     }
   }
-  return augmentedPages
+  return augmentedPagesWithPaths
 }
 
 const SFC_SCRIPT_RE = /<script(?<attrs>[^>]*)>(?<content>[\s\S]*?)<\/script[^>]*>/i

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -142,10 +142,11 @@ export function generateRoutesFromFiles (files: ScannedFile[], options: Generate
 
 export async function augmentPages (routes: NuxtPage[], vfs: Record<string, string>, augmentedPagesWithPaths = new Set<string>(), parentPath = '') {
   for (const route of routes) {
-    if (route.file && !augmentedPagesWithPaths.has(route.file)) {
+    const key = `${route.file}_${parentPath}${route.path}`
+    if (route.file && !augmentedPagesWithPaths.has(key)) {
       const fileContent = route.file in vfs ? vfs[route.file] : fs.readFileSync(await resolvePath(route.file), 'utf-8')
       Object.assign(route, await getRouteMeta(fileContent, route.file))
-      augmentedPagesWithPaths.add(`${route.file}_${parentPath}${route.path}`)
+      augmentedPagesWithPaths.add(key)
     }
 
     if (route.children && route.children.length > 0) {

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -140,16 +140,16 @@ export function generateRoutesFromFiles (files: ScannedFile[], options: Generate
   return prepareRoutes(routes)
 }
 
-export async function augmentPages (routes: NuxtPage[], vfs: Record<string, string>, augmentedPagesWithPaths = new Set<string>()) {
+export async function augmentPages (routes: NuxtPage[], vfs: Record<string, string>, augmentedPagesWithPaths = new Set<string>(), parentPath = '') {
   for (const route of routes) {
     if (route.file && !augmentedPagesWithPaths.has(route.file)) {
       const fileContent = route.file in vfs ? vfs[route.file] : fs.readFileSync(await resolvePath(route.file), 'utf-8')
       Object.assign(route, await getRouteMeta(fileContent, route.file))
-      augmentedPagesWithPaths.add(`${route.file}_${route.path}`)
+      augmentedPagesWithPaths.add(`${route.file}_${parentPath}${route.path}`)
     }
 
     if (route.children && route.children.length > 0) {
-      await augmentPages(route.children, vfs)
+      await augmentPages(route.children, vfs, augmentedPagesWithPaths, route.path)
     }
   }
   return augmentedPagesWithPaths


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/27814

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

Before, when augmenting pages via scanPageMeta, we cached the already-augmented pages based on the file path. When to different routes used the same file, this would lead to not augmenting the second route. This PR caches them by using file path and route path as key

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
