### PR TITLE
refactor(kit,nitro,nuxt,schema,vite): explicitly import process/performance

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -143,6 +143,47 @@ export default createConfigForNuxt({
 
   // Append local rules
   .append(
+    {
+      files: ['packages/**/*.ts', 'packages/**/*.mts', 'packages/**/*.js', 'packages/**/*.mjs'],
+      name: 'local/requires/explicit-node-imports',
+      rules: {
+    // Ban direct use of restricted global identifiers
+      'no-restricted-globals': [
+      'error',
+        {
+          name: 'process',
+          message: 'Use explicit import: import process from "node:process" (or a scoped alias). Implicit globals are banned for clarity and tree-shakability.',
+      },
+      {
+          name: 'performance',
+          message: 'Use explicit import: import { performance } from "node:perf_hooks". Implicit global performance is banned in server contexts to ensure Node.js-specific usage.',
+      },
+    ],
+
+      // Ban the 'node:' prefix as a bare identifier (catches `node:process` or `node:perf` in require/import/typeof)
+      '@typescript-eslint/no-restricted-imports': [
+      'error',
+        {
+          paths: [
+            {
+              name: 'node:process',
+              message: 'Use quoted module specifier: import ... from "node:process" (not bare node:process).',
+          },
+          {
+              name: 'node:perf_hooks',
+              message: 'Use quoted module specifier: import ... from "node:perf_hooks" (not bare node:perf_hooks).',
+          },
+        ],
+        patterns: [
+          {
+              group: ['node:process', 'node:perf_hooks'],
+              message: 'Bare node: prefixes are banned. Use "node:process" or "node:perf_hooks" as strings in import/require.',
+              },
+            ],
+          },
+        ],
+      },
+    },
     // @ts-expect-error type issues
     {
       files: ['**/*.vue', '**/*.ts', '**/*.mts', '**/*.js', '**/*.cjs', '**/*.mjs'],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -157,32 +157,9 @@ export default createConfigForNuxt({
       {
           name: 'performance',
           message: 'Use explicit import: import { performance } from "node:perf_hooks". Implicit global performance is banned in server contexts to ensure Node.js-specific usage.',
-      },
-    ],
-
-      // Ban the 'node:' prefix as a bare identifier (catches `node:process` or `node:perf` in require/import/typeof)
-      '@typescript-eslint/no-restricted-imports': [
-      'error',
-        {
-          paths: [
-            {
-              name: 'node:process',
-              message: 'Use quoted module specifier: import ... from "node:process" (not bare node:process).',
-          },
-          {
-              name: 'node:perf_hooks',
-              message: 'Use quoted module specifier: import ... from "node:perf_hooks" (not bare node:perf_hooks).',
-          },
-        ],
-        patterns: [
-          {
-              group: ['node:process', 'node:perf_hooks'],
-              message: 'Bare node: prefixes are banned. Use "node:process" or "node:perf_hooks" as strings in import/require.',
-              },
-            ],
-          },
-        ],
-      },
+        },
+      ],
+     },
     },
     // @ts-expect-error type issues
     {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -147,19 +147,19 @@ export default createConfigForNuxt({
       files: ['packages/**/*.ts', 'packages/**/*.mts', 'packages/**/*.js', 'packages/**/*.mjs'],
       name: 'local/requires/explicit-node-imports',
       rules: {
-    // Ban direct use of restricted global identifiers
-      'no-restricted-globals': [
-      'error',
-        {
-          name: 'process',
-          message: 'Use explicit import: import process from "node:process" (or a scoped alias). Implicit globals are banned for clarity and tree-shakability.',
+        // Ban direct use of restricted global identifiers
+        'no-restricted-globals': [
+          'error',
+          //   {
+          //     name: 'process',
+          //     message: 'Use explicit import: import process from "node:process" (or a scoped alias). Implicit globals are banned for clarity and tree-shakability.',
+          // },
+          {
+            message: 'Use explicit import: import { performance } from "node:perf_hooks". Implicit global performance is banned in server contexts to ensure Node.js-specific usage.',
+            name: 'performance',
+          },
+        ],
       },
-      {
-          name: 'performance',
-          message: 'Use explicit import: import { performance } from "node:perf_hooks". Implicit global performance is banned in server contexts to ensure Node.js-specific usage.',
-        },
-      ],
-     },
     },
     // @ts-expect-error type issues
     {
@@ -239,6 +239,7 @@ export default createConfigForNuxt({
                   'errx', /* only used in dev */
                   // internal deps
                   'nuxt/app',
+                  'node:perf_hooks',
                 ].map(r => `!${r}`),
                 '!#[a-z]*/**', // aliases
                 '!.*/**', // relative imports

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -145,6 +145,7 @@ export default createConfigForNuxt({
   .append(
     {
       files: ['packages/**/*.ts', 'packages/**/*.mts', 'packages/**/*.js', 'packages/**/*.mjs'],
+      ignores: ['packages/**/*.client.ts', 'packages/**/*.client.mts', 'packages/**/*.client.js', 'packages/**/*.client.mjs'],
       name: 'local/requires/explicit-node-imports',
       rules: {
         // Ban direct use of restricted global identifiers
@@ -239,7 +240,6 @@ export default createConfigForNuxt({
                   'errx', /* only used in dev */
                   // internal deps
                   'nuxt/app',
-                  'node:perf_hooks',
                 ].map(r => `!${r}`),
                 '!#[a-z]*/**', // aliases
                 '!.*/**', // relative imports

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -151,10 +151,10 @@ export default createConfigForNuxt({
         // Ban direct use of restricted global identifiers
         'no-restricted-globals': [
           'error',
-          //   {
-          //     name: 'process',
-          //     message: 'Use explicit import: import process from "node:process" (or a scoped alias). Implicit globals are banned for clarity and tree-shakability.',
-          // },
+          {
+            message: 'Use explicit import: import process from "node:process" (or a scoped alias). Implicit globals are banned for clarity and tree-shakability.',
+            name: 'process',
+          },
           {
             message: 'Use explicit import: import { performance } from "node:perf_hooks". Implicit global performance is banned in server contexts to ensure Node.js-specific usage.',
             name: 'performance',

--- a/packages/kit/src/loader/config.ts
+++ b/packages/kit/src/loader/config.ts
@@ -1,4 +1,5 @@
 import { existsSync } from 'node:fs'
+import process from 'node:process'
 import type { JSValue } from 'untyped'
 import { applyDefaults } from 'untyped'
 import type { ConfigLayer, ConfigLayerMeta, LoadConfigOptions } from 'c12'

--- a/packages/kit/src/resolve.ts
+++ b/packages/kit/src/resolve.ts
@@ -1,5 +1,6 @@
 import { promises as fsp } from 'node:fs'
 import { fileURLToPath } from 'node:url'
+import process from 'node:process'
 import { basename, dirname, isAbsolute, join, normalize, resolve } from 'pathe'
 import { type GlobOptions, glob } from 'tinyglobby'
 import { resolveModulePath } from 'exsolve'

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -1,6 +1,7 @@
 import { pathToFileURL } from 'node:url'
 import { existsSync, promises as fsp, readFileSync } from 'node:fs'
 import { cpus } from 'node:os'
+import process from 'node:process'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import type { Nuxt, NuxtOptions } from '@nuxt/schema'

--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
+import process from 'node:process'
 import {
   getPrefetchLinks,
   getPreloadLinks,

--- a/packages/nitro-server/src/runtime/utils/cache.ts
+++ b/packages/nitro-server/src/runtime/utils/cache.ts
@@ -2,6 +2,7 @@
 // This is likely not portable. A type annotation is necessary.
 import type {} from 'unstorage'
 import { useStorage } from 'nitropack/runtime'
+import process from 'node:process'
 
 export const payloadCache = import.meta.prerender ? useStorage('internal:nuxt:prerender:payload') : null
 export const islandCache = import.meta.prerender ? useStorage('internal:nuxt:prerender:island') : null

--- a/packages/nitro-server/src/runtime/utils/renderer/app.ts
+++ b/packages/nitro-server/src/runtime/utils/renderer/app.ts
@@ -1,3 +1,4 @@
+import process from 'node:process'
 import type { H3Event } from 'h3'
 import { useRuntimeConfig } from 'nitropack/runtime'
 import { createHead } from '@unhead/vue/server'

--- a/packages/nitro-server/src/runtime/utils/renderer/build-files.ts
+++ b/packages/nitro-server/src/runtime/utils/renderer/build-files.ts
@@ -1,3 +1,4 @@
+import process from 'node:process'
 import { createRenderer } from 'vue-bundle-renderer/runtime'
 import type { Manifest, PrecomputedData } from 'vue-bundle-renderer'
 import { renderToString as _renderToString } from 'vue/server-renderer'

--- a/packages/nitro-server/src/runtime/utils/renderer/payload.ts
+++ b/packages/nitro-server/src/runtime/utils/renderer/payload.ts
@@ -1,4 +1,5 @@
 import type { RenderResponse } from 'nitropack/types'
+import process from 'node:process'
 import { getResponseStatus, getResponseStatusText } from 'h3'
 import devalue from '@nuxt/devalue'
 import { stringify, uneval } from 'devalue'

--- a/packages/nuxt/src/app/plugins/browser-devtools-timing.client.ts
+++ b/packages/nuxt/src/app/plugins/browser-devtools-timing.client.ts
@@ -1,3 +1,4 @@
+import { performance } from 'node:perf_hooks'
 import { defineNuxtPlugin } from '../nuxt'
 
 export default defineNuxtPlugin({

--- a/packages/nuxt/src/app/plugins/browser-devtools-timing.client.ts
+++ b/packages/nuxt/src/app/plugins/browser-devtools-timing.client.ts
@@ -1,4 +1,3 @@
-import { performance } from 'node:perf_hooks'
 import { defineNuxtPlugin } from '../nuxt'
 
 export default defineNuxtPlugin({

--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -1,4 +1,5 @@
 import { promises as fsp, mkdirSync, writeFileSync } from 'node:fs'
+import { performance } from 'node:perf_hooks'
 import { dirname, join, relative, resolve } from 'pathe'
 import { defu } from 'defu'
 import { findPath, getLayerDirectories, normalizePlugin, normalizeTemplate, resolveFiles, resolvePath } from '@nuxt/kit'

--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -1,4 +1,5 @@
 import { promises as fsp, mkdirSync, writeFileSync } from 'node:fs'
+import process from 'node:process'
 import { performance } from 'node:perf_hooks'
 import { dirname, join, relative, resolve } from 'pathe'
 import { defu } from 'defu'

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -1,3 +1,4 @@
+import process from 'node:process'
 import { existsSync } from 'node:fs'
 import { rm } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'

--- a/packages/nuxt/src/core/plugins/virtual.ts
+++ b/packages/nuxt/src/core/plugins/virtual.ts
@@ -1,3 +1,4 @@
+import process from 'node:process'
 import { resolveAlias } from '@nuxt/kit'
 import type { Nuxt } from '@nuxt/schema'
 import { dirname, isAbsolute, resolve } from 'pathe'

--- a/packages/nuxt/test/components-tree-shake.test.ts
+++ b/packages/nuxt/test/components-tree-shake.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs'
 import path from 'node:path'
+import process from 'node:process'
 import { describe, expect, it, vi } from 'vitest'
 import * as VueCompilerSFC from 'vue/compiler-sfc'
 import type { Plugin } from 'vite'

--- a/packages/nuxt/test/unhead-imports.test.ts
+++ b/packages/nuxt/test/unhead-imports.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import process from 'node:process'
 import { describe, expect, it } from 'vitest'
 import { compileScript, parse } from '@vue/compiler-sfc'
 import { UnheadImportsPlugin } from '../src/head/plugins/unhead-imports'

--- a/packages/schema/src/config/app.ts
+++ b/packages/schema/src/config/app.ts
@@ -1,3 +1,4 @@
+import process from 'node:process'
 import { defu } from 'defu'
 import { resolve } from 'pathe'
 import { defineResolvers } from '../utils/definition'

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -1,3 +1,4 @@
+import process from 'node:process'
 import { existsSync } from 'node:fs'
 import { readdir } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'

--- a/packages/schema/src/config/dev.ts
+++ b/packages/schema/src/config/dev.ts
@@ -1,3 +1,4 @@
+import process from 'node:process'
 import { defineResolvers } from '../utils/definition'
 import { template as loadingTemplate } from '../../../ui-templates/dist/templates/loading'
 

--- a/packages/schema/src/config/webpack.ts
+++ b/packages/schema/src/config/webpack.ts
@@ -1,3 +1,4 @@
+import process from 'node:process'
 import { defu } from 'defu'
 import { defineResolvers } from '../utils/definition'
 

--- a/packages/schema/test/folder-structure.spec.ts
+++ b/packages/schema/test/folder-structure.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { applyDefaults } from 'untyped'
+import process from 'node:process'
 
 import { normalize } from 'pathe'
 import { NuxtConfigSchema } from '../src'

--- a/packages/ui-templates/vite.config.ts
+++ b/packages/ui-templates/vite.config.ts
@@ -1,3 +1,4 @@
+import process from 'node:process'
 import { fileURLToPath } from 'node:url'
 import { resolve } from 'node:path'
 import { readdirSync } from 'node:fs'

--- a/packages/vite/src/plugins/vite-node.ts
+++ b/packages/vite/src/plugins/vite-node.ts
@@ -1,3 +1,4 @@
+import process from 'node:process'
 import { mkdir, unlink, writeFile } from 'node:fs/promises'
 import type { Socket } from 'node:net'
 import net from 'node:net'

--- a/packages/vite/src/runtime/vite-node-shared.mjs
+++ b/packages/vite/src/runtime/vite-node-shared.mjs
@@ -1,4 +1,5 @@
 // @ts-check
+import process from 'node:process'
 import net from 'node:net'
 import { Buffer } from 'node:buffer'
 import { isTest } from 'std-env'

--- a/packages/vite/src/runtime/vite-node.mjs
+++ b/packages/vite/src/runtime/vite-node.mjs
@@ -1,5 +1,6 @@
 // @ts-check
 
+import process from 'node:process'
 import { performance } from 'node:perf_hooks'
 import { createError } from 'h3'
 import { ViteNodeRunner } from 'vite-node/client'

--- a/packages/vite/src/utils/logger.ts
+++ b/packages/vite/src/utils/logger.ts
@@ -1,3 +1,4 @@
+import process from 'node:process'
 import type * as vite from 'vite'
 import { createLogger } from 'vite'
 import { logger } from '@nuxt/kit'

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -1,4 +1,5 @@
 import { existsSync } from 'node:fs'
+import { performance } from 'node:perf_hooks'
 import { createBuilder, createServer, mergeConfig } from 'vite'
 import * as vite from 'vite'
 import { basename, dirname, join, resolve } from 'pathe'


### PR DESCRIPTION
@danielroe , I've updated eslint config. if we run pnpm lint then it shows some error for `process` or `performance` if not explicitly imported.