### PR TITLE
perf(nuxt): drop `pathe` browser dep for deep server components

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-island.ts
+++ b/packages/nuxt/src/app/components/nuxt-island.ts
@@ -7,7 +7,6 @@ import { type ActiveHeadEntry, type Head, injectHead } from '@unhead/vue'
 import { randomUUID } from 'uncrypto'
 import { joinURL, withQuery } from 'ufo'
 import type { FetchResponse } from 'ofetch'
-import { join } from 'pathe'
 
 import type { NuxtIslandResponse } from '../types'
 import { useNuxtApp, useRuntimeConfig } from '../nuxt'
@@ -37,7 +36,7 @@ async function loadComponents (source = appBaseURL, paths: NuxtIslandResponse['c
   for (const [component, item] of Object.entries(paths)) {
     if (!(components!.has(component))) {
       promises.push((async () => {
-        const chunkSource = join(source, item.chunk)
+        const chunkSource = joinURL(source, item.chunk)
         const c = await import(/* @vite-ignore */ chunkSource).then(m => m.default || m)
         components!.set(component, c)
       })())

--- a/packages/nuxt/src/app/components/nuxt-teleport-island-component.ts
+++ b/packages/nuxt/src/app/components/nuxt-teleport-island-component.ts
@@ -3,6 +3,8 @@ import { Teleport, defineComponent, h, inject, provide, useId } from 'vue'
 import { useNuxtApp } from '../nuxt'
 // @ts-expect-error virtual file
 import { paths } from '#build/components-chunk'
+// @ts-expect-error virtual file
+import { buildAssetsURL } from '#internal/nuxt/paths'
 
 type ExtendedComponent = Component & {
   __file: string
@@ -41,7 +43,7 @@ export default defineComponent({
       const name = (slotType.__name || slotType.name) as string
 
       islandContext.components[to] = {
-        chunk: import.meta.dev ? nuxtApp.$config.app.buildAssetsDir + paths[name] : paths[name],
+        chunk: import.meta.dev ? buildAssetsURL(paths[name]) : paths[name],
         props: slot.props || {},
       }
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

noticed we were using `join` from `pathe` in a runtime context - we probably want `joinURL` instead (unless there's a reason I'm unaware of)