### PR TITLE
fix(vite): use rolldown replace only in build

### DIFF
--- a/packages/vite/src/plugins/replace.ts
+++ b/packages/vite/src/plugins/replace.ts
@@ -19,7 +19,7 @@ export function ReplacePlugin (): Plugin {
         }
       }
 
-      if ((vite as any).rolldownVersion) {
+      if (config.isProduction && (vite as any).rolldownVersion) {
         const { replacePlugin } = await import('rolldown/experimental')
         return replacePlugin(replaceOptions, { preventAssignment: true })
       } else {


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/33602

resolved by https://github.com/rolldown/rolldown/pull/6782

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This probably isn't wanted as the final fix should be done in rolldown-vite. It's temporary

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/4.x/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
