### PR TITLE
feat(nuxt): add `pollEvery` option to `useAsyncData` composable 

### DIFF
--- a/docs/1.getting-started/6.data-fetching.md
+++ b/docs/1.getting-started/6.data-fetching.md
@@ -458,6 +458,27 @@ For finer control, the `status` variable can be:
 - `error` when the fetch fails
 - `success` when the fetch is completed successfully
 
+### Polling
+
+You can set up automatic polling for your data retrievals using the `pollEvery` option. This is useful for keeping data up to date without requiring user interaction.
+
+```vue
+<script setup>
+const { data, error } = await useFetch('/api/users', {
+  pollEvery: 5000 // Poll every 5 seconds
+})
+</script>
+```
+
+When using `pollEvery`:
+- The number given is in milliseconds.
+- Only works in the client side.
+- Polling starts immediately after the first fetch.
+- Polling will continue as long as the component is mounted.
+- You can manually trigger a refresh using the `refresh` function, which will reset the polling interval.
+
+Be careful when using polling, especially with short intervals, as it can lead to increased server load and network usage. Consider using WebSockets or server-sent events for real-time updates if your backend supports them.
+
 ## Passing Headers and cookies
 
 When we call `$fetch` in the browser, user headers like `cookie` will be directly sent to the API. But during server-side-rendering, since the `$fetch` request takes place 'internally' within the server, it doesn't include the user's browser cookies, nor does it pass on cookies from the fetch response.

--- a/docs/3.api/2.composables/use-async-data.md
+++ b/docs/3.api/2.composables/use-async-data.md
@@ -76,6 +76,7 @@ const { data: posts } = await useAsyncData(
   - `dedupe`: avoid fetching same key more than once at a time (defaults to `cancel`). Possible options:
     - `cancel` - cancels existing requests when a new one is made
     - `defer` - does not make new requests at all if there is a pending request
+  - `pollEvery`: a number in milliseconds that defines the interval for polling the data. When set, the data will be automatically refreshed at the specified interval.
 
 ::note
 Under the hood, `lazy: false` uses `<Suspense>` to block the loading of the route before the data has been fetched. Consider using `lazy: true` and implementing a loading state instead for a snappier user experience.
@@ -127,6 +128,7 @@ type AsyncDataOptions<DataT> = {
   pick?: string[]
   watch?: WatchSource[]
   getCachedData?: (key: string, nuxtApp: NuxtApp) => DataT
+  pollEvery?: number
 }
 
 type AsyncData<DataT, ErrorT> = {

--- a/docs/3.api/2.composables/use-fetch.md
+++ b/docs/3.api/2.composables/use-fetch.md
@@ -97,6 +97,7 @@ Watch the video from Alexander Lichter to avoid using `useFetch` the wrong way!
   - `timeout`: Milliseconds to automatically abort request
   - `cache`: Handles cache control according to [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/fetch#cache)
     - You can pass boolean to disable the cache or you can pass one of the following values: `default`, `no-store`, `reload`, `no-cache`, `force-cache`, and `only-if-cached`.
+  - `pollEvery`: a number in milliseconds that defines the interval for polling the data. When set, the data will be automatically refreshed at the specified interval.
 
 ::note
 All fetch options can be given a `computed` or `ref` value. These will be watched and new requests made automatically with any new values if they are updated.


### PR DESCRIPTION
### 🔗 Linked issue

#29565


### 📚 Description

This pull request adds a `pollEvery` option to the `useAsyncData` composable, allowing developers to set an interval for automatically polling asynchronous data. This feature is particularly useful for applications that require frequent data updates, such as dashboards, real-time notifications, or live feeds.

#### Major changes
- Added a `pollEvery` option to `AsyncDataOptions`, allowing users to specify a polling interval (in milliseconds).
- Implemented polling logic within the composable:
  - Polling starts automatically when `pollEvery` is set and immediate is true.
  - Polling is paused and resumed as needed, and the interval is cleared on component destruction.
- The refresh method is overridden to restart polling after each refresh.

### Example usage

```ts
const { data } = useAsyncData('key', () => fetchData(), { pollEvery: 5000 /* 5s */ });
const { data } = useFetch('/api/users', { pollEvery: 5000 /* 5s */ });
```

This change streamlines the process of setting up data polling and ensures proper cleanup of polling intervals.

### 🚀 Why this change is needed

Currently, to implement polling with `useAsyncData`, developers must manually set up `setInterval` calls and manage cleanup using lifecycle hooks. This PR simplifies the process by providing a built-in polling mechanism that integrates with `useAsyncData`'s existing lifecycle and reactive system.

### Documentation

The documentation has been updated to reflect the new `pollEvery` option in the useAsyncData API reference.

### Remaining questions

- What should the option be called? Currently it is called `pollEveryone`, but it could also be `refreshEveryone`. (Suggested by @daniluk4000).
- Should we add a new state called `polling`. This is the state when polling is active but just waiting for the interval to end. This state could also be `idle` to not add more complexity.
- What about adding a method to stop/start polling manually? Just in case people could stop polling once they've received their data, the user has left the page, etc. (suggested by @daniluk4000)


PS: If you don't think this feature is a good fit, feel free to close it - I haven't discussed it with anyone beforehand, but I'm eager to do it anyway. 😄