### PR TITLE
refactor(nuxt): improve implementation of error composables

### DIFF
--- a/packages/nuxt/src/app/composables/error.ts
+++ b/packages/nuxt/src/app/composables/error.ts
@@ -9,6 +9,7 @@ import { useRouter } from './router'
 export const NUXT_ERROR_SIGNATURE = '__nuxt_error'
 
 /** @since 3.0.0 */
+/* @__NO_SIDE_EFFECTS__ */
 export const useError = (): Ref<NuxtPayload['error']> => toRef(useNuxtApp().payload, 'error')
 
 export interface NuxtError<DataT = unknown> extends H3Error<DataT> {
@@ -25,10 +26,10 @@ export const showError = <DataT = unknown>(
   const nuxtError = createError<DataT>(error)
 
   try {
-    const nuxtApp = useNuxtApp()
     const error = useError()
 
     if (import.meta.client) {
+      const nuxtApp = useNuxtApp()
       nuxtApp.hooks.callHook('app:error', nuxtError)
     }
 


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 📚 Description

1. The `useNuxtApp()` call within `showError` is moved to be client-side only.
	**Before**
    <img width="323" height="221" alt="截圖 2025-09-15 下午5 43 24" src="https://github.com/user-attachments/assets/fb42346e-33ae-46c1-9ffb-b538f9ea84f0" />
    **After**
    <img width="376" height="209" alt="截圖 2025-09-15 下午5 38 14" src="https://github.com/user-attachments/assets/1f75e0d3-7fc1-4f5b-8ceb-3c8d420e3ea1" />
    
2. The `useError` composable is marked as no side-effect (`/* @__NO_SIDE_EFFECTS__ */`). This provides a hint to bundlers, allowing for better tree-shaking if the composable is not used.

	**Before**
	<img width="584" height="324" alt="截圖 2025-09-15 下午5 42 28" src="https://github.com/user-attachments/assets/96e85bc1-2fc8-4b9c-8ad6-6a452e62a370" />
    **After**
    <img width="578" height="303" alt="截圖 2025-09-15 下午5 41 06" src="https://github.com/user-attachments/assets/7ffeb166-11cd-407d-a265-dbf00d557afc" />



