### PR TITLE
feat(nuxt): add `<NuxtTime>` component for ssr-safe time display

### DIFF
--- a/docs/3.api/1.components/13.nuxt-time.md
+++ b/docs/3.api/1.components/13.nuxt-time.md
@@ -1,0 +1,173 @@
+---
+title: '<NuxtTime>'
+description: 'The <NuxtTime> component displays time in a locale-friendly format with server-client consistency.'
+navigation:
+  badge: New
+links:
+  - label: Source
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/nuxt/blob/main/packages/nuxt/src/app/components/nuxt-time.vue
+    size: xs
+---
+
+::important
+This component is available in Nuxt v3.17+.
+::
+
+The `<NuxtTime>` component lets you display dates and times in a locale-friendly format with proper `<time>` HTML semantics. It ensures consistent rendering between server and client without hydration mismatches.
+
+## Usage
+
+You can use the `<NuxtTime>` component anywhere in your app:
+
+```vue
+<template>
+  <NuxtTime :datetime="Date.now()" />
+</template>
+```
+
+## Props
+
+### `datetime`
+
+- Type: `Date | number | string`
+- Required: `true`
+
+The date and time value to display. You can provide:
+- A `Date` object
+- A timestamp (number)
+- An ISO-formatted date string
+
+```vue
+<template>
+  <NuxtTime :datetime="Date.now()" />
+  <NuxtTime :datetime="new Date()" />
+  <NuxtTime datetime="2023-06-15T09:30:00.000Z" />
+</template>
+```
+
+### `locale`
+
+- Type: `string`
+- Required: `false`
+- Default: Uses the browser or server's default locale
+
+The [BCP 47 language tag](https://datatracker.ietf.org/doc/html/rfc5646) for formatting (e.g., 'en-US', 'fr-FR', 'ja-JP'):
+
+```vue
+<template>
+  <NuxtTime :datetime="Date.now()" locale="fr-FR" />
+</template>
+```
+
+### Formatting Props
+
+The component accepts any property from the [Intl.DateTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat) options:
+
+```vue
+<template>
+  <NuxtTime 
+    :datetime="Date.now()" 
+    year="numeric"
+    month="long"
+    day="numeric"
+    hour="2-digit"
+    minute="2-digit"
+  />
+</template>
+```
+
+This would output something like: "April 22, 2025, 08:30 AM"
+
+### `relative`
+
+- Type: `boolean`
+- Required: `false`
+- Default: `false`
+
+Enables relative time formatting using the Intl.RelativeTimeFormat API:
+
+```vue
+<template>
+  <!-- Shows something like "5 minutes ago" -->
+  <NuxtTime :datetime="Date.now() - 5 * 60 * 1000" relative />
+</template>
+```
+
+### Relative Time Formatting Props
+
+When `relative` is set to `true`, the component also accepts properties from [Intl.RelativeTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/RelativeTimeFormat):
+
+```vue
+<template>
+  <NuxtTime 
+    :datetime="Date.now() - 3 * 24 * 60 * 60 * 1000" 
+    relative 
+    numeric="auto"
+    style="long"
+  />
+</template>
+```
+
+This would output something like: "3 days ago" or "last Friday" depending on the `numeric` setting.
+
+## Examples
+
+### Basic Usage
+
+```vue
+<template>
+  <NuxtTime :datetime="Date.now()" />
+</template>
+```
+
+### Custom Formatting
+
+```vue
+<template>
+  <NuxtTime 
+    :datetime="Date.now()" 
+    weekday="long"
+    year="numeric"
+    month="short"
+    day="numeric"
+    hour="numeric"
+    minute="numeric"
+    second="numeric"
+    timeZoneName="short"
+  />
+</template>
+```
+
+### Relative Time
+
+```vue
+<template>
+  <div>
+    <p>
+      <NuxtTime :datetime="Date.now() - 30 * 1000" relative />
+      <!-- 30 seconds ago -->
+    </p>
+    <p>  
+      <NuxtTime :datetime="Date.now() - 45 * 60 * 1000" relative />
+      <!-- 45 minutes ago -->
+    </p>
+    <p>
+      <NuxtTime :datetime="Date.now() + 2 * 24 * 60 * 60 * 1000" relative />
+      <!-- in 2 days -->
+    </p>
+  </div>
+</template>
+```
+
+### With Custom Locale
+
+```vue
+<template>
+  <div>
+    <NuxtTime :datetime="Date.now()" locale="en-US" weekday="long" />
+    <NuxtTime :datetime="Date.now()" locale="fr-FR" weekday="long" />
+    <NuxtTime :datetime="Date.now()" locale="ja-JP" weekday="long" />
+  </div>
+</template>
+```

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "installed-check": "9.3.0",
     "jiti": "2.4.2",
     "knip": "5.50.5",
+    "magic-regexp": "0.10.0",
     "magic-string": "0.30.17",
     "markdownlint-cli": "0.44.0",
     "memfs": "4.17.0",

--- a/packages/nuxt/src/app/components/nuxt-time.vue
+++ b/packages/nuxt/src/app/components/nuxt-time.vue
@@ -1,0 +1,150 @@
+<script setup lang="ts">
+import { computed, getCurrentInstance, onBeforeUnmount, ref } from 'vue'
+import { onPrehydrate } from '../composables/ssr'
+import { useNuxtApp } from '../nuxt'
+
+const props = withDefaults(defineProps<{
+  locale?: string
+  datetime: string | number | Date
+  localeMatcher?: 'best fit' | 'lookup'
+  weekday?: 'long' | 'short' | 'narrow'
+  era?: 'long' | 'short' | 'narrow'
+  year?: 'numeric' | '2-digit'
+  month?: 'numeric' | '2-digit' | 'long' | 'short' | 'narrow'
+  day?: 'numeric' | '2-digit'
+  hour?: 'numeric' | '2-digit'
+  minute?: 'numeric' | '2-digit'
+  second?: 'numeric' | '2-digit'
+  timeZoneName?: 'short' | 'long' | 'shortOffset' | 'longOffset' | 'shortGeneric' | 'longGeneric'
+  formatMatcher?: 'best fit' | 'basic'
+  hour12?: boolean
+  timeZone?: string
+
+  calendar?: string
+  dayPeriod?: 'narrow' | 'short' | 'long'
+  numberingSystem?: string
+
+  dateStyle?: 'full' | 'long' | 'medium' | 'short'
+  timeStyle?: 'full' | 'long' | 'medium' | 'short'
+  hourCycle?: 'h11' | 'h12' | 'h23' | 'h24'
+  relative?: boolean
+  title?: boolean | string
+}>(), {
+  hour12: undefined,
+})
+
+const el = getCurrentInstance()?.vnode.el
+const renderedDate = el?.getAttribute('datetime')
+const _locale = el?.getAttribute('data-locale')
+
+const nuxtApp = useNuxtApp()
+
+const date = computed(() => {
+  const date = props.datetime
+  if (renderedDate && nuxtApp.isHydrating) { return new Date(renderedDate) }
+  if (!props.datetime) { return new Date() }
+  return new Date(date)
+})
+
+const now = ref(import.meta.client && nuxtApp.isHydrating && window._nuxtTimeNow ? new Date(window._nuxtTimeNow) : new Date())
+if (import.meta.client && props.relative) {
+  const handler = () => {
+    now.value = new Date()
+  }
+  const interval = setInterval(handler, 1000)
+  onBeforeUnmount(() => clearInterval(interval))
+}
+
+const formatter = computed(() => {
+  const { locale: propsLocale, relative, ...rest } = props
+  if (relative) {
+    return new Intl.RelativeTimeFormat(_locale ?? propsLocale, rest)
+  }
+  return new Intl.DateTimeFormat(_locale ?? propsLocale, rest)
+})
+
+const formattedDate = computed(() => {
+  if (props.relative) {
+    const diffInSeconds = (date.value.getTime() - now.value.getTime()) / 1000
+    const units: Array<{ unit: Intl.RelativeTimeFormatUnit, value: number }> = [
+      { unit: 'second', value: diffInSeconds },
+      { unit: 'minute', value: diffInSeconds / 60 },
+      { unit: 'hour', value: diffInSeconds / 3600 },
+      { unit: 'day', value: diffInSeconds / 86400 },
+      { unit: 'month', value: diffInSeconds / 2592000 },
+      { unit: 'year', value: diffInSeconds / 31536000 },
+    ]
+    const { unit, value } = units.find(({ value }) => Math.abs(value) < 60) || units[units.length - 1]!
+    return formatter.value.format(Math.round(value), unit)
+  }
+
+  return (formatter.value as Intl.DateTimeFormat).format(date.value)
+})
+
+const isoDate = computed(() => date.value.toISOString())
+const title = computed(() => props.title === true ? isoDate.value : typeof props.title === 'string' ? props.title : undefined)
+const dataset: Record<string, string | number | boolean | Date | undefined> = {}
+
+if (import.meta.server) {
+  for (const prop in props) {
+    if (prop !== 'datetime') {
+      const value = props?.[prop as keyof typeof props]
+      if (value) {
+        const propInKebabCase = prop.split(/(?=[A-Z])/).join('-')
+        dataset[`data-${propInKebabCase}`] = props?.[prop as keyof typeof props]
+      }
+    }
+  }
+  onPrehydrate((el) => {
+    const now = window._nuxtTimeNow ||= Date.now()
+    const toCamelCase = (name: string, index: number) => {
+      if (index > 0) {
+        return name[0]!.toUpperCase() + name.slice(1)
+      }
+      return name
+    }
+
+    const date = new Date(el.getAttribute('datetime')!)
+    const options: Intl.DateTimeFormatOptions & { locale?: Intl.LocalesArgument, relative?: boolean } = {}
+    for (const name of el.getAttributeNames()) {
+      if (name.startsWith('data-')) {
+        const optionName = name.slice(5).split('-').map(toCamelCase).join('') as keyof Intl.DateTimeFormatOptions
+
+        options[optionName] = el.getAttribute(name) as any
+      }
+    }
+
+    if (options.relative) {
+      const diffInSeconds = (date.getTime() - now) / 1000
+      const units: Array<{ unit: Intl.RelativeTimeFormatUnit, value: number }> = [
+        { unit: 'second', value: diffInSeconds },
+        { unit: 'minute', value: diffInSeconds / 60 },
+        { unit: 'hour', value: diffInSeconds / 3600 },
+        { unit: 'day', value: diffInSeconds / 86400 },
+        { unit: 'month', value: diffInSeconds / 2592000 },
+        { unit: 'year', value: diffInSeconds / 31536000 },
+      ]
+      const { unit, value } = units.find(({ value }) => Math.abs(value) < 60) || units[units.length - 1]!
+      const formatter = new Intl.RelativeTimeFormat(options.locale, options)
+      el.textContent = formatter.format(Math.round(value), unit)
+    } else {
+      const formatter = new Intl.DateTimeFormat(options.locale, options)
+      el.textContent = formatter.format(date)
+    }
+  })
+}
+
+declare global {
+  interface Window {
+    _nuxtTimeNow?: number
+  }
+}
+</script>
+
+<template>
+  <time
+    v-bind="dataset"
+    :datetime="isoDate"
+    :title="title"
+  >{{ formattedDate }}</time>
+</template>

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -488,6 +488,13 @@ async function initNuxt (nuxt: Nuxt) {
     filePath: resolve(nuxt.options.appDir, 'components/nuxt-loading-indicator'),
   })
 
+  // Add <NuxtTime>
+  addComponent({
+    name: 'NuxtTime',
+    priority: 10, // built-in that we do not expect the user to override
+    filePath: resolve(nuxt.options.appDir, 'components/nuxt-time.vue'),
+  })
+
   // Add <NuxtRouteAnnouncer>
   addComponent({
     name: 'NuxtRouteAnnouncer',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,6 +157,9 @@ importers:
       knip:
         specifier: 5.50.5
         version: 5.50.5(@types/node@22.14.1)(typescript@5.8.3)
+      magic-regexp:
+        specifier: 0.10.0
+        version: 0.10.0
       magic-string:
         specifier: ^0.30.17
         version: 0.30.17
@@ -5247,6 +5250,9 @@ packages:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
 
+  magic-regexp@0.10.0:
+    resolution: {integrity: sha512-Uly1Bu4lO1hwHUW0CQeSWuRtzCMNO00CmXtS8N6fyvB3B979GOEEeAkiTUDsmbYLAbvpUS/Kt5c4ibosAzVyVg==}
+
   magic-string-ast@0.7.0:
     resolution: {integrity: sha512-686fgAHaJY7wLTFEq7nnKqeQrhqmXB19d1HnqT35Ci7BN6hbAYLZUezTQ062uUHM7ggZEQlqJ94Ftls+KDXU8Q==}
     engines: {node: '>=16.14.0'}
@@ -7054,6 +7060,9 @@ packages:
   type-fest@4.26.1:
     resolution: {integrity: sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg==}
     engines: {node: '>=16'}
+
+  type-level-regexp@0.1.17:
+    resolution: {integrity: sha512-wTk4DH3cxwk196uGLK/E9pE45aLfeKJacKmcEgEOA/q5dnPGNxXt0cfYdFxb57L+sEpf1oJH4Dnx/pnRcku9jg==}
 
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
@@ -12242,6 +12251,16 @@ snapshots:
 
   lz-string@1.5.0: {}
 
+  magic-regexp@0.10.0:
+    dependencies:
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+      mlly: 1.7.4
+      regexp-tree: 0.1.27
+      type-level-regexp: 0.1.17
+      ufo: 1.6.1
+      unplugin: 2.3.2
+
   magic-string-ast@0.7.0:
     dependencies:
       magic-string: 0.30.17
@@ -14464,6 +14483,8 @@ snapshots:
   type-detect@4.1.0: {}
 
   type-fest@4.26.1: {}
+
+  type-level-regexp@0.1.17: {}
 
   typescript@5.8.3: {}
 

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -6,6 +6,7 @@ import { isCI, isWindows } from 'std-env'
 import { join, normalize } from 'pathe'
 import { $fetch, createPage, fetch, isDev, setup, startServer, url, useTestContext } from '@nuxt/test-utils/e2e'
 import { $fetchComponent } from '@nuxt/test-utils/experimental'
+import { createRegExp, exactly } from 'magic-regexp'
 
 import { expectNoClientErrors, expectWithPolling, gotoPath, isRenderingJson, parseData, parsePayload, renderPage } from './utils'
 
@@ -3052,5 +3053,75 @@ describe('namespace access to useNuxtApp', () => {
     expect(error).toBeTruthy()
 
     await page.close()
+  })
+})
+
+describe('nuxt-time', () => {
+  it('ssr', async () => {
+    const html = await $fetch<string>('/components/nuxt-time')
+    const snap = html.match(/<time[^>]*data-testid="fixed"[^>]*>([^<]*)<\/time>/)?.[0].replace(/ data-prehydrate-id="[^"]*"/g, '')
+    expect(snap).toContain(
+      '<time data-month="long" data-day="numeric" datetime="2023-02-11T08:24:08.396Z" data-testid="fixed">',
+    )
+  })
+
+  it.skipIf(isDev)('injects one script', async () => {
+    const html = await $fetch<string>('/components/nuxt-time')
+
+    const string = createRegExp(exactly('document.querySelectorAll'), ['g'])
+    expect(html.match(string)?.length).toEqual(1)
+  })
+
+  it('has no hydration errors on the client', async () => {
+    const page = await createPage(undefined, { locale: 'en-GB' })
+    const logs: string[] = []
+
+    page.on('console', (event) => {
+      if (!event.text().includes('<Suspense>')) {
+        logs.push(event.text())
+      }
+    })
+
+    await page.goto(url('/components/nuxt-time'), { waitUntil: 'networkidle' })
+
+    expect(await page.getByTestId('switchable').textContent()).toMatchInlineSnapshot(
+      '"11 February at 8"',
+    )
+    expect(await page.getByTestId('fixed').textContent()).toMatchInlineSnapshot('"11 February"')
+
+    await page.getByText('Switch locale').click()
+    expect(await page.getByTestId('switchable').textContent()).toMatchInlineSnapshot(
+      '"11 février à 8"',
+    )
+    expect(await page.getByTestId('fixed').textContent()).toMatchInlineSnapshot('"11 février"')
+
+    await page.getByText('Update time').click()
+    expect(await page.getByTestId('switchable').textContent()).not.toEqual('11 février à 8')
+    expect(await page.getByTestId('fixed').textContent()).toMatchInlineSnapshot('"11 février"')
+
+    // No hydration errors
+    expect(logs.join('')).toMatchInlineSnapshot('""')
+  })
+
+  it('displays relative time correctly', async () => {
+    const page = await createPage(undefined, { locale: 'en-GB' })
+    const logs: string[] = []
+
+    page.on('console', (event) => {
+      if (!event.text().includes('<Suspense>')) {
+        logs.push(event.text())
+      }
+    })
+
+    await page.goto(url('/components/nuxt-time'), { waitUntil: 'networkidle' })
+
+    expect(await page.getByTestId('relative').textContent()).toMatchInlineSnapshot(
+      '"30 seconds ago"',
+    )
+
+    await page.getByTestId('relative').getByText('32 seconds ago').textContent()
+
+    // No hydration errors
+    expect(logs.join('')).toMatchInlineSnapshot('""')
   })
 })

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -3077,7 +3077,7 @@ describe('nuxt-time', () => {
     const logs: string[] = []
 
     page.on('console', (event) => {
-      if (!event.text().includes('<Suspense>')) {
+      if (!event.text().includes('<Suspense>') && !event.text().includes('[vite]')) {
         logs.push(event.text())
       }
     })
@@ -3108,7 +3108,7 @@ describe('nuxt-time', () => {
     const logs: string[] = []
 
     page.on('console', (event) => {
-      if (!event.text().includes('<Suspense>')) {
+      if (!event.text().includes('<Suspense>') && !event.text().includes('[vite]')) {
         logs.push(event.text())
       }
     })

--- a/test/fixtures/basic/pages/components/nuxt-time.vue
+++ b/test/fixtures/basic/pages/components/nuxt-time.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+const locale = ref()
+const switchLocale = () => {
+  locale.value = locale.value !== 'fr' ? 'fr' : 'en-GB'
+}
+const date = ref(new Date('2023-02-11T08:24:08.396Z').valueOf())
+const changeDate = () => {
+  date.value = Date.now()
+}
+</script>
+
+<template>
+  <div>
+    <NuxtTime
+      :locale="locale"
+      data-testid="switchable"
+      :datetime="date"
+      second="numeric"
+      month="long"
+      day="numeric"
+    />
+    <br>
+    <NuxtTime
+      :locale="locale"
+      data-testid="present"
+      :datetime="new Date()"
+      second="numeric"
+      month="long"
+      day="numeric"
+    />
+    <br>
+    <NuxtTime
+      :locale="locale"
+      data-testid="fixed"
+      datetime="2023-02-11T08:24:08.396Z"
+      month="long"
+      day="numeric"
+    />
+    <br>
+    <NuxtTime
+      datetime="2023-08-19T02:57:00.000Z"
+      time-zone="America/New_York"
+    />
+    <br>
+    <NuxtTime
+      data-testid="relative"
+      :datetime="Date.now() - (1 * 30 * 1000)"
+      relative
+    />
+    <br>
+    <button @click="switchLocale">
+      Switch locale
+    </button>
+    <br>
+    <button @click="changeDate">
+      Update time
+    </button>
+  </div>
+</template>

--- a/test/nuxt/nuxt-time.test.ts
+++ b/test/nuxt/nuxt-time.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { defineComponent, h } from 'vue'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+
+import { NuxtTime } from '#components'
+
+describe('<NuxtTime>', () => {
+  it('should not serialise data in the DOM in the client', async () => {
+    const thing = await mountSuspended(
+      defineComponent({
+        render: () =>
+          h(NuxtTime, {
+            datetime: '2023-02-11T18:26:41.058Z',
+            locale: 'en-GB',
+            month: 'long',
+            day: 'numeric',
+            second: 'numeric',
+          }),
+      }),
+    )
+    expect(thing.html()).toMatchInlineSnapshot(
+      `"<time datetime="2023-02-11T18:26:41.058Z">11 February at 41</time>"`,
+    )
+  })
+
+  it('should display relative time correctly', async () => {
+    const datetime = Date.now() - 5 * 60 * 1000
+    const thing = await mountSuspended(
+      defineComponent({
+        render: () =>
+          h(NuxtTime, {
+            datetime,
+            relative: true,
+          }),
+      }),
+    )
+    expect(thing.html()).toMatchInlineSnapshot(
+      `"<time datetime="${new Date(datetime).toISOString()}">5 minutes ago</time>"`,
+    )
+  })
+
+  it('should display datetime in title', async () => {
+    const datetime = Date.now() - 5 * 60 * 1000
+    const thing = await mountSuspended(
+      defineComponent({
+        render: () =>
+          h(NuxtTime, {
+            datetime,
+            relative: true,
+            title: true,
+          }),
+      }),
+    )
+    expect(thing.html()).toMatchInlineSnapshot(
+      `"<time datetime="${new Date(datetime).toISOString()}" title="${new Date(datetime).toISOString()}">5 minutes ago</time>"`,
+    )
+  })
+
+  it('should display custom title', async () => {
+    const datetime = Date.now() - 5 * 60 * 1000
+    const thing = await mountSuspended(
+      defineComponent({
+        render: () =>
+          h(NuxtTime, {
+            datetime,
+            relative: true,
+            title: 'test',
+          }),
+      }),
+    )
+    expect(thing.html()).toMatchInlineSnapshot(
+      `"<time datetime="${new Date(datetime).toISOString()}" title="test">5 minutes ago</time>"`,
+    )
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this ports the current implementation + tests from https://github.com/danielroe/nuxt-time to Nuxt as a built-in SSR-safe replacement for `<time>`.