### PR TITLE
docs: clarify extends removal in TypeScript config migration

### DIFF
--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -1173,8 +1173,13 @@ However, to take advantage of improved type checking, you can opt in to the new 
 
 1. **Update your root `tsconfig.json`** to use project references:
 
+   ::note
+   If your `tsconfig.json` currently has an `"extends": "./.nuxt/tsconfig.json"` line, **remove it** before adding the references. Project references and extends are mutually exclusive.
+   ::
+
    ```json
    {
+     // Remove "extends": "./.nuxt/tsconfig.json" if present
      "files": [],
      "references": [
        { "path": "./.nuxt/tsconfig.app.json" },


### PR DESCRIPTION
### 🔗 Linked issue

Fixes: #33481

## 📝 Description

Clarifies that users must remove the `"extends": "./.nuxt/tsconfig.json"` line from their root `tsconfig.json` when migrating to TypeScript project references, as these two features are mutually exclusive.

## 🐛 Problem

Users following the migration steps were encountering:
- 100+ unexpected TypeScript errors
- Language server crashes
- Confusion about why types suddenly broke

The root cause was that the docs didn't explicitly state that `extends` must be removed when adding `references`.

## 📦 Changes

- Added a prominent note before the code example
- Added a comment in the JSON example
- Makes it crystal clear that extends and references cannot coexist
