### PR TITLE
fix(nuxt): resolve shared externals to absolute paths

### DIFF
--- a/packages/nuxt/src/core/plugins/resolve-deep-imports.ts
+++ b/packages/nuxt/src/core/plugins/resolve-deep-imports.ts
@@ -34,7 +34,7 @@ export function resolveDeepImportsPlugin (nuxt: Nuxt): Plugin {
       conditions = [...resolvedConditions]
 
       const { runtimeDependencies = [] } = await tryImportModule<typeof import('nitro/runtime/meta')>('nitro/runtime/meta', {
-        url: nuxt.options.modulesDir.map(d => directoryToURL(d)),
+        url: new URL(import.meta.url),
       }) || {}
 
       external = new Set([

--- a/packages/nuxt/src/core/plugins/resolve-deep-imports.ts
+++ b/packages/nuxt/src/core/plugins/resolve-deep-imports.ts
@@ -2,8 +2,9 @@ import { parseNodeModulePath } from 'mlly'
 import { resolveModulePath } from 'exsolve'
 import { isAbsolute, normalize, resolve } from 'pathe'
 import type { Plugin } from 'vite'
-import { directoryToURL, resolveAlias } from '@nuxt/kit'
+import { directoryToURL, resolveAlias, tryImportModule } from '@nuxt/kit'
 import type { Nuxt } from '@nuxt/schema'
+import type { Nitro } from 'nitro/types'
 
 import { pkgDir } from '../../dirs'
 import { logger } from '../../utils'
@@ -13,10 +14,12 @@ const VIRTUAL_RE = /^\0?virtual:(?:nuxt:)?/
 export function resolveDeepImportsPlugin (nuxt: Nuxt): Plugin {
   const exclude: string[] = ['virtual:', '\0virtual:', '/__skip_vite', '@vitest/']
   let conditions: string[]
+  let external: Set<string>
+
   return {
     name: 'nuxt:resolve-bare-imports',
     enforce: 'post',
-    configResolved (config) {
+    async configResolved (config) {
       const resolvedConditions = new Set([nuxt.options.dev ? 'development' : 'production', ...config.resolve.conditions])
       if (resolvedConditions.has('browser')) {
         resolvedConditions.add('web')
@@ -29,11 +32,26 @@ export function resolveDeepImportsPlugin (nuxt: Nuxt): Plugin {
         resolvedConditions.add('require')
       }
       conditions = [...resolvedConditions]
+
+      const { runtimeDependencies = [] } = await tryImportModule<typeof import('nitro/runtime/meta')>('nitro/runtime/meta', {
+        url: nuxt.options.modulesDir.map(d => directoryToURL(d)),
+      }) || {}
+
+      external = new Set([
+        // explicit dependencies we use in our ssr renderer - these can be inlined (if necessary) in the nitro build
+        'unhead', '@unhead/vue', 'unctx', 'h3', 'devalue', '@nuxt/devalue', 'radix3', 'rou3', 'unstorage', 'hookable',
+        // ensure we only have one version of vue if nitro is going to inline anyway
+        ...((nuxt as any)._nitro as Nitro).options.inlineDynamicImports ? ['vue', '@vue/server-renderer', '@unhead/vue'] : [],
+        // dependencies we might share with nitro - these can be inlined (if necessary) in the nitro build
+        ...runtimeDependencies,
+      ])
     },
     async resolveId (id, importer) {
       if (!importer || isAbsolute(id) || (!isAbsolute(importer) && !VIRTUAL_RE.test(importer)) || exclude.some(e => id.startsWith(e))) {
         return
       }
+
+      const overrides = external.has(id) ? { external: 'absolute' } as const : {}
 
       const normalisedId = resolveAlias(normalize(id), nuxt.options.alias)
       const isNuxtTemplate = importer.startsWith('virtual:nuxt')
@@ -44,7 +62,10 @@ export function resolveDeepImportsPlugin (nuxt: Nuxt): Plugin {
         if (template?._path) {
           const res = await this.resolve?.(normalisedId, template._path, { skipSelf: true })
           if (res !== undefined && res !== null) {
-            return res
+            return {
+              ...res,
+              ...overrides,
+            }
           }
         }
       }
@@ -53,7 +74,10 @@ export function resolveDeepImportsPlugin (nuxt: Nuxt): Plugin {
 
       const res = await this.resolve?.(normalisedId, dir, { skipSelf: true })
       if (res !== undefined && res !== null) {
-        return res
+        return {
+          ...res,
+          ...overrides,
+        }
       }
 
       const path = resolveModulePath(id, {
@@ -66,6 +90,13 @@ export function resolveDeepImportsPlugin (nuxt: Nuxt): Plugin {
       if (!path) {
         logger.debug('Could not resolve id', id, importer)
         return null
+      }
+
+      if (external.has(id)) {
+        return {
+          id: normalize(path),
+          external: 'absolute',
+        }
       }
 
       return normalize(path)

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -2,7 +2,7 @@ import { resolve } from 'pathe'
 import * as vite from 'vite'
 import vuePlugin from '@vitejs/plugin-vue'
 import viteJsxPlugin from '@vitejs/plugin-vue-jsx'
-import { directoryToURL, logger, resolvePath, tryImportModule } from '@nuxt/kit'
+import { logger, resolvePath } from '@nuxt/kit'
 import { joinURL, withTrailingSlash, withoutLeadingSlash } from 'ufo'
 import type { ViteConfig } from '@nuxt/schema'
 import defu from 'defu'
@@ -114,22 +114,6 @@ export async function buildServer (ctx: ViteBuildContext) {
       hmr: false,
     },
   } satisfies vite.InlineConfig, ctx.nuxt.options.vite.$server || {}))
-
-  if (!ctx.nuxt.options.dev) {
-    const { runtimeDependencies = [] } = await tryImportModule<typeof import('nitro/runtime/meta')>('nitro/runtime/meta', {
-      url: ctx.nuxt.options.modulesDir.map(d => directoryToURL(d)),
-    }) || {}
-    if (Array.isArray(serverConfig.ssr!.external)) {
-      serverConfig.ssr!.external.push(
-        // explicit dependencies we use in our ssr renderer - these can be inlined (if necessary) in the nitro build
-        'unhead', '@unhead/vue', 'unctx', 'h3', 'devalue', '@nuxt/devalue', 'radix3', 'rou3', 'unstorage', 'hookable',
-        // ensure we only have one version of vue if nitro is going to inline anyway
-        ...((ctx.nuxt as any)._nitro as Nitro).options.inlineDynamicImports ? ['vue', '@vue/server-renderer', '@unhead/vue'] : [],
-        // dependencies we might share with nitro - these can be inlined (if necessary) in the nitro build
-        ...runtimeDependencies,
-      )
-    }
-  }
 
   // tell rollup's nitro build about the original sources of the generated vite server build
   if (ctx.nuxt.options.sourcemap.server && !ctx.nuxt.options.dev) {

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -58,7 +58,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(rootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"208k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"221k"`)
 
     const modules = await analyzeSizes(['node_modules/**/*'], serverDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"1397k"`)
@@ -97,7 +97,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(rootDir, '.output-inline/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"558k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"572k"`)
 
     const modules = await analyzeSizes(['node_modules/**/*'], serverDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"90.9k"`)
@@ -121,10 +121,10 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(pagesRootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"303k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"318k"`)
 
     const modules = await analyzeSizes(['node_modules/**/*'], serverDir)
-    expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"1408k"`)
+    expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"1397k"`)
 
     const packages = modules.files
       .filter(m => m.endsWith('package.json'))


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/31222

### 📚 Description

previous implementation in https://github.com/nuxt/nuxt/pull/22812 seems was no longer working. so this PR moves marking as external to our deep imports plugin

it marks as external but with absolute path so that when nitro resolves, the deduplication will only occur with the same version of the library.

it does adds a bit to the `server.mjs` (so not fully deduplicating as before) but likely a cost worth paying