### PR TITLE
fix(vite): ensure optimizeDeps config is applied with environment api

### DIFF
--- a/packages/vite/src/plugins/environments.ts
+++ b/packages/vite/src/plugins/environments.ts
@@ -24,6 +24,7 @@ export function EnvironmentsPlugin (nuxt: Nuxt): Plugin {
 
   return {
     name: 'nuxt:environments',
+    enforce: 'pre', // run before other plugins
     config (config) {
       viteConfig = config
       if (!nuxt.options.dev) {


### PR DESCRIPTION
### 🔗 Linked issue

Fixes: #33582

## Summary

  Adds `enforce: 'pre'` to the EnvironmentsPlugin to ensure it runs before other Vite plugins, fixing issues where dependency optimization configuration was not correctly
   applied.

  ## Problem

  After migrating to Vite's Environment API, certain packages (like `ufo`, `@supabase/postgrest-js`) failed to load with errors:
  - `The entry point "ufo" cannot be marked as external`
  - `The requested module doesn't provide an export named: 'default'`

  This happened because the `optimizeDeps` configuration from `clientEnvironment()` was being overridden or not correctly merged by other plugins running later in the
  pipeline.

  ## Solution

  By adding `enforce: 'pre'` to the EnvironmentsPlugin, we ensure:
  1. The plugin runs before all normal plugins
  2. The `optimizeDeps` configuration is correctly applied at the root level
  3. Vite properly optimizes CJS dependencies to ESM before other plugins can interfere

  ## Test Plan

  - [x] Tested with `@nuxtjs/supabase` module in playground
  - [x] Verified no "ufo" external errors
  - [x] Confirmed Supabase client initializes correctly
  - [x] Checked that CJS modules are properly optimized