### PR TITLE
fix(nitro): remove `<nuxt-error-overlay>` iframe border

### DIFF
--- a/packages/nitro-server/src/runtime/utils/dev.ts
+++ b/packages/nitro-server/src/runtime/utils/dev.ts
@@ -145,6 +145,7 @@ const errorCSS = /* css */ `
   top: 0;
   width: 100vw;
   height: 100vh;
+  border: none;
   z-index: var(--z-base);
 }
 #frame[inert] {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/4.x/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->

Remove iframe border for `<nuxt-error-overlay>`.

||Fullscreen|Inert|
|-|-|-|
|Before|<img width="1409" height="1087" alt="QQ_1761979029397" src="https://github.com/user-attachments/assets/97e266fa-da82-47d9-b5d6-9daf03291902" />|<img width="1409" height="1087" alt="QQ_1761979069351" src="https://github.com/user-attachments/assets/e440e5bb-7458-4f83-9ff9-47845574cb95" />|
|After|<img width="1409" height="1087" alt="QQ_1761979178860" src="https://github.com/user-attachments/assets/543df8b7-a974-49ee-ab87-9c7ca3432dfb" />|<img width="1409" height="1087" alt="QQ_1761979222453" src="https://github.com/user-attachments/assets/01affcf0-8699-4303-b984-f338f35684e4" />|

BTW, the white line in the right of the iframe button is youch's scrollbar (https://github.com/poppinss/youch/pull/80).