### PR TITLE
fix(vite): include tsconfig references during `typeCheck`

### DIFF
--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -188,6 +188,7 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
     addVitePlugin(checker({
       vueTsc: {
         tsconfigPath: await resolveTSConfig(nuxt.options.rootDir),
+        buildMode: true,
       },
     }), { server: nuxt.options.ssr })
   }


### PR DESCRIPTION
### 🔗 Linked issue
* #32823
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Resolves #32823

@danielroe 
The type checking is not using the `-b` argument, so no type errors are reported in projects using the new tsconfig structure. 

We should probably check if the project is using tsconfig references and enable `buildMode` based on that.

This seems to work, but it seems to report type errors in server routes twice 🤔, it also adds `tsconfig.*.tsbuildinfo` files in `.nuxt` for each tsconfig file it contains which may be undesirable.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
