### PR TITLE
fix(nuxt): ensure `useAsyncData` reactive to `key` changes when `immediate: false`

### DIFF
--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -76,6 +76,7 @@ export default defineNuxtConfig({
   //   spaLoadingTemplateLocation: 'within',
   //   parseErrorData: false,
   //   pendingWhenIdle: true,
+  //   alwaysRunFetchOnKeyChange: true,
   //   defaults: {
   //     useAsyncData: {
   //       deep: true
@@ -751,6 +752,46 @@ Alternatively, you can temporarily revert to the previous behavior with:
 export default defineNuxtConfig({
   experimental: {
     pendingWhenIdle: true
+  }
+})
+```
+
+### Key Change Behavior in `useAsyncData` and `useFetch`
+
+🚦 **Impact Level**: Medium
+
+#### What Changed
+
+When using reactive keys in `useAsyncData` or `useFetch`, Nuxt automatically refetches data when the key changes. When `immediate: false` is set, `useAsyncData` will only fetch data when the key changes if the data has already been fetched once.
+
+Previously, `useFetch` had slightly different behavior. It would always fetch data when the key changed.
+
+Now, `useFetch` and `useAsyncData` behave consistently - by only fetch data when the key changes if the data has already been fetched once.
+
+#### Reasons for Change
+
+This ensures consistent behavior between `useAsyncData` and `useFetch`, and prevents unexpected fetches. If you have set `immediate: false`, then you must call `refresh` or `execute` or data will never be fetched in `useFetch` or `useAsyncData`.
+
+#### Migration Steps
+
+This change should generally improve the expected behavior, but if you were expecting changing the key or options of a non-immediate `useFetch`, you now will need to trigger it manually the first time.
+
+```diff
+  const id = ref('123')
+  const { data, execute } = await useFetch('/api/test', {
+    query: { id },
+    immediate: false
+  )
++ watch(id, execute, { once: true })
+```
+
+To opt out of this behavior:
+
+```ts
+// Or globally in your Nuxt config
+export default defineNuxtConfig({
+  experimental: {
+    alwaysRunFetchOnKeyChange: true
   }
 })
 ```

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -362,15 +362,11 @@ export function useAsyncData<
       if (oldKey) {
         unregister(oldKey)
       }
-
-      let nextAsyncData = nuxtApp._asyncData[newKey]
-
-      if (!nextAsyncData?._init) {
-        nuxtApp._asyncData[newKey] = nextAsyncData = createAsyncData(nuxtApp, newKey, _handler, options, options.getCachedData!(newKey, nuxtApp, { cause: 'initial' }))
+      if (!nuxtApp._asyncData[newKey]?._init) {
+        nuxtApp._asyncData[newKey] = createAsyncData(nuxtApp, newKey, _handler, options, options.getCachedData!(newKey, nuxtApp, { cause: 'initial' }))
       }
-
-      nextAsyncData._deps++
-      nextAsyncData.execute({ cause: 'initial', dedupe: options.dedupe })
+      nuxtApp._asyncData[newKey]._deps++
+      nuxtApp._asyncData[newKey].execute({ cause: 'initial', dedupe: options.dedupe })
     }, { flush: 'sync' })
 
     if (hasScope) {

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -274,8 +274,8 @@ export function useAsyncData<
   if (!nuxtApp._asyncData[key.value]?._init) {
     nuxtApp._asyncData[key.value] = createAsyncData(nuxtApp, key.value, _handler, options, initialCachedData)
   }
+  const asyncData = nuxtApp._asyncData[key.value]!
 
-  let asyncData = nuxtApp._asyncData[key.value]!
   asyncData._deps++
 
   const initialFetch = () => nuxtApp._asyncData[key.value]!.execute({ cause: 'initial', dedupe: options.dedupe })
@@ -350,13 +350,8 @@ export function useAsyncData<
 
     // setup watchers/instance
     const hasScope = getCurrentScope()
-    let freeze = false
     if (options.watch) {
       const unsubExecute = watch(options.watch, () => {
-        if (freeze) {
-          freeze = false
-          return
-        }
         asyncData._execute({ cause: 'watch', dedupe: options.dedupe })
       }, { flush: 'post' })
       if (hasScope) {
@@ -364,8 +359,6 @@ export function useAsyncData<
       }
     }
     const unsubKey = watch(key, (newKey, oldKey) => {
-      freeze = true
-
       if (oldKey) {
         unregister(oldKey)
       }
@@ -378,8 +371,6 @@ export function useAsyncData<
 
       nextAsyncData._deps++
       nextAsyncData.execute({ cause: 'initial', dedupe: options.dedupe })
-
-      asyncData = nextAsyncData
     }, { flush: 'sync' })
 
     if (hasScope) {

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -359,6 +359,7 @@ export function useAsyncData<
       }
     }
     const unsubKey = watch(key, (newKey, oldKey) => {
+      const hasRun = nuxtApp._asyncData[oldKey]?.data.value !== asyncDataDefaults.value
       if (oldKey) {
         unregister(oldKey)
       }
@@ -366,7 +367,9 @@ export function useAsyncData<
         nuxtApp._asyncData[newKey] = createAsyncData(nuxtApp, newKey, _handler, options, options.getCachedData!(newKey, nuxtApp, { cause: 'initial' }))
       }
       nuxtApp._asyncData[newKey]._deps++
-      nuxtApp._asyncData[newKey].execute({ cause: 'initial', dedupe: options.dedupe })
+      if (options.immediate || hasRun) {
+        nuxtApp._asyncData[newKey].execute({ cause: 'initial', dedupe: options.dedupe })
+      }
     }, { flush: 'sync' })
 
     if (hasScope) {

--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -110,7 +110,7 @@ export function useFetch<
     default: defaultFn,
     transform,
     pick,
-    watch,
+    watch: watchSources,
     immediate,
     getCachedData,
     deep,
@@ -134,7 +134,7 @@ export function useFetch<
     getCachedData,
     deep,
     dedupe,
-    watch: watch === false ? [] : [...(watch || []), _fetchOptions],
+    watch: watchSources === false ? [] : [...(watchSources || []), _fetchOptions],
   }
 
   if (import.meta.dev) {

--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -1,7 +1,7 @@
 import type { FetchError, FetchOptions } from 'ofetch'
 import type { $Fetch, H3Event$Fetch, NitroFetchRequest, TypedInternalResponse, AvailableRouterMethod as _AvailableRouterMethod } from 'nitro/types'
 import type { MaybeRef, MaybeRefOrGetter, Ref } from 'vue'
-import { computed, reactive, toValue, watch } from 'vue'
+import { computed, reactive, toValue } from 'vue'
 import { hash } from 'ohash'
 
 import { isPlainObject } from '@vue/shared'
@@ -140,13 +140,6 @@ export function useFetch<
   if (import.meta.dev) {
     // @ts-expect-error private property
     _asyncDataOptions._functionName ||= 'useFetch'
-  }
-
-  // ensure that updates to watched sources trigger an update
-  if (watchSources !== false && !immediate) {
-    watch([...(watchSources || []), _fetchOptions], () => {
-      _asyncDataOptions.immediate = true
-    }, { flush: 'sync', once: true })
   }
 
   let controller: AbortController

--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -110,7 +110,7 @@ export function useFetch<
     default: defaultFn,
     transform,
     pick,
-    watch: watchSources,
+    watch,
     immediate,
     getCachedData,
     deep,
@@ -134,7 +134,7 @@ export function useFetch<
     getCachedData,
     deep,
     dedupe,
-    watch: watchSources === false ? [] : [...(watchSources || []), _fetchOptions],
+    watch: watch === false ? [] : [...(watch || []), _fetchOptions],
   }
 
   if (import.meta.dev) {

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -573,6 +573,7 @@ export const nuxtConfigTemplate: NuxtTemplate = {
       `export const purgeCachedData = ${!!ctx.nuxt.options.experimental.purgeCachedData}`,
       `export const granularCachedData = ${!!ctx.nuxt.options.experimental.granularCachedData}`,
       `export const pendingWhenIdle = ${!!ctx.nuxt.options.experimental.pendingWhenIdle}`,
+      `export const alwaysRunFetchOnKeyChange = ${!!ctx.nuxt.options.experimental.alwaysRunFetchOnKeyChange}`,
     ].join('\n\n')
   },
 }

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -608,6 +608,17 @@ export default defineResolvers({
     },
 
     /**
+     * Whether to run `useFetch` when the key changes, even if it is set to `immediate: false` and it has not been triggered yet.
+     *
+     * `useFetch` and `useAsyncData` will always run when the key changes if `immediate: true` or if it has been already triggered.
+     */
+    alwaysRunFetchOnKeyChange: {
+      $resolve: async (val, get) => {
+        return typeof val === 'boolean' ? val : ((await get('future')).compatibilityVersion !== 4)
+      },
+    },
+
+    /**
      * Whether to parse `error.data` when rendering a server error page.
      */
     parseErrorData: {

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1586,6 +1586,15 @@ export interface ConfigSchema {
     granularCachedData: boolean
 
     /**
+     * Whether to run `useFetch` when the key changes, even if it is set to `immediate: false` and it has not been triggered yet.
+     *
+     * `useFetch` and `useAsyncData` will always run when the key changes if `immediate: true` or if it has been already triggered.
+     *
+     * @default false
+     */
+    alwaysRunFetchOnKeyChange: boolean
+
+    /**
      * Whether to parse `error.data` when rendering a server error page.
      *
      * @default true

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -6,7 +6,7 @@ import { destr } from 'destr'
 
 import { mountSuspended, registerEndpoint } from '@nuxt/test-utils/runtime'
 
-import { hasProtocol } from 'ufo'
+import { hasProtocol, withQuery } from 'ufo'
 import { flushPromises } from '@vue/test-utils'
 import { createClientPage } from '../../packages/nuxt/src/components/runtime/client-component'
 import * as composables from '#app/composables'
@@ -700,6 +700,24 @@ describe('useFetch', () => {
     const q = ref('')
     const { data } = await useFetch('/api/immediate-false', {
       query: { q },
+      immediate: false,
+    })
+
+    expect(data.value).toBe(undefined)
+    q.value = 'test'
+
+    await flushPromises()
+    await nextTick()
+    await flushPromises()
+
+    expect(data.value).toEqual({ url: '/api/immediate-false' })
+  })
+
+  it('should work with reactive request path and immediate: false', async () => {
+    registerEndpoint('/api/immediate-false', defineEventHandler(() => ({ url: '/api/immediate-false' })))
+
+    const q = ref('')
+    const { data } = await useFetch(() => withQuery('/api/immediate-false', { q: q.value }), {
       immediate: false,
     })
 

--- a/vitest.nuxt.config.ts
+++ b/vitest.nuxt.config.ts
@@ -21,6 +21,7 @@ export default defineVitestConfig({
           },
           experimental: {
             appManifest: process.env.TEST_MANIFEST !== 'manifest-off',
+            alwaysRunFetchOnKeyChange: true,
           },
           imports: {
             polyfills: false,


### PR DESCRIPTION
### 🔗 Linked issue

Resolves https://github.com/nuxt/nuxt/issues/31976

### 📚 Description

This PR addresses an issue where `useAsyncData` does not react to changes in the `key` parameter when `immediate: false`. As a result, data is not re-fetched upon key changes, leading to potential inconsistencies.

Thank you very much for your time and review! If there’s anything I might have overlooked, please feel free to let me know.
