### PR TITLE
fix(nuxt): fix cookie expiration timeout for long-lived cookies

### DIFF
--- a/packages/nuxt/src/app/composables/cookie.ts
+++ b/packages/nuxt/src/app/composables/cookie.ts
@@ -290,18 +290,22 @@ function cookieRef<T> (value: T | undefined, delay: number, shouldWatch: boolean
   return customRef((track, trigger) => {
     if (shouldWatch) { unsubscribe = watch(internalRef, trigger) }
 
-    function createExpirationTimeout () {
-      elapsed = 0
-      clearTimeout(timeout)
+    function scheduleTimeout () {
       const timeRemaining = delay - elapsed
       const timeoutLength = timeRemaining < MAX_TIMEOUT_DELAY ? timeRemaining : MAX_TIMEOUT_DELAY
       timeout = setTimeout(() => {
         elapsed += timeoutLength
-        if (elapsed < delay) { return createExpirationTimeout() }
+        if (elapsed < delay) { return scheduleTimeout() }
 
         internalRef.value = undefined
         trigger()
       }, timeoutLength)
+    }
+
+    function createExpirationTimeout () {
+      elapsed = 0
+      clearTimeout(timeout)
+      scheduleTimeout()
     }
 
     return {

--- a/test/nuxt/cookie-expiration.test.ts
+++ b/test/nuxt/cookie-expiration.test.ts
@@ -1,0 +1,137 @@
+/// <reference path="../fixtures/basic/.nuxt/nuxt.d.ts" />
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { computed } from 'vue'
+
+const MAX_TIMEOUT_DELAY = 2_147_483_647
+
+describe('useCookie expiration timeout', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('should expire cookie ref after maxAge elapses', () => {
+    const maxAge = 60 // 60 seconds
+    const cookie = useCookie('expire-short', {
+      default: () => 'value',
+      maxAge,
+    })
+
+    expect(cookie.value).toBe('value')
+
+    // Setting the cookie starts the expiration timeout
+    cookie.value = 'updated'
+    expect(cookie.value).toBe('updated')
+
+    // Advance time just before expiration
+    vi.advanceTimersByTime(maxAge * 1000 - 1)
+    expect(cookie.value).toBe('updated')
+
+    // Advance past expiration
+    vi.advanceTimersByTime(1)
+    expect(cookie.value).toBeUndefined()
+  })
+
+  it('should expire cookie ref when maxAge exceeds MAX_TIMEOUT_DELAY', () => {
+    // 30 days in seconds — exceeds MAX_TIMEOUT_DELAY (~24.8 days in ms)
+    const maxAge = 30 * 24 * 60 * 60
+    const delayMs = maxAge * 1000
+
+    // Sanity check: this delay requires chunked timeouts
+    expect(delayMs).toBeGreaterThan(MAX_TIMEOUT_DELAY)
+
+    const cookie = useCookie('expire-long', {
+      default: () => 'long-lived',
+      maxAge,
+    })
+
+    // Trigger the expiration timeout by setting a value
+    cookie.value = 'long-lived'
+    expect(cookie.value).toBe('long-lived')
+
+    // Advance past one MAX_TIMEOUT_DELAY chunk — should still be alive
+    vi.advanceTimersByTime(MAX_TIMEOUT_DELAY)
+    expect(cookie.value).toBe('long-lived')
+
+    // Advance remaining time minus 1ms
+    const remaining = delayMs - MAX_TIMEOUT_DELAY
+    vi.advanceTimersByTime(remaining - 1)
+    expect(cookie.value).toBe('long-lived')
+
+    // Final millisecond triggers expiration
+    vi.advanceTimersByTime(1)
+    expect(cookie.value).toBeUndefined()
+  })
+
+  it('should expire cookie ref when maxAge requires more than two timeout chunks', () => {
+    // 60 days in seconds — requires 3 chunks
+    const maxAge = 60 * 24 * 60 * 60
+    const delayMs = maxAge * 1000
+
+    expect(delayMs).toBeGreaterThan(MAX_TIMEOUT_DELAY * 2)
+
+    const cookie = useCookie('expire-very-long', {
+      default: () => 'value',
+      maxAge,
+    })
+
+    cookie.value = 'value'
+    expect(cookie.value).toBe('value')
+
+    // Advance through first two chunks
+    vi.advanceTimersByTime(MAX_TIMEOUT_DELAY)
+    expect(cookie.value).toBe('value')
+
+    vi.advanceTimersByTime(MAX_TIMEOUT_DELAY)
+    expect(cookie.value).toBe('value')
+
+    // Advance remaining time
+    const remaining = delayMs - MAX_TIMEOUT_DELAY * 2
+    vi.advanceTimersByTime(remaining)
+    expect(cookie.value).toBeUndefined()
+  })
+
+  it('should reset expiration when cookie value is re-set', () => {
+    const maxAge = 60
+    const cookie = useCookie('expire-reset', {
+      default: () => 'initial',
+      maxAge,
+    })
+
+    cookie.value = 'first'
+
+    // Advance halfway
+    vi.advanceTimersByTime(maxAge * 1000 / 2)
+    expect(cookie.value).toBe('first')
+
+    // Re-set the value — this should reset the expiration timer
+    cookie.value = 'second'
+
+    // Advance to what would have been the original expiration
+    vi.advanceTimersByTime(maxAge * 1000 / 2)
+    expect(cookie.value).toBe('second')
+
+    // Advance the remaining half — now it should expire
+    vi.advanceTimersByTime(maxAge * 1000 / 2)
+    expect(cookie.value).toBeUndefined()
+  })
+
+  it('should be reactive when cookie expires', () => {
+    const maxAge = 10
+    const cookie = useCookie('expire-reactive', {
+      default: () => 'tracked',
+      maxAge,
+    })
+
+    cookie.value = 'tracked'
+    const derived = computed(() => cookie.value ?? 'expired')
+    expect(derived.value).toBe('tracked')
+
+    vi.advanceTimersByTime(maxAge * 1000)
+    expect(derived.value).toBe('expired')
+  })
+})


### PR DESCRIPTION
`cookieRef` chains multiple `setTimeout` calls to handle cookie expiration delays that exceed the browser's `MAX_TIMEOUT_DELAY` (~24.8 days). The chaining never actually progresses because `createExpirationTimeout` resets `elapsed = 0` at the top of every call, including recursive ones from within the timeout callback.

For a 30-day cookie:
1. `elapsed` resets to 0, schedules a ~24.8-day timeout
2. Timeout fires, `elapsed` reaches ~24.8 days, still less than 30
3. Calls `createExpirationTimeout()` again, `elapsed` resets to 0
4. Back to step 1, forever

Any cookie with `maxAge` over ~24.8 days (30 days, 90 days, 1 year - all pretty standard values) hits this. The client-side ref never expires.

The fix splits the reset logic (`createExpirationTimeout`, called from `set`) from the scheduling logic (`scheduleTimeout`, called recursively). `elapsed` only resets when the cookie value actually changes, not during timeout chaining.