### PR TITLE
fix(nitro): resolve h3 export path in nitro vfs

### DIFF
--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -105,14 +105,17 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
   }
 
   if (nuxt.options.experimental.componentIslands) {
-    // sync conditions with /packages/nuxt/src/core/templates.ts#L539
-    nuxt.options.nitro.virtual ||= {}
+    const islandHandlerPath = JSON.stringify(resolve(distDir, 'runtime/handlers/island'))
+    const h3Path = JSON.stringify(resolve(distDir, 'runtime/h3-compat'))
     const ISLAND_RENDERER_KEY = '#internal/nuxt/island-renderer.mjs'
+
+    nuxt.options.nitro.virtual ||= {}
     nuxt.options.nitro.virtual[ISLAND_RENDERER_KEY] = () => {
+      // sync conditions with /packages/nuxt/src/core/templates.ts#L539
       if (nuxt.options.dev || nuxt.options.experimental.componentIslands !== 'auto' || nuxt.apps.default?.pages?.some(p => p.mode === 'server') || nuxt.apps.default?.components?.some(c => c.mode === 'server' && !nuxt.apps.default?.components.some(other => other.pascalName === c.pascalName && other.mode === 'client'))) {
-        return `export { default } from '${resolve(distDir, 'runtime/handlers/island')}'`
+        return `export { default } from ${islandHandlerPath}`
       }
-      return `import { defineEventHandler } from 'nitro/h3'; export default defineEventHandler(() => {});`
+      return `import { defineEventHandler } from ${h3Path}; export default defineEventHandler(() => {});`
     }
     nuxt.options.nitro.handlers ||= []
     nuxt.options.nitro.handlers.push({


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

nitro was not able to resolve `nitro/h3` as nitro wasn't a direct dependency.