### PR TITLE
fix(nuxt): resolve watch callback after reactive key change in useAsyncData

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -384,7 +384,7 @@ export function useAsyncData<
     const unsubParamsWatcher = options.watch
       ? watch(options.watch, () => {
           if (keyChanging) { return } // avoid double execute while the key switch is being processed
-          asyncData._execute({ cause: 'watch', dedupe: options.dedupe })
+          nuxtApp._asyncData[key.value]?._execute({ cause: 'watch', dedupe: options.dedupe })
         })
       : () => {}
 

--- a/test/nuxt/use-async-data.test.ts
+++ b/test/nuxt/use-async-data.test.ts
@@ -898,6 +898,62 @@ describe('useAsyncData', () => {
     expect(promiseFn).toHaveBeenCalledTimes(3) // initial + 2 changes
   })
 
+  // https://github.com/nuxt/nuxt/issues/33777
+  it('should continue watching params after reactive key changes', async () => {
+    const id = ref('1')
+    const page = ref(0)
+    const promiseFn = vi.fn((id: string, page: number) => Promise.resolve(`id: ${id}, page: ${page}`))
+
+    const params = computed(() => ({ id: id.value, page: page.value }))
+
+    const { data, error } = await useAsyncData(
+      () => `data-${id.value}`,
+      () => promiseFn(params.value.id, params.value.page),
+      {
+        watch: [params],
+        immediate: true,
+      },
+    )
+
+    // Initial call
+    expect(data.value).toBe('id: 1, page: 0')
+    expect(promiseFn).toHaveBeenCalledTimes(1)
+    expect(promiseFn).toHaveBeenLastCalledWith('1', 0)
+
+    // Change key: id changes from '1' to '2'
+    id.value = '2'
+    await nextTick()
+    await flushPromises()
+    await new Promise(resolve => setTimeout(resolve, 5))
+
+    expect(promiseFn).toHaveBeenCalledTimes(2)
+    expect(promiseFn).toHaveBeenLastCalledWith('2', 0)
+    expect(error.value).toBe(undefined)
+    expect(data.value).toBe('id: 2, page: 0')
+
+    // Verify params watcher continues to work after key change (issue #33777)
+    page.value = 1
+    await nextTick()
+    await flushPromises()
+    await new Promise(resolve => setTimeout(resolve, 5))
+
+    expect(promiseFn).toHaveBeenCalledTimes(3)
+    expect(promiseFn).toHaveBeenLastCalledWith('2', 1)
+    expect(error.value).toBe(undefined)
+    expect(data.value).toBe('id: 2, page: 1')
+
+    // Another params change to be thorough
+    page.value = 2
+    await nextTick()
+    await flushPromises()
+    await new Promise(resolve => setTimeout(resolve, 5))
+
+    expect(promiseFn).toHaveBeenCalledTimes(4)
+    expect(promiseFn).toHaveBeenLastCalledWith('2', 2)
+    expect(error.value).toBe(undefined)
+    expect(data.value).toBe('id: 2, page: 2')
+  })
+
   it('should trigger AbortController on clear', () => {
     let aborted = false
 


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #33777

### 📝 Description

When using useAsyncData with a reactive key (getter function) and the watch option, the params watcher stops working after the key changes.

Expected: Params changes trigger new fetches

### Root Cause

The params watcher captured a static reference to the initial `asyncData` container. When the key watcher detected a key change, it created a new container in `nuxtApp._asyncData[newKey]`, but the params watcher continued calling `_execute()` on the old, stale container.

### The Fix

Use dynamic lookup to ensure the params watcher always targets the current container:
```typescript
watch(options.watch, () => {
  nuxtApp._asyncData[key.value]?._execute(...) // Dynamic lookup
})
```

### Testing

  - ✅ Added regression test: "should continue watching params after reactive key changes"
  - ✅ All existing tests pass
  - ✅ Test fails without the fix, passes with the fix
