### PR TITLE
fix(nuxt): strip DevOnly components with attributes in production builds

### DIFF
--- a/packages/nuxt/src/core/plugins/dev-only.ts
+++ b/packages/nuxt/src/core/plugins/dev-only.ts
@@ -8,8 +8,8 @@ interface DevOnlyPluginOptions {
   sourcemap?: boolean
 }
 
-const DEVONLY_COMP_SINGLE_RE = /<(?:dev-only|DevOnly|lazy-dev-only|LazyDevOnly)>[\s\S]*?<\/(?:dev-only|DevOnly|lazy-dev-only|LazyDevOnly)>/
-const DEVONLY_COMP_RE = /<(?:dev-only|DevOnly|lazy-dev-only|LazyDevOnly)>[\s\S]*?<\/(?:dev-only|DevOnly|lazy-dev-only|LazyDevOnly)>/g
+const DEVONLY_COMP_SINGLE_RE = /<(?:dev-only|DevOnly|lazy-dev-only|LazyDevOnly)(?:\s(?:[^>"']|"[^"]*"|'[^']*')*)?>[\s\S]*?<\/(?:dev-only|DevOnly|lazy-dev-only|LazyDevOnly)>/
+const DEVONLY_COMP_RE = /<(?:dev-only|DevOnly|lazy-dev-only|LazyDevOnly)(?:\s(?:[^>"']|"[^"]*"|'[^']*')*)?>[\s\S]*?<\/(?:dev-only|DevOnly|lazy-dev-only|LazyDevOnly)>/g
 
 export const DevOnlyPlugin = (options: DevOnlyPluginOptions) => createUnplugin(() => {
   return {

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -149,6 +149,12 @@ describe('pages', () => {
     expect(html).toContain('This is a custom component with a named export.')
     // should remove dev-only and replace with any fallback content
     expect(html).toContain(isDev ? 'Some dev-only info' : 'Some prod-only info')
+    // should strip dev-only with attributes in production
+    if (isDev) {
+      expect(html).toContain('Dev-only with attributes')
+    } else {
+      expect(html).not.toContain('Dev-only with attributes')
+    }
     // should render server-only components
     expect(html.replaceAll(/ data-island-uid="[^"]*"/g, '')).toContain('<div class="server-only" style="background-color:gray;"> server-only component <div> server-only component child (non-server-only) </div></div>')
     // should register global components automatically

--- a/test/fixtures/basic/app/pages/index.vue
+++ b/test/fixtures/basic/app/pages/index.vue
@@ -11,6 +11,9 @@
     <div>Composable | star: {{ useNestedBar() }}</div>
     <DevOnly>Some dev-only info</DevOnly>
     <div><DevOnly>Some dev-only info</DevOnly></div>
+    <DevOnly class="test-attr">
+      Dev-only with attributes
+    </DevOnly>
     <div>
       <DevOnly>
         Some dev-only info


### PR DESCRIPTION
### 🔗 Linked issue

<!-- no existing issue -->

### 📚 Description

The regex in `DevOnlyPlugin` that strips `<DevOnly>` components from production templates only matched opening tags without attributes. `<DevOnly v-if="condition">` or `<DevOnly class="debug">` would pass through the regex and stay in the production bundle as dead code.

The component itself still renders correctly (shows fallback or nothing), but the dev-only content remains in the compiled template output, bloating the bundle.

Updated the regex to handle quoted attribute values, including edge cases like `v-if="a > b"` where `>` appears inside quotes.