### PR TITLE
perf(vite): remove client entry from server warmup

### DIFF
--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -152,9 +152,6 @@ export async function buildClient (ctx: ViteBuildContext) {
     ],
     appType: 'custom',
     server: {
-      warmup: {
-        clientFiles: [ctx.entry],
-      },
       middlewareMode: true,
     },
   } satisfies vite.InlineConfig, ctx.nuxt.options.vite.$client || {}))


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
Starting dev server with client entry added to the vite server warmup is too slow (10x): this PR removes the server warmup in the vite client module included in this PR https://github.com/nuxt/nuxt/pull/27963

This should be ported to 3.* version (3.15.1).

You can start the playground in nuxt repo: on i18n nuxt module playground, it takes 20sc or even more on my laptop.


![image](https://github.com/user-attachments/assets/4a0281b2-561d-4a15-8a63-b36c4d7f5490)
_Nuxt playground with this PR_

![image](https://github.com/user-attachments/assets/59ec51f9-846c-4267-99c2-5626af09f020)
_Nuxt playground without this PR_

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
