### PR TITLE
docs: `bunx` -> `bun x`

### DIFF
--- a/docs/1.getting-started/12.upgrade.md
+++ b/docs/1.getting-started/12.upgrade.md
@@ -26,7 +26,7 @@ pnpm dlx nuxi upgrade
 ```
 
 ```bash [bun]
-bunx nuxi upgrade
+bun x nuxi upgrade
 ```
 
 ::

--- a/docs/1.getting-started/2.installation.md
+++ b/docs/1.getting-started/2.installation.md
@@ -50,7 +50,7 @@ pnpm dlx nuxi@latest init <project-name>
 ```
 
 ```bash [bun]
-bunx nuxi@latest init <project-name>
+bun x nuxi@latest init <project-name>
 ```
 
 ::

--- a/docs/1.getting-started/9.prerendering.md
+++ b/docs/1.getting-started/9.prerendering.md
@@ -29,7 +29,7 @@ pnpm dlx nuxi generate
 ```
 
 ```bash [bun]
-bunx nuxi generate
+bun x nuxi generate
 ```
 
 ::

--- a/docs/2.guide/3.going-further/3.modules.md
+++ b/docs/2.guide/3.going-further/3.modules.md
@@ -28,7 +28,7 @@ pnpm dlx nuxi init -t module my-module
 ```
 
 ```bash [bun]
-bunx nuxi init -t module my-module
+bun x nuxi init -t module my-module
 ```
 ::
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves #28061 

### 📚 Description

The current version of Bun requires the use of `bun x` instead of `bunx`