### PR TITLE
fix(nuxt): consider full path when de-duplicating routes

### DIFF
--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -198,9 +198,9 @@ export default defineNuxtModule({
             nuxt.apps.default.pages = pages
           }
           const addedPagePaths = new Set<string>()
-          function addPage (parent: EditableTreeNode, page: NuxtPage) {
+          function addPage (parent: EditableTreeNode, page: NuxtPage, basePath: string = '') {
             // Avoid duplicate keys in the generated RouteNamedMap type
-            const absolutePagePath = joinURL(parent.path, page.path)
+            const absolutePagePath = joinURL(basePath, page.path)
 
             // way to add a route without a file, which must be possible
             const route = addedPagePaths.has(absolutePagePath)
@@ -226,7 +226,7 @@ export default defineNuxtModule({
             // TODO: implement redirect support
             // if (page.redirect) {}
             if (page.children) {
-              page.children.forEach(child => addPage(route, child))
+              page.children.forEach(child => addPage(route, child, absolutePagePath))
             }
           }
 


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #31848

### 📚 Description

The de-duplication logic did not compute proper `absolutePagePath`. It was relative to the parent . This caused nested routes sharing common suffix to be treated as the same page, despite being different. The fix ensures we actually use absolute path.

Logs `debug: { router: true }`

```
# Before
<index>
├─ typed-pages
├─┬ typed-pages/parent1
│ └─┬ :param()
│   └─ items
└─┬ typed-pages/parent2
  └─ :param()
```
```
# After
<index>
├─ typed-pages
├─┬ typed-pages/parent1
│ └─┬ :param()
│   └─ items
└─┬ typed-pages/parent2
  └─┬ :param()
    └─ items
```