### PR TITLE
feat: improve `isNuxtError()` type inference

### DIFF
--- a/packages/nuxt/src/app/composables/error.ts
+++ b/packages/nuxt/src/app/composables/error.ts
@@ -53,7 +53,7 @@ export const clearError = async (options: { redirect?: string } = {}) => {
 
 /** @since 3.0.0 */
 export const isNuxtError = <DataT = unknown>(
-  error?: string | object,
+  error: unknown,
 ): error is NuxtError<DataT> => !!error && typeof error === 'object' && NUXT_ERROR_SIGNATURE in error
 
 /** @since 3.0.0 */


### PR DESCRIPTION
### 🔗 Linked issue

resolves #28813

### 📚 Description

This PR will improve the type inference of `isNuxtError()`, **without changing its implementation at all**.

The change is a one-liner, very simple, but it offers several advantages:
- **Wider param type:** the runtime code is already resilient to all parameter types, so its type is set to `unknown` to improve DX and avoid casting.
- **Always infer type:** in this way, the type inference (`error is NuxtError<DataT>`) will always be applied after being asserted.
- **Mandatory param:** I thought it was good to avoid using `isNuxtError()` without a param, as it's not particularly meaningful on its own.