### PR TITLE
docs: update auto-imports.md to reflect useFetch() use correct

### DIFF
--- a/docs/2.guide/1.concepts/1.auto-imports.md
+++ b/docs/2.guide/1.concepts/1.auto-imports.md
@@ -33,7 +33,7 @@ Nuxt auto-imports functions and composables to perform [data fetching](/docs/get
 
 ```vue twoslash
 <script setup lang="ts">
-/* useAsyncData() and $fetch() are auto-imported */
+/* useFetch() is auto-imported */
 const { data, refresh, status } = await useFetch('/api/hello')
 </script>
 ```


### PR DESCRIPTION
### 📚 Description
In the documentation's auto-imports section, there was an example where the comments were not aligned with the corresponding code.

This PR corrects the misaligned comments to ensure proper alignment.

<img width="590" alt="nuxt-auto-imports" src="https://github.com/user-attachments/assets/d6c610d7-b389-4bf2-b6d0-b3054fcce92e">
