### PR TITLE
docs: update testing `setupTimeout` and add `teardownTimeout`

### DIFF
--- a/docs/1.getting-started/17.testing.md
+++ b/docs/1.getting-started/17.testing.md
@@ -604,7 +604,11 @@ Please use the options below for the `setup` method.
 
 - `setupTimeout`: The amount of time (in milliseconds) to allow for `setupTest` to complete its work (which could include building or generating files for a Nuxt application, depending on the options that are passed).
   - Type: `number`
-  - Default: `60000`
+  - Default: `120000` or `240000` on windows
+
+- `teardownTimeout`: The amount of time (in milliseconds) to allow tearing down the test environment, such as closing the browser.
+  - Type: `number`
+  - Default: `30000`
 
 #### Features
 


### PR DESCRIPTION
### 📚 Description

While looking at the `@nuxt/test-utils` package I noticed `setupTimeout` default value was updated and `teardownTimeout` was added in this commit https://github.com/nuxt/test-utils/commit/af2ddf29bebd47a251c4798cc0c7a7a4cb85eaf8

This PR updates `setupTimeout` default value and adds `teardownTimeout`

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
