### PR TITLE
fix(kit)!: support loading nuxt 4 and drop support for <=2

### DIFF
--- a/packages/kit/src/loader/nuxt.ts
+++ b/packages/kit/src/loader/nuxt.ts
@@ -1,6 +1,7 @@
 import { pathToFileURL } from 'node:url'
 import { readPackageJSON, resolvePackageJSON } from 'pkg-types'
 import type { Nuxt } from '@nuxt/schema'
+import { resolve } from 'pathe'
 import { importModule, tryImportModule } from '../internal/esm'
 import type { LoadNuxtConfigOptions } from './config'
 
@@ -10,64 +11,29 @@ export interface LoadNuxtOptions extends LoadNuxtConfigOptions {
 
   /** Use lazy initialization of nuxt if set to false */
   ready?: boolean
-
-  /** @deprecated Use cwd option */
-  rootDir?: LoadNuxtConfigOptions['cwd']
-
-  /** @deprecated use overrides option */
-  config?: LoadNuxtConfigOptions['overrides']
 }
 
 export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
   // Backward compatibility
-  opts.cwd = opts.cwd || opts.rootDir
-  opts.overrides = opts.overrides || opts.config || {}
+  opts.cwd = resolve(opts.cwd || (opts as any).rootDir /* backwards compat */ || '.')
+  opts.overrides = opts.overrides || (opts as any).config as {} /* backwards compat */ || {}
 
   // Apply dev as config override
   opts.overrides.dev = !!opts.dev
 
-  const nearestNuxtPkg = await Promise.all(['nuxt-nightly', 'nuxt3', 'nuxt', 'nuxt-edge']
+  const nearestNuxtPkg = await Promise.all(['nuxt-nightly', 'nuxt']
     .map(pkg => resolvePackageJSON(pkg, { url: opts.cwd }).catch(() => null)))
     .then(r => (r.filter(Boolean) as string[]).sort((a, b) => b.length - a.length)[0])
   if (!nearestNuxtPkg) {
     throw new Error(`Cannot find any nuxt version from ${opts.cwd}`)
   }
   const pkg = await readPackageJSON(nearestNuxtPkg)
-  const majorVersion = pkg.version ? Number.parseInt(pkg.version.split('.')[0]) : ''
 
-  const rootDir = pathToFileURL(opts.cwd || process.cwd()).href
+  const rootDir = pathToFileURL(opts.cwd!).href
 
-  // Nuxt 3
-  if (majorVersion === 3) {
-    const { loadNuxt } = await importModule((pkg as any)._name || pkg.name, rootDir)
-    const nuxt = await loadNuxt(opts)
-    return nuxt
-  }
-
-  // Nuxt 2
-  const { loadNuxt } = await tryImportModule('nuxt-edge', rootDir) || await importModule('nuxt', rootDir)
-  const nuxt = await loadNuxt({
-    rootDir: opts.cwd,
-    for: opts.dev ? 'dev' : 'build',
-    configOverrides: opts.overrides,
-    ready: opts.ready,
-    envConfig: opts.dotenv, // TODO: Backward format conversion
-  })
-
-  // Mock new hookable methods
-  nuxt.removeHook ||= nuxt.clearHook.bind(nuxt)
-  nuxt.removeAllHooks ||= nuxt.clearHooks.bind(nuxt)
-  nuxt.hookOnce ||= (name: string, fn: (...args: any[]) => any, ...hookArgs: any[]) => {
-    const unsub = nuxt.hook(name, (...args: any[]) => {
-      unsub()
-      return fn(...args)
-    }, ...hookArgs)
-    return unsub
-  }
-  // https://github.com/nuxt/nuxt/tree/main/packages/kit/src/module/define.ts#L111-L113
-  nuxt.hooks ||= nuxt
-
-  return nuxt as Nuxt
+  const { loadNuxt } = await importModule((pkg as any)._name || pkg.name, rootDir)
+  const nuxt = await loadNuxt(opts)
+  return nuxt
 }
 
 export async function buildNuxt (nuxt: Nuxt): Promise<any> {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This removes the hard-coded version constraint in `loadNuxt` and also drops the support for loading Nuxt 2, following up on https://github.com/nuxt/nuxt/pull/27706.