### PR TITLE
fix(schema): support pfx certificate for dev server

### DIFF
--- a/packages/schema/src/config/dev.ts
+++ b/packages/schema/src/config/dev.ts
@@ -16,7 +16,7 @@ export default defineUntypedSchema({
      *   }
      * })
      * ```
-     * @type {boolean | { key: string; cert: string }}
+     * @type {boolean | { key: string; cert: string } | { pfx: string; passphrase: string }}
      */
     https: false,
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves nuxt/cli [#123](https://github.com/nuxt/cli/issues/623)

### 📚 Description

This fixes the <span>@</span>type for devServer.https to allow PFX certificates. Also might want to consider removing the <span>@</span>example.
