### PR TITLE
feat(nuxt): add trailingSlash prop to NuxtLink

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -147,12 +147,13 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
   function resolveTrailingSlashBehavior (to: string, resolve: Router['resolve'], trailingSlash?: NuxtLinkOptions['trailingSlash']): string
   function resolveTrailingSlashBehavior (to: RouteLocationRaw, resolve: Router['resolve'], trailingSlash?: NuxtLinkOptions['trailingSlash']): Exclude<RouteLocationRaw, string>
   function resolveTrailingSlashBehavior (to: RouteLocationRaw | undefined, resolve: Router['resolve'], trailingSlash?: NuxtLinkOptions['trailingSlash']): RouteLocationRaw | RouteLocation | undefined {
-    if (!to || (trailingSlash !== 'append' && trailingSlash !== 'remove')) {
+    const effectiveTrailingSlash = trailingSlash ?? options.trailingSlash
+    if (!to || (effectiveTrailingSlash !== 'append' && effectiveTrailingSlash !== 'remove')) {
       return to
     }
 
     if (typeof to === 'string') {
-      return applyTrailingSlashBehavior(to, trailingSlash)
+      return applyTrailingSlashBehavior(to, effectiveTrailingSlash)
     }
 
     const path = 'path' in to && to.path !== undefined ? to.path : resolve(to).path
@@ -160,7 +161,7 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
     const resolvedPath = {
       ...to,
       name: undefined, // named routes would otherwise always override trailing slash behavior
-      path: applyTrailingSlashBehavior(path, trailingSlash),
+      path: applyTrailingSlashBehavior(path, effectiveTrailingSlash),
     }
 
     return resolvedPath
@@ -210,6 +211,7 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
 
     // Resolves `to` value if it's a route location object
     const href = computed(() => {
+      const effectiveTrailingSlash = props.trailingSlash ?? options.trailingSlash
       if (!to.value || isAbsoluteUrl.value || isHashLinkWithoutHashMode(to.value)) {
         return to.value as string
       }
@@ -218,14 +220,14 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
         const path = typeof to.value === 'object' && 'path' in to.value ? resolveRouteObject(to.value) : to.value
         // separately resolve route objects with a 'name' property and without 'path'
         const href = typeof path === 'object' ? router.resolve(path).href : path
-        return applyTrailingSlashBehavior(href, props.trailingSlash)
+        return applyTrailingSlashBehavior(href, effectiveTrailingSlash)
       }
 
       if (typeof to.value === 'object') {
         return router.resolve(to.value)?.href ?? null
       }
 
-      return applyTrailingSlashBehavior(joinURL(config.app.baseURL, to.value), props.trailingSlash)
+      return applyTrailingSlashBehavior(joinURL(config.app.baseURL, to.value), effectiveTrailingSlash)
     })
 
     return {

--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -77,6 +77,11 @@ export interface NuxtLinkProps<CustomProp extends boolean = false> extends Omit<
    * Escape hatch to disable `prefetch` attribute.
    */
   noPrefetch?: boolean
+  /**
+   * An option to either add or remove trailing slashes in the `href` for this specific link.
+   * Overrides the global `trailingSlash` option if provided.
+   */
+  trailingSlash?: 'append' | 'remove'
 }
 
 /**
@@ -139,15 +144,15 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
     return !hashMode && typeof link === 'string' && link.startsWith('#')
   }
 
-  function resolveTrailingSlashBehavior (to: string, resolve: Router['resolve']): string
-  function resolveTrailingSlashBehavior (to: RouteLocationRaw, resolve: Router['resolve']): Exclude<RouteLocationRaw, string>
-  function resolveTrailingSlashBehavior (to: RouteLocationRaw | undefined, resolve: Router['resolve']): RouteLocationRaw | RouteLocation | undefined {
-    if (!to || (options.trailingSlash !== 'append' && options.trailingSlash !== 'remove')) {
+  function resolveTrailingSlashBehavior (to: string, resolve: Router['resolve'], trailingSlash?: NuxtLinkOptions['trailingSlash']): string
+  function resolveTrailingSlashBehavior (to: RouteLocationRaw, resolve: Router['resolve'], trailingSlash?: NuxtLinkOptions['trailingSlash']): Exclude<RouteLocationRaw, string>
+  function resolveTrailingSlashBehavior (to: RouteLocationRaw | undefined, resolve: Router['resolve'], trailingSlash?: NuxtLinkOptions['trailingSlash']): RouteLocationRaw | RouteLocation | undefined {
+    if (!to || (trailingSlash !== 'append' && trailingSlash !== 'remove')) {
       return to
     }
 
     if (typeof to === 'string') {
-      return applyTrailingSlashBehavior(to, options.trailingSlash)
+      return applyTrailingSlashBehavior(to, trailingSlash)
     }
 
     const path = 'path' in to && to.path !== undefined ? to.path : resolve(to).path
@@ -155,7 +160,7 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
     const resolvedPath = {
       ...to,
       name: undefined, // named routes would otherwise always override trailing slash behavior
-      path: applyTrailingSlashBehavior(path, options.trailingSlash),
+      path: applyTrailingSlashBehavior(path, trailingSlash),
     }
 
     return resolvedPath
@@ -198,7 +203,7 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
       checkPropConflicts(props, 'to', 'href')
       const path = props.to || props.href || '' // Defaults to empty string (won't render any `href` attribute)
       if (isExternal.value) { return path }
-      return resolveTrailingSlashBehavior(path, router.resolve)
+      return resolveTrailingSlashBehavior(path, router.resolve, props.trailingSlash)
     })
 
     const link = isExternal.value ? undefined : useBuiltinLink?.({ ...props, to })
@@ -213,14 +218,14 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
         const path = typeof to.value === 'object' && 'path' in to.value ? resolveRouteObject(to.value) : to.value
         // separately resolve route objects with a 'name' property and without 'path'
         const href = typeof path === 'object' ? router.resolve(path).href : path
-        return resolveTrailingSlashBehavior(href, router.resolve /* will not be called */) as string
+        return applyTrailingSlashBehavior(href, props.trailingSlash)
       }
 
       if (typeof to.value === 'object') {
         return router.resolve(to.value)?.href ?? null
       }
 
-      return resolveTrailingSlashBehavior(joinURL(config.app.baseURL, to.value), router.resolve /* will not be called */)
+      return applyTrailingSlashBehavior(joinURL(config.app.baseURL, to.value), props.trailingSlash)
     })
 
     return {
@@ -332,6 +337,12 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
       // Slot API
       custom: {
         type: Boolean as PropType<NuxtLinkProps['custom']>,
+        default: undefined,
+        required: false,
+      },
+      // Behavior
+      trailingSlash: {
+        type: String as PropType<NuxtLinkProps['trailingSlash']>,
         default: undefined,
         required: false,
       },

--- a/packages/nuxt/test/nuxt-link.test.ts
+++ b/packages/nuxt/test/nuxt-link.test.ts
@@ -283,7 +283,7 @@ describe('nuxt-link:propsOrAttributes', () => {
     })
 
     describe('trailingSlashBehavior', () => {
-      it('append slash', () => {
+      it('append slash using options', () => {
         const appendSlashOptions: NuxtLinkOptions = { trailingSlash: 'append' }
 
         expect(nuxtLink({ to: '/to' }, appendSlashOptions).props.to).toEqual('/to/')
@@ -299,7 +299,7 @@ describe('nuxt-link:propsOrAttributes', () => {
         expect(nuxtLink({ href: 'mailto:test@example.com' }, appendSlashOptions).props.href).toEqual('mailto:test@example.com')
       })
 
-      it('remove slash', () => {
+      it('remove slash using options', () => {
         const removeSlashOptions: NuxtLinkOptions = { trailingSlash: 'remove' }
 
         expect(nuxtLink({ to: '/to' }, removeSlashOptions).props.to).toEqual('/to')
@@ -312,6 +312,39 @@ describe('nuxt-link:propsOrAttributes', () => {
         expect(nuxtLink({ to: '/to/?param=1' }, removeSlashOptions).props.to).toEqual('/to?param=1')
         expect(nuxtLink({ to: '/to/?param=1#abc' }, removeSlashOptions).props.to).toEqual('/to?param=1#abc')
         expect(nuxtLink({ href: 'mailto:test@example.com' }, removeSlashOptions).props.href).toEqual('mailto:test@example.com')
+      })
+
+      it('prop overrides option: append', () => {
+        const removeSlashOptions: NuxtLinkOptions = { trailingSlash: 'remove' }
+        // Prop takes priority
+        expect(nuxtLink({ to: '/to', trailingSlash: 'append' }, removeSlashOptions).props.to).toEqual('/to/')
+        expect(nuxtLink({ to: '/to/', trailingSlash: 'append' }, removeSlashOptions).props.to).toEqual('/to/')
+        expect(nuxtLink({ to: { path: '/to' }, trailingSlash: 'append' }, removeSlashOptions).props.to).toHaveProperty('path', '/to/')
+        // External links
+        expect(nuxtLink({ to: '/to', external: true, trailingSlash: 'append' }, removeSlashOptions).props.href).toBe('/to/')
+      })
+
+      it('prop overrides option: remove', () => {
+        const appendSlashOptions: NuxtLinkOptions = { trailingSlash: 'append' }
+        // Prop takes priority
+        expect(nuxtLink({ to: '/to/', trailingSlash: 'remove' }, appendSlashOptions).props.to).toEqual('/to')
+        expect(nuxtLink({ to: '/to', trailingSlash: 'remove' }, appendSlashOptions).props.to).toEqual('/to')
+        expect(nuxtLink({ to: { path: '/to/' }, trailingSlash: 'remove' }, appendSlashOptions).props.to).toHaveProperty('path', '/to')
+        // External links
+        expect(nuxtLink({ to: '/to/', external: true, trailingSlash: 'remove' }, appendSlashOptions).props.href).toBe('/to')
+      })
+
+      it('uses option when prop is not provided', () => {
+        const appendSlashOptions: NuxtLinkOptions = { trailingSlash: 'append' }
+        const removeSlashOptions: NuxtLinkOptions = { trailingSlash: 'remove' }
+
+        // Use append option
+        expect(nuxtLink({ to: '/to' }, appendSlashOptions).props.to).toEqual('/to/')
+        // Use remove option
+        expect(nuxtLink({ to: '/to/' }, removeSlashOptions).props.to).toEqual('/to')
+        // External links with options
+        expect(nuxtLink({ to: '/to', external: true }, appendSlashOptions).props.href).toBe('/to/')
+        expect(nuxtLink({ to: '/to/', external: true }, removeSlashOptions).props.href).toBe('/to')
       })
     })
   })


### PR DESCRIPTION
### 🔗 Linked issue

resolves #31819 

### 📚 Description

Adds an optional 'trailingSlash' prop to the NuxtLink component, allowing per-link override of the global trailingSlash behavior

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
