### PR TITLE
chore(nuxt): show brotli size by default when analyzing bundle

### DIFF
--- a/packages/vite/src/plugins/analyze.ts
+++ b/packages/vite/src/plugins/analyze.ts
@@ -33,7 +33,7 @@ export function analyzePlugin (ctx: ViteBuildContext): Plugin[] {
       filename: 'filename' in analyzeOptions ? analyzeOptions.filename!.replace('{name}', 'client') : undefined,
       title: 'Client bundle stats',
       gzipSize: true,
-      brotliSize: true
+      brotliSize: true,
     }),
   ]
 }

--- a/packages/vite/src/plugins/analyze.ts
+++ b/packages/vite/src/plugins/analyze.ts
@@ -33,6 +33,7 @@ export function analyzePlugin (ctx: ViteBuildContext): Plugin[] {
       filename: 'filename' in analyzeOptions ? analyzeOptions.filename!.replace('{name}', 'client') : undefined,
       title: 'Client bundle stats',
       gzipSize: true,
+      brotliSize: true
     }),
   ]
 }


### PR DESCRIPTION
As Brotli is the go-to text compression, it should be reflected when using `nuxi analyze` (or `analyze: true` in the config) by default. This PR adds the info to the tree map.