### PR TITLE
feat(kit): add support to set env/nuxt config variables from the file content

### DIFF
--- a/packages/kit/src/loader/config.ts
+++ b/packages/kit/src/loader/config.ts
@@ -25,7 +25,7 @@ const merger = createDefu((obj, key, value) => {
   }
 })
 
-export async function loadNuxtConfig(opts: LoadNuxtConfigOptions): Promise<NuxtOptions> {
+export async function loadNuxtConfig (opts: LoadNuxtConfigOptions): Promise<NuxtOptions> {
   expandWithEnvFilesContent()
 
   // Automatically detect and import layers from `~~/layers/` directory
@@ -132,7 +132,7 @@ export async function loadNuxtConfig(opts: LoadNuxtConfigOptions): Promise<NuxtO
   return await applyDefaults(NuxtConfigSchema, nuxtConfig as NuxtConfig & Record<string, JSValue>) as unknown as NuxtOptions
 }
 
-async function loadNuxtSchema(cwd: string) {
+async function loadNuxtSchema (cwd: string) {
   const url = directoryToURL(cwd)
   const urls: Array<URL | string> = [url]
   const nuxtPath = resolveModuleURL('nuxt', { try: true, from: url }) ?? resolveModuleURL('nuxt-nightly', { try: true, from: url })
@@ -143,7 +143,7 @@ async function loadNuxtSchema(cwd: string) {
   return await import(schemaPath).then(r => r.NuxtConfigSchema)
 }
 
-async function withDefineNuxtConfig<T>(fn: () => Promise<T>) {
+async function withDefineNuxtConfig<T> (fn: () => Promise<T>) {
   const key = 'defineNuxtConfig'
   const globalSelf = globalThis as any
 
@@ -162,7 +162,7 @@ async function withDefineNuxtConfig<T>(fn: () => Promise<T>) {
   }
 }
 
-function expandWithEnvFilesContent() {
+function expandWithEnvFilesContent () {
   for (const key in process.env) {
     if (key.endsWith('_FILE')) {
       const valueKey = key.slice(0, -'_FILE'.length)

--- a/packages/kit/src/loader/config.ts
+++ b/packages/kit/src/loader/config.ts
@@ -25,7 +25,7 @@ const merger = createDefu((obj, key, value) => {
   }
 })
 
-export async function loadNuxtConfig (opts: LoadNuxtConfigOptions): Promise<NuxtOptions> {
+export async function loadNuxtConfig(opts: LoadNuxtConfigOptions): Promise<NuxtOptions> {
   expandWithEnvFilesContent()
 
   // Automatically detect and import layers from `~~/layers/` directory
@@ -132,7 +132,7 @@ export async function loadNuxtConfig (opts: LoadNuxtConfigOptions): Promise<Nuxt
   return await applyDefaults(NuxtConfigSchema, nuxtConfig as NuxtConfig & Record<string, JSValue>) as unknown as NuxtOptions
 }
 
-async function loadNuxtSchema (cwd: string) {
+async function loadNuxtSchema(cwd: string) {
   const url = directoryToURL(cwd)
   const urls: Array<URL | string> = [url]
   const nuxtPath = resolveModuleURL('nuxt', { try: true, from: url }) ?? resolveModuleURL('nuxt-nightly', { try: true, from: url })
@@ -143,7 +143,7 @@ async function loadNuxtSchema (cwd: string) {
   return await import(schemaPath).then(r => r.NuxtConfigSchema)
 }
 
-async function withDefineNuxtConfig<T> (fn: () => Promise<T>) {
+async function withDefineNuxtConfig<T>(fn: () => Promise<T>) {
   const key = 'defineNuxtConfig'
   const globalSelf = globalThis as any
 
@@ -162,7 +162,7 @@ async function withDefineNuxtConfig<T> (fn: () => Promise<T>) {
   }
 }
 
-function expandWithEnvFilesContent () {
+function expandWithEnvFilesContent() {
   for (const key in process.env) {
     if (key.endsWith('_FILE')) {
       const valueKey = key.slice(0, -'_FILE'.length)
@@ -173,7 +173,9 @@ function expandWithEnvFilesContent () {
       if (filePath && existsSync(filePath)) {
         try {
           process.env[valueKey] = readFileSync(filePath, 'utf-8').trim()
-        } catch { }
+        } catch {
+          console.error(`Failed to read file content from ${filePath}`)
+        }
       }
     }
   }


### PR DESCRIPTION
### 🔗 Linked issue

resolves #32349

### 📚 Description

Add a utility method that checks every env var with the `_FILE` suffix and adds additional values to the process env map.

The PR is created as a draft to receive feedback. I am not sure about the following things:

- Is it ok to check the env var in the Nuxt loader? - I didn't manage to handle such a case in the useRuntimeConfig() function
- Will be ok in case I add the doc about the feature [here](https://nuxt.com/docs/4.x/directory-structure/env)?
