### PR TITLE
fix(nuxt): handle rejected promise in view transition abort

### DIFF
--- a/packages/nuxt/src/app/plugins/view-transitions.client.ts
+++ b/packages/nuxt/src/app/plugins/view-transitions.client.ts
@@ -93,7 +93,7 @@ export default defineNuxtPlugin((nuxtApp) => {
       ? document.startViewTransition!({ update, types: allTypes })
       : document.startViewTransition!(update)
 
-    transition.finished.then(resetTransitionState)
+    transition.finished.then(resetTransitionState).catch(resetTransitionState)
 
     await nuxtApp.callHook('page:view-transition:start', transition)
 

--- a/packages/nuxt/src/app/plugins/view-transitions.client.ts
+++ b/packages/nuxt/src/app/plugins/view-transitions.client.ts
@@ -93,7 +93,7 @@ export default defineNuxtPlugin((nuxtApp) => {
       ? document.startViewTransition!({ update, types: allTypes })
       : document.startViewTransition!(update)
 
-    transition.finished.then(resetTransitionState).catch(resetTransitionState)
+    transition.finished.finally(resetTransitionState)
 
     await nuxtApp.callHook('page:view-transition:start', transition)
 

--- a/packages/nuxt/src/app/plugins/view-transitions.client.ts
+++ b/packages/nuxt/src/app/plugins/view-transitions.client.ts
@@ -93,7 +93,7 @@ export default defineNuxtPlugin((nuxtApp) => {
       ? document.startViewTransition!({ update, types: allTypes })
       : document.startViewTransition!(update)
 
-    transition.finished.finally(resetTransitionState)
+    transition.finished.catch(() => {}).finally(resetTransitionState)
 
     await nuxtApp.callHook('page:view-transition:start', transition)
 


### PR DESCRIPTION
When a view transition gets aborted (navigation error, app error, or Vue error), the error handlers call `abortTransition()` which rejects the update callback's promise. This causes `transition.finished` to reject too, but `.then(resetTransitionState)` only attached a resolve handler - the derived promise rejected with no catch, producing an unhandled promise rejection warning in the browser console.

Added `.catch(resetTransitionState)` so rejections run the same idempotent cleanup. The error handlers already deal with the actual error; this just prevents the stray rejection.

Repro: enable `experimental.viewTransition`, trigger a navigation error (e.g. a middleware that throws) while a view transition is in progress.