### PR TITLE
fix(vite): override previous `#app-manifest` alias

### DIFF
--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -110,12 +110,12 @@ export async function buildClient (ctx: ViteBuildContext) {
     },
     resolve: {
       alias: {
-        // work around vite optimizer bug
-        '#app-manifest': 'unenv/runtime/mock/empty',
         // user aliases
         ...nodeCompat.alias,
         ...ctx.config.resolve?.alias,
         'nitro/runtime': join(ctx.nuxt.options.buildDir, 'nitro.client.mjs'),
+        // work around vite optimizer bug
+        '#app-manifest': 'unenv/runtime/mock/empty',
       },
       dedupe: [
         'vue',


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/30461

### 📚 Description

the last fix was incomplete - we reordered to allow user override but this ended up negating the fix