### PR TITLE
fix(nuxt): use joinURL when remote island is provided

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-island.ts
+++ b/packages/nuxt/src/app/components/nuxt-island.ts
@@ -195,8 +195,7 @@ export default defineComponent({
 
       if (!force && nuxtApp.payload.data[key]?.html) { return nuxtApp.payload.data[key] }
 
-      const url = remoteComponentIslands && props.source ? new URL(`/__nuxt_island/${key}.json`, props.source).href : `/__nuxt_island/${key}.json`
-
+      const url = remoteComponentIslands && props.source ? joinURL(props.source, `/__nuxt_island/${key}.json`) : `/__nuxt_island/${key}.json`
       if (import.meta.server && import.meta.prerender) {
         // Hint to Nitro to prerender the island component
         nuxtApp.runWithContext(() => prerenderRoutes(url))

--- a/test/nuxt/nuxt-island.test.ts
+++ b/test/nuxt/nuxt-island.test.ts
@@ -94,6 +94,34 @@ describe('runtime server component', () => {
     await server.close()
   })
 
+    it('expect remote island with baseURL to be rendered', async () => {
+    const port = await getPort({ host: 'localhost', public: false, random: true })
+    let url: string
+    const server = serve({
+      port,
+     fetch (r) {
+        url = r.url
+        return new Response(JSON.stringify({
+          html: '<div>hello world from another server</div>',
+          state: {},
+          head: { link: [], style: [] },
+        }), { headers: { 'Content-Type': 'application/json' } })
+      },
+    })
+
+    await server.ready()
+
+    const wrapper = await mountSuspended(NuxtIsland, {
+      props: {
+        name: 'Test',
+        source: `http://localhost:${port}/app`,
+      },
+    })
+
+    expect(wrapper.html()).toMatchInlineSnapshot('"<div>hello world from another server</div>"')
+    expect(url!.startsWith(`http://localhost:${port}/app/__nuxt_island`)).toBe(true)
+    await server.close()
+  })
   it('force refresh', async () => {
     let count = 0
     const stubFetch = vi.fn(() => {
@@ -210,9 +238,8 @@ describe('client components', () => {
     })
 
     expect(fetch).toHaveBeenCalledOnce()
-
-    expect(wrapper.html()).toMatchInlineSnapshot(`
-      "<div data-island-uid="5">hello<div data-island-uid="5" data-island-component="Client-12345">
+    expect(removeDataIslandUid(wrapper.html())).toMatchInlineSnapshot(`
+      "<div>hello<div data-island-component="Client-12345">
           <div>client component</div>
         </div>
       </div>
@@ -237,12 +264,12 @@ describe('client components', () => {
 
     await wrapper.vm.$.exposed!.refresh()
     await nextTick()
-    expect(wrapper.html()).toMatchInlineSnapshot(`
-      "<div data-island-uid="5">hello<div>
-          <div>fallback</div>
-        </div>
-      </div>"
-    `)
+    expect(removeDataIslandUid(wrapper.html())).toMatchInlineSnapshot(`
+        "<div>hello<div>
+            <div>fallback</div>
+          </div>
+        </div>"
+      `)
 
     vi.mocked(fetch).mockReset()
     expectNoConsoleIssue()
@@ -330,10 +357,10 @@ describe('client components', () => {
       attachTo: 'body',
     })
     expect(fetch).toHaveBeenCalledOnce()
-    expect(wrapper.html()).toMatchInlineSnapshot(`
-      "<div data-island-uid="7">hello<div data-island-uid="7" data-island-component="ClientWithSlot-12345">
+    expect(removeDataIslandUid(wrapper.html())).toMatchInlineSnapshot(`
+      "<div>hello<div data-island-component="ClientWithSlot-12345">
           <div class="client-component">
-            <div style="display: contents" data-island-uid="" data-island-slot="default">
+            <div style="display: contents" data-island-slot="default">
               <div>slot in client component</div>
             </div>
           </div>
@@ -346,3 +373,8 @@ describe('client components', () => {
     expectNoConsoleIssue()
   })
 })
+
+
+function removeDataIslandUid (html: string) {
+  return html.replaceAll(/ data-island-uid="[^"]*"/g, '')
+}

--- a/test/nuxt/nuxt-island.test.ts
+++ b/test/nuxt/nuxt-island.test.ts
@@ -94,12 +94,12 @@ describe('runtime server component', () => {
     await server.close()
   })
 
-    it('expect remote island with baseURL to be rendered', async () => {
+  it('expect remote island with baseURL to be rendered', async () => {
     const port = await getPort({ host: 'localhost', public: false, random: true })
     let url: string
     const server = serve({
       port,
-     fetch (r) {
+      fetch (r) {
         url = r.url
         return new Response(JSON.stringify({
           html: '<div>hello world from another server</div>',
@@ -373,7 +373,6 @@ describe('client components', () => {
     expectNoConsoleIssue()
   })
 })
-
 
 function removeDataIslandUid (html: string) {
   return html.replaceAll(/ data-island-uid="[^"]*"/g, '')


### PR DESCRIPTION
### 🔗 Linked issue

fix [#32637](https://github.com/nuxt/nuxt/issues/32637)
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This PR makes nuxtisland use joinURL instead of cosntructing the URL with new URL which removes any base path from the provided remote source 

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
