### PR TITLE
fix(nitro): encode unicode paths in `x-nitro-prerender` header

### DIFF
--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -2,7 +2,7 @@ import { AsyncLocalStorage } from 'node:async_hooks'
 import { getPrefetchLinks, getPreloadLinks, getRequestDependencies, renderResourceHeaders } from 'vue-bundle-renderer/runtime'
 import type { RenderResponse } from 'nitropack/types'
 import { appendResponseHeader, createError, getQuery, getResponseStatus, getResponseStatusText, writeEarlyHints } from 'h3'
-import { getQuery as getURLQuery, joinURL } from 'ufo'
+import { encodePath, getQuery as getURLQuery, joinURL } from 'ufo'
 import { propsToString, renderSSRHead } from '@unhead/vue/server'
 import type { HeadEntryOptions, Link, Script } from '@unhead/vue/types'
 import destr from 'destr'
@@ -172,7 +172,8 @@ export default defineRenderHandler(async (event): Promise<Partial<RenderResponse
 
   if (_PAYLOAD_EXTRACTION && import.meta.prerender) {
     // Hint nitro to prerender payload for this route
-    appendResponseHeader(event, 'x-nitro-prerender', joinURL(ssrContext.url.replace(/\?.*$/, ''), PAYLOAD_FILENAME))
+    // Encode the path for the header since ssrContext.url is decoded
+    appendResponseHeader(event, 'x-nitro-prerender', encodePath(joinURL(ssrContext.url.replace(/\?.*$/, ''), PAYLOAD_FILENAME)))
     // Use same ssr context to generate payload for this route
     await payloadCache!.setItem(ssrContext.url === '/' ? '/' : ssrContext.url.replace(/\/$/, ''), renderPayloadResponse(ssrContext))
   }

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -641,6 +641,11 @@ describe('pages', () => {
     expect(html).toContain('should be prerendered: true')
   })
 
+  it('renders unicode routes correctly', async () => {
+    const html = await $fetch('/random/日本語')
+    expect(html).toContain('Japanese random route')
+  })
+
   it('should trigger page:loading:end only once', async () => {
     const { page, consoleLogs } = await renderPage('/')
 

--- a/test/fixtures/basic/app/pages/random/[id].vue
+++ b/test/fixtures/basic/app/pages/random/[id].vue
@@ -24,6 +24,9 @@
     >
       Random (C)
     </NuxtLink>
+    <NuxtLink to="/random/日本語">
+      Random (Japanese)
+    </NuxtLink>
     <ServerOnlyComponent />
     <br>
 

--- a/test/fixtures/basic/app/pages/random/日本語.vue
+++ b/test/fixtures/basic/app/pages/random/日本語.vue
@@ -1,0 +1,6 @@
+<template>
+  <div>
+    <NuxtLink to="/">Home</NuxtLink>
+    <p>Japanese random route</p>
+  </div>
+</template>


### PR DESCRIPTION
closes #34162

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

When prerendering routes with unicode characters (e.g., `/联想` or `/日本語`), the `x-nitro-prerender` header value needs to be encoded since ssrContext.url is now decoded after #33990.

This fixes prerendering failing for routes discovered via crawler that contain unicode characters.

Closes #34162