### PR TITLE
feat(nuxt): add support for printing nuxt hook timing in browser devtools

### DIFF
--- a/packages/nuxt/src/app/plugins/browser-devtools-timing.client.ts
+++ b/packages/nuxt/src/app/plugins/browser-devtools-timing.client.ts
@@ -5,12 +5,15 @@ export default defineNuxtPlugin({
   enforce: 'pre',
   setup (nuxtApp) {
     nuxtApp.hooks.beforeEach((event) => {
-      performance.mark(event.name + ' start')
+      // @ts-expect-error __startTime is not a public API
+      event.__startTime = performance.now()
     })
 
+    // After each
     nuxtApp.hooks.afterEach((event) => {
       performance.measure(event.name, {
-        start: event.name + ' start',
+        // @ts-expect-error __startTime is not a public API
+        start: event.__startTime,
         detail: {
           devtools: {
             dataType: 'track-entry',

--- a/packages/nuxt/src/app/plugins/browser-devtools-timing.client.ts
+++ b/packages/nuxt/src/app/plugins/browser-devtools-timing.client.ts
@@ -1,0 +1,39 @@
+import { defineNuxtPlugin } from '../nuxt'
+
+export default defineNuxtPlugin({
+  name: 'nuxt:browser-devtools-timing',
+  enforce: 'pre',
+  setup (nuxtApp) {
+    nuxtApp.hooks.beforeEach((event) => {
+      performance.mark(event.name + ' start')
+    })
+
+    nuxtApp.hooks.afterEach((event) => {
+      performance.measure(event.name, {
+        start: event.name + ' start',
+        detail: {
+          devtools: {
+            dataType: 'track-entry',
+            track: 'nuxt',
+            color: 'tertiary-dark',
+          } satisfies ExtensionTrackEntryPayload,
+        },
+      })
+    })
+  },
+})
+
+type DevToolsColor =
+  'primary' | 'primary-light' | 'primary-dark' |
+  'secondary' | 'secondary-light' | 'secondary-dark' |
+  'tertiary' | 'tertiary-light' | 'tertiary-dark' |
+  'error'
+
+interface ExtensionTrackEntryPayload {
+  dataType?: 'track-entry' // Defaults to "track-entry"
+  color?: DevToolsColor // Defaults to "primary"
+  track: string // Required: Name of the custom track
+  trackGroup?: string // Optional: Group for organizing tracks
+  properties?: [string, string][] // Key-value pairs for detailed view
+  tooltipText?: string // Short description for tooltip
+}

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -536,6 +536,12 @@ async function initNuxt (nuxt: Nuxt) {
     addPlugin(resolve(nuxt.options.appDir, 'plugins/debug'))
   }
 
+  // Add experimental Chrome devtools timings support
+  // https://developer.chrome.com/docs/devtools/performance/extension
+  if (nuxt.options.experimental.browserDevtoolsTiming) {
+    addPlugin(resolve(nuxt.options.appDir, 'plugins/browser-devtools-timing.client'))
+  }
+
   for (const [key, options] of modulesToInstall) {
     await installModule(key, options)
   }

--- a/packages/nuxt/test/app.test.ts
+++ b/packages/nuxt/test/app.test.ts
@@ -77,10 +77,6 @@ describe('resolveApp', () => {
             "mode": "all",
             "src": "<repoRoot>/packages/nuxt/src/app/plugins/router.ts",
           },
-          {
-            "mode": "client",
-            "src": "<repoRoot>/packages/nuxt/src/app/plugins/browser-devtools-timing.client.ts",
-          },
         ],
         "rootComponent": "<repoRoot>/packages/nuxt/src/app/components/nuxt-root.vue",
         "templates": [],

--- a/packages/nuxt/test/app.test.ts
+++ b/packages/nuxt/test/app.test.ts
@@ -77,6 +77,10 @@ describe('resolveApp', () => {
             "mode": "all",
             "src": "<repoRoot>/packages/nuxt/src/app/plugins/router.ts",
           },
+          {
+            "mode": "client",
+            "src": "<repoRoot>/packages/nuxt/src/app/plugins/browser-devtools-timing.client.ts",
+          },
         ],
         "rootComponent": "<repoRoot>/packages/nuxt/src/app/components/nuxt-root.vue",
         "templates": [],

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -407,12 +407,12 @@ export default defineUntypedSchema({
         return val ?? ((await get('future') as Record<string, unknown>).compatibilityVersion === 4)
       },
     },
-  },
 
-  /**
-   * Enable timings for Nuxt application hooks in the performance panel of Chromium-based browsers.
-   *
-   * @see [the Chrome DevTools extensibility API](https://developer.chrome.com/docs/devtools/performance/extension#tracks)
-   */
-  browserDevtoolsTiming: true,
+    /**
+     * Enable timings for Nuxt application hooks in the performance panel of Chromium-based browsers.
+     *
+     * @see [the Chrome DevTools extensibility API](https://developer.chrome.com/docs/devtools/performance/extension#tracks)
+     */
+    browserDevtoolsTiming: true,
+  },
 })

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -413,6 +413,8 @@ export default defineUntypedSchema({
      *
      * @see [the Chrome DevTools extensibility API](https://developer.chrome.com/docs/devtools/performance/extension#tracks)
      */
-    browserDevtoolsTiming: true,
+    browserDevtoolsTiming: {
+      $resolve: async (val, get) => val ?? await get('dev'),
+    },
   },
 })

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -408,4 +408,11 @@ export default defineUntypedSchema({
       },
     },
   },
+
+  /**
+   * Enable timings for Nuxt application hooks in the performance panel of Chromium-based browsers.
+   *
+   * @see [the Chrome DevTools extensibility API](https://developer.chrome.com/docs/devtools/performance/extension#tracks)
+   */
+  browserDevtoolsTiming: true,
 })


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This uses the [Chrome DevTools extensibility API](https://developer.chrome.com/docs/devtools/performance/extension) to add support for printing nuxt hook timings in the browser devtools performance panel.

![CleanShot 2024-11-14 at 15 05 22@2x](https://github.com/user-attachments/assets/57525027-750a-462f-b713-398302aec0cd)

We can improve this further:

- [ ] add information on which plugins (by filename?) ran


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new plugin for tracking browser DevTools timings, enhancing performance monitoring during navigation events.
	- Added an experimental configuration option for enabling browser DevTools timings in the Nuxt application.

- **Improvements**
	- Enhanced handling of module installation and compatibility date prompts to improve user experience and configuration management.
	- Refined logic for core module registration and improved flexibility in application structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->