### PR TITLE
fix: #29894 addTemplate should consider the entire path

### DIFF
--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -22,9 +22,9 @@ export function addTemplate<T> (_template: NuxtTemplate<T> | string) {
   // Normalize template
   const template = normalizeTemplate(_template)
 
-  // Remove any existing template with the same filename
+  // Remove any existing template with the same destination path
   nuxt.options.build.templates = nuxt.options.build.templates
-    .filter(p => normalizeTemplate(p).filename !== template.filename)
+    .filter(p => normalizeTemplate(p).dst !== template.dst)
 
   // Add to templates array
   nuxt.options.build.templates.push(template)


### PR DESCRIPTION
### 🔗 Linked issue

resolves #29894

### 📚 Description

When using addTemplate with the same filename but different subfolders only the last template is considered, the ones before it are silently ignored.

It is a breaking change in nuxt 3 from nuxt 2 because on the previous version all files are created as expected.

Feel free to edit or request changes if needed.

-----
<a href="https://stackblitz.com/~/github.com/guska8/nuxt/tree/guska8/issue29894"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz" align="left" width="103" height="20"></a> _Submitted with [StackBlitz](https://stackblitz.com/~/github.com/guska8/nuxt/tree/guska8/issue29894)._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved template management by ensuring that duplicates are identified based on destination paths instead of filenames, enhancing the overall template handling process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->