### PR TITLE
fix(nuxt): always inject explicit prerender routes into prerender queue

### DIFF
--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -407,7 +407,7 @@ export default defineNuxtModule({
       ]
 
       // Inject page patterns that explicitly match `prerender: true` route rule
-      if (!nitro.options.static && !nitro.options.prerender.crawlLinks) {
+      if (!nitro.options.static) {
         const routeRulesRouter = createRou3Router<NitroRouteRules>()
         for (const [route, rules] of Object.entries(nitro.options.routeRules)) {
           addRoute(routeRulesRouter, undefined, route, rules)


### PR DESCRIPTION
### 🔗 Linked issue

Fixes: #34269 

### 📚 Description

The `crawlLinks` check prevented routes with explicit `prerender: true` route rules (nuxt.config). This assumed the crawler would discover them at runtime, but when the entry route uses `ssr: false` (SPA), the crawler receives an empty shell with no links and never finds those routes. 