### PR TITLE
perf(kit): exclude `.data` directory from type-checking

### DIFF
--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -177,6 +177,8 @@ export async function _generateTypes (nuxt: Nuxt) {
   const exclude = new Set<string>([
     // nitro generate output: https://github.com/nuxt/nuxt/blob/main/packages/nuxt/src/core/nitro.ts#L186
     relativeWithDot(nuxt.options.buildDir, resolve(nuxt.options.rootDir, 'dist')),
+    // nitro generate .data in development when kv storage is used
+    relativeWithDot(nuxt.options.buildDir, resolve(nuxt.options.rootDir, '.data')),
   ])
 
   for (const dir of nuxt.options.modulesDir) {

--- a/packages/kit/test/generate-types.spec.ts
+++ b/packages/kit/test/generate-types.spec.ts
@@ -52,6 +52,7 @@ describe('tsConfig generation', () => {
     expect(tsConfig.exclude).toMatchInlineSnapshot(`
       [
         "../dist",
+        "../.data",
         "../modules/test/node_modules",
         "../modules/node_modules",
         "../node_modules/@some/module/node_modules",


### PR DESCRIPTION
As Nitro generates this directory (or NuxtHub) and used for data, we can safely exclude this directory in the generates `tsconfig.json` for performance reasons.