### PR TITLE
fix(nuxt): script block extract regex conflict

### DIFF
--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -183,7 +183,7 @@ export async function augmentPages (routes: NuxtPage[], vfs: Record<string, stri
   return ctx.augmentedPages
 }
 
-const SFC_SCRIPT_RE = /<script(?<attrs>[^>]*)>(?<content>[\s\S]*?)<\/script[^>]*>/gi
+const SFC_SCRIPT_RE = /<script(?<attrs>[^>]*)>(?<content>[\s\S]*?)<\/script[^>]*>/g
 export function extractScriptContent (sfc: string) {
   const contents: Array<{ loader: 'tsx' | 'ts', code: string }> = []
   for (const match of sfc.matchAll(SFC_SCRIPT_RE)) {

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -7,7 +7,6 @@ import { genArrayFromRaw, genDynamicImport, genImport, genSafeVariableName } fro
 import { filename } from 'pathe/utils'
 import { hash } from 'ohash'
 
-import { parse as parseSFC } from '@vue/compiler-sfc'
 import { defu } from 'defu'
 import { klona } from 'klona'
 import { parseAndWalk } from 'oxc-walker'
@@ -184,14 +183,14 @@ export async function augmentPages (routes: NuxtPage[], vfs: Record<string, stri
   return ctx.augmentedPages
 }
 
+const SFC_SCRIPT_RE = /<script(?=\s|>)(?<attrs>[^>]*)>(?<content>[\s\S]*?)<\/script\s*>/gi
 export function extractScriptContent (sfc: string) {
   const contents: Array<{ loader: 'tsx' | 'ts', code: string }> = []
-  const { descriptor } = parseSFC(sfc, { pad: false })
-  for (const block of [descriptor.script, descriptor.scriptSetup]) {
-    if (block?.content.trim()) {
+  for (const match of sfc.matchAll(SFC_SCRIPT_RE)) {
+    if (match?.groups?.content) {
       contents.push({
-        loader: block.lang && /[tj]sx/.test(block.lang) ? 'tsx' : 'ts',
-        code: block.content.trim(),
+        loader: match.groups.attrs && /[tj]sx/.test(match.groups.attrs) ? 'tsx' : 'ts',
+        code: match.groups.content.trim(),
       })
     }
   }

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -7,6 +7,7 @@ import { genArrayFromRaw, genDynamicImport, genImport, genSafeVariableName } fro
 import { filename } from 'pathe/utils'
 import { hash } from 'ohash'
 
+import { ELEMENT_NODE, parse as parseHTML } from 'ultrahtml'
 import { defu } from 'defu'
 import { klona } from 'klona'
 import { parseAndWalk } from 'oxc-walker'
@@ -183,15 +184,18 @@ export async function augmentPages (routes: NuxtPage[], vfs: Record<string, stri
   return ctx.augmentedPages
 }
 
-const SFC_SCRIPT_RE = /<script(?<attrs>[^>]*)>(?<content>[\s\S]*?)<\/script[^>]*>/g
 export function extractScriptContent (sfc: string) {
   const contents: Array<{ loader: 'tsx' | 'ts', code: string }> = []
-  for (const match of sfc.matchAll(SFC_SCRIPT_RE)) {
-    if (match?.groups?.content) {
-      contents.push({
-        loader: match.groups.attrs && /[tj]sx/.test(match.groups.attrs) ? 'tsx' : 'ts',
-        code: match.groups.content.trim(),
-      })
+  const tree = parseHTML(sfc)
+  for (const node of tree.children) {
+    if (node.type === ELEMENT_NODE && node.name === 'script') {
+      const code = sfc.slice(node.loc[0].end, node.loc[1].start).trim()
+      if (code) {
+        contents.push({
+          loader: /[tj]sx/.test(node.attributes.lang || '') ? 'tsx' : 'ts',
+          code,
+        })
+      }
     }
   }
 

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -7,7 +7,7 @@ import { genArrayFromRaw, genDynamicImport, genImport, genSafeVariableName } fro
 import { filename } from 'pathe/utils'
 import { hash } from 'ohash'
 
-import { ELEMENT_NODE, parse as parseHTML } from 'ultrahtml'
+import { parse as parseSFC } from '@vue/compiler-sfc'
 import { defu } from 'defu'
 import { klona } from 'klona'
 import { parseAndWalk } from 'oxc-walker'
@@ -186,16 +186,13 @@ export async function augmentPages (routes: NuxtPage[], vfs: Record<string, stri
 
 export function extractScriptContent (sfc: string) {
   const contents: Array<{ loader: 'tsx' | 'ts', code: string }> = []
-  const tree = parseHTML(sfc)
-  for (const node of tree.children) {
-    if (node.type === ELEMENT_NODE && node.name === 'script') {
-      const code = sfc.slice(node.loc[0].end, node.loc[1].start).trim()
-      if (code) {
-        contents.push({
-          loader: /[tj]sx/.test(node.attributes.lang || '') ? 'tsx' : 'ts',
-          code,
-        })
-      }
+  const { descriptor } = parseSFC(sfc, { pad: false })
+  for (const block of [descriptor.script, descriptor.scriptSetup]) {
+    if (block?.content.trim()) {
+      contents.push({
+        loader: block.lang && /[tj]sx/.test(block.lang) ? 'tsx' : 'ts',
+        code: block.content.trim(),
+      })
     }
   }
 

--- a/packages/nuxt/test/page-metadata.test.ts
+++ b/packages/nuxt/test/page-metadata.test.ts
@@ -53,6 +53,46 @@ definePageMeta({
     })
   })
 
+  it('should handle multiple script blocks and escaped closing tags', () => {
+    const meta = getRouteMeta(`
+<script>
+export default { inheritAttrs: false }
+</script>
+
+<script setup lang="ts">
+const snippet = '<\\/script>'
+definePageMeta({
+  name: 'multi',
+})
+</script>
+
+<template><div /></template>`, filePath)
+
+    expect(meta).toStrictEqual({
+      name: 'multi',
+    })
+  })
+
+  it('should handle script tag references inside template without extracting them', () => {
+    const meta = getRouteMeta(`
+<template>
+  <div>
+    <script-placeholder />
+    <component is="script" />
+  </div>
+</template>
+
+<script setup lang="ts">
+definePageMeta({
+  path: '/safe',
+})
+</script>`, filePath)
+
+    expect(meta).toStrictEqual({
+      path: '/safe',
+    })
+  })
+
   it('should extract metadata from JS/JSX files', () => {
     const fileContents = `definePageMeta({ name: 'bar' })`
     for (const ext of ['js', 'jsx', 'ts', 'tsx', 'mjs', 'cjs']) {

--- a/packages/nuxt/test/page-metadata.test.ts
+++ b/packages/nuxt/test/page-metadata.test.ts
@@ -32,6 +32,27 @@ describe('page metadata', () => {
     expect(getRouteMeta('<template><div>Hi</div></template>', filePath)).toEqual({})
   })
 
+  it('should not confuse Script* component tags with <script> blocks', () => {
+    const meta = getRouteMeta(`
+<template>
+  <div>
+    <ScriptYouTubePlayer video-id="dQw4w9WgXcQ" />
+  </div>
+</template>
+
+<script setup lang="ts">
+definePageMeta({
+  layout: 'dark',
+})
+</script>`, filePath)
+
+    expect(meta).toStrictEqual({
+      meta: {
+        __nuxt_dynamic_meta_key: new Set(['meta']),
+      },
+    })
+  })
+
   it('should extract metadata from JS/JSX files', () => {
     const fileContents = `definePageMeta({ name: 'bar' })`
     for (const ext of ['js', 'jsx', 'ts', 'tsx', 'mjs', 'cjs']) {


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/scripts/issues/613

### 📚 Description

`extractScriptContent` used a regex to pull `<script>` blocks from Vue SFCs. The pattern `<script[^>]*>` matched any tag starting with `script`, including component tags like `<ScriptYouTubePlayer>`.

```vue
<template>
  <div>
    <ScriptYouTubePlayer video-id="dQw4w9WgXcQ" />
    <!--        ↑ regex matches this as <script ...>        -->
  </div>
</template>
<!--            ↑ [\s\S]*? consumes everything in between   -->
<script setup lang="ts">
definePageMeta({ layout: 'dark' })
</script>
<!--        ↑ regex matches this as </script>, ending here   -->
```

The fix adds a lookahead `(?=\s|>)` after `script` so the tag name must be followed by whitespace or `>` matching `<script>` and `<script setup>` but not `<ScriptYouTubePlayer>`.

New regex is ~16% faster.