### PR TITLE
fix(nuxt): check file freshness before truncating in cache restore

### DIFF
--- a/packages/nuxt/src/core/cache.ts
+++ b/packages/nuxt/src/core/cache.ts
@@ -294,7 +294,8 @@ async function restoreCacheFromFile (cwd: string, cacheFile: string) {
 
       // Stat before open('w') since it truncates the file
       const existingStats = await stat(filePath).catch(() => null)
-      if (existingStats?.isFile() && existingStats.size) {
+      const cachedSize = file.data?.byteLength ?? 0
+      if (existingStats?.isFile() && existingStats.size === cachedSize) {
         const lastModified = Number.parseInt(file.attrs?.mtime?.toString().padEnd(13, '0') || '0')
         if (existingStats.mtime.getTime() >= lastModified) {
           consola.debug(`Skipping \`${file.name}\` (up to date or newer than cache)`)

--- a/packages/nuxt/src/core/cache.ts
+++ b/packages/nuxt/src/core/cache.ts
@@ -292,16 +292,17 @@ async function restoreCacheFromFile (cwd: string, cacheFile: string) {
 
       await mkdir(dirname(filePath), { recursive: true })
 
-      fd = await open(filePath, 'w')
-
-      const stats = await fd.stat().catch(() => null)
-      if (stats?.isFile() && stats.size) {
+      // Stat before open('w') since it truncates the file
+      const existingStats = await stat(filePath).catch(() => null)
+      if (existingStats?.isFile() && existingStats.size) {
         const lastModified = Number.parseInt(file.attrs?.mtime?.toString().padEnd(13, '0') || '0')
-        if (stats.mtime.getTime() >= lastModified) {
+        if (existingStats.mtime.getTime() >= lastModified) {
           consola.debug(`Skipping \`${file.name}\` (up to date or newer than cache)`)
           continue
         }
       }
+
+      fd = await open(filePath, 'w')
       await fd.writeFile(file.data!)
     } catch (err) {
       console.error(err)


### PR DESCRIPTION
`restoreCacheFromFile` checks whether a cached file is already up to date before writing it, but the check never worked. The function calls `open(filePath, 'w')` before `stat()`, and `'w'` mode truncates the file to zero length immediately. So `fd.stat()` always returns `size: 0`, the freshness comparison is always skipped, and every file gets rewritten unconditionally.

This moves the `stat()` call before `open('w')` so the existing file's size and mtime are read while the file still has its contents. Files that are already current get skipped, saving I/O during cache restoration.