### PR TITLE
chore: install corepack globally

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,4 +6,4 @@ RUN apt-get update && \
     apt-get autoremove --yes && \
     rm -rf /var/lib/{apt,dpkg,cache,log}
 
-RUN corepack enable && npx playwright install
+RUN npm i -g corepack && corepack enable && npx playwright install


### PR DESCRIPTION
@danielroe , actually I am not sure, but when we use `corepack enable`, shouldn't we need to install it first globally 