### PR TITLE
docs(nuxt): edit `url type` to preserve `autocompletion`

### DIFF
--- a/docs/2.guide/4.recipes/3.custom-usefetch.md
+++ b/docs/2.guide/4.recipes/3.custom-usefetch.md
@@ -77,8 +77,11 @@ Now that `$api` has the logic we want, let's create a `useAPI` composable to rep
 ```ts [composables/useAPI.ts]
 import type { UseFetchOptions } from 'nuxt/app'
 
+// use `parameter types` to preserve `autocompletion` in your ide
+type useFetchParameterUrl = Parameters<typeof useFetch>[0]
+
 export function useAPI<T>(
-  url: string | (() => string),
+  url: useFetchParameterUrl,
   options?: UseFetchOptions<T>,
 ) {
   return useFetch(url, {


### PR DESCRIPTION


### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

When wrapping `useFetch` the types for `parameters`,e.g. for the url, are not inferred automatically. They could also not be imported easily.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
