### PR TITLE
chore: only allow pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
+    "preinstall": "npx only-allow pnpm",
     "build": "pnpm --filter './packages/**' prepack",
     "build:stub": "pnpm dev:prepare",
     "dev": "pnpm play",


### PR DESCRIPTION
I think may be we may add `preinstall` because here we have pnpm-lock.yaml that means we should install deps with pnpm only.