### PR TITLE
fix(nuxt): support `head` option on `useHead`

### DIFF
--- a/packages/nuxt/src/head/runtime/composables.ts
+++ b/packages/nuxt/src/head/runtime/composables.ts
@@ -33,17 +33,17 @@ interface NuxtUseHeadOptions extends UseHeadOptions {
 }
 
 export function useHead (input: UseHeadInput, options: NuxtUseHeadOptions = {}): ActiveHeadEntry<UseHeadInput> {
-  const head = injectHead(options.nuxt)
+  const head = options.head || injectHead(options.nuxt)
   return headCore(input, { head, ...options }) as ActiveHeadEntry<UseHeadInput>
 }
 
 export function useHeadSafe (input: UseHeadSafeInput, options: NuxtUseHeadOptions = {}): ActiveHeadEntry<UseHeadSafeInput> {
-  const head = injectHead(options.nuxt)
+  const head = options.head || injectHead(options.nuxt)
   return headSafe(input, { head, ...options }) as ActiveHeadEntry<UseHeadSafeInput>
 }
 
 export function useSeoMeta (input: UseSeoMetaInput, options: NuxtUseHeadOptions = {}): ActiveHeadEntry<UseSeoMetaInput> {
-  const head = injectHead(options.nuxt)
+  const head = options.head || injectHead(options.nuxt)
   return seoMeta(input, { head, ...options }) as ActiveHeadEntry<UseSeoMetaInput>
 }
 
@@ -51,7 +51,7 @@ export function useSeoMeta (input: UseSeoMetaInput, options: NuxtUseHeadOptions 
  * @deprecated Use `useHead` instead and wrap with `if (import.meta.server)`
  */
 export function useServerHead (input: UseHeadInput, options: NuxtUseHeadOptions = {}): ActiveHeadEntry<UseHeadInput> {
-  const head = injectHead(options.nuxt)
+  const head = options.head || injectHead(options.nuxt)
   // eslint-disable-next-line @typescript-eslint/no-deprecated
   return serverHead(input, { head, ...options }) as ActiveHeadEntry<UseHeadInput>
 }
@@ -60,7 +60,7 @@ export function useServerHead (input: UseHeadInput, options: NuxtUseHeadOptions 
  * @deprecated Use `useHeadSafe` instead and wrap with `if (import.meta.server)`
  */
 export function useServerHeadSafe (input: UseHeadSafeInput, options: NuxtUseHeadOptions = {}): ActiveHeadEntry<UseHeadSafeInput> {
-  const head = injectHead(options.nuxt)
+  const head = options.head || injectHead(options.nuxt)
   // eslint-disable-next-line @typescript-eslint/no-deprecated
   return serverHeadSafe(input, { head, ...options }) as ActiveHeadEntry<UseHeadSafeInput>
 }
@@ -69,7 +69,7 @@ export function useServerHeadSafe (input: UseHeadSafeInput, options: NuxtUseHead
  * @deprecated Use `useSeoMeta` instead and wrap with `if (import.meta.server)`
  */
 export function useServerSeoMeta (input: UseSeoMetaInput, options: NuxtUseHeadOptions = {}): ActiveHeadEntry<UseSeoMetaInput> {
-  const head = injectHead(options.nuxt)
+  const head = options.head || injectHead(options.nuxt)
   // eslint-disable-next-line @typescript-eslint/no-deprecated
   return serverSeoMeta(input, { head, ...options }) as ActiveHeadEntry<UseSeoMetaInput>
 }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

All of the useHead* variant composables have an option to provide a direct `head` instance, this allows the Unhead instance to be passed as a value in nested async code that may have lost the Nuxt context.

We added a `nuxt` option which does essentially the same thing, but for consistency to the underlying API we should honour `head` before trying to resolve the instance through Nuxt.

This is quite an edge case and likely didn't affect anyone, but it did catch me out.

```ts
function useSeo() {
	const head = injectHead()
    const seoData = await fetchSeo()
    // would break in Nuxt v4 as it resolves through Nuxt first
    useSeoMeta(seoData, { head })
}
```

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
