### PR TITLE
fix(vite): add layer app dirs to optimizeDeps.entries for external layers

### DIFF
--- a/docs/1.getting-started/14.layers.md
+++ b/docs/1.getting-started/14.layers.md
@@ -82,6 +82,10 @@ export default defineNuxtConfig({
 
 Nuxt uses [unjs/c12](https://github.com/unjs/c12) and [unjs/giget](https://github.com/unjs/giget) for extending remote layers. Check the documentation for more information and all available options.
 
+:::note
+When you run `nuxt dev`, Vite scans the `app/` directories of layers outside your project to optimize their dependencies. Large external layers can increase the time required for the initial dependency optimization.
+:::
+
 ## Layer Priority
 
 When using multiple layers, it's important to understand the override order. Layers with **higher priority** override layers with lower priority when they define the same files or components.

--- a/packages/vite/src/plugins/layer-dep-optimize.ts
+++ b/packages/vite/src/plugins/layer-dep-optimize.ts
@@ -8,12 +8,13 @@ export function LayerDepOptimizePlugin (nuxt: Nuxt): Plugin | undefined {
     return
   }
 
-  // TODO: this may no longer be needed with most recent vite version
+  // Secondary fix: resolveId triggers optimization when a dep is first imported from a layer.
+  // Primary fix is adding layer app dirs to optimizeDeps.entries in client.ts (see #28631).
   // Identify which layers will need to have an extra resolve step.
   const layerDirs: string[] = []
-  const delimitedRootDir = nuxt.options.rootDir + '/'
+  const rootDirWithSlash = nuxt.options.rootDir + (nuxt.options.rootDir.endsWith('/') ? '' : '/')
   for (const dirs of getLayerDirectories(nuxt)) {
-    if (dirs.app !== nuxt.options.srcDir && !dirs.app.startsWith(delimitedRootDir)) {
+    if (dirs.app !== nuxt.options.srcDir && !dirs.app.startsWith(rootDirWithSlash)) {
       layerDirs.push(dirs.app)
     }
   }

--- a/packages/vite/src/plugins/layer-dep-optimize.ts
+++ b/packages/vite/src/plugins/layer-dep-optimize.ts
@@ -12,7 +12,7 @@ export function LayerDepOptimizePlugin (nuxt: Nuxt): Plugin | undefined {
   // Primary fix is adding layer app dirs to optimizeDeps.entries in client.ts (see #28631).
   // Identify which layers will need to have an extra resolve step.
   const layerDirs: string[] = []
-  const rootDirWithSlash = nuxt.options.rootDir + (nuxt.options.rootDir.endsWith('/') ? '' : '/')
+  const rootDirWithSlash = nuxt.options.rootDir.replace(/\/?$/, '/')
   for (const dirs of getLayerDirectories(nuxt)) {
     if (dirs.app !== nuxt.options.srcDir && !dirs.app.startsWith(rootDirWithSlash)) {
       layerDirs.push(dirs.app)

--- a/packages/vite/src/shared/client.ts
+++ b/packages/vite/src/shared/client.ts
@@ -1,12 +1,38 @@
 import type { Nuxt } from 'nuxt/schema'
-import { resolve } from 'pathe'
+import { join, resolve } from 'pathe'
+
+import { getLayerDirectories } from '@nuxt/kit'
 
 import { getTranspileStrings } from '../utils/transpile.ts'
+
+/**
+ * Collect optimizeDeps entry paths so that dependencies imported from layers
+ * (e.g. CJS packages like slugify used in app.vue from a layer) are discovered
+ * and pre-bundled. Without this, only the main app entry is scanned and
+ * layer-only imports can fail in dev with "does not provide an export named 'default'".
+ * @see https://github.com/nuxt/nuxt/issues/28631
+ */
+export function getOptimizeDepsEntries (nuxt: Nuxt, mainEntry: string): string[] {
+  const entries: string[] = [mainEntry]
+  const rootDirWithSlash = nuxt.options.rootDir + (nuxt.options.rootDir.endsWith('/') ? '' : '/')
+  const srcDir = nuxt.options.srcDir
+
+  for (const dirs of getLayerDirectories(nuxt)) {
+    if (dirs.app === srcDir || dirs.app.startsWith(rootDirWithSlash)) {
+      continue
+    }
+    entries.push(
+      join(dirs.app, '**/*.{vue,ts,tsx,js,jsx,mjs}'),
+    )
+  }
+
+  return entries
+}
 
 export const clientEnvironment = (nuxt: Nuxt, entry: string) => {
   return {
     optimizeDeps: {
-      entries: [entry],
+      entries: getOptimizeDepsEntries(nuxt, entry),
       include: [],
       // We exclude Vue and Nuxt common dependencies from optimization
       // as they already ship ESM.

--- a/packages/vite/src/shared/client.ts
+++ b/packages/vite/src/shared/client.ts
@@ -14,7 +14,7 @@ import { getTranspileStrings } from '../utils/transpile.ts'
  */
 export function getOptimizeDepsEntries (nuxt: Nuxt, mainEntry: string): string[] {
   const entries: string[] = [mainEntry]
-  const rootDirWithSlash = nuxt.options.rootDir + (nuxt.options.rootDir.endsWith('/') ? '' : '/')
+  const rootDirWithSlash = nuxt.options.rootDir.replace(/\/?$/, '/')
   const srcDir = nuxt.options.srcDir
 
   for (const dirs of getLayerDirectories(nuxt)) {

--- a/packages/vite/test/client-optimize-deps-entries.test.ts
+++ b/packages/vite/test/client-optimize-deps-entries.test.ts
@@ -1,0 +1,100 @@
+import { join } from 'pathe'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getOptimizeDepsEntries } from '../src/shared/client.ts'
+
+vi.mock('@nuxt/kit', () => ({
+  getLayerDirectories: vi.fn(),
+}))
+
+const { getLayerDirectories } = await import('@nuxt/kit')
+
+describe('getOptimizeDepsEntries (#28631)', () => {
+  const mainEntry = '/project/.nuxt/entry.mjs'
+
+  beforeEach(() => {
+    vi.mocked(getLayerDirectories).mockReturnValue([])
+  })
+
+  it('includes main entry only when no layers', () => {
+    const nuxt = {
+      options: {
+        rootDir: '/project',
+        srcDir: '/project/app',
+      },
+    } as any
+
+    const entries = getOptimizeDepsEntries(nuxt, mainEntry)
+
+    expect(entries).toEqual([mainEntry])
+  })
+
+  it('does not add glob for main app layer (same as srcDir)', () => {
+    const nuxt = {
+      options: {
+        rootDir: '/project',
+        srcDir: '/project/app',
+      },
+    } as any
+    vi.mocked(getLayerDirectories).mockReturnValue([
+      { app: '/project/app', root: '/project' } as any,
+    ])
+
+    const entries = getOptimizeDepsEntries(nuxt, mainEntry)
+
+    expect(entries).toEqual([mainEntry])
+  })
+
+  it('does not add glob for layer inside rootDir', () => {
+    const nuxt = {
+      options: {
+        rootDir: '/project',
+        srcDir: '/project/app',
+      },
+    } as any
+    vi.mocked(getLayerDirectories).mockReturnValue([
+      { app: '/project/app', root: '/project' } as any,
+      { app: '/project/node_modules/my-layer/app', root: '/project/node_modules/my-layer' } as any,
+    ])
+
+    const entries = getOptimizeDepsEntries(nuxt, mainEntry)
+
+    expect(entries).toEqual([mainEntry])
+  })
+
+  it('adds glob for external layer (app dir outside rootDir)', () => {
+    const nuxt = {
+      options: {
+        rootDir: '/project',
+        srcDir: '/project/app',
+      },
+    } as any
+    const externalApp = '/other/layer/app'
+    vi.mocked(getLayerDirectories).mockReturnValue([
+      { app: '/project/app', root: '/project' } as any,
+      { app: externalApp, root: '/other/layer' } as any,
+    ])
+
+    const entries = getOptimizeDepsEntries(nuxt, mainEntry)
+
+    expect(entries).toHaveLength(2)
+    expect(entries[0]).toBe(mainEntry)
+    expect(entries[1]).toBe(join(externalApp, '**/*.{vue,ts,tsx,js,jsx,mjs}'))
+  })
+
+  it('adds glob for external layer when rootDir has trailing slash', () => {
+    const nuxt = {
+      options: {
+        rootDir: '/project/',
+        srcDir: '/project/app',
+      },
+    } as any
+    vi.mocked(getLayerDirectories).mockReturnValue([
+      { app: '/outside/app', root: '/outside' } as any,
+    ])
+
+    const entries = getOptimizeDepsEntries(nuxt, mainEntry)
+
+    expect(entries).toHaveLength(2)
+    expect(entries[1]).toBe(join('/outside/app', '**/*.{vue,ts,tsx,js,jsx,mjs}'))
+  })
+})


### PR DESCRIPTION
Fix default import errors when `app.vue` or components live in a layer outside `rootDir`. In dev, Vite's dependency scanner only used the main entry, so CJS packages (e.g. `slugify`) imported only from layer code were not pre-bundled and failed with "does not provide an export named 'default'".

**Changes**
- **client.ts**: `getOptimizeDepsEntries()` builds `optimizeDeps.entries` from the main entry plus one glob per *external* layer (`dirs.app` not under `rootDir`), so layer app sources are scanned and their deps optimized.
- **layer-dep-optimize.ts**: Use the same `rootDir` + optional trailing slash logic as in client.ts to avoid double slash; align variable name (`rootDirWithSlash`).
- **Unit tests**: `getOptimizeDepsEntries` is exported and covered (no main-entry-only, no glob for main/in-rootDir layers, glob added for external layer, trailing slash on `rootDir` handled).

`LayerDepOptimizePlugin` remains as a fallback (resolveId-triggered optimization); the primary fix is adding layer entries up front.

Fixes #28631