### PR TITLE
fix(vite): use H3Error for 404 in dev server

### DIFF
--- a/packages/vite/src/plugins/dev-server.ts
+++ b/packages/vite/src/plugins/dev-server.ts
@@ -3,11 +3,12 @@ import type { Nuxt, ViteConfig } from '@nuxt/schema'
 import { getPort } from 'get-port-please'
 import { defu } from 'defu'
 import type { H3Event as H3V2Event } from 'h3-next'
-import { createError } from 'h3'
 import type { H3Event as H3V1Event } from 'h3'
 import { useNitro } from '@nuxt/kit'
 import { joinURL } from 'ufo'
 import type { IncomingMessage, ServerResponse } from 'node:http'
+
+import type { ErrorPartial } from '../types'
 
 export function DevServerPlugin (nuxt: Nuxt): Plugin {
   let useViteCors = false
@@ -183,7 +184,7 @@ export function DevServerPlugin (nuxt: Nuxt): Plugin {
 
         // if vite has not handled the request, we want to send a 404 for paths which are not in any static base or dev server handlers
         if (url.startsWith(nuxt.options.app.buildAssetsDir) && !staticBases.some(baseURL => url.startsWith(baseURL)) && !devHandlerRegexes.some(regex => regex.test(url))) {
-          throw createError({ statusCode: 404 })
+          throw { status: 404, unhandled: false } satisfies ErrorPartial
         }
       })
       await nuxt.callHook('server:devHandler', viteMiddleware, {

--- a/packages/vite/src/plugins/dev-server.ts
+++ b/packages/vite/src/plugins/dev-server.ts
@@ -3,12 +3,11 @@ import type { Nuxt, ViteConfig } from '@nuxt/schema'
 import { getPort } from 'get-port-please'
 import { defu } from 'defu'
 import type { H3Event as H3V2Event } from 'h3-next'
+import { createError } from 'h3'
 import type { H3Event as H3V1Event } from 'h3'
 import { useNitro } from '@nuxt/kit'
 import { joinURL } from 'ufo'
 import type { IncomingMessage, ServerResponse } from 'node:http'
-
-import type { ErrorPartial } from '../types'
 
 export function DevServerPlugin (nuxt: Nuxt): Plugin {
   let useViteCors = false
@@ -184,7 +183,7 @@ export function DevServerPlugin (nuxt: Nuxt): Plugin {
 
         // if vite has not handled the request, we want to send a 404 for paths which are not in any static base or dev server handlers
         if (url.startsWith(nuxt.options.app.buildAssetsDir) && !staticBases.some(baseURL => url.startsWith(baseURL)) && !devHandlerRegexes.some(regex => regex.test(url))) {
-          throw { status: 404 } satisfies ErrorPartial
+          throw createError({ statusCode: 404 })
         }
       })
       await nuxt.callHook('server:devHandler', viteMiddleware, {


### PR DESCRIPTION
Related to #34149 (separate issue from the stack overflow fix in #34195)

## Summary

The vite dev-server plugin was throwing `{ status: 404 }` (plain object) for unhandled `/_nuxt/` requests. The CLI's h3 error handler marks non-H3Error objects as "unhandled" and logs them with full stack traces.

Changed to use `createError({ statusCode: 404 })` so 404s are properly recognized as H3Errors.

## History

| Commit | PR | Change |
|--------|------|--------|
| `856637340` | #31543 | **Original fix** - Added 404 for non-existent `/_nuxt/` paths using `createError({ statusCode: 404 })` |
| `139ef2bd9` | #34048 | **Regression** - Changed to `throw { status: 404 }` during cors refactor (to reduce h3 dependency) |
| `0cd881230` | #34225 | **This PR** - Restored proper H3Error |

## StackBlitz

| | Link | Expected |
|---|---|---|
| Bug | [nuxt-34149-404](https://stackblitz.com/github/onmax/repros/tree/repro/nuxt-34149/nuxt-34149-404?startScript=dev) | ❌ Terminal error on `/_nuxt/` request |
| Fix | [nuxt-34149-404-fix](https://stackblitz.com/github/onmax/repros/tree/repro/nuxt-34149/nuxt-34149-404-fix?startScript=dev) | ✅ No terminal error |

## CLI Reproduction

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxt-34149 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxt-34149-404
cd nuxt-34149-404 && pnpm i && pnpm dev
# Then curl http://localhost:3000/_nuxt/
```

## Verify fix

```bash
git sparse-checkout add nuxt-34149-404-fix
cd ../nuxt-34149-404-fix && pnpm i && pnpm dev
# Then curl http://localhost:3000/_nuxt/ - no error
```

The `-fix` folder uses [pnpm patch](https://pnpm.io/cli/patch) to apply the fix locally.