### PR TITLE
fix(nuxt): fallback on failed key decoding in cache driver

### DIFF
--- a/packages/nitro-server/src/runtime/utils/cache-driver.js
+++ b/packages/nitro-server/src/runtime/utils/cache-driver.js
@@ -1,5 +1,6 @@
 // @ts-check
 
+import crypto from 'crypto'
 import { defineDriver } from 'unstorage'
 import fsDriver from 'unstorage/drivers/fs-lite'
 import lruCache from 'unstorage/drivers/lru-cache'
@@ -8,13 +9,10 @@ import lruCache from 'unstorage/drivers/lru-cache'
  * @param {string} item
  */
 function normalizeFsKey(item) {
-  const normalized = item.replaceAll(':', '_')
-  try {
-    return decodeURIComponent(normalized)
-  } catch (error) {
-    console.warn(`Failed to decode key "${item}", using "${normalized}" instead.`)
-    return normalized
-  }
+  const safe = item.replace(/[^a-zA-Z0-9._-]/g, '_')
+  const prefix = safe.slice(0, 20)
+  const hash = crypto.createHash('sha1').update(item).digest('hex').slice(0, 20)
+  return `${prefix}-${hash}`
 }
 
 /**

--- a/packages/nitro-server/src/runtime/utils/cache-driver.js
+++ b/packages/nitro-server/src/runtime/utils/cache-driver.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import crypto from 'crypto'
+import crypto from 'node:crypto'
 import { defineDriver } from 'unstorage'
 import fsDriver from 'unstorage/drivers/fs-lite'
 import lruCache from 'unstorage/drivers/lru-cache'
@@ -8,8 +8,8 @@ import lruCache from 'unstorage/drivers/lru-cache'
 /**
  * @param {string} item
  */
-function normalizeFsKey(item) {
-  const safe = item.replace(/[^a-zA-Z0-9._-]/g, '_')
+function normalizeFsKey (item) {
+  const safe = item.replace(/[^\w.-]/g, '_')
   const prefix = safe.slice(0, 20)
   const hash = crypto.createHash('sha1').update(item).digest('hex').slice(0, 20)
   return `${prefix}-${hash}`

--- a/packages/nitro-server/src/runtime/utils/cache-driver.js
+++ b/packages/nitro-server/src/runtime/utils/cache-driver.js
@@ -7,7 +7,15 @@ import lruCache from 'unstorage/drivers/lru-cache'
 /**
  * @param {string} item
  */
-const normalizeFsKey = item => decodeURIComponent(item.replaceAll(':', '_'))
+function normalizeFsKey(item) {
+  const normalized = item.replaceAll(':', '_')
+  try {
+    return decodeURIComponent(normalized)
+  } catch (error) {
+    console.warn(`Failed to decode key "${item}", using "${normalized}" instead.`)
+    return normalized
+  }
+}
 
 /**
  * @param {{ base: string }} opts

--- a/packages/nitro-server/src/runtime/utils/cache-driver.js
+++ b/packages/nitro-server/src/runtime/utils/cache-driver.js
@@ -11,7 +11,7 @@ import lruCache from 'unstorage/drivers/lru-cache'
 function normalizeFsKey (item) {
   const safe = item.replace(/[^\w.-]/g, '_')
   const prefix = safe.slice(0, 20)
-  const hash = crypto.createHash('sha1').update(item).digest('hex').slice(0, 20)
+  const hash = crypto.createHash('sha256').update(item).digest('hex')
   return `${prefix}-${hash}`
 }
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

introduced by https://github.com/nuxt/nuxt/pull/30973

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/4.x/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->

When using `useAsyncData('posts/%', ...)` in multiple pages, some pages occasionally receive an empty payload.

After investigation, the issue was traced to `normalizeFsKey`, where `decodeURIComponent` throws a *"URI malformed"* error if the key contains a literal `%` (not part of valid URI encoding). This breaks cache key normalization and causes cache misses.

---

### 🧪 Reproduction

1. Use the same key on multiple pages:

   ```ts
   await useAsyncData('posts/%', fetchPosts)
   ```
2. Pre-render or visit both pages
3. One of them may get an empty payload

---

### 🛠 Fix

Add a `try/catch` fallback around `decodeURIComponent` inside `normalizeFsKey`. If decoding fails, fall back to the normalized key. This ensures keys like `posts/%` work correctly without breaking cache consistency.
