### PR TITLE
fix: use tsx loader for jsx as well

### DIFF
--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -192,7 +192,7 @@ export function extractScriptContent (sfc: string) {
   for (const match of sfc.matchAll(SFC_SCRIPT_RE)) {
     if (match?.groups?.content) {
       contents.push({
-        loader: match.groups.attrs?.includes('tsx') ? 'tsx' : 'ts',
+        loader: match.groups.attrs && /[tj]sx/.test(match.groups.attrs) ? 'tsx' : 'ts',
         code: match.groups.content.trim(),
       })
     }

--- a/packages/nuxt/test/page-metadata.test.ts
+++ b/packages/nuxt/test/page-metadata.test.ts
@@ -42,6 +42,19 @@ export default {
     })
   })
 
+  it('should parse lang="jsx" from vue files', async () => {
+    const fileContents = `
+  <script setup lang="jsx">
+  const foo = <></>;
+  definePageMeta({ name: 'bar' })
+  </script>`
+
+    const meta = await getRouteMeta(fileContents, `/app/pages/index.vue`)
+    expect(meta).toStrictEqual({
+      name: 'bar',
+    })
+  })
+
   // TODO: https://github.com/nuxt/nuxt/pull/30066
   it.todo('should handle experimental decorators', async () => {
     const fileContents = `


### PR DESCRIPTION
### 🔗 Linked issue
Fixes: https://github.com/nuxt/nuxt/issues/30975
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
When transforming a script, the tsx loader is used when `lang="tsx"`.
It is also necessary to use the tsx loader when `lang="jsx"`.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
