### PR TITLE
refactor(nuxt): remove unnecessary `async/await` in `afterEach`

### DIFF
--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -263,7 +263,7 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
 
     router.afterEach((to) => {
       if (to.matched.length === 0) {
-        nuxtApp.runWithContext(() => showError(createError({
+        return nuxtApp.runWithContext(() => showError(createError({
           statusCode: 404,
           fatal: false,
           statusMessage: `Page not found: ${to.fullPath}`,

--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -261,9 +261,9 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
       await nuxtApp.callHook('page:loading:end')
     })
 
-    router.afterEach(async (to, _from) => {
+    router.afterEach((to) => {
       if (to.matched.length === 0) {
-        await nuxtApp.runWithContext(() => showError(createError({
+        nuxtApp.runWithContext(() => showError(createError({
           statusCode: 404,
           fatal: false,
           statusMessage: `Page not found: ${to.fullPath}`,


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 📚 Description

This is a very minor improvement, it simply removes unnecessary `async / await` usage.