### PR TITLE
refactor(nuxt): generate valid references for component declaration items

### DIFF
--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -95,7 +95,7 @@
     "impound": "^1.0.0",
     "jiti": "^2.6.1",
     "klona": "^2.0.6",
-    "knitwork": "^1.2.0",
+    "knitwork": "^1.3.0",
     "magic-string": "^0.30.21",
     "mlly": "^1.8.0",
     "nanotar": "^0.2.0",

--- a/packages/nuxt/src/components/templates.ts
+++ b/packages/nuxt/src/components/templates.ts
@@ -1,5 +1,5 @@
 import { isAbsolute, join, relative, resolve } from 'pathe'
-import { genDynamicImport } from 'knitwork'
+import { genDynamicImport, genDynamicTypeImport } from 'knitwork'
 import { distDir } from '../dirs'
 import type { NuxtApp, NuxtPluginTemplate, NuxtTemplate } from 'nuxt/schema'
 
@@ -119,11 +119,9 @@ function resolveComponentTypes (app: NuxtApp, baseDir: string) {
     }
     // Use declarationPath if provided, otherwise fall back to filePath
     const filePath = c.declarationPath || c.filePath
-    let type = `typeof ${
-      genDynamicImport(isAbsolute(filePath)
-        ? relative(baseDir, filePath).replace(NON_VUE_RE, '')
-        : filePath.replace(NON_VUE_RE, ''), { wrapper: false })
-    }['${c.export}']`
+    let type = genDynamicTypeImport(isAbsolute(filePath)
+      ? relative(baseDir, filePath).replace(NON_VUE_RE, '')
+      : filePath.replace(NON_VUE_RE, ''), c.export)
 
     if (c.mode === 'server') {
       if (app.components.some(other => other.pascalName === c.pascalName && other.mode === 'client')) {

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -43,7 +43,7 @@
     "file-loader": "^6.2.0",
     "h3": "^1.15.4",
     "jiti": "^2.6.1",
-    "knitwork": "^1.2.0",
+    "knitwork": "^1.3.0",
     "magic-string": "^0.30.21",
     "memfs": "^4.50.0",
     "ohash": "^2.0.11",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -47,7 +47,7 @@
     "get-port-please": "^3.2.0",
     "h3": "^1.15.4",
     "jiti": "^2.6.1",
-    "knitwork": "^1.2.0",
+    "knitwork": "^1.3.0",
     "magic-string": "^0.30.21",
     "mlly": "^1.8.0",
     "mocked-exports": "^0.1.1",

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -43,7 +43,7 @@
     "fork-ts-checker-webpack-plugin": "^9.1.0",
     "h3": "^1.15.4",
     "jiti": "^2.6.1",
-    "knitwork": "^1.2.0",
+    "knitwork": "^1.3.0",
     "magic-string": "^0.30.21",
     "memfs": "^4.50.0",
     "mini-css-extract-plugin": "^2.9.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -542,8 +542,8 @@ importers:
         specifier: ^2.0.6
         version: 2.0.6
       knitwork:
-        specifier: ^1.2.0
-        version: 1.2.0
+        specifier: ^1.3.0
+        version: 1.3.0
       magic-string:
         specifier: 0.30.21
         version: 0.30.21
@@ -708,8 +708,8 @@ importers:
         specifier: 2.6.1
         version: 2.6.1
       knitwork:
-        specifier: ^1.2.0
-        version: 1.2.0
+        specifier: ^1.3.0
+        version: 1.3.0
       magic-string:
         specifier: 0.30.21
         version: 0.30.21
@@ -1034,8 +1034,8 @@ importers:
         specifier: 2.6.1
         version: 2.6.1
       knitwork:
-        specifier: ^1.2.0
-        version: 1.2.0
+        specifier: ^1.3.0
+        version: 1.3.0
       magic-string:
         specifier: 0.30.21
         version: 0.30.21
@@ -1146,8 +1146,8 @@ importers:
         specifier: 2.6.1
         version: 2.6.1
       knitwork:
-        specifier: ^1.2.0
-        version: 1.2.0
+        specifier: ^1.3.0
+        version: 1.3.0
       magic-string:
         specifier: 0.30.21
         version: 0.30.21
@@ -5949,6 +5949,9 @@ packages:
 
   knitwork@1.2.0:
     resolution: {integrity: sha512-xYSH7AvuQ6nXkq42x0v5S8/Iry+cfulBz/DJQzhIyESdLD7425jXsPy4vn5cCXU+HhRN2kVw51Vd1K6/By4BQg==}
+
+  knitwork@1.3.0:
+    resolution: {integrity: sha512-4LqMNoONzR43B1W0ek0fhXMsDNW/zxa1NdFAVMY+k28pgZLovR4G3PB5MrpTxCy1QaZCqNoiaKPr5w5qZHfSNw==}
 
   kolorist@1.8.0:
     resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
@@ -13533,6 +13536,8 @@ snapshots:
 
   knitwork@1.2.0: {}
 
+  knitwork@1.3.0: {}
+
   kolorist@1.8.0: {}
 
   launch-editor@2.12.0:
@@ -16306,7 +16311,7 @@ snapshots:
 
   unwasm@0.3.11:
     dependencies:
-      knitwork: 1.2.0
+      knitwork: 1.3.0
       magic-string: 0.30.21
       mlly: 1.8.0
       pathe: 2.0.3
@@ -16316,7 +16321,7 @@ snapshots:
   unwasm@0.4.2:
     dependencies:
       exsolve: 1.0.8
-      knitwork: 1.2.0
+      knitwork: 1.3.0
       magic-string: 0.30.21
       mlly: 1.8.0
       pathe: 2.0.3


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

`typeof import('...').default` is a valid reference compared to `typeof import('...')['default']`. It is required to implement the secondary jump for Go to References.

Waiting for unjs/knitwork#125.