### PR TITLE
fix(kit): add layer `app/` and `server/` folders into tsconfigs

### DIFF
--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -166,10 +166,12 @@ export function resolveLayerPaths (dir: Nuxt['options']['dir'], buildDir: string
     nuxt: [
       join(relativeSrcDir, '**/*'),
       join(relativeModulesDir, `*/runtime/**/*`),
+      join(relativeRootDir, `layers/*/app/**/*`),
       join(relativeRootDir, `layers/*/modules/*/runtime/**/*`),
     ],
     nitro: [
       join(relativeModulesDir, `*/runtime/server/**/*`),
+      join(relativeRootDir, `layers/*/server/**/*`),
       join(relativeRootDir, `layers/*/modules/*/runtime/server/**/*`),
     ],
     node: [

--- a/packages/kit/test/generate-types.spec.ts
+++ b/packages/kit/test/generate-types.spec.ts
@@ -129,6 +129,7 @@ describe('resolveLayerPaths', () => {
         ],
         "nitro": [
           "../custom-modules/*/runtime/server/**/*",
+          "../layers/*/server/**/*",
           "../layers/*/modules/*/runtime/server/**/*",
         ],
         "node": [
@@ -142,6 +143,7 @@ describe('resolveLayerPaths', () => {
         "nuxt": [
           "../app/**/*",
           "../custom-modules/*/runtime/**/*",
+          "../layers/*/app/**/*",
           "../layers/*/modules/*/runtime/**/*",
         ],
         "shared": [


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/32590

### 📚 Description

this ensures that vue can correctly resolve types in `layers/*/app/` folders.

note that this hard-codes the need to use the `app/` directory within layers, if types are going to work seamlessly.