### PR TITLE
docs: add v4.4 badge for layout props

### DIFF
--- a/docs/2.directory-structure/1.app/1.layouts.md
+++ b/docs/2.directory-structure/1.app/1.layouts.md
@@ -168,7 +168,7 @@ This is useful when you want to manage layouts centrally in your configuration r
 
 :link-example{to="/docs/4.x/examples/features/layouts"}
 
-## Passing Props to Layouts
+## Passing Props to Layouts :badge[+4.4]{color="primary" class="align-middle"}
 
 You can pass props to layouts in several ways.
 


### PR DESCRIPTION
closes #34527

<img width="435" height="175" alt="image" src="https://github.com/user-attachments/assets/f7f534a8-ebde-40ad-9eb1-f454be4a6a6f" />
