### PR TITLE
fix(nuxt): ensure `getRouteRules` works with nitro signature

### DIFF
--- a/packages/nuxt/src/app/composables/manifest.ts
+++ b/packages/nuxt/src/app/composables/manifest.ts
@@ -1,6 +1,8 @@
 import type { MatcherExport, RouteMatcher } from 'radix3'
 import { createMatcherFromExport, createRouter as createRadixRouter, toRouteMatcher } from 'radix3'
 import { defu } from 'defu'
+import type { H3Event } from 'h3'
+import type { NitroRouteRules } from 'nitro/types'
 import { useNuxtApp, useRuntimeConfig } from '../nuxt'
 // @ts-expect-error virtual file
 import { appManifest as isAppManifestEnabled } from '#build/nuxt.config.mjs'
@@ -52,7 +54,10 @@ export function getAppManifest (): Promise<NuxtAppManifest> {
 }
 
 /** @since 3.7.4 */
-export async function getRouteRules (url: string) {
+export async function getRouteRules (url: string): Promise<Record<string, any>>
+export async function getRouteRules (event: H3Event): Promise<NitroRouteRules>
+export async function getRouteRules (url: string | H3Event) {
+  url = typeof url === 'string' ? url : url.path
   if (import.meta.server) {
     useNuxtApp().ssrContext!._preloadManifest = true
     const _routeRulesMatcher = toRouteMatcher(

--- a/packages/nuxt/src/app/composables/manifest.ts
+++ b/packages/nuxt/src/app/composables/manifest.ts
@@ -54,16 +54,18 @@ export function getAppManifest (): Promise<NuxtAppManifest> {
 }
 
 /** @since 3.7.4 */
-export async function getRouteRules (url: string): Promise<Record<string, any>>
 export async function getRouteRules (event: H3Event): Promise<NitroRouteRules>
-export async function getRouteRules (url: string | H3Event) {
-  url = typeof url === 'string' ? url : url.path
+export async function getRouteRules (options: { path: string }): Promise<Record<string, any>>
+/** @deprecated use `getRouteRules({ path })` instead */
+export async function getRouteRules (url: string): Promise<Record<string, any>>
+export async function getRouteRules (arg: string | H3Event | { path: string }) {
+  const path = typeof arg === 'string' ? arg : arg.path
   if (import.meta.server) {
     useNuxtApp().ssrContext!._preloadManifest = true
     const _routeRulesMatcher = toRouteMatcher(
       createRadixRouter({ routes: useRuntimeConfig().nitro!.routeRules }),
     )
-    return defu({} as Record<string, any>, ..._routeRulesMatcher.matchAll(url).reverse())
+    return defu({} as Record<string, any>, ..._routeRulesMatcher.matchAll(path).reverse())
   }
   await getAppManifest()
   if (!matcher) {
@@ -71,7 +73,7 @@ export async function getRouteRules (url: string | H3Event) {
     return {}
   }
   try {
-    return defu({} as Record<string, any>, ...matcher.matchAll(url).reverse())
+    return defu({} as Record<string, any>, ...matcher.matchAll(path).reverse())
   } catch (e) {
     console.error('[nuxt] Error matching route rules.', e)
     return {}

--- a/packages/nuxt/src/app/composables/payload.ts
+++ b/packages/nuxt/src/app/composables/payload.ts
@@ -94,7 +94,7 @@ export async function isPrerendered (url = useRoute().path) {
     return true
   }
   return nuxtApp.runWithContext(async () => {
-    const rules = await getRouteRules(url)
+    const rules = await getRouteRules({ path: url })
     return !!rules.prerender && !rules.redirect
   })
 }

--- a/packages/nuxt/src/app/middleware/manifest-route-rule.ts
+++ b/packages/nuxt/src/app/middleware/manifest-route-rule.ts
@@ -4,7 +4,7 @@ import { getRouteRules } from '../composables/manifest'
 
 export default defineNuxtRouteMiddleware(async (to) => {
   if (import.meta.server || import.meta.test) { return }
-  const rules = await getRouteRules(to.path)
+  const rules = await getRouteRules({ path: to.path })
   if (rules.redirect) {
     if (hasProtocol(rules.redirect, { acceptRelative: true })) {
       window.location.href = rules.redirect

--- a/packages/nuxt/src/app/plugins/router.ts
+++ b/packages/nuxt/src/app/plugins/router.ts
@@ -248,7 +248,7 @@ export default defineNuxtPlugin<{ route: Route, router: Router }>({
           const middlewareEntries = new Set<RouteGuard>([...globalMiddleware, ...nuxtApp._middleware.global])
 
           if (isAppManifestEnabled) {
-            const routeRules = await nuxtApp.runWithContext(() => getRouteRules(to.path))
+            const routeRules = await nuxtApp.runWithContext(() => getRouteRules({ path: to.path }))
 
             if (routeRules.appMiddleware) {
               for (const key in routeRules.appMiddleware) {

--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -199,7 +199,7 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
         }
 
         if (isAppManifestEnabled) {
-          const routeRules = await nuxtApp.runWithContext(() => getRouteRules(to.path))
+          const routeRules = await nuxtApp.runWithContext(() => getRouteRules({ path: to.path }))
 
           if (routeRules.appMiddleware) {
             for (const key in routeRules.appMiddleware) {

--- a/test/fixtures/basic-types/types.ts
+++ b/test/fixtures/basic-types/types.ts
@@ -2,6 +2,9 @@ import { describe, expectTypeOf, it } from 'vitest'
 import type { Ref, SlotsType } from 'vue'
 import type { FetchError } from 'ofetch'
 import type { NavigationFailure, RouteLocationNormalized, RouteLocationRaw, Router, useRouter as vueUseRouter } from 'vue-router'
+import type { H3Event } from 'h3'
+import { getRouteRules as getNitroRouteRules } from 'nitro/runtime'
+import type { NitroRouteRules } from 'nitro/types'
 
 import type { AppConfig, RuntimeValue, UpperSnakeCase } from 'nuxt/schema'
 import { defineNuxtModule } from 'nuxt/kit'
@@ -107,6 +110,21 @@ describe('API routes', () => {
 
     expectTypeOf(useLazyFetch('/error').error).toEqualTypeOf<Ref<FetchError | DefaultAsyncDataErrorValue>>()
     expectTypeOf(useLazyFetch<any, string>('/error').error).toEqualTypeOf<Ref<string | DefaultAsyncDataErrorValue>>()
+  })
+})
+
+describe('nitro compatible APIs', () => {
+  it('getRouteRules', async () => {
+    const a = await getRouteRules('/test')
+    const b = await getRouteRules({} as H3Event)
+    const c = getNitroRouteRules({} as H3Event)
+
+    expectTypeOf(b).toEqualTypeOf(c)
+    expectTypeOf(c).toEqualTypeOf<NitroRouteRules>()
+    expectTypeOf(a).toEqualTypeOf<Record<string, any>>()
+  })
+  it('useRuntimeConfig', () => {
+    useRuntimeConfig({} as H3Event)
   })
 })
 

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -557,8 +557,8 @@ describe.skipIf(process.env.TEST_MANIFEST === 'manifest-off')('app manifests', (
     `)
   })
   it('getRouteRules', async () => {
-    expect(await getRouteRules('/')).toMatchInlineSnapshot('{}')
-    expect(await getRouteRules('/pre')).toMatchInlineSnapshot(`
+    expect(await getRouteRules({ path: '/' })).toMatchInlineSnapshot('{}')
+    expect(await getRouteRules({ path: '/pre' })).toMatchInlineSnapshot(`
       {
         "prerender": true,
       }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

reported in https://github.com/nitrojs/nitro/issues/2939

we need to make sure the type is compatible with the one exposed by Nitro, to avoid type errors

cc: @pi0 