### PR TITLE
fix(nuxt): pass error data to `error.vue`

### DIFF
--- a/packages/nuxt/src/core/runtime/nitro/handlers/error.ts
+++ b/packages/nuxt/src/core/runtime/nitro/handlers/error.ts
@@ -33,6 +33,8 @@ export default <NitroErrorHandler> async function errorhandler (error, event, { 
   errorObject.url = url.pathname + url.search + url.hash
   // add default server message
   errorObject.message ||= 'Server Error'
+  // we will be rendering this error internally so we can pass along the error.data safely
+  errorObject.data ||= error.data
 
   delete defaultRes.headers['content-type'] // this would be set to application/json
   delete defaultRes.headers['content-security-policy'] // this would disable JS execution in the error page


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/31449

### 📚 Description

nitro default error hander doesn't return `error.data` (as expected) as an API response in production, but we do want to pass this along when rendering `error.vue` so user can choose whether to use this data in rendering/handling the page