### PR TITLE
fix(vite): include module symbols in generated code

### DIFF
--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -85,6 +85,7 @@ export async function buildServer (ctx: ViteBuildContext) {
           entryFileNames: '[name].mjs',
           format: 'module',
           generatedCode: {
+            symbols: true, // temporary fix for https://github.com/vuejs/core/issues/8351,
             constBindings: true,
           },
         },


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/27836

### 📚 Description

This configures rollup to emit code that will allow Vue to detect the import of the component, and de-default it. It should make it possible use dynamic imports of Vue modules without interop-default.