### PR TITLE
fix(vite): provide fallback alias for `#app-manifest`

### DIFF
--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -110,9 +110,11 @@ export async function buildClient (ctx: ViteBuildContext) {
     },
     resolve: {
       alias: {
+        // work around vite optimizer bug
+        '#app-manifest': 'unenv/runtime/mock/empty',
+        // user aliases
         ...nodeCompat.alias,
         ...ctx.config.resolve?.alias,
-        'nitro/runtime': join(ctx.nuxt.options.buildDir, 'nitro.client.mjs'),
       },
       dedupe: [
         'vue',

--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -115,6 +115,7 @@ export async function buildClient (ctx: ViteBuildContext) {
         // user aliases
         ...nodeCompat.alias,
         ...ctx.config.resolve?.alias,
+        'nitro/runtime': join(ctx.nuxt.options.buildDir, 'nitro.client.mjs'),
       },
       dedupe: [
         'vue',


### PR DESCRIPTION
resolves https://github.com/nuxt/nuxt/issues/30461

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This seems to be caused by a Vite bug triggered in the process of building an app (so it's only replicable _after_ a build but not on a clean install, or after running `nuxi dev`). If you remove `node_modules/.cache/vite` before running the dev server you won't encounter an issue.

Providing an alias allows Vite to resolve the alias, even if it's never used, but this should probably be replicated and raised upstream for Vite (cc: @antfu).