### PR TITLE
fix(nuxt): recompile templates on `change` events

### DIFF
--- a/packages/nuxt/src/imports/module.ts
+++ b/packages/nuxt/src/imports/module.ts
@@ -107,12 +107,9 @@ export default defineNuxtModule<Partial<ImportsOptions>>({
 
     const priorities = nuxt.options._layers.map((layer, i) => [layer.config.srcDir, -i] as const).sort(([a], [b]) => b.length - a.length)
 
+    const IMPORTS_TEMPLATE_RE = /\/imports\.(?:d\.ts|mjs)$/
     function isImportsTemplate (template: ResolvedNuxtTemplate) {
-      return [
-        '/types/imports.d.ts',
-        '/imports.d.ts',
-        '/imports.mjs',
-      ].some(i => template.filename.endsWith(i))
+      return IMPORTS_TEMPLATE_RE.test(template.filename)
     }
 
     const regenerateImports = async () => {


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/29891

### 📚 Description

This allows templates to be updated when files change. Also shipped two small perf changes which speed up the compilation.

We might consider on-demand recompilation in future, for example, doing so within the virtual plugin rather than relying on our own watcher.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved handling of file system events for app component updates, ensuring immediate recompilation after relevant changes.
	- Enhanced logic for managing composables directories, streamlining the import process.

- **Bug Fixes**
	- Resolved issues with redundant import path resolution through a new caching mechanism.

- **Refactor**
	- Centralized template identification with a new regular expression for better maintainability.
	- Organized the structure of the import handling logic for clarity and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->