### PR TITLE
fix(nuxt): update global reference to globalThis in useRequestFetch

### DIFF
--- a/packages/nuxt/src/app/composables/ssr.ts
+++ b/packages/nuxt/src/app/composables/ssr.ts
@@ -42,7 +42,7 @@ export function useRequestHeader (header: string) {
 }
 
 /** @since 3.2.0 */
-export function useRequestFetch (): H3Event$Fetch | typeof global.$fetch {
+export function useRequestFetch (): H3Event$Fetch | typeof globalThis.$fetch {
   if (import.meta.client) {
     return globalThis.$fetch
   }


### PR DESCRIPTION
### 🔗 Linked issue

None.

### 📚 Description

This change fixes an issue where `useRequestFetch` was inferred as `any` instead of the correct type.
