### PR TITLE
docs: reference `noUncheckedIndexedAccess` rule change in v4 guide

### DIFF
--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -985,10 +985,12 @@ Nuxt now generates separate TypeScript configurations for different contexts to 
 
 1. **New TypeScript configuration files**: Nuxt now generates additional TypeScript configurations:
    * `.nuxt/tsconfig.app.json` - For your app code (Vue components, composables, etc.)
+   * * `noUncheckedIndexedAccess` rule was changed from `false` to `true`.
    * `.nuxt/tsconfig.server.json` - For your server-side code (Nitro/server directory)  
    * `.nuxt/tsconfig.node.json` - For your build-time code (modules, `nuxt.config.ts`, etc.)
    * `.nuxt/tsconfig.shared.json` - For code shared between app and server contexts (like types and non-environment specific utilities)
    * `.nuxt/tsconfig.json` - Legacy configuration for backward compatibility
+   * * `noUncheckedIndexedAccess` rule was changed from `false` to `true`.
 
 2. **Backward compatibility**: Existing projects that extend `.nuxt/tsconfig.json` will continue to work as before.
 
@@ -1011,7 +1013,23 @@ For example, auto-imports are not available in your `nuxt.config.ts` (but previo
 
 #### Migration Steps
 
-**No migration is required** - existing projects will continue to work as before.
+If you want your typechecking to continue working **exactly** as before, you'll have to change the `noUncheckedIndexedAccess` rule back to `false`.
+You can do that by updating your `nuxt.config.ts`:
+    <!-- @case-police-ignore tsConfig -->
+
+   ```ts
+   export default defineNuxtConfig({
+     typescript: {
+       tsConfig: {
+         compilerOptions: {
+           noUncheckedIndexedAccess: false
+         }
+       },
+     }
+   })
+   ```
+
+**No further migration is required** - existing projects will continue to work as before.
 
 However, to take advantage of improved type checking, you can opt in to the new project references approach:
 

--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -975,7 +975,41 @@ const importName = genSafeVariableName
 You can automate this step by running `npx codemod@latest nuxt/4/template-compilation-changes`
 ::
 
-### TypeScript Configuration Changes
+### Default TypeScript Configuration Changes
+
+🚦 **Impact Level**: Minimal
+
+#### What Changed
+
+`compilerOptions.noUncheckedIndexedAccess` is now `true` instead of `false`.
+
+#### Reasons for Change
+
+This change is a follow up to a prior [3.12 config update](https://github.com/nuxt/nuxt/pull/27485) where we improved our defaults, mostly adhering to [TotalTypeScript's recommendations](https://www.totaltypescript.com/tsconfig-cheat-sheet).
+
+#### Migration Steps
+
+There are two approaches:
+
+1. Run a typecheck on your app and fix any new errors (recommended).
+
+2. Override the new default in your `nuxt.config.ts`:
+
+   <!-- @case-police-ignore tsConfig -->
+
+   ```ts
+   export default defineNuxtConfig({
+     typescript: {
+       tsConfig: {
+         compilerOptions: {
+           noUncheckedIndexedAccess: false
+         }
+       }
+     }
+   })
+   ```
+
+### TypeScript Configuration Splitting
 
 🚦 **Impact Level**: Minimal
 
@@ -985,12 +1019,10 @@ Nuxt now generates separate TypeScript configurations for different contexts to 
 
 1. **New TypeScript configuration files**: Nuxt now generates additional TypeScript configurations:
    * `.nuxt/tsconfig.app.json` - For your app code (Vue components, composables, etc.)
-   * * `noUncheckedIndexedAccess` rule was changed from `false` to `true`.
    * `.nuxt/tsconfig.server.json` - For your server-side code (Nitro/server directory)  
    * `.nuxt/tsconfig.node.json` - For your build-time code (modules, `nuxt.config.ts`, etc.)
    * `.nuxt/tsconfig.shared.json` - For code shared between app and server contexts (like types and non-environment specific utilities)
    * `.nuxt/tsconfig.json` - Legacy configuration for backward compatibility
-   * * `noUncheckedIndexedAccess` rule was changed from `false` to `true`.
 
 2. **Backward compatibility**: Existing projects that extend `.nuxt/tsconfig.json` will continue to work as before.
 
@@ -1013,23 +1045,7 @@ For example, auto-imports are not available in your `nuxt.config.ts` (but previo
 
 #### Migration Steps
 
-If you want your typechecking to continue working **exactly** as before, you'll have to change the `noUncheckedIndexedAccess` rule back to `false`.
-You can do that by updating your `nuxt.config.ts`:
-    <!-- @case-police-ignore tsConfig -->
-
-   ```ts
-   export default defineNuxtConfig({
-     typescript: {
-       tsConfig: {
-         compilerOptions: {
-           noUncheckedIndexedAccess: false
-         }
-       },
-     }
-   })
-   ```
-
-**No further migration is required** - existing projects will continue to work as before.
+**No migration is required** - existing projects will continue to work as before.
 
 However, to take advantage of improved type checking, you can opt in to the new project references approach:
 


### PR DESCRIPTION
### 🔗 Linked issue

None.

### 📚 Description

The `noUncheckedIndexedAccess` rule change makes the new typescript configuration not 100% backward compatible.
I added the required migration step, but left the "Backward compatibility" bullet point because I think it's still relevant.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
