### PR TITLE
fix: type error invalid for alias suffix

### DIFF
--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -821,7 +821,7 @@ export interface ConfigSchema {
    * </style>
    * ```
    */
-  alias: Record<string, string>
+  alias: Record<string, string> & { [key: `${string}/*`]: never }
 
   /**
    * Pass options directly to `node-ignore` (which is used by Nuxt to ignore files).


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

https://github.com/nuxt/nuxt/issues/34019

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

Create a type error further upstream.

[See example here &rarr;](https://www.typescriptlang.org/play/?ssl=1&ssc=37&pln=1&pc=70#code/MYewdgzgLgBAhgGwJZwgLhgJQKagE4AmAPNHkmAOYA0Mp5FAfDAGQwDeMA2gNbYCeGAAYASNnUoBfAPQAqQQF0MYbADdseGBJgBedgCgYMAOQALbAgQgjGU+ctGqB4wHcQeBAVnWXbjw70SQA)

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/4.x/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
