### PR TITLE
docs: update getting started to include WebStorm

### DIFF
--- a/docs/1.getting-started/2.installation.md
+++ b/docs/1.getting-started/2.installation.md
@@ -22,7 +22,7 @@ Or follow the steps below to set up a new Nuxt project on your computer.
 #### Prerequisites
 
 - **Node.js** - [`v18.0.0`](https://nodejs.org/en) or newer
-- **Text editor** - We recommend [Visual Studio Code](https://code.visualstudio.com/) with the [official Vue extension](https://marketplace.visualstudio.com/items?itemName=Vue.volar) (previously known as Volar)
+- **Text editor** - We recommend [Visual Studio Code](https://code.visualstudio.com/) with the [official Vue extension](https://marketplace.visualstudio.com/items?itemName=Vue.volar) (previously known as Volar) or [WebStorm](https://www.jetbrains.com/webstorm/) and other [JetBrains IDEs](https://www.jetbrains.com/ides/), that offer great Nuxt support right out-of-the-box.
 - **Terminal** - In order to run Nuxt commands
 
 ::note

--- a/docs/1.getting-started/2.installation.md
+++ b/docs/1.getting-started/2.installation.md
@@ -21,8 +21,8 @@ Or follow the steps below to set up a new Nuxt project on your computer.
 <!-- markdownlint-disable-next-line MD001 -->
 #### Prerequisites
 
-- **Node.js** - [`v18.0.0`](https://nodejs.org/en) or newer
-- **Text editor** - We recommend [Visual Studio Code](https://code.visualstudio.com/) with the [official Vue extension](https://marketplace.visualstudio.com/items?itemName=Vue.volar) (previously known as Volar) or [WebStorm](https://www.jetbrains.com/webstorm/) and other [JetBrains IDEs](https://www.jetbrains.com/ides/), that offer great Nuxt support right out-of-the-box.
+- **Node.js** - [`18.x`](https://nodejs.org/en) or newer (but we recommend the [active LTS release](https://github.com/nodejs/release#release-schedule))
+- **Text editor** - There is no IDE requirement, but we recommend [Visual Studio Code](https://code.visualstudio.com/) with the [official Vue extension](https://marketplace.visualstudio.com/items?itemName=Vue.volar) (previously known as Volar) or [WebStorm](https://www.jetbrains.com/webstorm/), which, along with [other JetBrains IDEs](https://www.jetbrains.com/ides/), offers great Nuxt support right out-of-the-box.
 - **Terminal** - In order to run Nuxt commands
 
 ::note


### PR DESCRIPTION
Similar to VsCode, WebStorm is also built on top of Volar and additionally offers some Nuxt-specific features (e.g. intellisense for file-based routing). It is also free for non-commercial usage so I think it'd be fair to mention it here. 

This was briefly discussed with @danielroe. But I am more than happy to adjust the wording or anything else that'd make you more comfortable with such a change. Many thanks for consideration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Revised the Installation guide to broaden Node.js version requirements to `18.x` and emphasize using the active LTS release.
	- Expanded text editor recommendations to include WebStorm and other JetBrains IDEs, clarifying no strict IDE requirement.
	- Retained the note on using even-numbered Node.js versions while maintaining the overall structure of the installation instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->