### PR TITLE
fix(nuxt): de-default async layout components

### DIFF
--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -285,7 +285,7 @@ export const layoutTemplate: NuxtTemplate = {
   filename: 'layouts.mjs',
   getContents ({ app }) {
     const layoutsObject = genObjectFromRawEntries(Object.values(app.layouts).map(({ name, file }) => {
-      return [name, `defineAsyncComponent(${genDynamicImport(file)})`]
+      return [name, `defineAsyncComponent(${genDynamicImport(file, { interopDefault: true })})`]
     }))
     return [
       `import { defineAsyncComponent } from 'vue'`,


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/30188
maybe linked to https://github.com/nuxt/nuxt/issues/30123

### 📚 Description

When a single file is created (inlining dynamic imports), it seems we have a problem with de-defaulting Vue async components once again for cloudflare.

Context:
- https://github.com/nuxt/nuxt/pull/28912
- https://github.com/nuxt/nuxt/pull/28509

(Setting the corresponding option in the nitro code does not resolve it - cc: @pi0.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced TypeScript support and plugin management in template generation.
	- Improved handling of module options and documentation links in the schema template.
- **Bug Fixes**
	- Refined logic for plugin imports and exports in client and server plugin templates.
- **Documentation**
	- Added links to documentation in the generated types for better usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->