### PR TITLE
docs: use node v20 for minimum requirement for nuxt setup

### DIFF
--- a/docs/1.getting-started/02.installation.md
+++ b/docs/1.getting-started/02.installation.md
@@ -21,7 +21,7 @@ Or follow the steps below to set up a new Nuxt project on your computer.
 <!-- markdownlint-disable-next-line MD001 -->
 #### Prerequisites
 
-- **Node.js** - [`18.x`](https://nodejs.org/en) or newer (but we recommend the [active LTS release](https://github.com/nodejs/release#release-schedule))
+- **Node.js** - [`20.x`](https://nodejs.org/en) or newer (but we recommend the [active LTS release](https://github.com/nodejs/release#release-schedule))
 - **Text editor** - There is no IDE requirement, but we recommend [Visual Studio Code](https://code.visualstudio.com/) with the [official Vue extension](https://marketplace.visualstudio.com/items?itemName=Vue.volar) (previously known as Volar) or [WebStorm](https://www.jetbrains.com/webstorm/), which, along with [other JetBrains IDEs](https://www.jetbrains.com/ides/), offers great Nuxt support right out-of-the-box.
 - **Terminal** - In order to run Nuxt commands
 


### PR DESCRIPTION
Actually I have seen vite has moved to minimum 20+ requirement, Nitro is also I guess. That is why I thought we can go it for Nuxt also because Nuxt is built with Vite + Nitro. 