### PR TITLE
fix(nuxt): avoid invoke `shouldPrefetch` on the server side

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -325,10 +325,13 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
       const elRef = import.meta.server ? undefined : (ref: any) => { el!.value = props.custom ? ref?.$el?.nextElementSibling : ref?.$el }
 
       function shouldPrefetch (mode: 'visibility' | 'interaction') {
+        if (import.meta.server) { return }
         return !prefetched.value && (typeof props.prefetchOn === 'string' ? props.prefetchOn === mode : (props.prefetchOn?.[mode] ?? options.prefetchOn?.[mode])) && (props.prefetch ?? options.prefetch) !== false && props.noPrefetch !== true && props.target !== '_blank' && !isSlowConnection()
       }
 
       async function prefetch (nuxtApp = useNuxtApp()) {
+        if (import.meta.server) { return }
+
         if (prefetched.value) { return }
 
         prefetched.value = true
@@ -395,12 +398,14 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
           // `custom` API cannot support fallthrough attributes as the slot
           // may render fragment or text root nodes (#14897, #19375)
           if (!props.custom) {
-            if (shouldPrefetch('interaction')) {
-              routerLinkProps.onPointerenter = prefetch.bind(null, undefined)
-              routerLinkProps.onFocus = prefetch.bind(null, undefined)
-            }
-            if (prefetched.value) {
-              routerLinkProps.class = props.prefetchedClass || options.prefetchedClass
+            if (import.meta.client) {
+              if (shouldPrefetch('interaction')) {
+                routerLinkProps.onPointerenter = prefetch.bind(null, undefined)
+                routerLinkProps.onFocus = prefetch.bind(null, undefined)
+              }
+              if (prefetched.value) {
+                routerLinkProps.class = props.prefetchedClass || options.prefetchedClass
+              }
             }
             routerLinkProps.rel = props.rel || undefined
           }


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 📚 Description

The current `<NuxtLink>` runs `shouldPrefetch('interaction')` on the server side to determine whether to bind the `onPointerenter` and `onFocus` events.

https://github.com/nuxt/nuxt/blob/07146ddf48284361c9ea2ae6fa07efdc53eda776/packages/nuxt/src/app/components/nuxt-link.ts#L395-L406

In this PR, I have attempted to address and improve this:

- Ensured that `shouldPrefetch('interaction')` is executed only on the client side.  
- Added `if (import.meta.server) { return }` to both the `shouldPrefetch` and `prefetch` functions, allowing the server side to tree-shake unused code.  

If there’s anything I’ve missed, please let me know. Thank you! 
