### PR TITLE
feat(kit): support single import in `addServerImports`

### DIFF
--- a/docs/3.api/5.kit/11.nitro.md
+++ b/docs/3.api/5.kit/11.nitro.md
@@ -305,16 +305,16 @@ import { defineNuxtModule, createResolver, addServerImports } from '@nuxt/kit'
 export default defineNuxtModule({
   setup(options) {
     const names = [
-      "useStoryblok",
-      "useStoryblokApi",
-      "useStoryblokBridge",
-      "renderRichText",
-      "RichTextSchema"
-    ];
+      'useStoryblok',
+      'useStoryblokApi',
+      'useStoryblokBridge',
+      'renderRichText',
+      'RichTextSchema'
+    ]
 
     names.forEach((name) =>
-      addServerImports({ name, as: name, from: "@storyblok/vue" })
-    );
+      addServerImports({ name, as: name, from: '@storyblok/vue' })
+    )
   }
 })
 ```

--- a/docs/3.api/5.kit/11.nitro.md
+++ b/docs/3.api/5.kit/11.nitro.md
@@ -293,7 +293,6 @@ function addPrerenderRoutes (routes: string | string[]): void
 | ----------- | ------------------------------- | -------- | ---------------------------------------------- |
 | `routes`    | `string \| string[]`{lang="ts"} | `true`   | A route or an array of routes to prerender.    |
 
-
 ## `addServerImports`
 
 Add imports to the server. It makes your imports available in Nitro without the need to import them manually.

--- a/docs/3.api/5.kit/11.nitro.md
+++ b/docs/3.api/5.kit/11.nitro.md
@@ -293,6 +293,54 @@ function addPrerenderRoutes (routes: string | string[]): void
 | ----------- | ------------------------------- | -------- | ---------------------------------------------- |
 | `routes`    | `string \| string[]`{lang="ts"} | `true`   | A route or an array of routes to prerender.    |
 
+
+## `addServerImports`
+
+Add imports to the server. It makes your imports available in Nitro without the need to import them manually.
+
+### Usage
+
+```ts twoslash
+import { defineNuxtModule, createResolver, addServerImports } from '@nuxt/kit'
+
+export default defineNuxtModule({
+  setup(options) {
+    const names = [
+      "useStoryblok",
+      "useStoryblokApi",
+      "useStoryblokBridge",
+      "renderRichText",
+      "RichTextSchema"
+    ];
+
+    names.forEach((name) =>
+      addServerImports({ name, as: name, from: "@storyblok/vue" })
+    );
+  }
+})
+```
+
+### Type
+
+```ts
+function addServerImports (dirs: Import | Import[]): void
+```
+
+### Parameters
+
+`imports`: An object or an array of objects with the following properties:
+
+| Property           | Type                         | Required | Description                                                                                                     |
+| ------------------ | ---------------------------- | -------- | --------------------------------------------------------------------------------------------------------------- |
+| `name`             | `string`                     | `true`   | Import name to be detected.                                                                                     |
+| `from`             | `string`                     | `true`   | Module specifier to import from.                                                                                |
+| `priority`         | `number`                     | `false`  | Priority of the import; if multiple imports have the same name, the one with the highest priority will be used. |
+| `disabled`         | `boolean`                    | `false`  | If this import is disabled.                                                                                     |
+| `meta`             | `Record<string, any>`        | `false`  | Metadata of the import.                                                                                         |
+| `type`             | `boolean`                    | `false`  | If this import is a pure type import.                                                                           |
+| `typeFrom`         | `string`                     | `false`  | Use this as the `from` value when generating type declarations.                                                 |
+| `as`               | `string`                     | `false`  | Import as this name.                                                                                            |
+
 ## `addServerImportsDir`
 
 Add a directory to be scanned for auto-imports by Nitro.

--- a/docs/3.api/5.kit/4.autoimports.md
+++ b/docs/3.api/5.kit/4.autoimports.md
@@ -34,16 +34,16 @@ import { defineNuxtModule, addImports } from "@nuxt/kit";
 export default defineNuxtModule({
   setup(options, nuxt) {
     const names = [
-      "useStoryblok",
-      "useStoryblokApi",
-      "useStoryblokBridge",
-      "renderRichText",
-      "RichTextSchema"
-    ];
+      'useStoryblok',
+      'useStoryblokApi',
+      'useStoryblokBridge',
+      'renderRichText',
+      'RichTextSchema'
+    ]
 
     names.forEach((name) =>
-      addImports({ name, as: name, from: "@storyblok/vue" })
-    );
+      addImports({ name, as: name, from: '@storyblok/vue' })
+    )
   }
 })
 ```

--- a/packages/kit/src/nitro.ts
+++ b/packages/kit/src/nitro.ts
@@ -86,12 +86,13 @@ export function useNitro (): Nitro {
 /**
  * Add server imports to be auto-imported by Nitro
  */
-export function addServerImports (imports: Import[]) {
+export function addServerImports (imports: Import | Import[]) {
   const nuxt = useNuxt()
+  const _imports = toArray(imports)
   nuxt.hook('nitro:config', (config) => {
     config.imports ||= {}
     config.imports.imports ||= []
-    config.imports.imports.push(...imports)
+    config.imports.imports.push(..._imports)
   })
 }
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Noticed that `addServerImports` does not support passing a single import like [`addImports`](https://nuxt.com/docs/api/kit/autoimports#addimports) does. I haven't actually tested the code changes, but I matched the logic of `addServerImportsDir`.

While adding this I noticed the documentation was missing `addServerImports` entirely so I added that as well, this is basically the same as the documentation for `addImports`, feels a bit weird to duplicate it...
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
