### PR TITLE
docs: improve `addImports` example

### DIFF
--- a/docs/3.guide/4.modules/3.recipes-basics.md
+++ b/docs/3.guide/4.modules/3.recipes-basics.md
@@ -148,9 +148,26 @@ export default defineNuxtModule({
 
     addImports({
       name: 'useComposable', // name of the composable to be used
-      as: 'useComposable',
+      as: 'useMyComposable', // optional alias that will be available for the consuming apps
       from: resolver.resolve('runtime/composables/useComposable'), // path of composable
     })
+  },
+})
+```
+
+Multiple entries can be passed as an array:
+
+```ts
+import { addImports, createResolver, defineNuxtModule } from '@nuxt/kit'
+
+export default defineNuxtModule({
+  setup (options, nuxt) {
+    const resolver = createResolver(import.meta.url)
+
+    addImports([
+      { name: 'useFirstComposable', from: resolver.resolve('runtime/composables/useFirstComposable') },
+      { name: 'useSecondComposable', from: resolver.resolve('runtime/composables/useSecondComposable') },
+    ])
   },
 })
 ```


### PR DESCRIPTION
### 🔗 Linked issue

No issue (should I open one?)

### 📚 Description

This little addition is aiming to improve two things that weren't clear to me when I read the docs:

1. Parameter `as` is not required (yes, you can tell that from looking to the type signature, but usually you just grab the example from docs first and start thinking later)
2. More entries can be passed at once in an array (again, can be inferred from checking types, but like this it is more explicit)

Open to discussion or even a rejection, if you think this is adding unnecessary info

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/4.x/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
