### PR TITLE
fix(vite): prevent 404 for existent dev server handlers under `_nuxt/` paths in development

### DIFF
--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -248,10 +248,10 @@ export async function buildClient (ctx: ViteBuildContext) {
       }
     }
 
-    const devHandlerBases: RegExp[] = []
+    const devHandlerRegexes: RegExp[] = []
     for (const handler of ctx.nuxt.options.devServerHandlers) {
       if (handler.route && handler.route !== '/' && handler.route.startsWith(ctx.nuxt.options.app.buildAssetsDir)) {
-        devHandlerBases.push(new RegExp(
+        devHandlerRegexes.push(new RegExp(
           `^${handler.route
             .replace(/:[^/]+/g, '[^/]+') // dynamic segments (:param)
             .replace(/\*\*/g, '.*') // double wildcard (**) to match any path
@@ -289,7 +289,7 @@ export async function buildClient (ctx: ViteBuildContext) {
       })
 
       // if vite has not handled the request, we want to send a 404 for paths which are not in any static base or dev server handlers
-      if (!event.handled && event.path.startsWith(ctx.nuxt.options.app.buildAssetsDir) && !staticBases.some(baseURL => event.path.startsWith(baseURL)) && !devHandlerBases.some(baseRegex => baseRegex.test(event.path))) {
+      if (!event.handled && event.path.startsWith(ctx.nuxt.options.app.buildAssetsDir) && !staticBases.some(baseURL => event.path.startsWith(baseURL)) && !devHandlerRegexes.some(regex => regex.test(event.path))) {
         throw createError({
           statusCode: 404,
         })

--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -276,8 +276,8 @@ export async function buildClient (ctx: ViteBuildContext) {
         })
       })
 
-      // if vite has not handled the request, we want to send a 404 for paths which are not in any static base
-      if (!event.handled && event.path.startsWith(ctx.nuxt.options.app.buildAssetsDir) && !staticBases.some(baseURL => event.path.startsWith(baseURL))) {
+      // if vite has not handled the request, we want to send a 404 for paths which are not in any static base or dev server handlers
+      if (!event.handled && event.path.startsWith(ctx.nuxt.options.app.buildAssetsDir) && !staticBases.some(baseURL => event.path.startsWith(baseURL)) && !ctx.nuxt.options.devServerHandlers.some(handler => handler.route && event.path.startsWith(handler.route))) {
         throw createError({
           statusCode: 404,
         })

--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -248,6 +248,18 @@ export async function buildClient (ctx: ViteBuildContext) {
       }
     }
 
+    const devHandlerBases: RegExp[] = []
+    for (const handler of ctx.nuxt.options.devServerHandlers) {
+      if (handler.route && handler.route !== '/' && handler.route.startsWith(ctx.nuxt.options.app.buildAssetsDir)) {
+        devHandlerBases.push(new RegExp(
+          `^${handler.route
+            .replace(/:[^/]+/g, '[^/]+') // dynamic segments (:param)
+            .replace(/\*\*/g, '.*') // double wildcard (**) to match any path
+            .replace(/\*/g, '[^/]*')}$`, // single wildcard (*) to match any segment
+        ))
+      }
+    }
+
     const viteMiddleware = defineEventHandler(async (event) => {
       const viteRoutes: string[] = []
       for (const viteRoute of viteServer.middlewares.stack) {
@@ -277,7 +289,7 @@ export async function buildClient (ctx: ViteBuildContext) {
       })
 
       // if vite has not handled the request, we want to send a 404 for paths which are not in any static base or dev server handlers
-      if (!event.handled && event.path.startsWith(ctx.nuxt.options.app.buildAssetsDir) && !staticBases.some(baseURL => event.path.startsWith(baseURL)) && !ctx.nuxt.options.devServerHandlers.some(handler => handler.route && event.path.startsWith(handler.route))) {
+      if (!event.handled && event.path.startsWith(ctx.nuxt.options.app.buildAssetsDir) && !staticBases.some(baseURL => event.path.startsWith(baseURL)) && !devHandlerBases.some(baseRegex => baseRegex.test(event.path))) {
         throw createError({
           statusCode: 404,
         })

--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -253,6 +253,7 @@ export async function buildClient (ctx: ViteBuildContext) {
       if (handler.route && handler.route !== '/' && handler.route.startsWith(ctx.nuxt.options.app.buildAssetsDir)) {
         devHandlerRegexes.push(new RegExp(
           `^${handler.route
+            .replace(/[.+?^${}()|[\]\\]/g, '\\$&') // escape regex syntax characters
             .replace(/:[^/]+/g, '[^/]+') // dynamic segments (:param)
             .replace(/\*\*/g, '.*') // double wildcard (**) to match any path
             .replace(/\*/g, '[^/]*')}$`, // single wildcard (*) to match any segment


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #31639

### 📚 Description

This PR resolves an issue where dev server handlers added using `addDevServerHandler` with routes under the `_nuxt` prefix (or the configured buildAssetsDir) would result in a 404 error in development

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
