### PR TITLE
fix(nuxt): decode encoded route records

### DIFF
--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -42,7 +42,7 @@ function createCurrentLocation (
   return path + (path.includes('?') ? '' : search) + hash
 }
 
-const PCT_ENCODE_RE = /%[0-9A-Fa-f]{2}/
+const PCT_ENCODE_RE = /%[0-9A-F]{2}/i
 function normalizeRouteStr (value: string) {
   return PCT_ENCODE_RE.test(value) ? decodePath(value) : value
 }

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -38,7 +38,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
   it('default client bundle size (pages)', async () => {
     const clientStats = await analyzeSizes(['**/*.js'], join(pagesRootDir, '.output/public'))
 
-    expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"176k"`)
+    expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"177k"`)
 
     const files = clientStats!.files.map(f => f.replace(/\..*\.js/, '.js'))
 
@@ -118,7 +118,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(pagesRootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"292k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"293k"`)
 
     const modules = await analyzeSizes(['node_modules/**/*'], serverDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"1441k"`)

--- a/test/fixtures/basic/app/pages/i18n-unicode-city.vue
+++ b/test/fixtures/basic/app/pages/i18n-unicode-city.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+definePageMeta({
+  path: '/es/citt%C3%A0',
+})
+</script>
+
+<template>
+  <div id="city-ok">CITY_PAGE_OK</div>
+</template>

--- a/test/fixtures/basic/app/pages/i18n-unicode-city.vue
+++ b/test/fixtures/basic/app/pages/i18n-unicode-city.vue
@@ -5,5 +5,7 @@ definePageMeta({
 </script>
 
 <template>
-  <div id="city-ok">CITY_PAGE_OK</div>
+  <div id="city-ok">
+    CITY_PAGE_OK
+  </div>
 </template>

--- a/test/fixtures/basic/app/pages/i18n-unicode-link.vue
+++ b/test/fixtures/basic/app/pages/i18n-unicode-link.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    <NuxtLink to="/es/città">Go ES city</NuxtLink>
+  </div>
+</template>


### PR DESCRIPTION
Fixes #34249

When a module (e.g. @nuxtjs/i18n custom routes) emits percent-encoded route record paths like `/es/citt%C3%A0`, vue-router may fail to match decoded runtime locations like `/es/città`, causing 404s.

This normalizes route records once at router creation: decode route record `path`/`alias` only if `%xx` sequences are present (via `ufo` `decodePath`).
