### PR TITLE
fix(nuxt): propagate Set-Cookie headers from internal API calls during SSR

### DIFF
--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -684,6 +684,18 @@ describe('nuxt composables', () => {
     const cookies = res.headers.get('set-cookie')
     expect(cookies).toMatchInlineSnapshot('"set-in-plugin=true; Path=/, accessed-with-default-value=default; Path=/, set=set; Path=/, browser-set=set; Path=/, browser-set-to-null=; Max-Age=0; Path=/, browser-set-to-null-with-default=; Max-Age=0; Path=/, browser-object-default=%7B%22foo%22%3A%22bar%22%7D; Path=/, theCookie=show; Path=/"')
   })
+
+  it('propagates httpOnly cookies from useFetch during SSR', async () => {
+    const res = await fetch('/cookie-test')
+    const setCookieHeader = res.headers.get('set-cookie')
+    expect(setCookieHeader).toBeTruthy()
+    expect(setCookieHeader).toContain('my-h3-counter=')
+    expect(setCookieHeader).toContain('HttpOnly')
+    expect(setCookieHeader).toContain('Secure')
+    const html = await res.text()
+    expect(html).toContain('Counter:')
+  })
+
   it('updates cookies when they are changed', async () => {
     const { page } = await renderPage('/cookies')
     async function extractCookie () {

--- a/test/fixtures/basic/app/pages/cookie-test.vue
+++ b/test/fixtures/basic/app/pages/cookie-test.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+const result = await useFetch('/api/cookie-test', {
+  method: 'POST',
+})
+</script>
+
+<template>
+  <div>
+    <h1>Cookie Test</h1>
+    <p>Counter: {{ result.data?.value?.count }}</p>
+  </div>
+</template>

--- a/test/fixtures/basic/server/api/cookie-test.ts
+++ b/test/fixtures/basic/server/api/cookie-test.ts
@@ -1,4 +1,4 @@
-import type { H3Event, EventHandlerRequest } from 'h3'
+import type { EventHandlerRequest, H3Event } from 'h3'
 
 export default defineEventHandler(async (event) => {
   const body = await readBody<{ reset?: boolean }>(event)
@@ -10,7 +10,7 @@ export default defineEventHandler(async (event) => {
   return { count }
 })
 
-async function h3Counter(event: H3Event<EventHandlerRequest>, name: string, reset = false) {
+async function h3Counter (event: H3Event<EventHandlerRequest>, name: string, reset = false) {
   const session = await useSession<{ counter?: number }>(event, {
     name,
     password: 'supersecretpasswordsupersecretpasswordsupersecretpasswordsupersecretpasswordsupersecretpassword',

--- a/test/fixtures/basic/server/api/cookie-test.ts
+++ b/test/fixtures/basic/server/api/cookie-test.ts
@@ -1,0 +1,30 @@
+import type { H3Event, EventHandlerRequest } from 'h3'
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody<{ reset?: boolean }>(event)
+  if (body?.reset) {
+    const count = await h3Counter(event, 'my-h3-counter', true)
+    return { count }
+  }
+  const count = await h3Counter(event, 'my-h3-counter')
+  return { count }
+})
+
+async function h3Counter(event: H3Event<EventHandlerRequest>, name: string, reset = false) {
+  const session = await useSession<{ counter?: number }>(event, {
+    name,
+    password: 'supersecretpasswordsupersecretpasswordsupersecretpasswordsupersecretpasswordsupersecretpassword',
+    cookie: {
+      httpOnly: true,
+      secure: true,
+      sameSite: 'strict',
+    },
+  })
+  if (reset) {
+    await session.update({ counter: 0 })
+    return 0
+  }
+  const currentCount = session.data.counter || 0
+  await session.update({ counter: currentCount + 1 })
+  return currentCount + 1
+}


### PR DESCRIPTION
### 🔗 Linked issue

Fixes: #33560

### 📚 Description

When using `useFetch()` during SSR to call internal Nuxt API routes (e.g., `/api/endpoint`), `Set-Cookie`
   headers set by the API handler were not being propagated to the client browser. This meant that
  HTTP-only session cookies and other secure cookies set by the server would not reach the client during
  server-side rendering.

  ## Changes
  - Added `onResponse` hook in `useFetch` for local fetch calls during SSR that captures `Set-Cookie`
  headers from the internal API response and appends them to the SSR response
  - Uses `getSetCookie()` when available (newer Fetch API) for proper cookie handling
  - Falls back to iterating headers for compatibility with older runtimes
  - Preserves existing `onResponse` hooks (both single functions and arrays of hooks)

  ## Test Plan
  - Added test case `propagates httpOnly cookies from useFetch during SSR` in `test/basic.test.ts`
  - Created test fixtures:
    - `/cookie-test` page that uses `useFetch` to call an internal API
    - `/api/cookie-test` endpoint that sets an HTTP-only secure session cookie
  - Test verifies that the `Set-Cookie` header with `HttpOnly` and `Secure` flags is present in the SSR
  response
