### PR TITLE
fix(nitro): allow navigation from error page to external protocols

### DIFF
--- a/packages/nitro-server/src/runtime/utils/dev.ts
+++ b/packages/nitro-server/src/runtime/utils/dev.ts
@@ -360,7 +360,7 @@ function webComponentScript (base64HTML: string, startMinimized: boolean) {
     iframe.id = 'frame';
     iframe.src = 'data:text/html;base64,${base64HTML}';
     iframe.title = 'Detailed error stack trace';
-    iframe.setAttribute('sandbox', 'allow-scripts allow-same-origin');
+    iframe.setAttribute('sandbox', 'allow-scripts allow-same-origin allow-top-navigation-by-user-activation');
 
     const preview = el('div');
     preview.id = 'preview';


### PR DESCRIPTION
### 🔗 Linked issue

nuxt/nuxt/issues/34404

### 📚 Description

When `nuxt-error-overlay` is active, the error overlay iframe blocks navigation to external protocols due to sandbox restrictions.

Clicking on a link that triggers an external protocol (e.g., `vscode:`, `phpstomr:`, etc.) results in the following error in the browser console:

> Navigation to external protocol blocked by sandbox, because it doesn't contain any of: 'allow-top-navigation-to-custom-protocols',
'allow-top-navigation-by-user-activation', 'allow-top-navigation', or 'allow-popups'. See https://chromestatus.com/feature/5680742077038592
> and https://chromeenterprise.google/policies/#SandboxExternalProtocolBlockedUnderstand this error

This change adds `allow-top-navigation-by-user-activation` to the iframe sandbox protocols which resolves the issue.

```diff
-iframe.setAttribute('sandbox', 'allow-scripts allow-same-origin');
+iframe.setAttribute('sandbox', 'allow-scripts allow-same-origin allow-top-navigation-by-user-activation');
```

