### PR TITLE
fix(nuxt): do not disallow importing nitro dependencies

### DIFF
--- a/packages/nuxt/src/core/plugins/import-protection.ts
+++ b/packages/nuxt/src/core/plugins/import-protection.ts
@@ -36,7 +36,7 @@ export const createImportProtectionPatterns = (nuxt: { options: NuxtOptions }, o
     ])
   }
 
-  for (const i of [/(^|node_modules\/)@nuxt\/(kit|test-utils)/, /(^|node_modules\/)nuxi/, /(^|node_modules\/)nitro(?:pack)?(?:-nightly)?(?:$|\/)(?!(?:dist\/)?(?:presets|runtime|types))/, /(^|node_modules\/)nuxt\/(config|kit|schema)/]) {
+  for (const i of [/(^|node_modules\/)@nuxt\/(kit|test-utils)/, /(^|node_modules\/)nuxi/, /(^|node_modules\/)nitro(?:pack)?(?:-nightly)?(?:$|\/)(?!(?:dist\/)?(?:node_modules|presets|runtime|types))/, /(^|node_modules\/)nuxt\/(config|kit|schema)/]) {
     patterns.push([i, `This module cannot be imported in ${context}.`])
   }
 


### PR DESCRIPTION
resolves https://github.com/nuxt/nuxt/issues/29884
resolves https://github.com/nuxt/nuxt/issues/29920

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

some package managers can end up with dependencies in a `node_modules` folder nested under nitro, which shouldn't be disallowed from being imported

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced import protection logic by refining the exclusion criteria for module imports, preventing unintended imports from the `node_modules` directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->