### PR TITLE
docs: add proper line-breaks to tips in Module Author Guide

### DIFF
--- a/docs/2.guide/3.going-further/3.modules.md
+++ b/docs/2.guide/3.going-further/3.modules.md
@@ -228,9 +228,9 @@ Learn more about asset injection in [the recipes section](#recipes).
 
 ::warning
 Published modules cannot leverage auto-imports for assets within their runtime directory. Instead, they have to import them explicitly from `#imports` or alike.
-
+:br :br
 Indeed, auto-imports are not enabled for files within `node_modules` (the location where a published module will eventually live) for performance reasons.
-
+:br :br
 If you are using the module starter, auto-imports will not be enabled in your playground either.
 ::
 
@@ -638,7 +638,7 @@ Testing helps ensuring your module works as expected given various setup. Find i
 
 ::tip
 We're still discussing and exploring how to ease unit and integration testing on Nuxt Modules.
-
+:br :br
 [Check out this RFC to join the conversation](https://github.com/nuxt/nuxt/discussions/18399).
 ::
 


### PR DESCRIPTION
### 🔗 Linked issue

None.

### 📚 Description

Added proper line-breaks to tips in Module Author Guide section. Before there were no line-breaks or spacing between words.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
