### PR TITLE
fix(nuxt): consider doc `scroll-padding-top` in scrollBehavior

### DIFF
--- a/packages/nuxt/src/pages/runtime/router.options.ts
+++ b/packages/nuxt/src/pages/runtime/router.options.ts
@@ -58,7 +58,7 @@ function _getHashElementScrollMarginTop (selector: string): number {
   try {
     const elem = document.querySelector(selector)
     if (elem) {
-      return Number.parseFloat(getComputedStyle(elem).scrollMarginTop)
+      return Number.parseFloat(getComputedStyle(elem).scrollMarginTop) + Number.parseFloat(getComputedStyle(document.documentElement).scrollPaddingTop)
     }
   } catch {
     // ignore any errors parsing scrollMarginTop


### PR DESCRIPTION
…ult router scrollBehavior calculates the expected scroll position of the HashElement

### 🔗 Linked issue
#20555 

### 📚 Description
calculating the scroll-padding-top of the document when the default router scrollBehavior calculates the expected scroll position of the HashElement
