### PR TITLE
docs: add parallel data fetching tip in best practices section

### DIFF
--- a/docs/3.guide/2.best-practices/performance.md
+++ b/docs/3.guide/2.best-practices/performance.md
@@ -112,6 +112,17 @@ To optimize your app, you may want to delay the hydration of some components unt
 
 To avoid fetching same data twice (once on the server and once on client) Nuxt provides [`useFetch`](/docs/4.x/api/composables/use-fetch) and [`useAsyncData`](/docs/4.x/api/composables/use-async-data). They ensure that if an API call is made on the server, the data is forwarded to the client in the payload instead of being fetched again.
 
+To avoid a waterfall effect when you need to make multiple API calls, you can use `Promise.all` to run them in parallel, improving performance:
+
+```ts
+const { data } = await useAsyncData(() => {
+    return Promise.all([
+        $fetch("/api/products/"),
+        $fetch("/api/category/shoes")
+    ]);
+});
+```
+
 :read-more{title="Data fetching" to="/docs/4.x/getting-started/data-fetching"}
 
 ## Core Nuxt Modules


### PR DESCRIPTION
### 📚 Description

This PR adds a small section about how to avoid waterfall effect when you need to do multiple API calls. The suggestion is to use `Promise.all` to fetch in parallel to improve performance.