### PR TITLE
perf(vite)!: move `@vitejs/plugin-vue-jsx` to optional peer dep

### DIFF
--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -381,6 +381,48 @@ If you previously set `experimental.externalVue` explicitly, you should now remo
 If you use `vue.runtimeCompiler: true`, the real compiler packages are still included as before.
 ::
 
+### `@vitejs/plugin-vue-jsx` Is Now Optional
+
+🚦 **Impact Level**: Minimal
+
+#### What Changed
+
+`@vitejs/plugin-vue-jsx` is no longer installed by default with `@nuxt/vite-builder`. It is now an optional peer dependency that is loaded on demand only when a `.jsx` or `.tsx` file is encountered during the build.
+
+If your project uses JSX/TSX components, Nuxt will automatically detect this and prompt you to install the package.
+
+#### Reasons for Change
+
+The `@vitejs/plugin-vue-jsx` plugin pulls in a significant dependency tree (Babel, `@vue/babel-plugin-jsx`, etc.) that is unnecessary for projects that don't use JSX. Making it optional reduces the default install size and speeds up dependency resolution for the majority of Nuxt projects.
+
+#### Migration Steps
+
+If your project uses `.jsx` or `.tsx` files, add `@vitejs/plugin-vue-jsx` as a dev dependency:
+
+::code-group{sync="pm"}
+
+```bash [npm]
+npm install -D @vitejs/plugin-vue-jsx
+```
+
+```bash [yarn]
+yarn add -D @vitejs/plugin-vue-jsx
+```
+
+```bash [pnpm]
+pnpm add -D @vitejs/plugin-vue-jsx
+```
+
+```bash [bun]
+bun add -D @vitejs/plugin-vue-jsx
+```
+
+::
+
+Alternatively, Nuxt will prompt you to install it automatically the first time a JSX/TSX file is processed during development.
+
+If your project does not use JSX, no changes are needed.
+
 ### Removal of Legacy `_renderResponse` Support
 
 🚦 **Impact Level**: Minimal

--- a/packages/nitro-server/package.json
+++ b/packages/nitro-server/package.json
@@ -45,6 +45,7 @@
     "impound": "^1.1.5",
     "klona": "^2.0.6",
     "knitwork": "^1.3.0",
+    "lru-cache": "^11.2.7",
     "mlly": "^1.8.1",
     "mocked-exports": "^0.1.1",
     "nitro": "^3.0.260311-beta",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -31,7 +31,6 @@
     "@nuxt/kit": "workspace:*",
     "@rollup/plugin-replace": "^6.0.3",
     "@vitejs/plugin-vue": "^6.0.5",
-    "@vitejs/plugin-vue-jsx": "^5.1.5",
     "consola": "^3.4.2",
     "defu": "^6.1.4",
     "escape-string-regexp": "^5.0.0",
@@ -57,6 +56,7 @@
     "@babel/plugin-proposal-decorators": "7.29.0",
     "@babel/plugin-syntax-jsx": "7.28.6",
     "@nuxt/schema": "workspace:*",
+    "@vitejs/plugin-vue-jsx": "5.1.5",
     "autoprefixer": "^10.4.27",
     "cssnano": "7.1.3",
     "h3": "1.15.6",
@@ -72,6 +72,7 @@
   "peerDependencies": {
     "@babel/plugin-proposal-decorators": "^7.25.0",
     "@babel/plugin-syntax-jsx": "^7.25.0",
+    "@vitejs/plugin-vue-jsx": "^5.1.5",
     "autoprefixer": "^10.4.27",
     "cssnano": "^7.1.3",
     "nuxt": "workspace:*",
@@ -84,6 +85,9 @@
       "optional": true
     },
     "@babel/plugin-syntax-jsx": {
+      "optional": true
+    },
+    "@vitejs/plugin-vue-jsx": {
       "optional": true
     },
     "autoprefixer": {

--- a/packages/vite/src/plugins/vue-jsx.ts
+++ b/packages/vite/src/plugins/vue-jsx.ts
@@ -1,0 +1,129 @@
+import type { Plugin, ResolvedConfig } from 'vite'
+import { ensureDependencyInstalled, logger } from '@nuxt/kit'
+import type { Nuxt } from '@nuxt/schema'
+import type { Options } from '@vitejs/plugin-vue-jsx'
+
+const JSX_RE = /\.[jt]sx$/
+const VUE_JSX_VIRTUAL_RE = /^\/__vue-jsx/
+
+/**
+ * A lazy wrapper around `@vitejs/plugin-vue-jsx` that defers installation
+ * and loading of the real plugin until a JSX/TSX file is actually encountered.
+ *
+ * This avoids pulling in the plugin's heavy dependency tree (Babel, etc.) for
+ * projects that don't use JSX.
+ */
+export function VueJsxPlugin (nuxt: Nuxt, options?: Options): Plugin[] {
+  let resolvedPlugin: Plugin | undefined
+  let installPromise: Promise<Plugin | undefined> | undefined
+  let installFailed = false
+  let resolvedConfig: ResolvedConfig
+
+  function loadPlugin (): Promise<Plugin | undefined> {
+    if (resolvedPlugin) {
+      return Promise.resolve(resolvedPlugin)
+    }
+    if (installFailed) {
+      return Promise.resolve(undefined)
+    }
+
+    // Deduplicate concurrent calls while install is in progress
+    installPromise ||= _loadPlugin()
+    return installPromise
+  }
+
+  async function _loadPlugin (): Promise<Plugin | undefined> {
+    const result = await ensureDependencyInstalled('@vitejs/plugin-vue-jsx', {
+      rootDir: nuxt.options.rootDir,
+      searchPaths: nuxt.options.modulesDir,
+      from: import.meta.url,
+    })
+
+    if (!result) {
+      installFailed = true
+      logger.warn('Install `@vitejs/plugin-vue-jsx` to enable JSX support.')
+      return undefined
+    }
+
+    const { default: viteJsxPlugin } = await import('@vitejs/plugin-vue-jsx')
+    resolvedPlugin = viteJsxPlugin(options)
+
+    // Replay configResolved so the real plugin captures HMR/sourcemap state
+    if (resolvedConfig && typeof resolvedPlugin.configResolved === 'function') {
+      resolvedPlugin.configResolved.call({} as any, resolvedConfig)
+    }
+
+    return resolvedPlugin
+  }
+
+  const transformPlugin: Plugin = {
+    name: 'nuxt:vue-jsx',
+    configResolved (config) {
+      resolvedConfig = config
+    },
+    transform: {
+      filter: {
+        id: {
+          include: [JSX_RE],
+        },
+      },
+      async handler (code, id, transformOptions) {
+        const plugin = await loadPlugin()
+        if (!plugin) {
+          return
+        }
+
+        const transform = typeof plugin.transform === 'function'
+          ? plugin.transform
+          : plugin.transform?.handler
+        if (transform) {
+          return transform.call(this, code, id, transformOptions)
+        }
+      },
+    },
+  }
+
+  const virtualPlugin: Plugin = {
+    name: 'nuxt:vue-jsx-virtual',
+    resolveId: {
+      filter: {
+        id: {
+          include: [VUE_JSX_VIRTUAL_RE],
+        },
+      },
+      async handler (id, importer, options) {
+        const plugin = await loadPlugin()
+        if (!plugin) {
+          return
+        }
+        const resolveId = typeof plugin.resolveId === 'function'
+          ? plugin.resolveId
+          : plugin.resolveId?.handler
+        if (resolveId) {
+          return resolveId.call(this, id, importer, options)
+        }
+      },
+    },
+    load: {
+      filter: {
+        id: {
+          include: [VUE_JSX_VIRTUAL_RE],
+        },
+      },
+      async handler (id) {
+        const plugin = await loadPlugin()
+        if (!plugin) {
+          return
+        }
+        const load = typeof plugin.load === 'function'
+          ? plugin.load
+          : plugin.load?.handler
+        if (load) {
+          return load.call(this, id)
+        }
+      },
+    },
+  }
+
+  return [transformPlugin, virtualPlugin]
+}

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -6,7 +6,6 @@ import { basename, dirname, join, resolve } from 'pathe'
 import type { NuxtBuilder, ViteConfig } from '@nuxt/schema'
 import { createIsIgnored, getLayerDirectories, logger, resolvePath, useNitro } from '@nuxt/kit'
 import { sanitizeFilePath } from 'mlly'
-import viteJsxPlugin from '@vitejs/plugin-vue-jsx'
 import vuePlugin from '@vitejs/plugin-vue'
 import { joinURL, withTrailingSlash, withoutLeadingSlash } from 'ufo'
 import { filename } from 'pathe/utils'
@@ -18,6 +17,7 @@ import { resolveCSSOptions } from './css.ts'
 import { createViteLogger, logLevelMap } from './utils/logger.ts'
 import { OptimizeDepsHintPlugin, optimizerCallbacks, userOptimizeDepsInclude } from './plugins/optimize-deps-hint.ts'
 
+import { VueJsxPlugin } from './plugins/vue-jsx.ts'
 import { SSRStylesPlugin } from './plugins/ssr-styles.ts'
 import { PublicDirsPlugin } from './plugins/public-dirs.ts'
 import { ReplacePlugin } from './plugins/replace.ts'
@@ -185,7 +185,7 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
         ResolveDeepImportsPlugin(nuxt),
         ResolveExternalsPlugin(nuxt),
         vuePlugin(viteConfig.vue),
-        viteJsxPlugin(viteConfig.vueJsx),
+        ...VueJsxPlugin(nuxt, viteConfig.vueJsx),
         ViteNodePlugin(nuxt),
         ClientManifestPlugin(nuxt),
         DevServerPlugin(nuxt),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1013,9 +1013,6 @@ importers:
       '@vitejs/plugin-vue':
         specifier: ^6.0.5
         version: 6.0.5(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
-      '@vitejs/plugin-vue-jsx':
-        specifier: ^5.1.5
-        version: 5.1.5(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
       consola:
         specifier: ^3.4.2
         version: 3.4.2
@@ -1089,6 +1086,9 @@ importers:
       '@nuxt/schema':
         specifier: workspace:*
         version: link:../schema
+      '@vitejs/plugin-vue-jsx':
+        specifier: 5.1.5
+        version: 5.1.5(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
       autoprefixer:
         specifier: ^10.4.27
         version: 10.4.27(postcss@8.5.8)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,7 +168,7 @@ importers:
         version: 4.56.11(tslib@2.8.1)
       nitro:
         specifier: 3.0.260311-beta
-        version: 3.0.260311-beta(chokidar@5.0.0)(dotenv@17.3.1)(giget@3.1.2)(ioredis@5.10.0)(jiti@2.6.1)(lru-cache@11.2.6)(rollup@4.59.0)(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.2))
+        version: 3.0.260311-beta(chokidar@5.0.0)(dotenv@17.3.1)(giget@3.1.2)(ioredis@5.10.0)(jiti@2.6.1)(lru-cache@11.2.7)(rollup@4.59.0)(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.2))
       nuxt:
         specifier: workspace:*
         version: link:packages/nuxt
@@ -318,7 +318,7 @@ importers:
         version: 6.0.1
       nitro:
         specifier: 3.0.260311-beta
-        version: 3.0.260311-beta(chokidar@5.0.0)(dotenv@17.3.1)(giget@3.1.2)(ioredis@5.10.0)(jiti@2.6.1)(lru-cache@11.2.6)(rollup@4.59.0)(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.2))
+        version: 3.0.260311-beta(chokidar@5.0.0)(dotenv@17.3.1)(giget@3.1.2)(ioredis@5.10.0)(jiti@2.6.1)(lru-cache@11.2.7)(rollup@4.59.0)(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.2))
       nitropack:
         specifier: 2.13.1
         version: 2.13.1(rolldown@1.0.0-rc.9)
@@ -382,6 +382,9 @@ importers:
       knitwork:
         specifier: ^1.3.0
         version: 1.3.0
+      lru-cache:
+        specifier: ^11.2.7
+        version: 11.2.7
       mlly:
         specifier: ^1.8.1
         version: 1.8.1
@@ -390,7 +393,7 @@ importers:
         version: 0.1.1
       nitro:
         specifier: ^3.0.260311-beta
-        version: 3.0.260311-beta(chokidar@5.0.0)(dotenv@17.3.1)(giget@3.1.2)(ioredis@5.10.0)(jiti@2.6.1)(lru-cache@11.2.6)(rollup@4.59.0)(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.2))
+        version: 3.0.260311-beta(chokidar@5.0.0)(dotenv@17.3.1)(giget@3.1.2)(ioredis@5.10.0)(jiti@2.6.1)(lru-cache@11.2.7)(rollup@4.59.0)(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.2))
       ohash:
         specifier: ^2.0.11
         version: 2.0.11
@@ -414,7 +417,7 @@ importers:
         version: 2.5.0
       unstorage:
         specifier: ^2.0.0-alpha.6
-        version: 2.0.0-alpha.6(chokidar@5.0.0)(db0@0.3.4)(ioredis@5.10.0)(lru-cache@11.2.6)(ofetch@1.5.1)
+        version: 2.0.0-alpha.6(chokidar@5.0.0)(db0@0.3.4)(ioredis@5.10.0)(lru-cache@11.2.7)(ofetch@2.0.0-alpha.3)
       vue:
         specifier: 3.5.30
         version: 3.5.30(typescript@5.9.3)
@@ -901,7 +904,7 @@ importers:
         version: 2.10.1(webpack@5.105.4(esbuild@0.27.4))
       nitro:
         specifier: 3.0.260311-beta
-        version: 3.0.260311-beta(chokidar@5.0.0)(dotenv@17.3.1)(giget@3.1.2)(ioredis@5.10.0)(jiti@2.6.1)(lru-cache@11.2.6)(rollup@4.59.0)(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.2))
+        version: 3.0.260311-beta(chokidar@5.0.0)(dotenv@17.3.1)(giget@3.1.2)(ioredis@5.10.0)(jiti@2.6.1)(lru-cache@11.2.7)(rollup@4.59.0)(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.2))
       obuild:
         specifier: 0.4.32
         version: 0.4.32(chokidar@5.0.0)(dotenv@17.3.1)(giget@3.1.2)(jiti@2.6.1)(magicast@0.5.2)(oxc-resolver@11.19.1)(picomatch@4.0.3)(rollup@4.59.0)(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))
@@ -6680,6 +6683,10 @@ packages:
 
   lru-cache@11.2.6:
     resolution: {integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==}
+    engines: {node: 20 || >=22}
+
+  lru-cache@11.2.7:
+    resolution: {integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==}
     engines: {node: 20 || >=22}
 
   lru-cache@5.1.1:
@@ -14718,6 +14725,8 @@ snapshots:
 
   lru-cache@11.2.6: {}
 
+  lru-cache@11.2.7: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -15316,7 +15325,7 @@ snapshots:
 
   nf3@0.3.11: {}
 
-  nitro@3.0.260311-beta(chokidar@5.0.0)(dotenv@17.3.1)(giget@3.1.2)(ioredis@5.10.0)(jiti@2.6.1)(lru-cache@11.2.6)(rollup@4.59.0)(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.2)):
+  nitro@3.0.260311-beta(chokidar@5.0.0)(dotenv@17.3.1)(giget@3.1.2)(ioredis@5.10.0)(jiti@2.6.1)(lru-cache@11.2.7)(rollup@4.59.0)(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.2)):
     dependencies:
       consola: 3.4.2
       crossws: 0.4.4(srvx@0.11.9)
@@ -15331,7 +15340,7 @@ snapshots:
       rolldown: 1.0.0-rc.9
       srvx: 0.11.9
       unenv: 2.0.0-rc.24
-      unstorage: 2.0.0-alpha.6(chokidar@5.0.0)(db0@0.3.4)(ioredis@5.10.0)(lru-cache@11.2.6)(ofetch@2.0.0-alpha.3)
+      unstorage: 2.0.0-alpha.6(chokidar@5.0.0)(db0@0.3.4)(ioredis@5.10.0)(lru-cache@11.2.7)(ofetch@2.0.0-alpha.3)
     optionalDependencies:
       dotenv: 17.3.1
       giget: 3.1.2
@@ -17539,20 +17548,12 @@ snapshots:
       db0: 0.3.4
       ioredis: 5.10.0
 
-  unstorage@2.0.0-alpha.6(chokidar@5.0.0)(db0@0.3.4)(ioredis@5.10.0)(lru-cache@11.2.6)(ofetch@1.5.1):
+  unstorage@2.0.0-alpha.6(chokidar@5.0.0)(db0@0.3.4)(ioredis@5.10.0)(lru-cache@11.2.7)(ofetch@2.0.0-alpha.3):
     optionalDependencies:
       chokidar: 5.0.0
       db0: 0.3.4
       ioredis: 5.10.0
-      lru-cache: 11.2.6
-      ofetch: 1.5.1
-
-  unstorage@2.0.0-alpha.6(chokidar@5.0.0)(db0@0.3.4)(ioredis@5.10.0)(lru-cache@11.2.6)(ofetch@2.0.0-alpha.3):
-    optionalDependencies:
-      chokidar: 5.0.0
-      db0: 0.3.4
-      ioredis: 5.10.0
-      lru-cache: 11.2.6
+      lru-cache: 11.2.7
       ofetch: 2.0.0-alpha.3
 
   untun@0.1.3:


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

`@vitejs/plugin-vue-jsx` pulls in [a lot of dependencies](https://npmx.dev/package/@vitejs/plugin-vue-jsx) (18 Mb, including the whole babel subtree).

for most nuxt projects this isn't needed, so instead we can prompt user to install when they first use JSX...
