### PR TITLE
fix(nuxt): signal error state and clear timers in loading indicator cleanup

### DIFF
--- a/packages/nuxt/src/app/composables/loading-indicator.ts
+++ b/packages/nuxt/src/app/composables/loading-indicator.ts
@@ -141,13 +141,14 @@ function createLoadingIndicator (opts: Partial<LoadingIndicatorOpts> = {}) {
     const unsubLoadingFinishHook = nuxtApp.hook('page:loading:end', () => {
       finish()
     })
-    const unsubError = nuxtApp.hook('vue:error', () => finish())
+    const unsubError = nuxtApp.hook('vue:error', () => finish({ error: true }))
 
     _cleanup = () => {
       unsubError()
       unsubLoadingStartHook()
       unsubLoadingFinishHook()
       clear()
+      _clearTimeouts()
     }
   }
 


### PR DESCRIPTION
## Description

Two small fixes in the loading indicator composable:

1. The `vue:error` hook now calls `finish({ error: true })` instead of bare `finish()`. Without this, the `NuxtLoadingIndicator` component's `errorColor` prop never activates on Vue errors during navigation -- the prop exists but the automatic code path never triggers it.

2. The `_cleanup` function (called on unmount) now also clears `hideTimeout` and `resetTimeout` via `_clearTimeouts()`. Previously it only called `clear()` which handles `throttleTimeout` and `rafId`, but the two setTimeout-based timers could fire after disposal.
