### PR TITLE
docs: remove deprecated node version

### DIFF
--- a/docs/1.getting-started/02.installation.md
+++ b/docs/1.getting-started/02.installation.md
@@ -28,7 +28,7 @@ Or follow the steps below to set up a new Nuxt project on your computer.
 ::note
   ::details
   :summary[Additional notes for an optimal setup:]
-  - **Node.js**: Make sure to use an even numbered version (18, 20, etc)
+  - **Node.js**: Make sure to use an even numbered version (20, 22, etc.)
   - **Nuxtr**: Install the community-developed [Nuxtr extension](https://marketplace.visualstudio.com/items?itemName=Nuxtr.nuxtr-vscode)
   - **WSL**: If you are using Windows and experience slow HMR, you may want to try using [WSL (Windows Subsystem for Linux)](https://docs.microsoft.com/en-us/windows/wsl/install) which may solve some performance issues.
   - **Windows slow DNS resolution** - instead of using `localhost:3000` for local dev server on Windows, use `127.0.0.1` for much faster loading experience on browsers.


### PR DESCRIPTION
I think for both vite and nuxt node v18 is deprecated now.