### PR TITLE
fix: add plugin to acorn to parse files with decorators

### DIFF
--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -71,6 +71,7 @@
     "@unhead/vue": "^1.11.11",
     "@vue/shared": "^3.5.13",
     "acorn": "8.14.0",
+    "acorn-typescript": "^1.4.13",
     "c12": "^2.0.1",
     "chokidar": "^4.0.1",
     "compatx": "^0.1.8",

--- a/packages/nuxt/src/core/plugins/prehydrate.ts
+++ b/packages/nuxt/src/core/plugins/prehydrate.ts
@@ -1,14 +1,14 @@
 import { transform } from 'esbuild'
-import { parse } from 'acorn'
 import { walk } from 'estree-walker'
 import type { Node } from 'estree-walker'
 import type { Nuxt } from '@nuxt/schema'
 import { createUnplugin } from 'unplugin'
 import type { SimpleCallExpression } from 'estree'
 import MagicString from 'magic-string'
-
 import { hash } from 'ohash'
 import { isJS, isVue } from '../utils'
+import * as acorn from 'acorn'
+import { tsPlugin } from 'acorn-typescript'
 
 export function prehydrateTransformPlugin (nuxt: Nuxt) {
   return createUnplugin(() => ({

--- a/packages/nuxt/src/core/plugins/prehydrate.ts
+++ b/packages/nuxt/src/core/plugins/prehydrate.ts
@@ -22,9 +22,10 @@ export function prehydrateTransformPlugin (nuxt: Nuxt) {
       const s = new MagicString(code)
       const promises: Array<Promise<any>> = []
 
-      walk(parse(code, {
+      walk(acorn.Parser.extend(tsPlugin()).parse(code, {
         sourceType: 'module',
         ecmaVersion: 'latest',
+        locations: true,
         ranges: true,
       }) as Node, {
         enter (_node) {

--- a/packages/nuxt/src/pages/route-rules.ts
+++ b/packages/nuxt/src/pages/route-rules.ts
@@ -3,11 +3,12 @@ import type { Node } from 'estree-walker'
 import type { CallExpression } from 'estree'
 import { walk } from 'estree-walker'
 import { transform } from 'esbuild'
-import { parse } from 'acorn'
 import type { NuxtPage } from '@nuxt/schema'
 import type { NitroRouteConfig } from 'nitro/types'
 import { normalize } from 'pathe'
 import { extractScriptContent, pathToNitroGlob } from './utils'
+import * as acorn from 'acorn'
+import tsPlugin from 'acorn-typescript'
 
 const ROUTE_RULE_RE = /\bdefineRouteRules\(/
 const ruleCache: Record<string, NitroRouteConfig | null> = {}
@@ -26,9 +27,10 @@ export async function extractRouteRules (code: string): Promise<NitroRouteConfig
     code = script?.code || code
 
     const js = await transform(code, { loader: script?.loader || 'ts' })
-    walk(parse(js.code, {
+    walk(acorn.Parser.extend(tsPlugin()).parse(js.code, {
       sourceType: 'module',
       ecmaVersion: 'latest',
+      locations: true,
     }) as Node, {
       enter (_node) {
         if (_node.type !== 'CallExpression' || (_node as CallExpression).callee.type !== 'Identifier') { return }

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -243,18 +243,11 @@ export async function getRouteMeta (contents: string, absolutePath: string): Pro
       enter (node) {
         if (foundMeta) { return }
 
-        const class = node.type !== "ArrowFunctionExpression" || node.body.type !== "CallExpression" || node.body.callee.type !== "Identifier" || node.body.callee.name !== "definePageMeta"
-        const other = node.type !== 'ExpressionStatement' || node.expression.type !== 'CallExpression' || node.expression.callee.type !== 'Identifier' || node.expression.callee.name !== 'definePageMeta'
-
-        if (class || other) { return }
+        if ((node.type !== "ArrowFunctionExpression" || node.body.type !== "CallExpression" || node.body.callee.type !== "Identifier" || node.body.callee.name !== "definePageMeta") 
+            || (node.type !== 'ExpressionStatement' || node.expression.type !== 'CallExpression' || node.expression.callee.type !== 'Identifier' || node.expression.callee.name !== 'definePageMeta')) { return }
 
         foundMeta = true
-
-        if (class) {
-          const pageMetaArgument = (node as ExpressionStatement).body.arguments[0] as ObjectExpression
-        } else {
-          const pageMetaArgument = ((node as ExpressionStatement).expression as CallExpression).arguments[0] as ObjectExpression
-        }
+        const pageMetaArgument = node.type !== "ArrowFunctionExpression" ? ((node as ExpressionStatement).body as any).arguments[0] as ObjectExpression ? ((node as ExpressionStatement).expression as CallExpression).arguments[0] as ObjectExpression
 
         for (const key of extractionKeys) {
           const property = pageMetaArgument.properties.find(property => property.type === 'Property' && property.key.type === 'Identifier' && property.key.name === key) as Property

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -244,7 +244,7 @@ export async function getRouteMeta (contents: string, absolutePath: string): Pro
         if (foundMeta) { return }
 
         if ((node.type !== "ArrowFunctionExpression" || node.body.type !== "CallExpression" || node.body.callee.type !== "Identifier" || node.body.callee.name !== "definePageMeta") 
-            || (node.type !== 'ExpressionStatement' || node.expression.type !== 'CallExpression' || node.expression.callee.type !== 'Identifier' || node.expression.callee.name !== 'definePageMeta')) { return }
+            && (node.type !== 'ExpressionStatement' || node.expression.type !== 'CallExpression' || node.expression.callee.type !== 'Identifier' || node.expression.callee.name !== 'definePageMeta')) { return }
 
         foundMeta = true
         const pageMetaArgument = node.type !== "ArrowFunctionExpression" ? ((node as ExpressionStatement).body as any).arguments[0] as ObjectExpression ? ((node as ExpressionStatement).expression as CallExpression).arguments[0] as ObjectExpression

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -8,10 +8,11 @@ import escapeRE from 'escape-string-regexp'
 import { filename } from 'pathe/utils'
 import { hash } from 'ohash'
 import { transform } from 'esbuild'
-import { parse } from 'acorn'
 import { walk } from 'estree-walker'
 import type { CallExpression, ExpressionStatement, ObjectExpression, Program, Property } from 'estree'
 import type { NuxtPage } from 'nuxt/schema'
+import * as acorn from 'acorn'
+import tsPlugin from 'acorn-typescript'
 
 import { getLoader, uniqueBy } from '../core/utils'
 import { toArray } from '../utils'
@@ -227,9 +228,10 @@ export async function getRouteMeta (contents: string, absolutePath: string): Pro
     }
 
     const js = await transform(script.code, { loader: script.loader })
-    const ast = parse(js.code, {
+    const ast = acorn.Parser.extend(tsPlugin()).parse(js.code, {
       sourceType: 'module',
       ecmaVersion: 'latest',
+      locations: true,
       ranges: true,
     }) as unknown as Program
 
@@ -241,10 +243,18 @@ export async function getRouteMeta (contents: string, absolutePath: string): Pro
       enter (node) {
         if (foundMeta) { return }
 
-        if (node.type !== 'ExpressionStatement' || node.expression.type !== 'CallExpression' || node.expression.callee.type !== 'Identifier' || node.expression.callee.name !== 'definePageMeta') { return }
+        const class = node.type !== "ArrowFunctionExpression" || node.body.type !== "CallExpression" || node.body.callee.type !== "Identifier" || node.body.callee.name !== "definePageMeta"
+        const other = node.type !== 'ExpressionStatement' || node.expression.type !== 'CallExpression' || node.expression.callee.type !== 'Identifier' || node.expression.callee.name !== 'definePageMeta'
+
+        if (class || other) { return }
 
         foundMeta = true
-        const pageMetaArgument = ((node as ExpressionStatement).expression as CallExpression).arguments[0] as ObjectExpression
+
+        if (class) {
+          const pageMetaArgument = (node as ExpressionStatement).body.arguments[0] as ObjectExpression
+        } else {
+          const pageMetaArgument = ((node as ExpressionStatement).expression as CallExpression).arguments[0] as ObjectExpression
+        }
 
         for (const key of extractionKeys) {
           const property = pageMetaArgument.properties.find(property => property.type === 'Property' && property.key.type === 'Identifier' && property.key.name === key) as Property


### PR DESCRIPTION
### 🔗 Linked issue

resolves #29790


### 📚 Description
Add plugin to acorn to parse files with decorators


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced support for TypeScript syntax in the parsing of JavaScript code across various components.
	- Improved metadata extraction capabilities for routing and page definitions, allowing for more complex configurations.

- **Bug Fixes**
	- Retained robust error handling for malformed metadata and JSON parsing issues.

- **Chores**
	- Added a new dependency, `acorn-typescript`, to improve TypeScript parsing capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->