### PR TITLE
fix(nuxt): do not purge nuxt data if active `useNuxtData`

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -497,6 +497,23 @@ export function useNuxtData<DataT = any> (key: string): { data: Ref<DataT | unde
     nuxtApp.payload.data[key] = asyncDataDefaults.value
   }
 
+  if (nuxtApp._asyncData[key]) {
+    const data = nuxtApp._asyncData[key]
+    data._deps++
+    if (getCurrentScope()) {
+      onScopeDispose(() => {
+        data._deps--
+        // clean up memory when it no longer is needed
+        if (data._deps === 0) {
+          data?._off()
+          if (purgeCachedData) {
+            clearNuxtDataByKey(nuxtApp, key)
+          }
+        }
+      })
+    }
+  }
+
   return {
     data: computed({
       get () {

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -558,6 +558,19 @@ describe('useAsyncData', () => {
         return () => h('div', [data.value])
       },
     })
+    const getData = async () => {
+      const component = await mountSuspended(defineComponent({
+        setup () {
+          const { data } = useNuxtData(key)
+          return () => data.value === undefined ? 'undefined' : data.value
+        },
+      }))
+      try {
+        return component.html({ raw: true })
+      } finally {
+        component.unmount()
+      }
+    }
 
     const comp1 = await mountSuspended(component)
     expect(promiseFn).toHaveBeenCalledTimes(1)
@@ -567,11 +580,11 @@ describe('useAsyncData', () => {
 
     comp1.unmount()
     await nextTick()
-    expect(useNuxtData(key).data.value).toMatchInlineSnapshot('"test"')
+    expect(await getData()).toMatchInlineSnapshot('"test"')
 
     comp2.unmount()
     await nextTick()
-    expect(useNuxtData(key).data.value).toBeUndefined()
+    expect(await getData()).toBe('undefined')
   })
 
   it('should be synced with useNuxtData', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This addresses a potential issue if useAsyncData + useNuxtData are being used with `purgeCachedData`. The data should not disappear as long as a composable is being used in a component that is accessing it.