### PR TITLE
fix(nuxt): clear previous head in island-renderer

### DIFF
--- a/packages/nuxt/src/app/components/island-renderer.ts
+++ b/packages/nuxt/src/app/components/island-renderer.ts
@@ -18,7 +18,7 @@ export default defineComponent({
   setup (props) {
     // reset head - we don't want to have any head tags from plugin or anywhere else.
     const head = injectHead()
-    head.headEntries().splice(0, head.headEntries().length)
+    head.entries.clear()
 
     const component = islandComponents[props.context.name] as ReturnType<typeof defineAsyncComponent>
 

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1023,7 +1023,7 @@ describe('head tags', () => {
     // should render charset by default
     expect(indexHtml).toContain('<meta charset="utf-8">')
     // should render <Head> components
-    expect(indexHtml).toContain('<title>Basic fixture - Fixture</title>')
+    expect(indexHtml).toContain('<title>Basic fixture</title>')
   })
 
   it('SSR script setup should render tags', async () => {
@@ -2045,6 +2045,7 @@ describe('server components/islands', () => {
     const html = await $fetch<string>('/server-page')
     // test island head
     expect(html).toContain('<meta name="author" content="Nuxt">')
+    expect(html).toContain('plugin-style')
   })
 
   it('/server-page - client side navigation', async () => {
@@ -2274,7 +2275,6 @@ describe('component islands', () => {
         "head": {
           "link": [],
           "style": [],
-          "titleTemplate": "%s - Fixture",
         },
         "html": "<pre data-island-uid>    Route: /foo
         </pre>",
@@ -2297,7 +2297,6 @@ describe('component islands', () => {
         "head": {
           "link": [],
           "style": [],
-          "titleTemplate": "%s - Fixture",
         },
         "html": "<div data-island-uid><div> count is above 2 </div><!--[--><div style="display: contents;" data-island-uid data-island-slot="default"><!--teleport start--><!--teleport end--></div><!--]--> that was very long ... <div id="long-async-component-count">3</div>  <!--[--><div style="display: contents;" data-island-uid data-island-slot="test"><!--teleport start--><!--teleport end--></div><!--]--><p>hello world !!!</p><!--[--><div style="display: contents;" data-island-uid data-island-slot="hello"><!--teleport start--><!--teleport end--></div><!--teleport start--><!--teleport end--><!--]--><!--[--><div style="display: contents;" data-island-uid data-island-slot="fallback"><!--teleport start--><!--teleport end--></div><!--teleport start--><!--teleport end--><!--]--></div>",
         "slots": {
@@ -2361,7 +2360,6 @@ describe('component islands', () => {
         "head": {
           "link": [],
           "style": [],
-          "titleTemplate": "%s - Fixture",
         },
         "html": "<div data-island-uid> This is a .server (20ms) async component that was very long ... <div id="async-server-component-count">2</div><div class="sugar-counter"> Sugar Counter 12 x 1 = 12 <button> Inc </button></div><!--[--><div style="display: contents;" data-island-uid data-island-slot="default"><!--teleport start--><!--teleport end--></div><!--]--></div>",
         "props": {},
@@ -2393,7 +2391,6 @@ describe('component islands', () => {
           "head": {
             "link": [],
             "style": [],
-            "titleTemplate": "%s - Fixture",
           },
           "html": "<div data-island-uid> ServerWithClient.server.vue : <p>count: 0</p> This component should not be preloaded <div><!--[--><div>a</div><div>b</div><div>c</div><!--]--></div> This is not interactive <div class="sugar-counter"> Sugar Counter 12 x 1 = 12 <button> Inc </button></div><div class="interactive-component-wrapper" style="border:solid 1px red;"> The component below is not a slot but declared as interactive <!--[--><div style="display: contents;" data-island-uid data-island-component></div><!--teleport start--><!--teleport end--><!--]--></div></div>",
           "slots": {},
@@ -2442,7 +2439,6 @@ describe('component islands', () => {
               "innerHTML": "pre[data-v-xxxxx]{color:#00f}",
             },
           ],
-          "titleTemplate": "%s - Fixture",
         }
       `)
     } else if (isDev() && !isWebpack) {

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -2459,7 +2459,6 @@ describe('component islands', () => {
             },
           ],
           "style": [],
-          "titleTemplate": "%s - Fixture",
         }
       `)
     }

--- a/test/fixtures/basic/plugins/my-plugin.ts
+++ b/test/fixtures/basic/plugins/my-plugin.ts
@@ -1,6 +1,11 @@
 export default defineNuxtPlugin(() => {
   useHead({
     titleTemplate: '%s - Fixture',
+    style: [{
+      innerHTML: () => 'body { color: red }',
+      tagPriority: -2,
+      id: 'plugin-style',
+    }],
   })
   const path = useRoute()?.path
   return {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This bug has been mentioned multiple times, such as in [this comment](https://github.com/nuxt/nuxt/issues/19772#issuecomment-2776775639). Essentially, the logic for clearing entries in head used a deprecated method that didn't function properly.

As a result, every server component in project that uses @nuxt/ui includes the entire css variables declaration, significantly impacting performance. The difference is striking: current code, the head size is 7778 bytes; after my changes, it's only 394 bytes—nearly a 20x difference, for a very simple markdown component.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
