### PR TITLE
fix(nuxt): do not read user's package.json when looking for nuxt deps

### DIFF
--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -708,9 +708,9 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
 }
 
 async function checkDependencyVersion (name: string, nuxtVersion: string): Promise<void> {
-  const path = await resolvePath(name).catch(() => null)
+  const path = await resolvePath(name, { fallbackToOriginal: true }).catch(() => null)
 
-  if (!path) { return }
+  if (!path || path === name) { return }
   const { version } = await readPackageJSON(path)
 
   if (version && gt(nuxtVersion, version)) {

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -307,7 +307,7 @@ async function initNuxt (nuxt: Nuxt) {
   for (const _mod of nuxt.options.modules) {
     const mod = Array.isArray(_mod) ? _mod[0] : _mod
     if (typeof mod !== 'string') { continue }
-    const modPath = await resolvePath(resolveAlias(mod))
+    const modPath = await resolvePath(resolveAlias(mod), { fallbackToOriginal: true })
     specifiedModules.add(modPath)
   }
 

--- a/packages/nuxt/test/load-nuxt.test.ts
+++ b/packages/nuxt/test/load-nuxt.test.ts
@@ -56,8 +56,9 @@ describe('dependency mismatch', () => {
       cwd: repoRoot,
     })
 
+    // @nuxt/kit is explicitly installed in repo root but @nuxt/schema isn't, so we only
+    // get warnings about @nuxt/schema
     expect(console.warn).toHaveBeenCalledWith(`[nuxt] Expected \`@nuxt/kit\` to be at least \`${version}\` but got \`3.0.0\`. This might lead to unexpected behavior. Check your package.json or refresh your lockfile.`)
-    expect(console.warn).toHaveBeenCalledWith(`[nuxt] Expected \`@nuxt/schema\` to be at least \`${version}\` but got \`3.0.0\`. This might lead to unexpected behavior. Check your package.json or refresh your lockfile.`)
 
     vi.mocked(readPackageJSON).mockRestore()
     await nuxt.close()


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This is a follow-up on https://github.com/nuxt/nuxt/pull/27507. Noticed we were getting weird issues with `@nuxt/schema` + kit versions - and this was because when `@nuxt/schema` was not installed explicitly in a pnpm project, Nuxt was silently reading `package.json` from user's project because the module was resolved as `/user/path/@nuxt/schema` and the closest `package.json` to this nonexistent path was in fact the user project.

cc: @huang-julien 