### PR TITLE
docs: mention `bun.lock` for lockfile

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,5 +6,5 @@ To report a vulnerability, please [privately report it via the Security tab](htt
 
 All security vulnerabilities will be promptly verified and addressed. 
 
-While the discovery of new vulnerabilities is rare, we also recommend always using the latest versions of Nuxt and other dependencies by maintaining lock files (`yarn.lock`, `package-lock.json` and `pnpm-lock.yaml`) in order to ensure your application remains as secure as possible.
+While the discovery of new vulnerabilities is rare, we also recommend always using the latest versions of Nuxt and other dependencies by maintaining lock files (`yarn.lock`, `package-lock.json`, `pnpm-lock.yaml`, and `bun.lock`) in order to ensure your application remains as secure as possible.
 


### PR DESCRIPTION
I think here we can also mention bun.lock for lockfile. bun generates default `bun.lock` from v1.2. 
https://bun.sh/docs/install/lockfile
