### PR TITLE
docs: wrap use-route-announcer.md sample code in vue section

### DIFF
--- a/docs/3.api/2.composables/use-route-announcer.md
+++ b/docs/3.api/2.composables/use-route-announcer.md
@@ -51,7 +51,7 @@ Sets the message with `politeness = "assertive"`
 
 ## Example
 
-```ts
+```vue [pages/index.vue]
 <script setup lang="ts">
   const { message, politeness, set, polite, assertive } = useRouteAnnouncer({
     politeness: 'assertive'


### PR DESCRIPTION
### 🔗 Linked issue

n/a

### 📚 Description

Wrap the sample code on the `use-route-announcer.md` page with the vue attribute to enable syntactic color in the codeblock.