### PR TITLE
fix(kit,vite): ensure all `modulesDir` paths are added to `fs.allow`

### DIFF
--- a/packages/schema/src/config/vite.ts
+++ b/packages/schema/src/config/vite.ts
@@ -114,13 +114,12 @@ export default defineResolvers({
       fs: {
         allow: {
           $resolve: async (val, get) => {
-            const [buildDir, srcDir, rootDir, workspaceDir, modulesDir] = await Promise.all([get('buildDir'), get('srcDir'), get('rootDir'), get('workspaceDir'), get('modulesDir')])
+            const [buildDir, srcDir, rootDir, workspaceDir] = await Promise.all([get('buildDir'), get('srcDir'), get('rootDir'), get('workspaceDir')])
             return [...new Set([
               buildDir,
               srcDir,
               rootDir,
               workspaceDir,
-              ...(modulesDir),
               ...Array.isArray(val) ? val : [],
             ])]
           },

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -37,6 +37,7 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
   let allowDirs = [
     nuxt.options.appDir,
     nuxt.options.workspaceDir,
+    ...nuxt.options.modulesDir,
     ...nuxt.options._layers.map(l => l.config.rootDir),
     ...Object.values(nuxt.apps).flatMap(app => [
       ...app.components.map(c => dirname(c.filePath)),


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/31311

### 📚 Description

this bundles two changes:

1. more accurately resolves node_modules folder when a module is not within `node_modules/` (e.g. local modules)
2. passes `modulesDir` to fs.allow later on, which accounts for intervening changes (modules being pushed to `modulesDir` after the schema is initially resolved)