### PR TITLE
feat(kit,nuxt): resolve template imports from originating module

### DIFF
--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -1,6 +1,6 @@
 import { existsSync, promises as fsp } from 'node:fs'
 import { fileURLToPath } from 'node:url'
-import { basename, isAbsolute, join, parse, relative, resolve } from 'pathe'
+import { basename, isAbsolute, join, normalize, parse, relative, resolve } from 'pathe'
 import { hash } from 'ohash'
 import type { Nuxt, NuxtServerTemplate, NuxtTemplate, NuxtTypeTemplate, ResolvedNuxtTemplate, TSReference } from '@nuxt/schema'
 import { withTrailingSlash } from 'ufo'
@@ -11,7 +11,7 @@ import { readPackageJSON } from 'pkg-types'
 import { resolveModulePath } from 'exsolve'
 import { captureStackTrace } from 'errx'
 
-import { distDir, filterInPlace } from './utils'
+import { distDirURL, filterInPlace } from './utils'
 import { directoryToURL } from './internal/esm'
 import { getDirectory } from './module/install'
 import { tryUseNuxt, useNuxt } from './context'
@@ -30,9 +30,10 @@ export function addTemplate<T> (_template: NuxtTemplate<T> | string) {
   filterInPlace(nuxt.options.build.templates, p => normalizeTemplate(p).dst !== template.dst)
 
   try {
-    const { source } = captureStackTrace().find(e => e.source && !e.source.startsWith('file://' + distDir)) ?? {}
+    const distDir = distDirURL.toString()
+    const { source } = captureStackTrace().find(e => e.source && !e.source.startsWith(distDir)) ?? {}
     if (source) {
-      const path = fileURLToPath(source)
+      const path = normalize(fileURLToPath(source))
       if (existsSync(path)) {
         template._path = path
       }

--- a/packages/kit/src/utils.ts
+++ b/packages/kit/src/utils.ts
@@ -1,4 +1,3 @@
-import { fileURLToPath } from 'node:url'
 
 /** @since 3.9.0 */
 export function toArray<T> (value: T | T[]): T[] {

--- a/packages/kit/src/utils.ts
+++ b/packages/kit/src/utils.ts
@@ -1,3 +1,5 @@
+import { fileURLToPath } from 'node:url'
+
 /** @since 3.9.0 */
 export function toArray<T> (value: T | T[]): T[] {
   return Array.isArray(value) ? value : [value]
@@ -19,3 +21,5 @@ export function filterInPlace<T> (array: T[], predicate: (item: T, index: number
 }
 
 export const MODE_RE = /\.(server|client)(\.\w+)*$/
+
+export const distDir = fileURLToPath(new URL('.', import.meta.url))

--- a/packages/kit/src/utils.ts
+++ b/packages/kit/src/utils.ts
@@ -1,4 +1,3 @@
-
 /** @since 3.9.0 */
 export function toArray<T> (value: T | T[]): T[] {
   return Array.isArray(value) ? value : [value]

--- a/packages/kit/src/utils.ts
+++ b/packages/kit/src/utils.ts
@@ -22,4 +22,4 @@ export function filterInPlace<T> (array: T[], predicate: (item: T, index: number
 
 export const MODE_RE = /\.(server|client)(\.\w+)*$/
 
-export const distDir = fileURLToPath(new URL('.', import.meta.url))
+export const distDirURL = new URL('.', import.meta.url)

--- a/packages/nuxt/src/core/plugins/resolve-deep-imports.ts
+++ b/packages/nuxt/src/core/plugins/resolve-deep-imports.ts
@@ -1,12 +1,14 @@
 import { parseNodeModulePath } from 'mlly'
 import { resolveModulePath } from 'exsolve'
-import { isAbsolute, normalize } from 'pathe'
+import { isAbsolute, normalize, resolve } from 'pathe'
 import type { Plugin } from 'vite'
 import { directoryToURL, resolveAlias } from '@nuxt/kit'
 import type { Nuxt } from '@nuxt/schema'
 
 import { pkgDir } from '../../dirs'
 import { logger } from '../../utils'
+
+const VIRTUAL_RE = /^\0?virtual:(?:nuxt:)?/
 
 export function resolveDeepImportsPlugin (nuxt: Nuxt): Plugin {
   const exclude: string[] = ['virtual:', '\0virtual:', '/__skip_vite', '@vitest/']
@@ -29,12 +31,24 @@ export function resolveDeepImportsPlugin (nuxt: Nuxt): Plugin {
       conditions = [...resolvedConditions]
     },
     async resolveId (id, importer) {
-      if (!importer || isAbsolute(id) || (!isAbsolute(importer) && !importer.startsWith('virtual:') && !importer.startsWith('\0virtual:')) || exclude.some(e => id.startsWith(e))) {
+      if (!importer || isAbsolute(id) || (!isAbsolute(importer) && !VIRTUAL_RE.test(importer)) || exclude.some(e => id.startsWith(e))) {
         return
       }
 
       const normalisedId = resolveAlias(normalize(id), nuxt.options.alias)
-      const normalisedImporter = importer.replace(/^\0?virtual:(?:nuxt:)?/, '')
+      const isNuxtTemplate = importer.startsWith('virtual:nuxt')
+      const normalisedImporter = (isNuxtTemplate ? decodeURIComponent(importer) : importer).replace(VIRTUAL_RE, '')
+
+      if (nuxt.options.experimental.templateImportResolution !== false && isNuxtTemplate) {
+        const template = nuxt.options.build.templates.find(t => resolve(nuxt.options.buildDir, t.filename!) === normalisedImporter)
+        if (template?._path) {
+          const res = await this.resolve?.(normalisedId, template._path, { skipSelf: true })
+          if (res !== undefined && res !== null) {
+            return res
+          }
+        }
+      }
+
       const dir = parseNodeModulePath(normalisedImporter).dir || pkgDir
 
       const res = await this.resolve?.(normalisedId, dir, { skipSelf: true })

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -487,5 +487,10 @@ export default defineResolvers({
         return typeof val === 'boolean' ? val : true
       },
     },
+
+    /**
+     * Disable resolving imports into Nuxt templates from the path of the module that added the template.
+     */
+    templateImportResolution: true,
   },
 })

--- a/packages/schema/src/types/nuxt.ts
+++ b/packages/schema/src/types/nuxt.ts
@@ -43,6 +43,11 @@ export interface NuxtTemplate<Options = TemplateDefaultOptions> {
   getContents?: (data: { nuxt: Nuxt, app: NuxtApp, options: Options }) => string | Promise<string>
   /** Write to filesystem */
   write?: boolean
+  /**
+   * The source path of the template (to try resolving dependencies from).
+   * @internal
+   */
+  _path?: string
 }
 
 export interface NuxtServerTemplate {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this adds a fast-path return for when we can resolve a module from the path that called `addTemplate` or `addPluginTemplate`, which allows different major versions of certain libraries used in templates (e.g. `ohash` to coexist simultaneously).

if you experience any issues, you can disable it with:

```ts
export default defineNuxtConfig({
  experimental: {
    templateImportResolution: false
  }
})
```