### PR TITLE
docs: add info about runtime directories + type checking

### DIFF
--- a/docs/2.directory-structure/1.modules.md
+++ b/docs/2.directory-structure/1.modules.md
@@ -18,7 +18,7 @@ You don't need to add those local modules to your [`nuxt.config.ts`](/docs/4.x/d
 ```ts twoslash [modules/hello/index.ts]
 // `nuxt/kit` is a helper subpath import you can use when defining local modules
 // that means you do not need to add `@nuxt/kit` to your project's dependencies
-import { addServerHandler, createResolver, defineNuxtModule } from 'nuxt/kit'
+import { addServerHandler, createResolver, defineNuxtModule, addComponentsDir } from 'nuxt/kit'
 
 export default defineNuxtModule({
   meta: {
@@ -31,6 +31,12 @@ export default defineNuxtModule({
     addServerHandler({
       route: '/api/hello',
       handler: resolver.resolve('./runtime/api-route'),
+    })
+
+    // Add components
+    addComponentsDir({
+      path: resolver.resolve('./runtime/app/components'),
+      pathPrefix: true // Prefix your exports to avoid conflicts with user code or other modules
     })
   },
 })
@@ -45,6 +51,10 @@ export default defineEventHandler(() => {
 ::
 
 When starting Nuxt, the `hello` module will be registered and the `/api/hello` route will be available.
+
+::note
+Note that all components/pages/composables and other files that should be normally placed in `app` folder need to be in `/modules/your-module/runtime/app/components`. This will properly set TS types for both Vue/Nuxt utils and your module files.
+::
 
 Modules are executed in the following sequence:
 - First, the modules defined in [`nuxt.config.ts`](/docs/4.x/api/nuxt-config#modules-1) are loaded.

--- a/docs/2.directory-structure/1.modules.md
+++ b/docs/2.directory-structure/1.modules.md
@@ -53,7 +53,7 @@ export default defineEventHandler(() => {
 When starting Nuxt, the `hello` module will be registered and the `/api/hello` route will be available.
 
 ::note
-Note that all components/pages/composables and other files that should be normally placed in `app` folder need to be in `/modules/your-module/runtime/app/components`. This will properly set TS types for both Vue/Nuxt utils and your module files.
+Note that all components, pages, composables and other files that would be normally placed in your `app/` folder need to be in `/modules/your-module/runtime/app/`. This will mean they can be type checked properly.
 ::
 
 Modules are executed in the following sequence:

--- a/docs/2.directory-structure/1.modules.md
+++ b/docs/2.directory-structure/1.modules.md
@@ -53,7 +53,7 @@ export default defineEventHandler(() => {
 When starting Nuxt, the `hello` module will be registered and the `/api/hello` route will be available.
 
 ::note
-Note that all components, pages, composables and other files that would be normally placed in your `app/` folder need to be in `/modules/your-module/runtime/app/`. This will mean they can be type checked properly.
+Note that all components, pages, composables and other files that would be normally placed in your `app/` folder need to be in `runtime/app/`. This will mean they can be type checked properly.
 ::
 
 Modules are executed in the following sequence:

--- a/docs/2.directory-structure/1.modules.md
+++ b/docs/2.directory-structure/1.modules.md
@@ -53,7 +53,7 @@ export default defineEventHandler(() => {
 When starting Nuxt, the `hello` module will be registered and the `/api/hello` route will be available.
 
 ::note
-Note that all components, pages, composables and other files that would be normally placed in your `app/` folder need to be in `modules/your-module/runtime/app/`. This will mean they can be type checked properly.
+Note that all components, pages, composables and other files that would be normally placed in your `app/` directory need to be in `modules/your-module/runtime/app/`. This ensures they can be type-checked properly.
 ::
 
 Modules are executed in the following sequence:

--- a/docs/2.directory-structure/1.modules.md
+++ b/docs/2.directory-structure/1.modules.md
@@ -53,7 +53,7 @@ export default defineEventHandler(() => {
 When starting Nuxt, the `hello` module will be registered and the `/api/hello` route will be available.
 
 ::note
-Note that all components, pages, composables and other files that would be normally placed in your `app/` folder need to be in `runtime/app/`. This will mean they can be type checked properly.
+Note that all components, pages, composables and other files that would be normally placed in your `app/` folder need to be in `modules/your-module/runtime/app/`. This will mean they can be type checked properly.
 ::
 
 Modules are executed in the following sequence:

--- a/docs/3.guide/4.modules/3.recipes-basics.md
+++ b/docs/3.guide/4.modules/3.recipes-basics.md
@@ -100,7 +100,7 @@ export default defineNuxtModule({
     addComponent({
       name: 'MySuperComponent', // name of the component to be used in vue templates
       export: 'MySuperComponent', // (optional) if the component is a named (rather than default) export
-      filePath: resolver.resolve('runtime/components/MySuperComponent.vue'),
+      filePath: resolver.resolve('runtime/app/components/MySuperComponent.vue'),
     })
 
     // From a library
@@ -123,7 +123,7 @@ export default defineNuxtModule({
     const resolver = createResolver(import.meta.url)
 
     addComponentsDir({
-      path: resolver.resolve('runtime/components'),
+      path: resolver.resolve('runtime/app/components'),
     })
   },
 })
@@ -133,6 +133,10 @@ export default defineNuxtModule({
 It is highly recommended to prefix your exports to avoid conflicts with user code or other modules.
 
 :read-more{to="/docs/4.x/guide/modules/best-practices#prefix-your-exports"}
+::
+
+::note
+Note that all components, pages, composables and other files that would be normally placed in your `app/` folder need to be in `/modules/your-module/runtime/app/`. This will mean they can be type checked properly.
 ::
 
 ## Add Composables
@@ -149,7 +153,7 @@ export default defineNuxtModule({
     addImports({
       name: 'useComposable', // name of the composable to be used
       as: 'useMyComposable', // optional alias that will be available for the consuming apps
-      from: resolver.resolve('runtime/composables/useComposable'), // path of composable
+      from: resolver.resolve('runtime/app/composables/useComposable'), // path of composable
     })
   },
 })
@@ -190,6 +194,10 @@ export default defineNuxtModule({
 It is highly recommended to prefix your exports to avoid conflicts with user code or other modules.
 
 :read-more{to="/docs/4.x/guide/modules/best-practices#prefix-your-exports"}
+::
+
+::note
+Note that all components, pages, composables and other files that would be normally placed in your `app/` folder need to be in `/modules/your-module/runtime/app/`. This will mean they can be type checked properly.
 ::
 
 ## Add Server Routes

--- a/docs/3.guide/4.modules/3.recipes-basics.md
+++ b/docs/3.guide/4.modules/3.recipes-basics.md
@@ -136,7 +136,7 @@ It is highly recommended to prefix your exports to avoid conflicts with user cod
 ::
 
 ::note
-Note that all components, pages, composables and other files that would be normally placed in your `app/` folder need to be in `/modules/your-module/runtime/app/`. This will mean they can be type checked properly.
+Note that all components, pages, composables and other files that would be normally placed in your `app/` folder need to be in `runtime/app/`. This will mean they can be type checked properly.
 ::
 
 ## Add Composables

--- a/docs/3.guide/4.modules/3.recipes-basics.md
+++ b/docs/3.guide/4.modules/3.recipes-basics.md
@@ -197,7 +197,7 @@ It is highly recommended to prefix your exports to avoid conflicts with user cod
 ::
 
 ::note
-Note that all components, pages, composables and other files that would be normally placed in your `app/` folder need to be in `/modules/your-module/runtime/app/`. This will mean they can be type checked properly.
+Note that all components, pages, composables and other files that would be normally placed in your `app/` folder need to be in `runtime/app/`. This will mean they can be type checked properly.
 ::
 
 ## Add Server Routes


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

Resolves #34095

### 📚 Description

Add info about runtime app to local module to fix the TS issue.

@danielroe please let me know if I should update https://nuxt.com/docs/4.x/guide/modules/recipes-basics#add-components as there seems to be not already about runtime but there is no mention about `runtime/app/components`. If you believe that it should be changed as well, I will make add it there as well :)
