### PR TITLE
ci: add reproduire-sur-stackblitz workflow

### DIFF
--- a/.github/workflows/reproduire-sur-stackblitz.yml
+++ b/.github/workflows/reproduire-sur-stackblitz.yml
@@ -1,0 +1,17 @@
+name: reproduire-sur-stackblitz
+on:
+    issues:
+        types:
+            opened
+
+permissions:
+    issues: write
+
+jobs:
+    reproduire-sur-stackblitz:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - uses: huang-julien/reproduire-sur-stackblitz@v1.0.0
+              with:
+                reproduction-heading: '### Reproduction'


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description


This PR adds `reproduire-sur-stackblitz` action. For issues with a GH repo, this will generate a message with a link to stackblitz that clones the gh repo mentionned in the reproduction section.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
