### PR TITLE
fix(nuxt): load live data from `vfs` even if a file exists in `buildDir`

### DIFF
--- a/packages/nuxt/src/core/plugins/virtual.ts
+++ b/packages/nuxt/src/core/plugins/virtual.ts
@@ -28,26 +28,30 @@ export const VirtualFSPlugin = (nuxt: Nuxt, options: VirtualFSPluginOptions) => 
 
   return {
     name: 'nuxt:virtual',
-    resolveId (id, importer) {
-      id = resolveAlias(id, alias)
 
-      if (process.platform === 'win32' && isAbsolute(id)) {
-        // Add back C: prefix on Windows
-        id = resolve(id)
-      }
+    resolveId: {
+      order: 'pre',
+      handler (id, importer) {
+        id = resolveAlias(id, alias)
 
-      const resolvedId = resolveWithExt(id)
-      if (resolvedId) {
-        return PREFIX + encodeURIComponent(resolvedId)
-      }
-
-      if (importer && RELATIVE_ID_RE.test(id)) {
-        const path = resolve(dirname(withoutPrefix(decodeURIComponent(importer))), id)
-        const resolved = resolveWithExt(path)
-        if (resolved) {
-          return PREFIX + encodeURIComponent(resolved)
+        if (process.platform === 'win32' && isAbsolute(id)) {
+          // Add back C: prefix on Windows
+          id = resolve(id)
         }
-      }
+
+        const resolvedId = resolveWithExt(id)
+        if (resolvedId) {
+          return PREFIX + encodeURIComponent(resolvedId)
+        }
+
+        if (importer && RELATIVE_ID_RE.test(id)) {
+          const path = resolve(dirname(withoutPrefix(decodeURIComponent(importer))), id)
+          const resolved = resolveWithExt(path)
+          if (resolved) {
+            return PREFIX + encodeURIComponent(resolved)
+          }
+        }
+      },
     },
 
     loadInclude (id) {

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -190,7 +190,7 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
     const clientCSSMap = {}
 
     nuxt.hook('vite:extendConfig', (config, { isServer }) => {
-      config.plugins!.push(ssrStylesPlugin({
+      config.plugins!.unshift(ssrStylesPlugin({
         srcDir: ctx.nuxt.options.srcDir,
         clientCSSMap,
         chunksWithInlinedCSS,


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/30575
resolves https://github.com/nuxt/nuxt/issues/30403
resolves https://github.com/nuxt/nuxt/issues/26648

### 📚 Description

this moves the virtual file `resolveId` hook to run as early as possible, to ensure vite/rollup doesn't resolve the id to a real file on disk (often the case with `write: true`)

