### PR TITLE
fix(postcss): disable cssnano calc optimization to prevent incorrect CSS simplification

### DIFF
--- a/packages/schema/src/config/postcss.ts
+++ b/packages/schema/src/config/postcss.ts
@@ -46,7 +46,9 @@ export default defineResolvers({
           if (await get('dev')) {
             return false
           }
-          return {}
+          return {
+            preset: ['default', { calc: false }],
+          }
         },
       },
     },


### PR DESCRIPTION
## Summary

Fixes #34366

cssnano's default preset includes `postcss-calc`, which aggressively simplifies nested `calc()` expressions using algebraic reduction. This causes `calc(100vh - calc(100vh - 100%))` to be incorrectly reduced to `100%` in production builds.

While `a - (a - b) = b` is mathematically correct, it is **semantically incorrect** in CSS — `100vh` and `100%` are not equivalent on mobile browsers where `100vh` includes the browser chrome (address bar), making this a common technique for handling mobile viewport heights.

## Changes

- Set cssnano's default preset to `['default', { calc: false }]` in `packages/schema/src/config/postcss.ts`
- All other CSSNano optimisations remain enabled
- User-defined CSSNano configuration is not affected (existing override check is preserved)

## Before / After

**Before** (production build output):
```css
.test { height: 100% }
```

After (production build output):
```css
.test { height: calc(100vh - calc(100vh - 100%)) }
```