### PR TITLE
perf(kit): run components compat check synchronously

### DIFF
--- a/packages/kit/src/compatibility.ts
+++ b/packages/kit/src/compatibility.ts
@@ -14,6 +14,11 @@ const builderMap = {
   '@nuxt/webpack-builder': 'webpack',
 }
 
+export function checkNuxtVersion (version: string, nuxt: Nuxt = useNuxt()) {
+  const nuxtVersion = getNuxtVersion(nuxt)
+  return satisfies(normalizeSemanticVersion(nuxtVersion), version, { includePrerelease: true })
+}
+
 /**
  * Check version constraints and return incompatibility issues as an array
  */
@@ -23,7 +28,7 @@ export async function checkNuxtCompatibility (constraints: NuxtCompatibility, nu
   // Nuxt version check
   if (constraints.nuxt) {
     const nuxtVersion = getNuxtVersion(nuxt)
-    if (!satisfies(normalizeSemanticVersion(nuxtVersion), constraints.nuxt, { includePrerelease: true })) {
+    if (!checkNuxtVersion(constraints.nuxt, nuxt)) {
       issues.push({
         name: 'nuxt',
         message: `Nuxt version \`${constraints.nuxt}\` is required but currently using \`${nuxtVersion}\``,

--- a/packages/kit/src/components.ts
+++ b/packages/kit/src/components.ts
@@ -1,16 +1,18 @@
 import { kebabCase, pascalCase } from 'scule'
 import type { Component, ComponentsDir } from '@nuxt/schema'
 import { useNuxt } from './context'
-import { assertNuxtCompatibility } from './compatibility'
+import { checkNuxtVersion } from './compatibility'
 import { logger } from './logger'
 import { MODE_RE } from './utils'
 
 /**
  * Register a directory to be scanned for components and imported only when used.
  */
-export async function addComponentsDir (dir: ComponentsDir, opts: { prepend?: boolean } = {}) {
+export function addComponentsDir (dir: ComponentsDir, opts: { prepend?: boolean } = {}) {
   const nuxt = useNuxt()
-  await assertNuxtCompatibility({ nuxt: '>=2.13' }, nuxt)
+  if (!checkNuxtVersion('>=2.13', nuxt)) {
+    throw new Error(`\`addComponentsDir\` requires Nuxt 2.13 or higher.`)
+  }
   nuxt.options.components ||= []
   dir.priority ||= 0
   nuxt.hook('components:dirs', (dirs) => { dirs[opts.prepend ? 'unshift' : 'push'](dir) })
@@ -23,9 +25,12 @@ export type AddComponentOptions = { name: string, filePath: string } & Partial<E
 /**
  * Register a component by its name and filePath.
  */
-export async function addComponent (opts: AddComponentOptions) {
+export function addComponent (opts: AddComponentOptions) {
   const nuxt = useNuxt()
-  await assertNuxtCompatibility({ nuxt: '>=2.13' }, nuxt)
+  if (!checkNuxtVersion('>=2.13', nuxt)) {
+    throw new Error(`\`addComponent\` requires Nuxt 2.13 or higher.`)
+  }
+
   nuxt.options.components ||= []
 
   if (!opts.mode) {

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -127,7 +127,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(pagesRootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"302k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"303k"`)
 
     const modules = await analyzeSizes(['node_modules/**/*'], serverDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"1398k"`)


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

currently `addComponent` and `addComponentsDir` are async functions that check nuxt version and also call an async hook (`kit:compatibility`). None of this is required. They don't require any constraint extensions - which is only really required for custom builder or additional keys added - and they are unique in the kit composables in being async. Not to mention there's the possibility of race conditions.

This PR adds an internal synchronous check for asserting nuxt version compatibility - and we can further drop this check in Kit v4 as we've already dropped support for Nuxt v2 there.