### PR TITLE
fix(kit): ensure legacy tsConfig doesn't exclude too many types

### DIFF
--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -992,6 +992,7 @@ Nuxt now generates separate TypeScript configurations for different contexts to 
    * `.nuxt/tsconfig.app.json` - For your app code (Vue components, composables, etc.)
    * `.nuxt/tsconfig.server.json` - For your server-side code (Nitro/server directory)  
    * `.nuxt/tsconfig.node.json` - For your build-time code (modules, `nuxt.config.ts`, etc.)
+   * `.nuxt/tsconfig.shared.json` - For code shared between app and server contexts (like types and non-environment specific utilities)
    * `.nuxt/tsconfig.json` - Legacy configuration for backward compatibility
 
 2. **Backward compatibility**: Existing projects that extend `.nuxt/tsconfig.json` will continue to work as before.
@@ -1027,6 +1028,7 @@ However, to take advantage of improved type checking, you can opt in to the new 
      "references": [
        { "path": "./.nuxt/tsconfig.app.json" },
        { "path": "./.nuxt/tsconfig.server.json" },
+       { "path": "./.nuxt/tsconfig.shared.json" },
        { "path": "./.nuxt/tsconfig.node.json" }
      ]
    }

--- a/docs/2.guide/1.concepts/8.typescript.md
+++ b/docs/2.guide/1.concepts/8.typescript.md
@@ -92,6 +92,7 @@ When you run `nuxt dev` or `nuxt build`, Nuxt will generate multiple `tsconfig.j
 - **`.nuxt/tsconfig.app.json`** - Configuration for your application code
 - **`.nuxt/tsconfig.node.json`** - Configuration for your `nuxt.config` and modules
 - **`.nuxt/tsconfig.server.json`** - Configuration for server-side code (when applicable)
+- **`.nuxt/tsconfig.shared.json`** - For code shared between app and server contexts (like types and non-environment specific utilities)
 - **`.nuxt/tsconfig.json`** - Legacy configuration for backward compatibility
 
 Each of these files is configured to reference the appropriate dependencies and provide optimal type-checking for their specific context.

--- a/docs/2.guide/2.directory-structure/3.tsconfig.md
+++ b/docs/2.guide/2.directory-structure/3.tsconfig.md
@@ -5,7 +5,7 @@ head.title: "tsconfig.json"
 navigation.icon: i-lucide-file
 ---
 
-Nuxt [automatically generates](/docs/guide/concepts/typescript) multiple TypeScript configuration files (`.nuxt/tsconfig.app.json`, `.nuxt/tsconfig.server.json`, `.nuxt/tsconfig.node.json`) with the resolved aliases you are using in your Nuxt project, as well as with other sensible defaults.
+Nuxt [automatically generates](/docs/guide/concepts/typescript) multiple TypeScript configuration files (`.nuxt/tsconfig.app.json`, `.nuxt/tsconfig.server.json`, `.nuxt/tsconfig.node.json` and `.nuxt/tsconfig.shared.json`) with the resolved aliases you are using in your Nuxt project, as well as with other sensible defaults.
 
 You can benefit from this by creating a `tsconfig.json` in the root of your project with the following content:
 
@@ -18,6 +18,9 @@ You can benefit from this by creating a `tsconfig.json` in the root of your proj
     },
     {
       "path": "./.nuxt/tsconfig.server.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.shared.json"
     },
     {
       "path": "./.nuxt/tsconfig.node.json"

--- a/docs/7.migration/2.configuration.md
+++ b/docs/7.migration/2.configuration.md
@@ -165,6 +165,9 @@ Nuxt can type-check your app using [`vue-tsc`](https://github.com/vuejs/language
          "path": "./.nuxt/tsconfig.server.json"
        },
        {
+         "path": "./.nuxt/tsconfig.shared.json"
+       },
+       {
          "path": "./.nuxt/tsconfig.node.json"
        }
      ]

--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -180,7 +180,7 @@ const excludedAlias = [/^@vue\/.*$/, /^#internal\/nuxt/]
 export async function _generateTypes (nuxt: Nuxt) {
   const include = new Set<string>(['./nuxt.d.ts'])
   const nodeInclude = new Set<string>(['./nuxt.node.d.ts'])
-  const legacyInclude = new Set<string>(['./nuxt.d.ts'])
+  const legacyInclude = new Set<string>([...include, ...nodeInclude])
 
   const exclude = new Set<string>()
   const nodeExclude = new Set<string>()
@@ -468,8 +468,9 @@ export async function _generateTypes (nuxt: Nuxt) {
   ].join('\n')
 
   // Legacy tsConfig for backward compatibility
-  const legacyTsConfig: TSConfig = defu({}, tsConfig, {
-    include: [...legacyInclude],
+  const legacyTsConfig: TSConfig = defu({}, {
+    ...tsConfig,
+    include: [...new Set([...tsConfig.include, ...legacyInclude])],
     exclude: [...legacyExclude],
   })
 

--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -68,7 +68,7 @@ export function addServerTemplate (template: NuxtServerTemplate) {
  *
  * If no context object is passed, then it will only be added to the nuxt context.
  */
-export function addTypeTemplate<T> (_template: NuxtTypeTemplate<T>, context?: { nitro?: boolean, nuxt?: boolean, node?: boolean }) {
+export function addTypeTemplate<T> (_template: NuxtTypeTemplate<T>, context?: { nitro?: boolean, nuxt?: boolean, node?: boolean, shared?: boolean }) {
   const nuxt = useNuxt()
 
   const template = addTemplate(_template)
@@ -88,6 +88,12 @@ export function addTypeTemplate<T> (_template: NuxtTypeTemplate<T>, context?: { 
       nodeReferences.push({ path: template.dst })
     })
   }
+  if (context?.shared) {
+    nuxt.hook('prepare:types', ({ sharedReferences }) => {
+      sharedReferences.push({ path: template.dst })
+    })
+  }
+
   if (context?.nitro) {
     nuxt.hook('nitro:prepare:types', ({ references }) => {
       references.push({ path: template.dst })
@@ -151,25 +157,42 @@ export async function updateTemplates (options?: { filter?: (template: ResolvedN
   return await tryUseNuxt()?.hooks.callHook('builder:generateApp', options)
 }
 
-function resolveLayerPaths (buildDir: string, rootDir: string, srcDir: string) {
+export function resolveLayerPaths (dir: Nuxt['options']['dir'], buildDir: string, rootDir: string, srcDir: string) {
   const relativeRootDir = relativeWithDot(buildDir, rootDir)
+  const relativeSrcDir = relativeWithDot(buildDir, srcDir)
+  const relativeModulesDir = relativeWithDot(buildDir, resolve(rootDir, dir.modules || 'modules'))
+  const relativeSharedDir = relativeWithDot(buildDir, resolve(rootDir, dir.shared || 'shared'))
   return {
     nuxt: [
-      join(relativeWithDot(buildDir, srcDir), '**/*'),
-      join(relativeRootDir, 'modules/*/runtime/**/*'),
-      join(relativeRootDir, 'layers/*/modules/*/runtime/**/*'),
+      join(relativeSrcDir, '**/*'),
+      join(relativeModulesDir, `*/runtime/**/*`),
+      join(relativeRootDir, `layers/*/modules/*/runtime/**/*`),
     ],
     nitro: [
-      join(relativeRootDir, 'modules/*/runtime/server/**/*'),
-      join(relativeRootDir, 'layers/*/modules/*/runtime/server/**/*'),
+      join(relativeModulesDir, `*/runtime/server/**/*`),
+      join(relativeRootDir, `layers/*/modules/*/runtime/server/**/*`),
     ],
     node: [
-      join(relativeRootDir, 'modules/**/*'),
-      join(relativeRootDir, 'nuxt.config.*'),
-      join(relativeRootDir, '.config/nuxt.*'),
-      join(relativeRootDir, 'layers/*/nuxt.config.*'),
-      join(relativeRootDir, 'layers/*/.config/nuxt.*'),
-      join(relativeRootDir, 'layers/*/modules/**/*'),
+      join(relativeModulesDir, `**/*`),
+      join(relativeRootDir, `nuxt.config.*`),
+      join(relativeRootDir, `.config/nuxt.*`),
+      join(relativeRootDir, `layers/*/nuxt.config.*`),
+      join(relativeRootDir, `layers/*/.config/nuxt.*`),
+      join(relativeRootDir, `layers/*/modules/**/*`),
+    ],
+    shared: [
+      join(relativeSharedDir, `**/*`),
+      join(relativeModulesDir, `*/shared/**/*`),
+      join(relativeRootDir, `layers/*/shared/**/*`),
+    ],
+    sharedDeclarations: [
+      join(relativeSharedDir, `**/*.d.ts`),
+      join(relativeModulesDir, `*/shared/**/*.d.ts`),
+      join(relativeRootDir, `layers/*/shared/**/*.d.ts`),
+    ],
+    globalDeclarations: [
+      join(relativeSrcDir, `**/*.d.ts`),
+      join(relativeRootDir, `layers/*/*.d.ts`),
     ],
   }
 }
@@ -180,10 +203,12 @@ const excludedAlias = [/^@vue\/.*$/, /^#internal\/nuxt/]
 export async function _generateTypes (nuxt: Nuxt) {
   const include = new Set<string>(['./nuxt.d.ts'])
   const nodeInclude = new Set<string>(['./nuxt.node.d.ts'])
+  const sharedInclude = new Set<string>(['./nuxt.shared.d.ts'])
   const legacyInclude = new Set<string>([...include, ...nodeInclude])
 
   const exclude = new Set<string>()
   const nodeExclude = new Set<string>()
+  const sharedExclude = new Set<string>()
   const legacyExclude = new Set<string>()
 
   if (nuxt.options.typescript.includeWorkspace && nuxt.options.workspaceDir !== nuxt.options.srcDir) {
@@ -211,7 +236,7 @@ export async function _generateTypes (nuxt: Nuxt) {
     const srcOrCwd = withTrailingSlash(layer.config.srcDir ?? layer.cwd)
     if (!srcOrCwd.startsWith(rootDirWithSlash) || layer.cwd === nuxt.options.rootDir || srcOrCwd.includes('node_modules')) {
       const rootGlob = join(relativeWithDot(nuxt.options.buildDir, layer.cwd), '**/*')
-      const paths = resolveLayerPaths(nuxt.options.buildDir, layer.cwd, layer.config.srcDir)
+      const paths = resolveLayerPaths(defu(layer.config.dir, nuxt.options.dir), nuxt.options.buildDir, layer.cwd, layer.config.srcDir)
       for (const path of paths.nuxt) {
         include.add(path)
         legacyInclude.add(path)
@@ -228,6 +253,18 @@ export async function _generateTypes (nuxt: Nuxt) {
         nodeInclude.add(path)
         legacyInclude.add(path)
         exclude.add(path)
+      }
+      for (const path of paths.shared) {
+        legacyInclude.add(path)
+        sharedInclude.add(path)
+      }
+      for (const path of paths.sharedDeclarations) {
+        include.add(path)
+      }
+      for (const path of paths.globalDeclarations) {
+        include.add(path)
+        legacyInclude.add(path)
+        sharedInclude.add(path)
       }
     }
   }
@@ -274,42 +311,6 @@ export async function _generateTypes (nuxt: Nuxt) {
   hasTypescriptVersionWithModulePreserve ??= true
 
   const useDecorators = Boolean(nuxt.options.experimental?.decorators)
-
-  const nodeReferences: TSReference[] = []
-
-  // This describes the environment where we load `nuxt.config.ts` (and modules)
-  const nodeTsConfig: TSConfig = defu(nuxt.options.typescript?.nodeTsConfig, {
-    compilerOptions: {
-      /* Base options: */
-      esModuleInterop: true,
-      skipLibCheck: true,
-      target: 'ESNext',
-      allowJs: true,
-      resolveJsonModule: true,
-      moduleDetection: 'force',
-      isolatedModules: true,
-      verbatimModuleSyntax: true,
-      /* Strictness */
-      strict: nuxt.options.typescript?.strict ?? true,
-      noUncheckedIndexedAccess: true,
-      forceConsistentCasingInFileNames: true,
-      noImplicitOverride: true,
-      /* If NOT transpiling with TypeScript: */
-      module: hasTypescriptVersionWithModulePreserve ? 'preserve' : 'ESNext',
-      noEmit: true,
-      /* remove auto-scanning for types */
-      types: [],
-      /* add paths object for filling-in later */
-      paths: {},
-      /* Possibly consider removing the following in future */
-      moduleResolution: hasTypescriptVersionWithModulePreserve ? undefined : 'Bundler',
-      useDefineForClassFields: true, /* implied by target: es2022+ */
-      noImplicitThis: true, /* enabled with `strict` */
-      allowSyntheticDefaultImports: true,
-    },
-    include: [...nodeInclude],
-    exclude: [...nodeExclude],
-  } satisfies TSConfig)
 
   // https://www.totaltypescript.com/tsconfig-cheat-sheet
   const tsConfig: TSConfig = defu(nuxt.options.typescript?.tsConfig, {
@@ -362,6 +363,74 @@ export async function _generateTypes (nuxt: Nuxt) {
     exclude: [...exclude],
   } satisfies TSConfig)
 
+  // This describes the environment where we load `nuxt.config.ts` (and modules)
+  const nodeTsConfig: TSConfig = defu(nuxt.options.typescript?.nodeTsConfig, {
+    compilerOptions: {
+      /* Base options: */
+      esModuleInterop: tsConfig.compilerOptions?.esModuleInterop,
+      skipLibCheck: tsConfig.compilerOptions?.skipLibCheck,
+      target: tsConfig.compilerOptions?.target,
+      allowJs: tsConfig.compilerOptions?.allowJs,
+      resolveJsonModule: tsConfig.compilerOptions?.resolveJsonModule,
+      moduleDetection: tsConfig.compilerOptions?.moduleDetection,
+      isolatedModules: tsConfig.compilerOptions?.isolatedModules,
+      verbatimModuleSyntax: tsConfig.compilerOptions?.verbatimModuleSyntax,
+      /* Strictness */
+      strict: tsConfig.compilerOptions?.strict,
+      noUncheckedIndexedAccess: tsConfig.compilerOptions?.noUncheckedIndexedAccess,
+      forceConsistentCasingInFileNames: tsConfig.compilerOptions?.forceConsistentCasingInFileNames,
+      noImplicitOverride: tsConfig.compilerOptions?.noImplicitOverride,
+      /* If NOT transpiling with TypeScript: */
+      module: tsConfig.compilerOptions?.module,
+      noEmit: true,
+      /* remove auto-scanning for types */
+      types: [],
+      /* add paths object for filling-in later */
+      paths: {},
+      /* Possibly consider removing the following in future */
+      moduleResolution: tsConfig.compilerOptions?.moduleResolution,
+      useDefineForClassFields: tsConfig.compilerOptions?.useDefineForClassFields,
+      noImplicitThis: tsConfig.compilerOptions?.noImplicitThis,
+      allowSyntheticDefaultImports: tsConfig.compilerOptions?.allowSyntheticDefaultImports,
+    },
+    include: [...nodeInclude],
+    exclude: [...nodeExclude],
+  } satisfies TSConfig)
+
+  // This describes the environment where we load `nuxt.config.ts` (and modules)
+  const sharedTsConfig: TSConfig = defu(nuxt.options.typescript?.sharedTsConfig, {
+    compilerOptions: {
+      /* Base options: */
+      esModuleInterop: tsConfig.compilerOptions?.esModuleInterop,
+      skipLibCheck: tsConfig.compilerOptions?.skipLibCheck,
+      target: tsConfig.compilerOptions?.target,
+      allowJs: tsConfig.compilerOptions?.allowJs,
+      resolveJsonModule: tsConfig.compilerOptions?.resolveJsonModule,
+      moduleDetection: tsConfig.compilerOptions?.moduleDetection,
+      isolatedModules: tsConfig.compilerOptions?.isolatedModules,
+      verbatimModuleSyntax: tsConfig.compilerOptions?.verbatimModuleSyntax,
+      /* Strictness */
+      strict: tsConfig.compilerOptions?.strict,
+      noUncheckedIndexedAccess: tsConfig.compilerOptions?.noUncheckedIndexedAccess,
+      forceConsistentCasingInFileNames: tsConfig.compilerOptions?.forceConsistentCasingInFileNames,
+      noImplicitOverride: tsConfig.compilerOptions?.noImplicitOverride,
+      /* If NOT transpiling with TypeScript: */
+      module: tsConfig.compilerOptions?.module,
+      noEmit: true,
+      /* remove auto-scanning for types */
+      types: [],
+      /* add paths object for filling-in later */
+      paths: {},
+      /* Possibly consider removing the following in future */
+      moduleResolution: tsConfig.compilerOptions?.moduleResolution,
+      useDefineForClassFields: tsConfig.compilerOptions?.useDefineForClassFields,
+      noImplicitThis: tsConfig.compilerOptions?.noImplicitThis,
+      allowSyntheticDefaultImports: tsConfig.compilerOptions?.allowSyntheticDefaultImports,
+    },
+    include: [...sharedInclude],
+    exclude: [...sharedExclude],
+  } satisfies TSConfig)
+
   const aliases: Record<string, string> = nuxt.options.alias
 
   const basePath = tsConfig.compilerOptions!.baseUrl
@@ -408,39 +477,59 @@ export async function _generateTypes (nuxt: Nuxt) {
   }
 
   const references: TSReference[] = []
+  const nodeReferences: TSReference[] = []
+  const sharedReferences: TSReference[] = []
+
+  // This adds types of all modules
   await Promise.all([...nuxt.options.modules, ...nuxt.options._modules].map(async (id) => {
     if (typeof id !== 'string') { return }
 
     for (const parent of nestedModulesDirs) {
       const pkg = await readPackageJSON(id, { parent }).catch(() => null)
       if (pkg) {
-        references.push(({ types: pkg.name ?? id }))
+        nodeReferences.push(({ types: pkg.name ?? id }))
         return
       }
     }
 
-    references.push(({ types: id }))
+    nodeReferences.push(({ types: id }))
   }))
 
   const declarations: string[] = []
 
-  await nuxt.callHook('prepare:types', { references, declarations, tsConfig, nodeTsConfig, nodeReferences })
+  await nuxt.callHook('prepare:types', { references, declarations, tsConfig, nodeTsConfig, nodeReferences, sharedTsConfig, sharedReferences })
 
-  for (const alias in tsConfig.compilerOptions!.paths) {
-    const paths = tsConfig.compilerOptions!.paths[alias]
-    tsConfig.compilerOptions!.paths[alias] = await Promise.all(paths.map(async (path: string) => {
-      if (!isAbsolute(path)) { return path }
-      const stats = await fsp.stat(path).catch(() => null /* file does not exist */)
-      return relativeWithDot(nuxt.options.buildDir, stats?.isFile() ? path.replace(EXTENSION_RE, '') /* remove extension */ : path)
-    }))
+  // Legacy tsConfig for backward compatibility
+  const legacyTsConfig: TSConfig = defu({}, {
+    ...tsConfig,
+    include: [...tsConfig.include, ...legacyInclude],
+    exclude: [...legacyExclude],
+  })
+
+  async function resolveConfig (tsConfig: TSConfig) {
+    for (const alias in tsConfig.compilerOptions!.paths) {
+      const paths = tsConfig.compilerOptions!.paths[alias]
+      tsConfig.compilerOptions!.paths[alias] = [...new Set(await Promise.all(paths.map(async (path: string) => {
+        if (!isAbsolute(path)) { return path }
+        const stats = await fsp.stat(path).catch(() => null /* file does not exist */)
+        return relativeWithDot(nuxt.options.buildDir, stats?.isFile() ? path.replace(EXTENSION_RE, '') /* remove extension */ : path)
+      })))]
+    }
+
+    // Ensure `#build` is placed at the end of the paths object.
+    // https://github.com/nuxt/nuxt/issues/30325
+    sortTsPaths(tsConfig.compilerOptions!.paths)
+
+    tsConfig.include = [...new Set(tsConfig.include!.map(p => isAbsolute(p) ? relativeWithDot(nuxt.options.buildDir, p) : p))]
+    tsConfig.exclude = [...new Set(tsConfig.exclude!.map(p => isAbsolute(p) ? relativeWithDot(nuxt.options.buildDir, p) : p))]
   }
 
-  // Ensure `#build` is placed at the end of the paths object.
-  // https://github.com/nuxt/nuxt/issues/30325
-  sortTsPaths(tsConfig.compilerOptions.paths)
-
-  tsConfig.include = [...new Set(tsConfig.include.map(p => isAbsolute(p) ? relativeWithDot(nuxt.options.buildDir, p) : p))]
-  tsConfig.exclude = [...new Set(tsConfig.exclude!.map(p => isAbsolute(p) ? relativeWithDot(nuxt.options.buildDir, p) : p))]
+  await Promise.all([
+    resolveConfig(tsConfig),
+    resolveConfig(nodeTsConfig),
+    resolveConfig(sharedTsConfig),
+    resolveConfig(legacyTsConfig),
+  ])
 
   const declaration = [
     ...references.map((ref) => {
@@ -467,15 +556,22 @@ export async function _generateTypes (nuxt: Nuxt) {
     '',
   ].join('\n')
 
-  // Legacy tsConfig for backward compatibility
-  const legacyTsConfig: TSConfig = defu({}, {
-    ...tsConfig,
-    include: [...new Set([...tsConfig.include, ...legacyInclude])],
-    exclude: [...legacyExclude],
-  })
+  const sharedDeclaration = [
+    ...sharedReferences.map((ref) => {
+      if ('path' in ref && isAbsolute(ref.path)) {
+        ref.path = relative(nuxt.options.buildDir, ref.path)
+      }
+      return `/// <reference ${renderAttrs(ref)} />`
+    }),
+    '',
+    'export {}',
+    '',
+  ].join('\n')
 
   return {
     declaration,
+    sharedTsConfig,
+    sharedDeclaration,
     nodeTsConfig,
     nodeDeclaration,
     tsConfig,
@@ -484,21 +580,26 @@ export async function _generateTypes (nuxt: Nuxt) {
 }
 
 export async function writeTypes (nuxt: Nuxt) {
-  const { tsConfig, nodeTsConfig, nodeDeclaration, declaration, legacyTsConfig } = await _generateTypes(nuxt)
+  const { tsConfig, nodeTsConfig, nodeDeclaration, declaration, legacyTsConfig, sharedDeclaration, sharedTsConfig } = await _generateTypes(nuxt)
 
   const appTsConfigPath = resolve(nuxt.options.buildDir, 'tsconfig.app.json')
   const legacyTsConfigPath = resolve(nuxt.options.buildDir, 'tsconfig.json')
   const nodeTsConfigPath = resolve(nuxt.options.buildDir, 'tsconfig.node.json')
+  const sharedTsConfigPath = resolve(nuxt.options.buildDir, 'tsconfig.shared.json')
+
   const declarationPath = resolve(nuxt.options.buildDir, 'nuxt.d.ts')
   const nodeDeclarationPath = resolve(nuxt.options.buildDir, 'nuxt.node.d.ts')
+  const sharedDeclarationPath = resolve(nuxt.options.buildDir, 'nuxt.shared.d.ts')
 
   await fsp.mkdir(nuxt.options.buildDir, { recursive: true })
   await Promise.all([
     fsp.writeFile(appTsConfigPath, JSON.stringify(tsConfig, null, 2)),
     fsp.writeFile(legacyTsConfigPath, JSON.stringify(legacyTsConfig, null, 2)),
     fsp.writeFile(nodeTsConfigPath, JSON.stringify(nodeTsConfig, null, 2)),
+    fsp.writeFile(sharedTsConfigPath, JSON.stringify(sharedTsConfig, null, 2)),
     fsp.writeFile(declarationPath, declaration),
     fsp.writeFile(nodeDeclarationPath, nodeDeclaration),
+    fsp.writeFile(sharedDeclarationPath, sharedDeclaration),
   ])
 }
 

--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -191,7 +191,7 @@ export function resolveLayerPaths (dir: Nuxt['options']['dir'], buildDir: string
       join(relativeRootDir, `layers/*/shared/**/*.d.ts`),
     ],
     globalDeclarations: [
-      join(relativeSrcDir, `**/*.d.ts`),
+      join(relativeRootDir, `*.d.ts`),
       join(relativeRootDir, `layers/*/*.d.ts`),
     ],
   }

--- a/packages/kit/test/generate-types.spec.ts
+++ b/packages/kit/test/generate-types.spec.ts
@@ -1,8 +1,12 @@
+import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import type { Nuxt, NuxtConfig } from '@nuxt/schema'
 import { defu } from 'defu'
+import { withoutTrailingSlash } from 'ufo'
+import { normalize } from 'pathe'
 
-import { _generateTypes } from '../src/template'
+import { loadNuxtConfig } from '../src/loader/config'
+import { _generateTypes, resolveLayerPaths } from '../src/template'
 
 type DeepPartial<T> = {
   [P in keyof T]?: T[P] extends Record<string, any> ? DeepPartial<T[P]> : T[P]
@@ -98,5 +102,55 @@ describe('tsConfig generation', () => {
         './build-dir/*',
       ],
     })
+  })
+})
+
+describe('resolveLayerPaths', () => {
+  const repoRoot = withoutTrailingSlash(normalize(fileURLToPath(new URL('../../../', import.meta.url))))
+
+  it('should respect custom nuxt options', async () => {
+    const nuxtOptions = await loadNuxtConfig({
+      cwd: repoRoot,
+      overrides: {
+        _prepare: true,
+        srcDir: 'app',
+        dir: {
+          modules: 'custom-modules',
+          shared: 'custom-shared',
+        },
+      },
+    })
+    const paths = resolveLayerPaths(nuxtOptions.dir, nuxtOptions.buildDir, nuxtOptions.rootDir, nuxtOptions.srcDir)
+    expect(paths).toMatchInlineSnapshot(`
+      {
+        "nitro": [
+          "../custom-modules/*/runtime/server/**/*",
+          "../layers/*/modules/*/runtime/server/**/*",
+        ],
+        "node": [
+          "../custom-modules/**/*",
+          "../nuxt.config.*",
+          "../.config/nuxt.*",
+          "../layers/*/nuxt.config.*",
+          "../layers/*/.config/nuxt.*",
+          "../layers/*/modules/**/*",
+        ],
+        "nuxt": [
+          "../app/**/*",
+          "../custom-modules/*/runtime/**/*",
+          "../layers/*/modules/*/runtime/**/*",
+        ],
+        "shared": [
+          "../custom-shared/**/*",
+          "../custom-modules/*/shared/**/*",
+          "../layers/*/shared/**/*",
+        ],
+        "sharedDeclarations": [
+          "../custom-shared/**/*.d.ts",
+          "../custom-modules/*/shared/**/*.d.ts",
+          "../layers/*/shared/**/*.d.ts",
+        ],
+      }
+    `)
   })
 })

--- a/packages/kit/test/generate-types.spec.ts
+++ b/packages/kit/test/generate-types.spec.ts
@@ -123,6 +123,10 @@ describe('resolveLayerPaths', () => {
     const paths = resolveLayerPaths(nuxtOptions.dir, nuxtOptions.buildDir, nuxtOptions.rootDir, nuxtOptions.srcDir)
     expect(paths).toMatchInlineSnapshot(`
       {
+        "globalDeclarations": [
+          "../*.d.ts",
+          "../layers/*/*.d.ts",
+        ],
         "nitro": [
           "../custom-modules/*/runtime/server/**/*",
           "../layers/*/modules/*/runtime/server/**/*",

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -267,17 +267,24 @@ async function initNuxt (nuxt: Nuxt) {
     opts.nodeReferences.push({ path: resolve(nuxt.options.buildDir, 'types/app.config.d.ts') })
     opts.nodeReferences.push({ types: 'nuxt' })
 
+    opts.sharedReferences.push({ path: resolve(nuxt.options.buildDir, 'types/runtime-config.d.ts') })
+    opts.sharedReferences.push({ path: resolve(nuxt.options.buildDir, 'types/app.config.d.ts') })
+
     // Set Nuxt resolutions for types that might be obscured with shamefully-hoist=false
     opts.tsConfig.compilerOptions = defu(opts.tsConfig.compilerOptions, { paths: { ...paths } })
 
     // Set Nuxt resolutions for types that might be obscured with shamefully-hoist=false
     opts.nodeTsConfig.compilerOptions = defu(opts.nodeTsConfig.compilerOptions, { paths: { ...paths } })
 
+    // Set Nuxt resolutions for types that might be obscured with shamefully-hoist=false
+    opts.sharedTsConfig.compilerOptions = defu(opts.sharedTsConfig.compilerOptions, { paths: { ...paths } })
+
     for (const layer of nuxt.options._layers) {
       const declaration = join(layer.cwd, 'index.d.ts')
       if (existsSync(declaration)) {
         opts.references.push({ path: declaration })
         opts.nodeReferences.push({ path: declaration })
+        opts.sharedReferences.push({ path: declaration })
       }
     }
   })

--- a/packages/nuxt/src/core/schema.ts
+++ b/packages/nuxt/src/core/schema.ts
@@ -32,6 +32,7 @@ export default defineNuxtModule({
     // Register module types
     nuxt.hook('prepare:types', async (ctx) => {
       ctx.references.push({ path: 'schema/nuxt.schema.d.ts' })
+      ctx.sharedReferences.push({ path: 'schema/nuxt.schema.d.ts' })
       ctx.nodeReferences.push({ path: 'schema/nuxt.schema.d.ts' })
       if (nuxt.options._prepare) {
         await writeSchema(schema)

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -191,14 +191,9 @@ export const schemaTemplate: NuxtTemplate = {
 
     return [
       `import { RuntimeConfig as UserRuntimeConfig, PublicRuntimeConfig as UserPublicRuntimeConfig } from 'nuxt/schema'`,
-      `declare module '@nuxt/schema' {`,
-      `  interface RuntimeConfig extends UserRuntimeConfig {}`,
-      `  interface PublicRuntimeConfig extends UserPublicRuntimeConfig {}`,
-      `}`,
-      `declare module 'nuxt/schema' {`,
       generateTypes(await resolveSchema(privateRuntimeConfig as Record<string, JSValue>),
         {
-          interfaceName: 'RuntimeConfig',
+          interfaceName: 'SharedRuntimeConfig',
           addExport: false,
           addDefaults: false,
           allowExtraKeys: false,
@@ -206,12 +201,19 @@ export const schemaTemplate: NuxtTemplate = {
         }),
       generateTypes(await resolveSchema(nuxt.options.runtimeConfig.public as Record<string, JSValue>),
         {
-          interfaceName: 'PublicRuntimeConfig',
+          interfaceName: 'SharedPublicRuntimeConfig',
           addExport: false,
           addDefaults: false,
           allowExtraKeys: false,
           indentation: 2,
         }),
+      `declare module '@nuxt/schema' {`,
+      `  interface RuntimeConfig extends UserRuntimeConfig {}`,
+      `  interface PublicRuntimeConfig extends UserPublicRuntimeConfig {}`,
+      `}`,
+      `declare module 'nuxt/schema' {`,
+      `  interface RuntimeConfig extends SharedRuntimeConfig {}`,
+      `  interface PublicRuntimeConfig extends SharedPublicRuntimeConfig {}`,
       '}',
       `declare module 'vue' {
         interface ComponentCustomProperties {
@@ -448,6 +450,10 @@ export const appConfigDeclarationTemplate: NuxtTemplate = {
 import type { CustomAppConfig } from 'nuxt/schema'
 import type { Defu } from 'defu'
 ${configPaths.map((id: string, index: number) => `import ${`cfg${index}`} from ${JSON.stringify(id)}`).join('\n')}
+
+declare global {
+  const defineAppConfig: <T>(appConfig: T) => T
+}
 
 declare const inlineConfig = ${JSON.stringify(nuxt.options.appConfig, null, 2)}
 type ResolvedAppConfig = Defu<typeof inlineConfig, [${app.configs.map((_id: string, index: number) => `typeof cfg${index}`).join(', ')}]>

--- a/packages/nuxt/types.d.mts
+++ b/packages/nuxt/types.d.mts
@@ -12,6 +12,11 @@ declare global {
   const defineNuxtConfig: DefineNuxtConfig
   const defineAppConfig: <T>(appConfig: T) => T
   const defineNuxtSchema: (schema: SchemaDefinition) => SchemaDefinition
+
+  interface ImportMeta {
+    url: string
+    readonly env: ImportMetaEnv
+  }
 }
 
 // Note: Keep in sync with packages/nuxt/src/core/templates.ts

--- a/packages/nuxt/types.d.mts
+++ b/packages/nuxt/types.d.mts
@@ -10,7 +10,6 @@ export * from './dist/index.js'
 
 declare global {
   const defineNuxtConfig: DefineNuxtConfig
-  const defineAppConfig: <T>(appConfig: T) => T
   const defineNuxtSchema: (schema: SchemaDefinition) => SchemaDefinition
 
   interface ImportMeta {

--- a/packages/nuxt/types.d.ts
+++ b/packages/nuxt/types.d.ts
@@ -12,6 +12,11 @@ declare global {
   const defineNuxtConfig: DefineNuxtConfig
   const defineAppConfig: <T>(appConfig: T) => T
   const defineNuxtSchema: (schema: SchemaDefinition) => SchemaDefinition
+
+  interface ImportMeta {
+    url: string
+    readonly env: ImportMetaEnv
+  }
 }
 
 // Note: Keep in sync with packages/nuxt/src/core/templates.ts

--- a/packages/nuxt/types.d.ts
+++ b/packages/nuxt/types.d.ts
@@ -10,7 +10,6 @@ export * from './dist/index'
 
 declare global {
   const defineNuxtConfig: DefineNuxtConfig
-  const defineAppConfig: <T>(appConfig: T) => T
   const defineNuxtSchema: (schema: SchemaDefinition) => SchemaDefinition
 
   interface ImportMeta {

--- a/packages/schema/src/types/hooks.ts
+++ b/packages/schema/src/types/hooks.ts
@@ -306,7 +306,7 @@ export interface NuxtHooks {
    * @param options Objects containing `references`, `declarations`, `tsConfig`
    * @returns Promise
    */
-  'prepare:types': (options: { references: TSReference[], declarations: string[], tsConfig: VueTSConfig, nodeTsConfig: TSConfig, nodeReferences: TSReference[] }) => HookResult
+  'prepare:types': (options: { references: TSReference[], declarations: string[], tsConfig: VueTSConfig, nodeTsConfig: TSConfig, nodeReferences: TSReference[], sharedTsConfig: TSConfig, sharedReferences: TSReference[] }) => HookResult
   /**
    * Called when the dev server is loading.
    * @param listenerServer The HTTP/HTTPS server object

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1635,14 +1635,19 @@ export interface ConfigSchema {
     typeCheck: boolean | 'build'
 
     /**
-     * You can extend generated `.nuxt/tsconfig.json` using this option.
+     * You can extend the generated `.nuxt/tsconfig.app.json` (and legacy `.nuxt/tsconfig.json`) using this option.
      */
     tsConfig: 0 extends 1 & RawVueCompilerOptions ? TSConfig : TSConfig & { vueCompilerOptions?: RawVueCompilerOptions }
 
     /**
-     * You can extend generated `.nuxt/tsconfig.node.json` using this option.
+     * You can extend the generated `.nuxt/tsconfig.node.json` using this option.
      */
     nodeTsConfig: TSConfig
+
+    /**
+     * You can extend the generated `.nuxt/tsconfig.shared.json` using this option.
+     */
+    sharedTsConfig: TSConfig
 
     /**
      * Generate a `*.vue` shim.

--- a/playground/tsconfig.json
+++ b/playground/tsconfig.json
@@ -8,6 +8,9 @@
       "path": "./.nuxt/tsconfig.server.json"
     },
     {
+      "path": "./.nuxt/tsconfig.shared.json"
+    },
+    {
       "path": "./.nuxt/tsconfig.node.json"
     }
   ]

--- a/test/fixtures/basic-types/nuxt.config.ts
+++ b/test/fixtures/basic-types/nuxt.config.ts
@@ -92,14 +92,6 @@ export default defineNuxtConfig({
     appManifest: true,
   },
   compatibilityDate: 'latest',
-  typescript: {
-    tsConfig: {
-      include: ['../index.d.ts'],
-    },
-    nodeTsConfig: {
-      include: ['../index.d.ts'],
-    },
-  },
   telemetry: false, // for testing telemetry types - it is auto-disabled in tests
   hooks: {
     'schema:extend' (schemas) {

--- a/test/fixtures/basic-types/tsconfig.json
+++ b/test/fixtures/basic-types/tsconfig.json
@@ -8,6 +8,9 @@
       "path": "./.nuxt/tsconfig.server.json"
     },
     {
+      "path": "./.nuxt/tsconfig.shared.json"
+    },
+    {
       "path": "./.nuxt/tsconfig.node.json"
     }
   ]

--- a/test/fixtures/basic/tsconfig.json
+++ b/test/fixtures/basic/tsconfig.json
@@ -8,6 +8,9 @@
       "path": "./.nuxt/tsconfig.server.json"
     },
     {
+      "path": "./.nuxt/tsconfig.shared.json"
+    },
+    {
       "path": "./.nuxt/tsconfig.node.json"
     }
   ]

--- a/test/fixtures/hmr/tsconfig.json
+++ b/test/fixtures/hmr/tsconfig.json
@@ -8,6 +8,9 @@
       "path": "./.nuxt/tsconfig.server.json"
     },
     {
+      "path": "./.nuxt/tsconfig.shared.json"
+    },
+    {
       "path": "./.nuxt/tsconfig.node.json"
     }
   ]

--- a/test/fixtures/minimal-pages/tsconfig.json
+++ b/test/fixtures/minimal-pages/tsconfig.json
@@ -8,6 +8,9 @@
       "path": "./.nuxt/tsconfig.server.json"
     },
     {
+      "path": "./.nuxt/tsconfig.shared.json"
+    },
+    {
       "path": "./.nuxt/tsconfig.node.json"
     }
   ]

--- a/test/fixtures/minimal-types/tsconfig.json
+++ b/test/fixtures/minimal-types/tsconfig.json
@@ -8,6 +8,9 @@
       "path": "./.nuxt/tsconfig.server.json"
     },
     {
+      "path": "./.nuxt/tsconfig.shared.json"
+    },
+    {
       "path": "./.nuxt/tsconfig.node.json"
     }
   ]

--- a/test/fixtures/minimal/tsconfig.json
+++ b/test/fixtures/minimal/tsconfig.json
@@ -8,6 +8,9 @@
       "path": "./.nuxt/tsconfig.server.json"
     },
     {
+      "path": "./.nuxt/tsconfig.shared.json"
+    },
+    {
       "path": "./.nuxt/tsconfig.node.json"
     }
   ]

--- a/test/fixtures/runtime-compiler/tsconfig.json
+++ b/test/fixtures/runtime-compiler/tsconfig.json
@@ -8,6 +8,9 @@
       "path": "./.nuxt/tsconfig.server.json"
     },
     {
+      "path": "./.nuxt/tsconfig.shared.json"
+    },
+    {
       "path": "./.nuxt/tsconfig.node.json"
     }
   ]

--- a/test/fixtures/spa-loader/tsconfig.json
+++ b/test/fixtures/spa-loader/tsconfig.json
@@ -8,6 +8,9 @@
       "path": "./.nuxt/tsconfig.server.json"
     },
     {
+      "path": "./.nuxt/tsconfig.shared.json"
+    },
+    {
       "path": "./.nuxt/tsconfig.node.json"
     }
   ]

--- a/test/fixtures/suspense/tsconfig.json
+++ b/test/fixtures/suspense/tsconfig.json
@@ -8,6 +8,9 @@
       "path": "./.nuxt/tsconfig.server.json"
     },
     {
+      "path": "./.nuxt/tsconfig.shared.json"
+    },
+    {
       "path": "./.nuxt/tsconfig.node.json"
     }
   ]

--- a/test/nuxt/tsconfig.json
+++ b/test/nuxt/tsconfig.json
@@ -8,6 +8,9 @@
       "path": "../../.nuxt/tsconfig.server.json"
     },
     {
+      "path": "../../.nuxt/tsconfig.shared.json"
+    },
+    {
       "path": "../../.nuxt/tsconfig.node.json"
     }
   ]


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/32519
https://github.com/nuxt/nuxt/discussions/32485#discussioncomment-13603921

### 📚 Description

this includes a number of type related fixes following https://github.com/nuxt/nuxt/issues/32343:

1. we now have a separate `tsconfig.shared.json` to govern the `shared/` folder
2. we now ensure that the legacy `tsconfig.json` doesn't exclude too many types
