### PR TITLE
fix(nuxt): ensure component imports are injected last

### DIFF
--- a/packages/nuxt/src/components/transform.ts
+++ b/packages/nuxt/src/components/transform.ts
@@ -51,6 +51,7 @@ export function createTransformPlugin (nuxt: Nuxt, getComponents: getComponentsT
 
   return createUnplugin(() => ({
     name: 'nuxt:components:imports',
+    enforce: 'post',
     transformInclude (id) {
       id = normalize(id)
       return id.startsWith('virtual:') || id.startsWith('\0virtual:') || id.startsWith(nuxt.options.buildDir) || !isIgnored(id)


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

detected in https://github.com/elk-zone/elk/pull/2946.

otherwise if `.vue` files were not already transformed the injections were inserted at the beginning of the file, not in the `<script>` block.

cc: @userquin 