### PR TITLE
docs: clarify lifecycle behavior of `<NuxtPage>` during page changes

### DIFF
--- a/docs/3.api/1.components/2.nuxt-page.md
+++ b/docs/3.api/1.components/2.nuxt-page.md
@@ -38,6 +38,10 @@ By default, Nuxt does not enable `<Transition>` and `<KeepAlive>`. You can enabl
 If you enable `<Transition>` in your page component, ensure that the page has a single root element.
 ::
 
+Since `<NuxtPage>` uses `<Suspense>` under the hood, the component lifecycle behavior during page changes differs from that of a typical Vue application.
+
+In a typical Vue application, a new page component is mounted **only after** the previous one has been fully unmounted. However, in Nuxt, due to how Vue `<Suspense>` is implemented, the new page component is mounted **before** the previous one is unmounted.  
+
 ## Props
 
 - `name`: tells `<RouterView>` to render the component with the corresponding name in the matched route record's components option.


### PR DESCRIPTION
### 🔗 Linked issue

Resolve #28182

### 📚 Description

Explain how `<Suspense>` affects the lifecycle of Vue page components when navigating between pages.
