### PR TITLE
feat: add import.meta.envName

### DIFF
--- a/docs/3.api/6.advanced/2.import-meta.md
+++ b/docs/3.api/6.advanced/2.import-meta.md
@@ -27,7 +27,7 @@ Property | Type | Description
 `import.meta.dev` | boolean | True when running the Nuxt dev server.
 `import.meta.test` | boolean | True when running in a test context.
 `import.meta.prerender` | boolean | True when rendering HTML on the server in the prerender stage of your build.
-`import.meta.envName` | string | Specifies the current environment name (e.g., 'development', 'production', …).
+`import.meta.envName` | string | Specifies the current environment name (e.g., 'development', 'production', 'staging', …).
 
 ## Builder Properties
 

--- a/docs/3.api/6.advanced/2.import-meta.md
+++ b/docs/3.api/6.advanced/2.import-meta.md
@@ -27,6 +27,7 @@ Property | Type | Description
 `import.meta.dev` | boolean | True when running the Nuxt dev server.
 `import.meta.test` | boolean | True when running in a test context.
 `import.meta.prerender` | boolean | True when rendering HTML on the server in the prerender stage of your build.
+`import.meta.envName` | string | Specifies the current environment name (e.g., 'development', 'production', …).
 
 ## Builder Properties
 

--- a/docs/3.api/6.advanced/2.import-meta.md
+++ b/docs/3.api/6.advanced/2.import-meta.md
@@ -27,7 +27,7 @@ Property | Type | Description
 `import.meta.dev` | boolean | True when running the Nuxt dev server.
 `import.meta.test` | boolean | True when running in a test context.
 `import.meta.prerender` | boolean | True when rendering HTML on the server in the prerender stage of your build.
-`import.meta.envName` | string | Specifies the current environment name (e.g., 'development', 'production', 'staging', …).
+`import.meta.envName` | string | Specifies the current environment name (e.g., `development`, `production`, `staging`, …).
 
 ## Builder Properties
 

--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -57,6 +57,7 @@ export async function buildClient (ctx: ViteBuildContext) {
       'import.meta.browser': true,
       'import.meta.nitro': false,
       'import.meta.prerender': false,
+      'import.meta.envName': JSON.stringify(ctx.config.mode),
       'module.hot': false,
       ...nodeCompat.define,
     },

--- a/packages/webpack/src/presets/base.ts
+++ b/packages/webpack/src/presets/base.ts
@@ -232,6 +232,7 @@ function getEnv (ctx: WebpackConfigContext) {
     'import.meta.browser': ctx.isClient,
     'import.meta.client': ctx.isClient,
     'import.meta.server': ctx.isServer,
+    'import.meta.envName': JSON.stringify(ctx.config.mode),
   }
 
   if (ctx.userConfig.aggressiveCodeRemoval) {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
Currently, the environment name is defined only by `process.env.NODE_ENV` and is not documented.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
