### PR TITLE
fix: process prerender routes on `pages:resolved`

### DIFF
--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -388,7 +388,7 @@ export default defineNuxtModule({
       }
     }
 
-    nuxt.hook('pages:extend', (pages) => {
+    nuxt.hook('pages:resolved', (pages) => {
       if (nuxt.options.dev) { return }
 
       prerenderRoutes.clear()


### PR DESCRIPTION
### 🔗 Linked issue
* Resolves https://github.com/nuxt/nuxt/issues/33614

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Prerendering currently ignores changes made to pages/routes in `pages:resolved`.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/4.x/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
