### PR TITLE
fix(kit): avoid mutating cached ESM config in layer resolution

### DIFF
--- a/packages/kit/src/loader/config.ts
+++ b/packages/kit/src/loader/config.ts
@@ -80,12 +80,16 @@ export async function loadNuxtConfig (opts: LoadNuxtConfigOptions): Promise<Nuxt
   const localRelativePaths = new Set(localLayers)
   for (const layer of layers) {
     // Resolve `rootDir` & `srcDir` of layers
-    layer.config ||= {}
-    layer.config.rootDir ??= layer.cwd!
+    // Create a shallow copy to avoid mutating the cached ESM config object
+    const resolvedRootDir = layer.config?.rootDir ?? layer.cwd!
+    layer.config = {
+      ...(layer.config || {}),
+      rootDir: resolvedRootDir,
+    }
 
     // Only process/resolve layers once
-    if (processedLayers.has(layer.config.rootDir)) { continue }
-    processedLayers.add(layer.config.rootDir)
+    if (processedLayers.has(resolvedRootDir)) { continue }
+    processedLayers.add(resolvedRootDir)
 
     // Normalise layer directories
     layer.config = await applyDefaults(layerSchema, layer.config as NuxtConfig & Record<string, JSValue>) as unknown as NuxtConfig


### PR DESCRIPTION
### 🔗 Linked issue

Resolves: #33733

### 📚 Description

Fixes `.output` being created in layer subdirectory instead of project root when layers use ESM configs (`.mjs`, `.js` with "type": "module", or from `node_modules`).

The bug occurred because `layer.config.rootDir ??= layer.cwd!` directly mutated the cached ESM module object. On subsequent builds, the cached object already had `rootDir` set to the layer's directory.

Fix: Create a shallow copy via spread operator instead of mutating the original.