### PR TITLE
feat(nuxt): add `throwOnError` option to `useAsyncData`

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -97,6 +97,15 @@ export interface AsyncDataOptions<
    * @default 'cancel'
    */
   dedupe?: 'cancel' | 'defer'
+
+  /**
+   * Throw an error if handler function fails
+   * Accepts a boolean value or a function that returns a NuxtError object.
+   * If set to true, the returned promise will reject when an error occurs.
+   * If a function is provided, it will be called with the error object and should return a NuxtError object.
+   * @default false
+   */
+  throwOnError?: boolean | ((e: unknown) => NuxtError)
 }
 
 export interface AsyncDataExecuteOptions {
@@ -669,6 +678,11 @@ function createAsyncData<
           asyncData.error.value = createError<NuxtErrorDataT>(error) as (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>)
           asyncData.data.value = unref(options.default!())
           asyncData.status.value = 'error'
+
+          if (options.throwOnError) {
+            const _error = typeof options.throwOnError === 'function' ? options.throwOnError(error) : asyncData.error.value
+            throw _error
+          }
         })
         .finally(() => {
           if ((promise as any).cancelled) { return }

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -102,10 +102,10 @@ export interface AsyncDataOptions<
    * Throw an error if handler function fails
    * Accepts a boolean value or a function that returns a NuxtError object.
    * If set to true, the returned promise will reject when an error occurs.
-   * If a function is provided, it will be called with the error object and should return a NuxtError object.
+   * If a function is provided, it will be called with the error object and should return a NuxtError object or undefined. If undefined is returned, no error is thrown.
    * @default false
    */
-  throwOnError?: boolean | ((e: unknown) => NuxtError)
+  throwOnError?: boolean | ((e: unknown) => NuxtError | undefined)
 }
 
 export interface AsyncDataExecuteOptions {
@@ -681,7 +681,10 @@ function createAsyncData<
 
           if (options.throwOnError) {
             const _error = typeof options.throwOnError === 'function' ? options.throwOnError(error) : asyncData.error.value
-            throw _error
+
+            if (_error) {
+              throw _error
+            }
           }
         })
         .finally(() => {

--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -122,6 +122,7 @@ export function useFetch<
     getCachedData,
     deep,
     dedupe,
+    throwOnError,
     ...fetchOptions
   } = opts
 
@@ -141,6 +142,7 @@ export function useFetch<
     getCachedData,
     deep,
     dedupe,
+    throwOnError,
     watch: watch === false ? [] : [_fetchOptions, _request, ...(watch || [])],
   }
 


### PR DESCRIPTION
### 🔗 Linked issue

#31743

### 📚 Description

Inspired by #31766. I am not sure whether the features are conflicting or complimentary. Main benefit over `showError`:

```ts
// Before - optional-chaining, if checks when not feasible
const { data } = await useFetch<Post>('/blog/404')
const upvote = () => data.value ? $fetch(`/${data.value.id}/upvote`) : {}
const loadAuthor = () => {
  if (!data.value) { return }
  return $fetch(`/author/${data.value.meta.authorId}`)
}

// After - data is always available, safe to bang, types could further be improved
const { data } = await useFetch<Post>('/blog/404', { throwOnError: true })
const upvote = () => $fetch(`/${data.value!.id}/upvote`) 
const loadAuthor = () => $fetch(`/author/${data.value!.meta.authorId}`)
```

Ideally, we would get the return type as `Post`, not `Post | undefined`.
Draft PR, because I think this is the clue: https://github.com/nuxt/nuxt/issues/31743#issuecomment-2811312234
