### PR TITLE
refactor(nitro,nuxt,vite,webpack): use `status`/`statusText` + deprecate old props

### DIFF
--- a/docs/1.getting-started/07.routing.md
+++ b/docs/1.getting-started/07.routing.md
@@ -135,7 +135,7 @@ definePageMeta({
 
 Nuxt offers route validation via the `validate` property in [`definePageMeta()`](/docs/4.x/api/utils/define-page-meta) in each page you wish to validate.
 
-The `validate` property accepts the `route` as an argument. You can return a boolean value to determine whether or not this is a valid route to be rendered with this page. If you return `false`, this will cause a 404 error. You can also directly return an object with `statusCode`/`statusMessage` to customize the error returned.
+The `validate` property accepts the `route` as an argument. You can return a boolean value to determine whether or not this is a valid route to be rendered with this page. If you return `false`, this will cause a 404 error. You can also directly return an object with `status`/`statusText` to customize the error returned.
 
 If you have a more complex use case, then you can use anonymous route middleware instead.
 

--- a/docs/1.getting-started/12.error-handling.md
+++ b/docs/1.getting-started/12.error-handling.md
@@ -99,7 +99,7 @@ const handleError = () => clearError({ redirect: '/' })
 
 <template>
   <div>
-    <h2>{{ error?.statusCode }}</h2>
+    <h2>{{ error?.status }}</h2>
     <button @click="handleError">
       Clear errors
     </button>
@@ -140,7 +140,7 @@ If you are running on Node 16 and you set any cookies when rendering your error 
 ### `useError`
 
 ```ts [TS Signature]
-function useError (): Ref<Error | { url, statusCode, statusMessage, message, description, data }>
+function useError (): Ref<Error | { url, status, statusText, message, description, data }>
 ```
 
 This function will return the global Nuxt error that is being handled.
@@ -152,7 +152,7 @@ Read more about `useError` composable.
 ### `createError`
 
 ```ts [TS Signature]
-function createError (err: string | { cause, data, message, name, stack, statusCode, statusMessage, fatal }): Error
+function createError (err: string | { cause, data, message, name, stack, status, statusText, fatal }): Error
 ```
 
 Create an error object with additional metadata. You can pass a string to be set as the error `message` or an object containing error properties. It is usable in both the Vue and Server portions of your app, and is meant to be thrown.
@@ -168,8 +168,8 @@ const { data } = await useFetch(`/api/movies/${route.params.slug}`)
 
 if (!data.value) {
   throw createError({
-    statusCode: 404,
-    statusMessage: 'Page Not Found',
+    status: 404,
+    statusText: 'Page Not Found',
   })
 }
 </script>
@@ -182,7 +182,7 @@ Read more about `createError` util.
 ### `showError`
 
 ```ts [TS Signature]
-function showError (err: string | Error | { statusCode, statusMessage }): Error
+function showError (err: string | Error | { status, statusText }): Error
 ```
 
 You can call this function at any point on client-side, or (on server side) directly within middleware, plugins or `setup()` functions. It will trigger a full-screen error page which you can clear with [`clearError`](/docs/4.x/getting-started/error-handling#clearerror).

--- a/docs/1.getting-started/13.server.md
+++ b/docs/1.getting-started/13.server.md
@@ -74,7 +74,7 @@ export default defineNuxtConfig({
     '/api/*': { cache: { maxAge: 60 * 60 } },
     // Redirection to avoid 404
     '/old-page': {
-      redirect: { to: '/new-page', status: 302 },
+      redirect: { to: '/new-page', statusCode: 302 },
     },
     // ...
   },

--- a/docs/1.getting-started/13.server.md
+++ b/docs/1.getting-started/13.server.md
@@ -74,7 +74,7 @@ export default defineNuxtConfig({
     '/api/*': { cache: { maxAge: 60 * 60 } },
     // Redirection to avoid 404
     '/old-page': {
-      redirect: { to: '/new-page', statusCode: 302 },
+      redirect: { to: '/new-page', status: 302 },
     },
     // ...
   },

--- a/docs/2.directory-structure/1.app/3.error.md
+++ b/docs/2.directory-structure/1.app/3.error.md
@@ -16,7 +16,7 @@ const props = defineProps<{ error: NuxtError }>()
 
 <template>
   <div>
-    <h1>{{ error.statusCode }}</h1>
+    <h1>{{ error.status }}</h1>
     <NuxtLink to="/">Go back home</NuxtLink>
   </div>
 </template>
@@ -31,12 +31,16 @@ The error page has a single prop - `error` which contains an error for you to ha
 The `error` object provides the following fields:
 ```ts
 interface NuxtError {
-  statusCode: number
+  status: number
   fatal: boolean
   unhandled: boolean
-  statusMessage?: string
+  statusText?: string
   data?: unknown
   cause?: unknown
+  // legacy/deprecated equivalent of `status`
+  statusCode: number
+  // legacy/deprecated equivalent of `statusText`
+  statusMessage?: string
 }
 ```
 
@@ -44,8 +48,8 @@ If you have an error with custom fields they will be lost; you should assign the
 
 ```ts
 throw createError({
-  statusCode: 404,
-  statusMessage: 'Page Not Found',
+  status: 404,
+  statusText: 'Page Not Found',
   data: {
     myCustomField: true,
   },

--- a/docs/2.directory-structure/1.server.md
+++ b/docs/2.directory-structure/1.server.md
@@ -295,8 +295,8 @@ export default defineEventHandler((event) => {
 
   if (!Number.isInteger(id)) {
     throw createError({
-      statusCode: 400,
-      statusMessage: 'ID should be an integer',
+      status: 400,
+      statusText: 'ID should be an integer',
     })
   }
   return 'All good'

--- a/docs/3.guide/1.concepts/2.nuxt-lifecycle.md
+++ b/docs/3.guide/1.concepts/2.nuxt-lifecycle.md
@@ -54,7 +54,7 @@ After this step, Nuxt calls the [`app:created`](/docs/4.x/api/advanced/hooks#app
 After initializing plugins and before executing middleware, Nuxt calls the `validate` method if it is defined in the `definePageMeta` function. The `validate` method, which can be synchronous or asynchronous, is often used to validate dynamic route parameters.
 
 - The `validate` function should return `true` if the parameters are valid.
-- If validation fails, it should return `false` or an object containing a `statusCode` and/or `statusMessage` to terminate the request.
+- If validation fails, it should return `false` or an object containing a `status` and/or `statusText` to terminate the request.
 
 For more information, see the [Route Validation documentation](/docs/4.x/getting-started/routing#route-validation).
 

--- a/docs/3.guide/5.recipes/3.custom-usefetch.md
+++ b/docs/3.guide/5.recipes/3.custom-usefetch.md
@@ -98,7 +98,7 @@ import type { UseFetchOptions } from 'nuxt/app'
 
 interface CustomError {
   message: string
-  statusCode: number
+  status: number
 }
 
 export function useAPI<T> (

--- a/docs/3.guide/5.recipes/4.sessions-and-authentication.md
+++ b/docs/3.guide/5.recipes/4.sessions-and-authentication.md
@@ -65,7 +65,7 @@ export default defineEventHandler(async (event) => {
     return {}
   }
   throw createError({
-    statusCode: 401,
+    status: 401,
     message: 'Bad credentials',
   })
 })

--- a/docs/4.api/2.composables/use-error.md
+++ b/docs/4.api/2.composables/use-error.md
@@ -22,8 +22,8 @@ You can use this composable in your components, pages, or plugins to access or r
 
 ```ts
 interface NuxtError<DataT = unknown> {
-  statusCode: number
-  statusMessage: string
+  status: number
+  statusText: string
   message: string
   data?: DataT
   error?: true

--- a/docs/4.api/3.utils/create-error.md
+++ b/docs/4.api/3.utils/create-error.md
@@ -12,9 +12,9 @@ You can use this function to create an error object with additional metadata. It
 
 ## Parameters
 
-- `err`: `string | { cause, data, message, name, stack, statusCode, statusMessage, fatal }`
+- `err`: `string | { cause, data, message, name, stack, status, statusText, fatal }`
 
-You can pass either a string or an object to the `createError` function. If you pass a string, it will be used as the error `message`, and the `statusCode` will default to `500`. If you pass an object, you can set multiple properties of the error, such as `statusCode`, `message`, and other error properties.
+You can pass either a string or an object to the `createError` function. If you pass a string, it will be used as the error `message`, and the `status` will default to `500`. If you pass an object, you can set multiple properties of the error, such as `status`, `message`, and other error properties.
 
 ## In Vue App
 
@@ -30,7 +30,7 @@ If you throw an error created with `createError`:
 const route = useRoute()
 const { data } = await useFetch(`/api/movies/${route.params.slug}`)
 if (!data.value) {
-  throw createError({ statusCode: 404, statusMessage: 'Page Not Found' })
+  throw createError({ status: 404, statusText: 'Page Not Found' })
 }
 </script>
 ```
@@ -44,12 +44,12 @@ Use `createError` to trigger error handling in server API routes.
 ```ts [server/api/error.ts]
 export default eventHandler(() => {
   throw createError({
-    statusCode: 404,
-    statusMessage: 'Page Not Found',
+    status: 404,
+    statusText: 'Page Not Found',
   })
 })
 ```
 
-In API routes, using `createError` by passing an object with a short `statusMessage` is recommended because it can be accessed on the client side. Otherwise, a `message` passed to `createError` on an API route will not propagate to the client. Alternatively, you can use the `data` property to pass data back to the client. In any case, always consider avoiding to put dynamic user input to the message to avoid potential security issues.
+In API routes, using `createError` by passing an object with a short `statusText` is recommended because it can be accessed on the client side. Otherwise, a `message` passed to `createError` on an API route will not propagate to the client. Alternatively, you can use the `data` property to pass data back to the client. In any case, always consider avoiding to put dynamic user input to the message to avoid potential security issues.
 
 :read-more{to="/docs/4.x/getting-started/error-handling"}

--- a/docs/4.api/3.utils/define-nuxt-route-middleware.md
+++ b/docs/4.api/3.utils/define-nuxt-route-middleware.md
@@ -39,7 +39,7 @@ You can use route middleware to throw errors and show helpful error messages:
 ```ts [app/middleware/error.ts]
 export default defineNuxtRouteMiddleware((to) => {
   if (to.params.id === '1') {
-    throw createError({ statusCode: 404, statusMessage: 'Page Not Found' })
+    throw createError({ status: 404, statusText: 'Page Not Found' })
   }
 })
 ```

--- a/docs/4.api/3.utils/define-page-meta.md
+++ b/docs/4.api/3.utils/define-page-meta.md
@@ -130,7 +130,7 @@ interface PageMeta {
 
   - **Type**: `(route: RouteLocationNormalized) => boolean | Promise<boolean> | Partial<NuxtError> | Promise<Partial<NuxtError>>`
 
-    Validate whether a given route can validly be rendered with this page. Return true if it is valid, or false if not. If another match can't be found, this will mean a 404. You can also directly return an object with `statusCode`/`statusMessage` to respond immediately with an error (other matches will not be checked).
+    Validate whether a given route can validly be rendered with this page. Return true if it is valid, or false if not. If another match can't be found, this will mean a 404. You can also directly return an object with `status`/`statusText` to respond immediately with an error (other matches will not be checked).
 
   **`scrollToTop`**
 

--- a/docs/4.api/3.utils/set-response-status.md
+++ b/docs/4.api/3.utils/set-response-status.md
@@ -1,6 +1,6 @@
 ---
 title: 'setResponseStatus'
-description: setResponseStatus sets the statusCode (and optionally the statusMessage) of the response.
+description: setResponseStatus sets the status (and optionally the statusText) of the response.
 links:
   - label: Source
     icon: i-simple-icons-github
@@ -10,7 +10,7 @@ links:
 
 Nuxt provides composables and utilities for first-class server-side-rendering support.
 
-`setResponseStatus` sets the statusCode (and optionally the statusMessage) of the response.
+`setResponseStatus` sets the status (and optionally the statusText) of the response.
 
 ::important
 `setResponseStatus` can only be called in the [Nuxt context](/docs/4.x/guide/going-further/nuxt-app#the-nuxt-context).

--- a/docs/4.api/3.utils/show-error.md
+++ b/docs/4.api/3.utils/show-error.md
@@ -12,13 +12,13 @@ Within the [Nuxt context](/docs/4.x/guide/going-further/nuxt-app#the-nuxt-contex
 
 **Parameters:**
 
-- `error`: `string | Error | Partial<{ cause, data, message, name, stack, statusCode, statusMessage }>`
+- `error`: `string | Error | Partial<{ cause, data, message, name, stack, status, statusText }>`
 
 ```ts
 showError('😱 Oh no, an error has been thrown.')
 showError({
-  statusCode: 404,
-  statusMessage: 'Page Not Found',
+  status: 404,
+  statusText: 'Page Not Found',
 })
 ```
 

--- a/docs/4.api/5.kit/7.pages.md
+++ b/docs/4.api/5.kit/7.pages.md
@@ -88,7 +88,7 @@ export default defineNuxtModule({
     extendRouteRules('/preview', {
       redirect: {
         to: '/preview-new',
-        statusCode: 302,
+        status: 302,
       },
     })
 

--- a/docs/4.api/5.kit/7.pages.md
+++ b/docs/4.api/5.kit/7.pages.md
@@ -88,7 +88,7 @@ export default defineNuxtModule({
     extendRouteRules('/preview', {
       redirect: {
         to: '/preview-new',
-        status: 302,
+        statusCode: 302,
       },
     })
 

--- a/docs/7.migration/7.component-options.md
+++ b/docs/7.migration/7.component-options.md
@@ -124,7 +124,7 @@ Similar to `key`, specify it within the [`definePageMeta`](/docs/4.x/api/utils/d
 
 ## `validate`
 
-The validate hook in Nuxt 3 only accepts a single argument, the `route`. Just as in Nuxt 2, you can return a boolean value. If you return false and another match can't be found, this will mean a 404. You can also directly return an object with `statusCode`/`statusMessage` to respond immediately with an error (other matches will not be checked).
+The validate hook in Nuxt 3 only accepts a single argument, the `route`. Just as in Nuxt 2, you can return a boolean value. If you return false and another match can't be found, this will mean a 404. You can also directly return an object with `status`/`statusText` to respond immediately with an error (other matches will not be checked).
 
 ```diff [app/pages/users/[id\\].vue]
 - <script>

--- a/packages/nitro-server/src/runtime/handlers/error.ts
+++ b/packages/nitro-server/src/runtime/handlers/error.ts
@@ -16,8 +16,8 @@ export default <NitroErrorHandler> async function errorhandler (error, event, { 
   const defaultRes = await defaultHandler(error, event, { json: true })
 
   // let Nitro handle redirect if appropriate
-  const statusCode = error.statusCode || 500
-  if (statusCode === 404 && defaultRes.status === 302) {
+  const status = (error as any).status || error.statusCode || 500
+  if (status === 404 && defaultRes.status === 302) {
     setResponseHeaders(event, defaultRes.headers)
     setResponseStatus(event, defaultRes.status, defaultRes.statusText)
     return send(event, JSON.stringify(defaultRes.body, null, 2))
@@ -28,7 +28,7 @@ export default <NitroErrorHandler> async function errorhandler (error, event, { 
     defaultRes.body.stack = defaultRes.body.stack.join('\n')
   }
 
-  const errorObject = defaultRes.body as Pick<NonNullable<NuxtPayload['error']>, 'error' | 'statusCode' | 'statusMessage' | 'message' | 'stack'> & { url: string, data: any }
+  const errorObject = defaultRes.body as Pick<NonNullable<NuxtPayload['error']>, 'error' | 'status' | 'statusText' | 'message' | 'stack'> & { url: string, data: any }
   // remove proto/hostname/port from URL
   const url = new URL(errorObject.url)
   errorObject.url = withoutBase(url.pathname, useRuntimeConfig(event).app.baseURL) + url.search + url.hash
@@ -36,7 +36,7 @@ export default <NitroErrorHandler> async function errorhandler (error, event, { 
   errorObject.message ||= 'Server Error'
   // we will be rendering this error internally so we can pass along the error.data safely
   errorObject.data ||= error.data
-  errorObject.statusMessage ||= error.statusMessage
+  errorObject.statusText ||= (error as any).statusText || error.statusMessage
 
   delete defaultRes.headers['content-type'] // this would be set to application/json
   delete defaultRes.headers['content-security-policy'] // this would disable JS execution in the error page
@@ -85,7 +85,7 @@ export default <NitroErrorHandler> async function errorhandler (error, event, { 
 
   if (import.meta.dev && !import.meta.test && typeof html === 'string') {
     const prettyResponse = await defaultHandler(error, event, { json: false })
-    return send(event, html.replace('</body>', `${generateErrorOverlayHTML(prettyResponse.body as string, { startMinimized: 300 <= statusCode && statusCode < 500 })}</body>`))
+    return send(event, html.replace('</body>', `${generateErrorOverlayHTML(prettyResponse.body as string, { startMinimized: 300 <= status && status < 500 })}</body>`))
   }
 
   return send(event, html)

--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -40,13 +40,6 @@ if (NUXT_ASYNC_CONTEXT && !('AsyncLocalStorage' in globalThis)) {
   (globalThis as any).AsyncLocalStorage = AsyncLocalStorage
 }
 
-export interface NuxtRenderResponse {
-  body: string
-  statusCode: number
-  statusMessage?: string
-  headers: Record<string, string>
-}
-
 const HAS_APP_TELEPORTS = !!(appTeleportTag && appTeleportAttrs.id)
 const APP_TELEPORT_OPEN_TAG = HAS_APP_TELEPORTS ? `<${appTeleportTag}${propsToString(appTeleportAttrs)}>` : ''
 const APP_TELEPORT_CLOSE_TAG = HAS_APP_TELEPORTS ? `</${appTeleportTag}>` : ''
@@ -66,8 +59,9 @@ export default defineRenderHandler(async (event): Promise<Partial<RenderResponse
 
   if (ssrError && !('__unenv__' in event.node.req) /* allow internal fetch */) {
     throw createError({
-      statusCode: 404,
-      statusMessage: 'Page Not Found: /__nuxt_error',
+      status: 404,
+      statusText: 'Page Not Found: /__nuxt_error',
+      message: 'Page Not Found: /__nuxt_error',
     })
   }
 
@@ -79,7 +73,12 @@ export default defineRenderHandler(async (event): Promise<Partial<RenderResponse
   ssrContext.head.push(appHead, headEntryOptions)
 
   if (ssrError) {
-    ssrError.statusCode &&= Number.parseInt(ssrError.statusCode as any)
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    const status = ssrError.status || ssrError.statusCode
+    if (status) {
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
+      ssrError.status = ssrError.statusCode = Number.parseInt(status as any)
+    }
     if (PARSE_ERROR_DATA && typeof ssrError.data === 'string') {
       try {
         ssrError.data = destr(ssrError.data)

--- a/packages/nuxt/src/app/compat/interval.ts
+++ b/packages/nuxt/src/app/compat/interval.ts
@@ -7,7 +7,7 @@ export const setInterval: typeof globalThis.setInterval = import.meta.client
   : (() => {
       if (import.meta.dev) {
         throw createError({
-          statusCode: 500,
+          status: 500,
           message: intervalError,
         })
       }

--- a/packages/nuxt/src/app/components/island-renderer.ts
+++ b/packages/nuxt/src/app/components/island-renderer.ts
@@ -24,8 +24,8 @@ export default defineComponent({
 
     if (!component) {
       throw createError({
-        statusCode: 404,
-        statusMessage: `Island component not found: ${props.context.name}`,
+        status: 404,
+        statusText: `Island component not found: ${props.context.name}`,
       })
     }
 

--- a/packages/nuxt/src/app/components/nuxt-error-page.vue
+++ b/packages/nuxt/src/app/components/nuxt-error-page.vue
@@ -1,5 +1,5 @@
 <template>
-  <ErrorTemplate v-bind="{ statusCode, statusMessage, description, stack }" />
+  <ErrorTemplate v-bind="{ status, statusText, statusCode: status, statusMessage: statusText, description, stack }" />
 </template>
 
 <script setup>
@@ -34,10 +34,10 @@ const stacktrace = import.meta.dev && _error.stack
   : ''
 
 // Error page props
-const statusCode = Number(_error.statusCode || 500)
-const is404 = statusCode === 404
+const status = Number(_error.statusCode || 500)
+const is404 = status === 404
 
-const statusMessage = _error.statusMessage ?? (is404 ? 'Page Not Found' : 'Internal Server Error')
+const statusText = _error.statusMessage ?? (is404 ? 'Page Not Found' : 'Internal Server Error')
 const description = _error.message || _error.toString()
 const stack = import.meta.dev && !is404 ? _error.description || `<pre>${stacktrace}</pre>` : undefined
 

--- a/packages/nuxt/src/app/components/nuxt-island.ts
+++ b/packages/nuxt/src/app/components/nuxt-island.ts
@@ -206,7 +206,7 @@ export default defineComponent({
         props: props.props ? JSON.stringify(props.props) : undefined,
       }))
       if (!r.ok) {
-        throw createError({ statusCode: r.status, statusMessage: r.statusText })
+        throw createError({ status: r.status, statusText: r.statusText })
       }
       try {
         const result = await r.json()

--- a/packages/nuxt/src/app/components/nuxt-stubs.ts
+++ b/packages/nuxt/src/app/components/nuxt-stubs.ts
@@ -3,8 +3,8 @@ import { createError } from '../composables/error'
 function renderStubMessage (name: string): never {
   throw createError({
     fatal: true,
-    statusCode: 500,
-    statusMessage: `${name} is provided by @nuxt/image. Check your console to install it or run 'npx nuxt module add @nuxt/image'`,
+    status: 500,
+    statusText: `${name} is provided by @nuxt/image. Check your console to install it or run 'npx nuxt module add @nuxt/image'`,
   })
 }
 

--- a/packages/nuxt/src/app/composables/error.ts
+++ b/packages/nuxt/src/app/composables/error.ts
@@ -12,8 +12,14 @@ export const NUXT_ERROR_SIGNATURE = '__nuxt_error'
 /* @__NO_SIDE_EFFECTS__ */
 export const useError = (): Ref<NuxtPayload['error']> => toRef(useNuxtApp().payload, 'error')
 
-export interface NuxtError<DataT = unknown> extends H3Error<DataT> {
+export interface NuxtError<DataT = unknown> extends Omit<H3Error<DataT>, 'statusCode' | 'statusMessage'> {
   error?: true
+  status?: number
+  statusText?: string
+  /** @deprecated Use `status` */
+  statusCode?: H3Error<DataT>['statusCode']
+  /** @deprecated Use `statusText` */
+  statusMessage?: H3Error<DataT>['statusMessage']
 }
 
 /** @since 3.0.0 */
@@ -61,12 +67,11 @@ export const isNuxtError = <DataT = unknown>(
 ): error is NuxtError<DataT> => !!error && typeof error === 'object' && NUXT_ERROR_SIGNATURE in error
 
 /** @since 3.0.0 */
-export const createError = <DataT = unknown>(
-  error: string | Error | (Partial<NuxtError<DataT>> & {
-    status?: number
-    statusText?: string
-  }),
-) => {
+export const createError = <DataT = unknown>(error: string | Error | Partial<NuxtError<DataT>>) => {
+  if (typeof error !== 'string' && (error as Partial<NuxtError<DataT>>).statusText) {
+    error.message ??= (error as Partial<NuxtError<DataT>>).statusText
+  }
+
   const nuxtError: NuxtError<DataT> = createH3Error<DataT>(error)
 
   Object.defineProperty(nuxtError, NUXT_ERROR_SIGNATURE, {

--- a/packages/nuxt/src/app/composables/script-stubs.ts
+++ b/packages/nuxt/src/app/composables/script-stubs.ts
@@ -6,8 +6,8 @@ function renderStubMessage (name: string) {
   if (import.meta.client) {
     throw createError({
       fatal: true,
-      statusCode: 500,
-      statusMessage: message,
+      status: 500,
+      statusText: message,
     })
   }
 }

--- a/packages/nuxt/src/app/plugins/router.ts
+++ b/packages/nuxt/src/app/plugins/router.ts
@@ -274,8 +274,8 @@ export default defineNuxtPlugin<{ route: Route, router: Router }>({
             if (import.meta.server) {
               if (result === false || result instanceof Error) {
                 const error = result || createError({
-                  statusCode: 404,
-                  statusMessage: `Page Not Found: ${initialURL}`,
+                  status: 404,
+                  statusText: `Page Not Found: ${initialURL}`,
                   data: {
                     path: initialURL,
                   },

--- a/packages/nuxt/src/components/runtime/server-component.ts
+++ b/packages/nuxt/src/components/runtime/server-component.ts
@@ -61,7 +61,6 @@ export const createIslandPage = (name: string) => {
             onError: (e) => {
               if (e.cause && e.cause instanceof Response) {
                 throw createError({
-                  statusCode: e.cause.status,
                   statusText: e.cause.statusText,
                   status: e.cause.status,
                 })

--- a/packages/nuxt/src/pages/runtime/composables.ts
+++ b/packages/nuxt/src/pages/runtime/composables.ts
@@ -13,7 +13,7 @@ export interface PageMeta {
    *
    * Return true if it is valid, or false if not. If another match can't be found,
    * this will mean a 404. You can also directly return an object with
-   * statusCode/statusMessage to respond immediately with an error (other matches
+   * status/statusText to respond immediately with an error (other matches
    * will not be checked).
    */
   validate?: (route: RouteLocationNormalized) => boolean | Partial<NuxtError> | Promise<boolean | Partial<NuxtError>>

--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -229,8 +229,8 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
             if (import.meta.server || (!nuxtApp.payload.serverRendered && nuxtApp.isHydrating)) {
               if (result === false || result instanceof Error) {
                 const error = result || createError({
-                  statusCode: 404,
-                  statusMessage: `Page Not Found: ${initialURL}`,
+                  status: 404,
+                  statusText: `Page Not Found: ${initialURL}`,
                 })
                 await nuxtApp.runWithContext(() => showError(error))
                 return false
@@ -266,9 +266,9 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
     router.afterEach((to) => {
       if (to.matched.length === 0) {
         return nuxtApp.runWithContext(() => showError(createError({
-          statusCode: 404,
+          status: 404,
           fatal: false,
-          statusMessage: `Page not found: ${to.fullPath}`,
+          statusText: `Page not found: ${to.fullPath}`,
           data: {
             path: to.fullPath,
           },

--- a/packages/nuxt/src/pages/runtime/validate.ts
+++ b/packages/nuxt/src/pages/runtime/validate.ts
@@ -11,8 +11,10 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
 
   const error = createError({
     fatal: import.meta.client,
-    statusCode: (result && result.statusCode) || 404,
-    statusMessage: (result && result.statusMessage) || `Page Not Found: ${to.fullPath}`,
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    status: (result && (result.status || result.statusCode)) || 404,
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    statusText: (result && (result.statusText || result.statusMessage)) || `Page Not Found: ${to.fullPath}`,
     data: {
       path: to.fullPath,
     },

--- a/packages/ui-templates/templates/error-404/index.html
+++ b/packages/ui-templates/templates/error-404/index.html
@@ -1,21 +1,25 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <title>{{ messages.statusCode }} - {{ messages.statusMessage }} | {{ messages.appName }}</title>
-    <meta charset="utf-8"/>
-    <meta content="width=device-width,initial-scale=1.0,minimum-scale=1.0" name="viewport"/>
-    <script type="module" src="/styles.ts"></script>
-  </head>
-  <body class="font-sans antialiased bg-white dark:bg-[#020420] text-[#020420] tracking-wide dark:text-white grid min-h-screen place-content-center overflow-hidden ">
-    <div class="max-w-520px text-center">
-      <h1 class="text-[80px] sm:text-[110px] font-semibold mb-4 tabular-nums leading-none">{{ messages.statusCode }}</h1>
-      <h2 class="text-2xl font-semibold sm:text-3xl mb-2">{{ messages.statusMessage }}</h2>
-      <p class="text-[#64748B] text-md mb-4 px-2">{{ messages.description }}</p>
-      <div class="w-full flex items-center justify-center">
-        <a href="/" class="underline underline-offset-3 text-sm font-medium hover:text-[#00DC82]">
-          {{ messages.backHome }}
-        </a>
-     </div>
+
+<head>
+  <title>{{ messages.status }} - {{ messages.statusText }} | {{ messages.appName }}</title>
+  <meta charset="utf-8" />
+  <meta content="width=device-width,initial-scale=1.0,minimum-scale=1.0" name="viewport" />
+  <script type="module" src="/styles.ts"></script>
+</head>
+
+<body
+  class="font-sans antialiased bg-white dark:bg-[#020420] text-[#020420] tracking-wide dark:text-white grid min-h-screen place-content-center overflow-hidden ">
+  <div class="max-w-520px text-center">
+    <h1 class="text-[80px] sm:text-[110px] font-semibold mb-4 tabular-nums leading-none">{{ messages.status }}</h1>
+    <h2 class="text-2xl font-semibold sm:text-3xl mb-2">{{ messages.statusText }}</h2>
+    <p class="text-[#64748B] text-md mb-4 px-2">{{ messages.description }}</p>
+    <div class="w-full flex items-center justify-center">
+      <a href="/" class="underline underline-offset-3 text-sm font-medium hover:text-[#00DC82]">
+        {{ messages.backHome }}
+      </a>
     </div>
-  </body>
+  </div>
+</body>
+
 </html>

--- a/packages/ui-templates/templates/error-404/messages.json
+++ b/packages/ui-templates/templates/error-404/messages.json
@@ -1,6 +1,6 @@
 {
-  "statusCode": 404,
-  "statusMessage": "Page not found",
+  "status": 404,
+  "statusText": "Page not found",
   "description": "Sorry, the page you are looking for could not be found.",
   "backHome": "Go back home"
 }

--- a/packages/ui-templates/templates/error-500/index.html
+++ b/packages/ui-templates/templates/error-500/index.html
@@ -1,16 +1,20 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <title>{{ messages.statusCode }} - {{ messages.statusMessage }} | {{ messages.appName }}</title>
-    <meta charset="utf-8"/>
-    <meta content="width=device-width,initial-scale=1.0,minimum-scale=1.0" name="viewport"/>
-    <script type="module" src="/styles.ts"></script>
-  </head>
-  <body class="font-sans antialiased bg-white dark:bg-[#020420] text-[#020420] tracking-wide dark:text-white grid min-h-screen place-content-center overflow-hidden ">
-    <div class="max-w-520px text-center">
-      <h1 class="text-[80px] sm:text-[110px] font-semibold mb-4 tabular-nums leading-none">{{ messages.statusCode }}</h1>
-      <h2 class="text-2xl font-semibold sm:text-3xl mb-2">{{ messages.statusMessage }}</h2>
-      <p class="text-[#64748B] text-md mb-4 px-2">{{ messages.description }}</p>
-    </div>
-  </body>
+
+<head>
+  <title>{{ messages.status }} - {{ messages.statusText }} | {{ messages.appName }}</title>
+  <meta charset="utf-8" />
+  <meta content="width=device-width,initial-scale=1.0,minimum-scale=1.0" name="viewport" />
+  <script type="module" src="/styles.ts"></script>
+</head>
+
+<body
+  class="font-sans antialiased bg-white dark:bg-[#020420] text-[#020420] tracking-wide dark:text-white grid min-h-screen place-content-center overflow-hidden ">
+  <div class="max-w-520px text-center">
+    <h1 class="text-[80px] sm:text-[110px] font-semibold mb-4 tabular-nums leading-none">{{ messages.status }}</h1>
+    <h2 class="text-2xl font-semibold sm:text-3xl mb-2">{{ messages.statusText }}</h2>
+    <p class="text-[#64748B] text-md mb-4 px-2">{{ messages.description }}</p>
+  </div>
+</body>
+
 </html>

--- a/packages/ui-templates/templates/error-500/messages.json
+++ b/packages/ui-templates/templates/error-500/messages.json
@@ -1,6 +1,6 @@
 {
-  "statusCode": 500,
-  "statusMessage": "Internal server error",
+  "status": 500,
+  "statusText": "Internal server error",
   "description": "This page is temporarily unavailable.",
   "refresh": "Refresh this page"
 }

--- a/packages/vite/src/plugins/dev-server.ts
+++ b/packages/vite/src/plugins/dev-server.ts
@@ -177,7 +177,7 @@ export function DevServerPlugin (nuxt: Nuxt): Plugin {
           // if vite has not handled the request, we want to send a 404 for paths which are not in any static base or dev server handlers
           const ended = event.node.res.writableEnded || event.handled
           if (!ended && event.path.startsWith(nuxt.options.app.buildAssetsDir) && !staticBases.some(baseURL => event.path.startsWith(baseURL)) && !devHandlerRegexes.some(regex => regex.test(event.path))) {
-            throw createError({ statusCode: 404 })
+            throw createError({ status: 404 })
           }
         })
       })

--- a/packages/vite/src/plugins/vite-node.ts
+++ b/packages/vite/src/plugins/vite-node.ts
@@ -274,7 +274,7 @@ function createViteNodeSocketServer (nuxt: Nuxt, ssrServer: ViteDevServer, clien
           case 'resolve': {
             const { id: resolveId, importer } = request.payload
             if (!resolveId) {
-              throw createError({ statusCode: 400, message: 'Missing id for resolve' })
+              throw createError({ status: 400, message: 'Missing id for resolve' })
             }
             const ssrNode = nuxt.options.experimental.viteEnvironmentApi
               ? ssrServer.environments.ssr.pluginContainer
@@ -285,7 +285,7 @@ function createViteNodeSocketServer (nuxt: Nuxt, ssrServer: ViteDevServer, clien
           }
           case 'module': {
             if (request.payload.moduleId === '/') {
-              throw createError({ statusCode: 400, message: 'Invalid moduleId' })
+              throw createError({ status: 400, message: 'Invalid moduleId' })
             }
             const ssrNode = nuxt.options.experimental.viteEnvironmentApi
               ? ssrServer.environments.ssr
@@ -318,7 +318,7 @@ function createViteNodeSocketServer (nuxt: Nuxt, ssrServer: ViteDevServer, clien
           }
           default:
             // @ts-expect-error this should never happen
-            throw createError({ statusCode: 400, message: `Unknown request type: ${request.type}` })
+            throw createError({ status: 400, message: `Unknown request type: ${request.type}` })
         }
       } catch (error: any) {
         sendError(socket, request.id, error)
@@ -474,8 +474,8 @@ function sendError (socket: net.Socket, id: number, error: any) {
     error: {
       message: error.message,
       stack: error.stack,
-      statusCode: error.statusCode,
-      statusMessage: error.statusMessage,
+      status: error.status,
+      statusText: error.statusText,
       data: error.data,
     },
   }

--- a/packages/vite/src/vite-node-entry.ts
+++ b/packages/vite/src/vite-node-entry.ts
@@ -51,7 +51,7 @@ function createRunner () {
         try {
           const { message, stack } = formatViteError(errorData, id)
           _err = createError({
-            statusMessage: 'Vite Error',
+            statusText: 'Vite Error',
             message,
             stack,
           })
@@ -60,7 +60,7 @@ function createRunner () {
           const message = `[vite-node] [TransformError] ${errorData?.message || '-'}`
           consola.error(message, errorData)
           throw createError({
-            statusMessage: 'Vite Error',
+            statusText: 'Vite Error',
             message,
             stack: `${message}\nat ${id}\n` + (errorData?.stack || ''),
           })

--- a/packages/vite/src/vite-node.ts
+++ b/packages/vite/src/vite-node.ts
@@ -139,7 +139,7 @@ function connectSocket (): Promise<Socket> {
                   // @ts-expect-error We are augmenting the error object
                   err.data = response.error.data
                   // @ts-expect-error We are augmenting the error object
-                  err.statusCode = response.error.statusCode
+                  err.statusCode = err.status = response.error.status || response.error.statusCode
                   rejectRequest(err)
                 } else {
                   resolveRequest(response.data)

--- a/packages/webpack/src/webpack.ts
+++ b/packages/webpack/src/webpack.ts
@@ -140,7 +140,7 @@ function wdmToH3Handler (devMiddleware: webpackDevMiddleware.API<IncomingMessage
 
     // disallow cross-site requests in no-cors mode
     if (getRequestHeader(event, 'sec-fetch-mode') === 'no-cors' && getRequestHeader(event, 'sec-fetch-site') === 'cross-site') {
-      throw createError({ statusCode: 403 })
+      throw createError({ status: 403 })
     }
 
     setHeader(event, 'Vary', 'Origin')


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

in nitro v3 and h3 v2, we will be using web apis with status/statusText as default syntax.

for a while now, h3 has support backwards compat on these properties and this moves to use them internally, and add backwards compatible handling for the old properties.