### PR TITLE
fix(vite): pin rollup-plugin-visualizer to exact version for Node 20.x compatibility

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -57,7 +57,7 @@
     "pathe": "^2.0.3",
     "pkg-types": "^2.3.0",
     "postcss": "^8.5.6",
-    "rollup-plugin-visualizer": "^6.0.5",
+    "rollup-plugin-visualizer": "6.0.5",
     "seroval": "^1.5.0",
     "std-env": "^3.10.0",
     "ufo": "^1.6.3",


### PR DESCRIPTION
## Summary

- Pin `rollup-plugin-visualizer` from `^6.0.5` to `6.0.5` in `packages/vite/package.json`
- `rollup-plugin-visualizer@6.0.8` raised its Node.js engine requirement to `>=22`, which breaks Node 20.x users
- `@nuxt/vite-builder` declares support for `^20.19.0 || >=22.12.0`, so this is a regression
- This aligns with `packages/schema/package.json` which already pins to exact `6.0.5`

Closes #34394