### PR TITLE
docs: fix typo

### DIFF
--- a/docs/2.guide/3.going-further/2.hooks.md
+++ b/docs/2.guide/3.going-further/2.hooks.md
@@ -11,9 +11,9 @@ The hooking system is powered by [unjs/hookable](https://github.com/unjs/hookabl
 
 These hooks are available for [Nuxt Modules](/docs/guide/going-further/modules) and build context.
 
-### Within `nuxt.config`
+### Within `nuxt.config.ts`
 
-```js [nuxt.config]
+```js [nuxt.config.ts]
 export default defineNuxtConfig({
   hooks: {
     close: () => { }


### PR DESCRIPTION
### 🔗 Linked issue

### 📚 Description
Fix an error in file name on [Lifecycle Hooks](https://nuxt.com/docs/guide/going-further/hooks#within-nuxtconfig)

Before: `nuxt.config`
After: `nuxt.config.ts`
