### PR TITLE
fix(nuxt): add status/statusText getters to NuxtError

### DIFF
--- a/packages/nuxt/src/app/composables/error.ts
+++ b/packages/nuxt/src/app/composables/error.ts
@@ -80,5 +80,17 @@ export const createError = <DataT = unknown>(error: string | Error | Partial<Nux
     writable: false,
   })
 
+  // #34165 - TODO: remove in Nuxt 5 when statusCode/statusMessage are removed
+  Object.defineProperty(nuxtError, 'status', {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    get: () => nuxtError.statusCode,
+    configurable: true,
+  })
+  Object.defineProperty(nuxtError, 'statusText', {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    get: () => nuxtError.statusMessage,
+    configurable: true,
+  })
+
   return nuxtError
 }

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -118,7 +118,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(pagesRootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"291k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"292k"`)
 
     const modules = await analyzeSizes(['node_modules/**/*'], serverDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"1441k"`)

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -150,6 +150,21 @@ describe('errors', () => {
     `)
   })
 
+  // #34165 - TODO: remove in Nuxt 5 when statusCode/statusMessage are removed
+  it('supports status/statusText getters', () => {
+    const error = createError({ status: 404, statusText: 'Not Found' })
+    expect(error.status).toBe(404)
+    expect(error.statusText).toBe('Not Found')
+    // backwards compat
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    expect(error.statusCode).toBe(404)
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    expect(error.statusMessage).toBe('Not Found')
+    // non-enumerable (no duplicate in toJSON)
+    expect(Object.keys(error.toJSON())).not.toContain('status')
+    expect(Object.keys(error.toJSON())).not.toContain('statusText')
+  })
+
   it('isNuxtError', () => {
     const error = createError({ statusCode: 404 })
     expect(isNuxtError(error)).toBe(true)


### PR DESCRIPTION
Closes #34165

## Problem
- `createError({ status, statusText })` accepts new property names (per #33912)
- But runtime error object only had `statusCode`/`statusMessage` (from H3)
- `error.status` returned `undefined` instead of the status code

## Solution
Add non-enumerable getters for `status`/`statusText` in `createError()`. Non-enumerable prevents `toJSON()` from outputting both `status: 404` AND `statusCode: 404`.