### PR TITLE
refactor(nitro): move tree-shaken flags from replace plugin -> vfs

### DIFF
--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -191,6 +191,17 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
       // this will be overridden in vite plugin
       '#internal/entry-chunk.mjs': () => `export const entryFileName = undefined`,
       '#internal/nuxt/entry-ids.mjs': () => `export default []`,
+      '#internal/nuxt/nitro-config.mjs': () => [
+        `export const NUXT_NO_SSR = ${nuxt.options.ssr === false}`,
+        `export const NUXT_EARLY_HINTS = ${nuxt.options.experimental.writeEarlyHints !== false}`,
+        `export const NUXT_NO_SCRIPTS = ${nuxt.options.features.noScripts === 'all' || (!!nuxt.options.features.noScripts && !nuxt.options.dev)}`,
+        `export const NUXT_INLINE_STYLES = ${!!nuxt.options.features.inlineStyles}`,
+        `export const PARSE_ERROR_DATA = ${!!nuxt.options.experimental.parseErrorData}`,
+        `export const NUXT_JSON_PAYLOADS = ${!!nuxt.options.experimental.renderJsonPayloads}`,
+        `export const NUXT_ASYNC_CONTEXT = ${!!nuxt.options.experimental.asyncContext}`,
+        `export const NUXT_SHARED_DATA = ${!!nuxt.options.experimental.sharedPrerenderData}`,
+        `export const NUXT_PAYLOAD_EXTRACTION = ${!!nuxt.options.experimental.payloadExtraction}`,
+      ].join('\n'),
     },
     routeRules: {
       '/__nuxt_error': { cache: false },
@@ -293,15 +304,6 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
       '#internal/nuxt/paths': resolve(distDir, 'runtime/utils/paths'),
     },
     replace: {
-      'process.env.NUXT_NO_SSR': String(nuxt.options.ssr === false),
-      'process.env.NUXT_EARLY_HINTS': String(nuxt.options.experimental.writeEarlyHints !== false),
-      'process.env.NUXT_NO_SCRIPTS': String(nuxt.options.features.noScripts === 'all' || (!!nuxt.options.features.noScripts && !nuxt.options.dev)),
-      'process.env.NUXT_INLINE_STYLES': String(!!nuxt.options.features.inlineStyles),
-      'process.env.PARSE_ERROR_DATA': String(!!nuxt.options.experimental.parseErrorData),
-      'process.env.NUXT_JSON_PAYLOADS': String(!!nuxt.options.experimental.renderJsonPayloads),
-      'process.env.NUXT_ASYNC_CONTEXT': String(!!nuxt.options.experimental.asyncContext),
-      'process.env.NUXT_SHARED_DATA': String(!!nuxt.options.experimental.sharedPrerenderData),
-      'process.dev': String(nuxt.options.dev),
       '__VUE_PROD_DEVTOOLS__': String(false),
     },
     rollupConfig: {

--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -1,11 +1,5 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
-import process from 'node:process'
-import {
-  getPrefetchLinks,
-  getPreloadLinks,
-  getRequestDependencies,
-  renderResourceHeaders,
-} from 'vue-bundle-renderer/runtime'
+import { getPrefetchLinks, getPreloadLinks, getRequestDependencies, renderResourceHeaders } from 'vue-bundle-renderer/runtime'
 import type { RenderResponse } from 'nitropack/types'
 import { appendResponseHeader, createError, getQuery, getResponseStatus, getResponseStatusText, writeEarlyHints } from 'h3'
 import { getQuery as getURLQuery, joinURL } from 'ufo'
@@ -24,7 +18,8 @@ import { renderInlineStyles } from '../utils/renderer/inline-styles'
 import { replaceIslandTeleports } from '../utils/renderer/islands'
 // @ts-expect-error virtual file
 import { renderSSRHeadOptions } from '#internal/unhead.config.mjs'
-
+// @ts-expect-error virtual file
+import { NUXT_ASYNC_CONTEXT, NUXT_EARLY_HINTS, NUXT_INLINE_STYLES, NUXT_JSON_PAYLOADS, NUXT_NO_SCRIPTS, NUXT_PAYLOAD_EXTRACTION, PARSE_ERROR_DATA } from '#internal/nuxt/nitro-config.mjs'
 // @ts-expect-error virtual file
 import { appHead, appTeleportAttrs, appTeleportTag, componentIslands, appManifest as isAppManifestEnabled } from '#internal/nuxt.config.mjs'
 // @ts-expect-error virtual file
@@ -41,7 +36,7 @@ globalThis.__buildAssetsURL = buildAssetsURL
 globalThis.__publicAssetsURL = publicAssetsURL
 
 // Polyfill for unctx (https://github.com/unjs/unctx#native-async-context)
-if (process.env.NUXT_ASYNC_CONTEXT && !('AsyncLocalStorage' in globalThis)) {
+if (NUXT_ASYNC_CONTEXT && !('AsyncLocalStorage' in globalThis)) {
   (globalThis as any).AsyncLocalStorage = AsyncLocalStorage
 }
 
@@ -56,8 +51,8 @@ const HAS_APP_TELEPORTS = !!(appTeleportTag && appTeleportAttrs.id)
 const APP_TELEPORT_OPEN_TAG = HAS_APP_TELEPORTS ? `<${appTeleportTag}${propsToString(appTeleportAttrs)}>` : ''
 const APP_TELEPORT_CLOSE_TAG = HAS_APP_TELEPORTS ? `</${appTeleportTag}>` : ''
 
-const PAYLOAD_URL_RE = process.env.NUXT_JSON_PAYLOADS ? /^[^?]*\/_payload.json(?:\?.*)?$/ : /^[^?]*\/_payload.js(?:\?.*)?$/
-const PAYLOAD_FILENAME = process.env.NUXT_JSON_PAYLOADS ? '_payload.json' : '_payload.js'
+const PAYLOAD_URL_RE = NUXT_JSON_PAYLOADS ? /^[^?]*\/_payload.json(?:\?.*)?$/ : /^[^?]*\/_payload.js(?:\?.*)?$/
+const PAYLOAD_FILENAME = NUXT_JSON_PAYLOADS ? '_payload.json' : '_payload.js'
 
 let entryPath: string
 
@@ -85,7 +80,7 @@ export default defineRenderHandler(async (event): Promise<Partial<RenderResponse
 
   if (ssrError) {
     ssrError.statusCode &&= Number.parseInt(ssrError.statusCode as any)
-    if (process.env.PARSE_ERROR_DATA && typeof ssrError.data === 'string') {
+    if (PARSE_ERROR_DATA && typeof ssrError.data === 'string') {
       try {
         ssrError.data = destr(ssrError.data)
       } catch {
@@ -96,7 +91,7 @@ export default defineRenderHandler(async (event): Promise<Partial<RenderResponse
   }
 
   // Whether we are rendering payload route
-  const isRenderingPayload = process.env.NUXT_PAYLOAD_EXTRACTION && PAYLOAD_URL_RE.test(ssrContext.url)
+  const isRenderingPayload = NUXT_PAYLOAD_EXTRACTION && PAYLOAD_URL_RE.test(ssrContext.url)
   if (isRenderingPayload) {
     const url = ssrContext.url.substring(0, ssrContext.url.lastIndexOf('/')) || '/'
     ssrContext.url = url
@@ -115,21 +110,21 @@ export default defineRenderHandler(async (event): Promise<Partial<RenderResponse
   }
 
   // Whether we are prerendering route
-  const _PAYLOAD_EXTRACTION = import.meta.prerender && process.env.NUXT_PAYLOAD_EXTRACTION && !ssrContext.noSSR
+  const _PAYLOAD_EXTRACTION = import.meta.prerender && NUXT_PAYLOAD_EXTRACTION && !ssrContext.noSSR
   const payloadURL = _PAYLOAD_EXTRACTION ? joinURL(ssrContext.runtimeConfig.app.cdnURL || ssrContext.runtimeConfig.app.baseURL, ssrContext.url.replace(/\?.*$/, ''), PAYLOAD_FILENAME) + '?' + ssrContext.runtimeConfig.app.buildId : undefined
 
   // Render app
   const renderer = await getRenderer(ssrContext)
 
   // Render 103 Early Hints
-  if (process.env.NUXT_EARLY_HINTS && !isRenderingPayload && !import.meta.prerender) {
+  if (NUXT_EARLY_HINTS && !isRenderingPayload && !import.meta.prerender) {
     const { link } = renderResourceHeaders({}, renderer.rendererContext)
     if (link) {
       writeEarlyHints(event, link)
     }
   }
 
-  if (process.env.NUXT_INLINE_STYLES) {
+  if (NUXT_INLINE_STYLES) {
     for (const id of entryIds) {
       ssrContext.modules!.add(id)
     }
@@ -148,7 +143,7 @@ export default defineRenderHandler(async (event): Promise<Partial<RenderResponse
 
   // Render inline styles
   // TODO: remove _renderResponse in nuxt v5
-  const inlinedStyles = process.env.NUXT_INLINE_STYLES && !ssrContext['~renderResponse'] && !ssrContext._renderResponse && !isRenderingPayload
+  const inlinedStyles = NUXT_INLINE_STYLES && !ssrContext['~renderResponse'] && !ssrContext._renderResponse && !isRenderingPayload
     ? await renderInlineStyles(ssrContext.modules ?? [])
     : []
 
@@ -180,7 +175,7 @@ export default defineRenderHandler(async (event): Promise<Partial<RenderResponse
     await payloadCache!.setItem(ssrContext.url === '/' ? '/' : ssrContext.url.replace(/\/$/, ''), renderPayloadResponse(ssrContext))
   }
 
-  const NO_SCRIPTS = process.env.NUXT_NO_SCRIPTS || routeOptions.noScripts
+  const NO_SCRIPTS = NUXT_NO_SCRIPTS || routeOptions.noScripts
 
   // Setup head
   const { styles, scripts } = getRequestDependencies(ssrContext, renderer.rendererContext)
@@ -215,7 +210,7 @@ export default defineRenderHandler(async (event): Promise<Partial<RenderResponse
   if (_PAYLOAD_EXTRACTION && !NO_SCRIPTS) {
     ssrContext.head.push({
       link: [
-        process.env.NUXT_JSON_PAYLOADS
+        NUXT_JSON_PAYLOADS
           ? { rel: 'preload', as: 'fetch', crossorigin: 'anonymous', href: payloadURL }
           : { rel: 'modulepreload', crossorigin: '', href: payloadURL },
       ],
@@ -262,10 +257,10 @@ export default defineRenderHandler(async (event): Promise<Partial<RenderResponse
     // 5. Payloads
     ssrContext.head.push({
       script: _PAYLOAD_EXTRACTION
-        ? process.env.NUXT_JSON_PAYLOADS
+        ? NUXT_JSON_PAYLOADS
           ? renderPayloadJsonScript({ ssrContext, data: splitPayload(ssrContext).initial, src: payloadURL })
           : renderPayloadScript({ ssrContext, data: splitPayload(ssrContext).initial, src: payloadURL })
-        : process.env.NUXT_JSON_PAYLOADS
+        : NUXT_JSON_PAYLOADS
           ? renderPayloadJsonScript({ ssrContext, data: ssrContext.payload })
           : renderPayloadScript({ ssrContext, data: ssrContext.payload }),
     }, {
@@ -278,7 +273,7 @@ export default defineRenderHandler(async (event): Promise<Partial<RenderResponse
 
   // 6. Scripts
   if (!routeOptions.noScripts) {
-    const tagPosition = (_PAYLOAD_EXTRACTION && !process.env.NUXT_JSON_PAYLOADS) ? 'bodyClose' : 'head'
+    const tagPosition = (_PAYLOAD_EXTRACTION && !NUXT_JSON_PAYLOADS) ? 'bodyClose' : 'head'
 
     ssrContext.head.push({
       script: Object.values(scripts).map(resource => (<Script> {

--- a/packages/nitro-server/src/runtime/utils/cache.ts
+++ b/packages/nitro-server/src/runtime/utils/cache.ts
@@ -2,15 +2,16 @@
 // This is likely not portable. A type annotation is necessary.
 import type {} from 'unstorage'
 import { useStorage } from 'nitropack/runtime'
-import process from 'node:process'
+// @ts-expect-error virtual file
+import { NUXT_SHARED_DATA } from '#internal/nuxt/nitro-config.mjs'
 
 export const payloadCache = import.meta.prerender ? useStorage('internal:nuxt:prerender:payload') : null
 export const islandCache = import.meta.prerender ? useStorage('internal:nuxt:prerender:island') : null
 export const islandPropCache = import.meta.prerender ? useStorage('internal:nuxt:prerender:island-props') : null
-export const sharedPrerenderPromises = import.meta.prerender && process.env.NUXT_SHARED_DATA ? new Map<string, Promise<any>>() : null
+export const sharedPrerenderPromises = import.meta.prerender && NUXT_SHARED_DATA ? new Map<string, Promise<any>>() : null
 
 const sharedPrerenderKeys = new Set<string>()
-export const sharedPrerenderCache = import.meta.prerender && process.env.NUXT_SHARED_DATA
+export const sharedPrerenderCache = import.meta.prerender && NUXT_SHARED_DATA
   ? {
       get<T = unknown> (key: string): Promise<T> | undefined {
         if (sharedPrerenderKeys.has(key)) {

--- a/packages/nitro-server/src/runtime/utils/renderer/app.ts
+++ b/packages/nitro-server/src/runtime/utils/renderer/app.ts
@@ -1,4 +1,3 @@
-import process from 'node:process'
 import type { H3Event } from 'h3'
 import { useRuntimeConfig } from 'nitropack/runtime'
 import { createHead } from '@unhead/vue/server'
@@ -6,6 +5,8 @@ import type { NuxtPayload, NuxtSSRContext } from 'nuxt/app'
 import { sharedPrerenderCache } from '../cache'
 // @ts-expect-error virtual file
 import unheadOptions from '#internal/unhead-options.mjs'
+// @ts-expect-error virtual file
+import { NUXT_NO_SSR, NUXT_SHARED_DATA } from '#internal/nuxt/nitro-config.mjs'
 
 const PRERENDER_NO_SSR_ROUTES = new Set(['/index.html', '/200.html', '/404.html'])
 
@@ -14,7 +15,7 @@ export function createSSRContext (event: H3Event): NuxtSSRContext {
     url: event.path,
     event,
     runtimeConfig: useRuntimeConfig(event) as NuxtSSRContext['runtimeConfig'],
-    noSSR: !!(process.env.NUXT_NO_SSR) || event.context.nuxt?.noSSR || (import.meta.prerender ? PRERENDER_NO_SSR_ROUTES.has(event.path) : false),
+    noSSR: !!(NUXT_NO_SSR) || event.context.nuxt?.noSSR || (import.meta.prerender ? PRERENDER_NO_SSR_ROUTES.has(event.path) : false),
     head: createHead(unheadOptions),
     error: false,
     nuxt: undefined!, /* NuxtApp */
@@ -24,7 +25,7 @@ export function createSSRContext (event: H3Event): NuxtSSRContext {
   }
 
   if (import.meta.prerender) {
-    if (process.env.NUXT_SHARED_DATA) {
+    if (NUXT_SHARED_DATA) {
       ssrContext['~sharedPrerenderCache'] = sharedPrerenderCache!
     }
     ssrContext.payload.prerenderedAt = Date.now()

--- a/packages/nitro-server/src/runtime/utils/renderer/build-files.ts
+++ b/packages/nitro-server/src/runtime/utils/renderer/build-files.ts
@@ -8,6 +8,8 @@ import { useRuntimeConfig } from 'nitropack/runtime'
 import type { NuxtSSRContext } from 'nuxt/app'
 
 // @ts-expect-error virtual file
+import { NUXT_NO_SSR } from '#internal/nuxt/nitro-config.mjs'
+// @ts-expect-error virtual file
 import { appRootAttrs, appRootTag, appSpaLoaderAttrs, appSpaLoaderTag, spaLoadingTemplateOutside } from '#internal/nuxt.config.mjs'
 // @ts-expect-error virtual file
 import { buildAssetsURL } from '#internal/nuxt/paths'
@@ -124,7 +126,7 @@ function lazyCachedFunction<T> (fn: () => Promise<T>): () => Promise<T> {
 }
 
 export function getRenderer (ssrContext: NuxtSSRContext): Promise<Renderer> {
-  return (process.env.NUXT_NO_SSR || ssrContext.noSSR) ? getSPARenderer() : getSSRRenderer()
+  return (NUXT_NO_SSR || ssrContext.noSSR) ? getSPARenderer() : getSSRRenderer()
 }
 
 // @ts-expect-error file will be produced after app build

--- a/packages/nitro-server/src/runtime/utils/renderer/payload.ts
+++ b/packages/nitro-server/src/runtime/utils/renderer/payload.ts
@@ -1,5 +1,4 @@
 import type { RenderResponse } from 'nitropack/types'
-import process from 'node:process'
 import { getResponseStatus, getResponseStatusText } from 'h3'
 import devalue from '@nuxt/devalue'
 import { stringify, uneval } from 'devalue'
@@ -9,16 +8,18 @@ import type { NuxtPayload, NuxtSSRContext } from 'nuxt/app'
 
 // @ts-expect-error virtual file
 import { appId, multiApp } from '#internal/nuxt.config.mjs'
+// @ts-expect-error virtual file
+import { NUXT_JSON_PAYLOADS, NUXT_NO_SSR, NUXT_PAYLOAD_EXTRACTION } from '#internal/nuxt/nitro-config.mjs'
 
 export function renderPayloadResponse (ssrContext: NuxtSSRContext): RenderResponse {
   return {
-    body: process.env.NUXT_JSON_PAYLOADS
+    body: NUXT_JSON_PAYLOADS
       ? stringify(splitPayload(ssrContext).payload, ssrContext['~payloadReducers'])
       : `export default ${devalue(splitPayload(ssrContext).payload)}`,
     statusCode: getResponseStatus(ssrContext.event),
     statusMessage: getResponseStatusText(ssrContext.event),
     headers: {
-      'content-type': process.env.NUXT_JSON_PAYLOADS ? 'application/json;charset=utf-8' : 'text/javascript;charset=utf-8',
+      'content-type': NUXT_JSON_PAYLOADS ? 'application/json;charset=utf-8' : 'text/javascript;charset=utf-8',
       'x-powered-by': 'Nuxt',
     },
   }
@@ -30,7 +31,7 @@ export function renderPayloadJsonScript (opts: { ssrContext: NuxtSSRContext, dat
     'type': 'application/json',
     'innerHTML': contents,
     'data-nuxt-data': appId,
-    'data-ssr': !(process.env.NUXT_NO_SSR || opts.ssrContext.noSSR),
+    'data-ssr': !(NUXT_NO_SSR || opts.ssrContext.noSSR),
   }
   if (!multiApp) {
     payload.id = '__NUXT_DATA__'
@@ -51,7 +52,7 @@ export function renderPayloadJsonScript (opts: { ssrContext: NuxtSSRContext, dat
 
 export function renderPayloadScript (opts: { ssrContext: NuxtSSRContext, data?: any, src?: string }): Script[] {
   opts.data.config = opts.ssrContext.config
-  const _PAYLOAD_EXTRACTION = import.meta.prerender && process.env.NUXT_PAYLOAD_EXTRACTION && !opts.ssrContext.noSSR
+  const _PAYLOAD_EXTRACTION = import.meta.prerender && NUXT_PAYLOAD_EXTRACTION && !opts.ssrContext.noSSR
   const nuxtData = devalue(opts.data)
   if (_PAYLOAD_EXTRACTION) {
     const singleAppPayload = `import p from "${opts.src}";window.__NUXT__={...p,...(${nuxtData})}`

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -734,8 +734,6 @@ export default defineNuxtPlugin({
     logger.warn('Using experimental payload extraction for full-static output. You can opt-out by setting `experimental.payloadExtraction` to `false`.')
     nuxt.options.experimental.payloadExtraction = true
   }
-  nitro.options.replace['process.env.NUXT_PAYLOAD_EXTRACTION'] = String(!!nuxt.options.experimental.payloadExtraction)
-  nitro.options._config.replace!['process.env.NUXT_PAYLOAD_EXTRACTION'] = String(!!nuxt.options.experimental.payloadExtraction)
 
   if (!nuxt.options.dev && nuxt.options.experimental.payloadExtraction) {
     addPlugin(resolve(nuxt.options.appDir, 'plugins/payload.client'))


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

currently `process.env.` is confusing as it looks like it might overridden at runtime. this moves configuration for tree-shaking to a virtual file (which should also be more performant)