### PR TITLE
refactor(kit,nuxt,ui-templates,vite): address deprecations + improve regexp perf

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,7 @@ import noOnlyTests from 'eslint-plugin-no-only-tests'
 import typegen from 'eslint-typegen'
 import perfectionist from 'eslint-plugin-perfectionist'
 import { importX } from 'eslint-plugin-import-x'
+import parser from '@typescript-eslint/parser'
 
 import { runtimeDependencies } from './packages/nuxt/src/meta.mjs'
 
@@ -14,6 +15,7 @@ export default createConfigForNuxt({
       commaDangle: 'always-multiline',
     },
     tooling: true,
+    typescript: true,
   },
 })
   .prepend(
@@ -91,6 +93,21 @@ export default createConfigForNuxt({
         // TODO: Discuss if we want to enable this
         '@typescript-eslint/no-invalid-void-type': 'off',
       },
+    },
+  })
+
+  .append({
+    files: ['packages/**/*.{mjs,js,ts}'],
+    ignores: ['packages/nuxt/src/app/types/augments.ts'],
+    languageOptions: {
+      parser,
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-deprecated': 'error',
     },
   })
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -98,7 +98,10 @@ export default createConfigForNuxt({
 
   .append({
     files: ['packages/**/*.{mjs,js,ts}', '**/*.{spec,test}.{mjs,js,ts}'],
-    ignores: ['packages/nuxt/src/app/types/augments.ts'],
+    ignores: [
+      'packages/nuxt/src/app/types/augments.ts',
+      'test/fixtures/basic/app/plugins/this-should-not-load.spec.js',
+    ],
     languageOptions: {
       parser,
       parserOptions: {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -97,7 +97,7 @@ export default createConfigForNuxt({
   })
 
   .append({
-    files: ['packages/**/*.{mjs,js,ts}'],
+    files: ['packages/**/*.{mjs,js,ts}', '**/*.{spec,test}.{mjs,js,ts}'],
     ignores: ['packages/nuxt/src/app/types/augments.ts'],
     languageOptions: {
       parser,

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "@types/babel__helper-plugin-utils": "7.10.3",
     "@types/node": "22.18.0",
     "@types/semver": "7.7.0",
+    "@typescript-eslint/parser": "8.41.0",
     "@unhead/vue": "2.0.14",
     "@vitest/coverage-v8": "3.2.4",
     "@vue/test-utils": "2.4.6",

--- a/packages/kit/src/context.ts
+++ b/packages/kit/src/context.ts
@@ -29,6 +29,7 @@ export const getNuxtCtx = () => asyncNuxtStorage.tryUse()
  * ```
  */
 export function useNuxt (): Nuxt {
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   const instance = asyncNuxtStorage.tryUse() || nuxtCtx.tryUse()
   if (!instance) {
     throw new Error('Nuxt instance is unavailable!')
@@ -49,6 +50,7 @@ export function useNuxt (): Nuxt {
  * ```
  */
 export function tryUseNuxt (): Nuxt | null {
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   return asyncNuxtStorage.tryUse() || nuxtCtx.tryUse()
 }
 

--- a/packages/kit/src/internal/esm.ts
+++ b/packages/kit/src/internal/esm.ts
@@ -33,6 +33,7 @@ export function tryResolveModule (id: string, url: string | string[] | URL | URL
 
 export function resolveModule (id: string, options?: ResolveModuleOptions) {
   return resolveModulePath(id, {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     from: options?.url ?? options?.paths ?? [import.meta.url],
     extensions: ['.js', '.mjs', '.cjs', '.ts', '.mts', '.cts'],
   })
@@ -73,6 +74,7 @@ export function requireModule<T = unknown> (id: string, opts?: ImportModuleOptio
   const jiti = createJiti(import.meta.url, {
     interopDefault: opts?.interopDefault !== false,
   })
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   return jiti(pathToFileURL(resolvedPath).href) as T
 }
 
@@ -81,6 +83,7 @@ export function requireModule<T = unknown> (id: string, opts?: ImportModuleOptio
  */
 export function tryRequireModule<T = unknown> (id: string, opts?: ImportModuleOptions) {
   try {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return requireModule<T>(id, opts)
   } catch {
     // intentionally empty as this is a `try-` function

--- a/packages/kit/src/plugin.ts
+++ b/packages/kit/src/plugin.ts
@@ -42,6 +42,7 @@ export function normalizePlugin (plugin: NuxtPlugin | string): NuxtPlugin {
   }
 
   // Normalize mode
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   if (plugin.ssr) {
     plugin.mode = 'server'
   }

--- a/packages/nuxt/src/components/plugins/islands-transform.ts
+++ b/packages/nuxt/src/components/plugins/islands-transform.ts
@@ -16,7 +16,8 @@ interface ServerOnlyComponentTransformPluginOptions {
   selectiveClient?: boolean | 'deep'
 }
 
-const SCRIPT_RE = /<script[^>]*>/gi
+const SCRIPT_RE = /<script[^>]*>/i
+const SCRIPT_RE_GLOBAL = /<script[^>]*>/gi
 const HAS_SLOT_OR_CLIENT_RE = /<slot[^>]*>|nuxt-client/
 const TEMPLATE_RE = /<template>[\s\S]*<\/template>/
 const NUXTCLIENT_ATTR_RE = /\s:?nuxt-client(?:="[^"]*")?/g
@@ -59,7 +60,7 @@ export const IslandsTransformPlugin = (options: ServerOnlyComponentTransformPlug
         if (!SCRIPT_RE.test(code)) {
           s.prepend('<script setup>' + IMPORT_CODE + '</script>')
         } else {
-          s.replace(SCRIPT_RE, (full) => {
+          s.replace(SCRIPT_RE_GLOBAL, (full) => {
             return full + IMPORT_CODE
           })
         }

--- a/packages/nuxt/src/components/plugins/islands-transform.ts
+++ b/packages/nuxt/src/components/plugins/islands-transform.ts
@@ -18,10 +18,10 @@ interface ServerOnlyComponentTransformPluginOptions {
 
 const SCRIPT_RE = /<script[^>]*>/gi
 const HAS_SLOT_OR_CLIENT_RE = /<slot[^>]*>|nuxt-client/
-const TEMPLATE_RE = /<template>([\s\S]*)<\/template>/
-const NUXTCLIENT_ATTR_RE = /\s:?nuxt-client(="[^"]*")?/g
+const TEMPLATE_RE = /<template>[\s\S]*<\/template>/
+const NUXTCLIENT_ATTR_RE = /\s:?nuxt-client(?:="[^"]*")?/g
 const IMPORT_CODE = '\nimport { mergeProps as __mergeProps } from \'vue\'' + '\nimport { vforToArray as __vforToArray } from \'#app/components/utils\'' + '\nimport NuxtTeleportIslandComponent from \'#app/components/nuxt-teleport-island-component\'' + '\nimport NuxtTeleportSsrSlot from \'#app/components/nuxt-teleport-island-slot\''
-const EXTRACTED_ATTRS_RE = /v-(?:if|else-if|else)(="[^"]*")?/g
+const EXTRACTED_ATTRS_RE = /v-(?:if|else-if|else)(?:="[^"]*")?/g
 const KEY_RE = /:?key="[^"]"/g
 
 function wrapWithVForDiv (code: string, vfor: string): string {
@@ -56,7 +56,7 @@ export const IslandsTransformPlugin = (options: ServerOnlyComponentTransformPlug
         const startingIndex = template.index || 0
         const s = new MagicString(code)
 
-        if (!code.match(SCRIPT_RE)) {
+        if (!SCRIPT_RE.test(code)) {
           s.prepend('<script setup>' + IMPORT_CODE + '</script>')
         } else {
           s.replace(SCRIPT_RE, (full) => {

--- a/packages/nuxt/src/components/plugins/lazy-hydration-transform.ts
+++ b/packages/nuxt/src/components/plugins/lazy-hydration-transform.ts
@@ -81,7 +81,7 @@ export const LazyHydrationTransformPlugin = (options: LoaderOptions) => createUn
               return
             }
 
-            const pascalName = pascalCase(node.name.replace(/^(Lazy|lazy-)/, ''))
+            const pascalName = pascalCase(node.name.replace(/^(?:Lazy|lazy-)/, ''))
             if (!components.has(pascalName)) {
               // not auto-imported
               return

--- a/packages/nuxt/src/components/scan.ts
+++ b/packages/nuxt/src/components/scan.ts
@@ -11,8 +11,8 @@ import type { Component, ComponentsDir } from 'nuxt/schema'
 
 const ISLAND_RE = /\.island(?:\.global)?$/
 const GLOBAL_RE = /\.global(?:\.island)?$/
-const COMPONENT_MODE_RE = /(?<=\.)(client|server)(\.global|\.island)*$/
-const MODE_REPLACEMENT_RE = /(\.(client|server))?(\.global|\.island)*$/
+const COMPONENT_MODE_RE = /(?<=\.)(client|server)(?:\.global|\.island)*$/
+const MODE_REPLACEMENT_RE = /(?:\.(?:client|server))?(?:\.global|\.island)*$/
 /**
  * Scan the components inside different components folders
  * and return a unique list of components

--- a/packages/nuxt/src/core/builder.ts
+++ b/packages/nuxt/src/core/builder.ts
@@ -26,11 +26,11 @@ export async function build (nuxt: Nuxt) {
         const path = resolve(nuxt.options.srcDir, relativePath)
         for (const layer of nuxt.options._layers) {
           const relativePath = relative(layer.config.srcDir || layer.cwd, path)
-          if (relativePath.match(/^app\./i)) {
+          if (/^app\./i.test(relativePath)) {
             app.mainComponent = undefined
             break
           }
-          if (relativePath.match(/^error\./i)) {
+          if (/^error\./i.test(relativePath)) {
             app.errorComponent = undefined
             break
           }

--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -266,6 +266,7 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
     logLevel: logLevelMapReverse[nuxt.options.logLevel],
   } satisfies NitroConfig)
 
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   if (nuxt.options.experimental.serverAppConfig && nitroConfig.imports) {
     nitroConfig.imports.imports ||= []
     nitroConfig.imports.imports.push({

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -124,10 +124,14 @@ export function createNuxt (options: NuxtOptions): Nuxt {
     })
   }
 
+  // TODO: remove in nuxt v5
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   if (!nuxtCtx.tryUse()) {
     // backward compatibility with 3.x
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     nuxtCtx.set(nuxt)
     nuxt.hook('close', () => {
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       nuxtCtx.unset()
     })
   }

--- a/packages/nuxt/src/core/plugins/plugin-metadata.ts
+++ b/packages/nuxt/src/core/plugins/plugin-metadata.ts
@@ -44,7 +44,7 @@ export function extractMetadata (code: string, loader = 'ts' as 'ts' | 'tsx') {
   if (metaCache[code]) {
     return metaCache[code]
   }
-  if (code.match(/defineNuxtPlugin\s*\([\w(]/)) {
+  if (/defineNuxtPlugin\s*\([\w(]/.test(code)) {
     return {}
   }
   parseAndWalk(code, `file.${loader}`, (node) => {

--- a/packages/nuxt/src/core/plugins/plugin-metadata.ts
+++ b/packages/nuxt/src/core/plugins/plugin-metadata.ts
@@ -44,6 +44,7 @@ export function extractMetadata (code: string, loader = 'ts' as 'ts' | 'tsx') {
   if (metaCache[code]) {
     return metaCache[code]
   }
+  // non-object syntax plugin
   if (/defineNuxtPlugin\s*\([\w(]/.test(code)) {
     return {}
   }

--- a/packages/nuxt/src/core/runtime/nitro/handlers/island.ts
+++ b/packages/nuxt/src/core/runtime/nitro/handlers/island.ts
@@ -14,7 +14,7 @@ import { renderInlineStyles } from '../utils/renderer/inline-styles'
 import { getClientIslandResponse, getServerComponentHTML, getSlotIslandResponse } from '../utils/renderer/islands'
 import type { NuxtIslandContext, NuxtIslandResponse } from '../utils/renderer/islands'
 
-const ISLAND_SUFFIX_RE = /\.json(\?.*)?$/
+const ISLAND_SUFFIX_RE = /\.json(?:\?.*)?$/
 
 export default defineEventHandler(async (event) => {
   const nitroApp = useNitroApp()
@@ -75,6 +75,7 @@ export default defineEventHandler(async (event) => {
 
   const islandHead: SerializableHead = {}
   for (const entry of ssrContext.head.entries.values()) {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     for (const [key, value] of Object.entries(resolveUnrefHeadInput(entry.input as any) as SerializableHead)) {
       const currentValue = islandHead[key as keyof SerializableHead]
       if (Array.isArray(currentValue)) {

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -58,7 +58,7 @@ export const cssTemplate: NuxtTemplate = {
   getContents: ctx => ctx.nuxt.options.css.map(i => genImport(i)).join('\n'),
 }
 
-const PLUGIN_TEMPLATE_RE = /_(45|46|47)/g
+const PLUGIN_TEMPLATE_RE = /_(?:45|46|47)/g
 export const clientPluginTemplate: NuxtTemplate = {
   filename: 'plugins.client.mjs',
   async getContents (ctx) {

--- a/packages/nuxt/src/dirs.ts
+++ b/packages/nuxt/src/dirs.ts
@@ -2,6 +2,6 @@ import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'pathe'
 
 let _distDir = dirname(fileURLToPath(import.meta.url))
-if (_distDir.match(/(chunks|shared)$/)) { _distDir = dirname(_distDir) }
+if (/(?:chunks|shared)$/.test(_distDir)) { _distDir = dirname(_distDir) }
 export const distDir = _distDir
 export const pkgDir = resolve(distDir, '..')

--- a/packages/nuxt/src/head/runtime/composables.ts
+++ b/packages/nuxt/src/head/runtime/composables.ts
@@ -52,6 +52,7 @@ export function useSeoMeta (input: UseSeoMetaInput, options: NuxtUseHeadOptions 
  */
 export function useServerHead (input: UseHeadInput, options: NuxtUseHeadOptions = {}): ActiveHeadEntry<UseHeadInput> {
   const head = injectHead(options.nuxt)
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   return serverHead(input, { head, ...options }) as ActiveHeadEntry<UseHeadInput>
 }
 
@@ -60,6 +61,7 @@ export function useServerHead (input: UseHeadInput, options: NuxtUseHeadOptions 
  */
 export function useServerHeadSafe (input: UseHeadSafeInput, options: NuxtUseHeadOptions = {}): ActiveHeadEntry<UseHeadSafeInput> {
   const head = injectHead(options.nuxt)
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   return serverHeadSafe(input, { head, ...options }) as ActiveHeadEntry<UseHeadSafeInput>
 }
 
@@ -68,5 +70,6 @@ export function useServerHeadSafe (input: UseHeadSafeInput, options: NuxtUseHead
  */
 export function useServerSeoMeta (input: UseSeoMetaInput, options: NuxtUseHeadOptions = {}): ActiveHeadEntry<UseSeoMetaInput> {
   const head = injectHead(options.nuxt)
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
   return serverSeoMeta(input, { head, ...options }) as ActiveHeadEntry<UseSeoMetaInput>
 }

--- a/packages/nuxt/src/pages/plugins/page-meta.ts
+++ b/packages/nuxt/src/pages/plugins/page-meta.ts
@@ -146,7 +146,7 @@ export const PageMetaPlugin = (options: PageMetaPluginOptions = {}) => createUnp
       const addedDeclarations = new Set<string>()
 
       function addDeclaration (node: ScopeTrackerNode) {
-        const codeSectionKey = `${node.start}-${node.end}`
+        const codeSectionKey = `${resolveStart(node)}-${resolveEnd(node)}`
         if (addedDeclarations.has(codeSectionKey)) { return }
         addedDeclarations.add(codeSectionKey)
         declarationNodes.push(node)
@@ -278,7 +278,7 @@ export const PageMetaPlugin = (options: PageMetaPluginOptions = {}) => createUnp
                   declaration.isUnderScope(definePageMetaScope)
                   // ensures that we compare the correct declaration to the reference
                   // (when in the same scope, the declaration must come before the reference, otherwise it must be in a parent scope)
-                  && (scopeTracker.isCurrentScopeUnder(declaration.scope) || declaration.start < node.start)
+                  && (scopeTracker.isCurrentScopeUnder(declaration.scope) || resolveStart(declaration) < node.start)
                 ) {
                   return
                 }
@@ -295,8 +295,8 @@ export const PageMetaPlugin = (options: PageMetaPluginOptions = {}) => createUnp
           const importStatements = Array.from(addedImports).join('\n')
 
           const declarations = declarationNodes
-            .sort((a, b) => a.start - b.start)
-            .map(node => code.slice(node.start, node.end))
+            .sort((a, b) => resolveStart(a) - resolveStart(b))
+            .map(node => code.slice(resolveStart(node), resolveEnd(node)))
             .join('\n')
 
           const extracted = [
@@ -360,4 +360,11 @@ function parseMacroQuery (id: string) {
 const QUOTED_SPECIFIER_RE = /(["']).*\1/
 function getQuotedSpecifier (id: string) {
   return id.match(QUOTED_SPECIFIER_RE)?.[0]
+}
+
+function resolveStart (node: ScopeTrackerNode) {
+  return 'fnNode' in node ? node.fnNode.start : node.start
+}
+function resolveEnd (node: ScopeTrackerNode) {
+  return 'fnNode' in node ? node.fnNode.end : node.end
 }

--- a/packages/nuxt/test/pages.test.ts
+++ b/packages/nuxt/test/pages.test.ts
@@ -41,7 +41,7 @@ describe('pages:generateRoutesFromFiles', () => {
           const files = test.files.map(file => ({
             shouldUseServerComponents: true,
             absolutePath: file.path,
-            relativePath: file.path.replace(/^(pages|layer\/pages)\//, ''),
+            relativePath: file.path.replace(/^(?:pages|layer\/pages)\//, ''),
           })).sort((a, b) => enUSComparator.compare(a.relativePath, b.relativePath))
 
           result = generateRoutesFromFiles(files).map((route, index) => {

--- a/packages/ui-templates/lib/dev.ts
+++ b/packages/ui-templates/lib/dev.ts
@@ -28,7 +28,7 @@ export const DevRenderingPlugin = () => {
 
       const messages = JSON.parse(await fsp.readFile(r(page, 'messages.json'), 'utf-8'))
 
-      const chunks = contents.split(/\{{2,3}[^{}]+\}{2,3}/g)
+      const chunks = contents.split(/\{{2,3}[^{}]+\}{2,3}/)
       let templateString = chunks.shift()
       for (const expression of contents.matchAll(/\{{2,3}([^{}]+)\}{2,3}/g)) {
         const value = runInNewContext(expression[1]!.trim(), {

--- a/packages/ui-templates/lib/render.ts
+++ b/packages/ui-templates/lib/render.ts
@@ -58,7 +58,7 @@ export const RenderPlugin = () => {
         // Inline SVGs
         const svgSources: string[] = []
 
-        for (const [_, src] of html.matchAll(/src="([^"]+)"|url([^)]+)/g)) {
+        for (const [_, src] of html.matchAll(/src="([^"]+)"|url\([^)]+\)/g)) {
           if (src?.match(/\.svg$/)) {
             svgSources.push(src)
           }
@@ -99,7 +99,7 @@ export const RenderPlugin = () => {
         const messages = JSON.parse(readFileSync(r(`templates/${templateName}/messages.json`), 'utf-8'))
 
         // Serialize into a js function
-        const chunks = html.split(/\{{2,3}[^{}]+\}{2,3}/g).map(chunk => JSON.stringify(chunk))
+        const chunks = html.split(/\{{2,3}[^{}]+\}{2,3}/).map(chunk => JSON.stringify(chunk))
         const hasMessages = chunks.length > 1
         let hasExpression = false
         let templateString = chunks.shift()
@@ -123,22 +123,22 @@ export const RenderPlugin = () => {
         ].join('\n')
 
         const templateContent = html
-          .match(/<body[^>]*>([\s\S]*)<\/body>/)?.[0]
+          .match(/<body[^>]*>[\s\S]*<\/body>/)?.[0]
           .replace(/(?<=<\/|<)body/g, 'div')
           .replace(/messages\./g, '')
-          .replace(/<script[^>]*>([\s\S]*?)<\/script>/g, '')
+          .replace(/<script[^>]*>[\s\S]*?<\/script>/g, '')
           .replace(/<a href="(\/[^"]*)"([^>]*)>([\s\S]*)<\/a>/g, '<NuxtLink to="$1"$2>\n$3\n</NuxtLink>')
 
-          .replace(/<([^>]+) ([a-z]+)="([^"]*)(\{\{\s*(\w+)\s*\}\})([^"]*)"([^>]*)>/g, '<$1 :$2="`$3${$5}$6`"$7>')
+          .replace(/<([^>]+) ([a-z]+)="([^"]*)\{\{\s*(\w+)\s*\}\}([^"]*)"([^>]*)>/g, '<$1 :$2="`$3${$4}$5`"$6>')
           .replace(/>\{\{\s*(\w+)\s*\}\}<\/[\w-]*>/g, ' v-text="$1" />')
           .replace(/>\{\{\{\s*(\w+)\s*\}\}\}<\/[\w-]*>/g, ' v-html="$1" />')
         // We are not matching <link> <script> and <meta> tags as these aren't used yet in nuxt/ui
         // and should be taken care of wherever this SFC is used
-        const title = html.match(/<title[^>]*>([\s\S]*)<\/title>/)?.[1]?.replace(/\{\{([\s\S]+?)\}\}/g, (r) => {
+        const title = html.match(/<title[^>]*>([\s\S]*)<\/title>/)?.[1]?.replace(/\{\{[\s\S]+?\}\}/g, (r) => {
           return `\${${r.slice(2, -2)}}`.replace(/messages\./g, 'props.')
         })
         const styleContent = Array.from(html.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/g)).map(block => block[1]).join('\n')
-        const globalStyles = styleContent.replace(/(\.[^{\d][^{]*\{[^}]*\})+.?/g, (r) => {
+        const globalStyles = styleContent.replace(/(?:\.[^{\d][^{]*\{[^}]*\})+.?/g, (r) => {
           const lastChar = r[r.length - 1]
           if (lastChar && !['}', '.', '@', '*', ':'].includes(lastChar)) {
             return ';' + lastChar

--- a/packages/ui-templates/uno.config.ts
+++ b/packages/ui-templates/uno.config.ts
@@ -1,8 +1,8 @@
-import { defineConfig, presetUno } from 'unocss'
+import { defineConfig, presetWind3 } from 'unocss'
 
 export default defineConfig({
   presets: [
-    presetUno({
+    presetWind3({
       dark: 'media',
     }),
   ],

--- a/packages/vite/src/dirs.ts
+++ b/packages/vite/src/dirs.ts
@@ -2,5 +2,5 @@ import { fileURLToPath } from 'node:url'
 import { dirname } from 'pathe'
 
 let _distDir = dirname(fileURLToPath(import.meta.url))
-if (_distDir.match(/(chunks|shared)$/)) { _distDir = dirname(_distDir) }
+if (/(?:chunks|shared)$/.test(_distDir)) { _distDir = dirname(_distDir) }
 export const distDir = _distDir

--- a/packages/vite/src/runtime/vite-node.mjs
+++ b/packages/vite/src/runtime/vite-node.mjs
@@ -15,7 +15,7 @@ let render
 export default async (ssrContext) => {
   // Workaround for stub mode
   // https://github.com/nuxt/framework/pull/3983
-  // eslint-disable-next-line nuxt/prefer-import-meta
+  // eslint-disable-next-line nuxt/prefer-import-meta,@typescript-eslint/no-deprecated
   process.server = true
   import.meta.server = true
 

--- a/packages/vite/src/utils/warmup.ts
+++ b/packages/vite/src/utils/warmup.ts
@@ -24,7 +24,7 @@ function normaliseURL (url: string, base: string) {
     url = url.slice('/@id/'.length).replace('__x00__', '\0')
   }
   // strip query
-  url = url.replace(/(\?|&)import=?(?:&|$)/, '').replace(/[?&]$/, '')
+  url = url.replace(/[?&]import=?(?:&|$)/, '').replace(/[?&]$/, '')
   return url
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,9 @@ importers:
       '@types/semver':
         specifier: 7.7.0
         version: 7.7.0
+      '@typescript-eslint/parser':
+        specifier: 8.41.0
+        version: 8.41.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)
       '@unhead/vue':
         specifier: 2.0.14
         version: 2.0.14(vue@3.5.20(typescript@5.9.2))
@@ -1188,7 +1191,7 @@ importers:
         version: 1.6.1
       unplugin:
         specifier: latest
-        version: 2.3.8
+        version: 2.3.9
       vue:
         specifier: 3.5.20
         version: 3.5.20(typescript@5.9.2)
@@ -3187,8 +3190,8 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: 5.9.2
 
-  '@typescript-eslint/parser@8.39.1':
-    resolution: {integrity: sha512-pUXGCuHnnKw6PyYq93lLRiZm3vjuslIy7tus1lIQTYVK9bL8XBgJnCWm8a0KcTtHC84Yya1Q6rtll+duSMj0dg==}
+  '@typescript-eslint/parser@8.41.0':
+    resolution: {integrity: sha512-gTtSdWX9xiMPA/7MV9STjJOOYtWwIJIYxkQxnSV1U3xcE+mnJSH3f6zI0RYP+ew66WSlZ5ed+h0VCxsvdC1jJg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -3200,12 +3203,28 @@ packages:
     peerDependencies:
       typescript: 5.9.2
 
+  '@typescript-eslint/project-service@8.41.0':
+    resolution: {integrity: sha512-b8V9SdGBQzQdjJ/IO3eDifGpDBJfvrNTp2QD9P2BeqWTGrRibgfgIlBSw6z3b6R7dPzg752tOs4u/7yCLxksSQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: 5.9.2
+
   '@typescript-eslint/scope-manager@8.39.1':
     resolution: {integrity: sha512-RkBKGBrjgskFGWuyUGz/EtD8AF/GW49S21J8dvMzpJitOF1slLEbbHnNEtAHtnDAnx8qDEdRrULRnWVx27wGBw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/scope-manager@8.41.0':
+    resolution: {integrity: sha512-n6m05bXn/Cd6DZDGyrpXrELCPVaTnLdPToyhBoFkLIMznRUQUEQdSp96s/pcWSQdqOhrgR1mzJ+yItK7T+WPMQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/tsconfig-utils@8.39.1':
     resolution: {integrity: sha512-ePUPGVtTMR8XMU2Hee8kD0Pu4NDE1CN9Q1sxGSGd/mbOtGZDM7pnhXNJnzW63zk/q+Z54zVzj44HtwXln5CvHA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: 5.9.2
+
+  '@typescript-eslint/tsconfig-utils@8.41.0':
+    resolution: {integrity: sha512-TDhxYFPUYRFxFhuU5hTIJk+auzM/wKvWgoNYOPcOf6i4ReYlOoYN8q1dV5kOTjNQNJgzWN3TUUQMtlLOcUgdUw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: 5.9.2
@@ -3221,8 +3240,18 @@ packages:
     resolution: {integrity: sha512-7sPDKQQp+S11laqTrhHqeAbsCfMkwJMrV7oTDvtDds4mEofJYir414bYKUEb8YPUm9QL3U+8f6L6YExSoAGdQw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/types@8.41.0':
+    resolution: {integrity: sha512-9EwxsWdVqh42afLbHP90n2VdHaWU/oWgbH2P0CfcNfdKL7CuKpwMQGjwev56vWu9cSKU7FWSu6r9zck6CVfnag==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/typescript-estree@8.39.1':
     resolution: {integrity: sha512-EKkpcPuIux48dddVDXyQBlKdeTPMmALqBUbEk38McWv0qVEZwOpVJBi7ugK5qVNgeuYjGNQxrrnoM/5+TI/BPw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: 5.9.2
+
+  '@typescript-eslint/typescript-estree@8.41.0':
+    resolution: {integrity: sha512-D43UwUYJmGhuwHfY7MtNKRZMmfd8+p/eNSfFe6tH5mbVDto+VQCayeAt35rOx3Cs6wxD16DQtIKw/YXxt5E0UQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: 5.9.2
@@ -3236,6 +3265,10 @@ packages:
 
   '@typescript-eslint/visitor-keys@8.39.1':
     resolution: {integrity: sha512-W8FQi6kEh2e8zVhQ0eeRnxdvIoOkAp/CPAahcNio6nO9dsIwb9b34z90KOlheoyuVf6LSOEdjlkxSkapNEc+4A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.41.0':
+    resolution: {integrity: sha512-+GeGMebMCy0elMNg67LRNoVnUFPIm37iu5CmHESVx56/9Jsfdpsvbv605DQ81Pi/x11IdKUsS5nzgTYbCQU9fg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript/vfs@1.6.1':
@@ -8150,6 +8183,10 @@ packages:
     resolution: {integrity: sha512-lkaSIlxceytPyt9yfb1h7L9jDFqwMqvUZeGsKB7Z8QrvAO3xZv2S+xMQQYzxk0AGJHcQhbcvhKEstrMy99jnuQ==}
     engines: {node: '>=18.12.0'}
 
+  unplugin@2.3.9:
+    resolution: {integrity: sha512-2dcbZq6aprwXTkzptq3k5qm5B8cvpjG9ynPd5fyM2wDJuuF7PeUK64Sxf0d+X1ZyDOeGydbNzMqBSIVlH8GIfA==}
+    engines: {node: '>=18.12.0'}
+
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
 
@@ -9043,7 +9080,7 @@ snapshots:
   '@es-joy/jsdoccomment@0.53.0':
     dependencies:
       '@types/estree': 1.0.8
-      '@typescript-eslint/types': 8.39.1
+      '@typescript-eslint/types': 8.41.0
       comment-parser: 1.4.1
       esquery: 1.6.0
       jsdoc-type-pratt-parser: 4.8.0
@@ -9667,8 +9704,8 @@ snapshots:
       '@eslint/js': 9.34.0
       '@nuxt/eslint-plugin': 1.9.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)
       '@stylistic/eslint-plugin': 5.2.3(eslint@9.34.0(jiti@2.5.1))
-      '@typescript-eslint/eslint-plugin': 8.39.1(@typescript-eslint/parser@8.39.1(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)
-      '@typescript-eslint/parser': 8.39.1(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)
+      '@typescript-eslint/eslint-plugin': 8.39.1(@typescript-eslint/parser@8.41.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)
+      '@typescript-eslint/parser': 8.41.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)
       eslint: 9.34.0(jiti@2.5.1)
       eslint-config-flat-gitignore: 2.1.0(eslint@9.34.0(jiti@2.5.1))
       eslint-flat-config-utils: 2.1.1
@@ -9678,7 +9715,7 @@ snapshots:
       eslint-plugin-jsdoc: 54.1.0(eslint@9.34.0(jiti@2.5.1))
       eslint-plugin-regexp: 2.10.0(eslint@9.34.0(jiti@2.5.1))
       eslint-plugin-unicorn: 60.0.0(eslint@9.34.0(jiti@2.5.1))
-      eslint-plugin-vue: 10.4.0(@typescript-eslint/parser@8.39.1(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.34.0(jiti@2.5.1))(vue-eslint-parser@10.2.0(eslint@9.34.0(jiti@2.5.1)))
+      eslint-plugin-vue: 10.4.0(@typescript-eslint/parser@8.41.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.34.0(jiti@2.5.1))(vue-eslint-parser@10.2.0(eslint@9.34.0(jiti@2.5.1)))
       eslint-processor-vue-blocks: 2.0.0(@vue/compiler-sfc@3.5.20)(eslint@9.34.0(jiti@2.5.1))
       globals: 16.3.0
       local-pkg: 1.1.2
@@ -9693,7 +9730,7 @@ snapshots:
 
   '@nuxt/eslint-plugin@1.9.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)':
     dependencies:
-      '@typescript-eslint/types': 8.39.1
+      '@typescript-eslint/types': 8.41.0
       '@typescript-eslint/utils': 8.39.1(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)
       eslint: 9.34.0(jiti@2.5.1)
     transitivePeerDependencies:
@@ -10533,7 +10570,7 @@ snapshots:
   '@stylistic/eslint-plugin@5.2.3(eslint@9.34.0(jiti@2.5.1))':
     dependencies:
       '@eslint-community/eslint-utils': 4.7.0(eslint@9.34.0(jiti@2.5.1))
-      '@typescript-eslint/types': 8.39.1
+      '@typescript-eslint/types': 8.41.0
       eslint: 9.34.0(jiti@2.5.1)
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
@@ -10701,10 +10738,10 @@ snapshots:
       '@types/node': 22.18.0
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.39.1(@typescript-eslint/parser@8.39.1(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)':
+  '@typescript-eslint/eslint-plugin@8.39.1(@typescript-eslint/parser@8.41.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.39.1(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)
+      '@typescript-eslint/parser': 8.41.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)
       '@typescript-eslint/scope-manager': 8.39.1
       '@typescript-eslint/type-utils': 8.39.1(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)
       '@typescript-eslint/utils': 8.39.1(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)
@@ -10718,12 +10755,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.39.1(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)':
+  '@typescript-eslint/parser@8.41.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.39.1
-      '@typescript-eslint/types': 8.39.1
-      '@typescript-eslint/typescript-estree': 8.39.1(typescript@5.9.2)
-      '@typescript-eslint/visitor-keys': 8.39.1
+      '@typescript-eslint/scope-manager': 8.41.0
+      '@typescript-eslint/types': 8.41.0
+      '@typescript-eslint/typescript-estree': 8.41.0(typescript@5.9.2)
+      '@typescript-eslint/visitor-keys': 8.41.0
       debug: 4.4.1
       eslint: 9.34.0(jiti@2.5.1)
       typescript: 5.9.2
@@ -10733,7 +10770,16 @@ snapshots:
   '@typescript-eslint/project-service@8.39.1(typescript@5.9.2)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.39.1(typescript@5.9.2)
-      '@typescript-eslint/types': 8.39.1
+      '@typescript-eslint/types': 8.41.0
+      debug: 4.4.1
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.41.0(typescript@5.9.2)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.41.0(typescript@5.9.2)
+      '@typescript-eslint/types': 8.41.0
       debug: 4.4.1
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -10744,7 +10790,16 @@ snapshots:
       '@typescript-eslint/types': 8.39.1
       '@typescript-eslint/visitor-keys': 8.39.1
 
+  '@typescript-eslint/scope-manager@8.41.0':
+    dependencies:
+      '@typescript-eslint/types': 8.41.0
+      '@typescript-eslint/visitor-keys': 8.41.0
+
   '@typescript-eslint/tsconfig-utils@8.39.1(typescript@5.9.2)':
+    dependencies:
+      typescript: 5.9.2
+
+  '@typescript-eslint/tsconfig-utils@8.41.0(typescript@5.9.2)':
     dependencies:
       typescript: 5.9.2
 
@@ -10762,12 +10817,30 @@ snapshots:
 
   '@typescript-eslint/types@8.39.1': {}
 
+  '@typescript-eslint/types@8.41.0': {}
+
   '@typescript-eslint/typescript-estree@8.39.1(typescript@5.9.2)':
     dependencies:
       '@typescript-eslint/project-service': 8.39.1(typescript@5.9.2)
       '@typescript-eslint/tsconfig-utils': 8.39.1(typescript@5.9.2)
       '@typescript-eslint/types': 8.39.1
       '@typescript-eslint/visitor-keys': 8.39.1
+      debug: 4.4.1
+      fast-glob: 3.3.3
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.7.2
+      ts-api-utils: 2.1.0(typescript@5.9.2)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@8.41.0(typescript@5.9.2)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.41.0(typescript@5.9.2)
+      '@typescript-eslint/tsconfig-utils': 8.41.0(typescript@5.9.2)
+      '@typescript-eslint/types': 8.41.0
+      '@typescript-eslint/visitor-keys': 8.41.0
       debug: 4.4.1
       fast-glob: 3.3.3
       is-glob: 4.0.3
@@ -10792,6 +10865,11 @@ snapshots:
   '@typescript-eslint/visitor-keys@8.39.1':
     dependencies:
       '@typescript-eslint/types': 8.39.1
+      eslint-visitor-keys: 4.2.1
+
+  '@typescript-eslint/visitor-keys@8.41.0':
+    dependencies:
+      '@typescript-eslint/types': 8.41.0
       eslint-visitor-keys: 4.2.1
 
   '@typescript/vfs@1.6.1(typescript@5.9.2)':
@@ -12270,7 +12348,7 @@ snapshots:
 
   detective-typescript@14.0.0(typescript@5.9.2):
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.39.1(typescript@5.9.2)
+      '@typescript-eslint/typescript-estree': 8.41.0(typescript@5.9.2)
       ast-module-types: 6.0.1
       node-source-walk: 7.0.1
       typescript: 5.9.2
@@ -12561,7 +12639,7 @@ snapshots:
   eslint-plugin-import-lite@0.3.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2):
     dependencies:
       '@eslint-community/eslint-utils': 4.7.0(eslint@9.34.0(jiti@2.5.1))
-      '@typescript-eslint/types': 8.39.1
+      '@typescript-eslint/types': 8.41.0
       eslint: 9.34.0(jiti@2.5.1)
     optionalDependencies:
       typescript: 5.9.2
@@ -12644,7 +12722,7 @@ snapshots:
       semver: 7.7.2
       strip-indent: 4.0.0
 
-  eslint-plugin-vue@10.4.0(@typescript-eslint/parser@8.39.1(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.34.0(jiti@2.5.1))(vue-eslint-parser@10.2.0(eslint@9.34.0(jiti@2.5.1))):
+  eslint-plugin-vue@10.4.0(@typescript-eslint/parser@8.41.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.34.0(jiti@2.5.1))(vue-eslint-parser@10.2.0(eslint@9.34.0(jiti@2.5.1))):
     dependencies:
       '@eslint-community/eslint-utils': 4.7.0(eslint@9.34.0(jiti@2.5.1))
       eslint: 9.34.0(jiti@2.5.1)
@@ -12655,7 +12733,7 @@ snapshots:
       vue-eslint-parser: 10.2.0(eslint@9.34.0(jiti@2.5.1))
       xml-name-validator: 4.0.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.39.1(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)
+      '@typescript-eslint/parser': 8.41.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2)
 
   eslint-processor-vue-blocks@2.0.0(@vue/compiler-sfc@3.5.20)(eslint@9.34.0(jiti@2.5.1)):
     dependencies:
@@ -16573,6 +16651,13 @@ snapshots:
       webpack-virtual-modules: 0.6.2
 
   unplugin@2.3.8:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      acorn: 8.15.0
+      picomatch: 4.0.3
+      webpack-virtual-modules: 0.6.2
+
+  unplugin@2.3.9:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       acorn: 8.15.0

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -884,7 +884,7 @@ describe('nuxt links', () => {
 
   it('respects external links in edge cases', async () => {
     const html = await $fetch<string>('/nuxt-link/custom-external')
-    const hrefs = html.match(/<a[^>]*href="([^"]+)"/g)
+    const hrefs = html.match(/<a[^>]*href="[^"]+"/g)
     expect(hrefs).toMatchInlineSnapshot(`
       [
         "<a href="https://thehackernews.com/2024/01/urgent-upgrade-gitlab-critical.html"",
@@ -1664,7 +1664,7 @@ describe('nested suspense', () => {
     expect(text).toContain('Async parent: 1')
 
     const first = start.match(/\/suspense\/(?<parentType>a?sync)-(?<parentNum>\d)\/(?<childType>a?sync)-(?<childNum>\d)\//)!.groups!
-    const last = nav.match(/\/suspense\/(?<parentType>a?sync)-(?<parentNum>\d)\//)!.groups!
+    const last = nav.match(/\/suspense\/(?<parentType>a?sync)-\d\//)!.groups!
 
     await page.waitForFunction(path => window.useNuxtApp?.()._route.fullPath === path, nav)
 
@@ -1701,7 +1701,7 @@ describe('nested suspense', () => {
     // const text = await parent.innerText()
     expect(text).toContain('Async parent: 1')
 
-    const first = start.match(/\/suspense\/(?<parentType>a?sync)-(?<parentNum>\d)\//)!.groups!
+    const first = start.match(/\/suspense\/(?<parentType>a?sync)-\d\//)!.groups!
     const last = nav.match(/\/suspense\/(?<parentType>a?sync)-(?<parentNum>\d)\/(?<childType>a?sync)-(?<childNum>\d)\//)!.groups!
 
     expect(consoleLogs.map(l => l.text).filter(i => !i.includes('[vite]') && !i.includes('<Suspense> is an experimental feature')).sort()).toEqual([
@@ -2005,7 +2005,7 @@ describe('server components/islands', () => {
     await page.waitForLoadState('networkidle')
     await page.getByText('Go to page without lazy server component').click()
 
-    const text = (await page.innerText('pre')).replaceAll(/ data-island-uid="([^"]*)"/g, '').replace(/data-island-component="([^"]*)"/g, 'data-island-component')
+    const text = (await page.innerText('pre')).replaceAll(/ data-island-uid="[^"]*"/g, '').replace(/data-island-component="[^"]*"/g, 'data-island-component')
 
     if (isWebpack) {
       expect(text).toMatchInlineSnapshot('" End page <pre></pre><section id="fallback"><div> This is a .server (20ms) async component that was very long ... <div id="async-server-component-count">42</div><div class="sugar-counter"> Sugar Counter 12 x 1 = 12 <button> Inc </button></div><!--[--><div style="display: contents;" data-island-slot="default"><!--teleport start--><!--teleport end--></div><!--]--></div></section><section id="no-fallback"><div> This is a .server (20ms) async component that was very long ... <div id="async-server-component-count">42</div><div class="sugar-counter"> Sugar Counter 12 x 1 = 12 <button> Inc </button></div><!--[--><div style="display: contents;" data-island-slot="default"><!--teleport start--><!--teleport end--></div><!--]--></div></section><div> ServerWithClient.server.vue : <p>count: 0</p> This component should not be preloaded <div><!--[--><div>a</div><div>b</div><div>c</div><!--]--></div> This is not interactive <div class="sugar-counter"> Sugar Counter 12 x 1 = 12 <button> Inc </button></div><div class="interactive-component-wrapper" style="border:solid 1px red;"> The component below is not a slot but declared as interactive <div class="sugar-counter" nuxt-client=""> Sugar Counter 12 x 1 = 12 <button> Inc </button></div></div></div>"')
@@ -2132,8 +2132,8 @@ describe.skipIf(isDev())('dynamic paths', () => {
 
   it('should work with no overrides', async () => {
     const html: string = await $fetch<string>('/assets')
-    for (const match of html.matchAll(/(href|src)="(.*?)"|url\(([^)]*)\)/g)) {
-      const url = match[2] || match[3]!
+    for (const match of html.matchAll(/(?:href|src)="(.*?)"|url\(([^)]*)\)/g)) {
+      const url = match[1] || match[2]!
       expect(url.startsWith('/_nuxt/') || isPublicFile('/', url)).toBeTruthy()
     }
   })
@@ -2163,8 +2163,8 @@ describe.skipIf(isDev())('dynamic paths', () => {
     })
 
     const html = await $fetch<string>('/foo/assets')
-    for (const match of html.matchAll(/(href|src)="(.*?)"|url\(([^)]*)\)/g)) {
-      const url = match[2] || match[3]!
+    for (const match of html.matchAll(/(?:href|src)="(.*?)"|url\(([^)]*)\)/g)) {
+      const url = match[1] || match[2]!
       expect(url.startsWith('/foo/_other/') || isPublicFile('/foo/', url)).toBeTruthy()
     }
 
@@ -2179,8 +2179,8 @@ describe.skipIf(isDev())('dynamic paths', () => {
     })
 
     const html = await $fetch<string>('/assets')
-    for (const match of html.matchAll(/(href|src)="(.*?)"|url\(([^)]*)\)/g)) {
-      const url = match[2] || match[3]!
+    for (const match of html.matchAll(/(?:href|src)="(.*?)"|url\(([^)]*)\)/g)) {
+      const url = match[1] || match[2]!
       expect(url.startsWith('./_nuxt/') || isPublicFile('./', url)).toBeTruthy()
       expect(url.startsWith('./_nuxt/_nuxt')).toBeFalsy()
     }
@@ -2208,8 +2208,8 @@ describe.skipIf(isDev())('dynamic paths', () => {
     })
 
     const html = await $fetch<string>('/foo/assets')
-    for (const match of html.matchAll(/(href|src)="(.*?)"|url\(([^)]*)\)/g)) {
-      const url = match[2] || match[3]!
+    for (const match of html.matchAll(/(?:href|src)="(.*?)"|url\(([^)]*)\)/g)) {
+      const url = match[1] || match[2]!
       expect(url.startsWith('https://example.com/_cdn/') || isPublicFile('https://example.com/', url)).toBeTruthy()
     }
   })
@@ -2275,7 +2275,7 @@ describe('component islands', () => {
 
     result.head.link ||= []
     result.head.style ||= []
-    result.html = result.html.replaceAll(/ (data-island-uid|data-island-component)="([^"]*)"/g, '')
+    result.html = result.html.replaceAll(/ (?:data-island-uid|data-island-component)="[^"]*"/g, '')
     expect(result).toMatchInlineSnapshot(`
       {
         "head": {
@@ -2339,7 +2339,7 @@ describe('component islands', () => {
     result.props = {}
     result.components = {}
     result.slots = {}
-    result.html = result.html.replaceAll(/ (data-island-uid|data-island-component)="([^"]*)"/g, '')
+    result.html = result.html.replaceAll(/ (?:data-island-uid|data-island-component)="[^"]*"/g, '')
 
     expect(result).toMatchInlineSnapshot(`
       {
@@ -2368,7 +2368,7 @@ describe('component islands', () => {
       const { components } = result
       result.components = {}
       result.slots = {}
-      result.html = result.html.replace(/data-island-component="([^"]*)"/g, 'data-island-component')
+      result.html = result.html.replace(/data-island-component="[^"]*"/g, 'data-island-component')
 
       const teleportsEntries = Object.entries(components || {})
 
@@ -2405,7 +2405,7 @@ describe('component islands', () => {
         obj: { foo: 42, bar: false, me: 'hi' },
       }),
     }))
-    result.html = result.html.replace(/ data-island-uid="([^"]*)"/g, '')
+    result.html = result.html.replace(/ data-island-uid="[^"]*"/g, '')
 
     if (isDev()) {
       const fixtureDir = normalize(fileURLToPath(new URL('./fixtures/basic', import.meta.url)))
@@ -2551,7 +2551,8 @@ describe.skipIf(isDev() || isWindows || !isRenderingJson)('payload rendering', (
     })
   })
 
-  it('does not fetch a prefetched payload', async () => {
+  // TODO: looks like this test is flaky
+  it('does not fetch a prefetched payload', { retry: 3 }, async () => {
     const { page, requests } = await renderPage()
 
     await gotoPath(page, '/random/a')
@@ -2590,8 +2591,6 @@ describe.skipIf(isDev() || isWindows || !isRenderingJson)('payload rendering', (
     // expect(requests.filter(p => p.includes('_payload')).length).toBe(isDev() ? 1 : 0)
 
     await page.close()
-  }, {
-    retry: 3, // looks like this test is flaky
   })
 
   it.skipIf(!isRenderingJson)('should not include server-component HTML in payload', async () => {
@@ -3060,7 +3059,7 @@ describe('namespace access to useNuxtApp', () => {
 describe('nuxt-time', () => {
   it('ssr', async () => {
     const html = await $fetch<string>('/components/nuxt-time')
-    const snap = html.match(/<time[^>]*data-testid="fixed"[^>]*>([^<]*)<\/time>/)?.[0].replace(/ data-prehydrate-id="[^"]*"/g, '')
+    const snap = html.match(/<time[^>]*data-testid="fixed"[^>]*>[^<]*<\/time>/)?.[0].replace(/ data-prehydrate-id="[^"]*"/g, '')
     expect(snap).toContain(
       '<time data-month="long" data-day="numeric" datetime="2023-02-11T08:24:08.396Z" data-testid="fixed">',
     )

--- a/test/nuxt/nuxt-time.test.ts
+++ b/test/nuxt/nuxt-time.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { defineComponent, h } from 'vue'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import { injectHead } from '#unhead/composables'
@@ -102,15 +102,13 @@ describe('<NuxtTime>', () => {
     expect(thing.html()).toEqual(
       `<time data-relative="true" data-title="test" datetime="${new Date(datetime).toISOString()}" title="test" ssr="true" data-prehydrate-id="${id}">${description}</time>`,
     )
-    const oldQuerySelector = document.querySelectorAll
 
-    // @ts-expect-error ignoring types here
-    document.querySelectorAll = (selector) => {
+    vi.spyOn(document, 'querySelectorAll').mockImplementation((selector) => {
       if (selector === `[data-prehydrate-id*="${id}"]`) {
-        return [thing.element]
+        return [thing.element] as any
       }
-      return oldQuerySelector.call(document, selector)
-    }
+      return []
+    })
 
     const head = injectHead()
     // @ts-expect-error craziness
@@ -124,6 +122,6 @@ describe('<NuxtTime>', () => {
       `<time data-relative="true" data-title="test" datetime="${new Date(datetime).toISOString()}" title="test" ssr="true" data-prehydrate-id="${id}">${description}</time>`,
     )
 
-    document.querySelectorAll = oldQuerySelector
+    vi.resetAllMocks()
   })
 })

--- a/test/nuxt/nuxt-time.test.ts
+++ b/test/nuxt/nuxt-time.test.ts
@@ -122,6 +122,6 @@ describe('<NuxtTime>', () => {
       `<time data-relative="true" data-title="test" datetime="${new Date(datetime).toISOString()}" title="test" ssr="true" data-prehydrate-id="${id}">${description}</time>`,
     )
 
-    vi.resetAllMocks()
+    vi.restoreAllMocks()
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this adds typescript config and prevents use of deprecated methods (or explicitly allows them internally)

it also fixes some issues of regexp performance.