### PR TITLE
fix(nuxt): correct warning message for prefetch/noPrefetch conflict

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -384,7 +384,7 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
       }
 
       if (import.meta.client) {
-        checkPropConflicts(props, 'prefetch', 'noPrefetch')
+        checkPropConflicts(props, 'noPrefetch', 'prefetch')
         if (shouldPrefetch('visibility')) {
           const nuxtApp = useNuxtApp()
           let idleId: number


### PR DESCRIPTION
### 🔗 Linked issue

resolves #33616

### 📚 Description

Swap argument order in checkPropConflicts to match actual implementation behavior.

The warning message now correctly states that `prefetch` will be ignored when both `prefetch` and `noPrefetch` are used together, which matches the actual implementation where `noPrefetch` takes priority.

