### PR TITLE
fix(nuxt): do not early return when there's a priority conflict

### DIFF
--- a/docs/2.directory-structure/1.server.md
+++ b/docs/2.directory-structure/1.server.md
@@ -130,7 +130,7 @@ export const defineWrappedResponseHandler = <T extends EventHandlerRequest, D> (
   })
 ```
 ```ts [server/api/hello.get.ts]
-export default defineWrappedResponseHandler((event) => 'hello world')
+export default defineWrappedResponseHandler(event => 'hello world')
 ```
 
 ## Server Alias

--- a/packages/kit/src/components.ts
+++ b/packages/kit/src/components.ts
@@ -59,7 +59,7 @@ function addComponents (addedComponents: Component[]) {
         const existingPriority = existingComponent.priority ?? 0
         const newPriority = component.priority ?? 0
 
-        if (newPriority < existingPriority) { return }
+        if (newPriority < existingPriority) { continue }
 
         // We override where new component priority is equal or higher
         // but we warn if they are equal.

--- a/packages/kit/test/components.spec.ts
+++ b/packages/kit/test/components.spec.ts
@@ -1,19 +1,18 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createHooks } from 'hookable'
 import type { Component } from '@nuxt/schema'
 import { relative } from 'pathe'
 
-import { addComponentExports } from '../src/components.ts'
+import { addComponent, addComponentExports } from '../src/components.ts'
 import { createResolver } from '../src/resolve.ts'
 
-const mockHooks = createHooks()
 const mockNuxt = {
   options: {
     components: [],
     modulesDir: [],
     extensions: ['.vue', '.js', '.ts'],
   },
-  hook: mockHooks.hook.bind(mockHooks),
+  hook: undefined as unknown,
 }
 
 vi.mock('../src/context', async original => ({
@@ -23,6 +22,12 @@ vi.mock('../src/context', async original => ({
 }))
 
 describe('addComponentExports', () => {
+  let mockHooks: ReturnType<typeof createHooks>
+  beforeEach(() => {
+    mockHooks = createHooks()
+    mockNuxt.hook = mockHooks.hook.bind(mockHooks)
+  })
+
   it('should add components exports', async () => {
     const resolver = createResolver(import.meta.url)
     addComponentExports({
@@ -71,6 +76,45 @@ describe('addComponentExports', () => {
           "shortPath": "Named",
         },
       ]
+    `)
+  })
+  it('should add components other than an existing component', async () => {
+    const resolver = createResolver(import.meta.url)
+    addComponent({
+      filePath: resolver.resolve('./components-fixture/Named'),
+      name: 'TestNamedExport',
+      export: 'NamedExport',
+      priority: 1,
+    })
+    addComponentExports({
+      filePath: resolver.resolve('./components-fixture/Named'),
+      prefix: 'test',
+    })
+    await mockHooks.callHook('components:dirs', [])
+    const components: Component[] = []
+    await mockHooks.callHook('components:extend', components)
+    for (const c of components) {
+      c.filePath = relative(resolver.resolve('./components-fixture'), c.filePath)
+      c.shortPath = relative(resolver.resolve('./components-fixture'), c.shortPath)
+    }
+    expect(components.length).eq(2)
+    expect(components[1]).toMatchInlineSnapshot(`
+        {
+          "chunkName": "components/test",
+          "export": "default",
+          "filePath": "Named",
+          "global": false,
+          "kebabName": "test",
+          "meta": {},
+          "mode": "all",
+          "name": "Test",
+          "pascalName": "Test",
+          "prefetch": false,
+          "prefix": "test",
+          "preload": false,
+          "priority": 0,
+          "shortPath": "Named",
+        }
     `)
   })
 })

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -96,7 +96,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(rootDir, '.output-inline/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"558k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"559k"`)
 
     const modules = await analyzeSizes(['node_modules/**/*'], serverDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"96.7k"`)


### PR DESCRIPTION
### 🔗 Linked issue

resolves #33954

### 📚 Description

`addComponents` should continue its work on conflict.