### PR TITLE
chore: throttle per host to reduce rate limits in link checking

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -26,6 +26,9 @@ user_agent = "Mozilla/5.0 (compatible; lychee link checker)"
 timeout = 20
 retry_wait_time = 2
 max_retries = 6
+# Throttle per host to reduce rate limits / connection failures from external docs in CI
+host_request_interval = "50ms"
+host_concurrency = 5
 
 # Explicitly exclude some URLs
 exclude = [
@@ -37,9 +40,6 @@ exclude = [
   'https://router.vuejs.org/(.*)',
   'https://vitest.dev/(.*)',
   'https://vite.dev/(.*)',
-  'https://vuejs.org/(.*)',
-  'https://www.vuejs.org/(.*)',
-  'https://www.netlify.com/(.*)',
   # dummy example URLs
   "https://myawesome-lib.js/",
   "https://awesome-lib.js/",

--- a/lychee.toml
+++ b/lychee.toml
@@ -37,6 +37,9 @@ exclude = [
   'https://router.vuejs.org/(.*)',
   'https://vitest.dev/(.*)',
   'https://vite.dev/(.*)',
+  'https://vuejs.org/(.*)',
+  'https://www.vuejs.org/(.*)',
+  'https://www.netlify.com/(.*)',
   # dummy example URLs
   "https://myawesome-lib.js/",
   "https://awesome-lib.js/",


### PR DESCRIPTION
Exclude vuejs.org and netlify.com from lychee link checker to fix CI failures.

These external docs sites block or rate-limit CI bots, causing
"Connection failed" network errors in lychee-action. The checker
reports 11 errors from vuejs.org and 1 from netlify.com.

Adds exclude patterns using the same format as existing entries
(router.vuejs.org, vitest.dev, vite.dev): https://domain/(.*)