### PR TITLE
perf(kit,nuxt): reduce unnecessary iteration in nuxt code

### DIFF
--- a/packages/kit/src/loader/nuxt.ts
+++ b/packages/kit/src/loader/nuxt.ts
@@ -23,10 +23,10 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
   // Apply dev as config override
   opts.overrides.dev = !!opts.dev
 
-  const resolvedPath = ['nuxt-nightly', 'nuxt']
-    .map(pkg => resolveModulePath(pkg, { try: true, from: [directoryToURL(opts.cwd!)] }))
-    .filter((p): p is NonNullable<typeof p> => !!p)
-    .sort((a, b) => b.length - a.length)[0]
+  const resolvedPath = ['nuxt-nightly', 'nuxt'].reduce((resolvedPath, pkg) => {
+    const path = resolveModulePath(pkg, { try: true, from: [directoryToURL(opts.cwd!)] })
+    return path && path.length > resolvedPath.length ? path : resolvedPath
+  }, '')
 
   if (!resolvedPath) {
     throw new Error(`Cannot find any nuxt version from ${opts.cwd}`)

--- a/packages/nuxt/src/app/composables/preload.ts
+++ b/packages/nuxt/src/app/composables/preload.ts
@@ -61,11 +61,11 @@ export async function preloadRouteComponents (to: RouteLocationRaw, router: Rout
 
   router._routePreloaded.add(path)
 
-  const components = matched
-    .map(component => component.components?.default)
-    .filter(component => typeof component === 'function')
-
-  for (const component of components) {
+  for (const route of matched) {
+    const component = route.components?.default
+    if (typeof component !== 'function') {
+      continue
+    }
     const promise = Promise.resolve((component as () => unknown)())
       .catch(() => {})
       .finally(() => promises.splice(promises.indexOf(promise)))

--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -146,12 +146,14 @@ export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: Na
   if (import.meta.client && options?.open) {
     const { target = '_blank', windowFeatures = {} } = options.open
 
-    const features = Object.entries(windowFeatures)
-      .filter(([_, value]) => value !== undefined)
-      .map(([feature, value]) => `${feature.toLowerCase()}=${value}`)
-      .join(', ')
+    const features: string[] = []
+    for (const [feature, value] of Object.entries(windowFeatures)) {
+      if (value !== undefined) {
+        features.push(`${feature.toLowerCase()}=${value}`)
+      }
+    }
 
-    open(toPath, target, features)
+    open(toPath, target, features.join(', '))
     return Promise.resolve()
   }
 

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -580,7 +580,10 @@ export function defineAppConfig<C extends AppConfigInput> (config: C): C {
 const loggedKeys = new Set<string>()
 function wrappedConfig (runtimeConfig: Record<string, unknown>) {
   if (!import.meta.dev || import.meta.server) { return runtimeConfig }
-  const keys = Object.keys(runtimeConfig).map(key => `\`${key}\``)
+  const keys: string[] = []
+  for (const key in runtimeConfig) {
+    keys.push(`\`${key}\``)
+  }
   const lastKey = keys.pop()
   return new Proxy(runtimeConfig, {
     get (target, p, receiver) {

--- a/packages/nuxt/src/components/plugins/islands-transform.ts
+++ b/packages/nuxt/src/components/plugins/islands-transform.ts
@@ -167,7 +167,13 @@ function isBinding (attr: string): boolean {
 function getPropsToString (bindings: Record<string, string>): string {
   const vfor = bindings['v-for']?.split(' in ').map((v: string) => v.trim()) as [string, string] | undefined
   if (Object.keys(bindings).length === 0) { return 'undefined' }
-  const content = Object.entries(bindings).filter(b => b[0] && (b[0] !== '_bind' && b[0] !== 'v-for')).map(([name, value]) => isBinding(name) ? `[\`${name.slice(1)}\`]: ${value}` : `[\`${name}\`]: \`${value}\``).join(',')
+  const contentParts: string[] = []
+  for (const [name, value] of Object.entries(bindings)) {
+    if (name && (name !== '_bind' && name !== 'v-for')) {
+      contentParts.push(isBinding(name) ? `[\`${name.slice(1)}\`]: ${value}` : `[\`${name}\`]: \`${value}\``)
+    }
+  }
+  const content = contentParts.join(',')
   const data = bindings._bind ? `__mergeProps(${bindings._bind}, { ${content} })` : `{ ${content} }`
   if (!vfor) {
     return `[${data}]`

--- a/packages/nuxt/src/core/modules.ts
+++ b/packages/nuxt/src/core/modules.ts
@@ -1,11 +1,19 @@
 import { normalizeModuleTranspilePath } from '@nuxt/kit'
 import type { Nuxt } from '@nuxt/schema'
+import escapeStringRegexp from 'escape-string-regexp'
 
 export const addModuleTranspiles = (nuxt: Nuxt) => {
   // Try to sanitize modules to better match imports
-  function isTranspilePresent (mod: string) {
-    return nuxt.options.build.transpile
-      .some(t => !(t instanceof Function) && (t instanceof RegExp ? t.test(mod) : new RegExp(t).test(mod)))
+  const transpile: RegExp[] = []
+  for (const t of nuxt.options.build.transpile) {
+    if (t instanceof Function) {
+      continue
+    }
+    if (typeof t === 'string') {
+      transpile.push(new RegExp(escapeStringRegexp(t)))
+    } else {
+      transpile.push(t)
+    }
   }
 
   for (const m of [...nuxt.options.modules, ...nuxt.options._modules]) {
@@ -15,7 +23,7 @@ export const addModuleTranspiles = (nuxt: Nuxt) => {
     }
     const path = normalizeModuleTranspilePath(mod)
     // Automatically add used modules to the transpile
-    if (!isTranspilePresent(path)) {
+    if (!transpile.some(t => t.test(path))) {
       nuxt.options.build.transpile.push(path)
     }
   }

--- a/packages/nuxt/src/core/nitro.ts
+++ b/packages/nuxt/src/core/nitro.ts
@@ -34,10 +34,25 @@ const PNPM_NODE_MODULES_RE = /\.pnpm\/.+\/node_modules\/(.+)$/
 export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
   // Resolve config
   const layerDirs = getLayerDirectories(nuxt)
-  const excludePaths = layerDirs.flatMap(dirs => [
-    dirs.root.match(NODE_MODULES_RE)?.[1]?.replace(/\/$/, ''),
-    dirs.root.match(PNPM_NODE_MODULES_RE)?.[1]?.replace(/\/$/, ''),
-  ].filter((dir): dir is string => Boolean(dir)).map(dir => escapeRE(dir)))
+  const excludePaths: string[] = []
+  for (const dirs of layerDirs) {
+    const paths = [
+      dirs.root.match(NODE_MODULES_RE)?.[1]?.replace(/\/$/, ''),
+      dirs.root.match(PNPM_NODE_MODULES_RE)?.[1]?.replace(/\/$/, ''),
+    ]
+    for (const dir of paths) {
+      if (dir) {
+        excludePaths.push(escapeRE(dir))
+      }
+    }
+  }
+
+  const layerPublicAssetsDirs: Array<{ dir: string }> = []
+  for (const dirs of layerDirs) {
+    if (existsSync(dirs.public)) {
+      layerPublicAssetsDirs.push({ dir: dirs.public })
+    }
+  }
 
   const excludePattern = excludePaths.length
     ? [new RegExp(`node_modules\\/(?!${excludePaths.join('|')})`)]
@@ -155,7 +170,7 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
               join(moduleDir, 'dist/runtime/server'),
             ]
           }),
-          ...getLayerDirectories(nuxt).map(dirs => relativeWithDot(nuxt.options.buildDir, join(dirs.shared, '**/*.d.ts'))),
+          ...layerDirs.map(dirs => relativeWithDot(nuxt.options.buildDir, join(dirs.shared, '**/*.d.ts'))),
         ],
         exclude: [
           ...nuxt.options.modulesDir.map(m => relativeWithDot(nuxt.options.buildDir, m)),
@@ -172,9 +187,7 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
             maxAge: 31536000 /* 1 year */,
             baseURL: nuxt.options.app.buildAssetsDir,
           },
-      ...getLayerDirectories(nuxt)
-        .filter(dirs => existsSync(dirs.public))
-        .map(dirs => ({ dir: dirs.public })),
+      ...layerPublicAssetsDirs,
     ],
     prerender: {
       ignoreUnprefixedPublicAssets: true,
@@ -200,7 +213,7 @@ export async function initNitro (nuxt: Nuxt & { _nitro?: Nitro }) {
         'nuxt-nightly/dist',
         distDir,
         // Ensure app config files have auto-imports injected even if they are pure .js files
-        ...getLayerDirectories(nuxt).map(dirs => join(dirs.app, 'app.config')),
+        ...layerDirs.map(dirs => join(dirs.app, 'app.config')),
       ],
       traceInclude: [
         // force include files used in generated code from the runtime-compiler

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -709,10 +709,15 @@ export default defineNuxtPlugin({
     }
   })
 
-  // Normalize windows transpile paths added by modules
-  nuxt.options.build.transpile = nuxt.options.build.transpile.map(t => typeof t === 'string' ? normalize(t) : t)
+  nuxt.options.build.transpile = nuxt.options.build.transpile.map((t) => {
+    if (typeof t !== 'string') {
+      return t
+    }
+    // Normalize windows transpile paths added by modules
+    return normalize(t).split('node_modules/').pop()!
+  })
 
-  addModuleTranspiles()
+  addModuleTranspiles(nuxt)
 
   // Init nitro
   await initNitro(nuxt)

--- a/packages/nuxt/src/core/runtime/nitro/handlers/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/handlers/renderer.ts
@@ -326,7 +326,14 @@ export default defineRenderHandler(async (event): Promise<Partial<RenderResponse
 })
 
 function normalizeChunks (chunks: (string | undefined)[]) {
-  return chunks.filter(Boolean).map(i => i!.trim())
+  const result: string[] = []
+  for (const _chunk of chunks) {
+    const chunk = _chunk?.trim()
+    if (chunk) {
+      result.push(chunk)
+    }
+  }
+  return result
 }
 
 function joinTags (tags: Array<string | undefined>) {

--- a/packages/nuxt/src/core/runtime/nitro/utils/renderer/build-files.ts
+++ b/packages/nuxt/src/core/runtime/nitro/utils/renderer/build-files.ts
@@ -118,7 +118,13 @@ export function getRenderer (ssrContext: NuxtSSRContext) {
 export const getSSRStyles = lazyCachedFunction((): Promise<Record<string, () => Promise<string[]>>> => import('#build/dist/server/styles.mjs').then(r => r.default || r))
 
 // for inlined styles
-export const getEntryIds: () => Promise<string[]> = () => getClientManifest().then(r => Object.values(r).filter(r =>
-  // @ts-expect-error internal key set by CSS inlining configuration
-  r._globalCSS,
-).map(r => r.src!))
+export const getEntryIds: () => Promise<string[]> = () => getClientManifest().then((r) => {
+  const entryIds: string[] = []
+  for (const entry of Object.values(r)) {
+    // @ts-expect-error internal key set by CSS inlining configuration
+    if (entry._globalCSS) {
+      entryIds.push(entry.src!)
+    }
+  }
+  return entryIds
+})

--- a/packages/nuxt/src/head/runtime/components.ts
+++ b/packages/nuxt/src/head/runtime/components.ts
@@ -1,5 +1,5 @@
 import { defineComponent, inject, onUnmounted, provide, reactive } from 'vue'
-import type { PropType } from 'vue'
+import type { PropType, VNodeNormalizedChildren } from 'vue'
 import type {
   BodyAttributes,
   HtmlAttributes,
@@ -141,11 +141,16 @@ export const NoScript = defineComponent({
     return () => {
       const noscript = normalizeProps(props) as Noscript
       const slotVnodes = slots.default?.()
-      const textContent = slotVnodes
-        ? slotVnodes.filter(({ children }) => children).map(({ children }) => children).join('')
-        : ''
-      if (textContent) {
-        noscript.innerHTML = textContent
+      const textContent: VNodeNormalizedChildren[] = []
+      if (slotVnodes) {
+        for (const vnode of slotVnodes) {
+          if (vnode.children) {
+            textContent.push(vnode.children)
+          }
+        }
+      }
+      if (textContent.length > 0) {
+        noscript.innerHTML = textContent.join('')
       }
       input.noscript![idx] = noscript
       return null

--- a/packages/nuxt/src/pages/runtime/page.ts
+++ b/packages/nuxt/src/pages/runtime/page.ts
@@ -233,10 +233,14 @@ export default defineComponent({
 }
 
 function _mergeTransitionProps (routeProps: TransitionProps[]): TransitionProps {
-  const _props: TransitionProps[] = routeProps.filter(Boolean).map(prop => ({
-    ...prop,
-    onAfterLeave: prop.onAfterLeave ? toArray(prop.onAfterLeave) : undefined,
-  }))
+  const _props: TransitionProps[] = []
+  for (const prop of routeProps) {
+    if (!prop) { continue }
+    _props.push({
+      ...prop,
+      onAfterLeave: prop.onAfterLeave ? toArray(prop.onAfterLeave) : undefined,
+    })
+  }
   return defu(..._props as [TransitionProps, TransitionProps])
 }
 

--- a/packages/webpack/src/plugins/vue/client.ts
+++ b/packages/webpack/src/plugins/vue/client.ts
@@ -83,7 +83,13 @@ export default class VueSSRClientPlugin {
           continue
         }
         const id = m.identifier!.replace(/\s\w+$/, '') // remove appended hash
-        const filesSet = new Set(chunk.files.map(fileToIndex).filter(i => i !== -1))
+        const filesSet = new Set<number>()
+        for (const file of chunk.files) {
+          const index = fileToIndex(file)
+          if (index !== -1) {
+            filesSet.add(index)
+          }
+        }
 
         for (const chunkName of chunk.names!) {
           if (!entrypoints[chunkName]) {

--- a/packages/webpack/src/plugins/vue/server.ts
+++ b/packages/webpack/src/plugins/vue/server.ts
@@ -55,7 +55,7 @@ export default class VueSSRServerPlugin {
           maps: {} as Record<string, string>,
         }
 
-        stats.assets!.forEach((asset: any) => {
+        for (const asset of stats.assets!) {
           if (isJS(asset.name)) {
             const queryPart = extractQueryPartJS(asset.name)
             if (queryPart !== undefined) {
@@ -69,7 +69,7 @@ export default class VueSSRServerPlugin {
             // Do not emit non-js assets for server
             delete assets[asset.name]
           }
-        })
+        }
 
         const src = JSON.stringify(bundle, null, 2)
 

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -95,7 +95,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(rootDir, '.output-inline/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"549k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"550k"`)
 
     const modules = await analyzeSizes(['node_modules/**/*'], serverDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"82.0k"`)


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

building on work by @GalacticHypernova, this replaces a number of chained array methods like `.map().filter().map()` etc.

many of these functions are called over and over again