### PR TITLE
feat(docs): add events page

### DIFF
--- a/docs/2.guide/3.going-further/1.events.md
+++ b/docs/2.guide/3.going-further/1.events.md
@@ -55,7 +55,7 @@ await nuxtApp.callHook('app:user:registered', {
 ```
 
 ::tip
-You can inspect events using the **Nuxt Devtools** Hooks panel.
+You can inspect events using the **Nuxt DevTools** Hooks panel.
 ::
 
 ## Augmenting Types

--- a/docs/2.guide/3.going-further/1.events.md
+++ b/docs/2.guide/3.going-further/1.events.md
@@ -1,0 +1,75 @@
+---
+title: "Events"
+description: "Nuxt provides a powerful event system powered by hookable."
+
+Using events is a great way to decouple your application and allow for more flexible and modular communication between different parts of your code. Events can have multiple listeners that do not depend on each other. For example, you may wish to send an email to your user each time an order has shipped. Instead of coupling your order processing code to your email code, you can emit an event which a listener can receive and use to dispatch an email.
+
+The Nuxt event system is powered by [unjs/hookable](https://github.com/unjs/hookable), which is the same library that powers the Nuxt hooks system.
+
+## Creating Events and Listeners
+
+You can create your own custom events using the `hook` method:
+
+``ts
+const nuxtApp = useNuxtApp()
+
+nuxtApp.hook('app:user:registered', payload => {
+  console.log('A new user has registered!', payload)
+})
+```
+
+To emit an event and notify any listeners, use `callHook`:
+
+```ts
+const nuxtApp = useNuxtApp()
+
+await nuxtApp.callHook('app:user:registered', {
+  id: 1,
+  name: 'John Doe',
+})
+```
+
+You can also use the payload object to enable two-way communication between the emitter and listeners. Since the payload is passed by reference, a listener can modify it to send data back to the emitter or other listeners.
+
+```ts
+const nuxtApp = useNuxtApp()
+
+nuxtApp.hook('app:user:registered', payload => {
+  payload.message = 'Welcome to our app!'
+})
+
+const payload = {
+  id: 1,
+  name: 'John Doe',
+}
+
+await nuxtApp.callHook('app:user:registered', {
+  id: 1,
+  name: 'John Doe',
+})
+
+// payload.message will be 'Welcome to our app!'
+```
+
+## Augmenting Types
+
+You can augment the types of hooks provided by Nuxt.
+
+```ts
+import { HookResult } from "@nuxt/schema";
+
+declare module '#app' {
+  interface RuntimeNuxtHooks {
+    'your-nuxt-runtime-hook': () => HookResult
+  }
+  interface NuxtHooks {
+    'your-nuxt-hook': () => HookResult
+  }
+}
+
+declare module 'nitro/types' {
+  interface NitroRuntimeHooks {
+    'your-nitro-hook': () => void;
+  }
+}
+```

--- a/docs/2.guide/3.going-further/1.events.md
+++ b/docs/2.guide/3.going-further/1.events.md
@@ -32,7 +32,7 @@ await nuxtApp.callHook('app:user:registered', {
 })
 ```
 
-You can also use the payload object to enable two-way communication between the emitter and listeners. Since the payload is passed by reference, a listener can modify it to send data back to the emitter or other listeners.
+You can also use the payload object to enable two-way communication between the emitter and listeners. Since the payload is passed by reference, a listener can modify it to send data back to the emitter.
 
 ```ts
 const nuxtApp = useNuxtApp()
@@ -55,7 +55,7 @@ await nuxtApp.callHook('app:user:registered', {
 ```
 
 ::tip
-You can inspect events using the **Nuxt DevTools** Hooks panel.
+You can inspect all events using the **Nuxt DevTools** Hooks panel.
 ::
 
 ## Augmenting Types

--- a/docs/2.guide/3.going-further/1.events.md
+++ b/docs/2.guide/3.going-further/1.events.md
@@ -1,6 +1,9 @@
 ---
 title: "Events"
 description: "Nuxt provides a powerful event system powered by hookable."
+---
+
+# Events
 
 Using events is a great way to decouple your application and allow for more flexible and modular communication between different parts of your code. Events can have multiple listeners that do not depend on each other. For example, you may wish to send an email to your user each time an order has shipped. Instead of coupling your order processing code to your email code, you can emit an event which a listener can receive and use to dispatch an email.
 
@@ -10,7 +13,7 @@ The Nuxt event system is powered by [unjs/hookable](https://github.com/unjs/hook
 
 You can create your own custom events using the `hook` method:
 
-``ts
+```ts
 const nuxtApp = useNuxtApp()
 
 nuxtApp.hook('app:user:registered', payload => {

--- a/docs/2.guide/3.going-further/1.events.md
+++ b/docs/2.guide/3.going-further/1.events.md
@@ -54,6 +54,10 @@ await nuxtApp.callHook('app:user:registered', {
 // payload.message will be 'Welcome to our app!'
 ```
 
+::tip
+You can inspect events using the **Nuxt Devtools** Hooks panel.
+::
+
 ## Augmenting Types
 
 You can augment the types of hooks provided by Nuxt.

--- a/docs/2.guide/3.going-further/2.hooks.md
+++ b/docs/2.guide/3.going-further/2.hooks.md
@@ -76,23 +76,4 @@ Learn more about available Nitro lifecycle hooks.
 
 ## Additional Hooks
 
-You can add additional hooks by augmenting the types provided by Nuxt. This can be useful for modules.
-
-```ts
-import { HookResult } from "@nuxt/schema";
-
-declare module '#app' {
-  interface RuntimeNuxtHooks {
-    'your-nuxt-runtime-hook': () => HookResult
-  }
-  interface NuxtHooks {
-    'your-nuxt-hook': () => HookResult
-  }
-}
-
-declare module 'nitro/types' {
-  interface NitroRuntimeHooks {
-    'your-nitro-hook': () => void;
-  }
-}
-```
+Learn more about creating custom hooks in the [Events section](/docs/guide/going-further/hooks).

--- a/docs/2.guide/3.going-further/2.hooks.md
+++ b/docs/2.guide/3.going-further/2.hooks.md
@@ -76,4 +76,4 @@ Learn more about available Nitro lifecycle hooks.
 
 ## Additional Hooks
 
-Learn more about creating custom hooks in the [Events section](/docs/guide/going-further/hooks).
+Learn more about creating custom hooks in the [Events section](/docs/guide/going-further/events).


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #31892

### 📚 Description

I noticed that Nuxt docs did not have a dedicated page for creating custom events. This has caused some confusion in the community as users have used the `useEventBus` from VueUse or other solutions not knowing that Nuxt comes with a powerful event system out of the box.

This PR adds an "Events" page to the docs to document how to create custom events using hookable.

We also discussed in #31892 that it would be useful to have a Devtools module to monitor events. I will open an issue in the Devtools repo regarding this.

**Inspiration from other frameworks:**
Laravel: https://laravel.com/docs/12.x/events
Symfony: https://symfony.com/doc/current/event_dispatcher.html
NestJS: https://docs.nestjs.com/techniques/events