### PR TITLE
perf(nuxt): remove watcher from `hydrate-when` lazy hydration strategy

### DIFF
--- a/docs/2.guide/2.directory-structure/1.app/1.components.md
+++ b/docs/2.guide/2.directory-structure/1.app/1.components.md
@@ -133,6 +133,10 @@ Nuxt supports this using lazy (or delayed) hydration, allowing you to control wh
 
 Nuxt provides a range of built-in hydration strategies. Only one strategy can be used per lazy component.
 
+::note
+Any prop change on a lazily hydrated component will trigger hydration immediately. (e.g., changing a prop on a component with `hydrate-never` will cause it to hydrate)
+::
+
 ::warning
 Currently Nuxt's built-in lazy hydration only works in single-file components (SFCs), and requires you to define the prop in the template (rather than spreading an object of props via `v-bind`). It also does not work with direct imports from `#components`.
 ::

--- a/packages/nuxt/src/components/runtime/lazy-hydrated-component.ts
+++ b/packages/nuxt/src/components/runtime/lazy-hydrated-component.ts
@@ -1,4 +1,4 @@
-import { defineAsyncComponent, defineComponent, h, hydrateOnIdle, hydrateOnInteraction, hydrateOnMediaQuery, hydrateOnVisible, mergeProps, watch } from 'vue'
+import { defineAsyncComponent, defineComponent, h, hydrateOnIdle, hydrateOnInteraction, hydrateOnMediaQuery, hydrateOnVisible, mergeProps } from 'vue'
 import type { AsyncComponentLoader, ComponentObjectPropsOptions, ExtractPropTypes, HydrationStrategy } from 'vue'
 import { useNuxtApp } from '#app/nuxt'
 
@@ -83,10 +83,7 @@ export const createLazyIfComponent = defineLazyComponent({
 },
 props => props.hydrateWhen
   ? undefined /* hydrate immediately */
-  : (hydrate) => {
-      const unwatch = watch(() => props.hydrateWhen, () => hydrate(), { once: true })
-      return () => unwatch()
-    },
+  : () => {}, /* Vue will trigger the hydration automatically when the prop changes */
 )
 
 /* @__NO_SIDE_EFFECTS__ */


### PR DESCRIPTION
### 🔗 Linked issue
resolves https://github.com/nuxt/nuxt/issues/33193

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
I noticed that any prop change on a component using lazy hydration in Vue will cause it to hydrate. This means that it is not necessary to call the `hydrate` function in the `hydrate-when` strategy, and actually, doing so produces a warning in dev mode (https://github.com/vuejs/core/pull/13283).

<img width="609" height="34" alt="image" src="https://github.com/user-attachments/assets/09bcd519-9055-43fe-94a1-f21b54c4cc72" />

This PR removes the watcher, which calls `hydrate()` unnecessarily in the next tick and also updates the docs.

Could this cause a problem in some cases?


<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
