### PR TITLE
docs: document the --modules flag in the init command

### DIFF
--- a/docs/3.api/4.commands/init.md
+++ b/docs/3.api/4.commands/init.md
@@ -38,6 +38,8 @@ Option | Default | Description
 `--gitInit` |  | Initialize git repository
 `--shell` |  | Start shell after installation in project directory
 `--packageManager` |  | Package manager choice (npm, pnpm, yarn, bun)
+`--modules` |  | Nuxt modules to install (comma separated without spaces)
+`--no-modules` |  | Skip module installation prompt
 <!--/init-opts-->
 
 ## Environment variables


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This change updates the docs to include the `--modules` and `--no-modules` args. https://github.com/nuxt/cli/blob/c7c4dd100ed0488bc84f97d3610b0d30474f9e73/packages/nuxi/src/commands/init.ts#L124

(`--no-modules` is only in an RC release at this point, so I can remove that if necessary)

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
