### PR TITLE
docs: added new Shared folder to the example of v4 folder structure

### DIFF
--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -140,6 +140,7 @@ layers/
 modules/
 node_modules/
 public/
+shared/
 server/
   api/
   middleware/


### PR DESCRIPTION
### 📚 Description

new `shared/` folder was not shown on the example of v4 folder structure https://nuxt.com/docs/4.x/getting-started/upgrade
