### PR TITLE
docs: add `status` detail and enhance `getCachedData` readability

### DIFF
--- a/docs/3.api/2.composables/use-async-data.md
+++ b/docs/3.api/2.composables/use-async-data.md
@@ -69,7 +69,13 @@ const { data: posts } = await useAsyncData(
   - `immediate`: when set to `false`, will prevent the request from firing immediately. (defaults to `true`)
   - `default`: a factory function to set the default value of the `data`, before the async function resolves - useful with the `lazy: true` or `immediate: false` option
   - `transform`: a function that can be used to alter `handler` function result after resolving
-  - `getCachedData`: Provide a function which returns cached data. A _null_ or _undefined_ return value will trigger a fetch. By default, this is: `key => nuxt.isHydrating ? nuxt.payload.data[key] : nuxt.static.data[key]`, which only caches data when `payloadExtraction` is enabled.
+  - `getCachedData`: Provide a function which returns cached data. A `null` or `undefined` return value will trigger a fetch. By default, this is:
+    ```ts
+    const getDefaultCachedData = (key) => nuxtApp.isHydrating 
+      ? nuxtApp.payload.data[key] 
+      : nuxtApp.static.data[key]
+    ```
+    Which only caches data when `experimental.payloadExtraction` of `nuxt.config` is enabled.
   - `pick`: only pick specified keys in this array from the `handler` function result
   - `watch`: watch reactive sources to auto-refresh
   - `deep`: return data in a deep ref object. It is `false` by default to return data in a shallow ref object for performance.
@@ -95,6 +101,12 @@ Learn how to use `transform` and `getCachedData` to avoid superfluous calls to a
 - `refresh`/`execute`: a function that can be used to refresh the data returned by the `handler` function.
 - `error`: an error object if the data fetching failed.
 - `status`: a string indicating the status of the data request (`"idle"`, `"pending"`, `"success"`, `"error"`).
+  - `idle`: when request did not star.
+    - set `{ immediate: false }` and `execute` not called.
+    - set `{ server: false }` and on server side.
+  - `pending`: the request is in progress.
+  - `success`: the request has completed successfully.
+  - `error`: the request has failed.
 - `clear`: a function which will set `data` to `undefined`, set `error` to `null`, set `status` to `'idle'`, and mark any currently pending requests as cancelled.
 
 By default, Nuxt waits until a `refresh` is finished before it can be executed again.

--- a/docs/3.api/2.composables/use-async-data.md
+++ b/docs/3.api/2.composables/use-async-data.md
@@ -101,9 +101,9 @@ Learn how to use `transform` and `getCachedData` to avoid superfluous calls to a
 - `refresh`/`execute`: a function that can be used to refresh the data returned by the `handler` function.
 - `error`: an error object if the data fetching failed.
 - `status`: a string indicating the status of the data request:
-  - `idle`: when the request has not started:
-    - set `{ immediate: false }` and `execute` not called
-    - set `{ server: false }` and on the server side
+  - `idle`: when the request has not started, such as:
+    - when `execute` has not yet been called and `{ immediate: false }` is set
+    - when rendering HTML on the server and `{ server: false }` is set
   - `pending`: the request is in progress
   - `success`: the request has completed successfully
   - `error`: the request has failed

--- a/docs/3.api/2.composables/use-async-data.md
+++ b/docs/3.api/2.composables/use-async-data.md
@@ -100,13 +100,13 @@ Learn how to use `transform` and `getCachedData` to avoid superfluous calls to a
 - `data`: the result of the asynchronous function that is passed in.
 - `refresh`/`execute`: a function that can be used to refresh the data returned by the `handler` function.
 - `error`: an error object if the data fetching failed.
-- `status`: a string indicating the status of the data request (`"idle"`, `"pending"`, `"success"`, `"error"`).
-  - `idle`: when request did not star.
-    - set `{ immediate: false }` and `execute` not called.
-    - set `{ server: false }` and on server side.
-  - `pending`: the request is in progress.
-  - `success`: the request has completed successfully.
-  - `error`: the request has failed.
+- `status`: a string indicating the status of the data request:
+  - `idle`: when the request has not started:
+    - set `{ immediate: false }` and `execute` not called
+    - set `{ server: false }` and on the server side
+  - `pending`: the request is in progress
+  - `success`: the request has completed successfully
+  - `error`: the request has failed
 - `clear`: a function which will set `data` to `undefined`, set `error` to `null`, set `status` to `'idle'`, and mark any currently pending requests as cancelled.
 
 By default, Nuxt waits until a `refresh` is finished before it can be executed again.

--- a/docs/3.api/2.composables/use-fetch.md
+++ b/docs/3.api/2.composables/use-fetch.md
@@ -141,9 +141,9 @@ Learn how to use `transform` and `getCachedData` to avoid superfluous calls to a
 - `refresh`/`execute`: a function that can be used to refresh the data returned by the `handler` function.
 - `error`: an error object if the data fetching failed.
 - `status`: a string indicating the status of the data request:
-  - `idle`: when the request has not started:
-    - set `{ immediate: false }` and `execute` not called
-    - set `{ server: false }` and on the server side
+  - `idle`: when the request has not started, such as:
+    - when `execute` has not yet been called and `{ immediate: false }` is set
+    - when rendering HTML on the server and `{ server: false }` is set
   - `pending`: the request is in progress
   - `success`: the request has completed successfully
   - `error`: the request has failed

--- a/docs/3.api/2.composables/use-fetch.md
+++ b/docs/3.api/2.composables/use-fetch.md
@@ -140,13 +140,13 @@ Learn how to use `transform` and `getCachedData` to avoid superfluous calls to a
 - `data`: the result of the asynchronous function that is passed in.
 - `refresh`/`execute`: a function that can be used to refresh the data returned by the `handler` function.
 - `error`: an error object if the data fetching failed.
-- `status`: a string indicating the status of the data request (`"idle"`, `"pending"`, `"success"`, `"error"`).
-  - `idle`: when request did not star.
-    - set `{ immediate: false }` and `execute` not called.
-    - set `{ server: false }` and on server side.
-  - `pending`: the request is in progress.
-  - `success`: the request has completed successfully.
-  - `error`: the request has failed.
+- `status`: a string indicating the status of the data request:
+  - `idle`: when the request has not started:
+    - set `{ immediate: false }` and `execute` not called
+    - set `{ server: false }` and on the server side
+  - `pending`: the request is in progress
+  - `success`: the request has completed successfully
+  - `error`: the request has failed
 - `clear`: a function which will set `data` to `undefined`, set `error` to `null`, set `status` to `'idle'`, and mark any currently pending requests as cancelled.
 
 By default, Nuxt waits until a `refresh` is finished before it can be executed again.

--- a/docs/3.api/2.composables/use-fetch.md
+++ b/docs/3.api/2.composables/use-fetch.md
@@ -109,7 +109,13 @@ All fetch options can be given a `computed` or `ref` value. These will be watche
   - `immediate`: when set to `false`, will prevent the request from firing immediately. (defaults to `true`)
   - `default`: a factory function to set the default value of the `data`, before the async function resolves - useful with the `lazy: true` or `immediate: false` option
   - `transform`: a function that can be used to alter `handler` function result after resolving
-  - `getCachedData`: Provide a function which returns cached data. A _null_ or _undefined_ return value will trigger a fetch. By default, this is: `key => nuxt.isHydrating ? nuxt.payload.data[key] : nuxt.static.data[key]`, which only caches data when `payloadExtraction` is enabled.
+  - `getCachedData`: Provide a function which returns cached data. A `null` or `undefined` return value will trigger a fetch. By default, this is:
+    ```ts
+    const getDefaultCachedData = (key) => nuxtApp.isHydrating 
+      ? nuxtApp.payload.data[key] 
+      : nuxtApp.static.data[key]
+    ```
+    Which only caches data when `experimental.payloadExtraction` of `nuxt.config` is enabled.
   - `pick`: only pick specified keys in this array from the `handler` function result
   - `watch`: watch an array of reactive sources and auto-refresh the fetch result when they change. Fetch options and URL are watched by default. You can completely ignore reactive sources by using `watch: false`. Together with `immediate: false`, this allows for a fully-manual `useFetch`. (You can [see an example here](/docs/getting-started/data-fetching#watch) of using `watch`.)
   - `deep`: return data in a deep ref object. It is `false` by default to return data in a shallow ref object for performance.
@@ -135,6 +141,12 @@ Learn how to use `transform` and `getCachedData` to avoid superfluous calls to a
 - `refresh`/`execute`: a function that can be used to refresh the data returned by the `handler` function.
 - `error`: an error object if the data fetching failed.
 - `status`: a string indicating the status of the data request (`"idle"`, `"pending"`, `"success"`, `"error"`).
+  - `idle`: when request did not star.
+    - set `{ immediate: false }` and `execute` not called.
+    - set `{ server: false }` and on server side.
+  - `pending`: the request is in progress.
+  - `success`: the request has completed successfully.
+  - `error`: the request has failed.
 - `clear`: a function which will set `data` to `undefined`, set `error` to `null`, set `status` to `'idle'`, and mark any currently pending requests as cancelled.
 
 By default, Nuxt waits until a `refresh` is finished before it can be executed again.


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 📚 Description

- Added the explanation for each `status` state, referring to the description in #18810.  
- Improved the formatting of the `getCachedData` description in the docs to enhance readability.


  **Before**
    <img src="https://github.com/user-attachments/assets/83e2437d-a838-4a64-a017-1ca855e800d7" alt="Before" width="689" />
  **After**
    <img src="https://github.com/user-attachments/assets/7300662f-eedd-4662-ae46-10a7c53e14f9" alt="After" width="689"  />

