### PR TITLE
fix(nuxt): expose shared aliases within `shared/` dir

### DIFF
--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -750,16 +750,3 @@ async function spaLoadingTemplate (nuxt: Nuxt) {
 
   return ''
 }
-
-function arrayEquals (_arr1: string[], _arr2: string[]) {
-  const arr1 = [...new Set(_arr1)].sort()
-  const arr2 = [...new Set(_arr2)].sort()
-  if (arr1.length !== arr2.length) {
-    return false
-  }
-  for (let i = 0; i < arr1.length; i++) {
-    if (arr1[i] !== arr2[i]) {
-      return false
-    }
-  }
-}

--- a/test/fixtures/basic-types/shared/other.ts
+++ b/test/fixtures/basic-types/shared/other.ts
@@ -1,0 +1,1 @@
+export const foo = 'bar'

--- a/test/fixtures/basic-types/shared/shared-types.ts
+++ b/test/fixtures/basic-types/shared/shared-types.ts
@@ -1,0 +1,10 @@
+import { describe, expectTypeOf, it } from 'vitest'
+
+import { foo } from '#shared/other'
+
+describe('shared folder', () => {
+  it('can reference its own aliases', () => {
+    expectTypeOf(foo).not.toBeAny()
+    expectTypeOf(foo).toEqualTypeOf<string>()
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/32556

### 📚 Description

this checks for aliases which are shared between nuxt + nitro and includes them in the shared `tsconfig.json`