### PR TITLE
fix(nuxt): `useCookie` cannot serialize all class instances

### DIFF
--- a/packages/nuxt/src/app/composables/cookie.ts
+++ b/packages/nuxt/src/app/composables/cookie.ts
@@ -5,7 +5,6 @@ import { parse, serialize } from 'cookie-es'
 import { deleteCookie, getCookie, getRequestHeader, setCookie } from 'h3'
 import type { H3Event } from 'h3'
 import destr from 'destr'
-import { klona } from 'klona'
 import { useNuxtApp } from '../nuxt'
 import { useRequestEvent } from './ssr'
 

--- a/packages/nuxt/src/app/composables/cookie.ts
+++ b/packages/nuxt/src/app/composables/cookie.ts
@@ -89,7 +89,7 @@ export function useCookie<T = string | null | undefined> (name: string, _opts?: 
     }
     const callback = (force = false) => {
       if (!force) {
-        if (opts.readonly || isEqual(cookie.value, cookies[name])) { return }
+        if (opts.readonly || isEqual(cookie.value, cookies[name] as T)) { return }
       }
       writeClientCookie(name, cookie.value, opts as CookieSerializeOptions)
 
@@ -153,11 +153,11 @@ export function useCookie<T = string | null | undefined> (name: string, _opts?: 
   } else if (import.meta.server) {
     const nuxtApp = useNuxtApp()
     const writeFinalCookieValue = () => {
-      if (opts.readonly || isEqual(cookie.value, cookies[name])) { return }
+      if (opts.readonly || isEqual(cookie.value, cookies[name] as T)) { return }
       nuxtApp._cookies ||= {}
       if (name in nuxtApp._cookies) {
         // do not append a second `set-cookie` header
-        if (isEqual(cookie.value, nuxtApp._cookies[name])) { return }
+        if (isEqual(cookie.value, nuxtApp._cookies[name] as T)) { return }
         // warn in dev mode
         if (import.meta.dev) {
           console.warn(`[nuxt] cookie \`${name}\` was previously set to \`${opts.encode(nuxtApp._cookies[name] as any)}\` and is being overridden to \`${opts.encode(cookie.value as any)}\`. This may cause unexpected issues.`)

--- a/packages/nuxt/src/app/composables/cookie.ts
+++ b/packages/nuxt/src/app/composables/cookie.ts
@@ -5,7 +5,6 @@ import { parse, serialize } from 'cookie-es'
 import { deleteCookie, getCookie, getRequestHeader, setCookie } from 'h3'
 import type { H3Event } from 'h3'
 import destr from 'destr'
-import { isEqual } from 'ohash'
 import { klona } from 'klona'
 import { useNuxtApp } from '../nuxt'
 import { useRequestEvent } from './ssr'
@@ -64,6 +63,10 @@ export function useCookie<T = string | null | undefined> (name: string, _opts?: 
   const hasExpired = delay !== undefined && delay <= 0
   const shouldSetInitialClientCookie = import.meta.client && (hasExpired || cookies[name] === undefined || cookies[name] === null)
   const cookieValue = klona(hasExpired ? undefined : (cookies[name] as any) ?? opts.default?.())
+
+  const isEqual = (a: T, b: T) => {
+    return opts.encode(a) === opts.encode(b)
+  }
 
   // use a custom ref to expire the cookie on client side otherwise use basic ref
   const cookie = import.meta.client && delay && !hasExpired

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -719,10 +719,7 @@ describe('useCookie', () => {
   })
 
   it('should work with any value, when encode and decode is set', () => {
-    const encode = vi.fn((val: Intl.Locale) => val.toString())
-    const decode = vi.fn((val: string) => new Intl.Locale(val))
-
-    const locale = useCookie('locale', { watch: true, default: () => new Intl.Locale('de-DE'), encode, decode })
+    const locale = useCookie('locale', { watch: true, default: () => new Intl.Locale('de-DE'), encode: (val: Intl.Locale) => val.toString(), decode: (val: string) => new Intl.Locale(val) })
     expect(locale.value.language).toBe('de')
     locale.value = new Intl.Locale('fr-FR')
     expect(locale.value.language).toBe('fr')

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -661,7 +661,7 @@ describe('useCookie', () => {
     expect(computedVal.value).toBe(0)
   })
 
-  it('cookie decode function should be invoked once', () => {
+  it('cookie decode function should be invoked once for decode and once for clone', () => {
     // Pre-set cookies
     document.cookie = 'foo=Foo'
     document.cookie = 'bar=%7B%22s2%22%3A0%7D'
@@ -677,7 +677,7 @@ describe('useCookie', () => {
     })
     bazCookie.value.s2++
     expect(bazCookie.value.s2).toEqual(1)
-    expect(barCallCount).toBe(1)
+    expect(barCallCount).toBe(2)
 
     let quxCallCount = 0
     const quxCookie = useCookie<{ s3: number }>('qux', {
@@ -690,7 +690,7 @@ describe('useCookie', () => {
     })
     quxCookie.value.s3++
     expect(quxCookie.value.s3).toBe(0)
-    expect(quxCallCount).toBe(2)
+    expect(quxCallCount).toBe(4)
   })
 
   it('should not watch custom cookie refs when shallow', () => {

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -717,6 +717,16 @@ describe('useCookie', () => {
     useCookie('cookie-readonly', { default: () => 'foo', readonly: true })
     expect(document.cookie).toContain('cookie-readonly=foo')
   })
+
+  it('should work with any value, when encode and decode is set', () => {
+    const encode = vi.fn((val: Intl.Locale) => val.toString())
+    const decode = vi.fn((val: string) => new Intl.Locale(val))
+
+    const locale = useCookie('locale', { watch: true, default: () => new Intl.Locale('de-DE'), encode, decode })
+    expect(locale.value.language).toBe('de')
+    locale.value = new Intl.Locale('fr-FR')
+    expect(locale.value.language).toBe('fr')
+  })
 })
 
 describe('callOnce', () => {


### PR DESCRIPTION
### 📚 Description

I think we should match the encoded string instead of using the `isEqual` method of `ohash`, because `ohash` doesnt support all/custom class instances. 

The equality check with the encoded value should good enough, as this is the string stored in the cookie. 

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/4.x/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
