### PR TITLE
chore(security): remove pull_request_target

### DIFF
--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,7 +1,7 @@
 name: chore
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
     branches:

--- a/.github/workflows/semantic-pull-requests.yml
+++ b/.github/workflows/semantic-pull-requests.yml
@@ -1,7 +1,7 @@
 name: chore
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Remove pull_request_target workflow triggers.

Combining `pull_request_target` workflow triggers with an explicit checkout of an untrusted PR is dangerous and could lead to repository compromise.

See https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/

