### PR TITLE
fix(nuxt): avoid any return type from `callHookWith` in `vue:setup`

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-root.vue
+++ b/packages/nuxt/src/app/components/nuxt-root.vue
@@ -50,7 +50,7 @@ const SingleRenderer = import.meta.test && import.meta.dev && import.meta.server
 provide(PageRouteSymbol, useRoute())
 
 // vue:setup hook
-const results = nuxtApp.hooks.callHookWith(hooks => hooks.map(hook => hook()), 'vue:setup')
+const results = nuxtApp.hooks.callHookWith(hooks => hooks.map(hook => hook()), 'vue:setup', [])
 if (import.meta.dev && results && results.some(i => i && 'then' in i)) {
   console.error('[nuxt] Error in `vue:setup`. Callbacks must be synchronous.')
 }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

the same logic caused a type error in the nuxt upgrade PR in test-utils
> error TS2554: Expected 3 arguments, but got 2.

https://github.com/nuxt/test-utils/pull/1616

before:
<img width="615" height="99" alt="image" src="https://github.com/user-attachments/assets/717b048a-c11f-46f5-87ca-34e39b3ba6d5" />

after:
<img width="609" height="123" alt="image" src="https://github.com/user-attachments/assets/1ae7c50c-b84a-43f6-baa0-a725615ba98a" />

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
