### PR TITLE
fix(nuxt): do not warn about `[[` optional dynamic params

### DIFF
--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -425,7 +425,9 @@ function parseSegment (segment: string, absolutePath: string) {
         } else if (c && PARAM_CHAR_RE.test(c)) {
           buffer += c
         } else if (state === SegmentParserState.dynamic || state === SegmentParserState.optional) {
-          logger.warn(`'\`${c}\`' is not allowed in a dynamic route parameter and has been ignored. Consider renaming \`${absolutePath}\`.`)
+          if (c !== '[' && c !== ']') {
+            logger.warn(`'\`${c}\`' is not allowed in a dynamic route parameter and has been ignored. Consider renaming \`${absolutePath}\`.`)
+          }
         }
         break
     }


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/30616

### 📚 Description

this exempts `[` and `]` from the warning about invalid characters