### PR TITLE
test(nuxt): avoid invalid nested font face

### DIFF
--- a/test/fixtures/basic/pages/assets.vue
+++ b/test/fixtures/basic/pages/assets.vue
@@ -24,16 +24,13 @@ import logo from '~/assets/logo.svg'
   background-image: url('~/assets/logo.svg');
   background-repeat: no-repeat;
   background-position: bottom right;
-  @font-face {
-    src: url("/public.svg") format("woff2");
-  }
 }
 body {
   background-image: url('/public.svg');
   background-repeat: no-repeat;
   background-position: top;
-  @font-face {
-    src: url('/public.svg') format('woff2');
-  }
+}
+@font-face {
+  src: url('/public.svg') format('woff2');
 }
 </style>


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

[`@font-face` is not allowed to be nested](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_nesting/Nesting_at-rules).
This tests works fine with Vite using postcss. But when lightningcss is used for minify or transform, this test fails because lightningcss errors.
Rolldown powered Vite uses lightningcss to minify the CSS by default, so this PR helps the test to pass when Rolldown powered Vite is used.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
