### PR TITLE
docs: mention autoimport resolveComponent only works with literal strings

### DIFF
--- a/docs/2.guide/2.directory-structure/1.components.md
+++ b/docs/2.guide/2.directory-structure/1.components.md
@@ -79,8 +79,7 @@ const MyButton = resolveComponent('MyButton')
 ```
 
 ::important
-If you are using `resolveComponent` to handle dynamic components, make sure not to insert anything but the name of the component, which must be a literal string (template strings are not valid) and not a variable.
-The string is statically analyzed at compilation step.
+If you are using `resolveComponent` to handle dynamic components, make sure not to insert anything but the name of the component, which must be a literal string and not be or contain a variable. The string is statically analyzed at compilation step.
 ::
 
 ::tip{icon="i-lucide-video" to="https://www.youtube.com/watch?v=4kq8E5IUM2U" target="\_blank"}

--- a/docs/2.guide/2.directory-structure/1.components.md
+++ b/docs/2.guide/2.directory-structure/1.components.md
@@ -79,8 +79,8 @@ const MyButton = resolveComponent('MyButton')
 ```
 
 ::important
-If you are using `resolveComponent` to handle dynamic components, make sure not to insert anything but the name of the component, which must be a string and not a variable.
-Autoimports only works with literal strings and does not accept any operations nor template strings within `resolveComponent`.
+If you are using `resolveComponent` to handle dynamic components, make sure not to insert anything but the name of the component, which must be a literal string (template strings are not valid) and not a variable.
+The string is statically analyzed at compilation step.
 ::
 
 ::tip{icon="i-lucide-video" to="https://www.youtube.com/watch?v=4kq8E5IUM2U" target="\_blank"}

--- a/docs/2.guide/2.directory-structure/1.components.md
+++ b/docs/2.guide/2.directory-structure/1.components.md
@@ -80,6 +80,7 @@ const MyButton = resolveComponent('MyButton')
 
 ::important
 If you are using `resolveComponent` to handle dynamic components, make sure not to insert anything but the name of the component, which must be a string and not a variable.
+Autoimports only works with literal strings and does not accept any operations nor template strings within `resolveComponent`.
 ::
 
 ::tip{icon="i-lucide-video" to="https://www.youtube.com/watch?v=4kq8E5IUM2U" target="\_blank"}


### PR DESCRIPTION

### 🔗 Linked issue

fix #31503


<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Docs are maybe not clear enough that autoimports only accept literal strings

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
