### PR TITLE
Set automatic immediate as default

### DIFF
--- a/docs/2.guide/3.going-further/1.experimental-features.md
+++ b/docs/2.guide/3.going-further/1.experimental-features.md
@@ -59,16 +59,18 @@ This feature will likely be removed in a near future.
 
 ## emitRouteChunkError
 
-Emits `app:chunkError` hook when there is an error loading vite/webpack chunks. Default behavior is to perform a reload of the new route on navigation to a new route when a chunk fails to load.
+Emits `app:chunkError` hook when there is an error loading vite/webpack chunks. The default value is `'automatic-immediate'`, which will cause the current route to be reloaded immediately on chunk errors. This is useful for chunk errors that are not triggered by navigation, e.g., when your Nuxt app fails to load a [lazy component](/docs/guide/directory-structure/components#dynamic-imports). A potential downside of this behavior is undesired reloads, e.g., when your app does not need the chunk that caused the error.
 
-If you set this to `'automatic-immediate'` Nuxt will reload the current route immediately, instead of waiting for a navigation. This is useful for chunk errors that are not triggered by navigation, e.g., when your Nuxt app fails to load a [lazy component](/docs/guide/directory-structure/components#dynamic-imports). A potential downside of this behavior is undesired reloads, e.g., when your app does not need the chunk that caused the error.
+Chunk errors can happen when a new release invalidates old code. When building the app, files are hashed and the hashes are used as filenames. If a component imports a filename that is subsequently removed in a new release, a chunk error will be thrown.
+
+`'automatic'` will only perform a reload of the new route on navigation to a new route when a chunk fails to load.
 
 You can disable automatic handling by setting this to `false`, or handle chunk errors manually by setting it to `manual`.
 
 ```ts twoslash [nuxt.config.ts]
 export default defineNuxtConfig({
   experimental: {
-    emitRouteChunkError: 'automatic' // or 'automatic-immediate', 'manual' or false
+    emitRouteChunkError: 'automatic-immediate' // or 'automatic', 'manual' or false
   }
 })
 ```

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -88,7 +88,7 @@ export default defineResolvers({
           return val as EmitRouteChunkError
         }
 
-        return 'automatic'
+        return 'automatic-immediate'
       },
     },
     templateRouteInjection: true,


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
Had a quick discussion in this PR about it: https://github.com/nuxt/nuxt/pull/28160#issuecomment-3037036793
Should hopefully also help with https://github.com/nuxt/nuxt/issues/26565

### 📚 Description

When using dynamically imported components, users risk getting chunk loading errors when the app is updated. With this change, the app is reloaded when any chunk errors happen.

This could potentially cause a unwanted reload if the component isn't needed for rendering the page. However I still think this is preferable to breaking the app, which can happen if the component is needed. 

At work we’ve seen the same error even with non‑lazy components pulled from other packages in the monorepo and `'automatic-immediate'` seems to have fixed it.



<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
