### PR TITLE
fix(nuxt): populate `route.meta.layout` from `appLayout` route rules

### DIFF
--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -182,6 +182,12 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
       if (nuxtApp.isHydrating && initialLayout && !isReadonly(to.meta.layout)) {
         to.meta.layout = initialLayout as Exclude<PageMeta['layout'], Ref | false>
       }
+      if (to.meta.layout === undefined) {
+        const appLayout = getRouteRules({ path: to.path }).appLayout
+        if (appLayout) {
+          to.meta.layout = appLayout as Exclude<PageMeta['layout'], Ref | false>
+        }
+      }
       nuxtApp._processingMiddleware = true
 
       if (import.meta.client || !nuxtApp.ssrContext?.islandContext) {

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -109,6 +109,7 @@ describe('route rules', () => {
   it('should set layout defined in routeRules config', async () => {
     const html = await $fetch<string>('/route-rules/layout')
     expect(html).toContain('Custom Layout')
+    expect(html).toContain('route-meta-layout:custom')
   })
 })
 

--- a/test/fixtures/basic/app/pages/route-rules/layout.vue
+++ b/test/fixtures/basic/app/pages/route-rules/layout.vue
@@ -1,5 +1,10 @@
+<script setup lang="ts">
+const route = useRoute()
+</script>
+
 <template>
   <div>
     <div>Should use layout set in route-rules</div>
+    <div>route-meta-layout:{{ route.meta.layout }}</div>
   </div>
 </template>


### PR DESCRIPTION
### 🔗 Linked issue

resolves #34305

### 📚 Description

`route.meta.layout` is `undefined` when using `appLayout` in route rules, even though the layout renders correctly. The layout was only being resolved inside `NuxtLayout` but never written back to `route.meta.layout`.

This sets `to.meta.layout` from the route rule's `appLayout` in the router `beforeEach` guard, same spot and pattern used for `appMiddleware`. It only applies when `to.meta.layout === undefined` so it won't override `definePageMeta` or `layout: false`.

Also added a test to check `route.meta.layout` is actually set on the route-rules layout page.
