### PR TITLE
fix(nuxt): handle uncached current build manifests

### DIFF
--- a/packages/nuxt/src/app/plugins/check-outdated-build.client.ts
+++ b/packages/nuxt/src/app/plugins/check-outdated-build.client.ts
@@ -1,4 +1,4 @@
-import { FetchError } from 'ofetch'
+import type { FetchError } from 'ofetch'
 import { defineNuxtPlugin } from '../nuxt'
 import { getAppManifest } from '../composables/manifest'
 import type { NuxtAppManifestMeta } from '../composables/manifest'
@@ -18,9 +18,10 @@ export default defineNuxtPlugin((nuxtApp) => {
     try {
       currentManifest = await getAppManifest()
     } catch (e) {
-      // The build is already outdated but the manifest is not cached
-      if (!(e instanceof FetchError && (e.status === 404 || e.status === 403))) {
-        throw e
+      const err = e as FetchError | Error
+      // The build is already outdated but the manifest was not cached
+      if (!('status' in err && (err.status === 404 || err.status === 403))) {
+        throw err
       }
     }
     if (timeout) { clearTimeout(timeout) }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

Closes #32912

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

Check if the `getAppManifest()` call returned a 404 or 403 (usually returned when the CDN does not have access to list files). If so, proceed anyway so that the `app:manifest:update` hook can still be called.

This issue affects both Nuxt 3 and 4.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
