### PR TITLE
fix(schema): allow overriding `dev`/`test` environment value

### DIFF
--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -247,12 +247,16 @@ export default defineUntypedSchema({
    *
    * Normally, you should not need to set this.
    */
-  dev: Boolean(isDevelopment),
+  dev: {
+    $resolve: val => val ?? Boolean(isDevelopment),
+  },
 
   /**
    * Whether your app is being unit tested.
    */
-  test: Boolean(isTest),
+  test: {
+    $resolve: val => val ?? Boolean(isTest),
+  },
 
   /**
    * Set to `true` to enable debug mode.


### PR DESCRIPTION
resolves https://github.com/nuxt/nuxt/issues/30637

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

these values end up getting hard-coded when imported, which means it makes a difference whether `@nuxt/schema` is imported before/after overriding `NODE_ENV`

this is a hotfix but I'm looking at refactoring how we load default values in `@nuxt/schema` which should resolve this more fully.