### PR TITLE
feat(schema): split dev/prod build directories

### DIFF
--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -189,16 +189,14 @@ export default defineUntypedSchema({
         return defaultBuildDir
       }
 
-      const buildId = await get('buildId') as string
-
       // TODO: nuxi CLI should ensure .nuxt dir exists
       if (!existsSync(defaultBuildDir)) {
         // This is to ensure that types continue to work for CI builds
         return defaultBuildDir
       }
 
-      // TODO: handle build caching
-      return resolve(rootDir, 'node_modules/.cache/nuxt/builds', buildId)
+      // TODO: handle build caching + using buildId in directory
+      return resolve(rootDir, 'node_modules/.cache/nuxt/builds', 'production')
     },
   },
 

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -175,7 +175,31 @@ export default defineUntypedSchema({
    * ```
    */
   buildDir: {
-    $resolve: async (val: string | undefined, get): Promise<string> => resolve(await get('rootDir') as string, val || '.nuxt'),
+    $resolve: async (val: string | undefined, get): Promise<string> => {
+      const rootDir = await get('rootDir') as string
+
+      if (val) {
+        return resolve(rootDir, val)
+      }
+
+      const defaultBuildDir = resolve(rootDir, '.nuxt')
+
+      const isDev = await get('dev') as boolean
+      if (isDev) {
+        return defaultBuildDir
+      }
+
+      const buildId = await get('buildId') as string
+
+      // TODO: nuxi CLI should ensure .nuxt dir exists
+      if (!existsSync(defaultBuildDir)) {
+        // This is to ensure that types continue to work for CI builds
+        return defaultBuildDir
+      }
+
+      // TODO: handle build caching
+      return resolve(rootDir, 'node_modules/.cache/nuxt/builds', buildId)
+    },
   },
 
   /**

--- a/test/fixtures/basic-types/nuxt.config.ts
+++ b/test/fixtures/basic-types/nuxt.config.ts
@@ -9,7 +9,6 @@ export default defineNuxtConfig({
   future: {
     typescriptBundlerResolution: process.env.MODULE_RESOLUTION === 'bundler',
   },
-  buildDir: process.env.NITRO_BUILD_DIR,
   builder: process.env.TEST_BUILDER as 'webpack' | 'vite' ?? 'vite',
   theme: './extends/bar',
   extends: [

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -31,7 +31,6 @@ export default defineNuxtConfig({
       include: ['keepalive-in-config', 'not-keepalive-in-nuxtpage'],
     },
   },
-  buildDir: process.env.NITRO_BUILD_DIR,
   builder: process.env.TEST_BUILDER as 'webpack' | 'vite' ?? 'vite',
   appId: 'nuxt-app-basic',
   build: {
@@ -68,7 +67,6 @@ export default defineNuxtConfig({
       '/hydration/spa-redirection/**': { ssr: false },
       '/no-scripts': { experimentalNoScripts: true },
     },
-    output: { dir: process.env.NITRO_OUTPUT_DIR },
     prerender: {
       routes: [
         '/random/a',

--- a/test/hmr.test.ts
+++ b/test/hmr.test.ts
@@ -23,8 +23,6 @@ if (process.env.TEST_ENV !== 'built' && !isWindows) {
     setupTimeout: (isWindows ? 360 : 120) * 1000,
     nuxtConfig: {
       builder: isWebpack ? 'webpack' : 'vite',
-      buildDir: process.env.NITRO_BUILD_DIR,
-      nitro: { output: { dir: process.env.NITRO_OUTPUT_DIR } },
     },
   })
 

--- a/test/suspense.test.ts
+++ b/test/suspense.test.ts
@@ -14,8 +14,6 @@ await setup({
   setupTimeout: (isWindows ? 360 : 120) * 1000,
   nuxtConfig: {
     builder: isWebpack ? 'webpack' : 'vite',
-    buildDir: process.env.NITRO_BUILD_DIR,
-    nitro: { output: { dir: process.env.NITRO_OUTPUT_DIR } },
   },
 })
 


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/14607

### 📚 Description

This adds support for splitting dev + production build directories. Because type-support is based on having a `.nuxt/tsconfig.json` in place, we can't _always_ split out the build directory.

I've opted to use `buildId` for the production build directory to allow parallel production builds - but this implementation detail will likely change when we implement https://github.com/nuxt/nuxt/issues/23392 (next on the list!)

This should enable running parallel builds alongside a dev server (or even multiple builds in parallel at the same time).

### Next steps
- [ ] consider whether `nuxi` should run prepare step on a separate directory before building (?)
- [x] https://github.com/nuxt/nuxt/issues/14605
- [x] https://github.com/nuxt/nuxt/issues/23392
