### PR TITLE
docs: fix tip formatting

### DIFF
--- a/docs/1.getting-started/6.data-fetching.md
+++ b/docs/1.getting-started/6.data-fetching.md
@@ -117,7 +117,7 @@ Be very careful before proxying headers to an external API and just include head
 
 ::tip
 You can also use [`useRequestFetch`](/docs/api/composables/use-request-fetch) to proxy headers to the call automatically.
-:::
+::
 
 ## `useFetch`
 


### PR DESCRIPTION
### 📚 Description

Fix formatting of https://nuxt.com/docs/getting-started/data-fetching#usefetch docs by removing one to many `:` in `tip` block.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced explanations of data fetching in Nuxt, focusing on `useFetch`, `useAsyncData`, and `$fetch`.
	- Expanded sections on the necessity of using `useFetch` and `useAsyncData` to prevent issues like double fetching.
	- Introduced a new section on `Suspense` for managing asynchronous data.
	- Added examples for `useFetch` and `useAsyncData`, including handling loading states and caching.
	- Included detailed explanations on passing headers, cookies, and serialization of data.
	- Added practical use cases in the recipes section, such as consuming Server-Sent Events (SSE).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->