### PR TITLE
fix(nuxt): include shared types in tsconfig.server.json

### DIFF
--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -146,6 +146,12 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
         include: [
           join(nuxt.options.buildDir, 'types/nitro-nuxt.d.ts'),
           ...modules.map(m => join(relativeWithDot(nuxt.options.buildDir, m), 'runtime/server')),
+          ...nuxt.options._layers.map(layer =>
+            relativeWithDot(
+              nuxt.options.buildDir,
+              resolve(layer.config.rootDir, layer.config.dir?.shared ?? 'shared', '**/*.d.ts'),
+            ),
+          ),
         ],
         exclude: [
           ...nuxt.options.modulesDir.map(m => relativeWithDot(nuxt.options.buildDir, m)),


### PR DESCRIPTION
### 🔗 Linked issue

resolves #32593 

### Problem
The generated `.nuxt/tsconfig.server.json` was missing the shared types include pattern (`../shared/**/*.d.ts`), while `tsconfig.json` and `tsconfig.app.json` correctly included it. This prevented types in the `shared/` directory from being available in server routes, breaking type sharing between client and server.

### Solution
Added the shared types pattern to the server tsconfig generation in `packages/nuxt/src/core/nitro.ts` to match the pattern used in `tsconfig.app.json`.

### Changes
- **Added** shared types include pattern for each layer in the server tsconfig generation
- **Matches** the existing pattern used in `tsconfig.app.json`: `../shared/**/*.d.ts`
- **Ensures** parity between client and server type availability

### Before
```json
// .nuxt/tsconfig.server.json
{
  "include": [
    "./types/nitro-nuxt.d.ts",
    ".../devtools/runtime/server",
    // ❌ Missing shared types
  ]
}
```

### After
```json
// .nuxt/tsconfig.server.json
{
  "include": [
    "./types/nitro-nuxt.d.ts",
    ".../devtools/runtime/server",
    "../shared/**/*.d.ts"  // ✅ Now included
  ]
}
```

### Testing
- ✅ Verified shared types are now included in generated `tsconfig.server.json`
- ✅ Confirmed type sharing works between client and server routes
- ✅ No breaking changes to existing functionality

### Related
Fixes issue where server routes could not access types defined in `shared/` directory.

---

**Type:** Bug Fix  
**Breaking Change:** No  
**Testing:** Manual verification with local Nuxt build
<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
