### PR TITLE
fix(kit): include shared/**/* in tsconfig.app.json for enum resolution

### DIFF
--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -280,6 +280,7 @@ export async function _generateTypes (nuxt: Nuxt) {
         exclude.add(path)
       }
       for (const path of paths.shared) {
+        include.add(path)
         legacyInclude.add(path)
         sharedInclude.add(path)
       }

--- a/test/fixtures/basic-types/app/app-types.ts
+++ b/test/fixtures/basic-types/app/app-types.ts
@@ -646,3 +646,15 @@ describe('kit utilities', () => {
     const _fromage: Fromage = 'cheese'
   })
 })
+
+describe('shared folder', () => {
+  it('works with enums', () => {
+    function test (a: string, b: Foo.Bar): void
+    function test (a: number, b: Foo.Baz): void
+    function test (a: string | number, b: Foo): void {
+      console.log(Foo.Bar)
+    }
+
+    test(2, Foo.Bar)
+  })
+})

--- a/test/fixtures/basic-types/shared/types/enum.ts
+++ b/test/fixtures/basic-types/shared/types/enum.ts
@@ -1,0 +1,4 @@
+export const enum Foo {
+  Bar,
+  Baz,
+}


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #33780

### 📚 Description

Enums from shared/ directory were not properly auto-imported because TypeScript couldn't resolve `enum` members.

Root cause: `shared/**/*` was **not** added to `tsconfig.app.json` (only `shared/**/*.d.ts` was included).

TypeScript needs the source `.ts` files (not just .d.ts) to resolve (const) enum members when using `typeof import()`.
