### PR TITLE
fix(nuxt): handle negative zero in getUserTrace slice boundary

### DIFF
--- a/packages/nuxt/src/app/utils.ts
+++ b/packages/nuxt/src/app/utils.ts
@@ -19,7 +19,7 @@ export function getUserTrace (): Trace[] {
   if (start === -1 || end === -1) {
     return []
   }
-  return trace.slice(start, -end).map(i => ({
+  return trace.slice(start, end > 0 ? -end : undefined).map(i => ({
     ...i,
     source: i.source.replace(/^file:\/\//, ''),
   }))


### PR DESCRIPTION
`getUserTrace()` uses `trace.slice(start, -end)` to extract user-code frames from a captured stack trace. `end` comes from a reversed `findIndex` - the number of trailing non-user frames.

When `end` is `0` (the last frame is already user code), `-end` produces `-0`, which JavaScript treats as `0`. So `slice(start, 0)` returns an empty array instead of the expected trace entries.

This means dev warnings that rely on `getUserTrace()` (like the `useRoute` in middleware warning in `composables/router.ts`) silently lose their stack trace when the call stack happens to end with user code.

The fix guards the boundary: `end > 0 ? -end : undefined`. When `end` is zero, `undefined` lets `slice` include everything from `start` onward.