### PR TITLE
fix(nuxt): escape HTML in development error page stack trace

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-error-page.vue
+++ b/packages/nuxt/src/app/components/nuxt-error-page.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script setup>
-import { defineAsyncComponent } from 'vue'
+import { defineAsyncComponent, escapeHtml } from 'vue'
 
 const props = defineProps({
   error: Object,
@@ -28,7 +28,7 @@ const stacktrace = _error.stack
           line.includes('internal') ||
           line.includes('new Promise'),
         }
-      }).map(i => `<span class="stack${i.internal ? ' internal' : ''}">${i.text}</span>`).join('\n')
+      }).map(i => `<span class="stack${i.internal ? ' internal' : ''}">${escapeHtml(i.text)}</span>`).join('\n')
   : ''
 
 // Error page props

--- a/packages/nuxt/src/app/components/nuxt-error-page.vue
+++ b/packages/nuxt/src/app/components/nuxt-error-page.vue
@@ -13,7 +13,7 @@ const props = defineProps({
 const _error = props.error
 
 // TODO: extract to a separate utility
-const stacktrace = _error.stack
+const stacktrace = import.meta.dev && _error.stack
   ? _error.stack
       .split('\n')
       .splice(1)

--- a/packages/nuxt/src/app/components/nuxt-error-page.vue
+++ b/packages/nuxt/src/app/components/nuxt-error-page.vue
@@ -3,7 +3,9 @@
 </template>
 
 <script setup>
-import { defineAsyncComponent, escapeHtml } from 'vue'
+import { defineAsyncComponent } from 'vue'
+// eslint-disable-next-line vue/prefer-import-from-vue
+import { escapeHtml } from '@vue/shared'
 
 const props = defineProps({
   error: Object,


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #33790

### 📚 Description

The development error page (`nuxt-error-page.vue`) was not escaping the stack trace text before inserting it into HTML, which could lead to XSS if the error message contained malicious content like `<script>` tags.