### PR TITLE
docs: remove deprecated `pending` variable from data fetching docs

### DIFF
--- a/docs/1.getting-started/6.data-fetching.md
+++ b/docs/1.getting-started/6.data-fetching.md
@@ -370,7 +370,7 @@ Every time a dependency changes, the data will be fetched using the newly constr
 <script setup lang="ts">
 const id = ref(null)
 
-const { data, status, status } = useLazyFetch(() => `/api/users/${id.value}`, {
+const { data, status } = useLazyFetch(() => `/api/users/${id.value}`, {
   immediate: false
 })
 

--- a/docs/1.getting-started/6.data-fetching.md
+++ b/docs/1.getting-started/6.data-fetching.md
@@ -407,7 +407,7 @@ With that, you will need both the `status` to handle the fetch lifecycle, and `e
 
 ```vue
 <script setup lang="ts">
-const { data, error, execute, status, status } = await useLazyFetch('/api/comments', {
+const { data, error, execute, status } = await useLazyFetch('/api/comments', {
   immediate: false
 })
 </script>

--- a/docs/1.getting-started/6.data-fetching.md
+++ b/docs/1.getting-started/6.data-fetching.md
@@ -134,7 +134,7 @@ The `useAsyncData` composable is a great way to wrap and wait for multiple `$fet
 
 ```vue
 <script setup lang="ts">
-const { data: discounts, pending } = await useAsyncData('cart-discount', async () => {
+const { data: discounts, status } = await useAsyncData('cart-discount', async () => {
   const [coupons, offers] = await Promise.all([
     $fetch('/cart/coupons'),
     $fetch('/cart/offers')
@@ -156,14 +156,13 @@ Read more about `useAsyncData`.
 `useFetch` and `useAsyncData` have the same return values listed below.
 
 - `data`: the result of the asynchronous function that is passed in.
-- `pending`: a boolean indicating whether the data is still being fetched.
 - `refresh`/`execute`: a function that can be used to refresh the data returned by the `handler` function.
 - `clear`: a function that can be used to set `data` to undefined, set `error` to `null`, set `pending` to `false`, set `status` to `idle`, and mark any currently pending requests as cancelled.
 - `error`: an error object if the data fetching failed.
 - `status`: a string indicating the status of the data request (`"idle"`, `"pending"`, `"success"`, `"error"`).
 
 ::note
-`data`, `pending`, `error` and `status` are Vue refs accessible with `.value` in `<script setup>`
+`data`, `error` and `status` are Vue refs accessible with `.value` in `<script setup>`
 ::
 
 By default, Nuxt waits until a `refresh` is finished before it can be executed again.
@@ -178,18 +177,18 @@ If you have not fetched data on the server (for example, with `server: false`), 
 
 ### Lazy
 
-By default, data fetching composables will wait for the resolution of their asynchronous function before navigating to a new page by using Vue’s Suspense. This feature can be ignored on client-side navigation with the `lazy` option. In that case, you will have to manually handle loading state using the `pending` value.
+By default, data fetching composables will wait for the resolution of their asynchronous function before navigating to a new page by using Vue’s Suspense. This feature can be ignored on client-side navigation with the `lazy` option. In that case, you will have to manually handle loading state using the `status` value.
 
 ```vue twoslash [app.vue]
 <script setup lang="ts">
-const { pending, data: posts } = useFetch('/api/posts', {
+const { status, data: posts } = useFetch('/api/posts', {
   lazy: true
 })
 </script>
 
 <template>
   <!-- you will need to handle a loading state -->
-  <div v-if="pending">
+  <div v-if="status === 'pending'">
     Loading ...
   </div>
   <div v-else>
@@ -204,7 +203,7 @@ You can alternatively use [`useLazyFetch`](/docs/api/composables/use-lazy-fetch)
 
 ```vue twoslash
 <script setup lang="ts">
-const { pending, data: posts } = useLazyFetch('/api/posts')
+const { status, data: posts } = useLazyFetch('/api/posts')
 </script>
 ```
 
@@ -227,7 +226,7 @@ Combined with the `lazy` option, this can be useful for data that is not needed 
 const articles = await useFetch('/api/article')
 
 /* This call will only be performed on the client */
-const { pending, data: comments } = useFetch('/api/comments', {
+const { status, data: comments } = useFetch('/api/comments', {
   lazy: true,
   server: false
 })
@@ -355,7 +354,7 @@ Sometimes you may need to compute an URL from reactive values, and refresh the d
 <script setup lang="ts">
 const id = ref(null)
 
-const { data, pending } = useLazyFetch('/api/user', {
+const { data, status } = useLazyFetch('/api/user', {
   query: {
     user_id: id
   }
@@ -371,9 +370,11 @@ Every time a dependency changes, the data will be fetched using the newly constr
 <script setup lang="ts">
 const id = ref(null)
 
-const { data, pending, status } = useLazyFetch(() => `/api/users/${id.value}`, {
+const { data, status, status } = useLazyFetch(() => `/api/users/${id.value}`, {
   immediate: false
 })
+
+const pending = computed(()=> status.value === 'pending');
 </script>
 
 <template>
@@ -406,7 +407,7 @@ With that, you will need both the `status` to handle the fetch lifecycle, and `e
 
 ```vue
 <script setup lang="ts">
-const { data, error, execute, pending, status } = await useLazyFetch('/api/comments', {
+const { data, error, execute, status, status } = await useLazyFetch('/api/comments', {
   immediate: false
 })
 </script>
@@ -416,7 +417,7 @@ const { data, error, execute, pending, status } = await useLazyFetch('/api/comme
     <button @click="execute">Get data</button>
   </div>
 
-  <div v-else-if="pending">
+  <div v-else-if="status === 'pending'">
     Loading comments...
   </div>
 

--- a/docs/1.getting-started/6.data-fetching.md
+++ b/docs/1.getting-started/6.data-fetching.md
@@ -157,7 +157,7 @@ Read more about `useAsyncData`.
 
 - `data`: the result of the asynchronous function that is passed in.
 - `refresh`/`execute`: a function that can be used to refresh the data returned by the `handler` function.
-- `clear`: a function that can be used to set `data` to undefined, set `error` to `null`, set `pending` to `false`, set `status` to `idle`, and mark any currently pending requests as cancelled.
+- `clear`: a function that can be used to set `data` to undefined, set `error` to `null`, set `status` to `idle`, and mark any currently pending requests as cancelled.
 - `error`: an error object if the data fetching failed.
 - `status`: a string indicating the status of the data request (`"idle"`, `"pending"`, `"success"`, `"error"`).
 
@@ -374,7 +374,7 @@ const { data, status } = useLazyFetch(() => `/api/users/${id.value}`, {
   immediate: false
 })
 
-const pending = computed(()=> status.value === 'pending');
+const pending = computed(() => status.value === 'pending');
 </script>
 
 <template>

--- a/docs/2.guide/1.concepts/1.auto-imports.md
+++ b/docs/2.guide/1.concepts/1.auto-imports.md
@@ -34,7 +34,7 @@ Nuxt auto-imports functions and composables to perform [data fetching](/docs/get
 ```vue twoslash
 <script setup lang="ts">
 /* useAsyncData() and $fetch() are auto-imported */
-const { data, refresh, pending } = await useFetch('/api/hello')
+const { data, refresh, status } = await useFetch('/api/hello')
 </script>
 ```
 

--- a/docs/3.api/2.composables/use-async-data.md
+++ b/docs/3.api/2.composables/use-async-data.md
@@ -18,7 +18,7 @@ Within your pages, components, and plugins you can use useAsyncData to get acces
 
 ```vue [pages/index.vue]
 <script setup lang="ts">
-const { data, pending, error, refresh, clear } = await useAsyncData(
+const { data, status, error, refresh, clear } = await useAsyncData(
   'mountains',
   () => $fetch('https://api.nuxtjs.dev/mountains')
 )
@@ -30,7 +30,7 @@ If you're using a custom useAsyncData wrapper, do not await it in the composable
 ::
 
 ::note
-`data`, `pending`, `status` and `error` are Vue refs and they should be accessed with `.value` when used within the `<script setup>`, while `refresh`/`execute` and `clear` are plain functions.
+`data`, `status` and `error` are Vue refs and they should be accessed with `.value` when used within the `<script setup>`, while `refresh`/`execute` and `clear` are plain functions.
 ::
 
 ### Watch Params
@@ -92,11 +92,10 @@ Learn how to use `transform` and `getCachedData` to avoid superfluous calls to a
 ## Return Values
 
 - `data`: the result of the asynchronous function that is passed in.
-- `pending`: a boolean indicating whether the data is still being fetched.
 - `refresh`/`execute`: a function that can be used to refresh the data returned by the `handler` function.
 - `error`: an error object if the data fetching failed.
 - `status`: a string indicating the status of the data request (`"idle"`, `"pending"`, `"success"`, `"error"`).
-- `clear`: a function which will set `data` to `undefined`, set `error` to `null`, set `pending` to `false`, set `status` to `'idle'`, and mark any currently pending requests as cancelled.
+- `clear`: a function which will set `data` to `undefined`, set `error` to `null`, set `status` to `'idle'`, and mark any currently pending requests as cancelled.
 
 By default, Nuxt waits until a `refresh` is finished before it can be executed again.
 
@@ -132,7 +131,6 @@ type AsyncDataOptions<DataT> = {
 
 type AsyncData<DataT, ErrorT> = {
   data: Ref<DataT | null>
-  pending: Ref<boolean>
   refresh: (opts?: AsyncDataExecuteOptions) => Promise<void>
   execute: (opts?: AsyncDataExecuteOptions) => Promise<void>
   clear: () => void

--- a/docs/3.api/2.composables/use-fetch.md
+++ b/docs/3.api/2.composables/use-fetch.md
@@ -19,7 +19,7 @@ It automatically generates a key based on URL and fetch options, provides type h
 
 ```vue [pages/modules.vue]
 <script setup lang="ts">
-const { data, pending, error, refresh, clear } = await useFetch('/api/modules', {
+const { data, status, error, refresh, clear } = await useFetch('/api/modules', {
   pick: ['title']
 })
 </script>
@@ -30,14 +30,14 @@ If you're using a custom useFetch wrapper, do not await it in the composable, as
 ::
 
 ::note
-`data`, `pending`, `status` and `error` are Vue refs and they should be accessed with `.value` when used within the `<script setup>`, while `refresh`/`execute` and `clear` are plain functions..
+`data`, `status` and `error` are Vue refs and they should be accessed with `.value` when used within the `<script setup>`, while `refresh`/`execute` and `clear` are plain functions..
 ::
 
 Using the `query` option, you can add search parameters to your query. This option is extended from [unjs/ofetch](https://github.com/unjs/ofetch) and is using [unjs/ufo](https://github.com/unjs/ufo) to create the URL. Objects are automatically stringified.
 
 ```ts
 const param1 = ref('value1')
-const { data, pending, error, refresh } = await useFetch('/api/modules', {
+const { data, status, error, refresh } = await useFetch('/api/modules', {
   query: { param1, param2: 'value2' }
 })
 ```
@@ -47,7 +47,7 @@ The above example results in `https://api.nuxt.com/modules?param1=value1&param2=
 You can also use [interceptors](https://github.com/unjs/ofetch#%EF%B8%8F-interceptors):
 
 ```ts
-const { data, pending, error, refresh, clear } = await useFetch('/api/auth/login', {
+const { data, status, error, refresh, clear } = await useFetch('/api/auth/login', {
   onRequest({ request, options }) {
     // Set the request headers
     options.headers = options.headers || {}
@@ -128,11 +128,10 @@ Learn how to use `transform` and `getCachedData` to avoid superfluous calls to a
 ## Return Values
 
 - `data`: the result of the asynchronous function that is passed in.
-- `pending`: a boolean indicating whether the data is still being fetched.
 - `refresh`/`execute`: a function that can be used to refresh the data returned by the `handler` function.
 - `error`: an error object if the data fetching failed.
 - `status`: a string indicating the status of the data request (`"idle"`, `"pending"`, `"success"`, `"error"`).
-- `clear`: a function which will set `data` to `undefined`, set `error` to `null`, set `pending` to `false`, set `status` to `'idle'`, and mark any currently pending requests as cancelled.
+- `clear`: a function which will set `data` to `undefined`, set `error` to `null`, set `status` to `'idle'`, and mark any currently pending requests as cancelled.
 
 By default, Nuxt waits until a `refresh` is finished before it can be executed again.
 
@@ -170,7 +169,6 @@ type UseFetchOptions<DataT> = {
 
 type AsyncData<DataT, ErrorT> = {
   data: Ref<DataT | null>
-  pending: Ref<boolean>
   refresh: (opts?: AsyncDataExecuteOptions) => Promise<void>
   execute: (opts?: AsyncDataExecuteOptions) => Promise<void>
   clear: () => void

--- a/docs/3.api/2.composables/use-lazy-async-data.md
+++ b/docs/3.api/2.composables/use-lazy-async-data.md
@@ -23,9 +23,9 @@ By default, [`useAsyncData`](/docs/api/composables/use-async-data) blocks naviga
 ```vue [pages/index.vue]
 <script setup lang="ts">
 /* Navigation will occur before fetching is complete.
-  Handle pending and error states directly within your component's template
+  Handle 'pending' and 'error' states directly within your component's template
 */
-const { pending, data: count } = await useLazyAsyncData('count', () => $fetch('/api/count'))
+const { status, data: count } = await useLazyAsyncData('count', () => $fetch('/api/count'))
 
 watch(count, (newCount) => {
   // Because count might start out null, you won't have access
@@ -35,7 +35,7 @@ watch(count, (newCount) => {
 
 <template>
   <div>
-    {{ pending ? 'Loading' : count }}
+    {{ status === 'pending' ? 'Loading' : count }}
   </div>
 </template>
 ```

--- a/docs/3.api/2.composables/use-lazy-fetch.md
+++ b/docs/3.api/2.composables/use-lazy-fetch.md
@@ -23,9 +23,9 @@ By default, [`useFetch`](/docs/api/composables/use-fetch) blocks navigation unti
 ```vue [pages/index.vue]
 <script setup lang="ts">
 /* Navigation will occur before fetching is complete.
-  Handle pending and error states directly within your component's template
-*/
-const { pending, data: posts } = await useLazyFetch('/api/posts')
+ * Handle 'pending' and 'error' states directly within your component's template
+ */
+const { status, data: posts } = await useLazyFetch('/api/posts')
 watch(posts, (newPosts) => {
   // Because posts might start out null, you won't have access
   // to its contents immediately, but you can watch it.
@@ -33,7 +33,7 @@ watch(posts, (newPosts) => {
 </script>
 
 <template>
-  <div v-if="pending">
+  <div v-if="status === 'pending'">
     Loading ...
   </div>
   <div v-else>

--- a/docs/3.api/3.utils/refresh-nuxt-data.md
+++ b/docs/3.api/3.utils/refresh-nuxt-data.md
@@ -58,13 +58,13 @@ This example below refreshes only data where the key matches to `count`.
 
 ```vue [pages/some-page.vue]
 <script setup lang="ts">
-const { pending, data: count } = await useLazyAsyncData('count', () => $fetch('/api/count'))
+const { status, data: count } = await useLazyAsyncData('count', () => $fetch('/api/count'))
 const refresh = () => refreshNuxtData('count')
 </script>
 
 <template>
   <div>
-    {{ pending ? 'Loading' : count }}
+    {{ status === 'pending' ? 'Loading' : count }}
   </div>
   <button @click="refresh">Refresh</button>
 </template>


### PR DESCRIPTION
### 📚 Description

My IDE tells me the pending variable is deprecated in favor of status. This makes the docs lineup with this change.


<img width="613" alt="Screenshot 2024-07-03 at 4 33 00 PM" src="https://github.com/nuxt/nuxt/assets/7635209/415cff43-b0e8-4dac-ad22-3ca052df28f4">
