### PR TITLE
chore(types): provide array of any type instead of any

### DIFF
--- a/packages/nuxt/src/app/composables/once.ts
+++ b/packages/nuxt/src/app/composables/once.ts
@@ -17,7 +17,7 @@ let _isHmrUpdating = false
  */
 export function callOnce (key?: string, fn?: (() => any | Promise<any>), options?: CallOnceOptions): Promise<void>
 export function callOnce (fn?: (() => any | Promise<any>), options?: CallOnceOptions): Promise<void>
-export async function callOnce (...args: any): Promise<void> {
+export async function callOnce (...args: any[]): Promise<void> {
   const autoKey = typeof args[args.length - 1] === 'string' ? args.pop() : undefined
   if (typeof args[0] !== 'string') { args.unshift(autoKey) }
   const [_key, fn, options] = args as [string, (() => any | Promise<any>), CallOnceOptions | undefined]


### PR DESCRIPTION
If we remove type then vs code infers ...args as `any[]` instead of `any`. I think it might be better to give array of any what typescript infers. and i've seen other code in nuxt, ...args type is always given as `array` for something. 