### PR TITLE
feat(nuxt): build lock

### DIFF
--- a/packages/nuxt/src/core/build-lock.ts
+++ b/packages/nuxt/src/core/build-lock.ts
@@ -1,11 +1,9 @@
 import process from 'node:process'
-import { close as fdClose, mkdirSync, openSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
+import { closeSync, mkdirSync, openSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
 import { join, relative } from 'pathe'
 
 const LOCK_FILENAME = '.build.lock'
 
-// Max age before a lock is considered stale regardless of PID status (10 min).
-// Guards against PID recycling on all platforms.
 const MAX_LOCK_AGE_MS = 10 * 60 * 1000
 
 interface LockData {
@@ -36,10 +34,6 @@ function readLock (lockPath: string): LockData | null {
   }
 }
 
-function isLockStale (lock: LockData): boolean {
-  return lockAge(lock) > MAX_LOCK_AGE_MS
-}
-
 function lockAge (lock: LockData): number {
   return Date.now() - new Date(lock.startedAt).getTime()
 }
@@ -53,27 +47,33 @@ function formatAge (ms: number): string {
   return rtf.format(-Math.round(minutes / 60), 'hour')
 }
 
-/**
- * Attempts to acquire an exclusive build lock.
- * Returns a release function on success, or throws with `pid` and `startedAt`
- * properties on the error so callers can implement their own retry strategy.
- */
+function isLockActive (lock: LockData): boolean {
+  if (lock.pid === process.pid) { return false }
+  if (!isProcessAlive(lock.pid)) { return false }
+  if (lockAge(lock) > MAX_LOCK_AGE_MS) { return false }
+  return true
+}
+
+function throwLockError (lock: LockData, lockPath: string, rootDir?: string): never {
+  const age = formatAge(lockAge(lock))
+  const displayPath = rootDir ? relative(rootDir, lockPath) : lockPath
+  const err = new Error(
+    `Another Nuxt build is already running (PID ${lock.pid}, started ${age}).\n`
+    + `If the previous build process crashed, you can remove the stale lock file: ${displayPath}`,
+  ) as Error & BuildLockError
+  err.pid = lock.pid
+  err.startedAt = lock.startedAt
+  throw err
+}
+
 export function acquireBuildLock (buildDir: string, rootDir?: string): () => void {
   mkdirSync(buildDir, { recursive: true })
 
   const lockPath = join(buildDir, LOCK_FILENAME)
 
   const existing = readLock(lockPath)
-  if (existing && existing.pid !== process.pid && isProcessAlive(existing.pid) && !isLockStale(existing)) {
-    const age = formatAge(lockAge(existing))
-    const displayPath = rootDir ? relative(rootDir, lockPath) : lockPath
-    const err = new Error(
-      `Another Nuxt build is already running (PID ${existing.pid}, started ${age}).\n`
-      + `If this is unexpected, you can remove the lock file: ${displayPath}`,
-    ) as Error & BuildLockError
-    err.pid = existing.pid
-    err.startedAt = existing.startedAt
-    throw err
+  if (existing && isLockActive(existing)) {
+    throwLockError(existing, lockPath, rootDir)
   }
 
   const lockData: LockData = {
@@ -81,15 +81,23 @@ export function acquireBuildLock (buildDir: string, rootDir?: string): () => voi
     startedAt: new Date().toISOString(),
   }
 
-  // Use exclusive create (wx) to reduce race window between two concurrent acquires.
-  // If it fails (file exists from stale lock we're overwriting), fall back to normal write.
+  const content = JSON.stringify(lockData, null, 2)
+
   try {
     const fd = openSync(lockPath, 'wx')
-    const content = JSON.stringify(lockData, null, 2)
-    writeFileSync(fd, content)
-    fdClose(fd, () => {})
-  } catch {
-    writeFileSync(lockPath, JSON.stringify(lockData, null, 2))
+    try {
+      writeFileSync(fd, content)
+    } finally {
+      closeSync(fd)
+    }
+  } catch (error: any) {
+    if (error?.code === 'EEXIST') {
+      const current = readLock(lockPath)
+      if (current && isLockActive(current)) {
+        throwLockError(current, lockPath, rootDir)
+      }
+    }
+    writeFileSync(lockPath, content)
   }
 
   let released = false

--- a/packages/nuxt/src/core/build-lock.ts
+++ b/packages/nuxt/src/core/build-lock.ts
@@ -1,6 +1,6 @@
 import process from 'node:process'
 import { close as fdClose, mkdirSync, openSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
-import { join } from 'pathe'
+import { join, relative } from 'pathe'
 
 const LOCK_FILENAME = '.build.lock'
 
@@ -37,8 +37,20 @@ function readLock (lockPath: string): LockData | null {
 }
 
 function isLockStale (lock: LockData): boolean {
-  const age = Date.now() - new Date(lock.startedAt).getTime()
-  return age > MAX_LOCK_AGE_MS
+  return lockAge(lock) > MAX_LOCK_AGE_MS
+}
+
+function lockAge (lock: LockData): number {
+  return Date.now() - new Date(lock.startedAt).getTime()
+}
+
+function formatAge (ms: number): string {
+  const rtf = new Intl.RelativeTimeFormat('en', { numeric: 'always', style: 'long' })
+  const seconds = Math.round(ms / 1000)
+  if (seconds < 60) { return rtf.format(-seconds, 'second') }
+  const minutes = Math.round(seconds / 60)
+  if (minutes < 60) { return rtf.format(-minutes, 'minute') }
+  return rtf.format(-Math.round(minutes / 60), 'hour')
 }
 
 /**
@@ -46,16 +58,18 @@ function isLockStale (lock: LockData): boolean {
  * Returns a release function on success, or throws with `pid` and `startedAt`
  * properties on the error so callers can implement their own retry strategy.
  */
-export function acquireBuildLock (buildDir: string): () => void {
+export function acquireBuildLock (buildDir: string, rootDir?: string): () => void {
   mkdirSync(buildDir, { recursive: true })
 
   const lockPath = join(buildDir, LOCK_FILENAME)
 
   const existing = readLock(lockPath)
   if (existing && existing.pid !== process.pid && isProcessAlive(existing.pid) && !isLockStale(existing)) {
+    const age = formatAge(lockAge(existing))
+    const displayPath = rootDir ? relative(rootDir, lockPath) : lockPath
     const err = new Error(
-      `Another Nuxt build is already running (PID ${existing.pid}, started ${existing.startedAt}).\n`
-      + `If this is unexpected, you can remove the lock file: ${lockPath}`,
+      `Another Nuxt build is already running (PID ${existing.pid}, started ${age}).\n`
+      + `If this is unexpected, you can remove the lock file: ${displayPath}`,
     ) as Error & BuildLockError
     err.pid = existing.pid
     err.startedAt = existing.startedAt

--- a/packages/nuxt/src/core/build-lock.ts
+++ b/packages/nuxt/src/core/build-lock.ts
@@ -1,0 +1,94 @@
+import process from 'node:process'
+import { close as fdClose, mkdirSync, openSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
+import { join } from 'pathe'
+
+const LOCK_FILENAME = '.build.lock'
+
+// Max age before a lock is considered stale regardless of PID status (10 min).
+// Guards against PID recycling on all platforms.
+const MAX_LOCK_AGE_MS = 10 * 60 * 1000
+
+interface LockData {
+  pid: number
+  startedAt: string
+}
+
+export interface BuildLockError {
+  pid: number
+  startedAt: string
+}
+
+function isProcessAlive (pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (err: any) {
+    // EPERM means the process exists but we lack permission to signal it
+    return err?.code === 'EPERM'
+  }
+}
+
+function readLock (lockPath: string): LockData | null {
+  try {
+    return JSON.parse(readFileSync(lockPath, 'utf-8'))
+  } catch {
+    return null
+  }
+}
+
+function isLockStale (lock: LockData): boolean {
+  const age = Date.now() - new Date(lock.startedAt).getTime()
+  return age > MAX_LOCK_AGE_MS
+}
+
+/**
+ * Attempts to acquire an exclusive build lock.
+ * Returns a release function on success, or throws with `pid` and `startedAt`
+ * properties on the error so callers can implement their own retry strategy.
+ */
+export function acquireBuildLock (buildDir: string): () => void {
+  mkdirSync(buildDir, { recursive: true })
+
+  const lockPath = join(buildDir, LOCK_FILENAME)
+
+  const existing = readLock(lockPath)
+  if (existing && existing.pid !== process.pid && isProcessAlive(existing.pid) && !isLockStale(existing)) {
+    const err = new Error(
+      `Another Nuxt build is already running (PID ${existing.pid}, started ${existing.startedAt}).\n`
+      + `If this is unexpected, you can remove the lock file: ${lockPath}`,
+    ) as Error & BuildLockError
+    err.pid = existing.pid
+    err.startedAt = existing.startedAt
+    throw err
+  }
+
+  const lockData: LockData = {
+    pid: process.pid,
+    startedAt: new Date().toISOString(),
+  }
+
+  // Use exclusive create (wx) to reduce race window between two concurrent acquires.
+  // If it fails (file exists from stale lock we're overwriting), fall back to normal write.
+  try {
+    const fd = openSync(lockPath, 'wx')
+    const content = JSON.stringify(lockData, null, 2)
+    writeFileSync(fd, content)
+    fdClose(fd, () => {})
+  } catch {
+    writeFileSync(lockPath, JSON.stringify(lockData, null, 2))
+  }
+
+  let released = false
+  return () => {
+    if (released) { return }
+    released = true
+    try {
+      const current = readLock(lockPath)
+      if (current && current.pid === process.pid) {
+        unlinkSync(lockPath)
+      }
+    } catch {
+      // ignore cleanup errors — file may already be gone (e.g. manual delete, CI cleanup)
+    }
+  }
+}

--- a/packages/nuxt/src/core/builder.ts
+++ b/packages/nuxt/src/core/builder.ts
@@ -9,9 +9,16 @@ import { isDirectory, logger } from '../utils.ts'
 import { generateApp as _generateApp, createApp } from './app.ts'
 import { checkForExternalConfigurationFiles } from './external-config-files.ts'
 import { cleanupCaches, getVueHash } from './cache.ts'
+import { acquireBuildLock } from './build-lock.ts'
 import type { Nuxt, NuxtBuilder, NuxtHooks } from 'nuxt/schema'
 
 export async function build (nuxt: Nuxt): Promise<void> {
+  // Acquire build lock to prevent concurrent builds
+  if (!nuxt.options.dev && !nuxt.options._prepare && !nuxt.options.test) {
+    const releaseLock = acquireBuildLock(nuxt.options.buildDir)
+    nuxt.hooks.hookOnce('close', releaseLock)
+  }
+
   nuxt._perf?.startPhase('app:generate')
   const app = createApp(nuxt)
   nuxt.apps.default = app

--- a/packages/nuxt/src/core/builder.ts
+++ b/packages/nuxt/src/core/builder.ts
@@ -9,16 +9,9 @@ import { isDirectory, logger } from '../utils.ts'
 import { generateApp as _generateApp, createApp } from './app.ts'
 import { checkForExternalConfigurationFiles } from './external-config-files.ts'
 import { cleanupCaches, getVueHash } from './cache.ts'
-import { acquireBuildLock } from './build-lock.ts'
 import type { Nuxt, NuxtBuilder, NuxtHooks } from 'nuxt/schema'
 
 export async function build (nuxt: Nuxt): Promise<void> {
-  // Acquire build lock to prevent concurrent builds
-  if (!nuxt.options.dev && !nuxt.options._prepare && !nuxt.options.test) {
-    const releaseLock = acquireBuildLock(nuxt.options.buildDir)
-    nuxt.hooks.hookOnce('close', releaseLock)
-  }
-
   nuxt._perf?.startPhase('app:generate')
   const app = createApp(nuxt)
   nuxt.apps.default = app

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -810,6 +810,8 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
   if (!options.dev && !options._prepare && !options.test) {
     try {
       releaseBuildLock = acquireBuildLock(options.buildDir, options.rootDir)
+      // Ensure lock is released if process exits before close-hook is registered
+      process.once('exit', () => releaseBuildLock?.())
     } catch (err: any) {
       if (err.pid) { throw err }
     }
@@ -918,6 +920,7 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
 
   if (releaseBuildLock) {
     nuxt.hooks.hookOnce('close', releaseBuildLock)
+    // Release is idempotent, so the process.exit handler registered earlier is harmless
   }
 
   if (perf) {

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -806,12 +806,13 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
 
   const options = await loadNuxtConfig(opts)
 
-  // Acquire build lock as early as possible, before modules/init work.
-  // There is no explicit `_build` flag set by @nuxt/cli, so we infer
-  // build mode by excluding dev, prepare, and test.
   let releaseBuildLock: (() => void) | undefined
   if (!options.dev && !options._prepare && !options.test) {
-    releaseBuildLock = acquireBuildLock(options.buildDir, options.rootDir)
+    try {
+      releaseBuildLock = acquireBuildLock(options.buildDir, options.rootDir)
+    } catch (err: any) {
+      if (err.pid) { throw err }
+    }
   }
 
   if (!perf && typeof options.debug === 'object' && options.debug.perf) {

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -33,6 +33,7 @@ import componentsModule from '../components/module.ts'
 import importsModule from '../imports/module.ts'
 import compilerModule from '../compiler/module.ts'
 
+import { acquireBuildLock } from './build-lock.ts'
 import { restoreCachedBuildId } from './cache.ts'
 import { distDir, pkgDir } from '../dirs.ts'
 import { runtimeDependencies } from '../../meta.js'
@@ -805,6 +806,14 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
 
   const options = await loadNuxtConfig(opts)
 
+  // Acquire build lock as early as possible, before modules/init work.
+  // There is no explicit `_build` flag set by @nuxt/cli, so we infer
+  // build mode by excluding dev, prepare, and test.
+  let releaseBuildLock: (() => void) | undefined
+  if (!options.dev && !options._prepare && !options.test) {
+    releaseBuildLock = acquireBuildLock(options.buildDir, options.rootDir)
+  }
+
   if (!perf && typeof options.debug === 'object' && options.debug.perf) {
     perf = new NuxtPerfProfiler({ startTime: cliStartTime })
   }
@@ -905,6 +914,10 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
   })
 
   const nuxt = createNuxt(options)
+
+  if (releaseBuildLock) {
+    nuxt.hooks.hookOnce('close', releaseBuildLock)
+  }
 
   if (perf) {
     nuxt._perf = perf

--- a/packages/nuxt/test/build-lock.test.ts
+++ b/packages/nuxt/test/build-lock.test.ts
@@ -1,0 +1,110 @@
+import process from 'node:process'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { rm } from 'node:fs/promises'
+import { join } from 'pathe'
+import { findWorkspaceDir } from 'pkg-types'
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { acquireBuildLock } from '../src/core/build-lock.ts'
+import type { BuildLockError } from '../src/core/build-lock.ts'
+
+describe('build-lock', async () => {
+  const workspaceDir = await findWorkspaceDir()
+  const tmpDir = join(workspaceDir, '.test/build-lock')
+
+  beforeEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+    mkdirSync(tmpDir, { recursive: true })
+  })
+
+  afterAll(async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('acquires lock and creates lock file', () => {
+    const release = acquireBuildLock(tmpDir)
+    const lockPath = join(tmpDir, '.build.lock')
+
+    expect(existsSync(lockPath)).toBe(true)
+
+    const data = JSON.parse(readFileSync(lockPath, 'utf-8'))
+    expect(data.pid).toBe(process.pid)
+    expect(data.startedAt).toBeTruthy()
+
+    release()
+    expect(existsSync(lockPath)).toBe(false)
+  })
+
+  it('allows re-acquire by same PID', () => {
+    const release1 = acquireBuildLock(tmpDir)
+    const release2 = acquireBuildLock(tmpDir)
+
+    release2()
+    release1()
+  })
+
+  it('throws when another live process holds the lock', () => {
+    // Use PID 1 (init/systemd) which is always alive
+    const lockPath = join(tmpDir, '.build.lock')
+    writeFileSync(lockPath, JSON.stringify({ pid: 1, startedAt: new Date().toISOString() }))
+
+    try {
+      acquireBuildLock(tmpDir)
+      expect.unreachable('should have thrown')
+    } catch (err: unknown) {
+      const error = err as Error & BuildLockError
+      expect(error.message).toContain('Another Nuxt build is already running')
+      expect(error.message).toContain('remove the lock file')
+      expect(error.pid).toBe(1)
+      expect(error.startedAt).toBeTruthy()
+    }
+  })
+
+  it('overwrites stale lock from dead process', () => {
+    const lockPath = join(tmpDir, '.build.lock')
+    // PID 99999999 should not exist
+    writeFileSync(lockPath, JSON.stringify({ pid: 99999999, startedAt: new Date().toISOString() }))
+
+    const release = acquireBuildLock(tmpDir)
+    const data = JSON.parse(readFileSync(lockPath, 'utf-8'))
+    expect(data.pid).toBe(process.pid)
+
+    release()
+  })
+
+  it('overwrites lock from live process if older than max age', () => {
+    const lockPath = join(tmpDir, '.build.lock')
+    // PID 1 is alive, but timestamp is 20 minutes ago (past MAX_LOCK_AGE_MS of 10 min)
+    const oldDate = new Date(Date.now() - 20 * 60 * 1000).toISOString()
+    writeFileSync(lockPath, JSON.stringify({ pid: 1, startedAt: oldDate }))
+
+    const release = acquireBuildLock(tmpDir)
+    const data = JSON.parse(readFileSync(lockPath, 'utf-8'))
+    expect(data.pid).toBe(process.pid)
+
+    release()
+  })
+
+  it('handles corrupted lock file gracefully', () => {
+    const lockPath = join(tmpDir, '.build.lock')
+    writeFileSync(lockPath, 'not json')
+
+    const release = acquireBuildLock(tmpDir)
+    expect(existsSync(lockPath)).toBe(true)
+
+    release()
+  })
+
+  it('release is idempotent', () => {
+    const release = acquireBuildLock(tmpDir)
+    release()
+    release() // should not throw
+  })
+
+  it('creates buildDir if it does not exist', () => {
+    const nestedDir = join(tmpDir, 'nested/deep/dir')
+    const release = acquireBuildLock(nestedDir)
+
+    expect(existsSync(join(nestedDir, '.build.lock'))).toBe(true)
+    release()
+  })
+})

--- a/packages/nuxt/test/build-lock.test.ts
+++ b/packages/nuxt/test/build-lock.test.ts
@@ -53,16 +53,16 @@ describe('build-lock', async () => {
     } catch (err: unknown) {
       const error = err as Error & BuildLockError
       expect(error.message).toContain('Another Nuxt build is already running')
-      expect(error.message).toContain('remove the lock file')
+      expect(error.message).toContain('remove the stale lock file')
       expect(error.message).toMatch(/started \d+ seconds? ago/)
       expect(error.pid).toBe(1)
       expect(error.startedAt).toBeTruthy()
     }
   })
 
-  it('overwrites stale lock from dead process', () => {
+  it('overwrites lock from dead process', () => {
     const lockPath = join(tmpDir, '.build.lock')
-    // PID 99999999 should not exist
+    // PID 99999999 should not exist — dead process lock is always overwritten
     writeFileSync(lockPath, JSON.stringify({ pid: 99999999, startedAt: new Date().toISOString() }))
 
     const release = acquireBuildLock(tmpDir)
@@ -72,9 +72,9 @@ describe('build-lock', async () => {
     release()
   })
 
-  it('overwrites lock from live process if older than max age', () => {
+  it('overwrites old lock from live process (PID recycling)', () => {
     const lockPath = join(tmpDir, '.build.lock')
-    // PID 1 is alive, but timestamp is 20 minutes ago (past MAX_LOCK_AGE_MS of 10 min)
+    // PID 1 is alive but lock is 20min old — likely a recycled PID, not the original build
     const oldDate = new Date(Date.now() - 20 * 60 * 1000).toISOString()
     writeFileSync(lockPath, JSON.stringify({ pid: 1, startedAt: oldDate }))
 

--- a/packages/nuxt/test/build-lock.test.ts
+++ b/packages/nuxt/test/build-lock.test.ts
@@ -54,6 +54,7 @@ describe('build-lock', async () => {
       const error = err as Error & BuildLockError
       expect(error.message).toContain('Another Nuxt build is already running')
       expect(error.message).toContain('remove the lock file')
+      expect(error.message).toMatch(/started \d+ seconds? ago/)
       expect(error.pid).toBe(1)
       expect(error.startedAt).toBeTruthy()
     }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

When we run agents in our Nuxt projects, they'll tend to verify that their changes have worked correctly by doing a `nuxt build`. When we have multiple agents working on the same project, and they find themselves verifying their changes with `nuxt build`, it's common that they'll hit another agent doing a build (especially if builds take a few minutes). This ends up creating a race condition where agents start debugging why their build failed (due to the new build), and waste a lot of time.

To solve this, we implement a build lock that doesn't allow you to do another build while one is running. This should also catch the issues when running a build, where maybe a local deployment is happening or just unexpected behavior from having multiple builds running.

```sh
❯   pnpm nuxi build playground & pnpm nuxi build playground
[1] 348822
┌  Building Nuxt for production...
┌  Building Nuxt for production...
│
●  Nuxt 4.3.1 (with Nitro 3.0.260311-beta, Vite 8.0.0 and Vue 3.5.30)
│
●  Nuxt 4.3.1 (with Nitro 3.0.260311-beta, Vite 8.0.0 and Vue 3.5.30)

 ERROR  Another Nuxt build is already running (PID 348857, started 0 seconds ago).                                                                                                                                      4:44:57 pm
If this is unexpected, you can remove the lock file: node_modules/.cache/nuxt/.nuxt/.build.lock

    at acquireBuildLock (/home/harlan/pkg/nuxt/packages/nuxt/src/core/build-lock.ts:70:17)
    at loadNuxt (/home/harlan/pkg/nuxt/packages/nuxt/src/core/nuxt.ts:814:56)
    at async Module.loadNuxt (/home/harlan/pkg/nuxt/packages/kit/src/loader/nuxt.ts:35:16)
    at async Object.run (/home/harlan/pkg/nuxt/node_modules/.pnpm/@nuxt+cli@3.34.0_@nuxt+schema@packages+schema_cac@6.7.14_magicast@0.5.2/node_modules/@nuxt/cli/dist/dev-DmuOeJjt.mjs:51:17)
    at async runCommand (/home/harlan/pkg/nuxt/node_modules/.pnpm/citty@0.2.1/node_modules/citty/dist/index.mjs:188:47)
    at async runCommand (/home/harlan/pkg/nuxt/node_modules/.pnpm/citty@0.2.1/node_modules/citty/dist/index.mjs:185:21)
    at async runMain (/home/harlan/pkg/nuxt/node_modules/.pnpm/citty@0.2.1/node_modules/citty/dist/index.mjs:285:10) 
```

:question: While this shouldn't affect real user behavior, it's possible it could, so I'm open to only enabling the check when we detect an agent is running the command. Need feedback on that.	

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
