### PR TITLE
fix: compat bun oven-sh/bun#18737

### DIFF
--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -21,6 +21,12 @@ import { ModulePreloadPolyfillPlugin } from './plugins/module-preload-polyfill'
 import { ViteNodePlugin } from './vite-node'
 import { createViteLogger } from './utils/logger'
 
+// https://github.com/oven-sh/bun/issues/18737
+const removeTrailingSlash = (s: string) => {
+  const parsed = new URL(s, 'http://example.com').pathname
+  return parsed.length > 1 && parsed.at(-1) === '/' ? parsed.slice(0, -1) : parsed
+}
+
 export async function buildClient (nuxt: Nuxt, ctx: ViteBuildContext) {
   const nodeCompat = nuxt.options.experimental.clientNodeCompat
     ? {
@@ -32,7 +38,7 @@ export async function buildClient (nuxt: Nuxt, ctx: ViteBuildContext) {
   const clientConfig: ViteConfig = vite.mergeConfig(ctx.config, vite.mergeConfig({
     configFile: false,
     base: nuxt.options.dev
-      ? joinURL(nuxt.options.app.baseURL.replace(/^\.\//, '/') || '/', nuxt.options.app.buildAssetsDir)
+      ? removeTrailingSlash(joinURL(nuxt.options.app.baseURL.replace(/^\.\//, '/') || '/', nuxt.options.app.buildAssetsDir))
       : './',
     css: {
       devSourcemap: !!nuxt.options.sourcemap.client,

--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -6,7 +6,7 @@ import viteJsxPlugin from '@vitejs/plugin-vue-jsx'
 import type { BuildOptions, ServerOptions } from 'vite'
 import { logger, useNitro } from '@nuxt/kit'
 import { getPort } from 'get-port-please'
-import { joinURL, withoutLeadingSlash } from 'ufo'
+import { joinURL, withoutLeadingSlash, withoutTrailingSlash } from 'ufo'
 import { defu } from 'defu'
 import { defineEnv } from 'unenv'
 import { resolveModulePath } from 'exsolve'
@@ -21,12 +21,6 @@ import { ModulePreloadPolyfillPlugin } from './plugins/module-preload-polyfill'
 import { ViteNodePlugin } from './vite-node'
 import { createViteLogger } from './utils/logger'
 
-// https://github.com/oven-sh/bun/issues/18737
-const removeTrailingSlash = (s: string) => {
-  const parsed = new URL(s, 'http://example.com').pathname
-  return parsed.length > 1 && parsed.at(-1) === '/' ? parsed.slice(0, -1) : parsed
-}
-
 export async function buildClient (nuxt: Nuxt, ctx: ViteBuildContext) {
   const nodeCompat = nuxt.options.experimental.clientNodeCompat
     ? {
@@ -38,7 +32,8 @@ export async function buildClient (nuxt: Nuxt, ctx: ViteBuildContext) {
   const clientConfig: ViteConfig = vite.mergeConfig(ctx.config, vite.mergeConfig({
     configFile: false,
     base: nuxt.options.dev
-      ? removeTrailingSlash(joinURL(nuxt.options.app.baseURL.replace(/^\.\//, '/') || '/', nuxt.options.app.buildAssetsDir))
+      // https://github.com/oven-sh/bun/issues/18737
+      ? withoutTrailingSlash(joinURL(nuxt.options.app.baseURL.replace(/^\.\//, '/') || '/', nuxt.options.app.buildAssetsDir))
       : './',
     css: {
       devSourcemap: !!nuxt.options.sourcemap.client,


### PR DESCRIPTION
### 🔗 Linked issue

oven-sh/bun#18737

### 📚 Description

After upgrading to v4, Nuxt dev server could't work. When I visit the page:

```
[14:17:48]  ERROR  [unhandledRejection] { [Error: Malformed_HTTP_Response fetching "http://127.0.0.1:51684/_nuxt/?token=Gje1rGQ5rAeF". For more information, pass verbose: true in the second argument to fetch()]
  code: 'Malformed_HTTP_Response',
  path: 'http://127.0.0.1:51684/_nuxt/?token=Gje1rGQ5rAeF',
  errno: 0 }
```

So I spent 3 hrs working on this ✅