### PR TITLE
docs: add a section about augmenting types with TS project references

### DIFF
--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -1071,15 +1071,15 @@ However, to take advantage of improved type checking, you can opt in to the new 
    - "typecheck": "nuxt prepare && vue-tsc --noEmit"
    + "typecheck": "nuxt prepare && vue-tsc -b --noEmit"
    ```
-   
-4. **Move all type augmentations into their appropriate context**:
-   - If you are augmenting types for the app context, move the files to the `app/` directory.
-   - If you are augmenting types for the server context, move the files to the `server/` directory.
-   - If you are augmenting types that are **shared between the app and server**, move the files to the `shared/` directory.
 
-::warning
-Augmenting types from outside the `app/`, `server/`, or `shared/` directories will not work with the new project references setup.
-::
+4. **Move all type augmentations into their appropriate context**:
+   * If you are augmenting types for the app context, move the files to the `app/` directory.
+   * If you are augmenting types for the server context, move the files to the `server/` directory.
+   * If you are augmenting types that are **shared between the app and server**, move the files to the `shared/` directory.
+
+    ::warning
+    Augmenting types from outside the `app/`, `server/`, or `shared/` directories will not work with the new project references setup.
+    ::
 
 5. **Configure Node.js TypeScript options** if needed:
    <!-- @case-police-ignore tsConfig -->

--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -1071,8 +1071,17 @@ However, to take advantage of improved type checking, you can opt in to the new 
    - "typecheck": "nuxt prepare && vue-tsc --noEmit"
    + "typecheck": "nuxt prepare && vue-tsc -b --noEmit"
    ```
+   
+4. **Move all type augmentations into their appropriate context**:
+   - If you are augmenting types for the app context, move the files to the `app/` directory.
+   - If you are augmenting types for the server context, move the files to the `server/` directory.
+   - If you are augmenting types that are **shared between the app and server**, move the files to the `shared/` directory.
 
-4. **Configure Node.js TypeScript options** if needed:
+::warning
+Augmenting types from outside the `app/`, `server/`, or `shared/` directories will not work with the new project references setup.
+::
+
+5. **Configure Node.js TypeScript options** if needed:
    <!-- @case-police-ignore tsConfig -->
 
    ```ts
@@ -1094,7 +1103,7 @@ However, to take advantage of improved type checking, you can opt in to the new 
    })
    ```
 
-5. **Update any CI/build scripts** that run TypeScript checking to ensure they use the new project references approach.
+6. **Update any CI/build scripts** that run TypeScript checking to ensure they use the new project references approach.
 
 The new configuration provides better type safety and IntelliSense for projects that opt in, while maintaining full backward compatibility for existing setups.
 

--- a/docs/2.guide/1.concepts/8.typescript.md
+++ b/docs/2.guide/1.concepts/8.typescript.md
@@ -108,6 +108,22 @@ Each of these files is configured to reference the appropriate dependencies and 
 The project reference setup is handled automatically by Nuxt. You typically don't need to modify these configurations manually, but understanding how they work can help you troubleshoot type-checking issues.
 ::
 
+### Augmenting Types with Project References
+
+Since the project is divided into **multiple type contexts**, it's important to **augment types within the correct context** to ensure they are properly recognized.
+
+For example, if you want to augment types for the `app` context, the augmentation file should be placed in the `app/` directory.
+
+Similarly:
+- For the `server` context, place the augmentation file in the `server/` directory.
+- For types that are **shared between the app and server**, place the file in the `shared/` directory.
+
+::warning
+Augmenting types outside of these directories will not be recognized by TypeScript.
+::
+
+
+
 ## Strict Checks
 
 TypeScript comes with certain checks to give you more safety and analysis of your program.

--- a/docs/2.guide/1.concepts/8.typescript.md
+++ b/docs/2.guide/1.concepts/8.typescript.md
@@ -122,8 +122,6 @@ Similarly:
 Augmenting types outside of these directories will not be recognized by TypeScript.
 ::
 
-
-
 ## Strict Checks
 
 TypeScript comes with certain checks to give you more safety and analysis of your program.


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/32727

### 📚 Description
This adds a section about needing to augment types in the correct context with the new Project Referneces TS setup and also mentions it in the upgrade guide to Nuxt 4.

----
I wasn't able to able to get augmentations recognized outside the default contexts (i.e. in `/types/` which would be in the same directory as `nuxt.config.ts`) by doing this:
```ts
typescript: {
    nodeTsConfig: {
        include: [
            resolve('./types/**/*.ts'),
        ],
    },
},
```
So I didn't mention it yet.

It did pick up the augmentations when I added the directory to `typescript.tsConfig.include` - but if I'm not mistaken, that only includes it in the `app` context. It also didn't work when I tried defining it in `typescript.sharedTsConfig.include`.
Is there something I'm missing? https://stackblitz.com/edit/github-1zim1ccd?file=project%2Fnuxt.config.ts


<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
