### PR TITLE
fix(vite): move `rollup-plugin-visualizer` to optional peer dep

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -27,16 +27,6 @@
     "build:stub": "obuild --stub",
     "test:attw": "attw --pack"
   },
-  "devDependencies": {
-    "@nuxt/schema": "workspace:*",
-    "h3": "1.15.5",
-    "h3-next": "npm:h3@2.0.1-rc.14",
-    "nitropack": "2.13.1",
-    "obuild": "0.4.31",
-    "rolldown": "1.0.0-rc.7",
-    "rollup": "4.59.0",
-    "vue": "3.5.29"
-  },
   "dependencies": {
     "@nuxt/kit": "workspace:*",
     "@rollup/plugin-replace": "^6.0.3",
@@ -66,6 +56,17 @@
     "vite-node": "^5.3.0",
     "vite-plugin-checker": "^0.12.0",
     "vue-bundle-renderer": "^2.2.0"
+  },
+  "devDependencies": {
+    "@nuxt/schema": "workspace:*",
+    "h3": "1.15.5",
+    "h3-next": "npm:h3@2.0.1-rc.14",
+    "nitropack": "2.13.1",
+    "obuild": "0.4.31",
+    "rolldown": "1.0.0-rc.7",
+    "rollup": "4.59.0",
+    "rollup-plugin-visualizer": "7.0.1",
+    "vue": "3.5.29"
   },
   "peerDependencies": {
     "nuxt": "workspace:*",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -54,10 +54,10 @@
     "magic-string": "^0.30.21",
     "mlly": "^1.8.1",
     "mocked-exports": "^0.1.1",
+    "nypm": "^0.6.5",
     "pathe": "^2.0.3",
     "pkg-types": "^2.3.0",
     "postcss": "^8.5.8",
-    "rollup-plugin-visualizer": "^7.0.1",
     "seroval": "^1.5.0",
     "std-env": "^3.10.0",
     "ufo": "^1.6.3",
@@ -70,10 +70,14 @@
   "peerDependencies": {
     "nuxt": "workspace:*",
     "rolldown": "^1.0.0-beta.38",
+    "rollup-plugin-visualizer": "^6.0.0 || ^7.0.1",
     "vue": "^3.3.4"
   },
   "peerDependenciesMeta": {
     "rolldown": {
+      "optional": true
+    },
+    "rollup-plugin-visualizer": {
       "optional": true
     }
   },

--- a/packages/vite/src/plugins/analyze.ts
+++ b/packages/vite/src/plugins/analyze.ts
@@ -18,13 +18,20 @@ export async function AnalyzePlugin (nuxt: Nuxt): Promise<Plugin | undefined> {
     return
   }
 
-  const { visualizer } = await import('rollup-plugin-visualizer').catch(async (err) => {
-    if (err.code !== 'MODULE_NOT_FOUND') {
+  let visualizer: typeof import('rollup-plugin-visualizer').visualizer | undefined
+
+  try {
+    visualizer = await import('rollup-plugin-visualizer').then(r => r.visualizer)
+  } catch (_err) {
+    const err = _err as NodeJS.ErrnoException
+
+    if (err.code !== 'ERR_MODULE_NOT_FOUND' && err.code !== 'MODULE_NOT_FOUND') {
       throw err
     }
 
     if (!isCI && hasTTY) {
-      const shouldInstall = await logger.prompt('Install rollup-plugin-visualizer?', {
+      logger.info('Analyzing bundles requires an additional dependency.')
+      const shouldInstall = await logger.prompt('Install `rollup-plugin-visualizer`?', {
         type: 'confirm',
         choices: [
           { name: 'Yes', value: true },
@@ -33,19 +40,20 @@ export async function AnalyzePlugin (nuxt: Nuxt): Promise<Plugin | undefined> {
       })
 
       if (shouldInstall) {
+        logger.start('Installing `rollup-plugin-visualizer`...')
         await addDependency('rollup-plugin-visualizer', {
           dev: true,
           cwd: nuxt.options.rootDir,
           silent: true,
         })
-        logger.info('Rerun Nuxt to use `rollup-plugin-visualizer`.')
+        logger.info('Rerun Nuxt to analyze your bundle.')
         process.exit(1)
       }
     }
 
     logger.info('Cannot find `rollup-plugin-visualizer`.')
     process.exit(1)
-  })
+  }
 
   return {
     name: 'nuxt:analyze',

--- a/packages/vite/src/plugins/analyze.ts
+++ b/packages/vite/src/plugins/analyze.ts
@@ -18,7 +18,7 @@ export async function AnalyzePlugin (nuxt: Nuxt): Promise<Plugin | undefined> {
     return
   }
 
-  let visualizer: typeof import('rollup-plugin-visualizer').visualizer | undefined
+  let visualizer: typeof import('rollup-plugin-visualizer').visualizer
 
   try {
     visualizer = await import('rollup-plugin-visualizer').then(r => r.visualizer)

--- a/packages/vite/src/plugins/analyze.ts
+++ b/packages/vite/src/plugins/analyze.ts
@@ -1,8 +1,12 @@
+import process from 'node:process'
 import type { Plugin } from 'vite'
 import { transformWithEsbuild } from 'vite'
 import { defu } from 'defu'
+import { addDependency } from 'nypm'
 import type { Nuxt, NuxtOptions } from '@nuxt/schema'
 import type { RenderedModule } from 'rollup'
+import { logger } from '@nuxt/kit'
+import { hasTTY, isCI } from 'std-env'
 
 export async function AnalyzePlugin (nuxt: Nuxt): Promise<Plugin | undefined> {
   if (nuxt.options.test) {
@@ -14,7 +18,34 @@ export async function AnalyzePlugin (nuxt: Nuxt): Promise<Plugin | undefined> {
     return
   }
 
-  const { visualizer } = await import('rollup-plugin-visualizer')
+  const { visualizer } = await import('rollup-plugin-visualizer').catch(async (err) => {
+    if (err.code !== 'MODULE_NOT_FOUND') {
+      throw err
+    }
+
+    if (!isCI && hasTTY) {
+      const shouldInstall = await logger.prompt('Install rollup-plugin-visualizer?', {
+        type: 'confirm',
+        choices: [
+          { name: 'Yes', value: true },
+          { name: 'No', value: false },
+        ],
+      })
+
+      if (shouldInstall) {
+        await addDependency('rollup-plugin-visualizer', {
+          dev: true,
+          cwd: nuxt.options.rootDir,
+          silent: true,
+        })
+        logger.info('Rerun Nuxt to use `rollup-plugin-visualizer`.')
+        process.exit(1)
+      }
+    }
+
+    logger.info('Cannot find `rollup-plugin-visualizer`.')
+    process.exit(1)
+  })
 
   return {
     name: 'nuxt:analyze',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1036,6 +1036,9 @@ importers:
       nuxt:
         specifier: workspace:*
         version: link:../nuxt
+      nypm:
+        specifier: ^0.6.5
+        version: 0.6.5
       pathe:
         specifier: ^2.0.3
         version: 2.0.3
@@ -1046,7 +1049,7 @@ importers:
         specifier: ^8.5.8
         version: 8.5.8
       rollup-plugin-visualizer:
-        specifier: ^7.0.1
+        specifier: ^6.0.0 || ^7.0.1
         version: 7.0.1(rolldown@1.0.0-rc.7)(rollup@4.59.0)
       seroval:
         specifier: ^1.5.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1048,9 +1048,6 @@ importers:
       postcss:
         specifier: ^8.5.8
         version: 8.5.8
-      rollup-plugin-visualizer:
-        specifier: ^6.0.0 || ^7.0.1
-        version: 7.0.1(rolldown@1.0.0-rc.7)(rollup@4.59.0)
       seroval:
         specifier: ^1.5.0
         version: 1.5.0
@@ -1097,6 +1094,9 @@ importers:
       rollup:
         specifier: 4.59.0
         version: 4.59.0
+      rollup-plugin-visualizer:
+        specifier: 7.0.1
+        version: 7.0.1(rolldown@1.0.0-rc.7)(rollup@4.59.0)
       vue:
         specifier: 3.5.29
         version: 3.5.29(typescript@5.9.3)


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/34394
closes https://github.com/nuxt/nuxt/pull/34403

### 📚 Description

this moves `rollup-plugin-visualizer` to a peer dependency (optional). this saves about [~3Mb of install space](https://npmx.dev/package/rollup-plugin-visualizer) for most users

when users run `nuxt analyze` it will prompt to install it.