### PR TITLE
fix(nuxt): await parcel watcher subscription before registering close hook

### DIFF
--- a/packages/nuxt/src/core/builder.ts
+++ b/packages/nuxt/src/core/builder.ts
@@ -207,7 +207,7 @@ async function createParcelWatcher () {
     const pathsToWatch = resolvePathsToWatch(nuxt, { parentDirectories: true })
     for (const dir of pathsToWatch) {
       if (!await isDirectory(dir)) { continue }
-      const watcher = subscribe(dir, (err, events) => {
+      const subscription = await subscribe(dir, (err, events) => {
         if (err) { return }
         for (const event of events) {
           if (isIgnored(event.path)) { continue }
@@ -219,13 +219,11 @@ async function createParcelWatcher () {
           'node_modules',
         ],
       })
-      watcher.then((subscription) => {
-        if (nuxt.options.debug && nuxt.options.debug.watchers) {
+      if (nuxt.options.debug && nuxt.options.debug.watchers) {
         // eslint-disable-next-line no-console
-          console.timeEnd('[nuxt] builder:parcel:watch')
-        }
-        nuxt.hook('close', () => subscription.unsubscribe())
-      })
+        console.timeEnd('[nuxt] builder:parcel:watch')
+      }
+      nuxt.hook('close', () => subscription.unsubscribe())
     }
     return true
   } catch {


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 📚 Description

`subscribe()` returns a promise, but it was chained with `.then()` and never awaited. The close hook that calls `subscription.unsubscribe()` only gets registered inside that `.then()` callback, so if Nuxt shuts down before the promise resolves, the watcher subscription leaks. Errors from `subscribe()` also silently became unhandled rejections instead of hitting the try/catch that falls back to chokidar.

Awaiting the subscription directly fixes both: close hooks are registered synchronously after each subscription resolves, and failures propagate to the fallback path.