### PR TITLE
docs: add information about islands directory

### DIFF
--- a/docs/3.api/1.components/8.nuxt-island.md
+++ b/docs/3.api/1.components/8.nuxt-island.md
@@ -41,6 +41,10 @@ Remote islands need `experimental.componentIslands` to be `'local+remote'` in yo
 It is strongly discouraged to enable `dangerouslyLoadClientComponents` as you can't trust a remote server's javascript.
 ::
 
+::note
+The NuxtIsland component accepts a prop called `name` which is the name of a component inside `/components/islands` directory.
+::
+
 ## Slots
 
 Slots can be passed to an island component if declared.

--- a/docs/3.api/1.components/8.nuxt-island.md
+++ b/docs/3.api/1.components/8.nuxt-island.md
@@ -42,7 +42,7 @@ It is strongly discouraged to enable `dangerouslyLoadClientComponents` as you ca
 ::
 
 ::note
-The NuxtIsland component accepts a prop called `name` which is the name of a component inside `/components/islands` directory.
+By default, component islands are scanned from the `~/components/islands/` directory. So the `~/components/islands/MyIsland.vue` component could be rendered with `<NuxtIsland name="MyIsland" />`.
 ::
 
 ## Slots


### PR DESCRIPTION
### 📚 Description

Hi, I think it would be helpful to include information about the islands directory in the documentation.
It can take a lot of time to try using the `name` prop for the `<NuxtIsland/>` component before finding information about it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the documentation for the `<NuxtIsland>` component to clarify the usage of the `name` prop.
	- Enhanced details on props, slots, references, and events while maintaining existing definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->