### PR TITLE
perf(nitro,schema): inline payload in HTML for cached routes + add `payloadExtraction: 'client'`

### DIFF
--- a/docs/3.guide/6.going-further/1.experimental-features.md
+++ b/docs/3.guide/6.going-further/1.experimental-features.md
@@ -238,12 +238,19 @@ export default defineNuxtConfig({
 
 ## payloadExtraction
 
-Enables extraction of payloads of pages generated with `nuxt generate`.
+Controls how payload data is delivered for prerendered and cached (ISR/SWR) pages.
+
+- `'client'` - Payload is inlined in HTML for the initial server render, and extracted to `_payload.json` files for client-side navigation. This avoids a separate network request on initial load while still enabling efficient client-side navigation.
+- `true` - Payload is extracted to a separate `_payload.json` file for both the initial server render and client-side navigation.
+- `false` - Payload extraction is disabled entirely. Payload is always inlined in HTML and no `_payload.json` files are generated.
+
+The default is `true`, or `'client'` when `compatibilityVersion: 5` is set.
 
 ```ts twoslash [nuxt.config.ts]
 export default defineNuxtConfig({
   experimental: {
-    payloadExtraction: true,
+    // Inline payload in HTML, extract for client-side navigation only
+    payloadExtraction: 'client',
   },
 })
 ```
@@ -253,7 +260,7 @@ Payload extraction also works for routes using ISR (Incremental Static Regenerat
 ```ts twoslash [nuxt.config.ts]
 export default defineNuxtConfig({
   experimental: {
-    payloadExtraction: true,
+    payloadExtraction: 'client',
   },
   routeRules: {
     // Payload files will be generated for these cached routes

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -227,7 +227,8 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
           `export const NUXT_JSON_PAYLOADS = ${!!nuxt.options.experimental.renderJsonPayloads}`,
           `export const NUXT_ASYNC_CONTEXT = ${!!nuxt.options.experimental.asyncContext}`,
           `export const NUXT_SHARED_DATA = ${!!nuxt.options.experimental.sharedPrerenderData}`,
-          `export const NUXT_PAYLOAD_EXTRACTION = ${!!nuxt.options.experimental.payloadExtraction}`,
+          `export const NUXT_PAYLOAD_EXTRACTION = ${nuxt.options.experimental.payloadExtraction !== false}`,
+          `export const NUXT_PAYLOAD_INLINE = ${nuxt.options.experimental.payloadExtraction !== true}`,
           `export const NUXT_RUNTIME_PAYLOAD_EXTRACTION = ${hasCachedRoutes}`,
         ].join('\n')
       },
@@ -672,11 +673,9 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
         }))
   }
 
-  // TODO: remove when app manifest support is landed in https://github.com/nuxt/nuxt/pull/21641
-  // Add prerender payload support
-  if (nitro.options.static && nuxt.options.experimental.payloadExtraction === undefined) {
-    logger.warn('Using experimental payload extraction for full-static output. You can opt-out by setting `experimental.payloadExtraction` to `false`.')
-    nuxt.options.experimental.payloadExtraction = true
+  // For full-static output, ensure payload extraction is not disabled
+  if (nitro.options.static && nuxt.options.experimental.payloadExtraction === false) {
+    logger.warn('Payload extraction is recommended for full-static output. You can enable it by setting `experimental.payloadExtraction` to `true` or `\'client\'`.')
   }
 
   // Trigger Nitro reload when SPA loading template changes

--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -20,7 +20,7 @@ import { replaceIslandTeleports } from '../utils/renderer/islands'
 // @ts-expect-error virtual file
 import { renderSSRHeadOptions } from '#internal/unhead.config.mjs'
 // @ts-expect-error virtual file
-import { NUXT_ASYNC_CONTEXT, NUXT_EARLY_HINTS, NUXT_INLINE_STYLES, NUXT_JSON_PAYLOADS, NUXT_NO_SCRIPTS, NUXT_PAYLOAD_EXTRACTION, NUXT_RUNTIME_PAYLOAD_EXTRACTION, PARSE_ERROR_DATA } from '#internal/nuxt/nitro-config.mjs'
+import { NUXT_ASYNC_CONTEXT, NUXT_EARLY_HINTS, NUXT_INLINE_STYLES, NUXT_JSON_PAYLOADS, NUXT_NO_SCRIPTS, NUXT_PAYLOAD_EXTRACTION, NUXT_PAYLOAD_INLINE, NUXT_RUNTIME_PAYLOAD_EXTRACTION, PARSE_ERROR_DATA } from '#internal/nuxt/nitro-config.mjs'
 // @ts-expect-error virtual file
 import { appHead, appTeleportAttrs, appTeleportTag, componentIslands, appManifest as isAppManifestEnabled } from '#internal/nuxt.config.mjs'
 // @ts-expect-error virtual file
@@ -99,14 +99,19 @@ const handler: EventHandler = defineRenderHandler(async (event): Promise<Partial
     || (NUXT_RUNTIME_PAYLOAD_EXTRACTION && (routeOptions.isr || routeOptions.cache))
   )
 
+  // When NUXT_PAYLOAD_INLINE is true (payloadExtraction: 'client'), we inline the full payload
+  // in the HTML to avoid a separate _payload.json fetch on initial load (which would trigger a
+  // second render or lambda invocation). The _payload.json endpoint still works for client-side nav.
+  const _PAYLOAD_INLINE = !_PAYLOAD_EXTRACTION || NUXT_PAYLOAD_INLINE
+
   const isRenderingPayload = (_PAYLOAD_EXTRACTION || (import.meta.dev && routeOptions.prerender)) && PAYLOAD_URL_RE.test(ssrContext.url)
   if (isRenderingPayload) {
     const url = ssrContext.url.substring(0, ssrContext.url.lastIndexOf('/')) || '/'
     ssrContext.url = url
 
     event._path = event.node.req.url = url
-    if (import.meta.prerender && await payloadCache!.hasItem(url)) {
-      return payloadCache!.getItem(url) as Promise<Partial<RenderResponse>>
+    if (payloadCache && await payloadCache.hasItem(url)) {
+      return payloadCache.getItem(url) as Promise<Partial<RenderResponse>>
     }
   }
 
@@ -165,17 +170,22 @@ const handler: EventHandler = defineRenderHandler(async (event): Promise<Partial
   // Directly render payload routes
   if (isRenderingPayload) {
     const response = renderPayloadResponse(ssrContext)
-    if (import.meta.prerender) {
-      await payloadCache!.setItem(ssrContext.url, response)
+    if (payloadCache) {
+      await payloadCache.setItem(ssrContext.url, response)
     }
     return response
   }
 
-  if (_PAYLOAD_EXTRACTION && import.meta.prerender) {
-    // Hint nitro to prerender payload for this route
-    appendResponseHeader(event, 'x-nitro-prerender', joinURL(ssrContext.url.replace(/\?.*$/, ''), PAYLOAD_FILENAME))
-    // Use same ssr context to generate payload for this route
-    await payloadCache!.setItem(ssrContext.url === '/' ? '/' : ssrContext.url.replace(/\/$/, ''), renderPayloadResponse(ssrContext))
+  if (_PAYLOAD_EXTRACTION) {
+    if (import.meta.prerender) {
+      // Hint nitro to prerender payload for this route
+      appendResponseHeader(event, 'x-nitro-prerender', joinURL(ssrContext.url.replace(/\?.*$/, ''), PAYLOAD_FILENAME))
+    }
+    // Cache payload from the current SSR context so _payload.json requests can be served
+    // without a full re-render (during prerender via LRU+FS, at runtime via in-memory TTL cache)
+    if (payloadCache) {
+      await payloadCache.setItem(ssrContext.url === '/' ? '/' : ssrContext.url.replace(/\/$/, ''), renderPayloadResponse(ssrContext))
+    }
   }
 
   const NO_SCRIPTS = NUXT_NO_SCRIPTS || routeOptions.noScripts
@@ -210,7 +220,8 @@ const handler: EventHandler = defineRenderHandler(async (event): Promise<Partial
     }, headEntryOptions)
   }
   // 1. Preload payloads and app manifest
-  if (_PAYLOAD_EXTRACTION && !NO_SCRIPTS) {
+  // Skip preload when inlining full payload in HTML (no separate fetch needed for initial load)
+  if (_PAYLOAD_EXTRACTION && !_PAYLOAD_INLINE && !NO_SCRIPTS) {
     ssrContext.head.push({
       link: [
         NUXT_JSON_PAYLOADS
@@ -266,13 +277,15 @@ const handler: EventHandler = defineRenderHandler(async (event): Promise<Partial
     }, headEntryOptions)
     // 5. Payloads
     ssrContext.head.push({
-      script: _PAYLOAD_EXTRACTION
+      script: _PAYLOAD_INLINE
+        // Inline full payload in HTML (payloadExtraction: 'client' | false, or non-cached route)
         ? NUXT_JSON_PAYLOADS
-          ? renderPayloadJsonScript({ ssrContext, data: splitPayload(ssrContext).initial, src: payloadURL })
-          : renderPayloadScript({ ssrContext, data: splitPayload(ssrContext).initial, routeOptions, src: payloadURL })
-        : NUXT_JSON_PAYLOADS
           ? renderPayloadJsonScript({ ssrContext, data: ssrContext.payload })
-          : renderPayloadScript({ ssrContext, data: ssrContext.payload, routeOptions }),
+          : renderPayloadScript({ ssrContext, data: ssrContext.payload, routeOptions })
+        // Split payload: inline initial data, reference external _payload.json via src (payloadExtraction: true)
+        : NUXT_JSON_PAYLOADS
+          ? renderPayloadJsonScript({ ssrContext, data: splitPayload(ssrContext).initial, src: payloadURL })
+          : renderPayloadScript({ ssrContext, data: splitPayload(ssrContext).initial, routeOptions, src: payloadURL }),
     }, {
       ...headEntryOptions,
       // this should come before another end of body scripts
@@ -283,7 +296,7 @@ const handler: EventHandler = defineRenderHandler(async (event): Promise<Partial
 
   // 6. Scripts
   if (!routeOptions.noScripts) {
-    const tagPosition = (_PAYLOAD_EXTRACTION && !NUXT_JSON_PAYLOADS) ? 'bodyClose' : 'head'
+    const tagPosition = (_PAYLOAD_EXTRACTION && !_PAYLOAD_INLINE && !NUXT_JSON_PAYLOADS) ? 'bodyClose' : 'head'
 
     ssrContext.head.push({
       script: Object.values(scripts).map(resource => (<Script> {

--- a/packages/nitro-server/src/runtime/utils/cache.ts
+++ b/packages/nitro-server/src/runtime/utils/cache.ts
@@ -1,11 +1,17 @@
 // Workaround for 'The inferred type of 'payloadCache' cannot be named without a reference to '.pnpm/unstorage@1.16.0_db0@0.3.2_ioredis@5.6.1/node_modules/unstorage'.
 // This is likely not portable. A type annotation is necessary.
 import type { Storage } from 'unstorage'
+import { createStorage } from 'unstorage'
 import { useStorage } from 'nitropack/runtime'
+import lruCacheDriver from 'unstorage/drivers/lru-cache'
 // @ts-expect-error virtual file
-import { NUXT_SHARED_DATA } from '#internal/nuxt/nitro-config.mjs'
+import { NUXT_RUNTIME_PAYLOAD_EXTRACTION, NUXT_SHARED_DATA } from '#internal/nuxt/nitro-config.mjs'
 
-export const payloadCache: Storage | null = import.meta.prerender ? useStorage('internal:nuxt:prerender:payload') : null
+export const payloadCache: Storage | null = import.meta.prerender
+  ? useStorage('internal:nuxt:prerender:payload')
+  : NUXT_RUNTIME_PAYLOAD_EXTRACTION
+    ? createStorage({ driver: lruCacheDriver({ max: 100, ttl: 30_000 }) })
+    : null
 export const islandCache: Storage | null = import.meta.prerender ? useStorage('internal:nuxt:prerender:island') : null
 export const islandPropCache: Storage | null = import.meta.prerender ? useStorage('internal:nuxt:prerender:island-props') : null
 export const sharedPrerenderPromises: Map<string, Promise<any>> | null = import.meta.prerender && NUXT_SHARED_DATA ? new Map<string, Promise<any>>() : null

--- a/packages/nitro-server/src/runtime/utils/cache.ts
+++ b/packages/nitro-server/src/runtime/utils/cache.ts
@@ -1,16 +1,14 @@
 // Workaround for 'The inferred type of 'payloadCache' cannot be named without a reference to '.pnpm/unstorage@1.16.0_db0@0.3.2_ioredis@5.6.1/node_modules/unstorage'.
 // This is likely not portable. A type annotation is necessary.
 import type { Storage } from 'unstorage'
-import { createStorage } from 'unstorage'
 import { useStorage } from 'nitropack/runtime'
-import lruCacheDriver from 'unstorage/drivers/lru-cache'
 // @ts-expect-error virtual file
 import { NUXT_RUNTIME_PAYLOAD_EXTRACTION, NUXT_SHARED_DATA } from '#internal/nuxt/nitro-config.mjs'
 
 export const payloadCache: Storage | null = import.meta.prerender
   ? useStorage('internal:nuxt:prerender:payload')
   : NUXT_RUNTIME_PAYLOAD_EXTRACTION
-    ? createStorage({ driver: lruCacheDriver({ max: 100, ttl: 30_000 }) })
+    ? useStorage('cache:nuxt:payload')
     : null
 export const islandCache: Storage | null = import.meta.prerender ? useStorage('internal:nuxt:prerender:island') : null
 export const islandPropCache: Storage | null = import.meta.prerender ? useStorage('internal:nuxt:prerender:island-props') : null

--- a/packages/nitro-server/src/runtime/utils/renderer/payload.ts
+++ b/packages/nitro-server/src/runtime/utils/renderer/payload.ts
@@ -9,7 +9,7 @@ import type { NuxtPayload, NuxtSSRContext } from 'nuxt/app'
 // @ts-expect-error virtual file
 import { appId, multiApp } from '#internal/nuxt.config.mjs'
 // @ts-expect-error virtual file
-import { NUXT_JSON_PAYLOADS, NUXT_NO_SSR, NUXT_PAYLOAD_EXTRACTION, NUXT_RUNTIME_PAYLOAD_EXTRACTION } from '#internal/nuxt/nitro-config.mjs'
+import { NUXT_JSON_PAYLOADS, NUXT_NO_SSR } from '#internal/nuxt/nitro-config.mjs'
 
 export function renderPayloadResponse (ssrContext: NuxtSSRContext): RenderResponse {
   return {
@@ -75,12 +75,8 @@ function escapeJsString (str: string): string {
 
 export function renderPayloadScript (opts: { ssrContext: NuxtSSRContext, routeOptions: NitroRouteRules, data?: any, src?: string }): Script[] {
   opts.data.config = opts.ssrContext.config
-  const _PAYLOAD_EXTRACTION = !opts.ssrContext.noSSR && (
-    (import.meta.prerender && NUXT_PAYLOAD_EXTRACTION)
-    || (NUXT_RUNTIME_PAYLOAD_EXTRACTION && (opts.routeOptions.isr || opts.routeOptions.cache))
-  )
   const nuxtData = devalue(opts.data)
-  if (_PAYLOAD_EXTRACTION) {
+  if (opts.src) {
     // Escape the URL to prevent XSS when interpolated into a JS string literal
     const escapedSrc = escapeJsString(opts.src!)
     const singleAppPayload = `import p from "${escapedSrc}";window.__NUXT__={...p,...(${nuxtData})}`

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -97,7 +97,12 @@ export default defineResolvers({
     restoreState: false,
     renderJsonPayloads: true,
     noVueServer: false,
-    payloadExtraction: true,
+    payloadExtraction: {
+      $resolve: async (val, get) => {
+        if (val === 'client' || typeof val === 'boolean') { return val }
+        return (await get('future.compatibilityVersion')) >= 5 ? 'client' as const : true
+      },
+    },
     clientFallback: false,
     crossOriginPrefetch: false,
 

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1121,11 +1121,19 @@ export interface ConfigSchema {
     noVueServer: boolean
 
     /**
-     * When this option is enabled (by default) payload of pages that are prerendered are extracted
+     * Controls how payload data is delivered for prerendered and cached (ISR/SWR) pages.
+     *
+     * - `'client'` - Payload is inlined in HTML for the initial server render, and extracted to
+     *   `_payload.json` files for client-side navigation. This avoids a separate request on
+     *   initial load while still enabling efficient client-side navigation.
+     * - `true` - Payload is extracted to a separate `_payload.json` file for both the initial
+     *   server render and client-side navigation.
+     * - `false` - Payload extraction is disabled entirely. Payload is always inlined in HTML and
+     *   no `_payload.json` files are generated.
      *
      * @default true
      */
-    payloadExtraction: boolean | undefined
+    payloadExtraction: 'client' | boolean | undefined
 
     /**
      * Whether to enable the experimental `<NuxtClientFallback>` component for rendering content on the client if there's an error in SSR.

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1131,7 +1131,7 @@ export interface ConfigSchema {
      * - `false` - Payload extraction is disabled entirely. Payload is always inlined in HTML and
      *   no `_payload.json` files are generated.
      *
-     * @default true
+     * `@default` true (or 'client' when compatibilityVersion >= 5)
      */
     payloadExtraction: 'client' | boolean | undefined
 

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -58,7 +58,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(rootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"199k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"200k"`)
 
     const modules = await analyzeSizes(['node_modules/**/*'], serverDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"1441k"`)
@@ -118,7 +118,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(pagesRootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"294k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"295k"`)
 
     const modules = await analyzeSizes(['node_modules/**/*'], serverDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"1452k"`)


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

when a cached route (ISR/SWR) is rendered at runtime with payload extraction enabled, the HTML references an external `_payload.json`.

the browser immediately fetches this as a second request, which triggers a full SSR re-render of the same page just to extract the data portion. in a serverless environment, this can spin up a second lambda before the first response has even finished streaming...

this PR addresses this in two ways:

1. adds a new `payloadExtraction: 'client'` mode that inlines the full payload in the initial HTML response while still generating `_payload.json` for client-side navigation (bypassing the issue entirely)
2. adds a runtime in-memory LRU payload cache so that `_payload.json` requests (from client-side navigation) can be served without a full re-render when the HTML was already rendered in the same process

The new `payloadExtraction: 'client'` is only default with `compatibilityVersion: 5`, to avoid a breaking change, but the runtime cache should still solve the issue for these users.

#### context

surveying the issues, spotted some requests _for_ extraction even on the initial render

- to keep html small - #33019
- to avoid duplication - #10451, #2083

hence allowing 'true' to force extraction on server side as well. we might revisit as I think there's plenty of space for optimisation here