### PR TITLE
fix(nuxt): handle arrays in app config correctly during HMR

### DIFF
--- a/packages/nuxt/src/app/config.ts
+++ b/packages/nuxt/src/app/config.ts
@@ -21,6 +21,12 @@ function isPojoOrArray (val: unknown): val is object {
 }
 
 function deepDelete (obj: any, newObj: any) {
+  if (Array.isArray(obj) && Array.isArray(newObj)) {
+    obj.length = 0
+    obj.push(...newObj)
+    return
+  }
+
   for (const key in obj) {
     const val = newObj[key]
     if (!(key in newObj)) {
@@ -39,7 +45,12 @@ function deepAssign (obj: any, newObj: any) {
     const val = newObj[key]
     if (isPojoOrArray(val)) {
       const defaultVal = Array.isArray(val) ? [] : {}
-      obj[key] ||= defaultVal
+      if (Array.isArray(obj[key]) !== Array.isArray(val)) {
+        obj[key] = defaultVal
+      } else {
+        obj[key] ??= defaultVal
+      }
+
       deepAssign(obj[key], val)
     } else {
       obj[key] = val
@@ -55,6 +66,7 @@ export function useAppConfig (): AppConfig {
 
 export function _replaceAppConfig (newConfig: AppConfig) {
   const appConfig = useAppConfig()
+  console.log('replacing', appConfig, newConfig)
 
   deepAssign(appConfig, newConfig)
   deepDelete(appConfig, newConfig)

--- a/packages/nuxt/src/app/config.ts
+++ b/packages/nuxt/src/app/config.ts
@@ -66,7 +66,6 @@ export function useAppConfig (): AppConfig {
 
 export function _replaceAppConfig (newConfig: AppConfig) {
   const appConfig = useAppConfig()
-  console.log('replacing', appConfig, newConfig)
 
   deepAssign(appConfig, newConfig)
   deepDelete(appConfig, newConfig)

--- a/packages/nuxt/test/app-config.test.ts
+++ b/packages/nuxt/test/app-config.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { _replaceAppConfig } from '../src/app/config'
+
+const mockNuxt = {
+  _appConfig: {} as Partial<{
+    apiUrl: string
+    featureFlags: Record<string, boolean>
+    entries: Array<{ label: string }>
+  }>,
+}
+
+vi.mock('../src/app/nuxt', () => ({
+  useNuxtApp: () => mockNuxt,
+}))
+
+describe('_replaceAppConfig', () => {
+  beforeEach(() => {
+    mockNuxt._appConfig = {
+      apiUrl: 'https://api.example.com',
+      featureFlags: { foo: false },
+      entries: [{ label: 'foo' }, { label: 'bar' }],
+    }
+  })
+
+  it('should remove properties not in new config', () => {
+    const newConfig = {
+      featureFlags: { baz: true },
+      entries: [{ label: 'baz' }],
+    }
+
+    _replaceAppConfig(newConfig)
+    expect(mockNuxt._appConfig).toEqual({
+      featureFlags: { baz: true },
+      entries: [{ label: 'baz' }],
+    })
+  })
+
+  it('should add new properties from new config', () => {
+    const newConfig = {
+      apiUrl: 'https://api.newexample.com',
+      featureFlags: { foo: true, baz: true },
+      entries: [{ label: 'foo' }, { label: 'bar' }, { label: 'baz' }],
+    }
+
+    _replaceAppConfig(newConfig)
+
+    expect(mockNuxt._appConfig).toEqual({
+      apiUrl: 'https://api.newexample.com',
+      featureFlags: { foo: true, baz: true },
+      entries: [{ label: 'foo' }, { label: 'bar' }, { label: 'baz' }],
+    })
+
+    expect(mockNuxt._appConfig.entries?.length).toEqual(3)
+  })
+
+  it('should update properties in arrays', () => {
+    const newConfig = {
+      entries: [{ label: 'updated-foo' }, { label: 'updated-bar' }],
+    }
+
+    _replaceAppConfig(newConfig)
+
+    expect(mockNuxt._appConfig.entries).toEqual([
+      { label: 'updated-foo' },
+      { label: 'updated-bar' },
+    ])
+  })
+
+  it('should handle replacing arrays with objects and vice versa', () => {
+    const newConfig = {
+      entries: { first: { label: 'only-entry' } },
+    }
+
+    _replaceAppConfig(newConfig)
+
+    expect(mockNuxt._appConfig.entries).toEqual({ first: { label: 'only-entry' } })
+
+    const anotherNewConfig = {
+      entries: [{ label: 'restored-entry' }],
+    }
+
+    _replaceAppConfig(anotherNewConfig)
+
+    expect(mockNuxt._appConfig.entries).toEqual([{ label: 'restored-entry' }])
+  })
+
+  it('should preserve element order in arrays', () => {
+    const newConfig = {
+      entries: [{ label: 'foo' }, { label: 'baz' }, { label: 'bar' }],
+    }
+
+    _replaceAppConfig(newConfig)
+
+    expect(mockNuxt._appConfig.entries).toEqual([
+      { label: 'foo' },
+      { label: 'baz' },
+      { label: 'bar' },
+    ])
+  })
+
+  it('should preserve object references for unchanged properties', () => {
+    const originalFeatureFlags = mockNuxt._appConfig.featureFlags
+    const newConfig = {
+      apiUrl: 'https://api.example.com',
+      featureFlags: { foo: false }, // unchanged
+      entries: [{ label: 'new-entry' }],
+    }
+
+    _replaceAppConfig(newConfig)
+
+    expect(mockNuxt._appConfig.featureFlags).toBe(originalFeatureFlags)
+  })
+
+  it('should preserve object references in arrays for unchanged elements', () => {
+    const originalEntries = mockNuxt._appConfig.entries
+    const newConfig = {
+      entries: [originalEntries![0], { label: 'new-bar' }],
+    }
+
+    _replaceAppConfig(newConfig)
+
+    expect(mockNuxt._appConfig.entries![0]).toBe(originalEntries![0])
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue
fix https://github.com/nuxt/nuxt/issues/33553
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
This fixes several issues with app config merging during HMR. Previously, the implementation would leave gaps in arrays where properties were removed, or fail to correctly replace arrays with objects and vice versa.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/4.x/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
