### PR TITLE
fix(nuxt): ensure `<NuxtLayout>` `fallback` prop is typed

### DIFF
--- a/test/fixtures/basic-types/types.ts
+++ b/test/fixtures/basic-types/types.ts
@@ -258,7 +258,7 @@ describe('typed router integration', () => {
 })
 
 describe('layouts', () => {
-  it('recognizes named layouts', () => {
+  it('definePageMeta recognizes named layouts', () => {
     definePageMeta({ layout: 'custom' })
     definePageMeta({ layout: 'pascal-case' })
     definePageMeta({ layout: 'override' })
@@ -266,11 +266,14 @@ describe('layouts', () => {
     definePageMeta({ layout: 'invalid-layout' })
   })
 
-  it('allows typing layouts', () => {
+  it('NuxtLayout recognizes named layouts', () => {
     h(NuxtLayout, { name: 'custom' })
-
     // @ts-expect-error Invalid layout
     h(NuxtLayout, { name: 'invalid-layout' })
+
+    h(NuxtLayout, { fallback: 'custom' })
+    // @ts-expect-error Invalid layout
+    h(NuxtLayout, { fallback: 'invalid-layout' })
   })
 })
 


### PR DESCRIPTION
### 🔗 Linked issue

### 📚 Description

This makes the `fallback`'s type available, kinda like https://github.com/nuxt/nuxt/pull/22855. Previously it got stripped completely [even though it's documented](https://nuxt.com/docs/api/components/nuxt-layout#props).
It now exists and is typed to match existing layout names similar to the `name` prop.

I also restructured the props assignment, avoiding the need to repeat the types of `defineComponent` in the type assertion below.
The assertion is sadly still necessary as the result otherwise simplifies the type, stripping the `PageMeta['layout']`. 
Though I'm not sure where the issue lies now that https://github.com/unjs/mkdist/pull/154 got merged.

<details>
<summary>If someones interested, here are the outputs with and without the type assertion:</summary>

#### With type assertion (working)
```ts
import type { DefineComponent, ExtractPublicPropTypes, MaybeRef, PropType } from 'vue';
import type { PageMeta } from '../../pages/runtime/composables.js';
declare const nuxtLayoutProps: {
    name: {
        type: PropType<unknown extends PageMeta["layout"] ? MaybeRef<string | false> : PageMeta["layout"]>;
        default: null;
    };
    fallback: {
        type: PropType<unknown extends PageMeta["layout"] ? MaybeRef<string> : PageMeta["layout"]>;
        default: null;
    };
};
declare const _default: DefineComponent<ExtractPublicPropTypes<typeof nuxtLayoutProps>>;
export default _default;
```

#### Without type assertion (correct types are later overriden by the & {...})
```ts
import type { DefineComponent, ExtractPropTypes, MaybeRef, PropType } from 'vue';
import type { PageMeta } from '../../pages/runtime/composables.js';
declare const _default: DefineComponent<ExtractPropTypes<{
    name: {
        type: PropType<unknown extends PageMeta["layout"] ? MaybeRef<string | false> : PageMeta["layout"]>;
        default: null;
    };
    fallback: {
        type: PropType<unknown extends PageMeta["layout"] ? MaybeRef<string> : PageMeta["layout"]>;
        default: null;
    };
}>, () => any, {}, {}, {}, import("vue").ComponentOptionsMixin, import("vue").ComponentOptionsMixin, {}, string, import("vue").PublicProps, Readonly<ExtractPropTypes<{
    name: {
        type: PropType<unknown extends PageMeta["layout"] ? MaybeRef<string | false> : PageMeta["layout"]>;
        default: null;
    };
    fallback: {
        type: PropType<unknown extends PageMeta["layout"] ? MaybeRef<string> : PageMeta["layout"]>;
        default: null;
    };
}>> & Readonly<{}>, {
    name: MaybeRef<string | false>;
    fallback: MaybeRef<string>;
}, {}, {}, {}, string, import("vue").ComponentProvideOptions, true, {}, any>;
export default _default;
```
</details>

