### PR TITLE
fix(nuxt): strip base url from `error.url`

### DIFF
--- a/packages/nuxt/src/core/runtime/nitro/handlers/error.ts
+++ b/packages/nuxt/src/core/runtime/nitro/handlers/error.ts
@@ -1,4 +1,4 @@
-import { joinURL, withQuery } from 'ufo'
+import { joinURL, withQuery, withoutBase } from 'ufo'
 import type { NitroErrorHandler } from 'nitro/types'
 import { getRequestHeaders, send, setResponseHeader, setResponseHeaders, setResponseStatus } from 'h3'
 
@@ -30,7 +30,7 @@ export default <NitroErrorHandler> async function errorhandler (error, event, { 
   const errorObject = defaultRes.body as Pick<NonNullable<NuxtPayload['error']>, 'error' | 'statusCode' | 'statusMessage' | 'message' | 'stack'> & { url: string, data: any }
   // remove proto/hostname/port from URL
   const url = new URL(errorObject.url)
-  errorObject.url = url.pathname + url.search + url.hash
+  errorObject.url = withoutBase(useRuntimeConfig(event).app.baseURL, url.pathname) + url.search + url.hash
   // add default server message
   errorObject.message ||= 'Server Error'
   // we will be rendering this error internally so we can pass along the error.data safely


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/31678

### 📚 Description

in https://github.com/nuxt/nuxt/pull/31230 we didn't account for an upstream behaviour change that didn't strip the baseURL from the error url.

this preserves the previous behaviour when handling errors on the client.

(however we should consider aligning for v4 to keep the baseURL present - what do you think @pi0?)