### PR TITLE
fix: Do not recommend installing the Nuxtr VS Code extension

### DIFF
--- a/docs/1.getting-started/02.installation.md
+++ b/docs/1.getting-started/02.installation.md
@@ -27,7 +27,6 @@ Or follow the steps below to set up a new Nuxt project on your computer.
   ::details
   :summary[Additional notes for an optimal setup:]
   - **Node.js**: Make sure to use an even numbered version (20, 22, etc.)
-  - **Nuxtr**: Install the community-developed [Nuxtr extension](https://marketplace.visualstudio.com/items?itemName=Nuxtr.nuxtr-vscode)
   - **WSL**: If you are using Windows and experience slow HMR, you may want to try using [WSL (Windows Subsystem for Linux)](https://learn.microsoft.com/en-us/windows/wsl/install) which may solve some performance issues.
   - **Windows slow DNS resolution**: Instead of using `localhost:3000` for local dev server on Windows, use `127.0.0.1` for much faster loading experience on browsers.
   ::


### PR DESCRIPTION
Removed mention of the Nuxtr extension from installation notes.

Nuxtr had its last release in March 2024 and is not ready for Nuxt 4. There's apparently a rewrite ongoing somewhere, but that's neither ready nor officially announced (see also https://github.com/nuxtrdev/nuxtr-vscode/issues/150).