### PR TITLE
fix(vite): revert externality

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -41,6 +41,7 @@
     "defu": "^6.1.4",
     "esbuild": "^0.24.2",
     "escape-string-regexp": "^5.0.0",
+    "externality": "^1.0.2",
     "get-port-please": "^3.1.2",
     "h3": "npm:h3-nightly@1.14.0-20250122-114730-3f9e703",
     "jiti": "^2.4.2",

--- a/packages/vite/src/utils/external.ts
+++ b/packages/vite/src/utils/external.ts
@@ -1,0 +1,35 @@
+import type { ExternalsOptions } from 'externality'
+import { ExternalsDefaults, isExternal } from 'externality'
+import type { ViteDevServer } from 'vite'
+import escapeStringRegexp from 'escape-string-regexp'
+import { withTrailingSlash } from 'ufo'
+import type { Nuxt } from 'nuxt/schema'
+import { resolve } from 'pathe'
+import { toArray } from '.'
+
+export function createIsExternal (viteServer: ViteDevServer, nuxt: Nuxt) {
+  const externalOpts: ExternalsOptions = {
+    inline: [
+      /virtual:/,
+      /\.ts$/,
+      ...ExternalsDefaults.inline || [],
+      ...(
+        viteServer.config.ssr.noExternal && viteServer.config.ssr.noExternal !== true
+          ? toArray(viteServer.config.ssr.noExternal)
+          : []
+      ),
+    ],
+    external: [
+      '#shared',
+      new RegExp('^' + escapeStringRegexp(withTrailingSlash(resolve(nuxt.options.rootDir, nuxt.options.dir.shared)))),
+      ...(viteServer.config.ssr.external as string[]) || [],
+      /node_modules/,
+    ],
+    resolve: {
+      modules: nuxt.options.modulesDir,
+      type: 'module',
+      extensions: ['.ts', '.js', '.json', '.vue', '.mjs', '.jsx', '.tsx', '.wasm'],
+    },
+  }
+  return (id: string) => isExternal(id, nuxt.options.rootDir, externalOpts)
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -870,6 +870,9 @@ importers:
       escape-string-regexp:
         specifier: ^5.0.0
         version: 5.0.0
+      externality:
+        specifier: ^1.0.2
+        version: 1.0.2
       get-port-please:
         specifier: ^3.1.2
         version: 3.1.2
@@ -4626,6 +4629,9 @@ packages:
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  externality@1.0.2:
+    resolution: {integrity: sha512-LyExtJWKxtgVzmgtEHyQtLFpw1KFhQphF9nTG8TpAIVkiI/xQ3FJh75tRFLYl4hkn7BNIIdLJInuDAavX35pMw==}
 
   fake-indexeddb@6.0.0:
     resolution: {integrity: sha512-YEboHE5VfopUclOck7LncgIqskAqnv4q0EWbYCaxKKjAvO93c+TJIaBuGy8CBFdbg9nKdpN3AuPRwVBJ4k7NrQ==}
@@ -12490,6 +12496,13 @@ snapshots:
   expect-type@1.1.0: {}
 
   extend@3.0.2: {}
+
+  externality@1.0.2:
+    dependencies:
+      enhanced-resolve: 5.18.0
+      mlly: 1.7.4
+      pathe: 1.1.2
+      ufo: 1.5.4
 
   fake-indexeddb@6.0.0: {}
 


### PR DESCRIPTION
### 🔗 Linked issue

This fixes a regression from https://github.com/nuxt/nuxt/pull/30634 that fixes #30749
Reverting to be dependent on `externality` and `mlly` to determine the absolute path of external packages.


### 📚 Description
There should be a better way, but I frankly don't understand how the default `vite-node` behavior was considered fine in #30634, How does vite-node resolve a module-Id ?