### PR TITLE
fix(nuxt): encode cookie strings with quotes to prevent unwanted parse to object

### DIFF
--- a/packages/nuxt/src/app/composables/cookie.ts
+++ b/packages/nuxt/src/app/composables/cookie.ts
@@ -38,7 +38,7 @@ const CookieDefaults = {
     }
     return parsed
   },
-  encode: val => encodeURIComponent(typeof val === 'string' ? val : JSON.stringify(val)),
+  encode: val => encodeURIComponent(JSON.stringify(val)),
 } satisfies CookieOptions<any>
 
 // we use globalThis to avoid crashes in web workers

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -26,6 +26,7 @@ import { useRuntimeHook } from '#app/composables/runtime-hook'
 import { shouldLoadPayload } from '#app/composables/payload'
 import { NuxtPage } from '#components'
 import { isTestingAppManifest } from '../matrix'
+import { flushPromises } from '@vue/test-utils'
 
 registerEndpoint('/api/test', defineEventHandler(event => ({
   method: event.method,
@@ -723,7 +724,7 @@ describe('useCookie', () => {
     expect(json.value).toBe('{"hello": "world"}')
   })
 
-  it.fails('should not parse json by default when decoded by change event', () => {
+  it('should not parse json by default when decoded by change event', async () => {
     const j1 = useCookie('j1', { default: () => '{"hello": "world"}' })
     expect.soft(j1.value).not.toEqual({ hello: 'world' })
     expect.soft(j1.value).toBe('{"hello": "world"}')
@@ -733,6 +734,8 @@ describe('useCookie', () => {
     j1.value = '{"hello": "welt"}'
     expect.soft(j1.value).not.toEqual({ hello: 'welt' })
     expect.soft(j1.value).toBe('{"hello": "welt"}')
+    await nextTick()
+    await flushPromises()
     expect.soft(j2.value).not.toEqual({ hello: 'welt' })
     expect.soft(j2.value).toBe('{"hello": "welt"}')
   })

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -709,13 +709,13 @@ describe('useCookie', () => {
 
   it('should set cookie value when called on client', () => {
     useCookie('cookie-watch-false', { default: () => 'foo', watch: false })
-    expect(document.cookie).toContain('cookie-watch-false=foo')
+    expect(document.cookie).toContain('cookie-watch-false=%22foo%22')
 
     useCookie('cookie-watch-true', { default: () => 'foo', watch: true })
-    expect(document.cookie).toContain('cookie-watch-true=foo')
+    expect(document.cookie).toContain('cookie-watch-true=%22foo%22')
 
     useCookie('cookie-readonly', { default: () => 'foo', readonly: true })
-    expect(document.cookie).toContain('cookie-readonly=foo')
+    expect(document.cookie).toContain('cookie-readonly=%22foo%22')
   })
 
   it('should not parse json by default', () => {

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -725,10 +725,16 @@ describe('useCookie', () => {
 
   it.fails('should not parse json by default when decoded by change event', () => {
     const j1 = useCookie('j1', { default: () => '{"hello": "world"}' })
+    expect.soft(j1.value).not.toEqual({ hello: 'world' })
+    expect.soft(j1.value).toBe('{"hello": "world"}')
     const j2 = useCookie('j1')
-    expect(j2.value).toBe('{"hello": "world"}')
+    expect.soft(j2.value).not.toEqual({ hello: 'world' })
+    expect.soft(j2.value).toBe('{"hello": "world"}')
     j1.value = '{"hello": "welt"}'
-    expect(j2.value).toBe('{"hello": "welt"}')
+    expect.soft(j1.value).not.toEqual({ hello: 'welt' })
+    expect.soft(j1.value).toBe('{"hello": "welt"}')
+    expect.soft(j2.value).not.toEqual({ hello: 'welt' })
+    expect.soft(j2.value).toBe('{"hello": "welt"}')
   })
 })
 

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -717,6 +717,19 @@ describe('useCookie', () => {
     useCookie('cookie-readonly', { default: () => 'foo', readonly: true })
     expect(document.cookie).toContain('cookie-readonly=foo')
   })
+
+  it('should not parse json by default', () => {
+    const json = useCookie('json', { default: () => '{"hello": "world"}' })
+    expect(json.value).toBe('{"hello": "world"}')
+  })
+
+  it.fails('should not parse json by default when decoded by change event', () => {
+    const j1 = useCookie('j1', { default: () => '{"hello": "world"}' })
+    const j2 = useCookie('j1')
+    expect(j2.value).toBe('{"hello": "world"}')
+    j1.value = '{"hello": "welt"}'
+    expect(j2.value).toBe('{"hello": "welt"}')
+  })
 })
 
 describe('callOnce', () => {


### PR DESCRIPTION
EDIT: I think fb4db7a could be a valid fix, but I am not sure about the side effects

----------

### 🔗 Linked issue

related to ongoing PR https://github.com/nuxt/nuxt/pull/34106

### 📚 Description

This PR adds a failing test that reproduces an issue that occurs when cookie values are decoded. The value is incorrectly parsed as an object. This issue arose while working on #34106. This PR is separate for two reasons:

- proof that this is bug is unrelated to #34106 implementation
- maybe to fix the bug unrelated to progress or state of #34106

(all the j2 tests are the failing ones)