### PR TITLE
fix(nuxt): do not pass listeners to custom `NuxtLink`

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -381,13 +381,15 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
             replace: props.replace,
             ariaCurrentValue: props.ariaCurrentValue,
             custom: props.custom,
-            onPointerenter: shouldPrefetch('interaction') ? prefetch.bind(null, undefined) : undefined,
-            onFocus: shouldPrefetch('interaction') ? prefetch.bind(null, undefined) : undefined,
           }
 
           // `custom` API cannot support fallthrough attributes as the slot
           // may render fragment or text root nodes (#14897, #19375)
           if (!props.custom) {
+            if (shouldPrefetch('interaction')) {
+              routerLinkProps.onPointerenter = prefetch.bind(null, undefined)
+              routerLinkProps.onFocus = prefetch.bind(null, undefined)
+            }
             if (prefetched.value) {
               routerLinkProps.class = props.prefetchedClass || options.prefetchedClass
             }
@@ -427,6 +429,7 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
           return slots.default({
             href: href.value,
             navigate,
+            prefetch,
             get route () {
               if (!href.value) { return undefined }
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/28732
resolves https://github.com/primefaces/primevue/issues/6283

### 📚 Description

This avoids passing listeners to `RouterLink` if it's `custom` and instead passes `prefetch` through the slot.

