### PR TITLE
feat(nuxt,schema): make build cache location configurable

### DIFF
--- a/packages/nuxt/src/core/cache.ts
+++ b/packages/nuxt/src/core/cache.ts
@@ -1,6 +1,6 @@
 import { mkdir, open, readFile, stat, unlink, writeFile } from 'node:fs/promises'
 import type { FileHandle } from 'node:fs/promises'
-import { resolve } from 'node:path'
+import { isAbsolute, resolve } from 'node:path'
 import { existsSync } from 'node:fs'
 import { createIsIgnored } from '@nuxt/kit'
 import type { Nuxt, NuxtConfig, NuxtConfigLayer } from '@nuxt/schema'
@@ -38,7 +38,23 @@ export async function getVueHash (nuxt: Nuxt) {
     },
   })
 
-  const cacheFile = join(nuxt.options.workspaceDir, 'node_modules/.cache/nuxt/builds', id, hash + '.tar')
+  const cacheDir = resolveCacheDir(nuxt)
+
+  function resolveCacheDir (nuxt: Nuxt): string {
+    const buildCache = nuxt.options.experimental.buildCache
+    const rootDir = nuxt.options.rootDir
+    const workspaceDir = nuxt.options.workspaceDir
+    if (typeof buildCache === 'object') {
+      const cacheDir = buildCache.cacheDir
+      if (isAbsolute(cacheDir)) {
+        return cacheDir
+      }
+      return join(rootDir, cacheDir)
+    }
+    return workspaceDir
+  }
+
+  const cacheFile = join(cacheDir, 'node_modules/.cache/nuxt/builds', id, hash + '.tar')
 
   return {
     hash,

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1442,7 +1442,7 @@ export interface ConfigSchema {
      *
      * @default false
      */
-    buildCache: boolean
+    buildCache: boolean | { cacheDir: string }
 
     /**
      * Ensure that auto-generated Vue component names match the full component name you would use to auto-import the component.


### PR DESCRIPTION
### 🔗 Linked issue
resolve https://github.com/nuxt/nuxt/issues/31899
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

by default, we use the workspace dir to store the cache of `experimental.buildCache`. This PR makes it configurable

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
