### PR TITLE
docs: update app config paths to use app/app.config.ts

### DIFF
--- a/docs/1.getting-started/03.configuration.md
+++ b/docs/1.getting-started/03.configuration.md
@@ -104,7 +104,7 @@ The `app.config.ts` file, located in the source directory (by default `app/`), i
 
 A minimal configuration file exports the `defineAppConfig` function containing an object with your configuration. The `defineAppConfig` helper is globally available without import.
 
-```ts [app.config.ts]
+```ts [app/app.config.ts]
 export default defineAppConfig({
   title: 'Hello Nuxt',
   theme: {

--- a/docs/2.guide/2.directory-structure/1.app/3.app-config.md
+++ b/docs/2.guide/2.directory-structure/1.app/3.app-config.md
@@ -5,7 +5,7 @@ description: Expose reactive configuration within your application with the App 
 navigation.icon: i-lucide-file
 ---
 
-Nuxt provides an `app/app.config` config file to expose reactive configuration within your application with the ability to update it at runtime within lifecycle or using a nuxt plugin and editing it with HMR (hot-module-replacement).
+Nuxt provides an `app/app.config.ts` config file to expose reactive configuration within your application with the ability to update it at runtime within lifecycle or using a nuxt plugin and editing it with HMR (hot-module-replacement).
 
 You can easily provide runtime app configuration using `app.config.ts` file. It can have either of `.ts`, `.js`, or `.mjs` extensions.
 

--- a/docs/2.guide/2.directory-structure/1.app/3.app-config.md
+++ b/docs/2.guide/2.directory-structure/1.app/3.app-config.md
@@ -5,11 +5,11 @@ description: Expose reactive configuration within your application with the App 
 navigation.icon: i-lucide-file
 ---
 
-Nuxt provides an `app.config` config file to expose reactive configuration within your application with the ability to update it at runtime within lifecycle or using a nuxt plugin and editing it with HMR (hot-module-replacement).
+Nuxt provides an `app/app.config` config file to expose reactive configuration within your application with the ability to update it at runtime within lifecycle or using a nuxt plugin and editing it with HMR (hot-module-replacement).
 
 You can easily provide runtime app configuration using `app.config.ts` file. It can have either of `.ts`, `.js`, or `.mjs` extensions.
 
-```ts twoslash [app.config.ts]
+```ts twoslash [app/app.config.ts]
 export default defineAppConfig({
   foo: 'bar'
 })
@@ -27,7 +27,7 @@ When configuring a custom [`srcDir`](/docs/4.x/api/nuxt-config#srcdir), make sur
 
 To expose config and environment variables to the rest of your app, you will need to define configuration in `app.config` file.
 
-```ts twoslash [app.config.ts]
+```ts twoslash [app/app.config.ts]
 export default defineAppConfig({
   theme: {
     primaryColor: '#ababab'
@@ -126,14 +126,14 @@ Here's an example of how you can use:
 
 ::code-group
 
-```ts twoslash [layer/app.config.ts]
+```ts twoslash [layer/app/app.config.ts]
 export default defineAppConfig({
   // Default array value
   array: ['hello'],
 })
 ```
 
-```ts twoslash [app.config.ts]
+```ts twoslash [app/app.config.ts]
 export default defineAppConfig({
   // Overwrite default array value by using a merger function
   array: () => ['bonjour'],

--- a/docs/2.guide/2.directory-structure/2.env.md
+++ b/docs/2.guide/2.directory-structure/2.env.md
@@ -74,6 +74,6 @@ Note that for a purely static site, it is not possible to set runtime configurat
 :read-more{to="/docs/guide/going-further/runtime-config"}
 
 ::note
-If you want to use environment variables set at build time but do not care about updating these down the line (or only need to update them reactively _within_ your app) then `appConfig` may be a better choice. You can define `appConfig` both within your `nuxt.config` (using environment variables) and also within an `~/app/app.config.ts` file in your project.
+If you want to use environment variables set at build time but do not care about updating these down the line (or only need to update them reactively _within_ your app) then `appConfig` may be a better choice. You can define `appConfig` both within your `nuxt.config` (using environment variables) and also within an `~/app.config.ts` file in your project.
 :read-more{to="/docs/guide/directory-structure/app-config"}
 ::

--- a/docs/2.guide/2.directory-structure/2.env.md
+++ b/docs/2.guide/2.directory-structure/2.env.md
@@ -74,6 +74,6 @@ Note that for a purely static site, it is not possible to set runtime configurat
 :read-more{to="/docs/guide/going-further/runtime-config"}
 
 ::note
-If you want to use environment variables set at build time but do not care about updating these down the line (or only need to update them reactively _within_ your app) then `appConfig` may be a better choice. You can define `appConfig` both within your `nuxt.config` (using environment variables) and also within an `~/app.config.ts` file in your project.
+If you want to use environment variables set at build time but do not care about updating these down the line (or only need to update them reactively _within_ your app) then `appConfig` may be a better choice. You can define `appConfig` both within your `nuxt.config` (using environment variables) and also within an `~/app/app.config.ts` file in your project.
 :read-more{to="/docs/guide/directory-structure/app-config"}
 ::


### PR DESCRIPTION
### 🔗 Linked issue

\-

### 📚 Description

Updated the paths to `app.config.ts` in accordance with the new `app/` directory.