### PR TITLE
fix(nuxt): watch server/ for builder:watch hook

### DIFF
--- a/packages/nuxt/src/core/builder.ts
+++ b/packages/nuxt/src/core/builder.ts
@@ -102,7 +102,7 @@ function createWatcher () {
   const nuxt = useNuxt()
   const isIgnored = createIsIgnored(nuxt)
 
-  const watcher = chokidarWatch(getLayerDirectories(nuxt).map(dirs => dirs.app), {
+  const watcher = chokidarWatch(getLayerDirectories(nuxt).flatMap(dirs => [dirs.app, dirs.server].filter(Boolean)), {
     ...nuxt.options.watchers.chokidar,
     ignoreInitial: true,
     ignored: [isIgnored, /[\\/]node_modules[\\/]/],
@@ -248,9 +248,12 @@ async function loadBuilder (nuxt: Nuxt, builder: string): Promise<NuxtBuilder> {
 function resolvePathsToWatch (nuxt: Nuxt, opts: { parentDirectories?: boolean } = {}): Set<string> {
   const pathsToWatch = new Set<string>()
   for (const dirs of getLayerDirectories(nuxt)) {
-    if (!dirs.app || isIgnored(dirs.app)) { continue }
-
-    pathsToWatch.add(dirs.app)
+    if (dirs.app && !isIgnored(dirs.app)) {
+      pathsToWatch.add(dirs.app)
+    }
+    if (dirs.server && !isIgnored(dirs.server)) {
+      pathsToWatch.add(dirs.server)
+    }
   }
   for (const pattern of nuxt.options.watch) {
     if (typeof pattern !== 'string') { continue }

--- a/packages/nuxt/src/core/builder.ts
+++ b/packages/nuxt/src/core/builder.ts
@@ -107,7 +107,7 @@ function createWatcher () {
   for (const layer of layerDirs) {
     paths.push(layer.app)
     // Only add server if it's not inside app (avoid double-watching)
-    if (!layer.server.includes(layer.app.replace(/\/?$/, '/'))) {
+    if (!layer.server.startsWith(layer.app.replace(/\/?$/, '/'))) {
       paths.push(layer.server)
     }
   }
@@ -262,7 +262,7 @@ function resolvePathsToWatch (nuxt: Nuxt, opts: { parentDirectories?: boolean } 
       pathsToWatch.add(dirs.app)
     }
     // Only add server if it's not inside app (avoid double-watching)
-    if (!isIgnored(dirs.server) && !dirs.server.includes(dirs.app.replace(/\/?$/, '/'))) {
+    if (!isIgnored(dirs.server) && !dirs.server.startsWith(dirs.app.replace(/\/?$/, '/'))) {
       pathsToWatch.add(dirs.server)
     }
   }


### PR DESCRIPTION
Closes #33827

## Summary

`builder:watch` hook not triggered for server/ changes. Regression from #33098 refactor.

## Context

- PR #33098 refactored to use `dirs.app` instead of `srcDir`
- In v4, server/ is outside app/, so it stopped being watched
- Fix: add `dirs.server` to watched paths

## StackBlitz

| | Link | Expected |
|---|---|---|
| Bug | [nuxt-33827](https://stackblitz.com/github/onmax/repros/tree/repro/nuxt-33827/nuxt-33827?startScript=dev) | No log on server/ change |
| Fix | [nuxt-33827-fix](https://stackblitz.com/github/onmax/repros/tree/repro/nuxt-33827/nuxt-33827-fix?startScript=dev) | Log appears |