### PR TITLE
fix(nuxt): start error overlay minimized based on status code

### DIFF
--- a/packages/nitro-server/src/runtime/handlers/error.ts
+++ b/packages/nitro-server/src/runtime/handlers/error.ts
@@ -85,7 +85,7 @@ export default <NitroErrorHandler> async function errorhandler (error, event, { 
 
   if (import.meta.dev) {
     const prettyResponse = await defaultHandler(error, event, { json: false })
-    return send(event, html.replace('</body>', `${generateErrorOverlayHTML(prettyResponse.body as string)}</body>`))
+    return send(event, html.replace('</body>', `${generateErrorOverlayHTML(prettyResponse.body as string, { startMinimized: 300 <= statusCode && statusCode < 500 })}</body>`))
   }
 
   return send(event, html)

--- a/packages/nitro-server/src/runtime/utils/dev.ts
+++ b/packages/nitro-server/src/runtime/utils/dev.ts
@@ -207,7 +207,7 @@ const errorCSS = /* css */ `
 }
 `
 
-function webComponentScript (base64HTML: string) {
+function webComponentScript (base64HTML: string, startMinimized: boolean) {
   return /* js */ `
   (function() {
     try {
@@ -299,6 +299,11 @@ function webComponentScript (base64HTML: string) {
       shadow.appendChild(preview);
       shadow.appendChild(button);
       
+      if (${startMinimized}) {
+        iframe.setAttribute('inert', '');
+        button.setAttribute('aria-expanded', 'false');
+      }
+      
       // Initialize preview
       setTimeout(updatePreview, 100);
       
@@ -309,13 +314,13 @@ function webComponentScript (base64HTML: string) {
   `
 }
 
-export function generateErrorOverlayHTML (html: string) {
+export function generateErrorOverlayHTML (html: string, options?: { startMinimized?: boolean }) {
   const nonce = Array.from(crypto.getRandomValues(new Uint8Array(16)), b => b.toString(16).padStart(2, '0')).join('')
   const errorPage = html.replace('<head>', `<head><script>${iframeStorageBridge(nonce)}</script>`)
   const base64HTML = Buffer.from(errorPage, 'utf8').toString('base64')
   return `
     <script>${parentStorageBridge(nonce)}</script>
     <nuxt-error-overlay></nuxt-error-overlay>
-    <script>${webComponentScript(base64HTML)}</script>
+    <script>${webComponentScript(base64HTML, options?.startMinimized ?? false)}</script>
   `
 }


### PR DESCRIPTION
### 🔗 Linked issue
resolves https://github.com/nuxt/nuxt/issues/33573

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Non-critical errors will now initially show the error page instead of the error overlay.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/4.x/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
