### PR TITLE
docs: add a note about compatibilityVersion feature flag

### DIFF
--- a/docs/1.getting-started/12.upgrade.md
+++ b/docs/1.getting-started/12.upgrade.md
@@ -56,6 +56,10 @@ First, upgrade Nuxt to the [latest release](https://github.com/nuxt/nuxt/release
 
 Then you can set your `compatibilityVersion` to match Nuxt 4 behavior:
 
+::note
+For now, you need to define the compatibility version in each layer that opts into Nuxt 4 behavior. This will not be required after Nuxt 4 is released.
+::
+
 ```ts twoslash [nuxt.config.ts]
 export default defineNuxtConfig({
   future: {

--- a/docs/2.guide/3.going-further/1.features.md
+++ b/docs/2.guide/3.going-further/1.features.md
@@ -40,7 +40,7 @@ There is also a `future` namespace for early opting-in to new features that will
 ### compatibilityVersion
 
 ::important
-This configuration option is available in Nuxt v3.12+.
+This configuration option is available in Nuxt v3.12+. Please note, that for now, you need to define the compatibility version in each layer that opts into Nuxt 4 behavior. This will not be required after Nuxt 4 is released.
 ::
 
 This enables early access to Nuxt features or flags.


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/27904

### 📚 Description

Multiple issues have been opened regarding layers and `future.compatibilityVersion` not working as expected. So this PR adds a note in the documentation about it. See comment - https://github.com/nuxt/nuxt/issues/27904#issuecomment-2198106225
