### PR TITLE
fix(nuxt): handle `execute being passed to `watch`

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -622,7 +622,7 @@ function createAsyncData<
     execute: (...args) => {
       const [_opts, newValue = undefined] = args
       const opts = _opts && newValue === undefined && typeof _opts === 'object' ? _opts : {}
-      if (import.meta.dev && opts !== _opts) {
+      if (import.meta.dev && newValue !== undefined && (!_opts || typeof _opts !== 'object')) {
         // @ts-expect-error private property
         console.warn(`[nuxt] [${options._functionName}] Do not pass \`execute\` directly to \`watch\`. Instead, use an inline function, such as \`watch(q, () => execute())\`.`)
       }

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -619,7 +619,13 @@ function createAsyncData<
     pending: pendingWhenIdle ? shallowRef(!hasCachedData) : computed(() => asyncData.status.value === 'pending'),
     error: toRef(nuxtApp.payload._errors, key) as any,
     status: shallowRef('idle'),
-    execute: (opts = {}) => {
+    execute: (...args) => {
+      const [_opts, newValue = undefined] = args
+      const opts = _opts && newValue === undefined && typeof _opts === 'object' ? _opts : {}
+      if (import.meta.dev && newValue !== undefined) {
+        // @ts-expect-error private property
+        console.warn(`[nuxt] [${options._functionName}] Do not pass \`execute\` directly to \`watch\`. Instead, use an inline function, such as \`watch(q, () => execute())\`.`)
+      }
       if (nuxtApp._asyncDataPromises[key]) {
         if ((opts.dedupe ?? options.dedupe) === 'defer') {
         // Avoid fetching same key more than once at a time

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -622,7 +622,7 @@ function createAsyncData<
     execute: (...args) => {
       const [_opts, newValue = undefined] = args
       const opts = _opts && newValue === undefined && typeof _opts === 'object' ? _opts : {}
-      if (import.meta.dev && newValue !== undefined) {
+      if (import.meta.dev && opts !== _opts) {
         // @ts-expect-error private property
         console.warn(`[nuxt] [${options._functionName}] Do not pass \`execute\` directly to \`watch\`. Instead, use an inline function, such as \`watch(q, () => execute())\`.`)
       }

--- a/test/nuxt/use-async-data.test.ts
+++ b/test/nuxt/use-async-data.test.ts
@@ -691,6 +691,23 @@ describe('useAsyncData', () => {
     expect(promiseFn).toHaveBeenCalledTimes(1)
   })
 
+  it('should handle being passed to watch', async () => {
+    const q = ref<null | string>('test')
+    const promiseFn = vi.fn(() => Promise.resolve('test'))
+    const { execute } = useAsyncData(promiseFn, { immediate: false })
+    expect(promiseFn).toHaveBeenCalledTimes(0)
+
+    // @ts-expect-error type is not valid
+    watch(q, execute)
+
+    expect(promiseFn).toHaveBeenCalledTimes(0)
+    
+    q.value = null
+    await nextTick()
+    await flushPromises()
+    expect(promiseFn).toHaveBeenCalledTimes(1)
+  })
+
   it('should not refetch on the client when hydrating', () => {
     useNuxtData('hydration-on-client').data.value = 'server-renderered'
     useNuxtApp().isHydrating = true

--- a/test/nuxt/use-async-data.test.ts
+++ b/test/nuxt/use-async-data.test.ts
@@ -701,7 +701,7 @@ describe('useAsyncData', () => {
     watch(q, execute)
 
     expect(promiseFn).toHaveBeenCalledTimes(0)
-    
+
     q.value = null
     await nextTick()
     await flushPromises()


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/32583

### 📚 Description

a minimal approach for protecting against `watch(query, execute)`, in the interests of not requiring changes to code when adopting v4