### PR TITLE
fix(vite): don't show interim vite build output files

### DIFF
--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -131,7 +131,7 @@ export async function buildServer (ctx: ViteBuildContext) {
     })
   }
 
-  serverConfig.customLogger = createViteLogger(serverConfig)
+  serverConfig.customLogger = createViteLogger(serverConfig, { hideOutput: !ctx.nuxt.options.dev })
 
   await ctx.nuxt.callHook('vite:extendConfig', serverConfig, { isClient: false, isServer: true })
 

--- a/packages/vite/src/utils/logger.ts
+++ b/packages/vite/src/utils/logger.ts
@@ -4,6 +4,7 @@ import { logger } from '@nuxt/kit'
 import { colorize } from 'consola/utils'
 import { hasTTY, isCI } from 'std-env'
 import type { NuxtOptions } from '@nuxt/schema'
+import { relative } from 'pathe'
 import { useResolveFromPublicAssets } from '../plugins/public-dirs'
 
 let duplicateCount = 0
@@ -24,10 +25,11 @@ const logLevelMapReverse: Record<NonNullable<vite.UserConfig['logLevel']>, numbe
 }
 
 const RUNTIME_RESOLVE_REF_RE = /^([^ ]+) referenced in/m
-export function createViteLogger (config: vite.InlineConfig): vite.Logger {
+export function createViteLogger (config: vite.InlineConfig, ctx: { hideOutput?: boolean } = {}): vite.Logger {
   const loggedErrors = new WeakSet<any>()
   const canClearScreen = hasTTY && !isCI && config.clearScreen
   const _logger = createLogger()
+  const relativeOutDir = relative(config.root!, config.build!.outDir || '')
   const clear = () => {
     _logger.clearScreen(
       // @ts-expect-error silent is a log level but not a valid option for clearScreens
@@ -48,6 +50,7 @@ export function createViteLogger (config: vite.InlineConfig): vite.Logger {
         const id = msg.trim().match(RUNTIME_RESOLVE_REF_RE)?.[1]
         if (id && resolveFromPublicAssets(id)) { return }
       }
+      if (type === 'info' && ctx.hideOutput && msg.includes(relativeOutDir)) { return }
     }
 
     const sameAsLast = lastType === type && lastMsg === msg


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

particularly noticeable now that we emit longer filenames in the interim stage between vite + nitro server builds, this PR hides build output in server build