### PR TITLE
fix(vite): strip queries when skipping vite transform middleware

### DIFF
--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -233,7 +233,7 @@ export async function buildClient (ctx: ViteBuildContext) {
       route: '',
       handle: (req: IncomingMessage & { _skip_transform?: boolean }, res: ServerResponse, next: (err?: any) => void) => {
         // 'Skip' the transform middleware
-        if (req._skip_transform) { req.url = joinURL('/__skip_vite', req.url!) }
+        if (req._skip_transform) { req.url = joinURL('/__skip_vite', req.url!.replace(/\?.*/, '')) }
         next()
       },
     })


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/31397

### 📚 Description

seemingly a `vue` ending for a request, even if it starts with `/__skip_vite` still results in the vue plugin processing the file.

this strips the query from the url as it is not actually used