### PR TITLE
fix(nuxt): ensure `provide` / `inject` work in `setup` of `defineNuxtComponent`

### DIFF
--- a/packages/nuxt/src/app/composables/component.ts
+++ b/packages/nuxt/src/app/composables/component.ts
@@ -2,7 +2,7 @@ import { getCurrentInstance, reactive, toRefs } from 'vue'
 import type { DefineComponent, defineComponent } from 'vue'
 import { useHead } from '@unhead/vue'
 import type { NuxtApp } from '../nuxt'
-import { callWithNuxtContext, useNuxtApp } from '../nuxt'
+import { getNuxtAppCtx, useNuxtApp } from '../nuxt'
 import { useAsyncData } from './asyncData'
 import { useRoute } from './router'
 import { createError } from './error'
@@ -32,7 +32,7 @@ async function runLegacyAsyncData (res: Record<string, any> | Promise<Record<str
 export const defineNuxtComponent: typeof defineComponent =
   function defineNuxtComponent (...args: any[]): any {
     const [options, key] = args
-    const { setup } = options
+    const { setup } = options as DefineComponent
 
     // Avoid wrapping if no options api is used
     if (!setup && !options.asyncData && !options.head) {
@@ -48,7 +48,18 @@ export const defineNuxtComponent: typeof defineComponent =
       ...options,
       setup (props, ctx) {
         const nuxtApp = useNuxtApp()
-        const res = setup ? Promise.resolve(callWithNuxtContext(nuxtApp, () => setup(props, ctx))).then(r => r || {}) : {}
+
+        let res = {}
+        if (setup) {
+          const fn = (): Promise<Record<string, any>> => Promise.resolve(setup(props, ctx)).then((r: any) => r || {})
+          const nuxtAppCtx = getNuxtAppCtx(nuxtApp._id)
+          if (import.meta.server) {
+            res = nuxtAppCtx.callAsync(nuxtApp, fn)
+          } else {
+            nuxtAppCtx.set(nuxtApp)
+            res = fn()
+          }
+        }
 
         const promises: Promise<any>[] = []
         if (options.asyncData) {

--- a/packages/nuxt/src/app/composables/component.ts
+++ b/packages/nuxt/src/app/composables/component.ts
@@ -2,7 +2,7 @@ import { getCurrentInstance, reactive, toRefs } from 'vue'
 import type { DefineComponent, defineComponent } from 'vue'
 import { useHead } from '@unhead/vue'
 import type { NuxtApp } from '../nuxt'
-import { runWithNuxtContext, useNuxtApp } from '../nuxt'
+import { callWithNuxtContext, useNuxtApp } from '../nuxt'
 import { useAsyncData } from './asyncData'
 import { useRoute } from './router'
 import { createError } from './error'
@@ -48,7 +48,7 @@ export const defineNuxtComponent: typeof defineComponent =
       ...options,
       setup (props, ctx) {
         const nuxtApp = useNuxtApp()
-        const res = setup ? Promise.resolve(runWithNuxtContext(nuxtApp, () => setup(props, ctx))).then(r => r || {}) : {}
+        const res = setup ? Promise.resolve(callWithNuxtContext(nuxtApp, () => setup(props, ctx))).then(r => r || {}) : {}
 
         const promises: Promise<any>[] = []
         if (options.asyncData) {

--- a/packages/nuxt/src/app/composables/component.ts
+++ b/packages/nuxt/src/app/composables/component.ts
@@ -2,7 +2,7 @@ import { getCurrentInstance, reactive, toRefs } from 'vue'
 import type { DefineComponent, defineComponent } from 'vue'
 import { useHead } from '@unhead/vue'
 import type { NuxtApp } from '../nuxt'
-import { useNuxtApp } from '../nuxt'
+import { runWithNuxtContext, useNuxtApp } from '../nuxt'
 import { useAsyncData } from './asyncData'
 import { useRoute } from './router'
 import { createError } from './error'
@@ -48,7 +48,7 @@ export const defineNuxtComponent: typeof defineComponent =
       ...options,
       setup (props, ctx) {
         const nuxtApp = useNuxtApp()
-        const res = setup ? Promise.resolve(nuxtApp.runWithContext(() => setup(props, ctx))).then(r => r || {}) : {}
+        const res = setup ? Promise.resolve(runWithNuxtContext(nuxtApp, () => setup(props, ctx))).then(r => r || {}) : {}
 
         const promises: Promise<any>[] = []
         if (options.asyncData) {

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -492,19 +492,11 @@ export function isNuxtPlugin (plugin: unknown) {
  * @since 3.0.0
  */
 export function callWithNuxt<T extends (...args: any[]) => any> (nuxt: NuxtApp | _NuxtApp, setup: T, args?: Parameters<T>) {
-  const fn: () => ReturnType<T> = () => args ? setup(...args as Parameters<T>) : setup()
-  const nuxtAppCtx = getNuxtAppCtx(nuxt._id)
-  if (import.meta.server) {
-    return nuxt.vueApp.runWithContext(() => nuxtAppCtx.callAsync(nuxt as NuxtApp, fn))
-  } else {
-    // In client side we could assume nuxt app is singleton
-    nuxtAppCtx.set(nuxt as NuxtApp)
-    return nuxt.vueApp.runWithContext(fn)
-  }
+  return nuxt.vueApp.runWithContext(() => callWithNuxtContext(nuxt, setup, args))
 }
 
-// [WIP]
-export function runWithNuxtContext<T extends () => any> (nuxt: NuxtApp | _NuxtApp, fn: T): ReturnType<T> | Promise<Awaited<ReturnType<T>>> {
+export function callWithNuxtContext<T extends (...args: any[]) => any> (nuxt: NuxtApp | _NuxtApp, setup: T, args?: Parameters<T>) {
+  const fn: () => ReturnType<T> = () => args ? setup(...args as Parameters<T>) : setup()
   const nuxtAppCtx = getNuxtAppCtx(nuxt._id)
   if (import.meta.server) {
     return nuxtAppCtx.callAsync(nuxt as NuxtApp, fn)

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -503,6 +503,18 @@ export function callWithNuxt<T extends (...args: any[]) => any> (nuxt: NuxtApp |
   }
 }
 
+// [WIP]
+export function runWithNuxtContext<T extends () => any> (nuxt: NuxtApp | _NuxtApp, fn: T): ReturnType<T> | Promise<Awaited<ReturnType<T>>> {
+  const nuxtAppCtx = getNuxtAppCtx(nuxt._id)
+  if (import.meta.server) {
+    return nuxtAppCtx.callAsync(nuxt as NuxtApp, fn)
+  } else {
+    // In client side we could assume nuxt app is singleton
+    nuxtAppCtx.set(nuxt as NuxtApp)
+    return fn()
+  }
+}
+
 /* @__NO_SIDE_EFFECTS__ */
 /**
  * Returns the current Nuxt instance.

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -24,7 +24,7 @@ import type { RouteAnnouncer } from '../app/composables/route-announcer'
 // @ts-expect-error virtual file
 import { appId, chunkErrorEvent, multiApp } from '#build/nuxt.config.mjs'
 
-function getNuxtAppCtx (id = appId || 'nuxt-app') {
+export function getNuxtAppCtx (id = appId || 'nuxt-app') {
   return getContext<NuxtApp>(id, {
     asyncContext: !!__NUXT_ASYNC_CONTEXT__ && import.meta.server,
   })
@@ -492,18 +492,14 @@ export function isNuxtPlugin (plugin: unknown) {
  * @since 3.0.0
  */
 export function callWithNuxt<T extends (...args: any[]) => any> (nuxt: NuxtApp | _NuxtApp, setup: T, args?: Parameters<T>) {
-  return nuxt.vueApp.runWithContext(() => callWithNuxtContext(nuxt, setup, args))
-}
-
-export function callWithNuxtContext<T extends (...args: any[]) => any> (nuxt: NuxtApp | _NuxtApp, setup: T, args?: Parameters<T>) {
   const fn: () => ReturnType<T> = () => args ? setup(...args as Parameters<T>) : setup()
   const nuxtAppCtx = getNuxtAppCtx(nuxt._id)
   if (import.meta.server) {
-    return nuxtAppCtx.callAsync(nuxt as NuxtApp, fn)
+    return nuxt.vueApp.runWithContext(() => nuxtAppCtx.callAsync(nuxt as NuxtApp, fn))
   } else {
     // In client side we could assume nuxt app is singleton
     nuxtAppCtx.set(nuxt as NuxtApp)
-    return fn()
+    return nuxt.vueApp.runWithContext(fn)
   }
 }
 

--- a/packages/schema/src/config/build.ts
+++ b/packages/schema/src/config/build.ts
@@ -217,7 +217,7 @@ export default defineResolvers({
      * @type {typeof import('unctx/transform').TransformerOptions}
      */
     asyncTransforms: {
-      asyncFunctions: ['defineNuxtPlugin', 'defineNuxtRouteMiddleware'],
+      asyncFunctions: ['defineNuxtPlugin', 'defineNuxtRouteMiddleware', 'callWithNuxtContext'],
       objectDefinitions: {
         defineNuxtComponent: ['asyncData', 'setup'],
         defineNuxtPlugin: ['setup'],

--- a/packages/schema/src/config/build.ts
+++ b/packages/schema/src/config/build.ts
@@ -217,7 +217,7 @@ export default defineResolvers({
      * @type {typeof import('unctx/transform').TransformerOptions}
      */
     asyncTransforms: {
-      asyncFunctions: ['defineNuxtPlugin', 'defineNuxtRouteMiddleware', 'callWithNuxtContext'],
+      asyncFunctions: ['defineNuxtPlugin', 'defineNuxtRouteMiddleware'],
       objectDefinitions: {
         defineNuxtComponent: ['asyncData', 'setup'],
         defineNuxtPlugin: ['setup'],

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -2885,6 +2885,11 @@ describe('defineNuxtComponent', () => {
     await page.getByText('Go to route 1').click()
     expect(await page.getByTestId('define-nuxt-component-route-1-path').innerText()).include('route-1')
   })
+
+  it ('should get correctly inject value', async () => {
+    const { page } = await renderPage('/define-nuxt-component/inject')
+    expect(await page.getByTestId('define-nuxt-component-inject-value').innerText()).toBe('bar')
+  })
 })
 
 describe('namespace access to useNuxtApp', () => {

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -2868,13 +2868,22 @@ describe('lazy import components', () => {
   })
 })
 
-describe('defineNuxtComponent watch duplicate', () => {
-  it('test after navigation duplicate', async () => {
+describe('defineNuxtComponent', () => {
+  it('watches duplicate updates after navigation', async () => {
     const { page } = await renderPage('/define-nuxt-component')
     await page.getByTestId('define-nuxt-component-bar').click()
     await page.getByTestId('define-nuxt-component-state').click()
     await page.getByTestId('define-nuxt-component-foo').click()
     expect(await page.getByTestId('define-nuxt-component-state').first().innerText()).toBe('2')
+  })
+
+  it('get correctly route when navigating between routes', async () => {
+    const { page } = await renderPage('/define-nuxt-component/route-1')
+    await page.getByText('Go to route 2').click()
+    expect(await page.getByTestId('define-nuxt-component-route-2-path').innerText()).include('route-2')
+
+    await page.getByText('Go to route 1').click()
+    expect(await page.getByTestId('define-nuxt-component-route-1-path').innerText()).include('route-1')
   })
 })
 

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -2888,7 +2888,7 @@ describe('defineNuxtComponent', () => {
 
   it ('should get correctly inject value', async () => {
     const { page } = await renderPage('/define-nuxt-component/inject')
-    expect(await page.getByTestId('define-nuxt-component-inject-value').innerText()).toBe('bar')
+    expect(await page.getByTestId('define-nuxt-component-inject-value').innerText()).include('bar')
   })
 })
 

--- a/test/fixtures/basic/pages/define-nuxt-component/inject.vue
+++ b/test/fixtures/basic/pages/define-nuxt-component/inject.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+provide('foo', 'bar')
+</script>
+
+<template>
+  <NuxtPage />
+</template>

--- a/test/fixtures/basic/pages/define-nuxt-component/inject/index.vue
+++ b/test/fixtures/basic/pages/define-nuxt-component/inject/index.vue
@@ -1,0 +1,17 @@
+<script lang="ts">
+export default defineNuxtComponent({
+  name: 'DefineNuxtComponentTest',
+  setup () {
+    const value = inject('foo')
+    return {
+      value,
+    }
+  },
+})
+</script>
+
+<template>
+  <div testid="define-nuxt-component-inject-value">
+    {{ value }}
+  </div>
+</template>

--- a/test/fixtures/basic/pages/define-nuxt-component/inject/index.vue
+++ b/test/fixtures/basic/pages/define-nuxt-component/inject/index.vue
@@ -11,7 +11,7 @@ export default defineNuxtComponent({
 </script>
 
 <template>
-  <div testid="define-nuxt-component-inject-value">
+  <div data-testid="define-nuxt-component-inject-value">
     {{ value }}
   </div>
 </template>

--- a/test/fixtures/basic/pages/define-nuxt-component/route-1.vue
+++ b/test/fixtures/basic/pages/define-nuxt-component/route-1.vue
@@ -1,0 +1,23 @@
+<script lang="ts">
+export default defineNuxtComponent({
+  name: 'DefineNuxtComponentTest',
+  setup () {
+    const route = useRoute()
+    const path = route.path.toString()
+
+    return {
+      path,
+    }
+  },
+})
+</script>
+
+<template>
+  <div>
+    <h1>route-1</h1>
+    <NuxtLink to="/define-nuxt-component/route-2">Go to route 2</NuxtLink>
+    <div data-testid="define-nuxt-component-route-1-path">
+      {{ path }}
+    </div>
+  </div>
+</template>

--- a/test/fixtures/basic/pages/define-nuxt-component/route-2.vue
+++ b/test/fixtures/basic/pages/define-nuxt-component/route-2.vue
@@ -1,0 +1,23 @@
+<script lang="ts">
+export default defineNuxtComponent({
+  name: 'DefineNuxtComponentTest',
+  setup () {
+    const route = useRoute()
+    const path = route.path.toString()
+
+    return {
+      path,
+    }
+  },
+})
+</script>
+
+<template>
+  <div>
+    <h2>route-2</h2>
+    <NuxtLink to="/define-nuxt-component/route-1">Go to route 1</NuxtLink>
+    <div data-testid="define-nuxt-component-route-2-path">
+      {{ path }}
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
### 🔗 Linked issue

Resolve #30977
Resolve #28573


### 📚 Description

The `setup` function in `defineNuxtComponent` needs to run within the Nuxt context. However, if it is executed inside Vue’s `runWithContext`, it can cause issues with `provide` and `inject`.  

```ts
vueApp.runWithContext(() => {
  // This retrieves `provide` data directly from vueApp, which may lead to unexpected results.
  inject()
})
```

This PR introduces `callWithNuxtContext`, an internal function that executes a callback with the current Nuxt as the injection context, without the Vue app context. It ensures the correct context is provided when executing `setup` inside `defineNuxtComponent`.  

If there’s anything I haven’t considered thoroughly, please let me know. I really appreciate your time. Thank you! 