### PR TITLE
fix(nuxt): ensure injected `route` has enumerable keys

### DIFF
--- a/packages/nuxt/src/app/components/route-provider.ts
+++ b/packages/nuxt/src/app/components/route-provider.ts
@@ -27,6 +27,7 @@ export const RouteProvider = defineComponent({
     for (const key in props.route) {
       Object.defineProperty(route, key, {
         get: () => previousKey === props.renderKey ? props.route[key as keyof RouteLocationNormalizedLoaded] : previousRoute[key as keyof RouteLocationNormalizedLoaded],
+        enumerable: true,
       })
     }
 

--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -122,6 +122,7 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
     for (const key in _route.value) {
       Object.defineProperty(route, key, {
         get: () => _route.value[key as keyof RouteLocation],
+        enumerable: true,
       })
     }
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/26691

### 📚 Description

Although accessing `route.<someValue>` would return the correct value, logging out `route` would appear to be an empty object, and reactivity tracking _might_ have been affected.

This ensures that the route object can be logged as expected.