### PR TITLE
docs: fix typo in example command

### DIFF
--- a/docs/2.guide/2.directory-structure/2.env.md
+++ b/docs/2.guide/2.directory-structure/2.env.md
@@ -28,7 +28,7 @@ Note that removing a variable from `.env` or removing the `.env` file entirely w
 If you want to use a different file - for example, to use `.env.local` or `.env.production` - you can do so by passing the `--dotenv` flag when using `nuxi`.
 
 ```bash [Terminal]
-npx nuxi dev -- --dotenv .env.local
+npx nuxi dev --dotenv .env.local
 ```
 
 When updating `.env` in development mode, the Nuxt instance is automatically restarted to apply new values to the `process.env`.


### PR DESCRIPTION
`--` will make `--dotenv` a folder name instead of an argument. This seems to be an typo