### PR TITLE
fix(nitro,schema)!: remove `experimental.externalVue`

### DIFF
--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -367,7 +367,7 @@ By always mocking these compiler dependencies, the default server bundle size is
 
 #### Migration Steps
 
-If you previously set `experimental.externalVue: false` to reduce your server bundle size, you can remove it — this is now the default behavior:
+If you previously set `experimental.externalVue` explicitly, you should now remove it.
 
 ```diff
   export default defineNuxtConfig({
@@ -376,8 +376,6 @@ If you previously set `experimental.externalVue: false` to reduce your server bu
     },
   })
 ```
-
-If you had `experimental.externalVue: true` (or relied on the default), no action is needed — the compiler mocking is now applied automatically.
 
 ::note
 If you use `vue.runtimeCompiler: true`, the real compiler packages are still included as before.

--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -349,6 +349,40 @@ If you define redirect route rules, the property name has changed:
 - **Runtime hooks**: `nitroApp.hooks.hook('beforeResponse', ...)` and `nitroApp.hooks.hook('afterResponse', ...)` have been replaced by `nitroApp.hooks.hook('response', ...)`.
 - **`getRouteRules()` from `nitro/app`**: On the server, the Nitro helper changed from `getRouteRules(event)` to `getRouteRules(method, pathname)`, which returns `{ routeRules }`.
 
+### Removal of `experimental.externalVue`
+
+🚦 **Impact Level**: Minimal
+
+#### What Changed
+
+The `experimental.externalVue` option has been removed. Vue compiler dependencies (`@babel/parser`, `@vue/compiler-core`, `@vue/compiler-dom`, `@vue/compiler-ssr`, `estree-walker`) are now always replaced with mock proxies in the server bundle when `vue.runtimeCompiler` is not enabled.
+
+#### Reasons for Change
+
+With the migration to Nitro v3, all dependencies are bundled into the server output by default (unlike Nitro v2, which externalized `node_modules`). The `externalVue` option was originally designed to keep Vue as an external dependency, which was needed to avoid multiple copies of Vue from being bundled, but since Nitro v3 bundles everything regardless, the option became a no-op.
+
+Vue's server builds include the full compiler toolchain, pulling `@babel/parser` (465KB) and other compiler packages into the server bundle unnecessarily. These compiler packages are only needed when `vue.runtimeCompiler` is enabled for runtime template compilation.
+
+By always mocking these compiler dependencies, the default server bundle size is reduced by approximately 860KB (~59%).
+
+#### Migration Steps
+
+If you previously set `experimental.externalVue: false` to reduce your server bundle size, you can remove it — this is now the default behavior:
+
+```diff
+  export default defineNuxtConfig({
+    experimental: {
+-     externalVue: false,
+    },
+  })
+```
+
+If you had `experimental.externalVue: true` (or relied on the default), no action is needed — the compiler mocking is now applied automatically.
+
+::note
+If you use `vue.runtimeCompiler: true`, the real compiler packages are still included as before.
+::
+
 ### Removal of Legacy `_renderResponse` Support
 
 🚦 **Impact Level**: Minimal

--- a/docs/3.guide/6.going-further/1.experimental-features.md
+++ b/docs/3.guide/6.going-further/1.experimental-features.md
@@ -69,24 +69,6 @@ export default defineNuxtConfig({
 })
 ```
 
-## externalVue
-
-Externalizes `vue`, `@vue/*` and `vue-router` when building.
-
-This flag is enabled by default, but you can disable this feature:
-
-```ts twoslash [nuxt.config.ts]
-export default defineNuxtConfig({
-  experimental: {
-    externalVue: false,
-  },
-})
-```
-
-::warning
-This feature will likely be removed in a near future.
-::
-
 ## extractAsyncDataHandlers
 
 Extracts handler functions from `useAsyncData` and `useLazyAsyncData` calls into separate chunks for improved code splitting and caching efficiency.

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -277,7 +277,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
     sourcemap: !!nuxt.options.sourcemap.server,
     traceDeps: [
       // force include files used in generated code from the runtime-compiler
-      ...(nuxt.options.vue.runtimeCompiler && !nuxt.options.experimental.externalVue)
+      ...(nuxt.options.vue.runtimeCompiler)
         ? [
             ...nuxt.options.modulesDir.reduce<string[]>((targets, path) => {
               const serverRendererPath = resolve(path, 'vue/server-renderer/index.js')
@@ -291,7 +291,6 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
       ...(nuxt.options.dev
         ? []
         : [
-            ...nuxt.options.experimental.externalVue ? [] : ['vue', '@vue/'],
             '@nuxt/',
             nuxt.options.buildDir,
           ]),
@@ -306,7 +305,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
     ],
     alias: {
       // Vue 3 mocks
-      ...nuxt.options.vue.runtimeCompiler || nuxt.options.experimental.externalVue
+      ...nuxt.options.vue.runtimeCompiler
         ? {}
         : {
             'estree-walker': mockProxy,

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -67,9 +67,6 @@ export default defineResolvers({
       $resolve: val => typeof val === 'boolean' ? val : false,
     },
 
-    // TODO: Remove when nitro has support for mocking traced dependencies
-    // https://github.com/nitrojs/nitro/issues/1118
-    externalVue: true,
     serverAppConfig: true,
     emitRouteChunkError: {
       $resolve: (val) => {

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1071,14 +1071,6 @@ export interface ConfigSchema {
     asyncEntry: boolean
 
     /**
-     * Externalize `vue`, `@vue/*` and `vue-router` when building.
-     *
-     * @default true
-     * @see [Nuxt Issue #13632](https://github.com/nuxt/nuxt/issues/13632)
-     */
-    externalVue: boolean
-
-    /**
      * Enable accessing `appConfig` from server routes.
      *
      * @default true

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -15,22 +15,17 @@ describe.skipIf(isStubbed || process.env.SKIP_BUNDLE_SIZE === 'true' || process.
 
   beforeAll(async () => {
     await Promise.all([
-      exec('pnpm', ['nuxt', 'build', rootDir], { nodeOptions: { env: { EXTERNAL_VUE: 'false' } } }),
-      exec('pnpm', ['nuxt', 'build', rootDir], { nodeOptions: { env: { EXTERNAL_VUE: 'true' } } }),
+      exec('pnpm', ['nuxt', 'build', rootDir]),
       exec('pnpm', ['nuxt', 'build', pagesRootDir]),
     ])
   }, 120 * 1000)
 
-  // Identical behaviour between inline/external vue options as this should only affect the server build
-
   it('default client bundle size', async () => {
-    const [clientStats, clientStatsInlined] = await Promise.all((['.output', '.output-inline'])
-      .map(outputDir => analyzeSizes(['**/*.js'], join(rootDir, outputDir, 'public'))))
+    const clientStats = await analyzeSizes(['**/*.js'], join(rootDir, '.output/public'))
 
     expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"113k"`)
-    expect.soft(roundToKilobytes(clientStatsInlined!.totalBytes)).toMatchInlineSnapshot(`"113k"`)
 
-    const files = new Set([...clientStats!.files, ...clientStatsInlined!.files].map(f => f.replace(/\..*\.js/, '.js')))
+    const files = clientStats!.files.map(f => f.replace(/\..*\.js/, '.js'))
 
     expect([...files]).toMatchInlineSnapshot(`
       [
@@ -62,41 +57,6 @@ describe.skipIf(isStubbed || process.env.SKIP_BUNDLE_SIZE === 'true' || process.
 
   it('default server bundle size', async () => {
     const serverDir = join(rootDir, '.output/server')
-
-    const serverStats = await analyzeSizes(['**/*.mjs', '!_libs'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"66.3k"`)
-
-    const modules = await analyzeSizes(['_libs/**/*'], serverDir)
-    expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"1281k"`)
-
-    const packages = modules.files
-      .map(m => m.replace('_libs/', '').replace(/\.mjs$/, ''))
-      .sort()
-    expect(packages).toMatchInlineSnapshot(`
-      [
-        "@unhead/vue+[...]",
-        "babel__parser",
-        "defu",
-        "destr",
-        "devalue",
-        "h3+rou3+srvx",
-        "ocache+ohash",
-        "ofetch",
-        "pathe",
-        "scule",
-        "ufo",
-        "unctx",
-        "unstorage",
-        "vue",
-        "vue-bundle-renderer",
-        "vue__compiler-ssr",
-        "vue__server-renderer",
-      ]
-    `)
-  })
-
-  it('default server bundle size (inlined vue modules)', async () => {
-    const serverDir = join(rootDir, '.output-inline/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!_libs'], serverDir)
     expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"66.6k"`)
@@ -135,7 +95,7 @@ describe.skipIf(isStubbed || process.env.SKIP_BUNDLE_SIZE === 'true' || process.
     expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"274k"`)
 
     const modules = await analyzeSizes(['_libs/**/*'], serverDir)
-    expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"1290k"`)
+    expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"470k"`)
 
     const packages = modules.files
       .map(m => m.replace('_libs/', '').replace(/\.mjs$/, ''))
@@ -143,7 +103,6 @@ describe.skipIf(isStubbed || process.env.SKIP_BUNDLE_SIZE === 'true' || process.
     expect(packages).toMatchInlineSnapshot(`
       [
         "@unhead/vue+[...]",
-        "babel__parser",
         "defu",
         "destr",
         "devalue",
@@ -160,7 +119,6 @@ describe.skipIf(isStubbed || process.env.SKIP_BUNDLE_SIZE === 'true' || process.
         "unstorage",
         "vue",
         "vue-bundle-renderer",
-        "vue__compiler-ssr",
         "vue__server-renderer",
       ]
     `)

--- a/test/fixtures/minimal/nuxt.config.ts
+++ b/test/fixtures/minimal/nuxt.config.ts
@@ -1,8 +1,6 @@
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 
-const testWithInlineVue = process.env.EXTERNAL_VUE === 'false'
-
 const nuxtEntry = fileURLToPath(new URL('../../../packages/nuxt/dist/index.mjs', import.meta.url))
 const isStubbed = readFileSync(nuxtEntry, 'utf-8').includes('const _module = await jiti')
 
@@ -23,15 +21,8 @@ export default defineNuxtConfig({
   },
   pages: false,
   devtools: { enabled: false },
-  buildDir: testWithInlineVue ? '.nuxt-inline' : '.nuxt',
   sourcemap: false,
-  experimental: {
-    externalVue: !testWithInlineVue,
-  },
   compatibilityDate: 'latest',
-  nitro: {
-    output: { dir: fileURLToPath(new URL(testWithInlineVue ? './.output-inline' : './.output', import.meta.url)) },
-  },
   typescript: {
     typeCheck: isStubbed ? false : 'build',
   },

--- a/test/fixtures/runtime-compiler/nuxt.config.ts
+++ b/test/fixtures/runtime-compiler/nuxt.config.ts
@@ -7,6 +7,5 @@ export default withMatrix({
   },
   experimental: {
     nitroAutoImports: true,
-    externalVue: false,
   },
 })


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this addresses a TODO from previously - I think we can now remove given nitro updates/improvements

cc: @pi0 

here's the corresponding section from the upgrade guide:

#### What Changed

The `experimental.externalVue` option has been removed. Vue compiler dependencies (`@babel/parser`, `@vue/compiler-core`, `@vue/compiler-dom`, `@vue/compiler-ssr`, `estree-walker`) are now always replaced with mock proxies in the server bundle when `vue.runtimeCompiler` is not enabled.

#### Reasons for Change

With the migration to Nitro v3, all dependencies are bundled into the server output by default (unlike Nitro v2, which externalized `node_modules`). The `externalVue` option was originally designed to keep Vue as an external dependency, which was needed to avoid multiple copies of Vue from being bundled, but since Nitro v3 bundles everything regardless, the option became a no-op.

Vue's server builds include the full compiler toolchain, pulling `@babel/parser` (465KB) and other compiler packages into the server bundle unnecessarily. These compiler packages are only needed when `vue.runtimeCompiler` is enabled for runtime template compilation.

By always mocking these compiler dependencies, the default server bundle size is reduced by approximately 860KB (~59%).

#### Migration Steps

If you previously set `experimental.externalVue: false` to reduce your server bundle size, you can remove it — this is now the default behavior:

```diff
  export default defineNuxtConfig({
    experimental: {
-     externalVue: false,
    },
  })
```

If you had `experimental.externalVue: true` (or relied on the default), no action is needed — the compiler mocking is now applied automatically.

> [!NOTE]
> If you use `vue.runtimeCompiler: true`, the real compiler packages are still included as before.
