### PR TITLE
fix(nuxt): defer unsetting error handler until suspense resolves

### DIFF
--- a/packages/nuxt/src/app/entry.ts
+++ b/packages/nuxt/src/app/entry.ts
@@ -67,6 +67,10 @@ if (import.meta.client) {
     }
 
     vueApp.config.errorHandler = handleVueError
+    // If the errorHandler is not overridden by the user, we unset it after the app is hydrated
+    nuxt.hook('app:suspense:resolve', () => {
+      if (vueApp.config.errorHandler === handleVueError) { vueApp.config.errorHandler = undefined }
+    })
 
     try {
       await applyPlugins(nuxt, plugins)
@@ -83,9 +87,6 @@ if (import.meta.client) {
     } catch (err) {
       handleVueError(err)
     }
-
-    // If the errorHandler is not overridden by the user, we unset it
-    if (vueApp.config.errorHandler === handleVueError) { vueApp.config.errorHandler = undefined }
 
     return vueApp
   }


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/25691

### 📚 Description

if there is an error when rendering a component/layout that is async, when mounting the app, this was previously not handled by the start-up error handler.

this PR only unsets the `errorHandler` after suspense finally resolves