### PR TITLE
docs: provide `async` keyword

### DIFF
--- a/docs/3.api/2.composables/use-runtime-config.md
+++ b/docs/3.api/2.composables/use-runtime-config.md
@@ -55,7 +55,7 @@ Variables that need to be accessible on the server are added directly inside `ru
 To access runtime config, we can use `useRuntimeConfig()` composable:
 
 ```ts [server/api/test.ts]
-export default defineEventHandler((event) => {
+export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig(event)
 
   // Access public variables


### PR DESCRIPTION
since we are using `await $fetch`, I think the function should be `async` also.