### PR TITLE
docs: add `nuxi upgrade` channel flag

### DIFF
--- a/docs/3.api/4.commands/upgrade.md
+++ b/docs/3.api/4.commands/upgrade.md
@@ -17,3 +17,4 @@ The `upgrade` command upgrades Nuxt to the latest version.
 Option        | Default          | Description
 -------------------------|-----------------|------------------
 `--force, -f` | `false` | Removes `node_modules` and lock files before upgrade.
+`--channel, -ch` | `"stable"` | Specify a channel to install from ("nightly" or "stable")


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Adds documentation for the channel option for the `nuxi upgrade` command
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new option `--channel` (or `-ch`) for the `nuxi upgrade` command, allowing users to specify the installation channel (either `"nightly"` or `"stable"`).
- **Documentation**
	- Updated documentation to reflect the new option for enhanced user control over Nuxt version upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->