### PR TITLE
docs: update module count and fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
   <a href="https://www.npmjs.com/package/nuxt"><img src="https://img.shields.io/npm/v/nuxt.svg?style=flat&colorA=18181B&colorB=28CF8D" alt="Version"></a>
   <a href="https://www.npmjs.com/package/nuxt"><img src="https://img.shields.io/npm/dm/nuxt.svg?style=flat&colorA=18181B&colorB=28CF8D" alt="Downloads"></a>
   <a href="https://github.com/nuxt/nuxt/blob/main/LICENSE"><img src="https://img.shields.io/github/license/nuxt/nuxt.svg?style=flat&colorA=18181B&colorB=28CF8D" alt="License"></a>
+  <a href="https://nuxt.com/modules"><img src="https://img.shields.io/badge/dynamic/json?url=https://nuxt.com/api/v1/modules&query=$.stats.modules&label=Modules&style=flat&colorA=18181B&colorB=28CF8D" alt="Modules"></a>
   <a href="https://nuxt.com"><img src="https://img.shields.io/badge/Nuxt%20Docs-18181B?logo=nuxt" alt="Website"></a>
   <a href="https://chat.nuxt.dev"><img src="https://img.shields.io/badge/Nuxt%20Discord-18181B?logo=discord" alt="Discord"></a>
   <a href="https://securityscorecards.dev/"><img src="https://api.securityscorecards.dev/projects/github.com/nuxt/nuxt/badge" alt="Nuxt openssf scorecard score"></a>

--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ It provides a number of features that make it easy to build fast, SEO-friendly, 
 - Auto imports of components, composables and utils
 - TypeScript with zero configuration
 - Go full-stack with our server/ directory
-- Extensible with [200+ modules](https://nuxt.com/modules)
+- Extensible with [300+ modules](https://nuxt.com/modules)
 - Deployment to a variety of [hosting platforms](https://nuxt.com/deploy)
 - ...[and much more](https://nuxt.com) 🚀
 
 ### Table of Contents
 
 - 🚀 [Getting Started](#getting-started)
-- 💻 [ Vue Development](#vue-development)
+- 💻 [Vue Development](#vue-development)
 - 📖 [Documentation](#documentation)
 - 🧩 [Modules](#modules)
 - ❤️ [Contribute](#contribute)


### PR DESCRIPTION
## Summary

  - Update module count from 200+ to 300+ (currently 308)
  - Fix extra whitespace in Table of Contents
  - Add dynamic module badge on top or README