### PR TITLE
fix(nuxt): always prerender at least one page when crawler activated

### DIFF
--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -315,25 +315,22 @@ export default defineNuxtModule({
       processPages(pages)
     })
 
-    nuxt.hook('nitro:init', (nitro) => {
+    nuxt.hook('nitro:build:before', (nitro) => {
       if (nuxt.options.dev || !nitro.options.static || nuxt.options.router.options.hashMode || !nitro.options.prerender.crawlLinks) { return }
 
       // Only hint the first route when `ssr: true` and no routes are provided
+      // as the rest will be injected at runtime when this is prerendered
       if (nuxt.options.ssr) {
-        nitro.hooks.hook('prerender:routes', (routes) => {
-          const [firstPage] = [...prerenderRoutes].sort()
-          routes.add(firstPage || '/')
-        })
+        const [firstPage] = [...prerenderRoutes].sort()
+        nitro.options.prerender.routes.push(firstPage || '/')
         return
       }
 
       // Prerender all non-dynamic page routes when generating `ssr: false` app
-      nuxt.hook('nitro:build:before', (nitro) => {
-        for (const route of nitro.options.prerender.routes || []) {
-          prerenderRoutes.add(route)
-        }
-        nitro.options.prerender.routes = Array.from(prerenderRoutes)
-      })
+      for (const route of nitro.options.prerender.routes || []) {
+        prerenderRoutes.add(route)
+      }
+      nitro.options.prerender.routes = Array.from(prerenderRoutes)
     })
 
     nuxt.hook('imports:extend', (imports) => {

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -316,10 +316,8 @@ export default defineNuxtModule({
       // Only hint the first route when `ssr: true` and no routes are provided
       if (nuxt.options.ssr) {
         nitro.hooks.hook('prerender:routes', (routes) => {
-          if ([...routes].every(r => r.match(/(^\/api|\.\w+)/))) {
-            const [firstPage] = [...prerenderRoutes].sort()
-            routes.add(firstPage || '/')
-          }
+          const [firstPage] = [...prerenderRoutes].sort()
+          routes.add(firstPage || '/')
         })
         return
       }

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -148,6 +148,12 @@ export default defineNuxtModule({
         priority: 10, // built-in that we do not expect the user to override
         filePath: resolve(distDir, 'pages/runtime/page-placeholder'),
       })
+      // Prerender index if pages integration is not enabled
+      nuxt.hook('nitro:init', (nitro) => {
+        if (nuxt.options.dev || !nuxt.options.ssr || !nitro.options.static || !nitro.options.prerender.crawlLinks) { return }
+
+        nitro.options.prerender.routes.push('/')
+      })
       return
     }
 
@@ -309,7 +315,6 @@ export default defineNuxtModule({
       processPages(pages)
     })
 
-    // For static sites with ssr: false with crawl, prerender all routes
     nuxt.hook('nitro:init', (nitro) => {
       if (nuxt.options.dev || !nitro.options.static || nuxt.options.router.options.hashMode || !nitro.options.prerender.crawlLinks) { return }
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/28037

### 📚 Description

This is the latest instalment in a saga of prerendering routes. We were attempting to make sure we respected runtime routes (which can be customised entirely in `app/router.options.ts`) but unfortunately the edge cases were too many. This way we will always prerender at least one page with `ssr: true` (which will then use a runtime hook to hint the rest of the routes to be prerendered) - and we will prerender all of them with `ssr: false`.

If this change is not desired it can be worked around with:

```ts
export default defineNuxtConfig({
  nitro: {
    hooks: {
      'prerender:routes' (routes) {
        routes.delete('/')
      },
    },
  },
})
```