### PR TITLE
fix(nuxt): resolve implicit any types in schema.ts

### DIFF
--- a/packages/nuxt/src/core/schema.ts
+++ b/packages/nuxt/src/core/schema.ts
@@ -10,13 +10,14 @@ import { generateTypes, resolveSchema as resolveUntypedSchema } from 'untyped'
 import type { Schema, SchemaDefinition } from 'untyped'
 import untypedPlugin from 'untyped/babel-plugin'
 import { createJiti } from 'jiti'
+import type { Nuxt } from '@nuxt/schema'
 import { logger } from '../utils.ts'
 
 export default defineNuxtModule({
   meta: {
     name: 'nuxt:nuxt-config-schema',
   },
-  async setup (_, nuxt) {
+  async setup(_: unknown, nuxt: Nuxt) {
     const resolver = createResolver(import.meta.url)
 
     // Initialize untyped/jiti loader
@@ -30,7 +31,7 @@ export default defineNuxtModule({
     })
 
     // Register module types
-    nuxt.hook('prepare:types', async (ctx) => {
+    nuxt.hook('prepare:types', async (ctx: any) => {
       ctx.references.push({ path: 'schema/nuxt.schema.d.ts' })
       ctx.sharedReferences.push({ path: 'schema/nuxt.schema.d.ts' })
       ctx.nodeReferences.push({ path: 'schema/nuxt.schema.d.ts' })
@@ -82,7 +83,7 @@ export default defineNuxtModule({
       }
 
       const isIgnored = createIsIgnored(nuxt)
-      const rootDirs = layerDirs.map(layer => layer.root)
+      const rootDirs = layerDirs.map((layer: { root: string }) => layer.root)
       const SCHEMA_RE = /(?:^|\/)nuxt.schema.\w+$/
       const watcher = watch(rootDirs, {
         ...nuxt.options.watchers.chokidar,
@@ -100,10 +101,10 @@ export default defineNuxtModule({
 
     // --- utils ---
 
-    async function resolveSchema () {
+    async function resolveSchema() {
       // Global import
       // @ts-expect-error adding to globalThis for 'auto-import' support within nuxt.config file
-      globalThis.defineNuxtSchema = (val: any) => val
+      globalThis.defineNuxtSchema = (val: SchemaDefinition) => val
 
       // Load schema from layers
       const schemaDefs: SchemaDefinition[] = [nuxt.options.$schema]
@@ -143,7 +144,7 @@ export default defineNuxtModule({
       return schema
     }
 
-    async function writeSchema (schema: Schema) {
+    async function writeSchema(schema: Schema) {
       await nuxt.hooks.callHook('schema:beforeWrite', schema)
       // Write it to build dir
       await mkdir(resolve(nuxt.options.buildDir, 'schema'), { recursive: true })

--- a/packages/nuxt/src/core/schema.ts
+++ b/packages/nuxt/src/core/schema.ts
@@ -17,7 +17,7 @@ export default defineNuxtModule({
   meta: {
     name: 'nuxt:nuxt-config-schema',
   },
-  async setup(_: unknown, nuxt: Nuxt) {
+  async setup (_: unknown, nuxt: Nuxt) {
     const resolver = createResolver(import.meta.url)
 
     // Initialize untyped/jiti loader
@@ -101,7 +101,7 @@ export default defineNuxtModule({
 
     // --- utils ---
 
-    async function resolveSchema() {
+    async function resolveSchema () {
       // Global import
       // @ts-expect-error adding to globalThis for 'auto-import' support within nuxt.config file
       globalThis.defineNuxtSchema = (val: SchemaDefinition) => val
@@ -144,7 +144,7 @@ export default defineNuxtModule({
       return schema
     }
 
-    async function writeSchema(schema: Schema) {
+    async function writeSchema (schema: Schema) {
       await nuxt.hooks.callHook('schema:beforeWrite', schema)
       // Write it to build dir
       await mkdir(resolve(nuxt.options.buildDir, 'schema'), { recursive: true })

--- a/packages/nuxt/src/core/schema.ts
+++ b/packages/nuxt/src/core/schema.ts
@@ -31,13 +31,13 @@ export default defineNuxtModule({
     })
 
     // Register module types
-    nuxt.hook('prepare:types', async (ctx: any) => {
-      ctx.references.push({ path: 'schema/nuxt.schema.d.ts' })
-      ctx.sharedReferences.push({ path: 'schema/nuxt.schema.d.ts' })
-      ctx.nodeReferences.push({ path: 'schema/nuxt.schema.d.ts' })
+    nuxt.hook('prepare:types', async ({ references, sharedReferences, nodeReferences, nodeTsConfig }) => {
+      references.push({ path: 'schema/nuxt.schema.d.ts' })
+      sharedReferences.push({ path: 'schema/nuxt.schema.d.ts' })
+      nodeReferences.push({ path: 'schema/nuxt.schema.d.ts' })
 
-      ctx.nodeTsConfig.include ||= []
-      ctx.nodeTsConfig.include.push(
+      nodeTsConfig.include ||= []
+      nodeTsConfig.include.push(
         relative(nuxt.options.buildDir, join(nuxt.options.rootDir, 'nuxt.schema.*')),
         relative(nuxt.options.buildDir, join(nuxt.options.rootDir, 'layers/*/nuxt.schema.*')),
       )


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This PR resolves `implicitly has an 'any' type` errors in [packages/nuxt/src/core/schema.ts](cci:7://frame/packages/nuxt/src/core/schema.ts:0:0-0:0) to improve type safety and ensure the codebase passes strict type checks.

Changes included:
- Imported [Nuxt](cci:1://frame/packages/nuxt/src/core/schema.ts:104:6-106:66) type from `@nuxt/schema` for better type safety in [setup](cci:1://file:///Users/arpitsarang/Desktop/frame/packages/nuxt/src/core/schema.ts:19:2-183:3).
- Added explicit type annotations to [setup](cci:1://file://frame/packages/nuxt/src/core/schema.ts:19:2-183:3) function parameters (`_`, `nuxt`).
- Added explicit type annotation to `prepare:types` hook context.
- Added explicit type annotation for `layer` in `getLayerDirectories` map function to resolve inference issues.

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/4.x/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->