### PR TITLE
fix(rspack): rspack builder usage without installing webpack

### DIFF
--- a/packages/rspack/builder.mjs
+++ b/packages/rspack/builder.mjs
@@ -1,5 +1,7 @@
 import webpack from '@rspack/core'
 
+export { default as WebpackBarPlugin } from 'webpackbar/rspack'
+
 export const builder = 'rspack'
 export { webpack }
 export const MiniCssExtractPlugin = webpack.CssExtractRspackPlugin

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -72,7 +72,7 @@
     "webpack-dev-middleware": "^7.4.2",
     "webpack-hot-middleware": "^2.26.1",
     "webpack-virtual-modules": "^0.6.2",
-    "webpackbar": "^6.0.1"
+    "webpackbar": "^7.0.0"
   },
   "devDependencies": {
     "@nuxt/schema": "workspace:*",

--- a/packages/webpack/builder.d.ts
+++ b/packages/webpack/builder.d.ts
@@ -1,8 +1,10 @@
 declare module '#builder' {
   import type Webpack from 'webpack'
+  import type WebpackBarPlugin from 'webpackbar'
   import type MiniCssExtractPlugin from 'mini-css-extract-plugin'
 
   export const webpack: typeof Webpack
+  export const WebpackBarPlugin: typeof WebpackBarPlugin
   export const MiniCssExtractPlugin: typeof MiniCssExtractPlugin
   export const builder: 'webpack' | 'rspack'
 }

--- a/packages/webpack/builder.d.ts
+++ b/packages/webpack/builder.d.ts
@@ -1,10 +1,9 @@
 declare module '#builder' {
   import type Webpack from 'webpack'
-  import type WebpackBarPlugin from 'webpackbar'
   import type MiniCssExtractPlugin from 'mini-css-extract-plugin'
 
   export const webpack: typeof Webpack
-  export const WebpackBarPlugin: typeof WebpackBarPlugin
+  export const WebpackBarPlugin: typeof import('webpackbar').default
   export const MiniCssExtractPlugin: typeof MiniCssExtractPlugin
   export const builder: 'webpack' | 'rspack'
 }

--- a/packages/webpack/builder.mjs
+++ b/packages/webpack/builder.mjs
@@ -1,3 +1,4 @@
 export const builder = 'webpack'
 export { default as webpack } from 'webpack'
 export { default as MiniCssExtractPlugin } from 'mini-css-extract-plugin'
+export { default as WebpackBarPlugin } from 'webpackbar'

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -72,7 +72,7 @@
     "webpack-bundle-analyzer": "^4.10.2",
     "webpack-dev-middleware": "^7.4.2",
     "webpack-hot-middleware": "^2.26.1",
-    "webpackbar": "^6.0.1"
+    "webpackbar": "^7.0.0"
   },
   "devDependencies": {
     "@nuxt/schema": "workspace:*",

--- a/packages/webpack/src/presets/base.ts
+++ b/packages/webpack/src/presets/base.ts
@@ -104,14 +104,15 @@ function basePlugins (ctx: WebpackConfigContext) {
             if (stats.hasErrors()) {
               ctx.nuxt.callHook(`${builder}:error`)
             } else {
-              // @ts-expect-error TODO: this should be valid
+              // @ts-expect-error TODO
               logger.success(`${stats.name} ${stats.message}`)
             }
           },
           allDone: () => {
             ctx.nuxt.callHook(`${builder}:done`)
           },
-          progress (_, { statesArray }) {
+          // @ts-expect-error TODO: there is NO statesArray on type ProgressPlugin, this error is correct
+          progress ({ statesArray }) {
             ctx.nuxt.callHook(`${builder}:progress`, statesArray)
           },
         },

--- a/packages/webpack/src/presets/base.ts
+++ b/packages/webpack/src/presets/base.ts
@@ -94,12 +94,12 @@ function basePlugins (ctx: WebpackConfigContext) {
       stats: !ctx.isDev,
       reporter: {
         reporter: {
-          change: (_, { shortPath }) => {
+          change: (_: any, { shortPath }: any) => {
             if (!ctx.isServer) {
               ctx.nuxt.callHook(`${builder}:change`, shortPath)
             }
           },
-          done: ({ state }) => {
+          done: ({ state }: any) => {
             if (state.hasErrors) {
               ctx.nuxt.callHook(`${builder}:error`)
             } else {
@@ -109,7 +109,7 @@ function basePlugins (ctx: WebpackConfigContext) {
           allDone: () => {
             ctx.nuxt.callHook(`${builder}:done`)
           },
-          progress ({ statesArray }) {
+          progress ({ statesArray }: any) {
             ctx.nuxt.callHook(`${builder}:progress`, statesArray)
           },
         },

--- a/packages/webpack/src/presets/base.ts
+++ b/packages/webpack/src/presets/base.ts
@@ -104,8 +104,7 @@ function basePlugins (ctx: WebpackConfigContext) {
             if (stats.hasErrors()) {
               ctx.nuxt.callHook(`${builder}:error`)
             } else {
-              // @ts-expect-error TODO
-              logger.success(`${stats.name} ${stats.message}`)
+              logger.success(`Finished building ${stats.compilation.name ?? 'Nuxt app'}`)
             }
           },
           allDone: () => {

--- a/packages/webpack/src/presets/base.ts
+++ b/packages/webpack/src/presets/base.ts
@@ -15,7 +15,7 @@ import WarningIgnorePlugin from '../plugins/warning-ignore'
 import type { WebpackConfigContext } from '../utils/config'
 import { applyPresets, fileName } from '../utils/config'
 
-import { builder, webpack } from '#builder'
+import { builder, webpack, WebpackBarPlugin } from '#builder'
 
 export async function base (ctx: WebpackConfigContext) {
   await applyPresets(ctx, [
@@ -88,11 +88,10 @@ function basePlugins (ctx: WebpackConfigContext) {
       server: 'orange',
       modern: 'blue',
     }
-    ctx.config.plugins.push(new WebpackBar({
+    ctx.config.plugins.push(new WebpackBarPlugin({
       name: ctx.name,
       color: colors[ctx.name as keyof typeof colors],
       reporters: ['stats'],
-      // @ts-expect-error TODO: this is a valid option for Webpack.ProgressPlugin and needs to be declared for WebpackBar
       stats: !ctx.isDev,
       reporter: {
         reporter: {

--- a/packages/webpack/src/presets/base.ts
+++ b/packages/webpack/src/presets/base.ts
@@ -91,25 +91,27 @@ function basePlugins (ctx: WebpackConfigContext) {
       name: ctx.name,
       color: colors[ctx.name as keyof typeof colors],
       reporters: ['stats'],
+      // @ts-expect-error TODO: this is a valid option for Webpack.ProgressPlugin and needs to be declared for WebpackBar
       stats: !ctx.isDev,
       reporter: {
         reporter: {
-          change: (_: any, { shortPath }: any) => {
+          change: (_, { shortPath }) => {
             if (!ctx.isServer) {
               ctx.nuxt.callHook(`${builder}:change`, shortPath)
             }
           },
-          done: ({ state }: any) => {
-            if (state.hasErrors) {
+          done: (_, { stats }) => {
+            if (stats.hasErrors()) {
               ctx.nuxt.callHook(`${builder}:error`)
             } else {
-              logger.success(`${state.name} ${state.message}`)
+              // @ts-expect-error TODO: this should be valid
+              logger.success(`${stats.name} ${stats.message}`)
             }
           },
           allDone: () => {
             ctx.nuxt.callHook(`${builder}:done`)
           },
-          progress ({ statesArray }: any) {
+          progress (_, { statesArray }) {
             ctx.nuxt.callHook(`${builder}:progress`, statesArray)
           },
         },

--- a/packages/webpack/src/presets/base.ts
+++ b/packages/webpack/src/presets/base.ts
@@ -111,9 +111,8 @@ function basePlugins (ctx: WebpackConfigContext) {
           allDone: () => {
             ctx.nuxt.callHook(`${builder}:done`)
           },
-          // @ts-expect-error TODO: there is NO statesArray on type ProgressPlugin, this error is correct
-          progress ({ statesArray }) {
-            ctx.nuxt.callHook(`${builder}:progress`, statesArray)
+          progress: ({ webpackbar }) => {
+            ctx.nuxt.callHook(`${builder}:progress`, webpackbar.statesArray)
           },
         },
       },

--- a/packages/webpack/src/presets/base.ts
+++ b/packages/webpack/src/presets/base.ts
@@ -1,7 +1,6 @@
 import { normalize, resolve } from 'pathe'
 // @ts-expect-error missing types
 import TimeFixPlugin from 'time-fix-plugin'
-import WebpackBar from 'webpackbar'
 import type { Configuration } from 'webpack'
 import { logger } from '@nuxt/kit'
 // @ts-expect-error missing types
@@ -15,7 +14,7 @@ import WarningIgnorePlugin from '../plugins/warning-ignore'
 import type { WebpackConfigContext } from '../utils/config'
 import { applyPresets, fileName } from '../utils/config'
 
-import { builder, webpack, WebpackBarPlugin } from '#builder'
+import { WebpackBarPlugin, builder, webpack } from '#builder'
 
 export async function base (ctx: WebpackConfigContext) {
   await applyPresets(ctx, [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -638,8 +638,8 @@ importers:
         specifier: ^0.6.2
         version: 0.6.2
       webpackbar:
-        specifier: ^6.0.1
-        version: 6.0.1(webpack@5.96.1)
+        specifier: ^7.0.0
+        version: 7.0.0(@rspack/core@1.0.14)(webpack@5.96.1)
     devDependencies:
       '@nuxt/schema':
         specifier: workspace:*
@@ -1088,8 +1088,8 @@ importers:
         specifier: ^2.26.1
         version: 2.26.1
       webpackbar:
-        specifier: ^6.0.1
-        version: 6.0.1(webpack@5.96.1)
+        specifier: ^7.0.0
+        version: 7.0.0(@rspack/core@1.0.14)(webpack@5.96.1)
     devDependencies:
       '@nuxt/schema':
         specifier: workspace:*
@@ -3478,6 +3478,10 @@ packages:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
 
+  ansis@3.3.2:
+    resolution: {integrity: sha512-cFthbBlt+Oi0i9Pv/j6YdVWJh54CtjGACaMPCIrEV4Ha7HWsIjXDwseYV79TIL0B4+KfSwD5S70PeQDkPUd1rA==}
+    engines: {node: '>=15'}
+
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
@@ -4521,10 +4525,6 @@ packages:
       picomatch:
         optional: true
 
-  figures@3.2.0:
-    resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
-    engines: {node: '>=8'}
-
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -5456,9 +5456,6 @@ packages:
   markdown-it@14.1.0:
     resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
     hasBin: true
-
-  markdown-table@2.0.0:
-    resolution: {integrity: sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==}
 
   markdown-table@3.0.3:
     resolution: {integrity: sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw==}
@@ -6572,10 +6569,6 @@ packages:
 
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
-
-  repeat-string@1.6.1:
-    resolution: {integrity: sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==}
-    engines: {node: '>=0.10'}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -7695,11 +7688,17 @@ packages:
       webpack-cli:
         optional: true
 
-  webpackbar@6.0.1:
-    resolution: {integrity: sha512-TnErZpmuKdwWBdMoexjio3KKX6ZtoKHRVvLIU0A47R0VVBDtx3ZyOJDktgYixhoJokZTYTt1Z37OkO9pnGJa9Q==}
+  webpackbar@7.0.0:
+    resolution: {integrity: sha512-aS9soqSO2iCHgqHoCrj4LbfGQUboDCYJPSFOAchEK+9psIjNrfSWW4Y0YEz67MKURNvMmfo0ycOg9d/+OOf9/Q==}
     engines: {node: '>=14.21.3'}
     peerDependencies:
+      '@rspack/core': '*'
       webpack: 3 || 4 || 5
+    peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
+      webpack:
+        optional: true
 
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
@@ -10515,6 +10514,8 @@ snapshots:
 
   ansi-styles@6.2.1: {}
 
+  ansis@3.3.2: {}
+
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
@@ -11712,10 +11713,6 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.2
 
-  figures@3.2.0:
-    dependencies:
-      escape-string-regexp: 1.0.5
-
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -12695,10 +12692,6 @@ snapshots:
       mdurl: 2.0.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0
-
-  markdown-table@2.0.0:
-    dependencies:
-      repeat-string: 1.6.1
 
   markdown-table@3.0.3: {}
 
@@ -14229,8 +14222,6 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
-  repeat-string@1.6.1: {}
-
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
@@ -15571,17 +15562,15 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpackbar@6.0.1(webpack@5.96.1):
+  webpackbar@7.0.0(@rspack/core@1.0.14)(webpack@5.96.1):
     dependencies:
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
+      ansis: 3.3.2
       consola: 3.2.3
-      figures: 3.2.0
-      markdown-table: 2.0.0
       pretty-time: 1.1.0
       std-env: 3.7.0
+    optionalDependencies:
+      '@rspack/core': 1.0.14
       webpack: 5.96.1
-      wrap-ansi: 7.0.0
 
   whatwg-mimetype@3.0.0: {}
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

Resolves #29811.

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

Checking what's the type of builder using and importing it to avoid modules not found problem.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced `WebpackBarPlugin` for improved build progress reporting and error handling.
  
- **Dependency Updates**
	- Upgraded `webpackbar` dependency from version `^6.0.1` to `^7.0.0` in both `@nuxt/rspack-builder` and `@nuxt/webpack-builder` packages.

- **Bug Fixes**
	- Enhanced error state evaluation and progress reporting within the Webpack preset configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->