### PR TITLE
fix(nuxt): `NuxtTime` relative time formatting props support

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-time.vue
+++ b/packages/nuxt/src/app/components/nuxt-time.vue
@@ -23,6 +23,7 @@ export interface NuxtTimeProps {
   calendar?: string
   dayPeriod?: 'narrow' | 'short' | 'long'
   numberingSystem?: string
+  numeric?: 'always' | 'auto'
 
   dateStyle?: 'full' | 'long' | 'medium' | 'short'
   timeStyle?: 'full' | 'long' | 'medium' | 'short'

--- a/test/nuxt/nuxt-time.test.ts
+++ b/test/nuxt/nuxt-time.test.ts
@@ -42,6 +42,24 @@ describe('<NuxtTime>', () => {
     )
   })
 
+  it('should accept rest props for relative time', async () => {
+    const datetime = Date.now() - 24 * 60 * 60 * 1000
+    const thing = await mountSuspended(
+      defineComponent({
+        render: () =>
+          h(NuxtTime, {
+            datetime,
+            relative: true,
+            locale: 'en-GB',
+            numeric: 'auto',
+          }),
+      }),
+    )
+    expect(thing.html()).toMatchInlineSnapshot(
+      `"<time datetime="${new Date(datetime).toISOString()}">yesterday</time>"`,
+    )
+  })
+
   it('should display datetime in title', async () => {
     const datetime = Date.now() - 5 * 60 * 1000
     const thing = await mountSuspended(


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/4.x/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->

According to the [NuxtTime docs](https://nuxt.com/docs/4.x/api/components/nuxt-time#relative-time-formatting-props), the `<NuxtTime>` component should support the `numeric` and `style` props, as defined by [`Intl.RelativeTimeFormat` options](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat/RelativeTimeFormat#options), but neither is implemented.

This PR implements the `numeric` prop for `<NuxtTime>`.

The `style` option cannot be added directly since style is a reserved Vue attribute. Further discussion needed.
