### PR TITLE
fix(nuxt): use `ohash` to calculate legacy async data key without hash

### DIFF
--- a/packages/nuxt/src/app/composables/component.ts
+++ b/packages/nuxt/src/app/composables/component.ts
@@ -15,7 +15,7 @@ async function runLegacyAsyncData (res: Record<string, any> | Promise<Record<str
   const vm = getCurrentInstance()!
   const { fetchKey, _fetchKeyBase } = vm.proxy!.$options
   const key = (typeof fetchKey === 'function' ? fetchKey(() => '') : fetchKey) ||
-    ([_fetchKeyBase, route.fullPath, route.matched.findIndex(r => Object.values(r.components || {}).includes(vm.type))].join(':'))
+    ([_fetchKeyBase, route.fullPath.replace(/#.*$/, ''), route.matched.findIndex(r => Object.values(r.components || {}).includes(vm.type))].join(':'))
   const { data, error } = await useAsyncData(`options:asyncdata:${key}`, () => import.meta.server ? nuxtApp.runWithContext(() => fn(nuxtApp)) : fn(nuxtApp))
   if (error.value) {
     throw createError(error.value)

--- a/packages/nuxt/src/app/composables/component.ts
+++ b/packages/nuxt/src/app/composables/component.ts
@@ -1,6 +1,7 @@
 import { getCurrentInstance, reactive, toRefs } from 'vue'
 import type { DefineComponent, defineComponent } from 'vue'
 import { useHead } from '@unhead/vue'
+import { hash } from 'ohash'
 import type { NuxtApp } from '../nuxt'
 import { getNuxtAppCtx, useNuxtApp } from '../nuxt'
 import { useAsyncData } from './asyncData'
@@ -9,13 +10,23 @@ import { createError } from './error'
 
 export const NuxtComponentIndicator = '__nuxt_component'
 
+/* @__NO_SIDE_EFFECTS__ */
+function getFetchKey () {
+  const vm = getCurrentInstance()!
+  const route = useRoute()
+  const { _fetchKeyBase } = vm.proxy!.$options
+  return hash([
+    _fetchKeyBase,
+    route.path,
+    route.query,
+    route.matched.findIndex(r => Object.values(r.components || {}).includes(vm.type)),
+  ])
+}
+
 async function runLegacyAsyncData (res: Record<string, any> | Promise<Record<string, any>>, fn: (nuxtApp: NuxtApp) => Promise<Record<string, any>>) {
   const nuxtApp = useNuxtApp()
-  const route = useRoute()
-  const vm = getCurrentInstance()!
-  const { fetchKey, _fetchKeyBase } = vm.proxy!.$options
-  const key = (typeof fetchKey === 'function' ? fetchKey(() => '') : fetchKey) ||
-    ([_fetchKeyBase, route.fullPath.replace(/#.*$/, ''), route.matched.findIndex(r => Object.values(r.components || {}).includes(vm.type))].join(':'))
+  const { fetchKey } = getCurrentInstance()!.proxy!.$options
+  const key = (typeof fetchKey === 'function' ? fetchKey(() => '') : fetchKey) || getFetchKey()
   const { data, error } = await useAsyncData(`options:asyncdata:${key}`, () => import.meta.server ? nuxtApp.runWithContext(() => fn(nuxtApp)) : fn(nuxtApp))
   if (error.value) {
     throw createError(error.value)


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/30976

### 📚 Description

hash will always mismatch between client + server.

this goes further than just stripping the hash as we also want to avoid mismatch with trailing slash