### PR TITLE
fix(nuxt): ignore non-reference identifiers when extracting pageMeta

### DIFF
--- a/packages/nuxt/src/core/utils/parse.ts
+++ b/packages/nuxt/src/core/utils/parse.ts
@@ -476,7 +476,7 @@ function getPatternIdentifiers (pattern: WithLocations<Node>) {
   return identifiers
 }
 
-function isNotReferencePosition (node: WithLocations<Node>, parent: WithLocations<Node> | null) {
+export function isNotReferencePosition (node: WithLocations<Node>, parent: WithLocations<Node> | null) {
   if (!parent || node.type !== 'Identifier') { return false }
 
   switch (parent.type) {

--- a/packages/nuxt/test/page-metadata.test.ts
+++ b/packages/nuxt/test/page-metadata.test.ts
@@ -467,4 +467,81 @@ definePageMeta({
 
     expect(wasErrorThrown).toBe(true)
   })
+
+  it('should only add definitions for reference identifiers', () => {
+    const sfc = `
+<script setup lang="ts">
+const foo = 'foo'
+const bar = { bar: 'bar' }.bar, baz = { baz: 'baz' }.baz, x = { foo }
+const test = 'test'
+const prop = 'prop'
+const num = 1
+
+const val = 'val'
+
+const useVal = () => ({ val: 'val' })
+
+function recursive () {
+  recursive()
+}
+
+definePageMeta({
+  middleware: [
+    () => {
+      console.log(bar, baz)
+      recursive()
+
+      const val = useVal().val
+      const obj = {
+        num,
+        prop: 'prop',
+      }
+
+      const c = class test {
+        prop = 'prop'
+        test () {}
+      }
+    },
+  ],
+})
+</script>
+      `
+    const res = compileScript(parse(sfc).descriptor, { id: 'component.vue' })
+    expect(transformPlugin.transform.call({
+      parse: (code: string, opts: any = {}) => Parser.parse(code, {
+        sourceType: 'module',
+        ecmaVersion: 'latest',
+        locations: true,
+        ...opts,
+      }),
+    }, res.content, 'component.vue?macro=true')?.code).toMatchInlineSnapshot(`
+      "const foo = 'foo'
+      const num = 1
+      const bar = { bar: 'bar' }.bar, baz = { baz: 'baz' }.baz, x = { foo }
+      const useVal = () => ({ val: 'val' })
+      function recursive () {
+        recursive()
+      }
+      const __nuxt_page_meta = {
+        middleware: [
+          () => {
+            console.log(bar, baz)
+            recursive()
+
+            const val = useVal().val
+            const obj = {
+              num,
+              prop: 'prop',
+            }
+
+            const c = class test {
+              prop = 'prop'
+              test () {}
+            }
+          },
+        ],
+      }
+      export default __nuxt_page_meta"
+    `)
+  })
 })


### PR DESCRIPTION
### 🔗 Linked issue
Fix #30378

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
This fixes an issue where we didn't check if an identifier was a reference one or not while extracting pageMeta.
This could lead to an infinite recursion loop when encountering a member expression, for example:
```ts
const bar = { bar: 'bar' }.bar  // <- this `bar` property access
                                // would trigger `processDeclaration()` for `bar` again

definePageMeta({
  middleware: [
    () => {
      const a = bar
    },
  ],
})
```

I added a regression test too!

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
