### PR TITLE
chore: enforce consistent return-await usage

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -113,6 +113,8 @@ export default createConfigForNuxt({
     },
     rules: {
       '@typescript-eslint/no-deprecated': 'error',
+      '@typescript-eslint/return-await': ['error', 'in-try-catch'],
+      'no-return-await': 'off',
     },
   })
 

--- a/packages/kit/src/loader/config.ts
+++ b/packages/kit/src/loader/config.ts
@@ -128,7 +128,7 @@ export async function loadNuxtConfig (opts: LoadNuxtConfigOptions): Promise<Nuxt
   return await applyDefaults(NuxtConfigSchema, nuxtConfig as NuxtConfig & Record<string, JSValue>) as unknown as NuxtOptions
 }
 
-async function loadNuxtSchema (cwd: string) {
+function loadNuxtSchema (cwd: string) {
   const url = directoryToURL(cwd)
   const urls: Array<URL | string> = [url]
   const nuxtPath = resolveModuleURL('nuxt', { try: true, from: url }) ?? resolveModuleURL('nuxt-nightly', { try: true, from: url })
@@ -136,7 +136,7 @@ async function loadNuxtSchema (cwd: string) {
     urls.unshift(nuxtPath)
   }
   const schemaPath = resolveModuleURL('@nuxt/schema', { try: true, from: urls }) ?? '@nuxt/schema'
-  return await import(schemaPath).then(r => r.NuxtConfigSchema)
+  return import(schemaPath).then(r => r.NuxtConfigSchema)
 }
 
 async function withDefineNuxtConfig<T> (fn: () => Promise<T>) {

--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -168,7 +168,7 @@ export function normalizeTemplate<T> (template: NuxtTemplate<T> | string, buildD
  * You can pass a filter within the options to selectively regenerate a subset of templates.
  */
 export async function updateTemplates (options?: { filter?: (template: ResolvedNuxtTemplate<any>) => boolean }): Promise<void> {
-  return await tryUseNuxt()?.hooks.callHook('builder:generateApp', options)
+  await tryUseNuxt()?.hooks.callHook('builder:generateApp', options)
 }
 
 interface LayerPaths {

--- a/packages/nuxt/src/app/composables/payload.ts
+++ b/packages/nuxt/src/app/composables/payload.ts
@@ -116,7 +116,7 @@ async function _isPrerenderedInManifest (url: string) {
 /**
  * @internal
  */
-export function shouldLoadPayload (url = useRoute().path) {
+export async function shouldLoadPayload (url = useRoute().path) {
   const rules = getRouteRules({ path: url })
   if (rules.ssr === false) {
     return false
@@ -130,17 +130,19 @@ export function shouldLoadPayload (url = useRoute().path) {
     return true
   }
 
-  return _isPrerenderedInManifest(url)
+  const prerendered = await _isPrerenderedInManifest(url)
+  return prerendered
 }
 
 /** @since 3.0.0 */
-export function isPrerendered (url = useRoute().path) {
+export async function isPrerendered (url = useRoute().path) {
   const res = _shouldLoadPrerenderedPayload(getRouteRules({ path: url }))
   if (res !== undefined) {
     return res
   }
 
-  return _isPrerenderedInManifest(url)
+  const prerendered = await _isPrerenderedInManifest(url)
+  return prerendered
 }
 
 let payloadCache: NuxtPayload | null = null

--- a/packages/nuxt/src/app/composables/payload.ts
+++ b/packages/nuxt/src/app/composables/payload.ts
@@ -116,7 +116,7 @@ async function _isPrerenderedInManifest (url: string) {
 /**
  * @internal
  */
-export async function shouldLoadPayload (url = useRoute().path) {
+export function shouldLoadPayload (url = useRoute().path) {
   const rules = getRouteRules({ path: url })
   if (rules.ssr === false) {
     return false
@@ -130,17 +130,17 @@ export async function shouldLoadPayload (url = useRoute().path) {
     return true
   }
 
-  return await _isPrerenderedInManifest(url)
+  return _isPrerenderedInManifest(url)
 }
 
 /** @since 3.0.0 */
-export async function isPrerendered (url = useRoute().path) {
+export function isPrerendered (url = useRoute().path) {
   const res = _shouldLoadPrerenderedPayload(getRouteRules({ path: url }))
   if (res !== undefined) {
     return res
   }
 
-  return await _isPrerenderedInManifest(url)
+  return _isPrerenderedInManifest(url)
 }
 
 let payloadCache: NuxtPayload | null = null

--- a/packages/nuxt/src/app/plugins/router.ts
+++ b/packages/nuxt/src/app/plugins/router.ts
@@ -133,7 +133,7 @@ export default defineNuxtPlugin<{ route: Route, router: Router }>({
           // Cancel navigation
           if (result === false || result instanceof Error) { return }
           // Redirect
-          if (typeof result === 'string' && result.length) { return handleNavigation(result, true) }
+          if (typeof result === 'string' && result.length) { return await handleNavigation(result, true) }
         }
 
         for (const handler of hooks['resolve:before']) {

--- a/packages/nuxt/src/core/builder.ts
+++ b/packages/nuxt/src/core/builder.ts
@@ -51,7 +51,8 @@ export async function build (nuxt: Nuxt): Promise<void> {
     const { restoreCache, collectCache } = await getVueHash(nuxt)
     if (await restoreCache()) {
       await nuxt.callHook('build:done')
-      return await nuxt.callHook('close', nuxt)
+      await nuxt.callHook('close', nuxt)
+      return
     }
     nuxt.hooks.hookOnce('nitro:build:before', () => collectCache())
     nuxt.hooks.hookOnce('close', () => cleanupCaches(nuxt))

--- a/packages/nuxt/src/core/cache.ts
+++ b/packages/nuxt/src/core/cache.ts
@@ -248,6 +248,8 @@ async function readFileWithMeta (dir: string, fileName: string, count = 0): Prom
 
     // retry if file has changed during read
     if ((await fd.stat()).mtime.getTime() !== mtime) {
+      await fd.close()
+      fd = undefined
       if (count < 5) {
         return await readFileWithMeta(dir, fileName, count + 1)
       }

--- a/packages/nuxt/src/core/cache.ts
+++ b/packages/nuxt/src/core/cache.ts
@@ -249,7 +249,7 @@ async function readFileWithMeta (dir: string, fileName: string, count = 0): Prom
     // retry if file has changed during read
     if ((await fd.stat()).mtime.getTime() !== mtime) {
       if (count < 5) {
-        return readFileWithMeta(dir, fileName, count + 1)
+        return await readFileWithMeta(dir, fileName, count + 1)
       }
       console.warn(`Failed to read file \`${fileName}\` as it changed during read.`)
       return

--- a/packages/nuxt/src/core/external-config-files.ts
+++ b/packages/nuxt/src/core/external-config-files.ts
@@ -25,35 +25,35 @@ export async function checkForExternalConfigurationFiles () {
   }
 }
 
-async function checkViteConfig () {
+function checkViteConfig () {
   // https://github.com/vitejs/vite/blob/8fe69524d25d45290179175ba9b9956cbce87a91/packages/vite/src/node/constants.ts#L38
-  return await checkAndWarnAboutConfigFileExistence({
+  return checkAndWarnAboutConfigFileExistence({
     fileName: 'vite.config',
     extensions: ['.js', '.mjs', '.ts', '.cjs', '.mts', '.cts'],
     createWarningMessage: foundFile => `Using \`${foundFile}\` is not supported together with Nuxt. Use \`options.vite\` instead. You can read more in \`https://nuxt.com/docs/4.x/api/nuxt-config#vite\`.`,
   })
 }
 
-async function checkWebpackConfig () {
+function checkWebpackConfig () {
   // https://webpack.js.org/configuration/configuration-languages/
-  return await checkAndWarnAboutConfigFileExistence({
+  return checkAndWarnAboutConfigFileExistence({
     fileName: 'webpack.config',
     extensions: ['.js', '.mjs', '.ts', '.cjs', '.mts', '.cts', 'coffee'],
     createWarningMessage: foundFile => `Using \`${foundFile}\` is not supported together with Nuxt. Use \`options.webpack\` instead. You can read more in \`https://nuxt.com/docs/4.x/api/nuxt-config#webpack-1\`.`,
   })
 }
 
-async function checkNitroConfig () {
+function checkNitroConfig () {
   // https://nitro.build/config
-  return await checkAndWarnAboutConfigFileExistence({
+  return checkAndWarnAboutConfigFileExistence({
     fileName: 'nitro.config',
     extensions: ['.ts', '.mts'],
     createWarningMessage: foundFile => `Using \`${foundFile}\` is not supported together with Nuxt. Use \`options.nitro\` instead. You can read more in \`https://nuxt.com/docs/4.x/api/nuxt-config#nitro\`.`,
   })
 }
 
-async function checkPostCSSConfig () {
-  return await checkAndWarnAboutConfigFileExistence({
+function checkPostCSSConfig () {
+  return checkAndWarnAboutConfigFileExistence({
     fileName: 'postcss.config',
     extensions: ['.js', '.cjs'],
     createWarningMessage: foundFile => `Using \`${foundFile}\` is not supported together with Nuxt. Use \`options.postcss\` instead. You can read more in \`https://nuxt.com/docs/4.x/api/nuxt-config#postcss\`.`,

--- a/packages/nuxt/src/core/plugins/layer-aliasing.ts
+++ b/packages/nuxt/src/core/plugins/layer-aliasing.ts
@@ -64,7 +64,7 @@ export const LayerAliasingPlugin = (options: LayerAliasingOptions) => createUnpl
         filter: {
           id: ALIAS_ID_RE,
         },
-        async handler (id, importer) {
+        handler (id, importer) {
           if (!importer) { return }
 
           const layer = layers.find(l => importer.startsWith(l))
@@ -72,7 +72,7 @@ export const LayerAliasingPlugin = (options: LayerAliasingOptions) => createUnpl
 
           const resolvedId = resolveAlias(id, aliases[layer])
           if (resolvedId !== id) {
-            return await this.resolve(resolvedId, importer, { skipSelf: true })
+            return this.resolve(resolvedId, importer, { skipSelf: true })
           }
         },
       },

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -23,7 +23,7 @@ export default defineResolvers({
       const rootDir = await get('rootDir')
       return val && typeof val === 'string'
         ? resolve(rootDir, val)
-        : await findWorkspaceDir(rootDir, {
+        : findWorkspaceDir(rootDir, {
             gitConfig: 'closest',
             try: true,
           }).catch(() => rootDir)

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -199,7 +199,7 @@ export default defineResolvers({
       },
     },
     browserDevtoolsTiming: {
-      $resolve: async (val, get) => typeof val === 'boolean' ? val : await get('dev'),
+      $resolve: (val, get) => typeof val === 'boolean' ? val : get('dev'),
     },
     chromeDevtoolsProjectSettings: true,
     debugModuleMutation: {

--- a/packages/schema/src/config/vite.ts
+++ b/packages/schema/src/config/vite.ts
@@ -5,7 +5,7 @@ import { defineResolvers } from '../utils/definition.ts'
 export default defineResolvers({
   vite: {
     root: {
-      $resolve: async (val, get) => typeof val === 'string' ? val : (await get('srcDir')),
+      $resolve: (val, get) => typeof val === 'string' ? val : (get('srcDir')),
     },
     mode: {
       $resolve: async (val, get) => typeof val === 'string' ? val : (await get('dev') ? 'development' : 'production'),

--- a/packages/schema/src/config/webpack.ts
+++ b/packages/schema/src/config/webpack.ts
@@ -13,7 +13,7 @@ export default defineResolvers({
     profile: process.argv.includes('--profile'),
     extractCSS: true,
     cssSourceMap: {
-      $resolve: async (val, get) => typeof val === 'boolean' ? val : await get('dev'),
+      $resolve: (val, get) => typeof val === 'boolean' ? val : get('dev'),
     },
     serverURLPolyfill: 'url',
     filenames: {
@@ -117,7 +117,7 @@ export default defineResolvers({
     postcss: {
       postcssOptions: {
         plugins: {
-          $resolve: async (val, get) => val && typeof val === 'object' ? val : (await get('postcss.plugins')),
+          $resolve: (val, get) => val && typeof val === 'object' ? val : (get('postcss.plugins')),
         },
       },
     },

--- a/packages/vite/src/vite-node-runner.ts
+++ b/packages/vite/src/vite-node-runner.ts
@@ -11,12 +11,12 @@ function createRunner () {
   return new ViteNodeRunner({
     root: viteNodeOptions.root, // Equals to Nuxt `srcDir`
     base: viteNodeOptions.base,
-    async resolveId (id, importer) {
-      return await viteNodeFetch.resolveId(id, importer)
+    resolveId (id, importer) {
+      return viteNodeFetch.resolveId(id, importer)
     },
-    async fetchModule (id) {
+    fetchModule (id) {
       id = id.replace(/\/\//g, '/') // TODO: fix in vite-node
-      return await viteNodeFetch.fetchModule(id).catch((err) => {
+      return viteNodeFetch.fetchModule(id).catch((err) => {
         const errorData = err?.data?.data
         if (!errorData) {
           throw err

--- a/packages/vite/src/vite-node.ts
+++ b/packages/vite/src/vite-node.ts
@@ -225,7 +225,7 @@ async function sendRequest<T extends keyof ViteNodeRequestMap> (type: T, payload
     try {
       const socket = await connectSocket()
 
-      return new Promise((resolve, reject) => {
+      return await new Promise((resolve, reject) => {
         const timeoutId = setTimeout(() => {
           pendingRequests.delete(requestId)
           reject(new Error(`Request timeout after ${REQUEST_TIMEOUT_MS}ms for type: ${type}`))


### PR DESCRIPTION
### 🔗 Linked issue

resolves #34474

### 📚 Description

Add `@typescript-eslint/return-await` rule with the `in-try-catch` option to enforce consistent usage of `return await` across the codebase.

- Outside try-catch: `return await fn()` → `return fn()` (await is redundant)
- Inside try-catch: `return fn()` → `return await fn()` (required for proper error catching)

Also disables the base `no-return-await` rule as it conflicts with the TypeScript-aware version.
