### PR TITLE
fix(schema): make serverDir only relative to root

### DIFF
--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -156,9 +156,7 @@ export default defineUntypedSchema({
    */
   serverDir: {
     $resolve: async (val: string | undefined, get): Promise<string> => {
-      const isV4 = ((await get('future') as Record<string, unknown>).compatibilityVersion === 4)
-
-      return resolve(isV4 ? await get('rootDir') as string : await get('srcDir') as string, val ?? 'server')
+      return resolve(await get('rootDir') as string, val ?? 'server')
     },
   },
 

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'node:fs'
 import { readdir } from 'node:fs/promises'
 import { defineUntypedSchema } from 'untyped'
-import { basename, relative, resolve } from 'pathe'
+import { basename, join, relative, resolve } from 'pathe'
 import { isDebug, isDevelopment, isTest } from 'std-env'
 import { defu } from 'defu'
 import { findWorkspaceDir } from 'pkg-types'
@@ -156,7 +156,12 @@ export default defineUntypedSchema({
    */
   serverDir: {
     $resolve: async (val: string | undefined, get): Promise<string> => {
-      return resolve(await get('rootDir') as string, val ?? 'server')
+      if (val) {
+        const rootDir = await get('rootDir') as string
+        return resolve(rootDir, val)
+      }
+      const isV4 = (await get('future') as Record<string, unknown>).compatibilityVersion === 4
+      return join(isV4 ? await get('rootDir') as string : await get('srcDir') as string, 'server')
     },
   },
 


### PR DESCRIPTION
### 🔗 Linked issue


resolves https://github.com/nuxt/nuxt/issues/28695
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description


This PR make server dir relative paths only relative to rootdir as stated in the doc
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
