### PR TITLE
fix(webpack,rspack): preserve prerender + nitro flags in server builds

### DIFF
--- a/packages/webpack/src/presets/base.ts
+++ b/packages/webpack/src/presets/base.ts
@@ -250,10 +250,10 @@ function getEnv (ctx: WebpackConfigContext) {
     _env['import.meta.prerender'] = false
     _env['import.meta.nitro'] = false
   } else {
-    _env['process.prerender'] = webpack.DefinePlugin.runtimeValue(() => 'import.meta.prerender', true)
-    _env['process.nitro'] = webpack.DefinePlugin.runtimeValue(() => 'process.nitro', true)
-    _env['import.meta.prerender'] = webpack.DefinePlugin.runtimeValue(() => 'import.meta.prerender', true)
-    _env['import.meta.nitro'] = webpack.DefinePlugin.runtimeValue(() => 'import.meta.nitro', true)
+    _env['process.prerender'] = 'process.prerender'
+    _env['process.nitro'] = 'process.nitro'
+    _env['import.meta.prerender'] = 'import.meta.prerender'
+    _env['import.meta.nitro'] = 'import.meta.nitro'
   }
 
   if (ctx.userConfig.aggressiveCodeRemoval) {

--- a/packages/webpack/src/presets/base.ts
+++ b/packages/webpack/src/presets/base.ts
@@ -249,17 +249,12 @@ function getEnv (ctx: WebpackConfigContext) {
     _env['process.nitro'] = false
     _env['import.meta.prerender'] = false
     _env['import.meta.nitro'] = false
-  } else if (ctx.nuxt.options.builder !== '@nuxt/rspack-builder') {
-    // https://github.com/web-infra-dev/rspack/issues/5606
-    _env['process.prerender'] = webpack.DefinePlugin.runtimeValue(() => 'process.prerender', true)
-    _env['process.nitro'] = webpack.DefinePlugin.runtimeValue(() => 'process.nitro', true)
-    _env['import.meta.prerender'] = webpack.DefinePlugin.runtimeValue(() => 'import.meta.prerender', true)
-    _env['import.meta.nitro'] = webpack.DefinePlugin.runtimeValue(() => 'import.meta.nitro', true)
   } else {
-    _env['process.prerender'] = 'process.prerender'
-    _env['process.nitro'] = 'process.nitro'
-    _env['import.meta.prerender'] = 'import.meta.prerender'
-    _env['import.meta.nitro'] = 'import.meta.nitro'
+    // wrap in an IIFE, forcing it to be evaluated at runtime
+    _env['process.prerender'] = '(()=>process.prerender)()'
+    _env['process.nitro'] = '(()=>process.nitro)()'
+    _env['import.meta.prerender'] = '(()=>import.meta.prerender)()'
+    _env['import.meta.nitro'] = '(()=>import.meta.nitro)()'
   }
 
   if (ctx.userConfig.aggressiveCodeRemoval) {

--- a/packages/webpack/src/presets/base.ts
+++ b/packages/webpack/src/presets/base.ts
@@ -227,7 +227,7 @@ function getWarningIgnoreFilter (ctx: WebpackConfigContext): WarningFilter {
 }
 
 function getEnv (ctx: WebpackConfigContext) {
-  const _env: Record<string, string | boolean> = {
+  const _env: Record<string, string | boolean | InstanceType<typeof webpack.DefinePlugin>['definitions'][string]> = {
     'process.env.NODE_ENV': JSON.stringify(ctx.config.mode),
     '__NUXT_VERSION__': JSON.stringify(ctx.nuxt._version),
     '__NUXT_ASYNC_CONTEXT__': ctx.options.experimental.asyncContext,
@@ -242,6 +242,18 @@ function getEnv (ctx: WebpackConfigContext) {
     'import.meta.browser': ctx.isClient,
     'import.meta.client': ctx.isClient,
     'import.meta.server': ctx.isServer,
+  }
+
+  if (ctx.isClient) {
+    _env['process.prerender'] = false
+    _env['process.nitro'] = false
+    _env['import.meta.prerender'] = false
+    _env['import.meta.nitro'] = false
+  } else {
+    _env['process.prerender'] = webpack.DefinePlugin.runtimeValue(() => 'import.meta.prerender', true)
+    _env['process.nitro'] = webpack.DefinePlugin.runtimeValue(() => 'process.nitro', true)
+    _env['import.meta.prerender'] = webpack.DefinePlugin.runtimeValue(() => 'import.meta.prerender', true)
+    _env['import.meta.nitro'] = webpack.DefinePlugin.runtimeValue(() => 'import.meta.nitro', true)
   }
 
   if (ctx.userConfig.aggressiveCodeRemoval) {

--- a/packages/webpack/src/presets/base.ts
+++ b/packages/webpack/src/presets/base.ts
@@ -249,11 +249,17 @@ function getEnv (ctx: WebpackConfigContext) {
     _env['process.nitro'] = false
     _env['import.meta.prerender'] = false
     _env['import.meta.nitro'] = false
-  } else {
-    _env['process.prerender'] = webpack.DefinePlugin.runtimeValue(() => 'import.meta.prerender', true)
+  } else if (ctx.nuxt.options.builder !== '@nuxt/rspack-builder') {
+    // https://github.com/web-infra-dev/rspack/issues/5606
+    _env['process.prerender'] = webpack.DefinePlugin.runtimeValue(() => 'process.prerender', true)
     _env['process.nitro'] = webpack.DefinePlugin.runtimeValue(() => 'process.nitro', true)
     _env['import.meta.prerender'] = webpack.DefinePlugin.runtimeValue(() => 'import.meta.prerender', true)
     _env['import.meta.nitro'] = webpack.DefinePlugin.runtimeValue(() => 'import.meta.nitro', true)
+  } else {
+    _env['process.prerender'] = 'process.prerender'
+    _env['process.nitro'] = 'process.nitro'
+    _env['import.meta.prerender'] = 'import.meta.prerender'
+    _env['import.meta.nitro'] = 'import.meta.nitro'
   }
 
   if (ctx.userConfig.aggressiveCodeRemoval) {

--- a/packages/webpack/src/presets/base.ts
+++ b/packages/webpack/src/presets/base.ts
@@ -250,10 +250,10 @@ function getEnv (ctx: WebpackConfigContext) {
     _env['import.meta.prerender'] = false
     _env['import.meta.nitro'] = false
   } else {
-    _env['process.prerender'] = 'process.prerender'
-    _env['process.nitro'] = 'process.nitro'
-    _env['import.meta.prerender'] = 'import.meta.prerender'
-    _env['import.meta.nitro'] = 'import.meta.nitro'
+    _env['process.prerender'] = webpack.DefinePlugin.runtimeValue(() => 'import.meta.prerender', true)
+    _env['process.nitro'] = webpack.DefinePlugin.runtimeValue(() => 'process.nitro', true)
+    _env['import.meta.prerender'] = webpack.DefinePlugin.runtimeValue(() => 'import.meta.prerender', true)
+    _env['import.meta.nitro'] = webpack.DefinePlugin.runtimeValue(() => 'import.meta.nitro', true)
   }
 
   if (ctx.userConfig.aggressiveCodeRemoval) {

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -621,7 +621,7 @@ describe('pages', () => {
     }
   })
 
-  it.skipIf(isDev || isWebpack /* TODO: fix bug with import.meta.prerender being undefined in webpack build */)('prerenders pages hinted with a route rule', async () => {
+  it.skipIf(isDev)('prerenders pages hinted with a route rule', async () => {
     const html = await $fetch('/prerender/test')
     expect(html).toContain('should be prerendered: true')
   })
@@ -1231,7 +1231,7 @@ describe('errors', () => {
 
   it('should allow catching errors within error boundaries', async () => {
     const { page } = await renderPage('/error/error-boundary')
-    await page.getByText('This is the error rendering')
+    await page.getByText('This is the error rendering').first().waitFor()
     await page.close()
 
     await expectNoClientErrors('/error/error-boundary')
@@ -2043,7 +2043,7 @@ describe('server components/islands', () => {
     await page.close()
   })
 
-  it.skipIf(isDev || isWebpack /* TODO: fix bug with import.meta.prerender being undefined in webpack build */)('should allow server-only components to set prerender hints', async () => {
+  it.skipIf(isDev)('should allow server-only components to set prerender hints', async () => {
     // @ts-expect-error ssssh! untyped secret property
     const publicDir = useTestContext().nuxt._nitro.options.output.publicDir
     expect(await readdir(join(publicDir, 'catchall', 'some', 'url', 'from', 'server-only', 'component')).catch(() => [])).toContain(


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

previously `import.meta.prerender` was being replaced by `undefined` in the server webpack/rspack build and so nitro couldn't replace this with true/false during prerender/built, meaning a whole host of server code wasn't working properly in prerender mode.

this fixes the issue by preserving the value.