### PR TITLE
perf(vite): use vite to clear screen

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -26,7 +26,6 @@
   },
   "devDependencies": {
     "@nuxt/schema": "workspace:*",
-    "@types/clear": "0.1.4",
     "rollup": "4.28.1",
     "unbuild": "3.0.1",
     "vue": "3.5.13"
@@ -37,7 +36,6 @@
     "@vitejs/plugin-vue": "^5.2.1",
     "@vitejs/plugin-vue-jsx": "^4.1.1",
     "autoprefixer": "^10.4.20",
-    "clear": "^0.1.0",
     "consola": "^3.2.3",
     "cssnano": "^7.0.6",
     "defu": "^6.1.4",

--- a/packages/vite/src/utils/logger.ts
+++ b/packages/vite/src/utils/logger.ts
@@ -1,8 +1,8 @@
 import type * as vite from 'vite'
+import { createLogger } from 'vite'
 import { logger } from '@nuxt/kit'
 import { colorize } from 'consola/utils'
 import { hasTTY, isCI } from 'std-env'
-import clear from 'clear'
 import type { NuxtOptions } from '@nuxt/schema'
 import { useResolveFromPublicAssets } from '../plugins/public-dirs'
 
@@ -27,6 +27,13 @@ const RUNTIME_RESOLVE_REF_RE = /^([^ ]+) referenced in/m
 export function createViteLogger (config: vite.InlineConfig): vite.Logger {
   const loggedErrors = new WeakSet<any>()
   const canClearScreen = hasTTY && !isCI && config.clearScreen
+  const _logger = createLogger()
+  const clear = () => {
+    _logger.clearScreen(
+      // @ts-expect-error silent is a log level but not a valid option for clearScreens
+      'silent',
+    )
+  }
   const clearScreen = canClearScreen ? clear : () => {}
 
   const { resolveFromPublicAssets } = useResolveFromPublicAssets()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -822,9 +822,6 @@ importers:
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.4.49)
-      clear:
-        specifier: ^0.1.0
-        version: 0.1.0
       consola:
         specifier: ^3.2.3
         version: 3.2.3
@@ -901,9 +898,6 @@ importers:
       '@nuxt/schema':
         specifier: workspace:*
         version: link:../schema
-      '@types/clear':
-        specifier: 0.1.4
-        version: 0.1.4
       rollup:
         specifier: 4.28.1
         version: 4.28.1
@@ -2577,9 +2571,6 @@ packages:
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
-  '@types/clear@0.1.4':
-    resolution: {integrity: sha512-4nJjoilJPTbYF7Q4y5+F7JFDK8QdcwOItzwVv3RDEMWALT9Mx9UzfxCiUfpbFK05REhieXTCvhbNkiDW/Wfejw==}
-
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
@@ -3596,9 +3587,6 @@ packages:
   clean-stack@2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
     engines: {node: '>=6'}
-
-  clear@0.1.0:
-    resolution: {integrity: sha512-qMjRnoL+JDPJHeLePZJuao6+8orzHMGP04A8CdwCNsKhRbOnKRjefxONR7bwILT3MHecxKBjHkKL/tkZ8r4Uzw==}
 
   cli-highlight@2.1.11:
     resolution: {integrity: sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==}
@@ -9426,8 +9414,6 @@ snapshots:
 
   '@types/aria-query@5.0.4': {}
 
-  '@types/clear@0.1.4': {}
-
   '@types/connect@3.4.38':
     dependencies:
       '@types/node': 22.10.2
@@ -10818,8 +10804,6 @@ snapshots:
       escape-string-regexp: 1.0.5
 
   clean-stack@2.2.0: {}
-
-  clear@0.1.0: {}
 
   cli-highlight@2.1.11:
     dependencies:


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this drops a package we don't need

we could also inline this code:

```ts
function clearScreen() {
  const repeatCount = process.stdout.rows - 2
  const blank = repeatCount > 0 ? '\n'.repeat(repeatCount) : ''
  console.log(blank)
  readline.cursorTo(process.stdout, 0, 0)
  readline.clearScreenDown(process.stdout)
}
```