### PR TITLE
fix(nuxt): allow updating `appConfig` with non-iterable objects

### DIFF
--- a/packages/nuxt/src/app/config.ts
+++ b/packages/nuxt/src/app/config.ts
@@ -11,6 +11,15 @@ type DeepPartial<T> = T extends Function ? T : T extends Record<string, any> ? {
 // Workaround for vite HMR with virtual modules
 export const _getAppConfig = () => __appConfig as AppConfig
 
+function isPojoOrArray (val: unknown): val is object {
+  return (
+    Array.isArray(val) ||
+    (!!val &&
+      typeof val === 'object' &&
+      val.constructor?.name === 'Object')
+  )
+}
+
 function deepDelete (obj: any, newObj: any) {
   for (const key in obj) {
     const val = newObj[key]
@@ -18,7 +27,7 @@ function deepDelete (obj: any, newObj: any) {
       delete (obj as any)[key]
     }
 
-    if (val !== null && typeof val === 'object') {
+    if (isPojoOrArray(val)) {
       deepDelete(obj[key], newObj[key])
     }
   }
@@ -27,7 +36,7 @@ function deepDelete (obj: any, newObj: any) {
 function deepAssign (obj: any, newObj: any) {
   for (const key in newObj) {
     const val = newObj[key]
-    if (val !== null && typeof val === 'object') {
+    if (isPojoOrArray(val)) {
       const defaultVal = Array.isArray(val) ? [] : {}
       obj[key] = obj[key] || defaultVal
       deepAssign(obj[key], val)

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -31,23 +31,33 @@ registerEndpoint('/api/test', defineEventHandler(event => ({
 describe('app config', () => {
   it('can be updated', () => {
     const appConfig = useAppConfig()
-    expect(appConfig).toMatchInlineSnapshot(`
-      {
-        "nuxt": {},
-      }
-    `)
-    updateAppConfig({
+    expect(appConfig).toStrictEqual({ nuxt: {} })
+
+    type UpdateAppConfig = Parameters<typeof updateAppConfig>[0]
+
+    const initConfig: UpdateAppConfig = {
       new: 'value',
       nuxt: { nested: 42 },
+      regExp: /foo/g,
+      date: new Date(1111, 11, 11),
+      arr: [1, 2, 3],
+    }
+    updateAppConfig(initConfig)
+    expect(appConfig).toStrictEqual(initConfig)
+
+    const newConfig: UpdateAppConfig = {
+      nuxt: { anotherNested: 24 },
+      regExp: /bar/g,
+      date: new Date(2222, 12, 12),
+      arr: [4, 5],
+    }
+    updateAppConfig(newConfig)
+    expect(appConfig).toStrictEqual({
+      ...initConfig,
+      ...newConfig,
+      nuxt: { ...initConfig.nuxt, ...newConfig.nuxt },
+      arr: [4, 5, 3],
     })
-    expect(appConfig).toMatchInlineSnapshot(`
-      {
-        "new": "value",
-        "nuxt": {
-          "nested": 42,
-        },
-      }
-    `)
   })
 })
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves #28772

### 📚 Description

The bug occurred when calling `updateAppConfig` with **non-POJO objects**, e.g. `RegExp` or `Date`.

Let's say `val` is a `RegExp` (e.g. `val: /pattern/i`), here's what happened:
1. Inside `deepAssign()`, [`val !== null && typeof val === 'object'`](https://github.com/nuxt/nuxt/blob/c90631203447780c8c37dffc1134929198c693c9/packages/nuxt/src/app/config.ts#L30) was true.
2. Then, [`obj[key] = obj[key] || defaultVal`](https://github.com/nuxt/nuxt/blob/c90631203447780c8c37dffc1134929198c693c9/packages/nuxt/src/app/config.ts#L32): if the value didn't exist it was initialized to `{}`, otherwise it just copied from the previous value.
3. Then, the next [recursive `deepAssign()`](https://github.com/nuxt/nuxt/blob/c90631203447780c8c37dffc1134929198c693c9/packages/nuxt/src/app/config.ts#L33) was called, but **didn't have any effect** because `for (const key in newObj)` didn't run at all when `newObj` is not a POJO, like `RegExp` or `Date`. Therefore, the new value was set to either `{}` (if didn't exist previously) or the same previous value. It was not updated to the new value.

## Solution

I replaced [`val !== null && typeof val === 'object'`](https://github.com/nuxt/nuxt/blob/c90631203447780c8c37dffc1134929198c693c9/packages/nuxt/src/app/config.ts#L30) with a strictier check which returns _true_ only if the value is an Array or a POJO.
In all other cases (including RegExp or Date), that value will be successfully replaced [in the `else` block](https://github.com/nuxt/nuxt/blob/c90631203447780c8c37dffc1134929198c693c9/packages/nuxt/src/app/config.ts#L34-L36).

**Implementation:** to check if a value was a POJO, I used `val.constructor?.name === 'Object'` (ref [here](https://masteringjs.io/tutorials/fundamentals/pojo)), which will exclude objects created with `Object.create(null)` but I think it's negligible in our case.

I've also added some **tests** (`pnpm test:runtime`) regarding this:
- Now the "app config" test also includes a `RegExp` and a `Date`.
- I've also changed a little bit the assertion/expect behaviour: instead of `.toMatchInlineObject`, which was quite unpredictable with object order, I used `.toStrictEqual` which should do the same thing, i.e. strictly check all the object properties and throw an error even if there's one attribute more or missing ([docs](https://vitest.dev/api/expect.html#tostrictequal)).
- (Not related to this issue) I though it might be helpful to include an array in the test as well, since it has its own [merging strategy](https://nuxt.com/docs/guide/directory-structure/app-config#merging-strategy).