### PR TITLE
fix(nuxt): add setting retainPreviousDataOnKeyChange to asyncData

### DIFF
--- a/docs/3.api/2.composables/use-async-data.md
+++ b/docs/3.api/2.composables/use-async-data.md
@@ -102,6 +102,7 @@ The `handler` function should be **side-effect free** to ensure predictable beha
   - `dedupe`: avoid fetching same key more than once at a time (defaults to `cancel`). Possible options:
     - `cancel` - cancels existing requests when a new one is made
     - `defer` - does not make new requests at all if there is a pending request
+  - `retainPreviousDataOnKeyChange`: on reactive key change retain data from previous key during refetch
 
 ::note
 Under the hood, `lazy: false` uses `<Suspense>` to block the loading of the route before the data has been fetched. Consider using `lazy: true` and implementing a loading state instead for a snappier user experience.
@@ -124,6 +125,7 @@ The following options **must be consistent** across all calls with the same key:
 - `pick` array
 - `getCachedData` function
 - `default` value
+- `retainPreviousDataOnKeyChange` value
 
 The following options **can differ** without triggering warnings:
 - `server`
@@ -185,6 +187,7 @@ type AsyncDataOptions<DataT> = {
   immediate?: boolean
   deep?: boolean
   dedupe?: 'cancel' | 'defer'
+  retainPreviousDataOnKeyChange?: boolean
   default?: () => DataT | Ref<DataT> | null
   transform?: (input: DataT) => DataT | Promise<DataT>
   pick?: string[]

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -755,5 +755,6 @@ function createHash (_handler: () => unknown, options: Partial<Record<keyof Asyn
     transform: options.transform ? hash(options.transform) : undefined,
     pick: options.pick ? hash(options.pick) : undefined,
     getCachedData: options.getCachedData ? hash(options.getCachedData) : undefined,
+    retainPreviousDataOnKeyChange: hash(options.retainPreviousDataOnKeyChange ?? true),
   }
 }

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -234,7 +234,7 @@ export function useAsyncData<
     if (values.handler !== currentData._hash?.handler) {
       warnings.push(`different handler`)
     }
-    for (const opt of ['transform', 'pick', 'getCachedData'] as const) {
+    for (const opt of ['transform', 'pick', 'getCachedData', 'retainPreviousDataOnKeyChange'] as const) {
       if (values[opt] !== currentData._hash![opt]) {
         warnings.push(`different \`${opt}\` option`)
       }

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -102,7 +102,7 @@ export interface AsyncDataOptions<
    * When a reactive key changes retain the data from the old key during handler exection.
    * @default true
    */
-  retainPreviousDataOnKeyChange: boolean
+  retainPreviousDataOnKeyChange?: boolean
 }
 
 export interface AsyncDataExecuteOptions {

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -98,6 +98,11 @@ export interface AsyncDataOptions<
    * @default 'cancel'
    */
   dedupe?: 'cancel' | 'defer'
+  /**
+   * When a reactive key changes retain the data from the old key during handler exection.
+   * @default true
+   */
+  retainPreviousDataOnKeyChange: boolean
 }
 
 export interface AsyncDataExecuteOptions {
@@ -216,6 +221,7 @@ export function useAsyncData<
   options.immediate ??= true
   options.deep ??= asyncDataDefaults.deep
   options.dedupe ??= 'cancel'
+  options.retainPreviousDataOnKeyChange ??= true
 
   // @ts-expect-error private property
   const functionName = options._functionName || 'useAsyncData'
@@ -334,7 +340,7 @@ export function useAsyncData<
         const initialFetchOptions: AsyncDataExecuteOptions = { cause: 'initial', dedupe: options.dedupe }
         if (!nuxtApp._asyncData[newKey]?._init) {
           let value: NoInfer<DataT> | undefined
-          if (oldKey && hasRun) {
+          if (options.retainPreviousDataOnKeyChange && oldKey && hasRun) {
             value = nuxtApp._asyncData[oldKey]?.data.value as NoInfer<DataT>
           } else {
             value = options.getCachedData!(newKey, nuxtApp, { cause: 'initial' })

--- a/test/nuxt/use-async-data.test.ts
+++ b/test/nuxt/use-async-data.test.ts
@@ -747,4 +747,30 @@ describe('useAsyncData', () => {
     expect(promiseFn).toHaveBeenCalledTimes(2)
     vi.useRealTimers()
   })
+
+  it('should not retain the old data when a computed key changes and retainPreviousDataOnKeyChange set to false', async () => {
+    vi.useFakeTimers()
+    const page = ref('index')
+    const promiseFn = vi.fn(() => new Promise(resolve => setTimeout(() => resolve(page.value), 100)))
+    const { data, status } = useAsyncData(() => page.value, promiseFn, { retainPreviousDataOnKeyChange: false })
+
+    vi.advanceTimersToNextTimer()
+    await flushPromises()
+    expect(data.value).toBe('index')
+    expect(promiseFn).toHaveBeenCalledTimes(1)
+
+    page.value = 'about'
+    await nextTick()
+    await flushPromises()
+    expect(promiseFn).toHaveBeenCalledTimes(2)
+    expect(data.value).toBe(undefined)
+    expect(status.value).toBe('pending')
+
+    vi.advanceTimersToNextTimer()
+    await flushPromises()
+    await nextTick()
+    expect(data.value).toBe('about')
+    expect(promiseFn).toHaveBeenCalledTimes(2)
+    vi.useRealTimers()
+  })
 })


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

initial resolution to #32836 

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

This PR introduces a config setting to `useAsyncData` to allow users to disable the behavior introduced in https://github.com/nuxt/nuxt/pull/32616.

I'm still not convinced that the default for this setting should be `true` but I don't wish to introduce a breaking change as the current behavior is non-configurable. I have also added this to the settings that cannot be different as this would cause inconsistent behavior if it was.

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
