### PR TITLE
fix(kit): include user-defined types before internal ones when generating `tsconfig.json`

### DIFF
--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -155,6 +155,7 @@ export async function _generateTypes (nuxt: Nuxt) {
 
   const include = new Set<string>([
     join(relativeRootDir, '**/*'),
+    join(relativeRootDir, '.config/nuxt.*'),
     './nuxt.d.ts',
   ])
 

--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -154,9 +154,8 @@ export async function _generateTypes (nuxt: Nuxt) {
   const relativeRootDir = relativeWithDot(nuxt.options.buildDir, nuxt.options.rootDir)
 
   const include = new Set<string>([
-    './nuxt.d.ts',
-    join(relativeRootDir, '.config/nuxt.*'),
     join(relativeRootDir, '**/*'),
+    './nuxt.d.ts',
   ])
 
   if (nuxt.options.srcDir !== nuxt.options.rootDir) {

--- a/test/fixtures/basic-types/index.d.ts
+++ b/test/fixtures/basic-types/index.d.ts
@@ -1,0 +1,7 @@
+declare module 'nuxt/schema' {
+  interface PublicRuntimeConfig {
+    ids: (1 | 2 | 3)[]
+  }
+}
+
+export {}

--- a/test/fixtures/basic-types/types.ts
+++ b/test/fixtures/basic-types/types.ts
@@ -352,14 +352,14 @@ describe('runtimeConfig', () => {
     expectTypeOf(runtimeConfig.public.testConfig).toEqualTypeOf<number>()
     expectTypeOf(runtimeConfig.public.needsFallback).toEqualTypeOf<string>()
     expectTypeOf(runtimeConfig.privateConfig).toEqualTypeOf<string>()
-    expectTypeOf(runtimeConfig.public.ids).toEqualTypeOf<number[]>()
+    expectTypeOf(runtimeConfig.public.ids).toEqualTypeOf<(1 | 2 | 3)[]>()
     expectTypeOf(runtimeConfig.unknown).toEqualTypeOf<unknown>()
 
     const injectedConfig = useNuxtApp().$config
     expectTypeOf(injectedConfig.public.testConfig).toEqualTypeOf<number>()
     expectTypeOf(injectedConfig.public.needsFallback).toEqualTypeOf<string>()
     expectTypeOf(injectedConfig.privateConfig).toEqualTypeOf<string>()
-    expectTypeOf(injectedConfig.public.ids).toEqualTypeOf<number[]>()
+    expectTypeOf(injectedConfig.public.ids).toEqualTypeOf<(1 | 2 | 3)[]>()
     expectTypeOf(injectedConfig.unknown).toEqualTypeOf<unknown>()
   })
   it('provides hints on overriding these values', () => {
@@ -376,7 +376,7 @@ describe('runtimeConfig', () => {
     expectTypeOf(val.runtimeConfig!.privateConfig).toEqualTypeOf<undefined | RuntimeValue<string, 'You can override this value at runtime with NUXT_PRIVATE_CONFIG'>>()
     expectTypeOf(val.runtimeConfig!.baseURL).toEqualTypeOf<undefined | RuntimeValue<string, 'You can override this value at runtime with NUXT_BASE_URL'>>()
     expectTypeOf(val.runtimeConfig!.baseAPIToken).toEqualTypeOf<undefined | RuntimeValue<string, 'You can override this value at runtime with NUXT_BASE_API_TOKEN'>>()
-    expectTypeOf(val.runtimeConfig!.public!.ids).toEqualTypeOf<undefined | RuntimeValue<Array<number>, 'You can override this value at runtime with NUXT_PUBLIC_IDS'>>()
+    expectTypeOf(val.runtimeConfig!.public!.ids).toEqualTypeOf<undefined | RuntimeValue<(1 | 2 | 3)[], 'You can override this value at runtime with NUXT_PUBLIC_IDS'>>()
     expectTypeOf(val.runtimeConfig!.unknown).toEqualTypeOf<unknown>()
   })
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/20379

### 📚 Description

This prioritises user-defined types over `nuxt.d.ts` (and others) and removes redundant `.config/nuxt.*` entry which is already included in `**/*`.