### PR TITLE
refactor(nitro,vite): use babel for experimental decorator support

### DIFF
--- a/docs/3.guide/6.going-further/1.experimental-features.md
+++ b/docs/3.guide/6.going-further/1.experimental-features.md
@@ -773,7 +773,9 @@ export default defineNuxtConfig({
 
 ## decorators
 
-This option enables enabling decorator syntax across your entire Nuxt/Nitro app, powered by [esbuild](https://github.com/evanw/esbuild/releases/tag/v0.21.3).
+This option enables decorator syntax across your entire Nuxt/Nitro app.
+
+When using the Vite builder (default), decorators are lowered via [Babel](https://babeljs.io/) using [`@babel/plugin-proposal-decorators`](https://babeljs.io/docs/babel-plugin-proposal-decorators). When using the webpack or rspack builders, decorators are lowered via [esbuild](https://github.com/evanw/esbuild/releases/tag/v0.21.3).
 
 For a long time, TypeScript has had support for decorators via `compilerOptions.experimentalDecorators`. This implementation predated the TC39 standardization process. Now, decorators are a [Stage 3 Proposal](https://github.com/tc39/proposal-decorators), and supported without special configuration in TS 5.0+ (see https://github.com/microsoft/TypeScript/pull/52582 and https://devblogs.microsoft.com/typescript/announcing-typescript-5-0-beta/#decorators).
 
@@ -792,6 +794,24 @@ export default defineNuxtConfig({
   },
 })
 ```
+
+When using the Vite builder or the Nitro server build, you will need to install additional Babel packages as dev dependencies:
+
+::code-group
+```bash [npm]
+npm install -D @babel/plugin-proposal-decorators @babel/plugin-syntax-jsx
+```
+```bash [pnpm]
+pnpm add -D @babel/plugin-proposal-decorators @babel/plugin-syntax-jsx
+```
+```bash [yarn]
+yarn add -D @babel/plugin-proposal-decorators @babel/plugin-syntax-jsx
+```
+::
+
+::tip
+Nuxt will prompt you to install these automatically if they are not already present.
+::
 
 ```ts [app/app.vue]
 function something (_method: () => unknown) {

--- a/packages/nitro-server/package.json
+++ b/packages/nitro-server/package.json
@@ -31,6 +31,7 @@
     "test:attw": "attw --pack"
   },
   "dependencies": {
+    "@babel/plugin-syntax-typescript": "^7.28.6",
     "@nuxt/devalue": "^2.0.2",
     "@nuxt/kit": "workspace:*",
     "@unhead/vue": "^2.1.10",
@@ -47,6 +48,7 @@
     "klona": "^2.0.6",
     "mocked-exports": "^0.1.1",
     "nitropack": "^2.13.1",
+    "nypm": "^0.6.5",
     "ohash": "^2.0.11",
     "pathe": "^2.0.3",
     "pkg-types": "^2.3.0",
@@ -60,10 +62,22 @@
     "vue-devtools-stub": "^0.1.0"
   },
   "peerDependencies": {
+    "@babel/plugin-proposal-decorators": "^7.25.0",
+    "@rollup/plugin-babel": "^6.0.0 || ^7.0.0",
     "nuxt": "workspace:^"
   },
+  "peerDependenciesMeta": {
+    "@babel/plugin-proposal-decorators": {
+      "optional": true
+    },
+    "@rollup/plugin-babel": {
+      "optional": true
+    }
+  },
   "devDependencies": {
+    "@babel/plugin-proposal-decorators": "7.29.0",
     "@nuxt/schema": "workspace:*",
+    "@rollup/plugin-babel": "7.0.0",
     "nuxt": "workspace:*",
     "obuild": "0.4.31",
     "vitest": "4.0.18"

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -17,7 +17,8 @@ import { addPlugin, addTemplate, addVitePlugin, createIsIgnored, findPath, getDi
 import escapeRE from 'escape-string-regexp'
 import { defu } from 'defu'
 import { defineEventHandler, dynamicEventHandler, handleCors, setHeader } from 'h3'
-import { isWindows } from 'std-env'
+import { addDependency } from 'nypm'
+import { hasTTY, isCI, isWindows } from 'std-env'
 import { ImpoundPlugin } from 'impound'
 import { resolveModulePath } from 'exsolve'
 import { runtimeDependencies } from 'nitropack/runtime/meta'
@@ -563,6 +564,69 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
     // In case a non-normalized absolute path is called for on Windows
     if (process.platform === 'win32') {
       nitroConfig.virtual!['#build/dist/server/styles.mjs'.replace(FORWARD_SLASH_RE, '\\')] = 'export default {}'
+    }
+  }
+
+  // Add decorator support via Babel when experimental.decorators is enabled.
+  if (nuxt.options.experimental.decorators) {
+    const nitroDecoratorDeps = ['@rollup/plugin-babel', '@babel/plugin-proposal-decorators']
+    let hasDeps = true
+    for (const pkg of nitroDecoratorDeps) {
+      try {
+        await import(pkg)
+      } catch (_err) {
+        const err = _err as NodeJS.ErrnoException
+        if (err.code !== 'ERR_MODULE_NOT_FOUND' && err.code !== 'MODULE_NOT_FOUND') {
+          throw err
+        }
+        if (!isCI && hasTTY) {
+          logger.info('Decorator support requires additional dependencies.')
+          const shouldInstall = await logger.prompt(`Install \`${nitroDecoratorDeps.join('` and `')}\`?`, {
+            type: 'confirm',
+            initial: true,
+          })
+          if (shouldInstall) {
+            logger.start(`Installing ${nitroDecoratorDeps.map(d => `\`${d}\``).join(' and ')}...`)
+            await addDependency(nitroDecoratorDeps, {
+              dev: true,
+              cwd: nuxt.options.rootDir,
+              silent: true,
+            })
+            logger.info('Rerun Nuxt to enable decorator support.')
+            process.exit(1)
+          }
+        }
+        logger.warn(`Cannot find \`${pkg}\`. Install \`${nitroDecoratorDeps.join('` and `')}\` to enable decorator support.`)
+        hasDeps = false
+        break
+      }
+    }
+
+    if (hasDeps) {
+      const { babel } = await import('@rollup/plugin-babel')
+      nitroConfig.rollupConfig!.plugins = toArray(await nitroConfig.rollupConfig!.plugins || [])
+      nitroConfig.rollupConfig!.plugins!.unshift(
+        babel({
+          babelHelpers: 'bundled',
+          configFile: false,
+          extensions: ['.ts', '.js', '.mjs', '.mts'],
+          plugins: [
+            // Syntax plugin allows Babel to parse TypeScript without transforming it,
+            // since the actual TS stripping is handled later by the bundler's esbuild plugin.
+            ['@babel/plugin-syntax-typescript', { isTSX: false }],
+            ['@babel/plugin-proposal-decorators', { version: '2023-11' }],
+          ],
+        }),
+        babel({
+          babelHelpers: 'bundled',
+          configFile: false,
+          extensions: ['.tsx', '.jsx'],
+          plugins: [
+            ['@babel/plugin-syntax-typescript', { isTSX: true }],
+            ['@babel/plugin-proposal-decorators', { version: '2023-11' }],
+          ],
+        }),
+      )
     }
   }
 

--- a/packages/schema/src/config/esbuild.ts
+++ b/packages/schema/src/config/esbuild.ts
@@ -10,6 +10,13 @@ export default defineResolvers({
           if (typeof val === 'string') {
             return val
           }
+          // Only lower to es2024 for non-vite builders (webpack/rspack) where
+          // esbuild handles decorator lowering. The vite builder uses Babel instead.
+          const builder = await get('builder')
+          const isVite = !builder || builder === 'vite' || (builder as any) === '@nuxt/vite-builder'
+          if (isVite) {
+            return 'esnext'
+          }
           // https://github.com/vitejs/vite-plugin-vue/issues/528
           const useDecorators = await get('experimental').then(r => r?.decorators === true)
           if (useDecorators) {

--- a/packages/schema/src/config/oxc.ts
+++ b/packages/schema/src/config/oxc.ts
@@ -4,21 +4,7 @@ export default defineResolvers({
   oxc: {
     transform: {
       options: {
-        target: {
-          $resolve: async (val, get) => {
-            if (typeof val === 'string') {
-              return val
-            }
-            // https://github.com/vitejs/vite-plugin-vue/issues/528
-            const useDecorators = await get('experimental').then(
-              r => r?.decorators === true,
-            )
-            if (useDecorators) {
-              return 'es2024'
-            }
-            return 'esnext'
-          },
-        },
+        target: 'esnext',
         jsxFactory: 'h',
         jsxFragment: 'Fragment',
       },

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -58,6 +58,8 @@
     "vue-bundle-renderer": "^2.2.0"
   },
   "devDependencies": {
+    "@babel/plugin-proposal-decorators": "7.29.0",
+    "@babel/plugin-syntax-jsx": "7.28.6",
     "@nuxt/schema": "workspace:*",
     "h3": "1.15.5",
     "h3-next": "npm:h3@2.0.1-rc.14",
@@ -69,12 +71,20 @@
     "vue": "3.5.29"
   },
   "peerDependencies": {
+    "@babel/plugin-proposal-decorators": "^7.25.0",
+    "@babel/plugin-syntax-jsx": "^7.25.0",
     "nuxt": "workspace:*",
     "rolldown": "^1.0.0-beta.38",
     "rollup-plugin-visualizer": "^6.0.0 || ^7.0.1",
     "vue": "^3.3.4"
   },
   "peerDependenciesMeta": {
+    "@babel/plugin-proposal-decorators": {
+      "optional": true
+    },
+    "@babel/plugin-syntax-jsx": {
+      "optional": true
+    },
     "rolldown": {
       "optional": true
     },

--- a/packages/vite/src/plugins/decorators.ts
+++ b/packages/vite/src/plugins/decorators.ts
@@ -1,0 +1,98 @@
+import process from 'node:process'
+import type { Plugin } from 'vite'
+import { addDependency } from 'nypm'
+import { logger } from '@nuxt/kit'
+import { hasTTY, isCI } from 'std-env'
+import type { Nuxt } from '@nuxt/schema'
+
+const BABEL_DECORATOR_DEPS = ['@babel/plugin-proposal-decorators', '@babel/plugin-syntax-jsx'] as const
+
+async function ensureBabelDecoratorDeps (nuxt: Nuxt): Promise<boolean> {
+  for (const pkg of BABEL_DECORATOR_DEPS) {
+    try {
+      await import(pkg)
+    } catch (_err) {
+      const err = _err as NodeJS.ErrnoException
+
+      if (err.code !== 'ERR_MODULE_NOT_FOUND' && err.code !== 'MODULE_NOT_FOUND') {
+        throw err
+      }
+
+      if (!isCI && hasTTY) {
+        logger.info('Decorator support requires additional dependencies.')
+        const shouldInstall = await logger.prompt(`Install \`${BABEL_DECORATOR_DEPS.join('` and `')}\`?`, {
+          type: 'confirm',
+          initial: true,
+        })
+
+        if (shouldInstall) {
+          logger.start(`Installing ${BABEL_DECORATOR_DEPS.map(d => `\`${d}\``).join(' and ')}...`)
+          for (const dep of BABEL_DECORATOR_DEPS) {
+            await addDependency(dep, {
+              dev: true,
+              cwd: nuxt.options.rootDir,
+              silent: true,
+            })
+          }
+          logger.info('Rerun Nuxt to enable decorator support.')
+          process.exit(1)
+        }
+      }
+
+      logger.warn(`Cannot find \`${pkg}\`. Install \`${BABEL_DECORATOR_DEPS.join('` and `')}\` to enable decorator support.`)
+      return false
+    }
+  }
+  return true
+}
+
+export function DecoratorsPlugin (nuxt: Nuxt): Plugin {
+  let transformSync: typeof import('@babel/core').transformSync
+
+  return {
+    name: 'nuxt:decorators',
+    apply: () => !!nuxt.options.experimental.decorators,
+    async applyToEnvironment () {
+      if (!await ensureBabelDecoratorDeps(nuxt)) {
+        return false
+      }
+      transformSync = await import('@babel/core').then(r => r.transformSync)
+      return true
+    },
+    transform: {
+      filter: {
+        // Only run on files containing @ (a prerequisite for decorator syntax)
+        code: '@',
+        // Exclude Vue style and template blocks
+        id: {
+          exclude: [
+            /\.vue\?.*\btype=(?:style|template)\b/,
+          ],
+        },
+      },
+      handler (code, id) {
+        // Skip uncompiled SFC markup (raw .vue files not yet processed by @vitejs/plugin-vue)
+        if (id.includes('.vue') && code.trimStart().startsWith('<')) {
+          return
+        }
+
+        const result = transformSync(code, {
+          filename: id,
+          configFile: false,
+          plugins: [
+            '@babel/plugin-syntax-jsx',
+            ['@babel/plugin-proposal-decorators', { version: '2023-11' }],
+          ],
+          sourceMaps: true,
+        })
+
+        if (result?.code != null) {
+          return {
+            code: result.code,
+            map: result.map,
+          }
+        }
+      },
+    },
+  }
+}

--- a/packages/vite/src/plugins/decorators.ts
+++ b/packages/vite/src/plugins/decorators.ts
@@ -5,7 +5,7 @@ import { logger } from '@nuxt/kit'
 import { hasTTY, isCI } from 'std-env'
 import type { Nuxt } from '@nuxt/schema'
 
-const BABEL_DECORATOR_DEPS = ['@babel/plugin-proposal-decorators', '@babel/plugin-syntax-jsx'] as const
+const BABEL_DECORATOR_DEPS = ['@babel/plugin-proposal-decorators', '@babel/plugin-syntax-jsx']
 
 async function ensureBabelDecoratorDeps (nuxt: Nuxt): Promise<boolean> {
   for (const pkg of BABEL_DECORATOR_DEPS) {
@@ -27,13 +27,11 @@ async function ensureBabelDecoratorDeps (nuxt: Nuxt): Promise<boolean> {
 
         if (shouldInstall) {
           logger.start(`Installing ${BABEL_DECORATOR_DEPS.map(d => `\`${d}\``).join(' and ')}...`)
-          for (const dep of BABEL_DECORATOR_DEPS) {
-            await addDependency(dep, {
-              dev: true,
-              cwd: nuxt.options.rootDir,
-              silent: true,
-            })
-          }
+          await addDependency(BABEL_DECORATOR_DEPS, {
+            dev: true,
+            cwd: nuxt.options.rootDir,
+            silent: true,
+          })
           logger.info('Rerun Nuxt to enable decorator support.')
           process.exit(1)
         }

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -28,6 +28,7 @@ import { LayerDepOptimizePlugin } from './plugins/layer-dep-optimize.ts'
 import { distDir } from './dirs.ts'
 import { SourcemapPreserverPlugin } from './plugins/sourcemap-preserver.ts'
 import { DevStyleSSRPlugin } from './plugins/dev-style-ssr.ts'
+import { DecoratorsPlugin } from './plugins/decorators.ts'
 import { RuntimePathsPlugin } from './plugins/runtime-paths.ts'
 import { TypeCheckPlugin } from './plugins/type-check.ts'
 import { ModulePreloadPolyfillPlugin } from './plugins/module-preload-polyfill.ts'
@@ -211,6 +212,8 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
               DevServerPlugin(nuxt),
             ]
           : [],
+        // lower decorators after Vue SFC compilation and TypeScript stripping
+        DecoratorsPlugin(nuxt),
         // add resolver for files in public assets directories
         PublicDirsPlugin({
           dev: nuxt.options.dev,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -342,6 +342,9 @@ importers:
 
   packages/nitro-server:
     dependencies:
+      '@babel/plugin-syntax-typescript':
+        specifier: ^7.28.6
+        version: 7.28.6(@babel/core@7.29.0)
       '@nuxt/devalue':
         specifier: ^2.0.2
         version: 2.0.2
@@ -390,6 +393,9 @@ importers:
       nitropack:
         specifier: ^2.13.1
         version: 2.13.1(rolldown@1.0.0-rc.7)
+      nypm:
+        specifier: ^0.6.5
+        version: 0.6.5
       ohash:
         specifier: ^2.0.11
         version: 2.0.11
@@ -424,9 +430,15 @@ importers:
         specifier: ^0.1.0
         version: 0.1.0
     devDependencies:
+      '@babel/plugin-proposal-decorators':
+        specifier: 7.29.0
+        version: 7.29.0(@babel/core@7.29.0)
       '@nuxt/schema':
         specifier: workspace:*
         version: link:../schema
+      '@rollup/plugin-babel':
+        specifier: 7.0.0
+        version: 7.0.0(@babel/core@7.29.0)(@types/babel__core@7.20.5)(rollup@4.59.0)
       nuxt:
         specifier: workspace:*
         version: link:../nuxt
@@ -1073,6 +1085,12 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0
     devDependencies:
+      '@babel/plugin-proposal-decorators':
+        specifier: 7.29.0
+        version: 7.29.0(@babel/core@7.29.0)
+      '@babel/plugin-syntax-jsx':
+        specifier: 7.28.6
+        version: 7.28.6(@babel/core@7.29.0)
       '@nuxt/schema':
         specifier: workspace:*
         version: link:../schema
@@ -1511,8 +1529,20 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  '@babel/plugin-syntax-jsx@7.27.1':
-    resolution: {integrity: sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==}
+  '@babel/plugin-proposal-decorators@7.29.0':
+    resolution: {integrity: sha512-CVBVv3VY/XRMxRYq5dwr2DS7/MvqPm23cOCjbwNnVrfOqcWlnefua1uUs0sjdKOGjvPUG633o07uWzJq4oI6dA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-decorators@7.28.6':
+    resolution: {integrity: sha512-71EYI0ONURHJBL4rSFXnITXqXrrY8q4P0q006DPfN+Rk+ASM+++IBXem/ruokgBZR8YNEWZ8R6B+rCb8VcUTqA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-jsx@7.28.6':
+    resolution: {integrity: sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3553,9 +3583,6 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.2':
     resolution: {integrity: sha512-izyXV/v+cHiRfozX62W9htOAvwMo4/bXKDrQ+vom1L1qRuexPock/7VZDAhnpHCLNejd3NJ6hiab+tO0D44Rgw==}
 
-  '@rolldown/pluginutils@1.0.0-rc.6':
-    resolution: {integrity: sha512-Y0+JT8Mi1mmW08K6HieG315XNRu4L0rkfCpA364HtytjgiqYnMYRdFPcxRl+BQQqNXzecL2S9nii+RUpO93XIA==}
-
   '@rolldown/pluginutils@1.0.0-rc.7':
     resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
 
@@ -3574,6 +3601,19 @@ packages:
     peerDependencies:
       rollup: '>=4.0.0'
     peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rollup/plugin-babel@7.0.0':
+    resolution: {integrity: sha512-NS2+P7v80N3MQqehZEjgpaFb9UyX3URNMW/zvoECKGo4PY4DvJfQusTI7BX/Ks+CPvtTfk3TqcR6S9VYBi/C+A==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+      '@types/babel__core': ^7.1.9
+      rollup: ^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      '@types/babel__core':
+        optional: true
       rollup:
         optional: true
 
@@ -9678,7 +9718,21 @@ snapshots:
     dependencies:
       '@babel/types': 8.0.0-rc.1
 
-  '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/plugin-syntax-decorators': 7.28.6(@babel/core@7.29.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-syntax-decorators@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
@@ -11327,8 +11381,6 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.2': {}
 
-  '@rolldown/pluginutils@1.0.0-rc.6': {}
-
   '@rolldown/pluginutils@1.0.0-rc.7': {}
 
   '@rollup/plugin-alias@5.1.1(rollup@4.59.0)':
@@ -11338,6 +11390,17 @@ snapshots:
   '@rollup/plugin-alias@6.0.0(rollup@4.59.0)':
     optionalDependencies:
       rollup: 4.59.0
+
+  '@rollup/plugin-babel@7.0.0(@babel/core@7.29.0)(@types/babel__core@7.20.5)(rollup@4.59.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
+    optionalDependencies:
+      '@types/babel__core': 7.20.5
+      rollup: 4.59.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@rollup/plugin-commonjs@28.0.9(rollup@4.59.0)':
     dependencies:
@@ -12151,7 +12214,7 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
-      '@rolldown/pluginutils': 1.0.0-rc.6
+      '@rolldown/pluginutils': 1.0.0-rc.7
       '@vue/babel-plugin-jsx': 2.0.1(@babel/core@7.29.0)
       vite: 7.3.1(@types/node@24.11.0)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
       vue: 3.5.29(typescript@5.9.3)
@@ -12255,7 +12318,7 @@ snapshots:
     dependencies:
       '@babel/helper-module-imports': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
       '@babel/template': 7.28.6
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -195,7 +195,8 @@ describe('pages', () => {
 
   it('preserves page metadata added in pages:extend hook', async () => {
     const html = await $fetch<string>('/some-custom-path')
-    expect (html.match(/<pre>([^<]*)<\/pre>/)?.[1]?.trim().replace(/&quot;/g, '"').replace(/&gt;/g, '>')).toMatchInlineSnapshot(`
+    // Normalise arrow function whitespace (esbuild with es2024 target strips spaces around =>)
+    expect(html.match(/<pre>([^<]*)<\/pre>/)?.[1]?.trim().replace(/&quot;/g, '"').replace(/&gt;/g, '>').replace(/\(\)\s*=>\s*/g, '() => ')).toMatchInlineSnapshot(`
       "{
         "name": "some-custom-name",
         "path": "/some-custom-path",


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

both nitro + vite will drop support for decorators due to moving to `rolldown`

this is a preliminary PR to move support for experimental decorators to babel (via optional peerDependencies, to avoid adding the extra 12Mb for all users)