### PR TITLE
fix(nuxt): call client legacy `asyncData` without overriding vue instance

### DIFF
--- a/packages/nuxt/src/app/composables/component.ts
+++ b/packages/nuxt/src/app/composables/component.ts
@@ -16,7 +16,7 @@ async function runLegacyAsyncData (res: Record<string, any> | Promise<Record<str
   const { fetchKey, _fetchKeyBase } = vm.proxy!.$options
   const key = (typeof fetchKey === 'function' ? fetchKey(() => '') : fetchKey) ||
     ([_fetchKeyBase, route.fullPath, route.matched.findIndex(r => Object.values(r.components || {}).includes(vm.type))].join(':'))
-  const { data, error } = await useAsyncData(`options:asyncdata:${key}`, () => nuxtApp.runWithContext(() => fn(nuxtApp)))
+  const { data, error } = await useAsyncData(`options:asyncdata:${key}`, () => import.meta.server ? nuxtApp.runWithContext(() => fn(nuxtApp)) : fn(nuxtApp))
   if (error.value) {
     throw createError(error.value)
   }


### PR DESCRIPTION
### 🔗 Linked issue

resolves #28650

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

When calling with `nuxtApp.runWithContext` we no longer have access to the underlying component, meaning we lose the route injected by Nuxt. It's safe to skip this on client as `nuxtApp` is passed directly to the `asyncData` function, and is also set globally.