### PR TITLE
fix(nuxt): ensure correct order of inlined styles

### DIFF
--- a/test/fixtures/basic/app/pages/styles.vue
+++ b/test/fixtures/basic/app/pages/styles.vue
@@ -3,7 +3,7 @@
     <ClientOnlyScript />
     <FunctionalComponent />
     <ServerOnlyComponent />
-    <SharedComponent />
+    <SharedComponent class="style-from-parent" />
   </div>
 </template>
 
@@ -22,5 +22,9 @@ import '~/assets/assets.css'
   /* definePageMeta( */
   div {
     --scoped: 'scoped';
+  }
+
+  .style-from-parent {
+    --style-from-parent: 'style-from-parent';
   }
 </style>


### PR DESCRIPTION
### 🔗 Linked issue

fix https://github.com/nuxt/nuxt/issues/33041

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

An attempt to fix the order of inlined styles in production build. I'm currently reviewing the implementation to determine the best approach (any guidance would be much appreciated 🙏)

So far, I've only added a regression test.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
