### PR TITLE
fix(nuxt): when `<NuxtLink>` renders native anchor tag, handle click with `navigateTo`

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -513,7 +513,9 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
           onClick: (event) => {
             event.preventDefault()
 
-            navigateTo(href.value)
+            return props.replace
+              ? router.replace(href.value)
+              : router.push(href.value)
           },
         }, slots.default?.())
       }

--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -505,8 +505,17 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
           } satisfies NuxtLinkDefaultSlotProps<true>)
         }
 
-        // converts `""` to `null` to prevent the attribute from being added as empty (`href=""`)
-        return h('a', { ref: el, href: href.value || null, rel, target }, slots.default?.())
+        return h('a', {
+          ref: el,
+          href: href.value || null, // converts `""` to `null` to prevent the attribute from being added as empty (`href=""`)
+          rel,
+          target,
+          onClick: (event) => {
+            event.preventDefault()
+
+            navigateTo(href.value)
+          },
+        }, slots.default?.())
       }
     },
     // }) as unknown as DefineComponent<NuxtLinkProps, object, object, ComputedOptions, MethodOptions, object, object, EmitsOptions, string, object, NuxtLinkProps, object, SlotsType<NuxtLinkSlots>>


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/32329

### 📚 Description

This allows for rendering a plain anchor tag without breaking smooth scroll behavior.