### PR TITLE
fix(nuxt): do not provide default `prefetchOn` prop

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -253,10 +253,7 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
       },
       prefetchOn: {
         type: [String, Object] as PropType<NuxtLinkProps['prefetchOn']>,
-        default: options.prefetchOn || {
-          visibility: true,
-          interaction: false,
-        } satisfies NuxtLinkProps['prefetchOn'],
+        default: undefined,
         required: false,
       },
       noPrefetch: {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

We already respect createNuxtLink options for defaults here, so we don't need additional defaults.