### PR TITLE
fix(docs): broken links

### DIFF
--- a/docs/4.api/2.composables/use-route-announcer.md
+++ b/docs/4.api/2.composables/use-route-announcer.md
@@ -15,7 +15,7 @@ This composable is available in Nuxt v3.12+.
 ## Description
 
 A composable which observes the page title changes and updates the announcer message accordingly. Used by [`<NuxtRouteAnnouncer>`](/docs/4.x/api/components/nuxt-route-announcer) and controllable.
-It hooks into Unhead's [`dom:rendered`](https://unhead.unjs.io/docs/typescript/head/api/hooks/dom-rendered) to read the page's title and set it as the announcer message.
+It hooks into Unhead's `dom:rendered` hook to read the page's title and set it as the announcer message.
 
 ## Parameters
 

--- a/docs/4.api/4.commands/add.md
+++ b/docs/4.api/4.commands/add.md
@@ -4,7 +4,7 @@ description: "Scaffold an entity into your Nuxt application."
 links:
   - label: Source
     icon: i-simple-icons-github
-    to: https://github.com/nuxt/cli/blob/main/packages/nuxi/src/commands/add.ts
+    to: https://github.com/nuxt/cli/blob/main/packages/nuxi/src/commands/add-template.ts
     size: xs
 ---
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -33,6 +33,9 @@ exclude = [
   "https://www.webpagetest.org/",
   "https://stackoverflow.com/help/minimal-reproducible-example",
   "https://gsap.com/",
+  # external docs sites that block or rate-limit CI bots
+  'https://router.vuejs.org/(.*)',
+  'https://vitest.dev/(.*)',
   # dummy example URLs
   "https://myawesome-lib.js/",
   "https://awesome-lib.js/",


### PR DESCRIPTION
Fixes broken links caught by CI link-checker:

- `add.md`: source link pointed to `add.ts` (renamed to `add-template.ts`)
- `use-route-announcer.md`: unhead hooks docs link returns 404 (removed link, kept text)
- excluded `router.vuejs.org` and `vitest.dev` from link-checker (external sites that rate-limit CI bots)