### PR TITLE
docs: improve explanation of global middleware

### DIFF
--- a/docs/2.guide/1.concepts/10.nuxt-lifecycle.md
+++ b/docs/2.guide/1.concepts/10.nuxt-lifecycle.md
@@ -68,7 +68,7 @@ In Nuxt, there are three types of middleware:
 - **Named route middleware**
 - **Anonymous (or inline) route middleware**
 
-Nuxt automatically executes global middleware for first-time entry(initial page load) to the application and every time before route navigation. Named and anonymous middleware are executed only on the routes specified in the middleware property of the page(route) meta defined in the corresponding page components.
+Nuxt executes all global middleware on the initial page load (both on server and client) and then again before any client-side navigation. Named and anonymous middleware are executed only on the routes specified in the middleware property of the page(route) meta defined in the corresponding page components.
 
 For details about each type and examples, see the [Middleware documentation](/docs/guide/directory-structure/middleware).
 

--- a/docs/2.guide/1.concepts/10.nuxt-lifecycle.md
+++ b/docs/2.guide/1.concepts/10.nuxt-lifecycle.md
@@ -68,7 +68,7 @@ In Nuxt, there are three types of middleware:
 - **Named route middleware**
 - **Anonymous (or inline) route middleware**
 
-Nuxt automatically executes global middleware for first time enter to the application and every time before route navigation. Named and anonymous middleware are executed only on the routes specified in the middleware property of the page(route) meta defined in the corresponding page components.
+Nuxt automatically executes global middleware for first-time entry(initial page load) to the application and every time before route navigation. Named and anonymous middleware are executed only on the routes specified in the middleware property of the page(route) meta defined in the corresponding page components.
 
 For details about each type and examples, see the [Middleware documentation](/docs/guide/directory-structure/middleware).
 


### PR DESCRIPTION
…eware is executed automatically on initial page load

This is an improvement to the statement: "Nuxt automatically executes global middleware for first time enter to the application" which is not very clear or grammatically correct.

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
