### PR TITLE
fix(kit,nuxt): expose global types to vue compiler

### DIFF
--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -94,6 +94,15 @@ export function addTypeTemplate<T> (_template: NuxtTypeTemplate<T>, context?: { 
     })
   }
 
+  if (!context || context.nuxt || context.shared) {
+    // expose global types to vue compiler
+    nuxt.options.vite.vue = defu(nuxt.options.vite.vue, {
+      script: {
+        globalTypeFiles: [template.dst],
+      },
+    })
+  }
+
   if (context?.nitro) {
     nuxt.hook('nitro:prepare:types', ({ references }) => {
       references.push({ path: template.dst })

--- a/packages/kit/test/templates.spec.ts
+++ b/packages/kit/test/templates.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { addTypeTemplate, buildNuxt, loadNuxt } from '../src'
+import { findWorkspaceDir } from 'pkg-types'
+import { resolve } from 'node:path'
+import { randomUUID } from 'node:crypto'
+import { mkdir, writeFile } from 'node:fs/promises'
+
+describe('addTypeTemplate', () => {
+  it('should add type templates to vue global files', async () => {
+    const repoRoot = await findWorkspaceDir()
+    const rootDir = resolve(repoRoot, 'node_modules/.fixture', randomUUID())
+    await mkdir(rootDir, { recursive: true })
+    await writeFile(resolve(rootDir, 'app.vue'), `
+      <script setup lang="ts">
+      defineProps<TestComponentProps>()
+      </script>
+      <template><div /></template>
+    `)
+    const nuxt = await loadNuxt({
+      cwd: rootDir,
+      overrides: {
+        modules: [
+          function () {
+            addTypeTemplate({
+              filename: 'some-type-template.d.ts',
+              getContents: () => `
+                declare global {
+                  type TestComponentProps = { foo?: string }
+                }
+                export {};
+              `,
+            })
+          },
+        ],
+      },
+    })
+
+    await expect(buildNuxt(nuxt)).resolves.not.toThrow()
+
+    await nuxt.close()
+  })
+})

--- a/packages/kit/test/templates.spec.ts
+++ b/packages/kit/test/templates.spec.ts
@@ -6,7 +6,7 @@ import { randomUUID } from 'node:crypto'
 import { mkdir, writeFile } from 'node:fs/promises'
 
 describe('addTypeTemplate', () => {
-  it('should add type templates to vue global files', async () => {
+  it('should add type templates to vue global files', { timeout: 20_000 }, async () => {
     const repoRoot = await findWorkspaceDir()
     const rootDir = resolve(repoRoot, 'node_modules/.fixture', randomUUID())
     await mkdir(rootDir, { recursive: true })

--- a/packages/nuxt/src/components/module.ts
+++ b/packages/nuxt/src/components/module.ts
@@ -6,7 +6,7 @@ import { resolveModulePath } from 'exsolve'
 import { distDir } from '../dirs'
 import { logger } from '../utils'
 import { lazyHydrationMacroPreset } from '../imports/presets'
-import { componentNamesTemplate, componentsIslandsTemplate, componentsMetadataTemplate, componentsPluginTemplate, componentsTypeTemplate } from './templates'
+import { componentNamesTemplate, componentsDeclarationTemplate, componentsIslandsTemplate, componentsMetadataTemplate, componentsPluginTemplate, componentsTypeTemplate } from './templates'
 import { scanComponents } from './scan'
 
 import { LoaderPlugin } from './plugins/loader'
@@ -128,6 +128,8 @@ export default defineNuxtModule<ComponentsOptions>({
     })
 
     // components.d.ts
+    addTemplate(componentsDeclarationTemplate)
+    // types/components.d.ts
     addTypeTemplate(componentsTypeTemplate)
     // components.plugin.mjs
     addPluginTemplate(componentsPluginTemplate)

--- a/packages/nuxt/src/components/templates.ts
+++ b/packages/nuxt/src/components/templates.ts
@@ -1,7 +1,7 @@
 import { isAbsolute, relative, resolve } from 'pathe'
 import { genDynamicImport } from 'knitwork'
 import { distDir } from '../dirs'
-import type { NuxtPluginTemplate, NuxtTemplate } from 'nuxt/schema'
+import type { Nuxt, NuxtApp, NuxtPluginTemplate, NuxtTemplate } from 'nuxt/schema'
 
 type ImportMagicCommentsOptions = {
   chunkName: string
@@ -104,25 +104,24 @@ export const componentsIslandsTemplate: NuxtTemplate = {
 }
 
 const NON_VUE_RE = /\b\.(?!vue)\w+$/g
-export const componentsTypeTemplate = {
-  filename: 'components.d.ts' as const,
-  getContents: ({ app, nuxt }) => {
-    const buildDir = nuxt.options.buildDir
-    const serverPlaceholderPath = resolve(distDir, 'app/components/server-placeholder')
-    const componentTypes = app.components.filter(c => !c.island).map((c) => {
-      const type = `typeof ${genDynamicImport(isAbsolute(c.filePath)
-        ? relative(buildDir, c.filePath).replace(NON_VUE_RE, '')
-        : c.filePath.replace(NON_VUE_RE, ''), { wrapper: false })}['${c.export}']`
-      const isServerOnly = c.mode === 'server' && c.filePath !== serverPlaceholderPath && !app.components.some(other => other.pascalName === c.pascalName && other.mode === 'client')
-      return [
-        c.pascalName,
-        isServerOnly ? `IslandComponent<${type}>` : type,
-      ]
-    })
-    const islandType = 'type IslandComponent<T extends DefineComponent> = T & DefineComponent<{}, {refresh: () => Promise<void>}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, SlotsType<{ fallback: { error: unknown } }>>'
-    return `
-import type { DefineComponent, SlotsType } from 'vue'
-${nuxt.options.experimental.componentIslands ? islandType : ''}
+function resolveComponentTypes (nuxt: Nuxt, app: NuxtApp) {
+  const buildDir = nuxt.options.buildDir
+  const serverPlaceholderPath = resolve(distDir, 'app/components/server-placeholder')
+  const componentTypes = app.components.filter(c => !c.island).map((c) => {
+    const type = `typeof ${genDynamicImport(isAbsolute(c.filePath)
+      ? relative(buildDir, c.filePath).replace(NON_VUE_RE, '')
+      : c.filePath.replace(NON_VUE_RE, ''), { wrapper: false })}['${c.export}']`
+    const isServerOnly = c.mode === 'server' && c.filePath !== serverPlaceholderPath && !app.components.some(other => other.pascalName === c.pascalName && other.mode === 'client')
+    return [
+      c.pascalName,
+      isServerOnly ? `IslandComponent<${type}>` : type,
+    ]
+  })
+
+  return componentTypes
+}
+const islandType = 'type IslandComponent<T extends DefineComponent> = T & DefineComponent<{}, {refresh: () => Promise<void>}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, SlotsType<{ fallback: { error: unknown } }>>'
+const hydrationTypes = `
 type HydrationStrategies = {
   hydrateOnVisible?: IntersectionObserverInit | true
   hydrateOnIdle?: number | true
@@ -133,6 +132,33 @@ type HydrationStrategies = {
   hydrateNever?: true
 }
 type LazyComponent<T> = (T & DefineComponent<HydrationStrategies, {}, {}, {}, {}, {}, {}, { hydrated: () => void }>)
+`
+export const componentsDeclarationTemplate = {
+  filename: 'components.d.ts' as const,
+  write: true,
+  getContents: ({ app, nuxt }) => {
+    const componentTypes = resolveComponentTypes(nuxt, app)
+    return `
+import type { DefineComponent, SlotsType } from 'vue'
+${nuxt.options.experimental.componentIslands ? islandType : ''}
+${hydrationTypes}
+
+${componentTypes.map(([pascalName, type]) => `export const ${pascalName}: ${type}`).join('\n')}
+${componentTypes.map(([pascalName, type]) => `export const Lazy${pascalName}: LazyComponent<${type}>`).join('\n')}
+
+export const componentNames: string[]
+`
+  },
+} satisfies NuxtTemplate
+
+export const componentsTypeTemplate = {
+  filename: 'types/components.d.ts' as const,
+  getContents: ({ app, nuxt }) => {
+    const componentTypes = resolveComponentTypes(nuxt, app)
+    return `
+import type { DefineComponent, SlotsType } from 'vue'
+${nuxt.options.experimental.componentIslands ? islandType : ''}
+${hydrationTypes}
 interface _GlobalComponents {
   ${componentTypes.map(([pascalName, type]) => `    '${pascalName}': ${type}`).join('\n')}
   ${componentTypes.map(([pascalName, type]) => `    'Lazy${pascalName}': LazyComponent<${type}>`).join('\n')}
@@ -142,10 +168,7 @@ declare module 'vue' {
   export interface GlobalComponents extends _GlobalComponents { }
 }
 
-${componentTypes.map(([pascalName, type]) => `export const ${pascalName}: ${type}`).join('\n')}
-${componentTypes.map(([pascalName, type]) => `export const Lazy${pascalName}: LazyComponent<${type}>`).join('\n')}
-
-export const componentNames: string[]
+export {}
 `
   },
 } satisfies NuxtTemplate


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/29757

### 📚 Description

This adds global type files registered with `addTypeTemplate` (in shared/nuxt contexts) so that Vue is aware of them for the purpose of resolving component props.