### PR TITLE
fix(schema): change `pendingWhenIdle` to opt-in

### DIFF
--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -637,7 +637,7 @@ export default defineResolvers({
      */
     pendingWhenIdle: {
       $resolve: async (val, get) => {
-        return typeof val === 'boolean' ? val : (await get('future')).compatibilityVersion !== 4
+        return typeof val === 'boolean' ? val : (await get('future')).compatibilityVersion === 4
       },
     },
   },

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -185,7 +185,7 @@ describe('useAsyncData', () => {
     const nonimmediate = await useAsyncData(() => Promise.resolve('test'), { immediate: false })
     expect(nonimmediate.data.value).toBe(undefined)
     expect(nonimmediate.status.value).toBe('idle')
-    expect(nonimmediate.pending.value).toBe(false)
+    expect(nonimmediate.pending.value).toBe(true)
   })
 
   it('should capture errors', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
`pendingWhenIdle` was introduced in https://github.com/nuxt/nuxt/pull/25864, but because it is currently opt-out, it breaks existing applications.
`pendingWhenIdle` should only be enabled when the Nuxt 4.


<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
