### PR TITLE
fix(nuxt): await `page:finish` hook on page enter with a hash link in scrollBehavior

### DIFF
--- a/packages/nuxt/src/pages/runtime/router.options.ts
+++ b/packages/nuxt/src/pages/runtime/router.options.ts
@@ -29,25 +29,28 @@ export default <RouterConfig> {
 
     // Hash routes on the same page, no page hook is fired so resolve here
     if (to.path === from.path) {
-      if (from.hash && !to.hash) {
-        return { left: 0, top: 0 }
+      if (!to.hash) {
+        if (from.hash) {
+          return { left: 0, top: 0 }
+        }
+
+        // The route isn't changing so keep current scroll position
+        return false
       }
-      if (to.hash) {
-        return { el: to.hash, top: _getHashElementScrollMarginTop(to.hash), behavior }
-      }
-      // The route isn't changing so keep current scroll position
-      return false
     }
 
     // Wait for `page:transition:finish` or `page:finish` depending on if transitions are enabled or not
     const hasTransition = (route: RouteLocationNormalized) => !!(route.meta.pageTransition ?? defaultPageTransition)
     const hookToWait = (hasTransition(from) && hasTransition(to)) ? 'page:transition:finish' : 'page:finish'
+
     return new Promise((resolve) => {
       nuxtApp.hooks.hookOnce(hookToWait, async () => {
         await new Promise(resolve => setTimeout(resolve, 0))
+
         if (to.hash) {
           position = { el: to.hash, top: _getHashElementScrollMarginTop(to.hash), behavior }
         }
+
         resolve(position)
       })
     })
@@ -57,11 +60,13 @@ export default <RouterConfig> {
 function _getHashElementScrollMarginTop (selector: string): number {
   try {
     const elem = document.querySelector(selector)
+
     if (elem) {
       return (Number.parseFloat(getComputedStyle(elem).scrollMarginTop) || 0) + (Number.parseFloat(getComputedStyle(document.documentElement).scrollPaddingTop) || 0)
     }
   } catch {
     // ignore any errors parsing scrollMarginTop
   }
+
   return 0
 }

--- a/packages/nuxt/src/pages/runtime/router.options.ts
+++ b/packages/nuxt/src/pages/runtime/router.options.ts
@@ -28,15 +28,13 @@ export default <RouterConfig> {
     }
 
     // Hash routes on the same page, no page hook is fired so resolve here
-    if (to.path === from.path) {
-      if (!to.hash) {
-        if (from.hash) {
-          return { left: 0, top: 0 }
-        }
-
-        // The route isn't changing so keep current scroll position
-        return false
+    if (to.path === from.path && !to.hash) {
+      if (from.hash) {
+        return { left: 0, top: 0 }
       }
+
+      // The route isn't changing so keep current scroll position
+      return false
     }
 
     // Wait for `page:transition:finish` or `page:finish` depending on if transitions are enabled or not


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/28992

### 📚 Description

With `ssr:false` and page enter/refresh containing a hash link, we weren't awaiting the `page:finish` hook. This caused `_getHashElementScrollMarginTop` to execute `const elem = document.querySelector(selector)` too early and return `null`.