### PR TITLE
docs: update example to `useTemplateRef`

### DIFF
--- a/docs/3.api/1.components/1.client-only.md
+++ b/docs/3.api/1.components/1.client-only.md
@@ -60,12 +60,10 @@ Components inside `<ClientOnly>` are rendered only after being mounted. To acces
 
 ```vue [pages/example.vue]
 <script setup lang="ts">
-import { useTemplateRef } from 'vue'
-
-const myRef = useTemplateRef('nuxtWelcomeRef')
+const nuxtWelcomeRef = useTemplateRef('nuxtWelcomeRef')
 
 // The watch will be triggered when the component is available
-watch(myRef, () => {
+watch(nuxtWelcomeRef, () => {
  console.log('<NuxtWelcome /> mounted')
 }, { once: true })
 </script>

--- a/docs/3.api/1.components/1.client-only.md
+++ b/docs/3.api/1.components/1.client-only.md
@@ -60,10 +60,12 @@ Components inside `<ClientOnly>` are rendered only after being mounted. To acces
 
 ```vue [pages/example.vue]
 <script setup lang="ts">
-const nuxtWelcomeRef = ref()
+import { useTemplateRef } from 'vue'
+
+const myRef = useTemplateRef('nuxtWelcomeRef')
 
 // The watch will be triggered when the component is available
-watch(nuxtWelcomeRef, () => {
+watch(myRef, () => {
  console.log('<NuxtWelcome /> mounted')
 }, { once: true })
 </script>


### PR DESCRIPTION
### 📚 Description

As of Vue 3.5 useTemplateRef (vuejs.org/guide/essentials/template-refs#accessing-the-refs‌​) is the way to reference a html element or component
