### PR TITLE
docs: remove d suffix in example

### DIFF
--- a/docs/2.guide/2.directory-structure/1.shared.md
+++ b/docs/2.guide/2.directory-structure/1.shared.md
@@ -77,7 +77,7 @@ The way `shared/utils` and `shared/types` auto-imports work and are scanned is i
 -----| formatters
 -------| upper.ts         # Not auto-imported
 ---| types/
------| bar.d.ts           # Auto-imported
+-----| bar.ts             # Auto-imported
 ```
 
 Any other files you create in the `shared/` folder must be manually imported using the `#shared` alias (automatically configured by Nuxt):


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 📚 Description

The shared imports uses a `*.d.ts` file in the example, but this is not recommended.
