### PR TITLE
docs: avoid variable shadowing in locale example

### DIFF
--- a/docs/1.getting-started/11.state-management.md
+++ b/docs/1.getting-started/11.state-management.md
@@ -178,8 +178,8 @@ const date = useLocaleDate(new Date('2016-10-26'))
     <p>{{ date }}</p>
     <label for="locale-chooser">Preview a different locale</label>
     <select id="locale-chooser" v-model="locale">
-      <option v-for="locale of locales" :key="locale" :value="locale">
-        {{ locale }}
+      <option v-for="loc of locales" :key="loc" :value="loc">
+        {{ loc }}
       </option>
     </select>
   </div>


### PR DESCRIPTION
### 🔗 Linked issue

N/A (no linked issue)

### 📚 Description

Currently, the locale variable from `useLocale()` is shadowed inside a v-for loop:

```html
<option v-for="locale of locales" :key="locale" :value="locale">
  {{ locale }}
</option>
```
This can be confusing for developers since the same variable name is used in two different contexts.

Solution: The inner variable was renamed to loc:

```html
<option v-for="loc of locales" :key="loc" :value="loc">
  {{ loc }}
</option>
```
