### PR TITLE
fix(nuxt): use vnode key for tag deduplication

### DIFF
--- a/docs/1.getting-started/08.seo-meta.md
+++ b/docs/1.getting-started/08.seo-meta.md
@@ -134,6 +134,10 @@ const title = ref('Hello World')
 
 It's suggested to wrap your components in either a `<Head>` or `<Html>` components as tags will be deduped more intuitively.
 
+::warning
+If you need to duplicate tags across client-server boundaries, apply a `key` attribute on the `<Head>` component.
+::
+
 ## Types
 
 Below are the non-reactive types used for [`useHead`](/docs/4.x/api/composables/use-head), [`app.head`](/docs/4.x/api/nuxt-config#head) and components.

--- a/packages/nuxt/src/head/runtime/components.ts
+++ b/packages/nuxt/src/head/runtime/components.ts
@@ -63,10 +63,11 @@ function createHeadComponentCtx (): HeadComponentCtx {
   if (prev) {
     return prev
   }
-  const key = getCurrentInstance()?.vnode.key
+  const vnodeKey = getCurrentInstance()?.vnode.key
+  const key = vnodeKey != null && typeof vnodeKey !== 'symbol' ? String(vnodeKey) : undefined
   const input = reactive({})
   const entry = useHead(input, {
-    key: key != null ? String(key) : undefined,
+    key,
   })
   const ctx: HeadComponentCtx = { input, entry }
   provide(HeadComponentCtxSymbol, ctx)

--- a/packages/nuxt/src/head/runtime/components.ts
+++ b/packages/nuxt/src/head/runtime/components.ts
@@ -1,4 +1,4 @@
-import { defineComponent, inject, onUnmounted, provide, reactive } from 'vue'
+import { defineComponent, getCurrentInstance, inject, onUnmounted, provide, reactive } from 'vue'
 import type { PropType, VNodeNormalizedChildren } from 'vue'
 import type {
   BodyAttributes,
@@ -63,8 +63,11 @@ function createHeadComponentCtx (): HeadComponentCtx {
   if (prev) {
     return prev
   }
+  const key = getCurrentInstance()?.vnode.key
   const input = reactive({})
-  const entry = useHead(input)
+  const entry = useHead(input, {
+    key: key != null ? String(key) : undefined,
+  })
   const ctx: HeadComponentCtx = { input, entry }
   provide(HeadComponentCtxSymbol, ctx)
   return ctx


### PR DESCRIPTION
### 🔗 Linked issue

fix https://github.com/nuxt/nuxt/issues/33722

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This PR allows to deduplicate <Head> across client-server using the key of the vnode if provided.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/4.x/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
