### PR TITLE
fix(nuxt): improve hashing for complex body in `useFetch`

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -376,10 +376,10 @@ export function useAsyncData<
   }
 
   const asyncReturn: _AsyncData<ResT, (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>)> = {
-    data: writableComputedRef(() => nuxtApp._asyncData[key.value]!.data as Ref<ResT>),
-    pending: writableComputedRef(() => nuxtApp._asyncData[key.value]!.pending),
-    status: writableComputedRef(() => nuxtApp._asyncData[key.value]!.status),
-    error: writableComputedRef(() => nuxtApp._asyncData[key.value]!.error as Ref<NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>>),
+    data: writableComputedRef(() => nuxtApp._asyncData[key.value]?.data as Ref<ResT>),
+    pending: writableComputedRef(() => nuxtApp._asyncData[key.value]?.pending as Ref<boolean>),
+    status: writableComputedRef(() => nuxtApp._asyncData[key.value]?.status as Ref<AsyncDataRequestStatus>),
+    error: writableComputedRef(() => nuxtApp._asyncData[key.value]?.error as Ref<NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>>),
     refresh: (...args) => nuxtApp._asyncData[key.value]!.execute(...args),
     execute: (...args) => nuxtApp._asyncData[key.value]!.execute(...args),
     clear: () => clearNuxtDataByKey(nuxtApp, key.value),
@@ -395,10 +395,13 @@ export function useAsyncData<
 function writableComputedRef<T> (getter: () => Ref<T>) {
   return computed({
     get () {
-      return getter().value
+      return getter()?.value
     },
     set (value) {
-      getter().value = value
+      const ref = getter()
+      if (ref) {
+        ref.value = value
+      }
     },
   })
 }

--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -267,7 +267,8 @@ function generateOptionSegments<_ResT, DataT, DefaultT> (opts: UseFetchOptions<_
     segments.push(unwrapped)
   }
   if (opts.body) {
-    segments.push(hash(toValue(opts.body)))
+    const value = toValue(opts.body)
+    segments.push(hash(value && typeof value === 'object' ? reactive(value) : value))
   }
   return segments
 }

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -712,6 +712,24 @@ describe('useFetch', () => {
     await flushPromises()
   })
 
+  it('should handle complex objects in body', async () => {
+    registerEndpoint('/api/complex-objects', defineEventHandler(() => ({ url: '/api/complex-objects' })))
+    const testCases = [
+      { ref: ref('test') },
+      ref('test'),
+      new FormData(),
+      new ArrayBuffer(),
+    ]
+    for (const value of testCases) {
+      // @ts-expect-error auto-key is not valid in type signature
+      const { data: original } = await useFetch('/api/complex-objects', { body: value }, 'autokey')
+      original.value = 'new value'
+      // @ts-expect-error auto-key is not valid in type signature
+      const { data } = await useFetch('/api/complex-objects', { body: value, immediate: false }, 'autokey')
+      expect(data.value).toEqual('new value')
+    }
+  })
+
   it('should timeout', async () => {
     const { status, error } = await useFetch(
       // @ts-expect-error should resolve to a string


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/31955
resolves https://github.com/nuxt/nuxt/issues/31962

### 📚 Description

This was slightly different from other issues - we added support for including `body` in the key, but neglected to 'unwrap' it, so keys would mismatch if a ref was used inside the body.