### PR TITLE
perf(nuxt): prefer structuredClone over stringify/parse

### DIFF
--- a/packages/nuxt/src/imports/module.ts
+++ b/packages/nuxt/src/imports/module.ts
@@ -33,7 +33,7 @@ export default defineNuxtModule<Partial<ImportsOptions>>({
   }),
   async setup (options, nuxt) {
     // TODO: fix sharing of defaults between invocations of modules
-    const presets = JSON.parse(JSON.stringify(options.presets)) as ImportPresetWithDeprecation[]
+    const presets = structuredClone(options.presets as ImportPresetWithDeprecation[]) 
 
     // Allow modules extending sources
     await nuxt.callHook('imports:sources', presets)

--- a/packages/nuxt/src/imports/module.ts
+++ b/packages/nuxt/src/imports/module.ts
@@ -33,7 +33,7 @@ export default defineNuxtModule<Partial<ImportsOptions>>({
   }),
   async setup (options, nuxt) {
     // TODO: fix sharing of defaults between invocations of modules
-    const presets = structuredClone(options.presets as ImportPresetWithDeprecation[]) 
+    const presets = structuredClone(options.presets as ImportPresetWithDeprecation[])
 
     // Allow modules extending sources
     await nuxt.callHook('imports:sources', presets)


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description


`structuredClone` is faster than the good old `JSON.stringify(JSON.parse())` 🫡
![image](https://github.com/user-attachments/assets/022e5c93-b3cd-449a-9344-2cd6ac2f9357)


<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new function for generating type templates for imports, enhancing type declaration management.
	- Improved the cloning process for import presets, ensuring better handling of object structures.
	- Added a caching mechanism for import paths to optimize path resolution.

- **Bug Fixes**
	- Enhanced path resolution logic to prevent issues with shared references in import presets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->