### PR TITLE
docs:  bunx command example typo in Upgrading Nuxt page

### DIFF
--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -25,7 +25,7 @@ pnpm nuxt upgrade
 ```
 
 ```bash [bun]
-bun x nuxt upgrade
+bunx nuxt upgrade
 ```
 
 ::


### PR DESCRIPTION
### 📚 Description

There's an extra space in the bunx command example to upgrade Nuxt : 

`bun x` -> `bunx`

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
