### PR TITLE
fix(nuxt): make vue server warnings much less verbose in dev mode

### DIFF
--- a/packages/nuxt/src/app/plugins/warn.dev.server.ts
+++ b/packages/nuxt/src/app/plugins/warn.dev.server.ts
@@ -1,0 +1,7 @@
+import { defineNuxtPlugin } from '../nuxt'
+
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.vueApp.config.warnHandler ??= (msg, _instance, trace) => {
+    console.warn(`[Vue warn]: ${msg}`, trace)
+  }
+})

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -370,6 +370,9 @@ async function initNuxt (nuxt: Nuxt) {
   if (nuxt.options.dev) {
     // Add plugin to check if layouts are defined without NuxtLayout being instantiated
     addPlugin(resolve(nuxt.options.appDir, 'plugins/check-if-layout-used'))
+
+    // add plugin to make warnings less verbose in dev mode
+    addPlugin(resolve(nuxt.options.appDir, 'plugins/warn.dev.server'))
   }
 
   if (nuxt.options.dev && nuxt.options.features.devLogs) {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

in development mode, Vue's default warnHandler can produce very long output:

<details>
<summary>for example</summary>


```
❯ pnpm nuxt dev
Nuxt 4.0.3 with Nitro 2.12.4                                                                                                          nuxi 14:06:04
[get-port] Unable to find an available port (tried 3000 on host "localhost"). Using alternative port 3001.                                 14:06:04
                                                                                                                                           14:06:04
  ➜ Local:    http://localhost:3001/
  ➜ Network:  use --host to expose

  ➜ DevTools: press Shift + Option + D in the browser (v2.6.2)                                                                             14:06:04

✔ Vite client built in 16ms                                                                                                               14:06:05
✔ Vite server built in 17ms                                                                                                               14:06:05
✔ Nuxt Nitro server built in 306ms                                                                                                  nitro 14:06:05
ℹ Vite client warmed up in 1ms                                                                                                            14:06:05
ℹ Vite server warmed up in 14ms                                                                                                           14:06:05
 WARN  [Vue warn]: Failed to resolve component: NuxtLink                                                                                   14:06:07
If this is a native custom element, make sure to exclude it from component resolution via compilerOptions.isCustomElement. 
  at <Anonymous> 
  at <Index onVnodeUnmounted=fn<onVnodeUnmounted> ref=Ref< undefined > > 
  at <RouteProvider vnode= { __v_isVNode: true,
  __v_skip: true,
  type:
   { setup: [Function (anonymous)],
     ssrRender: [Function: _sfc_ssrRender],
     __file: '/private/tmp/conditional-resolution/app/pages/index.vue' },
  props:
   { onVnodeUnmounted: [Function: onVnodeUnmounted],
     ref:
      RefImpl {
        dep: [Dep],
        __v_isRef: true,
        __v_isShallow: false,
        _rawValue: undefined,
        _value: undefined } },
  key: null,
  ref:
   { i:
      { uid: 6,
        vnode: [Object],
        type: [Object],
        parent: [Object],
        appContext: [Object],
        root: [Object],
        next: null,
        subTree: [Object],
        effect: null,
        update: null,
        job: null,
        scope: [EffectScope],
        render: [Function (anonymous)],
        proxy: [Object],
        exposed: null,
        exposeProxy: null,
        withProxy: null,
        provides: [Object <Complex prototype>],
        ids: [Array],
        accessCache: [Object: null prototype] {},
        renderCache: [],
        components: null,
        directives: null,
        propsOptions: [Array],
        emitsOptions: null,
        emit: [Function: bound emit],
        emitted: null,
        propsDefaults: [Object: null prototype] {},
        inheritAttrs: false,
        ctx: [Object],
        data: {},
        props: [Object],
        attrs: {},
        slots: [Object],
        refs: {},
        setupState: {},
        setupContext: [Object],
        suspense: null,
        suspenseId: 0,
        asyncDep: null,
        asyncResolved: false,
        isMounted: false,
        isUnmounted: false,
        isDeactivated: false,
        bc: null,
        c: null,
        bm: null,
        m: null,
        bu: null,
        u: null,
        um: null,
        bum: null,
        da: null,
        a: null,
        rtg: null,
        rtc: null,
        ec: null,
        sp: null },
     r:
      RefImpl {
        dep: [Dep],
        __v_isRef: true,
        __v_isShallow: false,
        _rawValue: undefined,
        _value: undefined },
     k: undefined,
     f: false },
  scopeId: null,
  slotScopeIds: null,
  children: null,
  component: null,
  suspense: null,
  ssContent: null,
  ssFallback: null,
  dirs: null,
  transition: null,
  el: null,
  anchor: null,
  target: null,
  targetStart: null,
  targetAnchor: null,
  staticCount: 0,
  shapeFlag: 4,
  patchFlag: 0,
  dynamicProps: null,
  dynamicChildren: null,
  appContext: null,
  ctx:
   <ref *1> {
     uid: 6,
     vnode:
      { __v_isVNode: true,
        __v_skip: true,
        type: [Object],
        props: [Object],
        key: null,
        ref: null,
        scopeId: null,
        slotScopeIds: null,
        children: [Object],
        component: [Circular *1],
        suspense: null,
        ssContent: null,
        ssFallback: null,
        dirs: null,
        transition: null,
        el: null,
        anchor: null,
        target: null,
        targetStart: null,
        targetAnchor: null,
        staticCount: 0,
        shapeFlag: 36,
        patchFlag: 0,
        dynamicProps: null,
        dynamicChildren: null,
        appContext: null,
        ctx: [Object] },
     type:
      { name: 'RouterView',
        inheritAttrs: false,
        props: [Object],
        compatConfig: [Object],
        setup: [Function: setup] },
     parent:
      { uid: 5,
        vnode: [Object],
        type: [Object],
        parent: [Object],
        appContext: [Object],
        root: [Object],
        next: null,
        subTree: [Object],
        effect: null,
        update: null,
        job: null,
        scope: [EffectScope],
        render: [Function (anonymous)],
        proxy: [Object],
        exposed: [Object],
        exposeProxy: null,
        withProxy: null,
        provides: [Object <Complex prototype>],
        ids: [Array],
        accessCache: [Object: null prototype] {},
        renderCache: [],
        components: null,
        directives: null,
        propsOptions: [Array],
        emitsOptions: null,
        emit: [Function: bound emit],
        emitted: null,
        propsDefaults: [Object: null prototype] {},
        inheritAttrs: false,
        ctx: [Object],
        data: {},
        props: [Object],
        attrs: {},
        slots: {},
        refs: {},
        setupState: {},
        setupContext: [Object],
        suspense: null,
        suspenseId: 0,
        asyncDep: null,
        asyncResolved: false,
        isMounted: false,
        isUnmounted: false,
        isDeactivated: false,
        bc: null,
        c: null,
        bm: null,
        m: null,
        bu: null,
        u: null,
        um: null,
        bum: null,
        da: null,
        a: null,
        rtg: null,
        rtc: null,
        ec: null,
        sp: null },
     appContext:
      { app: [Object],
        config: [Object],
        mixins: [],
        components: [Object],
        directives: {},
        provides: [Object: null prototype],
        optionsCache: [WeakMap],
        propsCache: [WeakMap],
        emitsCache: [WeakMap] },
     root:
      <ref *2> {
        uid: 0,
        vnode: [Object],
        type: [Object],
        parent: null,
        appContext: [Object],
        root: [Circular *2],
        next: null,
        subTree: null,
        effect: null,
        update: null,
        job: null,
        scope: [EffectScope],
        render: [Function: NOOP],
        proxy: {},
        exposed: {},
        exposeProxy: null,
        withProxy: null,
        provides: [Object <Complex prototype>],
        ids: [Array],
        accessCache: [Object: null prototype] {},
        renderCache: [],
        components: null,
        directives: null,
        propsOptions: [],
        emitsOptions: null,
        emit: [Function: bound emit],
        emitted: null,
        propsDefaults: [Object: null prototype] {},
        inheritAttrs: undefined,
        ctx: {},
        data: {},
        props: {},
        attrs: {},
        slots: {},
        refs: {},
        setupState: [Object],
        setupContext: [Object],
        suspense: null,
        suspenseId: 0,
        asyncDep: null,
        asyncResolved: false,
        isMounted: false,
        isUnmounted: false,
        isDeactivated: false,
        bc: null,
        c: null,
        bm: null,
        m: null,
        bu: null,
        u: null,
        um: null,
        bum: null,
        da: null,
        a: null,
        rtg: null,
        rtc: null,
        ec: [Array],
        sp: null,
        devtoolsRawSetupState: [Object] },
     next: null,
     subTree:
      { __v_isVNode: true,
        __v_skip: true,
        type: [Object],
        props: [Object],
        key: null,
        ref: null,
        scopeId: null,
        slotScopeIds: null,
        children: [Object],
        component: null,
        suspense: null,
        ssContent: [Object],
        ssFallback: [Object],
        dirs: null,
        transition: null,
        el: null,
        anchor: null,
        target: null,
        targetStart: null,
        targetAnchor: null,
        staticCount: 0,
        shapeFlag: 160,
        patchFlag: 0,
        dynamicProps: null,
        dynamicChildren: null,
        appContext: null,
        ctx: [Object] },
     effect: null,
     update: null,
     job: null,
     scope:
      EffectScope {
        detached: true,
        _active: true,
        _on: 0,
        effects: [],
        cleanups: [],
        _isPaused: false,
        parent: undefined,
        prevScope: undefined },
     render: [Function (anonymous)],
     proxy: { name: [Getter/Setter], route: [Getter/Setter] },
     exposed: null,
     exposeProxy: null,
     withProxy: null,
     provides:
      Object <Object <Complex prototype>> {
        Symbol(router view depth): [ComputedRefImpl],
        Symbol(router view location matched): [ComputedRefImpl],
        Symbol(router view location): [ComputedRefImpl] },
     ids: [ '', 0, 0 ],
     accessCache: [Object: null prototype] {},
     renderCache: [],
     components: null,
     directives: null,
     propsOptions: [ [Object], [Array] ],
     emitsOptions: null,
     emit: [Function: bound emit],
     emitted: null,
     propsDefaults: [Object: null prototype] {},
     inheritAttrs: false,
     ctx: { name: [Getter/Setter], route: [Getter/Setter] },
     data: {},
     props: { route: undefined, name: 'default' },
     attrs: {},
     slots: { default: [Function] },
     refs: {},
     setupState: {},
     setupContext: { attrs: [Getter], slots: [Getter], emit: [Getter], expose: [Function: expose] },
     suspense: null,
     suspenseId: 0,
     asyncDep: null,
     asyncResolved: false,
     isMounted: false,
     isUnmounted: false,
     isDeactivated: false,
     bc: null,
     c: null,
     bm: null,
     m: null,
     bu: null,
     u: null,
     um: null,
     bum: null,
     da: null,
     a: null,
     rtg: null,
     rtc: null,
     ec: null,
     sp: null } } route= { fullPath: '/',
  hash: '',
  query: {},
  name: 'index',
  path: '/',
  params: {},
  matched:
   [ { path: '/',
       redirect: undefined,
       name: 'index',
       meta: {},
       aliasOf: undefined,
       beforeEnter: undefined,
       props: [Object],
       children: [],
       instances: {},
       leaveGuards: Set(0) {},
       updateGuards: Set(0) {},
       enterCallbacks: {},
       components: [Object] } ],
  meta: {},
  redirectedFrom: undefined,
  href: '/' } vnodeRef=Ref< undefined > > 
  at <RouterView name=undefined route=undefined > 
  at <NuxtPage> 
  at <NuxtLayoutProvider layoutProps= { ref:
   RefImpl {
     dep:
      Dep {
        computed: undefined,
        version: 0,
        activeLink: undefined,
        subs: undefined,
        map: undefined,
        key: undefined,
        sc: 0,
        __v_skip: true,
        subsHead: undefined },
     __v_isRef: true,
     __v_isShallow: true,
     _rawValue: undefined,
     _value: undefined } } key="default" name="default"  ... > 
  at <NuxtLayout > 
  at <App> 
  at <NuxtRoot>
```

</details>


this is because we pass a `vnode` as a prop in LayoutProvider + RouteProvider and when stringified this also includes the full route, etc.

this PR simplifies that to simply a list of the component trace:

```
❯ pnpm nuxt dev playground
Nuxt 4.0.3 with Nitro 2.12.4                                                                                            nuxi 2:22:00 PM
                                                                                                                             2:22:00 PM
  ➜ Local:    http://localhost:3000/
  ➜ Network:  use --host to expose

  ➜ DevTools: press Shift + Option + D in the browser (v2.6.2)                                                               2:22:00 PM

✔ Vite client built in 15ms                                                                                                 2:22:00 PM
✔ Vite server built in 9ms                                                                                                  2:22:00 PM
✔ Nuxt Nitro server built in 335ms                                                                                    nitro 2:22:01 PM
ℹ Vite client warmed up in 2ms                                                                                              2:22:01 PM
ℹ Vite server warmed up in 19ms                                                                                             2:22:01 PM
 WARN  [Vue warn]: Failed to resolve component: NuxtLink                                                                     2:22:03 PM
If this is a native custom element, make sure to exclude it from component resolution via compilerOptions.isCustomElement. at <Anonymous>
at <RouteProvider>
at <RouterView>
at <NuxtPage>
at <NuxtLayoutProvider>
at <NuxtLayout>
at <App>
at <NuxtRoot>
```

there may be a better approach here, so I'd welcome feedback.