### PR TITLE
fix(kit): prevent duplicate `moduleDependencies` options

### DIFF
--- a/packages/kit/src/module/install.ts
+++ b/packages/kit/src/module/install.ts
@@ -150,13 +150,13 @@ export async function installModules (modulesToInstall: Map<ModuleToInstall, Rec
     const configKey = meta.configKey as keyof NuxtOptions | undefined
 
     // Merge options
-    const optionsFns = [
+    const optionsFns = new Set([
       ...nuxt._moduleOptionsFunctions.get(moduleToInstall) || [],
       ...meta?.name ? nuxt._moduleOptionsFunctions.get(meta.name) || [] : [],
       // TODO: consider dropping options functions keyed by config key
       ...configKey ? nuxt._moduleOptionsFunctions.get(configKey) || [] : [],
-    ]
-    if (optionsFns.length > 0) {
+    ])
+    if (optionsFns.size > 0) {
       const overrides = [] as unknown as [Record<string, unknown> | undefined, ...Array<Record<string, unknown> | undefined>]
       const defaults: Array<Record<string, unknown> | undefined> = []
       for (const fn of optionsFns) {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Noticed this while checking `moduleDependencies` and what needs to be documented for nuxt-i18n (probably only need to require absolute paths for locale dir and locale files).

The following code will result in duplicate entries, this can be an issue for module options that contain arrays as `defu` will append/merge those:
```ts
    const optionsFns = [
      ...nuxt._moduleOptionsFunctions.get(moduleToInstall) || [],
      ...meta?.name ? nuxt._moduleOptionsFunctions.get(meta.name) || [] : [],
      // TODO: consider dropping options functions keyed by config key
      ...configKey ? nuxt._moduleOptionsFunctions.get(configKey) || [] : [],
    ]
```

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/4.x/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
