### PR TITLE
docs: update vite-node

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -60,7 +60,7 @@
     "ufo": "^1.6.1",
     "unenv": "^2.0.0-rc.24",
     "vite": "^7.1.12",
-    "vite-node": "^3.2.4",
+    "vite-node": "^5.0.0-beta.2",
     "vite-plugin-checker": "^0.11.0",
     "vue-bundle-renderer": "^2.2.0"
   },

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -60,7 +60,7 @@
     "ufo": "^1.6.1",
     "unenv": "^2.0.0-rc.24",
     "vite": "^7.1.12",
-    "vite-node": "^5.0.0-beta.2",
+    "vite-node": "^5.0.0",
     "vite-plugin-checker": "^0.11.0",
     "vue-bundle-renderer": "^2.2.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1076,8 +1076,8 @@ importers:
         specifier: 7.1.12
         version: 7.1.12(@types/node@24.10.0)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.1)
       vite-node:
-        specifier: ^5.0.0-beta.2
-        version: 5.0.0-beta.2(@types/node@24.10.0)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.1)
+        specifier: ^5.0.0
+        version: 5.0.0(@types/node@24.10.0)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.1)
       vite-plugin-checker:
         specifier: ^0.11.0
         version: 0.11.0(eslint@9.39.0(jiti@2.6.1))(optionator@0.9.4)(typescript@5.9.3)(vite@7.1.12(@types/node@24.10.0)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.1))(vue-tsc@3.1.3(typescript@5.9.3))
@@ -8130,8 +8130,8 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
-  vite-node@5.0.0-beta.2:
-    resolution: {integrity: sha512-JRThfAQEqZJIHKEcDV8B2IpTY27M7i9b4HUpNDUYVZ9Jw3GNkEo4OGNC2/FQ4ndp2Y0TEP6AlS0dFy1O0VuUUg==}
+  vite-node@5.0.0:
+    resolution: {integrity: sha512-nJINVH7lHBKoyDFYnwrXbNUrmTJ2ssBHTd/mXVZfLq/O5K7ksv4CayQOA5KkbOSrsgSQg8antcVPgQmzBWWn/w==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
@@ -16331,7 +16331,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@5.0.0-beta.2(@types/node@24.10.0)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.1):
+  vite-node@5.0.0(@types/node@24.10.0)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1076,8 +1076,8 @@ importers:
         specifier: 7.1.12
         version: 7.1.12(@types/node@24.10.0)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.1)
       vite-node:
-        specifier: ^3.2.4
-        version: 3.2.4(@types/node@24.10.0)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.1)
+        specifier: ^5.0.0-beta.2
+        version: 5.0.0-beta.2(@types/node@24.10.0)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.1)
       vite-plugin-checker:
         specifier: ^0.11.0
         version: 0.11.0(eslint@9.39.0(jiti@2.6.1))(optionator@0.9.4)(typescript@5.9.3)(vite@7.1.12(@types/node@24.10.0)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.1))(vue-tsc@3.1.3(typescript@5.9.3))
@@ -8127,6 +8127,11 @@ packages:
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite-node@5.0.0-beta.2:
+    resolution: {integrity: sha512-JRThfAQEqZJIHKEcDV8B2IpTY27M7i9b4HUpNDUYVZ9Jw3GNkEo4OGNC2/FQ4ndp2Y0TEP6AlS0dFy1O0VuUUg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
@@ -16306,6 +16311,27 @@ snapshots:
       vite: 7.1.12(@types/node@24.10.0)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.1)
 
   vite-node@3.2.4(@types/node@24.10.0)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.1):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.1.12(@types/node@24.10.0)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite-node@5.0.0-beta.2(@types/node@24.10.0)(jiti@2.6.1)(terser@5.44.0)(yaml@2.8.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3

--- a/renovate.json
+++ b/renovate.json
@@ -24,7 +24,6 @@
     {
       "groupName": "vitest",
       "matchPackageNames": [
-        "vite-node",
         "vitest",
         "/^@vitest//"
       ]


### PR DESCRIPTION
`vite-node` has now moved outside of Vitest: https://github.com/antfu-collective/vite-node/pull/5

This PR is for running the test to verify everything works as-is.