### PR TITLE
fix(kit,nuxt,schema): deprecate `ImportPresetWithDeprecation`

### DIFF
--- a/packages/kit/src/imports.ts
+++ b/packages/kit/src/imports.ts
@@ -1,5 +1,4 @@
-import type { Import } from 'unimport'
-import type { ImportPresetWithDeprecation } from '@nuxt/schema'
+import type { Import, InlinePreset } from 'unimport'
 import { useNuxt } from './context'
 import { toArray } from './utils'
 
@@ -16,8 +15,8 @@ export function addImportsDir (dirs: string | string[], opts: { prepend?: boolea
     }
   })
 }
-export function addImportsSources (presets: ImportPresetWithDeprecation | ImportPresetWithDeprecation[]) {
-  useNuxt().hook('imports:sources', (_presets: ImportPresetWithDeprecation[]) => {
+export function addImportsSources (presets: InlinePreset | InlinePreset[]) {
+  useNuxt().hook('imports:sources', (_presets: InlinePreset[]) => {
     for (const preset of toArray(presets)) {
       _presets.push(preset)
     }

--- a/packages/nuxt/src/imports/module.ts
+++ b/packages/nuxt/src/imports/module.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'node:fs'
 import { addBuildPlugin, addTemplate, addTypeTemplate, createIsIgnored, defineNuxtModule, directoryToURL, getLayerDirectories, resolveAlias, tryResolveModule, updateTemplates, useNuxt } from '@nuxt/kit'
 import { isAbsolute, join, normalize, relative, resolve } from 'pathe'
-import type { Import, Unimport } from 'unimport'
+import type { Import, InlinePreset, Unimport } from 'unimport'
 import { createUnimport, scanDirExports, toExports } from 'unimport'
 import escapeRE from 'escape-string-regexp'
 
@@ -9,7 +9,7 @@ import { lookupNodeModuleSubpath, parseNodeModulePath } from 'mlly'
 import { isDirectory, logger, resolveToAlias } from '../utils'
 import { TransformPlugin } from './transform'
 import { appCompatPresets, defaultPresets } from './presets'
-import type { ImportPresetWithDeprecation, ImportsOptions, ResolvedNuxtTemplate } from 'nuxt/schema'
+import type { ImportsOptions, ResolvedNuxtTemplate } from 'nuxt/schema'
 
 import { pagesImportPresets, routeRulesPresets } from '../pages/module'
 
@@ -42,7 +42,7 @@ export default defineNuxtModule<Partial<ImportsOptions>>({
   }),
   setup (options, nuxt) {
     // TODO: fix sharing of defaults between invocations of modules
-    const presets = JSON.parse(JSON.stringify(options.presets)) as ImportPresetWithDeprecation[]
+    const presets: InlinePreset[] = JSON.parse(JSON.stringify(options.presets))
 
     if (options.polyfills) {
       presets.push(...appCompatPresets)

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -2,7 +2,9 @@
 export type { NuxtCompatibility, NuxtCompatibilityIssue, NuxtCompatibilityIssues } from './types/compatibility'
 export type { Component, ComponentMeta, ComponentsDir, ComponentsOptions, ScanDir } from './types/components'
 export type { AppConfig, AppConfigInput, CustomAppConfig, NuxtAppConfig, NuxtBuilder, NuxtConfig, NuxtConfigLayer, NuxtOptions, PublicRuntimeConfig, RuntimeConfig, RuntimeValue, SchemaDefinition, UpperSnakeCase, ViteConfig, ViteOptions } from './types/config'
-export type { GenerateAppOptions, HookResult, ImportPresetWithDeprecation, NuxtAnalyzeMeta, NuxtHookName, NuxtHooks, NuxtLayout, NuxtMiddleware, NuxtPage, TSReference, VueTSConfig, WatchEvent } from './types/hooks'
+// eslint-disable-next-line @typescript-eslint/no-deprecated
+export type { ImportPresetWithDeprecation } from './types/hooks'
+export type { GenerateAppOptions, HookResult, NuxtAnalyzeMeta, NuxtHookName, NuxtHooks, NuxtLayout, NuxtMiddleware, NuxtPage, TSReference, VueTSConfig, WatchEvent } from './types/hooks'
 export type { ImportsOptions } from './types/imports'
 export type { AppHeadMetaObject, MetaObject, MetaObjectRaw } from './types/head'
 export type { ModuleDefinition, ModuleDependencies, ModuleDependencyMeta, ModuleMeta, ModuleOptions, ModuleSetupInstallResult, ModuleSetupReturn, NuxtModule, ResolvedModuleOptions } from './types/module'

--- a/packages/schema/src/types/hooks.ts
+++ b/packages/schema/src/types/hooks.ts
@@ -61,6 +61,9 @@ export type NuxtLayout = {
   file: string
 }
 
+/**
+ * @deprecated Use {@link InlinePreset}
+ */
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface ImportPresetWithDeprecation extends InlinePreset {
 }
@@ -223,7 +226,7 @@ export interface NuxtHooks {
    * @param presets Array containing presets objects
    * @returns Promise
    */
-  'imports:sources': (presets: ImportPresetWithDeprecation[]) => HookResult
+  'imports:sources': (presets: InlinePreset[]) => HookResult
   /**
    * Called at setup allowing modules to extend imports.
    * @param imports Array containing the imports to extend


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Ran into this confusing parameter type, it used to contain a deprecated property which was removed 3 years ago.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/4.x/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
