### PR TITLE
docs: fix TypeScript errors for examples

### DIFF
--- a/docs/2.guide/4.recipes/1.custom-routing.md
+++ b/docs/2.guide/4.recipes/1.custom-routing.md
@@ -39,6 +39,8 @@ You can add, change or remove pages from the scanned routes with the `pages:exte
 For example, to prevent creating routes for any `.ts` files:
 
 ```ts [nuxt.config.ts]
+import type { NuxtPage } from '@nuxt/schema'
+
 export default defineNuxtConfig({
   hooks: {
     'pages:extend' (pages) {
@@ -51,12 +53,14 @@ export default defineNuxtConfig({
 
       // remove routes
       function removePagesMatching (pattern: RegExp, pages: NuxtPage[] = []) {
-        const pagesToRemove = []
+        const pagesToRemove: NuxtPage[] = []
         for (const page of pages) {
-          if (pattern.test(page.file)) {
-            pagesToRemove.push(page)
-          } else {
-            removePagesMatching(pattern, page.children)
+          if (page.file !== undefined) {
+            if (pattern.test(page.file)) {
+              pagesToRemove.push(page)
+            } else {
+              removePagesMatching(pattern, page.children)
+            }
           }
         }
         for (const page of pagesToRemove) {
@@ -85,7 +89,7 @@ On top of customizing options for [`vue-router`](https://router.vuejs.org/api/in
 
 This is the recommended way to specify [router options](/docs/api/nuxt-config#router).
 
-```js [app/router.options.ts]
+```ts [app/router.options.ts]
 import type { RouterConfig } from '@nuxt/schema'
 
 export default <RouterConfig> {
@@ -99,6 +103,8 @@ Adding a router options file in this hook will switch on page-based routing, unl
 ::
 
 ```ts [nuxt.config.ts]
+import { createResolver } from '@nuxt/kit'
+
 export default defineNuxtConfig({
   hooks: {
     'pages:routerOptions' ({ files }) {
@@ -166,7 +172,7 @@ export default defineNuxtConfig({
 
 You can optionally override history mode using a function that accepts the base URL and returns the history mode. If it returns `null` or `undefined`, Nuxt will fallback to the default history.
 
-```js [app/router.options.ts]
+```ts [app/router.options.ts]
 import type { RouterConfig } from '@nuxt/schema'
 import { createMemoryHistory } from 'vue-router'
 


### PR DESCRIPTION
### 📚 Description

1. `RegExp.text()` needs a `string` but `NuxtPage.file` is a `string | undefined`, and `undefined` will convert to `"undefined"`.
2. Explicitly specify the imports.
3. Add type defining.
4. Change language tags of fenced code blocks to ts.