### PR TITLE
fix(nuxt): update `getCachedData` type to fix type inference

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -63,7 +63,7 @@ export interface AsyncDataOptions<
    * An `undefined` return value will trigger a fetch.
    * Default is `key => nuxt.isHydrating ? nuxt.payload.data[key] : nuxt.static.data[key]` which only caches data when payloadExtraction is enabled.
    */
-  getCachedData?: (key: string, nuxtApp: NuxtApp) => NoInfer<DataT> | undefined
+  getCachedData?: (key: string, nuxtApp: NuxtApp) => NoInfer<DataT | undefined>
   /**
    * A function that can be used to alter handler function result after resolving.
    * Do not use it along with the `pick` option.


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/29567

### 📚 Description

Implements a fix suggested by @cjpearson to include `undefined` in the `NoInfer` type.