### PR TITLE
fix(nuxt): include correct type declaration for `vue-router`

### DIFF
--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -233,7 +233,7 @@ export default defineNuxtModule({
     nuxt.hook('imports:sources', (sources) => {
       const routerImports = sources.find(s => s.from === '#app/composables/router' && s.imports.includes('onBeforeRouteLeave'))
       if (routerImports) {
-        routerImports.from = 'vue-router'
+        routerImports.from = 'vue-router/dist/vue-router.d.ts'
       }
     })
 
@@ -336,7 +336,7 @@ export default defineNuxtModule({
     nuxt.hook('imports:extend', (imports) => {
       imports.push(
         { name: 'definePageMeta', as: 'definePageMeta', from: resolve(runtimeDir, 'composables') },
-        { name: 'useLink', as: 'useLink', from: 'vue-router' },
+        { name: 'useLink', as: 'useLink', from: 'vue-router/dist/vue-router.d.ts' },
       )
       if (nuxt.options.experimental.inlineRouteRules) {
         imports.push({ name: 'defineRouteRules', as: 'defineRouteRules', from: resolve(runtimeDir, 'composables') })


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
resolves #28218 

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
This updates the module specifier to be more specific when importing the types for `vue-router`. Currently it is resolving `../../node_modules/vue-router/auto-routes` instead of `../../node_modules/vue-router`. This happens because `mlly` finds the `./auto-routes` export first and uses that instead of the `./` which is [last in the exports object](https://github.com/vuejs/router/blob/77d7217be5295a31cf57771a0b05cd363b30233d/packages/router/package.json#L9-L60).

This fixes the type imports for:
- `onBeforeRouteLeave`
- `onBeforeRouteUpdate`
- `useLink`

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
