### PR TITLE
fix(nuxt): use correct cwd for layers in `buildCache` handling

### DIFF
--- a/packages/nuxt/src/core/cache.ts
+++ b/packages/nuxt/src/core/cache.ts
@@ -16,7 +16,7 @@ export async function getVueHash (nuxt: Nuxt) {
 
   const { hash } = await getHashes(nuxt, {
     id,
-    cwd: layer => layer.config?.srcDir,
+    cwd: layer => layer.cwd,
     patterns: layer => [
       join(relative(layer.cwd, layer.config.srcDir), '**'),
       `!${relative(layer.cwd, layer.config.serverDir || join(layer.cwd, 'server'))}/**`,


### PR DESCRIPTION
The `buildCache` option currently doesn't work when working with the nuxt v4 folder structure.
Some debugging has shown that it is because the wrong `cwd` is used in the call of `getHashes()`:

All paths in `patterns` are specified relative to `layer.cwd`, but `layer.config?.srcDir` is used as the `cwd` itself, not `layer.cwd`:

```
  const { hash } = await getHashes(nuxt, {
    id,
    cwd: layer => layer.config?.srcDir,
    patterns: layer => [
      join(relative(layer.cwd, layer.config.srcDir), '**'),
      `!${relative(layer.cwd, layer.config.serverDir || join(layer.cwd, 'server'))}/**`,
      `!${relative(layer.cwd, resolve(layer.config.srcDir || layer.cwd, layer.config.dir?.public || 'public'))}/**`,
      `!${relative(layer.cwd, resolve(layer.config.srcDir || layer.cwd, layer.config.dir?.static || 'public'))}/**`,
      '!node_modules/**',
      '!nuxt.config.*',
    ],
```