### PR TITLE
refactor(nuxt): hoist `purgeCachedData` check for  tree-shaking

### DIFF
--- a/packages/nuxt/src/app/plugins/payload.client.ts
+++ b/packages/nuxt/src/app/plugins/payload.client.ts
@@ -19,8 +19,8 @@ export default defineNuxtPlugin({
       if (to.path === from.path) { return }
       const payload = await loadPayload(to.path)
       if (!payload) { return }
-      for (const key of staticKeysToRemove) {
-        if (purgeCachedData) {
+      if (purgeCachedData) {
+        for (const key of staticKeysToRemove) {
           delete nuxtApp.static.data[key]
         }
       }

--- a/packages/nuxt/src/app/plugins/payload.client.ts
+++ b/packages/nuxt/src/app/plugins/payload.client.ts
@@ -25,8 +25,10 @@ export default defineNuxtPlugin({
         }
       }
       for (const key in payload.data) {
-        if (!(key in nuxtApp.static.data)) {
-          staticKeysToRemove.add(key)
+        if (purgeCachedData) {
+          if (!(key in nuxtApp.static.data)) {
+            staticKeysToRemove.add(key)
+          }
         }
         nuxtApp.static.data[key] = payload.data[key]
       }


### PR DESCRIPTION
### 🔗 Linked issue

### 📚 Description

Move purgeCachedData condition outside the loop to enable better tree-shaking in production builds when `experimental.purgeCachedData` is `false`.

**Before**

```js
const staticKeysToRemove = /* @__PURE__ */ new Set();
useRouter().beforeResolve(async (to, from) => {
  if (to.path === from.path) {
    return;
  }
  const payload = await loadPayload(to.path);
  if (!payload) {
    return;
  }
  for (const key of staticKeysToRemove) {
  }
  for (const key in payload.data) {
    if (!(key in nuxtApp.static.data)) {
      staticKeysToRemove.add(key);
    }
    nuxtApp.static.data[key] = payload.data[key];
  }
});
```

**After**

```js
useRouter().beforeResolve(async (to, from) => {
  if (to.path === from.path) {
    return;
  }
  const payload = await loadPayload(to.path);
  if (!payload) {
    return;
  }
  for (const key in payload.data) {
    nuxtApp.static.data[key] = payload.data[key];
  }
});
 ```