### PR TITLE
fix(nuxt): ensure externals are resolved first

### DIFF
--- a/packages/nuxt/src/core/plugins/resolve-deep-imports.ts
+++ b/packages/nuxt/src/core/plugins/resolve-deep-imports.ts
@@ -2,24 +2,22 @@ import { parseNodeModulePath } from 'mlly'
 import { resolveModulePath } from 'exsolve'
 import { isAbsolute, normalize, resolve } from 'pathe'
 import type { Plugin } from 'vite'
-import { directoryToURL, resolveAlias, tryImportModule } from '@nuxt/kit'
+import { directoryToURL, resolveAlias } from '@nuxt/kit'
 import type { Nuxt } from '@nuxt/schema'
-import type { Nitro } from 'nitro/types'
 
 import { pkgDir } from '../../dirs'
 import { logger } from '../../utils'
 
 const VIRTUAL_RE = /^\0?virtual:(?:nuxt:)?/
 
-export function resolveDeepImportsPlugin (nuxt: Nuxt): Plugin {
+export function ResolveDeepImportsPlugin (nuxt: Nuxt): Plugin {
   const exclude: string[] = ['virtual:', '\0virtual:', '/__skip_vite', '@vitest/']
   let conditions: string[]
-  let external: Set<string>
 
   return {
     name: 'nuxt:resolve-bare-imports',
     enforce: 'post',
-    async configResolved (config) {
+    configResolved (config) {
       const resolvedConditions = new Set([nuxt.options.dev ? 'development' : 'production', ...config.resolve.conditions])
       if (resolvedConditions.has('browser')) {
         resolvedConditions.add('web')
@@ -32,26 +30,11 @@ export function resolveDeepImportsPlugin (nuxt: Nuxt): Plugin {
         resolvedConditions.add('require')
       }
       conditions = [...resolvedConditions]
-
-      const { runtimeDependencies = [] } = await tryImportModule<typeof import('nitro/runtime/meta')>('nitro/runtime/meta', {
-        url: new URL(import.meta.url),
-      }) || {}
-
-      external = new Set([
-        // explicit dependencies we use in our ssr renderer - these can be inlined (if necessary) in the nitro build
-        'unhead', '@unhead/vue', 'unctx', 'h3', 'devalue', '@nuxt/devalue', 'radix3', 'rou3', 'unstorage', 'hookable',
-        // ensure we only have one version of vue if nitro is going to inline anyway
-        ...((nuxt as any)._nitro as Nitro).options.inlineDynamicImports ? ['vue', '@vue/server-renderer', '@unhead/vue'] : [],
-        // dependencies we might share with nitro - these can be inlined (if necessary) in the nitro build
-        ...runtimeDependencies,
-      ])
     },
     async resolveId (id, importer) {
       if (!importer || isAbsolute(id) || (!isAbsolute(importer) && !VIRTUAL_RE.test(importer)) || exclude.some(e => id.startsWith(e))) {
         return
       }
-
-      const overrides = external.has(id) ? { external: 'absolute' } as const : {}
 
       const normalisedId = resolveAlias(normalize(id), nuxt.options.alias)
       const isNuxtTemplate = importer.startsWith('virtual:nuxt')
@@ -62,10 +45,7 @@ export function resolveDeepImportsPlugin (nuxt: Nuxt): Plugin {
         if (template?._path) {
           const res = await this.resolve?.(normalisedId, template._path, { skipSelf: true })
           if (res !== undefined && res !== null) {
-            return {
-              ...res,
-              ...overrides,
-            }
+            return res
           }
         }
       }
@@ -74,10 +54,7 @@ export function resolveDeepImportsPlugin (nuxt: Nuxt): Plugin {
 
       const res = await this.resolve?.(normalisedId, dir, { skipSelf: true })
       if (res !== undefined && res !== null) {
-        return {
-          ...res,
-          ...overrides,
-        }
+        return res
       }
 
       const path = resolveModulePath(id, {
@@ -90,13 +67,6 @@ export function resolveDeepImportsPlugin (nuxt: Nuxt): Plugin {
       if (!path) {
         logger.debug('Could not resolve id', id, importer)
         return null
-      }
-
-      if (external.has(id)) {
-        return {
-          id: normalize(path),
-          external: 'absolute',
-        }
       }
 
       return normalize(path)

--- a/packages/nuxt/src/core/plugins/resolved-externals.ts
+++ b/packages/nuxt/src/core/plugins/resolved-externals.ts
@@ -1,0 +1,42 @@
+import type { Plugin } from 'vite'
+import { tryImportModule } from '@nuxt/kit'
+import type { Nuxt } from '@nuxt/schema'
+import type { Nitro } from 'nitro/types'
+
+export function ResolveExternalsPlugin (nuxt: Nuxt): Plugin {
+  let external: Set<string> = new Set()
+
+  return {
+    name: 'nuxt:resolve-externals',
+    enforce: 'pre',
+    async configResolved () {
+      if (!nuxt.options.dev) {
+        const { runtimeDependencies = [] } = await tryImportModule<typeof import('nitro/runtime/meta')>('nitro/runtime/meta', {
+          url: new URL(import.meta.url),
+        }) || {}
+
+        external = new Set([
+          // explicit dependencies we use in our ssr renderer - these can be inlined (if necessary) in the nitro build
+          'unhead', '@unhead/vue', 'unctx', 'h3', 'devalue', '@nuxt/devalue', 'radix3', 'rou3', 'unstorage', 'hookable',
+          // ensure we only have one version of vue if nitro is going to inline anyway
+          ...((nuxt as any)._nitro as Nitro).options.inlineDynamicImports ? ['vue', '@vue/server-renderer', '@unhead/vue'] : [],
+          // dependencies we might share with nitro - these can be inlined (if necessary) in the nitro build
+          ...runtimeDependencies,
+        ])
+      }
+    },
+    async resolveId (id, importer) {
+      if (!external.has(id)) {
+        return
+      }
+
+      const res = await this.resolve?.(id, importer, { skipSelf: true })
+      if (res !== undefined && res !== null) {
+        return {
+          ...res,
+          external: 'absolute',
+        }
+      }
+    },
+  }
+}

--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -90,6 +90,7 @@ export async function buildServer (ctx: ViteBuildContext) {
           new RegExp('^' + escapeStringRegexp(withTrailingSlash(resolve(ctx.nuxt.options.rootDir, ctx.nuxt.options.dir.shared)))),
         ],
         output: {
+          preserveModules: true,
           entryFileNames: '[name].mjs',
           format: 'module',
           generatedCode: {

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -58,7 +58,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(rootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"221k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"204k"`)
 
     const modules = await analyzeSizes(['node_modules/**/*'], serverDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"1397k"`)
@@ -97,7 +97,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(rootDir, '.output-inline/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"572k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"555k"`)
 
     const modules = await analyzeSizes(['node_modules/**/*'], serverDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"90.9k"`)
@@ -121,10 +121,10 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(pagesRootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"318k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"299k"`)
 
     const modules = await analyzeSizes(['node_modules/**/*'], serverDir)
-    expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"1397k"`)
+    expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"1408k"`)
 
     const packages = modules.files
       .filter(m => m.endsWith('package.json'))


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

follow up to https://github.com/nuxt/nuxt/pull/31227, there's scope for improving things by ensuring we resolve _first_.

this also address bundle size regression from that PR, and makes a further improvement by preserving module structure (https://rollupjs.org/configuration-options/#output-preservemodules) which avoids some overhead of multiple passes by rollup, trusting nitro with more of the bundling.