### PR TITLE
fix(kit): include prereleases in semver satisfy check

### DIFF
--- a/packages/kit/src/module/install.test.ts
+++ b/packages/kit/src/module/install.test.ts
@@ -1,0 +1,81 @@
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { join } from 'pathe'
+import { findWorkspaceDir } from 'pkg-types'
+import { loadNuxt } from '../loader/nuxt.ts'
+import { defineNuxtModule } from './define.ts'
+
+const repoRoot = await findWorkspaceDir()
+
+describe('nuxt module install', () => {
+  const tempDir = join(repoRoot, 'node_modules/.temp/module-prerelease-test')
+
+  beforeAll(async () => {
+    const prereleaseModule = join(tempDir, 'node_modules/prerelease-module')
+    await mkdir(prereleaseModule, { recursive: true })
+    await writeFile(join(prereleaseModule, 'package.json'), JSON.stringify({
+      name: 'prerelease-module',
+      version: '2.0.0-beta.1',
+      type: 'module',
+      exports: './index.js',
+    }))
+    await writeFile(join(prereleaseModule, 'index.js'), `
+export default Object.assign(() => {}, {
+  getMeta: () => ({
+    name: 'prerelease-module',
+    configKey: 'prereleaseModule'
+  })
+})
+    `)
+  })
+
+  afterAll(async () => {
+    await rm(tempDir, { recursive: true, force: true })
+  })
+
+  it('accounts for prerelease versions in module dependencies', async () => {
+    const nuxt = await loadNuxt({
+      cwd: tempDir,
+      overrides: {
+        modules: [
+          defineNuxtModule({
+            meta: {
+              name: 'parent-module',
+              version: '1.0.0',
+            },
+            moduleDependencies: {
+              'prerelease-module': {
+                version: '>=1',
+              },
+            },
+            setup () {},
+          }),
+        ],
+      },
+    })
+
+    await nuxt.close()
+  })
+
+  it('rejects incompatible prerelease versions in module dependencies', async () => {
+    await expect(loadNuxt({
+      cwd: tempDir,
+      overrides: {
+        modules: [
+          defineNuxtModule({
+            meta: {
+              name: 'parent-module',
+              version: '1.0.0',
+            },
+            moduleDependencies: {
+              'prerelease-module': {
+                version: '>=3',
+              },
+            },
+            setup () {},
+          }),
+        ],
+      },
+    })).rejects.toThrow(/Module `prerelease-module` version \(`2\.0\.0-beta\.1`\) does not satisfy `>=3`/)
+  })
+})

--- a/packages/kit/src/module/install.ts
+++ b/packages/kit/src/module/install.ts
@@ -77,7 +77,7 @@ export async function installModules (modulesToInstall: Map<ModuleToInstall, Rec
       if (value.version) {
         const resolvePaths = [res.resolvedModulePath!, ...nuxt.options.modulesDir].filter(Boolean)
         const pkg = await readPackageJSON(name, { from: resolvePaths }).catch(() => null)
-        if (pkg?.version && !semver.satisfies(pkg.version, value.version)) {
+        if (pkg?.version && !semver.satisfies(pkg.version, value.version, { includePrerelease: true })) {
           const message = `Module \`${name}\` version (\`${pkg.version}\`) does not satisfy \`${value.version}\` (requested by ${moduleToAttribute}).`
           error = new TypeError(message)
         }


### PR DESCRIPTION
### 🔗 Linked issue

none

### 📚 Description

If a module specifies the range for another module to be `>=5.1` for example, the other module could not be installed as `6.0.0-beta.1`. This PR allows for that.

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/4.x/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
