### PR TITLE
fix(nuxt): remove null-byte prefix for virtual files

### DIFF
--- a/packages/nuxt/src/core/plugins/virtual.ts
+++ b/packages/nuxt/src/core/plugins/virtual.ts
@@ -3,7 +3,7 @@ import type { Nuxt } from '@nuxt/schema'
 import { dirname, isAbsolute, resolve } from 'pathe'
 import { createUnplugin } from 'unplugin'
 
-const PREFIX = '\0virtual:nuxt:'
+const PREFIX = 'virtual:nuxt:'
 
 interface VirtualFSPluginOptions {
   mode: 'client' | 'server'


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/29787
resolves https://github.com/nuxt/nuxt/issues/29797

### 📚 Description

The additional null byte `\0` before the prefix for virtual files seems to prevent layouts from being processed (either with vue files or by unocss). This probably had a performance benefit so there could be something to investigate/improve here in future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the virtual file identifier prefix to improve compatibility and functionality within the plugin.
  
This change enhances the overall performance and reliability of virtual file handling in the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->