### PR TITLE
fix(nuxt): skip internal stub routes from prerender

### DIFF
--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -371,6 +371,9 @@ export default defineNuxtModule({
 
     function processPages (pages: NuxtPage[], currentPath = '/') {
       for (const page of pages) {
+        // Skip internal stub routes (redirects, test routes) from prerendering
+        if (page._sync) { continue }
+
         // Add root of optional dynamic paths and catchalls
         if (OPTIONAL_PARAM_RE.test(page.path) && !page.children?.length) {
           prerenderRoutes.add(currentPath)


### PR DESCRIPTION
Fixes #33824

## Problem
`nuxt generate` doesn't crawl/discover pages when initial route has a redirect routeRule.

## Context
- PR #33662 moved prerender hook from `pages:extend` to `pages:resolved`
- routeRules redirects add stub routes with `_sync: true` via `pages:extend`
- After #33662, these stubs appear in pages when `pages:resolved` fires
- `/` stub gets sorted first → crawler starts from redirect → no links discovered

## Solution
Skip `_sync` routes in `processPages()`. These are internal stubs (redirects, test routes) that shouldn't be used as prerender seeds.

## Reproduce bug
```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxt-33824 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxt-33824
cd nuxt-33824 && pnpm i && pnpm generate
```
Only 3 routes generated.

## Verify fix
```bash
git sparse-checkout add nuxt-33824-fixed
cd ../nuxt-33824-fixed && pnpm i && pnpm generate
```
All 9 routes generated.


Not sure if this PR requires test for future regressions 🤔 