### PR TITLE
refactor(nuxt): simplify conditional branches of `<NuxtPage>`

### DIFF
--- a/packages/nuxt/src/pages/runtime/page.ts
+++ b/packages/nuxt/src/pages/runtime/page.ts
@@ -31,7 +31,7 @@ export interface NuxtPageProps extends RouterViewProps {
   pageKey?: string | ((route: RouteLocationNormalizedLoaded) => string)
 }
 
-const _routeProviders = import.meta.dev ? new Map<Component, ReturnType<typeof defineRouteProvider> | undefined>() : new WeakMap<Component, ReturnType<typeof defineRouteProvider> | undefined>()
+const _routeProviders = import.meta.dev ? new Map<string, ReturnType<typeof defineRouteProvider> | undefined>() : new WeakMap<Component, ReturnType<typeof defineRouteProvider> | undefined>()
 
 export default defineComponent({
   name: 'NuxtPage',
@@ -73,7 +73,7 @@ export default defineComponent({
       useRouter().beforeEach(removeErrorHook)
     }
 
-    if (props.pageKey) {
+    if (import.meta.client && props.pageKey) {
       watch(() => props.pageKey, (next, prev) => {
         if (next !== prev) {
           nuxtApp.callHook('page:loading:start')
@@ -84,6 +84,7 @@ export default defineComponent({
     if (import.meta.dev) {
       nuxtApp._isNuxtPageUsed = true
     }
+
     let pageLoadingEndHookAlreadyCalled = false
     if (import.meta.client) {
       const unsub = useRouter().beforeResolve(() => {
@@ -96,118 +97,109 @@ export default defineComponent({
 
     return () => {
       return h(RouterView, { name: props.name, route: props.route, ...attrs }, {
-        default: (routeProps: RouterViewSlotProps) => {
-          const isRenderingNewRouteInOldFork = import.meta.client && haveParentRoutesRendered(forkRoute, routeProps.route, routeProps.Component)
-          const hasSameChildren = import.meta.client && forkRoute && forkRoute.matched.length === routeProps.route.matched.length
-
-          if (!routeProps.Component) {
-            // If we're rendering a `<NuxtPage>` child route on navigation to a route which lacks a child page
-            // we'll render the old vnode until the new route finishes resolving
-            if (import.meta.client && vnode && !hasSameChildren) {
-              return vnode
+        default: import.meta.server
+          ? (routeProps: RouterViewSlotProps) => {
+              return h(Suspense, { suspensible: true }, {
+                default () {
+                  return h(RouteProvider, {
+                    vnode: slots.default ? normalizeSlot(slots.default, routeProps) : routeProps.Component,
+                    route: routeProps.route,
+                    vnodeRef: pageRef,
+                  })
+                },
+              })
             }
-            done()
-            return
-          }
+          : (routeProps: RouterViewSlotProps) => {
+              const isRenderingNewRouteInOldFork = haveParentRoutesRendered(forkRoute, routeProps.route, routeProps.Component)
+              const hasSameChildren = forkRoute && forkRoute.matched.length === routeProps.route.matched.length
 
-          // Return old vnode if we are rendering _new_ page suspense fork in _old_ layout suspense fork
-          if (import.meta.client && vnode && _layoutMeta && !_layoutMeta.isCurrent(routeProps.route)) {
-            return vnode
-          }
+              if (!routeProps.Component) {
+              // If we're rendering a `<NuxtPage>` child route on navigation to a route which lacks a child page
+              // we'll render the old vnode until the new route finishes resolving
+                if (vnode && !hasSameChildren) {
+                  return vnode
+                }
+                done()
+                return
+              }
 
-          if (import.meta.client && isRenderingNewRouteInOldFork && forkRoute && (!_layoutMeta || _layoutMeta?.isCurrent(forkRoute))) {
-            // if leaving a route with an existing child route, render the old vnode
-            if (hasSameChildren) {
+              // Return old vnode if we are rendering _new_ page suspense fork in _old_ layout suspense fork
+              if (vnode && _layoutMeta && !_layoutMeta.isCurrent(routeProps.route)) {
+                return vnode
+              }
+
+              if (isRenderingNewRouteInOldFork && forkRoute && (!_layoutMeta || _layoutMeta?.isCurrent(forkRoute))) {
+              // if leaving a route with an existing child route, render the old vnode
+                if (hasSameChildren) {
+                  return vnode
+                }
+                // If _leaving_ null child route, return null vnode
+                return null
+              }
+
+              const key = generateRouteKey(routeProps, props.pageKey)
+
+              const willRenderAnotherChild = hasChildrenRoutes(forkRoute, routeProps.route, routeProps.Component)
+              if (!nuxtApp.isHydrating && previousPageKey === key && !willRenderAnotherChild) {
+                nuxtApp.callHook('page:loading:end')
+                pageLoadingEndHookAlreadyCalled = true
+              }
+
+              previousPageKey = key
+
+              // Client side rendering
+              const hasTransition = !!(props.transition ?? routeProps.route.meta.pageTransition ?? defaultPageTransition)
+              const transitionProps = hasTransition && _mergeTransitionProps([
+                props.transition,
+                routeProps.route.meta.pageTransition,
+                defaultPageTransition,
+                { onAfterLeave: () => { nuxtApp.callHook('page:transition:finish', routeProps.Component) } },
+              ])
+
+              const keepaliveConfig = props.keepalive ?? routeProps.route.meta.keepalive ?? (defaultKeepaliveConfig as KeepAliveProps)
+              vnode = _wrapInTransition(hasTransition && transitionProps,
+                wrapInKeepAlive(keepaliveConfig, h(Suspense, {
+                  suspensible: true,
+                  onPending: () => nuxtApp.callHook('page:start', routeProps.Component),
+                  onResolve: () => {
+                    nextTick(() => nuxtApp.callHook('page:finish', routeProps.Component).then(() => {
+                      if (!pageLoadingEndHookAlreadyCalled && !willRenderAnotherChild) {
+                        pageLoadingEndHookAlreadyCalled = true
+                        return nuxtApp.callHook('page:loading:end')
+                      }
+                    }).finally(done))
+                  },
+                }, {
+                  default: () => {
+                    const routeProviderProps = {
+                      key: key || undefined,
+                      vnode: slots.default ? normalizeSlot(slots.default, routeProps) : routeProps.Component,
+                      route: routeProps.route,
+                      renderKey: key || undefined,
+                      trackRootNodes: hasTransition,
+                      vnodeRef: pageRef,
+                    }
+
+                    if (!keepaliveConfig) {
+                      return h(RouteProvider, routeProviderProps)
+                    }
+
+                    const routerComponentType = routeProps.Component.type as any
+                    const routeProviderKey = import.meta.dev ? routerComponentType.name || routerComponentType.__name : routerComponentType
+                    let PageRouteProvider = _routeProviders.get(routeProviderKey)
+
+                    if (!PageRouteProvider) {
+                      PageRouteProvider = defineRouteProvider(routerComponentType.name || routerComponentType.__name)
+                      _routeProviders.set(routeProviderKey, PageRouteProvider)
+                    }
+
+                    return h(PageRouteProvider, routeProviderProps)
+                  },
+                }),
+                )).default()
+
               return vnode
-            }
-            // If _leaving_ null child route, return null vnode
-            return null
-          }
-
-          const key = generateRouteKey(routeProps, props.pageKey)
-
-          const willRenderAnotherChild = import.meta.client && hasChildrenRoutes(forkRoute, routeProps.route, routeProps.Component)
-          if (!nuxtApp.isHydrating && previousPageKey === key && !willRenderAnotherChild) {
-            nuxtApp.callHook('page:loading:end')
-            pageLoadingEndHookAlreadyCalled = true
-          }
-
-          previousPageKey = key
-
-          if (import.meta.server) {
-            vnode = h(Suspense, {
-              suspensible: true,
-            }, {
-              default: () => {
-                const providerVNode = h(RouteProvider, {
-                  key: key || undefined,
-                  vnode: slots.default ? normalizeSlot(slots.default, routeProps) : routeProps.Component,
-                  route: routeProps.route,
-                  renderKey: key || undefined,
-                  vnodeRef: pageRef,
-                })
-                return providerVNode
-              },
-            })
-
-            return vnode
-          }
-
-          // Client side rendering
-          const hasTransition = !!(props.transition ?? routeProps.route.meta.pageTransition ?? defaultPageTransition)
-          const transitionProps = hasTransition && _mergeTransitionProps([
-            props.transition,
-            routeProps.route.meta.pageTransition,
-            defaultPageTransition,
-            { onAfterLeave: () => { nuxtApp.callHook('page:transition:finish', routeProps.Component) } },
-          ].filter(Boolean))
-
-          const keepaliveConfig = props.keepalive ?? routeProps.route.meta.keepalive ?? (defaultKeepaliveConfig as KeepAliveProps)
-          vnode = _wrapInTransition(hasTransition && transitionProps,
-            wrapInKeepAlive(keepaliveConfig, h(Suspense, {
-              suspensible: true,
-              onPending: () => nuxtApp.callHook('page:start', routeProps.Component),
-              onResolve: () => {
-                nextTick(() => nuxtApp.callHook('page:finish', routeProps.Component).then(() => {
-                  if (!pageLoadingEndHookAlreadyCalled && !willRenderAnotherChild) {
-                    pageLoadingEndHookAlreadyCalled = true
-                    return nuxtApp.callHook('page:loading:end')
-                  }
-                }).finally(done))
-              },
-            }, {
-              default: () => {
-                const routeProviderProps = {
-                  key: key || undefined,
-                  vnode: slots.default ? normalizeSlot(slots.default, routeProps) : routeProps.Component,
-                  route: routeProps.route,
-                  renderKey: key || undefined,
-                  trackRootNodes: hasTransition,
-                  vnodeRef: pageRef,
-                }
-
-                if (!keepaliveConfig) {
-                  return h(RouteProvider, routeProviderProps)
-                }
-
-                const routerComponentType = routeProps.Component.type as any
-                const routeProviderKey = import.meta.dev ? routerComponentType.name || routerComponentType.__name : routerComponentType
-                let PageRouteProvider = import.meta.client ? _routeProviders.get(routeProviderKey) : undefined
-
-                if (!PageRouteProvider) {
-                  PageRouteProvider = defineRouteProvider(routerComponentType.name || routerComponentType.__name)
-                  if (import.meta.client) {
-                    _routeProviders.set(routeProviderKey, PageRouteProvider)
-                  }
-                }
-
-                return h(PageRouteProvider, routeProviderProps)
-              },
-            }),
-            )).default()
-
-          return vnode
-        },
+            },
       })
     }
   },
@@ -231,7 +223,7 @@ export default defineComponent({
 }
 
 function _mergeTransitionProps (routeProps: TransitionProps[]): TransitionProps {
-  const _props: TransitionProps[] = routeProps.map(prop => ({
+  const _props: TransitionProps[] = routeProps.filter(Boolean).map(prop => ({
     ...prop,
     onAfterLeave: prop.onAfterLeave ? toArray(prop.onAfterLeave) : undefined,
   }))

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -117,7 +117,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(pagesRootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"280k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"279k"`)
 
     const modules = await analyzeSizes(['node_modules/**/*'], serverDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"1395k"`)


### PR DESCRIPTION
### 🔗 Linked issue

### 📚 Description

This is a small refactor of the `<NuxtPage>` component to simplify some conditional branches and improve readability.

- Removed some redundant `import.meta.client` checks by consolidating server-side logic into a single block.
- Improved type safety by switching from `Map<Component, Provider>` to `Map<string, Provider>` in dev mode.
- Ensured the `watch(() => () => props.pageKey)` only runs on the client side.

This PR doesn't aim to change any behavior, it's just a minor readability and structure improvement.

I'm not entirely sure if all of these changes are appropriate or desirable, so I’d really appreciate any feedback or suggestions.
