### PR TITLE
docs: add missing word

### DIFF
--- a/docs/2.guide/2.directory-structure/1.plugins.md
+++ b/docs/2.guide/2.directory-structure/1.plugins.md
@@ -108,7 +108,7 @@ In case you're new to 'alphabetical' numbering, remember that filenames are sort
 
 ### Parallel Plugins
 
-By default, Nuxt loads plugins sequentially. You can define a plugin as `parallel` so Nuxt won't wait the end of the plugin's execution before loading the next plugin.
+By default, Nuxt loads plugins sequentially. You can define a plugin as `parallel` so Nuxt won't wait until the end of the plugin's execution before loading the next plugin.
 
 ```ts twoslash [plugins/my-plugin.ts]
 export default defineNuxtPlugin({


### PR DESCRIPTION
### 🔗 Linked issue

No issue for this.

### 📚 Description

Minor typo fix in doc chapter about plugins.