### PR TITLE
fix(nuxt): exclude head runtime from unhead imports transform

### DIFF
--- a/packages/nuxt/src/head/plugins/unhead-imports.ts
+++ b/packages/nuxt/src/head/plugins/unhead-imports.ts
@@ -15,6 +15,7 @@ interface UnheadImportsPluginOptions {
 }
 
 const UNHEAD_LIB_RE = /node_modules[/\\](?:@unhead[/\\][^/\\]+|unhead)[/\\]/
+const NUXT_HEAD_RE = /node_modules[/\\]nuxt[/\\]dist[/\\]head[/\\]runtime[/\\]/
 
 function toImports (specifiers: ImportSpecifier[]) {
   return specifiers.map((specifier) => {
@@ -42,7 +43,8 @@ export const UnheadImportsPlugin = (options: UnheadImportsPluginOptions) => crea
         (isJS(id) || isVue(id, { type: ['script'] })) &&
         !id.startsWith('virtual:') &&
         !id.startsWith(normalize(distDir)) &&
-        !UNHEAD_LIB_RE.test(id)
+        !UNHEAD_LIB_RE.test(id) &&
+        !NUXT_HEAD_RE.test(id)
       )
     },
     transform: {

--- a/packages/nuxt/test/unhead-imports.test.ts
+++ b/packages/nuxt/test/unhead-imports.test.ts
@@ -35,6 +35,17 @@ describe('UnheadImportsPlugin', () => {
       expect(transformInclude('/project/node_modules/@unhead/vue/index.js')).toBe(false)
       expect(transformInclude('/project/node_modules/unhead/index.js')).toBe(false)
     })
+
+    it('should exclude nuxt head runtime composables', () => {
+      // Unix paths
+      expect(transformInclude('/project/node_modules/nuxt/dist/head/runtime/composables.js')).toBe(false)
+      expect(transformInclude('/project/node_modules/nuxt/dist/head/runtime/index.js')).toBe(false)
+      // Windows paths
+      expect(transformInclude('C:\\project\\node_modules\\nuxt\\dist\\head\\runtime\\composables.js')).toBe(false)
+      // Should NOT exclude - different paths
+      expect(transformInclude('/project/node_modules/nuxt/dist/head/plugin.js')).toBe(true)
+      expect(transformInclude('/project/node_modules/nuxt/dist/app/composables.js')).toBe(true)
+    })
   })
 
   describe('transform', () => {


### PR DESCRIPTION
Closes #34149

## Summary

`UnheadImportsPlugin` was transforming Nuxt's own `head/runtime/composables.js`, rewriting `@unhead/vue` imports to `#app/composables/head` which re-exports from `#unhead/composables` (same file) → infinite recursion causing `Maximum call stack size exceeded`.

The existing `distDir` exclusion used path prefix matching that fails with pnpm/bun symlinks. Added explicit regex pattern to exclude `node_modules/nuxt/dist/head/runtime/`.

## StackBlitz

| | Link | Expected |
|---|---|---|
| Bug | [nuxt-34149](https://stackblitz.com/github/onmax/repros/tree/repro/nuxt-34149/nuxt-34149?startScript=dev) | ❌ Stack overflow (may not reproduce on all systems) |
| Fix | [nuxt-34149-fix](https://stackblitz.com/github/onmax/repros/tree/repro/nuxt-34149/nuxt-34149-fix?startScript=dev) | ✅ Page renders |

## CLI Reproduction

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxt-34149 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxt-34149
cd nuxt-34149 && pnpm i && pnpm dev
```

## Verify fix

```bash
git sparse-checkout add nuxt-34149-fix
cd ../nuxt-34149-fix && pnpm i && pnpm dev
```

The `-fix` folder uses [pnpm patch](https://pnpm.io/cli/patch) to apply the fix locally.