### PR TITLE
refactor(utils): optimize in-place array filtering ~70,000x faster

### DIFF
--- a/packages/kit/src/utils.ts
+++ b/packages/kit/src/utils.ts
@@ -13,7 +13,9 @@ export function filterInPlace<T> (array: T[], predicate: (item: T, index: number
   for (let i = array.length; i--; i >= 0) {
     if (!predicate(array[i]!, i, array)) {
       const last = --array.length
-      if (i < last) { array[i] = array[last]! }
+      if (i < last) {
+        array[i] = array[last]!
+      }
     }
   }
   return array

--- a/packages/kit/src/utils.ts
+++ b/packages/kit/src/utils.ts
@@ -4,17 +4,35 @@ export function toArray<T> (value: T | T[]): T[] {
 }
 
 /**
- * Filter out items from an array in place. This function mutates the array.
- * `predicate` get through the array from the end to the start for performance.
+ * Turbo-charged in-place array filtering. This function mutates the array.
+ * Optimized for both small and large arrays using different strategies:
+ * - For small arrays (<=16 items): Uses splice for better memory efficiency
+ * - For large arrays: Uses optimized swap-and-truncate strategy
  *
- * This function should be faster than `Array.prototype.filter` on large arrays.
+ * Processes array from end to start for maximum performance.
+ * Benchmarks show this is significantly faster than Array.prototype.filter
+ * and standard filterInPlace implementations.
  */
 export function filterInPlace<T> (array: T[], predicate: (item: T, index: number, arr: T[]) => unknown) {
-  for (let i = array.length; i--; i >= 0) {
-    if (!predicate(array[i]!, i, array)) {
-      array.splice(i, 1)
+  let i = array.length
+
+  if (i <= 16) {
+    while (i--) {
+      if (!predicate(array[i]!, i, array)) {
+        array.splice(i, 1)
+      }
+    }
+  } else {
+    while (i--) {
+      if (!predicate(array[i]!, i, array)) {
+        const last = --array.length
+        if (i < last) {
+          array[i] = array[last] as T
+        }
+      }
     }
   }
+
   return array
 }
 

--- a/packages/kit/src/utils.ts
+++ b/packages/kit/src/utils.ts
@@ -14,23 +14,12 @@ export function toArray<T> (value: T | T[]): T[] {
  * and standard filterInPlace implementations.
  */
 export function filterInPlace<T> (array: T[], predicate: (item: T, index: number, arr: T[]) => unknown) {
-  const len = array.length
-
-  if (len <= 16) {
-    for (let i = len; i--; i >= 0) {
-      if (!predicate(array[i]!, i, array)) {
-        array.splice(i, 1)
-      }
-    }
-  } else {
-    for (let i = len; i--; i >= 0) {
-      if (!predicate(array[i]!, i, array)) {
-        const last = --array.length
-        if (i < last) { array[i] = array[last]! }
-      }
+  for (let i = array.length; i--; i >= 0) {
+    if (!predicate(array[i]!, i, array)) {
+      const last = --array.length
+      if (i < last) { array[i] = array[last]! }
     }
   }
-
   return array
 }
 

--- a/packages/kit/src/utils.ts
+++ b/packages/kit/src/utils.ts
@@ -14,21 +14,19 @@ export function toArray<T> (value: T | T[]): T[] {
  * and standard filterInPlace implementations.
  */
 export function filterInPlace<T> (array: T[], predicate: (item: T, index: number, arr: T[]) => unknown) {
-  let i = array.length
+  const len = array.length
 
-  if (i <= 16) {
-    while (i--) {
+  if (len <= 16) {
+    for (let i = len; i--; i >= 0) {
       if (!predicate(array[i]!, i, array)) {
         array.splice(i, 1)
       }
     }
   } else {
-    while (i--) {
+    for (let i = len; i--; i >= 0) {
       if (!predicate(array[i]!, i, array)) {
         const last = --array.length
-        if (i < last) {
-          array[i] = array[last] as T
-        }
+        if (i < last) { array[i] = array[last]! }
       }
     }
   }

--- a/packages/kit/src/utils.ts
+++ b/packages/kit/src/utils.ts
@@ -4,14 +4,10 @@ export function toArray<T> (value: T | T[]): T[] {
 }
 
 /**
- * Turbo-charged in-place array filtering. This function mutates the array.
- * Optimized for both small and large arrays using different strategies:
- * - For small arrays (<=16 items): Uses splice for better memory efficiency
- * - For large arrays: Uses optimized swap-and-truncate strategy
+ * Filter out items from an array in place. This function mutates the array.
+ * `predicate` get through the array from the end to the start for performance.
  *
- * Processes array from end to start for maximum performance.
- * Benchmarks show this is significantly faster than Array.prototype.filter
- * and standard filterInPlace implementations.
+ * This function should be faster than `Array.prototype.filter` on large arrays.
  */
 export function filterInPlace<T> (array: T[], predicate: (item: T, index: number, arr: T[]) => unknown) {
   for (let i = array.length; i--; i >= 0) {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

I got excited about Antfu’s work, but it inspired a new algorithm idea for me. The more arrays increase, the faster the new algorithm becomes indirectly. This is actually about using 

This [pr](https://github.com/nuxt/nuxt/pull/30589)
x.filterInPlace(...) instead of x = x.filter(...) to avoid creating new arrays.


~~New ([microbenchmark](https://jsbenchmark.com/#eyJjYXNlcyI6W3siaWQiOiJXR01CMEJLVXgwbUJDYVc3NmFHSVciLCJjb2RlIjoibGV0IGEgPSBEQVRBXG5hID0gZmlsdGVyKGEsIGkgPT4gaSAlIDUwID09PSAwKVxuYSA9IGZpbHRlcihhLCBpID0-IGkgJSAxMCA9PT0gMClcbmEgPSBmaWx0ZXIoYSwgaSA9PiBpICUgMiA9PT0gMCkiLCJuYW1lIjoiZmlsdGVyIiwiZGVwZW5kZW5jaWVzIjpbXX0seyJpZCI6Ik9VSnozNU1QTkdhWVZ2eVo3S3A1UiIsImNvZGUiOiJsZXQgYSA9IERBVEFcbmEgPSBmaWx0ZXJJblBsYWNlKGEsIGkgPT4gaSAlIDUwID09PSAwKVxuYSA9IGZpbHRlckluUGxhY2UoYSwgaSA9PiBpICUgMTAgPT09IDApXG5hID0gZmlsdGVySW5QbGFjZShhLCBpID0-IGkgJSAyID09PSAwKSIsIm5hbWUiOiJmaWx0ZXJJblBsYWNlIiwiZGVwZW5kZW5jaWVzIjpbXX0seyJpZCI6InctMm8ybWt5VzBmUXZpdi1CTUdmbiIsImNvZGUiOiJsZXQgYSA9IERBVEFcbmEgPSB0dXJib0ZpbHRlckluUGxhY2UoYSwgaSA9PiBpICUgNTAgPT09IDApXG5hID0gdHVyYm9GaWx0ZXJJblBsYWNlKGEsIGkgPT4gaSAlIDEwID09PSAwKVxuYSA9IHR1cmJvRmlsdGVySW5QbGFjZShhLCBpID0-IGkgJSAyID09PSAwKSIsImRlcGVuZGVuY2llcyI6W10sIm5hbWUiOiJ0dXJib0ZpbHRlciJ9XSwiY29uZmlnIjp7Im5hbWUiOiJCYXNpYyBleGFtcGxlIiwicGFyYWxsZWwiOnRydWUsImdsb2JhbFRlc3RDb25maWciOnsiZGVwZW5kZW5jaWVzIjpbXX0sImRhdGFDb2RlIjoiZ2xvYmFsVGhpcy5maWx0ZXIgPSBmdW5jdGlvbiBmaWx0ZXIoZGF0YSwgcHJlZGljYXRlKSB7XG4gIHJldHVybiBkYXRhLmZpbHRlcihwcmVkaWNhdGUpXG59XG5cbmdsb2JhbFRoaXMuZmlsdGVySW5QbGFjZSA9IGZ1bmN0aW9uIGZpbHRlckluUGxhY2UoZGF0YSwgcHJlZGljYXRlKSB7XG4gIGZvciAobGV0IGkgPSBkYXRhLmxlbmd0aDsgaS0tOyBpPj0wKSB7XG4gICAgaWYgKCFwcmVkaWNhdGUoZGF0YVtpXSwgaSwgZGF0YSkpXG4gICAgICBkYXRhLnNwbGljZShpLCAxKVxuICB9XG4gIHJldHVybiBkYXRhXG59XG5cbmdsb2JhbFRoaXMudHVyYm9GaWx0ZXJJblBsYWNlID0gZnVuY3Rpb24gdHVyYm9GaWx0ZXIoZGF0YSwgcHJlZGljYXRlKSB7XG4gIGNvbnN0IGxlbiA9IGRhdGEubGVuZ3RoO1xuICBcbiAgaWYgKGxlbiA8PSAxNikge1xuICAgIGZvciAobGV0IGkgPSBsZW47IGktLTsgaSA-PSAwKSB7XG4gICAgICBpZiAoIXByZWRpY2F0ZShkYXRhW2ldLCBpLCBkYXRhKSkge1xuICAgICAgICBkYXRhLnNwbGljZShpLCAxKTtcbiAgICAgIH1cbiAgICB9XG4gIH0gZWxzZSB7XG4gICAgZm9yIChsZXQgaSA9IGxlbjsgaS0tOyBpID49IDApIHtcbiAgICAgIGlmICghcHJlZGljYXRlKGRhdGFbaV0sIGksIGRhdGEpKSB7XG4gICAgICAgIGNvbnN0IGxhc3QgPSAtLWRhdGEubGVuZ3RoO1xuICAgICAgICBpZiAoaSA8IGxhc3QpIGRhdGFbaV0gPSBkYXRhW2xhc3RdO1xuICAgICAgfVxuICAgIH1cbiAgfVxuICBcbiAgcmV0dXJuIGRhdGE7XG59XG5cbnJldHVybiBbLi4uQXJyYXkoMTAwMCkua2V5cygpLC4uLkFycmF5KDEwMDApLmtleXMoKSwuLi5BcnJheSgxMDAwKS5rZXlzKCldIn19))~~

<details><summary>Details</summary>
<p>

[...Array(1).keys(),...Array(1).keys(),...Array(1).keys()]

```ts
filter (1x)
Ops/s: 22,426,363
Average run time: 0.000045 ms

filterInPlace (2.53x faster)
Ops/s: 56,845,507
Average run time: 0.000018 ms

turboFilter(NEW) (2.52x faster)
Ops/s: 56,621,754 
Average run time: 0.000018 ms
```  

[...Array(1000).keys(),...Array(1000).keys(),...Array(1000).keys()]

```ts
filter
Ops/s: 199,824 (1x)
Average run time: 0.0050 ms

filterInPlace (16.4x faster)
Ops/s: 3,280,728
Average run time: 0.00030 ms

turboFilter(NEW) (442.8x faster)
Ops/s: 88,473,526
Average run time: 0.000011 ms

```

[...Array(50000).keys(),...Array(50000).keys(),...Array(50000).keys()]

```ts
filter (1x)
Ops/s: 784
Average run time: 1.28 ms

filterInPlace  (100x faster)
Ops/s: 78,353
Average run time: 0.013 ms

turboFilter(NEW) (650x faster)
Ops/s: 53,821,993
Average run time: 0.000019 ms
``` 


</p>
</details> 

New Updated 

[New microbenchmark](https://jsbenchmark.com/#eyJjYXNlcyI6W3siaWQiOiJXR01CMEJLVXgwbUJDYVc3NmFHSVciLCJjb2RlIjoibGV0IGEgPSBEQVRBXG5hID0gZmlsdGVyKGEsIGkgPT4gaSAlIDUwID09PSAwKVxuYSA9IGZpbHRlcihhLCBpID0-IGkgJSAxMCA9PT0gMClcbmEgPSBmaWx0ZXIoYSwgaSA9PiBpICUgMiA9PT0gMCkiLCJuYW1lIjoiZmlsdGVyIiwiZGVwZW5kZW5jaWVzIjpbXX0seyJpZCI6Ik9VSnozNU1QTkdhWVZ2eVo3S3A1UiIsImNvZGUiOiJsZXQgYSA9IERBVEFcbmEgPSBmaWx0ZXJJblBsYWNlKGEsIGkgPT4gaSAlIDUwID09PSAwKVxuYSA9IGZpbHRlckluUGxhY2UoYSwgaSA9PiBpICUgMTAgPT09IDApXG5hID0gZmlsdGVySW5QbGFjZShhLCBpID0-IGkgJSAyID09PSAwKSIsIm5hbWUiOiJmaWx0ZXJJblBsYWNlIiwiZGVwZW5kZW5jaWVzIjpbXX0seyJpZCI6InctMm8ybWt5VzBmUXZpdi1CTUdmbiIsImNvZGUiOiJsZXQgYSA9IERBVEFcbmEgPSB0dXJib0ZpbHRlckluUGxhY2UoYSwgaSA9PiBpICUgNTAgPT09IDApXG5hID0gdHVyYm9GaWx0ZXJJblBsYWNlKGEsIGkgPT4gaSAlIDEwID09PSAwKVxuYSA9IHR1cmJvRmlsdGVySW5QbGFjZShhLCBpID0-IGkgJSAyID09PSAwKSIsImRlcGVuZGVuY2llcyI6W10sIm5hbWUiOiJ0dXJib0ZpbHRlciJ9XSwiY29uZmlnIjp7Im5hbWUiOiJCYXNpYyBleGFtcGxlIiwicGFyYWxsZWwiOmZhbHNlLCJnbG9iYWxUZXN0Q29uZmlnIjp7ImRlcGVuZGVuY2llcyI6W119LCJkYXRhQ29kZSI6Imdsb2JhbFRoaXMuZmlsdGVyID0gZnVuY3Rpb24gZmlsdGVyKGRhdGEsIHByZWRpY2F0ZSkge1xuICByZXR1cm4gZGF0YS5maWx0ZXIocHJlZGljYXRlKVxufVxuXG5nbG9iYWxUaGlzLmZpbHRlckluUGxhY2UgPSBmdW5jdGlvbiBmaWx0ZXJJblBsYWNlKGRhdGEsIHByZWRpY2F0ZSkge1xuICBmb3IgKGxldCBpID0gZGF0YS5sZW5ndGg7IGktLTsgaT49MCkge1xuICAgIGlmICghcHJlZGljYXRlKGRhdGFbaV0sIGksIGRhdGEpKVxuICAgICAgZGF0YS5zcGxpY2UoaSwgMSlcbiAgfVxuICByZXR1cm4gZGF0YVxufVxuXG5nbG9iYWxUaGlzLnR1cmJvRmlsdGVySW5QbGFjZSA9IGZ1bmN0aW9uIHR1cmJvRmlsdGVyKGRhdGEsIHByZWRpY2F0ZSkge1xuICBmb3IgKGxldCBpID0gZGF0YS5sZW5ndGg7IGktLTsgaSA-PSAwKSB7XG4gICAgaWYgKCFwcmVkaWNhdGUoZGF0YVtpXSwgaSwgZGF0YSkpIHtcbiAgICAgIGNvbnN0IGxhc3QgPSAtLWRhdGEubGVuZ3RoO1xuICAgICAgaWYgKGkgPCBsYXN0KSBkYXRhW2ldID0gZGF0YVtsYXN0XTtcbiAgICB9XG4gIH1cbiAgcmV0dXJuIGRhdGE7XG59XG5yZXR1cm4gWy4uLkFycmF5KDUwMDAwKS5rZXlzKCksLi4uQXJyYXkoNTAwMDApLmtleXMoKSwuLi5BcnJheSg1MDAwMCkua2V5cygpXSJ9fQ)

```ts
filter
Ops/s: 782 (1x)
Average run time: 1.28 ms

filterInPlace
Ops/s: 49,105 (62.8x faster)
Average run time: 0.020 ms

turboFilter
Ops/s: 54,732,335 (70,000x faster)
Average run time: 0.000018 ms
````


<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
