### PR TITLE
docs: add tips on how to override layers aliases

### DIFF
--- a/docs/1.getting-started/9.layers.md
+++ b/docs/1.getting-started/9.layers.md
@@ -64,7 +64,7 @@ export default defineNuxtConfig({
       { 
         meta: {
           name: 'my-awesome-theme',
-        } 
+        },
       },
     ],
   ]

--- a/docs/1.getting-started/9.layers.md
+++ b/docs/1.getting-started/9.layers.md
@@ -53,6 +53,26 @@ export default defineNuxtConfig({
 })
 ```
 
+::tip
+You can override a layer's alias by specifying it in the options next to the layer source.
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  extends: [
+    [
+      'github:my-themes/awesome',
+      { 
+        meta: {
+          name: 'my-awesome-theme',
+        } 
+      },
+    ],
+  ]
+})
+```
+
+::
+
 Nuxt uses [unjs/c12](https://c12.unjs.io) and [unjs/giget](https://giget.unjs.io) for extending remote layers. Check the documentation for more information and all available options.
 
 ::read-more{to="/docs/guide/going-further/layers"}


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

N/A.

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

Add info on how to override a layer's alias, beside using `$meta.name`.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
