### PR TITLE
fix(nuxt): ensure `runtimeConfig.public` is reactive on client

### DIFF
--- a/packages/nuxt/src/app/composables/payload.ts
+++ b/packages/nuxt/src/app/composables/payload.ts
@@ -122,8 +122,8 @@ export async function getNuxtClientPayload () {
     ...window.__NUXT__,
   }
 
-  if (payloadCache?.config?.public) {
-    payloadCache.config.public = reactive(payloadCache.config.public)
+  if (payloadCache!.config?.public) {
+    payloadCache!.config.public = reactive(payloadCache!.config.public)
   }
 
   return payloadCache

--- a/packages/nuxt/src/app/composables/payload.ts
+++ b/packages/nuxt/src/app/composables/payload.ts
@@ -1,7 +1,7 @@
 import { hasProtocol, joinURL, withoutTrailingSlash } from 'ufo'
 import { parse } from 'devalue'
 import { useHead } from '@unhead/vue'
-import { getCurrentInstance, onServerPrefetch } from 'vue'
+import { getCurrentInstance, onServerPrefetch, reactive } from 'vue'
 import { useNuxtApp, useRuntimeConfig } from '../nuxt'
 import type { NuxtPayload } from '../nuxt'
 
@@ -120,6 +120,10 @@ export async function getNuxtClientPayload () {
     ...inlineData,
     ...externalData,
     ...window.__NUXT__,
+  }
+
+  if (payloadCache?.config?.public) {
+    payloadCache.config.public = reactive(payloadCache.config.public)
   }
 
   return payloadCache


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

We document that public runtimeConfig is both writable and reactive on client-side:

![CleanShot 2024-08-07 at 13 17 45@2x](https://github.com/user-attachments/assets/b27d2c76-27c6-431d-b4d0-1ab4b3a2f7a2)

https://nuxt.com/docs/guide/going-further/runtime-config

I'm not sure at what point this was no longer the case, but this ensures that it remains reactive.