### PR TITLE
docs: clarify route middleware doesn't affect API routes

### DIFF
--- a/docs/1.getting-started/07.routing.md
+++ b/docs/1.getting-started/07.routing.md
@@ -91,7 +91,7 @@ Route middleware runs within the Vue part of your Nuxt app. Despite the similar 
 ::
 
 ::important
-Route middleware does **not** run for API routes (`/api/*`) or other server requests. To handle server requests, use [server middleware](/docs/4.x/guide/directory-structure/server#server-middleware) instead.
+Route middleware does **not** run for server routes (e.g. `/api/*`) or other server requests. To apply middleware to these requests, use [server middleware](/docs/4.x/guide/directory-structure/server#server-middleware) instead.
 ::
 
 There are three kinds of route middleware:

--- a/docs/1.getting-started/07.routing.md
+++ b/docs/1.getting-started/07.routing.md
@@ -90,6 +90,10 @@ Nuxt provides a customizable route middleware framework you can use throughout y
 Route middleware runs within the Vue part of your Nuxt app. Despite the similar name, they are completely different from server middleware, which are run in the Nitro server part of your app.
 ::
 
+::important
+Route middleware does **not** run for API routes (`/api/*`) or other server requests. To handle server requests, use [server middleware](/docs/4.x/guide/directory-structure/server#server-middleware) instead.
+::
+
 There are three kinds of route middleware:
 
 1. Anonymous (or inline) route middleware, which are defined directly in the pages where they are used.


### PR DESCRIPTION
Fixes #33642

Route middleware only runs during page navigation (Vue Router), not for API routes. Added callout to clarify this.

**Implementation:**
- Route middleware: [`packages/nuxt/src/pages/runtime/plugins/router.ts:182-260`](https://github.com/nuxt/nuxt/blob/89f59b7efd2bffa1b1f8c95f5e3c89888e3fcc64/packages/nuxt/src/pages/runtime/plugins/router.ts#L182-L260) (Vue Router `beforeEach`)
- API routes use Nitro/h3 `defineEventHandler` (separate runtime for now 😉)