### PR TITLE
feat(nuxt): add route masking support

### DIFF
--- a/docs/3.guide/5.recipes/5.route-masking.md
+++ b/docs/3.guide/5.recipes/5.route-masking.md
@@ -43,7 +43,7 @@ The most flexible approach - use the `mask` option when navigating programmatica
 <script setup lang="ts">
 const route = useRoute()
 
-async function openModal() {
+async function openModal () {
   await navigateTo(`/photos/${route.params.id}/modal`, {
     mask: `/photos/${route.params.id}`,
   })
@@ -52,8 +52,10 @@ async function openModal() {
 
 <template>
   <div>
-    <img :src="`/photos/${route.params.id}.jpg`" />
-    <button @click="openModal">View Details</button>
+    <img :src="`/photos/${route.params.id}.jpg`">
+    <button @click="openModal">
+      View Details
+    </button>
   </div>
 </template>
 ```
@@ -110,7 +112,7 @@ You can also use a function to compute the mask dynamically based on the route:
 ```vue [app/pages/photos/[id]/edit.vue]
 <script setup lang="ts">
 definePageMeta({
-  mask: (route) => `/photos/${route.params.id}`,
+  mask: route => `/photos/${route.params.id}`,
 })
 </script>
 ```
@@ -193,7 +195,7 @@ A common use case is showing a modal overlay while keeping a clean URL:
 <script setup lang="ts">
 const products = await $fetch('/api/products')
 
-function openQuickView(id: number) {
+function openQuickView (id: number) {
   navigateTo(`/products/${id}/quick-view`, {
     mask: `/products/${id}`,
   })
@@ -202,8 +204,11 @@ function openQuickView(id: number) {
 
 <template>
   <div class="product-grid">
-    <div v-for="product in products" :key="product.id">
-      <img :src="product.image" />
+    <div
+      v-for="product in products"
+      :key="product.id"
+    >
+      <img :src="product.image">
       <button @click="openQuickView(product.id)">
         Quick View
       </button>
@@ -217,17 +222,22 @@ function openQuickView(id: number) {
 const route = useRoute()
 const product = await $fetch(`/api/products/${route.params.id}`)
 
-function closeModal() {
+function closeModal () {
   navigateTo('/products')
 }
 </script>
 
 <template>
-  <div class="modal-overlay" @click.self="closeModal">
+  <div
+    class="modal-overlay"
+    @click.self="closeModal"
+  >
     <div class="modal-content">
       <h1>{{ product.name }}</h1>
       <p>{{ product.description }}</p>
-      <button @click="closeModal">Close</button>
+      <button @click="closeModal">
+        Close
+      </button>
     </div>
   </div>
 </template>
@@ -241,7 +251,7 @@ Show different content panels while maintaining a consistent URL:
 <script setup lang="ts">
 const activeTab = ref('overview')
 
-function switchTab(tab: string) {
+function switchTab (tab: string) {
   navigateTo(`/dashboard/${tab}`, {
     mask: '/dashboard',
   })
@@ -261,16 +271,13 @@ function switchTab(tab: string) {
 
 ## TypeScript Support
 
-Route masking is fully type-safe. The `mask` option accepts:
+Route masking is fully type-safe. The `mask` option in `navigateTo` or `definePageMeta` accepts:
 
 ```ts
-// String path
-mask: '/photos/5'
-
-// With definePageMeta - string or function
 definePageMeta({
+  // a string
   mask: '/photos',
-  // or
-  mask: (route) => `/photos/${route.params.id}`,
+  // or a function
+  mask: route => `/photos/${route.params.id}`,
 })
 ```

--- a/docs/3.guide/5.recipes/5.route-masking.md
+++ b/docs/3.guide/5.recipes/5.route-masking.md
@@ -183,9 +183,9 @@ Route masking works seamlessly with browser navigation:
 
 A common use case is showing a modal overlay while keeping a clean URL:
 
-```
-/products           → Product list page
-/products/5         → Product detail (masked URL for modal)
+```text
+/products               → Product list page
+/products/5             → Product detail (masked URL for modal)
 /products/5/quick-view  → Actual modal route (real route)
 ```
 

--- a/docs/3.guide/5.recipes/5.route-masking.md
+++ b/docs/3.guide/5.recipes/5.route-masking.md
@@ -1,0 +1,276 @@
+---
+title: "Route Masking"
+description: "Route masking allows you to display a different URL in the browser's address bar than the actual route being rendered. This is useful for modals, overlays, and other UI patterns where you want a shareable URL that differs from the internal route structure."
+---
+
+## What is Route Masking?
+
+Route masking is a feature that allows you to display a different URL in the browser's address bar while rendering a different route internally. The "masked" URL is what users see and can share, while the "real" route determines what content is actually rendered.
+
+This is particularly useful for:
+
+- **Modal dialogs** - Show `/photos/5` in the URL while rendering `/photos/5/modal`
+- **Overlay content** - Display `/posts/123` while rendering `/posts/123/comments`
+- **Clean shareable URLs** - Hide implementation details like query parameters or nested routes
+- **Progressive enhancement** - Allow deep-linking to specific UI states without exposing internal routing
+
+## How It Works
+
+When you navigate with a mask, Nuxt:
+
+1. Navigates to the **real route** (renders the actual page component)
+2. Updates the browser's URL to show the **masked URL**
+3. Stores the real route in the browser's history state
+
+This means:
+- Users see and can copy the masked URL
+- Browser back/forward buttons work correctly
+- The real route is preserved for internal navigation
+
+::note
+When a masked URL is shared externally and opened in a new browser, the masked URL is loaded directly (since history state isn't shared). Design your routes so that masked URLs are valid entry points.
+::
+
+## Usage
+
+There are three ways to use route masking in Nuxt:
+
+### 1. Using `navigateTo`
+
+The most flexible approach - use the `mask` option when navigating programmatically:
+
+```vue [app/pages/photos/[id].vue]
+<script setup lang="ts">
+const route = useRoute()
+
+async function openModal() {
+  await navigateTo(`/photos/${route.params.id}/modal`, {
+    mask: `/photos/${route.params.id}`,
+  })
+}
+</script>
+
+<template>
+  <div>
+    <img :src="`/photos/${route.params.id}.jpg`" />
+    <button @click="openModal">View Details</button>
+  </div>
+</template>
+```
+
+When the button is clicked:
+- The browser navigates to `/photos/5/modal` (real route)
+- The URL bar shows `/photos/5` (masked URL)
+- The modal page component is rendered
+
+### 2. Using `<NuxtLink>`
+
+For declarative navigation, use the `mask` prop on `<NuxtLink>`:
+
+```vue [app/pages/posts/index.vue]
+<template>
+  <div>
+    <NuxtLink
+      v-for="post in posts"
+      :key="post.id"
+      :to="`/posts/${post.id}/comments`"
+      :mask="`/posts/${post.id}`"
+    >
+      {{ post.title }} - View Comments
+    </NuxtLink>
+  </div>
+</template>
+```
+
+### 3. Using `definePageMeta`
+
+For route-level masking, define a mask directly in your page component:
+
+```vue [app/pages/settings/modal.vue]
+<script setup lang="ts">
+definePageMeta({
+  mask: '/settings',
+})
+</script>
+
+<template>
+  <div class="modal">
+    <h1>Settings</h1>
+    <!-- Modal content -->
+  </div>
+</template>
+```
+
+With this approach, any navigation to `/settings/modal` will automatically show `/settings` in the URL bar.
+
+#### Dynamic Masks
+
+You can also use a function to compute the mask dynamically based on the route:
+
+```vue [app/pages/photos/[id]/edit.vue]
+<script setup lang="ts">
+definePageMeta({
+  mask: (route) => `/photos/${route.params.id}`,
+})
+</script>
+```
+
+## Reload Behavior
+
+By default, when a user reloads a page with a masked route, the mask is **preserved**. This means:
+- URL stays as `/photos/5` (masked)
+- Content renders from `/photos/5/modal` (real route)
+
+### Unmasking on Reload
+
+If you want the real URL to be shown after a page reload, use `unmaskOnReload: true`:
+
+```ts
+// With navigateTo
+await navigateTo('/photos/5/modal', {
+  mask: '/photos/5',
+  unmaskOnReload: true,
+})
+```
+
+```vue
+<!-- With NuxtLink -->
+<NuxtLink
+  to="/photos/5/modal"
+  mask="/photos/5"
+  :unmask-on-reload="true"
+>
+  View Photo
+</NuxtLink>
+```
+
+```vue
+<!-- With definePageMeta -->
+<script setup lang="ts">
+definePageMeta({
+  mask: '/photos',
+  unmaskOnReload: true,
+})
+</script>
+```
+
+### Global Default
+
+You can set the default reload behavior globally in your `nuxt.config.ts`:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  router: {
+    options: {
+      // Show real URL after reload by default
+      unmaskOnReload: true,
+    },
+  },
+})
+```
+
+## Browser Navigation
+
+Route masking works seamlessly with browser navigation:
+
+- **Back button**: Returns to the previous page (respects the actual navigation history)
+- **Forward button**: Moves forward in history (restores masked state if applicable)
+- **History state**: The real route is stored in `window.history.state` and restored automatically
+
+## Common Patterns
+
+### Modal Pattern
+
+A common use case is showing a modal overlay while keeping a clean URL:
+
+```
+/products           → Product list page
+/products/5         → Product detail (masked URL for modal)
+/products/5/quick-view  → Actual modal route (real route)
+```
+
+```vue [app/pages/products/index.vue]
+<script setup lang="ts">
+const products = await $fetch('/api/products')
+
+function openQuickView(id: number) {
+  navigateTo(`/products/${id}/quick-view`, {
+    mask: `/products/${id}`,
+  })
+}
+</script>
+
+<template>
+  <div class="product-grid">
+    <div v-for="product in products" :key="product.id">
+      <img :src="product.image" />
+      <button @click="openQuickView(product.id)">
+        Quick View
+      </button>
+    </div>
+  </div>
+</template>
+```
+
+```vue [app/pages/products/[id]/quick-view.vue]
+<script setup lang="ts">
+const route = useRoute()
+const product = await $fetch(`/api/products/${route.params.id}`)
+
+function closeModal() {
+  navigateTo('/products')
+}
+</script>
+
+<template>
+  <div class="modal-overlay" @click.self="closeModal">
+    <div class="modal-content">
+      <h1>{{ product.name }}</h1>
+      <p>{{ product.description }}</p>
+      <button @click="closeModal">Close</button>
+    </div>
+  </div>
+</template>
+```
+
+### Tab or Panel Pattern
+
+Show different content panels while maintaining a consistent URL:
+
+```vue [app/pages/dashboard.vue]
+<script setup lang="ts">
+const activeTab = ref('overview')
+
+function switchTab(tab: string) {
+  navigateTo(`/dashboard/${tab}`, {
+    mask: '/dashboard',
+  })
+}
+</script>
+```
+
+## Best Practices
+
+1. **Ensure masked URLs are valid routes**: Since shared URLs don't include history state, the masked URL should ideally resolve to a sensible default view.
+
+2. **Use for UI state, not security**: Route masking is for UX improvement, not hiding sensitive routes. The real route is visible in browser developer tools.
+
+3. **Consider SEO implications**: Search engines will index the URL they see. If the masked URL differs significantly from the content, consider your SEO strategy.
+
+4. **Test browser navigation**: Always test that back/forward buttons work as expected with your masked routes.
+
+## TypeScript Support
+
+Route masking is fully type-safe. The `mask` option accepts:
+
+```ts
+// String path
+mask: '/photos/5'
+
+// With definePageMeta - string or function
+definePageMeta({
+  mask: '/photos',
+  // or
+  mask: (route) => `/photos/${route.params.id}`,
+})
+```

--- a/docs/4.api/1.components/4.nuxt-link.md
+++ b/docs/4.api/1.components/4.nuxt-link.md
@@ -157,6 +157,35 @@ A `noRel` prop can be used to prevent the default `rel` attribute from being add
 `noRel` and `rel` cannot be used together. `rel` will be ignored.
 ::
 
+## Route Masking
+
+You can display a different URL in the browser's address bar while navigating to a specific route. This is useful for modals, overlays, or other UI patterns where you want a clean, shareable URL.
+
+```vue [app/pages/index.vue]
+<template>
+  <!-- Navigate to /photos/5/modal but show /photos/5 in URL bar -->
+  <NuxtLink
+    to="/photos/5/modal"
+    mask="/photos/5"
+  >
+    View Photo Details
+  </NuxtLink>
+
+  <!-- Unmask the URL after page reload -->
+  <NuxtLink
+    to="/photos/5/modal"
+    mask="/photos/5"
+    :unmask-on-reload="true"
+  >
+    View Photo (reveals real URL on reload)
+  </NuxtLink>
+</template>
+```
+
+When the link is clicked, the browser navigates to `/photos/5/modal` (real route) while showing `/photos/5` (masked URL) in the address bar.
+
+:read-more{to="/docs/4.x/guide/recipes/route-masking"}
+
 ## Prefetch Links
 
 Nuxt automatically includes smart prefetching. That means it detects when a link is visible (by default), either in the viewport or when scrolling and prefetches the JavaScript for those pages so that they are ready when the user clicks the link. Nuxt only loads the resources when the browser isn't busy and skips prefetching if your connection is offline or if you only have 2g connection.
@@ -262,6 +291,8 @@ When not using `external`, `<NuxtLink>` supports all Vue Router's [`RouterLink` 
 - `prefetchOn`: Allows custom control of when to prefetch links. Possible options are `interaction` and `visibility` (default). You can also pass an object for full control, for example: `{ interaction: true, visibility: true }`. This prop is only used when `prefetch` is enabled (default) and `noPrefetch` is not set.
 - `noPrefetch`: Disables prefetching.
 - `prefetchedClass`: A class to apply to links that have been prefetched.
+- `mask`: A URL to display in the browser's address bar instead of the actual route. Useful for modals and overlays where you want a clean shareable URL. See [Route Masking](/docs/4.x/guide/recipes/route-masking).
+- `unmaskOnReload`: When `true`, the actual URL will be shown after a page reload instead of the masked URL. Defaults to `false`.
 
 ### Anchor
 

--- a/docs/4.api/3.utils/define-page-meta.md
+++ b/docs/4.api/3.utils/define-page-meta.md
@@ -41,6 +41,8 @@ interface PageMeta {
   layout?: false | LayoutKey | Ref<LayoutKey> | ComputedRef<LayoutKey>
   middleware?: MiddlewareKey | NavigationGuard | Array<MiddlewareKey | NavigationGuard>
   scrollToTop?: boolean | ((to: RouteLocationNormalizedLoaded, from: RouteLocationNormalizedLoaded) => boolean)
+  mask?: string | ((route: RouteLocationNormalizedLoaded) => string)
+  unmaskOnReload?: boolean
   [key: string]: unknown
 }
 ```
@@ -145,6 +147,35 @@ interface PageMeta {
 
     Tell Nuxt to scroll to the top before rendering the page or not. If you want to overwrite the default scroll behavior of Nuxt, you can do so in `~/router.options.ts` (see [custom routing](/docs/4.x/guide/recipes/custom-routing#using-routeroptions)) for more info.
 
+  **`mask`**
+
+  - **Type**: `string | ((route: RouteLocationNormalizedLoaded) => string)`
+
+    Display a different URL in the browser's address bar when this page is navigated to. The actual route is used for rendering while the masked URL is shown to the user. This is useful for modals, overlays, or other UI patterns where you want a clean shareable URL.
+
+    ```vue
+    <script setup lang="ts">
+    // Static mask
+    definePageMeta({
+      mask: '/photos',
+    })
+
+    // Dynamic mask based on route params
+    definePageMeta({
+      mask: (route) => `/photos/${route.params.id}`,
+    })
+    </script>
+    ```
+
+    :read-more{to="/docs/4.x/guide/recipes/route-masking"}
+
+  **`unmaskOnReload`**
+
+  - **Type**: `boolean`
+  - **Default**: `false` (or global `router.options.unmaskOnReload` value)
+
+    Controls whether the real URL should be shown after a page reload. By default, the masked URL persists across reloads. Set to `true` to reveal the actual route URL when the page is refreshed.
+
   **`[key: string]`**
 
   - **Type**: `any`
@@ -239,3 +270,24 @@ definePageMeta({
 })
 </script>
 ```
+
+### Route Masking
+
+You can mask the URL displayed in the browser while rendering a different route. This is useful for modals or overlays where you want a clean, shareable URL:
+
+```vue [app/pages/photos/[id]/modal.vue]
+<script setup lang="ts">
+definePageMeta({
+  // Show /photos/123 in URL bar while rendering /photos/123/modal
+  mask: (route) => `/photos/${route.params.id}`,
+})
+</script>
+
+<template>
+  <div class="modal">
+    <!-- Modal content -->
+  </div>
+</template>
+```
+
+:read-more{to="/docs/4.x/guide/recipes/route-masking"}

--- a/docs/4.api/3.utils/define-page-meta.md
+++ b/docs/4.api/3.utils/define-page-meta.md
@@ -162,7 +162,7 @@ interface PageMeta {
 
     // Dynamic mask based on route params
     definePageMeta({
-      mask: (route) => `/photos/${route.params.id}`,
+      mask: route => `/photos/${route.params.id}`,
     })
     </script>
     ```
@@ -279,7 +279,7 @@ You can mask the URL displayed in the browser while rendering a different route.
 <script setup lang="ts">
 definePageMeta({
   // Show /photos/123 in URL bar while rendering /photos/123/modal
-  mask: (route) => `/photos/${route.params.id}`,
+  mask: route => `/photos/${route.params.id}`,
 })
 </script>
 

--- a/docs/4.api/3.utils/navigate-to.md
+++ b/docs/4.api/3.utils/navigate-to.md
@@ -114,6 +114,27 @@ await navigateTo('https://nuxt.com', {
 </script>
 ```
 
+### Route Masking
+
+You can display a different URL in the browser's address bar while navigating to a specific route. This is useful for modals, overlays, or other UI patterns where you want a clean, shareable URL.
+
+```vue
+<script setup lang="ts">
+// Navigate to /photos/5/modal but show /photos/5 in URL bar
+await navigateTo('/photos/5/modal', {
+  mask: '/photos/5',
+})
+
+// With unmaskOnReload: true, the real URL is shown after page refresh
+await navigateTo('/photos/5/modal', {
+  mask: '/photos/5',
+  unmaskOnReload: true,
+})
+</script>
+```
+
+:read-more{to="/docs/4.x/guide/recipes/route-masking"}
+
 ## Type
 
 ```ts [Signature]
@@ -127,6 +148,8 @@ interface NavigateToOptions {
   redirectCode?: number
   external?: boolean
   open?: OpenOptions
+  mask?: string
+  unmaskOnReload?: boolean
 }
 
 type OpenOptions = {
@@ -228,3 +251,32 @@ An object accepting the following properties:
       | `noreferrer`              | `boolean` | Prevents the Referer header from being sent and implicitly enables `noopener`.                 |
 
       Refer to the [documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#windowfeatures) for more detailed information on the **windowFeatures** properties.
+
+- `mask`
+
+  - **Type**: `string`
+
+  - Allows displaying a different URL in the browser's address bar while navigating to the specified route. The actual route is stored in the browser's history state and used for rendering, while the masked URL is shown to the user.
+
+    This is useful for modals, overlays, or other UI patterns where you want a shareable URL that differs from the internal route structure.
+
+    ```ts
+    // Navigate to /photos/5/modal but show /photos/5 in the URL bar
+    await navigateTo('/photos/5/modal', { mask: '/photos/5' })
+    ```
+
+    :read-more{to="/docs/4.x/guide/recipes/route-masking"}
+
+- `unmaskOnReload`
+
+  - **Type**: `boolean`
+  - **Default**: `false` (or global `router.options.unmaskOnReload` value)
+
+  - Controls whether the real URL should be shown after a page reload. By default, the masked URL persists across reloads. Set to `true` to reveal the actual route URL when the page is refreshed.
+
+    ```ts
+    await navigateTo('/photos/5/modal', {
+      mask: '/photos/5',
+      unmaskOnReload: true, // Show /photos/5/modal after reload
+    })
+    ```

--- a/packages/nuxt/src/app/composables/index.ts
+++ b/packages/nuxt/src/app/composables/index.ts
@@ -14,7 +14,7 @@ export type { CookieOptions, CookieRef } from './cookie'
 export { onPrehydrate, prerenderRoutes, useRequestHeaders, useRequestEvent, useRequestFetch, setResponseStatus, useResponseHeader } from './ssr'
 export { onNuxtReady } from './ready'
 export { abortNavigation, addRouteMiddleware, defineNuxtRouteMiddleware, onBeforeRouteLeave, onBeforeRouteUpdate, setPageLayout, navigateTo, useRoute, useRouter } from './router'
-export type { AddRouteMiddlewareOptions, RouteMiddleware } from './router'
+export type { AddRouteMiddlewareOptions, MaskedHistoryState, NavigateToOptions, RouteMiddleware } from './router'
 export { preloadComponents, prefetchComponents, preloadRouteComponents } from './preload'
 export { isPrerendered, loadPayload, preloadPayload, definePayloadReducer, definePayloadReviver } from './payload'
 // eslint-disable-next-line @typescript-eslint/no-deprecated

--- a/packages/nuxt/src/pages/build.d.ts
+++ b/packages/nuxt/src/pages/build.d.ts
@@ -2,6 +2,7 @@ declare module '#build/router.options.mjs' {
   import type { RouterOptions } from '@nuxt/schema'
 
   export const hashMode: boolean
+  export const defaultUnmaskOnReload: boolean
   const _default: RouterOptions
   export default _default
 }

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -573,6 +573,7 @@ export default defineNuxtModule({
             ...hashModes,
             nuxt.options.router.options.hashMode,
           ].join(' ?? ')}`,
+          `export const defaultUnmaskOnReload = ${nuxt.options.router.options.unmaskOnReload ?? false}`,
           'export default {',
           '...configRouterOptions,',
           ...routerOptionsFiles.map((_, index) => `...routerOptions${index},`),

--- a/packages/nuxt/src/pages/runtime/composables.ts
+++ b/packages/nuxt/src/pages/runtime/composables.ts
@@ -53,6 +53,28 @@ export interface PageMeta {
   props?: RouteRecordRaw['props']
   /** Set to `false` to avoid scrolling to top on page navigations */
   scrollToTop?: boolean | ((to: RouteLocationNormalizedLoaded, from: RouteLocationNormalizedLoaded) => boolean)
+  /**
+   * Display a different URL in the browser when this page is active.
+   * Useful for modals or overlays where you want a shareable URL
+   * that differs from the internal route structure.
+   *
+   * Can be a string or a function that receives the route and returns a string.
+   *
+   * @example
+   * ```ts
+   * // In pages/photos/[id]/modal.vue
+   * definePageMeta({
+   *   mask: (route) => `/photos/${route.params.id}`
+   * })
+   * ```
+   */
+  mask?: string | ((route: RouteLocationNormalizedLoaded) => string | undefined)
+  /**
+   * When true, the real URL will be shown after page refresh instead of the mask.
+   * By default, the mask persists across page refreshes.
+   * @default false
+   */
+  unmaskOnReload?: boolean
 }
 
 declare module 'vue-router' {

--- a/packages/nuxt/test/nuxt-link.test.ts
+++ b/packages/nuxt/test/nuxt-link.test.ts
@@ -349,3 +349,21 @@ describe('nuxt-link:propsOrAttributes', () => {
     })
   })
 })
+
+describe('nuxt-link:mask', () => {
+  it('renders as anchor with mask URL in href', () => {
+    // When mask is provided:
+    // - Renders as <a> (not RouterLink) to control href attribute
+    // - href shows the MASK URL (for SEO, copy link, etc.)
+    // - Click handler navigates to real route and applies mask
+    const link = nuxtLink({ to: '/photos/1/modal', mask: '/photos/1' })
+    expect(link.type).toBe(EXTERNAL) // <a> tag
+    expect(link.props.href).toBe('/photos/1') // mask URL in href
+  })
+
+  it('accepts `unmaskOnReload` prop alongside `mask`', () => {
+    const link = nuxtLink({ to: '/modal', mask: '/clean', unmaskOnReload: true })
+    expect(link.type).toBe(EXTERNAL)
+    expect(link.props.href).toBe('/clean')
+  })
+})

--- a/packages/schema/src/types/router.ts
+++ b/packages/schema/src/types/router.ts
@@ -5,6 +5,13 @@ export type RouterOptions = Partial<Omit<_RouterOptions, 'history' | 'routes'>> 
   routes?: (_routes: _RouterOptions['routes']) => _RouterOptions['routes'] | Promise<_RouterOptions['routes']>
   hashMode?: boolean
   scrollBehaviorType?: 'smooth' | 'auto'
+  /**
+   * Default behavior for unmasking routes on page reload.
+   * When true, masked routes will show their real URL after a page refresh.
+   * Can be overridden per-navigation or per-page via definePageMeta.
+   * @default false
+   */
+  unmaskOnReload?: boolean
 }
 
 export type RouterConfig = RouterOptions
@@ -12,4 +19,4 @@ export type RouterConfig = RouterOptions
 /**
  * Only JSON serializable router options are configurable from nuxt config
  */
-export type RouterConfigSerializable = Pick<RouterConfig, 'linkActiveClass' | 'linkExactActiveClass' | 'end' | 'sensitive' | 'strict' | 'hashMode' | 'scrollBehaviorType'>
+export type RouterConfigSerializable = Pick<RouterConfig, 'linkActiveClass' | 'linkExactActiveClass' | 'end' | 'sensitive' | 'strict' | 'hashMode' | 'scrollBehaviorType' | 'unmaskOnReload'>

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1475,7 +1475,10 @@ describe('route masking', () => {
     // Wait for page to be fully loaded
     await page.waitForSelector('h1:has-text("Mask Test Modal")')
 
-    // With unmaskOnReload: true (default in test fixture), URL should show real route after reload
+    // With unmaskOnReload: true (default in test fixture), URL should show the real route after reload
+    expect(page.url()).toContain('/mask-test/modal')
+    expect(page.url()).not.toContain('/mask-test/clean')
+
     // The modal page should still be displayed correctly
     const heading = await page.locator('h1:has-text("Mask Test Modal")').textContent()
     expect(heading).toBe('Mask Test Modal')

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1379,6 +1379,117 @@ describe('middlewares', () => {
   })
 })
 
+describe('route masking', () => {
+  it('navigateTo with mask should set history state and display mask URL', async () => {
+    const { page } = await renderPage('/mask-test')
+
+    // Click button to navigate with mask
+    await page.getByTestId('navigate-mask').click()
+
+    // Wait for mask to be applied (URL changes to mask URL)
+    await page.waitForFunction(() => window.location.pathname.includes('clean'))
+
+    // The browser URL should be the mask URL
+    const browserUrl = page.url()
+    expect(browserUrl).toContain('/mask-test/clean')
+
+    // Check that we're on the modal page (real route was loaded)
+    await page.waitForSelector('h1:has-text("Mask Test Modal")')
+    const heading = await page.locator('h1:has-text("Mask Test Modal")').textContent()
+    expect(heading).toBe('Mask Test Modal')
+
+    // The history state should have the real route stored
+    const historyState = await page.evaluate(() => window.history.state)
+    expect(historyState.__tempLocation).toContain('/mask-test/modal')
+    expect(historyState.__maskUrl).toContain('/mask-test/clean')
+
+    await page.close()
+  })
+
+  it('NuxtLink with mask prop should work like navigateTo with mask', async () => {
+    const { page } = await renderPage('/mask-test')
+
+    // Click NuxtLink with mask
+    await page.getByTestId('nuxt-link-mask').click()
+
+    // Wait for mask to be applied
+    await page.waitForFunction(() => window.location.pathname.includes('link-clean'))
+
+    // The browser URL should be the mask URL
+    const browserUrl = page.url()
+    expect(browserUrl).toContain('/mask-test/link-clean')
+
+    // Check that we're on the modal page (real route was loaded)
+    await page.waitForSelector('h1:has-text("Mask Test Modal")')
+
+    // The history state should have the real route stored
+    const historyState = await page.evaluate(() => window.history.state)
+    expect(historyState.__tempLocation).toContain('/mask-test/modal')
+    expect(historyState.__maskUrl).toContain('/mask-test/link-clean')
+
+    await page.close()
+  })
+
+  it('browser back should restore previous URL after masked navigation', async () => {
+    const { page } = await renderPage('/mask-test')
+
+    // Navigate with mask
+    await page.getByTestId('navigate-mask').click()
+    await page.waitForFunction(() => window.location.pathname.includes('clean'))
+
+    // Verify we're on modal page with masked URL
+    await page.waitForSelector('h1:has-text("Mask Test Modal")')
+    expect(page.url()).toContain('/mask-test/clean')
+
+    // Go back
+    await page.goBack()
+
+    // Should be back on index page with original URL
+    await page.waitForSelector('h1:has-text("Mask Test Index")')
+    expect(page.url()).toContain('/mask-test')
+    expect(page.url()).not.toContain('/clean')
+    expect(page.url()).not.toContain('/modal')
+
+    await page.close()
+  })
+
+  it('page reload after masked navigation should work without hydration errors', async () => {
+    const { page } = await renderPage('/mask-test')
+
+    // Navigate with mask
+    await page.getByTestId('navigate-mask').click()
+    await page.waitForFunction(() => window.location.pathname.includes('clean'))
+    await page.waitForSelector('h1:has-text("Mask Test Modal")')
+
+    // Collect any console errors during reload
+    const consoleErrors: string[] = []
+    page.on('console', (msg) => {
+      if (msg.type() === 'error' || msg.type() === 'warning') {
+        consoleErrors.push(msg.text())
+      }
+    })
+
+    // Reload the page
+    await page.reload()
+
+    // Wait for page to be fully loaded
+    await page.waitForSelector('h1:has-text("Mask Test Modal")')
+
+    // With unmaskOnReload: true (default in test fixture), URL should show real route after reload
+    // The modal page should still be displayed correctly
+    const heading = await page.locator('h1:has-text("Mask Test Modal")').textContent()
+    expect(heading).toBe('Mask Test Modal')
+
+    // Check for hydration mismatch errors
+    const hydrationErrors = consoleErrors.filter(e =>
+      e.includes('hydration') || e.includes('Hydration') || e.includes('mismatch'),
+    )
+    expect(hydrationErrors).toHaveLength(0)
+
+    await page.close()
+  })
+})
+
 describe('plugins', () => {
   it('basic plugin', async () => {
     const html = await $fetch<string>('/plugins')

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -38,7 +38,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
   it('default client bundle size (pages)', async () => {
     const clientStats = await analyzeSizes(['**/*.js'], join(pagesRootDir, '.output/public'))
 
-    expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"172k"`)
+    expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"174k"`)
 
     const files = clientStats!.files.map(f => f.replace(/\..*\.js/, '.js'))
 

--- a/test/fixtures/basic/app/pages/mask-test/index.vue
+++ b/test/fixtures/basic/app/pages/mask-test/index.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+const historyState = ref<any>(null)
+const currentUrl = ref('')
+
+function updateState () {
+  if (import.meta.client) {
+    historyState.value = window.history.state
+    currentUrl.value = window.location.pathname + window.location.search + window.location.hash
+  }
+}
+
+onMounted(() => {
+  updateState()
+})
+
+async function navigateWithMask () {
+  await navigateTo('/mask-test/modal', { mask: '/mask-test/clean' })
+  updateState()
+}
+</script>
+
+<template>
+  <div>
+    <h1>Mask Test Index</h1>
+    <p data-testid="index-current-url">
+      URL: {{ currentUrl }}
+    </p>
+    <p data-testid="index-temp-location">
+      TempLocation: {{ historyState?.__tempLocation || 'none' }}
+    </p>
+    <p data-testid="index-mask-url">
+      MaskUrl: {{ historyState?.__maskUrl || 'none' }}
+    </p>
+    <button
+      data-testid="navigate-mask"
+      @click="navigateWithMask"
+    >
+      Navigate with Mask
+    </button>
+    <NuxtLink
+      to="/mask-test/modal"
+      mask="/mask-test/link-clean"
+      data-testid="nuxt-link-mask"
+    >
+      NuxtLink with Mask
+    </NuxtLink>
+  </div>
+</template>

--- a/test/fixtures/basic/app/pages/mask-test/modal.vue
+++ b/test/fixtures/basic/app/pages/mask-test/modal.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+const historyState = ref<any>(null)
+const currentUrl = ref('')
+
+function updateState () {
+  if (import.meta.client) {
+    historyState.value = window.history.state
+    currentUrl.value = window.location.pathname + window.location.search + window.location.hash
+  }
+}
+
+onMounted(() => {
+  updateState()
+})
+</script>
+
+<template>
+  <div>
+    <h1>Mask Test Modal</h1>
+    <p data-testid="modal-current-url">
+      URL: {{ currentUrl }}
+    </p>
+    <p data-testid="modal-temp-location">
+      TempLocation: {{ historyState?.__tempLocation || 'none' }}
+    </p>
+    <p data-testid="modal-mask-url">
+      MaskUrl: {{ historyState?.__maskUrl || 'none' }}
+    </p>
+    <NuxtLink
+      to="/mask-test"
+      data-testid="back-link"
+    >Back to Index</NuxtLink>
+  </div>
+</template>

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -121,6 +121,12 @@ export default withMatrix({
       },
     },
   },
+  router: {
+    options: {
+      // For route masking tests: reveal real URL after page reload
+      unmaskOnReload: true,
+    },
+  },
   appConfig: {
     fromNuxtConfig: true,
     nested: {


### PR DESCRIPTION
## 🔗 Linked feature request

resolves #33949

## 📚 Description
Adds route masking support to `Nuxt`, enabling a different URL to be displayed in the browser's address bar while rendering another route internally.

This is commonly used for modal patterns: clicking a photo opens a modal at `/photos/1/modal`, but the URL shows `/photos/1` - a clean, shareable link that renders the full page when visited directly.

### Features

Three ways to mask routes:
```typescript
// navigateTo with mask option
navigateTo('/photos/1/modal', { mask: '/photos/1' })

// NuxtLink with mask prop
<NuxtLink to="/photos/1/modal" mask="/photos/1">View</NuxtLink>

// definePageMeta with mask
definePageMeta({
  mask: route => `/photos/${route.params.id}`
})
```
Global configuration:

```typescript
// nuxt.config.ts
export default defineNuxtConfig({
   router: {
     options: {
       unmaskOnReload: true // reveal real URL on page refresh
     }
   }
})
```

### Playground
I uploaded all needed files to test in this Gist: https://gist.github.com/Flo0806/26a8e955d75be862fc221245b7e486c6

### Documentation

- New: docs/3.guide/5.recipes/5.route-masking.md – comprehensive guide
- Updated: docs/4.api/3.utils/navigate-to.md – added mask and unmaskOnReload options
- Updated: docs/4.api/1.components/4.nuxt-link.md – added mask and unmaskOnReload props
- Updated: docs/4.api/3.utils/define-page-meta.md – added mask and unmaskOnReload meta

### Test Coverage

**Unit tests (packages/nuxt/test/nuxt-link.test.ts):**
- renders as anchor with mask URL in href
- accepts unmaskOnReload prop alongside mask

**E2E tests (test/basic.test.ts):**
- navigateTo with mask should set history state and display mask URL
- NuxtLink with mask prop should work like navigateTo with mask
- browser back should restore previous URL after masked navigation
- page reload after masked navigation should work without hydration errors