### PR TITLE
fix(nuxt): respect `replace` in middleware with `navigateTo`

### DIFF
--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -153,7 +153,7 @@ export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: Na
   // Early redirect on client-side
   if (import.meta.client && !isExternal && inMiddleware) {
     const replace = options?.replace ?? false
-    return typeof to === 'string' ? { path: to, replace  } : { ...to, replace }
+    return typeof to === 'string' ? { path: to, replace } : { ...to, replace }
   }
 
   const router = useRouter()

--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -152,7 +152,7 @@ export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: Na
 
   // Early redirect on client-side
   if (import.meta.client && !isExternal && inMiddleware) {
-    return to
+    return { path: to, replace: options?.replace ?? false }
   }
 
   const router = useRouter()

--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -152,8 +152,10 @@ export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: Na
 
   // Early redirect on client-side
   if (import.meta.client && !isExternal && inMiddleware) {
-    const replace = options?.replace ?? false
-    return typeof to === 'string' ? { path: to, replace } : { ...to, replace }
+    if (options?.replace) {
+      return typeof to === 'string' ? { path: to, replace: true } : { ...to, replace: true }
+    }
+    return to
   }
 
   const router = useRouter()

--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -152,7 +152,8 @@ export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: Na
 
   // Early redirect on client-side
   if (import.meta.client && !isExternal && inMiddleware) {
-    return { path: to, replace: options?.replace ?? false }
+    const replace = options?.replace ?? false
+    return typeof to === 'string' ? { path: to, replace  } : { ...to, replace }
   }
 
   const router = useRouter()

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -21,8 +21,8 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const [clientStats, clientStatsInlined] = await Promise.all((['.output', '.output-inline'])
       .map(outputDir => analyzeSizes(['**/*.js'], join(rootDir, outputDir, 'public'))))
 
-    expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"115k"`)
-    expect.soft(roundToKilobytes(clientStatsInlined!.totalBytes)).toMatchInlineSnapshot(`"115k"`)
+    expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"116k"`)
+    expect.soft(roundToKilobytes(clientStatsInlined!.totalBytes)).toMatchInlineSnapshot(`"116k"`)
 
     const files = new Set([...clientStats!.files, ...clientStatsInlined!.files].map(f => f.replace(/\..*\.js/, '.js')))
 

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -623,6 +623,18 @@ describe('routing utilities: `navigateTo`', () => {
       expect(() => navigateTo(url, { external: true })).toThrowError(`Cannot navigate to a URL with '${protocol}:' protocol.`)
     }
   })
+  it('navigateTo should replace current navigation state if called within middleware', () => {
+    const nuxtApp = useNuxtApp()
+    nuxtApp._processingMiddleware = true
+    expect(navigateTo('/')).toMatchInlineSnapshot(`"/"`)
+    expect(navigateTo('/', { replace: true })).toMatchInlineSnapshot(`
+      {
+        "path": "/",
+        "replace": true,
+      }
+    `)
+    nuxtApp._processingMiddleware = false
+  })
 })
 
 describe('routing utilities: `resolveRouteObject`', () => {


### PR DESCRIPTION
### 🔗 Linked issue

resolves #30282

### 📚 Description

navigateTo doesn't use NavigateToOptions in middleware. This fixes it.
