### PR TITLE
fix(nuxt): do not hoist identifiers declared locally in `definePageMeta` when extracting page metadata

### DIFF
--- a/packages/nuxt/src/pages/plugins/page-meta.ts
+++ b/packages/nuxt/src/pages/plugins/page-meta.ts
@@ -228,6 +228,8 @@ export const PageMetaPlugin = (options: PageMetaPluginOptions = {}) => createUnp
 
           if (!meta) { return }
 
+          const definePageMetaScope = scopeTracker.getCurrentScope()
+
           walk(meta, {
             scopeTracker,
             enter (node, parent) {
@@ -236,10 +238,24 @@ export const PageMetaPlugin = (options: PageMetaPluginOptions = {}) => createUnp
                 || node.type !== 'Identifier' // checking for `node.type` to narrow down the type
               ) { return }
 
+              const declaration = scopeTracker.getDeclaration(node.name)
+              if (declaration) {
+                // check if the declaration was made inside `definePageMeta` and if so, do not process it
+                // (ensures that we don't hoist local variables in inline middleware, for example)
+                if (
+                  declaration.isUnderScope(definePageMetaScope)
+                  // ensures that we compare the correct declaration to the reference
+                  // (when in the same scope, the declaration must come before the reference, otherwise it must be in a parent scope)
+                  && (scopeTracker.isCurrentScopeUnder(declaration.scope) || declaration.start < node.start)
+                ) {
+                  return
+                }
+              }
+
               if (isStaticIdentifier(node.name)) {
                 addImport(node.name)
-              } else {
-                processDeclaration(scopeTracker.getDeclaration(node.name))
+              } else if (declaration) {
+                processDeclaration(declaration)
               }
             },
           })


### PR DESCRIPTION
### 📚 Description
I've identified another issue, where local identifiers would get hoisted and extracted too.
Example:
```ts
definePageMeta({
  middleware: () => {
    const auth = useState('auth')
    if (!auth.value.isLoggedIn) {
      return navigateTo('/login')
    }
  },
})

// extracted:

import { useState } from '#app/composables/state'

const auth = useState('auth')  // <<<
const __nuxt_page_meta = {
  middleware: () => {
      const auth = useState('auth')
      if (!auth.value.isLoggedIn) {
        return navigateTo('/login')
      }
    }
}
```

I've added scope information to ScopeTracker nodes and a comparison function.
Additionally, the implementation now supports shadowing imports and only adds the import, if it is being used.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
