### PR TITLE
fix(vite): prevent assignment for rolldown's replacement plugin

### DIFF
--- a/packages/vite/src/plugins/replace.ts
+++ b/packages/vite/src/plugins/replace.ts
@@ -21,7 +21,7 @@ export function ReplacePlugin (): Plugin {
 
       if ((vite as any).rolldownVersion) {
         const { replacePlugin } = await import('rolldown/experimental')
-        return replacePlugin(replaceOptions)
+        return replacePlugin(replaceOptions, { preventAssignment: true })
       } else {
         return replacePlugin({ ...replaceOptions, preventAssignment: true })
       }


### PR DESCRIPTION
### 🔗 Linked issue

Resolves https://github.com/nuxt/nuxt/issues/33418

### 📚 Description

When using `rolldown-vite`, the replacement plugin was used but the `preventAssignment` option wasn't passed, leading to issues loading the app. This should be fixed with this PR.