### PR TITLE
docs: update experimental typedPages documentation

### DIFF
--- a/docs/3.guide/6.going-further/1.experimental-features.md
+++ b/docs/3.guide/6.going-further/1.experimental-features.md
@@ -366,7 +366,7 @@ export default defineNuxtConfig({
 
 ## typedPages
 
-Enable the new experimental typed router using [`unplugin-vue-router`](https://github.com/posva/unplugin-vue-router).
+Enable the new experimental typed router.
 
 ```ts twoslash [nuxt.config.ts]
 export default defineNuxtConfig({
@@ -379,14 +379,6 @@ export default defineNuxtConfig({
 Out of the box, this will enable typed usage of [`navigateTo`](/docs/4.x/api/utils/navigate-to), [`<NuxtLink>`](/docs/4.x/api/components/nuxt-link), [`router.push()`](/docs/4.x/api/composables/use-router) and more.
 
 You can even get typed params within a page by using `const route = useRoute('route-name')`.
-
-::important
-If you use `pnpm` without `shamefully-hoist=true`, you will need to add `unplugin-vue-router` as a hoist pattern in your `pnpm-workspace.yaml` in order for this feature to work.
-```yaml
-publicHoistPattern:
-  - "unplugin-vue-router"
-```
-::
 
 :video-accordion{title="Watch a video from Daniel Roe explaining type-safe routing in Nuxt" videoId="SXk-L19gTZk"}
 


### PR DESCRIPTION
### 📚 Description

Removed instructions for pnpm hoisting for `unplugin-vue-router`. This is not needed anymore because Nuxt 4.4 uses `vue-router@5` and not `unplugin-vue-router` for typed pages.
