### PR TITLE
docs(nuxt): update 7.state-management.md

### DIFF
--- a/docs/1.getting-started/7.state-management.md
+++ b/docs/1.getting-started/7.state-management.md
@@ -23,7 +23,7 @@ Read more about `useState` composable.
 ## Best Practices
 
 ::warning
-Never define `const state = ref()` outside of `<script setup>` or `setup()` function.
+Never define `const state = ref()` outside of `<script setup>` or `setup()` function.<br>
 For example, doing `export myState = ref({})` would result in state shared across requests on the server and can lead to memory leaks.
 ::
 

--- a/docs/1.getting-started/7.state-management.md
+++ b/docs/1.getting-started/7.state-management.md
@@ -24,8 +24,7 @@ Read more about `useState` composable.
 
 ::warning
 Never define `const state = ref()` outside of `<script setup>` or `setup()` function.
-For example, doing `export myState = ref({})` would result in state shared across requests on the server.<br>
-Such state will be shared across all users visiting your website and can lead to memory leaks!
+For example, doing `export myState = ref({})` would result in state shared across requests on the server and can lead to memory leaks.
 ::
 
 ::tip{icon="i-ph-check-circle-duotone"}

--- a/docs/1.getting-started/7.state-management.md
+++ b/docs/1.getting-started/7.state-management.md
@@ -23,7 +23,8 @@ Read more about `useState` composable.
 ## Best Practices
 
 ::warning
-Never define `const state = ref()` outside of `<script setup>` or `setup()` function.<br>
+Never define `const state = ref()` outside of `<script setup>` or `setup()` function.
+For example, doing `export myState = ref({})` would result in state shared across requests on the server.<br>
 Such state will be shared across all users visiting your website and can lead to memory leaks!
 ::
 


### PR DESCRIPTION
### 📚 Description

The website docs say not to use the practice of ref() outside of a component's setup. It's not clear what's an example of a bad practice of using it. Adding an [example shared by Daniel Roe](https://x.com/danielcroe/status/1808232524956455106) to clarify one use-case (that shouldn't be followed).

This update to the README help clarifies it.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
