### PR TITLE
docs: mention possibility of prerendering api routes

### DIFF
--- a/docs/1.getting-started/9.prerendering.md
+++ b/docs/1.getting-started/9.prerendering.md
@@ -144,6 +144,7 @@ You can use this at runtime within a [Nuxt context](/docs/guide/going-further/nu
 ```vue [pages/index.vue]
 <script setup>
 prerenderRoutes(["/some/other/url"]);
+prerenderRoutes("/api/content/article/my-article");
 </script>
 
 <template>

--- a/docs/3.api/3.utils/prerender-routes.md
+++ b/docs/3.api/3.utils/prerender-routes.md
@@ -32,7 +32,7 @@ In the browser, or if called outside prerendering, `prerenderRoutes` will have n
 You can even prerender API routes which is particularly useful for full statically generated sites (SSG) because you can then `$fetch` data as if you have an available server!
 
 ```js
-prerenderRoutes('/api/content/article/name-of-article');
+prerenderRoutes('/api/content/article/name-of-article')
 
 // Somewhere later in App
 const articleContent = await $fetch('/api/content/article/name-of-article', {
@@ -41,6 +41,6 @@ const articleContent = await $fetch('/api/content/article/name-of-article', {
 ```
 
 ::warning
-Prerendered API routes in production may not return the expected response headers, depending on the provider you deploy to. For example, a JSON response might be served with an `application/octet-stream` content type. In this case, you may have to specify an explicit `responseType`.
-Always manually set `responseType` when fetching prerenderered API routes!
+Prerendered API routes in production may not return the expected response headers, depending on the provider you deploy to. For example, a JSON response might be served with an `application/octet-stream` content type.
+Always manually set `responseType` when fetching prerenderered API routes.
 ::

--- a/docs/3.api/3.utils/prerender-routes.md
+++ b/docs/3.api/3.utils/prerender-routes.md
@@ -28,3 +28,19 @@ prerenderRoutes(['/', '/about'])
 ::note
 In the browser, or if called outside prerendering, `prerenderRoutes` will have no effect.
 ::
+
+You can even prerender API routes which is particularly useful for full Statically Generated Sites (SSG) because you can then `$fetch` data as if you have an available server!
+
+```js
+prerenderRoutes('/api/content/article/name-of-article');
+
+// Somewhere later in App
+const articleContent = await $fetch('/api/content/article/name-of-article', {
+  responseType: 'json',
+});
+```
+
+::warning
+Fetching prerendered API routes on production looses all headers you set up in `defineEventHandler` on server side! This means the data you fetch will most likely have `application/octet-stream` content type even if it is just a JSON and therefore break the application in unpredictable ways.
+Always manually set `responseType` when fetching prerenderered API routes!
+::

--- a/docs/3.api/3.utils/prerender-routes.md
+++ b/docs/3.api/3.utils/prerender-routes.md
@@ -42,5 +42,5 @@ const articleContent = await $fetch('/api/content/article/name-of-article', {
 
 ::warning
 Prerendered API routes in production may not return the expected response headers, depending on the provider you deploy to. For example, a JSON response might be served with an `application/octet-stream` content type.
-Always manually set `responseType` when fetching prerenderered API routes.
+Always manually set `responseType` when fetching prerendered API routes.
 ::

--- a/docs/3.api/3.utils/prerender-routes.md
+++ b/docs/3.api/3.utils/prerender-routes.md
@@ -29,7 +29,7 @@ prerenderRoutes(['/', '/about'])
 In the browser, or if called outside prerendering, `prerenderRoutes` will have no effect.
 ::
 
-You can even prerender API routes which is particularly useful for full Statically Generated Sites (SSG) because you can then `$fetch` data as if you have an available server!
+You can even prerender API routes which is particularly useful for full statically generated sites (SSG) because you can then `$fetch` data as if you have an available server!
 
 ```js
 prerenderRoutes('/api/content/article/name-of-article');
@@ -37,10 +37,10 @@ prerenderRoutes('/api/content/article/name-of-article');
 // Somewhere later in App
 const articleContent = await $fetch('/api/content/article/name-of-article', {
   responseType: 'json',
-});
+})
 ```
 
 ::warning
-Fetching prerendered API routes on production looses all headers you set up in `defineEventHandler` on server side! This means the data you fetch will most likely have `application/octet-stream` content type even if it is just a JSON and therefore break the application in unpredictable ways.
+Prerendered API routes in production may not return the expected response headers, depending on the provider you deploy to. For example, a JSON response might be served with an `application/octet-stream` content type. In this case, you may have to specify an explicit `responseType`.
 Always manually set `responseType` when fetching prerenderered API routes!
 ::


### PR DESCRIPTION
### 📚 Description

It is not clear that `prerenderRoutes` allows to prerender API routes as well, allowing to `$fetch` data on SSG sites as if live server is available. This allows a way to get data without polluting payload.

Also, I added warning about headers that are lost when prerendering.
