### PR TITLE
fix(vite): handle resolving string vite input

### DIFF
--- a/packages/vite/src/utils/config.ts
+++ b/packages/vite/src/utils/config.ts
@@ -2,8 +2,13 @@ import type { ResolvedConfig } from 'vite'
 
 export function resolveClientEntry (config: ResolvedConfig) {
   const input = config.environments.client?.build.rollupOptions.input ?? config.build.rollupOptions.input
-  if (input && typeof input !== 'string' && !Array.isArray(input) && input.entry) {
-    return input.entry
+  if (input) {
+    if (typeof input === 'string') {
+      return input
+    }
+    if (!Array.isArray(input) && input.entry) {
+      return input.entry
+    }
   }
 
   throw new Error('No entry found in rollupOptions.input')
@@ -11,8 +16,13 @@ export function resolveClientEntry (config: ResolvedConfig) {
 
 export function resolveServerEntry (config: ResolvedConfig) {
   const input = config.environments.ssr?.build.rollupOptions.input ?? config.build.rollupOptions.input
-  if (input && typeof input !== 'string' && !Array.isArray(input) && input.server) {
-    return input.server
+  if (input) {
+    if (typeof input === 'string') {
+      return input
+    }
+    if (!Array.isArray(input) && input.server) {
+      return input.server
+    }
   }
 
   throw new Error('No entry found in rollupOptions.input')


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

when used with storybook, [the entry is a string](https://github.com/storybookjs/storybook/blob/cc7d0f5c871799242aa153a996eac6097249a857/code/builders/builder-vite/src/plugins/code-generator-plugin.ts#L65) (and this might also be true with other vite-based integrations which reuse part of the nuxt vite config, e.g. test-utils, histoire, etc.)

spotted by @yannbf ❤️ 
