### PR TITLE
docs: clarify shared type context limitations for custom imports

### DIFF
--- a/docs/4.api/5.kit/11.nitro.md
+++ b/docs/4.api/5.kit/11.nitro.md
@@ -301,6 +301,10 @@ function addPrerenderRoutes (routes: string | string[]): void
 
 Add imports to the server. It makes your imports available in Nitro without the need to import them manually.
 
+::warning
+If you want to provide a utility that works in both server and client contexts and is usable in the [`shared/`](/docs/4.x/directory-structure/shared) directory, the function must be imported from the same source file for both [`addImports`](/docs/4.x/api/kit/autoimports#addimports) and `addServerImports` and should have identical signature. That source file should not import anything context-specific (i.e., Nitro context, Nuxt app context) or else it might cause errors during type-checking.
+::
+
 ### Usage
 
 ```ts twoslash

--- a/docs/4.api/5.kit/4.autoimports.md
+++ b/docs/4.api/5.kit/4.autoimports.md
@@ -24,7 +24,11 @@ Watch Vue School video about Auto-imports Nuxt Kit utilities.
 
 ## `addImports`
 
-Add imports to the Nuxt application. It makes your imports available in the Nuxt application without the need to import them manually.
+Add imports to the Nuxt application. It makes your imports available in the Nuxt app context without the need to import them manually.
+
+::tip
+To add imports for the Nitro server context, refer to the [`addServerImports`](/docs/4.x/api/kit/nitro#addserverimports) function.
+::
 
 ### Usage
 


### PR DESCRIPTION
### 🔗 Linked issue

related https://github.com/nuxt/nuxt/pull/34191

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
This documents the limitations of supporting auto-imports for custom functions in the shared context.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/4.x/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
