### PR TITLE
ci: trigger website redeploy on main branch

### DIFF
--- a/.github/workflows/notify-nuxt-website.yml
+++ b/.github/workflows/notify-nuxt-website.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - 3.x
+      - main
     paths:
       - "docs/**"
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

I've been waiting for https://github.com/nuxt/nuxt/pull/31609#event-18707421674 to deploy for quite a while. Seems like we forgot to dispatch the event on main branch update 

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
