### PR TITLE
chore: add `pending triage` to blank issues

### DIFF
--- a/.github/workflows/label-issue.yml
+++ b/.github/workflows/label-issue.yml
@@ -1,0 +1,27 @@
+name: chore
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-pr-labels:
+    name: Add labels
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    if: github.repository == 'nuxt/nuxt'
+    steps:
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            # add 'pending triage' label if issue is created with no labels
+            if (context.payload.issue.labels.length === 0) {
+              github.rest.issues.addLabels({
+                issue_number: pullRequest.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                labels: ['pending triage']
+              })
+            }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this adds `pending triage` if people create a blank issue, so it won't be missed