### PR TITLE
fix(nuxt): update NuxtPage when nested NuxtLayout has name=false

### DIFF
--- a/docs/4.api/1.components/3.nuxt-layout.md
+++ b/docs/4.api/1.components/3.nuxt-layout.md
@@ -22,8 +22,8 @@ You can use `<NuxtLayout />` component to activate the `default` layout on `app.
 
 ## Props
 
-- `name`: Specify a layout name to be rendered, can be a string, reactive reference or a computed property. It **must** match the name of the corresponding layout file in the [`app/layouts/`](/docs/4.x/directory-structure/app/layouts) directory.
-  - **type**: `string`
+- `name`: Specify a layout name to be rendered, can be a string, reactive reference or a computed property. It **must** match the name of the corresponding layout file in the [`app/layouts/`](/docs/4.x/directory-structure/app/layouts) directory, or `false` to disable the layout.
+  - **type**: `string | false`
   - **default**: `default`
 
 ```vue [app/pages/index.vue]

--- a/packages/nuxt/src/app/components/nuxt-layout.ts
+++ b/packages/nuxt/src/app/components/nuxt-layout.ts
@@ -143,7 +143,8 @@ const LayoutProvider = defineComponent({
     const name = props.name
     if (props.shouldProvide) {
       provide(LayoutMetaSymbol, {
-        isCurrent: (route: RouteLocationNormalizedLoaded) => name === (route.meta.layout ?? routeRulesMatcher(route.path).appLayout ?? 'default'),
+        // When name=false, always return true so NuxtPage doesn't skip rendering
+        isCurrent: (route: RouteLocationNormalizedLoaded) => name === false || name === (route.meta.layout ?? routeRulesMatcher(route.path).appLayout ?? 'default'),
       })
     }
 

--- a/test/nuxt/nuxt-layout.test.ts
+++ b/test/nuxt/nuxt-layout.test.ts
@@ -189,6 +189,31 @@ describe('NuxtLayout', () => {
     expect.soft(routeChanges).toBe(3)
   })
 
+  it('should update NuxtPage when nested NuxtLayout has name=false', async () => {
+    // Test for https://github.com/nuxt/nuxt/issues/34074
+    // Mount component with nested layouts where inner layout has name=false
+    const nestedEl = await mountSuspended({
+      // @ts-expect-error dynamically-added layout is not typed
+      setup: () => () => h(NuxtLayout, { name: 'layout-1' }, {
+        default: () => h(NuxtLayout, { name: false }, {
+          default: () => h(NuxtPage),
+        }),
+      }),
+    })
+
+    await navigateTo('/layout-1')
+    await flushPromises()
+
+    // Check that the page content shows the current route
+    expect.soft(nestedEl.find('h3').text()).toBe('Current route: /layout-1')
+
+    await navigateTo('/layout-2')
+    await flushPromises()
+
+    // Page content (h3) should update even with name=false on inner layout
+    expect.soft(nestedEl.find('h3').text()).toBe('Current route: /layout-2')
+  })
+
   it.todo('should not change layout before child page resolves', async () => {
     await navigateTo('/layout-1')
     await flushPromises()


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #34074

### 📚 Description
- Fixes `NuxtPage` not re-rendering when navigating between routes with a nested `<NuxtLayout :name="false">`
- When `name=false`, `isCurrent()` now returns `true` so NuxtPage renders normally instead of returning cached vnode


## Tests
- [x] Added unit test for nested `NuxtLayout` with `name=false`
