### PR TITLE
fix(nuxt): respect `inheritAttrs: false` in `createClientOnly` fn

### DIFF
--- a/packages/nuxt/src/app/components/client-only.ts
+++ b/packages/nuxt/src/app/components/client-only.ts
@@ -123,9 +123,11 @@ export function createClientOnly<T extends ComponentOptions> (component: T) {
         return (...args: any[]) => {
           if (mounted$.value) {
             const res = setupState(...args)
+            const attrs = clone.inheritAttrs !== false ? ctx.attrs : undefined
+
             return (res.children === null || typeof res.children === 'string')
-              ? cloneVNode(res, ctx.attrs)
-              : h(res, ctx.attrs)
+              ? cloneVNode(res, attrs)
+              : h(res, attrs)
           }
           return elToStaticVNode(instance?.vnode.el, STATIC_DIV)
         }

--- a/test/nuxt/client-only.test.ts
+++ b/test/nuxt/client-only.test.ts
@@ -79,6 +79,22 @@ describe('client-only', () => {
   })
 })
 
+describe('createClientOnly', () => {
+  it('should not inherit attributes if disabled', async () => {
+    const NonInherited = createClientOnly({
+      inheritAttrs: false,
+      setup: () => () => h('div', 'foo'),
+    })
+    const component = defineComponent({
+      setup () {
+        return () => h(NonInherited, { class: 'test', id: 'test' })
+      },
+    })
+    const wrapper = await mountSuspended(component)
+    expect(wrapper.html()).toMatchInlineSnapshot(`"<div>foo</div>"`)
+  })
+})
+
 const Client = defineComponent({
   name: 'TestClient',
   setup () {


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/32317

### 📚 Description

Makes client component respect `inheritAttrs: false` in linked case.