### PR TITLE
fix(nuxt): preserve falsy prop values in `NuxtTime` data attribute serialization

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-time.vue
+++ b/packages/nuxt/src/app/components/nuxt-time.vue
@@ -108,7 +108,7 @@ if (import.meta.server) {
   for (const prop in props) {
     if (prop !== 'datetime') {
       const value = props?.[prop as keyof typeof props]
-      if (value) {
+      if (value !== undefined && value !== null) {
         const propInKebabCase = prop.split(/(?=[A-Z])/).join('-')
         dataset[`data-${propInKebabCase}`] = props?.[prop as keyof typeof props]
       }
@@ -141,7 +141,8 @@ if (import.meta.server) {
           optionName = 'style'
         }
 
-        options[optionName] = el.getAttribute(name) as any
+        const attrValue = el.getAttribute(name)
+        options[optionName] = (attrValue === 'true' ? true : attrValue === 'false' ? false : attrValue) as any
       }
     }
 

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -3226,7 +3226,7 @@ describe('nuxt-time', () => {
     const html = await $fetch<string>('/components/nuxt-time')
     const snap = html.match(/<time[^>]*data-testid="fixed"[^>]*>[^<]*<\/time>/)?.[0].replace(/ data-prehydrate-id="[^"]*"/g, '')
     expect(snap).toContain(
-      '<time data-month="long" data-day="numeric" datetime="2023-02-11T08:24:08.396Z" data-testid="fixed">',
+      '<time data-month="long" data-day="numeric" data-relative="false" data-title="false" datetime="2023-02-11T08:24:08.396Z" data-testid="fixed">',
     )
   })
 

--- a/test/nuxt/nuxt-time.test.ts
+++ b/test/nuxt/nuxt-time.test.ts
@@ -170,6 +170,51 @@ describe('<NuxtTime>', () => {
     vi.restoreAllMocks()
   })
 
+  it('should serialize falsy prop values like hour12=false into data attributes', async () => {
+    const thing = await mountSuspended(
+      defineComponent({
+        render: () =>
+          h(NuxtTime, {
+            ssr: true,
+            datetime: '2023-02-11T18:26:41.058Z',
+            locale: 'en-GB',
+            hour: 'numeric',
+            minute: 'numeric',
+            hour12: false,
+            timeZone: 'UTC',
+          }),
+      }),
+    )
+    const html = thing.html()
+    expect(html).toContain('data-hour12="false"')
+
+    // Verify round-trip: prehydrate should parse "false" back to boolean
+    const id = html.match(/data-prehydrate-id="([^"]+)"/)?.[1]
+    expect(id).toBeDefined()
+
+    vi.spyOn(document, 'querySelectorAll').mockImplementation((selector) => {
+      if (selector === `[data-prehydrate-id*="${id}"]`) {
+        return [thing.element] as any
+      }
+      return []
+    })
+
+    const head = injectHead()
+    const prehydrateEntry = [...head.entries.values()].find(
+      // @ts-expect-error untyped internal
+      e => e.input?.script?.[0]?.innerHTML?.includes('_nuxtTimeNow'),
+    )
+    expect(prehydrateEntry).toBeDefined()
+    // @ts-expect-error untyped internal
+    const fn = new Function(prehydrateEntry!.input.script[0].innerHTML)
+    fn()
+
+    // With hour12: false the formatted time should use 24-hour format
+    expect(thing.element.textContent).toContain('18:26')
+
+    vi.restoreAllMocks()
+  })
+
   describe('invalid date handling', () => {
     it('should display "Invalid Date" and omit datetime attribute for invalid date without relative mode', async () => {
       const thing = await mountSuspended(


### PR DESCRIPTION
### 🔗 Linked issue

n/a

### 📚 Description

`<NuxtTime>`'s server-side prop serialization uses `if (value)` to filter which props get written into `data-*` attributes for prehydration. That drops `false` and `0` since both are falsy, so `hour12={false}` (force 24-hour clock) never reaches the prehydrate script. The client-side formatter then falls back to the locale default and you get a visible flash from 24h to 12h format on hydration.

Two fixes:
- dataset loop now checks `value !== undefined && value !== null` instead of `if (value)`
- prehydrate attribute reader converts `"true"`/`"false"` strings back to booleans, so `Intl.DateTimeFormat` gets the right type