### PR TITLE
docs: add custom nuxt module addServerPlugin warning

### DIFF
--- a/docs/3.api/5.kit/11.nitro.md
+++ b/docs/3.api/5.kit/11.nitro.md
@@ -197,6 +197,10 @@ Add plugin to extend Nitro's runtime behavior.
 You can read more about Nitro plugins in the [Nitro documentation](https://nitro.build/guide/plugins).
 ::
 
+::warning
+It is necessary to explicitly import `defineNitroPlugin` from `nitropack/runtime` within your plugin file. The same requirement applies to utilities such as `useRuntimeConfig`.
+::
+
 ### Usage
 
 ```ts twoslash


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/33406

### 📚 Description

Registering nitro plugin within custom nuxt module does not work out of the box. You actually have to explicitly import stuff like `defineNitroPlugin` or `useRuntimeConfig` for it to work. Added that section to the docs.
