### PR TITLE
perf(vite): optimize `nuxt:ssr-styles` plugin

### DIFF
--- a/packages/vite/src/plugins/ssr-styles.ts
+++ b/packages/vite/src/plugins/ssr-styles.ts
@@ -13,6 +13,7 @@ import { resolveClientEntry } from '../utils/config'
 import { useNitro } from '@nuxt/kit'
 
 const SUPPORTED_FILES_RE = /\.(?:vue|(?:[cm]?j|t)sx?)$/
+const QUERY_RE = /\?.+$/
 
 export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
   if (nuxt.options.dev) { return }
@@ -58,6 +59,7 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
     // .server components without a corresponding .client component will need to be rendered as an island
     (component.mode === 'server' && !components.some(c => c.pascalName === component.pascalName && c.mode === 'client')),
   )
+  const islandPaths = new Set(islands.map(c => c.filePath))
 
   let entry: string
 
@@ -187,7 +189,7 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
 
             const relativePath = relativeToSrcDir(moduleId)
             if (relativePath in cssMap) {
-              cssMap[relativePath]!.inBundle = cssMap[relativePath]!.inBundle ?? ((isVue(moduleId) && !!relativeToSrcDir(moduleId)) || isEntry)
+              cssMap[relativePath]!.inBundle = cssMap[relativePath]!.inBundle ?? ((isVue(moduleId) && !!relativePath) || isEntry)
             }
           }
 
@@ -227,12 +229,12 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
 
           const { pathname, search } = parseURL(decodeURIComponent(pathToFileURL(id).href))
 
-          if (!(id in clientCSSMap) && !islands.some(c => c.filePath === pathname)) { return }
+          if (!(id in clientCSSMap) && !islandPaths.has(pathname)) { return }
 
           const query = parseQuery(search)
           if (query.macro || query.nuxt_component) { return }
 
-          if (!islands.some(c => c.filePath === pathname)) {
+          if (!islandPaths.has(pathname)) {
             if (options.shouldInline === false || (typeof options.shouldInline === 'function' && !options.shouldInline(id))) { return }
           }
 
@@ -240,10 +242,13 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
           const idMap = cssMap[relativeId] ||= { files: [] }
 
           const emittedIds = new Set<string>()
+          const idFilename = filename(id)
 
           let styleCtr = 0
           const ids = clientCSSMap[id] || []
           for (const file of ids) {
+            if (emittedIds.has(file)) { continue }
+            const inlineId = file + '?inline&used'
             const resolved = await this.resolve(file) ?? await this.resolve(file, id)
             const res = await this.resolve(file + '?inline&used') ?? await this.resolve(file + '?inline&used', id)
             if (!resolved || !res) {
@@ -253,11 +258,11 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
               }
               continue
             }
-            if (emittedIds.has(file)) { continue }
+            emittedIds.add(file)
             const ref = this.emitFile({
               type: 'chunk',
-              name: `${filename(id)}-styles-${++styleCtr}.mjs`,
-              id: file + '?inline&used',
+              name: `${idFilename}-styles-${++styleCtr}.mjs`,
+              id: inlineId,
             })
 
             idRefMap[relativeToSrcDir(file)] = ref
@@ -267,8 +272,7 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
           if (!SUPPORTED_FILES_RE.test(pathname)) { return }
 
           for (const i of findStaticImports(code)) {
-            const { type } = parseQuery(i.specifier)
-            if (type !== 'style' && !i.specifier.endsWith('.css')) { continue }
+            if (!i.specifier.endsWith('.css') && parseQuery(i.specifier).type !== 'style') { continue }
 
             const resolved = await this.resolve(i.specifier, id)
             if (!resolved) { continue }
@@ -283,7 +287,7 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
             if (emittedIds.has(resolved.id)) { continue }
             const ref = this.emitFile({
               type: 'chunk',
-              name: `${filename(id)}-styles-${++styleCtr}.mjs`,
+              name: `${idFilename}-styles-${++styleCtr}.mjs`,
               id: resolved.id + '?inline&used',
             })
 
@@ -297,5 +301,5 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
 }
 
 function filename (name: string) {
-  return _filename(name.replace(/\?.+$/, ''))
+  return _filename(name.replace(QUERY_RE, ''))
 }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

With Vite v8 beta I noticed the `ssr-styles` plugin was taking up a significant amount of time. I did some profiling on it and found a lot of the time was spent on normalizing paths.

I've tried to apply some (safe :crossed_fingers:) changes to reduce the amount of path checks and other micro optimizations.

The cache for relative path lookup is a bit overkill looking, but I benchmarked it against nuxtseo.com which is quite large now and getting roughly  25-35% hits on duplicate relative path resolves (390 hits, 1140 misses).

Some benchmarks although not sure how much they can be trusted.

  | Benchmark                            | Speedup     |
  |--------------------------------------|-------------|
  | transform: island 2 css              | ~3.3x       |
  | transform: island 20 css             | ~4.5x       |
  | transform: non-matching (early exit) | ~1.32x      |
  | transform: file in clientCSSMap      | ~2.36x      |
  | resolveId: .vue/.css                 | ~1.27-1.36x |
  | renderChunk: server 100 modules      | ~11.6x      |


<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/4.x/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
