### PR TITLE
refactor: replace `useServerHead` in `onPrehydrate` with `useHead`

### DIFF
--- a/packages/nuxt/src/app/composables/ssr.ts
+++ b/packages/nuxt/src/app/composables/ssr.ts
@@ -6,7 +6,7 @@ import type { H3Event$Fetch } from 'nitro/types'
 import type { NuxtApp } from '../nuxt'
 import { useNuxtApp } from '../nuxt'
 import { toArray } from '../utils'
-import { useServerHead } from './head'
+import { useHead } from './head'
 
 /** @since 3.0.0 */
 export function useRequestEvent (nuxtApp: NuxtApp = useNuxtApp()) {
@@ -130,7 +130,7 @@ export function onPrehydrate (callback: string | ((el: HTMLElement) => void), ke
     ? `document.querySelectorAll('[${PREHYDRATE_ATTR_KEY}*=${JSON.stringify(key)}]').forEach` + callback
     : (callback + '()')
 
-  useServerHead({
+  useHead({
     script: [{
       key: vm && key ? key : undefined,
       tagPosition: 'bodyClose',


### PR DESCRIPTION
### 🔗 Linked issue

### 📚 Description

The `useServerHead` composable has been deprecated. According to the unhead documentation, it is recommended to use `useHead` instead and wrap it with `if (import.meta.server)`.