### PR TITLE
fix(kit): include module types in `app` context

### DIFF
--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -495,11 +495,13 @@ export async function _generateTypes (nuxt: Nuxt) {
       const pkg = await readPackageJSON(id, { parent }).catch(() => null)
       if (pkg) {
         nodeReferences.push(({ types: pkg.name ?? id }))
+        references.push(({ types: pkg.name ?? id }))
         return
       }
     }
 
     nodeReferences.push(({ types: id }))
+    references.push(({ types: id }))
   }))
 
   const declarations: string[] = []


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/32754

### 📚 Description

this adds back module types to `app` context as well as node context. modules can augment server/app/node and until we have a more specific way for them to target just one context, we need to ensure their types still work.