### PR TITLE
feat(schema): add `#server` alias for server directory imports

### DIFF
--- a/docs/2.directory-structure/1.server.md
+++ b/docs/2.directory-structure/1.server.md
@@ -130,6 +130,24 @@ export const defineWrappedResponseHandler = <T extends EventHandlerRequest, D> (
   })
 ```
 
+## Server Alias
+
+You can use the `#server` alias to import files from anywhere within the `server/` directory, regardless of the importing file's location.
+
+```ts [server/api/users/[id]/profile.ts]
+// Instead of relative paths like this:
+// import { formatUser } from '../../../utils/formatUser'
+
+// Use the #server alias:
+import { formatUser } from '#server/utils/formatUser'
+```
+
+This alias ensures consistent imports across your server code, especially useful in deeply nested route handlers.
+
+::note
+The `#server` alias can only be used within the `server/` directory. Importing from `#server` in client code will result in an error.
+::
+
 ## Server Types
 
 Auto-imports and other types are different for the `server/` directory, as it is running in a different context from the `app/` directory.

--- a/packages/kit/test/load-nuxt-config.spec.ts
+++ b/packages/kit/test/load-nuxt-config.spec.ts
@@ -17,6 +17,7 @@ describe('loadNuxtConfig', () => {
         "#layers/c": "<rootDir>/layers/c/",
         "#layers/d": "<rootDir>/layers/d/",
         "#layers/layer-fixture": "<rootDir>/",
+        "#server": "<rootDir>/server/",
         "#shared": "<rootDir>/shared/",
         "@": "<rootDir>/",
         "@@": "<rootDir>/",

--- a/packages/nuxt/src/core/plugins/import-protection.ts
+++ b/packages/nuxt/src/core/plugins/import-protection.ts
@@ -53,6 +53,10 @@ export function createImportProtectionPatterns (nuxt: { options: NuxtOptions }, 
       new RegExp(escapeRE(relative(nuxt.options.srcDir, resolve(nuxt.options.srcDir, nuxt.options.serverDir || 'server'))) + '\\/(api|routes|middleware|plugins)\\/'),
       `Importing from server is not allowed in ${context}.`,
     ])
+    patterns.push([
+      /^#server(\/|$)/,
+      `Server aliases are not allowed in ${context}.`,
+    ])
   }
 
   return patterns

--- a/packages/nuxt/test/load-nuxt.test.ts
+++ b/packages/nuxt/test/load-nuxt.test.ts
@@ -156,6 +156,17 @@ describe('loadNuxt', () => {
 
     await nuxt.close()
   })
+
+  it('includes #server alias in nitro tsconfig paths', async () => {
+    const nuxt = await loadNuxt({ cwd: repoRoot, ready: true })
+
+    const tsConfigPaths = (nuxt as any)._nitro?.options.typescript?.tsConfig?.compilerOptions?.paths ?? {}
+
+    expect(tsConfigPaths).toHaveProperty('#server')
+    expect(tsConfigPaths).toHaveProperty('#server/*')
+
+    await nuxt.close()
+  })
 })
 
 const pagesDetectionTests: [test: string, overrides: NuxtConfig, result: NuxtConfig['pages']][] = [

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -200,7 +200,7 @@ export default defineResolvers({
   },
   alias: {
     $resolve: async (val, get) => {
-      const [srcDir, rootDir, buildDir, sharedDir] = await Promise.all([get('srcDir'), get('rootDir'), get('buildDir'), get('dir.shared')])
+      const [srcDir, rootDir, buildDir, sharedDir, serverDir] = await Promise.all([get('srcDir'), get('rootDir'), get('buildDir'), get('dir.shared'), get('serverDir')])
       const srcWithTrailingSlash = withTrailingSlash(srcDir)
       const rootWithTrailingSlash = withTrailingSlash(rootDir)
       return {
@@ -209,6 +209,7 @@ export default defineResolvers({
         '~~': rootWithTrailingSlash,
         '@@': rootWithTrailingSlash,
         '#shared': withTrailingSlash(resolve(rootDir, sharedDir)),
+        '#server': withTrailingSlash(serverDir),
         '#build': withTrailingSlash(buildDir),
         '#internal/nuxt/paths': resolve(buildDir, 'paths.mjs'),
         ...typeof val === 'object' ? val : {},


### PR DESCRIPTION
### 🔗 Linked issue

Fixes: #33853

## Summary

Adds a `#server` alias for clean imports within the server directory.

**Before:**
```ts
// server/api/users/[id]/profile.ts
import { helper } from '../../../../utils/helper'
```

After:
```ts
import { helper } from '#server/utils/helper'
```

- Works like #shared but for server directory
- Import protection prevents usage in client/shared context

### Docs
- Added a short description to the server docs.

### Tests
- Test added in packages/nuxt/test/load-nuxt.test.ts