### PR TITLE
fix(nuxt): replace destr with JSON.parse in cookie encode/decode

### DIFF
--- a/packages/nuxt/src/app/composables/cookie.ts
+++ b/packages/nuxt/src/app/composables/cookie.ts
@@ -4,7 +4,6 @@ import type { CookieParseOptions, CookieSerializeOptions } from 'cookie-es'
 import { parse, serialize } from 'cookie-es'
 import { deleteCookie, getCookie, getRequestHeader, setCookie } from '@nuxt/nitro-server/h3'
 import type { H3Event } from '@nuxt/nitro-server/h3'
-import destr from 'destr'
 import { isEqual } from 'ohash'
 import { klona } from 'klona'
 import { useNuxtApp } from '../nuxt'
@@ -12,6 +11,16 @@ import { useRequestEvent } from './ssr'
 
 // @ts-expect-error virtual import
 import { cookieStore } from '#build/nuxt.config.mjs'
+
+function parseCookieValue (value: string) {
+  if (value === 'undefined') { return undefined }
+  try {
+    const parsed = JSON.parse(value)
+    // avoid coercing number-like strings that lose precision or overflow (e.g. '4e71375682906041' -> Infinity)
+    if (typeof parsed === 'number' && String(parsed) !== value) { return value }
+    return parsed
+  } catch { return value }
+}
 
 type _CookieOptions = Omit<CookieSerializeOptions & CookieParseOptions, 'decode' | 'encode'>
 
@@ -44,16 +53,22 @@ export interface CookieRef<T> extends Ref<T> {}
 const CookieDefaults = {
   path: '/',
   watch: true,
-  decode: (val) => {
-    const decoded = decodeURIComponent(val)
-    const parsed = destr(decoded)
-    // destr can return Infinity or precision-loss numbers - keep original string
-    if (typeof parsed === 'number' && (!Number.isFinite(parsed) || String(parsed) !== decoded)) {
-      return decoded
+  decode: val => parseCookieValue(decodeURIComponent(val)),
+  encode: (val) => {
+    // JSON-quote strings that would be coerced on decode (e.g. '42', 'true', 'null', 'undefined')
+    if (typeof val !== 'string' || val === 'undefined') {
+      return encodeURIComponent(JSON.stringify(val))
     }
-    return parsed
+
+    try {
+      if (typeof JSON.parse(val) !== 'string') {
+        return encodeURIComponent(JSON.stringify(val))
+      }
+    } catch {
+      // ignore - value is not JSON, so encode as-is
+    }
+    return encodeURIComponent(val)
   },
-  encode: val => encodeURIComponent(typeof val === 'string' ? val : JSON.stringify(val)),
   refresh: false,
 } satisfies CookieOptions<any>
 

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -199,7 +199,7 @@ describe('pages', () => {
   it('validates routes', async () => {
     const { status, headers } = await fetch('/catchall/forbidden')
     expect(status).toEqual(404)
-    expect(headers.get('Set-Cookie')).toBe('set-in-plugin=true; Path=/')
+    expect(headers.get('Set-Cookie')).toBe('set-in-plugin=%22true%22; Path=/')
 
     const { page } = await renderPage('/navigate-to-forbidden')
 
@@ -714,7 +714,7 @@ describe('nuxt composables', () => {
       },
     })
     const cookies = res.headers.get('set-cookie')
-    expect(cookies).toMatchInlineSnapshot('"set-in-plugin=true; Path=/, accessed-with-default-value=default; Path=/, set=set; Path=/, browser-set=set; Path=/, browser-set-to-null=; Max-Age=0; Path=/, browser-set-to-null-with-default=; Max-Age=0; Path=/, browser-object-default=%7B%22foo%22%3A%22bar%22%7D; Path=/, theCookie=show; Path=/"')
+    expect(cookies).toMatchInlineSnapshot('"set-in-plugin=%22true%22; Path=/, accessed-with-default-value=default; Path=/, set=set; Path=/, browser-set=set; Path=/, browser-set-to-null=; Max-Age=0; Path=/, browser-set-to-null-with-default=; Max-Age=0; Path=/, browser-object-default=%7B%22foo%22%3A%22bar%22%7D; Path=/, theCookie=show; Path=/"')
   })
   it('updates cookies when they are changed', async () => {
     const { page } = await renderPage('/cookies')
@@ -1213,7 +1213,7 @@ describe('errors', () => {
 
   it('should render a HTML error page', async () => {
     const res = await fetch('/error')
-    expect(res.headers.get('Set-Cookie')).toBe('set-in-plugin=true; Path=/, some-error=was%20set; Path=/')
+    expect(res.headers.get('Set-Cookie')).toBe('set-in-plugin=%22true%22; Path=/, some-error=was%20set; Path=/')
     expect(await res.text()).toContain('This is a custom error')
   })
 

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -2,8 +2,6 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineEventHandler } from 'h3'
-import { destr } from 'destr'
-
 import { mountSuspended, registerEndpoint } from '@nuxt/test-utils/runtime'
 
 import { hasProtocol } from 'ufo'
@@ -884,7 +882,7 @@ describe('useCookie', () => {
       default: () => ({ s2: -1 }),
       decode (value) {
         barCallCount++
-        return destr(decodeURIComponent(value))
+        return JSON.parse(decodeURIComponent(value))
       },
     })
     bazCookie.value.s2++
@@ -897,7 +895,7 @@ describe('useCookie', () => {
       filter: key => key === 'bar' || key === 'baz',
       decode (value) {
         quxCallCount++
-        return destr(decodeURIComponent(value))
+        return JSON.parse(decodeURIComponent(value))
       },
     })
     quxCookie.value.s3++


### PR DESCRIPTION
### 🔗 Linked issue

resolves #34006
extracted from https://github.com/nuxt/nuxt/pull/34037

### 📚 Description

this drops use of `destr` to decode cookies with a lighter weight `parseCookieValue` wrapper around `JSON.parse`

