### PR TITLE
perf(vite): don't write stub manifest for legacy bundler

### DIFF
--- a/packages/vite/src/manifest.ts
+++ b/packages/vite/src/manifest.ts
@@ -5,7 +5,6 @@ import { relative, resolve } from 'pathe'
 import { withTrailingSlash, withoutLeadingSlash } from 'ufo'
 import escapeRE from 'escape-string-regexp'
 import { normalizeViteManifest } from 'vue-bundle-renderer'
-import type { Manifest } from 'vue-bundle-renderer'
 import type { ViteBuildContext } from './vite'
 
 export async function writeManifest (ctx: ViteBuildContext) {
@@ -13,26 +12,8 @@ export async function writeManifest (ctx: ViteBuildContext) {
   const clientDist = resolve(ctx.nuxt.options.buildDir, 'dist/client')
   const serverDist = resolve(ctx.nuxt.options.buildDir, 'dist/server')
 
-  const devClientManifest: Manifest = {
-    '@vite/client': {
-      isEntry: true,
-      file: '@vite/client',
-      css: [],
-      module: true,
-      resourceType: 'script',
-    },
-    [ctx.entry]: {
-      isEntry: true,
-      file: ctx.entry,
-      module: true,
-      resourceType: 'script',
-    },
-  }
-
   const manifestFile = resolve(clientDist, 'manifest.json')
-  const clientManifest = ctx.nuxt.options.dev
-    ? devClientManifest
-    : JSON.parse(readFileSync(manifestFile, 'utf-8'))
+  const clientManifest = JSON.parse(readFileSync(manifestFile, 'utf-8'))
 
   const buildAssetsDir = withTrailingSlash(withoutLeadingSlash(ctx.nuxt.options.app.buildAssetsDir))
   const BASE_RE = new RegExp(`^${escapeRE(buildAssetsDir)}`)

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -143,9 +143,6 @@ export async function buildServer (ctx: ViteBuildContext) {
     return
   }
 
-  // Write dev client manifest
-  await writeManifest(ctx)
-
   if (!ctx.nuxt.options.ssr) {
     await onBuild()
     return

--- a/packages/vite/src/vite-node.ts
+++ b/packages/vite/src/vite-node.ts
@@ -1,8 +1,8 @@
-import { writeFile } from 'node:fs/promises'
+import { mkdir, writeFile } from 'node:fs/promises'
 import { pathToFileURL } from 'node:url'
 import { createApp, createError, defineEventHandler, defineLazyEventHandler, eventHandler, toNodeListener } from 'h3'
 import { ViteNodeServer } from 'vite-node/server'
-import { isAbsolute, normalize, resolve } from 'pathe'
+import { isAbsolute, join, normalize, resolve } from 'pathe'
 import { addDevServerHandler } from '@nuxt/kit'
 import { isFileServingAllowed } from 'vite'
 import type { ModuleNode, Plugin as VitePlugin } from 'vite'
@@ -191,6 +191,8 @@ export async function initViteNodeServer (ctx: ViteBuildContext) {
 
   const serverResolvedPath = resolve(distDir, 'runtime/vite-node.mjs')
   const manifestResolvedPath = resolve(distDir, 'runtime/client.manifest.mjs')
+
+  await mkdir(join(ctx.nuxt.options.buildDir, 'dist/server'), { recursive: true })
 
   await writeFile(
     resolve(ctx.nuxt.options.buildDir, 'dist/server/server.mjs'),


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Now that we no longer use the dev-bundler legacy vite option, we do not need to write a stub vite manifest - we use a runtime vite-node endpoint for that.