### PR TITLE
fix(schema)!: remove top level generate option

### DIFF
--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -1004,6 +1004,44 @@ These options have been set to their current values for some time and we do not 
 
 * `respectNoSSRHeader`is implementable in user-land with [server middleware](https://github.com/nuxt/nuxt/blob/c660b39447f0d5b8790c0826092638d321cd6821/packages/nuxt/src/core/runtime/nitro/no-ssr.ts#L8-L9)
 
+### Removal of Top-Level `generate` Configuration
+
+🚦 **Impact Level**: Minimal
+
+#### What Changed
+
+The top-level `generate` configuration option is no longer available in Nuxt 4. This includes all of its properties:
+
+* `generate.exclude` - for excluding routes from prerendering
+* `generate.routes` - for specifying routes to prerender
+
+#### Reasons for Change
+
+The top level `generate` configuration was a holdover from Nuxt 2. We've supported `nitro.prerender` for a while now, and it is the preferred way to configure prerendering in Nuxt 3+.
+
+#### Migration Steps
+
+Replace `generate` configuration with the corresponding `nitro.prerender` options:
+
+```diff
+export default defineNuxtConfig({
+- generate: {
+-   exclude: ['/admin', '/private'],
+-   routes: ['/sitemap.xml', '/robots.txt']
+- }
++ nitro: {
++   prerender: {
++     ignore: ['/admin', '/private'],
++     routes: ['/sitemap.xml', '/robots.txt']
++   }
++ }
+})
+```
+
+::read-more{to="https://nitro.build/config/#prerender"}
+Read more about Nitro's prerender configuration options.
+::
+
 ## Nuxt 2 vs. Nuxt 3+
 
 In the table below, there is a quick comparison between 3 versions of Nuxt:

--- a/docs/3.api/6.nuxt-config.md
+++ b/docs/3.api/6.nuxt-config.md
@@ -1340,28 +1340,6 @@ You can set it to false to use the legacy 'Node' mode, which is the default for 
 
 **See**: [TypeScript PR implementing `bundler` module resolution](https://github.com/microsoft/TypeScript/pull/51669)
 
-## generate
-
-### `exclude`
-
-This option is no longer used. Instead, use `nitro.prerender.ignore`.
-
-- **Type**: `array`
-
-### `routes`
-
-The routes to generate.
-
-If you are using the crawler, this will be only the starting point for route generation. This is often necessary when using dynamic routes.
-It is preferred to use `nitro.prerender.routes`.
-
-- **Type**: `array`
-
-**Example**:
-```js
-routes: ['/users/1', '/users/2', '/users/3']
-```
-
 ## hooks
 
 Hooks are listeners to Nuxt events that are typically used in modules, but are also available in `nuxt.config`.

--- a/packages/nuxt/src/core/cache.ts
+++ b/packages/nuxt/src/core/cache.ts
@@ -35,7 +35,6 @@ export async function getVueHash (nuxt: Nuxt) {
       runtimeConfig: undefined,
       logLevel: undefined,
       devServerHandlers: undefined,
-      generate: undefined,
       devtools: undefined,
     },
   })

--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -170,7 +170,9 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
       ignoreUnprefixedPublicAssets: true,
       failOnError: true,
       concurrency: cpus().length * 4 || 4,
-      routes: ([] as string[]).concat(nuxt.options.generate.routes),
+      routes: ([] as string[])
+        // @ts-expect-error TODO: remove in nuxt v5
+        .concat(nuxt.options.generate.routes),
     },
     sourceMap: nuxt.options.sourcemap.server,
     externals: {

--- a/packages/schema/src/config/generate.ts
+++ b/packages/schema/src/config/generate.ts
@@ -1,25 +1,9 @@
 import { defineResolvers } from '../utils/definition'
 
 export default defineResolvers({
+  // @ts-expect-error TODO: remove in nuxt v5
   generate: {
-    /**
-     * The routes to generate.
-     *
-     * If you are using the crawler, this will be only the starting point for route generation.
-     * This is often necessary when using dynamic routes.
-     *
-     * It is preferred to use `nitro.prerender.routes`.
-     * @example
-     * ```js
-     * routes: ['/users/1', '/users/2', '/users/3']
-     * ```
-     */
     routes: [],
-
-    /**
-     * This option is no longer used. Instead, use `nitro.prerender.ignore`.
-     * @deprecated
-     */
     exclude: [],
   },
 })

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1474,28 +1474,6 @@ export interface ConfigSchema {
     pendingWhenIdle: boolean
   }
 
-  generate: {
-  /**
-   * The routes to generate.
-   *
-   * If you are using the crawler, this will be only the starting point for route generation. This is often necessary when using dynamic routes.
-   * It is preferred to use `nitro.prerender.routes`.
-   *
-   * @example
-   * ```js
-   * routes: ['/users/1', '/users/2', '/users/3']
-   * ```
-   */
-    routes: string | string[]
-
-    /**
-     * This option is no longer used. Instead, use `nitro.prerender.ignore`.
-     *
-     * @deprecated
-     */
-    exclude: Array<any>
-  }
-
   /**
    *
    * @private
@@ -1506,37 +1484,7 @@ export interface ConfigSchema {
    *
    * @private
    */
-  _legacyGenerate: boolean
-
-  /**
-   *
-   * @private
-   */
-  _start: boolean
-
-  /**
-   *
-   * @private
-   */
-  _build: boolean
-
-  /**
-   *
-   * @private
-   */
-  _generate: boolean
-
-  /**
-   *
-   * @private
-   */
   _prepare: boolean
-
-  /**
-   *
-   * @private
-   */
-  _cli: boolean
 
   /**
    *


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/12364

### 📚 Description

this removes top-level `generate` option.

I've also removed types for old CLI flags that are no longer used, although the values (for those) are still present so it will still work at runtime