### PR TITLE
fix(nuxt): allow url-specific chars in vfs

### DIFF
--- a/packages/nuxt/src/core/plugins/virtual.ts
+++ b/packages/nuxt/src/core/plugins/virtual.ts
@@ -38,25 +38,25 @@ export const VirtualFSPlugin = (nuxt: Nuxt, options: VirtualFSPluginOptions) => 
 
       const resolvedId = resolveWithExt(id)
       if (resolvedId) {
-        return PREFIX + resolvedId
+        return PREFIX + encodeURIComponent(resolvedId)
       }
 
       if (importer && RELATIVE_ID_RE.test(id)) {
         const path = resolve(dirname(withoutPrefix(importer)), id)
         const resolved = resolveWithExt(path)
         if (resolved) {
-          return PREFIX + resolved
+          return PREFIX + encodeURIComponent(resolved)
         }
       }
     },
 
     loadInclude (id) {
-      return id.startsWith(PREFIX) && withoutPrefix(id) in nuxt.vfs
+      return id.startsWith(PREFIX) && withoutPrefix(decodeURIComponent(id)) in nuxt.vfs
     },
 
     load (id) {
       return {
-        code: nuxt.vfs[withoutPrefix(id)] || '',
+        code: nuxt.vfs[withoutPrefix(decodeURIComponent(id))] || '',
         map: null,
       }
     },

--- a/packages/nuxt/src/pages/plugins/page-meta.ts
+++ b/packages/nuxt/src/pages/plugins/page-meta.ts
@@ -287,9 +287,9 @@ export const PageMetaPlugin = (options: PageMetaPluginOptions = {}) => createUnp
       handleHotUpdate: {
         order: 'post',
         handler: ({ file, modules, server }) => {
-          if (options.isPage?.(file)) {
+          if (options.routesPath && options.isPage?.(file)) {
             const macroModule = server.moduleGraph.getModuleById(file + '?macro=true')
-            const routesModule = server.moduleGraph.getModuleById('virtual:nuxt:' + options.routesPath)
+            const routesModule = server.moduleGraph.getModuleById('virtual:nuxt:' + encodeURIComponent(options.routesPath))
             return [
               ...modules,
               ...macroModule ? [macroModule] : [],

--- a/packages/vite/src/vite-node.ts
+++ b/packages/vite/src/vite-node.ts
@@ -44,7 +44,7 @@ export function viteNodePlugin (ctx: ViteBuildContext): VitePlugin {
       // invalidate changed virtual modules when templates are regenerated
       ctx.nuxt.hook('app:templatesGenerated', (_app, changedTemplates) => {
         for (const template of changedTemplates) {
-          const mods = server.moduleGraph.getModulesByFile(`virtual:nuxt:${template.dst}`)
+          const mods = server.moduleGraph.getModulesByFile(`virtual:nuxt:${encodeURIComponent(template.dst)}`)
 
           for (const mod of mods || []) {
             markInvalidate(mod)

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -212,7 +212,7 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
     // Invalidate virtual modules when templates are re-generated
     ctx.nuxt.hook('app:templatesGenerated', (_app, changedTemplates) => {
       for (const template of changedTemplates) {
-        for (const mod of server.moduleGraph.getModulesByFile(`virtual:nuxt:${template.dst}`) || []) {
+        for (const mod of server.moduleGraph.getModulesByFile(`virtual:nuxt:${encodeURIComponent(template.dst)}`) || []) {
           server.moduleGraph.invalidateModule(mod)
           server.reloadModule(mod)
         }

--- a/test/hmr.test.ts
+++ b/test/hmr.test.ts
@@ -134,7 +134,7 @@ if (process.env.TEST_ENV !== 'built' && !isWindows) {
           'type': 'debug',
         },
         {
-          'text': `[vite] hot updated: /@id/virtual:nuxt:${fixturePath}/.nuxt/routes.mjs`,
+          'text': `[vite] hot updated: /@id/virtual:nuxt:${encodeURIComponent(join(fixturePath, '.nuxt/routes.mjs'))}`,
           'type': 'debug',
         },
       ])


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

resolves https://github.com/nuxt/nuxt/issues/30576.

`#` and subsequent chars were being stripped as they aren't passed in a URL, and it occurs to me this might be relevant for other issues (like utf-16 chars), whereas we can normalise this at source to resolve 

(need to confirm this works for webpack as well)