### PR TITLE
fix(nuxt): cookie composable does not propogate null to all refs

### DIFF
--- a/packages/nuxt/src/app/composables/cookie.ts
+++ b/packages/nuxt/src/app/composables/cookie.ts
@@ -104,8 +104,13 @@ export function useCookie<T = string | null | undefined> (name: string, _opts?: 
 
     if (store) {
       const changeHandler = (event: any) => {
+        // The cookieStore API does not include the cookies that have
+        // been set to null, so we need to check the cookies object
         const cookie = event.changed.find((c: any) => c.name === name)
-        if (cookie) { handleChange({ value: cookie.value }) }
+
+        if (cookie || cookies[name] !== null) {
+          handleChange({ value: cookie?.value ?? null })
+        }
       }
       store.addEventListener('change', changeHandler)
       if (hasScope) {

--- a/packages/nuxt/src/app/composables/cookie.ts
+++ b/packages/nuxt/src/app/composables/cookie.ts
@@ -103,13 +103,17 @@ export function useCookie<T = string | null | undefined> (name: string, _opts?: 
     }
 
     if (store) {
+      /* event is of type CookieChangeEvent */
       const changeHandler = (event: any) => {
-        // The cookieStore API does not include the cookies that have
-        // been set to null, so we need to check the cookies object
-        const cookie = event.changed.find((c: any) => c.name === name)
+        const changedCookie = event.changed.find((c: any) => c.name === name)
+        const removedCookie = event.deleted.find((c: any) => c.name === name)
 
-        if (cookie || cookies[name] !== null) {
-          handleChange({ value: cookie?.value ?? null })
+        if (changedCookie) {
+          handleChange({ value: changedCookie.value })
+        }
+
+        if (removedCookie) {
+          handleChange({ value: null })
         }
       }
       store.addEventListener('change', changeHandler)

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -640,7 +640,7 @@ describe('nuxt composables', () => {
       },
     })
     const cookies = res.headers.get('set-cookie')
-    expect(cookies).toMatchInlineSnapshot('"set-in-plugin=true; Path=/, accessed-with-default-value=default; Path=/, set=set; Path=/, browser-set=set; Path=/, browser-set-to-null=; Max-Age=0; Path=/, browser-set-to-null-with-default=; Max-Age=0; Path=/, browser-object-default=%7B%22foo%22%3A%22bar%22%7D; Path=/"')
+    expect(cookies).toMatchInlineSnapshot('"set-in-plugin=true; Path=/, accessed-with-default-value=default; Path=/, set=set; Path=/, browser-set=set; Path=/, browser-set-to-null=; Max-Age=0; Path=/, browser-set-to-null-with-default=; Max-Age=0; Path=/, browser-object-default=%7B%22foo%22%3A%22bar%22%7D; Path=/, theCookie=show; Path=/"')
   })
   it('updates cookies when they are changed', async () => {
     const { page } = await renderPage('/cookies')
@@ -660,6 +660,26 @@ describe('nuxt composables', () => {
     await page.getByText('Refresh cookie').click()
     text = await page.innerText('pre')
     expect(text).toContain('foobar')
+    await page.close()
+  })
+
+  it('sets cookies in composable to null in all components', async () => {
+    const { page } = await renderPage('/cookies')
+    const parentBannerText = await page.locator('#parent-banner').textContent()
+    expect(parentBannerText).toContain('parent banner')
+
+    const childBannerText = await page.locator('#child-banner').innerText()
+    expect(childBannerText).toContain('child banner')
+
+    // Clear the composable cookie
+    await page.getByText('Toggle cookie banner').click()
+    await page.evaluate(() => new Promise(resolve => setTimeout(resolve, 10)))
+
+    const parentBannerAfterToggle = await page.locator('#parent-banner').isVisible()
+    expect(parentBannerAfterToggle).toBe(false)
+
+    const childBannerAfterToggle = await page.locator('#child-banner').isVisible()
+    expect(childBannerAfterToggle).toBe(false)
     await page.close()
   })
 

--- a/test/fixtures/basic/components/ComponentUsingCookie.vue
+++ b/test/fixtures/basic/components/ComponentUsingCookie.vue
@@ -1,0 +1,14 @@
+<script setup>
+import { useCookieManager } from '../composables/cookie-manager'
+
+const { showCookieBanner } = useCookieManager()
+</script>
+
+<template>
+  <div
+    v-if="showCookieBanner"
+    id="child-banner"
+  >
+    child banner
+  </div>
+</template>

--- a/test/fixtures/basic/composables/cookie-manager.ts
+++ b/test/fixtures/basic/composables/cookie-manager.ts
@@ -1,0 +1,18 @@
+export function useCookieManager () {
+  const theCookie = useCookie<null | string>('theCookie', {
+    default: () => 'show',
+  })
+
+  const showCookieBanner = computed(() => {
+    return theCookie.value === 'show'
+  })
+
+  function toggle () {
+    theCookie.value = theCookie.value === 'show' ? null : 'show'
+  }
+
+  return {
+    showCookieBanner,
+    toggle,
+  }
+}

--- a/test/fixtures/basic/pages/cookies.vue
+++ b/test/fixtures/basic/pages/cookies.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+import CookieComponent from '../components/ComponentUsingCookie.vue'
+import { useCookieManager } from '../composables/cookie-manager'
+
 useCookie('accessed-but-not-used')
 useCookie('accessed-with-default-value', { default: () => 'default' })
 useCookie('set').value = 'set'
@@ -25,6 +28,8 @@ function changeCookie () {
     objectCookie.value!.foo = 'baz'
   }
 }
+
+const { showCookieBanner, toggle } = useCookieManager()
 </script>
 
 <template>
@@ -37,6 +42,17 @@ function changeCookie () {
     </button>
     <button @click="refreshCookie('browser-object-default')">
       Refresh cookie
+    </button>
+
+    <CookieComponent />
+    <div
+      v-if="showCookieBanner"
+      id="parent-banner"
+    >
+      parent banner
+    </div>
+    <button @click="toggle">
+      Toggle cookie banner
     </button>
   </div>
 </template>


### PR DESCRIPTION
### 🔗 Linked issue

resolves #28343

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

When `useCookie` is in a composable and used in different layers of pages/components. Calling `.value = null` from a parent layer does not unset the cookie in the children via the event listener.

The reason is that, in the event listener, the null'ed cookie is not included in the array of changes and therefor never updated in the ref, because it is not found by the `.find` call.

## Solution

Check in the `event.deleted` if the cookie was not removed or updated with a time in the past:

https://developer.mozilla.org/en-US/docs/Web/API/CookieChangeEvent/deleted

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
