### PR TITLE
feat(kit): allow module defaults to be async

### DIFF
--- a/packages/kit/src/module/define.ts
+++ b/packages/kit/src/module/define.ts
@@ -65,7 +65,7 @@ function _defineNuxtModule<
 
     const optionsDefaults: TOptionsDefaults =
       module.defaults instanceof Function
-        ? module.defaults(nuxt)
+        ? await module.defaults(nuxt)
         : module.defaults ?? <TOptionsDefaults> {}
 
     let options = defu(inlineOptions, nuxtConfigOptions, optionsDefaults)

--- a/packages/schema/src/types/module.ts
+++ b/packages/schema/src/types/module.ts
@@ -64,7 +64,7 @@ export interface ModuleDefinition<
   TWith extends boolean,
 > {
   meta?: ModuleMeta
-  defaults?: TOptionsDefaults | ((nuxt: Nuxt) => TOptionsDefaults)
+  defaults?: TOptionsDefaults | ((nuxt: Nuxt) => Awaitable<TOptionsDefaults>)
   schema?: TOptions
   hooks?: Partial<NuxtHooks>
   setup?: (


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

Just a small PR as I was hoping/wondering if we could allow module defaults to be async. Use case:

```ts
export default defineNuxtModule({
  defaults: async (nuxt) => {
     const somepath = nuxt.options.ssr ? await import('somepath') : undefined
     return { config: somepath?.obj }
  }
})
```

(real use case: https://github.com/nuxt-modules/tailwindcss/pull/913/files#r1848185106)

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced asynchronous handling in module definitions, allowing for improved performance and flexibility.
	- Updated module interface to support promises in the `defaults` property, enabling more dynamic configurations.

- **Bug Fixes**
	- Improved error handling for cases where the Nuxt context may be undefined, preventing potential runtime errors.

- **Documentation**
	- Updated function signatures to reflect changes in asynchronous behavior and return types for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->