### PR TITLE
docs: fix typo

### DIFF
--- a/docs/2.guide/1.concepts/4.server-engine.md
+++ b/docs/2.guide/1.concepts/4.server-engine.md
@@ -7,7 +7,7 @@ While building Nuxt 3, we created a new server engine: [Nitro](https://nitro.unj
 
 It is shipped with many features:
 
-- Cross-platform support for Node.js, Browsers, service-workers and more.
+- Cross-platform support for Node.js, Browsers, Service Workers and more.
 - Serverless support out-of-the-box.
 - API routes support.
 - Automatic code-splitting and async-loaded chunks.

--- a/docs/2.guide/1.concepts/4.server-engine.md
+++ b/docs/2.guide/1.concepts/4.server-engine.md
@@ -7,7 +7,7 @@ While building Nuxt 3, we created a new server engine: [Nitro](https://nitro.unj
 
 It is shipped with many features:
 
-- Cross-platform support for Node.js, Browsers, Service Workers and more.
+- Cross-platform support for Node.js, browsers, service workers and more.
 - Serverless support out-of-the-box.
 - API routes support.
 - Automatic code-splitting and async-loaded chunks.


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

service workers are not written with hypen (-) service-workers. it is always written with two different words as far as I have seen. I think it should not be service-workers, rather it should be two different words, `Service Workers` like that.

https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers
https://web.dev/learn/pwa/service-workers/

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
