### PR TITLE
docs: Improve description about app.vue

### DIFF
--- a/docs/2.guide/2.directory-structure/3.app.md
+++ b/docs/2.guide/2.directory-structure/3.app.md
@@ -59,7 +59,6 @@ Learn more about how to structure your pages using the `pages/` directory.
 
 When your application requires different layouts for different pages, you can use the `layouts/` directory with the [`<NuxtLayout>`](/docs/api/components/nuxt-layout) component. This allows you to define multiple layouts and apply them per page.
 
-
 ```vue [app.vue]
 <template>
   <NuxtLayout>

--- a/docs/2.guide/2.directory-structure/3.app.md
+++ b/docs/2.guide/2.directory-structure/3.app.md
@@ -51,6 +51,10 @@ You can also define the common structure of your application directly in `app.vu
 Remember that `app.vue` acts as the main component of your Nuxt application. Anything you add to it (JS and CSS) will be global and included in every page.
 ::
 
+::read-more{to="/docs/guide/directory-structure/pages"}
+Learn more about how to structure your pages using the `pages/` directory.
+::
+
 ### Usage with Layouts
 
 When your application requires different layouts for different pages, you can use the `layouts/` directory with the [`<NuxtLayout>`](/docs/api/components/nuxt-layout) component. This allows you to define multiple layouts and apply them per page.

--- a/docs/2.guide/2.directory-structure/3.app.md
+++ b/docs/2.guide/2.directory-structure/3.app.md
@@ -5,9 +5,15 @@ head.title: "app.vue"
 navigation.icon: i-lucide-file
 ---
 
-## Minimal Usage
+::tip
+If you have a `pages/` directory, the `app.vue` file is optional. Nuxt will automatically include a default `app.vue`, but you can still add your own to customize the structure and content as needed.
+::
 
-With Nuxt, the [`pages/`](/docs/guide/directory-structure/pages) directory is optional. If not present, Nuxt won't include [vue-router](https://router.vuejs.org) dependency. This is useful when working on a landing page or an application that does not need routing.
+## Usage
+
+### Minimal Usage
+
+With Nuxt, the [`pages/`](/docs/guide/directory-structure/pages) directory is optional. If it is not present, Nuxt will not include the [vue-router](https://router.vuejs.org) dependency. This is useful when building a landing page or an application that does not require routing.
 
 ```vue [app.vue]
 <template>
@@ -17,28 +23,47 @@ With Nuxt, the [`pages/`](/docs/guide/directory-structure/pages) directory is op
 
 :link-example{to="/docs/examples/hello-world"}
 
-## Usage with Pages
+### Usage with Pages
 
-If you have a [`pages/`](/docs/guide/directory-structure/pages) directory, to display the current page, use the [`<NuxtPage>`](/docs/api/components/nuxt-page) component:
+When you have a [`pages/`](/docs/guide/directory-structure/pages) directory, you need to use the [`<NuxtPage>`](/docs/api/components/nuxt-page) component to display the current page:
 
 ```vue [app.vue]
 <template>
-  <div>
-    <NuxtLayout>
-      <NuxtPage/>
-    </NuxtLayout>
-  </div>
+  <NuxtPage />
 </template>
 ```
 
-::warning
-Since [`<NuxtPage>`](/docs/api/components/nuxt-page) internally uses Vue's [`<Suspense>`](https://vuejs.org/guide/built-ins/suspense.html#suspense) component, it cannot be set as a root element.
-::
+You can also define the common structure of your application directly in `app.vue`. This is useful when you want to include global elements such as a header or footer:
+
+```vue [app.vue]
+<template>
+  <header>
+    Header content
+  </header>
+  <NuxtPage />
+  <footer>
+    Footer content
+  </footer>
+</template>
+```
 
 ::note
 Remember that `app.vue` acts as the main component of your Nuxt application. Anything you add to it (JS and CSS) will be global and included in every page.
 ::
 
+### Usage with Layouts
+
+When your application requires different layouts for different pages, you can use the `layouts/` directory with the [`<NuxtLayout>`](/docs/api/components/nuxt-layout) component. This allows you to define multiple layouts and apply them per page.
+
+
+```vue [app.vue]
+<template>
+  <NuxtLayout>
+    <NuxtPage />
+  </NuxtLayout>
+</template>
+```
+
 ::read-more{to="/docs/guide/directory-structure/layouts"}
-If you want to have the possibility to customize the structure around the page between pages, check out the `layouts/` directory.
+Learn more about how to structure your layouts using the `layouts/` directory.
 ::


### PR DESCRIPTION
### 🔗 Linked issue

### 📚 Description

Updated the `app.vue` documentation with some structural adjust and two main changes:

- Mentioned that `app.vue` is optional when have a `pages/`.
- Removed the note about `<NuxtPage>` not being usable as a root component.

If there’s anything that could be improved, I’m happy to adjust. Thank you!
