### PR TITLE
fix(nuxt): ensure appConfig sources are not duplicated

### DIFF
--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -229,7 +229,6 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
     }
   }
 
-
   // Extend app
   await nuxt.callHook('app:resolve', app)
 

--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -224,17 +224,20 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
   app.configs = []
   for (const config of layerConfigs) {
     const appConfigPath = await findPath(resolve(config.srcDir, 'app.config'))
-    if (appConfigPath && !app.configs.includes(appConfigPath)) {
+    if (appConfigPath) {
       app.configs.push(appConfigPath)
     }
   }
 
+  app.configs = [...new Set(app.configs)]
+
   // Extend app
   await nuxt.callHook('app:resolve', app)
 
-  // Normalize and de-duplicate plugins and middleware
+  // Normalize and de-duplicate plugins, middleware and app configs
   app.middleware = uniqueBy(await resolvePaths(nuxt, app.middleware, 'path'), 'name')
   app.plugins = uniqueBy(await resolvePaths(nuxt, app.plugins, 'src'), 'src')
+  app.configs = [...new Set(app.configs)]
 }
 
 function resolvePaths<Item extends Record<string, any>> (nuxt: Nuxt, items: Item[], key: { [K in keyof Item]: Item[K] extends string ? K : never }[keyof Item]) {

--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -229,7 +229,6 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
     }
   }
 
-  app.configs = [...new Set(app.configs)]
 
   // Extend app
   await nuxt.callHook('app:resolve', app)

--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -224,7 +224,7 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
   app.configs = []
   for (const config of layerConfigs) {
     const appConfigPath = await findPath(resolve(config.srcDir, 'app.config'))
-    if (appConfigPath) {
+    if (appConfigPath && !app.configs.includes(appConfigPath)) {
       app.configs.push(appConfigPath)
     }
   }


### PR DESCRIPTION
### 🔗 Linked issue

nuxt-themes/docus#1077

### 📚 Description

#### This issue is related to how Nuxt Content handles HMR:

Updating Markdown content in local development with HMR triggers duplication of bottom links in the table of content of Docus v2 (currently [WIP](https://github.com/nuxt-themes/docus/tree/feat/docus-v2)). Those links are represented by an array in the [app.config.ts](https://github.com/nuxt-themes/docus/blob/feat/docus-v2/docs/app.config.ts#L59-L69) file.

Nuxt Content is calling [updateTemplates](https://github.com/nuxt/content/blob/main/src/utils/dev.ts#L63-L69) to update dump and manifest templates and ensure database integrity. 

This call triggers the `builder:generateApp` which itself call the `resolveApp` method. Since `resolveApp` is also called by Nuxt HMR it results in multiple call happening at the same time and updating the same `app` instance. 

In this case same config files are push to `app.configs` and are duplicated.

I'm simply ensuring that config file are push only if they do not already exist. 

Here is a video to explain the issue:

https://github.com/user-attachments/assets/a0c053dc-99de-4912-a813-42300f4494e1

PS1: I'll be happy to provide a reproduction in test but I need help to create the test.

PS: It might also exists an issue with the way [defufn is handling array merge here](https://github.com/nuxt/nuxt/blob/main/packages/nuxt/src/core/templates.ts#L488) but I'm not sure how to provide a fix.
 
<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
