### PR TITLE
fix(nuxt): decode URI components in cache driver methods

### DIFF
--- a/packages/nuxt/src/core/runtime/nitro/cache-driver.js
+++ b/packages/nuxt/src/core/runtime/nitro/cache-driver.js
@@ -7,7 +7,7 @@ import lruCache from 'unstorage/drivers/lru-cache'
 /**
  * @param {string} item
  */
-const normalizeFsKey = item => item.replaceAll(':', '_')
+const normalizeFsKey = item => decodeURIComponent(item.replaceAll(':', '_'))
 
 /**
  * @param {{ base: string }} opts
@@ -20,15 +20,15 @@ export default defineDriver((opts) => {
     ...fs, // fall back to file system - only the bottom three methods are used in renderer
     async setItem (key, value, opts) {
       await Promise.all([
-        fs.setItem?.(normalizeFsKey(decodeURIComponent(key)), value, opts),
+        fs.setItem?.(normalizeFsKey(key), value, opts),
         lru.setItem?.(key, value, opts),
       ])
     },
     async hasItem (key, opts) {
-      return await lru.hasItem(key, opts) || await fs.hasItem(normalizeFsKey(decodeURIComponent(key)), opts)
+      return await lru.hasItem(key, opts) || await fs.hasItem(normalizeFsKey(key), opts)
     },
     async getItem (key, opts) {
-      return await lru.getItem(key, opts) || await fs.getItem(normalizeFsKey(decodeURIComponent(key)), opts)
+      return await lru.getItem(key, opts) || await fs.getItem(normalizeFsKey(key), opts)
     },
   }
 })

--- a/packages/nuxt/src/core/runtime/nitro/cache-driver.js
+++ b/packages/nuxt/src/core/runtime/nitro/cache-driver.js
@@ -20,15 +20,15 @@ export default defineDriver((opts) => {
     ...fs, // fall back to file system - only the bottom three methods are used in renderer
     async setItem (key, value, opts) {
       await Promise.all([
-        fs.setItem?.(normalizeFsKey(key), value, opts),
+        fs.setItem?.(normalizeFsKey(decodeURIComponent(key)), value, opts),
         lru.setItem?.(key, value, opts),
       ])
     },
     async hasItem (key, opts) {
-      return await lru.hasItem(key, opts) || await fs.hasItem(normalizeFsKey(key), opts)
+      return await lru.hasItem(key, opts) || await fs.hasItem(normalizeFsKey(decodeURIComponent(key)), opts)
     },
     async getItem (key, opts) {
-      return await lru.getItem(key, opts) || await fs.getItem(normalizeFsKey(key), opts)
+      return await lru.getItem(key, opts) || await fs.getItem(normalizeFsKey(decodeURIComponent(key)), opts)
     },
   }
 })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #27722

### 📚 Description

When using Nuxt version 3.11 or above, pre-rendering pages with multilingual slugs (including non-ASCII characters) causes filenames to be encoded to US-ASCII. This encoding significantly increases the filename length, potentially exceeding the file system's 255-character limit, and ultimately triggers an "ENAMETOOLONG" error. This issue did not occur in version 3.10 and earlier.

To address this, I reviewed all the commits between https://github.com/nuxt/nuxt/compare/v3.10.3...v3.11.0. One commit in particular stood out: in https://github.com/nuxt/nuxt/commit/bc44dfc48404fd3aee58a662099952568ed71f58, @danielroe updated the `nitro.options._config.storage` configuration for the pre-render cache (`internal:nuxt:prerender`).

**Before:**
```ts
nitro.options._config.storage['internal:nuxt:prerender'] = { driver: 'memory' }
```

**After:**
```ts
nitro.options._config.storage = defu(nitro.options._config.storage, {
  'internal:nuxt:prerender': {
    driver: pathToFileURL(await resolvePath(join(distDir, 'core/runtime/nitro/cache-driver'))).href,
    base: resolve(nuxt.options.buildDir, 'cache/nitro/prerender')
  }
})
```

Previously, the pre-render cache was stored in memory. With the updated configuration, the cache is now stored using a `cache-driver` in the `<rootDir>/.nuxt/cache/nitro/prerender` folder.

Upon further inspection of the `cache-driver` code, I discovered that when a pathname includes non-ASCII characters, it is used directly as a filename. This can lead to the "ENAMETOOLONG" error when the filename exceeds the 255-character limit. To resolve this, I added a call to `decodeURIComponent` to decode the pathnames before they are used, ensuring that filenames remain within acceptable length limits.
