### PR TITLE
fix: `getNuxtVersion` returning `any`

### DIFF
--- a/packages/kit/src/compatibility.ts
+++ b/packages/kit/src/compatibility.ts
@@ -108,7 +108,7 @@ export function isNuxt3 (nuxt: Nuxt = useNuxt()) {
  */
 export function getNuxtVersion (nuxt: Nuxt | any = useNuxt() /* TODO: LegacyNuxt */) {
   const rawVersion = nuxt?._version || nuxt?.version || nuxt?.constructor?.version
-  if (!rawVersion) {
+  if (!rawVersion || typeof rawVersion !== 'string') {
     throw new Error('Cannot determine nuxt version! Is current instance passed?')
   }
   return rawVersion.replace(/^v/g, '')

--- a/packages/kit/src/compatibility.ts
+++ b/packages/kit/src/compatibility.ts
@@ -108,7 +108,7 @@ export function isNuxt3 (nuxt: Nuxt = useNuxt()) {
  */
 export function getNuxtVersion (nuxt: Nuxt | any = useNuxt() /* TODO: LegacyNuxt */) {
   const rawVersion = nuxt?._version || nuxt?.version || nuxt?.constructor?.version
-  if (!rawVersion || typeof rawVersion !== 'string') {
+  if (typeof rawVersion !== 'string') {
     throw new Error('Cannot determine nuxt version! Is current instance passed?')
   }
   return rawVersion.replace(/^v/g, '')

--- a/packages/kit/src/compatibility.ts
+++ b/packages/kit/src/compatibility.ts
@@ -109,7 +109,7 @@ export function isNuxt3 (nuxt: Nuxt = useNuxt()) {
 export function getNuxtVersion (nuxt: Nuxt | any = useNuxt() /* TODO: LegacyNuxt */) {
   const rawVersion = nuxt?._version || nuxt?.version || nuxt?.constructor?.version
   if (typeof rawVersion !== 'string') {
-    throw new Error('Cannot determine nuxt version! Is current instance passed?')
+    throw new TypeError('Cannot determine nuxt version! Is current instance passed?')
   }
   return rawVersion.replace(/^v/g, '')
 }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Currently the return type does not match the documentation: https://nuxt.com/docs/api/kit/compatibility#getnuxtversion
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
