### PR TITLE
fix(nuxt): improve dx around compatibility date prompt

### DIFF
--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -149,7 +149,7 @@ async function initNuxt (nuxt: Nuxt) {
       console.log(`Using \`${fallbackCompatibilityDate}\` as fallback compatibility date.`)
     }
 
-    nuxt.hooks.hookOnce('nitro:init', nitro => {
+    nuxt.hooks.hookOnce('nitro:init', (nitro) => {
       if (warnedAboutCompatDate) { return }
 
       nitro.hooks.hookOnce('compiled', () => {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this aims to improve dx around compatibility date prompt by not blocking nitro build/dev server (otherwise user might just think Nuxt is being very slow to start)