### PR TITLE
refactor(vite): use vite's `transformWithEsbuild` for analysis

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -45,7 +45,6 @@
     "consola": "^3.4.2",
     "cssnano": "^7.1.2",
     "defu": "^6.1.4",
-    "esbuild": "^0.27.3",
     "escape-string-regexp": "^5.0.0",
     "exsolve": "^1.0.8",
     "get-port-please": "^3.2.0",

--- a/packages/vite/src/plugins/analyze.ts
+++ b/packages/vite/src/plugins/analyze.ts
@@ -1,5 +1,5 @@
 import type { Plugin } from 'vite'
-import { transform } from 'esbuild'
+import { transformWithEsbuild } from 'vite'
 import { defu } from 'defu'
 import type { Nuxt, NuxtOptions } from '@nuxt/schema'
 import type { RenderedModule } from 'rollup'
@@ -32,7 +32,7 @@ export async function AnalyzePlugin (nuxt: Nuxt): Promise<Plugin | undefined> {
               const minifiedModuleEntryPromises: Array<Promise<[string, RenderedModule]>> = []
               for (const [moduleId, module] of Object.entries(bundle.modules)) {
                 minifiedModuleEntryPromises.push(
-                  transform(module.code || '', { minify: true })
+                  transformWithEsbuild(module.code || '', moduleId, { minify: true })
                     .then(result => [moduleId, { ...module, code: result.code }]),
                 )
               }

--- a/packages/vite/src/plugins/analyze.ts
+++ b/packages/vite/src/plugins/analyze.ts
@@ -32,7 +32,7 @@ export async function AnalyzePlugin (nuxt: Nuxt): Promise<Plugin | undefined> {
               const minifiedModuleEntryPromises: Array<Promise<[string, RenderedModule]>> = []
               for (const [moduleId, module] of Object.entries(bundle.modules)) {
                 minifiedModuleEntryPromises.push(
-                  transformWithEsbuild(module.code || '', moduleId, { minify: true })
+                  transformWithEsbuild(module.code || '', 'index.js', { minify: true })
                     .then(result => [moduleId, { ...module, code: result.code }]),
                 )
               }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1032,9 +1032,6 @@ importers:
       defu:
         specifier: ^6.1.4
         version: 6.1.4
-      esbuild:
-        specifier: ^0.27.3
-        version: 0.27.3
       escape-string-regexp:
         specifier: ^5.0.0
         version: 5.0.0


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this avoids two copies of `esbuild` in the tree