### PR TITLE
docs: first pass at the shared directory documentation

### DIFF
--- a/docs/2.guide/2.directory-structure/1.shared.md
+++ b/docs/2.guide/2.directory-structure/1.shared.md
@@ -1,0 +1,77 @@
+﻿---
+title: 'shared'
+head.title: 'shared/'
+description: Use the shared/ directory to share functionality between the Vue app and the Nitro server.
+navigation.icon: i-ph-folder
+---
+
+The `shared/` directory allows you to share code that can be used in both the Vue app and the Nitro server.
+
+::tip
+The `shared/` directory is available in Nuxt v3.14+.
+::
+
+::important
+Code in the shared directory cannot import any Vue or nitro code.
+::
+
+## Usage
+
+**Method 1:** Using named export
+
+```ts twoslash [shared/utils/capitalize.ts]
+export const capitalize = (input: string) => {
+  return input[0].toUpperCase() + input.slice(1)
+}
+```
+
+**Method 2:** Using default export
+
+```ts twoslash [shared/utils/capitalize.ts]
+export default function capitalize (input: string) {
+  return input[0].toUpperCase() + input.slice(1)
+}
+```
+
+**Usage:** You can now use auto-imported utility functions in `.js`, `.ts` and `.vue` files within your Vue app and the `server/` directory. 
+
+If you are using `compatibilityVersion: 4`, you can use the auto-imported functions in the `app/` directory.
+
+```vue [app.vue]
+<script setup lang="ts">
+const hello = capitalize('hello')
+</script>
+
+<template>
+  <div>
+    {{ hello }}
+  </div>
+</template>
+```
+
+```ts [server/api/hello.get.ts]
+export default defineEventHandler((event) => {
+  return {
+    hello: capitalize('hello')
+  }
+})
+```
+
+## Auto Imports
+
+Only files in the `shared/utils/` and `shared/types/` directories will be auto-imported.
+
+```bash [Directory Structure]
+-| shared/
+---| foo.ts        # Not auto-imported
+---| utils/
+-----| bar.ts      # Auto-imported
+---| types/
+-----| bar.d.ts    # Auto-imported
+```
+
+Any other files you create in the shared folder must be manually imported using `import foo from '#shared/foo'`.
+
+This includes nested directories. A file located at `shared/formatters/lower.ts` will be imported with `import lower from '#shared/formatters/lower'`.
+
+:read-more{to="/docs/guide/concepts/auto-imports"}

--- a/docs/2.guide/2.directory-structure/1.shared.md
+++ b/docs/2.guide/2.directory-structure/1.shared.md
@@ -37,6 +37,8 @@ export default function capitalize (input: string) {
 
 If you have set `compatibilityVersion: 4` in your `nuxt.config.ts`, you can use the auto-imported functions in the `app/` directory. This is part of Nuxt's progressive compatibility features preparing for version 4.
 
+If you have [set `compatibilityVersion: 4` in your `nuxt.config.ts`](https://nuxt.com/docs/getting-started/upgrade#opting-in-to-nuxt-4), you can use the auto-imported functions in the `app/` directory. This is part of Nuxt's progressive compatibility features preparing for version 4.
+
 ```vue [app.vue]
 <script setup lang="ts">
 const hello = capitalize('hello')

--- a/docs/2.guide/2.directory-structure/1.shared.md
+++ b/docs/2.guide/2.directory-structure/1.shared.md
@@ -35,8 +35,6 @@ export default function capitalize (input: string) {
 
 **Usage:** You can now use auto-imported utility functions in `.js`, `.ts` and `.vue` files within your Vue app and the `server/` directory.
 
-If you have set `compatibilityVersion: 4` in your `nuxt.config.ts`, you can use the auto-imported functions in the `app/` directory. This is part of Nuxt's progressive compatibility features preparing for version 4.
-
 If you have [set `compatibilityVersion: 4` in your `nuxt.config.ts`](https://nuxt.com/docs/getting-started/upgrade#opting-in-to-nuxt-4), you can use the auto-imported functions in the `app/` directory. This is part of Nuxt's progressive compatibility features preparing for version 4.
 
 ```vue [app.vue]

--- a/docs/2.guide/2.directory-structure/1.shared.md
+++ b/docs/2.guide/2.directory-structure/1.shared.md
@@ -35,7 +35,7 @@ export default function capitalize (input: string) {
 
 **Usage:** You can now use auto-imported utility functions in `.js`, `.ts` and `.vue` files within your Vue app and the `server/` directory. 
 
-If you are using `compatibilityVersion: 4`, you can use the auto-imported functions in the `app/` directory.
+If you have set `compatibilityVersion: 4` in your `nuxt.config.ts`, you can use the auto-imported functions in the `app/` directory. This is part of Nuxt's progressive compatibility features preparing for version 4.
 
 ```vue [app.vue]
 <script setup lang="ts">
@@ -59,19 +59,34 @@ export default defineEventHandler((event) => {
 
 ## Auto Imports
 
-Only files in the `shared/utils/` and `shared/types/` directories will be auto-imported.
+Only files in the `shared/utils/` and `shared/types/` directories will be auto-imported. Files nested in directories within `shared/utils/` or `shared/types/` will not be auto-imported.
 
 ```bash [Directory Structure]
 -| shared/
----| foo.ts        # Not auto-imported
+---| capitalize.ts        # Not auto-imported
+---| fotmatters
+-----| lower.ts           # Not auto-imported
 ---| utils/
------| bar.ts      # Auto-imported
+-----| lower.ts           # Auto-imported
+-----| formatters
+-------| upper.ts         # Not auto-imported
 ---| types/
------| bar.d.ts    # Auto-imported
+-----| bar.d.ts           # Auto-imported
 ```
 
-Any other files you create in the shared folder must be manually imported using `import foo from '#shared/foo'`.
+Any other files you create in the shared folder must be manually imported using the `#shared` alias (automatically configured by Nuxt):
 
-This includes nested directories. A file located at `shared/formatters/lower.ts` will be imported with `import lower from '#shared/formatters/lower'`.
+```ts
+// For files directly in the shared directory
+import capitalize from '#shared/capitalize'
+
+// For files in nested directories
+import lower from '#shared/formatters/lower'
+
+// For files nested in a folder within utils
+import upper from '#shared/utils/formatters/upper'
+```
+
+This alias ensures consistent imports across your application, regardless of the importing file's location.
 
 :read-more{to="/docs/guide/concepts/auto-imports"}

--- a/docs/2.guide/2.directory-structure/1.shared.md
+++ b/docs/2.guide/2.directory-structure/1.shared.md
@@ -1,0 +1,77 @@
+﻿---
+title: 'shared'
+head.title: 'shared/'
+description: Use the shared/ directory to share functionality between the Vue app Nitro and server.
+navigation.icon: i-ph-folder
+---
+
+The `shared/` directory allows you to share code that can be used in both the Vue app and the Nitro server.
+
+::tip
+The `shared/` directory is available in Nuxt v3.14+.
+::
+
+::important
+Code in the shared directory cannot import any Vue or nitro code.
+::
+
+## Usage
+
+**Method 1:** Using named export
+
+```ts twoslash [shared/utils/capitalize.ts]
+export const capitalize = (input: string) => {
+  return input[0].toUpperCase() + input.slice(1)
+}
+```
+
+**Method 2:** Using default export
+
+```ts twoslash [shared/utils/capitalize.ts]
+export default function capitalize (input: string) {
+  return input[0].toUpperCase() + input.slice(1)
+}
+```
+
+**Usage:** You can now use auto-imported utility functions in `.js`, `.ts` and `.vue` files within your Vue app and the `server/` directory. 
+
+If you are using `compatibilityVersion: 4`, you can use the auto-imported functions in the `app/` directory.
+
+```vue [app.vue]
+<script setup lang="ts">
+const hello = capitalize('hello')
+</script>
+
+<template>
+  <div>
+    {{ hello }}
+  </div>
+</template>
+```
+
+```ts [server/api/hello.get.ts]
+export default defineEventHandler((event) => {
+  return {
+    hello: capitalize('hello')
+  }
+})
+```
+
+## Auto Imports
+
+Only files in the `shared/utils/` and `shared/types/` directories will be auto-imported.
+
+```bash [Directory Structure]
+-| shared/
+---| foo.ts        # Not auto-imported
+---| utils/
+-----| bar.ts      # Auto-imported
+---| types/
+-----| bar.d.ts    # Auto-imported
+```
+
+Any other files you create in the shared folder must be manually imported using `import foo from '#shared/foo'`.
+
+This includes nested directories. A file located at `shared/formatters/lower.ts` will be imported with `import lower from '#shared/formatters/lower'`.
+
+:read-more{to="/docs/guide/concepts/auto-imports"}

--- a/docs/2.guide/2.directory-structure/1.shared.md
+++ b/docs/2.guide/2.directory-structure/1.shared.md
@@ -12,7 +12,7 @@ The `shared/` directory is available in Nuxt v3.14+.
 ::
 
 ::important
-Code in the shared directory cannot import any Vue or nitro code.
+Code in the `shared/` directory cannot import any Vue or Nitro code.
 ::
 
 ## Usage
@@ -59,7 +59,13 @@ export default defineEventHandler((event) => {
 
 ## Auto Imports
 
-Only files in the `shared/utils/` and `shared/types/` directories will be auto-imported. Files nested in directories within `shared/utils/` or `shared/types/` will not be auto-imported.
+Only files in the `shared/utils/` and `shared/types/` directories will be auto-imported. Files nested within subdirectories of these directories will not be auto-imported.
+
+::tip
+The way `shared/utils` and `shared/types` auto-imports work and are scanned is identical to the [`composables/`](/docs/guide/directory-structure/composables) and [`utils/`](/docs/guide/directory-structure/utils) directories.
+::
+
+:read-more{to="/docs/guide/directory-structure/composables#how-files-are-scanned"}
 
 ```bash [Directory Structure]
 -| shared/
@@ -74,7 +80,7 @@ Only files in the `shared/utils/` and `shared/types/` directories will be auto-i
 -----| bar.d.ts           # Auto-imported
 ```
 
-Any other files you create in the shared folder must be manually imported using the `#shared` alias (automatically configured by Nuxt):
+Any other files you create in the `shared/` folder must be manually imported using the `#shared` alias (automatically configured by Nuxt):
 
 ```ts
 // For files directly in the shared directory

--- a/docs/2.guide/2.directory-structure/1.shared.md
+++ b/docs/2.guide/2.directory-structure/1.shared.md
@@ -7,7 +7,7 @@ navigation.icon: 'i-ph-folder'
 
 The `shared/` directory allows you to share code that can be used in both the Vue app and the Nitro server.
 
-::tip
+::note
 The `shared/` directory is available in Nuxt v3.14+.
 ::
 

--- a/docs/2.guide/2.directory-structure/1.shared.md
+++ b/docs/2.guide/2.directory-structure/1.shared.md
@@ -1,8 +1,8 @@
 ﻿---
 title: 'shared'
 head.title: 'shared/'
-description: Use the shared/ directory to share functionality between the Vue app and the Nitro server.
-navigation.icon: i-ph-folder
+description: 'Use the shared/ directory to share functionality between the Vue app and the Nitro server.'
+navigation.icon: 'i-ph-folder'
 ---
 
 The `shared/` directory allows you to share code that can be used in both the Vue app and the Nitro server.
@@ -33,7 +33,7 @@ export default function capitalize (input: string) {
 }
 ```
 
-**Usage:** You can now use auto-imported utility functions in `.js`, `.ts` and `.vue` files within your Vue app and the `server/` directory. 
+**Usage:** You can now use auto-imported utility functions in `.js`, `.ts` and `.vue` files within your Vue app and the `server/` directory.
 
 If you have set `compatibilityVersion: 4` in your `nuxt.config.ts`, you can use the auto-imported functions in the `app/` directory. This is part of Nuxt's progressive compatibility features preparing for version 4.
 
@@ -64,7 +64,7 @@ Only files in the `shared/utils/` and `shared/types/` directories will be auto-i
 ```bash [Directory Structure]
 -| shared/
 ---| capitalize.ts        # Not auto-imported
----| fotmatters
+---| formatters
 -----| lower.ts           # Not auto-imported
 ---| utils/
 -----| lower.ts           # Auto-imported

--- a/docs/2.guide/2.directory-structure/1.shared.md
+++ b/docs/2.guide/2.directory-structure/1.shared.md
@@ -35,7 +35,7 @@ export default function capitalize (input: string) {
 
 **Usage:** You can now use auto-imported utility functions in `.js`, `.ts` and `.vue` files within your Vue app and the `server/` directory.
 
-If you have [set `compatibilityVersion: 4` in your `nuxt.config.ts`](https://nuxt.com/docs/getting-started/upgrade#opting-in-to-nuxt-4), you can use the auto-imported functions in the `app/` directory. This is part of Nuxt's progressive compatibility features preparing for version 4.
+If you have [set `compatibilityVersion: 4` in your `nuxt.config.ts`](/docs/getting-started/upgrade#opting-in-to-nuxt-4), you can use the auto-imported functions in the `app/` directory. This is part of Nuxt's progressive compatibility features preparing for version 4.
 
 ```vue [app.vue]
 <script setup lang="ts">


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #29798

### 📚 Description

This PR will add documentation for the new `shared` directory that was added in v3.14.0. This is a first pass so any additions or corrections would be greatly appreciated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Added comprehensive guidelines for utilizing the `shared/` directory for code sharing between the Vue application and Nitro server, effective from Nuxt version 3.14.
	- Clarified the prohibition of importing Vue or Nitro code within the `shared/` directory to maintain separation of concerns.
	- Detailed methods for exporting utility functions with TypeScript examples and outlined auto-importing processes for `.js`, `.ts`, and `.vue` files.
	- Provided an example directory structure to illustrate auto-import eligibility and manual import requirements for other files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->