### PR TITLE
fix(nuxt): skip external `<NuxtLink>`'s custom on click handler

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -511,6 +511,10 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
           rel,
           target,
           onClick: (event) => {
+            if (isExternal.value || hasTarget.value) {
+              return
+            }
+
             event.preventDefault()
 
             return props.replace


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/32498

### 📚 Description

This PR prevents the custom on click handler from executing when link is external or has target attr other than `_self`.