### PR TITLE
fix(vite): don't force hmr protocol if `devServer.https` is disabled

### DIFF
--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -184,7 +184,7 @@ export async function buildClient (ctx: ViteBuildContext) {
   if (clientConfig.server && clientConfig.server.hmr !== false) {
     const serverDefaults: Omit<ServerOptions, 'hmr'> & { hmr: Exclude<ServerOptions['hmr'], boolean> } = {
       hmr: {
-        protocol: ctx.nuxt.options.devServer.https ? 'wss' : 'ws',
+        protocol: ctx.nuxt.options.devServer.https ? 'wss' : undefined,
       },
     }
     if (typeof clientConfig.server.hmr !== 'object' || !clientConfig.server.hmr.server) {


### PR DESCRIPTION
The devServer could be behind a reverse proxy which is independent from vite, which means we cannot know for certain whether `ws` or `wss` will be used in browser to connect to hmr server. By letting vite decide the websocket protocol based on whether http or https is used in browser (default behavior), we can avoid potential protocol mismatch errors and automatic protocol upgrades by the browser.

See https://github.com/nuxt/nuxt/issues/27558#issuecomment-2328614165 for where it started. Easy reproduction using caddy is also provided in a different comment at https://github.com/nuxt/nuxt/issues/27558#issuecomment-2188504331.

Alternatively the developer may set `vite.server.hmr.protocol = 'wss'` to force hmr protocol, which will make it only work through the chosen proxy. By letting vite decide by default, we revert to behavior that was present prior to https://github.com/nuxt/cli/pull/420 where blank configuration would lead to the right protocol being chosen regardless of whether accessing dev server via reverse proxy or without it.

### 🔗 Linked issue

resolves #27558
resolves https://github.com/nuxt/nuxt/issues/28398