### PR TITLE
fix(kit): resolve to directories in `resolvePath` too and normalize file extensions

### DIFF
--- a/packages/kit/src/utils.ts
+++ b/packages/kit/src/utils.ts
@@ -21,3 +21,5 @@ export function filterInPlace<T> (array: T[], predicate: (item: T, index: number
 export const MODE_RE = /\.(server|client)(\.\w+)*$/
 
 export const distDirURL = new URL('.', import.meta.url)
+
+export type RequirePicked<T extends Record<string, any>, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>


### PR DESCRIPTION
### 📚 Description
This PR adds a way to specify the target path type (file or a directory) in `resolvePath` and ensures that the provided file extensions are normalized.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
