### PR TITLE
fix(nuxt): support component auto-imports as arguments of `h()`

### DIFF
--- a/packages/nuxt/src/components/plugins/loader.ts
+++ b/packages/nuxt/src/components/plugins/loader.ts
@@ -73,7 +73,7 @@ export const LoaderPlugin = (options: LoaderOptions) => createUnplugin(() => {
           map.set(component, identifier)
 
           const isServerOnly = !component._raw && component.mode === 'server' &&
-          !components.some(c => c.pascalName === component.pascalName && c.mode === 'client')
+            !components.some(c => c.pascalName === component.pascalName && c.mode === 'client')
           if (isServerOnly) {
             imports.add(genImport(options.serverComponentRuntime, [{ name: 'createServerComponent' }]))
             imports.add(`const ${identifier} = createServerComponent(${JSON.stringify(component.pascalName)})`)

--- a/packages/nuxt/test/component-loader.test.ts
+++ b/packages/nuxt/test/component-loader.test.ts
@@ -112,6 +112,102 @@ function _tracer(line, column, vnode) { return _tracerRecordPosition("app.vue", 
     `)
   })
 
+  it('should auto-import JSX components with h() calls', async () => {
+    const component = `
+    import { h } from 'vue'
+    export default {
+      render() {
+        return h('div', [
+          h(MyComponent, { foo: 'bar' }),
+          h(MyComponent, null, 'Hello')
+        ])
+      }
+    }
+    `
+    const code = await transform(component, '/pages/jsx-h.tsx')
+    expect(code).toContain('import __nuxt_component_0 from \'../components/MyComponent.vue\'')
+    expect(code).toContain('h(__nuxt_component_0,')
+  })
+
+  it('should auto-import JSX components in various contexts', async () => {
+    const component = `
+    import { h, defineComponent } from 'vue'
+    export default defineComponent({
+      setup() {
+        return () => h('div', [
+          h(MyComponent),
+          h(MyComponent, {}),
+          h(MyComponent, { prop: true }),
+          h(MyComponent, null, ['children']),
+        ])
+      }
+    })
+    `
+    const code = await transform(component, '/pages/contexts.tsx')
+    expect(code).toContain('import __nuxt_component_0 from \'../components/MyComponent.vue\'')
+    // Should replace all h(MyComponent) instances
+    const matches = code.match(/h\(__nuxt_component_0/g)
+    expect(matches).toHaveLength(4)
+  })
+
+  it('should handle multiple different JSX components', async () => {
+    const component = `
+    import { h } from 'vue'
+    export default {
+      render() {
+        return h('div', [
+          h(MyComponent, { id: 1 }),
+          h(OtherComponent, { id: 2 }),
+          h(MyComponent, { id: 3 })
+        ])
+      }
+    }
+    `
+    const code = await transform(component, '/pages/multiple.tsx')
+    expect(code).toContain('import __nuxt_component_0 from \'../components/MyComponent.vue\'')
+    // MyComponent should appear twice
+    const myComponentMatches = code.match(/h\(__nuxt_component_0/g)
+    expect(myComponentMatches).toHaveLength(2)
+    // OtherComponent should not be replaced (not in components list)
+    expect(code).toContain('h(OtherComponent,')
+  })
+
+  it('should not replace h() calls with lowercase component names', async () => {
+    const component = `
+    import { h } from 'vue'
+    export default {
+      render() {
+        return h('div', [
+          h(myComponent),
+          h(myOtherComponent)
+        ])
+      }
+    }
+    `
+    const code = await transform(component, '/pages/lowercase.tsx')
+    // Should not auto-import lowercase identifiers
+    expect(code).not.toContain('import __nuxt_component')
+    expect(code).toContain('h(myComponent')
+    expect(code).toContain('h(myOtherComponent')
+  })
+
+  it('should handle JSX with lazy components in JSX syntax', async () => {
+    const component = `
+    import { defineComponent } from 'vue'
+    export default defineComponent({
+      setup() {
+        return () => <div>
+          <LazyMyComponent foo="bar" />
+        </div>
+      }
+    })
+    `
+    const code = await transform(component, '/pages/lazy-jsx.tsx')
+    expect(code).toContain('defineAsyncComponent')
+    expect(code).toContain('__nuxt_component_0_lazy')
+    expect(code).toContain('createVNode(__nuxt_component_0_lazy,')
+  })
+
   it('should correctly resolve lazy hydration components', async () => {
     const sfc = `
     <template>

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -147,8 +147,7 @@ describe('pages', () => {
     await expectNoClientErrors('/')
   })
 
-  // TODO: support jsx with webpack
-  it.runIf(!isWebpack)('supports jsx', async () => {
+  it('supports jsx', async () => {
     const html = await $fetch<string>('/jsx')
 
     // should import JSX/TSX components with custom elements


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this addresses a long-standing issue with JSX support on webpack