### PR TITLE
fix(nuxt): make asyncData properties reactive in Options API

### DIFF
--- a/packages/nuxt/src/app/composables/component.ts
+++ b/packages/nuxt/src/app/composables/component.ts
@@ -37,8 +37,7 @@ async function runLegacyAsyncData (res: Record<string, any> | Promise<Record<str
       _res[key] = computed({
         get: () => data.value?.[key],
         set (v) {
-          data.value ||= {}
-          data.value[key] = v
+          data.value = data.value ? { ...data.value, [key]: v } : { [key]: v }
         },
       })
     }

--- a/test/nuxt/define-nuxt-component.test.ts
+++ b/test/nuxt/define-nuxt-component.test.ts
@@ -71,6 +71,20 @@ describe('defineNuxtComponent', () => {
     expect(wrapper.html()).toBe('<div>1</div>')
   })
 
+  it('should update reactively when asyncData properties are modified', async () => {
+    const component = defineNuxtComponent({
+      asyncData: () => ({ count: 0 }),
+      template: '<div>{{ count }}</div>',
+      mounted () {
+        // @ts-expect-error count is not typed in options api
+        this.count = 42
+      },
+    })
+    const wrapper = await mountSuspended(component)
+    await nextTick()
+    expect(wrapper.html()).toBe('<div>42</div>')
+  })
+
   it('should handle state and watchers correctly without duplicate updates', async () => {
     let watcherCallCount = 0
 


### PR DESCRIPTION
eFixes #34117

## Problem

asyncData setter mutates shallowRef property - no reactivity trigger

## Solution

Replace entire object to trigger shallowRef reactivity

## StackBlitz


|     | Link                                                                                                      | Expected               |
| --- | --------------------------------------------------------------------------------------------------------- | ---------------------- |
| Bug | [nuxt-34117](https://stackblitz.com/github/onmax/repros/tree/repro/nuxt-34117/nuxt-34117?startScript=dev)             | ❌ Click doesn't update |
| Fix | [nuxt-34117-fixed](https://stackblitz.com/github/onmax/repros/tree/repro/nuxt-34117/nuxt-34117-fixed?startScript=dev) | ✅ Click increments     |


