### PR TITLE
fix(nuxt): set `nuxt.options.pages` to detected configuration

### DIFF
--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -47,11 +47,12 @@ export default defineNuxtModule({
     configKey: 'pages',
   },
   defaults: nuxt => ({
-    enabled: undefined as undefined | boolean,
+    enabled: typeof nuxt.options.pages === 'boolean' ? nuxt.options.pages : undefined as undefined | boolean,
     pattern: `**/*{${nuxt.options.extensions.join(',')}}` as string | string[],
   }),
   async setup (_options, nuxt) {
-    const options = typeof _options === 'boolean' ? { enabled: _options, pattern: `**/*{${nuxt.options.extensions.join(',')}}` } : _options
+    const options = typeof _options === 'boolean' ? { enabled: _options ?? nuxt.options.pages, pattern: `**/*{${nuxt.options.extensions.join(',')}}` } : { ..._options }
+    options.pattern = Array.isArray(options.pattern) ? [...new Set(options.pattern)] : options.pattern
 
     const useExperimentalTypedPages = nuxt.options.experimental.typedPages
     const builtInRouterOptions = await findPath(resolve(runtimeDir, 'router.options')) || resolve(runtimeDir, 'router.options')
@@ -95,7 +96,6 @@ export default defineNuxtModule({
       return false
     }
     options.enabled = await isPagesEnabled()
-    // to be reviewed
     nuxt.options.pages = options
 
     if (nuxt.options.dev && options.enabled) {

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -95,6 +95,8 @@ export default defineNuxtModule({
       return false
     }
     options.enabled = await isPagesEnabled()
+    // to be reviewed
+    nuxt.options.pages = options
 
     if (nuxt.options.dev && options.enabled) {
       // Add plugin to check if pages are enabled without NuxtPage being instantiated

--- a/packages/nuxt/test/load-nuxt.test.ts
+++ b/packages/nuxt/test/load-nuxt.test.ts
@@ -150,16 +150,16 @@ describe('loadNuxt', () => {
 })
 
 const pagesDetectionTests: [test: string, overrides: NuxtConfig, result: NuxtConfig['pages']][] = [
-  ['unset', {}, { enabled: true }],
-  ['no pages', { dir: { pages: 'non-existent-dir' } }, { enabled: false }],
-  ['config disabled (boolean)', { pages: false }, { enabled: false }],
-  ['config disabled (object)', { pages: { enabled: false } }, { enabled: false }],
-  ['config enabled with pattern', { pages: { enabled: true, pattern: '**/*{.vue}' } }, { enabled: true, pattern: '**/*{.vue}' }],
+  ['pages dir', {}, { enabled: true }],
+  ['pages dir empty', { dir: { pages: 'empty-dir' } }, { enabled: false }],
+  ['user config', { pages: false }, { enabled: false }],
+  ['user config', { pages: { enabled: false } }, { enabled: false }],
+  ['user config', { pages: { enabled: true, pattern: '**/*{.vue}' } }, { enabled: true, pattern: '**/*{.vue}' }],
 ]
 
 const pagesFixtureDir = withoutTrailingSlash(normalize(fileURLToPath(new URL('./pages-fixture', import.meta.url))))
 describe('pages detection', () => {
-  it.each(pagesDetectionTests)('%s', async (_, overrides, result) => {
+  it.each(pagesDetectionTests)('%s `%s`', async (_, overrides, result) => {
     const { options: { pages } } = await loadNuxt({ cwd: pagesFixtureDir, overrides })
     // @ts-expect-error should resolve to object?
     expect(pages).toMatchObject(result)

--- a/packages/nuxt/test/load-nuxt.test.ts
+++ b/packages/nuxt/test/load-nuxt.test.ts
@@ -120,8 +120,9 @@ const pagesDetectionTests: [test: string, overrides: NuxtConfig, result: NuxtCon
 const pagesFixtureDir = withoutTrailingSlash(normalize(fileURLToPath(new URL('./pages-fixture', import.meta.url))))
 describe('pages detection', () => {
   it.each(pagesDetectionTests)('%s `%s`', async (_, overrides, result) => {
-    const { options: { pages } } = await loadNuxt({ cwd: pagesFixtureDir, overrides })
+    const nuxt = await loadNuxt({ cwd: pagesFixtureDir, overrides, ready: true })
     // @ts-expect-error should resolve to object?
-    expect(pages).toMatchObject(result)
+    expect(nuxt.options.pages).toMatchObject(result)
+    await nuxt.close()
   })
 })

--- a/packages/nuxt/test/load-nuxt.test.ts
+++ b/packages/nuxt/test/load-nuxt.test.ts
@@ -82,46 +82,6 @@ describe('loadNuxt', () => {
     expect(loggerWarn).not.toHaveBeenCalled()
   })
 
-  // it('pages detection', async () => {
-  //   const pagesFixtureDir = withoutTrailingSlash(normalize(fileURLToPath(new URL('./pages-fixture', import.meta.url))))
-
-  //   const { options: { pages: pagesEnabled } } = await loadNuxt({ cwd: pagesFixtureDir })
-  //   expect(pagesEnabled).toMatchInlineSnapshot(`
-  //     {
-  //       "enabled": true,
-  //       "pattern": "**/*{.js,.jsx,.mjs,.ts,.tsx,.vue}",
-  //     }
-  //   `)
-
-  //   const { options: { pages: pagesDisabled } } = await loadNuxt({ cwd: pagesFixtureDir, overrides: {
-  //     dir: {
-  //       pages: 'non-existent-dir',
-  //     },
-  //   } })
-  //   expect(pagesDisabled).toMatchInlineSnapshot(`
-  //     {
-  //       "enabled": false,
-  //       "pattern": "**/*{.js,.jsx,.mjs,.ts,.tsx,.vue}",
-  //     }
-  //   `)
-
-  //   const { options: { pages: pagesManual } } = await loadNuxt({ cwd: pagesFixtureDir, overrides: { pages: false } })
-  //   expect(pagesManual).toMatchInlineSnapshot(`
-  //     {
-  //       "enabled": false,
-  //       "pattern": "**/*{.js,.jsx,.mjs,.ts,.tsx,.vue}",
-  //     }
-  //   `)
-
-  //   const { options: { pages: pagesManualObject } } = await loadNuxt({ cwd: pagesFixtureDir, overrides: { pages: { enabled: true, pattern: '**/*{.vue}' } } })
-  //   expect(pagesManualObject).toMatchInlineSnapshot(`
-  //     {
-  //       "enabled": false,
-  //       "pattern": "**/*{.js,.jsx,.mjs,.ts,.tsx,.vue}",
-  //     }
-  //   `)
-  // })
-
   it('expect hooks to get the correct context outside of initNuxt', async () => {
     const nuxt = await loadNuxt({
       cwd: repoRoot,

--- a/packages/nuxt/test/pages-fixture/nuxt.config.ts
+++ b/packages/nuxt/test/pages-fixture/nuxt.config.ts
@@ -1,0 +1,1 @@
+export default defineNuxtConfig({})

--- a/packages/nuxt/test/pages-fixture/pages/index.vue
+++ b/packages/nuxt/test/pages-fixture/pages/index.vue
@@ -1,0 +1,3 @@
+<template>
+  <div />
+</template>


### PR DESCRIPTION
### 🔗 Linked issue
* https://github.com/nuxt/nuxt/pull/31090
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Adds tests to check whether the `nuxt.options.pages` property is overwritten with detected values. I'm sure there is a better way to test this, but this was the quickest and easiest way for me to add them.

This has a change to overwrite the `nuxt.options.pages` property, the tests still fail with (and without) this change, please check if the test cases cover the expected behavior.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
