### PR TITLE
fix(schema): enable `propsDestructure` by default

### DIFF
--- a/packages/schema/src/config/app.ts
+++ b/packages/schema/src/config/app.ts
@@ -31,11 +31,10 @@ export default defineUntypedSchema({
     },
 
     /**
-     * Vue Experimental: Enable reactive destructure for `defineProps`
-     * @see [Vue RFC#502](https://github.com/vuejs/rfcs/discussions/502)
+     * Enable reactive destructure for `defineProps`
      * @type {boolean}
      */
-    propsDestructure: false,
+    propsDestructure: true,
   },
 
   /**


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

resolves https://github.com/nuxt/nuxt/issues/28829.

`propsDestructure` is now enabled by default.