### PR TITLE
docs: add explanation of 200.html and 404.html SPA fallbacks

### DIFF
--- a/docs/1.getting-started/15.prerendering.md
+++ b/docs/1.getting-started/15.prerendering.md
@@ -40,6 +40,8 @@ deno x nuxt generate
 
 You can now deploy the `.output/public` directory to any static hosting service or preview it locally with `npx serve .output/public`.
 
+When the build runs in static/prerender mode, Nitro also generates **`200.html`** and **`404.html`** SPA fallback pages so static hosts can serve your app for any path or 404. For an explanation of what they are and when they are produced (including hybrid setups with client-only routes), see [What are 200.html and 404.html?](/docs/4.x/guide/concepts/rendering#what-are-200html-and-404html) in the rendering guide.
+
 Working of the Nitro crawler:
 
 1. Load the HTML of your application's root route (`/`), any non-dynamic pages in your `~/pages` directory, and any other routes in the `nitro.prerender.routes` array.

--- a/docs/1.getting-started/15.prerendering.md
+++ b/docs/1.getting-started/15.prerendering.md
@@ -40,7 +40,7 @@ deno x nuxt generate
 
 You can now deploy the `.output/public` directory to any static hosting service or preview it locally with `npx serve .output/public`.
 
-When the build runs in static/prerender mode, Nitro also generates **`200.html`** and **`404.html`** SPA fallback pages so static hosts can serve your app for any path or 404. For an explanation of what they are and when they are produced (including hybrid setups with client-only routes), see [What are 200.html and 404.html?](/docs/4.x/guide/concepts/rendering#what-are-200html-and-404html) in the rendering guide.
+Static and prerender builds also emit `200.html` and `404.html` SPA fallbacks. See [What are 200.html and 404.html?](/docs/4.x/guide/concepts/rendering#what-are-200html-and-404html).
 
 Working of the Nitro crawler:
 

--- a/docs/1.getting-started/16.deployment.md
+++ b/docs/1.getting-started/16.deployment.md
@@ -77,7 +77,7 @@ By default, the workload gets distributed to the workers with the round robin st
 
 There are two ways to deploy a Nuxt application to any static hosting services:
 
-- Static site generation (SSG) with `ssr: true` pre-renders routes of your application at build time. (This is the default behavior when running `nuxt generate`.) It will also generate `/200.html` and `/404.html` single-page app fallback pages, which can render dynamic routes or 404 errors on the client (though you may need to configure this on your static host). For a detailed explanation of what these files are and when they are generated, see [What are 200.html and 404.html?](/docs/4.x/guide/concepts/rendering#what-are-200html-and-404html).
+- Static site generation (SSG) with `ssr: true` pre-renders routes of your application at build time. (This is the default behavior when running `nuxt generate`.) It will also generate `/200.html` and `/404.html` single-page app fallback pages, which can render dynamic routes or 404 errors on the client (though you may need to configure this on your static host). See [What are 200.html and 404.html?](/docs/4.x/guide/concepts/rendering#what-are-200html-and-404html).
 - Alternatively, you can prerender your site with `ssr: false` (static single-page app). This will produce HTML pages with an empty `<div id="__nuxt"></div>` where your Vue app would normally be rendered. You will lose many SEO benefits of prerendering your site, so it is suggested instead to use [`<ClientOnly>`](/docs/4.x/api/components/client-only) to wrap the portions of your site that cannot be server rendered (if any).
 
 ### Static Fallback Pages

--- a/docs/1.getting-started/16.deployment.md
+++ b/docs/1.getting-started/16.deployment.md
@@ -77,7 +77,7 @@ By default, the workload gets distributed to the workers with the round robin st
 
 There are two ways to deploy a Nuxt application to any static hosting services:
 
-- Static site generation (SSG) with `ssr: true` pre-renders routes of your application at build time. (This is the default behavior when running `nuxt generate`.) It will also generate `/200.html` and `/404.html` single-page app fallback pages, which can render dynamic routes or 404 errors on the client (though you may need to configure this on your static host).
+- Static site generation (SSG) with `ssr: true` pre-renders routes of your application at build time. (This is the default behavior when running `nuxt generate`.) It will also generate `/200.html` and `/404.html` single-page app fallback pages, which can render dynamic routes or 404 errors on the client (though you may need to configure this on your static host). For a detailed explanation of what these files are and when they are generated, see [What are 200.html and 404.html?](/docs/4.x/guide/concepts/rendering#what-are-200html-and-404html).
 - Alternatively, you can prerender your site with `ssr: false` (static single-page app). This will produce HTML pages with an empty `<div id="__nuxt"></div>` where your Vue app would normally be rendered. You will lose many SEO benefits of prerendering your site, so it is suggested instead to use [`<ClientOnly>`](/docs/4.x/api/components/client-only) to wrap the portions of your site that cannot be server rendered (if any).
 
 ### Static Fallback Pages

--- a/docs/3.guide/1.concepts/1.rendering.md
+++ b/docs/3.guide/1.concepts/1.rendering.md
@@ -126,12 +126,12 @@ This will produce three files:
 
 #### What are 200.html and 404.html?
 
-These are **SPA fallback pages** for static hosting. Static hosts serve a single file per request, so when a user visits a client-side route (e.g. `/dashboard`) or gets a 404, the server must return an HTML file that loads your app; the Vue Router then handles the path or shows the 404 page in the browser.
+Static hosts need an HTML shell for client-side routes and missing paths. Nuxt emits two SPA fallbacks for that:
 
-- **`200.html`** — Fallback for **all requests** (any path). Configure your static host to serve `200.html` for requests that do not match a pre-rendered file. The browser receives the same app shell, and the client-side router renders the matching page or your app’s 404 view.
-- **`404.html`** — Fallback for **404 responses**. Some hosts serve this when no file is found so your SPA can display its own 404 page instead of a generic server 404.
+- **`200.html`**. Serve this for unmatched paths when you want the client router to handle the URL.
+- **`404.html`**. Serve this when the host should keep a 404 status and still load your app.
 
-They are generated when you run a **static/prerender build** (`nuxt generate` or `nuxt build --prerender`) with the default Nitro behavior: the build adds these routes so they are emitted into `.output/public/`. If you use **hybrid** route rules (e.g. some routes prerendered, others `ssr: false`), a plain `nuxt build` without prerender does not produce static fallbacks; use `nuxt generate` or `nuxt build --prerender` if you need `200.html` and `404.html` for SPA routes. After building, configure your static host to serve `200.html` (and optionally `404.html`) for unmatched or error requests as required by your provider.
+`nuxt generate` and `nuxt build --prerender` write these into `.output/public/`. A plain `nuxt build` without prerender does not. With hybrid route rules, add the fallbacks with route rules or run a prerender build if you need them. Point your host at the file your provider expects.
 
 #### Skipping Client Fallback Generation
 

--- a/docs/3.guide/1.concepts/1.rendering.md
+++ b/docs/3.guide/1.concepts/1.rendering.md
@@ -124,7 +124,14 @@ This will produce three files:
 - `200.html`
 - `404.html`
 
-The `200.html` file is intended for static hosts that need a success-status fallback for client-side routing. The `404.html` file is intended for static hosts that serve a not-found page while preserving a 404 status. Which file you should use depends on your hosting provider's fallback or rewrite settings.
+#### What are 200.html and 404.html?
+
+These are **SPA fallback pages** for static hosting. Static hosts serve a single file per request, so when a user visits a client-side route (e.g. `/dashboard`) or gets a 404, the server must return an HTML file that loads your app; the Vue Router then handles the path or shows the 404 page in the browser.
+
+- **`200.html`** — Fallback for **all requests** (any path). Configure your static host to serve `200.html` for requests that do not match a pre-rendered file. The browser receives the same app shell, and the client-side router renders the matching page or your app’s 404 view.
+- **`404.html`** — Fallback for **404 responses**. Some hosts serve this when no file is found so your SPA can display its own 404 page instead of a generic server 404.
+
+They are generated when you run a **static/prerender build** (`nuxt generate` or `nuxt build --prerender`) with the default Nitro behavior: the build adds these routes so they are emitted into `.output/public/`. If you use **hybrid** route rules (e.g. some routes prerendered, others `ssr: false`), a plain `nuxt build` without prerender does not produce static fallbacks; use `nuxt generate` or `nuxt build --prerender` if you need `200.html` and `404.html` for SPA routes. After building, configure your static host to serve `200.html` (and optionally `404.html`) for unmatched or error requests as required by your provider.
 
 #### Skipping Client Fallback Generation
 


### PR DESCRIPTION
Explain what `200.html` and `404.html` are, when Nuxt writes them, and how they differ for static hosts.

`nuxt generate` / `nuxt build --prerender` emit these SPA fallbacks. Plain `nuxt build` without prerender does not. The rendering guide covers that; prerendering and deployment link to it.

Fixes #23055