### PR TITLE
fix(kit,nuxt,schema)!: remove other support for nuxt2/bridge

### DIFF
--- a/packages/kit/src/components.ts
+++ b/packages/kit/src/components.ts
@@ -6,8 +6,6 @@ import { logger } from './logger'
 
 /**
  * Register a directory to be scanned for components and imported only when used.
- *
- * Requires Nuxt 2.13+
  */
 export async function addComponentsDir (dir: ComponentsDir, opts: { prepend?: boolean } = {}) {
   const nuxt = useNuxt()
@@ -23,8 +21,6 @@ export type AddComponentOptions = { name: string, filePath: string } & Partial<E
 
 /**
  * Register a component by its name and filePath.
- *
- * Requires Nuxt 2.13+
  */
 export async function addComponent (opts: AddComponentOptions) {
   const nuxt = useNuxt()

--- a/packages/kit/src/imports.ts
+++ b/packages/kit/src/imports.ts
@@ -1,20 +1,15 @@
 import type { Import } from 'unimport'
 import type { ImportPresetWithDeprecation } from '@nuxt/schema'
 import { useNuxt } from './context'
-import { assertNuxtCompatibility } from './compatibility'
 import { toArray } from './utils'
 
 export function addImports (imports: Import | Import[]) {
-  assertNuxtCompatibility({ bridge: true })
-
   useNuxt().hook('imports:extend', (_imports) => {
     _imports.push(...toArray(imports))
   })
 }
 
 export function addImportsDir (dirs: string | string[], opts: { prepend?: boolean } = {}) {
-  assertNuxtCompatibility({ bridge: true })
-
   useNuxt().hook('imports:dirs', (_dirs: string[]) => {
     for (const dir of toArray(dirs)) {
       _dirs[opts.prepend ? 'unshift' : 'push'](dir)
@@ -22,8 +17,6 @@ export function addImportsDir (dirs: string | string[], opts: { prepend?: boolea
   })
 }
 export function addImportsSources (presets: ImportPresetWithDeprecation | ImportPresetWithDeprecation[]) {
-  assertNuxtCompatibility({ bridge: true })
-
   useNuxt().hook('imports:sources', (_presets: ImportPresetWithDeprecation[]) => {
     for (const preset of toArray(presets)) {
       _presets.push(preset)

--- a/packages/kit/src/layout.ts
+++ b/packages/kit/src/layout.ts
@@ -5,7 +5,7 @@ import { useNuxt } from './context'
 import { logger } from './logger'
 import { addTemplate } from './template'
 
-export function addLayout (this: any, template: NuxtTemplate | string, name?: string) {
+export function addLayout (template: NuxtTemplate | string, name?: string) {
   const nuxt = useNuxt()
   const { filename, src } = addTemplate(template)
   const layoutName = kebabCase(name || parse(filename).name).replace(/["']/g, '')

--- a/packages/kit/src/module/define.ts
+++ b/packages/kit/src/module/define.ts
@@ -79,9 +79,9 @@ function _defineNuxtModule<
   }
 
   // Module format is always a simple function
-  async function normalizedModule (this: any, inlineOptions: Partial<TOptions>, nuxt: Nuxt): Promise<ModuleSetupReturn> {
+  async function normalizedModule (inlineOptions: Partial<TOptions>, nuxt = tryUseNuxt()!): Promise<ModuleSetupReturn> {
     if (!nuxt) {
-      nuxt = tryUseNuxt() || this.nuxt /* invoked by nuxt 2 */
+      throw new TypeError('Cannot use module outside of Nuxt context')
     }
 
     // Avoid duplicate installs

--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -320,11 +320,6 @@ export async function writeTypes (nuxt: Nuxt) {
     await fsp.writeFile(declarationPath, GeneratedBy + '\n' + declaration)
   }
 
-  // This is needed for Nuxt 2 which clears the build directory again before building
-  // https://github.com/nuxt/nuxt/blob/2.x/packages/builder/src/builder.js#L144
-  // @ts-expect-error TODO: Nuxt 2 hook
-  nuxt.hook('builder:prepared', writeFile)
-
   await writeFile()
 }
 

--- a/packages/nuxt/src/core/plugins/plugin-metadata.ts
+++ b/packages/nuxt/src/core/plugins/plugin-metadata.ts
@@ -149,28 +149,11 @@ export const RemovePluginMetadataPlugin = (nuxt: Nuxt) => createUnplugin(() => {
             if (_node.type === 'ImportSpecifier' && (_node.imported.name === 'defineNuxtPlugin' || _node.imported.name === 'definePayloadPlugin')) {
               wrapperNames.add(_node.local.name)
             }
-            if (_node.type === 'ExportDefaultDeclaration' && (_node.declaration.type === 'FunctionDeclaration' || _node.declaration.type === 'ArrowFunctionExpression')) {
-              if ('params' in _node.declaration && _node.declaration.params.length > 1) {
-                logger.warn(`Plugin \`${plugin.src}\` is in legacy Nuxt 2 format (context, inject) which is likely to be broken and will be ignored.`)
-                s.overwrite(0, code.length, 'export default () => {}')
-                wrapped = true // silence a duplicate error
-                return
-              }
-            }
             if (_node.type !== 'CallExpression' || (_node as CallExpression).callee.type !== 'Identifier') { return }
             const node = _node as CallExpression & { start: number, end: number }
             const name = 'name' in node.callee && node.callee.name
             if (!name || !wrapperNames.has(name)) { return }
             wrapped = true
-
-            if (node.arguments[0].type !== 'ObjectExpression') {
-              // TODO: Warn if legacy plugin format is detected
-              if ('params' in node.arguments[0] && node.arguments[0].params.length > 1) {
-                logger.warn(`Plugin \`${plugin.src}\` is in legacy Nuxt 2 format (context, inject) which is likely to be broken and will be ignored.`)
-                s.overwrite(0, code.length, 'export default () => {}')
-                return
-              }
-            }
 
             // Remove metadata that already has been extracted
             if (!('order' in plugin) && !('name' in plugin)) { return }

--- a/packages/nuxt/test/plugin-metadata.test.ts
+++ b/packages/nuxt/test/plugin-metadata.test.ts
@@ -40,7 +40,6 @@ describe('plugin-metadata', () => {
   it('should overwrite invalid plugins', () => {
     const invalidPlugins = [
       'export const plugin = {}',
-      'export default function (ctx, inject) {}',
     ]
     for (const plugin of invalidPlugins) {
       expect(transformPlugin.transform.call({ parse }, plugin, 'my-plugin.mjs').code).toBe('export default () => {}')

--- a/packages/schema/src/types/compatibility.ts
+++ b/packages/schema/src/types/compatibility.ts
@@ -1,17 +1,9 @@
 export interface NuxtCompatibility {
   /**
    * Required nuxt version in semver format.
-   * @example `^2.14.0` or `>=3.0.0-27219851.6e49637`.
+   * @example `^3.2.0` or `>=3.13.0`.
    */
   nuxt?: string
-
-  /**
-   * Bridge constraint for Nuxt 2 support.
-   *
-   * - `true`:  When using Nuxt 2, using bridge module is required.
-   * - `false`: When using Nuxt 2, using bridge module is not supported.
-   */
-  bridge?: boolean
 
   /**
    * Mark a builder as incompatible, or require a particular version.

--- a/test/fixtures/basic/plugins/invalid-plugin-2.ts
+++ b/test/fixtures/basic/plugins/invalid-plugin-2.ts
@@ -1,3 +1,0 @@
-export default function previousPlugin (one, inject) {
-  inject()
-}


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This PR drops support for running Nuxt modules or `addLayout` in Nuxt v2, and removes `bridge` as a valid constraint when defining modules.

We also no longer check whether plugins are in a legacy Nuxt 2 format.