### PR TITLE
docs: refine auto-imports documentation for clarity and structure

### DIFF
--- a/docs/3.api/5.kit/4.autoimports.md
+++ b/docs/3.api/5.kit/4.autoimports.md
@@ -8,15 +8,15 @@ links:
     size: xs
 ---
 
-# Auto-imports
+Nuxt auto-imports helper functions, composables and Vue APIs to use across your application without explicitly importing them. Based on the directory structure, every Nuxt application can also use auto-imports for its own composables and plugins.
 
-Nuxt auto-imports helper functions, composables and Vue APIs to use across your application without explicitly importing them. Based on the directory structure, every Nuxt application can also use auto-imports for its own composables and plugins. With Nuxt Kit you can also add your own auto-imports. `addImports` and `addImportsDir` allow you to add imports to the Nuxt application. `addImportsSources` allows you to add listed imports from 3rd party packages to the Nuxt application.
+With Nuxt Kit you can also add your own auto-imports. `addImports` and `addImportsDir` allow you to add imports to the Nuxt application. `addImportsSources` allows you to add listed imports from 3rd party packages to the Nuxt application.
+
+These utilities are powered by [`unimport`](https://github.com/unjs/unimport), which provides the underlying auto-import mechanism used in Nuxt.
 
 ::note
 These functions are designed for registering your own utils, composables and Vue APIs. For pages, components and plugins, please refer to the specific sections: [Pages](/docs/api/kit/pages), [Components](/docs/api/kit/components), [Plugins](/docs/api/kit/plugins).
 ::
-
-Nuxt auto-imports helper functions, composables and Vue APIs to use across your application without explicitly importing them. Based on the directory structure, every Nuxt application can also use auto-imports for its own composables and plugins. Composables or plugins can use these functions.
 
 ::tip{icon="i-lucide-video" to="https://vueschool.io/lessons/expanding-nuxt-s-auto-imports?friend=nuxt" target="_blank"}
 Watch Vue School video about Auto-imports Nuxt Kit utilities.
@@ -26,110 +26,10 @@ Watch Vue School video about Auto-imports Nuxt Kit utilities.
 
 Add imports to the Nuxt application. It makes your imports available in the Nuxt application without the need to import them manually.
 
-### Type
+### Usage
 
-```ts
-function addImports (imports: Import | Import[]): void
-
-interface Import {
-  from: string
-  priority?: number
-  disabled?: boolean
-  meta?: {
-    description?: string
-    docsUrl?: string
-    [key: string]: any
-  }
-  type?: boolean
-  typeFrom?: string
-  name: string
-  as?: string
-}
-```
-
-### Parameters
-
-#### `imports`
-
-**Type**: `Import | Import[]`
-
-**Required**: `true`
-
-An object or an array of objects with the following properties:
-
-- `from` (required)
-
-  **Type**: `string`
-
-  Module specifier to import from.
-
-- `priority` (optional)
-
-  **Type**: `number`
-
-  **Default**: `1`
-
-  Priority of the import, if multiple imports have the same name, the one with the highest priority will be used.
-
-- `disabled` (optional)
-
-  **Type**: `boolean`
-
-  If this import is disabled.
-
-- `meta` (optional)
-
-  **Type**: `object`
-
-  Metadata of the import.
-
-- `meta.description` (optional)
-
-  **Type**: `string`
-
-  Short description of the import.
-
-- `meta.docsUrl` (optional)
-
-  **Type**: `string`
-
-  URL to the documentation.
-
-- `meta[key]` (optional)
-
-  **Type**: `any`
-
-  Additional metadata.
-
-- `type` (optional)
-
-  **Type**: `boolean`
-
-  If this import is a pure type import.
-
-- `typeFrom` (optional)
-
-  **Type**: `string`
-
-  Using this as the from when generating type declarations.
-
-- `name` (required)
-
-  **Type**: `string`
-
-  Import name to be detected.
-
-- `as` (optional)
-
-  **Type**: `string`
-
-  Import as this name.
-
-### Examples
-
-```ts
-// https://github.com/pi0/storyblok-nuxt
-import { defineNuxtModule, addImports, createResolver } from '@nuxt/kit'
+```ts twoslash
+import { defineNuxtModule, addImports } from "@nuxt/kit";
 
 export default defineNuxtModule({
   setup(options, nuxt) {
@@ -148,38 +48,35 @@ export default defineNuxtModule({
 })
 ```
 
-## `addImportsDir`
-
-Add imports from a directory to the Nuxt application. It will automatically import all files from the directory and make them available in the Nuxt application without the need to import them manually.
-
 ### Type
 
 ```ts
-function addImportsDir (dirs: string | string[], options?: { prepend?: boolean }): void
+function addImports (imports: Import | Import[]): void
 ```
 
 ### Parameters
 
-#### `dirs`
+`imports`: An object or an array of objects with the following properties:
 
-**Type**: `string | string[]`
+| Prop               | Type                         | Required | Description                                                                                                     |
+| ------------------ | ---------------------------- | -------- | --------------------------------------------------------------------------------------------------------------- |
+| `name`             | `string`                     | `true`   | Import name to be detected.                                                                                     |
+| `from`             | `string`                     | `true`   | Module specifier to import from.                                                                                |
+| `priority`         | `number`                     | `false`  | Priority of the import; if multiple imports have the same name, the one with the highest priority will be used. |
+| `disabled`         | `boolean`                    | `false`  | If this import is disabled.                                                                                     |
+| `meta`             | `Record<string, any>`        | `false`  | Metadata of the import.                                                                                         |
+| `type`             | `boolean`                    | `false`  | If this import is a pure type import.                                                                           |
+| `typeFrom`         | `string`                     | `false`  | Use this as the `from` value when generating type declarations.                                                 |
+| `as`               | `string`                     | `false`  | Import as this name.                                                                                            |
 
-**Required**: `true`
 
-A string or an array of strings with the path to the directory to import from.
+## `addImportsDir`
 
-#### `options`
+Add imports from a directory to the Nuxt application. It will automatically import all files from the directory and make them available in the Nuxt application without the need to import them manually.
 
-**Type**: `{ prepend?: boolean }`
+### Usage
 
-**Default**: `{}`
-
-Options to pass to the import. If `prepend` is set to `true`, the imports will be prepended to the list of imports.
-
-### Examples
-
-```ts
-// https://github.com/vueuse/motion/tree/main/src/nuxt
+```ts twoslash
 import { defineNuxtModule, addImportsDir, createResolver } from '@nuxt/kit'
 
 export default defineNuxtModule({
@@ -193,137 +90,56 @@ export default defineNuxtModule({
   },
 })
 ```
+### Type
+
+```ts
+function addImportsDir (dirs: string | string[], options?: { prepend?: boolean }): void
+```
+
+### Parameters
+
+| Prop               | Type                         | Required | Description                                                                                                     |
+| ------------------ | ---------------------------- | -------- | --------------------------------------------------------------------------------------------------------------- |
+| `dirs`             | `string \| string[]`{lang="ts"}          | `true`   | A string or an array of strings with the path to the directory to import from.                                 |
+| `options`          | `{ prepend?: boolean }`{lang="ts"}      | `false`  | Options to pass to the import. If `prepend` is set to `true`, the imports will be prepended to the list of imports. |
+
 
 ## `addImportsSources`
 
 Add listed imports to the Nuxt application.
 
-### Type
+### Usage
 
-```ts
-function addImportsSources (importSources: ImportSource | ImportSource[]): void
-
-interface Import {
-  from: string
-  priority?: number
-  disabled?: boolean
-  meta?: {
-    description?: string
-    docsUrl?: string
-    [key: string]: any
-  }
-  type?: boolean
-  typeFrom?: string
-  name: string
-  as?: string
-}
-
-interface ImportSource extends Import {
-  imports: (PresetImport | ImportSource)[]
-}
-
-type PresetImport = Omit<Import, 'from'> | string | [name: string, as?: string, from?: string]
-```
-
-### Parameters
-
-#### `importSources`
-
-**Type**: `ImportSource | ImportSource[]`
-
-**Required**: `true`
-
-An object or an array of objects with the following properties:
-
-- `imports` (required)
-
-  **Type**: `PresetImport | ImportSource[]`
-
-  **Required**: `true`
-
-  An object or an array of objects, which can be import names, import objects or import sources.
-
-- `from` (required)
-
-  **Type**: `string`
-
-  Module specifier to import from.
-
-- `priority` (optional)
-
-  **Type**: `number`
-
-  **Default**: `1`
-
-  Priority of the import, if multiple imports have the same name, the one with the highest priority will be used.
-
-- `disabled` (optional)
-
-  **Type**: `boolean`
-
-  If this import is disabled.
-
-- `meta` (optional)
-
-  **Type**: `object`
-
-  Metadata of the import.
-
-- `meta.description` (optional)
-
-  **Type**: `string`
-
-  Short description of the import.
-
-- `meta.docsUrl` (optional)
-
-  **Type**: `string`
-
-  URL to the documentation.
-
-- `meta[key]` (optional)
-
-  **Type**: `any`
-
-  Additional metadata.
-
-- `type` (optional)
-
-  **Type**: `boolean`
-
-  If this import is a pure type import.
-
-- `typeFrom` (optional)
-
-  **Type**: `string`
-
-  Using this as the from when generating type declarations.
-
-- `name` (required)
-
-  **Type**: `string`
-
-  Import name to be detected.
-
-- `as` (optional)
-
-  **Type**: `string`
-
-  Import as this name.
-
-### Examples
-
-```ts
-// https://github.com/elk-zone/elk
+```ts twoslash
 import { defineNuxtModule, addImportsSources } from '@nuxt/kit'
 
 export default defineNuxtModule({
   setup() {
-    // add imports from h3 to make them autoimported
     addImportsSources({
       from: 'h3',
-      imports: ['defineEventHandler', 'getQuery', 'getRouterParams', 'readBody', 'sendRedirect'] as Array<keyof typeof import('h3')>,
+      imports: [
+        'defineEventHandler',
+        'getQuery',
+        'getRouterParams',
+        'readBody',
+        'sendRedirect'
+      ],
     })
   }
 })
 ```
+
+### Type
+
+```ts
+function addImportsSources (importSources: ImportSource | ImportSource[]): void
+```
+
+### Parameters
+
+**importSources**: An object or an array of objects with the following properties:
+
+| Prop               | Type                         | Required | Description                                                                                                     |
+| ------------------ | ---------------------------- | -------- | --------------------------------------------------------------------------------------------------------------- |
+| `from`             | `string`                     | `true`   | Module specifier to import from.                                                                                |
+| `imports`          | `PresetImport \| ImportSource[]`{lang="ts"} | `true`   | An object or an array of objects, which can be import names, import objects or import sources.                  |

--- a/docs/3.api/5.kit/4.autoimports.md
+++ b/docs/3.api/5.kit/4.autoimports.md
@@ -69,7 +69,6 @@ function addImports (imports: Import | Import[]): void
 | `typeFrom`         | `string`                     | `false`  | Use this as the `from` value when generating type declarations.                                                 |
 | `as`               | `string`                     | `false`  | Import as this name.                                                                                            |
 
-
 ## `addImportsDir`
 
 Add imports from a directory to the Nuxt application. It will automatically import all files from the directory and make them available in the Nuxt application without the need to import them manually.
@@ -90,6 +89,7 @@ export default defineNuxtModule({
   },
 })
 ```
+
 ### Type
 
 ```ts
@@ -102,7 +102,6 @@ function addImportsDir (dirs: string | string[], options?: { prepend?: boolean }
 | ------------------ | ---------------------------- | -------- | --------------------------------------------------------------------------------------------------------------- |
 | `dirs`             | `string \| string[]`{lang="ts"}          | `true`   | A string or an array of strings with the path to the directory to import from.                                 |
 | `options`          | `{ prepend?: boolean }`{lang="ts"}      | `false`  | Options to pass to the import. If `prepend` is set to `true`, the imports will be prepended to the list of imports. |
-
 
 ## `addImportsSources`
 


### PR DESCRIPTION
### 🔗 Linked issue

### 📚 Description

This PR improves the documentation for the Auto-imports page:

- Adds a note linking to [unimport](https://github.com/unjs/unimport) as the underlying engine for auto-imports in Nuxt.  
- Restructures parameter descriptions into tables for improved readability .
- Removes duplicate descriptions.



