### PR TITLE
test(nuxt): set locale to en for nuxt-time tests

### DIFF
--- a/test/nuxt/nuxt-time.test.ts
+++ b/test/nuxt/nuxt-time.test.ts
@@ -33,6 +33,7 @@ describe('<NuxtTime>', () => {
           h(NuxtTime, {
             datetime,
             relative: true,
+            locale: 'en-GB',
           }),
       }),
     )
@@ -50,6 +51,7 @@ describe('<NuxtTime>', () => {
             datetime,
             relative: true,
             title: true,
+            locale: 'en-GB',
           }),
       }),
     )
@@ -67,6 +69,7 @@ describe('<NuxtTime>', () => {
             datetime,
             relative: true,
             title: 'test',
+            locale: 'en-GB',
           }),
       }),
     )
@@ -93,6 +96,7 @@ describe('<NuxtTime>', () => {
             datetime,
             relative: true,
             title: 'test',
+            locale: 'en-GB',
           }),
       }),
     )
@@ -100,7 +104,7 @@ describe('<NuxtTime>', () => {
     const html = thing.html()
     const id = html.match(/data-prehydrate-id="([^"]+)"/)?.[1]
     expect(thing.html()).toEqual(
-      `<time data-relative="true" data-title="test" datetime="${new Date(datetime).toISOString()}" title="test" ssr="true" data-prehydrate-id="${id}">${description}</time>`,
+      `<time data-locale="en-GB" data-relative="true" data-title="test" datetime="${new Date(datetime).toISOString()}" title="test" ssr="true" data-prehydrate-id="${id}">${description}</time>`,
     )
 
     vi.spyOn(document, 'querySelectorAll').mockImplementation((selector) => {
@@ -119,7 +123,7 @@ describe('<NuxtTime>', () => {
     expect(window._nuxtTimeNow).toBeDefined()
 
     expect(thing.html()).toEqual(
-      `<time data-relative="true" data-title="test" datetime="${new Date(datetime).toISOString()}" title="test" ssr="true" data-prehydrate-id="${id}">${description}</time>`,
+      `<time data-locale="en-GB" data-relative="true" data-title="test" datetime="${new Date(datetime).toISOString()}" title="test" ssr="true" data-prehydrate-id="${id}">${description}</time>`,
     )
 
     vi.restoreAllMocks()


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This PR sets the locale to EN-GB for nuxt-time tests so contributors with any other locale would see their tests go green locally

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/4.x/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
