### PR TITLE
fix(nuxt): run `prepare(nitro)` only in build

### DIFF
--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -647,7 +647,9 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
   // nuxt build/dev
   nuxt.hook('build:done', async () => {
     await nuxt.callHook('nitro:build:before', nitro)
-    await prepare(nitro)
+    if (!nuxt.options.dev) {
+      await prepare(nitro)
+    }
     if (nuxt.options.dev) {
       return build(nitro)
     }


### PR DESCRIPTION
### 🔗 Linked issue

fix #32432 

this one can be merge in v3 too
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

`prepare(nitro)` only need to be called when building nitro
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
