### PR TITLE
feat(nuxt): add @error handler for NuxtLink route navigation failures

### DIFF
--- a/docs/4.api/1.components/4.nuxt-link.md
+++ b/docs/4.api/1.components/4.nuxt-link.md
@@ -295,8 +295,36 @@ With the `custom` prop, `prefetch`, `prefetchOn` and `prefetchedClass` do not at
 - `target`: A `target` attribute value to apply on the link
 - `rel`: A `rel` attribute value to apply on the link. Defaults to `"noopener noreferrer"` for external links.
 
+### Error Handling
+
+- `onError`: Callback invoked when navigation fails (e.g. route not found, middleware abort). Use for imperative error handling alongside or instead of the `@error` event.
+
 ::tip
 Defaults can be overwritten, see [overwriting defaults](/docs/4.x/api/components/nuxt-link#overwriting-defaults) if you want to change them.
+::
+
+## Events
+
+- `@error`: Emitted when navigation fails (e.g. route not found, middleware abort). The payload is a `NuxtLinkNavigationError` with `name` (`'NavigationError'` | `'NavigationAborted'`), `message`, `cause`, and optional `route`.
+
+```vue [app/pages/index.vue]
+<template>
+  <NuxtLink to="/non-existent" @error="handleError">
+    Navigate
+  </NuxtLink>
+</template>
+
+<script setup>
+function handleError (error) {
+  console.error('Navigation failed:', error.message)
+  // error.name: 'NavigationError' | 'NavigationAborted'
+  // error.route: the attempted route string
+}
+</script>
+```
+
+::tip
+Use `onError` prop for imperative handling or `@error` for event-based handling. Both work with custom slots.
 ::
 
 ## Overwriting Defaults

--- a/docs/4.api/1.components/4.nuxt-link.md
+++ b/docs/4.api/1.components/4.nuxt-link.md
@@ -309,7 +309,10 @@ Defaults can be overwritten, see [overwriting defaults](/docs/4.x/api/components
 
 ```vue [app/pages/index.vue]
 <template>
-  <NuxtLink to="/non-existent" @error="handleError">
+  <NuxtLink
+    to="/non-existent"
+    @error="handleError"
+  >
     Navigate
   </NuxtLink>
 </template>

--- a/docs/4.api/1.components/4.nuxt-link.md
+++ b/docs/4.api/1.components/4.nuxt-link.md
@@ -297,7 +297,7 @@ With the `custom` prop, `prefetch`, `prefetchOn` and `prefetchedClass` do not at
 
 ### Error Handling
 
-- `onError`: Callback invoked when navigation fails (e.g. route not found, middleware abort). Use for imperative error handling alongside or instead of the `@error` event.
+- `onNavigationError`: Callback invoked when navigation fails (e.g. route not found, middleware abort). Use for imperative error handling alongside or instead of the `@error` event.
 
 ::tip
 Defaults can be overwritten, see [overwriting defaults](/docs/4.x/api/components/nuxt-link#overwriting-defaults) if you want to change them.
@@ -327,7 +327,7 @@ function handleError (error) {
 ```
 
 ::tip
-Use `onError` prop for imperative handling or `@error` for event-based handling. Both work with custom slots.
+Use `onNavigationError` prop for imperative handling or `@error` for event-based handling. Both work with custom slots.
 ::
 
 ## Overwriting Defaults

--- a/packages/nuxt/src/app/components/index.ts
+++ b/packages/nuxt/src/app/components/index.ts
@@ -1,5 +1,5 @@
 // defineNuxtLink
 export { defineNuxtLink } from './nuxt-link'
-export type { NuxtLinkOptions, NuxtLinkProps } from './nuxt-link'
+export type { NuxtLinkNavigationError, NuxtLinkOptions, NuxtLinkProps } from './nuxt-link'
 
 export type { NuxtTimeProps } from './nuxt-time.vue'

--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -12,7 +12,7 @@ import type {
   VNodeProps,
 } from 'vue'
 import { computed, defineComponent, h, inject, onBeforeUnmount, onMounted, provide, ref, resolveComponent, shallowRef, unref } from 'vue'
-import { isNavigationFailure, NavigationFailureType } from 'vue-router'
+import { NavigationFailureType, isNavigationFailure } from 'vue-router'
 import type { RouteLocation, RouteLocationRaw, Router, RouterLink, RouterLinkProps, UseLinkReturn, useLink } from 'vue-router'
 import { hasProtocol, isScriptProtocol, joinURL, parseQuery, withTrailingSlash, withoutTrailingSlash } from 'ufo'
 import { preloadRouteComponents } from '../composables/preload'

--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -413,18 +413,25 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
     setup (props, { slots, emit, attrs }) {
       const router = useRouter()
 
-      const { to, href, navigate, isExternal, hasTarget, isAbsoluteUrl } = useNuxtLink(props)
+      const { to, href, navigate, isExternal, hasTarget, isAbsoluteUrl, isActive, isExactActive, route: resolvedRoute } = useNuxtLink(props)
 
       const hasErrorHandler = computed(() => !!(props.onError || attrs?.onError))
 
       function toNavigationError (error: unknown): NuxtLinkNavigationError {
-        const err = error as Error
-        const isAborted = err?.name === 'NavigationAborted' || err?.name === 'NavigationDuplicated'
-        return Object.assign(new Error(err?.message || 'Navigation failed'), {
-          name: isAborted ? 'NavigationAborted' : 'NavigationError',
-          cause: err?.cause,
-          route: typeof href.value === 'string' ? href.value : undefined,
-        }) as NuxtLinkNavigationError
+        const isAborted = error instanceof Error && (error.name === 'NavigationAborted' || error.name === 'NavigationDuplicated')
+        const name = isAborted ? 'NavigationAborted' : 'NavigationError' as const
+        const route = typeof href.value === 'string' ? href.value : undefined
+
+        if (error instanceof Error) {
+          Object.assign(error, { name, route })
+          return error as NuxtLinkNavigationError
+        }
+
+        const err = new Error(typeof error === 'string' ? error : 'Navigation failed') as NuxtLinkNavigationError
+        err.name = name
+        err.cause = error
+        err.route = route
+        return err
       }
 
       async function navigateWithErrorHandling (e?: MouseEvent) {
@@ -525,7 +532,11 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
           href: href.value,
           navigate: hasErrorHandler.value ? navigateWithErrorHandling : navigate,
           get route () {
+            const route = resolvedRoute.value
             if (!href.value) { return undefined }
+            if (route && 'path' in route) {
+              return { ...route, href: href.value } as RouteLocation & { href: string }
+            }
 
             const url = new URL(href.value, import.meta.client ? window.location.href : 'http://localhost')
             return {
@@ -544,8 +555,8 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
           rel,
           target,
           isExternal: isExternal.value || hasTarget.value,
-          isActive: false,
-          isExactActive: false,
+          isActive: isActive.value,
+          isExactActive: isExactActive.value,
           ...routerLinkSlotProps,
           prefetch,
           prefetched: prefetched.value,
@@ -597,11 +608,30 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
           return slots.default(getCustomSlotProps())
         }
 
+        const anchorClasses: string[] = []
+        if (import.meta.client) {
+          if (isActive.value && (props.activeClass || options.activeClass)) {
+            anchorClasses.push(props.activeClass || options.activeClass!)
+          }
+          if (isExactActive.value && (props.exactActiveClass || options.exactActiveClass)) {
+            anchorClasses.push(props.exactActiveClass || options.exactActiveClass!)
+          }
+          if (prefetched.value && (props.prefetchedClass || options.prefetchedClass)) {
+            anchorClasses.push(props.prefetchedClass || options.prefetchedClass!)
+          }
+        }
+
         return h('a', {
           ref: el,
           href: href.value || null, // converts `""` to `null` to prevent the attribute from being added as empty (`href=""`)
           rel,
           target,
+          ...(anchorClasses.length > 0 && { class: anchorClasses.join(' ') }),
+          ...(isExactActive.value && props.ariaCurrentValue && { 'aria-current': props.ariaCurrentValue }),
+          ...(import.meta.client && shouldPrefetch('interaction') && {
+            onPointerenter: prefetch.bind(null, undefined),
+            onFocus: prefetch.bind(null, undefined),
+          }),
           onClick: async (event) => {
             if (isExternal.value || hasTarget.value) {
               return

--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -11,7 +11,7 @@ import type {
   VNode,
   VNodeProps,
 } from 'vue'
-import { computed, defineComponent, h, inject, onBeforeUnmount, onMounted, provide, ref, resolveComponent, shallowRef, unref } from 'vue'
+import { computed, defineComponent, getCurrentInstance, h, inject, onBeforeUnmount, onMounted, provide, ref, resolveComponent, shallowRef, unref } from 'vue'
 import { NavigationFailureType, isNavigationFailure } from 'vue-router'
 import type { RouteLocation, RouteLocationRaw, Router, RouterLink, RouterLinkProps, UseLinkReturn, useLink } from 'vue-router'
 import { hasProtocol, isScriptProtocol, joinURL, parseQuery, withTrailingSlash, withoutTrailingSlash } from 'ufo'
@@ -417,7 +417,17 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
 
       const { to, href, navigate, isExternal, hasTarget, isAbsoluteUrl, isActive, isExactActive, route: resolvedRoute } = useNuxtLink(props)
 
-      const hasErrorHandler = computed(() => !!(props.onNavigationError || attrs?.onError))
+      const hasErrorHandler = computed(() => {
+        const instance = getCurrentInstance()
+        const vnodeProps = instance?.vnode?.props
+        return !!(
+          props.onNavigationError ||
+          attrs?.onError ||
+          attrs?.onNavigationError ||
+          vnodeProps?.onError ||
+          vnodeProps?.onNavigationError
+        )
+      })
 
       function toNavigationError (error: unknown): NuxtLinkNavigationError {
         const isAborted = isNavigationFailure(error, NavigationFailureType.aborted | NavigationFailureType.duplicated)
@@ -668,10 +678,13 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
             })
             try {
               const encodedHref = encodeRoutePath(href.value ?? '')
-              await Promise.race([
+              const result = await Promise.race([
                 props.replace ? router.replace(encodedHref) : router.push(encodedHref),
                 errorPromise,
               ])
+              if (isNavigationFailure(result)) {
+                throw result
+              }
             } catch (error) {
               if (hasErrorHandler.value) {
                 const navigationError = toNavigationError(error)

--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -111,6 +111,21 @@ export interface NuxtLinkProps<CustomProp extends boolean = false> extends Omit<
    * Overrides the global `trailingSlash` option if provided.
    */
   trailingSlash?: 'append' | 'remove'
+  /**
+   * Callback invoked when navigation fails (e.g. route not found, middleware abort).
+   * Use for imperative error handling alongside or instead of the `@error` event.
+   */
+  onError?: (error: NuxtLinkNavigationError) => void
+}
+
+/**
+ * Error emitted when NuxtLink navigation fails.
+ * @see https://nuxt.com/docs/4.x/api/components/nuxt-link#error-event
+ */
+export interface NuxtLinkNavigationError extends Error {
+  name: 'NavigationError' | 'NavigationAborted'
+  cause?: unknown
+  route?: string
 }
 
 type NuxtLinkDefaultSlotProps<CustomProp extends boolean = false> = CustomProp extends true
@@ -383,12 +398,45 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
         default: undefined,
         required: false,
       },
+
+      // Error handling
+      onError: {
+        type: Function as PropType<NuxtLinkProps['onError']>,
+        default: undefined,
+        required: false,
+      },
+    },
+    emits: {
+      error: (error: NuxtLinkNavigationError) => true,
     },
     useLink: useNuxtLink,
-    setup (props, { slots }) {
+    setup (props, { slots, emit, attrs }) {
       const router = useRouter()
 
       const { to, href, navigate, isExternal, hasTarget, isAbsoluteUrl } = useNuxtLink(props)
+
+      const hasErrorHandler = computed(() => !!(props.onError || attrs?.onError))
+
+      function toNavigationError (error: unknown): NuxtLinkNavigationError {
+        const err = error as Error
+        const isAborted = err?.name === 'NavigationAborted' || err?.name === 'NavigationDuplicated'
+        return Object.assign(new Error(err?.message || 'Navigation failed'), {
+          name: isAborted ? 'NavigationAborted' : 'NavigationError',
+          cause: err?.cause,
+          route: typeof href.value === 'string' ? href.value : undefined,
+        }) as NuxtLinkNavigationError
+      }
+
+      async function navigateWithErrorHandling (e?: MouseEvent) {
+        try {
+          await navigate(e)
+        } catch (error) {
+          const navigationError = toNavigationError(error)
+          emit('error', navigationError)
+          props.onError?.(navigationError)
+          throw error
+        }
+      }
 
       // Prefetching
       const prefetched = shallowRef(false)
@@ -475,7 +523,7 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
 
         const getCustomSlotProps = (routerLinkSlotProps?: RouterLinkSlotProps): NuxtLinkDefaultSlotProps<true> => ({
           href: href.value,
-          navigate,
+          navigate: hasErrorHandler.value ? navigateWithErrorHandling : navigate,
           get route () {
             if (!href.value) { return undefined }
 
@@ -504,7 +552,7 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
           shouldPrefetch,
         })
 
-        if (!isExternal.value && !hasTarget.value && !isHashLinkWithoutHashMode(to.value)) {
+        if (!isExternal.value && !hasTarget.value && !isHashLinkWithoutHashMode(to.value) && !hasErrorHandler.value) {
           const routerLinkProps: RouterLinkProps & VNodeProps & AllowedComponentProps & AnchorHTMLAttributes = {
             ref: elRef,
             to: to.value,
@@ -564,6 +612,13 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
             try {
               const encodedHref = encodeRoutePath(href.value ?? '')
               return await (props.replace ? router.replace(encodedHref) : router.push(encodedHref))
+            } catch (error) {
+              if (hasErrorHandler.value) {
+                const navigationError = toNavigationError(error)
+                emit('error', navigationError)
+                props.onError?.(navigationError)
+              }
+              throw error
             } finally {
               // Focus the target element for hash links to restore accessibility behavior
               // that was prevented by event.preventDefault()

--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -407,7 +407,7 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
       },
     },
     emits: {
-      error: (error: NuxtLinkNavigationError) => true,
+      error: (_error: NuxtLinkNavigationError) => true,
     },
     useLink: useNuxtLink,
     setup (props, { slots, emit, attrs }) {

--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -609,16 +609,14 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
         }
 
         const anchorClasses: string[] = []
-        if (import.meta.client) {
-          if (isActive.value && (props.activeClass || options.activeClass)) {
-            anchorClasses.push(props.activeClass || options.activeClass!)
-          }
-          if (isExactActive.value && (props.exactActiveClass || options.exactActiveClass)) {
-            anchorClasses.push(props.exactActiveClass || options.exactActiveClass!)
-          }
-          if (prefetched.value && (props.prefetchedClass || options.prefetchedClass)) {
-            anchorClasses.push(props.prefetchedClass || options.prefetchedClass!)
-          }
+        if (isActive.value && (props.activeClass || options.activeClass)) {
+          anchorClasses.push(props.activeClass || options.activeClass!)
+        }
+        if (isExactActive.value && (props.exactActiveClass || options.exactActiveClass)) {
+          anchorClasses.push(props.exactActiveClass || options.exactActiveClass!)
+        }
+        if (import.meta.client && prefetched.value && (props.prefetchedClass || options.prefetchedClass)) {
+          anchorClasses.push(props.prefetchedClass || options.prefetchedClass!)
         }
 
         return h('a', {

--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -114,8 +114,9 @@ export interface NuxtLinkProps<CustomProp extends boolean = false> extends Omit<
   /**
    * Callback invoked when navigation fails (e.g. route not found, middleware abort).
    * Use for imperative error handling alongside or instead of the `@error` event.
+   * Named `onNavigationError` to avoid collision with Vue's `@error` → `onError` normalization.
    */
-  onError?: (error: NuxtLinkNavigationError) => void
+  onNavigationError?: (error: NuxtLinkNavigationError) => void
 }
 
 /**
@@ -400,8 +401,8 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
       },
 
       // Error handling
-      onError: {
-        type: Function as PropType<NuxtLinkProps['onError']>,
+      onNavigationError: {
+        type: Function as PropType<NuxtLinkProps['onNavigationError']>,
         default: undefined,
         required: false,
       },
@@ -415,33 +416,43 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
 
       const { to, href, navigate, isExternal, hasTarget, isAbsoluteUrl, isActive, isExactActive, route: resolvedRoute } = useNuxtLink(props)
 
-      const hasErrorHandler = computed(() => !!(props.onError || attrs?.onError))
+      const hasErrorHandler = computed(() => !!(props.onNavigationError || attrs?.onError))
 
       function toNavigationError (error: unknown): NuxtLinkNavigationError {
         const isAborted = error instanceof Error && (error.name === 'NavigationAborted' || error.name === 'NavigationDuplicated')
         const name = isAborted ? 'NavigationAborted' : 'NavigationError' as const
         const route = typeof href.value === 'string' ? href.value : undefined
 
-        if (error instanceof Error) {
-          Object.assign(error, { name, route })
-          return error as NuxtLinkNavigationError
-        }
-
-        const err = new Error(typeof error === 'string' ? error : 'Navigation failed') as NuxtLinkNavigationError
+        const err = new Error(
+          error instanceof Error ? error.message : (typeof error === 'string' ? error : 'Navigation failed'),
+        ) as NuxtLinkNavigationError
         err.name = name
         err.cause = error
         err.route = route
+        if (error instanceof Error && error.stack) {
+          err.stack = error.stack
+        }
         return err
       }
 
       async function navigateWithErrorHandling (e?: MouseEvent) {
+        let unregister: (() => void) | undefined
+        const errorPromise = new Promise<never>((_, reject) => {
+          unregister = (router as { onError?: (fn: (err: unknown) => void) => () => void }).onError?.((err: unknown) => {
+            unregister?.()
+            reject(err)
+          })
+        })
         try {
-          await navigate(e)
+          await Promise.race([navigate(e), errorPromise])
         } catch (error) {
           const navigationError = toNavigationError(error)
           emit('error', navigationError)
-          // Re-throw original so router.onError receives it; @error/onError listeners get normalized navigationError above
+          props.onNavigationError?.(navigationError)
+          // Re-throw original so router.onError receives it; @error/onNavigationError get normalized navigationError above
           throw error
+        } finally {
+          unregister?.()
         }
       }
 
@@ -625,7 +636,7 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
           rel,
           target,
           ...(anchorClasses.length > 0 && { class: anchorClasses.join(' ') }),
-          ...(isExactActive.value && props.ariaCurrentValue && { 'aria-current': props.ariaCurrentValue }),
+          ...(isExactActive.value && { 'aria-current': props.ariaCurrentValue ?? 'page' }),
           ...(import.meta.client && shouldPrefetch('interaction') && {
             onPointerenter: prefetch.bind(null, undefined),
             onFocus: prefetch.bind(null, undefined),
@@ -634,20 +645,42 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
             if (isExternal.value || hasTarget.value) {
               return
             }
+            if (
+              event.defaultPrevented ||
+              event.button !== 0 ||
+              event.metaKey ||
+              event.altKey ||
+              event.ctrlKey ||
+              event.shiftKey
+            ) {
+              return
+            }
 
             event.preventDefault()
 
+            let unregister: (() => void) | undefined
+            const errorPromise = new Promise<never>((_, reject) => {
+              unregister = (router as { onError?: (fn: (err: unknown) => void) => () => void }).onError?.((err: unknown) => {
+                unregister?.()
+                reject(err)
+              })
+            })
             try {
               const encodedHref = encodeRoutePath(href.value ?? '')
-              return await (props.replace ? router.replace(encodedHref) : router.push(encodedHref))
+              await Promise.race([
+                props.replace ? router.replace(encodedHref) : router.push(encodedHref),
+                errorPromise,
+              ])
             } catch (error) {
               if (hasErrorHandler.value) {
                 const navigationError = toNavigationError(error)
                 emit('error', navigationError)
+                props.onNavigationError?.(navigationError)
               }
-              // Re-throw original so router.onError receives it; @error/onError listeners get normalized navigationError above
+              // Re-throw original so router.onError receives it; @error/onNavigationError get normalized navigationError above
               throw error
             } finally {
+              unregister?.()
               // Focus the target element for hash links to restore accessibility behavior
               // that was prevented by event.preventDefault()
               if (import.meta.client && isHashLinkWithoutHashMode(to.value)) {

--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -12,6 +12,7 @@ import type {
   VNodeProps,
 } from 'vue'
 import { computed, defineComponent, h, inject, onBeforeUnmount, onMounted, provide, ref, resolveComponent, shallowRef, unref } from 'vue'
+import { isNavigationFailure, NavigationFailureType } from 'vue-router'
 import type { RouteLocation, RouteLocationRaw, Router, RouterLink, RouterLinkProps, UseLinkReturn, useLink } from 'vue-router'
 import { hasProtocol, isScriptProtocol, joinURL, parseQuery, withTrailingSlash, withoutTrailingSlash } from 'ufo'
 import { preloadRouteComponents } from '../composables/preload'
@@ -419,7 +420,7 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
       const hasErrorHandler = computed(() => !!(props.onNavigationError || attrs?.onError))
 
       function toNavigationError (error: unknown): NuxtLinkNavigationError {
-        const isAborted = error instanceof Error && (error.name === 'NavigationAborted' || error.name === 'NavigationDuplicated')
+        const isAborted = isNavigationFailure(error, NavigationFailureType.aborted | NavigationFailureType.duplicated)
         const name = isAborted ? 'NavigationAborted' : 'NavigationError' as const
         const route = typeof href.value === 'string' ? href.value : undefined
 

--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -440,7 +440,7 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
         } catch (error) {
           const navigationError = toNavigationError(error)
           emit('error', navigationError)
-          props.onError?.(navigationError)
+          // Re-throw original so router.onError receives it; @error/onError listeners get normalized navigationError above
           throw error
         }
       }
@@ -644,8 +644,8 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
               if (hasErrorHandler.value) {
                 const navigationError = toNavigationError(error)
                 emit('error', navigationError)
-                props.onError?.(navigationError)
               }
+              // Re-throw original so router.onError receives it; @error/onError listeners get normalized navigationError above
               throw error
             } finally {
               // Focus the target element for hash links to restore accessibility behavior

--- a/packages/nuxt/src/app/index.ts
+++ b/packages/nuxt/src/app/index.ts
@@ -10,7 +10,7 @@ export { defineNuxtComponent, useAsyncData, useLazyAsyncData, useNuxtData, refre
 export type { AddRouteMiddlewareOptions, AnnouncerPoliteness, AsyncData, AsyncDataOptions, AsyncDataRequestStatus, CookieOptions, CookieRef, FetchResult, NuxtAnnouncer, NuxtAnnouncerOpts, NuxtAppManifest, NuxtAppManifestMeta, NuxtError, Politeness, ReloadNuxtAppOptions, RouteMiddleware, UseFetchOptions, $Fetch } from './composables/index'
 
 export { defineNuxtLink } from './components/index'
-export type { NuxtLinkOptions, NuxtLinkProps, NuxtTimeProps } from './components/index'
+export type { NuxtLinkNavigationError, NuxtLinkOptions, NuxtLinkProps, NuxtTimeProps } from './components/index'
 export { getIslandHash, serializeIslandProps } from './island-hash'
 export { hashKey } from './utils/hash'
 export { _getAppConfig, updateAppConfig, useAppConfig } from './config'

--- a/packages/nuxt/test/nuxt-link.test.ts
+++ b/packages/nuxt/test/nuxt-link.test.ts
@@ -62,7 +62,7 @@ const INTERNAL = 'RouterLink'
 const nuxtLink = (
   props: NuxtLinkProps = {},
   nuxtLinkOptions: Partial<NuxtLinkOptions> = {},
-  context?: { emit?: (event: string, ...args: unknown[]) => void; attrs?: Record<string, unknown> },
+  context?: { emit?: (event: string, ...args: unknown[]) => void, attrs?: Record<string, unknown> },
 ): { type: string, props: Record<string, unknown>, slots: unknown } => {
   const component = defineNuxtLink({ componentName: 'NuxtLink', ...nuxtLinkOptions })
 

--- a/packages/nuxt/test/nuxt-link.test.ts
+++ b/packages/nuxt/test/nuxt-link.test.ts
@@ -49,7 +49,7 @@ vi.mock('../src/app/composables/router', () => ({
     },
     push: (...args: unknown[]) => routerPushMock(...args),
     replace: (...args: unknown[]) => routerReplaceMock(...args),
-    onError: (handler: (err: unknown) => void) => () => {},
+    onError: (_handler: (err: unknown) => void) => () => {},
     currentRoute: { value: { path: '/' } },
   }),
 }))

--- a/packages/nuxt/test/nuxt-link.test.ts
+++ b/packages/nuxt/test/nuxt-link.test.ts
@@ -49,6 +49,7 @@ vi.mock('../src/app/composables/router', () => ({
     },
     push: (...args: unknown[]) => routerPushMock(...args),
     replace: (...args: unknown[]) => routerReplaceMock(...args),
+    onError: (handler: (err: unknown) => void) => () => {},
     currentRoute: { value: { path: '/' } },
   }),
 }))
@@ -61,14 +62,14 @@ const INTERNAL = 'RouterLink'
 const nuxtLink = (
   props: NuxtLinkProps = {},
   nuxtLinkOptions: Partial<NuxtLinkOptions> = {},
-  context?: { emit?: (event: string, ...args: unknown[]) => void },
+  context?: { emit?: (event: string, ...args: unknown[]) => void; attrs?: Record<string, unknown> },
 ): { type: string, props: Record<string, unknown>, slots: unknown } => {
   const component = defineNuxtLink({ componentName: 'NuxtLink', ...nuxtLinkOptions })
 
   const setupContext = {
     slots: { default: () => null },
     emit: context?.emit ?? (() => {}),
-    attrs: {},
+    attrs: context?.attrs ?? {},
   }
   const [type, _props, slots] = (
     component as unknown as { setup: (props: NuxtLinkProps, ctx: typeof setupContext) => () => [string, Record<string, unknown>, unknown] }
@@ -580,26 +581,31 @@ describe('nuxt-link:useLink', () => {
 })
 
 describe('nuxt-link:error-handling', () => {
-  it('renders as `<a>` instead of RouterLink when onError is provided', () => {
+  it('renders as `<a>` instead of RouterLink when onNavigationError is provided', () => {
     expect(nuxtLink({ to: '/foo' }).type).toBe(INTERNAL)
-    expect(nuxtLink({ to: '/foo', onError: () => {} }).type).toBe(EXTERNAL)
+    expect(nuxtLink({ to: '/foo', onNavigationError: () => {} }).type).toBe(EXTERNAL)
   })
 
-  it('has onError prop and error emit defined', () => {
+  it('renders as `<a>` instead of RouterLink when @error listener is provided', () => {
+    const link = nuxtLink({ to: '/foo' }, {}, { attrs: { onError: () => {} } })
+    expect(link.type).toBe(EXTERNAL)
+  })
+
+  it('has onNavigationError prop and error emit defined', () => {
     const component = defineNuxtLink({ componentName: 'NuxtLink' })
     expect(component.props).toBeDefined()
-    expect((component.props as Record<string, unknown>).onError).toBeDefined()
+    expect((component.props as Record<string, unknown>).onNavigationError).toBeDefined()
     expect(component.emits).toBeDefined()
     expect((component.emits as Record<string, unknown>).error).toBeDefined()
   })
 
-  it('calls onError and emit when navigation fails', async () => {
-    const onErrorMock = vi.fn()
+  it('calls onNavigationError and emit when navigation fails', async () => {
+    const onNavigationErrorMock = vi.fn()
     const emitMock = vi.fn()
     routerPushMock.mockRejectedValueOnce(new Error('Page not found'))
 
     const link = nuxtLink(
-      { to: '/non-existent', onError: onErrorMock },
+      { to: '/non-existent', onNavigationError: onNavigationErrorMock },
       {},
       { emit: emitMock },
     )
@@ -607,13 +613,56 @@ describe('nuxt-link:error-handling', () => {
     expect(link.props.onClick).toBeDefined()
     const { onClick } = link.props as { onClick: (e: MouseEvent) => Promise<void> }
 
-    const event = { preventDefault: vi.fn() } as unknown as MouseEvent
+    const event = { preventDefault: vi.fn(), button: 0 } as unknown as MouseEvent
     await expect(onClick(event)).rejects.toThrow('Page not found')
-    expect(onErrorMock).toHaveBeenCalledTimes(1)
-    expect(onErrorMock.mock.calls[0]?.[0]).toMatchObject({
+    expect(onNavigationErrorMock).toHaveBeenCalledTimes(1)
+    expect(onNavigationErrorMock.mock.calls[0]?.[0]).toMatchObject({
       name: 'NavigationError',
       message: 'Page not found',
     })
+    expect(emitMock).toHaveBeenCalledWith('error', expect.objectContaining({
+      name: 'NavigationError',
+      message: 'Page not found',
+    }))
+  })
+
+  it('calls emit when navigation fails with @error only (no onNavigationError prop)', async () => {
+    const emitMock = vi.fn()
+    routerPushMock.mockRejectedValueOnce(new Error('Page not found'))
+
+    const link = nuxtLink(
+      { to: '/non-existent' },
+      {},
+      { emit: emitMock, attrs: { onError: vi.fn() } },
+    )
+    expect(link.type).toBe(EXTERNAL)
+    expect(link.props.onClick).toBeDefined()
+    const { onClick } = link.props as { onClick: (e: MouseEvent) => Promise<void> }
+
+    const event = { preventDefault: vi.fn(), button: 0 } as unknown as MouseEvent
+    await expect(onClick(event)).rejects.toThrow('Page not found')
+    expect(emitMock).toHaveBeenCalledWith('error', expect.objectContaining({
+      name: 'NavigationError',
+      message: 'Page not found',
+    }))
+  })
+
+  it('calls both onNavigationError and emit exactly once when both provided and navigation fails', async () => {
+    const onNavigationErrorMock = vi.fn()
+    const emitMock = vi.fn()
+    routerPushMock.mockRejectedValueOnce(new Error('Page not found'))
+
+    const link = nuxtLink(
+      { to: '/non-existent', onNavigationError: onNavigationErrorMock },
+      {},
+      { emit: emitMock },
+    )
+    const { onClick } = link.props as { onClick: (e: MouseEvent) => Promise<void> }
+
+    const event = { preventDefault: vi.fn(), button: 0 } as unknown as MouseEvent
+    await expect(onClick(event)).rejects.toThrow('Page not found')
+    expect(onNavigationErrorMock).toHaveBeenCalledTimes(1)
+    expect(emitMock).toHaveBeenCalledTimes(1)
     expect(emitMock).toHaveBeenCalledWith('error', expect.objectContaining({
       name: 'NavigationError',
       message: 'Page not found',

--- a/packages/nuxt/test/nuxt-link.test.ts
+++ b/packages/nuxt/test/nuxt-link.test.ts
@@ -27,10 +27,13 @@ vi.mock('vue', async () => {
 
 // Mocks Nuxt `useRouter()` and `navigateTo()`
 const navigateToMock = vi.fn()
+const routerPushMock = vi.fn().mockResolvedValue(undefined)
+const routerReplaceMock = vi.fn().mockResolvedValue(undefined)
 vi.mock('../src/app/composables/router', () => ({
   resolveRouteObject (to: Exclude<RouteLocationRaw, string>) {
     return withQuery(to.path || '', to.query || {}) + (to.hash || '')
   },
+  encodeRoutePath: (url: string) => url,
   navigateTo: (...args: unknown[]) => navigateToMock(...args),
   useRouter: () => ({
     resolve: (route: string | RouteLocation): Partial<RouteLocation> & { href: string } => {
@@ -44,6 +47,8 @@ vi.mock('../src/app/composables/router', () => ({
         href: route.path || `/${route.name?.toString()}`,
       }
     },
+    push: (...args: unknown[]) => routerPushMock(...args),
+    replace: (...args: unknown[]) => routerReplaceMock(...args),
     currentRoute: { value: { path: '/' } },
   }),
 }))
@@ -56,12 +61,18 @@ const INTERNAL = 'RouterLink'
 const nuxtLink = (
   props: NuxtLinkProps = {},
   nuxtLinkOptions: Partial<NuxtLinkOptions> = {},
+  context?: { emit?: (event: string, ...args: unknown[]) => void },
 ): { type: string, props: Record<string, unknown>, slots: unknown } => {
   const component = defineNuxtLink({ componentName: 'NuxtLink', ...nuxtLinkOptions })
 
+  const setupContext = {
+    slots: { default: () => null },
+    emit: context?.emit ?? (() => {}),
+    attrs: {},
+  }
   const [type, _props, slots] = (
-    component as unknown as { setup: (props: NuxtLinkProps, context: { slots: Record<string, () => unknown> }) => () => [string, Record<string, unknown>, unknown] }
-  ).setup(props, { slots: { default: () => null } })()
+    component as unknown as { setup: (props: NuxtLinkProps, ctx: typeof setupContext) => () => [string, Record<string, unknown>, unknown] }
+  ).setup(props, setupContext)()
 
   return { type, props: _props, slots }
 }
@@ -565,5 +576,46 @@ describe('nuxt-link:useLink', () => {
     const trailingSlash = ref<'append' | 'remove'>('append')
     const link = component.useLink({ to: '/about', trailingSlash })
     expect(link.to.value).toBe('/about/')
+  })
+})
+
+describe('nuxt-link:error-handling', () => {
+  it('renders as `<a>` instead of RouterLink when onError is provided', () => {
+    expect(nuxtLink({ to: '/foo' }).type).toBe(INTERNAL)
+    expect(nuxtLink({ to: '/foo', onError: () => {} }).type).toBe(EXTERNAL)
+  })
+
+  it('has onError prop and error emit defined', () => {
+    const component = defineNuxtLink({ componentName: 'NuxtLink' })
+    expect(component.props).toBeDefined()
+    expect((component.props as Record<string, unknown>).onError).toBeDefined()
+    expect(component.emits).toBeDefined()
+    expect((component.emits as Record<string, unknown>).error).toBeDefined()
+  })
+
+  it('calls onError and emit when navigation fails', async () => {
+    const onErrorMock = vi.fn()
+    const emitMock = vi.fn()
+    routerPushMock.mockRejectedValueOnce(new Error('Page not found'))
+
+    const link = nuxtLink(
+      { to: '/non-existent', onError: onErrorMock },
+      {},
+      { emit: emitMock },
+    )
+    expect(link.type).toBe(EXTERNAL)
+    expect(link.props.onClick).toBeDefined()
+
+    const event = { preventDefault: vi.fn() } as unknown as MouseEvent
+    await expect(link.props.onClick(event)).rejects.toThrow('Page not found')
+    expect(onErrorMock).toHaveBeenCalledTimes(1)
+    expect(onErrorMock.mock.calls[0][0]).toMatchObject({
+      name: 'NavigationError',
+      message: 'Page not found',
+    })
+    expect(emitMock).toHaveBeenCalledWith('error', expect.objectContaining({
+      name: 'NavigationError',
+      message: 'Page not found',
+    }))
   })
 })

--- a/packages/nuxt/test/nuxt-link.test.ts
+++ b/packages/nuxt/test/nuxt-link.test.ts
@@ -605,11 +605,12 @@ describe('nuxt-link:error-handling', () => {
     )
     expect(link.type).toBe(EXTERNAL)
     expect(link.props.onClick).toBeDefined()
+    const { onClick } = link.props as { onClick: (e: MouseEvent) => Promise<void> }
 
     const event = { preventDefault: vi.fn() } as unknown as MouseEvent
-    await expect(link.props.onClick(event)).rejects.toThrow('Page not found')
+    await expect(onClick(event)).rejects.toThrow('Page not found')
     expect(onErrorMock).toHaveBeenCalledTimes(1)
-    expect(onErrorMock.mock.calls[0][0]).toMatchObject({
+    expect(onErrorMock.mock.calls[0]?.[0]).toMatchObject({
       name: 'NavigationError',
       message: 'Page not found',
     })


### PR DESCRIPTION
Add component-level error handling for `<NuxtLink>` to catch navigation failures (e.g. route not found, middleware abort) directly at the link level.

Previously, the only way to detect navigation failures for link clicks was a global `router.beforeEach` guard. This adds `@error` event and `onError` prop for granular, per-link error handling.

**API:**
- `@error` event — emitted when navigation fails
- `onError` prop — callback for imperative handling
- `NuxtLinkNavigationError` — typed error with `name` (NavigationError | NavigationAborted), `message`, `cause`, `route`

**Implementation:** When `onError` or `@error` is provided, internal links render as `<a>` instead of `RouterLink` so we can intercept `router.push/replace` and catch rejections. Errors are always re-thrown after handling to preserve propagation.

Fixes #32383