### PR TITLE
fix(kit): share `asyncNuxtStorage` across kit instances

### DIFF
--- a/packages/kit/src/context.ts
+++ b/packages/kit/src/context.ts
@@ -1,5 +1,5 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
-import { createContext, getContext } from 'unctx'
+import { getContext } from 'unctx'
 import type { UseContext } from 'unctx'
 import type { Nuxt } from '@nuxt/schema'
 
@@ -10,7 +10,7 @@ import type { Nuxt } from '@nuxt/schema'
 export const nuxtCtx: UseContext<Nuxt> = getContext<Nuxt>('nuxt')
 
 /** async local storage for the name of the current nuxt instance */
-const asyncNuxtStorage = createContext<Nuxt>({
+const asyncNuxtStorage = getContext<Nuxt>('asyncNuxtStorage', {
   asyncContext: true,
   AsyncLocalStorage,
 })

--- a/packages/kit/test/async-nuxt-storage.spec.ts
+++ b/packages/kit/test/async-nuxt-storage.spec.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { Nuxt } from '@nuxt/schema'
+import { runWithNuxtContext, tryUseNuxt } from '@nuxt/kit'
+
+describe('asyncNuxtStorage', () => {
+  it('should return nuxt instance', () => {
+    const nuxt = { __name: '1' } as Nuxt
+    expect(tryUseNuxt()?.__name).toBeUndefined()
+    expect(runWithNuxtContext(nuxt, () => tryUseNuxt()?.__name)).toBe('1')
+  })
+
+  it('should isolate async ctx', async () => {
+    const nuxt1 = { __name: '1' } as Nuxt
+    const nuxt2 = { __name: '2' } as Nuxt
+    const nuxt3 = { __name: '3' } as Nuxt
+
+    let resolve!: () => void
+    const promise = new Promise<void>(resolve_ => resolve = resolve_)
+
+    expect(tryUseNuxt()?.__name).toBeUndefined()
+
+    await expect(Promise.all([
+      runWithNuxtContext(nuxt1, async () => {
+        await promise
+        return tryUseNuxt()?.__name
+      }),
+      runWithNuxtContext(nuxt2, async () => {
+        await new Promise(resolve => setTimeout(resolve, 1))
+        resolve()
+        return tryUseNuxt()?.__name
+      }),
+      runWithNuxtContext(nuxt3, async () => {
+        await promise
+        return tryUseNuxt()?.__name
+      }),
+    ])).resolves.toEqual(['1', '2', '3'])
+
+    expect(tryUseNuxt()?.__name).toBeUndefined()
+  })
+
+  it('should share ctx with same kit', async () => {
+    const sameKit = await import('@nuxt/kit')
+
+    expect(sameKit.tryUseNuxt).toBe(tryUseNuxt)
+
+    const nuxt = { __name: '1' } as Nuxt
+
+    expect(tryUseNuxt()?.__name).toBeUndefined()
+    expect(sameKit.tryUseNuxt()?.__name).toBeUndefined()
+
+    expect(runWithNuxtContext(nuxt, () => tryUseNuxt()?.__name)).toBe('1')
+    expect(runWithNuxtContext(nuxt, () => sameKit.tryUseNuxt()?.__name)).toBe('1')
+
+    expect(tryUseNuxt()?.__name).toBeUndefined()
+    expect(sameKit.tryUseNuxt()?.__name).toBeUndefined()
+  })
+
+  it('should share ctx with another kit', async () => {
+    vi.resetModules()
+    const anotherKit = await import('@nuxt/kit')
+
+    expect(anotherKit.tryUseNuxt).not.toBe(tryUseNuxt)
+
+    const nuxt = { __name: '1' } as Nuxt
+
+    expect(tryUseNuxt()?.__name).toBeUndefined()
+    expect(anotherKit.tryUseNuxt()?.__name).toBeUndefined()
+
+    expect(runWithNuxtContext(nuxt, () => tryUseNuxt()?.__name)).toBe('1')
+    expect(runWithNuxtContext(nuxt, () => anotherKit.tryUseNuxt()?.__name)).toBe('1')
+
+    expect(tryUseNuxt()?.__name).toBeUndefined()
+    expect(anotherKit.tryUseNuxt()?.__name).toBeUndefined()
+  })
+
+  it('should isolate ctx with another kit', async () => {
+    vi.resetModules()
+    const anotherKit = await import('@nuxt/kit')
+
+    expect(anotherKit.tryUseNuxt).not.toBe(tryUseNuxt)
+
+    const nuxt1 = { __name: '1' } as Nuxt
+    const nuxt2 = { __name: '2' } as Nuxt
+
+    expect(anotherKit.tryUseNuxt()?.__name).toBeUndefined()
+
+    expect(runWithNuxtContext(nuxt1, () => anotherKit.tryUseNuxt()?.__name)).toBe('1')
+    expect(runWithNuxtContext(nuxt2, () => anotherKit.tryUseNuxt()?.__name)).toBe('2')
+
+    expect(anotherKit.tryUseNuxt()?.__name).toBeUndefined()
+  })
+
+  it('should isolate async ctx with another kit', async () => {
+    vi.resetModules()
+    const anotherKit = await import('@nuxt/kit')
+
+    expect(anotherKit.tryUseNuxt).not.toBe(tryUseNuxt)
+
+    const nuxt1 = { __name: '1' } as Nuxt
+    const nuxt2 = { __name: '2' } as Nuxt
+    const nuxt3 = { __name: '3' } as Nuxt
+
+    let resolve!: () => void
+    const promise = new Promise<void>(resolve_ => resolve = resolve_)
+
+    expect(tryUseNuxt()?.__name).toBeUndefined()
+    expect(anotherKit.tryUseNuxt()?.__name).toBeUndefined()
+
+    await expect(Promise.all([
+      runWithNuxtContext(nuxt1, async () => {
+        await promise
+        return anotherKit.tryUseNuxt()?.__name
+      }),
+      runWithNuxtContext(nuxt2, async () => {
+        await new Promise(resolve => setTimeout(resolve, 1))
+        resolve()
+        return anotherKit.tryUseNuxt()?.__name
+      }),
+      anotherKit.runWithNuxtContext(nuxt3, async () => {
+        await promise
+        return tryUseNuxt()?.__name
+      }),
+    ])).resolves.toEqual(['1', '2', '3'])
+
+    expect(tryUseNuxt()?.__name).toBeUndefined()
+    expect(anotherKit.tryUseNuxt()?.__name).toBeUndefined()
+  })
+
+  it('should conflict error nested ctx with same kit', () => {
+    const nuxt1 = { __name: '1' } as Nuxt
+    const nuxt2 = { __name: '2' } as Nuxt
+
+    expect(() => runWithNuxtContext(nuxt1, () =>
+      runWithNuxtContext(nuxt2, () => tryUseNuxt()?.__name),
+    )).toThrow(/conflict/)
+  })
+
+  it('should conflict error nested ctx with another kit', async () => {
+    vi.resetModules()
+    const anotherKit = await import('@nuxt/kit')
+
+    expect(anotherKit.tryUseNuxt).not.toBe(tryUseNuxt)
+
+    const nuxt1 = { __name: '1' } as Nuxt
+    const nuxt2 = { __name: '2' } as Nuxt
+
+    expect(() => runWithNuxtContext(nuxt1, () =>
+      anotherKit.runWithNuxtContext(nuxt2, () => tryUseNuxt()?.__name),
+    )).toThrow(/conflict/)
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

there is an issue where loading multiple Nuxt projects concurrently in test-utils fails.
it seems that when modules use different versions of kit, they refer to different `asyncNuxtStorage`, causing the Nuxt instance to become `undefined` and fall back to the wrong one via `nuxtCtx`.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
