### PR TITLE
fix: allow customising status code in validate method

### DIFF
--- a/packages/nuxt/src/pages/runtime/validate.ts
+++ b/packages/nuxt/src/pages/runtime/validate.ts
@@ -14,8 +14,8 @@ export default defineNuxtRouteMiddleware(async (to) => {
   }
 
   const error = createError({
-    statusCode: result && result.statusCode || 404,
-    statusMessage: result && result.statusMessage || `Page Not Found: ${to.fullPath}`,
+    statusCode: (result && result.statusCode) || 404,
+    statusMessage: (result && result.statusMessage) || `Page Not Found: ${to.fullPath}`,
     data: {
       path: to.fullPath,
     },

--- a/packages/nuxt/src/pages/runtime/validate.ts
+++ b/packages/nuxt/src/pages/runtime/validate.ts
@@ -12,13 +12,10 @@ export default defineNuxtRouteMiddleware(async (to) => {
   if (result === true) {
     return
   }
-  if (import.meta.server) {
-    return result
-  }
 
   const error = createError({
-    statusCode: 404,
-    statusMessage: `Page Not Found: ${to.fullPath}`,
+    statusCode: result && result.statusCode || 404,
+    statusMessage: result && result.statusMessage || `Page Not Found: ${to.fullPath}`,
     data: {
       path: to.fullPath,
     },
@@ -32,7 +29,7 @@ export default defineNuxtRouteMiddleware(async (to) => {
         // We pretend to have navigated to the invalid route so
         // that the user can return to the previous page with
         // the back button.
-        window.history.pushState({}, '', to.fullPath)
+        window?.history.pushState({}, '', to.fullPath)
       })
       // We stop the navigation immediately before it resolves
       // if there is no other route matching it.

--- a/test/fixtures/basic/pages/navigate-to-validate-custom-error.vue
+++ b/test/fixtures/basic/pages/navigate-to-validate-custom-error.vue
@@ -1,0 +1,14 @@
+<template>
+  <div>
+    <div>navigate-to-validate-custom-error.vue</div>
+    <NuxtLink to="/validate-custom-error">
+      should throw a 401 error with custom message
+    </NuxtLink>
+  </div>
+</template>
+
+<script setup lang="ts">
+definePageMeta({
+  middleware: ['override'],
+})
+</script>

--- a/test/fixtures/basic/pages/validate-custom-error.vue
+++ b/test/fixtures/basic/pages/validate-custom-error.vue
@@ -1,0 +1,12 @@
+<template>
+  <div>You should not see this</div>
+</template>
+
+<script setup lang="ts">
+definePageMeta({
+  validate: to => ({
+    statusCode: 401,
+    statusMessage: 'Custom error message',
+  }),
+})
+</script>


### PR DESCRIPTION
### 🔗 Linked issue

resolves #26046
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
Allow customising status code in validate method of definePageMeta, the way it's already described [in the docs](https://nuxt.com/docs/getting-started/routing#route-validation).

Also unifies behaviour between client-side navigation and server-side navigation (calling route directly) for pages with validate methods that return an object.
- Previous behaviour:
  - Client-side navigation: showed 404 page
  - Server-side navigation: ended up in an infinte-loop and showed 500
- New behaviour:
  - Both: show error-page with defined status-code (404 as fallback)
<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
