### PR TITLE
fix(nuxt): resolve aliases in `imports.dirs`

### DIFF
--- a/packages/nuxt/src/imports/module.ts
+++ b/packages/nuxt/src/imports/module.ts
@@ -66,7 +66,7 @@ export default defineNuxtModule<Partial<ImportsOptions>>({
 
         for (const dir of (layer.config.imports?.dirs ?? [])) {
           if (dir) {
-            composablesDirs.push(resolve(layer.config.srcDir, dir))
+            composablesDirs.push(resolve(layer.config.srcDir, resolveAlias(dir, nuxt.options.alias)))
           }
         }
       }


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/32953

### 📚 Description

this respects nuxt aliases set in `imports.dirs`