### PR TITLE
fix(nuxt): sort hash sources and files

### DIFF
--- a/packages/nuxt/src/core/cache.ts
+++ b/packages/nuxt/src/core/cache.ts
@@ -117,7 +117,7 @@ async function getHashes (nuxt: Nuxt, options: GetHashOptions): Promise<Hashes> 
       name: f.name,
       size: f.attrs?.size,
       data: hash(f.data),
-    }))
+    })).sort((a, b) => a.name.localeCompare(b.name))
 
     const isIgnored = createIsIgnored(nuxt)
     const sourceFiles = await readFilesRecursive(options.cwd(layer), {
@@ -151,6 +151,8 @@ async function getHashes (nuxt: Nuxt, options: GetHashOptions): Promise<Hashes> 
       data: normalizeFiles(rootFiles),
     })
   }
+
+  hashSources.sort((a, b) => a.name.localeCompare(b.name))
 
   const res = ((nuxt as any)[`_${options.id}BuildHash`] = {
     hash: hash(hashSources),


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/32047

### 📚 Description

this sorts hash sources as a potential solution to https://github.com/nuxt/nuxt/issues/32047