### PR TITLE
feat(vite): preserve vite sourcemaps for nitro build

### DIFF
--- a/packages/vite/src/plugins/nitro-sourcemap.ts
+++ b/packages/vite/src/plugins/nitro-sourcemap.ts
@@ -1,5 +1,5 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
-import { dirname, join, resolve } from 'pathe'
+import { dirname, resolve } from 'pathe'
 
 import type { Plugin as RollupPlugin } from 'rollup'
 import type { Plugin as VitePlugin } from 'vite'
@@ -17,7 +17,7 @@ export const createSourcemapPreserver = () => {
       for (const chunk of Object.values(bundle)) {
         if (chunk.type !== 'chunk' || !chunk.map) { continue }
 
-        const id = join(outputDir, chunk.fileName)
+        const id = resolve(outputDir, chunk.fileName)
         ids.add(id)
         const dest = id + '.map.json'
         await mkdir(dirname(dest), { recursive: true })

--- a/packages/vite/src/plugins/nitro-sourcemap.ts
+++ b/packages/vite/src/plugins/nitro-sourcemap.ts
@@ -1,0 +1,63 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname, join, resolve } from 'pathe'
+
+import type { Plugin as RollupPlugin } from 'rollup'
+import type { Plugin as VitePlugin } from 'vite'
+
+export const createSourcemapPreserver = () => {
+  let outputDir: string
+  const ids = new Set<string>()
+
+  const vitePlugin = {
+    name: 'nuxt:sourcemap-export',
+    configResolved (config) {
+      outputDir = config.build.outDir
+    },
+    async writeBundle (_options, bundle) {
+      for (const chunk of Object.values(bundle)) {
+        if (chunk.type !== 'chunk' || !chunk.map) { continue }
+
+        const id = join(outputDir, chunk.fileName)
+        ids.add(id)
+        const dest = id + '.map.json'
+        await mkdir(dirname(dest), { recursive: true })
+        await writeFile(dest, JSON.stringify({
+          file: chunk.map.file,
+          mappings: chunk.map.mappings,
+          names: chunk.map.names,
+          sources: chunk.map.sources,
+          sourcesContent: chunk.map.sourcesContent,
+          version: chunk.map.version,
+        }))
+      }
+    },
+  } satisfies VitePlugin
+
+  const nitroPlugin = {
+    name: 'nuxt:sourcemap-import',
+    async load (id) {
+      id = resolve(id)
+      if (!ids.has(id)) { return }
+
+      const [code, map] = await Promise.all([
+        readFile(id, 'utf-8').catch(() => undefined),
+        readFile(id + '.map.json', 'utf-8').catch(() => undefined),
+      ])
+
+      if (!code) {
+        this.warn('Failed loading file')
+        return null
+      }
+
+      return {
+        code,
+        map,
+      }
+    },
+  } satisfies RollupPlugin
+
+  return {
+    vitePlugin,
+    nitroPlugin,
+  }
+}

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -5,11 +5,13 @@ import viteJsxPlugin from '@vitejs/plugin-vue-jsx'
 import { logger, resolvePath, tryImportModule } from '@nuxt/kit'
 import { joinURL, withTrailingSlash, withoutLeadingSlash } from 'ufo'
 import type { ViteConfig } from '@nuxt/schema'
+import defu from 'defu'
 import type { ViteBuildContext } from './vite'
 import { createViteLogger } from './utils/logger'
 import { initViteNodeServer } from './vite-node'
 import { writeManifest } from './manifest'
 import { transpile } from './utils/transpile'
+import { createSourcemapPreserver } from './plugins/nitro-sourcemap'
 
 export async function buildServer (ctx: ViteBuildContext) {
   const helper = ctx.nuxt.options.nitro.imports !== false ? '' : 'globalThis.'
@@ -119,6 +121,17 @@ export async function buildServer (ctx: ViteBuildContext) {
         ...runtimeDependencies,
       )
     }
+  }
+
+  // tell rollup's nitro build about the original sources of the generated vite server build
+  if (ctx.nuxt.options.sourcemap.server && !ctx.nuxt.options.dev) {
+    const { vitePlugin, nitroPlugin } = createSourcemapPreserver()
+    serverConfig.plugins!.push(vitePlugin)
+    ctx.nuxt.hook('nitro:build:before', (nitro) => {
+      nitro.options.rollupConfig = defu(nitro.options.rollupConfig, {
+        plugins: [nitroPlugin],
+      })
+    })
   }
 
   serverConfig.customLogger = createViteLogger(serverConfig)


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/28506

### 📚 Description

We have two builds for the Nuxt server - a Vite/webpack build and then a Nitro build. This means that server sourcemaps end up pointing to the intermediate Vite build rather than the original source file. As both Vite + Nitro are based on rollup at the moment, we can preserve sourcemaps between the builds in the form of JSON, without needing to use something like [rollup-plugin-sourcemaps](https://github.com/maxdavidson/rollup-plugin-sourcemaps) (which is both outdated and has a greater performance cost - see https://github.com/rollup/rollup/issues/4532).

We write the sourcemaps to disk rather than persisting them in memory to avoid excessive memory consumption.