### PR TITLE
feat: add buildAssetsFileNamePrefix option

### DIFF
--- a/docs/3.api/6.nuxt-config.md
+++ b/docs/3.api/6.nuxt-config.md
@@ -113,6 +113,29 @@ The folder name for the built site assets, relative to `baseURL` (or `cdnURL` if
 - **Type**: `string`
 - **Default:** `"/_nuxt/"`
 
+### `buildAssetsFileNamePrefix`
+
+A prefix to add to the file names of built assets. This can be used to add a custom prefix to all generated asset file names.
+
+- **Type**: `string`
+- **Default:** `""`
+
+**Example**:
+```ts
+export default defineNuxtConfig({
+  app: {
+    buildAssetsFileNamePrefix: 'custom-'
+  }
+})
+```
+
+This can be set to a different value at runtime by setting the `NUXT_APP_BUILD_ASSETS_FILE_NAME_PREFIX` environment variable.
+
+**Example**:
+```bash
+NUXT_APP_BUILD_ASSETS_FILE_NAME_PREFIX=custom- node .output/server/index.mjs
+```
+
 ### `cdnURL`
 
 An absolute URL to serve the public folder from (production-only).

--- a/packages/schema/src/config/app.ts
+++ b/packages/schema/src/config/app.ts
@@ -41,6 +41,15 @@ export default defineResolvers({
       },
     },
 
+    buildAssetsFileNamePrefix: {
+      $resolve: (val) => {
+        if (typeof val === 'string') {
+          return val
+        }
+        return process.env.NUXT_APP_BUILD_ASSETS_FILE_NAME_PREFIX || ''
+      },
+    },
+
     cdnURL: {
       $resolve: async (val, get) => {
         if (await get('dev')) {

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -152,6 +152,22 @@ export interface ConfigSchema {
     buildAssetsDir: string
 
     /**
+     * A prefix to add to the file names of built assets. This can be used to add a custom prefix to all generated asset file names.
+     *
+     * This can be set to a different value at runtime by setting the `NUXT_APP_BUILD_ASSETS_FILE_NAME_PREFIX` environment variable.
+     *
+     * @example
+     * ```ts
+     * export default defineNuxtConfig({
+     *   app: {
+     *     buildAssetsFileNamePrefix: 'custom-'
+     *   }
+     * })
+     * ```
+     */
+    buildAssetsFileNamePrefix: string
+
+    /**
      * An absolute URL to serve the public folder from (production-only).
      *
      * For example:

--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -157,7 +157,7 @@ export async function buildClient (nuxt: Nuxt, ctx: ViteBuildContext) {
   }
 
   // We want to respect users' own rollup output options
-  const fileNames = withoutLeadingSlash(join(nuxt.options.app.buildAssetsDir, '[hash].js'))
+  const fileNames = withoutLeadingSlash(join(nuxt.options.app.buildAssetsDir, `${nuxt.options.app.buildAssetsFileNamePrefix || ''}[hash].js`))
   clientConfig.build!.rollupOptions = defu(clientConfig.build!.rollupOptions!, {
     output: {
       chunkFileNames: nuxt.options.dev ? undefined : fileNames,


### PR DESCRIPTION
Hi team! ▲▲

### 📚 Description

This PR adds a new configuration option `buildAssetsFileNamePrefix` that allows users to specify a prefix for built asset file names. This feature is useful for:

- Adding version identifiers to asset files (e.g., `v1-[hash].js`)
- Distinguishing assets from different environments (e.g., `prod-[hash].js`, `staging-[hash].js`)
- Implementing custom naming conventions for organization or caching purposes

_Note: I know about the `vite.build.rollupOptions.output`, but I don't want to override Nuxt's generation of filename because it can be changed in the future on the Nuxt side._

Example usage:
```ts
// nuxt.config.ts
export default defineNuxtConfig({
  app: {
    buildAssetsFileNamePrefix: 'custom-'
  }
})
```

Or via environment variable:
```bash
NUXT_APP_BUILD_ASSETS_FILE_NAME_PREFIX=custom- node .output/server/index.mjs
```