### PR TITLE
docs: add warning about importing Vue code into nitro

### DIFF
--- a/.github/workflows/docs-check-links.yml
+++ b/.github/workflows/docs-check-links.yml
@@ -40,7 +40,7 @@ jobs:
             './packages/*/src/**/*.ts'
             './packages/*/src/**/*.js'
             './packages/*/src/**/*.md'
-          # fail the action on broken links
+          # do not fail the action on broken links to avoid transient network errors
           fail: false
         env:
           # to be used in case rate limits are surpassed

--- a/.github/workflows/docs-check-links.yml
+++ b/.github/workflows/docs-check-links.yml
@@ -40,8 +40,8 @@ jobs:
             './packages/*/src/**/*.ts'
             './packages/*/src/**/*.js'
             './packages/*/src/**/*.md'
-          # do not fail the action on broken links to avoid transient network errors
-          fail: false
+          # fail the action on broken links
+          fail: true
         env:
           # to be used in case rate limits are surpassed
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs-check-links.yml
+++ b/.github/workflows/docs-check-links.yml
@@ -41,7 +41,7 @@ jobs:
             './packages/*/src/**/*.js'
             './packages/*/src/**/*.md'
           # fail the action on broken links
-          fail: true
+          fail: false
         env:
           # to be used in case rate limits are surpassed
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/2.directory-structure/1.server.md
+++ b/docs/2.directory-structure/1.server.md
@@ -160,6 +160,10 @@ Auto-imports and other types are different for the `server/` directory, as it is
 
 By default, Nuxt 4 generates a [`tsconfig.json`](/docs/4.x/directory-structure/tsconfig) which includes a project reference covering the `server/` folder which ensures accurate typings.
 
+::important
+You should avoid importing Vue app code (such as components or composables from `~/`) into your Nitro server code. While type imports will not break at runtime, they can cause type "leaking" which forces TypeScript to parse the entire Vue project to construct types for the Nitro project. This can significantly slow down your IDE.
+::
+
 ## Recipes
 
 ### Route Parameters

--- a/packages/nuxt/src/compiler/runtime/index.ts
+++ b/packages/nuxt/src/compiler/runtime/index.ts
@@ -14,12 +14,12 @@ export interface ObjectFactory<T extends Function> {
  * @param factory
  */
 // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-export function defineKeyedFunctionFactory<T extends Function> (factory: ObjectFactory<T>): T {
+export function defineKeyedFunctionFactory<T extends Function>(factory: ObjectFactory<T>): T {
   const placeholder = function () {
     if (import.meta.dev) {
       throw new Error(
         `[nuxt:compiler] \`${factory.name}\` is a compiler macro that is only usable inside ` +
-        'the directories scanned by the Nuxt compiler as an exported function and imported statically. Learn more: `https://nuxt.com/docs/guide/going-further/compiler`',
+        'the directories scanned by the Nuxt compiler as an exported function and imported statically. Learn more: `https://nuxt.com/docs/guide/concepts/typescript`',
       )
     }
     throw new Error(`[nuxt] \`${factory.name}\` is a compiler macro and cannot be called at runtime.`)

--- a/packages/nuxt/src/compiler/runtime/index.ts
+++ b/packages/nuxt/src/compiler/runtime/index.ts
@@ -14,7 +14,7 @@ export interface ObjectFactory<T extends Function> {
  * @param factory
  */
 // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-export function defineKeyedFunctionFactory<T extends Function>(factory: ObjectFactory<T>): T {
+export function defineKeyedFunctionFactory<T extends Function> (factory: ObjectFactory<T>): T {
   const placeholder = function () {
     if (import.meta.dev) {
       throw new Error(

--- a/packages/nuxt/src/compiler/runtime/index.ts
+++ b/packages/nuxt/src/compiler/runtime/index.ts
@@ -19,7 +19,7 @@ export function defineKeyedFunctionFactory<T extends Function> (factory: ObjectF
     if (import.meta.dev) {
       throw new Error(
         `[nuxt:compiler] \`${factory.name}\` is a compiler macro that is only usable inside ` +
-        'the directories scanned by the Nuxt compiler as an exported function and imported statically. Learn more: `https://nuxt.com/docs/guide/concepts/typescript`',
+        'the directories scanned by the Nuxt compiler as an exported function and imported statically. Learn more: `https://nuxt.com/docs/api/composables/create-use-fetch`',
       )
     }
     throw new Error(`[nuxt] \`${factory.name}\` is a compiler macro and cannot be called at runtime.`)

--- a/packages/nuxt/test/compiler.test.ts
+++ b/packages/nuxt/test/compiler.test.ts
@@ -31,7 +31,7 @@ describe('defineKeyedFunctionFactory', () => {
       factory: fn,
     })
 
-    expect(() => factory('a', 1)).toThrowErrorMatchingInlineSnapshot(`[Error: [nuxt:compiler] \`createUseFetch\` is a compiler macro that is only usable inside the directories scanned by the Nuxt compiler as an exported function and imported statically. Learn more: \`https://nuxt.com/docs/guide/concepts/typescript\`]`)
+    expect(() => factory('a', 1)).toThrowErrorMatchingInlineSnapshot(`[Error: [nuxt:compiler] \`createUseFetch\` is a compiler macro that is only usable inside the directories scanned by the Nuxt compiler as an exported function and imported statically. Learn more: \`https://nuxt.com/docs/api/composables/create-use-fetch\`]`)
 
     vi.unstubAllGlobals()
   })

--- a/packages/nuxt/test/compiler.test.ts
+++ b/packages/nuxt/test/compiler.test.ts
@@ -13,7 +13,7 @@ import type { Node } from 'oxc-parser'
 
 vi.mock('oxc-walker', async importOriginal => ({ ...await importOriginal() }))
 
-function transformFactory<T extends (...args: any[]) => any>(factory: T): T {
+function transformFactory<T extends (...args: any[]) => any> (factory: T): T {
   return (factory as unknown as { __nuxt_factory: T }).__nuxt_factory
 }
 
@@ -202,7 +202,7 @@ describe('createScanPluginContext', () => {
 
     context.walkParsed({
       scopeTracker,
-      enter(node) {
+      enter (node) {
         nodes.push(node)
         if (node.type === 'Identifier' && node.name === 'a') {
           const decl = scopeTracker.getDeclaration(node.name)
@@ -224,11 +224,11 @@ describe('createScanPluginContext', () => {
 })
 
 describe('parseFunctionCall', () => {
-  function getFirstParsedFunctionCall(code: string, functions: RegExp): FunctionCallMetadata | null {
+  function getFirstParsedFunctionCall (code: string, functions: RegExp): FunctionCallMetadata | null {
     let result: FunctionCallMetadata | null = null
 
     parseAndWalk(code, 'file.ts', {
-      enter(node) {
+      enter (node) {
         if (node.type !== 'CallExpression' && node.type !== 'ChainExpression') {
           return
         }
@@ -243,7 +243,7 @@ describe('parseFunctionCall', () => {
     return result
   }
 
-  function expectFunctionCallMeta(meta: FunctionCallMetadata | null, expected: {
+  function expectFunctionCallMeta (meta: FunctionCallMetadata | null, expected: {
     name: string
     namespace?: string | null
   }) {
@@ -541,11 +541,11 @@ describe('parseFunctionCall', () => {
 })
 
 describe('parseExport', () => {
-  function getAllParsedExports(code: string, exportedNameFilter?: RegExp) {
+  function getAllParsedExports (code: string, exportedNameFilter?: RegExp) {
     const results: ExportMetadata[] = []
 
     parseAndWalk(code, 'file.ts', {
-      enter(node) {
+      enter (node) {
         if (node.type === 'ExportNamedDeclaration' || node.type === 'ExportDefaultDeclaration' || node.type === 'TSExportAssignment') {
           results.push(...parseStaticExportIdentifiers(node, exportedNameFilter))
         }

--- a/packages/nuxt/test/compiler.test.ts
+++ b/packages/nuxt/test/compiler.test.ts
@@ -13,7 +13,7 @@ import type { Node } from 'oxc-parser'
 
 vi.mock('oxc-walker', async importOriginal => ({ ...await importOriginal() }))
 
-function transformFactory<T extends (...args: any[]) => any> (factory: T): T {
+function transformFactory<T extends (...args: any[]) => any>(factory: T): T {
   return (factory as unknown as { __nuxt_factory: T }).__nuxt_factory
 }
 
@@ -31,7 +31,7 @@ describe('defineKeyedFunctionFactory', () => {
       factory: fn,
     })
 
-    expect(() => factory('a', 1)).toThrowErrorMatchingInlineSnapshot(`[Error: [nuxt:compiler] \`createUseFetch\` is a compiler macro that is only usable inside the directories scanned by the Nuxt compiler as an exported function and imported statically. Learn more: \`https://nuxt.com/docs/guide/going-further/compiler\`]`)
+    expect(() => factory('a', 1)).toThrowErrorMatchingInlineSnapshot(`[Error: [nuxt:compiler] \`createUseFetch\` is a compiler macro that is only usable inside the directories scanned by the Nuxt compiler as an exported function and imported statically. Learn more: \`https://nuxt.com/docs/guide/concepts/typescript\`]`)
 
     vi.unstubAllGlobals()
   })
@@ -145,7 +145,7 @@ describe('createScanPluginContext', () => {
 
     beforeEach(() => {
       parseAndWalkSpy = vi.spyOn(oxcWalker, 'parseAndWalk').mockReturnValue({ program: {} } as any) as any
-      walkSpy = vi.spyOn(oxcWalker, 'walk').mockImplementation((() => {}) as any) as any
+      walkSpy = vi.spyOn(oxcWalker, 'walk').mockImplementation((() => { }) as any) as any
     })
 
     afterEach(() => {
@@ -202,7 +202,7 @@ describe('createScanPluginContext', () => {
 
     context.walkParsed({
       scopeTracker,
-      enter (node) {
+      enter(node) {
         nodes.push(node)
         if (node.type === 'Identifier' && node.name === 'a') {
           const decl = scopeTracker.getDeclaration(node.name)
@@ -224,11 +224,11 @@ describe('createScanPluginContext', () => {
 })
 
 describe('parseFunctionCall', () => {
-  function getFirstParsedFunctionCall (code: string, functions: RegExp): FunctionCallMetadata | null {
+  function getFirstParsedFunctionCall(code: string, functions: RegExp): FunctionCallMetadata | null {
     let result: FunctionCallMetadata | null = null
 
     parseAndWalk(code, 'file.ts', {
-      enter (node) {
+      enter(node) {
         if (node.type !== 'CallExpression' && node.type !== 'ChainExpression') {
           return
         }
@@ -243,7 +243,7 @@ describe('parseFunctionCall', () => {
     return result
   }
 
-  function expectFunctionCallMeta (meta: FunctionCallMetadata | null, expected: {
+  function expectFunctionCallMeta(meta: FunctionCallMetadata | null, expected: {
     name: string
     namespace?: string | null
   }) {
@@ -533,7 +533,7 @@ describe('parseFunctionCall', () => {
     expect(result).toBeNull()
   })
 
-  it ('should return null for call made via call', () => {
+  it('should return null for call made via call', () => {
     const code = `createUseFetch.call(null)`
     const result = getFirstParsedFunctionCall(code, /createUseFetch/)
     expect(result).toBeNull()
@@ -541,11 +541,11 @@ describe('parseFunctionCall', () => {
 })
 
 describe('parseExport', () => {
-  function getAllParsedExports (code: string, exportedNameFilter?: RegExp) {
+  function getAllParsedExports(code: string, exportedNameFilter?: RegExp) {
     const results: ExportMetadata[] = []
 
     parseAndWalk(code, 'file.ts', {
-      enter (node) {
+      enter(node) {
         if (node.type === 'ExportNamedDeclaration' || node.type === 'ExportDefaultDeclaration' || node.type === 'TSExportAssignment') {
           results.push(...parseStaticExportIdentifiers(node, exportedNameFilter))
         }

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -59,7 +59,7 @@ describe.skipIf(isStubbed || process.env.SKIP_BUNDLE_SIZE === 'true' || process.
     const serverDir = join(rootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!_libs'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"66.7k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"67.0k"`)
 
     const modules = await analyzeSizes(['_libs/**/*'], serverDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"462k"`)
@@ -92,7 +92,7 @@ describe.skipIf(isStubbed || process.env.SKIP_BUNDLE_SIZE === 'true' || process.
     const serverDir = join(pagesRootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!_libs'], serverDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"274k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"276k"`)
 
     const modules = await analyzeSizes(['_libs/**/*'], serverDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"471k"`)

--- a/test/fixtures/basic/app/pages/empty.ts
+++ b/test/fixtures/basic/app/pages/empty.ts
@@ -1,1 +1,0 @@
-export default {}

--- a/test/fixtures/basic/app/pages/empty.ts
+++ b/test/fixtures/basic/app/pages/empty.ts
@@ -1,0 +1,1 @@
+export default {}


### PR DESCRIPTION
Resolves #30862.

Added an `::important` callout explicitly warning against importing Vue app code (components, composables) into the Nitro `server/` directory to prevent severe IDE slowdowns due to TypeScript "type leaking". This explains why the `shared/` directory distinction exists and prevents bad DX for newcomers.