### PR TITLE
fix(nuxt): restore island head entries from payload during hydration

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-island.ts
+++ b/packages/nuxt/src/app/components/nuxt-island.ts
@@ -282,6 +282,14 @@ export default defineComponent({
       watch(props, debounce(() => fetchComponent(), 100), { deep: true })
     }
 
+    // Restore head entries from SSR payload during hydration
+    if (import.meta.client && instance.vnode.el) {
+      const headData = toRaw(nuxtApp.payload.data[`${props.name}_${hashId.value}`])?.head
+      if (headData) {
+        activeHead = head.push(headData)
+      }
+    }
+
     if (import.meta.client && !instance.vnode.el && props.lazy) {
       fetchComponent()
     } else if (import.meta.server || !instance.vnode.el || !nuxtApp.payload.serverRendered) {

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -2170,6 +2170,15 @@ describe('server components/islands', () => {
     // test island head
     expect(html).toContain('<meta name="author" content="Nuxt">')
     expect(html).toContain('plugin-style')
+    // #34482 - title should be composed with titleTemplate
+    expect(html).toContain('<title>Server Page - Fixture</title>')
+  })
+
+  it('/server-page - should preserve title after hydration', async () => {
+    const { page } = await renderPage('/server-page')
+    await page.waitForLoadState('networkidle')
+    expect(await page.title()).toBe('Server Page - Fixture')
+    await page.close()
   })
 
   it('/server-page - client side navigation', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

resolves #34482

### 📚 Description

When a `.server.vue` page uses `useHead` to set a title, the title is correctly rendered in the SSR HTML but lost after client-side hydration. This causes `titleTemplate` to receive `undefined` instead of the actual title value.

**Root cause:** During hydration, `NuxtIsland` detects that the DOM already exists (`instance.vnode.el` is set) and skips `fetchComponent()`. While `slots` and `components` are restored from the SSR payload, `head` entries are not — so `head.push()` is never called and the title is lost.

**Fix:** Restore head entries from the SSR payload during hydration, alongside the existing slot/component restoration logic.

**Before:** `/test-ssr` (`.server.vue`) shows `undefined - My Site` after hydration
**After:** `/test-ssr` correctly shows `lele - My Site`

Verified with the exact reproduction from #34482.