### PR TITLE
docs: narrow link to just middleware

### DIFF
--- a/docs/1.getting-started/07.routing.md
+++ b/docs/1.getting-started/07.routing.md
@@ -94,7 +94,7 @@ There are three kinds of route middleware:
 
 1. Anonymous (or inline) route middleware, which are defined directly in the pages where they are used.
 2. Named route middleware, which are placed in the [`middleware/`](/docs/guide/directory-structure/middleware) directory and will be automatically loaded via asynchronous import when used on a page. (**Note**: The route middleware name is normalized to kebab-case, so `someMiddleware` becomes `some-middleware`.)
-3. Global route middleware, which are placed in the [`middleware/` directory](/docs/guide/directory-structure/middleware) (with a `.global` suffix) and will be automatically run on every route change.
+3. Global route middleware, which are placed in the [`middleware/`](/docs/guide/directory-structure/middleware) directory (with a `.global` suffix) and will be automatically run on every route change.
 
 Example of an `auth` middleware protecting the `/dashboard` page:
 


### PR DESCRIPTION
### 📚 Description
It can be seen that when the mouse moves into the green box area, only _`middleware`_ is selected, but when the mouse moves into the red box area, the _`directory`_ after the _`middleware/`_ will also be selected

<details><summary>Details</summary>
<p>

The link now exclusively targets _`middleware/`_, aligning selection behaviour with the named middleware example above and preventing the unwanted inclusion of _`directory`_ in the hover/selection region.

</p>
</details> 

![image](https://github.com/user-attachments/assets/3801b81f-ea9a-4a64-872b-89cec1593ef5)

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
