### PR TITLE
feat(nuxt,schema): add `throwOnError` option to async data

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -122,22 +122,25 @@ export interface AsyncDataExecuteOptions {
    * not be cancelled, but their result will not affect the data/pending state - and any
    * previously awaited promises will not resolve until this new request resolves.
    */
-  dedupe?: 'cancel' | 'defer'
+  'dedupe'?: 'cancel' | 'defer'
 
-  cause?: AsyncDataRefreshCause
+  'cause'?: AsyncDataRefreshCause
 
-  /** @internal */
-  cachedData?: any
+  'signal'?: AbortSignal
 
-  signal?: AbortSignal
-
-  timeout?: number
+  'timeout'?: number
 
   /**
    * When `true`, the promise returned by `execute` / `refresh` will reject
    * when the handler throws, overriding the composable-level `throwOnError` option.
    */
-  throwOnError?: boolean
+  'throwOnError'?: boolean
+
+  /** @internal */
+  '~cachedData'?: any
+
+  /** @internal */
+  '~rethrow'?: boolean
 }
 
 export interface _AsyncData<DataT, ErrorT> {
@@ -312,8 +315,8 @@ export const createUseAsyncData = defineKeyedFunctionFactory({
       function createInitialFetch () {
         const initialFetchOptions: AsyncDataExecuteOptions = { cause: 'initial', dedupe: opts.dedupe }
         if (!nuxtApp._asyncData[key.value]?._init) {
-          initialFetchOptions.cachedData = opts.getCachedData!(key.value, nuxtApp, { cause: 'initial' })
-          nuxtApp._asyncData[key.value] = buildAsyncData(nuxtApp, key.value, _handler, opts, initialFetchOptions.cachedData)
+          initialFetchOptions['~cachedData'] = opts.getCachedData!(key.value, nuxtApp, { cause: 'initial' })
+          nuxtApp._asyncData[key.value] = buildAsyncData(nuxtApp, key.value, _handler, opts, initialFetchOptions['~cachedData'])
         }
         return () => nuxtApp._asyncData[key.value]!.execute(initialFetchOptions)
       }
@@ -369,10 +372,10 @@ export const createUseAsyncData = defineKeyedFunctionFactory({
         } else if (instance && ((!isWithinClientOnly && nuxtApp.payload.serverRendered && nuxtApp.isHydrating) || opts.lazy) && opts.immediate) {
           // 2. Initial load (server: false): fetch on mounted
           // 3. Initial load or navigation (lazy: true): fetch on mounted
-          instance._nuxtOnBeforeMountCbs.push(initialFetch)
+          instance._nuxtOnBeforeMountCbs.push(() => { initialFetch().catch(() => {}) })
         } else if (opts.immediate && asyncData.status.value !== 'success') {
           // 4. Navigation (lazy: false) - or plugin usage: await fetch
-          initialFetch()
+          initialFetch().catch(() => {})
         }
 
         function unregister (key: string) {
@@ -396,7 +399,7 @@ export const createUseAsyncData = defineKeyedFunctionFactory({
             const hadData = nuxtApp._asyncData[oldKey]?.data.value !== undefined
             const wasRunning = nuxtApp._asyncDataPromises[oldKey] !== undefined
 
-            const initialFetchOptions: AsyncDataExecuteOptions = { cause: 'initial', dedupe: opts.dedupe }
+            const initialFetchOptions: AsyncDataExecuteOptions = { 'cause': 'initial', 'dedupe': opts.dedupe, '~rethrow': false }
 
             // Ensure destination container exists; read/migrate value BEFORE unregistering the old key.
             if (!nuxtApp._asyncData[newKey]?._init) {
@@ -406,7 +409,7 @@ export const createUseAsyncData = defineKeyedFunctionFactory({
                 initialValue = nuxtApp._asyncData[oldKey]!.data.value as NoInfer<DataT>
               } else {
                 initialValue = opts.getCachedData!(newKey, nuxtApp, { cause: 'initial' })
-                initialFetchOptions.cachedData = initialValue
+                initialFetchOptions['~cachedData'] = initialValue
               }
 
               nuxtApp._asyncData[newKey] = buildAsyncData(nuxtApp, newKey, _handler, opts, initialValue)
@@ -442,7 +445,7 @@ export const createUseAsyncData = defineKeyedFunctionFactory({
                   nuxtApp._asyncData[key.value]?._execute.flush()
                 })
               }
-              nuxtApp._asyncData[key.value]?._execute({ cause: 'watch', dedupe: opts.dedupe })
+              nuxtApp._asyncData[key.value]?._execute({ 'cause': 'watch', 'dedupe': opts.dedupe, '~rethrow': false })
             })
           : () => {}
 
@@ -669,7 +672,7 @@ function buildAsyncData<
   const hasCachedData = initialCachedData !== undefined
   const unsubRefreshAsyncData = nuxtApp.hook('app:data:refresh', async (keys) => {
     if (!keys || keys.includes(key)) {
-      await asyncData.execute({ cause: 'refresh:hook' })
+      await asyncData.execute({ 'cause': 'refresh:hook', '~rethrow': false })
     }
   })
   const asyncData: CreatedAsyncData<ResT, NuxtErrorDataT, DataT, DefaultT> = {
@@ -692,7 +695,7 @@ function buildAsyncData<
       }
       // Avoid fetching same key that is already fetched
       if (granularCachedData || opts.cause === 'initial' || nuxtApp.isHydrating) {
-        const cachedData = 'cachedData' in opts ? opts.cachedData : options.getCachedData!(key, nuxtApp, { cause: opts.cause ?? 'refresh:manual' })
+        const cachedData = '~cachedData' in opts ? opts['~cachedData'] : options.getCachedData!(key, nuxtApp, { cause: opts.cause ?? 'refresh:manual' })
         if (cachedData !== undefined) {
           nuxtApp.payload.data[key] = asyncData.data.value = cachedData as DataT
           asyncData.error.value = undefined
@@ -772,7 +775,7 @@ function buildAsyncData<
           asyncData.data.value = unref(options.default!())
           asyncData.status.value = 'error'
 
-          if (opts.throwOnError ?? options.throwOnError) {
+          if ((opts.throwOnError ?? options.throwOnError) && opts['~rethrow'] !== false) {
             throw asyncData.error.value
           }
         })

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -104,6 +104,16 @@ export interface AsyncDataOptions<
    * A timeout in milliseconds after which the request will be aborted if it has not resolved yet.
    */
   timeout?: number
+  /**
+   * When `true`, the promise returned by `useAsyncData` / `execute` / `refresh` will reject
+   * when the handler throws, instead of silently capturing the error in the `error` ref.
+   *
+   * The `error` ref, `data` ref and `status` ref are still updated before the error is
+   * re-thrown, so reactive state remains consistent.
+   *
+   * @default false
+   */
+  throwOnError?: boolean
 }
 
 export interface AsyncDataExecuteOptions {
@@ -122,6 +132,12 @@ export interface AsyncDataExecuteOptions {
   signal?: AbortSignal
 
   timeout?: number
+
+  /**
+   * When `true`, the promise returned by `execute` / `refresh` will reject
+   * when the handler throws, overriding the composable-level `throwOnError` option.
+   */
+  throwOnError?: boolean
 }
 
 export interface _AsyncData<DataT, ErrorT> {
@@ -251,6 +267,7 @@ export const createUseAsyncData = defineKeyedFunctionFactory({
       opts.immediate ??= true
       opts.deep ??= asyncDataDefaults.deep
       opts.dedupe ??= 'cancel'
+      opts.throwOnError ??= asyncDataDefaults.throwOnError ?? false
 
       // assign overrides from factory
       if (shouldFactoryOptionsOverride) {
@@ -754,6 +771,10 @@ function buildAsyncData<
           asyncData.error.value = createError<NuxtErrorDataT>(error) as (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>)
           asyncData.data.value = unref(options.default!())
           asyncData.status.value = 'error'
+
+          if (opts.throwOnError ?? options.throwOnError) {
+            throw asyncData.error.value
+          }
         })
         .finally(() => {
           if (pendingWhenIdle) {

--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -175,6 +175,7 @@ export const createUseFetch = defineKeyedFunctionFactory({
         deep,
         dedupe,
         timeout,
+        throwOnError,
         ...fetchOptions
       } = {
         ...(typeof options === 'function' ? {} : factoryOptions),
@@ -199,6 +200,7 @@ export const createUseFetch = defineKeyedFunctionFactory({
         deep,
         dedupe,
         timeout,
+        throwOnError,
         watch: watchSources === false ? [] : [...(watchSources || []), _fetchOptions],
       }
 

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -167,6 +167,7 @@ export default defineResolvers({
       },
       useAsyncData: {
         deep: false,
+        throwOnError: false,
       },
       useState: {
         resetOnClear: {

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1316,6 +1316,19 @@ export interface ConfigSchema {
        */
       useAsyncData: {
         deep: boolean
+        /**
+         * When `true`, `useAsyncData` will throw (reject) when the handler errors
+         * instead of silently capturing the error in the `error` ref.
+         *
+         * The `error` ref, `data` ref and `status` ref are still updated before
+         * the error is re-thrown, so reactive state remains consistent.
+         *
+         * Can be overridden per-call via `useAsyncData(handler, { throwOnError: true })`
+         * or per-execute via `execute({ throwOnError: true })`.
+         *
+         * @default false
+         */
+        throwOnError: boolean
       }
 
       /**

--- a/test/nuxt/use-async-data.test.ts
+++ b/test/nuxt/use-async-data.test.ts
@@ -128,6 +128,23 @@ describe('useAsyncData', () => {
     vi.unstubAllGlobals()
   })
 
+  it('should throw on error when throwOnError option is set', async () => {
+    await expect(
+      useAsyncData(uniqueKey, () => Promise.reject(new Error('test')), { throwOnError: true }),
+    ).rejects.toThrow()
+  })
+
+  it('should throw on error via execute option override', async () => {
+    const { execute } = useAsyncData(uniqueKey, () => Promise.reject(new Error('test')), { immediate: false })
+    await expect(execute({ throwOnError: true })).rejects.toThrow()
+  })
+
+  it('should not throw when throwOnError is false (default)', async () => {
+    const { error, status } = await useAsyncData(uniqueKey, () => Promise.reject(new Error('test')))
+    expect(error.value).toBeTruthy()
+    expect(status.value).toBe('error')
+  })
+
   // https://github.com/nuxt/nuxt/issues/23411
   it('should initialize with error set to null when immediate: false', async () => {
     const { error, execute } = useAsyncData(() => Promise.resolve({}), { immediate: false })

--- a/test/nuxt/use-async-data.test.ts
+++ b/test/nuxt/use-async-data.test.ts
@@ -145,6 +145,25 @@ describe('useAsyncData', () => {
     expect(status.value).toBe('error')
   })
 
+  it('should not cause unhandled rejection when watch triggers re-fetch with throwOnError', async () => {
+    const trigger = ref(0)
+    let callCount = 0
+    const { error } = await useAsyncData(uniqueKey, () => {
+      callCount++
+      // First call succeeds, subsequent (watch-triggered) calls fail
+      if (callCount === 1) { return Promise.resolve('ok') }
+      return Promise.reject(new Error('watch-triggered error'))
+    }, { throwOnError: true, watch: [trigger] })
+
+    expect(error.value).toBeFalsy()
+
+    // Without _rethrow guard, this would throw as an unhandled rejection.
+    trigger.value++
+    await flushPromises()
+
+    expect(error.value).toBeTruthy()
+  })
+
   // https://github.com/nuxt/nuxt/issues/23411
   it('should initialize with error set to null when immediate: false', async () => {
     const { error, execute } = useAsyncData(() => Promise.resolve({}), { immediate: false })

--- a/test/nuxt/use-fetch.test.ts
+++ b/test/nuxt/use-fetch.test.ts
@@ -302,5 +302,4 @@ describe('useFetch', () => {
       useFetch('/api/throw-test-default'),
     ).resolves.toBeDefined()
   })
-  })
 })

--- a/test/nuxt/use-fetch.test.ts
+++ b/test/nuxt/use-fetch.test.ts
@@ -299,7 +299,8 @@ describe('useFetch', () => {
     }))
 
     await expect(
-      useFetch('/api/throw-test-default', { throwOnError: false }),
+      useFetch('/api/throw-test-default'),
     ).resolves.toBeDefined()
+  })
   })
 })

--- a/test/nuxt/use-fetch.test.ts
+++ b/test/nuxt/use-fetch.test.ts
@@ -282,4 +282,24 @@ describe('useFetch', () => {
     clear()
     expect(aborted).toBe(true)
   })
+
+  it('should throw on error when throwOnError option is set', async () => {
+    registerEndpoint('/api/throw-test', defineEventHandler(() => {
+      throw new Error('fetch error')
+    }))
+
+    await expect(
+      useFetch('/api/throw-test', { throwOnError: true }),
+    ).rejects.toThrow()
+  })
+
+  it('should not throw when throwOnError is false (default)', async () => {
+    registerEndpoint('/api/throw-test-default', defineEventHandler(() => {
+      throw new Error('fetch error')
+    }))
+
+    await expect(
+      useFetch('/api/throw-test-default', { throwOnError: false }),
+    ).resolves.toBeDefined()
+  })
 })


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/31743
resolves https://github.com/nuxt/nuxt/issues/34531

### 📚 Description

This PR adds a `throwOnError` option to `useAsyncData`/`useFetch` composables. It can be set either globally in nuxt.config via `experimental.defaults.useAsyncData.throwOnError`, using the async data options, or per `execute`/`refresh` call.

Feedback on whether this PR fully addresses users' use-cases is much appreciated!