### PR TITLE
perf(nuxt): clean-up build hooks + emit gc'd snapshots

### DIFF
--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -50,7 +50,7 @@
     "@nuxt/schema": "workspace:*",
     "@rspack/core": "1.7.8",
     "@types/semver": "7.7.1",
-    "hookable": "6.0.1",
+    "hookable": "6.1.0",
     "nitro": "3.0.260311-beta",
     "nitropack": "2.13.1",
     "obuild": "0.4.32",

--- a/packages/nitro-server/package.json
+++ b/packages/nitro-server/package.json
@@ -77,7 +77,7 @@
     "@babel/plugin-proposal-decorators": "7.29.0",
     "@nuxt/schema": "workspace:*",
     "@rollup/plugin-babel": "7.0.0",
-    "hookable": "6.0.1",
+    "hookable": "6.1.0",
     "nuxt": "workspace:*",
     "obuild": "0.4.32",
     "vitest": "4.0.18"

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -74,7 +74,7 @@
     "errx": "^0.1.0",
     "escape-string-regexp": "^5.0.0",
     "exsolve": "^1.0.8",
-    "hookable": "^6.0.1",
+    "hookable": "^6.1.0",
     "ignore": "^7.0.5",
     "impound": "^1.1.5",
     "jiti": "^2.6.1",

--- a/packages/nuxt/src/core/builder.ts
+++ b/packages/nuxt/src/core/builder.ts
@@ -9,7 +9,7 @@ import { isDirectory, logger } from '../utils.ts'
 import { generateApp as _generateApp, createApp } from './app.ts'
 import { checkForExternalConfigurationFiles } from './external-config-files.ts'
 import { cleanupCaches, getVueHash } from './cache.ts'
-import type { Nuxt, NuxtBuilder } from 'nuxt/schema'
+import type { Nuxt, NuxtBuilder, NuxtHooks } from 'nuxt/schema'
 
 export async function build (nuxt: Nuxt): Promise<void> {
   nuxt._perf?.startPhase('app:generate')
@@ -76,6 +76,18 @@ export async function build (nuxt: Nuxt): Promise<void> {
   nuxt._perf?.startPhase('build:bundle')
   await bundle(nuxt)
   nuxt._perf?.endPhase('build:bundle')
+
+  // release hooks that will never fire again.
+  if (!nuxt.options.dev) {
+    clearBuildHooks(nuxt)
+  }
+
+  // allow GC to reclaim any now-unreferenced bundler memory
+  if (!nuxt.options.dev && typeof globalThis.gc === 'function') {
+    nuxt._perf?.startPhase('build:gc')
+    globalThis.gc()
+    nuxt._perf?.endPhase('build:gc')
+  }
 
   await nuxt.callHook('build:done')
 
@@ -255,6 +267,41 @@ async function loadBuilder (nuxt: Nuxt, builder: string): Promise<NuxtBuilder> {
     return await importModule(builder, { url: [directoryToURL(nuxt.options.rootDir), new URL(import.meta.url)] })
   } catch (err) {
     throw new Error(`Loading \`${builder}\` builder failed. You can read more about the nuxt \`builder\` option at: \`https://nuxt.com/docs/4.x/api/nuxt-config#builder\``, { cause: err })
+  }
+}
+
+const hooksToClear: Array<keyof NuxtHooks> = [
+  // config-phase hooks that fire before the build starts
+  'vite:extend',
+  'vite:extendConfig',
+  'vite:configResolved',
+  'vite:compiled',
+  'webpack:config',
+  'webpack:configResolved',
+  'webpack:compile',
+  'webpack:compiled',
+  'webpack:change',
+  'webpack:error',
+  'webpack:done',
+  'webpack:progress',
+  'rspack:config',
+  'rspack:configResolved',
+  'rspack:compile',
+  'rspack:compiled',
+  'rspack:change',
+  'rspack:error',
+  'rspack:done',
+  // manifest hook - fires after build
+  'build:manifest',
+  // builder hooks
+  'builder:watch',
+  'builder:generateApp',
+  'app:templatesGenerated',
+]
+
+function clearBuildHooks (nuxt: Nuxt): void {
+  for (const name of hooksToClear) {
+    nuxt.hooks.clearHook(name)
   }
 }
 

--- a/packages/nuxt/src/core/perf.ts
+++ b/packages/nuxt/src/core/perf.ts
@@ -21,6 +21,7 @@ interface PerfPhase {
   memoryBefore: MemorySnapshot
   memoryAfter: MemorySnapshot
   memoryDelta: { rss: number, heapUsed: number }
+  retainedMemory?: MemorySnapshot
 }
 
 interface OpenPhase {
@@ -56,6 +57,7 @@ export interface BundlerPluginTiming {
 export interface PerfReport {
   totalDuration: number
   totalMemoryDelta: { rss: number, heapUsed: number }
+  hasGCSnapshots: boolean
   phases: Array<{
     name: string
     duration: number
@@ -64,6 +66,7 @@ export interface PerfReport {
     memoryAfter: MemorySnapshot
     memoryDelta: { rss: number, heapUsed: number }
     ownMemoryDelta: { rss: number, heapUsed: number }
+    retainedHeap?: number
   }>
   slowHooks: SlowHook[]
   modules: ModuleTiming[]
@@ -71,7 +74,17 @@ export interface PerfReport {
   timestamp: string
 }
 
+const hasGC = typeof globalThis.gc === 'function'
+
 function getMemorySnapshot (): MemorySnapshot {
+  const mem = process.memoryUsage()
+  return { rss: mem.rss, heapUsed: mem.heapUsed, heapTotal: mem.heapTotal }
+}
+
+function getRetainedMemorySnapshot (): MemorySnapshot {
+  if (hasGC) {
+    globalThis.gc!()
+  }
   const mem = process.memoryUsage()
   return { rss: mem.rss, heapUsed: mem.heapUsed, heapTotal: mem.heapTotal }
 }
@@ -225,6 +238,12 @@ export class NuxtPerfProfiler {
     const endTime = performance.now()
     const memoryAfter = getMemorySnapshot()
 
+    // For top-level phases (nothing else on the stack), take a GC'd snapshot
+    // to measure truly retained memory. This is expensive so we only do it
+    // at major phase boundaries when --expose-gc is available.
+    const isTopLevel = this.#phaseStack.length === 0
+    const retainedMemory = isTopLevel && hasGC ? getRetainedMemorySnapshot() : undefined
+
     this.#phases.push({
       name: open.name,
       startTime: open.startTime,
@@ -236,6 +255,7 @@ export class NuxtPerfProfiler {
         rss: memoryAfter.rss - open.memoryBefore.rss,
         heapUsed: memoryAfter.heapUsed - open.memoryBefore.heapUsed,
       },
+      retainedMemory,
     })
   }
 
@@ -331,6 +351,7 @@ export class NuxtPerfProfiler {
         rss: globalMemoryAfter.rss - this.#globalMemoryBefore.rss,
         heapUsed: globalMemoryAfter.heapUsed - this.#globalMemoryBefore.heapUsed,
       },
+      hasGCSnapshots: hasGC,
       phases: allPhases.map((p) => {
         const own = computeOwn(p)
         return {
@@ -341,6 +362,7 @@ export class NuxtPerfProfiler {
           memoryAfter: p.memoryAfter,
           memoryDelta: p.memoryDelta,
           ownMemoryDelta: own.ownMemoryDelta,
+          retainedHeap: p.retainedMemory?.heapUsed,
         }
       }),
       slowHooks: this.#computeSlowHooks(new Set(allPhases.map(p => p.name))),
@@ -383,17 +405,23 @@ export class NuxtPerfProfiler {
     const colDuration = 10
     const colRss = 14
     const colHeap = 14
+    const colRetained = 16
+    const showRetained = report.hasGCSnapshots
     const maxDuration = Math.max(...topPhases.map(p => p.ownDuration), 1)
 
-    const header = [
+    const headerCols = [
       pad(colors.bold('Phase'), colPhase),
       pad(colors.bold('Duration'), colDuration, 'right'),
       pad(colors.bold('RSS Delta'), colRss, 'right'),
       pad(colors.bold('Heap Delta'), colHeap, 'right'),
-    ].join('  ')
-    consola.log(`  ${header}`)
+    ]
+    if (showRetained) {
+      headerCols.push(pad(colors.bold('Retained Heap'), colRetained, 'right'))
+    }
+    consola.log(`  ${headerCols.join('  ')}`)
 
-    const separator = '  ' + colors.dim('─'.repeat(colPhase + colDuration + colRss + colHeap + 6))
+    const separatorWidth = colPhase + colDuration + colRss + colHeap + 6 + (showRetained ? colRetained + 2 : 0)
+    const separator = '  ' + colors.dim('─'.repeat(separatorWidth))
     consola.log(separator)
 
     const maxRss = Math.max(...topPhases.map(p => Math.abs(p.ownMemoryDelta.rss)), 1)
@@ -418,23 +446,37 @@ export class NuxtPerfProfiler {
 
       const bar = durColor('█'.repeat(durBar)) + memColor('░'.repeat(memBar))
 
-      const row = [
+      const rowCols = [
         pad(phase.name, colPhase),
         pad(durColor(formatDuration(dur)), colDuration, 'right'),
         pad(memColor((rss >= 0 ? '+' : '') + formatBytes(rss)), colRss, 'right'),
         pad((heap >= 0 ? '+' : '') + formatBytes(heap), colHeap, 'right'),
-      ].join('  ')
-      consola.log(`  ${row}  ${bar}`)
+      ]
+      if (showRetained) {
+        if (phase.retainedHeap != null) {
+          const retainedColor = phase.retainedHeap > 200 * 1024 * 1024 ? colors.red : phase.retainedHeap > 100 * 1024 * 1024 ? colors.yellow : colors.green
+          rowCols.push(pad(retainedColor(formatBytes(phase.retainedHeap)), colRetained, 'right'))
+        } else {
+          rowCols.push(pad(colors.dim('—'), colRetained, 'right'))
+        }
+      }
+      consola.log(`  ${rowCols.join('  ')}  ${bar}`)
     }
 
     consola.log(separator)
-    const totalRow = [
+    const totalCols = [
       pad(colors.bold('Total'), colPhase),
       pad(colors.bold(formatDuration(report.totalDuration)), colDuration, 'right'),
       pad(colors.bold((report.totalMemoryDelta.rss >= 0 ? '+' : '') + formatBytes(report.totalMemoryDelta.rss)), colRss, 'right'),
       pad(colors.bold((report.totalMemoryDelta.heapUsed >= 0 ? '+' : '') + formatBytes(report.totalMemoryDelta.heapUsed)), colHeap, 'right'),
-    ].join('  ')
-    consola.log(`  ${totalRow}`)
+    ]
+    if (showRetained) {
+      totalCols.push(pad('', colRetained))
+    }
+    consola.log(`  ${totalCols.join('  ')}`)
+    if (!showRetained) {
+      consola.log(colors.dim('  Tip: run with NODE_OPTIONS=--expose-gc to see retained heap per phase'))
+    }
     consola.log('')
 
     const significantModules = report.modules.filter(m => m.setupTime > 5)
@@ -636,6 +678,19 @@ export class NuxtPerfProfiler {
           args: { rss: phase.memoryAfter.rss, heapUsed: phase.memoryAfter.heapUsed },
         },
       )
+      // If we have a GC'd retained memory snapshot, emit it as a separate counter
+      // so it's visible in Perfetto as a distinct series
+      if (phase.retainedMemory) {
+        events.push({
+          name: 'Retained Memory',
+          cat: 'memory',
+          ph: 'C',
+          ts: toUs(phase.endTime) + 1, // slightly after to ensure ordering
+          pid,
+          tid: 0,
+          args: { heapRetained: phase.retainedMemory.heapUsed, rssRetained: phase.retainedMemory.rss },
+        })
+      }
     }
 
     return events

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -48,7 +48,7 @@
     "esbuild-loader": "4.4.2",
     "file-loader": "6.2.0",
     "h3": "2.0.1-rc.16",
-    "hookable": "6.0.1",
+    "hookable": "6.1.0",
     "ignore": "7.0.5",
     "mini-css-extract-plugin": "2.10.1",
     "nitro": "3.0.260311-beta",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6017,9 +6017,6 @@ packages:
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
 
-  hookable@6.0.1:
-    resolution: {integrity: sha512-uKGyY8BuzN/a5gvzvA+3FVWo0+wUjgtfSdnmjtrOVwQCZPHpHDH2WRO3VZSOeluYrHoDCiXFffZXs8Dj1ULWtw==}
-
   hookable@6.1.0:
     resolution: {integrity: sha512-ZoKZSJgu8voGK2geJS+6YtYjvIzu9AOM/KZXsBxr83uhLL++e9pEv/dlgwgy3dvHg06kTz6JOh1hk3C8Ceiymw==}
 
@@ -11788,7 +11785,7 @@ snapshots:
 
   '@unhead/vue@2.1.12(vue@3.5.30(typescript@5.9.3))':
     dependencies:
-      hookable: 6.0.1
+      hookable: 6.1.0
       unhead: 2.1.12
       vue: 3.5.30(typescript@5.9.3)
 
@@ -14109,8 +14106,6 @@ snapshots:
 
   hookable@5.5.3: {}
 
-  hookable@6.0.1: {}
-
   hookable@6.1.0: {}
 
   hosted-git-info@7.0.2:
@@ -15328,7 +15323,7 @@ snapshots:
       db0: 0.3.4
       env-runner: 0.1.6
       h3: 2.0.1-rc.16(crossws@0.4.4(srvx@0.11.9))
-      hookable: 6.0.1
+      hookable: 6.1.0
       nf3: 0.3.11
       ocache: 0.1.2
       ofetch: 2.0.0-alpha.3
@@ -17371,7 +17366,7 @@ snapshots:
 
   unhead@2.1.12:
     dependencies:
-      hookable: 6.0.1
+      hookable: 6.1.0
 
   unicode-emoji-modifier-base@1.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,8 +314,8 @@ importers:
         specifier: 7.7.1
         version: 7.7.1
       hookable:
-        specifier: 6.0.1
-        version: 6.0.1
+        specifier: 6.1.0
+        version: 6.1.0
       nitro:
         specifier: 3.0.260311-beta
         version: 3.0.260311-beta(chokidar@5.0.0)(dotenv@17.3.1)(giget@3.1.2)(ioredis@5.10.0)(jiti@2.6.1)(lru-cache@11.2.6)(rollup@4.59.0)(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.0)(yaml@2.8.2))
@@ -435,8 +435,8 @@ importers:
         specifier: 7.0.0
         version: 7.0.0(@babel/core@7.29.0)(@types/babel__core@7.20.5)(rollup@4.59.0)
       hookable:
-        specifier: 6.0.1
-        version: 6.0.1
+        specifier: 6.1.0
+        version: 6.1.0
       nuxt:
         specifier: workspace:*
         version: link:../nuxt
@@ -513,8 +513,8 @@ importers:
         specifier: ^1.0.8
         version: 1.0.8
       hookable:
-        specifier: ^6.0.1
-        version: 6.0.1
+        specifier: ^6.1.0
+        version: 6.1.0
       ignore:
         specifier: ^7.0.5
         version: 7.0.5
@@ -891,8 +891,8 @@ importers:
         specifier: 2.0.1-rc.16
         version: 2.0.1-rc.16(crossws@0.4.4(srvx@0.11.9))
       hookable:
-        specifier: 6.0.1
-        version: 6.0.1
+        specifier: 6.1.0
+        version: 6.1.0
       ignore:
         specifier: 7.0.5
         version: 7.0.5
@@ -6020,6 +6020,9 @@ packages:
   hookable@6.0.1:
     resolution: {integrity: sha512-uKGyY8BuzN/a5gvzvA+3FVWo0+wUjgtfSdnmjtrOVwQCZPHpHDH2WRO3VZSOeluYrHoDCiXFffZXs8Dj1ULWtw==}
 
+  hookable@6.1.0:
+    resolution: {integrity: sha512-ZoKZSJgu8voGK2geJS+6YtYjvIzu9AOM/KZXsBxr83uhLL++e9pEv/dlgwgy3dvHg06kTz6JOh1hk3C8Ceiymw==}
+
   hosted-git-info@7.0.2:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -7742,8 +7745,8 @@ packages:
   pug-attrs@3.0.0:
     resolution: {integrity: sha512-azINV9dUtzPMFQktvTXciNAfAuVh/L/JCl0vtPCwvOA21uZrC08K/UnmrL+SXGEVc1FwzjW62+xw5S/uaLj6cA==}
 
-  pug-code-gen@3.0.3:
-    resolution: {integrity: sha512-cYQg0JW0w32Ux+XTeZnBEeuWrAY7/HNE6TWnhiHGnnRYlCgyAUPoyh9KzCMa9WhcJlJ1AtQqpEYHc+vbCzA+Aw==}
+  pug-code-gen@3.0.4:
+    resolution: {integrity: sha512-6okWYIKdasTyXICyEtvobmTZAVX57JkzgzIi4iRJlin8kmhG+Xry2dsus+Mun/nGCn6F2U49haHI5mkELXB14g==}
 
   pug-error@2.1.0:
     resolution: {integrity: sha512-lv7sU9e5Jk8IeUheHata6/UThZ7RK2jnaaNztxfPYUY+VxZyk/ePVaNZ/vwmH8WqGvDz3LrNYt/+gA55NDg6Pg==}
@@ -10405,7 +10408,7 @@ snapshots:
       execa: 8.0.1
       fast-npm-meta: 1.4.2
       get-port-please: 3.2.0
-      hookable: 6.0.1
+      hookable: 6.1.0
       image-meta: 0.2.2
       is-installed-globally: 1.0.0
       launch-editor: 2.13.1
@@ -14108,6 +14111,8 @@ snapshots:
 
   hookable@6.0.1: {}
 
+  hookable@6.1.0: {}
+
   hosted-git-info@7.0.2:
     dependencies:
       lru-cache: 10.4.3
@@ -16235,7 +16240,7 @@ snapshots:
       js-stringify: 1.0.2
       pug-runtime: 3.0.1
 
-  pug-code-gen@3.0.3:
+  pug-code-gen@3.0.4:
     dependencies:
       constantinople: 4.0.1
       doctypes: 1.1.0
@@ -16292,7 +16297,7 @@ snapshots:
 
   pug@3.0.3:
     dependencies:
-      pug-code-gen: 3.0.3
+      pug-code-gen: 3.0.4
       pug-filters: 4.0.0
       pug-lexer: 5.0.1
       pug-linker: 4.0.0


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this PR cleans up vite/webpack build hooks before we build nitro, if we're building for production.

additionally, using new `--profile` support ([cli](https://github.com/nuxt/cli/pull/1243), [nuxt](https://github.com/nuxt/nuxt/pull/34468)), we now garbage collect before taking snapshots, if this is enabled.

to use:

```shell
NODE_OPTIONS="--expose-gc" pnpm nuxt build --profile=verbose
```