### PR TITLE
chore(nuxt): align global components indent

### DIFF
--- a/packages/nuxt/src/components/templates.ts
+++ b/packages/nuxt/src/components/templates.ts
@@ -168,8 +168,8 @@ import type { DefineComponent, SlotsType } from 'vue'
 ${nuxt.options.experimental.componentIslands ? islandType : ''}
 ${hydrationTypes}
 interface _GlobalComponents {
-  ${componentTypes.map(([pascalName, type]) => `    '${pascalName}': ${type}`).join('\n')}
-  ${componentTypes.map(([pascalName, type]) => `    'Lazy${pascalName}': LazyComponent<${type}>`).join('\n')}
+${componentTypes.map(([pascalName, type]) => `  '${pascalName}': ${type}`).join('\n')}
+${componentTypes.map(([pascalName, type]) => `  'Lazy${pascalName}': LazyComponent<${type}>`).join('\n')}
 }
 
 declare module 'vue' {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

| before | after |
| --- | --- |
| <img width="740" height="296" alt="image" src="https://github.com/user-attachments/assets/ddffb1f0-4988-4589-970f-7cf7daec804b" /> | <img width="740" height="296" alt="image" src="https://github.com/user-attachments/assets/d6ca8d84-8a82-45c7-8e60-4fa033a8cf54" /> |