### PR TITLE
perf(vite): start warmups after nitro build

### DIFF
--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -217,6 +217,7 @@ export async function buildClient (ctx: ViteBuildContext) {
     // Dev
     const viteServer = await vite.createServer(clientConfig)
     ctx.clientServer = viteServer
+    ctx.nuxt.hook('close', async () => viteServer.close())
     await ctx.nuxt.callHook('vite:serverCreated', viteServer, { isClient: true, isServer: false })
     const transformHandler = viteServer.middlewares.stack.findIndex(m => m.handle instanceof Function && m.handle.name === 'viteTransformMiddleware')
     viteServer.middlewares.stack.splice(transformHandler, 0, {
@@ -257,10 +258,6 @@ export async function buildClient (ctx: ViteBuildContext) {
       })
     })
     await ctx.nuxt.callHook('server:devHandler', viteMiddleware)
-
-    ctx.nuxt.hook('close', async () => {
-      await viteServer.close()
-    })
   } else {
     // Build
     logger.info('Building client...')

--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -139,6 +139,9 @@ export async function buildClient (ctx: ViteBuildContext) {
     ],
     appType: 'custom',
     server: {
+      warmup: {
+        clientFiles: [ctx.entry],
+      },
       middlewareMode: true,
     },
   } satisfies vite.InlineConfig, ctx.nuxt.options.vite.$client || {}))

--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -220,7 +220,7 @@ export async function buildClient (ctx: ViteBuildContext) {
     // Dev
     const viteServer = await vite.createServer(clientConfig)
     ctx.clientServer = viteServer
-    ctx.nuxt.hook('close', async () => viteServer.close())
+    ctx.nuxt.hook('close', () => viteServer.close())
     await ctx.nuxt.callHook('vite:serverCreated', viteServer, { isClient: true, isServer: false })
     const transformHandler = viteServer.middlewares.stack.findIndex(m => m.handle instanceof Function && m.handle.name === 'viteTransformMiddleware')
     viteServer.middlewares.stack.splice(transformHandler, 0, {

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -97,6 +97,9 @@ export async function buildServer (ctx: ViteBuildContext) {
       },
     },
     server: {
+      warmup: {
+        ssrFiles: [ctx.entry],
+      },
       // https://github.com/vitest-dev/vitest/issues/229#issuecomment-1002685027
       preTransformRequests: false,
       hmr: false,

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -155,10 +155,10 @@ export async function buildServer (ctx: ViteBuildContext) {
   const viteServer = await vite.createServer(serverConfig)
   ctx.ssrServer = viteServer
 
-  await ctx.nuxt.callHook('vite:serverCreated', viteServer, { isClient: false, isServer: true })
-
   // Close server on exit
   ctx.nuxt.hook('close', () => viteServer.close())
+
+  await ctx.nuxt.callHook('vite:serverCreated', viteServer, { isClient: false, isServer: true })
 
   // Initialize plugins
   await viteServer.pluginContainer.buildStart({})

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'node:fs'
 import * as vite from 'vite'
 import { dirname, join, normalize, resolve } from 'pathe'
 import type { Nuxt, NuxtBuilder, ViteConfig } from '@nuxt/schema'
-import { addVitePlugin, isIgnored, logger, resolvePath } from '@nuxt/kit'
+import { addVitePlugin, isIgnored, logger, resolvePath, useNitro } from '@nuxt/kit'
 import replace from '@rollup/plugin-replace'
 import type { RollupReplaceOptions } from '@rollup/plugin-replace'
 import { sanitizeFilePath } from 'mlly'
@@ -216,11 +216,15 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
       }
     })
 
+
     if (nuxt.options.vite.warmupEntry !== false) {
-      const start = Date.now()
-      warmupViteServer(server, [ctx.entry], env.isServer)
-        .then(() => logger.info(`Vite ${env.isClient ? 'client' : 'server'} warmed up in ${Date.now() - start}ms`))
-        .catch(logger.error)
+      // Don't delay nitro build for warmup
+      useNitro().hooks.hook('compiled', () => {
+        const start = Date.now()
+        warmupViteServer(server, [ctx.entry], env.isServer)
+          .then(() => logger.info(`Vite ${env.isClient ? 'client' : 'server'} warmed up in ${Date.now() - start}ms`))
+          .catch(logger.error)
+      })
     }
   })
 

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -219,7 +219,7 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
 
     if (nuxt.options.vite.warmupEntry !== false) {
       // Don't delay nitro build for warmup
-      useNitro().hooks.hook('compiled', () => {
+      useNitro().hooks.hookOnce('compiled', () => {
         const start = Date.now()
         warmupViteServer(server, [ctx.entry], env.isServer)
           .then(() => logger.info(`Vite ${env.isClient ? 'client' : 'server'} warmed up in ${Date.now() - start}ms`))

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -216,7 +216,6 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
       }
     })
 
-
     if (nuxt.options.vite.warmupEntry !== false) {
       // Don't delay nitro build for warmup
       useNitro().hooks.hookOnce('compiled', () => {
@@ -234,7 +233,7 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
 
 const globalThisReplacements = Object.fromEntries([';', '(', '{', '}', ' ', '\t', '\n'].map(d => [`${d}global.`, `${d}globalThis.`]))
 
-async function withLogs(fn: () => Promise<void>, message: string, enabled = true) {
+async function withLogs (fn: () => Promise<void>, message: string, enabled = true) {
   if (!enabled) { return fn() }
 
   const start = performance.now()

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -228,8 +228,17 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
     }
   })
 
-  await buildClient(ctx)
-  await buildServer(ctx)
+  withLogs(() => buildClient(ctx), 'Vite client built', ctx.nuxt.options.dev)
+  withLogs(() => buildServer(ctx), 'Vite server built', ctx.nuxt.options.dev)
 }
 
 const globalThisReplacements = Object.fromEntries([';', '(', '{', '}', ' ', '\t', '\n'].map(d => [`${d}global.`, `${d}globalThis.`]))
+
+async function withLogs(fn: () => Promise<void>, message: string, enabled = true) {
+  if (!enabled) { return fn() }
+
+  const start = performance.now()
+  await fn()
+  const duration = performance.now() - start
+  logger.success(`${message} in ${Math.round(duration)}ms`)
+}

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -228,8 +228,8 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
     }
   })
 
-  withLogs(() => buildClient(ctx), 'Vite client built', ctx.nuxt.options.dev)
-  withLogs(() => buildServer(ctx), 'Vite server built', ctx.nuxt.options.dev)
+  await withLogs(() => buildClient(ctx), 'Vite client built', ctx.nuxt.options.dev)
+  await withLogs(() => buildServer(ctx), 'Vite server built', ctx.nuxt.options.dev)
 }
 
 const globalThisReplacements = Object.fromEntries([';', '(', '{', '}', ' ', '\t', '\n'].map(d => [`${d}global.`, `${d}globalThis.`]))


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/26211
https://github.com/nuxt/nuxt/issues/27106

### 📚 Description

Investigating reports of slow startup time for Nuxt, I think there are a couple of ways we can improve things:

1. use Vite's own warmup mechanism.
2. ensure we do not block the nitro _build_ with the warmup's heavy fs read operations (it's not a technical block as they run in parallel, but I think in practice it delays it)

Before | After
-- | --
![CleanShot 2024-07-02 at 13 51 20@2x](https://github.com/nuxt/nuxt/assets/28706372/9d462132-3b58-4592-9474-7e48bc36b2b1) | ![CleanShot 2024-07-02 at 13 54 32@2x](https://github.com/nuxt/nuxt/assets/28706372/e27681df-5908-4e91-9ea9-08a48215c80c)

We definitely warm up fewer files this way (for example, in the test fixture I'm running, we don't warm up plugin files) and this may be a problem.

I'm also - related to https://github.com/nuxt/nuxt/issues/26211 - trying to track down an issue on Windows machines where vite warmup seems to be non-effective in the server build - even passing entry file to `server.warmup` doesn't yield transform results for key files. (Maybe a Vite bug - cc: @antfu?)