### PR TITLE
fix(schema): fix router-options type

### DIFF
--- a/packages/schema/src/types/router.ts
+++ b/packages/schema/src/types/router.ts
@@ -1,7 +1,7 @@
 import type { RouterHistory, RouterOptions as _RouterOptions } from 'vue-router'
 
 export type RouterOptions = Partial<Omit<_RouterOptions, 'history' | 'routes'>> & {
-  history?: (baseURL?: string) => RouterHistory
+  history?: (baseURL?: string) => RouterHistory | null | undefined
   routes?: (_routes: _RouterOptions['routes']) => _RouterOptions['routes'] | Promise<_RouterOptions['routes']>
   hashMode?: boolean
   scrollBehaviorType?: 'smooth' | 'auto'


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

The [nuxt documentation](https://nuxt.com/docs/guide/recipes/custom-routing#custom-history-advanced) states that `history` can return `null` or `undefined`, but this will cause a type error in the code.

<img width="678" alt="image" src="https://github.com/user-attachments/assets/e91bb319-e679-4839-9e0b-23af6baebb29">
<img width="906" alt="image" src="https://github.com/user-attachments/assets/4c969bcb-51bc-4f0a-92e9-a0b2a28f2ae6">


<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced flexibility of the `history` function to return `null` or `undefined`, allowing for better handling of various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->