### PR TITLE
fix(vite): show plugin error messages in overlay

### DIFF
--- a/packages/vite/src/plugins/vite-node.ts
+++ b/packages/vite/src/plugins/vite-node.ts
@@ -250,6 +250,17 @@ export function ViteNodePlugin (nuxt: Nuxt): VitePlugin {
   }
 }
 
+function pickSerializableLoc (loc: { file?: string, id?: string, url?: string, line?: number | string, column?: number | string } | null | undefined) {
+  if (!loc || typeof loc !== 'object') { return undefined }
+  const out: Record<string, string | number | undefined> = {}
+  if (loc.file != null) { out.file = String(loc.file) }
+  if (loc.id != null) { out.id = String(loc.id) }
+  if (loc.url != null) { out.url = String(loc.url) }
+  if (loc.line != null) { out.line = typeof loc.line === 'number' ? loc.line : String(loc.line) }
+  if (loc.column != null) { out.column = typeof loc.column === 'number' ? loc.column : String(loc.column) }
+  return Object.keys(out).length ? out : undefined
+}
+
 function createViteNodeSocketServer (nuxt: Nuxt, ssrServer: ViteDevServer, clientServer: ViteDevServer, invalidates: Set<string>, config: ViteNodeServerOptions) {
   const server = net.createServer((socket) => {
     const INITIAL_BUFFER_SIZE = 64 * 1024 // 64kB
@@ -299,6 +310,12 @@ function createViteNodeSocketServer (nuxt: Nuxt, ssrServer: ViteDevServer, clien
                   message: err.message || '',
                 }
                 if (err.frame) { errorData.frame = err.frame }
+                if (err.plugin) { errorData.plugin = err.plugin }
+                if (err.reason) { errorData.reason = err.reason }
+                // Normalize loc/location to serializable fields only (file, id, url, line, column)
+                // to avoid IPC issues with non-JSON-serializable AST or other objects
+                if (err.loc) { errorData.loc = pickSerializableLoc(err.loc) }
+                if (err.location) { errorData.location = pickSerializableLoc(err.location) }
 
                 if (!errorData.frame && err.code === 'PARSE_ERROR') {
                   try {

--- a/packages/vite/src/utils/format-vite-error.ts
+++ b/packages/vite/src/utils/format-vite-error.ts
@@ -4,9 +4,9 @@ export function formatViteError (errorData: any, id: string): { message: string,
   const errorCode = errorData.name || errorData.reasonCode || errorData.code
   const frame = errorData.frame || errorData.source || errorData.pluginCode
 
-  const getLocId = (locObj: { file?: string, id?: string, url?: string } = {}) => locObj.file || locObj.id || locObj.url || id || ''
+  const getLocId = (locObj: { file?: string, id?: string, url?: string } = {}) => locObj.file || locObj.id || locObj.url || ''
   const getLocPos = (locObj: { line?: string, column?: string } = {}) => locObj.line ? `${locObj.line}:${locObj.column || 0}` : ''
-  const locId = getLocId(errorData.loc) || getLocId(errorData.location) || getLocId(errorData.input) || getLocId(errorData)
+  const locId = getLocId(errorData.loc) || getLocId(errorData.location) || getLocId(errorData.input) || getLocId(errorData) || id
   const locPos = getLocPos(errorData.loc) || getLocPos(errorData.location) || getLocPos(errorData.input) || getLocPos(errorData)
   const loc = locId.replace(process.cwd(), '.') + (locPos ? `:${locPos}` : '')
 

--- a/packages/vite/src/utils/format-vite-error.ts
+++ b/packages/vite/src/utils/format-vite-error.ts
@@ -1,0 +1,33 @@
+import process from 'node:process'
+
+export function formatViteError (errorData: any, id: string): { message: string, stack: string } {
+  const errorCode = errorData.name || errorData.reasonCode || errorData.code
+  const frame = errorData.frame || errorData.source || errorData.pluginCode
+
+  const getLocId = (locObj: { file?: string, id?: string, url?: string } = {}) => locObj.file || locObj.id || locObj.url || id || ''
+  const getLocPos = (locObj: { line?: string, column?: string } = {}) => locObj.line ? `${locObj.line}:${locObj.column || 0}` : ''
+  const locId = getLocId(errorData.loc) || getLocId(errorData.location) || getLocId(errorData.input) || getLocId(errorData)
+  const locPos = getLocPos(errorData.loc) || getLocPos(errorData.location) || getLocPos(errorData.input) || getLocPos(errorData)
+  const loc = locId.replace(process.cwd(), '.') + (locPos ? `:${locPos}` : '')
+
+  const reasonOrMessage = errorData.reason || errorData.message
+  const message = [
+    '[vite-node]',
+    errorData.plugin && `[plugin:${errorData.plugin}]`,
+    errorCode && `[${errorCode}]`,
+    loc,
+    reasonOrMessage && `: ${reasonOrMessage}`,
+    frame && `<br><pre>${frame.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')}</pre><br>`,
+  ].filter(Boolean).join(' ')
+
+  const stack = [
+    message,
+    `at ${loc}`,
+    errorData.stack,
+  ].filter(Boolean).join('\n')
+
+  return {
+    message,
+    stack,
+  }
+}

--- a/packages/vite/src/vite-node-runner.ts
+++ b/packages/vite/src/vite-node-runner.ts
@@ -3,7 +3,7 @@ import { ViteNodeRunner } from 'vite-node/client'
 import { consola } from 'consola'
 import { viteNodeFetch, viteNodeOptions } from '#vite-node'
 import type { ErrorPartial } from './types'
-import { formatViteError } from './utils/format-vite-error'
+import { formatViteError } from './utils/format-vite-error.ts'
 
 const runner: ViteNodeRunner = createRunner()
 
@@ -45,5 +45,5 @@ function createRunner () {
   })
 }
 
-export { formatViteError } from './utils/format-vite-error'
+export { formatViteError } from './utils/format-vite-error.ts'
 export default runner

--- a/packages/vite/src/vite-node-runner.ts
+++ b/packages/vite/src/vite-node-runner.ts
@@ -2,8 +2,8 @@ import { ViteNodeRunner } from 'vite-node/client'
 
 import { consola } from 'consola'
 import { viteNodeFetch, viteNodeOptions } from '#vite-node'
-import process from 'node:process'
 import type { ErrorPartial } from './types'
+import { formatViteError } from './utils/format-vite-error'
 
 const runner: ViteNodeRunner = createRunner()
 
@@ -45,35 +45,5 @@ function createRunner () {
   })
 }
 
-function formatViteError (errorData: any, id: string) {
-  const errorCode = errorData.name || errorData.reasonCode || errorData.code
-  const frame = errorData.frame || errorData.source || errorData.pluginCode
-
-  const getLocId = (locObj: { file?: string, id?: string, url?: string } = {}) => locObj.file || locObj.id || locObj.url || id || ''
-  const getLocPos = (locObj: { line?: string, column?: string } = {}) => locObj.line ? `${locObj.line}:${locObj.column || 0}` : ''
-  const locId = getLocId(errorData.loc) || getLocId(errorData.location) || getLocId(errorData.input) || getLocId(errorData)
-  const locPos = getLocPos(errorData.loc) || getLocPos(errorData.location) || getLocPos(errorData.input) || getLocPos(errorData)
-  const loc = locId.replace(process.cwd(), '.') + (locPos ? `:${locPos}` : '')
-
-  const message = [
-    '[vite-node]',
-    errorData.plugin && `[plugin:${errorData.plugin}]`,
-    errorCode && `[${errorCode}]`,
-    loc,
-    errorData.reason && `: ${errorData.reason}`,
-    frame && `<br><pre>${frame.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')}</pre><br>`,
-  ].filter(Boolean).join(' ')
-
-  const stack = [
-    message,
-    `at ${loc}`,
-    errorData.stack,
-  ].filter(Boolean).join('\n')
-
-  return {
-    message,
-    stack,
-  }
-}
-
+export { formatViteError } from './utils/format-vite-error'
 export default runner

--- a/packages/vite/test/vite-node-runner.test.ts
+++ b/packages/vite/test/vite-node-runner.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { formatViteError } from '../src/utils/format-vite-error'
+
+describe('formatViteError', () => {
+  it('uses message when reason is absent (plugin errors)', () => {
+    const errorData = {
+      code: 'VITE_ERROR',
+      id: '/project/app.vue',
+      message: 'Tailwind config error: invalid theme',
+      stack: 'Error: Tailwind config error...',
+    }
+    const { message } = formatViteError(errorData, '/project/app.vue')
+    expect(message).toContain('Tailwind config error: invalid theme')
+    expect(message).toContain('[vite-node]')
+  })
+
+  it('prefers reason over message when both present (Rollup-style)', () => {
+    const errorData = {
+      code: 'PARSE_ERROR',
+      reason: 'Unexpected token',
+      message: 'Parse error',
+      id: '/project/foo.ts',
+    }
+    const { message } = formatViteError(errorData, '/project/foo.ts')
+    expect(message).toContain('Unexpected token')
+    expect(message).not.toContain('Parse error')
+  })
+
+  it('includes plugin name when present', () => {
+    const errorData = {
+      code: 'VITE_ERROR',
+      plugin: 'tailwindcss',
+      message: 'Invalid config',
+      id: '/project/app.css',
+    }
+    const { message } = formatViteError(errorData, '/project/app.css')
+    expect(message).toContain('[plugin:tailwindcss]')
+    expect(message).toContain('Invalid config')
+  })
+
+  it('includes loc when present', () => {
+    const errorData = {
+      code: 'VITE_ERROR',
+      message: 'Syntax error',
+      loc: { file: '/project/bar.ts', line: 10, column: 5 },
+    }
+    const { message } = formatViteError(errorData, '/project/bar.ts')
+    expect(message).toContain('bar.ts')
+    expect(message).toContain('10:5')
+  })
+
+  it('includes frame when present', () => {
+    const errorData = {
+      code: 'VITE_ERROR',
+      message: 'Unexpected <',
+      frame: '  <div>\n    ^',
+    }
+    const { message } = formatViteError(errorData, '/project/x.vue')
+    expect(message).toContain('<pre>')
+    expect(message).toContain('&lt;div&gt;')
+    expect(message).toContain('Unexpected <')
+  })
+
+  it('returns empty error text when neither reason nor message', () => {
+    const errorData = {
+      code: 'VITE_ERROR',
+      id: '/project/empty.vue',
+    }
+    const { message } = formatViteError(errorData, '/project/empty.vue')
+    expect(message).toContain('[vite-node]')
+    expect(message).toContain('[VITE_ERROR]')
+    // loc is derived from id; full path may be shortened to ./path if cwd is replaced
+    expect(message).toMatch(/empty\.vue/)
+  })
+})


### PR DESCRIPTION
Fix Vite overlay not showing plugin error text (e.g. Tailwind 4) in Nuxt 4.4.x

**Problem**: In Nuxt 4.4.2 the error overlay showed empty or generic messages for Vite plugin errors (Tailwind 4, etc.), unlike 4.3.1 where the actual error text was visible.

**Solution**:
- Pass `plugin`, `reason`, `loc`, `location` from vite-node plugin to errorData for IPC
- Add `pickSerializableLoc()` to serialize only `file`, `id`, `url`, `line`, `column` (IPC-safe)
- In `formatViteError`, fallback to `errorData.message` when `reason` is absent
- Extract `formatViteError` to `utils/format-vite-error.ts` for testability
- Add unit tests for `formatViteError`

**Clean code**: Extracted `reasonOrMessage` variable to avoid duplication; explicit return type for isolatedDeclarations.

Fixes #34593