### PR TITLE
feat(nuxt): support `routeRules` through `definePageMeta`

### DIFF
--- a/docs/2.guide/2.directory-structure/1.app/1.pages.md
+++ b/docs/2.guide/2.directory-structure/1.app/1.pages.md
@@ -337,7 +337,15 @@ You may define a path matcher, if you have a more complex pattern than can be ex
 
 #### `props`
 
-Allows accessing the route `params` as props passed to the page component. See[the `vue-router` docs](https://router.vuejs.org/guide/essentials/passing-props) for more information.
+Allows accessing the route `params` as props passed to the page component. See [the `vue-router` docs](https://router.vuejs.org/guide/essentials/passing-props) for more information.
+
+#### `routeRules`
+
+You can define Nitro [route rules](/docs/guide/concepts/rendering#route-rules) for this page's route, this allows you to set prerendering, caching, and other rules.
+
+These are applied to routes matching a glob pattern based on the page's path, for example:
+  - A rule defined in `~/pages/foo/bar.vue` will be applied to `/foo/bar` requests.
+  - A rule in `~/pages/foo/[id].vue` will be applied to `/foo/**` requests.
 
 ### Typing Custom Metadata
 

--- a/docs/3.api/3.utils/define-page-meta.md
+++ b/docs/3.api/3.utils/define-page-meta.md
@@ -138,7 +138,7 @@ interface PageMeta {
   - **Type**: `boolean | (to: RouteLocationNormalized, from: RouteLocationNormalized) => boolean`
 
     Tell Nuxt to scroll to the top before rendering the page or not. If you want to overwrite the default scroll behavior of Nuxt, you can do so in `~/router.options.ts` (see [custom routing](/docs/guide/recipes/custom-routing#using-approuteroptions)) for more info.
-    
+
   **`routeRules`**
 
   - **Type**: [`NitroRouteConfig`](/docs/guide/concepts/rendering#route-rules)
@@ -148,8 +148,6 @@ interface PageMeta {
   - These are applied to routes matching a glob pattern based on the page's path, for example:
     - A rule defined in `~/pages/foo/bar.vue` will be applied to `/foo/bar` requests.
     - A rule in `~/pages/foo/[id].vue` will be applied to `/foo/**` requests.
-    
-  
 
   **`[key: string]`**
 

--- a/docs/3.api/3.utils/define-page-meta.md
+++ b/docs/3.api/3.utils/define-page-meta.md
@@ -40,6 +40,7 @@ interface PageMeta {
   layout?: false | LayoutKey | Ref<LayoutKey> | ComputedRef<LayoutKey>
   middleware?: MiddlewareKey | NavigationGuard | Array<MiddlewareKey | NavigationGuard>
   scrollToTop?: boolean | ((to: RouteLocationNormalizedLoaded, from: RouteLocationNormalizedLoaded) => boolean)
+  routeRules?: NitroRouteConfig
   [key: string]: unknown
 }
 ```
@@ -137,6 +138,18 @@ interface PageMeta {
   - **Type**: `boolean | (to: RouteLocationNormalized, from: RouteLocationNormalized) => boolean`
 
     Tell Nuxt to scroll to the top before rendering the page or not. If you want to overwrite the default scroll behavior of Nuxt, you can do so in `~/router.options.ts` (see [custom routing](/docs/guide/recipes/custom-routing#using-approuteroptions)) for more info.
+    
+  **`routeRules`**
+
+  - **Type**: [`NitroRouteConfig`](/docs/guide/concepts/rendering#route-rules)
+
+    Define route rules for the current page. This allows you to set prerendering, caching, and other rules for the route.
+
+  - These are applied to routes matching a glob pattern based on the page's path, for example:
+    - A rule defined in `~/pages/foo/bar.vue` will be applied to `/foo/bar` requests.
+    - A rule in `~/pages/foo/[id].vue` will be applied to `/foo/**` requests.
+    
+  
 
   **`[key: string]`**
 

--- a/packages/nuxt/src/pages/route-rules.ts
+++ b/packages/nuxt/src/pages/route-rules.ts
@@ -59,7 +59,7 @@ export function getMappedPages (pages: NuxtPage[], paths = {} as { [absolutePath
 
 export function globRouteRulesFromPages (pages: NuxtPage[], paths = {} as { [glob: string]: NitroRouteConfig }, prefix = '') {
   for (const page of pages) {
-    if (page.meta?.routeRules) {
+    if (page.meta?.routeRules && Object.keys(page.meta.routeRules).length) {
       const glob = pathToNitroGlob(prefix + page.path)
       if (glob) {
         paths[glob] = page.meta.routeRules
@@ -75,6 +75,9 @@ export function globRouteRulesFromPages (pages: NuxtPage[], paths = {} as { [glo
 export function removePagesMetaRouteRules (routes: NuxtPage[]) {
   for (const route of routes) {
     delete route.meta?.routeRules
+    if (route.meta && Object.keys(route.meta).length === 0) {
+      delete route.meta
+    }
     if (route.children?.length) {
       removePagesMetaRouteRules(route.children)
     }

--- a/packages/nuxt/src/pages/route-rules.ts
+++ b/packages/nuxt/src/pages/route-rules.ts
@@ -56,3 +56,27 @@ export function getMappedPages (pages: NuxtPage[], paths = {} as { [absolutePath
   }
   return paths
 }
+
+export function globRouteRulesFromPages (pages: NuxtPage[], paths = {} as { [glob: string]: NitroRouteConfig }, prefix = '') {
+  for (const page of pages) {
+    if (page.meta?.routeRules) {
+      const glob = pathToNitroGlob(prefix + page.path)
+      if (glob) {
+        paths[glob] = page.meta.routeRules
+      }
+    }
+    if (page.children?.length) {
+      globRouteRulesFromPages(page.children, paths, page.path + '/')
+    }
+  }
+  return paths
+}
+
+export function removePagesMetaRouteRules (routes: NuxtPage[]) {
+  for (const route of routes) {
+    delete route.meta?.routeRules
+    if (route.children?.length) {
+      removePagesMetaRouteRules(route.children)
+    }
+  }
+}

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -75,6 +75,7 @@ export async function resolvePagesRoutes (pattern: string | string[], nuxt = use
   const augmentCtx = {
     extraExtractionKeys: new Set([
       'middleware',
+      'routeRules',
       ...extraPageMetaExtractionKeys,
     ]),
     fullyResolvedPaths: new Set(scannedFiles.map(file => file.absolutePath)),

--- a/packages/nuxt/test/route-rules.test.ts
+++ b/packages/nuxt/test/route-rules.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { extractRouteRules } from '../src/pages/route-rules'
+import { extractRouteRules, globRouteRulesFromPages, removePagesMetaRouteRules } from '../src/pages/route-rules'
 
 describe('route-rules', () => {
   it('should extract route rules from pages', () => {
@@ -53,3 +53,47 @@ export default {
 }
     `,
 }
+
+describe('routeRules from page meta', () => {
+  const pages = [
+    {
+      path: '/',
+      meta: { routeRules: { prerender: true } },
+    },
+    // page with routeRules and other meta
+    {
+      path: '/about',
+      meta: { foo: 'foo', routeRules: { prerender: true } },
+    },
+    // parent without routeRules
+    {
+      path: '/users',
+      meta: {},
+      children: [{ path: ':id', meta: { routeRules: { prerender: true } } }],
+    },
+    // page with empty routeRules
+    {
+      path: '/contact',
+      meta: { routeRules: {} },
+    },
+  ]
+
+  it('extracts route rules from pages meta', () => {
+    const result = globRouteRulesFromPages(pages)
+    expect(result).toEqual({
+      '/': { prerender: true },
+      '/about': { prerender: true },
+      '/users/**': { prerender: true },
+    })
+  })
+
+  it('removes route rules from pages meta', () => {
+    removePagesMetaRouteRules(pages)
+    expect(pages).toEqual([
+      { path: '/' },
+      { path: '/about', meta: { foo: 'foo' } },
+      { path: '/users', children: [{ path: ':id' }] },
+      { path: '/contact' },
+    ])
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue
* #32810

### 📚 Description
Resolves #32810

Adds support for setting `routeRules` in `definePageMeta`:
```html
<script setup lang="ts">
definePageMeta({
  routeRules: {
    prerender: true
  }
})
</script>
```

This also adds support for setting the `routeRules` on pages `meta.routeRules` from `pages:extend` or `pages:resolved` hooks directly.

The `meta.routeRules` property is removed after extraction to prevent exposing this in the final build.

---

I'm not entirely sure where the logic fits, suggestions on reorganization welcome 🙏

BTW, wrapping `resolvePageRoutes` rather than using `pages:extend` or `pages:resolved` hooks is intentional since the `routeRules` are processed and removed from the routes after those hooks.

I was studying how `inlineRouteRules` works and noticed some edge cases/bugs:
* Does not support multiple route paths
  * `pageToGlobMap` maps files to 1 path, this is an easy fix
* Route rules linger on route removal/rename 
  * `pageToGlobMap` is updated in `pages:extend` before `builder:watch` removes the routeRules from the `inlineRules` object, not sure how to fix that cleanly
