### PR TITLE
fix(nuxt): re-execute callOnce during HMR

### DIFF
--- a/packages/nuxt/src/app/composables/once.ts
+++ b/packages/nuxt/src/app/composables/once.ts
@@ -42,9 +42,8 @@ export async function callOnce (...args: any): Promise<void> {
 
   // If key already ran
   if (nuxtApp.payload.once.has(_key)) {
-    if (import.meta.dev && _isHmrUpdating) {
-      // Allow re-execution during HMR
-    } else {
+    // Allow re-execution during HMR
+    if (!import.meta.dev || !_isHmrUpdating) {
       return
     }
   }

--- a/packages/nuxt/src/app/composables/once.ts
+++ b/packages/nuxt/src/app/composables/once.ts
@@ -5,6 +5,8 @@ type CallOnceOptions = {
   mode?: 'navigation' | 'render'
 }
 
+let _isHmrUpdating = false
+
 /**
  * An SSR-friendly utility to call a method once
  * @param key a unique key ensuring the function can be properly de-duplicated across requests
@@ -40,7 +42,11 @@ export async function callOnce (...args: any): Promise<void> {
 
   // If key already ran
   if (nuxtApp.payload.once.has(_key)) {
-    return
+    if (import.meta.dev && _isHmrUpdating) {
+      // Allow re-execution during HMR
+    } else {
+      return
+    }
   }
 
   nuxtApp._once ||= {}
@@ -48,4 +54,18 @@ export async function callOnce (...args: any): Promise<void> {
   await nuxtApp._once[_key]
   nuxtApp.payload.once.add(_key)
   delete nuxtApp._once[_key]
+}
+
+if (import.meta.hot) {
+  import.meta.hot.on('vite:beforeUpdate', (payload) => {
+    if (payload.updates.some((u: any) => u.type === 'js-update')) {
+      _isHmrUpdating = true
+    }
+  })
+
+  import.meta.hot.on('vite:afterUpdate', (payload) => {
+    if (payload.updates.some((u: any) => u.type === 'js-update')) {
+      _isHmrUpdating = false
+    }
+  })
 }


### PR DESCRIPTION
### 🔗 Linked issue

fix https://github.com/nuxt/nuxt/issues/33788


<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This PR re-executes `callOnce` during HMR. 

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/4.x/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
