### PR TITLE
docs: pin codemod to v0.18.7 for migration recipe

### DIFF
--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -221,19 +221,23 @@ You can run all the codemods mentioned in this guide using the following `codemo
 ::code-group
 
 ```bash [npm]
-npx codemod@latest nuxt/4/migration-recipe
+# Using pinned version due to https://github.com/codemod-com/codemod/issues/1710
+npx codemod@0.18.7 nuxt/4/migration-recipe
 ```
 
 ```bash [yarn]
-yarn dlx codemod@latest nuxt/4/migration-recipe
+# Using pinned version due to https://github.com/codemod-com/codemod/issues/1710
+yarn dlx codemod@0.18.7 nuxt/4/migration-recipe
 ```
 
 ```bash [pnpm]
-pnpm dlx codemod@latest nuxt/4/migration-recipe
+# Using pinned version due to https://github.com/codemod-com/codemod/issues/1710
+pnpm dlx codemod@0.18.7 nuxt/4/migration-recipe
 ```
 
 ```bash [bun]
-bun x codemod@latest nuxt/4/migration-recipe
+# Using pinned version due to https://github.com/codemod-com/codemod/issues/1710
+bun x codemod@0.18.7 nuxt/4/migration-recipe
 ```
 
 ::


### PR DESCRIPTION
### 🔗 Linked issue

fixes: https://github.com/codemod/codemod/issues/1710
fixes: #33519

## 📝 Description

Pins codemod version to `0.18.7` in the Nuxt 4 migration guide due to a bug in later versions.

## 📦 Changes

- Updated all package manager commands (`npm`, `yarn`, `pnpm`, `bun`) to use `codemod@0.18.7` instead of `@latest`

## ✅ Checklist

- [x] Documentation updated for all package managers
- [x] Version pinned consistently across all examples
