### PR TITLE
fix(webpack): use H3Error for 403 in dev server

### DIFF
--- a/packages/webpack/src/webpack.ts
+++ b/packages/webpack/src/webpack.ts
@@ -1,5 +1,4 @@
 import pify from 'pify'
-import { createError } from 'h3'
 import type { H3Event as H3V1Event } from 'h3'
 import type { H3Event as H3V2Event } from 'h3-next'
 import type { IncomingMessage, MultiWatching, ServerResponse } from 'webpack-dev-middleware'
@@ -141,7 +140,7 @@ function wdmToH3Handler (devMiddleware: webpackDevMiddleware.API<IncomingMessage
     // disallow cross-site requests in no-cors mode
     const { req, res } = 'runtime' in event ? event.runtime!.node! : event.node
     if (req.headers['sec-fetch-mode'] === 'no-cors' && req.headers['sec-fetch-site'] === 'cross-site') {
-      throw createError({ statusCode: 403 })
+      throw { status: 403, unhandled: false }
     }
 
     event.context.webpack = {

--- a/packages/webpack/src/webpack.ts
+++ b/packages/webpack/src/webpack.ts
@@ -1,4 +1,5 @@
 import pify from 'pify'
+import { createError } from 'h3'
 import type { H3Event as H3V1Event } from 'h3'
 import type { H3Event as H3V2Event } from 'h3-next'
 import type { IncomingMessage, MultiWatching, ServerResponse } from 'webpack-dev-middleware'
@@ -140,7 +141,7 @@ function wdmToH3Handler (devMiddleware: webpackDevMiddleware.API<IncomingMessage
     // disallow cross-site requests in no-cors mode
     const { req, res } = 'runtime' in event ? event.runtime!.node! : event.node
     if (req.headers['sec-fetch-mode'] === 'no-cors' && req.headers['sec-fetch-site'] === 'cross-site') {
-      throw { status: 403 }
+      throw createError({ statusCode: 403 })
     }
 
     event.context.webpack = {


### PR DESCRIPTION
Same pattern as #34225 for vite dev-server.

**Before:** `throw { status: 403 }` logs `[h3] [unhandled]` error to terminal
**After:** `throw createError({ statusCode: 403 })` is properly handled

Closes #34149 (together with #34225)