### PR TITLE
fix(nuxt): add missing trailing slash in cwd to update the correct nuxt.config.ts

### DIFF
--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs'
 import { rm } from 'node:fs/promises'
-import { join, normalize, relative, resolve } from 'pathe'
+import { join, normalize, sep as pathSep, relative, resolve } from 'pathe'
 import { createDebugger, createHooks } from 'hookable'
 import ignore from 'ignore'
 import type { LoadNuxtOptions } from '@nuxt/kit'
@@ -118,9 +118,13 @@ async function initNuxt (nuxt: Nuxt) {
       }
 
       try {
+        let cwd = normalize(nuxt.options.rootDir)
+        if (!cwd.endsWith(pathSep)) {
+          cwd += pathSep
+        }
         const res = await updateConfig({
           configFile: 'nuxt.config',
-          cwd: nuxt.options.rootDir,
+          cwd,
           async onCreate ({ configFile }) {
             const shallCreate = await consola.prompt(`Do you want to create ${colorize('cyan', relative(nuxt.options.rootDir, configFile))}?`, {
               type: 'confirm',
@@ -135,7 +139,6 @@ async function initNuxt (nuxt: Nuxt) {
             config.compatibilityDate = todaysDate
           },
         })
-
         if (res?.configFile) {
           nuxt.options.compatibilityDate = resolveCompatibilityDatesFromEnv(todaysDate)
           consola.success(`Compatibility date set to \`${todaysDate}\` in \`${relative(nuxt.options.rootDir, res.configFile)}\``)


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #28776

### 📚 Description

Added a trailing slash in the `cwd` option passed to the `updateConfig` function of `c12`. This allows updating the right `nuxt.config` file.

Prior to this change, when the `compatibilityDate` was missing in the `nuxt.config` file, the CLI updated the incorrect config file - i.e. it updated the config file in the parent directory. Refer to this video where I'm running the nuxt server in the `playground/` directory and it updated the config file present in the parent dir:

https://github.com/user-attachments/assets/575f8d0c-2563-4b91-be67-73de13893b24

With this change, the correct config file is updated. Refer:

https://github.com/user-attachments/assets/e36098bb-2052-43c1-af58-4668509e6614
