### PR TITLE
fix(ui-templates): pass pointer events through spotlight div in error dev template

### DIFF
--- a/packages/ui-templates/templates/error-dev/index.html
+++ b/packages/ui-templates/templates/error-dev/index.html
@@ -16,7 +16,7 @@
     </style>
   </head>
   <body class="font-sans antialiased bg-white px-10 pt-14 dark:bg-black text-black dark:text-white min-h-screen flex flex-col">
-    <div class="fixed left-0 right-0 spotlight"></div>
+    <div class="fixed left-0 right-0 spotlight pointer-events-none"></div>
     <h1 class="text-6xl sm:text-8xl font-medium mb-6">{{ messages.statusCode }}</h1>
     <p class="text-xl sm:text-2xl font-light mb-8 leading-tight">{{ messages.description }}</p>
     <div class="bg-white rounded-t-md bg-black/5 dark:bg-white/10 flex-1 overflow-y-auto h-auto">

--- a/packages/ui-templates/test/__snapshots__/templates.spec.ts.snap
+++ b/packages/ui-templates/test/__snapshots__/templates.spec.ts.snap
@@ -545,6 +545,9 @@ exports[`template > produces correct output for error-dev template 1`] = `
   height: 60vh;
   opacity: 0.8;
 }
+.pointer-events-none {
+  pointer-events: none;
+}
 .fixed {
   position: fixed;
 }


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/31885

### 📚 Description

Allows pointer events to pass through the spotlight div in error dev template.