### PR TITLE
fix(nuxt): pass deleteCount to splice in preloadRouteComponents

### DIFF
--- a/packages/nuxt/src/app/composables/preload.ts
+++ b/packages/nuxt/src/app/composables/preload.ts
@@ -68,7 +68,7 @@ export async function preloadRouteComponents (to: RouteLocationRaw, router: Rout
     }
     const promise = Promise.resolve((component as () => unknown)())
       .catch(() => {})
-      .finally(() => promises.splice(promises.indexOf(promise)))
+      .finally(() => promises.splice(promises.indexOf(promise), 1))
     promises.push(promise)
   }
 


### PR DESCRIPTION
`preloadRouteComponents` uses `Array.splice` without a `deleteCount` argument to remove resolved promises from the tracking array:

```js
.finally(() => promises.splice(promises.indexOf(promise)))
```

Without the second argument, `splice(index)` removes every element from `index` to the end of the array, not just the single resolved promise. When the first component finishes loading, it wipes all remaining entries from `router._preloadPromises`, even if those are still in-flight.

The `> 4` concurrency throttle relies on `promises.length` to decide whether to defer new preload requests. With the array getting emptied prematurely, the throttle never kicks in.

The fix adds `, 1` so only the resolved promise is removed, matching the same pattern used in `scan.ts` and `router.ts` elsewhere in the repo.