### PR TITLE
feat(nuxt): add `experimental.forwardClientIP` to auto-set x-forwarded-for in SSR

### DIFF
--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -550,6 +550,7 @@ export const nuxtConfigTemplate: NuxtTemplate = {
       `export const granularCachedData = ${!!ctx.nuxt.options.experimental.granularCachedData}`,
       `export const pendingWhenIdle = ${!!ctx.nuxt.options.experimental.pendingWhenIdle}`,
       `export const alwaysRunFetchOnKeyChange = ${!!ctx.nuxt.options.experimental.alwaysRunFetchOnKeyChange}`,
+      `export const forwardClientIP = ${!!ctx.nuxt.options.experimental.forwardClientIP}`,
     ].join('\n\n')
   },
 }

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -204,6 +204,11 @@ export default defineResolvers({
         return typeof val === 'boolean' ? val : false
       },
     },
+    forwardClientIP: {
+      $resolve: (val) => {
+        return typeof val === 'boolean' ? val : false
+      },
+    },
     parseErrorData: {
       $resolve: (val) => {
         return typeof val === 'boolean' ? val : true

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1504,12 +1504,12 @@ export interface ConfigSchema {
 
     /**
      * When enabled, Nuxt will automatically forward the client IP address in the `x-forwarded-for`
-     * header for all server-side fetch requests made via `useFetch`, `useAsyncData` or `$fetch`.
+     * header for server-side fetch requests made via `useFetch` and `useRequestFetch`.
      *
      * This is useful when backends use IP-based rate limiting, as it prevents the Nuxt server
      * itself from being throttled instead of the actual client.
      *
-     * @default false
+     * `@default` false
      */
     forwardClientIP: boolean
 

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1503,6 +1503,17 @@ export interface ConfigSchema {
     alwaysRunFetchOnKeyChange: boolean
 
     /**
+     * When enabled, Nuxt will automatically forward the client IP address in the `x-forwarded-for`
+     * header for all server-side fetch requests made via `useFetch`, `useAsyncData` or `$fetch`.
+     *
+     * This is useful when backends use IP-based rate limiting, as it prevents the Nuxt server
+     * itself from being throttled instead of the actual client.
+     *
+     * @default false
+     */
+    forwardClientIP: boolean
+
+    /**
      * Whether to parse `error.data` when rendering a server error page.
      *
      * @default true

--- a/test/mocks/nuxt-config.ts
+++ b/test/mocks/nuxt-config.ts
@@ -1,3 +1,5 @@
 export const nuxtLinkDefaults = {
   componentName: 'NuxtLink',
 }
+
+export const forwardClientIP = false

--- a/test/nuxt/use-fetch.test.ts
+++ b/test/nuxt/use-fetch.test.ts
@@ -234,6 +234,11 @@ describe('useFetch', () => {
     expect.soft(status.value).toBe('pending')
   })
 
+  it.runIf(process.env.PROJECT === 'nuxt-forward-client-ip')('should forward client IP in x-forwarded-for header with `experimental.forwardClientIP`', async () => {
+    const { data } = await useFetch<TestData>('/api/test')
+    expect(data.value?.headers['x-forwarded-for']).toBeDefined()
+  })
+
   it('should pick values from data', async () => {
     const { data } = await useFetch<TestData>('/api/test', { pick: ['method'] })
     expect(data.value).toEqual({ method: 'GET' })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -30,6 +30,11 @@ const projects: Record<string, NuxtConfig> = {
       alwaysRunFetchOnKeyChange: true,
     },
   },
+  'nuxt-forward-client-ip': {
+    experimental: {
+      forwardClientIP: true,
+    },
+  },
 }
 
 export default defineConfig({


### PR DESCRIPTION
## Summary

Fixes #34357

When Nuxt performs SSR fetch calls to backend APIs, the backend sees the
Nuxt server's IP instead of the real client IP. This causes IP-based rate
limiters to throttle the Nuxt server itself.

This PR adds an opt-in `experimental.forwardClientIP` option that
automatically builds the proper `x-forwarded-for` chain on every
server-side fetch.

### How it works

- **Local fetches** (`/api/...`): wraps `event.$fetch` to prepend the
  client IP to any existing `x-forwarded-for` value from the incoming
  request, following standard proxy behaviour
- **External fetches** (`https://...`): creates a scoped `$fetch` instance
  that adds **only** `x-forwarded-for` — other sensitive headers (cookies,
  auth tokens, etc.) are intentionally **not** forwarded
- Users can still override the header manually via `onRequest` or fetch
  options

### Usage

```ts
// nuxt.config.ts
export default defineNuxtConfig({
  experimental: {
    forwardClientIP: true,
  },
})
```
