### PR TITLE
docs: clarify module setups in .nuxtrc example

### DIFF
--- a/docs/2.directory-structure/2.nuxtrc.md
+++ b/docs/2.directory-structure/2.nuxtrc.md
@@ -24,7 +24,7 @@ devtools.enabled=true
 modules[]=@nuxt/image
 modules[]=nuxt-security
 
-# Module setups
+# Module setups (automatically added by Nuxt)
 setups.@nuxt/test-utils="3.23.0"
 ```
 

--- a/docs/2.directory-structure/2.nuxtrc.md
+++ b/docs/2.directory-structure/2.nuxtrc.md
@@ -23,6 +23,9 @@ devtools.enabled=true
 # Add Nuxt modules
 modules[]=@nuxt/image
 modules[]=nuxt-security
+
+# Module setups
+setups.@nuxt/test-utils="3.23.0"
 ```
 
 If present, the properties in the `nuxt.config` file will overwrite the properties in `.nuxtrc` file.


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
When running tests with `@nuxt/test-utils`, `setups.@nuxt/test-utils` is now automatically added to `.nuxtrc`.

While there is already a note explaining the `setups` section, I think including an actual example in the `.nuxtrc` code block would make it clearer for users who encounter this in their projects.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/4.x/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
