### PR TITLE
fix(schema): fix srcDir being overriden by default value

### DIFF
--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -158,7 +158,7 @@ export default defineUntypedSchema({
     $resolve: async (val: string | undefined, get): Promise<string> => {
       const isV4 = ((await get('future') as Record<string, unknown>).compatibilityVersion === 4)
 
-      return val ? val : resolve(await get('rootDir') as string, isV4 ? 'server' : resolve(await get('srcDir') as string, 'server'))
+      return resolve(isV4 ? await get('rootDir') as string : await get('srcDir') as string, val ?? 'server')
     },
   },
 

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -158,7 +158,7 @@ export default defineUntypedSchema({
     $resolve: async (val: string | undefined, get): Promise<string> => {
       const isV4 = ((await get('future') as Record<string, unknown>).compatibilityVersion === 4)
 
-      return resolve(await get('rootDir') as string, (val || isV4) ? 'server' : resolve(await get('srcDir') as string, 'server'))
+      return val ? val : resolve(await get('rootDir') as string, isV4 ? 'server' : resolve(await get('srcDir') as string, 'server'))
     },
   },
 

--- a/packages/schema/test/folder-structure.spec.ts
+++ b/packages/schema/test/folder-structure.spec.ts
@@ -77,6 +77,23 @@ describe('nuxt folder structure', () => {
       }
     `)
   })
+
+  it('should not override value from user for serverDir', async () => {
+    const result = await applyDefaults(NuxtConfigSchema, { future: { compatibilityVersion: 4 }, serverDir: '/myServer' })
+    expect(getDirs(result as unknown as NuxtOptions)).toMatchInlineSnapshot(`
+      {
+        "dir": {
+          "app": "<cwd>/app",
+          "modules": "<cwd>/modules",
+          "public": "<cwd>/public",
+        },
+        "rootDir": "<cwd>",
+        "serverDir": "/myServer",
+        "srcDir": "<cwd>/app",
+        "workspaceDir": "<cwd>",
+      }
+    `)
+  })
 })
 
 function getDirs (options: NuxtOptions) {


### PR DESCRIPTION
### 🔗 Linked issue

fix #28242 
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this PR fix schema to stop overridinguser value for srcDir by the default value

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
