### PR TITLE
fix(nuxt): definePageMeta props set true

### DIFF
--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -273,7 +273,7 @@ export async function getRouteMeta (contents: string, absolutePath: string): Pro
             continue
           }
 
-          if (property.value.type !== 'Literal' || typeof property.value.value !== 'string') {
+          if (property.value.type !== 'Literal' || (typeof property.value.value !== 'string' && typeof property.value.value !== 'boolean')) {
             console.debug(`[nuxt] Skipping extraction of \`${key}\` metadata as it is not a string literal or array of string literals (reading \`${absolutePath}\`).`)
             dynamicProperties.add(key)
             continue
@@ -571,6 +571,10 @@ async function createClientPage(loader) {
 
       if (route.children) {
         metaRoute.children = route.children
+      }
+
+      if (route.props) {
+        metaRoute.props = route.props
       }
 
       if (route.meta) {

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -574,7 +574,7 @@ async function createClientPage(loader) {
       }
 
       if (route.props) {
-        metaRoute.props = route.props
+        metaRoute.props = serializeRouteValue(route.props)
       }
 
       if (route.meta) {

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -273,7 +273,7 @@ export async function getRouteMeta (contents: string, absolutePath: string): Pro
             continue
           }
 
-          if (property.value.type !== 'Literal' || (typeof property.value.value !== 'string' && typeof property.value.value !== 'boolean')) {
+          if (property.value.type !== 'Literal' || typeof property.value.value !== 'string') {
             console.debug(`[nuxt] Skipping extraction of \`${key}\` metadata as it is not a string literal or array of string literals (reading \`${absolutePath}\`).`)
             dynamicProperties.add(key)
             continue

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -543,7 +543,7 @@ export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = 
       const metaRoute: NormalizedRoute = {
         name: `${metaImportName}?.name ?? ${route.name}`,
         path: `${metaImportName}?.path ?? ${route.path}`,
-        props: `${metaImportName}?.props ?? false`,
+        props: `${metaImportName}?.props ?? ${route.props ?? false}`,
         meta: `${metaImportName} || {}`,
         alias: `${metaImportName}?.alias || []`,
         redirect: `${metaImportName}?.redirect`,
@@ -572,10 +572,6 @@ async function createClientPage(loader) {
 
       if (route.children) {
         metaRoute.children = route.children
-      }
-
-      if (route.props) {
-        metaRoute.props = route.props
       }
 
       if (route.meta) {

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -507,13 +507,14 @@ export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = 
 
       const route: NormalizedRoute = {
         path: serializeRouteValue(page.path),
+        props: serializeRouteValue(page.props),
         name: serializeRouteValue(page.name),
         meta: serializeRouteValue(metaFiltered, skipMeta),
         alias: serializeRouteValue(toArray(page.alias), skipAlias),
         redirect: serializeRouteValue(page.redirect),
       }
 
-      for (const key of ['path', 'name', 'meta', 'alias', 'redirect'] satisfies NormalizedRouteKeys) {
+      for (const key of ['path', 'props', 'name', 'meta', 'alias', 'redirect'] satisfies NormalizedRouteKeys) {
         if (route[key] === undefined) {
           delete route[key]
         }
@@ -574,7 +575,7 @@ async function createClientPage(loader) {
       }
 
       if (route.props) {
-        metaRoute.props = serializeRouteValue(route.props)
+        metaRoute.props = route.props
       }
 
       if (route.meta) {

--- a/packages/nuxt/test/__snapshots__/pages-override-meta-disabled.test.ts.snap
+++ b/packages/nuxt/test/__snapshots__/pages-override-meta-disabled.test.ts.snap
@@ -36,7 +36,7 @@
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "page-with-props"",
       "path": "mockMeta?.path ?? "/page-with-props"",
-      "props": "mockMeta?.props ?? false",
+      "props": "true",
       "redirect": "mockMeta?.redirect",
     },
   ],

--- a/packages/nuxt/test/__snapshots__/pages-override-meta-disabled.test.ts.snap
+++ b/packages/nuxt/test/__snapshots__/pages-override-meta-disabled.test.ts.snap
@@ -36,7 +36,7 @@
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "page-with-props"",
       "path": "mockMeta?.path ?? "/page-with-props"",
-      "props": "true",
+      "props": "mockMeta?.props ?? true",
       "redirect": "mockMeta?.redirect",
     },
   ],

--- a/packages/nuxt/test/__snapshots__/pages-override-meta-enabled.test.ts.snap
+++ b/packages/nuxt/test/__snapshots__/pages-override-meta-enabled.test.ts.snap
@@ -29,6 +29,7 @@
       "component": "() => import("pages/page-with-props.vue")",
       "name": ""page-with-props"",
       "path": ""/page-with-props"",
+      "props": "true",
     },
   ],
   "should allow pages with `:` in their path": [

--- a/packages/nuxt/test/__snapshots__/pages-override-meta-enabled.test.ts.snap
+++ b/packages/nuxt/test/__snapshots__/pages-override-meta-enabled.test.ts.snap
@@ -29,6 +29,7 @@
       "component": "() => import("pages/page-with-props.vue")",
       "name": ""page-with-props"",
       "path": ""/page-with-props"",
+      "props": "mockMeta?.props ?? false",
     },
   ],
   "should allow pages with `:` in their path": [

--- a/packages/nuxt/test/__snapshots__/pages-override-meta-enabled.test.ts.snap
+++ b/packages/nuxt/test/__snapshots__/pages-override-meta-enabled.test.ts.snap
@@ -29,7 +29,6 @@
       "component": "() => import("pages/page-with-props.vue")",
       "name": ""page-with-props"",
       "path": ""/page-with-props"",
-      "props": "mockMeta?.props ?? false",
     },
   ],
   "should allow pages with `:` in their path": [

--- a/packages/nuxt/test/pages.test.ts
+++ b/packages/nuxt/test/pages.test.ts
@@ -621,7 +621,7 @@ describe('pages:generateRoutesFromFiles', () => {
           path: '/page-with-props',
           file: `${pagesDir}/page-with-props.vue`,
           children: [],
-          props: true,
+          meta: { [DYNAMIC_META_KEY]: new Set(['props']) },
         },
       ],
     },

--- a/packages/nuxt/test/pages.test.ts
+++ b/packages/nuxt/test/pages.test.ts
@@ -621,7 +621,7 @@ describe('pages:generateRoutesFromFiles', () => {
           path: '/page-with-props',
           file: `${pagesDir}/page-with-props.vue`,
           children: [],
-          meta: { [DYNAMIC_META_KEY]: new Set(['props']) },
+          props: true,
         },
       ],
     },


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/pull/29586

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Sorry for this, I find that, in this pull request, this judgment condition has some effect.

```
// /pages/[params]/[id].vue
// not work
definePageMeta({
   props: true,
})
```

```
if (property.value.type !== 'Literal' || (typeof property.value.value !== 'string' && typeof property.value.value !== 'boolean')) {
```

Please recheck this. @danielroe 

Thank you very much❤

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
