### PR TITLE
docs: add layers directory documentation

### DIFF
--- a/docs/1.getting-started/14.layers.md
+++ b/docs/1.getting-started/14.layers.md
@@ -125,6 +125,10 @@ If you also have `~~/layers/custom`, the priority order is:
 
 This means your project files will override any layer, and `~~/layers/custom` will override anything in `extends`.
 
+::read-more{to="/docs/4.x/directory-structure/layers"}
+Learn about the **layers/ directory** and see practical examples.
+::
+
 ::read-more{to="/docs/4.x/guide/going-further/layers"}
 Read more about layers in the **Layer Author Guide**.
 ::

--- a/docs/1.getting-started/14.layers.md
+++ b/docs/1.getting-started/14.layers.md
@@ -86,32 +86,60 @@ Nuxt uses [unjs/c12](https://github.com/unjs/c12) and [unjs/giget](https://githu
 
 When using multiple layers, it's important to understand the override order. Layers with **higher priority** override layers with lower priority when they define the same files or components.
 
-The priority order from highest to lowest is:
+### Priority Order
+
+From highest to lowest priority:
 
 1. **Your project files** - always have the highest priority
 2. **Auto-scanned layers** from `~~/layers` directory - sorted alphabetically (Z has higher priority than A)
 3. **Layers in `extends`** config - first entry has higher priority than second
 
-### When to Use Each
+### Practical Example
 
-- **`extends`** - Use for external dependencies (npm packages, remote repositories) or layers outside your project directory
-- **`~~/layers` directory** - Use for local layers that are part of your project
+Consider multiple layers defining the same component:
+
+```bash [Directory structure]
+layers/
+  1.base/
+    app/components/Button.vue    # Base button style
+  2.theme/
+    app/components/Button.vue    # Themed button (overrides base)
+app/
+  components/Button.vue          # Project button (overrides all layers)
+```
+
+In this case:
+- If only layers exist, `2.theme/Button.vue` is used (higher alphabetically)
+- If `app/components/Button.vue` exists in your project, it overrides all layers
+
+### Controlling Priority
+
+You can prefix layer directories with numbers to control the order:
+
+```bash [Directory structure]
+layers/
+  1.base/        # Lowest priority
+  2.features/    # Medium priority
+  3.admin/       # Highest priority (among layers)
+```
 
 ::tip
-If you need to control the order of auto-scanned layers, you can prefix them with numbers: `~/layers/1.z-layer`, `~/layers/2.a-layer`. This way `2.a-layer` will have higher priority than `1.z-layer`.
+This pattern is useful for creating base layers with defaults that can be progressively overridden by more specific layers.
 ::
 
-### Example
+### When to Use Each
+
+- **`~~/layers` directory** - Use for local layers that are part of your project
+- **`extends`** - Use for external dependencies (npm packages, remote repositories) or layers outside your project directory
+
+### Full Example with extends
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   extends: [
-    // Local layer outside the project
-    '../base',
-    // NPM package
-    '@my-themes/awesome',
-    // Remote repository
-    'github:my-themes/awesome#v1',
+    '../base',                      // Local layer outside project
+    '@my-themes/awesome',           // NPM package
+    'github:my-themes/awesome#v1',  // Remote repository
   ],
 })
 ```
@@ -123,10 +151,8 @@ If you also have `~~/layers/custom`, the priority order is:
 - `@my-themes/awesome`
 - `github:my-themes/awesome#v1` (lowest)
 
-This means your project files will override any layer, and `~~/layers/custom` will override anything in `extends`.
-
 ::read-more{to="/docs/4.x/directory-structure/layers"}
-Learn about the **layers/ directory** and see practical examples.
+Learn about the **layers/ directory** to organize and share reusable code, components, composables, and configurations across your Nuxt application.
 ::
 
 ::read-more{to="/docs/4.x/guide/going-further/layers"}

--- a/docs/2.directory-structure/1.layers.md
+++ b/docs/2.directory-structure/1.layers.md
@@ -78,58 +78,10 @@ Each layer can include:
 
 ## Priority Order
 
-When multiple layers define the same component, composable, page, or other resource, the layer with **higher priority wins** and overrides the others.
+When multiple layers define the same resource (component, composable, page, etc.), the layer with **higher priority wins**. Layers are sorted alphabetically, with later letters having higher priority (Z > A).
 
-Layers in the `layers/` directory are sorted alphabetically, with layers that come **later** in alphabetical order having **higher priority** (Z > A).
+To control the order, prefix directories with numbers: `1.base/`, `2.features/`, `3.admin/`.
 
-### Controlling Priority
-
-If you need to control the order, you can prefix layer directories with numbers:
-
-```bash [Directory structure]
-layers/
-  1.base/
-    nuxt.config.ts
-  2.features/
-    nuxt.config.ts
-  3.admin/
-    nuxt.config.ts
-```
-
-This way `3.admin` will have higher priority than `2.features`, and `2.features` will have higher priority than `1.base`.
-
-### Priority Example
-
-Consider multiple layers defining the same component:
-
-```bash [Directory structure]
-layers/
-  1.base/
-    app/components/Button.vue    # Base button style
-  2.theme/
-    app/components/Button.vue    # Themed button (overrides base)
-  3.admin/
-    app/components/Button.vue    # Admin button (overrides theme)
-app/
-  components/Button.vue          # Project button (overrides all layers)
-```
-
-In this case:
-- If only layers exist, `3.admin/Button.vue` is used (highest layer priority)
-- If `app/components/Button.vue` exists in your project, it overrides all layers
-
-### Complete Priority Order
-
-From highest to lowest priority:
-
-1. **Your project files** - always have the highest priority
-2. **Auto-scanned layers** from `layers/` directory - sorted alphabetically (Z > A, 3 > 2 > 1)
-3. **Layers in `extends`** config - first entry has higher priority than second
-
-::tip
-This pattern is useful for creating base layers with defaults that can be progressively overridden by more specific layers.
-::
-
-:read-more{to="/docs/4.x/getting-started/layers"}
+:read-more{to="/docs/4.x/getting-started/layers#layer-priority"}
 
 :video-accordion{title="Watch a video from Learn Vue about Nuxt Layers" videoId="lnFCM7c9f7I"}

--- a/docs/2.directory-structure/1.layers.md
+++ b/docs/2.directory-structure/1.layers.md
@@ -1,0 +1,135 @@
+---
+title: 'layers'
+head.title: 'layers/'
+description: Use the layers/ directory to organize and auto-register local layers within your application.
+navigation.icon: i-vscode-icons-folder-type-nuxt
+---
+
+The `layers/` directory allows you to organize and share reusable code, components, composables, and configurations across your Nuxt application. Any layers within your project in the `layers/` directory will be automatically registered.
+
+::note
+The `layers/` directory auto-registration is available in Nuxt v3.12.0+.
+::
+
+::tip{icon="i-lucide-lightbulb"}
+Layers are ideal for organizing large codebases with **Domain-Driven Design (DDD)**, creating reusable **UI libraries** or **themes**, sharing **configuration presets** across projects, and separating concerns like **admin panels** or **feature modules**.
+::
+
+## Structure
+
+Each subdirectory within `layers/` is treated as a separate layer. A layer can contain the same structure as a standard Nuxt application.
+
+::important
+Every layer **must have** a `nuxt.config.ts` file to be recognized as a valid layer, even if it's empty.
+::
+
+```bash [Directory structure]
+-| layers/
+---| base/
+-----| nuxt.config.ts
+-----| app/
+-------| components/
+---------| BaseButton.vue
+-------| composables/
+---------| useBase.ts
+-----| server/
+-------| api/
+---------| hello.ts
+---| admin/
+-----| nuxt.config.ts
+-----| app/
+-------| pages/
+---------| admin.vue
+-------| layouts/
+---------| admin.vue
+```
+
+## Automatic Aliases
+
+Named layer aliases to the `srcDir` of each layer are automatically created. You can access a layer using the `#layers/[name]` alias:
+
+```ts
+// Access the base layer
+import something from '#layers/base/path/to/file'
+
+// Access the admin layer
+import { useAdmin } from '#layers/admin/composables/useAdmin'
+```
+
+::note
+Named layer aliases were introduced in Nuxt v3.16.0.
+::
+
+## Layer Content
+
+Each layer can include:
+
+- [`nuxt.config.ts`](/docs/4.x/directory-structure/nuxt-config) - Layer-specific configuration that will be merged with the main config
+- [`app.config.ts`](/docs/4.x/directory-structure/app/app-config) - Reactive application configuration
+- [`app/components/`](/docs/4.x/directory-structure/app/components) - Vue components (auto-imported)
+- [`app/composables/`](/docs/4.x/directory-structure/app/composables) - Vue composables (auto-imported)
+- [`app/utils/`](/docs/4.x/directory-structure/app/utils) - Utility functions (auto-imported)
+- [`app/pages/`](/docs/4.x/directory-structure/app/pages) - Application pages
+- [`app/layouts/`](/docs/4.x/directory-structure/app/layouts) - Application layouts
+- [`app/middleware/`](/docs/4.x/directory-structure/app/middleware) - Route middleware
+- [`app/plugins/`](/docs/4.x/directory-structure/app/plugins) - Nuxt plugins
+- [`server/`](/docs/4.x/directory-structure/server) - Server routes, middleware, and utilities
+- [`shared/`](/docs/4.x/directory-structure/shared) - Shared code between app and server
+
+## Priority Order
+
+When multiple layers define the same component, composable, page, or other resource, the layer with **higher priority wins** and overrides the others.
+
+Layers in the `layers/` directory are sorted alphabetically, with layers that come **later** in alphabetical order having **higher priority** (Z > A).
+
+### Controlling Priority
+
+If you need to control the order, you can prefix layer directories with numbers:
+
+```bash [Directory structure]
+layers/
+  1.base/
+    nuxt.config.ts
+  2.features/
+    nuxt.config.ts
+  3.admin/
+    nuxt.config.ts
+```
+
+This way `3.admin` will have higher priority than `2.features`, and `2.features` will have higher priority than `1.base`.
+
+### Priority Example
+
+Consider multiple layers defining the same component:
+
+```bash [Directory structure]
+layers/
+  1.base/
+    app/components/Button.vue    # Base button style
+  2.theme/
+    app/components/Button.vue    # Themed button (overrides base)
+  3.admin/
+    app/components/Button.vue    # Admin button (overrides theme)
+app/
+  components/Button.vue          # Project button (overrides all layers)
+```
+
+In this case:
+- If only layers exist, `3.admin/Button.vue` is used (highest layer priority)
+- If `app/components/Button.vue` exists in your project, it overrides all layers
+
+### Complete Priority Order
+
+From highest to lowest priority:
+
+1. **Your project files** - always have the highest priority
+2. **Auto-scanned layers** from `layers/` directory - sorted alphabetically (Z > A, 3 > 2 > 1)
+3. **Layers in `extends`** config - first entry has higher priority than second
+
+::tip
+This pattern is useful for creating base layers with defaults that can be progressively overridden by more specific layers.
+::
+
+:read-more{to="/docs/4.x/getting-started/layers"}
+
+:video-accordion{title="Watch a video from Learn Vue about Nuxt Layers" videoId="lnFCM7c9f7I"}

--- a/docs/2.directory-structure/index.md
+++ b/docs/2.directory-structure/index.md
@@ -54,6 +54,10 @@ The [`content/`](/docs/4.x/directory-structure/content) directory is enabled by 
 
 The [`modules/`](/docs/4.x/directory-structure/modules) directory is the directory that contains the local modules of the Nuxt application. Modules are used to extend the functionality of the Nuxt application.
 
+## Layers Directory
+
+The [`layers/`](/docs/4.x/directory-structure/layers) directory allows you to organize and share reusable code, components, composables, and configurations. Layers within this directory are automatically registered in your project.
+
 ## Nuxt Files
 
 - [`nuxt.config.ts`](/docs/4.x/directory-structure/nuxt-config) file is the main configuration file for the Nuxt application.


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #33904

### 📚 Description

This PR adds the “layers” page to the “structure” section of the documentation.
