### PR TITLE
fix(nuxt): reset hasUAVisualTransition flag per navigation

### DIFF
--- a/packages/nuxt/src/app/plugins/view-transitions.client.ts
+++ b/packages/nuxt/src/app/plugins/view-transitions.client.ts
@@ -17,7 +17,6 @@ export default defineNuxtPlugin((nuxtApp) => {
 
   const resetTransitionState = () => {
     transition = undefined
-    hasUAVisualTransition = false
     abortTransition = undefined
     finishTransition = undefined
   }
@@ -42,6 +41,12 @@ export default defineNuxtPlugin((nuxtApp) => {
   router.beforeResolve(async (to, from) => {
     if (to.matched.length === 0) { return }
 
+    // Capture and reset the flag so it only applies to the current (popstate) navigation.
+    // Without this, a popstate with hasUAVisualTransition would permanently disable
+    // view transitions for subsequent programmatic/click navigations.
+    const skipForUATransition = hasUAVisualTransition
+    hasUAVisualTransition = false
+
     const toViewTransitionOptions = normalizeViewTransitionOptions(to.meta.viewTransition)
     const fromViewTransitionOptions = normalizeViewTransitionOptions(from.meta.viewTransition)
     const viewTransitionMode = toViewTransitionOptions.enabled ?? defaultViewTransition.enabled
@@ -51,7 +56,7 @@ export default defineNuxtPlugin((nuxtApp) => {
     if (
       viewTransitionMode === false ||
       prefersNoTransition ||
-      hasUAVisualTransition ||
+      skipForUATransition ||
       !isChangingPage(to, from)
     ) {
       return


### PR DESCRIPTION
### 🔗 Linked issue

<!-- no existing issue -->

### 📚 Description

`hasUAVisualTransition` gets set in the `popstate` handler when the browser provides its own visual transition, which correctly skips the custom view transition for that navigation. But the flag was only cleared inside `resetTransitionState`, which runs after `transition.finished`. Since the early return in `beforeResolve` means no transition is created, `resetTransitionState` never fires and the flag stays true permanently, blocking view transitions on all subsequent click/programmatic navigations.

Moved the reset into the `beforeResolve` guard itself so the flag only applies to the navigation that triggered the popstate.