### PR TITLE
fix(nuxt): move key imports logic after all modules run

### DIFF
--- a/packages/nuxt/src/imports/module.ts
+++ b/packages/nuxt/src/imports/module.ts
@@ -40,7 +40,7 @@ export default defineNuxtModule<Partial<ImportsOptions>>({
     virtualImports: ['#imports'],
     polyfills: true,
   }),
-  async setup (options, nuxt) {
+  setup (options, nuxt) {
     // TODO: fix sharing of defaults between invocations of modules
     const presets = JSON.parse(JSON.stringify(options.presets)) as ImportPresetWithDeprecation[]
 

--- a/packages/nuxt/src/imports/transform.ts
+++ b/packages/nuxt/src/imports/transform.ts
@@ -10,7 +10,7 @@ import type { ImportsOptions } from 'nuxt/schema'
 const NODE_MODULES_RE = /[\\/]node_modules[\\/]/
 const IMPORTS_RE = /(['"])#imports\1/
 
-export const TransformPlugin = ({ ctx, options, sourcemap }: { ctx: Unimport, options: Partial<ImportsOptions>, sourcemap?: boolean }) => createUnplugin(() => {
+export const TransformPlugin = ({ ctx, options, sourcemap }: { ctx: Pick<Unimport, 'injectImports'>, options: Partial<ImportsOptions>, sourcemap?: boolean }) => createUnplugin(() => {
   return {
     name: 'nuxt:imports-transform',
     enforce: 'post',


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/33196

### 📚 Description

with `moduleDependencies`, it was possible for modules to be added _after_ core nuxt modules like the imports module.

this PR adapts the logic of the imports module to move the creation of the unimport context after all modules have run.