### PR TITLE
fix(nuxt): guard route-rules virtual import

### DIFF
--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -372,7 +372,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
     `!${join(nuxt.options.buildDir, 'dist/client', nuxt.options.app.buildAssetsDir, '**/*')}`,
   )
 
-  const validManifestKeys = ['prerender', 'redirect', 'appMiddleware', 'appLayout', 'cache', 'isr', 'swr']
+  const validManifestKeys = ['prerender', 'redirect', 'appMiddleware', 'appLayout', 'cache', 'isr', 'swr', 'ssr']
 
   function getRouteRulesRouter () {
     const routeRulesRouter = createRou3Router<NitroRouteRules>()

--- a/packages/nuxt/src/app/composables/payload.ts
+++ b/packages/nuxt/src/app/composables/payload.ts
@@ -36,7 +36,11 @@ function detectLinkRelType () {
 /** @since 3.0.0 */
 export function preloadPayload (url: string, opts: LoadPayloadOptions = {}): Promise<void> {
   const nuxtApp = useNuxtApp()
-  const promise = _getPayloadURL(url, opts).then((payloadURL) => {
+  const promise = shouldLoadPayload(url).then(async (shouldPreload) => {
+    if (!shouldPreload) {
+      return
+    }
+    const payloadURL = await _getPayloadURL(url, opts)
     const link = renderJsonPayloads
       ? { rel: detectLinkRelType(), as: 'fetch', crossorigin: 'anonymous', href: payloadURL } as const
       : { rel: 'modulepreload', crossorigin: '', href: payloadURL } as const
@@ -114,6 +118,9 @@ async function _isPrerenderedInManifest (url: string) {
  */
 export async function shouldLoadPayload (url = useRoute().path) {
   const rules = getRouteRules({ path: url })
+  if (rules.ssr === false) {
+    return false
+  }
   const res = _shouldLoadPrerenderedPayload(rules)
   if (res !== undefined) {
     return res

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -522,7 +522,7 @@ export const nuxtConfigTemplate: NuxtTemplate = {
     )
     const nitro = useNitro()
     const hasCachedRoutes = Object.values(nitro.options.routeRules).some(r => r.isr || r.cache)
-    const payloadExtraction = !!ctx.nuxt.options.experimental.payloadExtraction && (nitro.options.static || hasCachedRoutes || (nitro.options.prerender.routes && nitro.options.prerender.routes.length > 0) || Object.values(nitro.options.routeRules).some(r => r.prerender))
+    const payloadExtraction = ctx.nuxt.options.ssr !== false && !!ctx.nuxt.options.experimental.payloadExtraction && (nitro.options.static || hasCachedRoutes || (nitro.options.prerender.routes && nitro.options.prerender.routes.length > 0) || Object.values(nitro.options.routeRules).some(r => r.prerender))
     return [
       ...Object.entries(ctx.nuxt.options.app).map(([k, v]) => `export const ${camelCase('app-' + k)} = ${JSON.stringify(v)}`),
       `export const renderJsonPayloads = ${!!ctx.nuxt.options.experimental.renderJsonPayloads}`,

--- a/packages/nuxt/test/virtual.test.ts
+++ b/packages/nuxt/test/virtual.test.ts
@@ -46,6 +46,14 @@ describe('virtual fs plugin', () => {
       export { foo };"
     `)
   })
+
+  it('should provide a fallback matcher for #build/route-rules.mjs', async () => {
+    const code = await generateCode('import routeRulesMatcher from "#build/route-rules.mjs"; export const rules = routeRulesMatcher("/")', {
+      vfs: {},
+    })
+    expect(code).toContain('function routeRulesMatcher')
+    expect(code).toContain('const rules = routeRulesMatcher()')
+  })
 })
 
 async function generateCode (input: string, options: { mode?: 'client' | 'server', vfs: Record<string, string> }) {

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -99,7 +99,9 @@ export default defineResolvers({
     noVueServer: false,
     payloadExtraction: {
       async $resolve (val, get) {
-        if ((await get('ssr')) === false) { return false }
+        if ((await get('ssr')) === false) {
+          return false
+        }
         return typeof val === 'boolean' ? val : true
       },
     },

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -97,7 +97,12 @@ export default defineResolvers({
     restoreState: false,
     renderJsonPayloads: true,
     noVueServer: false,
-    payloadExtraction: true,
+    payloadExtraction: {
+      async $resolve (val, get) {
+        if ((await get('ssr')) === false) { return false }
+        return typeof val === 'boolean' ? val : true
+      },
+    },
     clientFallback: false,
     crossOriginPrefetch: false,
     viewTransition: false,

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -376,6 +376,10 @@ describe.skipIf(!isTestingAppManifest)('app manifests', () => {
             "/pre": {
               "prerender": true,
             },
+            "/pre/spa": {
+              "prerender": true,
+              "ssr": false,
+            },
           },
         },
         "prerendered": [],
@@ -387,6 +391,12 @@ describe.skipIf(!isTestingAppManifest)('app manifests', () => {
     expect(getRouteRules({ path: '/pre' })).toMatchInlineSnapshot(`
       {
         "prerender": true,
+      }
+    `)
+    expect(getRouteRules({ path: '/pre/spa/thing' })).toMatchInlineSnapshot(`
+      {
+        "prerender": true,
+        "ssr": false,
       }
     `)
     expect(getRouteRules({ path: '/pre/test' })).toMatchInlineSnapshot(`
@@ -411,6 +421,10 @@ describe('compiled route rules', () => {
     // wildcard routes with prerender: true should load payloads
     const shouldLoadPre = await shouldLoadPayload('/pre/thing')
     expect(shouldLoadPre).toBe(true)
+
+    // prerendered routes with ssr: false should not load payloads
+    const shouldLoadSpaPre = await shouldLoadPayload('/pre/spa/thing')
+    expect(shouldLoadSpaPre).toBe(false)
 
     // specific prerendered routes should load payloads
     const shouldLoadSpecific = await shouldLoadPayload('/specific-prerendered')

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,7 @@ const commonSettings: NuxtConfig = {
   routeRules: {
     '/specific-prerendered': { prerender: true },
     '/pre/test': { redirect: '/' },
+    '/pre/spa/**': { prerender: true, ssr: false },
     '/pre/**': { prerender: true },
   },
   experimental: {


### PR DESCRIPTION
Closes #34346

## Summary
- guard `#build/route-rules.mjs` in virtual FS resolve/load when the template entry is temporarily missing from `nuxt.vfs`
- return a safe fallback matcher module instead of failing module resolution
- add unit coverage in `packages/nuxt/test/virtual.test.ts`

## Reproduction
- Bug: https://github.com/onmax/repros/tree/repro/nuxt-34346/nuxt-34346
- Fix: https://github.com/onmax/repros/tree/repro/nuxt-34346/nuxt-34346-fix

StackBlitz:
- Bug: https://stackblitz.com/github/onmax/repros/tree/repro/nuxt-34346/nuxt-34346?startScript=verify
- Fix: https://stackblitz.com/github/onmax/repros/tree/repro/nuxt-34346/nuxt-34346-fix?startScript=verify

## Tests
- `pnpm vitest run packages/nuxt/test/virtual.test.ts`
- `pnpm vitest run packages/nuxt/test/route-rules.test.ts`
