### PR TITLE
fix(nuxt): account for app's base URL when reloading app in `nuxt:chunk-reload-immediate`

### DIFF
--- a/packages/nuxt/src/app/plugins/chunk-reload-immediate.client.ts
+++ b/packages/nuxt/src/app/plugins/chunk-reload-immediate.client.ts
@@ -18,8 +18,8 @@ export default defineNuxtPlugin({
     const config = useRuntimeConfig()
 
     function reloadAppAtPath (to: RouteLocationNormalized) {
-      const isHash = 'href' in to && (to.href as string)[0] === '#'
-      const path = isHash ? config.app.baseURL + (to as any).href : joinURL(config.app.baseURL, to.fullPath)
+      const path = joinURL(config.app.baseURL, to.fullPath)
+
       reloadNuxtApp({ path, persistState: true })
     }
 

--- a/packages/nuxt/src/app/plugins/chunk-reload.client.ts
+++ b/packages/nuxt/src/app/plugins/chunk-reload.client.ts
@@ -13,11 +13,12 @@ export default defineNuxtPlugin({
     const chunkErrors = new Set<Error>()
 
     router.beforeEach(() => { chunkErrors.clear() })
+
     nuxtApp.hook('app:chunkError', ({ error }) => { chunkErrors.add(error) })
 
     function reloadAppAtPath (to: RouteLocationNormalized) {
-      const isHash = 'href' in to && (to.href as string)[0] === '#'
-      const path = isHash ? config.app.baseURL + (to as any).href : joinURL(config.app.baseURL, to.fullPath)
+      const path = joinURL(config.app.baseURL, to.fullPath)
+
       reloadNuxtApp({ path, persistState: true })
     }
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/32312

### 📚 Description

Takes into account app's base URL when reloading an app on chunk error/manifest update.