### PR TITLE
fix(nuxt,schema): resolve `shared` dir from config

### DIFF
--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -57,8 +57,8 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
         continue
       }
 
-      sharedDirs.add(resolve(layer.config.rootDir, 'shared', 'utils'))
-      sharedDirs.add(resolve(layer.config.rootDir, 'shared', 'types'))
+      sharedDirs.add(resolve(layer.config.rootDir, layer.config.dir?.shared ?? 'shared', 'utils'))
+      sharedDirs.add(resolve(layer.config.rootDir, layer.config.dir?.shared ?? 'shared', 'types'))
     }
   }
 

--- a/packages/nuxt/src/imports/module.ts
+++ b/packages/nuxt/src/imports/module.ts
@@ -79,8 +79,8 @@ export default defineNuxtModule<Partial<ImportsOptions>>({
         composablesDirs.push(resolve(layer.config.srcDir, 'utils'))
 
         if (isNuxtV4) {
-          composablesDirs.push(resolve(layer.config.rootDir, 'shared', 'utils'))
-          composablesDirs.push(resolve(layer.config.rootDir, 'shared', 'types'))
+          composablesDirs.push(resolve(layer.config.rootDir, layer.config.dir?.shared ?? 'shared', 'utils'))
+          composablesDirs.push(resolve(layer.config.rootDir, layer.config.dir?.shared ?? 'shared', 'types'))
         }
 
         for (const dir of (layer.config.imports?.dirs ?? [])) {

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -405,7 +405,11 @@ export default defineResolvers({
     /**
      * The shared directory. This directory is shared between the app and the server.
      */
-    shared: 'shared',
+    shared: {
+      $resolve: (val) => {
+        return val && typeof val === 'string' ? val : 'shared'
+      },
+    },
 
     /**
      * The directory containing your static files, which will be directly accessible via the Nuxt server


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
Resolves #31082

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
Shared dir was statically resolved. This fix ensures shared dir is dynamically resolved from config.dir.shared if exist.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
