### PR TITLE
fix(schema): add direnv and vendor to default ignore

### DIFF
--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -228,7 +228,8 @@ export default defineResolvers({
         '**/*.{spec,test}.{js,cts,mts,ts,jsx,tsx}', // ignore tests
         '**/*.d.{cts,mts,ts}', // ignore type declarations
         '**/*.d.vue.{cts,mts,ts}',
-        '**/.{pnpm-store,vercel,netlify,output,git,cache,data}',
+        '**/.{pnpm-store,vercel,netlify,output,git,cache,data,direnv}',
+        '/vendor',
         '**/node-compile-cache',
         '**/test-results',
         '**/*.sock',


### PR DESCRIPTION
Closes #31575
Closes #30756

## Summary
Add `.direnv` and `/vendor` to default ignore patterns to prevent EMFILE errors from file watchers.

| Directory | Used by | Why many files |
|-----------|---------|----------------|
| `.direnv` | [direnv](https://direnv.net/) (popular in Nix/NixOS) | Cached environment files |
| `vendor` | PHP/Composer, Go modules | Dependencies (like node_modules) |

**Note**: Uses `/vendor` (not `vendor`) to match only root-level vendor directory, preserving `server/utils/vendor/` etc.

## Why `vite.server.watch.ignored` Doesn't Work

Users tried `vite: { server: { watch: { ignored: ['vendor'] } } }` but still got EMFILE errors.

**Root cause**: Nuxt has 5+ independent file watchers:

| Watcher | Uses `nuxt.options.ignore`? |
|---------|---------------------------|
| Nuxt builder (chokidar) | ✅ via `createIsIgnored()` |
| Nuxt builder (parcel) | ✅ directly |
| Vite dev server | ✅ (merged with Nuxt's defaults) |
| Nitro internal | Partial |
| Schema watcher | ❌ hardcoded |

`vite.server.watch.ignored` only affects Vite's watcher. The **canonical solution** is `nuxt.options.ignore` which is used by most watchers via `createIsIgnored()`.

Adding `/vendor` and `.direnv` to **defaults** ensures all watchers respect them automatically.

## StackBlitz

| | Link | Expected |
|---|---|---|
| Bug | [nuxt-31575](https://stackblitz.com/github/onmax/repros/tree/repro/nuxt-31575/nuxt-31575?startScript=dev) | ❌ EMFILE error |
| Fix | [nuxt-31575-fix](https://stackblitz.com/github/onmax/repros/tree/repro/nuxt-31575/nuxt-31575-fix?startScript=dev) | ✅ Dev starts |

## CLI Reproduction

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxt-31575 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxt-31575
cd nuxt-31575 && pnpm i && pnpm dev
```

## Verify fix

```bash
git sparse-checkout add nuxt-31575-fix
cd ../nuxt-31575-fix && pnpm i && pnpm dev
```

The `-fix` folder uses [pnpm patch](https://pnpm.io/cli/patch) to apply the fix locally.