### PR TITLE
fix(webpack,rspack): add adapter for webpack-dev-middleware

### DIFF
--- a/packages/webpack/src/webpack.ts
+++ b/packages/webpack/src/webpack.ts
@@ -1,8 +1,7 @@
 import pify from 'pify'
-import type { NodeMiddleware } from 'h3'
 import { resolve } from 'pathe'
 import { defineEventHandler, fromNodeMiddleware } from 'h3'
-import type { MultiWatching } from 'webpack-dev-middleware'
+import type { IncomingMessage, MultiWatching, ServerResponse } from 'webpack-dev-middleware'
 import webpackDevMiddleware from 'webpack-dev-middleware'
 import webpackHotMiddleware from 'webpack-hot-middleware'
 import type { Compiler, Stats, Watching } from 'webpack'
@@ -130,16 +129,49 @@ async function createDevMiddleware (compiler: Compiler) {
     path: joinURL(nuxt.options.app.baseURL, '__webpack_hmr', compiler.options.name!),
     ...hotMiddlewareOptions,
   })
-
-  // Register devMiddleware on server
-  const devHandler = fromNodeMiddleware(devMiddleware as NodeMiddleware)
-  const hotHandler = fromNodeMiddleware(hotMiddleware as NodeMiddleware)
+  const devHandler = wdmToH3Handler(devMiddleware)
+  const hotHandler = fromNodeMiddleware(hotMiddleware)
   await nuxt.callHook('server:devHandler', defineEventHandler(async (event) => {
-    await devHandler(event)
+    const body = await devHandler(event)
+    if (body !== undefined) {
+      return body
+    }
     await hotHandler(event)
   }))
 
   return devMiddleware
+}
+
+function wdmToH3Handler (devMiddleware: webpackDevMiddleware.API<IncomingMessage, ServerResponse>) {
+  return defineEventHandler(async (event) => {
+    event.context.webpack = {
+      ...event.context.webpack,
+      devMiddleware: devMiddleware.context,
+    }
+    const { req, res } = event.node
+    const body = await new Promise((resolve, reject) => {
+      // @ts-expect-error handle injected methods
+      res.stream = (stream) => {
+        resolve(stream)
+      }
+      // @ts-expect-error handle injected methods
+      res.send = (data) => {
+        resolve(data)
+      }
+      // @ts-expect-error handle injected methods
+      res.finish = (data) => {
+        resolve(data)
+      }
+      devMiddleware(req, res, (err) => {
+        if (err) {
+          reject(err)
+        } else {
+          resolve(undefined)
+        }
+      })
+    })
+    return body
+  })
 }
 
 async function compile (compiler: Compiler) {

--- a/packages/webpack/src/webpack.ts
+++ b/packages/webpack/src/webpack.ts
@@ -129,6 +129,8 @@ async function createDevMiddleware (compiler: Compiler) {
     path: joinURL(nuxt.options.app.baseURL, '__webpack_hmr', compiler.options.name!),
     ...hotMiddlewareOptions,
   })
+
+  // Register devMiddleware on server
   const devHandler = wdmToH3Handler(devMiddleware)
   const hotHandler = fromNodeMiddleware(hotMiddleware)
   await nuxt.callHook('server:devHandler', defineEventHandler(async (event) => {
@@ -142,6 +144,7 @@ async function createDevMiddleware (compiler: Compiler) {
   return devMiddleware
 }
 
+// TODO: implement upstream in `webpack-dev-middleware`
 function wdmToH3Handler (devMiddleware: webpackDevMiddleware.API<IncomingMessage, ServerResponse>) {
   return defineEventHandler(async (event) => {
     event.context.webpack = {


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/unjs/nitro/issues/2541

### 📚 Description

this adds an adapter for `webpack-dev-middleware` when used with nitro.

ultimately this will need to be a change in `webpack-dev-middleware` itself but this is a hotfix until that point

we might see if we can implement in a way that is forwards-compatible (so self-disabling once this feature exists in wdm)?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced middleware handling for improved event context and response management.
	- Introduced a new function for better integration of development middleware.

- **Improvements**
	- Updated type imports for enhanced type safety in middleware operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->