### PR TITLE
fix(nuxt): don't trigger scroll when changing trailing slash

### DIFF
--- a/packages/nuxt/src/app/composables/payload.ts
+++ b/packages/nuxt/src/app/composables/payload.ts
@@ -1,4 +1,4 @@
-import { hasProtocol, joinURL, withoutTrailingSlash } from 'ufo'
+import { hasProtocol, joinURL } from 'ufo'
 import { parse } from 'devalue'
 import { getCurrentInstance, onServerPrefetch, reactive } from 'vue'
 import { useNuxtApp, useRuntimeConfig } from '../nuxt'
@@ -96,7 +96,7 @@ export async function isPrerendered (url = useRoute().path) {
   const nuxtApp = useNuxtApp()
   // Note: Alternative for server is checking x-nitro-prerender header
   if (!appManifest) { return !!nuxtApp.payload.prerenderedAt }
-  url = withoutTrailingSlash(url)
+  url = url.replace(/\/$/, '')
   const manifest = await getAppManifest()
   if (manifest.prerendered.includes(url)) {
     return true

--- a/packages/nuxt/src/core/runtime/nitro/handlers/renderer.ts
+++ b/packages/nuxt/src/core/runtime/nitro/handlers/renderer.ts
@@ -7,7 +7,7 @@ import {
 } from 'vue-bundle-renderer/runtime'
 import type { RenderResponse } from 'nitropack/types'
 import { appendResponseHeader, createError, getQuery, getResponseStatus, getResponseStatusText, writeEarlyHints } from 'h3'
-import { getQuery as getURLQuery, joinURL, withoutTrailingSlash } from 'ufo'
+import { getQuery as getURLQuery, joinURL } from 'ufo'
 import { propsToString, renderSSRHead } from '@unhead/vue/server'
 import type { HeadEntryOptions, Link, Script } from '@unhead/vue/types'
 import destr from 'destr'
@@ -179,7 +179,7 @@ export default defineRenderHandler(async (event): Promise<Partial<RenderResponse
     // Hint nitro to prerender payload for this route
     appendResponseHeader(event, 'x-nitro-prerender', joinURL(ssrContext.url.replace(/\?.*$/, ''), PAYLOAD_FILENAME))
     // Use same ssr context to generate payload for this route
-    await payloadCache!.setItem(withoutTrailingSlash(ssrContext.url), renderPayloadResponse(ssrContext))
+    await payloadCache!.setItem(ssrContext.url.replace(/\/$/, ''), renderPayloadResponse(ssrContext))
   }
 
   const NO_SCRIPTS = process.env.NUXT_NO_SCRIPTS || routeOptions.noScripts

--- a/packages/nuxt/src/pages/runtime/router.options.ts
+++ b/packages/nuxt/src/pages/runtime/router.options.ts
@@ -3,6 +3,7 @@ import type { RouteLocationNormalized, RouterScrollBehavior } from 'vue-router'
 import type { RouterConfig } from 'nuxt/schema'
 import { useNuxtApp } from '#app/nuxt'
 import { isChangingPage } from '#app/components/utils'
+import { withoutTrailingSlash } from 'ufo'
 import { useRouter } from '#app/composables/router'
 
 type ScrollPosition = Awaited<ReturnType<RouterScrollBehavior>>
@@ -15,8 +16,8 @@ export default <RouterConfig> {
     // @ts-expect-error untyped, nuxt-injected option
     const hashScrollBehaviour = useRouter().options?.scrollBehaviorType ?? 'auto'
 
-    // Hash routes on the same page, no page hook is fired so resolve here
-    if (to.path === from.path) {
+    // Hash routes on the same page, no page hook is fired so resolve here, trailing slash agnostic
+    if (withoutTrailingSlash(to.path) === withoutTrailingSlash(from.path)) {
       if (from.hash && !to.hash) {
         return { left: 0, top: 0 }
       }

--- a/packages/nuxt/src/pages/runtime/router.options.ts
+++ b/packages/nuxt/src/pages/runtime/router.options.ts
@@ -3,7 +3,6 @@ import type { RouteLocationNormalized, RouterScrollBehavior } from 'vue-router'
 import type { RouterConfig } from 'nuxt/schema'
 import { useNuxtApp } from '#app/nuxt'
 import { isChangingPage } from '#app/components/utils'
-import { withoutTrailingSlash } from 'ufo'
 import { useRouter } from '#app/composables/router'
 
 type ScrollPosition = Awaited<ReturnType<RouterScrollBehavior>>
@@ -16,8 +15,8 @@ export default <RouterConfig> {
     // @ts-expect-error untyped, nuxt-injected option
     const hashScrollBehaviour = useRouter().options?.scrollBehaviorType ?? 'auto'
 
-    // Hash routes on the same page, no page hook is fired so resolve here, trailing slash agnostic
-    if (withoutTrailingSlash(to.path) === withoutTrailingSlash(from.path)) {
+    // Hash routes on the same page, no page hook is fired so resolve here
+    if (to.path.replace(/\/$/, '') === from.path.replace(/\/$/, '')) {
       if (from.hash && !to.hash) {
         return { left: 0, top: 0 }
       }

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -117,7 +117,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(pagesRootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"288k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"290k"`)
 
     const modules = await analyzeSizes(['node_modules/**/*'], serverDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"1421k"`)

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -117,7 +117,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(pagesRootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"290k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"289k"`)
 
     const modules = await analyzeSizes(['node_modules/**/*'], serverDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"1421k"`)

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -117,7 +117,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(pagesRootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"289k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"288k"`)
 
     const modules = await analyzeSizes(['node_modules/**/*'], serverDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"1421k"`)

--- a/test/nuxt/router.options.test.ts
+++ b/test/nuxt/router.options.test.ts
@@ -25,6 +25,16 @@ describe('scrollBehavior of router options with global transition', () => {
     children: [{ path: 'async', component: AsyncComponent }, { path: 'sync', component: SyncComponent }],
   })
 
+  async function completeNavigation () {
+    await flushPromises()
+
+    // Ensure everything is settled
+    await expect.poll(() => pageTransitionFinish.mock.calls.length).toBeGreaterThan(0)
+
+    expect(pageTransitionFinish).toHaveBeenCalled()
+    expect(pageLoadingEnd).toHaveBeenCalled()
+  }
+
   beforeAll(async () => {
     cleanups.push(nuxtApp.hook('page:transition:finish', pageTransitionFinish))
     cleanups.push(nuxtApp.hook('page:loading:end', pageLoadingEnd))
@@ -57,40 +67,30 @@ describe('scrollBehavior of router options with global transition', () => {
   })
 
   it('should not trigger scrollTo when trailing slash is added/removed', async () => {
-    // Same page as in beforeEach but with trailing slash at the end
-    await navigateTo('//')
-    await flushPromises()
+    await navigateTo('/about')
+    await completeNavigation()
 
-    // Ensure everything is settled
-    await expect.poll(() => pageTransitionFinish.mock.calls.length).toBeGreaterThan(0)
+    expect(scrollTo).toHaveBeenCalled()
+    scrollTo.mockClear()
 
-    expect(pageTransitionFinish).toHaveBeenCalled()
-    expect(pageLoadingEnd).toHaveBeenCalled()
+    await navigateTo('/about/')
+    await completeNavigation()
 
-    // Scroll decision should be "trailing-slash" agnostic
     expect(scrollTo).not.toHaveBeenCalled()
   })
 
   it('should call scrollTo after page transition is finished with async component', async () => {
     await navigateTo('/transitions/async')
+    await completeNavigation()
 
-    // Ensure everything is settled
-    await expect.poll(() => pageTransitionFinish.mock.calls.length).toBeGreaterThan(0)
-
-    expect(pageTransitionFinish).toHaveBeenCalled()
-    expect(pageLoadingEnd).toHaveBeenCalled()
     expect(scrollTo).toHaveBeenCalled()
     expect(pageTransitionFinish).toHaveBeenCalledBefore(scrollTo)
   })
 
   it('should call scrollTo after page transition is finished with sync component', async () => {
     await navigateTo('/transitions/sync')
+    await completeNavigation()
 
-    // Ensure everything is settled
-    await expect.poll(() => pageTransitionFinish.mock.calls.length).toBeGreaterThan(0)
-
-    expect(pageTransitionFinish).toHaveBeenCalled()
-    expect(pageLoadingEnd).toHaveBeenCalled()
     expect(scrollTo).toHaveBeenCalled()
     expect(pageTransitionFinish).toHaveBeenCalledBefore(scrollTo)
   })

--- a/test/nuxt/router.options.test.ts
+++ b/test/nuxt/router.options.test.ts
@@ -71,7 +71,7 @@ describe('scrollBehavior of router options with global transition', () => {
     await completeNavigation()
 
     expect(scrollTo).toHaveBeenCalled()
-    scrollTo.mockClear()
+    vi.clearAllMocks()
 
     await navigateTo('/about/')
     await completeNavigation()

--- a/test/nuxt/router.options.test.ts
+++ b/test/nuxt/router.options.test.ts
@@ -56,6 +56,21 @@ describe('scrollBehavior of router options with global transition', () => {
     }
   })
 
+  it('should not trigger scrollTo when trailing slash is added/removed', async () => {
+    // Same page as in beforeEach but with trailing slash at the end
+    await navigateTo('//')
+    await flushPromises()
+
+    // Ensure everything is settled
+    await expect.poll(() => pageTransitionFinish.mock.calls.length).toBeGreaterThan(0)
+
+    expect(pageTransitionFinish).toHaveBeenCalled()
+    expect(pageLoadingEnd).toHaveBeenCalled()
+
+    // Scroll decision should be "trailing-slash" agnostic
+    expect(scrollTo).not.toHaveBeenCalled()
+  })
+
   it('should call scrollTo after page transition is finished with async component', async () => {
     await navigateTo('/transitions/async')
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves #33315 

### 📚 Description

When users get to a page, default nuxt router behavior is to compare "from" & "to" path using `===` method. Base on that comparison it evaluates whether it should apply scroll-to-top effect or not. 

However, this comparison is not suitable in case of URLs ending with trailing slash. When navigating from page ending with trailing slash to same page not containing trailing slash at the end, it evaluates the page as being different page and it applies scroll to top effect.

**How to reproduce:**

It happens even in nuxt website.
- Land here (with trailing slash): https://nuxt.com/modules/
- Scroll down a bit
- Click a tag for filtering
- See page scrolling to top

### Fix Description

My fix is using "ufo" library with function `withoutTrailingSlash` which will make decision for scroll behavior by default **trailing slash agnostic**. 
