### PR TITLE
fix(vite,webpack): use node.res to send 403/404

### DIFF
--- a/packages/vite/src/plugins/dev-server.ts
+++ b/packages/vite/src/plugins/dev-server.ts
@@ -8,8 +8,6 @@ import { useNitro } from '@nuxt/kit'
 import { joinURL } from 'ufo'
 import type { IncomingMessage, ServerResponse } from 'node:http'
 
-import type { ErrorPartial } from '../types'
-
 export function DevServerPlugin (nuxt: Nuxt): Plugin {
   let useViteCors = false
   const nitro = useNitro()
@@ -184,7 +182,9 @@ export function DevServerPlugin (nuxt: Nuxt): Plugin {
 
         // if vite has not handled the request, we want to send a 404 for paths which are not in any static base or dev server handlers
         if (url.startsWith(nuxt.options.app.buildAssetsDir) && !staticBases.some(baseURL => url.startsWith(baseURL)) && !devHandlerRegexes.some(regex => regex.test(url))) {
-          throw { status: 404, unhandled: false } satisfies ErrorPartial
+          res!.statusCode = 404
+          res!.end('Not Found')
+          return
         }
       })
       await nuxt.callHook('server:devHandler', viteMiddleware, {

--- a/packages/webpack/src/webpack.ts
+++ b/packages/webpack/src/webpack.ts
@@ -140,7 +140,9 @@ function wdmToH3Handler (devMiddleware: webpackDevMiddleware.API<IncomingMessage
     // disallow cross-site requests in no-cors mode
     const { req, res } = 'runtime' in event ? event.runtime!.node! : event.node
     if (req.headers['sec-fetch-mode'] === 'no-cors' && req.headers['sec-fetch-site'] === 'cross-site') {
-      throw { status: 403, unhandled: false }
+      res!.statusCode = 403
+      res!.end('Forbidden')
+      return
     }
 
     event.context.webpack = {


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/cli/issues/1212
resolves https://github.com/nuxt/cli/issues/1199

### 📚 Description

this supersedes https://github.com/nuxt/nuxt/pull/34225, https://github.com/nuxt/nuxt/pull/34233

h3 doesn't let us throw a raw object, and we don't want to have a dependency on h3 in the vite/webpack builders