### PR TITLE
fix(nuxt): asyncData default would be same as createAsyncData default value when clearNuxtData

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -703,7 +703,7 @@ function createAsyncData<
       return nuxtApp._asyncDataPromises[key]!
     },
     _execute: debounce((...args) => asyncData.execute(...args), 0, { leading: true }),
-    _default: options.default!,
+    _default: () => hasCachedData ? initialCachedData : options.default!(),
     _deps: 0,
     _init: true,
     _hash: isDev ? createHash(_handler, options) : undefined,


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

https://github.com/nuxt/nuxt/blob/23f57e9ff58815729f84e3f32d0613ce00281548/packages/nuxt/src/app/composables/asyncData.ts#L563

When use `clearNuxtData`, I think it would be same as `createAsyncData().data` with the default `cache` or `default`.

Is it right? Thank you ❤ 

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
