### PR TITLE
fix(nuxt): hoist environment types

### DIFF
--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -4,7 +4,7 @@ import { join, normalize, relative, resolve } from 'pathe'
 import { createDebugger, createHooks } from 'hookable'
 import ignore from 'ignore'
 import type { LoadNuxtOptions } from '@nuxt/kit'
-import { addBuildPlugin, addComponent, addPlugin, addPluginTemplate, addRouteMiddleware, addServerPlugin, addVitePlugin, addWebpackPlugin, installModule, loadNuxtConfig, logger, nuxtCtx, resolveAlias, resolveFiles, resolveIgnorePatterns, resolvePath, tryResolveModule, useNitro } from '@nuxt/kit'
+import { addBuildPlugin, addComponent, addPlugin, addPluginTemplate, addRouteMiddleware, addServerPlugin, addTypeTemplate, addVitePlugin, addWebpackPlugin, installModule, loadNuxtConfig, logger, nuxtCtx, resolveAlias, resolveFiles, resolveIgnorePatterns, resolvePath, tryResolveModule, useNitro } from '@nuxt/kit'
 import type { Nuxt, NuxtHooks, NuxtModule, NuxtOptions } from 'nuxt/schema'
 import type { PackageJson } from 'pkg-types'
 import { readPackageJSON } from 'pkg-types'
@@ -20,6 +20,7 @@ import { ImpoundPlugin } from 'impound'
 import defu from 'defu'
 import { gt, satisfies } from 'semver'
 import { hasTTY, isCI } from 'std-env'
+import { genImport } from 'knitwork'
 
 import { installNuxtModule } from '../core/features'
 import pagesModule from '../pages/module'
@@ -177,6 +178,36 @@ async function initNuxt (nuxt: Nuxt) {
   nuxt.hook('close', () => nuxtCtx.unset())
 
   const coreTypePackages = nuxt.options.typescript.hoist || []
+
+  // Disable environment types entirely if `typescript.builder` is false
+  if (nuxt.options.typescript.builder !== false) {
+    const envMap = {
+      // defaults from `builder` based on package name
+      '@nuxt/rspack-builder': '@rspack/core/module',
+      '@nuxt/vite-builder': 'vite/client',
+      '@nuxt/webpack-builder': 'webpack/module',
+      // simpler overrides from `typescript.builder` for better DX
+      'rspack': '@rspack/core/module',
+      'vite': 'vite/client',
+      'webpack': 'webpack/module',
+      // default 'merged' builder environment for module authors
+      'shared': '@nuxt/schema/builder-env',
+    }
+
+    const overrideEnv = nuxt.options.typescript.builder && envMap[nuxt.options.typescript.builder]
+    // If there's no override, infer based on builder. If a custom builder is provided, we disable shared types
+    const defaultEnv = typeof nuxt.options.builder === 'string' ? envMap[nuxt.options.builder] : false
+    const environmentTypes = overrideEnv || defaultEnv
+
+    if (environmentTypes) {
+      nuxt.options.typescript.hoist.push(environmentTypes)
+      addTypeTemplate({
+        filename: 'types/builder-env.d.ts',
+        getContents: () => genImport(environmentTypes),
+      })
+    }
+  }
+
   const packageJSON = await readPackageJSON(nuxt.options.rootDir).catch(() => ({}) as PackageJson)
   const NESTED_PKG_RE = /^[^@]+\//
   nuxt._dependencies = new Set([...Object.keys(packageJSON.dependencies || {}), ...Object.keys(packageJSON.devDependencies || {})])
@@ -518,31 +549,6 @@ async function initNuxt (nuxt: Nuxt) {
   if (nuxt.options.builder === '@nuxt/webpack-builder') {
     addPlugin(resolve(nuxt.options.appDir, 'plugins/preload.server'))
   }
-
-  const envMap = {
-    // defaults from `builder` based on package name
-    '@nuxt/rspack-builder': '@rspack/core/module',
-    '@nuxt/vite-builder': 'vite/client',
-    '@nuxt/webpack-builder': 'webpack/module',
-    // simpler overrides from `typescript.builder` for better DX
-    'rspack': '@rspack/core/module',
-    'vite': 'vite/client',
-    'webpack': 'webpack/module',
-    // default 'merged' builder environment for module authors
-    'shared': '@nuxt/schema/builder-env',
-  }
-
-  nuxt.hook('prepare:types', ({ references }) => {
-    // Disable entirely if `typescript.builder` is false
-    if (nuxt.options.typescript.builder === false) { return }
-
-    const overrideEnv = nuxt.options.typescript.builder && envMap[nuxt.options.typescript.builder]
-    // If there's no override, infer based on builder. If a custom builder is provided, we disable shared types
-    const defaultEnv = typeof nuxt.options.builder === 'string' ? envMap[nuxt.options.builder] : false
-    const types = overrideEnv || defaultEnv
-
-    if (types) { references.push({ types }) }
-  })
 
   // Add nuxt app debugger
   if (nuxt.options.debug) {


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/28197

### 📚 Description

`/// <reference types="vite/client" />` was not working unless `vite` was installed - even hoisting `vite/client` didn't resolve....

instead we can use an ambient import to resolve the issue. we also need to move a little earlier to update the hoisting configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method for adding TypeScript type templates, enhancing TypeScript builder configurations.
- **Bug Fixes**
	- Improved error handling to prompt users for configuration updates when necessary.
- **Refactor**
	- Streamlined logic for managing TypeScript types related to builders by integrating it into a new conditional structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->