### PR TITLE
fix(nuxt): pass statusMessage to error.vue

### DIFF
--- a/packages/nuxt/src/core/runtime/nitro/handlers/error.ts
+++ b/packages/nuxt/src/core/runtime/nitro/handlers/error.ts
@@ -35,6 +35,7 @@ export default <NitroErrorHandler> async function errorhandler (error, event, { 
   errorObject.message ||= 'Server Error'
   // we will be rendering this error internally so we can pass along the error.data safely
   errorObject.data ||= error.data
+  errorObject.statusMessage ||= error.statusMessage
 
   delete defaultRes.headers['content-type'] // this would be set to application/json
   delete defaultRes.headers['content-security-policy'] // this would disable JS execution in the error page


### PR DESCRIPTION
### 📚 Description

nitro default error hander doesn't return error.statusMessage (as expected) as an API response in production, but we do want to pass this along when rendering error.vue so user can choose whether to use this data in rendering/handling the page