### PR TITLE
fix: make devServer.url dynamic based on port and host configuration

### DIFF
--- a/packages/schema/src/config/dev.ts
+++ b/packages/schema/src/config/dev.ts
@@ -6,7 +6,19 @@ export default defineResolvers({
     https: false,
     port: Number(process.env.NUXT_PORT || process.env.NITRO_PORT || process.env.PORT || 3000),
     host: process.env.NUXT_HOST || process.env.NITRO_HOST || process.env.HOST || undefined,
-    url: 'http://localhost:3000',
+    url: {
+      $resolve: async (val, get) => {
+        if (typeof val === 'string') {
+          return val
+        }
+        const port = await get('devServer.port')
+        const host = await get('devServer.host')
+        const https = await get('devServer.https')
+        const protocol = https ? 'https' : 'http'
+        const hostname = host || 'localhost'
+        return `${protocol}://${hostname}:${port}`
+      },
+    },
     loadingTemplate,
     cors: {
       origin: [/^https?:\/\/(?:(?:[^:]+\.)?localhost|127\.0\.0\.1|\[::1\])(?::\d+)?$/],


### PR DESCRIPTION
- Replace hardcoded 'http://localhost:3000' with dynamic URL generation
- Use  to access devServer.port, devServer.host, and devServer.https
- Support custom ports, hosts, and HTTPS configuration
- Maintain backward compatibility when url is explicitly set
- Fix getClientManifest to use correct port in development mode

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
