### PR TITLE
fix(nuxt): allow configured server middlewares to run before scanned

### DIFF
--- a/docs/2.directory-structure/1.server.md
+++ b/docs/2.directory-structure/1.server.md
@@ -67,7 +67,7 @@ Note that currently server routes do not support the full functionality of dynam
 
 Nuxt will automatically read in any file in the `~~/server/middleware` to create server middleware for your project.
 
-Middleware handlers will run on every request before any other server route to add or check headers, log requests, or extend the event's request object. By default, handlers added via `serverHandlers` or `addServerHandler` (e.g. from modules) run **before** these auto-scanned middlewares, so your app middleware can depend on `event.context` set by module middleware. You can change this with [`serverMiddlewareOrder`](/docs/api/nuxt-config#servermiddlewareorder).
+Middleware handlers will run on every request before any other server route to add or check headers, log requests, or extend the event's request object. By default, handlers added via `serverHandlers` or `addServerHandler` (e.g. from modules) run **before** these auto-scanned middlewares, so your app middleware can depend on `event.context` set by module middleware. You can change this with [`serverMiddlewareOrder`](/docs/4.x/api/nuxt-config#servermiddlewareorder).
 
 ::note
 Middleware handlers should not return anything (nor close or respond to the request) and only inspect or extend the request context or throw an error.

--- a/docs/2.directory-structure/1.server.md
+++ b/docs/2.directory-structure/1.server.md
@@ -67,7 +67,7 @@ Note that currently server routes do not support the full functionality of dynam
 
 Nuxt will automatically read in any file in the `~~/server/middleware` to create server middleware for your project.
 
-Middleware handlers will run on every request before any other server route to add or check headers, log requests, or extend the event's request object.
+Middleware handlers will run on every request before any other server route to add or check headers, log requests, or extend the event's request object. By default, handlers added via `serverHandlers` or `addServerHandler` (e.g. from modules) run **before** these auto-scanned middlewares, so your app middleware can depend on `event.context` set by module middleware. You can change this with [`serverMiddlewareOrder`](/docs/api/nuxt-config#servermiddlewareorder).
 
 ::note
 Middleware handlers should not return anything (nor close or respond to the request) and only inspect or extend the request context or throw an error.

--- a/docs/4.api/6.nuxt-config.md
+++ b/docs/4.api/6.nuxt-config.md
@@ -1335,6 +1335,13 @@ export default defineNuxtConfig({
 })
 ```
 
+## serverMiddlewareOrder
+
+Order of server middleware execution. When `configuredFirst` (default), handlers added via `serverHandlers` or `addServerHandler` (e.g. from modules) run **before** auto-scanned handlers from `server/middleware/`. This allows app middleware to depend on `event.context` set by module middleware. Use `scannedFirst` to restore the previous behavior (scanned handlers run first).
+
+- **Type**: `'configuredFirst' | 'scannedFirst'`
+- **Default:** `"configuredFirst"`
+
 ## sourcemap
 
 Configures whether and how sourcemaps are generated for server and/or client bundles.

--- a/packages/nitro-server/src/augments.ts
+++ b/packages/nitro-server/src/augments.ts
@@ -115,6 +115,13 @@ declare module '@nuxt/schema' {
     serverHandlers: NitroEventHandler[]
 
     /**
+     * Order of server middleware execution. When `configuredFirst` (default), handlers added via
+     * `serverHandlers` / `addServerHandler` run before auto-scanned handlers from `server/middleware/`.
+     * Use `scannedFirst` to restore the previous behavior (scanned handlers run first).
+     */
+    serverMiddlewareOrder: 'configuredFirst' | 'scannedFirst'
+
+    /**
      * Nitro development-only server handlers.
      *
      * @see [Nitro server routes documentation](https://nitro.build/guide/routing)
@@ -218,6 +225,13 @@ declare module 'nuxt/schema' {
      * ```
      */
     serverHandlers: NitroEventHandler[]
+
+    /**
+     * Order of server middleware execution. When `configuredFirst` (default), handlers added via
+     * `serverHandlers` / `addServerHandler` run before auto-scanned handlers from `server/middleware/`.
+     * Use `scannedFirst` to restore the previous behavior (scanned handlers run first).
+     */
+    serverMiddlewareOrder: 'configuredFirst' | 'scannedFirst'
 
     /**
      * Nitro development-only server handlers.

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -6,11 +6,11 @@ import process from 'node:process'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import type { Nuxt, NuxtOptions } from '@nuxt/schema'
-import { join, relative, resolve } from 'pathe'
+import { join, normalize, relative, resolve } from 'pathe'
 import { joinURL, withTrailingSlash } from 'ufo'
 import nuxtPkg from 'nuxt/package.json' with { type: 'json' }
 import { build, copyPublicAssets, createDevServer, createNitro, prepare, prerender, writeTypes } from 'nitro/builder'
-import type { Nitro, NitroConfig, NitroRouteRules } from 'nitro/types'
+import type { Nitro, NitroConfig, NitroEventHandler, NitroRouteRules } from 'nitro/types'
 import { addPlugin, addTemplate, addVitePlugin, createIsIgnored, ensureDependencyInstalled, findPath, getDirectory, getLayerDirectories, logger, resolveAlias, resolveIgnorePatterns, resolveNuxtModule } from '@nuxt/kit'
 import escapeRE from 'escape-string-regexp'
 import { defu } from 'defu'
@@ -37,6 +37,83 @@ const logLevelMapReverse = {
 
 const NODE_MODULES_RE = /(?<=\/)node_modules\/(.+)$/
 const PNPM_NODE_MODULES_RE = /\.pnpm\/.+\/node_modules\/(.+)$/
+
+const NUXT_ERROR_ROUTE = '/__nuxt_error'
+
+function normalizeHandlerPath (path: string): string {
+  return normalize(path).replace(/\.[cm]?[tj]sx?$/, '')
+}
+
+/**
+ * Intercepts writes to `nitro.scannedHandlers` so that every time Nitro
+ * rescans server directories, configured middleware handlers are moved
+ * before scanned middleware handlers in the array.
+ *
+ * Nitro internally builds globalMiddleware as `[...scannedHandlers, ...options.handlers]`,
+ * so without this interception, scanned middleware always runs before configured.
+ *
+ * Our strategy: move configured middleware handlers from `options.handlers`
+ * into the front of `scannedHandlers`, so they appear first in the combined list.
+ */
+export function installMiddlewareReorder (nuxt: Nuxt, nitro: Nitro, distDir: string): void {
+  const alias = nitro.options.alias || nuxt.options.alias
+  const configuredPaths = new Set<string>()
+
+  if (nuxt.options.experimental.runtimeBaseURL) {
+    configuredPaths.add(normalizeHandlerPath(resolve(distDir, 'runtime/middleware/base-url')))
+  }
+  for (const h of nuxt.options.serverHandlers) {
+    if (typeof h.handler === 'string') {
+      const resolved = resolve(nuxt.options.rootDir, resolveAlias(h.handler, alias))
+      configuredPaths.add(normalizeHandlerPath(resolved))
+    }
+  }
+
+  if (configuredPaths.size === 0) { return }
+
+  const isConfiguredHandler = (h: NitroEventHandler): boolean => {
+    if (!h.handler || typeof h.handler !== 'string') { return false }
+    return configuredPaths.has(normalizeHandlerPath(h.handler))
+  }
+
+  // Intercept scannedHandlers assignment via a property trap.
+  // Every time Nitro sets scannedHandlers (after scanning dirs), we
+  // move configured middleware from options.handlers into the front of
+  // scannedHandlers so that the sync() call produces the right order.
+  let _scannedHandlers = nitro.scannedHandlers || []
+
+  // Build configured middleware handlers once at install time
+  const configuredMiddlewareSnapshot: NitroEventHandler[] = []
+  for (const h of nitro.options.handlers) {
+    if (h.middleware && isConfiguredHandler(h)) {
+      configuredMiddlewareSnapshot.push(h)
+    }
+  }
+
+  if (configuredMiddlewareSnapshot.length === 0) { return }
+
+  const configuredHandlerPaths = new Set(
+    configuredMiddlewareSnapshot.map(h => normalizeHandlerPath(h.handler as string)),
+  )
+
+  Object.defineProperty(nitro, 'scannedHandlers', {
+    get: () => _scannedHandlers,
+    set (value: NitroEventHandler[]) {
+      // Filter out configured middleware from incoming scanned handlers (avoid duplicates)
+      const filteredValue = value.filter((h) => {
+        if (!h.middleware || typeof h.handler !== 'string') { return true }
+        return !configuredHandlerPaths.has(normalizeHandlerPath(h.handler))
+      })
+      _scannedHandlers = [...configuredMiddlewareSnapshot, ...filteredValue]
+    },
+    configurable: true,
+    enumerable: true,
+  })
+
+  // Apply reorder for current state
+  nitro.scannedHandlers = nitro.scannedHandlers
+}
+
 export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
   // Resolve config
   const layerDirs = getLayerDirectories(nuxt)
@@ -867,6 +944,11 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
     lazy: true,
     handler: resolve(distDir, 'runtime/handlers/renderer'),
   })
+
+  // Run configured server handlers before scanned ones (issue #26012)
+  if (nuxt.options.serverMiddlewareOrder !== 'scannedFirst') {
+    installMiddlewareReorder(nuxt, nitro, distDir)
+  }
 
   // TODO: refactor into a module when this is more full-featured
   // add Chrome devtools integration

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -111,7 +111,8 @@ export function installMiddlewareReorder (nuxt: Nuxt, nitro: Nitro, distDir: str
   })
 
   // Apply reorder for current state
-  nitro.scannedHandlers = nitro.scannedHandlers
+  const currentScannedHandlers = nitro.scannedHandlers
+  nitro.scannedHandlers = currentScannedHandlers
 }
 
 export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -84,11 +84,13 @@ export function installMiddlewareReorder (nuxt: Nuxt, nitro: Nitro, distDir: str
 
   // Build configured middleware handlers once at install time
   const configuredMiddlewareSnapshot: NitroEventHandler[] = []
-  for (const h of nitro.options.handlers) {
+  nitro.options.handlers = nitro.options.handlers.filter((h) => {
     if (h.middleware && isConfiguredHandler(h)) {
       configuredMiddlewareSnapshot.push(h)
+      return false
     }
-  }
+    return true
+  })
 
   if (configuredMiddlewareSnapshot.length === 0) { return }
 

--- a/packages/nitro-server/test/server-middleware-order.test.ts
+++ b/packages/nitro-server/test/server-middleware-order.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest'
+import { resolve } from 'pathe'
+import type { Nuxt } from '@nuxt/schema'
+import type { Nitro, NitroEventHandler } from 'nitro/types'
+import { installMiddlewareReorder } from '../src/index'
+
+function createMocks (options: {
+  serverHandlers: NitroEventHandler[]
+  optionsHandlers: NitroEventHandler[]
+  scannedHandlers: NitroEventHandler[]
+  runtimeBaseURL?: boolean
+}) {
+  const rootDir = resolve('/fake/root')
+  const distDir = resolve('/fake/nuxt/dist')
+
+  const nuxt = {
+    options: {
+      rootDir,
+      serverMiddlewareOrder: 'configuredFirst' as const,
+      serverHandlers: options.serverHandlers,
+      experimental: { runtimeBaseURL: options.runtimeBaseURL ?? false },
+      alias: { '#server': resolve(rootDir, 'server') + '/' },
+    },
+  } as unknown as Nuxt
+
+  const nitro = {
+    options: {
+      handlers: [...options.optionsHandlers],
+      alias: { '#server': resolve(rootDir, 'server') + '/' },
+    },
+    scannedHandlers: [...options.scannedHandlers],
+    routing: { sync: () => {}, globalMiddleware: [] },
+  } as unknown as Nitro
+
+  return { nuxt, nitro, distDir, rootDir }
+}
+
+describe('server middleware order (issue #26012)', () => {
+  it('moves configured middleware to front of scannedHandlers', () => {
+    const rootDir = resolve('/fake/root')
+    const configuredHandler = resolve(rootDir, 'server/utils/configured.ts')
+    const scannedHandler = resolve(rootDir, 'server/middleware/scanned.ts')
+
+    const { nuxt, nitro, distDir } = createMocks({
+      serverHandlers: [
+        { middleware: true, handler: '#server/utils/configured.ts' },
+      ],
+      optionsHandlers: [
+        { route: '/__nuxt_error', handler: resolve('/fake/nuxt/dist', 'runtime/handlers/renderer') },
+        { route: '/**', handler: configuredHandler, middleware: true },
+      ],
+      scannedHandlers: [
+        { route: '/**', handler: scannedHandler, middleware: true },
+      ],
+    })
+
+    installMiddlewareReorder(nuxt, nitro, distDir)
+
+    expect(nitro.scannedHandlers[0].handler).toBe(configuredHandler)
+    expect(nitro.scannedHandlers[1].handler).toBe(scannedHandler)
+  })
+
+  it('reorders correctly on subsequent scannedHandlers assignments (simulating rescan)', () => {
+    const rootDir = resolve('/fake/root')
+    const configuredHandler = resolve(rootDir, 'server/utils/auth.ts')
+    const scannedHandler1 = resolve(rootDir, 'server/middleware/logger.ts')
+    const scannedHandler2 = resolve(rootDir, 'server/middleware/cors.ts')
+
+    const { nuxt, nitro, distDir } = createMocks({
+      serverHandlers: [
+        { middleware: true, handler: '#server/utils/auth.ts' },
+      ],
+      optionsHandlers: [
+        { route: '/**', handler: configuredHandler, middleware: true },
+      ],
+      scannedHandlers: [
+        { route: '/**', handler: scannedHandler1, middleware: true },
+      ],
+    })
+
+    installMiddlewareReorder(nuxt, nitro, distDir)
+
+    expect(nitro.scannedHandlers[0].handler).toBe(configuredHandler)
+    expect(nitro.scannedHandlers[1].handler).toBe(scannedHandler1)
+
+    // Simulate Nitro rescan — configured should still be first
+    nitro.scannedHandlers = [
+      { route: '/**', handler: scannedHandler1, middleware: true },
+      { route: '/**', handler: scannedHandler2, middleware: true },
+    ]
+
+    expect(nitro.scannedHandlers[0].handler).toBe(configuredHandler)
+    expect(nitro.scannedHandlers[1].handler).toBe(scannedHandler1)
+    expect(nitro.scannedHandlers[2].handler).toBe(scannedHandler2)
+  })
+
+  it('does nothing when there are no configured middleware handlers', () => {
+    const rootDir = resolve('/fake/root')
+    const scannedHandler = resolve(rootDir, 'server/middleware/scanned.ts')
+
+    const { nuxt, nitro, distDir } = createMocks({
+      serverHandlers: [],
+      optionsHandlers: [
+        { route: '/__nuxt_error', handler: 'error' },
+      ],
+      scannedHandlers: [
+        { route: '/**', handler: scannedHandler, middleware: true },
+      ],
+    })
+
+    installMiddlewareReorder(nuxt, nitro, distDir)
+
+    expect(nitro.scannedHandlers.length).toBe(1)
+    expect(nitro.scannedHandlers[0].handler).toBe(scannedHandler)
+  })
+})

--- a/packages/nitro-server/test/server-middleware-order.test.ts
+++ b/packages/nitro-server/test/server-middleware-order.test.ts
@@ -56,8 +56,12 @@ describe('server middleware order (issue #26012)', () => {
 
     installMiddlewareReorder(nuxt, nitro, distDir)
 
-    expect(nitro.scannedHandlers[0].handler).toBe(configuredHandler)
-    expect(nitro.scannedHandlers[1].handler).toBe(scannedHandler)
+    expect(nitro.scannedHandlers).toHaveLength(2)
+    const [first, second] = nitro.scannedHandlers
+    expect(first).toBeDefined()
+    expect(second).toBeDefined()
+    expect(first!.handler).toBe(configuredHandler)
+    expect(second!.handler).toBe(scannedHandler)
   })
 
   it('reorders correctly on subsequent scannedHandlers assignments (simulating rescan)', () => {

--- a/packages/nitro-server/test/server-middleware-order.test.ts
+++ b/packages/nitro-server/test/server-middleware-order.test.ts
@@ -43,7 +43,7 @@ describe('server middleware order (issue #26012)', () => {
 
     const { nuxt, nitro, distDir } = createMocks({
       serverHandlers: [
-        { middleware: true, handler: '#server/utils/configured.ts' },
+        { route: '/**', middleware: true, handler: '#server/utils/configured.ts' },
       ],
       optionsHandlers: [
         { route: '/__nuxt_error', handler: resolve('/fake/nuxt/dist', 'runtime/handlers/renderer') },

--- a/packages/schema/src/config/nitro.ts
+++ b/packages/schema/src/config/nitro.ts
@@ -45,4 +45,10 @@ export default defineResolvers({
   routeRules: {},
   serverHandlers: [],
   devServerHandlers: [],
+  /**
+   * Order of server middleware execution. When `configuredFirst` (default), handlers added via
+   * `serverHandlers` / `addServerHandler` run before auto-scanned handlers from `server/middleware/`.
+   * Use `scannedFirst` to restore the previous behavior (scanned handlers run first).
+   */
+  serverMiddlewareOrder: 'configuredFirst',
 })

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1637,6 +1637,13 @@ describe('extends support', () => {
     })
   })
 
+  describe('server middleware order (issue #26012)', () => {
+    it('runs configured serverHandlers before scanned server/middleware when serverMiddlewareOrder is configuredFirst', async () => {
+      const { headers } = await fetch('/')
+      expect(headers.get('x-server-middleware-order')).toEqual('configured-first')
+    })
+  })
+
   describe('app', () => {
     it('extends foo/app/router.options & bar/app/router.options', async () => {
       const html: string = await $fetch<string>('/')

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -212,6 +212,9 @@ export default withMatrix({
     },
   },
   telemetry: false, // for testing telemetry types - it is auto-disabled in tests
+  serverHandlers: [
+    { middleware: true, handler: '#server/utils/configured-middleware.ts' },
+  ],
   hooks: {
     'webpack:config' (configs) {
       // in order to test bigint serialization we need to set target to a more modern one

--- a/test/fixtures/basic/server/middleware/order-check.ts
+++ b/test/fixtures/basic/server/middleware/order-check.ts
@@ -1,0 +1,7 @@
+import type { H3Event } from 'nitro/h3'
+
+export default defineEventHandler((event: H3Event) => {
+  if (event.context.fromConfiguredMiddleware) {
+    event.res.headers.set('x-server-middleware-order', 'configured-first')
+  }
+})

--- a/test/fixtures/basic/server/utils/configured-middleware.ts
+++ b/test/fixtures/basic/server/utils/configured-middleware.ts
@@ -1,0 +1,5 @@
+import type { H3Event } from 'nitro/h3'
+
+export default defineEventHandler((event: H3Event) => {
+  event.context.fromConfiguredMiddleware = true
+})


### PR DESCRIPTION
Allow modules and application configs to register server middleware that
executes **before** auto-scanned handlers from `server/middleware/`.

### Problem

Nitro internally assembles global middleware as
`[...scannedHandlers, ...options.handlers]`, which means auto-scanned
`server/middleware/` handlers always run before manually configured ones
(via `serverHandlers` config or `addServerHandler`). This makes it
impossible for modules to guarantee their middleware runs first — a
common need when middleware sets `event.context` properties consumed by
downstream handlers.

### Solution

Adds a new `serverMiddlewareOrder` option:

| Value | Behavior |
|---|---|
| `'configuredFirst'` (default) | Handlers from `serverHandlers` / `addServerHandler` run before scanned `server/middleware/` |
| `'scannedFirst'` | Previous behavior — scanned handlers run first |

Implementation uses an `Object.defineProperty` trap on
`nitro.scannedHandlers` to prepend configured middleware on every scan
cycle, ensuring correct order even during dev-mode hot reloads.

### Changes

- **`packages/schema/src/config/nitro.ts`** — schema definition for `serverMiddlewareOrder`
- **`packages/nitro-server/src/augments.ts`** — type augmentation
- **`packages/nitro-server/src/index.ts`** — `installMiddlewareReorder()` function and hook
- **`packages/nitro-server/test/server-middleware-order.test.ts`** — unit tests (initial order, rescan, no-op)
- **`test/basic.test.ts`** — E2E test validating header set by ordered middleware
- **`test/fixtures/basic/`** — test fixtures (configured + scanned middleware pair)
- **`docs/`** — documentation for the new option

Closes #26012