### PR TITLE
fix(nitro): include layer server directories in tsconfig.server.json

### DIFF
--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -214,6 +214,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }) {
               join(moduleDir, 'dist/runtime/server'),
             ]
           }),
+          ...layerDirs.map(dirs => relativeWithDot(nuxt.options.buildDir, join(dirs.server, '**/*'))),
           ...layerDirs.map(dirs => relativeWithDot(nuxt.options.buildDir, join(dirs.shared, '**/*.d.ts'))),
         ],
         exclude: [

--- a/playground/layers/test-layer/nuxt.config.ts
+++ b/playground/layers/test-layer/nuxt.config.ts
@@ -1,0 +1,3 @@
+export default defineNuxtConfig({
+  // Test layer for verifying server TypeScript configuration fix
+})

--- a/playground/layers/test-layer/server/plugins/test.ts
+++ b/playground/layers/test-layer/server/plugins/test.ts
@@ -1,0 +1,3 @@
+export default defineNitroPlugin((_nitroApp) => {
+  // Test layer server plugin - verifying TypeScript support
+})

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,4 +1,7 @@
 export default defineNuxtConfig({
+  extends: [
+    './layers/test-layer',
+  ],
   devtools: { enabled: true },
   compatibilityDate: 'latest',
 })


### PR DESCRIPTION

**Fixes #33477**

In Nuxt 4.1.3, server files inside layer directories (e.g. `layers/*/server/**`) were not being included in the generated `.nuxt/tsconfig.server.json`. This caused TypeScript errors in IDEs such as WebStorm (e.g. `Cannot find name 'defineNitroPlugin'`), even though the application ran correctly.

This change updates the TypeScript configuration generation to automatically include all layer server directories, matching how Nitro already includes them in its `scanDirs` configuration.

### Changes

* Added layer server paths to the `include` array in `.nuxt/tsconfig.server.json`
* Restored IDE TypeScript support for server files inside layers
* Removed the need for manual configuration via `nitro.typescript.tsConfig.include`

### Linked issue

Fixes #33477

### Notes

This aligns the handling of layer server directories with the main server directory, improving TypeScript developer experience without affecting runtime behavior.