### PR TITLE
fix(nuxt): prevent in-flight requests from overwriting cleared async data

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -713,6 +713,11 @@ function buildAsyncData<
           }
         })
         .then(async (_result) => {
+          // If the promise was replaced or cleared (e.g. by clearNuxtData), skip the update
+          if (nuxtApp._asyncDataPromises[key] !== promise) {
+            return
+          }
+
           let result = _result as unknown as DataT
           if (options.transform) {
             result = await options.transform(_result)
@@ -735,8 +740,8 @@ function buildAsyncData<
           asyncData.status.value = 'success'
         })
         .catch((error: any) => {
-          // If the promise was replaced by another one, we do not update the asyncData
-          if (nuxtApp._asyncDataPromises[key] && nuxtApp._asyncDataPromises[key] !== promise) {
+          // If the promise was replaced or cleared (e.g. by clearNuxtData), do not update the asyncData
+          if (nuxtApp._asyncDataPromises[key] !== promise) {
             return nuxtApp._asyncDataPromises[key]
           }
 
@@ -756,12 +761,15 @@ function buildAsyncData<
           asyncData.status.value = 'error'
         })
         .finally(() => {
-          if (pendingWhenIdle) {
-            asyncData.pending.value = false
-          }
           cleanupController.abort()
 
-          delete nuxtApp._asyncDataPromises[key]
+          // Only clean up if this promise is still the current one
+          if (nuxtApp._asyncDataPromises[key] === promise) {
+            if (pendingWhenIdle) {
+              asyncData.pending.value = false
+            }
+            delete nuxtApp._asyncDataPromises[key]
+          }
         })
       nuxtApp._asyncDataPromises[key] = promise
       return nuxtApp._asyncDataPromises[key]!

--- a/test/nuxt/use-async-data.test.ts
+++ b/test/nuxt/use-async-data.test.ts
@@ -249,6 +249,31 @@ describe('useAsyncData', () => {
     expect(status.value).toBe('idle')
   })
 
+  it('should not overwrite cleared data when in-flight request completes', async () => {
+    vi.useFakeTimers()
+
+    const { data, status, refresh } = await useAsyncData(uniqueKey, () => Promise.resolve('initial'))
+    expect(data.value).toBe('initial')
+
+    // Start a slow refresh
+    const refreshPromise = refresh()
+
+    // Clear while the refresh is in flight
+    clearNuxtData(uniqueKey)
+    expect(data.value).toBeUndefined()
+    expect(status.value).toBe('idle')
+
+    // Let the refresh complete
+    vi.advanceTimersByTime(0)
+    await refreshPromise
+
+    // Data should stay cleared
+    expect(data.value).toBeUndefined()
+    expect(status.value).toBe('idle')
+
+    vi.useRealTimers()
+  })
+
   it('should have correct status for previously fetched requests', async () => {
     vi.useFakeTimers()
 


### PR DESCRIPTION
`clearNuxtData()` sets `_asyncDataPromises[key]` to `undefined` and resets the data state, but the `.then` handler of the still-in-flight promise has no guard - when the request completes, it writes the result back, overwriting the cleared state.

The `.catch` handler had a partial guard (`&&` short-circuits when the promise ref is `undefined`) but still fell through to error-setting code paths. The `.finally` handler also unconditionally deleted the promise reference, which could remove a *newer* promise's reference when two `execute()` calls overlap.

This adds promise identity checks across all three handlers:
- `.then`: skip data writes if the promise was replaced or cleared
- `.catch`: skip error state updates if the promise was replaced or cleared
- `.finally`: only delete the promise ref and update pending state if this is still the current promise

Includes a regression test.