### PR TITLE
fix(nuxt): use greedy catchall when `/index` is the last segment

### DIFF
--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -139,7 +139,7 @@ export function generateRoutesFromFiles (files: ScannedFile[], options: Generate
       route.name += (route.name && '/') + segmentName
 
       // ex: parent.vue + parent/child.vue
-      const routePath = getRoutePath(tokens, segments[i + 1] !== undefined)
+      const routePath = getRoutePath(tokens, segments[i + 1] !== undefined && segments[i + 1] !== 'index')
       const path = withLeadingSlash(joinURL(route.path, routePath.replace(INDEX_PAGE_RE, '/')))
       const child = parent.find(parentRoute => parentRoute.name === route.name && parentRoute.path === path)
 

--- a/packages/nuxt/test/__snapshots__/pages-override-meta-disabled.test.ts.snap
+++ b/packages/nuxt/test/__snapshots__/pages-override-meta-disabled.test.ts.snap
@@ -594,6 +594,15 @@
   "should use more performant regexp when catchall is used in middle of path": [
     {
       "alias": "mockMeta?.alias || []",
+      "component": "() => import("pages/[...id]/index.vue")",
+      "meta": "mockMeta || {}",
+      "name": "mockMeta?.name ?? "id"",
+      "path": "mockMeta?.path ?? "/:id(.*)*"",
+      "props": "mockMeta?.props ?? false",
+      "redirect": "mockMeta?.redirect",
+    },
+    {
+      "alias": "mockMeta?.alias || []",
       "component": "() => import("pages/[...id]/suffix.vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "id-suffix"",

--- a/packages/nuxt/test/__snapshots__/pages-override-meta-enabled.test.ts.snap
+++ b/packages/nuxt/test/__snapshots__/pages-override-meta-enabled.test.ts.snap
@@ -372,6 +372,11 @@
   ],
   "should use more performant regexp when catchall is used in middle of path": [
     {
+      "component": "() => import("pages/[...id]/index.vue")",
+      "name": ""id"",
+      "path": ""/:id(.*)*"",
+    },
+    {
       "component": "() => import("pages/[...id]/suffix.vue")",
       "name": ""id-suffix"",
       "path": ""/:id([^/]*)*/suffix"",

--- a/packages/nuxt/test/pages.test.ts
+++ b/packages/nuxt/test/pages.test.ts
@@ -608,8 +608,18 @@ describe('pages:generateRoutesFromFiles', () => {
         {
           path: `${pagesDir}/[...id]/suffix.vue`,
         },
+        {
+          path: `${pagesDir}/[...id]/index.vue`,
+        },
       ],
       output: [
+        {
+          name: 'id',
+          meta: undefined,
+          path: '/:id(.*)*',
+          file: `${pagesDir}/[...id]/index.vue`,
+          children: [],
+        },
         {
           name: 'id-suffix',
           meta: undefined,


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt-modules/i18n/issues/3464

### 📚 Description

we don't want to apply the more narrow regexp when there is no following segment, but we neglected to check for `/index` as a segment (which we ignore) meaning the path matcher we created had too low of a priority