### PR TITLE
perf(nuxt): use hash for process template comparison

### DIFF
--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -3,7 +3,7 @@ import { dirname, join, relative, resolve } from 'pathe'
 import { defu } from 'defu'
 import { findPath, normalizePlugin, normalizeTemplate, resolveFiles, resolvePath } from '@nuxt/kit'
 import type { Nuxt, NuxtApp, NuxtPlugin, NuxtTemplate, ResolvedNuxtTemplate } from 'nuxt/schema'
-
+import { hash } from 'ohash'
 import type { PluginMeta } from 'nuxt/app'
 
 import { logger } from '../utils'
@@ -63,14 +63,17 @@ export async function generateApp (nuxt: Nuxt, app: NuxtApp, options: { filter?:
   async function processTemplate (template: ResolvedNuxtTemplate) {
     const fullPath = template.dst || resolve(nuxt.options.buildDir, template.filename!)
     const start = performance.now()
-    const oldContents = nuxt.vfs[fullPath]
     const contents = await compileTemplate(template, templateContext).catch((e) => {
       logger.error(`Could not compile template \`${template.filename}\`.`)
       logger.error(e)
       throw e
     })
 
-    template.modified = oldContents !== contents
+    const oldHash = template.hash as string | undefined
+    const newHash = hash(contents)
+    template.modified = oldHash !== newHash
+    template.hash = newHash
+
     if (template.modified) {
       nuxt.vfs[fullPath] = contents
 

--- a/packages/schema/src/types/nuxt.ts
+++ b/packages/schema/src/types/nuxt.ts
@@ -60,6 +60,7 @@ export interface ResolvedNuxtTemplate<Options = TemplateDefaultOptions> extends 
   filename: string
   dst: string
   modified?: boolean
+  hash?: string
 }
 
 export interface NuxtTypeTemplate<Options = TemplateDefaultOptions> extends Omit<NuxtTemplate<Options>, 'write' | 'filename'> {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
