### PR TITLE
fix(nuxt): append `set-cookie` headers in error handler

### DIFF
--- a/packages/nuxt/src/core/runtime/nitro/handlers/error.ts
+++ b/packages/nuxt/src/core/runtime/nitro/handlers/error.ts
@@ -1,6 +1,6 @@
 import { joinURL, withQuery, withoutBase } from 'ufo'
 import type { NitroErrorHandler } from 'nitropack/types'
-import { getRequestHeaders, send, setResponseHeader, setResponseHeaders, setResponseStatus } from 'h3'
+import { appendResponseHeader, getRequestHeaders, send, setResponseHeader, setResponseHeaders, setResponseStatus } from 'h3'
 
 import { useNitroApp, useRuntimeConfig } from 'nitropack/runtime'
 import { isJsonRequest } from '../utils/error'
@@ -74,6 +74,10 @@ export default <NitroErrorHandler> async function errorhandler (error, event, { 
 
   const html = await res.text()
   for (const [header, value] of res.headers.entries()) {
+    if (header === 'set-cookie') {
+      appendResponseHeader(event, header, value)
+      continue
+    }
     setResponseHeader(event, header, value)
   }
   setResponseStatus(event, res.status && res.status !== 200 ? res.status : defaultRes.status, res.statusText || defaultRes.statusText)


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/32472

### 📚 Description

this uses `appendResponseHeader` so set-cookie can be merged (by browser).