### PR TITLE
fix(docs): correct path reference for local fonts in styling guide

### DIFF
--- a/docs/1.getting-started/06.styling.md
+++ b/docs/1.getting-started/06.styling.md
@@ -51,7 +51,7 @@ The stylesheets will be inlined in the HTML rendered by Nuxt, injected globally 
 
 ### Working With Fonts
 
-Place your local fonts files in your `~/public/` directory, for example in `~/public/fonts`. You can then reference them in your stylesheets using `url()`.
+Place your local fonts files in your `public/` directory, for example in `public/fonts`. You can then reference them in your stylesheets using `url()`.
 
 ```css [assets/css/main.css]
 @font-face {


### PR DESCRIPTION
🔗 Linked issue
#32657

📚 Description
Fixed incorrect font loading paths in the styling guide documentation. Changed from using ~/public/ alias to proper absolute /fonts/ paths and clarified that files in public/ are served from the root URL /. This prevents module resolution errors when loading fonts.

