### PR TITLE
fix(nuxt): do not relativise importmap if `cdnURL` is set

### DIFF
--- a/packages/nuxt/src/core/runtime/nitro/handlers/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/handlers/renderer.ts
@@ -192,7 +192,7 @@ export default defineRenderHandler(async (event): Promise<Partial<RenderResponse
     let path = entryPath
     if (!path) {
       path = buildAssetsURL(entryFileName) as string
-      if (/^(?:\/|\.+\/)/.test(path) || hasProtocol(path, { acceptRelative: true })) {
+      if (ssrContext.runtimeConfig.app.cdnURL || !/^(?:\/|\.+\/)/.test(path) || hasProtocol(path, { acceptRelative: true })) {
         // cache absolute entry path
         entryPath = path
       } else {

--- a/packages/nuxt/src/core/runtime/nitro/handlers/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/handlers/renderer.ts
@@ -7,7 +7,7 @@ import {
 } from 'vue-bundle-renderer/runtime'
 import type { RenderResponse } from 'nitropack/types'
 import { appendResponseHeader, createError, getQuery, getResponseStatus, getResponseStatusText, writeEarlyHints } from 'h3'
-import { getQuery as getURLQuery, hasProtocol, joinURL, withoutTrailingSlash } from 'ufo'
+import { getQuery as getURLQuery, joinURL, withoutTrailingSlash } from 'ufo'
 import { propsToString, renderSSRHead } from '@unhead/vue/server'
 import type { HeadEntryOptions, Link, Script } from '@unhead/vue/types'
 import destr from 'destr'
@@ -192,7 +192,7 @@ export default defineRenderHandler(async (event): Promise<Partial<RenderResponse
     let path = entryPath
     if (!path) {
       path = buildAssetsURL(entryFileName) as string
-      if (ssrContext.runtimeConfig.app.cdnURL || !/^(?:\/|\.+\/)/.test(path) || hasProtocol(path, { acceptRelative: true })) {
+      if (ssrContext.runtimeConfig.app.cdnURL || /^(?:\/|\.+\/)/.test(path)) {
         // cache absolute entry path
         entryPath = path
       } else {

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -2218,7 +2218,6 @@ describe.skipIf(isDev())('dynamic paths', () => {
     await startServer({
       env: {
         NUXT_APP_BASE_URL: '',
-        NUXT_APP_CDN_URL: '',
         NUXT_APP_BUILD_ASSETS_DIR: 'assets/',
       },
     })

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -2218,6 +2218,7 @@ describe.skipIf(isDev())('dynamic paths', () => {
     await startServer({
       env: {
         NUXT_APP_BASE_URL: '',
+        NUXT_APP_CDN_URL: '',
         NUXT_APP_BUILD_ASSETS_DIR: 'assets/',
       },
     })


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/33266

### 📚 Description

if `cdnURL` is set it isn't going to be a relative path so we can skip checking/relativising the app