### PR TITLE
ci: add `--pnpm` flag to correctly publish prerelease

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,5 +390,4 @@ jobs:
           name: dist
           path: packages
 
-      # TODO: './packages/nitro-server'
-      - run: pnpm pkg-pr-new publish --compact --pnpm './packages/kit' './packages/nuxt' './packages/rspack' './packages/schema' './packages/vite' './packages/webpack'
+      - run: pnpm pkg-pr-new publish --compact --pnpm './packages/kit' './packages/nitro-server' './packages/nuxt' './packages/rspack' './packages/schema' './packages/vite' './packages/webpack'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,5 +390,5 @@ jobs:
           name: dist
           path: packages
 
-      # TODO: './packages/nitro-server' 
-      - run: pnpm pkg-pr-new publish --compact './packages/kit' './packages/nuxt' './packages/rspack' './packages/schema' './packages/vite' './packages/webpack'
+      # TODO: './packages/nitro-server'
+      - run: pnpm pkg-pr-new publish --compact --pnpm './packages/kit' './packages/nuxt' './packages/rspack' './packages/schema' './packages/vite' './packages/webpack'


### PR DESCRIPTION
### 🔗 Linked issue

Related to testing prerelease of https://github.com/nuxt/nuxt/pull/33446

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This forces pr.pkg.new to use `pnpm pack` instead of `npm pack`.

This should fix errors like this:

```
In : "@nuxt/nitro-server@workspace:*" is in the dependencies but no package named "@nuxt/nitro-server" is present in the workspace
```

Should we handle the todo (`# TODO: './packages/nitro-server'`)?

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/4.x/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
