### PR TITLE
fix(nuxt): add backwards compat for `#app` barrel export in keyed functions

### DIFF
--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -637,6 +637,7 @@ async function initNuxt (nuxt: Nuxt) {
     keyedFunctions: normalizedKeyedFunctions,
     alias: nuxt.options.alias,
     getAutoImports: unimport!.getImports,
+    appDir: nuxt.options.appDir,
   }))
 
   // remove duplicate css after modules are done

--- a/packages/nuxt/src/core/plugins/keyed-functions.ts
+++ b/packages/nuxt/src/core/plugins/keyed-functions.ts
@@ -161,7 +161,11 @@ export const KeyedFunctionsPlugin = (options: KeyedFunctionsOptions) => createUn
             if (fnMeta) { return fnMeta }
 
             // TODO: remove in Nuxt 5
-            if (source.startsWith(nuxtSrcPath)) {
+            if (
+              source.startsWith(nuxtSrcPath)
+              // ensure that the path has been resolved
+              && nuxtSrcPath !== '#app'
+            ) {
               for (const [fnSource, meta] of sourcesToMetas) {
                 if (meta.name !== functionName || !fnSource.startsWith(nuxtSrcPath)) { continue }
                 return meta

--- a/packages/nuxt/test/keyed-functions.test.ts
+++ b/packages/nuxt/test/keyed-functions.test.ts
@@ -63,7 +63,7 @@ describe('keyed functions plugin', () => {
     },
   ]
 
-  const transformPlugin = KeyedFunctionsPlugin({ sourcemap: false, keyedFunctions, alias: {}, getAutoImports: () => Promise.resolve(autoImports) }).raw({}, {} as any) as { transform: { handler: (code: string, id: string) => Promise<{ code: string } | null> } }
+  const transformPlugin = KeyedFunctionsPlugin({ sourcemap: false, keyedFunctions, alias: {}, getAutoImports: () => Promise.resolve(autoImports), appDir: '/nuxt/dist/app/' }).raw({}, {} as any) as { transform: { handler: (code: string, id: string) => Promise<{ code: string } | null> } }
 
   it('should add hash when there is none already provided', async () => {
     const code = `
@@ -150,7 +150,7 @@ useRenamedDefault()`
 
     const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {})
 
-    KeyedFunctionsPlugin({ sourcemap: false, keyedFunctions, alias: {}, getAutoImports: () => Promise.resolve(autoImports) }).raw({}, {} as any)
+    KeyedFunctionsPlugin({ sourcemap: false, keyedFunctions, alias: {}, getAutoImports: () => Promise.resolve(autoImports), appDir: '/nuxt/dist/app/' }).raw({}, {} as any)
 
     expect(warn).toHaveBeenCalledWith(expect.stringMatching(
       /\[nuxt:compiler\] \[keyed-functions\] Duplicate function name `useKeyTwo` with the same source `#app` found. Overwriting the existing entry./,
@@ -810,7 +810,7 @@ describe('core keyed functions', () => {
     { name: 'useLazyAsyncData', argumentLength: 3, source: '#app/composables/asyncData' },
     { name: 'useLazyFetch', argumentLength: 3, source: '#app/composables/fetch' },
   ]
-  const transformPlugin = KeyedFunctionsPlugin({ sourcemap: false, keyedFunctions, alias: {}, getAutoImports: () => Promise.resolve([]) }).raw({}, {} as any) as { transform: { handler: (code: string, id: string) => Promise<{ code: string } | null> } }
+  const transformPlugin = KeyedFunctionsPlugin({ sourcemap: false, keyedFunctions, alias: {}, getAutoImports: () => Promise.resolve([]), appDir: '/nuxt/dist/app/' }).raw({}, {} as any) as { transform: { handler: (code: string, id: string) => Promise<{ code: string } | null> } }
 
   it('should detect string type keys and not add a hash', async () => {
     const code = `

--- a/packages/nuxt/test/keyed-functions.test.ts
+++ b/packages/nuxt/test/keyed-functions.test.ts
@@ -521,12 +521,7 @@ import { useKeyTwo } from '#application' // deliberately using an alias starting
 useKey()
 useKeyTwo()
 `
-    expect((await transformPlugin.transform.handler(code, 'plugin.ts'))?.code.trim()).toMatchInlineSnapshot(`
-      "import { useKey } from 'some-other-source'
-      import { useKeyTwo } from '#application' // deliberately using an alias starting with #app
-      useKey()
-      useKeyTwo('$HJiaryoL2y' /* nuxt-injected */)"
-    `)
+    expect((await transformPlugin.transform.handler(code, 'plugin.ts'))?.code.trim()).toMatchInlineSnapshot(`undefined`)
   })
 
   it('should add hash when renamed in import', async () => {

--- a/packages/nuxt/test/keyed-functions.test.ts
+++ b/packages/nuxt/test/keyed-functions.test.ts
@@ -521,7 +521,12 @@ import { useKeyTwo } from '#application' // deliberately using an alias starting
 useKey()
 useKeyTwo()
 `
-    expect((await transformPlugin.transform.handler(code, 'plugin.ts'))?.code.trim()).toMatchInlineSnapshot(`undefined`)
+    expect((await transformPlugin.transform.handler(code, 'plugin.ts'))?.code.trim()).toMatchInlineSnapshot(`
+      "import { useKey } from 'some-other-source'
+      import { useKeyTwo } from '#application' // deliberately using an alias starting with #app
+      useKey()
+      useKeyTwo('$HJiaryoL2y' /* nuxt-injected */)"
+    `)
   })
 
   it('should add hash when renamed in import', async () => {

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1847,6 +1847,10 @@ describe('automatically keyed composables', () => {
     expect(html).toContain('true')
     expect(html).not.toContain('false')
   })
+  // TODO: remove in Nuxt 5
+  it('should work when imported from #app barrel export', async () => {
+    await expectNoClientErrors('/keyed-composables/barrel-import')
+  })
 })
 
 describe.runIf(isDev && !isWebpack)('css links', () => {

--- a/test/fixtures/basic/app/pages/keyed-composables/barrel-import.vue
+++ b/test/fixtures/basic/app/pages/keyed-composables/barrel-import.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+// check that `useState` works when imported from barrel export `#app`
+// - this is only for backwards compat
+import { useState } from '#app'
+
+const state = useState()
+</script>
+
+<template>
+  <div />
+</template>


### PR DESCRIPTION
### 🔗 Linked issue

fix https://github.com/nuxt/nuxt/issues/34192
fix https://github.com/nuxt/nuxt/issues/34185 (possibly; no reproduction, but the description looks similar)

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This adds backwards compatibility for the case when keyed functions are imported from the deprecated `#app` barrel export file.

---

Another possible solution would be to add the definitions for `keyedComposables` with the barrel file `#app` as the source. (we would have each composable defined twice with a different source)
https://github.com/nuxt/nuxt/blob/c9fed804b9bef362276033b03ca43730c6efa7dc/packages/schema/src/config/build.ts#L77-L86

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/4.x/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
