### PR TITLE
fix(nitro): validate island handler context

### DIFF
--- a/packages/nitro-server/src/runtime/handlers/island.ts
+++ b/packages/nitro-server/src/runtime/handlers/island.ts
@@ -3,7 +3,7 @@ import type { RenderResponse } from 'nitropack/types'
 import type { Link, SerializableHead } from '@unhead/vue/types'
 import { destr } from 'destr'
 import type { EventHandler, H3Event } from 'h3'
-import { defineEventHandler, getQuery, readBody, setResponseHeaders } from 'h3'
+import { createError, defineEventHandler, getQuery, readBody, setResponseHeaders } from 'h3'
 import { resolveUnrefHeadInput } from '@unhead/vue'
 import { getRequestDependencies } from 'vue-bundle-renderer/runtime'
 import { getQuery as getURLQuery } from 'ufo'
@@ -110,29 +110,37 @@ const handler: EventHandler = defineEventHandler(async (event) => {
 
 export default handler
 
+const ISLAND_PATH_PREFIX = '/__nuxt_island/'
+const VALID_COMPONENT_NAME_RE = /^[a-z][\w.-]*$/i
+
 async function getIslandContext (event: H3Event): Promise<NuxtIslandContext> {
-  // TODO: Strict validation for url
   let url = event.path || ''
   if (import.meta.prerender && event.path && await islandPropCache!.hasItem(event.path)) {
     // rehydrate props from cache so we can rerender island if cache does not have it any more
     url = await islandPropCache!.getItem(event.path) as string
   }
-  const componentParts = url.substring('/__nuxt_island'.length + 1).replace(ISLAND_SUFFIX_RE, '').split('_')
+
+  if (!url.startsWith(ISLAND_PATH_PREFIX)) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid island request path' })
+  }
+
+  const componentParts = url.substring(ISLAND_PATH_PREFIX.length).replace(ISLAND_SUFFIX_RE, '').split('_')
   const hashId = componentParts.length > 1 ? componentParts.pop() : undefined
   const componentName = componentParts.join('_')
 
-  // TODO: Validate context
+  if (!componentName || !VALID_COMPONENT_NAME_RE.test(componentName)) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid island component name' })
+  }
+
   const context = event.method === 'GET' ? getQuery(event) : await readBody(event)
 
-  const ctx: NuxtIslandContext = {
-    url: '/',
-    ...context,
+  // Only extract known context fields to prevent arbitrary data injection
+  return {
+    url: typeof context.url === 'string' ? context.url : '/',
     id: hashId,
     name: componentName,
     props: destr(context.props) || {},
     slots: {},
     components: {},
   }
-
-  return ctx
 }

--- a/packages/nitro-server/src/runtime/handlers/island.ts
+++ b/packages/nitro-server/src/runtime/handlers/island.ts
@@ -136,7 +136,7 @@ async function getIslandContext (event: H3Event): Promise<NuxtIslandContext> {
 
   // Only extract known context fields to prevent arbitrary data injection
   return {
-    url: typeof context.url === 'string' ? context.url : '/',
+    url: typeof context?.url === 'string' ? context.url : '/',
     id: hashId,
     name: componentName,
     props: destr(context.props) || {},

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -124,7 +124,7 @@ describe.skipIf(isStubbed || process.env.SKIP_BUNDLE_SIZE === 'true' || process.
     const serverDir = join(pagesRootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"403k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"404k"`)
 
     const modules = await analyzeSizes(['node_modules/**/*'], serverDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"1461k"`)


### PR DESCRIPTION
### 🔗 Linked issue

<!-- no existing issue, this addresses inline TODOs -->

### 📚 Description

`getIslandContext` had two TODOs about missing validation: one for strict URL validation and one for context validation. The function also spread untrusted request data (`...context`) into the island context, though only the `url` field actually survived (everything else was overwritten right after).

This adds:
- a path prefix check so the handler rejects requests that don't target `/__nuxt_island/`
- component name validation against `/^[a-z][\w.-]*$/i`
- explicit extraction of known fields instead of the spread, which prevents arbitrary properties from leaking into the context