### PR TITLE
fix(nuxt): do not resolve non-absolute component paths

### DIFF
--- a/packages/nuxt/src/components/module.ts
+++ b/packages/nuxt/src/components/module.ts
@@ -1,5 +1,5 @@
 import { existsSync, statSync, writeFileSync } from 'node:fs'
-import { join, normalize, relative, resolve } from 'pathe'
+import { isAbsolute, join, normalize, relative, resolve } from 'pathe'
 import { addPluginTemplate, addTemplate, addTypeTemplate, addVitePlugin, addWebpackPlugin, defineNuxtModule, logger, resolveAlias, resolvePath, updateTemplates } from '@nuxt/kit'
 import type { Component, ComponentsDir, ComponentsOptions } from 'nuxt/schema'
 
@@ -169,7 +169,7 @@ export default defineNuxtModule<ComponentsOptions>({
       await nuxt.callHook('components:extend', newComponents)
       // add server placeholder for .client components server side. issue: #7085
       for (const component of newComponents) {
-        if (!(component as any /* untyped internal property */)._scanned && !(component.filePath in nuxt.vfs) && !existsSync(component.filePath)) {
+        if (!(component as any /* untyped internal property */)._scanned && !(component.filePath in nuxt.vfs) && isAbsolute(component.filePath) && !existsSync(component.filePath)) {
           // attempt to resolve component path
           component.filePath = await resolvePath(component.filePath, { fallbackToOriginal: true })
         }


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt-modules/leaflet/issues/80
resolves https://github.com/nuxt/nuxt/issues/29028

### 📚 Description

We now resolve components that don't have file extensions (https://github.com/nuxt/nuxt/pull/28843) but this is also currently fully resolving paths to libraries in `node_modules/`, which is wrong on several fronts - most notably that the path might be different between node + browser.

We can skip this if not passed an absolute path as the intention here is just to add a file extension when a _partial_ path is provided.