### PR TITLE
fix(nuxt): render relative importmap entry path if required

### DIFF
--- a/packages/nuxt/src/core/runtime/nitro/handlers/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/handlers/renderer.ts
@@ -196,6 +196,7 @@ export default defineRenderHandler(async (event): Promise<Partial<RenderResponse
         // cache absolute entry path
         entryPath = path
       } else {
+        // TODO: provide support for relative paths in assets as well
         // relativise path
         path = relative(event.path.replace(/\/[^/]+$/, '/'), joinURL('/', path))
         if (!/^(?:\/|\.+\/)/.test(path)) {

--- a/packages/nuxt/src/core/runtime/nitro/handlers/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/handlers/renderer.ts
@@ -7,7 +7,7 @@ import {
 } from 'vue-bundle-renderer/runtime'
 import type { RenderResponse } from 'nitropack/types'
 import { appendResponseHeader, createError, getQuery, getResponseStatus, getResponseStatusText, writeEarlyHints } from 'h3'
-import { getQuery as getURLQuery, joinURL, withoutTrailingSlash } from 'ufo'
+import { getQuery as getURLQuery, hasProtocol, joinURL, withoutTrailingSlash } from 'ufo'
 import { propsToString, renderSSRHead } from '@unhead/vue/server'
 import type { HeadEntryOptions, Link, Script } from '@unhead/vue/types'
 import destr from 'destr'
@@ -192,7 +192,7 @@ export default defineRenderHandler(async (event): Promise<Partial<RenderResponse
     let path = entryPath
     if (!path) {
       path = buildAssetsURL(entryFileName) as string
-      if (/^(?:\/|\.+\/)/.test(path)) {
+      if (/^(?:\/|\.+\/)/.test(path) || hasProtocol(path, { acceptRelative: true })) {
         // cache absolute entry path
         entryPath = path
       } else {

--- a/packages/nuxt/src/core/runtime/nitro/handlers/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/handlers/renderer.ts
@@ -65,6 +65,8 @@ const APP_TELEPORT_CLOSE_TAG = HAS_APP_TELEPORTS ? `</${appTeleportTag}>` : ''
 const PAYLOAD_URL_RE = process.env.NUXT_JSON_PAYLOADS ? /^[^?]*\/_payload.json(?:\?.*)?$/ : /^[^?]*\/_payload.js(?:\?.*)?$/
 const PAYLOAD_FILENAME = process.env.NUXT_JSON_PAYLOADS ? '_payload.json' : '_payload.js'
 
+let entryPath: string
+
 export default defineRenderHandler(async (event): Promise<Partial<RenderResponse>> => {
   const nitroApp = useNitroApp()
 
@@ -186,12 +188,18 @@ export default defineRenderHandler(async (event): Promise<Partial<RenderResponse
 
   // 0. Add import map for stable chunk hashes
   if (entryFileName && !NO_SCRIPTS) {
+    if (!entryPath) {
+      entryPath = buildAssetsURL(entryFileName)
+      if (!/^(?:\/|\.+\/)/.test(entryPath)) {
+        entryPath = './' + entryPath
+      }
+    }
     ssrContext.head.push({
       script: [{
         tagPosition: 'head',
         tagPriority: -2,
         type: 'importmap',
-        innerHTML: JSON.stringify({ imports: { '#entry': buildAssetsURL(entryFileName) } }),
+        innerHTML: JSON.stringify({ imports: { '#entry': entryPath } }),
       }],
     }, headEntryOptions)
   }

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -2214,6 +2214,18 @@ describe.skipIf(isDev())('dynamic paths', () => {
     }
   })
 
+  it('should render relative importmap path with relative path', async () => {
+    await startServer({
+      env: {
+        NUXT_APP_BASE_URL: '',
+        NUXT_APP_BUILD_ASSETS_DIR: 'assets/',
+      },
+    })
+
+    const html = await $fetch<string>('/')
+    expect(html).toContain('<script type="importmap">{"imports":{"#entry":"./assets')
+  })
+
   it('restore server', async () => {
     await startServer()
   })

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -2214,7 +2214,7 @@ describe.skipIf(isDev())('dynamic paths', () => {
     }
   })
 
-  it.skipIf(isDev())('should render relative importmap path with relative path', async () => {
+  it.skipIf(isDev() || isWebpack)('should render relative importmap path with relative path', async () => {
     await startServer({
       env: {
         NUXT_APP_BASE_URL: '',

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -2214,7 +2214,7 @@ describe.skipIf(isDev())('dynamic paths', () => {
     }
   })
 
-  it('should render relative importmap path with relative path', async () => {
+  it.skipIf(isDev())('should render relative importmap path with relative path', async () => {
     await startServer({
       env: {
         NUXT_APP_BASE_URL: '',


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/32948#issuecomment-3253725631

### 📚 Description

this addresses an issue where the importmap path was incorrect if used with a relative path.

hhaving said that, we do not support rendering relative paths for other assets in `vue-bundle-renderer` and this is a nice improvement that we could handle, later on