### PR TITLE
fix(nuxt): add TS parenthesis and as expression for page meta extraction

### DIFF
--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -675,7 +675,7 @@ export function isSerializable (code: string, node: Node): { value?: any, serial
     }
   }
 
-  if (node.type === 'TSSatisfiesExpression') {
+  if (node.type === 'TSSatisfiesExpression' || node.type === 'TSAsExpression' || node.type === 'ParenthesizedExpression') {
     return isSerializable(code, node.expression)
   }
 

--- a/packages/nuxt/test/page-metadata.test.ts
+++ b/packages/nuxt/test/page-metadata.test.ts
@@ -153,6 +153,39 @@ definePageMeta({ name: 'bar' })
     `)
   })
 
+  it('should extract metadata with TS as expression', () => {
+    const meta = getRouteMeta(`
+    <script setup lang="ts">
+    type PageName = 'name-from-page-meta' | 'whatever';
+
+    definePageMeta({
+      name: 'name-from-page-meta' as PageName,
+    });
+    </script>
+    `, filePath)
+
+    expect(meta).toMatchInlineSnapshot(`
+      {
+        "name": "name-from-page-meta",
+      }
+    `)
+  })
+
+  it('should extract metadata with TS ParenthesisExpression with as', () => {
+    const meta = getRouteMeta(`
+    <script setup lang="ts">
+    definePageMeta({
+      name: ('name-from-page-meta') as const,
+    });
+    </script>
+    `, filePath)
+
+    expect(meta).toMatchInlineSnapshot(`
+      {
+        "name": "name-from-page-meta",
+      }
+    `)
+  })
   it('should not extract non-serialisable meta', () => {
     const meta = getRouteMeta(`
     <script setup>


### PR DESCRIPTION
### 🔗 Linked issue
https://github.com/nuxt/nuxt/pull/32902#issuecomment-3170662491
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this PR handles additionnal TS expressions for page meta extraction

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
