### PR TITLE
fix: preserve page keepalive across layout changes

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-layout.ts
+++ b/packages/nuxt/src/app/components/nuxt-layout.ts
@@ -1,5 +1,5 @@
 import type { DefineComponent, ExtractPublicPropTypes, MaybeRef, PropType, VNode } from 'vue'
-import { Suspense, computed, defineComponent, h, inject, mergeProps, nextTick, onMounted, provide, shallowReactive, shallowRef, unref } from 'vue'
+import { KeepAlive, Suspense, computed, defineComponent, h, inject, mergeProps, nextTick, onMounted, provide, shallowReactive, shallowRef, unref } from 'vue'
 import type { RouteLocationNormalizedLoaded } from 'vue-router'
 
 import type { PageMeta } from '../../pages/runtime/composables'
@@ -94,17 +94,23 @@ export default defineComponent({
       return _wrapInTransition(hasLayout && transitionProps, {
         default: () => h(Suspense, { suspensible: true, onResolve: () => { nextTick(done) } }, {
           default: () => h(
-            LayoutProvider,
-            {
-              layoutProps: mergeProps(context.attrs, { ref: layoutRef }),
-              key: layout.value || undefined,
-              name: layout.value,
-              shouldProvide: !props.name,
-              isRenderingNewLayout: (name?: string | boolean) => {
-                return (name !== previouslyRenderedLayout && name === layout.value)
+            KeepAlive,
+            {},
+            [h(
+              LayoutProvider,
+              {
+                layoutProps: mergeProps(context.attrs, { ref: layoutRef }),
+                key: layout.value || undefined,
+                name: layout.value,
+                shouldProvide: !props.name,
+                isRenderingNewLayout: (name?: string | boolean) => {
+                  return (name !== previouslyRenderedLayout && name === layout.value)
+                },
+                hasTransition: !!transitionProps,
               },
-              hasTransition: !!transitionProps,
-            }, context.slots),
+              context.slots,
+            )],
+          ),
         }),
       }).default()
     }

--- a/test/nuxt/nuxt-page.test.ts
+++ b/test/nuxt/nuxt-page.test.ts
@@ -4,12 +4,18 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import { NuxtLayout, NuxtPage } from '#components'
+import layouts from '#build/layouts.mjs'
 
 describe('NuxtPage should work with keepalive options', () => {
   let visits = 0
   const router = useRouter()
   beforeEach(() => {
     visits = 0
+    layouts.other = defineComponent({
+      setup (_, ctx) {
+        return () => h('div', ctx.slots.default?.())
+      },
+    })
     router.addRoute({
       name: 'home',
       path: '/home',
@@ -21,9 +27,22 @@ describe('NuxtPage should work with keepalive options', () => {
         },
       }),
     })
+    router.addRoute({
+      name: 'other',
+      path: '/other',
+      meta: { layout: 'other' },
+      component: defineComponent({
+        name: 'other',
+        setup () {
+          return () => h('div', 'other')
+        },
+      }),
+    })
   })
   afterEach(() => {
     router.removeRoute('home')
+    router.removeRoute('other')
+    delete layouts.other
   })
   // include/exclude/boolean
   it('should reload setup every time a page is visited, without keepalive', async () => {
@@ -90,6 +109,19 @@ describe('NuxtPage should work with keepalive options', () => {
     await navigateTo('/home')
     pages.value = 'home,catchall'
     await navigateTo('/')
+    await navigateTo('/home')
+    expect(visits).toBe(1)
+    el.unmount()
+  })
+
+  it('should preserve keepalive when layout changes', async () => {
+    const el = await mountSuspended({
+      setup () {
+        return () => h(NuxtLayout, {}, { default: () => h(NuxtPage, { keepalive: true }) })
+      },
+    })
+    await navigateTo('/home')
+    await navigateTo('/other')
     await navigateTo('/home')
     expect(visits).toBe(1)
     el.unmount()


### PR DESCRIPTION
## Summary
- ensure `NuxtLayout` caches layouts with `<KeepAlive>` so page keepalive survives layout switches
- add regression test for keepalive across layout changes

## Testing
- `pnpm vitest test/nuxt/nuxt-page.test.ts`
- `pnpm lint packages/nuxt/src/app/components/nuxt-layout.ts test/nuxt/nuxt-page.test.ts`

resolves https://github.com/nuxt/nuxt/issues/26270


------
https://chatgpt.com/codex/tasks/task_e_689e4bcdd2a083288514a1c01b6eefb9