### PR TITLE
fix(nuxt,nitro): add `Symbol` serialization for dev server logs

### DIFF
--- a/packages/nitro-server/src/runtime/plugins/dev-server-logs.ts
+++ b/packages/nitro-server/src/runtime/plugins/dev-server-logs.ts
@@ -21,6 +21,7 @@ import { appId } from '#internal/nuxt.config.mjs'
 const devReducers: Record<string, (data: any) => any> = {
   VNode: data => isVNode(data) ? { type: data.type, props: data.props } : undefined,
   URL: data => data instanceof URL ? data.toString() : undefined,
+  Symbol: data => typeof data === 'symbol' ? data.toString() : undefined,
 }
 
 interface NuxtDevAsyncContext {

--- a/packages/nitro-server/src/runtime/plugins/dev-server-logs.ts
+++ b/packages/nitro-server/src/runtime/plugins/dev-server-logs.ts
@@ -21,7 +21,7 @@ import { appId } from '#internal/nuxt.config.mjs'
 const devReducers: Record<string, (data: any) => any> = {
   VNode: data => isVNode(data) ? { type: data.type, props: data.props } : undefined,
   URL: data => data instanceof URL ? data.toString() : undefined,
-  Symbol: data => typeof data === 'symbol' ? data.toString() : undefined,
+  Symbol: data => typeof data === 'symbol' ? data.description ?? '' : undefined,
 }
 
 interface NuxtDevAsyncContext {

--- a/packages/nuxt/src/app/plugins/dev-server-logs.ts
+++ b/packages/nuxt/src/app/plugins/dev-server-logs.ts
@@ -14,6 +14,7 @@ const devRevivers: Record<string, (data: any) => any> = import.meta.server
   : {
       VNode: data => h(data.type, data.props),
       URL: data => new URL(data),
+      Symbol: data => data,
     }
 
 export default defineNuxtPlugin(async (nuxtApp) => {

--- a/packages/nuxt/src/app/plugins/dev-server-logs.ts
+++ b/packages/nuxt/src/app/plugins/dev-server-logs.ts
@@ -14,7 +14,7 @@ const devRevivers: Record<string, (data: any) => any> = import.meta.server
   : {
       VNode: data => h(data.type, data.props),
       URL: data => new URL(data),
-      Symbol: data => data,
+      Symbol: data => Symbol.for(data),
     }
 
 export default defineNuxtPlugin(async (nuxtApp) => {


### PR DESCRIPTION
### 📚 Description

I've encountered an issue where console.logging a symbol in a middleware caused a `500`. I think it's useful to be able to show its stringified value instead of an unhandled error.

I was a little unsure whether to keep it as a string on the client side as well, or to create a new unique instance.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
