### PR TITLE
perf(nuxt): remove interop default for dynamic components

### DIFF
--- a/docs/2.guide/4.recipes/1.custom-routing.md
+++ b/docs/2.guide/4.recipes/1.custom-routing.md
@@ -22,7 +22,7 @@ export default {
     {
       name: 'home',
       path: '/',
-      component: () => import('~/pages/home.vue').then(r => r.default || r)
+      component: () => import('~/pages/home.vue')
     }
   ],
 } satisfies RouterConfig

--- a/packages/nuxt/src/app/components/nuxt-error-page.vue
+++ b/packages/nuxt/src/app/components/nuxt-error-page.vue
@@ -40,10 +40,10 @@ const description = _error.message || _error.toString()
 const stack = import.meta.dev && !is404 ? _error.description || `<pre>${stacktrace}</pre>` : undefined
 
 // TODO: Investigate side-effect issue with imports
-const _Error404 = defineAsyncComponent(() => import('./error-404.vue').then(r => r.default || r))
+const _Error404 = defineAsyncComponent(() => import('./error-404.vue'))
 const _Error = import.meta.dev
-  ? defineAsyncComponent(() => import('./error-dev.vue').then(r => r.default || r))
-  : defineAsyncComponent(() => import('./error-500.vue').then(r => r.default || r))
+  ? defineAsyncComponent(() => import('./error-dev.vue'))
+  : defineAsyncComponent(() => import('./error-500.vue'))
 
 const ErrorTemplate = is404 ? _Error404 : _Error
 </script>

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -279,7 +279,7 @@ export const layoutTemplate: NuxtTemplate = {
   filename: 'layouts.mjs',
   getContents ({ app }) {
     const layoutsObject = genObjectFromRawEntries(Object.values(app.layouts).map(({ name, file }) => {
-      return [name, genDynamicImport(file, { interopDefault: true })]
+      return [name, genDynamicImport(file)]
     }))
     return [
       `export default ${layoutsObject}`,

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -521,7 +521,7 @@ export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = 
         metaImports.add(genImport(file, [{ name: 'default', as: pageImportName }]))
       }
 
-      const pageImport = page._sync && page.mode !== 'client' ? pageImportName : genDynamicImport(file, { interopDefault: true })
+      const pageImport = page._sync && page.mode !== 'client' ? pageImportName : genDynamicImport(file)
 
       const metaRoute: NormalizedRoute = {
         name: `${metaImportName}?.name ?? ${route.name}`,

--- a/packages/nuxt/test/__snapshots__/pages-override-meta-disabled.test.ts.snap
+++ b/packages/nuxt/test/__snapshots__/pages-override-meta-disabled.test.ts.snap
@@ -2,7 +2,7 @@
   "pushed route, skips generation from file": [
     {
       "alias": "["pushed-route-alias"].concat(mockMeta?.alias || [])",
-      "component": "() => import("pages/route-file.vue").then(m => m.default || m)",
+      "component": "() => import("pages/route-file.vue")",
       "meta": "{ ...(mockMeta || {}), ...{"someMetaData":true} }",
       "name": "mockMeta?.name ?? "pushed-route"",
       "path": "mockMeta?.path ?? "/"",
@@ -20,7 +20,7 @@
   "route.meta generated from file": [
     {
       "alias": "mockMeta?.alias || []",
-      "component": "() => import("pages/page-with-meta.vue").then(m => m.default || m)",
+      "component": "() => import("pages/page-with-meta.vue")",
       "meta": "{ ...(mockMeta || {}), ...{"test":1} }",
       "name": "mockMeta?.name ?? "page-with-meta"",
       "path": "mockMeta?.path ?? "/page-with-meta"",
@@ -30,7 +30,7 @@
   "should allow pages with `:` in their path": [
     {
       "alias": "mockMeta?.alias || []",
-      "component": "() => import("pages/test:name.vue").then(m => m.default || m)",
+      "component": "() => import("pages/test:name.vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "test:name"",
       "path": "mockMeta?.path ?? "/test\\:name"",
@@ -46,7 +46,7 @@
           "children": [
             {
               "alias": "mockMeta?.alias || []",
-              "component": "() => import("pages/param/index/index.vue").then(m => m.default || m)",
+              "component": "() => import("pages/param/index/index.vue")",
               "meta": "mockMeta || {}",
               "name": "mockMeta?.name ?? "param-index"",
               "path": "mockMeta?.path ?? """,
@@ -54,14 +54,14 @@
             },
             {
               "alias": "mockMeta?.alias || []",
-              "component": "() => import("layer/pages/param/index/sibling.vue").then(m => m.default || m)",
+              "component": "() => import("layer/pages/param/index/sibling.vue")",
               "meta": "mockMeta || {}",
               "name": "mockMeta?.name ?? "param-index-sibling"",
               "path": "mockMeta?.path ?? "sibling"",
               "redirect": "mockMeta?.redirect",
             },
           ],
-          "component": "() => import("layer/pages/param/index.vue").then(m => m.default || m)",
+          "component": "() => import("layer/pages/param/index.vue")",
           "meta": "mockMeta || {}",
           "name": "mockMeta?.name ?? undefined",
           "path": "mockMeta?.path ?? """,
@@ -69,14 +69,14 @@
         },
         {
           "alias": "mockMeta?.alias || []",
-          "component": "() => import("pages/param/sibling.vue").then(m => m.default || m)",
+          "component": "() => import("pages/param/sibling.vue")",
           "meta": "mockMeta || {}",
           "name": "mockMeta?.name ?? "param-sibling"",
           "path": "mockMeta?.path ?? "sibling"",
           "redirect": "mockMeta?.redirect",
         },
       ],
-      "component": "() => import("pages/param.vue").then(m => m.default || m)",
+      "component": "() => import("pages/param.vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? undefined",
       "path": "mockMeta?.path ?? "/param"",
@@ -87,7 +87,7 @@
       "children": [
         {
           "alias": "mockMeta?.alias || []",
-          "component": "() => import("layer/pages/wrapper-expose/other/index.vue").then(m => m.default || m)",
+          "component": "() => import("layer/pages/wrapper-expose/other/index.vue")",
           "meta": "mockMeta || {}",
           "name": "mockMeta?.name ?? "wrapper-expose-other"",
           "path": "mockMeta?.path ?? """,
@@ -95,14 +95,14 @@
         },
         {
           "alias": "mockMeta?.alias || []",
-          "component": "() => import("pages/wrapper-expose/other/sibling.vue").then(m => m.default || m)",
+          "component": "() => import("pages/wrapper-expose/other/sibling.vue")",
           "meta": "mockMeta || {}",
           "name": "mockMeta?.name ?? "wrapper-expose-other-sibling"",
           "path": "mockMeta?.path ?? "sibling"",
           "redirect": "mockMeta?.redirect",
         },
       ],
-      "component": "() => import("pages/wrapper-expose/other.vue").then(m => m.default || m)",
+      "component": "() => import("pages/wrapper-expose/other.vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? undefined",
       "path": "mockMeta?.path ?? "/wrapper-expose/other"",
@@ -112,7 +112,7 @@
   "should extract serializable values and override fallback when normalized with `overrideMeta: true`": [
     {
       "alias": "["sweet-home"].concat(mockMeta?.alias || [])",
-      "component": "() => import("pages/index.vue").then(m => m.default || m)",
+      "component": "() => import("pages/index.vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "home"",
       "path": "mockMeta?.path ?? "/"",
@@ -122,7 +122,7 @@
   "should generate correct catch-all route": [
     {
       "alias": "mockMeta?.alias || []",
-      "component": "() => import("pages/[...slug].vue").then(m => m.default || m)",
+      "component": "() => import("pages/[...slug].vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "slug"",
       "path": "mockMeta?.path ?? "/:slug(.*)*"",
@@ -130,7 +130,7 @@
     },
     {
       "alias": "mockMeta?.alias || []",
-      "component": "() => import("pages/index.vue").then(m => m.default || m)",
+      "component": "() => import("pages/index.vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "index"",
       "path": "mockMeta?.path ?? "/"",
@@ -140,7 +140,7 @@
   "should generate correct dynamic routes": [
     {
       "alias": "mockMeta?.alias || []",
-      "component": "() => import("pages/index.vue").then(m => m.default || m)",
+      "component": "() => import("pages/index.vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "index"",
       "path": "mockMeta?.path ?? "/"",
@@ -148,7 +148,7 @@
     },
     {
       "alias": "mockMeta?.alias || []",
-      "component": "() => import("pages/[slug].vue").then(m => m.default || m)",
+      "component": "() => import("pages/[slug].vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "slug"",
       "path": "mockMeta?.path ?? "/:slug()"",
@@ -159,14 +159,14 @@
       "children": [
         {
           "alias": "mockMeta?.alias || []",
-          "component": "() => import("pages/[[foo]]/index.vue").then(m => m.default || m)",
+          "component": "() => import("pages/[[foo]]/index.vue")",
           "meta": "mockMeta || {}",
           "name": "mockMeta?.name ?? "foo"",
           "path": "mockMeta?.path ?? """,
           "redirect": "mockMeta?.redirect",
         },
       ],
-      "component": "() => import("pages/[[foo]]").then(m => m.default || m)",
+      "component": "() => import("pages/[[foo]]")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? undefined",
       "path": "mockMeta?.path ?? "/:foo?"",
@@ -174,7 +174,7 @@
     },
     {
       "alias": "mockMeta?.alias || []",
-      "component": "() => import("pages/optional/[[opt]].vue").then(m => m.default || m)",
+      "component": "() => import("pages/optional/[[opt]].vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "optional-opt"",
       "path": "mockMeta?.path ?? "/optional/:opt?"",
@@ -182,7 +182,7 @@
     },
     {
       "alias": "mockMeta?.alias || []",
-      "component": "() => import("pages/optional/prefix-[[opt]].vue").then(m => m.default || m)",
+      "component": "() => import("pages/optional/prefix-[[opt]].vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "optional-prefix-opt"",
       "path": "mockMeta?.path ?? "/optional/prefix-:opt?"",
@@ -190,7 +190,7 @@
     },
     {
       "alias": "mockMeta?.alias || []",
-      "component": "() => import("pages/optional/[[opt]]-postfix.vue").then(m => m.default || m)",
+      "component": "() => import("pages/optional/[[opt]]-postfix.vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "optional-opt-postfix"",
       "path": "mockMeta?.path ?? "/optional/:opt?-postfix"",
@@ -198,7 +198,7 @@
     },
     {
       "alias": "mockMeta?.alias || []",
-      "component": "() => import("pages/optional/prefix-[[opt]]-postfix.vue").then(m => m.default || m)",
+      "component": "() => import("pages/optional/prefix-[[opt]]-postfix.vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "optional-prefix-opt-postfix"",
       "path": "mockMeta?.path ?? "/optional/prefix-:opt?-postfix"",
@@ -206,7 +206,7 @@
     },
     {
       "alias": "mockMeta?.alias || []",
-      "component": "() => import("pages/[bar]/index.vue").then(m => m.default || m)",
+      "component": "() => import("pages/[bar]/index.vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "bar"",
       "path": "mockMeta?.path ?? "/:bar()"",
@@ -214,7 +214,7 @@
     },
     {
       "alias": "mockMeta?.alias || []",
-      "component": "() => import("pages/nonopt/[slug].vue").then(m => m.default || m)",
+      "component": "() => import("pages/nonopt/[slug].vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "nonopt-slug"",
       "path": "mockMeta?.path ?? "/nonopt/:slug()"",
@@ -222,7 +222,7 @@
     },
     {
       "alias": "mockMeta?.alias || []",
-      "component": "() => import("pages/opt/[[slug]].vue").then(m => m.default || m)",
+      "component": "() => import("pages/opt/[[slug]].vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "opt-slug"",
       "path": "mockMeta?.path ?? "/opt/:slug?"",
@@ -230,7 +230,7 @@
     },
     {
       "alias": "mockMeta?.alias || []",
-      "component": "() => import("pages/[[sub]]/route-[slug].vue").then(m => m.default || m)",
+      "component": "() => import("pages/[[sub]]/route-[slug].vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "sub-route-slug"",
       "path": "mockMeta?.path ?? "/:sub?/route-:slug()"",
@@ -240,7 +240,7 @@
   "should generate correct id for catchall (order 1)": [
     {
       "alias": "mockMeta?.alias || []",
-      "component": "() => import("pages/[...stories].vue").then(m => m.default || m)",
+      "component": "() => import("pages/[...stories].vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "stories"",
       "path": "mockMeta?.path ?? "/:stories(.*)*"",
@@ -248,7 +248,7 @@
     },
     {
       "alias": "mockMeta?.alias || []",
-      "component": "() => import("pages/stories/[id].vue").then(m => m.default || m)",
+      "component": "() => import("pages/stories/[id].vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "stories-id"",
       "path": "mockMeta?.path ?? "/stories/:id()"",
@@ -258,7 +258,7 @@
   "should generate correct id for catchall (order 2)": [
     {
       "alias": "mockMeta?.alias || []",
-      "component": "() => import("pages/stories/[id].vue").then(m => m.default || m)",
+      "component": "() => import("pages/stories/[id].vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "stories-id"",
       "path": "mockMeta?.path ?? "/stories/:id()"",
@@ -266,7 +266,7 @@
     },
     {
       "alias": "mockMeta?.alias || []",
-      "component": "() => import("pages/[...stories].vue").then(m => m.default || m)",
+      "component": "() => import("pages/[...stories].vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "stories"",
       "path": "mockMeta?.path ?? "/:stories(.*)*"",
@@ -276,7 +276,7 @@
   "should generate correct route for kebab-case file": [
     {
       "alias": "mockMeta?.alias || []",
-      "component": "() => import("pages/kebab-case.vue").then(m => m.default || m)",
+      "component": "() => import("pages/kebab-case.vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "kebab-case"",
       "path": "mockMeta?.path ?? "/kebab-case"",
@@ -286,7 +286,7 @@
   "should generate correct route for snake_case file": [
     {
       "alias": "mockMeta?.alias || []",
-      "component": "() => import("pages/snake_case.vue").then(m => m.default || m)",
+      "component": "() => import("pages/snake_case.vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "snake_case"",
       "path": "mockMeta?.path ?? "/snake_case"",
@@ -296,7 +296,7 @@
   "should generate correct routes for index pages": [
     {
       "alias": "mockMeta?.alias || []",
-      "component": "() => import("pages/index.vue").then(m => m.default || m)",
+      "component": "() => import("pages/index.vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "index"",
       "path": "mockMeta?.path ?? "/"",
@@ -304,7 +304,7 @@
     },
     {
       "alias": "mockMeta?.alias || []",
-      "component": "() => import("pages/parent/index.vue").then(m => m.default || m)",
+      "component": "() => import("pages/parent/index.vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "parent"",
       "path": "mockMeta?.path ?? "/parent"",
@@ -312,7 +312,7 @@
     },
     {
       "alias": "mockMeta?.alias || []",
-      "component": "() => import("pages/parent/child/index.vue").then(m => m.default || m)",
+      "component": "() => import("pages/parent/child/index.vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "parent-child"",
       "path": "mockMeta?.path ?? "/parent/child"",
@@ -325,14 +325,14 @@
       "children": [
         {
           "alias": "mockMeta?.alias || []",
-          "component": "() => import("pages/parent/child.vue").then(m => m.default || m)",
+          "component": "() => import("pages/parent/child.vue")",
           "meta": "mockMeta || {}",
           "name": "mockMeta?.name ?? "parent-child"",
           "path": "mockMeta?.path ?? "child"",
           "redirect": "mockMeta?.redirect",
         },
       ],
-      "component": "() => import("pages/parent.vue").then(m => m.default || m)",
+      "component": "() => import("pages/parent.vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "parent"",
       "path": "mockMeta?.path ?? "/parent"",
@@ -342,7 +342,7 @@
   "should handle route groups": [
     {
       "alias": "mockMeta?.alias || []",
-      "component": "() => import("pages/(foo)/index.vue").then(m => m.default || m)",
+      "component": "() => import("pages/(foo)/index.vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "index"",
       "path": "mockMeta?.path ?? "/"",
@@ -353,14 +353,14 @@
       "children": [
         {
           "alias": "mockMeta?.alias || []",
-          "component": "() => import("pages/(bar)/about/index.vue").then(m => m.default || m)",
+          "component": "() => import("pages/(bar)/about/index.vue")",
           "meta": "mockMeta || {}",
           "name": "mockMeta?.name ?? "about"",
           "path": "mockMeta?.path ?? """,
           "redirect": "mockMeta?.redirect",
         },
       ],
-      "component": "() => import("pages/(foo)/about.vue").then(m => m.default || m)",
+      "component": "() => import("pages/(foo)/about.vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? undefined",
       "path": "mockMeta?.path ?? "/about"",
@@ -373,14 +373,14 @@
       "children": [
         {
           "alias": "mockMeta?.alias || []",
-          "component": "() => import("pages/index/index/all.vue").then(m => m.default || m)",
+          "component": "() => import("pages/index/index/all.vue")",
           "meta": "mockMeta || {}",
           "name": "mockMeta?.name ?? "index-index-all"",
           "path": "mockMeta?.path ?? "all"",
           "redirect": "mockMeta?.redirect",
         },
       ],
-      "component": "() => import("pages/index/index.vue").then(m => m.default || m)",
+      "component": "() => import("pages/index/index.vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "index"",
       "path": "mockMeta?.path ?? "/"",
@@ -390,7 +390,7 @@
   "should merge route.meta with meta from file": [
     {
       "alias": "mockMeta?.alias || []",
-      "component": "() => import("pages/page-with-meta.vue").then(m => m.default || m)",
+      "component": "() => import("pages/page-with-meta.vue")",
       "meta": "{ ...(mockMeta || {}), ...{"test":1} }",
       "name": "mockMeta?.name ?? "page-with-meta"",
       "path": "mockMeta?.path ?? "/page-with-meta"",
@@ -400,7 +400,7 @@
   "should not generate colliding route names when hyphens are in file name": [
     {
       "alias": "mockMeta?.alias || []",
-      "component": "() => import("pages/parent/[child].vue").then(m => m.default || m)",
+      "component": "() => import("pages/parent/[child].vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "parent-child"",
       "path": "mockMeta?.path ?? "/parent/:child()"",
@@ -408,7 +408,7 @@
     },
     {
       "alias": "mockMeta?.alias || []",
-      "component": "() => import("pages/parent-[child].vue").then(m => m.default || m)",
+      "component": "() => import("pages/parent-[child].vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "parent-child"",
       "path": "mockMeta?.path ?? "/parent-:child()"",
@@ -418,7 +418,7 @@
   "should not merge required param as a child of optional param": [
     {
       "alias": "mockMeta?.alias || []",
-      "component": "() => import("pages/[[foo]].vue").then(m => m.default || m)",
+      "component": "() => import("pages/[[foo]].vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "foo"",
       "path": "mockMeta?.path ?? "/:foo?"",
@@ -426,7 +426,7 @@
     },
     {
       "alias": "mockMeta?.alias || []",
-      "component": "() => import("pages/[foo].vue").then(m => m.default || m)",
+      "component": "() => import("pages/[foo].vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "foo"",
       "path": "mockMeta?.path ?? "/:foo()"",
@@ -436,7 +436,7 @@
   "should only allow "_" & "." as special character for dynamic route": [
     {
       "alias": "mockMeta?.alias || []",
-      "component": "() => import("pages/[a1_1a].vue").then(m => m.default || m)",
+      "component": "() => import("pages/[a1_1a].vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "a1_1a"",
       "path": "mockMeta?.path ?? "/:a1_1a()"",
@@ -444,7 +444,7 @@
     },
     {
       "alias": "mockMeta?.alias || []",
-      "component": "() => import("pages/[b2.2b].vue").then(m => m.default || m)",
+      "component": "() => import("pages/[b2.2b].vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "b2.2b"",
       "path": "mockMeta?.path ?? "/:b2.2b()"",
@@ -452,7 +452,7 @@
     },
     {
       "alias": "mockMeta?.alias || []",
-      "component": "() => import("pages/[b2]_[2b].vue").then(m => m.default || m)",
+      "component": "() => import("pages/[b2]_[2b].vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "b2_2b"",
       "path": "mockMeta?.path ?? "/:b2()_:2b()"",
@@ -460,7 +460,7 @@
     },
     {
       "alias": "mockMeta?.alias || []",
-      "component": "() => import("pages/[[c3@3c]].vue").then(m => m.default || m)",
+      "component": "() => import("pages/[[c3@3c]].vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "c33c"",
       "path": "mockMeta?.path ?? "/:c33c?"",
@@ -468,7 +468,7 @@
     },
     {
       "alias": "mockMeta?.alias || []",
-      "component": "() => import("pages/[[d4-4d]].vue").then(m => m.default || m)",
+      "component": "() => import("pages/[[d4-4d]].vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "d44d"",
       "path": "mockMeta?.path ?? "/:d44d?"",
@@ -478,7 +478,7 @@
   "should properly override route name if definePageMeta name override is defined.": [
     {
       "alias": "mockMeta?.alias || []",
-      "component": "() => import("pages/index.vue").then(m => m.default || m)",
+      "component": "() => import("pages/index.vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "home"",
       "path": "mockMeta?.path ?? "/"",
@@ -488,7 +488,7 @@
   "should use fallbacks when normalized with `overrideMeta: true`": [
     {
       "alias": "mockMeta?.alias || []",
-      "component": "() => import("pages/index.vue").then(m => m.default || m)",
+      "component": "() => import("pages/index.vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "index"",
       "path": "mockMeta?.path ?? "/"",

--- a/packages/nuxt/test/__snapshots__/pages-override-meta-enabled.test.ts.snap
+++ b/packages/nuxt/test/__snapshots__/pages-override-meta-enabled.test.ts.snap
@@ -2,7 +2,7 @@
   "pushed route, skips generation from file": [
     {
       "alias": "["pushed-route-alias"]",
-      "component": "() => import("pages/route-file.vue").then(m => m.default || m)",
+      "component": "() => import("pages/route-file.vue")",
       "meta": "{"someMetaData":true}",
       "name": ""pushed-route"",
       "path": ""/"",
@@ -18,7 +18,7 @@
   ],
   "route.meta generated from file": [
     {
-      "component": "() => import("pages/page-with-meta.vue").then(m => m.default || m)",
+      "component": "() => import("pages/page-with-meta.vue")",
       "meta": "{"test":1}",
       "name": ""page-with-meta"",
       "path": ""/page-with-meta"",
@@ -26,7 +26,7 @@
   ],
   "should allow pages with `:` in their path": [
     {
-      "component": "() => import("pages/test:name.vue").then(m => m.default || m)",
+      "component": "() => import("pages/test:name.vue")",
       "name": ""test:name"",
       "path": ""/test\\:name"",
     },
@@ -37,44 +37,44 @@
         {
           "children": [
             {
-              "component": "() => import("pages/param/index/index.vue").then(m => m.default || m)",
+              "component": "() => import("pages/param/index/index.vue")",
               "name": ""param-index"",
               "path": """",
             },
             {
-              "component": "() => import("layer/pages/param/index/sibling.vue").then(m => m.default || m)",
+              "component": "() => import("layer/pages/param/index/sibling.vue")",
               "name": ""param-index-sibling"",
               "path": ""sibling"",
             },
           ],
-          "component": "() => import("layer/pages/param/index.vue").then(m => m.default || m)",
+          "component": "() => import("layer/pages/param/index.vue")",
           "name": "mockMeta?.name",
           "path": """",
         },
         {
-          "component": "() => import("pages/param/sibling.vue").then(m => m.default || m)",
+          "component": "() => import("pages/param/sibling.vue")",
           "name": ""param-sibling"",
           "path": ""sibling"",
         },
       ],
-      "component": "() => import("pages/param.vue").then(m => m.default || m)",
+      "component": "() => import("pages/param.vue")",
       "name": "mockMeta?.name",
       "path": ""/param"",
     },
     {
       "children": [
         {
-          "component": "() => import("layer/pages/wrapper-expose/other/index.vue").then(m => m.default || m)",
+          "component": "() => import("layer/pages/wrapper-expose/other/index.vue")",
           "name": ""wrapper-expose-other"",
           "path": """",
         },
         {
-          "component": "() => import("pages/wrapper-expose/other/sibling.vue").then(m => m.default || m)",
+          "component": "() => import("pages/wrapper-expose/other/sibling.vue")",
           "name": ""wrapper-expose-other-sibling"",
           "path": ""sibling"",
         },
       ],
-      "component": "() => import("pages/wrapper-expose/other.vue").then(m => m.default || m)",
+      "component": "() => import("pages/wrapper-expose/other.vue")",
       "name": "mockMeta?.name",
       "path": ""/wrapper-expose/other"",
     },
@@ -82,7 +82,7 @@
   "should extract serializable values and override fallback when normalized with `overrideMeta: true`": [
     {
       "alias": "["sweet-home"]",
-      "component": "() => import("pages/index.vue").then(m => m.default || m)",
+      "component": "() => import("pages/index.vue")",
       "meta": "mockMeta || {}",
       "name": ""home"",
       "path": ""/"",
@@ -91,131 +91,131 @@
   ],
   "should generate correct catch-all route": [
     {
-      "component": "() => import("pages/[...slug].vue").then(m => m.default || m)",
+      "component": "() => import("pages/[...slug].vue")",
       "name": ""slug"",
       "path": ""/:slug(.*)*"",
     },
     {
-      "component": "() => import("pages/index.vue").then(m => m.default || m)",
+      "component": "() => import("pages/index.vue")",
       "name": ""index"",
       "path": ""/"",
     },
   ],
   "should generate correct dynamic routes": [
     {
-      "component": "() => import("pages/index.vue").then(m => m.default || m)",
+      "component": "() => import("pages/index.vue")",
       "name": ""index"",
       "path": ""/"",
     },
     {
-      "component": "() => import("pages/[slug].vue").then(m => m.default || m)",
+      "component": "() => import("pages/[slug].vue")",
       "name": ""slug"",
       "path": ""/:slug()"",
     },
     {
       "children": [
         {
-          "component": "() => import("pages/[[foo]]/index.vue").then(m => m.default || m)",
+          "component": "() => import("pages/[[foo]]/index.vue")",
           "name": ""foo"",
           "path": """",
         },
       ],
-      "component": "() => import("pages/[[foo]]").then(m => m.default || m)",
+      "component": "() => import("pages/[[foo]]")",
       "name": "mockMeta?.name",
       "path": ""/:foo?"",
     },
     {
-      "component": "() => import("pages/optional/[[opt]].vue").then(m => m.default || m)",
+      "component": "() => import("pages/optional/[[opt]].vue")",
       "name": ""optional-opt"",
       "path": ""/optional/:opt?"",
     },
     {
-      "component": "() => import("pages/optional/prefix-[[opt]].vue").then(m => m.default || m)",
+      "component": "() => import("pages/optional/prefix-[[opt]].vue")",
       "name": ""optional-prefix-opt"",
       "path": ""/optional/prefix-:opt?"",
     },
     {
-      "component": "() => import("pages/optional/[[opt]]-postfix.vue").then(m => m.default || m)",
+      "component": "() => import("pages/optional/[[opt]]-postfix.vue")",
       "name": ""optional-opt-postfix"",
       "path": ""/optional/:opt?-postfix"",
     },
     {
-      "component": "() => import("pages/optional/prefix-[[opt]]-postfix.vue").then(m => m.default || m)",
+      "component": "() => import("pages/optional/prefix-[[opt]]-postfix.vue")",
       "name": ""optional-prefix-opt-postfix"",
       "path": ""/optional/prefix-:opt?-postfix"",
     },
     {
-      "component": "() => import("pages/[bar]/index.vue").then(m => m.default || m)",
+      "component": "() => import("pages/[bar]/index.vue")",
       "name": ""bar"",
       "path": ""/:bar()"",
     },
     {
-      "component": "() => import("pages/nonopt/[slug].vue").then(m => m.default || m)",
+      "component": "() => import("pages/nonopt/[slug].vue")",
       "name": ""nonopt-slug"",
       "path": ""/nonopt/:slug()"",
     },
     {
-      "component": "() => import("pages/opt/[[slug]].vue").then(m => m.default || m)",
+      "component": "() => import("pages/opt/[[slug]].vue")",
       "name": ""opt-slug"",
       "path": ""/opt/:slug?"",
     },
     {
-      "component": "() => import("pages/[[sub]]/route-[slug].vue").then(m => m.default || m)",
+      "component": "() => import("pages/[[sub]]/route-[slug].vue")",
       "name": ""sub-route-slug"",
       "path": ""/:sub?/route-:slug()"",
     },
   ],
   "should generate correct id for catchall (order 1)": [
     {
-      "component": "() => import("pages/[...stories].vue").then(m => m.default || m)",
+      "component": "() => import("pages/[...stories].vue")",
       "name": ""stories"",
       "path": ""/:stories(.*)*"",
     },
     {
-      "component": "() => import("pages/stories/[id].vue").then(m => m.default || m)",
+      "component": "() => import("pages/stories/[id].vue")",
       "name": ""stories-id"",
       "path": ""/stories/:id()"",
     },
   ],
   "should generate correct id for catchall (order 2)": [
     {
-      "component": "() => import("pages/stories/[id].vue").then(m => m.default || m)",
+      "component": "() => import("pages/stories/[id].vue")",
       "name": ""stories-id"",
       "path": ""/stories/:id()"",
     },
     {
-      "component": "() => import("pages/[...stories].vue").then(m => m.default || m)",
+      "component": "() => import("pages/[...stories].vue")",
       "name": ""stories"",
       "path": ""/:stories(.*)*"",
     },
   ],
   "should generate correct route for kebab-case file": [
     {
-      "component": "() => import("pages/kebab-case.vue").then(m => m.default || m)",
+      "component": "() => import("pages/kebab-case.vue")",
       "name": ""kebab-case"",
       "path": ""/kebab-case"",
     },
   ],
   "should generate correct route for snake_case file": [
     {
-      "component": "() => import("pages/snake_case.vue").then(m => m.default || m)",
+      "component": "() => import("pages/snake_case.vue")",
       "name": ""snake_case"",
       "path": ""/snake_case"",
     },
   ],
   "should generate correct routes for index pages": [
     {
-      "component": "() => import("pages/index.vue").then(m => m.default || m)",
+      "component": "() => import("pages/index.vue")",
       "name": ""index"",
       "path": ""/"",
     },
     {
-      "component": "() => import("pages/parent/index.vue").then(m => m.default || m)",
+      "component": "() => import("pages/parent/index.vue")",
       "name": ""parent"",
       "path": ""/parent"",
     },
     {
-      "component": "() => import("pages/parent/child/index.vue").then(m => m.default || m)",
+      "component": "() => import("pages/parent/child/index.vue")",
       "name": ""parent-child"",
       "path": ""/parent/child"",
     },
@@ -224,31 +224,31 @@
     {
       "children": [
         {
-          "component": "() => import("pages/parent/child.vue").then(m => m.default || m)",
+          "component": "() => import("pages/parent/child.vue")",
           "name": ""parent-child"",
           "path": ""child"",
         },
       ],
-      "component": "() => import("pages/parent.vue").then(m => m.default || m)",
+      "component": "() => import("pages/parent.vue")",
       "name": ""parent"",
       "path": ""/parent"",
     },
   ],
   "should handle route groups": [
     {
-      "component": "() => import("pages/(foo)/index.vue").then(m => m.default || m)",
+      "component": "() => import("pages/(foo)/index.vue")",
       "name": ""index"",
       "path": ""/"",
     },
     {
       "children": [
         {
-          "component": "() => import("pages/(bar)/about/index.vue").then(m => m.default || m)",
+          "component": "() => import("pages/(bar)/about/index.vue")",
           "name": ""about"",
           "path": """",
         },
       ],
-      "component": "() => import("pages/(foo)/about.vue").then(m => m.default || m)",
+      "component": "() => import("pages/(foo)/about.vue")",
       "name": "mockMeta?.name",
       "path": ""/about"",
     },
@@ -257,19 +257,19 @@
     {
       "children": [
         {
-          "component": "() => import("pages/index/index/all.vue").then(m => m.default || m)",
+          "component": "() => import("pages/index/index/all.vue")",
           "name": ""index-index-all"",
           "path": ""all"",
         },
       ],
-      "component": "() => import("pages/index/index.vue").then(m => m.default || m)",
+      "component": "() => import("pages/index/index.vue")",
       "name": ""index"",
       "path": ""/"",
     },
   ],
   "should merge route.meta with meta from file": [
     {
-      "component": "() => import("pages/page-with-meta.vue").then(m => m.default || m)",
+      "component": "() => import("pages/page-with-meta.vue")",
       "meta": "{ ...(mockMeta || {}), ...{"test":1} }",
       "name": ""page-with-meta"",
       "path": ""/page-with-meta"",
@@ -277,58 +277,58 @@
   ],
   "should not generate colliding route names when hyphens are in file name": [
     {
-      "component": "() => import("pages/parent/[child].vue").then(m => m.default || m)",
+      "component": "() => import("pages/parent/[child].vue")",
       "name": ""parent-child"",
       "path": ""/parent/:child()"",
     },
     {
-      "component": "() => import("pages/parent-[child].vue").then(m => m.default || m)",
+      "component": "() => import("pages/parent-[child].vue")",
       "name": ""parent-child"",
       "path": ""/parent-:child()"",
     },
   ],
   "should not merge required param as a child of optional param": [
     {
-      "component": "() => import("pages/[[foo]].vue").then(m => m.default || m)",
+      "component": "() => import("pages/[[foo]].vue")",
       "name": ""foo"",
       "path": ""/:foo?"",
     },
     {
-      "component": "() => import("pages/[foo].vue").then(m => m.default || m)",
+      "component": "() => import("pages/[foo].vue")",
       "name": ""foo"",
       "path": ""/:foo()"",
     },
   ],
   "should only allow "_" & "." as special character for dynamic route": [
     {
-      "component": "() => import("pages/[a1_1a].vue").then(m => m.default || m)",
+      "component": "() => import("pages/[a1_1a].vue")",
       "name": ""a1_1a"",
       "path": ""/:a1_1a()"",
     },
     {
-      "component": "() => import("pages/[b2.2b].vue").then(m => m.default || m)",
+      "component": "() => import("pages/[b2.2b].vue")",
       "name": ""b2.2b"",
       "path": ""/:b2.2b()"",
     },
     {
-      "component": "() => import("pages/[b2]_[2b].vue").then(m => m.default || m)",
+      "component": "() => import("pages/[b2]_[2b].vue")",
       "name": ""b2_2b"",
       "path": ""/:b2()_:2b()"",
     },
     {
-      "component": "() => import("pages/[[c3@3c]].vue").then(m => m.default || m)",
+      "component": "() => import("pages/[[c3@3c]].vue")",
       "name": ""c33c"",
       "path": ""/:c33c?"",
     },
     {
-      "component": "() => import("pages/[[d4-4d]].vue").then(m => m.default || m)",
+      "component": "() => import("pages/[[d4-4d]].vue")",
       "name": ""d44d"",
       "path": ""/:d44d?"",
     },
   ],
   "should properly override route name if definePageMeta name override is defined.": [
     {
-      "component": "() => import("pages/index.vue").then(m => m.default || m)",
+      "component": "() => import("pages/index.vue")",
       "name": ""home"",
       "path": ""/"",
     },
@@ -336,7 +336,7 @@
   "should use fallbacks when normalized with `overrideMeta: true`": [
     {
       "alias": "mockMeta?.alias || []",
-      "component": "() => import("pages/index.vue").then(m => m.default || m)",
+      "component": "() => import("pages/index.vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "index"",
       "path": ""/"",

--- a/packages/nuxt/test/page-metadata.test.ts
+++ b/packages/nuxt/test/page-metadata.test.ts
@@ -170,21 +170,21 @@ describe('normalizeRoutes', () => {
 
     const { routes, imports } = normalizeRoutes([page], new Set(), true)
     expect({ routes, imports }).toMatchInlineSnapshot(`
+      {
+        "imports": Set {
+          "import { default as indexN6pT4Un8hYMeta } from "/app/pages/index.vue?macro=true";",
+        },
+        "routes": "[
         {
-          "imports": Set {
-            "import { default as indexN6pT4Un8hYMeta } from "/app/pages/index.vue?macro=true";",
-          },
-          "routes": "[
-          {
-            name: "some-custom-name",
-            path: indexN6pT4Un8hYMeta?.path ?? "/",
-            meta: { ...(indexN6pT4Un8hYMeta || {}), ...{"layout":"test","foo":"bar"} },
-            redirect: "/",
-            component: () => import("/app/pages/index.vue").then(m => m.default || m)
-          }
-        ]",
+          name: "some-custom-name",
+          path: indexN6pT4Un8hYMeta?.path ?? "/",
+          meta: { ...(indexN6pT4Un8hYMeta || {}), ...{"layout":"test","foo":"bar"} },
+          redirect: "/",
+          component: () => import("/app/pages/index.vue")
         }
-      `)
+      ]",
+      }
+    `)
   })
 
   it('should produce valid route objects when used without extracted meta', () => {
@@ -195,21 +195,21 @@ describe('normalizeRoutes', () => {
 
     const { routes, imports } = normalizeRoutes([page], new Set())
     expect({ routes, imports }).toMatchInlineSnapshot(`
+      {
+        "imports": Set {
+          "import { default as indexN6pT4Un8hYMeta } from "/app/pages/index.vue?macro=true";",
+        },
+        "routes": "[
         {
-          "imports": Set {
-            "import { default as indexN6pT4Un8hYMeta } from "/app/pages/index.vue?macro=true";",
-          },
-          "routes": "[
-          {
-            name: indexN6pT4Un8hYMeta?.name ?? undefined,
-            path: indexN6pT4Un8hYMeta?.path ?? "/",
-            meta: { ...(indexN6pT4Un8hYMeta || {}), ...{"layout":"test","foo":"bar"} },
-            alias: indexN6pT4Un8hYMeta?.alias || [],
-            redirect: indexN6pT4Un8hYMeta?.redirect,
-            component: () => import("/app/pages/index.vue").then(m => m.default || m)
-          }
-        ]",
+          name: indexN6pT4Un8hYMeta?.name ?? undefined,
+          path: indexN6pT4Un8hYMeta?.path ?? "/",
+          meta: { ...(indexN6pT4Un8hYMeta || {}), ...{"layout":"test","foo":"bar"} },
+          alias: indexN6pT4Un8hYMeta?.alias || [],
+          redirect: indexN6pT4Un8hYMeta?.redirect,
+          component: () => import("/app/pages/index.vue")
         }
-      `)
+      ]",
+      }
+    `)
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

since https://github.com/nuxt/nuxt/pull/28509 (released in v3.13.0), we no longer need an interop default for dynamic vue components as Vue + Vue router already do this check themselves, which also will slightly reduce bundle size.

By removing the interopDefault in the case of vue-router, we unlock possibilities for vue-router to do things with named exports (such as data loading 👀).