### PR TITLE
fix(nitro-server): encode unicode paths in prerender header

### DIFF
--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -172,7 +172,7 @@ export default defineRenderHandler(async (event): Promise<Partial<RenderResponse
 
   if (_PAYLOAD_EXTRACTION && import.meta.prerender) {
     // Hint nitro to prerender payload for this route
-    appendResponseHeader(event, 'x-nitro-prerender', joinURL(ssrContext.url.replace(/\?.*$/, ''), PAYLOAD_FILENAME))
+    appendResponseHeader(event, 'x-nitro-prerender', encodeURI(joinURL(ssrContext.url.replace(/\?.*$/, ''), PAYLOAD_FILENAME)))
     // Use same ssr context to generate payload for this route
     await payloadCache!.setItem(ssrContext.url === '/' ? '/' : ssrContext.url.replace(/\/$/, ''), renderPayloadResponse(ssrContext))
   }


### PR DESCRIPTION
## 🔗 Linked issue
closes #34162

## ❓ Problem
Prerender fails with 500 for routes containing unicode characters (e.g. `/联想`). Works in 4.2.2, broken in 4.3.0.

The `x-nitro-prerender` header was using `ssrContext.url` which contains decoded unicode. HTTP headers require ASCII, so unicode characters caused:
```
TypeError: Cannot convert argument to a ByteString because the character at index 1 has a value of 32852 which is greater than 255.
```

## ✅ Solution
Add `encodeURI()` when setting the `x-nitro-prerender` header in the renderer.

## 📚 Reproduction
- Bug: https://stackblitz.com/github/onmax/repros/tree/repro/nuxt-34162/nuxt-34162
- Fix: https://stackblitz.com/github/onmax/repros/tree/repro/nuxt-34162/nuxt-34162-fix