### PR TITLE
chore(vite): avoid redundant postcss plugins overwrite

### DIFF
--- a/packages/vite/src/css.ts
+++ b/packages/vite/src/css.ts
@@ -9,7 +9,7 @@ function sortPlugins ({ plugins, order }: NuxtOptions['postcss']): string[] {
 }
 
 export async function resolveCSSOptions (nuxt: Nuxt): Promise<ViteConfig['css']> {
-  const css: ViteConfig['css'] & { postcss: NonNullable<Exclude<NonNullable<ViteConfig['css']>['postcss'], string>> & {plugins: Plugin[] } } = {
+  const css: ViteConfig['css'] & { postcss: NonNullable<Exclude<NonNullable<ViteConfig['css']>['postcss'], string>> & { plugins: Plugin[] } } = {
     postcss: {
       plugins: [],
     },

--- a/packages/vite/src/css.ts
+++ b/packages/vite/src/css.ts
@@ -15,7 +15,6 @@ export async function resolveCSSOptions (nuxt: Nuxt): Promise<ViteConfig['css']>
     },
   }
 
-  css.postcss.plugins = []
   const postcssOptions = nuxt.options.postcss
 
   const jiti = createJiti(nuxt.options.rootDir, { alias: nuxt.options.alias })

--- a/packages/vite/src/css.ts
+++ b/packages/vite/src/css.ts
@@ -27,7 +27,7 @@ export async function resolveCSSOptions (nuxt: Nuxt): Promise<ViteConfig['css']>
     for (const parentURL of nuxt.options.modulesDir) {
       pluginFn = await jiti.import(pluginName, { parentURL: parentURL.replace(/\/node_modules\/?$/, ''), try: true, default: true }) as (opts: Record<string, any>) => Plugin
       if (typeof pluginFn === 'function') {
-        css.postcss.plugins!.push(pluginFn(pluginOptions))
+        css.postcss.plugins.push(pluginFn(pluginOptions))
         break
       }
     }

--- a/packages/vite/src/css.ts
+++ b/packages/vite/src/css.ts
@@ -9,7 +9,7 @@ function sortPlugins ({ plugins, order }: NuxtOptions['postcss']): string[] {
 }
 
 export async function resolveCSSOptions (nuxt: Nuxt): Promise<ViteConfig['css']> {
-  const css: ViteConfig['css'] & { postcss: NonNullable<Exclude<NonNullable<ViteConfig['css']>['postcss'], string>> } = {
+  const css: ViteConfig['css'] & { postcss: NonNullable<Exclude<NonNullable<ViteConfig['css']>['postcss'], string>> & {plugins: Plugin[] } } = {
     postcss: {
       plugins: [],
     },
@@ -27,7 +27,7 @@ export async function resolveCSSOptions (nuxt: Nuxt): Promise<ViteConfig['css']>
     for (const parentURL of nuxt.options.modulesDir) {
       pluginFn = await jiti.import(pluginName, { parentURL: parentURL.replace(/\/node_modules\/?$/, ''), try: true, default: true }) as (opts: Record<string, any>) => Plugin
       if (typeof pluginFn === 'function') {
-        css.postcss.plugins.push(pluginFn(pluginOptions))
+        css.postcss.plugins!.push(pluginFn(pluginOptions))
         break
       }
     }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
Since the plugins array is initialized as empty, there is no need to make it empty again
<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
