### PR TITLE
fix(nuxt): fix broken hook cleanup in route announcer

### DIFF
--- a/packages/nuxt/src/app/composables/route-announcer.ts
+++ b/packages/nuxt/src/app/composables/route-announcer.ts
@@ -47,9 +47,7 @@ function createRouteAnnouncer (opts: NuxtRouteAnnouncerOpts = {}) {
 
   _updateMessageWithPageHeading()
 
-  activeHead?.hooks?.hook('dom:rendered', () => {
-    _updateMessageWithPageHeading()
-  })
+  activeHead?.hooks?.hook('dom:rendered', _updateMessageWithPageHeading)
 
   return {
     _cleanup,


### PR DESCRIPTION
## Description

In `createRouteAnnouncer`, the `dom:rendered` hook is registered with an anonymous arrow function wrapper, but `_cleanup()` calls `removeHook` with `_updateMessageWithPageHeading` directly. Since hookable's `removeHook` uses reference equality (`indexOf`), the cleanup never actually removes the hook.

This causes the hook to keep firing after the route announcer is disposed, and the closure keeps references alive (memory leak).

Fix: pass `_updateMessageWithPageHeading` directly to `hook()` so the same reference is used for both registration and removal.