### PR TITLE
fix(kit): normalize layer directory paths with trailing slashes to support dotted folder names

### DIFF
--- a/packages/kit/src/loader/config.ts
+++ b/packages/kit/src/loader/config.ts
@@ -11,7 +11,7 @@ import { basename, join, relative } from 'pathe'
 import { resolveModuleURL } from 'exsolve'
 
 import { directoryToURL } from '../internal/esm'
-import { withTrailingSlash } from 'ufo'
+import { withTrailingSlash, withoutTrailingSlash } from 'ufo'
 
 export interface LoadNuxtConfigOptions extends Omit<LoadConfigOptions<NuxtConfig>, 'overrides'> {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
@@ -30,7 +30,7 @@ export async function loadNuxtConfig (opts: LoadNuxtConfigOptions): Promise<Nuxt
   const localLayers = (await glob('layers/*', {
     onlyDirectories: true, cwd: opts.cwd || process.cwd(),
   }))
-    .map((d: string) => d.endsWith('/') ? d.substring(0, d.length - 1) : d)
+    .map((d: string) => withTrailingSlash(d))
     .sort((a, b) => b.localeCompare(a))
   opts.overrides = defu(opts.overrides, { _extends: localLayers })
 
@@ -77,7 +77,7 @@ export async function loadNuxtConfig (opts: LoadNuxtConfigOptions): Promise<Nuxt
 
   const _layers: ConfigLayer<NuxtConfig, ConfigLayerMeta>[] = []
   const processedLayers = new Set<string>()
-  const localRelativePaths = new Set(localLayers)
+  const localRelativePaths = new Set(localLayers.map(layer => withoutTrailingSlash(layer)))
   for (const layer of layers) {
     // Resolve `rootDir` & `srcDir` of layers
     // Create a shallow copy to avoid mutating the cached ESM config object


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/33855
### 🐞 Can't import variables from ordered layers in nuxt config #33855

Nuxt’s auto layer discovery strips the trailing slash from layers/* results.
When a layer folder contains a dot (e.g. 01.base), the resolver interprets it as a file extension instead of a directory and throws:

`
Cannot find module 'layers/01.base'
`


The change makes Nuxt always keep a trailing slash on auto-detected layer paths, so dotted folders are consistently handled as directories. Fairly simple, straight forward fix. 

Cheers!
