### PR TITLE
Nested layouts

### DIFF
--- a/docs/2.guide/2.directory-structure/1.app/1.pages.md
+++ b/docs/2.guide/2.directory-structure/1.app/1.pages.md
@@ -156,7 +156,50 @@ Navigating to `/hello/world` would render:
 
 It is possible to display [nested routes](https://next.router.vuejs.org/guide/essentials/nested-routes.html) with `<NuxtPage>`.
 
-Example:
+### Approach 1: Using parent/@layout.vue (Recommended)
+
+Create a layout file at `pages/parent/@layout.vue`:
+
+```bash [Directory Structure]
+-| pages/
+---| parent/
+-----| @layout.vue
+-----| child.vue
+```
+
+This file tree will generate these routes:
+
+```js
+[
+  {
+    path: '/parent',
+    component: '~/pages/parent/@layout.vue',
+    name: 'parent',
+    children: [
+      {
+        path: 'child',
+        component: '~/pages/parent/child.vue',
+        name: 'parent-child'
+      }
+    ]
+  }
+]
+```
+
+Insert the `<NuxtPage>` component inside `pages/parent/@layout.vue`:
+
+```vue {}[pages/parent/@layout.vue]
+<template>
+  <div>
+    <h1>I am the parent layout</h1>
+    <NuxtPage :foobar="123" />
+  </div>
+</template>
+```
+
+### Approach 2: Using parent.vue
+
+Create a page file at `pages/parent.vue`:
 
 ```bash [Directory Structure]
 -| pages/
@@ -184,7 +227,7 @@ This file tree will generate these routes:
 ]
 ```
 
-To display the `child.vue` component, you have to insert the `<NuxtPage>` component inside `pages/parent.vue`:
+Insert the `<NuxtPage>` component inside `pages/parent.vue`:
 
 ```vue {}[pages/parent.vue]
 <template>
@@ -195,6 +238,8 @@ To display the `child.vue` component, you have to insert the `<NuxtPage>` compon
 </template>
 ```
 
+Finally, create a child page file at `pages/parent/child.vue`:
+
 ```vue {}[pages/parent/child.vue]
 <script setup lang="ts">
 const props = defineProps(['foobar'])
@@ -202,6 +247,8 @@ const props = defineProps(['foobar'])
 console.log(props.foobar)
 </script>
 ```
+
+Both methods are well-supported, but using `@layout.vue` is the preferred approach as it provides better separation of concerns and takes priority over the page file when both exist.
 
 ### Child Route Keys
 

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -43,6 +43,7 @@ interface SegmentToken {
 interface ScannedFile {
   relativePath: string
   absolutePath: string
+  priority: number
 }
 
 const enUSComparator = new Intl.Collator('en-US')
@@ -54,12 +55,27 @@ export async function resolvePagesRoutes (pattern: string | string[], nuxt = use
   const scannedFiles: ScannedFile[] = []
   for (const dir of pagesDirs) {
     const files = await resolveFiles(dir, pattern)
-    scannedFiles.push(...files.map(file => ({ relativePath: relative(dir, file), absolutePath: file })))
+    scannedFiles.push(...files.map((file) => {
+      let relativePath = relative(dir, file)
+
+      // normalize @layout.vue → parent.vue
+      let priority = 0
+      if (relativePath.endsWith('/@layout.vue')) {
+        relativePath = relativePath.replace(/\/@layout.vue$/, '.vue')
+        priority = 1
+      }
+
+      return { relativePath, absolutePath: file, priority }
+    }))
   }
 
   // sort scanned files using en-US locale to make the result consistent across different system locales
-
-  scannedFiles.sort((a, b) => enUSComparator.compare(a.relativePath, b.relativePath))
+  scannedFiles.sort((a, b) => {
+    if (a.priority !== b.priority) {
+      return b.priority - a.priority
+    }
+    return enUSComparator.compare(a.relativePath, b.relativePath)
+  })
 
   const allRoutes = generateRoutesFromFiles(uniqueBy(scannedFiles, 'relativePath'), {
     shouldUseServerComponents: !!nuxt.options.experimental.componentIslands,


### PR DESCRIPTION
### 🔗 Linked issue

resolves #33073 

### 📚 Description

This PR introduces support for a **pseudo layout convention** using `@layout.vue` in nested routes.

Previously, nested routes required a `parent.vue` file to act as a wrapper for its children. With this change:

* If `parent/@layout.vue` exists, it **replaces `parent.vue`** as the route wrapper.
* Children (`parent/index.vue`, `parent/child.vue`, etc.) still render normally using `<NuxtPage />`.
* If both `parent.vue` and `parent/@layout.vue` exist, `@layout.vue` **takes priority** automatically.
* The scanned files normalization and sorting ensures that `@layout.vue` always overrides its corresponding `parent.vue`, without generating duplicate routes.

This improves clarity in larger projects by explicitly separating **route wrappers (pseudo layouts)** from individual pages, while maintaining full nested route functionality.

**Example usage:**

```
-| pages/
---| parent/
-----| @layout.vue   // acts as parent route wrapper
-----| child.vue
```

Generated routes:

```js
[
  {
    path: '/parent',
    component: '~/pages/parent/@layout.vue',
    name: 'parent',
    children: [
      { path: 'child', component: '~/pages/parent/child.vue', name: 'parent-child' }
    ]
  }
]
```

**Notes:**

* `<NuxtPage />` should be used inside `@layout.vue` to render child routes.
* Backward compatibility: if `parent.vue` exists without `@layout.vue`, the behavior remains unchanged.