### PR TITLE
docs: vite link points to the wrong location

### DIFF
--- a/docs/1.getting-started/4.styling.md
+++ b/docs/1.getting-started/4.styling.md
@@ -416,7 +416,7 @@ SFC style blocks support preprocessors syntax. Vite come with built-in support f
 
 ::
 
-You can refer to the [Vite CSS docs](https://vite.devuide/features.html#css) and the [@vitejs/plugin-vue docs](https://github.com/vitejs/vite-plugin-vue/tree/main/packages/plugin-vue).
+You can refer to the [Vite CSS docs](https://vite.dev/guide/features.html#css) and the [@vitejs/plugin-vue docs](https://github.com/vitejs/vite-plugin-vue/tree/main/packages/plugin-vue).
 For webpack users, refer to the [vue loader docs](https://vue-loader.vuejs.org).
 
 ## Using PostCSS


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

I saw an incorrect link in the recent submissions.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced clarity and accuracy of styling instructions for Nuxt applications.
	- Updated sections on local stylesheets, font usage, and npm package integration.
	- Revised guidance on external stylesheets and dynamic head manipulation.
	- Expanded explanations on preprocessors and Single File Components (SFC) styling.
	- Improved links and references, along with advanced optimization tips for fonts and CSS loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->