### PR TITLE
docs: fix module initialization command for pnpm

### DIFF
--- a/docs/2.guide/3.going-further/3.modules.md
+++ b/docs/2.guide/3.going-further/3.modules.md
@@ -24,7 +24,7 @@ yarn create nuxt -t module my-module
 ```
 
 ```bash [pnpm]
-pnpm create nuxt -- -t module my-module
+pnpm create nuxt -t module my-module
 ```
 
 ```bash [bun]


### PR DESCRIPTION

### 📚 Description

I copied and paste the command from the docs to create my module. As you can see it created a folder `-t` instead of `my-module`

![image](https://github.com/user-attachments/assets/6013bc29-1d82-4c2b-b046-a18e832b9f62)

Removing `--` seems to work
