### PR TITLE
add nuxt link encoding advice

### DIFF
--- a/docs/3.api/1.components/4.nuxt-link.md
+++ b/docs/3.api/1.components/4.nuxt-link.md
@@ -57,6 +57,9 @@ By default, `<NuxtLink>` uses Vue Router's client side navigation for relative r
 
 The `external` prop explicitly indicates that the link is external. `<NuxtLink>` will render the link as a standard HTML `<a>` tag. This ensures the link behaves correctly, bypassing Vue Router’s logic and directly pointing to the resource.
 
+#### Query Parameters & URL Encoding
+`<NuxtLink>` fully leverages Vue Router’s handling of query parameters and automatically URL-encodes all keys and values. You don’t need to call `encodeURI` or `encodeURIComponent` manually—just pass an object to the query field.
+
 #### Linking to Static Files
 
 For static files in the `/public` directory, such as PDFs or images, use the `external` prop to ensure the link resolves correctly.

--- a/docs/3.api/1.components/4.nuxt-link.md
+++ b/docs/3.api/1.components/4.nuxt-link.md
@@ -58,6 +58,7 @@ By default, `<NuxtLink>` uses Vue Router's client side navigation for relative r
 The `external` prop explicitly indicates that the link is external. `<NuxtLink>` will render the link as a standard HTML `<a>` tag. This ensures the link behaves correctly, bypassing Vue Router’s logic and directly pointing to the resource.
 
 #### Query Parameters & URL Encoding
+
 `<NuxtLink>` fully leverages Vue Router’s handling of query parameters and automatically URL-encodes all keys and values. You don’t need to call `encodeURI` or `encodeURIComponent` manually—just pass an object to the query field.
 
 #### Linking to Static Files


### PR DESCRIPTION
### 📚 Description

This PR adds a new “Query Parameters & URL Encoding” section to the <NuxtLink> documentation. By explicitly documenting NuxtLink’s built-in encoding behavior, this change closes an important gap in the reference and prevents developers from manually using encodeURI/encodeURIComponent.
