### PR TITLE
feat(nuxt): add serializer to `useState` for custom read/write 

### DIFF
--- a/.idea/nuxt.iml
+++ b/.idea/nuxt.iml
@@ -11,6 +11,7 @@
       <excludeFolder url="file://$MODULE_DIR$/test/fixtures/minimal/.nuxt-inline" />
       <excludeFolder url="file://$MODULE_DIR$/test/fixtures/minimal/.output" />
       <excludeFolder url="file://$MODULE_DIR$/test/fixtures/minimal/.output-inline" />
+      <excludeFolder url="file://$MODULE_DIR$/test/fixtures/basic/.output" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/packages/nuxt/src/app/composables/state.ts
+++ b/packages/nuxt/src/app/composables/state.ts
@@ -1,7 +1,14 @@
-import { isRef, toRef } from 'vue'
+import { computed, isRef, toRef } from 'vue'
 import type { Ref } from 'vue'
 import { useNuxtApp } from '../nuxt'
 import { toArray } from '../utils'
+
+type UseStateOptions<T> = {
+  serializer?: {
+    read: (value: any) => T
+    write: (value: T) => unknown
+  }
+}
 
 const useStateKeyPrefix = '$s'
 /**
@@ -9,13 +16,15 @@ const useStateKeyPrefix = '$s'
  * @since 3.0.0
  * @param key a unique key ensuring that data fetching can be properly de-duplicated across requests
  * @param init a function that provides initial value for the state when it's not initiated
+ * @param options options to transform the state on get/set
  */
-export function useState<T> (key?: string, init?: (() => T | Ref<T>)): Ref<T>
-export function useState<T> (init?: (() => T | Ref<T>)): Ref<T>
+export function useState<T> (key?: string, init?: (() => T | Ref<T>), options?: UseStateOptions<T>): Ref<T>
+export function useState<T> (init?: (() => T | Ref<T>), options?: UseStateOptions<T>): Ref<T>
 export function useState<T> (...args: any): Ref<T> {
   const autoKey = typeof args[args.length - 1] === 'string' ? args.pop() : undefined
   if (typeof args[0] !== 'string') { args.unshift(autoKey) }
-  const [_key, init] = args as [string, (() => T | Ref<T>)]
+  const [_key, init, options = {}] = args as [string, (() => T | Ref<T>), UseStateOptions<T>]
+
   if (!_key || typeof _key !== 'string') {
     throw new TypeError('[nuxt] [useState] key must be a string: ' + _key)
   }
@@ -25,12 +34,24 @@ export function useState<T> (...args: any): Ref<T> {
   const key = useStateKeyPrefix + _key
 
   const nuxtApp = useNuxtApp()
-  const state = toRef(nuxtApp.payload.state, key)
-  if (state.value === undefined && init) {
+  const _state = toRef(nuxtApp.payload.state, key)
+
+  const serializerWrite = options.serializer?.write || ((v: T) => v)
+  const serializerRead = options.serializer?.read || ((v: any) => v as T)
+
+  const state = computed<T>({
+    get () {
+      return serializerRead(_state.value)
+    },
+    set (value) {
+      _state.value = serializerWrite(value)
+    },
+  })
+  if (_state.value === undefined && init) {
     const initialValue = init()
     if (isRef(initialValue)) {
       // vue will unwrap the ref for us
-      nuxtApp.payload.state[key] = initialValue
+      nuxtApp.payload.state[key] = serializerWrite(initialValue.value)
       return initialValue as Ref<T>
     }
     state.value = initialValue

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -209,6 +209,39 @@ describe('useState', () => {
   it('registers state in payload', () => {
     useState('key', () => 'value')
     expect(Object.entries(useNuxtApp().payload.state)).toContainEqual(['$skey', 'value'])
+    useState('keyNumber', () => 1)
+    expect(Object.entries(useNuxtApp().payload.state)).toContainEqual(['$skeyNumber', 1])
+  })
+
+  it('should accept serializer options', () => {
+    const state = useState('transform', () => 1, {
+      serializer: {
+        write (v) {
+          return String(v)
+        },
+        read (v) {
+          return Number(v)
+        },
+      },
+    })
+    expect(Object.entries(useNuxtApp().payload.state)).toContainEqual(['$stransform', '1'])
+    expect(state.value).toBe(1)
+
+    const nonPojo = useState('serialize-non-pojo', () => new Intl.Locale('de-DE'), {
+      serializer: {
+        write (v) {
+          return v.maximize().toString()
+        },
+        read (v) {
+          return new Intl.Locale(v)
+        },
+      },
+    })
+    expect(Object.entries(useNuxtApp().payload.state)).toContainEqual(['$sserialize-non-pojo', 'de-Latn-DE'])
+    expect(nonPojo.value.baseName).toBe('de-Latn-DE')
+    nonPojo.value = new Intl.Locale('fr-FR', { calendar: 'gregory' })
+    expect(Object.entries(useNuxtApp().payload.state)).toContainEqual(['$sserialize-non-pojo', 'fr-Latn-FR-u-ca-gregory'])
+    expect(nonPojo.value.baseName).toBe('fr-Latn-FR')
   })
 })
 


### PR DESCRIPTION
### 📚 Description

I was wondering why there is no serializer option for `useState` so I quickly wrote one. 

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

### ToDos

- [ ] approve direction
- [ ] write docs
- [ ] maybe add serializer to `useCookie` an other composables using `useState`

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/4.x/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
