### PR TITLE
docs: use `vs.` consistently

### DIFF
--- a/docs/1.getting-started/03.configuration.md
+++ b/docs/1.getting-started/03.configuration.md
@@ -126,7 +126,7 @@ const appConfig = useAppConfig()
 
 :read-more{to="/docs/guide/directory-structure/app-config"}
 
-## `runtimeConfig` vs. `app.config`
+## `runtimeConfig` vs `app.config`
 
 As stated above, `runtimeConfig` and `app.config` are both used to expose variables to the rest of your application. To determine whether you should use one or the other, here are some guidelines:
 

--- a/docs/1.getting-started/03.configuration.md
+++ b/docs/1.getting-started/03.configuration.md
@@ -126,7 +126,7 @@ const appConfig = useAppConfig()
 
 :read-more{to="/docs/guide/directory-structure/app-config"}
 
-## `runtimeConfig` vs `app.config`
+## `runtimeConfig` vs. `app.config`
 
 As stated above, `runtimeConfig` and `app.config` are both used to expose variables to the rest of your application. To determine whether you should use one or the other, here are some guidelines:
 

--- a/docs/1.getting-started/10.data-fetching.md
+++ b/docs/1.getting-started/10.data-fetching.md
@@ -288,7 +288,7 @@ Read more about `useLazyFetch`.
 Read more about `useLazyAsyncData`.
 ::
 
-:video-accordion{title="Watch a video from Vue School on blocking vs non-blocking (lazy) requests" videoId="1022000555" platform="vimeo"}
+:video-accordion{title="Watch a video from Vue School on blocking vs. non-blocking (lazy) requests" videoId="1022000555" platform="vimeo"}
 
 ### Client-only fetching
 

--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -806,7 +806,7 @@ These options have been set to their current values for some time and we do not 
 
 * `respectNoSSRHeader`is implementable in user-land with [server middleware](https://github.com/nuxt/nuxt/blob/c660b39447f0d5b8790c0826092638d321cd6821/packages/nuxt/src/core/runtime/nitro/no-ssr.ts#L8-L9)
 
-## Nuxt 2 vs Nuxt 3+
+## Nuxt 2 vs. Nuxt 3+
 
 In the table below, there is a quick comparison between 3 versions of Nuxt:
 

--- a/docs/2.guide/1.concepts/7.esm.md
+++ b/docs/2.guide/1.concepts/7.esm.md
@@ -22,7 +22,7 @@ Bundlers like webpack and Rollup support this syntax and allow you to use module
 
 ### ESM Syntax
 
-Most of the time, when people talk about ESM vs CJS, they are talking about a different syntax for writing [modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules).
+Most of the time, when people talk about ESM vs. CJS, they are talking about a different syntax for writing [modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules).
 
 ```js
 import a from './a'

--- a/docs/2.guide/3.going-further/1.internals.md
+++ b/docs/2.guide/3.going-further/1.internals.md
@@ -70,7 +70,7 @@ const nuxtApp = {
 
 For more details, check out [the source code](https://github.com/nuxt/nuxt/blob/main/packages/nuxt/src/app/nuxt.ts).
 
-## Runtime Context vs. Build Context
+## Runtime Context vs Build Context
 
 Nuxt builds and bundles project using Node.js but also has a runtime side.
 

--- a/docs/2.guide/3.going-further/1.internals.md
+++ b/docs/2.guide/3.going-further/1.internals.md
@@ -70,7 +70,7 @@ const nuxtApp = {
 
 For more details, check out [the source code](https://github.com/nuxt/nuxt/blob/main/packages/nuxt/src/app/nuxt.ts).
 
-## Runtime Context vs Build Context
+## Runtime Context vs. Build Context
 
 Nuxt builds and bundles project using Node.js but also has a runtime side.
 


### PR DESCRIPTION
I think the correct form is  "vs." with a period.