### PR TITLE
fix(nuxt): throwing undefined `error` variable

### DIFF
--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -445,7 +445,7 @@ export async function applyPlugins (nuxtApp: NuxtApp, plugins: Array<Plugin & Ob
       }).catch((e) => {
         // short circuit if we are not rendering `error.vue`
         if (!plugin.parallel && !nuxtApp.payload.error) {
-          throw error
+          throw e
         }
         error ||= e
       })


### PR DESCRIPTION
### 🔗 Linked issue
* #32744
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
The changes in #32744 now throws a variable before it is set to an error.
https://github.com/nuxt/nuxt/pull/32744#discussion_r2239418632


<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
