### PR TITLE
feat(nuxt): added an immediate option to createLoadingIndicator.

### DIFF
--- a/docs/3.api/2.composables/use-loading-indicator.md
+++ b/docs/3.api/2.composables/use-loading-indicator.md
@@ -18,6 +18,7 @@ It hooks into [`page:loading:start`](/docs/api/advanced/hooks#app-hooks-runtime)
 - `duration`: Duration of the loading bar, in milliseconds (default `2000`).
 - `throttle`: Throttle the appearing and hiding, in milliseconds (default `200`).
 - `estimatedProgress`: By default Nuxt will back off as it approaches 100%. You can provide a custom function to customize the progress estimation, which is a function that receives the duration of the loading bar (above) and the elapsed time. It should return a value between 0 and 100.
+- `immediate`: If set to true, the loading bar will start immediately and ignore throttle (default `false`).
 
 ## Properties
 

--- a/packages/nuxt/src/app/composables/loading-indicator.ts
+++ b/packages/nuxt/src/app/composables/loading-indicator.ts
@@ -11,6 +11,8 @@ export type LoadingIndicatorOpts = {
   hideDelay: number
   /** @default 400 */
   resetDelay: number
+  /** @default false */
+  immediate: boolean
   /**
    * You can provide a custom function to customize the progress estimation,
    * which is a function that receives the duration of the loading bar (above)
@@ -36,7 +38,7 @@ function defaultEstimatedProgress (duration: number, elapsed: number): number {
 }
 
 function createLoadingIndicator (opts: Partial<LoadingIndicatorOpts> = {}) {
-  const { duration = 2000, throttle = 200, hideDelay = 500, resetDelay = 400 } = opts
+  const { duration = 2000, throttle = 200, hideDelay = 500, resetDelay = 400, immediate = false } = opts
   const getProgress = opts.estimatedProgress || defaultEstimatedProgress
   const nuxtApp = useNuxtApp()
   const progress = ref(0)
@@ -61,7 +63,7 @@ function createLoadingIndicator (opts: Partial<LoadingIndicatorOpts> = {}) {
     if (at >= 100) { return finish() }
     clear()
     progress.value = at < 0 ? 0 : at
-    if (throttle && import.meta.client) {
+    if (throttle && import.meta.client && !immediate) {
       throttleTimeout = setTimeout(() => {
         isLoading.value = true
         _startProgress()


### PR DESCRIPTION


### 🔗 Linked issue

resolves #30071 

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Added an immediate option to createLoadingIndicator and updated all types. If true the function ignores throttle including the default throttle value of 200. The default value of immediate is false. 

Also updated the documentation to include the new option with a clear description.

Useful it helps provide consistent user feedback on specific actions in local first environment where most of the actions are completed without hitting the throttleTimeout. Example: Show the green "finished" loader when changes are saved frequently and a toast would bother too much.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new parameter `immediate` to the loading indicator, allowing it to start immediately when set to true.
  
- **Documentation**
	- Updated documentation for the `useLoadingIndicator` composable to include the new `immediate` parameter and clarify its functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->