### PR TITLE
fix(nuxt): use `fullPath` instead of empty string in router hmr

### DIFF
--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -642,7 +642,7 @@ if (import.meta.hot) {
       for (const route of routes) {
         router.addRoute(route)
       }
-      router.replace('')
+      router.replace(router.currentRoute.value.fullPath)
     }
     if (routes && 'then' in routes) {
       routes.then(addRoutes)


### PR DESCRIPTION
### 🔗 Linked issue

resolves #30469

### 📚 Description

When HMR occurs, it uses router.replace("") with an empty string as the argument. In my tests with Vue, this method removes query parameters from the URL. To address this, I tried using fullPath, and it seems to work.
