### PR TITLE
fix(kit): load `@nuxt/schema` from `nuxt` package dir

### DIFF
--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -27,7 +27,6 @@
     "test:attw": "attw --pack"
   },
   "dependencies": {
-    "@nuxt/schema": "workspace:*",
     "c12": "^2.0.1",
     "consola": "^3.4.0",
     "defu": "^6.1.4",
@@ -50,6 +49,7 @@
     "untyped": "^1.5.2"
   },
   "devDependencies": {
+    "@nuxt/schema": "workspace:*",
     "@rspack/core": "1.2.2",
     "@types/semver": "7.5.8",
     "nitro": "npm:nitro-nightly@3.0.0-beta-28938837.19ec5395",

--- a/packages/kit/src/loader/config.ts
+++ b/packages/kit/src/loader/config.ts
@@ -1,4 +1,5 @@
 import { existsSync } from 'node:fs'
+import { pathToFileURL } from 'node:url'
 import type { JSValue } from 'untyped'
 import { applyDefaults } from 'untyped'
 import type { ConfigLayer, ConfigLayerMeta, LoadConfigOptions } from 'c12'
@@ -7,6 +8,7 @@ import type { NuxtConfig, NuxtOptions } from '@nuxt/schema'
 import { globby } from 'globby'
 import defu from 'defu'
 import { join } from 'pathe'
+import { isWindows } from 'std-env'
 import { tryResolveModule } from '../internal/esm'
 
 export interface LoadNuxtConfigOptions extends Omit<LoadConfigOptions<NuxtConfig>, 'overrides'> {
@@ -99,5 +101,5 @@ async function loadNuxtSchema (cwd: string) {
     paths.unshift(nuxtPath)
   }
   const schemaPath = await tryResolveModule('@nuxt/schema', paths) ?? '@nuxt/schema'
-  return await import(schemaPath).then(r => r.NuxtConfigSchema)
+  return await import(isWindows ? pathToFileURL(schemaPath).href : schemaPath).then(r => r.NuxtConfigSchema)
 }

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -83,7 +83,6 @@ const nightlies = {
 
 export const keyDependencies = [
   '@nuxt/kit',
-  '@nuxt/schema',
 ]
 
 let warnedAboutCompatDate = false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -233,9 +233,6 @@ importers:
 
   packages/kit:
     dependencies:
-      '@nuxt/schema':
-        specifier: workspace:*
-        version: link:../schema
       c12:
         specifier: 2.0.1
         version: 2.0.1(magicast@0.3.5)
@@ -297,6 +294,9 @@ importers:
         specifier: ^1.5.2
         version: 1.5.2
     devDependencies:
+      '@nuxt/schema':
+        specifier: workspace:*
+        version: link:../schema
       '@rspack/core':
         specifier: 1.2.2
         version: 1.2.2


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this addresses a potential issue we had - that every nuxt kit brought its own version of the nuxt defaults, whereas we only want to load the version of nuxt's defaults that matches the version of nuxt.

more changes/refactors will be made to this part of the code, but this is a separate fix we can either merge in now, or keep pending until we move more of the defaults into nuxt itself