### PR TITLE
fix(nuxt): pass attrs down to single child of `<ClientOnly>`

### DIFF
--- a/packages/nuxt/src/app/components/client-only.ts
+++ b/packages/nuxt/src/app/components/client-only.ts
@@ -31,7 +31,7 @@ export default defineComponent({
       if (mounted.value) {
         const vnodes = slots.default?.()
         if (vnodes && vnodes.length === 1) {
-          return h(vnodes[0]!, attrs)
+          return cloneVNode(vnodes[0]!, attrs)
         }
         return vnodes
       }

--- a/packages/nuxt/src/app/components/client-only.ts
+++ b/packages/nuxt/src/app/components/client-only.ts
@@ -31,7 +31,7 @@ export default defineComponent({
       if (mounted.value) {
         const vnodes = slots.default?.()
         if (vnodes && vnodes.length === 1) {
-          return cloneVNode(vnodes[0]!, attrs)
+          return [cloneVNode(vnodes[0]!, attrs)]
         }
         return vnodes
       }

--- a/packages/nuxt/src/app/components/client-only.ts
+++ b/packages/nuxt/src/app/components/client-only.ts
@@ -12,7 +12,6 @@ const STATIC_DIV = '<div></div>'
 export default defineComponent({
   name: 'ClientOnly',
   inheritAttrs: false,
-
   props: ['fallback', 'placeholder', 'placeholderTag', 'fallbackTag'],
   setup (props, { slots, attrs }) {
     const mounted = ref(false)
@@ -29,7 +28,13 @@ export default defineComponent({
     }
     provide(clientOnlySymbol, true)
     return () => {
-      if (mounted.value) { return slots.default?.() }
+      if (mounted.value) {
+        const vnodes = slots.default?.()
+        if (vnodes && vnodes.length === 1) {
+          return h(vnodes[0]!, attrs)
+        }
+        return vnodes
+      }
       const slot = slots.fallback || slots.placeholder
       if (slot) { return h(slot) }
       const fallbackStr = props.fallback || props.placeholder || ''

--- a/test/nuxt/client-only.test.ts
+++ b/test/nuxt/client-only.test.ts
@@ -6,6 +6,7 @@ import { flushPromises, mount } from '@vue/test-utils'
 
 import { createClientOnly } from '../../packages/nuxt/src/app/components/client-only'
 import { createClientPage } from '../../packages/nuxt/dist/components/runtime/client-component'
+import { ClientOnly } from '#components'
 
 describe('client pages', () => {
   it('should render without a wrapper', async () => {
@@ -49,6 +50,32 @@ describe('client pages', () => {
     await flushPromises()
     expect(wrapper.find('#async').exists()).toBe(true)
     expect(wrapper.find('#fallback').exists()).toBe(false)
+  })
+})
+
+describe('client-only', () => {
+  it('should render its children', async () => {
+    const component = defineComponent({
+      setup () {
+        return () => h(ClientOnly, {}, {
+          default: () => h('div', {}, 'client-only'),
+        })
+      },
+    })
+    const wrapper = await mountSuspended(component)
+    expect(wrapper.html()).toMatchInlineSnapshot(`"<div>client-only</div>"`)
+  })
+
+  it('should support inherited attributes', async () => {
+    const component = defineComponent({
+      setup () {
+        return () => h(ClientOnly, { class: 'test', id: 'test' }, {
+          default: () => h('div', {}, 'client-only'),
+        })
+      },
+    })
+    const wrapper = await mountSuspended(component)
+    expect(wrapper.html()).toMatchInlineSnapshot(`"<div class="test" id="test">client-only</div>"`)
   })
 })
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/32108

### 📚 Description

When `<ClientOnly>` has a single child, it can pass any attrs it receives down to this child.