### PR TITLE
fix(nuxt): focus `<NuxtLink />` after click

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -358,7 +358,7 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
 
       // Prefetching
       const prefetched = shallowRef(false)
-      const el = import.meta.server ? undefined : ref<HTMLElement | null>(null)
+      const el = import.meta.server ? undefined : ref<HTMLAnchorElement | null>(null)
       const elRef = import.meta.server ? undefined : (ref: any) => { el!.value = props.custom ? ref?.$el?.nextElementSibling : ref?.$el }
 
       function shouldPrefetch (mode: 'visibility' | 'interaction') {
@@ -394,7 +394,7 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
             onNuxtReady(() => {
               idleId = requestIdleCallback(() => {
                 if (el?.value?.tagName) {
-                  unobserve = observer!.observe(el.value as HTMLElement, async () => {
+                  unobserve = observer!.observe(el.value as HTMLAnchorElement, async () => {
                     unobserve?.()
                     unobserve = null
                     await prefetch(nuxtApp)
@@ -517,6 +517,8 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
             }
 
             event.preventDefault()
+
+            ;(event.target as HTMLAnchorElement)?.focus()
 
             return props.replace
               ? router.replace(href.value)


### PR DESCRIPTION
### 🔗 Linked issue

fixes #33668

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This manually focuses the `<a />` element after preventDefault. This should improve a11y.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/4.x/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
