### PR TITLE
fix(nuxt): keep vnode when leaving deeper nested route

### DIFF
--- a/packages/nuxt/src/pages/runtime/page.ts
+++ b/packages/nuxt/src/pages/runtime/page.ts
@@ -130,7 +130,7 @@ export default defineComponent({
 
               if (isRenderingNewRouteInOldFork && forkRoute && (!_layoutMeta || _layoutMeta?.isCurrent(forkRoute))) {
               // if leaving a route with an existing child route, render the old vnode
-                if (hasSameChildren) {
+                if (hasSameChildren || vnode) {
                   return vnode
                 }
                 // If _leaving_ null child route, return null vnode


### PR DESCRIPTION
### 🔗 Linked issue

Resolves: #33766

### 📚 Description

 Fixes a visual flash when navigating between nested routes with different depths (e.g., 3 levels → 2 levels).

The condition at line 133 only checked `hasSameChildren` (same route depth) before returning the existing vnode. When navigating from a deeper to a shallower route, it would return null even though a valid vnode existed - causing a brief flash.

Fix: `if (hasSameChildren) → if (hasSameChildren || vnode)`

Now null is only returned when there was no previous content (as the comment always intended).
