### PR TITLE
docs: document server routes dynamic params limitations and workarounds

### DIFF
--- a/docs/2.directory-structure/1.server.md
+++ b/docs/2.directory-structure/1.server.md
@@ -65,9 +65,7 @@ export default defineEventHandler(() => 'Hello World!')
 
 Given the example above, the `/hello` route will be accessible at <http://localhost:3000/hello>.
 
-::note
-Note that currently server routes do not support the full functionality of dynamic routes as [pages](/docs/4.x/directory-structure/app/pages#dynamic-routes) do.
-::
+Server routes follow [rou3](https://github.com/h3js/rou3) conventions (used by Nitro) and do not support the same dynamic route patterns as [pages](/docs/4.x/directory-structure/app/pages#dynamic-routes). In particular, **mixed params** (static text and `[param]` in the same path segment) are not supported: a file like `server/routes/test2-[id]-test2.ts` is treated as a literal path `/test2-[id]-test2`, not as a dynamic route. Use a separate segment for each param (e.g. `server/routes/test2/[id]/test2.ts` → `/test2/:id/test2`) or register routes programmatically. See [Route Parameters](/docs/4.x/directory-structure/server#route-parameters) and [Nitro routing](https://nitro.build/guide/routing) for supported patterns and workarounds.
 
 ## Server Middleware
 
@@ -170,6 +168,8 @@ By default, Nuxt 4 generates a [`tsconfig.json`](/docs/4.x/directory-structure/t
 
 ### Route Parameters
 
+Route path patterns for server routes follow [rou3](https://github.com/h3js/rou3) conventions (used by Nitro under the hood). Each dynamic segment must be either a full segment (e.g. `[id].ts` or `[id]/`) and cannot be mixed with static text in the same segment.
+
 Server routes can use dynamic parameters within brackets in the file name like `/api/hello/[name].ts` and be accessed via `event.context.params`.
 
 ```ts [server/api/hello/[name\\].ts]
@@ -185,6 +185,25 @@ Alternatively, use `getValidatedRouterParams` with a schema validator such as Zo
 ::
 
 You can now universally call this API on `/api/hello/nuxt` and get `Hello, nuxt!`.
+
+#### Dynamic route limitations
+
+Server routes (Nitro/rou3) do not support all dynamic patterns that [pages](/docs/4.x/directory-structure/app/pages#dynamic-routes) support:
+
+| Pattern | Pages | Server routes |
+|---------|-------|----------------|
+| Param in segment | `test-[id]-test.vue` → `/test-:id-test` | Not supported (literal path) |
+| Param as folder | `[id]/index.vue` | `[id]/index.ts` → `/:id` |
+| Param in filename | `[id].vue` | `[id].ts` → `/:id` |
+| Optional param | `[[slug]].vue` | Not documented |
+| Catch-all | `[...slug].vue` | `[...slug].ts` → `/**` |
+
+**Workarounds for mixed segments:** use one param per segment or register the route in config:
+
+- **Nested structure:** `server/routes/test2/[id]/test2.ts` → `/test2/:id/test2`
+- **Programmatic handler:** in `nuxt.config.ts`, under `nitro.handlers`, add `{ route: '/test2/:id/test2', handler: '~/server/routes/test2-id-test2.ts' }`
+
+:read-more{to="https://nitro.build/guide/routing" title="Nitro routing" target="_blank"}
 
 ### Matching HTTP Method
 

--- a/docs/2.directory-structure/1.server.md
+++ b/docs/2.directory-structure/1.server.md
@@ -195,7 +195,7 @@ Server routes (Nitro/rou3) do not support all dynamic patterns that [pages](/doc
 | Param in segment | `test-[id]-test.vue` → `/test-:id-test` | Not supported (literal path) |
 | Param as folder | `[id]/index.vue` | `[id]/index.ts` → `/:id` |
 | Param in filename | `[id].vue` | `[id].ts` → `/:id` |
-| Optional param | `[[slug]].vue` | Not documented |
+| Optional param | `[[slug]].vue` | Not supported |
 | Catch-all | `[...slug].vue` | `[...slug].ts` → `/**` |
 
 **Workarounds for mixed segments:** use one param per segment or register the route in config:

--- a/docs/2.directory-structure/1.server.md
+++ b/docs/2.directory-structure/1.server.md
@@ -168,8 +168,7 @@ By default, Nuxt 4 generates a [`tsconfig.json`](/docs/4.x/directory-structure/t
 
 ### Route Parameters
 
-Route path patterns for server routes follow [rou3](https://github.com/h3js/rou3) conventions (used by Nitro under the hood). Each dynamic segment must be either a full segment (e.g. `[id].ts` or `[id]/`) and cannot be mixed with static text in the same segment.
-
+Route path patterns for server routes follow [rou3](https://github.com/h3js/rou3) conventions (used by Nitro under the hood). Each dynamic segment must be a full segment (e.g. `[id].ts` or `[id]/`) and cannot be mixed with static text in the same segment.
 Server routes can use dynamic parameters within brackets in the file name like `/api/hello/[name].ts` and be accessed via `event.context.params`.
 
 ```ts [server/api/hello/[name\\].ts]

--- a/docs/2.directory-structure/1.server.md
+++ b/docs/2.directory-structure/1.server.md
@@ -201,7 +201,7 @@ Server routes (Nitro/rou3) do not support all dynamic patterns that [pages](/doc
 **Workarounds for mixed segments:** use one param per segment or register the route in config:
 
 - **Nested structure:** `server/routes/test2/[id]/test2.ts` → `/test2/:id/test2`
-- **Programmatic handler:** create the handler in a non-scanned directory (e.g. `server/handlers/test2-id-test2.ts`) so it is not auto-registered as a literal route, then in `nuxt.config.ts`, under `nitro.handlers`, add `{ route: '/test2/:id/test2', handler: '~/server/handlers/test2-id-test2.ts' }`
+- **Programmatic handler:** create the handler in a non-scanned directory (e.g. `server/handlers/test2-id-test2.ts`) so it is not auto-registered as a literal route, then in `nuxt.config.ts`, under `nitro.handlers`, add `{ route: '/test2/:id/test2', handler: '~/server/handlers/test2-id-test2.ts' }`.
 
 :read-more{to="https://nitro.build/guide/routing" title="Nitro routing" target="_blank"}
 

--- a/docs/2.directory-structure/1.server.md
+++ b/docs/2.directory-structure/1.server.md
@@ -201,7 +201,7 @@ Server routes (Nitro/rou3) do not support all dynamic patterns that [pages](/doc
 **Workarounds for mixed segments:** use one param per segment or register the route in config:
 
 - **Nested structure:** `server/routes/test2/[id]/test2.ts` → `/test2/:id/test2`
-- **Programmatic handler:** in `nuxt.config.ts`, under `nitro.handlers`, add `{ route: '/test2/:id/test2', handler: '~/server/routes/test2-id-test2.ts' }`
+- **Programmatic handler:** create the handler in a non-scanned directory (e.g. `server/handlers/test2-id-test2.ts`) so it is not auto-registered as a literal route, then in `nuxt.config.ts`, under `nitro.handlers`, add `{ route: '/test2/:id/test2', handler: '~/server/handlers/test2-id-test2.ts' }`
 
 :read-more{to="https://nitro.build/guide/routing" title="Nitro routing" target="_blank"}
 


### PR DESCRIPTION
Document server route limitations vs pages for dynamic params (mixed segments), and add workarounds.

**Why:** Issue #21781 reports that `server/routes/test2-[id]-test2.ts` returns 404 while `pages/test-[id]-test.vue` works. Server routes use Nitro/rou3 and do not support mixed params in the same path segment; this was only briefly noted and lacked examples and alternatives.

**Changes:**
- Replace the short note with an explicit explanation: mixed params not supported, link to rou3 and Nitro routing
- In Route Parameters: state that patterns follow rou3; add a "Dynamic route limitations" table (pages vs server) and workarounds (nested structure, programmatic `nitro.handlers`)
- Add :read-more to Nitro routing guide

**Refs:** [Nitro routing](https://nitro.build/guide/routing), [rou3](https://github.com/h3js/rou3). Alternative considered: no code change in Nitro (per maintainer comment, differences are by design for performance).

Fixes #21781