### PR TITLE
fix(nitro): add noUncheckedIndexedAccess to server tsconfig

### DIFF
--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -222,6 +222,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
         compilerOptions: {
           lib: ['esnext', 'webworker', 'dom.iterable'],
           skipLibCheck: true,
+          noUncheckedIndexedAccess: true,
         },
         include: [
           join(nuxt.options.buildDir, 'types/nitro-nuxt.d.ts'),


### PR DESCRIPTION
## Summary
Adds `noUncheckedIndexedAccess: true` to the Nitro server TypeScript configuration.

## Problem
The `noUncheckedIndexedAccess` compiler option is enabled in `app/` and `shared/` tsconfigs but missing from the `server/` configuration. This creates inconsistent type-checking behavior where the same code patterns work differently depending on location.

## Solution
Added `noUncheckedIndexedAccess: true` to the nitro typescript config in `packages/nitro-server/src/index.ts`.

## Test plan
- [x] Verified the change matches the pattern used in other tsconfigs

Fixes #32941