### PR TITLE
chore(nuxt): fix lint `console log/info` in nuxt core

### DIFF
--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -104,6 +104,7 @@ async function initNuxt (nuxt: Nuxt) {
 
     const shouldShowPrompt = nuxt.options.dev && hasTTY && !isCI
     if (!shouldShowPrompt) {
+      // eslint-disable-next-line no-console
       console.log(`Using \`${fallbackCompatibilityDate}\` as fallback compatibility date.`)
     }
 
@@ -113,6 +114,7 @@ async function initNuxt (nuxt: Nuxt) {
         default: true,
       })
       if (result !== true) {
+        // eslint-disable-next-line no-console
         console.log(`Using \`${fallbackCompatibilityDate}\` as fallback compatibility date.`)
         return
       }
@@ -147,6 +149,7 @@ async function initNuxt (nuxt: Nuxt) {
         consola.error(`Failed to update config: ${message}`)
       }
 
+      // eslint-disable-next-line no-console
       console.log(`Using \`${fallbackCompatibilityDate}\` as fallback compatibility date.`)
     }
 
@@ -156,6 +159,7 @@ async function initNuxt (nuxt: Nuxt) {
       nitro.hooks.hookOnce('compiled', () => {
         warnedAboutCompatDate = true
         // Print warning
+        // eslint-disable-next-line no-console
         console.info(`Nuxt now supports pinning the behavior of provider and deployment presets with a compatibility date. We recommend you specify a \`compatibilityDate\` in your \`nuxt.config\` file, or set an environment variable, such as \`COMPATIBILITY_DATE=${todaysDate}\`.`)
         if (shouldShowPrompt) { promptAndUpdate() }
       })
@@ -665,6 +669,7 @@ async function initNuxt (nuxt: Nuxt) {
   // Show compatibility version banner when Nuxt is running with a compatibility version
   // that is different from the current major version
   if (!(satisfies(nuxt._version, nuxt.options.future.compatibilityVersion + '.x'))) {
+    // eslint-disable-next-line no-console
     console.info(`Running with compatibility version \`${nuxt.options.future.compatibilityVersion}\``)
   }
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
NA

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
Running `pnpm lint` there are some console log/info in nuxt core module, this PR just adds `// eslint-disable-next-line no-console` to fix the lint script.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
