### PR TITLE
fix(nuxt): accept refs as inputs in `NuxtLink.useLink`

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -8,7 +8,8 @@ import type {
   PropType,
   SlotsType,
   UnwrapRef,
-  VNode, VNodeProps,
+  VNode,
+  VNodeProps,
 } from 'vue'
 import { computed, defineComponent, h, inject, onBeforeUnmount, onMounted, provide, ref, resolveComponent, shallowRef, unref } from 'vue'
 import type { RouteLocation, RouteLocationRaw, Router, RouterLink, RouterLinkProps, UseLinkReturn, useLink } from 'vue-router'
@@ -208,7 +209,7 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
       return resolveTrailingSlashBehavior(path, router.resolve, unref(props.trailingSlash))
     })
 
-    const link = isExternal.value ? undefined : useBuiltinLink?.({ ...props, to })
+    const link = isExternal.value ? undefined : useBuiltinLink?.({ ...props, to, viewTransition: unref(props.viewTransition) })
 
     // Resolves `to` value if it's a route location object
     const href = computed(() => {

--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -4,13 +4,12 @@ import type {
   ComputedRef,
   DefineSetupFnComponent,
   InjectionKey,
+  MaybeRef,
   PropType,
   SlotsType,
   UnwrapRef,
-  VNode,
-  VNodeProps,
+  VNode, VNodeProps,
 } from 'vue'
-import type { MaybeRef } from 'vue'
 import { computed, defineComponent, h, inject, onBeforeUnmount, onMounted, provide, ref, resolveComponent, shallowRef, unref } from 'vue'
 import type { RouteLocation, RouteLocationRaw, Router, RouterLink, RouterLinkProps, UseLinkReturn, useLink } from 'vue-router'
 import { hasProtocol, joinURL, parseQuery, withTrailingSlash, withoutTrailingSlash } from 'ufo'

--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -10,7 +10,8 @@ import type {
   VNode,
   VNodeProps,
 } from 'vue'
-import { computed, defineComponent, h, inject, onBeforeUnmount, onMounted, provide, ref, resolveComponent, shallowRef } from 'vue'
+import type { MaybeRef } from 'vue'
+import { computed, defineComponent, h, inject, onBeforeUnmount, onMounted, provide, ref, resolveComponent, shallowRef, unref } from 'vue'
 import type { RouteLocation, RouteLocationRaw, Router, RouterLink, RouterLinkProps, UseLinkReturn, useLink } from 'vue-router'
 import { hasProtocol, joinURL, parseQuery, withTrailingSlash, withoutTrailingSlash } from 'ufo'
 import { preloadRouteComponents } from '../composables/preload'
@@ -168,15 +169,15 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
     return resolvedPath
   }
 
-  function useNuxtLink (props: NuxtLinkProps) {
+  function useNuxtLink (props: { [K in keyof NuxtLinkProps]: MaybeRef<NuxtLinkProps[K]> }) {
     const router = useRouter()
     const config = useRuntimeConfig()
 
-    const hasTarget = computed(() => !!props.target && props.target !== '_self')
+    const hasTarget = computed(() => !!unref(props.target) && unref(props.target) !== '_self')
 
     // Lazily check whether to.value has a protocol
     const isAbsoluteUrl = computed(() => {
-      const path = props.to || props.href || ''
+      const path = unref(props.to) || unref(props.href) || ''
       return typeof path === 'string' && hasProtocol(path, { acceptRelative: true })
     })
 
@@ -186,11 +187,11 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
     // Resolving link type
     const isExternal = computed<boolean>(() => {
       // External prop is explicitly set
-      if (props.external) {
+      if (unref(props.external)) {
         return true
       }
 
-      const path = props.to || props.href || ''
+      const path = unref(props.to) || unref(props.href) || ''
 
       // When `to` is a route object then it's an internal link
       if (typeof path === 'object') {
@@ -202,17 +203,17 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
 
     // Resolving `to` value from `to` and `href` props
     const to: ComputedRef<RouteLocationRaw> = computed(() => {
-      checkPropConflicts(props, 'to', 'href')
-      const path = props.to || props.href || '' // Defaults to empty string (won't render any `href` attribute)
+      checkPropConflicts(props as NuxtLinkProps, 'to', 'href')
+      const path = unref(props.to) || unref(props.href) || '' // Defaults to empty string (won't render any `href` attribute)
       if (isExternal.value) { return path }
-      return resolveTrailingSlashBehavior(path, router.resolve, props.trailingSlash)
+      return resolveTrailingSlashBehavior(path, router.resolve, unref(props.trailingSlash))
     })
 
     const link = isExternal.value ? undefined : useBuiltinLink?.({ ...props, to })
 
     // Resolves `to` value if it's a route location object
     const href = computed(() => {
-      const effectiveTrailingSlash = props.trailingSlash ?? options.trailingSlash
+      const effectiveTrailingSlash = unref(props.trailingSlash) ?? options.trailingSlash
       if (!to.value || isAbsoluteUrl.value || isHashLinkWithoutHashMode(to.value)) {
         return to.value as string
       }
@@ -242,7 +243,7 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
       isExactActive: link?.isExactActive ?? computed(() => to.value === router.currentRoute.value.path),
       route: link?.route ?? computed(() => router.resolve(to.value)),
       async navigate (_e?: MouseEvent) {
-        await navigateTo(href.value, { replace: props.replace, external: isExternal.value || hasTarget.value })
+        await navigateTo(href.value, { replace: unref(props.replace), external: isExternal.value || hasTarget.value })
       },
     } satisfies ReturnType<typeof useLink> & {
       to: ComputedRef<RouteLocationRaw>

--- a/packages/nuxt/test/nuxt-link.test.ts
+++ b/packages/nuxt/test/nuxt-link.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { RouteLocation, RouteLocationRaw } from 'vue-router'
+import { ref } from 'vue'
 import { withQuery } from 'ufo'
 import type { NuxtLinkOptions, NuxtLinkProps } from '../src/app/components/nuxt-link.ts'
 import { defineNuxtLink } from '../src/app/components/nuxt-link.ts'
@@ -347,5 +348,39 @@ describe('nuxt-link:propsOrAttributes', () => {
         expect(nuxtLink({ to: '/to/', external: true }, removeSlashOptions).props.href).toBe('/to')
       })
     })
+  })
+})
+
+describe('nuxt-link:useLink', () => {
+  it('accepts plain values for `to`', () => {
+    const component = defineNuxtLink({ componentName: 'NuxtLink' })
+    const link = component.useLink({ to: '/about' })
+    expect(link.href.value).toBe('/about')
+    expect(link.isExternal.value).toBe(false)
+  })
+
+  it('accepts a Ref for `to`', () => {
+    const component = defineNuxtLink({ componentName: 'NuxtLink' })
+    const to = ref('/about')
+    const link = component.useLink({ to })
+    expect(link.href.value).toBe('/about')
+    expect(link.isExternal.value).toBe(false)
+  })
+
+  it('reacts to changes in a Ref `to`', () => {
+    const component = defineNuxtLink({ componentName: 'NuxtLink' })
+    const to = ref('/about')
+    const link = component.useLink({ to })
+    expect(link.href.value).toBe('/about')
+    to.value = '/contact'
+    expect(link.href.value).toBe('/contact')
+  })
+
+  it('correctly identifies external links via Ref `to`', () => {
+    const component = defineNuxtLink({ componentName: 'NuxtLink' })
+    const to = ref('https://nuxtjs.org')
+    const link = component.useLink({ to })
+    expect(link.isExternal.value).toBe(true)
+    expect(link.href.value).toBe('https://nuxtjs.org')
   })
 })


### PR DESCRIPTION
## Summary

Fixes #34376

`NuxtLink.useLink` did not accept `Ref` values for its inputs (e.g. `to`, `href`, `external`, etc.), unlike Vue Router's own `useLink` which accepts `to: Ref<RouteLocationRaw> | RouteLocationRaw`. This caused programmatic navigation to silently break when using reactive refs:

```ts
// Before: broken — navigate() would not route correctly
const to = ref('/about')
const link = NuxtLink.useLink({ to })

// After: works as expected
const to = ref('/about')
const link = NuxtLink.useLink({ to })
await link.navigate()
```
## Changes
- nuxt-link.ts: Change useNuxtLink parameter type from NuxtLinkProps to { [K in keyof NuxtLinkProps]: MaybeRef<NuxtLinkProps[K]> }, and wrap all props.xxx accesses with unref() inside computed callbacks and the navigate function. Plain (non-ref) values continue to work unchanged since unref() is a no-op for non-refs.

- nuxt-link.test.ts: Add a nuxt-link:useLink test suite covering:

- Plain string value for to
- Ref<string> value for to
- Reactivity when the ref's value changes
- External link detection via a ref

# Test plan

- [x] All existing `nuxt-link` unit tests pass
- [x] New `nuxt-link:useLink` tests pass (4 cases)
- [ ] Verify `NuxtLink.useLink({ to: ref('/about') })` navigates correctly in a Nuxt app
- [ ] Verify static `NuxtLink.useLink({ to: '/about' })` still works as before