### PR TITLE
docs: change SPA to CSR in the ssr param of Rendering Route Rules

### DIFF
--- a/docs/2.guide/1.concepts/3.rendering.md
+++ b/docs/2.guide/1.concepts/3.rendering.md
@@ -136,7 +136,7 @@ export default defineNuxtConfig({
 
 The different properties you can use are the following:
 - `redirect: string`{lang=ts} - Define server-side redirects.
-- `ssr: boolean`{lang=ts} - Disables server-side rendering for sections of your app and make them SPA-only with `ssr: false`
+- `ssr: boolean`{lang=ts} - Disables server-side rendering for sections of your app and make them CSR-only with `ssr: false`
 - `cors: boolean`{lang=ts} - Automatically adds cors headers with `cors: true` - you can customize the output by overriding with `headers`
 - `headers: object`{lang=ts} - Add specific headers to sections of your site - for example, your assets
 - `swr: number | boolean`{lang=ts} - Add cache headers to the server response and cache it on the server or reverse proxy for a configurable TTL (time to live). The `node-server` preset of Nitro is able to cache the full response. When the TTL expired, the cached response will be sent while the page will be regenerated in the background. If true is used, a `stale-while-revalidate` header is added without a MaxAge.

--- a/docs/2.guide/1.concepts/3.rendering.md
+++ b/docs/2.guide/1.concepts/3.rendering.md
@@ -136,7 +136,7 @@ export default defineNuxtConfig({
 
 The different properties you can use are the following:
 - `redirect: string`{lang=ts} - Define server-side redirects.
-- `ssr: boolean`{lang=ts} - Disables server-side rendering for sections of your app and make them CSR-only with `ssr: false`
+- `ssr: boolean`{lang=ts} - Disables server-side rendering of the HTML for sections of your app and make them render only in the browser (CSR) with `ssr: false`
 - `cors: boolean`{lang=ts} - Automatically adds cors headers with `cors: true` - you can customize the output by overriding with `headers`
 - `headers: object`{lang=ts} - Add specific headers to sections of your site - for example, your assets
 - `swr: number | boolean`{lang=ts} - Add cache headers to the server response and cache it on the server or reverse proxy for a configurable TTL (time to live). The `node-server` preset of Nitro is able to cache the full response. When the TTL expired, the cached response will be sent while the page will be regenerated in the background. If true is used, a `stale-while-revalidate` header is added without a MaxAge.

--- a/docs/2.guide/1.concepts/3.rendering.md
+++ b/docs/2.guide/1.concepts/3.rendering.md
@@ -136,7 +136,7 @@ export default defineNuxtConfig({
 
 The different properties you can use are the following:
 - `redirect: string`{lang=ts} - Define server-side redirects.
-- `ssr: boolean`{lang=ts} - Disables server-side rendering of the HTML for sections of your app and make them render only in the browser (CSR) with `ssr: false`
+- `ssr: boolean`{lang=ts} - Disables server-side rendering of the HTML for sections of your app and make them render only in the browser with `ssr: false`
 - `cors: boolean`{lang=ts} - Automatically adds cors headers with `cors: true` - you can customize the output by overriding with `headers`
 - `headers: object`{lang=ts} - Add specific headers to sections of your site - for example, your assets
 - `swr: number | boolean`{lang=ts} - Add cache headers to the server response and cache it on the server or reverse proxy for a configurable TTL (time to live). The `node-server` preset of Nitro is able to cache the full response. When the TTL expired, the cached response will be sent while the page will be regenerated in the background. If true is used, a `stale-while-revalidate` header is added without a MaxAge.


### PR DESCRIPTION
### 🔗 Linked issue

resolves #28968

### 📚 Description

As asked in the issue, it changes SPA to CSR, since the terminology is used more in the documentation.

### Aditional info

Let me know if there's anything wrong in the PR, so I can change it accordingly. Regards.