### PR TITLE
fix(vite): write dev manifest when `ssr: false`

### DIFF
--- a/packages/vite/src/manifest.ts
+++ b/packages/vite/src/manifest.ts
@@ -8,12 +8,29 @@ import { normalizeViteManifest } from 'vue-bundle-renderer'
 import type { ViteBuildContext } from './vite'
 
 export async function writeManifest (ctx: ViteBuildContext) {
+  // This is only used for ssr: false - when ssr is enabled we use vite-node runtime manifest
+  const devClientManifest = {
+    '@vite/client': {
+      isEntry: true,
+      file: '@vite/client',
+      css: [],
+      module: true,
+      resourceType: 'script',
+    },
+    [ctx.entry]: {
+      isEntry: true,
+      file: ctx.entry,
+      module: true,
+      resourceType: 'script',
+    },
+  }
+
   // Write client manifest for use in vue-bundle-renderer
   const clientDist = resolve(ctx.nuxt.options.buildDir, 'dist/client')
   const serverDist = resolve(ctx.nuxt.options.buildDir, 'dist/server')
 
   const manifestFile = resolve(clientDist, 'manifest.json')
-  const clientManifest = JSON.parse(readFileSync(manifestFile, 'utf-8'))
+  const clientManifest = ctx.nuxt.options.dev ? devClientManifest : JSON.parse(readFileSync(manifestFile, 'utf-8'))
 
   const buildAssetsDir = withTrailingSlash(withoutLeadingSlash(ctx.nuxt.options.app.buildAssetsDir))
   const BASE_RE = new RegExp(`^${escapeRE(buildAssetsDir)}`)

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -148,6 +148,7 @@ export async function buildServer (ctx: ViteBuildContext) {
   }
 
   if (!ctx.nuxt.options.ssr) {
+    await writeManifest(ctx)
     await onBuild()
     return
   }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This handles an unreported issue in `main` where we were not writing a client manifest in dev mode when `ssr: false`.