### PR TITLE
feat(nuxt): add private option to useAsyncData (#29064)

### DIFF
--- a/docs/3.api/2.composables/use-async-data.md
+++ b/docs/3.api/2.composables/use-async-data.md
@@ -65,6 +65,7 @@ const { data: posts } = await useAsyncData(
 - `handler`: an asynchronous function that must return a truthy value (for example, it should not be `undefined` or `null`) or the request may be duplicated on the client side
 - `options`:
   - `server`: whether to fetch the data on the server (defaults to `true`)
+  - `private`: when true, `server` will default to `false` on cached pages and `true` on uncached pages (defaults to `false`)
   - `lazy`: whether to resolve the async function after loading the route, instead of blocking client-side navigation (defaults to `false`)
   - `immediate`: when set to `false`, will prevent the request from firing immediately. (defaults to `true`)
   - `default`: a factory function to set the default value of the `data`, before the async function resolves - useful with the `lazy: true` or `immediate: false` option

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -50,6 +50,11 @@ export interface AsyncDataOptions<
    */
   server?: boolean
   /**
+   * When true, `server` will default to false on cached pages and true on uncached pages
+   * @default false
+   */
+  private?: false
+  /**
    * Whether to resolve the async function after loading the route, instead of blocking client-side navigation
    * @default false
    */
@@ -230,7 +235,8 @@ export function useAsyncData<
   const getDefaultCachedData = () => nuxtApp.isHydrating ? nuxtApp.payload.data[key] : nuxtApp.static.data[key]
 
   // Apply defaults
-  options.server = options.server ?? true
+  const cachedRoute = !!nuxtApp.ssrContext?.event?.context.cache
+  options.server = options.server ?? (options.private ? !cachedRoute : true)
   options.default = options.default ?? (getDefault as () => DefaultT)
   options.getCachedData = options.getCachedData ?? getDefaultCachedData
 


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/29064

### 📚 Description

This change adds a new `private` option to `useAsyncData`. This option changes the default value of `server` based on the cache settings of the page.

The intended use-case is for composables and components which may be used in different pages and rely on `useAsyncData`. When fetching private data on cached routes it is important that the fetch is not done in SSR so that the cached page will not include the sensitive data. But it's perfectly fine to do so on non-cached pages.

The current implementation is based on the `event.context.cache` property from Nitro 2.10, but I've also tried reading the `routeRules` when working with older Nitro version.

```ts
  const routeRules = nuxtApp.ssrContext?.event?.context._nitro.routeRules
  const cachedRoute = !!(routeRules?.cache || routeRules?.isr || routeRules?.swr)
```

I'm also not sure what the best for the option behavior/naming is. The current approach just modifies the defaulting of the `server` option, but perhaps it would be better to extend the server option? Something like defining the option as `server: undefined | boolean | 'private'`?

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
