### PR TITLE
refactor(nuxt): improve tree-shaking of `useRequestEvent` on client

### DIFF
--- a/packages/nuxt/src/app/composables/ssr.ts
+++ b/packages/nuxt/src/app/composables/ssr.ts
@@ -9,7 +9,9 @@ import { toArray } from '../utils'
 import { useServerHead } from './head'
 
 /** @since 3.0.0 */
-export function useRequestEvent (nuxtApp: NuxtApp = useNuxtApp()) {
+export function useRequestEvent (nuxtApp?: NuxtApp) {
+  if (import.meta.client) { return }
+  nuxtApp ||= useNuxtApp()
   return nuxtApp.ssrContext?.event
 }
 


### PR DESCRIPTION
### 🔗 Linked issue

### 📚 Description

**Before (client build output)**

```js
function useRequestEvent(nuxtApp = useNuxtApp()) {
  var _a;
  return (_a = nuxtApp.ssrContext) == null ? void 0 : _a.event;
}
```

**After**

```js
function useRequestEvent(nuxtApp) {
  {
    return;
  }
}
```
