### PR TITLE
refactor(nuxt): use attrs from `useAttrs` instead of `vnode` for `<NuxtTime />`

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-time.vue
+++ b/packages/nuxt/src/app/components/nuxt-time.vue
@@ -36,14 +36,13 @@ const props = withDefaults(defineProps<NuxtTimeProps>(), {
 })
 
 const attrs = useAttrs()
-const renderedDate = attrs.datetime as string | undefined
 const _locale = attrs['data-locale'] as string | undefined
 
 const nuxtApp = useNuxtApp()
 
 const date = computed(() => {
   const date = props.datetime
-  if (renderedDate && nuxtApp.isHydrating) { return new Date(renderedDate) }
+  if (props.datetime && nuxtApp.isHydrating) { return new Date(props.datetime) }
   if (!props.datetime) { return new Date() }
   return new Date(date)
 })

--- a/packages/nuxt/src/app/components/nuxt-time.vue
+++ b/packages/nuxt/src/app/components/nuxt-time.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, getCurrentInstance, onBeforeUnmount, ref } from 'vue'
+import { computed, getCurrentInstance, onBeforeUnmount, ref, useAttrs } from 'vue'
 import { onPrehydrate } from '../composables/ssr'
 import { useNuxtApp } from '../nuxt'
 
@@ -35,9 +35,9 @@ const props = withDefaults(defineProps<NuxtTimeProps>(), {
   hour12: undefined,
 })
 
-const el = getCurrentInstance()?.vnode.el
-const renderedDate = el?.getAttribute('datetime')
-const _locale = el?.getAttribute('data-locale')
+const attrs = useAttrs()
+const renderedDate = attrs.datetime as string | undefined
+const _locale = attrs['data-locale'] as string | undefined
 
 const nuxtApp = useNuxtApp()
 

--- a/packages/nuxt/src/app/components/nuxt-time.vue
+++ b/packages/nuxt/src/app/components/nuxt-time.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, getCurrentInstance, onBeforeUnmount, ref, useAttrs } from 'vue'
+import { computed, onBeforeUnmount, ref, useAttrs } from 'vue'
 import { onPrehydrate } from '../composables/ssr'
 import { useNuxtApp } from '../nuxt'
 

--- a/packages/nuxt/src/app/components/nuxt-time.vue
+++ b/packages/nuxt/src/app/components/nuxt-time.vue
@@ -36,13 +36,14 @@ const props = withDefaults(defineProps<NuxtTimeProps>(), {
 })
 
 const attrs = useAttrs()
+const renderedDate = attrs.datetime as string | undefined
 const _locale = attrs['data-locale'] as string | undefined
 
 const nuxtApp = useNuxtApp()
 
 const date = computed(() => {
   const date = props.datetime
-  if (props.datetime && nuxtApp.isHydrating) { return new Date(props.datetime) }
+  if (renderedDate && nuxtApp.isHydrating) { return new Date(renderedDate) }
   if (!props.datetime) { return new Date() }
   return new Date(date)
 })

--- a/packages/nuxt/src/app/components/nuxt-time.vue
+++ b/packages/nuxt/src/app/components/nuxt-time.vue
@@ -36,16 +36,13 @@ const props = withDefaults(defineProps<NuxtTimeProps>(), {
 })
 
 const attrs = useAttrs()
-const renderedDate = attrs.datetime as string | undefined
 const _locale = attrs['data-locale'] as string | undefined
 
 const nuxtApp = useNuxtApp()
 
 const date = computed(() => {
-  const date = props.datetime
-  if (renderedDate && nuxtApp.isHydrating) { return new Date(renderedDate) }
   if (!props.datetime) { return new Date() }
-  return new Date(date)
+  return new Date(props.datetime)
 })
 
 const now = ref(import.meta.client && nuxtApp.isHydrating && window._nuxtTimeNow ? new Date(window._nuxtTimeNow) : new Date())


### PR DESCRIPTION
### 🔗 Linked issue

related #32859

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

I just stumbled upon this. I am opening it to try and understand the reason for using the vnode approach over the `useAttrs`.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/4.x/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
