### PR TITLE
fix(nuxt): clear async data after a tick

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -1,4 +1,4 @@
-import { computed, getCurrentInstance, getCurrentScope, inject, isShallow, onBeforeMount, onScopeDispose, onServerPrefetch, onUnmounted, ref, shallowRef, toRef, toValue, unref, watch } from 'vue'
+import { computed, getCurrentInstance, getCurrentScope, inject, isShallow, nextTick, onBeforeMount, onScopeDispose, onServerPrefetch, onUnmounted, ref, shallowRef, toRef, toValue, unref, watch } from 'vue'
 import type { MaybeRefOrGetter, MultiWatchSources, Ref } from 'vue'
 import { captureStackTrace } from 'errx'
 import { debounce } from 'perfect-debounce'
@@ -712,8 +712,12 @@ function createAsyncData<
       asyncData._init = false
       // TODO: disable in v4 in favour of custom caching strategies
       if (purgeCachedData && !hasCustomGetCachedData) {
-        clearNuxtDataByKey(nuxtApp, key)
-        asyncData.execute = () => Promise.resolve()
+        nextTick(() => {
+          if (!asyncData._init) {
+            clearNuxtDataByKey(nuxtApp, key)
+            asyncData.execute = () => Promise.resolve()
+          }
+        })
       }
     },
   }


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/32093

### 📚 Description

when clearing nuxt data _inside_ a transition this can break the transition totally (likely a vue upstream bug in here that would be worth investigating and reporting)

a workaround is to defer this until the next tick