### PR TITLE
docs: fix vue-tsc version in TypeScript page

### DIFF
--- a/docs/2.guide/1.concepts/8.typescript.md
+++ b/docs/2.guide/1.concepts/8.typescript.md
@@ -12,19 +12,19 @@ To enable type-checking at build or development time, install `vue-tsc` and `typ
 ::code-group
 
   ```bash [yarn]
-  yarn add --dev vue-tsc@^2 typescript
+  yarn add --dev vue-tsc typescript
   ```
 
   ```bash [npm]
-  npm install --save-dev vue-tsc@^2 typescript
+  npm install --save-dev vue-tsc typescript
   ```
 
   ```bash [pnpm]
-  pnpm add -D vue-tsc@^2 typescript
+  pnpm add -D vue-tsc typescript
   ```
 
   ```bash [bun]
-  bun add -D vue-tsc@^2 typescript
+  bun add -D vue-tsc typescript
   ```
 
 ::

--- a/docs/2.guide/1.concepts/8.typescript.md
+++ b/docs/2.guide/1.concepts/8.typescript.md
@@ -12,19 +12,19 @@ To enable type-checking at build or development time, install `vue-tsc` and `typ
 ::code-group
 
   ```bash [yarn]
-  yarn add --dev vue-tsc@^1 typescript
+  yarn add --dev vue-tsc@^2 typescript
   ```
 
   ```bash [npm]
-  npm install --save-dev vue-tsc@^1 typescript
+  npm install --save-dev vue-tsc@^2 typescript
   ```
 
   ```bash [pnpm]
-  pnpm add -D vue-tsc@^1 typescript
+  pnpm add -D vue-tsc@^2 typescript
   ```
 
   ```bash [bun]
-  bun add -D vue-tsc@^1 typescript
+  bun add -D vue-tsc@^2 typescript
   ```
 
 ::


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

None

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

[The TypeScript page in Key Concepts](https://nuxt.com/docs/guide/concepts/typescript) currently recommends an outdated version of `vue-tsc`, causing type-checking issues with Nuxt 3.12.4.

```
$ pnpm add -D vue-tsc@^1 typescript

# ...

devDependencies:
+ typescript 5.5.4
+ vue-tsc 1.8.27 (2.0.29 is available)

 WARN  Issues with peer dependencies found
.
└─┬ nuxt 3.12.4
  └─┬ @nuxt/vite-builder 3.12.4
    └─┬ vite-plugin-checker 0.7.2
      └── ✕ unmet peer vue-tsc@>=2.0.0: found 1.8.27

$ pnpm exec nuxi typecheck

<project-path>/node_modules/.pnpm/vue-tsc@1.8.27_typescript@5.5.4/node_modules/vue-tsc/bin/vue-tsc.js:68
			throw err;
			^
Search string not found: "for (const existingRoot of buildInfoVersionMap.roots) {"
(Use `node --trace-uncaught ...` to show where the exception was thrown)

Node.js v20.16.0
```

Installing `vue-tsc@^2` or `vue-tsc@latest` resolves the issue. I have updated the documentation to guide users to install the correct version of `vue-tsc`.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
