### PR TITLE
feat(kit,nuxt,vite): `directoryToURL` to normalise paths

### DIFF
--- a/packages/kit/src/index.ts
+++ b/packages/kit/src/index.ts
@@ -32,5 +32,5 @@ export { addTemplate, addServerTemplate, addTypeTemplate, normalizeTemplate, upd
 export { logger, useLogger } from './logger'
 
 // Internal Utils
-export { resolveModule, tryResolveModule, importModule, tryImportModule, requireModule, tryRequireModule } from './internal/esm'
+export { directoryToParentURL, resolveModule, tryResolveModule, importModule, tryImportModule, requireModule, tryRequireModule } from './internal/esm'
 export type { ImportModuleOptions, ResolveModuleOptions } from './internal/esm'

--- a/packages/kit/src/index.ts
+++ b/packages/kit/src/index.ts
@@ -32,5 +32,5 @@ export { addTemplate, addServerTemplate, addTypeTemplate, normalizeTemplate, upd
 export { logger, useLogger } from './logger'
 
 // Internal Utils
-export { directoryToParentURL, resolveModule, tryResolveModule, importModule, tryImportModule, requireModule, tryRequireModule } from './internal/esm'
+export { directoryToURL, resolveModule, tryResolveModule, importModule, tryImportModule, requireModule, tryRequireModule } from './internal/esm'
 export type { ImportModuleOptions, ResolveModuleOptions } from './internal/esm'

--- a/packages/kit/src/internal/esm.ts
+++ b/packages/kit/src/internal/esm.ts
@@ -33,7 +33,7 @@ export async function tryResolveModule (id: string, url: string | string[] | URL
 }
 
 export function resolveModule (id: string, options?: ResolveModuleOptions) {
-  return resolvePathSync(id, { url: options?.url ?? options?.url ?? [importMetaURL] })
+  return resolvePathSync(id, { url: options?.url ?? options?.paths ?? [importMetaURL] })
 }
 
 export interface ImportModuleOptions extends ResolveModuleOptions {

--- a/packages/kit/src/internal/esm.ts
+++ b/packages/kit/src/internal/esm.ts
@@ -2,6 +2,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url'
 import { interopDefault, resolvePath, resolvePathSync } from 'mlly'
 import { createJiti } from 'jiti'
 import { captureStackTrace } from 'errx'
+import { normalize } from 'pathe'
 
 export interface ResolveModuleOptions {
   /** @deprecated use `url` with URLs pointing at a file - never a directory */
@@ -10,7 +11,7 @@ export interface ResolveModuleOptions {
 }
 
 export function directoryToParentURL (directory: string) {
-  return new URL('./index.js', pathToFileURL(directory.replace(/\/?$/, '/')))
+  return new URL('./index.js', pathToFileURL(normalize(directory).replace(/\/?$/, '/')))
 }
 
 const importMetaURL = new URL(import.meta.url)

--- a/packages/kit/src/internal/esm.ts
+++ b/packages/kit/src/internal/esm.ts
@@ -2,7 +2,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url'
 import { interopDefault, resolvePath, resolvePathSync } from 'mlly'
 import { createJiti } from 'jiti'
 import { captureStackTrace } from 'errx'
-import { normalize } from 'pathe'
+import { join } from 'pathe'
 
 export interface ResolveModuleOptions {
   /** @deprecated use `url` with URLs pointing at a file - never a directory */
@@ -10,8 +10,8 @@ export interface ResolveModuleOptions {
   url?: URL | URL[]
 }
 
-export function directoryToParentURL (directory: string) {
-  return new URL('./index.js', pathToFileURL(normalize(directory).replace(/\/?$/, '/')))
+export function directoryToParentURL (dir: string): URL {
+  return pathToFileURL(join(dir, '_index.js'))
 }
 
 const importMetaURL = new URL(import.meta.url)

--- a/packages/kit/src/internal/esm.ts
+++ b/packages/kit/src/internal/esm.ts
@@ -14,8 +14,6 @@ export function directoryToParentURL (dir: string): URL {
   return pathToFileURL(join(dir, '_index.js'))
 }
 
-const importMetaURL = new URL(import.meta.url)
-
 /**
  * Resolve a module from a given root path using an algorithm patterned on
  * the upcoming `import.meta.resolve`. It returns a file URL
@@ -25,7 +23,7 @@ const importMetaURL = new URL(import.meta.url)
 export async function tryResolveModule (id: string, url: URL | URL[]): Promise<string | undefined>
 /** @deprecated pass URLs pointing at files */
 export async function tryResolveModule (id: string, url: string | string[]): Promise<string | undefined>
-export async function tryResolveModule (id: string, url: string | string[] | URL | URL[] = importMetaURL) {
+export async function tryResolveModule (id: string, url: string | string[] | URL | URL[] = import.meta.url) {
   try {
     return await resolvePath(id, { url })
   } catch {
@@ -34,7 +32,7 @@ export async function tryResolveModule (id: string, url: string | string[] | URL
 }
 
 export function resolveModule (id: string, options?: ResolveModuleOptions) {
-  return resolvePathSync(id, { url: options?.url ?? options?.paths ?? [importMetaURL] })
+  return resolvePathSync(id, { url: options?.url ?? options?.paths ?? [import.meta.url] })
 }
 
 export interface ImportModuleOptions extends ResolveModuleOptions {

--- a/packages/kit/src/internal/esm.ts
+++ b/packages/kit/src/internal/esm.ts
@@ -2,7 +2,6 @@ import { fileURLToPath, pathToFileURL } from 'node:url'
 import { interopDefault, resolvePath, resolvePathSync } from 'mlly'
 import { createJiti } from 'jiti'
 import { captureStackTrace } from 'errx'
-import { join } from 'pathe'
 
 export interface ResolveModuleOptions {
   /** @deprecated use `url` with URLs pointing at a file - never a directory */
@@ -10,8 +9,8 @@ export interface ResolveModuleOptions {
   url?: URL | URL[]
 }
 
-export function directoryToParentURL (dir: string): URL {
-  return pathToFileURL(join(dir, '_index.js'))
+export function directoryToURL (dir: string): URL {
+  return pathToFileURL(dir + '/')
 }
 
 /**

--- a/packages/kit/src/internal/esm.ts
+++ b/packages/kit/src/internal/esm.ts
@@ -4,8 +4,16 @@ import { createJiti } from 'jiti'
 import { captureStackTrace } from 'errx'
 
 export interface ResolveModuleOptions {
+  /** @deprecated use `url` with URLs pointing at a file - never a directory */
   paths?: string | string[]
+  url?: URL | URL[]
 }
+
+export function directoryToParentURL (directory: string) {
+  return new URL('./index.js', pathToFileURL(directory.replace(/\/?$/, '/')))
+}
+
+const importMetaURL = new URL(import.meta.url)
 
 /**
  * Resolve a module from a given root path using an algorithm patterned on
@@ -13,7 +21,10 @@ export interface ResolveModuleOptions {
  *
  * @internal
  */
-export async function tryResolveModule (id: string, url: string | string[] = import.meta.url) {
+export async function tryResolveModule (id: string, url: URL | URL[]): Promise<string | undefined>
+/** @deprecated pass URLs pointing at files */
+export async function tryResolveModule (id: string, url: string | string[]): Promise<string | undefined>
+export async function tryResolveModule (id: string, url: string | string[] | URL | URL[] = importMetaURL) {
   try {
     return await resolvePath(id, { url })
   } catch {
@@ -22,7 +33,7 @@ export async function tryResolveModule (id: string, url: string | string[] = imp
 }
 
 export function resolveModule (id: string, options?: ResolveModuleOptions) {
-  return resolvePathSync(id, { url: options?.paths ?? [import.meta.url] })
+  return resolvePathSync(id, { url: options?.url ?? options?.url ?? [importMetaURL] })
 }
 
 export interface ImportModuleOptions extends ResolveModuleOptions {
@@ -31,8 +42,8 @@ export interface ImportModuleOptions extends ResolveModuleOptions {
 }
 
 export async function importModule<T = unknown> (id: string, opts?: ImportModuleOptions) {
-  const resolvedPath = await resolveModule(id, opts)
-  return import(pathToFileURL(resolvedPath).href).then(r => opts?.interopDefault !== false ? interopDefault(r) : r) as Promise<T>
+  const resolvedPath = resolveModule(id, opts)
+  return await import(pathToFileURL(resolvedPath).href).then(r => opts?.interopDefault !== false ? interopDefault(r) : r) as Promise<T>
 }
 
 export function tryImportModule<T = unknown> (id: string, opts?: ImportModuleOptions) {

--- a/packages/kit/src/loader/config.ts
+++ b/packages/kit/src/loader/config.ts
@@ -9,7 +9,7 @@ import { globby } from 'globby'
 import defu from 'defu'
 import { basename, join, relative } from 'pathe'
 import { isWindows } from 'std-env'
-import { tryResolveModule } from '../internal/esm'
+import { directoryToParentURL, tryResolveModule } from '../internal/esm'
 
 export interface LoadNuxtConfigOptions extends Omit<LoadConfigOptions<NuxtConfig>, 'overrides'> {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
@@ -108,11 +108,12 @@ export async function loadNuxtConfig (opts: LoadNuxtConfigOptions): Promise<Nuxt
 }
 
 async function loadNuxtSchema (cwd: string) {
-  const paths = [cwd]
-  const nuxtPath = await tryResolveModule('nuxt', cwd) ?? await tryResolveModule('nuxt-nightly', cwd)
+  const url = directoryToParentURL(cwd)
+  const urls = [url]
+  const nuxtPath = await tryResolveModule('nuxt', url) ?? await tryResolveModule('nuxt-nightly', url)
   if (nuxtPath) {
-    paths.unshift(nuxtPath)
+    urls.unshift(new URL(nuxtPath))
   }
-  const schemaPath = await tryResolveModule('@nuxt/schema', paths) ?? '@nuxt/schema'
+  const schemaPath = await tryResolveModule('@nuxt/schema', urls) ?? '@nuxt/schema'
   return await import(isWindows ? pathToFileURL(schemaPath).href : schemaPath).then(r => r.NuxtConfigSchema)
 }

--- a/packages/kit/src/loader/config.ts
+++ b/packages/kit/src/loader/config.ts
@@ -9,7 +9,7 @@ import { globby } from 'globby'
 import defu from 'defu'
 import { basename, join, relative } from 'pathe'
 import { isWindows } from 'std-env'
-import { directoryToParentURL, tryResolveModule } from '../internal/esm'
+import { directoryToURL, tryResolveModule } from '../internal/esm'
 
 export interface LoadNuxtConfigOptions extends Omit<LoadConfigOptions<NuxtConfig>, 'overrides'> {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
@@ -108,7 +108,7 @@ export async function loadNuxtConfig (opts: LoadNuxtConfigOptions): Promise<Nuxt
 }
 
 async function loadNuxtSchema (cwd: string) {
-  const url = directoryToParentURL(cwd)
+  const url = directoryToURL(cwd)
   const urls = [url]
   const nuxtPath = await tryResolveModule('nuxt', url) ?? await tryResolveModule('nuxt-nightly', url)
   if (nuxtPath) {

--- a/packages/kit/src/loader/config.ts
+++ b/packages/kit/src/loader/config.ts
@@ -112,7 +112,7 @@ async function loadNuxtSchema (cwd: string) {
   const urls = [url]
   const nuxtPath = await tryResolveModule('nuxt', url) ?? await tryResolveModule('nuxt-nightly', url)
   if (nuxtPath) {
-    urls.unshift(new URL(nuxtPath))
+    urls.unshift(pathToFileURL(nuxtPath))
   }
   const schemaPath = await tryResolveModule('@nuxt/schema', urls) ?? '@nuxt/schema'
   return await import(isWindows ? pathToFileURL(schemaPath).href : schemaPath).then(r => r.NuxtConfigSchema)

--- a/packages/kit/src/loader/nuxt.ts
+++ b/packages/kit/src/loader/nuxt.ts
@@ -1,9 +1,7 @@
-import { pathToFileURL } from 'node:url'
 import { readPackageJSON, resolvePackageJSON } from 'pkg-types'
 import type { Nuxt, NuxtConfig } from '@nuxt/schema'
 import { resolve } from 'pathe'
-import { withTrailingSlash } from 'ufo'
-import { importModule, tryImportModule } from '../internal/esm'
+import { directoryToParentURL, importModule, tryImportModule } from '../internal/esm'
 import { runWithNuxtContext } from '../context'
 import type { LoadNuxtConfigOptions } from './config'
 
@@ -23,24 +21,24 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
   // Apply dev as config override
   opts.overrides.dev = !!opts.dev
 
-  const rootDir = withTrailingSlash(pathToFileURL(opts.cwd!).href)
+  const rootURL = directoryToParentURL(opts.cwd!)
 
   const nearestNuxtPkg = await Promise.all(['nuxt-nightly', 'nuxt']
-    .map(pkg => resolvePackageJSON(pkg, { url: rootDir }).catch(() => null)))
+    .map(pkg => resolvePackageJSON(pkg, { url: rootURL }).catch(() => null)))
     .then(r => (r.filter(Boolean) as string[]).sort((a, b) => b.length - a.length)[0])
   if (!nearestNuxtPkg) {
     throw new Error(`Cannot find any nuxt version from ${opts.cwd}`)
   }
   const pkg = await readPackageJSON(nearestNuxtPkg)
 
-  const { loadNuxt } = await importModule<typeof import('nuxt')>((pkg as any)._name || pkg.name, { paths: rootDir })
+  const { loadNuxt } = await importModule<typeof import('nuxt')>((pkg as any)._name || pkg.name, { url: rootURL })
   const nuxt = await loadNuxt(opts)
   return nuxt
 }
 
 export async function buildNuxt (nuxt: Nuxt): Promise<any> {
-  const rootDir = withTrailingSlash(pathToFileURL(nuxt.options.rootDir).href)
+  const rootURL = directoryToParentURL(nuxt.options.rootDir)
 
-  const { build } = await tryImportModule<typeof import('nuxt')>('nuxt-nightly', { paths: rootDir }) || await importModule<typeof import('nuxt')>('nuxt', { paths: rootDir })
+  const { build } = await tryImportModule<typeof import('nuxt')>('nuxt-nightly', { url: rootURL }) || await importModule<typeof import('nuxt')>('nuxt', { url: rootURL })
   return runWithNuxtContext(nuxt, () => build(nuxt))
 }

--- a/packages/kit/src/loader/nuxt.ts
+++ b/packages/kit/src/loader/nuxt.ts
@@ -1,7 +1,7 @@
 import { readPackageJSON, resolvePackageJSON } from 'pkg-types'
 import type { Nuxt, NuxtConfig } from '@nuxt/schema'
 import { resolve } from 'pathe'
-import { directoryToParentURL, importModule, tryImportModule } from '../internal/esm'
+import { directoryToURL, importModule, tryImportModule } from '../internal/esm'
 import { runWithNuxtContext } from '../context'
 import type { LoadNuxtConfigOptions } from './config'
 
@@ -21,7 +21,7 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
   // Apply dev as config override
   opts.overrides.dev = !!opts.dev
 
-  const rootURL = directoryToParentURL(opts.cwd!)
+  const rootURL = directoryToURL(opts.cwd!)
 
   const nearestNuxtPkg = await Promise.all(['nuxt-nightly', 'nuxt']
     .map(pkg => resolvePackageJSON(pkg, { url: rootURL }).catch(() => null)))
@@ -37,7 +37,7 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
 }
 
 export async function buildNuxt (nuxt: Nuxt): Promise<any> {
-  const rootURL = directoryToParentURL(nuxt.options.rootDir)
+  const rootURL = directoryToURL(nuxt.options.rootDir)
 
   const { build } = await tryImportModule<typeof import('nuxt')>('nuxt-nightly', { url: rootURL }) || await importModule<typeof import('nuxt')>('nuxt', { url: rootURL })
   return runWithNuxtContext(nuxt, () => build(nuxt))

--- a/packages/kit/src/module/install.ts
+++ b/packages/kit/src/module/install.ts
@@ -6,6 +6,7 @@ import { defu } from 'defu'
 import { createJiti } from 'jiti'
 import { parseNodeModulePath, resolve as resolveModule } from 'mlly'
 import { isRelative } from 'ufo'
+import { directoryToParentURL } from '../internal/esm'
 import { useNuxt } from '../context'
 import { resolveAlias, resolvePath } from '../resolve'
 import { logger } from '../logger'
@@ -101,7 +102,10 @@ export async function loadNuxtModuleInstance (nuxtModule: string | NuxtModule, n
       try {
         const src = isAbsolute(path)
           ? pathToFileURL(await resolvePath(path, { fallbackToOriginal: false, extensions: nuxt.options.extensions })).href
-          : await resolveModule(path, { url: nuxt.options.modulesDir.map(m => pathToFileURL(m.replace(/\/node_modules\/?$/, ''))), extensions: nuxt.options.extensions })
+          : await resolveModule(path, {
+            url: nuxt.options.modulesDir.map(m => directoryToParentURL(m.replace(/\/node_modules\/?$/, '/'))),
+            extensions: nuxt.options.extensions,
+          })
 
         nuxtModule = await jiti.import(src, { default: true }) as NuxtModule
         resolvedModulePath = fileURLToPath(new URL(src))

--- a/packages/kit/src/module/install.ts
+++ b/packages/kit/src/module/install.ts
@@ -6,7 +6,7 @@ import { defu } from 'defu'
 import { createJiti } from 'jiti'
 import { parseNodeModulePath, resolve as resolveModule } from 'mlly'
 import { isRelative } from 'ufo'
-import { directoryToParentURL } from '../internal/esm'
+import { directoryToURL } from '../internal/esm'
 import { useNuxt } from '../context'
 import { resolveAlias, resolvePath } from '../resolve'
 import { logger } from '../logger'
@@ -103,7 +103,7 @@ export async function loadNuxtModuleInstance (nuxtModule: string | NuxtModule, n
         const src = isAbsolute(path)
           ? pathToFileURL(await resolvePath(path, { fallbackToOriginal: false, extensions: nuxt.options.extensions })).href
           : await resolveModule(path, {
-            url: nuxt.options.modulesDir.map(m => directoryToParentURL(m.replace(/\/node_modules\/?$/, '/'))),
+            url: nuxt.options.modulesDir.map(m => directoryToURL(m.replace(/\/node_modules\/?$/, '/'))),
             extensions: nuxt.options.extensions,
           })
 

--- a/packages/kit/src/resolve.ts
+++ b/packages/kit/src/resolve.ts
@@ -4,10 +4,10 @@ import { basename, dirname, isAbsolute, join, normalize, resolve } from 'pathe'
 import { globby } from 'globby'
 import { resolvePath as _resolvePath } from 'mlly'
 import { resolveAlias as _resolveAlias } from 'pathe/utils'
+import { directoryToParentURL } from './internal/esm'
 import { tryUseNuxt } from './context'
 import { isIgnored } from './ignore'
 import { toArray } from './utils'
-import { directoryToParentURL } from 'nuxt/kit'
 
 export interface ResolvePathOptions {
   /** Base for resolving paths from. Default is Nuxt rootDir. */

--- a/packages/kit/src/resolve.ts
+++ b/packages/kit/src/resolve.ts
@@ -4,7 +4,7 @@ import { basename, dirname, isAbsolute, join, normalize, resolve } from 'pathe'
 import { globby } from 'globby'
 import { resolvePath as _resolvePath } from 'mlly'
 import { resolveAlias as _resolveAlias } from 'pathe/utils'
-import { directoryToParentURL } from './internal/esm'
+import { directoryToURL } from './internal/esm'
 import { tryUseNuxt } from './context'
 import { isIgnored } from './ignore'
 import { toArray } from './utils'
@@ -202,7 +202,7 @@ async function _resolvePathGranularly (path: string, opts: ResolvePathOptions = 
   }
 
   // Try to resolve as module id
-  const resolvedModulePath = await _resolvePath(_path, { url: [cwd, ...modulesDir].map(d => directoryToParentURL(d)) }).catch(() => null)
+  const resolvedModulePath = await _resolvePath(_path, { url: [cwd, ...modulesDir].map(d => directoryToURL(d)) }).catch(() => null)
   if (resolvedModulePath) {
     return {
       path: resolvedModulePath,

--- a/packages/kit/src/resolve.ts
+++ b/packages/kit/src/resolve.ts
@@ -7,6 +7,7 @@ import { resolveAlias as _resolveAlias } from 'pathe/utils'
 import { tryUseNuxt } from './context'
 import { isIgnored } from './ignore'
 import { toArray } from './utils'
+import { directoryToParentURL } from 'nuxt/kit'
 
 export interface ResolvePathOptions {
   /** Base for resolving paths from. Default is Nuxt rootDir. */
@@ -201,7 +202,7 @@ async function _resolvePathGranularly (path: string, opts: ResolvePathOptions = 
   }
 
   // Try to resolve as module id
-  const resolvedModulePath = await _resolvePath(_path, { url: [cwd, ...modulesDir] }).catch(() => null)
+  const resolvedModulePath = await _resolvePath(_path, { url: [cwd, ...modulesDir].map(d => directoryToParentURL(d)) }).catch(() => null)
   if (resolvedModulePath) {
     return {
       path: resolvedModulePath,

--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -9,7 +9,7 @@ import { gte } from 'semver'
 import { readPackageJSON } from 'pkg-types'
 
 import { filterInPlace } from './utils'
-import { tryResolveModule } from './internal/esm'
+import { directoryToParentURL, tryResolveModule } from './internal/esm'
 import { getDirectory } from './module/install'
 import { tryUseNuxt, useNuxt } from './context'
 import { resolveNuxtModule } from './resolve'
@@ -244,6 +244,8 @@ export async function _generateTypes (nuxt: Nuxt) {
   tsConfig.compilerOptions.paths ||= {}
   tsConfig.include ||= []
 
+  const importPaths = nuxt.options.modulesDir.map(d => directoryToParentURL(d))
+
   for (const alias in aliases) {
     if (excludedAlias.some(re => re.test(alias))) {
       continue
@@ -251,7 +253,7 @@ export async function _generateTypes (nuxt: Nuxt) {
     let absolutePath = resolve(basePath, aliases[alias]!)
     let stats = await fsp.stat(absolutePath).catch(() => null /* file does not exist */)
     if (!stats) {
-      const resolvedModule = await tryResolveModule(aliases[alias]!, nuxt.options.modulesDir)
+      const resolvedModule = await tryResolveModule(aliases[alias]!, importPaths)
       if (resolvedModule) {
         absolutePath = resolvedModule
         stats = await fsp.stat(resolvedModule).catch(() => null)

--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -9,7 +9,7 @@ import { gte } from 'semver'
 import { readPackageJSON } from 'pkg-types'
 
 import { filterInPlace } from './utils'
-import { directoryToParentURL, tryResolveModule } from './internal/esm'
+import { directoryToURL, tryResolveModule } from './internal/esm'
 import { getDirectory } from './module/install'
 import { tryUseNuxt, useNuxt } from './context'
 import { resolveNuxtModule } from './resolve'
@@ -244,7 +244,7 @@ export async function _generateTypes (nuxt: Nuxt) {
   tsConfig.compilerOptions.paths ||= {}
   tsConfig.include ||= []
 
-  const importPaths = nuxt.options.modulesDir.map(d => directoryToParentURL(d))
+  const importPaths = nuxt.options.modulesDir.map(d => directoryToURL(d))
 
   for (const alias in aliases) {
     if (excludedAlias.some(re => re.test(alias))) {

--- a/packages/nuxt/src/core/builder.ts
+++ b/packages/nuxt/src/core/builder.ts
@@ -1,7 +1,7 @@
 import type { EventType } from '@parcel/watcher'
 import type { FSWatcher } from 'chokidar'
 import { watch as chokidarWatch } from 'chokidar'
-import { createIsIgnored, importModule, isIgnored, tryResolveModule, useNuxt } from '@nuxt/kit'
+import { createIsIgnored, directoryToParentURL, importModule, isIgnored, tryResolveModule, useNuxt } from '@nuxt/kit'
 import { debounce } from 'perfect-debounce'
 import { normalize, relative, resolve } from 'pathe'
 import type { Nuxt, NuxtBuilder } from 'nuxt/schema'
@@ -193,7 +193,7 @@ async function createParcelWatcher () {
     // eslint-disable-next-line no-console
     console.time('[nuxt] builder:parcel:watch')
   }
-  const watcherPath = await tryResolveModule('@parcel/watcher', [nuxt.options.rootDir, ...nuxt.options.modulesDir])
+  const watcherPath = await tryResolveModule('@parcel/watcher', [nuxt.options.rootDir, ...nuxt.options.modulesDir].map(d => directoryToParentURL(d)))
   if (!watcherPath) {
     logger.warn('Falling back to `chokidar-granular` as `@parcel/watcher` cannot be resolved in your project.')
     return false
@@ -244,7 +244,7 @@ async function bundle (nuxt: Nuxt) {
 }
 
 async function loadBuilder (nuxt: Nuxt, builder: string): Promise<NuxtBuilder> {
-  const builderPath = await tryResolveModule(builder, [nuxt.options.rootDir, import.meta.url])
+  const builderPath = await tryResolveModule(builder, [directoryToParentURL(nuxt.options.rootDir), new URL(import.meta.url)])
 
   if (!builderPath) {
     throw new Error(`Loading \`${builder}\` builder failed. You can read more about the nuxt \`builder\` option at: \`https://nuxt.com/docs/api/nuxt-config#builder\``)

--- a/packages/nuxt/src/core/builder.ts
+++ b/packages/nuxt/src/core/builder.ts
@@ -1,7 +1,7 @@
 import type { EventType } from '@parcel/watcher'
 import type { FSWatcher } from 'chokidar'
 import { watch as chokidarWatch } from 'chokidar'
-import { createIsIgnored, directoryToParentURL, importModule, isIgnored, tryResolveModule, useNuxt } from '@nuxt/kit'
+import { createIsIgnored, directoryToURL, importModule, isIgnored, tryResolveModule, useNuxt } from '@nuxt/kit'
 import { debounce } from 'perfect-debounce'
 import { normalize, relative, resolve } from 'pathe'
 import type { Nuxt, NuxtBuilder } from 'nuxt/schema'
@@ -193,7 +193,7 @@ async function createParcelWatcher () {
     // eslint-disable-next-line no-console
     console.time('[nuxt] builder:parcel:watch')
   }
-  const watcherPath = await tryResolveModule('@parcel/watcher', [nuxt.options.rootDir, ...nuxt.options.modulesDir].map(d => directoryToParentURL(d)))
+  const watcherPath = await tryResolveModule('@parcel/watcher', [nuxt.options.rootDir, ...nuxt.options.modulesDir].map(d => directoryToURL(d)))
   if (!watcherPath) {
     logger.warn('Falling back to `chokidar-granular` as `@parcel/watcher` cannot be resolved in your project.')
     return false
@@ -244,7 +244,7 @@ async function bundle (nuxt: Nuxt) {
 }
 
 async function loadBuilder (nuxt: Nuxt, builder: string): Promise<NuxtBuilder> {
-  const builderPath = await tryResolveModule(builder, [directoryToParentURL(nuxt.options.rootDir), new URL(import.meta.url)])
+  const builderPath = await tryResolveModule(builder, [directoryToURL(nuxt.options.rootDir), new URL(import.meta.url)])
 
   if (!builderPath) {
     throw new Error(`Loading \`${builder}\` builder failed. You can read more about the nuxt \`builder\` option at: \`https://nuxt.com/docs/api/nuxt-config#builder\``)

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -6,7 +6,7 @@ import { join, normalize, relative, resolve } from 'pathe'
 import { createDebugger, createHooks } from 'hookable'
 import ignore from 'ignore'
 import type { LoadNuxtOptions } from '@nuxt/kit'
-import { addBuildPlugin, addComponent, addPlugin, addPluginTemplate, addRouteMiddleware, addServerPlugin, addTypeTemplate, addVitePlugin, addWebpackPlugin, directoryToParentURL, installModule, loadNuxtConfig, nuxtCtx, resolveAlias, resolveFiles, resolveIgnorePatterns, resolvePath, runWithNuxtContext, tryResolveModule, useNitro } from '@nuxt/kit'
+import { addBuildPlugin, addComponent, addPlugin, addPluginTemplate, addRouteMiddleware, addServerPlugin, addTypeTemplate, addVitePlugin, addWebpackPlugin, directoryToURL, installModule, loadNuxtConfig, nuxtCtx, resolveAlias, resolveFiles, resolveIgnorePatterns, resolvePath, runWithNuxtContext, tryResolveModule, useNitro } from '@nuxt/kit'
 import type { Nuxt, NuxtHooks, NuxtModule, NuxtOptions } from 'nuxt/schema'
 import type { PackageJson } from 'pkg-types'
 import { readPackageJSON } from 'pkg-types'
@@ -391,7 +391,7 @@ async function initNuxt (nuxt: Nuxt) {
   }
 
   nuxt.hook('modules:done', async () => {
-    const importPaths = nuxt.options.modulesDir.map(dir => directoryToParentURL((dir)))
+    const importPaths = nuxt.options.modulesDir.map(dir => directoryToURL((dir)))
     // Add unctx transform
     addBuildPlugin(UnctxTransformPlugin({
       sourcemap: !!nuxt.options.sourcemap.server || !!nuxt.options.sourcemap.client,

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -6,7 +6,7 @@ import { join, normalize, relative, resolve } from 'pathe'
 import { createDebugger, createHooks } from 'hookable'
 import ignore from 'ignore'
 import type { LoadNuxtOptions } from '@nuxt/kit'
-import { addBuildPlugin, addComponent, addPlugin, addPluginTemplate, addRouteMiddleware, addServerPlugin, addTypeTemplate, addVitePlugin, addWebpackPlugin, installModule, loadNuxtConfig, nuxtCtx, resolveAlias, resolveFiles, resolveIgnorePatterns, resolvePath, runWithNuxtContext, tryResolveModule, useNitro } from '@nuxt/kit'
+import { addBuildPlugin, addComponent, addPlugin, addPluginTemplate, addRouteMiddleware, addServerPlugin, addTypeTemplate, addVitePlugin, addWebpackPlugin, directoryToParentURL, installModule, loadNuxtConfig, nuxtCtx, resolveAlias, resolveFiles, resolveIgnorePatterns, resolvePath, runWithNuxtContext, tryResolveModule, useNitro } from '@nuxt/kit'
 import type { Nuxt, NuxtHooks, NuxtModule, NuxtOptions } from 'nuxt/schema'
 import type { PackageJson } from 'pkg-types'
 import { readPackageJSON } from 'pkg-types'
@@ -391,12 +391,13 @@ async function initNuxt (nuxt: Nuxt) {
   }
 
   nuxt.hook('modules:done', async () => {
+    const importPaths = nuxt.options.modulesDir.map(dir => directoryToParentURL((dir)))
     // Add unctx transform
     addBuildPlugin(UnctxTransformPlugin({
       sourcemap: !!nuxt.options.sourcemap.server || !!nuxt.options.sourcemap.client,
       transformerOptions: {
         ...nuxt.options.optimization.asyncTransforms,
-        helperModule: await tryResolveModule('unctx', nuxt.options.modulesDir) ?? 'unctx',
+        helperModule: await tryResolveModule('unctx', importPaths) ?? 'unctx',
       },
     }))
 

--- a/packages/nuxt/src/core/plugins/resolve-deep-imports.ts
+++ b/packages/nuxt/src/core/plugins/resolve-deep-imports.ts
@@ -1,7 +1,7 @@
 import { parseNodeModulePath, resolvePath } from 'mlly'
 import { isAbsolute, normalize } from 'pathe'
 import type { Plugin } from 'vite'
-import { directoryToParentURL, resolveAlias } from '@nuxt/kit'
+import { directoryToURL, resolveAlias } from '@nuxt/kit'
 import type { Nuxt } from '@nuxt/schema'
 
 import { pkgDir } from '../../dirs'
@@ -37,7 +37,7 @@ export function resolveDeepImportsPlugin (nuxt: Nuxt): Plugin {
       const dir = parseNodeModulePath(normalisedImporter).dir || pkgDir
 
       return await this.resolve?.(normalisedId, dir, { skipSelf: true }) ?? await resolvePath(id, {
-        url: [dir, ...nuxt.options.modulesDir].map(d => directoryToParentURL(d)),
+        url: [dir, ...nuxt.options.modulesDir].map(d => directoryToURL(d)),
         conditions,
       }).catch(() => {
         logger.debug('Could not resolve id', id, importer)

--- a/packages/nuxt/src/core/plugins/resolve-deep-imports.ts
+++ b/packages/nuxt/src/core/plugins/resolve-deep-imports.ts
@@ -1,7 +1,7 @@
 import { parseNodeModulePath, resolvePath } from 'mlly'
 import { isAbsolute, normalize } from 'pathe'
 import type { Plugin } from 'vite'
-import { resolveAlias } from '@nuxt/kit'
+import { directoryToParentURL, resolveAlias } from '@nuxt/kit'
 import type { Nuxt } from '@nuxt/schema'
 
 import { pkgDir } from '../../dirs'
@@ -37,7 +37,7 @@ export function resolveDeepImportsPlugin (nuxt: Nuxt): Plugin {
       const dir = parseNodeModulePath(normalisedImporter).dir || pkgDir
 
       return await this.resolve?.(normalisedId, dir, { skipSelf: true }) ?? await resolvePath(id, {
-        url: [dir, ...nuxt.options.modulesDir],
+        url: [dir, ...nuxt.options.modulesDir].map(d => directoryToParentURL(d)),
         conditions,
       }).catch(() => {
         logger.debug('Could not resolve id', id, importer)

--- a/packages/nuxt/src/core/schema.ts
+++ b/packages/nuxt/src/core/schema.ts
@@ -5,7 +5,7 @@ import { resolve } from 'pathe'
 import { watch } from 'chokidar'
 import { defu } from 'defu'
 import { debounce } from 'perfect-debounce'
-import { createIsIgnored, createResolver, defineNuxtModule, importModule, tryResolveModule } from '@nuxt/kit'
+import { createIsIgnored, createResolver, defineNuxtModule, directoryToParentURL, importModule, tryResolveModule } from '@nuxt/kit'
 import { generateTypes, resolveSchema as resolveUntypedSchema } from 'untyped'
 import type { Schema, SchemaDefinition } from 'untyped'
 import untypedPlugin from 'untyped/babel-plugin'
@@ -54,7 +54,7 @@ export default defineNuxtModule({
       })
 
       if (nuxt.options.experimental.watcher === 'parcel') {
-        const watcherPath = await tryResolveModule('@parcel/watcher', [nuxt.options.rootDir, ...nuxt.options.modulesDir])
+        const watcherPath = await tryResolveModule('@parcel/watcher', [nuxt.options.rootDir, ...nuxt.options.modulesDir].map(dir => directoryToParentURL(dir)))
         if (watcherPath) {
           const { subscribe } = await importModule<typeof import('@parcel/watcher')>(watcherPath)
           for (const layer of nuxt.options._layers) {

--- a/packages/nuxt/src/core/schema.ts
+++ b/packages/nuxt/src/core/schema.ts
@@ -5,7 +5,7 @@ import { resolve } from 'pathe'
 import { watch } from 'chokidar'
 import { defu } from 'defu'
 import { debounce } from 'perfect-debounce'
-import { createIsIgnored, createResolver, defineNuxtModule, directoryToParentURL, importModule, tryResolveModule } from '@nuxt/kit'
+import { createIsIgnored, createResolver, defineNuxtModule, directoryToURL, importModule, tryResolveModule } from '@nuxt/kit'
 import { generateTypes, resolveSchema as resolveUntypedSchema } from 'untyped'
 import type { Schema, SchemaDefinition } from 'untyped'
 import untypedPlugin from 'untyped/babel-plugin'
@@ -54,7 +54,7 @@ export default defineNuxtModule({
       })
 
       if (nuxt.options.experimental.watcher === 'parcel') {
-        const watcherPath = await tryResolveModule('@parcel/watcher', [nuxt.options.rootDir, ...nuxt.options.modulesDir].map(dir => directoryToParentURL(dir)))
+        const watcherPath = await tryResolveModule('@parcel/watcher', [nuxt.options.rootDir, ...nuxt.options.modulesDir].map(dir => directoryToURL(dir)))
         if (watcherPath) {
           const { subscribe } = await importModule<typeof import('@parcel/watcher')>(watcherPath)
           for (const layer of nuxt.options._layers) {

--- a/packages/nuxt/src/core/utils/types.ts
+++ b/packages/nuxt/src/core/utils/types.ts
@@ -1,11 +1,11 @@
 import { resolvePackageJSON } from 'pkg-types'
 import { resolvePath as _resolvePath } from 'mlly'
 import { dirname } from 'pathe'
-import { directoryToParentURL, tryUseNuxt } from '@nuxt/kit'
+import { directoryToURL, tryUseNuxt } from '@nuxt/kit'
 
 export async function resolveTypePath (path: string, subpath: string, searchPaths = tryUseNuxt()?.options.modulesDir) {
   try {
-    const r = await _resolvePath(path, { url: searchPaths?.map(d => directoryToParentURL(d)), conditions: ['types', 'import', 'require'] })
+    const r = await _resolvePath(path, { url: searchPaths?.map(d => directoryToURL(d)), conditions: ['types', 'import', 'require'] })
     if (subpath) {
       return r.replace(/(?:\.d)?\.[mc]?[jt]s$/, '')
     }

--- a/packages/nuxt/src/core/utils/types.ts
+++ b/packages/nuxt/src/core/utils/types.ts
@@ -1,11 +1,11 @@
 import { resolvePackageJSON } from 'pkg-types'
 import { resolvePath as _resolvePath } from 'mlly'
 import { dirname } from 'pathe'
-import { tryUseNuxt } from '@nuxt/kit'
+import { directoryToParentURL, tryUseNuxt } from '@nuxt/kit'
 
 export async function resolveTypePath (path: string, subpath: string, searchPaths = tryUseNuxt()?.options.modulesDir) {
   try {
-    const r = await _resolvePath(path, { url: searchPaths, conditions: ['types', 'import', 'require'] })
+    const r = await _resolvePath(path, { url: searchPaths?.map(d => directoryToParentURL(d)), conditions: ['types', 'import', 'require'] })
     if (subpath) {
       return r.replace(/(?:\.d)?\.[mc]?[jt]s$/, '')
     }

--- a/packages/nuxt/src/head/module.ts
+++ b/packages/nuxt/src/head/module.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'pathe'
-import { addComponent, addImportsSources, addPlugin, addTemplate, defineNuxtModule, tryResolveModule } from '@nuxt/kit'
+import { addComponent, addImportsSources, addPlugin, addTemplate, defineNuxtModule, directoryToParentURL, tryResolveModule } from '@nuxt/kit'
 import type { NuxtOptions } from '@nuxt/schema'
 import { distDir } from '../dirs'
 
@@ -52,7 +52,8 @@ export default defineNuxtModule<NuxtOptions['unhead']>({
     })
 
     // Opt-out feature allowing dependencies using @vueuse/head to work
-    const unheadVue = await tryResolveModule('@unhead/vue', nuxt.options.modulesDir) || '@unhead/vue'
+    const importPaths = nuxt.options.modulesDir.map(d => directoryToParentURL(d))
+    const unheadVue = await tryResolveModule('@unhead/vue', importPaths) || '@unhead/vue'
 
     addTemplate({
       filename: 'unhead-plugins.mjs',

--- a/packages/nuxt/src/head/module.ts
+++ b/packages/nuxt/src/head/module.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'pathe'
-import { addComponent, addImportsSources, addPlugin, addTemplate, defineNuxtModule, directoryToParentURL, tryResolveModule } from '@nuxt/kit'
+import { addComponent, addImportsSources, addPlugin, addTemplate, defineNuxtModule, directoryToURL, tryResolveModule } from '@nuxt/kit'
 import type { NuxtOptions } from '@nuxt/schema'
 import { distDir } from '../dirs'
 
@@ -52,7 +52,7 @@ export default defineNuxtModule<NuxtOptions['unhead']>({
     })
 
     // Opt-out feature allowing dependencies using @vueuse/head to work
-    const importPaths = nuxt.options.modulesDir.map(d => directoryToParentURL(d))
+    const importPaths = nuxt.options.modulesDir.map(d => directoryToURL(d))
     const unheadVue = await tryResolveModule('@unhead/vue', importPaths) || '@unhead/vue'
 
     addTemplate({

--- a/packages/nuxt/src/imports/module.ts
+++ b/packages/nuxt/src/imports/module.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs'
-import { addBuildPlugin, addTemplate, addTypeTemplate, createIsIgnored, defineNuxtModule, directoryToParentURL, resolveAlias, tryResolveModule, updateTemplates, useNuxt } from '@nuxt/kit'
+import { addBuildPlugin, addTemplate, addTypeTemplate, createIsIgnored, defineNuxtModule, directoryToURL, resolveAlias, tryResolveModule, updateTemplates, useNuxt } from '@nuxt/kit'
 import { isAbsolute, join, normalize, relative, resolve } from 'pathe'
 import type { Import, Unimport } from 'unimport'
 import { createUnimport, scanDirExports, toExports } from 'unimport'
@@ -181,7 +181,7 @@ function addDeclarationTemplates (ctx: Unimport, options: Partial<ImportsOptions
 
   const SUPPORTED_EXTENSION_RE = new RegExp(`\\.(${nuxt.options.extensions.map(i => i.replace('.', '')).join('|')})$`)
 
-  const importPaths = nuxt.options.modulesDir.map(dir => directoryToParentURL(dir))
+  const importPaths = nuxt.options.modulesDir.map(dir => directoryToURL(dir))
 
   async function cacheImportPaths (imports: Import[]) {
     const importSource = Array.from(new Set(imports.map(i => i.from)))

--- a/packages/nuxt/src/imports/module.ts
+++ b/packages/nuxt/src/imports/module.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs'
-import { addBuildPlugin, addTemplate, addTypeTemplate, createIsIgnored, defineNuxtModule, resolveAlias, tryResolveModule, updateTemplates, useNuxt } from '@nuxt/kit'
+import { addBuildPlugin, addTemplate, addTypeTemplate, createIsIgnored, defineNuxtModule, directoryToParentURL, resolveAlias, tryResolveModule, updateTemplates, useNuxt } from '@nuxt/kit'
 import { isAbsolute, join, normalize, relative, resolve } from 'pathe'
 import type { Import, Unimport } from 'unimport'
 import { createUnimport, scanDirExports, toExports } from 'unimport'
@@ -181,6 +181,8 @@ function addDeclarationTemplates (ctx: Unimport, options: Partial<ImportsOptions
 
   const SUPPORTED_EXTENSION_RE = new RegExp(`\\.(${nuxt.options.extensions.map(i => i.replace('.', '')).join('|')})$`)
 
+  const importPaths = nuxt.options.modulesDir.map(dir => directoryToParentURL(dir))
+
   async function cacheImportPaths (imports: Import[]) {
     const importSource = Array.from(new Set(imports.map(i => i.from)))
     // skip relative import paths for node_modules that are explicitly installed
@@ -190,7 +192,7 @@ function addDeclarationTemplates (ctx: Unimport, options: Partial<ImportsOptions
       }
       let path = resolveAlias(from)
       if (!isAbsolute(path)) {
-        path = await tryResolveModule(from, nuxt.options.modulesDir).then(async (r) => {
+        path = await tryResolveModule(from, importPaths).then(async (r) => {
           if (!r) { return r }
 
           const { dir, name } = parseNodeModulePath(r)

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -2,7 +2,7 @@ import { resolve } from 'pathe'
 import * as vite from 'vite'
 import vuePlugin from '@vitejs/plugin-vue'
 import viteJsxPlugin from '@vitejs/plugin-vue-jsx'
-import { directoryToParentURL, logger, resolvePath, tryImportModule } from '@nuxt/kit'
+import { directoryToURL, logger, resolvePath, tryImportModule } from '@nuxt/kit'
 import { joinURL, withTrailingSlash, withoutLeadingSlash } from 'ufo'
 import type { ViteConfig } from '@nuxt/schema'
 import defu from 'defu'
@@ -117,7 +117,7 @@ export async function buildServer (ctx: ViteBuildContext) {
 
   if (!ctx.nuxt.options.dev) {
     const { runtimeDependencies = [] } = await tryImportModule<typeof import('nitro/runtime/meta')>('nitro/runtime/meta', {
-      url: ctx.nuxt.options.modulesDir.map(d => directoryToParentURL(d)),
+      url: ctx.nuxt.options.modulesDir.map(d => directoryToURL(d)),
     }) || {}
     if (Array.isArray(serverConfig.ssr!.external)) {
       serverConfig.ssr!.external.push(

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -2,7 +2,7 @@ import { resolve } from 'pathe'
 import * as vite from 'vite'
 import vuePlugin from '@vitejs/plugin-vue'
 import viteJsxPlugin from '@vitejs/plugin-vue-jsx'
-import { logger, resolvePath, tryImportModule } from '@nuxt/kit'
+import { directoryToParentURL, logger, resolvePath, tryImportModule } from '@nuxt/kit'
 import { joinURL, withTrailingSlash, withoutLeadingSlash } from 'ufo'
 import type { ViteConfig } from '@nuxt/schema'
 import defu from 'defu'
@@ -117,7 +117,7 @@ export async function buildServer (ctx: ViteBuildContext) {
 
   if (!ctx.nuxt.options.dev) {
     const { runtimeDependencies = [] } = await tryImportModule<typeof import('nitro/runtime/meta')>('nitro/runtime/meta', {
-      paths: ctx.nuxt.options.modulesDir,
+      url: ctx.nuxt.options.modulesDir.map(d => directoryToParentURL(d)),
     }) || {}
     if (Array.isArray(serverConfig.ssr!.external)) {
       serverConfig.ssr!.external.push(


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this should improve perf with import path resolution because we can avoid an extra fs stat call and accurately communicate that paths like `nuxt.options.modulesDir` are directories and not paths.