### PR TITLE
fix(nuxt): don't render errors if event is already handled

### DIFF
--- a/packages/nuxt/src/core/runtime/nitro/handlers/error.ts
+++ b/packages/nuxt/src/core/runtime/nitro/handlers/error.ts
@@ -7,7 +7,7 @@ import { isJsonRequest } from '../utils/error'
 import type { NuxtPayload } from '#app/nuxt'
 
 export default <NitroErrorHandler> async function errorhandler (error, event, { defaultHandler }) {
-  if (isJsonRequest(event)) {
+  if (event.handled || isJsonRequest(event)) {
     // let Nitro handle JSON errors
     return
   }


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/31874

### 📚 Description

when porting across https://github.com/nuxt/nuxt/pull/31230, we dropped a couple of checks for `error.handled`. this adds one back to ensure we don't try to handle an error that the user has already handled for whatever reason.