### PR TITLE
fix(nuxt): delete existing properties on app config template's HMR

### DIFF
--- a/packages/nuxt/src/app/config.ts
+++ b/packages/nuxt/src/app/config.ts
@@ -55,13 +55,19 @@ export function useAppConfig (): AppConfig {
 }
 
 /**
- * Deep assign the current appConfig with the new one.
+ * Deep assign the current app config with the new one.
  *
- * Will preserve existing properties.
+ * Will preserve existing properties by default.
+ * @param appConfig - The new app config to assign.
+ * @param deleteExistingProperties - If true, exisiting properties will be deleted.
  */
-export function updateAppConfig (appConfig: DeepPartial<AppConfig>) {
+export function updateAppConfig (appConfig: DeepPartial<AppConfig>, deleteExistingProperties: boolean = false) {
   const _appConfig = useAppConfig()
   deepAssign(_appConfig, appConfig)
+
+  if (deleteExistingProperties) {
+    deepDelete(_appConfig, appConfig)
+  }
 }
 
 // HMR Support

--- a/packages/nuxt/src/app/config.ts
+++ b/packages/nuxt/src/app/config.ts
@@ -54,7 +54,7 @@ export function useAppConfig (): AppConfig {
   return nuxtApp._appConfig
 }
 
-export function replaceAppConfig (newConfig: AppConfig) {
+export function _replaceAppConfig (newConfig: AppConfig) {
   const appConfig = useAppConfig()
 
   deepAssign(appConfig, newConfig)

--- a/packages/nuxt/src/app/config.ts
+++ b/packages/nuxt/src/app/config.ts
@@ -54,20 +54,21 @@ export function useAppConfig (): AppConfig {
   return nuxtApp._appConfig
 }
 
+export function replaceAppConfig (newConfig: AppConfig) {
+  const appConfig = useAppConfig()
+
+  deepAssign(appConfig, newConfig)
+  deepDelete(appConfig, newConfig)
+}
+
 /**
- * Deep assign the current app config with the new one.
+ * Deep assign the current appConfig with the new one.
  *
- * Will preserve existing properties by default.
- * @param appConfig - The new app config to assign.
- * @param deleteExistingProperties - If true, exisiting properties will be deleted.
+ * Will preserve existing properties.
  */
-export function updateAppConfig (appConfig: DeepPartial<AppConfig>, deleteExistingProperties: boolean = false) {
+export function updateAppConfig (appConfig: DeepPartial<AppConfig>) {
   const _appConfig = useAppConfig()
   deepAssign(_appConfig, appConfig)
-
-  if (deleteExistingProperties) {
-    deepDelete(_appConfig, appConfig)
-  }
 }
 
 // HMR Support

--- a/packages/nuxt/src/app/index.ts
+++ b/packages/nuxt/src/app/index.ts
@@ -6,7 +6,7 @@ export type { AddRouteMiddlewareOptions, AsyncData, AsyncDataOptions, AsyncDataR
 
 export { defineNuxtLink } from './components/index'
 export type { NuxtLinkOptions, NuxtLinkProps } from './components/index'
-export { _getAppConfig, updateAppConfig, useAppConfig } from './config'
+export { _getAppConfig, updateAppConfig, useAppConfig, replaceAppConfig } from './config'
 export { cancelIdleCallback, requestIdleCallback } from './compat/idle-callback'
 export type { NuxtAppLiterals, NuxtIslandContext, NuxtIslandResponse, NuxtRenderHTMLContext, PageMeta, NuxtPageProps } from './types'
 

--- a/packages/nuxt/src/app/index.ts
+++ b/packages/nuxt/src/app/index.ts
@@ -6,7 +6,7 @@ export type { AddRouteMiddlewareOptions, AsyncData, AsyncDataOptions, AsyncDataR
 
 export { defineNuxtLink } from './components/index'
 export type { NuxtLinkOptions, NuxtLinkProps } from './components/index'
-export { _getAppConfig, updateAppConfig, useAppConfig, replaceAppConfig } from './config'
+export { _getAppConfig, updateAppConfig, useAppConfig } from './config'
 export { cancelIdleCallback, requestIdleCallback } from './compat/idle-callback'
 export type { NuxtAppLiterals, NuxtIslandContext, NuxtIslandResponse, NuxtRenderHTMLContext, PageMeta, NuxtPageProps } from './types'
 

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -428,12 +428,12 @@ import { defuFn } from 'defu'
 const inlineConfig = ${JSON.stringify(nuxt.options.appConfig, null, 2)}
 
 /** client **/
-import { updateAppConfig } from '#app/config'
+import { replaceAppConfig } from '#app/config'
 
 // Vite - webpack is handled directly in #app/config
 if (import.meta.dev && !import.meta.nitro && import.meta.hot) {
   import.meta.hot.accept((newModule) => {
-    updateAppConfig(newModule.default, true)
+    replaceAppConfig(newModule.default)
   })
 }
 /** client-end **/

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -433,7 +433,7 @@ import { _replaceAppConfig } from '#app/config'
 // Vite - webpack is handled directly in #app/config
 if (import.meta.dev && !import.meta.nitro && import.meta.hot) {
   import.meta.hot.accept((newModule) => {
-   _replaceAppConfig(newModule.default)
+    _replaceAppConfig(newModule.default)
   })
 }
 /** client-end **/

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -433,7 +433,7 @@ import { updateAppConfig } from '#app/config'
 // Vite - webpack is handled directly in #app/config
 if (import.meta.dev && !import.meta.nitro && import.meta.hot) {
   import.meta.hot.accept((newModule) => {
-    updateAppConfig(newModule.default)
+    updateAppConfig(newModule.default, true)
   })
 }
 /** client-end **/

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -428,12 +428,12 @@ import { defuFn } from 'defu'
 const inlineConfig = ${JSON.stringify(nuxt.options.appConfig, null, 2)}
 
 /** client **/
-import { replaceAppConfig } from '#app/config'
+import { _replaceAppConfig } from '#app/config'
 
 // Vite - webpack is handled directly in #app/config
 if (import.meta.dev && !import.meta.nitro && import.meta.hot) {
   import.meta.hot.accept((newModule) => {
-    replaceAppConfig(newModule.default)
+   _replaceAppConfig(newModule.default)
   })
 }
 /** client-end **/


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/30916

### 📚 Description

Adds `replaceAppConfig` util, which allows for deep assign/delete of app config.