### PR TITLE
fix(nuxt): do not include `<NuxtWelcome>` when building

### DIFF
--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -408,6 +408,7 @@ async function initNuxt (nuxt: Nuxt) {
   }
 
   // Add <NuxtWelcome>
+  // TODO: revert when deep server component config is properly bundle-split: https://github.com/nuxt/nuxt/pull/29956
   const islandsConfig = nuxt.options.experimental.componentIslands
   if (nuxt.options.dev || !(typeof islandsConfig === 'object' && islandsConfig.selectiveClient === 'deep')) {
     addComponent({

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -408,7 +408,8 @@ async function initNuxt (nuxt: Nuxt) {
   }
 
   // Add <NuxtWelcome>
-  if (nuxt.options.dev) {
+  const islandsConfig = nuxt.options.experimental.componentIslands
+  if (nuxt.options.dev || !islandsConfig || islandsConfig === true || typeof islandsConfig === 'string' || islandsConfig.selectiveClient !== 'deep') {
     addComponent({
       name: 'NuxtWelcome',
       priority: 10, // built-in that we do not expect the user to override

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -408,11 +408,13 @@ async function initNuxt (nuxt: Nuxt) {
   }
 
   // Add <NuxtWelcome>
-  addComponent({
-    name: 'NuxtWelcome',
-    priority: 10, // built-in that we do not expect the user to override
-    filePath: resolve(nuxt.options.appDir, 'components/welcome'),
-  })
+  if (nuxt.options.dev) {
+    addComponent({
+      name: 'NuxtWelcome',
+      priority: 10, // built-in that we do not expect the user to override
+      filePath: resolve(nuxt.options.appDir, 'components/welcome'),
+    })
+  }
 
   addComponent({
     name: 'NuxtLayout',

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -409,7 +409,7 @@ async function initNuxt (nuxt: Nuxt) {
 
   // Add <NuxtWelcome>
   const islandsConfig = nuxt.options.experimental.componentIslands
-  if (nuxt.options.dev || !islandsConfig || islandsConfig === true || typeof islandsConfig === 'string' || islandsConfig.selectiveClient !== 'deep') {
+  if (nuxt.options.dev || !(typeof islandsConfig === 'object' && islandsConfig.selectiveClient === 'deep')) {
     addComponent({
       name: 'NuxtWelcome',
       priority: 10, // built-in that we do not expect the user to override


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/29838

### 📚 Description

This should avoid bundling `<NuxtWelcome>` - though we can also investigate why it's being included in the main bundle rather than as an async chunk....

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced conditional logic for the `NuxtWelcome` component, enhancing component management based on user settings.
	- Maintained the addition of components like `NuxtLayout`, `NuxtErrorBoundary`, and others without modifications.

- **Documentation**
	- Added comments for clarity on handling experimental features and component registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->