### PR TITLE
-fix: Update 2.installation.md: corrected a typo

### DIFF
--- a/docs/1.getting-started/2.installation.md
+++ b/docs/1.getting-started/2.installation.md
@@ -38,7 +38,7 @@ Open a terminal (if you're using [Visual Studio Code](https://code.visualstudio.
 ::package-managers
 
 ```bash [npm]
-npx nuxi@latest init <project-name>
+npx nuxt@latest init <project-name>
 ```
 
 ```bash [yarn]


### PR DESCRIPTION
I corrected (what I believe to be) a typo in the installation instructions: nuxi in the bash command instead of nuxt: npx nuxi@latest init <project-name>. I ran the command and it gave an error. The corrected command: npx nuxt@latest init <project-name> ran correctly.
I did not see this in the issue list. 
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
