### PR TITLE
fix(nuxt): handle unsafe number parsing in useCookie decode

### DIFF
--- a/packages/nuxt/src/app/composables/cookie.ts
+++ b/packages/nuxt/src/app/composables/cookie.ts
@@ -29,7 +29,15 @@ export interface CookieRef<T> extends Ref<T> {}
 const CookieDefaults = {
   path: '/',
   watch: true,
-  decode: val => destr(decodeURIComponent(val)),
+  decode: (val) => {
+    const decoded = decodeURIComponent(val)
+    const parsed = destr(decoded)
+    // destr can return Infinity or precision-loss numbers - keep original string
+    if (typeof parsed === 'number' && (!Number.isFinite(parsed) || String(parsed) !== decoded)) {
+      return decoded
+    }
+    return parsed
+  },
   encode: val => encodeURIComponent(typeof val === 'string' ? val : JSON.stringify(val)),
 } satisfies CookieOptions<any>
 


### PR DESCRIPTION
Fixes #34006

## Problem

`useCookie` uses `destr` to parse cookie values, which aggressively coerces number-like strings. This causes:
- `4e71375682906041` → `Infinity` (scientific notation overflow)
- `9007199254740993` → `9007199254740992` (precision loss)

This breaks tokens/IDs/access keys that happen to look like numbers.

## Solution

Check if `destr` returned an unsafe number (Infinity or precision loss) and keep the original string instead.

The String(parsed) !== decoded check is clever - it catches both precision loss AND format changes in one comparison.

let me know if a test is required.

## Reproduction

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxt-34006 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxt-34006
cd nuxt-34006 && pnpm i && pnpm dev
# Visit /set-cookies then / to see the bug
```

## Verify fix

```bash
git sparse-checkout add nuxt-34006-fixed
cd ../nuxt-34006-fixed && pnpm i && pnpm dev
# Visit /set-cookies then / to see the fix
```