### PR TITLE
docs: add warning you should not prefix sensitive with NUXT_

### DIFF
--- a/docs/1.getting-started/3.configuration.md
+++ b/docs/1.getting-started/3.configuration.md
@@ -44,7 +44,7 @@ export default defineNuxtConfig({
     //
   },
   $myCustomName: {
-    // 
+    //
   },
 })
 ```
@@ -87,6 +87,8 @@ export default defineNuxtConfig({
 NUXT_API_SECRET=api_secret_token
 ```
 
+::warning
+Remember that all prefix NUXT_ are available in the client. Therefore you should not prefix sensitive ENV data with NUXT_.
 ::
 
 These variables are exposed to the rest of your application using the [`useRuntimeConfig()`](/docs/api/composables/use-runtime-config) composable.

--- a/docs/2.guide/3.going-further/10.runtime-config.md
+++ b/docs/2.guide/3.going-further/10.runtime-config.md
@@ -72,6 +72,10 @@ NUXT_API_SECRET=api_secret_token
 NUXT_PUBLIC_API_BASE=https://nuxtjs.org
 ```
 
+::warning
+Remember that all prefix NUXT_ are available in the client. Therefore you should not prefix sensitive ENV data with NUXT_.
+::
+
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   runtimeConfig: {

--- a/docs/3.api/2.composables/use-runtime-config.md
+++ b/docs/3.api/2.composables/use-runtime-config.md
@@ -87,6 +87,10 @@ NUXT_PUBLIC_API_BASE = "https://api.localhost:5555"
 NUXT_API_SECRET = "123"
 ```
 
+::warning
+Remember that all prefix NUXT_ are available in the client. Therefore you should not prefix sensitive ENV data with NUXT_.
+::
+
 ::note
 Any environment variables set within `.env` file are accessed using `process.env` in the Nuxt app during **development** and **build/generate**.
 ::

--- a/docs/7.migration/8.runtime-config.md
+++ b/docs/7.migration/8.runtime-config.md
@@ -55,4 +55,8 @@ NUXT_API_SECRET=api_secret_token
 NUXT_PUBLIC_API_BASE=https://nuxtjs.org
 ```
 
+::warning
+Remember that all prefix NUXT_ are available in the client. Therefore you should not prefix sensitive ENV data with NUXT_.
+::
+
 ::

--- a/docs/7.migration/8.runtime-config.md
+++ b/docs/7.migration/8.runtime-config.md
@@ -55,8 +55,8 @@ NUXT_API_SECRET=api_secret_token
 NUXT_PUBLIC_API_BASE=https://nuxtjs.org
 ```
 
-::warning
-Remember that all prefix NUXT_ are available in the client. Therefore you should not prefix sensitive ENV data with NUXT_.
 ::
 
+::warning
+Remember that all prefix NUXT_ are available in the client. Therefore you should not prefix sensitive ENV data with NUXT_.
 ::


### PR DESCRIPTION
### 🔗 Linked issue
- no issue open

### 📚 Description
This PR adds an important security note to the documentation regarding the usage of the `NUXT_` prefix for environment variables. The change explicitly warns developers that all environment variables with the `NUXT_` prefix are exposed to the client-side, and therefore should not be used for sensitive data.

The addition helps prevent potential security vulnerabilities where developers might unknowingly expose sensitive information (like API keys, database credentials, etc.) to the client by using the `NUXT_` prefix.

Changes made:
- Added a clear warning about `NUXT_` prefixed environment variables being available on the client
- Included a recommendation against using this prefix for sensitive data

This documentation improvement aligns with security best practices and helps developers make informed decisions about handling sensitive configuration data in their Nuxt applications.

Please review this addition to ensure it effectively communicates this important security consideration to our users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Documentation Updates**
	- Enhanced clarity on Nuxt configuration, particularly regarding environment variables and security warnings.
	- Added guidance on using `useRuntimeConfig` for environment variables in Nuxt 3.
	- Expanded sections on runtime configuration, including client-side vs. server-side access.
	- Provided migration instructions from Nuxt 2 to Nuxt 3 with practical code examples.
	- Emphasized security best practices to prevent exposure of sensitive information, particularly regarding `NUXT_` prefixed variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->