### PR TITLE
fix(nuxt): changed abort exceptions from string to DOMException

### DIFF
--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -152,7 +152,7 @@ export function useFetch<
   let controller: AbortController
 
   const asyncData = useAsyncData<_ResT, ErrorT, DataT, PickKeys, DefaultT>(key, () => {
-    controller?.abort?.('Request aborted as another request to the same endpoint was initiated.')
+    controller?.abort?.(new DOMException('Request aborted as another request to the same endpoint was initiated.', 'AbortError'))
     controller = typeof AbortController !== 'undefined' ? new AbortController() : {} as AbortController
 
     /**
@@ -164,7 +164,7 @@ export function useFetch<
     const timeoutLength = toValue(opts.timeout)
     let timeoutId: NodeJS.Timeout
     if (timeoutLength) {
-      timeoutId = setTimeout(() => controller.abort('Request aborted due to timeout.'), timeoutLength)
+      timeoutId = setTimeout(() => controller.abort(new DOMException('Request aborted due to timeout.', 'AbortError')), timeoutLength)
       controller.signal.onabort = () => clearTimeout(timeoutId)
     }
 


### PR DESCRIPTION
### 🔗 Linked issue
https://github.com/nuxt/nuxt/pull/28517

### 📚 Description
The linked pull-request breaks existing behavior, such as checking `error.name === 'AbortError'` for thrown errors.
And doesn't satisfy Error interface as well

`interface Error { 
  name: string
  message: string
  stack?: string
}`

![image](https://github.com/user-attachments/assets/ab56656a-4a6d-46d3-8db3-698766cf867c)


https://developer.mozilla.org/en-US/docs/Web/API/AbortController/abort
Code sample is taken from docs with little modifications

![image](https://github.com/user-attachments/assets/780c4c05-b00e-40b6-b36d-f3ad1fe26616)
