### PR TITLE
fix(nuxt): ensure legacy async data remains reactive

### DIFF
--- a/packages/nuxt/src/app/composables/component.ts
+++ b/packages/nuxt/src/app/composables/component.ts
@@ -1,4 +1,4 @@
-import { getCurrentInstance, reactive, toRefs } from 'vue'
+import { computed, getCurrentInstance } from 'vue'
 import type { DefineComponent, defineComponent } from 'vue'
 import { hash } from 'ohash'
 import type { NuxtApp } from '../nuxt'
@@ -32,7 +32,16 @@ async function runLegacyAsyncData (res: Record<string, any> | Promise<Record<str
     throw createError(error.value)
   }
   if (data.value && typeof data.value === 'object') {
-    Object.assign(await res, toRefs(reactive(data.value)))
+    const _res = await res
+    for (const key in data.value) {
+      _res[key] = computed({
+        get: () => data.value?.[key],
+        set (v) {
+          data.value ||= {}
+          data.value[key] = v
+        },
+      })
+    }
   } else if (import.meta.dev) {
     console.warn('[nuxt] asyncData should return an object', data)
   }

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -1240,6 +1240,31 @@ describe('defineNuxtComponent', () => {
     nuxtApp.isHydrating = false
     nuxtApp.payload.serverRendered = false
   })
+
+  it('should support Options API refreshNuxtData', async () => {
+    let count = 0
+    const component = defineNuxtComponent({
+      asyncData: () => ({
+        number: count++,
+      }),
+      setup () {
+        const vm = getCurrentInstance()
+        return () => {
+          // @ts-expect-error go directly to jail 😈
+          return h('div', vm!.render.number.value)
+        }
+      },
+    })
+
+    const wrapper = await mountSuspended(component)
+    expect(wrapper.html()).toMatchInlineSnapshot(`"<div>0</div>"`)
+
+    await refreshNuxtData()
+    await nextTick()
+
+    expect(wrapper.html()).toMatchInlineSnapshot(`"<div>1</div>"`)
+  })
+
   it.todo('should support Options API head')
 })
 

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -1260,7 +1260,6 @@ describe('defineNuxtComponent', () => {
     expect(wrapper.html()).toMatchInlineSnapshot(`"<div>0</div>"`)
 
     await refreshNuxtData()
-    await nextTick()
 
     expect(wrapper.html()).toMatchInlineSnapshot(`"<div>1</div>"`)
   })


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/29368
closes https://github.com/nuxt/nuxt/pull/29518

### 📚 Description

this ensures we don't 'freeze' the value in legacy asyncData but keep it reactive