### PR TITLE
fix(nuxt): fall back to original component `filePath`

### DIFF
--- a/packages/nuxt/src/components/module.ts
+++ b/packages/nuxt/src/components/module.ts
@@ -171,7 +171,7 @@ export default defineNuxtModule<ComponentsOptions>({
       for (const component of newComponents) {
         if (!(component as any /* untyped internal property */)._scanned && !(component.filePath in nuxt.vfs) && !existsSync(component.filePath)) {
           // attempt to resolve component path
-          component.filePath = await resolvePath(component.filePath)
+          component.filePath = await resolvePath(component.filePath, { fallbackToOriginal: true })
         }
         if (component.mode === 'client' && !newComponents.some(c => c.pascalName === component.pascalName && c.mode === 'server')) {
           newComponents.push({


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

when resolving component filePath, if we cannot do so (for example, because it is in a template) we should return original path rather than joining it to the `srcDir`