### PR TITLE
fix(vite): log transformation result when a PARSE_ERROR happens

### DIFF
--- a/packages/vite/src/vite-node.ts
+++ b/packages/vite/src/vite-node.ts
@@ -141,7 +141,7 @@ function createViteNodeApp (ctx: ViteBuildContext, invalidates: Set<string> = ne
         web: [],
       },
     })
-    
+
     const isExternal = createIsExternal(viteServer, ctx.nuxt.options.rootDir, ctx.nuxt.options.modulesDir)
     node.shouldExternalize = async (id: string) => {
       const result = await isExternal(id)

--- a/packages/vite/src/vite-node.ts
+++ b/packages/vite/src/vite-node.ts
@@ -15,8 +15,6 @@ import { isCSS } from './utils'
 import { createIsExternal } from './utils/external'
 import { transpile } from './utils/transpile'
 
-const NEED_FRAME_ERRORS = ['PARSE_ERROR']
-
 // TODO: Remove this in favor of registerViteNodeMiddleware
 // after Nitropack or h3 fixed for adding middlewares after setup
 export function viteNodePlugin (ctx: ViteBuildContext): VitePlugin {
@@ -141,7 +139,7 @@ function createViteNodeApp (ctx: ViteBuildContext, invalidates: Set<string> = ne
         web: [],
       },
     })
-    
+
     const isExternal = createIsExternal(viteServer, ctx.nuxt.options.rootDir, ctx.nuxt.options.modulesDir)
     node.shouldExternalize = async (id: string) => {
       const result = await isExternal(id)
@@ -164,11 +162,10 @@ function createViteNodeApp (ctx: ViteBuildContext, invalidates: Set<string> = ne
           code: 'VITE_ERROR',
           id: moduleId,
           stack: '',
-          message: err.message,
           ...err,
         }
 
-        if (!errorData.frame && NEED_FRAME_ERRORS.includes(errorData.code)) {
+        if (!errorData.frame && errorData.code === 'PARSE_ERROR') {
           errorData.frame = await node.transformModule(moduleId, 'web').then(({ code }) => `${err.message || ''}\n${code}`).catch(() => undefined)
         }
         throw createError({ data: errorData })


### PR DESCRIPTION
### 🔗 Linked issue

fix #25525 
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This PR log the transform result of a file if there is a JS parsing issue following all the trasformation of a file. This will greatly help developers when an issue happens due to transfrormation plugins in vite since their own file could be 100% fine.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
