### PR TITLE
docs: clarify catch all notation for `addServerHandler`

### DIFF
--- a/docs/3.guide/4.modules/3.recipes-basics.md
+++ b/docs/3.guide/4.modules/3.recipes-basics.md
@@ -222,6 +222,12 @@ export default defineNuxtModule({
       route: '/api/_my-module/hello/:name',
       handler: resolver.resolve('./runtime/server/api/hello/[name].get'),
     })
+
+    // Or using a catch all route
+    addServerHandler({
+      route: '/api/_my-module/files/**:path',
+      handler: resolver.resolve('./runtime/server/api/files/[...path].get'),
+    })
   },
 })
 ```
@@ -230,6 +236,10 @@ export default defineNuxtModule({
 It is highly recommended to prefix your server routes to avoid conflicts with user-defined routes. Common paths like `/api/auth`, `/api/login`, or `/api/user` may already be used by the application.
 
 :read-more{to="/docs/4.x/guide/modules/best-practices#prefix-your-exports"}
+::
+
+::note
+Nuxt uses H3's [`<Router>`](https://github.com/h3js/rou3) module under the hood to match and handle server routes.
 ::
 
 ## Add Other Assets

--- a/docs/3.guide/4.modules/3.recipes-basics.md
+++ b/docs/3.guide/4.modules/3.recipes-basics.md
@@ -238,10 +238,6 @@ It is highly recommended to prefix your server routes to avoid conflicts with us
 :read-more{to="/docs/4.x/guide/modules/best-practices#prefix-your-exports"}
 ::
 
-::note
-Nuxt uses H3's [`<Router>`](https://github.com/h3js/rou3) module under the hood to match and handle server routes.
-::
-
 ## Add Other Assets
 
 If your module should provide other kinds of assets, they can also be injected. Here's a simple example module injecting a stylesheet through Nuxt's `css` array.


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/34044#issuecomment-3735541159

### 📚 Description

Clarifies route notation for catch all routes when using **addServerHandler** within a module definition. Across the nuxt app there are multiple notations for pages, server routes & server route rules. From the current docs is not clear that **addServerHandler** matches the later. Thanks to  @cernymatej for the guidance.