### PR TITLE
fix(nuxt): seed crawler when prerendering pages

### DIFF
--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -503,11 +503,7 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
       for (const route of ['/200.html', '/404.html']) {
         routes.add(route)
       }
-      if (nuxt.options.ssr) {
-        if (nitro.options.prerender.crawlLinks) {
-          routes.add('/')
-        }
-      } else {
+      if (!nuxt.options.ssr) {
         routes.add('/index.html')
       }
     })

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -307,7 +307,7 @@ export default defineNuxtModule({
 
       // Only hint the first route when `ssr: true` and no routes are provided
       if (nuxt.options.ssr) {
-        nitro.hooks.hook('prerender:routes', routes => {
+        nitro.hooks.hook('prerender:routes', (routes) => {
           if ([...routes].every(r => r.endsWith('.html'))) {
             const [firstPage] = [...prerenderRoutes].sort()
             if (firstPage) {

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -3,6 +3,7 @@ import { mkdir, readFile } from 'node:fs/promises'
 import { addBuildPlugin, addComponent, addPlugin, addTemplate, addTypeTemplate, addVitePlugin, addWebpackPlugin, defineNuxtModule, findPath, logger, resolvePath, updateTemplates, useNitro } from '@nuxt/kit'
 import { dirname, join, relative, resolve } from 'pathe'
 import { genImport, genObjectFromRawEntries, genString } from 'knitwork'
+import { joinURL } from 'ufo'
 import type { Nuxt, NuxtApp, NuxtPage } from 'nuxt/schema'
 import { createRoutesContext } from 'unplugin-vue-router'
 import { resolveOptions } from 'unplugin-vue-router/options'
@@ -17,6 +18,8 @@ import { extractRouteRules, getMappedPages } from './route-rules'
 import type { PageMetaPluginOptions } from './plugins/page-meta'
 import { PageMetaPlugin } from './plugins/page-meta'
 import { RouteInjectionPlugin } from './plugins/route-injection'
+
+const OPTIONAL_PARAM_RE = /^\/?:.*(?:\?|\(\.\*\)\*)$/
 
 export default defineNuxtModule({
   meta: {
@@ -267,6 +270,61 @@ export default defineNuxtModule({
           mode: 'server',
         })
       }
+    })
+
+    // Record all pages for use in prerendering
+    const prerenderRoutes = new Set<string>()
+
+    function processPages (pages: NuxtPage[], currentPath = '/') {
+      for (const page of pages) {
+        // Add root of optional dynamic paths and catchalls
+        if (OPTIONAL_PARAM_RE.test(page.path) && !page.children?.length) {
+          prerenderRoutes.add(currentPath)
+        }
+
+        // Skip dynamic paths
+        if (page.path.includes(':')) { continue }
+
+        const route = joinURL(currentPath, page.path)
+        prerenderRoutes.add(route)
+
+        if (page.children) {
+          processPages(page.children, route)
+        }
+      }
+    }
+
+    nuxt.hook('pages:extend', (pages) => {
+      if (nuxt.options.dev) { return }
+
+      prerenderRoutes.clear()
+      processPages(pages)
+    })
+
+    // For static sites with ssr: false with crawl, prerender all routes
+    nuxt.hook('nitro:init', (nitro) => {
+      if (nuxt.options.dev || !nitro.options.static || nuxt.options.router.options.hashMode || !nitro.options.prerender.crawlLinks) { return }
+
+      // Only hint the first route when `ssr: true` and no routes are provided
+      if (nuxt.options.ssr) {
+        nitro.hooks.hook('prerender:routes', routes => {
+          if ([...routes].every(r => r.endsWith('.html'))) {
+            const [firstPage] = [...prerenderRoutes].sort()
+            if (firstPage) {
+              routes.add(firstPage)
+            }
+          }
+        })
+        return
+      }
+
+      // Prerender all non-dynamic page routes when generating `ssr: false` app
+      nuxt.hook('nitro:build:before', (nitro) => {
+        for (const route of nitro.options.prerender.routes || []) {
+          prerenderRoutes.add(route)
+        }
+        nitro.options.prerender.routes = Array.from(prerenderRoutes)
+      })
     })
 
     nuxt.hook('imports:extend', (imports) => {


### PR DESCRIPTION
### 🔗 Linked issue

includes https://github.com/nuxt/nuxt/pull/27851
resolves https://github.com/nuxt/nuxt/issues/27828
resolves https://github.com/nuxt/nuxt/issues/27694

### 📚 Description

This tweaks how pages are crawled when running `nuxi generate`.

* when `ssr: false` we add all pages to be prerendered, as before https://github.com/nuxt/nuxt/pull/26694
* when `ssr: true` we ensure there is at least one page seeded (the shortest route), deferring to the runtime code to add the rest of the paths, with the runtime `prerenderRoutes` hint from https://github.com/nuxt/nuxt/pull/26694. If this is incorrect for whatever reason, it's possible to override by providing a 'base' route in `nitro.prerender.routes`.

These tweaks are only applied when running a static build with `nitro.prerender.crawlLinks` enabled (which it is by default with `nuxi generate`). In other words, it should not affect `nuxi build`