### PR TITLE
docs: update file path for pinia store

### DIFF
--- a/docs/1.getting-started/11.state-management.md
+++ b/docs/1.getting-started/11.state-management.md
@@ -88,7 +88,7 @@ Make sure to install the Pinia module with `npx nuxt module add pinia` or follow
 ::
 
 ::code-group
-```ts [stores/website.ts]
+```ts [app/stores/website.ts]
 export const useWebsiteStore = defineStore('websiteStore', {
   state: () => ({
     name: '',


### PR DESCRIPTION
I believe the default pinia stores location for nuxt 4 is inside the app folder now.