### PR TITLE
docs: mention content in upgrade guide v4 folder structure

### DIFF
--- a/docs/1.getting-started/12.upgrade.md
+++ b/docs/1.getting-started/12.upgrade.md
@@ -131,8 +131,8 @@ app/
   app.config.ts
   app.vue
   router.options.ts
-layers/
 content/
+layers/
 modules/
 node_modules/
 public/

--- a/docs/1.getting-started/12.upgrade.md
+++ b/docs/1.getting-started/12.upgrade.md
@@ -132,6 +132,7 @@ app/
   app.vue
   router.options.ts
 layers/
+content/
 modules/
 node_modules/
 public/

--- a/docs/1.getting-started/12.upgrade.md
+++ b/docs/1.getting-started/12.upgrade.md
@@ -109,7 +109,8 @@ Nuxt now defaults to a new directory structure, with backwards compatibility (so
 
 * the new Nuxt default `srcDir` is `app/` by default, and most things are resolved from there.
 * `serverDir` now defaults to `<rootDir>/server` rather than `<srcDir>/server`
-* `layers`, `modules` and `public` are resolved relative to `<rootDir>` by default
+* `layers/`, `modules/` and `public/` are resolved relative to `<rootDir>` by default
+* if using [Nuxt Content v2.13+](https://github.com/nuxt/content/pull/2649), `content/` is resolved relative to `<rootDir>`
 * a new `dir.app` is added, which is the directory we look for `router.options.ts` and `spa-loading-template.html` - this defaults to `<srcDir>/`
 
 <details>
@@ -158,7 +159,7 @@ nuxt.config.ts
 
 1. Create a new directory called `app/`.
 1. Move your `assets/`, `components/`, `composables/`, `layouts/`, `middleware/`, `pages/`, `plugins/` and `utils/` folders under it, as well as `app.vue`, `error.vue`, `app.config.ts`. If you have an `app/router-options.ts` or `app/spa-loading-template.html`, these paths remain the same.
-1. Make sure your `nuxt.config.ts`, `modules/`, `public/` and `server/` folders remain outside the `app/` folder, in the root of your project.
+1. Make sure your `nuxt.config.ts`, `content/`, `layers/`, `modules/`, `public/` and `server/` folders remain outside the `app/` folder, in the root of your project.
 
 However, migration is _not required_. If you wish to keep your current folder structure, Nuxt should auto-detect it. (If it does not, please raise an issue.) The one exception is that if you _already_ have a custom `srcDir`. In this case, you should be aware that your `modules/`, `public/` and `server/` folders will be resolved from your `rootDir` rather than from your custom `srcDir`. You can override this by configuring `dir.modules`, `dir.public` and `serverDir` if you need to.
 


### PR DESCRIPTION
### 📚 Description

Show `content/` in the upgrade guide "v4 folder structue reference" in docs.

🔗 Linked Nuxt Content PR
[#2649](https://github.com/nuxt/content/pull/2649)


<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
