### PR TITLE
perf(nuxt,vite,webpack): use string parsing for module ids

### DIFF
--- a/packages/nuxt/src/components/plugins/islands-transform.ts
+++ b/packages/nuxt/src/components/plugins/islands-transform.ts
@@ -1,12 +1,10 @@
-import { pathToFileURL } from 'node:url'
 import type { Component } from '@nuxt/schema'
-import { parseURL } from 'ufo'
 import { createUnplugin } from 'unplugin'
 import MagicString from 'magic-string'
 import { ELEMENT_NODE, parse, walk } from 'ultrahtml'
 import { genObjectFromRawEntries, genString } from 'knitwork'
 import type { Plugin } from 'vite'
-import { isVue } from '../../core/utils/index.ts'
+import { isVue, parseModuleId } from '../../core/utils/index.ts'
 
 interface ServerOnlyComponentTransformPluginOptions {
   getComponents: () => Component[]
@@ -42,7 +40,7 @@ export const IslandsTransformPlugin = (options: ServerOnlyComponentTransformPlug
       const islands = components.filter(component =>
         component.island || (component.mode === 'server' && !components.some(c => c.pascalName === component.pascalName && c.mode === 'client')),
       )
-      const { pathname } = parseURL(decodeURIComponent(pathToFileURL(id).href))
+      const { pathname } = parseModuleId(id)
       return islands.some(c => c.filePath === pathname)
     },
     transform: {

--- a/packages/nuxt/src/components/plugins/islands-transform.ts
+++ b/packages/nuxt/src/components/plugins/islands-transform.ts
@@ -4,6 +4,7 @@ import MagicString from 'magic-string'
 import { ELEMENT_NODE, parse, walk } from 'ultrahtml'
 import { genObjectFromRawEntries, genString } from 'knitwork'
 import type { Plugin } from 'vite'
+import { normalize } from 'pathe'
 import { isVue, parseModuleId } from '../../core/utils/index.ts'
 
 interface ServerOnlyComponentTransformPluginOptions {
@@ -40,7 +41,7 @@ export const IslandsTransformPlugin = (options: ServerOnlyComponentTransformPlug
       const islands = components.filter(component =>
         component.island || (component.mode === 'server' && !components.some(c => c.pascalName === component.pascalName && c.mode === 'client')),
       )
-      const { pathname } = parseModuleId(id)
+      const { pathname } = parseModuleId(normalize(id))
       return islands.some(c => c.filePath === pathname)
     },
     transform: {

--- a/packages/nuxt/src/components/plugins/transform.ts
+++ b/packages/nuxt/src/components/plugins/transform.ts
@@ -3,8 +3,7 @@ import { isIgnored } from '@nuxt/kit'
 import type { Import } from 'unimport'
 import { createUnimport } from 'unimport'
 import { createUnplugin } from 'unplugin'
-import { parseURL } from 'ufo'
-import { parseQuery } from 'vue-router'
+import { parseModuleId } from '../../core/utils/plugins.ts'
 import { isAbsolute, normalize } from 'pathe'
 import { type PackageJson, readPackage } from 'pkg-types'
 import { genImport } from 'knitwork'
@@ -72,11 +71,11 @@ export function TransformPlugin (nuxt: Nuxt, options: TransformPluginOptions) {
         },
         handler (_code, id) {
           // Virtual component wrapper
-          const { search } = parseURL(id)
-          const query = parseQuery(search)
-          const mode = query.nuxt_component
+          const { search } = parseModuleId(id)
+          const params = new URLSearchParams(search)
+          const mode = params.get('nuxt_component')
           const bare = id.replace(/\?.*/, '')
-          const componentExport = query.nuxt_component_export as string || 'default'
+          const componentExport = params.get('nuxt_component_export') || 'default'
           const exportWording = componentExport === 'default' ? 'export default' : `export const ${componentExport} =`
           if (mode === 'async') {
             return {
@@ -105,7 +104,7 @@ export function TransformPlugin (nuxt: Nuxt, options: TransformPluginOptions) {
               map: null,
             }
           } else if (mode === 'server' || mode === 'server,async') {
-            const name = query.nuxt_component_name
+            const name = params.get('nuxt_component_name')
             return {
               code: [
                 `import { createServerComponent } from ${JSON.stringify(options.serverComponentRuntime)}`,

--- a/packages/nuxt/src/components/plugins/tree-shake.ts
+++ b/packages/nuxt/src/components/plugins/tree-shake.ts
@@ -1,5 +1,3 @@
-import { pathToFileURL } from 'node:url'
-import { parseURL } from 'ufo'
 import MagicString from 'magic-string'
 import { createUnplugin } from 'unplugin'
 import type { Component } from '@nuxt/schema'
@@ -8,6 +6,7 @@ import { resolve } from 'pathe'
 import { parseAndWalk, walk } from 'oxc-walker'
 import type { BindingPattern, BindingProperty, CallExpression, Node, ObjectExpression, Program, ReturnStatement, VariableDeclaration } from 'oxc-parser'
 import { distDir } from '../../dirs.ts'
+import { parseModuleId } from '../../core/utils/plugins.ts'
 
 interface TreeShakeTemplatePluginOptions {
   sourcemap?: boolean
@@ -24,7 +23,7 @@ export const TreeShakeTemplatePlugin = (options: TreeShakeTemplatePluginOptions)
     name: 'nuxt:tree-shake-template',
     enforce: 'post',
     transformInclude (id) {
-      const { pathname } = parseURL(decodeURIComponent(pathToFileURL(id).href))
+      const { pathname } = parseModuleId(id)
       return pathname.endsWith('.vue')
     },
     transform (code, id) {

--- a/packages/nuxt/src/components/plugins/tree-shake.ts
+++ b/packages/nuxt/src/components/plugins/tree-shake.ts
@@ -6,7 +6,7 @@ import { resolve } from 'pathe'
 import { parseAndWalk, walk } from 'oxc-walker'
 import type { BindingPattern, BindingProperty, CallExpression, Node, ObjectExpression, Program, ReturnStatement, VariableDeclaration } from 'oxc-parser'
 import { distDir } from '../../dirs.ts'
-import { parseModuleId } from '../../core/utils/plugins.ts'
+import { VUE_ID_RE } from '../../core/utils/plugins.ts'
 
 interface TreeShakeTemplatePluginOptions {
   sourcemap?: boolean
@@ -22,86 +22,87 @@ export const TreeShakeTemplatePlugin = (options: TreeShakeTemplatePluginOptions)
   return {
     name: 'nuxt:tree-shake-template',
     enforce: 'post',
-    transformInclude (id) {
-      const { pathname } = parseModuleId(id)
-      return pathname.endsWith('.vue')
-    },
-    transform (code, id) {
-      const components = options.getComponents()
+    transform: {
+      filter: {
+        id: { include: VUE_ID_RE },
+      },
+      handler (code, id) {
+        const components = options.getComponents()
 
-      if (!regexpMap.has(components)) {
-        const serverPlaceholderPath = resolve(distDir, 'app/components/server-placeholder')
-        const clientOnlyComponents = components
-          .filter(c => c.mode === 'client' && !components.some(other => other.mode !== 'client' && other.pascalName === c.pascalName && !other.filePath.startsWith(serverPlaceholderPath)))
-          .flatMap(c => [c.pascalName, c.kebabName.replaceAll('-', '_')])
-          .concat(['ClientOnly', 'client_only'])
+        if (!regexpMap.has(components)) {
+          const serverPlaceholderPath = resolve(distDir, 'app/components/server-placeholder')
+          const clientOnlyComponents = components
+            .filter(c => c.mode === 'client' && !components.some(other => other.mode !== 'client' && other.pascalName === c.pascalName && !other.filePath.startsWith(serverPlaceholderPath)))
+            .flatMap(c => [c.pascalName, c.kebabName.replaceAll('-', '_')])
+            .concat(['ClientOnly', 'client_only'])
 
-        regexpMap.set(components, [new RegExp(`(${clientOnlyComponents.join('|')})`), new RegExp(`^(${clientOnlyComponents.map(c => `(?:(?:_unref\\()?(?:_component_)?(?:Lazy|lazy_)?${c}\\)?)`).join('|')})$`), clientOnlyComponents])
-      }
-
-      const s = new MagicString(code)
-
-      const [COMPONENTS_RE, COMPONENTS_IDENTIFIERS_RE] = regexpMap.get(components)!
-      if (!COMPONENTS_RE.test(code)) { return }
-
-      const componentsToRemoveSet = new Set<string>()
-
-      // remove client only components or components called in ClientOnly default slot
-      const { program: ast } = parseAndWalk(code, id, (node) => {
-        if (!isSsrRender(node)) {
-          return
+          regexpMap.set(components, [new RegExp(`(${clientOnlyComponents.join('|')})`), new RegExp(`^(${clientOnlyComponents.map(c => `(?:(?:_unref\\()?(?:_component_)?(?:Lazy|lazy_)?${c}\\)?)`).join('|')})$`), clientOnlyComponents])
         }
 
-        const [componentCall, _, children] = node.arguments
-        if (!componentCall) { return }
+        const s = new MagicString(code)
 
-        if (componentCall.type === 'Identifier' || componentCall.type === 'MemberExpression' || componentCall.type === 'CallExpression') {
-          const componentName = getComponentName(node)
-          if (!componentName || !COMPONENTS_IDENTIFIERS_RE.test(componentName) || children?.type !== 'ObjectExpression') { return }
+        const [COMPONENTS_RE, COMPONENTS_IDENTIFIERS_RE] = regexpMap.get(components)!
+        if (!COMPONENTS_RE.test(code)) { return }
 
-          const isClientOnlyComponent = CLIENT_ONLY_NAME_RE.test(componentName)
-          const slotsToRemove = isClientOnlyComponent ? children.properties.filter(prop => prop.type === 'Property' && prop.key.type === 'Identifier' && !PLACEHOLDER_EXACT_RE.test(prop.key.name)) : children.properties
+        const componentsToRemoveSet = new Set<string>()
 
-          for (const slot of slotsToRemove) {
-            s.remove(slot.start, slot.end + 1)
-            const removedCode = `({${code.slice(slot.start, slot.end + 1)}})`
-            const currentState = s.toString()
+        // remove client only components or components called in ClientOnly default slot
+        const { program: ast } = parseAndWalk(code, id, (node) => {
+          if (!isSsrRender(node)) {
+            return
+          }
 
-            parseAndWalk(removedCode, id, (node) => {
-              if (!isSsrRender(node)) { return }
-              const name = getComponentName(node)
-              if (!name) { return }
+          const [componentCall, _, children] = node.arguments
+          if (!componentCall) { return }
 
-              // detect if the component is called else where
-              const nameToRemove = isComponentNotCalledInSetup(currentState, id, name)
-              if (nameToRemove) {
-                componentsToRemoveSet.add(nameToRemove)
-              }
-            })
+          if (componentCall.type === 'Identifier' || componentCall.type === 'MemberExpression' || componentCall.type === 'CallExpression') {
+            const componentName = getComponentName(node)
+            if (!componentName || !COMPONENTS_IDENTIFIERS_RE.test(componentName) || children?.type !== 'ObjectExpression') { return }
+
+            const isClientOnlyComponent = CLIENT_ONLY_NAME_RE.test(componentName)
+            const slotsToRemove = isClientOnlyComponent ? children.properties.filter(prop => prop.type === 'Property' && prop.key.type === 'Identifier' && !PLACEHOLDER_EXACT_RE.test(prop.key.name)) : children.properties
+
+            for (const slot of slotsToRemove) {
+              s.remove(slot.start, slot.end + 1)
+              const removedCode = `({${code.slice(slot.start, slot.end + 1)}})`
+              const currentState = s.toString()
+
+              parseAndWalk(removedCode, id, (node) => {
+                if (!isSsrRender(node)) { return }
+                const name = getComponentName(node)
+                if (!name) { return }
+
+                // detect if the component is called else where
+                const nameToRemove = isComponentNotCalledInSetup(currentState, id, name)
+                if (nameToRemove) {
+                  componentsToRemoveSet.add(nameToRemove)
+                }
+              })
+            }
+          }
+        })
+
+        const componentsToRemove = [...componentsToRemoveSet]
+        const removedNodes = new WeakSet<Node>()
+
+        for (const componentName of componentsToRemove) {
+        // remove import declaration if it exists
+          removeImportDeclaration(ast, componentName, s)
+          // remove variable declaration
+          removeVariableDeclarator(ast, componentName, s, removedNodes)
+          // remove from setup return statement
+          removeFromSetupReturn(ast, componentName, s)
+        }
+
+        if (s.hasChanged()) {
+          return {
+            code: s.toString(),
+            map: options.sourcemap
+              ? s.generateMap({ hires: true })
+              : undefined,
           }
         }
-      })
-
-      const componentsToRemove = [...componentsToRemoveSet]
-      const removedNodes = new WeakSet<Node>()
-
-      for (const componentName of componentsToRemove) {
-        // remove import declaration if it exists
-        removeImportDeclaration(ast, componentName, s)
-        // remove variable declaration
-        removeVariableDeclarator(ast, componentName, s, removedNodes)
-        // remove from setup return statement
-        removeFromSetupReturn(ast, componentName, s)
-      }
-
-      if (s.hasChanged()) {
-        return {
-          code: s.toString(),
-          map: options.sourcemap
-            ? s.generateMap({ hires: true })
-            : undefined,
-        }
-      }
+      },
     },
   }
 })

--- a/packages/nuxt/src/core/plugins/extract-async-data-handlers.ts
+++ b/packages/nuxt/src/core/plugins/extract-async-data-handlers.ts
@@ -1,16 +1,18 @@
-import { pathToFileURL } from 'node:url'
 import type { SourceMapInput } from 'rollup'
 import { createUnplugin } from 'unplugin'
 import MagicString from 'magic-string'
 import { dirname } from 'pathe'
-import { parseQuery, parseURL } from 'ufo'
 import { ScopeTracker, parseAndWalk, walk } from 'oxc-walker'
 import type { ArrowFunctionExpression, Function } from 'oxc-parser'
+
+import { parseModuleId } from '../utils/plugins.ts'
 
 const functionsToExtract = new Set(['useAsyncData', 'useLazyAsyncData'])
 const FUNCTIONS_RE = /\buse(?:Lazy)?AsyncData\b/
 const SUPPORTED_EXT_RE = /\.(?:m?[jt]sx?|vue)$/
 const SCRIPT_RE = /(?<=<script[^>]*>)[\s\S]*?(?=<\/script>)/i
+const STYLE_QUERY_RE = /[?&]type=style/
+const MACRO_QUERY_RE = /[?&]macro(?:=|&|$)/
 
 export interface ExtractAsyncDataHandlersOptions {
   sourcemap: boolean
@@ -36,8 +38,8 @@ export const ExtractAsyncDataHandlersPlugin = (options: ExtractAsyncDataHandlers
       }
     },
     transformInclude (id) {
-      const { pathname, search } = parseURL(decodeURIComponent(pathToFileURL(id).href))
-      return SUPPORTED_EXT_RE.test(pathname) && parseQuery(search).type !== 'style' && !parseQuery(search).macro
+      const { pathname, search } = parseModuleId(id)
+      return SUPPORTED_EXT_RE.test(pathname) && !STYLE_QUERY_RE.test(search) && !MACRO_QUERY_RE.test(search)
     },
     transform: {
       filter: {

--- a/packages/nuxt/src/core/plugins/extract-async-data-handlers.ts
+++ b/packages/nuxt/src/core/plugins/extract-async-data-handlers.ts
@@ -5,11 +5,9 @@ import { dirname } from 'pathe'
 import { ScopeTracker, parseAndWalk, walk } from 'oxc-walker'
 import type { ArrowFunctionExpression, Function } from 'oxc-parser'
 
-import { parseModuleId } from '../utils/plugins.ts'
-
 const functionsToExtract = new Set(['useAsyncData', 'useLazyAsyncData'])
 const FUNCTIONS_RE = /\buse(?:Lazy)?AsyncData\b/
-const SUPPORTED_EXT_RE = /\.(?:m?[jt]sx?|vue)$/
+const SUPPORTED_EXT_RE = /^[^?]*\.(?:m?[jt]sx?|vue)(?:$|\?)/
 const SCRIPT_RE = /(?<=<script[^>]*>)[\s\S]*?(?=<\/script>)/i
 const STYLE_QUERY_RE = /[?&]type=style/
 const MACRO_QUERY_RE = /[?&]macro(?:=|&|$)/
@@ -37,14 +35,11 @@ export const ExtractAsyncDataHandlersPlugin = (options: ExtractAsyncDataHandlers
         return asyncDatas[id]
       }
     },
-    transformInclude (id) {
-      const { pathname, search } = parseModuleId(id)
-      return SUPPORTED_EXT_RE.test(pathname) && !STYLE_QUERY_RE.test(search) && !MACRO_QUERY_RE.test(search)
-    },
     transform: {
       filter: {
         id: {
-          exclude: [/nuxt\/(src|dist)\/app/],
+          include: SUPPORTED_EXT_RE,
+          exclude: [/nuxt\/(src|dist)\/app/, STYLE_QUERY_RE, MACRO_QUERY_RE],
         },
         code: { include: FUNCTIONS_RE },
       },

--- a/packages/nuxt/src/core/plugins/keyed-functions.ts
+++ b/packages/nuxt/src/core/plugins/keyed-functions.ts
@@ -1,8 +1,7 @@
-import { pathToFileURL } from 'node:url'
 import { createUnplugin } from 'unplugin'
 import MagicString from 'magic-string'
 import { hash } from 'ohash'
-import { parseQuery, parseURL } from 'ufo'
+
 import { isAbsolute, join, parse } from 'pathe'
 import { camelCase } from 'scule'
 import escapeRE from 'escape-string-regexp'
@@ -14,6 +13,7 @@ import type { Node } from 'oxc-parser'
 import type { Import } from 'unimport'
 
 import { isWhitespace, logger, stripExtension } from '../../utils.ts'
+import { parseModuleId } from '../utils/plugins.ts'
 import type { FunctionCallMetadata } from '../utils/parse-utils.ts'
 import { parseStaticExportIdentifiers, parseStaticFunctionCall, processImports } from '../utils/parse-utils.ts'
 
@@ -32,16 +32,18 @@ const NUXT_LIB_RE = /node_modules\/(?:nuxt|nuxt3|nuxt-nightly|@nuxt)\//
 const SUPPORTED_EXT_RE = /\.(?:m?[jt]sx?|vue)/
 const SCRIPT_RE = /(?<=<script[^>]*>)[\s\S]*?(?=<\/script>)/i
 const NUXT_INJECTED_MARKER = '/* nuxt-injected */'
+const STYLE_QUERY_RE = /[?&]type=style/
+const MACRO_QUERY_RE = /[?&]macro(?:=|&|$)/
 
 export function shouldTransformFile (id: string, extensions: RegExp | readonly string[]) {
-  const { pathname, search } = parseURL(decodeURIComponent(pathToFileURL(id).href))
+  const { pathname, search } = parseModuleId(id)
   return !NUXT_LIB_RE.test(pathname)
     && (
       extensions instanceof RegExp
         ? extensions.test(pathname)
         : new RegExp(`\\.(${extensions.map(e => escapeRE(e)).join('|')})$`).test(pathname)
     )
-    && parseQuery(search).type !== 'style' && !parseQuery(search).macro
+    && !STYLE_QUERY_RE.test(search) && !MACRO_QUERY_RE.test(search)
 }
 
 // TODO: remove in Nuxt 5

--- a/packages/nuxt/src/core/plugins/keyed-functions.ts
+++ b/packages/nuxt/src/core/plugins/keyed-functions.ts
@@ -13,7 +13,6 @@ import type { Node } from 'oxc-parser'
 import type { Import } from 'unimport'
 
 import { isWhitespace, logger, stripExtension } from '../../utils.ts'
-import { parseModuleId } from '../utils/plugins.ts'
 import type { FunctionCallMetadata } from '../utils/parse-utils.ts'
 import { parseStaticExportIdentifiers, parseStaticFunctionCall, processImports } from '../utils/parse-utils.ts'
 
@@ -28,23 +27,12 @@ interface KeyedFunctionsOptions {
 }
 
 const stringTypes: Array<string | undefined> = ['Literal', 'TemplateLiteral']
-const NUXT_LIB_RE = /node_modules\/(?:nuxt|nuxt3|nuxt-nightly|@nuxt)\//
-const SUPPORTED_EXT_RE = /\.(?:m?[jt]sx?|vue)/
+const NUXT_LIB_RE = /^[^?]*node_modules\/(?:nuxt|nuxt3|nuxt-nightly|@nuxt)\//
+const SUPPORTED_EXT_RE = /^[^?]*\.(?:m?[jt]sx?|vue)(?:$|\?)/
 const SCRIPT_RE = /(?<=<script[^>]*>)[\s\S]*?(?=<\/script>)/i
 const NUXT_INJECTED_MARKER = '/* nuxt-injected */'
 const STYLE_QUERY_RE = /[?&]type=style/
 const MACRO_QUERY_RE = /[?&]macro(?:=|&|$)/
-
-export function shouldTransformFile (id: string, extensions: RegExp | readonly string[]) {
-  const { pathname, search } = parseModuleId(id)
-  return !NUXT_LIB_RE.test(pathname)
-    && (
-      extensions instanceof RegExp
-        ? extensions.test(pathname)
-        : new RegExp(`\\.(${extensions.map(e => escapeRE(e)).join('|')})$`).test(pathname)
-    )
-    && !STYLE_QUERY_RE.test(search) && !MACRO_QUERY_RE.test(search)
-}
 
 // TODO: remove in Nuxt 5
 type BackwardsCompatibleKeyedFunction = Omit<KeyedFunction, 'source'> & { source?: KeyedFunction['source'] | RegExp }
@@ -104,9 +92,12 @@ export const KeyedFunctionsPlugin = (options: KeyedFunctionsOptions) => createUn
   return {
     name: 'nuxt:compiler:keyed-functions',
     enforce: 'post',
-    transformInclude: id => shouldTransformFile(id, SUPPORTED_EXT_RE),
     transform: {
       filter: {
+        id: {
+          include: SUPPORTED_EXT_RE,
+          exclude: [NUXT_LIB_RE, STYLE_QUERY_RE, MACRO_QUERY_RE],
+        },
         code: { include: CODE_INCLUDE_RE },
       },
       async handler (code, _id) {

--- a/packages/nuxt/src/core/utils/index.ts
+++ b/packages/nuxt/src/core/utils/index.ts
@@ -1,5 +1,5 @@
 export { getNameFromPath, hasSuffix, resolveComponentNameSegments } from './names.ts'
-export { getLoader, isJS, isVue } from './plugins.ts'
+export { getLoader, isJS, isVue, parseModuleId } from './plugins.ts'
 
 export function uniqueBy<T, K extends keyof T> (arr: T[], key: K) {
   if (arr.length < 2) {

--- a/packages/nuxt/src/core/utils/plugins.ts
+++ b/packages/nuxt/src/core/utils/plugins.ts
@@ -1,10 +1,29 @@
-import { pathToFileURL } from 'node:url'
 import { extname } from 'pathe'
-import { parseQuery, parseURL } from 'ufo'
+
+/**
+ * Split a bundler module ID into its pathname and search (query) parts.
+ *
+ * Module IDs from Vite/webpack are already-normalized filesystem paths
+ * that may carry query strings (e.g. `?vue&type=style&lang=css`).
+ */
+export function parseModuleId (id: string): { pathname: string, search: string } {
+  const qIndex = id.indexOf('?')
+  if (qIndex === -1) {
+    return { pathname: id, search: '' }
+  }
+  return { pathname: id.slice(0, qIndex), search: id.slice(qIndex) }
+}
+
+const NUXT_COMPONENT_RE = /[?&]nuxt_component=/
+const MACRO_RE = /[?&]macro=/
+const VUE_QUERY_RE = /[?&]vue(?:&|$)/
+const SETUP_QUERY_RE = /[?&]setup(?:=|&|$)/
+const TYPE_QUERY_RE = /[?&]type=([^&]*)/
 
 export function isVue (id: string, opts: { type?: Array<'template' | 'script' | 'style'> } = {}) {
+  const { search } = parseModuleId(id)
+
   // Bare `.vue` file (in Vite)
-  const { search } = parseURL(decodeURIComponent(pathToFileURL(id).href))
   if (id.endsWith('.vue') && !search) {
     return true
   }
@@ -13,22 +32,26 @@ export function isVue (id: string, opts: { type?: Array<'template' | 'script' | 
     return false
   }
 
-  const query = parseQuery(search)
-
   // Component async/lazy wrapper
-  if (query.nuxt_component) {
+  if (NUXT_COMPONENT_RE.test(search)) {
     return false
   }
 
   // Macro
-  if (query.macro && (search === '?macro=true' || !opts.type || opts.type.includes('script'))) {
+  if (MACRO_RE.test(search) && (search === '?macro=true' || !opts.type || opts.type.includes('script'))) {
     return true
   }
 
   // Non-Vue or Styles
-  const type = 'setup' in query ? 'script' : query.type as 'script' | 'template' | 'style'
-  if (!('vue' in query) || (opts.type && !opts.type.includes(type))) {
+  if (!VUE_QUERY_RE.test(search)) {
     return false
+  }
+
+  if (opts.type) {
+    const type = SETUP_QUERY_RE.test(search) ? 'script' : TYPE_QUERY_RE.exec(search)?.[1] as 'script' | 'template' | 'style' | undefined
+    if (!type || !opts.type.includes(type)) {
+      return false
+    }
   }
 
   // Query `?vue&type=template` (in Webpack or external template)
@@ -39,12 +62,12 @@ const JS_RE = /\.(?:[cm]?j|t)sx?$/
 
 export function isJS (id: string) {
   // JavaScript files
-  const { pathname } = parseURL(decodeURIComponent(pathToFileURL(id).href))
+  const { pathname } = parseModuleId(id)
   return JS_RE.test(pathname)
 }
 
 export function getLoader (id: string): 'vue' | 'ts' | 'tsx' | null {
-  const { pathname } = parseURL(decodeURIComponent(pathToFileURL(id).href))
+  const { pathname } = parseModuleId(id)
   const ext = extname(pathname)
   if (ext === '.vue') {
     return 'vue'

--- a/packages/nuxt/src/core/utils/plugins.ts
+++ b/packages/nuxt/src/core/utils/plugins.ts
@@ -60,6 +60,9 @@ export function isVue (id: string, opts: { type?: Array<'template' | 'script' | 
 
 const JS_RE = /\.(?:[cm]?j|t)sx?$/
 
+/** Matches module IDs for Vue files (ignoring query strings). */
+export const VUE_ID_RE = /\.vue(?:\?|$)/
+
 export function isJS (id: string) {
   // JavaScript files
   const { pathname } = parseModuleId(id)

--- a/packages/nuxt/src/pages/plugins/page-meta.ts
+++ b/packages/nuxt/src/pages/plugins/page-meta.ts
@@ -378,11 +378,12 @@ const MACRO_QUERY_RE = /[?&]macro=true(?:&|$)/
 const TYPE_PARAM_RE = /[?&]type=([^?&]+)/
 const LANG_PARAM_RE = /[?&]lang=([^?&]+)/
 function parseMacroQuery (id: string) {
+  const { search } = parseModuleId(id)
   const query: { macro?: string, type?: string, lang?: ParserOptions['lang'] } = {
-    type: TYPE_PARAM_RE.exec(id)?.[1],
-    lang: LANG_PARAM_RE.exec(id)?.[1] as ParserOptions['lang'] ?? undefined,
+    type: TYPE_PARAM_RE.exec(search)?.[1],
+    lang: LANG_PARAM_RE.exec(search)?.[1] as ParserOptions['lang'] ?? undefined,
   }
-  if (MACRO_QUERY_RE.test(id)) {
+  if (MACRO_QUERY_RE.test(search)) {
     query.macro = 'true'
   }
   return query

--- a/packages/nuxt/src/pages/plugins/page-meta.ts
+++ b/packages/nuxt/src/pages/plugins/page-meta.ts
@@ -48,12 +48,10 @@ export const PageMetaPlugin = (options: PageMetaPluginOptions = {}) => createUnp
   return {
     name: 'nuxt:pages-macros-transform',
     enforce: 'post',
-    transformInclude (id) {
-      return !!parseMacroQuery(id).macro
-    },
     transform: {
       filter: {
         id: {
+          include: /[?&]macro=true/,
           exclude: [/(?:\?|%3F).*type=(?:style|template)/],
         },
         code: {

--- a/packages/nuxt/src/pages/plugins/page-meta.ts
+++ b/packages/nuxt/src/pages/plugins/page-meta.ts
@@ -376,14 +376,15 @@ function rewriteQuery (id: string) {
   return id.replace(/\?.+$/, r => '?macro=true&' + r.replace(QUERY_START_RE, '').replace(MACRO_RE, ''))
 }
 
+const MACRO_QUERY_RE = /[?&]macro=true(?:&|$)/
+const TYPE_PARAM_RE = /[?&]type=([^?&]+)/
+const LANG_PARAM_RE = /[?&]lang=([^?&]+)/
 function parseMacroQuery (id: string) {
-  const { search } = parseModuleId(id.replace(/\?macro=true$/, ''))
-  const params = new URLSearchParams(search)
   const query: { macro?: string, type?: string, lang?: ParserOptions['lang'] } = {
-    type: params.get('type') ?? undefined,
-    lang: params.get('lang') as ParserOptions['lang'] ?? undefined,
+    type: TYPE_PARAM_RE.exec(id)?.[1],
+    lang: LANG_PARAM_RE.exec(id)?.[1] as ParserOptions['lang'] ?? undefined,
   }
-  if (id.includes('?macro=true')) {
+  if (MACRO_QUERY_RE.test(id)) {
     query.macro = 'true'
   }
   return query

--- a/packages/nuxt/src/pages/plugins/page-meta.ts
+++ b/packages/nuxt/src/pages/plugins/page-meta.ts
@@ -1,15 +1,12 @@
-import { pathToFileURL } from 'node:url'
 import { createUnplugin } from 'unplugin'
-import { parseQuery, parseURL } from 'ufo'
-import type { ParsedQuery } from 'ufo'
 import type { StaticImport } from 'mlly'
 import { findExports, findStaticImports, parseStaticImport } from 'mlly'
 import MagicString from 'magic-string'
-import { isAbsolute } from 'pathe'
 import { ScopeTracker, getUndeclaredIdentifiersInFunction, isBindingIdentifier, parseAndWalk, walk } from 'oxc-walker'
 import type { ScopeTrackerNode } from 'oxc-walker'
 
 import { logger } from '../../utils.ts'
+import { parseModuleId } from '../../core/utils/plugins.ts'
 import { isSerializable } from '../utils.ts'
 import type { ObjectPropertyKind, ParserOptions } from 'oxc-parser'
 
@@ -115,7 +112,7 @@ export const PageMetaPlugin = (options: PageMetaPluginOptions = {}) => createUnp
         if (!hasMacro && !code.includes('export { default }') && !code.includes('__nuxt_page_meta')) {
           if (!code) {
             s.append(options.dev ? (CODE_DEV_EMPTY + CODE_HMR) : CODE_EMPTY)
-            const { pathname } = parseURL(decodeURIComponent(pathToFileURL(id).href))
+            const { pathname } = parseModuleId(id)
             logger.error(`The file \`${pathname}\` is not a valid page as it has no content.`)
           } else {
             s.overwrite(0, code.length, options.dev ? (CODE_DEV_EMPTY + CODE_HMR) : CODE_EMPTY)
@@ -380,12 +377,14 @@ function rewriteQuery (id: string) {
 }
 
 function parseMacroQuery (id: string) {
-  const { search } = parseURL(decodeURIComponent(isAbsolute(id) ? pathToFileURL(id).href : id).replace(/\?macro=true$/, ''))
-  const query = parseQuery<{
-    lang?: ParserOptions['lang']
-  } & ParsedQuery>(search)
+  const { search } = parseModuleId(id.replace(/\?macro=true$/, ''))
+  const params = new URLSearchParams(search)
+  const query: { macro?: string, type?: string, lang?: ParserOptions['lang'] } = {
+    type: params.get('type') ?? undefined,
+    lang: params.get('lang') as ParserOptions['lang'] ?? undefined,
+  }
   if (id.includes('?macro=true')) {
-    return { macro: 'true', ...query }
+    query.macro = 'true'
   }
   return query
 }

--- a/packages/nuxt/src/pages/plugins/page-meta.ts
+++ b/packages/nuxt/src/pages/plugins/page-meta.ts
@@ -51,7 +51,7 @@ export const PageMetaPlugin = (options: PageMetaPluginOptions = {}) => createUnp
     transform: {
       filter: {
         id: {
-          include: /[?&]macro=true/,
+          include: /[?&]macro=true\b/,
           exclude: [/(?:\?|%3F).*type=(?:style|template)/],
         },
         code: {

--- a/packages/nuxt/test/components-tree-shake.test.ts
+++ b/packages/nuxt/test/components-tree-shake.test.ts
@@ -57,7 +57,7 @@ const treeshakeTemplatePlugin = TreeShakeTemplatePlugin({
 
 const treeshake = async (source: string): Promise<string> => {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-  const result = await (treeshakeTemplatePlugin.transform! as Function)(source, 'test.ts')
+  const result = await ((treeshakeTemplatePlugin.transform as any)!.handler as Function)(source, 'test.vue')
   return typeof result === 'string' ? result : result?.code
 }
 

--- a/packages/vite/src/plugins/runtime-paths.ts
+++ b/packages/vite/src/plugins/runtime-paths.ts
@@ -1,10 +1,9 @@
-import { pathToFileURL } from 'node:url'
 import MagicString from 'magic-string'
-import { parseQuery, parseURL } from 'ufo'
 import type { Plugin } from 'vite'
-import { isCSS } from '../utils/index.ts'
+import { isCSS, parseModuleId } from '../utils/index.ts'
 
 const VITE_ASSET_RE = /__VITE_ASSET__|__VITE_PUBLIC_ASSET__/
+const STYLE_QUERY_RE = /[?&]type=style/
 
 export function RuntimePathsPlugin (): Plugin {
   let sourcemap: boolean
@@ -16,14 +15,14 @@ export function RuntimePathsPlugin (): Plugin {
       sourcemap = !!config.build.sourcemap
     },
     transform (code, id) {
-      const { pathname, search } = parseURL(decodeURIComponent(pathToFileURL(id).href))
+      const { pathname, search } = parseModuleId(id)
 
       // skip import into css files
       if (isCSS(pathname)) { return }
 
       // skip import into <style> vue files
       if (pathname.endsWith('.vue')) {
-        if (search && parseQuery(search).type === 'style') { return }
+        if (STYLE_QUERY_RE.test(search)) { return }
       }
 
       if (VITE_ASSET_RE.test(code)) {

--- a/packages/vite/src/plugins/ssr-styles.ts
+++ b/packages/vite/src/plugins/ssr-styles.ts
@@ -1,20 +1,21 @@
-import { pathToFileURL } from 'node:url'
 import type { Plugin } from 'vite'
 import { dirname, relative } from 'pathe'
 import { genArrayFromRaw, genImport, genObjectFromRawEntries } from 'knitwork'
 import { filename as _filename } from 'pathe/utils'
-import { parseQuery, parseURL } from 'ufo'
 import type { Nuxt } from '@nuxt/schema'
 import MagicString from 'magic-string'
 import { findStaticImports } from 'mlly'
 
-import { IS_CSS_RE, isCSS, isVue } from '../utils/index.ts'
+import { IS_CSS_RE, isCSS, isVue, parseModuleId } from '../utils/index.ts'
 import { resolveClientEntry } from '../utils/config.ts'
 import { useNitro } from '@nuxt/kit'
 import escapeStringRegexp from 'escape-string-regexp'
 
 const SUPPORTED_FILES_RE = /\.(?:vue|(?:[cm]?j|t)sx?)$/
 const QUERY_RE = /\?.+$/
+const MACRO_QUERY_RE = /[?&]macro(?:=|&|$)/
+const NUXT_COMPONENT_QUERY_RE = /[?&]nuxt_component=/
+const STYLE_QUERY_RE = /[?&]type=style/
 
 export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
   if (nuxt.options.dev) { return }
@@ -268,12 +269,11 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
               return
             }
 
-            const { pathname, search } = parseURL(decodeURIComponent(pathToFileURL(id).href))
+            const { pathname, search } = parseModuleId(id)
 
             if (!(id in clientCSSMap) && !islandPaths.has(pathname)) { return }
 
-            const query = parseQuery(search)
-            if (query.macro || query.nuxt_component) { return }
+            if (MACRO_QUERY_RE.test(search) || NUXT_COMPONENT_QUERY_RE.test(search)) { return }
 
             if (!islandPaths.has(pathname)) {
               if (options.shouldInline === false || (typeof options.shouldInline === 'function' && !options.shouldInline(id))) { return }
@@ -320,7 +320,7 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
             if (!SUPPORTED_FILES_RE.test(pathname)) { return }
 
             for (const i of findStaticImports(code)) {
-              if (!i.specifier.endsWith('.css') && parseQuery(i.specifier).type !== 'style') { continue }
+              if (!i.specifier.endsWith('.css') && !STYLE_QUERY_RE.test(i.specifier)) { continue }
 
               const resolved = await this.resolve(i.specifier, id)
               if (!resolved) { continue }

--- a/packages/vite/src/utils/index.ts
+++ b/packages/vite/src/utils/index.ts
@@ -1,4 +1,4 @@
-export { isVue } from '../../../nuxt/src/core/utils/plugins.ts'
+export { isVue, parseModuleId } from '../../../nuxt/src/core/utils/plugins.ts'
 
 // Copied from vue-bundle-renderer utils
 export const IS_CSS_RE = /\.(?:css|scss|sass|postcss|pcss|less|stylus|styl)(?:\?[^.]+)?$/

--- a/packages/webpack/src/plugins/ssr-styles.ts
+++ b/packages/webpack/src/plugins/ssr-styles.ts
@@ -1,11 +1,11 @@
 import { existsSync, readFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
-import { pathToFileURL } from 'node:url'
 import { isAbsolute, relative, resolve } from 'pathe'
-import { parseURL, withTrailingSlash } from 'ufo'
+import { withTrailingSlash } from 'ufo'
 import { genArrayFromRaw, genObjectFromRawEntries } from 'knitwork'
 import type { Nuxt } from '@nuxt/schema'
 import { resolveAlias, useNitro } from '@nuxt/kit'
+import { parseModuleId } from '../../../nuxt/src/core/utils/plugins.ts'
 import type { Compilation, Compiler, Module, NormalModule } from 'webpack'
 import type { CssModule } from 'mini-css-extract-plugin'
 import { compileStyle, parse } from '@vue/compiler-sfc'
@@ -18,7 +18,7 @@ const isCSSLike = (name: string) => /\.(?:css|scss|sass|less|styl(?:us)?|postcss
 
 function normalizePath (nuxt: Nuxt, id?: string | null): string | null {
   if (!id) { return null }
-  const { pathname } = parseURL(decodeURIComponent(pathToFileURL(id).href))
+  const { pathname } = parseModuleId(id)
   const rel = relative(nuxt.options.srcDir, pathname)
   if (rel.startsWith('..')) { return null }
   return rel
@@ -26,7 +26,7 @@ function normalizePath (nuxt: Nuxt, id?: string | null): string | null {
 
 function resolveFilePath (id?: string | null): string | null {
   if (!id) { return null }
-  return parseURL(decodeURIComponent(pathToFileURL(id).href)).pathname || null
+  return parseModuleId(id).pathname || null
 }
 
 function sanitizeStyleAssetName (rel: string) {

--- a/packages/webpack/src/plugins/ssr-styles.ts
+++ b/packages/webpack/src/plugins/ssr-styles.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
-import { isAbsolute, relative, resolve } from 'pathe'
+import { isAbsolute, normalize, relative, resolve } from 'pathe'
 import { withTrailingSlash } from 'ufo'
 import { genArrayFromRaw, genObjectFromRawEntries } from 'knitwork'
 import type { Nuxt } from '@nuxt/schema'
@@ -26,7 +26,7 @@ function normalizePath (nuxt: Nuxt, id?: string | null): string | null {
 
 function resolveFilePath (id?: string | null): string | null {
   if (!id) { return null }
-  return parseModuleId(id).pathname || null
+  return parseModuleId(normalize(id)).pathname || null
 }
 
 function sanitizeStyleAssetName (rel: string) {
@@ -229,12 +229,6 @@ export class SSRStylesPlugin {
     }
 
     return null
-  }
-
-  private normalizeResourcePath (resource?: string | null): string | null {
-    if (!resource) { return null }
-    const withoutQuery = resource.split('?')[0]
-    return resolveFilePath(withoutQuery)
   }
 
   apply (compiler: Compiler) {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this is a performance-focused PR to improve id resolution speed - in some situations this is **14 THOUSAND times faster**.

did some quick benchmarks with `mitata` - obviously this is a _micro_-benchmark but within a plugin, this is called often and seems worthwhile ...

| Input | Before | Now | Speedup |
|-------|:-:|:-:|:-:|
| POSIX, no query | 1.22 µs | 1.41 ns | 862x |
| POSIX, with query | 1.57 µs | 384 ps | 4,088x |
| Windows fwd-slash, no query | 1.69 µs | 8 ns | 211x |
| Windows fwd-slash, with query | 2.22 µs | 383 ps | 5,806x |
| Windows backslash, no query | 2.10 µs | 147 ps | 14,340x |
| Windows backslash, with query | 2.25 µs | 390 ps | 5,786x |

previously we were doing a `new URL()` construction via `pathToFileURL`, `decodeURIComponent`, then 3 regex matches inside `parseURL`/`parsePath` from `ufo`.

The new parseModuleId is just a single `indexOf('?')` + at most two slice calls — both O(1) in V8 as they create string slices without copying ...