### PR TITLE
docs: private Vue School video removed

### DIFF
--- a/docs/1.getting-started/10.data-fetching.md
+++ b/docs/1.getting-started/10.data-fetching.md
@@ -814,5 +814,3 @@ const { data } = await useAsyncData((_nuxtApp, { signal }) => {
 const comments = computed(() => data.value?.[0])
 const author = computed(() => data.value?.[1])
 ```
-
-:video-accordion{title="Watch a video from Vue School on parallel data fetching" videoId="1024262536" platform="vimeo"}


### PR DESCRIPTION
### 📚 Description

https://nuxt.com/docs/4.x/getting-started/data-fetching#making-parallel-requests

The VueSchool video is private, so users cannot watch it.
I think there's no point in displaying it here?
