### PR TITLE
fix(nuxt): use first existing modulesDir to store build cache files

### DIFF
--- a/packages/nuxt/src/core/cache.ts
+++ b/packages/nuxt/src/core/cache.ts
@@ -10,6 +10,7 @@ import { consola } from 'consola'
 import { dirname, join, relative } from 'pathe'
 import { createTar, parseTar } from 'nanotar'
 import type { TarFileInput } from 'nanotar'
+import { getFirstNodeModulesDir } from '../utils'
 
 export async function getVueHash (nuxt: Nuxt) {
   const id = 'vue'
@@ -38,7 +39,7 @@ export async function getVueHash (nuxt: Nuxt) {
     },
   })
 
-  const cacheFile = join(nuxt.options.workspaceDir, 'node_modules/.cache/nuxt/builds', id, hash + '.tar')
+  const cacheFile = join(getFirstNodeModulesDir() ?? join(nuxt.options.workspaceDir, 'node_modules'), '.cache/nuxt/builds', id, hash + '.tar')
 
   return {
     hash,

--- a/packages/nuxt/src/core/cache.ts
+++ b/packages/nuxt/src/core/cache.ts
@@ -38,17 +38,7 @@ export async function getVueHash (nuxt: Nuxt) {
     },
   })
 
-  let cacheDir = join(nuxt.options.workspaceDir, 'node_modules')
-  if (!existsSync(cacheDir)) {
-    for (const dir of [...nuxt.options.modulesDir].sort((a, b) => a.length - b.length)) {
-      if (existsSync(dir)) {
-        cacheDir = dir
-        break
-      }
-    }
-  }
-
-  const cacheFile = join(cacheDir, '.cache/nuxt/builds', id, hash + '.tar')
+  const cacheFile = join(getCacheDir(nuxt), id, hash + '.tar')
 
   return {
     hash,
@@ -73,7 +63,7 @@ export async function getVueHash (nuxt: Nuxt) {
 export async function cleanupCaches (nuxt: Nuxt) {
   const start = Date.now()
   const caches = await glob(['*/*.tar'], {
-    cwd: join(nuxt.options.workspaceDir, 'node_modules/.cache/nuxt/builds'),
+    cwd: getCacheDir(nuxt),
     absolute: true,
   })
   if (caches.length >= 10) {
@@ -283,4 +273,17 @@ async function writeCache (cwd: string, sources: string | string[], cacheFile: s
   const tarData = createTar(fileEntries)
   await mkdir(dirname(cacheFile), { recursive: true })
   await writeFile(cacheFile, tarData)
+}
+
+function getCacheDir (nuxt: Nuxt) {
+  let cacheDir = join(nuxt.options.workspaceDir, 'node_modules')
+  if (!existsSync(cacheDir)) {
+    for (const dir of [...nuxt.options.modulesDir].sort((a, b) => a.length - b.length)) {
+      if (existsSync(dir)) {
+        cacheDir = dir
+        break
+      }
+    }
+  }
+  return join(cacheDir, '.cache/nuxt/builds')
 }

--- a/packages/nuxt/src/core/cache.ts
+++ b/packages/nuxt/src/core/cache.ts
@@ -39,10 +39,12 @@ export async function getVueHash (nuxt: Nuxt) {
   })
 
   let cacheDir = join(nuxt.options.workspaceDir, 'node_modules')
-  for (const dir of nuxt.options.modulesDir) {
-    if (existsSync(dir)) {
-      cacheDir = dir
-      break
+  if (!existsSync(cacheDir)) {
+    for (const dir of [...nuxt.options.modulesDir].sort((a, b) => a.length - b.length)) {
+      if (existsSync(dir)) {
+        cacheDir = dir
+        break
+      }
     }
   }
 

--- a/packages/nuxt/src/core/cache.ts
+++ b/packages/nuxt/src/core/cache.ts
@@ -10,7 +10,6 @@ import { consola } from 'consola'
 import { dirname, join, relative } from 'pathe'
 import { createTar, parseTar } from 'nanotar'
 import type { TarFileInput } from 'nanotar'
-import { getFirstNodeModulesDir } from '../utils'
 
 export async function getVueHash (nuxt: Nuxt) {
   const id = 'vue'
@@ -39,7 +38,15 @@ export async function getVueHash (nuxt: Nuxt) {
     },
   })
 
-  const cacheFile = join(getFirstNodeModulesDir() ?? join(nuxt.options.workspaceDir, 'node_modules'), '.cache/nuxt/builds', id, hash + '.tar')
+  let cacheDir = join(nuxt.options.workspaceDir, 'node_modules')
+  for (const dir of nuxt.options.modulesDir) {
+    if (existsSync(dir)) {
+      cacheDir = dir
+      break
+    }
+  }
+
+  const cacheFile = join(cacheDir, '.cache/nuxt/builds', id, hash + '.tar')
 
   return {
     hash,

--- a/packages/nuxt/src/utils.ts
+++ b/packages/nuxt/src/utils.ts
@@ -14,7 +14,7 @@ export const logger = useLogger('nuxt')
 
 export function getFirstNodeModulesDir () {
   const nuxt = useNuxt()
-  for(const dir of nuxt.options.modulesDir) {
+  for (const dir of nuxt.options.modulesDir) {
     if (existsSync(dir)) {
       return dir
     }

--- a/packages/nuxt/src/utils.ts
+++ b/packages/nuxt/src/utils.ts
@@ -1,5 +1,5 @@
-import { existsSync, promises as fsp } from 'node:fs'
-import { useLogger, useNuxt } from '@nuxt/kit'
+import { promises as fsp } from 'node:fs'
+import { useLogger } from '@nuxt/kit'
 
 /** @since 3.9.0 */
 export function toArray<T> (value: T | T[]): T[] {
@@ -11,12 +11,3 @@ export async function isDirectory (path: string) {
 }
 
 export const logger = useLogger('nuxt')
-
-export function getFirstNodeModulesDir () {
-  const nuxt = useNuxt()
-  for (const dir of nuxt.options.modulesDir) {
-    if (existsSync(dir)) {
-      return dir
-    }
-  }
-}

--- a/packages/nuxt/src/utils.ts
+++ b/packages/nuxt/src/utils.ts
@@ -1,5 +1,5 @@
-import { promises as fsp } from 'node:fs'
-import { useLogger } from '@nuxt/kit'
+import { existsSync, promises as fsp } from 'node:fs'
+import { useLogger, useNuxt } from '@nuxt/kit'
 
 /** @since 3.9.0 */
 export function toArray<T> (value: T | T[]): T[] {
@@ -11,3 +11,12 @@ export async function isDirectory (path: string) {
 }
 
 export const logger = useLogger('nuxt')
+
+export function getFirstNodeModulesDir () {
+  const nuxt = useNuxt()
+  for(const dir of nuxt.options.modulesDir) {
+    if (existsSync(dir)) {
+      return dir
+    }
+  }
+}


### PR DESCRIPTION
### 🔗 Linked issue
closes https://github.com/nuxt/nuxt/pull/31904 
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Do we want to make it configurable ?

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
