### PR TITLE
test: add case for key only changes with `immediate: false`

### DIFF
--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -743,6 +743,20 @@ describe('useAsyncData', () => {
     expect.soft(handler).toHaveBeenCalledTimes(1)
     expect.soft(getCachedData).toHaveBeenCalledTimes(1)
   })
+
+  it('should not execute if immediate is false and only the key changes', async () => {
+    const promiseFn = vi.fn(() => Promise.resolve('test'))
+    const key = shallowRef('a')
+    const { status } = useAsyncData(key, promiseFn, { immediate: false })
+
+    expect.soft(status.value).toBe('idle')
+    expect.soft(promiseFn).toHaveBeenCalledTimes(0)
+
+    key.value += 'a'
+    await nextTick()
+    expect.soft(status.value).toBe('idle')
+    expect.soft(promiseFn).toHaveBeenCalledTimes(0)
+  })
 })
 
 describe('useFetch', () => {
@@ -898,6 +912,8 @@ describe('useFetch', () => {
     expect(status.value).toBe('error')
     expect(error.value).toMatchInlineSnapshot(`[Error: [GET] "[object Promise]": <no response> Failed to parse URL from [object Promise]]`)
   })
+
+  it('should refetch ')
 })
 
 describe('errors', () => {

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -913,7 +913,16 @@ describe('useFetch', () => {
     expect(error.value).toMatchInlineSnapshot(`[Error: [GET] "[object Promise]": <no response> Failed to parse URL from [object Promise]]`)
   })
 
-  it('should refetch ')
+  it('should fetch if immediate is false and only the key changes with `experimental.alwaysRunFetchOnKeyChange`', async () => {
+    const key = shallowRef('a')
+    const { status } = useFetch('/api/test', { key, immediate: false })
+
+    expect.soft(status.value).toBe('idle')
+
+    key.value += 'a'
+    await nextTick()
+    expect.soft(status.value).toBe('pending')
+  })
 })
 
 describe('errors', () => {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This PR introduces a small test for asyncData to track the `immediate: false` behaviour when key is changed, without altering any watch sources.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
