### PR TITLE
fix(nitro): check prettyResponse.body type before error overlay

### DIFF
--- a/packages/nitro-server/src/runtime/handlers/error.ts
+++ b/packages/nitro-server/src/runtime/handlers/error.ts
@@ -85,7 +85,9 @@ export default <NitroErrorHandler> async function errorhandler (error, event, { 
 
   if (import.meta.dev && !import.meta.test && typeof html === 'string') {
     const prettyResponse = await defaultHandler(error, event, { json: false })
-    return send(event, html.replace('</body>', `${generateErrorOverlayHTML(prettyResponse.body as string, { startMinimized: 300 <= status && status < 500 })}</body>`))
+    if (typeof prettyResponse.body === 'string') {
+      return send(event, html.replace('</body>', `${generateErrorOverlayHTML(prettyResponse.body, { startMinimized: 300 <= status && status < 500 })}</body>`))
+    }
   }
 
   return send(event, html)


### PR DESCRIPTION
## 🔗 Linked issue

Resolves #33748

## 📋 Problem Statement

Users are seeing this error in dev mode, commonly triggered by service worker requests (`/sw.js`, `/dev-sw.js`):

```
ERROR  html.replace is not a function

    at generateErrorOverlayHTML (.nuxt/dev/index.mjs:1961:26)
    at errorhandler (.nuxt/dev/index.mjs:2024:53)
```

## 🔍 Root Cause

In Nitro's dev error handler, the logic for determining JSON vs HTML response is:

```javascript
const useJSON = opts?.json || !getRequestHeader(event, "accept")?.includes("text/html");
```

When `defaultHandler(error, event, { json: false })` is called, `opts.json` is falsy so it still checks the `Accept` header. Requests like `/sw.js` don't include `Accept: text/html`, so `useJSON` ends up `true` and returns an object instead of HTML string.

This causes `generateErrorOverlayHTML` to fail when calling `.replace()` on a non-string.

## ✅ Solution

Add a type check before passing `prettyResponse.body` to `generateErrorOverlayHTML`:

```typescript
if (typeof prettyResponse.body === 'string') {
  return send(event, html.replace('</body>', `${generateErrorOverlayHTML(prettyResponse.body, ...)}...`))
}
```

Falls back to regular error page without overlay when body is not a string.