### PR TITLE
docs: mention workaround for `typedPages` in unhoisted pnpm setups

### DIFF
--- a/docs/2.guide/3.going-further/1.experimental-features.md
+++ b/docs/2.guide/3.going-further/1.experimental-features.md
@@ -256,6 +256,10 @@ Out of the box, this will enable typed usage of [`navigateTo`](/docs/api/utils/n
 
 You can even get typed params within a page by using `const route = useRoute('route-name')`.
 
+::important
+If you use `pnpm` without `shamefully-hoist=true`, you will need to have `unplugin-vue-router` installed as a devDependency in order for this feature to work.
+::
+
 ::tip{icon="i-ph-video" to="https://www.youtube.com/watch?v=SXk-L19gTZk" target="_blank"}
 Watch a video from Daniel Roe explaining type-safe routing in Nuxt.
 ::


### PR DESCRIPTION
### 🔗 Linked issue

related https://github.com/nuxt/nuxt/issues/30676

### 📚 Description

Documents a workaround for pnpm users, so they can find out why `typedPages: true` isn't working for them more easily.

![image](https://github.com/user-attachments/assets/121d4363-2f5a-4129-b10e-4a1ddc62a80d)


<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
