### PR TITLE
fix(nuxt): wrap slot with `h()` in ClientOnly

### DIFF
--- a/packages/nuxt/src/app/components/client-only.ts
+++ b/packages/nuxt/src/app/components/client-only.ts
@@ -14,7 +14,7 @@ export default defineComponent({
   inheritAttrs: false,
 
   props: ['fallback', 'placeholder', 'placeholderTag', 'fallbackTag'],
-  setup (_, { slots, attrs }) {
+  setup (props, { slots, attrs }) {
     const mounted = ref(false)
     onMounted(() => { mounted.value = true })
     // Bail out of checking for pages/layouts as they might be included under `<ClientOnly>` 🤷‍♂️
@@ -24,10 +24,10 @@ export default defineComponent({
       nuxtApp._isNuxtLayoutUsed = true
     }
     provide(clientOnlySymbol, true)
-    return (props: any) => {
+    return () => {
       if (mounted.value) { return slots.default?.() }
       const slot = slots.fallback || slots.placeholder
-      if (slot) { return h(slot()) }
+      if (slot) { return h(slot) }
       const fallbackStr = props.fallback || props.placeholder || ''
       const fallbackTag = props.fallbackTag || props.placeholderTag || 'span'
       return createElementBlock(fallbackTag, attrs, fallbackStr)

--- a/packages/nuxt/src/app/components/client-only.ts
+++ b/packages/nuxt/src/app/components/client-only.ts
@@ -27,7 +27,7 @@ export default defineComponent({
     return (props: any) => {
       if (mounted.value) { return slots.default?.() }
       const slot = slots.fallback || slots.placeholder
-      if (slot) { return slot() }
+      if (slot) { return h(slot()) }
       const fallbackStr = props.fallback || props.placeholder || ''
       const fallbackTag = props.fallbackTag || props.placeholderTag || 'span'
       return createElementBlock(fallbackTag, attrs, fallbackStr)


### PR DESCRIPTION
### 🔗 Linked issue

fix https://github.com/nuxt/nuxt/issues/30638
fix https://github.com/nuxt/nuxt/issues/30243
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Hye :wave:

We forgot to wrap the slot with `h()` in `ClientOnly`

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
