### PR TITLE
fix(nuxt): pass slots through to lazy hydrated components

### DIFF
--- a/packages/nuxt/src/components/runtime/lazy-hydrated-component.ts
+++ b/packages/nuxt/src/components/runtime/lazy-hydrated-component.ts
@@ -22,7 +22,7 @@ function defineLazyComponent<P extends ComponentObjectPropsOptions> (props: P, d
         loader: () => Promise.resolve(child),
       })
       const onVnodeMounted = () => { ctx.emit('hydrated') }
-      return () => h(comp, mergeProps(ctx.attrs, { onVnodeMounted }))
+      return () => h(comp, mergeProps(ctx.attrs, { onVnodeMounted }), ctx.slots)
     },
   })
 }


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/31633

### 📚 Description

we weren't passing slots through; this fixes the issue.