### PR TITLE
docs: move custom directories note to the correct place

### DIFF
--- a/docs/2.guide/2.directory-structure/1.components.md
+++ b/docs/2.guide/2.directory-structure/1.components.md
@@ -166,6 +166,10 @@ export default defineNuxtConfig({
 })
 ```
 
+::note
+Any nested directories need to be added first as they are scanned in order.
+::
+
 ## npm Packages
 
 If you want to auto-import components from an npm package, you can use [`addComponent`](/docs/api/kit/components#addcomponent) in a [local module](/docs/guide/directory-structure/modules) to register them.
@@ -196,10 +200,6 @@ export default defineNuxtModule({
 </template>
 ```
 
-::
-
-::note
-Any nested directories need to be added first as they are scanned in order.
 ::
 
 ## Component Extensions


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
This PR moves the note related to Custom Directories to the appropriate section, instead of being under npm Packages.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
