### PR TITLE
fix(nuxt): check if match exists with new unplugin filter

### DIFF
--- a/packages/nuxt/src/components/plugins/component-names.ts
+++ b/packages/nuxt/src/components/plugins/component-names.ts
@@ -26,7 +26,10 @@ export const ComponentNamePlugin = (options: NameDevPluginOptions) => createUnpl
         id: { include: FILENAME_RE },
       },
       handler (code, id) {
-        const filename = id.match(FILENAME_RE)![1]!
+        const filename = id.match(FILENAME_RE)?.[1]
+        if (!filename) {
+          return
+        }
         const component = options.getComponents().find(c => c.filePath === id)
 
         if (!component) {

--- a/packages/nuxt/src/components/plugins/lazy-hydration-transform.ts
+++ b/packages/nuxt/src/components/plugins/lazy-hydration-transform.ts
@@ -47,8 +47,8 @@ export const LazyHydrationTransformPlugin = (options: LoaderOptions) => createUn
       },
       async handler (code) {
         // change <LazyMyComponent hydrate-on-idle /> to <LazyIdleMyComponent hydrate-on-idle />
-        const { 0: template, index: offset = 0 } = code.match(TEMPLATE_RE)!
-        if (!LAZY_HYDRATION_PROPS_RE.test(template)) {
+        const { 0: template, index: offset = 0 } = code.match(TEMPLATE_RE) || {}
+        if (!template || !LAZY_HYDRATION_PROPS_RE.test(template)) {
           return
         }
         const s = new MagicString(code)


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/31924

### 📚 Description


this adds some extra guards when using with new unplugin filter, in case for some reason the package manager does not correctly make the version we are depending on available to us 🤦 