### PR TITLE
docs: fix note in layers usage chapter

### DIFF
--- a/docs/1.getting-started/9.layers.md
+++ b/docs/1.getting-started/9.layers.md
@@ -20,7 +20,9 @@ One of the core features of Nuxt is the layers and extending support. You can ex
 
 By default, any layers within your project in the `~/layers` directory will be automatically registered as layers in your project
 
-::note Layer auto-registration was introduced in Nuxt v3.12.0 ::
+::note
+Layer auto-registration was introduced in Nuxt v3.12.0
+::
 
 In addition, you can extend from a layer by adding the [extends](/docs/api/nuxt-config#extends) property to your [`nuxt.config`](/docs/guide/directory-structure/nuxt-config) file.
 


### PR DESCRIPTION
### 🔗 Linked issue

n/a

### 📚 Description

https://github.com/nuxt/nuxt/pull/28128 introduced information about automatic layers registration. The note wrapped with 
the `::note ::` isn't rendered properly due to missing line breaks.

See also [Nuxt Content MDC Block Components](https://content.nuxt.com/usage/markdown#block-components).