### PR TITLE
test: add failing route-rules disk repro

### DIFF
--- a/test/route-rules-missing-template.test.ts
+++ b/test/route-rules-missing-template.test.ts
@@ -1,0 +1,33 @@
+import { existsSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { join } from 'pathe'
+import { fetch, setup } from '@nuxt/test-utils/e2e'
+import { builder, isDev } from './matrix'
+
+const fixtureDir = fileURLToPath(new URL('./fixtures/minimal-pages', import.meta.url))
+const buildDir = join(fixtureDir, '.nuxt', 'test', Math.random().toString(36).slice(2, 8))
+
+await setup({
+  rootDir: fixtureDir,
+  dev: isDev,
+  server: true,
+  browser: false,
+  nuxtConfig: {
+    buildDir: isDev ? buildDir : undefined,
+    routeRules: {
+      '/swr': { swr: 60 },
+      '/isr': { isr: 60 },
+    },
+  },
+})
+
+describe.skipIf(builder !== 'vite' || !isDev)('route-rules template materialization', () => {
+  it('starts app and writes expected templates to disk', async () => {
+    const { status } = await fetch('/')
+    expect(status).toBe(200)
+
+    expect(existsSync(join(buildDir, 'app.config.mjs'))).toBe(true)
+    expect(existsSync(join(buildDir, 'route-rules.mjs'))).toBe(true)
+  })
+})


### PR DESCRIPTION
Adds a single failing test that asserts `route-rules.mjs` is materialized on disk in Vite dev when `routeRules` are configured.

Source repro (from `~/repros`): [onmax/repros/nuxt-route-rules-ci-repro](https://github.com/onmax/repros/tree/repro/nuxt-route-rules-runtime-repro/nuxt-route-rules-runtime-repro)

Issue context: [#34164](https://github.com/nuxt/nuxt/issues/34164).

Given prior guidance that most `#build` templates are virtual, should this repro be considered invalid? If so, what runtime behavior should the test assert instead (rather than checking `route-rules.mjs` on disk)?
