### PR TITLE
feat(nuxt): experimental `defineLazyNuxtPlugin` 

### DIFF
--- a/docs/2.directory-structure/1.app/1.plugins.md
+++ b/docs/2.directory-structure/1.app/1.plugins.md
@@ -118,6 +118,42 @@ export default defineNuxtPlugin({
 })
 ```
 
+### Lazy Plugins
+
+Plugins that don't need to run before the app is interactive — such as analytics, tracking, or A/B testing — can be marked as lazy. Lazy plugins are code-split into a separate chunk and executed after hydration via `defineLazyNuxtPlugin`, reducing the initial JS bundle size.
+
+```ts twoslash [plugins/analytics.client.ts]
+import { init, trackPageView } from 'my-analytics-library'
+
+export default defineLazyNuxtPlugin((nuxtApp) => {
+  const config = useRuntimeConfig()
+  init({ siteId: config.public.analyticsId })
+
+  // Track page views on each navigation
+  nuxtApp.hook('page:finish', () => {
+    trackPageView({ path: useRoute().fullPath })
+  })
+})
+```
+
+Alternatively, you can mark any plugin as lazy in `nuxt.config.ts`:
+
+```ts twoslash [nuxt.config.ts]
+export default defineNuxtConfig({
+  plugins: [
+    { src: '~/plugins/analytics.client', lazy: true },
+  ],
+})
+```
+
+::note
+Lazy loading only applies on the client side — on the server, lazy plugins are included normally. Since most lazy plugins (analytics, tracking, etc.) are client-only, use the `.client.ts` suffix to avoid shipping them to the server entirely.
+::
+
+::warning
+Lazy plugins cannot use `provide` (since they run after the app is mounted), `dependsOn`, `order`, or `enforce` (since they run outside the normal plugin pipeline). Nuxt will warn at build time if contradictory options are detected.
+::
+
 ### Plugins With Dependencies
 
 If a plugin needs to wait for another plugin before it runs, you can add the plugin's name to the `dependsOn` array.

--- a/docs/2.directory-structure/1.app/1.plugins.md
+++ b/docs/2.directory-structure/1.app/1.plugins.md
@@ -123,6 +123,7 @@ export default defineNuxtPlugin({
 Plugins that don't need to run before the app is interactive — such as analytics, tracking, or A/B testing — can be marked as lazy. Lazy plugins are code-split into a separate chunk and executed after hydration via `defineLazyNuxtPlugin`, reducing the initial JS bundle size.
 
 ```ts twoslash [plugins/analytics.client.ts]
+// @errors: 2307
 import { init, trackPageView } from 'my-analytics-library'
 
 export default defineLazyNuxtPlugin((nuxtApp) => {

--- a/docs/2.directory-structure/1.app/1.plugins.md
+++ b/docs/2.directory-structure/1.app/1.plugins.md
@@ -118,9 +118,13 @@ export default defineNuxtPlugin({
 })
 ```
 
-### Lazy Plugins
+### Lazy Plugins :u-badge{label="Experimental" variant="subtle" class="align-middle ml-2"}
 
-Plugins that don't need to run before the app is interactive — such as analytics, tracking, or A/B testing — can be marked as lazy. Lazy plugins are code-split into a separate chunk and executed after hydration via `defineLazyNuxtPlugin`, reducing the initial JS bundle size.
+::callout{icon="i-heroicons-beaker" color="amber"}
+This feature is experimental. Enable it with `experimental.lazyPlugins` in your `nuxt.config.ts`.
+::
+
+Plugins that don't need to run before the app is interactive, such as analytics, tracking, or A/B testing, can be marked as lazy. Lazy plugins are code-split into a separate chunk and executed after hydration via `defineLazyNuxtPlugin`, reducing the initial JS bundle size.
 
 ```ts twoslash [plugins/analytics.client.ts]
 // @errors: 2307
@@ -137,10 +141,23 @@ export default defineLazyNuxtPlugin((nuxtApp) => {
 })
 ```
 
+First, enable the feature:
+
+```ts twoslash [nuxt.config.ts]
+export default defineNuxtConfig({
+  experimental: {
+    lazyPlugins: true,
+  },
+})
+```
+
 Alternatively, you can mark any plugin as lazy in `nuxt.config.ts`:
 
 ```ts twoslash [nuxt.config.ts]
 export default defineNuxtConfig({
+  experimental: {
+    lazyPlugins: true,
+  },
   plugins: [
     { src: '~/plugins/analytics.client', lazy: true },
   ],

--- a/docs/4.api/3.utils/define-lazy-nuxt-plugin.md
+++ b/docs/4.api/3.utils/define-lazy-nuxt-plugin.md
@@ -1,0 +1,131 @@
+---
+title: "defineLazyNuxtPlugin"
+description: defineLazyNuxtPlugin() defines a plugin that is code-split and executed after hydration.
+links:
+  - label: Source
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/nuxt/blob/main/packages/nuxt/src/app/nuxt.ts
+    size: xs
+---
+
+`defineLazyNuxtPlugin` creates a plugin that is excluded from the critical entry bundle. The plugin is dynamically imported and executed after hydration completes (on `app:suspense:resolve`), reducing initial JS parse time for code that doesn't need to run before the app is interactive.
+
+```ts twoslash [plugins/analytics.client.ts]
+import { init } from 'my-analytics-library'
+
+export default defineLazyNuxtPlugin(() => {
+  init({ siteId: useRuntimeConfig().public.analyticsId })
+})
+```
+
+:read-more{to="/docs/4.x/directory-structure/app/plugins#lazy-plugins"}
+
+## Type
+
+```ts [Signature]
+function defineLazyNuxtPlugin (
+  plugin: ((nuxtApp: NuxtApp) => void | Promise<void>) | LazyPluginOptions,
+): Plugin & ObjectPlugin
+
+interface LazyPluginOptions {
+  name?: string
+  hooks?: Partial<RuntimeNuxtHooks>
+  setup: (nuxtApp: NuxtApp) => void | Promise<void>
+  env?: {
+    islands?: boolean
+  }
+}
+```
+
+## Parameters
+
+**plugin**: A lazy plugin can be defined in two ways:
+
+1. **Function Plugin**: A function that receives the `NuxtApp` instance. Unlike `defineNuxtPlugin`, it cannot return `provide` since the app is already mounted.
+2. **Object Plugin**: An object with a subset of properties — `dependsOn`, `order`, and `enforce` are not available since lazy plugins run outside the normal plugin pipeline.
+
+| Property | Type                                   | Required | Description                                                    |
+|----------|----------------------------------------|----------|----------------------------------------------------------------|
+| `name`   | `string`                               | `false`  | Optional name for the plugin, useful for debugging.            |
+| `setup`  | `(nuxtApp: NuxtApp) => void \| Promise<void>`{lang="ts"} | `true` | The main plugin function.                    |
+| `hooks`  | `Partial<RuntimeNuxtHooks>`{lang="ts"} | `false`  | Nuxt app runtime hooks to register directly.                   |
+| `env`    | `{ islands?: boolean }`{lang="ts"}     | `false`  | Control plugin behavior in island/server-only components.      |
+
+## How It Works
+
+At build time, Nuxt wraps lazy plugins with `_createLazyPlugin`, which:
+
+1. Registers a one-time `app:suspense:resolve` hook during the plugin pipeline
+2. After hydration, dynamically imports the plugin chunk
+3. Executes the plugin's `setup` function within `nuxtApp.runWithContext`
+4. If the import or setup fails, logs the error and calls `app:error`
+
+The wrapper sets `parallel: true` so it never blocks other plugins.
+
+::note
+Lazy loading only applies on the client side — on the server, lazy plugins are included normally. Since most lazy plugins (analytics, tracking, etc.) are client-only, use the `.client.ts` suffix to avoid shipping them to the server entirely.
+::
+
+## Examples
+
+### Analytics Plugin
+
+```ts twoslash [plugins/analytics.client.ts]
+import { init, trackPageView } from 'my-analytics-library'
+
+export default defineLazyNuxtPlugin((nuxtApp) => {
+  const config = useRuntimeConfig()
+  init({ siteId: config.public.analyticsId })
+
+  // Track page views on each navigation
+  nuxtApp.hook('page:finish', () => {
+    trackPageView({ path: useRoute().fullPath })
+  })
+})
+```
+
+### Named Lazy Plugin with Hooks
+
+Object syntax lets you declare hooks declaratively rather than imperatively:
+
+```ts twoslash [plugins/error-reporting.client.ts]
+import { captureError, initErrorReporter } from 'my-error-reporter'
+
+export default defineLazyNuxtPlugin({
+  name: 'error-reporting',
+  hooks: {
+    'app:error' (error) {
+      captureError(error)
+    },
+    'vue:error' (error) {
+      captureError(error)
+    },
+  },
+  setup () {
+    initErrorReporter({ dsn: useRuntimeConfig().public.errorReporterDsn })
+  },
+})
+```
+
+### Via nuxt.config.ts
+
+Any plugin can be made lazy via config instead of using `defineLazyNuxtPlugin`:
+
+```ts twoslash [nuxt.config.ts]
+export default defineNuxtConfig({
+  plugins: [
+    { src: '~/plugins/analytics.client', lazy: true },
+  ],
+})
+```
+
+Or with object syntax in the plugin file itself:
+
+```ts twoslash [plugins/analytics.client.ts]
+export default defineNuxtPlugin({
+  lazy: true,
+  setup (nuxtApp) {
+    // Runs after hydration
+  },
+})
+```

--- a/docs/4.api/3.utils/define-lazy-nuxt-plugin.md
+++ b/docs/4.api/3.utils/define-lazy-nuxt-plugin.md
@@ -11,6 +11,7 @@ links:
 `defineLazyNuxtPlugin` creates a plugin that is excluded from the critical entry bundle. The plugin is dynamically imported and executed after hydration completes (on `app:suspense:resolve`), reducing initial JS parse time for code that doesn't need to run before the app is interactive.
 
 ```ts twoslash [plugins/analytics.client.ts]
+// @errors: 2307
 import { init } from 'my-analytics-library'
 
 export default defineLazyNuxtPlugin(() => {
@@ -71,6 +72,7 @@ Lazy loading only applies on the client side — on the server, lazy plugins are
 ### Analytics Plugin
 
 ```ts twoslash [plugins/analytics.client.ts]
+// @errors: 2307
 import { init, trackPageView } from 'my-analytics-library'
 
 export default defineLazyNuxtPlugin((nuxtApp) => {
@@ -89,6 +91,7 @@ export default defineLazyNuxtPlugin((nuxtApp) => {
 Object syntax lets you declare hooks declaratively rather than imperatively:
 
 ```ts twoslash [plugins/error-reporting.client.ts]
+// @errors: 2307
 import { captureError, initErrorReporter } from 'my-error-reporter'
 
 export default defineLazyNuxtPlugin({

--- a/docs/4.api/3.utils/define-lazy-nuxt-plugin.md
+++ b/docs/4.api/3.utils/define-lazy-nuxt-plugin.md
@@ -8,6 +8,10 @@ links:
     size: xs
 ---
 
+::callout{icon="i-heroicons-beaker" color="amber"}
+This feature is experimental. Enable it with `experimental.lazyPlugins: true` in your `nuxt.config.ts`.
+::
+
 `defineLazyNuxtPlugin` creates a plugin that is excluded from the critical entry bundle. The plugin is dynamically imported and executed after hydration completes (on `app:suspense:resolve`), reducing initial JS parse time for code that doesn't need to run before the app is interactive.
 
 ```ts twoslash [plugins/analytics.client.ts]
@@ -116,13 +120,16 @@ Any plugin can be made lazy via config instead of using `defineLazyNuxtPlugin`:
 
 ```ts twoslash [nuxt.config.ts]
 export default defineNuxtConfig({
+  experimental: {
+    lazyPlugins: true,
+  },
   plugins: [
     { src: '~/plugins/analytics.client', lazy: true },
   ],
 })
 ```
 
-Or with object syntax in the plugin file itself:
+Or with object syntax in the plugin file itself (requires `experimental.lazyPlugins: true`):
 
 ```ts twoslash [plugins/analytics.client.ts]
 export default defineNuxtPlugin({

--- a/packages/kit/src/plugin.ts
+++ b/packages/kit/src/plugin.ts
@@ -74,6 +74,14 @@ export function normalizePlugin (plugin: NuxtPlugin | string): NuxtPlugin {
  *   filename: 'foo.server.js' // [optional] only include in server bundle
  * })
  * ```
+ *
+ * Use `lazy: true` to code-split the plugin and defer execution until after hydration:
+ * ```js
+ * addPlugin({
+ *   src: resolver.resolve('templates/analytics.client.js'),
+ *   lazy: true
+ * })
+ * ```
  */
 export interface AddPluginOptions { append?: boolean }
 export function addPlugin (_plugin: NuxtPlugin | string, opts: AddPluginOptions = {}): NuxtPlugin {

--- a/packages/kit/src/plugin.ts
+++ b/packages/kit/src/plugin.ts
@@ -75,7 +75,9 @@ export function normalizePlugin (plugin: NuxtPlugin | string): NuxtPlugin {
  * })
  * ```
  *
- * Use `lazy: true` to code-split the plugin and defer execution until after hydration:
+ * Use `lazy: true` to code-split the plugin and defer execution until after hydration.
+ * Requires `experimental.lazyPlugins: true` in your Nuxt config.
+ * Lazy plugins cannot use `provide`, `dependsOn`, `order`, or `enforce`.
  * ```js
  * addPlugin({
  *   src: resolver.resolve('templates/analytics.client.js'),

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -202,6 +202,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
       // this will be overridden in vite plugin
       '#internal/entry-chunk.mjs': () => `export const entryFileName = undefined`,
       '#internal/nuxt/entry-ids.mjs': () => `export default []`,
+      '#internal/nuxt/lazy-plugin-entries.mjs': () => `export default []`,
       '#internal/nuxt/nitro-config.mjs': () => {
         const hasCachedRoutes = nitro.routing.routeRules.routes.some(r => r.data.isr || r.data.cache)
         return [

--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -30,6 +30,8 @@ import entryIds from '#internal/nuxt/entry-ids.mjs'
 // @ts-expect-error virtual file
 import { entryFileName } from '#internal/entry-chunk.mjs'
 // @ts-expect-error virtual file
+import lazyPluginEntries from '#internal/nuxt/lazy-plugin-entries.mjs'
+// @ts-expect-error virtual file
 import { buildAssetsURL, publicAssetsURL } from '#internal/nuxt/paths'
 import type { AppConfig } from '@nuxt/schema'
 
@@ -251,6 +253,17 @@ const handler: ReturnType<typeof defineEventHandler> = defineEventHandler(async 
     ssrContext.head.push({
       link: getPrefetchLinks(ssrContext, renderer.rendererContext) as Link[],
     }, headEntryOptions)
+    // Low-priority modulepreload for lazy plugin chunks
+    if ((lazyPluginEntries as string[]).length) {
+      ssrContext.head.push({
+        link: (lazyPluginEntries as string[]).map(file => (<Link> {
+          rel: 'modulepreload',
+          href: renderer.rendererContext.buildAssetsURL(file),
+          crossorigin: '',
+          fetchpriority: 'low',
+        })),
+      }, headEntryOptions)
+    }
     // 5. Payloads
     ssrContext.head.push({
       script: _PAYLOAD_INLINE

--- a/packages/nuxt/src/app/index.ts
+++ b/packages/nuxt/src/app/index.ts
@@ -1,7 +1,7 @@
 import '../../dist/app/types/augments'
 
-export { applyPlugin, applyPlugins, callWithNuxt, createNuxtApp, defineAppConfig, defineNuxtPlugin, definePayloadPlugin, isNuxtPlugin, registerPluginHooks, tryUseNuxtApp, useNuxtApp, useRuntimeConfig } from './nuxt'
-export type { CreateOptions, NuxtApp, NuxtPayload, NuxtPluginIndicator, NuxtSSRContext, ObjectPlugin, Plugin, PluginEnvContext, PluginMeta, ResolvedPluginMeta, RuntimeNuxtHooks } from './nuxt'
+export { _createLazyPlugin, applyPlugin, applyPlugins, callWithNuxt, createNuxtApp, defineAppConfig, defineLazyNuxtPlugin, defineNuxtPlugin, definePayloadPlugin, isNuxtPlugin, registerPluginHooks, tryUseNuxtApp, useNuxtApp, useRuntimeConfig } from './nuxt'
+export type { CreateOptions, LazyPluginOptions, NuxtApp, NuxtPayload, NuxtPluginIndicator, NuxtSSRContext, ObjectPlugin, Plugin, PluginEnvContext, PluginMeta, ResolvedPluginMeta, RuntimeNuxtHooks } from './nuxt'
 
 // eslint-disable-next-line @typescript-eslint/no-deprecated
 export { defineNuxtComponent, useAsyncData, useLazyAsyncData, useNuxtData, refreshNuxtData, clearNuxtData, useHydration, callOnce, useState, clearNuxtState, clearError, createError, isNuxtError, showError, useError, useFetch, useLazyFetch, useCookie, refreshCookie, onPrehydrate, prerenderRoutes, useRequestHeaders, useRequestEvent, useRequestFetch, setResponseStatus, useResponseHeader, onNuxtReady, abortNavigation, addRouteMiddleware, defineNuxtRouteMiddleware, onBeforeRouteLeave, onBeforeRouteUpdate, setPageLayout, navigateTo, useRoute, useRouter, preloadComponents, prefetchComponents, preloadRouteComponents, isPrerendered, loadPayload, preloadPayload, definePayloadReducer, definePayloadReviver, getAppManifest, getRouteRules, reloadNuxtApp, useRequestURL, usePreviewMode, useId, useRouteAnnouncer, useAnnouncer, useHead, useHeadSafe, useServerSeoMeta, useServerHeadSafe, useServerHead, useSeoMeta, injectHead, useRuntimeHook } from './composables/index'

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -446,17 +446,17 @@ export function registerPluginHooks (nuxtApp: NuxtApp, plugin: Plugin & ObjectPl
  * only when executed, keeping it out of the critical entry bundle.
  * @internal
  */
-export function _createLazyPlugin (loader: () => Promise<{ default: Plugin & ObjectPlugin<any> }>, name?: string): Plugin & ObjectPlugin<any> {
+export function _createLazyPlugin (loader: () => Promise<{ default: Plugin | ObjectPlugin<any> }>, name?: string): Plugin & ObjectPlugin<any> {
   const wrapper = ((nuxtApp: NuxtApp) => {
     // Fire-and-forget: load and execute after hydration, don't block plugin pipeline
     nuxtApp.hooks.hookOnce('app:suspense:resolve', () => {
       loader().then((mod) => {
         const plugin = mod.default
-        registerPluginHooks(nuxtApp, plugin)
+        registerPluginHooks(nuxtApp, plugin as Plugin & ObjectPlugin<any>)
         if (typeof plugin === 'function') {
           return nuxtApp.runWithContext(() => plugin(nuxtApp))
         }
-        if (plugin.setup) {
+        if ('setup' in plugin && plugin.setup) {
           return nuxtApp.runWithContext(() => plugin.setup!(nuxtApp))
         }
       }).catch((err) => {

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -235,6 +235,11 @@ export interface PluginMeta {
    * It overrides the value of `enforce` and is used to sort plugins.
    */
   order?: number
+  /**
+   * When true, the plugin is code-split and executed after hydration.
+   * Automatically set when using `defineLazyNuxtPlugin`.
+   */
+  lazy?: boolean
 }
 
 export interface PluginEnvContext {
@@ -436,6 +441,36 @@ export function registerPluginHooks (nuxtApp: NuxtApp, plugin: Plugin & ObjectPl
   }
 }
 
+/**
+ * Creates a lazy plugin wrapper that dynamically imports the plugin module
+ * only when executed, keeping it out of the critical entry bundle.
+ * @internal
+ */
+export function _createLazyPlugin (loader: () => Promise<{ default: Plugin & ObjectPlugin<any> }>, name?: string): Plugin & ObjectPlugin<any> {
+  const wrapper = ((nuxtApp: NuxtApp) => {
+    // Fire-and-forget: load and execute after hydration, don't block plugin pipeline
+    nuxtApp.hooks.hookOnce('app:suspense:resolve', () => {
+      loader().then((mod) => {
+        const plugin = mod.default
+        registerPluginHooks(nuxtApp, plugin)
+        if (typeof plugin === 'function') {
+          return nuxtApp.runWithContext(() => plugin(nuxtApp))
+        }
+        if (plugin.setup) {
+          return nuxtApp.runWithContext(() => plugin.setup!(nuxtApp))
+        }
+      }).catch((err) => {
+        console.error(`[nuxt] Error loading lazy plugin${name ? ` "${name}"` : ''}:`, err)
+        return nuxtApp.callHook('app:error', err)
+      })
+    })
+  }) as Plugin & ObjectPlugin<any>
+  wrapper[NuxtPluginIndicator] = true
+  wrapper._name = 'lazy:' + (name || 'unknown')
+  wrapper.parallel = true
+  return wrapper
+}
+
 /** @since 3.0.0 */
 export async function applyPlugin (nuxtApp: NuxtApp, plugin: Plugin & ObjectPlugin<any>): Promise<void> {
   if (typeof plugin === 'function') {
@@ -518,6 +553,27 @@ export function defineNuxtPlugin<T extends Record<string, unknown>> (plugin: Plu
   const _name = plugin._name || plugin.name
   delete plugin.name
   return Object.assign(plugin.setup || (() => {}), plugin, { [NuxtPluginIndicator]: true, _name } as const)
+}
+
+export interface LazyPluginOptions {
+  name?: string
+  /**
+   * You can directly register Nuxt app runtime hooks here.
+   */
+  hooks?: Partial<RuntimeNuxtHooks>
+  setup: (nuxtApp: NuxtApp) => void | Promise<void>
+  env?: PluginEnvContext
+}
+
+/**
+ * Define a lazy plugin that is code-split and executed after hydration.
+ * Lazy plugins cannot use `provide`, `dependsOn`, `order`, or `enforce`
+ * since they run after the app is mounted outside the plugin pipeline.
+ * @since 3.17.0
+ */
+/* @__NO_SIDE_EFFECTS__ */
+export function defineLazyNuxtPlugin (plugin: ((nuxtApp: NuxtApp) => void | Promise<void>) | LazyPluginOptions): Plugin & ObjectPlugin {
+  return defineNuxtPlugin(typeof plugin === 'function' ? plugin as Plugin : plugin as ObjectPlugin)
 }
 
 /* @__NO_SIDE_EFFECTS__ */

--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -270,6 +270,18 @@ export async function annotatePlugins (nuxt: Nuxt, plugins: NuxtPlugin[]) {
     }
   }
 
+  for (const plugin of _plugins) {
+    if (plugin.lazy) {
+      const name = plugin.name || relative(nuxt.options.rootDir, plugin.src)
+      if (plugin.dependsOn?.length) {
+        logger.warn(`Lazy plugin \`${name}\` has \`dependsOn\` which is ignored — lazy plugins run after hydration.`)
+      }
+      if (plugin.order != null && plugin.order < orderMap.default) {
+        logger.warn(`Lazy plugin \`${name}\` has early ordering which is contradictory — lazy plugins run after hydration.`)
+      }
+    }
+  }
+
   return _plugins.sort((a, b) => (a.order ?? orderMap.default) - (b.order ?? orderMap.default))
 }
 

--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -270,14 +270,16 @@ export async function annotatePlugins (nuxt: Nuxt, plugins: NuxtPlugin[]) {
     }
   }
 
-  for (const plugin of _plugins) {
-    if (plugin.lazy) {
-      const name = plugin.name || relative(nuxt.options.rootDir, plugin.src)
-      if (plugin.dependsOn?.length) {
-        logger.warn(`Lazy plugin \`${name}\` has \`dependsOn\` which is ignored — lazy plugins run after hydration.`)
-      }
-      if (plugin.order != null && plugin.order < orderMap.default) {
-        logger.warn(`Lazy plugin \`${name}\` has early ordering which is contradictory — lazy plugins run after hydration.`)
+  if (nuxt.options.experimental.lazyPlugins) {
+    for (const plugin of _plugins) {
+      if (plugin.lazy) {
+        const name = plugin.name || relative(nuxt.options.rootDir, plugin.src)
+        if (plugin.dependsOn?.length) {
+          logger.warn(`Lazy plugin \`${name}\` has \`dependsOn\` which is ignored; lazy plugins run after hydration.`)
+        }
+        if (plugin.order != null && plugin.order < orderMap.default) {
+          logger.warn(`Lazy plugin \`${name}\` has early ordering which is contradictory; lazy plugins run after hydration.`)
+        }
       }
     }
   }

--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -276,6 +276,7 @@ export async function annotatePlugins (nuxt: Nuxt, plugins: NuxtPlugin[]) {
         const name = plugin.name || relative(nuxt.options.rootDir, plugin.src)
         if (plugin.dependsOn?.length) {
           logger.warn(`Lazy plugin \`${name}\` has \`dependsOn\` which is ignored; lazy plugins run after hydration.`)
+          plugin.dependsOn = undefined
         }
         if (plugin.order != null && plugin.order < orderMap.default) {
           logger.warn(`Lazy plugin \`${name}\` has early ordering which is contradictory; lazy plugins run after hydration.`)

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -701,7 +701,7 @@ async function initNuxt (nuxt: Nuxt) {
 
   if (nuxt.options.experimental.appManifest) {
     if (nuxt.options.experimental.checkOutdatedBuildInterval !== false) {
-      addPlugin({ src: resolve(nuxt.options.appDir, 'plugins/check-outdated-build.client'), lazy: true })
+      addPlugin(resolve(nuxt.options.appDir, 'plugins/check-outdated-build.client'))
     }
   }
 

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -701,7 +701,7 @@ async function initNuxt (nuxt: Nuxt) {
 
   if (nuxt.options.experimental.appManifest) {
     if (nuxt.options.experimental.checkOutdatedBuildInterval !== false) {
-      addPlugin(resolve(nuxt.options.appDir, 'plugins/check-outdated-build.client'))
+      addPlugin({ src: resolve(nuxt.options.appDir, 'plugins/check-outdated-build.client'), lazy: true })
     }
   }
 

--- a/packages/nuxt/src/core/plugins/plugin-metadata.ts
+++ b/packages/nuxt/src/core/plugins/plugin-metadata.ts
@@ -44,7 +44,10 @@ export function extractMetadata (code: string, loader = 'ts' as 'ts' | 'tsx') {
   if (metaCache[code]) {
     return metaCache[code]
   }
-  // non-object syntax plugin
+  // non-object syntax plugin fast paths
+  if (/defineLazyNuxtPlugin\s*\([\w(]/.test(code)) {
+    return { lazy: true, order: orderMap.default }
+  }
   if (/defineNuxtPlugin\s*\([\w(]/.test(code)) {
     return {}
   }
@@ -52,7 +55,7 @@ export function extractMetadata (code: string, loader = 'ts' as 'ts' | 'tsx') {
     if (node.type !== 'CallExpression' || node.callee.type !== 'Identifier') { return }
 
     const name = 'name' in node.callee && node.callee.name
-    if (name !== 'defineNuxtPlugin' && name !== 'definePayloadPlugin') { return }
+    if (name !== 'defineNuxtPlugin' && name !== 'definePayloadPlugin' && name !== 'defineLazyNuxtPlugin') { return }
 
     if (name === 'definePayloadPlugin') {
       meta.order = internalOrderMap['user-revivers']
@@ -71,6 +74,11 @@ export function extractMetadata (code: string, loader = 'ts' as 'ts' | 'tsx') {
       meta = defu(extractMetaFromObject(plugin.properties), meta)
     }
 
+    // Set after defu merge so defineLazyNuxtPlugin always wins over object properties
+    if (name === 'defineLazyNuxtPlugin') {
+      meta.lazy = true
+    }
+
     meta.order ||= orderMap[meta.enforce || 'default'] || orderMap.default
     delete meta.enforce
   })
@@ -84,6 +92,7 @@ const keys: Record<PluginMetaKey, string> = {
   order: 'order',
   enforce: 'enforce',
   dependsOn: 'dependsOn',
+  lazy: 'lazy',
 }
 function isMetadataKey (key: string | IdentifierName): key is PluginMetaKey {
   return typeof key !== 'string' ? key.name in keys : key in keys
@@ -142,11 +151,11 @@ export const RemovePluginMetadataPlugin = (nuxt: Nuxt) => createUnplugin(() => {
 
       const s = new MagicString(code)
       let wrapped = false
-      const wrapperNames = new Set(['defineNuxtPlugin', 'definePayloadPlugin'])
+      const wrapperNames = new Set(['defineNuxtPlugin', 'definePayloadPlugin', 'defineLazyNuxtPlugin'])
 
       try {
         parseAndWalk(code, id, (node) => {
-          if (node.type === 'ImportSpecifier' && node.imported.type === 'Identifier' && (node.imported.name === 'defineNuxtPlugin' || node.imported.name === 'definePayloadPlugin')) {
+          if (node.type === 'ImportSpecifier' && node.imported.type === 'Identifier' && (node.imported.name === 'defineNuxtPlugin' || node.imported.name === 'definePayloadPlugin' || node.imported.name === 'defineLazyNuxtPlugin')) {
             wrapperNames.add(node.local.name)
           }
           if (node.type !== 'CallExpression' || node.callee.type !== 'Identifier') { return }
@@ -156,7 +165,7 @@ export const RemovePluginMetadataPlugin = (nuxt: Nuxt) => createUnplugin(() => {
           wrapped = true
 
           // Remove metadata that already has been extracted
-          if (!('order' in plugin) && !('name' in plugin)) { return }
+          if (!('order' in plugin) && !('name' in plugin) && !('lazy' in plugin)) { return }
           for (const [argIndex, arg] of node.arguments.entries()) {
             if (arg.type !== 'ObjectExpression') { continue }
 
@@ -164,7 +173,7 @@ export const RemovePluginMetadataPlugin = (nuxt: Nuxt) => createUnplugin(() => {
               if (property.type === 'SpreadElement' || !('name' in property.key)) { continue }
 
               const propertyKey = property.key.name
-              if (propertyKey === 'order' || propertyKey === 'enforce' || propertyKey === 'name') {
+              if (propertyKey === 'order' || propertyKey === 'enforce' || propertyKey === 'name' || propertyKey === 'lazy') {
                 const nextNode = arg.properties[propertyIndex + 1] || node.arguments[argIndex + 1]
                 const nextIndex = nextNode?.start || (arg.end - 1)
 

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -67,11 +67,12 @@ export const clientPluginTemplate: NuxtTemplate = {
     checkForCircularDependencies(clientPlugins)
     const exports: string[] = []
     const imports: string[] = []
+    const lazyEnabled = ctx.nuxt.options.experimental.lazyPlugins
     let hasLazy = false
     for (const plugin of clientPlugins) {
       const path = relative(ctx.nuxt.options.rootDir, plugin.src)
       const variable = genSafeVariableName(filename(plugin.src) || path).replace(PLUGIN_TEMPLATE_RE, '_') + '_' + hash(path).replace(/-/g, '_')
-      if (plugin.lazy) {
+      if (lazyEnabled && plugin.lazy) {
         hasLazy = true
         // Lazy plugins are dynamically imported after hydration, keeping them out of the critical entry bundle
         imports.push(`const ${variable} = /*#__PURE__*/ _createLazyPlugin(() => ${genDynamicImport(plugin.src, { wrapper: false })}, ${genString(plugin.name || filename(plugin.src) || path)})`)

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -67,16 +67,27 @@ export const clientPluginTemplate: NuxtTemplate = {
     checkForCircularDependencies(clientPlugins)
     const exports: string[] = []
     const imports: string[] = []
+    let hasLazy = false
     for (const plugin of clientPlugins) {
       const path = relative(ctx.nuxt.options.rootDir, plugin.src)
       const variable = genSafeVariableName(filename(plugin.src) || path).replace(PLUGIN_TEMPLATE_RE, '_') + '_' + hash(path).replace(/-/g, '_')
-      exports.push(variable)
-      imports.push(genImport(plugin.src, variable))
+      if (plugin.lazy) {
+        hasLazy = true
+        // Lazy plugins are dynamically imported after hydration, keeping them out of the critical entry bundle
+        imports.push(`const ${variable} = /*#__PURE__*/ _createLazyPlugin(() => ${genDynamicImport(plugin.src, { wrapper: false })}, ${JSON.stringify(plugin.name || filename(plugin.src) || path)})`)
+        exports.push(variable)
+      } else {
+        exports.push(variable)
+        imports.push(genImport(plugin.src, variable))
+      }
     }
-    return [
-      ...imports,
-      `export default ${genArrayFromRaw(exports)}`,
-    ].join('\n')
+    const lines = []
+    if (hasLazy) {
+      lines.push(`import { _createLazyPlugin } from '#app/nuxt'`)
+    }
+    lines.push(...imports)
+    lines.push(`export default ${genArrayFromRaw(exports)}`)
+    return lines.join('\n')
   },
 }
 

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -74,7 +74,7 @@ export const clientPluginTemplate: NuxtTemplate = {
       if (plugin.lazy) {
         hasLazy = true
         // Lazy plugins are dynamically imported after hydration, keeping them out of the critical entry bundle
-        imports.push(`const ${variable} = /*#__PURE__*/ _createLazyPlugin(() => ${genDynamicImport(plugin.src, { wrapper: false })}, ${JSON.stringify(plugin.name || filename(plugin.src) || path)})`)
+        imports.push(`const ${variable} = /*#__PURE__*/ _createLazyPlugin(() => ${genDynamicImport(plugin.src, { wrapper: false })}, ${genString(plugin.name || filename(plugin.src) || path)})`)
         exports.push(variable)
       } else {
         exports.push(variable)

--- a/packages/nuxt/src/imports/presets.ts
+++ b/packages/nuxt/src/imports/presets.ts
@@ -18,7 +18,7 @@ const granularAppPresets: InlinePreset[] = [
     imports: ['defineNuxtLink'],
   },
   {
-    imports: ['useNuxtApp', 'tryUseNuxtApp', 'defineNuxtPlugin', 'definePayloadPlugin', 'useRuntimeConfig', 'defineAppConfig'],
+    imports: ['useNuxtApp', 'tryUseNuxtApp', 'defineNuxtPlugin', 'defineLazyNuxtPlugin', 'definePayloadPlugin', 'useRuntimeConfig', 'defineAppConfig'],
     from: '#app/nuxt',
   },
   {

--- a/packages/nuxt/test/app.test.ts
+++ b/packages/nuxt/test/app.test.ts
@@ -47,6 +47,7 @@ describe('resolveApp', () => {
             "src": "<repoRoot>/packages/nuxt/src/app/plugins/navigation-repaint.client.ts",
           },
           {
+            "lazy": true,
             "mode": "client",
             "src": "<repoRoot>/packages/nuxt/src/app/plugins/check-outdated-build.client.ts",
           },

--- a/packages/nuxt/test/app.test.ts
+++ b/packages/nuxt/test/app.test.ts
@@ -47,7 +47,6 @@ describe('resolveApp', () => {
             "src": "<repoRoot>/packages/nuxt/src/app/plugins/navigation-repaint.client.ts",
           },
           {
-            "lazy": true,
             "mode": "client",
             "src": "<repoRoot>/packages/nuxt/src/app/plugins/check-outdated-build.client.ts",
           },

--- a/packages/nuxt/test/plugin-metadata.test.ts
+++ b/packages/nuxt/test/plugin-metadata.test.ts
@@ -58,6 +58,125 @@ describe('plugin-metadata', () => {
   })
 })
 
+describe('lazy plugin metadata', () => {
+  describe('defineLazyNuxtPlugin', () => {
+    it('extracts lazy from arrow function', () => {
+      const meta = extractMetadata(`export default defineLazyNuxtPlugin(() => {})`)
+      expect(meta).toEqual({ lazy: true, order: 0 })
+    })
+
+    it('extracts lazy from named-param arrow function', () => {
+      const meta = extractMetadata(`export default defineLazyNuxtPlugin((nuxtApp) => {})`)
+      expect(meta).toEqual({ lazy: true, order: 0 })
+    })
+
+    it('extracts lazy from async function', () => {
+      const meta = extractMetadata(`export default defineLazyNuxtPlugin(async (nuxtApp) => { await something() })`)
+      expect(meta).toEqual({ lazy: true, order: 0 })
+    })
+
+    it('extracts lazy + name from object syntax', () => {
+      const meta = extractMetadata(`export default defineLazyNuxtPlugin({ name: 'analytics', setup: () => {} })`)
+      expect(meta).toEqual({ lazy: true, name: 'analytics', order: 0 })
+    })
+  })
+
+  describe('defineNuxtPlugin with lazy: true', () => {
+    it('extracts lazy from object syntax', () => {
+      const meta = extractMetadata(`export default defineNuxtPlugin({ lazy: true, setup: () => {} })`)
+      expect(meta).toEqual({ lazy: true, order: 0 })
+    })
+
+    it('extracts lazy: false as falsy (omitted)', () => {
+      const meta = extractMetadata(`export default defineNuxtPlugin({ lazy: false, setup: () => {} })`)
+      // lazy: false is falsy, order defaults to 0
+      expect(meta).toEqual({ lazy: false, order: 0 })
+    })
+
+    it('extracts lazy with name and enforce', () => {
+      const meta = extractMetadata(`export default defineNuxtPlugin({ lazy: true, name: 'tracking', enforce: 'post', setup: () => {} })`)
+      expect(meta).toEqual({ lazy: true, name: 'tracking', order: 20 })
+    })
+
+    it('extracts lazy with custom order', () => {
+      const meta = extractMetadata(`export default defineNuxtPlugin({ lazy: true, order: 5, setup: () => {} })`)
+      expect(meta).toEqual({ lazy: true, order: 5 })
+    })
+  })
+
+  describe('non-lazy plugins', () => {
+    it('does not include lazy for function-syntax defineNuxtPlugin', () => {
+      const meta = extractMetadata(`export default defineNuxtPlugin(() => {})`)
+      expect(meta).toEqual({})
+    })
+
+    it('does not include lazy for object-syntax defineNuxtPlugin without lazy', () => {
+      const meta = extractMetadata(`export default defineNuxtPlugin({ name: 'foo', setup: () => {} })`)
+      expect(meta).toEqual({ name: 'foo', order: 0 })
+    })
+  })
+
+  describe('edge cases', () => {
+    it('defineLazyNuxtPlugin with redundant lazy: true in object syntax', () => {
+      const meta = extractMetadata(`export default defineLazyNuxtPlugin({ lazy: true, name: 'double', setup: () => {} })`)
+      expect(meta).toEqual({ lazy: true, name: 'double', order: 0 })
+    })
+
+    it('defineLazyNuxtPlugin with lazy: false in object syntax still gets lazy from wrapper', () => {
+      // defineLazyNuxtPlugin always forces lazy: true, regardless of object properties
+      const meta = extractMetadata(`export default defineLazyNuxtPlugin({ lazy: false, setup: () => {} })`)
+      expect(meta).toEqual({ lazy: true, order: 0 })
+    })
+  })
+
+  describe('RemovePluginMetadataPlugin strips lazy', () => {
+    const transformPlugin: any = RemovePluginMetadataPlugin({
+      options: { sourcemap: { client: true } },
+      apps: { default: { plugins: [{ src: 'lazy-plugin.mjs', order: 0, lazy: true }] } },
+    } as any).raw({}, {} as any)
+
+    it('should remove name and lazy from object-syntax lazy plugin', () => {
+      const plugin = `
+        export default defineNuxtPlugin({
+          name: 'analytics',
+          lazy: true,
+          setup: () => {},
+        })
+      `
+      const result = transformPlugin.transform(plugin, 'lazy-plugin.mjs')
+      expect(result.code).toMatchInlineSnapshot(`
+        "
+                export default defineNuxtPlugin({
+                  setup: () => {},
+                })
+              "
+      `)
+    })
+
+    it('should strip lazy when it is the only metadata property', () => {
+      const onlyLazyPlugin: any = RemovePluginMetadataPlugin({
+        options: { sourcemap: { client: true } },
+        apps: { default: { plugins: [{ src: 'only-lazy.mjs', lazy: true }] } },
+      } as any).raw({}, {} as any)
+
+      const plugin = `
+        export default defineNuxtPlugin({
+          lazy: true,
+          setup: () => {},
+        })
+      `
+      const result = onlyLazyPlugin.transform(plugin, 'only-lazy.mjs')
+      expect(result.code).toMatchInlineSnapshot(`
+        "
+                export default defineNuxtPlugin({
+                  setup: () => {},
+                })
+              "
+      `)
+    })
+  })
+})
+
 describe('plugin sanity checking', () => {
   it('non-existent depends are warned', () => {
     vi.spyOn(console, 'error')

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -138,6 +138,11 @@ export default defineResolvers({
         return 'chokidar' as const
       },
     },
+    /**
+     * Enable lazy plugin support via `defineLazyNuxtPlugin`. Lazy plugins are code-split
+     * and executed after hydration, reducing initial JS bundle size.
+     */
+    lazyPlugins: false,
     asyncContext: false,
     headNext: true,
     inlineRouteRules: false,

--- a/packages/schema/src/types/nuxt.ts
+++ b/packages/schema/src/types/nuxt.ts
@@ -20,6 +20,12 @@ export interface NuxtPlugin {
    */
   order?: number
   /**
+   * When true, the plugin will be dynamically imported and executed after hydration
+   * instead of being included in the critical entry bundle. This reduces initial JS
+   * parse time for plugins that only need to run post-hydration.
+   */
+  lazy?: boolean
+  /**
    * @internal
    */
   name?: string

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1626,6 +1626,12 @@ export interface ConfigSchema {
      * multiple times on the same Nuxt instance (e.g. in benchmarks).
      */
     clearBuildHooks: boolean
+
+    /**
+     * Enable lazy plugin support via `defineLazyNuxtPlugin`. Lazy plugins are code-split
+     * and executed after hydration, reducing initial JS bundle size.
+     */
+    lazyPlugins: boolean
   }
 
   /**

--- a/packages/vite/src/plugins/lazy-plugins.ts
+++ b/packages/vite/src/plugins/lazy-plugins.ts
@@ -8,7 +8,7 @@ import type { Plugin } from 'vite'
 const LAZY_PLUGIN_RE = /defineLazyNuxtPlugin/
 
 export function LazyPluginPreloadPlugin (nuxt: Nuxt): Plugin | undefined {
-  if (nuxt.options.dev) { return }
+  if (nuxt.options.dev || !nuxt.options.experimental.lazyPlugins) { return }
 
   const nitro = useNitro()
   const lazyPluginSrcs = new Set<string>()

--- a/packages/vite/src/plugins/lazy-plugins.ts
+++ b/packages/vite/src/plugins/lazy-plugins.ts
@@ -1,0 +1,45 @@
+import { useNitro } from '@nuxt/kit'
+import type { Nuxt } from '@nuxt/schema'
+import { relative } from 'pathe'
+import { withoutLeadingSlash } from 'ufo'
+import type { Plugin } from 'vite'
+
+export function LazyPluginPreloadPlugin (nuxt: Nuxt): Plugin | undefined {
+  if (nuxt.options.dev) { return }
+
+  const nitro = useNitro()
+  const lazyPluginFiles: string[] = []
+
+  return {
+    name: 'nuxt:lazy-plugin-preload',
+    apply: 'build',
+    applyToEnvironment (environment) {
+      return environment.name === 'client'
+    },
+    buildEnd () {
+      const clientPlugins = nuxt.apps.default?.plugins?.filter(p => p.lazy && (!p.mode || p.mode !== 'server')) || []
+      for (const plugin of clientPlugins) {
+        lazyPluginFiles.push(relative(nuxt.options.rootDir, plugin.src))
+      }
+    },
+    generateBundle (_options, bundle) {
+      const prefix = withoutLeadingSlash(nuxt.options.app.buildAssetsDir)
+      const lazyChunkFiles: string[] = []
+      for (const chunk of Object.values(bundle)) {
+        if (chunk.type !== 'chunk' || !chunk.isDynamicEntry || !chunk.facadeModuleId) { continue }
+        const relativeId = relative(nuxt.options.rootDir, chunk.facadeModuleId)
+        if (lazyPluginFiles.includes(relativeId)) {
+          let file = chunk.fileName
+          if (file.startsWith(prefix)) {
+            file = file.slice(prefix.length)
+          }
+          lazyChunkFiles.push(file)
+        }
+      }
+
+      nitro.options.virtual ||= {}
+      nitro.options._config.virtual ||= {}
+      nitro.options._config.virtual['#internal/nuxt/lazy-plugin-entries.mjs'] = nitro.options.virtual['#internal/nuxt/lazy-plugin-entries.mjs'] = () => `export default ${JSON.stringify(lazyChunkFiles)}`
+    },
+  }
+}

--- a/packages/vite/src/plugins/lazy-plugins.ts
+++ b/packages/vite/src/plugins/lazy-plugins.ts
@@ -22,12 +22,13 @@ export function LazyPluginPreloadPlugin (nuxt: Nuxt): Plugin | undefined {
     buildEnd () {
       const clientPlugins = nuxt.apps.default?.plugins?.filter(p => !p.mode || p.mode !== 'server') || []
       for (const plugin of clientPlugins) {
-        // Check explicit lazy flag (from nuxt.config or addPlugin)
+        // Plugin objects in nuxt.apps don't carry lazy annotations from extractMetadata
+        // (those only exist during template generation via annotatePlugins), so we check both
+        // the explicit flag from nuxt.config/addPlugin and the source for defineLazyNuxtPlugin.
         if (plugin.lazy) {
           lazyPluginSrcs.add(normalize(plugin.src))
           continue
         }
-        // Detect defineLazyNuxtPlugin in source
         try {
           const code = nuxt.vfs[plugin.src] ?? readFileSync(plugin.src, 'utf-8')
           if (LAZY_PLUGIN_RE.test(code)) {

--- a/packages/vite/src/plugins/lazy-plugins.ts
+++ b/packages/vite/src/plugins/lazy-plugins.ts
@@ -33,7 +33,7 @@ export function LazyPluginPreloadPlugin (nuxt: Nuxt): Plugin | undefined {
           if (LAZY_PLUGIN_RE.test(code)) {
             lazyPluginSrcs.add(normalize(plugin.src))
           }
-        } catch {}
+        } catch { /* plugin may be virtual or unreadable */ }
       }
     },
     generateBundle (_options, bundle) {

--- a/packages/vite/src/plugins/lazy-plugins.ts
+++ b/packages/vite/src/plugins/lazy-plugins.ts
@@ -1,8 +1,11 @@
+import { readFileSync } from 'node:fs'
 import { useNitro } from '@nuxt/kit'
 import type { Nuxt } from '@nuxt/schema'
 import { normalize } from 'pathe'
 import { withoutLeadingSlash } from 'ufo'
 import type { Plugin } from 'vite'
+
+const LAZY_PLUGIN_RE = /defineLazyNuxtPlugin/
 
 export function LazyPluginPreloadPlugin (nuxt: Nuxt): Plugin | undefined {
   if (nuxt.options.dev) { return }
@@ -17,9 +20,20 @@ export function LazyPluginPreloadPlugin (nuxt: Nuxt): Plugin | undefined {
       return environment.name === 'client'
     },
     buildEnd () {
-      const clientPlugins = nuxt.apps.default?.plugins?.filter(p => p.lazy && (!p.mode || p.mode !== 'server')) || []
+      const clientPlugins = nuxt.apps.default?.plugins?.filter(p => !p.mode || p.mode !== 'server') || []
       for (const plugin of clientPlugins) {
-        lazyPluginSrcs.add(normalize(plugin.src))
+        // Check explicit lazy flag (from nuxt.config or addPlugin)
+        if (plugin.lazy) {
+          lazyPluginSrcs.add(normalize(plugin.src))
+          continue
+        }
+        // Detect defineLazyNuxtPlugin in source
+        try {
+          const code = nuxt.vfs[plugin.src] ?? readFileSync(plugin.src, 'utf-8')
+          if (LAZY_PLUGIN_RE.test(code)) {
+            lazyPluginSrcs.add(normalize(plugin.src))
+          }
+        } catch {}
       }
     },
     generateBundle (_options, bundle) {

--- a/packages/vite/src/plugins/lazy-plugins.ts
+++ b/packages/vite/src/plugins/lazy-plugins.ts
@@ -1,6 +1,6 @@
 import { useNitro } from '@nuxt/kit'
 import type { Nuxt } from '@nuxt/schema'
-import { relative } from 'pathe'
+import { normalize } from 'pathe'
 import { withoutLeadingSlash } from 'ufo'
 import type { Plugin } from 'vite'
 
@@ -8,7 +8,7 @@ export function LazyPluginPreloadPlugin (nuxt: Nuxt): Plugin | undefined {
   if (nuxt.options.dev) { return }
 
   const nitro = useNitro()
-  const lazyPluginFiles: string[] = []
+  const lazyPluginSrcs = new Set<string>()
 
   return {
     name: 'nuxt:lazy-plugin-preload',
@@ -19,7 +19,7 @@ export function LazyPluginPreloadPlugin (nuxt: Nuxt): Plugin | undefined {
     buildEnd () {
       const clientPlugins = nuxt.apps.default?.plugins?.filter(p => p.lazy && (!p.mode || p.mode !== 'server')) || []
       for (const plugin of clientPlugins) {
-        lazyPluginFiles.push(relative(nuxt.options.rootDir, plugin.src))
+        lazyPluginSrcs.add(normalize(plugin.src))
       }
     },
     generateBundle (_options, bundle) {
@@ -27,8 +27,8 @@ export function LazyPluginPreloadPlugin (nuxt: Nuxt): Plugin | undefined {
       const lazyChunkFiles: string[] = []
       for (const chunk of Object.values(bundle)) {
         if (chunk.type !== 'chunk' || !chunk.isDynamicEntry || !chunk.facadeModuleId) { continue }
-        const relativeId = relative(nuxt.options.rootDir, chunk.facadeModuleId)
-        if (lazyPluginFiles.includes(relativeId)) {
+        const moduleId = normalize(chunk.facadeModuleId.replace(/\?.*$/, ''))
+        if (lazyPluginSrcs.has(moduleId)) {
           let file = chunk.fileName
           if (file.startsWith(prefix)) {
             file = file.slice(prefix.length)

--- a/packages/vite/src/plugins/lazy-plugins.ts
+++ b/packages/vite/src/plugins/lazy-plugins.ts
@@ -5,7 +5,7 @@ import { normalize } from 'pathe'
 import { withoutLeadingSlash } from 'ufo'
 import type { Plugin } from 'vite'
 
-const LAZY_PLUGIN_RE = /defineLazyNuxtPlugin/
+const LAZY_PLUGIN_RE = /defineLazyNuxtPlugin|lazy:\s*true/
 
 export function LazyPluginPreloadPlugin (nuxt: Nuxt): Plugin | undefined {
   if (nuxt.options.dev || !nuxt.options.experimental.lazyPlugins) { return }

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -30,6 +30,7 @@ import { RuntimePathsPlugin } from './plugins/runtime-paths.ts'
 import { TypeCheckPlugin } from './plugins/type-check.ts'
 import { ModulePreloadPolyfillPlugin } from './plugins/module-preload-polyfill.ts'
 import { StableEntryPlugin } from './plugins/stable-entry.ts'
+import { LazyPluginPreloadPlugin } from './plugins/lazy-plugins.ts'
 import { VitePluginCheckerPlugin } from './plugins/vite-plugin-checker.ts'
 import { AnalyzePlugin } from './plugins/analyze.ts'
 import { DevServerPlugin } from './plugins/dev-server.ts'
@@ -215,6 +216,7 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
         ModulePreloadPolyfillPlugin(),
         // ensure changes in chunks do not invalidate whole build
         StableEntryPlugin(nuxt),
+        LazyPluginPreloadPlugin(nuxt),
         AnalyzePlugin(nuxt),
         OptimizeDepsHintPlugin(nuxt),
       ],

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1456,6 +1456,81 @@ describe('plugins', () => {
     expect(html).toContain('asyncPlugin: Async plugin works! 123')
     expect(html).toContain('useFetch works!')
   })
+
+  it('lazy .client plugin is not included in SSR', async () => {
+    const html = await $fetch<string>('/lazy-plugin')
+    // lazy.client.ts runs post-hydration, so SSR shows default false
+    expect(html).toContain('<div data-testid="lazy-ran">false</div>')
+  })
+
+  it('lazy universal plugin runs on the server', async () => {
+    const html = await $fetch<string>('/lazy-plugin')
+    // lazy-universal.ts has no .client suffix — on server it runs as a normal plugin
+    expect(html).toContain('<div data-testid="lazy-universal-ran">true</div>')
+  })
+
+  it('lazy plugin runs after hydration on client', async () => {
+    const { page } = await renderPage('/lazy-plugin')
+
+    // Wait for hydration + lazy plugin to execute
+    await page.waitForFunction(() => window.useNuxtApp?.() && !window.useNuxtApp?.().isHydrating)
+    await page.waitForFunction(
+      () => document.querySelector('[data-testid="lazy-ran"]')?.textContent?.trim() === 'true',
+      { timeout: 5_000 },
+    )
+
+    const ran = await page.textContent('[data-testid="lazy-ran"]')
+    expect(ran?.trim()).toBe('true')
+
+    await page.close()
+  })
+
+  it.skipIf(isDev || isWebpack)('lazy plugin chunks have low-priority modulepreload links', async () => {
+    const html = await $fetch<string>('/lazy-plugin')
+    const modulepreloadLinks = html.match(/<link[^>]*rel="modulepreload"[^>]*>/g) || []
+    const lazyPreloads = modulepreloadLinks.filter(link => link.includes('fetchpriority="low"'))
+
+    expect(lazyPreloads.length).toBeGreaterThanOrEqual(1)
+
+    const hrefs = lazyPreloads.map(link => link.match(/href="([^"]+)"/)?.[1])
+    for (const href of hrefs) {
+      expect(href).toMatch(/\/_nuxt\/.*\.js$/)
+    }
+
+    // Low-priority modulepreloads should NOT also appear in normal (high-priority) modulepreloads
+    const normalPreloads = modulepreloadLinks.filter(link => !link.includes('fetchpriority="low"'))
+    const normalHrefs = new Set(normalPreloads.map(link => link.match(/href="([^"]+)"/)?.[1]))
+    for (const href of hrefs) {
+      expect(normalHrefs.has(href), `${href} should not be in both normal and lazy preloads`).toBe(false)
+    }
+
+    for (const link of lazyPreloads) {
+      expect(link).toContain('crossorigin')
+    }
+  })
+
+  it('lazy plugin hooks fire on navigation', async () => {
+    const { page } = await renderPage('/lazy-plugin')
+
+    // Wait for lazy plugin to initialize
+    await page.waitForFunction(() => window.useNuxtApp?.() && !window.useNuxtApp?.().isHydrating)
+    await page.waitForFunction(
+      () => document.querySelector('[data-testid="lazy-ran"]')?.textContent?.trim() === 'true',
+      { timeout: 5_000 },
+    )
+
+    // Navigate to trigger page:finish hook
+    await page.click('a')
+    await page.waitForFunction(
+      () => document.querySelector('[data-testid="lazy-navigated"]')?.textContent?.trim() === 'true',
+      { timeout: 5_000 },
+    )
+
+    const navigated = await page.textContent('[data-testid="lazy-navigated"]')
+    expect(navigated?.trim()).toBe('true')
+
+    await page.close()
+  })
 })
 
 describe('layouts', () => {

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -46,17 +46,51 @@ describe.skipIf(isStubbed || process.env.SKIP_BUNDLE_SIZE === 'true' || process.
         "_nuxt/a.js",
         "_nuxt/client-component.js",
         "_nuxt/default.js",
+        "_nuxt/defu.js",
         "_nuxt/entry.js",
+        "_nuxt/manifest.js",
         "_nuxt/pages.js",
         "_nuxt/runtime-core.js",
         "_nuxt/server-component.js",
-        "_nuxt/utils.js",
       ]
     `)
   })
 
   it('default server bundle size', async () => {
     const serverDir = join(rootDir, '.output/server')
+
+    const serverStats = await analyzeSizes(['**/*.mjs', '!_libs'], serverDir)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"66.7k"`)
+
+    const modules = await analyzeSizes(['_libs/**/*'], serverDir)
+    expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"462k"`)
+
+    const packages = modules.files
+      .map(m => m.replace('_libs/', '').replace(/\.mjs$/, ''))
+      .sort()
+    expect(packages).toMatchInlineSnapshot(`
+      [
+        "@unhead/vue+[...]",
+        "defu",
+        "destr",
+        "devalue",
+        "h3+rou3+srvx",
+        "ocache+ohash",
+        "ofetch",
+        "pathe",
+        "scule",
+        "ufo",
+        "unctx",
+        "unstorage",
+        "vue",
+        "vue-bundle-renderer",
+        "vue__server-renderer",
+      ]
+    `)
+  })
+
+  it('default server bundle size (inlined vue modules)', async () => {
+    const serverDir = join(rootDir, '.output-inline/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!_libs'], serverDir)
     expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"66.7k"`)

--- a/test/fixtures/basic/app/pages/lazy-plugin-target.vue
+++ b/test/fixtures/basic/app/pages/lazy-plugin-target.vue
@@ -1,0 +1,11 @@
+<template>
+  <div>
+    <div data-testid="lazy-navigated">
+      {{ lazyPluginNavigated }}
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+const lazyPluginNavigated = useState('lazy-plugin-navigated', () => false)
+</script>

--- a/test/fixtures/basic/app/pages/lazy-plugin.vue
+++ b/test/fixtures/basic/app/pages/lazy-plugin.vue
@@ -1,0 +1,22 @@
+<template>
+  <div>
+    <div data-testid="lazy-ran">
+      {{ lazyPluginRan }}
+    </div>
+    <div data-testid="lazy-navigated">
+      {{ lazyPluginNavigated }}
+    </div>
+    <div data-testid="lazy-universal-ran">
+      {{ lazyUniversalRan }}
+    </div>
+    <NuxtLink to="/lazy-plugin-target">
+      navigate
+    </NuxtLink>
+  </div>
+</template>
+
+<script setup lang="ts">
+const lazyPluginRan = useState('lazy-plugin-ran', () => false)
+const lazyPluginNavigated = useState('lazy-plugin-navigated', () => false)
+const lazyUniversalRan = useState('lazy-universal-ran', () => false)
+</script>

--- a/test/fixtures/basic/app/plugins/lazy-universal.ts
+++ b/test/fixtures/basic/app/plugins/lazy-universal.ts
@@ -1,0 +1,3 @@
+export default defineLazyNuxtPlugin(() => {
+  useState('lazy-universal-ran').value = true
+})

--- a/test/fixtures/basic/app/plugins/lazy.client.ts
+++ b/test/fixtures/basic/app/plugins/lazy.client.ts
@@ -1,0 +1,7 @@
+export default defineLazyNuxtPlugin((nuxtApp) => {
+  useState('lazy-plugin-ran').value = true
+
+  nuxtApp.hook('page:finish', () => {
+    useState('lazy-plugin-navigated').value = true
+  })
+})

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -164,6 +164,7 @@ export default withMatrix({
       selectiveClient: 'deep',
     },
     inlineRouteRules: true,
+    lazyPlugins: true,
   },
   nitro: {
     publicAssets: [

--- a/test/nuxt/plugin.test.ts
+++ b/test/nuxt/plugin.test.ts
@@ -379,9 +379,9 @@ describe('lazy plugins', () => {
       const nuxtApp = useNuxtApp()
       const sequence: string[] = []
 
-      const lazyPlugin = _createLazyPlugin(async () => {
+      const lazyPlugin = _createLazyPlugin(() => {
         sequence.push('lazy-loaded')
-        return { default: defineNuxtPlugin(() => { sequence.push('lazy-setup') }) }
+        return Promise.resolve({ default: defineNuxtPlugin(() => { sequence.push('lazy-setup') }) })
       }, 'lazy')
 
       const normalPlugin = defineNuxtPlugin({

--- a/test/nuxt/plugin.test.ts
+++ b/test/nuxt/plugin.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { applyPlugins } from '#app/nuxt'
+import { _createLazyPlugin, applyPlugins } from '#app/nuxt'
 import { defineNuxtPlugin } from '#app'
 
 vi.mock('#app', async (original) => {
@@ -281,6 +281,254 @@ describe('plugin dependsOn', () => {
       'start C',
       'end C',
     ])
+  })
+})
+
+describe('lazy plugins', () => {
+  describe('_createLazyPlugin wrapper', () => {
+    it('returns a plugin with parallel: true', () => {
+      const plugin = _createLazyPlugin(() => Promise.resolve({ default: defineNuxtPlugin(() => {}) }), 'analytics')
+      expect(plugin.parallel).toBe(true)
+    })
+
+    it('sets _name with lazy: prefix', () => {
+      const plugin = _createLazyPlugin(() => Promise.resolve({ default: defineNuxtPlugin(() => {}) }), 'my-analytics')
+      expect(plugin._name).toBe('lazy:my-analytics')
+    })
+
+    it('defaults _name to lazy:unknown when no name provided', () => {
+      const plugin = _createLazyPlugin(() => Promise.resolve({ default: defineNuxtPlugin(() => {}) }))
+      expect(plugin._name).toBe('lazy:unknown')
+    })
+
+    it('is a valid NuxtPlugin indicator', () => {
+      const plugin = _createLazyPlugin(() => Promise.resolve({ default: defineNuxtPlugin(() => {}) }))
+      expect(typeof plugin).toBe('function')
+    })
+  })
+
+  describe('deferred execution', () => {
+    it('does NOT call loader during applyPlugins', async () => {
+      const nuxtApp = useNuxtApp()
+      const loader = vi.fn(() => Promise.resolve({ default: defineNuxtPlugin(() => {}) }))
+      const plugin = _createLazyPlugin(loader, 'deferred')
+
+      await applyPlugins(nuxtApp, [plugin])
+
+      expect(loader).not.toHaveBeenCalled()
+    })
+
+    it('does NOT run setup during applyPlugins', async () => {
+      const nuxtApp = useNuxtApp()
+      const setup = vi.fn()
+      const loader = vi.fn(() => Promise.resolve({ default: defineNuxtPlugin(setup) }))
+      const plugin = _createLazyPlugin(loader, 'deferred')
+
+      await applyPlugins(nuxtApp, [plugin])
+
+      expect(setup).not.toHaveBeenCalled()
+    })
+
+    it('executes loader after app:suspense:resolve', async () => {
+      const nuxtApp = useNuxtApp()
+      const setup = vi.fn()
+      const loader = vi.fn(() => Promise.resolve({ default: defineNuxtPlugin(setup) }))
+      const plugin = _createLazyPlugin(loader, 'post-hydration')
+
+      await applyPlugins(nuxtApp, [plugin])
+      expect(loader).not.toHaveBeenCalled()
+
+      await nuxtApp.hooks.callHook('app:suspense:resolve')
+      await new Promise(resolve => setTimeout(resolve, 10))
+
+      expect(loader).toHaveBeenCalledOnce()
+      expect(setup).toHaveBeenCalledOnce()
+    })
+
+    it('executes object-syntax plugin setup after app:suspense:resolve', async () => {
+      const nuxtApp = useNuxtApp()
+      const setup = vi.fn()
+      const loader = vi.fn(() => Promise.resolve({
+        default: defineNuxtPlugin({ name: 'obj-lazy', setup }),
+      }))
+      const plugin = _createLazyPlugin(loader, 'obj-lazy')
+
+      await applyPlugins(nuxtApp, [plugin])
+      await nuxtApp.hooks.callHook('app:suspense:resolve')
+      await new Promise(resolve => setTimeout(resolve, 10))
+
+      expect(setup).toHaveBeenCalledOnce()
+    })
+
+    it('only fires once even if app:suspense:resolve is called multiple times', async () => {
+      const nuxtApp = useNuxtApp()
+      const loader = vi.fn(() => Promise.resolve({ default: defineNuxtPlugin(() => {}) }))
+      const plugin = _createLazyPlugin(loader, 'once')
+
+      await applyPlugins(nuxtApp, [plugin])
+      await nuxtApp.hooks.callHook('app:suspense:resolve')
+      await nuxtApp.hooks.callHook('app:suspense:resolve')
+      await new Promise(resolve => setTimeout(resolve, 10))
+
+      expect(loader).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('does not block other plugins', () => {
+    it('runs alongside normal plugins without blocking', async () => {
+      const nuxtApp = useNuxtApp()
+      const sequence: string[] = []
+
+      const lazyPlugin = _createLazyPlugin(async () => {
+        sequence.push('lazy-loaded')
+        return { default: defineNuxtPlugin(() => { sequence.push('lazy-setup') }) }
+      }, 'lazy')
+
+      const normalPlugin = defineNuxtPlugin({
+        name: 'normal',
+        setup () { sequence.push('normal-setup') },
+      })
+
+      await applyPlugins(nuxtApp, [lazyPlugin, normalPlugin])
+
+      // Normal plugin runs, lazy does not
+      expect(sequence).toEqual(['normal-setup'])
+    })
+  })
+
+  describe('error handling', () => {
+    it('triggers app:error hook on loader failure', async () => {
+      const nuxtApp = useNuxtApp()
+      const errorHandler = vi.fn()
+      nuxtApp.hooks.hook('app:error', errorHandler)
+
+      const error = new Error('chunk load failed')
+      const plugin = _createLazyPlugin(() => Promise.reject(error), 'broken')
+
+      await applyPlugins(nuxtApp, [plugin])
+      await nuxtApp.hooks.callHook('app:suspense:resolve')
+      await new Promise(resolve => setTimeout(resolve, 10))
+
+      expect(errorHandler).toHaveBeenCalledWith(error)
+    })
+
+    it('triggers app:error hook when plugin setup throws', async () => {
+      const nuxtApp = useNuxtApp()
+      const errorHandler = vi.fn()
+      nuxtApp.hooks.hook('app:error', errorHandler)
+
+      const error = new Error('setup crashed')
+      const plugin = _createLazyPlugin(() => Promise.resolve({
+        default: defineNuxtPlugin(() => { throw error }),
+      }), 'crasher')
+
+      await applyPlugins(nuxtApp, [plugin])
+      await nuxtApp.hooks.callHook('app:suspense:resolve')
+      await new Promise(resolve => setTimeout(resolve, 10))
+
+      expect(errorHandler).toHaveBeenCalledWith(error)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('multiple lazy plugins each defer independently', async () => {
+      const nuxtApp = useNuxtApp()
+      const sequence: string[] = []
+
+      const lazyA = _createLazyPlugin(() => Promise.resolve({
+        default: defineNuxtPlugin(() => { sequence.push('lazy-A') }),
+      }), 'A')
+      const lazyB = _createLazyPlugin(() => Promise.resolve({
+        default: defineNuxtPlugin(() => { sequence.push('lazy-B') }),
+      }), 'B')
+
+      await applyPlugins(nuxtApp, [lazyA, lazyB])
+      expect(sequence).toEqual([])
+
+      await nuxtApp.hooks.callHook('app:suspense:resolve')
+      await new Promise(resolve => setTimeout(resolve, 10))
+
+      expect(sequence).toContain('lazy-A')
+      expect(sequence).toContain('lazy-B')
+    })
+
+    it('lazy plugin _name is not resolvable as dependsOn target', async () => {
+      const nuxtApp = useNuxtApp()
+      const sequence: string[] = []
+
+      const lazyPlugin = _createLazyPlugin(() => Promise.resolve({
+        default: defineNuxtPlugin(() => { sequence.push('lazy') }),
+      }), 'lazy-dep')
+
+      // Plugin B depends on 'lazy:lazy-dep' — but lazy plugins run outside the pipeline,
+      // so B should execute without waiting (dependsOn can't find the name)
+      const pluginB = defineNuxtPlugin({
+        name: 'B',
+        // @ts-expect-error testing invalid dependsOn
+        dependsOn: ['lazy:lazy-dep'],
+        setup () { sequence.push('B') },
+        parallel: true,
+      })
+
+      await applyPlugins(nuxtApp, [lazyPlugin, pluginB])
+      // B should not be blocked — lazy:lazy-dep is never "resolved" by applyPlugins
+      // since the lazy wrapper doesn't resolve plugin names in the pipeline
+      expect(sequence).toContain('B')
+    })
+
+    it('handles module default that is a plain function (not defineNuxtPlugin)', async () => {
+      const nuxtApp = useNuxtApp()
+      const setup = vi.fn()
+
+      // Simulates a plugin file that exports a bare function
+      const plugin = _createLazyPlugin(() => Promise.resolve({
+        default: setup as any,
+      }), 'bare-fn')
+
+      await applyPlugins(nuxtApp, [plugin])
+      await nuxtApp.hooks.callHook('app:suspense:resolve')
+      await new Promise(resolve => setTimeout(resolve, 10))
+
+      expect(setup).toHaveBeenCalledOnce()
+    })
+
+    it('lazy plugins mixed with sequential and parallel normal plugins', async () => {
+      const nuxtApp = useNuxtApp()
+      const sequence: string[] = []
+
+      const seqPlugin = defineNuxtPlugin({
+        name: 'seq',
+        async setup () {
+          sequence.push('start seq')
+          await new Promise(resolve => setTimeout(resolve, 10))
+          sequence.push('end seq')
+        },
+      })
+
+      const lazyPlugin = _createLazyPlugin(() => Promise.resolve({
+        default: defineNuxtPlugin(() => { sequence.push('lazy') }),
+      }), 'lazy')
+
+      const parallelPlugin = defineNuxtPlugin({
+        name: 'par',
+        parallel: true,
+        async setup () {
+          sequence.push('start par')
+          await new Promise(resolve => setTimeout(resolve, 5))
+          sequence.push('end par')
+        },
+      })
+
+      await applyPlugins(nuxtApp, [seqPlugin, lazyPlugin, parallelPlugin])
+
+      // Lazy should not appear, sequential should complete before parallel starts
+      expect(sequence).toEqual(['start seq', 'end seq', 'start par', 'end par'])
+
+      await nuxtApp.hooks.callHook('app:suspense:resolve')
+      await new Promise(resolve => setTimeout(resolve, 10))
+
+      expect(sequence).toContain('lazy')
+    })
   })
 })
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- No directly related open issue — this is a new feature -->

### 📚 Description

Nuxt plugins are the entry point for us to add generic behavior for our entire app. While they have always been designed to run _before_ our app starts, so that they can provide anything required for our app to run properly, there are cases where we want to run app-wide code but don't really care about _when_ it runs.

A common example of this would be any sort of analytics, tracking, a+b testing scripts. In the Nuxt repo itself, it has two examples of plugins that don't need to block the Nuxt render: `check-outdated-build.client.ts` and `navigation-repaint.client.ts`.

To solve this we take the already existing `lazy` architecture that Nuxt implements throughout the app (lazy async data, lazy vue components, etc). and introduce it to plugins. As we already have AST parsing on plugins the implementation of this slots in without much effort.

### Usage

`defineLazyNuxtPlugin` defers plugin execution until **after hydration** (`app:suspense:resolve`) but before idle. Lazy plugins are automatically code-split into their own chunks, keeping them out of the entry bundle. In production we preload the module as low priority allowing critical scripts to run first `<link rel="modulepreload" fetchpriority="low">`.

It works for both client / server - for server there's no delay.


```ts
// plugins/analytics.client.ts
import { initAnalytics } from 'some-heavy-dependency' 

export default defineLazyNuxtPlugin((nuxtApp) => {
  initAnalytics()

  const router = nuxtApp.$router
  router.afterEach((to) => {
    trackPageView(to.fullPath)
  })
})
```

Module authors register lazy plugin.

```ts
addPlugin({
  src: resolve('./runtime/analytics.client'),
  lazy: true,
})
```

#### Constraints

Lazy plugins cannot use `provide`, `dependsOn`, `order`, or `enforce`; they run outside the plugin pipeline after the app is mounted. The types are set up to avoid issues there and some runtime checks.

#### :question: Decisions

- We may consider bundling lazy plugin chunks together for a faster preload /execution.
- How do we handle lazy chunks which use dependencies in the main entry (or will be used).
