### PR TITLE
perf(kit): get absolute path from `tinyglobby` in `resolveFiles`

### DIFF
--- a/packages/kit/src/resolve.ts
+++ b/packages/kit/src/resolve.ts
@@ -244,8 +244,7 @@ function existsInVFS (path: string, nuxt = tryUseNuxt()) {
 
 export async function resolveFiles (path: string, pattern: string | string[], opts: { followSymbolicLinks?: boolean } = {}) {
   const files: string[] = []
-  for (const file of await glob(pattern, { cwd: path, followSymbolicLinks: opts.followSymbolicLinks ?? true })) {
-    const p = resolve(path, file)
+  for (const p of await glob(pattern, { cwd: path, followSymbolicLinks: opts.followSymbolicLinks ?? true, absolute: true })) {
     if (!isIgnored(p)) {
       files.push(p)
     }


### PR DESCRIPTION
### 📚 Description

This should bring a small performance improvement to the `resolveFiles` funcion by getting the absolute path directly from `tinyglobby` instead of performing additional resolution.

From my simple local testing on MacOS (M2 Max) with 500 files in a single directory, it has reduced the execution time from ~4.35ms to ~3.2ms.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
