### PR TITLE
docs: fix duplicate word in Nuxt Island docs

### DIFF
--- a/docs/4.api/1.components/8.nuxt-island.md
+++ b/docs/4.api/1.components/8.nuxt-island.md
@@ -74,4 +74,4 @@ Some slots are reserved to `NuxtIsland` for special cases.
   - **parameters**:
     - **error**:
       - **type**: `unknown`
-  - **description**: emitted when when `NuxtIsland` fails to fetch the new island.
+  - **description**: emitted when `NuxtIsland` fails to fetch the new island.


### PR DESCRIPTION
## Summary\n- Fix a duplicated word in the Nuxt Island docs.\n\n## Related issue\n- N/A\n\n## Guideline alignment\n- https://nuxt.com/docs/4.x/community/contribution\n\n## Validation/testing\n- Not run (docs-only).