### PR TITLE
fix(vite): do not replace `global` with `globalThis`

### DIFF
--- a/packages/nuxt/src/app/entry.ts
+++ b/packages/nuxt/src/app/entry.ts
@@ -4,6 +4,8 @@ import type { App } from 'vue'
 // This file must be imported first as we set globalThis.$fetch via this import
 // @ts-expect-error virtual file
 import '#build/fetch.mjs'
+// @ts-expect-error virtual file
+import '#build/global-polyfills.mjs'
 
 import { applyPlugins, createNuxtApp } from './nuxt'
 import type { CreateOptions } from './nuxt'

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -520,6 +520,17 @@ export const publicPathTemplate: NuxtTemplate = {
   },
 }
 
+export const globalPolyfillsTemplate: NuxtTemplate = {
+  filename: 'global-polyfills.mjs',
+  getContents () {
+    // Node.js compatibility
+    return `
+if (!("global" in globalThis)) {
+  globalThis.global = globalThis;
+}`
+  },
+}
+
 export const dollarFetchTemplate: NuxtTemplate = {
   filename: 'fetch.mjs',
   getContents () {

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -107,7 +107,6 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
             sourcemap: !!nuxt.options.sourcemap.server,
             baseURL: nuxt.options.app.baseURL,
           }),
-          replace({ preventAssignment: true, ...globalThisReplacements }),
         ],
         server: {
           watch: { ...nuxt.options.watchers.chokidar, ignored: [isIgnored, /[\\/]node_modules[\\/]/] },
@@ -242,8 +241,6 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
   await withLogs(() => buildClient(ctx), 'Vite client built', ctx.nuxt.options.dev)
   await withLogs(() => buildServer(ctx), 'Vite server built', ctx.nuxt.options.dev)
 }
-
-const globalThisReplacements = Object.fromEntries([';', '(', '{', '}', ' ', '\t', '\n'].map(d => [`${d}global.`, `${d}globalThis.`]))
 
 async function withLogs (fn: () => Promise<void>, message: string, enabled = true) {
   if (!enabled) { return fn() }


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/32127

### 📚 Description

previously, we added this workaround (https://github.com/nuxt/framework/pull/4958) to resolve https://github.com/nuxt/nuxt/issues/13941 and help resolve issues with dependencies that used CJS (https://github.com/nuxt/nuxt/issues/12830).

I think we _might_ be able to drop it now. https://github.com/nuxt/nuxt/issues/13941 is no longer reproducible with the current version of Vite.

(Note that Nitro will also [do the same thing](https://github.com/unjs/nitro/blob/eab51cf32b43b31d4b8880eedab94e3e5f767ef4/src/build/config.ts#L57-L62) though, so this might not totally resolve the issue.)