### PR TITLE
Documentation Improvement for useCookie Composable

### DIFF
--- a/docs/3.api/2.composables/use-cookie.md
+++ b/docs/3.api/2.composables/use-cookie.md
@@ -14,10 +14,6 @@ Within your pages, components and plugins you can use `useCookie`, an SSR-friend
 const cookie = useCookie(name, options)
 ```
 
-::note
-`useCookie` only works in the [Nuxt context](/docs/guide/going-further/nuxt-app#the-nuxt-context).
-::
-
 ::tip
 `useCookie` ref will automatically serialize and deserialize cookie value to JSON.
 ::


### PR DESCRIPTION
### 📚 Description

In the current documentation for `useCookie` (https://nuxt.com/docs/api/composables/use-cookie), there is a potentially misleading statement:

> `useCookie` only works in the Nuxt context.

This statement can be misinterpreted to mean that `useCookie` is only usable in Nuxt-specific components or pages, which is not accurate.
