### PR TITLE
docs: add note on default branch for layers

### DIFF
--- a/docs/1.getting-started/14.layers.md
+++ b/docs/1.getting-started/14.layers.md
@@ -56,6 +56,10 @@ export default defineNuxtConfig({
 })
 ```
 
+::note
+This will fetch the main branch by default
+::
+
 ::tip
 You can override a layer's alias by specifying it in the options next to the layer source.
 

--- a/docs/1.getting-started/14.layers.md
+++ b/docs/1.getting-started/14.layers.md
@@ -57,7 +57,7 @@ export default defineNuxtConfig({
 ```
 
 ::note
-This will fetch the main branch by default
+If a branch is not specified, this will clone `main`.
 ::
 
 ::tip


### PR DESCRIPTION


### 🔗 Linked issue

None

### 📚 Description
It's not noted that it tries to fetch the `main` branch automatically which resulted in me trying to figure out why it's not detecting the repository. It should be clear that you need to specify the branch for people who set the branch as `master`
