### PR TITLE
chore: add configuration for JetBrains IDEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ coverage
 # Intellij idea
 *.iml
 .idea
+!.idea/nuxt.iml
+!.idea/modules.xml
+!.idea/inspectionProfiles/Project_Default.xml
 
 # OSX
 .DS_Store

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
+  </profile>
+</component>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/nuxt.iml" filepath="$PROJECT_DIR$/.idea/nuxt.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/nuxt.iml
+++ b/.idea/nuxt.iml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/packages/nuxt/dist" />
+      <excludeFolder url="file://$MODULE_DIR$/temp" />
+      <excludeFolder url="file://$MODULE_DIR$/tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/packages/schema/schema" />
+      <excludeFolder url="file://$MODULE_DIR$/playground/.output" />
+      <excludeFolder url="file://$MODULE_DIR$/test/fixtures/minimal/.nuxt-inline" />
+      <excludeFolder url="file://$MODULE_DIR$/test/fixtures/minimal/.output" />
+      <excludeFolder url="file://$MODULE_DIR$/test/fixtures/minimal/.output-inline" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
This PR turns on Eslint on by default in JetBrains IDEs and excludes some of the generated directories from being indexed.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
