### PR TITLE
fix(nuxt): retain old data when computed key changes

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -333,8 +333,14 @@ export function useAsyncData<
         }
         const initialFetchOptions: AsyncDataExecuteOptions = { cause: 'initial', dedupe: options.dedupe }
         if (!nuxtApp._asyncData[newKey]?._init) {
-          initialFetchOptions.cachedData = options.getCachedData!(newKey, nuxtApp, { cause: 'initial' })
-          nuxtApp._asyncData[newKey] = createAsyncData(nuxtApp, newKey, _handler, options, initialFetchOptions.cachedData)
+          let value: NoInfer<DataT> | undefined
+          if (oldKey && hasRun) {
+            value = nuxtApp._asyncData[oldKey]?.data.value as NoInfer<DataT>
+          } else {
+            value = options.getCachedData!(newKey, nuxtApp, { cause: 'initial' })
+            initialFetchOptions.cachedData = value
+          }
+          nuxtApp._asyncData[newKey] = createAsyncData(nuxtApp, newKey, _handler, options, value)
         }
         nuxtApp._asyncData[newKey]._deps++
 

--- a/test/nuxt/use-async-data.test.ts
+++ b/test/nuxt/use-async-data.test.ts
@@ -739,5 +739,6 @@ describe('useAsyncData', () => {
     await nextTick()
     expect(data.value).toBe('about')
     expect(promiseFn).toHaveBeenCalledTimes(2)
+    vi.useRealTimers()
   })
 })

--- a/test/nuxt/use-async-data.test.ts
+++ b/test/nuxt/use-async-data.test.ts
@@ -716,4 +716,28 @@ describe('useAsyncData', () => {
     expect(status.value).toBe('success')
     useNuxtApp().isHydrating = false
   })
+
+  it('should retain the old data when a computed key changes', async () => {
+    vi.useFakeTimers()
+    const page = ref('index')
+    const promiseFn = vi.fn(() => new Promise(resolve => setTimeout(() => resolve(page.value), 100)))
+    const { data } = useAsyncData(() => page.value, promiseFn)
+
+    vi.advanceTimersToNextTimer()
+    await flushPromises()
+    expect(data.value).toBe('index')
+    expect(promiseFn).toHaveBeenCalledTimes(1)
+
+    page.value = 'about'
+    await nextTick()
+    await flushPromises()
+    expect(promiseFn).toHaveBeenCalledTimes(2)
+    expect(data.value).toBe('index')
+
+    vi.advanceTimersToNextTimer()
+    await flushPromises()
+    await nextTick()
+    expect(data.value).toBe('about')
+    expect(promiseFn).toHaveBeenCalledTimes(2)
+  })
 })


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/31999

### 📚 Description

this preserves the current state of asyncData when fetching new data after a computed key changes. (it might be possible to build on it to solve https://github.com/nuxt/nuxt/issues/32102 by updating key _but not updating contents_ if `watch: false` is set.