### PR TITLE
fix(nuxt): preload async layouts

### DIFF
--- a/packages/nuxt/src/app/composables/preload.ts
+++ b/packages/nuxt/src/app/composables/preload.ts
@@ -36,7 +36,7 @@ export const prefetchComponents = (components: string | string[]) => {
 
 // --- Internal ---
 
-function _loadAsyncComponent (component: Component) {
+export function _loadAsyncComponent (component: Component) {
   if ((component as any)?.__asyncLoader && !(component as any).__asyncResolved) {
     return (component as any).__asyncLoader()
   }

--- a/packages/nuxt/src/pages/runtime/plugins/prefetch.client.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/prefetch.client.ts
@@ -6,6 +6,7 @@ import { useRouter } from '#app/composables/router'
 import layouts from '#build/layouts'
 // @ts-expect-error virtual file
 import { namedMiddleware } from '#build/middleware'
+import { _loadAsyncComponent } from '#app/composables/preload'
 
 export default defineNuxtPlugin({
   name: 'nuxt:prefetch',
@@ -36,8 +37,8 @@ export default defineNuxtPlugin({
         }
       }
 
-      if (layout && typeof layouts[layout] === 'function') {
-        layouts[layout]()
+      if (typeof layout === 'string' && layout in layouts) {
+        _loadAsyncComponent(layouts[layout])
       }
     })
   },

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -38,7 +38,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
   it('default client bundle size (pages)', async () => {
     const clientStats = await analyzeSizes(['**/*.js'], join(pagesRootDir, '.output/public'))
 
-    expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"171k"`)
+    expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"172k"`)
 
     const files = clientStats!.files.map(f => f.replace(/\..*\.js/, '.js'))
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/31975

### 📚 Description

regression from https://github.com/nuxt/nuxt/pull/29957, we neglected to update the prefetch mechanism after converting nuxt layouts to async components