### PR TITLE
fix(nuxt): make middleware `_path` property configurable for HMR

### DIFF
--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -345,7 +345,7 @@ export const middlewareTemplate: NuxtTemplate = {
         : [
             `const _globalMiddleware = ${genObjectFromRawEntries(globalMiddleware.map(mw => [reverseResolveAlias(mw.path, alias).pop() || mw.path, genSafeVariableName(mw.name)]))}`,
             `for (const path in _globalMiddleware) {`,
-            `  Object.defineProperty(_globalMiddleware[path], '_path', { value: path })`,
+            `  Object.defineProperty(_globalMiddleware[path], '_path', { value: path, configurable: true })`,
             `}`,
             `export const globalMiddleware = Object.values(_globalMiddleware)`,
             `const _namedMiddleware = ${genArrayFromRaw(namedMiddleware.map(mw => ({
@@ -356,7 +356,7 @@ export const middlewareTemplate: NuxtTemplate = {
             `for (const mw of _namedMiddleware) {`,
             `  const i = mw.import`,
             `  mw.import = () => i().then(r => {`,
-            `    Object.defineProperty(r.default || r, '_path', { value: mw.path })`,
+            `    Object.defineProperty(r.default || r, '_path', { value: mw.path, configurable: true })`,
             `    return r`,
             `  })`,
             `}`,


### PR DESCRIPTION
### 🔗 Linked issue

fix #33378 

### 📚 Description

Fixes `"Cannot redefine property: _path" error during HMR when CSS changes trigger middleware module reload.`

## Problem

When CSS files change, Vite-Node triggers HMR and reloads the middleware module. The `_path` property was defined without `configurable: true`, causing TypeErrors when the property was redefined in the same context.

## Solution

Add `configurable: true` to both `Object.defineProperty` calls in the middleware template, allowing properties to be safely redefined during HMR.
