### PR TITLE
fix(nuxt): dedupe rel="alternate" link tags

### DIFF
--- a/packages/nuxt/src/head/runtime/components.ts
+++ b/packages/nuxt/src/head/runtime/components.ts
@@ -206,7 +206,7 @@ export const Link = defineComponent({
     const { input, update } = useHeadComponentCtx()
     input.link ||= []
     const idx: keyof typeof input.link = input.link.push({}) - 1
-    const key = useVNodeStringKey()
+    const vnodeKey = useVNodeStringKey()
 
     onUnmounted(() => {
       input.link![idx] = null
@@ -214,6 +214,11 @@ export const Link = defineComponent({
     })
 
     return () => {
+      // Auto-generate key for rel="alternate" deduplication
+      let key = vnodeKey
+      if (!key && props.rel === 'alternate') {
+        key = `alternate:${props.hreflang ?? 'x-default'}:${props.href ?? ''}`
+      }
       input.link![idx] = normalizeProps(props, key) as UnheadLink
       update()
       return null

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1074,8 +1074,7 @@ describe('head tags', () => {
     expect(html).toContain('<meta http-equiv="content-security-policy" content="default-src https">')
   })
 
-  // TODO: https://github.com/nuxt/nuxt/issues/32670
-  it.fails('should not duplicate link tags with rel="alternate"', async () => {
+  it('should not duplicate link tags with rel="alternate"', async () => {
     const page = await createPage('/head-component')
 
     await page.waitForFunction(() => window.useNuxtApp?.() && !window.useNuxtApp?.().isHydrating)


### PR DESCRIPTION
Fixes #32670

## Problem
`<Link rel="alternate">` duplicates in client HTML after hydration.

## Solution
Auto-generate dedupe key for `rel="alternate"` links based on hreflang.

## StackBlitz

| | Link | Expected |
|---|---|---|
| Bug | [nuxt-32670](https://stackblitz.com/github/onmax/repros/tree/repro/nuxt-32670/nuxt-32670?startScript=dev) | ❌ Duplicate link |
| Fix | [nuxt-32670-fixed](https://stackblitz.com/github/onmax/repros/tree/repro/nuxt-32670/nuxt-32670-fixed?startScript=dev) | ✅ Single link |

## What to check
1. Open DevTools → Elements → `<head>`
2. Search for `link[rel="alternate"]`
   - **Bug**: appears **twice** after hydration
   - **Fixed**: appears **once**
3. `link[rel="canonical"]` should appear once in both (already working)

## CLI Reproduction
```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxt-32670 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxt-32670
cd nuxt-32670 && pnpm i && pnpm dev
```