### PR TITLE
fix(nuxt): augment app config in server context

### DIFF
--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -399,6 +399,7 @@ export const nitroSchemaTemplate: NuxtTemplate = {
 
     return /* typescript */`
 ${lines.join('\n')}
+/// <reference path="./app.config.d.ts" />
 /// <reference path="./runtime-config.d.ts" />
 
 import type { RuntimeConfig } from 'nuxt/schema'


### PR DESCRIPTION
### 🔗 Linked issue

fix #32768

### 📚 Description

`app/app.config.ts` is imported by `types/nitro-config.d.ts`, so the app config needs to be properly argumented in the server context.

I also wonder why `useAppConfig` in nitropack returns `any` instead of `AppConfig`.