### PR TITLE
fix(nuxt): ensure NuxtError extends Error type

### DIFF
--- a/packages/nuxt/src/app/composables/error.ts
+++ b/packages/nuxt/src/app/composables/error.ts
@@ -12,7 +12,9 @@ export const NUXT_ERROR_SIGNATURE = '__nuxt_error'
 /* @__NO_SIDE_EFFECTS__ */
 export const useError = (): Ref<NuxtPayload['error']> => toRef(useNuxtApp().payload, 'error')
 
-export interface NuxtError<DataT = unknown> extends Omit<H3Error<DataT>, 'statusCode' | 'statusMessage'> {
+// #34138 - `Omit` breaks the Error inheritance chain, causing `@typescript-eslint/only-throw-error` to fail
+// Adding `Error` explicitly restores throwability. TODO: remove `Error` in Nuxt 5 when `Omit` is no longer needed
+export interface NuxtError<DataT = unknown> extends Omit<H3Error<DataT>, 'statusCode' | 'statusMessage'>, Error {
   error?: true
   status?: number
   statusText?: string


### PR DESCRIPTION
### 🔗 Linked issue

Resolves: #34138 

### 📚 Description

`Omit` breaks the Error inheritance chain, causing `@typescript-eslint/only-throw-error` to fail.
Adding `Error` explicitly restores throwability. 

⚠️ We must remove `Error` in Nuxt 5 when `Omit` is no longer needed.


