### PR TITLE
fix(nuxt): reinitialise stale async data

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -270,7 +270,10 @@ export function useAsyncData<
 
   // Create or use a shared asyncData entity
   const initialCachedData = options.getCachedData!(key.value, nuxtApp, { cause: 'initial' })
-  const asyncData = nuxtApp._asyncData[key.value] ??= createAsyncData(nuxtApp, key.value, _handler, options, initialCachedData)
+  if (!nuxtApp._asyncData[key.value]?._deps) {
+    nuxtApp._asyncData[key.value] = createAsyncData(nuxtApp, key.value, _handler, options, initialCachedData)
+  }
+  const asyncData = nuxtApp._asyncData[key.value]!
 
   asyncData._deps++
 
@@ -353,8 +356,8 @@ export function useAsyncData<
       if (oldKey) {
         unregister(oldKey)
       }
-      if (!nuxtApp._asyncData[key]) {
-        nuxtApp._asyncData[key] ??= createAsyncData(nuxtApp, key, _handler, options, options.getCachedData!(key, nuxtApp, { cause: 'initial' }))
+      if (!nuxtApp._asyncData[key]?._deps) {
+        nuxtApp._asyncData[key] = createAsyncData(nuxtApp, key, _handler, options, options.getCachedData!(key, nuxtApp, { cause: 'initial' }))
       }
       nuxtApp._asyncData[key]._deps++
       if (options.immediate) {

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -338,6 +338,7 @@ export function useAsyncData<
           data?._off()
           if (purgeCachedData) {
             clearNuxtDataByKey(nuxtApp, key)
+            data.execute = () => Promise.resolve()
           }
         }
       }

--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -133,22 +133,7 @@ export function useFetch<
     getCachedData,
     deep,
     dedupe,
-    watch: watch === false
-      ? []
-      : [
-          ...(watch || []),
-          opts.key
-            ? _fetchOptions
-            : reactive({
-                ..._fetchOptions,
-                // these methods are included in the `key`
-                method: undefined,
-                baseURL: undefined,
-                params: undefined,
-                query: undefined,
-                body: undefined,
-              }),
-        ],
+    watch: watch === false ? [] : [...(watch || []), _fetchOptions],
   }
 
   if (import.meta.dev) {

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -587,6 +587,25 @@ describe('useAsyncData', () => {
     expect(await getData()).toBe('undefined')
   })
 
+  it('should remain reactive after being reinitialised', async () => {
+    const promiseFn = vi.fn((value: string) => Promise.resolve(value))
+    const component = (value: string) => defineComponent({
+      setup () {
+        const { data } = useAsyncData('fixed', () => promiseFn(value))
+        return () => h('div', [data.value])
+      },
+    })
+
+    const comp1 = await mountSuspended(component('first'))
+    expect(promiseFn).toHaveBeenCalledTimes(1)
+    comp1.unmount()
+
+    const comp2 = await mountSuspended(component('second'))
+    expect(promiseFn).toHaveBeenCalledTimes(2)
+    expect(promiseFn).toHaveBeenLastCalledWith('second')
+    expect(comp2.html()).toMatchInlineSnapshot(`"<div>second</div>"`)
+  })
+
   it('should be synced with useNuxtData', async () => {
     const { data: nuxtData } = useNuxtData('nuxtdata-sync')
     const promise = useAsyncData('nuxtdata-sync', () => Promise.resolve('test'), { default: () => 'default' })


### PR DESCRIPTION
### 🔗 Linked issue

reverts https://github.com/nuxt/nuxt/pull/31903
resolves https://github.com/nuxt/nuxt/issues/31937

### 📚 Description

the `execute` function from previously initialised async data was sticking around, leading to a memory leak and a 'stale' fetcher function which was accessing no-longer-reactive params/refs.