### PR TITLE
docs: inprove description of `page:start` and `page:finish` hooks

### DIFF
--- a/docs/3.api/6.advanced/1.hooks.md
+++ b/docs/3.api/6.advanced/1.hooks.md
@@ -24,8 +24,8 @@ Hook                   | Arguments           | Environment     | Description
 `app:manifest:update`  | `{ id, timestamp }` | Client          | Called when there is a newer version of your app detected.
 `app:data:refresh`     | `keys?`             | Client          | Called when `refreshNuxtData` is called.
 `link:prefetch`        | `to`                | Client          | Called when a `<NuxtLink>` is observed to be prefetched.
-`page:start`           | `pageComponent?`    | Client          | Called on [Suspense](https://vuejs.org/guide/built-ins/suspense.html#suspense) pending event.
-`page:finish`          | `pageComponent?`    | Client          | Called on [Suspense](https://vuejs.org/guide/built-ins/suspense.html#suspense) resolved event.
+`page:start`           | `pageComponent?`    | Client          | Called on [Suspense](https://vuejs.org/guide/built-ins/suspense.html#suspense) inside of `NuxtPage` pending event.
+`page:finish`          | `pageComponent?`    | Client          | Called on [Suspense](https://vuejs.org/guide/built-ins/suspense.html#suspense) inside of `NuxtPage` resolved event.
 `page:loading:start`   | -                   | Client          | Called when the `setup()` of the new page is running.
 `page:loading:end`     | -                   | Client          | Called after `page:finish`
 `page:transition:finish`| `pageComponent?`    | Client          | After page transition [onAfterLeave](https://vuejs.org/guide/built-ins/transition.html#javascript-hooks) event.


### PR DESCRIPTION
### 🔗 Linked issue

Resolve #31159

### 📚 Description

This PR improves the descriptions of `page:start` and `page:finish` hooks to clarify that they are triggered specifically inside `<NuxtPage>` Suspense events.
