### PR TITLE
docs: add link to h3 blogpost

### DIFF
--- a/docs/2.guide/2.directory-structure/1.server.md
+++ b/docs/2.guide/2.directory-structure/1.server.md
@@ -158,7 +158,7 @@ export default defineEventHandler((event) => {
 })
 ```
 
-::tip{to="https://unjs.io/blog/2023-08-15-h3-towards-the-edge-of-the-web#runtime-type-safe-request-utils"}
+::tip{to="https://h3.unjs.io/examples/validate-data#validate-params"}
 Alternatively, use `getValidatedRouterParams` with a schema validator such as Zod for runtime and type safety.
 ::
 

--- a/docs/2.guide/2.directory-structure/1.server.md
+++ b/docs/2.guide/2.directory-structure/1.server.md
@@ -158,7 +158,7 @@ export default defineEventHandler((event) => {
 })
 ```
 
-::tip
+::tip{to="https://unjs.io/blog/2023-08-15-h3-towards-the-edge-of-the-web#runtime-type-safe-request-utils"}
 Alternatively, use `getValidatedRouterParams` with a schema validator such as Zod for runtime and type safety.
 ::
 


### PR DESCRIPTION
This is also done here:

https://github.com/nuxt/nuxt/blob/71c2413cf4f973a09f527a351194c0ec91b92c44/docs/2.guide/2.directory-structure/1.server.md?plain=1#L237-L239

~As the function described in the blog post also refers to `getValidatedRouterParams`, it should also be clickable.~

I'm linking to an example of the `unjs` page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced clarity on server directory structure, including API, routes, middleware, and plugins.
	- Expanded explanations on server routes, middleware usage, and error handling.
	- Introduced sections on runtime configuration and cookie handling in server routes.
	- Added advanced usage scenarios for nested routers and legacy middleware handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->