### PR TITLE
refactor: clean up route rules extraction and prepare internal rou3 matcher

### DIFF
--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -82,7 +82,7 @@ export default defineNuxtModule({
       const pages = await _resolvePagesRoutes(pattern, nuxt)
 
       if (nuxt.options.experimental.inlineRouteRules) {
-        const routeRules = globRouteRulesFromPages(pages)
+        const routeRules = globRouteRulesFromPages(pages).paths
         await updateRouteConfig?.(routeRules)
       } else {
         // also remove rules when disabled

--- a/packages/nuxt/src/pages/route-rules.ts
+++ b/packages/nuxt/src/pages/route-rules.ts
@@ -2,24 +2,31 @@ import type { NuxtPage } from '@nuxt/schema'
 import type { NitroRouteConfig } from 'nitropack/types'
 
 import { pathToNitroGlob } from './utils.ts'
+import { addRoute, createRouter } from 'rou3'
+import { compileRouter } from 'rou3/compiler'
 
-export function globRouteRulesFromPages (pages: NuxtPage[], paths = {} as { [glob: string]: NitroRouteConfig }, prefix = '') {
+export function globRouteRulesFromPages (pages: NuxtPage[], paths = {} as { [glob: string]: NitroRouteConfig }, prefix = '', router = createRouter()) {
   for (const page of pages) {
     if (page.rules) {
       if (Object.keys(page.rules).length) {
         const glob = pathToNitroGlob(prefix + page.path)
         if (glob) {
           paths[glob] = page.rules
+          addRoute(router, undefined, glob, page.rules)
         }
       }
       // remove rules to prevent exposing in build
       delete page.rules
     }
     if (page.children?.length) {
-      globRouteRulesFromPages(page.children, paths, prefix + page.path + '/')
+      globRouteRulesFromPages(page.children, paths, prefix + page.path + '/', router)
     }
   }
-  return paths
+
+  // compile router at the end
+  const matcher = compileRouter(router)
+
+  return { paths, matcher }
 }
 
 export function removePagesRules (routes: NuxtPage[]) {

--- a/packages/nuxt/test/route-rules.test.ts
+++ b/packages/nuxt/test/route-rules.test.ts
@@ -32,7 +32,7 @@ describe('routeRules from page meta', () => {
 
   it('extracts route rules from pages', () => {
     const pages = getPages()
-    const result = globRouteRulesFromPages(pages)
+    const result = globRouteRulesFromPages(pages).paths
     expect(result).toEqual({
       '/': { prerender: true },
       '/some/nested/page': { prerender: true },
@@ -52,5 +52,17 @@ describe('routeRules from page meta', () => {
       },
       { path: '/contact' },
     ])
+  })
+
+  it('allows rou3 to match /path/** with a /path route rule', () => {
+    const pages = [
+      ...getPages(),
+      {
+        path: '/path',
+        rules: { prerender: true },
+      },
+    ]
+    const result = globRouteRulesFromPages(pages)
+    expect(result.paths['/path']).toEqual({ prerender: true })
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

related to #32480

### 📚 Description

Refactoring the internal handling of route rules in Nuxt:

- Modified ```globRouteRulesFromPages``` to centralize router creation and cleanup.
- Added an rou3 matcher which is returned by ```globRouteRulesFromPages```.  This matcher is added for future use and is not exposed or used yet.
- Slightly changed the use of ```globRouteRulesFromPages``` everywhere to match the new returns from this function.