### PR TITLE
fix(nuxt): add documentation link to server builder error message

### DIFF
--- a/packages/nuxt/src/core/server.ts
+++ b/packages/nuxt/src/core/server.ts
@@ -20,7 +20,6 @@ async function loadServerBuilder (nuxt: Nuxt, builder = '@nuxt/nitro-server'): P
   try {
     return await importModule(builder, { url: [directoryToURL(nuxt.options.rootDir), new URL(import.meta.url)] })
   } catch (err) {
-    // TODO: docs
-    throw new Error(`Loading \`${builder}\` server builder failed.`, { cause: err })
+    throw new Error(`Loading \`${builder}\` server builder failed. You can read more about the nuxt \`server.builder\` option at: \`https://nuxt.com/docs/4.x/api/nuxt-config#server\``, { cause: err })
   }
 }

--- a/packages/nuxt/src/core/server.ts
+++ b/packages/nuxt/src/core/server.ts
@@ -20,6 +20,6 @@ async function loadServerBuilder (nuxt: Nuxt, builder = '@nuxt/nitro-server'): P
   try {
     return await importModule(builder, { url: [directoryToURL(nuxt.options.rootDir), new URL(import.meta.url)] })
   } catch (err) {
-    throw new Error(`Loading \`${builder}\` server builder failed. You can read more about the nuxt \`server.builder\` option at: \`https://nuxt.com/docs/4.x/api/nuxt-config#server\``, { cause: err })
+    throw new Error(`Loading \`${builder}\` server builder failed. You can read more about the nuxt \`server.builder\` option at: \`https://nuxt.com/docs/4.x/api/nuxt-config#builder-1\``, { cause: err })
   }
 }


### PR DESCRIPTION
## Description
Improve error message when server builder fails to load by adding a link to the documentation, matching the pattern used in `builder.ts`.

## Changes
- Removed TODO comment in `packages/nuxt/src/core/server.ts`
- Added documentation link to error message for better developer experience
- Follows the same pattern as the client builder error message

## Benefits
- Better error messages with direct link to relevant documentation
- Consistent error handling across builders
- Improved developer experience when troubleshooting server builder issues