### PR TITLE
fix(nuxt): don't inject shared types for differing auto-imports

### DIFF
--- a/test/fixtures/basic-types/shared/shared-types.ts
+++ b/test/fixtures/basic-types/shared/shared-types.ts
@@ -11,4 +11,15 @@ describe('shared folder', () => {
   it('can reference auto-imported utils', () => {
     expectTypeOf(useSharedUtil()).toEqualTypeOf<string>()
   })
+
+  it('can reference useRuntimeConfig', () => {
+    const config = useRuntimeConfig()
+    expectTypeOf(config).not.toBeAny()
+    expectTypeOf(config.public).not.toBeAny()
+  })
+
+  it('can reference useAppConfig', () => {
+    const config = useAppConfig()
+    expectTypeOf(config).not.toBeAny()
+  })
 })


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/34140

### 📚 Description

this filters out imports with differing implementations, and adds 'safe' declarations for certain key nuxt imports.