### PR TITLE
fix(nuxt): `nuxt` and `nuxt/app` resolutions

### DIFF
--- a/packages/nuxt/app.d.ts
+++ b/packages/nuxt/app.d.ts
@@ -1,1 +1,1 @@
-export * from './dist/app/index.js'
+export * from './dist/app/index'

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -43,6 +43,14 @@
     "#app": {
       "types": "./dist/app/index.d.ts",
       "import": "./dist/app/index.js"
+    },
+    "#app/defaults": {
+      "types": "./dist/app/defaults.d.ts",
+      "import": "./dist/app/defaults.js"
+    },
+    "#app/nuxt": {
+      "types": "./dist/app/nuxt.d.ts",
+      "import": "./dist/app/nuxt.js"
     }
   },
   "files": [

--- a/packages/nuxt/src/app/types/augments.d.ts
+++ b/packages/nuxt/src/app/types/augments.d.ts
@@ -1,5 +1,5 @@
 import type { UseHeadInput } from '@unhead/vue'
-import type { NuxtApp, useNuxtApp } from '../nuxt'
+import type { NuxtApp, useNuxtApp } from '../nuxt.js'
 
 declare global {
   namespace NodeJS {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
NA

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
No idea how to fix `nuxt` and  `nuxt/app`, imports entry ignored when using node10 (for example, `#app` cannot be resolved).

Check https://arethetypeswrong.github.io/?p=nuxt%403.14.1592:

![imagen](https://github.com/user-attachments/assets/9b862c1d-153e-4536-88ce-742a4f82a06b)

With this PR:

![imagen](https://github.com/user-attachments/assets/b0e7f74b-4d97-4aeb-a2c1-594f094fe357)

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced module import capabilities with new paths: `#app/defaults` and `#app/nuxt`.

- **Bug Fixes**
	- Updated import paths for `NuxtApp` and `useNuxtApp` to ensure correct references.

These changes improve the flexibility of module imports and ensure compatibility with the updated file structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->