### PR TITLE
fix(nuxt): add missing lazyhydration prop in regex

### DIFF
--- a/packages/nuxt/src/components/plugins/lazy-hydration-transform.ts
+++ b/packages/nuxt/src/components/plugins/lazy-hydration-transform.ts
@@ -23,7 +23,7 @@ const hydrationStrategyMap = {
   hydrateWhen: 'If',
   hydrateNever: 'Never',
 }
-const LAZY_HYDRATION_PROPS_RE = /\bhydrate-?on-?idle|hydrate-?on-?visible|hydrate-?on-?interaction|hydrate-?on-?media-?query|hydrate-?after|hydrate-?when\b/
+const LAZY_HYDRATION_PROPS_RE = /\bhydrate-?on-?idle|hydrate-?on-?visible|hydrate-?on-?interaction|hydrate-?on-?media-?query|hydrate-?after|hydrate-?when|hydrate-?never\b/
 export const LazyHydrationTransformPlugin = (options: LoaderOptions) => createUnplugin(() => {
   const exclude = options.transform?.exclude || []
   const include = options.transform?.include || []

--- a/packages/nuxt/test/component-loader.test.ts
+++ b/packages/nuxt/test/component-loader.test.ts
@@ -121,6 +121,24 @@ describe('components:loader', () => {
       const __nuxt_component_0_lazy_never = createLazyNeverComponent("components/MyComponent.vue", () => import('../components/MyComponent.vue').then(c => c.default || c));"
     `)
   })
+
+  it.each([
+    ['hydrate-on-idle', 'createLazyIdleComponent'],
+    ['hydrate-on-visible', 'createLazyVisibleComponent'],
+    ['hydrate-on-interaction', 'createLazyInteractionComponent'],
+    ['hydrate-on-media-query', 'createLazyMediaQueryComponent'],
+    ['hydrate-after', 'createLazyTimeComponent'],
+    ['hydrate-when', 'createLazyIfComponent'],
+    ['hydrate-never', 'createLazyNeverComponent'],
+  ])('should correctly resolve lazy hydration components %s', async (prop, component) => {
+    const sfc = `
+    <template>
+      <LazyMyComponent ${prop} />
+    </template>
+    `
+    const result = await transform(sfc, '/pages/index.vue').then(r => r.split('\n'))
+    expect(result.join('\n')).toContain(component)
+  })
 })
 
 async function transform (code: string, filename: string) {


### PR DESCRIPTION
### 🔗 Linked issue

fix #31357 

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

`hydrate-never` was missing from th prop list in the regex

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->

TODO
- [x] tests