### PR TITLE
fix: remove unimplemented `page:transition:start` type

### DIFF
--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -49,7 +49,6 @@ export interface RuntimeNuxtHooks {
   'link:prefetch': (link: string) => HookResult
   'page:start': (Component?: VNode) => HookResult
   'page:finish': (Component?: VNode) => HookResult
-  'page:transition:start': () => HookResult
   'page:transition:finish': (Component?: VNode) => HookResult
   'page:view-transition:start': (transition: ViewTransition) => HookResult
   'page:loading:start': () => HookResult


### PR DESCRIPTION
### 🔗 Linked issue

Close #31000

### 📚 Description

In the type definitions for hooks, there is a `page:transition:start`, but I couldn’t find any related implementation through a global search.  

Therefore, this PR removes that type definition.  

If there’s anything I might have overlooked, please let me know. I truly appreciate your feedback!
