### PR TITLE
docs: capitalize title

### DIFF
--- a/docs/1.getting-started/04.views.md
+++ b/docs/1.getting-started/04.views.md
@@ -142,7 +142,7 @@ If you want to create more layouts and learn how to use them in your pages, find
 ## Advanced: Extending the HTML Template
 
 ::note
-If you only need to modify the `<head>`, you can refer to the [SEO and meta section](/docs/getting-started/seo-meta).
+If you only need to modify the `<head>`, you can refer to the [SEO and Meta section](/docs/getting-started/seo-meta).
 ::
 
 You can have full control over the HTML template by adding a Nitro plugin that registers a hook.


### PR DESCRIPTION
SEO and Meta. Here I think Meta should be with capital `M`. Because I think in other place the title is given like `SEO and Meta`.