### PR TITLE
fix(nuxt): make createError throwable

### DIFF
--- a/packages/nuxt/src/app/composables/error.ts
+++ b/packages/nuxt/src/app/composables/error.ts
@@ -12,16 +12,21 @@ export const NUXT_ERROR_SIGNATURE = '__nuxt_error'
 /* @__NO_SIDE_EFFECTS__ */
 export const useError = (): Ref<NuxtPayload['error']> => toRef(useNuxtApp().payload, 'error')
 
-// #34138 - `Omit` breaks the Error inheritance chain, causing `@typescript-eslint/only-throw-error` to fail
-// Adding `Error` explicitly restores throwability. TODO: remove `Error` in Nuxt 5 when `Omit` is no longer needed
-export interface NuxtError<DataT = unknown> extends Omit<H3Error<DataT>, 'statusCode' | 'statusMessage'>, Error {
-  error?: true
-  status?: number
-  statusText?: string
+// #34138 - `Omit` breaks the Error inheritance chain for `@typescript-eslint/only-throw-error`
+// TODO: remove in Nuxt 5 when `NuxtError` no longer needs the `Omit` compatibility shape
+// Keep a class type here so `createError()` stays throwable while `createH3Error()` remains the runtime source of truth.
+export class NuxtError<DataT = unknown> extends Error {
+  declare [NUXT_ERROR_SIGNATURE]: true
+  declare error?: true
+  declare data?: DataT
+  declare fatal?: boolean
+  declare unhandled?: boolean
+  declare status?: number
+  declare statusText?: string
   /** @deprecated Use `status` */
-  statusCode?: H3Error<DataT>['statusCode']
+  declare statusCode?: H3Error<DataT>['statusCode']
   /** @deprecated Use `statusText` */
-  statusMessage?: H3Error<DataT>['statusMessage']
+  declare statusMessage?: H3Error<DataT>['statusMessage']
 }
 
 /** @since 3.0.0 */
@@ -30,7 +35,7 @@ export const showError = <DataT = unknown>(
     status?: number
     statusText?: string
   }),
-) => {
+): NuxtError<DataT> => {
   const nuxtError = createError<DataT>(error)
 
   try {
@@ -74,7 +79,7 @@ export const createError = <DataT = unknown>(error: string | Error | Partial<Nux
     error.message ??= (error as Partial<NuxtError<DataT>>).statusText
   }
 
-  const nuxtError: NuxtError<DataT> = createH3Error<DataT>(error)
+  const nuxtError = createH3Error<DataT>(error) as NuxtError<DataT>
 
   Object.defineProperty(nuxtError, NUXT_ERROR_SIGNATURE, {
     value: true,

--- a/test/fixtures/basic-types/app/app-types.ts
+++ b/test/fixtures/basic-types/app/app-types.ts
@@ -155,6 +155,11 @@ describe('aliases', () => {
 })
 
 describe('middleware', () => {
+  it('treats createError as throwable', () => {
+    const error: Error = createError({ statusCode: 404 })
+    expectTypeOf(error).toEqualTypeOf<Error>()
+  })
+
   it('recognizes named middleware', () => {
     definePageMeta({ middleware: 'named' })
     // provided by layer

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -138,7 +138,9 @@ describe('composables', () => {
 
 describe('errors', () => {
   it('createError', () => {
-    expect(createError({ statusCode: 404 }).toJSON()).toMatchInlineSnapshot(`
+    const notFoundError = createError({ statusCode: 404 })
+    expect(notFoundError).toBeInstanceOf(Error)
+    expect(notFoundError.toJSON()).toMatchInlineSnapshot(`
       {
         "message": "",
         "statusCode": 404,


### PR DESCRIPTION
## Summary

- make `createError()` throwable for `@typescript-eslint/only-throw-error`
- keep `createH3Error()` as the runtime source of truth and model `NuxtError` as an `Error` subtype via class/interface merging
- keep the existing `status`/`statusText` compatibility layer
- add minimal runtime and type coverage for the regression

## Validation

- `pnpm vitest run test/nuxt/composables.test.ts`
- dedicated repro in `/Users/maxi/repros/nuxt-34056-create-error`
  - baseline on published `nuxt@4.3.0`: `pnpm lint` fails with `@typescript-eslint/only-throw-error`
  - after `pnpm patch nuxt` with the reduced patch: `pnpm lint` passes

## Notes

- no Vite changes are included here
- `pnpm --filter ./test/fixtures/basic-types test:types` still fails in this worktree because of unrelated existing workspace type issues in `packages/schema` and `packages/vite`

Ref: https://github.com/nuxt/nuxt/issues/34138
