### PR TITLE
fix(nuxt): clear cached rejected promise in `callOnce`

### DIFF
--- a/packages/nuxt/src/app/composables/once.ts
+++ b/packages/nuxt/src/app/composables/once.ts
@@ -50,7 +50,12 @@ export async function callOnce (...args: any[]): Promise<void> {
 
   nuxtApp._once ||= {}
   nuxtApp._once[_key] ||= fn() || true
-  await nuxtApp._once[_key]
+  try {
+    await nuxtApp._once[_key]
+  } catch (e) {
+    delete nuxtApp._once[_key]
+    throw e
+  }
   nuxtApp.payload.once.add(_key)
   delete nuxtApp._once[_key]
 }

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -1066,6 +1066,18 @@ describe('callOnce', () => {
       await execute()
       expect(fn).toHaveBeenCalledTimes(2)
     })
+
+    it('should retry after a rejected promise', async () => {
+      const fn = vi.fn()
+        .mockRejectedValueOnce(new Error('fail'))
+        .mockResolvedValueOnce(undefined)
+      const execute = () => options ? callOnce('retry-key', fn, options) : callOnce('retry-key', fn)
+      await expect(execute()).rejects.toThrow('fail')
+      expect(fn).toHaveBeenCalledTimes(1)
+
+      await execute()
+      expect(fn).toHaveBeenCalledTimes(2)
+    })
   })
 })
 


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 📚 Description

`callOnce` caches the return value of `fn()` in `nuxtApp._once[key]` to deduplicate concurrent calls. If `fn()` rejects, the rejected promise stays cached because `||=` sees a truthy value and never reassigns. Every subsequent `callOnce` with that key re-throws the stale rejection instead of calling `fn()` again.

The fix deletes `_once[key]` on rejection so the next call gets a fresh attempt.