### PR TITLE
fix(nuxt): Improper code sanitization on JSON.stringify

### DIFF
--- a/packages/nuxt/src/components/plugins/transform.ts
+++ b/packages/nuxt/src/components/plugins/transform.ts
@@ -1,3 +1,22 @@
+
+const charMap = {
+  '<': '\\u003C',
+  '>': '\\u003E',
+  '/': '\\u002F',
+  '\\': '\\\\',
+  '\b': '\\b',
+  '\f': '\\f',
+  '\n': '\\n',
+  '\r': '\\r',
+  '\t': '\\t',
+  '\0': '\\0',
+  '\u2028': '\\u2028',
+  '\u2029': '\\u2029',
+};
+
+function escapeUnsafeChars(str: string): string {
+  return str.replace(/[<>\b\f\n\r\t\0\u2028\u2029]/g, x => charMap[x] || x);
+}
 import { isIgnored } from '@nuxt/kit'
 import type { Import } from 'unimport'
 import { createUnimport } from 'unimport'
@@ -74,7 +93,7 @@ export function TransformPlugin (nuxt: Nuxt, options: TransformPluginOptions) {
           return {
             code: [
               'import { defineAsyncComponent } from "vue"',
-              `${exportWording} defineAsyncComponent(() => import(${JSON.stringify(bare)}).then(r => r[${JSON.stringify(componentExport)}] || r.default || r))`,
+              `${exportWording} defineAsyncComponent(() => import(${JSON.stringify(escapeUnsafeChars(bare))}).then(r => r[${JSON.stringify(componentExport)}] || r.default || r))`,
             ].join('\n'),
             map: null,
           }

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -478,9 +478,27 @@ function prepareRoutes (routes: NuxtPage[], parent?: NuxtPage, names = new Set<s
   return routes
 }
 
+function escapeUnsafeChars(str: string): string {
+  const charMap = {
+    '<': '\\u003C',
+    '>': '\\u003E',
+    '/': '\\u002F',
+    '\\': '\\\\',
+    '\b': '\\b',
+    '\f': '\\f',
+    '\n': '\\n',
+    '\r': '\\r',
+    '\t': '\\t',
+    '\0': '\\0',
+    '\u2028': '\\u2028',
+    '\u2029': '\\u2029'
+  };
+  return str.replace(/[<>\b\f\n\r\t\0\u2028\u2029]/g, x => charMap[x]);
+}
+
 function serializeRouteValue (value: any, skipSerialisation = false) {
   if (skipSerialisation || value === undefined) { return undefined }
-  return JSON.stringify(value)
+  return escapeUnsafeChars(JSON.stringify(value))
 }
 
 type NormalizedRoute = Partial<Record<Exclude<keyof NuxtPage, 'file'>, string>> & { component?: string }


### PR DESCRIPTION
https://github.com/nuxt/nuxt/blob/232b14e2f9708463148b08d9124e98303c12e9f3/packages/nuxt/src/pages/utils.ts#L551-L551
https://github.com/nuxt/nuxt/blob/232b14e2f9708463148b08d9124e98303c12e9f3/packages/nuxt/src/components/plugins/transform.ts#L77-L77

Using string concatenation to construct JavaScript code can be error-prone, or in the worst case, enable code injection if an input is constructed by an attacker.


fix the issue ensure that all potentially dangerous characters in values used to construct JavaScript code are escaped. This can be achieved by introducing a utility function (e.g., `escapeUnsafeChars`) that escapes characters like `<`, `>`, `\`, and others that could break out of JavaScript contexts or introduce vulnerabilities. The `serializeRouteValue` function should be updated to apply this escaping to its output. The changes require the following steps:
1. Define an `escapeUnsafeChars` function based on the provided safe escaping logic.
2. Update the `serializeRouteValue` function to apply `escapeUnsafeChars` to the result of `JSON.stringify`.
