### PR TITLE
refactor(nitro,nuxt,schema): use augments for nitro schema types

### DIFF
--- a/docs/1.getting-started/15.prerendering.md
+++ b/docs/1.getting-started/15.prerendering.md
@@ -54,6 +54,7 @@ Read more about the `nuxt generate` command.
 You can manually specify routes that [Nitro](/docs/4.x/guide/concepts/server-engine) will fetch and pre-render during the build or ignore routes that you don't want to pre-render like `/dynamic` in the `nuxt.config` file:
 
 ```ts twoslash [nuxt.config.ts]
+// @errors: 2353
 export default defineNuxtConfig({
   nitro: {
     prerender: {
@@ -67,6 +68,7 @@ export default defineNuxtConfig({
 You can combine this with the `crawlLinks` option to pre-render a set of routes that the crawler can't discover like your `/sitemap.xml` or `/robots.txt`:
 
 ```ts twoslash [nuxt.config.ts]
+// @errors: 2353
 export default defineNuxtConfig({
   nitro: {
     prerender: {

--- a/docs/1.getting-started/16.deployment.md
+++ b/docs/1.getting-started/16.deployment.md
@@ -98,6 +98,7 @@ In addition to Node.js servers and static hosting services, a Nuxt project can b
 You can explicitly set the desired preset in the [`nuxt.config.ts`](/docs/4.x/directory-structure/nuxt-config) file:
 
 ```ts twoslash [nuxt.config.ts]
+// @errors: 2353
 export default defineNuxtConfig({
   nitro: {
     preset: 'node-server',

--- a/docs/2.directory-structure/3.tsconfig.md
+++ b/docs/2.directory-structure/3.tsconfig.md
@@ -42,6 +42,7 @@ Read more about the different type contexts of a Nuxt project here.
 You can customize the TypeScript configuration of your Nuxt project for each context (`app`, `shared`, `node`, and `server`) in the `nuxt.config.ts` file.
 <!-- @case-police-ignore tsConfig -->
 ```ts twoslash [nuxt.config.ts]
+// @errors: 2353
 export default defineNuxtConfig({
   typescript: {
     // customize tsconfig.app.json

--- a/docs/3.guide/1.concepts/1.rendering.md
+++ b/docs/3.guide/1.concepts/1.rendering.md
@@ -131,6 +131,7 @@ The `200.html` and `404.html` might be useful for the hosting provider you are u
 When prerendering a client-rendered app, Nuxt will generate `index.html`, `200.html` and `404.html` files by default. However, if you need to prevent any (or all) of these files from being generated in your build, you can use the `'prerender:generate'` hook from [Nitro](/docs/4.x/getting-started/prerendering#prerendergenerate-nitro-hook).
 
 ```ts twoslash [nuxt.config.ts]
+// @errors: 2353 7006
 export default defineNuxtConfig({
   ssr: false,
   nitro: {

--- a/packages/nitro-server/src/augments.ts
+++ b/packages/nitro-server/src/augments.ts
@@ -1,9 +1,8 @@
-import type {} from 'nitropack/types'
-
-import type { H3Event } from 'h3'
+import type { Nitro, NitroConfig, NitroDevEventHandler, NitroEventHandler, NitroOptions, NitroRouteConfig, NitroRuntimeConfig, NitroRuntimeConfigApp } from 'nitropack/types'
+import type { EventHandler, H3Event } from 'h3'
 import type { LogObject } from 'consola'
 import type { NuxtIslandContext, NuxtIslandResponse, NuxtRenderHTMLContext } from 'nuxt/app'
-import type { RuntimeConfig } from 'nuxt/schema'
+import type { HookResult, RuntimeConfig, TSReference } from 'nuxt/schema'
 
 declare module 'nitropack' {
   interface NitroRuntimeConfigApp {
@@ -64,6 +63,111 @@ declare module 'nitropack/types' {
     'dev:ssr-logs': (ctx: { logs: LogObject[], path: string }) => void | Promise<void>
     'render:html': (htmlContext: NuxtRenderHTMLContext, context: { event: H3Event }) => void | Promise<void>
     'render:island': (islandResponse: NuxtIslandResponse, context: { event: H3Event, islandContext: NuxtIslandContext }) => void | Promise<void>
+  }
+}
+
+declare module '@nuxt/schema' {
+  interface NuxtHooks {
+    /**
+     * Called when the dev middleware is being registered on the Nitro dev server.
+     * @param handler the Vite or Webpack event handler
+     * @returns Promise
+     */
+    'server:devHandler': (handler: EventHandler) => HookResult
+
+    /**
+     * Called before Nitro writes `.nuxt/tsconfig.server.json`, allowing addition of custom references and declarations.
+     * @param options Objects containing `references`, `declarations`
+     * @returns Promise
+     */
+    'nitro:prepare:types': (options: { references: TSReference[], declarations: string[] }) => HookResult
+    /**
+     * Called before initializing Nitro, allowing customization of Nitro's configuration.
+     * @param nitroConfig The nitro config to be extended
+     * @returns Promise
+     */
+    'nitro:config': (nitroConfig: NitroConfig) => HookResult
+    /**
+     * Called after Nitro is initialized, which allows registering Nitro hooks and interacting directly with Nitro.
+     * @param nitro The created nitro object
+     * @returns Promise
+     */
+    'nitro:init': (nitro: Nitro) => HookResult
+    /**
+     * Called before building the Nitro instance.
+     * @param nitro The created nitro object
+     * @returns Promise
+     */
+    'nitro:build:before': (nitro: Nitro) => HookResult
+    /**
+     * Called after copying public assets. Allows modifying public assets before Nitro server is built.
+     * @param nitro The created nitro object
+     * @returns Promise
+     */
+    'nitro:build:public-assets': (nitro: Nitro) => HookResult
+  }
+
+  interface ConfigSchema {
+    /**
+     * Configuration for Nitro.
+     *
+     * @see [Nitro configuration docs](https://nitro.build/config)
+     */
+    nitro: NitroConfig
+
+    /**
+     * Global route options applied to matching server routes.
+     *
+     * @experimental This is an experimental feature and API may change in the future.
+     *
+     * @see [Nitro route rules documentation](https://nitro.build/config#routerules)
+     */
+    routeRules: NitroConfig['routeRules']
+
+    /**
+     * Nitro server handlers.
+     *
+     * Each handler accepts the following options:
+     * - handler: The path to the file defining the handler. - route: The route under which the handler is available. This follows the conventions of [rou3](https://github.com/h3js/rou3). - method: The HTTP method of requests that should be handled. - middleware: Specifies whether it is a middleware handler. - lazy: Specifies whether to use lazy loading to import the handler.
+     *
+     * @see [`server/` directory documentation](https://nuxt.com/docs/4.x/directory-structure/server)
+     *
+     * @note Files from `server/api`, `server/middleware` and `server/routes` will be automatically registered by Nuxt.
+     *
+     * @example
+     * ```js
+     * serverHandlers: [
+     *   { route: '/path/foo/**:name', handler: '~/server/foohandler.ts' }
+     * ]
+     * ```
+     */
+    serverHandlers: NitroEventHandler[]
+
+    /**
+     * Nitro development-only server handlers.
+     *
+     * @see [Nitro server routes documentation](https://nitro.build/guide/routing)
+     */
+    devServerHandlers: NitroDevEventHandler[]
+  }
+
+  interface NuxtConfig {
+    nitro?: NitroConfig
+  }
+
+  interface RuntimeConfig {
+    app: NitroRuntimeConfigApp
+    /** Only available on the server. */
+    nitro?: NitroRuntimeConfig['nitro']
+  }
+
+  interface NuxtDebugOptions {
+    /** Debug options for Nitro */
+    nitro?: NitroOptions['debug']
+  }
+
+  interface NuxtPage {
+    rules?: NitroRouteConfig
   }
 }
 

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -146,30 +146,32 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
       name: 'nuxt',
       version: nuxtVersion || nitroBuilder.version,
     },
-    imports: {
-      autoImport: nuxt.options.imports.autoImport as boolean,
-      dirs: [...sharedDirs],
-      imports: [
-        {
-          as: '__buildAssetsURL',
-          name: 'buildAssetsURL',
-          from: resolve(distDir, 'runtime/utils/paths'),
+    imports: nuxt.options.experimental.nitroAutoImports === false
+      ? false
+      : {
+          autoImport: nuxt.options.imports.autoImport as boolean,
+          dirs: [...sharedDirs],
+          imports: [
+            {
+              as: '__buildAssetsURL',
+              name: 'buildAssetsURL',
+              from: resolve(distDir, 'runtime/utils/paths'),
+            },
+            {
+              as: '__publicAssetsURL',
+              name: 'publicAssetsURL',
+              from: resolve(distDir, 'runtime/utils/paths'),
+            },
+            {
+              // TODO: Remove after https://github.com/nitrojs/nitro/issues/1049
+              as: 'defineAppConfig',
+              name: 'defineAppConfig',
+              from: resolve(distDir, 'runtime/utils/config'),
+              priority: -1,
+            },
+          ],
+          exclude: [...excludePattern, /[\\/]\.git[\\/]/],
         },
-        {
-          as: '__publicAssetsURL',
-          name: 'publicAssetsURL',
-          from: resolve(distDir, 'runtime/utils/paths'),
-        },
-        {
-          // TODO: Remove after https://github.com/nitrojs/nitro/issues/1049
-          as: 'defineAppConfig',
-          name: 'defineAppConfig',
-          from: resolve(distDir, 'runtime/utils/config'),
-          priority: -1,
-        },
-      ],
-      exclude: [...excludePattern, /[\\/]\.git[\\/]/],
-    },
     esbuild: {
       options: { exclude: excludePattern },
     },
@@ -324,8 +326,9 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
     logLevel: logLevelMapReverse[nuxt.options.logLevel],
   } satisfies NitroConfig)
 
+  // TODO: _remove_ useAppConfig auto import when this is disabled in nuxt v4
   // eslint-disable-next-line @typescript-eslint/no-deprecated
-  if (nuxt.options.experimental.serverAppConfig && nitroConfig.imports) {
+  if (nuxt.options.experimental.serverAppConfig === true && nitroConfig.imports) {
     nitroConfig.imports.imports ||= []
     nitroConfig.imports.imports.push({
       name: 'useAppConfig',
@@ -581,6 +584,22 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
     },
   }
 
+  // Hoist types for nitro implicit dependencies
+  nuxt.options.typescript.hoist.push(
+    // Nitro auto-imported/augmented dependencies
+    'nitro/types',
+    'nitro/runtime',
+    // TODO: remove in v5
+    'nitropack/types',
+    'nitropack/runtime',
+    'nitropack',
+    'defu',
+    'h3',
+    'consola',
+    'ofetch',
+    'crossws',
+  )
+
   // Extend nitro config with hook
   await nuxt.callHook('nitro:config', nitroConfig)
 
@@ -619,6 +638,24 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
     compatibilityDate: nuxt.options.compatibilityDate,
     dotenv: nuxt.options._loadOptions?.dotenv,
   })
+
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
+  if (nuxt.options.experimental.serverAppConfig === false && nitro.options.imports) {
+    nitro.options.imports.presets ||= []
+    nitro.options.imports.presets = nitro.options.imports.presets.map(preset => typeof preset === 'string' || !('imports' in preset)
+      ? preset
+      : ({
+          ...preset,
+          imports: preset.imports.filter(i => i !== 'useAppConfig'),
+        }))
+  }
+
+  // TODO: remove when app manifest support is landed in https://github.com/nuxt/nuxt/pull/21641
+  // Add prerender payload support
+  if (nitro.options.static && nuxt.options.experimental.payloadExtraction === undefined) {
+    logger.warn('Using experimental payload extraction for full-static output. You can opt-out by setting `experimental.payloadExtraction` to `false`.')
+    nuxt.options.experimental.payloadExtraction = true
+  }
 
   // Trigger Nitro reload when SPA loading template changes
   const spaLoadingTemplateFilePath = await spaLoadingTemplatePath(nuxt)

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -7,7 +7,7 @@ import { join, normalize, relative, resolve } from 'pathe'
 import { createDebugger, createHooks } from 'hookable'
 import ignore from 'ignore'
 import type { LoadNuxtOptions } from '@nuxt/kit'
-import { addBuildPlugin, addComponent, addPlugin, addPluginTemplate, addRouteMiddleware, addTypeTemplate, addVitePlugin, getLayerDirectories, installModules, loadNuxtConfig, nuxtCtx, resolveFiles, resolveIgnorePatterns, resolveModuleWithOptions, resolvePath, runWithNuxtContext, useNitro } from '@nuxt/kit'
+import { addBuildPlugin, addComponent, addPlugin, addPluginTemplate, addRouteMiddleware, addTypeTemplate, addVitePlugin, getLayerDirectories, installModules, loadNuxtConfig, nuxtCtx, resolveFiles, resolveIgnorePatterns, resolveModuleWithOptions, resolvePath, runWithNuxtContext } from '@nuxt/kit'
 import type { PackageJson } from 'pkg-types'
 import { readPackageJSON } from 'pkg-types'
 import { hash } from 'ohash'
@@ -763,14 +763,6 @@ export default defineNuxtPlugin({
   // Init nitro
   await bundleServer(nuxt)
 
-  // TODO: remove when app manifest support is landed in https://github.com/nuxt/nuxt/pull/21641
-  // Add prerender payload support
-  const nitro = useNitro()
-  if (nitro.options.static && nuxt.options.experimental.payloadExtraction === undefined) {
-    logger.warn('Using experimental payload extraction for full-static output. You can opt-out by setting `experimental.payloadExtraction` to `false`.')
-    nuxt.options.experimental.payloadExtraction = true
-  }
-
   // Add prerender payload support
   if (nuxt.options.experimental.payloadExtraction) {
     addPlugin(resolve(nuxt.options.appDir, 'plugins/payload.client'))
@@ -865,11 +857,11 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
   }
 
   // Ensure we share key config between Nuxt and Nitro
-  createPortalProperties(options.nitro.runtimeConfig, options, ['nitro.runtimeConfig', 'runtimeConfig'])
-  createPortalProperties(options.nitro.routeRules, options, ['nitro.routeRules', 'routeRules'])
+  const nitroOptions = options.nitro
+  createPortalProperties(nitroOptions.runtimeConfig, options, ['nitro.runtimeConfig', 'runtimeConfig'])
+  createPortalProperties(nitroOptions.routeRules, options, ['nitro.routeRules', 'routeRules'])
 
   // prevent replacement of options.nitro
-  const nitroOptions = options.nitro
   Object.defineProperties(options, {
     nitro: {
       configurable: false,

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -7,7 +7,6 @@ import escapeRE from 'escape-string-regexp'
 import { hash } from 'ohash'
 import { camelCase } from 'scule'
 import { filename, reverseResolveAlias } from 'pathe/utils'
-import type { Nitro } from 'nitropack/types'
 import { useNitro } from '@nuxt/kit'
 
 import { annotatePlugins, checkForCircularDependencies } from './app.ts'

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -545,7 +545,7 @@ export const nuxtConfigTemplate: NuxtTemplate = {
       `export const outdatedBuildInterval = ${ctx.nuxt.options.experimental.checkOutdatedBuildInterval}`,
       `export const multiApp = ${!!ctx.nuxt.options.future.multiApp}`,
       `export const chunkErrorEvent = ${ctx.nuxt.options.experimental.emitRouteChunkError ? ctx.nuxt.options.builder === '@nuxt/vite-builder' ? '"vite:preloadError"' : '"nuxt:preloadError"' : 'false'}`,
-      `export const crawlLinks = ${!!((ctx.nuxt as any)._nitro as Nitro).options.prerender.crawlLinks}`,
+      `export const crawlLinks = ${!!nitro.options.prerender.crawlLinks}`,
       `export const spaLoadingTemplateOutside = ${ctx.nuxt.options.experimental.spaLoadingTemplateLocation === 'body'}`,
       `export const purgeCachedData = ${!!ctx.nuxt.options.experimental.purgeCachedData}`,
       `export const granularCachedData = ${!!ctx.nuxt.options.experimental.granularCachedData}`,

--- a/packages/schema/build.config.ts
+++ b/packages/schema/build.config.ts
@@ -29,8 +29,6 @@ export default defineBuildConfig({
     'hookable',
     'ignore',
     'mini-css-extract-plugin',
-    'nitro',
-    'nitropack',
     'nuxt/app',
     'ofetch',
     'oxc-transform',

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -56,7 +56,6 @@
     "hookable": "5.5.3",
     "ignore": "7.0.5",
     "mini-css-extract-plugin": "2.9.4",
-    "nitropack": "2.12.9",
     "ofetch": "1.5.1",
     "oxc-transform": "0.107.0",
     "postcss": "8.5.6",

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -62,6 +62,7 @@ export default defineResolvers({
     },
   },
   experimental: {
+    runtimeBaseURL: false,
     decorators: false,
     asyncEntry: {
       $resolve: val => typeof val === 'boolean' ? val : false,
@@ -70,7 +71,7 @@ export default defineResolvers({
     // TODO: Remove when nitro has support for mocking traced dependencies
     // https://github.com/nitrojs/nitro/issues/1118
     externalVue: true,
-    serverAppConfig: false,
+    serverAppConfig: true,
     emitRouteChunkError: {
       $resolve: (val) => {
         if (val === true) {
@@ -223,6 +224,11 @@ export default defineResolvers({
     viteEnvironmentApi: {
       $resolve: async (val, get) => {
         return typeof val === 'boolean' ? val : (await get('future.compatibilityVersion')) >= 5
+      },
+    },
+    nitroAutoImports: {
+      $resolve: async (val, get) => {
+        return typeof val === 'boolean' ? val : (await get('future.compatibilityVersion')) < 5
       },
     },
   },

--- a/packages/schema/src/config/typescript.ts
+++ b/packages/schema/src/config/typescript.ts
@@ -19,18 +19,6 @@ export default defineResolvers({
     hoist: {
       $resolve: (val) => {
         const defaults = [
-          // Nitro auto-imported/augmented dependencies
-          'nitro/types',
-          'nitro/runtime',
-          // TODO: remove in v5
-          'nitropack/types',
-          'nitropack/runtime',
-          'nitropack',
-          'defu',
-          'h3',
-          'consola',
-          'ofetch',
-          'crossws',
           // Key nuxt dependencies
           '@unhead/vue',
           '@nuxt/devtools',

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -11,7 +11,8 @@ export type { AppHeadMetaObject, MetaObject, MetaObjectRaw } from './types/head.
 export type { ModuleDefinition, ModuleDependencies, ModuleDependencyMeta, ModuleMeta, ModuleOptions, ModuleSetupInstallResult, ModuleSetupReturn, NuxtModule, ResolvedModuleOptions } from './types/module.ts'
 export type { Nuxt, NuxtApp, NuxtPlugin, NuxtPluginTemplate, NuxtTemplate, NuxtTypeTemplate, NuxtServerTemplate, ResolvedNuxtTemplate } from './types/nuxt.ts'
 export type { RouterConfig, RouterConfigSerializable, RouterOptions } from './types/router.ts'
-export type { NuxtDebugContext, NuxtDebugModuleMutationRecord } from './types/debug.ts'
+export type { ConfigSchema } from './types/schema.ts'
+export type { NuxtDebugContext, NuxtDebugOptions, NuxtDebugModuleMutationRecord } from './types/debug.ts'
 
 // Schema
 export { default as NuxtConfigSchema } from './config/index.ts'

--- a/packages/schema/src/types/config.ts
+++ b/packages/schema/src/types/config.ts
@@ -3,7 +3,6 @@ import type { ServerOptions as ViteServerOptions, UserConfig as ViteUserConfig }
 import type { Options as VuePluginOptions } from '@vitejs/plugin-vue'
 import type { Options as VueJsxPluginOptions } from '@vitejs/plugin-vue-jsx'
 import type { SchemaDefinition } from 'untyped'
-import type { NitroConfig, NitroRuntimeConfig, NitroRuntimeConfigApp } from 'nitropack/types'
 import type { SnakeCase } from 'scule'
 import type { ResolvedConfig } from 'c12'
 import type { ConfigSchema } from './schema.ts'
@@ -39,20 +38,20 @@ type RuntimeConfigNamespace = Record<string, unknown>
 export interface PublicRuntimeConfig extends RuntimeConfigNamespace { }
 
 export interface RuntimeConfig extends RuntimeConfigNamespace {
-  app: NitroRuntimeConfigApp
-  /** Only available on the server. */
-  nitro?: NitroRuntimeConfig['nitro']
   public: PublicRuntimeConfig
 }
 
-// User configuration in `nuxt.config` file
+// Avoid DeepPartial for some problematic config, including:
+// - nitro config interface (#31908) located in packages/nitro-server/src/augments.ts
+// - vite config interface (#4772)
+
+/**
+ * User configuration in `nuxt.config` file
+ */
 export interface NuxtConfig extends DeepPartial<Omit<ConfigSchema, 'components' | 'vue' | 'vite' | 'runtimeConfig' | 'webpack' | 'nitro'>> {
   components?: ConfigSchema['components']
   vue?: Omit<DeepPartial<ConfigSchema['vue']>, 'config'> & { config?: Partial<Filter<VueAppConfig, string | boolean>> }
-  // Avoid DeepPartial for vite config interface (#4772)
   vite?: ConfigSchema['vite']
-  // Avoid DeepPartial for nitro config interface (#31908)
-  nitro?: NitroConfig
   runtimeConfig?: Overrideable<RuntimeConfig>
   webpack?: DeepPartial<ConfigSchema['webpack']> & {
     $client?: DeepPartial<ConfigSchema['webpack']>

--- a/packages/schema/src/types/debug.ts
+++ b/packages/schema/src/types/debug.ts
@@ -1,4 +1,3 @@
-import type { NitroOptions } from 'nitropack/types'
 import type { NuxtModule } from './module.ts'
 
 export interface NuxtDebugContext {
@@ -24,8 +23,6 @@ export interface NuxtDebugOptions {
   modules?: boolean
   /** Debug for file watchers */
   watchers?: boolean
-  /** Debug options for Nitro */
-  nitro?: NitroOptions['debug']
   /** Debug for production hydration mismatch */
   hydration?: boolean
   /** Debug for Vue Router */

--- a/packages/schema/src/types/hooks.ts
+++ b/packages/schema/src/types/hooks.ts
@@ -3,10 +3,8 @@ import type { Server as HttpsServer } from 'node:https'
 import type { TSConfig } from 'pkg-types'
 import type { ViteDevServer } from 'vite'
 import type { Manifest } from 'vue-bundle-renderer'
-import type { EventHandler } from 'h3'
 import type { Import, InlinePreset, Unimport } from 'unimport'
 import type { Compiler, Configuration, Stats } from 'webpack'
-import type { Nitro, NitroConfig, NitroRouteConfig } from 'nitropack/types'
 import type { Schema, SchemaDefinition } from 'untyped'
 import type { RouteLocationRaw, RouteRecordRaw } from 'vue-router'
 import type { RawVueCompilerOptions } from '@vue/language-core'
@@ -26,7 +24,7 @@ export type WatchEvent = 'add' | 'addDir' | 'change' | 'unlink' | 'unlinkDir'
 // thus making the whole `VueTSConfig` type `any`. We only augment TSConfig if RawVueCompilerOptions is available.
 export type VueTSConfig = 0 extends 1 & RawVueCompilerOptions ? TSConfig : TSConfig & { vueCompilerOptions?: RawVueCompilerOptions }
 
-export type NuxtPage = {
+export interface NuxtPage {
   name?: string
   path: string
   props?: RouteRecordRaw['props']
@@ -36,7 +34,6 @@ export type NuxtPage = {
   redirect?: RouteLocationRaw
   children?: NuxtPage[]
   middleware?: string[] | string
-  rules?: NitroRouteConfig
   /**
    * Set the render mode.
    *
@@ -216,13 +213,6 @@ export interface NuxtHooks {
   'pages:routerOptions': (context: { files: Array<{ path: string, optional?: boolean }> }) => HookResult
 
   /**
-   * Called when the dev middleware is being registered on the Nitro dev server.
-   * @param handler the Vite or Webpack event handler
-   * @returns Promise
-   */
-  'server:devHandler': (handler: EventHandler) => HookResult
-
-  /**
    * Called at setup allowing modules to extend sources.
    * @param presets Array containing presets objects
    * @returns Promise
@@ -261,37 +251,6 @@ export interface NuxtHooks {
    */
   'components:extend': (components: Component[]) => HookResult
 
-  // Nitropack
-  /**
-   * Called before Nitro writes `.nuxt/tsconfig.server.json`, allowing addition of custom references and declarations.
-   * @param options Objects containing `references`, `declarations`
-   * @returns Promise
-   */
-  'nitro:prepare:types': (options: { references: TSReference[], declarations: string[] }) => HookResult
-  /**
-   * Called before initializing Nitro, allowing customization of Nitro's configuration.
-   * @param nitroConfig The nitro config to be extended
-   * @returns Promise
-   */
-  'nitro:config': (nitroConfig: NitroConfig) => HookResult
-  /**
-   * Called after Nitro is initialized, which allows registering Nitro hooks and interacting directly with Nitro.
-   * @param nitro The created nitro object
-   * @returns Promise
-   */
-  'nitro:init': (nitro: Nitro) => HookResult
-  /**
-   * Called before building the Nitro instance.
-   * @param nitro The created nitro object
-   * @returns Promise
-   */
-  'nitro:build:before': (nitro: Nitro) => HookResult
-  /**
-   * Called after copying public assets. Allows modifying public assets before Nitro server is built.
-   * @param nitro The created nitro object
-   * @returns Promise
-   */
-  'nitro:build:public-assets': (nitro: Nitro) => HookResult
   /**
    * Allows extending the routes to be pre-rendered.
    * @param ctx Nuxt context

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -9,10 +9,10 @@ import type { DotenvOptions, SourceOptions } from 'c12'
 import type { CompatibilityDateSpec } from 'compatx'
 import type { Options } from 'ignore'
 import type { ChokidarOptions } from 'chokidar'
-import type { H3CorsOptions } from 'h3'
+// @ts-expect-error compatibility import for h3 (v1 + v2)
+import type { CorsOptions, H3CorsOptions } from 'h3'
 import type { NuxtLinkOptions } from 'nuxt/app'
 import type { FetchOptions } from 'ofetch'
-import type { NitroConfig, NitroDevEventHandler, NitroEventHandler } from 'nitropack/types'
 import type { Options as AutoprefixerOptions } from 'autoprefixer'
 import type { Options as CssnanoOptions } from 'cssnano'
 import type { TSConfig } from 'pkg-types'
@@ -982,7 +982,11 @@ export interface ConfigSchema {
     /**
      * Set CORS options for the dev server
      */
-    cors: H3CorsOptions
+    cors: 'origin' extends keyof H3CorsOptions
+      ? 'origin' extends keyof CorsOptions
+        ? CorsOptions | H3CorsOptions
+        : H3CorsOptions
+      : CorsOptions
   }
 
   /**
@@ -1471,6 +1475,18 @@ export interface ConfigSchema {
      * @see https://github.com/KazariEX/dxup
      */
     typescriptPlugin: boolean
+    /**
+     * Whether to add a middleware to handle changes of base URL at runtime (has a performance overhead)
+     *
+     * This option only has effect when using Nitro v3+.
+     */
+    runtimeBaseURL: boolean
+
+    /**
+     * Whether to enable a compatibility layer for Nitro auto imports.
+     * We recommend migrating to direct imports instead.
+     */
+    nitroAutoImports: boolean
   }
 
   /**
@@ -1533,48 +1549,6 @@ export interface ConfigSchema {
   server: {
     builder?: '@nuxt/nitro-server' | (string & {}) | { bundle: (nuxt: Nuxt) => Promise<void> }
   }
-
-  /**
-   * Configuration for Nitro.
-   *
-   * @see [Nitro configuration docs](https://nitro.build/config)
-   */
-  nitro: NitroConfig
-
-  /**
-   * Global route options applied to matching server routes.
-   *
-   * @experimental This is an experimental feature and API may change in the future.
-   *
-   * @see [Nitro route rules documentation](https://nitro.build/config#routerules)
-   */
-  routeRules: NitroConfig['routeRules']
-
-  /**
-   * Nitro server handlers.
-   *
-   * Each handler accepts the following options:
-   * - handler: The path to the file defining the handler. - route: The route under which the handler is available. This follows the conventions of [rou3](https://github.com/h3js/rou3). - method: The HTTP method of requests that should be handled. - middleware: Specifies whether it is a middleware handler. - lazy: Specifies whether to use lazy loading to import the handler.
-   *
-   * @see [`server/` directory documentation](https://nuxt.com/docs/4.x/directory-structure/server)
-   *
-   * @note Files from `server/api`, `server/middleware` and `server/routes` will be automatically registered by Nuxt.
-   *
-   * @example
-   * ```js
-   * serverHandlers: [
-   *   { route: '/path/foo/**:name', handler: '~/server/foohandler.ts' }
-   * ]
-   * ```
-   */
-  serverHandlers: NitroEventHandler[]
-
-  /**
-   * Nitro development-only server handlers.
-   *
-   * @see [Nitro server routes documentation](https://nitro.build/guide/routing)
-   */
-  devServerHandlers: NitroDevEventHandler[]
 
   postcss: {
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -905,9 +905,6 @@ importers:
       mini-css-extract-plugin:
         specifier: 2.9.4
         version: 2.9.4(webpack@5.104.1(esbuild@0.27.2))
-      nitropack:
-        specifier: 2.12.9
-        version: 2.12.9(rolldown@1.0.0-beta.58)
       ofetch:
         specifier: 1.5.1
         version: 1.5.1


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/pull/33005

### 📚 Description

this prepares for https://github.com/nuxt/nuxt/pull/33005 by moving nitro-specific types out of nuxt/schema and into nitro builder.

the aim is to enable people to continue to use nuxt/kit and nuxt/schema _v4_ without requiring a major bump of these dependencies for nuxt v5.