### PR TITLE
fix(nuxt): remove query and params from `useAsyncData` watch list for `useFetch`

### DIFF
--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -128,7 +128,7 @@ export function useFetch<
     getCachedData,
     deep,
     dedupe,
-    watch: watchSources === false ? [] : [...(watchSources || []), _fetchOptions],
+    watch: watchSources === false ? [] : [...(watchSources || []), reactive({ ..._fetchOptions, query: undefined, params: undefined })],
   }
 
   if (import.meta.dev) {

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -786,11 +786,13 @@ describe('useFetch', () => {
     registerEndpoint('/api/rerun', defineEventHandler(() => ({ count: count++ })))
 
     const q = ref('')
-    const mockedFetch = vi.fn(url => $fetch(url)) as unknown as $Fetch
+    const mockedFetch = vi.fn(url => $fetch(url))
     const { data } = await useFetch('/api/rerun', {
       query: { q },
-      $fetch: mockedFetch,
+      $fetch: mockedFetch as unknown as $Fetch,
     })
+
+    mockedFetch.mockClear()
 
     expect(data.value).toStrictEqual({ count: 0 })
     q.value = 'test'


### PR DESCRIPTION
### 🔗 Linked issue

#32233

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This PR fixes a perf issue and a bug. `query`/`params` are sent to `useAsyncData` for watch but `useFetch` also depends on theses to generate the key that `useAsyncData` also watches to re-trigger the handler. 


<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
