### PR TITLE
perf(kit,nuxt): don't resolve paths from local layers/modules

### DIFF
--- a/packages/kit/src/module/install.ts
+++ b/packages/kit/src/module/install.ts
@@ -38,7 +38,7 @@ export async function installModule<
     const parsed = parseNodeModulePath(modulePath)
     const moduleRoot = parsed.dir ? parsed.dir + parsed.name : modulePath
     nuxt.options.build.transpile.push(normalizeModuleTranspilePath(moduleRoot))
-    const directory = parsed.dir ? moduleRoot : getDirectory(modulePath)
+    const directory = (parsed.dir ? moduleRoot : getDirectory(modulePath)).replace(/\/?$/, '/')
     if (directory !== moduleToInstall && !localLayerModuleDirs.some(dir => directory.startsWith(dir))) {
       nuxt.options.modulesDir.push(resolve(directory, 'node_modules'))
     }

--- a/packages/kit/src/module/install.ts
+++ b/packages/kit/src/module/install.ts
@@ -19,11 +19,11 @@ export async function installModule<
 > (moduleToInstall: T, inlineOptions?: [Config] extends [never] ? any : Config[1], nuxt: Nuxt = useNuxt()) {
   const { nuxtModule, buildTimeModuleMeta, resolvedModulePath } = await loadNuxtModuleInstance(moduleToInstall, nuxt)
 
-  const localLayerModuleDirs = new Set<string>()
+  const localLayerModuleDirs: string[] = []
   for (const l of nuxt.options._layers) {
     const srcDir = l.config.srcDir || l.cwd
     if (!NODE_MODULES_RE.test(srcDir)) {
-      localLayerModuleDirs.add(resolve(srcDir, l.config?.dir?.modules || 'modules'))
+      localLayerModuleDirs.push(resolve(srcDir, l.config?.dir?.modules || 'modules').replace(/\/?$/, '/'))
     }
   }
 
@@ -39,7 +39,7 @@ export async function installModule<
     const moduleRoot = parsed.dir ? parsed.dir + parsed.name : modulePath
     nuxt.options.build.transpile.push(normalizeModuleTranspilePath(moduleRoot))
     const directory = parsed.dir ? moduleRoot : getDirectory(modulePath)
-    if (directory !== moduleToInstall && !localLayerModuleDirs.has(directory)) {
+    if (directory !== moduleToInstall && !localLayerModuleDirs.some(dir => directory.startsWith(dir))) {
       nuxt.options.modulesDir.push(resolve(directory, 'node_modules'))
     }
   }

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -574,6 +574,7 @@ async function initNuxt (nuxt: Nuxt) {
   nuxt._ignore.add(resolveIgnorePatterns())
 
   await nuxt.callHook('modules:done')
+  console.log(nuxt.options.modulesDir, nuxt.options.modulesDir.length)
 
   // Add <NuxtIsland>
   if (nuxt.options.experimental.componentIslands) {

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -404,8 +404,11 @@ async function initNuxt (nuxt: Nuxt) {
     ...nuxt.options._layers.filter(i => i.cwd.includes('node_modules')).map(i => i.cwd as string),
   )
 
-  // Ensure we can resolve dependencies within layers
-  nuxt.options.modulesDir.push(...nuxt.options._layers.map(l => resolve(l.cwd, 'node_modules')))
+  // Ensure we can resolve dependencies within layers - filtering out local `~/layers` directories
+  const locallyScannedLayersDirs = nuxt.options._layers.map(l => resolve(l.cwd, 'layers').replace(/\/?$/, '/'))
+  nuxt.options.modulesDir.push(...nuxt.options._layers
+    .filter(l => l.cwd !== nuxt.options.rootDir && locallyScannedLayersDirs.every(dir => !l.cwd.startsWith(dir)))
+    .map(l => resolve(l.cwd, 'node_modules')))
 
   // Init user modules
   await nuxt.callHook('modules:before')


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

All layers and modules have a `node_modules/` directory appended to `nuxt.options.modulesDir`. This increases the resolution time for any path/module. But we don't expect local layers (scanned from `~/layers`) or local modules (scanned from `~/modules`) to have their own `node_modules/` directory and we can safely avoid doing so.

this reduces paths to resolve from from 14 -> 6 in the basic fixture