### PR TITLE
perf(nuxt): stop watching app manifest once a change has been detected

### DIFF
--- a/packages/nuxt/src/app/plugins/check-outdated-build.client.ts
+++ b/packages/nuxt/src/app/plugins/check-outdated-build.client.ts
@@ -21,7 +21,7 @@ export default defineNuxtPlugin((nuxtApp) => {
       if (meta.id !== currentManifest.id) {
         // There is a newer build which we will let the user handle
         nuxtApp.hooks.callHook('app:manifest:update', meta)
-        if(timeout) { clearTimeout(timeout) }
+        if (timeout) { clearTimeout(timeout) }
       }
     } catch {
       // fail gracefully on network issue

--- a/packages/nuxt/src/app/plugins/check-outdated-build.client.ts
+++ b/packages/nuxt/src/app/plugins/check-outdated-build.client.ts
@@ -10,7 +10,7 @@ import { outdatedBuildInterval } from '#build/nuxt.config.mjs'
 export default defineNuxtPlugin((nuxtApp) => {
   if (import.meta.test) { return }
 
-  let timeout: NodeJS.Timeout
+  let timeout: ReturnType<typeof setTimeout>
 
   async function getLatestManifest () {
     const currentManifest = await getAppManifest()
@@ -21,6 +21,7 @@ export default defineNuxtPlugin((nuxtApp) => {
       if (meta.id !== currentManifest.id) {
         // There is a newer build which we will let the user handle
         nuxtApp.hooks.callHook('app:manifest:update', meta)
+        if(timeout) { clearTimeout(timeout) }
       }
     } catch {
       // fail gracefully on network issue


### PR DESCRIPTION


### 🔗 Linked issue


Fixes #32839

### 📚 Description

Once a change to the app manifest has been detected, the hook is called. It is then no longer necessary to keep polling the server for an updated app manifest. 

I have also updated the type of the timeout. As this is a client only plugin, it will be using [window.setTimeout](https://developer.mozilla.org/en-US/docs/Web/API/Window/setTimeout) not [NodeJS.setTimeout](https://nodejs.org/api/timers.html#settimeoutcallback-delay-args).

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
