### PR TITLE
fix(nuxt): pass `output.generatedCode.symbols: true` to nitro for rolldown-vite

### DIFF
--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -239,7 +239,7 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
     rollupConfig: {
       output: {
         generatedCode: {
-          symbols: true, // temporary fix for https://github.com/vuejs/core/issues/8351,
+          symbols: true, // temporary fix for https://github.com/vuejs/core/issues/8351
         },
       },
       plugins: [],

--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -237,7 +237,11 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
       '__VUE_PROD_DEVTOOLS__': String(false),
     },
     rollupConfig: {
-      output: {},
+      output: {
+        generatedCode: {
+          symbols: true, // temporary fix for https://github.com/vuejs/core/issues/8351,
+        },
+      },
       plugins: [],
     },
     logLevel: logLevelMapReverse[nuxt.options.logLevel],


### PR DESCRIPTION
### 🔗 Linked issue

refs #30654
refs #31812

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Rolldown currently does not inline dynamic imports that imports statically imported modules (https://github.com/rolldown/rolldown/issues/4905). This is the feature in rollup that requires Nuxt to set `output.generatedCode.symbols: true` as a workaround for https://github.com/vuejs/core/issues/8351.

Because Rolldown does not inline dynamic imports, Nitro (which uses Rollup) sees that and inlines them. However, since `output.generatedCode.symbols: true` is not set for Nitro's Rollup build, the generated code encounters https://github.com/vuejs/core/issues/8351. This leads to a test failure due to an import error on server side for this component: https://github.com/nuxt/nuxt/blob/017d1bed05b83e889d51c27d251a69c326ca7beb/test/fixtures/basic/app/pages/lazy-import-components/index.vue#L4

Because I didn't find any problems with setting `output.generatedCode.symbols: true` for normal Vite, I've added it unconditionally.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
