### PR TITLE
fix(nuxt): filter `clearNuxtState` key enumeration by useState prefix

### DIFF
--- a/packages/nuxt/src/app/composables/state.ts
+++ b/packages/nuxt/src/app/composables/state.ts
@@ -68,6 +68,7 @@ export function clearNuxtState (
 
   const nuxtApp = useNuxtApp()
   const _allKeys = Object.keys(nuxtApp.payload.state)
+    .filter(key => key.startsWith(useStateKeyPrefix))
     .map(key => key.substring(useStateKeyPrefix.length))
 
   const _keys: string[] = !keys

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -362,6 +362,35 @@ describe('clearNuxtState', () => {
     const state3 = useState('clearNuxtState-test', () => 'test')
     expect(state3.value).toBe('test')
   })
+
+  it('should only enumerate useState keys, ignoring internal payload.state entries', () => {
+    const nuxtApp = useNuxtApp()
+    // Simulate internal state entries that don't use the useState prefix
+    nuxtApp.payload.state._layout = 'default'
+    nuxtApp.payload.state._layoutProps = { foo: 'bar' }
+
+    const state = useState('clearNuxtState-test', () => 'test')
+    expect(state.value).toBe('test')
+
+    const matchedKeys: string[] = []
+    clearNuxtState((key) => {
+      matchedKeys.push(key)
+      return true
+    })
+
+    // Filter function should only receive actual useState keys, not garbled internal keys
+    expect(matchedKeys).not.toContain('ayout')
+    expect(matchedKeys).not.toContain('ayoutProps')
+    expect(matchedKeys).toContain('clearNuxtState-test')
+
+    // Internal state entries should not be affected
+    expect(nuxtApp.payload.state._layout).toBe('default')
+    expect(nuxtApp.payload.state._layoutProps).toEqual({ foo: 'bar' })
+
+    // Clean up
+    delete nuxtApp.payload.state._layout
+    delete nuxtApp.payload.state._layoutProps
+  })
 })
 
 describe('url', () => {


### PR DESCRIPTION
`clearNuxtState` enumerates all keys from `payload.state` and strips the `$s` prefix to produce user-facing state keys. But `payload.state` also holds internal entries like `_layout` and `_layoutProps` (set by `setPageLayout`) that don't use the `$s` prefix.

Without the prefix filter, those internal keys get stripped to garbled strings (`ayout`, `ayoutProps`) and either iterated unnecessarily or passed to user-provided filter functions, which is confusing if you're debugging what keys exist.

One-line fix: `.filter(key => key.startsWith(useStateKeyPrefix))` before the `.map()` that strips the prefix. No functional breakage since the reconstructed keys (`$sayout`) never matched anything in `payload.state` anyway, but correctness matters for filter predicates.

Includes a test that sets internal `_layout`/`_layoutProps` entries on `payload.state` and verifies they don't leak into the filter callback.