### PR TITLE
docs: Removal of Nuxt 2 mention from the Table of Contents 

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ It provides a number of features that make it easy to build fast, SEO-friendly, 
 - 🧩 [Modules](#modules)
 - ❤️  [Contribute](#contribute)
 - 🏠 [Local Development](#local-development)
-- ⛰️ [Nuxt 2](#nuxt-2)
 - 🛟 [Professional Support](#professional-support)
 - 🔗 [Follow Us](#follow-us)
 - ⚖️ [License](#license)


### PR DESCRIPTION
### 📚 Description

The content itself was deleted in this [commit](https://github.com/awfulness/nuxt/commit/2a864638ee4f236af40d48491ee46fe226e7d8d5)
