### PR TITLE
fix(vite): omit css `?raw` from head when in dev mode

### DIFF
--- a/packages/vite/src/manifest.ts
+++ b/packages/vite/src/manifest.ts
@@ -8,7 +8,7 @@ import { normalizeViteManifest } from 'vue-bundle-renderer'
 import type { Manifest } from 'vue-bundle-renderer'
 import type { ViteBuildContext } from './vite'
 
-export async function writeManifest (ctx: ViteBuildContext, css: string[] = []) {
+export async function writeManifest (ctx: ViteBuildContext) {
   // Write client manifest for use in vue-bundle-renderer
   const clientDist = resolve(ctx.nuxt.options.buildDir, 'dist/client')
   const serverDist = resolve(ctx.nuxt.options.buildDir, 'dist/server')
@@ -17,7 +17,7 @@ export async function writeManifest (ctx: ViteBuildContext, css: string[] = []) 
     '@vite/client': {
       isEntry: true,
       file: '@vite/client',
-      css,
+      css: [],
       module: true,
       resourceType: 'script',
     },


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/27753

### 📚 Description

We use a vite-node hook to generate a CSS manifest on demand in dev mode - to reduce flickering.

This is a quick fix to ensure we aren't rendering links to `?raw` css files in the head, as vite won't be able to parse them when fetching from the client.