### PR TITLE
fix(nuxt): safe-guard `extraPageMetaExtractionKeys`

### DIFF
--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -489,7 +489,12 @@ export default defineNuxtModule({
     }
 
     // Extract macros from pages
-    const extractedKeys = [...defaultExtractionKeys, 'middleware', ...nuxt.options.experimental.extraPageMetaExtractionKeys]
+    const extraPageMetaExtractionKeys = nuxt.options.experimental.extraPageMetaExtractionKeys
+    const extractedKeys = [
+      ...defaultExtractionKeys,
+      'middleware',
+      ...(Array.isArray(extraPageMetaExtractionKeys) ? extraPageMetaExtractionKeys : []),
+    ]
 
     nuxt.hook('modules:done', () => {
       addBuildPlugin(PageMetaPlugin({

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -489,7 +489,7 @@ export default defineNuxtModule({
     }
 
     // Extract macros from pages
-    const extraPageMetaExtractionKeys = nuxt.options.experimental.extraPageMetaExtractionKeys
+    const extraPageMetaExtractionKeys = nuxt.options?.experimental?.extraPageMetaExtractionKeys
     const extractedKeys = [
       ...defaultExtractionKeys,
       'middleware',

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -489,11 +489,10 @@ export default defineNuxtModule({
     }
 
     // Extract macros from pages
-    const extraPageMetaExtractionKeys = nuxt.options?.experimental?.extraPageMetaExtractionKeys
+    const extraPageMetaExtractionKeys = nuxt.options?.experimental?.extraPageMetaExtractionKeys || []
     const extractedKeys = [
       ...defaultExtractionKeys,
-      'middleware',
-      ...(Array.isArray(extraPageMetaExtractionKeys) ? extraPageMetaExtractionKeys : []),
+      ...extraPageMetaExtractionKeys,
     ]
 
     nuxt.hook('modules:done', () => {

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -70,7 +70,7 @@ export async function resolvePagesRoutes (pattern: string | string[], nuxt = use
     return pages
   }
 
-  const extraPageMetaExtractionKeys = nuxt.options.experimental.extraPageMetaExtractionKeys
+  const extraPageMetaExtractionKeys = nuxt.options?.experimental?.extraPageMetaExtractionKeys
 
   const augmentCtx = {
     extraExtractionKeys: new Set([

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -70,12 +70,12 @@ export async function resolvePagesRoutes (pattern: string | string[], nuxt = use
     return pages
   }
 
-  const extraPageMetaExtractionKeys = nuxt.options?.experimental?.extraPageMetaExtractionKeys
+  const extraPageMetaExtractionKeys = nuxt.options?.experimental?.extraPageMetaExtractionKeys || []
 
   const augmentCtx = {
     extraExtractionKeys: new Set([
       'middleware',
-      ...(Array.isArray(extraPageMetaExtractionKeys) ? extraPageMetaExtractionKeys : []),
+      ...extraPageMetaExtractionKeys,
     ]),
     fullyResolvedPaths: new Set(scannedFiles.map(file => file.absolutePath)),
   }

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -70,8 +70,13 @@ export async function resolvePagesRoutes (pattern: string | string[], nuxt = use
     return pages
   }
 
+  const extraPageMetaExtractionKeys = nuxt.options.experimental.extraPageMetaExtractionKeys
+
   const augmentCtx = {
-    extraExtractionKeys: new Set(['middleware', ...nuxt.options.experimental.extraPageMetaExtractionKeys]),
+    extraExtractionKeys: new Set([
+      'middleware',
+      ...(Array.isArray(extraPageMetaExtractionKeys) ? extraPageMetaExtractionKeys : []),
+    ]),
     fullyResolvedPaths: new Set(scannedFiles.map(file => file.absolutePath)),
   }
   if (shouldAugment === 'after-resolve') {


### PR DESCRIPTION
### 🔗 Linked issue

This issue came up while checking the canary tests in Sentry Nuxt: https://github.com/getsentry/sentry-javascript/issues/16762

Building the application resulted in this error: `nuxt.options.experimental.extraPageMetaExtractionKeys is not iterable`

### 📚 Description

This PR creates a safeguard (`Array.isArray()`) before spreading the experimental value.
