### PR TITLE
fix(nitro-server): write route-rules template to disk

### DIFF
--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -389,6 +389,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
   const cachedMatchers: Record<string, string> = {}
   addTemplate({
     filename: 'route-rules.mjs',
+    write: true,
     getContents () {
       const key = hash(nuxt._nitro?.options.routeRules || {})
       if (cachedMatchers[key]) {


### PR DESCRIPTION
Closes #34164

## Summary

`route-rules.mjs` template was only in VFS (virtual file system). In pnpm monorepos with deep `.pnpm` store paths, Vite's `import-analysis` plugin fails to resolve it. Adding `write: true` ensures the file is written to `.nuxt/` on disk, matching the pattern used by `app.config.mjs`.

## StackBlitz

| | Link | Expected |
|---|---|---|
| Bug | [nuxt-34164](https://stackblitz.com/github/onmax/repros/tree/repro/nuxt-34164/nuxt-34164?startScript=prepare) | `.nuxt/route-rules.mjs` missing |
| Fix | [nuxt-34164-fix](https://stackblitz.com/github/onmax/repros/tree/repro/nuxt-34164/nuxt-34164-fix?startScript=prepare) | `.nuxt/route-rules.mjs` exists |

## CLI Reproduction

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxt-34164 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxt-34164
cd nuxt-34164 && pnpm i && cd apps/web && pnpm prepare
ls .nuxt/route-rules.mjs  # does not exist
```

## Verify fix

```bash
cd /tmp && git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxt-34164 https://github.com/onmax/repros.git repros-fix
cd repros-fix && git sparse-checkout set nuxt-34164-fix
cd nuxt-34164-fix && pnpm i && cd apps/web && pnpm prepare
ls .nuxt/route-rules.mjs  # exists
```

The `-fix` folder uses [pnpm patch](https://pnpm.io/cli/patch) to apply the fix locally.