### PR TITLE
refactor(nuxt): remove requestIdleCallback polyfill

### DIFF
--- a/packages/nuxt/src/app/compat/idle-callback.ts
+++ b/packages/nuxt/src/app/compat/idle-callback.ts
@@ -1,16 +1,7 @@
-// Polyfills for Safari support
-// https://caniuse.com/requestidlecallback
 export const requestIdleCallback: Window['requestIdleCallback'] = import.meta.server
   ? (() => {}) as any
-  : (globalThis.requestIdleCallback || ((cb) => {
-      const start = Date.now()
-      const idleDeadline = {
-        didTimeout: false,
-        timeRemaining: () => Math.max(0, 50 - (Date.now() - start)),
-      }
-      return setTimeout(() => { cb(idleDeadline) }, 1)
-    }))
+  : globalThis.requestIdleCallback
 
 export const cancelIdleCallback: Window['cancelIdleCallback'] = import.meta.server
   ? (() => {}) as any
-  : (globalThis.cancelIdleCallback || ((id) => { clearTimeout(id) }))
+  : globalThis.cancelIdleCallback


### PR DESCRIPTION
## Closed

Safari does NOT support `requestIdleCallback` - it's disabled by default in all versions (13.1-26.3).

The baseline in `stable-entry.ts` is for import maps support, not the general browser target.

Sources:
- https://caniuse.com/requestidlecallback
- https://github.com/mdn/browser-compat-data/issues/24573