### PR TITLE
Fix(docs): mispell in docs/3.guide/4.sessions-and-authentication.md at line 17

### DIFF
--- a/docs/3.guide/5.recipes/4.sessions-and-authentication.md
+++ b/docs/3.guide/5.recipes/4.sessions-and-authentication.md
@@ -14,7 +14,7 @@ The module uses secured & sealed cookies to store session data, so you don't nee
 Install the `nuxt-auth-utils` module using the `nuxt` CLI.
 
 ```bash [Terminal]
-npx nuxt module add auth-utils
+npx nuxi module add auth-utils
 ```
 
 ::callout


### PR DESCRIPTION
### 🔗 Linked issue

Not sure that there are any

### 📚 Description

Fix an simple mispell in docs/3.guide/4.sessions-and-authentication.md at line 17

Before: `npx **nuxt** module add auth-utils`
After: `npx **nuxi** module add auth-utils`
