### PR TITLE
fix(nuxt): trigger `execute` when non-immediate fetch key changes

### DIFF
--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -1,7 +1,7 @@
 import type { FetchError, FetchOptions } from 'ofetch'
 import type { $Fetch, H3Event$Fetch, NitroFetchRequest, TypedInternalResponse, AvailableRouterMethod as _AvailableRouterMethod } from 'nitro/types'
 import type { MaybeRef, MaybeRefOrGetter, Ref } from 'vue'
-import { computed, reactive, toValue } from 'vue'
+import { computed, reactive, toValue, watch } from 'vue'
 import { hash } from 'ohash'
 
 import { useRequestFetch } from './ssr'
@@ -109,7 +109,7 @@ export function useFetch<
     default: defaultFn,
     transform,
     pick,
-    watch,
+    watch: watchSources,
     immediate,
     getCachedData,
     deep,
@@ -133,12 +133,19 @@ export function useFetch<
     getCachedData,
     deep,
     dedupe,
-    watch: watch === false ? [] : [...(watch || []), _fetchOptions],
+    watch: watchSources === false ? [] : [...(watchSources || []), _fetchOptions],
   }
 
   if (import.meta.dev) {
     // @ts-expect-error private property
     _asyncDataOptions._functionName ||= 'useFetch'
+  }
+
+  // ensure that updates to watched sources trigger an update
+  if (watchSources !== false && !immediate) {
+    watch([...(watchSources || []), _fetchOptions], () => {
+      _asyncDataOptions.immediate = true
+    }, { flush: 'pre', once: true })
   }
 
   let controller: AbortController

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -672,6 +672,25 @@ describe('useFetch', () => {
     expect(error.value).toBe(undefined)
   })
 
+  it('should work with reactive keys and immediate: false', async () => {
+    registerEndpoint('/api/immediate-false', defineEventHandler(() => ({ url: '/api/immediate-false' })))
+
+    const q = ref('')
+    const { data } = await useFetch('/api/immediate-false', {
+      query: { q },
+      immediate: false,
+    })
+
+    expect(data.value).toBe(undefined)
+    q.value = 'test'
+
+    await flushPromises()
+    await nextTick()
+    await flushPromises()
+
+    expect(data.value).toEqual({ url: '/api/immediate-false' })
+  })
+
   it('should timeout', async () => {
     const { status, error } = await useFetch(
       // @ts-expect-error should resolve to a string


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/31939

### 📚 Description

basically when reactive fetch source change, a 'new' asyncData is created, and `immediate: false` is respected there too. as this is a change from previous behaviour, this PR seeks to automatically re-fetch when sources change