### PR TITLE
fix(nuxt): add warning for lazy-hydration missing prefix

### DIFF
--- a/packages/nuxt/src/components/plugins/lazy-hydration-transform.ts
+++ b/packages/nuxt/src/components/plugins/lazy-hydration-transform.ts
@@ -76,7 +76,8 @@ export const LazyHydrationTransformPlugin = (options: LoaderOptions) => createUn
             }
             if (!/^(?:Lazy|lazy-)/.test(node.name)) {
               if (node.name !== 'template') {
-                logger.warn(`Component ${node.name} has lazy-hydration props but it's not declared as lazy component. \nChange it to <Lazy${node.name} /> or remove the lazy-hydration props.`)
+                logger.warn(`Component <${node.name}> has lazy-hydration props but is not declared as a lazy component.\n` +
+                  `Rename it to <Lazy${node.name} /> or remove the lazy-hydration props to avoid unexpected behavior.`)
               }
               return
             }

--- a/packages/nuxt/src/components/plugins/lazy-hydration-transform.ts
+++ b/packages/nuxt/src/components/plugins/lazy-hydration-transform.ts
@@ -75,6 +75,9 @@ export const LazyHydrationTransformPlugin = (options: LoaderOptions) => createUn
               return
             }
             if (!/^(?:Lazy|lazy-)/.test(node.name)) {
+              if (node.name !== 'template') {
+                logger.warn(`Component ${node.name} has lazy-hydration props but it's not declared as lazy component. \nChange it to <Lazy${node.name} /> or remove the lazy-hydration props.`)
+              }
               return
             }
 

--- a/packages/nuxt/src/components/plugins/lazy-hydration-transform.ts
+++ b/packages/nuxt/src/components/plugins/lazy-hydration-transform.ts
@@ -8,6 +8,7 @@ import { ScopeTracker, parseAndWalk } from 'oxc-walker'
 import { isVue } from '../../core/utils'
 import { logger } from '../../utils'
 import type { Component, ComponentsOptions } from 'nuxt/schema'
+import { reverseResolveAlias } from 'pathe/utils'
 
 interface LoaderOptions {
   getComponents (): Component[]
@@ -78,9 +79,9 @@ export const LazyHydrationTransformPlugin = (options: LoaderOptions) => createUn
             }
             if (!/^(?:Lazy|lazy-)/.test(node.name)) {
               if (node.name !== 'template' && (nuxt?.options.dev || nuxt?.options.test)) {
-                logger.warn(`Component <${node.name}> has lazy-hydration props but is not declared as a lazy component.\n` +
-                  `Rename it to <Lazy${node.name} /> or remove the lazy-hydration props to avoid unexpected behavior. \n` +
-                  `Cause: ${id}`)
+                const relativePath = reverseResolveAlias(id, { ...nuxt?.options.alias || {}, ...strippedAtAliases }).pop() || id
+                logger.warn(`Component \`<${node.name}>\` (used in \`${relativePath}\`) has lazy-hydration props but is not declared as a lazy component.\n` +
+                  `Rename it to \`<Lazy${node.name} />\` or remove the lazy-hydration props to avoid unexpected behavior.`)
               }
               return
             }
@@ -137,3 +138,8 @@ export const LazyHydrationTransformPlugin = (options: LoaderOptions) => createUn
     },
   }
 })
+
+const strippedAtAliases = {
+  '@': '',
+  '@@': '',
+}

--- a/packages/nuxt/src/components/plugins/lazy-hydration-transform.ts
+++ b/packages/nuxt/src/components/plugins/lazy-hydration-transform.ts
@@ -79,7 +79,8 @@ export const LazyHydrationTransformPlugin = (options: LoaderOptions) => createUn
             if (!/^(?:Lazy|lazy-)/.test(node.name)) {
               if (node.name !== 'template' && (nuxt?.options.dev || nuxt?.options.test)) {
                 logger.warn(`Component <${node.name}> has lazy-hydration props but is not declared as a lazy component.\n` +
-                  `Rename it to <Lazy${node.name} /> or remove the lazy-hydration props to avoid unexpected behavior.`)
+                  `Rename it to <Lazy${node.name} /> or remove the lazy-hydration props to avoid unexpected behavior. \n` +
+                  `Cause: ${id}`)
               }
               return
             }

--- a/packages/nuxt/src/components/plugins/lazy-hydration-transform.ts
+++ b/packages/nuxt/src/components/plugins/lazy-hydration-transform.ts
@@ -2,6 +2,7 @@ import { createUnplugin } from 'unplugin'
 import MagicString from 'magic-string'
 import { camelCase, pascalCase } from 'scule'
 
+import { tryUseNuxt } from '@nuxt/kit'
 import { parse, walk } from 'ultrahtml'
 import { ScopeTracker, parseAndWalk } from 'oxc-walker'
 import { isVue } from '../../core/utils'
@@ -31,6 +32,7 @@ const LAZY_HYDRATION_PROPS_RE = /\b(?:hydrate-on-idle|hydrateOnIdle|hydrate-on-v
 export const LazyHydrationTransformPlugin = (options: LoaderOptions) => createUnplugin(() => {
   const exclude = options.transform?.exclude || []
   const include = options.transform?.include || []
+  const nuxt = tryUseNuxt()
 
   return {
     name: 'nuxt:components-loader-pre',
@@ -75,7 +77,7 @@ export const LazyHydrationTransformPlugin = (options: LoaderOptions) => createUn
               return
             }
             if (!/^(?:Lazy|lazy-)/.test(node.name)) {
-              if (node.name !== 'template') {
+              if (node.name !== 'template' && (nuxt?.options.dev || nuxt?.options.test)) {
                 logger.warn(`Component <${node.name}> has lazy-hydration props but is not declared as a lazy component.\n` +
                   `Rename it to <Lazy${node.name} /> or remove the lazy-hydration props to avoid unexpected behavior.`)
               }


### PR DESCRIPTION
### 🔗 Linked issue

resolves #32736
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Add a missing warning for components that use the `lazy-hydration` props but aren't prefixed with `<Lazy`. This helps catch cases where developers intend to lazy-load a component but forget the naming convention, potentially leading to unexpected behavior.

Example:
```vue
<template>
  <SomeComp hydrate-never/>
</template>
```

Warning:
<img width="695" height="74" alt="obraz" src="https://github.com/user-attachments/assets/9b6cc746-9dd8-4b7e-9dec-46388a96e17d" />



<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
