### PR TITLE
test: refactor stubbing of `import.meta.dev`

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -46,17 +46,9 @@ export default defineNuxtConfig({
     app: fileURLToPath(new URL('./test/runtime/app', import.meta.url)),
   },
   vite: {
-    plugins: [
-      {
-        name: 'enable some dev logging',
-        enforce: 'pre',
-        transform (code) {
-          if (code.includes('import.meta.dev /* and in test */')) {
-            return code.replace('import.meta.dev /* and in test */', 'true')
-          }
-        },
-      },
-    ],
+    define: {
+      'import.meta.dev': 'globalThis.__TEST_DEV__',
+    },
   },
   typescript: {
     shim: process.env.DOCS_TYPECHECK === 'true',

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -222,7 +222,7 @@ export function useAsyncData<
 
   // check and warn if different defaults/fetcher are provided
   const currentData = nuxtApp._asyncData[key.value]
-  if (isDev && currentData) {
+  if (import.meta.dev && currentData) {
     const warnings: string[] = []
     const values = createHash(_handler, options)
     if (values.handler !== currentData._hash?.handler) {
@@ -587,8 +587,6 @@ function pick (obj: Record<string, any>, keys: string[]) {
 
 export type CreatedAsyncData<ResT, NuxtErrorDataT = unknown, DataT = ResT, DefaultT = undefined> = Omit<_AsyncData<DataT | DefaultT, (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>)>, 'clear' | 'refresh'> & { _off: () => void, _hash?: Record<string, string | undefined>, _default: () => unknown, _init: boolean, _deps: number, _execute: (opts?: AsyncDataExecuteOptions) => Promise<void> }
 
-const isDev = import.meta.dev /* and in test */
-
 function createAsyncData<
   ResT,
   NuxtErrorDataT = unknown,
@@ -712,7 +710,7 @@ function createAsyncData<
     _default: options.default!,
     _deps: 0,
     _init: true,
-    _hash: isDev ? createHash(_handler, options) : undefined,
+    _hash: import.meta.dev ? createHash(_handler, options) : undefined,
     _off: () => {
       unsubRefreshAsyncData()
       if (nuxtApp._asyncData[key]?._init) {

--- a/test/nuxt/use-async-data.test.ts
+++ b/test/nuxt/use-async-data.test.ts
@@ -70,6 +70,8 @@ describe('useAsyncData', () => {
   })
 
   it('should capture errors', async () => {
+    vi.stubGlobal('__TEST_DEV__', true)
+
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
     const { data, error, status, pending } = await useAsyncData(uniqueKey, () => Promise.reject(new Error('test')), { default: () => 'default' })
@@ -90,6 +92,7 @@ describe('useAsyncData', () => {
       /\[nuxt\] \[useAsyncData\] Incompatible options detected for "[^"]+" \(used at .*:\d+:\d+\):\n- different handler\n- different `default` value\nYou can use a different key or move the call to a composable to ensure the options are shared across calls./,
     ))
     warn.mockRestore()
+    vi.unstubAllGlobals()
   })
 
   // https://github.com/nuxt/nuxt/issues/23411
@@ -372,6 +375,7 @@ describe('useAsyncData', () => {
   })
 
   it('should warn if incompatible options are used', async () => {
+    vi.stubGlobal('__TEST_DEV__', true)
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
     await mountWithAsyncData('dedupedKey3', () => Promise.resolve('test'), { deep: false })
@@ -407,6 +411,7 @@ describe('useAsyncData', () => {
     ))
 
     warn.mockReset()
+    vi.unstubAllGlobals()
   })
 
   it('should only refresh asyncdata once when watched dependency is updated', async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -50,6 +50,9 @@ export default defineConfig({
         },
       },
       {
+        define: {
+          'import.meta.dev': 'globalThis.__TEST_DEV__',
+        },
         test: {
           name: 'fixtures',
           include: ['test/*.test.ts'],
@@ -61,6 +64,9 @@ export default defineConfig({
         },
       },
       {
+        define: {
+          'import.meta.dev': 'globalThis.__TEST_DEV__',
+        },
         resolve: {
           alias: {
             '#build/nuxt.config.mjs': resolve('./test/mocks/nuxt-config'),
@@ -93,6 +99,9 @@ export default defineConfig({
         },
       }),
       ...await Promise.all(Object.entries(projects).map(([project, config]) => defineVitestProject({
+        define: {
+          'import.meta.dev': 'globalThis.__TEST_DEV__',
+        },
         test: {
           name: project,
           dir: './test/nuxt',


### PR DESCRIPTION

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
This PR allows to stub `import.meta.dev` on a per-test basis by refactoring it to use a global variable in tests instead of a vite plugin.
It will allow us to check both cases `in dev / in prod` to ensure that we don't log in production, for example.

```ts
// in tests where we want to check dev behaviour
vi.stubGlobal('__TEST_DEV__', true)
```

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
