### PR TITLE
feat(nuxt): warn if user uses reserved `runtimeConfig.app` namespace

### DIFF
--- a/docs/1.getting-started/03.configuration.md
+++ b/docs/1.getting-started/03.configuration.md
@@ -62,7 +62,7 @@ If you're authoring layers, you can also use the `$meta` key to provide metadata
 
 ### Environment Variables and Private Tokens
 
-The `runtimeConfig` API exposes values like environment variables to the rest of your application. By default, these keys are only available server-side. The keys within `runtimeConfig.public` are also available client-side.
+The `runtimeConfig` API exposes values like environment variables to the rest of your application. By default, these keys are only available server-side. The keys within `runtimeConfig.public` and `runtimeConfig.app` (which is used by Nuxt internally) are also available client-side.
 
 Those values should be defined in `nuxt.config` and can be overridden using environment variables.
 

--- a/docs/2.guide/3.going-further/10.runtime-config.md
+++ b/docs/2.guide/3.going-further/10.runtime-config.md
@@ -92,7 +92,7 @@ Within the Vue part of your Nuxt app, you will need to call [`useRuntimeConfig()
 ::important
 The behavior is different between the client-side and server-side:
 
-- On client-side, only keys in `runtimeConfig.public` are available, and the object is both writable and reactive.
+- On client-side, only keys in `runtimeConfig.public` and `runtimeConfig.app` (which is used by Nuxt internally) are available, and the object is both writable and reactive.
 
 - On server-side, the entire runtime config is available, but it is read-only to avoid context sharing.
 ::

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -788,6 +788,15 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
     options._modules.push('@nuxt/telemetry')
   }
 
+  // warn if user is using reserved namespaces
+  const allowedKeys = new Set(['baseURL', 'buildAssetsDir', 'cdnURL', 'buildId'])
+  for (const key in options.runtimeConfig.app) {
+    if (!allowedKeys.has(key)) {
+      logger.warn(`The \`app\` namespace is reserved for Nuxt and is exposed to the browser. Please move \`runtimeConfig.app.${key}\` to a different namespace.`)
+      delete options.runtimeConfig[key]
+    }
+  }
+
   // Ensure we share key config between Nuxt and Nitro
   createPortalProperties(options.nitro.runtimeConfig, options, ['nitro.runtimeConfig', 'runtimeConfig'])
   createPortalProperties(options.nitro.routeRules, options, ['nitro.routeRules', 'routeRules'])

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -793,7 +793,7 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
   for (const key in options.runtimeConfig.app) {
     if (!allowedKeys.has(key)) {
       logger.warn(`The \`app\` namespace is reserved for Nuxt and is exposed to the browser. Please move \`runtimeConfig.app.${key}\` to a different namespace.`)
-      delete options.runtimeConfig[key]
+      delete options.runtimeConfig.app[key]
     }
   }
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Nuxt uses an internal namespace in `runtimeConfig` which is exposed to the browser.

this PR warns + removes user configuration set here, and we also document that this is exposed to the client.