### PR TITLE
fix(nuxt): retain promise methods after destructuring

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -432,7 +432,12 @@ export function useAsyncData<
   // Allow directly awaiting on asyncData
   const asyncDataPromise = Promise.resolve(nuxtApp._asyncDataPromises[key.value]).then(() => asyncReturn) as AsyncData<ResT, (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>)>
   Object.assign(asyncDataPromise, asyncReturn)
-
+  // Allow destructuring without loosing promise methods
+  Object.defineProperties(asyncDataPromise, {
+    then: { enumerable: true, value: asyncDataPromise.then.bind(asyncDataPromise) },
+    catch: { enumerable: true, value: asyncDataPromise.catch.bind(asyncDataPromise) },
+    finally: { enumerable: true, value: asyncDataPromise.finally.bind(asyncDataPromise) },
+  })
   return asyncDataPromise as AsyncData<PickFrom<DataT, PickKeys>, (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>)>
 }
 

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -432,7 +432,7 @@ export function useAsyncData<
   // Allow directly awaiting on asyncData
   const asyncDataPromise = Promise.resolve(nuxtApp._asyncDataPromises[key.value]).then(() => asyncReturn) as AsyncData<ResT, (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>)>
   Object.assign(asyncDataPromise, asyncReturn)
-  // Allow destructuring without loosing promise methods
+  // Allow destructuring without losing promise methods
   Object.defineProperties(asyncDataPromise, {
     then: { enumerable: true, value: asyncDataPromise.then.bind(asyncDataPromise) },
     catch: { enumerable: true, value: asyncDataPromise.catch.bind(asyncDataPromise) },


### PR DESCRIPTION
### 🔗 Linked issue

see https://github.com/nuxt/nuxt/issues/33644#issuecomment-3883368735

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/4.x/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
