### PR TITLE
chore: provide `"type": "module"` for syntax detection

### DIFF
--- a/playground/package.json
+++ b/playground/package.json
@@ -1,6 +1,7 @@
 {
   "name": "nuxt-playground",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "nuxt dev",
     "build": "nuxt build",


### PR DESCRIPTION
Though it is playground, but may be we can provide type to module for syntax detection. The Node.js doc says, "Syntax detection should have no performance impact on CommonJS modules, but it incurs a slight performance penalty for ES modules; add `"type": "module"` to the nearest parent `package.json` file to eliminate the performance cost."

https://nodejs.org/en/blog/release/v20.19.0#module-syntax-detection-is-now-enabled-by-default
