### PR TITLE
fix(vite): use arrow functions in dynamic imports

### DIFF
--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -101,6 +101,8 @@ export async function buildServer (ctx: ViteBuildContext) {
           generatedCode: {
             symbols: true, // temporary fix for https://github.com/vuejs/core/issues/8351,
             constBindings: true,
+            // temporary fix for https://github.com/rollup/rollup/issues/5975
+            arrowFunctions: true,
           },
         },
         onwarn (warning, rollupWarn) {


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/32175

### 📚 Description

due to an upstream rollup bug in how arrow functions vs inline functions are treated (it fails to collect dependencies correctly), it strips default exports from dynamically imported modules

by emitting arrow functions instead we bypass this, but we can revisit when it a fix is merged upstream