### PR TITLE
fix(nuxt): write initial cookie value if different from `document.cookie`

### DIFF
--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -794,6 +794,17 @@ describe('useCookie', () => {
       expect(computedVal.value).toBe(-1)
     }
   })
+
+  it('should set cookie value when called on client', () => {
+    useCookie('cookie-watch-false', { default: () => 'foo', watch: false })
+    expect(document.cookie).toContain('cookie-watch-false=foo')
+
+    useCookie('cookie-watch-true', { default: () => 'foo', watch: true })
+    expect(document.cookie).toContain('cookie-watch-true=foo')
+
+    useCookie('cookie-readonly', { default: () => 'foo', readonly: true })
+    expect(document.cookie).toContain('cookie-readonly=foo')
+  })
 })
 
 describe('callOnce', () => {


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/26701

### 📚 Description

this ensures we always write initial cookie value in the browser if it has expired or we are using the default cookie value