### PR TITLE
fix(vite): resolve package CSS paths in dev manifest

### DIFF
--- a/packages/vite/src/plugins/vite-node.ts
+++ b/packages/vite/src/plugins/vite-node.ts
@@ -96,8 +96,10 @@ function getManifest (nuxt: Nuxt, viteServer: ViteDevServer, clientEntry: string
           from: nuxt.options.modulesDir.map(d => directoryToURL(d)),
         })
         if (!resolved) { continue }
+        css.add('/@fs' + resolved)
+      } else {
+        css.add(resolved)
       }
-      css.add('/@fs' + resolved)
     }
   }
 

--- a/packages/vite/src/plugins/vite-node.ts
+++ b/packages/vite/src/plugins/vite-node.ts
@@ -6,8 +6,8 @@ import os from 'node:os'
 import fs from 'node:fs' // For sync operations like unlinkSync if needed during setup
 import { pathToFileURL } from 'node:url'
 import { Buffer } from 'node:buffer'
-import { join, normalize } from 'pathe'
-import { resolveAlias, tryUseNuxt } from '@nuxt/kit'
+import { isAbsolute, join, normalize } from 'pathe'
+import { directoryToURL, resolveAlias, tryUseNuxt } from '@nuxt/kit'
 import type { EnvironmentModuleNode, ModuleNode, PluginContainer, ViteDevServer, Plugin as VitePlugin } from 'vite'
 import { getQuery } from 'ufo'
 import type { FetchResult } from 'vite-node'
@@ -87,7 +87,17 @@ function getManifest (nuxt: Nuxt, viteServer: ViteDevServer, clientEntry: string
   // This ensures CSS is in manifest even if moduleGraph isn't populated yet
   for (const globalCss of nuxt.options.css) {
     if (typeof globalCss === 'string') {
-      css.add(resolveAlias(globalCss, nuxt.options.alias))
+      let resolved: string | undefined = resolveAlias(globalCss, nuxt.options.alias)
+
+      // Resolve bare module specifiers to absolute paths
+      if (!isAbsolute(resolved)) {
+        resolved = resolveModulePath(resolved, {
+          try: true,
+          from: nuxt.options.modulesDir.map(d => directoryToURL(d)),
+        })
+        if (!resolved) { continue }
+      }
+      css.add('/@fs' + resolved)
     }
   }
 


### PR DESCRIPTION
### 🔗 Linked issue

Fixes: #34298 
Fixes: #34393

### 📚 Description
- CSS paths from npm packages (e.g. `vue-final-modal/style.css`) were added unresolved to the dev manifest and causing 404 errors
- Now properly resolves bare module specifiers to absolute paths using `resolveModulePath` before converting to Vite `/@fs/` URLs

#33856 — the FOUC fix added global CSS from config as fallback but only used `resolveAlias`, which doesn't handle npm package paths
