### PR TITLE
fix(nuxt): print route middleware path in warning

### DIFF
--- a/packages/nuxt/src/app/plugins/router.ts
+++ b/packages/nuxt/src/app/plugins/router.ts
@@ -268,7 +268,7 @@ export default defineNuxtPlugin<{ route: Route, router: Router }>({
 
           for (const middleware of middlewareEntries) {
             if (import.meta.dev) {
-              nuxtApp._processingMiddleware = middleware.name || true
+              nuxtApp._processingMiddleware = (middleware as any)._path || true
             }
             const result = await nuxtApp.runWithContext(() => middleware(to, from))
             if (import.meta.server) {

--- a/packages/nuxt/src/app/plugins/router.ts
+++ b/packages/nuxt/src/app/plugins/router.ts
@@ -8,7 +8,7 @@ import { clearError, showError } from '../composables/error'
 import { navigateTo } from '../composables/router'
 
 // @ts-expect-error virtual file
-import { globalMiddleware, globalMiddlewareNameMap } from '#build/middleware'
+import { globalMiddleware } from '#build/middleware'
 // @ts-expect-error virtual file
 import { appManifest as isAppManifestEnabled } from '#build/nuxt.config.mjs'
 
@@ -268,7 +268,7 @@ export default defineNuxtPlugin<{ route: Route, router: Router }>({
 
           for (const middleware of middlewareEntries) {
             if (import.meta.dev) {
-              nuxtApp._processingMiddleware = globalMiddlewareNameMap[globalMiddleware.indexOf(middleware)] || middleware.name || true
+              nuxtApp._processingMiddleware = middleware.name || true
             }
             const result = await nuxtApp.runWithContext(() => middleware(to, from))
             if (import.meta.server) {

--- a/packages/nuxt/src/app/plugins/router.ts
+++ b/packages/nuxt/src/app/plugins/router.ts
@@ -8,7 +8,7 @@ import { clearError, showError } from '../composables/error'
 import { navigateTo } from '../composables/router'
 
 // @ts-expect-error virtual file
-import { globalMiddleware } from '#build/middleware'
+import { globalMiddleware, globalMiddlewareNameMap } from '#build/middleware'
 // @ts-expect-error virtual file
 import { appManifest as isAppManifestEnabled } from '#build/nuxt.config.mjs'
 
@@ -268,7 +268,7 @@ export default defineNuxtPlugin<{ route: Route, router: Router }>({
 
           for (const middleware of middlewareEntries) {
             if (import.meta.dev) {
-              nuxtApp._processingMiddleware = middleware.name || true
+              nuxtApp._processingMiddleware = globalMiddlewareNameMap[globalMiddleware.indexOf(middleware)] || middleware.name || true
             }
             const result = await nuxtApp.runWithContext(() => middleware(to, from))
             if (import.meta.server) {

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -6,7 +6,7 @@ import { generateTypes, resolveSchema } from 'untyped'
 import escapeRE from 'escape-string-regexp'
 import { hash } from 'ohash'
 import { camelCase } from 'scule'
-import { filename } from 'pathe/utils'
+import { filename, reverseResolveAlias } from 'pathe/utils'
 import type { Nitro } from 'nitropack/types'
 
 import { annotatePlugins, checkForCircularDependencies } from './app'
@@ -331,22 +331,38 @@ export const layoutTemplate: NuxtTemplate = {
 // Add middleware template
 export const middlewareTemplate: NuxtTemplate = {
   filename: 'middleware.mjs',
-  getContents ({ app }) {
+  getContents ({ app, nuxt }) {
     const globalMiddleware = app.middleware.filter(mw => mw.global)
-    const globalMiddlewareObject = genObjectFromRawEntries(globalMiddleware.map(mw => [mw.name, genSafeVariableName(mw.name)]))
     const namedMiddleware = app.middleware.filter(mw => !mw.global)
-    const namedMiddlewareObject = genObjectFromRawEntries(namedMiddleware.map(mw => [mw.name, genDynamicImport(mw.path)]))
+    const alias = nuxt.options.dev ? { ...nuxt?.options.alias || {}, ...strippedAtAliases } : {}
     return [
       ...globalMiddleware.map(mw => genImport(mw.path, genSafeVariableName(mw.name))),
-      `const _globalMiddleware = ${globalMiddlewareObject}`,
-      `if (import.meta.dev) {`,
-      `  for (const name in _globalMiddleware) {`,
-      `    if (Object.getOwnPropertyDescriptor(_globalMiddleware[name], 'name')?.value) continue`,
-      `    Object.defineProperty(_globalMiddleware[name], 'name', { value: name })`,
-      `  }`,
-      `}`,
-      `export const globalMiddleware = import.meta.dev ? Object.values(_globalMiddleware) : ${genArrayFromRaw(globalMiddleware.map(mw => genSafeVariableName(mw.name)))}`,
-      `export const namedMiddleware = ${namedMiddlewareObject}`,
+      ...!nuxt.options.dev
+        ? [
+            `export const globalMiddleware = ${genArrayFromRaw(globalMiddleware.map(mw => genSafeVariableName(mw.name)))}`,
+            `export const namedMiddleware = ${genObjectFromRawEntries(namedMiddleware.map(mw => [mw.name, genDynamicImport(mw.path)]))}`,
+          ]
+        : [
+            `const _globalMiddleware = ${genObjectFromRawEntries(globalMiddleware.map(mw => [reverseResolveAlias(mw.path, alias).pop() || mw.path, genSafeVariableName(mw.name)]))}`,
+            `for (const path in _globalMiddleware) {`,
+            `  Object.defineProperty(_globalMiddleware[path], '_path', { value: path })`,
+            `}`,
+            `export const globalMiddleware = Object.values(_globalMiddleware)`,
+            `const _namedMiddleware = ${genArrayFromRaw(namedMiddleware.map(mw => ({
+              name: genString(mw.name),
+              path: genString(reverseResolveAlias(mw.path, alias).pop() || mw.path),
+              import: genDynamicImport(mw.path),
+            })))}`,
+            `for (const mw of _namedMiddleware) {`,
+            `  const i = mw.import`,
+            `  mw.import = () => i().then(r => {`,
+            `    Object.defineProperty(r.default || r, '_path', { value: mw.path })`,
+            `    return r`,
+            `  })`,
+            `}`,
+            `export const namedMiddleware = Object.fromEntries(_namedMiddleware.map(mw => [mw.name, mw.import]))`,
+          ],
+
     ].join('\n')
   },
 }
@@ -656,4 +672,9 @@ export const buildTypeTemplate: NuxtTemplate = {
 
     return declarations
   },
+}
+
+const strippedAtAliases = {
+  '@': '',
+  '@@': '',
 }

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -345,7 +345,7 @@ export const middlewareTemplate: NuxtTemplate = {
       `    Object.defineProperty(_globalMiddleware[name], 'name', { value: name })`,
       `  }`,
       `}`,
-      `export const globalMiddleware = Object.values(_globalMiddleware)`,
+      `export const globalMiddleware = import.meta.dev ? Object.values(_globalMiddleware) : ${genArrayFromRaw(globalMiddleware.map(mw => genSafeVariableName(mw.name)))}`,
       `export const namedMiddleware = ${namedMiddlewareObject}`,
     ].join('\n')
   },

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -338,6 +338,7 @@ export const middlewareTemplate: NuxtTemplate = {
     return [
       ...globalMiddleware.map(mw => genImport(mw.path, genSafeVariableName(mw.name))),
       `export const globalMiddleware = ${genArrayFromRaw(globalMiddleware.map(mw => genSafeVariableName(mw.name)))}`,
+      `export const globalMiddlewareNameMap = ${JSON.stringify(globalMiddleware.map(mw => mw.name))}`,
       `export const namedMiddleware = ${namedMiddlewareObject}`,
     ].join('\n')
   },

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -339,8 +339,11 @@ export const middlewareTemplate: NuxtTemplate = {
     return [
       ...globalMiddleware.map(mw => genImport(mw.path, genSafeVariableName(mw.name))),
       `const _globalMiddleware = ${globalMiddlewareObject}`,
-      `for (const name in _globalMiddleware) {`,
-      `  Object.defineProperty(_globalMiddleware[name], 'name', { value: name })`,
+      `if (import.meta.dev) {`,
+      `  for (const name in _globalMiddleware) {`,
+      `    if (Object.getOwnPropertyDescriptor(_globalMiddleware[name], 'name')?.value) continue`,
+      `    Object.defineProperty(_globalMiddleware[name], 'name', { value: name })`,
+      `  }`,
       `}`,
       `export const globalMiddleware = Object.values(_globalMiddleware)`,
       `export const namedMiddleware = ${namedMiddlewareObject}`,

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -339,7 +339,7 @@ export const middlewareTemplate: NuxtTemplate = {
     return [
       ...globalMiddleware.map(mw => genImport(mw.path, genSafeVariableName(mw.name))),
       `const _globalMiddleware = ${globalMiddlewareObject}`,
-      `for(const name in _globalMiddleware) {`,
+      `for (const name in _globalMiddleware) {`,
       `  Object.defineProperty(_globalMiddleware[name], 'name', { value: name })`,
       `}`,
       `export const globalMiddleware = Object.values(_globalMiddleware)`,

--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -19,7 +19,7 @@ import { appManifest as isAppManifestEnabled } from '#build/nuxt.config.mjs'
 import _routes, { handleHotUpdate } from '#build/routes'
 import routerOptions, { hashMode } from '#build/router.options'
 // @ts-expect-error virtual file
-import { globalMiddleware, namedMiddleware } from '#build/middleware'
+import { globalMiddleware, globalMiddlewareNameMap, namedMiddleware } from '#build/middleware'
 
 // https://github.com/vuejs/router/blob/4a0cc8b9c1e642cdf47cc007fa5bbebde70afc66/packages/router/src/history/html5.ts#L37
 function createCurrentLocation (
@@ -224,7 +224,7 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
 
           try {
             if (import.meta.dev) {
-              nuxtApp._processingMiddleware = (typeof entry === 'string' ? entry : middleware.name) || true
+              nuxtApp._processingMiddleware = globalMiddlewareNameMap[globalMiddleware.indexOf(entry)] || (typeof entry === 'string' ? entry : middleware.name) || true
             }
             const result = await nuxtApp.runWithContext(() => middleware(to, from))
             if (import.meta.server || (!nuxtApp.payload.serverRendered && nuxtApp.isHydrating)) {

--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -224,7 +224,7 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
 
           try {
             if (import.meta.dev) {
-              nuxtApp._processingMiddleware = (typeof entry === 'string' ? entry : middleware.name) || true
+              nuxtApp._processingMiddleware = (middleware as any)._path || (typeof entry === 'string' ? entry : true)
             }
             const result = await nuxtApp.runWithContext(() => middleware(to, from))
             if (import.meta.server || (!nuxtApp.payload.serverRendered && nuxtApp.isHydrating)) {

--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -19,7 +19,7 @@ import { appManifest as isAppManifestEnabled } from '#build/nuxt.config.mjs'
 import _routes, { handleHotUpdate } from '#build/routes'
 import routerOptions, { hashMode } from '#build/router.options'
 // @ts-expect-error virtual file
-import { globalMiddleware, globalMiddlewareNameMap, namedMiddleware } from '#build/middleware'
+import { globalMiddleware, namedMiddleware } from '#build/middleware'
 
 // https://github.com/vuejs/router/blob/4a0cc8b9c1e642cdf47cc007fa5bbebde70afc66/packages/router/src/history/html5.ts#L37
 function createCurrentLocation (
@@ -224,7 +224,7 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
 
           try {
             if (import.meta.dev) {
-              nuxtApp._processingMiddleware = globalMiddlewareNameMap[globalMiddleware.indexOf(entry)] || (typeof entry === 'string' ? entry : middleware.name) || true
+              nuxtApp._processingMiddleware = (typeof entry === 'string' ? entry : middleware.name) || true
             }
             const result = await nuxtApp.runWithContext(() => middleware(to, from))
             if (import.meta.server || (!nuxtApp.payload.serverRendered && nuxtApp.isHydrating)) {

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -38,7 +38,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
   it('default client bundle size (pages)', async () => {
     const clientStats = await analyzeSizes(['**/*.js'], join(pagesRootDir, '.output/public'))
 
-    expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"170k"`)
+    expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"171k"`)
 
     const files = clientStats!.files.map(f => f.replace(/\..*\.js/, '.js'))
 
@@ -95,7 +95,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(rootDir, '.output-inline/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"548k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"549k"`)
 
     const modules = await analyzeSizes(['node_modules/**/*'], serverDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"82.0k"`)

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -38,7 +38,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
   it('default client bundle size (pages)', async () => {
     const clientStats = await analyzeSizes(['**/*.js'], join(pagesRootDir, '.output/public'))
 
-    expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"171k"`)
+    expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"170k"`)
 
     const files = clientStats!.files.map(f => f.replace(/\..*\.js/, '.js'))
 
@@ -95,7 +95,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(rootDir, '.output-inline/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"549k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"548k"`)
 
     const modules = await analyzeSizes(['node_modules/**/*'], serverDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"82.0k"`)


### PR DESCRIPTION
### 🔗 Linked issue
* https://github.com/nuxt/nuxt/pull/33039
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
This may work without too much changes, but it feels suboptimal.

With these changes, the warning trace will include the name of the global middleware.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
