### PR TITLE
fix(nuxt): skip view transition if user agent is providing one before defining `transition`

### DIFF
--- a/packages/nuxt/src/app/plugins/view-transitions.client.ts
+++ b/packages/nuxt/src/app/plugins/view-transitions.client.ts
@@ -23,7 +23,7 @@ export default defineNuxtPlugin((nuxtApp) => {
 
   window.addEventListener('popstate', (event) => {
     hasUAVisualTransition = event.hasUAVisualTransition
-    if (hasUAVisualTransition) transition?.skipTransition()
+    if (hasUAVisualTransition) { transition?.skipTransition() }
   })
 
   const router = useRouter()

--- a/packages/nuxt/src/app/plugins/view-transitions.client.ts
+++ b/packages/nuxt/src/app/plugins/view-transitions.client.ts
@@ -9,8 +9,15 @@ export default defineNuxtPlugin((nuxtApp) => {
     return
   }
 
+  let transition: undefined | ViewTransition
   let finishTransition: undefined | (() => void)
   let abortTransition: undefined | (() => void)
+
+  window.addEventListener('popstate', (event) => {
+    if (event.hasUAVisualTransition && transition) {
+      transition.skipTransition()
+    }
+  })
 
   const router = useRouter()
 
@@ -31,7 +38,7 @@ export default defineNuxtPlugin((nuxtApp) => {
     let changeRoute: () => void
     const ready = new Promise<void>(resolve => (changeRoute = resolve))
 
-    const transition = document.startViewTransition!(() => {
+    transition = document.startViewTransition!(() => {
       changeRoute()
       return promise
     })

--- a/packages/nuxt/src/app/plugins/view-transitions.client.ts
+++ b/packages/nuxt/src/app/plugins/view-transitions.client.ts
@@ -36,8 +36,8 @@ export default defineNuxtPlugin((nuxtApp) => {
     if (
       viewTransitionMode === false ||
       prefersNoTransition ||
-      !isChangingPage(to, from) ||
-      hasUAVisualTransition
+      hasUAVisualTransition ||
+      !isChangingPage(to, from)
     ) {
       return
     }

--- a/packages/nuxt/src/app/plugins/view-transitions.client.ts
+++ b/packages/nuxt/src/app/plugins/view-transitions.client.ts
@@ -10,13 +10,20 @@ export default defineNuxtPlugin((nuxtApp) => {
   }
 
   let transition: undefined | ViewTransition
+  let hasUAVisualTransition = false
   let finishTransition: undefined | (() => void)
   let abortTransition: undefined | (() => void)
 
+  const resetTransitionState = () => {
+    transition = undefined
+    hasUAVisualTransition = false
+    abortTransition = undefined
+    finishTransition = undefined
+  }
+
   window.addEventListener('popstate', (event) => {
-    if (event.hasUAVisualTransition && transition) {
-      transition.skipTransition()
-    }
+    hasUAVisualTransition = event.hasUAVisualTransition
+    if (hasUAVisualTransition) transition?.skipTransition()
   })
 
   const router = useRouter()
@@ -26,7 +33,12 @@ export default defineNuxtPlugin((nuxtApp) => {
     const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
     const prefersNoTransition = prefersReducedMotion && viewTransitionMode !== 'always'
 
-    if (viewTransitionMode === false || prefersNoTransition || !isChangingPage(to, from)) {
+    if (
+      viewTransitionMode === false ||
+      prefersNoTransition ||
+      !isChangingPage(to, from) ||
+      hasUAVisualTransition
+    ) {
       return
     }
 
@@ -43,10 +55,7 @@ export default defineNuxtPlugin((nuxtApp) => {
       return promise
     })
 
-    transition.finished.then(() => {
-      abortTransition = undefined
-      finishTransition = undefined
-    })
+    transition.finished.then(resetTransitionState)
 
     await nuxtApp.callHook('page:view-transition:start', transition)
 
@@ -55,11 +64,11 @@ export default defineNuxtPlugin((nuxtApp) => {
 
   nuxtApp.hook('vue:error', () => {
     abortTransition?.()
-    abortTransition = undefined
+    resetTransitionState()
   })
 
   nuxtApp.hook('page:finish', () => {
     finishTransition?.()
-    finishTransition = undefined
+    resetTransitionState()
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #31928


https://github.com/user-attachments/assets/b7be0212-7ec8-4224-be4a-f3dffa044c26



### 📚 Description

This PR is a follow-up to #31938, where the transition is skipped when `PopStateEvent.hasUAVisualTransition` is `true` by calling `transition.skipTransition()`. However, after a page reload, it can happen that the `popstate` event of the subsequent navigation is fired before `transition` is created, so calling `transition.skipTransition()` has no effect.  
This PR covers this edge case by setting a flag and checking it when the `transition` is created.


### 📱 Recording


https://github.com/user-attachments/assets/d5342ea7-ba6e-478a-9de6-8be6add7a49d


