### PR TITLE
docs: add missing deno icon

### DIFF
--- a/docs/1.getting-started/02.installation.md
+++ b/docs/1.getting-started/02.installation.md
@@ -54,11 +54,10 @@ pnpm create nuxt@latest <project-name>
 ```bash [bun]
 bun create nuxt@latest <project-name>
 ```
-
+// deno icon missing
 ```bash [deno]
 deno -A npm:create-nuxt@latest <project-name>
 ```
-
 ::
 
 ::tip
@@ -101,7 +100,7 @@ bun run dev -o
 # To use the Bun runtime during development
 # bun --bun run dev -o
 ```
-
+// deno icon missing
 ```bash [deno]
 deno run dev -o
 ```


### PR DESCRIPTION
@danielroe , 
Look, all package managers icon is present except deno. deno's icon is missing. This is in the installation page. (https://nuxt.com/docs/4.x/getting-started/installation).
I think is special class in the span e.g., for bun it is `iconify i-vscode-icons:file-type-bun size-4 shrink-0`. I have inspected in browser and get it. I have searched in vs code but i cannot get it. I cannot understand from where i need to change the code for giving the missing deno icon. please help me.  


<img width="1201" height="423" alt="icon" src="https://github.com/user-attachments/assets/c5fc46e1-220a-4dc4-ae7e-ff6b5b2dd249" />
