### PR TITLE
feat(nuxt): warn if dups is deteced in layouts & pages

### DIFF
--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -169,7 +169,10 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
         logger.warn(`No layout name could be resolved for \`~/${relative(nuxt.options.srcDir, file)}\`. Bear in mind that \`index\` is ignored for the purpose of creating a layout name.`)
         continue
       }
-      app.layouts[name] = app.layouts[name] || { name, file }
+      if (app.layouts[name]) {
+        logger.warn(`Duplicate layout file detected: \`~/${relative(nuxt.options.srcDir, file)}\` overrides \`~/${relative(nuxt.options.srcDir, app.layouts[name].file)}\`.`)
+      }
+      app.layouts[name] = { name, file }
     }
   }
 


### PR DESCRIPTION
This PR adds warning logs when duplicate page or layout files are detected in different Nuxt layers. It enhances DX to help identify and resolve conflicts caused by files with the same relative paths.

Sample output logs:

![image](https://github.com/user-attachments/assets/7f3a14f4-ecf1-49fc-becf-ad2464a70c9e)