### PR TITLE
fix(nuxt): change the name of the RouteProvider componet when keepalive

### DIFF
--- a/packages/nuxt/src/pages/runtime/page.ts
+++ b/packages/nuxt/src/pages/runtime/page.ts
@@ -126,7 +126,7 @@ export default defineComponent({
                   trackRootNodes: hasTransition,
                   vnodeRef: pageRef,
                 })
-                if (import.meta.client && keepaliveConfig) {
+                if (import.meta.client && keepaliveConfig && !(providerVNode.type as any).name) {
                   (providerVNode.type as any).name = (routeProps.Component.type as any).name || (routeProps.Component.type as any).__name || 'RouteProvider'
                 }
                 return providerVNode


### PR DESCRIPTION
### 🔗 Linked issue
[keepalive include Bug](https://github.com/nuxt/nuxt/issues/27777)

### 📚 Description
now, I can not dynamic control keepalive by change include config 

