### PR TITLE
docs: resolve twoslash errors that during `nuxt generate`

### DIFF
--- a/docs/1.getting-started/11.testing.md
+++ b/docs/1.getting-started/11.testing.md
@@ -174,6 +174,7 @@ Under the hood, `mountSuspended` wraps `mount` from `@vue/test-utils`, so you ca
 For example:
 
 ```ts twoslash
+// @noErrors
 import { it, expect } from 'vitest'
 import type { Component } from 'vue'
 declare module '#components' {
@@ -194,6 +195,7 @@ it('can mount some component', async () => {
 ```
 
 ```ts twoslash
+// @noErrors
 import { it, expect } from 'vitest'
 // ---cut---
 // tests/components/SomeComponents.nuxt.spec.ts
@@ -225,6 +227,7 @@ The passed in component will be rendered inside a `<div id="test-wrapper"></div>
 Examples:
 
 ```ts twoslash
+// @noErrors
 import { it, expect } from 'vitest'
 import type { Component } from 'vue'
 declare module '#components' {
@@ -243,6 +246,7 @@ it('can render some component', async () => {
 ```
 
 ```ts twoslash
+// @noErrors
 import { it, expect } from 'vitest'
 // ---cut---
 // tests/App.nuxt.spec.ts


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt.com/issues/1705

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Declare twoslash error to provide correct rendering.

Refer to the image below, the left side is the Nuxt official website, and the right side is the Nuxt Chinese documentation that I built. Twoslash works correctly.

![image](https://github.com/user-attachments/assets/c24dced6-2018-48f1-86e0-fadd390ac21c)

I have verified that this method works in the commit at https://github.com/zhcndoc/nuxt-docs/commit/078768e5adbb1d1547b2d48ec8d00add16faf1fa.

https://nuxt.com/docs/getting-started/testing

https://nuxt.zhcndoc.com/docs/getting-started/testing

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
