### PR TITLE
fix(nuxt): add missing element/vnode props for `<NuxtLink>`

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -526,8 +526,8 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
       }
     },
     // }) as unknown as DefineComponent<NuxtLinkProps, object, object, ComputedOptions, MethodOptions, object, object, EmitsOptions, string, object, NuxtLinkProps, object, SlotsType<NuxtLinkSlots>>
-  }) as unknown as (new<CustomProp extends boolean = false>(props: NuxtLinkProps<CustomProp>) => InstanceType<DefineSetupFnComponent<
-    NuxtLinkProps<CustomProp>,
+  }) as unknown as (new<CustomProp extends boolean = false>(props: NuxtLinkProps<CustomProp> & VNodeProps & AllowedComponentProps & AnchorHTMLAttributes) => InstanceType<DefineSetupFnComponent<
+    NuxtLinkProps<CustomProp> & VNodeProps & AllowedComponentProps & AnchorHTMLAttributes,
     [],
     SlotsType<NuxtLinkSlots<CustomProp>>
   >>) & Record<string, any>


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/33304

### 📚 Description

this adds some missing props/attrs accepted by `<NuxtLink>`