### PR TITLE
fix(nuxt): use `_` for NuxtIsland name on server pages

### DIFF
--- a/packages/nuxt/src/components/runtime/server-component.ts
+++ b/packages/nuxt/src/components/runtime/server-component.ts
@@ -53,7 +53,7 @@ export const createIslandPage = (name: string) => {
       return () => {
         return h('div', [
           h(NuxtIsland, {
-            name: `page:${name}`,
+            name: `page_${name}`,
             lazy: props.lazy,
             ref: islandRef,
             context: { url: path },

--- a/packages/nuxt/src/components/templates.ts
+++ b/packages/nuxt/src/components/templates.ts
@@ -84,7 +84,7 @@ export const componentsIslandsTemplate: NuxtTemplate = {
     )
 
     const pageExports = pages?.filter(p => (p.mode === 'server' && p.file && p.name)).map((p) => {
-      return `"page:${p.name}": defineAsyncComponent(${genDynamicImport(p.file!)}.then(c => c.default || c))`
+      return `"page_${p.name}": defineAsyncComponent(${genDynamicImport(p.file!)}.then(c => c.default || c))`
     }) || []
 
     return [

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -2510,7 +2510,7 @@ describe('component islands', () => {
     const { page } = await renderPage('/')
 
     const islandPageRequest = page.waitForRequest((req) => {
-      return req.url().includes('/__nuxt_island/page:server-page')
+      return req.url().includes('/__nuxt_island/page_server-page')
     })
     await page.getByText('to server page').click()
     await islandPageRequest


### PR DESCRIPTION
### 📚 Description

This should avoid generating files with `:` in it, potentially creating issues when reading the `dist/` with `unstorage`.