### PR TITLE
perf(nuxt): rewrite all `ref` with primitive values to be `shallowRef`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,5 @@ test-results/
 playwright-report
 
 temp
+
+packages/ui-templates/node-compile-cache/

--- a/packages/nuxt/src/app/components/client-fallback.client.ts
+++ b/packages/nuxt/src/app/components/client-fallback.client.ts
@@ -1,4 +1,4 @@
-import { createElementBlock, defineComponent, onMounted, ref, useId } from 'vue'
+import { createElementBlock, defineComponent, onMounted, shallowRef, useId } from 'vue'
 import { useState } from '../composables/state'
 
 export default defineComponent({
@@ -26,7 +26,7 @@ export default defineComponent({
   },
   emits: ['ssr-error'],
   setup (props, ctx) {
-    const mounted = ref(false)
+    const mounted = shallowRef(false)
     const ssrFailed = useState(useId())
 
     if (ssrFailed.value) {

--- a/packages/nuxt/src/app/components/client-fallback.server.ts
+++ b/packages/nuxt/src/app/components/client-fallback.server.ts
@@ -1,4 +1,4 @@
-import { defineComponent, getCurrentInstance, onErrorCaptured, ref, useId } from 'vue'
+import { defineComponent, getCurrentInstance, onErrorCaptured, shallowRef, useId } from 'vue'
 import { ssrRenderAttrs, ssrRenderSlot, ssrRenderVNode } from 'vue/server-renderer'
 
 import { isPromise } from '@vue/shared'
@@ -35,7 +35,7 @@ const NuxtClientFallbackServer = defineComponent({
   },
   async setup (_, ctx) {
     const vm = getCurrentInstance()
-    const ssrFailed = ref(false)
+    const ssrFailed = shallowRef(false)
     const error = useState<boolean | undefined>(useId())
 
     onErrorCaptured((err) => {

--- a/packages/nuxt/src/app/components/client-only.ts
+++ b/packages/nuxt/src/app/components/client-only.ts
@@ -1,4 +1,4 @@
-import { cloneVNode, createElementBlock, defineComponent, getCurrentInstance, h, onMounted, provide, ref } from 'vue'
+import { cloneVNode, createElementBlock, defineComponent, getCurrentInstance, h, onMounted, provide, shallowRef } from 'vue'
 import type { ComponentInternalInstance, ComponentOptions, InjectionKey } from 'vue'
 import { isPromise } from '@vue/shared'
 import { useNuxtApp } from '../nuxt'
@@ -14,7 +14,7 @@ export default defineComponent({
   inheritAttrs: false,
   props: ['fallback', 'placeholder', 'placeholderTag', 'fallbackTag'],
   setup (props, { slots, attrs }) {
-    const mounted = ref(false)
+    const mounted = shallowRef(false)
     onMounted(() => { mounted.value = true })
     // Bail out of checking for pages/layouts as they might be included under `<ClientOnly>` 🤷‍♂️
     if (import.meta.dev) {
@@ -78,7 +78,7 @@ export function createClientOnly<T extends ComponentOptions> (component: T) {
 
   clone.setup = (props, ctx) => {
     const nuxtApp = useNuxtApp()
-    const mounted$ = ref(nuxtApp.isHydrating === false)
+    const mounted$ = shallowRef(nuxtApp.isHydrating === false)
     const instance = getCurrentInstance()!
 
     if (nuxtApp.isHydrating) {

--- a/packages/nuxt/src/app/components/nuxt-island.ts
+++ b/packages/nuxt/src/app/components/nuxt-island.ts
@@ -1,5 +1,5 @@
 import type { Component, PropType, RendererNode, VNode } from 'vue'
-import { Fragment, Teleport, computed, createStaticVNode, createVNode, defineComponent, getCurrentInstance, h, nextTick, onBeforeUnmount, onMounted, ref, toRaw, watch, withMemo } from 'vue'
+import { Fragment, Teleport, computed, createStaticVNode, createVNode, defineComponent, getCurrentInstance, h, nextTick, onBeforeUnmount, onMounted, ref, shallowRef, toRaw, watch, withMemo } from 'vue'
 import { debounce } from 'perfect-debounce'
 import { hash } from 'ohash'
 import { appendResponseHeader } from 'h3'
@@ -80,8 +80,8 @@ export default defineComponent({
   emits: ['error'],
   async setup (props, { slots, expose, emit }) {
     let canTeleport = import.meta.server
-    const teleportKey = ref(0)
-    const key = ref(0)
+    const teleportKey = shallowRef(0)
+    const key = shallowRef(0)
     const canLoadClientComponent = computed(() => selectiveClient && (props.dangerouslyLoadClientComponents || !props.source))
     const error = ref<unknown>(null)
     const config = useRuntimeConfig()
@@ -95,7 +95,7 @@ export default defineComponent({
 
     // TODO: remove use of `$fetch.raw` when nitro 503 issues on windows dev server are resolved
     const eventFetch = import.meta.server ? event!.fetch : import.meta.dev ? $fetch.raw : globalThis.fetch
-    const mounted = ref(false)
+    const mounted = shallowRef(false)
     onMounted(() => { mounted.value = true; teleportKey.value++ })
     onBeforeUnmount(() => { if (activeHead) { activeHead.dispose() } })
     function setPayload (key: string, result: NuxtIslandResponse) {

--- a/packages/nuxt/src/app/components/nuxt-layout.ts
+++ b/packages/nuxt/src/app/components/nuxt-layout.ts
@@ -1,5 +1,5 @@
 import type { DefineComponent, ExtractPublicPropTypes, MaybeRef, PropType, VNode } from 'vue'
-import { Suspense, computed, defineComponent, h, inject, mergeProps, nextTick, onMounted, provide, ref, shallowReactive, unref } from 'vue'
+import { Suspense, computed, defineComponent, h, inject, mergeProps, nextTick, onMounted, provide, ref, shallowReactive, shallowRef, unref, useTemplateRef } from 'vue'
 import type { RouteLocationNormalizedLoaded } from 'vue-router'
 
 import type { PageMeta } from '../../pages/runtime/composables'
@@ -68,7 +68,7 @@ export default defineComponent({
       return layout
     })
 
-    const layoutRef = ref()
+    const layoutRef = shallowRef()
     context.expose({ layoutRef })
 
     const done = nuxtApp.deferHydration()

--- a/packages/nuxt/src/app/components/nuxt-layout.ts
+++ b/packages/nuxt/src/app/components/nuxt-layout.ts
@@ -1,5 +1,5 @@
 import type { DefineComponent, ExtractPublicPropTypes, MaybeRef, PropType, VNode } from 'vue'
-import { Suspense, computed, defineComponent, h, inject, mergeProps, nextTick, onMounted, provide, ref, shallowReactive, shallowRef, unref, useTemplateRef } from 'vue'
+import { Suspense, computed, defineComponent, h, inject, mergeProps, nextTick, onMounted, provide, shallowReactive, shallowRef, unref } from 'vue'
 import type { RouteLocationNormalizedLoaded } from 'vue-router'
 
 import type { PageMeta } from '../../pages/runtime/composables'

--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -10,7 +10,7 @@ import type {
   VNode,
   VNodeProps,
 } from 'vue'
-import { computed, defineComponent, h, inject, onBeforeUnmount, onMounted, provide, ref, resolveComponent } from 'vue'
+import { computed, defineComponent, h, inject, onBeforeUnmount, onMounted, provide, ref, resolveComponent, shallowRef } from 'vue'
 import type { RouteLocation, RouteLocationRaw, Router, RouterLink, RouterLinkProps, UseLinkReturn, useLink } from 'vue-router'
 import { hasProtocol, joinURL, parseQuery, withTrailingSlash, withoutTrailingSlash } from 'ufo'
 import { preloadRouteComponents } from '../composables/preload'
@@ -356,7 +356,7 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
       const { to, href, navigate, isExternal, hasTarget, isAbsoluteUrl } = useNuxtLink(props)
 
       // Prefetching
-      const prefetched = ref(false)
+      const prefetched = shallowRef(false)
       const el = import.meta.server ? undefined : ref<HTMLElement | null>(null)
       const elRef = import.meta.server ? undefined : (ref: any) => { el!.value = props.custom ? ref?.$el?.nextElementSibling : ref?.$el }
 

--- a/packages/nuxt/src/components/runtime/client-component.ts
+++ b/packages/nuxt/src/components/runtime/client-component.ts
@@ -1,4 +1,4 @@
-import { getCurrentInstance, h, onMounted, provide, ref, shallowRef } from 'vue'
+import { getCurrentInstance, h, onMounted, provide, shallowRef } from 'vue'
 import type { AsyncComponentLoader, ComponentOptions } from 'vue'
 import { isPromise } from '@vue/shared'
 import { useNuxtApp } from '#app/nuxt'

--- a/packages/nuxt/src/components/runtime/client-component.ts
+++ b/packages/nuxt/src/components/runtime/client-component.ts
@@ -1,4 +1,4 @@
-import { getCurrentInstance, h, onMounted, provide, ref } from 'vue'
+import { getCurrentInstance, h, onMounted, provide, ref, shallowRef } from 'vue'
 import type { AsyncComponentLoader, ComponentOptions } from 'vue'
 import { isPromise } from '@vue/shared'
 import { useNuxtApp } from '#app/nuxt'
@@ -45,7 +45,7 @@ function pageToClientOnly<T extends ComponentOptions> (component: T) {
 
   clone.setup = (props, ctx) => {
     const nuxtApp = useNuxtApp()
-    const mounted$ = ref(nuxtApp.isHydrating === false)
+    const mounted$ = shallowRef(nuxtApp.isHydrating === false)
     provide(clientOnlySymbol, true)
     const vm = getCurrentInstance()
     if (vm) {

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -2602,6 +2602,8 @@ describe.skipIf(isDev() || isWindows || !isRenderingJson)('payload rendering', (
     // expect(requests.filter(p => p.includes('_payload')).length).toBe(isDev() ? 1 : 0)
 
     await page.close()
+  }, {
+    retry: 3, // looks like this test is flaky
   })
 
   it.skipIf(!isRenderingJson)('should not include server-component HTML in payload', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

This PR refactors every ref with a primitive value so that it becomes an explicit shallowRef. This should not cause any issues and should provide a slight performance boost.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
