### PR TITLE
fix(nuxt): preserve route-specific metadata on `route.meta`

### DIFF
--- a/docs/1.getting-started/12.upgrade.md
+++ b/docs/1.getting-started/12.upgrade.md
@@ -206,7 +206,6 @@ export default defineNuxtConfig({
 
 It's possible to set some route metadata using `definePageMeta`, such as the `name`, `path`, and so on. Previously these were available both on the route and on route metadata (for example, `route.name` and `route.meta.name`).
 
-
 Now, they are only accessible on the route object.
 
 ##### Reasons for Change

--- a/docs/1.getting-started/12.upgrade.md
+++ b/docs/1.getting-started/12.upgrade.md
@@ -198,6 +198,32 @@ export default defineNuxtConfig({
 })
 ```
 
+#### Deduplication of Route Metadata
+
+🚦 **Impact Level**: Minimal
+
+##### What Changed
+
+It's possible to set some route metadata using `definePageMeta`, such as the `name`, `path`, and so on. Previously these were available both on the route and on route metadata (for example, `route.name` and `route.meta.name`).
+
+
+Now, they are only accessible on the route object.
+
+##### Reasons for Change
+
+This is a result of enabling `experimental.scanPageMeta` by default, and is a performance optimization.
+
+##### Migration Steps
+
+The migration should be straightforward:
+
+```diff
+  const route = useRoute()
+  
+- console.log(route.meta.name)
++ console.log(route.name)
+```
+
 #### Shared Prerender Data
 
 🚦 **Impact Level**: Medium

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -279,7 +279,7 @@ export async function getRouteMeta (contents: string, absolutePath: string): Pro
           continue
         }
         const name = property.key.type === 'Identifier' ? property.key.name : String(property.value)
-        if (!(extractionKeys as unknown as string[]).includes(name)) {
+        if (name) {
           dynamicProperties.add('meta')
           break
         }

--- a/packages/nuxt/test/__snapshots__/pages-override-meta-enabled.test.ts.snap
+++ b/packages/nuxt/test/__snapshots__/pages-override-meta-enabled.test.ts.snap
@@ -329,6 +329,7 @@
   "should properly override route name if definePageMeta name override is defined.": [
     {
       "component": "() => import("pages/index.vue").then(m => m.default || m)",
+      "meta": "mockMeta || {}",
       "name": ""home"",
       "path": ""/"",
     },

--- a/packages/nuxt/test/page-metadata.test.ts
+++ b/packages/nuxt/test/page-metadata.test.ts
@@ -15,7 +15,10 @@ describe('page metadata', () => {
     for (const ext of ['js', 'jsx', 'ts', 'tsx', 'mjs', 'cjs']) {
       const meta = await getRouteMeta(fileContents, `/app/pages/index.${ext}`)
       expect(meta).toStrictEqual({
-        name: 'bar',
+        'name': 'bar',
+        'meta': {
+          '__nuxt_dynamic_meta_key': new Set(['meta']),
+        },
       })
     }
   })

--- a/packages/nuxt/test/pages.test.ts
+++ b/packages/nuxt/test/pages.test.ts
@@ -348,6 +348,7 @@ describe('pages:generateRoutesFromFiles', () => {
           name: 'home',
           path: '/',
           file: `${pagesDir}/index.vue`,
+          meta: { [DYNAMIC_META_KEY]: new Set(['meta']) },
           children: [],
         },
       ],


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/28436

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Do not exclude `extractionKeys` in meta

```
 const extractionKeys = ['name', 'path', 'alias', 'redirect']
```

[reproduction](https://stackblitz.com/edit/github-znsjbh-esn93f?file=pages%2Ftest.vue,pages%2Findex.vue,nuxt.config.ts,pages%2Ftest1.vue,pages%2Ftest-more-key.vue,app.vue)


<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
