### PR TITLE
feat(nuxt): ensure `prefetchComponents` be treeshake on server

### DIFF
--- a/packages/nuxt/src/app/composables/preload.ts
+++ b/packages/nuxt/src/app/composables/preload.ts
@@ -23,6 +23,8 @@ export const preloadComponents = async (components: string | string[]) => {
  * @since 3.0.0
  */
 export const prefetchComponents = (components: string | string[]) => {
+  if (import.meta.server) { return }
+
   // TODO
   return preloadComponents(components)
 }


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 📚 Description

**Before**

```ts
export const prefetchComponents = (components: string | string[]) => {
  return preloadComponents(components)
}
```

<img width="638" alt="Before" src="https://github.com/nuxt/nuxt/assets/39984251/090a9268-af3b-4d7f-97f6-0bf2bfff76f0">

`prefetchComponents` and `preloadComponents` are both not tree shaken on the server side.


**After**

```ts
export const prefetchComponents = (components: string | string[]) => {
  if (import.meta.server) { return }
  return preloadComponents(components)
}
```


<img width="638" alt="After" src="https://github.com/nuxt/nuxt/assets/39984251/e6919b6c-a623-4d0e-99cc-003bf9be674e">

`prefetchComponents` and `preloadComponents` are both tree shaken on the server side.

