### PR TITLE
feat(schema): enable devtools by default

### DIFF
--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -827,9 +827,11 @@ function createPortalProperties (sourceValue: any, options: NuxtOptions, paths: 
   }
 }
 
-const _getDefaultNuxtConfig = () => /* js */
-  `// https://nuxt.com/docs/api/configuration/nuxt-config
+const _getDefaultNuxtConfig = () => {
+  const todaysDate = formatDate(new Date())
+  return /* js */ `// https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
-  devtools: { enabled: true }
+  compatibilityDate: '${todaysDate}'
 })
 `
+}

--- a/packages/schema/src/config/adhoc.ts
+++ b/packages/schema/src/config/adhoc.ts
@@ -64,5 +64,7 @@ export default defineUntypedSchema({
    * @see  [Nuxt DevTools](https://devtools.nuxt.com/) for more information.
    * @type { { enabled: boolean, [key: string]: any } }
    */
-  devtools: {},
+  devtools: {
+    enabled: true,
+  },
 })


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This moves to make `devtools` enabled by default for v4+

(Let me know if you have any concerns at all about this approach.)