### PR TITLE
fix(nuxt): ignore definePageMeta warning for client only pages in dev

### DIFF
--- a/packages/nuxt/src/components/runtime/client-component.ts
+++ b/packages/nuxt/src/components/runtime/client-component.ts
@@ -7,7 +7,7 @@ export const createClientPage = (loader: AsyncComponentLoader) => {
   const page = defineAsyncComponent(import.meta.dev
     ? () => loader().then((m) => {
         // mark component as client-only for `definePageMeta`
-        (m || m.default).__clientOnlyPage = true
+        (m.default || m).__clientOnlyPage = true
         return m.default || m
       })
     : loader)

--- a/packages/nuxt/src/components/runtime/client-component.ts
+++ b/packages/nuxt/src/components/runtime/client-component.ts
@@ -4,7 +4,13 @@ import ClientOnly from '#app/components/client-only'
 
 /* @__NO_SIDE_EFFECTS__ */
 export const createClientPage = (loader: AsyncComponentLoader) => {
-  const page = defineAsyncComponent(loader)
+  const page = defineAsyncComponent(import.meta.dev
+    ? () => loader().then((m) => {
+        // mark component as client-only for `definePageMeta`
+        (m || m.default).__clientOnlyPage = true
+        return m.default || m
+      })
+    : loader)
 
   return defineComponent({
     inheritAttrs: false,

--- a/packages/nuxt/src/pages/runtime/composables.ts
+++ b/packages/nuxt/src/pages/runtime/composables.ts
@@ -60,9 +60,8 @@ export const definePageMeta = (meta: PageMeta): void => {
     try {
       const isRouteComponent = component && useRoute().matched.some(p => Object.values(p.components || {}).includes(component))
       const isRenderingServerPage = import.meta.server && useNuxtApp().ssrContext?.islandContext
-      const isRenderingClientOnlyPage = component?.__name?.endsWith('.client')
-      if (isRouteComponent || isRenderingServerPage || isRenderingClientOnlyPage) {
-        // don't warn if it's being used in a route component (or server page or client only page)
+      if (isRouteComponent || isRenderingServerPage || ((component as any)?.__clientOnlyPage)) {
+        // don't warn if it's being used in a route component (or server page)
         return
       }
     } catch {

--- a/packages/nuxt/src/pages/runtime/composables.ts
+++ b/packages/nuxt/src/pages/runtime/composables.ts
@@ -60,7 +60,7 @@ export const definePageMeta = (meta: PageMeta): void => {
     try {
       const isRouteComponent = component && useRoute().matched.some(p => Object.values(p.components || {}).includes(component))
       const isRenderingServerPage = import.meta.server && useNuxtApp().ssrContext?.islandContext
-      if (isRouteComponent || isRenderingServerPage) {
+      if (isRouteComponent || isRenderingServerPage || component?.__name?.endsWith('.client')) {
         // don't warn if it's being used in a route component (or server page)
         return
       }

--- a/packages/nuxt/src/pages/runtime/composables.ts
+++ b/packages/nuxt/src/pages/runtime/composables.ts
@@ -60,7 +60,8 @@ export const definePageMeta = (meta: PageMeta): void => {
     try {
       const isRouteComponent = component && useRoute().matched.some(p => Object.values(p.components || {}).includes(component))
       const isRenderingServerPage = import.meta.server && useNuxtApp().ssrContext?.islandContext
-      if (isRouteComponent || isRenderingServerPage || component?.__name?.endsWith('.client')) {
+      const isRenderingClientOnlyPage = component?.__name?.endsWith('.client')
+      if (isRouteComponent || isRenderingServerPage || isRenderingClientOnlyPage) {
         // don't warn if it's being used in a route component (or server page)
         return
       }

--- a/packages/nuxt/src/pages/runtime/composables.ts
+++ b/packages/nuxt/src/pages/runtime/composables.ts
@@ -62,7 +62,7 @@ export const definePageMeta = (meta: PageMeta): void => {
       const isRenderingServerPage = import.meta.server && useNuxtApp().ssrContext?.islandContext
       const isRenderingClientOnlyPage = component?.__name?.endsWith('.client')
       if (isRouteComponent || isRenderingServerPage || isRenderingClientOnlyPage) {
-        // don't warn if it's being used in a route component (or server page)
+        // don't warn if it's being used in a route component (or server page or client only page)
         return
       }
     } catch {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Hi :wave: this PR fix an issue with https://github.com/nuxt/nuxt/pull/27839
Since the wrapper is being rendered as the route component for client-pages, we need to mark clientonly page components so `definePageMeta`  can ignore it in dev

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
