### PR TITLE
docs: added note about awaiting `useLazyFetch`

### DIFF
--- a/docs/3.api/2.composables/use-lazy-fetch.md
+++ b/docs/3.api/2.composables/use-lazy-fetch.md
@@ -17,7 +17,7 @@ By default, [`useFetch`](/docs/api/composables/use-fetch) blocks navigation unti
 ::
 
 ::note
-Awaiting `useLazyFetch` in this mode only ensures the call is initialized; data will be fetched client-side after navigation and may not be immediately available.
+Awaiting `useLazyFetch` in this mode only ensures the call is initialized. On client-side navigation, data may not be immediately available, and you should make sure to handle the pending state in your app.
 ::
 
 :read-more{to="/docs/api/composables/use-fetch"}

--- a/docs/3.api/2.composables/use-lazy-fetch.md
+++ b/docs/3.api/2.composables/use-lazy-fetch.md
@@ -16,6 +16,10 @@ By default, [`useFetch`](/docs/api/composables/use-fetch) blocks navigation unti
 `useLazyFetch` has the same signature as [`useFetch`](/docs/api/composables/use-fetch).
 ::
 
+::note
+Awaiting `useLazyFetch` in this mode only ensures the call is initialized; data will be fetched client-side after navigation and may not be immediately available.
+::
+
 :read-more{to="/docs/api/composables/use-fetch"}
 
 ## Example


### PR DESCRIPTION
Updated use-lazy-fetch.md by adding a note that await only ensures that the call is initialized, not that the data is available.

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
resolves #29931 

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
As suggested, I added a note that addresses the confusion about the functionality of `await` on `useLazyFetch()`

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated the documentation for `useLazyFetch` to clarify its functionality and usage.
	- Added a note regarding the behavior of data fetching and the importance of handling 'pending' and 'error' states.
	- Included a warning against naming custom functions with the same name as `useLazyFetch`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->