### PR TITLE
fix(nuxt): add key to head components for proper deduplication

### DIFF
--- a/packages/nuxt/src/head/runtime/components.ts
+++ b/packages/nuxt/src/head/runtime/components.ts
@@ -142,12 +142,16 @@ export const NoScript = defineComponent({
     title: String,
   },
   setup (props, { slots }) {
-    const { input } = useHeadComponentCtx()
+    const { input, update } = useHeadComponentCtx()
     input.noscript ||= []
     const idx: keyof typeof input.noscript = input.noscript.push({}) - 1
-    onUnmounted(() => input.noscript![idx] = null)
+    onUnmounted(() => {
+      input.noscript![idx] = null
+      update()
+    })
+    const key = useVNodeStringKey()
     return () => {
-      const noscript = normalizeProps(props) as Noscript
+      const noscript = normalizeProps(props, key) as Noscript
       const slotVnodes = slots.default?.()
       const textContent: VNodeNormalizedChildren[] = []
       if (slotVnodes) {
@@ -161,6 +165,7 @@ export const NoScript = defineComponent({
         noscript.innerHTML = textContent.join('')
       }
       input.noscript![idx] = noscript
+      update()
       return null
     }
   },
@@ -228,7 +233,10 @@ export const Base = defineComponent({
   setup (props) {
     const { input, update } = useHeadComponentCtx()
     const key = useVNodeStringKey()
-    onUnmounted(() => input.base = null)
+    onUnmounted(() => {
+      input.base = null
+      update()
+    })
     return () => {
       input.base = normalizeProps(props, key) as UnheadBase
       update()
@@ -243,7 +251,10 @@ export const Title = defineComponent({
   inheritAttrs: false,
   setup (_, { slots }) {
     const { input, update } = useHeadComponentCtx()
-    onUnmounted(() => input.title = null)
+    onUnmounted(() => {
+      input.title = null
+      update()
+    })
     return () => {
       const defaultSlot = slots.default?.()
       input.title = defaultSlot?.[0]?.children ? String(defaultSlot?.[0]?.children) : undefined
@@ -272,11 +283,15 @@ export const Meta = defineComponent({
   },
   setup (props) {
     const { input, update } = useHeadComponentCtx()
+    const key = useVNodeStringKey()
     input.meta ||= []
     const idx: keyof typeof input.meta = input.meta.push({}) - 1
-    onUnmounted(() => input.meta![idx] = null)
+    onUnmounted(() => {
+      input.meta![idx] = null
+      update()
+    })
     return () => {
-      const meta = { 'http-equiv': props.httpEquiv, ...normalizeProps(props) } as UnheadMeta
+      const meta = { 'http-equiv': props.httpEquiv, ...normalizeProps(props, key) } as UnheadMeta
       // fix casing for http-equiv
       if ('httpEquiv' in meta) {
         delete meta.httpEquiv
@@ -307,11 +322,15 @@ export const Style = defineComponent({
   },
   setup (props, { slots }) {
     const { input, update } = useHeadComponentCtx()
+    const key = useVNodeStringKey()
     input.style ||= []
     const idx: keyof typeof input.style = input.style.push({}) - 1
-    onUnmounted(() => input.style![idx] = null)
+    onUnmounted(() => {
+      input.style![idx] = null
+      update()
+    })
     return () => {
-      const style = normalizeProps(props) as UnheadStyle
+      const style = normalizeProps(props, key) as UnheadStyle
       const textContent = slots.default?.()?.[0]?.children
       if (textContent) {
         if (import.meta.dev && typeof textContent !== 'string') {
@@ -348,7 +367,10 @@ export const Html = defineComponent({
   },
   setup (_props, ctx) {
     const { input, update } = useHeadComponentCtx()
-    onUnmounted(() => input.htmlAttrs = null)
+    onUnmounted(() => {
+      input.htmlAttrs = null
+      update()
+    })
     return () => {
       input.htmlAttrs = { ..._props, ...ctx.attrs } as HtmlAttributes
       update()
@@ -364,7 +386,10 @@ export const Body = defineComponent({
   props: globalProps,
   setup (_props, ctx) {
     const { input, update } = useHeadComponentCtx()
-    onUnmounted(() => input.bodyAttrs = null)
+    onUnmounted(() => {
+      input.bodyAttrs = null
+      update()
+    })
     return () => {
       input.bodyAttrs = { ..._props, ...ctx.attrs } as BodyAttributes
       update()

--- a/packages/nuxt/src/head/runtime/components.ts
+++ b/packages/nuxt/src/head/runtime/components.ts
@@ -1,4 +1,4 @@
-import { defineComponent, getCurrentInstance, inject, onUnmounted, provide, reactive, watch } from 'vue'
+import { defineComponent, getCurrentInstance, inject, onUnmounted, provide, reactive } from 'vue'
 import type { PropType, VNodeNormalizedChildren } from 'vue'
 import type {
   BodyAttributes,

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1073,7 +1073,7 @@ describe('head tags', () => {
     await page.close()
   })
 
-  it('should deduplicat head tags with key', async () => {
+  it('should deduplicate head tags with key', async () => {
     const page = await createPage('/head-component')
     await page.waitForFunction(() => window.useNuxtApp?.() && !window.useNuxtApp?.().isHydrating)
 

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1073,6 +1073,21 @@ describe('head tags', () => {
     await page.close()
   })
 
+  it('should deduplicat head tags with key', async () => {
+    const page = await createPage('/head-component')
+    await page.waitForFunction(() => window.useNuxtApp?.() && !window.useNuxtApp?.().isHydrating)
+
+    expect(await page.locator('link[data-hid="dedupe-key"]').count()).toBe(1)
+    expect(await page.locator('link[data-hid="dedupe-key"]').getAttribute('href')).toBe('client')
+    expect(await page.locator('link[data-hid="dedupe-key"]').getAttribute('rel')).toBe('x-test')
+
+    await page.close()
+
+    const html = await $fetch<string>('/head-component')
+    expect((html.match(/data-hid="dedupe-key"/g) || []).length).toBe(1)
+    expect(html).toContain('<link rel="x-test" href="server" data-hid="dedupe-key">')
+  })
+
   // TODO: Doesn't adds header in test environment
   // it.todo('should render stylesheet link tag (SPA mode)', async () => {
   //   const html = await $fetch<string>('/head', { headers: { 'x-nuxt-no-ssr': '1' } })

--- a/test/fixtures/basic/app/pages/head-component.vue
+++ b/test/fixtures/basic/app/pages/head-component.vue
@@ -5,6 +5,15 @@
         rel="alternate"
         href="/"
       />
+      <Link
+        key="dedupe-key"
+        rel="x-test"
+        :href="isServer ? 'server' : 'client'"
+      />
     </Head>
   </div>
 </template>
+
+<script setup lang="ts">
+const isServer = import.meta.server
+</script>


### PR DESCRIPTION
### 🔗 Linked issue

fix https://github.com/nuxt/nuxt/pull/33958

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This PR fixes the previous PR. 
The issue is that key needed to be assigned at the <Link> <Style> components level. Then we'd need to call `entry.patch` when updating the input

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/4.x/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
