### PR TITLE
fix(nuxt): short circuit middleware when validate returns false

### DIFF
--- a/docs/1.getting-started/07.routing.md
+++ b/docs/1.getting-started/07.routing.md
@@ -131,7 +131,7 @@ definePageMeta({
 
 Nuxt offers route validation via the `validate` property in [`definePageMeta()`](/docs/api/utils/define-page-meta) in each page you wish to validate.
 
-The `validate` property accepts the `route` as an argument. You can return a boolean value to determine whether or not this is a valid route to be rendered with this page. If you return `false`, and another match can't be found, this will cause a 404 error. You can also directly return an object with `statusCode`/`statusMessage` to respond immediately with an error (other matches will not be checked).
+The `validate` property accepts the `route` as an argument. You can return a boolean value to determine whether or not this is a valid route to be rendered with this page. If you return `false`, this will cause a 404 error. You can also directly return an object with `statusCode`/`statusMessage` to customize the error returned.
 
 If you have a more complex use case, then you can use anonymous route middleware instead.
 

--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -2,7 +2,6 @@ import { isReadonly, reactive, shallowReactive, shallowRef } from 'vue'
 import type { Ref } from 'vue'
 import type { RouteLocation, RouteLocationNormalizedLoaded, Router, RouterScrollBehavior } from 'vue-router'
 import { START_LOCATION, createMemoryHistory, createRouter, createWebHashHistory, createWebHistory } from 'vue-router'
-import { createError } from 'h3'
 import { isSamePath, withoutBase } from 'ufo'
 
 import type { Plugin, RouteMiddleware } from 'nuxt/app'
@@ -12,7 +11,7 @@ import { toArray } from '../utils'
 
 import { getRouteRules } from '#app/composables/manifest'
 import { defineNuxtPlugin, useRuntimeConfig } from '#app/nuxt'
-import { clearError, isNuxtError, showError, useError } from '#app/composables/error'
+import { clearError, createError, isNuxtError, showError, useError } from '#app/composables/error'
 import { navigateTo } from '#app/composables/router'
 
 // @ts-expect-error virtual file

--- a/packages/nuxt/src/pages/runtime/validate.ts
+++ b/packages/nuxt/src/pages/runtime/validate.ts
@@ -1,12 +1,11 @@
 import { createError, showError } from '#app/composables/error'
 import { useNuxtApp } from '#app/nuxt'
-import { defineNuxtRouteMiddleware, useRouter } from '#app/composables/router'
+import { defineNuxtRouteMiddleware } from '#app/composables/router'
 
-export default defineNuxtRouteMiddleware(async (to) => {
+export default defineNuxtRouteMiddleware(async (to, from) => {
   if (!to.meta?.validate) { return }
 
   const nuxtApp = useNuxtApp()
-  const router = useRouter()
 
   const result = await Promise.resolve(to.meta.validate(to))
   if (result === true) {
@@ -20,22 +19,15 @@ export default defineNuxtRouteMiddleware(async (to) => {
       path: to.fullPath,
     },
   })
-  const unsub = router.beforeResolve((final) => {
-    unsub()
-    if (final === to) {
-      const unsub = router.afterEach(async () => {
-        unsub()
-        await nuxtApp.runWithContext(() => showError(error))
-        // We pretend to have navigated to the invalid route so
-        // that the user can return to the previous page with
-        // the back button.
-        if (typeof window !== 'undefined') {
-          window.history.pushState({}, '', to.fullPath)
-        }
-      })
-      // We stop the navigation immediately before it resolves
-      // if there is no other route matching it.
-      return false
-    }
-  })
+
+  await nuxtApp.runWithContext(() => showError(error))
+
+  // We pretend to have navigated to the invalid route so
+  // that the user can return to the previous page with
+  // the back button.
+  if (typeof window !== 'undefined') {
+    window.history.pushState({}, '', from.fullPath)
+  }
+
+  return error
 })

--- a/packages/nuxt/src/pages/runtime/validate.ts
+++ b/packages/nuxt/src/pages/runtime/validate.ts
@@ -1,11 +1,8 @@
-import { createError, showError } from '#app/composables/error'
-import { useNuxtApp } from '#app/nuxt'
+import { createError } from '#app/composables/error'
 import { defineNuxtRouteMiddleware } from '#app/composables/router'
 
 export default defineNuxtRouteMiddleware(async (to, from) => {
   if (!to.meta?.validate) { return }
-
-  const nuxtApp = useNuxtApp()
 
   const result = await Promise.resolve(to.meta.validate(to))
   if (result === true) {
@@ -13,14 +10,13 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
   }
 
   const error = createError({
+    fatal: true,
     statusCode: (result && result.statusCode) || 404,
     statusMessage: (result && result.statusMessage) || `Page Not Found: ${to.fullPath}`,
     data: {
       path: to.fullPath,
     },
   })
-
-  await nuxtApp.runWithContext(() => showError(error))
 
   // We pretend to have navigated to the invalid route so
   // that the user can return to the previous page with

--- a/packages/nuxt/src/pages/runtime/validate.ts
+++ b/packages/nuxt/src/pages/runtime/validate.ts
@@ -10,7 +10,7 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
   }
 
   const error = createError({
-    fatal: true,
+    fatal: import.meta.client,
     statusCode: (result && result.statusCode) || 404,
     statusMessage: (result && result.statusMessage) || `Page Not Found: ${to.fullPath}`,
     data: {

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -117,7 +117,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(pagesRootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"281k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"282k"`)
 
     const modules = await analyzeSizes(['node_modules/**/*'], serverDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"1396k"`)

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -117,7 +117,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(pagesRootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"282k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"281k"`)
 
     const modules = await analyzeSizes(['node_modules/**/*'], serverDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"1396k"`)

--- a/test/fixtures/basic/pages/catchall/[...slug].vue
+++ b/test/fixtures/basic/pages/catchall/[...slug].vue
@@ -8,7 +8,14 @@
 
 <script setup lang="ts">
 definePageMeta({
-  middleware: ['override'],
+  middleware: ['override', (to) => {
+    if (to.path === '/catchall/forbidden') {
+      throw createError({
+        statusCode: 500,
+        message: 'This middleware should not be run',
+      })
+    }
+  }],
   validate: to => to.path !== '/catchall/forbidden',
 })
 const route = useRoute('catchall-slug')


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/29250

### 📚 Description

this updates middleware behaviour to short circuit when `validate` returns false

I'd like to confirm this isn't a breaking change but wasn't able to replicate 'falling through' to other routes if validate returned `false`