### PR TITLE
refactor(schema)!: remove config.schema.json export + defaults

### DIFF
--- a/docs/3.api/6.nuxt-config.md
+++ b/docs/3.api/6.nuxt-config.md
@@ -33,7 +33,7 @@ your alias by prefixing it with `~`.
 ::callout
 **Note**: These aliases will be automatically added to the generated `.nuxt/tsconfig.json` so you can get full
 type support and path auto-complete. In case you need to extend options provided by `./.nuxt/tsconfig.json`
-further, make sure to add them here or within the `typescript.tsConfig` property in `nuxt.config`.
+further, make sure to add them here or within the `typescript.TSConfig` property in `nuxt.config`.
 ::
 
 **Example**:
@@ -79,7 +79,6 @@ If a relative path is specified, it will be relative to your `rootDir`.
 
 Nuxt App configuration.
 
-
 ### `baseURL`
 
 The base path of your Nuxt application.
@@ -104,14 +103,12 @@ export default defineNuxtConfig({
 NUXT_APP_BASE_URL=/prefix/ node .output/server/index.mjs
 ```
 
-
 ### `buildAssetsDir`
 
 The folder name for the built site assets, relative to `baseURL` (or `cdnURL` if set). This is set at build time and should not be customized at runtime.
 
 - **Type**: `string`
 - **Default:** `"/_nuxt/"`
-
 
 ### `cdnURL`
 
@@ -136,7 +133,6 @@ export default defineNuxtConfig({
 ```bash
 NUXT_APP_CDN_URL=https://mycdn.org/ node .output/server/index.mjs
 ```
-
 
 ### `head`
 
@@ -191,7 +187,6 @@ app: {
 }
 ```
 
-
 ### `keepalive`
 
 Default values for KeepAlive configuration between pages.
@@ -202,7 +197,6 @@ This can be overridden with `definePageMeta` on an individual page. Only JSON-se
 - **Default:** `false`
 
 **See**: [Vue KeepAlive](https://vuejs.org/api/built-in-components.html#keepalive)
-
 
 ### `layoutTransition`
 
@@ -215,7 +209,6 @@ This can be overridden with `definePageMeta` on an individual page. Only JSON-se
 
 **See**: [Vue Transition docs](https://vuejs.org/api/built-in-components.html#transition)
 
-
 ### `pageTransition`
 
 Default values for page transitions.
@@ -226,7 +219,6 @@ This can be overridden with `definePageMeta` on an individual page. Only JSON-se
 - **Default:** `false`
 
 **See**: [Vue Transition docs](https://vuejs.org/api/built-in-components.html#transition)
-
 
 ### `rootAttrs`
 
@@ -240,14 +232,12 @@ Customize Nuxt root element id.
 }
 ```
 
-
 ### `rootId`
 
 Customize Nuxt root element id.
 
 - **Type**: `string`
 - **Default:** `"__nuxt"`
-
 
 ### `rootTag`
 
@@ -256,17 +246,14 @@ Customize Nuxt root element tag.
 - **Type**: `string`
 - **Default:** `"div"`
 
-
 ### `spaLoaderAttrs`
 
 Customize Nuxt Nuxt SpaLoader element attributes.
-
 
 #### `id`
 
 - **Type**: `string`
 - **Default:** `"__nuxt-loader"`
-
 
 ### `spaLoaderTag`
 
@@ -274,7 +261,6 @@ Customize Nuxt SpaLoader element tag.
 
 - **Type**: `string`
 - **Default:** `"div"`
-
 
 ### `teleportAttrs`
 
@@ -288,7 +274,6 @@ Customize Nuxt Teleport element attributes.
 }
 ```
 
-
 ### `teleportId`
 
 Customize Nuxt Teleport element id.
@@ -296,14 +281,12 @@ Customize Nuxt Teleport element id.
 - **Type**: `string`
 - **Default:** `"teleports"`
 
-
 ### `teleportTag`
 
 Customize Nuxt Teleport element tag.
 
 - **Type**: `string`
 - **Default:** `"div"`
-
 
 ### `viewTransition`
 
@@ -323,9 +306,7 @@ Additional app configuration
 
 For programmatic usage and type support, you can directly provide app config with this option. It will be merged with `app.config` file as default value.
 
-
 ### `nuxt`
-
 
 ## appId
 
@@ -339,7 +320,6 @@ Defaults to `nuxt-app`.
 ## build
 
 Shared build configuration.
-
 
 ### `analyze`
 
@@ -364,7 +344,6 @@ analyze: {
 }
 ```
 
-
 ### `templates`
 
 It is recommended to use `addTemplate` from `@nuxt/kit` instead of this option.
@@ -380,7 +359,6 @@ templates: [
   }
 ]
 ```
-
 
 ### `transpile`
 
@@ -431,7 +409,6 @@ Specify a compatibility date for your app.
 
 This is used to control the behavior of presets in Nitro, Nuxt Image and other modules that may change behavior without a major version bump.
 We plan to improve the tooling around this feature in the future.
-
 
 ## components
 
@@ -496,11 +473,9 @@ Normally, you should not need to set this.
 
 ## devServer
 
-
 ### `cors`
 
 Set CORS options for the dev server
-
 
 #### `origin`
 
@@ -512,12 +487,9 @@ Set CORS options for the dev server
 ]
 ```
 
-
 ### `host`
 
 Dev server listening host
-
-
 
 ### `https`
 
@@ -538,13 +510,11 @@ export default defineNuxtConfig({
 })
 ```
 
-
 ### `loadingTemplate`
 
 Template to show a loading screen
 
 - **Type**: `function`
-
 
 ### `port`
 
@@ -552,7 +522,6 @@ Dev server listening port
 
 - **Type**: `number`
 - **Default:** `3000`
-
 
 ### `url`
 
@@ -577,7 +546,6 @@ Enable Nuxt DevTools for development.
 
 Breaking changes for devtools might not reflect on the version of Nuxt.
 
-
 **See**:  [Nuxt DevTools](https://devtools.nuxt.com/) for more information.
 
 ## dir
@@ -586,12 +554,10 @@ Customize default directory structure used by Nuxt.
 
 It is better to stick with defaults unless needed.
 
-
 ### `app`
 
 - **Type**: `string`
 - **Default:** `"app"`
-
 
 ### `assets`
 
@@ -600,14 +566,12 @@ The assets directory (aliased as `~assets` in your build).
 - **Type**: `string`
 - **Default:** `"assets"`
 
-
 ### `layouts`
 
 The layouts directory, each file of which will be auto-registered as a Nuxt layout.
 
 - **Type**: `string`
 - **Default:** `"layouts"`
-
 
 ### `middleware`
 
@@ -616,14 +580,12 @@ The middleware directory, each file of which will be auto-registered as a Nuxt m
 - **Type**: `string`
 - **Default:** `"middleware"`
 
-
 ### `modules`
 
 The modules directory, each file in which will be auto-registered as a Nuxt module.
 
 - **Type**: `string`
 - **Default:** `"modules"`
-
 
 ### `pages`
 
@@ -632,14 +594,12 @@ The directory which will be processed to auto-generate your application page rou
 - **Type**: `string`
 - **Default:** `"pages"`
 
-
 ### `plugins`
 
 The plugins directory, each file of which will be auto-registered as a Nuxt plugin.
 
 - **Type**: `string`
 - **Default:** `"plugins"`
-
 
 ### `public`
 
@@ -648,14 +608,12 @@ The directory containing your static files, which will be directly accessible vi
 - **Type**: `string`
 - **Default:** `"public"`
 
-
 ### `shared`
 
 The shared directory. This directory is shared between the app and the server.
 
 - **Type**: `string`
 - **Default:** `"shared"`
-
 
 ### `static`
 
@@ -664,36 +622,30 @@ The shared directory. This directory is shared between the app and the server.
 
 ## esbuild
 
-
 ### `options`
 
-Configure shared esbuild options used within Nuxt and passed to other builders, such as Vite or Webpack.
-
+Configure shared esbuild options used within Nuxt and passed to other builders, such as Vite or webpack.
 
 #### `jsxFactory`
 
 - **Type**: `string`
 - **Default:** `"h"`
 
-
 #### `jsxFragment`
 
 - **Type**: `string`
 - **Default:** `"Fragment"`
-
 
 #### `target`
 
 - **Type**: `string`
 - **Default:** `"esnext"`
 
-
 #### `tsconfigRaw`
 
 - **Type**: `object`
 
 ## experimental
-
 
 ### `alwaysRunFetchOnKeyChange`
 
@@ -704,14 +656,12 @@ Whether to run `useFetch` when the key changes, even if it is set to `immediate:
 - **Type**: `boolean`
 - **Default:** `true`
 
-
 ### `appManifest`
 
 Use app manifests to respect route rules on client-side.
 
 - **Type**: `boolean`
 - **Default:** `true`
-
 
 ### `asyncContext`
 
@@ -722,14 +672,12 @@ Enable native async context to be accessible for nested composables
 
 **See**: [Nuxt PR #20918](https://github.com/nuxt/nuxt/pull/20918)
 
-
 ### `asyncEntry`
 
 Set to true to generate an async entry point for the Vue bundle (for module federation support).
 
 - **Type**: `boolean`
 - **Default:** `false`
-
 
 ### `browserDevtoolsTiming`
 
@@ -755,7 +703,6 @@ export default defineNuxtConfig({
 
 **See**: [Chrome DevTools Performance API](https://developer.chrome.com/docs/devtools/performance/extension#tracks)
 
-
 ### `buildCache`
 
 Cache Nuxt/Nitro build artifacts based on a hash of the configuration and source files.
@@ -764,7 +711,6 @@ This only works for source files within `srcDir` and `serverDir` for the Vue/Nit
 
 - **Type**: `boolean`
 - **Default:** `false`
-
 
 ### `checkOutdatedBuildInterval`
 
@@ -775,14 +721,12 @@ Set to `false` to disable.
 - **Type**: `number`
 - **Default:** `3600000`
 
-
 ### `clientFallback`
 
 Whether to enable the experimental `<NuxtClientFallback>` component for rendering content on the client if there's an error in SSR.
 
 - **Type**: `boolean`
 - **Default:** `false`
-
 
 ### `clientNodeCompat`
 
@@ -809,7 +753,6 @@ This flag will be removed with the release of v4 and exists only for advance tes
 - **Type**: `boolean`
 - **Default:** `true`
 
-
 ### `componentIslands`
 
 Experimental component islands support with `<NuxtIsland>` and `.island.vue` files.
@@ -818,7 +761,6 @@ By default it is set to 'auto', which means it will be enabled only when there a
 
 - **Type**: `string`
 - **Default:** `"auto"`
-
 
 ### `configSchema`
 
@@ -829,7 +771,6 @@ Config schema support
 
 **See**: [Nuxt Issue #15592](https://github.com/nuxt/nuxt/issues/15592)
 
-
 ### `cookieStore`
 
 Enables CookieStore support to listen for cookie updates (if supported by the browser) and refresh `useCookie` ref values.
@@ -839,14 +780,12 @@ Enables CookieStore support to listen for cookie updates (if supported by the br
 
 **See**: [CookieStore](https://developer.mozilla.org/en-US/docs/Web/API/CookieStore)
 
-
 ### `crossOriginPrefetch`
 
 Enable cross-origin prefetch using the Speculation Rules API.
 
 - **Type**: `boolean`
 - **Default:** `false`
-
 
 ### `debugModuleMutation`
 
@@ -870,7 +809,6 @@ export default defineNuxtConfig({
 
 **See**: [PR #30555](https://github.com/nuxt/nuxt/pull/30555)
 
-
 ### `decorators`
 
 Enable to use experimental decorators in Nuxt and Nitro.
@@ -880,64 +818,51 @@ Enable to use experimental decorators in Nuxt and Nitro.
 
 **See**: https://github.com/tc39/proposal-decorators
 
-
 ### `defaults`
 
 This allows specifying the default options for core Nuxt components and composables.
 
 These options will likely be moved elsewhere in the future, such as into `app.config` or into the `app/` directory.
 
-
 #### `nuxtLink`
-
 
 ##### `componentName`
 
 - **Type**: `string`
 - **Default:** `"NuxtLink"`
 
-
 ##### `prefetch`
 
 - **Type**: `boolean`
 - **Default:** `true`
 
-
 ##### `prefetchOn`
-
 
 ###### `visibility`
 
 - **Type**: `boolean`
 - **Default:** `true`
 
-
 #### `useAsyncData`
 
 Options that apply to `useAsyncData` (and also therefore `useFetch`)
-
 
 ##### `deep`
 
 - **Type**: `boolean`
 - **Default:** `true`
 
-
 ##### `errorValue`
 
 - **Type**: `string`
 - **Default:** `"null"`
-
 
 ##### `value`
 
 - **Type**: `string`
 - **Default:** `"null"`
 
-
 #### `useFetch`
-
-
 
 ### `emitRouteChunkError`
 
@@ -952,14 +877,12 @@ You can disable automatic handling by setting this to `false`, or handle chunk e
 
 **See**: [Nuxt PR #19038](https://github.com/nuxt/nuxt/pull/19038)
 
-
 ### `enforceModuleCompatibility`
 
 Whether Nuxt should stop if a Nuxt module is incompatible.
 
 - **Type**: `boolean`
 - **Default:** `false`
-
 
 ### `externalVue`
 
@@ -970,7 +893,6 @@ Externalize `vue`, `@vue/*` and `vue-router` when building.
 
 **See**: [Nuxt Issue #13632](https://github.com/nuxt/nuxt/issues/13632)
 
-
 ### `extraPageMetaExtractionKeys`
 
 Configure additional keys to extract from the page metadata when using `scanPageMeta`.
@@ -979,14 +901,12 @@ This allows modules to access additional metadata from the page metadata. It's r
 
 - **Type**: `array`
 
-
 ### `granularCachedData`
 
 Whether to call and use the result from `getCachedData` on manual refresh for `useAsyncData` and `useFetch`.
 
 - **Type**: `boolean`
 - **Default:** `false`
-
 
 ### `headNext`
 
@@ -999,7 +919,6 @@ Use new experimental head optimisations:
 
 **See**: [Nuxt Discussion #22632](https://github.com/nuxt/nuxt/discussions/22632)
 
-
 ### `inlineRouteRules`
 
 Allow defining `routeRules` directly within your `~/pages` directory using `defineRouteRules`.
@@ -1009,7 +928,6 @@ For more control, such as if you are using a custom `path` or `alias` set in the
 
 - **Type**: `boolean`
 - **Default:** `false`
-
 
 ### `lazyHydration`
 
@@ -1039,14 +957,12 @@ export default defineNuxtConfig({
 
 **See**: [PR #26468](https://github.com/nuxt/nuxt/pull/26468)
 
-
 ### `localLayerAliases`
 
 Resolve `~`, `~~`, `@` and `@@` aliases located within layers with respect to their layer source and root directories.
 
 - **Type**: `boolean`
 - **Default:** `true`
-
 
 ### `navigationRepaint`
 
@@ -1057,14 +973,12 @@ It can reduce INP when navigating on prerendered routes.
 - **Type**: `boolean`
 - **Default:** `true`
 
-
 ### `noVueServer`
 
 Disable vue server renderer endpoint within nitro.
 
 - **Type**: `boolean`
 - **Default:** `false`
-
 
 ### `normalizeComponentNames`
 
@@ -1073,14 +987,12 @@ Ensure that auto-generated Vue component names match the full component name you
 - **Type**: `boolean`
 - **Default:** `false`
 
-
 ### `parseErrorData`
 
 Whether to parse `error.data` when rendering a server error page.
 
 - **Type**: `boolean`
 - **Default:** `false`
-
 
 ### `payloadExtraction`
 
@@ -1089,14 +1001,12 @@ When this option is enabled (by default) payload of pages that are prerendered a
 - **Type**: `boolean`
 - **Default:** `true`
 
-
 ### `pendingWhenIdle`
 
 For `useAsyncData` and `useFetch`, whether `pending` should be `true` when data has not yet started to be fetched.
 
 - **Type**: `boolean`
 - **Default:** `true`
-
 
 ### `polyfillVueUseHead`
 
@@ -1106,7 +1016,6 @@ This is disabled to reduce the client-side bundle by ~0.5kb.
 
 - **Type**: `boolean`
 - **Default:** `false`
-
 
 ### `purgeCachedData`
 
@@ -1130,7 +1039,6 @@ export default defineNuxtConfig({
 
 **See**: [PR #31379](https://github.com/nuxt/nuxt/pull/31379)
 
-
 ### `relativeWatchPaths`
 
 Whether to provide relative paths in the `builder:watch` hook.
@@ -1140,14 +1048,12 @@ This flag will be removed with the release of v4 and exists only for advance tes
 - **Type**: `boolean`
 - **Default:** `true`
 
-
 ### `renderJsonPayloads`
 
 Render JSON payloads with support for revivifying complex types.
 
 - **Type**: `boolean`
 - **Default:** `true`
-
 
 ### `resetAsyncDataToUndefined`
 
@@ -1156,14 +1062,12 @@ Whether `clear` and `clearNuxtData` should reset async data to its _default_ val
 - **Type**: `boolean`
 - **Default:** `true`
 
-
 ### `respectNoSSRHeader`
 
 Allow disabling Nuxt SSR responses by setting the `x-nuxt-no-ssr` header.
 
 - **Type**: `boolean`
 - **Default:** `false`
-
 
 ### `restoreState`
 
@@ -1175,7 +1079,6 @@ Consider carefully before enabling this as it can cause unexpected behavior, and
 - **Type**: `boolean`
 - **Default:** `false`
 
-
 ### `scanPageMeta`
 
 Allow exposing some route metadata defined in `definePageMeta` at build-time to modules (alias, name, path, redirect, props, middleware).
@@ -1186,7 +1089,6 @@ This only works with static or strings/arrays rather than variables or condition
 - **Default:** `true`
 
 **See**: [Nuxt Issues #24770](https://github.com/nuxt/nuxt/issues/24770)
-
 
 ### `sharedPrerenderData`
 
@@ -1211,7 +1113,6 @@ const { data } = await useAsyncData(route.params.slug, async () => {
 })
 ```
 
-
 ### `spaLoadingTemplateLocation`
 
 Keep showing the spa-loading-template until suspense:resolve
@@ -1220,7 +1121,6 @@ Keep showing the spa-loading-template until suspense:resolve
 - **Default:** `"within"`
 
 **See**: [Nuxt Issues #24770](https://github.com/nuxt/nuxt/issues/21721)
-
 
 ### `templateImportResolution`
 
@@ -1244,7 +1144,6 @@ export default defineNuxtConfig({
 
 **See**: [PR #31175](https://github.com/nuxt/nuxt/pull/31175)
 
-
 ### `templateRouteInjection`
 
 By default the route object returned by the auto-imported `useRoute()` composable is kept in sync with the current page in view in `<NuxtPage>`. This is not true for `vue-router`'s exported `useRoute` or for the default `$route` object available in your Vue templates.
@@ -1253,7 +1152,6 @@ By enabling this option a mixin will be injected to keep the `$route` template o
 
 - **Type**: `boolean`
 - **Default:** `true`
-
 
 ### `templateUtils`
 
@@ -1264,7 +1162,6 @@ This flag will be removed with the release of v4 and exists only for advance tes
 - **Type**: `boolean`
 - **Default:** `true`
 
-
 ### `treeshakeClientOnly`
 
 Tree shakes contents of client-only components from server bundle.
@@ -1274,14 +1171,12 @@ Tree shakes contents of client-only components from server bundle.
 
 **See**: [Nuxt PR #5750](https://github.com/nuxt/framework/pull/5750)
 
-
 ### `typedPages`
 
 Enable the new experimental typed router using [unplugin-vue-router](https://github.com/posva/unplugin-vue-router).
 
 - **Type**: `boolean`
 - **Default:** `false`
-
 
 ### `viewTransition`
 
@@ -1291,7 +1186,6 @@ Enable View Transition API integration with client-side router.
 - **Default:** `false`
 
 **See**: [View Transitions API](https://developer.chrome.com/docs/web-platform/view-transitions)
-
 
 ### `watcher`
 
@@ -1307,7 +1201,6 @@ You can also set this to `chokidar` to watch all files in your source directory.
 **See**: [chokidar](https://github.com/paulmillr/chokidar)
 
 **See**: [@parcel/watcher](https://github.com/parcel-bundler/watcher)
-
 
 ### `writeEarlyHints`
 
@@ -1326,7 +1219,6 @@ Extend project from multiple local or remote sources.
 
 Value should be either a string or array of strings pointing to source directories or config path relative to current config.
 You can use `github:`, `gh:` `gitlab:` or `bitbucket:`
-
 
 **See**: [`c12` docs on extending config layers](https://github.com/unjs/c12#extending-config-layer-from-remote-sources)
 
@@ -1353,7 +1245,6 @@ The extensions that should be resolved by the Nuxt resolver.
 
 Some features of Nuxt are available on an opt-in basis, or can be disabled based on your needs.
 
-
 ### `devLogs`
 
 Stream server logs to the client as you are developing. These logs can be handled in the `dev:ssr-logs` hook.
@@ -1363,7 +1254,6 @@ If set to `silent`, the logs will not be printed to the browser console.
 - **Type**: `boolean`
 - **Default:** `false`
 
-
 ### `inlineStyles`
 
 Inline styles when rendering HTML (currently vite only).
@@ -1372,7 +1262,6 @@ You can also pass a function that receives the path of a Vue component and retur
 
 - **Type**: `boolean`
 - **Default:** `true`
-
 
 ### `noScripts`
 
@@ -1386,7 +1275,6 @@ If set to 'production' or `true`, JS will be disabled in production mode only.
 ## future
 
 `future` is for early opting-in to new features that will become default in a future (possibly major) version of the framework.
-
 
 ### `compatibilityVersion`
 
@@ -1427,7 +1315,6 @@ export default defineNuxtConfig({
 })
 ```
 
-
 ### `multiApp`
 
 This enables early access to the experimental multi-app support.
@@ -1436,7 +1323,6 @@ This enables early access to the experimental multi-app support.
 - **Default:** `false`
 
 **See**: [Nuxt Issue #21635](https://github.com/nuxt/nuxt/issues/21635)
-
 
 ### `typescriptBundlerResolution`
 
@@ -1451,7 +1337,6 @@ You can set it to false to use the legacy 'Node' mode, which is the default for 
 **See**: [TypeScript PR implementing `bundler` module resolution](https://github.com/microsoft/TypeScript/pull/51669)
 
 ## generate
-
 
 ### `exclude`
 
@@ -1481,7 +1366,6 @@ Hooks are listeners to Nuxt events that are typically used in modules, but are a
 
 Internally, hooks follow a naming pattern using colons (e.g., build:done).
 For ease of configuration, you can also structure them as an hierarchical object in `nuxt.config` (as below).
-
 
 **Example**:
 ```js
@@ -1525,7 +1409,6 @@ More customizable than `ignorePrefix`: all files matching glob patterns specifie
 
 Pass options directly to `node-ignore` (which is used by Nuxt to ignore files).
 
-
 **See**: [node-ignore](https://github.com/kaelzhang/node-ignore)
 
 **Example**:
@@ -1548,7 +1431,6 @@ Configure how Nuxt auto-imports composables into your application.
 
 **See**: [Nuxt documentation](https://nuxt.com/docs/guide/directory-structure/composables)
 
-
 ### `dirs`
 
 An array of custom directories that will be auto-imported. Note that this option will not override the default directories (~/composables, ~/utils).
@@ -1563,12 +1445,10 @@ imports: {
 }
 ```
 
-
 ### `global`
 
 - **Type**: `boolean`
 - **Default:** `false`
-
 
 ### `scan`
 
@@ -1581,7 +1461,7 @@ Whether to scan your `composables/` and `utils/` directories for composables to 
 
 Log level when building logs.
 
-Defaults to 'silent' when running in CI or when a TTY is not available. This option is then used as 'silent' in Vite and 'none' in Webpack
+Defaults to 'silent' when running in CI or when a TTY is not available. This option is then used as 'silent' in Vite and 'none' in webpack
 
 - **Type**: `string`
 - **Default:** `"info"`
@@ -1642,11 +1522,9 @@ Configuration for Nitro.
 
 **See**: [Nitro configuration docs](https://nitro.build/config/)
 
-
 ### `routeRules`
 
 - **Type**: `object`
-
 
 ### `runtimeConfig`
 
@@ -1671,11 +1549,9 @@ Configuration for Nitro.
 
 Build time optimization configuration.
 
-
 ### `asyncTransforms`
 
 Options passed directly to the transformer from `unctx` that preserves async context after `await`.
-
 
 #### `asyncFunctions`
 
@@ -1688,9 +1564,7 @@ Options passed directly to the transformer from `unctx` that preserves async con
 ]
 ```
 
-
 #### `objectDefinitions`
-
 
 ##### `defineNuxtComponent`
 
@@ -1703,7 +1577,6 @@ Options passed directly to the transformer from `unctx` that preserves async con
 ]
 ```
 
-
 ##### `defineNuxtPlugin`
 
 - **Type**: `array`
@@ -1713,7 +1586,6 @@ Options passed directly to the transformer from `unctx` that preserves async con
   "setup"
 ]
 ```
-
 
 ##### `definePageMeta`
 
@@ -1725,7 +1597,6 @@ Options passed directly to the transformer from `unctx` that preserves async con
   "validate"
 ]
 ```
-
 
 ### `keyedComposables`
 
@@ -1769,11 +1640,9 @@ The key will be unique based on the location of the function being invoked withi
 ]
 ```
 
-
 ### `treeShake`
 
 Tree shake code from specific builds.
-
 
 #### `composables`
 
@@ -1783,7 +1652,6 @@ Tree shake composables from the server or client builds.
 ```js
 treeShake: { client: { myPackage: ['useServerOnlyComposable'] } }
 ```
-
 
 ##### `client`
 
@@ -1803,7 +1671,6 @@ treeShake: { client: { myPackage: ['useServerOnlyComposable'] } }
   ]
 }
 ```
-
 
 ##### `server`
 
@@ -1835,7 +1702,6 @@ treeShake: { client: { myPackage: ['useServerOnlyComposable'] } }
 Whether to use the vue-router integration in Nuxt 3. If you do not provide a value it will be enabled if you have a `pages/` directory in your source folder.
 
 Additionally, you can provide a glob pattern or an array of patterns to scan only certain files for pages.
-
 
 **Example**:
 ```js
@@ -1875,13 +1741,11 @@ plugins: [
 
 ## postcss
 
-
 ### `order`
 
 A strategy for ordering PostCSS plugins.
 
 - **Type**: `function`
-
 
 ### `plugins`
 
@@ -1889,14 +1753,11 @@ Options for configuring PostCSS plugins.
 
 **See**: [PostCSS docs](https://postcss.org/)
 
-
 #### `autoprefixer`
 
 Plugin to parse CSS and add vendor prefixes to CSS rules.
 
-
 **See**: [`autoprefixer`](https://github.com/postcss/autoprefixer)
-
 
 #### `cssnano`
 
@@ -1918,13 +1779,11 @@ It is normally not needed to configure this option.
 
 Global route options applied to matching server routes.
 
-
 **Experimental**: This is an experimental feature and API may change in the future.
 
 **See**: [Nitro route rules documentation](https://nitro.build/config/#routerules)
 
 ## router
-
 
 ### `options`
 
@@ -1937,7 +1796,6 @@ For more control, you can use `app/router.options.ts` file.
 
 **See**: [Vue Router documentation](https://router.vuejs.org/api/interfaces/routeroptions.html).
 
-
 #### `hashMode`
 
 You can enable hash history in SPA mode. In this mode, router uses a hash character (#) before the actual URL that is internally passed. When enabled, the **URL is never sent to the server** and **SSR is not supported**.
@@ -1946,7 +1804,6 @@ You can enable hash history in SPA mode. In this mode, router uses a hash charac
 - **Default:** `false`
 
 **Default**: false
-
 
 #### `scrollBehaviorType`
 
@@ -2140,7 +1997,6 @@ Whether to enable rendering of HTML - either dynamically (in server mode) or at 
 
 Manually disable nuxt telemetry.
 
-
 **See**: [Nuxt Telemetry](https://github.com/nuxt/telemetry) for more information.
 
 ## test
@@ -2163,7 +2019,6 @@ You can use `github:`, `gitlab:`, `bitbucket:` or `https://` to extend from a re
 
 Configuration for Nuxt's TypeScript integration.
 
-
 ### `builder`
 
 Which builder types to include for your project.
@@ -2172,7 +2027,6 @@ By default Nuxt infers this based on your `builder` option (defaulting to 'vite'
 The 'shared' option is advised for module authors, who will want to support multiple possible builders.
 
 - **Default:** `null`
-
 
 ### `hoist`
 
@@ -2202,14 +2056,12 @@ Modules to generate deep aliases for within `compilerOptions.paths`. This does n
 ]
 ```
 
-
 ### `includeWorkspace`
 
 Include parent workspace in the Nuxt project. Mostly useful for themes and module authors.
 
 - **Type**: `boolean`
 - **Default:** `false`
-
 
 ### `shim`
 
@@ -2221,7 +2073,6 @@ Note that you may wish to set this to `true` if you are using other libraries, s
 - **Type**: `boolean`
 - **Default:** `false`
 
-
 ### `strict`
 
 TypeScript comes with certain checks to give you more safety and analysis of your program. Once you’ve converted your codebase to TypeScript, you can start enabling these checks for greater safety. [Read More](https://www.typescriptlang.org/docs/handbook/migrating-from-javascript.html#getting-stricter-checks)
@@ -2229,12 +2080,9 @@ TypeScript comes with certain checks to give you more safety and analysis of you
 - **Type**: `boolean`
 - **Default:** `true`
 
-
-### `tsConfig`
+### `TSConfig`
 
 You can extend generated `.nuxt/tsconfig.json` using this option.
-
-
 
 ### `typeCheck`
 
@@ -2250,7 +2098,6 @@ If set to true, this will type check in development. You can restrict this to bu
 ## unhead
 
 An object that allows us to configure the `unhead` nuxt module.
-
 
 ### `legacy`
 
@@ -2268,7 +2115,6 @@ export default defineNuxtConfig({
   legacy: true
 })
 ```
-
 
 ### `renderSSRHeadOptions`
 
@@ -2299,33 +2145,27 @@ Configuration that will be passed directly to Vite.
 **See**: [Vite configuration docs](https://vite.dev/config) for more information.
 Please note that not all vite options are supported in Nuxt.
 
-
 ### `build`
-
 
 #### `assetsDir`
 
 - **Type**: `string`
 - **Default:** `"_nuxt/"`
 
-
 #### `emptyOutDir`
 
 - **Type**: `boolean`
 - **Default:** `false`
-
 
 ### `cacheDir`
 
 - **Type**: `string`
 - **Default:** `"/<rootDir>/node_modules/.cache/vite"`
 
-
 ### `clearScreen`
 
 - **Type**: `boolean`
 - **Default:** `true`
-
 
 ### `define`
 
@@ -2341,7 +2181,6 @@ Please note that not all vite options are supported in Nuxt.
 }
 ```
 
-
 ### `esbuild`
 
 - **Type**: `object`
@@ -2355,15 +2194,12 @@ Please note that not all vite options are supported in Nuxt.
 }
 ```
 
-
 ### `mode`
 
 - **Type**: `string`
 - **Default:** `"production"`
 
-
 ### `optimizeDeps`
-
 
 #### `esbuildOptions`
 
@@ -2378,7 +2214,6 @@ Please note that not all vite options are supported in Nuxt.
 }
 ```
 
-
 #### `exclude`
 
 - **Type**: `array`
@@ -2389,13 +2224,9 @@ Please note that not all vite options are supported in Nuxt.
 ]
 ```
 
-
 ### `publicDir`
 
-
-
 ### `resolve`
-
 
 #### `extensions`
 
@@ -2413,18 +2244,14 @@ Please note that not all vite options are supported in Nuxt.
 ]
 ```
 
-
 ### `root`
 
 - **Type**: `string`
 - **Default:** `"/<srcDir>"`
 
-
 ### `server`
 
-
 #### `fs`
-
 
 ##### `allow`
 
@@ -2439,39 +2266,29 @@ Please note that not all vite options are supported in Nuxt.
 ]
 ```
 
-
 ### `vue`
 
-
 #### `features`
-
 
 ##### `propsDestructure`
 
 - **Type**: `boolean`
 - **Default:** `true`
 
-
 #### `isProduction`
 
 - **Type**: `boolean`
 - **Default:** `true`
 
-
 #### `script`
-
 
 ##### `hoistStatic`
 
-
-
 #### `template`
-
 
 ##### `compilerOptions`
 
 - **Type**: `object`
-
 
 ##### `transformAssetUrls`
 
@@ -2500,7 +2317,6 @@ Please note that not all vite options are supported in Nuxt.
 }
 ```
 
-
 ### `vueJsx`
 
 - **Type**: `object`
@@ -2521,22 +2337,17 @@ Please note that not all vite options are supported in Nuxt.
 
 Vue.js config
 
-
 ### `compilerOptions`
 
 Options for the Vue compiler that will be passed at build time.
 
-
 **See**: [Vue documentation](https://vuejs.org/api/application.html#app-config-compileroptions)
-
 
 ### `config`
 
 It is possible to pass configure the Vue app globally. Only serializable options may be set in your `nuxt.config`. All other options should be set at runtime in a Nuxt plugin..
 
-
 **See**: [Vue app config documentation](https://vuejs.org/api/application.html#app-config)
-
 
 ### `propsDestructure`
 
@@ -2545,7 +2356,6 @@ Enable reactive destructure for `defineProps`
 - **Type**: `boolean`
 - **Default:** `true`
 
-
 ### `runtimeCompiler`
 
 Include Vue compiler in runtime bundle.
@@ -2553,9 +2363,7 @@ Include Vue compiler in runtime bundle.
 - **Type**: `boolean`
 - **Default:** `false`
 
-
 ### `transformAssetUrls`
-
 
 #### `image`
 
@@ -2568,7 +2376,6 @@ Include Vue compiler in runtime bundle.
 ]
 ```
 
-
 #### `img`
 
 - **Type**: `array`
@@ -2578,7 +2385,6 @@ Include Vue compiler in runtime bundle.
   "src"
 ]
 ```
-
 
 #### `source`
 
@@ -2590,7 +2396,6 @@ Include Vue compiler in runtime bundle.
 ]
 ```
 
-
 #### `use`
 
 - **Type**: `array`
@@ -2601,7 +2406,6 @@ Include Vue compiler in runtime bundle.
   "href"
 ]
 ```
-
 
 #### `video`
 
@@ -2626,38 +2430,31 @@ It is an array of strings or regular expressions. Strings should be either absol
 
 The watchers property lets you overwrite watchers configuration in your `nuxt.config`.
 
-
 ### `chokidar`
 
 Options to pass directly to `chokidar`.
 
 **See**: [chokidar](https://github.com/paulmillr/chokidar#api)
 
-
 #### `ignoreInitial`
 
 - **Type**: `boolean`
 - **Default:** `true`
-
 
 #### `ignorePermissionErrors`
 
 - **Type**: `boolean`
 - **Default:** `true`
 
-
 ### `rewatchOnRawEvents`
 
 An array of event types, which, when received, will cause the watcher to restart.
-
-
 
 ### `webpack`
 
 `watchOptions` to pass directly to webpack.
 
 **See**: [webpack@4 watch options](https://v4.webpack.js.org/configuration/watch/#watchoptions).
-
 
 #### `aggregateTimeout`
 
@@ -2666,14 +2463,12 @@ An array of event types, which, when received, will cause the watcher to restart
 
 ## webpack
 
-
 ### `aggressiveCodeRemoval`
 
 Hard-replaces `typeof process`, `typeof window` and `typeof document` to tree-shake bundle.
 
 - **Type**: `boolean`
 - **Default:** `false`
-
 
 ### `analyze`
 
@@ -2698,7 +2493,6 @@ analyze: {
 }
 ```
 
-
 ### `cssSourceMap`
 
 Enables CSS source map support (defaults to `true` in development).
@@ -2706,23 +2500,18 @@ Enables CSS source map support (defaults to `true` in development).
 - **Type**: `boolean`
 - **Default:** `false`
 
-
 ### `devMiddleware`
 
 See [webpack-dev-middleware](https://github.com/webpack/webpack-dev-middleware) for available options.
-
 
 #### `stats`
 
 - **Type**: `string`
 - **Default:** `"none"`
 
-
 ### `experiments`
 
 Configure [webpack experiments](https://webpack.js.org/configuration/experiments/)
-
-
 
 ### `extractCSS`
 
@@ -2772,7 +2561,6 @@ export default {
 }
 ```
 
-
 ### `filenames`
 
 Customize bundle filenames.
@@ -2792,36 +2580,29 @@ filenames: {
 }
 ```
 
-
 #### `app`
 
 - **Type**: `function`
-
 
 #### `chunk`
 
 - **Type**: `function`
 
-
 #### `css`
 
 - **Type**: `function`
-
 
 #### `font`
 
 - **Type**: `function`
 
-
 #### `img`
 
 - **Type**: `function`
 
-
 #### `video`
 
 - **Type**: `function`
-
 
 ### `friendlyErrors`
 
@@ -2830,76 +2611,60 @@ Set to `false` to disable the overlay provided by [FriendlyErrorsWebpackPlugin](
 - **Type**: `boolean`
 - **Default:** `true`
 
-
 ### `hotMiddleware`
 
 See [webpack-hot-middleware](https://github.com/webpack-contrib/webpack-hot-middleware) for available options.
-
-
 
 ### `loaders`
 
 Customize the options of Nuxt's integrated webpack loaders.
 
-
 #### `css`
 
 See [css-loader](https://github.com/webpack-contrib/css-loader) for available options.
-
 
 ##### `esModule`
 
 - **Type**: `boolean`
 - **Default:** `false`
 
-
 ##### `importLoaders`
 
 - **Type**: `number`
 - **Default:** `0`
 
-
 ##### `url`
-
 
 ###### `filter`
 
 - **Type**: `function`
 
-
 #### `cssModules`
 
 See [css-loader](https://github.com/webpack-contrib/css-loader) for available options.
-
 
 ##### `esModule`
 
 - **Type**: `boolean`
 - **Default:** `false`
 
-
 ##### `importLoaders`
 
 - **Type**: `number`
 - **Default:** `0`
 
-
 ##### `modules`
-
 
 ###### `localIdentName`
 
 - **Type**: `string`
 - **Default:** `"[local]_[hash:base64:5]"`
 
-
 ##### `url`
-
 
 ###### `filter`
 
 - **Type**: `function`
-
 
 #### `esbuild`
 
@@ -2916,7 +2681,6 @@ See [css-loader](https://github.com/webpack-contrib/css-loader) for available op
 
 **See**: [esbuild loader](https://github.com/esbuild-kit/esbuild-loader)
 
-
 #### `file`
 
 **See**: [`file-loader` Options](https://github.com/webpack-contrib/file-loader#options)
@@ -2926,18 +2690,15 @@ See [css-loader](https://github.com/webpack-contrib/css-loader) for available op
 { esModule: false }
 ```
 
-
 ##### `esModule`
 
 - **Type**: `boolean`
 - **Default:** `false`
 
-
 ##### `limit`
 
 - **Type**: `number`
 - **Default:** `1000`
-
 
 #### `fontUrl`
 
@@ -2948,18 +2709,15 @@ See [css-loader](https://github.com/webpack-contrib/css-loader) for available op
 { esModule: false }
 ```
 
-
 ##### `esModule`
 
 - **Type**: `boolean`
 - **Default:** `false`
 
-
 ##### `limit`
 
 - **Type**: `number`
 - **Default:** `1000`
-
 
 #### `imgUrl`
 
@@ -2970,18 +2728,15 @@ See [css-loader](https://github.com/webpack-contrib/css-loader) for available op
 { esModule: false }
 ```
 
-
 ##### `esModule`
 
 - **Type**: `boolean`
 - **Default:** `false`
 
-
 ##### `limit`
 
 - **Type**: `number`
 - **Default:** `1000`
-
 
 #### `less`
 
@@ -2994,12 +2749,9 @@ See [css-loader](https://github.com/webpack-contrib/css-loader) for available op
 
 **See**: [`less-loader` Options](https://github.com/webpack-contrib/less-loader#options)
 
-
 #### `pugPlain`
 
-
 **See**: [`pug` options](https://pugjs.org/api/reference.html#options)
-
 
 #### `sass`
 
@@ -3014,15 +2766,12 @@ See [css-loader](https://github.com/webpack-contrib/css-loader) for available op
 }
 ```
 
-
 ##### `sassOptions`
-
 
 ###### `indentedSyntax`
 
 - **Type**: `boolean`
 - **Default:** `true`
-
 
 #### `scss`
 
@@ -3035,7 +2784,6 @@ See [css-loader](https://github.com/webpack-contrib/css-loader) for available op
 
 **See**: [`sass-loader` Options](https://github.com/webpack-contrib/sass-loader#options)
 
-
 #### `stylus`
 
 - **Default**
@@ -3047,22 +2795,18 @@ See [css-loader](https://github.com/webpack-contrib/css-loader) for available op
 
 **See**: [`stylus-loader` Options](https://github.com/webpack-contrib/stylus-loader#options)
 
-
 #### `vue`
 
 See [vue-loader](https://github.com/vuejs/vue-loader) for available options.
-
 
 ##### `compilerOptions`
 
 - **Type**: `object`
 
-
 ##### `propsDestructure`
 
 - **Type**: `boolean`
 - **Default:** `true`
-
 
 ##### `transformAssetUrls`
 
@@ -3091,7 +2835,6 @@ See [vue-loader](https://github.com/vuejs/vue-loader) for available options.
 }
 ```
 
-
 #### `vueStyle`
 
 - **Default**
@@ -3101,11 +2844,9 @@ See [vue-loader](https://github.com/vuejs/vue-loader) for available options.
 }
 ```
 
-
 ### `optimization`
 
 Configure [webpack optimization](https://webpack.js.org/configuration/optimization/).
-
 
 #### `minimize`
 
@@ -3114,37 +2855,28 @@ Set minimize to `false` to disable all minimizers. (It is disabled in developmen
 - **Type**: `boolean`
 - **Default:** `true`
 
-
 #### `minimizer`
 
 You can set minimizer to a customized array of plugins.
-
-
 
 #### `runtimeChunk`
 
 - **Type**: `string`
 - **Default:** `"single"`
 
-
 #### `splitChunks`
-
 
 ##### `automaticNameDelimiter`
 
 - **Type**: `string`
 - **Default:** `"/"`
 
-
 ##### `cacheGroups`
-
-
 
 ##### `chunks`
 
 - **Type**: `string`
 - **Default:** `"all"`
-
 
 ### `optimizeCSS`
 
@@ -3156,7 +2888,6 @@ Defaults to true when `extractCSS` is enabled.
 - **Default:** `false`
 
 **See**: [css-minimizer-webpack-plugin documentation](https://github.com/webpack-contrib/css-minimizer-webpack-plugin).
-
 
 ### `plugins`
 
@@ -3176,14 +2907,11 @@ plugins: [
 ]
 ```
 
-
 ### `postcss`
 
 Customize PostCSS Loader. same options as [`postcss-loader` options](https://github.com/webpack-contrib/postcss-loader#options)
 
-
 #### `postcssOptions`
-
 
 ##### `plugins`
 
@@ -3196,7 +2924,6 @@ Customize PostCSS Loader. same options as [`postcss-loader` options](https://git
 }
 ```
 
-
 ### `profile`
 
 Enable the profiler in webpackbar.
@@ -3208,7 +2935,6 @@ It is normally enabled by CLI argument `--profile`.
 
 **See**: [webpackbar](https://github.com/unjs/webpackbar#profile).
 
-
 ### `serverURLPolyfill`
 
 The polyfill library to load to provide URL and URLSearchParams.
@@ -3217,7 +2943,6 @@ Defaults to `'url'` ([see package](https://www.npmjs.com/package/url)).
 
 - **Type**: `string`
 - **Default:** `"url"`
-
 
 ### `warningIgnoreFilters`
 

--- a/docs/3.api/6.nuxt-config.md
+++ b/docs/3.api/6.nuxt-config.md
@@ -5,8 +5,3232 @@ description: Discover all the options you can use in your nuxt.config.ts file.
 navigation.icon: i-lucide-cog
 ---
 
-::note{icon="i-simple-icons-github" to="https://github.com/nuxt/nuxt/tree/main/packages/schema/src/config" target="_blank"}
-This file is auto-generated from Nuxt source code.
+## alias
+
+You can improve your DX by defining additional aliases to access custom directories within your JavaScript and CSS.
+
+- **Type**: `object`
+- **Default**
+```json
+{
+  "~": "/<srcDir>",
+  "@": "/<srcDir>",
+  "~~": "/<rootDir>",
+  "@@": "/<rootDir>",
+  "#shared": "/<rootDir>/shared",
+  "assets": "/<srcDir>/assets",
+  "public": "/<srcDir>/public",
+  "#build": "/<rootDir>/.nuxt",
+  "#internal/nuxt/paths": "/<rootDir>/.nuxt/paths.mjs"
+}
+```
+
+::callout
+**Note**: Within a webpack context (image sources, CSS - but not JavaScript) you _must_ access
+your alias by prefixing it with `~`.
 ::
 
-<!-- GENERATED_CONFIG_DOCS -->
+::callout
+**Note**: These aliases will be automatically added to the generated `.nuxt/tsconfig.json` so you can get full
+type support and path auto-complete. In case you need to extend options provided by `./.nuxt/tsconfig.json`
+further, make sure to add them here or within the `typescript.tsConfig` property in `nuxt.config`.
+::
+
+**Example**:
+```js
+export default {
+  alias: {
+    'images': fileURLToPath(new URL('./assets/images', import.meta.url)),
+    'style': fileURLToPath(new URL('./assets/style', import.meta.url)),
+    'data': fileURLToPath(new URL('./assets/other/data', import.meta.url))
+  }
+}
+```
+
+<!-- ```html
+<template>
+  <img src="~images/main-bg.jpg">
+</template>
+
+<script>
+import data from 'data/test.json'
+</script>
+
+<style>
+// Uncomment the below
+//@import '~style/variables.scss';
+//@import '~style/utils.scss';
+//@import '~style/base.scss';
+body {
+  background-image: url('~images/main-bg.jpg');
+}
+</style>
+``` -->
+## analyzeDir
+
+The directory where Nuxt will store the generated files when running `nuxt analyze`.
+
+If a relative path is specified, it will be relative to your `rootDir`.
+
+- **Type**: `string`
+- **Default:** `"/<rootDir>/.nuxt/analyze"`
+
+## app
+
+Nuxt App configuration.
+
+
+### `baseURL`
+
+The base path of your Nuxt application.
+
+For example:
+
+- **Type**: `string`
+- **Default:** `"/"`
+
+**Example**:
+```ts
+export default defineNuxtConfig({
+  app: {
+    baseURL: '/prefix/'
+  }
+})
+```
+
+<!-- This can also be set at runtime by setting the NUXT_APP_BASE_URL environment variable. -->
+**Example**:
+```bash
+NUXT_APP_BASE_URL=/prefix/ node .output/server/index.mjs
+```
+
+
+### `buildAssetsDir`
+
+The folder name for the built site assets, relative to `baseURL` (or `cdnURL` if set). This is set at build time and should not be customized at runtime.
+
+- **Type**: `string`
+- **Default:** `"/_nuxt/"`
+
+
+### `cdnURL`
+
+An absolute URL to serve the public folder from (production-only).
+
+For example:
+
+- **Type**: `string`
+- **Default:** `""`
+
+**Example**:
+```ts
+export default defineNuxtConfig({
+  app: {
+    cdnURL: 'https://mycdn.org/'
+  }
+})
+```
+
+<!-- This can be set to a different value at runtime by setting the `NUXT_APP_CDN_URL` environment variable. -->
+**Example**:
+```bash
+NUXT_APP_CDN_URL=https://mycdn.org/ node .output/server/index.mjs
+```
+
+
+### `head`
+
+Set default configuration for `<head>` on every page.
+
+- **Type**: `object`
+- **Default**
+```json
+{
+  "meta": [
+    {
+      "name": "viewport",
+      "content": "width=device-width, initial-scale=1"
+    },
+    {
+      "charset": "utf-8"
+    }
+  ],
+  "link": [],
+  "style": [],
+  "script": [],
+  "noscript": []
+}
+```
+
+**Example**:
+```js
+app: {
+  head: {
+    meta: [
+      // <meta name="viewport" content="width=device-width, initial-scale=1">
+      { name: 'viewport', content: 'width=device-width, initial-scale=1' }
+    ],
+    script: [
+      // <script src="https://myawesome-lib.js"></script>
+      { src: 'https://awesome-lib.js' }
+    ],
+    link: [
+      // <link rel="stylesheet" href="https://myawesome-lib.css">
+      { rel: 'stylesheet', href: 'https://awesome-lib.css' }
+    ],
+    // please note that this is an area that is likely to change
+    style: [
+      // <style>:root { color: red }</style>
+      { textContent: ':root { color: red }' }
+    ],
+    noscript: [
+      // <noscript>JavaScript is required</noscript>
+      { textContent: 'JavaScript is required' }
+    ]
+  }
+}
+```
+
+
+### `keepalive`
+
+Default values for KeepAlive configuration between pages.
+
+This can be overridden with `definePageMeta` on an individual page. Only JSON-serializable values are allowed.
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+**See**: [Vue KeepAlive](https://vuejs.org/api/built-in-components.html#keepalive)
+
+
+### `layoutTransition`
+
+Default values for layout transitions.
+
+This can be overridden with `definePageMeta` on an individual page. Only JSON-serializable values are allowed.
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+**See**: [Vue Transition docs](https://vuejs.org/api/built-in-components.html#transition)
+
+
+### `pageTransition`
+
+Default values for page transitions.
+
+This can be overridden with `definePageMeta` on an individual page. Only JSON-serializable values are allowed.
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+**See**: [Vue Transition docs](https://vuejs.org/api/built-in-components.html#transition)
+
+
+### `rootAttrs`
+
+Customize Nuxt root element id.
+
+- **Type**: `object`
+- **Default**
+```json
+{
+  "id": "__nuxt"
+}
+```
+
+
+### `rootId`
+
+Customize Nuxt root element id.
+
+- **Type**: `string`
+- **Default:** `"__nuxt"`
+
+
+### `rootTag`
+
+Customize Nuxt root element tag.
+
+- **Type**: `string`
+- **Default:** `"div"`
+
+
+### `spaLoaderAttrs`
+
+Customize Nuxt Nuxt SpaLoader element attributes.
+
+
+#### `id`
+
+- **Type**: `string`
+- **Default:** `"__nuxt-loader"`
+
+
+### `spaLoaderTag`
+
+Customize Nuxt SpaLoader element tag.
+
+- **Type**: `string`
+- **Default:** `"div"`
+
+
+### `teleportAttrs`
+
+Customize Nuxt Teleport element attributes.
+
+- **Type**: `object`
+- **Default**
+```json
+{
+  "id": "teleports"
+}
+```
+
+
+### `teleportId`
+
+Customize Nuxt Teleport element id.
+
+- **Type**: `string`
+- **Default:** `"teleports"`
+
+
+### `teleportTag`
+
+Customize Nuxt Teleport element tag.
+
+- **Type**: `string`
+- **Default:** `"div"`
+
+
+### `viewTransition`
+
+Default values for view transitions.
+
+This only has an effect when **experimental** support for View Transitions is [enabled in your nuxt.config file](/docs/getting-started/transitions#view-transitions-api-experimental).
+This can be overridden with `definePageMeta` on an individual page.
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+**See**: [Nuxt View Transition API docs](https://nuxt.com/docs/getting-started/transitions#view-transitions-api-experimental)
+
+## appConfig
+
+Additional app configuration
+
+For programmatic usage and type support, you can directly provide app config with this option. It will be merged with `app.config` file as default value.
+
+
+### `nuxt`
+
+
+## appId
+
+For multi-app projects, the unique id of the Nuxt application.
+
+Defaults to `nuxt-app`.
+
+- **Type**: `string`
+- **Default:** `"nuxt-app"`
+
+## build
+
+Shared build configuration.
+
+
+### `analyze`
+
+Nuxt allows visualizing your bundles and how to optimize them.
+
+Set to `true` to enable bundle analysis, or pass an object with options: [for webpack](https://github.com/webpack-contrib/webpack-bundle-analyzer#options-for-plugin) or [for vite](https://github.com/btd/rollup-plugin-visualizer#options).
+
+- **Type**: `object`
+- **Default**
+```json
+{
+  "template": "treemap",
+  "projectRoot": "/<rootDir>",
+  "filename": "/<rootDir>/.nuxt/analyze/{name}.html"
+}
+```
+
+**Example**:
+```js
+analyze: {
+  analyzerMode: 'static'
+}
+```
+
+
+### `templates`
+
+It is recommended to use `addTemplate` from `@nuxt/kit` instead of this option.
+
+- **Type**: `array`
+
+**Example**:
+```js
+templates: [
+  {
+    src: '~/modules/support/plugin.js', // `src` can be absolute or relative
+    dst: 'support.js', // `dst` is relative to project `.nuxt` dir
+  }
+]
+```
+
+
+### `transpile`
+
+If you want to transpile specific dependencies with Babel, you can add them here. Each item in transpile can be a package name, a function, a string or regex object matching the dependency's file name.
+
+You can also use a function to conditionally transpile. The function will receive an object ({ isDev, isServer, isClient, isModern, isLegacy }).
+
+- **Type**: `array`
+
+**Example**:
+```js
+transpile: [({ isLegacy }) => isLegacy && 'ky']
+```
+
+## buildDir
+
+Define the directory where your built Nuxt files will be placed.
+
+Many tools assume that `.nuxt` is a hidden directory (because it starts with a `.`). If that is a problem, you can use this option to prevent that.
+
+- **Type**: `string`
+- **Default:** `"/<rootDir>/.nuxt"`
+
+**Example**:
+```js
+export default {
+  buildDir: 'nuxt-build'
+}
+```
+
+## buildId
+
+A unique identifier matching the build. This may contain the hash of the current state of the project.
+
+- **Type**: `string`
+- **Default:** `"4a2e2d30-418f-41df-8e58-ed5df06de7fd"`
+
+## builder
+
+The builder to use for bundling the Vue part of your application.
+
+- **Type**: `string`
+- **Default:** `"@nuxt/vite-builder"`
+
+## compatibilityDate
+
+Specify a compatibility date for your app.
+
+This is used to control the behavior of presets in Nitro, Nuxt Image and other modules that may change behavior without a major version bump.
+We plan to improve the tooling around this feature in the future.
+
+
+## components
+
+Configure Nuxt component auto-registration.
+
+Any components in the directories configured here can be used throughout your pages, layouts (and other components) without needing to explicitly import them.
+
+- **Type**: `object`
+- **Default**
+```json
+{
+  "dirs": [
+    {
+      "path": "~/components/global",
+      "global": true
+    },
+    "~/components"
+  ]
+}
+```
+
+**See**: [`components/` directory documentation](https://nuxt.com/docs/guide/directory-structure/components)
+
+## css
+
+You can define the CSS files/modules/libraries you want to set globally (included in every page).
+
+Nuxt will automatically guess the file type by its extension and use the appropriate pre-processor. You will still need to install the required loader if you need to use them.
+
+- **Type**: `array`
+
+**Example**:
+```js
+css: [
+  // Load a Node.js module directly (here it's a Sass file).
+  'bulma',
+  // CSS file in the project
+  '~/assets/css/main.css',
+  // SCSS file in the project
+  '~/assets/css/main.scss'
+]
+```
+
+## debug
+
+Set to `true` to enable debug mode.
+
+At the moment, it prints out hook names and timings on the server, and logs hook arguments as well in the browser.
+You can also set this to an object to enable specific debug options.
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+## dev
+
+Whether Nuxt is running in development mode.
+
+Normally, you should not need to set this.
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+## devServer
+
+
+### `cors`
+
+Set CORS options for the dev server
+
+
+#### `origin`
+
+- **Type**: `array`
+- **Default**
+```json
+[
+  {}
+]
+```
+
+
+### `host`
+
+Dev server listening host
+
+
+
+### `https`
+
+Whether to enable HTTPS.
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+**Example**:
+```ts
+export default defineNuxtConfig({
+  devServer: {
+    https: {
+      key: './server.key',
+      cert: './server.crt'
+    }
+  }
+})
+```
+
+
+### `loadingTemplate`
+
+Template to show a loading screen
+
+- **Type**: `function`
+
+
+### `port`
+
+Dev server listening port
+
+- **Type**: `number`
+- **Default:** `3000`
+
+
+### `url`
+
+Listening dev server URL.
+
+This should not be set directly as it will always be overridden by the dev server with the full URL (for module and internal use).
+
+- **Type**: `string`
+- **Default:** `"http://localhost:3000"`
+
+## devServerHandlers
+
+Nitro development-only server handlers.
+
+- **Type**: `array`
+
+**See**: [Nitro server routes documentation](https://nitro.build/guide/routing)
+
+## devtools
+
+Enable Nuxt DevTools for development.
+
+Breaking changes for devtools might not reflect on the version of Nuxt.
+
+
+**See**:  [Nuxt DevTools](https://devtools.nuxt.com/) for more information.
+
+## dir
+
+Customize default directory structure used by Nuxt.
+
+It is better to stick with defaults unless needed.
+
+
+### `app`
+
+- **Type**: `string`
+- **Default:** `"app"`
+
+
+### `assets`
+
+The assets directory (aliased as `~assets` in your build).
+
+- **Type**: `string`
+- **Default:** `"assets"`
+
+
+### `layouts`
+
+The layouts directory, each file of which will be auto-registered as a Nuxt layout.
+
+- **Type**: `string`
+- **Default:** `"layouts"`
+
+
+### `middleware`
+
+The middleware directory, each file of which will be auto-registered as a Nuxt middleware.
+
+- **Type**: `string`
+- **Default:** `"middleware"`
+
+
+### `modules`
+
+The modules directory, each file in which will be auto-registered as a Nuxt module.
+
+- **Type**: `string`
+- **Default:** `"modules"`
+
+
+### `pages`
+
+The directory which will be processed to auto-generate your application page routes.
+
+- **Type**: `string`
+- **Default:** `"pages"`
+
+
+### `plugins`
+
+The plugins directory, each file of which will be auto-registered as a Nuxt plugin.
+
+- **Type**: `string`
+- **Default:** `"plugins"`
+
+
+### `public`
+
+The directory containing your static files, which will be directly accessible via the Nuxt server and copied across into your `dist` folder when your app is generated.
+
+- **Type**: `string`
+- **Default:** `"public"`
+
+
+### `shared`
+
+The shared directory. This directory is shared between the app and the server.
+
+- **Type**: `string`
+- **Default:** `"shared"`
+
+
+### `static`
+
+- **Type**: `string`
+- **Default:** `"public"`
+
+## esbuild
+
+
+### `options`
+
+Configure shared esbuild options used within Nuxt and passed to other builders, such as Vite or Webpack.
+
+
+#### `jsxFactory`
+
+- **Type**: `string`
+- **Default:** `"h"`
+
+
+#### `jsxFragment`
+
+- **Type**: `string`
+- **Default:** `"Fragment"`
+
+
+#### `target`
+
+- **Type**: `string`
+- **Default:** `"esnext"`
+
+
+#### `tsconfigRaw`
+
+- **Type**: `object`
+
+## experimental
+
+
+### `alwaysRunFetchOnKeyChange`
+
+Whether to run `useFetch` when the key changes, even if it is set to `immediate: false` and it has not been triggered yet.
+
+`useFetch` and `useAsyncData` will always run when the key changes if `immediate: true` or if it has been already triggered.
+
+- **Type**: `boolean`
+- **Default:** `true`
+
+
+### `appManifest`
+
+Use app manifests to respect route rules on client-side.
+
+- **Type**: `boolean`
+- **Default:** `true`
+
+
+### `asyncContext`
+
+Enable native async context to be accessible for nested composables
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+**See**: [Nuxt PR #20918](https://github.com/nuxt/nuxt/pull/20918)
+
+
+### `asyncEntry`
+
+Set to true to generate an async entry point for the Vue bundle (for module federation support).
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+
+### `browserDevtoolsTiming`
+
+Enable timings for Nuxt application hooks in the performance panel of Chromium-based browsers.
+
+This feature adds performance markers for Nuxt hooks, allowing you to track their execution time in the browser's Performance tab. This is particularly useful for debugging performance issues.
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+**Example**:
+```ts
+// nuxt.config.ts
+export default defineNuxtConfig({
+  experimental: {
+    // Enable performance markers for Nuxt hooks in browser devtools
+    browserDevtoolsTiming: true
+  }
+})
+```
+
+**See**: [PR #29922](https://github.com/nuxt/nuxt/pull/29922)
+
+**See**: [Chrome DevTools Performance API](https://developer.chrome.com/docs/devtools/performance/extension#tracks)
+
+
+### `buildCache`
+
+Cache Nuxt/Nitro build artifacts based on a hash of the configuration and source files.
+
+This only works for source files within `srcDir` and `serverDir` for the Vue/Nitro parts of your app.
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+
+### `checkOutdatedBuildInterval`
+
+Set the time interval (in ms) to check for new builds. Disabled when `experimental.appManifest` is `false`.
+
+Set to `false` to disable.
+
+- **Type**: `number`
+- **Default:** `3600000`
+
+
+### `clientFallback`
+
+Whether to enable the experimental `<NuxtClientFallback>` component for rendering content on the client if there's an error in SSR.
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+
+### `clientNodeCompat`
+
+Automatically polyfill Node.js imports in the client build using `unenv`.
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+**See**: [unenv](https://github.com/unjs/unenv)
+
+<!-- **Note:** To make globals like `Buffer` work in the browser, you need to manually inject them. -->
+<!-- ```ts
+import { Buffer } from 'node:buffer'
+
+globalThis.Buffer = globalThis.Buffer || Buffer
+``` -->
+
+### `compileTemplate`
+
+Whether to use `lodash.template` to compile Nuxt templates.
+
+This flag will be removed with the release of v4 and exists only for advance testing within Nuxt v3.12+ or in [the nightly release channel](/docs/guide/going-further/nightly-release-channel).
+
+- **Type**: `boolean`
+- **Default:** `true`
+
+
+### `componentIslands`
+
+Experimental component islands support with `<NuxtIsland>` and `.island.vue` files.
+
+By default it is set to 'auto', which means it will be enabled only when there are islands, server components or server pages in your app.
+
+- **Type**: `string`
+- **Default:** `"auto"`
+
+
+### `configSchema`
+
+Config schema support
+
+- **Type**: `boolean`
+- **Default:** `true`
+
+**See**: [Nuxt Issue #15592](https://github.com/nuxt/nuxt/issues/15592)
+
+
+### `cookieStore`
+
+Enables CookieStore support to listen for cookie updates (if supported by the browser) and refresh `useCookie` ref values.
+
+- **Type**: `boolean`
+- **Default:** `true`
+
+**See**: [CookieStore](https://developer.mozilla.org/en-US/docs/Web/API/CookieStore)
+
+
+### `crossOriginPrefetch`
+
+Enable cross-origin prefetch using the Speculation Rules API.
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+
+### `debugModuleMutation`
+
+Record mutations to `nuxt.options` in module context, helping to debug configuration changes made by modules during the Nuxt initialization phase.
+
+When enabled, Nuxt will track which modules modify configuration options, making it easier to trace unexpected configuration changes.
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+**Example**:
+```ts
+// nuxt.config.ts
+export default defineNuxtConfig({
+  experimental: {
+    // Enable tracking of config mutations by modules
+    debugModuleMutation: true
+  }
+})
+```
+
+**See**: [PR #30555](https://github.com/nuxt/nuxt/pull/30555)
+
+
+### `decorators`
+
+Enable to use experimental decorators in Nuxt and Nitro.
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+**See**: https://github.com/tc39/proposal-decorators
+
+
+### `defaults`
+
+This allows specifying the default options for core Nuxt components and composables.
+
+These options will likely be moved elsewhere in the future, such as into `app.config` or into the `app/` directory.
+
+
+#### `nuxtLink`
+
+
+##### `componentName`
+
+- **Type**: `string`
+- **Default:** `"NuxtLink"`
+
+
+##### `prefetch`
+
+- **Type**: `boolean`
+- **Default:** `true`
+
+
+##### `prefetchOn`
+
+
+###### `visibility`
+
+- **Type**: `boolean`
+- **Default:** `true`
+
+
+#### `useAsyncData`
+
+Options that apply to `useAsyncData` (and also therefore `useFetch`)
+
+
+##### `deep`
+
+- **Type**: `boolean`
+- **Default:** `true`
+
+
+##### `errorValue`
+
+- **Type**: `string`
+- **Default:** `"null"`
+
+
+##### `value`
+
+- **Type**: `string`
+- **Default:** `"null"`
+
+
+#### `useFetch`
+
+
+
+### `emitRouteChunkError`
+
+Emit `app:chunkError` hook when there is an error loading vite/webpack chunks.
+
+By default, Nuxt will also perform a reload of the new route when a chunk fails to load when navigating to a new route (`automatic`).
+Setting `automatic-immediate` will lead Nuxt to perform a reload of the current route right when a chunk fails to load (instead of waiting for navigation).
+You can disable automatic handling by setting this to `false`, or handle chunk errors manually by setting it to `manual`.
+
+- **Type**: `string`
+- **Default:** `"automatic"`
+
+**See**: [Nuxt PR #19038](https://github.com/nuxt/nuxt/pull/19038)
+
+
+### `enforceModuleCompatibility`
+
+Whether Nuxt should stop if a Nuxt module is incompatible.
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+
+### `externalVue`
+
+Externalize `vue`, `@vue/*` and `vue-router` when building.
+
+- **Type**: `boolean`
+- **Default:** `true`
+
+**See**: [Nuxt Issue #13632](https://github.com/nuxt/nuxt/issues/13632)
+
+
+### `extraPageMetaExtractionKeys`
+
+Configure additional keys to extract from the page metadata when using `scanPageMeta`.
+
+This allows modules to access additional metadata from the page metadata. It's recommended to augment the NuxtPage types with your keys.
+
+- **Type**: `array`
+
+
+### `granularCachedData`
+
+Whether to call and use the result from `getCachedData` on manual refresh for `useAsyncData` and `useFetch`.
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+
+### `headNext`
+
+Use new experimental head optimisations:
+
+- Add the capo.js head plugin in order to render tags in of the head in a more performant way. - Uses the hash hydration plugin to reduce initial hydration
+
+- **Type**: `boolean`
+- **Default:** `true`
+
+**See**: [Nuxt Discussion #22632](https://github.com/nuxt/nuxt/discussions/22632)
+
+
+### `inlineRouteRules`
+
+Allow defining `routeRules` directly within your `~/pages` directory using `defineRouteRules`.
+
+Rules are converted (based on the path) and applied for server requests. For example, a rule defined in `~/pages/foo/bar.vue` will be applied to `/foo/bar` requests. A rule in `~/pages/foo/[id].vue` will be applied to `/foo/**` requests.
+For more control, such as if you are using a custom `path` or `alias` set in the page's `definePageMeta`, you should set `routeRules` directly within your `nuxt.config`.
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+
+### `lazyHydration`
+
+Enable automatic configuration of hydration strategies for `<Lazy>` components.
+
+This feature intelligently determines when to hydrate lazy components based on visibility, idle time, or other triggers, improving performance by deferring hydration of components until they're needed.
+
+- **Type**: `boolean`
+- **Default:** `true`
+
+**Example**:
+```ts
+// nuxt.config.ts
+export default defineNuxtConfig({
+  experimental: {
+    lazyHydration: true // Enable smart hydration strategies for Lazy components
+  }
+})
+
+// In your Vue components
+<template>
+  <Lazy>
+    <ExpensiveComponent />
+  </Lazy>
+</template>
+```
+
+**See**: [PR #26468](https://github.com/nuxt/nuxt/pull/26468)
+
+
+### `localLayerAliases`
+
+Resolve `~`, `~~`, `@` and `@@` aliases located within layers with respect to their layer source and root directories.
+
+- **Type**: `boolean`
+- **Default:** `true`
+
+
+### `navigationRepaint`
+
+Wait for a single animation frame before navigation, which gives an opportunity for the browser to repaint, acknowledging user interaction.
+
+It can reduce INP when navigating on prerendered routes.
+
+- **Type**: `boolean`
+- **Default:** `true`
+
+
+### `noVueServer`
+
+Disable vue server renderer endpoint within nitro.
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+
+### `normalizeComponentNames`
+
+Ensure that auto-generated Vue component names match the full component name you would use to auto-import the component.
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+
+### `parseErrorData`
+
+Whether to parse `error.data` when rendering a server error page.
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+
+### `payloadExtraction`
+
+When this option is enabled (by default) payload of pages that are prerendered are extracted
+
+- **Type**: `boolean`
+- **Default:** `true`
+
+
+### `pendingWhenIdle`
+
+For `useAsyncData` and `useFetch`, whether `pending` should be `true` when data has not yet started to be fetched.
+
+- **Type**: `boolean`
+- **Default:** `true`
+
+
+### `polyfillVueUseHead`
+
+Whether or not to add a compatibility layer for modules, plugins or user code relying on the old `@vueuse/head` API.
+
+This is disabled to reduce the client-side bundle by ~0.5kb.
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+
+### `purgeCachedData`
+
+Whether to clean up Nuxt static and asyncData caches on route navigation.
+
+Nuxt will automatically purge cached data from `useAsyncData` and `nuxtApp.static.data`. This helps prevent memory leaks and ensures fresh data is loaded when needed, but it is possible to disable it.
+
+- **Type**: `boolean`
+- **Default:** `true`
+
+**Example**:
+```ts
+// nuxt.config.ts
+export default defineNuxtConfig({
+  experimental: {
+    // Disable automatic cache cleanup (default is true)
+    purgeCachedData: false
+  }
+})
+```
+
+**See**: [PR #31379](https://github.com/nuxt/nuxt/pull/31379)
+
+
+### `relativeWatchPaths`
+
+Whether to provide relative paths in the `builder:watch` hook.
+
+This flag will be removed with the release of v4 and exists only for advance testing within Nuxt v3.12+ or in [the nightly release channel](/docs/guide/going-further/nightly-release-channel).
+
+- **Type**: `boolean`
+- **Default:** `true`
+
+
+### `renderJsonPayloads`
+
+Render JSON payloads with support for revivifying complex types.
+
+- **Type**: `boolean`
+- **Default:** `true`
+
+
+### `resetAsyncDataToUndefined`
+
+Whether `clear` and `clearNuxtData` should reset async data to its _default_ value or update it to `null`/`undefined`.
+
+- **Type**: `boolean`
+- **Default:** `true`
+
+
+### `respectNoSSRHeader`
+
+Allow disabling Nuxt SSR responses by setting the `x-nuxt-no-ssr` header.
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+
+### `restoreState`
+
+Whether to restore Nuxt app state from `sessionStorage` when reloading the page after a chunk error or manual `reloadNuxtApp()` call.
+
+To avoid hydration errors, it will be applied only after the Vue app has been mounted, meaning there may be a flicker on initial load.
+Consider carefully before enabling this as it can cause unexpected behavior, and consider providing explicit keys to `useState` as auto-generated keys may not match across builds.
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+
+### `scanPageMeta`
+
+Allow exposing some route metadata defined in `definePageMeta` at build-time to modules (alias, name, path, redirect, props, middleware).
+
+This only works with static or strings/arrays rather than variables or conditional assignment.
+
+- **Type**: `boolean`
+- **Default:** `true`
+
+**See**: [Nuxt Issues #24770](https://github.com/nuxt/nuxt/issues/24770)
+
+
+### `sharedPrerenderData`
+
+Automatically share payload _data_ between pages that are prerendered. This can result in a significant performance improvement when prerendering sites that use `useAsyncData` or `useFetch` and fetch the same data in different pages.
+
+It is particularly important when enabling this feature to make sure that any unique key of your data is always resolvable to the same data. For example, if you are using `useAsyncData` to fetch data related to a particular page, you should provide a key that uniquely matches that data. (`useFetch` should do this automatically for you.)
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+**Example**:
+```ts
+// This would be unsafe in a dynamic page (e.g. `[slug].vue`) because the route slug makes a difference
+// to the data fetched, but Nuxt can't know that because it's not reflected in the key.
+const route = useRoute()
+const { data } = await useAsyncData(async () => {
+  return await $fetch(`/api/my-page/${route.params.slug}`)
+})
+// Instead, you should use a key that uniquely identifies the data fetched.
+const { data } = await useAsyncData(route.params.slug, async () => {
+  return await $fetch(`/api/my-page/${route.params.slug}`)
+})
+```
+
+
+### `spaLoadingTemplateLocation`
+
+Keep showing the spa-loading-template until suspense:resolve
+
+- **Type**: `string`
+- **Default:** `"within"`
+
+**See**: [Nuxt Issues #24770](https://github.com/nuxt/nuxt/issues/21721)
+
+
+### `templateImportResolution`
+
+Disable resolving imports into Nuxt templates from the path of the module that added the template.
+
+By default, Nuxt attempts to resolve imports in templates relative to the module that added them. Setting this to `false` disables this behavior, which may be useful if you're experiencing resolution conflicts in certain environments.
+
+- **Type**: `boolean`
+- **Default:** `true`
+
+**Example**:
+```ts
+// nuxt.config.ts
+export default defineNuxtConfig({
+  experimental: {
+    // Disable template import resolution from module path
+    templateImportResolution: false
+  }
+})
+```
+
+**See**: [PR #31175](https://github.com/nuxt/nuxt/pull/31175)
+
+
+### `templateRouteInjection`
+
+By default the route object returned by the auto-imported `useRoute()` composable is kept in sync with the current page in view in `<NuxtPage>`. This is not true for `vue-router`'s exported `useRoute` or for the default `$route` object available in your Vue templates.
+
+By enabling this option a mixin will be injected to keep the `$route` template object in sync with Nuxt's managed `useRoute()`.
+
+- **Type**: `boolean`
+- **Default:** `true`
+
+
+### `templateUtils`
+
+Whether to provide a legacy `templateUtils` object (with `serialize`, `importName` and `importSources`) when compiling Nuxt templates.
+
+This flag will be removed with the release of v4 and exists only for advance testing within Nuxt v3.12+ or in [the nightly release channel](/docs/guide/going-further/nightly-release-channel).
+
+- **Type**: `boolean`
+- **Default:** `true`
+
+
+### `treeshakeClientOnly`
+
+Tree shakes contents of client-only components from server bundle.
+
+- **Type**: `boolean`
+- **Default:** `true`
+
+**See**: [Nuxt PR #5750](https://github.com/nuxt/framework/pull/5750)
+
+
+### `typedPages`
+
+Enable the new experimental typed router using [unplugin-vue-router](https://github.com/posva/unplugin-vue-router).
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+
+### `viewTransition`
+
+Enable View Transition API integration with client-side router.
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+**See**: [View Transitions API](https://developer.chrome.com/docs/web-platform/view-transitions)
+
+
+### `watcher`
+
+Set an alternative watcher that will be used as the watching service for Nuxt.
+
+Nuxt uses 'chokidar-granular' if your source directory is the same as your root directory . This will ignore top-level directories (like `node_modules` and `.git`) that are excluded from watching.
+You can set this instead to `parcel` to use `@parcel/watcher`, which may improve performance in large projects or on Windows platforms.
+You can also set this to `chokidar` to watch all files in your source directory.
+
+- **Type**: `string`
+- **Default:** `"chokidar"`
+
+**See**: [chokidar](https://github.com/paulmillr/chokidar)
+
+**See**: [@parcel/watcher](https://github.com/parcel-bundler/watcher)
+
+
+### `writeEarlyHints`
+
+Write early hints when using node server.
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+::callout
+**Note**: nginx does not support 103 Early hints in the current version.
+::
+
+## extends
+
+Extend project from multiple local or remote sources.
+
+Value should be either a string or array of strings pointing to source directories or config path relative to current config.
+You can use `github:`, `gh:` `gitlab:` or `bitbucket:`
+
+
+**See**: [`c12` docs on extending config layers](https://github.com/unjs/c12#extending-config-layer-from-remote-sources)
+
+**See**: [`giget` documentation](https://github.com/unjs/giget)
+
+## extensions
+
+The extensions that should be resolved by the Nuxt resolver.
+
+- **Type**: `array`
+- **Default**
+```json
+[
+  ".js",
+  ".jsx",
+  ".mjs",
+  ".ts",
+  ".tsx",
+  ".vue"
+]
+```
+
+## features
+
+Some features of Nuxt are available on an opt-in basis, or can be disabled based on your needs.
+
+
+### `devLogs`
+
+Stream server logs to the client as you are developing. These logs can be handled in the `dev:ssr-logs` hook.
+
+If set to `silent`, the logs will not be printed to the browser console.
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+
+### `inlineStyles`
+
+Inline styles when rendering HTML (currently vite only).
+
+You can also pass a function that receives the path of a Vue component and returns a boolean indicating whether to inline the styles for that component.
+
+- **Type**: `boolean`
+- **Default:** `true`
+
+
+### `noScripts`
+
+Turn off rendering of Nuxt scripts and JS resource hints. You can also disable scripts more granularly within `routeRules`.
+
+If set to 'production' or `true`, JS will be disabled in production mode only.
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+## future
+
+`future` is for early opting-in to new features that will become default in a future (possibly major) version of the framework.
+
+
+### `compatibilityVersion`
+
+Enable early access to Nuxt v4 features or flags.
+
+Setting `compatibilityVersion` to `4` changes defaults throughout your Nuxt configuration, but you can granularly re-enable Nuxt v3 behaviour when testing (see example). Please file issues if so, so that we can address in Nuxt or in the ecosystem.
+
+- **Type**: `number`
+- **Default:** `3`
+
+**Example**:
+```ts
+export default defineNuxtConfig({
+  future: {
+    compatibilityVersion: 4,
+  },
+  // To re-enable _all_ Nuxt v3 behaviour, set the following options:
+  srcDir: '.',
+  dir: {
+    app: 'app'
+  },
+  experimental: {
+    compileTemplate: true,
+    templateUtils: true,
+    relativeWatchPaths: true,
+    resetAsyncDataToUndefined: true,
+    defaults: {
+      useAsyncData: {
+        deep: true
+      }
+    }
+  },
+  unhead: {
+    renderSSRHeadOptions: {
+      omitLineBreaks: false
+    }
+  }
+})
+```
+
+
+### `multiApp`
+
+This enables early access to the experimental multi-app support.
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+**See**: [Nuxt Issue #21635](https://github.com/nuxt/nuxt/issues/21635)
+
+
+### `typescriptBundlerResolution`
+
+This enables 'Bundler' module resolution mode for TypeScript, which is the recommended setting for frameworks like Nuxt and Vite.
+
+It improves type support when using modern libraries with `exports`.
+You can set it to false to use the legacy 'Node' mode, which is the default for TypeScript.
+
+- **Type**: `boolean`
+- **Default:** `true`
+
+**See**: [TypeScript PR implementing `bundler` module resolution](https://github.com/microsoft/TypeScript/pull/51669)
+
+## generate
+
+
+### `exclude`
+
+This option is no longer used. Instead, use `nitro.prerender.ignore`.
+
+- **Type**: `array`
+
+<!-- @deprecated -->
+
+### `routes`
+
+The routes to generate.
+
+If you are using the crawler, this will be only the starting point for route generation. This is often necessary when using dynamic routes.
+It is preferred to use `nitro.prerender.routes`.
+
+- **Type**: `array`
+
+**Example**:
+```js
+routes: ['/users/1', '/users/2', '/users/3']
+```
+
+## hooks
+
+Hooks are listeners to Nuxt events that are typically used in modules, but are also available in `nuxt.config`.
+
+Internally, hooks follow a naming pattern using colons (e.g., build:done).
+For ease of configuration, you can also structure them as an hierarchical object in `nuxt.config` (as below).
+
+
+**Example**:
+```js
+import fs from 'node:fs'
+import path from 'node:path'
+export default {
+  hooks: {
+    build: {
+      done(builder) {
+        const extraFilePath = path.join(
+          builder.nuxt.options.buildDir,
+          'extra-file'
+        )
+        fs.writeFileSync(extraFilePath, 'Something extra')
+      }
+    }
+  }
+}
+```
+
+## ignore
+
+More customizable than `ignorePrefix`: all files matching glob patterns specified inside the `ignore` array will be ignored in building.
+
+- **Type**: `array`
+- **Default**
+```json
+[
+  "**/*.stories.{js,cts,mts,ts,jsx,tsx}",
+  "**/*.{spec,test}.{js,cts,mts,ts,jsx,tsx}",
+  "**/*.d.{cts,mts,ts}",
+  "**/.{pnpm-store,vercel,netlify,output,git,cache,data}",
+  "**/*.sock",
+  ".nuxt/analyze",
+  ".nuxt",
+  "**/-*.*"
+]
+```
+
+## ignoreOptions
+
+Pass options directly to `node-ignore` (which is used by Nuxt to ignore files).
+
+
+**See**: [node-ignore](https://github.com/kaelzhang/node-ignore)
+
+**Example**:
+```js
+ignoreOptions: {
+  ignorecase: false
+}
+```
+
+## ignorePrefix
+
+Any file in `pages/`, `layouts/`, `middleware/`, and `public/` directories will be ignored during the build process if its filename starts with the prefix specified by `ignorePrefix`. This is intended to prevent certain files from being processed or served in the built application. By default, the `ignorePrefix` is set to '-', ignoring any files starting with '-'.
+
+- **Type**: `string`
+- **Default:** `"-"`
+
+## imports
+
+Configure how Nuxt auto-imports composables into your application.
+
+**See**: [Nuxt documentation](https://nuxt.com/docs/guide/directory-structure/composables)
+
+
+### `dirs`
+
+An array of custom directories that will be auto-imported. Note that this option will not override the default directories (~/composables, ~/utils).
+
+- **Type**: `array`
+
+**Example**:
+```js
+imports: {
+  // Auto-import pinia stores defined in `~/stores`
+  dirs: ['stores']
+}
+```
+
+
+### `global`
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+
+### `scan`
+
+Whether to scan your `composables/` and `utils/` directories for composables to auto-import. Auto-imports registered by Nuxt or other modules, such as imports from `vue` or `nuxt`, will still be enabled.
+
+- **Type**: `boolean`
+- **Default:** `true`
+
+## logLevel
+
+Log level when building logs.
+
+Defaults to 'silent' when running in CI or when a TTY is not available. This option is then used as 'silent' in Vite and 'none' in Webpack
+
+- **Type**: `string`
+- **Default:** `"info"`
+
+## modules
+
+Modules are Nuxt extensions which can extend its core functionality and add endless integrations.
+
+Each module is either a string (which can refer to a package, or be a path to a file), a tuple with the module as first string and the options as a second object, or an inline module function.
+Nuxt tries to resolve each item in the modules array using node require path (in `node_modules`) and then will be resolved from project `srcDir` if `~` alias is used.
+
+- **Type**: `array`
+
+::callout
+**Note**: Modules are executed sequentially so the order is important. First, the modules defined in `nuxt.config.ts` are loaded. Then, modules found in the `modules/`
+directory are executed, and they load in alphabetical order.
+::
+
+**Example**:
+```js
+modules: [
+  // Using package name
+  '@nuxtjs/axios',
+  // Relative to your project srcDir
+  '~/modules/awesome.js',
+  // Providing options
+  ['@nuxtjs/google-analytics', { ua: 'X1234567' }],
+  // Inline definition
+  function () {}
+]
+```
+
+## modulesDir
+
+Used to set the modules directories for path resolving (for example, webpack's `resolveLoading`, `nodeExternals` and `postcss`).
+
+The configuration path is relative to `options.rootDir` (default is current working directory).
+Setting this field may be necessary if your project is organized as a yarn workspace-styled mono-repository.
+
+- **Type**: `array`
+- **Default**
+```json
+[
+  "/<rootDir>/node_modules"
+]
+```
+
+**Example**:
+```js
+export default {
+  modulesDir: ['../../node_modules']
+}
+```
+
+## nitro
+
+Configuration for Nitro.
+
+**See**: [Nitro configuration docs](https://nitro.build/config/)
+
+
+### `routeRules`
+
+- **Type**: `object`
+
+
+### `runtimeConfig`
+
+- **Type**: `object`
+- **Default**
+```json
+{
+  "public": {},
+  "app": {
+    "buildId": "4a2e2d30-418f-41df-8e58-ed5df06de7fd",
+    "baseURL": "/",
+    "buildAssetsDir": "/_nuxt/",
+    "cdnURL": ""
+  },
+  "nitro": {
+    "envPrefix": "NUXT_"
+  }
+}
+```
+
+## optimization
+
+Build time optimization configuration.
+
+
+### `asyncTransforms`
+
+Options passed directly to the transformer from `unctx` that preserves async context after `await`.
+
+
+#### `asyncFunctions`
+
+- **Type**: `array`
+- **Default**
+```json
+[
+  "defineNuxtPlugin",
+  "defineNuxtRouteMiddleware"
+]
+```
+
+
+#### `objectDefinitions`
+
+
+##### `defineNuxtComponent`
+
+- **Type**: `array`
+- **Default**
+```json
+[
+  "asyncData",
+  "setup"
+]
+```
+
+
+##### `defineNuxtPlugin`
+
+- **Type**: `array`
+- **Default**
+```json
+[
+  "setup"
+]
+```
+
+
+##### `definePageMeta`
+
+- **Type**: `array`
+- **Default**
+```json
+[
+  "middleware",
+  "validate"
+]
+```
+
+
+### `keyedComposables`
+
+Functions to inject a key for.
+
+As long as the number of arguments passed to the function is less than `argumentLength`, an additional magic string will be injected that can be used to deduplicate requests between server and client. You will need to take steps to handle this additional key.
+The key will be unique based on the location of the function being invoked within the file.
+
+- **Type**: `array`
+- **Default**
+```json
+[
+  {
+    "name": "callOnce",
+    "argumentLength": 3
+  },
+  {
+    "name": "defineNuxtComponent",
+    "argumentLength": 2
+  },
+  {
+    "name": "useState",
+    "argumentLength": 2
+  },
+  {
+    "name": "useFetch",
+    "argumentLength": 3
+  },
+  {
+    "name": "useAsyncData",
+    "argumentLength": 3
+  },
+  {
+    "name": "useLazyAsyncData",
+    "argumentLength": 3
+  },
+  {
+    "name": "useLazyFetch",
+    "argumentLength": 3
+  }
+]
+```
+
+
+### `treeShake`
+
+Tree shake code from specific builds.
+
+
+#### `composables`
+
+Tree shake composables from the server or client builds.
+
+**Example**:
+```js
+treeShake: { client: { myPackage: ['useServerOnlyComposable'] } }
+```
+
+
+##### `client`
+
+- **Type**: `object`
+- **Default**
+```json
+{
+  "vue": [
+    "onRenderTracked",
+    "onRenderTriggered",
+    "onServerPrefetch"
+  ],
+  "#app": [
+    "definePayloadReducer",
+    "definePageMeta",
+    "onPrehydrate"
+  ]
+}
+```
+
+
+##### `server`
+
+- **Type**: `object`
+- **Default**
+```json
+{
+  "vue": [
+    "onMounted",
+    "onUpdated",
+    "onUnmounted",
+    "onBeforeMount",
+    "onBeforeUpdate",
+    "onBeforeUnmount",
+    "onRenderTracked",
+    "onRenderTriggered",
+    "onActivated",
+    "onDeactivated"
+  ],
+  "#app": [
+    "definePayloadReviver",
+    "definePageMeta"
+  ]
+}
+```
+
+## pages
+
+Whether to use the vue-router integration in Nuxt 3. If you do not provide a value it will be enabled if you have a `pages/` directory in your source folder.
+
+Additionally, you can provide a glob pattern or an array of patterns to scan only certain files for pages.
+
+
+**Example**:
+```js
+pages: {
+  pattern: ['**\/*\/*.vue', '!**\/*.spec.*'],
+}
+```
+
+## plugins
+
+An array of nuxt app plugins.
+
+Each plugin can be a string (which can be an absolute or relative path to a file). If it ends with `.client` or `.server` then it will be automatically loaded only in the appropriate context.
+It can also be an object with `src` and `mode` keys.
+
+- **Type**: `array`
+
+::callout
+**Note**: Plugins are also auto-registered from the `~/plugins` directory
+and these plugins do not need to be listed in `nuxt.config` unless you
+need to customize their order. All plugins are deduplicated by their src path.
+::
+
+**See**: [`plugins/` directory documentation](https://nuxt.com/docs/guide/directory-structure/plugins)
+
+**Example**:
+```js
+plugins: [
+  '~/plugins/foo.client.js', // only in client side
+  '~/plugins/bar.server.js', // only in server side
+  '~/plugins/baz.js', // both client & server
+  { src: '~/plugins/both-sides.js' },
+  { src: '~/plugins/client-only.js', mode: 'client' }, // only on client side
+  { src: '~/plugins/server-only.js', mode: 'server' } // only on server side
+]
+```
+
+## postcss
+
+
+### `order`
+
+A strategy for ordering PostCSS plugins.
+
+- **Type**: `function`
+
+
+### `plugins`
+
+Options for configuring PostCSS plugins.
+
+**See**: [PostCSS docs](https://postcss.org/)
+
+
+#### `autoprefixer`
+
+Plugin to parse CSS and add vendor prefixes to CSS rules.
+
+
+**See**: [`autoprefixer`](https://github.com/postcss/autoprefixer)
+
+
+#### `cssnano`
+
+- **Type**: `object`
+
+**See**: [`cssnano` configuration options](https://cssnano.github.io/cssnano/docs/config-file/#configuration-options)
+
+## rootDir
+
+Define the root directory of your application.
+
+This property can be overwritten (for example, running `nuxt ./my-app/` will set the `rootDir` to the absolute path of `./my-app/` from the current/working directory.
+It is normally not needed to configure this option.
+
+- **Type**: `string`
+- **Default:** `"/<rootDir>"`
+
+## routeRules
+
+Global route options applied to matching server routes.
+
+
+**Experimental**: This is an experimental feature and API may change in the future.
+
+**See**: [Nitro route rules documentation](https://nitro.build/config/#routerules)
+
+## router
+
+
+### `options`
+
+Additional router options passed to `vue-router`. On top of the options for `vue-router`, Nuxt offers additional options to customize the router (see below).
+
+::callout
+**Note**: Only JSON serializable options should be passed by Nuxt config.
+For more control, you can use `app/router.options.ts` file.
+::
+
+**See**: [Vue Router documentation](https://router.vuejs.org/api/interfaces/routeroptions.html).
+
+
+#### `hashMode`
+
+You can enable hash history in SPA mode. In this mode, router uses a hash character (#) before the actual URL that is internally passed. When enabled, the **URL is never sent to the server** and **SSR is not supported**.
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+**Default**: false
+
+
+#### `scrollBehaviorType`
+
+Customize the scroll behavior for hash links.
+
+- **Type**: `string`
+- **Default:** `"auto"`
+
+**Default**: 'auto'
+
+## runtimeConfig
+
+Runtime config allows passing dynamic config and environment variables to the Nuxt app context.
+
+The value of this object is accessible from server only using `useRuntimeConfig`.
+It mainly should hold _private_ configuration which is not exposed on the frontend. This could include a reference to your API secret tokens.
+Anything under `public` and `app` will be exposed to the frontend as well.
+Values are automatically replaced by matching env variables at runtime, e.g. setting an environment variable `NUXT_API_KEY=my-api-key NUXT_PUBLIC_BASE_URL=/foo/` would overwrite the two values in the example below.
+
+- **Type**: `object`
+- **Default**
+```json
+{
+  "public": {},
+  "app": {
+    "buildId": "4a2e2d30-418f-41df-8e58-ed5df06de7fd",
+    "baseURL": "/",
+    "buildAssetsDir": "/_nuxt/",
+    "cdnURL": ""
+  }
+}
+```
+
+**Example**:
+```js
+export default {
+ runtimeConfig: {
+    apiKey: '', // Default to an empty string, automatically set at runtime using process.env.NUXT_API_KEY
+    public: {
+       baseURL: '' // Exposed to the frontend as well.
+    }
+  }
+}
+```
+
+## serverDir
+
+Define the server directory of your Nuxt application, where Nitro routes, middleware and plugins are kept.
+
+If a relative path is specified, it will be relative to your `rootDir`.
+
+- **Type**: `string`
+- **Default:** `"/<srcDir>/server"`
+
+## serverHandlers
+
+Nitro server handlers.
+
+Each handler accepts the following options:
+- handler: The path to the file defining the handler. - route: The route under which the handler is available. This follows the conventions of [rou3](https://github.com/unjs/rou3). - method: The HTTP method of requests that should be handled. - middleware: Specifies whether it is a middleware handler. - lazy: Specifies whether to use lazy loading to import the handler.
+
+- **Type**: `array`
+
+**See**: [`server/` directory documentation](https://nuxt.com/docs/guide/directory-structure/server)
+
+::callout
+**Note**: Files from `server/api`, `server/middleware` and `server/routes` will be automatically registered by Nuxt.
+::
+
+**Example**:
+```js
+serverHandlers: [
+  { route: '/path/foo/**:name', handler: '~/server/foohandler.ts' }
+]
+```
+
+## sourcemap
+
+Configures whether and how sourcemaps are generated for server and/or client bundles.
+
+If set to a single boolean, that value applies to both server and client. Additionally, the `'hidden'` option is also available for both server and client.
+Available options for both client and server: - `true`: Generates sourcemaps and includes source references in the final bundle. - `false`: Does not generate any sourcemaps. - `'hidden'`: Generates sourcemaps but does not include references in the final bundle.
+
+- **Type**: `object`
+- **Default**
+```json
+{
+  "server": true,
+  "client": false
+}
+```
+
+## spaLoadingTemplate
+
+Boolean or a path to an HTML file with the contents of which will be inserted into any HTML page rendered with `ssr: false`.
+
+- If it is unset, it will use `~/app/spa-loading-template.html` file in one of your layers, if it exists. - If it is false, no SPA loading indicator will be loaded. - If true, Nuxt will look for `~/app/spa-loading-template.html` file in one of your layers, or a
+  default Nuxt image will be used.
+Some good sources for spinners are [SpinKit](https://github.com/tobiasahlin/SpinKit) or [SVG Spinners](https://icones.js.org/collection/svg-spinners).
+
+- **Default:** `null`
+
+**Example**: ~/app/spa-loading-template.html
+```html
+<!-- https://github.com/barelyhuman/snips/blob/dev/pages/css-loader.md -->
+<div class="loader"></div>
+<style>
+.loader {
+  display: block;
+  position: fixed;
+  z-index: 1031;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 18px;
+  height: 18px;
+  box-sizing: border-box;
+  border: solid 2px transparent;
+  border-top-color: #000;
+  border-left-color: #000;
+  border-bottom-color: #efefef;
+  border-right-color: #efefef;
+  border-radius: 50%;
+  -webkit-animation: loader 400ms linear infinite;
+  animation: loader 400ms linear infinite;
+}
+
+@-webkit-keyframes loader {
+  0% {
+    -webkit-transform: translate(-50%, -50%) rotate(0deg);
+  }
+  100% {
+    -webkit-transform: translate(-50%, -50%) rotate(360deg);
+  }
+}
+@keyframes loader {
+  0% {
+    transform: translate(-50%, -50%) rotate(0deg);
+  }
+  100% {
+    transform: translate(-50%, -50%) rotate(360deg);
+  }
+}
+</style>
+```
+
+## srcDir
+
+Define the source directory of your Nuxt application.
+
+If a relative path is specified, it will be relative to the `rootDir`.
+
+- **Type**: `string`
+- **Default:** `"/<srcDir>"`
+
+**Example**:
+```js
+export default {
+  srcDir: 'src/'
+}
+```
+This would work with the following folder structure:
+```bash
+-| app/
+---| node_modules/
+---| nuxt.config.js
+---| package.json
+---| src/
+------| assets/
+------| components/
+------| layouts/
+------| middleware/
+------| pages/
+------| plugins/
+------| public/
+------| store/
+------| server/
+------| app.config.ts
+------| app.vue
+------| error.vue
+```
+
+## ssr
+
+Whether to enable rendering of HTML - either dynamically (in server mode) or at generate time. If set to `false` generated pages will have no content.
+
+- **Type**: `boolean`
+- **Default:** `true`
+
+## telemetry
+
+Manually disable nuxt telemetry.
+
+
+**See**: [Nuxt Telemetry](https://github.com/nuxt/telemetry) for more information.
+
+## test
+
+Whether your app is being unit tested.
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+## theme
+
+Extend project from a local or remote source.
+
+Value should be a string pointing to source directory or config path relative to current config.
+You can use `github:`, `gitlab:`, `bitbucket:` or `https://` to extend from a remote git repository.
+
+- **Type**: `string`
+
+## typescript
+
+Configuration for Nuxt's TypeScript integration.
+
+
+### `builder`
+
+Which builder types to include for your project.
+
+By default Nuxt infers this based on your `builder` option (defaulting to 'vite') but you can either turn off builder environment types (with `false`) to handle this fully yourself, or opt for a 'shared' option.
+The 'shared' option is advised for module authors, who will want to support multiple possible builders.
+
+- **Default:** `null`
+
+
+### `hoist`
+
+Modules to generate deep aliases for within `compilerOptions.paths`. This does not yet support subpaths. It may be necessary when using Nuxt within a pnpm monorepo with `shamefully-hoist=false`.
+
+- **Type**: `array`
+- **Default**
+```json
+[
+  "nitropack/types",
+  "nitropack/runtime",
+  "nitropack",
+  "defu",
+  "h3",
+  "consola",
+  "ofetch",
+  "@unhead/vue",
+  "@nuxt/devtools",
+  "vue",
+  "@vue/runtime-core",
+  "@vue/compiler-sfc",
+  "vue-router",
+  "vue-router/auto-routes",
+  "unplugin-vue-router/client",
+  "@nuxt/schema",
+  "nuxt"
+]
+```
+
+
+### `includeWorkspace`
+
+Include parent workspace in the Nuxt project. Mostly useful for themes and module authors.
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+
+### `shim`
+
+Generate a `*.vue` shim.
+
+We recommend instead letting the [official Vue extension](https://marketplace.visualstudio.com/items?itemName=Vue.volar) generate accurate types for your components.
+Note that you may wish to set this to `true` if you are using other libraries, such as ESLint, that are unable to understand the type of `.vue` files.
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+
+### `strict`
+
+TypeScript comes with certain checks to give you more safety and analysis of your program. Once you’ve converted your codebase to TypeScript, you can start enabling these checks for greater safety. [Read More](https://www.typescriptlang.org/docs/handbook/migrating-from-javascript.html#getting-stricter-checks)
+
+- **Type**: `boolean`
+- **Default:** `true`
+
+
+### `tsConfig`
+
+You can extend generated `.nuxt/tsconfig.json` using this option.
+
+
+
+### `typeCheck`
+
+Enable build-time type checking.
+
+If set to true, this will type check in development. You can restrict this to build-time type checking by setting it to `build`. Requires to install `typescript` and `vue-tsc` as dev dependencies.
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+**See**: [Nuxt TypeScript docs](https://nuxt.com/docs/guide/concepts/typescript)
+
+## unhead
+
+An object that allows us to configure the `unhead` nuxt module.
+
+
+### `legacy`
+
+Enable the legacy compatibility mode for `unhead` module. This applies the following changes: - Disables Capo.js sorting - Adds the `DeprecationsPlugin`: supports `hid`, `vmid`, `children`, `body` - Adds the `PromisesPlugin`: supports promises as input
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+**See**: [`unhead` migration documentation](https://unhead.unjs.io/docs/typescript/head/guides/get-started/migration)
+
+**Example**:
+```ts
+export default defineNuxtConfig({
+ unhead: {
+  legacy: true
+})
+```
+
+
+### `renderSSRHeadOptions`
+
+An object that will be passed to `renderSSRHead` to customize the output.
+
+- **Type**: `object`
+- **Default**
+```json
+{
+  "omitLineBreaks": false
+}
+```
+
+**Example**:
+```ts
+export default defineNuxtConfig({
+ unhead: {
+  renderSSRHeadOptions: {
+   omitLineBreaks: true
+  }
+})
+```
+
+## vite
+
+Configuration that will be passed directly to Vite.
+
+**See**: [Vite configuration docs](https://vite.dev/config) for more information.
+Please note that not all vite options are supported in Nuxt.
+
+
+### `build`
+
+
+#### `assetsDir`
+
+- **Type**: `string`
+- **Default:** `"_nuxt/"`
+
+
+#### `emptyOutDir`
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+
+### `cacheDir`
+
+- **Type**: `string`
+- **Default:** `"/<rootDir>/node_modules/.cache/vite"`
+
+
+### `clearScreen`
+
+- **Type**: `boolean`
+- **Default:** `true`
+
+
+### `define`
+
+- **Type**: `object`
+- **Default**
+```json
+{
+  "__VUE_PROD_HYDRATION_MISMATCH_DETAILS__": false,
+  "process.dev": false,
+  "import.meta.dev": false,
+  "process.test": false,
+  "import.meta.test": false
+}
+```
+
+
+### `esbuild`
+
+- **Type**: `object`
+- **Default**
+```json
+{
+  "target": "esnext",
+  "jsxFactory": "h",
+  "jsxFragment": "Fragment",
+  "tsconfigRaw": {}
+}
+```
+
+
+### `mode`
+
+- **Type**: `string`
+- **Default:** `"production"`
+
+
+### `optimizeDeps`
+
+
+#### `esbuildOptions`
+
+- **Type**: `object`
+- **Default**
+```json
+{
+  "target": "esnext",
+  "jsxFactory": "h",
+  "jsxFragment": "Fragment",
+  "tsconfigRaw": {}
+}
+```
+
+
+#### `exclude`
+
+- **Type**: `array`
+- **Default**
+```json
+[
+  "vue-demi"
+]
+```
+
+
+### `publicDir`
+
+
+
+### `resolve`
+
+
+#### `extensions`
+
+- **Type**: `array`
+- **Default**
+```json
+[
+  ".mjs",
+  ".js",
+  ".ts",
+  ".jsx",
+  ".tsx",
+  ".json",
+  ".vue"
+]
+```
+
+
+### `root`
+
+- **Type**: `string`
+- **Default:** `"/<srcDir>"`
+
+
+### `server`
+
+
+#### `fs`
+
+
+##### `allow`
+
+- **Type**: `array`
+- **Default**
+```json
+[
+  "/<rootDir>/.nuxt",
+  "/<srcDir>",
+  "/<rootDir>",
+  "/<workspaceDir>"
+]
+```
+
+
+### `vue`
+
+
+#### `features`
+
+
+##### `propsDestructure`
+
+- **Type**: `boolean`
+- **Default:** `true`
+
+
+#### `isProduction`
+
+- **Type**: `boolean`
+- **Default:** `true`
+
+
+#### `script`
+
+
+##### `hoistStatic`
+
+
+
+#### `template`
+
+
+##### `compilerOptions`
+
+- **Type**: `object`
+
+
+##### `transformAssetUrls`
+
+- **Type**: `object`
+- **Default**
+```json
+{
+  "video": [
+    "src",
+    "poster"
+  ],
+  "source": [
+    "src"
+  ],
+  "img": [
+    "src"
+  ],
+  "image": [
+    "xlink:href",
+    "href"
+  ],
+  "use": [
+    "xlink:href",
+    "href"
+  ]
+}
+```
+
+
+### `vueJsx`
+
+- **Type**: `object`
+- **Default**
+```json
+{
+  "isCustomElement": {
+    "$schema": {
+      "title": "",
+      "description": "",
+      "tags": []
+    }
+  }
+}
+```
+
+## vue
+
+Vue.js config
+
+
+### `compilerOptions`
+
+Options for the Vue compiler that will be passed at build time.
+
+
+**See**: [Vue documentation](https://vuejs.org/api/application.html#app-config-compileroptions)
+
+
+### `config`
+
+It is possible to pass configure the Vue app globally. Only serializable options may be set in your `nuxt.config`. All other options should be set at runtime in a Nuxt plugin..
+
+
+**See**: [Vue app config documentation](https://vuejs.org/api/application.html#app-config)
+
+
+### `propsDestructure`
+
+Enable reactive destructure for `defineProps`
+
+- **Type**: `boolean`
+- **Default:** `true`
+
+
+### `runtimeCompiler`
+
+Include Vue compiler in runtime bundle.
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+
+### `transformAssetUrls`
+
+
+#### `image`
+
+- **Type**: `array`
+- **Default**
+```json
+[
+  "xlink:href",
+  "href"
+]
+```
+
+
+#### `img`
+
+- **Type**: `array`
+- **Default**
+```json
+[
+  "src"
+]
+```
+
+
+#### `source`
+
+- **Type**: `array`
+- **Default**
+```json
+[
+  "src"
+]
+```
+
+
+#### `use`
+
+- **Type**: `array`
+- **Default**
+```json
+[
+  "xlink:href",
+  "href"
+]
+```
+
+
+#### `video`
+
+- **Type**: `array`
+- **Default**
+```json
+[
+  "src",
+  "poster"
+]
+```
+
+## watch
+
+The watch property lets you define patterns that will restart the Nuxt dev server when changed.
+
+It is an array of strings or regular expressions. Strings should be either absolute paths or relative to the `srcDir` (and the `srcDir` of any layers). Regular expressions will be matched against the path relative to the project `srcDir` (and the `srcDir` of any layers).
+
+- **Type**: `array`
+
+## watchers
+
+The watchers property lets you overwrite watchers configuration in your `nuxt.config`.
+
+
+### `chokidar`
+
+Options to pass directly to `chokidar`.
+
+**See**: [chokidar](https://github.com/paulmillr/chokidar#api)
+
+
+#### `ignoreInitial`
+
+- **Type**: `boolean`
+- **Default:** `true`
+
+
+#### `ignorePermissionErrors`
+
+- **Type**: `boolean`
+- **Default:** `true`
+
+
+### `rewatchOnRawEvents`
+
+An array of event types, which, when received, will cause the watcher to restart.
+
+
+
+### `webpack`
+
+`watchOptions` to pass directly to webpack.
+
+**See**: [webpack@4 watch options](https://v4.webpack.js.org/configuration/watch/#watchoptions).
+
+
+#### `aggregateTimeout`
+
+- **Type**: `number`
+- **Default:** `1000`
+
+## webpack
+
+
+### `aggressiveCodeRemoval`
+
+Hard-replaces `typeof process`, `typeof window` and `typeof document` to tree-shake bundle.
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+
+### `analyze`
+
+Nuxt uses `webpack-bundle-analyzer` to visualize your bundles and how to optimize them.
+
+Set to `true` to enable bundle analysis, or pass an object with options: [for webpack](https://github.com/webpack-contrib/webpack-bundle-analyzer#options-for-plugin) or [for vite](https://github.com/btd/rollup-plugin-visualizer#options).
+
+- **Type**: `object`
+- **Default**
+```json
+{
+  "template": "treemap",
+  "projectRoot": "/<rootDir>",
+  "filename": "/<rootDir>/.nuxt/analyze/{name}.html"
+}
+```
+
+**Example**:
+```js
+analyze: {
+  analyzerMode: 'static'
+}
+```
+
+
+### `cssSourceMap`
+
+Enables CSS source map support (defaults to `true` in development).
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+
+### `devMiddleware`
+
+See [webpack-dev-middleware](https://github.com/webpack/webpack-dev-middleware) for available options.
+
+
+#### `stats`
+
+- **Type**: `string`
+- **Default:** `"none"`
+
+
+### `experiments`
+
+Configure [webpack experiments](https://webpack.js.org/configuration/experiments/)
+
+
+
+### `extractCSS`
+
+Enables Common CSS Extraction.
+
+Using [mini-css-extract-plugin](https://github.com/webpack-contrib/mini-css-extract-plugin) under the hood, your CSS will be extracted into separate files, usually one per component. This allows caching your CSS and JavaScript separately.
+
+- **Type**: `boolean`
+- **Default:** `true`
+
+**Example**:
+```js
+export default {
+  webpack: {
+    extractCSS: true,
+    // or
+    extractCSS: {
+      ignoreOrder: true
+    }
+  }
+}
+```
+
+<!-- If you want to extract all your CSS to a single file, there is a workaround for this.
+However, note that it is not recommended to extract everything into a single file.
+Extracting into multiple CSS files is better for caching and preload isolation. It
+can also improve page performance by downloading and resolving only those resources
+that are needed. -->
+**Example**:
+```js
+export default {
+  webpack: {
+    extractCSS: true,
+    optimization: {
+      splitChunks: {
+        cacheGroups: {
+          styles: {
+            name: 'styles',
+            test: /\.(css|vue)$/,
+            chunks: 'all',
+            enforce: true
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+
+### `filenames`
+
+Customize bundle filenames.
+
+To understand a bit more about the use of manifests, take a look at [webpack documentation](https://webpack.js.org/guides/code-splitting/).
+
+::callout
+**Note**: Be careful when using non-hashed based filenames in production
+as most browsers will cache the asset and not detect the changes on first load.
+::
+
+<!-- This example changes fancy chunk names to numerical ids: -->
+**Example**:
+```js
+filenames: {
+  chunk: ({ isDev }) => (isDev ? '[name].js' : '[id].[contenthash].js')
+}
+```
+
+
+#### `app`
+
+- **Type**: `function`
+
+
+#### `chunk`
+
+- **Type**: `function`
+
+
+#### `css`
+
+- **Type**: `function`
+
+
+#### `font`
+
+- **Type**: `function`
+
+
+#### `img`
+
+- **Type**: `function`
+
+
+#### `video`
+
+- **Type**: `function`
+
+
+### `friendlyErrors`
+
+Set to `false` to disable the overlay provided by [FriendlyErrorsWebpackPlugin](https://github.com/nuxt/friendly-errors-webpack-plugin).
+
+- **Type**: `boolean`
+- **Default:** `true`
+
+
+### `hotMiddleware`
+
+See [webpack-hot-middleware](https://github.com/webpack-contrib/webpack-hot-middleware) for available options.
+
+
+
+### `loaders`
+
+Customize the options of Nuxt's integrated webpack loaders.
+
+
+#### `css`
+
+See [css-loader](https://github.com/webpack-contrib/css-loader) for available options.
+
+
+##### `esModule`
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+
+##### `importLoaders`
+
+- **Type**: `number`
+- **Default:** `0`
+
+
+##### `url`
+
+
+###### `filter`
+
+- **Type**: `function`
+
+
+#### `cssModules`
+
+See [css-loader](https://github.com/webpack-contrib/css-loader) for available options.
+
+
+##### `esModule`
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+
+##### `importLoaders`
+
+- **Type**: `number`
+- **Default:** `0`
+
+
+##### `modules`
+
+
+###### `localIdentName`
+
+- **Type**: `string`
+- **Default:** `"[local]_[hash:base64:5]"`
+
+
+##### `url`
+
+
+###### `filter`
+
+- **Type**: `function`
+
+
+#### `esbuild`
+
+- **Type**: `object`
+- **Default**
+```json
+{
+  "target": "esnext",
+  "jsxFactory": "h",
+  "jsxFragment": "Fragment",
+  "tsconfigRaw": {}
+}
+```
+
+**See**: [esbuild loader](https://github.com/esbuild-kit/esbuild-loader)
+
+
+#### `file`
+
+**See**: [`file-loader` Options](https://github.com/webpack-contrib/file-loader#options)
+
+**Default**:
+```ts
+{ esModule: false }
+```
+
+
+##### `esModule`
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+
+##### `limit`
+
+- **Type**: `number`
+- **Default:** `1000`
+
+
+#### `fontUrl`
+
+**See**: [`file-loader` Options](https://github.com/webpack-contrib/file-loader#options)
+
+**Default**:
+```ts
+{ esModule: false }
+```
+
+
+##### `esModule`
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+
+##### `limit`
+
+- **Type**: `number`
+- **Default:** `1000`
+
+
+#### `imgUrl`
+
+**See**: [`file-loader` Options](https://github.com/webpack-contrib/file-loader#options)
+
+**Default**:
+```ts
+{ esModule: false }
+```
+
+
+##### `esModule`
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+
+##### `limit`
+
+- **Type**: `number`
+- **Default:** `1000`
+
+
+#### `less`
+
+- **Default**
+```json
+{
+  "sourceMap": false
+}
+```
+
+**See**: [`less-loader` Options](https://github.com/webpack-contrib/less-loader#options)
+
+
+#### `pugPlain`
+
+
+**See**: [`pug` options](https://pugjs.org/api/reference.html#options)
+
+
+#### `sass`
+
+**See**: [`sass-loader` Options](https://github.com/webpack-contrib/sass-loader#options)
+
+**Default**:
+```ts
+{
+  sassOptions: {
+    indentedSyntax: true
+  }
+}
+```
+
+
+##### `sassOptions`
+
+
+###### `indentedSyntax`
+
+- **Type**: `boolean`
+- **Default:** `true`
+
+
+#### `scss`
+
+- **Default**
+```json
+{
+  "sourceMap": false
+}
+```
+
+**See**: [`sass-loader` Options](https://github.com/webpack-contrib/sass-loader#options)
+
+
+#### `stylus`
+
+- **Default**
+```json
+{
+  "sourceMap": false
+}
+```
+
+**See**: [`stylus-loader` Options](https://github.com/webpack-contrib/stylus-loader#options)
+
+
+#### `vue`
+
+See [vue-loader](https://github.com/vuejs/vue-loader) for available options.
+
+
+##### `compilerOptions`
+
+- **Type**: `object`
+
+
+##### `propsDestructure`
+
+- **Type**: `boolean`
+- **Default:** `true`
+
+
+##### `transformAssetUrls`
+
+- **Type**: `object`
+- **Default**
+```json
+{
+  "video": [
+    "src",
+    "poster"
+  ],
+  "source": [
+    "src"
+  ],
+  "img": [
+    "src"
+  ],
+  "image": [
+    "xlink:href",
+    "href"
+  ],
+  "use": [
+    "xlink:href",
+    "href"
+  ]
+}
+```
+
+
+#### `vueStyle`
+
+- **Default**
+```json
+{
+  "sourceMap": false
+}
+```
+
+
+### `optimization`
+
+Configure [webpack optimization](https://webpack.js.org/configuration/optimization/).
+
+
+#### `minimize`
+
+Set minimize to `false` to disable all minimizers. (It is disabled in development by default).
+
+- **Type**: `boolean`
+- **Default:** `true`
+
+
+#### `minimizer`
+
+You can set minimizer to a customized array of plugins.
+
+
+
+#### `runtimeChunk`
+
+- **Type**: `string`
+- **Default:** `"single"`
+
+
+#### `splitChunks`
+
+
+##### `automaticNameDelimiter`
+
+- **Type**: `string`
+- **Default:** `"/"`
+
+
+##### `cacheGroups`
+
+
+
+##### `chunks`
+
+- **Type**: `string`
+- **Default:** `"all"`
+
+
+### `optimizeCSS`
+
+OptimizeCSSAssets plugin options.
+
+Defaults to true when `extractCSS` is enabled.
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+**See**: [css-minimizer-webpack-plugin documentation](https://github.com/webpack-contrib/css-minimizer-webpack-plugin).
+
+
+### `plugins`
+
+Add webpack plugins.
+
+- **Type**: `array`
+
+**Example**:
+```js
+import webpack from 'webpack'
+import { version } from './package.json'
+// ...
+plugins: [
+  new webpack.DefinePlugin({
+    'process.VERSION': version
+  })
+]
+```
+
+
+### `postcss`
+
+Customize PostCSS Loader. same options as [`postcss-loader` options](https://github.com/webpack-contrib/postcss-loader#options)
+
+
+#### `postcssOptions`
+
+
+##### `plugins`
+
+- **Type**: `object`
+- **Default**
+```json
+{
+  "autoprefixer": {},
+  "cssnano": {}
+}
+```
+
+
+### `profile`
+
+Enable the profiler in webpackbar.
+
+It is normally enabled by CLI argument `--profile`.
+
+- **Type**: `boolean`
+- **Default:** `false`
+
+**See**: [webpackbar](https://github.com/unjs/webpackbar#profile).
+
+
+### `serverURLPolyfill`
+
+The polyfill library to load to provide URL and URLSearchParams.
+
+Defaults to `'url'` ([see package](https://www.npmjs.com/package/url)).
+
+- **Type**: `string`
+- **Default:** `"url"`
+
+
+### `warningIgnoreFilters`
+
+Filters to hide build warnings.
+
+- **Type**: `array`
+
+## workspaceDir
+
+Define the workspace directory of your application.
+
+Often this is used when in a monorepo setup. Nuxt will attempt to detect your workspace directory automatically, but you can override it here.
+It is normally not needed to configure this option.
+
+- **Type**: `string`
+- **Default:** `"/<workspaceDir>"`

--- a/docs/3.api/6.nuxt-config.md
+++ b/docs/3.api/6.nuxt-config.md
@@ -47,7 +47,7 @@ export default {
 }
 ```
 
-<!-- ```html
+```html
 <template>
   <img src="~images/main-bg.jpg">
 </template>
@@ -65,7 +65,8 @@ body {
   background-image: url('~images/main-bg.jpg');
 }
 </style>
-``` -->
+```
+
 ## analyzeDir
 
 The directory where Nuxt will store the generated files when running `nuxt analyze`.
@@ -97,7 +98,8 @@ export default defineNuxtConfig({
 })
 ```
 
-<!-- This can also be set at runtime by setting the NUXT_APP_BASE_URL environment variable. -->
+This can also be set at runtime by setting the NUXT_APP_BASE_URL environment variable.
+
 **Example**:
 ```bash
 NUXT_APP_BASE_URL=/prefix/ node .output/server/index.mjs
@@ -128,7 +130,8 @@ export default defineNuxtConfig({
 })
 ```
 
-<!-- This can be set to a different value at runtime by setting the `NUXT_APP_CDN_URL` environment variable. -->
+This can be set to a different value at runtime by setting the `NUXT_APP_CDN_URL` environment variable.
+
 **Example**:
 ```bash
 NUXT_APP_CDN_URL=https://mycdn.org/ node .output/server/index.mjs
@@ -737,12 +740,13 @@ Automatically polyfill Node.js imports in the client build using `unenv`.
 
 **See**: [unenv](https://github.com/unjs/unenv)
 
-<!-- **Note:** To make globals like `Buffer` work in the browser, you need to manually inject them. -->
-<!-- ```ts
+**Note:** To make globals like `Buffer` work in the browser, you need to manually inject them.
+
+```ts
 import { Buffer } from 'node:buffer'
 
 globalThis.Buffer = globalThis.Buffer || Buffer
-``` -->
+```
 
 ### `compileTemplate`
 
@@ -1343,8 +1347,6 @@ You can set it to false to use the legacy 'Node' mode, which is the default for 
 This option is no longer used. Instead, use `nitro.prerender.ignore`.
 
 - **Type**: `array`
-
-<!-- @deprecated -->
 
 ### `routes`
 
@@ -2535,11 +2537,12 @@ export default {
 }
 ```
 
-<!-- If you want to extract all your CSS to a single file, there is a workaround for this.
+If you want to extract all your CSS to a single file, there is a workaround for this.
 However, note that it is not recommended to extract everything into a single file.
 Extracting into multiple CSS files is better for caching and preload isolation. It
 can also improve page performance by downloading and resolving only those resources
-that are needed. -->
+that are needed.
+
 **Example**:
 ```js
 export default {
@@ -2572,7 +2575,8 @@ To understand a bit more about the use of manifests, take a look at [webpack doc
 as most browsers will cache the asset and not detect the changes on first load.
 ::
 
-<!-- This example changes fancy chunk names to numerical ids: -->
+This example changes fancy chunk names to numerical ids:
+
 **Example**:
 ```js
 filenames: {

--- a/lychee.toml
+++ b/lychee.toml
@@ -37,4 +37,5 @@ exclude = [
   # excluded URLs from test suite
   "http://auth.com",
   "http://example2.com/",
+  "~images/main-bg.jpg",
 ]

--- a/packages/schema/build.config.ts
+++ b/packages/schema/build.config.ts
@@ -4,20 +4,6 @@ import { stubOptions } from '../../debug/build-config'
 export default defineBuildConfig({
   declaration: true,
   entries: [
-    {
-      input: 'src/config/index',
-      outDir: 'schema',
-      name: 'config',
-      builder: 'untyped',
-      defaults: {
-        srcDir: '/<srcDir>/',
-        workspaceDir: '/<workspaceDir>/',
-        rootDir: '/<rootDir>/',
-        vite: {
-          base: '/',
-        },
-      },
-    },
     'src/index',
     'src/builder-env',
   ],

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -22,7 +22,6 @@
       "types": "./dist/builder-env.d.ts",
       "import": "./dist/builder-env.mjs"
     },
-    "./schema/config.schema.json": "./schema/config.schema.json",
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/schema/src/config/adhoc.ts
+++ b/packages/schema/src/config/adhoc.ts
@@ -7,7 +7,6 @@ export default defineResolvers({
    * Any components in the directories configured here can be used throughout your
    * pages, layouts (and other components) without needing to explicitly import them.
    * @see [`components/` directory documentation](https://nuxt.com/docs/guide/directory-structure/components)
-   * @type {boolean | typeof import('../src/types/components').ComponentsOptions | typeof import('../src/types/components').ComponentsOptions['dirs']}
    */
   components: {
     $resolve: (val) => {
@@ -27,7 +26,6 @@ export default defineResolvers({
   /**
    * Configure how Nuxt auto-imports composables into your application.
    * @see [Nuxt documentation](https://nuxt.com/docs/guide/directory-structure/composables)
-   * @type {typeof import('../src/types/imports').ImportsOptions}
    */
   imports: {
     global: false,
@@ -63,14 +61,12 @@ export default defineResolvers({
    *   pattern: ['**\/*\/*.vue', '!**\/*.spec.*'],
    * }
    * ```
-   * @type {boolean | { enabled?: boolean, pattern?: string | string[] }}
    */
   pages: undefined,
 
   /**
    * Manually disable nuxt telemetry.
    * @see [Nuxt Telemetry](https://github.com/nuxt/telemetry) for more information.
-   * @type {boolean | Record<string, any>}
    */
   telemetry: undefined,
 
@@ -79,7 +75,6 @@ export default defineResolvers({
    *
    * Breaking changes for devtools might not reflect on the version of Nuxt.
    * @see  [Nuxt DevTools](https://devtools.nuxt.com/) for more information.
-   * @type { { enabled: boolean, [key: string]: any } }
    */
   devtools: {},
 })

--- a/packages/schema/src/config/app.ts
+++ b/packages/schema/src/config/app.ts
@@ -9,7 +9,6 @@ export default defineResolvers({
    * Vue.js config
    */
   vue: {
-    /** @type {typeof import('@vue/compiler-sfc').AssetURLTagConfig} */
     transformAssetUrls: {
       video: ['src', 'poster'],
       source: ['src'],
@@ -20,7 +19,6 @@ export default defineResolvers({
     /**
      * Options for the Vue compiler that will be passed at build time.
      * @see [Vue documentation](https://vuejs.org/api/application.html#app-config-compileroptions)
-     * @type {typeof import('@vue/compiler-core').CompilerOptions}
      */
     compilerOptions: {},
 
@@ -44,7 +42,6 @@ export default defineResolvers({
 
     /**
      * Enable reactive destructure for `defineProps`
-     * @type {boolean}
      */
     propsDestructure: true,
 
@@ -156,7 +153,6 @@ export default defineResolvers({
      *   }
      * }
      * ```
-     * @type {typeof import('../src/types/config').NuxtAppConfig['head']}
      */
     head: {
       $resolve: async (_val, get) => {
@@ -198,7 +194,6 @@ export default defineResolvers({
      * This can be overridden with `definePageMeta` on an individual page.
      * Only JSON-serializable values are allowed.
      * @see [Vue Transition docs](https://vuejs.org/api/built-in-components.html#transition)
-     * @type {typeof import('../src/types/config').NuxtAppConfig['layoutTransition']}
      */
     layoutTransition: false,
 
@@ -208,7 +203,6 @@ export default defineResolvers({
      * This can be overridden with `definePageMeta` on an individual page.
      * Only JSON-serializable values are allowed.
      * @see [Vue Transition docs](https://vuejs.org/api/built-in-components.html#transition)
-     * @type {typeof import('../src/types/config').NuxtAppConfig['pageTransition']}
      */
     pageTransition: false,
 
@@ -220,7 +214,6 @@ export default defineResolvers({
      *
      * This can be overridden with `definePageMeta` on an individual page.
      * @see [Nuxt View Transition API docs](https://nuxt.com/docs/getting-started/transitions#view-transitions-api-experimental)
-     * @type {typeof import('../src/types/config').NuxtAppConfig['viewTransition']}
      */
     viewTransition: {
       $resolve: async (val, get) => {
@@ -238,13 +231,11 @@ export default defineResolvers({
      * This can be overridden with `definePageMeta` on an individual page.
      * Only JSON-serializable values are allowed.
      * @see [Vue KeepAlive](https://vuejs.org/api/built-in-components.html#keepalive)
-     * @type {typeof import('../src/types/config').NuxtAppConfig['keepalive']}
      */
     keepalive: false,
 
     /**
      * Customize Nuxt root element id.
-     * @type {string | false}
      * @deprecated Prefer `rootAttrs.id` instead
      */
     rootId: {
@@ -260,7 +251,6 @@ export default defineResolvers({
 
     /**
      * Customize Nuxt root element id.
-     * @type {typeof import('../src/types/head').SerializableHtmlAttributes}
      */
     rootAttrs: {
       $resolve: async (val, get) => {
@@ -281,7 +271,6 @@ export default defineResolvers({
 
     /**
      * Customize Nuxt Teleport element id.
-     * @type {string | false}
      * @deprecated Prefer `teleportAttrs.id` instead
      */
     teleportId: {
@@ -290,7 +279,6 @@ export default defineResolvers({
 
     /**
      * Customize Nuxt Teleport element attributes.
-     * @type {typeof import('../src/types/head').SerializableHtmlAttributes}
      */
     teleportAttrs: {
       $resolve: async (val, get) => {
@@ -311,7 +299,6 @@ export default defineResolvers({
 
     /**
      * Customize Nuxt Nuxt SpaLoader element attributes.
-     * @type {typeof import('../src/types/head').SerializableHtmlAttributes}
      */
     spaLoaderAttrs: {
       id: '__nuxt-loader',
@@ -371,7 +358,6 @@ export default defineResolvers({
    * }
    * </style>
    * ```
-   * @type {string | boolean | undefined | null}
    */
   spaLoadingTemplate: {
     $resolve: async (val, get) => {
@@ -408,7 +394,6 @@ export default defineResolvers({
    *   { src: '~/plugins/server-only.js', mode: 'server' } // only on server side
    * ]
    * ```
-   * @type {(typeof import('../src/types/nuxt').NuxtPlugin | string)[]}
    */
   plugins: [],
 
@@ -430,7 +415,6 @@ export default defineResolvers({
    *   '~/assets/css/main.scss'
    * ]
    * ```
-   * @type {string[]}
    */
   css: {
     $resolve: (val) => {
@@ -469,7 +453,6 @@ export default defineResolvers({
      *   legacy: true
      * })
      * ```
-     * @type {boolean}
      */
     legacy: false,
     /**
@@ -484,7 +467,6 @@ export default defineResolvers({
      *   }
      * })
      * ```
-     * @type {typeof import('@unhead/vue/types').RenderSSRHeadOptions}
      */
     renderSSRHeadOptions: {
       $resolve: async (val, get) => {

--- a/packages/schema/src/config/build.ts
+++ b/packages/schema/src/config/build.ts
@@ -2,13 +2,12 @@ import { defu } from 'defu'
 import { join } from 'pathe'
 import { isTest } from 'std-env'
 import { consola } from 'consola'
-import type { Nuxt } from 'nuxt/schema'
+import type { Nuxt } from '@nuxt/schema'
 import { defineResolvers } from '../utils/definition'
 
 export default defineResolvers({
   /**
    * The builder to use for bundling the Vue part of your application.
-   * @type {'vite' | 'webpack' | 'rspack' | { bundle: (nuxt: typeof import('../src/types/nuxt').Nuxt) => Promise<void> }}
    */
   builder: {
     $resolve: async (val, get) => {
@@ -44,7 +43,6 @@ export default defineResolvers({
    * - `false`: Does not generate any sourcemaps.
    * - `'hidden'`: Generates sourcemaps but does not include references in the final bundle.
    *
-   * @type {boolean | { server?: boolean | 'hidden', client?: boolean | 'hidden' }}
    */
   sourcemap: {
     $resolve: async (val, get) => {
@@ -64,7 +62,6 @@ export default defineResolvers({
    *
    * Defaults to 'silent' when running in CI or when a TTY is not available.
    * This option is then used as 'silent' in Vite and 'none' in Webpack
-   * @type {'silent' | 'info' | 'verbose'}
    */
   logLevel: {
     $resolve: (val) => {
@@ -89,7 +86,6 @@ export default defineResolvers({
      * ```js
      * transpile: [({ isLegacy }) => isLegacy && 'ky']
      * ```
-     * @type {Array<string | RegExp | ((ctx: { isClient?: boolean; isServer?: boolean; isDev: boolean }) => string | RegExp | false)>}
      */
     transpile: {
       $resolve: (val) => {
@@ -120,7 +116,6 @@ export default defineResolvers({
      *   }
      * ]
      * ```
-     * @type {typeof import('../src/types/nuxt').NuxtTemplate<any>[]}
      */
     templates: [],
 
@@ -134,7 +129,6 @@ export default defineResolvers({
      *   analyzerMode: 'static'
      * }
      * ```
-     * @type {boolean | { enabled?: boolean } & ((0 extends 1 & typeof import('webpack-bundle-analyzer').BundleAnalyzerPlugin.Options ? Record<string, unknown> : typeof import('webpack-bundle-analyzer').BundleAnalyzerPlugin.Options) | typeof import('rollup-plugin-visualizer').PluginVisualizerOptions)}
      */
     analyze: {
       $resolve: async (val, get) => {
@@ -161,7 +155,6 @@ export default defineResolvers({
      * and client. You will need to take steps to handle this additional key.
      *
      * The key will be unique based on the location of the function being invoked within the file.
-     * @type {Array<{ name: string, source?: string | RegExp, argumentLength: number }>}
      */
     keyedComposables: {
       $resolve: val => [
@@ -214,7 +207,6 @@ export default defineResolvers({
     /**
      * Options passed directly to the transformer from `unctx` that preserves async context
      * after `await`.
-     * @type {typeof import('unctx/transform').TransformerOptions}
      */
     asyncTransforms: {
       asyncFunctions: ['defineNuxtPlugin', 'defineNuxtRouteMiddleware'],

--- a/packages/schema/src/config/build.ts
+++ b/packages/schema/src/config/build.ts
@@ -2,7 +2,7 @@ import { defu } from 'defu'
 import { join } from 'pathe'
 import { isTest } from 'std-env'
 import { consola } from 'consola'
-import type { Nuxt } from '@nuxt/schema'
+import type { Nuxt } from '../types/nuxt'
 import { defineResolvers } from '../utils/definition'
 
 export default defineResolvers({

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -19,7 +19,6 @@ export default defineResolvers({
    * You can use `github:`, `gh:` `gitlab:` or `bitbucket:`
    * @see [`c12` docs on extending config layers](https://github.com/unjs/c12#extending-config-layer-from-remote-sources)
    * @see [`giget` documentation](https://github.com/unjs/giget)
-   * @type {string | [string, typeof import('c12').SourceOptions?] | (string | [string, typeof import('c12').SourceOptions?])[]}
    */
   extends: undefined,
 
@@ -31,7 +30,6 @@ export default defineResolvers({
    *
    * We plan to improve the tooling around this feature in the future.
    *
-   * @type {typeof import('compatx').CompatibilityDateSpec}
    */
   compatibilityDate: undefined,
 
@@ -41,7 +39,6 @@ export default defineResolvers({
    * Value should be a string pointing to source directory or config path relative to current config.
    *
    * You can use `github:`, `gitlab:`, `bitbucket:` or `https://` to extend from a remote git repository.
-   * @type {string}
    */
   theme: undefined,
 
@@ -277,7 +274,6 @@ export default defineResolvers({
    *
    * You can also set this to an object to enable specific debug options.
    *
-   * @type {boolean | (typeof import('../src/types/debug').NuxtDebugOptions) | undefined}
    */
   debug: {
     $resolve: (val) => {
@@ -334,7 +330,6 @@ export default defineResolvers({
    *   function () {}
    * ]
    * ```
-   * @type {(typeof import('../src/types/module').NuxtModule<any> | string | [typeof import('../src/types/module').NuxtModule | string, Record<string, any>] | undefined | null | false)[]}
    */
   modules: {
     $resolve: (val) => {
@@ -498,7 +493,6 @@ export default defineResolvers({
    * }
    * </style>
    * ```
-   * @type {Record<string, string>}
    */
   alias: {
     $resolve: async (val, get) => {
@@ -527,7 +521,6 @@ export default defineResolvers({
    *   ignorecase: false
    * }
    * ```
-   * @type {typeof import('ignore').Options}
    */
   ignoreOptions: undefined,
 
@@ -577,7 +570,6 @@ export default defineResolvers({
    * It is an array of strings or regular expressions. Strings should be either absolute paths or
    * relative to the `srcDir` (and the `srcDir` of any layers). Regular expressions will be matched
    * against the path relative to the project `srcDir` (and the `srcDir` of any layers).
-   * @type {Array<string | RegExp>}
    */
   watch: {
     $resolve: (val) => {
@@ -604,7 +596,6 @@ export default defineResolvers({
     /**
      * Options to pass directly to `chokidar`.
      * @see [chokidar](https://github.com/paulmillr/chokidar#api)
-     * @type {typeof import('chokidar').ChokidarOptions}
      */
     chokidar: {
       ignoreInitial: true,
@@ -638,7 +629,6 @@ export default defineResolvers({
    *   }
    * }
    * ```
-   * @type {typeof import('../src/types/hooks').NuxtHooks}
    */
   hooks: undefined,
 
@@ -665,7 +655,6 @@ export default defineResolvers({
    *   }
    * }
    * ```
-   * @type {typeof import('../src/types/config').RuntimeConfig}
    */
   runtimeConfig: {
     $resolve: async (_val, get) => {
@@ -689,7 +678,6 @@ export default defineResolvers({
    *
    * For programmatic usage and type support, you can directly provide app config with this option.
    * It will be merged with `app.config` file as default value.
-   * @type {typeof import('../src/types/config').AppConfig}
    */
   appConfig: {
     nuxt: {},

--- a/packages/schema/src/config/dev.ts
+++ b/packages/schema/src/config/dev.ts
@@ -16,7 +16,6 @@ export default defineResolvers({
      *   }
      * })
      * ```
-     * @type {boolean | { key: string; cert: string } | { pfx: string; passphrase: string }}
      */
     https: false,
 
@@ -25,7 +24,6 @@ export default defineResolvers({
 
     /**
      * Dev server listening host
-     * @type {string | undefined}
      */
     host: process.env.NUXT_HOST || process.env.NITRO_HOST || process.env.HOST || undefined,
 
@@ -39,13 +37,11 @@ export default defineResolvers({
 
     /**
      * Template to show a loading screen
-     * @type {(data: { loading?: string }) => string}
      */
     loadingTemplate,
 
     /**
      * Set CORS options for the dev server
-     * @type {typeof import('h3').H3CorsOptions}
      */
     cors: {
       origin: [/^https?:\/\/(?:(?:[^:]+\.)?localhost|127\.0\.0\.1|\[::1\])(?::\d+)?$/],

--- a/packages/schema/src/config/esbuild.ts
+++ b/packages/schema/src/config/esbuild.ts
@@ -6,7 +6,6 @@ export default defineResolvers({
   esbuild: {
     /**
      * Configure shared esbuild options used within Nuxt and passed to other builders, such as Vite or Webpack.
-     * @type {import('esbuild').TransformOptions}
      */
     options: {
       target: {

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -10,7 +10,6 @@ export default defineResolvers({
      * Enable early access to future features or flags.
      *
      * It is currently not configurable but may be in future.
-     * @type {4}
      */
     compatibilityVersion: 4,
     /**
@@ -50,7 +49,6 @@ export default defineResolvers({
      *
      * You can also pass a function that receives the path of a Vue component
      * and returns a boolean indicating whether to inline the styles for that component.
-     * @type {boolean | ((id?: string) => boolean)}
      */
     inlineStyles: {
       async $resolve (_val, get) {
@@ -77,7 +75,6 @@ export default defineResolvers({
      * be handled in the `dev:ssr-logs` hook.
      *
      * If set to `silent`, the logs will not be printed to the browser console.
-     * @type {boolean | 'silent'}
      */
     devLogs: {
       async $resolve (val, get) {
@@ -94,7 +91,6 @@ export default defineResolvers({
      * You can also disable scripts more granularly within `routeRules`.
      *
      * If set to 'production' or `true`, JS will be disabled in production mode only.
-     * @type {'production' | 'all' | boolean}
      */
     noScripts: {
       async $resolve (val, get) {
@@ -151,7 +147,6 @@ export default defineResolvers({
      * You can disable automatic handling by setting this to `false`, or handle
      * chunk errors manually by setting it to `manual`.
      * @see [Nuxt PR #19038](https://github.com/nuxt/nuxt/pull/19038)
-     * @type {false | 'manual' | 'automatic' | 'automatic-immediate'}
      */
     emitRouteChunkError: {
       $resolve: (val) => {
@@ -196,7 +191,6 @@ export default defineResolvers({
      * Consider carefully before enabling this as it can cause unexpected behavior, and
      * consider providing explicit keys to `useState` as auto-generated keys may not match
      * across builds.
-     * @type {boolean}
      */
     restoreState: false,
 
@@ -210,7 +204,6 @@ export default defineResolvers({
 
     /**
      * When this option is enabled (by default) payload of pages that are prerendered are extracted
-     * @type {boolean | undefined}
      */
     payloadExtraction: true,
 
@@ -226,7 +219,6 @@ export default defineResolvers({
     /**
      * Enable View Transition API integration with client-side router.
      * @see [View Transitions API](https://developer.chrome.com/docs/web-platform/view-transitions)
-     * @type {boolean | 'always'}
      */
     viewTransition: false,
 
@@ -241,7 +233,6 @@ export default defineResolvers({
      *
      * By default it is set to 'auto', which means it will be enabled only when there are islands,
      * server components or server pages in your app.
-     * @type {true | 'auto' | 'local' | 'local+remote' | Partial<{ remoteIsland: boolean, selectiveClient: boolean | 'deep' }> | false}
      */
     componentIslands: {
       $resolve: (val) => {
@@ -270,7 +261,6 @@ export default defineResolvers({
      * Set the time interval (in ms) to check for new builds. Disabled when `experimental.appManifest` is `false`.
      *
      * Set to `false` to disable.
-     * @type {number | false}
      */
     checkOutdatedBuildInterval: 1000 * 60 * 60,
 
@@ -287,7 +277,6 @@ export default defineResolvers({
      * You can also set this to `chokidar` to watch all files in your source directory.
      * @see [chokidar](https://github.com/paulmillr/chokidar)
      * @see [@parcel/watcher](https://github.com/parcel-bundler/watcher)
-     * @type {'chokidar' | 'parcel' | 'chokidar-granular'}
      */
     watcher: {
       $resolve: async (val, get) => {
@@ -338,7 +327,6 @@ export default defineResolvers({
      * This only works with static or strings/arrays rather than variables or conditional assignment.
      *
      * @see [Nuxt Issues #24770](https://github.com/nuxt/nuxt/issues/24770)
-     * @type {boolean | 'after-resolve'}
      */
     scanPageMeta: {
       async $resolve (val, get) {
@@ -352,7 +340,6 @@ export default defineResolvers({
      * This allows modules to access additional metadata from the page metadata. It's recommended
      * to augment the NuxtPage types with your keys.
      *
-     * @type {string[]}
      */
     extraPageMetaExtractionKeys: [],
 
@@ -398,7 +385,6 @@ export default defineResolvers({
      * `app/` directory.
      */
     defaults: {
-      /** @type {typeof import('nuxt/app')['NuxtLinkOptions']} */
       nuxtLink: {
         componentName: 'NuxtLink',
         prefetch: true,
@@ -412,7 +398,6 @@ export default defineResolvers({
       useAsyncData: {
         deep: false,
       },
-      /** @type {Pick<typeof import('ofetch')['FetchOptions'], 'timeout' | 'retry' | 'retryDelay' | 'retryStatusCodes'>} */
       useFetch: {},
     },
 
@@ -427,7 +412,6 @@ export default defineResolvers({
      *
      * globalThis.Buffer = globalThis.Buffer || Buffer
      * ```
-     * @type {boolean}
      */
     clientNodeCompat: false,
 
@@ -459,7 +443,6 @@ export default defineResolvers({
     /**
      * Keep showing the spa-loading-template until suspense:resolve
      * @see [Nuxt Issues #21721](https://github.com/nuxt/nuxt/issues/21721)
-     * @type {'body' | 'within'}
      */
     spaLoadingTemplateLocation: {
       $resolve: async (val, get) => {

--- a/packages/schema/src/config/generate.ts
+++ b/packages/schema/src/config/generate.ts
@@ -13,7 +13,6 @@ export default defineResolvers({
      * ```js
      * routes: ['/users/1', '/users/2', '/users/3']
      * ```
-     * @type {string | string[]}
      */
     routes: [],
 

--- a/packages/schema/src/config/index.ts
+++ b/packages/schema/src/config/index.ts
@@ -1,5 +1,3 @@
-import type { ResolvableConfigSchema } from '../utils/definition'
-
 import adhoc from './adhoc'
 import app from './app'
 import build from './build'
@@ -32,4 +30,4 @@ export default {
   ...esbuild,
   ...vite,
   ...webpack,
-} satisfies ResolvableConfigSchema
+}

--- a/packages/schema/src/config/internal.ts
+++ b/packages/schema/src/config/internal.ts
@@ -19,7 +19,6 @@ export default defineResolvers({
   _requiredModules: {},
   /**
    * @private
-   * @type {{ dotenv?: boolean | import('c12').DotenvOptions }}
    */
   _loadOptions: undefined,
   /** @private */
@@ -30,7 +29,6 @@ export default defineResolvers({
   appDir: '',
   /**
    * @private
-   * @type {Array<{ meta: typeof import('../src/types/module').ModuleMeta; module: typeof import('../src/types/module').NuxtModule, timings?: Record<string, number | undefined>; entryPath?: string }>}
    */
   _installedModules: [],
   /** @private */

--- a/packages/schema/src/config/nitro.ts
+++ b/packages/schema/src/config/nitro.ts
@@ -4,7 +4,6 @@ export default defineResolvers({
   /**
    * Configuration for Nitro.
    * @see [Nitro configuration docs](https://nitro.build/config/)
-   * @type {typeof import('nitropack/types')['NitroConfig']}
    */
   nitro: {
     runtimeConfig: {
@@ -39,7 +38,6 @@ export default defineResolvers({
    * Global route options applied to matching server routes.
    * @experimental This is an experimental feature and API may change in the future.
    * @see [Nitro route rules documentation](https://nitro.build/config/#routerules)
-   * @type {typeof import('nitropack/types')['NitroConfig']['routeRules']}
    */
   routeRules: {},
 
@@ -62,14 +60,12 @@ export default defineResolvers({
    *   { route: '/path/foo/**:name', handler: '~/server/foohandler.ts' }
    * ]
    * ```
-   * @type {typeof import('nitropack/types')['NitroEventHandler'][]}
    */
   serverHandlers: [],
 
   /**
    * Nitro development-only server handlers.
    * @see [Nitro server routes documentation](https://nitro.build/guide/routing)
-   * @type {typeof import('nitropack/types')['NitroDevEventHandler'][]}
    */
   devServerHandlers: [],
 })

--- a/packages/schema/src/config/postcss.ts
+++ b/packages/schema/src/config/postcss.ts
@@ -22,7 +22,6 @@ export default defineResolvers({
     /**
      * A strategy for ordering PostCSS plugins.
      *
-     * @type {'cssnanoLast' | 'autoprefixerLast' | 'autoprefixerAndCssnanoLast' | string[] | ((names: string[]) => string[])}
      */
     order: {
       $resolve: (val) => {
@@ -45,7 +44,6 @@ export default defineResolvers({
      * Options for configuring PostCSS plugins.
      *
      * @see [PostCSS docs](https://postcss.org/)
-     * @type {Record<string, unknown> & { autoprefixer?: typeof import('autoprefixer').Options; cssnano?: typeof import('cssnano').Options }}
      */
     plugins: {
       /**

--- a/packages/schema/src/config/router.ts
+++ b/packages/schema/src/config/router.ts
@@ -14,13 +14,11 @@ export default defineResolvers({
        * You can enable hash history in SPA mode. In this mode, router uses a hash character (#) before
        * the actual URL that is internally passed. When enabled, the
        * **URL is never sent to the server** and **SSR is not supported**.
-       * @default false
        */
       hashMode: false,
 
       /**
        * Customize the scroll behavior for hash links.
-       * @default 'auto'
        */
       scrollBehaviorType: 'auto',
     },

--- a/packages/schema/src/config/router.ts
+++ b/packages/schema/src/config/router.ts
@@ -8,21 +8,18 @@ export default defineResolvers({
      * @note Only JSON serializable options should be passed by Nuxt config.
      * For more control, you can use `app/router.options.ts` file.
      * @see [Vue Router documentation](https://router.vuejs.org/api/interfaces/routeroptions.html).
-     * @type {typeof import('../src/types/router').RouterConfigSerializable}
      */
     options: {
       /**
        * You can enable hash history in SPA mode. In this mode, router uses a hash character (#) before
        * the actual URL that is internally passed. When enabled, the
        * **URL is never sent to the server** and **SSR is not supported**.
-       * @type {typeof import('../src/types/router').RouterConfigSerializable['hashMode']}
        * @default false
        */
       hashMode: false,
 
       /**
        * Customize the scroll behavior for hash links.
-       * @type {typeof import('../src/types/router').RouterConfigSerializable['scrollBehaviorType']}
        * @default 'auto'
        */
       scrollBehaviorType: 'auto',

--- a/packages/schema/src/config/typescript.ts
+++ b/packages/schema/src/config/typescript.ts
@@ -20,7 +20,6 @@ export default defineResolvers({
      * builder environment types (with `false`) to handle this fully yourself, or opt for a 'shared' option.
      *
      * The 'shared' option is advised for module authors, who will want to support multiple possible builders.
-     * @type {'vite' | 'webpack' | 'rspack' | 'shared' | false | undefined | null}
      */
     builder: {
       $resolve: (val) => {
@@ -81,13 +80,11 @@ export default defineResolvers({
      * If set to true, this will type check in development. You can restrict this to build-time type checking by setting it to `build`.
      * Requires to install `typescript` and `vue-tsc` as dev dependencies.
      * @see [Nuxt TypeScript docs](https://nuxt.com/docs/guide/concepts/typescript)
-     * @type {boolean | 'build'}
      */
     typeCheck: false,
 
     /**
      * You can extend generated `.nuxt/tsconfig.json` using this option.
-     * @type {0 extends 1 & RawVueCompilerOptions ? typeof import('pkg-types')['TSConfig'] : typeof import('pkg-types')['TSConfig'] & { vueCompilerOptions?: typeof import('@vue/language-core')['RawVueCompilerOptions'] }}
      */
     tsConfig: {},
 

--- a/packages/schema/src/config/vite.ts
+++ b/packages/schema/src/config/vite.ts
@@ -10,7 +10,6 @@ export default defineResolvers({
    *
    * @see [Vite configuration docs](https://vite.dev/config) for more information.
    * Please note that not all vite options are supported in Nuxt.
-   * @type {typeof import('../src/types/config').ViteConfig & { $client?: typeof import('../src/types/config').ViteConfig, $server?: typeof import('../src/types/config').ViteConfig }}
    */
   vite: {
     root: {

--- a/packages/schema/src/config/webpack.ts
+++ b/packages/schema/src/config/webpack.ts
@@ -163,28 +163,16 @@ export default defineResolvers({
 
       /**
        * @see [`file-loader` Options](https://github.com/webpack-contrib/file-loader#options)
-       * @default
-       * ```ts
-       * { esModule: false }
-       * ```
        */
       file: { esModule: false, limit: 1000 },
 
       /**
        * @see [`file-loader` Options](https://github.com/webpack-contrib/file-loader#options)
-       * @default
-       * ```ts
-       * { esModule: false }
-       * ```
        */
       fontUrl: { esModule: false, limit: 1000 },
 
       /**
        * @see [`file-loader` Options](https://github.com/webpack-contrib/file-loader#options)
-       * @default
-       * ```ts
-       * { esModule: false }
-       * ```
        */
       imgUrl: { esModule: false, limit: 1000 },
 
@@ -213,8 +201,6 @@ export default defineResolvers({
        */
       css: {
         importLoaders: 0,
-        /**
-         */
         url: {
           filter: (url: string, _resourcePath: string) => url[0] !== '/',
         },
@@ -226,8 +212,6 @@ export default defineResolvers({
        */
       cssModules: {
         importLoaders: 0,
-        /**
-         */
         url: {
           filter: (url: string, _resourcePath: string) => url[0] !== '/',
         },
@@ -244,14 +228,6 @@ export default defineResolvers({
 
       /**
        * @see [`sass-loader` Options](https://github.com/webpack-contrib/sass-loader#options)
-       * @default
-       * ```ts
-       * {
-       *   sassOptions: {
-       *     indentedSyntax: true
-       *   }
-       * }
-       * ```
        */
       sass: {
         sassOptions: {

--- a/packages/schema/src/config/webpack.ts
+++ b/packages/schema/src/config/webpack.ts
@@ -13,7 +13,6 @@ export default defineResolvers({
      *   analyzerMode: 'static'
      * }
      * ```
-     * @type {boolean | { enabled?: boolean } & typeof import('webpack-bundle-analyzer').BundleAnalyzerPlugin.Options}
      */
     analyze: {
       $resolve: async (val, get) => {
@@ -74,7 +73,6 @@ export default defineResolvers({
      *   }
      * }
      * ```
-     * @type {boolean | typeof import('mini-css-extract-plugin').PluginOptions}
      */
     extractCSS: true,
 
@@ -106,7 +104,6 @@ export default defineResolvers({
      *   chunk: ({ isDev }) => (isDev ? '[name].js' : '[id].[contenthash].js')
      * }
      * ```
-     * @type {
      *  Record<
      *    string,
      *    string |
@@ -157,7 +154,6 @@ export default defineResolvers({
 
       /**
        * @see [esbuild loader](https://github.com/esbuild-kit/esbuild-loader)
-       * @type {Omit<typeof import('esbuild-loader')['LoaderOptions'], 'loader'>}
        */
       esbuild: {
         $resolve: async (val, get) => {
@@ -194,13 +190,11 @@ export default defineResolvers({
 
       /**
        * @see [`pug` options](https://pugjs.org/api/reference.html#options)
-       * @type {typeof import('pug')['Options']}
        */
       pugPlain: {},
 
       /**
        * See [vue-loader](https://github.com/vuejs/vue-loader) for available options.
-       * @type {Partial<typeof import('vue-loader')['VueLoaderOptions']>}
        */
       vue: {
         transformAssetUrls: {
@@ -220,7 +214,6 @@ export default defineResolvers({
       css: {
         importLoaders: 0,
         /**
-         * @type {boolean | { filter: (url: string, resourcePath: string) => boolean }}
          */
         url: {
           filter: (url: string, _resourcePath: string) => url[0] !== '/',
@@ -234,7 +227,6 @@ export default defineResolvers({
       cssModules: {
         importLoaders: 0,
         /**
-         * @type {boolean | { filter: (url: string, resourcePath: string) => boolean }}
          */
         url: {
           filter: (url: string, _resourcePath: string) => url[0] !== '/',
@@ -306,7 +298,6 @@ export default defineResolvers({
      *
      * Defaults to true when `extractCSS` is enabled.
      * @see [css-minimizer-webpack-plugin documentation](https://github.com/webpack-contrib/css-minimizer-webpack-plugin).
-     * @type {false | typeof import('css-minimizer-webpack-plugin').BasePluginOptions & typeof import('css-minimizer-webpack-plugin').DefinedDefaultMinimizerAndOptions<{}>}
      */
     optimizeCSS: {
       $resolve: async (val, get) => {
@@ -321,7 +312,6 @@ export default defineResolvers({
 
     /**
      * Configure [webpack optimization](https://webpack.js.org/configuration/optimization/).
-     * @type {false | typeof import('webpack').Configuration['optimization']}
      */
     optimization: {
       runtimeChunk: 'single',
@@ -341,7 +331,6 @@ export default defineResolvers({
     /**
      * Customize PostCSS Loader.
      * same options as [`postcss-loader` options](https://github.com/webpack-contrib/postcss-loader#options)
-     * @type {{ execute?: boolean, postcssOptions: typeof import('postcss').ProcessOptions & { plugins: Record<string, unknown> & { autoprefixer?: typeof import('autoprefixer').Options; cssnano?: typeof import('cssnano').Options } }, sourceMap?: boolean, implementation?: any }}
      */
     postcss: {
       postcssOptions: {
@@ -353,7 +342,6 @@ export default defineResolvers({
 
     /**
      * See [webpack-dev-middleware](https://github.com/webpack/webpack-dev-middleware) for available options.
-     * @type {typeof import('webpack-dev-middleware').Options<typeof import('http').IncomingMessage, typeof import('http').ServerResponse>}
      */
     devMiddleware: {
       stats: 'none',
@@ -361,7 +349,6 @@ export default defineResolvers({
 
     /**
      * See [webpack-hot-middleware](https://github.com/webpack-contrib/webpack-hot-middleware) for available options.
-     * @type {typeof import('webpack-hot-middleware').MiddlewareOptions & { client?: typeof import('webpack-hot-middleware').ClientOptions }}
      */
     hotMiddleware: {},
 
@@ -372,13 +359,11 @@ export default defineResolvers({
 
     /**
      * Filters to hide build warnings.
-     * @type {Array<(warn: typeof import('webpack').WebpackError) => boolean>}
      */
     warningIgnoreFilters: [],
 
     /**
      * Configure [webpack experiments](https://webpack.js.org/configuration/experiments/)
-     * @type {false | typeof import('webpack').Configuration['experiments']}
      */
     experiments: {},
   },

--- a/packages/schema/src/types/builder-env/vite.ts
+++ b/packages/schema/src/types/builder-env/vite.ts
@@ -38,7 +38,6 @@ export interface ImportGlobOptions<
   as?: AsType
   /**
    * Import as static or dynamic
-   * @default false
    */
   eager?: Eager
   /**
@@ -51,7 +50,6 @@ export interface ImportGlobOptions<
   query?: string | Record<string, string | number | boolean>
   /**
    * Search files also inside `node_modules/` and hidden directories (e.g. `.git/`). This might have impact on performance.
-   * @default false
    */
   exhaustive?: boolean
 }

--- a/packages/schema/src/types/components.ts
+++ b/packages/schema/src/types/components.ts
@@ -116,7 +116,6 @@ export interface ComponentsOptions {
    * but they can also be used dynamically, for example `<component :is="`icon-${myIcon}`">`.
    *
    * This can be overridden by an individual component directory entry.
-   * @default false
    */
   global?: boolean
   /**

--- a/packages/schema/src/types/head.ts
+++ b/packages/schema/src/types/head.ts
@@ -6,13 +6,11 @@ export type MetaObject = MetaObjectRaw
 export type AppHeadMetaObject = MetaObjectRaw & {
   /**
    * The character encoding in which the document is encoded => `<meta charset="<value>" />`
-   * @default `'utf-8'`
    */
   charset?: string
   /**
    * Configuration of the viewport (the area of the window in which web content can be seen),
    * mapped to => `<meta name="viewport" content="<value>" />`
-   * @default `'width=device-width, initial-scale=1'`
    */
   viewport?: string
 }

--- a/packages/schema/src/types/hooks.ts
+++ b/packages/schema/src/types/hooks.ts
@@ -43,7 +43,6 @@ export type NuxtPage = {
    * `server` means pages are automatically rendered with server components, so there will be no JavaScript to render the page in your client bundle.
    *
    * `client` means that page will render on the client-side only.
-   * @default 'all'
    */
   mode?: 'client' | 'server' | 'all'
   /** @internal */

--- a/packages/schema/src/types/imports.ts
+++ b/packages/schema/src/types/imports.ts
@@ -4,27 +4,23 @@ export interface ImportsOptions extends UnimportOptions {
   /**
    * Enable implicit auto import from Vue, Nuxt and module contributed utilities.
    * Generate global TypeScript definitions.
-   * @default true
    */
   autoImport?: boolean
 
   /**
    * Directories to scan for auto imports.
    * @see https://nuxt.com/docs/guide/directory-structure/composables#how-files-are-scanned
-   * @default ['./composables', './utils']
    */
   dirs?: string[]
 
   /**
    * Enabled scan for local directories for auto imports.
    * When this is disabled, `dirs` options will be ignored.
-   * @default true
    */
   scan?: boolean
 
   /**
    * Assign auto imported utilities to `globalThis` instead of using built time transformation.
-   * @default false
    */
   global?: boolean
 
@@ -35,7 +31,6 @@ export interface ImportsOptions extends UnimportOptions {
 
   /**
    * Add polyfills for setInterval, requestIdleCallback, and others
-   * @default true
    */
   polyfills?: boolean
 }

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -19,7 +19,7 @@ import type { TSConfig } from 'pkg-types'
 import type { RawVueCompilerOptions } from '@vue/language-core'
 import type { PluginOptions } from 'mini-css-extract-plugin'
 import type { LoaderOptions } from 'esbuild-loader'
-import type { Options as Options2 } from 'pug'
+import type { Options as PugOptions } from 'pug'
 import type { VueLoaderOptions } from 'vue-loader'
 import type { BasePluginOptions, DefinedDefaultMinimizerAndOptions } from 'css-minimizer-webpack-plugin'
 import type { Configuration, WebpackError } from 'webpack'
@@ -100,15 +100,11 @@ export interface ConfigSchema {
 
     /**
      * Include Vue compiler in runtime bundle.
-     *
-     * @default false
      */
     runtimeCompiler: boolean
 
     /**
      * Enable reactive destructure for `defineProps`
-     *
-     * @default true
      */
     propsDestructure: boolean
 
@@ -129,7 +125,6 @@ export interface ConfigSchema {
    *
    * For example:
    *
-   * @default "/"
    *
    * @example
    * ```ts
@@ -151,8 +146,6 @@ export interface ConfigSchema {
 
     /**
      * The folder name for the built site assets, relative to `baseURL` (or `cdnURL` if set). This is set at build time and should not be customized at runtime.
-     *
-     * @default "/_nuxt/"
      */
     buildAssetsDir: string
 
@@ -161,7 +154,6 @@ export interface ConfigSchema {
      *
      * For example:
      *
-     * @default ""
      *
      * @example
      * ```ts
@@ -220,7 +212,6 @@ export interface ConfigSchema {
      *
      * This can be overridden with `definePageMeta` on an individual page. Only JSON-serializable values are allowed.
      *
-     * @default false
      *
      * @see [Vue Transition docs](https://vuejs.org/api/built-in-components.html#transition)
      */
@@ -231,7 +222,6 @@ export interface ConfigSchema {
      *
      * This can be overridden with `definePageMeta` on an individual page. Only JSON-serializable values are allowed.
      *
-     * @default false
      *
      * @see [Vue Transition docs](https://vuejs.org/api/built-in-components.html#transition)
      */
@@ -243,7 +233,6 @@ export interface ConfigSchema {
      * This only has an effect when **experimental** support for View Transitions is [enabled in your nuxt.config file](/docs/getting-started/transitions#view-transitions-api-experimental).
      * This can be overridden with `definePageMeta` on an individual page.
      *
-     * @default false
      *
      * @see [Nuxt View Transition API docs](https://nuxt.com/docs/getting-started/transitions#view-transitions-api-experimental)
      */
@@ -254,7 +243,6 @@ export interface ConfigSchema {
      *
      * This can be overridden with `definePageMeta` on an individual page. Only JSON-serializable values are allowed.
      *
-     * @default false
      *
      * @see [Vue KeepAlive](https://vuejs.org/api/built-in-components.html#keepalive)
      */
@@ -263,7 +251,6 @@ export interface ConfigSchema {
     /**
      * Customize Nuxt root element id.
      *
-     * @default "__nuxt"
      *
      * @deprecated Prefer `rootAttrs.id` instead
      */
@@ -271,28 +258,22 @@ export interface ConfigSchema {
 
     /**
      * Customize Nuxt root element tag.
-     *
-     * @default "div"
      */
     rootTag: string
 
     /**
      * Customize Nuxt root element id.
-     *
      */
     rootAttrs: SerializableHtmlAttributes
 
     /**
      * Customize Nuxt Teleport element tag.
-     *
-     * @default "div"
      */
     teleportTag: string
 
     /**
      * Customize Nuxt Teleport element id.
      *
-     * @default "teleports"
      *
      * @deprecated Prefer `teleportAttrs.id` instead
      */
@@ -300,20 +281,16 @@ export interface ConfigSchema {
 
     /**
      * Customize Nuxt Teleport element attributes.
-     *
      */
     teleportAttrs: SerializableHtmlAttributes
 
     /**
      * Customize Nuxt SpaLoader element tag.
-     *
-     * @default "div"
      */
     spaLoaderTag: string
 
     /**
      * Customize Nuxt Nuxt SpaLoader element attributes.
-     *
      */
     spaLoaderAttrs: SerializableHtmlAttributes
   }
@@ -423,7 +400,6 @@ export interface ConfigSchema {
   /**
    * Enable the legacy compatibility mode for `unhead` module. This applies the following changes: - Disables Capo.js sorting - Adds the `DeprecationsPlugin`: supports `hid`, `vmid`, `children`, `body` - Adds the `PromisesPlugin`: supports promises as input
    *
-   * @default false
    *
    * @see [`unhead` migration documentation](https://unhead.unjs.io/docs/typescript/head/guides/get-started/migration)
    *
@@ -456,7 +432,6 @@ export interface ConfigSchema {
   /**
    * The builder to use for bundling the Vue part of your application.
    *
-   * @default "@nuxt/vite-builder"
    */
   builder: 'vite' | 'webpack' | 'rspack' | { bundle: (nuxt: Nuxt) => Promise<void> }
 
@@ -473,7 +448,6 @@ export interface ConfigSchema {
    *
    * Defaults to 'silent' when running in CI or when a TTY is not available. This option is then used as 'silent' in Vite and 'none' in Webpack
    *
-   * @default "info"
    */
   logLevel: 'silent' | 'info' | 'verbose'
 
@@ -533,13 +507,11 @@ export interface ConfigSchema {
    * As long as the number of arguments passed to the function is less than `argumentLength`, an additional magic string will be injected that can be used to deduplicate requests between server and client. You will need to take steps to handle this additional key.
    * The key will be unique based on the location of the function being invoked within the file.
    *
-   * @default [{"name":"callOnce","argumentLength":3},{"name":"defineNuxtComponent","argumentLength":2},{"name":"useState","argumentLength":2},{"name":"useFetch","argumentLength":3},{"name":"useAsyncData","argumentLength":3},{"name":"useLazyAsyncData","argumentLength":3},{"name":"useLazyFetch","argumentLength":3}]
    */
     keyedComposables: Array<{ name: string, source?: string | RegExp, argumentLength: number }>
 
     /**
      * Tree shake code from specific builds.
-     *
      */
     treeShake: {
       /**
@@ -559,7 +531,6 @@ export interface ConfigSchema {
 
     /**
      * Options passed directly to the transformer from `unctx` that preserves async context after `await`.
-     *
      */
     asyncTransforms: TransformerOptions
   }
@@ -598,7 +569,6 @@ export interface ConfigSchema {
    * This property can be overwritten (for example, running `nuxt ./my-app/` will set the `rootDir` to the absolute path of `./my-app/` from the current/working directory.
    * It is normally not needed to configure this option.
    *
-   * @default "/<rootDir>"
    */
   rootDir: string
 
@@ -608,7 +578,6 @@ export interface ConfigSchema {
    * Often this is used when in a monorepo setup. Nuxt will attempt to detect your workspace directory automatically, but you can override it here.
    * It is normally not needed to configure this option.
    *
-   * @default "/<workspaceDir>"
    */
   workspaceDir: string
 
@@ -617,7 +586,6 @@ export interface ConfigSchema {
    *
    * If a relative path is specified, it will be relative to the `rootDir`.
    *
-   * @default "/<srcDir>"
    *
    * @example
    * ```js
@@ -653,7 +621,6 @@ export interface ConfigSchema {
    *
    * If a relative path is specified, it will be relative to your `rootDir`.
    *
-   * @default "/<rootDir>/server"
    */
   serverDir: string
 
@@ -662,7 +629,6 @@ export interface ConfigSchema {
    *
    * Many tools assume that `.nuxt` is a hidden directory (because it starts with a `.`). If that is a problem, you can use this option to prevent that.
    *
-   * @default "/<rootDir>/.nuxt"
    *
    * @example
    * ```js
@@ -678,14 +644,12 @@ export interface ConfigSchema {
    *
    * Defaults to `nuxt-app`.
    *
-   * @default "nuxt-app"
    */
   appId: string
 
   /**
    * A unique identifier matching the build. This may contain the hash of the current state of the project.
    *
-   * @default "fa3ef6bd-0e10-41c8-9a55-ef6e58d5badd"
    */
   buildId: string
 
@@ -695,7 +659,6 @@ export interface ConfigSchema {
    * The configuration path is relative to `options.rootDir` (default is current working directory).
    * Setting this field may be necessary if your project is organized as a yarn workspace-styled mono-repository.
    *
-   * @default ["/<rootDir>/node_modules"]
    *
    * @example
    * ```js
@@ -711,7 +674,6 @@ export interface ConfigSchema {
    *
    * If a relative path is specified, it will be relative to your `rootDir`.
    *
-   * @default "/<rootDir>/.nuxt/analyze"
    */
   analyzeDir: string
 
@@ -720,14 +682,12 @@ export interface ConfigSchema {
    *
    * Normally, you should not need to set this.
    *
-   * @default false
    */
   dev: boolean
 
   /**
    * Whether your app is being unit tested.
    *
-   * @default false
    */
   test: boolean
 
@@ -737,14 +697,12 @@ export interface ConfigSchema {
    * At the moment, it prints out hook names and timings on the server, and logs hook arguments as well in the browser.
    * You can also set this to an object to enable specific debug options.
    *
-   * @default false
    */
   debug: boolean | (NuxtDebugOptions) | undefined
 
   /**
    * Whether to enable rendering of HTML - either dynamically (in server mode) or at generate time. If set to `false` generated pages will have no content.
    *
-   * @default true
    */
   ssr: boolean
 
@@ -779,67 +737,49 @@ export interface ConfigSchema {
    * It is better to stick with defaults unless needed.
    */
   dir: {
-  /** @default "/<srcDir>" */
     app: string
 
     /**
      * The assets directory (aliased as `~assets` in your build).
-     *
-     * @default "assets"
      */
     assets: string
 
     /**
      * The layouts directory, each file of which will be auto-registered as a Nuxt layout.
-     *
-     * @default "layouts"
      */
     layouts: string
 
     /**
      * The middleware directory, each file of which will be auto-registered as a Nuxt middleware.
-     *
-     * @default "middleware"
      */
     middleware: string
 
     /**
      * The modules directory, each file in which will be auto-registered as a Nuxt module.
-     *
-     * @default "/<rootDir>/modules"
      */
     modules: string
 
     /**
      * The directory which will be processed to auto-generate your application page routes.
-     *
-     * @default "pages"
      */
     pages: string
 
     /**
      * The plugins directory, each file of which will be auto-registered as a Nuxt plugin.
-     *
-     * @default "plugins"
      */
     plugins: string
 
     /**
      * The shared directory. This directory is shared between the app and the server.
-     *
-     * @default "shared"
      */
     shared: string
 
     /**
      * The directory containing your static files, which will be directly accessible via the Nuxt server and copied across into your `dist` folder when your app is generated.
-     *
-     * @default "/<rootDir>/public"
      */
     public: string
 
     /**
-     * @default "public"
      *
      * @deprecated use `dir.public` option instead
      */
@@ -849,7 +789,6 @@ export interface ConfigSchema {
   /**
    * The extensions that should be resolved by the Nuxt resolver.
    *
-   * @default [".js",".jsx",".mjs",".ts",".tsx",".vue"]
    */
   extensions: Array<string>
 
@@ -913,14 +852,12 @@ export interface ConfigSchema {
   /**
    * Any file in `pages/`, `layouts/`, `middleware/`, and `public/` directories will be ignored during the build process if its filename starts with the prefix specified by `ignorePrefix`. This is intended to prevent certain files from being processed or served in the built application. By default, the `ignorePrefix` is set to '-', ignoring any files starting with '-'.
    *
-   * @default "-"
    */
   ignorePrefix: string
 
   /**
    * More customizable than `ignorePrefix`: all files matching glob patterns specified inside the `ignore` array will be ignored in building.
    *
-   * @default ["**\/*.stories.{js,cts,mts,ts,jsx,tsx}","**\/*.{spec,test}.{js,cts,mts,ts,jsx,tsx}","**\/*.d.{cts,mts,ts}","**\/.{pnpm-store,vercel,netlify,output,git,cache,data}","**\/*.sock",".nuxt/analyze",".nuxt","**\/-*.*"]
    */
   ignore: Array<string>
 
@@ -946,7 +883,6 @@ export interface ConfigSchema {
      * @see [webpack@4 watch options](https://v4.webpack.js.org/configuration/watch/#watchoptions).
      */
     webpack: {
-      /** @default 1000 */
       aggregateTimeout: number
     }
 
@@ -1018,7 +954,6 @@ export interface ConfigSchema {
   /**
    * Whether to enable HTTPS.
    *
-   * @default false
    *
    * @example
    * ```ts
@@ -1036,14 +971,11 @@ export interface ConfigSchema {
 
     /**
      * Dev server listening port
-     *
-     * @default 3000
      */
     port: number
 
     /**
      * Dev server listening host
-     *
      */
     host: string | undefined
 
@@ -1051,20 +983,16 @@ export interface ConfigSchema {
      * Listening dev server URL.
      *
      * This should not be set directly as it will always be overridden by the dev server with the full URL (for module and internal use).
-     *
-     * @default "http://localhost:3000"
      */
     url: string
 
     /**
      * Template to show a loading screen
-     *
      */
     loadingTemplate: (data: { loading?: string }) => string
 
     /**
      * Set CORS options for the dev server
-     *
      */
     cors: H3CorsOptions
   }
@@ -1078,14 +1006,12 @@ export interface ConfigSchema {
    *
    * It is currently not configurable but may be in future.
    *
-   * @default 4
    */
     compatibilityVersion: 4
 
     /**
      * This enables early access to the experimental multi-app support.
      *
-     * @default false
      *
      * @see [Nuxt Issue #21635](https://github.com/nuxt/nuxt/issues/21635)
      */
@@ -1097,7 +1023,6 @@ export interface ConfigSchema {
      * It improves type support when using modern libraries with `exports`.
      * You can set it to false to use the legacy 'Node' mode, which is the default for TypeScript.
      *
-     * @default true
      *
      * @see [TypeScript PR implementing `bundler` module resolution](https://github.com/microsoft/TypeScript/pull/51669)
      */
@@ -1119,8 +1044,6 @@ export interface ConfigSchema {
      * Stream server logs to the client as you are developing. These logs can be handled in the `dev:ssr-logs` hook.
      *
      * If set to `silent`, the logs will not be printed to the browser console.
-     *
-     * @default false
      */
     devLogs: boolean | 'silent'
 
@@ -1128,8 +1051,6 @@ export interface ConfigSchema {
      * Turn off rendering of Nuxt scripts and JS resource hints. You can also disable scripts more granularly within `routeRules`.
      *
      * If set to 'production' or `true`, JS will be disabled in production mode only.
-     *
-     * @default false
      */
     noScripts: 'production' | 'all' | boolean
   }
@@ -1138,7 +1059,6 @@ export interface ConfigSchema {
   /**
    * Enable to use experimental decorators in Nuxt and Nitro.
    *
-   * @default false
    *
    * @see https://github.com/tc39/proposal-decorators
    */
@@ -1146,15 +1066,12 @@ export interface ConfigSchema {
 
     /**
      * Set to true to generate an async entry point for the Vue bundle (for module federation support).
-     *
-     * @default false
      */
     asyncEntry: boolean
 
     /**
      * Externalize `vue`, `@vue/*` and `vue-router` when building.
      *
-     * @default true
      *
      * @see [Nuxt Issue #13632](https://github.com/nuxt/nuxt/issues/13632)
      */
@@ -1163,7 +1080,6 @@ export interface ConfigSchema {
     /**
      * Enable accessing `appConfig` from server routes.
      *
-     * @default false
      *
      * @deprecated This option is not recommended.
      */
@@ -1176,7 +1092,6 @@ export interface ConfigSchema {
      * Setting `automatic-immediate` will lead Nuxt to perform a reload of the current route right when a chunk fails to load (instead of waiting for navigation).
      * You can disable automatic handling by setting this to `false`, or handle chunk errors manually by setting it to `manual`.
      *
-     * @default "automatic"
      *
      * @see [Nuxt PR #19038](https://github.com/nuxt/nuxt/pull/19038)
      */
@@ -1186,8 +1101,6 @@ export interface ConfigSchema {
      * By default the route object returned by the auto-imported `useRoute()` composable is kept in sync with the current page in view in `<NuxtPage>`. This is not true for `vue-router`'s exported `useRoute` or for the default `$route` object available in your Vue templates.
      *
      * By enabling this option a mixin will be injected to keep the `$route` template object in sync with Nuxt's managed `useRoute()`.
-     *
-     * @default true
      */
     templateRouteInjection: boolean
 
@@ -1196,50 +1109,37 @@ export interface ConfigSchema {
      *
      * To avoid hydration errors, it will be applied only after the Vue app has been mounted, meaning there may be a flicker on initial load.
      * Consider carefully before enabling this as it can cause unexpected behavior, and consider providing explicit keys to `useState` as auto-generated keys may not match across builds.
-     *
-     * @default false
      */
     restoreState: boolean
 
     /**
      * Render JSON payloads with support for revivifying complex types.
-     *
-     * @default true
      */
     renderJsonPayloads: boolean
 
     /**
      * Disable vue server renderer endpoint within nitro.
-     *
-     * @default false
      */
     noVueServer: boolean
 
     /**
      * When this option is enabled (by default) payload of pages that are prerendered are extracted
-     *
-     * @default true
      */
     payloadExtraction: boolean | undefined
 
     /**
      * Whether to enable the experimental `<NuxtClientFallback>` component for rendering content on the client if there's an error in SSR.
-     *
-     * @default false
      */
     clientFallback: boolean
 
     /**
      * Enable cross-origin prefetch using the Speculation Rules API.
-     *
-     * @default false
      */
     crossOriginPrefetch: boolean
 
     /**
      * Enable View Transition API integration with client-side router.
      *
-     * @default false
      *
      * @see [View Transitions API](https://developer.chrome.com/docs/web-platform/view-transitions)
      */
@@ -1248,7 +1148,6 @@ export interface ConfigSchema {
     /**
      * Write early hints when using node server.
      *
-     * @default false
      *
      * @note nginx does not support 103 Early hints in the current version.
      */
@@ -1258,29 +1157,21 @@ export interface ConfigSchema {
      * Experimental component islands support with `<NuxtIsland>` and `.island.vue` files.
      *
      * By default it is set to 'auto', which means it will be enabled only when there are islands, server components or server pages in your app.
-     *
-     * @default "auto"
      */
     componentIslands: true | 'auto' | 'local' | 'local+remote' | Partial<{ remoteIsland: boolean, selectiveClient: boolean | 'deep' }> | false
 
     /**
      * Resolve `~`, `~~`, `@` and `@@` aliases located within layers with respect to their layer source and root directories.
-     *
-     * @default true
      */
     localLayerAliases: boolean
 
     /**
      * Enable the new experimental typed router using [unplugin-vue-router](https://github.com/posva/unplugin-vue-router).
-     *
-     * @default false
      */
     typedPages: boolean
 
     /**
      * Use app manifests to respect route rules on client-side.
-     *
-     * @default true
      */
     appManifest: boolean
 
@@ -1288,8 +1179,6 @@ export interface ConfigSchema {
      * Set the time interval (in ms) to check for new builds. Disabled when `experimental.appManifest` is `false`.
      *
      * Set to `false` to disable.
-     *
-     * @default 3600000
      */
     checkOutdatedBuildInterval: number | false
 
@@ -1300,7 +1189,6 @@ export interface ConfigSchema {
      * You can set this instead to `parcel` to use `@parcel/watcher`, which may improve performance in large projects or on Windows platforms.
      * You can also set this to `chokidar` to watch all files in your source directory.
      *
-     * @default "chokidar"
      *
      * @see [chokidar](https://github.com/paulmillr/chokidar)
      *
@@ -1311,7 +1199,6 @@ export interface ConfigSchema {
     /**
      * Enable native async context to be accessible for nested composables
      *
-     * @default false
      *
      * @see [Nuxt PR #20918](https://github.com/nuxt/nuxt/pull/20918)
      */
@@ -1322,7 +1209,6 @@ export interface ConfigSchema {
      *
      * - Add the capo.js head plugin in order to render tags in of the head in a more performant way. - Uses the hash hydration plugin to reduce initial hydration
      *
-     * @default true
      *
      * @see [Nuxt Discussion #22632](https://github.com/nuxt/nuxt/discussions/22632)
      */
@@ -1333,8 +1219,6 @@ export interface ConfigSchema {
      *
      * Rules are converted (based on the path) and applied for server requests. For example, a rule defined in `~/pages/foo/bar.vue` will be applied to `/foo/bar` requests. A rule in `~/pages/foo/[id].vue` will be applied to `/foo/**` requests.
      * For more control, such as if you are using a custom `path` or `alias` set in the page's `definePageMeta`, you should set `routeRules` directly within your `nuxt.config`.
-     *
-     * @default false
      */
     inlineRouteRules: boolean
 
@@ -1343,7 +1227,6 @@ export interface ConfigSchema {
      *
      * This only works with static or strings/arrays rather than variables or conditional assignment.
      *
-     * @default "after-resolve"
      *
      * @see [Nuxt Issues #24770](https://github.com/nuxt/nuxt/issues/24770)
      */
@@ -1353,7 +1236,6 @@ export interface ConfigSchema {
      * Configure additional keys to extract from the page metadata when using `scanPageMeta`.
      *
      * This allows modules to access additional metadata from the page metadata. It's recommended to augment the NuxtPage types with your keys.
-     *
      */
     extraPageMetaExtractionKeys: string[]
 
@@ -1362,7 +1244,6 @@ export interface ConfigSchema {
      *
      * It is particularly important when enabling this feature to make sure that any unique key of your data is always resolvable to the same data. For example, if you are using `useAsyncData` to fetch data related to a particular page, you should provide a key that uniquely matches that data. (`useFetch` should do this automatically for you.)
      *
-     * @default true
      *
      * @example
      * ```ts
@@ -1383,7 +1264,6 @@ export interface ConfigSchema {
     /**
      * Enables CookieStore support to listen for cookie updates (if supported by the browser) and refresh `useCookie` ref values.
      *
-     * @default true
      *
      * @see [CookieStore](https://developer.mozilla.org/en-US/docs/Web/API/CookieStore)
      */
@@ -1393,7 +1273,6 @@ export interface ConfigSchema {
      * This allows specifying the default options for core Nuxt components and composables.
      *
      * These options will likely be moved elsewhere in the future, such as into `app.config` or into the `app/` directory.
-     *
      */
     defaults: {
       nuxtLink: NuxtLinkOptions
@@ -1402,7 +1281,6 @@ export interface ConfigSchema {
        * Options that apply to `useAsyncData` (and also therefore `useFetch`)
        */
       useAsyncData: {
-        /** @default false */
         deep: boolean
       }
 
@@ -1412,7 +1290,6 @@ export interface ConfigSchema {
     /**
      * Automatically polyfill Node.js imports in the client build using `unenv`.
      *
-     * @default false
      *
      * @see [unenv](https://github.com/unjs/unenv)
      *
@@ -1430,8 +1307,6 @@ export interface ConfigSchema {
      * Wait for a single animation frame before navigation, which gives an opportunity for the browser to repaint, acknowledging user interaction.
      *
      * It can reduce INP when navigating on prerendered routes.
-     *
-     * @default true
      */
     navigationRepaint: boolean
 
@@ -1439,22 +1314,17 @@ export interface ConfigSchema {
      * Cache Nuxt/Nitro build artifacts based on a hash of the configuration and source files.
      *
      * This only works for source files within `srcDir` and `serverDir` for the Vue/Nitro parts of your app.
-     *
-     * @default false
      */
     buildCache: boolean
 
     /**
      * Ensure that auto-generated Vue component names match the full component name you would use to auto-import the component.
-     *
-     * @default true
      */
     normalizeComponentNames: boolean
 
     /**
      * Keep showing the spa-loading-template until suspense:resolve
      *
-     * @default "body"
      *
      * @see [Nuxt Issues #21721](https://github.com/nuxt/nuxt/issues/21721)
      */
@@ -1465,7 +1335,6 @@ export interface ConfigSchema {
      *
      * This feature adds performance markers for Nuxt hooks, allowing you to track their execution time in the browser's Performance tab. This is particularly useful for debugging performance issues.
      *
-     * @default false
      *
      * @example
      * ```ts
@@ -1489,7 +1358,6 @@ export interface ConfigSchema {
      *
      * When enabled, Nuxt will track which modules modify configuration options, making it easier to trace unexpected configuration changes.
      *
-     * @default false
      *
      * @example
      * ```ts
@@ -1511,7 +1379,6 @@ export interface ConfigSchema {
      *
      * This feature intelligently determines when to hydrate lazy components based on visibility, idle time, or other triggers, improving performance by deferring hydration of components until they're needed.
      *
-     * @default true
      *
      * @example
      * ```ts
@@ -1539,7 +1406,6 @@ export interface ConfigSchema {
      *
      * By default, Nuxt attempts to resolve imports in templates relative to the module that added them. Setting this to `false` disables this behavior, which may be useful if you're experiencing resolution conflicts in certain environments.
      *
-     * @default true
      *
      * @example
      * ```ts
@@ -1561,7 +1427,6 @@ export interface ConfigSchema {
      *
      * Nuxt will automatically purge cached data from `useAsyncData` and `nuxtApp.static.data`. This helps prevent memory leaks and ensures fresh data is loaded when needed, but it is possible to disable it.
      *
-     * @default true
      *
      * @example
      * ```ts
@@ -1580,8 +1445,6 @@ export interface ConfigSchema {
 
     /**
      * Whether to call and use the result from `getCachedData` on manual refresh for `useAsyncData` and `useFetch`.
-     *
-     * @default true
      */
     granularCachedData: boolean
 
@@ -1589,29 +1452,21 @@ export interface ConfigSchema {
      * Whether to run `useFetch` when the key changes, even if it is set to `immediate: false` and it has not been triggered yet.
      *
      * `useFetch` and `useAsyncData` will always run when the key changes if `immediate: true` or if it has been already triggered.
-     *
-     * @default false
      */
     alwaysRunFetchOnKeyChange: boolean
 
     /**
      * Whether to parse `error.data` when rendering a server error page.
-     *
-     * @default true
      */
     parseErrorData: boolean
 
     /**
      * Whether Nuxt should stop if a Nuxt module is incompatible.
-     *
-     * @default false
      */
     enforceModuleCompatibility: boolean
 
     /**
      * For `useAsyncData` and `useFetch`, whether `pending` should be `true` when data has not yet started to be fetched.
-     *
-     * @default false
      */
     pendingWhenIdle: boolean
   }
@@ -1639,49 +1494,42 @@ export interface ConfigSchema {
   }
 
   /**
-   * @default 4
    *
    * @private
    */
   _majorVersion: number
 
   /**
-   * @default false
    *
    * @private
    */
   _legacyGenerate: boolean
 
   /**
-   * @default false
    *
    * @private
    */
   _start: boolean
 
   /**
-   * @default false
    *
    * @private
    */
   _build: boolean
 
   /**
-   * @default false
    *
    * @private
    */
   _generate: boolean
 
   /**
-   * @default false
    *
    * @private
    */
   _prepare: boolean
 
   /**
-   * @default false
    *
    * @private
    */
@@ -1712,7 +1560,6 @@ export interface ConfigSchema {
   _nuxtConfigFiles: Array<string>
 
   /**
-   * @default ""
    *
    * @private
    */
@@ -1805,7 +1652,6 @@ export interface ConfigSchema {
   /**
    * TypeScript comes with certain checks to give you more safety and analysis of your program. Once you’ve converted your codebase to TypeScript, you can start enabling these checks for greater safety. [Read More](https://www.typescriptlang.org/docs/handbook/migrating-from-javascript.html#getting-stricter-checks)
    *
-   * @default true
    */
     strict: boolean
 
@@ -1814,21 +1660,16 @@ export interface ConfigSchema {
      *
      * By default Nuxt infers this based on your `builder` option (defaulting to 'vite') but you can either turn off builder environment types (with `false`) to handle this fully yourself, or opt for a 'shared' option.
      * The 'shared' option is advised for module authors, who will want to support multiple possible builders.
-     *
      */
     builder: 'vite' | 'webpack' | 'rspack' | 'shared' | false | undefined | null
 
     /**
      * Modules to generate deep aliases for within `compilerOptions.paths`. This does not yet support subpaths. It may be necessary when using Nuxt within a pnpm monorepo with `shamefully-hoist=false`.
-     *
-     * @default ["nitro/types","nitro/runtime","defu","h3","consola","ofetch","@unhead/vue","@nuxt/devtools","vue","@vue/runtime-core","@vue/compiler-sfc","vue-router","vue-router/auto-routes","unplugin-vue-router/client","@nuxt/schema","nuxt"]
      */
     hoist: Array<string>
 
     /**
      * Include parent workspace in the Nuxt project. Mostly useful for themes and module authors.
-     *
-     * @default false
      */
     includeWorkspace: boolean
 
@@ -1837,7 +1678,6 @@ export interface ConfigSchema {
      *
      * If set to true, this will type check in development. You can restrict this to build-time type checking by setting it to `build`. Requires to install `typescript` and `vue-tsc` as dev dependencies.
      *
-     * @default false
      *
      * @see [Nuxt TypeScript docs](https://nuxt.com/docs/guide/concepts/typescript)
      */
@@ -1845,7 +1685,6 @@ export interface ConfigSchema {
 
     /**
      * You can extend generated `.nuxt/tsconfig.json` using this option.
-     *
      */
     tsConfig: 0 extends 1 & RawVueCompilerOptions ? TSConfig : TSConfig & { vueCompilerOptions?: RawVueCompilerOptions }
 
@@ -1854,8 +1693,6 @@ export interface ConfigSchema {
      *
      * We recommend instead letting the [official Vue extension](https://marketplace.visualstudio.com/items?itemName=Vue.volar) generate accurate types for your components.
      * Note that you may wish to set this to `true` if you are using other libraries, such as ESLint, that are unable to understand the type of `.vue` files.
-     *
-     * @default false
      */
     shim: boolean
   }
@@ -1895,7 +1732,6 @@ export interface ConfigSchema {
      *
      * It is normally enabled by CLI argument `--profile`.
      *
-     * @default false
      *
      * @see [webpackbar](https://github.com/unjs/webpackbar#profile).
      */
@@ -1906,7 +1742,6 @@ export interface ConfigSchema {
      *
      * Using [mini-css-extract-plugin](https://github.com/webpack-contrib/mini-css-extract-plugin) under the hood, your CSS will be extracted into separate files, usually one per component. This allows caching your CSS and JavaScript separately.
      *
-     * @default true
      *
      * @example
      * ```js
@@ -1952,8 +1787,6 @@ export interface ConfigSchema {
 
     /**
      * Enables CSS source map support (defaults to `true` in development).
-     *
-     * @default false
      */
     cssSourceMap: boolean
 
@@ -1961,8 +1794,6 @@ export interface ConfigSchema {
      * The polyfill library to load to provide URL and URLSearchParams.
      *
      * Defaults to `'url'` ([see package](https://www.npmjs.com/package/url)).
-     *
-     * @default "url"
      */
     serverURLPolyfill: string
 
@@ -1999,7 +1830,6 @@ export interface ConfigSchema {
 
     /**
      * Customize the options of Nuxt's integrated webpack loaders.
-     *
      */
     loaders: {
       /**
@@ -2016,10 +1846,8 @@ export interface ConfigSchema {
        * ```
        */
       file: {
-        /** @default false */
         esModule: boolean
 
-        /** @default 1000 */
         limit: number
       }
 
@@ -2032,10 +1860,8 @@ export interface ConfigSchema {
        * ```
        */
       fontUrl: {
-        /** @default false */
         esModule: boolean
 
-        /** @default 1000 */
         limit: number
       }
 
@@ -2048,17 +1874,15 @@ export interface ConfigSchema {
        * ```
        */
       imgUrl: {
-        /** @default false */
         esModule: boolean
 
-        /** @default 1000 */
         limit: number
       }
 
       /**
        * @see [`pug` options](https://pugjs.org/api/reference.html#options)
        */
-      pugPlain: Options2
+      pugPlain: PugOptions
 
       /**
        * See [vue-loader](https://github.com/vuejs/vue-loader) for available options.
@@ -2069,12 +1893,10 @@ export interface ConfigSchema {
        * See [css-loader](https://github.com/webpack-contrib/css-loader) for available options.
        */
       css: {
-        /** @default 0 */
         importLoaders: number
 
         url: boolean | { filter: (url: string, resourcePath: string) => boolean }
 
-        /** @default false */
         esModule: boolean
       }
 
@@ -2082,16 +1904,13 @@ export interface ConfigSchema {
        * See [css-loader](https://github.com/webpack-contrib/css-loader) for available options.
        */
       cssModules: {
-        /** @default 0 */
         importLoaders: number
 
         url: boolean | { filter: (url: string, resourcePath: string) => boolean }
 
-        /** @default false */
         esModule: boolean
 
         modules: {
-          /** @default "[local]_[hash:base64:5]" */
           localIdentName: string
         }
       }
@@ -2115,7 +1934,6 @@ export interface ConfigSchema {
        */
       sass: {
         sassOptions: {
-          /** @default true */
           indentedSyntax: boolean
         }
       }
@@ -2152,8 +1970,6 @@ export interface ConfigSchema {
 
     /**
      * Hard-replaces `typeof process`, `typeof window` and `typeof document` to tree-shake bundle.
-     *
-     * @default false
      */
     aggressiveCodeRemoval: boolean
 
@@ -2162,7 +1978,6 @@ export interface ConfigSchema {
      *
      * Defaults to true when `extractCSS` is enabled.
      *
-     * @default false
      *
      * @see [css-minimizer-webpack-plugin documentation](https://github.com/webpack-contrib/css-minimizer-webpack-plugin).
      */
@@ -2171,44 +1986,36 @@ export interface ConfigSchema {
 
     /**
      * Configure [webpack optimization](https://webpack.js.org/configuration/optimization/).
-     *
      */
     optimization: false | Configuration['optimization']
 
     /**
      * Customize PostCSS Loader. same options as [`postcss-loader` options](https://github.com/webpack-contrib/postcss-loader#options)
-     *
      */
     postcss: { execute?: boolean, postcssOptions: ProcessOptions & { plugins: Record<string, unknown> & { autoprefixer?: Options0, cssnano?: Options1 } }, sourceMap?: boolean, implementation?: any }
 
     /**
      * See [webpack-dev-middleware](https://github.com/webpack/webpack-dev-middleware) for available options.
-     *
      */
     devMiddleware: Options3<IncomingMessage, ServerResponse>
 
     /**
      * See [webpack-hot-middleware](https://github.com/webpack-contrib/webpack-hot-middleware) for available options.
-     *
      */
     hotMiddleware: MiddlewareOptions & { client?: ClientOptions }
 
     /**
      * Set to `false` to disable the overlay provided by [FriendlyErrorsWebpackPlugin](https://github.com/nuxt/friendly-errors-webpack-plugin).
-     *
-     * @default true
      */
     friendlyErrors: boolean
 
     /**
      * Filters to hide build warnings.
-     *
      */
     warningIgnoreFilters: Array<(warn: WebpackError | Error) => boolean>
 
     /**
      * Configure [webpack experiments](https://webpack.js.org/configuration/experiments/)
-     *
      */
     experiments: false | Configuration['experiments']
   }

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1839,11 +1839,6 @@ export interface ConfigSchema {
 
       /**
        * @see [`file-loader` Options](https://github.com/webpack-contrib/file-loader#options)
-       *
-       * @default
-       * ```ts
-       * { esModule: false }
-       * ```
        */
       file: {
         esModule: boolean
@@ -1853,11 +1848,6 @@ export interface ConfigSchema {
 
       /**
        * @see [`file-loader` Options](https://github.com/webpack-contrib/file-loader#options)
-       *
-       * @default
-       * ```ts
-       * { esModule: false }
-       * ```
        */
       fontUrl: {
         esModule: boolean
@@ -1867,11 +1857,6 @@ export interface ConfigSchema {
 
       /**
        * @see [`file-loader` Options](https://github.com/webpack-contrib/file-loader#options)
-       *
-       * @default
-       * ```ts
-       * { esModule: false }
-       * ```
        */
       imgUrl: {
         esModule: boolean
@@ -1922,15 +1907,6 @@ export interface ConfigSchema {
 
       /**
        * @see [`sass-loader` Options](https://github.com/webpack-contrib/sass-loader#options)
-       *
-       * @default
-       * ```ts
-       * {
-       *   sassOptions: {
-       *     indentedSyntax: true
-       *   }
-       * }
-       * ```
        */
       sass: {
         sassOptions: {

--- a/packages/schema/src/utils/definition.ts
+++ b/packages/schema/src/utils/definition.ts
@@ -46,7 +46,5 @@ type Resolvable<Namespace> = keyof Exclude<NonNullable<Namespace>, boolean | str
   : Namespace | Resolvers<Namespace>
 
 export function defineResolvers<C extends Partial<Resolvable<ConfigSchema>>> (config: C) {
-  return config /* as C */
+  return config as any
 }
-
-export type ResolvableConfigSchema = Partial<Resolvable<ConfigSchema>>

--- a/packages/schema/src/utils/definition.ts
+++ b/packages/schema/src/utils/definition.ts
@@ -46,7 +46,7 @@ type Resolvable<Namespace> = keyof Exclude<NonNullable<Namespace>, boolean | str
   : Namespace | Resolvers<Namespace>
 
 export function defineResolvers<C extends Partial<Resolvable<ConfigSchema>>> (config: C) {
-  return config as C
+  return config /* as C */
 }
 
 export type ResolvableConfigSchema = Partial<Resolvable<ConfigSchema>>

--- a/packages/schema/src/utils/definition.ts
+++ b/packages/schema/src/utils/definition.ts
@@ -1,7 +1,5 @@
 import type { InputObject } from 'untyped'
 
-import { defineUntypedSchema } from 'untyped'
-
 import type { ConfigSchema } from '../types/schema'
 
 type KeysOf<T, Prefix extends string | unknown = unknown> = keyof T extends string
@@ -48,9 +46,7 @@ type Resolvable<Namespace> = keyof Exclude<NonNullable<Namespace>, boolean | str
   : Namespace | Resolvers<Namespace>
 
 export function defineResolvers<C extends Partial<Resolvable<ConfigSchema>>> (config: C) {
-  return defineUntypedSchema(config) /* as C */
+  return config as C
 }
 
 export type ResolvableConfigSchema = Partial<Resolvable<ConfigSchema>>
-
-export { defineUntypedSchema } from 'untyped'


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

we're moving to use a fully typed schema without generated types inferred from values. (follow up on https://github.com/nuxt/nuxt/pull/30844)

we move the generated docs into `docs/3.api/6.nuxt-config.md`, which will then be directly editable (cc: @atinux). we might be able (for example) to coalesce the https://nuxt.com/docs/guide/going-further/experimental-features section into the `nuxt.config` page.
