### PR TITLE
docs: add pnpm tip to LCP optimisation 💡

### DIFF
--- a/docs/1.getting-started/4.styling.md
+++ b/docs/1.getting-started/4.styling.md
@@ -530,11 +530,7 @@ export default defineNuxtConfig({
   hooks: {
     'build:manifest': (manifest) => {
       // find the app entry, css list
-      const [
-        entryFilePath = '',
-        _entryFileOptions
-      ] = Object.entries(manifest).find(([_path, options]) => options.isEntry) ?? [];
-      const css = manifest[entryFilePath]?.css;
+      const css = Object.values(manifest).find(options => options.isEntry)?.css
       if (css) {
         // start from the end of the array and go to the beginning
         for (let i = css.length - 1; i >= 0; i--) {

--- a/docs/1.getting-started/4.styling.md
+++ b/docs/1.getting-started/4.styling.md
@@ -544,6 +544,32 @@ export default defineNuxtConfig({
 ```
 
 ::tip
-If you are using pnpm, the actual path will be different.
-Read this [blog post](https://dev.to/dreitzner/nuxt3-lcp-advanced-optimizations-with-pnpm-12h3) to get started.
+If you are using pnpm, the actual path to the `entry.js` file will be different.
+Use the slightly modified code below.
 ::
+
+```ts [nuxt.config.ts]
+import { readdirSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+export default defineNuxtConfig({
+  hooks: {
+    'build:manifest': (manifest) => {
+      // find the app entry, css list
+      const baseModulesFolder = path.dirname(fileURLToPath(import.meta.url)) + '/node_modules/.pnpm/';
+      const nuxtFolder = readdirSync(baseModulesFolder).find((file) => typeof file === 'string' && file.startsWith('nuxt@'));
+      const entryFilePath = `node_modules/.pnpm/${nuxtFolder}/node_modules/nuxt/dist/app/entry.js`;
+
+      const css = manifest[entryFilePath]?.css;
+      if (css) {
+        // start from the end of the array and go to the beginning
+        for (let i = css.length - 1; i >= 0; i--) {
+          // if it starts with 'entry', remove it from the list
+          if (css[i].startsWith('entry')) css.splice(i, 1);
+        }
+      }
+    },
+  },
+})
+```

--- a/docs/1.getting-started/4.styling.md
+++ b/docs/1.getting-started/4.styling.md
@@ -530,43 +530,16 @@ export default defineNuxtConfig({
   hooks: {
     'build:manifest': (manifest) => {
       // find the app entry, css list
-      const css = manifest['node_modules/nuxt/dist/app/entry.js']?.css
-      if (css) {
-        // start from the end of the array and go to the beginning
-        for (let i = css.length - 1; i >= 0; i--) {
-          // if it starts with 'entry', remove it from the list
-          if (css[i].startsWith('entry')) css.splice(i, 1)
-        }
-      }
-    },
-  },
-})
-```
-
-::tip
-If you are using pnpm, the actual path to the `entry.js` file will be different.
-Use the slightly modified code below.
-::
-
-```ts [nuxt.config.ts]
-import { readdirSync } from 'fs';
-import path from 'path';
-import { fileURLToPath } from 'url';
-
-export default defineNuxtConfig({
-  hooks: {
-    'build:manifest': (manifest) => {
-      // find the app entry, css list
-      const baseModulesFolder = path.dirname(fileURLToPath(import.meta.url)) + '/node_modules/.pnpm/';
-      const nuxtFolder = readdirSync(baseModulesFolder).find((file) => typeof file === 'string' && file.startsWith('nuxt@'));
-      const entryFilePath = `node_modules/.pnpm/${nuxtFolder}/node_modules/nuxt/dist/app/entry.js`;
-
+      const [
+        entryFilePath = '',
+        _entryFileOptions
+      ] = Object.entries(manifest).find(([_path, options]) => options.isEntry) ?? [];
       const css = manifest[entryFilePath]?.css;
       if (css) {
         // start from the end of the array and go to the beginning
         for (let i = css.length - 1; i >= 0; i--) {
           // if it starts with 'entry', remove it from the list
-          if (css[i].startsWith('entry')) css.splice(i, 1);
+          if (css[i].startsWith('entry')) css.splice(i, 1)
         }
       }
     },

--- a/docs/1.getting-started/4.styling.md
+++ b/docs/1.getting-started/4.styling.md
@@ -542,3 +542,8 @@ export default defineNuxtConfig({
   },
 })
 ```
+
+::tip
+If you are using pnpm, the actual path will be different.
+Read this [blog post](https://dev.to/dreitzner/nuxt3-lcp-advanced-optimizations-with-pnpm-12h3) to get started.
+::


### PR DESCRIPTION
### 🔗 Linked issue

resolves #29272 

### 📚 Description

The current docs for LCP optimizations do not work with pnpm.

This adds a hint to the docs for all pnpm users.

[📘 Current docs](https://nuxt.com/docs/getting-started/styling#lcp-advanced-optimizations)
