### PR TITLE
fix: populate route.meta.layout from appLayout route rule

### DIFF
--- a/packages/nuxt/src/app/plugins/router.ts
+++ b/packages/nuxt/src/app/plugins/router.ts
@@ -263,6 +263,10 @@ export default defineNuxtPlugin<{ route: Route, router: Router }>({
             }
           }
 
+          if (routeRules.appLayout !== undefined && to.meta.layout === undefined) {
+            to.meta.layout = routeRules.appLayout as string | false
+          }
+
           for (const middleware of middlewareEntries) {
             if (import.meta.dev) {
               nuxtApp._processingMiddleware = (middleware as any)._path || true

--- a/packages/nuxt/src/app/plugins/router.ts
+++ b/packages/nuxt/src/app/plugins/router.ts
@@ -263,7 +263,7 @@ export default defineNuxtPlugin<{ route: Route, router: Router }>({
             }
           }
 
-          if (routeRules.appLayout !== undefined && to.meta.layout === undefined) {
+          if (routeRules.appLayout != null && to.meta.layout == null) {
             to.meta.layout = routeRules.appLayout as string | false
           }
 

--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -219,6 +219,10 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
           }
         }
 
+        if (routeRules.appLayout !== undefined && to.meta.layout === undefined) {
+          to.meta.layout = routeRules.appLayout as string | false
+        }
+
         for (const entry of middlewareEntries) {
           const middleware: RouteMiddleware = typeof entry === 'string' ? nuxtApp._middleware.named[entry] || await namedMiddleware[entry]?.().then((r: any) => r.default || r) : entry
 

--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -219,7 +219,7 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
           }
         }
 
-        if (routeRules.appLayout !== undefined && to.meta.layout === undefined) {
+        if (routeRules.appLayout != null && to.meta.layout == null) {
           to.meta.layout = routeRules.appLayout as string | false
         }
 

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -109,6 +109,11 @@ describe('route rules', () => {
     expect(html).toContain('Custom Layout')
   })
 
+  it('should populate route.meta.layout from appLayout route rule', async () => {
+    const html = await $fetch<string>('/route-rules/layout')
+    expect(html).toContain('data-testid="route-meta-layout">custom<')
+  })
+
   it('should not generate payload route rules for non-wildcard ssr: false routes', () => {
     // @ts-expect-error untyped internal property
     const routeRules = useTestContext().nuxt._nitro.options.routeRules

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -59,7 +59,7 @@ describe.skipIf(isStubbed || process.env.SKIP_BUNDLE_SIZE === 'true' || process.
     const serverDir = join(rootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!_libs'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"66.6k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"66.7k"`)
 
     const modules = await analyzeSizes(['_libs/**/*'], serverDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"462k"`)

--- a/test/fixtures/basic/app/pages/route-rules/layout.vue
+++ b/test/fixtures/basic/app/pages/route-rules/layout.vue
@@ -1,5 +1,6 @@
 <template>
   <div>
     <div>Should use layout set in route-rules</div>
+    <div data-testid="route-meta-layout">{{ $route.meta.layout }}</div>
   </div>
 </template>

--- a/test/fixtures/basic/app/pages/route-rules/layout.vue
+++ b/test/fixtures/basic/app/pages/route-rules/layout.vue
@@ -1,6 +1,8 @@
 <template>
   <div>
     <div>Should use layout set in route-rules</div>
-    <div data-testid="route-meta-layout">{{ $route.meta.layout }}</div>
+    <div data-testid="route-meta-layout">
+      {{ $route.meta.layout }}
+    </div>
   </div>
 </template>


### PR DESCRIPTION
## Description

Fixes #34305 — `route.meta.layout` is `undefined` when using `appLayout` in route rules (regression in Nuxt 4.3.1).

## Root Cause

When `appLayout` is configured via route rules (e.g. `routeRules: { '/foo': { appLayout: 'custom' } }`), `NuxtLayout` has a runtime fallback that reads `appLayout` via `routeRulesMatcher` and renders the correct layout. However, `route.meta.layout` was never explicitly populated from the route rule, so any code that checks `route.meta.layout` directly (in middleware, templates, or composables) would see `undefined`.

## Fix

In the `beforeEach` navigation guard (both the pages router plugin and the non-pages router plugin), after the existing `appMiddleware` route rule handling, we now also apply `appLayout`:

```ts
if (routeRules.appLayout !== undefined && to.meta.layout === undefined) {
  to.meta.layout = routeRules.appLayout as string | false
}
```

The `to.meta.layout === undefined` guard ensures explicit `definePageMeta({ layout: 'x' })` values are never overridden.

## Testing

- Added a test asserting that `route.meta.layout` is populated when visiting a route with `appLayout` configured
- Updated the fixture page to expose `$route.meta.layout` for assertion
- Existing test ("should set layout defined in routeRules config") continues to pass

## Related PRs
- #31092 (feat: support appLayout in route rules)
- #33707 (fix: sync internal route before calling page:finish hook)
- #34078 (fix: update NuxtPage when nested NuxtLayout has name=false)