### PR TITLE
docs: add more context about `navigation` mode in `callOnce` composable

### DIFF
--- a/docs/3.api/3.utils/call-once.md
+++ b/docs/3.api/3.utils/call-once.md
@@ -28,7 +28,7 @@ This is useful for code that should be executed only once, such as logging an ev
 
 ## Usage
 
-Running code only once. For example, if the code runs on the server it won't run again on the client. this demonstrates the default `render` mode behaviour.
+Running code only once. For example, if the code runs on the server it won't run again on the client. This demonstrates the default `render` mode behaviour.
 
 ```vue [app.vue]
 <script setup lang="ts">
@@ -41,7 +41,7 @@ await callOnce(async () => {
 </script>
 ```
 
-Sometimes you do want code to run on every navigation - just avoid the initial server/client double load. For this, there's a new mode: `navigation` option that will run the code only once per navigation.
+To run on every navigation while avoiding the initial server/client double load, use the `navigation` mode:
 
 ```vue [app.vue]
 <script setup lang="ts">

--- a/docs/3.api/3.utils/call-once.md
+++ b/docs/3.api/3.utils/call-once.md
@@ -28,7 +28,7 @@ This is useful for code that should be executed only once, such as logging an ev
 
 ## Usage
 
-Running code only once. For example, if the code runs on the server it won't run again on the client.
+Running code only once. For example, if the code runs on the server it won't run again on the client. this demonstrates the default `render` mode behaviour.
 
 ```vue [app.vue]
 <script setup lang="ts">
@@ -41,7 +41,7 @@ await callOnce(async () => {
 </script>
 ```
 
-Sometimes you do want code to run on every navigation - just avoid the initial server/client double load. For this, there's a new mode: 'navigation' option that will run the code only once per navigation.
+Sometimes you do want code to run on every navigation - just avoid the initial server/client double load. For this, there's a new mode: `navigation` option that will run the code only once per navigation.
 
 ```vue [app.vue]
 <script setup lang="ts">
@@ -73,10 +73,19 @@ Note that `callOnce` doesn't return anything. You should use [`useAsyncData`](/d
 ```ts
 callOnce (key?: string, fn?: (() => any | Promise<any>), options?: CallOnceOptions): Promise<void>
 callOnce(fn?: (() => any | Promise<any>), options?: CallOnceOptions): Promise<void>
+
+type CallOnceOptions = {
+  /**
+   * Execution mode for the callOnce function
+   * @default 'render'
+   */
+  mode?: 'navigation' | 'render'
+}
 ```
 
 ## Parameters
 
 - `key`: A unique key ensuring that the code is run once. If you do not provide a key, then a key that is unique to the file and line number of the instance of `callOnce` will be generated for you.
-- `fn`: The function to run once. This function can also return a `Promise` and a value.
-- `options`: Setup the mode, either to re-execute on navigation (`navigation`) or just once for lifetime of the app (`render`)
+- `options`: Setup the mode, either to re-execute on navigation (`navigation`) or just once for the lifetime of the app (`render`). Defaults to `render`.
+  - `render`: Executes once during initial render (either SSR or CSR) - Default mode
+  - `navigation`: Executes once during initial render and once per subsequent client-side navigation

--- a/docs/3.api/3.utils/call-once.md
+++ b/docs/3.api/3.utils/call-once.md
@@ -86,6 +86,7 @@ type CallOnceOptions = {
 ## Parameters
 
 - `key`: A unique key ensuring that the code is run once. If you do not provide a key, then a key that is unique to the file and line number of the instance of `callOnce` will be generated for you.
+- `fn`: The function to run once. This function can also return a `Promise` and a value.
 - `options`: Setup the mode, either to re-execute on navigation (`navigation`) or just once for the lifetime of the app (`render`). Defaults to `render`.
   - `render`: Executes once during initial render (either SSR or CSR) - Default mode
   - `navigation`: Executes once during initial render and once per subsequent client-side navigation

--- a/docs/3.api/3.utils/call-once.md
+++ b/docs/3.api/3.utils/call-once.md
@@ -14,6 +14,10 @@ links:
 This utility is available since [Nuxt v3.9](/blog/v3-9).
 ::
 
+::important
+`navigation` mode is available since [Nuxt v3.15](/blog/v3-15).
+::
+
 ## Purpose
 
 The `callOnce` function is designed to execute a given function or block of code only once during:
@@ -24,6 +28,8 @@ This is useful for code that should be executed only once, such as logging an ev
 
 ## Usage
 
+Running code only once. For example, if the code runs on the server it won't run again on the client.
+
 ```vue [app.vue]
 <script setup lang="ts">
 const websiteConfig = useState('config')
@@ -32,6 +38,19 @@ await callOnce(async () => {
   console.log('This will only be logged once')
   websiteConfig.value = await $fetch('https://my-cms.com/api/website-config')
 })
+</script>
+```
+
+Sometimes you do want code to run on every navigation - just avoid the initial server/client double load. For this, there's a new mode: 'navigation' option that will run the code only once per navigation.
+
+```vue [app.vue]
+<script setup lang="ts">
+const websiteConfig = useState('config')
+
+await callOnce(async () => {
+  console.log('This will only be logged once and then on every client side navigation')
+  websiteConfig.value = await $fetch('https://my-cms.com/api/website-config')
+}, { mode: 'navigation' })
 </script>
 ```
 
@@ -52,9 +71,11 @@ Note that `callOnce` doesn't return anything. You should use [`useAsyncData`](/d
 ## Type
 
 ```ts
-callOnce(fn?: () => any | Promise<any>): Promise<void>
-callOnce(key: string, fn?: () => any | Promise<any>): Promise<void>
+callOnce (key?: string, fn?: (() => any | Promise<any>), options?: CallOnceOptions): Promise<void>
+callOnce(fn?: (() => any | Promise<any>), options?: CallOnceOptions): Promise<void>
 ```
+## Parameters
 
-- `key`: A unique key ensuring that the code is run once. If you do not provide a key, then a key that is unique to the file and line number of the instance of `callOnce` will be generated for you.
-- `fn`: The function to run once. This function can also return a `Promise` and a value.
+* `key`: A unique key ensuring that the code is run once. If you do not provide a key, then a key that is unique to the file and line number of the instance of `callOnce` will be generated for you.
+* `fn`: The function to run once. This function can also return a `Promise` and a value.
+* `options`: Setup the mode, either to re-execute on navigation (`navigation`) or just once for lifetime of the app (`render`)

--- a/docs/3.api/3.utils/call-once.md
+++ b/docs/3.api/3.utils/call-once.md
@@ -74,8 +74,9 @@ Note that `callOnce` doesn't return anything. You should use [`useAsyncData`](/d
 callOnce (key?: string, fn?: (() => any | Promise<any>), options?: CallOnceOptions): Promise<void>
 callOnce(fn?: (() => any | Promise<any>), options?: CallOnceOptions): Promise<void>
 ```
+
 ## Parameters
 
-* `key`: A unique key ensuring that the code is run once. If you do not provide a key, then a key that is unique to the file and line number of the instance of `callOnce` will be generated for you.
-* `fn`: The function to run once. This function can also return a `Promise` and a value.
-* `options`: Setup the mode, either to re-execute on navigation (`navigation`) or just once for lifetime of the app (`render`)
+- `key`: A unique key ensuring that the code is run once. If you do not provide a key, then a key that is unique to the file and line number of the instance of `callOnce` will be generated for you.
+- `fn`: The function to run once. This function can also return a `Promise` and a value.
+- `options`: Setup the mode, either to re-execute on navigation (`navigation`) or just once for lifetime of the app (`render`)

--- a/docs/3.api/3.utils/call-once.md
+++ b/docs/3.api/3.utils/call-once.md
@@ -14,10 +14,6 @@ links:
 This utility is available since [Nuxt v3.9](/blog/v3-9).
 ::
 
-::important
-`navigation` mode is available since [Nuxt v3.15](/blog/v3-15).
-::
-
 ## Purpose
 
 The `callOnce` function is designed to execute a given function or block of code only once during:
@@ -53,6 +49,10 @@ await callOnce(async () => {
 }, { mode: 'navigation' })
 </script>
 ```
+
+::important
+`navigation` mode is available since [Nuxt v3.15](/blog/v3-15).
+::
 
 ::tip{to="/docs/getting-started/state-management#usage-with-pinia"}
 `callOnce` is useful in combination with the [Pinia module](/modules/pinia) to call store actions.

--- a/docs/3.api/3.utils/call-once.md
+++ b/docs/3.api/3.utils/call-once.md
@@ -28,7 +28,7 @@ This is useful for code that should be executed only once, such as logging an ev
 
 ## Usage
 
-Running code only once. For example, if the code runs on the server it won't run again on the client. This demonstrates the default `render` mode behaviour.
+The default mode of `callOnce` is to run code only once. For example, if the code runs on the server it won't run again on the client. It also won't run again if you `callOnce` more than once on the client, for example by navigating back to this page.
 
 ```vue [app.vue]
 <script setup lang="ts">
@@ -41,7 +41,7 @@ await callOnce(async () => {
 </script>
 ```
 
-To run on every navigation while avoiding the initial server/client double load, use the `navigation` mode:
+It is also possible to run on every navigation while still avoiding the initial server/client double load. For this, it is possible to use the `navigation` mode:
 
 ```vue [app.vue]
 <script setup lang="ts">


### PR DESCRIPTION
### 📚 Description

With the release of Nuxt `3.15`, the documentation regarding the `callOnce` composable became outdated. This pull request aims to update the documentation to reflect the latest changes - mainly the new 'navigation' mode.