### PR TITLE
fix(kit): use `mlly` to resolve module paths to avoid cjs fallback

### DIFF
--- a/packages/kit/src/module/install.ts
+++ b/packages/kit/src/module/install.ts
@@ -77,12 +77,11 @@ export async function loadNuxtModuleInstance (nuxtModule: string | NuxtModule, n
 
   // Import if input is string
   if (typeof nuxtModule === 'string') {
-    nuxtModule = resolveAlias(nuxtModule)
     const paths = [join(nuxtModule, 'nuxt'), join(nuxtModule, 'module'), nuxtModule, join(nuxt.options.rootDir, nuxtModule)]
     for (const path of paths) {
       for (const parentURL of nuxt.options.modulesDir) {
         try {
-          const src = await resolveModule(path, { url: parentURL.replace(/\/node_modules\/?$/, ''), extensions: nuxt.options.extensions })
+          const src = await resolveModule(resolveAlias(path), { url: parentURL.replace(/\/node_modules\/?$/, ''), extensions: nuxt.options.extensions })
           nuxtModule = await jiti.import(src, { default: true }) as NuxtModule
 
           // nuxt-module-builder generates a module.json with metadata including the version

--- a/packages/kit/src/module/install.ts
+++ b/packages/kit/src/module/install.ts
@@ -3,6 +3,7 @@ import type { ModuleMeta, Nuxt, NuxtConfig, NuxtModule } from '@nuxt/schema'
 import { dirname, isAbsolute, join, resolve } from 'pathe'
 import { defu } from 'defu'
 import { createJiti } from 'jiti'
+import { resolve as resolveModule } from 'mlly'
 import { useNuxt } from '../context'
 import { resolveAlias } from '../resolve'
 import { logger } from '../logger'
@@ -76,12 +77,12 @@ export async function loadNuxtModuleInstance (nuxtModule: string | NuxtModule, n
 
   // Import if input is string
   if (typeof nuxtModule === 'string') {
-    const paths = [join(nuxtModule, 'nuxt'), join(nuxtModule, 'module'), nuxtModule, join(nuxt.options.rootDir, nuxtModule)]
+    const paths = [nuxtModule, join(nuxtModule, 'nuxt'), join(nuxtModule, 'module'), join(nuxt.options.rootDir, nuxtModule), join(nuxtModule, 'index')]
 
-    for (const parentURL of nuxt.options.modulesDir) {
-      for (const path of paths) {
+    for (const path of paths) {
+      for (const parentURL of nuxt.options.modulesDir) {
         try {
-          const src = jiti.esmResolve(path, { parentURL: parentURL.replace(/\/node_modules\/?$/, '') })
+          const src = await resolveModule(path, { url: parentURL.replace(/\/node_modules\/?$/, ''), extensions: nuxt.options.extensions })
           nuxtModule = await jiti.import(src, { default: true }) as NuxtModule
 
           // nuxt-module-builder generates a module.json with metadata including the version

--- a/packages/kit/src/module/install.ts
+++ b/packages/kit/src/module/install.ts
@@ -7,6 +7,7 @@ import { resolve as resolveModule } from 'mlly'
 import { useNuxt } from '../context'
 import { resolveAlias } from '../resolve'
 import { logger } from '../logger'
+import { pathToFileURL } from 'node:url'
 
 const NODE_MODULES_RE = /[/\\]node_modules[/\\]/
 
@@ -81,7 +82,7 @@ export async function loadNuxtModuleInstance (nuxtModule: string | NuxtModule, n
     for (const path of paths) {
       for (const parentURL of nuxt.options.modulesDir) {
         try {
-          const src = await resolveModule(resolveAlias(path), { url: parentURL.replace(/\/node_modules\/?$/, ''), extensions: nuxt.options.extensions })
+          const src = await resolveModule(resolveAlias(path), { url: pathToFileURL(parentURL.replace(/\/node_modules\/?$/, '')), extensions: nuxt.options.extensions })
           nuxtModule = await jiti.import(src, { default: true }) as NuxtModule
 
           // nuxt-module-builder generates a module.json with metadata including the version

--- a/packages/kit/src/module/install.ts
+++ b/packages/kit/src/module/install.ts
@@ -1,4 +1,5 @@
 import { existsSync, promises as fsp, lstatSync } from 'node:fs'
+import { pathToFileURL } from 'node:url'
 import type { ModuleMeta, Nuxt, NuxtConfig, NuxtModule } from '@nuxt/schema'
 import { dirname, isAbsolute, join, resolve } from 'pathe'
 import { defu } from 'defu'
@@ -7,7 +8,6 @@ import { resolve as resolveModule } from 'mlly'
 import { useNuxt } from '../context'
 import { resolveAlias } from '../resolve'
 import { logger } from '../logger'
-import { pathToFileURL } from 'node:url'
 
 const NODE_MODULES_RE = /[/\\]node_modules[/\\]/
 

--- a/packages/kit/src/module/install.ts
+++ b/packages/kit/src/module/install.ts
@@ -77,8 +77,8 @@ export async function loadNuxtModuleInstance (nuxtModule: string | NuxtModule, n
 
   // Import if input is string
   if (typeof nuxtModule === 'string') {
-    const paths = [nuxtModule, join(nuxtModule, 'nuxt'), join(nuxtModule, 'module'), join(nuxt.options.rootDir, nuxtModule), join(nuxtModule, 'index')]
-
+    nuxtModule = resolveAlias(nuxtModule)
+    const paths = [join(nuxtModule, 'nuxt'), join(nuxtModule, 'module'), nuxtModule, join(nuxt.options.rootDir, nuxtModule)]
     for (const path of paths) {
       for (const parentURL of nuxt.options.modulesDir) {
         try {
@@ -93,7 +93,7 @@ export async function loadNuxtModuleInstance (nuxtModule: string | NuxtModule, n
           break
         } catch (error: unknown) {
           const code = (error as Error & { code?: string }).code
-          if (code === 'MODULE_NOT_FOUND' || code === 'ERR_PACKAGE_PATH_NOT_EXPORTED' || code === 'ERR_MODULE_NOT_FOUND' || code === 'ERR_UNSUPPORTED_DIR_IMPORT') {
+          if (code === 'MODULE_NOT_FOUND' || code === 'ERR_PACKAGE_PATH_NOT_EXPORTED' || code === 'ERR_MODULE_NOT_FOUND' || code === 'ERR_UNSUPPORTED_DIR_IMPORT' || code === 'ENOTDIR') {
             continue
           }
           logger.error(`Error while importing module \`${nuxtModule}\`: ${error}`)


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/29779
resolves https://github.com/unovue/shadcn-vue/issues/864

### 📚 Description

`jiti.esmResolve` was falling back to `require.resolve` if it couldn't find a path; this fix ensures that we don't fallback to the CJS path

in addition, we should speed up resolution by iterating over the paths/urls differently (for the most common use case, the exact string in `modules` is the thing that should be imported, not the `/nuxt` or `/module` subpaths)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced module resolution logic for improved path handling.
	- Refined error handling during module loading to increase robustness.

- **Bug Fixes**
	- Improved error logging for better debugging of module imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->