### PR TITLE
docs: switch to using code groups to have yarn, pnpm and bun in module guide

### DIFF
--- a/docs/2.guide/3.going-further/3.modules.md
+++ b/docs/2.guide/3.going-further/3.modules.md
@@ -13,9 +13,24 @@ With modules, you can encapsulate, properly test, and share custom solutions as 
 
 We recommend you get started with Nuxt Modules using our [starter template](https://github.com/nuxt/starter/tree/module):
 
-```bash [Terminal]
+::code-group
+
+```bash [npm]
 npx nuxi init -t module my-module
 ```
+
+```bash [yarn]
+yarn dlx nuxi init -t module my-module
+```
+
+```bash [pnpm]
+pnpm dlx nuxi init -t module my-module
+```
+
+```bash [bun]
+bunx nuxi init -t module my-module
+```
+::
 
 This will create a `my-module` project with all the boilerplate necessary to develop and publish your module.
 


### PR DESCRIPTION
…or guide

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
Continues #27790 

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
It adds other package managers apart from npm to the module author guide docs.
<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
