### PR TITLE
feat: update documentation bug from Module Author Guide

### DIFF
--- a/docs/2.guide/3.going-further/3.modules.md
+++ b/docs/2.guide/3.going-further/3.modules.md
@@ -13,7 +13,7 @@ With modules, you can encapsulate, properly test, and share custom solutions as 
 
 We recommend you get started with Nuxt Modules using our [starter template](https://github.com/nuxt/starter/tree/module):
 
-```bash [npm]
+```bash
 npx nuxi init [-t, --template] module my-module
 ```
 

--- a/docs/2.guide/3.going-further/3.modules.md
+++ b/docs/2.guide/3.going-further/3.modules.md
@@ -13,24 +13,9 @@ With modules, you can encapsulate, properly test, and share custom solutions as 
 
 We recommend you get started with Nuxt Modules using our [starter template](https://github.com/nuxt/starter/tree/module):
 
-::package-managers
-
 ```bash [npm]
-npm create nuxt -- -t module my-module
+npx nuxi init [-t, --template] module my-module
 ```
-
-```bash [yarn]
-yarn create nuxt -t module my-module
-```
-
-```bash [pnpm]
-pnpm create nuxt -- -t module my-module
-```
-
-```bash [bun]
-bun create nuxt -t module my-module
-```
-::
 
 This will create a `my-module` project with all the boilerplate necessary to develop and publish your module.
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves #31474

### 📚 Description

In the module author guide on the documentation from Nuxt there is a command that should open the starter project of a module but the command is outdated.

#### Documentation page:
[Module Author Guide](https://nuxt.com/docs/guide/going-further/modules)

#### Command:
```bash
npm create nuxt -t module my-module
```

#### Fix:
Use the npx nuxi init method
```
npx nuxi init [-t, --template] module my-module
```
