### PR TITLE
docs: move augmenting hook types in hooks page

### DIFF
--- a/docs/2.guide/3.going-further/1.events.md
+++ b/docs/2.guide/3.going-further/1.events.md
@@ -58,6 +58,6 @@ await nuxtApp.callHook('app:user:registered', {
 You can inspect all events using the **Nuxt DevTools** Hooks panel.
 ::
 
-::read-more{to="/docs/2.guide/3.going-further/2.hooks.md"}
+::read-more{to="/docs/guide/going-further/hooks"}
 Learn more about Nuxt's built-in hooks and how to extend them
 ::

--- a/docs/2.guide/3.going-further/1.events.md
+++ b/docs/2.guide/3.going-further/1.events.md
@@ -58,25 +58,8 @@ await nuxtApp.callHook('app:user:registered', {
 You can inspect all events using the **Nuxt DevTools** Hooks panel.
 ::
 
-## Augmenting Types
+## Declaring events to typescript
 
-You can augment the types of hooks provided by Nuxt.
-
-```ts
-import { HookResult } from "@nuxt/schema";
-
-declare module '#app' {
-  interface RuntimeNuxtHooks {
-    'your-nuxt-runtime-hook': () => HookResult
-  }
-  interface NuxtHooks {
-    'your-nuxt-hook': () => HookResult
-  }
-}
-
-declare module 'nitropack/types' {
-  interface NitroRuntimeHooks {
-    'your-nitro-hook': () => void;
-  }
-}
-```
+::read-more{to="/docs/2.guide/3.going-further/2.hooks.md"}
+Learn more about adding your own hooks
+::

--- a/docs/2.guide/3.going-further/1.events.md
+++ b/docs/2.guide/3.going-further/1.events.md
@@ -58,8 +58,6 @@ await nuxtApp.callHook('app:user:registered', {
 You can inspect all events using the **Nuxt DevTools** Hooks panel.
 ::
 
-## Declaring events to typescript
-
 ::read-more{to="/docs/2.guide/3.going-further/2.hooks.md"}
-Learn more about adding your own hooks
+Learn more about Nuxt's built-in hooks and how to extend them
 ::

--- a/docs/2.guide/3.going-further/2.hooks.md
+++ b/docs/2.guide/3.going-further/2.hooks.md
@@ -74,9 +74,9 @@ export default defineNitroPlugin((nitroApp) => {
 Learn more about available Nitro lifecycle hooks.
 ::
 
-## Augmenting Types
+## Adding Custom Hooks
 
-You can augment the types of hooks provided by Nuxt.
+You can define your own custom hooks support by extending Nuxt's hook interfaces.
 
 ```ts
 import { HookResult } from "@nuxt/schema";

--- a/docs/2.guide/3.going-further/2.hooks.md
+++ b/docs/2.guide/3.going-further/2.hooks.md
@@ -74,6 +74,25 @@ export default defineNitroPlugin((nitroApp) => {
 Learn more about available Nitro lifecycle hooks.
 ::
 
-## Additional Hooks
+## Augmenting Types
 
-Learn more about creating custom hooks in the [Events section](/docs/guide/going-further/events).
+You can augment the types of hooks provided by Nuxt.
+
+```ts
+import { HookResult } from "@nuxt/schema";
+
+declare module '#app' {
+  interface RuntimeNuxtHooks {
+    'your-nuxt-runtime-hook': () => HookResult
+  }
+  interface NuxtHooks {
+    'your-nuxt-hook': () => HookResult
+  }
+}
+
+declare module 'nitropack/types' {
+  interface NitroRuntimeHooks {
+    'your-nitro-hook': () => void;
+  }
+}
+```


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

A small issue I noticed in the doc. 

We should show how to extend hooks within the hooks page, not in the event page. It's currently a bit harder for users to find the doc about how to extend hooks. 

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
