### PR TITLE
fix(nuxt): call `app:error` in ssr

### DIFF
--- a/packages/nuxt/src/app/composables/error.ts
+++ b/packages/nuxt/src/app/composables/error.ts
@@ -24,9 +24,7 @@ export const showError = <DataT = unknown>(
     const nuxtApp = useNuxtApp()
     const error = useError()
 
-    if (import.meta.client) {
-      nuxtApp.hooks.callHook('app:error', nuxtError)
-    }
+    nuxtApp.hooks.callHook('app:error', nuxtError)
 
     error.value = error.value || nuxtError
   } catch {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This PR reverts partially https://github.com/nuxt/nuxt/pull/20585 .
Currently throwing an error in a vue component does call `app:error` but not when calling `showError` . The issue mentionned does not happen anymore (app:error being called twice)

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
