### PR TITLE
fix(nuxt): skip deep merge in dev mode for prototype keys 

### DIFF
--- a/packages/nuxt/src/app/config.ts
+++ b/packages/nuxt/src/app/config.ts
@@ -35,6 +35,7 @@ function deepDelete (obj: any, newObj: any) {
 
 function deepAssign (obj: any, newObj: any) {
   for (const key in newObj) {
+    if (key === "__proto__" || key === "constructor") continue;
     const val = newObj[key]
     if (isPojoOrArray(val)) {
       const defaultVal = Array.isArray(val) ? [] : {}

--- a/packages/nuxt/src/app/config.ts
+++ b/packages/nuxt/src/app/config.ts
@@ -35,7 +35,7 @@ function deepDelete (obj: any, newObj: any) {
 
 function deepAssign (obj: any, newObj: any) {
   for (const key in newObj) {
-    if (key === "__proto__" || key === "constructor") continue;
+    if (key === '__proto__' || key === 'constructor') { continue }
     const val = newObj[key]
     if (isPojoOrArray(val)) {
       const defaultVal = Array.isArray(val) ? [] : {}


### PR DESCRIPTION
This is a fix for a false-positive security issue. `_replaceAppConfig` is only used by Nuxt's hot module reloading in development - with user-authored code. (But it doesn't harm anything to fix it.)

---

Potential fix for [https://github.com/nuxt/nuxt/security/code-scanning/1887](https://github.com/nuxt/nuxt/security/code-scanning/1887)

To fix the problem, we need to ensure that the `deepAssign` function does not allow prototype pollution by blocking the `__proto__` and `constructor` properties. This can be done by adding a check to skip these properties during the assignment process.

- Modify the `deepAssign` function to include a check that skips the `__proto__` and `constructor` properties.
- This change should be made in the `packages/nuxt/src/app/config.ts` file, specifically within the `deepAssign` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
