### PR TITLE
fix: ensure proper handling of CSS layers with HMR in dev-ssr plugin

### DIFF
--- a/packages/vite/src/plugins/dev-ssr-css.ts
+++ b/packages/vite/src/plugins/dev-ssr-css.ts
@@ -25,7 +25,7 @@ export function devStyleSSRPlugin (options: DevStyleSSRPluginOptions): Plugin {
       // When dev <style> is injected, remove the <link> styles from manifest
       const selectors = [
         joinURL(options.buildAssetsURL, moduleId),
-        joinURL(options.buildAssetsURL, '@fs', moduleId)
+        joinURL(options.buildAssetsURL, '@fs', moduleId),
       ]
 
       // Added custom attribute check

--- a/packages/vite/src/plugins/dev-ssr-css.ts
+++ b/packages/vite/src/plugins/dev-ssr-css.ts
@@ -22,9 +22,22 @@ export function devStyleSSRPlugin (options: DevStyleSSRPluginOptions): Plugin {
         moduleId = moduleId.slice(options.srcDir.length)
       }
 
-      // When dev `<style>` is injected, remove the `<link>` styles from manifest
-      const selectors = [joinURL(options.buildAssetsURL, moduleId), joinURL(options.buildAssetsURL, '@fs', moduleId)]
-      return code + selectors.map(selector => `\ndocument.querySelectorAll(\`link[href="${selector}"]\`).forEach(i=>i.remove())`).join('')
+      // When dev <style> is injected, remove the <link> styles from manifest
+      const selectors = [
+        joinURL(options.buildAssetsURL, moduleId),
+        joinURL(options.buildAssetsURL, '@fs', moduleId)
+      ]
+
+      // Added custom attribute check
+      const updatedCode = selectors.map(selector => `
+        document.querySelectorAll('link[href="${selector}"]').forEach(i => {
+          if (i.getAttribute('data-vite-dev-style')) {
+            i.remove();
+          }
+        })
+      `).join('')
+
+      return code + updatedCode
     },
   }
 }


### PR DESCRIPTION
- Added custom attribute check (`data-vite-dev-style`) to `<link> `elements
- Modified` dev-ssr-css` plugin to only remove `<link>` elements with the custom attribute
- Ensures compatibility with PrimeVue's layer styles and Nuxt's HMR system


### 🔗[ Linked issue](https://github.com/nuxt/nuxt/issues/25995)

This Pull Request Resolves - Issue #25995 


### 📚 Description

This PR introduces a custom attribute check (data-vite-dev-style) for <link> elements to ensure proper handling of CSS layers in the dev-ssr-css plugin. It modifies the plugin to only remove <link> elements with the custom attribute during the HMR process, maintaining compatibility with PrimeVue's layer styles and Nuxt's HMR system.
