### PR TITLE
feat(nuxt): add `isolate` page meta

### DIFF
--- a/docs/3.api/3.utils/define-page-meta.md
+++ b/docs/3.api/3.utils/define-page-meta.md
@@ -91,7 +91,7 @@ interface PageMeta {
 
   **`isolate`**
   - Type: boolean
-    
+
     Set to `true` when you do not want the page to inherit from your `app.vue`.
   
   **`layout`**

--- a/docs/3.api/3.utils/define-page-meta.md
+++ b/docs/3.api/3.utils/define-page-meta.md
@@ -38,6 +38,7 @@ interface PageMeta {
   key?: false | string | ((route: RouteLocationNormalizedLoaded) => string)
   keepalive?: boolean | KeepAliveProps
   layout?: false | LayoutKey | Ref<LayoutKey> | ComputedRef<LayoutKey>
+  isolate?: boolean 
   middleware?: MiddlewareKey | NavigationGuard | Array<MiddlewareKey | NavigationGuard>
   scrollToTop?: boolean | ((to: RouteLocationNormalizedLoaded, from: RouteLocationNormalizedLoaded) => boolean)
   [key: string]: unknown
@@ -88,6 +89,11 @@ interface PageMeta {
 
     Set `key` value when you need more control over when the `<NuxtPage>` component is re-rendered.
 
+  **`isolate`**
+  - Type: boolean
+    
+    Set to `true` when you do not want the page to inherit from your `app.vue`.
+  
   **`layout`**
 
   - **Type**: `false` | `LayoutKey` | `Ref<LayoutKey>` | `ComputedRef<LayoutKey>`

--- a/packages/nuxt/src/app/components/nuxt-root.vue
+++ b/packages/nuxt/src/app/components/nuxt-root.vue
@@ -13,6 +13,7 @@
       :is="SingleRenderer"
       v-else-if="SingleRenderer"
     />
+    <NuxtPage v-else-if="route?.meta?.isolate" />
     <AppComponent v-else />
   </Suspense>
 </template>
@@ -43,8 +44,9 @@ const url = import.meta.server ? nuxtApp.ssrContext.url : window.location.pathna
 const SingleRenderer = import.meta.test && import.meta.dev && import.meta.server && url.startsWith('/__nuxt_component_test__/') && defineAsyncComponent(() => import('#build/test-component-wrapper.mjs')
   .then(r => r.default(import.meta.server ? url : window.location.href)))
 
+const route = useRoute()
 // Inject default route (outside of pages) as active route
-provide(PageRouteSymbol, useRoute())
+provide(PageRouteSymbol, route)
 
 // vue:setup hook
 const results = nuxtApp.hooks.callHookWith(hooks => hooks.map(hook => hook()), 'vue:setup')

--- a/packages/nuxt/src/app/components/nuxt-root.vue
+++ b/packages/nuxt/src/app/components/nuxt-root.vue
@@ -13,7 +13,10 @@
       :is="SingleRenderer"
       v-else-if="SingleRenderer"
     />
-    <NuxtPage v-else-if="route?.meta?.isolate" />
+    <component
+      :is="IsolatedPage"
+      v-else-if="IsolatedPage && route?.meta?.isolate"
+    />
     <AppComponent v-else />
   </Suspense>
 </template>
@@ -47,6 +50,8 @@ const SingleRenderer = import.meta.test && import.meta.dev && import.meta.server
 const route = useRoute()
 // Inject default route (outside of pages) as active route
 provide(PageRouteSymbol, route)
+
+const IsolatedPage = defineAsyncComponent(() => import('#build/isolated-page.mjs'))
 
 // vue:setup hook
 const results = nuxtApp.hooks.callHookWith(hooks => hooks.map(hook => hook()), 'vue:setup')

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -10,7 +10,6 @@ import { filename } from 'pathe/utils'
 import type { NuxtTemplate } from 'nuxt/schema'
 import type { Nitro } from 'nitro/types'
 
-import { distDir } from '../dirs'
 import { annotatePlugins, checkForCircularDependencies } from './app'
 import { EXTENSION_RE } from './utils'
 

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -10,6 +10,7 @@ import { filename } from 'pathe/utils'
 import type { NuxtTemplate } from 'nuxt/schema'
 import type { Nitro } from 'nitro/types'
 
+import { distDir } from '../dirs'
 import { annotatePlugins, checkForCircularDependencies } from './app'
 import { EXTENSION_RE } from './utils'
 
@@ -551,5 +552,13 @@ export const buildTypeTemplate: NuxtTemplate = {
     }
 
     return declarations
+  },
+}
+
+export const isolatedPageTemplate: NuxtTemplate = {
+  filename: 'isolated-page.mjs',
+  getContents (ctx) {
+    const hasPages = ctx.nuxt.options.dev || ctx.app.pages?.length
+    return hasPages ? genExport(resolve(ctx.nuxt.options.appDir, '../pages/runtime/page'), ['default']) : 'export default null'
   },
 }

--- a/packages/nuxt/src/pages/runtime/composables.ts
+++ b/packages/nuxt/src/pages/runtime/composables.ts
@@ -44,6 +44,9 @@ export interface PageMeta {
   props?: RouteRecordRaw['props']
   /** Set to `false` to avoid scrolling to top on page navigations */
   scrollToTop?: boolean | ((to: RouteLocationNormalizedLoaded, from: RouteLocationNormalizedLoaded) => boolean)
+
+  /** Set to `true` to render this page without inheriting from `app.vue` */
+  isolate?: boolean
 }
 
 declare module 'vue-router' {

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -625,6 +625,13 @@ describe('pages', () => {
     const html = await $fetch('/prerender/test')
     expect(html).toContain('should be prerendered: true')
   })
+
+  it('should render pages with meta.isolate independently', async () => {
+    expect(await $fetch('/not-isolated')).toContain('Nuxt App')
+    const html = await $fetch('/isolated')
+    expect(html).not.toContain('Nuxt App')
+    expect(html).toContain('isolated')
+  })
 })
 
 describe('nuxt composables', () => {

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -21,14 +21,15 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const [clientStats, clientStatsInlined] = await Promise.all((['.output', '.output-inline'])
       .map(outputDir => analyzeSizes(['**/*.js'], join(rootDir, outputDir, 'public'))))
 
-    expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"119k"`)
-    expect.soft(roundToKilobytes(clientStatsInlined!.totalBytes)).toMatchInlineSnapshot(`"119k"`)
+    expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"122k"`)
+    expect.soft(roundToKilobytes(clientStatsInlined!.totalBytes)).toMatchInlineSnapshot(`"122k"`)
 
     const files = new Set([...clientStats!.files, ...clientStatsInlined!.files].map(f => f.replace(/\..*\.js/, '.js')))
 
     expect([...files]).toMatchInlineSnapshot(`
       [
         "_nuxt/entry.js",
+        "_nuxt/isolated-page.js",
       ]
     `)
   })
@@ -37,7 +38,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(rootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"208k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"210k"`)
 
     const modules = await analyzeSizes(['node_modules/**/*'], serverDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"1393k"`)
@@ -78,7 +79,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(rootDir, '.output-inline/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"557k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"559k"`)
 
     const modules = await analyzeSizes(['node_modules/**/*'], serverDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"94.2k"`)

--- a/test/fixtures/basic/app.vue
+++ b/test/fixtures/basic/app.vue
@@ -1,0 +1,6 @@
+<template>
+  <NuxtLayout>
+    <p>Nuxt App</p>
+    <NuxtPage />
+  </NuxtLayout>
+</template>

--- a/test/fixtures/basic/pages/isolated.vue
+++ b/test/fixtures/basic/pages/isolated.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+definePageMeta({
+  isolate: true,
+  layout: false,
+})
+</script>
+
+<template>
+  <div> isolated </div>
+</template>

--- a/test/fixtures/basic/pages/not-isolated.vue
+++ b/test/fixtures/basic/pages/not-isolated.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+definePageMeta({
+  layout: false,
+})
+</script>
+
+<template>
+  <div> not isolated </div>
+</template>


### PR DESCRIPTION
### 🔗 Linked issue

resolves #29365 

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
This PR introduces a new page meta `isolate` to render pages without inheriting from the `app.vue` component.   

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced the `isolate` property in the `PageMeta` interface, allowing pages to render independently from the default layout.
  - Added new components: `isolated.vue` and `not-isolated.vue`, demonstrating the use of the `isolate` property.
  - Implemented a new template for isolated pages to enhance rendering control.

- **Bug Fixes**
  - Improved rendering logic to ensure isolated pages do not inherit settings from the main app.

- **Tests**
  - Added a test case to verify rendering behavior for isolated and non-isolated pages.

- **Documentation**
  - Updated documentation for the `definePageMeta` function to include the new `isolate` property.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->