### PR TITLE
docs: improve `<NuxtImg>` fetch priority example

### DIFF
--- a/docs/3.guide/2.best-practices/performance.md
+++ b/docs/3.guide/2.best-practices/performance.md
@@ -144,7 +144,7 @@ Images in your website can usually be separated by importance; the ones that are
     format="webp"
     preload
     loading="eager"
-    fetch-priority="high"
+    fetchpriority="high"
     width="200"
     height="100"
   />
@@ -154,7 +154,7 @@ Images in your website can usually be separated by importance; the ones that are
     src="/facebook-logo.jpg"
     format="webp"
     loading="lazy"
-    fetch-priority="low"
+    fetchpriority="low"
     width="200"
     height="100"
   />

--- a/docs/3.guide/2.best-practices/performance.md
+++ b/docs/3.guide/2.best-practices/performance.md
@@ -144,7 +144,6 @@ Images in your website can usually be separated by importance; the ones that are
     format="webp"
     :preload="{ fetchPriority: 'high' }"
     loading="eager"
-    fetchpriority="high"
     width="200"
     height="100"
   />

--- a/docs/3.guide/2.best-practices/performance.md
+++ b/docs/3.guide/2.best-practices/performance.md
@@ -142,7 +142,7 @@ Images in your website can usually be separated by importance; the ones that are
   <NuxtImg
     src="/hero-banner.jpg"
     format="webp"
-    preload
+    :preload="{ fetchPriority: 'high' }"
     loading="eager"
     fetchpriority="high"
     width="200"


### PR DESCRIPTION
Hello, I updated the documented attribute 'fetch-priority' to 'fetchpriority' to match the specification:

https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/fetchpriority

### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt.com/issues/2061

### 📚 Description

The docs currently suggest using the 'fetch-attribute' on NuxtImg. That attributed is passed directly onto the img tag and therefore the documented attribute isn't correct. 

The correct attribute would be the non-hyphenated version: 'fetchattribute'

https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/fetchpriority#html.elements.script.fetchpriority
