### PR TITLE
fix(vite): remove explicit vite-node configuration of `deps.inline`

### DIFF
--- a/packages/vite/src/server.ts
+++ b/packages/vite/src/server.ts
@@ -45,6 +45,7 @@ export async function buildServer (nuxt: Nuxt, ctx: ViteBuildContext) {
     },
     optimizeDeps: {
       noDiscovery: true,
+      include: undefined,
     },
     resolve: {
       conditions: ((nuxt as any)._nitro as Nitro)?.options.exportConditions,

--- a/packages/vite/src/vite-node.ts
+++ b/packages/vite/src/vite-node.ts
@@ -237,9 +237,6 @@ let _node: ViteNodeServer | undefined
 
 function getNode (server: ViteDevServer) {
   return _node ||= new ViteNodeServer(server, {
-    deps: {
-      inline: [/^#/, /\?/],
-    },
     transformMode: {
       ssr: [/.*/],
       web: [],


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/32948

### 📚 Description

it seems we might not need this explicit configuration in the latest version of `vite-node`