### PR TITLE
chore: provide version in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,5 +137,5 @@
     "webpack": "5.97.1"
   },
   "packageManager": "pnpm@9.15.4",
-  "version": ""
+  "version": "3.15.2"
 }


### PR DESCRIPTION
Here in the package.json file, version is empty. That is why I thought we can give the current version of Nuxt.