### PR TITLE
fix(kit,schema): align module `onUpgrade` arguments with types

### DIFF
--- a/docs/3.guide/4.modules/6.best-practices.md
+++ b/docs/3.guide/4.modules/6.best-practices.md
@@ -52,7 +52,7 @@ export default defineNuxtModule({
     // One-time setup: create database schema, generate config files, etc.
     await generateDatabaseConfig(nuxt.options.rootDir)
   },
-  async onUpgrade (options, nuxt, previousVersion) {
+  async onUpgrade (nuxt, options, previousVersion) {
     // Handle version-specific migrations
     if (semver.lt(previousVersion, '1.0.0')) {
       await migrateLegacyData()

--- a/docs/4.api/5.kit/1.modules.md
+++ b/docs/4.api/5.kit/1.modules.md
@@ -64,7 +64,7 @@ export function defineNuxtModule<TOptions extends ModuleOptions> (): {
 | `hooks`              | `Partial<NuxtHooks>`{lang="ts"}                                                                                   | `false`  | Hooks to be installed for the module. If provided, the module will install the hooks.                                                                                                                              |
 | `moduleDependencies` | `Record<string, ModuleDependency> \| ((nuxt: Nuxt) => Record<string, ModuleDependency>)`{lang="ts"}               | `false`  | Dependencies on other modules with version constraints and configuration. Can be an object or a function that receives the Nuxt instance. See [example](/docs/4.x/api/kit/modules#specifying-module-dependencies). |
 | `onInstall`          | `(nuxt: Nuxt) => Awaitable<void>`{lang="ts"}                                                                      | `false`  | Lifecycle hook called when the module is first installed. Requires `meta.name` and `meta.version` to be defined.                                                                                                   |
-| `onUpgrade`          | `(options: T, nuxt: Nuxt, previousVersion: string) => Awaitable<void>`{lang="ts"}                                 | `false`  | Lifecycle hook called when the module is upgraded to a newer version. Requires `meta.name` and `meta.version` to be defined.                                                                                       |
+| `onUpgrade`          | `(nuxt: Nuxt, options: T, previousVersion: string) => Awaitable<void>`{lang="ts"}                                 | `false`  | Lifecycle hook called when the module is upgraded to a newer version. Requires `meta.name` and `meta.version` to be defined.                                                                                       |
 | `setup`              | `(this: void, resolvedOptions: T, nuxt: Nuxt) => Awaitable<void \| false \| ModuleSetupInstallResult>`{lang="ts"} | `false`  | Setup function for the module. If provided, the module will call the setup function.                                                                                                                               |
 
 ### Examples
@@ -216,7 +216,7 @@ export default defineNuxtModule({
     // - Perform initial data migration
   },
 
-  onUpgrade (options, nuxt, previousVersion) {
+  onUpgrade (nuxt, options, previousVersion) {
     // This runs when the module is upgraded to a newer version
     console.log(`Upgrading my-awesome-module from ${previousVersion} to 1.2.0`)
 

--- a/packages/kit/src/module/install.ts
+++ b/packages/kit/src/module/install.ts
@@ -350,7 +350,7 @@ async function callLifecycleHooks (nuxtModule: NuxtModule<any, Partial<any>, fal
     if (!previousVersion) {
       await nuxtModule.onInstall?.(nuxt)
     } else if (semver.gt(meta.version, previousVersion)) {
-      await nuxtModule.onUpgrade?.(inlineOptions, nuxt, previousVersion)
+      await nuxtModule.onUpgrade?.(nuxt, inlineOptions, previousVersion)
     }
     if (previousVersion !== meta.version) {
       updateRc(

--- a/packages/schema/src/types/module.ts
+++ b/packages/schema/src/types/module.ts
@@ -92,7 +92,7 @@ export interface ModuleDefinition<
   hooks?: Partial<NuxtHooks>
   moduleDependencies?: ModuleDependencies | ((nuxt: Nuxt) => Awaitable<ModuleDependencies>)
   onInstall?: (nuxt: Nuxt) => Awaitable<void>
-  onUpgrade?: (options: TOptions, nuxt: Nuxt, previousVersion: string) => Awaitable<void>
+  onUpgrade?: (nuxt: Nuxt, options: TOptions, previousVersion: string) => Awaitable<void>
   setup?: (
     this: void,
     resolvedOptions: TWith extends true
@@ -126,10 +126,10 @@ export interface NuxtModule<
   getMeta?: () => Promise<ModuleMeta>
   onInstall?: (nuxt: Nuxt) => Awaitable<void>
   onUpgrade?: (
+    nuxt: Nuxt,
     options: TWith extends true
       ? ResolvedModuleOptions<TOptions, TOptionsDefaults>
       : TOptions,
-    nuxt: Nuxt,
     previousVersion: string,
   ) => Awaitable<void>
 }

--- a/packages/schema/src/types/module.ts
+++ b/packages/schema/src/types/module.ts
@@ -92,7 +92,7 @@ export interface ModuleDefinition<
   hooks?: Partial<NuxtHooks>
   moduleDependencies?: ModuleDependencies | ((nuxt: Nuxt) => Awaitable<ModuleDependencies>)
   onInstall?: (nuxt: Nuxt) => Awaitable<void>
-  onUpgrade?: (nuxt: Nuxt, options: TOptions, previousVersion: string) => Awaitable<void>
+  onUpgrade?: (options: TOptions, nuxt: Nuxt, previousVersion: string) => Awaitable<void>
   setup?: (
     this: void,
     resolvedOptions: TWith extends true


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 📚 Description

Aligns the module `onUpgrade` lifecycle interface with `onInstall`, passing the `nuxt` object first. This also fix inconsistent type definitions for `onUpgade` (see *Previously* section for initial work)

<details>
<summary>Previously</summary>

It seems the module `onUpgrade` lifecycle only honors the following interface:
```ts
onUpgrade?: (options, nuxt, previousVersion) => Awaitable
```

So I assume the overload:
```ts
onUpgrade?: (nuxt, options, previousVersion) => Awaitable
```

Is/was wrong? I'm not sure if this is a deprecated overload for it, couldn't see trace of normalization of the `onUpgrade` interface in the code :thinking: Sorry if I'm wrong!

</details>



<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/4.x/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
