### PR TITLE
docs: update Nuxt installation command to use `npm create nuxt@latest`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ It provides a number of features that make it easy to build fast, SEO-friendly, 
 Use the following command to create a new starter project. This will create a starter project with all the necessary files and dependencies:
 
 ```bash
-npm create nuxt <my-project>
+npm create nuxt@latest <my-project>
 ```
 
 > [!TIP]

--- a/docs/1.getting-started/02.installation.md
+++ b/docs/1.getting-started/02.installation.md
@@ -39,19 +39,19 @@ Open a terminal (if you're using [Visual Studio Code](https://code.visualstudio.
 ::code-group{sync="pm"}
 
 ```bash [npm]
-npm create nuxt <project-name>
+npm create nuxt@latest <project-name>
 ```
 
 ```bash [yarn]
-yarn create nuxt <project-name>
+yarn create nuxt@latest <project-name>
 ```
 
 ```bash [pnpm]
-pnpm create nuxt <project-name>
+pnpm create nuxt@latest <project-name>
 ```
 
 ```bash [bun]
-bun create nuxt <project-name>
+bun create nuxt@latest <project-name>
 ```
 
 ```bash [deno]


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Replace XX with the correct issue number -->
resolves #XX

### ❓ Type of change
 - [x] 📖 Documentation (updates to the documentation or readme)
 - [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
 - [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
 - [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
 - [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR updates the Nuxt installation instructions in the documentation:

- **Before:** `npm create nuxt`
- **After:**  `npm create nuxt@latest`

Using `@latest` guarantees developers scaffold projects with the most recent Nuxt release (v4+), avoiding situations where a locally-cached version of `create-nuxt` falls back to Nuxt 3.17.7 or earlier. It's not necessary, but with the very recent transition from Nuxt 3 to 4, it's a good idea to highlight it (even if it means removing the @latest later).

<img width="911" height="202" alt="image" src="https://github.com/user-attachments/assets/8fa2bf67-76eb-4a59-ae46-f11d6d7fc1dc" />
