### PR TITLE
docs: fix links to Nitro docs

### DIFF
--- a/docs/1.getting-started/15.prerendering.md
+++ b/docs/1.getting-started/15.prerendering.md
@@ -99,7 +99,7 @@ export default defineNuxtConfig({
 });
 ```
 
-::read-more{to="https://nitro.build/config/#routerules"}
+::read-more{to="https://nitro.build/config#routerules"}
 Read more about Nitro's `routeRules` configuration.
 ::
 

--- a/docs/1.getting-started/16.deployment.md
+++ b/docs/1.getting-started/16.deployment.md
@@ -62,7 +62,7 @@ By default, the workload gets distributed to the workers with the round robin st
 
 ### Learn More
 
-:read-more{to="https://nitro.build/deploy/node" title="the Nitro documentation for node-server preset"}
+:read-more{to="https://nitro.build/deploy/runtimes/node" title="the Nitro documentation for node-server preset"}
 
 :video-accordion{title="Watch Daniel Roe's short video on the topic" videoId="0x1H6K5yOfs"}
 

--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -1156,7 +1156,7 @@ export default defineNuxtConfig({
 })
 ```
 
-::read-more{to="https://nitro.build/config/#prerender"}
+::read-more{to="https://nitro.build/config#prerender"}
 Read more about Nitro's prerender configuration options.
 ::
 

--- a/docs/3.api/6.nuxt-config.md
+++ b/docs/3.api/6.nuxt-config.md
@@ -1468,7 +1468,7 @@ export default {
 
 Configuration for Nitro.
 
-**See**: [Nitro configuration docs](https://nitro.build/config/)
+**See**: [Nitro configuration docs](https://nitro.build/config)
 
 ### `routeRules`
 
@@ -1729,7 +1729,7 @@ Global route options applied to matching server routes.
 
 **Experimental**: This is an experimental feature and API may change in the future.
 
-**See**: [Nitro route rules documentation](https://nitro.build/config/#routerules)
+**See**: [Nitro route rules documentation](https://nitro.build/config#routerules)
 
 ## router
 

--- a/packages/nuxt/src/core/external-config-files.ts
+++ b/packages/nuxt/src/core/external-config-files.ts
@@ -44,7 +44,7 @@ async function checkWebpackConfig () {
 }
 
 async function checkNitroConfig () {
-  // https://nitro.build/config#configuration
+  // https://nitro.build/config
   return await checkAndWarnAboutConfigFileExistence({
     fileName: 'nitro.config',
     extensions: ['.ts', '.mts'],

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1502,7 +1502,7 @@ export interface ConfigSchema {
   /**
    * Configuration for Nitro.
    *
-   * @see [Nitro configuration docs](https://nitro.build/config/)
+   * @see [Nitro configuration docs](https://nitro.build/config)
    */
   nitro: NitroConfig
 
@@ -1511,7 +1511,7 @@ export interface ConfigSchema {
    *
    * @experimental This is an experimental feature and API may change in the future.
    *
-   * @see [Nitro route rules documentation](https://nitro.build/config/#routerules)
+   * @see [Nitro route rules documentation](https://nitro.build/config#routerules)
    */
   routeRules: NitroConfig['routeRules']
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves #32690

### 📚 Description

Some of the links to `nitro.build` documentation don't work anymore, i.e. `https://nitro.build/config/#routerules` (the trailing slash is wrong).

The PR also updates a few other that do work, but only via redirects.
