### PR TITLE
perf(nuxt): reduce number of `mkdirSync` calls

### DIFF
--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -57,6 +57,7 @@ export async function generateApp (nuxt: Nuxt, app: NuxtApp, options: { filter?:
   const templateContext = { nuxt, app }
 
   const writes: Array<() => void> = []
+  const dirs = new Set<string>()
   const changedTemplates: Array<ResolvedNuxtTemplate<any>> = []
   const FORWARD_SLASH_RE = /\//g
   async function processTemplate (template: ResolvedNuxtTemplate) {
@@ -93,7 +94,7 @@ export async function generateApp (nuxt: Nuxt, app: NuxtApp, options: { filter?:
 
     if (template.modified && template.write) {
       writes.push(() => {
-        mkdirSync(dirname(fullPath), { recursive: true })
+        dirs.add(dirname(fullPath))
         writeFileSync(fullPath, contents, 'utf8')
       })
     }
@@ -104,7 +105,12 @@ export async function generateApp (nuxt: Nuxt, app: NuxtApp, options: { filter?:
 
   // Write template files in single synchronous step to avoid (possible) additional
   // runtime overhead of cascading HMRs from vite/webpack
-  for (const write of writes) { write() }
+  for (const dir of dirs) {
+    mkdirSync(dirname(dir), { recursive: true })
+  }
+  for (const write of writes) {
+    write()
+  }
 
   if (changedTemplates.length) {
     await nuxt.callHook('app:templatesGenerated', app, changedTemplates, options)

--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -106,7 +106,7 @@ export async function generateApp (nuxt: Nuxt, app: NuxtApp, options: { filter?:
   // Write template files in single synchronous step to avoid (possible) additional
   // runtime overhead of cascading HMRs from vite/webpack
   for (const dir of dirs) {
-    mkdirSync(dirname(dir), { recursive: true })
+    mkdirSync(dir, { recursive: true })
   }
   for (const write of writes) {
     write()

--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -94,9 +94,7 @@ export async function generateApp (nuxt: Nuxt, app: NuxtApp, options: { filter?:
 
     if (template.modified && template.write) {
       dirs.add(dirname(fullPath))
-      writes.push(() => {
-        writeFileSync(fullPath, contents, 'utf8')
-      })
+      writes.push(() => writeFileSync(fullPath, contents, 'utf8'))
     }
   }
 

--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -93,8 +93,8 @@ export async function generateApp (nuxt: Nuxt, app: NuxtApp, options: { filter?:
     }
 
     if (template.modified && template.write) {
+      dirs.add(dirname(fullPath))
       writes.push(() => {
-        dirs.add(dirname(fullPath))
         writeFileSync(fullPath, contents, 'utf8')
       })
     }

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -213,6 +213,9 @@ export default defineNuxtConfig({
   },
   telemetry: false, // for testing telemetry types - it is auto-disabled in tests
   hooks: {
+    'build:done' () {
+      process.exit()
+    },
     'webpack:config' (configs) {
       // in order to test bigint serialization we need to set target to a more modern one
       for (const config of configs) {

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -213,9 +213,6 @@ export default defineNuxtConfig({
   },
   telemetry: false, // for testing telemetry types - it is auto-disabled in tests
   hooks: {
-    'build:done' () {
-      process.exit()
-    },
     'webpack:config' (configs) {
       // in order to test bigint serialization we need to set target to a more modern one
       for (const config of configs) {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

currently we call `mkdirSync` for every template we write to disk, but of course there are only a few real directories created, with lots of files inside them