### PR TITLE
fix: disable esbuild `drop` option in development mode for both vite and nitro

### DIFF
--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -454,6 +454,15 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
     },
   }
 
+  // esbuild.drop is a production-only optimization.
+  // We explicitly disable it for development mode to preserve console logs
+  // for server-side debugging.
+  if (nuxt.options.dev) {
+    if (nitroConfig.esbuild?.options) {
+      nitroConfig.esbuild.options.drop = undefined
+    }
+  }
+
   // Extend nitro config with hook
   await nuxt.callHook('nitro:config', nitroConfig)
 

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -127,6 +127,14 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
     ctx.config.build!.watch = undefined
   }
 
+  // FIX: esbuild.drop is a production-only optimization and should not
+  // be applied in development mode as it breaks essential debugging tools.
+  if (nuxt.options.dev) {
+    if (ctx.config.esbuild && 'drop' in ctx.config.esbuild) {
+      ctx.config.esbuild.drop = undefined
+    }
+  }
+
   // TODO: this may no longer be needed with most recent vite version
   if (nuxt.options.dev) {
     // Identify which layers will need to have an extra resolve step.


### PR DESCRIPTION
### 🔗 Linked issue

resolves #32445

### 📚 Description

This pull request addresses an issue where configuring esbuild.drop for either Vite or Nitro in nuxt.config.ts incorrectly removes console and debugger statements in development mode. This behavior affects both client-side and server-side code, significantly hindering debugging workflows.

The esbuild.drop option is a production-only optimization intended to strip debugging statements from the final build. However, both the Vite and Nitro builders in Nuxt currently merge this configuration unconditionally, regardless of the environment.

**1. Vite (Client-Side):**
In packages/vite/src/vite.ts, the user's Vite config (including esbuild.drop) is merged and passed to the Vite dev server. The dev server uses esbuild for on-the-fly transpilation, which results in console logs being stripped from client-side code before it reaches the browser.

**2. Nitro (Server-Side):**
Similarly, in packages/nuxt/src/core/nitro.ts, the user's Nitro config is merged. The Nitro dev server then uses this configuration to compile server-side code (like API routes and SSR logic), removing console logs and preventing them from appearing in the terminal.

This PR introduces a consistent fix for both builders by explicitly disabling the esbuild.drop option when the application is running in development mode (nuxt.options.dev). This restores the expected behavior, allowing developers to use console.log for debugging on both the client and server during development, while preserving the optimization for production builds.

Before
With the following configuration in nuxt.config.ts:
```ts
export default defineNuxtConfig({
  vite: {
    esbuild: {
      drop: ['console'],
    },
  },
  nitro: {
    esbuild: {
      options: {
        drop: ['console'],
      },
    },
  },
})
```

Running `pnpm dev` would cause console.log statements to be removed from:
The browser console (client-side code).
The terminal output (server-side code).

After
With the same configuration, running `pnpm dev` now correctly preserves all console.log statements on both the client and the server. The drop optimization is properly isolated and only applies during a production build (`pnpm build`), as intended.