### PR TITLE
feat(nuxt): ignore files & folders prefixed with an underscore

### DIFF
--- a/docs/2.guide/2.directory-structure/1.pages.md
+++ b/docs/2.guide/2.directory-structure/1.pages.md
@@ -15,6 +15,10 @@ Pages are Vue components and can have any [valid extension](/docs/api/configurat
 
 Nuxt will automatically create a route for every page in your `~/pages/` directory.
 
+::important
+Nuxt ignores files and directories prefixed with an underscore (`_`) and will not generate routes for them. This is useful for components, composables, utilities, or other files you want to co-locate within the `pages` directory without them becoming routes.
+::
+
 ::code-group
 
 ```vue [pages/index.vue]
@@ -40,6 +44,18 @@ export default defineComponent({
     return <h1>Index page</h1>
   }
 })
+```
+
+```vue [pages/profile/_components/Card.vue]
+<!-- Nuxt will not generate a route for this comopnent. -->
+<template>
+  <div>Profile Card</div>
+</template>
+```
+
+```ts twoslash [pages/_utils/helper.ts]
+// Nuxt will not generate a route for this utility.
+export const helper = () => { /* ... */ }
 ```
 
 ::

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -102,6 +102,11 @@ export function generateRoutesFromFiles (files: ScannedFile[], options: Generate
       .replace(new RegExp(`${escapeRE(extname(file.relativePath))}$`), '')
       .split('/')
 
+    // Ignore files and directories starting with an underscore
+    if (segments.some(segment => segment.startsWith('_'))) {
+      continue
+    }
+
     const route: NuxtPage = {
       name: '',
       path: '',

--- a/packages/nuxt/test/__snapshots__/pages-override-meta-disabled.test.ts.snap
+++ b/packages/nuxt/test/__snapshots__/pages-override-meta-disabled.test.ts.snap
@@ -471,6 +471,35 @@
       "redirect": "mockMeta?.redirect",
     },
   ],
+  "should ignore routes with segments starting with underscore": [
+    {
+      "alias": "mockMeta?.alias || []",
+      "component": "() => import("pages/index.vue")",
+      "meta": "mockMeta || {}",
+      "name": "mockMeta?.name ?? "index"",
+      "path": "mockMeta?.path ?? "/"",
+      "props": "mockMeta?.props ?? false",
+      "redirect": "mockMeta?.redirect",
+    },
+    {
+      "alias": "mockMeta?.alias || []",
+      "component": "() => import("pages/products.vue")",
+      "meta": "mockMeta || {}",
+      "name": "mockMeta?.name ?? "products"",
+      "path": "mockMeta?.path ?? "/products"",
+      "props": "mockMeta?.props ?? false",
+      "redirect": "mockMeta?.redirect",
+    },
+    {
+      "alias": "mockMeta?.alias || []",
+      "component": "() => import("pages/profile/index.vue")",
+      "meta": "mockMeta || {}",
+      "name": "mockMeta?.name ?? "profile"",
+      "path": "mockMeta?.path ?? "/profile"",
+      "props": "mockMeta?.props ?? false",
+      "redirect": "mockMeta?.redirect",
+    },
+  ],
   "should merge route.meta with meta from file": [
     {
       "alias": "mockMeta?.alias || []",

--- a/packages/nuxt/test/__snapshots__/pages-override-meta-enabled.test.ts.snap
+++ b/packages/nuxt/test/__snapshots__/pages-override-meta-enabled.test.ts.snap
@@ -294,6 +294,23 @@
       "path": ""/"",
     },
   ],
+  "should ignore routes with segments starting with underscore": [
+    {
+      "component": "() => import("pages/index.vue")",
+      "name": ""index"",
+      "path": ""/"",
+    },
+    {
+      "component": "() => import("pages/products.vue")",
+      "name": ""products"",
+      "path": ""/products"",
+    },
+    {
+      "component": "() => import("pages/profile/index.vue")",
+      "name": ""profile"",
+      "path": ""/profile"",
+    },
+  ],
   "should merge route.meta with meta from file": [
     {
       "component": "() => import("pages/page-with-meta.vue")",

--- a/packages/nuxt/test/auto-imports.test.ts
+++ b/packages/nuxt/test/auto-imports.test.ts
@@ -197,7 +197,7 @@ const excludedVueHelpers = [
 
 describe('imports:vue', () => {
   for (const name of Object.keys(VueFunctions)) {
-    if (excludedVueHelpers.includes(name)) {
+    if (excludedVueHelpers.includes(name) || name === 'module.exports') {
       continue
     }
     it(`should register ${name} globally`, () => {

--- a/packages/nuxt/test/pages.test.ts
+++ b/packages/nuxt/test/pages.test.ts
@@ -715,6 +715,42 @@ describe('pages:generateRoutesFromFiles', () => {
         },
       ],
     },
+    {
+      description:
+        'should ignore routes with segments starting with underscore',
+      files: [
+        { path: `${pagesDir}/index.vue` },
+        { path: `${pagesDir}/products.vue` },
+        { path: `${pagesDir}/profile/index.vue` },
+        { path: `${pagesDir}/_utils/helperFn.ts` },
+        { path: `${pagesDir}/users/_[id]/settings.vue` },
+        { path: `${pagesDir}/users/_(admins)/panel.vue` },
+        { path: `${pagesDir}/profile/_components/ProfileCard.vue` },
+      ],
+      output: [
+        {
+          name: 'index',
+          path: '/',
+          file: `${pagesDir}/index.vue`,
+          meta: undefined,
+          children: [],
+        },
+        {
+          name: 'products',
+          path: '/products',
+          file: `${pagesDir}/products.vue`,
+          meta: undefined,
+          children: [],
+        },
+        {
+          name: 'profile',
+          path: '/profile',
+          file: `${pagesDir}/profile/index.vue`,
+          meta: undefined,
+          children: [],
+        },
+      ],
+    },
   ]
 
   const normalizedResults: Record<string, any> = {}

--- a/test/nuxt/polyfills.test.ts
+++ b/test/nuxt/polyfills.test.ts
@@ -1,6 +1,8 @@
+/* @vitest-environment happy-dom */
+
 import { mount } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
-import { defineComponent, h } from 'vue'
+import { defineComponent, h, ref } from 'vue'
 
 describe('app/compat', () => {
   const Component = defineComponent({


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #31979

### 📚 Description

Details and use case are outlined in the linked issue.
