### PR TITLE
fix(nuxt): allow restarting nuxt on paths outside `srcDir`

### DIFF
--- a/packages/nuxt/src/core/builder.ts
+++ b/packages/nuxt/src/core/builder.ts
@@ -108,6 +108,18 @@ function createWatcher () {
     ignored: [isIgnored, /[\\/]node_modules[\\/]/],
   })
 
+  const restartPaths = new Set<string>()
+  const srcDir = nuxt.options.srcDir.replace(/\/?$/, '/')
+  for (const pattern of nuxt.options.watch) {
+    if (typeof pattern !== 'string') { continue }
+    const path = resolve(nuxt.options.srcDir, pattern)
+    if (!path.startsWith(srcDir)) {
+      restartPaths.add(path)
+    }
+  }
+
+  watcher.add([...restartPaths])
+
   watcher.on('all', (event, path) => {
     if (event === 'all' || event === 'ready' || event === 'error' || event === 'raw') {
       return

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -414,7 +414,6 @@ async function initNuxt (nuxt: Nuxt) {
   await nuxt.callHook('modules:before')
   const modulesToInstall = new Map<string | NuxtModule, Record<string, any>>()
 
-  const watchedPaths = new Set<string>()
   const specifiedModules = new Set<string>()
 
   for (const _mod of nuxt.options.modules) {
@@ -432,7 +431,7 @@ async function initNuxt (nuxt: Nuxt) {
       `${modulesDir}/*/index{${nuxt.options.extensions.join(',')}}`,
     ])
     for (const mod of layerModules) {
-      watchedPaths.add(mod)
+      nuxt.options.watch.push(mod)
       if (specifiedModules.has(mod)) { continue }
       specifiedModules.add(mod)
       modulesToInstall.set(mod, {})
@@ -660,10 +659,6 @@ export default defineNuxtPlugin({
 
   nuxt.hooks.hook('builder:watch', (event, relativePath) => {
     const path = resolve(nuxt.options.srcDir, relativePath)
-    // Local module patterns
-    if (watchedPaths.has(path)) {
-      return nuxt.callHook('restart', { hard: true })
-    }
 
     // User provided patterns
     const layerRelativePaths = nuxt.options._layers.map(l => relative(l.config.srcDir || l.cwd, path))


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

With upcoming change to move local `modules/` out of the `srcDir`, changes to local modules no longer trigger restarts

this PR allows watching selected paths outside of `srcDir` (adding them individually to the existing watcher).