### PR TITLE
fix(nuxt): added a class on wrapper div on createClientPage

### DIFF
--- a/packages/nuxt/src/components/runtime/client-component.ts
+++ b/packages/nuxt/src/components/runtime/client-component.ts
@@ -20,7 +20,7 @@ export const createClientPage = (loader: AsyncComponentLoader) => {
       if (import.meta.server || nuxtApp.isHydrating) {
         // wrapped with div to avoid Transition issues
         // @see https://github.com/nuxt/nuxt/pull/25037#issuecomment-1877423894
-        return () => h('div', [
+        return () => h('div', { class: 'client-page-wrapper' }, [
           h(ClientOnly, undefined, {
             default: () => h(page, attrs),
           }),


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #30344

### 📚 Description

There is a limitation to client-only pages where they generate a classless and id-less div which is tricky to target with CSS. 
I added a 'client-page-wrapper' class to the generated wrapper to more easily target this div with CSS.

I've checked the effects via running the playground with the corresponding issue's reproduction steps:
![nuxt-client-page-wrapper](https://github.com/user-attachments/assets/510157b1-3a44-4c07-bd24-677314d5f6e1)

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
