### PR TITLE
docs: update to new `ofetch` headers for interceptors

### DIFF
--- a/docs/2.guide/4.recipes/3.custom-usefetch.md
+++ b/docs/2.guide/4.recipes/3.custom-usefetch.md
@@ -31,14 +31,7 @@ export default defineNuxtPlugin((nuxtApp) => {
     baseURL: 'https://api.nuxt.com',
     onRequest({ request, options, error }) {
       if (session.value?.token) {
-        const headers = options.headers ||= {}
-        if (Array.isArray(headers)) {
-          headers.push(['Authorization', `Bearer ${session.value?.token}`])
-        } else if (headers instanceof Headers) {
-          headers.set('Authorization', `Bearer ${session.value?.token}`)
-        } else {
-          headers.Authorization = `Bearer ${session.value?.token}`
-        }
+        options.headers.set('Authorization', `Bearer ${session.value?.token}`)
       }
     },
     async onResponseError({ response }) {

--- a/docs/2.guide/4.recipes/3.custom-usefetch.md
+++ b/docs/2.guide/4.recipes/3.custom-usefetch.md
@@ -31,6 +31,7 @@ export default defineNuxtPlugin((nuxtApp) => {
     baseURL: 'https://api.nuxt.com',
     onRequest({ request, options, error }) {
       if (session.value?.token) {
+        // note that this relies on ofetch >= 1.4.0 - you may need to refresh your lockfile
         options.headers.set('Authorization', `Bearer ${session.value?.token}`)
       }
     },

--- a/docs/3.api/2.composables/use-fetch.md
+++ b/docs/3.api/2.composables/use-fetch.md
@@ -50,8 +50,7 @@ You can also use [interceptors](https://github.com/unjs/ofetch#%EF%B8%8F-interce
 const { data, status, error, refresh, clear } = await useFetch('/api/auth/login', {
   onRequest({ request, options }) {
     // Set the request headers
-    options.headers = options.headers || {}
-    options.headers.authorization = '...'
+    options.headers.set('Authorization', '...')
   },
   onRequestError({ request, options, error }) {
     // Handle the request errors

--- a/docs/3.api/2.composables/use-fetch.md
+++ b/docs/3.api/2.composables/use-fetch.md
@@ -50,6 +50,7 @@ You can also use [interceptors](https://github.com/unjs/ofetch#%EF%B8%8F-interce
 const { data, status, error, refresh, clear } = await useFetch('/api/auth/login', {
   onRequest({ request, options }) {
     // Set the request headers
+    // note that this relies on ofetch >= 1.4.0 - you may need to refresh your lockfile
     options.headers.set('Authorization', '...')
   },
   onRequestError({ request, options, error }) {


### PR DESCRIPTION
I guess we should wait until we force `ofetch@^1.4.0`

Related PR: https://github.com/unjs/ofetch/pull/436