### PR TITLE
docs: add alternative editor LSP setup guidance

### DIFF
--- a/docs/1.getting-started/02.installation.md
+++ b/docs/1.getting-started/02.installation.md
@@ -20,13 +20,14 @@ Or follow the steps below to set up a new Nuxt project on your computer.
 ### Prerequisites
 
 - **Node.js** - [`20.x`](https://nodejs.org/en) or newer (but we recommend the [active LTS release](https://github.com/nodejs/release#release-schedule))
-- **Text editor** - There is no IDE requirement, but we recommend [Visual Studio Code](https://code.visualstudio.com/) with the [official Vue extension](https://marketplace.visualstudio.com/items?itemName=Vue.volar) (previously known as Volar) or [WebStorm](https://www.jetbrains.com/webstorm/), which, along with [other JetBrains IDEs](https://www.jetbrains.com/ides/), offers great Nuxt support right out-of-the-box.
+- **Text editor** - There is no IDE requirement, but we recommend [Visual Studio Code](https://code.visualstudio.com/) with the [official Vue extension](https://marketplace.visualstudio.com/items?itemName=Vue.volar) (previously known as Volar) or [WebStorm](https://www.jetbrains.com/webstorm/), which, along with [other JetBrains IDEs](https://www.jetbrains.com/ides/), offers great Nuxt support right out-of-the-box. If you use another editor, such as Neovim, you can configure [Vue Language Server](https://github.com/vuejs/language-tools) support by following the [Vue Language Tools setup guides](https://github.com/vuejs/language-tools/wiki).
 - **Terminal** - In order to run Nuxt commands
 
 ::note
   ::details
   :summary[Additional notes for an optimal setup:]
   - **Node.js**: Make sure to use an even numbered version (20, 22, etc.)
+  - **Neovim**: When configuring the Vue TypeScript plugin, make sure `location` points to the `@vue/language-server` package directory, not its binary. See the [Neovim setup guide](https://github.com/vuejs/language-tools/wiki/Neovim) for a working configuration.
   - **WSL**: If you are using Windows and experience slow HMR, you may want to try using [WSL (Windows Subsystem for Linux)](https://learn.microsoft.com/en-us/windows/wsl/install) which may solve some performance issues.
   - **Windows slow DNS resolution**: Instead of using `localhost:3000` for local dev server on Windows, use `127.0.0.1` for much faster loading experience on browsers.
   ::


### PR DESCRIPTION
## Summary

- Expand the "Text editor" prerequisite in the installation docs to mention that editors with Vue Language Server support (such as Neovim) also work well for Nuxt development, with a link to the Vue Language Tools wiki for setup guides.
- Add a Neovim-specific tip under "Additional notes for an optimal setup" covering a common `@vue/typescript-plugin` location pitfall that causes LSP errors in Nuxt projects.

## Context

Addresses a gap in the docs where only VS Code and JetBrains are mentioned as recommended editors. Users of Neovim and other editors with LSP support had no guidance on getting Vue/Nuxt language features working. This was reported and discussed in #33635, where the issue author identified a common misconfiguration that this change documents.

Closes #33635