### PR TITLE
fix(nuxt): access server build from `webpack` memfs

### DIFF
--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -545,6 +545,12 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
 
   // nuxt dev
   if (nuxt.options.dev) {
+    nuxt.hook('webpack:compile', ({ name, compiler }) => {
+      if (name === 'server') {
+        const memfs = compiler.outputFileSystem as typeof import('node:fs')
+        nitro.options.virtual['#build/dist/server/server.mjs'] = () => memfs.readFileSync(join(nuxt.options.buildDir, 'dist/server/server.mjs'), 'utf-8')
+      }
+    })
     nuxt.hook('webpack:compiled', () => { nuxt.server.reload() })
     nuxt.hook('vite:compiled', () => { nuxt.server.reload() })
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/29020

### 📚 Description

This addresses a regression introduced in #27787. Previously, we were using a `memfs` but then immediately overwriting it with native fs utilities - meaning Nitro could resolve the `dist/server/server.mjs` file on disk. This was wrongly removed in that PR.

However, the original implementation was non-optimal, and also likely caused a range of other bugs that have been reported (like a 'stale' compiled server being used in development mode).

This fix instead uses the `memfs` in dev mode as the source for a Nitro virtual template.

Until this is released you can use the following code as a workaround:

```ts
import { join } from 'pathe'

export default defineNuxtConfig({
  builder: 'webpack',
  modules: [
    function(options, nuxt) {
      if (nuxt.options.dev) {
        nuxt.hook('nitro:init', nitro => {
          nuxt.hook('webpack:compile',  ({ name, compiler }) => {
            if (name === 'server') {
              const memfs = compiler.outputFileSystem as typeof import('node:fs')
              nitro.options.virtual['#build/dist/server/server.mjs'] = () => memfs.readFileSync(join(nuxt.options.buildDir, 'dist/server/server.mjs'), 'utf-8')
            }
          })
        })
      }
    }
  ],
})
```