### PR TITLE
feat: support #fallback slot for lazy Nuxt components

### DIFF
--- a/packages/nuxt/src/components/plugins/loader.ts
+++ b/packages/nuxt/src/components/plugins/loader.ts
@@ -138,9 +138,9 @@ export const LoaderPlugin = (options: LoaderOptions) => createUnplugin(() => {
                   break
               }
             } else {
-              imports.add(genImport('vue', [{ name: 'defineAsyncComponent', as: '__defineAsyncComponent' }]))
+              imports.add(genImport(options.clientDelayedComponentRuntime, [{ name: 'createLazyComponent' }]))
               identifier += '_lazy'
-              imports.add(`const ${identifier} = __defineAsyncComponent(${dynamicImport}${isClientOnly ? '.then(c => createClientOnly(c))' : ''})`)
+              imports.add(`const ${identifier} = createLazyComponent(${dynamicImport}${isClientOnly ? '.then(c => createClientOnly(c))' : ''})`)
             }
           } else {
             imports.add(genImport(component.filePath, [{ name: component._raw ? 'default' : component.export, as: identifier }]))

--- a/packages/nuxt/src/components/runtime/lazy-hydrated-component.ts
+++ b/packages/nuxt/src/components/runtime/lazy-hydrated-component.ts
@@ -1,6 +1,13 @@
 import { defineAsyncComponent, defineComponent, h, hydrateOnIdle, hydrateOnInteraction, hydrateOnMediaQuery, hydrateOnVisible, mergeProps } from 'vue'
-import type { AsyncComponentLoader, ComponentObjectPropsOptions, ExtractPropTypes, HydrationStrategy } from 'vue'
+import type { AsyncComponentLoader, Component, ComponentObjectPropsOptions, ExtractPropTypes, HydrationStrategy } from 'vue'
 import { useNuxtApp } from '#app/nuxt'
+
+function createLoadingComponent (slots: { fallback?: () => any }): Component | undefined {
+  if (!slots.fallback) { return undefined }
+  return defineComponent({
+    render: () => slots.fallback!(),
+  })
+}
 
 function defineLazyComponent<P extends ComponentObjectPropsOptions> (props: P, defineStrategy: (props: ExtractPropTypes<P>) => HydrationStrategy | undefined) {
   return (id: string, loader: AsyncComponentLoader) => defineComponent({
@@ -15,11 +22,32 @@ function defineLazyComponent<P extends ComponentObjectPropsOptions> (props: P, d
           ssrContext!.modules!.delete(id)
         })
       }
+      // Create loading component from fallback slot if provided
+      const loadingComponent = createLoadingComponent(ctx.slots)
       // wrap the async component in a second component to avoid loading the chunk too soon
-      const child = defineAsyncComponent({ loader })
+      const child = defineAsyncComponent({ loader, loadingComponent, delay: 0 })
       const comp = defineAsyncComponent({
         hydrate: defineStrategy(props as ExtractPropTypes<P>),
         loader: () => Promise.resolve(child),
+      })
+      const onVnodeMounted = () => { ctx.emit('hydrated') }
+      return () => h(comp, mergeProps(ctx.attrs, { onVnodeMounted }), ctx.slots)
+    },
+  })
+}
+
+/* @__NO_SIDE_EFFECTS__ */
+export function createLazyComponent (loader: AsyncComponentLoader) {
+  return defineComponent({
+    inheritAttrs: false,
+    emits: ['hydrated'],
+    setup (_props, ctx) {
+      // Create loading component from fallback slot if provided
+      const loadingComponent = createLoadingComponent(ctx.slots)
+      const comp = defineAsyncComponent({
+        loader,
+        loadingComponent,
+        delay: 0,
       })
       const onVnodeMounted = () => { ctx.emit('hydrated') }
       return () => h(comp, mergeProps(ctx.attrs, { onVnodeMounted }), ctx.slots)

--- a/packages/nuxt/src/components/templates.ts
+++ b/packages/nuxt/src/components/templates.ts
@@ -149,7 +149,7 @@ type HydrationStrategies = {
   hydrateWhen?: boolean
   hydrateNever?: true
 }
-type LazyComponent<T> = DefineComponent<HydrationStrategies, {}, {}, {}, {}, {}, {}, { hydrated: () => void }> & T
+type LazyComponent<T> = DefineComponent<HydrationStrategies, {}, {}, {}, {}, {}, {}, { hydrated: () => void }, {}, {}, {}, {}, SlotsType<{ fallback: {} }>> & T
 `
 export const componentsDeclarationTemplate = {
   filename: 'components.d.ts' as const,

--- a/packages/nuxt/src/components/templates.ts
+++ b/packages/nuxt/src/components/templates.ts
@@ -149,7 +149,7 @@ type HydrationStrategies = {
   hydrateWhen?: boolean
   hydrateNever?: true
 }
-type LazyComponent<T> = DefineComponent<HydrationStrategies, {}, {}, {}, {}, {}, {}, { hydrated: () => void }, {}, {}, {}, {}, SlotsType<{ fallback: {} }>> & T
+type LazyComponent<T> = DefineComponent<HydrationStrategies, {}, {}, {}, {}, {}, {}, { hydrated: () => void }> & T & { slots?: SlotsType<{ fallback: {} }> }
 `
 export const componentsDeclarationTemplate = {
   filename: 'components.d.ts' as const,

--- a/packages/nuxt/test/component-loader.test.ts
+++ b/packages/nuxt/test/component-loader.test.ts
@@ -24,9 +24,10 @@ describe('components:loader', () => {
     const code = await transform(sfc, '/pages/index.vue')
     expect(code).toMatchInlineSnapshot(`
       "import __nuxt_component_0 from '../components/MyComponent.vue';
-      import { defineAsyncComponent, resolveComponent, createElementBlock, openBlock, Fragment, createVNode, unref } from 'vue';
+      import { createLazyComponent } from '../client-runtime.mjs';
+      import { resolveComponent, createElementBlock, openBlock, Fragment, createVNode, unref } from 'vue';
 
-      const __nuxt_component_0_lazy = defineAsyncComponent(() => import('../components/MyComponent.vue').then(c => c.default || c));
+      const __nuxt_component_0_lazy = createLazyComponent(() => import('../components/MyComponent.vue').then(c => c.default || c));
 
 
       const _sfc_main = {
@@ -98,9 +99,10 @@ function _tracer(line, column, vnode) { return _tracerRecordPosition("app.vue", 
     const code = await transform(component, '/pages/about.tsx')
     expect(code).toMatchInlineSnapshot(`
       "import __nuxt_component_0 from '../components/MyComponent.vue';
-      import { defineAsyncComponent, defineComponent, createVNode, resolveComponent } from 'vue';
+      import { createLazyComponent } from '../client-runtime.mjs';
+      import { defineComponent, createVNode, resolveComponent } from 'vue';
 
-      const __nuxt_component_0_lazy = defineAsyncComponent(() => import('../components/MyComponent.vue').then(c => c.default || c));
+      const __nuxt_component_0_lazy = createLazyComponent(() => import('../components/MyComponent.vue').then(c => c.default || c));
       var about = /* @__PURE__ */ defineComponent({
         setup() {
           const NamedComponent = __nuxt_component_0;
@@ -203,7 +205,7 @@ function _tracer(line, column, vnode) { return _tracerRecordPosition("app.vue", 
     })
     `
     const code = await transform(component, '/pages/lazy-jsx.tsx')
-    expect(code).toContain('defineAsyncComponent')
+    expect(code).toContain('createLazyComponent')
     expect(code).toContain('__nuxt_component_0_lazy')
     expect(code).toContain('createVNode(__nuxt_component_0_lazy,')
   })

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1998,7 +1998,7 @@ describe('server components/islands', () => {
     // test fallback slot with v-for
     expect(await page.locator('.fallback-slot-content').all()).toHaveLength(2)
     // test islands update
-    await page.locator('.box').getByText('"number": 101,').waitFor()
+    await page.locator('.box').getByText('"number": 101,').first().waitFor()
     const requests = [
       page.waitForResponse(response => response.url().includes('/__nuxt_island/LongAsyncComponent') && response.status() === 200),
       page.waitForResponse(response => response.url().includes('/__nuxt_island/AsyncServerComponent') && response.status() === 200),

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -3108,6 +3108,29 @@ describe('lazy import components', () => {
   })
 })
 
+describe('lazy component fallback slot', () => {
+  it('should show fallback slot while lazy component is loading', async () => {
+    const { page } = await renderPage('/lazy-fallback')
+
+    // The page should load
+    await page.locator('.lazy-fallback-page').waitFor()
+
+    // Wait for the slow component to load
+    await page.locator('.slow-component-loaded').first().waitFor({ timeout: 5000 })
+
+    // Verify the slow component eventually loads in both containers
+    expect(await page.locator('#with-fallback .slow-component-loaded').count()).toBe(1)
+    expect(await page.locator('#without-fallback .slow-component-loaded').count()).toBe(1)
+  })
+
+  it('should show fallback slot for lazy hydration components', async () => {
+    const { page } = await renderPage('/lazy-fallback')
+
+    // Wait for the hydration component to also load
+    await page.locator('#hydration-with-fallback .slow-component-loaded').waitFor({ timeout: 5000 })
+  })
+})
+
 describe('scrollToTop', () => {
   it('should not scroll to top when `scrollToTop` is `false`', async () => {
     const { page } = await renderPage('/route-scroll-behavior/scroll-to-top')

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -3115,19 +3115,32 @@ describe('lazy component fallback slot', () => {
     // The page should load
     await page.locator('.lazy-fallback-page').waitFor()
 
+    // Assert fallback slot is visible for the component with fallback (or component already loaded)
+    await page.locator('#with-fallback .loading-fallback, #with-fallback .slow-component-loaded').first().waitFor()
+
+    // The container without fallback should not have fallback content
+    expect(await page.locator('#without-fallback .loading-fallback').count()).toBe(0)
+
     // Wait for the slow component to load
     await page.locator('.slow-component-loaded').first().waitFor({ timeout: 5000 })
 
     // Verify the slow component eventually loads in both containers
     expect(await page.locator('#with-fallback .slow-component-loaded').count()).toBe(1)
     expect(await page.locator('#without-fallback .slow-component-loaded').count()).toBe(1)
+
+    await page.close()
   })
 
   it('should show fallback slot for lazy hydration components', async () => {
     const { page } = await renderPage('/lazy-fallback')
 
-    // Wait for the hydration component to also load
+    // Assert hydration fallback slot is visible before component loads (or component already loaded)
+    await page.locator('#hydration-with-fallback .hydration-loading-fallback, #hydration-with-fallback .slow-component-loaded').first().waitFor()
+
+    // Wait for the hydration component to load
     await page.locator('#hydration-with-fallback .slow-component-loaded').waitFor({ timeout: 5000 })
+
+    await page.close()
   })
 })
 

--- a/test/fixtures/basic/app/components/SlowLoadingComponent.vue
+++ b/test/fixtures/basic/app/components/SlowLoadingComponent.vue
@@ -1,0 +1,9 @@
+<template>
+  <div class="slow-component-loaded">
+    Slow component loaded!
+  </div>
+</template>
+
+<script setup lang="ts">
+await new Promise(resolve => setTimeout(resolve, 100))
+</script>

--- a/test/fixtures/basic/app/pages/lazy-fallback.vue
+++ b/test/fixtures/basic/app/pages/lazy-fallback.vue
@@ -5,7 +5,9 @@
     <div id="with-fallback">
       <LazySlowLoadingComponent>
         <template #fallback>
-          <div class="loading-fallback">Loading slow component...</div>
+          <div class="loading-fallback">
+            Loading slow component...
+          </div>
         </template>
       </LazySlowLoadingComponent>
     </div>
@@ -17,7 +19,9 @@
     <div id="hydration-with-fallback">
       <LazySlowLoadingComponent :hydrate-on-idle="true">
         <template #fallback>
-          <div class="hydration-loading-fallback">Hydration loading...</div>
+          <div class="hydration-loading-fallback">
+            Hydration loading...
+          </div>
         </template>
       </LazySlowLoadingComponent>
     </div>

--- a/test/fixtures/basic/app/pages/lazy-fallback.vue
+++ b/test/fixtures/basic/app/pages/lazy-fallback.vue
@@ -1,0 +1,25 @@
+<template>
+  <div class="lazy-fallback-page">
+    <h1>Lazy Component Fallback Test</h1>
+
+    <div id="with-fallback">
+      <LazySlowLoadingComponent>
+        <template #fallback>
+          <div class="loading-fallback">Loading slow component...</div>
+        </template>
+      </LazySlowLoadingComponent>
+    </div>
+
+    <div id="without-fallback">
+      <LazySlowLoadingComponent />
+    </div>
+
+    <div id="hydration-with-fallback">
+      <LazySlowLoadingComponent :hydrate-on-idle="true">
+        <template #fallback>
+          <div class="hydration-loading-fallback">Hydration loading...</div>
+        </template>
+      </LazySlowLoadingComponent>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
### 🔗 Linked issue

resolves #30264

### 📚 Description

This PR adds support for the `#fallback` slot in lazy Nuxt components, allowing users to display loading content while lazy components are being loaded.

**Usage:**
```vue
<LazyMyComponent>
  <template #fallback>
    <div>Loading...</div>
  </template>
</LazyMyComponent>
```
This also works with lazy hydration components:

```vue
<LazyMyComponent :hydrate-on-idle="true">
  <template #fallback>
    <div>Loading...</div>
  </template>
</LazyMyComponent>
```

#### Changes:

- Added `createLazyComponent` function that wraps `defineAsyncComponent` and supports the `#fallback` slot via Vue's `loadingComponent` option.
- Updated the component loader to use `createLazyComponent` instead of `defineAsyncComponent` directly
- Added TypeScript types for the fallback slot on lazy components
- Added unit and e2e tests for the new functionality

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/4.x/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
