### PR TITLE
feat(nuxt): add showError option to `useAsyncData`

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -332,7 +332,7 @@ export function useAsyncData<
         asyncData.data.value = unref(options.default!())
         asyncData.status.value = 'error'
 
-        if (options.showError === true || typeof options.showError === 'function') {
+        if (options.showError) {
           const _error = typeof options.showError === 'function' ? options.showError(error) : createError(error)
           return nuxtApp.runWithContext(() => showError(_error))
         }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This can be quite useful when users think that some `useAsyncData` is mandatory for a page. Instead of having to watch an error, we can directly trigger a `showError`

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
