### PR TITLE
fix(nuxt): respect cachedData with multiple asyncData calls

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -109,6 +109,9 @@ export interface AsyncDataExecuteOptions {
   dedupe?: 'cancel' | 'defer'
 
   cause?: AsyncDataRefreshCause
+
+  /** @internal */
+  cachedData?: any
 }
 
 export interface _AsyncData<DataT, ErrorT> {
@@ -258,15 +261,16 @@ export function useAsyncData<
   }
 
   // Create or use a shared asyncData entity
-  const initialCachedData = options.getCachedData!(key.value, nuxtApp, { cause: 'initial' })
+  const initialFetchOptions: AsyncDataExecuteOptions = { cause: 'initial', dedupe: options.dedupe }
   if (!nuxtApp._asyncData[key.value]?._init) {
-    nuxtApp._asyncData[key.value] = createAsyncData(nuxtApp, key.value, _handler, options, initialCachedData)
+    initialFetchOptions.cachedData = options.getCachedData!(key.value, nuxtApp, { cause: 'initial' })
+    nuxtApp._asyncData[key.value] = createAsyncData(nuxtApp, key.value, _handler, options, initialFetchOptions.cachedData)
   }
   const asyncData = nuxtApp._asyncData[key.value]!
 
   asyncData._deps++
 
-  const initialFetch = () => nuxtApp._asyncData[key.value]!.execute({ cause: 'initial', dedupe: options.dedupe })
+  const initialFetch = () => nuxtApp._asyncData[key.value]!.execute(initialFetchOptions)
 
   const fetchOnServer = options.server !== false && nuxtApp.payload.serverRendered
 
@@ -305,7 +309,7 @@ export function useAsyncData<
 
     const isWithinClientOnly = instance && (instance._nuxtClientOnly || inject(clientOnlySymbol, false))
 
-    if (fetchOnServer && nuxtApp.isHydrating && (asyncData.error.value || typeof initialCachedData !== 'undefined')) {
+    if (fetchOnServer && nuxtApp.isHydrating && (asyncData.error.value || asyncData.data.value !== asyncDataDefaults.value)) {
       // 1. Hydration (server: true): no fetch
       if (pendingWhenIdle) {
         asyncData.pending.value = false
@@ -346,12 +350,14 @@ export function useAsyncData<
       if (oldKey) {
         unregister(oldKey)
       }
+      const initialFetchOptions: AsyncDataExecuteOptions = { cause: 'initial', dedupe: options.dedupe }
       if (!nuxtApp._asyncData[newKey]?._init) {
-        nuxtApp._asyncData[newKey] = createAsyncData(nuxtApp, newKey, _handler, options, options.getCachedData!(newKey, nuxtApp, { cause: 'initial' }))
+        initialFetchOptions.cachedData = options.getCachedData!(newKey, nuxtApp, { cause: 'initial' })
+        nuxtApp._asyncData[newKey] = createAsyncData(nuxtApp, newKey, _handler, options, initialFetchOptions.cachedData)
       }
       nuxtApp._asyncData[newKey]._deps++
       if (options.immediate || hasRun) {
-        nuxtApp._asyncData[newKey].execute({ cause: 'initial', dedupe: options.dedupe })
+        nuxtApp._asyncData[newKey].execute(initialFetchOptions)
       }
     }, { flush: 'sync' })
 
@@ -552,7 +558,7 @@ export function clearNuxtData (keys?: string | string[] | ((key: string) => bool
 
 function clearNuxtDataByKey (nuxtApp: NuxtApp, key: string): void {
   if (key in nuxtApp.payload.data) {
-    nuxtApp.payload.data[key] = undefined
+    nuxtApp.payload.data[key] = asyncDataDefaults.value
   }
 
   if (key in nuxtApp.payload._errors) {
@@ -614,7 +620,7 @@ function createAsyncData<
       }
 
   const _ref = options.deep ? ref : shallowRef
-  const hasCachedData = typeof initialCachedData !== 'undefined'
+  const hasCachedData = initialCachedData !== asyncDataDefaults.value
   const unsubRefreshAsyncData = nuxtApp.hook('app:data:refresh', async (keys) => {
     if (!keys || keys.includes(key)) {
       await asyncData.execute({ cause: 'refresh:hook' })
@@ -635,9 +641,9 @@ function createAsyncData<
       }
       // Avoid fetching same key that is already fetched
       if (granularCachedData || opts.cause === 'initial' || nuxtApp.isHydrating) {
-        const cachedData = opts.cause === 'initial' ? initialCachedData : options.getCachedData!(key, nuxtApp, { cause: opts.cause ?? 'refresh:manual' })
-        if (typeof cachedData !== 'undefined') {
-          nuxtApp.payload.data[key] = asyncData.data.value = cachedData
+        const cachedData = 'cachedData' in opts ? opts.cachedData : options.getCachedData!(key, nuxtApp, { cause: opts.cause ?? 'refresh:manual' })
+        if (cachedData !== asyncDataDefaults.value) {
+          nuxtApp.payload.data[key] = asyncData.data.value = cachedData as DataT
           asyncData.error.value = asyncDataDefaults.errorValue
           asyncData.status.value = 'success'
           return Promise.resolve(cachedData)


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/pull/31373#issuecomment-2867085136

### 📚 Description

this addresses a bug highlighted by @gerrywilko (thank you for the report + excellent test case!) whereby if an asyncData instance was _initialised_ with no cached data, then subsequent asyncData instances with the same key would also 'think' there was no cached data and call the handler on initial request.