### PR TITLE
feat(nuxt): add `onWatcherCleanup` to imports presets

### DIFF
--- a/packages/nuxt/src/imports/presets.ts
+++ b/packages/nuxt/src/imports/presets.ts
@@ -201,6 +201,7 @@ const vuePreset = defineUnimportPreset({
     'watchEffect',
     'watchPostEffect',
     'watchSyncEffect',
+    'onWatcherCleanup',
     'isShallow',
 
     // effect


### PR DESCRIPTION
### 📚 Description

Vue 3.5 introduced new reactivity API called `onWatcherCleanup` (read [more](https://vuejs.org/api/reactivity-core.html#onwatchercleanup)). This can be also auto-imported by Nuxt for convenience and better DX.

