### PR TITLE
fix(nuxt): support `v-slot:fallback` longform syntax in `<DevOnly>`

### DIFF
--- a/packages/nuxt/src/core/plugins/dev-only.ts
+++ b/packages/nuxt/src/core/plugins/dev-only.ts
@@ -28,9 +28,9 @@ export const DevOnlyPlugin = (options: DevOnlyPluginOptions) => createUnplugin((
           const ast: Node = parse(match[0]).children[0]
           const fallback: Node | undefined = ast.children?.find((n: Node) => {
             if (n.name !== 'template') { return false }
-            return 'fallback' in n.attributes || '#fallback' in n.attributes
+            return 'fallback' in n.attributes || '#fallback' in n.attributes || 'v-slot:fallback' in n.attributes
           })
-          const replacement = fallback ? match[0].slice(fallback.loc[0].end, fallback.loc[fallback.loc.length - 1].start) : ''
+          const replacement = fallback ? match[0].slice(fallback.loc[0].end, fallback.loc.at(-1).start) : ''
           s.overwrite(match.index!, match.index! + match[0].length, replacement)
         }
 


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 📚 Description

`<DevOnly>` previously supported only the shorthand slot syntax `#fallback`. This PR extends support to the longform `v-slot:fallback` syntax.
