### PR TITLE
docs: fix link to vitest globals config

### DIFF
--- a/docs/1.getting-started/17.testing.md
+++ b/docs/1.getting-started/17.testing.md
@@ -267,7 +267,7 @@ it('can also mount an app', async () => {
 
 This should be used together with utilities from Testing Library, e.g. `screen` and `fireEvent`. Install [@testing-library/vue](https://testing-library.com/docs/vue-testing-library/intro/) in your project to use these.
 
-Additionally, Testing Library also relies on testing globals for cleanup. You should turn these on in your [Vitest config](https://vitest.dev/config/#globals).
+Additionally, Testing Library also relies on testing globals for cleanup. You should turn these on in your [Vitest config](https://vitest.dev/config/globals).
 
 The passed in component will be rendered inside a `<div id="test-wrapper"></div>`.
 


### PR DESCRIPTION
### 🔗 Linked issue
### 📚 Description
Not sure what changed but linking to https://vitest.dev/config/#globals doesn't properly resolve, https://vitest.dev/config/globals does.