### PR TITLE
docs: update auto-imports to advertise the scan feature

### DIFF
--- a/docs/2.guide/1.concepts/1.auto-imports.md
+++ b/docs/2.guide/1.concepts/1.auto-imports.md
@@ -140,8 +140,29 @@ export default defineNuxtConfig({
   }
 })
 ```
-
 This will disable auto-imports completely but it's still possible to use [explicit imports](#explicit-imports) from `#imports`.
+
+### Partially Disabling Auto-imports
+
+If you want framework-specific functions like `ref` to remain auto-imported but wish to disable auto-imports for your own code (e.g., custom composables), you can set the `imports.scan` option to `false` in your `nuxt.config.ts` file:
+
+```ts
+export default defineNuxtConfig({
+  imports: {
+    scan: false
+  }
+})
+```
+
+With this configuration:
+- Framework functions like `ref`, `computed`, or `watch` will still work without needing manual imports.
+- Custom code, such as composables, will need to be manually imported in your files.
+
+::warning
+**Caution:** This setup has certain limitations:
+- If you structure your project to include an "abstract layer" which extends from a "core layer" (which is an npm package), you’ll need to import composables from the npm package similarly to third-party packages (e.g., `vue-i18n`) into your "abstract layer".
+- This breaks the layer system’s override feature. If you use `imports.scan: false`, ensure you understand this side-effect and adjust your architecture accordingly.
+::
 
 ## Auto-imported Components
 

--- a/docs/2.guide/1.concepts/1.auto-imports.md
+++ b/docs/2.guide/1.concepts/1.auto-imports.md
@@ -140,6 +140,7 @@ export default defineNuxtConfig({
   }
 })
 ```
+
 This will disable auto-imports completely but it's still possible to use [explicit imports](#explicit-imports) from `#imports`.
 
 ### Partially Disabling Auto-imports
@@ -160,7 +161,7 @@ With this configuration:
 
 ::warning
 **Caution:** This setup has certain limitations:
-- If you structure your project to include an "abstract layer" which extends from a "core layer" (which is an npm package), you’ll need to import composables from the npm package similarly to third-party packages (e.g., `vue-i18n`) into your "abstract layer".
+- If you structure your project with layers, you will need to explicitly import the composables from each layer, rather than relying on auto-imports.
 - This breaks the layer system’s override feature. If you use `imports.scan: false`, ensure you understand this side-effect and adjust your architecture accordingly.
 ::
 

--- a/packages/schema/src/config/adhoc.ts
+++ b/packages/schema/src/config/adhoc.ts
@@ -29,7 +29,8 @@ export default defineUntypedSchema({
   imports: {
     global: false,
     /**
-     * Whether to auto-import custom source files or not (framework functions will still be auto-imported)
+     * Whether to scan your `composables/` and `utils/` directories for composables to auto-import.
+     * Auto-imports registered by Nuxt or other modules, such as imports from `vue` or `nuxt`, will still be enabled.
      */
     scan: true,
 

--- a/packages/schema/src/config/adhoc.ts
+++ b/packages/schema/src/config/adhoc.ts
@@ -28,6 +28,10 @@ export default defineUntypedSchema({
    */
   imports: {
     global: false,
+    /**
+     * Whether to auto-import custom source files or not (framework functions will still be auto-imported)
+     */
+    scan: true,
 
     /**
      * An array of custom directories that will be auto-imported.


### PR DESCRIPTION
- advertise imports.scan feature
- name limitations in layer systems

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
The source came from the video of alexander lichter "Auto Imports in Vue and Nuxt - The Good and the Bad" https://youtu.be/YHdDraNNGCk?si=PFNmmI6o2JSXj9KQ&t=910

I saw, that this is not covered in the docs. As I tried it in my project I faced issues with the layer system.
Please review the "### Partially Disabling Auto-imports" Section and the caution I mentioned. Let me know if I should remove that  caution part from the docs.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
