### PR TITLE
feat(nuxt): auto-generate statusText in createError when not provided

### DIFF
--- a/docs/4.api/3.utils/create-error.md
+++ b/docs/4.api/3.utils/create-error.md
@@ -30,7 +30,7 @@ If you throw an error created with `createError`:
 const route = useRoute()
 const { data } = await useFetch(`/api/movies/${route.params.slug}`)
 if (!data.value) {
-  throw createError({ status: 404 })  // statusText auto-generated as "Not Found"
+  throw createError({ status: 404 }) // statusText auto-generated as "Not Found"
 }
 </script>
 ```
@@ -61,7 +61,7 @@ Use `createError` to trigger error handling in server API routes.
 
 ```ts [server/api/error.ts]
 export default eventHandler(() => {
-  throw createError({ status: 404 })  // statusText auto-generated as "Not Found"
+  throw createError({ status: 404 }) // statusText auto-generated as "Not Found"
 })
 ```
 

--- a/docs/4.api/3.utils/create-error.md
+++ b/docs/4.api/3.utils/create-error.md
@@ -14,7 +14,7 @@ You can use this function to create an error object with additional metadata. It
 
 - `err`: `string | { cause, data, message, name, stack, status, statusText, fatal }`
 
-You can pass either a string or an object to the `createError` function. If you pass a string, it will be used as the error `message`, and the `status` will default to `500`. If you pass an object, you can set multiple properties of the error, such as `status`, `message`, and other error properties.
+You can pass either a string or an object to the `createError` function. If you pass a string, it will be used as the error `message`, and the `status` will default to `500`. If you pass an object, you can set multiple properties of the error, such as `status`, `message`, and other error properties. The `statusText` is optional—when omitted, it is auto-generated from the `status` code (e.g. `404` → `"Not Found"`, `500` → `"Internal Server Error"`).
 
 ## In Vue App
 
@@ -30,7 +30,7 @@ If you throw an error created with `createError`:
 const route = useRoute()
 const { data } = await useFetch(`/api/movies/${route.params.slug}`)
 if (!data.value) {
-  throw createError({ status: 404, statusText: 'Page Not Found' })
+  throw createError({ status: 404 })  // statusText auto-generated as "Not Found"
 }
 </script>
 ```
@@ -61,13 +61,10 @@ Use `createError` to trigger error handling in server API routes.
 
 ```ts [server/api/error.ts]
 export default eventHandler(() => {
-  throw createError({
-    status: 404,
-    statusText: 'Page Not Found',
-  })
+  throw createError({ status: 404 })  // statusText auto-generated as "Not Found"
 })
 ```
 
-In API routes, using `createError` by passing an object with a short `statusText` is recommended because it can be accessed on the client side. Otherwise, a `message` passed to `createError` on an API route will not propagate to the client. Alternatively, you can use the `data` property to pass data back to the client. When handling the error with `useFetch`, the custom data is available at `error.value.data.data`. In any case, always consider avoiding to put dynamic user input to the message to avoid potential security issues.
+You can omit `statusText`—it is auto-generated from the status code. To customize it, pass `statusText` explicitly. In API routes, a short `statusText` (or the auto-generated one) is accessible on the client side. Otherwise, a `message` passed to `createError` on an API route will not propagate to the client. Alternatively, you can use the `data` property to pass data back to the client. When handling the error with `useFetch`, the custom data is available at `error.value.data.data`. In any case, always consider avoiding putting dynamic user input in the message to avoid potential security issues.
 
 :read-more{to="/docs/4.x/getting-started/error-handling"}

--- a/packages/nuxt/src/app/composables/error.ts
+++ b/packages/nuxt/src/app/composables/error.ts
@@ -96,10 +96,50 @@ export class NuxtError<DataT = unknown> extends HTTPError<DataT> implements _Nux
   }
 }
 
+// Default HTTP status text for common codes (RFC 7231, etc.). Used when statusText/statusMessage is not provided.
+const DEFAULT_STATUS_TEXT: Record<number, string> = {
+  400: 'Bad Request',
+  401: 'Unauthorized',
+  402: 'Payment Required',
+  403: 'Forbidden',
+  404: 'Not Found',
+  405: 'Method Not Allowed',
+  408: 'Request Timeout',
+  409: 'Conflict',
+  410: 'Gone',
+  422: 'Unprocessable Entity',
+  429: 'Too Many Requests',
+  500: 'Internal Server Error',
+  501: 'Not Implemented',
+  502: 'Bad Gateway',
+  503: 'Service Unavailable',
+  504: 'Gateway Timeout',
+}
+
 /** @since 3.0.0 */
 export const createError = <DataT = unknown>(error: string | Error | Partial<NuxtError<DataT>>): NuxtError<DataT> => {
   if (isNuxtError<DataT>(error)) { return error }
-  return typeof error === 'string'
-    ? new NuxtError<DataT>(error)
-    : new NuxtError<DataT>(error.message, error)
+  if (typeof error === 'string') {
+    return new NuxtError<DataT>(error)
+  }
+
+  const err = { ...error } as Partial<NuxtError<DataT>>
+  if (err.statusText) {
+    err.message ??= err.statusText
+  }
+
+  // Auto-generate statusText from status code when not provided (#34280)
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
+  const statusCode = typeof err.status === 'number' ? err.status : err.statusCode
+  if (typeof statusCode === 'number') {
+    err.status ??= statusCode
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    if (err.statusText === undefined && err.statusMessage === undefined) {
+      const defaultText = DEFAULT_STATUS_TEXT[statusCode] ?? 'Error'
+      err.statusText = defaultText
+      err.message ??= defaultText
+    }
+  }
+
+  return new NuxtError<DataT>(err.message, err)
 }

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -147,9 +147,9 @@ describe('errors', () => {
     expect(createError({ statusCode: 404 }).toJSON()).toMatchInlineSnapshot(`
       {
         "data": undefined,
-        "message": "HTTPError 404",
+        "message": "Not Found",
         "status": 404,
-        "statusText": undefined,
+        "statusText": "Not Found",
         "unhandled": undefined,
       }
     `)
@@ -162,6 +162,38 @@ describe('errors', () => {
         "unhandled": undefined,
       }
     `)
+  })
+
+  it('auto-generates statusText from status code when not provided (#34280)', () => {
+    const error = createError({ status: 404 })
+    expect(error.status).toBe(404)
+    expect(error.statusText).toBe('Not Found')
+    const error400 = createError({ status: 400 })
+    expect(error400.statusText).toBe('Bad Request')
+    const error500 = createError({ status: 500 })
+    expect(error500.statusText).toBe('Internal Server Error')
+  })
+
+  it('uses "Error" for unknown status codes', () => {
+    const error = createError({ status: 499 })
+    expect(error.statusText).toBe('Error')
+  })
+
+  it('does not overwrite explicit statusText', () => {
+    const error = createError({ status: 404, statusText: 'Custom Not Found' })
+    expect(error.statusText).toBe('Custom Not Found')
+  })
+
+  it('auto-generates statusText from deprecated statusCode when status is not set', () => {
+    const error = createError({ statusCode: 404 })
+    expect(error.status).toBe(404)
+    expect(error.statusText).toBe('Not Found')
+  })
+
+  it('supports status/statusText getters', () => {
+    const error = createError({ status: 404, statusText: 'Not Found' })
+    expect(error.status).toBe(404)
+    expect(error.statusText).toBe('Not Found')
   })
 
   it('isNuxtError', () => {


### PR DESCRIPTION
Automatically derive `statusText` in `createError` when `status` (or deprecated `statusCode`) is set but `statusText`/`statusMessage` is not provided. Uses a mapping for common HTTP codes (400, 401, 403, 404, 500, etc.); unknown codes fall back to `'Error'`.

This reduces boilerplate when throwing errors—`throw createError({ status: 404 })` now gets `statusText: 'Not Found'` without explicit specification. Explicit `statusText`/ `statusMessage` is preserved when provided.

Backward compatibility: deprecated `statusCode` is supported for auto-generation when `status` is not set.

Fixes #34280