### PR TITLE
fix(nuxt): move parcel watcher debug timer outside subscription loop

### DIFF
--- a/packages/nuxt/src/core/builder.ts
+++ b/packages/nuxt/src/core/builder.ts
@@ -231,11 +231,11 @@ async function createParcelWatcher () {
           'node_modules',
         ],
       })
-      if (nuxt.options.debug && nuxt.options.debug.watchers) {
-        // eslint-disable-next-line no-console
-        console.timeEnd('[nuxt] builder:parcel:watch')
-      }
       nuxt.hook('close', () => subscription.unsubscribe())
+    }
+    if (nuxt.options.debug && nuxt.options.debug.watchers) {
+      // eslint-disable-next-line no-console
+      console.timeEnd('[nuxt] builder:parcel:watch')
     }
     return true
   } catch {


### PR DESCRIPTION
### 🔗 Linked issue

follow-up to #34573

### 📚 Description

`console.timeEnd('[nuxt] builder:parcel:watch')` sits inside the `for` loop that iterates watched directories. `console.time` fires once before the loop (line 215), but `timeEnd` fires once per directory (line 234). `resolvePathsToWatch` returns at least 2 entries for a basic project (app + server), more with layers or custom watch patterns - so the second+ calls log "Timer does not exist" warnings.

The chokidar watcher in the same file (lines 200-206) handles this correctly with a pending counter that only calls `timeEnd` when all watchers are ready. For the parcel watcher the subscriptions are sequential (`await` inside the loop), so moving `timeEnd` after the loop is enough.

This slipped in during #34573 when the `.then()` callback was refactored to `await`. The `.then()` version had the same issue but async execution masked it.