### PR TITLE
refactor(nuxt): define layouts as async vue components

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-layout.ts
+++ b/packages/nuxt/src/app/components/nuxt-layout.ts
@@ -16,7 +16,6 @@ import layouts from '#build/layouts'
 // @ts-expect-error virtual file
 import { appLayoutTransition as defaultLayoutTransition } from '#build/nuxt.config.mjs'
 
-// TODO: revert back to defineAsyncComponent when https://github.com/vuejs/core/issues/6638 is resolved
 const LayoutLoader = defineComponent({
   name: 'LayoutLoader',
   inheritAttrs: false,
@@ -24,13 +23,10 @@ const LayoutLoader = defineComponent({
     name: String,
     layoutProps: Object,
   },
-  async setup (props, context) {
+  setup (props, context) {
     // This is a deliberate hack - this component must always be called with an explicit key to ensure
     // that setup reruns when the name changes.
-
-    const LayoutComponent = await layouts[props.name]().then((r: any) => r.default || r)
-
-    return () => h(LayoutComponent, props.layoutProps, context.slots)
+    return () => h(layouts[props.name], props.layoutProps, context.slots)
   },
 })
 

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -285,9 +285,10 @@ export const layoutTemplate: NuxtTemplate = {
   filename: 'layouts.mjs',
   getContents ({ app }) {
     const layoutsObject = genObjectFromRawEntries(Object.values(app.layouts).map(({ name, file }) => {
-      return [name, genDynamicImport(file)]
+      return [name, `defineAsyncComponent(${genDynamicImport(file)})`]
     }))
     return [
+      `import { defineAsyncComponent } from 'vue'`,
       `export default ${layoutsObject}`,
     ].join('\n')
   },


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this follows up on https://github.com/vuejs/core/issues/6638 to mark layouts as explicit vue components

it should also be slightly more performant 🙏 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified layout loading process by switching from asynchronous to synchronous calls, which may enhance performance.
	- Enhanced functionality of layout and middleware templates for better component and middleware handling.

- **Bug Fixes**
	- Maintained error handling for invalid layouts with console warnings.

- **Documentation**
	- Updated comments and added TODOs for future improvements in the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->