### PR TITLE
docs: remove backslashes in `spaLoadingTemplate` example

### DIFF
--- a/packages/schema/src/config/app.ts
+++ b/packages/schema/src/config/app.ts
@@ -314,7 +314,7 @@ export default defineUntypedSchema({
    *   animation: loader 400ms linear infinite;
    * }
    *
-   * \@-webkit-keyframes loader {
+   * @-webkit-keyframes loader {
    *   0% {
    *     -webkit-transform: translate(-50%, -50%) rotate(0deg);
    *   }
@@ -322,7 +322,7 @@ export default defineUntypedSchema({
    *     -webkit-transform: translate(-50%, -50%) rotate(360deg);
    *   }
    * }
-   * \@keyframes loader {
+   * @keyframes loader {
    *   0% {
    *     transform: translate(-50%, -50%) rotate(0deg);
    *   }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

No linked issue. This is a minor fix to the template example.

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

This PR removes unnecessary backslashes in the `keyframes` example within the `spa-loading-template.html` file. These backslashes were unintentional and do not affect functionality, but correcting them improves the clarity and accuracy of the template example.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
