### PR TITLE
fix: prevent Pre-transform error when renaming component to same import name

### DIFF
--- a/packages/nuxt/src/components/module.ts
+++ b/packages/nuxt/src/components/module.ts
@@ -192,6 +192,7 @@ export default defineNuxtModule<ComponentsOptions>({
     })
 
     // HMR: when a component file is renamed, invalidate importers after generateApp so they resolve to the new path (fixes #31569)
+    // Applies to client and SSR Vite environments so full navigation (SSR + hydration) still resolves `#components` after a rename.
     // Uses `hotUpdate` hook (not deprecated `handleHotUpdate`) which fires for all event types: create, update, delete.
     const getComponentDirs = () => componentDirs
     const UNLINK_INVALIDATE_DELAY_MS = 200
@@ -272,7 +273,7 @@ export default defineNuxtModule<ComponentsOptions>({
           }
           return [...new Set([...options.modules, ...pending.importers])]
         },
-      }, { server: false })
+      })
     }
 
     const serverPlaceholderPath = await findPath(join(distDir, 'app/components/server-placeholder')) ?? join(distDir, 'app/components/server-placeholder')

--- a/packages/nuxt/src/components/module.ts
+++ b/packages/nuxt/src/components/module.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs'
 import { isAbsolute, join, normalize, relative, resolve } from 'pathe'
-import { addBuildPlugin, addImportsSources, addPluginTemplate, addTemplate, addTypeTemplate, addVitePlugin, componentDiagnostics, defineNuxtModule, findPath, getLayerDirectories, resolveAlias, tryUseNuxt } from '@nuxt/kit'
+import { addBuildPlugin, addImportsSources, addPluginTemplate, addTemplate, addTypeTemplate, addVitePlugin, componentDiagnostics, defineNuxtModule, findPath, getLayerDirectories, resolveAlias } from '@nuxt/kit'
 import type { DevEnvironment, EnvironmentModuleNode } from 'vite'
 
 import { resolveModulePath } from 'exsolve'
@@ -197,21 +197,53 @@ export default defineNuxtModule<ComponentsOptions>({
     const getComponentDirs = () => componentDirs
     const UNLINK_INVALIDATE_DELAY_MS = 200
     if (nuxt.options.dev && nuxt.options.builder === '@nuxt/vite-builder') {
-      const pendingUnlinkInvalidations = new Map<string, { importers: EnvironmentModuleNode[], timeoutId?: ReturnType<typeof setTimeout> }>()
+      type PendingUnlinkInvalidation = { importers: EnvironmentModuleNode[], timeoutId?: ReturnType<typeof setTimeout> }
+      // Environment-scoped so client and SSR each keep their own pending rename maps/timers
+      const pendingUnlinkInvalidations = new Map<string, Map<string, PendingUnlinkInvalidation>>()
 
-      const getComponentDirForFile = (filePath: string): string | null => {
+      const getPendingMapForEnvironment = (envName: string) => {
+        let envMap = pendingUnlinkInvalidations.get(envName)
+        if (!envMap) {
+          envMap = new Map()
+          pendingUnlinkInvalidations.set(envName, envMap)
+        }
+        return envMap
+      }
+
+      const getComponentDirForFile = (filePath: string): ComponentsDir | null => {
         const normalized = normalize(filePath)
         for (const dir of getComponentDirs()) {
           const dirPath = normalize(dir.path)
           if (normalized === dirPath || normalized.startsWith(dirPath + '/')) {
-            return dirPath
+            return dir
           }
         }
         return null
       }
 
+      const getFileExtension = (filePath: string) => {
+        const base = filePath.split('/').pop() ?? ''
+        const idx = base.lastIndexOf('.')
+        return idx >= 0 ? base.slice(idx + 1) : ''
+      }
+
+      const isComponentFileForDir = (filePath: string, dir: ComponentsDir) => {
+        const extensions = (dir.extensions?.length
+          ? dir.extensions
+          : nuxt.options.extensions.map(e => e.replace(STARTER_DOT_RE, '')))
+        return extensions.includes(getFileExtension(filePath))
+      }
+
+      const invalidateAndReloadModules = async (environment: DevEnvironment, modules: Iterable<EnvironmentModuleNode>) => {
+        await Promise.all([...modules].map(async (mod) => {
+          environment.moduleGraph.invalidateModule(mod)
+          await environment.reloadModule(mod)
+        }))
+      }
+
       const scheduleUnlinkInvalidation = (dirPath: string, importers: EnvironmentModuleNode[], environment: DevEnvironment) => {
-        const existing = pendingUnlinkInvalidations.get(dirPath)
+        const envMap = getPendingMapForEnvironment(environment.name)
+        const existing = envMap.get(dirPath)
         if (existing?.timeoutId) {
           clearTimeout(existing.timeoutId)
         }
@@ -220,18 +252,26 @@ export default defineNuxtModule<ComponentsOptions>({
           merged.add(m)
         }
         const timeoutId = setTimeout(async () => {
-          pendingUnlinkInvalidations.delete(dirPath)
-          const nuxtInstance = tryUseNuxt()
-          if (nuxtInstance) {
-            await nuxtInstance.callHook('builder:generateApp', {})
+          envMap.delete(dirPath)
+          if (envMap.size === 0) {
+            pendingUnlinkInvalidations.delete(environment.name)
           }
-          for (const mod of merged) {
-            environment.moduleGraph.invalidateModule(mod)
-            await environment.reloadModule(mod)
-          }
+          await nuxt.callHook('builder:generateApp', {})
+          await invalidateAndReloadModules(environment, merged)
         }, UNLINK_INVALIDATE_DELAY_MS)
-        pendingUnlinkInvalidations.set(dirPath, { importers: [...merged], timeoutId })
+        envMap.set(dirPath, { importers: [...merged], timeoutId })
       }
+
+      nuxt.hook('close', () => {
+        for (const envMap of pendingUnlinkInvalidations.values()) {
+          for (const pending of envMap.values()) {
+            if (pending.timeoutId) {
+              clearTimeout(pending.timeoutId)
+            }
+          }
+        }
+        pendingUnlinkInvalidations.clear()
+      })
 
       const collectModulesForPath = (environment: DevEnvironment, file: string): EnvironmentModuleNode[] => {
         const seen = new Set<EnvironmentModuleNode>()
@@ -283,6 +323,8 @@ export default defineNuxtModule<ComponentsOptions>({
           }
 
           const environment = this.environment
+          const componentDirPath = normalize(componentDir.path)
+          const envMap = getPendingMapForEnvironment(environment.name)
 
           if (options.type === 'delete') {
             let componentModules = options.modules
@@ -291,30 +333,24 @@ export default defineNuxtModule<ComponentsOptions>({
             }
             const importers = collectImportersOfComponentModules(componentModules)
             if (importers.size === 0) {
-              const nuxtInstance = tryUseNuxt()
-              const srcRoot = nuxtInstance && normalize(nuxtInstance.options.srcDir!)
-              if (srcRoot) {
-                for (const mod of collectPageLayoutVueModules(environment, srcRoot)) {
-                  importers.add(mod)
-                }
+              const srcRoot = normalize(nuxt.options.srcDir!)
+              for (const mod of collectPageLayoutVueModules(environment, srcRoot)) {
+                importers.add(mod)
               }
             }
             if (importers.size > 0) {
-              scheduleUnlinkInvalidation(componentDir, [...importers], environment)
+              scheduleUnlinkInvalidation(componentDirPath, [...importers], environment)
             }
             return []
           }
 
           // For 'create' or 'update' — check for a pending rename in the same component dir
-          const pending = pendingUnlinkInvalidations.get(componentDir)
+          const pending = envMap.get(componentDirPath)
           if (!pending?.importers.length) {
             // Atomic rename can leave no pending invalidation when delete had no module nodes (path mismatch)
             // or importers were not wired yet. Regenerate the registry and reload the new file + pages that use components.
-            if (options.type === 'create' && normalizedFile.endsWith('.vue')) {
-              const nuxtInstance = tryUseNuxt()
-              if (nuxtInstance) {
-                await nuxtInstance.callHook('builder:generateApp', {})
-              }
+            if (options.type === 'create' && isComponentFileForDir(normalizedFile, componentDir)) {
+              await nuxt.callHook('builder:generateApp', {})
               const mods = new Set<EnvironmentModuleNode>(options.modules)
               for (const m of collectModulesForPath(environment, options.file)) {
                 mods.add(m)
@@ -327,20 +363,15 @@ export default defineNuxtModule<ComponentsOptions>({
                 }
               }
               if (toReload.size === 0) {
-                const srcRoot = normalize(nuxtInstance?.options.srcDir ?? '')
-                if (srcRoot) {
-                  for (const mod of collectPageLayoutVueModules(environment, srcRoot)) {
-                    toReload.add(mod)
-                  }
+                const srcRoot = normalize(nuxt.options.srcDir!)
+                for (const mod of collectPageLayoutVueModules(environment, srcRoot)) {
+                  toReload.add(mod)
                 }
               }
               if (toReload.size === 0) {
                 return
               }
-              for (const mod of toReload) {
-                environment.moduleGraph.invalidateModule(mod)
-                await environment.reloadModule(mod)
-              }
+              await invalidateAndReloadModules(environment, toReload)
               return [...toReload]
             }
             return
@@ -348,13 +379,13 @@ export default defineNuxtModule<ComponentsOptions>({
           if (pending.timeoutId) {
             clearTimeout(pending.timeoutId)
           }
-          pendingUnlinkInvalidations.delete(componentDir)
-
-          await tryUseNuxt()?.callHook('builder:generateApp', {})
-          for (const mod of pending.importers) {
-            environment.moduleGraph.invalidateModule(mod)
-            await environment.reloadModule(mod)
+          envMap.delete(componentDirPath)
+          if (envMap.size === 0) {
+            pendingUnlinkInvalidations.delete(environment.name)
           }
+
+          await nuxt.callHook('builder:generateApp', {})
+          await invalidateAndReloadModules(environment, pending.importers)
           return [...new Set([...options.modules, ...pending.importers])]
         },
       })

--- a/packages/nuxt/src/components/module.ts
+++ b/packages/nuxt/src/components/module.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'node:fs'
 import { isAbsolute, join, normalize, relative, resolve } from 'pathe'
-import { addBuildPlugin, addImportsSources, addPluginTemplate, addTemplate, addTypeTemplate, addVitePlugin, componentDiagnostics, defineNuxtModule, findPath, getLayerDirectories, resolveAlias } from '@nuxt/kit'
+import { addBuildPlugin, addImportsSources, addPluginTemplate, addTemplate, addTypeTemplate, addVitePlugin, componentDiagnostics, defineNuxtModule, findPath, getLayerDirectories, resolveAlias, tryUseNuxt } from '@nuxt/kit'
+import type { ModuleNode } from 'vite'
 
 import { resolveModulePath } from 'exsolve'
 import { distDir } from '../dirs.ts'
@@ -189,6 +190,101 @@ export default defineNuxtModule<ComponentsOptions>({
         return nuxt.callHook('restart')
       }
     })
+
+    // HMR: when a component file is renamed, invalidate importers after generateApp so they resolve to the new path (fixes #31569)
+    const getComponentDirs = () => componentDirs
+    // Delay to allow filesystem "add" after rename before we invalidate (so generateApp sees the new file)
+    const UNLINK_INVALIDATE_DELAY_MS = 200
+    if (nuxt.options.dev && nuxt.options.builder === '@nuxt/vite-builder') {
+      const pendingUnlinkInvalidations = new Map<string, { modules: ModuleNode[], timeoutId?: ReturnType<typeof setTimeout> }>()
+
+      const getComponentDirForFile = (filePath: string): string | null => {
+        const normalized = normalize(filePath)
+        for (const dir of getComponentDirs()) {
+          const dirPath = normalize(dir.path)
+          if (normalized === dirPath || normalized.startsWith(dirPath + '/')) {
+            return dirPath
+          }
+        }
+        return null
+      }
+
+      const scheduleUnlinkInvalidation = (dirPath: string, modules: ModuleNode[], server: { moduleGraph: { invalidateModule: (m: ModuleNode) => void }, reloadModule: (m: ModuleNode) => Promise<void> }) => {
+        const existing = pendingUnlinkInvalidations.get(dirPath)
+        if (existing?.timeoutId) {
+          clearTimeout(existing.timeoutId)
+        }
+        const merged = new Set<ModuleNode>(existing?.modules ?? [])
+        for (const m of modules) {
+          merged.add(m)
+        }
+        const timeoutId = setTimeout(async () => {
+          pendingUnlinkInvalidations.delete(dirPath)
+          const nuxtInstance = tryUseNuxt()
+          if (nuxtInstance) {
+            await nuxtInstance.callHook('builder:generateApp', {})
+          }
+          for (const mod of merged) {
+            server.moduleGraph.invalidateModule(mod)
+            await server.reloadModule(mod)
+          }
+        }, UNLINK_INVALIDATE_DELAY_MS)
+        pendingUnlinkInvalidations.set(dirPath, { modules: [...merged], timeoutId })
+      }
+
+      addVitePlugin({
+        name: 'nuxt:components-rename-hmr',
+        configureServer (server) {
+          server.watcher.on('unlink', (path) => {
+            const normalizedPath = normalize(path)
+            const dirPath = getComponentDirForFile(normalizedPath)
+            if (!dirPath) {
+              return
+            }
+            const mods = server.moduleGraph.getModulesByFile(normalizedPath) || []
+            const importers = new Set<ModuleNode>()
+            for (const mod of mods) {
+              for (const imp of mod.importers) {
+                importers.add(imp)
+              }
+            }
+            if (importers.size > 0) {
+              scheduleUnlinkInvalidation(dirPath, [...importers], server)
+            }
+          })
+        },
+        async handleHotUpdate (ctx) {
+          const normalizedFile = normalize(ctx.file)
+          const componentDir = getComponentDirForFile(normalizedFile)
+          if (!componentDir) {
+            return
+          }
+          const isUnlink = !existsSync(ctx.file)
+          if (isUnlink) {
+            if (ctx.modules.length > 0) {
+              scheduleUnlinkInvalidation(componentDir, ctx.modules, ctx.server)
+            }
+            return []
+          }
+          const pending = pendingUnlinkInvalidations.get(componentDir)
+          if (pending?.timeoutId) {
+            clearTimeout(pending.timeoutId)
+            pendingUnlinkInvalidations.delete(componentDir)
+          }
+          // pending.modules is expected non-empty here (set on unlink with importers)
+          if (!pending?.modules.length) {
+            return
+          }
+          await tryUseNuxt()?.callHook('builder:generateApp', {})
+          for (const mod of pending.modules) {
+            ctx.server.moduleGraph.invalidateModule(mod)
+            await ctx.server.reloadModule(mod)
+          }
+          const allModules = new Set<ModuleNode>([...ctx.modules, ...pending.modules])
+          return [...allModules]
+        },
+      }, { server: false })
+    }
 
     const serverPlaceholderPath = await findPath(join(distDir, 'app/components/server-placeholder')) ?? join(distDir, 'app/components/server-placeholder')
 

--- a/packages/nuxt/src/components/module.ts
+++ b/packages/nuxt/src/components/module.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'node:fs'
 import { isAbsolute, join, normalize, relative, resolve } from 'pathe'
 import { addBuildPlugin, addImportsSources, addPluginTemplate, addTemplate, addTypeTemplate, addVitePlugin, componentDiagnostics, defineNuxtModule, findPath, getLayerDirectories, resolveAlias, tryUseNuxt } from '@nuxt/kit'
-import type { ModuleNode } from 'vite'
+import type { DevEnvironment, EnvironmentModuleNode } from 'vite'
 
 import { resolveModulePath } from 'exsolve'
 import { distDir } from '../dirs.ts'
@@ -192,11 +192,11 @@ export default defineNuxtModule<ComponentsOptions>({
     })
 
     // HMR: when a component file is renamed, invalidate importers after generateApp so they resolve to the new path (fixes #31569)
+    // Uses `hotUpdate` hook (not deprecated `handleHotUpdate`) which fires for all event types: create, update, delete.
     const getComponentDirs = () => componentDirs
-    // Delay to allow filesystem "add" after rename before we invalidate (so generateApp sees the new file)
     const UNLINK_INVALIDATE_DELAY_MS = 200
     if (nuxt.options.dev && nuxt.options.builder === '@nuxt/vite-builder') {
-      const pendingUnlinkInvalidations = new Map<string, { modules: ModuleNode[], timeoutId?: ReturnType<typeof setTimeout> }>()
+      const pendingUnlinkInvalidations = new Map<string, { importers: EnvironmentModuleNode[], timeoutId?: ReturnType<typeof setTimeout> }>()
 
       const getComponentDirForFile = (filePath: string): string | null => {
         const normalized = normalize(filePath)
@@ -209,13 +209,13 @@ export default defineNuxtModule<ComponentsOptions>({
         return null
       }
 
-      const scheduleUnlinkInvalidation = (dirPath: string, modules: ModuleNode[], server: { moduleGraph: { invalidateModule: (m: ModuleNode) => void }, reloadModule: (m: ModuleNode) => Promise<void> }) => {
+      const scheduleUnlinkInvalidation = (dirPath: string, importers: EnvironmentModuleNode[], environment: DevEnvironment) => {
         const existing = pendingUnlinkInvalidations.get(dirPath)
         if (existing?.timeoutId) {
           clearTimeout(existing.timeoutId)
         }
-        const merged = new Set<ModuleNode>(existing?.modules ?? [])
-        for (const m of modules) {
+        const merged = new Set<EnvironmentModuleNode>(existing?.importers ?? [])
+        for (const m of importers) {
           merged.add(m)
         }
         const timeoutId = setTimeout(async () => {
@@ -225,63 +225,52 @@ export default defineNuxtModule<ComponentsOptions>({
             await nuxtInstance.callHook('builder:generateApp', {})
           }
           for (const mod of merged) {
-            server.moduleGraph.invalidateModule(mod)
-            await server.reloadModule(mod)
+            environment.moduleGraph.invalidateModule(mod)
+            await environment.reloadModule(mod)
           }
         }, UNLINK_INVALIDATE_DELAY_MS)
-        pendingUnlinkInvalidations.set(dirPath, { modules: [...merged], timeoutId })
+        pendingUnlinkInvalidations.set(dirPath, { importers: [...merged], timeoutId })
       }
 
       addVitePlugin({
         name: 'nuxt:components-rename-hmr',
-        configureServer (server) {
-          server.watcher.on('unlink', (path) => {
-            const normalizedPath = normalize(path)
-            const dirPath = getComponentDirForFile(normalizedPath)
-            if (!dirPath) {
-              return
-            }
-            const mods = server.moduleGraph.getModulesByFile(normalizedPath) || []
-            const importers = new Set<ModuleNode>()
-            for (const mod of mods) {
+        async hotUpdate (options) {
+          const normalizedFile = normalize(options.file)
+          const componentDir = getComponentDirForFile(normalizedFile)
+          if (!componentDir) {
+            return
+          }
+
+          if (options.type === 'delete') {
+            const importers = new Set<EnvironmentModuleNode>()
+            for (const mod of options.modules) {
               for (const imp of mod.importers) {
                 importers.add(imp)
               }
             }
             if (importers.size > 0) {
-              scheduleUnlinkInvalidation(dirPath, [...importers], server)
-            }
-          })
-        },
-        async handleHotUpdate (ctx) {
-          const normalizedFile = normalize(ctx.file)
-          const componentDir = getComponentDirForFile(normalizedFile)
-          if (!componentDir) {
-            return
-          }
-          const isUnlink = !existsSync(ctx.file)
-          if (isUnlink) {
-            if (ctx.modules.length > 0) {
-              scheduleUnlinkInvalidation(componentDir, ctx.modules, ctx.server)
+              scheduleUnlinkInvalidation(componentDir, [...importers], this.environment)
             }
             return []
           }
+
+          // For 'create' or 'update' — check for a pending rename in the same component dir
           const pending = pendingUnlinkInvalidations.get(componentDir)
-          if (pending?.timeoutId) {
-            clearTimeout(pending.timeoutId)
-            pendingUnlinkInvalidations.delete(componentDir)
-          }
-          // pending.modules is expected non-empty here (set on unlink with importers)
-          if (!pending?.modules.length) {
+          if (!pending?.importers.length) {
             return
           }
-          await tryUseNuxt()?.callHook('builder:generateApp', {})
-          for (const mod of pending.modules) {
-            ctx.server.moduleGraph.invalidateModule(mod)
-            await ctx.server.reloadModule(mod)
+          if (pending.timeoutId) {
+            clearTimeout(pending.timeoutId)
           }
-          const allModules = new Set<ModuleNode>([...ctx.modules, ...pending.modules])
-          return [...allModules]
+          pendingUnlinkInvalidations.delete(componentDir)
+
+          await tryUseNuxt()?.callHook('builder:generateApp', {})
+          const environment = this.environment
+          for (const mod of pending.importers) {
+            environment.moduleGraph.invalidateModule(mod)
+            await environment.reloadModule(mod)
+          }
+          return [...new Set([...options.modules, ...pending.importers])]
         },
       }, { server: false })
     }

--- a/packages/nuxt/src/components/module.ts
+++ b/packages/nuxt/src/components/module.ts
@@ -233,6 +233,46 @@ export default defineNuxtModule<ComponentsOptions>({
         pendingUnlinkInvalidations.set(dirPath, { importers: [...merged], timeoutId })
       }
 
+      const collectModulesForPath = (environment: DevEnvironment, file: string): EnvironmentModuleNode[] => {
+        const seen = new Set<EnvironmentModuleNode>()
+        const out: EnvironmentModuleNode[] = []
+        for (const candidate of new Set([file, normalize(file), resolve(file)])) {
+          const fromFile = environment.moduleGraph.getModulesByFile(candidate)
+          if (!fromFile) {
+            continue
+          }
+          for (const mod of fromFile) {
+            if (!seen.has(mod)) {
+              seen.add(mod)
+              out.push(mod)
+            }
+          }
+        }
+        return out
+      }
+
+      const collectImportersOfComponentModules = (componentModules: EnvironmentModuleNode[]) => {
+        const importers = new Set<EnvironmentModuleNode>()
+        for (const mod of componentModules) {
+          for (const imp of mod.importers) {
+            importers.add(imp)
+          }
+        }
+        return importers
+      }
+
+      const collectPageLayoutVueModules = (environment: DevEnvironment, srcRoot: string): EnvironmentModuleNode[] => {
+        const out: EnvironmentModuleNode[] = []
+        const root = normalize(srcRoot)
+        for (const mod of environment.moduleGraph.idToModuleMap.values()) {
+          const f = mod.file && normalize(mod.file)
+          if (f && f.startsWith(root) && f.endsWith('.vue') && (f.includes('/pages/') || f.includes('/layouts/'))) {
+            out.push(mod)
+          }
+        }
+        return out
+      }
+
       addVitePlugin({
         name: 'nuxt:components-rename-hmr',
         async hotUpdate (options) {
@@ -242,15 +282,25 @@ export default defineNuxtModule<ComponentsOptions>({
             return
           }
 
+          const environment = this.environment
+
           if (options.type === 'delete') {
-            const importers = new Set<EnvironmentModuleNode>()
-            for (const mod of options.modules) {
-              for (const imp of mod.importers) {
-                importers.add(imp)
+            let componentModules = options.modules
+            if (componentModules.length === 0) {
+              componentModules = collectModulesForPath(environment, options.file)
+            }
+            const importers = collectImportersOfComponentModules(componentModules)
+            if (importers.size === 0) {
+              const nuxtInstance = tryUseNuxt()
+              const srcRoot = nuxtInstance && normalize(nuxtInstance.options.srcDir!)
+              if (srcRoot) {
+                for (const mod of collectPageLayoutVueModules(environment, srcRoot)) {
+                  importers.add(mod)
+                }
               }
             }
             if (importers.size > 0) {
-              scheduleUnlinkInvalidation(componentDir, [...importers], this.environment)
+              scheduleUnlinkInvalidation(componentDir, [...importers], environment)
             }
             return []
           }
@@ -258,6 +308,41 @@ export default defineNuxtModule<ComponentsOptions>({
           // For 'create' or 'update' — check for a pending rename in the same component dir
           const pending = pendingUnlinkInvalidations.get(componentDir)
           if (!pending?.importers.length) {
+            // Atomic rename can leave no pending invalidation when delete had no module nodes (path mismatch)
+            // or importers were not wired yet. Regenerate the registry and reload the new file + pages that use components.
+            if (options.type === 'create' && normalizedFile.endsWith('.vue')) {
+              const nuxtInstance = tryUseNuxt()
+              if (nuxtInstance) {
+                await nuxtInstance.callHook('builder:generateApp', {})
+              }
+              const mods = new Set<EnvironmentModuleNode>(options.modules)
+              for (const m of collectModulesForPath(environment, options.file)) {
+                mods.add(m)
+              }
+              const toReload = new Set<EnvironmentModuleNode>()
+              for (const mod of mods) {
+                toReload.add(mod)
+                for (const imp of mod.importers) {
+                  toReload.add(imp)
+                }
+              }
+              if (toReload.size === 0) {
+                const srcRoot = normalize(nuxtInstance?.options.srcDir ?? '')
+                if (srcRoot) {
+                  for (const mod of collectPageLayoutVueModules(environment, srcRoot)) {
+                    toReload.add(mod)
+                  }
+                }
+              }
+              if (toReload.size === 0) {
+                return
+              }
+              for (const mod of toReload) {
+                environment.moduleGraph.invalidateModule(mod)
+                await environment.reloadModule(mod)
+              }
+              return [...toReload]
+            }
             return
           }
           if (pending.timeoutId) {
@@ -266,7 +351,6 @@ export default defineNuxtModule<ComponentsOptions>({
           pendingUnlinkInvalidations.delete(componentDir)
 
           await tryUseNuxt()?.callHook('builder:generateApp', {})
-          const environment = this.environment
           for (const mod of pending.importers) {
             environment.moduleGraph.invalidateModule(mod)
             await environment.reloadModule(mod)

--- a/test/e2e/hmr.test.ts
+++ b/test/e2e/hmr.test.ts
@@ -310,8 +310,7 @@ test.describe('vite-only HMR tests', () => {
       await expect(page.getByTestId('example')).toHaveText('example-test.vue', { timeout: 15000 })
 
       expect(page).toHaveNoErrorsOrWarnings()
-    }
-    finally {
+    } finally {
       restoreExampleTestComponent()
     }
   })

--- a/test/e2e/hmr.test.ts
+++ b/test/e2e/hmr.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync, renameSync, writeFileSync } from 'node:fs'
+import { copyFileSync, existsSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { rm } from 'node:fs/promises'
 import { isWindows } from 'std-env'
@@ -9,6 +9,15 @@ const fixtureDir = fileURLToPath(new URL('../fixtures-temp/hmr', import.meta.url
 const sourceDir = fileURLToPath(new URL('../fixtures/hmr', import.meta.url))
 const siblingLayerFixtureDir = fileURLToPath(new URL('../fixtures-temp/hmr-sibling-layer', import.meta.url))
 const siblingLayerSourceDir = fileURLToPath(new URL('../fixtures/hmr-sibling-layer', import.meta.url))
+
+function restoreExampleTestComponent () {
+  const renamed = join(fixtureDir, 'app/components/example/example-test.vue')
+  const dest = join(fixtureDir, 'app/components/example/test.vue')
+  if (existsSync(renamed)) {
+    unlinkSync(renamed)
+  }
+  copyFileSync(join(sourceDir, 'app/components/example/test.vue'), dest)
+}
 
 test.use({
   nuxt: {
@@ -281,25 +290,30 @@ test.describe('vite-only HMR tests', () => {
   })
 
   test('should support renaming files to same import name (#31569)', async ({ page, goto }) => {
-    await goto('/rename-component')
+    try {
+      await goto('/rename-component')
 
-    await expect(page.getByTestId('example')).toHaveText('test.vue')
+      await expect(page.getByTestId('example')).toHaveText('test.vue')
 
-    renameSync(join(fixtureDir, 'app/components/example/test.vue'), join(fixtureDir, 'app/components/example/example-test.vue'))
+      renameSync(join(fixtureDir, 'app/components/example/test.vue'), join(fixtureDir, 'app/components/example/example-test.vue'))
 
-    writeFileSync(
-      join(fixtureDir, 'app/components/example/example-test.vue'),
-      `<template><div data-testid="example">example-test.vue</div></template>`,
-    )
+      writeFileSync(
+        join(fixtureDir, 'app/components/example/example-test.vue'),
+        `<template><div data-testid="example">example-test.vue</div></template>`,
+      )
 
-    // HMR should update without "Pre-transform error: Failed to load url"
-    await expect(page.getByTestId('example')).toHaveText('example-test.vue', { timeout: 15000 })
+      // HMR should update without "Pre-transform error: Failed to load url"
+      await expect(page.getByTestId('example')).toHaveText('example-test.vue', { timeout: 15000 })
 
-    await goto('/rename-component')
+      await goto('/rename-component')
 
-    await expect(page.getByTestId('example')).toHaveText('example-test.vue', { timeout: 15000 })
+      await expect(page.getByTestId('example')).toHaveText('example-test.vue', { timeout: 15000 })
 
-    expect(page).toHaveNoErrorsOrWarnings()
+      expect(page).toHaveNoErrorsOrWarnings()
+    }
+    finally {
+      restoreExampleTestComponent()
+    }
   })
 
   test('should allow hmr with useAsyncData (#32177)', async ({ page, goto }) => {

--- a/test/e2e/hmr.test.ts
+++ b/test/e2e/hmr.test.ts
@@ -295,9 +295,9 @@ test.describe('vite-only HMR tests', () => {
     // HMR should update without "Pre-transform error: Failed to load url"
     await expect(page.getByTestId('example')).toHaveText('example-test.vue', { timeout: 15000 })
 
-    await page.reload()
+    await goto('/rename-component')
 
-    await expect(page.getByTestId('example')).toHaveText('example-test.vue')
+    await expect(page.getByTestId('example')).toHaveText('example-test.vue', { timeout: 15000 })
 
     expect(page).toHaveNoErrorsOrWarnings()
   })

--- a/test/e2e/hmr.test.ts
+++ b/test/e2e/hmr.test.ts
@@ -280,7 +280,7 @@ test.describe('vite-only HMR tests', () => {
     expect(filteredLogs).toStrictEqual([])
   })
 
-  test.fail('should support renaming files to same import name', async ({ page, goto }) => {
+  test('should support renaming files to same import name (#31569)', async ({ page, goto }) => {
     await goto('/rename-component')
 
     await expect(page.getByTestId('example')).toHaveText('test.vue')
@@ -292,11 +292,14 @@ test.describe('vite-only HMR tests', () => {
       `<template><div data-testid="example">example-test.vue</div></template>`,
     )
 
-    await expect.soft(page.getByTestId('example')).toHaveText('example-test.vue')
+    // HMR should update without "Pre-transform error: Failed to load url"
+    await expect(page.getByTestId('example')).toHaveText('example-test.vue', { timeout: 15000 })
 
     await page.reload()
 
     await expect(page.getByTestId('example')).toHaveText('example-test.vue')
+
+    expect(page).toHaveNoErrorsOrWarnings()
   })
 
   test('should allow hmr with useAsyncData (#32177)', async ({ page, goto }) => {

--- a/test/e2e/hmr.test.ts
+++ b/test/e2e/hmr.test.ts
@@ -302,11 +302,13 @@ test.describe('vite-only HMR tests', () => {
 
       renameSync(join(fixtureDir, 'app/components/example/test.vue'), join(fixtureDir, 'app/components/example/example-test.vue'))
 
-      // Let the watcher emit unlink/create before the follow-up write (rename + write in one turn can coalesce to a single update in Vite)
-      await new Promise(resolve => setTimeout(resolve, 50))
+      const renamedPath = join(fixtureDir, 'app/components/example/example-test.vue')
+      // Wait until the rename is visible on disk so the watcher can emit unlink/create before the follow-up write
+      await expect(() => existsSync(renamedPath)).toBeWithPolling(true, { timeout: 5000, interval: 20 })
+      await new Promise(resolve => setTimeout(resolve, 20))
 
       writeFileSync(
-        join(fixtureDir, 'app/components/example/example-test.vue'),
+        renamedPath,
         `<template><div data-testid="example">example-test.vue</div></template>`,
       )
 

--- a/test/e2e/hmr.test.ts
+++ b/test/e2e/hmr.test.ts
@@ -138,27 +138,32 @@ test('CSS styles persist after nuxt.config restart (#34381)', async ({ fetch }) 
 
 test('HMR for island components', async ({ page, goto }) => {
   const componentPath = join(fixtureDir, 'app/components/islands/HmrComponent.vue')
-  const componentContents = readFileSync(join(sourceDir, 'app/components/islands/HmrComponent.vue'), 'utf8')
-  writeFileSync(componentPath, componentContents)
+  const sourcePath = join(sourceDir, 'app/components/islands/HmrComponent.vue')
+  const componentContents = readFileSync(sourcePath, 'utf8')
+  try {
+    writeFileSync(componentPath, componentContents)
 
-  // Navigate to the page with the island components
-  await goto('/server-component')
+    // Navigate to the page with the island components
+    await goto('/server-component')
 
-  // Test initial state of the component
-  await expect(page.getByTestId('hmr-id')).toHaveText('0')
+    // Test initial state of the component
+    await expect(page.getByTestId('hmr-id')).toHaveText('0')
 
-  // Function to update the component and check for changes
-  const triggerHmr = (number: string) => writeFileSync(componentPath, componentContents.replace('ref(0)', `ref(${number})`))
+    // Function to update the component and check for changes
+    const triggerHmr = (number: string) => writeFileSync(componentPath, componentContents.replace('ref(0)', `ref(${number})`))
 
-  // First edit
-  triggerHmr('1')
-  await expect(page.getByTestId('hmr-id')).toHaveText('1', { timeout: 10000 })
+    // First edit
+    triggerHmr('1')
+    await expect(page.getByTestId('hmr-id')).toHaveText('1', { timeout: 10000 })
 
-  // Second edit to make sure HMR is working consistently
-  triggerHmr('2')
-  await expect(page.getByTestId('hmr-id')).toHaveText('2', { timeout: 10000 })
+    // Second edit to make sure HMR is working consistently
+    triggerHmr('2')
+    await expect(page.getByTestId('hmr-id')).toHaveText('2', { timeout: 10000 })
 
-  expect(page).toHaveNoErrorsOrWarnings()
+    expect(page).toHaveNoErrorsOrWarnings()
+  } finally {
+    writeFileSync(componentPath, componentContents)
+  }
 })
 
 test.describe('vite-only HMR tests', () => {
@@ -296,6 +301,9 @@ test.describe('vite-only HMR tests', () => {
       await expect(page.getByTestId('example')).toHaveText('test.vue')
 
       renameSync(join(fixtureDir, 'app/components/example/test.vue'), join(fixtureDir, 'app/components/example/example-test.vue'))
+
+      // Let the watcher emit unlink/create before the follow-up write (rename + write in one turn can coalesce to a single update in Vite)
+      await new Promise(resolve => setTimeout(resolve, 50))
 
       writeFileSync(
         join(fixtureDir, 'app/components/example/example-test.vue'),


### PR DESCRIPTION
Fix "Pre-transform error: Failed to load url" when renaming a component file to a name that resolves to the same auto-import (e.g. `test.vue` → `example-test.vue` both as `ExampleTest`). After rename, Vite's module graph still had the old URL; on unlink it invalidated dependents which then tried to load the deleted file.

**Approach:** Vite plugin `nuxt:components-rename-hmr` (client only, dev + Vite builder): on component file unlink we store its importers in a map keyed by component dir; on add in the same dir we await `builder:generateApp` so the component list is updated, then invalidate those importers so they re-resolve from `#components` to the new path. A 200ms fallback timeout handles plain file delete (no add).

Uses the modern `hotUpdate` hook (not the deprecated `handleHotUpdate`) and `DevEnvironment`-scoped APIs (`environment.moduleGraph.invalidateModule`/`reloadModule`) for correct typing with `EnvironmentModuleNode`.

E2E test "should support renaming files to same import name" is enabled (was `test.fail`) and uses `goto()` instead of `page.reload()` for the post-HMR assertion — `goto` waits for hydration, which is necessary because `builder:generateApp` triggers Nitro hot-reload making `page.reload()` unreliable.

Fixes #31569