### PR TITLE
fix(nitro,nuxt,schema): don't extract payloads w/ `ssr: false`

### DIFF
--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -450,6 +450,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
       nitro.hooks.hook('build:before', (nitro) => {
         for (const [route, value] of Object.entries(nitro.options.routeRules)) {
           if (!route.endsWith('*') && !route.endsWith('/_payload.json')) {
+            if (value.ssr === false) { continue }
             if ((value.isr || value.cache) || (value.prerender && nuxt.options.dev)) {
               const payloadKey = route + '/_payload.json'
               const defaults = {} as Record<string, any>

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -373,7 +373,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
     `!${join(nuxt.options.buildDir, 'dist/client', nuxt.options.app.buildAssetsDir, '**/*')}`,
   )
 
-  const validManifestKeys = ['prerender', 'redirect', 'appMiddleware', 'appLayout', 'cache', 'isr', 'swr']
+  const validManifestKeys = ['prerender', 'redirect', 'appMiddleware', 'appLayout', 'cache', 'isr', 'swr', 'ssr']
 
   function getRouteRulesRouter () {
     const routeRulesRouter = createRou3Router<NitroRouteRules>()

--- a/packages/nuxt/src/app/composables/payload.ts
+++ b/packages/nuxt/src/app/composables/payload.ts
@@ -36,7 +36,11 @@ function detectLinkRelType () {
 /** @since 3.0.0 */
 export function preloadPayload (url: string, opts: LoadPayloadOptions = {}): Promise<void> {
   const nuxtApp = useNuxtApp()
-  const promise = _getPayloadURL(url, opts).then((payloadURL) => {
+  const promise = shouldLoadPayload(url).then(async (shouldPreload) => {
+    if (!shouldPreload) {
+      return
+    }
+    const payloadURL = await _getPayloadURL(url, opts)
     const link = renderJsonPayloads
       ? { rel: detectLinkRelType(), as: 'fetch', crossorigin: 'anonymous', href: payloadURL } as const
       : { rel: 'modulepreload', crossorigin: '', href: payloadURL } as const
@@ -114,6 +118,9 @@ async function _isPrerenderedInManifest (url: string) {
  */
 export async function shouldLoadPayload (url = useRoute().path) {
   const rules = getRouteRules({ path: url })
+  if (rules.ssr === false) {
+    return false
+  }
   const res = _shouldLoadPrerenderedPayload(rules)
   if (res !== undefined) {
     return res

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -522,7 +522,7 @@ export const nuxtConfigTemplate: NuxtTemplate = {
     )
     const nitro = useNitro()
     const hasCachedRoutes = Object.values(nitro.options.routeRules).some(r => r.isr || r.cache)
-    const payloadExtraction = !!ctx.nuxt.options.experimental.payloadExtraction && (nitro.options.static || hasCachedRoutes || (nitro.options.prerender.routes && nitro.options.prerender.routes.length > 0) || Object.values(nitro.options.routeRules).some(r => r.prerender))
+    const payloadExtraction = ctx.nuxt.options.ssr !== false && !!ctx.nuxt.options.experimental.payloadExtraction && (nitro.options.static || hasCachedRoutes || (nitro.options.prerender.routes && nitro.options.prerender.routes.length > 0) || Object.values(nitro.options.routeRules).some(r => r.prerender))
     return [
       ...Object.entries(ctx.nuxt.options.app).map(([k, v]) => `export const ${camelCase('app-' + k)} = ${JSON.stringify(v)}`),
       `export const renderJsonPayloads = ${!!ctx.nuxt.options.experimental.renderJsonPayloads}`,

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -522,7 +522,7 @@ export const nuxtConfigTemplate: NuxtTemplate = {
     )
     const nitro = useNitro()
     const hasCachedRoutes = Object.values(nitro.options.routeRules).some(r => r.isr || r.cache)
-    const payloadExtraction = ctx.nuxt.options.ssr !== false && !!ctx.nuxt.options.experimental.payloadExtraction && (nitro.options.static || hasCachedRoutes || (nitro.options.prerender.routes && nitro.options.prerender.routes.length > 0) || Object.values(nitro.options.routeRules).some(r => r.prerender))
+    const payloadExtraction = !!ctx.nuxt.options.experimental.payloadExtraction && (nitro.options.static || hasCachedRoutes || (nitro.options.prerender.routes && nitro.options.prerender.routes.length > 0) || Object.values(nitro.options.routeRules).some(r => r.prerender))
     return [
       ...Object.entries(ctx.nuxt.options.app).map(([k, v]) => `export const ${camelCase('app-' + k)} = ${JSON.stringify(v)}`),
       `export const renderJsonPayloads = ${!!ctx.nuxt.options.experimental.renderJsonPayloads}`,

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -99,6 +99,7 @@ export default defineResolvers({
     noVueServer: false,
     payloadExtraction: {
       $resolve: async (val, get) => {
+        if ((await get('ssr')) === false) { return false }
         if (val === 'client' || typeof val === 'boolean') { return val }
         return (await get('future.compatibilityVersion')) >= 5 ? 'client' as const : true
       },

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -110,6 +110,17 @@ describe('route rules', () => {
     const html = await $fetch<string>('/route-rules/layout')
     expect(html).toContain('Custom Layout')
   })
+
+  it('should not generate payload route rules for non-wildcard ssr: false routes', () => {
+    // @ts-expect-error untyped internal property
+    const routeRules = useTestContext().nuxt._nitro.options.routeRules
+
+    expect(routeRules['/route-rules/isr-spa']).toMatchObject({
+      isr: 60,
+      ssr: false,
+    })
+    expect(routeRules['/route-rules/isr-spa/_payload.json']).toBeUndefined()
+  })
 })
 
 describe('modules', () => {

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -120,6 +120,7 @@ describe('route rules', () => {
       ssr: false,
     })
     expect(routeRules['/route-rules/isr-spa/_payload.json']).toBeUndefined()
+    expect(routeRules['/route-rules/isr-spa/_payload.js']).toBeUndefined()
   })
 })
 

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -187,6 +187,7 @@ export default withMatrix({
       '/prerender/**': { prerender: true },
       '/route-rules/redirect': { redirect: '/' },
       '/isr': { isr: 60 },
+      '/route-rules/isr-spa': { isr: 60, ssr: false },
       '/swr': { swr: 60 },
     },
     prerender: {

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -479,6 +479,10 @@ describe.skipIf(!isTestingAppManifest)('app manifests', () => {
             "/pre": {
               "prerender": true,
             },
+            "/pre/spa": {
+              "prerender": true,
+              "ssr": false,
+            },
           },
         },
         "prerendered": [],
@@ -490,6 +494,12 @@ describe.skipIf(!isTestingAppManifest)('app manifests', () => {
     expect(getRouteRules({ path: '/pre' })).toMatchInlineSnapshot(`
       {
         "prerender": true,
+      }
+    `)
+    expect(getRouteRules({ path: '/pre/spa/thing' })).toMatchInlineSnapshot(`
+      {
+        "prerender": true,
+        "ssr": false,
       }
     `)
     expect(getRouteRules({ path: '/pre/test' })).toMatchInlineSnapshot(`
@@ -514,6 +524,10 @@ describe('compiled route rules', () => {
     // wildcard routes with prerender: true should load payloads
     const shouldLoadPre = await shouldLoadPayload('/pre/thing')
     expect(shouldLoadPre).toBe(true)
+
+    // prerendered routes with ssr: false should not load payloads
+    const shouldLoadSpaPre = await shouldLoadPayload('/pre/spa/thing')
+    expect(shouldLoadSpaPre).toBe(false)
 
     // specific prerendered routes should load payloads
     const shouldLoadSpecific = await shouldLoadPayload('/specific-prerendered')

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -518,6 +518,7 @@ describe('compiled route rules', () => {
     expect(await isPrerendered('/test')).toBeFalsy()
     expect(await isPrerendered('/pre/test')).toBeFalsy()
     expect(await isPrerendered('/pre/thing')).toBeTruthy()
+    expect(await isPrerendered('/pre/spa/thing')).toBeTruthy()
   })
 
   it('should determine if payload should be loaded based on route rules', async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,7 @@ const commonSettings: NuxtConfig = {
   routeRules: {
     '/specific-prerendered': { prerender: true },
     '/pre/test': { redirect: '/' },
+    '/pre/spa/**': { prerender: true, ssr: false },
     '/pre/**': { prerender: true },
   },
   experimental: {


### PR DESCRIPTION
Fixes payload extraction behavior when SSR is disabled.

When `ssr: false` (globally or per-route), loading `_payload.json` is invalid and can return HTML instead of JSON. This PR prevents payload loading in that case.

This PR:
- auto-disables `experimental.payloadExtraction` when global `ssr` is `false`
- includes `ssr` in app manifest route rules
- makes `shouldLoadPayload()` return `false` for routes with `ssr: false`
- ensures generated runtime config does not enable payload extraction when SSR is off

Related: [nuxt-hub/core#839](https://github.com/nuxt-hub/core/issues/839)
