### PR TITLE
fix(nuxt): log more context of prerendering errors

### DIFF
--- a/packages/nuxt/src/core/runtime/nitro/error.ts
+++ b/packages/nuxt/src/core/runtime/nitro/error.ts
@@ -31,7 +31,7 @@ export default <NitroErrorHandler> async function errorhandler (error: H3Error, 
       error.fatal && '[fatal]',
       Number(errorObject.statusCode) !== 200 && `[${errorObject.statusCode}]`,
     ].filter(Boolean).join(' ')
-    console.error(tags, errorObject.message + '\n' + stack.map(l => '  ' + l.text).join('  \n'))
+    console.error(tags, (error.message || error.toString() || 'internal server error') + '\n' + stack.map(l => '  ' + l.text).join('  \n'))
   }
 
   if (event.handled) { return }
@@ -119,7 +119,7 @@ function normalizeError (error: any) {
   // Hide details of unhandled/fatal errors in production
   const hideDetails = !import.meta.dev && error.unhandled
 
-  const stack = hideDetails
+  const stack = hideDetails && !import.meta.prerender
     ? []
     : ((error.stack as string) || '')
         .split('\n')


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Previously, we were swallowing most content of prerendering errors just as we would in production. This PR does a couple of things:

1. it prints out the stack trace of errors when prerendering
2. it prints out the full error message on the console when prerendering + in production as opposed to the sanitised 'internal server error' which is a bit cryptic