### PR TITLE
docs: fix issue in cookie passing example 

### DIFF
--- a/docs/1.getting-started/6.data-fetching.md
+++ b/docs/1.getting-started/6.data-fetching.md
@@ -466,13 +466,13 @@ Be very careful before proxying headers to an external API and just include head
  If you want to pass on/proxy cookies in the other direction, from an internal request back to the client, you will need to handle this yourself.
 
 ```ts [composables/fetch.ts]
-import { appendResponseHeader, H3Event } from 'h3'
+import { appendResponseHeader, H3Event, splitCookiesString } from 'h3'
 
 export const fetchWithCookie = async (event: H3Event, url: string) => {
   /* Get the response from the server endpoint */
   const res = await $fetch.raw(url)
   /* Get the cookies from the response */
-  const cookies = (res.headers.get('set-cookie') || '').split(',')
+  const cookies = splitCookiesString(res.headers.get('set-cookie') || '')
   /* Attach each cookie to our incoming Request */
   for (const cookie of cookies) {
     appendResponseHeader(event, 'set-cookie', cookie)


### PR DESCRIPTION
Use H3's `splitCookiesString` function to split the set-cookie header without choking on commas that are within a single set-cookie field-value, such as in the Expires portion. 