### PR TITLE
docs: improve typing of default exports

### DIFF
--- a/docs/2.guide/4.recipes/1.custom-routing.md
+++ b/docs/2.guide/4.recipes/1.custom-routing.md
@@ -16,7 +16,7 @@ If it returns `null` or `undefined`, Nuxt will fall back to the default routes (
 ```ts [app/router.options.ts]
 import type { RouterConfig } from '@nuxt/schema'
 
-export default <RouterConfig> {
+export default {
   // https://router.vuejs.org/api/interfaces/routeroptions.html#routes
   routes: (_routes) => [
     {
@@ -25,7 +25,7 @@ export default <RouterConfig> {
       component: () => import('~/pages/home.vue').then(r => r.default || r)
     }
   ],
-}
+} satisfies RouterConfig
 ```
 
 ::note
@@ -90,8 +90,8 @@ This is the recommended way to specify [router options](/docs/api/nuxt-config#ro
 ```ts [app/router.options.ts]
 import type { RouterConfig } from '@nuxt/schema'
 
-export default <RouterConfig> {
-}
+export default {
+} satisfies RouterConfig
 ```
 
 It is possible to add more router options files by adding files within the `pages:routerOptions` hook. Later items in the array override earlier ones.
@@ -174,8 +174,8 @@ You can optionally override history mode using a function that accepts the base 
 import type { RouterConfig } from '@nuxt/schema'
 import { createMemoryHistory } from 'vue-router'
 
-export default <RouterConfig> {
+export default {
   // https://router.vuejs.org/api/interfaces/routeroptions.html
   history: base => import.meta.client ? createMemoryHistory(base) : null /* default */
-}
+} satisfies RouterConfig
 ```


### PR DESCRIPTION
### 🔗 Linked issue

### 📚 Description

`satisfies` ensures type conformity without altering the object's type, better than `<T>` casting.