### PR TITLE
fix(nuxt): update nitropack preset directory

### DIFF
--- a/packages/nuxt/src/core/plugins/import-protection.ts
+++ b/packages/nuxt/src/core/plugins/import-protection.ts
@@ -36,7 +36,7 @@ export const createImportProtectionPatterns = (nuxt: { options: NuxtOptions }, o
     ])
   }
 
-  for (const i of [/(^|node_modules\/)@nuxt\/(kit|test-utils)/, /(^|node_modules\/)nuxi/, /(^|node_modules\/)nitro(?:pack)?(?:-nightly)?(?:$|\/)(?!(?:dist\/)?runtime|types)/, /(^|node_modules\/)nuxt\/(config|kit|schema)/]) {
+  for (const i of [/(^|node_modules\/)@nuxt\/(kit|test-utils)/, /(^|node_modules\/)nuxi/, /(^|node_modules\/)nitro(?:pack)?(?:-nightly)?(?:$|\/)(?!(?:dist\/)?presets|runtime|types)/, /(^|node_modules\/)nuxt\/(config|kit|schema)/]) {
     patterns.push([i, `This module cannot be imported in ${context}.`])
   }
 

--- a/packages/nuxt/src/core/plugins/import-protection.ts
+++ b/packages/nuxt/src/core/plugins/import-protection.ts
@@ -36,7 +36,7 @@ export const createImportProtectionPatterns = (nuxt: { options: NuxtOptions }, o
     ])
   }
 
-  for (const i of [/(^|node_modules\/)@nuxt\/(kit|test-utils)/, /(^|node_modules\/)nuxi/, /(^|node_modules\/)nitro(?:pack)?(?:-nightly)?(?:$|\/)(?!(?:dist\/)?presets|runtime|types)/, /(^|node_modules\/)nuxt\/(config|kit|schema)/]) {
+  for (const i of [/(^|node_modules\/)@nuxt\/(kit|test-utils)/, /(^|node_modules\/)nuxi/, /(^|node_modules\/)nitro(?:pack)?(?:-nightly)?(?:$|\/)(?!(?:dist\/)?(?:presets|runtime|types))/, /(^|node_modules\/)nuxt\/(config|kit|schema)/]) {
     patterns.push([i, `This module cannot be imported in ${context}.`])
   }
 

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -37,32 +37,67 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(rootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"0.0k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"208k"`)
 
     const modules = await analyzeSizes(['node_modules/**/*'], serverDir)
-    expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"0.0k"`)
+    expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"1394k"`)
 
     const packages = modules.files
       .filter(m => m.endsWith('package.json'))
       .map(m => m.replace('/package.json', '').replace('node_modules/', ''))
       .sort()
-    expect(packages).toMatchInlineSnapshot(`[]`)
+    expect(packages).toMatchInlineSnapshot(`
+      [
+        "@babel/parser",
+        "@unhead/dom",
+        "@unhead/shared",
+        "@unhead/ssr",
+        "@vue/compiler-core",
+        "@vue/compiler-dom",
+        "@vue/compiler-ssr",
+        "@vue/reactivity",
+        "@vue/runtime-core",
+        "@vue/runtime-dom",
+        "@vue/server-renderer",
+        "@vue/shared",
+        "db0",
+        "devalue",
+        "entities",
+        "estree-walker",
+        "hookable",
+        "source-map-js",
+        "ufo",
+        "unhead",
+        "vue",
+        "vue-bundle-renderer",
+      ]
+    `)
   })
 
   it('default server bundle size (inlined vue modules)', async () => {
     const serverDir = join(rootDir, '.output-inline/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"0.0k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"557k"`)
 
     const modules = await analyzeSizes(['node_modules/**/*'], serverDir)
-    expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"0.0k"`)
+    expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"94.4k"`)
 
     const packages = modules.files
       .filter(m => m.endsWith('package.json'))
       .map(m => m.replace('/package.json', '').replace('node_modules/', ''))
       .sort()
-    expect(packages).toMatchInlineSnapshot(`[]`)
+    expect(packages).toMatchInlineSnapshot(`
+      [
+        "@unhead/dom",
+        "@unhead/shared",
+        "@unhead/ssr",
+        "db0",
+        "devalue",
+        "hookable",
+        "unhead",
+      ]
+    `)
   })
 })
 

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -37,67 +37,32 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(rootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"208k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"0.0k"`)
 
     const modules = await analyzeSizes(['node_modules/**/*'], serverDir)
-    expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"1394k"`)
+    expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"0.0k"`)
 
     const packages = modules.files
       .filter(m => m.endsWith('package.json'))
       .map(m => m.replace('/package.json', '').replace('node_modules/', ''))
       .sort()
-    expect(packages).toMatchInlineSnapshot(`
-      [
-        "@babel/parser",
-        "@unhead/dom",
-        "@unhead/shared",
-        "@unhead/ssr",
-        "@vue/compiler-core",
-        "@vue/compiler-dom",
-        "@vue/compiler-ssr",
-        "@vue/reactivity",
-        "@vue/runtime-core",
-        "@vue/runtime-dom",
-        "@vue/server-renderer",
-        "@vue/shared",
-        "db0",
-        "devalue",
-        "entities",
-        "estree-walker",
-        "hookable",
-        "source-map-js",
-        "ufo",
-        "unhead",
-        "vue",
-        "vue-bundle-renderer",
-      ]
-    `)
+    expect(packages).toMatchInlineSnapshot(`[]`)
   })
 
   it('default server bundle size (inlined vue modules)', async () => {
     const serverDir = join(rootDir, '.output-inline/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"557k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"0.0k"`)
 
     const modules = await analyzeSizes(['node_modules/**/*'], serverDir)
-    expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"94.4k"`)
+    expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"0.0k"`)
 
     const packages = modules.files
       .filter(m => m.endsWith('package.json'))
       .map(m => m.replace('/package.json', '').replace('node_modules/', ''))
       .sort()
-    expect(packages).toMatchInlineSnapshot(`
-      [
-        "@unhead/dom",
-        "@unhead/shared",
-        "@unhead/ssr",
-        "db0",
-        "devalue",
-        "hookable",
-        "unhead",
-      ]
-    `)
+    expect(packages).toMatchInlineSnapshot(`[]`)
   })
 })
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/29777
resolves https://github.com/nitrojs/nitro/issues/2846

### 📚 Description

this updates the preset directory for Nitro v2.10+.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced import protection rules to exclude the `presets` directory from module imports.

- **Bug Fixes**
	- Improved regex pattern for better handling of module import patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->