### PR TITLE
fix(nuxt,kit): getNuxtModuleVersion not returning version

### DIFF
--- a/packages/kit/src/module/compatibility.ts
+++ b/packages/kit/src/module/compatibility.ts
@@ -58,8 +58,8 @@ export async function getNuxtModuleVersion (module: string | NuxtModule, nuxt: N
   }
   // it's possible that the module will be installed, it just hasn't been done yet, preemptively load the instance
   if (hasNuxtModule(moduleMeta.name)) {
-    const { nuxtModule } = await loadNuxtModuleInstance(moduleMeta.name, nuxt);
-    return nuxtModule.meta.version || false;
+    const { nuxtModule } = await loadNuxtModuleInstance(moduleMeta.name, nuxt)
+    return nuxtModule.meta.version || false
   }
   return false
 }

--- a/packages/kit/src/module/compatibility.ts
+++ b/packages/kit/src/module/compatibility.ts
@@ -59,7 +59,7 @@ export async function getNuxtModuleVersion (module: string | NuxtModule, nuxt: N
   // it's possible that the module will be installed, it just hasn't been done yet, preemptively load the instance
   if (hasNuxtModule(moduleMeta.name)) {
     const { nuxtModule, buildTimeModuleMeta } = await loadNuxtModuleInstance(moduleMeta.name, nuxt)
-    return buildTimeModuleMeta.version || nuxtModule.meta.version || false
+    return buildTimeModuleMeta.version || await nuxtModule.getMeta?.().then(r => r.version) || false
   }
   return false
 }

--- a/packages/kit/src/module/compatibility.ts
+++ b/packages/kit/src/module/compatibility.ts
@@ -58,8 +58,8 @@ export async function getNuxtModuleVersion (module: string | NuxtModule, nuxt: N
   }
   // it's possible that the module will be installed, it just hasn't been done yet, preemptively load the instance
   if (hasNuxtModule(moduleMeta.name)) {
-    const { nuxtModule } = await loadNuxtModuleInstance(moduleMeta.name, nuxt)
-    return nuxtModule.meta.version || false
+    const { nuxtModule, buildTimeModuleMeta } = await loadNuxtModuleInstance(moduleMeta.name, nuxt)
+    return buildTimeModuleMeta.version || nuxtModule.meta.version || false
   }
   return false
 }

--- a/packages/kit/src/module/compatibility.ts
+++ b/packages/kit/src/module/compatibility.ts
@@ -58,8 +58,8 @@ export async function getNuxtModuleVersion (module: string | NuxtModule, nuxt: N
   }
   // it's possible that the module will be installed, it just hasn't been done yet, preemptively load the instance
   if (hasNuxtModule(moduleMeta.name)) {
-    const { buildTimeModuleMeta } = await loadNuxtModuleInstance(moduleMeta.name, nuxt)
-    return buildTimeModuleMeta.version || false
+    const { nuxtModule } = await loadNuxtModuleInstance(moduleMeta.name, nuxt);
+    return nuxtModule.meta.version || false;
   }
   return false
 }


### PR DESCRIPTION
### 📚 Description

It all started with a warning when using the @nuxtjs/sitemap module.

![image](https://github.com/user-attachments/assets/b5d4b5d6-3ff8-44a7-9df3-f08354089612)

I ended up testing the `getNuxtModuleVersion` method, but it wasn't returning the version of my module.

So, I added `nuxtModule.meta.version` in the return condition. In my case, this solved the issue, as I’m using a remote monorepo composed of layers, one of which includes `@nuxtjs/i18n`. This solution might also help in other similar configurations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved version retrieval for Nuxt modules, ensuring more reliable access to module metadata.

- **Bug Fixes**
	- Enhanced error handling in the version retrieval process, providing fallback options when build-time metadata is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->