### PR TITLE
docs: ensure correct type for `url` in `useFetch`

### DIFF
--- a/docs/3.api/2.composables/use-fetch.md
+++ b/docs/3.api/2.composables/use-fetch.md
@@ -147,7 +147,7 @@ If you have not fetched data on the server (for example, with `server: false`), 
 
 ```ts [Signature]
 function useFetch<DataT, ErrorT>(
-  url: string | Request | Ref<string | Request> | (() => string) | Request,
+  url: string | Request | Ref<string | Request> | (() => string | Request),
   options?: UseFetchOptions<DataT>
 ): Promise<AsyncData<DataT, ErrorT>>
 


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 📚 Description

This PR addresses the issue of incorrect type definitions for the `url` in `useFetch` within the docs.