### PR TITLE
refactor: nuxt-link no longer imports router options

### DIFF
--- a/packages/nuxt/src/app/components/injections.ts
+++ b/packages/nuxt/src/app/components/injections.ts
@@ -8,3 +8,5 @@ export interface LayoutMeta {
 export const LayoutMetaSymbol: InjectionKey<LayoutMeta> = Symbol('layout-meta')
 
 export const PageRouteSymbol: InjectionKey<RouteLocationNormalizedLoaded> = Symbol('route')
+
+export const RouterHashModeSymbol: InjectionKey<boolean> = Symbol('router-hash-mode')

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -180,16 +180,6 @@ export default defineNuxtModule({
           'export const START_LOCATION = Symbol(\'router:start-location\')',
         ].join('\n'),
       })
-      // used by `<NuxtLink>`
-      addTemplate({
-        filename: 'router.options.mjs',
-        getContents: () => {
-          return [
-            'export const hashMode = false',
-            'export default {}',
-          ].join('\n')
-        },
-      })
       addTypeTemplate({
         filename: 'types/middleware.d.ts',
         getContents: () => [

--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -20,6 +20,7 @@ import _routes, { handleHotUpdate } from '#build/routes'
 import routerOptions, { hashMode } from '#build/router.options'
 // @ts-expect-error virtual file
 import { globalMiddleware, namedMiddleware } from '#build/middleware'
+import { RouterHashModeSymbol } from '#app/components/injections'
 
 // https://github.com/vuejs/router/blob/4a0cc8b9c1e642cdf47cc007fa5bbebde70afc66/packages/router/src/history/html5.ts#L37
 function createCurrentLocation (
@@ -94,6 +95,8 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
       window.history.scrollRestoration = 'auto'
     }
     nuxtApp.vueApp.use(router)
+
+    nuxtApp.vueApp.provide(RouterHashModeSymbol, hashMode)
 
     const previousRoute = shallowRef(router.currentRoute.value)
     router.afterEach((_to, from) => {

--- a/packages/nuxt/test/nuxt-link.test.ts
+++ b/packages/nuxt/test/nuxt-link.test.ts
@@ -42,6 +42,7 @@ vi.mock('../src/app/composables/router', () => ({
       }
     },
   }),
+  getRouterHashMode: () => false,
 }))
 
 // Helpers for test visibility

--- a/packages/nuxt/test/nuxt-link.test.ts
+++ b/packages/nuxt/test/nuxt-link.test.ts
@@ -42,7 +42,6 @@ vi.mock('../src/app/composables/router', () => ({
       }
     },
   }),
-  getRouterHashMode: () => false,
 }))
 
 // Helpers for test visibility


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

Not yet

### 📚 Description

Remove the import to `#build/router.options` from NuxtLink

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/4.x/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
