### PR TITLE
fix(nuxt): do not cache `_payload.json` in dev mode

### DIFF
--- a/packages/nuxt/src/app/composables/payload.ts
+++ b/packages/nuxt/src/app/composables/payload.ts
@@ -70,7 +70,7 @@ async function _getPayloadURL (url: string, opts: LoadPayloadOptions = {}) {
     throw new Error('Payload URL must not include hostname: ' + url)
   }
   const config = useRuntimeConfig()
-  const hash = opts.hash || (opts.fresh ? Date.now() : config.app.buildId)
+  const hash = opts.hash || (opts.fresh || import.meta.dev ? Date.now() : config.app.buildId)
   const cdnURL = config.app.cdnURL
   const baseOrCdnURL = cdnURL && await isPrerendered(url) ? cdnURL : config.app.baseURL
   return joinURL(baseOrCdnURL, u.pathname, filename + (hash ? `?${hash}` : ''))
@@ -79,7 +79,7 @@ async function _getPayloadURL (url: string, opts: LoadPayloadOptions = {}) {
 async function _importPayload (payloadURL: string) {
   if (import.meta.server || !payloadExtraction) { return null }
   const payloadPromise = renderJsonPayloads
-    ? fetch(payloadURL, { cache: 'force-cache' }).then(res => res.text().then(parsePayload))
+    ? fetch(payloadURL, import.meta.dev ? {} : { cache: 'force-cache' }).then(res => res.text().then(parsePayload))
     : import(/* webpackIgnore: true */ /* @vite-ignore */ payloadURL).then(r => r.default || r)
 
   try {


### PR DESCRIPTION
## Summary

- Use `Date.now()` as the payload URL hash in dev mode instead of the static `buildId`, ensuring each request gets a unique URL
- Skip `force-cache` fetch option in dev mode so the browser makes a fresh request to the server after HMR updates

## Problem

When `prerender: true` is set in `routeRules`, navigating to a prerendered page fetches `_payload.json` once. If `useAsyncData` is modified and HMR triggers, subsequent navigations still return the stale cached payload because:

1. `_getPayloadURL()` uses `config.app.buildId` as the query hash, which remains static during dev
2. `_importPayload()` uses `fetch()` with `{ cache: 'force-cache' }`, telling the browser to always prefer cached responses

This effectively breaks HMR for any page with payload extraction in dev mode.

## Solution

In `packages/nuxt/src/app/composables/payload.ts`:

- **Line 73**: Use `Date.now()` when `import.meta.dev` is true, generating a unique URL per request
- **Line 82**: Use empty fetch options `{}` when `import.meta.dev` is true, removing the `force-cache` directive

Both conditions are compile-time constants (`import.meta.dev`), so they are tree-shaken in production builds with zero runtime cost.

Resolves https://github.com/nuxt/nuxt/issues/34363
