### PR TITLE
chore(nuxt): remove double call to `useNuxtApp`

### DIFF
--- a/packages/nuxt/src/app/composables/component.ts
+++ b/packages/nuxt/src/app/composables/component.ts
@@ -56,7 +56,6 @@ export const defineNuxtComponent: typeof defineComponent =
         }
 
         if (options.head) {
-          const nuxtApp = useNuxtApp()
           useHead(typeof options.head === 'function' ? () => options.head(nuxtApp) : options.head)
         }
 


### PR DESCRIPTION
### 🔗 Linked issue


<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description


This PR removes an unecessary call to `useNuxtApp` (it's already called)

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
