### PR TITLE
fix(nuxt): use augmented `NuxtApp` as plugin argument type

### DIFF
--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -224,7 +224,7 @@ export interface ResolvedPluginMeta {
 }
 
 export interface Plugin<Injections extends Record<string, unknown> = Record<string, unknown>> {
-  (nuxt: _NuxtApp): Promise<void> | Promise<{ provide?: Injections }> | void | { provide?: Injections }
+  (nuxt: NuxtApp): Promise<void> | Promise<{ provide?: Injections }> | void | { provide?: Injections }
   [NuxtPluginIndicator]?: true
   meta?: ResolvedPluginMeta
 }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
The `_NuxtApp` type used for the argument of `defineNuxtPlugin` does not include augmentations, if this is intended I am curious to know why.

Every now and then an issue opens on nuxt-i18n that claim that the types are incorrect, this is the case when trying to access `nuxtApp.$i18n` rather than `useNuxtApp().$i18n`. But the same applies to other augmentations like `nuxtApp.$router`, but my guess is that users probably work around that by using the `useRouter()` composable.

Reproduction https://stackblitz.com/edit/github-z4qhnxvg?file=plugins%2Fmy-plugin.ts

The type issue
<img width="497" alt="image" src="https://github.com/user-attachments/assets/33bc9456-ff5b-4cea-b45f-f91379871244" />

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
