### PR TITLE
fix(nuxt): add `#vue-router` alias for backwards compat

### DIFF
--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs'
 import { rm } from 'node:fs/promises'
-import { dirname, join, normalize, relative, resolve } from 'pathe'
+import { join, normalize, relative, resolve } from 'pathe'
 import { createDebugger, createHooks } from 'hookable'
 import ignore from 'ignore'
 import type { LoadNuxtOptions } from '@nuxt/kit'

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -8,7 +8,7 @@ import { addBuildPlugin, addComponent, addPlugin, addRouteMiddleware, addServerP
 import { resolvePath as _resolvePath } from 'mlly'
 import type { Nuxt, NuxtHooks, NuxtModule, NuxtOptions } from 'nuxt/schema'
 import type { PackageJson } from 'pkg-types'
-import { readPackageJSON, resolvePackageJSON } from 'pkg-types'
+import { readPackageJSON } from 'pkg-types'
 import { hash } from 'ohash'
 
 import escapeRE from 'escape-string-regexp'
@@ -24,6 +24,7 @@ import importsModule from '../imports/module'
 import { distDir, pkgDir } from '../dirs'
 import { version } from '../../package.json'
 import { scriptsStubsPreset } from '../imports/presets'
+import { resolveTypePath } from './utils/types'
 import { ImportProtectionPlugin, nuxtImportProtections } from './plugins/import-protection'
 import type { UnctxTransformPluginOptions } from './plugins/unctx'
 import { UnctxTransformPlugin } from './plugins/unctx'
@@ -107,29 +108,16 @@ async function initNuxt (nuxt: Nuxt) {
     // ignore packages that exist in `package.json` as these can be resolved by TypeScript
     if (dependencies.has(_pkg) && !(_pkg in nightlies)) { return [] }
 
-    async function resolveTypePath (path: string) {
-      try {
-        const r = await _resolvePath(path, { url: nuxt.options.modulesDir, conditions: ['types', 'import', 'require'] })
-        if (subpath) {
-          return r.replace(/(?:\.d)?\.[mc]?[jt]s$/, '')
-        }
-        const rootPath = await resolvePackageJSON(r)
-        return dirname(rootPath)
-      } catch {
-        return null
-      }
-    }
-
     // deduplicate types for nightly releases
     if (_pkg in nightlies) {
       const nightly = nightlies[_pkg as keyof typeof nightlies]
-      const path = await resolveTypePath(nightly + subpath)
+      const path = await resolveTypePath(nightly + subpath, subpath, nuxt.options.modulesDir)
       if (path) {
         return [[pkg, [path]], [nightly + subpath, [path]]]
       }
     }
 
-    const path = await resolveTypePath(_pkg + subpath)
+    const path = await resolveTypePath(_pkg + subpath, subpath, nuxt.options.modulesDir)
     if (path) {
       return [[pkg, [path]]]
     }

--- a/packages/nuxt/src/core/utils/types.ts
+++ b/packages/nuxt/src/core/utils/types.ts
@@ -1,0 +1,17 @@
+import { resolvePackageJSON } from 'pkg-types'
+import { resolvePath as _resolvePath } from 'mlly'
+import { dirname } from 'pathe'
+import { tryUseNuxt } from '@nuxt/kit'
+
+export async function resolveTypePath (path: string, subpath: string, searchPaths = tryUseNuxt()?.options.modulesDir) {
+  try {
+    const r = await _resolvePath(path, { url: searchPaths, conditions: ['types', 'import', 'require'] })
+    if (subpath) {
+      return r.replace(/(?:\.d)?\.[mc]?[jt]s$/, '')
+    }
+    const rootPath = await resolvePackageJSON(r)
+    return dirname(rootPath)
+  } catch {
+    return null
+  }
+}

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -1,6 +1,6 @@
 import { existsSync, readdirSync } from 'node:fs'
 import { mkdir, readFile } from 'node:fs/promises'
-import { addBuildPlugin, addComponent, addPlugin, addTemplate, addTypeTemplate, addVitePlugin, addWebpackPlugin, defineNuxtModule, findPath, logger, resolvePath, tryResolveModule, updateTemplates, useNitro } from '@nuxt/kit'
+import { addBuildPlugin, addComponent, addPlugin, addTemplate, addTypeTemplate, addVitePlugin, addWebpackPlugin, defineNuxtModule, findPath, logger, resolvePath, updateTemplates, useNitro } from '@nuxt/kit'
 import { dirname, join, relative, resolve } from 'pathe'
 import { genImport, genObjectFromRawEntries, genString } from 'knitwork'
 import type { Nuxt, NuxtApp, NuxtPage } from 'nuxt/schema'
@@ -11,12 +11,12 @@ import type { EditableTreeNode, Options as TypedRouterOptions } from 'unplugin-v
 import type { NitroRouteConfig } from 'nitro/types'
 import { defu } from 'defu'
 import { distDir } from '../dirs'
+import { resolveTypePath } from '../core/utils/types'
 import { normalizeRoutes, resolvePagesRoutes, resolveRoutePaths } from './utils'
 import { extractRouteRules, getMappedPages } from './route-rules'
 import type { PageMetaPluginOptions } from './plugins/page-meta'
 import { PageMetaPlugin } from './plugins/page-meta'
 import { RouteInjectionPlugin } from './plugins/route-injection'
-import { resolveTypePath } from '../core/utils/types'
 
 export default defineNuxtModule({
   meta: {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Following up on latest upgrade of `vue-router`, we removed an internal alias for `#vue-router` as it was no longer needed. However, it seems there are a number of packages using this alias. This PR adds it back in to avoid breaking them.