### PR TITLE
fix(nuxt): update `style` prop type for head components

### DIFF
--- a/packages/nuxt/src/head/runtime/components.ts
+++ b/packages/nuxt/src/head/runtime/components.ts
@@ -67,7 +67,7 @@ const globalProps = {
     type: Boolean,
     default: undefined,
   },
-  style: String,
+  style: [String, Object, Array],
   tabindex: String,
   title: String,
   translate: String,


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

Right now, I get the following warning in my console:

```
[Vue warn]: Invalid prop: type check failed for prop "style". Expected String with value "[object Object]", got Object  
  at <Html ...
```

I changed the prop validation to allow object and array bindings for `style` (as it already exists for `class`).

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `style` property in global component settings to accept a wider range of data types, improving flexibility for component styling.

- **Bug Fixes**
	- No bug fixes were implemented in this release. 

- **Documentation**
	- Updated documentation to reflect changes in the `style` property type for better clarity on usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->