### PR TITLE
docs: warn about `refreshNuxtData` not working with `asyncData`

### DIFF
--- a/docs/3.api/3.utils/define-nuxt-component.md
+++ b/docs/3.api/3.utils/define-nuxt-component.md
@@ -36,6 +36,10 @@ export default defineNuxtComponent({
 </script>
 ```
 
+::warning
+Data from `useAsyncData` is only set once in the `setup` hook of your component. This means `refreshNuxtData` will not work with `asyncData`. If you need to re-run `useAsyncData`, you can change it with a `method` of the Option API.
+::
+
 ## `head()`
 
 If you choose not to use `setup()` in your app, you can use the `head()` method within your component definition:

--- a/docs/3.api/3.utils/define-nuxt-component.md
+++ b/docs/3.api/3.utils/define-nuxt-component.md
@@ -37,7 +37,7 @@ export default defineNuxtComponent({
 ```
 
 ::warning
-Data from `useAsyncData` is only set once in the `setup` hook of your component. This means `refreshNuxtData` will not work with `asyncData`. If you need to re-run `useAsyncData`, you can change it with a `method` of the Option API.
+Data from `useAsyncData` is only set once in the `setup` hook of your component. This means `refreshNuxtData` will not work with `asyncData`. If you need to re-run `useAsyncData`, you can change it with a `method` of the Options API.
 ::
 
 ## `head()`

--- a/docs/3.api/3.utils/refresh-nuxt-data.md
+++ b/docs/3.api/3.utils/refresh-nuxt-data.md
@@ -12,6 +12,10 @@ links:
 `refreshNuxtData` re-fetches all data from the server and updates the page as well as invalidates the cache of [`useAsyncData`](/docs/api/composables/use-async-data) , `useLazyAsyncData`, [`useFetch`](/docs/api/composables/use-fetch) and `useLazyFetch`.
 ::
 
+::warning
+`refreshNuxtData` only works with composition API. `asyncData` hook from the Options API does not work with `refreshNuxtData`.
+::
+
 ## Type
 
 ```ts

--- a/docs/3.api/3.utils/refresh-nuxt-data.md
+++ b/docs/3.api/3.utils/refresh-nuxt-data.md
@@ -13,7 +13,7 @@ links:
 ::
 
 ::warning
-`refreshNuxtData` only works with composition API. `asyncData` hook from the Options API does not work with `refreshNuxtData`.
+`refreshNuxtData` only works with Composition API. `asyncData` hook from the Options API does not work with `refreshNuxtData`.
 ::
 
 ## Type


### PR DESCRIPTION
### 🔗 Linked issue
close #29368 
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

`refreshNuxtData` does not work with `asyncData` hook. This PR warn about it. 

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
