### PR TITLE
perf(nuxt): use Intl.Collator instead of localeCompare

### DIFF
--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -42,6 +42,7 @@ interface ScannedFile {
   absolutePath: string
 }
 
+const enUSComparator = new Intl.Collator('en-US')
 export async function resolvePagesRoutes (pattern: string | string[], nuxt = useNuxt()): Promise<NuxtPage[]> {
   const pagesDirs = nuxt.options._layers.map(
     layer => resolve(layer.config.srcDir, (layer.config.rootDir === nuxt.options.rootDir ? nuxt.options.dir : layer.config.dir)?.pages || 'pages'),
@@ -54,8 +55,8 @@ export async function resolvePagesRoutes (pattern: string | string[], nuxt = use
   }
 
   // sort scanned files using en-US locale to make the result consistent across different system locales
-  const enUSComparator = new Intl.Collator('en-US').compare
-  scannedFiles.sort((a, b) => enUSComparator(a.relativePath, b.relativePath))
+
+  scannedFiles.sort((a, b) => enUSComparator.compare(a.relativePath, b.relativePath))
 
   const allRoutes = generateRoutesFromFiles(uniqueBy(scannedFiles, 'relativePath'), {
     shouldUseServerComponents: !!nuxt.options.experimental.componentIslands,

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -136,10 +136,7 @@ export function generateRoutesFromFiles (files: ScannedFile[], options: Generate
         continue
       }
 
-      const segmentName = tokens
-        .filter(token => token.type !== SegmentTokenType.group)
-        .map(token => token.value)
-        .join('')
+      const segmentName = tokens.map(({ value, type }) => type === SegmentTokenType.group ? '' : value).join('')
 
       // ex: parent/[slug].vue -> parent-slug
       route.name += (route.name && '/') + segmentName

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -95,6 +95,7 @@ type GenerateRoutesFromFilesOptions = {
 
 const INDEX_PAGE_RE = /\/index$/
 export function generateRoutesFromFiles (files: ScannedFile[], options: GenerateRoutesFromFilesOptions = {}): NuxtPage[] {
+  if (!files.length) { return [] }
   const routes: NuxtPage[] = []
 
   const sortedFiles = [...files].sort((a, b) => a.relativePath.length - b.relativePath.length)
@@ -135,7 +136,10 @@ export function generateRoutesFromFiles (files: ScannedFile[], options: Generate
         continue
       }
 
-      const segmentName = tokens.map(({ value, type }) => type === SegmentTokenType.group ? '' : value).join('')
+      const segmentName = tokens
+        .filter(token => token.type !== SegmentTokenType.group)
+        .map(token => token.value)
+        .join('')
 
       // ex: parent/[slug].vue -> parent-slug
       route.name += (route.name && '/') + segmentName

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -54,7 +54,8 @@ export async function resolvePagesRoutes (pattern: string | string[], nuxt = use
   }
 
   // sort scanned files using en-US locale to make the result consistent across different system locales
-  scannedFiles.sort((a, b) => a.relativePath.localeCompare(b.relativePath, 'en-US'))
+  const enUSComparator = new Intl.Collator('en-US').compare
+  scannedFiles.sort((a, b) => enUSComparator(a.relativePath, b.relativePath))
 
   const allRoutes = generateRoutesFromFiles(uniqueBy(scannedFiles, 'relativePath'), {
     shouldUseServerComponents: !!nuxt.options.experimental.componentIslands,


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
