### PR TITLE
fix(nuxt): use factory resolved options everywhere in `useFetch`

### DIFF
--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -151,14 +151,6 @@ export const createUseFetch = defineKeyedFunctionFactory({
     ) {
       const [opts = {}, autoKey] = typeof arg1 === 'string' ? [{}, arg1] : [arg1, arg2]
 
-      const _request = computed(() => toValue(request))
-
-      const key = computed(() => toValue(opts.key) || ('$f' + hash([autoKey, typeof _request.value === 'string' ? _request.value : '', ...generateOptionSegments(opts)])))
-
-      if (!opts.baseURL && typeof _request.value === 'string' && (_request.value[0] === '/' && _request.value[1] === '/')) {
-        throw new Error('[nuxt] [useFetch] the request URL must not start with "//".')
-      }
-
       const factoryOptions = (typeof options === 'function' ? options(opts as any) : options) as typeof opts
 
       // Merge factory options with user options:
@@ -181,6 +173,14 @@ export const createUseFetch = defineKeyedFunctionFactory({
         ...(typeof options === 'function' ? {} : factoryOptions),
         ...opts,
         ...(typeof options === 'function' ? factoryOptions : {}),
+      }
+
+      const _request = computed(() => toValue(request))
+
+      const key = computed(() => toValue(fetchOptions.key) || ('$f' + hash([autoKey, typeof _request.value === 'string' ? _request.value : '', ...generateOptionSegments(fetchOptions)])))
+
+      if (!fetchOptions.baseURL && typeof _request.value === 'string' && (_request.value[0] === '/' && _request.value[1] === '/')) {
+        throw new Error('[nuxt] [useFetch] the request URL must not start with "//".')
       }
 
       const _fetchOptions = reactive<typeof fetchOptions>({
@@ -218,7 +218,7 @@ export const createUseFetch = defineKeyedFunctionFactory({
       }
 
       const asyncData = useAsyncData<_ResT, ErrorT, DataT, PickKeys, DefaultT>(watchSources === false ? key.value : key, (_, { signal }) => {
-        const _$fetch: $Fetch<unknown, NitroFetchRequest> = opts.$fetch || $fetch
+        const _$fetch: $Fetch<unknown, NitroFetchRequest> = fetchOptions.$fetch || $fetch
 
         return _$fetch(_request.value, { signal, ..._fetchOptions } as any) as Promise<_ResT>
       }, _asyncDataOptions)

--- a/test/nuxt/use-fetch.test.ts
+++ b/test/nuxt/use-fetch.test.ts
@@ -1,6 +1,6 @@
 /// <reference path="../fixtures/basic/.nuxt/nuxt.d.ts" />
 
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineEventHandler } from 'h3'
 
 import { registerEndpoint } from '@nuxt/test-utils/runtime'
@@ -8,7 +8,10 @@ import { registerEndpoint } from '@nuxt/test-utils/runtime'
 import { withQuery } from 'ufo'
 import { flushPromises } from '@vue/test-utils'
 
-import { useFetch, useLazyFetch } from '#app/composables/fetch'
+import { createUseFetch as _createUseFetch, useFetch, useLazyFetch } from '#app/composables/fetch'
+import type { EffectScope } from 'vue'
+
+const createUseFetch = (_createUseFetch as unknown as { __nuxt_factory: typeof _createUseFetch }).__nuxt_factory
 
 interface TestData {
   method: string
@@ -281,5 +284,70 @@ describe('useFetch', () => {
     expect(aborted).toBe(false)
     clear()
     expect(aborted).toBe(true)
+  })
+})
+
+describe('createUseFetch', () => {
+  let scope: EffectScope
+  beforeEach(() => {
+    scope = effectScope()
+  })
+  afterEach(() => {
+    scope.stop()
+  })
+
+  it('should use custom $fetch from factory (defaults mode)', async () => {
+    const customFetch = vi.fn().mockResolvedValue({ variant: 'factory' })
+
+    const { data } = await scope.run(() => {
+      const useCustomFetch = createUseFetch({ $fetch: customFetch as unknown as typeof $fetch })
+      return useCustomFetch('/api/test')
+    })!
+
+    expect(customFetch).toHaveBeenCalledOnce()
+    expect(data.value).toEqual({ variant: 'factory' })
+  })
+
+  it('should allow per-call $fetch to override factory $fetch', async () => {
+    const factoryFetch = vi.fn().mockResolvedValue({ variant: 'factory' })
+    const callFetch = vi.fn().mockResolvedValue({ variant: 'call' })
+
+    const { data } = await scope.run(() => {
+      const useCustomFetch = createUseFetch({ $fetch: factoryFetch as unknown as typeof $fetch })
+      return useCustomFetch('/api/test', { $fetch: callFetch as unknown as typeof $fetch })
+    })!
+
+    expect(factoryFetch).not.toHaveBeenCalled()
+    expect(callFetch).toHaveBeenCalledOnce()
+    expect(data.value).toEqual({ variant: 'call' })
+  })
+
+  it('should use baseURL from factory for URL validation', async () => {
+    const customFetch = vi.fn().mockResolvedValue({ ok: true })
+
+    await scope.run(async () => {
+      const useCustomFetch = createUseFetch({ baseURL: 'https://example.com', $fetch: customFetch as unknown as typeof $fetch })
+      // should not throw because factory provides baseURL
+      await useCustomFetch('//api/test')
+    })
+
+    expect(customFetch).toHaveBeenCalledOnce()
+  })
+
+  it('should include factory options in cache key', async () => {
+    const nuxtApp = useNuxtApp()
+    const originalKeys = Object.keys(nuxtApp.payload.data)
+
+    await scope.run(async () => {
+      const customFetch = vi.fn().mockResolvedValue({ foo: 'bar' })
+      const useCustomFetch = createUseFetch({ baseURL: 'https://example.com', $fetch: customFetch as unknown as typeof $fetch })
+      // @ts-expect-error Overriding auto-key
+      await useFetch('/api/test', {}, '')
+      // @ts-expect-error Overriding auto-key
+      await useCustomFetch('/api/test', {}, '')
+    })
+
+    const keysAfter = Object.keys(nuxtApp.payload.data)
+    expect(keysAfter.length - originalKeys.length).toEqual(2)
   })
 })


### PR DESCRIPTION
### 📚 Description
This fixes an issue in `useFetch` where we didn't consider the factory options in certain cases.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
