### PR TITLE
fix(nitro): use directory paths in `moduleEntryPaths`

### DIFF
--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -10,7 +10,7 @@ import { createRouter as createRadixRouter, exportMatcher, toRouteMatcher } from
 import { joinURL, withTrailingSlash } from 'ufo'
 import { build, copyPublicAssets, createDevServer, createNitro, prepare, prerender, scanHandlers, writeTypes } from 'nitropack'
 import type { Nitro, NitroConfig, NitroOptions } from 'nitropack/types'
-import { addPlugin, addTemplate, addVitePlugin, createIsIgnored, findPath, getLayerDirectories, logger, resolveAlias, resolveIgnorePatterns, resolveNuxtModule } from '@nuxt/kit'
+import { addPlugin, addTemplate, addVitePlugin, createIsIgnored, findPath, getDirectory, getLayerDirectories, logger, resolveAlias, resolveIgnorePatterns, resolveNuxtModule } from '@nuxt/kit'
 import escapeRE from 'escape-string-regexp'
 import { defu } from 'defu'
 import { defineEventHandler, dynamicEventHandler } from 'h3'
@@ -67,7 +67,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }) {
   for (const m of nuxt.options._installedModules) {
     const path = m.meta?.rawPath || m.entryPath
     if (path) {
-      moduleEntryPaths.push(path)
+      moduleEntryPaths.push(getDirectory(path))
     }
   }
 


### PR DESCRIPTION
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
This fixes an issue where the generated tsconfig paths in

https://github.com/nuxt/nuxt/blob/89f59b7efd2bffa1b1f8c95f5e3c89888e3fcc64/packages/nitro-server/src/index.ts#L211-L215

were incorrect in some cases: _(notice the `index.ts` there)_

<img width="874" height="66" alt="image" src="https://github.com/user-attachments/assets/c0e03ef4-0141-4898-8d52-4fdebbdb57e2" />

<br>
<br>

I matched the implementation with:
https://github.com/nuxt/nuxt/blob/89f59b7efd2bffa1b1f8c95f5e3c89888e3fcc64/packages/kit/src/template.ts#L295-L301

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/4.x/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
