### PR TITLE
docs: fix typo and improve data fetching examples

### DIFF
--- a/docs/1.getting-started/6.data-fetching.md
+++ b/docs/1.getting-started/6.data-fetching.md
@@ -90,21 +90,34 @@ Read more about `$fetch`.
 
 ### Pass Client Headers to the API
 
-During server-side-rendering, since the `$fetch` request takes place 'internally' within the server, it won't include the user's browser cookies.
+When calling `useFetch` on the server, Nuxt will use [`useRequestFetch`](/docs/api/composables/use-request-fetch) to proxy client headers and cookies (with the exception of headers not meant to be forwarded, like `host`).
 
-We can use [`useRequestHeaders`](/docs/api/composables/use-request-headers) to access and proxy cookies to the API from server-side.
+```vue
+<script setup lang="ts">
+const { data } = await useFetch('/api/echo');
+</script>
+```
 
-The example below adds the request headers to an isomorphic `$fetch` call to ensure that the API endpoint has access to the same `cookie` header originally sent by the user.
+```ts
+// /api/echo.ts
+export default defineEventHandler(event => parseCookies(event))
+```
+
+Alternatively, the example below shows how to use [`useRequestHeaders`](/docs/api/composables/use-request-headers) to access and send cookies to the API from a server-side request (originating on the client). Using an isomorphic `$fetch` call, we ensure that the API endpoint has access to the same `cookie` header originally sent by the user's browser. This is only necessary if you aren't using `useFetch`.
 
 ```vue
 <script setup lang="ts">
 const headers = useRequestHeaders(['cookie'])
 
 async function getCurrentUser() {
-  return await $fetch('/api/me', { headers: headers.value })
+  return await $fetch('/api/me', { headers })
 }
 </script>
 ```
+
+::tip
+You can also use [`useRequestFetch`](/docs/api/composables/use-request-fetch) to proxy headers to the call automatically.
+::
 
 ::caution
 Be very careful before proxying headers to an external API and just include headers that you need. Not all headers are safe to be bypassed and might introduce unwanted behavior. Here is a list of common headers that are NOT to be proxied:
@@ -115,9 +128,6 @@ Be very careful before proxying headers to an external API and just include head
 - `cf-connecting-ip`, `cf-ray`
 ::
 
-::tip
-You can also use [`useRequestFetch`](/docs/api/composables/use-request-fetch) to proxy headers to the call automatically.
-::
 
 ## `useFetch`
 

--- a/docs/1.getting-started/6.data-fetching.md
+++ b/docs/1.getting-started/6.data-fetching.md
@@ -128,7 +128,6 @@ Be very careful before proxying headers to an external API and just include head
 - `cf-connecting-ip`, `cf-ray`
 ::
 
-
 ## `useFetch`
 
 The [`useFetch`](/docs/api/composables/use-fetch) composable uses `$fetch` under-the-hood to make SSR-safe network calls in the setup function.


### PR DESCRIPTION
### 🔗 Linked issue

none

### 📚 Description

This change fixes a typo on the `useRequestFetch` example. The `.value` is incorrect as the `useRequestHeaders` value is not a ref. 

I only discovered the fact that _useFetch_ already proxies headers to SSR event handlers after scrolling and re-reading the documentation. A small change to the data fetching section about sending cookies helps users know they may not need to reach for `useRequestFetch` if they are already using `useFetch`.
