### PR TITLE
fix(config): add back md4 monkey-patch if needed for wider ecosystem

### DIFF
--- a/packages/config/src/options.js
+++ b/packages/config/src/options.js
@@ -520,6 +520,17 @@ export function getNuxtConfig (_options) {
     options.build.indicator = false
   }
 
+  // Monkey patch crypto.createHash in dev/build to upgrade hashing fnction
+  if (parseInt(process.versions.node.slice(0, 2)) > 16 && !options.buildModules.some(m => m.name === 'patchMD4')) {
+    options.buildModules.push(function patchMD4 () {
+      const crypto = require('crypto')
+      const _createHash = crypto.createHash
+      crypto.createHash = function (algorithm, options) {
+        return _createHash(algorithm === 'md4' ? 'md5' : algorithm, options)
+      }
+    })
+  }
+
   // Components Module
   if (!options._start && getPKG('@nuxt/components')) {
     options._modules.push('@nuxt/components')

--- a/packages/config/test/config/index.test.js
+++ b/packages/config/test/config/index.test.js
@@ -24,6 +24,7 @@ describe('config', () => {
       UNIX_SOCKET: '/var/run/nuxt.sock'
     }
     const config = getDefaultNuxtConfig({ env })
+    config.buildModules = config.buildModules.filter(p => p.name !== 'patchMD4')
     expect(config).toMatchSnapshot()
   })
 })

--- a/packages/config/test/options.test.js
+++ b/packages/config/test/options.test.js
@@ -34,6 +34,7 @@ describe('config: options', () => {
         }
       }
     })
+    config.buildModules = config.buildModules.filter(p => p.name !== 'patchMD4')
     expect(config).toMatchSnapshot()
 
     process.cwd.mockRestore()
@@ -297,7 +298,7 @@ describe('config: options', () => {
       const config = getNuxtConfig({ devModules: ['foo'], buildModules: ['bar'] })
       expect(consola.warn).toHaveBeenCalledWith('`devModules` has been renamed to `buildModules` and will be removed in Nuxt 3.')
       expect(config.devModules).toBe(undefined)
-      expect(config.buildModules).toEqual(['bar', 'foo'])
+      expect(config.buildModules.filter(p => p.name !== 'patchMD4')).toEqual(['bar', 'foo'])
     })
 
     test('should deprecate build.extractCSS.allChunks', () => {


### PR DESCRIPTION
This reverts commit https://github.com/nuxt/nuxt/pull/23703.

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

We previously patched the `crypto.createHash` function for use on webpack 4. Webpack has now added this in core and we removed our patch, but there are still other plugins in the webpack ecosystem that fail if this monkey patch is not present, so this PR aims to revert the change before EOL for Nuxt 2.

resolves https://github.com/nuxt/nuxt/issues/10844