### PR TITLE
fix(nuxt): mark portal properties as configurable

### DIFF
--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -895,7 +895,7 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
   // prevent replacement of options.nitro
   Object.defineProperties(options, {
     nitro: {
-      configurable: false,
+      configurable: true,
       enumerable: true,
       get: () => nitroOptions,
       set (value) {
@@ -989,7 +989,7 @@ function createPortalProperties (sourceValue: any, options: NuxtOptions, paths: 
 
     Object.defineProperties(parent, {
       [key]: {
-        configurable: false,
+        configurable: true,
         enumerable: true,
         get: () => sharedValue,
         set (value) {


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/33436
resolves https://github.com/nuxt/nuxt/issues/34540

### 📚 Description

this hotfixes a set of issues in nuxt caused by https://github.com/nuxt/nuxt/issues/33464.

ultimately we need to resolve in c12 but for now this avoids a hard crash.