### PR TITLE
docs: align server alias examples with `#server` and `rootDir`

### DIFF
--- a/docs/1.getting-started/06.styling.md
+++ b/docs/1.getting-started/06.styling.md
@@ -155,7 +155,7 @@ Nuxt uses `unhead` under the hood, and you can refer to [its full documentation]
 
 If you need more advanced control, you can intercept the rendered html with a hook and modify the head programmatically.
 
-Create a plugin in `~/server/plugins/my-plugin.ts` like this:
+Create a plugin in `~~/server/plugins/my-plugin.ts` like this:
 
 <!-- TODO: figure out how to use twoslash to inject types for a different context -->
 

--- a/docs/2.directory-structure/1.server.md
+++ b/docs/2.directory-structure/1.server.md
@@ -43,11 +43,11 @@ const { data } = await useFetch('/api/hello')
 
 ## Server Routes
 
-Files inside the `~/server/api` are automatically prefixed with `/api` in their route.
+Files inside the `~~/server/api` are automatically prefixed with `/api` in their route.
 
 :video-accordion{title="Watch a video from Vue School on API routes" videoId="761468863" platform="vimeo"}
 
-To add server routes without `/api` prefix, put them into `~/server/routes` directory.
+To add server routes without `/api` prefix, put them into `~~/server/routes` directory.
 
 **Example:**
 
@@ -63,7 +63,7 @@ Note that currently server routes do not support the full functionality of dynam
 
 ## Server Middleware
 
-Nuxt will automatically read in any file in the `~/server/middleware` to create server middleware for your project.
+Nuxt will automatically read in any file in the `~~/server/middleware` to create server middleware for your project.
 
 Middleware handlers will run on every request before any other server route to add or check headers, log requests, or extend the event's request object.
 
@@ -87,7 +87,7 @@ export default defineEventHandler((event) => {
 
 ## Server Plugins
 
-Nuxt will automatically read any files in the `~/server/plugins` directory and register them as Nitro plugins. This allows extending Nitro's runtime behavior and hooking into lifecycle events.
+Nuxt will automatically read any files in the `~~/server/plugins` directory and register them as Nitro plugins. This allows extending Nitro's runtime behavior and hooking into lifecycle events.
 
 **Example:**
 
@@ -105,7 +105,7 @@ Server routes are powered by [h3js/h3](https://github.com/h3js/h3) which comes w
 
 :read-more{to="https://www.jsdocs.io/package/h3#package-index-functions" title="Available H3 Request Helpers" target="_blank"}
 
-You can add more helpers yourself inside the `~/server/utils` directory.
+You can add more helpers yourself inside the `~~/server/utils` directory.
 
 For example, you can define a custom handler utility that wraps the original handler and performs additional operations before returning the final response.
 
@@ -218,7 +218,7 @@ export default defineEventHandler((event) => {
 
 Catch-all routes are helpful for fallback route handling.
 
-For example, creating a file named `~/server/api/foo/[...].ts` will register a catch-all route for all requests that do not match any route handler, such as `/api/foo/bar/baz`.
+For example, creating a file named `~~/server/api/foo/[...].ts` will register a catch-all route for all requests that do not match any route handler, such as `/api/foo/bar/baz`.
 
 ```ts [server/api/foo/[...\\].ts]
 export default defineEventHandler((event) => {
@@ -228,7 +228,7 @@ export default defineEventHandler((event) => {
 })
 ```
 
-You can set a name for the catch-all route by using `~/server/api/foo/[...slug].ts` and access it via `event.context.params.slug`.
+You can set a name for the catch-all route by using `~~/server/api/foo/[...slug].ts` and access it via `event.context.params.slug`.
 
 ```ts [server/api/foo/[...slug\\].ts]
 export default defineEventHandler((event) => {

--- a/docs/3.guide/6.going-further/2.hooks.md
+++ b/docs/3.guide/6.going-further/2.hooks.md
@@ -57,7 +57,7 @@ Explore all available App hooks.
 
 These hooks are available for [server plugins](/docs/4.x/directory-structure/server#server-plugins) to hook into Nitro's runtime behavior.
 
-```ts [~/server/plugins/test.ts]
+```ts [~~/server/plugins/test.ts]
 export default defineNitroPlugin((nitroApp) => {
   nitroApp.hooks.hook('render:html', (html, { event }) => {
     console.log('render:html', html)

--- a/docs/4.api/5.kit/11.nitro.md
+++ b/docs/4.api/5.kit/11.nitro.md
@@ -426,10 +426,10 @@ export default defineEventHandler(() => {
 ## `addServerScanDir`
 
 Add directories to be scanned by Nitro. It will check for subdirectories, which will be registered
-just like the `~/server` folder is.
+just like the `~~/server` folder is.
 
 ::note
-Only `~/server/api`, `~/server/routes`, `~/server/middleware`, and `~/server/utils` are scanned.
+Only `~~/server/api`, `~~/server/routes`, `~~/server/middleware`, and `~~/server/utils` are scanned.
 ::
 
 ### Usage

--- a/docs/4.api/6.nuxt-config.md
+++ b/docs/4.api/6.nuxt-config.md
@@ -373,7 +373,7 @@ export default defineNuxtConfig({
   build: {
     templates: [
       {
-        src: '~/modules/support/plugin.js', // `src` can be absolute or relative
+        src: '~~/modules/support/plugin.js', // `src` can be absolute or relative
         dst: 'support.js', // `dst` is relative to project `.nuxt` dir
       },
     ],
@@ -881,7 +881,7 @@ Defaults to 'silent' when running in CI or when a TTY is not available. This opt
 Modules are Nuxt extensions which can extend its core functionality and add endless integrations.
 
 Each module is either a string (which can refer to a package, or be a path to a file), a tuple with the module as first string and the options as a second object, or an inline module function.
-Nuxt tries to resolve each item in the modules array using node require path (in `node_modules`) and then will be resolved from project `srcDir` if `~` alias is used.
+Nuxt tries to resolve each item in the modules array using node require path (in `node_modules`) and then will be resolved from project `rootDir` if `~~` alias is used.
 
 - **Type**: `array`
 
@@ -896,8 +896,8 @@ export default defineNuxtConfig({
   modules: [
   // Using package name
     '@nuxt/scripts',
-    // Relative to your project srcDir
-    '~/custom-modules/awesome.js',
+    // Relative to your project rootDir
+    '~~/custom-modules/awesome.js',
     // Providing options
     ['@nuxtjs/google-analytics', { ua: 'X1234567' }],
     // Inline definition
@@ -1298,7 +1298,7 @@ Define the server directory of your Nuxt application, where Nitro routes, middle
 If a relative path is specified, it will be relative to your `rootDir`.
 
 - **Type**: `string`
-- **Default:** `"/<srcDir>/server"`
+- **Default:** `"/<rootDir>/server"`
 
 ## serverHandlers
 
@@ -1319,7 +1319,7 @@ Each handler accepts the following options:
 ```ts
 export default defineNuxtConfig({
   serverHandlers: [
-    { route: '/path/foo/**:name', handler: '~/server/foohandler.ts' },
+    { route: '/path/foo/**:name', handler: '#server/foohandler.ts' },
   ],
 })
 ```
@@ -1409,22 +1409,27 @@ export default defineNuxtConfig({
   srcDir: 'app/',
 })
 ```
+
 This expects the following folder structure:
 ```bash
 -| app/
 ---| assets/
 ---| components/
+---| composables/
 ---| layouts/
 ---| middleware/
 ---| pages/
 ---| plugins/
+---| utils/
 ---| app.config.ts
 ---| app.vue
 ---| error.vue
 -| server/
+-| shared/
 -| public/
 -| modules/
--| nuxt.config.js
+-| layers/
+-| nuxt.config.ts
 -| package.json
 ```
 
@@ -1693,7 +1698,7 @@ Please note that not all vite options are supported in Nuxt.
 ### `root`
 
 - **Type**: `string`
-- **Default:** `"/<srcDir>"`
+- **Default:** `"/<rootDir>"`
 
 ### `server`
 
@@ -1706,7 +1711,7 @@ Please note that not all vite options are supported in Nuxt.
 ```json
 [
   "/<rootDir>/.nuxt",
-  "/<srcDir>",
+  "/<rootDir>/app",
   "/<rootDir>",
   "/<workspaceDir>"
 ]

--- a/docs/7.migration/11.server.md
+++ b/docs/7.migration/11.server.md
@@ -10,7 +10,7 @@ In a built Nuxt 3 application, there is no runtime Nuxt dependency. That means y
 ## Steps
 
 1. Remove the `render` key in your `nuxt.config`.
-2. Any files in `~/server/api` and `~/server/middleware` will be automatically registered; you can remove them from your `serverMiddleware` array.
+2. Any files in `~~/server/api` and `~~/server/middleware` will be automatically registered; you can remove them from your `serverMiddleware` array.
 3. Update any other items in your `serverMiddleware` array to point to files or npm packages directly, rather than using inline functions.
 
 :read-more{to="/docs/4.x/directory-structure/server"}

--- a/packages/kit/src/nitro.ts
+++ b/packages/kit/src/nitro.ts
@@ -113,7 +113,7 @@ export function addServerImportsDir (dirs: string | string[], opts: { prepend?: 
 
 /**
  * Add directories to be scanned by Nitro. It will check for subdirectories,
- * which will be registered just like the `~/server` folder is.
+ * which will be registered just like the `~~/server` folder is.
  */
 export function addServerScanDir (dirs: string | string[], opts: { prepend?: boolean } = {}): void {
   const nuxt = useNuxt()

--- a/packages/nitro-server/src/augments.ts
+++ b/packages/nitro-server/src/augments.ts
@@ -137,7 +137,7 @@ declare module '@nuxt/schema' {
      * @example
      * ```js
      * serverHandlers: [
-     *   { route: '/path/foo/**:name', handler: '~/server/foohandler.ts' }
+     *   { route: '/path/foo/**:name', handler: '#server/foohandler.ts' }
      * ]
      * ```
      */

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -92,7 +92,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
     }
   }
 
-  // Resolve aliases in user-provided input - so `~/server/test` will work
+  // Resolve aliases in user-provided input - so `~~/server/test` will work
   nuxt.options.nitro.plugins ||= []
   nuxt.options.nitro.plugins = nuxt.options.nitro.plugins.map(plugin => plugin ? resolveAlias(plugin, nuxt.options.alias) : plugin)
 


### PR DESCRIPTION
## Summary
- Switch docs examples from ~/server to #server across guides and migration notes
- Update Nuxt config examples to use rootDir/~~ where appropriate
- Sync related Nitro comments with #server wording

## Notes
- Docs + minor code comment updates
