### PR TITLE
ci: bump node v20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,7 +259,7 @@ jobs:
         context: ["async", "default"]
         manifest: ["manifest-on", "manifest-off"]
         payload: ["json", "js"]
-        node: [18]
+        node: [20]
         exclude:
           - builder: "webpack"
             payload: "js"


### PR DESCRIPTION
Actually node v18 EOL is April 30, 2025, which is within in 2 weeks I guess. I mean can we update it to v20 actually.