### PR TITLE
fix(nuxt): correct useAsyncData key type

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -214,16 +214,18 @@ export const createUseAsyncData = defineKeyedFunctionFactory({
       if (_isAutoKeyNeeded(args[0], args[1])) { args.unshift(autoKey) }
 
       // eslint-disable-next-line prefer-const
-      let [_key, _handler, opts = {}] = args as [string, AsyncDataHandler<ResT>, AsyncDataOptions<ResT, DataT, PickKeys, DefaultT>]
+      let [_key, _handler, opts = {}] = args as [MaybeRefOrGetter<string>, AsyncDataHandler<ResT>, AsyncDataOptions<ResT, DataT, PickKeys, DefaultT>]
       let keyChanging = false
 
       // Validate arguments
-      const key = computed(() => toValue(_key)!)
-      if (typeof key.value !== 'string') {
-        throw new TypeError('[nuxt] [useAsyncData] key must be a string.')
-      }
-      if (typeof _handler !== 'function') {
-        throw new TypeError('[nuxt] [useAsyncData] handler must be a function.')
+      const key = computed(() => toValue(_key))
+      if (import.meta.dev) {
+        if (!key.value || typeof key.value !== 'string') {
+          throw new TypeError('[nuxt] [useAsyncData] key must be a none empty string.')
+        }
+        if (typeof _handler !== 'function') {
+          throw new TypeError('[nuxt] [useAsyncData] handler must be a function.')
+        }
       }
 
       const shouldFactoryOptionsOverride = typeof options === 'function'

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -219,13 +219,11 @@ export const createUseAsyncData = defineKeyedFunctionFactory({
 
       // Validate arguments
       const key = computed(() => toValue(_key))
-      if (import.meta.dev) {
-        if (!key.value || typeof key.value !== 'string') {
-          throw new TypeError('[nuxt] [useAsyncData] key must be a non-empty string.')
-        }
-        if (typeof _handler !== 'function') {
-          throw new TypeError('[nuxt] [useAsyncData] handler must be a function.')
-        }
+      if (!key.value || typeof key.value !== 'string') {
+        throw new TypeError('[nuxt] [useAsyncData] key must be a non-empty string.')
+      }
+      if (typeof _handler !== 'function') {
+        throw new TypeError('[nuxt] [useAsyncData] handler must be a function.')
       }
 
       const shouldFactoryOptionsOverride = typeof options === 'function'

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -221,7 +221,7 @@ export const createUseAsyncData = defineKeyedFunctionFactory({
       const key = computed(() => toValue(_key))
       if (import.meta.dev) {
         if (!key.value || typeof key.value !== 'string') {
-          throw new TypeError('[nuxt] [useAsyncData] key must be a none empty string.')
+          throw new TypeError('[nuxt] [useAsyncData] key must be a non-empty string.')
         }
         if (typeof _handler !== 'function') {
           throw new TypeError('[nuxt] [useAsyncData] handler must be a function.')

--- a/test/nuxt/use-async-data.test.ts
+++ b/test/nuxt/use-async-data.test.ts
@@ -77,6 +77,10 @@ describe('useAsyncData', () => {
     expect(res.data.value).toBe('test')
   })
 
+  it('should throw TypeError when key is empty', () => {
+    expect(() => useAsyncData('', () => Promise.resolve('test'))).toThrowErrorMatchingInlineSnapshot('[TypeError: [nuxt] [useAsyncData] key must be a non-empty string.]')
+  })
+
   it('should keep promise methods after destructuring', async () => {
     const asyncData = useAsyncData(() => Promise.resolve('test'))
     const destructured = { ...asyncData, foo: 'foo' }

--- a/test/nuxt/use-async-data.test.ts
+++ b/test/nuxt/use-async-data.test.ts
@@ -1048,7 +1048,7 @@ describe('useAsyncData', () => {
     // Manual implementation of Promise.withResolvers for compatibility
     let resolve: (value: boolean) => void
     const promise = new Promise<boolean>((res) => { resolve = res })
-    const { clear } = useAsyncData('', () => promise)
+    const { clear } = useAsyncData('clear', () => promise)
     expect(aborted).toBe(false)
     clear()
     resolve!(true)


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Correct `_key` type to `MaybeRefOrGetter<string>`, and if  `key` passes `''`  also show error.

And show TypeError in dev. If this unnecessary please close it.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
