### PR TITLE
chore: rename deprecated vitest `workspace` to `projects`

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
       exclude: [...coverageConfigDefaults.exclude, 'playground', '**/test/', 'scripts'],
     },
     poolOptions: isCI ? { forks: { execArgv: getV8Flags() } } : undefined,
-    workspace: [
+    projects: [
       {
         plugins: isCI ? [codspeedPlugin()] : [],
         test: {


### PR DESCRIPTION
### 📚 Description

This PR fixes the deprecation warning from vitest
```
> nuxt-framework@ test:prepare /home/runner/work/nuxt/nuxt
> jiti ./test/prepare.ts
 DEPRECATED  The `workspace` option is deprecated and will be removed in the next major. To hide this warning, rename `workspace` option to `projects`.
```
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
