### PR TITLE
chore: update reproduction help text links

### DIFF
--- a/.github/reproduire/needs-reproduction.md
+++ b/.github/reproduire/needs-reproduction.md
@@ -23,8 +23,7 @@ Please use a template below to create a minimal reproduction
 
 A public GitHub repository is also perfect. 👌
 
-> [!WARNING]
-> Please ensure that the reproduction is as **minimal** as possible. See more details [in our guide](https://nuxt.com/docs/community/reporting-bugs/#create-a-minimal-reproduction).
+Please ensure that the reproduction is as **minimal** as possible. See more details [in our guide](https://nuxt.com/docs/community/reporting-bugs/#create-a-minimal-reproduction).
 
 You might also find these other articles interesting and/or helpful:
 

--- a/.github/reproduire/needs-reproduction.md
+++ b/.github/reproduire/needs-reproduction.md
@@ -16,6 +16,7 @@ If `needs reproduction` labeled issues don't receive any substantial activity (e
 ### How can I create a reproduction?
 
 Please use a template below to create a minimal reproduction
+
 [![Open v4 in Stackblitz](https://img.shields.io/badge/Stackblitz-Nuxt%204-blue?style=flat-square&logo=stackblitz)](https://stackblitz.com/github/nuxt/starter/tree/v4-stackblitz) [![Open v3 in Stackblitz](https://img.shields.io/badge/Stackblitz-Nuxt%203-blue?style=flat-square&logo=stackblitz)](https://stackblitz.com/github/nuxt/starter/tree/v3-stackblitz)
 [![Open v4 in CodeSandbox](https://img.shields.io/badge/CodeSandbox-Nuxt%204-blue?style=flat-square&logo=codesandbox)](https://codesandbox.io/s/github/nuxt/starter/tree/v4) [![Open v3 in CodeSandbox](https://img.shields.io/badge/CodeSandbox-Nuxt%203-blue?style=flat-square&logo=codesandbox)](https://codesandbox.io/s/github/nuxt/starter/tree/v3)
 

--- a/.github/reproduire/needs-reproduction.md
+++ b/.github/reproduire/needs-reproduction.md
@@ -23,7 +23,8 @@ Please use a template below to create a minimal reproduction
 
 A public GitHub repository is also perfect. 👌
 
-Please ensure that the reproduction is as **minimal** as possible. See more details [in our guide](https://nuxt.com/docs/community/reporting-bugs/#create-a-minimal-reproduction).
+> [!WARNING]
+> Please ensure that the reproduction is as **minimal** as possible. See more details [in our guide](https://nuxt.com/docs/community/reporting-bugs/#create-a-minimal-reproduction).
 
 You might also find these other articles interesting and/or helpful:
 

--- a/.github/reproduire/needs-reproduction.md
+++ b/.github/reproduire/needs-reproduction.md
@@ -15,10 +15,9 @@ If `needs reproduction` labeled issues don't receive any substantial activity (e
 
 ### How can I create a reproduction?
 
-We have a couple of templates for starting with a minimal reproduction:
-
-👉 https://stackblitz.com/github/nuxt/starter/tree/v3-stackblitz
-👉 https://codesandbox.io/s/github/nuxt/starter/v3-codesandbox
+Please use a template below to create a minimal reproduction
+[![Open v4 in Stackblitz](https://img.shields.io/badge/Stackblitz-Nuxt%204-blue?style=flat-square&logo=stackblitz)](https://stackblitz.com/github/nuxt/starter/tree/v4-stackblitz) [![Open v3 in Stackblitz](https://img.shields.io/badge/Stackblitz-Nuxt%203-blue?style=flat-square&logo=stackblitz)](https://stackblitz.com/github/nuxt/starter/tree/v3-stackblitz)
+[![Open v4 in CodeSandbox](https://img.shields.io/badge/CodeSandbox-Nuxt%204-blue?style=flat-square&logo=codesandbox)](https://codesandbox.io/s/github/nuxt/starter/tree/v4) [![Open v3 in CodeSandbox](https://img.shields.io/badge/CodeSandbox-Nuxt%203-blue?style=flat-square&logo=codesandbox)](https://codesandbox.io/s/github/nuxt/starter/tree/v3)
 
 A public GitHub repository is also perfect. 👌
 

--- a/.github/reproduire/needs-reproduction.md
+++ b/.github/reproduire/needs-reproduction.md
@@ -18,6 +18,7 @@ If `needs reproduction` labeled issues don't receive any substantial activity (e
 Please use a template below to create a minimal reproduction
 
 [![Open v4 in Stackblitz](https://img.shields.io/badge/Stackblitz-Nuxt%204-blue?style=flat-square&logo=stackblitz)](https://stackblitz.com/github/nuxt/starter/tree/v4-stackblitz) [![Open v3 in Stackblitz](https://img.shields.io/badge/Stackblitz-Nuxt%203-blue?style=flat-square&logo=stackblitz)](https://stackblitz.com/github/nuxt/starter/tree/v3-stackblitz)
+
 [![Open v4 in CodeSandbox](https://img.shields.io/badge/CodeSandbox-Nuxt%204-blue?style=flat-square&logo=codesandbox)](https://codesandbox.io/s/github/nuxt/starter/tree/v4) [![Open v3 in CodeSandbox](https://img.shields.io/badge/CodeSandbox-Nuxt%203-blue?style=flat-square&logo=codesandbox)](https://codesandbox.io/s/github/nuxt/starter/tree/v3)
 
 A public GitHub repository is also perfect. 👌


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This PR updates the urls for the "need reproduction" text.

Preview: https://github.com/OrbisK/nuxt/blob/reproduction-links/.github/reproduire/needs-reproduction.md

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
