### PR TITLE
fix(nuxt): navigateToOptions replace not keeping query/hash

### DIFF
--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -152,7 +152,7 @@ export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: Na
   if (import.meta.client && !isExternal && inMiddleware) {
     if (options?.replace) {
       if (typeof to === 'string') {
-        const { pathname, search, hash } = parseURL(fullPath)
+        const { pathname, search, hash } = parseURL(to)
         return { path: pathname, query: parseQuery: (search), hash, replace: true }
       }
       return { ...to, replace: true }

--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -153,7 +153,12 @@ export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: Na
     if (options?.replace) {
       if (typeof to === 'string') {
         const { pathname, search, hash } = parseURL(to)
-        return { path: pathname, query: parseQuery(search), hash, replace: true }
+        return {
+          path: pathname,
+          ...(search && { query: parseQuery(search) }),
+          ...(hash && { hash }),
+          replace: true
+        }
       }
       return { ...to, replace: true }
     }

--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -157,7 +157,7 @@ export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: Na
           path: pathname,
           ...(search && { query: parseQuery(search) }),
           ...(hash && { hash }),
-          replace: true
+          replace: true,
         }
       }
       return { ...to, replace: true }

--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -153,7 +153,7 @@ export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: Na
     if (options?.replace) {
       if (typeof to === 'string') {
         const { pathname, search, hash } = parseURL(to)
-        return { path: pathname, query: parseQuery: (search), hash, replace: true }
+        return { path: pathname, query: parseQuery(search), hash, replace: true }
       }
       return { ...to, replace: true }
     }

--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -2,7 +2,7 @@ import { getCurrentInstance, hasInjectionContext, inject, onScopeDispose } from 
 import type { Ref } from 'vue'
 import type { NavigationFailure, NavigationGuard, RouteLocationNormalized, RouteLocationRaw, Router, useRoute as _useRoute, useRouter as _useRouter } from 'vue-router'
 import { sanitizeStatusCode } from 'h3'
-import { hasProtocol, isScriptProtocol, joinURL, withQuery } from 'ufo'
+import { hasProtocol, isScriptProtocol, joinURL, parseQuery, parseURL, withQuery } from 'ufo'
 
 import type { PageMeta } from '../../pages/runtime/composables'
 
@@ -151,7 +151,11 @@ export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: Na
   // Early redirect on client-side
   if (import.meta.client && !isExternal && inMiddleware) {
     if (options?.replace) {
-      return typeof to === 'string' ? { path: to, replace: true } : { ...to, replace: true }
+      if (typeof to === 'string') {
+        const { pathname, search, hash } = parseURL(fullPath)
+        return { path: pathname, query: parseQuery: (search), hash, replace: true }
+      }
+      return { ...to, replace: true }
     }
     return to
   }

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -649,7 +649,9 @@ describe('routing utilities: `navigateTo`', () => {
     expect(navigateTo('/')).toMatchInlineSnapshot(`"/"`)
     expect(navigateTo('/', { replace: true })).toMatchInlineSnapshot(`
       {
+        "hash": "",
         "path": "/",
+        "query": {},
         "replace": true,
       }
     `)

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -649,9 +649,7 @@ describe('routing utilities: `navigateTo`', () => {
     expect(navigateTo('/')).toMatchInlineSnapshot(`"/"`)
     expect(navigateTo('/', { replace: true })).toMatchInlineSnapshot(`
       {
-        "hash": "",
         "path": "/",
-        "query": {},
         "replace": true,
       }
     `)


### PR DESCRIPTION
### 🔗 Linked issue

resolves #31236 

### 📚 Description

`navigateTo` arg1 (`RouteLocationRaw`) might be a string, so we have to parse it to extract the query/hash, and then send it off to vue router.
