### PR TITLE
fix: type augmentation for `$config` property

### DIFF
--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -254,11 +254,13 @@ export const schemaTemplate: NuxtTemplate = {
           indentation: 2,
         }),
       '}',
-      `declare module 'vue' {
-        interface ComponentCustomProperties {
-          $config: RuntimeConfig
-        }
-      }`,
+      ...['vue', '@vue/runtime-core', '@vue/runtime-dom'].flatMap(mod => [
+        `declare module '${mod}' {`,
+        '  interface ComponentCustomProperties {',
+        '    $config: RuntimeConfig',
+        '  }',
+        `}`,
+      ]),
     ].join('\n')
   },
 }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
The types for `$config` property didn't work (in my local project with nightly 3x installed), I'm guessing these changes should have been included in https://github.com/nuxt/nuxt/pull/28446?

I see https://github.com/nuxt/nuxt/pull/28542 reverts the changes in https://github.com/nuxt/nuxt/pull/28446 though, if we're going that route this can be closed 😅
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
