### PR TITLE
perf(nuxt): replace remaining instance of `globby`

### DIFF
--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -91,7 +91,6 @@
     "escape-string-regexp": "^5.0.0",
     "estree-walker": "^3.0.3",
     "exsolve": "^1.0.4",
-    "globby": "^14.1.0",
     "h3": "^1.15.1",
     "hookable": "^5.5.3",
     "ignore": "^7.0.3",

--- a/packages/nuxt/src/components/scan.ts
+++ b/packages/nuxt/src/components/scan.ts
@@ -1,6 +1,6 @@
 import { readdir } from 'node:fs/promises'
 import { basename, dirname, extname, join, relative } from 'pathe'
-import { globby } from 'globby'
+import { glob } from 'tinyglobby'
 import { kebabCase, pascalCase, splitByCase } from 'scule'
 import { isIgnored, useNuxt } from '@nuxt/kit'
 import { withTrailingSlash } from 'ufo'
@@ -37,7 +37,7 @@ export async function scanComponents (dirs: ComponentsDir[], srcDir: string): Pr
     // A map from resolved path to component name (used for making duplicate warning message)
     const resolvedNames = new Map<string, string>()
 
-    const files = (await globby(dir.pattern!, { cwd: dir.path, ignore: dir.ignore })).sort()
+    const files = (await glob(dir.pattern!, { cwd: dir.path, ignore: dir.ignore })).sort()
 
     // Check if the directory exists (globby will otherwise read it case insensitively on MacOS)
     if (files.length) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -401,9 +401,6 @@ importers:
       exsolve:
         specifier: ^1.0.4
         version: 1.0.4
-      globby:
-        specifier: ^14.1.0
-        version: 14.1.0
       h3:
         specifier: 1.15.1
         version: 1.15.1


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

follow up on https://github.com/nuxt/nuxt/pull/31668, this replaces the final instance of `globby` in the nuxt codebase