### PR TITLE
fix(nuxt)!: remove unused `globalName` property

### DIFF
--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -101,7 +101,6 @@ interface _NuxtApp {
   /** @internal */
   _name: string
   vueApp: App<Element>
-  globalName: string
   versions: Record<string, string>
 
   hooks: Hookable<RuntimeNuxtHooks>
@@ -244,7 +243,6 @@ export type ObjectPluginInput<Injections extends Record<string, unknown> = Recor
 export interface CreateOptions {
   vueApp: NuxtApp['vueApp']
   ssrContext?: NuxtApp['ssrContext']
-  globalName?: NuxtApp['globalName']
 }
 
 /** @since 3.0.0 */
@@ -254,7 +252,6 @@ export function createNuxtApp (options: CreateOptions) {
     _name: appId || 'nuxt-app',
     _scope: effectScope(),
     provide: undefined,
-    globalName: 'nuxt',
     versions: {
       get nuxt () { return __NUXT_VERSION__ },
       get vue () { return nuxtApp.vueApp.version },


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Remove the `globalName` property, which is no longer used by nuxt. This is a follow-up to https://github.com/nuxt/framework/pull/1277. 

This PR is based on the analysis of @obulat  in https://github.com/nuxt-modules/storybook/pull/723#issuecomment-2250731275. 

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
