### PR TITLE
fix(nuxt): prefer accessing `globalThis` over `window`

### DIFF
--- a/packages/nuxt/src/app/compat/interval.ts
+++ b/packages/nuxt/src/app/compat/interval.ts
@@ -3,7 +3,7 @@ import { createError } from '../composables/error'
 const intervalError = '[nuxt] `setInterval` should not be used on the server. Consider wrapping it with an `onNuxtReady`, `onBeforeMount` or `onMounted` lifecycle hook, or ensure you only call it in the browser by checking `import.meta.client`.'
 
 export const setInterval = import.meta.client
-  ? window.setInterval
+  ? globalThis.setInterval
   : () => {
       if (import.meta.dev) {
         throw createError({

--- a/packages/nuxt/src/app/composables/cookie.ts
+++ b/packages/nuxt/src/app/composables/cookie.ts
@@ -33,7 +33,8 @@ const CookieDefaults = {
   encode: val => encodeURIComponent(typeof val === 'string' ? val : JSON.stringify(val)),
 } satisfies CookieOptions<any>
 
-const store = import.meta.client && cookieStore ? window.cookieStore : undefined
+// we use globalThis to avoid crashes in web workers
+const store = import.meta.client && cookieStore ? globalThis.cookieStore : undefined
 
 /** @since 3.0.0 */
 export function useCookie<T = string | null | undefined> (name: string, _opts?: CookieOptions<T> & { readonly?: false }): CookieRef<T>

--- a/packages/nuxt/src/app/composables/url.ts
+++ b/packages/nuxt/src/app/composables/url.ts
@@ -6,5 +6,6 @@ export function useRequestURL (opts?: Parameters<typeof getRequestURL>[1]) {
   if (import.meta.server) {
     return getRequestURL(useRequestEvent()!, opts)
   }
-  return new URL(window.location.href)
+  // we use globalThis to avoid crashes in web workers
+  return new URL(globalThis.location.href)
 }


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/33124

### 📚 Description

we do not always have `window` globally available

I'll investigate also to see if there's anything else we can helpfully swap out for web workers