### PR TITLE
docs(useAsyncData): add missing pending field documentation

### DIFF
--- a/docs/3.api/2.composables/use-async-data.md
+++ b/docs/3.api/2.composables/use-async-data.md
@@ -18,7 +18,7 @@ Within your pages, components, and plugins you can use useAsyncData to get acces
 
 ```vue [app/pages/index.vue]
 <script setup lang="ts">
-const { data, status, error, refresh, clear } = await useAsyncData(
+const { data, pending, status, error, refresh, clear } = await useAsyncData(
   'mountains',
   () => $fetch('https://api.nuxtjs.dev/mountains'),
 )
@@ -150,6 +150,7 @@ Keyed state created using `useAsyncData` can be retrieved across your Nuxt appli
 ## Return Values
 
 - `data`: the result of the asynchronous function that is passed in.
+- `pending`: a boolean indicating whether the data is still being fetched.
 - `refresh`/`execute`: a function that can be used to refresh the data returned by the `handler` function.
 - `error`: an error object if the data fetching failed.
 - `status`: a string indicating the status of the data request:


### PR DESCRIPTION
## Description

This PR adds documentation for the `pending` field returned by `useAsyncData`, which was previously undocumented.

## Changes

- Added `pending` to the usage example
- Added `pending` to the Return Values section

## Context

The `pending` field is part of the `AsyncData` interface (defined in `packages/nuxt/src/app/composables/asyncData.ts`) but was not documented in the API reference.

Fixes #32956