### PR TITLE
Minor: Add missing comma to upgrade doc - Update 12.upgrade.md

### DIFF
--- a/docs/1.getting-started/12.upgrade.md
+++ b/docs/1.getting-started/12.upgrade.md
@@ -73,7 +73,7 @@ export default defineNuxtConfig({
   //   resetAsyncDataToUndefined: true,
   //   templateUtils: true,
   //   relativeWatchPaths: true,
-  //   normalizeComponentNames: false
+  //   normalizeComponentNames: false,
   //   defaults: {
   //     useAsyncData: {
   //       deep: true


### PR DESCRIPTION
Add a comma for copy and paste settings for nuxt 3 example when optioning into nuxt 4.

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the upgrade guide for transitioning to the latest version of Nuxt, including instructions for various package managers.
	- Highlighted significant changes in directory structure and component naming conventions.
	- Provided migration steps for maintaining backward compatibility and adapting to new features.
	- Explained the implications of breaking changes and introduced new configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->