### PR TITLE
fix(kit): do not double-urlify file urls when resolving schema

### DIFF
--- a/packages/kit/src/loader/config.ts
+++ b/packages/kit/src/loader/config.ts
@@ -8,7 +8,7 @@ import type { NuxtConfig, NuxtOptions } from '@nuxt/schema'
 import { glob } from 'tinyglobby'
 import defu, { createDefu } from 'defu'
 import { basename, join, relative } from 'pathe'
-import { resolveModuleURL } from 'exsolve'
+import { resolveModulePath, resolveModuleURL } from 'exsolve'
 
 import { directoryToURL } from '../internal/esm'
 
@@ -123,10 +123,10 @@ export async function loadNuxtConfig (opts: LoadNuxtConfigOptions): Promise<Nuxt
 
 async function loadNuxtSchema (cwd: string) {
   const url = directoryToURL(cwd)
-  const urls = [url]
+  const urls: Array<URL | string> = [url]
   const nuxtPath = resolveModuleURL('nuxt', { try: true, from: url }) ?? resolveModuleURL('nuxt-nightly', { try: true, from: url })
   if (nuxtPath) {
-    urls.unshift(pathToFileURL(nuxtPath))
+    urls.unshift(nuxtPath)
   }
   const schemaPath = resolveModuleURL('@nuxt/schema', { try: true, from: urls }) ?? '@nuxt/schema'
   return await import(schemaPath).then(r => r.NuxtConfigSchema)

--- a/packages/kit/src/loader/config.ts
+++ b/packages/kit/src/loader/config.ts
@@ -1,5 +1,4 @@
 import { existsSync } from 'node:fs'
-import { pathToFileURL } from 'node:url'
 import type { JSValue } from 'untyped'
 import { applyDefaults } from 'untyped'
 import type { ConfigLayer, ConfigLayerMeta, LoadConfigOptions } from 'c12'
@@ -8,7 +7,7 @@ import type { NuxtConfig, NuxtOptions } from '@nuxt/schema'
 import { glob } from 'tinyglobby'
 import defu, { createDefu } from 'defu'
 import { basename, join, relative } from 'pathe'
-import { resolveModulePath, resolveModuleURL } from 'exsolve'
+import { resolveModuleURL } from 'exsolve'
 
 import { directoryToURL } from '../internal/esm'
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/32311

### 📚 Description

we were wrongly converting file URLs to file URLs, meaning nuxt/schema wasn't being resolved from within the nuxt directory.