### PR TITLE
test: fix flaky tests

### DIFF
--- a/test/nuxt/nuxt-time.test.ts
+++ b/test/nuxt/nuxt-time.test.ts
@@ -15,6 +15,7 @@ describe('<NuxtTime>', () => {
             month: 'long',
             day: 'numeric',
             second: 'numeric',
+            timeZone: 'UTC',
           }),
       }),
     )


### PR DESCRIPTION
Fixed a flaky test case that relies on the system timezone

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

https://github.com/nuxt/nuxt/issues/32557

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->

Fix #32557 by passing the timezone in
