### PR TITLE
fix(nuxt): don't resolve relative import paths in types for deps

### DIFF
--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -179,13 +179,13 @@ async function initNuxt (nuxt: Nuxt) {
 
   const coreTypePackages = nuxt.options.typescript.hoist || []
   const packageJSON = await readPackageJSON(nuxt.options.rootDir).catch(() => ({}) as PackageJson)
-  const dependencies = new Set([...Object.keys(packageJSON.dependencies || {}), ...Object.keys(packageJSON.devDependencies || {})])
+  nuxt._dependencies = new Set([...Object.keys(packageJSON.dependencies || {}), ...Object.keys(packageJSON.devDependencies || {})])
   const paths = Object.fromEntries(await Promise.all(coreTypePackages.map(async (pkg) => {
     const [_pkg = pkg, _subpath] = /^[^@]+\//.test(pkg) ? pkg.split('/') : [pkg]
     const subpath = _subpath ? '/' + _subpath : ''
 
     // ignore packages that exist in `package.json` as these can be resolved by TypeScript
-    if (dependencies.has(_pkg) && !(_pkg in nightlies)) { return [] }
+    if (nuxt._dependencies?.has(_pkg) && !(_pkg in nightlies)) { return [] }
 
     // deduplicate types for nightly releases
     if (_pkg in nightlies) {

--- a/packages/nuxt/src/imports/module.ts
+++ b/packages/nuxt/src/imports/module.ts
@@ -166,8 +166,9 @@ function addDeclarationTemplates (ctx: Unimport, options: Partial<ImportsOptions
 
   async function cacheImportPaths (imports: Import[]) {
     const importSource = Array.from(new Set(imports.map(i => i.from)))
+    // skip relative import paths for node_modules that are explicitly installed
     await Promise.all(importSource.map(async (from) => {
-      if (resolvedImportPathMap.has(from)) {
+      if (resolvedImportPathMap.has(from) || nuxt._dependencies?.has(from)) {
         return
       }
       let path = resolveAlias(from)
@@ -176,6 +177,8 @@ function addDeclarationTemplates (ctx: Unimport, options: Partial<ImportsOptions
           if (!r) { return r }
 
           const { dir, name } = parseNodeModulePath(r)
+          if (name && nuxt._dependencies?.has(name)) { return from }
+
           if (!dir || !name) { return r }
           const subpath = await lookupNodeModuleSubpath(r)
           return join(dir, name, subpath || '')

--- a/packages/schema/src/types/nuxt.ts
+++ b/packages/schema/src/types/nuxt.ts
@@ -76,6 +76,7 @@ export interface Nuxt {
   // Private fields.
   _version: string
   _ignore?: Ignore
+  _dependencies?: Set<string>
 
   /** The resolved Nuxt configuration. */
   options: NuxtOptions


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/25412

### 📚 Description

this avoids resolving fully resolving dependency paths in `types/imports.d.ts` if the package is explicitly installed in `dependencies` or `devDependencies`.