### PR TITLE
fix(nuxt): scan jsx pages for page metadata

### DIFF
--- a/packages/nuxt/src/core/utils/index.ts
+++ b/packages/nuxt/src/core/utils/index.ts
@@ -1,5 +1,5 @@
 export { getNameFromPath, hasSuffix, resolveComponentNameSegments } from './names'
-export { isJS, isVue } from './plugins'
+export { getLoader, isJS, isVue } from './plugins'
 
 export function uniqueBy<T, K extends keyof T> (arr: T[], key: K) {
   if (arr.length < 2) {

--- a/packages/nuxt/src/core/utils/plugins.ts
+++ b/packages/nuxt/src/core/utils/plugins.ts
@@ -1,4 +1,5 @@
 import { pathToFileURL } from 'node:url'
+import { extname } from 'pathe'
 import { parseQuery, parseURL } from 'ufo'
 
 export function isVue (id: string, opts: { type?: Array<'template' | 'script' | 'style'> } = {}) {
@@ -40,4 +41,16 @@ export function isJS (id: string) {
   // JavaScript files
   const { pathname } = parseURL(decodeURIComponent(pathToFileURL(id).href))
   return JS_RE.test(pathname)
+}
+
+export function getLoader (id: string): 'vue' | 'ts' | 'tsx' | null {
+  const { pathname } = parseURL(decodeURIComponent(pathToFileURL(id).href))
+  const ext = extname(pathname)
+  if (ext === '.vue') {
+    return 'vue'
+  }
+  if (!JS_RE.test(ext)) {
+    return null
+  }
+  return ext.endsWith('x') ? 'tsx' : 'ts'
 }

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -13,7 +13,7 @@ import { walk } from 'estree-walker'
 import type { CallExpression, ExpressionStatement, ObjectExpression, Program, Property } from 'estree'
 import type { NuxtPage } from 'nuxt/schema'
 
-import { uniqueBy } from '../core/utils'
+import { getLoader, uniqueBy } from '../core/utils'
 import { toArray } from '../utils'
 import { distDir } from '../dirs'
 
@@ -188,7 +188,8 @@ export async function getRouteMeta (contents: string, absolutePath: string): Pro
 
   if (absolutePath in metaCache) { return metaCache[absolutePath] }
 
-  const script = extractScriptContent(contents)
+  const loader = getLoader(absolutePath)
+  const script = !loader ? null : loader === 'vue' ? extractScriptContent(contents) : { code: contents, loader }
   if (!script) {
     metaCache[absolutePath] = {}
     return {}

--- a/packages/nuxt/test/page-metadata.test.ts
+++ b/packages/nuxt/test/page-metadata.test.ts
@@ -10,6 +10,16 @@ describe('page metadata', () => {
     expect(await getRouteMeta('<template><div>Hi</div></template>', filePath)).toEqual({})
   })
 
+  it('should extract metadata from JS/JSX files', async () => {
+    const fileContents = `definePageMeta({ name: 'bar' })`
+    for (const ext of ['js', 'jsx', 'ts', 'tsx', 'mjs', 'cjs']) {
+      const meta = await getRouteMeta(fileContents, `/app/pages/index.${ext}`)
+      expect(meta).toStrictEqual({
+        name: 'bar',
+      })
+    }
+  })
+
   it('should use and invalidate cache', async () => {
     const fileContents = `<script setup>definePageMeta({ foo: 'bar' })</script>`
     const meta = await getRouteMeta(fileContents, filePath)


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/28245

### 📚 Description

We were parsing all pages as SFCs and skipping extracting page metadata if they were not.

This handles the case of JS/JSX page files.