### PR TITLE
docs: fix postcss codeblock typo

### DIFF
--- a/docs/1.getting-started/4.styling.md
+++ b/docs/1.getting-started/4.styling.md
@@ -427,8 +427,8 @@ Nuxt comes with postcss built-in. You can configure it in your `nuxt.config` fil
 export default defineNuxtConfig({
   postcss: {
     plugins: {
-      'postcss-nested': {}
-      "postcss-custom-media": {}
+      'postcss-nested': {},
+      'postcss-custom-media': {}
     }
   }
 })


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Welcome back everyone!

Following google search I stumbled onto this https://github.com/nuxt/docs

Any way we could remove this from the google search, and I guess we could upgrade the readme there.

I think the right UX would be to have a link at the bottom or top of each doc page to the source markdown file for easier collaborating for newcomers.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
