### PR TITLE
fix(nuxt): suppress client-side errors by crawlers

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-root.vue
+++ b/packages/nuxt/src/app/components/nuxt-root.vue
@@ -56,8 +56,12 @@ if (import.meta.dev && results && results.some(i => i && 'then' in i)) {
 const error = useError()
 // render an empty <div> when plugins have thrown an error but we're not yet rendering the error page
 const abortRender = import.meta.server && error.value && !nuxtApp.ssrContext.error
+const BOT_RE = /bot\b|index|spider|facebookexternalhit|crawl|wget|slurp|mediapartners-google|whatsapp/i
 onErrorCaptured((err, target, info) => {
   nuxtApp.hooks.callHook('vue:error', err, target, info).catch(hookError => console.error('[nuxt] Error in `vue:error` hook', hookError))
+  if (import.meta.client && BOT_RE.test(navigator.userAgent)) {
+    return false
+  }
   if (import.meta.server || (isNuxtError(err) && (err.fatal || err.unhandled))) {
     const p = nuxtApp.runWithContext(() => showError(err))
     onServerPrefetch(() => p)

--- a/packages/nuxt/src/app/components/nuxt-root.vue
+++ b/packages/nuxt/src/app/components/nuxt-root.vue
@@ -56,7 +56,7 @@ if (import.meta.dev && results && results.some(i => i && 'then' in i)) {
 const error = useError()
 // render an empty <div> when plugins have thrown an error but we're not yet rendering the error page
 const abortRender = import.meta.server && error.value && !nuxtApp.ssrContext.error
-const BOT_RE = /bot\b|index|spider|facebookexternalhit|crawl|wget|slurp|mediapartners-google|whatsapp/i
+const BOT_RE = /bot\b|chrome-lighthouse|facebookexternalhit|google\b|googlebot/i
 onErrorCaptured((err, target, info) => {
   nuxtApp.hooks.callHook('vue:error', err, target, info).catch(hookError => console.error('[nuxt] Error in `vue:error` hook', hookError))
   if (import.meta.client && BOT_RE.test(navigator.userAgent)) {


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/29624

### 📚 Description

the linked issue is _extremely_ pesky

the issue is reproducible across more than just nuxt websites, and seems to be related to a bug in Google's search index which leads to either:
1. storing HTML and then trying to visit it with JS later on, when some of the JS chunks may no longer be available after a deploy
2. exhausting a JS 'budget'

either of these cases can result in a full 500 error page being rendered on the client.

This PR is a relatively safe hotfix for this issue - it will simply suppress the full-page error when triggered by crawlers/bots.