### PR TITLE
fix(nuxt): use native vue-router composables

### DIFF
--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -229,6 +229,7 @@ export default defineNuxtModule({
       if (routerImports) {
         routerImports.from = 'vue-router'
       }
+    })
 
     // Regenerate templates when adding or removing pages
     const updateTemplatePaths = nuxt.options._layers.flatMap((l) => {

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -223,6 +223,13 @@ export default defineNuxtModule({
       references.push({ types: useExperimentalTypedPages ? 'vue-router/auto-routes' : 'vue-router' })
     })
 
+    // Add vue-router route guard imports
+    nuxt.hook('imports:sources', (sources) => {
+      const routerImports = sources.find(s => s.from === '#app/composables/router' && s.imports.includes('onBeforeRouteLeave'))
+      if (routerImports) {
+        routerImports.from = 'vue-router'
+      }
+
     // Regenerate templates when adding or removing pages
     const updateTemplatePaths = nuxt.options._layers.flatMap((l) => {
       const dir = (l.config.rootDir === nuxt.options.rootDir ? nuxt.options : l.config).dir


### PR DESCRIPTION
partially reverts 77d32cdcec9febb906b80b6dc7b35588421fd3df

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/28067

### 📚 Description

In removing the `#vue-router` stub we delved too greedily and too deep.