### PR TITLE
fix(nuxt): ensure asyncData is initialised before effects run

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -346,11 +346,15 @@ export function useAsyncData<
 
     // setup watchers/instance
     const hasScope = getCurrentScope()
-    const unsub = watch([key, ...options.watch || []], ([newKey], [oldKey]) => {
-      if (oldKey === newKey) {
+    if (options.watch) {
+      const unsubExecute = watch(options.watch, () => {
         asyncData._execute({ cause: 'watch', dedupe: options.dedupe })
-        return
+      }, { flush: 'post' })
+      if (hasScope) {
+        onScopeDispose(() => unsubExecute())
       }
+    }
+    const unsubKey = watch(key, (newKey, oldKey) => {
       if (oldKey) {
         unregister(oldKey)
       }
@@ -361,11 +365,11 @@ export function useAsyncData<
       if (options.immediate) {
         nuxtApp._asyncData[newKey]!.execute({ cause: 'initial', dedupe: options.dedupe })
       }
-    })
+    }, { flush: 'sync' })
 
     if (hasScope) {
       onScopeDispose(() => {
-        unsub()
+        unsubKey()
         unregister(key.value)
       })
     }

--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -145,7 +145,7 @@ export function useFetch<
   if (watchSources !== false && !immediate) {
     watch([...(watchSources || []), _fetchOptions], () => {
       _asyncDataOptions.immediate = true
-    }, { flush: 'pre', once: true })
+    }, { flush: 'sync', once: true })
   }
 
   let controller: AbortController

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -691,6 +691,27 @@ describe('useFetch', () => {
     expect(data.value).toEqual({ url: '/api/immediate-false' })
   })
 
+  it('should be accessible immediately', async () => {
+    registerEndpoint('/api/watchable-fetch', defineEventHandler(() => ({ url: '/api/watchable-fetch' })))
+
+    const searchTerm = ref('')
+
+    const { data } = await useFetch('/api/watchable-fetch', {
+      params: { q: searchTerm },
+    })
+
+    for (const value of [undefined, 'pre', 'post', 'sync'] as const) {
+      watchEffect(() => {
+        expect(() => data.value).not.toThrow()
+      }, { flush: value })
+    }
+
+    searchTerm.value = 'new'
+
+    await nextTick()
+    await flushPromises()
+  })
+
   it('should timeout', async () => {
     const { status, error } = await useFetch(
       // @ts-expect-error should resolve to a string


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this ensures that asyncData will be initialised when the key changes, to avoid accessing an undefined property in the new data

thanks to @benjamincanac for spotting the issue