### PR TITLE
fix(nuxt): move app augments to core `nuxt` types

### DIFF
--- a/packages/nuxt/src/app/index.ts
+++ b/packages/nuxt/src/app/index.ts
@@ -1,5 +1,3 @@
-/// <reference path="types/augments.d.ts" />
-
 export * from './nuxt'
 
 export * from './composables/index'

--- a/packages/nuxt/types.d.mts
+++ b/packages/nuxt/types.d.mts
@@ -1,4 +1,5 @@
 /// <reference types="nitro/types" />
+/// <reference path="dist/app/types/augments.d.ts" />
 
 import type { DefineNuxtConfig } from 'nuxt/config'
 import type { RuntimeConfig, SchemaDefinition } from 'nuxt/schema'

--- a/packages/nuxt/types.d.ts
+++ b/packages/nuxt/types.d.ts
@@ -1,4 +1,6 @@
 /// <reference types="nitro/types" />
+/// <reference path="dist/app/types/augments.d.ts" />
+
 import type { DefineNuxtConfig } from 'nuxt/config'
 import type { RuntimeConfig, SchemaDefinition } from 'nuxt/schema'
 import type { H3Event } from 'h3'


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Now that we are not explicitly importing from `#app` index it's possible for these augments to disappear mysteriously for a user. By adding them to core `nuxt` types we avoid that danger.

**Note**: we will probably move them again later - we'd like to separate the 'type namespaces' for nuxt configuration + runtime, but for now this is a good location.