### PR TITLE
fix(kit): safe assignment and cleanup of `defineNuxtConfig` for concurrent calls

### DIFF
--- a/packages/kit/src/loader/config.ts
+++ b/packages/kit/src/loader/config.ts
@@ -138,7 +138,7 @@ async function withDefineNuxtConfig<T> (fn: () => Promise<T>) {
   const key = 'defineNuxtConfig'
   const globalSelf = globalThis as any
 
-  if (!globalSelf[key]?.count) {
+  if (!globalSelf[key]) {
     globalSelf[key] = (c: any) => c
     globalSelf[key].count = 0
   }

--- a/packages/kit/src/loader/config.ts
+++ b/packages/kit/src/loader/config.ts
@@ -134,19 +134,22 @@ async function loadNuxtSchema (cwd: string) {
   return await import(schemaPath).then(r => r.NuxtConfigSchema)
 }
 
-let count = 0
 async function withDefineNuxtConfig<T> (fn: () => Promise<T>) {
+  const key = 'defineNuxtConfig'
+  const countKey = `_${key}Count`
   const globalSelf = globalThis as any
-  if (count === 0) {
-    globalSelf.defineNuxtConfig = (c: any) => c
+
+  if (!globalSelf[countKey]) {
+    globalSelf[countKey] = 0
+    globalSelf[key] = (c: any) => c
   }
-  count++
+  globalSelf[countKey]++
   try {
     return await fn()
   } finally {
-    count--
-    if (count === 0) {
-      delete globalSelf.defineNuxtConfig
+    globalSelf[countKey]--
+    if (!globalSelf[countKey]) {
+      delete globalSelf[key]
     }
   }
 }

--- a/packages/kit/src/loader/config.ts
+++ b/packages/kit/src/loader/config.ts
@@ -33,20 +33,19 @@ export async function loadNuxtConfig (opts: LoadNuxtConfigOptions): Promise<Nuxt
     .sort((a, b) => b.localeCompare(a))
   opts.overrides = defu(opts.overrides, { _extends: localLayers })
 
-  const globalSelf = globalThis as any
-  globalSelf.defineNuxtConfig = (c: any) => c
-  const { configFile, layers = [], cwd, config: nuxtConfig, meta } = await loadConfig<NuxtConfig>({
-    name: 'nuxt',
-    configFile: 'nuxt.config',
-    rcFile: '.nuxtrc',
-    extend: { extendKey: ['theme', '_extends', 'extends'] },
-    dotenv: true,
-    globalRc: true,
-    // @ts-expect-error TODO: fix type in c12, it should accept createDefu directly
-    merger,
-    ...opts,
-  })
-  delete globalSelf.defineNuxtConfig
+  const { configFile, layers = [], cwd, config: nuxtConfig, meta } = await withDefineNuxtConfig(
+    loadConfig<NuxtConfig>({
+      name: 'nuxt',
+      configFile: 'nuxt.config',
+      rcFile: '.nuxtrc',
+      extend: { extendKey: ['theme', '_extends', 'extends'] },
+      dotenv: true,
+      globalRc: true,
+      // @ts-expect-error TODO: fix type in c12, it should accept createDefu directly
+      merger,
+      ...opts,
+    }),
+  )
 
   // Fill config
   nuxtConfig.rootDir ||= cwd
@@ -133,4 +132,19 @@ async function loadNuxtSchema (cwd: string) {
   }
   const schemaPath = resolveModuleURL('@nuxt/schema', { try: true, from: urls }) ?? '@nuxt/schema'
   return await import(schemaPath).then(r => r.NuxtConfigSchema)
+}
+
+let count = 0
+async function withDefineNuxtConfig<T> (fn: Promise<T>) {
+  const globalSelf = globalThis as any
+  if (count === 0) {
+    globalSelf.defineNuxtConfig = (c: any) => c
+  }
+  count++
+  const returns = await fn
+  count--
+  if (count === 0) {
+    delete globalSelf.defineNuxtConfig
+  }
+  return returns
 }

--- a/packages/kit/src/loader/config.ts
+++ b/packages/kit/src/loader/config.ts
@@ -136,20 +136,18 @@ async function loadNuxtSchema (cwd: string) {
 
 async function withDefineNuxtConfig<T> (fn: () => Promise<T>) {
   const key = 'defineNuxtConfig'
-  const countKey = `_${key}Count`
   const globalSelf = globalThis as any
 
-  if (!globalSelf[countKey]) {
-    globalSelf[countKey] = 0
+  if (!globalSelf[key]?.count) {
     globalSelf[key] = (c: any) => c
+    globalSelf[key].count = 0
   }
-  globalSelf[countKey]++
+  globalSelf[key].count++
   try {
     return await fn()
   } finally {
-    globalSelf[countKey]--
-    if (!globalSelf[countKey]) {
-      delete globalSelf[countKey]
+    globalSelf[key].count--
+    if (!globalSelf[key].count) {
       delete globalSelf[key]
     }
   }

--- a/packages/kit/src/loader/config.ts
+++ b/packages/kit/src/loader/config.ts
@@ -149,6 +149,7 @@ async function withDefineNuxtConfig<T> (fn: () => Promise<T>) {
   } finally {
     globalSelf[countKey]--
     if (!globalSelf[countKey]) {
+      delete globalSelf[countKey]
       delete globalSelf[key]
     }
   }


### PR DESCRIPTION
### 🔗 Linked issue

### 📚 Description

To avoid errors like #33410 from happening again, we need to ensure that the call to `loadNuxtConfig` is concurrency-safe.