### PR TITLE
fix(nuxt): check resolved options for polyfills

### DIFF
--- a/packages/nuxt/src/imports/module.ts
+++ b/packages/nuxt/src/imports/module.ts
@@ -36,7 +36,7 @@ export default defineNuxtModule<Partial<ImportsOptions>>({
     // TODO: fix sharing of defaults between invocations of modules
     const presets = JSON.parse(JSON.stringify(options.presets)) as ImportPresetWithDeprecation[]
 
-    if (nuxt.options.imports.polyfills) {
+    if (options.polyfills) {
       presets.push(...appCompatPresets)
     }
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

small regression from https://github.com/nuxt/nuxt/pull/30332 - we were checking non-resolved options, which didn't respect the default value of `polyfills`