### PR TITLE
test: use '#teleports' target instead of 'body'

### DIFF
--- a/test/fixtures/basic/pages/teleport.vue
+++ b/test/fixtures/basic/pages/teleport.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <teleport to="body">
+    <teleport to="#teleports">
       <div>Teleport</div>
     </teleport>
     <h1>Normal content</h1>


### PR DESCRIPTION
### 🔗 Linked issue
https://github.com/nuxt/nuxt/issues/28483

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
Since the recommended teleport target is now `'#teleports'`, I figured it would be a good idea to update this test fixture as well. Not sure if it won't break something, though 🙈

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
