### PR TITLE
docs: add correct instructions to upgrade to latest Nuxt 3.x

### DIFF
--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -6,6 +6,35 @@ navigation.icon: i-lucide-circle-arrow-up
 
 ## Upgrading Nuxt
 
+### Latest Nuxt 3 release
+
+To upgrade Nuxt to the [latest v3 release](https://github.com/nuxt/nuxt/releases), use the `nuxt upgrade` command with `--channel=v3` flag.
+
+::code-group{sync="pm"}
+
+```bash [npm]
+npx nuxt upgrade --dedupe --channel=v3
+```
+
+```bash [yarn]
+yarn nuxt upgrade --dedupe --channel=v3
+```
+
+```bash [pnpm]
+pnpm nuxt upgrade --dedupe --channel=v3
+```
+
+```bash [bun]
+bun x nuxt upgrade --dedupe --channel=v3
+```
+
+::
+
+::note
+This will only work if you _already have_ a version of `@nuxt/cli` which has the `--channel` flag implemented. If this does not work, you can instead use `nuxi@latest` for the initial upgrade.
+E.g. `npx nuxi@latest upgrade --dedupe --channel=v3`
+::
+
 ### Latest release
 
 To upgrade Nuxt to the [latest release](https://github.com/nuxt/nuxt/releases), use the `nuxt upgrade` command.


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/cli/issues/484#issuecomment-3638079413

### 📚 Description

Currently the docs for 3.x branch have slightly outdated upgade instructions which are from the times when 4.x was just a pre-release.

This commit adds a dedicated section into 3.x docs about upgrade to the latest 3.x version, but keeps the general instructions about upgrading, so it is still possible to upgrade 3.x to 4.x (or whatever current version it will be in the future) if that is what user wants.

The instructions are similar to what we see in the [latest release notes](https://github.com/nuxt/nuxt/releases/tag/v3.20.2) for 3.x branch.

**Note:** Please review the commands for `pnpm` and `bun` as I don't use them and not sure if they are correct.