### PR TITLE
perf(vite): avoid an extra resolve call for every `resolveId` in layers

### DIFF
--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -144,7 +144,7 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
           async resolveId (source, _importer) {
             if (!_importer || !dirs.length) { return }
             const importer = normalize(_importer)
-            const layerIndex = dirs.findIndex((dir) => importer.startsWith(dir))
+            const layerIndex = dirs.findIndex(dir => importer.startsWith(dir))
             // Trigger vite to optimize dependencies imported within a layer, just as if they were imported in final project
             if (layerIndex !== -1) {
               dirs.splice(layerIndex, 1)

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -133,17 +133,24 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
       }
     }
     if (layerDirs.length > 0) {
-      ctx.config.plugins!.push({
-        name: 'nuxt:optimize-layer-deps',
-        enforce: 'pre',
-        async resolveId (source, _importer) {
-          if (!_importer) { return }
-          const importer = normalize(_importer)
-          if (layerDirs.some(dir => importer.startsWith(dir))) {
+      // Reverse so longest/most specific directories are searched first
+      layerDirs.sort().reverse()
+      ctx.nuxt.hook('vite:extendConfig', (config) => {
+        const dirs = [...layerDirs]
+        config.plugins!.push({
+          name: 'nuxt:optimize-layer-deps',
+          enforce: 'pre',
+          async resolveId (source, _importer) {
+            if (!_importer || !dirs.length) { return }
+            const importer = normalize(_importer)
+            const layerIndex = dirs.findIndex((dir) => importer.startsWith(dir))
             // Trigger vite to optimize dependencies imported within a layer, just as if they were imported in final project
-            await this.resolve(source, join(nuxt.options.srcDir, 'index.html'), { skipSelf: true }).catch(() => null)
-          }
-        },
+            if (layerIndex !== -1) {
+              dirs.splice(layerIndex, 1)
+              await this.resolve(source, join(nuxt.options.srcDir, 'index.html'), { skipSelf: true }).catch(() => null)
+            }
+          },
+        })
       })
     }
   }

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -123,6 +123,7 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
     ctx.config.build!.watch = undefined
   }
 
+  // TODO: this may no longer be needed with most recent vite version
   if (nuxt.options.dev) {
     // Identify which layers will need to have an extra resolve step.
     const layerDirs: string[] = []


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Looking into https://github.com/nuxt/nuxt/pull/25752#issuecomment-2203152143, found that the extra resolve call was adding quite a bit of overhead.

I couldn't reproduce the original issue with the current version of Vite, so this plugin may not be necessary any more. However, by reducing it to a single resolve call per layer per build, I think we have a reasonable compromise.

But we might remove entirely in future under a flag, or even in this PR if it is not needed.