### PR TITLE
fix(kit,vite,webpack): postcss paths from each modules dir

### DIFF
--- a/packages/kit/src/module/install.ts
+++ b/packages/kit/src/module/install.ts
@@ -85,7 +85,6 @@ export async function loadNuxtModuleInstance (nuxtModule: string | NuxtModule, n
 
   // Import if input is string
   if (typeof nuxtModule === 'string') {
-    let error: unknown
     const paths = [join(nuxtModule, 'nuxt'), join(nuxtModule, 'module'), nuxtModule, join(nuxt.options.rootDir, nuxtModule)]
 
     for (const parentURL of nuxt.options.modulesDir) {
@@ -100,15 +99,16 @@ export async function loadNuxtModuleInstance (nuxtModule: string | NuxtModule, n
             buildTimeModuleMeta = JSON.parse(await fsp.readFile(moduleMetadataPath, 'utf-8'))
           }
           break
-        } catch (_err: unknown) {
-          error = _err
+        } catch (error: unknown) {
+          const code = (error as Error & { code?: string }).code
+          if (code === 'MODULE_NOT_FOUND' || code === 'ERR_PACKAGE_PATH_NOT_EXPORTED' || code === 'ERR_MODULE_NOT_FOUND' || code === 'ERR_UNSUPPORTED_DIR_IMPORT') {
+            continue
+          }
+          logger.error(`Error while importing module \`${nuxtModule}\`: ${error}`)
+          throw error
         }
       }
       if (typeof nuxtModule !== 'string') { break }
-    }
-    if (typeof nuxtModule !== 'function' && error) {
-      logger.error(`Error while importing module \`${nuxtModule}\`: ${error}`)
-      throw error
     }
   }
 

--- a/packages/webpack/src/utils/postcss.ts
+++ b/packages/webpack/src/utils/postcss.ts
@@ -49,17 +49,18 @@ export async function getPostcssConfig (nuxt: Nuxt) {
       const pluginOptions = postcssOptions.plugins[pluginName]
       if (!pluginOptions) { continue }
 
-    let pluginFn: ((opts: Record<string, any>) => Plugin) | undefined
-    for (const parentURL of nuxt.options.modulesDir) {
-      pluginFn = await jiti.import(pluginName, { parentURL, try: true }) as (opts: Record<string, any>) => Plugin
-      if (typeof pluginFn === 'function') {
-        plugins.push(pluginFn(pluginOptions))
-        break
+      let pluginFn: ((opts: Record<string, any>) => Plugin) | undefined
+      for (const parentURL of nuxt.options.modulesDir) {
+        pluginFn = await jiti.import(pluginName, { parentURL, try: true }) as (opts: Record<string, any>) => Plugin
+        if (typeof pluginFn === 'function') {
+          plugins.push(pluginFn(pluginOptions))
+          break
+        }
       }
-    }
 
-    if (typeof pluginFn !== 'function') {
-      console.warn(`[nuxt] could not import postcss plugin \`${pluginName}\`. Please report this as a bug.`)
+      if (typeof pluginFn !== 'function') {
+        console.warn(`[nuxt] could not import postcss plugin \`${pluginName}\`. Please report this as a bug.`)
+      }
     }
 
     // @ts-expect-error we are mutating type here from object to array

--- a/packages/webpack/src/utils/postcss.ts
+++ b/packages/webpack/src/utils/postcss.ts
@@ -49,13 +49,17 @@ export async function getPostcssConfig (nuxt: Nuxt) {
       const pluginOptions = postcssOptions.plugins[pluginName]
       if (!pluginOptions) { continue }
 
-      const path = jiti.esmResolve(pluginName)
-      const pluginFn = (await jiti.import(path)) as (opts: Record<string, any>) => Plugin
+    let pluginFn: ((opts: Record<string, any>) => Plugin) | undefined
+    for (const parentURL of nuxt.options.modulesDir) {
+      pluginFn = await jiti.import(pluginName, { parentURL, try: true }) as (opts: Record<string, any>) => Plugin
       if (typeof pluginFn === 'function') {
         plugins.push(pluginFn(pluginOptions))
-      } else {
-        console.warn(`[nuxt] could not import postcss plugin \`${pluginName}\`. Please report this as a bug.`)
+        break
       }
+    }
+
+    if (typeof pluginFn !== 'function') {
+      console.warn(`[nuxt] could not import postcss plugin \`${pluginName}\`. Please report this as a bug.`)
     }
 
     // @ts-expect-error we are mutating type here from object to array


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/commit/70a622d433da42aeadc2f3c07fe4feadbcdca030
https://github.com/nuxt/nuxt/pull/29073
https://github.com/nuxt/nuxt/commit/c7fecd8a1e85d6c3d45c731a323fefda572a9515

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
