### PR TITLE
fix(nuxt): omit rendering payload prefetch when `noScripts`

### DIFF
--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -386,7 +386,7 @@ export default defineRenderHandler(async (event): Promise<Partial<RenderResponse
   // Setup head
   const { styles, scripts } = getRequestDependencies(ssrContext, renderer.rendererContext)
   // 1.Extracted payload preloading
-  if (_PAYLOAD_EXTRACTION && !isRenderingIsland) {
+  if (_PAYLOAD_EXTRACTION && !NO_SCRIPTS && !isRenderingIsland) {
     head.push({
       link: [
         process.env.NUXT_JSON_PAYLOADS


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/27937

### 📚 Description

When rendering a page without scripts, we can omit adding a prefetch link for the payload as it will never be fetched (by Nuxt, anyway).