### PR TITLE
fix(nuxt): preserve params/meta/matched when navigating with Route object

### DIFF
--- a/packages/nuxt/src/app/plugins/router.ts
+++ b/packages/nuxt/src/app/plugins/router.ts
@@ -40,7 +40,7 @@ function getRouteFromPath (fullPath: string | Partial<Route>) {
   let params: Route['params'] = {}
   let matched: Route['matched'] = []
   let meta: Route['meta'] = {}
-  
+
   if (typeof fullPath === 'object') {
     params = fullPath.params || {}
     matched = fullPath.matched || []

--- a/packages/nuxt/src/app/plugins/router.ts
+++ b/packages/nuxt/src/app/plugins/router.ts
@@ -37,7 +37,14 @@ interface Route {
 }
 
 function getRouteFromPath (fullPath: string | Partial<Route>) {
+  let params: Route['params'] = {}
+  let matched: Route['matched'] = []
+  let meta: Route['meta'] = {}
+  
   if (typeof fullPath === 'object') {
+    params = fullPath.params || {}
+    matched = fullPath.matched || []
+    meta = fullPath.meta || {}
     fullPath = stringifyParsedURL({
       pathname: fullPath.path || '',
       search: stringifyQuery(fullPath.query || {}),
@@ -52,11 +59,11 @@ function getRouteFromPath (fullPath: string | Partial<Route>) {
     query: parseQuery(url.search),
     hash: url.hash,
     // stub properties for compat with vue-router
-    params: {},
+    params,
     name: undefined,
-    matched: [],
+    matched,
     redirectedFrom: undefined,
-    meta: {},
+    meta,
     href: fullPath,
   }
 }

--- a/packages/nuxt/src/app/plugins/router.ts
+++ b/packages/nuxt/src/app/plugins/router.ts
@@ -37,14 +37,9 @@ interface Route {
 }
 
 function getRouteFromPath (fullPath: string | Partial<Route>) {
-  let params: Route['params'] = {}
-  let matched: Route['matched'] = []
-  let meta: Route['meta'] = {}
+  const route = fullPath && typeof fullPath === 'object' ? fullPath : {}
 
   if (typeof fullPath === 'object') {
-    params = fullPath.params || {}
-    matched = fullPath.matched || []
-    meta = fullPath.meta || {}
     fullPath = stringifyParsedURL({
       pathname: fullPath.path || '',
       search: stringifyQuery(fullPath.query || {}),
@@ -59,11 +54,11 @@ function getRouteFromPath (fullPath: string | Partial<Route>) {
     query: parseQuery(url.search),
     hash: url.hash,
     // stub properties for compat with vue-router
-    params,
+    params: route.params || {},
     name: undefined,
-    matched,
+    matched: route.matched || [],
     redirectedFrom: undefined,
-    meta,
+    meta: route.meta || {},
     href: fullPath,
   }
 }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

This change modifies the `getRouteFromPath` utility function to correctly handle cases where a `Partial<Route>` object is passed to navigation methods (`router.push`, `router.replace`, `navigateTo`).

Previously, properties like `params`, `meta`, and `matched` from the input object were discarded and overwritten with empty values in the returned route object, limiting the ability to pass rich, pre-defined route state.

With this update, `getRouteFromPath` now preserves `params`, `meta`, and `matched` if they are present in the input `Partial<Route>`.

This enhancement allows developers to pass more complete `Route` objects, ensuring custom context (especially via `meta`) and pre-calculated route information persists through the routing pipeline (middleware, navigation guards).

This opens up opportunities for more advanced routing strategies and state management. A key use case this enables is the ability to define navigation-specific `meta` context (e.g., to signal state restoration) which can be reliably accessed in middleware/guards, addressing scenarios where differentiating navigation types (forward vs. back-like) is necessary for specific page behaviors.

This is a backward-compatible change; navigating with just paths or simple location objects behaves as before.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
