### PR TITLE
fix(nuxt): empty nitro `buildDir` in dev mode

### DIFF
--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -529,11 +529,11 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
   // nuxt build/dev
   nuxt.hook('build:done', async () => {
     await nuxt.callHook('nitro:build:before', nitro)
+    await prepare(nitro)
     if (nuxt.options.dev) {
       return build(nitro)
     }
 
-    await prepare(nitro)
     await prerender(nitro)
 
     logger.restoreAll()


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/28181

### 📚 Description

When starting a dev server, we were not calling `prepare` and so nitro was reusing the previous dev server build, which could cause weird behaviour, such as calling a server plugin twice.

this normalises behaviour with nitro dev server behaviour:

https://github.com/unjs/nitro/blob/25df63e29867c0d467543444051dd9679ea31692/src/cli/commands/dev.ts#L64-L65