### PR TITLE
fix(nuxt): decode client-side pathname for non-ASCII route aliases

### DIFF
--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -2,7 +2,7 @@ import { isReadonly, reactive, shallowReactive, shallowRef } from 'vue'
 import type { Ref } from 'vue'
 import type { RouteLocationNormalizedLoadedGeneric, Router, RouterScrollBehavior } from 'vue-router'
 import { START_LOCATION, createMemoryHistory, createRouter, createWebHashHistory, createWebHistory } from 'vue-router'
-import { isSamePath, withoutBase } from 'ufo'
+import { decodePath, isSamePath, withoutBase } from 'ufo'
 
 import type { NuxtApp, Plugin, RouteMiddleware } from 'nuxt/app'
 import type { PageMeta } from '../composables'
@@ -35,9 +35,9 @@ function createCurrentLocation (
     let pathFromHash = hash.slice(slicePos)
     // prepend the starting slash to hash so the url starts with /#
     if (pathFromHash[0] !== '/') { pathFromHash = '/' + pathFromHash }
-    return withoutBase(pathFromHash, '')
+    return decodePath(withoutBase(pathFromHash, ''))
   }
-  const displayedPath = withoutBase(pathname, base)
+  const displayedPath = decodePath(withoutBase(pathname, base))
   const path = !renderedPath || isSamePath(displayedPath, renderedPath) ? displayedPath : renderedPath
   return path + (path.includes('?') ? '' : search) + hash
 }

--- a/packages/nuxt/test/__snapshots__/pages-override-meta-disabled.test.ts.snap
+++ b/packages/nuxt/test/__snapshots__/pages-override-meta-disabled.test.ts.snap
@@ -553,6 +553,17 @@
       "redirect": "mockMeta?.redirect",
     },
   ],
+  "should handle unicode characters in alias paths": [
+    {
+      "alias": "["/товары","/produits","/製品"].concat(mockMeta?.alias || [])",
+      "component": "() => import("pages/products.vue")",
+      "meta": "mockMeta || {}",
+      "name": "mockMeta?.name ?? "products"",
+      "path": "mockMeta?.path ?? "/products"",
+      "props": "mockMeta?.props ?? false",
+      "redirect": "mockMeta?.redirect",
+    },
+  ],
   "should merge route.meta with meta from file": [
     {
       "alias": "mockMeta?.alias || []",

--- a/packages/nuxt/test/__snapshots__/pages-override-meta-enabled.test.ts.snap
+++ b/packages/nuxt/test/__snapshots__/pages-override-meta-enabled.test.ts.snap
@@ -348,6 +348,14 @@
       "path": ""/خاص\\:جديد"",
     },
   ],
+  "should handle unicode characters in alias paths": [
+    {
+      "alias": "["/товары","/produits","/製品"]",
+      "component": "() => import("pages/products.vue")",
+      "name": ""products"",
+      "path": ""/products"",
+    },
+  ],
   "should merge route.meta with meta from file": [
     {
       "component": "() => import("pages/page-with-meta.vue")",

--- a/packages/nuxt/test/nitro-ssr-routes.test.ts
+++ b/packages/nuxt/test/nitro-ssr-routes.test.ts
@@ -66,6 +66,7 @@ describe('nitro-ssr-routes', () => {
         "/page1",
         "/",
         "/",
+        "/products",
         "/",
         "/",
         "/page-with-meta",

--- a/packages/nuxt/test/pages.test.ts
+++ b/packages/nuxt/test/pages.test.ts
@@ -836,6 +836,30 @@ export const pageTests: Array<{
     ],
   },
   {
+    description: 'should handle unicode characters in alias paths',
+    files: [
+      {
+        path: `${pagesDir}/products.vue`,
+        template: `
+            <script setup lang="ts">
+            definePageMeta({
+              alias: ['/товары', '/produits', '/製品']
+            })
+            </script>
+          `,
+      },
+    ],
+    output: [
+      {
+        name: 'products',
+        path: '/products',
+        file: `${pagesDir}/products.vue`,
+        alias: ['/товары', '/produits', '/製品'],
+        children: [],
+      },
+    ],
+  },
+  {
     description: 'route without file',
     output: [
       {


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #34042

### 📚 Description

## Problem

Non-ASCII characters in route aliases don't work on the client side. Users have to manually encode aliases:

```js
import { encodePath } from 'ufo'
definePageMeta({
  alias: [encodePath('/товары')] // workaround
})
```

## Root cause

The server decodes incoming URLs via `decodePath(event.path)` in `packages/nitro-server/src/runtime/utils/renderer/app.ts`, but the client uses `window.location.pathname` directly without decoding.

For non-ASCII characters, browsers return encoded paths in `location.pathname` (e.g., `/%D1%82%D0%BE%D0%B2%D0%B0%D1%80%D1%8B` instead of `/товары`), causing a mismatch with decoded aliases.

## Solution

Apply `decodePath` from `ufo` to client-side paths in `createCurrentLocation()` to match server behavior.

## Test plan

- Added test case for unicode characters in alias paths (`/товары`, `/produits`, `/製品`)
- All 707 unit tests pass
