### PR TITLE
fix: enable `allowArbitraryExtensions` by default in generated tsconfig

### DIFF
--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -375,6 +375,7 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
       moduleDetection: 'force',
       isolatedModules: true,
       verbatimModuleSyntax: true,
+      allowArbitraryExtensions: true,
       /* Strictness */
       strict: nuxt.options.typescript?.strict ?? true,
       noUncheckedIndexedAccess: true,

--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -427,6 +427,7 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
       moduleDetection: tsConfig.compilerOptions?.moduleDetection,
       isolatedModules: tsConfig.compilerOptions?.isolatedModules,
       verbatimModuleSyntax: tsConfig.compilerOptions?.verbatimModuleSyntax,
+      allowArbitraryExtensions: tsConfig.compilerOptions?.allowArbitraryExtensions,
       /* Strictness */
       strict: tsConfig.compilerOptions?.strict,
       noUncheckedIndexedAccess: tsConfig.compilerOptions?.noUncheckedIndexedAccess,
@@ -461,6 +462,7 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
       moduleDetection: tsConfig.compilerOptions?.moduleDetection,
       isolatedModules: tsConfig.compilerOptions?.isolatedModules,
       verbatimModuleSyntax: tsConfig.compilerOptions?.verbatimModuleSyntax,
+      allowArbitraryExtensions: tsConfig.compilerOptions?.allowArbitraryExtensions,
       /* Strictness */
       strict: tsConfig.compilerOptions?.strict,
       noUncheckedIndexedAccess: tsConfig.compilerOptions?.noUncheckedIndexedAccess,

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -246,6 +246,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
           lib: ['esnext', 'webworker', 'dom.iterable'],
           skipLibCheck: true,
           noUncheckedIndexedAccess: true,
+          allowArbitraryExtensions: true,
         },
         include: [
           join(nuxt.options.buildDir, 'types/nitro-nuxt.d.ts'),


### PR DESCRIPTION
### 🔗 Linked issue

Resolve #34083

### 📚 Description

The PR enabled `allowArbitraryExtensions` by default in all generated TSConfig, include `tsconfig.app.json`, `tsconfig.server.json`, `tsconfig.node.json`, `tsconfig.shared.json` and the legacy `tsconfig.json`.

