### PR TITLE
feat(kit,nitro,nuxt,schema,vite): add build profiling

### DIFF
--- a/docs/4.api/4.commands/build.md
+++ b/docs/4.api/4.commands/build.md
@@ -10,7 +10,7 @@ links:
 
 <!--build-cmd-->
 ```bash [Terminal]
-npx nuxt build [ROOTDIR] [--cwd=<directory>] [--logLevel=<silent|info|verbose>] [--prerender] [--preset] [--dotenv] [--envName] [-e, --extends=<layer-name>]
+npx nuxt build [ROOTDIR] [--cwd=<directory>] [--logLevel=<silent|info|verbose>] [--prerender] [--preset] [--dotenv] [--envName] [-e, --extends=<layer-name>] [--profile[=verbose]]
 ```
 <!--/build-cmd-->
 
@@ -36,6 +36,7 @@ The `build` command creates a `.output` directory with all your application, ser
 | `--dotenv`                           |         | Path to `.env` file to load, relative to the root directory                                                                                          |
 | `--envName`                          |         | The environment to use when resolving configuration overrides (default is `production` when building, and `development` when running the dev server) |
 | `-e, --extends=<layer-name>`         |         | Extend from a Nuxt layer                                                                                                                             |
+| `--profile`                          |         | Profile performance (v4.4+). Writes a V8 CPU profile and JSON report on exit. Use `--profile=verbose` for a full console report.                     |
 <!--/build-opts-->
 
 ::note

--- a/docs/4.api/4.commands/dev.md
+++ b/docs/4.api/4.commands/dev.md
@@ -10,7 +10,7 @@ links:
 
 <!--dev-cmd-->
 ```bash [Terminal]
-npx nuxt dev [ROOTDIR] [--cwd=<directory>] [--logLevel=<silent|info|verbose>] [--dotenv] [--envName] [-e, --extends=<layer-name>] [--clear] [--no-f, --no-fork] [-p, --port] [-h, --host] [--clipboard] [-o, --open] [--https] [--publicURL] [--qr] [--public] [--tunnel] [--sslCert] [--sslKey]
+npx nuxt dev [ROOTDIR] [--cwd=<directory>] [--logLevel=<silent|info|verbose>] [--dotenv] [--envName] [-e, --extends=<layer-name>] [--clear] [--no-f, --no-fork] [-p, --port] [-h, --host] [--clipboard] [-o, --open] [--https] [--publicURL] [--qr] [--public] [--tunnel] [--profile[=verbose]] [--sslCert] [--sslKey]
 ```
 <!--/dev-cmd-->
 
@@ -45,6 +45,7 @@ The `dev` command starts a development server with hot module replacement at [ht
 | `--qr`                               |         | Display The QR code of public URL when available                                                                                                     |
 | `--public`                           |         | Listen to all network interfaces                                                                                                                     |
 | `--tunnel`                           |         | Open a tunnel using https://github.com/unjs/untun                                                                                                    |
+| `--profile`                          |         | Profile performance (v4.4+). Writes a V8 CPU profile and JSON report on exit. Use `--profile=verbose` for a full console report.                     |
 | `--sslCert`                          |         | (DEPRECATED) Use `--https.cert` instead.                                                                                                             |
 | `--sslKey`                           |         | (DEPRECATED) Use `--https.key` instead.                                                                                                              |
 <!--/dev-opts-->

--- a/docs/4.api/4.commands/generate.md
+++ b/docs/4.api/4.commands/generate.md
@@ -10,7 +10,7 @@ links:
 
 <!--generate-cmd-->
 ```bash [Terminal]
-npx nuxt generate [ROOTDIR] [--cwd=<directory>] [--logLevel=<silent|info|verbose>] [--preset] [--dotenv] [--envName] [-e, --extends=<layer-name>]
+npx nuxt generate [ROOTDIR] [--cwd=<directory>] [--logLevel=<silent|info|verbose>] [--preset] [--dotenv] [--envName] [-e, --extends=<layer-name>] [--profile[=verbose]]
 ```
 <!--/generate-cmd-->
 
@@ -35,6 +35,7 @@ The `generate` command pre-renders every route of your application and stores th
 | `--dotenv`                           |         | Path to `.env` file to load, relative to the root directory                                                                                          |
 | `--envName`                          |         | The environment to use when resolving configuration overrides (default is `production` when building, and `development` when running the dev server) |
 | `-e, --extends=<layer-name>`         |         | Extend from a Nuxt layer                                                                                                                             |
+| `--profile`                          |         | Profile performance (v4.4+). Writes a V8 CPU profile and JSON report on exit. Use `--profile=verbose` for a full console report.                     |
 <!--/generate-opts-->
 
 ::read-more{to="/docs/4.x/getting-started/deployment#static-hosting"}

--- a/packages/kit/src/module/define.ts
+++ b/packages/kit/src/module/define.ts
@@ -122,16 +122,19 @@ function _defineNuxtModule<
     }
 
     // Call setup
+    const moduleName = uniqueKey || module.meta.name || '<no name>'
+    nuxt._perf?.startPhase(`module:${moduleName}`)
     const start = performance.now()
     const res = await module.setup?.call(null as any, _options, nuxt) ?? {}
     const perf = performance.now() - start
     const setupTime = Math.round((perf * 100)) / 100
+    nuxt._perf?.endPhase(`module:${moduleName}`)
 
     // Measure setup time
     if (setupTime > 5000 && uniqueKey !== '@nuxt/telemetry') {
-      logger.warn(`Slow module \`${uniqueKey || '<no name>'}\` took \`${setupTime}ms\` to setup.`)
+      logger.warn(`Slow module \`${moduleName}\` took \`${setupTime}ms\` to setup.`)
     } else if (nuxt.options.debug && nuxt.options.debug.modules) {
-      logger.info(`Module \`${uniqueKey || '<no name>'}\` took \`${setupTime}ms\` to setup.`)
+      logger.info(`Module \`${moduleName}\` took \`${setupTime}ms\` to setup.`)
     }
 
     // Check if module is ignored

--- a/packages/kit/src/module/define.ts
+++ b/packages/kit/src/module/define.ts
@@ -125,10 +125,14 @@ function _defineNuxtModule<
     const moduleName = uniqueKey || module.meta.name || '<no name>'
     nuxt._perf?.startPhase(`module:${moduleName}`)
     const start = performance.now()
-    const res = await module.setup?.call(null as any, _options, nuxt) ?? {}
+    let res = {} as ModuleSetupReturn
+    try {
+      res = await module.setup?.call(null as any, _options, nuxt) ?? {}
+    } finally {
+      nuxt._perf?.endPhase(`module:${moduleName}`)
+    }
     const perf = performance.now() - start
     const setupTime = Math.round((perf * 100)) / 100
-    nuxt._perf?.endPhase(`module:${moduleName}`)
 
     // Measure setup time
     if (setupTime > 5000 && uniqueKey !== '@nuxt/telemetry') {

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -722,10 +722,12 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
   }
 
   // Init nitro
+  nuxt._perf?.startPhase('nitro:createNitro')
   const nitro = await createNitro(nitroConfig, {
     compatibilityDate: nuxt.options.compatibilityDate,
     dotenv: nuxt.options._loadOptions?.dotenv,
   })
+  nuxt._perf?.endPhase('nitro:createNitro')
 
   // eslint-disable-next-line @typescript-eslint/no-deprecated
   if (nuxt.options.experimental.serverAppConfig === false && nitro.options.imports) {
@@ -948,24 +950,8 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
     }
   }
 
-  // nuxt build/dev
-  nuxt.hook('build:done', async () => {
-    await nuxt.callHook('nitro:build:before', nitro)
-    await prepare(nitro)
-    if (nuxt.options.dev) {
-      return build(nitro)
-    }
-
-    await prerender(nitro)
-
-    logger.restoreAll()
-    await build(nitro)
-    logger.wrapAll()
-
-    await symlinkDist()
-  })
-
   // nuxt dev
+  let waitUntilCompile: Promise<void> | undefined
   if (nuxt.options.dev) {
     for (const builder of ['webpack', 'rspack'] as const) {
       nuxt.hook(`${builder}:compile`, ({ name, compiler }) => {
@@ -992,9 +978,32 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
     })
     nuxt.server = createDevServer(nitro)
 
-    const waitUntilCompile = new Promise<void>(resolve => nitro.hooks.hook('compiled', () => resolve()))
-    nuxt.hook('build:done', () => waitUntilCompile)
+    waitUntilCompile = new Promise<void>(resolve => nitro.hooks.hook('compiled', () => resolve()))
   }
+
+  // nuxt build/dev
+  nuxt.hook('build:done', async () => {
+    nuxt._perf?.startPhase('nitro:build')
+    try {
+      await nuxt.callHook('nitro:build:before', nitro)
+      await prepare(nitro)
+      if (nuxt.options.dev) {
+        await build(nitro)
+        await waitUntilCompile
+        return
+      }
+
+      await prerender(nitro)
+
+      logger.restoreAll()
+      await build(nitro)
+      logger.wrapAll()
+
+      await symlinkDist()
+    } finally {
+      nuxt._perf?.endPhase('nitro:build')
+    }
+  })
 }
 
 const RELATIVE_RE = /^([^.])/

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -784,7 +784,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
           if (typeof original !== 'function') { continue }
           plugin[hookName] = function (this: any, ...args: any[]) {
             const start = performance.now()
-            const record = () => nuxt._perf?.recordBundlerPluginHook(pluginName, hookName, performance.now() - start)
+            const record = () => nuxt._perf?.recordBundlerPluginHook(pluginName, hookName, performance.now() - start, start)
             try {
               const result = original.apply(this, args)
               if (result && typeof result === 'object' && 'then' in result) {

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -782,15 +782,18 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
           if (typeof original !== 'function') { continue }
           plugin[hookName] = function (this: any, ...args: any[]) {
             const start = performance.now()
-            const result = original.apply(this, args)
-            if (result && typeof result === 'object' && 'then' in result) {
-              return (result as Promise<any>).then((v: any) => {
-                nuxt._perf?.recordBundlerPluginHook(pluginName, hookName, performance.now() - start)
-                return v
-              })
+            const record = () => nuxt._perf?.recordBundlerPluginHook(pluginName, hookName, performance.now() - start)
+            try {
+              const result = original.apply(this, args)
+              if (result && typeof result === 'object' && 'then' in result) {
+                return (result as Promise<any>).finally(record)
+              }
+              record()
+              return result
+            } catch (err) {
+              record()
+              throw err
             }
-            nuxt._perf?.recordBundlerPluginHook(pluginName, hookName, performance.now() - start)
-            return result
           } as any
         }
       }

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -1,3 +1,4 @@
+import { performance } from 'node:perf_hooks'
 import { pathToFileURL } from 'node:url'
 import { existsSync, promises as fsp, readFileSync } from 'node:fs'
 import { cpus } from 'node:os'
@@ -768,6 +769,33 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
   // Expose nitro to modules and kit
   nuxt._nitro = nitro
   await nuxt.callHook('nitro:init', nitro)
+
+  // Instrument Nitro rollup plugins for perf tracking
+  if (nuxt._perf) {
+    nitro.hooks.hook('rollup:before', (_nitro, rollupConfig) => {
+      const plugins = (rollupConfig.plugins || []) as Array<{ name?: string, transform?: (...a: any[]) => any, resolveId?: (...a: any[]) => any, load?: (...a: any[]) => any } | null>
+      for (const plugin of plugins) {
+        if (!plugin || !plugin.name) { continue }
+        const pluginName = `nitro:${plugin.name}`
+        for (const hookName of ['transform', 'resolveId', 'load'] as const) {
+          const original = plugin[hookName]
+          if (typeof original !== 'function') { continue }
+          plugin[hookName] = function (this: any, ...args: any[]) {
+            const start = performance.now()
+            const result = original.apply(this, args)
+            if (result && typeof result === 'object' && 'then' in result) {
+              return (result as Promise<any>).then((v: any) => {
+                nuxt._perf?.recordBundlerPluginHook(pluginName, hookName, performance.now() - start)
+                return v
+              })
+            }
+            nuxt._perf?.recordBundlerPluginHook(pluginName, hookName, performance.now() - start)
+            return result
+          } as any
+        }
+      }
+    })
+  }
 
   nuxt['~runtimeDependencies'] ||= []
   nuxt['~runtimeDependencies']!.push(

--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -88,10 +88,10 @@ export async function generateApp (nuxt: Nuxt, app: NuxtApp, options: { filter?:
     }
 
     const perf = performance.now() - start
-    const setupTime = Math.round((perf * 100)) / 100
+    const compileTime = Math.round((perf * 100)) / 100
 
-    if ((nuxt.options.debug && nuxt.options.debug.templates) || setupTime > 500) {
-      logger.info(`Compiled \`${template.filename}\` in ${setupTime}ms`)
+    if ((nuxt.options.debug && nuxt.options.debug.templates) || compileTime > 500) {
+      logger.info(`Compiled \`${template.filename}\` in ${compileTime}ms`)
     }
 
     if (template.modified && template.write) {

--- a/packages/nuxt/src/core/builder.ts
+++ b/packages/nuxt/src/core/builder.ts
@@ -12,11 +12,13 @@ import { cleanupCaches, getVueHash } from './cache.ts'
 import type { Nuxt, NuxtBuilder } from 'nuxt/schema'
 
 export async function build (nuxt: Nuxt): Promise<void> {
+  nuxt._perf?.startPhase('app:generate')
   const app = createApp(nuxt)
   nuxt.apps.default = app
 
   const generateApp = debounce(() => _generateApp(nuxt, app), undefined, { leading: true })
   await generateApp()
+  nuxt._perf?.endPhase('app:generate')
 
   if (nuxt.options.dev) {
     watch(nuxt)
@@ -70,9 +72,24 @@ export async function build (nuxt: Nuxt): Promise<void> {
     })
   }
 
+  nuxt._perf?.startPhase('build:bundle')
   await bundle(nuxt)
+  nuxt._perf?.endPhase('build:bundle')
 
   await nuxt.callHook('build:done')
+
+  // Print and write perf report after build (including Nitro build) is complete
+  if (nuxt._perf) {
+    const perfOption = nuxt.options.debug && (nuxt.options.debug as any).perf
+    const quiet = perfOption === 'quiet'
+    if (!quiet) {
+      const title = nuxt.options.dev
+        ? 'Nuxt Startup Performance'
+        : 'Nuxt Build Performance'
+      nuxt._perf.printReport({ title })
+    }
+    await nuxt._perf.writeReport(nuxt.options.buildDir, { quiet })
+  }
 
   if (!nuxt.options.dev) {
     await nuxt.callHook('close', nuxt)

--- a/packages/nuxt/src/core/builder.ts
+++ b/packages/nuxt/src/core/builder.ts
@@ -78,19 +78,6 @@ export async function build (nuxt: Nuxt): Promise<void> {
 
   await nuxt.callHook('build:done')
 
-  // Print and write perf report after build (including Nitro build) is complete
-  if (nuxt._perf) {
-    const perfOption = nuxt.options.debug && (nuxt.options.debug as any).perf
-    const quiet = perfOption === 'quiet'
-    if (!quiet) {
-      const title = nuxt.options.dev
-        ? 'Nuxt Startup Performance'
-        : 'Nuxt Build Performance'
-      nuxt._perf.printReport({ title })
-    }
-    await nuxt._perf.writeReport(nuxt.options.buildDir, { quiet })
-  }
-
   if (!nuxt.options.dev) {
     await nuxt.callHook('close', nuxt)
   }

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -47,6 +47,7 @@ import { DevOnlyPlugin } from './plugins/dev-only.ts'
 import { LayerAliasingPlugin } from './plugins/layer-aliasing.ts'
 import { addModuleTranspiles } from './modules.ts'
 import { bundleServer } from './server.ts'
+import { NuxtPerfProfiler } from './perf.ts'
 import schemaModule from './schema.ts'
 import { RemovePluginMetadataPlugin } from './plugins/plugin-metadata.ts'
 import { AsyncContextInjectionPlugin } from './plugins/async-context.ts'
@@ -167,6 +168,8 @@ export const keyDependencies: string[] = [
 let warnedAboutCompatDate = false
 
 async function initNuxt (nuxt: Nuxt) {
+  nuxt._perf?.startPhase('init')
+
   const layerDirs = getLayerDirectories(nuxt)
 
   // Register user hooks
@@ -485,6 +488,8 @@ async function initNuxt (nuxt: Nuxt) {
   }
 
   // Init user modules
+  nuxt._perf?.endPhase('init')
+  nuxt._perf?.startPhase('modules')
   await nuxt.callHook('modules:before')
 
   const { paths: watchedModulePaths, resolvedModulePaths, modules } = await resolveModules(nuxt)
@@ -637,6 +642,8 @@ async function initNuxt (nuxt: Nuxt) {
   })
 
   await nuxt.callHook('modules:done')
+  nuxt._perf?.endPhase('modules')
+  nuxt._perf?.collectModuleTimings(nuxt.options._installedModules)
 
   // Add keys for useFetch, useAsyncData, etc.
   const normalizedKeyedFunctions = await Promise.all(nuxt.options.optimization.keyedComposables.map(async ({ source, ...rest }) => ({
@@ -779,6 +786,7 @@ export default defineNuxtPlugin({
 
   // Init nitro
   await bundleServer(nuxt)
+  nuxt._perf?.startPhase('ready')
 
   // Add prerender payload support
   if (nuxt.options.experimental.payloadExtraction) {
@@ -792,10 +800,24 @@ export default defineNuxtPlugin({
   }
 
   await nuxt.callHook('ready', nuxt)
+  nuxt._perf?.endPhase('ready')
 }
 
 export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
+  // Start config phase profiling early (profiler may be replaced once config is loaded)
+  let perf: NuxtPerfProfiler | undefined
+  if (process.env.NUXT_DEBUG_PERF || (opts.overrides?.debug && (opts.overrides.debug === true || opts.overrides.debug?.perf))) {
+    perf = new NuxtPerfProfiler()
+    perf.startPhase('config')
+  }
+
   const options = await loadNuxtConfig(opts)
+
+  // Initialize profiler from resolved config if not already created
+  if (!perf && options.debug && (options.debug as any).perf) {
+    perf = new NuxtPerfProfiler()
+  }
+  perf?.endPhase('config')
 
   // Temporary until finding better placement for each
   options.appDir = options.alias['#app'] = withTrailingSlash(resolve(distDir, 'app'))
@@ -891,6 +913,13 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
   })
 
   const nuxt = createNuxt(options)
+
+  // Attach performance profiler if enabled
+  if (perf) {
+    nuxt._perf = perf
+    perf.installHookInterceptors(nuxt.hooks)
+    nuxt.hook('close', () => perf!.dispose())
+  }
 
   nuxt.runWithContext(() => {
     // We register hooks layer-by-layer so any overrides need to be registered separately

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -950,7 +950,7 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
       if (flushed || !perf) { return }
       flushed = true
       if (!quiet) { perf.printReport({ title }) }
-      perf.writeReportSync(nuxt.options.buildDir, { quiet })
+      perf.writeReport(nuxt.options.buildDir, { quiet })
       perf.dispose()
     }
 

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -804,18 +804,20 @@ export default defineNuxtPlugin({
 }
 
 export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
-  // Start config phase profiling early (profiler may be replaced once config is loaded)
+  // Early-init profiler when CLI passes perf overrides (captures config loading).
+  // Otherwise, create after config resolves from nuxt.config / env vars.
   let perf: NuxtPerfProfiler | undefined
-  if (process.env.NUXT_DEBUG_PERF || (opts.overrides?.debug && (opts.overrides.debug === true || opts.overrides.debug?.perf))) {
-    perf = new NuxtPerfProfiler()
+  const cliStartTime = (globalThis as any).__nuxt_cli__?.startTime as number | undefined
+  const perfOverride = typeof opts.overrides?.debug === 'object' && opts.overrides.debug.perf
+  if (perfOverride) {
+    perf = new NuxtPerfProfiler({ startTime: cliStartTime })
     perf.startPhase('config')
   }
 
   const options = await loadNuxtConfig(opts)
 
-  // Initialize profiler from resolved config if not already created
-  if (!perf && options.debug && (options.debug as any).perf) {
-    perf = new NuxtPerfProfiler()
+  if (!perf && typeof options.debug === 'object' && options.debug.perf) {
+    perf = new NuxtPerfProfiler({ startTime: cliStartTime })
   }
   perf?.endPhase('config')
 
@@ -919,18 +921,41 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
     nuxt._perf = perf
     perf.installHookInterceptors(nuxt.hooks)
 
-    // Start V8 CPU profiler if enabled (captures flame chart data)
+    const quiet = typeof options.debug === 'object' && options.debug.perf === 'quiet'
+
+    // Start V8 CPU profiler
     perf.startCpuProfile().catch(() => {})
 
+    // Flush perf data (report + CPU profile). Runs once — either via the
+    // close hook (async, preferred) or via a signal handler (sync, fallback).
+    let flushed = false
+    const title = nuxt.options.dev ? 'Nuxt Performance Report' : 'Nuxt Build Performance'
+
     nuxt.hook('close', async () => {
-      const perfOption = nuxt.options.debug && (nuxt.options.debug as any).perf
-      const quiet = perfOption === 'quiet'
-      if (nuxt.options.dev) {
-        if (!quiet) { perf!.printSessionSummary() }
-        await perf!.writeReport(nuxt.options.buildDir, { quiet })
-      }
-      await perf!.stopCpuProfile(nuxt.options.rootDir).catch(() => {})
+      if (flushed) { return }
+      flushed = true
+      if (!quiet) { perf!.printReport({ title }) }
+      await perf!.writeReport(nuxt.options.buildDir, { quiet })
+      await perf!.stopCpuProfile(nuxt.options.buildDir).catch(() => {})
       perf!.dispose()
+    })
+
+    // Signal handlers must be synchronous
+    const onSignal = () => {
+      if (!flushed) {
+        flushed = true
+        if (!quiet) { perf!.printReport({ title }) }
+        perf!.writeReportSync(nuxt.options.buildDir, { quiet })
+        perf!.stopCpuProfileSync(nuxt.options.buildDir)
+        perf!.dispose()
+      }
+      process.exit(0)
+    }
+    process.once('SIGINT', onSignal)
+    process.once('SIGTERM', onSignal)
+    nuxt.hook('close', () => {
+      process.off('SIGINT', onSignal)
+      process.off('SIGTERM', onSignal)
     })
   }
 

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -918,7 +918,20 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
   if (perf) {
     nuxt._perf = perf
     perf.installHookInterceptors(nuxt.hooks)
-    nuxt.hook('close', () => perf!.dispose())
+
+    // Start V8 CPU profiler if enabled (captures flame chart data)
+    perf.startCpuProfile().catch(() => {})
+
+    nuxt.hook('close', async () => {
+      const perfOption = nuxt.options.debug && (nuxt.options.debug as any).perf
+      const quiet = perfOption === 'quiet'
+      if (nuxt.options.dev) {
+        if (!quiet) { perf!.printSessionSummary() }
+        await perf!.writeReport(nuxt.options.buildDir, { quiet })
+      }
+      await perf!.stopCpuProfile(nuxt.options.rootDir).catch(() => {})
+      perf!.dispose()
+    })
   }
 
   nuxt.runWithContext(() => {

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -916,47 +916,25 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
 
   const nuxt = createNuxt(options)
 
-  // Attach performance profiler if enabled
   if (perf) {
     nuxt._perf = perf
     perf.installHookInterceptors(nuxt.hooks)
 
     const quiet = typeof options.debug === 'object' && options.debug.perf === 'quiet'
-
-    // Start V8 CPU profiler
-    perf.startCpuProfile().catch(() => {})
-
-    // Flush perf data (report + CPU profile). Runs once — either via the
-    // close hook (async, preferred) or via a signal handler (sync, fallback).
-    let flushed = false
     const title = nuxt.options.dev ? 'Nuxt Performance Report' : 'Nuxt Build Performance'
 
-    nuxt.hook('close', async () => {
-      if (flushed) { return }
+    let flushed = false
+    const flush = () => {
+      if (flushed || !perf) { return }
       flushed = true
-      if (!quiet) { perf!.printReport({ title }) }
-      await perf!.writeReport(nuxt.options.buildDir, { quiet })
-      await perf!.stopCpuProfile(nuxt.options.buildDir).catch(() => {})
-      perf!.dispose()
-    })
-
-    // Signal handlers must be synchronous
-    const onSignal = () => {
-      if (!flushed) {
-        flushed = true
-        if (!quiet) { perf!.printReport({ title }) }
-        perf!.writeReportSync(nuxt.options.buildDir, { quiet })
-        perf!.stopCpuProfileSync(nuxt.options.buildDir)
-        perf!.dispose()
-      }
-      process.exit(0)
+      if (!quiet) { perf.printReport({ title }) }
+      perf.writeReportSync(nuxt.options.buildDir, { quiet })
+      perf.dispose()
     }
-    process.once('SIGINT', onSignal)
-    process.once('SIGTERM', onSignal)
-    nuxt.hook('close', () => {
-      process.off('SIGINT', onSignal)
-      process.off('SIGTERM', onSignal)
-    })
+
+    nuxt.hook('close', flush)
+    process.once('exit', flush)
+    nuxt.hook('close', () => { process.off('exit', flush) })
   }
 
   nuxt.runWithContext(() => {

--- a/packages/nuxt/src/core/perf.ts
+++ b/packages/nuxt/src/core/perf.ts
@@ -1,0 +1,492 @@
+import { performance } from 'node:perf_hooks'
+import process from 'node:process'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { join } from 'pathe'
+import { consola } from 'consola'
+import { colors } from 'consola/utils'
+import type { Hookable } from 'hookable'
+import type { NuxtHooks } from 'nuxt/schema'
+
+export interface MemorySnapshot {
+  rss: number
+  heapUsed: number
+  heapTotal: number
+}
+
+interface PerfPhase {
+  name: string
+  startTime: number
+  endTime: number
+  duration: number
+  memoryBefore: MemorySnapshot
+  memoryAfter: MemorySnapshot
+  memoryDelta: { rss: number, heapUsed: number }
+}
+
+interface OpenPhase {
+  name: string
+  startTime: number
+  memoryBefore: MemorySnapshot
+}
+
+export interface SlowHook {
+  name: string
+  duration: number
+  ownDuration: number
+  phase: string
+}
+
+export interface ModuleTiming {
+  name: string
+  setupTime: number
+}
+
+export interface PluginHookTiming {
+  totalTime: number
+  count: number
+  maxTime: number
+  avgTime: number
+}
+
+export interface BundlerPluginTiming {
+  name: string
+  hooks: Record<string, PluginHookTiming>
+}
+
+export interface PerfReport {
+  totalDuration: number
+  totalMemoryDelta: { rss: number, heapUsed: number }
+  phases: Array<{
+    name: string
+    duration: number
+    ownDuration: number
+    memoryBefore: MemorySnapshot
+    memoryAfter: MemorySnapshot
+    memoryDelta: { rss: number, heapUsed: number }
+    ownMemoryDelta: { rss: number, heapUsed: number }
+  }>
+  slowHooks: SlowHook[]
+  modules: ModuleTiming[]
+  bundlerPlugins: BundlerPluginTiming[]
+  timestamp: string
+}
+
+function getMemorySnapshot (): MemorySnapshot {
+  const mem = process.memoryUsage()
+  return { rss: mem.rss, heapUsed: mem.heapUsed, heapTotal: mem.heapTotal }
+}
+
+function formatBytes (bytes: number): string {
+  const abs = Math.abs(bytes)
+  if (abs < 1024) { return `${bytes} B` }
+  if (abs < 1024 * 1024) { return `${(bytes / 1024).toFixed(1)} KB` }
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function formatDuration (ms: number): string {
+  if (ms < 1) { return `${Math.round(ms * 1000)}µs` }
+  if (ms < 1000) { return `${Math.round(ms)}ms` }
+  if (ms < 60_000) { return `${(ms / 1000).toFixed(1)}s` }
+  return `${(ms / 60_000).toFixed(1)}min`
+}
+
+// eslint-disable-next-line no-control-regex
+const ANSI_RE = /\x1B\[[0-9;]*m/g
+
+function pad (str: string, width: number, align: 'left' | 'right' = 'left'): string {
+  const stripped = str.replace(ANSI_RE, '')
+  const diff = width - stripped.length
+  if (diff <= 0) { return str }
+  const padding = ' '.repeat(diff)
+  return align === 'right' ? padding + str : str + padding
+}
+
+function round (n: number): number {
+  return Math.round(n * 100) / 100
+}
+
+const SLOW_HOOK_THRESHOLD_MS = Number(process.env.NUXT_PERF_SLOW_HOOK_MS) || 50
+
+const HOOK_PHASE_THRESHOLD_MS = 5
+
+export class NuxtPerfProfiler {
+  #phases: PerfPhase[] = []
+  #phaseStack: OpenPhase[] = []
+  #hookPhases: PerfPhase[] = []
+  #hookStarts = new Map<string, { time: number, memory: MemorySnapshot }>()
+  #hookStack: string[] = []
+  #modules: ModuleTiming[] = []
+  #bundlerPluginTimings = new Map<string, Map<string, { totalTime: number, count: number, maxTime: number }>>()
+  #globalStart: number
+  #globalMemoryBefore: MemorySnapshot
+  #unsubscribe?: () => void
+
+  constructor () {
+    this.#globalStart = performance.now()
+    this.#globalMemoryBefore = getMemorySnapshot()
+  }
+
+  installHookInterceptors (hooks: Hookable<NuxtHooks>): void {
+    const unsubBefore = hooks.beforeEach((event) => {
+      this.#hookStarts.set(event.name, {
+        time: performance.now(),
+        memory: getMemorySnapshot(),
+      })
+      this.#hookStack.push(event.name)
+    })
+
+    const unsubAfter = hooks.afterEach((event) => {
+      const start = this.#hookStarts.get(event.name)
+      if (!start) { return }
+      this.#hookStarts.delete(event.name)
+      this.#hookStack.pop()
+
+      const endTime = performance.now()
+      const memoryAfter = getMemorySnapshot()
+      const duration = round(endTime - start.time)
+
+      this.#hookPhases.push({
+        name: `hook:${event.name}`,
+        startTime: start.time,
+        endTime,
+        duration,
+        memoryBefore: start.memory,
+        memoryAfter,
+        memoryDelta: {
+          rss: memoryAfter.rss - start.memory.rss,
+          heapUsed: memoryAfter.heapUsed - start.memory.heapUsed,
+        },
+      })
+    })
+
+    this.#unsubscribe = () => {
+      unsubBefore()
+      unsubAfter()
+    }
+  }
+
+  startPhase (name: string): void {
+    this.#phaseStack.push({
+      name,
+      startTime: performance.now(),
+      memoryBefore: getMemorySnapshot(),
+    })
+  }
+
+  endPhase (name?: string): void {
+    let phaseIdx = this.#phaseStack.length - 1
+    if (name) {
+      phaseIdx = -1
+      for (let i = this.#phaseStack.length - 1; i >= 0; i--) {
+        if (this.#phaseStack[i]!.name === name) {
+          phaseIdx = i
+          break
+        }
+      }
+      if (phaseIdx === -1) { return }
+    }
+    if (phaseIdx < 0) { return }
+
+    const open = this.#phaseStack.splice(phaseIdx, 1)[0]!
+    const endTime = performance.now()
+    const memoryAfter = getMemorySnapshot()
+
+    this.#phases.push({
+      name: open.name,
+      startTime: open.startTime,
+      endTime,
+      duration: round(endTime - open.startTime),
+      memoryBefore: open.memoryBefore,
+      memoryAfter,
+      memoryDelta: {
+        rss: memoryAfter.rss - open.memoryBefore.rss,
+        heapUsed: memoryAfter.heapUsed - open.memoryBefore.heapUsed,
+      },
+    })
+  }
+
+  recordBundlerPluginHook (pluginName: string, hookName: string, durationMs: number): void {
+    let plugin = this.#bundlerPluginTimings.get(pluginName)
+    if (!plugin) {
+      plugin = new Map()
+      this.#bundlerPluginTimings.set(pluginName, plugin)
+    }
+    const entry = plugin.get(hookName)
+    if (entry) {
+      entry.totalTime += durationMs
+      entry.count++
+      if (durationMs > entry.maxTime) { entry.maxTime = durationMs }
+    } else {
+      plugin.set(hookName, { totalTime: durationMs, count: 1, maxTime: durationMs })
+    }
+  }
+
+  collectModuleTimings (installedModules: Array<{ meta?: { name?: string }, timings?: Record<string, number | undefined> }>): void {
+    for (const mod of installedModules) {
+      const name = mod.meta?.name || '(anonymous)'
+      const setupTime = mod.timings?.setup
+      if (setupTime != null) {
+        this.#modules.push({ name, setupTime })
+      }
+    }
+  }
+
+  getReport (): PerfReport {
+    const totalDuration = round(performance.now() - this.#globalStart)
+    const globalMemoryAfter = getMemorySnapshot()
+
+    // Merge manual phases with hook phases that exceeded the threshold
+    // and aren't already covered by a manual phase.
+    const allPhases: PerfPhase[] = [...this.#phases]
+    for (const hp of this.#hookPhases) {
+      if (hp.duration < HOOK_PHASE_THRESHOLD_MS) { continue }
+      const hookName = hp.name.slice(5) // strip "hook:" prefix
+      const alreadyCovered = this.#phases.some(p =>
+        p.name === hookName && p.startTime <= hp.startTime && p.endTime >= hp.endTime,
+      )
+      if (!alreadyCovered) {
+        allPhases.push({ ...hp, name: hookName })
+      }
+    }
+
+    // Sort by start time for correct display order
+    allPhases.sort((a, b) => a.startTime - b.startTime)
+
+    // Compute own-time and own-memory for each phase by subtracting
+    // child phases nested inside it.
+    function computeOwn (phase: PerfPhase) {
+      let childTime = 0
+      let childRss = 0
+      let childHeap = 0
+      for (const other of allPhases) {
+        if (other === phase) { continue }
+        if (other.startTime >= phase.startTime && other.endTime <= phase.endTime) {
+          childTime += other.duration
+          childRss += other.memoryDelta.rss
+          childHeap += other.memoryDelta.heapUsed
+        }
+      }
+      return {
+        ownDuration: round(phase.duration - childTime),
+        ownMemoryDelta: {
+          rss: phase.memoryDelta.rss - childRss,
+          heapUsed: phase.memoryDelta.heapUsed - childHeap,
+        },
+      }
+    }
+
+    return {
+      totalDuration,
+      totalMemoryDelta: {
+        rss: globalMemoryAfter.rss - this.#globalMemoryBefore.rss,
+        heapUsed: globalMemoryAfter.heapUsed - this.#globalMemoryBefore.heapUsed,
+      },
+      phases: allPhases.map((p) => {
+        const own = computeOwn(p)
+        return {
+          name: p.name,
+          duration: p.duration,
+          ownDuration: own.ownDuration,
+          memoryBefore: p.memoryBefore,
+          memoryAfter: p.memoryAfter,
+          memoryDelta: p.memoryDelta,
+          ownMemoryDelta: own.ownMemoryDelta,
+        }
+      }),
+      slowHooks: this.#computeSlowHooks(new Set(allPhases.map(p => p.name))),
+      modules: [...this.#modules].sort((a, b) => b.setupTime - a.setupTime),
+      bundlerPlugins: [...this.#bundlerPluginTimings.entries()]
+        .map(([name, hookMap]) => {
+          const hooks: Record<string, PluginHookTiming> = {}
+          for (const [hookName, t] of hookMap) {
+            hooks[hookName] = {
+              totalTime: round(t.totalTime),
+              count: t.count,
+              maxTime: round(t.maxTime),
+              avgTime: round(t.totalTime / t.count),
+            }
+          }
+          return { name, hooks }
+        })
+        .sort((a, b) => {
+          const aTotal = Object.values(a.hooks).reduce((s, h) => s + h.totalTime, 0)
+          const bTotal = Object.values(b.hooks).reduce((s, h) => s + h.totalTime, 0)
+          return bTotal - aTotal
+        }),
+      timestamp: new Date().toISOString(),
+    }
+  }
+
+  printReport (options?: { title?: string }): void {
+    const report = this.getReport()
+
+    // Sub-phases are module:* and vite:* — everything else goes in the main table
+    const isSubPhase = (name: string) => name.startsWith('module:') || name.startsWith('vite:')
+    const topPhases = report.phases.filter(p => !isSubPhase(p.name))
+    const subPhases = report.phases.filter(p => isSubPhase(p.name))
+
+    consola.log('')
+    consola.log(colors.bold(colors.cyan(` ${options?.title || 'Nuxt Performance Report'}`)))
+    consola.log('')
+
+    const colPhase = 24
+    const colDuration = 10
+    const colRss = 14
+    const colHeap = 14
+    const maxDuration = Math.max(...topPhases.map(p => p.ownDuration), 1)
+
+    const header = [
+      pad(colors.bold('Phase'), colPhase),
+      pad(colors.bold('Duration'), colDuration, 'right'),
+      pad(colors.bold('RSS Delta'), colRss, 'right'),
+      pad(colors.bold('Heap Delta'), colHeap, 'right'),
+    ].join('  ')
+    consola.log(`  ${header}`)
+
+    const separator = '  ' + colors.dim('─'.repeat(colPhase + colDuration + colRss + colHeap + 6))
+    consola.log(separator)
+
+    for (const phase of topPhases) {
+      const dur = phase.ownDuration
+      const rss = phase.ownMemoryDelta.rss
+      const heap = phase.ownMemoryDelta.heapUsed
+      const barWidth = Math.max(1, Math.round((dur / maxDuration) * 12))
+      const bar = colors.green('█'.repeat(barWidth))
+      const row = [
+        pad(phase.name, colPhase),
+        pad(formatDuration(dur), colDuration, 'right'),
+        pad((rss >= 0 ? '+' : '') + formatBytes(rss), colRss, 'right'),
+        pad((heap >= 0 ? '+' : '') + formatBytes(heap), colHeap, 'right'),
+      ].join('  ')
+      consola.log(`  ${row}  ${bar}`)
+    }
+
+    consola.log(separator)
+    const totalRow = [
+      pad(colors.bold('Total'), colPhase),
+      pad(colors.bold(formatDuration(report.totalDuration)), colDuration, 'right'),
+      pad(colors.bold((report.totalMemoryDelta.rss >= 0 ? '+' : '') + formatBytes(report.totalMemoryDelta.rss)), colRss, 'right'),
+      pad(colors.bold((report.totalMemoryDelta.heapUsed >= 0 ? '+' : '') + formatBytes(report.totalMemoryDelta.heapUsed)), colHeap, 'right'),
+    ].join('  ')
+    consola.log(`  ${totalRow}`)
+    consola.log('')
+
+    const significantModules = report.modules.filter(m => m.setupTime > 5)
+    if (significantModules.length > 0) {
+      consola.log(colors.bold(` Modules`))
+      consola.log('')
+      for (const mod of significantModules) {
+        const durColor = mod.setupTime > 500 ? colors.red : mod.setupTime > 100 ? colors.yellow : colors.dim
+        consola.log(`  ${colors.dim('•')} ${mod.name} ${colors.dim('—')} ${durColor(formatDuration(mod.setupTime))}`)
+      }
+      consola.log('')
+    }
+
+    if (report.bundlerPlugins.length > 0) {
+      const rows: Array<{ plugin: string, hook: string, timing: PluginHookTiming }> = []
+      for (const plugin of report.bundlerPlugins) {
+        for (const [hook, timing] of Object.entries(plugin.hooks)) {
+          if (timing.avgTime > 0.5) {
+            rows.push({ plugin: plugin.name, hook, timing })
+          }
+        }
+      }
+      rows.sort((a, b) => b.timing.avgTime - a.timing.avgTime)
+
+      if (rows.length > 0) {
+        consola.log(colors.bold(` Bundler Plugins`))
+        consola.log('')
+        for (const { plugin, hook, timing } of rows.slice(0, 15)) {
+          const durColor = timing.avgTime > 10 ? colors.red : timing.avgTime > 2 ? colors.yellow : colors.dim
+          const avgLabel = formatDuration(timing.avgTime) + '/file'
+          const maxLabel = timing.maxTime > timing.avgTime * 2 ? `, max ${formatDuration(timing.maxTime)}` : ''
+          consola.log(`  ${colors.dim('•')} ${plugin} ${colors.dim(hook)} ${colors.dim('—')} ${durColor(avgLabel)}${colors.dim(maxLabel)} ${colors.dim(`(${timing.count} calls)`)}`)
+        }
+        consola.log('')
+      }
+    }
+
+    if (report.slowHooks.length > 0) {
+      consola.log(colors.bold(colors.yellow(` Slow Hooks (>${SLOW_HOOK_THRESHOLD_MS}ms own time)`)))
+      consola.log('')
+      for (const hook of report.slowHooks) {
+        const durColor = hook.ownDuration > 500 ? colors.red : hook.ownDuration > 200 ? colors.yellow : colors.dim
+        const ownLabel = hook.ownDuration !== hook.duration
+          ? `${formatDuration(hook.ownDuration)} own / ${formatDuration(hook.duration)} total`
+          : formatDuration(hook.ownDuration)
+        consola.log(`  ${colors.dim('•')} ${hook.name} ${colors.dim('—')} ${durColor(ownLabel)} ${colors.dim(`(${hook.phase})`)}`)
+      }
+      consola.log('')
+    }
+
+    const significantSubs = subPhases.filter(p => p.duration > 5)
+    if (significantSubs.length > 0) {
+      consola.log(colors.bold(` Details`))
+      consola.log('')
+      for (const phase of significantSubs) {
+        const durColor = phase.duration > 500 ? colors.red : phase.duration > 100 ? colors.yellow : colors.dim
+        consola.log(`  ${colors.dim('•')} ${phase.name} ${colors.dim('—')} ${durColor(formatDuration(phase.duration))}`)
+      }
+      consola.log('')
+    }
+  }
+
+  async writeReport (buildDir: string, options?: { quiet?: boolean }): Promise<string> {
+    const report = this.getReport()
+    const reportPath = join(buildDir, 'perf-report.json')
+    await mkdir(buildDir, { recursive: true })
+    await writeFile(reportPath, JSON.stringify(report, null, 2), 'utf-8')
+    if (!options?.quiet) {
+      consola.log(colors.dim(` Full report written to ${reportPath}`))
+      consola.log('')
+    }
+    return reportPath
+  }
+
+  dispose (): void {
+    this.#unsubscribe?.()
+  }
+
+  #computeSlowHooks (reportedPhaseNames: Set<string>): SlowHook[] {
+    const hooks: SlowHook[] = []
+    for (const hp of this.#hookPhases) {
+      if (hp.duration < SLOW_HOOK_THRESHOLD_MS) { continue }
+
+      const hookName = hp.name.slice(5) // strip "hook:" prefix
+
+      // Skip hooks already shown as phases in the main table
+      if (reportedPhaseNames.has(hookName)) { continue }
+
+      // Subtract time attributed to phases (manual + promoted hooks) that overlap
+      let attributedTime = 0
+      for (const phase of this.#phases) {
+        const overlapStart = Math.max(phase.startTime, hp.startTime)
+        const overlapEnd = Math.min(phase.endTime, hp.endTime)
+        if (overlapEnd > overlapStart) {
+          attributedTime += overlapEnd - overlapStart
+        }
+      }
+      // Also subtract time from other hook phases that are nested inside this one
+      for (const other of this.#hookPhases) {
+        if (other === hp) { continue }
+        if (other.startTime >= hp.startTime && other.endTime <= hp.endTime) {
+          attributedTime += other.duration
+        }
+      }
+
+      const ownDuration = round(hp.duration - round(attributedTime))
+      if (ownDuration >= SLOW_HOOK_THRESHOLD_MS) {
+        const parentPhase = this.#phases.find(p =>
+          p.startTime <= hp.startTime && p.endTime >= hp.endTime,
+        )
+        hooks.push({
+          name: hookName,
+          duration: hp.duration,
+          ownDuration,
+          phase: parentPhase?.name || '(between phases)',
+        })
+      }
+    }
+    return hooks.sort((a, b) => b.ownDuration - a.ownDuration)
+  }
+}

--- a/packages/nuxt/src/core/perf.ts
+++ b/packages/nuxt/src/core/perf.ts
@@ -1,7 +1,8 @@
 import { performance } from 'node:perf_hooks'
 import process from 'node:process'
+import { mkdirSync, writeFileSync } from 'node:fs'
 import { mkdir, writeFile } from 'node:fs/promises'
-import { join, resolve } from 'pathe'
+import { join } from 'pathe'
 import { consola } from 'consola'
 import { colors } from 'consola/utils'
 import type { Hookable } from 'hookable'
@@ -123,8 +124,13 @@ export class NuxtPerfProfiler {
   #cpuProfileSession?: import('node:inspector').Session
   #cpuProfileCount = 0
 
-  constructor () {
-    this.#globalStart = performance.now()
+  constructor (options?: { startTime?: number }) {
+    if (options?.startTime) {
+      // Convert absolute Date.now() timestamp to performance.now() space
+      this.#globalStart = performance.now() - (Date.now() - options.startTime)
+    } else {
+      this.#globalStart = performance.now()
+    }
     this.#globalMemoryBefore = getMemorySnapshot()
   }
 
@@ -143,22 +149,46 @@ export class NuxtPerfProfiler {
     consola.info('CPU profiler started')
   }
 
-  stopCpuProfile (cwd?: string): Promise<string | undefined> {
+  stopCpuProfile (buildDir: string): Promise<string | undefined> {
     const session = this.#cpuProfileSession
     if (!session) { return Promise.resolve(undefined) }
     this.#cpuProfileSession = undefined
     return new Promise((res, rej) => {
       session.post('Profiler.stop', (err, { profile }) => {
         if (err) { return rej(err) }
-        const outPath = resolve(cwd || '.', `nuxt-profile-${this.#cpuProfileCount++}.cpuprofile`)
-        writeFile(outPath, JSON.stringify(profile)).then(() => {
-          consola.info(`CPU profile written to ${colors.cyan(outPath)}`)
-          consola.info(`Open it in ${colors.cyan('https://www.speedscope.app')} or Chrome DevTools`)
-          session.disconnect()
-          res(outPath)
-        }).catch(rej)
+        const outPath = join(buildDir, `profile-${this.#cpuProfileCount++}.cpuprofile`)
+        mkdir(buildDir, { recursive: true })
+          .then(() => writeFile(outPath, JSON.stringify(profile)))
+          .then(() => {
+            consola.info(`CPU profile written to ${colors.cyan(outPath)}`)
+            consola.info(`Open it in ${colors.cyan('https://www.speedscope.app')} or Chrome DevTools`)
+            session.disconnect()
+            res(outPath)
+          })
+          .catch(rej)
       })
     })
+  }
+
+  stopCpuProfileSync (buildDir: string): string | undefined {
+    const session = this.#cpuProfileSession
+    if (!session) { return }
+    this.#cpuProfileSession = undefined
+    let outPath: string | undefined
+    session.post('Profiler.stop', (_err, params) => {
+      if (_err || !params?.profile) { return }
+      outPath = join(buildDir, `profile-${this.#cpuProfileCount++}.cpuprofile`)
+      try {
+        mkdirSync(buildDir, { recursive: true })
+        writeFileSync(outPath, JSON.stringify(params.profile))
+        consola.info(`CPU profile written to ${colors.cyan(outPath)}`)
+        consola.info(`Open it in ${colors.cyan('https://www.speedscope.app')} or Chrome DevTools`)
+      } catch {
+        // don't throw an error if we can't write the file
+      }
+      session.disconnect()
+    })
+    return outPath
   }
 
   get isCpuProfileActive (): boolean {
@@ -371,7 +401,7 @@ export class NuxtPerfProfiler {
   printReport (options?: { title?: string }): void {
     const report = this.getReport()
 
-    // Sub-phases are module:* and vite:* — everything else goes in the main table
+    // Sub-phases are module:* and vite:* - everything else goes in the main table
     const isSubPhase = (name: string) => name.startsWith('module:') || name.startsWith('vite:')
     const topPhases = report.phases.filter(p => !isSubPhase(p.name))
     const subPhases = report.phases.filter(p => isSubPhase(p.name))
@@ -506,6 +536,22 @@ export class NuxtPerfProfiler {
     if (!options?.quiet) {
       consola.log(colors.dim(` Full report written to ${reportPath}`))
       consola.log('')
+    }
+    return reportPath
+  }
+
+  writeReportSync (buildDir: string, options?: { quiet?: boolean }): string {
+    const report = this.getReport()
+    const reportPath = join(buildDir, 'perf-report.json')
+    try {
+      mkdirSync(buildDir, { recursive: true })
+      writeFileSync(reportPath, JSON.stringify(report, null, 2), 'utf-8')
+      if (!options?.quiet) {
+        consola.log(colors.dim(` Full report written to ${reportPath}`))
+        consola.log('')
+      }
+    } catch {
+      // don't throw an error if we can't write the file
     }
     return reportPath
   }

--- a/packages/nuxt/src/core/perf.ts
+++ b/packages/nuxt/src/core/perf.ts
@@ -1,8 +1,7 @@
 import { performance } from 'node:perf_hooks'
 import process from 'node:process'
 import { mkdirSync, writeFileSync } from 'node:fs'
-import { mkdir, writeFile } from 'node:fs/promises'
-import { join } from 'pathe'
+import { join, relative } from 'pathe'
 import { consola } from 'consola'
 import { colors } from 'consola/utils'
 import type { Hookable } from 'hookable'
@@ -106,6 +105,26 @@ function round (n: number): number {
   return Math.round(n * 100) / 100
 }
 
+/** Chrome Trace Event format (subset used by Perfetto / chrome://tracing) */
+interface TraceEvent {
+  /** Event name */
+  name: string
+  /** Category */
+  cat: string
+  /** Phase: 'X' = complete, 'M' = metadata, 'C' = counter */
+  ph: string
+  /** Timestamp in microseconds */
+  ts: number
+  /** Duration in microseconds (for ph='X') */
+  dur?: number
+  /** Process ID */
+  pid: number
+  /** Thread ID */
+  tid: number
+  /** Arguments */
+  args?: Record<string, unknown>
+}
+
 const SLOW_HOOK_THRESHOLD_MS = Number(process.env.NUXT_PERF_SLOW_HOOK_MS) || 50
 
 const HOOK_PHASE_THRESHOLD_MS = 5
@@ -117,9 +136,12 @@ export class NuxtPerfProfiler {
   #hookStartStack: Array<{ name: string, time: number, memory: MemorySnapshot }> = []
   #modules: ModuleTiming[] = []
   #bundlerPluginTimings = new Map<string, Map<string, { totalTime: number, count: number, maxTime: number }>>()
+  #bundlerPluginSpans: Array<{ pluginName: string, hookName: string, startTime: number, durationMs: number }> = []
   #globalStart: number
   #globalMemoryBefore: MemorySnapshot
   #unsubscribe?: () => void
+  /** Offset to convert performance.now() (ms) to epoch microseconds for trace events */
+  #baseTs: number
 
   constructor (options?: { startTime?: number }) {
     if (options?.startTime) {
@@ -129,6 +151,8 @@ export class NuxtPerfProfiler {
       this.#globalStart = performance.now()
     }
     this.#globalMemoryBefore = getMemorySnapshot()
+    // Compute offset: epoch_us = (performance.now() * 1000) + baseTs
+    this.#baseTs = Date.now() * 1000 - this.#globalStart * 1000
   }
 
   installHookInterceptors (hooks: Hookable<NuxtHooks>): void {
@@ -215,7 +239,7 @@ export class NuxtPerfProfiler {
     })
   }
 
-  recordBundlerPluginHook (pluginName: string, hookName: string, durationMs: number): void {
+  recordBundlerPluginHook (pluginName: string, hookName: string, durationMs: number, startTime?: number): void {
     let plugin = this.#bundlerPluginTimings.get(pluginName)
     if (!plugin) {
       plugin = new Map()
@@ -228,6 +252,10 @@ export class NuxtPerfProfiler {
       if (durationMs > entry.maxTime) { entry.maxTime = durationMs }
     } else {
       plugin.set(hookName, { totalTime: durationMs, count: 1, maxTime: durationMs })
+    }
+    // Store per-invocation span for trace file (only if startTime provided and duration significant)
+    if (startTime != null && durationMs > 0.1) {
+      this.#bundlerPluginSpans.push({ pluginName, hookName, startTime, durationMs })
     }
   }
 
@@ -469,26 +497,163 @@ export class NuxtPerfProfiler {
     }
   }
 
-  async writeReport (buildDir: string, options?: { quiet?: boolean }): Promise<string> {
-    const report = this.getReport()
-    const reportPath = join(buildDir, 'perf-report.json')
-    await mkdir(buildDir, { recursive: true })
-    await writeFile(reportPath, JSON.stringify(report, null, 2), 'utf-8')
-    if (!options?.quiet) {
-      consola.log(colors.dim(` Full report written to ${reportPath}`))
-      consola.log('')
+  /**
+   * Generate trace events in Chrome Trace Event format.
+   * The output can be loaded in chrome://tracing or https://ui.perfetto.dev
+   */
+  getTraceEvents (): TraceEvent[] {
+    const events: TraceEvent[] = []
+    const pid = 1
+    const tidPhases = 1
+    const tidHooks = 2
+    // Bundler plugin spans use dynamic tids starting from this base
+    const tidPluginBase = 10
+
+    /** Convert performance.now() (ms) to epoch microseconds (integer) */
+    const toUs = (ms: number) => Math.round(ms * 1000 + this.#baseTs)
+
+    // Process/thread metadata
+    events.push(
+      { name: 'process_name', ph: 'M', ts: 0, pid, tid: 0, cat: '', args: { name: 'Nuxt Build' } },
+      { name: 'thread_name', ph: 'M', ts: 0, pid, tid: tidPhases, cat: '', args: { name: 'Build' } },
+      { name: 'thread_name', ph: 'M', ts: 0, pid, tid: tidHooks, cat: '', args: { name: 'Hooks' } },
+    )
+
+    /** Convert ms duration to integer microseconds */
+    const durUs = (ms: number) => Math.round(ms * 1000)
+
+    // Root span using B/E (begin/end) pair so nested phases display correctly
+    const globalEnd = performance.now()
+    events.push(
+      { name: 'nuxt build', cat: 'build', ph: 'B', ts: toUs(this.#globalStart), pid, tid: tidPhases },
+      { name: 'nuxt build', cat: 'build', ph: 'E', ts: toUs(globalEnd), pid, tid: tidPhases },
+    )
+
+    // Manual phases as B/E pairs (they nest: e.g. module:* inside modules, vite:* inside build:bundle)
+    for (const phase of this.#phases) {
+      events.push(
+        {
+          name: phase.name,
+          cat: 'phase',
+          ph: 'B',
+          ts: toUs(phase.startTime),
+          pid,
+          tid: tidPhases,
+          args: {
+            memoryBefore: { rss: phase.memoryBefore.rss, heapUsed: phase.memoryBefore.heapUsed },
+          },
+        },
+        {
+          name: phase.name,
+          cat: 'phase',
+          ph: 'E',
+          ts: toUs(phase.endTime),
+          pid,
+          tid: tidPhases,
+          args: {
+            memoryDelta: { rss: phase.memoryDelta.rss, heapUsed: phase.memoryDelta.heapUsed },
+          },
+        },
+      )
     }
-    return reportPath
+
+    // Hook invocations as B/E pairs (hooks can nest when one hook triggers another)
+    for (const hp of this.#hookPhases) {
+      const name = hp.name.startsWith('hook:') ? hp.name.slice(5) : hp.name
+      events.push(
+        { name, cat: 'hook', ph: 'B', ts: toUs(hp.startTime), pid, tid: tidHooks },
+        { name, cat: 'hook', ph: 'E', ts: toUs(hp.endTime), pid, tid: tidHooks },
+      )
+    }
+
+    // Bundler plugin per-invocation spans
+    // These can overlap (parallel transforms), so we assign dynamic thread IDs.
+    // Group by prefix (vite vs nitro) and use a simple lane allocator per group.
+    const viteSpans = this.#bundlerPluginSpans.filter(s => !s.pluginName.startsWith('nitro:'))
+    const nitroSpans = this.#bundlerPluginSpans.filter(s => s.pluginName.startsWith('nitro:'))
+
+    const emitPluginSpans = (spans: typeof viteSpans, label: string, baseTid: number) => {
+      if (spans.length === 0) { return }
+      // Sort by start time for lane allocation
+      const sorted = [...spans].sort((a, b) => a.startTime - b.startTime)
+      // Each lane tracks when it becomes free (end time in ms)
+      const laneEnds: number[] = []
+
+      for (const span of sorted) {
+        const endTime = span.startTime + span.durationMs
+        // Find a lane that's free (strictly ended before this span starts)
+        let lane = laneEnds.findIndex(end => end < span.startTime)
+        if (lane === -1) {
+          lane = laneEnds.length
+          laneEnds.push(0)
+        }
+        laneEnds[lane] = endTime
+
+        const tid = baseTid + lane
+        events.push({
+          name: `${span.pluginName}:${span.hookName}`,
+          cat: label,
+          ph: 'X',
+          ts: toUs(span.startTime),
+          dur: durUs(span.durationMs),
+          pid,
+          tid,
+        })
+      }
+
+      // Add thread name metadata for each lane used
+      for (let i = 0; i < laneEnds.length; i++) {
+        const suffix = laneEnds.length > 1 ? ` ${i + 1}` : ''
+        events.push({
+          name: 'thread_name', ph: 'M', ts: 0, pid, tid: baseTid + i, cat: '',
+          args: { name: `${label}${suffix}` },
+        })
+      }
+    }
+
+    emitPluginSpans(viteSpans, 'Vite Plugins', tidPluginBase)
+    emitPluginSpans(nitroSpans, 'Nitro Plugins', tidPluginBase + 100)
+
+    // Memory counter events at phase boundaries
+    for (const phase of this.#phases) {
+      events.push(
+        {
+          name: 'Memory',
+          cat: 'memory',
+          ph: 'C',
+          ts: toUs(phase.startTime),
+          pid,
+          tid: 0,
+          args: { rss: phase.memoryBefore.rss, heapUsed: phase.memoryBefore.heapUsed },
+        },
+        {
+          name: 'Memory',
+          cat: 'memory',
+          ph: 'C',
+          ts: toUs(phase.endTime),
+          pid,
+          tid: 0,
+          args: { rss: phase.memoryAfter.rss, heapUsed: phase.memoryAfter.heapUsed },
+        },
+      )
+    }
+
+    return events
   }
 
-  writeReportSync (buildDir: string, options?: { quiet?: boolean }): string {
+  writeReport (buildDir: string, options?: { quiet?: boolean }): string {
     const report = this.getReport()
     const reportPath = join(buildDir, 'perf-report.json')
+    const relativeReportPath = relative(process.cwd(), reportPath).replace(/^(?![^.]{1,2}\/)/, './')
+    const tracePath = join(buildDir, 'perf-trace.json')
+    const relativeTracePath = relative(process.cwd(), tracePath).replace(/^(?![^.]{1,2}\/)/, './')
     try {
       mkdirSync(buildDir, { recursive: true })
       writeFileSync(reportPath, JSON.stringify(report, null, 2), 'utf-8')
+      writeFileSync(tracePath, JSON.stringify({ traceEvents: this.getTraceEvents() }), 'utf-8')
       if (!options?.quiet) {
-        consola.log(colors.dim(` Full report written to ${reportPath}`))
+        consola.log(colors.dim(` Data dump written to ${relativeReportPath}`))
+        consola.log(colors.dim(` Trace written to ${relativeTracePath} (load in \`https://ui.perfetto.dev\`)`))
         consola.log('')
       }
     } catch {

--- a/packages/nuxt/src/core/perf.ts
+++ b/packages/nuxt/src/core/perf.ts
@@ -121,8 +121,6 @@ export class NuxtPerfProfiler {
   #globalStart: number
   #globalMemoryBefore: MemorySnapshot
   #unsubscribe?: () => void
-  #cpuProfileSession?: import('node:inspector').Session
-  #cpuProfileCount = 0
 
   constructor (options?: { startTime?: number }) {
     if (options?.startTime) {
@@ -132,67 +130,6 @@ export class NuxtPerfProfiler {
       this.#globalStart = performance.now()
     }
     this.#globalMemoryBefore = getMemorySnapshot()
-  }
-
-  async startCpuProfile (): Promise<void> {
-    const inspector = await import('node:inspector')
-    const session = new inspector.Session()
-    session.connect()
-    await new Promise<void>((res, rej) => {
-      session.post('Profiler.enable', () => {
-        session.post('Profiler.start', (err) => {
-          if (err) { rej(err) } else { res() }
-        })
-      })
-    })
-    this.#cpuProfileSession = session
-    consola.info('CPU profiler started')
-  }
-
-  stopCpuProfile (buildDir: string): Promise<string | undefined> {
-    const session = this.#cpuProfileSession
-    if (!session) { return Promise.resolve(undefined) }
-    this.#cpuProfileSession = undefined
-    return new Promise((res, rej) => {
-      session.post('Profiler.stop', (err, { profile }) => {
-        if (err) { return rej(err) }
-        const outPath = join(buildDir, `profile-${this.#cpuProfileCount++}.cpuprofile`)
-        mkdir(buildDir, { recursive: true })
-          .then(() => writeFile(outPath, JSON.stringify(profile)))
-          .then(() => {
-            consola.info(`CPU profile written to ${colors.cyan(outPath)}`)
-            consola.info(`Open it in ${colors.cyan('https://www.speedscope.app')} or Chrome DevTools`)
-            session.disconnect()
-            res(outPath)
-          })
-          .catch(rej)
-      })
-    })
-  }
-
-  stopCpuProfileSync (buildDir: string): string | undefined {
-    const session = this.#cpuProfileSession
-    if (!session) { return }
-    this.#cpuProfileSession = undefined
-    let outPath: string | undefined
-    session.post('Profiler.stop', (_err, params) => {
-      if (_err || !params?.profile) { return }
-      outPath = join(buildDir, `profile-${this.#cpuProfileCount++}.cpuprofile`)
-      try {
-        mkdirSync(buildDir, { recursive: true })
-        writeFileSync(outPath, JSON.stringify(params.profile))
-        consola.info(`CPU profile written to ${colors.cyan(outPath)}`)
-        consola.info(`Open it in ${colors.cyan('https://www.speedscope.app')} or Chrome DevTools`)
-      } catch {
-        // don't throw an error if we can't write the file
-      }
-      session.disconnect()
-    })
-    return outPath
-  }
-
-  get isCpuProfileActive (): boolean {
-    return !!this.#cpuProfileSession
   }
 
   installHookInterceptors (hooks: Hookable<NuxtHooks>): void {
@@ -554,42 +491,6 @@ export class NuxtPerfProfiler {
       // don't throw an error if we can't write the file
     }
     return reportPath
-  }
-
-  printSessionSummary (): void {
-    const report = this.getReport()
-    const elapsed = formatDuration(report.totalDuration)
-
-    consola.log('')
-    consola.log(colors.bold(colors.cyan(' Nuxt Session Summary')))
-    consola.log('')
-    consola.log(`  ${colors.dim('Session duration:')} ${elapsed}`)
-    consola.log(`  ${colors.dim('Memory:')} ${(report.totalMemoryDelta.rss >= 0 ? '+' : '') + formatBytes(report.totalMemoryDelta.rss)} RSS, ${(report.totalMemoryDelta.heapUsed >= 0 ? '+' : '') + formatBytes(report.totalMemoryDelta.heapUsed)} heap`)
-    consola.log('')
-
-    if (report.bundlerPlugins.length > 0) {
-      const rows: Array<{ plugin: string, hook: string, timing: PluginHookTiming }> = []
-      for (const plugin of report.bundlerPlugins) {
-        for (const [hook, timing] of Object.entries(plugin.hooks)) {
-          if (timing.avgTime > 0.5) {
-            rows.push({ plugin: plugin.name, hook, timing })
-          }
-        }
-      }
-      rows.sort((a, b) => b.timing.avgTime - a.timing.avgTime)
-
-      if (rows.length > 0) {
-        consola.log(colors.bold(` Bundler Plugins (session total)`))
-        consola.log('')
-        for (const { plugin, hook, timing } of rows.slice(0, 15)) {
-          const durColor = timing.avgTime > 10 ? colors.red : timing.avgTime > 2 ? colors.yellow : colors.dim
-          const avgLabel = formatDuration(timing.avgTime) + '/file'
-          const maxLabel = timing.maxTime > timing.avgTime * 2 ? `, max ${formatDuration(timing.maxTime)}` : ''
-          consola.log(`  ${colors.dim('•')} ${plugin} ${colors.dim(hook)} ${colors.dim('—')} ${durColor(avgLabel)}${colors.dim(maxLabel)} ${colors.dim(`(${timing.count} calls)`)}`)
-        }
-        consola.log('')
-      }
-    }
   }
 
   dispose (): void {

--- a/packages/nuxt/src/core/perf.ts
+++ b/packages/nuxt/src/core/perf.ts
@@ -1,7 +1,7 @@
 import { performance } from 'node:perf_hooks'
 import process from 'node:process'
 import { mkdir, writeFile } from 'node:fs/promises'
-import { join } from 'pathe'
+import { join, resolve } from 'pathe'
 import { consola } from 'consola'
 import { colors } from 'consola/utils'
 import type { Hookable } from 'hookable'
@@ -120,10 +120,49 @@ export class NuxtPerfProfiler {
   #globalStart: number
   #globalMemoryBefore: MemorySnapshot
   #unsubscribe?: () => void
+  #cpuProfileSession?: import('node:inspector').Session
+  #cpuProfileCount = 0
 
   constructor () {
     this.#globalStart = performance.now()
     this.#globalMemoryBefore = getMemorySnapshot()
+  }
+
+  async startCpuProfile (): Promise<void> {
+    const inspector = await import('node:inspector')
+    const session = new inspector.Session()
+    session.connect()
+    await new Promise<void>((res, rej) => {
+      session.post('Profiler.enable', () => {
+        session.post('Profiler.start', (err) => {
+          if (err) { rej(err) } else { res() }
+        })
+      })
+    })
+    this.#cpuProfileSession = session
+    consola.info('CPU profiler started')
+  }
+
+  stopCpuProfile (cwd?: string): Promise<string | undefined> {
+    const session = this.#cpuProfileSession
+    if (!session) { return Promise.resolve(undefined) }
+    this.#cpuProfileSession = undefined
+    return new Promise((res, rej) => {
+      session.post('Profiler.stop', (err, { profile }) => {
+        if (err) { return rej(err) }
+        const outPath = resolve(cwd || '.', `nuxt-profile-${this.#cpuProfileCount++}.cpuprofile`)
+        writeFile(outPath, JSON.stringify(profile)).then(() => {
+          consola.info(`CPU profile written to ${colors.cyan(outPath)}`)
+          consola.info(`Open it in ${colors.cyan('https://www.speedscope.app')} or Chrome DevTools`)
+          session.disconnect()
+          res(outPath)
+        }).catch(rej)
+      })
+    })
+  }
+
+  get isCpuProfileActive (): boolean {
+    return !!this.#cpuProfileSession
   }
 
   installHookInterceptors (hooks: Hookable<NuxtHooks>): void {
@@ -255,19 +294,31 @@ export class NuxtPerfProfiler {
     // Compute own-time and own-memory for each phase by subtracting
     // child phases nested inside it.
     function computeOwn (phase: PerfPhase) {
+      // Find direct children: phases nested inside this one that aren't
+      // themselves nested inside another child (to avoid double-subtraction).
+      const children = allPhases.filter(other =>
+        other !== phase
+        && other.startTime >= phase.startTime
+        && other.endTime <= phase.endTime,
+      )
+      const directChildren = children.filter(child =>
+        !children.some(other =>
+          other !== child
+          && child.startTime >= other.startTime
+          && child.endTime <= other.endTime,
+        ),
+      )
+
       let childTime = 0
       let childRss = 0
       let childHeap = 0
-      for (const other of allPhases) {
-        if (other === phase) { continue }
-        if (other.startTime >= phase.startTime && other.endTime <= phase.endTime) {
-          childTime += other.duration
-          childRss += other.memoryDelta.rss
-          childHeap += other.memoryDelta.heapUsed
-        }
+      for (const child of directChildren) {
+        childTime += child.duration
+        childRss += child.memoryDelta.rss
+        childHeap += child.memoryDelta.heapUsed
       }
       return {
-        ownDuration: round(phase.duration - childTime),
+        ownDuration: round(Math.max(0, phase.duration - childTime)),
         ownMemoryDelta: {
           rss: phase.memoryDelta.rss - childRss,
           heapUsed: phase.memoryDelta.heapUsed - childHeap,
@@ -346,16 +397,32 @@ export class NuxtPerfProfiler {
     const separator = '  ' + colors.dim('─'.repeat(colPhase + colDuration + colRss + colHeap + 6))
     consola.log(separator)
 
+    const maxRss = Math.max(...topPhases.map(p => Math.abs(p.ownMemoryDelta.rss)), 1)
+    const barMax = 20
+
     for (const phase of topPhases) {
       const dur = phase.ownDuration
       const rss = phase.ownMemoryDelta.rss
       const heap = phase.ownMemoryDelta.heapUsed
-      const barWidth = Math.max(1, Math.round((dur / maxDuration) * 12))
-      const bar = colors.green('█'.repeat(barWidth))
+
+      // Duration bar: log scale so small phases are still visible next to dominant ones
+      const durBar = dur > 0
+        ? Math.max(1, Math.round((Math.log(dur + 1) / Math.log(maxDuration + 1)) * (barMax / 2)))
+        : 0
+      // Memory bar: proportional to RSS delta
+      const memBar = Math.abs(rss) > 0
+        ? Math.max(0, Math.round((Math.abs(rss) / maxRss) * (barMax / 2)))
+        : 0
+
+      const durColor = dur > 1000 ? colors.red : dur > 200 ? colors.yellow : colors.green
+      const memColor = Math.abs(rss) > 50 * 1024 * 1024 ? colors.red : Math.abs(rss) > 10 * 1024 * 1024 ? colors.yellow : colors.green
+
+      const bar = durColor('█'.repeat(durBar)) + memColor('░'.repeat(memBar))
+
       const row = [
         pad(phase.name, colPhase),
-        pad(formatDuration(dur), colDuration, 'right'),
-        pad((rss >= 0 ? '+' : '') + formatBytes(rss), colRss, 'right'),
+        pad(durColor(formatDuration(dur)), colDuration, 'right'),
+        pad(memColor((rss >= 0 ? '+' : '') + formatBytes(rss)), colRss, 'right'),
         pad((heap >= 0 ? '+' : '') + formatBytes(heap), colHeap, 'right'),
       ].join('  ')
       consola.log(`  ${row}  ${bar}`)
@@ -441,6 +508,42 @@ export class NuxtPerfProfiler {
       consola.log('')
     }
     return reportPath
+  }
+
+  printSessionSummary (): void {
+    const report = this.getReport()
+    const elapsed = formatDuration(report.totalDuration)
+
+    consola.log('')
+    consola.log(colors.bold(colors.cyan(' Nuxt Session Summary')))
+    consola.log('')
+    consola.log(`  ${colors.dim('Session duration:')} ${elapsed}`)
+    consola.log(`  ${colors.dim('Memory:')} ${(report.totalMemoryDelta.rss >= 0 ? '+' : '') + formatBytes(report.totalMemoryDelta.rss)} RSS, ${(report.totalMemoryDelta.heapUsed >= 0 ? '+' : '') + formatBytes(report.totalMemoryDelta.heapUsed)} heap`)
+    consola.log('')
+
+    if (report.bundlerPlugins.length > 0) {
+      const rows: Array<{ plugin: string, hook: string, timing: PluginHookTiming }> = []
+      for (const plugin of report.bundlerPlugins) {
+        for (const [hook, timing] of Object.entries(plugin.hooks)) {
+          if (timing.avgTime > 0.5) {
+            rows.push({ plugin: plugin.name, hook, timing })
+          }
+        }
+      }
+      rows.sort((a, b) => b.timing.avgTime - a.timing.avgTime)
+
+      if (rows.length > 0) {
+        consola.log(colors.bold(` Bundler Plugins (session total)`))
+        consola.log('')
+        for (const { plugin, hook, timing } of rows.slice(0, 15)) {
+          const durColor = timing.avgTime > 10 ? colors.red : timing.avgTime > 2 ? colors.yellow : colors.dim
+          const avgLabel = formatDuration(timing.avgTime) + '/file'
+          const maxLabel = timing.maxTime > timing.avgTime * 2 ? `, max ${formatDuration(timing.maxTime)}` : ''
+          consola.log(`  ${colors.dim('•')} ${plugin} ${colors.dim(hook)} ${colors.dim('—')} ${durColor(avgLabel)}${colors.dim(maxLabel)} ${colors.dim(`(${timing.count} calls)`)}`)
+        }
+        consola.log('')
+      }
+    }
   }
 
   dispose (): void {

--- a/packages/nuxt/src/core/perf.ts
+++ b/packages/nuxt/src/core/perf.ts
@@ -114,8 +114,7 @@ export class NuxtPerfProfiler {
   #phases: PerfPhase[] = []
   #phaseStack: OpenPhase[] = []
   #hookPhases: PerfPhase[] = []
-  #hookStarts = new Map<string, { time: number, memory: MemorySnapshot }>()
-  #hookStack: string[] = []
+  #hookStartStack: Array<{ name: string, time: number, memory: MemorySnapshot }> = []
   #modules: ModuleTiming[] = []
   #bundlerPluginTimings = new Map<string, Map<string, { totalTime: number, count: number, maxTime: number }>>()
   #globalStart: number
@@ -134,18 +133,23 @@ export class NuxtPerfProfiler {
 
   installHookInterceptors (hooks: Hookable<NuxtHooks>): void {
     const unsubBefore = hooks.beforeEach((event) => {
-      this.#hookStarts.set(event.name, {
+      this.#hookStartStack.push({
+        name: event.name,
         time: performance.now(),
         memory: getMemorySnapshot(),
       })
-      this.#hookStack.push(event.name)
     })
 
     const unsubAfter = hooks.afterEach((event) => {
-      const start = this.#hookStarts.get(event.name)
-      if (!start) { return }
-      this.#hookStarts.delete(event.name)
-      this.#hookStack.pop()
+      let startIdx = -1
+      for (let i = this.#hookStartStack.length - 1; i >= 0; i--) {
+        if (this.#hookStartStack[i]!.name === event.name) {
+          startIdx = i
+          break
+        }
+      }
+      if (startIdx === -1) { return }
+      const start = this.#hookStartStack.splice(startIdx, 1)[0]!
 
       const endTime = performance.now()
       const memoryAfter = getMemorySnapshot()

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -130,10 +130,20 @@ export default defineResolvers({
           nitro: true,
           router: true,
           hydration: true,
+          perf: true,
         } satisfies Required<NuxtDebugOptions>
       }
       if (val && typeof val === 'object') {
+        // Support NUXT_DEBUG_PERF env var to enable perf profiling
+        if (process.env.NUXT_DEBUG_PERF) {
+          (val as NuxtDebugOptions).perf = process.env.NUXT_DEBUG_PERF === 'quiet' ? 'quiet' : true
+        }
         return val
+      }
+      // Support NUXT_DEBUG_PERF env var without other debug options
+      if (process.env.NUXT_DEBUG_PERF) {
+        const perf: boolean | 'quiet' = process.env.NUXT_DEBUG_PERF === 'quiet' ? 'quiet' : true
+        return { perf } satisfies Partial<NuxtDebugOptions>
       }
       return false
     },

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -130,7 +130,7 @@ export default defineResolvers({
           nitro: true,
           router: true,
           hydration: true,
-          perf: true,
+          perf: process.env.NUXT_DEBUG_PERF === 'quiet' ? 'quiet' : true,
         } satisfies Required<NuxtDebugOptions>
       }
       if (val && typeof val === 'object') {

--- a/packages/schema/src/types/debug.ts
+++ b/packages/schema/src/types/debug.ts
@@ -33,12 +33,14 @@ export interface NuxtDebugOptions {
     client?: boolean
   }
   /**
-   * Profile startup/build performance and write a report to `.nuxt/perf-report.json`.
+   * Profile startup/build performance.
    *
-   * - `true` — collect data, print a console summary, and write JSON
-   * - `'quiet'` — collect data and write JSON only (no console output)
+   * - `true` — full report printed to console, JSON + `.cpuprofile` written on exit
+   * - `'quiet'` — JSON + `.cpuprofile` written on exit with no console output
    *
-   * Can also be activated via `NUXT_DEBUG_PERF=1` (or `=quiet`) or `nuxt dev --profile`.
+   * Activated via `nuxi dev --profile=verbose`, `nuxi dev --profile` (quiet),
+   * `NUXT_DEBUG_PERF=1` (or `=quiet`), or `debug: { perf: true }` in nuxt.config.
+   * @since 4.4.0
    */
   perf?: boolean | 'quiet'
 }

--- a/packages/schema/src/types/debug.ts
+++ b/packages/schema/src/types/debug.ts
@@ -32,4 +32,13 @@ export interface NuxtDebugOptions {
     server?: boolean
     client?: boolean
   }
+  /**
+   * Profile startup/build performance and write a report to `.nuxt/perf-report.json`.
+   *
+   * - `true` — collect data, print a console summary, and write JSON
+   * - `'quiet'` — collect data and write JSON only (no console output)
+   *
+   * Can also be activated via `NUXT_DEBUG_PERF=1` (or `=quiet`) or `nuxt dev --profile`.
+   */
+  perf?: boolean | 'quiet'
 }

--- a/packages/schema/src/types/nuxt.ts
+++ b/packages/schema/src/types/nuxt.ts
@@ -94,6 +94,19 @@ export interface Nuxt {
   '_dependencies'?: Set<string>
   '~runtimeDependencies'?: string[]
   '_debug'?: NuxtDebugContext
+  /**
+   * Performance profiler instance, available when `debug.perf` is enabled.
+   * @internal
+   */
+  '_perf'?: {
+    startPhase: (name: string) => void
+    endPhase: (name?: string) => void
+    collectModuleTimings: (modules: Array<{ meta?: { name?: string }, timings?: Record<string, number | undefined> }>) => void
+    recordBundlerPluginHook: (pluginName: string, hookName: string, durationMs: number) => void
+    printReport: (options?: { title?: string }) => void
+    writeReport: (buildDir: string, options?: { quiet?: boolean }) => Promise<string>
+    dispose: () => void
+  }
   /** Async local storage for current running Nuxt module instance. */
   '_asyncLocalStorageModule'?: AsyncLocalStorage<NuxtModule>
   /**

--- a/packages/schema/src/types/nuxt.ts
+++ b/packages/schema/src/types/nuxt.ts
@@ -103,7 +103,11 @@ export interface Nuxt {
     endPhase: (name?: string) => void
     collectModuleTimings: (modules: Array<{ meta?: { name?: string }, timings?: Record<string, number | undefined> }>) => void
     recordBundlerPluginHook: (pluginName: string, hookName: string, durationMs: number) => void
+    startCpuProfile: () => Promise<void>
+    stopCpuProfile: (cwd?: string) => Promise<string | undefined>
+    isCpuProfileActive: boolean
     printReport: (options?: { title?: string }) => void
+    printSessionSummary: () => void
     writeReport: (buildDir: string, options?: { quiet?: boolean }) => Promise<string>
     dispose: () => void
   }

--- a/packages/schema/src/types/nuxt.ts
+++ b/packages/schema/src/types/nuxt.ts
@@ -102,10 +102,9 @@ export interface Nuxt {
     startPhase: (name: string) => void
     endPhase: (name?: string) => void
     collectModuleTimings: (modules: Array<{ meta?: { name?: string }, timings?: Record<string, number | undefined> }>) => void
-    recordBundlerPluginHook: (pluginName: string, hookName: string, durationMs: number) => void
+    recordBundlerPluginHook: (pluginName: string, hookName: string, durationMs: number, startTime?: number) => void
     printReport: (options?: { title?: string }) => void
-    writeReport: (buildDir: string, options?: { quiet?: boolean }) => Promise<string>
-    writeReportSync: (buildDir: string, options?: { quiet?: boolean }) => string
+    writeReport: (buildDir: string, options?: { quiet?: boolean }) => string
     dispose: () => void
   }
   /** Async local storage for current running Nuxt module instance. */

--- a/packages/schema/src/types/nuxt.ts
+++ b/packages/schema/src/types/nuxt.ts
@@ -104,11 +104,13 @@ export interface Nuxt {
     collectModuleTimings: (modules: Array<{ meta?: { name?: string }, timings?: Record<string, number | undefined> }>) => void
     recordBundlerPluginHook: (pluginName: string, hookName: string, durationMs: number) => void
     startCpuProfile: () => Promise<void>
-    stopCpuProfile: (cwd?: string) => Promise<string | undefined>
+    stopCpuProfile: (buildDir: string) => Promise<string | undefined>
+    stopCpuProfileSync: (buildDir: string) => string | undefined
     isCpuProfileActive: boolean
     printReport: (options?: { title?: string }) => void
     printSessionSummary: () => void
     writeReport: (buildDir: string, options?: { quiet?: boolean }) => Promise<string>
+    writeReportSync: (buildDir: string, options?: { quiet?: boolean }) => string
     dispose: () => void
   }
   /** Async local storage for current running Nuxt module instance. */

--- a/packages/schema/src/types/nuxt.ts
+++ b/packages/schema/src/types/nuxt.ts
@@ -103,12 +103,7 @@ export interface Nuxt {
     endPhase: (name?: string) => void
     collectModuleTimings: (modules: Array<{ meta?: { name?: string }, timings?: Record<string, number | undefined> }>) => void
     recordBundlerPluginHook: (pluginName: string, hookName: string, durationMs: number) => void
-    startCpuProfile: () => Promise<void>
-    stopCpuProfile: (buildDir: string) => Promise<string | undefined>
-    stopCpuProfileSync: (buildDir: string) => string | undefined
-    isCpuProfileActive: boolean
     printReport: (options?: { title?: string }) => void
-    printSessionSummary: () => void
     writeReport: (buildDir: string, options?: { quiet?: boolean }) => Promise<string>
     writeReportSync: (buildDir: string, options?: { quiet?: boolean }) => string
     dispose: () => void

--- a/packages/vite/src/plugins/perf.ts
+++ b/packages/vite/src/plugins/perf.ts
@@ -39,7 +39,7 @@ function wrapPluginHook (plugin: Plugin, pluginName: string, hookName: string, n
 
 function timedCall (fn: (...a: any[]) => any, ctx: any, args: any[], pluginName: string, hookName: string, nuxt: Nuxt): any {
   const start = performance.now()
-  const record = () => nuxt._perf?.recordBundlerPluginHook(pluginName, hookName, performance.now() - start)
+  const record = () => nuxt._perf?.recordBundlerPluginHook(pluginName, hookName, performance.now() - start, start)
   try {
     const result = fn.apply(ctx, args)
     if (result && typeof result === 'object' && 'then' in result) {

--- a/packages/vite/src/plugins/perf.ts
+++ b/packages/vite/src/plugins/perf.ts
@@ -41,13 +41,16 @@ function wrapPluginHook (plugin: Plugin, pluginName: string, hookName: string, n
 
 function timedCall (fn: (...a: any[]) => any, ctx: any, args: any[], pluginName: string, hookName: string, nuxt: Nuxt): any {
   const start = performance.now()
-  const result = fn.apply(ctx, args)
-  if (result && typeof result === 'object' && 'then' in result) {
-    return (result as Promise<any>).then((v: any) => {
-      nuxt._perf?.recordBundlerPluginHook(pluginName, hookName, performance.now() - start)
-      return v
-    })
+  const record = () => nuxt._perf?.recordBundlerPluginHook(pluginName, hookName, performance.now() - start)
+  try {
+    const result = fn.apply(ctx, args)
+    if (result && typeof result === 'object' && 'then' in result) {
+      return (result as Promise<any>).finally(record)
+    }
+    record()
+    return result
+  } catch (err) {
+    record()
+    throw err
   }
-  nuxt._perf?.recordBundlerPluginHook(pluginName, hookName, performance.now() - start)
-  return result
 }

--- a/packages/vite/src/plugins/perf.ts
+++ b/packages/vite/src/plugins/perf.ts
@@ -26,10 +26,8 @@ function wrapPluginHook (plugin: Plugin, pluginName: string, hookName: string, n
   if (!original) { return }
 
   if (typeof original === 'function') {
-    ;(plugin as any)[hookName] = {
-      handler (...args: any[]) {
-        return timedCall(original as (...a: any[]) => any, this, args, pluginName, hookName, nuxt)
-      },
+    ;(plugin as any)[hookName] = function (this: any, ...args: any[]) {
+      return timedCall(original as (...a: any[]) => any, this, args, pluginName, hookName, nuxt)
     }
   } else if (typeof original === 'object' && 'handler' in original) {
     const originalHandler = original.handler

--- a/packages/vite/src/plugins/perf.ts
+++ b/packages/vite/src/plugins/perf.ts
@@ -1,0 +1,53 @@
+import { performance } from 'node:perf_hooks'
+import type { Nuxt } from '@nuxt/schema'
+import type { Plugin } from 'vite'
+
+const HOOKS_TO_TRACK = ['transform', 'resolveId', 'load'] as const
+
+export function PerfPlugin (nuxt: Nuxt): Plugin {
+  return {
+    name: 'nuxt:perf',
+    enforce: 'pre',
+    apply: () => !!nuxt?._perf,
+    configResolved (config) {
+      for (const plugin of config.plugins) {
+        if (plugin.name === 'nuxt:perf') { continue }
+        const pluginName = plugin.name
+        for (const hookName of HOOKS_TO_TRACK) {
+          wrapPluginHook(plugin, pluginName, hookName, nuxt)
+        }
+      }
+    },
+  }
+}
+
+function wrapPluginHook (plugin: Plugin, pluginName: string, hookName: string, nuxt: Nuxt): void {
+  const original = plugin[hookName as keyof Plugin]
+  if (!original) { return }
+
+  if (typeof original === 'function') {
+    ;(plugin as any)[hookName] = {
+      handler (...args: any[]) {
+        return timedCall(original as (...a: any[]) => any, this, args, pluginName, hookName, nuxt)
+      },
+    }
+  } else if (typeof original === 'object' && 'handler' in original) {
+    const originalHandler = original.handler
+    original.handler = function (...args: any[]) {
+      return timedCall(originalHandler, this, args, pluginName, hookName, nuxt)
+    }
+  }
+}
+
+function timedCall (fn: (...a: any[]) => any, ctx: any, args: any[], pluginName: string, hookName: string, nuxt: Nuxt): any {
+  const start = performance.now()
+  const result = fn.apply(ctx, args)
+  if (result && typeof result === 'object' && 'then' in result) {
+    return (result as Promise<any>).then((v: any) => {
+      nuxt._perf?.recordBundlerPluginHook(pluginName, hookName, performance.now() - start)
+      return v
+    })
+  }
+  nuxt._perf?.recordBundlerPluginHook(pluginName, hookName, performance.now() - start)
+  return result
+}

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -38,6 +38,7 @@ import { ViteNodePlugin, writeDevServer } from './plugins/vite-node.ts'
 import { ClientManifestPlugin } from './plugins/client-manifest.ts'
 import { ResolveDeepImportsPlugin } from './plugins/resolve-deep-imports.ts'
 import { ResolveExternalsPlugin } from './plugins/resolved-externals.ts'
+import { PerfPlugin } from './plugins/perf.ts'
 
 export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
   const useAsyncEntry = nuxt.options.experimental.asyncEntry || nuxt.options.dev
@@ -114,7 +115,9 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
           const environments = Object.values(builder.environments)
           for (const environment of environments) {
             logger.restoreAll()
+            nuxt._perf?.startPhase(`vite:${environment.name}`)
             await builder.build(environment)
+            nuxt._perf?.endPhase(`vite:${environment.name}`)
             logger.wrapAll()
             await nuxt.callHook('vite:compiled')
           }
@@ -176,6 +179,8 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
         watch: { exclude: [...nuxt.options.ignore, /[\\/]node_modules[\\/]/] },
       },
       plugins: [
+        // per-plugin timing when profiling is enabled
+        PerfPlugin(nuxt),
         // add resolver for modules used in virtual files
         ResolveDeepImportsPlugin(nuxt),
         ResolveExternalsPlugin(nuxt),
@@ -261,10 +266,12 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
     return
   }
 
+  nuxt._perf?.startPhase('vite:dev-server')
   await withLogs(async () => {
     const server = await createServer(config)
     await server.environments.ssr.pluginContainer.buildStart({})
   }, 'Vite dev server built')
+  nuxt._perf?.endPhase('vite:dev-server')
 
   await writeDevServer(nuxt)
 }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

you can test with:

```shell
NUXT_DEBUG_PERF=1 pnpm nuxt build
```

<details>
<summary>this produces a report that looks like this after a build:</summary>

```
                                                                                                                12:15:38 PM
 Nuxt Build Performance                                                                                         12:15:38 PM
                                                                                                                12:15:38 PM
  Phase                       Duration       RSS Delta      Heap Delta                                          12:15:38 PM
  ────────────────────────────────────────────────────────────────────                                          12:15:38 PM
  config                           7ms       +144.0 KB         +3.5 MB  █                                       12:15:38 PM
  init                             2ms       +208.0 KB       +759.1 KB  █                                       12:15:38 PM
  modules                         37ms         +3.1 MB        -12.6 MB  █                                       12:15:38 PM
  modules:done                    17ms         +9.7 MB        -13.6 MB  █                                       12:15:38 PM
  nitro:config                   144ms        +20.8 MB         -2.3 MB  █                                       12:15:38 PM
  nitro:createNitro              452ms        -25.1 MB         -7.4 MB  █                                       12:15:38 PM
  ready                            2ms        +48.0 KB       +126.1 KB  █                                       12:15:38 PM
  prepare:types                  185ms      +1008.0 KB        +14.9 MB  █                                       12:15:38 PM
  app:generate                   271ms        -39.4 MB        -26.6 MB  █                                       12:15:38 PM
  app:resolve                      6ms       -464.0 KB       +270.7 KB  █                                       12:15:38 PM
  app:templates                  114ms        -21.3 MB         +8.8 MB  █                                       12:15:38 PM
  app:templatesGenerated         101ms        +43.8 MB        +17.0 MB  █                                       12:15:38 PM
  build:bundle                    3.3s        -17.6 MB        +20.4 MB  ███                                     12:15:38 PM
  build:done                       1ms       +256.0 KB        +44.0 KB  █                                       12:15:38 PM
  nitro:build                    13.0s       +455.4 MB       +215.6 MB  ████████████                            12:15:38 PM
  ────────────────────────────────────────────────────────────────────                                          12:15:38 PM
  Total                          27.0s       +948.2 MB       +655.4 MB                                          12:15:38 PM
                                                                                                                12:15:38 PM
 Modules                                                                                                        12:15:38 PM
                                                                                                                12:15:38 PM
  • @nuxt/devtools — 101ms                                                                                      12:15:38 PM
  • nuxt:pages — 46ms                                                                                           12:15:38 PM
                                                                                                                12:15:38 PM
 Bundler Plugins                                                                                                12:15:38 PM
                                                                                                                12:15:38 PM
  • vite:load-fallback load — 239ms/file, max 749ms (1193 calls)                                                12:15:38 PM
  • vite:css-post transform — 119ms/file, max 598ms (60 calls)                                                  12:15:38 PM
  • vite:esbuild transform — 119ms/file, max 1.1s (1726 calls)                                                  12:15:38 PM
  • vite:vue transform — 106ms/file, max 1.0s (1726 calls)                                                      12:15:38 PM
  • vite:define transform — 32ms/file, max 653ms (1726 calls)                                                   12:15:38 PM
  • vite:vue-jsx transform — 32ms/file, max 156ms (6 calls)                                                     12:15:38 PM
  • vite:css transform — 16ms/file, max 325ms (60 calls)                                                        12:15:38 PM
  • nuxt:components:imports-alias transform — 5ms/file, max 32ms (10 calls)                                     12:15:38 PM
  • nuxt:imports-transform transform — 3ms/file, max 39ms (2561 calls)                                          12:15:38 PM
  • nuxt:prehydrate-transform transform — 3ms/file, max 23ms (12 calls)                                         12:15:38 PM
  • nuxt:compiler:keyed-functions transform — 2ms/file, max 27ms (172 calls)                                    12:15:38 PM
  • nuxt:resolve-bare-imports resolveId — 1ms/file, max 39ms (72 calls)                                         12:15:38 PM
  • nuxt:tree-shake-composables:transform transform — 1ms/file, max 48ms (138 calls)                            12:15:38 PM
  • nuxt:lazy-hydration-macro transform — 710µs/file, max 2ms (18 calls)                                        12:15:38 PM
  • vite:resolve resolveId — 620µs/file, max 8ms (4044 calls)                                                   12:15:38 PM
                                                                                                                12:15:38 PM
 Details                                                                                                        12:15:38 PM
                                                                                                                12:15:38 PM
  • module:@nuxt/devtools — 101ms                                                                               12:15:38 PM
  • module:nuxt:pages — 46ms                                                                                    12:15:38 PM
  • vite:extend — 13ms                                                                                          12:15:38 PM
  • vite:client — 4.8s                                                                                          12:15:38 PM
  • vite:server — 3.5s                                                                                          12:15:38 PM
                                                                                                                12:15:38 PM
[12:15:38 PM]  Full report written to /home/daniel/code/nuxt/nuxt/test/fixtures/basic/node_modules/.cache/nuxt/.nuxt/perf-report.json
                                                                                                                12:15:38 PM
│                                                                                                               12:15:38 PM
└  ✨ Build complete!
```

</details>

<img width="679" height="806" alt="SCR-20260308-rxba" src="https://github.com/user-attachments/assets/18ffea6d-5fd5-49cc-86af-30d0d5a9fb24" />

## 🚧 TODO

- [x] ~~integrate with vite's profiler~~ we launch our own cpu profiler
- [x] enable `--profile` flag in `nuxt/cli`