### PR TITLE
fix(nuxt): check response status before parsing payload

### DIFF
--- a/packages/nuxt/src/app/composables/payload.ts
+++ b/packages/nuxt/src/app/composables/payload.ts
@@ -80,10 +80,15 @@ async function _getPayloadURL (url: string, opts: LoadPayloadOptions = {}) {
 
 async function _importPayload (payloadURL: string) {
   if (import.meta.server || !payloadExtraction) { return null }
-  const payloadPromise = fetch(payloadURL, import.meta.dev ? {} : { cache: 'force-cache' }).then(res => res.text().then(parsePayload))
-
   try {
-    return await payloadPromise
+    const res = await fetch(payloadURL, import.meta.dev ? {} : { cache: 'force-cache' })
+    if (!res.ok) {
+      if (import.meta.dev) {
+        console.warn(`[nuxt] Cannot load payload ${payloadURL}: ${res.status} ${res.statusText}`)
+      }
+      return null
+    }
+    return await parsePayload(await res.text())
   } catch (err) {
     console.warn('[nuxt] Cannot load payload ', payloadURL, err)
   }


### PR DESCRIPTION
`_importPayload` was feeding non-OK HTTP responses (404, 500) directly into `devalue`'s `parse()`, producing confusing `SyntaxError` messages when the actual problem is a missing or broken payload endpoint. The response body in those cases is typically an HTML error page, not valid payload JSON.

Added a `res.ok` guard that short-circuits before attempting to parse. In dev mode, a warning with the HTTP status is logged to make the root cause visible.

Related to the broader payload extraction debugging experience: #34547, #34496, #34501