### PR TITLE
docs: fix documentation error at 07.routing.md

### DIFF
--- a/docs/1.getting-started/07.routing.md
+++ b/docs/1.getting-started/07.routing.md
@@ -51,7 +51,7 @@ The [`<NuxtLink>`](/docs/api/components/nuxt-link) component links pages between
 
 When a [`<NuxtLink>`](/docs/api/components/nuxt-link) enters the viewport on the client side, Nuxt will automatically prefetch components and payload (generated pages) of the linked pages ahead of time, resulting in faster navigation.
 
-```vue [pages/app.vue]
+```vue [pages/index.vue]
 <template>
   <header>
     <nav>


### PR DESCRIPTION
The version 3.18 Getting Started->07.Routing with subsection Navigation references adding the navigation to pages/app.vue at the current stage of the documentation, read sequentially. This should be a mistake. What is probably meant is the pages/index.vue. 

This is further illustrated as in the Docs for further reading, it is correctly labeled as index.vue, as opposed to giving newcomers following along the wrong idea that you should move app.vue into pages and add the navigation elements there. This would not work either, as then there are no <NuxtPage> in the app/app.vue serving as the entrypoint for the pages API

### 🔗 Linked issue

Resolves #32998

### 📚 Description

The Getting Started documentation at 07. Routing section references pages/app.vue at the Navigation subsection instead of pages/index.vue, which is ostensibly what was meant. Going into the further documentation correctly references implementing the navigation elements in pages/index.vue

Otherwise implementing it in app.vue, or even moving the app.vue understandably doesn't work as intended, as there is no app.vue as the starting point for the application that refers to the pages with NuxtPage API

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
