### PR TITLE
docs: document client-side caching patterns for getCachedData

### DIFF
--- a/docs/1.getting-started/10.data-fetching.md
+++ b/docs/1.getting-started/10.data-fetching.md
@@ -556,7 +556,7 @@ const { data, status } = useFetch('/api/notifications', {
 ```
 
 ::tip
-Consider extracting either pattern into a reusable [composable](/docs/4.x/guide/directory-structure/composables) to keep options consistent across components and avoid repetition.
+Consider extracting either pattern into a reusable [composable](/docs/4.x/directory-structure/app/composables) to keep options consistent across components and avoid repetition.
 ::
 
 ::note

--- a/docs/1.getting-started/10.data-fetching.md
+++ b/docs/1.getting-started/10.data-fetching.md
@@ -500,6 +500,71 @@ const { data, execute } = await useFetch('/api/users', {
 id.value = 2
 ```
 
+#### Client-side Caching
+
+By default, Nuxt does not cache data across client-side navigations. Each time a component using `useFetch` or `useAsyncData` mounts, a new request is made. This is a deliberate design choice to prevent stale data and avoid memory leaks from unbounded caching.
+
+You can opt into client-side caching by providing a `getCachedData` function. This function receives the key, the Nuxt app instance, and a context object with the `cause` of the request (`'initial'`, `'refresh:manual'`, `'refresh:hook'`, or `'watch'`). Return `undefined` to trigger a fetch, or return cached data to skip the fetch.
+
+**Providing a custom `getCachedData` also prevents Nuxt from purging the data when the component unmounts**, making it essential for preserving data across navigations.
+
+::warning
+Since `getCachedData` is called on **every** fetch (including manual refreshes), returning any value other than `undefined` will short-circuit the fetch entirely. Always check `ctx.cause` if you want `refresh()` to bypass the cache. Otherwise, `refresh()` will return cached data instead of making a new request.
+::
+
+##### Cache until refresh
+
+This pattern caches data across navigations and only refetches when you explicitly call `refresh()` or `refreshNuxtData()`:
+
+```ts
+const { data, refresh } = useFetch('/api/notifications', {
+  key: 'inbox',
+  default: () => [],
+  getCachedData: (key, nuxtApp, ctx) => {
+    // Allow manual refreshes to bypass the cache
+    if (ctx.cause === 'refresh:manual' || ctx.cause === 'refresh:hook') {
+      return undefined
+    }
+    return nuxtApp.payload.data[key]
+  },
+})
+```
+
+Unlike the default behavior, this keeps data in `nuxtApp.payload.data` alive even after the component unmounts, so navigating back to the page will instantly show the cached data without a network request. Calling `refresh()` will still trigger a refetch.
+
+##### Stale-while-revalidate
+
+This pattern shows cached data instantly while always refetching fresh data in the background:
+
+```ts
+const key = 'inbox'
+const nuxtApp = useNuxtApp()
+
+const { data, status } = useFetch('/api/notifications', {
+  key,
+  default: () => nuxtApp.payload.data[key] ?? [],
+  getCachedData: () => undefined,
+})
+```
+
+`getCachedData: () => undefined` forces a background refetch on every navigation while also preventing Nuxt from purging the data on unmount. The `default` function reads the stale data from `nuxtApp.payload.data` to display it immediately while the request is in flight. You can use `status` to show a revalidation indicator:
+
+```vue
+<template>
+  <span v-if="status === 'pending' && data?.length">Updating...</span>
+</template>
+```
+
+::tip
+Consider extracting either pattern into a reusable [composable](/docs/4.x/guide/directory-structure/composables) to keep options consistent across components and avoid repetition.
+::
+
+::note
+Be mindful that caching data across navigations increases memory usage. If your application has many unique keys, consider limiting the number of cached entries or clearing stale data periodically.
+::
+
+:video-accordion{title="Watch a video from Alexander Lichter about getCachedData" videoId="aQPR0xn-MMk"}
+
 #### Computed URL
 
 Sometimes you may need to compute a URL from reactive values, and refresh the data each time these change. Instead of juggling your way around, you can attach each param as a reactive value. Nuxt will automatically use the reactive value and re-fetch each time it changes.

--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -362,7 +362,11 @@ Nuxt's data fetching system (`useAsyncData` and `useFetch`) has been significant
 
 3. **Reactive key support**: You can now use computed refs, plain refs or getter functions as keys, which enables automatic data refetching (and stores data separately).
 
-4. **Data cleanup**: When the last component using data fetched with `useAsyncData` is unmounted, Nuxt will remove that data to avoid ever-growing memory usage.
+4. **Data cleanup**: When the last component using data fetched with `useAsyncData` is unmounted, Nuxt will remove that data to avoid ever-growing memory usage. This means that navigating away from a page and back will trigger a new fetch by default.
+
+::note
+By design, the default `getCachedData` combined with data cleanup means data is **not preserved across client-side navigations**. If you need data to persist across page changes, provide a custom `getCachedData` function. This also prevents the automatic data cleanup on unmount. See the [data fetching guide](/docs/4.x/getting-started/data-fetching#client-side-caching) for caching patterns.
+::
 
 #### Reasons for Change
 
@@ -402,12 +406,30 @@ These changes have been made to improve memory usage and increase consistency wi
    -  }
    +  getCachedData: (key, nuxtApp, ctx) => {
    +    // ctx.cause - can be 'initial' | 'refresh:hook' | 'refresh:manual' | 'watch'
-   +    
+   +
    +    // Example: Don't use cache on manual refresh
    +    if (ctx.cause === 'refresh:manual') return undefined
-   +    
+   +
    +    return cachedData[key]
    +  }
+   })
+   ```
+
+3. **Preserve data across navigations**: If you relied on data being cached across client-side navigations (SPA behavior), provide a custom `getCachedData`:
+
+   ```ts
+   // Before (Nuxt 3): data was kept in memory across navigations by default
+   const { data } = useFetch('/api/notifications')
+
+   // After (Nuxt 4): provide getCachedData to preserve data across navigations
+   const { data } = useFetch('/api/notifications', {
+     getCachedData: (key, nuxtApp, ctx) => {
+       // Allow manual refreshes to bypass the cache
+       if (ctx.cause === 'refresh:manual' || ctx.cause === 'refresh:hook') {
+         return undefined
+       }
+       return nuxtApp.payload.data[key]
+     },
    })
    ```
 
@@ -500,7 +522,7 @@ The migration should be straightforward:
 
 ```diff
   const route = useRoute()
-  
+
 - console.log(route.meta.name)
 + console.log(route.name)
 ```
@@ -565,10 +587,10 @@ If you have issues you should verify:
 
 ```diff
 useHead({
-  meta: [{ 
-    name: 'description', 
-    // meta tags don't need a vmid, or a key    
--   vmid: 'description' 
+  meta: [{
+    name: 'description',
+    // meta tags don't need a vmid, or a key
+-   vmid: 'description'
 -   hid: 'description'
   }]
 })
@@ -820,7 +842,7 @@ The migration should be straightforward:
 
 ```diff
   const { refresh } = await useAsyncData(async () => ({ message: 'Hello, Nuxt 3!' }))
-  
+
   async function refreshData () {
 -   await refresh({ dedupe: true })
 +   await refresh({ dedupe: 'cancel' })
@@ -1158,7 +1180,7 @@ Nuxt now generates separate TypeScript configurations for different contexts to 
 
 1. **New TypeScript configuration files**: Nuxt now generates additional TypeScript configurations:
    - `.nuxt/tsconfig.app.json` - For your app code (Vue components, composables, etc.)
-   - `.nuxt/tsconfig.server.json` - For your server-side code (Nitro/server directory)  
+   - `.nuxt/tsconfig.server.json` - For your server-side code (Nitro/server directory)
    - `.nuxt/tsconfig.node.json` - For your build-time code (modules, `nuxt.config.ts`, etc.)
    - `.nuxt/tsconfig.shared.json` - For code shared between app and server contexts (like types and non-environment specific utilities)
    - `.nuxt/tsconfig.json` - Legacy configuration for backward compatibility

--- a/docs/4.api/2.composables/use-async-data.md
+++ b/docs/4.api/2.composables/use-async-data.md
@@ -150,11 +150,16 @@ The `handler` function should be **side-effect free** to ensure predictable beha
   - `transform`: a function that can be used to alter `handler` function result after resolving
   - `getCachedData`: Provide a function which returns cached data. An `undefined` return value will trigger a fetch. By default, this is:
     ```ts
-    const getDefaultCachedData = (key, nuxtApp, ctx) => nuxtApp.isHydrating
-      ? nuxtApp.payload.data[key]
-      : nuxtApp.static.data[key]
+    const getDefaultCachedData = (key, nuxtApp, ctx) => {
+      if (nuxtApp.isHydrating) {
+        return nuxtApp.payload.data[key]
+      }
+      if (ctx.cause !== 'refresh:manual' && ctx.cause !== 'refresh:hook') {
+        return nuxtApp.static.data[key]
+      }
+    }
     ```
-    Which only caches data when `experimental.payloadExtraction` of `nuxt.config` is enabled.
+    Which only caches data during hydration (from the SSR payload) or from static data when [`payloadExtraction`](/docs/4.x/guide/going-further/experimental-features#payloadextraction) is enabled. It does not cache data across client-side navigations. See the [data fetching guide](/docs/4.x/getting-started/data-fetching#client-side-caching) for custom caching patterns.
   - `pick`: only pick specified keys in this array from the `handler` function result
   - `watch`: watch reactive sources to auto-refresh
   - `deep`: return data in a deep ref object. It is `false` by default to return data in a shallow ref object, which can improve performance if your data does not need to be deeply reactive.

--- a/docs/4.api/2.composables/use-fetch.md
+++ b/docs/4.api/2.composables/use-fetch.md
@@ -214,11 +214,23 @@ All fetch options can be given a `computed` or `ref` value. These will be watche
 **getCachedData default:**
 
 ```ts
-const getDefaultCachedData = (key, nuxtApp, ctx) => nuxtApp.isHydrating
-  ? nuxtApp.payload.data[key]
-  : nuxtApp.static.data[key]
+const getDefaultCachedData = (key, nuxtApp, ctx) => {
+  if (nuxtApp.isHydrating) {
+    return nuxtApp.payload.data[key]
+  }
+  if (ctx.cause !== 'refresh:manual' && ctx.cause !== 'refresh:hook') {
+    return nuxtApp.static.data[key]
+  }
+}
 ```
-This only caches data when `experimental.payloadExtraction` in `nuxt.config` is enabled.
+
+By default, `getCachedData` does not cache data across client-side navigations. It only returns cached data during hydration (from the SSR payload) or from static data (when [`payloadExtraction`](/docs/4.x/guide/going-further/experimental-features#payloadextraction) is enabled).
+
+Additionally, when using the default `getCachedData`, Nuxt will automatically purge cached data when the last component using a key unmounts. This means navigating away and back will trigger a new fetch.
+
+::tip
+To opt into client-side caching, provide a custom `getCachedData`. This also prevents the automatic data purging on unmount. See the [data fetching guide](/docs/4.x/getting-started/data-fetching#client-side-caching) for caching patterns.
+::
 
 ## Return Values
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
Related: #24271 #31816

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
With Nuxt 4 defaulting to `purgeCachedData` and `granularCachedData`, data is no longer cached across client-side navigations. I ran into this on Volta and had to dig through the source to understand what changed.

This PR adds a "Client-side Caching" section to the data fetching guide with two patterns (cache until refresh and stale-while-revalidate), updates the `getDefaultCachedData` snippet in the API docs to match the actual source, and adds a migration step in the upgrade guide.

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/4.x/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
