### PR TITLE
fix(nuxt): remove `assets` alias for all resolvers

### DIFF
--- a/packages/schema/src/config/app.ts
+++ b/packages/schema/src/config/app.ts
@@ -7,11 +7,14 @@ import type { NuxtAppConfig } from '../types/config'
 export default defineResolvers({
   vue: {
     transformAssetUrls: {
-      video: ['src', 'poster'],
-      source: ['src'],
-      img: ['src'],
-      image: ['xlink:href', 'href'],
-      use: ['xlink:href', 'href'],
+      preserveTilde: true,
+      tags: {
+        video: ['src', 'poster'],
+        source: ['src'],
+        img: ['src'],
+        image: ['xlink:href', 'href'],
+        use: ['xlink:href', 'href'],
+      },
     },
     compilerOptions: {},
     runtimeCompiler: {

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -54,7 +54,7 @@ export default defineResolvers({
             return rootDir
           }
         }
-        const keys = ['assets', 'layouts', 'middleware', 'pages', 'plugins'] as const
+        const keys = ['layouts', 'middleware', 'pages', 'plugins'] as const
         const dirs = await Promise.all(keys.map(key => get(`dir.${key}`)))
         for (const dir of dirs) {
           if (existsSync(resolve(rootDir, dir))) {
@@ -163,7 +163,6 @@ export default defineResolvers({
         return resolve(await get('srcDir'), val && typeof val === 'string' ? val : (srcDir === rootDir ? 'app' : '.'))
       },
     },
-    assets: 'assets',
     layouts: 'layouts',
     middleware: 'middleware',
     modules: {

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs'
 import * as vite from 'vite'
-import { basename, dirname, join, normalize, resolve } from 'pathe'
+import { dirname, join, normalize, resolve } from 'pathe'
 import type { Nuxt, NuxtBuilder, ViteConfig } from '@nuxt/schema'
 import { addVitePlugin, createIsIgnored, logger, resolvePath, useNitro } from '@nuxt/kit'
 import replace from '@rollup/plugin-replace'
@@ -89,7 +89,6 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
         },
         resolve: {
           alias: {
-            [basename(nuxt.options.dir.assets)]: resolve(nuxt.options.srcDir, nuxt.options.dir.assets),
             ...nuxt.options.alias,
             '#app': nuxt.options.appDir,
             'web-streams-polyfill/ponyfill/es2018': mockEmpty,

--- a/packages/webpack/src/presets/base.ts
+++ b/packages/webpack/src/presets/base.ts
@@ -1,4 +1,4 @@
-import { basename, normalize, resolve } from 'pathe'
+import { normalize, resolve } from 'pathe'
 // @ts-expect-error missing types
 import TimeFixPlugin from 'time-fix-plugin'
 import type { Configuration } from 'webpack'
@@ -129,7 +129,6 @@ function basePlugins (ctx: WebpackConfigContext) {
 function baseAlias (ctx: WebpackConfigContext) {
   ctx.alias = {
     '#app': ctx.options.appDir,
-    [basename(ctx.nuxt.options.dir.assets)]: resolve(ctx.nuxt.options.srcDir, ctx.nuxt.options.dir.assets),
     ...ctx.options.alias,
     ...ctx.alias,
   }

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -61,7 +61,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"194k"`)
 
     const modules = await analyzeSizes(['node_modules/**/*'], serverDir)
-    expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"1401k"`)
+    expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"1402k"`)
 
     const packages = modules.files
       .filter(m => m.endsWith('package.json'))
@@ -117,10 +117,10 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(pagesRootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"288k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"287k"`)
 
     const modules = await analyzeSizes(['node_modules/**/*'], serverDir)
-    expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"1412k"`)
+    expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"1413k"`)
 
     const packages = modules.files
       .filter(m => m.endsWith('package.json'))


### PR DESCRIPTION
### 🔗 Linked issue

fixes https://github.com/nuxt/nuxt/issues/32657

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This PR follows up on https://github.com/nuxt/nuxt/pull/32119 and is wating for https://github.com/vuejs/core/pull/13462

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
