### PR TITLE
perf(schema): only inline styles for vue components

### DIFF
--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -59,8 +59,8 @@ export default defineUntypedSchema({
         if (val === false || (await get('dev')) || (await get('ssr')) === false || (await get('builder')) === '@nuxt/webpack-builder') {
           return false
         }
-        // Enabled by default for vite prod with ssr
-        return val ?? true
+        // Enabled by default for vite prod with ssr (for vue components)
+        return val ?? ((id: string) => id && id.includes('.vue'))
       },
     },
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

I think this is possibly a better default for 4.x. global CSS can be cached in a `.css` file and probably it's better not to include in the page HTML in this case, reserving inlined styles in HTML for _component-level_ CSS, which is unique to vue components.