### PR TITLE
docs: update package information in roadmap section

### DIFF
--- a/docs/5.community/6.roadmap.md
+++ b/docs/5.community/6.roadmap.md
@@ -59,17 +59,17 @@ We commit to support each major version of Nuxt for a minimum of six months afte
 
 ### Current Packages
 
-The current active version of [Nuxt](https://nuxt.com) is **v3** which is available as `nuxt` on npm with the `latest` tag.
+The current active version of [Nuxt](https://nuxt.com) is **v4** which is available as `nuxt` on npm with the `latest` tag.
 
-Nuxt 2 is in maintenance mode and is available on npm with the `2x` tag. It reached End of Life (EOL) on June 30, 2024.
+Nuxt 3 will continue to receive maintenance updates (both bug fixes and backports of features from Nuxt 4) until the end of January 2026.
 
 Each active version has its own nightly releases which are generated automatically. For more about enabling the Nuxt nightly release channel, see [the nightly release channel docs](/docs/guide/going-further/nightly-release-channel).
 
-Release                                 |                                                                                                  | Initial release | End Of Life  | Docs
-----------------------------------------|---------------------------------------------------------------------------------------------------|-----------------|--------------|-------
+Release                    |                                                                                                                                                                               | Initial release       | End Of Life                  | Docs
+-------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- | ---------------------------- | ---------------------------------------
 **5.x** (scheduled)        |                                                                                                                                                                               | Q4 2025 (estimated)   | TBA                          | &nbsp;
-**4.x** (scheduled)        |                                                                                                                                                                               | 2025-06-30 (planned)  | 6 months after 5.x release   | &nbsp;
-**3.x** (stable)           | <a href="https://npmjs.com/package/nuxt"><img alt="Nuxt latest 3.x version" src="https://flat.badgen.net/npm/v/nuxt?label=" class="not-prose"></a>                            | 2022-11-16            | 2025-12-31 (TBC)             | [nuxt.com](/docs)
+**4.x** (stable)           | <a href="https://www.npmjs.com/package/nuxt?activeTab=versions"><img alt="Nuxt latest version" src="https://flat.badgen.net/npm/v/nuxt?label=" class="not-prose"></a>         | 2025-07-16            | 6 months after 5.x release   | [nuxt.com](/docs/4.x)
+**3.x** (maintenance)      | <a href="https://www.npmjs.com/package/nuxt?activeTab=versions"><img alt="Nuxt 3.x version" src="https://flat.badgen.net/npm/v/nuxt/3x?label=" class="not-prose"></a>         | 2022-11-16            | 2026-01-31                   | [nuxt.com](/docs/3.x)
 **2.x** (unsupported)      | <a href="https://www.npmjs.com/package/nuxt?activeTab=versions"><img alt="Nuxt 2.x version" src="https://flat.badgen.net/npm/v/nuxt/2x?label=" class="not-prose"></a>         | 2018-09-21            | 2024-06-30                   | [v2.nuxt.com](https://v2.nuxt.com/docs)
 **1.x** (unsupported)      | <a href="https://www.npmjs.com/package/nuxt?activeTab=versions"><img alt="Nuxt 1.x version" src="https://flat.badgen.net/npm/v/nuxt/1x?label=" class="not-prose"></a>         | 2018-01-08            | 2019-09-21                   | &nbsp;
 


### PR DESCRIPTION
### 🔗 Linked issue

### 📚 Description

This pull request updates the Nuxt roadmap documentation to reflect the release of Nuxt 4 as the current active version and clarifies the maintenance and end-of-life timelines for Nuxt 3 and other versions.

Updates to version status and support timelines:

* Updated the documentation to indicate that Nuxt 4 is now the current active version available as `nuxt` on npm, replacing Nuxt 3.
* Clarified that Nuxt 3 will continue to receive maintenance updates, including bug fixes and backports from Nuxt 4, until the end of January 2026.
* Updated the release table to show Nuxt 4 as stable, Nuxt 3 as maintenance, and adjusted their respective release and end-of-life dates.

Sources: https://nuxt.com/blog/v4
