### PR TITLE
feat(nuxt): add new types to vue preset

### DIFF
--- a/packages/nuxt/src/imports/presets.ts
+++ b/packages/nuxt/src/imports/presets.ts
@@ -242,6 +242,8 @@ const vueTypesPreset = defineUnimportPreset({
     'Component',
     'ComponentPublicInstance',
     'ComputedRef',
+    'DirectiveBinding',
+    'ExtractDefaultPropTypes',
     'ExtractPropTypes',
     'ExtractPublicPropTypes',
     'InjectionKey',
@@ -250,6 +252,7 @@ const vueTypesPreset = defineUnimportPreset({
     'MaybeRef',
     'MaybeRefOrGetter',
     'VNode',
+    'WritableComputedRef',
   ],
 })
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
related https://github.com/nuxt/nuxt/pull/29203

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
Use the same types in Vue preset used in `unimport`: missing `DirectiveBinding` (missing here and in `unimport`), `ExtractDefaultPropTypes` and `WritableComputedRef` (`MaybeRef`  and `MaybeRefOrGetter` missing in `unimport`)

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced type definitions for Vue components with the addition of `DirectiveBinding` and `WritableComputedRef` in the `vueTypesPreset`.
  
- **Bug Fixes**
	- Improved type safety and developer experience without altering existing logic or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->