### PR TITLE
feat(nuxt,vite): use importmap to increase chunk stability

### DIFF
--- a/docs/2.guide/3.going-further/1.experimental-features.md
+++ b/docs/2.guide/3.going-further/1.experimental-features.md
@@ -637,3 +637,23 @@ export default defineNuxtConfig({
   }
 })
 ```
+
+## entryImportMap
+
+Whether to improve chunk stability by using an import map to resolve the entry chunk of the bundle.
+
+This will inject an import map at the top of your `<head>` tag:
+
+```html
+<script type="importmap">{"imports":{"#entry":"/_nuxt/DC5HVSK5.js"}}</script>
+```
+
+Within the script chunks emitted by Vite, imports will be from `#entry`. This means that changes to the entry will not invalidate chunks which are otherwise unchanged.
+
+```ts twoslash [nuxt.config.ts]
+export default defineNuxtConfig({
+  experimental: {
+    entryImportMap: true
+  }
+})
+```

--- a/docs/2.guide/3.going-further/1.experimental-features.md
+++ b/docs/2.guide/3.going-further/1.experimental-features.md
@@ -660,7 +660,7 @@ If you need to disable this feature you can do so:
 export default defineNuxtConfig({
   experimental: {
     entryImportMap: false
-  }
+  },
 // or, better, simply tell vite your desired target
   // which nuxt will respect
   vite: {

--- a/docs/2.guide/3.going-further/1.experimental-features.md
+++ b/docs/2.guide/3.going-further/1.experimental-features.md
@@ -650,6 +650,10 @@ This injects an import map at the top of your `<head>` tag:
 
 Within the script chunks emitted by Vite, imports will be from `#entry`. This means that changes to the entry will not invalidate chunks which are otherwise unchanged.
 
+::note
+Nuxt smartly disables this feature if you have not configured `vite.build.target` to include a browser that doesn't support import maps, or if you have configured `vite.build.rollupOptions.output.entryFileNames` to a value that does not include `[hash]`.
+::
+
 If you need to disable this feature you can do so:
 
 ```ts twoslash [nuxt.config.ts]

--- a/docs/2.guide/3.going-further/1.experimental-features.md
+++ b/docs/2.guide/3.going-further/1.experimental-features.md
@@ -651,7 +651,7 @@ This injects an import map at the top of your `<head>` tag:
 Within the script chunks emitted by Vite, imports will be from `#entry`. This means that changes to the entry will not invalidate chunks which are otherwise unchanged.
 
 ::note
-Nuxt smartly disables this feature if you have not configured `vite.build.target` to include a browser that doesn't support import maps, or if you have configured `vite.build.rollupOptions.output.entryFileNames` to a value that does not include `[hash]`.
+Nuxt smartly disables this feature if you have configured `vite.build.target` to include a browser that doesn't support import maps, or if you have configured `vite.build.rollupOptions.output.entryFileNames` to a value that does not include `[hash]`.
 ::
 
 If you need to disable this feature you can do so:

--- a/docs/2.guide/3.going-further/1.experimental-features.md
+++ b/docs/2.guide/3.going-further/1.experimental-features.md
@@ -661,5 +661,12 @@ export default defineNuxtConfig({
   experimental: {
     entryImportMap: false
   }
+// or, better, simply tell vite your desired target
+  // which nuxt will respect
+  vite: {
+    build: {
+      target: 'safari13'
+    },
+  },
 })
 ```

--- a/docs/2.guide/3.going-further/1.experimental-features.md
+++ b/docs/2.guide/3.going-further/1.experimental-features.md
@@ -640,9 +640,9 @@ export default defineNuxtConfig({
 
 ## entryImportMap
 
-Whether to improve chunk stability by using an import map to resolve the entry chunk of the bundle.
+By default, Nuxt improves chunk stability by using an import map to resolve the entry chunk of the bundle.
 
-This will inject an import map at the top of your `<head>` tag:
+This injects an import map at the top of your `<head>` tag:
 
 ```html
 <script type="importmap">{"imports":{"#entry":"/_nuxt/DC5HVSK5.js"}}</script>
@@ -650,10 +650,12 @@ This will inject an import map at the top of your `<head>` tag:
 
 Within the script chunks emitted by Vite, imports will be from `#entry`. This means that changes to the entry will not invalidate chunks which are otherwise unchanged.
 
+If you need to disable this feature you can do so:
+
 ```ts twoslash [nuxt.config.ts]
 export default defineNuxtConfig({
   experimental: {
-    entryImportMap: true
+    entryImportMap: false
   }
 })
 ```

--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -130,6 +130,8 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
       '#internal/nuxt.config.mjs': () => nuxt.vfs['#build/nuxt.config.mjs'] || '',
       '#internal/nuxt/app-config': () => nuxt.vfs['#build/app.config.mjs']?.replace(/\/\*\* client \*\*\/[\s\S]*\/\*\* client-end \*\*\//, '') || '',
       '#spa-template': async () => `export const template = ${JSON.stringify(await spaLoadingTemplate(nuxt))}`,
+      // this will be overridden in vite plugin
+      '#internal/entry-chunk.mjs': () => `export const entryFileName = undefined`,
     },
     routeRules: {
       '/__nuxt_error': { cache: false },

--- a/packages/nuxt/src/core/runtime/nitro/handlers/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/handlers/renderer.ts
@@ -28,6 +28,8 @@ import { renderSSRHeadOptions } from '#internal/unhead.config.mjs'
 // @ts-expect-error virtual file
 import { appHead, appTeleportAttrs, appTeleportTag, componentIslands, appManifest as isAppManifestEnabled } from '#internal/nuxt.config.mjs'
 // @ts-expect-error virtual file
+import { entryFileName } from '#internal/entry-chunk.mjs'
+// @ts-expect-error virtual file
 import { buildAssetsURL, publicAssetsURL } from '#internal/nuxt/paths'
 
 // @ts-expect-error private property consumed by vite-generated url helpers
@@ -181,6 +183,18 @@ export default defineRenderHandler(async (event): Promise<Partial<RenderResponse
 
   // Setup head
   const { styles, scripts } = getRequestDependencies(ssrContext, renderer.rendererContext)
+
+  // 0. Add import map for stable chunk hashes
+  if (entryFileName && !NO_SCRIPTS) {
+    ssrContext.head.push({
+      script: [{
+        tagPosition: 'head',
+        tagPriority: -2,
+        type: 'importmap',
+        innerHTML: JSON.stringify({ imports: { '#entry': buildAssetsURL(entryFileName) } }),
+      }],
+    }, headEntryOptions)
+  }
   // 1. Preload payloads and app manifest
   if (_PAYLOAD_EXTRACTION && !NO_SCRIPTS) {
     ssrContext.head.push({

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -216,5 +216,6 @@ export default defineResolvers({
         return typeof val === 'boolean' ? val : false
       },
     },
+    entryImportMap: false,
   },
 })

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -216,6 +216,6 @@ export default defineResolvers({
         return typeof val === 'boolean' ? val : false
       },
     },
-    entryImportMap: false,
+    entryImportMap: true,
   },
 })

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1443,6 +1443,11 @@ export interface ConfigSchema {
      * For `useAsyncData` and `useFetch`, whether `pending` should be `true` when data has not yet started to be fetched.
      */
     pendingWhenIdle: boolean
+
+    /**
+     * Whether to improve chunk stability by using an import map to resolve the entry chunk of the bundle.
+     */
+    entryImportMap: boolean
   }
 
   /**

--- a/packages/vite/src/client.ts
+++ b/packages/vite/src/client.ts
@@ -20,6 +20,7 @@ import { TypeCheckPlugin } from './plugins/type-check'
 import { ModulePreloadPolyfillPlugin } from './plugins/module-preload-polyfill'
 import { ViteNodePlugin } from './vite-node'
 import { createViteLogger } from './utils/logger'
+import { StableEntryPlugin } from './plugins/stable-entry'
 
 export async function buildClient (nuxt: Nuxt, ctx: ViteBuildContext) {
   const nodeCompat = nuxt.options.experimental.clientNodeCompat
@@ -132,6 +133,8 @@ export async function buildClient (nuxt: Nuxt, ctx: ViteBuildContext) {
       // Type checking client panel
       TypeCheckPlugin(nuxt),
       ModulePreloadPolyfillPlugin(),
+      // ensure changes in chunks do not invalidate whole build
+      StableEntryPlugin(nuxt),
     ],
     appType: 'custom',
     server: {

--- a/packages/vite/src/plugins/stable-entry.ts
+++ b/packages/vite/src/plugins/stable-entry.ts
@@ -1,0 +1,53 @@
+import { useNitro } from '@nuxt/kit'
+import type { Nuxt } from '@nuxt/schema'
+import escapeStringRegexp from 'escape-string-regexp'
+import MagicString from 'magic-string'
+import { basename } from 'pathe'
+import { withoutLeadingSlash } from 'ufo'
+import type { Plugin } from 'vite'
+
+export function StableEntryPlugin (nuxt: Nuxt): Plugin {
+  let sourcemap: boolean
+  let entryFileName: string | undefined
+
+  const nitro = useNitro()
+
+  nitro.options.virtual ||= {}
+  nitro.options._config.virtual ||= {}
+
+  nitro.options._config.virtual['#internal/entry-chunk.mjs'] = nitro.options.virtual['#internal/entry-chunk.mjs'] = () => `export const entryFileName = ${JSON.stringify(entryFileName)}`
+
+  return {
+    name: 'nuxt:stable-entry',
+    configResolved (config) {
+      sourcemap = !!config.build.sourcemap
+    },
+    applyToEnvironment: environment => environment.name === 'client',
+    apply: () => !nuxt.options.dev && nuxt.options.experimental.entryImportMap,
+    renderChunk (code, chunk, _options, meta) {
+      const entry = Object.values(meta.chunks).find(chunk => chunk.isEntry && chunk.name === 'entry')?.fileName
+      if (!entry || !chunk.imports.includes(entry)) {
+        return
+      }
+
+      const filename = new RegExp(`(?<=['"])[\\./]*${escapeStringRegexp(basename(entry))}`, 'g')
+      const s = new MagicString(code)
+      s.replaceAll(filename, '#entry')
+
+      if (s.hasChanged()) {
+        return {
+          code: s.toString(),
+          map: sourcemap ? s.generateMap({ hires: true }) : undefined,
+        }
+      }
+    },
+    writeBundle (_options, bundle) {
+      let entry = Object.values(bundle).find(chunk => chunk.type === 'chunk' && chunk.isEntry && chunk.name === 'entry')?.fileName
+      const prefix = withoutLeadingSlash(nuxt.options.app.buildAssetsDir)
+      if (entry?.startsWith(prefix)) {
+        entry = entry.slice(prefix.length)
+      }
+      entryFileName = entry
+    },
+  }
+}

--- a/packages/vite/src/plugins/stable-entry.ts
+++ b/packages/vite/src/plugins/stable-entry.ts
@@ -24,9 +24,15 @@ export function StableEntryPlugin (nuxt: Nuxt): Plugin {
       sourcemap = !!config.build.sourcemap
     },
     applyToEnvironment: environment => environment.name === 'client',
-    apply: (config) => {
+    apply (config) {
       if (nuxt.options.dev || !nuxt.options.experimental.entryImportMap) {
         return false
+      }
+      if (config.build?.target) {
+        const targets = toArray(config.build.target)
+        if (!targets.every(isSupported)) {
+          return false
+        }
       }
       // only apply plugin if the entry file name is hashed
       return toArray(config.build?.rollupOptions?.output).some(output => typeof output?.entryFileNames === 'string' && output?.entryFileNames.includes('[hash]'))
@@ -57,4 +63,25 @@ export function StableEntryPlugin (nuxt: Nuxt): Plugin {
       entryFileName = entry
     },
   }
+}
+
+// https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap#browser_compatibility
+const supportedEnvironments = {
+  chrome: 89,
+  edge: 89,
+  firefox: 108,
+  ie: Infinity,
+  ios: 16.4,
+  opera: 75,
+  safari: 16.4,
+}
+
+function isSupported (target: string) {
+  const [engine, _version] = target.split(/(?<=[a-z])(?=\d)/)
+  const constraint = supportedEnvironments[engine as keyof typeof supportedEnvironments]
+  if (!constraint) {
+    return true
+  }
+  const version = Number(_version)
+  return Number.isNaN(version) || Number(version) >= constraint
 }

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -152,6 +152,7 @@ export default defineNuxtConfig({
     inlineStyles: id => !!id && !id.includes('assets.vue'),
   },
   experimental: {
+    entryImportMap: true,
     decorators: true,
     typedPages: true,
     clientFallback: true,

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -152,7 +152,6 @@ export default defineNuxtConfig({
     inlineStyles: id => !!id && !id.includes('assets.vue'),
   },
   experimental: {
-    entryImportMap: true,
     decorators: true,
     typedPages: true,
     clientFallback: true,


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/27863

related: https://github.com/nuxt/nuxt/issues/26565 and https://github.com/nuxt/nuxt/issues/29624


### 📚 Description

#### Background

By default, JS chunks emitted in a vite build are hashed. This means they can be cached immutably because their content never changes without a file name change.

However, there are some very significant consequences. Namely, a change to a single component in a Nuxt build can cause _every_ hash to be invalidated, massively increasing the chance of 404s.

Here's an example:

1. a component is changed slightly. the hash of its JS chunk changes
2. the page which uses the component has to be updated to reference the new file name
3. the _entry_ now has its hash changed because it dynamically imports the page
4. _**EVERY OTHER FILE**_ which imports the entry has its hash changed because the entry file name is changed.

In a Nuxt app almost every file will import the entry, so it is particularly prone to this.

Other projects, like Vitepress, use a static hashmap which is embedded in the HTML and allows mapping every chunk.

#### Approach

This PR improves chunk stability by using an [import map](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap) to resolve the entry chunk of the bundle.

This injects an import map at the top of your `<head>` tag:

```html
<script type="importmap">{"imports":{"#entry":"/_nuxt/DC5HVSK5.js"}}</script>
```

Within the script chunks emitted by Vite, imports will be from `#entry`. This means that changes to the entry will not invalidate chunks which are otherwise unchanged. In the example above, steps 1, 2 and 3 still occur, but at that point a 'boundary' is in place and the rest of the project does not have its hashes invalidated.

Importantly, although we are rewriting imports to use `#entry` they are still treated as hashed assets by the browser so this should not impact (desired) cache invalidation.

This is more lightweight than the Vitepress approach of embedding a hashmap of the entire project.

If you need to disable this feature (to support Safari <16.4, for example - cross-browser lack of support for import maps is at [1.75%](https://caniuse.com/import-maps)) you can do so:

```ts twoslash [nuxt.config.ts]
export default defineNuxtConfig({
  experimental: {
    entryImportMap: false
  },
  // or, better, simply tell vite your desired target
  // which nuxt will respect
  vite: {
    build: {
      target: 'safari13'
    },
  },
})
```