### PR TITLE
fix(nitro): preserve error.message for fatal errors in SSR

### DIFF
--- a/packages/nitro-server/src/runtime/handlers/error.ts
+++ b/packages/nitro-server/src/runtime/handlers/error.ts
@@ -32,8 +32,10 @@ export default <NitroErrorHandler> async function errorhandler (error, event, { 
   // remove proto/hostname/port from URL
   const url = new URL(errorObject.url)
   errorObject.url = withoutBase(url.pathname, useRuntimeConfig(event).app.baseURL) + url.search + url.hash
-  // add default server message
-  errorObject.message ||= 'Server Error'
+  // add default server message (keep sanitized for unhandled errors)
+  errorObject.message = (error as any).unhandled
+    ? (errorObject.message || 'Server Error')
+    : (error.message || errorObject.message || 'Server Error')
   // we will be rendering this error internally so we can pass along the error.data safely
   errorObject.data ||= error.data
   errorObject.statusText ||= (error as any).statusText || error.statusMessage

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -96,7 +96,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(rootDir, '.output-inline/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"561k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"562k"`)
 
     const modules = await analyzeSizes(['node_modules/**/*'], serverDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"97.8k"`)


### PR DESCRIPTION
Closes #33432

## Summary

When using `createError()` with `fatal: true`, the custom error message was being stripped in production SSR responses, showing "Server Error" instead of the provided message. This fix preserves the original `error.message` for handled errors while keeping the security protection for unhandled errors.

## StackBlitz

| | Link | Expected |
|---|---|---|
| Bug | [nuxt-33432](https://stackblitz.com/github/onmax/repros/tree/repro/nuxt-33432/nuxt-33432?startScript=build) | ❌ SSR shows "Server Error" |
| Fix | [nuxt-33432-fix](https://stackblitz.com/github/onmax/repros/tree/repro/nuxt-33432/nuxt-33432-fix?startScript=build) | ✅ SSR shows custom message |

## CLI Reproduction

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxt-33432 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxt-33432
cd nuxt-33432 && pnpm i && pnpm build && pnpm start
# Visit http://localhost:3000/error - SSR shows "Server Error"
```

## Verify fix

```bash
git sparse-checkout add nuxt-33432-fix
cd ../nuxt-33432-fix && pnpm i && pnpm build && pnpm start
# Visit http://localhost:3000/error - SSR now shows the custom message
```

## Change

```diff
  // add default server message (keep sanitized for unhandled errors)
- errorObject.message ||= 'Server Error'
+ errorObject.message = (error as any).unhandled
+   ? (errorObject.message || 'Server Error')
+   : (error.message || errorObject.message || 'Server Error')
```

This preserves the security protection from #28156 (hiding messages for unhandled errors) while allowing intentional `createError()` messages to be shown.

## Related

- Original issue: #33432
- Security context: #28156 (hide unhandled error messages in prod)
- Investigation by @Yizack in the issue comments