### PR TITLE
fix(nuxt): self-remove hydration error guards after first navigation

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-layout.ts
+++ b/packages/nuxt/src/app/components/nuxt-layout.ts
@@ -79,7 +79,10 @@ export default defineComponent({
     const done = nuxtApp.deferHydration()
     if (import.meta.client && nuxtApp.isHydrating) {
       const removeErrorHook = nuxtApp.hooks.hookOnce('app:error', done)
-      useRouter().beforeEach(removeErrorHook)
+      const removeGuard = useRouter().beforeEach(() => {
+        removeErrorHook()
+        removeGuard()
+      })
     }
 
     if (import.meta.dev) {

--- a/packages/nuxt/src/app/components/nuxt-root.vue
+++ b/packages/nuxt/src/app/components/nuxt-root.vue
@@ -36,7 +36,10 @@ const nuxtApp = useNuxtApp()
 const onResolve = nuxtApp.deferHydration()
 if (import.meta.client && nuxtApp.isHydrating) {
   const removeErrorHook = nuxtApp.hooks.hookOnce('app:error', onResolve)
-  useRouter().beforeEach(removeErrorHook)
+  const removeGuard = useRouter().beforeEach(() => {
+    removeErrorHook()
+    removeGuard()
+  })
 }
 
 const url = import.meta.server ? nuxtApp.ssrContext.url : window.location.pathname

--- a/packages/nuxt/src/pages/runtime/page.ts
+++ b/packages/nuxt/src/pages/runtime/page.ts
@@ -71,7 +71,10 @@ export default defineComponent({
     let suspenseKey = 0
     if (import.meta.client && nuxtApp.isHydrating) {
       const removeErrorHook = nuxtApp.hooks.hookOnce('app:error', done)
-      useRouter().beforeEach(removeErrorHook)
+      const removeGuard = useRouter().beforeEach(() => {
+        removeErrorHook()
+        removeGuard()
+      })
     }
     if (import.meta.client && props.pageKey) {
       watch(() => props.pageKey, (next, prev) => {


### PR DESCRIPTION
### 🔗 Linked issue

N/A - found by code audit

### 📚 Description

`NuxtPage`, `NuxtLayout` and `nuxt-root` each register a `beforeEach` guard during hydration to proactively clean up an `app:error` hook. The guard does its job on the first navigation, but the return value from `beforeEach()` (the unsubscribe function) is never called, so the guard stays registered for the entire app lifetime running as a no-op on every navigation.

Each guard now removes itself after firing once. Matches the cleanup pattern already used a few lines below in `page.ts` where `beforeResolve` is properly unsubscribed via `onBeforeUnmount`.