### PR TITLE
fix(nuxt): prevent duplicate `set-cookie` headers

### DIFF
--- a/packages/nuxt/src/app/composables/cookie.ts
+++ b/packages/nuxt/src/app/composables/cookie.ts
@@ -126,6 +126,16 @@ export function useCookie<T = string | null | undefined> (name: string, _opts?: 
     const nuxtApp = useNuxtApp()
     const writeFinalCookieValue = () => {
       if (opts.readonly || isEqual(cookie.value, cookies[name])) { return }
+      nuxtApp._cookies ||= {}
+      if (name in nuxtApp._cookies) {
+        // do not append a second `set-cookie` header
+        if (isEqual(cookie.value, nuxtApp._cookies[name])) { return }
+        // warn in dev mode
+        if (import.meta.dev) {
+          console.warn(`[nuxt] cookie \`${name}\` was previously set to \`${opts.encode(nuxtApp._cookies[name] as any)}\` and is being overridden to \`${opts.encode(cookie.value as any)}\`. This may cause unexpected issues.`)
+        }
+      }
+      nuxtApp._cookies[name] = cookie.value
       writeServerCookie(useRequestEvent(nuxtApp)!, name, cookie.value, opts as CookieOptions<any>)
     }
     const unhook = nuxtApp.hooks.hookOnce('app:rendered', writeFinalCookieValue)

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -113,6 +113,8 @@ interface _NuxtApp {
   [key: string]: unknown
 
   /** @internal */
+  _cookies?: Record<string, unknown>
+  /** @internal */
   _id?: number
   /** @internal */
   _scope: EffectScope

--- a/test/fixtures/basic/pages/cookies.vue
+++ b/test/fixtures/basic/pages/cookies.vue
@@ -17,7 +17,6 @@ const objectCookieSecond = useCookie('browser-object-default', {
   default: () => ({ foo: 'bar' }),
 })
 function changeCookie () {
-  console.log(objectCookie.value, objectCookieSecond.value)
   if (objectCookie.value!.foo === 'baz') {
     objectCookie.value!.foo = 'bar'
   } else {

--- a/test/fixtures/basic/pages/cookies.vue
+++ b/test/fixtures/basic/pages/cookies.vue
@@ -9,6 +9,8 @@ useCookie<string | null>('set-to-null-with-default', { default: () => 'default' 
 useCookie('browser-accessed-but-not-used')
 useCookie('browser-accessed-with-default-value', { default: () => 'default' })
 useCookie('browser-set').value = 'set'
+// confirm that it only sets one `set-cookie` header
+useCookie('browser-set').value = 'set'
 useCookie('browser-set-to-null').value = null
 useCookie<string | null>('browser-set-to-null-with-default', { default: () => 'default' }).value = null
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

When `useCookie` is called more than once, it results in multiple `set-cookie` headers.

This avoids setting duplicate headers if the value is unchanged. (If it is changed, it will continue to previous behaviour and add a second header.)

In dev mode, it will warn if a different value is passed as this can indicate an issue that can trigger a hydration mismatch (e.g. https://github.com/nuxt/nuxt/issues/27660#issuecomment-2233048700).