### PR TITLE
fix(nuxt): constrain global `defineAppConfig` type

### DIFF
--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -447,12 +447,12 @@ export const appConfigDeclarationTemplate: NuxtTemplate = {
     const configPaths = app.configs.map(path => relative(typesDir, path).replace(EXTENSION_RE, ''))
 
     return `
-import type { CustomAppConfig } from 'nuxt/schema'
+import type { AppConfigInput, CustomAppConfig } from 'nuxt/schema'
 import type { Defu } from 'defu'
 ${configPaths.map((id: string, index: number) => `import ${`cfg${index}`} from ${JSON.stringify(id)}`).join('\n')}
 
 declare global {
-  const defineAppConfig: <T>(appConfig: T) => T
+  const defineAppConfig: <C extends AppConfigInput> (config: C) => C
 }
 
 declare const inlineConfig = ${JSON.stringify(nuxt.options.appConfig, null, 2)}


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/32745

### 📚 Description

the global type for `defineAppConfig` 'leaked' (regression from https://github.com/nuxt/nuxt/pull/32528) and removed the constraint we imposed here:

https://github.com/nuxt/nuxt/blob/85be4bd33adee4b2bf01bf1b8aed5312a209ff47/packages/nuxt/src/app/nuxt.ts#L564-L566