### PR TITLE
fix(nuxt): call `link:prefetch` with absolute urls for external links

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -328,8 +328,9 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
         const path = typeof to.value === 'string'
           ? to.value
           : isExternal.value ? resolveRouteObject(to.value) : router.resolve(to.value).fullPath
+        const normalizedPath = isExternal.value ? new URL(path, window.location.href).href : path
         await Promise.all([
-          nuxtApp.hooks.callHook('link:prefetch', path).catch(() => {}),
+          nuxtApp.hooks.callHook('link:prefetch', normalizedPath).catch(() => {}),
           !isExternal.value && !hasTarget.value && preloadRouteComponents(to.value as string, router).catch(() => {}),
         ])
       }


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/29313

### 📚 Description

Within `link:prefetch`, we can't tell if a link is internal or external. This ensures we pass absolute URLs if they are `external` links - which enables skipping prefetch behaviour in this case.