### PR TITLE
feat(nuxt): add integration with chrome devtools workspaces

### DIFF
--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -1,7 +1,7 @@
 import { pathToFileURL } from 'node:url'
 import { existsSync, promises as fsp, readFileSync } from 'node:fs'
 import { cpus } from 'node:os'
-import { readFile, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import { join, relative, resolve } from 'pathe'
 import { createRouter as createRadixRouter, exportMatcher, toRouteMatcher } from 'radix3'
@@ -568,13 +568,15 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
   // TODO: refactor into a module when this is more full-featured
   // add Chrome devtools integration
   if (nuxt.options.experimental.chromeDevtoolsProjectSettings) {
-    let projectConfiguration = await readFile(resolve(nuxt.options.rootDir, 'node_modules/.cache/nuxt/chrome-workspace.json'), 'utf-8')
+    const cacheDir = resolve(nuxt.options.rootDir, 'node_modules/.cache/nuxt')
+    let projectConfiguration = await readFile(join(cacheDir, 'chrome-workspace.json'), 'utf-8')
       .then(r => JSON.parse(r))
       .catch(() => null)
 
     if (!projectConfiguration) {
       projectConfiguration = { uuid: randomUUID() }
-      await writeFile(resolve(nuxt.options.rootDir, 'node_modules/.cache/nuxt/chrome-workspace.json'), JSON.stringify(projectConfiguration), 'utf-8')
+      await mkdir(cacheDir, { recursive: true })
+      await writeFile(join(cacheDir, 'chrome-workspace.json'), JSON.stringify(projectConfiguration), 'utf-8')
     }
 
     nitro.options.devHandlers.push({

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -494,6 +494,13 @@ export default defineResolvers({
     },
 
     /**
+     * Enable integration with Chrome DevTools Workspaces
+     * for Nuxt projects.
+     * @see [Chrome DevTools Project Settings](https://docs.google.com/document/d/1rfKPnxsNuXhnF7AiQZhu9kIwdiMS5hnAI05HBwFuBSM)
+     */
+    chromeDevtoolsProjectSettings: true,
+
+    /**
      * Record mutations to `nuxt.options` in module context, helping to debug configuration changes
      * made by modules during the Nuxt initialization phase.
      *

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1485,6 +1485,15 @@ export interface ConfigSchema {
     browserDevtoolsTiming: boolean
 
     /**
+     * Enable integration with Chrome DevTools Workspaces
+     * for Nuxt projects.
+     *
+     * @default true
+     * @see [Chrome DevTools Project Settings](https://docs.google.com/document/d/1rfKPnxsNuXhnF7AiQZhu9kIwdiMS5hnAI05HBwFuBSM)
+     */
+    chromeDevtoolsProjectSettings: boolean
+
+    /**
      * Record mutations to `nuxt.options` in module context, helping to debug configuration changes made by modules during the Nuxt initialization phase.
      *
      * When enabled, Nuxt will track which modules modify configuration options, making it easier to trace unexpected configuration changes.


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/31978

### 📚 Description

This adds support for the new Chrome DevTools [Project Settings API](https://docs.google.com/document/d/1rfKPnxsNuXhnF7AiQZhu9kIwdiMS5hnAI05HBwFuBSM), which at the moment only supports Automatic Workspace configuration.

I suggest we migrate this to an internal module when more features are supported.

cc: @bmeurer