### PR TITLE
fix(nuxt): return non-existent route component in RouteProvider

### DIFF
--- a/packages/nuxt/src/app/components/route-provider.ts
+++ b/packages/nuxt/src/app/components/route-provider.ts
@@ -6,14 +6,11 @@ import { PageRouteSymbol } from './injections'
 export const defineRouteProvider = (name = 'RouteProvider') => defineComponent({
   name,
   props: {
-    vnode: {
-      type: Object as () => VNode,
-      required: true,
-    },
     route: {
       type: Object as () => RouteLocationNormalizedLoaded,
       required: true,
     },
+    vnode: Object as () => VNode,
     vnodeRef: Object as () => Ref<any>,
     renderKey: String,
     trackRootNodes: Boolean,
@@ -47,6 +44,9 @@ export const defineRouteProvider = (name = 'RouteProvider') => defineComponent({
     }
 
     return () => {
+      if (!props.vnode) {
+        return props.vnode
+      }
       if (import.meta.dev && import.meta.client) {
         vnode = h(props.vnode, { ref: props.vnodeRef })
         return vnode


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

when rendering a nested child page that doesn't exist an undefined vnode might be passed to `<RouteProvider>`, leading to a long and unclear warning in the terminal. This directly returns the vnode in this case.