### PR TITLE
fix(nuxt,vite): do not override vite import conditions

### DIFF
--- a/packages/nuxt/src/core/plugins/resolve-deep-imports.ts
+++ b/packages/nuxt/src/core/plugins/resolve-deep-imports.ts
@@ -14,7 +14,18 @@ export function resolveDeepImportsPlugin (nuxt: Nuxt): Plugin {
     name: 'nuxt:resolve-bare-imports',
     enforce: 'post',
     configResolved (config) {
-      conditions = config.mode === 'test' ? [...config.resolve.conditions, 'import', 'require'] : config.resolve.conditions
+      const resolvedConditions = new Set([nuxt.options.dev ? 'development' : 'production', ...config.resolve.conditions])
+      if (resolvedConditions.has('browser')) {
+        resolvedConditions.add('web')
+        resolvedConditions.add('import')
+        resolvedConditions.add('module')
+        resolvedConditions.add('default')
+      }
+      if (config.mode === 'test') {
+        resolvedConditions.add('import')
+        resolvedConditions.add('require')
+      }
+      conditions = [...resolvedConditions]
     },
     async resolveId (id, importer) {
       if (!importer || isAbsolute(id) || (!isAbsolute(importer) && !importer.startsWith('virtual:') && !importer.startsWith('\0virtual:')) || exclude.some(e => id.startsWith(e))) {

--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -131,19 +131,6 @@ export async function buildClient (ctx: ViteBuildContext) {
       },
     },
     plugins: [
-      {
-        name: 'nuxt:import-conditions',
-        enforce: 'post',
-        config (_config, env) {
-          if (env.mode !== 'test') {
-            return {
-              resolve: {
-                conditions: [ctx.nuxt.options.dev ? 'development' : 'production', 'web', 'browser', 'import', 'module', 'default'],
-              },
-            }
-          }
-        },
-      },
       devStyleSSRPlugin({
         srcDir: ctx.nuxt.options.srcDir,
         buildAssetsURL: joinURL(ctx.nuxt.options.app.baseURL, ctx.nuxt.options.app.buildAssetsDir),


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/29674

### 📚 Description

This partially reverts https://github.com/nuxt/nuxt/pull/28846 to move the import condition resolution into the deep-imports plugin.