### PR TITLE
fix(nuxt): call app:error before throwing in renderer

### DIFF
--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -355,6 +355,7 @@ export default defineRenderHandler(async (event): Promise<Partial<RenderResponse
 
   // Handle errors
   if (ssrContext.payload?.error && !ssrError) {
+    await ssrContext.nuxt?.hooks.callHook('app:error', ssrContext.payload.error)
     throw ssrContext.payload.error
   }
 


### PR DESCRIPTION
### 🔗 Linked issue

#28162 

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This PR calls `app:error` before throwing in the renderer. 

- `showError` only call the hook client side
- `renderer.renderToString`'s catch re-throw the err, meaning it doesn't call `app:error` if it is not an error from `renderToString`

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
