### PR TITLE
fix(kit): expose Nuxt module dependency errors

### DIFF
--- a/packages/kit/src/module/install.ts
+++ b/packages/kit/src/module/install.ts
@@ -129,6 +129,7 @@ export async function loadNuxtModuleInstance (nuxtModule: string | NuxtModule, n
           // i.e module is importing a module that is missing
           if (!module || module.includes(nuxtModule as string)) {
             continue
+          }
         }
         logger.error(`Error while importing module \`${nuxtModule}\`: ${error}`)
         throw error

--- a/packages/kit/src/module/install.ts
+++ b/packages/kit/src/module/install.ts
@@ -118,8 +118,16 @@ export async function loadNuxtModuleInstance (nuxtModule: string | NuxtModule, n
         break
       } catch (error: unknown) {
         const code = (error as Error & { code?: string }).code
-        if (code === 'MODULE_NOT_FOUND' || code === 'ERR_PACKAGE_PATH_NOT_EXPORTED' || code === 'ERR_MODULE_NOT_FOUND' || code === 'ERR_UNSUPPORTED_DIR_IMPORT' || code === 'ENOTDIR') {
+        if (code === 'ERR_PACKAGE_PATH_NOT_EXPORTED' || code === 'ERR_UNSUPPORTED_DIR_IMPORT' || code === 'ENOTDIR') {
           continue
+        }
+        if (code === 'MODULE_NOT_FOUND' || code === 'ERR_MODULE_NOT_FOUND') {
+          // check that the first require stack entry is for a conventional Nuxt module entry
+          // if it is, then it's possible that the module itself has a missing module
+          const lastRequire = (error as Error).stack?.split('\n')?.[2] || ''
+          if (!lastRequire.endsWith(`${nuxtModule}/dist/module.mjs`)) {
+            continue
+          }
         }
         logger.error(`Error while importing module \`${nuxtModule}\`: ${error}`)
         throw error


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
https://github.com/nuxt-modules/og-image/issues/313,
https://github.com/harlan-zw/nuxt-seo/issues/390

Possibly: https://github.com/nuxt-modules/i18n/issues/3289, https://github.com/nuxt-modules/i18n/issues/3318

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

When Nuxt loads a module instance it attempts several paths, these paths predictably will throw errors as they may not exist. These errors are hidden from end users as they're just noise, however, the logic to hide the errors is too aggressive and is stopping some errors from within the module itself from bubbling up.

This makes it difficult for module authors to debug issues, specifically when the issues popping up relate to using specific package managers on specific environments (i.e NPM on Mac).

This issue can be replicated by adding a dependency (e.g. `nuxt-og-image`) and adding a missing dependency import to the `module.mjs` entry

```ts
import missingDep from 'missing-dep'
```

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
