### PR TITLE
refactor(nuxt): prefix all core modules with `nuxt:`

### DIFF
--- a/packages/nuxt/src/components/module.ts
+++ b/packages/nuxt/src/components/module.ts
@@ -28,7 +28,7 @@ export type getComponentsT = (mode?: 'client' | 'server' | 'all') => Component[]
 
 export default defineNuxtModule<ComponentsOptions>({
   meta: {
-    name: 'components',
+    name: 'nuxt:components',
     configKey: 'components',
   },
   defaults: {

--- a/packages/nuxt/src/core/schema.ts
+++ b/packages/nuxt/src/core/schema.ts
@@ -16,7 +16,7 @@ import { createJiti } from 'jiti'
 
 export default defineNuxtModule({
   meta: {
-    name: 'nuxt-config-schema',
+    name: 'nuxt:nuxt-config-schema',
   },
   async setup (_, nuxt) {
     const resolver = createResolver(import.meta.url)

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -186,7 +186,7 @@ export const schemaTemplate: NuxtTemplate = {
     const getImportName = (name: string) => (name[0] === '.' ? './' + join(relativeRoot, name) : name).replace(IMPORT_NAME_RE, '')
 
     const modules = nuxt.options._installedModules
-      .filter(m => m.meta && m.meta.configKey && m.meta.name && !m.meta.name.startsWith('nuxt:'))
+      .filter(m => m.meta && m.meta.configKey && m.meta.name && !m.meta.name.startsWith('nuxt:') && m.meta.name !== 'nuxt-config-schema')
       .map(m => [genString(m.meta.configKey), getImportName(m.entryPath || m.meta.name), m] as const)
 
     const privateRuntimeConfig = Object.create(null)

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -10,6 +10,7 @@ import { filename } from 'pathe/utils'
 import type { NuxtTemplate } from 'nuxt/schema'
 import type { Nitro } from 'nitro/types'
 
+import { NUXT_PREFIX } from '../utils'
 import { annotatePlugins, checkForCircularDependencies } from './app'
 import { EXTENSION_RE } from './utils'
 
@@ -177,7 +178,6 @@ export { }
   },
 }
 
-const adHocModules = ['router', 'pages', 'imports', 'meta', 'components', 'nuxt-config-schema']
 const IMPORT_NAME_RE = /\.\w+$/
 const GIT_RE = /^git\+/
 export const schemaTemplate: NuxtTemplate = {
@@ -187,7 +187,7 @@ export const schemaTemplate: NuxtTemplate = {
     const getImportName = (name: string) => (name[0] === '.' ? './' + join(relativeRoot, name) : name).replace(IMPORT_NAME_RE, '')
 
     const modules = nuxt.options._installedModules
-      .filter(m => m.meta && m.meta.configKey && m.meta.name && !adHocModules.includes(m.meta.name))
+      .filter(m => m.meta && m.meta.configKey && m.meta.name && !m.meta.name.startsWith(NUXT_PREFIX))
       .map(m => [genString(m.meta.configKey), getImportName(m.entryPath || m.meta.name), m] as const)
 
     const privateRuntimeConfig = Object.create(null)

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -10,7 +10,6 @@ import { filename } from 'pathe/utils'
 import type { NuxtTemplate } from 'nuxt/schema'
 import type { Nitro } from 'nitro/types'
 
-import { NUXT_PREFIX } from '../utils'
 import { annotatePlugins, checkForCircularDependencies } from './app'
 import { EXTENSION_RE } from './utils'
 
@@ -187,7 +186,7 @@ export const schemaTemplate: NuxtTemplate = {
     const getImportName = (name: string) => (name[0] === '.' ? './' + join(relativeRoot, name) : name).replace(IMPORT_NAME_RE, '')
 
     const modules = nuxt.options._installedModules
-      .filter(m => m.meta && m.meta.configKey && m.meta.name && !m.meta.name.startsWith(NUXT_PREFIX))
+      .filter(m => m.meta && m.meta.configKey && m.meta.name && !m.meta.name.startsWith('nuxt:'))
       .map(m => [genString(m.meta.configKey), getImportName(m.entryPath || m.meta.name), m] as const)
 
     const privateRuntimeConfig = Object.create(null)

--- a/packages/nuxt/src/head/module.ts
+++ b/packages/nuxt/src/head/module.ts
@@ -7,7 +7,7 @@ const components = ['NoScript', 'Link', 'Base', 'Title', 'Meta', 'Style', 'Head'
 
 export default defineNuxtModule<NuxtOptions['unhead']>({
   meta: {
-    name: 'meta',
+    name: 'nuxt:meta',
     configKey: 'unhead',
   },
   async setup (options, nuxt) {

--- a/packages/nuxt/src/imports/module.ts
+++ b/packages/nuxt/src/imports/module.ts
@@ -13,7 +13,7 @@ import { defaultPresets } from './presets'
 
 export default defineNuxtModule<Partial<ImportsOptions>>({
   meta: {
-    name: 'imports',
+    name: 'nuxt:imports',
     configKey: 'imports',
   },
   defaults: nuxt => ({

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -24,6 +24,7 @@ const OPTIONAL_PARAM_RE = /^\/?:.*(?:\?|\(\.\*\)\*)$/
 export default defineNuxtModule({
   meta: {
     name: 'nuxt:pages',
+    configKey: 'pages',
   },
   async setup (_options, nuxt) {
     const useExperimentalTypedPages = nuxt.options.experimental.typedPages

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -23,7 +23,7 @@ const OPTIONAL_PARAM_RE = /^\/?:.*(?:\?|\(\.\*\)\*)$/
 
 export default defineNuxtModule({
   meta: {
-    name: 'pages',
+    name: 'nuxt:pages',
   },
   async setup (_options, nuxt) {
     const useExperimentalTypedPages = nuxt.options.experimental.typedPages

--- a/packages/nuxt/src/utils.ts
+++ b/packages/nuxt/src/utils.ts
@@ -8,3 +8,5 @@ export function toArray<T> (value: T | T[]): T[] {
 export async function isDirectory (path: string) {
   return (await fsp.lstat(path)).isDirectory()
 }
+
+export const NUXT_PREFIX = 'nuxt:'

--- a/packages/nuxt/src/utils.ts
+++ b/packages/nuxt/src/utils.ts
@@ -8,5 +8,3 @@ export function toArray<T> (value: T | T[]): T[] {
 export async function isDirectory (path: string) {
   return (await fsp.lstat(path)).isDirectory()
 }
-
-export const NUXT_PREFIX = 'nuxt:'


### PR DESCRIPTION
### 🔗 Linked issue
resolves #29965
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This PR prefix all core modules name with `nuxt:` to harmonize then naming of core modules with core plugins.

This is kinda a breaking change if users were overwriting core modules ? 

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Updated module naming conventions for clarity (e.g., `nuxt:components`, `nuxt:imports`, `nuxt:pages`).
	- Enhanced handling of component directories and router options for improved functionality.
	- Introduced new type templates for middleware and layouts to enhance type safety.
	- Improved dynamic updates for imports and better handling of component paths.

- **Bug Fixes**
	- Improved error handling and logging for schema loading and route parsing.

- **Documentation**
	- Enhanced comments and structure to clarify the integration of modules within the Nuxt framework. 

These changes aim to improve the overall organization, error handling, and functionality of the Nuxt framework for developers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->