### PR TITLE
fix(nuxt): handle TSSatisfiesExpression in page augmentation

### DIFF
--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -675,6 +675,10 @@ export function isSerializable (code: string, node: Node): { value?: any, serial
     }
   }
 
+  if (node.type === 'TSSatisfiesExpression') {
+    return isSerializable(code, node.expression)
+  }
+
   return {
     serializable: false,
   }

--- a/packages/nuxt/test/page-metadata.test.ts
+++ b/packages/nuxt/test/page-metadata.test.ts
@@ -135,6 +135,23 @@ definePageMeta({ name: 'bar' })
       }
     `)
   })
+  it('should extract metadata with TS satisfies', () => {
+    const meta = getRouteMeta(`
+    <script setup lang="ts">
+    type PageName = 'name-from-page-meta' | 'whatever';
+
+    definePageMeta({
+      name: 'name-from-page-meta' satisfies PageName,
+    });
+    </script>
+    `, filePath)
+
+    expect(meta).toMatchInlineSnapshot(`
+      {
+        "name": "name-from-page-meta",
+      }
+    `)
+  })
 
   it('should not extract non-serialisable meta', () => {
     const meta = getRouteMeta(`


### PR DESCRIPTION
### 🔗 Linked issue

fix https://github.com/nuxt/nuxt/issues/32889

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this PR allows to handle TSSatisfiesExpression when extracting page meta data

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
