### PR TITLE
fix(nuxt): ensure we process files in `buildDir` for auto-imports

### DIFF
--- a/packages/nuxt/src/imports/transform.ts
+++ b/packages/nuxt/src/imports/transform.ts
@@ -8,7 +8,7 @@ import { isJS, isVue } from '../core/utils'
 const NODE_MODULES_RE = /[\\/]node_modules[\\/]/
 const IMPORTS_RE = /(['"])#imports\1/
 
-export const TransformPlugin = createUnplugin(({ ctx, options, sourcemap }: { ctx: Unimport, options: Partial<ImportsOptions>, sourcemap?: boolean }) => {
+export const TransformPlugin = ({ ctx, options, sourcemap }: { ctx: Unimport, options: Partial<ImportsOptions>, sourcemap?: boolean }) => createUnplugin(() => {
   return {
     name: 'nuxt:imports-transform',
     enforce: 'post',

--- a/packages/nuxt/test/auto-imports.test.ts
+++ b/packages/nuxt/test/auto-imports.test.ts
@@ -22,7 +22,7 @@ describe('imports:transform', () => {
     imports,
   })
 
-  const transformPlugin = TransformPlugin.raw({ ctx, options: { transform: { exclude: [/node_modules/] } } }, { framework: 'rollup' }) as Plugin
+  const transformPlugin = TransformPlugin({ ctx, options: { transform: { exclude: [/node_modules/] } } }).raw({}, { framework: 'rollup' }) as Plugin
   const transform = async (source: string) => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
     const result = await (transformPlugin.transform! as Function).call({ error: null, warn: null } as any, source, '')


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

resolves https://github.com/nuxt/nuxt/issues/28891

In v4 compatibility mode, we were locating the build directory under `node_modules/` which was therefore not being processed by unimport. This changes that.