### PR TITLE
fix(nitro,nuxt)!: drop support for script-type payloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,7 +325,6 @@ jobs:
         builder: ['vite', 'rspack', 'webpack']
         context: ['async', 'default']
         manifest: ['manifest-on', 'manifest-off']
-        payload: ['json', 'js']
         node: ['lts/-1']
         exclude:
           - builder: 'webpack'
@@ -377,7 +376,6 @@ jobs:
           TEST_BUILDER: ${{ matrix.builder }}
           TEST_MANIFEST: ${{ matrix.manifest }}
           TEST_CONTEXT: ${{ matrix.context }}
-          TEST_PAYLOAD: ${{ matrix.payload }}
           SKIP_BUNDLE_SIZE: true
           NITRO_NO_UNIX_SOCKET: ${{ matrix.env == 'dev' && '1' || '' }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,16 +327,6 @@ jobs:
         manifest: ['manifest-on', 'manifest-off']
         node: ['lts/-1']
         exclude:
-          - builder: 'webpack'
-            payload: 'js'
-          - builder: 'rspack'
-            payload: 'js'
-          - manifest: 'manifest-off'
-            payload: 'js'
-          - context: 'default'
-            payload: 'js'
-          - os: windows-latest
-            payload: 'js'
           - env: 'dev'
             builder: 'rspack'
           - manifest: 'manifest-off'

--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -1382,6 +1382,32 @@ However, to take advantage of improved type checking, you can opt in to the new 
 
 The new configuration provides better type safety and IntelliSense for projects that opt in, while maintaining full backward compatibility for existing setups.
 
+### Removal of Script-Type Payloads
+
+🚦 **Impact Level**: Minimal
+
+#### What Changed
+
+The `experimental.renderJsonPayloads` option has been removed. JSON payloads (`_payload.json`) are now the only supported payload format. Script-type payloads (`_payload.js`) are no longer available, and the `@nuxt/devalue` dependency has been removed.
+
+#### Reasons for Change
+
+JSON payloads have been the default since Nuxt 3.4 and offer better performance and security characteristics. Maintaining two payload formats added unnecessary complexity.
+
+#### Migration Steps
+
+If you had `experimental.renderJsonPayloads` set in your `nuxt.config.ts`, remove it:
+
+```diff
+  export default defineNuxtConfig({
+    experimental: {
+-     renderJsonPayloads: false,
+    },
+  })
+```
+
+If your application relied on script-type payloads (`_payload.js`), it will now automatically use JSON payloads (`_payload.json`) instead. No other changes should be required.
+
 ### Removal of Experimental Features
 
 🚦 **Impact Level**: Minimal
@@ -1395,6 +1421,7 @@ Four experimental features are no longer configurable in Nuxt 4:
 - `experimental.polyfillVueUseHead` will be `false` (default since v3.4)
 - `experimental.respectNoSSRHeader` will be `false` (default since v3.4)
 - `experimental.viteEnvironmentApi` is now always enabled and cannot be disabled
+- `experimental.renderJsonPayloads` has been removed (see [Removal of Script-Type Payloads](/docs/5.x/getting-started/upgrade#removal-of-script-type-payloads))
 
 #### Reasons for Change
 

--- a/docs/3.guide/6.going-further/1.experimental-features.md
+++ b/docs/3.guide/6.going-further/1.experimental-features.md
@@ -196,20 +196,6 @@ Read more in `defineRouteRules` utility.
 
 :read-more{to="/docs/4.x/guide/concepts/rendering#hybrid-rendering" icon="i-lucide-medal"}
 
-## renderJsonPayloads
-
-Allows rendering of JSON payloads with support for revivifying complex types.
-
-This flag is enabled by default, but you can disable this feature:
-
-```ts twoslash [nuxt.config.ts]
-export default defineNuxtConfig({
-  experimental: {
-    renderJsonPayloads: false,
-  },
-})
-```
-
 ## noVueServer
 
 Disables Vue server renderer endpoint within Nitro.

--- a/packages/nitro-server/package.json
+++ b/packages/nitro-server/package.json
@@ -32,7 +32,6 @@
   },
   "dependencies": {
     "@babel/plugin-syntax-typescript": "^7.28.6",
-    "@nuxt/devalue": "^2.0.2",
     "@nuxt/kit": "workspace:*",
     "@unhead/vue": "^2.1.12",
     "@vue/shared": "^3.5.30",

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -226,7 +226,6 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
           `export const NUXT_NO_SCRIPTS = ${nuxt.options.features.noScripts === 'all' || (!!nuxt.options.features.noScripts && !nuxt.options.dev)}`,
           `export const NUXT_INLINE_STYLES = ${!!nuxt.options.features.inlineStyles}`,
           `export const PARSE_ERROR_DATA = ${!!nuxt.options.experimental.parseErrorData}`,
-          `export const NUXT_JSON_PAYLOADS = ${!!nuxt.options.experimental.renderJsonPayloads}`,
           `export const NUXT_ASYNC_CONTEXT = ${!!nuxt.options.experimental.asyncContext}`,
           `export const NUXT_SHARED_DATA = ${!!nuxt.options.experimental.sharedPrerenderData}`,
           `export const NUXT_PAYLOAD_EXTRACTION = ${nuxt.options.experimental.payloadExtraction !== false}`,
@@ -517,7 +516,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
         const prerenderedRoutes = new Set<string>()
         const routeRulesMatcher = getRouteRulesRouter()
         if (nitro._prerenderedRoutes?.length) {
-          const payloadSuffix = nuxt.options.experimental.renderJsonPayloads ? '/_payload.json' : '/_payload.js'
+          const payloadSuffix = '/_payload.json'
           for (const route of nitro._prerenderedRoutes) {
             if (!route.error && route.route.endsWith(payloadSuffix)) {
               const url = route.route.slice(0, -payloadSuffix.length) || '/'

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -804,7 +804,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
   nuxt['~runtimeDependencies'] ||= []
   nuxt['~runtimeDependencies']!.push(
     ...runtimeDependencies,
-    'unhead', '@unhead/vue', '@nuxt/devalue', 'unstorage',
+    'unhead', '@unhead/vue', 'unstorage',
     // ensure we only have one version of vue if nitro is going to inline anyway
     ...nitro.options.inlineDynamicImports ? ['vue', '@vue/server-renderer'] : [],
   )

--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -13,14 +13,14 @@ import type { NuxtPayload, NuxtRenderHTMLContext, NuxtSSRContext } from 'nuxt/ap
 import { getRenderer } from '../utils/renderer/build-files'
 import { payloadCache } from '../utils/cache'
 
-import { renderPayloadJsonScript, renderPayloadResponse, renderPayloadScript, splitPayload } from '../utils/renderer/payload'
+import { renderPayloadJsonScript, renderPayloadResponse, splitPayload } from '../utils/renderer/payload'
 import { createSSRContext, setSSRError } from '../utils/renderer/app'
 import { renderInlineStyles } from '../utils/renderer/inline-styles'
 import { replaceIslandTeleports } from '../utils/renderer/islands'
 // @ts-expect-error virtual file
 import { renderSSRHeadOptions } from '#internal/unhead.config.mjs'
 // @ts-expect-error virtual file
-import { NUXT_ASYNC_CONTEXT, NUXT_EARLY_HINTS, NUXT_INLINE_STYLES, NUXT_JSON_PAYLOADS, NUXT_NO_SCRIPTS, NUXT_PAYLOAD_EXTRACTION, NUXT_PAYLOAD_INLINE, NUXT_RUNTIME_PAYLOAD_EXTRACTION, PARSE_ERROR_DATA } from '#internal/nuxt/nitro-config.mjs'
+import { NUXT_ASYNC_CONTEXT, NUXT_EARLY_HINTS, NUXT_INLINE_STYLES, NUXT_NO_SCRIPTS, NUXT_PAYLOAD_EXTRACTION, NUXT_PAYLOAD_INLINE, NUXT_RUNTIME_PAYLOAD_EXTRACTION, PARSE_ERROR_DATA } from '#internal/nuxt/nitro-config.mjs'
 // @ts-expect-error virtual file
 import { appHead, appTeleportAttrs, appTeleportTag, componentIslands, appManifest as isAppManifestEnabled } from '#internal/nuxt.config.mjs'
 // @ts-expect-error virtual file
@@ -45,8 +45,8 @@ const HAS_APP_TELEPORTS = !!(appTeleportTag && appTeleportAttrs.id)
 const APP_TELEPORT_OPEN_TAG = HAS_APP_TELEPORTS ? `<${appTeleportTag}${propsToString(appTeleportAttrs)}>` : ''
 const APP_TELEPORT_CLOSE_TAG = HAS_APP_TELEPORTS ? `</${appTeleportTag}>` : ''
 
-const PAYLOAD_URL_RE = NUXT_JSON_PAYLOADS ? /^[^?]*\/_payload.json(?:\?.*)?$/ : /^[^?]*\/_payload.js(?:\?.*)?$/
-const PAYLOAD_FILENAME = NUXT_JSON_PAYLOADS ? '_payload.json' : '_payload.js'
+const PAYLOAD_URL_RE = /^[^?]*\/_payload.json(?:\?.*)?$/
+const PAYLOAD_FILENAME = '_payload.json'
 
 let entryPath: string
 
@@ -74,10 +74,8 @@ const handler: EventHandler = defineRenderHandler(async (event): Promise<Partial
   ssrContext.head.push(appHead, headEntryOptions)
 
   if (ssrError) {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const status = ssrError.status || ssrError.statusCode
     if (status) {
-      // eslint-disable-next-line @typescript-eslint/no-deprecated
       ssrError.status = ssrError.statusCode = Number.parseInt(status as any)
     }
     if (PARSE_ERROR_DATA && typeof ssrError.data === 'string') {
@@ -224,9 +222,7 @@ const handler: EventHandler = defineRenderHandler(async (event): Promise<Partial
   if (_PAYLOAD_EXTRACTION && !_PAYLOAD_INLINE && !NO_SCRIPTS) {
     ssrContext.head.push({
       link: [
-        NUXT_JSON_PAYLOADS
-          ? { rel: 'preload', as: 'fetch', crossorigin: 'anonymous', href: payloadURL }
-          : { rel: 'modulepreload', crossorigin: '', href: payloadURL },
+        { rel: 'preload', as: 'fetch', crossorigin: 'anonymous', href: payloadURL },
       ],
     }, headEntryOptions)
   }
@@ -279,13 +275,9 @@ const handler: EventHandler = defineRenderHandler(async (event): Promise<Partial
     ssrContext.head.push({
       script: _PAYLOAD_INLINE
         // Inline full payload in HTML (payloadExtraction: 'client' | false, or non-cached route)
-        ? NUXT_JSON_PAYLOADS
-          ? renderPayloadJsonScript({ ssrContext, data: ssrContext.payload })
-          : renderPayloadScript({ ssrContext, data: ssrContext.payload, routeOptions })
+        ? renderPayloadJsonScript({ ssrContext, data: ssrContext.payload })
         // Split payload: inline initial data, reference external _payload.json via src (payloadExtraction: true)
-        : NUXT_JSON_PAYLOADS
-          ? renderPayloadJsonScript({ ssrContext, data: splitPayload(ssrContext).initial, src: payloadURL })
-          : renderPayloadScript({ ssrContext, data: splitPayload(ssrContext).initial, routeOptions, src: payloadURL }),
+        : renderPayloadJsonScript({ ssrContext, data: splitPayload(ssrContext).initial, src: payloadURL }),
     }, {
       ...headEntryOptions,
       // this should come before another end of body scripts
@@ -296,8 +288,6 @@ const handler: EventHandler = defineRenderHandler(async (event): Promise<Partial
 
   // 6. Scripts
   if (!routeOptions.noScripts) {
-    const tagPosition = (_PAYLOAD_EXTRACTION && !_PAYLOAD_INLINE && !NUXT_JSON_PAYLOADS) ? 'bodyClose' : 'head'
-
     ssrContext.head.push({
       script: Object.values(scripts).map(resource => (<Script> {
         type: resource.module ? 'module' : null,
@@ -305,7 +295,7 @@ const handler: EventHandler = defineRenderHandler(async (event): Promise<Partial
         defer: resource.module ? null : true,
         // if we are rendering script tag payloads that import an async payload
         // we need to ensure this resolves before executing the Nuxt entry
-        tagPosition,
+        tagPosition: 'head',
         crossorigin: '',
       })),
     }, headEntryOptions)

--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -74,8 +74,10 @@ const handler: EventHandler = defineRenderHandler(async (event): Promise<Partial
   ssrContext.head.push(appHead, headEntryOptions)
 
   if (ssrError) {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const status = ssrError.status || ssrError.statusCode
     if (status) {
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
       ssrError.status = ssrError.statusCode = Number.parseInt(status as any)
     }
     if (PARSE_ERROR_DATA && typeof ssrError.data === 'string') {

--- a/packages/nitro-server/src/runtime/utils/renderer/payload.ts
+++ b/packages/nitro-server/src/runtime/utils/renderer/payload.ts
@@ -1,6 +1,5 @@
-import type { NitroRouteRules, RenderResponse } from 'nitropack/types'
+import type { RenderResponse } from 'nitropack/types'
 import { getResponseStatus, getResponseStatusText } from 'h3'
-import devalue from '@nuxt/devalue'
 import { stringify, uneval } from 'devalue'
 import type { Script } from '@unhead/vue'
 
@@ -9,17 +8,15 @@ import type { NuxtPayload, NuxtSSRContext } from 'nuxt/app'
 // @ts-expect-error virtual file
 import { appId, multiApp } from '#internal/nuxt.config.mjs'
 // @ts-expect-error virtual file
-import { NUXT_JSON_PAYLOADS, NUXT_NO_SSR } from '#internal/nuxt/nitro-config.mjs'
+import { NUXT_NO_SSR } from '#internal/nuxt/nitro-config.mjs'
 
 export function renderPayloadResponse (ssrContext: NuxtSSRContext): RenderResponse {
   return {
-    body: NUXT_JSON_PAYLOADS
-      ? encodeForwardSlashes(stringify(splitPayload(ssrContext).payload, ssrContext['~payloadReducers']))
-      : `export default ${devalue(splitPayload(ssrContext).payload)}`,
+    body: encodeForwardSlashes(stringify(splitPayload(ssrContext).payload, ssrContext['~payloadReducers'])),
     statusCode: getResponseStatus(ssrContext.event),
     statusMessage: getResponseStatusText(ssrContext.event),
     headers: {
-      'content-type': NUXT_JSON_PAYLOADS ? 'application/json;charset=utf-8' : 'text/javascript;charset=utf-8',
+      'content-type': 'application/json;charset=utf-8',
       'x-powered-by': 'Nuxt',
     },
   }
@@ -57,44 +54,6 @@ export function renderPayloadJsonScript (opts: { ssrContext: NuxtSSRContext, dat
  */
 function encodeForwardSlashes (str: string): string {
   return str.replaceAll('/', '\\u002F')
-}
-
-/**
- * Escape a string for safe interpolation inside a double-quoted JavaScript string literal.
- * Prevents XSS when user-controlled URLs are embedded in inline `<script>` tags.
- */
-function escapeJsString (str: string): string {
-  return str
-    .replaceAll('\\', '\\\\')
-    .replaceAll('"', '\\"')
-    .replaceAll('\n', '\\n')
-    .replaceAll('\r', '\\r')
-    .replaceAll('/', '\\u002F')
-    .replaceAll('<', '\\u003C')
-}
-
-export function renderPayloadScript (opts: { ssrContext: NuxtSSRContext, routeOptions: NitroRouteRules, data?: any, src?: string }): Script[] {
-  opts.data.config = opts.ssrContext.config
-  const nuxtData = devalue(opts.data)
-  if (opts.src) {
-    // Escape the URL to prevent XSS when interpolated into a JS string literal
-    const escapedSrc = escapeJsString(opts.src!)
-    const singleAppPayload = `import p from "${escapedSrc}";window.__NUXT__={...p,...(${nuxtData})}`
-    const multiAppPayload = `import p from "${escapedSrc}";window.__NUXT__=window.__NUXT__||{};window.__NUXT__[${JSON.stringify(appId)}]={...p,...(${nuxtData})}`
-    return [
-      {
-        type: 'module',
-        innerHTML: multiApp ? multiAppPayload : singleAppPayload,
-      },
-    ]
-  }
-  const singleAppPayload = `window.__NUXT__=${nuxtData}`
-  const multiAppPayload = `window.__NUXT__=window.__NUXT__||{};window.__NUXT__[${JSON.stringify(appId)}]=${nuxtData}`
-  return [
-    {
-      innerHTML: multiApp ? multiAppPayload : singleAppPayload,
-    },
-  ]
 }
 
 interface SplitPayload {

--- a/packages/nuxt/src/app/composables/payload.ts
+++ b/packages/nuxt/src/app/composables/payload.ts
@@ -9,7 +9,7 @@ import { useRoute } from './router'
 import { getAppManifest, getRouteRules } from './manifest'
 
 // @ts-expect-error virtual import
-import { appId, appManifest, multiApp, payloadExtraction, renderJsonPayloads } from '#build/nuxt.config.mjs'
+import { appId, appManifest, multiApp, payloadExtraction } from '#build/nuxt.config.mjs'
 
 interface LoadPayloadOptions {
   fresh?: boolean
@@ -41,9 +41,8 @@ export function preloadPayload (url: string, opts: LoadPayloadOptions = {}): Pro
       return
     }
     const payloadURL = await _getPayloadURL(url, opts)
-    const link = renderJsonPayloads
-      ? { rel: detectLinkRelType(), as: 'fetch', crossorigin: 'anonymous', href: payloadURL } as const
-      : { rel: 'modulepreload', crossorigin: '', href: payloadURL } as const
+    const link = { rel: detectLinkRelType(), as: 'fetch', crossorigin: 'anonymous', href: payloadURL } as const
+
 
     if (import.meta.server) {
       nuxtApp.runWithContext(() => useHead({ link: [link] }))
@@ -67,7 +66,7 @@ export function preloadPayload (url: string, opts: LoadPayloadOptions = {}): Pro
 
 // --- Internal ---
 
-const filename = renderJsonPayloads ? '_payload.json' : '_payload.js'
+const filename = '_payload.json'
 async function _getPayloadURL (url: string, opts: LoadPayloadOptions = {}) {
   const u = new URL(url, 'http://localhost')
   if (u.host !== 'localhost' || hasProtocol(u.pathname, { acceptRelative: true })) {
@@ -82,9 +81,8 @@ async function _getPayloadURL (url: string, opts: LoadPayloadOptions = {}) {
 
 async function _importPayload (payloadURL: string) {
   if (import.meta.server || !payloadExtraction) { return null }
-  const payloadPromise = renderJsonPayloads
-    ? fetch(payloadURL, import.meta.dev ? {} : { cache: 'force-cache' }).then(res => res.text().then(parsePayload))
-    : import(/* webpackIgnore: true */ /* @vite-ignore */ payloadURL).then(r => r.default || r)
+  const payloadPromise = fetch(payloadURL, import.meta.dev ? {} : { cache: 'force-cache' }).then(res => res.text().then(parsePayload))
+
 
   try {
     return await payloadPromise

--- a/packages/nuxt/src/app/composables/payload.ts
+++ b/packages/nuxt/src/app/composables/payload.ts
@@ -43,7 +43,6 @@ export function preloadPayload (url: string, opts: LoadPayloadOptions = {}): Pro
     const payloadURL = await _getPayloadURL(url, opts)
     const link = { rel: detectLinkRelType(), as: 'fetch', crossorigin: 'anonymous', href: payloadURL } as const
 
-
     if (import.meta.server) {
       nuxtApp.runWithContext(() => useHead({ link: [link] }))
     } else {
@@ -82,7 +81,6 @@ async function _getPayloadURL (url: string, opts: LoadPayloadOptions = {}) {
 async function _importPayload (payloadURL: string) {
   if (import.meta.server || !payloadExtraction) { return null }
   const payloadPromise = fetch(payloadURL, import.meta.dev ? {} : { cache: 'force-cache' }).then(res => res.text().then(parsePayload))
-
 
   try {
     return await payloadPromise

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -720,11 +720,9 @@ async function initNuxt (nuxt: Nuxt) {
     addPlugin(resolve(nuxt.options.appDir, 'plugins/view-transitions.client'))
   }
 
-  // Add experimental support for custom types in JSON payload
-  if (nuxt.options.experimental.renderJsonPayloads) {
-    addPlugin(resolve(nuxt.options.appDir, 'plugins/revive-payload.client'))
-    addPlugin(resolve(nuxt.options.appDir, 'plugins/revive-payload.server'))
-  }
+  // Add support for custom types in JSON payload
+  addPlugin(resolve(nuxt.options.appDir, 'plugins/revive-payload.client'))
+  addPlugin(resolve(nuxt.options.appDir, 'plugins/revive-payload.server'))
 
   addRouteMiddleware({
     name: 'manifest-route-rule',

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -525,7 +525,6 @@ export const nuxtConfigTemplate: NuxtTemplate = {
     const payloadExtraction = !!ctx.nuxt.options.experimental.payloadExtraction && (nitro.options.static || hasCachedRoutes || (nitro.options.prerender.routes && nitro.options.prerender.routes.length > 0) || Object.values(nitro.options.routeRules).some(r => r.prerender))
     return [
       ...Object.entries(ctx.nuxt.options.app).map(([k, v]) => `export const ${camelCase('app-' + k)} = ${JSON.stringify(v)}`),
-      `export const renderJsonPayloads = ${!!ctx.nuxt.options.experimental.renderJsonPayloads}`,
       `export const componentIslands = ${shouldEnableComponentIslands}`,
       `export const payloadExtraction = ${payloadExtraction}`,
       `export const cookieStore = ${!!ctx.nuxt.options.experimental.cookieStore}`,

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -95,7 +95,6 @@ export default defineResolvers({
     },
     templateRouteInjection: true,
     restoreState: false,
-    renderJsonPayloads: true,
     noVueServer: false,
     payloadExtraction: {
       $resolve: async (val, get) => {

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1107,13 +1107,6 @@ export interface ConfigSchema {
     restoreState: boolean
 
     /**
-     * Render JSON payloads with support for revivifying complex types.
-     *
-     * @default true
-     */
-    renderJsonPayloads: boolean
-
-    /**
      * Disable vue server renderer endpoint within nitro.
      *
      * @default false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -346,9 +346,6 @@ importers:
       '@babel/plugin-syntax-typescript':
         specifier: ^7.28.6
         version: 7.28.6(@babel/core@7.29.0)
-      '@nuxt/devalue':
-        specifier: ^2.0.2
-        version: 2.0.2
       '@nuxt/kit':
         specifier: workspace:*
         version: link:../kit
@@ -2306,9 +2303,6 @@ packages:
     peerDependenciesMeta:
       '@nuxt/schema':
         optional: true
-
-  '@nuxt/devalue@2.0.2':
-    resolution: {integrity: sha512-GBzP8zOc7CGWyFQS6dv1lQz8VVpz5C2yRszbXufwG/9zhStTIH50EtD87NmWbTMwXDvZLNg8GIpb1UFdH93JCA==}
 
   '@nuxt/devtools-kit@2.7.0':
     resolution: {integrity: sha512-MIJdah6CF6YOW2GhfKnb8Sivu6HpcQheqdjOlZqShBr+1DyjtKQbAKSCAyKPaoIzZP4QOo2SmTFV6aN8jBeEIQ==}
@@ -10577,8 +10571,6 @@ snapshots:
       - commander
       - magicast
       - supports-color
-
-  '@nuxt/devalue@2.0.2': {}
 
   '@nuxt/devtools-kit@2.7.0(vite@8.0.0-beta.18(@types/node@24.12.0)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.2))':
     dependencies:

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -9,7 +9,7 @@ import { $fetchComponent } from '@nuxt/test-utils/experimental'
 import { createRegExp, exactly } from 'magic-regexp'
 import type { NuxtIslandResponse } from 'nuxt/app'
 
-import { asyncContext, builder, isDev, isRenderingJson, isTestingAppManifest, isWebpack } from './matrix'
+import { asyncContext, builder, isDev, isTestingAppManifest, isWebpack } from './matrix'
 import { expectNoClientErrors, gotoPath, parseData, parsePayload, renderPage } from './utils'
 
 await setup({
@@ -72,9 +72,7 @@ describe('route rules', () => {
 
     const { script, attrs } = parseData(headHtml)
     expect(script.serverRendered).toEqual(false)
-    if (isRenderingJson) {
-      expect(attrs['data-ssr']).toEqual('false')
-    }
+    expect(attrs['data-ssr']).toEqual('false')
     await expectNoClientErrors('/route-rules/spa')
   })
 
@@ -2193,15 +2191,11 @@ describe('server components/islands', () => {
   it.skipIf(isDev)('should allow server-only components to set prerender hints', async () => {
     // @ts-expect-error ssssh! untyped secret property
     const publicDir = useTestContext().nuxt._nitro.options.output.publicDir
-    expect(await readdir(join(publicDir, 'catchall', 'some', 'url', 'from', 'server-only', 'component')).catch(() => [])).toContain(
-      isRenderingJson
-        ? '_payload.json'
-        : '_payload.js',
-    )
+    expect(await readdir(join(publicDir, 'catchall', 'some', 'url', 'from', 'server-only', 'component')).catch(() => [])).toContain('_payload.json')
   })
 })
 
-describe.skipIf(isDev || isWindows || !isRenderingJson)('prefetching', () => {
+describe.skipIf(isDev || isWindows)('prefetching', () => {
   it('should prefetch components', async () => {
     await expectNoClientErrors('/prefetch/components')
   })
@@ -2708,7 +2702,7 @@ describe.runIf(isDev && !isWebpack)('vite plugins', () => {
   })
 })
 
-describe.skipIf(isWindows || !isRenderingJson)('payload rendering', () => {
+describe.skipIf(isWindows)('payload rendering', () => {
   it('renders a payload', async () => {
     const payload = await $fetch<string>('/random/a/_payload.json', { responseType: 'text' })
     const data = parsePayload(payload)
@@ -2771,7 +2765,7 @@ describe.skipIf(isWindows || !isRenderingJson)('payload rendering', () => {
     expect(res.status).toBe(404)
   })
 
-  it.skipIf(!isRenderingJson)('should not include server-component HTML in payload', async () => {
+  it('should not include server-component HTML in payload', async () => {
     const payload = await $fetch<string>('/prefetch/server-components/_payload.json', { responseType: 'text' })
     const entries = Object.entries(parsePayload(payload))
     const [key, serializedComponent] = entries.find(([key]) => key.startsWith('AsyncServerComponent')) || []

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -118,7 +118,6 @@ describe('route rules', () => {
       ssr: false,
     })
     expect(routeRules['/route-rules/isr-spa/_payload.json']).toBeUndefined()
-    expect(routeRules['/route-rules/isr-spa/_payload.js']).toBeUndefined()
   })
 })
 

--- a/test/matrix.ts
+++ b/test/matrix.ts
@@ -14,8 +14,6 @@ export const isTestingAppManifest = process.env.TEST_MANIFEST !== 'manifest-off'
 export const asyncContext = process.env.TEST_CONTEXT === 'async'
 export const typescriptBundlerResolution = process.env.MODULE_RESOLUTION !== 'node'
 
-export const isRenderingJson = process.env.TEST_PAYLOAD !== 'js'
-
 export function withMatrix (config: NuxtConfig) {
   return defu(config, {
     builder,
@@ -25,7 +23,6 @@ export function withMatrix (config: NuxtConfig) {
     experimental: {
       asyncContext,
       appManifest: isTestingAppManifest,
-      renderJsonPayloads: isRenderingJson,
     },
     compatibilityDate: 'latest',
   })

--- a/test/nuxt/nuxt-island.test.ts
+++ b/test/nuxt/nuxt-island.test.ts
@@ -41,8 +41,6 @@ vi.mock('#build/nuxt.config.mjs', () => {
     appTeleportAttrs: { id: 'teleports' },
     appTeleportTag: 'div',
     appViewTransition: false,
-    // nuxt.config.mjs template exports
-    renderJsonPayloads: true,
     componentIslands: true,
     payloadExtraction: false,
     cookieStore: false,

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -6,7 +6,6 @@ import { reactive, ref, shallowReactive, shallowRef } from 'vue'
 import { createError } from 'h3'
 import { getBrowser, url, useTestContext } from '@nuxt/test-utils/e2e'
 import { isCI } from 'std-env'
-import { isRenderingJson } from './matrix'
 
 export async function renderPage (path = '/', opts?: { retries?: number }) {
   const ctx = useTestContext()
@@ -93,15 +92,6 @@ export function parsePayload (payload: string) {
   return parse(payload || '', revivers)
 }
 export function parseData (html: string) {
-  if (!isRenderingJson) {
-    const { script = '' } = html.match(/<script>(?<script>window.__NUXT__.*?)<\/script>/)?.groups || {}
-    const _script = new Script(script)
-    return {
-      script: _script.runInContext(createContext({ window: {} })),
-      attrs: {},
-    }
-  }
-
   const regexp = /<script type="application\/json" data-nuxt-data="[^"]+"(?<attrs>[^>]+)>(?<script>.*?)<\/script>/
   const { script, attrs = '' } = html.match(regexp)?.groups || {}
   const _attrs: Record<string, string> = {}

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,4 +1,3 @@
-import { Script, createContext } from 'node:vm'
 import { expect, vi } from 'vitest'
 import type { Page } from 'playwright-core'
 import { parse } from 'devalue'


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this drops support for script-type payloads and the `@nuxt/devalue` dependency

🚦 **Impact Level**: Minimal

#### What Changed

The `experimental.renderJsonPayloads` option has been removed. JSON payloads (`_payload.json`) are now the only supported payload format. Script-type payloads (`_payload.js`) are no longer available, and the `@nuxt/devalue` dependency has been removed.

#### Reasons for Change

JSON payloads have been the default since Nuxt 3.4 and offer better performance and security characteristics. Maintaining two payload formats added unnecessary complexity.

#### Migration Steps

If you had `experimental.renderJsonPayloads` set in your `nuxt.config.ts`, remove it:

```diff
  export default defineNuxtConfig({
    experimental: {
-     renderJsonPayloads: false,
    },
  })
```

If your application relied on script-type payloads (`_payload.js`), it will now automatically use JSON payloads (`_payload.json`) instead. No other changes should be required.
