### PR TITLE
docs: add shared config recipe to module authors guide

### DIFF
--- a/docs/2.guide/3.going-further/3.modules.md
+++ b/docs/2.guide/3.going-further/3.modules.md
@@ -630,6 +630,29 @@ nuxt.hook('builder:watch', async (event, path) => {
 })
 ```
 
+#### Build And Runtime Config
+
+You might want to access your [`app.config`](/docs/guide/directory-structure/app-config) via `useAppConfig` from your module. This config is meant to be used at runtime and it is not available at build time.
+
+If you want to access `app.config` from your module you can create a shared configuration file like this:
+
+```js [~/config/shared.config.mjs]
+export default {
+  theme: 'default'
+}
+```
+
+And then include this configuration in your `app.config`:
+
+```ts [app.config.ts]
+defineAppConfig({
+  ...sharedConfig
+})
+```
+
+You should now be able to import `~~/config/shared.config` and access your shared configuration from your module.
+
+
 ### Testing
 
 Testing helps ensuring your module works as expected given various setup. Find in this section how to perform various kinds of tests against your module.

--- a/docs/2.guide/3.going-further/3.modules.md
+++ b/docs/2.guide/3.going-further/3.modules.md
@@ -634,9 +634,9 @@ nuxt.hook('builder:watch', async (event, path) => {
 
 You might want to access your [`app.config`](/docs/guide/directory-structure/app-config) via `useAppConfig` from your module. This config is meant to be used at runtime and it is not available at build time.
 
-If you want to access `app.config` from your module you can create a shared configuration file like this:
+If you want to access `app.config` from your module you can create a shared configuration file in your [shared folder](/docs/guide/directory-structure/shared) like this:
 
-```js [~/config/shared.config.mjs]
+```js [~/shared/shared.config.mjs]
 export default {
   theme: 'default'
 }
@@ -645,14 +645,14 @@ export default {
 And then include this configuration in your `app.config`:
 
 ```ts [app.config.ts]
-import sharedConfig from '~~/config/shared.config'
+import sharedConfig from '#shared/shared.config'
 
 defineAppConfig({
   ...sharedConfig
 })
 ```
 
-You should now be able to import `~~/config/shared.config` and access your shared configuration from your module.
+You should now be able to import `#shared/shared.config` and access your configuration from your module.
 
 ### Testing
 

--- a/docs/2.guide/3.going-further/3.modules.md
+++ b/docs/2.guide/3.going-further/3.modules.md
@@ -652,7 +652,6 @@ defineAppConfig({
 
 You should now be able to import `~~/config/shared.config` and access your shared configuration from your module.
 
-
 ### Testing
 
 Testing helps ensuring your module works as expected given various setup. Find in this section how to perform various kinds of tests against your module.

--- a/docs/2.guide/3.going-further/3.modules.md
+++ b/docs/2.guide/3.going-further/3.modules.md
@@ -645,6 +645,8 @@ export default {
 And then include this configuration in your `app.config`:
 
 ```ts [app.config.ts]
+import sharedConfig from '~~/config/shared.config'
+
 defineAppConfig({
   ...sharedConfig
 })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #18762 

### 📚 Description

Create a recipe about how to create a shared configuration to be accessed from build and runtime from `app.config`.
