### PR TITLE
docs: add Nuxt/Vite internals guide for module authors and external deps

### DIFF
--- a/docs/3.guide/1.concepts/7.esm.md
+++ b/docs/3.guide/1.concepts/7.esm.md
@@ -132,6 +132,12 @@ export default defineNuxtConfig({
 
 You may find that you _also_ need to add other packages that are being imported by these libraries.
 
+When using the Vite builder, Nuxt automatically adds transpiled dependencies to `vite.optimizeDeps.exclude` so they are processed by the transform pipeline instead of being pre-bundled.
+
+::read-more{to="/docs/4.x/guide/going-further/vite-internals"}
+See when to use transpile vs optimizeDeps include/exclude in the Vite internals guide.
+::
+
 ### Aliasing Libraries
 
 In some cases, you may also need to manually alias the library to the CJS version, for example:
@@ -304,3 +310,7 @@ const someFile = await resolvePath('my-lib', { url: import.meta.url })
   }
 }
 ```
+
+## See also
+
+- [Nuxt/Vite internals](/docs/4.x/guide/going-further/vite-internals) — virtual modules, transpile, optimizeDeps, imports transform, and import protection for module authors and external dependencies.

--- a/docs/3.guide/4.modules/1.getting-started.md
+++ b/docs/3.guide/4.modules/1.getting-started.md
@@ -34,6 +34,7 @@ This will create a `my-module` project with all the boilerplate necessary to dev
 2. Install dependencies using your favorite package manager
 3. Prepare local files for development using `npm run dev:prepare`
 4. Follow this document to learn more about Nuxt modules
+5. When adding Vite plugins or external dependencies, see [Nuxt/Vite internals](/docs/4.x/guide/going-further/vite-internals) for virtual modules, transpile, optimizeDeps, and import protection
 
 ## Use the Starter Template
 

--- a/docs/3.guide/5.recipes/2.vite-plugin.md
+++ b/docs/3.guide/5.recipes/2.vite-plugin.md
@@ -105,6 +105,14 @@ export default defineNuxtModule({
 If you're writing code that needs to access resolved Vite configuration, you should use the `config` and `configResolved` hooks _within_ your Vite plugin, rather than using Nuxt's `vite:extend`, `vite:extendConfig` and `vite:configResolved`.
 ::
 
+## Common configuration
+
+If a Vite plugin or its dependencies cause ESM/CJS errors, add them to [`build.transpile`](/docs/4.x/api/nuxt-config#transpile). If the dev server discovers new dependencies at runtime and suggests pre-bundling, add them to [`vite.optimizeDeps.include`](/docs/4.x/api/nuxt-config#optimizedeps) in `nuxt.config`.
+
+::read-more{to="/docs/4.x/guide/going-further/vite-internals"}
+When to use transpile vs optimizeDeps include/exclude is explained in the Nuxt/Vite internals guide.
+::
+
 ::read-more{to="/docs/4.x/api/kit/builder#addviteplugin"}
 Read more about `addVitePlugin` in the Nuxt Kit documentation.
 ::

--- a/docs/3.guide/6.going-further/12.vite-internals.md
+++ b/docs/3.guide/6.going-further/12.vite-internals.md
@@ -1,0 +1,162 @@
+---
+title: "Nuxt/Vite Internals"
+description: "Guide for module authors and developers adding external dependencies: virtual modules, transpile, optimizeDeps, imports transform, Nitro plugins, and import protection."
+---
+
+This guide explains Nuxt and Vite internals that matter when adding external dependencies (Vite plugins, local modules) or authoring Nuxt modules.
+
+## Virtual Modules and Alias
+
+### Nuxt virtual modules
+
+Nuxt exposes several virtual or alias-based "modules" resolved at build time:
+
+| Alias / prefix   | Purpose |
+|------------------|--------|
+| `#build`         | Generated files in `.nuxt` (templates). Use for runtime config or module-generated code. |
+| `#imports`       | Auto-imports (composables, utils). Prefer in app code over importing from `#app` when you want tree-shaking. |
+| `#components`    | Auto-registered components. Used by the component resolver. |
+| `#app`           | Nuxt app runtime (composables, etc.). |
+| `virtual:nuxt:*` | Internal VFS resolution; templates are served under this prefix. |
+
+For adding your own generated code, use [`addTemplate`](/docs/4.x/api/kit/templates#addtemplate) so the file lives in the virtual file system and can be imported via `#build/your-file.mjs`.
+
+### When to use addTemplate vs alias
+
+- **addTemplate**: You need a **generated** file (contents depend on config or build). The file is available as `#build/<filename>` and in the VFS as `virtual:nuxt:...`. See [Add Virtual Files](/docs/4.x/guide/modules/recipes-advanced#add-virtual-files) and [Templates](/docs/4.x/api/kit/templates#addtemplate).
+- **alias**: You need to **redirect** an import to an existing path (e.g. a different entry of a dependency). Configure in `nuxt.config`:
+
+```ts
+export default defineNuxtConfig({
+  alias: {
+    'my-lib': 'my-lib/dist/esm.js',
+  },
+})
+```
+
+## Transpile, optimizeDeps: include and exclude
+
+When a dependency does not work as expected, use this decision flow:
+
+```mermaid
+flowchart TD
+    subgraph dep [Зависимость не работает]
+        A[Ошибка ESM/CJS?] --> B[build.transpile]
+        C[Медленная загрузка в dev?] --> D[vite.optimizeDeps.include]
+        E[Конфликт pre-bundling?] --> F[vite.optimizeDeps.exclude]
+    end
+```
+
+### build.transpile
+
+Use when a library breaks because of ESM/CJS format (e.g. Node or bundler cannot handle it). Nuxt will transpile matching dependencies.
+
+```ts
+export default defineNuxtConfig({
+  build: {
+    transpile: ['sample-library'],
+  },
+})
+```
+
+You may need to add other packages that are imported by these libraries. See [ES Modules — Transpiling Libraries](/docs/4.x/guide/concepts/esm#transpiling-libraries).
+
+Nuxt automatically adds transpiled dependencies to Vite's `optimizeDeps.exclude` so they are not pre-bundled and stay in the transform pipeline.
+
+### vite.optimizeDeps.include
+
+Use when Vite discovers new dependencies at runtime and you want to pre-bundle them to avoid full page reloads in dev. Add the package name (and subpaths if needed):
+
+```ts
+export default defineNuxtConfig({
+  vite: {
+    optimizeDeps: {
+      include: ['cross-fetch', 'my-package/subpath'],
+    },
+  },
+})
+```
+
+In modules, prefer extending config inside a Vite plugin with `config` or `configEnvironment` (see [Builder](/docs/4.x/api/kit/builder#extendviteconfig)).
+
+### vite.optimizeDeps.exclude
+
+Use when a dependency must not be pre-bundled (e.g. ESM-only packages that break when pre-bundled). Transpiled dependencies are already excluded by default.
+
+```ts
+export default defineNuxtConfig({
+  vite: {
+    optimizeDeps: {
+      exclude: ['vue-demi'],
+    },
+  },
+})
+```
+
+## Nuxt imports: transform include/exclude
+
+Auto-imports are applied by a transform that runs on resolved files. You can restrict or extend which files are transformed.
+
+- **imports.transform.include**: Array of `RegExp`. If a file path matches, it is eligible for transform (unless excluded).
+- **imports.transform.exclude**: Array of `RegExp`. Matching files are not transformed.
+
+By default, transform runs for files under the build dir and for `.vue` / `.js` (and similar) files. Code inside `node_modules` is only transformed for the `#imports` virtual import, not for full auto-import injection.
+
+Use **include** when you need auto-imports inside code that lives outside the app source (e.g. a Vite plugin that uses Nuxt composables). Use **exclude** to skip transform for specific paths.
+
+```ts
+export default defineNuxtConfig({
+  imports: {
+    transform: {
+      include: [/\.vue$/, /\.(js|ts)$/, /node_modules\/my-vite-plugin/],
+      exclude: [/node_modules\/some-other-lib/],
+    },
+  },
+})
+```
+
+## Nitro event handlers and plugins
+
+Server runtime is powered by [Nitro](https://nitro.build). To extend it:
+
+- **addServerHandler**: Add API routes or middleware. See [Nitro — addServerHandler](/docs/4.x/api/kit/nitro#addserverhandler).
+- **addServerPlugin**: Run code once at server startup and hook into Nitro lifecycle. See [Nitro — addServerPlugin](/docs/4.x/api/kit/nitro#addserverplugin).
+
+Nitro plugins receive `nitroApp` and can use [Nitro runtime hooks](https://nitro.build/guide/plugins): `request`, `response`, `error`, `close`. These are **runtime** hooks (per request or on shutdown), unlike Nuxt hooks which are **build-time**.
+
+Example (in a plugin added via `addServerPlugin`):
+
+```ts
+import { definePlugin } from 'nitro'
+
+export default definePlugin((nitroApp) => {
+  nitroApp.hooks.hook('request', (event) => {
+    // runs at the start of each request
+  })
+  nitroApp.hooks.hook('response', (res, event) => {
+    // runs after the response is created
+  })
+})
+```
+
+## Import protection
+
+Nuxt blocks certain imports in runtime code to avoid using build-only or wrong-context code in the app or server.
+
+- **nuxt-app** (Vue app): You cannot import `nuxt`, `nuxt.config`, `@nuxt/kit`, `nitropack`, or server-only paths. Use `#app` / `#imports` for composables and `$fetch` or `useFetch` for API.
+- **nitro-app** (server): You cannot import Vue app aliases (`#app`, `#build/...` for app-only templates) or app-only code. Use server utilities and `#server` where intended.
+- **shared**: Same as above: no Nuxt/Vite build-time or context-specific imports.
+
+If you see an error like "cannot be imported in server runtime" or "Vue app aliases are not allowed", move the code to the correct layer (app vs server vs shared) or use the suggested alternatives (e.g. `#imports`, `$fetch`) from the error message.
+
+::read-more{to="/docs/4.x/guide/concepts/esm"}
+ES Modules and transpiling dependencies.
+::
+
+::read-more{to="/docs/4.x/guide/recipes/vite-plugin"}
+Using Vite plugins in Nuxt.
+::
+
+::read-more{to="/docs/4.x/api/kit/builder"}
+Nuxt Kit Builder API (extendViteConfig, addVitePlugin).
+::

--- a/docs/3.guide/6.going-further/12.vite-internals.md
+++ b/docs/3.guide/6.going-further/12.vite-internals.md
@@ -65,7 +65,7 @@ Nuxt automatically adds transpiled dependencies to Vite's `optimizeDeps.exclude`
 
 ### vite.optimizeDeps.include
 
-Use when Vite discovers new dependencies at runtime and you want to pre-bundle them to avoid full page reloads in dev. Add the package name (and subpaths if needed):
+Use when Vite discovers new dependencies at runtime, and you want to pre-bundle them to avoid full-page reloads in dev. Add the package name (and subpaths if needed):
 
 ```ts
 export default defineNuxtConfig({
@@ -122,7 +122,7 @@ Server runtime is powered by [Nitro](https://nitro.build). To extend it:
 - **addServerHandler**: Add API routes or middleware. See [Nitro — addServerHandler](/docs/4.x/api/kit/nitro#addserverhandler).
 - **addServerPlugin**: Run code once at server startup and hook into Nitro lifecycle. See [Nitro — addServerPlugin](/docs/4.x/api/kit/nitro#addserverplugin).
 
-Nitro plugins receive `nitroApp` and can use [Nitro runtime hooks](https://nitro.build/guide/plugins): `request`, `response`, `error`, `close`. These are **runtime** hooks (per request or on shutdown), unlike Nuxt hooks which are **build-time**.
+Nitro plugins receive `nitroApp` and can use [Nitro runtime hooks](https://nitro.build/guide/plugins): `request`, `response`, `error`, `close`. These are **runtime** hooks (per request or on shutdown), unlike Nuxt hooks, which are **build-time**.
 
 Example (in a plugin added via `addServerPlugin`):
 

--- a/docs/3.guide/6.going-further/12.vite-internals.md
+++ b/docs/3.guide/6.going-further/12.vite-internals.md
@@ -40,10 +40,10 @@ When a dependency does not work as expected, use this decision flow:
 
 ```mermaid
 flowchart TD
-    subgraph dep [Зависимость не работает]
-        A[Ошибка ESM/CJS?] --> B[build.transpile]
-        C[Медленная загрузка в dev?] --> D[vite.optimizeDeps.include]
-        E[Конфликт pre-bundling?] --> F[vite.optimizeDeps.exclude]
+    subgraph dep [Dependency not working]
+        A[ESM/CJS error?] --> B[build.transpile]
+        C[Slow dev load?] --> D[vite.optimizeDeps.include]
+        E[Pre-bundling conflict?] --> F[vite.optimizeDeps.exclude]
     end
 ```
 

--- a/docs/4.api/6.nuxt-config.md
+++ b/docs/4.api/6.nuxt-config.md
@@ -889,6 +889,33 @@ Whether to scan your `app/composables/` and `app/utils/` directories for composa
 - **Type**: `boolean`
 - **Default:** `true`
 
+### `transform`
+
+Control which files are transformed to inject auto-imports. Useful when code that should get auto-imports lives outside the default app source (e.g. inside `node_modules` for a Vite plugin).
+
+- **Type**: `object`
+- **Properties**:
+  - **include**: `RegExp[]` — If a file path matches any pattern, it is eligible for transform (unless excluded).
+  - **exclude**: `RegExp[]` — Matching files are not transformed.
+
+By default, transform runs for files under the build dir and for `.vue` / `.js` (and similar) files.
+
+**Example**:
+```ts
+export default defineNuxtConfig({
+  imports: {
+    transform: {
+      include: [/node_modules\/my-vite-plugin/],
+      exclude: [/node_modules\/some-lib/],
+    },
+  },
+})
+```
+
+::read-more{to="/docs/4.x/guide/going-further/vite-internals"}
+See the Vite internals guide for when to use transform include/exclude.
+::
+
 ## logLevel
 
 Log level when building logs.
@@ -1748,6 +1775,12 @@ Configuration that will be merged into Vite's configuration for the server build
 - **Default:** `"production"`
 
 ### `optimizeDeps`
+
+Options passed to [Vite's dependency optimization](https://vite.dev/guide/dep-pre-bundling). Use **include** to pre-bundle dependencies that are discovered at runtime (avoids full page reloads in dev). Use **exclude** when a dependency must not be pre-bundled (e.g. ESM-only packages). Dependencies in `build.transpile` are automatically excluded from pre-bundling.
+
+::read-more{to="/docs/4.x/guide/going-further/vite-internals"}
+When to use include vs exclude and how they relate to transpile is explained in the Nuxt/Vite internals guide.
+::
 
 #### `esbuildOptions`
 


### PR DESCRIPTION
Add documentation for Nuxt/Vite internals when adding external dependencies (Vite plugins, local modules) and for module authors, as requested in #29103.

**New guide** (`guide/going-further/vite-internals`):
- Virtual modules and alias (`#build`, `#imports`, `#components`, `#app`; when to use `addTemplate` vs `alias`)
- Transpile vs `optimizeDeps.include` vs `optimizeDeps.exclude` (decision flow, relation: transpile → exclude)
- `imports.transform.include` / `exclude` for auto-imports transform
- Nitro event handlers and plugins (`addServerPlugin`, runtime hooks) with link to Nitro docs
- Import protection (nuxt-app / nitro-app / shared contexts and how to fix errors)

**Updates to existing docs:**
- ESM: note that transpiled deps are added to `optimizeDeps.exclude`; "See also" link to the new guide
- Vite plugin recipe: "Common configuration" section (when to add transpile / optimizeDeps.include) and link to the guide
- nuxt.config: document `imports.transform` (include/exclude); short "when to use include vs exclude" for `vite.optimizeDeps` with link to the guide
- Modules getting started: next step linking to the vite-internals guide

Fixes #29103