### PR TITLE
docs: set correct default value for deep option in usefetch

### DIFF
--- a/docs/3.api/2.composables/use-fetch.md
+++ b/docs/3.api/2.composables/use-fetch.md
@@ -173,7 +173,7 @@ type AsyncDataRequestStatus = 'idle' | 'pending' | 'success' | 'error'
 | `getCachedData`| `(key, nuxtApp, ctx) => DataT \| undefined` | - | Function to return cached data. See below for default. |
 | `pick` | `string[]` | - | Only pick specified keys from the result. |
 | `watch` | `MultiWatchSources \| false` | - | Array of reactive sources to watch and auto-refresh. `false` disables watching. |
-| `deep` | `boolean` | `false` | Return data in a deep ref object. |
+| `deep` | `boolean` | `true` | Return data in a deep ref object. Set to `false` to return data in a shallow ref object, which can improve performance if your data does not need to be deeply reactive. |
 | `dedupe` | `'cancel' \| 'defer'` | `'cancel'` | Avoid fetching same key more than once at a time. |
 | `$fetch` | `typeof globalThis.$fetch` | - | Custom $fetch implementation. |
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This pull request updates the documentation for the deep option in useFetch to set the default value to `true` instead of `false`. This change aligns the documentation with the actual implementation in the source code and ensures consistency for users referencing the docs.

Motivation
Previously, there was a discrepancy between the Nuxt 3.x documentation and the codebase regarding the default value of the `deep` option. The documentation stated the default was `false`, while the implementation and expected behavior is true. This update corrects the documentation, helping prevent user confusion and improving clarity.

Summary of changes

- Set the documented default value of deep to `true`.
- Clarified related explanations to reflect this default.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
