### PR TITLE
fix(kit): pass moduleOptions instead of inlineOptions to Nuxt 2 module call

### DIFF
--- a/packages/kit/src/module/install.ts
+++ b/packages/kit/src/module/install.ts
@@ -400,7 +400,7 @@ async function callModule (nuxt: Nuxt, nuxtModule: NuxtModule<any, Partial<any>,
 
   const fn = () => isNuxtMajorVersion(2, nuxt)
     // @ts-expect-error Nuxt 2 `moduleContainer` is not typed
-    ? nuxtModule.call(nuxt.moduleContainer, inlineOptions, nuxt)
+    ? nuxtModule.call(nuxt.moduleContainer, moduleOptions, nuxt)
     : nuxt.options.experimental?.debugModuleMutation && nuxt._asyncLocalStorageModule
       ? nuxt._asyncLocalStorageModule.run(nuxtModule, () => nuxtModule(moduleOptions, nuxt))
       : nuxtModule(moduleOptions, nuxt)


### PR DESCRIPTION
### 🔗 Linked issue
https://github.com/nuxt/bridge/pull/1715
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
In `callModule`, the Nuxt 2 module invocation path was passing `inlineOptions`, which is a non-existent variable. It should be `moduleOptions` instead.

The Nuxt 3 path (`nuxtModule(moduleOptions, nuxt)`) already uses moduleOptions, but the Nuxt 2 path  (`nuxtModule.call(nuxt.moduleContainer, ...)`) was still referencing inlineOptions. This caused module options to not be passed correctly in the case of Nuxt 2.

This fix changes inlineOptions to moduleOptions so that both paths consistently receive the correct module options.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/4.x/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
