### PR TITLE
perf(nuxt): use static `hashMode` option

### DIFF
--- a/packages/nuxt/src/pages/build.d.ts
+++ b/packages/nuxt/src/pages/build.d.ts
@@ -1,6 +1,7 @@
 declare module '#build/router.options' {
   import type { RouterOptions } from '@nuxt/schema'
 
+  export const hashMode: boolean
   const _default: RouterOptions
   export default _default
 }

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -42,6 +42,7 @@ export default defineNuxtModule({
       delete tsConfig.compilerOptions.paths['#vue-router/*']
     })
 
+    const builtInRouterOptions = await findPath(resolve(runtimeDir, 'router.options')) || resolve(runtimeDir, 'router.options')
     async function resolveRouterOptions () {
       const context = {
         files: [] as Array<{ path: string, optional?: boolean }>,
@@ -53,7 +54,7 @@ export default defineNuxtModule({
       }
 
       // Add default options at beginning
-      context.files.unshift({ path: await findPath(resolve(runtimeDir, 'router.options')) || resolve(runtimeDir, 'router.options'), optional: true })
+      context.files.unshift({ path: builtInRouterOptions, optional: true })
 
       await nuxt.callHook('pages:routerOptions', context)
       return context.files
@@ -535,6 +536,7 @@ export default defineNuxtModule({
         return [
           ...routerOptionsFiles.map((file, index) => genImport(file.path, `routerOptions${index}`)),
           `const configRouterOptions = ${configRouterOptions}`,
+          `export const hashMode = ${[...routerOptionsFiles.filter(o => o.path !== builtInRouterOptions).map((_, index) => `routerOptions${index}.hashMode`).reverse(), nuxt.options.router.options.hashMode].join(' ?? ')}`,
           'export default {',
           '...configRouterOptions,',
           ...routerOptionsFiles.map((_, index) => `...routerOptions${index},`),

--- a/packages/nuxt/src/pages/runtime/plugins/prerender.server.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/prerender.server.ts
@@ -7,7 +7,7 @@ import { defineNuxtPlugin, useRuntimeConfig } from '#app/nuxt'
 import { prerenderRoutes } from '#app/composables/ssr'
 // @ts-expect-error virtual file
 import _routes from '#build/routes'
-import routerOptions from '#build/router.options'
+import routerOptions, { hashMode } from '#build/router.options'
 // @ts-expect-error virtual file
 import { crawlLinks } from '#build/nuxt.config.mjs'
 
@@ -16,7 +16,7 @@ let routes: string[]
 let _routeRulesMatcher: undefined | ReturnType<typeof toRouteMatcher> = undefined
 
 export default defineNuxtPlugin(async () => {
-  if (!import.meta.server || !import.meta.prerender || routerOptions.hashMode) {
+  if (!import.meta.server || !import.meta.prerender || hashMode) {
     return
   }
   if (routes && !routes.length) { return }

--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -19,7 +19,7 @@ import { navigateTo } from '#app/composables/router'
 import { appManifest as isAppManifestEnabled } from '#build/nuxt.config.mjs'
 // @ts-expect-error virtual file
 import _routes, { handleHotUpdate } from '#build/routes'
-import routerOptions from '#build/router.options'
+import routerOptions, { hashMode } from '#build/router.options'
 // @ts-expect-error virtual file
 import { globalMiddleware, namedMiddleware } from '#build/middleware'
 
@@ -51,13 +51,13 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
   enforce: 'pre',
   async setup (nuxtApp) {
     let routerBase = useRuntimeConfig().app.baseURL
-    if (routerOptions.hashMode && !routerBase.includes('#')) {
+    if (hashMode && !routerBase.includes('#')) {
       // allow the user to provide a `#` in the middle: `/base/#/app`
       routerBase += '#'
     }
 
     const history = routerOptions.history?.(routerBase) ?? (import.meta.client
-      ? (routerOptions.hashMode ? createWebHashHistory(routerBase) : createWebHistory(routerBase))
+      ? (hashMode ? createWebHashHistory(routerBase) : createWebHistory(routerBase))
       : createMemoryHistory(routerBase)
     )
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

spotted when reviewing https://github.com/nuxt/nuxt/pull/30190, currently we are not tree-shaking out `createWebHashHistory` from vue router

this change makes it possible to do so

(it's minor - just a couple of lines of code, but still worth it, I think)