### PR TITLE
docs: update example for component auto-import in nuxt modules

### DIFF
--- a/docs/2.guide/2.directory-structure/1.components.md
+++ b/docs/2.guide/2.directory-structure/1.components.md
@@ -550,7 +550,7 @@ There are a number of components that Nuxt provides, including `<ClientOnly>` an
 
 Making Vue component libraries with automatic tree-shaking and component registration is super easy. ✨
 
-You can use the `components:dirs` hook to extend the directory list without requiring user configuration in your Nuxt module.
+You can use the `addComponentsDir` method provided from the `@nuxt/kit` to register your components directory in your Nuxt module.
 
 Imagine a directory structure like this:
 
@@ -560,28 +560,27 @@ Imagine a directory structure like this:
 -----| components/
 -------| Alert.vue
 -------| Button.vue
------| nuxt.js
+-----| nuxt.ts
 -| pages/
 ---| index.vue
--| nuxt.config.js
+-| nuxt.config.ts
 ```
 
-Then in `awesome-ui/nuxt.js` you can use the `components:dirs` hook:
+Then in `awesome-ui/nuxt.ts` you can use the `addComponentsDir` hook:
 
 ```ts twoslash
-import { defineNuxtModule, createResolver } from '@nuxt/kit'
+import { createResolver, defineNuxtModule, addComponentsDir } from '@nuxt/kit'
 
 export default defineNuxtModule({
-  hooks: {
-    'components:dirs': (dirs) => {
-      const { resolve } = createResolver(import.meta.url)
-      // Add ./components dir to the list
-      dirs.push({
-        path: resolve('./components'),
-        prefix: 'awesome'
-      })
-    }
-  }
+  setup() {
+    const { resolve } = createResolver(import.meta.url)
+
+    // Add ./components dir to the list
+    addComponentsDir({
+      path: resolve('./components'),
+      prefix: 'awesome',
+    })
+  },
 })
 ```
 

--- a/docs/2.guide/2.directory-structure/1.components.md
+++ b/docs/2.guide/2.directory-structure/1.components.md
@@ -550,7 +550,7 @@ There are a number of components that Nuxt provides, including `<ClientOnly>` an
 
 Making Vue component libraries with automatic tree-shaking and component registration is super easy. ✨
 
-You can use the `addComponentsDir` method provided from the `@nuxt/kit` to register your components directory in your Nuxt module.
+You can use the [addComponentsDir](/docs/api/kit/components#addcomponentsdir) method provided from the `@nuxt/kit` to register your components directory in your Nuxt module.
 
 Imagine a directory structure like this:
 

--- a/docs/2.guide/2.directory-structure/1.components.md
+++ b/docs/2.guide/2.directory-structure/1.components.md
@@ -550,7 +550,7 @@ There are a number of components that Nuxt provides, including `<ClientOnly>` an
 
 Making Vue component libraries with automatic tree-shaking and component registration is super easy. ✨
 
-You can use the [addComponentsDir](/docs/api/kit/components#addcomponentsdir) method provided from the `@nuxt/kit` to register your components directory in your Nuxt module.
+You can use the [`addComponentsDir`](/docs/api/kit/components#addcomponentsdir) method provided from the `@nuxt/kit` to register your components directory in your Nuxt module.
 
 Imagine a directory structure like this:
 

--- a/docs/2.guide/2.directory-structure/1.components.md
+++ b/docs/2.guide/2.directory-structure/1.components.md
@@ -573,11 +573,11 @@ import { createResolver, defineNuxtModule, addComponentsDir } from '@nuxt/kit'
 
 export default defineNuxtModule({
   setup() {
-    const { resolve } = createResolver(import.meta.url)
+    const resolver = createResolver(import.meta.url)
 
     // Add ./components dir to the list
     addComponentsDir({
-      path: resolve('./components'),
+      path: resolver.resolve('./components'),
       prefix: 'awesome',
     })
   },

--- a/docs/2.guide/2.directory-structure/1.modules.md
+++ b/docs/2.guide/2.directory-structure/1.modules.md
@@ -25,12 +25,12 @@ export default defineNuxtModule({
     name: 'hello'
   },
   setup () {
-    const { resolve } = createResolver(import.meta.url)
+    const resolver = createResolver(import.meta.url)
 
     // Add an API route
     addServerHandler({
       route: '/api/hello',
-      handler: resolve('./runtime/api-route')
+      handler: resolver.resolve('./runtime/api-route')
     })
   }
 })

--- a/docs/2.guide/3.going-further/3.modules.md
+++ b/docs/2.guide/3.going-further/3.modules.md
@@ -325,9 +325,9 @@ import { defineNuxtModule, addPlugin, createResolver } from '@nuxt/kit'
 export default defineNuxtModule({
   setup (options, nuxt) {
     // Create resolver to resolve relative paths
-    const { resolve } = createResolver(import.meta.url)
+    const resolver = createResolver(import.meta.url)
 
-    addPlugin(resolve('./runtime/plugin'))
+    addPlugin(resolver.resolve('./runtime/plugin'))
   }
 })
 ```
@@ -455,9 +455,9 @@ import { defineNuxtModule, addPlugin, createResolver } from '@nuxt/kit'
 
 export default defineNuxtModule({
   setup (options, nuxt) {
-    const { resolve } = createResolver(import.meta.url)
+    const resolver = createResolver(import.meta.url)
 
-    nuxt.options.css.push(resolve('./runtime/style.css'))
+    nuxt.options.css.push(resolver.resolve('./runtime/style.css'))
   }
 })
 ```
@@ -469,12 +469,12 @@ import { defineNuxtModule, createResolver } from '@nuxt/kit'
 
 export default defineNuxtModule({
   setup (options, nuxt) {
-    const { resolve } = createResolver(import.meta.url)
+    const resolver = createResolver(import.meta.url)
 
     nuxt.hook('nitro:config', async (nitroConfig) => {
       nitroConfig.publicAssets ||= []
       nitroConfig.publicAssets.push({
-        dir: resolve('./runtime/public'),
+        dir: resolver.resolve('./runtime/public'),
         maxAge: 60 * 60 * 24 * 365 // 1 year
       })
     })
@@ -491,10 +491,10 @@ import { defineNuxtModule, createResolver, installModule } from '@nuxt/kit'
 
 export default defineNuxtModule<ModuleOptions>({
   async setup (options, nuxt) {
-    const { resolve } = createResolver(import.meta.url)
+    const resolver = createResolver(import.meta.url)
 
     // We can inject our CSS file which includes Tailwind's directives
-    nuxt.options.css.push(resolve('./runtime/assets/styles.css'))
+    nuxt.options.css.push(resolver.resolve('./runtime/assets/styles.css'))
 
     await installModule('@nuxtjs/tailwindcss', {
       // module configuration
@@ -503,8 +503,8 @@ export default defineNuxtModule<ModuleOptions>({
         darkMode: 'class',
         content: {
           files: [
-            resolve('./runtime/components/**/*.{vue,mjs,ts}'),
-            resolve('./runtime/*.{mjs,js,ts}')
+            resolver.resolve('./runtime/components/**/*.{vue,mjs,ts}'),
+            resolver.resolve('./runtime/*.{mjs,js,ts}')
           ]
         }
       }

--- a/test/fixtures/basic/modules/import-components/index.ts
+++ b/test/fixtures/basic/modules/import-components/index.ts
@@ -5,44 +5,44 @@ export default defineNuxtModule({
     name: 'import-components',
   },
   setup () {
-    const { resolve } = createResolver(import.meta.url)
+    const resolver = createResolver(import.meta.url)
 
     addComponent({
       name: 'DCompClient',
-      filePath: resolve('./runtime/components'),
+      filePath: resolver.resolve('./runtime/components'),
       mode: 'client',
     })
 
     addComponent({
       name: 'DCompServer',
-      filePath: resolve('./runtime/components'),
+      filePath: resolver.resolve('./runtime/components'),
       mode: 'server',
     })
 
     addComponent({
       name: 'DCompAll',
-      filePath: resolve('./runtime/components'),
+      filePath: resolver.resolve('./runtime/components'),
       mode: 'all',
     })
 
     addComponent({
       name: 'NCompClient',
       export: 'NComp',
-      filePath: resolve('./runtime/components'),
+      filePath: resolver.resolve('./runtime/components'),
       mode: 'client',
     })
 
     addComponent({
       name: 'NCompServer',
       export: 'NComp',
-      filePath: resolve('./runtime/components'),
+      filePath: resolver.resolve('./runtime/components'),
       mode: 'server',
     })
 
     addComponent({
       name: 'NCompAll',
       export: 'NComp',
-      filePath: resolve('./runtime/components'),
+      filePath: resolver.resolve('./runtime/components'),
       mode: 'all',
     })
   },

--- a/test/fixtures/basic/modules/lazy-import-components/index.ts
+++ b/test/fixtures/basic/modules/lazy-import-components/index.ts
@@ -5,26 +5,26 @@ export default defineNuxtModule({
     name: 'lazy-import-components',
   },
   setup () {
-    const { resolve } = createResolver(import.meta.url)
+    const resolver = createResolver(import.meta.url)
 
     addComponent({
       name: 'NCompClient',
       export: 'NComp',
-      filePath: resolve('./runtime/components'),
+      filePath: resolver.resolve('./runtime/components'),
       mode: 'client',
     })
 
     addComponent({
       name: 'NCompServer',
       export: 'NComp',
-      filePath: resolve('./runtime/components'),
+      filePath: resolver.resolve('./runtime/components'),
       mode: 'server',
     })
 
     addComponent({
       name: 'NCompAll',
       export: 'NComp',
-      filePath: resolve('./runtime/components'),
+      filePath: resolver.resolve('./runtime/components'),
       mode: 'all',
     })
   },


### PR DESCRIPTION
### 🔗 Linked issue

### 📚 Description

Replaced usage of `components:dirs` hook with the more recommended `addComponentsDir` helper from `@nuxt/kit`