### PR TITLE
fix(nuxt): don't warn about calling `useRoute` in SFC setup

### DIFF
--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -19,7 +19,7 @@ export const useRouter: typeof _useRouter = () => {
 /** @since 3.0.0 */
 export const useRoute: typeof _useRoute = () => {
   if (import.meta.dev && isProcessingMiddleware()) {
-    console.warn('[nuxt] Calling `useRoute` within middleware may lead to misleading results. Instead, use the (to, from) arguments passed to the middleware to access the new and old routes.')
+    console.warn('[nuxt] Calling `useRoute` in the process of page changing may lead to misleading results. If it is called within middleware, use the (to, from) arguments to access the new and old routes instead. In SFC components, pass a pre-created route data using props.')
   }
   if (hasInjectionContext()) {
     return inject(PageRouteSymbol, useNuxtApp()._route)

--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -18,8 +18,7 @@ export const useRouter: typeof _useRouter = () => {
 
 /** @since 3.0.0 */
 export const useRoute: typeof _useRoute = () => {
-  const notInsideSFC = !getCurrentInstance()
-  if (import.meta.dev && isProcessingMiddleware() && notInsideSFC) {
+  if (import.meta.dev && !getCurrentInstance() && isProcessingMiddleware()) {
     console.warn('[nuxt] Calling `useRoute` within middleware may lead to misleading results. Instead, use the (to, from) arguments passed to the middleware to access the new and old routes.')
   }
   if (hasInjectionContext()) {

--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -18,8 +18,9 @@ export const useRouter: typeof _useRouter = () => {
 
 /** @since 3.0.0 */
 export const useRoute: typeof _useRoute = () => {
-  if (import.meta.dev && isProcessingMiddleware()) {
-    console.warn('[nuxt] Calling `useRoute` in the process of page changing may lead to misleading results. If it is called within middleware, use the (to, from) arguments to access the new and old routes instead. In SFC components, pass a pre-created route data using props.')
+  const notInsideSFC = !getCurrentInstance()
+  if (import.meta.dev && isProcessingMiddleware() && notInsideSFC) {
+    console.warn('[nuxt] Calling `useRoute` within middleware may lead to misleading results. Instead, use the (to, from) arguments passed to the middleware to access the new and old routes.')
   }
   if (hasInjectionContext()) {
     return inject(PageRouteSymbol, useNuxtApp()._route)


### PR DESCRIPTION
### 🔗 Linked issue

Related [#28893](https://github.com/nuxt/nuxt/issues/28893#issuecomment-2615825977)

### 📚 Description

Provides more info about the problem of calling `useRoute` in the process of page change.
Current warn does not cover cases where an SFC component that calls `useRoute` in `setup` is created during page changing.

Also, if there is a way to tell if `useRoute` is called inside setup function of component, I think it would be better to check on this and leave the old warn message.