### PR TITLE
perf(nuxt): use `shallowRef` for built-in composables if possible

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -250,9 +250,9 @@ export function useAsyncData<
     const _ref = options.deep ? ref : shallowRef
     nuxtApp._asyncData[key] = {
       data: _ref(hasCachedData ? initialCachedData : options.default!()),
-      pending: ref(!hasCachedData),
+      pending: shallowRef(!hasCachedData),
       error: toRef(nuxtApp.payload._errors, key),
-      status: ref('idle'),
+      status: shallowRef('idle'),
       _default: options.default!,
     }
   }

--- a/packages/nuxt/src/app/composables/loading-indicator.ts
+++ b/packages/nuxt/src/app/composables/loading-indicator.ts
@@ -1,4 +1,4 @@
-import { computed, getCurrentScope, onScopeDispose, ref } from 'vue'
+import { computed, getCurrentScope, onScopeDispose, shallowRef } from 'vue'
 import type { Ref } from 'vue'
 import { useNuxtApp } from '../nuxt'
 
@@ -39,9 +39,9 @@ function createLoadingIndicator (opts: Partial<LoadingIndicatorOpts> = {}) {
   const { duration = 2000, throttle = 200, hideDelay = 500, resetDelay = 400 } = opts
   const getProgress = opts.estimatedProgress || defaultEstimatedProgress
   const nuxtApp = useNuxtApp()
-  const progress = ref(0)
-  const isLoading = ref(false)
-  const error = ref(false)
+  const progress = shallowRef(0)
+  const isLoading = shallowRef(false)
+  const error = shallowRef(false)
   let done = false
   let rafId: number
 

--- a/packages/nuxt/src/app/composables/route-announcer.ts
+++ b/packages/nuxt/src/app/composables/route-announcer.ts
@@ -1,5 +1,5 @@
 import type { Ref } from 'vue'
-import { getCurrentScope, onScopeDispose, ref } from 'vue'
+import { getCurrentScope, onScopeDispose, shallowRef } from 'vue'
 import { useNuxtApp } from '../nuxt'
 import { injectHead } from './head'
 
@@ -20,8 +20,8 @@ export type RouteAnnouncer = {
 }
 
 function createRouteAnnouncer (opts: NuxtRouteAnnouncerOpts = {}) {
-  const message = ref('')
-  const politeness = ref<Politeness>(opts.politeness || 'polite')
+  const message = shallowRef('')
+  const politeness = shallowRef<Politeness>(opts.politeness || 'polite')
   const activeHead = injectHead()
 
   function set (messageValue: string = '', politenessSetting: Politeness = 'polite') {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This PR uses shallowRefs for all refs with primitives. This should not break any thing. This should have minimal perf gain.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
