### PR TITLE
fix(nuxt): render inline styles before `app:rendered` is called

### DIFF
--- a/packages/nuxt/src/core/runtime/nitro/handlers/island.ts
+++ b/packages/nuxt/src/core/runtime/nitro/handlers/island.ts
@@ -44,9 +44,9 @@ export default defineEventHandler(async (event) => {
     throw error
   })
 
-  await ssrContext.nuxt?.hooks.callHook('app:rendered', { ssrContext, renderResult })
-
   const inlinedStyles = await renderInlineStyles(ssrContext.modules ?? [])
+
+  await ssrContext.nuxt?.hooks.callHook('app:rendered', { ssrContext, renderResult })
 
   if (inlinedStyles.length) {
     ssrContext.head.push({ style: inlinedStyles })

--- a/packages/nuxt/src/core/runtime/nitro/handlers/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/handlers/renderer.ts
@@ -138,6 +138,12 @@ export default defineRenderHandler(async (event): Promise<Partial<RenderResponse
     await ssrContext.nuxt?.hooks.callHook('app:error', _err)
     throw _err
   })
+
+  // Render inline styles
+  const inlinedStyles = process.env.NUXT_INLINE_STYLES && !ssrContext._renderResponse && !isRenderingPayload
+    ? await renderInlineStyles(ssrContext.modules ?? [])
+    : []
+
   await ssrContext.nuxt?.hooks.callHook('app:rendered', { ssrContext, renderResult: _rendered })
 
   if (ssrContext._renderResponse) { return ssrContext._renderResponse }
@@ -162,11 +168,6 @@ export default defineRenderHandler(async (event): Promise<Partial<RenderResponse
     // Use same ssr context to generate payload for this route
     await payloadCache!.setItem(withoutTrailingSlash(ssrContext.url), renderPayloadResponse(ssrContext))
   }
-
-  // Render inline styles
-  const inlinedStyles = process.env.NUXT_INLINE_STYLES
-    ? await renderInlineStyles(ssrContext.modules ?? [])
-    : []
 
   const NO_SCRIPTS = process.env.NUXT_NO_SCRIPTS || routeOptions.noScripts
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/31385

### 📚 Description

this renders inline styles before calling `app:rendered`, which is the hook we use to remove lazy-hydrated components from the modules list (which triggers adding scripts to `<head>`)

alternatively we could add another hook for removing modules from the list