### PR TITLE
fix(schema): don't constrain postcss plugin options

### DIFF
--- a/packages/schema/src/config/postcss.ts
+++ b/packages/schema/src/config/postcss.ts
@@ -39,7 +39,7 @@ export default defineUntypedSchema({
      * Options for configuring PostCSS plugins.
      *
      * https://postcss.org/
-     * @type {Record<string, Record<string, unknown> | false> & { autoprefixer?: typeof import('autoprefixer').Options; cssnano?: typeof import('cssnano').Options }}
+     * @type {Record<string, unknown> & { autoprefixer?: typeof import('autoprefixer').Options; cssnano?: typeof import('cssnano').Options }}
      */
     plugins: {
       /**


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

discovered in https://github.com/nuxt/ecosystem-ci/actions/runs/9803313914/job/27076078811

seems it's possible for some postcss plugins to accept other options, like string values