### PR TITLE
perf(kit): update env expansion regex to match nitro

### DIFF
--- a/packages/kit/src/runtime-config.test.ts
+++ b/packages/kit/src/runtime-config.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useRuntimeConfig } from './runtime-config'
+
+const { useNuxt, klona } = vi.hoisted(() => ({ useNuxt: vi.fn(), klona: vi.fn() }))
+
+vi.mock('./context', () => ({ useNuxt }))
+vi.mock('klona', () => ({ klona }))
+
+const testCases = [
+  {
+    description:
+      'should return runtime config with environment variables applied',
+    runtimeConfig: {
+      apiUrl: 'http://localhost',
+      authUrl: 'http://auth.com',
+    },
+    envExpansion: true,
+    env: {
+      NITRO_API_URL: 'http://example.com',
+    },
+    expected: {
+      apiUrl: 'http://example.com',
+      authUrl: 'http://auth.com',
+    },
+  },
+  {
+    description: 'should expand environment variables in strings',
+    runtimeConfig: {
+      apiUrl: '{{BASE_URL}}/api',
+      mail: '{{MAIL_SCHEME}}://{{MAIL_HOST}}:{{MAIL_PORT}}',
+    },
+    envExpansion: true,
+    env: {
+      BASE_URL: 'http://example.com',
+      MAIL_SCHEME: 'http',
+      MAIL_HOST: 'localhost',
+      MAIL_PORT: '3366',
+    },
+    expected: {
+      apiUrl: 'http://example.com/api',
+      mail: 'http://localhost:3366',
+    },
+  },
+  {
+    description:
+      'should not expand environment variables if envExpansion is false',
+    runtimeConfig: {
+      apiUrl: '{{BASE_URL}}/api',
+      someUrl: '',
+    },
+    envExpansion: false,
+    env: {
+      BASE_URL: 'http://example1.com',
+      NITRO_NOT_API_URL: 'http://example2.com',
+      NUXT_SOME_URL: 'http://example3.com',
+    },
+    expected: {
+      apiUrl: '{{BASE_URL}}/api',
+      someUrl: 'http://example3.com',
+    },
+  },
+]
+
+describe('useRuntimeConfig', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it.each(testCases)('$description', ({ runtimeConfig, envExpansion, env, expected }) => {
+    useNuxt.mockReturnValue({ options: { nitro: { runtimeConfig, experimental: { envExpansion } } } })
+    klona.mockReturnValue(runtimeConfig)
+    Object.entries(env).forEach(([key, value]) => vi.stubEnv(key, value))
+
+    expect(useRuntimeConfig()).toEqual(expected)
+  })
+})

--- a/packages/kit/src/runtime-config.ts
+++ b/packages/kit/src/runtime-config.ts
@@ -94,7 +94,7 @@ function applyEnv (
   return obj
 }
 
-const envExpandRx = /\{\{(.*?)\}\}/g
+const envExpandRx = /\{\{([^{}]*)\}\}/g
 
 function _expandFromEnv (value: string, env: Record<string, any> = process.env) {
   return value.replace(envExpandRx, (match, key) => {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

Resolves https://github.com/nuxt/nuxt/issues/30263
Appropriate PR for Nitro https://github.com/nitrojs/nitro/pull/3037

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

The current Regex for env expansion feature is vulnerable according to [Devina ReDos checker](https://devina.io/redos-checker).
<img src="https://github.com/user-attachments/assets/1276c155-fcb3-4cda-b368-ca7a956e3f76" width="300" />

This Enhancement makes the Regex safe with keeping functionality.
<img src="https://github.com/user-attachments/assets/6b3c2b92-9373-4c65-b437-65de6e0b0a87" width="300" />

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
