### PR TITLE
docs: add mcp setup instructions for claude desktop

### DIFF
--- a/docs/3.guide/3.ai/1.mcp.md
+++ b/docs/3.guide/3.ai/1.mcp.md
@@ -88,6 +88,28 @@ Add the server using the CLI command:
 claude mcp add --transport http nuxt-remote https://nuxt.com/mcp
 ```
 
+### Claude Desktop
+
+#### Setup Instructions
+
+1. Open Claude Desktop and navigate to "Settings" > "Developer".
+2. Click on "Edit Config". This will open the local Claude directory.
+3. Modify the `claude_desktop_config.json` file with your custom MCP server configuration.
+    ```json [claude_desktop_config.json]
+    {
+      "mcpServers": {
+        "nuxt": {
+          "command": "npx",
+          "args": [
+            "mcp-remote",
+            "https://nuxt.com/mcp"
+          ]
+        }
+      }
+    }
+    ```
+4. Restart Claude Desktop app. The Nuxt MCP server should now be registered.
+
 ### Cursor
 
 Click the button below to install the Nuxt MCP server directly in Cursor:


### PR DESCRIPTION
### 🔗 Linked issue

This PR doesn't resolve any particular issue. It's a small documentation improvement.

### 📚 Description

The Nuxt MCP server page in the docs doesn't currently include setup instructions for Claude Desktop. This PR adds those instructions for it.