### PR TITLE
docs: fix codemod command typos

### DIFF
--- a/docs/1.getting-started/12.upgrade.md
+++ b/docs/1.getting-started/12.upgrade.md
@@ -386,7 +386,7 @@ In most cases, no migration steps are required, but if you rely on the reactivit
    ```
 
 ::tip
-If you need to, you can automate this step by running `npx codemod@latest nuxt/4/shallow-data-reactivity`
+If you need to, you can automate this step by running `npx codemod@latest nuxt/4/shallow-function-reactivity`
 ::
 
 #### Absolute Watch Paths in `builder:watch`
@@ -417,7 +417,7 @@ However, if you are a module author using the `builder:watch` hook and wishing t
 ```
 
 ::tip
-You can automate this step by running `npx codemod@latest nuxt/4/absolute-watch-paths`
+You can automate this step by running `npx codemod@latest nuxt/4/absolute-watch-path`
 ::
 
 #### Removal of `window.__NUXT__` object


### PR DESCRIPTION
### 📚 Description

Typos in [Nuxt 4 migration](https://nuxt.com/docs/getting-started/upgrade#opting-in-to-nuxt-4) codemod names cause invalid command when running codemod.

~~`npx codemod@latest nuxt/4/shallow-data-reactivity`~~ → `npx codemod@latest nuxt/4/shallow-function-reactivity`
~~`npx codemod@latest nuxt/4/absolute-watch-paths`~~ → `npx codemod@latest nuxt/4/absolute-watch-path`
