### PR TITLE
fix(kit,nuxt): use `reverseResolveAlias` for better errors

### DIFF
--- a/packages/kit/src/layout.ts
+++ b/packages/kit/src/layout.ts
@@ -1,9 +1,10 @@
 import type { NuxtTemplate } from '@nuxt/schema'
-import { join, parse, relative } from 'pathe'
+import { join, parse } from 'pathe'
 import { kebabCase } from 'scule'
 import { useNuxt } from './context'
 import { logger } from './logger'
 import { addTemplate } from './template'
+import { reverseResolveAlias } from 'pathe/utils'
 
 const LAYOUT_RE = /["']/g
 export function addLayout (template: NuxtTemplate | string, name?: string) {
@@ -14,9 +15,9 @@ export function addLayout (template: NuxtTemplate | string, name?: string) {
   // Nuxt 3 adds layouts on app
   nuxt.hook('app:templates', (app) => {
     if (layoutName in app.layouts) {
-      const relativePath = relative(nuxt.options.srcDir, app.layouts[layoutName]!.file)
+      const relativePath = reverseResolveAlias(app.layouts[layoutName]!.file, { ...nuxt?.options.alias || {}, ...strippedAtAliases }).pop() || app.layouts[layoutName]!.file
       return logger.warn(
-        `Not overriding \`${layoutName}\` (provided by \`~/${relativePath}\`) with \`${src || filename}\`.`,
+        `Not overriding \`${layoutName}\` (provided by \`${relativePath}\`) with \`${src || filename}\`.`,
       )
     }
     app.layouts[layoutName] = {
@@ -24,4 +25,9 @@ export function addLayout (template: NuxtTemplate | string, name?: string) {
       name: layoutName,
     }
   })
+}
+
+const strippedAtAliases = {
+  '@': '',
+  '@@': '',
 }

--- a/packages/nuxt/src/components/plugins/lazy-hydration-transform.ts
+++ b/packages/nuxt/src/components/plugins/lazy-hydration-transform.ts
@@ -6,9 +6,8 @@ import { tryUseNuxt } from '@nuxt/kit'
 import { parse, walk } from 'ultrahtml'
 import { ScopeTracker, parseAndWalk } from 'oxc-walker'
 import { isVue } from '../../core/utils'
-import { logger } from '../../utils'
+import { logger, resolveToAlias } from '../../utils'
 import type { Component, ComponentsOptions } from 'nuxt/schema'
-import { reverseResolveAlias } from 'pathe/utils'
 
 interface LoaderOptions {
   getComponents (): Component[]
@@ -104,7 +103,7 @@ export const LazyHydrationTransformPlugin = (options: LoaderOptions) => createUn
 
             if (strategy && !/^(?:Lazy|lazy-)/.test(node.name)) {
               if (node.name !== 'template' && (nuxt?.options.dev || nuxt?.options.test)) {
-                const relativePath = reverseResolveAlias(id, { ...nuxt?.options.alias || {}, ...strippedAtAliases }).pop() || id
+                const relativePath = resolveToAlias(id, nuxt)
                 logger.warn(`Component \`<${node.name}>\` (used in \`${relativePath}\`) has lazy-hydration props but is not declared as a lazy component.\n` +
                   `Rename it to \`<Lazy${pascalCase(node.name)} />\` or remove the lazy-hydration props to avoid unexpected behavior.`)
               }
@@ -139,8 +138,3 @@ export const LazyHydrationTransformPlugin = (options: LoaderOptions) => createUn
     },
   }
 })
-
-const strippedAtAliases = {
-  '@': '',
-  '@@': '',
-}

--- a/packages/nuxt/src/components/plugins/loader.ts
+++ b/packages/nuxt/src/components/plugins/loader.ts
@@ -7,7 +7,7 @@ import { relative } from 'pathe'
 import { tryUseNuxt } from '@nuxt/kit'
 import { QUOTE_RE, SX_RE, isVue } from '../../core/utils'
 import { installNuxtModule } from '../../core/features'
-import { logger } from '../../utils'
+import { logger, resolveToAlias } from '../../utils'
 import type { Component, ComponentsOptions } from 'nuxt/schema'
 
 interface LoaderOptions {
@@ -59,8 +59,7 @@ export const LoaderPlugin = (options: LoaderOptions) => createUnplugin(() => {
           const internalInstall = ((component as any)._internal_install) as string
           if (internalInstall && nuxt?.options.test === false) {
             if (!nuxt.options.dev) {
-              const relativePath = relative(nuxt.options.rootDir, id)
-              throw new Error(`[nuxt] \`~/${relativePath}\` is using \`${component.pascalName}\` which requires \`${internalInstall}\``)
+              throw new Error(`[nuxt] \`${resolveToAlias(id, nuxt)}\` is using \`${component.pascalName}\` which requires \`${internalInstall}\``)
             }
             installNuxtModule(internalInstall)
           }

--- a/packages/nuxt/src/components/scan.ts
+++ b/packages/nuxt/src/components/scan.ts
@@ -48,9 +48,9 @@ export async function scanComponents (dirs: ComponentsDir[], srcDir: string): Pr
         for (const sibling of siblings) {
           if (sibling.toLowerCase() === directoryLowerCase) {
             const nuxt = useNuxt()
-            const original = relative(nuxt.options.srcDir, dir.path)
-            const corrected = relative(nuxt.options.srcDir, join(dirname(dir.path), sibling))
-            logger.warn(`Components not scanned from \`~/${corrected}\`. Did you mean to name the directory \`~/${original}\` instead?`)
+            const original = resolveToAlias(dir.path, nuxt)
+            const corrected = resolveToAlias(join(dirname(dir.path), sibling), nuxt)
+            logger.warn(`Components not scanned from \`${corrected}\`. Did you mean to name the directory \`${original}\` instead?`)
             break
           }
         }

--- a/packages/nuxt/src/components/scan.ts
+++ b/packages/nuxt/src/components/scan.ts
@@ -6,7 +6,7 @@ import { isIgnored, useNuxt } from '@nuxt/kit'
 import { withTrailingSlash } from 'ufo'
 
 import { QUOTE_RE, resolveComponentNameSegments } from '../core/utils'
-import { logger } from '../utils'
+import { logger, resolveToAlias } from '../utils'
 import type { Component, ComponentsDir } from 'nuxt/schema'
 
 const ISLAND_RE = /\.island(?:\.global)?$/
@@ -141,7 +141,7 @@ export async function scanComponents (dirs: ComponentsDir[], srcDir: string): Pr
 
       // Ignore files like `~/components/index.vue` which end up not having a name at all
       if (!pascalName) {
-        logger.warn(`Component did not resolve to a file name in \`~/${relative(srcDir, filePath)}\`.`)
+        logger.warn(`Component did not resolve to a file name in \`${resolveToAlias(filePath)}\`.`)
         continue
       }
 

--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -5,7 +5,7 @@ import { findPath, normalizePlugin, normalizeTemplate, resolveFiles, resolvePath
 
 import type { PluginMeta } from 'nuxt/app'
 
-import { logger } from '../utils'
+import { logger, resolveToAlias } from '../utils'
 import * as defaultTemplates from './templates'
 import { getNameFromPath, hasSuffix, uniqueBy } from './utils'
 import { extractMetadata, orderMap } from './plugins/plugin-metadata'
@@ -165,7 +165,7 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
       const name = getNameFromPath(file, resolve(config.srcDir, layoutDir))
       if (!name) {
         // Ignore files like `~/layouts/index.vue` which end up not having a name at all
-        logger.warn(`No layout name could be resolved for \`~/${relative(nuxt.options.srcDir, file)}\`. Bear in mind that \`index\` is ignored for the purpose of creating a layout name.`)
+        logger.warn(`No layout name could be resolved for \`${resolveToAlias(file, nuxt)}\`. Bear in mind that \`index\` is ignored for the purpose of creating a layout name.`)
         continue
       }
       app.layouts[name] ||= { name, file }
@@ -184,7 +184,7 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
       const name = getNameFromPath(file)
       if (!name) {
         // Ignore files like `~/middleware/index.vue` which end up not having a name at all
-        logger.warn(`No middleware name could be resolved for \`~/${relative(nuxt.options.srcDir, file)}\`. Bear in mind that \`index\` is ignored for the purpose of creating a middleware name.`)
+        logger.warn(`No middleware name could be resolved for \`${resolveToAlias(file, nuxt)}\`. Bear in mind that \`index\` is ignored for the purpose of creating a middleware name.`)
         continue
       }
       app.middleware.push({ name, path: file, global: hasSuffix(file, '.global') })

--- a/packages/nuxt/src/imports/module.ts
+++ b/packages/nuxt/src/imports/module.ts
@@ -6,7 +6,7 @@ import { createUnimport, scanDirExports, toExports } from 'unimport'
 import escapeRE from 'escape-string-regexp'
 
 import { lookupNodeModuleSubpath, parseNodeModulePath } from 'mlly'
-import { isDirectory, logger } from '../utils'
+import { isDirectory, logger, resolveToAlias } from '../utils'
 import { TransformPlugin } from './transform'
 import { appCompatPresets, defaultPresets } from './presets'
 import type { ImportPresetWithDeprecation, ImportsOptions, ResolvedNuxtTemplate } from 'nuxt/schema'
@@ -146,7 +146,7 @@ export default defineNuxtModule<Partial<ImportsOptions>>({
           if (!defaultImportSources.has(i.from)) {
             const value = i.as || i.name
             if (defaultImports.has(value) && (!i.priority || i.priority >= 0 /* default priority */)) {
-              const relativePath = isAbsolute(i.from) ? `~/${relative(nuxt.options.srcDir, i.from)}` : i.from
+              const relativePath = isAbsolute(i.from) ? `${resolveToAlias(i.from, nuxt)}` : i.from
               logger.error(`\`${value}\` is an auto-imported function that is in use by Nuxt. Overriding it will likely cause issues. Please consider renaming \`${value}\` in \`${relativePath}\`.`)
             }
           }

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -13,7 +13,7 @@ import type { NitroRouteConfig } from 'nitropack/types'
 import { defu } from 'defu'
 import { distDir } from '../dirs'
 import { resolveTypePath } from '../core/utils/types'
-import { logger } from '../utils'
+import { logger, resolveToAlias } from '../utils'
 import { defaultExtractionKeys, normalizeRoutes, resolvePagesRoutes, resolveRoutePaths, toRou3Patterns } from './utils'
 import { extractRouteRules, getMappedPages } from './route-rules'
 import { PageMetaPlugin } from './plugins/page-meta'
@@ -422,11 +422,11 @@ export default defineNuxtModule({
         const glob = pageToGlobMap[path]
         const code = path in nuxt.vfs ? nuxt.vfs[path]! : await readFile(path!, 'utf-8')
         try {
-          const extractedRule = await extractRouteRules(code, path)
+          const extractedRule = extractRouteRules(code, path)
           if (extractedRule) {
             if (!glob) {
-              const relativePath = relative(nuxt.options.srcDir, path)
-              logger.error(`Could not set inline route rules in \`~/${relativePath}\` as it could not be mapped to a Nitro route.`)
+              const relativePath = resolveToAlias(path, nuxt)
+              logger.error(`Could not set inline route rules in \`${relativePath}\` as it could not be mapped to a Nitro route.`)
               return
             }
 
@@ -436,8 +436,7 @@ export default defineNuxtModule({
           }
         } catch (e: any) {
           if (e.toString().includes('Error parsing route rules')) {
-            const relativePath = relative(nuxt.options.srcDir, path)
-            logger.error(`Error parsing route rules within \`~/${relativePath}\`. They should be JSON-serializable.`)
+            logger.error(`Error parsing route rules within \`${resolveToAlias(path, nuxt)}\`. They should be JSON-serializable.`)
           } else {
             logger.error(e)
           }

--- a/packages/nuxt/src/utils.ts
+++ b/packages/nuxt/src/utils.ts
@@ -1,5 +1,6 @@
 import { promises as fsp } from 'node:fs'
-import { useLogger } from '@nuxt/kit'
+import { tryUseNuxt, useLogger } from '@nuxt/kit'
+import { reverseResolveAlias } from 'pathe/utils'
 
 /** @since 3.9.0 */
 export function toArray<T> (value: T | T[]): T[] {
@@ -11,3 +12,12 @@ export async function isDirectory (path: string) {
 }
 
 export const logger = useLogger('nuxt')
+
+export function resolveToAlias (path: string, nuxt = tryUseNuxt()) {
+  return reverseResolveAlias(path, { ...nuxt?.options.alias || {}, ...strippedAtAliases }).pop() || path
+}
+
+const strippedAtAliases = {
+  '@': '',
+  '@@': '',
+}


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this PR updates a number of places where we hard-code `~/${somePath}` for more consistency and fixes bugs resolving paths that have a more precise path (such as in layers)

