### PR TITLE
feat(nuxt): skip view transition if user agent is providing one

### DIFF
--- a/packages/nuxt/src/app/plugins/view-transitions.client.ts
+++ b/packages/nuxt/src/app/plugins/view-transitions.client.ts
@@ -9,8 +9,15 @@ export default defineNuxtPlugin((nuxtApp) => {
     return
   }
 
+  let transition: undefined | ViewTransition
   let finishTransition: undefined | (() => void)
   let abortTransition: undefined | (() => void)
+
+  window.addEventListener('popstate', (event) => {
+    if (event.hasUAVisualTransition && transition) {
+      transition.skipTransition()
+    }
+  })
 
   const router = useRouter()
 
@@ -31,7 +38,7 @@ export default defineNuxtPlugin((nuxtApp) => {
     let changeRoute: () => void
     const ready = new Promise<void>(resolve => (changeRoute = resolve))
 
-    const transition = document.startViewTransition!(() => {
+    transition = document.startViewTransition!(() => {
       changeRoute()
       return promise
     })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #31928


https://github.com/user-attachments/assets/9aa2814e-a0f4-40ad-ad46-23c13b09bc1d



### 📚 Description

The new View Transition API became available in Safari 18. However, Safari’s default swipe gesture for back and forward navigation triggers the animation **after** the swipe gesture, causing a double transition effect.

This solution adds a `PopStateEvent` listener to the `window`, and if [`hasUAVisualTransition`](https://developer.mozilla.org/en-US/docs/Web/API/PopStateEvent/hasUAVisualTransition) is `true`, the visual transition is [skipped](https://developer.mozilla.org/en-US/docs/Web/API/ViewTransition/skipTransition).

In the future, it should also be considered to adopt [`NavigationEvent.hasUAVisualTransition`](https://developer.mozilla.org/en-US/docs/Web/API/NavigateEvent/hasUAVisualTransition) when available.


### 📱 Recording

https://github.com/user-attachments/assets/167554f5-4175-47e2-a101-abb29b7e5ef5


