### PR TITLE
fix(kit,nuxt): protect against resolved nuxt module subpath

### DIFF
--- a/packages/kit/src/module/install.ts
+++ b/packages/kit/src/module/install.ts
@@ -342,7 +342,7 @@ async function callModule (nuxtModule: NuxtModule<any, Partial<any>, false>, met
   }
 
   nuxt.options._installedModules ||= []
-  entryPath ||= typeof moduleToInstall === 'string' ? moduleToInstall : undefined
+  entryPath ||= typeof moduleToInstall === 'string' ? resolveAlias(moduleToInstall, nuxt.options.alias) : undefined
 
   if (typeof moduleToInstall === 'string' && entryPath !== moduleToInstall) {
     buildTimeModuleMeta.rawPath = moduleToInstall

--- a/packages/kit/src/module/install.ts
+++ b/packages/kit/src/module/install.ts
@@ -4,7 +4,7 @@ import type { ModuleMeta, ModuleOptions, Nuxt, NuxtConfig, NuxtModule, NuxtOptio
 import { dirname, isAbsolute, join, resolve } from 'pathe'
 import { defu } from 'defu'
 import { createJiti } from 'jiti'
-import { parseNodeModulePath } from 'mlly'
+import { lookupNodeModuleSubpath, parseNodeModulePath } from 'mlly'
 import { resolveModulePath, resolveModuleURL } from 'exsolve'
 import { isRelative } from 'ufo'
 import { readPackageJSON, resolvePackageJSON } from 'pkg-types'
@@ -322,8 +322,13 @@ async function callModule (nuxtModule: NuxtModule<any, Partial<any>, false>, met
   }
 
   const modulePath = resolvedModulePath || moduleToInstall
+  let entryPath: string | undefined
   if (typeof modulePath === 'string') {
     const parsed = parseNodeModulePath(modulePath)
+    if (parsed.name) {
+      const subpath = await lookupNodeModuleSubpath(modulePath) || '.'
+      entryPath = join(parsed.name, subpath === './' ? '.' : subpath)
+    }
     const moduleRoot = parsed.dir
       ? parsed.dir + parsed.name
       : await resolvePackageJSON(modulePath, { try: true }).then(r => r ? dirname(r) : modulePath)
@@ -335,7 +340,7 @@ async function callModule (nuxtModule: NuxtModule<any, Partial<any>, false>, met
   }
 
   nuxt.options._installedModules ||= []
-  const entryPath = typeof moduleToInstall === 'string' ? resolveAlias(moduleToInstall, nuxt.options.alias) : undefined
+  entryPath ||= typeof moduleToInstall === 'string' ? moduleToInstall : undefined
 
   if (typeof moduleToInstall === 'string' && entryPath !== moduleToInstall) {
     buildTimeModuleMeta.rawPath = moduleToInstall

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -327,29 +327,6 @@ async function initNuxt (nuxt: Nuxt) {
     composables: nuxt.options.optimization.keyedComposables,
   }))
 
-  // shared folder import protection
-  const sharedDir = withTrailingSlash(resolve(nuxt.options.rootDir, nuxt.options.dir.shared))
-  const relativeSharedDir = withTrailingSlash(relative(nuxt.options.rootDir, resolve(nuxt.options.rootDir, nuxt.options.dir.shared)))
-  const sharedPatterns = [/^#shared\//, new RegExp('^' + escapeRE(sharedDir)), new RegExp('^' + escapeRE(relativeSharedDir))]
-  const sharedProtectionConfig = {
-    cwd: nuxt.options.rootDir,
-    include: sharedPatterns,
-    patterns: createImportProtectionPatterns(nuxt, { context: 'shared' }),
-  }
-  addVitePlugin(() => ImpoundPlugin.vite(sharedProtectionConfig), { server: false })
-  addWebpackPlugin(() => ImpoundPlugin.webpack(sharedProtectionConfig), { server: false })
-
-  // Add import protection
-  const nuxtProtectionConfig = {
-    cwd: nuxt.options.rootDir,
-    // Exclude top-level resolutions by plugins
-    exclude: [relative(nuxt.options.rootDir, join(nuxt.options.srcDir, 'index.html')), ...sharedPatterns],
-    patterns: createImportProtectionPatterns(nuxt, { context: 'nuxt-app' }),
-  }
-  addVitePlugin(() => Object.assign(ImpoundPlugin.vite({ ...nuxtProtectionConfig, error: false }), { name: 'nuxt:import-protection' }), { client: false })
-  addVitePlugin(() => Object.assign(ImpoundPlugin.vite({ ...nuxtProtectionConfig, error: true }), { name: 'nuxt:import-protection' }), { server: false })
-  addWebpackPlugin(() => ImpoundPlugin.webpack(nuxtProtectionConfig))
-
   // add resolver for modules used in virtual files
   addVitePlugin(() => ResolveDeepImportsPlugin(nuxt))
 
@@ -392,6 +369,29 @@ async function initNuxt (nuxt: Nuxt) {
         composables: nuxt.options.optimization.treeShake.composables.client,
       }), { server: false })
     }
+
+    // shared folder import protection
+    const sharedDir = withTrailingSlash(resolve(nuxt.options.rootDir, nuxt.options.dir.shared))
+    const relativeSharedDir = withTrailingSlash(relative(nuxt.options.rootDir, resolve(nuxt.options.rootDir, nuxt.options.dir.shared)))
+    const sharedPatterns = [/^#shared\//, new RegExp('^' + escapeRE(sharedDir)), new RegExp('^' + escapeRE(relativeSharedDir))]
+    const sharedProtectionConfig = {
+      cwd: nuxt.options.rootDir,
+      include: sharedPatterns,
+      patterns: createImportProtectionPatterns(nuxt, { context: 'shared' }),
+    }
+    addVitePlugin(() => ImpoundPlugin.vite(sharedProtectionConfig), { server: false })
+    addWebpackPlugin(() => ImpoundPlugin.webpack(sharedProtectionConfig), { server: false })
+
+    // Add import protection
+    const nuxtProtectionConfig = {
+      cwd: nuxt.options.rootDir,
+      // Exclude top-level resolutions by plugins
+      exclude: [relative(nuxt.options.rootDir, join(nuxt.options.srcDir, 'index.html')), ...sharedPatterns],
+      patterns: createImportProtectionPatterns(nuxt, { context: 'nuxt-app' }),
+    }
+    addVitePlugin(() => Object.assign(ImpoundPlugin.vite({ ...nuxtProtectionConfig, error: false }), { name: 'nuxt:import-protection' }), { client: false })
+    addVitePlugin(() => Object.assign(ImpoundPlugin.vite({ ...nuxtProtectionConfig, error: true }), { name: 'nuxt:import-protection' }), { server: false })
+    addWebpackPlugin(() => ImpoundPlugin.webpack(nuxtProtectionConfig))
   })
 
   if (!nuxt.options.dev) {

--- a/packages/nuxt/src/core/plugins/import-protection.ts
+++ b/packages/nuxt/src/core/plugins/import-protection.ts
@@ -29,11 +29,13 @@ export function createImportProtectionPatterns (nuxt: { options: NuxtOptions }, 
 
   patterns.push([/(^|node_modules\/)@vue\/composition-api/])
 
-  for (const mod of nuxt.options.modules.filter(m => typeof m === 'string')) {
-    patterns.push([
-      new RegExp(`^${escapeRE(mod)}$`),
-      'Importing directly from module entry-points is not allowed.',
-    ])
+  for (const mod of nuxt.options._installedModules) {
+    if (mod.entryPath) {
+      patterns.push([
+        new RegExp(`^${escapeRE(mod.entryPath)}$`),
+        'Importing directly from module entry-points is not allowed.',
+      ])
+    }
   }
 
   for (const i of [/(^|node_modules\/)@nuxt\/(cli|kit|test-utils)/, /(^|node_modules\/)nuxi/, /(^|node_modules\/)nitro(?:pack)?(?:-nightly)?(?:$|\/)(?!(?:dist\/)?(?:node_modules|presets|runtime|types))/, /(^|node_modules\/)nuxt\/(config|kit|schema)/]) {

--- a/packages/nuxt/test/import-protection.test.ts
+++ b/packages/nuxt/test/import-protection.test.ts
@@ -22,6 +22,7 @@ const testsToTriggerOn = [
   ['nuxt/schema', 'components/Component.vue', true],
   ['/root/node_modules/@nuxt/kit', 'components/Component.vue', true],
   ['some-nuxt-module', 'components/Component.vue', true],
+  ['some-nuxt-module/runtime/something.vue', 'components/Component.vue', false],
   ['/root/src/server/api/test.ts', 'components/Component.vue', true],
   ['src/server/api/test.ts', 'components/Component.vue', true],
   ['node_modules/nitropack/node_modules/crossws/dist/adapters/bun.mjs', 'node_modules/nitropack/dist/presets/bun/runtime/bun.mjs', false],
@@ -44,7 +45,10 @@ const transformWithImportProtection = (id: string, importer: string, context: 'n
     cwd: '/root',
     patterns: createImportProtectionPatterns({
       options: {
-        modules: ['some-nuxt-module'],
+        _installedModules: [
+          // @ts-expect-error an incomplete module
+          { entryPath: 'some-nuxt-module' },
+        ],
         srcDir: '/root/src/',
         serverDir: '/root/src/server',
       } satisfies Partial<NuxtOptions> as NuxtOptions,


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

in cases where we have a nuxt module as a subpath (e.g. `somelib/nuxt`) it's nice - and intended! - to be able to specify `somelib` in the module array in nuxt.config.

however, this causes issues when there are imports from `somelib` as these are caught by nuxt's import protection rules, designed to prevent modules from being imported in the nuxt app

this refactors how we generate those rules. instead of using the string array of modules in nuxt config, we use the _actually_ installed module entry paths, using `mlly` to 'lookup' the resolved path

(I'd like to investigate performance of this - it would be better if we could track which subpath is being used to avoid the second lookup.... given we _already have_ a list we search)