### PR TITLE
fix(nitro,nuxt): do not import nitro deps in builders

### DIFF
--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -20,6 +20,7 @@ import { defineEventHandler, dynamicEventHandler, handleCors, setHeader } from '
 import { isWindows } from 'std-env'
 import { ImpoundPlugin } from 'impound'
 import { resolveModulePath } from 'exsolve'
+import { runtimeDependencies } from 'nitropack/runtime/meta'
 import './augments.ts'
 
 import nitroBuilder from '../package.json' with { type: 'json' }
@@ -680,6 +681,14 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
   // Expose nitro to modules and kit
   nuxt._nitro = nitro
   await nuxt.callHook('nitro:init', nitro)
+
+  nuxt['~runtimeDependencies'] ||= []
+  nuxt['~runtimeDependencies']!.push(
+    ...runtimeDependencies,
+    'unhead', '@unhead/vue', '@nuxt/devalue', 'unstorage',
+    // ensure we only have one version of vue if nitro is going to inline anyway
+    ...nitro.options.inlineDynamicImports ? ['vue', '@vue/server-renderer'] : [],
+  )
 
   // Connect vfs storages
   nitro.vfs = nuxt.vfs = nitro.vfs || nuxt.vfs || {}

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -34,6 +34,7 @@ import componentsModule from '../components/module.ts'
 import importsModule from '../imports/module.ts'
 
 import { distDir, pkgDir } from '../dirs.ts'
+import { runtimeDependencies } from '../../meta.js'
 import pkg from '../../package.json' with { type: 'json' }
 import { scriptsStubsPreset } from '../imports/presets.ts'
 import { logger } from '../utils.ts'
@@ -248,6 +249,7 @@ async function initNuxt (nuxt: Nuxt) {
 
   const packageJSON = await readPackageJSON(nuxt.options.rootDir).catch(() => ({}) as PackageJson)
   nuxt._dependencies = new Set([...Object.keys(packageJSON.dependencies || {}), ...Object.keys(packageJSON.devDependencies || {})])
+  nuxt['~runtimeDependencies'] = [...runtimeDependencies]
 
   // Set nitro resolutions for types that might be obscured with shamefully-hoist=false
   let paths: Record<string, [string]> | undefined

--- a/packages/schema/src/types/nuxt.ts
+++ b/packages/schema/src/types/nuxt.ts
@@ -88,34 +88,35 @@ export interface NuxtApp {
 
 export interface Nuxt {
   // Private fields.
-  __name: string
-  _version: string
-  _ignore?: Ignore
-  _dependencies?: Set<string>
-  _debug?: NuxtDebugContext
+  '__name': string
+  '_version': string
+  '_ignore'?: Ignore
+  '_dependencies'?: Set<string>
+  '~runtimeDependencies'?: string[]
+  '_debug'?: NuxtDebugContext
   /** Async local storage for current running Nuxt module instance. */
-  _asyncLocalStorageModule?: AsyncLocalStorage<NuxtModule>
+  '_asyncLocalStorageModule'?: AsyncLocalStorage<NuxtModule>
   /**
    * Module options functions collected from moduleDependencies.
    * @internal
    */
-  _moduleOptionsFunctions?: Map<string | NuxtModule, Array<() => { defaults?: Record<string, unknown>, overrides?: Record<string, unknown> }>>
+  '_moduleOptionsFunctions'?: Map<string | NuxtModule, Array<() => { defaults?: Record<string, unknown>, overrides?: Record<string, unknown> }>>
 
   /** The resolved Nuxt configuration. */
-  options: NuxtOptions
-  hooks: Hookable<NuxtHooks>
-  hook: Nuxt['hooks']['hook']
-  callHook: Nuxt['hooks']['callHook']
-  addHooks: Nuxt['hooks']['addHooks']
-  runWithContext: <T extends (...args: any[]) => any>(fn: T) => ReturnType<T>
+  'options': NuxtOptions
+  'hooks': Hookable<NuxtHooks>
+  'hook': Nuxt['hooks']['hook']
+  'callHook': Nuxt['hooks']['callHook']
+  'addHooks': Nuxt['hooks']['addHooks']
+  'runWithContext': <T extends (...args: any[]) => any>(fn: T) => ReturnType<T>
 
-  ready: () => Promise<void>
-  close: () => Promise<void>
+  'ready': () => Promise<void>
+  'close': () => Promise<void>
 
   /** The production or development server. */
-  server?: any
+  'server'?: any
 
-  vfs: Record<string, string>
+  'vfs': Record<string, string>
 
-  apps: Record<string, NuxtApp>
+  'apps': Record<string, NuxtApp>
 }

--- a/packages/vite/src/plugins/resolved-externals.ts
+++ b/packages/vite/src/plugins/resolved-externals.ts
@@ -1,31 +1,15 @@
 import type { Plugin } from 'vite'
-import { tryImportModule, useNitro } from '@nuxt/kit'
 import type { Nuxt } from '@nuxt/schema'
 import { resolveModulePath } from 'exsolve'
 import escapeStringRegexp from 'escape-string-regexp'
-import { runtimeDependencies as runtimeNuxtDependencies } from 'nuxt/meta'
 
 export function ResolveExternalsPlugin (nuxt: Nuxt): Plugin {
   let external: Set<string> = new Set()
-  const nitro = useNitro()
-
   return {
     name: 'nuxt:resolve-externals',
     enforce: 'pre',
-    async config () {
-      const { runtimeDependencies: runtimeNitroDependencies = [] } = await tryImportModule<typeof import('nitropack/runtime/meta')>('nitropack/runtime/meta', {
-        url: new URL(import.meta.url),
-      }) || {}
-
-      external = new Set([
-        // explicit dependencies we use in our ssr renderer - these can be inlined (if necessary) in the nitro build
-        'unhead', '@unhead/vue', '@nuxt/devalue', 'unstorage',
-        // ensure we only have one version of vue if nitro is going to inline anyway
-        ...nitro.options.inlineDynamicImports ? ['vue', '@vue/server-renderer'] : [],
-        ...runtimeNuxtDependencies,
-        // dependencies we might share with nitro - these can be inlined (if necessary) in the nitro build
-        ...runtimeNitroDependencies,
-      ])
+    config () {
+      external = new Set(nuxt['~runtimeDependencies'])
 
       return {
         optimizeDeps: {

--- a/packages/webpack/src/webpack.ts
+++ b/packages/webpack/src/webpack.ts
@@ -1,6 +1,6 @@
 import pify from 'pify'
-import type { H3Event as H3V2Event } from 'h3-next'
 import type { H3Event as H3V1Event } from 'h3'
+import type { H3Event as H3V2Event } from 'h3-next'
 import type { IncomingMessage, MultiWatching, ServerResponse } from 'webpack-dev-middleware'
 import webpackDevMiddleware from 'webpack-dev-middleware'
 import webpackHotMiddleware from 'webpack-hot-middleware'


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

rather than try to resolve nitropack within vite/webpack builders, this moves that responsibility out into a shared property on the nuxt instance