### PR TITLE
docs: remove specific Nuxt 4 release date

### DIFF
--- a/docs/1.getting-started/12.upgrade.md
+++ b/docs/1.getting-started/12.upgrade.md
@@ -43,7 +43,7 @@ You can opt in to the 3.x branch nightly releases with `"nuxt": "npm:nuxt-nightl
 
 ## Testing Nuxt 4
 
-The release date of Nuxt 4 is **to be announced**. It is dependent on having enough time after Nitro's major release to be properly tested in the community.
+The release date of Nuxt 4 is **to be announced**. It is dependent on having enough time after Nitro's major release to be properly tested in the community. You can follow progress towards Nitro's release in [this PR](https://github.com/unjs/nitro/pull/2521).
 
 Until the release, it is possible to test many of Nuxt 4's breaking changes from Nuxt version 3.12+.
 

--- a/docs/1.getting-started/12.upgrade.md
+++ b/docs/1.getting-started/12.upgrade.md
@@ -43,9 +43,9 @@ You can opt in to the 3.x branch nightly releases with `"nuxt": "npm:nuxt-nightl
 
 ## Testing Nuxt 4
 
-Nuxt 4 is planned to be released **on or before June 14** (though obviously this is dependent on having enough time after Nitro's major release to be properly tested in the community, so be aware that this is not an exact date).
+The release date of Nuxt 4 is **to be announced**. It is dependent on having enough time after Nitro's major release to be properly tested in the community.
 
-Until then, it is possible to test many of Nuxt 4's breaking changes from Nuxt version 3.12+.
+Until the release, it is possible to test many of Nuxt 4's breaking changes from Nuxt version 3.12+.
 
 ::tip{icon="i-ph-video" to="https://www.youtube.com/watch?v=r4wFKlcJK6c" target="_blank"}
 Watch a video from Alexander Lichter showing how to opt in to Nuxt 4's breaking changes already.


### PR DESCRIPTION
https://nuxt.com/docs/getting-started/upgrade


### 📚 Description

Currently, the documentation states that Nuxt 4 is planned to be released "_on or before June 14_". Those of us who are plugged in to the Nuxt community are aware that the actual timeline is "to be announced" (as detailed in #27716).

But for people new to Nuxt, or those who don't check the announcements that often, this might be confusing. One might think "June 14th has passed for a while – is it simply delayed? Or do the authors mean 2025? Am I safe to use Nuxt now or should I wait for v4?"

I think removing the specific date for the Nuxt 4 release in favour of a "to be announced" might clarify that confusion.