### PR TITLE
docs: update addRouteMiddleware path

### DIFF
--- a/docs/3.api/5.kit/7.pages.md
+++ b/docs/3.api/5.kit/7.pages.md
@@ -149,7 +149,7 @@ export default defineNuxtModule({
 
     addRouteMiddleware({
       name: 'auth',
-      path: resolve('runtime/auth.ts'),
+      path: resolve('runtime/auth'),
       global: true,
     }, { prepend: true })
   },


### PR DESCRIPTION
If there's a file extension for a middleware in your module you get this error in the downstream project:

```bash
Pre-transform error: Failed to resolve import "C:/Users/__MODULE__/core/dist/runtime/middleware/setup.ts" from "virtual:nuxt:C%3A%2FUsers%2F__MODULE__%2F.nuxt%2Fmiddleware.mjs". Does the file exist?   1:09:07 PM  
  Plugin: vite:import-analysis
  File: virtual:nuxt:C%3A%2FUsers%2F__MODULE__%2F.nuxt%2Fmiddleware.mjs:2:20
```

Removing the extension fixes the error.

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
