### PR TITLE
fix(nitro): provide essential imports when nitro auto-imports disabled

### DIFF
--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -37,17 +37,8 @@ const logLevelMapReverse = {
 } satisfies Record<NuxtOptions['logLevel'], NitroConfig['logLevel']>
 
 const NODE_MODULES_RE = /(?<=\/)node_modules\/(.+)$/
-
-// Essential imports that must be available regardless of nitroAutoImports setting.
-// These are internal functions required for Nuxt's core functionality (e.g., app.config.ts).
-function getCoreNitroImports () {
-  return [
-    { as: '__buildAssetsURL', name: 'buildAssetsURL', from: resolve(distDir, 'runtime/utils/paths') },
-    { as: '__publicAssetsURL', name: 'publicAssetsURL', from: resolve(distDir, 'runtime/utils/paths') },
-    // TODO: Remove after https://github.com/nitrojs/nitro/issues/1049
-    { as: 'defineAppConfig', name: 'defineAppConfig', from: resolve(distDir, 'runtime/utils/config'), priority: -1 },
-  ]
-}
+const APP_CONFIG_RE = /(?:^|[/\\])app\.config(?:\.[^/\\]+)?$/
+const DEFINE_APP_CONFIG_IMPORT_RE = /\bimport\s*(?:\{[^}]*\bdefineAppConfig\b[^}]*\}|defineAppConfig)\s*from\b/
 const PNPM_NODE_MODULES_RE = /\.pnpm\/.+\/node_modules\/(.+)$/
 export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
   // Resolve config
@@ -159,15 +150,29 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
       version: nuxtVersion || nitroBuilder.version,
     },
     imports: nuxt.options.experimental.nitroAutoImports === false
-      ? {
-          autoImport: false,
-          imports: getCoreNitroImports(),
-          exclude: [...excludePattern, /[\\/]\.git[\\/]/],
-        }
+      ? false
       : {
           autoImport: nuxt.options.imports.autoImport as boolean,
           dirs: [...sharedDirs],
-          imports: getCoreNitroImports(),
+          imports: [
+            {
+              as: '__buildAssetsURL',
+              name: 'buildAssetsURL',
+              from: resolve(distDir, 'runtime/utils/paths'),
+            },
+            {
+              as: '__publicAssetsURL',
+              name: 'publicAssetsURL',
+              from: resolve(distDir, 'runtime/utils/paths'),
+            },
+            {
+              // TODO: Remove after https://github.com/nitrojs/nitro/issues/1049
+              as: 'defineAppConfig',
+              name: 'defineAppConfig',
+              from: resolve(distDir, 'runtime/utils/config'),
+              priority: -1,
+            },
+          ],
           presets: [
             {
               from: 'h3',
@@ -657,6 +662,22 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
     compatibilityDate: nuxt.options.compatibilityDate,
     dotenv: nuxt.options._loadOptions?.dotenv,
   })
+
+  if (nuxt.options.experimental.nitroAutoImports === false) {
+    const defineAppConfigImport = `import { defineAppConfig } from ${JSON.stringify(resolve(distDir, 'runtime/utils/config'))}\n`
+    nitro.hooks.hook('rollup:before', (_nitro, rollupConfig) => {
+      rollupConfig.plugins.push({
+        name: 'nuxt:app-config-imports',
+        transform (code, id) {
+          const normalizedId = id.replace(/\\/g, '/')
+          if (!APP_CONFIG_RE.test(normalizedId) || !/\bdefineAppConfig\b/.test(code) || DEFINE_APP_CONFIG_IMPORT_RE.test(code)) {
+            return
+          }
+          return defineAppConfigImport + code
+        },
+      })
+    })
+  }
 
   // eslint-disable-next-line @typescript-eslint/no-deprecated
   if (nuxt.options.experimental.serverAppConfig === false && nitro.options.imports) {

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -160,6 +160,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
     },
     imports: nuxt.options.experimental.nitroAutoImports === false
       ? {
+          autoImport: false,
           imports: getCoreNitroImports(),
           exclude: [...excludePattern, /[\\/]\.git[\\/]/],
         }

--- a/packages/nuxt/test/load-nuxt.test.ts
+++ b/packages/nuxt/test/load-nuxt.test.ts
@@ -167,6 +167,23 @@ describe('loadNuxt', () => {
 
     await nuxt.close()
   })
+
+  it('provides defineAppConfig import when nitroAutoImports is disabled (#34142)', async () => {
+    const nuxt = await loadNuxt({
+      cwd: repoRoot,
+      ready: true,
+      overrides: {
+        experimental: { nitroAutoImports: false },
+      },
+    })
+
+    const nitroImports = (nuxt as any)._nitro?.options.imports?.imports ?? []
+    const hasDefineAppConfig = nitroImports.some((i: { name: string }) => i.name === 'defineAppConfig')
+
+    expect(hasDefineAppConfig).toBe(true)
+
+    await nuxt.close()
+  })
 })
 
 const pagesDetectionTests: [test: string, overrides: NuxtConfig, result: NuxtConfig['pages']][] = [

--- a/packages/nuxt/test/load-nuxt.test.ts
+++ b/packages/nuxt/test/load-nuxt.test.ts
@@ -179,8 +179,10 @@ describe('loadNuxt', () => {
 
     const nitroImports = (nuxt as any)._nitro?.options.imports?.imports ?? []
     const hasDefineAppConfig = nitroImports.some((i: { name: string }) => i.name === 'defineAppConfig')
+    const autoImport = (nuxt as any)._nitro?.options.imports?.autoImport
 
     expect(hasDefineAppConfig).toBe(true)
+    expect(autoImport).toBe(false)
 
     await nuxt.close()
   })

--- a/packages/nuxt/test/load-nuxt.test.ts
+++ b/packages/nuxt/test/load-nuxt.test.ts
@@ -168,7 +168,7 @@ describe('loadNuxt', () => {
     await nuxt.close()
   })
 
-  it('provides defineAppConfig import when nitroAutoImports is disabled (#34142)', async () => {
+  it('injects defineAppConfig into app.config when nitroAutoImports is disabled (#34142)', async () => {
     const nuxt = await loadNuxt({
       cwd: repoRoot,
       ready: true,
@@ -177,12 +177,15 @@ describe('loadNuxt', () => {
       },
     })
 
-    const nitroImports = (nuxt as any)._nitro?.options.imports?.imports ?? []
-    const hasDefineAppConfig = nitroImports.some((i: { name: string }) => i.name === 'defineAppConfig')
-    const autoImport = (nuxt as any)._nitro?.options.imports?.autoImport
+    const nitro = (nuxt as any)._nitro
+    const rollupConfig = { plugins: [] as Array<{ name: string, transform?: (code: string, id: string) => string | void }> }
+    await nitro?.hooks.callHook('rollup:before', nitro, rollupConfig)
 
-    expect(hasDefineAppConfig).toBe(true)
-    expect(autoImport).toBe(false)
+    const transformPlugin = rollupConfig.plugins.find(plugin => plugin.name === 'nuxt:app-config-imports')
+    const transformed = transformPlugin?.transform?.('export default defineAppConfig({ feature: true })\n', '/virtual/app.config.ts')
+
+    expect(transformed).toContain('import { defineAppConfig } from')
+    expect(transformed).toContain('runtime/utils/config')
 
     await nuxt.close()
   })


### PR DESCRIPTION
Closes #34142

## Summary
`defineAppConfig is not defined` error when using `compatibilityVersion: 5` because essential internal imports were not provided when `nitroAutoImports` was disabled.

## StackBlitz

| | Link | Expected |
|---|---|---|
| Bug | [nuxt-34142](https://stackblitz.com/github/onmax/repros/tree/repro/nuxt-34142/nuxt-34142?startScript=dev) | ❌ `defineAppConfig is not defined` |
| Fix | [nuxt-34142-fix](https://stackblitz.com/github/onmax/repros/tree/repro/nuxt-34142/nuxt-34142-fix?startScript=dev) | ✅ Renders without error |

## CLI Reproduction

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxt-34142 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxt-34142
cd nuxt-34142 && pnpm i && pnpm dev
```

## Verify fix

```bash
git sparse-checkout add nuxt-34142-fix
cd ../nuxt-34142-fix && pnpm i && pnpm dev
```

The `-fix` folder uses [pnpm patch](https://pnpm.io/cli/patch) to apply the fix locally.

## Related
- https://github.com/nuxt/nuxt/issues/34142