### PR TITLE
fix(nuxt): respect the scroll behavior set by `scrollToTop`

### DIFF
--- a/packages/nuxt/src/pages/runtime/page.ts
+++ b/packages/nuxt/src/pages/runtime/page.ts
@@ -141,13 +141,17 @@ export default defineComponent({
 
               const willRenderAnotherChild = hasChildrenRoutes(forkRoute, routeProps.route, routeProps.Component)
               if (!nuxtApp.isHydrating && previousPageKey === key && !willRenderAnotherChild) {
-                nuxtApp.callHook('page:loading:end')
-                pageLoadingEndHookAlreadyCalled = true
+                nextTick(() => {
+                  pageLoadingEndHookAlreadyCalled = true
+                  nuxtApp.callHook('page:loading:end')
+                  if (hasTransition) {
+                    nuxtApp.callHook('page:transition:finish', routeProps.Component)
+                  }
+                })
               }
 
               previousPageKey = key
 
-              // Client side rendering
               const hasTransition = !!(props.transition ?? routeProps.route.meta.pageTransition ?? defaultPageTransition)
               const transitionProps = hasTransition && _mergeTransitionProps([
                 props.transition,

--- a/packages/nuxt/src/pages/runtime/page.ts
+++ b/packages/nuxt/src/pages/runtime/page.ts
@@ -144,9 +144,6 @@ export default defineComponent({
                 nextTick(() => {
                   pageLoadingEndHookAlreadyCalled = true
                   nuxtApp.callHook('page:loading:end')
-                  if (hasTransition) {
-                    nuxtApp.callHook('page:transition:finish', routeProps.Component)
-                  }
                 })
               }
 
@@ -157,7 +154,15 @@ export default defineComponent({
                 props.transition,
                 routeProps.route.meta.pageTransition,
                 defaultPageTransition,
-                { onAfterLeave: () => { nuxtApp.callHook('page:transition:finish', routeProps.Component) } },
+                {
+                  onBeforeLeave () {
+                    nuxtApp._runningTransition = true
+                  },
+                  onAfterLeave () {
+                    delete nuxtApp._runningTransition
+                    nuxtApp.callHook('page:transition:finish', routeProps.Component)
+                  },
+                },
               ])
 
               const keepaliveConfig = props.keepalive ?? routeProps.route.meta.keepalive ?? (defaultKeepaliveConfig as KeepAliveProps)

--- a/packages/nuxt/src/pages/runtime/router.options.ts
+++ b/packages/nuxt/src/pages/runtime/router.options.ts
@@ -16,17 +16,6 @@ export default <RouterConfig> {
     // @ts-expect-error untyped, nuxt-injected option
     const behavior = useRouter().options?.scrollBehaviorType ?? 'auto'
 
-    // By default when the returned position is falsy or an empty object, vue-router will retain the current scroll position
-    // savedPosition is only available for popstate navigations (back button)
-    let position: ScrollPosition = savedPosition || undefined
-
-    const routeAllowsScrollToTop = typeof to.meta.scrollToTop === 'function' ? to.meta.scrollToTop(to, from) : to.meta.scrollToTop
-
-    // Scroll to top if route is changed by default
-    if (!position && from && to && routeAllowsScrollToTop !== false && isChangingPage(to, from)) {
-      position = { left: 0, top: 0 }
-    }
-
     // Hash routes on the same page, no page hook is fired so resolve here
     if (to.path === from.path) {
       if (from.hash && !to.hash) {
@@ -37,6 +26,19 @@ export default <RouterConfig> {
       }
       // The route isn't changing so keep current scroll position
       return false
+    }
+
+    const routeAllowsScrollToTop = typeof to.meta.scrollToTop === 'function' ? to.meta.scrollToTop(to, from) : to.meta.scrollToTop
+
+    if (routeAllowsScrollToTop === false) { return }
+
+    // By default when the returned position is falsy or an empty object, vue-router will retain the current scroll position
+    // savedPosition is only available for popstate navigations (back button)
+    let position: ScrollPosition = savedPosition || undefined
+
+    // Scroll to top if route is changed by default
+    if (!position && isChangingPage(to, from)) {
+      position = { left: 0, top: 0 }
     }
 
     // Wait for `page:transition:finish` or `page:finish` depending on if transitions are enabled or not

--- a/packages/nuxt/src/pages/runtime/router.options.ts
+++ b/packages/nuxt/src/pages/runtime/router.options.ts
@@ -1,10 +1,9 @@
+import { START_LOCATION } from 'vue-router'
 import type { RouteLocationNormalized, RouterScrollBehavior } from 'vue-router'
 import type { RouterConfig } from 'nuxt/schema'
 import { useNuxtApp } from '#app/nuxt'
 import { isChangingPage } from '#app/components/utils'
 import { useRouter } from '#app/composables/router'
-// @ts-expect-error virtual file
-import { appPageTransition as defaultPageTransition } from '#build/nuxt.config.mjs'
 
 type ScrollPosition = Awaited<ReturnType<RouterScrollBehavior>>
 
@@ -30,7 +29,7 @@ export default <RouterConfig> {
 
     const routeAllowsScrollToTop = typeof to.meta.scrollToTop === 'function' ? to.meta.scrollToTop(to, from) : to.meta.scrollToTop
 
-    if (routeAllowsScrollToTop === false) { return }
+    if (routeAllowsScrollToTop === false) { return false }
 
     // By default when the returned position is falsy or an empty object, vue-router will retain the current scroll position
     // savedPosition is only available for popstate navigations (back button)
@@ -41,10 +40,13 @@ export default <RouterConfig> {
       position = { left: 0, top: 0 }
     }
 
-    // Wait for `page:transition:finish` or `page:finish` depending on if transitions are enabled or not
-    const hasTransition = (route: RouteLocationNormalized) => !!(route.meta.pageTransition ?? defaultPageTransition)
-    const hookToWait = (hasTransition(from) && hasTransition(to)) ? 'page:transition:finish' : 'page:loading:end'
+    const hookToWait = nuxtApp._runningTransition ? 'page:transition:finish' : 'page:loading:end'
     return new Promise((resolve) => {
+      if (from === START_LOCATION) {
+        resolve(_calculatePosition(to, 'instant', position))
+        return
+      }
+
       nuxtApp.hooks.hookOnce(hookToWait, () => {
         requestAnimationFrame(() => resolve(_calculatePosition(to, 'instant', position)))
       })

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -3017,6 +3017,34 @@ describe('defineNuxtComponent', () => {
   })
 })
 
+describe('scrollToTop', () => {
+  it('should not scroll to top when `scrollToTop` is `false`', async () => {
+    const { page } = await renderPage('/route-scroll-behavior/scroll-to-top')
+
+    await page.locator('#do-not-scroll-to-top').scrollIntoViewIfNeeded()
+    await page.waitForFunction(() => window.scrollY > 0)
+
+    await page.click('#do-not-scroll-to-top')
+    await page.waitForFunction(() => window.useNuxtApp?.()._route.fullPath.includes('/scroll-to-top/do-not-scroll-to-top'))
+
+    const scrollY = await page.evaluate(() => window.scrollY)
+    expect(scrollY !== 0).toBe(true)
+  })
+
+  it('should scroll to top when `scrollToTop` is `true`', async () => {
+    const { page } = await renderPage('/route-scroll-behavior/scroll-to-top')
+
+    await page.locator('#scroll-to-top').scrollIntoViewIfNeeded()
+    await page.waitForFunction(() => window.scrollY > 0)
+
+    await page.click('#scroll-to-top')
+    await page.waitForFunction(() => window.useNuxtApp?.()._route.fullPath.includes('/scroll-to-top/scroll-to-top'))
+
+    const scrollY = await page.evaluate(() => window.scrollY)
+    expect(scrollY).toBe(0)
+  })
+})
+
 describe('namespace access to useNuxtApp', () => {
   it('should return the nuxt instance when used with correct appId', async () => {
     const { page, pageErrors } = await renderPage('/namespace-nuxt-app')

--- a/test/fixtures/basic/pages/route-scroll-behavior/scroll-to-top.vue
+++ b/test/fixtures/basic/pages/route-scroll-behavior/scroll-to-top.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+const nuxtApp = useNuxtApp()
+
+nuxtApp.hook('page:transition:finish', (Data) => {
+  console.log('動畫完成', Data)
+})
+</script>
+
+<template>
+  <div>
+    <NuxtPage />
+
+    <div style="height: 150vh" />
+
+    <NuxtLink
+      :to="{
+        name: 'route-scroll-behavior-scroll-to-top',
+      }"
+    >
+      Back to scroll to top
+    </NuxtLink> |
+    <NuxtLink
+      id="scroll-to-top"
+      :to="{
+        name: 'route-scroll-behavior-scroll-to-top-id',
+        params: { id: 'scroll-to-top' },
+        query: { scrollToTop: 'true' },
+      }"
+    >
+      Scroll to top
+    </NuxtLink> |
+    <NuxtLink
+      id="do-not-scroll-to-top"
+      :to="{
+        name: 'route-scroll-behavior-scroll-to-top-id',
+        params: { id: 'do-not-scroll-to-top' },
+        query: { scrollToTop: 'false' },
+      }"
+    >
+      Do not scroll to top
+    </NuxtLink>
+  </div>
+</template>

--- a/test/fixtures/basic/pages/route-scroll-behavior/scroll-to-top/[id].vue
+++ b/test/fixtures/basic/pages/route-scroll-behavior/scroll-to-top/[id].vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+definePageMeta({
+  scrollToTop (to) {
+    return to.query.scrollToTop === 'true'
+  },
+})
+
+const route = useRoute()
+</script>
+
+<template>
+  <div>
+    <h2>{{ route.params.id }}</h2>
+  </div>
+</template>

--- a/test/nuxt/loading-indicator.test.ts
+++ b/test/nuxt/loading-indicator.test.ts
@@ -101,9 +101,6 @@ describe('page loading indicator', () => {
       expect(getLoadingIndicator().attributes().style).toContain('opacity: 1;')
       onLoad?.()
 
-      // ensure loading hasn't already finished
-      await nextTick(() => new Promise(r => setTimeout(r, 0)))
-
       if (isLoading.value) {
         resolve!()
         await new Promise<void>(resolve => nuxtApp.hooks.hookOnce('page:loading:end', () => { resolve() }))


### PR DESCRIPTION
### 🔗 Linked issue

- related #31654
- related #31638
- resolves #25241
- Resolves #31650

### 📚 Description

Fix an issue where setting `scrollToTop: false` did not preserve the current scroll position when navigating within the same page component.  

After this PR, #31654, #31638 and #25241 can now be addressed by using the following approach to prevent scrolling to the top when navigating within the same page component:

```vue
<script setup lang="ts">
definePageMeta({
  scrollToTop: false,
})
</script>
```

- [#31654 fixed reproduction](https://stackblitz.com/edit/github-c5oaac3b-ifb1papv?file=pages/foo/%5Bid%5D.vue,package.json)
- [#31638 fixed reproduction](https://stackblitz.com/edit/github-prrsurkb-efbkjy6b?file=pages/schedule/%5Bday%5D.vue)
- [#25241 fixed reproduction](https://stackblitz.com/edit/nuxt-starter-qtuymnfi?file=pages/index.vue,pages/index/dialog.vue)

Additionally, this PR also corrects the registration and invocation order of the `page:loading:end` hook.

In current, when navigating within the same page component, the first navigation triggers `nuxtApp.callHook('page:loading:end')` inside `page.ts` **before** `nuxtApp.hooks.hookOnce('page:loading:end', () => { ... })` is registered in `router.options.ts`.

This explains why, in the provided minimal reproduction, the page does not scroll to the top on the first navigation but does on the second navigation.

https://stackblitz.com/edit/github-c5oaac3b-jwythaqo?file=pages/foo/%5Bid%5D.vue

Lastly, this PR also updates the `hookToWait` condition in `router.options.ts` to ensure that any method of enabling `<Transition>` is properly recognized.

- [#31650 fixed reproduction](https://stackblitz.com/edit/nuxt-starter-lbcyvm6q?file=pages/index.vue)

Thank you very much for your time and review! If there’s anything I might have overlooked, please feel free to let me know.
