### PR TITLE
fix: bump devalue

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "cssnano": "7.1.1",
     "defu": "6.1.4",
     "destr": "2.0.5",
-    "devalue": "5.1.1",
+    "devalue": "5.3.2",
     "eslint": "9.34.0",
     "eslint-plugin-import-x": "4.16.1",
     "eslint-plugin-no-only-tests": "3.3.0",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -84,7 +84,7 @@
     "cookie-es": "^2.0.0",
     "defu": "^6.1.4",
     "destr": "^2.0.5",
-    "devalue": "^5.1.1",
+    "devalue": "^5.3.2",
     "errx": "^0.1.0",
     "esbuild": "^0.25.9",
     "escape-string-regexp": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,8 +128,8 @@ importers:
         specifier: 2.0.5
         version: 2.0.5
       devalue:
-        specifier: 5.1.1
-        version: 5.1.1
+        specifier: 5.3.2
+        version: 5.3.2
       eslint:
         specifier: 9.34.0
         version: 9.34.0(jiti@2.5.1)
@@ -404,8 +404,8 @@ importers:
         specifier: ^2.0.5
         version: 2.0.5
       devalue:
-        specifier: ^5.1.1
-        version: 5.1.1
+        specifier: ^5.3.2
+        version: 5.3.2
       errx:
         specifier: ^0.1.0
         version: 0.1.0
@@ -4567,8 +4567,8 @@ packages:
     peerDependencies:
       typescript: 5.9.2
 
-  devalue@5.1.1:
-    resolution: {integrity: sha512-maua5KUiapvEwiEAe+XnlZ3Rh0GD+qI1J/nb9vrJc3muPXvcF/8gXYTWF76+5DAqHyDUtOIImEuo0YKE9mshVw==}
+  devalue@5.3.2:
+    resolution: {integrity: sha512-UDsjUbpQn9kvm68slnrs+mfxwFkIflOhkanmyabZ8zOYk8SMEIbJ3TK+88g70hSIeytu4y18f0z/hYHMTrXIWw==}
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
@@ -12290,7 +12290,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  devalue@5.1.1: {}
+  devalue@5.3.2: {}
 
   devlop@1.1.0:
     dependencies:

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -61,7 +61,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"194k"`)
 
     const modules = await analyzeSizes(['node_modules/**/*'], serverDir)
-    expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"1406k"`)
+    expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"1409k"`)
 
     const packages = modules.files
       .filter(m => m.endsWith('package.json'))
@@ -98,7 +98,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"548k"`)
 
     const modules = await analyzeSizes(['node_modules/**/*'], serverDir)
-    expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"79.2k"`)
+    expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"82.0k"`)
 
     const packages = modules.files
       .filter(m => m.endsWith('package.json'))
@@ -120,7 +120,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"288k"`)
 
     const modules = await analyzeSizes(['node_modules/**/*'], serverDir)
-    expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"1417k"`)
+    expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"1420k"`)
 
     const packages = modules.files
       .filter(m => m.endsWith('package.json'))


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/sveltejs/devalue/security/advisories/GHSA-vj54-72f3-p5jv

### 📚 Description

CVE-2025-57820 was recently reported in `devalue`. This PR upgrades Nuxt to the latest version