### PR TITLE
test: add tests to check 404 handling in client-side rendering

### DIFF
--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -249,6 +249,16 @@ describe('pages', () => {
     await serverPage.close()
   })
 
+  it('should render 404 page even in spa mode', async () => {
+    const { page } = await renderPage('/route-rules/spa')
+
+    await page.getByText('should throw a 404 error').click()
+    expect(await page.getByRole('heading').textContent()).toMatchInlineSnapshot(`"Page Not Found: /forbidden"`)
+    expect(await page.getByTestId('path').textContent()).toMatchInlineSnapshot(`" Path: /forbidden"`)
+
+    await page.close()
+  })
+
   it('returns 500 when there is an infinite redirect', async () => {
     const { status } = await fetch('/redirect-infinite', { redirect: 'manual' })
     expect(status).toEqual(500)

--- a/test/fixtures/basic/pages/route-rules/spa.vue
+++ b/test/fixtures/basic/pages/route-rules/spa.vue
@@ -1,5 +1,10 @@
 <template>
   <div>
-    should not be rendered on ssr
+    <div>
+      should not be rendered on ssr
+    </div>
+    <NuxtLink to="/forbidden">
+      should throw a 404 error
+    </NuxtLink>
   </div>
 </template>


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Hi ✋ 
Before adding https://github.com/nuxt/nuxt/pull/29054, I would like to add tests to check whether 404 handling in client-side rendering behaves as intended.

I would actually like to add tests for the case where there are no catch-all routes, but it was difficult because there are tests that depend on catch-all routes.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
