### PR TITLE
fix(nuxt): collect all identifiers before extracting page metadata

### DIFF
--- a/packages/nuxt/src/pages/plugins/page-meta.ts
+++ b/packages/nuxt/src/pages/plugins/page-meta.ts
@@ -173,7 +173,9 @@ export const PageMetaPlugin = (options: PageMetaPluginOptions = {}) => createUnp
         }
       }
 
-      const scopeTracker = new ScopeTracker()
+      const scopeTracker = new ScopeTracker({
+        keepExitedScopes: true,
+      })
 
       function processDeclaration (scopeTrackerNode: ScopeTrackerNode | null) {
         if (scopeTrackerNode?.type === 'Variable') {
@@ -210,7 +212,13 @@ export const PageMetaPlugin = (options: PageMetaPluginOptions = {}) => createUnp
         }
       }
 
-      parseAndWalk(code, id, {
+      const ast = parseAndWalk(code, id, {
+        scopeTracker,
+      })
+
+      scopeTracker.freeze()
+
+      walk(ast, {
         scopeTracker,
         enter: (node) => {
           if (node.type !== 'CallExpression' || node.callee.type !== 'Identifier') { return }
@@ -221,6 +229,7 @@ export const PageMetaPlugin = (options: PageMetaPluginOptions = {}) => createUnp
           if (!meta) { return }
 
           walk(meta, {
+            scopeTracker,
             enter (node, parent) {
               if (
                 isNotReferencePosition(node, parent)

--- a/packages/nuxt/test/page-metadata.test.ts
+++ b/packages/nuxt/test/page-metadata.test.ts
@@ -485,6 +485,8 @@ function recursive () {
   recursive()
 }
 
+const route = useRoute()
+
 definePageMeta({
   middleware: [
     () => {
@@ -501,9 +503,19 @@ definePageMeta({
         prop = 'prop'
         test () {}
       }
+
+      console.log(hoisted.value)
     },
   ],
+  validate: (route) => {
+    return route.params.id === 'test'
+  }
 })
+
+// the order of a ref relative to the 'definePageMeta' call should be preserved (in contrast to a simple const)
+// this tests whether the extraction handles all variables in the upper scope
+const hoisted = ref('hoisted')
+
 </script>
       `
     const res = compileScript(parse(sfc).descriptor, { id: 'component.vue' })
@@ -522,6 +534,7 @@ definePageMeta({
       function recursive () {
         recursive()
       }
+      const hoisted = ref('hoisted')
       const __nuxt_page_meta = {
         middleware: [
           () => {
@@ -538,8 +551,13 @@ definePageMeta({
               prop = 'prop'
               test () {}
             }
+
+            console.log(hoisted.value)
           },
         ],
+        validate: (route) => {
+          return route.params.id === 'test'
+        }
       }
       export default __nuxt_page_meta"
     `)


### PR DESCRIPTION
### 🔗 Linked issue
fix #30385

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
There were a few remaining issues with the page metadata extraction:

1) We weren't tracking the identifiers defined in `definePageMeta`.
_(missing `scopeTracker` in this `walk`)_
https://github.com/nuxt/nuxt/blob/ba764b212ff40d811caae9ab9eee0c4e1f896571/packages/nuxt/src/pages/plugins/page-meta.ts#L223-L225
As a result, when there was a variable in the root scope with the same name as a function parameter, for example, the variable would also get extracted.

```ts
const route = useRoute() // <---
definePageMeta({
  validate: (route /* <-- this wasn't tracked */ ) => {
    return route.params.id === 'test' // referencing `route` would extract the `route` variable from the root scope
  }
})
```
2) We weren't pre-collecting the identifiers. Therefore, if an identifier happened to appear (in the compiled code) below `definePageMeta`, it wouldn't be extracted.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
