### PR TITLE
fix(kit,nuxt,schema,vite)!: remove support for some deprecated options

### DIFF
--- a/packages/kit/src/loader/config.ts
+++ b/packages/kit/src/loader/config.ts
@@ -39,7 +39,8 @@ export async function loadNuxtConfig (opts: LoadNuxtConfigOptions): Promise<Nuxt
     extend: { extendKey: ['theme', '_extends', 'extends'] },
     dotenv: true,
     globalRc: true,
-    merger: merger as any, // TODO: fix type in c12, it should accept createDefu directly
+    // @ts-expect-error TODO: fix type in c12, it should accept createDefu directly
+    merger,
     ...opts,
   })
   delete globalSelf.defineNuxtConfig

--- a/packages/nuxt/src/core/cache.ts
+++ b/packages/nuxt/src/core/cache.ts
@@ -21,7 +21,6 @@ export async function getVueHash (nuxt: Nuxt) {
       join(relative(layer.cwd, layer.config.srcDir), '**'),
       `!${relative(layer.cwd, layer.config.serverDir || join(layer.cwd, 'server'))}/**`,
       `!${relative(layer.cwd, resolve(layer.config.srcDir || layer.cwd, layer.config.dir?.public || 'public'))}/**`,
-      `!${relative(layer.cwd, resolve(layer.config.srcDir || layer.cwd, layer.config.dir?.static || 'public'))}/**`,
       '!node_modules/**',
       '!nuxt.config.*',
     ],

--- a/packages/nuxt/src/core/runtime/nitro/handlers/island.ts
+++ b/packages/nuxt/src/core/runtime/nitro/handlers/island.ts
@@ -83,10 +83,6 @@ export default defineEventHandler(async (event) => {
     }
   }
 
-  // TODO: remove for v4
-  islandHead.link ||= []
-  islandHead.style ||= []
-
   const islandResponse: NuxtIslandResponse = {
     id: islandContext.id,
     head: islandHead,

--- a/packages/nuxt/src/core/runtime/nitro/handlers/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/handlers/renderer.ts
@@ -223,7 +223,6 @@ export default defineRenderHandler(async (event): Promise<Partial<RenderResponse
 
   if (!NO_SCRIPTS) {
     // 4. Resource Hints
-    // TODO: add priorities based on Capo
     ssrContext.head.push({
       link: getPreloadLinks(ssrContext, renderer.rendererContext) as Link[],
     }, headEntryOptions)

--- a/packages/schema/src/config/app.ts
+++ b/packages/schema/src/config/app.ts
@@ -26,17 +26,8 @@ export default defineResolvers({
      * Include Vue compiler in runtime bundle.
      */
     runtimeCompiler: {
-      $resolve: async (val, get) => {
-        if (typeof val === 'boolean') {
-          return val
-        }
-        // @ts-expect-error TODO: formally deprecate in v4
-        const legacyProperty = await get('experimental.runtimeVueCompiler') as unknown
-        if (typeof legacyProperty === 'boolean') {
-          return legacyProperty
-        }
-
-        return false
+      $resolve: (val) => {
+        return typeof val === 'boolean' ? val : false
       },
     },
 
@@ -155,14 +146,12 @@ export default defineResolvers({
      * ```
      */
     head: {
-      $resolve: async (_val, get) => {
-        // @ts-expect-error TODO: remove in Nuxt v4
-        const legacyMetaValues = await get('meta') as Record<string, unknown>
+      $resolve: (_val) => {
         const val: Partial<NuxtAppConfig['head']> = _val && typeof _val === 'object' ? _val : {}
 
         type NormalizedMetaObject = Required<Pick<AppHeadMetaObject, 'meta' | 'link' | 'style' | 'script' | 'noscript'>>
 
-        const resolved: NuxtAppConfig['head'] & NormalizedMetaObject = defu(val, legacyMetaValues, {
+        const resolved: NuxtAppConfig['head'] & NormalizedMetaObject = defu(val, {
           meta: [],
           link: [],
           style: [],
@@ -425,9 +414,6 @@ export default defineResolvers({
       for (const item of val) {
         if (typeof item === 'string') {
           css.push(item)
-        } else if (item && 'src' in item) {
-          // TODO: remove in Nuxt v4
-          css.push(item.src)
         }
       }
       return css

--- a/packages/schema/src/config/build.ts
+++ b/packages/schema/src/config/build.ts
@@ -10,7 +10,7 @@ export default defineResolvers({
    * The builder to use for bundling the Vue part of your application.
    */
   builder: {
-    $resolve: async (val, get) => {
+    $resolve: (val) => {
       if (val && typeof val === 'object' && 'bundle' in val) {
         return val as { bundle: (nuxt: Nuxt) => Promise<void> }
       }
@@ -23,10 +23,6 @@ export default defineResolvers({
       if (typeof val === 'string' && val in map) {
         // TODO: improve normalisation inference
         return map[val as keyof typeof map] as Builder
-      }
-      // @ts-expect-error TODO: remove old, unsupported config in v4
-      if (await get('vite') === false) {
-        return map.webpack as Builder
       }
       return map.vite as Builder
     },

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -398,19 +398,7 @@ export default defineResolvers({
      */
     public: {
       $resolve: async (val, get) => {
-        return resolve(await get('rootDir'), val && typeof val === 'string' ? val : (await get('dir.static') || 'public'))
-      },
-    },
-
-    // TODO: remove in v4
-    static: {
-      // @ts-expect-error schema has invalid types
-      $schema: { deprecated: 'use `dir.public` option instead' },
-      $resolve: async (val, get) => {
-        if (val && typeof val === 'string') {
-          return val
-        }
-        return await get('dir.public') || 'public'
+        return resolve(await get('rootDir'), val && typeof val === 'string' ? val : 'public')
       },
     },
   },

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -778,12 +778,6 @@ export interface ConfigSchema {
      * The directory containing your static files, which will be directly accessible via the Nuxt server and copied across into your `dist` folder when your app is generated.
      */
     public: string
-
-    /**
-     *
-     * @deprecated use `dir.public` option instead
-     */
-    static: string
   }
 
   /**

--- a/packages/vite/src/utils/warmup.ts
+++ b/packages/vite/src/utils/warmup.ts
@@ -1,4 +1,4 @@
-import { builtinModules } from 'node:module'
+import { isBuiltin } from 'node:module'
 import { logger } from '@nuxt/kit'
 import { join, normalize, relative } from 'pathe'
 import { withoutBase } from 'ufo'
@@ -26,12 +26,6 @@ function normaliseURL (url: string, base: string) {
   // strip query
   url = url.replace(/(\?|&)import=?(?:&|$)/, '').replace(/[?&]$/, '')
   return url
-}
-
-// TODO: remove when we drop support for node 18
-const builtins = new Set(builtinModules)
-function isBuiltin (id: string) {
-  return id.startsWith('node:') || builtins.has(id)
 }
 
 // TODO: use built-in warmup logic when we update to vite 5

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -2272,10 +2272,7 @@ describe('component islands', () => {
 
     expect(result).toMatchInlineSnapshot(`
       {
-        "head": {
-          "link": [],
-          "style": [],
-        },
+        "head": {},
         "html": "<pre data-island-uid>    Route: /foo
         </pre>",
       }
@@ -2294,10 +2291,7 @@ describe('component islands', () => {
     result.html = result.html.replaceAll(/ (data-island-uid|data-island-component)="([^"]*)"/g, '')
     expect(result).toMatchInlineSnapshot(`
       {
-        "head": {
-          "link": [],
-          "style": [],
-        },
+        "head": {},
         "html": "<div data-island-uid><div> count is above 2 </div><!--[--><div style="display: contents;" data-island-uid data-island-slot="default"><!--teleport start--><!--teleport end--></div><!--]--> that was very long ... <div id="long-async-component-count">3</div>  <!--[--><div style="display: contents;" data-island-uid data-island-slot="test"><!--teleport start--><!--teleport end--></div><!--]--><p>hello world !!!</p><!--[--><div style="display: contents;" data-island-uid data-island-slot="hello"><!--teleport start--><!--teleport end--></div><!--teleport start--><!--teleport end--><!--]--><!--[--><div style="display: contents;" data-island-uid data-island-slot="fallback"><!--teleport start--><!--teleport end--></div><!--teleport start--><!--teleport end--><!--]--></div>",
         "slots": {
           "default": {
@@ -2357,10 +2351,7 @@ describe('component islands', () => {
     expect(result).toMatchInlineSnapshot(`
       {
         "components": {},
-        "head": {
-          "link": [],
-          "style": [],
-        },
+        "head": {},
         "html": "<div data-island-uid> This is a .server (20ms) async component that was very long ... <div id="async-server-component-count">2</div><div class="sugar-counter"> Sugar Counter 12 x 1 = 12 <button> Inc </button></div><!--[--><div style="display: contents;" data-island-uid data-island-slot="default"><!--teleport start--><!--teleport end--></div><!--]--></div>",
         "props": {},
         "slots": {},
@@ -2388,10 +2379,7 @@ describe('component islands', () => {
       expect(result).toMatchInlineSnapshot(`
         {
           "components": {},
-          "head": {
-            "link": [],
-            "style": [],
-          },
+          "head": {},
           "html": "<div data-island-uid> ServerWithClient.server.vue : <p>count: 0</p> This component should not be preloaded <div><!--[--><div>a</div><div>b</div><div>c</div><!--]--></div> This is not interactive <div class="sugar-counter"> Sugar Counter 12 x 1 = 12 <button> Inc </button></div><div class="interactive-component-wrapper" style="border:solid 1px red;"> The component below is not a slot but declared as interactive <!--[--><div style="display: contents;" data-island-uid data-island-component></div><!--teleport start--><!--teleport end--><!--]--></div></div>",
           "slots": {},
         }
@@ -2433,7 +2421,6 @@ describe('component islands', () => {
     if (!isDev() && !isWebpack) {
       expect(normaliseIslandResult(result).head).toMatchInlineSnapshot(`
         {
-          "link": [],
           "style": [
             {
               "innerHTML": "pre[data-v-xxxxx]{color:#00f}",

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -2266,13 +2266,19 @@ describe('component islands', () => {
     const result = await $fetch<NuxtIslandResponse>('/__nuxt_island/RouteComponent.json?url=/foo')
 
     result.html = result.html.replace(/ data-island-uid="[^"]*"/g, '')
-    if (isDev() && result.head.link) {
+    if (isDev()) {
       result.head.link = result.head.link?.filter(l => typeof l.href !== 'string' || (!l.href.includes('_nuxt/components/islands/RouteComponent') && !l.href.includes('PureComponent') /* TODO: fix dev bug triggered by previous fetch of /islands */))
     }
 
+    result.head.link ||= []
+    result.head.style ||= []
+
     expect(result).toMatchInlineSnapshot(`
       {
-        "head": {},
+        "head": {
+          "link": [],
+          "style": [],
+        },
         "html": "<pre data-island-uid>    Route: /foo
         </pre>",
       }
@@ -2285,13 +2291,19 @@ describe('component islands', () => {
         count: 3,
       }),
     }))
-    if (isDev() && result.head.link) {
+    if (isDev()) {
       result.head.link = result.head.link?.filter(l => typeof l.href !== 'string' || (!l.href.includes('_nuxt/components/islands/LongAsyncComponent') && !l.href.includes('PureComponent') /* TODO: fix dev bug triggered by previous fetch of /islands */))
     }
+
+    result.head.link ||= []
+    result.head.style ||= []
     result.html = result.html.replaceAll(/ (data-island-uid|data-island-component)="([^"]*)"/g, '')
     expect(result).toMatchInlineSnapshot(`
       {
-        "head": {},
+        "head": {
+          "link": [],
+          "style": [],
+        },
         "html": "<div data-island-uid><div> count is above 2 </div><!--[--><div style="display: contents;" data-island-uid data-island-slot="default"><!--teleport start--><!--teleport end--></div><!--]--> that was very long ... <div id="long-async-component-count">3</div>  <!--[--><div style="display: contents;" data-island-uid data-island-slot="test"><!--teleport start--><!--teleport end--></div><!--]--><p>hello world !!!</p><!--[--><div style="display: contents;" data-island-uid data-island-slot="hello"><!--teleport start--><!--teleport end--></div><!--teleport start--><!--teleport end--><!--]--><!--[--><div style="display: contents;" data-island-uid data-island-slot="fallback"><!--teleport start--><!--teleport end--></div><!--teleport start--><!--teleport end--><!--]--></div>",
         "slots": {
           "default": {
@@ -2340,9 +2352,12 @@ describe('component islands', () => {
         count: 2,
       }),
     }))
-    if (isDev() && result.head.link) {
+    if (isDev()) {
       result.head.link = result.head.link?.filter(l => typeof l.href === 'string' && !l.href.includes('PureComponent') /* TODO: fix dev bug triggered by previous fetch of /islands */ && (!l.href.startsWith('_nuxt/components/islands/') || l.href.includes('AsyncServerComponent')))
     }
+
+    result.head.link ||= []
+    result.head.style ||= []
     result.props = {}
     result.components = {}
     result.slots = {}
@@ -2351,7 +2366,10 @@ describe('component islands', () => {
     expect(result).toMatchInlineSnapshot(`
       {
         "components": {},
-        "head": {},
+        "head": {
+          "link": [],
+          "style": [],
+        },
         "html": "<div data-island-uid> This is a .server (20ms) async component that was very long ... <div id="async-server-component-count">2</div><div class="sugar-counter"> Sugar Counter 12 x 1 = 12 <button> Inc </button></div><!--[--><div style="display: contents;" data-island-uid data-island-slot="default"><!--teleport start--><!--teleport end--></div><!--]--></div>",
         "props": {},
         "slots": {},
@@ -2362,7 +2380,7 @@ describe('component islands', () => {
   if (!isWebpack) {
     it('render server component with selective client hydration', async () => {
       const result = await $fetch<NuxtIslandResponse>('/__nuxt_island/ServerWithClient')
-      if (isDev() && result.head.link) {
+      if (isDev()) {
         result.head.link = result.head.link?.filter(l => typeof l.href !== 'string' || (!l.href.includes('_nuxt/components/islands/LongAsyncComponent') && !l.href.includes('PureComponent') /* TODO: fix dev bug triggered by previous fetch of /islands */))
 
         if (!result.head.link) {
@@ -2376,10 +2394,16 @@ describe('component islands', () => {
 
       const teleportsEntries = Object.entries(components || {})
 
+      result.head.link ||= []
+      result.head.style ||= []
+
       expect(result).toMatchInlineSnapshot(`
         {
           "components": {},
-          "head": {},
+          "head": {
+            "link": [],
+            "style": [],
+          },
           "html": "<div data-island-uid> ServerWithClient.server.vue : <p>count: 0</p> This component should not be preloaded <div><!--[--><div>a</div><div>b</div><div>c</div><!--]--></div> This is not interactive <div class="sugar-counter"> Sugar Counter 12 x 1 = 12 <button> Inc </button></div><div class="interactive-component-wrapper" style="border:solid 1px red;"> The component below is not a slot but declared as interactive <!--[--><div style="display: contents;" data-island-uid data-island-component></div><!--teleport start--><!--teleport end--><!--]--></div></div>",
           "slots": {},
         }

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -2266,7 +2266,7 @@ describe('component islands', () => {
     const result = await $fetch<NuxtIslandResponse>('/__nuxt_island/RouteComponent.json?url=/foo')
 
     result.html = result.html.replace(/ data-island-uid="[^"]*"/g, '')
-    if (isDev()) {
+    if (isDev() && result.head.link) {
       result.head.link = result.head.link?.filter(l => typeof l.href !== 'string' || (!l.href.includes('_nuxt/components/islands/RouteComponent') && !l.href.includes('PureComponent') /* TODO: fix dev bug triggered by previous fetch of /islands */))
     }
 
@@ -2285,7 +2285,7 @@ describe('component islands', () => {
         count: 3,
       }),
     }))
-    if (isDev()) {
+    if (isDev() && result.head.link) {
       result.head.link = result.head.link?.filter(l => typeof l.href !== 'string' || (!l.href.includes('_nuxt/components/islands/LongAsyncComponent') && !l.href.includes('PureComponent') /* TODO: fix dev bug triggered by previous fetch of /islands */))
     }
     result.html = result.html.replaceAll(/ (data-island-uid|data-island-component)="([^"]*)"/g, '')
@@ -2340,7 +2340,7 @@ describe('component islands', () => {
         count: 2,
       }),
     }))
-    if (isDev()) {
+    if (isDev() && result.head.link) {
       result.head.link = result.head.link?.filter(l => typeof l.href === 'string' && !l.href.includes('PureComponent') /* TODO: fix dev bug triggered by previous fetch of /islands */ && (!l.href.startsWith('_nuxt/components/islands/') || l.href.includes('AsyncServerComponent')))
     }
     result.props = {}
@@ -2362,7 +2362,7 @@ describe('component islands', () => {
   if (!isWebpack) {
     it('render server component with selective client hydration', async () => {
       const result = await $fetch<NuxtIslandResponse>('/__nuxt_island/ServerWithClient')
-      if (isDev()) {
+      if (isDev() && result.head.link) {
         result.head.link = result.head.link?.filter(l => typeof l.href !== 'string' || (!l.href.includes('_nuxt/components/islands/LongAsyncComponent') && !l.href.includes('PureComponent') /* TODO: fix dev bug triggered by previous fetch of /islands */))
 
         if (!result.head.link) {
@@ -2445,7 +2445,6 @@ describe('component islands', () => {
               "rel": "stylesheet",
             },
           ],
-          "style": [],
         }
       `)
     }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

removal of support for various options that have been invalid for a while:

- `dir.static` (now `dir.public`)
- `experimental.runtimeVueCompiler` (now `vue.runtimeCompiler`)
- `vite: false` (now `builder: 'webpack'`)
- `css: [{ src: 'something' }]` (now `css: ['something']`)
- dropping empty link/style arrays from island response