### PR TITLE
feat(nuxt,schema): add top-level `prerender` alias for `nitro.prerender`

### DIFF
--- a/docs/1.getting-started/15.prerendering.md
+++ b/docs/1.getting-started/15.prerendering.md
@@ -38,7 +38,7 @@ You can now deploy the `.output/public` directory to any static hosting service 
 
 Working of the Nitro crawler:
 
-1. Load the HTML of your application's root route (`/`), any non-dynamic pages in your `~/pages` directory, and any other routes in the `nitro.prerender.routes` array.
+1. Load the HTML of your application's root route (`/`), any non-dynamic pages in your `~/pages` directory, and any other routes in the `prerender.routes` array.
 2. Save the HTML and `payload.json` to the `~/.output/public/` directory to be served statically.
 3. Find all anchor tags (`<a href="...">`) in the HTML to navigate to other routes.
 4. Repeat steps 1-3 for each anchor tag found until there are no more anchor tags to crawl.
@@ -55,11 +55,9 @@ You can manually specify routes that [Nitro](/docs/guide/concepts/server-engine)
 
 ```ts twoslash [nuxt.config.ts]
 export default defineNuxtConfig({
-  nitro: {
-    prerender: {
-      routes: ["/user/1", "/user/2"],
-      ignore: ["/dynamic"],
-    },
+  prerender: {
+    routes: ["/user/1", "/user/2"],
+    ignore: ["/dynamic"],
   },
 });
 ```
@@ -68,16 +66,14 @@ You can combine this with the `crawlLinks` option to pre-render a set of routes 
 
 ```ts twoslash [nuxt.config.ts]
 export default defineNuxtConfig({
-  nitro: {
-    prerender: {
-      crawlLinks: true,
-      routes: ["/sitemap.xml", "/robots.txt"],
-    },
+  prerender: {
+    crawlLinks: true,
+    routes: ["/sitemap.xml", "/robots.txt"],
   },
 });
 ```
 
-Setting `nitro.prerender` to `true` is similar to `nitro.prerender.crawlLinks` to `true`.
+Setting `prerender` to `true` is similar to `prerender.crawlLinks` to `true`.
 
 ::read-more{to="https://nitro.build/config#prerender"}
 Read more about pre-rendering in the Nitro documentation.

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -812,6 +812,7 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
   // Ensure we share key config between Nuxt and Nitro
   createPortalProperties(options.nitro.runtimeConfig, options, ['nitro.runtimeConfig', 'runtimeConfig'])
   createPortalProperties(options.nitro.routeRules, options, ['nitro.routeRules', 'routeRules'])
+  createPortalProperties(options.nitro.prerender, options, ['nitro.prerender', 'prerender'])
 
   // prevent replacement of options.nitro
   const nitroOptions = options.nitro

--- a/packages/schema/src/config/nitro.ts
+++ b/packages/schema/src/config/nitro.ts
@@ -32,6 +32,14 @@ export default defineResolvers({
         }
       },
     },
+    prerender: {
+      $resolve: async (val, get) => {
+        return {
+          ...await get('prerender'),
+          ...(val && typeof val === 'object' ? val : {}),
+        }
+      },
+    },
   },
 
   /**
@@ -40,6 +48,8 @@ export default defineResolvers({
    * @see [Nitro route rules documentation](https://nitro.build/config/#routerules)
    */
   routeRules: {},
+
+  prerender: {},
 
   /**
    * Nitro server handlers.

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1596,6 +1596,8 @@ export interface ConfigSchema {
    */
   routeRules: NitroConfig['routeRules']
 
+  prerender: NitroConfig['prerender']
+
   /**
    * Nitro server handlers.
    *


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/15440

### 📚 Description

this adds a new top-level `prerender` optioni, which is an alias for `nitro.prerender`, much as nuxt also has a top-level `runtimeConfig` and `routeRules`. It will also be a place we can add nuxt-specific prerendering options in future.
