### PR TITLE
docs: clarify where logging tag is displayed

### DIFF
--- a/docs/3.api/5.kit/13.logging.md
+++ b/docs/3.api/5.kit/13.logging.md
@@ -36,7 +36,7 @@ function useLogger (tag?: string, options?: Partial<ConsolaOptions>): ConsolaIns
 
 ### Parameters
 
-**`tag`**: A tag to suffix all log messages with.
+**`tag`**: A tag to suffix all log messages with, displayed on the right near the timestamp.
 
 **`options`**: Consola configuration options.
 


### PR DESCRIPTION
### 🔗 Linked issue
https://github.com/nuxt/nuxt/issues/32434

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

A screenshot would also be helpful, but I wasn't sure where the best place to add the image was. In addition to showing the tag location, it would make it clear that this is formatted logging vs the usual system logging. As they say, a picture is worth a thousand words!

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
