### PR TITLE
docs: update default aliases in configuration reference

### DIFF
--- a/docs/4.api/6.nuxt-config.md
+++ b/docs/4.api/6.nuxt-config.md
@@ -13,12 +13,13 @@ You can improve your DX by defining additional aliases to access custom director
 - **Default**
 ```json
 {
-  "~": "/<srcDir>",
-  "@": "/<srcDir>",
+  "~": "/<rootDir>/app",
+  "@": "/<rootDir>/app",
   "~~": "/<rootDir>",
   "@@": "/<rootDir>",
   "#shared": "/<rootDir>/shared",
-  "assets": "/<srcDir>/assets",
+  "#server": "/<rootDir>/server",
+  "assets": "/<rootDir>/app/assets",
   "public": "/<rootDir>/public",
   "#build": "/<rootDir>/.nuxt",
   "#internal/nuxt/paths": "/<rootDir>/.nuxt/paths.mjs"


### PR DESCRIPTION
This PR updates the default alias configuration in [docs/4.api/6.nuxt-config.md](https://nuxt.com/docs/4.x/api/nuxt-config#alias).
Changes:
- Added the `#server` alias which defaults to `/<rootDir>/server`, matching the existing `#shared` alias.
- Updated `~`, `@`, and `assets` defaults to explicitly point to `/<rootDir>/app` instead of `/<srcDir>`. This aligns with the default Nuxt 4 directory structure (where `srcDir` is `app`) and provides better visual consistency with the other `rootDir` aliases.

**Before:**
```json
{
  "~": "/<srcDir>",
  "@": "/<srcDir>",
  "~~": "/<rootDir>",  
  "@@": "/<rootDir>",
  "#shared": "/<rootDir>/shared",
  "assets": "/<srcDir>/assets",
  "public": "/<rootDir>/public",
  "#build": "/<rootDir>/.nuxt",
  "#internal/nuxt/paths": "/<rootDir>/.nuxt/paths.mjs"
}
```

**After:**
```json
{
  "~": "/<rootDir>/app",
  "@": "/<rootDir>/app",
  "~~": "/<rootDir>",
  "@@": "/<rootDir>",
  "#shared": "/<rootDir>/shared",
  "#server": "/<rootDir>/server",
  "assets": "/<rootDir>/app/assets",
  "public": "/<rootDir>/public",
  "#build": "/<rootDir>/.nuxt",
  "#internal/nuxt/paths": "/<rootDir>/.nuxt/paths.mjs"
}
```