### PR TITLE
fix(nuxt): handle TS type assertions on member expression callees in keyed functions parser

### DIFF
--- a/packages/nuxt/src/core/utils/parse-utils.ts
+++ b/packages/nuxt/src/core/utils/parse-utils.ts
@@ -200,7 +200,6 @@ export function parseStaticFunctionCall (node: CallExpression | ChainExpression,
     return null
   }
 
-  // TODO: handle optional chaining, type assertions, non-null assertions, etc.
   // Member Expressions
   // foo.bar()
   if (callExpression.callee.type === 'MemberExpression') {
@@ -211,14 +210,31 @@ export function parseStaticFunctionCall (node: CallExpression | ChainExpression,
         callExpression,
       }
     }
-  // (foo.bar)()
-  } else if (callExpression.callee.type === 'ParenthesizedExpression' && callExpression.callee.expression.type === 'MemberExpression') {
-    const val = getParsedMemberExpression(callExpression.callee.expression)
-    if (val) {
-      return {
-        ...val,
-        node: callExpression.callee,
-        callExpression,
+  } else if (callExpression.callee.type === 'ParenthesizedExpression') {
+    let innerExpression = callExpression.callee.expression
+
+    // (foo.bar as any)()
+    // (<any>foo.bar)()
+    // (foo.bar!)()
+    if (
+      (
+        innerExpression.type === 'TSAsExpression'
+        || innerExpression.type === 'TSTypeAssertion'
+        || innerExpression.type === 'TSNonNullExpression'
+      )
+    ) {
+      innerExpression = innerExpression.expression
+    }
+
+    // (foo.bar)()
+    if (innerExpression.type === 'MemberExpression') {
+      const val = getParsedMemberExpression(innerExpression)
+      if (val) {
+        return {
+          ...val,
+          node: callExpression.callee,
+          callExpression,
+        }
       }
     }
   }

--- a/packages/nuxt/test/compiler.test.ts
+++ b/packages/nuxt/test/compiler.test.ts
@@ -361,6 +361,12 @@ describe('parseFunctionCall', () => {
     expectFunctionCallMeta(result, { name: 'createUseFetch', namespace: 'factories' })
   })
 
+  it('should handle a TS as-cast wrapping a member expression callee', () => {
+    const code = `const x = (factories.createUseFetch as any)()`
+    const result = getFirstParsedFunctionCall(code, /createUseFetch/)
+    expectFunctionCallMeta(result, { name: 'createUseFetch', namespace: 'factories' })
+  })
+
   it('should handle a TS non-null assertion callee', () => {
     const code = `const x = (createUseFetch!)()`
     const result = getFirstParsedFunctionCall(code, /createUseFetch/)
@@ -373,6 +379,12 @@ describe('parseFunctionCall', () => {
     expectFunctionCallMeta(result, { name: 'createUseFetch', namespace: 'factories' })
   })
 
+  it('should handle a TS non-null assertion wrapping a member expression callee', () => {
+    const code = `const x = (factories.createUseFetch!)()`
+    const result = getFirstParsedFunctionCall(code, /createUseFetch/)
+    expectFunctionCallMeta(result, { name: 'createUseFetch', namespace: 'factories' })
+  })
+
   it('should handle a TS type-assertion in parenthesized expression callee', () => {
     const code = `const x = (<any>createUseFetch)()`
     const result = getFirstParsedFunctionCall(code, /createUseFetch/)
@@ -381,6 +393,12 @@ describe('parseFunctionCall', () => {
 
   it('should handle a TS type-assertion in member expression object', () => {
     const code = `const x = (<any>factories).createUseFetch()`
+    const result = getFirstParsedFunctionCall(code, /createUseFetch/)
+    expectFunctionCallMeta(result, { name: 'createUseFetch', namespace: 'factories' })
+  })
+
+  it('should handle a TS type-assertion wrapping a member expression callee', () => {
+    const code = `const x = (<any>factories.createUseFetch)()`
     const result = getFirstParsedFunctionCall(code, /createUseFetch/)
     expectFunctionCallMeta(result, { name: 'createUseFetch', namespace: 'factories' })
   })


### PR DESCRIPTION
`parseStaticFunctionCall` already unwraps TS type assertions (`as`, angle-bracket casts, `!`) for simple callees like `(useFetch as any)()`, and it handles member expressions like `factories.createUseFetch()`. But when both are combined - a parenthesized type assertion wrapping a member expression - the parser bails and returns null.

That means patterns like `(factories.createUseFetch as any)()`, `(factories.createUseFetch!)()`, or `(<any>factories.createUseFetch)()` never get a key injected by the compiler, which can lead to state collisions or hydration mismatches at runtime.

The fix unwraps one layer of TS assertion inside the parenthesized expression before checking for a member expression, same approach already used for the simple callee branch. Resolves the TODO on the same line.