### PR TITLE
fix(nuxt): do not suppress chunk import error

### DIFF
--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -377,7 +377,7 @@ export function createNuxtApp (options: CreateOptions) {
     if (chunkErrorEvent) {
       window.addEventListener(chunkErrorEvent, (event) => {
         nuxtApp.callHook('app:chunkError', { error: (event as Event & { payload: Error }).payload })
-        if (nuxtApp.isHydrating || event.payload.message.includes('Unable to preload CSS')) {
+        if (event.payload.message.includes('Unable to preload CSS')) {
           event.preventDefault()
         }
       })


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
This PR does not completely handle  https://github.com/nuxt/nuxt/issues/29624 .
`Error: undefined is not an object (evaluating 'A.default').` occurs because the chunk error is `preventDefault` in `app:chunkError`, allowing execution to continue.
With this PR, the error message will change to `Failed to fetch dynamically imported module:`.

Additionally, the error `Couldn't resolve component "default" at "xxx"` will also change to `Failed to fetch dynamically imported module:`

With `emitRouteChunkError: "automatic-immediate"`, I confirmed that the page reloads even when the error occurs.
https://github.com/wattanx/middleware-chunk-error/

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
