### PR TITLE
chore: add ai config in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,10 @@ coverage
 !.idea/modules.xml
 !.idea/inspectionProfiles/Project_Default.xml
 
+# AI config 
+.agents
+.claude
+
 # OSX
 .DS_Store
 .AppleDouble


### PR DESCRIPTION
recently I've learned about skills. suppose we're using skills. it then creates two folders with many files. I think we can add those in gitignore.