### PR TITLE
fix(nuxt): do not accept attrs on NuxtErrorBoundary

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-error-boundary.ts
+++ b/packages/nuxt/src/app/components/nuxt-error-boundary.ts
@@ -2,6 +2,8 @@ import { defineComponent, onErrorCaptured, ref } from 'vue'
 import { useNuxtApp } from '../nuxt'
 
 export default defineComponent({
+  name: 'NuxtErrorBoundary',
+  inheritAttrs: false,
   emits: {
     error (_error: unknown) {
       return true

--- a/packages/nuxt/src/app/components/nuxt-error-boundary.ts
+++ b/packages/nuxt/src/app/components/nuxt-error-boundary.ts
@@ -13,14 +13,16 @@ export default defineComponent({
     const error = ref<Error | null>(null)
     const nuxtApp = useNuxtApp()
 
-    onErrorCaptured((err, target, info) => {
-      if (import.meta.client && (!nuxtApp.isHydrating || !nuxtApp.payload.serverRendered)) {
-        emit('error', err)
-        nuxtApp.hooks.callHook('vue:error', err, target, info)
-        error.value = err
-        return false
-      }
-    })
+    if (import.meta.client) {
+      onErrorCaptured((err, target, info) => {
+        if (!nuxtApp.isHydrating || !nuxtApp.payload.serverRendered) {
+          emit('error', err)
+          nuxtApp.hooks.callHook('vue:error', err, target, info)
+          error.value = err
+          return false
+        }
+      })
+    }
 
     function clearError () {
       error.value = null


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/28879

### 📚 Description

Not entirely sure _why_ this just started occurring, but `<NuxtErrorBoundary>` is not meant to receive/pass down attrs, any more than `<ClientOnly>`, etc.

This updates the implementation.