### PR TITLE
fix(nuxt): show fatal errors thrown in middleware

### DIFF
--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -117,7 +117,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(pagesRootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"280k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"281k"`)
 
     const modules = await analyzeSizes(['node_modules/**/*'], serverDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"1395k"`)


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/22731

### 📚 Description

this handles two additional ways errors can be thrown in middleware - either directly returning a fatal error or throwing an error.

in either case this is checked for the `fatal` property (which triggers showing an error page). Otherwise the error is returned to vue router for handling there.