### PR TITLE
fix(nuxt): prevent Infinity backgroundSize in loading indicator

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-loading-indicator.ts
+++ b/packages/nuxt/src/app/components/nuxt-loading-indicator.ts
@@ -26,48 +26,67 @@ export default defineComponent({
     },
     color: {
       type: [String, Boolean],
-      default: 'repeating-linear-gradient(to right,#00dc82 0%,#34cdfe 50%,#0047e1 100%)',
+      default:
+        'repeating-linear-gradient(to right,#00dc82 0%,#34cdfe 50%,#0047e1 100%)',
     },
     errorColor: {
       type: String,
       default: 'repeating-linear-gradient(to right,#f87171 0%,#ef4444 100%)',
     },
     estimatedProgress: {
-      type: Function as unknown as () => (duration: number, elapsed: number) => number,
+      type: Function as unknown as () => (
+        duration: number,
+        elapsed: number
+      ) => number,
       required: false,
     },
   },
   setup (props, { slots, expose }) {
-    const { progress, isLoading, error, start, finish, clear } = useLoadingIndicator({
-      duration: props.duration,
-      throttle: props.throttle,
-      hideDelay: props.hideDelay,
-      resetDelay: props.resetDelay,
-      estimatedProgress: props.estimatedProgress,
-    })
+    const { progress, isLoading, error, start, finish, clear } =
+      useLoadingIndicator({
+        duration: props.duration,
+        throttle: props.throttle,
+        hideDelay: props.hideDelay,
+        resetDelay: props.resetDelay,
+        estimatedProgress: props.estimatedProgress,
+      })
 
     expose({
-      progress, isLoading, error, start, finish, clear,
+      progress,
+      isLoading,
+      error,
+      start,
+      finish,
+      clear,
     })
 
-    return () => h('div', {
-      class: 'nuxt-loading-indicator',
-      style: {
-        position: 'fixed',
-        top: 0,
-        right: 0,
-        left: 0,
-        pointerEvents: 'none',
-        width: 'auto',
-        height: `${props.height}px`,
-        opacity: isLoading.value ? 1 : 0,
-        background: error.value ? props.errorColor : props.color || undefined,
-        backgroundSize: `${(100 / progress.value) * 100}% auto`,
-        transform: `scaleX(${progress.value}%)`,
-        transformOrigin: 'left',
-        transition: 'transform 0.1s, height 0.4s, opacity 0.4s',
-        zIndex: 999999,
-      },
-    }, slots)
+    return () =>
+      h(
+        'div',
+        {
+          class: 'nuxt-loading-indicator',
+          style: {
+            position: 'fixed',
+            top: 0,
+            right: 0,
+            left: 0,
+            pointerEvents: 'none',
+            width: 'auto',
+            height: `${props.height}px`,
+            opacity: isLoading.value ? 1 : 0,
+            background: error.value
+              ? props.errorColor
+              : props.color || undefined,
+            backgroundSize: `${
+              progress.value > 0 ? (100 / progress.value) * 100 : 0
+            }% auto`,
+            transform: `scaleX(${progress.value}%)`,
+            transformOrigin: 'left',
+            transition: 'transform 0.1s, height 0.4s, opacity 0.4s',
+            zIndex: 999999,
+          },
+        },
+        slots,
+      )
   },
 })

--- a/packages/nuxt/src/app/components/nuxt-loading-indicator.ts
+++ b/packages/nuxt/src/app/components/nuxt-loading-indicator.ts
@@ -26,67 +26,48 @@ export default defineComponent({
     },
     color: {
       type: [String, Boolean],
-      default:
-        'repeating-linear-gradient(to right,#00dc82 0%,#34cdfe 50%,#0047e1 100%)',
+      default: 'repeating-linear-gradient(to right,#00dc82 0%,#34cdfe 50%,#0047e1 100%)',
     },
     errorColor: {
       type: String,
       default: 'repeating-linear-gradient(to right,#f87171 0%,#ef4444 100%)',
     },
     estimatedProgress: {
-      type: Function as unknown as () => (
-        duration: number,
-        elapsed: number
-      ) => number,
+      type: Function as unknown as () => (duration: number, elapsed: number) => number,
       required: false,
     },
   },
   setup (props, { slots, expose }) {
-    const { progress, isLoading, error, start, finish, clear } =
-      useLoadingIndicator({
-        duration: props.duration,
-        throttle: props.throttle,
-        hideDelay: props.hideDelay,
-        resetDelay: props.resetDelay,
-        estimatedProgress: props.estimatedProgress,
-      })
-
-    expose({
-      progress,
-      isLoading,
-      error,
-      start,
-      finish,
-      clear,
+    const { progress, isLoading, error, start, finish, clear } = useLoadingIndicator({
+      duration: props.duration,
+      throttle: props.throttle,
+      hideDelay: props.hideDelay,
+      resetDelay: props.resetDelay,
+      estimatedProgress: props.estimatedProgress,
     })
 
-    return () =>
-      h(
-        'div',
-        {
-          class: 'nuxt-loading-indicator',
-          style: {
-            position: 'fixed',
-            top: 0,
-            right: 0,
-            left: 0,
-            pointerEvents: 'none',
-            width: 'auto',
-            height: `${props.height}px`,
-            opacity: isLoading.value ? 1 : 0,
-            background: error.value
-              ? props.errorColor
-              : props.color || undefined,
-            backgroundSize: `${
-              progress.value > 0 ? (100 / progress.value) * 100 : 0
-            }% auto`,
-            transform: `scaleX(${progress.value}%)`,
-            transformOrigin: 'left',
-            transition: 'transform 0.1s, height 0.4s, opacity 0.4s',
-            zIndex: 999999,
-          },
-        },
-        slots,
-      )
+    expose({
+      progress, isLoading, error, start, finish, clear,
+    })
+
+    return () => h('div', {
+      class: 'nuxt-loading-indicator',
+      style: {
+        position: 'fixed',
+        top: 0,
+        right: 0,
+        left: 0,
+        pointerEvents: 'none',
+        width: 'auto',
+        height: `${props.height}px`,
+        opacity: isLoading.value ? 1 : 0,
+        background: error.value ? props.errorColor : props.color || undefined,
+        backgroundSize: `${progress.value > 0 ? (100 / progress.value) * 100 : 0}% auto`,
+        transform: `scaleX(${progress.value}%)`,
+        transformOrigin: 'left',
+        transition: 'transform 0.1s, height 0.4s, opacity 0.4s',
+        zIndex: 999999,
+      },
+    }, slots)
   },
 })


### PR DESCRIPTION
### 🔗 Linked issue

resolves #33210

### 📚 Description

Fixes a bug in the **Nuxt loading indicator** where `backgroundSize` could become `Infinity` when `progress.value` was 0.  

Before:
```js
backgroundSize: `${(100 / progress.value) * 100}% auto`,
```
After:
```
backgroundSize: `${
  progress.value > 0 ? (100 / progress.value) * 100 : 0
}% auto`,
```