### PR TITLE
fix(nuxt): ensure `options.watch` in async data watcher is an array before spreading

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -324,7 +324,7 @@ export function useAsyncData<
 
     // setup watchers/instance
     const hasScope = getCurrentScope()
-    const unsubExecute = watch([key, ...toArray((options.watch || []))], ([newKey], [oldKey]) => {
+    const unsubExecute = watch([key, ...toArray(options.watch || [])], ([newKey], [oldKey]) => {
       if ((newKey || oldKey) && newKey !== oldKey) {
         const hasRun = nuxtApp._asyncData[oldKey]?.data.value !== undefined
         if (oldKey) {

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -324,7 +324,7 @@ export function useAsyncData<
 
     // setup watchers/instance
     const hasScope = getCurrentScope()
-    const unsubExecute = watch([key, ...(options.watch || [])], ([newKey], [oldKey]) => {
+    const unsubExecute = watch([key, ...toArray((options.watch || []))], ([newKey], [oldKey]) => {
       if ((newKey || oldKey) && newKey !== oldKey) {
         const hasRun = nuxtApp._asyncData[oldKey]?.data.value !== undefined
         if (oldKey) {


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/32385

### 📚 Description

`options.watch` passed to the watcher can be a ref instead of an array.