### PR TITLE
fix(nuxt): apply ignore rules to nitro `devStorage`

### DIFF
--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -6,7 +6,7 @@ import { createRouter as createRadixRouter, exportMatcher, toRouteMatcher } from
 import { joinURL, withTrailingSlash } from 'ufo'
 import { build, copyPublicAssets, createDevServer, createNitro, prepare, prerender, scanHandlers, writeTypes } from 'nitropack'
 import type { Nitro, NitroConfig, NitroOptions } from 'nitropack'
-import { findPath, logger, resolveAlias, resolveIgnorePatterns, resolveNuxtModule } from '@nuxt/kit'
+import { createIsIgnored, findPath, logger, resolveAlias, resolveIgnorePatterns, resolveNuxtModule } from '@nuxt/kit'
 import escapeRE from 'escape-string-regexp'
 import { defu } from 'defu'
 import { dynamicEventHandler } from 'h3'
@@ -406,6 +406,28 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
       exclude: [/core[\\/]runtime[\\/]nitro[\\/]renderer/, ...sharedPatterns],
     }),
   )
+
+  // Apply Nuxt's ignore configuration to the root and src unstorage mounts
+  // created by Nitro. This ensures that the unstorage watcher will use the
+  // same ignore list as Nuxt's watcher and can reduce unneccesary file handles.
+  const isIgnored = createIsIgnored(nuxt)
+  nitroConfig.devStorage ??= {}
+  nitroConfig.devStorage.root ??= {
+    driver: 'fs',
+    readOnly: true,
+    base: nitroConfig.rootDir,
+    watchOptions: {
+      ignored: [isIgnored],
+    },
+  }
+  nitroConfig.devStorage.src ??= {
+    driver: 'fs',
+    readOnly: true,
+    base: nitroConfig.srcDir,
+    watchOptions: {
+      ignored: [isIgnored],
+    },
+  }
 
   // Extend nitro config with hook
   await nuxt.callHook('nitro:config', nitroConfig)


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/31219

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

This change is an attempt to mitigate issues like https://github.com/nuxt/nuxt/issues/30481 by reducing the amount of files watched. It does this by applying the Nuxt ignore function to the development-only filesystem mounts created by Nitro. 

In my experience the threshold for the `EMFILE` error seems to vary, so this is no guarantee of eliminating it, but it may help. When I encountered https://github.com/nuxt/nuxt/issues/30481 the combination of switching to the parcel watcher and using fs-lite for nitro's root mount was sufficient to overcome the issue. Either alone was not enough.

For a rough estimate of the open file handles, I ran `lsof | grep '^node' | wc -l` while running in dev mode. Here are the results in my application:

Without changes: ~1500
Using fs-lite for the root mount (so no watching): ~650
Adding nuxt ignore (this PR):  ~1300

So in my case I have about 200 files in the application directory that should be ignored. This would vary for different codebases though and I'm not sure what's typical.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
