### PR TITLE
fix(nuxt): don't wrap setup with runWithContext

### DIFF
--- a/packages/nuxt/src/app/composables/component.ts
+++ b/packages/nuxt/src/app/composables/component.ts
@@ -47,10 +47,11 @@ export const defineNuxtComponent: typeof defineComponent =
       _fetchKeyBase: key,
       ...options,
       setup (props, ctx) {
+        const nuxtApp = useNuxtApp()
         const res = setup ? Promise.resolve(setup(props, ctx)).then(r => r || {}) : {}
         const promises: Promise<any>[] = []
         if (options.asyncData) {
-          promises.push(runLegacyAsyncData(res, options.asyncData))
+          promises.push(nuxtApp.runWithContext(() => runLegacyAsyncData(res, options.asyncData)))
         }
 
         if (options.head) {

--- a/packages/nuxt/src/app/composables/component.ts
+++ b/packages/nuxt/src/app/composables/component.ts
@@ -48,7 +48,7 @@ export const defineNuxtComponent: typeof defineComponent =
       ...options,
       setup (props, ctx) {
         const res = setup ? setup(props, ctx) : {}
-
+        const result = Promise.resolve(res).then(() => res || {})
         const promises: Promise<any>[] = []
         if (options.asyncData) {
           promises.push(runLegacyAsyncData(res, options.asyncData))
@@ -59,9 +59,9 @@ export const defineNuxtComponent: typeof defineComponent =
           useHead(typeof options.head === 'function' ? () => options.head(nuxtApp) : options.head)
         }
 
-        return Promise.resolve(res)
+        return Promise.resolve(result)
           .then(() => Promise.all(promises))
-          .then(() => res)
+          .then(() => result)
           .finally(() => {
             promises.length = 0
           })

--- a/packages/nuxt/src/app/composables/component.ts
+++ b/packages/nuxt/src/app/composables/component.ts
@@ -47,8 +47,7 @@ export const defineNuxtComponent: typeof defineComponent =
       _fetchKeyBase: key,
       ...options,
       setup (props, ctx) {
-        const nuxtApp = useNuxtApp()
-        const res = setup ? Promise.resolve(nuxtApp.runWithContext(() => setup(props, ctx))).then(r => r || {}) : {}
+        const res = setup ? setup(props, ctx) : {}
 
         const promises: Promise<any>[] = []
         if (options.asyncData) {

--- a/packages/nuxt/src/app/composables/component.ts
+++ b/packages/nuxt/src/app/composables/component.ts
@@ -47,8 +47,7 @@ export const defineNuxtComponent: typeof defineComponent =
       _fetchKeyBase: key,
       ...options,
       setup (props, ctx) {
-        const res = setup ? setup(props, ctx) : {}
-        const result = Promise.resolve(res).then(() => res || {})
+        const res = setup ? Promise.resolve(setup(props, ctx)).then(r => r || {}) : {}
         const promises: Promise<any>[] = []
         if (options.asyncData) {
           promises.push(runLegacyAsyncData(res, options.asyncData))
@@ -59,9 +58,9 @@ export const defineNuxtComponent: typeof defineComponent =
           useHead(typeof options.head === 'function' ? () => options.head(nuxtApp) : options.head)
         }
 
-        return Promise.resolve(result)
+        return Promise.resolve(res)
           .then(() => Promise.all(promises))
-          .then(() => result)
+          .then(() => res)
           .finally(() => {
             promises.length = 0
           })


### PR DESCRIPTION
### 🔗 Linked issue

fix #28573 
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This PR removes the `runWithContext` wrapper around the setup function. 
The reason is that the setup function doesn't loose the vue context until `runWithContext`  which uses `callWithAsync` from unctx. It makes the setup function loose the vue context (there's probably a transformation in a promise somewhere).

#### TODO

- [ ] run a bunch of tests with K6 to make sure there's no X state pollution

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
