### PR TITLE
fix(nuxt): augment `@vue/runtime-core` and `@vue/runtime-dom`

### DIFF
--- a/packages/nuxt/src/app/types/augments.d.ts
+++ b/packages/nuxt/src/app/types/augments.d.ts
@@ -51,3 +51,23 @@ declare module 'vue' {
     head?(nuxtApp: NuxtApp): UseHeadInput
   }
 }
+
+declare module '@vue/runtime-core' {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  interface App<HostElement> {
+    $nuxt: NuxtApp
+  }
+  interface ComponentCustomProperties {
+    $nuxt: NuxtApp
+  }
+}
+
+declare module '@vue/runtime-dom' {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  interface App<HostElement> {
+    $nuxt: NuxtApp
+  }
+  interface ComponentCustomProperties {
+    $nuxt: NuxtApp
+  }
+}

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -130,6 +130,14 @@ declare module '#app' {
   }
 }
 
+declare module '@vue/runtime-core' {
+  interface ComponentCustomProperties extends NuxtAppInjections { }
+}
+
+declare module '@vue/runtime-dom' {
+  interface ComponentCustomProperties extends NuxtAppInjections { }
+}
+
 declare module 'vue' {
   interface ComponentCustomProperties extends NuxtAppInjections { }
 }


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/28373, resolves https://github.com/nuxt/nuxt/issues/28440

### 📚 Description

Currently we need to augment `vue`, `@vue/runtime-dom` and `@vue/runtime-core` - or it will be possible that a library which augments only one of these will 'break' type augmentation.

However, it might be we have an opportunity across the ecosystem to migrate to augmenting only one of these (ideally just `vue`: https://vuejs.org/guide/typescript/options-api.html#augmenting-global-properties). Removing these duplicate augmentations would _also_ fix the issue in a minimal install of Nuxt but likely needs to be updated in other libraries/projects.

cc: @johnsoncodehk, @posva 