### PR TITLE
feat(nuxt): add route announcer to default app.vue

### DIFF
--- a/packages/nuxt/src/pages/runtime/app.vue
+++ b/packages/nuxt/src/pages/runtime/app.vue
@@ -1,5 +1,6 @@
 <template>
   <NuxtLayout>
+    <NuxtRouteAnnouncer />
     <NuxtPage />
   </NuxtLayout>
 </template>


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/32576

### 📚 Description

this adds a route announcer to the default `app.vue` used when there is a `pages/` directory