### PR TITLE
perf(nuxt): use reducer array and avoid crashing if prototype is modified

### DIFF
--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -267,6 +267,7 @@ export function createNuxtApp (options: CreateOptions) {
       get vue () { return nuxtApp.vueApp.version },
     },
     payload: shallowReactive({
+      ...options.ssrContext?.payload || {},
       data: shallowReactive({}),
       state: reactive({}),
       once: new Set<string>(),
@@ -308,6 +309,20 @@ export function createNuxtApp (options: CreateOptions) {
 
   if (import.meta.server) {
     nuxtApp.payload.serverRendered = true
+  }
+
+  if (import.meta.server && nuxtApp.ssrContext) {
+    nuxtApp.payload.path = nuxtApp.ssrContext.url
+
+    // Expose nuxt to the renderContext
+    nuxtApp.ssrContext.nuxt = nuxtApp
+    nuxtApp.ssrContext.payload = nuxtApp.payload
+
+    // Expose client runtime-config to the payload
+    nuxtApp.ssrContext.config = {
+      public: nuxtApp.ssrContext.runtimeConfig.public,
+      app: nuxtApp.ssrContext.runtimeConfig.app,
+    }
   }
 
   if (import.meta.client) {
@@ -355,27 +370,6 @@ export function createNuxtApp (options: CreateOptions) {
   // Inject $nuxt
   defineGetter(nuxtApp.vueApp, '$nuxt', nuxtApp)
   defineGetter(nuxtApp.vueApp.config.globalProperties, '$nuxt', nuxtApp)
-
-  if (import.meta.server) {
-    if (nuxtApp.ssrContext) {
-      // Expose nuxt to the renderContext
-      nuxtApp.ssrContext.nuxt = nuxtApp
-      // Expose current path
-      nuxtApp.payload.path = nuxtApp.ssrContext.url
-    }
-    // Expose to server renderer to create payload
-    nuxtApp.ssrContext = nuxtApp.ssrContext || {} as any
-    if (nuxtApp.ssrContext!.payload) {
-      Object.assign(nuxtApp.payload, nuxtApp.ssrContext!.payload)
-    }
-    nuxtApp.ssrContext!.payload = nuxtApp.payload
-
-    // Expose client runtime-config to the payload
-    nuxtApp.ssrContext!.config = {
-      public: options.ssrContext!.runtimeConfig.public,
-      app: options.ssrContext!.runtimeConfig.app,
-    }
-  }
 
   // Listen to chunk load errors
   if (import.meta.client) {

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -360,8 +360,6 @@ export function createNuxtApp (options: CreateOptions) {
     if (nuxtApp.ssrContext) {
       // Expose nuxt to the renderContext
       nuxtApp.ssrContext.nuxt = nuxtApp
-      // Expose payload types
-      nuxtApp.ssrContext._payloadReducers = {}
       // Expose current path
       nuxtApp.payload.path = nuxtApp.ssrContext.url
     }

--- a/packages/nuxt/src/app/plugins/revive-payload.server.ts
+++ b/packages/nuxt/src/app/plugins/revive-payload.server.ts
@@ -6,25 +6,25 @@ import { defineNuxtPlugin } from '../nuxt'
 // @ts-expect-error Virtual file.
 import { componentIslands } from '#build/nuxt.config.mjs'
 
-const reducers: Record<string, (data: any) => any> = {
-  NuxtError: data => isNuxtError(data) && data.toJSON(),
-  EmptyShallowRef: data => isRef(data) && isShallow(data) && !data.value && (typeof data.value === 'bigint' ? '0n' : (JSON.stringify(data.value) || '_')),
-  EmptyRef: data => isRef(data) && !data.value && (typeof data.value === 'bigint' ? '0n' : (JSON.stringify(data.value) || '_')),
-  ShallowRef: data => isRef(data) && isShallow(data) && data.value,
-  ShallowReactive: data => isReactive(data) && isShallow(data) && toRaw(data),
-  Ref: data => isRef(data) && data.value,
-  Reactive: data => isReactive(data) && toRaw(data),
-}
+const reducers: [string, (data: any) => any][] = [
+  ['NuxtError', data => isNuxtError(data) && data.toJSON()],
+  ['EmptyShallowRef', data => isRef(data) && isShallow(data) && !data.value && (typeof data.value === 'bigint' ? '0n' : (JSON.stringify(data.value) || '_'))],
+  ['EmptyRef', data => isRef(data) && !data.value && (typeof data.value === 'bigint' ? '0n' : (JSON.stringify(data.value) || '_'))],
+  ['ShallowRef', data => isRef(data) && isShallow(data) && data.value],
+  ['ShallowReactive', data => isReactive(data) && isShallow(data) && toRaw(data)],
+  ['Ref', data => isRef(data) && data.value],
+  ['Reactive', data => isReactive(data) && toRaw(data)],
+]
 
 if (componentIslands) {
-  reducers.Island = data => data && data?.__nuxt_island
+  reducers.push(['Island', data => data && data?.__nuxt_island])
 }
 
 export default defineNuxtPlugin({
   name: 'nuxt:revive-payload:server',
   setup () {
-    for (const reducer in reducers) {
-      definePayloadReducer(reducer, reducers[reducer as keyof typeof reducers])
+    for (const [reducer, fn] of reducers) {
+      definePayloadReducer(reducer, fn)
     }
   },
 })

--- a/packages/nuxt/src/core/runtime/nitro/dev-server-logs.ts
+++ b/packages/nuxt/src/core/runtime/nitro/dev-server-logs.ts
@@ -77,7 +77,8 @@ export default (nitroApp: NitroApp) => {
     const ctx = asyncContext.tryUse()
     if (!ctx) { return }
     try {
-      htmlContext.bodyAppend.unshift(`<script type="application/json" data-nuxt-logs="${appId}">${stringify(ctx.logs, { ...devReducers, ...ctx.event.context._payloadReducers })}</script>`)
+      const reducers = Object.assign(Object.create(null), devReducers, ctx.event.context._payloadReducers)
+      htmlContext.bodyAppend.unshift(`<script type="application/json" data-nuxt-logs="${appId}">${stringify(ctx.logs, reducers)}</script>`)
     } catch (e) {
       const shortError = e instanceof Error && 'toString' in e ? ` Received \`${e.toString()}\`.` : ''
       console.warn(`[nuxt] Failed to stringify dev server logs.${shortError} You can define your own reducer/reviver for rich types following the instructions in https://nuxt.com/docs/api/composables/use-nuxt-app#payload.`)

--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -305,7 +305,7 @@ export default defineRenderHandler(async (event): Promise<Partial<RenderResponse
     error: !!ssrError,
     nuxt: undefined!, /* NuxtApp */
     payload: (ssrError ? { error: ssrError } : {}) as NuxtPayload,
-    _payloadReducers: {},
+    _payloadReducers: Object.create(null),
     modules: new Set(),
     islandContext,
   }


### PR DESCRIPTION
### 🔗 Linked issue

resolves  https://github.com/nuxt/nuxt/issues/28769

### 📚 Description

`devalue` iterates over all properties (including prototype properties) of reducers passed to it (see https://github.com/Rich-Harris/devalue/pull/80). There may possibly be some valid use cases where users modify an object prototype, and this PR ensures that a Nuxt server won't crash in this case.

Regardless, for clarity, I would advise against mutating prototypes - plenty of other things may well crash in this case, without it being a bug or issue.

thanks to @lirantal for the original issue and working through this with me ❤️ 