### PR TITLE
docs: add giget limitation in nuxt layers documentation

### DIFF
--- a/docs/2.guide/3.going-further/7.layers.md
+++ b/docs/2.guide/3.going-further/7.layers.md
@@ -104,6 +104,11 @@ If you want to extend a private remote source, you need to add the environment v
 If you want to extend a remote source from a self-hosted GitHub or GitLab instance, you need to supply its URL with the `GIGET_GITHUB_URL=<url>` or `GIGET_GITLAB_URL=<url>` environment variable - or directly configure it with [the `auth` option](https://github.com/unjs/c12#extending-config-layer-from-remote-sources) in your `nuxt.config`.
 ::
 
+::warning
+Nuxt Layers that are installed with Giget should only requires Nuxt Modules, since dependencies that are not Nuxt modules cannot be resolved.
+If you wish to install dependencies in your layer to be shared with the Nuxt app, please install your Nuxt Layer using a package manager.
+::
+
 ::note
 When using git remote sources, if a layer has npm dependencies and you wish to install them, you can do so by specifying `install: true` in your layer options.
 

--- a/docs/2.guide/3.going-further/7.layers.md
+++ b/docs/2.guide/3.going-further/7.layers.md
@@ -105,8 +105,8 @@ If you want to extend a remote source from a self-hosted GitHub or GitLab instan
 ::
 
 ::warning
-Nuxt Layers that are installed with Giget should only requires Nuxt Modules, since dependencies that are not Nuxt modules cannot be resolved.
-If you wish to install dependencies in your layer to be shared with the Nuxt app, please install your Nuxt Layer using a package manager.
++Nuxt Layers installed with Giget should only require Nuxt modules. Other dependencies cannot be resolved because they are installed in a nested structure (node_modules/.c12/layer_name/node_modules) rather than at the root level.
++To share dependencies between your layer and the Nuxt app, install your Nuxt Layer using a package manager instead of Giget.
 ::
 
 ::note

--- a/docs/2.guide/3.going-further/7.layers.md
+++ b/docs/2.guide/3.going-further/7.layers.md
@@ -105,8 +105,7 @@ If you want to extend a remote source from a self-hosted GitHub or GitLab instan
 ::
 
 ::warning
-Nuxt Layers installed with Giget should only require Nuxt modules. Other dependencies cannot be resolved because they are installed in a nested structure (node_modules/.c12/layer_name/node_modules) rather than at the root level.
-To share dependencies between your layer and the Nuxt app, install your Nuxt Layer using a package manager instead of Giget.
+Bear in mind that if you are extending a remote source as a layer, you will not be able to access its dependencies outside of Nuxt. For example, if the remote layer depends on an eslint plugin, this will not be usable in your eslint config. That is because these dependencies will be located in a special location (`node_modules/.c12/layer_name/node_modules/`) that is not accessible to your package manager.
 ::
 
 ::note

--- a/docs/2.guide/3.going-further/7.layers.md
+++ b/docs/2.guide/3.going-further/7.layers.md
@@ -105,8 +105,8 @@ If you want to extend a remote source from a self-hosted GitHub or GitLab instan
 ::
 
 ::warning
-+Nuxt Layers installed with Giget should only require Nuxt modules. Other dependencies cannot be resolved because they are installed in a nested structure (node_modules/.c12/layer_name/node_modules) rather than at the root level.
-+To share dependencies between your layer and the Nuxt app, install your Nuxt Layer using a package manager instead of Giget.
+Nuxt Layers installed with Giget should only require Nuxt modules. Other dependencies cannot be resolved because they are installed in a nested structure (node_modules/.c12/layer_name/node_modules) rather than at the root level.
+To share dependencies between your layer and the Nuxt app, install your Nuxt Layer using a package manager instead of Giget.
 ::
 
 ::note


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
fix #30103

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
Improve the documentation by adding details about giget limitation.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced explanations of Nuxt layers for better understanding and usability.
	- Clarified the required structure and essential files for Nuxt layers.
	- Added a warning regarding dependencies when using Giget with Nuxt layers.
	- Expanded guidance on publishing layers and using npm packages.
	- Provided important notes on relative paths and multi-layer support for Nuxt modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->