### PR TITLE
fix(kit): reorder `#build` to the end of tsConfig paths

### DIFF
--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -291,6 +291,10 @@ export async function _generateTypes (nuxt: Nuxt) {
     }))
   }
 
+  // Ensure `#build` is placed at the end of the paths object.
+  // https://github.com/nuxt/nuxt/issues/30325
+  sortTsPaths(tsConfig.compilerOptions.paths)
+
   tsConfig.include = [...new Set(tsConfig.include.map(p => isAbsolute(p) ? relativeWithDot(nuxt.options.buildDir, p) : p))]
   tsConfig.exclude = [...new Set(tsConfig.exclude!.map(p => isAbsolute(p) ? relativeWithDot(nuxt.options.buildDir, p) : p))]
 
@@ -328,6 +332,17 @@ export async function writeTypes (nuxt: Nuxt) {
   }
 
   await writeFile()
+}
+
+function sortTsPaths (paths: Record<string, string[]>) {
+  for (const pathKey in paths) {
+    if (pathKey.startsWith('#build')) {
+      const pathValue = paths[pathKey]!
+      // Delete & Reassign to ensure key is inserted at the end of object.
+      delete paths[pathKey]
+      paths[pathKey] = pathValue
+    }
+  }
 }
 
 function renderAttrs (obj: Record<string, string>) {

--- a/packages/kit/test/generate-types.spec.ts
+++ b/packages/kit/test/generate-types.spec.ts
@@ -59,4 +59,42 @@ describe('tsConfig generation', () => {
       ]
     `)
   })
+
+  it('should add #build after #components to paths', async () => {
+    const { tsConfig } = await _generateTypes(mockNuxtWithOptions({
+      alias: {
+        '~': '/my-app',
+        '@': '/my-app',
+        'some-custom-alias': '/my-app/some-alias',
+        '#build': './build-dir',
+        '#build/*': './build-dir/*',
+        '#imports': './imports',
+        '#components': './components',
+      },
+    }))
+
+    expect(tsConfig.compilerOptions?.paths).toMatchObject({
+      '~': [
+        '..',
+      ],
+      'some-custom-alias': [
+        '../some-alias',
+      ],
+      '@': [
+        '..',
+      ],
+      '#imports': [
+        './imports',
+      ],
+      '#components': [
+        './components',
+      ],
+      '#build': [
+        './build-dir',
+      ],
+      '#build/*': [
+        './build-dir/*',
+      ],
+    })
+  })
 })


### PR DESCRIPTION
### 🔗 Linked issue

resolves #30325 

### 📚 Description

To ensure VSCode IDE always prioritizes `#components/` instead of `#build/components/` in auto-suggestion, the ordering of `paths` in the generated `tsconfig.json`, should be changed.

### Additional Context
This fix could have been implemented in two more different ways.
1. either postpone adding `#build` in `packages/schema/src/config/common.ts` to a later stage (line 442)
2. or change the order after line 198 of `packages/schema/src/config/common.ts`

However, these methods may not be as resilient to future developments as the proposed solution
