### PR TITLE
docs: warn about ref unwrapping when auto-importing `ref`s

### DIFF
--- a/docs/2.guide/1.concepts/1.auto-imports.md
+++ b/docs/2.guide/1.concepts/1.auto-imports.md
@@ -105,6 +105,11 @@ Nuxt directly auto-imports files created in defined directories:
 
 :link-example{to="/docs/examples/features/auto-imports"}
 
+::warning
+**Auto-imported `ref` and `computed` won't be unwrapped in a component `<template>`.** :br
+This is due to how Vue works with refs that aren't top-level to the template. You can read more about it [in the Vue documentation](https://vuejs.org/guide/essentials/reactivity-fundamentals.html#caveat-when-unwrapping-in-templates).
+::
+
 ### Explicit Imports
 
 Nuxt exposes every auto-import with the `#imports` alias that can be used to make the import explicit if needed:


### PR DESCRIPTION
Ref: #25054

### 🔗 Linked issue

resolves #27868

### 📚 Description