### PR TITLE
fix(schema): make `app.head.meta` config undefined-friendly

### DIFF
--- a/packages/schema/src/config/app.ts
+++ b/packages/schema/src/config/app.ts
@@ -175,10 +175,10 @@ export default defineResolvers({
         } satisfies NormalizedMetaObject)
 
         // provides default charset and viewport if not set
-        if (!resolved.meta.find(m => m.charset)?.charset) {
+        if (!resolved.meta.find(m => m?.charset)?.charset) {
           resolved.meta.unshift({ charset: resolved.charset || 'utf-8' })
         }
-        if (!resolved.meta.find(m => m.name === 'viewport')?.content) {
+        if (!resolved.meta.find(m => m?.name === 'viewport')?.content) {
           resolved.meta.unshift({ name: 'viewport', content: resolved.viewport || 'width=device-width, initial-scale=1' })
         }
 


### PR DESCRIPTION
### 🔗 Linked issue

### 📚 Description

Match the type of `app.head.meta`:

```ts
(property) meta?: ({
    [x: `data-${string}`]: Stringable | undefined;
    content?: Stringable | (Stringable | undefined)[] | null | undefined;
    id?: string | false | null | undefined;
    ... 14 more ...;
    processTemplateParams?: false | undefined;
} | undefined)[] | undefined
```
