### PR TITLE
fix(schema,vite): bump `requestTimeout` + allow configuration

### DIFF
--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1647,7 +1647,17 @@ export interface ConfigSchema {
    * @see [Vite configuration docs](https://vite.dev/config) for more information.
    * Please note that not all vite options are supported in Nuxt.
    */
-  vite: ViteConfig & { $client?: ViteConfig, $server?: ViteConfig }
+  vite: ViteConfig & { $client?: ViteConfig, $server?: ViteConfig } & {
+    viteNode?: {
+      maxRetryAttempts?: number
+      /** in milliseconds */
+      baseRetryDelay?: number
+      /** in milliseconds */
+      maxRetryDelay?: number
+      /** in milliseconds */
+      requestTimeout?: number
+    }
+  }
 
   webpack: {
   /**

--- a/packages/vite/src/runtime/vite-node-shared.mjs
+++ b/packages/vite/src/runtime/vite-node-shared.mjs
@@ -16,10 +16,10 @@ let requestIdCounter = 0
 let clientSocket
 /** @type {Promise<Socket> | undefined} */
 let currentConnectPromise
-const MAX_RETRY_ATTEMPTS = 5
-const BASE_RETRY_DELAY_MS = 100
-const MAX_RETRY_DELAY_MS = 2000
-const REQUEST_TIMEOUT_MS = 10000
+const MAX_RETRY_ATTEMPTS = viteNodeOptions.maxRetryAttempts ?? 5
+const BASE_RETRY_DELAY_MS = viteNodeOptions.baseRetryDelay ?? 100
+const MAX_RETRY_DELAY_MS = viteNodeOptions.maxRetryDelay ?? 2000
+const REQUEST_TIMEOUT_MS = viteNodeOptions.requestTimeout ?? 60000
 
 /**
  * Calculates exponential backoff delay with jitter.

--- a/packages/vite/src/vite-node.ts
+++ b/packages/vite/src/vite-node.ts
@@ -190,6 +190,10 @@ export function ViteNodePlugin (nuxt: Nuxt): VitePlugin {
           root: nuxt.options.srcDir,
           entryPath: resolveServerEntry(ssrServer.config),
           base: ssrServer.config.base || '/_nuxt/',
+          maxRetryAttempts: nuxt.options.vite.viteNode?.maxRetryAttempts,
+          baseRetryDelay: nuxt.options.vite.viteNode?.baseRetryDelay,
+          maxRetryDelay: nuxt.options.vite.viteNode?.maxRetryDelay,
+          requestTimeout: nuxt.options.vite.viteNode?.requestTimeout,
           // TODO: remove baseURL in future
           baseURL: nuxt.options.devServer.url,
         }
@@ -492,6 +496,10 @@ export type ViteNodeServerOptions = {
   root: string
   entryPath: string
   base: string
+  maxRetryAttempts?: number
+  baseRetryDelay?: number
+  maxRetryDelay?: number
+  requestTimeout?: number
 }
 
 export async function writeDevServer (nuxt: Nuxt) {


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/32789

### 📚 Description

this bumps the timeout for vite-node fetches to 1 minute and allows configuring this interval