### PR TITLE
docs: `compatibilityVersion` is available in the latest release.

### DIFF
--- a/docs/1.getting-started/12.upgrade.md
+++ b/docs/1.getting-started/12.upgrade.md
@@ -47,7 +47,7 @@ Watch a video from Alexander Lichter showing how to opt in to Nuxt 4's breaking 
 
 ### Opting in to Nuxt 4
 
-First, opt in to the nightly release channel [following these steps](/docs/guide/going-further/nightly-release-channel#opting-in).
+First, upgrade Nuxt to the [latest release](https://github.com/nuxt/nuxt/releases) or opt in to the nightly release channel [following these steps](/docs/guide/going-further/nightly-release-channel#opting-in).
 
 Then you can set your `compatibilityVersion` to match Nuxt 4 behavior:
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Hi! 
The first of the opt in steps in Nuxt 4 is the change to nightly release, but the `compatibilityVersion` is available in the latest version.
Therefore, we would like to clarify that it is also available in the latest version.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
