### PR TITLE
fix(nuxt): protect all server directory imports

### DIFF
--- a/packages/nuxt/src/core/plugins/import-protection.ts
+++ b/packages/nuxt/src/core/plugins/import-protection.ts
@@ -1,4 +1,4 @@
-import { relative, resolve } from 'pathe'
+import { relative } from 'pathe'
 import escapeRE from 'escape-string-regexp'
 import type { NuxtOptions } from 'nuxt/schema'
 
@@ -70,9 +70,9 @@ export function createImportProtectionPatterns (nuxt: { options: NuxtOptions }, 
   }
 
   if (options.context === 'nuxt-app' || options.context === 'shared') {
-    const serverRelative = escapeRE(relative(nuxt.options.rootDir, resolve(nuxt.options.srcDir, nuxt.options.serverDir || 'server')))
+    // Block all server directory imports
     patterns.push([
-      new RegExp('^' + serverRelative + '\\/(api|routes|middleware|plugins)\\/'),
+      new RegExp('(^|\\/)' + escapeRE(relative(nuxt.options.rootDir, nuxt.options.serverDir)) + '(\\/|$)'),
       `Importing from server is not allowed in ${context}.`,
       ['Use `$fetch()` or `useFetch()` to fetch data from server routes.', 'Move shared logic to the `shared/` directory.'],
     ])

--- a/packages/nuxt/test/import-protection.test.ts
+++ b/packages/nuxt/test/import-protection.test.ts
@@ -24,6 +24,10 @@ const testsToTriggerOn = [
   ['some-nuxt-module/runtime/something.vue', 'components/Component.vue', false],
   ['/root/src/server/api/test.ts', 'components/Component.vue', true],
   ['src/server/api/test.ts', 'components/Component.vue', true],
+  // All server subdirectories should be protected (not just api/routes/middleware/plugins)
+  ['src/server/utils/helper.ts', 'components/Component.vue', true],
+  ['/root/src/server/utils/secret.ts', 'components/Component.vue', true],
+  ['/root/src/server/services/db.ts', 'components/Component.vue', true],
   ['node_modules/nitropack/node_modules/crossws/dist/adapters/bun.mjs', 'node_modules/nitropack/dist/presets/bun/runtime/bun.mjs', false],
   ['nitro/builder', 'components/Component.vue', true],
   ['nitro/meta', 'components/Component.vue', true],
@@ -66,3 +70,69 @@ const transformWithImportProtection = (id: string, importer: string, context: 'n
 
   return (plugin as any).resolveId.call({ error: () => {} }, id, importer)
 }
+
+// Nuxt 4 structure: srcDir = app/, server is sibling of srcDir
+const transformWithImportProtectionNuxt4 = (id: string, importer: string, context: 'nitro-app' | 'nuxt-app' | 'shared') => {
+  const plugin = ImpoundPlugin.rollup({
+    cwd: '/root',
+    patterns: createImportProtectionPatterns({
+      options: {
+        _installedModules: [
+          // @ts-expect-error an incomplete module
+          { entryPath: 'some-nuxt-module' },
+        ],
+        rootDir: '/root/',
+        srcDir: '/root/app/',
+        serverDir: '/root/server',
+      } satisfies Partial<NuxtOptions> as NuxtOptions,
+    }, { context }),
+  })
+
+  return (plugin as any).resolveId.call({ error: () => {} }, id, importer)
+}
+
+const testsToTriggerOnNuxt4 = [
+  ['~/nuxt.config', 'app.vue', true],
+  ['./nuxt.config', 'app.vue', true],
+  ['./nuxt.config.ts', 'app.vue', true],
+  ['nuxt.config.ts', 'app.vue', true],
+  ['./.nuxt/nuxt.config', 'app.vue', false],
+  ['.nuxt/nuxt.config', 'app.vue', false],
+  ['nuxt', 'app/components/Component.vue', true],
+  ['nuxt3', 'app/components/Component.vue', true],
+  ['nuxt-nightly', 'app/components/Component.vue', true],
+  ['/root/node_modules/@vue/composition-api', 'app/components/Component.vue', true],
+  ['@vue/composition-api', 'app/components/Component.vue', true],
+  ['@nuxt/kit', 'app/components/Component.vue', true],
+  ['nuxt/config', 'app/components/Component.vue', true],
+  ['nuxt/kit', 'app/components/Component.vue', true],
+  ['nuxt/schema', 'app/components/Component.vue', true],
+  ['/root/node_modules/@nuxt/kit', 'app/components/Component.vue', true],
+  ['some-nuxt-module', 'app/components/Component.vue', true],
+  ['some-nuxt-module/runtime/something.vue', 'app/components/Component.vue', false],
+  ['/root/server/api/test.ts', 'app/components/Component.vue', true],
+  ['server/api/test.ts', 'app/components/Component.vue', true],
+  ['server/utils/helper.ts', 'app/components/Component.vue', true],
+  ['/root/server/utils/secret.ts', 'app/components/Component.vue', true],
+  ['/root/server/services/db.ts', 'app/components/Component.vue', true],
+  ['server/middleware/auth.ts', 'app/composables/useAuth.ts', true],
+  ['server/plugins/database.ts', 'app/pages/index.vue', true],
+  ['server/routes/health.ts', 'app/layouts/default.vue', true],
+  ['node_modules/nitropack/node_modules/crossws/dist/adapters/bun.mjs', 'node_modules/nitropack/dist/presets/bun/runtime/bun.mjs', false],
+  ['app/utils/helper.ts', 'app/pages/index.vue', false],
+  ['app/composables/useState.ts', 'app/components/Component.vue', false],
+  ['shared/types.ts', 'app/components/Component.vue', false],
+  ['shared/utils/format.ts', 'app/pages/index.vue', false],
+] as const
+
+describe('import protection (Nuxt 4 structure)', () => {
+  it.each(testsToTriggerOnNuxt4)('should protect %s', async (id, importer, isProtected) => {
+    const result = await transformWithImportProtectionNuxt4(id, importer, 'nuxt-app')
+    if (!isProtected) {
+      expect(result).toBeNull()
+    } else {
+      expect(result).toBeDefined()
+      expect(result).toContain('impound:proxy')
+    }
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

Fixes: #33874

### 📚 Description

- Fix import protection to block **all** server directory imports, not just `api/routes/middleware/plugins`, Updated Regex for more path security
- Use `rootDir` instead of `srcDir` for correct path matching in Nuxt 4 folder structure
- Improve error message with hint about `shared/` directory

With this we have a better error message when server paths are imported in client side.

### Tests
- Updated test for bundle size
- Updated test for `import-protection.test.ts`

## ⚠️ Important
The protect functions never worked under `Nuxt 4`. The path was resolved correctly (not a bug), but due to `src/app` (Nuxt 4), `../server` was returned, which never corresponds to `server/`. Therefore, it didn't work.

This wasn't noticed because the tests in `import-protection.test.ts` were **only** designed for `Nuxt 3`. I've now updated them. It now works for both `Nuxt 3` and `Nuxt 4`.
