### PR TITLE
fix(kit): normalise `serverDir` within layers using v4 compat

### DIFF
--- a/packages/kit/src/loader/config.ts
+++ b/packages/kit/src/loader/config.ts
@@ -11,7 +11,7 @@ export interface LoadNuxtConfigOptions extends Omit<LoadConfigOptions<NuxtConfig
   overrides?: Exclude<LoadConfigOptions<NuxtConfig>['overrides'], Promise<any> | Function>
 }
 
-const layerSchemaKeys = ['future', 'srcDir', 'rootDir', 'dir']
+const layerSchemaKeys = ['future', 'srcDir', 'rootDir', 'serverDir', 'dir']
 const layerSchema = Object.create(null)
 for (const key of layerSchemaKeys) {
   if (key in NuxtConfigSchema) {


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/27780

### 📚 Description

We need to normalise schemas in layers specifically, but we weren't doing this for `serverDir` when layers had opted in to v4 compatibility version.