### PR TITLE
docs: change return type of async data from `undefined` to `null` in v3 docs

### DIFF
--- a/docs/3.api/2.composables/use-async-data.md
+++ b/docs/3.api/2.composables/use-async-data.md
@@ -194,11 +194,11 @@ type AsyncDataRequestContext = {
 }
 
 type AsyncData<DataT, ErrorT> = {
-  data: Ref<DataT | undefined>
+  data: Ref<DataT | null>
   refresh: (opts?: AsyncDataExecuteOptions) => Promise<void>
   execute: (opts?: AsyncDataExecuteOptions) => Promise<void>
   clear: () => void
-  error: Ref<ErrorT | undefined>
+  error: Ref<ErrorT | null>
   status: Ref<AsyncDataRequestStatus>
 };
 

--- a/docs/3.api/2.composables/use-fetch.md
+++ b/docs/3.api/2.composables/use-fetch.md
@@ -129,11 +129,11 @@ type AsyncDataRequestContext = {
 }
 
 type AsyncData<DataT, ErrorT> = {
-  data: Ref<DataT | undefined>
+  data: Ref<DataT | null>
   refresh: (opts?: AsyncDataExecuteOptions) => Promise<void>
   execute: (opts?: AsyncDataExecuteOptions) => Promise<void>
   clear: () => void
-  error: Ref<ErrorT | undefined>
+  error: Ref<ErrorT | null>
   status: Ref<AsyncDataRequestStatus>
 }
 

--- a/docs/3.api/2.composables/use-nuxt-data.md
+++ b/docs/3.api/2.composables/use-nuxt-data.md
@@ -108,5 +108,5 @@ async function addTodo () {
 ## Type
 
 ```ts
-useNuxtData<DataT = any> (key: string): { data: Ref<DataT | undefined> }
+useNuxtData<DataT = any> (key: string): { data: Ref<DataT | null> }
 ```


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
No issue but had some discussion on discord:
https://discord.com/channels/473401852243869706/473407466630152201/1392132868557508628
![CleanShot 2025-07-08 at 15 38 06](https://github.com/user-attachments/assets/84158398-d668-4fa6-a4c0-6c28add6bd2c)


### 📚 Description

The return type of `AsyncData` is still `DataT | null` in v3. This changes the v3 docs to be in line with this. Same for error and `useNuxtData`.


<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
