### PR TITLE
fix(nuxt): allow scanning metadata from multiple files with same route

### DIFF
--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -160,6 +160,7 @@ interface AugmentPagesContext {
   augmentedPages?: Set<string>
 }
 export async function augmentPages (routes: NuxtPage[], vfs: Record<string, string>, ctx: AugmentPagesContext = {}) {
+  ctx.augmentedPages ??= new Set()
   for (const route of routes) {
     if (route.file && !ctx.pagesToSkip?.has(route.file)) {
       const fileContent = route.file in vfs ? vfs[route.file]! : fs.readFileSync(await resolvePath(route.file), 'utf-8')
@@ -169,7 +170,7 @@ export async function augmentPages (routes: NuxtPage[], vfs: Record<string, stri
       }
 
       Object.assign(route, routeMeta)
-      ctx.augmentedPages?.add(route.file)
+      ctx.augmentedPages.add(route.file)
     }
 
     if (route.children && route.children.length > 0) {

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -77,8 +77,8 @@ export async function resolvePagesRoutes (): Promise<NuxtPage[]> {
   } else {
     const augmentedPages = await augmentPages(pages, nuxt.vfs)
     await nuxt.callHook('pages:extend', pages)
-    await augmentPages(pages, nuxt.vfs, augmentedPages)
-    augmentedPages.clear()
+    await augmentPages(pages, nuxt.vfs, { pagesToSkip: augmentedPages })
+    augmentedPages?.clear()
   }
 
   await nuxt.callHook('pages:resolved', pages)
@@ -155,9 +155,13 @@ export function generateRoutesFromFiles (files: ScannedFile[], options: Generate
   return prepareRoutes(routes)
 }
 
-export async function augmentPages (routes: NuxtPage[], vfs: Record<string, string>, augmentedPages = new Set<string>()) {
+interface AugmentPagesContext {
+  pagesToSkip?: Set<string>
+  augmentedPages?: Set<string>
+}
+export async function augmentPages (routes: NuxtPage[], vfs: Record<string, string>, ctx: AugmentPagesContext = {}) {
   for (const route of routes) {
-    if (route.file && !augmentedPages.has(route.file)) {
+    if (route.file && !ctx.pagesToSkip?.has(route.file)) {
       const fileContent = route.file in vfs ? vfs[route.file]! : fs.readFileSync(await resolvePath(route.file), 'utf-8')
       const routeMeta = await getRouteMeta(fileContent, route.file)
       if (route.meta) {
@@ -165,14 +169,14 @@ export async function augmentPages (routes: NuxtPage[], vfs: Record<string, stri
       }
 
       Object.assign(route, routeMeta)
-      augmentedPages.add(route.file)
+      ctx.augmentedPages?.add(route.file)
     }
 
     if (route.children && route.children.length > 0) {
-      await augmentPages(route.children, vfs, augmentedPages)
+      await augmentPages(route.children, vfs, ctx)
     }
   }
-  return augmentedPages
+  return ctx.augmentedPages
 }
 
 const SFC_SCRIPT_RE = /<script(?<attrs>[^>]*)>(?<content>[\s\S]*?)<\/script[^>]*>/gi


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/29361

### 📚 Description

When scanning page metadata, if a given file was encountered more than once in the scanner, it was ignored the second time. This fix ensures that we do not ignore files we have encountered in the same 'scan'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved the structure and clarity of existing functions related to page augmentation and route handling.
	- Updated method signatures to enhance parameter organization and encapsulation.
- **Bug Fixes**
	- Enhanced handling of route metadata extraction for better consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->