### PR TITLE
fix(nuxt): extend import protection for Nitro and Vue contexts

### DIFF
--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -641,7 +641,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
       exclude: [
         /node_modules[\\/]/, // Don't apply import protection to deps (ufo, unhead, @vue/server-renderer, srvx, etc.)
         /[\\/]h3[\\/]/, // h3 legitimately imports srvx/node for Node adapter
-        /[\\/]\.nuxt[\\/]dist[\\/]/, // Nuxt server build output (styles.mjs, server.mjs, _nuxt/*)
+        /[\\/]\.nuxt[\\/]/, // Nuxt build output (styles.mjs, server.mjs, _nuxt/*)
         /(packages|@nuxt)[\\/]nitro-server(?:-nightly)?[\\/](src|dist)[\\/]runtime[\\/]/,
         ...sharedPatterns,
       ],

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -649,7 +649,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
       // onViolation: fallback when id is bare (srvx) before resolution or when excludeFiles misses edge cases.
       excludeFiles: [IMPORT_PROTECTION_ALLOWED.srvxPattern],
       onViolation (info) {
-        if (info.id?.includes('srvx') || info.message?.includes('srvx/node')) {
+        if (info.id && IMPORT_PROTECTION_ALLOWED.isAllowed(info.id)) {
           return false
         }
       },

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -649,7 +649,8 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
       // onViolation: fallback when id is bare (srvx) before resolution or when excludeFiles misses edge cases.
       excludeFiles: [IMPORT_PROTECTION_ALLOWED.srvxPattern],
       onViolation (info) {
-        if (info.id && IMPORT_PROTECTION_ALLOWED.isAllowed(info.id)) {
+        // Fallback: when id is bare/unresolved, message contains importer path (e.g. "from `node_modules/...`")
+        if (IMPORT_PROTECTION_ALLOWED.isAllowed(info.id ?? '', info.message)) {
           return false
         }
       },

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -26,7 +26,7 @@ import { setupNitroViteEnvironment } from './vite.ts'
 import { setupLegacyDevAndBuild } from './legacy.ts'
 import { template as defaultSpaLoadingTemplate } from './templates/spa-loading-icon.ts'
 // TODO: figure out a good way to share this
-import { createImportProtectionPatterns } from '../../nuxt/src/core/plugins/import-protection.ts'
+import { createImportProtectionPatterns, IMPORT_PROTECTION_ALLOWED } from '../../nuxt/src/core/plugins/import-protection.ts'
 import { nitroSchemaTemplate } from './templates.ts'
 import { getH3ImportsPreset, v2ImportsPreset } from './imports.ts'
 // Re-export a type from the augment module rather than a bare `import './augments.ts'`
@@ -638,7 +638,21 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
       cwd: nuxt.options.rootDir,
       trace: true,
       patterns: createImportProtectionPatterns(nuxt, { context: 'nitro-app' }),
-      exclude: [/node_modules[\\/]nitro(?:pack)?(?:-nightly)?[\\/]|(packages|@nuxt)[\\/]nitro-server(?:-nightly)?[\\/](src|dist)[\\/]runtime[\\/]/, ...sharedPatterns],
+      exclude: [
+        /node_modules[\\/]/, // Don't apply import protection to deps (ufo, unhead, @vue/server-renderer, srvx, etc.)
+        /[\\/]h3[\\/]/, // h3 legitimately imports srvx/node for Node adapter
+        /[\\/]\.nuxt[\\/]dist[\\/]/, // Nuxt server build output (styles.mjs, server.mjs, _nuxt/*)
+        /(packages|@nuxt)[\\/]nitro-server(?:-nightly)?[\\/](src|dist)[\\/]runtime[\\/]/,
+        ...sharedPatterns,
+      ],
+      // excludeFiles: skips when resolved import target matches (e.g. srvx/node after resolution).
+      // onViolation: fallback when id is bare (srvx) before resolution or when excludeFiles misses edge cases.
+      excludeFiles: [IMPORT_PROTECTION_ALLOWED.srvxPattern],
+      onViolation (info) {
+        if (info.id?.includes('srvx') || info.message?.includes('srvx/node')) {
+          return false
+        }
+      },
     }),
   )
 

--- a/packages/nuxt/src/core/plugins/import-protection.ts
+++ b/packages/nuxt/src/core/plugins/import-protection.ts
@@ -33,7 +33,7 @@ export const IMPORT_PROTECTION_ALLOWED = {
       return true
     }
     const pathToCheck = normalized ?? id
-    if (pathToCheck.includes('node_modules') || pathToCheck.includes('.nuxt/dist/')) {
+    if (pathToCheck.includes('node_modules') || pathToCheck.includes('.nuxt/')) {
       return true
     }
     if (APP_CONFIG_FILE_RE.test(pathToCheck)) {

--- a/packages/nuxt/src/core/plugins/import-protection.ts
+++ b/packages/nuxt/src/core/plugins/import-protection.ts
@@ -39,12 +39,18 @@ export const IMPORT_PROTECTION_ALLOWED = {
  * normalized !== dir excludes the directory itself (e.g. /root/src/), only nested paths are blocked.
  * @param excludeDir - When provided, paths under this directory are not blocked (e.g. serverDir in nitro-app).
  */
+function isSubpath (parent: string, child: string): boolean {
+  const rel = relative(parent, child)
+  return rel !== '' && !rel.startsWith('..') && !rel.startsWith('/')
+}
+
 function createResolvedPathBlocker (
   rootDir: string,
   dir: string,
   message: string,
   excludeDir?: string,
 ): (id: string) => false | string {
+  const dirNorm = withTrailingSlash(resolve(dir))
   const excludeDirNorm = excludeDir ? withTrailingSlash(resolve(excludeDir)) : ''
   return (id: string) => {
     if (IMPORT_PROTECTION_ALLOWED.isAllowed(id)) {
@@ -55,10 +61,10 @@ function createResolvedPathBlocker (
     if (IMPORT_PROTECTION_ALLOWED.isAllowed(id, normalized)) {
       return false
     }
-    if (excludeDirNorm && normalized.startsWith(excludeDirNorm)) {
+    if (excludeDirNorm && isSubpath(excludeDirNorm, normalized)) {
       return false
     }
-    return normalized.startsWith(dir) && normalized !== dir ? message : false
+    return isSubpath(dirNorm, normalized) ? message : false
   }
 }
 
@@ -114,15 +120,19 @@ export function createImportProtectionPatterns (nuxt: { options: NuxtOptions }, 
         ['Move this code to your Vue app directory or use a shared utility.'],
       ])
     }
-    // App directory aliases ~ and @ (resolve to srcDir). Exclude ~/server/ and @/server/ so
+    // App directory aliases ~ and @ (resolve to srcDir). Exclude ~/serverDir/ and @/serverDir/ so
     // nitro-app can import from serverDir. Order matters: these run before createResolvedPathBlocker.
+    const srcDirResolved = resolve(nuxt.options.rootDir, nuxt.options.srcDir)
+    const serverDirPath = resolve(srcDirResolved, nuxt.options.serverDir || 'server')
+    const serverDirRelative = relative(srcDirResolved, serverDirPath) || 'server'
+    const escapedServerDir = escapeRE(serverDirRelative.replace(/[/\\]+$/, ''))
     patterns.push([
-      /^~\/(?!server\/)/,
+      new RegExp(`^~\\/(?!${escapedServerDir}\\/)`),
       `Vue app aliases are not allowed in ${context}.`,
       ['Move this code to your Vue app directory or use a shared utility.'],
     ])
     patterns.push([
-      /^@\/(?!server\/)/,
+      new RegExp(`^@\\/(?!${escapedServerDir}\\/)`),
       `Vue app aliases are not allowed in ${context}.`,
       ['Move this code to your Vue app directory or use a shared utility.'],
     ])
@@ -143,12 +153,14 @@ export function createImportProtectionPatterns (nuxt: { options: NuxtOptions }, 
         }
         const absolute = isAbsolute(resolved) ? resolved : resolve(rootDir, resolved)
         const normalized = resolve(absolute)
-        const srcDirNorm = resolve(srcDir)
-        const serverDirNorm = resolve(serverDir)
-        if (normalized.startsWith(serverDirNorm)) {
+        const relToServer = relative(serverDir, normalized)
+        const relToSrc = relative(srcDir, normalized)
+        const isInsideServer = relToServer !== '' && !relToServer.startsWith('..') && !relToServer.startsWith('/')
+        const isInsideSrc = relToSrc !== '' && !relToSrc.startsWith('..') && !relToSrc.startsWith('/')
+        if (isInsideServer) {
           return false
         }
-        return normalized.startsWith(srcDirNorm) && normalized !== srcDirNorm
+        return isInsideSrc
           ? `Vue app aliases are not allowed in ${context}.`
           : false
       },
@@ -191,7 +203,7 @@ export function createImportProtectionPatterns (nuxt: { options: NuxtOptions }, 
         }
         const absolute = isAbsolute(resolved) ? resolved : resolve(nuxt.options.rootDir, resolved)
         const normalized = resolve(absolute)
-        return normalized.startsWith(serverDir) && normalized !== serverDir
+        return isSubpath(serverDir, normalized)
           ? `Importing from server is not allowed in ${context}.`
           : false
       },

--- a/packages/nuxt/src/core/plugins/import-protection.ts
+++ b/packages/nuxt/src/core/plugins/import-protection.ts
@@ -18,17 +18,46 @@ interface NuxtImportProtectionOptions {
 }
 
 /**
+ * Shared exclusions for import protection. Used by createResolvedPathBlocker and nitro-server
+ * ImpoundPlugin config so allowed imports stay in sync.
+ */
+export const IMPORT_PROTECTION_ALLOWED = {
+  /** Matches srvx (bare, srvx/, srvx/...) for excludeFiles. */
+  srvxPattern: /srvx(\/|$)/,
+  /** Returns true if id is allowed (srvx, node_modules, .nuxt/dist). */
+  isAllowed (id: string, normalized?: string): boolean {
+    if (id === 'srvx' || id.startsWith('srvx/') || id.includes('/srvx/')) {
+      return true
+    }
+    const pathToCheck = normalized ?? id
+    return pathToCheck.includes('node_modules') || pathToCheck.includes('.nuxt/dist/')
+  },
+}
+
+/**
  * Returns a pattern that blocks imports whose resolved path is under the given directory.
  * normalized !== dir excludes the directory itself (e.g. /root/src/), only nested paths are blocked.
+ * @param excludeDir - When provided, paths under this directory are not blocked (e.g. serverDir in nitro-app).
  */
 function createResolvedPathBlocker (
   rootDir: string,
   dir: string,
   message: string,
+  excludeDir?: string,
 ): (id: string) => false | string {
+  const excludeDirNorm = excludeDir ? withTrailingSlash(resolve(excludeDir)) : ''
   return (id: string) => {
+    if (IMPORT_PROTECTION_ALLOWED.isAllowed(id)) {
+      return false
+    }
     const absolute = isAbsolute(id) ? id : resolve(rootDir, id)
     const normalized = resolve(absolute)
+    if (IMPORT_PROTECTION_ALLOWED.isAllowed(id, normalized)) {
+      return false
+    }
+    if (excludeDirNorm && normalized.startsWith(excludeDirNorm)) {
+      return false
+    }
     return normalized.startsWith(dir) && normalized !== dir ? message : false
   }
 }
@@ -85,31 +114,41 @@ export function createImportProtectionPatterns (nuxt: { options: NuxtOptions }, 
         ['Move this code to your Vue app directory or use a shared utility.'],
       ])
     }
-    // App directory aliases ~ and @ (resolve to srcDir). Order matters: these run before
-    // createResolvedPathBlocker, so alias paths are handled here, not by the general blocker.
+    // App directory aliases ~ and @ (resolve to srcDir). Exclude ~/server/ and @/server/ so
+    // nitro-app can import from serverDir. Order matters: these run before createResolvedPathBlocker.
     patterns.push([
-      /^~\//,
+      /^~\/(?!server\/)/,
       `Vue app aliases are not allowed in ${context}.`,
       ['Move this code to your Vue app directory or use a shared utility.'],
     ])
     patterns.push([
-      /^@\//,
+      /^@\/(?!server\/)/,
       `Vue app aliases are not allowed in ${context}.`,
       ['Move this code to your Vue app directory or use a shared utility.'],
     ])
-    // ~~ and @@ resolve to rootDir; block only when resolved path is under srcDir (app).
-    // Slash after ~~/@@ is required; forms like ~~foo without slash are not standard Nuxt imports.
+    // Resolve aliases (~~, @@, or custom) and block when resolved path is under srcDir (app) but not serverDir.
     const rootDir = withTrailingSlash(nuxt.options.rootDir)
     const srcDir = withTrailingSlash(resolve(nuxt.options.rootDir, nuxt.options.srcDir))
+    const serverDir = withTrailingSlash(resolve(nuxt.options.rootDir, resolve(nuxt.options.srcDir, nuxt.options.serverDir || 'server')))
     const alias = nuxt.options.alias || {}
     patterns.push([
+      /**
+       * resolved === id means no alias matched; such imports (e.g. ./foo, ../bar) are
+       * checked by createResolvedPathBlocker, so we return false here.
+       */
       (id: string, _importer: string) => {
-        if (!/^~~\/|^@@\//.test(id)) {
+        const resolved = resolveAlias(id, alias)
+        if (!resolved || resolved === id) {
           return false
         }
-        const resolved = resolveAlias(id, alias)
         const absolute = isAbsolute(resolved) ? resolved : resolve(rootDir, resolved)
-        return absolute.startsWith(srcDir) && absolute !== srcDir
+        const normalized = resolve(absolute)
+        const srcDirNorm = resolve(srcDir)
+        const serverDirNorm = resolve(serverDir)
+        if (normalized.startsWith(serverDirNorm)) {
+          return false
+        }
+        return normalized.startsWith(srcDirNorm) && normalized !== srcDirNorm
           ? `Vue app aliases are not allowed in ${context}.`
           : false
       },
@@ -120,7 +159,7 @@ export function createImportProtectionPatterns (nuxt: { options: NuxtOptions }, 
     // then normalizes to cwd; we use rootDir as the unified base for the startsWith check.
     const appBlockMessage = `Vue app aliases are not allowed in ${context}.`
     patterns.push([
-      createResolvedPathBlocker(nuxt.options.rootDir, srcDir, appBlockMessage),
+      createResolvedPathBlocker(nuxt.options.rootDir, srcDir, appBlockMessage, serverDir),
       appBlockMessage,
       ['Move this code to your Vue app directory or use a shared utility.'],
     ])
@@ -140,8 +179,10 @@ export function createImportProtectionPatterns (nuxt: { options: NuxtOptions }, 
       ['Use `$fetch()` or `useFetch()` to call server endpoints.', 'Move shared logic to the `shared/` directory.'],
     ])
     const alias = nuxt.options.alias || {}
-    // Resolve aliases (e.g. custom module alias to server) and block when resolved path is under serverDir.
-    // resolved === id: resolveAlias returns the original path when no alias matched; we must not block those.
+    /**
+     * Resolve aliases (e.g. custom module alias to server) and block when resolved path is under serverDir.
+     * resolved === id means no alias matched; such imports are checked by createResolvedPathBlocker.
+     */
     patterns.push([
       (id: string) => {
         const resolved = resolveAlias(id, alias)

--- a/packages/nuxt/src/core/plugins/import-protection.ts
+++ b/packages/nuxt/src/core/plugins/import-protection.ts
@@ -21,16 +21,25 @@ interface NuxtImportProtectionOptions {
  * Shared exclusions for import protection. Used by createResolvedPathBlocker and nitro-server
  * ImpoundPlugin config so allowed imports stay in sync.
  */
+/** Matches app.config.js, app.config.ts, etc. - merged by #build/app.config.mjs in nitro-app. */
+const APP_CONFIG_FILE_RE = /[/\\]app\.config\.(js|ts|mjs|cts|mts)$/
+
 export const IMPORT_PROTECTION_ALLOWED = {
   /** Matches srvx (bare, srvx/, srvx/...) for excludeFiles. */
   srvxPattern: /srvx(\/|$)/,
-  /** Returns true if id is allowed (srvx, node_modules, .nuxt/dist). */
+  /** Returns true if id is allowed (srvx, node_modules, .nuxt/dist, app.config.*). */
   isAllowed (id: string, normalized?: string): boolean {
     if (id === 'srvx' || id.startsWith('srvx/') || id.includes('/srvx/')) {
       return true
     }
     const pathToCheck = normalized ?? id
-    return pathToCheck.includes('node_modules') || pathToCheck.includes('.nuxt/dist/')
+    if (pathToCheck.includes('node_modules') || pathToCheck.includes('.nuxt/dist/')) {
+      return true
+    }
+    if (APP_CONFIG_FILE_RE.test(pathToCheck)) {
+      return true
+    }
+    return false
   },
 }
 

--- a/packages/nuxt/src/core/plugins/import-protection.ts
+++ b/packages/nuxt/src/core/plugins/import-protection.ts
@@ -1,5 +1,7 @@
-import { relative, resolve } from 'pathe'
+import { isAbsolute, relative, resolve } from 'pathe'
+import { withTrailingSlash } from 'ufo'
 import escapeRE from 'escape-string-regexp'
+import { resolveAlias } from '@nuxt/kit'
 import type { NuxtOptions } from 'nuxt/schema'
 
 type ImportPattern = [importPattern: string | RegExp | ((id: string, importer: string) => boolean | string), warning?: string, suggestions?: string[]]
@@ -13,6 +15,22 @@ interface ImportProtectionOptions {
 
 interface NuxtImportProtectionOptions {
   context: 'nuxt-app' | 'nitro-app' | 'shared'
+}
+
+/**
+ * Returns a pattern that blocks imports whose resolved path is under the given directory.
+ * normalized !== dir excludes the directory itself (e.g. /root/src/), only nested paths are blocked.
+ */
+function createResolvedPathBlocker (
+  rootDir: string,
+  dir: string,
+  message: string,
+): (id: string) => false | string {
+  return (id: string) => {
+    const absolute = isAbsolute(id) ? id : resolve(rootDir, id)
+    const normalized = resolve(absolute)
+    return normalized.startsWith(dir) && normalized !== dir ? message : false
+  }
 }
 
 export function createImportProtectionPatterns (nuxt: { options: NuxtOptions }, options: NuxtImportProtectionOptions) {
@@ -67,10 +85,50 @@ export function createImportProtectionPatterns (nuxt: { options: NuxtOptions }, 
         ['Move this code to your Vue app directory or use a shared utility.'],
       ])
     }
+    // App directory aliases ~ and @ (resolve to srcDir). Order matters: these run before
+    // createResolvedPathBlocker, so alias paths are handled here, not by the general blocker.
+    patterns.push([
+      /^~\//,
+      `Vue app aliases are not allowed in ${context}.`,
+      ['Move this code to your Vue app directory or use a shared utility.'],
+    ])
+    patterns.push([
+      /^@\//,
+      `Vue app aliases are not allowed in ${context}.`,
+      ['Move this code to your Vue app directory or use a shared utility.'],
+    ])
+    // ~~ and @@ resolve to rootDir; block only when resolved path is under srcDir (app).
+    // Slash after ~~/@@ is required; forms like ~~foo without slash are not standard Nuxt imports.
+    const rootDir = withTrailingSlash(nuxt.options.rootDir)
+    const srcDir = withTrailingSlash(resolve(nuxt.options.rootDir, nuxt.options.srcDir))
+    const alias = nuxt.options.alias || {}
+    patterns.push([
+      (id: string, _importer: string) => {
+        if (!/^~~\/|^@@\//.test(id)) {
+          return false
+        }
+        const resolved = resolveAlias(id, alias)
+        const absolute = isAbsolute(resolved) ? resolved : resolve(rootDir, resolved)
+        return absolute.startsWith(srcDir) && absolute !== srcDir
+          ? `Vue app aliases are not allowed in ${context}.`
+          : false
+      },
+      `Vue app aliases are not allowed in ${context}.`,
+      ['Move this code to your Vue app directory or use a shared utility.'],
+    ])
+    // Resolved paths (e.g. from relative imports). ImpoundPlugin resolves relative to importer,
+    // then normalizes to cwd; we use rootDir as the unified base for the startsWith check.
+    const appBlockMessage = `Vue app aliases are not allowed in ${context}.`
+    patterns.push([
+      createResolvedPathBlocker(nuxt.options.rootDir, srcDir, appBlockMessage),
+      appBlockMessage,
+      ['Move this code to your Vue app directory or use a shared utility.'],
+    ])
   }
 
   if (options.context === 'nuxt-app' || options.context === 'shared') {
-    const serverRelative = escapeRE(relative(nuxt.options.rootDir, resolve(nuxt.options.srcDir, nuxt.options.serverDir || 'server')))
+    const serverDir = withTrailingSlash(resolve(nuxt.options.rootDir, resolve(nuxt.options.srcDir, nuxt.options.serverDir || 'server')))
+    const serverRelative = escapeRE(relative(nuxt.options.rootDir, serverDir))
     patterns.push([
       new RegExp('^' + serverRelative + '\\/(api|routes|middleware|plugins)\\/'),
       `Importing from server is not allowed in ${context}.`,
@@ -80,6 +138,31 @@ export function createImportProtectionPatterns (nuxt: { options: NuxtOptions }, 
       /^#server(\/|$)/,
       `Server aliases are not allowed in ${context}.`,
       ['Use `$fetch()` or `useFetch()` to call server endpoints.', 'Move shared logic to the `shared/` directory.'],
+    ])
+    const alias = nuxt.options.alias || {}
+    // Resolve aliases (e.g. custom module alias to server) and block when resolved path is under serverDir.
+    // resolved === id: resolveAlias returns the original path when no alias matched; we must not block those.
+    patterns.push([
+      (id: string) => {
+        const resolved = resolveAlias(id, alias)
+        if (!resolved || resolved === id) {
+          return false
+        }
+        const absolute = isAbsolute(resolved) ? resolved : resolve(nuxt.options.rootDir, resolved)
+        const normalized = resolve(absolute)
+        return normalized.startsWith(serverDir) && normalized !== serverDir
+          ? `Importing from server is not allowed in ${context}.`
+          : false
+      },
+      `Importing from server is not allowed in ${context}.`,
+      ['Use `$fetch()` or `useFetch()` to fetch data from server routes.', 'Move shared logic to the `shared/` directory.'],
+    ])
+    const serverBlockMessage = `Importing from server is not allowed in ${context}.`
+    const serverSuggestions = ['Use `$fetch()` or `useFetch()` to fetch data from server routes.', 'Move shared logic to the `shared/` directory.']
+    patterns.push([
+      createResolvedPathBlocker(nuxt.options.rootDir, serverDir, serverBlockMessage),
+      serverBlockMessage,
+      serverSuggestions,
     ])
   }
 

--- a/packages/nuxt/test/builder.test.ts
+++ b/packages/nuxt/test/builder.test.ts
@@ -9,17 +9,23 @@ import { build, loadNuxt } from 'nuxt'
 describe('builder:watch', { sequential: true }, async () => {
   const workspaceDir = await findWorkspaceDir()
   const fixtureRoot = join(workspaceDir!, 'test/fixtures/basic')
-  // Test relies on fixture structure: watch targets `other`, `../higher`, and `test` are created at runtime
   const watcherStrategies = ['chokidar', 'chokidar-granular', 'parcel'] as const
   it.each(watcherStrategies)('should restart Nuxt when a file is added with %s strategy', { timeout: 60_000 }, async (watcher) => {
     const rootDir = fixtureRoot
+    // Unique paths per run so we get 'add' events (reused paths would emit 'change')
+    const uniqueId = `${watcher}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    const watchTargets = {
+      inRoot: `test-${uniqueId}`,
+      other: join(rootDir, `other-${uniqueId}`),
+      higher: resolve(rootDir, `../higher-${uniqueId}`),
+    }
     const nuxt = await loadNuxt({
       cwd: rootDir,
       ready: true,
       overrides: {
         experimental: { watcher },
         dev: true,
-        watch: ['test', join(rootDir, 'other'), resolve(rootDir, '../higher')],
+        watch: [watchTargets.inRoot, watchTargets.other, watchTargets.higher],
       },
     })
     let restarts = 0
@@ -37,9 +43,9 @@ describe('builder:watch', { sequential: true }, async () => {
     // Allow watcher to stabilize before writing files (chokidar/parcel need time after ready)
     await new Promise(r => setTimeout(r, 100))
 
-    writeFileSync(resolve(rootDir, '../higher'), 'something')
-    writeFileSync(join(rootDir, 'test'), 'something')
-    writeFileSync(join(rootDir, 'other'), 'something')
+    writeFileSync(watchTargets.higher, 'something')
+    writeFileSync(join(rootDir, watchTargets.inRoot), 'something')
+    writeFileSync(watchTargets.other, 'something')
 
     // Wait for all three file events before closing (hookOnce would only wait for the first)
     const deadline = Date.now() + 5000
@@ -49,12 +55,13 @@ describe('builder:watch', { sequential: true }, async () => {
 
     await nuxt.close()
 
+    const expectedPaths = [
+      `../higher-${uniqueId}`,
+      `other-${uniqueId}`,
+      watchTargets.inRoot,
+    ].sort()
     expect.soft(restarts).toBe(3)
-    expect.soft(events.sort()).toStrictEqual([
-      '../higher',
-      'other',
-      'test',
-    ])
+    expect.soft(events.sort()).toStrictEqual(expectedPaths)
   })
 
   it('should restart Nuxt when a file is added with builder strategy', async () => {

--- a/packages/nuxt/test/builder.test.ts
+++ b/packages/nuxt/test/builder.test.ts
@@ -1,24 +1,18 @@
 import { writeFileSync } from 'node:fs'
-import { mkdir, rm } from 'node:fs/promises'
 
 import type { FSWatcher } from 'vite'
 import { join, relative, resolve } from 'pathe'
 import { findWorkspaceDir } from 'pkg-types'
-import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { build, loadNuxt } from 'nuxt'
 
 describe('builder:watch', { sequential: true }, async () => {
-  const tmpDir = join(await findWorkspaceDir(), '.test/builder-watch')
-  beforeEach(async () => {
-    await rm(tmpDir, { recursive: true, force: true })
-    await mkdir(join(tmpDir, 'project/node_modules'), { recursive: true })
-  })
-  afterAll(async () => {
-    await rm(tmpDir, { recursive: true, force: true })
-  })
+  const workspaceDir = await findWorkspaceDir()
+  const fixtureRoot = join(workspaceDir!, 'test/fixtures/basic')
+  // Test relies on fixture structure: watch targets `other`, `../higher`, and `test` are created at runtime
   const watcherStrategies = ['chokidar', 'chokidar-granular', 'parcel'] as const
-  it.each(watcherStrategies)('should restart Nuxt when a file is added with %s strategy', async (watcher) => {
-    const rootDir = join(tmpDir, 'project')
+  it.each(watcherStrategies)('should restart Nuxt when a file is added with %s strategy', { timeout: 60_000 }, async (watcher) => {
+    const rootDir = fixtureRoot
     const nuxt = await loadNuxt({
       cwd: rootDir,
       ready: true,
@@ -39,6 +33,9 @@ describe('builder:watch', { sequential: true }, async () => {
     })
 
     await build(nuxt)
+
+    // Allow watcher to stabilize before writing files (chokidar/parcel need time after ready)
+    await new Promise(r => setTimeout(r, 100))
 
     const watchPromise = new Promise(resolve => nuxt.hooks.hookOnce('builder:watch', resolve))
     writeFileSync(resolve(rootDir, '../higher'), 'something')

--- a/packages/nuxt/test/builder.test.ts
+++ b/packages/nuxt/test/builder.test.ts
@@ -1,31 +1,31 @@
 import { writeFileSync } from 'node:fs'
+import { mkdir, rm } from 'node:fs/promises'
 
 import type { FSWatcher } from 'vite'
 import { join, relative, resolve } from 'pathe'
 import { findWorkspaceDir } from 'pkg-types'
-import { describe, expect, it } from 'vitest'
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
 import { build, loadNuxt } from 'nuxt'
 
 describe('builder:watch', { sequential: true }, async () => {
-  const workspaceDir = await findWorkspaceDir()
-  const fixtureRoot = join(workspaceDir!, 'test/fixtures/basic')
+  const tmpDir = join(await findWorkspaceDir(), '.test/builder-watch')
+  beforeEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+    await mkdir(join(tmpDir, 'project/node_modules'), { recursive: true })
+  })
+  afterAll(async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+  })
   const watcherStrategies = ['chokidar', 'chokidar-granular', 'parcel'] as const
-  it.each(watcherStrategies)('should restart Nuxt when a file is added with %s strategy', { timeout: 120_000 }, async (watcher) => {
-    const rootDir = fixtureRoot
-    // Unique paths per run so we get 'add' events (reused paths would emit 'change')
-    const uniqueId = `${watcher}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
-    const watchTargets = {
-      inRoot: `test-${uniqueId}`,
-      other: join(rootDir, `other-${uniqueId}`),
-      higher: resolve(rootDir, `../higher-${uniqueId}`),
-    }
+  it.each(watcherStrategies)('should restart Nuxt when a file is added with %s strategy', async (watcher) => {
+    const rootDir = join(tmpDir, 'project')
     const nuxt = await loadNuxt({
       cwd: rootDir,
       ready: true,
       overrides: {
         experimental: { watcher },
         dev: true,
-        watch: [watchTargets.inRoot, watchTargets.other, watchTargets.higher],
+        watch: ['test', join(rootDir, 'other'), resolve(rootDir, '../higher')],
       },
     })
     let restarts = 0
@@ -40,28 +40,20 @@ describe('builder:watch', { sequential: true }, async () => {
 
     await build(nuxt)
 
-    // Allow watcher to stabilize before writing files (chokidar/parcel need time after ready)
-    await new Promise(r => setTimeout(r, 100))
-
-    writeFileSync(watchTargets.higher, 'something')
-    writeFileSync(join(rootDir, watchTargets.inRoot), 'something')
-    writeFileSync(watchTargets.other, 'something')
-
-    // Wait for all three file events before closing (hookOnce would only wait for the first)
-    const deadline = Date.now() + 5000
-    while (events.length < 3 && Date.now() < deadline) {
-      await new Promise(r => setTimeout(r, 50))
-    }
+    const watchPromise = new Promise(resolve => nuxt.hooks.hookOnce('builder:watch', resolve))
+    writeFileSync(resolve(rootDir, '../higher'), 'something')
+    writeFileSync(join(rootDir, 'test'), 'something')
+    writeFileSync(join(rootDir, 'other'), 'something')
+    await watchPromise
 
     await nuxt.close()
 
-    const expectedPaths = [
-      `../higher-${uniqueId}`,
-      `other-${uniqueId}`,
-      watchTargets.inRoot,
-    ].sort()
     expect.soft(restarts).toBe(3)
-    expect.soft(events.sort()).toStrictEqual(expectedPaths)
+    expect.soft(events.sort()).toStrictEqual([
+      '../higher',
+      'other',
+      'test',
+    ])
   })
 
   it('should restart Nuxt when a file is added with builder strategy', async () => {

--- a/packages/nuxt/test/builder.test.ts
+++ b/packages/nuxt/test/builder.test.ts
@@ -37,11 +37,15 @@ describe('builder:watch', { sequential: true }, async () => {
     // Allow watcher to stabilize before writing files (chokidar/parcel need time after ready)
     await new Promise(r => setTimeout(r, 100))
 
-    const watchPromise = new Promise(resolve => nuxt.hooks.hookOnce('builder:watch', resolve))
     writeFileSync(resolve(rootDir, '../higher'), 'something')
     writeFileSync(join(rootDir, 'test'), 'something')
     writeFileSync(join(rootDir, 'other'), 'something')
-    await watchPromise
+
+    // Wait for all three file events before closing (hookOnce would only wait for the first)
+    const deadline = Date.now() + 5000
+    while (events.length < 3 && Date.now() < deadline) {
+      await new Promise(r => setTimeout(r, 50))
+    }
 
     await nuxt.close()
 

--- a/packages/nuxt/test/builder.test.ts
+++ b/packages/nuxt/test/builder.test.ts
@@ -10,7 +10,7 @@ describe('builder:watch', { sequential: true }, async () => {
   const workspaceDir = await findWorkspaceDir()
   const fixtureRoot = join(workspaceDir!, 'test/fixtures/basic')
   const watcherStrategies = ['chokidar', 'chokidar-granular', 'parcel'] as const
-  it.each(watcherStrategies)('should restart Nuxt when a file is added with %s strategy', { timeout: 60_000 }, async (watcher) => {
+  it.each(watcherStrategies)('should restart Nuxt when a file is added with %s strategy', { timeout: 120_000 }, async (watcher) => {
     const rootDir = fixtureRoot
     // Unique paths per run so we get 'add' events (reused paths would emit 'change')
     const uniqueId = `${watcher}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`

--- a/packages/nuxt/test/import-protection.test.ts
+++ b/packages/nuxt/test/import-protection.test.ts
@@ -46,7 +46,11 @@ const nitroAppTests: [id: string, importer: string, isProtected: boolean][] = [
   ['src/composables/foo', 'server/api/bar.ts', true],
   ['../../src/utils/helper', '/root/server/api/bar.ts', true],
   ['~~/shared/utils', 'server/api/bar.ts', false],
+  ['~/server/utils/helper', 'server/api/bar.ts', false],
   ['nitro/h3', 'server/api/bar.ts', false],
+  ['srvx/node', 'node_modules/h3/dist/_entries/node.mjs', false],
+  ['srvx', 'node_modules/h3/dist/something.mjs', false],
+  ['~/server-utils/foo', 'server/api/bar.ts', true],
 ]
 
 const nuxtAppRelativeServerTests: [id: string, importer: string, isProtected: boolean][] = [

--- a/packages/nuxt/test/import-protection.test.ts
+++ b/packages/nuxt/test/import-protection.test.ts
@@ -162,7 +162,7 @@ const defaultNuxtOptions = {
     '~~': '/root/',
     '@@': '/root/',
   },
-} satisfies Partial<NuxtOptions> as NuxtOptions
+} satisfies Partial<NuxtOptions> as unknown as NuxtOptions
 
 const transformWithImportProtection = (id: string, importer: string, context: 'nitro-app' | 'nuxt-app' | 'shared') => {
   const plugin = ImpoundPlugin.rollup({

--- a/packages/nuxt/test/import-protection.test.ts
+++ b/packages/nuxt/test/import-protection.test.ts
@@ -51,6 +51,8 @@ const nitroAppTests: [id: string, importer: string, isProtected: boolean][] = [
   ['srvx/node', 'node_modules/h3/dist/_entries/node.mjs', false],
   ['srvx', 'node_modules/h3/dist/something.mjs', false],
   ['~/server-utils/foo', 'server/api/bar.ts', true],
+  // Custom alias to server-utils (not serverDir) - resolves outside srcDir, not protected
+  ['~~/shared/server-utils/helper', 'server/api/bar.ts', false],
 ]
 
 const nuxtAppRelativeServerTests: [id: string, importer: string, isProtected: boolean][] = [
@@ -60,6 +62,8 @@ const nuxtAppRelativeServerTests: [id: string, importer: string, isProtected: bo
 
 const nuxtAppAliasToServerTests: [id: string, importer: string, isProtected: boolean][] = [
   ['#api/foo', 'components/bar.vue', true],
+  // Custom alias to server-utils (not serverDir) - should NOT be treated as server import
+  ['~~/shared/server-utils/helper', 'components/bar.vue', false],
 ]
 
 describe('import protection', () => {
@@ -114,6 +118,33 @@ describe('import protection', () => {
       expect(result).toBeDefined()
       expect(result).toContain('impound:proxy')
     }
+  })
+
+  it('nitro-app with custom serverDir: ~/backend/ allowed when serverDir is backend', async () => {
+    const customOptions = {
+      ...defaultNuxtOptions,
+      serverDir: '/root/src/backend',
+    } as NuxtOptions
+    const plugin = ImpoundPlugin.rollup({
+      cwd: '/root',
+      patterns: createImportProtectionPatterns({ options: customOptions }, { context: 'nitro-app' }),
+    })
+    const result = (plugin as any).resolveId.call({ error: () => {} }, '~/backend/utils/helper', 'backend/api/bar.ts')
+    expect(result).toBeNull()
+  })
+
+  it('nitro-app with custom serverDir: ~/server-utils/ still protected (sibling of serverDir)', async () => {
+    const customOptions = {
+      ...defaultNuxtOptions,
+      serverDir: '/root/src/backend',
+    } as NuxtOptions
+    const plugin = ImpoundPlugin.rollup({
+      cwd: '/root',
+      patterns: createImportProtectionPatterns({ options: customOptions }, { context: 'nitro-app' }),
+    })
+    const result = (plugin as any).resolveId.call({ error: () => {} }, '~/server-utils/foo', 'backend/api/bar.ts')
+    expect(result).toBeDefined()
+    expect(result).toContain('impound:proxy')
   })
 })
 

--- a/packages/nuxt/test/import-protection.test.ts
+++ b/packages/nuxt/test/import-protection.test.ts
@@ -36,9 +36,74 @@ const testsToTriggerOn = [
   ['node_modules/some-pkg/server/api/helper.ts', 'components/Component.vue', false],
 ] as const
 
+const nitroAppTests: [id: string, importer: string, isProtected: boolean][] = [
+  ['#app', 'server/api/foo.ts', true],
+  ['#build/utils', 'server/api/foo.ts', true],
+  ['~/utils/foo', 'server/api/bar.ts', true],
+  ['@/composables/bar', 'server/api/bar.ts', true],
+  ['~~/src/utils/baz', 'server/api/bar.ts', true],
+  ['@@/src/composables/qux', 'server/api/bar.ts', true],
+  ['src/composables/foo', 'server/api/bar.ts', true],
+  ['../../src/utils/helper', '/root/server/api/bar.ts', true],
+  ['~~/shared/utils', 'server/api/bar.ts', false],
+  ['nitro/h3', 'server/api/bar.ts', false],
+]
+
+const nuxtAppRelativeServerTests: [id: string, importer: string, isProtected: boolean][] = [
+  ['src/server/api/foo.ts', 'components/bar.vue', true],
+  ['../server/api/foo', '/root/src/components/bar.vue', true],
+]
+
+const nuxtAppAliasToServerTests: [id: string, importer: string, isProtected: boolean][] = [
+  ['#api/foo', 'components/bar.vue', true],
+]
+
 describe('import protection', () => {
-  it.each(testsToTriggerOn)('should protect %s', async (id, importer, isProtected) => {
+  it.each(testsToTriggerOn)('should protect %s (nuxt-app)', async (id, importer, isProtected) => {
     const result = await transformWithImportProtection(id, importer, 'nuxt-app')
+    if (!isProtected) {
+      expect(result).toBeNull()
+    } else {
+      expect(result).toBeDefined()
+      expect(result).toContain('impound:proxy')
+    }
+  })
+
+  it.each(nitroAppTests)('nitro-app: %s from %s -> %s', async (id, importer, isProtected) => {
+    const result = await transformWithImportProtection(id, importer, 'nitro-app')
+    if (!isProtected) {
+      expect(result).toBeNull()
+    } else {
+      expect(result).toBeDefined()
+      expect(result).toContain('impound:proxy')
+    }
+  })
+
+  it.each(nuxtAppRelativeServerTests)('nuxt-app server import: %s from %s -> %s', async (id, importer, isProtected) => {
+    const result = await transformWithImportProtection(id, importer, 'nuxt-app')
+    if (!isProtected) {
+      expect(result).toBeNull()
+    } else {
+      expect(result).toBeDefined()
+      expect(result).toContain('impound:proxy')
+    }
+  })
+
+  // Separate setup: we need a custom alias (#api -> server) that modules might add at runtime.
+  it.each(nuxtAppAliasToServerTests)('nuxt-app alias to server: %s -> %s', async (id, importer, isProtected) => {
+    const plugin = ImpoundPlugin.rollup({
+      cwd: '/root',
+      patterns: createImportProtectionPatterns({
+        options: {
+          ...defaultNuxtOptions,
+          alias: {
+            ...defaultNuxtOptions.alias,
+            '#api': '/root/src/server/api',
+          },
+        } as NuxtOptions,
+      }, { context: 'nuxt-app' }),
+    })
+    const result = (plugin as any).resolveId.call({ error: () => {} }, id, importer)
     if (!isProtected) {
       expect(result).toBeNull()
     } else {
@@ -48,19 +113,27 @@ describe('import protection', () => {
   })
 })
 
+const defaultNuxtOptions = {
+  _installedModules: [
+    // @ts-expect-error an incomplete module
+    { entryPath: 'some-nuxt-module' },
+  ],
+  rootDir: '/root',
+  srcDir: '/root/src/',
+  serverDir: '/root/src/server',
+  alias: {
+    '~': '/root/src/',
+    '@': '/root/src/',
+    '~~': '/root/',
+    '@@': '/root/',
+  },
+} satisfies Partial<NuxtOptions> as NuxtOptions
+
 const transformWithImportProtection = (id: string, importer: string, context: 'nitro-app' | 'nuxt-app' | 'shared') => {
   const plugin = ImpoundPlugin.rollup({
     cwd: '/root',
     patterns: createImportProtectionPatterns({
-      options: {
-        _installedModules: [
-          // @ts-expect-error an incomplete module
-          { entryPath: 'some-nuxt-module' },
-        ],
-        rootDir: '/root',
-        srcDir: '/root/src/',
-        serverDir: '/root/src/server',
-      } satisfies Partial<NuxtOptions> as NuxtOptions,
+      options: defaultNuxtOptions,
     }, { context }),
   })
 


### PR DESCRIPTION
Extend import protection to block Vue app aliases (~/, @/, ~~/, @@/) and resolved paths under srcDir in Nitro/shared context, and server directory imports in Vue/nuxt-app context.

Previously, only regex patterns for #server and server path were enforced. Developers could bypass protection using ~/, @/, ~~/, @@/ or relative imports that resolve under srcDir/serverDir. This change adds alias resolution via resolveAlias and path resolution checks so all such imports are consistently blocked.

Alternative: Could have expanded regex coverage, but alias resolution is more robust for custom aliases and relative imports.

Fixes #34576