### PR TITLE
build(vite): add internal vite-node builds

### DIFF
--- a/packages/vite/build.config.ts
+++ b/packages/vite/build.config.ts
@@ -1,5 +1,5 @@
 import { defineBuildConfig } from 'unbuild'
-import { addRollupTimingsPlugin } from '../../debug/build-config'
+import { addRollupTimingsPlugin } from '../../debug/build-config.ts'
 
 export default defineBuildConfig({
   declaration: true,

--- a/packages/vite/build.config.ts
+++ b/packages/vite/build.config.ts
@@ -1,11 +1,12 @@
 import { defineBuildConfig } from 'unbuild'
-import { addRollupTimingsPlugin } from '../../debug/build-config.ts'
+import { addRollupTimingsPlugin } from '../../debug/build-config'
 
 export default defineBuildConfig({
   declaration: true,
   entries: [
     'src/index',
-    { input: 'src/runtime/', outDir: 'dist/runtime', format: 'esm' },
+    'src/vite-node',
+    'src/vite-node-entry',
   ],
   hooks: {
     'rollup:options' (ctx, options) {

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -17,6 +17,10 @@
       "import": "./dist/index.mjs"
     }
   },
+  "imports": {
+    "#vite-node": "./dist/vite-node.mjs",
+    "#vite-node-entry": "./dist/vite-node-entry.mjs"
+  },
   "files": [
     "dist"
   ],

--- a/packages/vite/src/plugins/analyze.ts
+++ b/packages/vite/src/plugins/analyze.ts
@@ -1,6 +1,6 @@
 import type { Plugin } from 'vite'
 import { transform } from 'esbuild'
-import defu from 'defu'
+import { defu } from 'defu'
 import type { Nuxt, NuxtOptions } from '@nuxt/schema'
 import type { RenderedModule } from 'rollup'
 

--- a/packages/vite/src/plugins/dev-server.ts
+++ b/packages/vite/src/plugins/dev-server.ts
@@ -1,7 +1,7 @@
 import type { Connect, Plugin, ServerOptions } from 'vite'
 import type { Nuxt, ViteConfig } from '@nuxt/schema'
 import { getPort } from 'get-port-please'
-import defu from 'defu'
+import { defu } from 'defu'
 import { createError, defineEventHandler, defineLazyEventHandler, handleCors, setHeader } from 'h3'
 import { useNitro } from '@nuxt/kit'
 import { joinURL } from 'ufo'

--- a/packages/vite/src/plugins/dev-style-ssr.ts
+++ b/packages/vite/src/plugins/dev-style-ssr.ts
@@ -1,6 +1,6 @@
 import { joinURL } from 'ufo'
 import type { Plugin } from 'vite'
-import { isCSS } from '../utils'
+import { isCSS } from '../utils/index'
 
 interface DevStyleSSRPluginOptions {
   srcDir: string

--- a/packages/vite/src/plugins/runtime-paths.ts
+++ b/packages/vite/src/plugins/runtime-paths.ts
@@ -2,7 +2,7 @@ import { pathToFileURL } from 'node:url'
 import MagicString from 'magic-string'
 import { parseQuery, parseURL } from 'ufo'
 import type { Plugin } from 'vite'
-import { isCSS } from '../utils'
+import { isCSS } from '../utils/index'
 
 const VITE_ASSET_RE = /__VITE_ASSET__|__VITE_PUBLIC_ASSET__/
 

--- a/packages/vite/src/plugins/sourcemap-preserver.ts
+++ b/packages/vite/src/plugins/sourcemap-preserver.ts
@@ -1,5 +1,5 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
-import defu from 'defu'
+import { defu } from 'defu'
 import type { Nuxt } from '@nuxt/schema'
 import { dirname, resolve } from 'pathe'
 

--- a/packages/vite/src/plugins/ssr-styles.ts
+++ b/packages/vite/src/plugins/ssr-styles.ts
@@ -8,7 +8,7 @@ import type { Nuxt } from '@nuxt/schema'
 import MagicString from 'magic-string'
 import { findStaticImports } from 'mlly'
 
-import { IS_CSS_RE, isCSS, isVue } from '../utils'
+import { IS_CSS_RE, isCSS, isVue } from '../utils/index'
 import { resolveClientEntry } from '../utils/config'
 import { useNitro } from '@nuxt/kit'
 

--- a/packages/vite/src/plugins/stable-entry.ts
+++ b/packages/vite/src/plugins/stable-entry.ts
@@ -5,7 +5,7 @@ import MagicString from 'magic-string'
 import { basename } from 'pathe'
 import { withoutLeadingSlash } from 'ufo'
 import type { Plugin } from 'vite'
-import { toArray } from '../utils'
+import { toArray } from '../utils/index'
 
 export function StableEntryPlugin (nuxt: Nuxt): Plugin {
   let sourcemap: boolean

--- a/packages/vite/src/plugins/vite-node.ts
+++ b/packages/vite/src/plugins/vite-node.ts
@@ -7,7 +7,7 @@ import fs from 'node:fs' // For sync operations like unlinkSync if needed during
 import { pathToFileURL } from 'node:url'
 import { Buffer } from 'node:buffer'
 import { createError } from 'h3'
-import { join, normalize, resolve } from 'pathe'
+import { join, normalize } from 'pathe'
 import { tryUseNuxt } from '@nuxt/kit'
 import type { EnvironmentModuleNode, ModuleNode, PluginContainer, ViteDevServer, Plugin as VitePlugin } from 'vite'
 import { getQuery } from 'ufo'
@@ -17,9 +17,9 @@ import { normalizeViteManifest } from 'vue-bundle-renderer'
 import type { Manifest } from 'vue-bundle-renderer'
 import type { Nuxt } from '@nuxt/schema'
 import { provider } from 'std-env'
+import { resolveModulePath } from 'exsolve'
 
-import { distDir } from '../dirs'
-import { isCSS } from '../utils'
+import { isCSS } from '../utils/index'
 import { resolveClientEntry, resolveServerEntry } from '../utils/config'
 
 type ResolveIdResponse = Awaited<ReturnType<PluginContainer['resolveId']>>
@@ -508,8 +508,8 @@ export type ViteNodeServerOptions = {
 }
 
 export async function writeDevServer (nuxt: Nuxt): Promise<void> {
-  const serverResolvedPath = resolve(distDir, 'runtime/vite-node.mjs')
-  const manifestResolvedPath = resolve(distDir, 'runtime/client.manifest.mjs')
+  const serverResolvedPath = resolveModulePath('#vite-node-entry', { from: import.meta.url })
+  const fetchResolvedPath = resolveModulePath('#vite-node', { from: import.meta.url })
 
   const serverDist = join(nuxt.options.buildDir, 'dist/server')
 
@@ -518,6 +518,9 @@ export async function writeDevServer (nuxt: Nuxt): Promise<void> {
   await Promise.all([
     writeFile(join(serverDist, 'server.mjs'), `export { default } from ${JSON.stringify(pathToFileURL(serverResolvedPath).href)}`),
     writeFile(join(serverDist, 'client.precomputed.mjs'), `export default undefined`),
-    writeFile(join(serverDist, 'client.manifest.mjs'), `export { default } from ${JSON.stringify(pathToFileURL(manifestResolvedPath).href)}`),
+    writeFile(join(serverDist, 'client.manifest.mjs'), `
+import { viteNodeFetch } from ${JSON.stringify(pathToFileURL(fetchResolvedPath))}
+export default () => viteNodeFetch.getManifest()
+    `),
   ])
 }

--- a/packages/vite/src/runtime/client.manifest.mjs
+++ b/packages/vite/src/runtime/client.manifest.mjs
@@ -1,4 +1,0 @@
-// @ts-check
-import { viteNodeFetch } from './vite-node-shared.mjs'
-
-export default () => viteNodeFetch.getManifest()

--- a/packages/vite/src/vite-node-entry.ts
+++ b/packages/vite/src/vite-node-entry.ts
@@ -1,19 +1,16 @@
-// @ts-check
-
 import process from 'node:process'
 import { performance } from 'node:perf_hooks'
 import { createError } from 'h3'
 import { ViteNodeRunner } from 'vite-node/client'
 import { consola } from 'consola'
-import { viteNodeFetch, viteNodeOptions } from './vite-node-shared.mjs'
+import { viteNodeFetch, viteNodeOptions } from '#vite-node'
+import type { NuxtSSRContext } from 'nuxt/app'
 
 const runner = createRunner()
 
-/** @type {(ssrContext: import('#app').NuxtSSRContext) => Promise<any>} */
-let render
+let render: (ssrContext: NuxtSSRContext) => Promise<any>
 
-/** @param {import('#app').NuxtSSRContext} ssrContext */
-export default async (ssrContext) => {
+export default async (ssrContext: NuxtSSRContext) => {
   // Workaround for stub mode
   // https://github.com/nuxt/framework/pull/3983
   // eslint-disable-next-line nuxt/prefer-import-meta,@typescript-eslint/no-deprecated
@@ -74,18 +71,12 @@ function createRunner () {
   })
 }
 
-/**
- * @param {any} errorData
- * @param {string} id
- */
-function formatViteError (errorData, id) {
+function formatViteError (errorData: any, id: string) {
   const errorCode = errorData.name || errorData.reasonCode || errorData.code
   const frame = errorData.frame || errorData.source || errorData.pluginCode
 
-  /** @param {{ file?: string, id?: string, url?: string }} locObj */
-  const getLocId = (locObj = {}) => locObj.file || locObj.id || locObj.url || id || ''
-  /** @param {{ line?: string, column?: string }} locObj */
-  const getLocPos = (locObj = {}) => locObj.line ? `${locObj.line}:${locObj.column || 0}` : ''
+  const getLocId = (locObj: { file?: string, id?: string, url?: string } = {}) => locObj.file || locObj.id || locObj.url || id || ''
+  const getLocPos = (locObj: { line?: string, column?: string } = {}) => locObj.line ? `${locObj.line}:${locObj.column || 0}` : ''
   const locId = getLocId(errorData.loc) || getLocId(errorData.location) || getLocId(errorData.input) || getLocId(errorData)
   const locPos = getLocPos(errorData.loc) || getLocPos(errorData.location) || getLocPos(errorData.input) || getLocPos(errorData)
   const loc = locId.replace(process.cwd(), '.') + (locPos ? `:${locPos}` : '')

--- a/packages/vite/src/vite-node.ts
+++ b/packages/vite/src/vite-node.ts
@@ -1,22 +1,16 @@
-// @ts-check
 import process from 'node:process'
+import type { Socket } from 'node:net'
 import net from 'node:net'
 import { Buffer } from 'node:buffer'
 import { isTest } from 'std-env'
+import type { ViteNodeFetch, ViteNodeRequestMap, ViteNodeServerOptions } from './plugins/vite-node'
 
-/** @typedef {import('node:net').Socket} Socket */
-/** @typedef {import('../plugins/vite-node').ViteNodeFetch} ViteNodeFetch */
+export const viteNodeOptions: ViteNodeServerOptions = JSON.parse(process.env.NUXT_VITE_NODE_OPTIONS || '{}')
 
-/** @type {import('../plugins/vite-node').ViteNodeServerOptions} */
-export const viteNodeOptions = JSON.parse(process.env.NUXT_VITE_NODE_OPTIONS || '{}')
-
-/** @type {Map<number, { resolve: (value: any) => void, reject: (reason?: any) => void }>} */
-const pendingRequests = new Map()
+const pendingRequests = new Map<number, { resolve: (value: any) => void, reject: (reason?: any) => void }>()
 let requestIdCounter = 0
-/** @type {Socket | undefined} */
-let clientSocket
-/** @type {Promise<Socket> | undefined} */
-let currentConnectPromise
+let clientSocket: Socket | undefined
+let currentConnectPromise: Promise<Socket> | undefined
 const MAX_RETRY_ATTEMPTS = viteNodeOptions.maxRetryAttempts ?? 5
 const BASE_RETRY_DELAY_MS = viteNodeOptions.baseRetryDelay ?? 100
 const MAX_RETRY_DELAY_MS = viteNodeOptions.maxRetryDelay ?? 2000
@@ -24,10 +18,10 @@ const REQUEST_TIMEOUT_MS = viteNodeOptions.requestTimeout ?? 60000
 
 /**
  * Calculates exponential backoff delay with jitter.
- * @param {number} attempt - The current attempt number (0-based).
- * @returns {number} Delay in milliseconds.
+ * @param attempt - The current attempt number (0-based).
+ * @returns Delay in milliseconds.
  */
-function calculateRetryDelay (attempt) {
+function calculateRetryDelay (attempt: number): number {
   const exponentialDelay = BASE_RETRY_DELAY_MS * Math.pow(2, attempt)
   const jitter = Math.random() * 0.1 * exponentialDelay // Add 10% jitter
   return Math.min(exponentialDelay + jitter, MAX_RETRY_DELAY_MS)
@@ -35,9 +29,9 @@ function calculateRetryDelay (attempt) {
 
 /**
  * Establishes or returns an existing IPC socket connection with retry logic.
- * @returns {Promise<Socket>} A promise that resolves with the connected socket.
+ * @returns A promise that resolves with the connected socket.
  */
-function connectSocket () {
+function connectSocket (): Promise<Socket> {
   if (clientSocket && !clientSocket.destroyed) {
     return Promise.resolve(clientSocket)
   }
@@ -46,7 +40,7 @@ function connectSocket () {
     return currentConnectPromise
   }
 
-  const thisPromise = new Promise((resolve, reject) => {
+  const thisPromise = new Promise<Socket>((resolve, reject) => {
     if (!viteNodeOptions.socketPath) {
       console.error('vite-node-shared: NUXT_VITE_NODE_OPTIONS.socketPath is not defined.')
       return reject(new Error('Vite Node IPC socket path not configured.'))
@@ -89,10 +83,7 @@ function connectSocket () {
         }
       }
 
-      /**
-       * @param {number} additionalBytes
-       */
-      const ensureBufferCapacity = (additionalBytes) => {
+      const ensureBufferCapacity = (additionalBytes: number) => {
         const requiredSize = writeOffset + additionalBytes
 
         if (requiredSize > MAX_BUFFER_SIZE) {
@@ -121,8 +112,7 @@ function connectSocket () {
         resolve(socket)
       }
 
-      /** @param {Buffer} data */
-      const onData = (data) => {
+      const onData = (data: Buffer) => {
         try {
           ensureBufferCapacity(data.length)
           data.copy(buffer, writeOffset)
@@ -145,11 +135,10 @@ function connectSocket () {
                 const { resolve: resolveRequest, reject: rejectRequest } = requestHandlers
                 if (response.type === 'error') {
                   const err = new Error(response.error.message)
-                  // @ts-ignore We are augmenting the error object
                   err.stack = response.error.stack
-                  // @ts-ignore
+                  // @ts-expect-error We are augmenting the error object
                   err.data = response.error.data
-                  // @ts-ignore
+                  // @ts-expect-error We are augmenting the error object
                   err.statusCode = response.error.statusCode
                   rejectRequest(err)
                 } else {
@@ -172,8 +161,7 @@ function connectSocket () {
         }
       }
 
-      /** @param {Error} err */
-      const onError = (err) => {
+      const onError = (err: Error) => {
         cleanup()
         resetBuffer()
 
@@ -219,12 +207,8 @@ function connectSocket () {
 
 /**
  * Sends a request over the IPC socket with automatic reconnection.
- * @template {keyof import('../plugins/vite-node').ViteNodeRequestMap} T
- * @param {T} type - The type of the request.
- * @param {import('../plugins/vite-node').ViteNodeRequestMap[T]['request']} [payload] - The payload for the request.
- * @returns {Promise<import('../plugins/vite-node').ViteNodeRequestMap[T]['response']>} A promise that resolves with the response data.
  */
-async function sendRequest (type, payload) {
+async function sendRequest<T extends keyof ViteNodeRequestMap> (type: T, payload: ViteNodeRequestMap[T]['request']): Promise<ViteNodeRequestMap[T]['response']> {
   const requestId = requestIdCounter++
   let lastError
 
@@ -285,15 +269,12 @@ async function sendRequest (type, payload) {
   throw lastError || new Error('Request failed after all retry attempts')
 }
 
-/**
- * @type {ViteNodeFetch}
- */
-export const viteNodeFetch = {
+export const viteNodeFetch: ViteNodeFetch = {
   getManifest () {
-    return sendRequest('manifest')
+    return sendRequest('manifest', undefined)
   },
   getInvalidates () {
-    return sendRequest('invalidates')
+    return sendRequest('invalidates', undefined)
   },
   resolveId (id, importer) {
     return sendRequest('resolve', { id, importer })


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this migrates vite away from mkdist mode - we simply have another two entries, rather than a `runtime/` directory