### PR TITLE
fix(nuxt): validate island key on client before fetching

### DIFF
--- a/packages/nuxt/src/app/plugins/revive-payload.client.ts
+++ b/packages/nuxt/src/app/plugins/revive-payload.client.ts
@@ -5,6 +5,7 @@ import { defineNuxtPlugin, useNuxtApp } from '../nuxt'
 
 // @ts-expect-error Virtual file.
 import { componentIslands } from '#build/nuxt.config.mjs'
+import { isValidIslandKey } from './utils'
 
 function parseRevivedData (data: string) {
   try {
@@ -27,7 +28,7 @@ const revivers: [string, (data: any) => any][] = [
 if (componentIslands) {
   revivers.push(['Island', ({ key, params, result }: any) => {
     const nuxtApp = useNuxtApp()
-    if (!nuxtApp.isHydrating) {
+    if (!nuxtApp.isHydrating && isValidIslandKey(key)) {
       nuxtApp.payload.data[key] ||= $fetch(`/__nuxt_island/${key}.json`, {
         responseType: 'json',
         ...params ? { params } : {},


### PR DESCRIPTION
### 🔗 Linked issue

<!-- no existing issue -->

### 📚 Description

The server-side payload reducer validates island keys through `isValidIslandKey` before serializing them, but the client-side reviver was using the key directly in a `$fetch` URL without the same check. Added the matching validation so both sides are consistent.