### PR TITLE
fix(kit,schema): set esbuild target for experimental decorators

### DIFF
--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -200,7 +200,6 @@ export async function _generateTypes (nuxt: Nuxt) {
       /* Decorator support */
       ...useDecorators
         ? {
-            useDefineForClassFields: false,
             experimentalDecorators: false,
           }
         : {},

--- a/packages/schema/src/config/esbuild.ts
+++ b/packages/schema/src/config/esbuild.ts
@@ -14,6 +14,7 @@ export default defineResolvers({
           if (typeof val === 'string') {
             return val
           }
+          // https://github.com/vitejs/vite-plugin-vue/issues/528
           const useDecorators = await get('experimental').then(r => r?.decorators === true)
           if (useDecorators) {
             return 'es2024'

--- a/packages/schema/src/config/esbuild.ts
+++ b/packages/schema/src/config/esbuild.ts
@@ -9,6 +9,18 @@ export default defineResolvers({
      * @type {import('esbuild').TransformOptions}
      */
     options: {
+      target: {
+        $resolve: async (val, get) => {
+          if (typeof val === 'string') {
+            return val
+          }
+          const useDecorators = await get('experimental').then(r => r?.decorators === true)
+          if (useDecorators) {
+            return 'es2024'
+          }
+          return 'esnext'
+        },
+      },
       jsxFactory: 'h',
       jsxFragment: 'Fragment',
       tsconfigRaw: {
@@ -19,12 +31,12 @@ export default defineResolvers({
           if (!useDecorators) {
             return val
           }
-          return defu(val, {
+          // Force experimentalDecorators to false if decorators are enabled
+          return defu({
             compilerOptions: {
-              useDefineForClassFields: false,
               experimentalDecorators: false,
             },
-          } satisfies TransformOptions['tsconfigRaw'])
+          } satisfies TransformOptions['tsconfigRaw'], val)
         },
       },
     },


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

following on from https://github.com/nuxt/nuxt/pull/27672, this avoids disabling `useDefineForClassFields` and instead uses an esbuild target to work around an upstream bug: https://github.com/vitejs/vite-plugin-vue/issues/528.

(We can remove once this is done.)

`esnext` is the default value for esbuild transformations ([docs](https://esbuild.github.io/api/#target))