### PR TITLE
docs: reverted to `npx nuxi init` where `--template` is used

### DIFF
--- a/docs/2.guide/3.going-further/3.modules.md
+++ b/docs/2.guide/3.going-further/3.modules.md
@@ -16,19 +16,19 @@ We recommend you get started with Nuxt Modules using our [starter template](http
 ::package-managers
 
 ```bash [npm]
-npm create nuxt -t module my-module
+npx nuxi init -t module my-module
 ```
 
 ```bash [yarn]
-yarn create nuxt -t module my-module
+npx nuxi init -t module my-module
 ```
 
 ```bash [pnpm]
-pnpm create nuxt -t module my-module
+npx nuxi init -t module my-module
 ```
 
 ```bash [bun]
-bun create nuxt -t module my-module
+npx nuxi init -t module my-module
 ```
 ::
 

--- a/docs/2.guide/3.going-further/3.modules.md
+++ b/docs/2.guide/3.going-further/3.modules.md
@@ -16,19 +16,19 @@ We recommend you get started with Nuxt Modules using our [starter template](http
 ::package-managers
 
 ```bash [npm]
-npx nuxi init -t module my-module
+npm create nuxt -- -t module my-module
 ```
 
 ```bash [yarn]
-npx nuxi init -t module my-module
+yarn create nuxt -t module my-module
 ```
 
 ```bash [pnpm]
-npx nuxi init -t module my-module
+pnpm create nuxt -- -t module my-module
 ```
 
 ```bash [bun]
-npx nuxi init -t module my-module
+bun create nuxt -t module my-module
 ```
 ::
 

--- a/docs/2.guide/3.going-further/7.layers.md
+++ b/docs/2.guide/3.going-further/7.layers.md
@@ -70,7 +70,7 @@ Additionally, certain other files in the layer directory will be auto-scanned an
 To get started you can initialize a layer with the [nuxt/starter/layer template](https://github.com/nuxt/starter/tree/layer). This will create a basic structure you can build upon. Execute this command within the terminal to get started:
 
 ```bash [Terminal]
-npm create nuxt --template layer nuxt-layer
+npx nuxi init --template layer nuxt-layer
 ```
 
 Follow up on the README instructions for the next steps.

--- a/docs/2.guide/3.going-further/7.layers.md
+++ b/docs/2.guide/3.going-further/7.layers.md
@@ -70,7 +70,7 @@ Additionally, certain other files in the layer directory will be auto-scanned an
 To get started you can initialize a layer with the [nuxt/starter/layer template](https://github.com/nuxt/starter/tree/layer). This will create a basic structure you can build upon. Execute this command within the terminal to get started:
 
 ```bash [Terminal]
-npx nuxi init --template layer nuxt-layer
+npm create nuxt -- --template layer nuxt-layer
 ```
 
 Follow up on the README instructions for the next steps.


### PR DESCRIPTION
### 📚 Description
Since `npm create nuxt` does not support the `--template` option, this PR reverts all changes of [fc4a8e8](https://github.com/nuxt/nuxt/commit/fc4a8e8fcfa109659e77f1ca19fb9cb59ecd692d) that use `--template`.
