### PR TITLE
refactor(nuxt): use `ComponentProps` helper to extract layout props

### DIFF
--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -632,7 +632,7 @@ export default defineNuxtModule({
           '',
           'declare module \'nuxt/app\' {',
           '  interface NuxtLayouts {',
-          ...Object.values(app.layouts).map(layout => `    ${genObjectKey(layout.name)}: ComponentProps<typeof ${genInlineTypeImport(layout.file)}>,`),
+          ...Object.values(app.layouts).map(layout => `    ${genObjectKey(layout.name)}: ComponentProps<${genInlineTypeImport(layout.file)}>,`),
           '}',
           '  export type LayoutKey = keyof NuxtLayouts extends never ? string : keyof NuxtLayouts',
           '  interface PageMeta {',


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

When `generic`(never) or `vapor`(possible after Vue 3.6 is out) is enabled on the layout, the component type will become a function instead of `DefineComponent`.

The code is from [`vue-component-type-helpers`](https://github.com/vuejs/language-tools/blob/3ffeab31db946d677ba23c1e7ebd853487e80a1b/packages/component-type-helpers/index.ts#L1-L3).