### PR TITLE
perf(nuxt): tree-shake router's `handleHotUpdate` in production

### DIFF
--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -87,7 +87,9 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
       routes,
     })
 
-    handleHotUpdate(router, routerOptions.routes ? routerOptions.routes : routes => routes)
+    if (import.meta.hot) {
+      handleHotUpdate(router, routerOptions.routes ? routerOptions.routes : routes => routes)
+    }
 
     if (import.meta.client && 'scrollRestoration' in window.history) {
       window.history.scrollRestoration = 'auto'


### PR DESCRIPTION
### 🔗 Linked issue

### 📚 Description

This PR ensures that `handleHotUpdate` in the router plugin is excluded from production builds.