### PR TITLE
fix(nuxt): provide typed slots for `<ClientOnly>` and `<DevOnly>`

### DIFF
--- a/packages/nuxt/src/app/components/client-only.ts
+++ b/packages/nuxt/src/app/components/client-only.ts
@@ -1,5 +1,5 @@
 import { cloneVNode, createElementBlock, defineComponent, getCurrentInstance, h, onMounted, provide, shallowRef } from 'vue'
-import type { ComponentInternalInstance, ComponentOptions, InjectionKey } from 'vue'
+import type { ComponentInternalInstance, ComponentOptions, InjectionKey, SlotsType, VNode } from 'vue'
 import { isPromise } from '@vue/shared'
 import { useNuxtApp } from '../nuxt'
 import ServerPlaceholder from './server-placeholder'
@@ -13,6 +13,17 @@ export default defineComponent({
   name: 'ClientOnly',
   inheritAttrs: false,
   props: ['fallback', 'placeholder', 'placeholderTag', 'fallbackTag'],
+  ...(import.meta.dev && {
+    slots: Object as SlotsType<{
+      default?: () => VNode[]
+
+      /**
+       * Specify a content to be rendered on the server and displayed until <ClientOnly> is mounted in the browser.
+       */
+      fallback?: () => VNode[]
+      placeholder?: () => VNode[]
+    }>,
+  }),
   setup (props, { slots, attrs }) {
     const mounted = shallowRef(false)
     onMounted(() => { mounted.value = true })

--- a/packages/nuxt/src/app/components/client-only.ts
+++ b/packages/nuxt/src/app/components/client-only.ts
@@ -18,7 +18,7 @@ export default defineComponent({
       default?: () => VNode[]
 
       /**
-       * Specify a content to be rendered on the server and displayed until <ClientOnly> is mounted in the browser.
+       * Specify a content to be rendered on the server and displayed until `<ClientOnly>` is mounted in the browser.
        */
       fallback?: () => VNode[]
       placeholder?: () => VNode[]

--- a/packages/nuxt/src/app/components/dev-only.ts
+++ b/packages/nuxt/src/app/components/dev-only.ts
@@ -1,8 +1,19 @@
 import { defineComponent } from 'vue'
+import type { SlotsType, VNode } from 'vue'
 
 export default defineComponent({
   name: 'DevOnly',
   inheritAttrs: false,
+  ...(import.meta.dev && {
+    slots: Object as SlotsType<{
+      default?: () => VNode[]
+
+      /**
+       * If you ever require to have a replacement during production.
+       */
+      fallback?: () => VNode[]
+    }>,
+  }),
   setup (_, props) {
     if (import.meta.dev) {
       return () => props.slots.default?.()


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 📚 Description

This PR introduces typed slots for the <ClientOnly> and <DevOnly> components. This should provide better autocompletion and type-safety when using these components in the template, hopefully making them a bit easier to work with.

<img width="539" height="228" alt="After PR" src="https://github.com/user-attachments/assets/2fba4b49-75d4-4260-96ba-983c72c0cb57" />

