### PR TITLE
docs: fix typo in composable name

### DIFF
--- a/docs/3.api/2.composables/use-nuxt-data.md
+++ b/docs/3.api/2.composables/use-nuxt-data.md
@@ -54,7 +54,7 @@ const { data } = await useAsyncData('todos', () => $fetch('/api/todos'))
 const newTodo = ref('')
 const previousTodos = ref([])
 
-// Access to the cached value of useFetch in todos.vue
+// Access to the cached value of useAsyncData in todos.vue
 const { data: todos } = useNuxtData('todos')
 
 const { data } = await useFetch('/api/addTodo', {


### PR DESCRIPTION
Update a comment in a line which indicates a composable different than the one being reference to

### 🔗 Linked issue

N/A

### 📚 Description

Update a comment in a line which indicates a composable different than the one being reference to, instead of **useFetch** it should be **useAsyncData**

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the documentation for the `useNuxtData` composable to clarify its functionality and usage.
	- Corrected comments in usage examples to accurately reflect the referenced composables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->