### PR TITLE
fix(kit): initialize tsconfig paths in `addTemplate` if undefined

### DIFF
--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -230,6 +230,7 @@ export async function _generateTypes (nuxt: Nuxt) {
     : nuxt.options.buildDir
 
   tsConfig.compilerOptions = tsConfig.compilerOptions || {}
+  tsConfig.compilerOptions.paths = tsConfig.compilerOptions.paths || {}
   tsConfig.include = tsConfig.include || []
 
   for (const alias in aliases) {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
fix

```ts
[7:43:24 PM]  ERROR  Cannot set properties of undefined (setting '~')

  at _generateTypes (node_modules/.pnpm/@nuxt+kit@3.14.1592_magicast@0.3.5_rollup@4.29.1/node_modules/@nuxt/kit/dist/index.mjs:3108:45)
  at async writeTypes (node_modules/.pnpm/@nuxt+kit@3.14.1592_magicast@0.3.5_rollup@4.29.1/node_modules/@nuxt/kit/dist/index.mjs:3164:37)
  at async Object.run (node_modules/.pnpm/nuxi@3.17.1/node_modules/nuxi/dist/chunks/prepare.mjs:76:5)
  at async runCommand$1 (node_modules/.pnpm/nuxi@3.17.1/node_modules/nuxi/dist/shared/nuxi.BpXDZ4Tv.mjs:1643:16)
  at async runCommand$1 (node_modules/.pnpm/nuxi@3.17.1/node_modules/nuxi/dist/shared/nuxi.BpXDZ4Tv.mjs:1634:11)
  at async runMain$1 (node_modules/.pnpm/nuxi@3.17.1/node_modules/nuxi/dist/shared/nuxi.BpXDZ4Tv.mjs:1772:7) 

``` 
<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
