### PR TITLE
fix(nuxt): render server errors with `ssr: false`

### DIFF
--- a/packages/nuxt/src/core/runtime/nitro/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/renderer.ts
@@ -158,9 +158,7 @@ const getSPARenderer = lazyCachedFunction(async () => {
   const renderToString = (ssrContext: NuxtSSRContext) => {
     const config = useRuntimeConfig(ssrContext.event)
     ssrContext.modules = ssrContext.modules || new Set<string>()
-    ssrContext!.payload = {
-      serverRendered: false,
-    }
+    ssrContext.payload.serverRendered = false
     ssrContext.config = {
       public: config.public,
       app: config.app,


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/28832

### 📚 Description

When rendering an error in SSR, such as hitting an API endpoint that throws an error, with `ssr: false` no error payload is passed to the client so the error page can be rendered there.

This fixes that issue by preserving the `payload.error` context.