### PR TITLE
feat: add emit logic as option to NuxtLink component

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -10,7 +10,7 @@ import type {
   VNode,
   VNodeProps,
 } from 'vue'
-import { computed, defineComponent, h, inject, onBeforeUnmount, onMounted, provide, ref, resolveComponent } from 'vue'
+import { computed, defineComponent, getCurrentInstance, h, inject, onBeforeUnmount, onMounted, provide, ref, resolveComponent } from 'vue'
 import type { RouteLocation, RouteLocationRaw, Router, RouterLink, RouterLinkProps, UseLinkReturn, useLink } from 'vue-router'
 import { hasProtocol, joinURL, parseQuery, withTrailingSlash, withoutTrailingSlash } from 'ufo'
 import { preloadRouteComponents } from '../composables/preload'
@@ -336,8 +336,11 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
         required: false,
       },
     },
+    emits: {
+      'navigation-complete': (_payload: { to: RouteLocation, from: RouteLocation }) => true,
+    },
     useLink: useNuxtLink,
-    setup (props, { slots }) {
+    setup (props, { slots, emit }) {
       const router = useRouter()
 
       const { to, href, navigate, isExternal, hasTarget, isAbsoluteUrl } = useNuxtLink(props)
@@ -350,6 +353,17 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
       function shouldPrefetch (mode: 'visibility' | 'interaction') {
         if (import.meta.server) { return }
         return !prefetched.value && (typeof props.prefetchOn === 'string' ? props.prefetchOn === mode : (props.prefetchOn?.[mode] ?? options.prefetchOn?.[mode])) && (props.prefetch ?? options.prefetch) !== false && props.noPrefetch !== true && props.target !== '_blank' && !isSlowConnection()
+      }
+
+      const instance = getCurrentInstance()
+      const hasNavigationCompleteListener = !!instance?.vnode.props?.onNavigationComplete
+      if (!isExternal.value && hasNavigationCompleteListener) {
+        onMounted(() => {
+          const unregister = router.afterEach((to, from) => {
+            emit('navigation-complete', { to, from })
+          })
+          onBeforeUnmount(unregister)
+        })
       }
 
       async function prefetch (nuxtApp = useNuxtApp()) {
@@ -500,7 +514,8 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
   }) as unknown as (new<CustomProp extends boolean = false>(props: NuxtLinkProps<CustomProp>) => InstanceType<DefineSetupFnComponent<
     NuxtLinkProps<CustomProp>,
     [],
-    SlotsType<NuxtLinkSlots<CustomProp>>
+    SlotsType<NuxtLinkSlots<CustomProp>>,
+    { 'navigation-complete': { to: RouteLocation, from: RouteLocation } }
   >>) & Record<string, any>
 }
 


### PR DESCRIPTION
### 🔗 Linked issue

#19928 

### 📚 Description

This is I think a first implementation to have emits after navigation using NuxtLink. I made some prototype to see if it works but i'm not sure about the details

I did take into account: 

- it shouldn't be used when its external
- We have to check if the emit is set to register it

I currently have an issue that the emit values are of type any although I set the type in the nuxt-link.ts file

What do you think about how to implement it?
