### PR TITLE
fix(nuxt): don't use reactive key for `useFetch` with `watch: false`

### DIFF
--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -148,14 +148,12 @@ export function useFetch<
       _asyncDataOptions.immediate = true
     }
     watch(key, setImmediate, { flush: 'sync', once: true })
-    if (watchSources) {
-      watch([...watchSources, _fetchOptions], setImmediate, { flush: 'sync', once: true })
-    }
+    watch([...watchSources || [], _fetchOptions], setImmediate, { flush: 'sync', once: true })
   }
 
   let controller: AbortController
 
-  const asyncData = useAsyncData<_ResT, ErrorT, DataT, PickKeys, DefaultT>(key, () => {
+  const asyncData = useAsyncData<_ResT, ErrorT, DataT, PickKeys, DefaultT>(watchSources === false ? key.value : key, () => {
     controller?.abort?.(new DOMException('Request aborted as another request to the same endpoint was initiated.', 'AbortError'))
     controller = typeof AbortController !== 'undefined' ? new AbortController() : {} as AbortController
 

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -701,7 +701,7 @@ describe('useFetch', () => {
     const q = ref('')
     const { data } = await useFetch('/api/rerun', {
       query: { q },
-      watch: false
+      watch: false,
     })
 
     expect(data.value).toStrictEqual({ count: 0 })

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -694,6 +694,26 @@ describe('useFetch', () => {
     expect(error.value).toBe(undefined)
   })
 
+  it('should not trigger rerunning fetch if `watch: false`', async () => {
+    let count = 0
+    registerEndpoint('/api/rerun', defineEventHandler(() => ({ count: count++ })))
+
+    const q = ref('')
+    const { data } = await useFetch('/api/rerun', {
+      query: { q },
+      watch: false
+    })
+
+    expect(data.value).toStrictEqual({ count: 0 })
+    q.value = 'test'
+
+    await flushPromises()
+    await nextTick()
+    await flushPromises()
+
+    expect(data.value).toStrictEqual({ count: 0 })
+  })
+
   it('should work with reactive keys and immediate: false', async () => {
     registerEndpoint('/api/immediate-false', defineEventHandler(() => ({ url: '/api/immediate-false' })))
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/32016

### 📚 Description

this prevents automatically rerunning fetch function by preventing use of a reactive key for `useFetch` with `watch: false`.

there may be a better solution that uses the new key when `refresh` is called but for now this should be non-breaking (and resolve the issue)