### PR TITLE
docs: add note on extending auto-imports

### DIFF
--- a/docs/2.guide/1.concepts/8.typescript.md
+++ b/docs/2.guide/1.concepts/8.typescript.md
@@ -59,6 +59,11 @@ Some of the references in the file are to files that are only generated within y
 
 This file contains the recommended basic TypeScript configuration for your project, including resolved aliases injected by Nuxt or modules you are using, so you can get full type support and path auto-complete for aliases like `~/file` or `#build/file`.
 
+::note
+Consider using the `imports` section of [nuxt.config](/docs/api/nuxt-config#imports) to include directories beyond the default ones. This can be useful for auto-importing types which you're using across your app.
+::
+
+
 [Read more about how to extend this configuration](/docs/guide/directory-structure/tsconfig).
 
 ::tip{icon="i-lucide-video" to="https://youtu.be/umLI7SlPygY" target="_blank"}

--- a/docs/2.guide/1.concepts/8.typescript.md
+++ b/docs/2.guide/1.concepts/8.typescript.md
@@ -63,7 +63,6 @@ This file contains the recommended basic TypeScript configuration for your proje
 Consider using the `imports` section of [nuxt.config](/docs/api/nuxt-config#imports) to include directories beyond the default ones. This can be useful for auto-importing types which you're using across your app.
 ::
 
-
 [Read more about how to extend this configuration](/docs/guide/directory-structure/tsconfig).
 
 ::tip{icon="i-lucide-video" to="https://youtu.be/umLI7SlPygY" target="_blank"}


### PR DESCRIPTION
### 🔗 Linked issue

Not applicable.

### 📚 Description

When using TypeScript, we'll eventually have types which are used in multiple places within the app. Instead of importing them everywhere, it can be useful to auto-import them. 

I'm adding a note about this in the TypeScript section because it wasn't immediately obvious to me how to approach this, so it might help others.