### PR TITLE
docs: fix transition types

### DIFF
--- a/docs/4.api/6.nuxt-config.md
+++ b/docs/4.api/6.nuxt-config.md
@@ -210,7 +210,7 @@ Default values for layout transitions.
 
 This can be overridden with `definePageMeta` on an individual page. Only JSON-serializable values are allowed.
 
-- **Type**: `boolean`
+- **Type**: `boolean | TransitionProps`
 - **Default:** `false`
 
 **See**: [Vue Transition docs](https://vuejs.org/api/built-in-components#transition)
@@ -221,7 +221,7 @@ Default values for page transitions.
 
 This can be overridden with `definePageMeta` on an individual page. Only JSON-serializable values are allowed.
 
-- **Type**: `boolean`
+- **Type**: `boolean | TransitionProps`
 - **Default:** `false`
 
 **See**: [Vue Transition docs](https://vuejs.org/api/built-in-components#transition)


### PR DESCRIPTION
### 🔗 Linked issue

Resolves https://github.com/nuxt/nuxt/issues/34081

### 📚 Description

Updates the documented types for layoutTransition and pageTransition to have `boolean | TransitionProps`.

Otherwise developers would have to click into the vue transition docs to find the correct documentation.

[related discord thread](https://discord.com/channels/473401852243869706/473407466630152201/1461119584722616506)

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/4.x/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
