### PR TITLE
chore(kit): improve DX by displaying module name when possible

### DIFF
--- a/packages/kit/src/module/define.ts
+++ b/packages/kit/src/module/define.ts
@@ -85,7 +85,7 @@ function _defineNuxtModule<
   // Module format is always a simple function
   async function normalizedModule (inlineOptions: Partial<TOptions>, nuxt = tryUseNuxt()!): Promise<ModuleSetupReturn> {
     if (!nuxt) {
-      throw new TypeError('Cannot use module outside of Nuxt context')
+      throw new TypeError(`Cannot use ${module.meta.name || 'module'} outside of Nuxt context`)
     }
 
     // Avoid duplicate installs


### PR DESCRIPTION
### 📚 Description

Small change to give clarity when by mistake we use a Nuxt module in `extends` so we know where the error can come from.