### PR TITLE
docs: update example of email validation

### DIFF
--- a/docs/3.guide/5.recipes/4.sessions-and-authentication.md
+++ b/docs/3.guide/5.recipes/4.sessions-and-authentication.md
@@ -47,7 +47,7 @@ Let's create a `/api/login` API route that will accept a POST request with the e
 import { z } from 'zod'
 
 const bodySchema = z.object({
-  email: z.string().email(),
+  email: z.email(),
   password: z.string().min(8),
 })
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves #34246

### 📚 Description
Declaration was marked as deprecated. Use `z.email()` instead.
