### PR TITLE
fix(nuxt): ensure getCachedData function is returning cache if possible

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -736,12 +736,8 @@ function createAsyncData<
 // Used to get default values
 const getDefault = () => undefined
 const getDefaultCachedData: AsyncDataOptions<any>['getCachedData'] = (key, nuxtApp, ctx) => {
-  if (nuxtApp.isHydrating) {
-    return nuxtApp.payload.data[key]
-  }
-
   if (ctx.cause !== 'refresh:manual' && ctx.cause !== 'refresh:hook') {
-    return nuxtApp.static.data[key]
+    return nuxtApp.payload.data[key] || nuxtApp.static.data[key] || undefined
   }
 }
 


### PR DESCRIPTION
Unless there is manual refresh or refresh() has been explicitly called, return the cache if available. use payload data first, fallback to static if that is not available. Returns undefined when no cache has been found, triggering a fetch. Previous default function only returned cache when hydrating, which is not desired in most scenarios, therefore the default is changed.

### 🔗 Linked issue

Resolves #31816 and #32658

### 📚 Description

When using `useAsyncData` our expectation is that for the same id cached data is returned, as long as there is no manual refresh of the page or `refresh()` is used. Currently this does not work as expected, a new request is made every time. This is due to the implementation of the default getCachedData function:

```js
const getDefaultCachedData = (key, nuxtApp, ctx) => {
  if (nuxtApp.isHydrating) {
    return nuxtApp.payload.data[key];
  }
  if (ctx.cause !== "refresh:manual" && ctx.cause !== "refresh:hook") {
    return nuxtApp.static.data[key];
  }
};
```

This function only returns cached data when `isHydrating` is `true`. As this is only true on the initial page load, you only get cached data when the page loads initially. However, our expectation would be to also get cached data beyond the point of hydration, in fact caching is typically a lot more important beyond that point in a SPA with many components sharing data. For example when using forms on tabs, the data is now fetched on every tab change, which is certainly not desired.