### PR TITLE
fix(schema): don't use `app/` as `srcDir` if it doesn't exist

### DIFF
--- a/packages/nuxt/test/app.test.ts
+++ b/packages/nuxt/test/app.test.ts
@@ -19,7 +19,7 @@ describe('resolveApp', () => {
       {
         "components": [],
         "configs": [],
-        "dir": "<rootDir>/app",
+        "dir": "<rootDir>",
         "errorComponent": "<repoRoot>/packages/nuxt/src/app/components/nuxt-error-page.vue",
         "extensions": [
           ".js",

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -118,13 +118,15 @@ export default defineUntypedSchema({
       }
 
       const srcDir = resolve(rootDir, 'app')
+      if (!existsSync(srcDir)) {
+        return rootDir
+      }
+
       const srcDirFiles = new Set<string>()
-      if (existsSync(srcDir)) {
-        const files = await readdir(srcDir).catch(() => [])
-        for (const file of files) {
-          if (file !== 'spa-loading-template.html' && !file.startsWith('router.options')) {
-            srcDirFiles.add(file)
-          }
+      const files = await readdir(srcDir).catch(() => [])
+      for (const file of files) {
+        if (file !== 'spa-loading-template.html' && !file.startsWith('router.options')) {
+          srcDirFiles.add(file)
         }
       }
       if (srcDirFiles.size === 0) {

--- a/packages/schema/test/folder-structure.spec.ts
+++ b/packages/schema/test/folder-structure.spec.ts
@@ -1,9 +1,13 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { applyDefaults } from 'untyped'
 
 import { normalize } from 'pathe'
 import { NuxtConfigSchema } from '../src'
 import type { NuxtOptions } from '../src'
+
+vi.mock('node:fs', () => ({
+  existsSync: (id: string) => id.endsWith('app'),
+}))
 
 describe('nuxt folder structure', () => {
   it('should resolve directories for v3 setup correctly', async () => {
@@ -17,7 +21,7 @@ describe('nuxt folder structure', () => {
         },
         "rootDir": "<cwd>",
         "serverDir": "<cwd>/server",
-        "srcDir": "<cwd>",
+        "srcDir": "<cwd>/app",
         "workspaceDir": "<cwd>",
       }
     `)
@@ -51,7 +55,7 @@ describe('nuxt folder structure', () => {
         },
         "rootDir": "<cwd>",
         "serverDir": "<cwd>/server",
-        "srcDir": "<cwd>",
+        "srcDir": "<cwd>/app",
         "workspaceDir": "<cwd>",
       }
     `)

--- a/packages/schema/test/folder-structure.spec.ts
+++ b/packages/schema/test/folder-structure.spec.ts
@@ -17,7 +17,7 @@ describe('nuxt folder structure', () => {
         },
         "rootDir": "<cwd>",
         "serverDir": "<cwd>/server",
-        "srcDir": "<cwd>/app",
+        "srcDir": "<cwd>",
         "workspaceDir": "<cwd>",
       }
     `)
@@ -51,7 +51,7 @@ describe('nuxt folder structure', () => {
         },
         "rootDir": "<cwd>",
         "serverDir": "<cwd>/server",
-        "srcDir": "<cwd>/app",
+        "srcDir": "<cwd>",
         "workspaceDir": "<cwd>",
       }
     `)


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/pull/28073

### 📚 Description

we were not handling case of no `app.vue` and no `app/` directory. In this case we should resolve to `rootDir` rather than a non-existent directory.