### PR TITLE
refactor(nitro,nuxt): use `~` prefix for internal ssrContext properties

### DIFF
--- a/packages/nitro-server/src/runtime/plugins/dev-server-logs.ts
+++ b/packages/nitro-server/src/runtime/plugins/dev-server-logs.ts
@@ -77,7 +77,7 @@ export default (nitroApp: NitroApp) => {
     const ctx = asyncContext.tryUse()
     if (!ctx) { return }
     try {
-      const reducers = Object.assign(Object.create(null), devReducers, ctx.event.context._payloadReducers)
+      const reducers = Object.assign(Object.create(null), devReducers, ctx.event.context['~payloadReducers'])
       htmlContext.bodyAppend.unshift(`<script type="application/json" data-nuxt-logs="${appId}">${stringify(ctx.logs, reducers)}</script>`)
     } catch (e) {
       const shortError = e instanceof Error && 'toString' in e ? ` Received \`${e.toString()}\`.` : ''

--- a/packages/nitro-server/src/runtime/utils/renderer/app.ts
+++ b/packages/nitro-server/src/runtime/utils/renderer/app.ts
@@ -19,13 +19,13 @@ export function createSSRContext (event: H3Event): NuxtSSRContext {
     error: false,
     nuxt: undefined!, /* NuxtApp */
     payload: {},
-    _payloadReducers: Object.create(null),
+    ['~payloadReducers']: Object.create(null),
     modules: new Set(),
   }
 
   if (import.meta.prerender) {
     if (process.env.NUXT_SHARED_DATA) {
-      ssrContext._sharedPrerenderCache = sharedPrerenderCache!
+      ssrContext['~sharedPrerenderCache'] = sharedPrerenderCache!
     }
     ssrContext.payload.prerenderedAt = Date.now()
   }

--- a/packages/nitro-server/src/runtime/utils/renderer/payload.ts
+++ b/packages/nitro-server/src/runtime/utils/renderer/payload.ts
@@ -13,7 +13,7 @@ import { appId, multiApp } from '#internal/nuxt.config.mjs'
 export function renderPayloadResponse (ssrContext: NuxtSSRContext) {
   return {
     body: process.env.NUXT_JSON_PAYLOADS
-      ? stringify(splitPayload(ssrContext).payload, ssrContext._payloadReducers)
+      ? stringify(splitPayload(ssrContext).payload, ssrContext['~payloadReducers'])
       : `export default ${devalue(splitPayload(ssrContext).payload)}`,
     statusCode: getResponseStatus(ssrContext.event),
     statusMessage: getResponseStatusText(ssrContext.event),
@@ -25,7 +25,7 @@ export function renderPayloadResponse (ssrContext: NuxtSSRContext) {
 }
 
 export function renderPayloadJsonScript (opts: { ssrContext: NuxtSSRContext, data?: any, src?: string }): Script[] {
-  const contents = opts.data ? stringify(opts.data, opts.ssrContext._payloadReducers) : ''
+  const contents = opts.data ? stringify(opts.data, opts.ssrContext['~payloadReducers']) : ''
   const payload: Script = {
     'type': 'application/json',
     'innerHTML': contents,

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -648,15 +648,15 @@ function createAsyncData<
   const hasCustomGetCachedData = options.getCachedData !== getDefaultCachedData
 
   // When prerendering, share payload data automatically between requests
-  const handler: AsyncDataHandler<ResT> = import.meta.client || !import.meta.prerender || !nuxtApp.ssrContext?._sharedPrerenderCache
+  const handler: AsyncDataHandler<ResT> = import.meta.client || !import.meta.prerender || !nuxtApp.ssrContext?.['~sharedPrerenderCache']
     ? _handler
     : (nuxtApp, options) => {
-        const value = nuxtApp.ssrContext!._sharedPrerenderCache!.get(key)
+        const value = nuxtApp.ssrContext!['~sharedPrerenderCache']!.get(key)
         if (value) { return value as Promise<ResT> }
 
         const promise = Promise.resolve().then(() => nuxtApp.runWithContext(() => _handler(nuxtApp, options)))
 
-        nuxtApp.ssrContext!._sharedPrerenderCache!.set(key, promise)
+        nuxtApp.ssrContext!['~sharedPrerenderCache']!.set(key, promise)
         return promise
       }
 

--- a/packages/nuxt/src/app/composables/manifest.ts
+++ b/packages/nuxt/src/app/composables/manifest.ts
@@ -48,7 +48,7 @@ export function getAppManifest (): Promise<NuxtAppManifest> {
     throw new Error('[nuxt] app manifest should be enabled with `experimental.appManifest`')
   }
   if (import.meta.server) {
-    useNuxtApp().ssrContext!._preloadManifest = true
+    useNuxtApp().ssrContext!['~preloadManifest'] = true
   }
   return manifest || fetchManifest()
 }
@@ -61,7 +61,7 @@ export async function getRouteRules (url: string): Promise<Record<string, any>>
 export async function getRouteRules (arg: string | H3Event | { path: string }) {
   const path = typeof arg === 'string' ? arg : arg.path
   if (import.meta.server) {
-    useNuxtApp().ssrContext!._preloadManifest = true
+    useNuxtApp().ssrContext!['~preloadManifest'] = true
     const _routeRulesMatcher = toRouteMatcher(
       createRadixRouter({ routes: useRuntimeConfig().nitro!.routeRules }),
     )

--- a/packages/nuxt/src/app/composables/payload.ts
+++ b/packages/nuxt/src/app/composables/payload.ts
@@ -153,7 +153,7 @@ export function definePayloadReducer (
   reduce: (data: any) => any,
 ) {
   if (import.meta.server) {
-    useNuxtApp().ssrContext!._payloadReducers[name] = reduce
+    useNuxtApp().ssrContext!['~payloadReducers'][name] = reduce
   }
 }
 

--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -203,7 +203,7 @@ export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: Na
         const encodedLoc = location.replace(URL_QUOTE_RE, '%22')
         const encodedHeader = encodeURL(location, isExternalHost)
 
-        nuxtApp.ssrContext!._renderResponse = {
+        nuxtApp.ssrContext!['~renderResponse'] = {
           statusCode: sanitizeStatusCode(options?.redirectCode || 302, 302),
           body: `<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=${encodedLoc}"></head></html>`,
           headers: { location: encodedHeader },

--- a/packages/nuxt/src/app/entry.ts
+++ b/packages/nuxt/src/app/entry.ts
@@ -38,7 +38,8 @@ if (import.meta.server) {
       await nuxt.hooks.callHook('app:error', error)
       nuxt.payload.error ||= createError(error as any)
     }
-    if (ssrContext?._renderResponse) { throw new Error('skipping render') }
+    // TODO: remove _renderResponse in nuxt v5
+    if (ssrContext && (ssrContext['~renderResponse'] || ssrContext._renderResponse)) { throw new Error('skipping render') }
 
     return vueApp
   }

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -73,16 +73,16 @@ export interface NuxtSSRContext extends SSRContext {
   teleports?: Record<string, string>
   islandContext?: NuxtIslandContext
   /** @internal */
-  _renderResponse?: Partial<RenderResponse>
+  ['~renderResponse']?: Partial<RenderResponse>
   /** @internal */
-  _payloadReducers: Record<string, (data: any) => any>
+  ['~payloadReducers']: Record<string, (data: any) => any>
   /** @internal */
-  _sharedPrerenderCache?: {
+  ['~sharedPrerenderCache']?: {
     get<T = unknown> (key: string): Promise<T> | undefined
     set<T> (key: string, value: Promise<T>): Promise<void>
   }
   /** @internal */
-  _preloadManifest?: boolean
+  ['~preloadManifest']?: boolean
 }
 
 export interface NuxtPayload {

--- a/packages/nuxt/src/app/plugins/dev-server-logs.ts
+++ b/packages/nuxt/src/app/plugins/dev-server-logs.ts
@@ -20,7 +20,7 @@ export default defineNuxtPlugin(async (nuxtApp) => {
   if (import.meta.test) { return }
 
   if (import.meta.server) {
-    nuxtApp.ssrContext!.event.context._payloadReducers = nuxtApp.ssrContext!._payloadReducers
+    nuxtApp.ssrContext!.event.context['~payloadReducers'] = nuxtApp.ssrContext!['~payloadReducers']
     return
   }
 

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -95,7 +95,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(rootDir, '.output-inline/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"556k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"557k"`)
 
     const modules = await analyzeSizes(['node_modules/**/*'], serverDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"96.7k"`)
@@ -117,7 +117,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(pagesRootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"288k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"289k"`)
 
     const modules = await analyzeSizes(['node_modules/**/*'], serverDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"1448k"`)


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this follows the good idea from @pi0 to prefix internal properties with `~` to mean they get sorted to the bottom of the list on autocomplete

they are all internal and shouldn't be used, but `_renderResponse` sadly has be and so we keep support for this until nuxt v5.