### PR TITLE
feat(nuxt,schema): add `modules:resolved` hook

### DIFF
--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -613,6 +613,8 @@ async function initNuxt (nuxt: Nuxt) {
 
   await nuxt.callHook('modules:done')
 
+  await nuxt.callHook('modules:resolved')
+
   // remove duplicate css after modules are done
   nuxt.options.css = nuxt.options.css
     .filter((value, index, array) => !array.includes(value, index + 1))

--- a/packages/schema/src/types/hooks.ts
+++ b/packages/schema/src/types/hooks.ts
@@ -125,6 +125,11 @@ export interface NuxtHooks {
    * @returns Promise
    */
   'modules:done': () => HookResult
+  /**
+   * Called during Nuxt initialization, after installing user modules and `modules:done` hook finish.
+   * @returns Promise
+   */
+  'modules:resolved': () => HookResult
 
   /**
    * Called after resolving the `app` instance.


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
related to https://github.com/nuxt/nuxt/issues/31674

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
This PR adding a new `modules:resolved` hook to allow auto import work when modules adding imports in `modules:done` hook.

This PR on draft since I have no idea if we need to rename it or even change more internal modules.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
