### PR TITLE
fix(kit,nitro,schema): ensure tsconfigs exist before build

### DIFF
--- a/packages/kit/src/loader/config.ts
+++ b/packages/kit/src/loader/config.ts
@@ -61,6 +61,12 @@ export async function loadNuxtConfig (opts: LoadNuxtConfigOptions): Promise<Nuxt
   }
 
   const defaultBuildDir = join(nuxtConfig.rootDir!, '.nuxt')
+
+  // preserve original buildDir for emitting types
+  nuxtConfig.typesDir ||= opts.overrides?.buildDir
+    ? layers.find(l => l.config?.buildDir && l.config.buildDir !== opts.overrides?.buildDir)?.config!.buildDir || defaultBuildDir
+    : nuxtConfig.buildDir
+
   if (!opts.overrides?._prepare && !nuxtConfig.dev && !nuxtConfig.buildDir && existsSync(defaultBuildDir)) {
     nuxtConfig.buildDir = join(nuxtConfig.rootDir!, 'node_modules/.cache/nuxt/.nuxt')
   }

--- a/packages/kit/src/loader/config.ts
+++ b/packages/kit/src/loader/config.ts
@@ -453,6 +453,15 @@ export async function loadNuxtConfig (opts: LoadNuxtConfigOptions): Promise<Nuxt
   }
 
   const defaultBuildDir = join(nuxtConfig.rootDir!, '.nuxt')
+
+  // the project `tsconfig.json` references the generated configurations by path, so they
+  // have to keep being written where the project expects them even when we build
+  // elsewhere. A `buildDir` supplied as an override (as test utilities do) is not what the
+  // project references, so prefer the value the project configured for itself.
+  nuxtConfig.typesDir ||= opts.overrides?.buildDir
+    ? layers.find(l => l.config?.buildDir && l.config.buildDir !== opts.overrides?.buildDir)?.config?.buildDir || defaultBuildDir
+    : nuxtConfig.buildDir || defaultBuildDir
+
   if (!opts.overrides?._prepare && !nuxtConfig.dev && !nuxtConfig.buildDir && existsSync(defaultBuildDir)) {
     nuxtConfig.buildDir = join(nuxtConfig.rootDir!, 'node_modules/.cache/nuxt/.nuxt')
   }

--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -62,7 +62,7 @@ export function addServerTemplate (template: NuxtServerTemplate): NuxtServerTemp
 }
 
 /**
- * Renders given types during build to disk in the project `buildDir`
+ * Renders given types during build to disk in the project `typesDir`
  * and register them as types.
  *
  * You can pass a second context object to specify in which context the type should be added.
@@ -238,6 +238,9 @@ interface GenerateTypesReturn {
   legacyTsConfig: TSConfig
 }
 export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> {
+  const defaultTypesPath = nuxt.options.typesDir || resolve(nuxt.options.rootDir, '.nuxt')
+  const typesPath = nuxt.options.typesDir || existsSync(defaultTypesPath) ? defaultTypesPath : resolve(nuxt.options.buildDir)
+
   const include = new Set<string>(['./nuxt.d.ts'])
   const nodeInclude = new Set<string>(['./nuxt.node.d.ts'])
   const sharedInclude = new Set<string>(['./nuxt.shared.d.ts'])
@@ -249,8 +252,8 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
   const legacyExclude = new Set<string>()
 
   if (nuxt.options.typescript.includeWorkspace && nuxt.options.workspaceDir !== nuxt.options.srcDir) {
-    include.add(join(relative(nuxt.options.buildDir, nuxt.options.workspaceDir), '**/*'))
-    legacyInclude.add(join(relative(nuxt.options.buildDir, nuxt.options.workspaceDir), '**/*'))
+    include.add(join(relative(typesPath, nuxt.options.workspaceDir), '**/*'))
+    legacyInclude.add(join(relative(typesPath, nuxt.options.workspaceDir), '**/*'))
   }
 
   const layerDirs = getLayerDirectories(nuxt)
@@ -262,25 +265,25 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
     // we only need to exclude node_modules directories if they are
     // being included automatically by being inside the source directory
     if (!sourceDirs.some(srcDir => dir.startsWith(srcDir))) {
-      exclude.add(relativeWithDot(nuxt.options.buildDir, dir))
+      exclude.add(relativeWithDot(typesPath, dir))
     }
-    nodeExclude.add(relativeWithDot(nuxt.options.buildDir, dir))
-    legacyExclude.add(relativeWithDot(nuxt.options.buildDir, dir))
+    nodeExclude.add(relativeWithDot(typesPath, dir))
+    legacyExclude.add(relativeWithDot(typesPath, dir))
   }
 
   // nitro generate output: https://github.com/nuxt/nuxt/blob/main/packages/nitro-server/src/index.ts
   // + nitro generate .data in development when kv storage is used
   for (const dir of ['dist', '.data']) {
-    exclude.add(relativeWithDot(nuxt.options.buildDir, resolve(nuxt.options.rootDir, dir)))
-    nodeExclude.add(relativeWithDot(nuxt.options.buildDir, resolve(nuxt.options.rootDir, dir)))
-    legacyExclude.add(relativeWithDot(nuxt.options.buildDir, resolve(nuxt.options.rootDir, dir)))
+    exclude.add(relativeWithDot(typesPath, resolve(nuxt.options.rootDir, dir)))
+    nodeExclude.add(relativeWithDot(typesPath, resolve(nuxt.options.rootDir, dir)))
+    legacyExclude.add(relativeWithDot(typesPath, resolve(nuxt.options.rootDir, dir)))
   }
 
   const rootDirWithSlash = withTrailingSlash(nuxt.options.rootDir)
   for (const dirs of layerDirs) {
     if (!dirs.app.startsWith(rootDirWithSlash) || dirs.root === rootDirWithSlash || dirs.app.includes('node_modules')) {
-      const rootGlob = join(relativeWithDot(nuxt.options.buildDir, dirs.root), '**/*')
-      const paths = resolveLayerPaths(dirs, nuxt.options.buildDir)
+      const rootGlob = join(relativeWithDot(typesPath, dirs.root), '**/*')
+      const paths = resolveLayerPaths(dirs, typesPath)
       for (const path of paths.nuxt) {
         include.add(path)
         legacyInclude.add(path)
@@ -324,7 +327,7 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
   const modulePaths = await resolveNuxtModule(rootDirWithSlash, moduleEntryPaths)
 
   for (const path of modulePaths) {
-    const relative = relativeWithDot(nuxt.options.buildDir, path)
+    const relative = relativeWithDot(typesPath, path)
     if (!path.includes('node_modules') && path.startsWith(rootDirWithSlash)) {
       include.add(join(relative, 'runtime'))
       include.add(join(relative, 'dist/runtime'))
@@ -488,8 +491,8 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
   const aliases: Record<string, string> = nuxt.options.alias
 
   const basePath = tsConfig.compilerOptions!.baseUrl
-    ? resolve(nuxt.options.buildDir, tsConfig.compilerOptions!.baseUrl)
-    : nuxt.options.buildDir
+    ? resolve(typesPath, tsConfig.compilerOptions!.baseUrl)
+    : typesPath
 
   tsConfig.compilerOptions ||= {}
   tsConfig.compilerOptions.paths ||= {}
@@ -515,7 +518,7 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
       }
     }
 
-    const relativePath = relativeWithDot(nuxt.options.buildDir, absolutePath)
+    const relativePath = relativeWithDot(typesPath, absolutePath)
     if (stats?.isDirectory() || aliases[alias]!.endsWith('/')) {
       tsConfig.compilerOptions.paths[alias] = [relativePath]
       tsConfig.compilerOptions.paths[`${alias}/*`] = [`${relativePath}/*`]
@@ -568,7 +571,7 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
       tsConfig.compilerOptions!.paths[alias] = [...new Set(await Promise.all(paths.map(async (path: string) => {
         if (!isAbsolute(path)) { return path }
         const stats = await fsp.stat(path).catch(() => null /* file does not exist */)
-        return relativeWithDot(nuxt.options.buildDir, stats?.isFile() ? path.replace(EXTENSION_RE, '') /* remove extension */ : path)
+        return relativeWithDot(typesPath, stats?.isFile() ? path.replace(EXTENSION_RE, '') /* remove extension */ : path)
       })))]
     }
 
@@ -576,8 +579,8 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
     // https://github.com/nuxt/nuxt/issues/30325
     sortTsPaths(tsConfig.compilerOptions!.paths)
 
-    tsConfig.include = [...new Set(tsConfig.include!.map(p => isAbsolute(p) ? relativeWithDot(nuxt.options.buildDir, p) : p))]
-    tsConfig.exclude = [...new Set(tsConfig.exclude!.map(p => isAbsolute(p) ? relativeWithDot(nuxt.options.buildDir, p) : p))]
+    tsConfig.include = [...new Set(tsConfig.include!.map(p => isAbsolute(p) ? relativeWithDot(typesPath, p) : p))]
+    tsConfig.exclude = [...new Set(tsConfig.exclude!.map(p => isAbsolute(p) ? relativeWithDot(typesPath, p) : p))]
   }
 
   await Promise.all([
@@ -588,7 +591,7 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
   ])
 
   const declaration = [
-    ...references.map(ref => renderReference(ref, nuxt.options.buildDir)),
+    ...references.map(ref => renderReference(ref, typesPath)),
     ...declarations,
     '',
     'export {}',
@@ -596,14 +599,14 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
   ].join('\n')
 
   const nodeDeclaration = [
-    ...nodeReferences.map(ref => renderReference(ref, nuxt.options.buildDir)),
+    ...nodeReferences.map(ref => renderReference(ref, typesPath)),
     '',
     'export {}',
     '',
   ].join('\n')
 
   const sharedDeclaration = [
-    ...sharedReferences.map(ref => renderReference(ref, nuxt.options.buildDir)),
+    ...sharedReferences.map(ref => renderReference(ref, typesPath)),
     '',
     'export {}',
     '',
@@ -623,16 +626,19 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
 export async function writeTypes (nuxt: Nuxt): Promise<void> {
   const { tsConfig, nodeTsConfig, nodeDeclaration, declaration, legacyTsConfig, sharedDeclaration, sharedTsConfig } = await _generateTypes(nuxt)
 
-  const appTsConfigPath = resolve(nuxt.options.buildDir, 'tsconfig.app.json')
-  const legacyTsConfigPath = resolve(nuxt.options.buildDir, 'tsconfig.json')
-  const nodeTsConfigPath = resolve(nuxt.options.buildDir, 'tsconfig.node.json')
-  const sharedTsConfigPath = resolve(nuxt.options.buildDir, 'tsconfig.shared.json')
+  const defaultTypesPath = nuxt.options.typesDir || resolve(nuxt.options.rootDir, '.nuxt')
+  const typesPath = nuxt.options.typesDir || existsSync(defaultTypesPath) ? defaultTypesPath : resolve(nuxt.options.buildDir)
 
-  const declarationPath = resolve(nuxt.options.buildDir, 'nuxt.d.ts')
-  const nodeDeclarationPath = resolve(nuxt.options.buildDir, 'nuxt.node.d.ts')
-  const sharedDeclarationPath = resolve(nuxt.options.buildDir, 'nuxt.shared.d.ts')
+  const appTsConfigPath = join(typesPath, 'tsconfig.app.json')
+  const legacyTsConfigPath = join(typesPath, 'tsconfig.json')
+  const nodeTsConfigPath = join(typesPath, 'tsconfig.node.json')
+  const sharedTsConfigPath = join(typesPath, 'tsconfig.shared.json')
 
-  await fsp.mkdir(nuxt.options.buildDir, { recursive: true })
+  const declarationPath = join(typesPath, 'nuxt.d.ts')
+  const nodeDeclarationPath = join(typesPath, 'nuxt.node.d.ts')
+  const sharedDeclarationPath = join(typesPath, 'nuxt.shared.d.ts')
+
+  await fsp.mkdir(typesPath, { recursive: true })
   await Promise.all([
     fsp.writeFile(appTsConfigPath, JSON.stringify(tsConfig, null, 2)),
     fsp.writeFile(legacyTsConfigPath, JSON.stringify(legacyTsConfig, null, 2)),

--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -67,7 +67,7 @@ export function addServerTemplate (template: NuxtServerTemplate, options: NitroV
 }
 
 /**
- * Renders given types during build to disk in the project `buildDir`
+ * Renders given types during build to disk in the project `typesDir`
  * and register them as types.
  *
  * You can pass a second context object to specify in which context the type should be added.
@@ -273,6 +273,9 @@ interface GenerateTypesReturn {
   legacyTsConfig: TSConfig
 }
 export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> {
+  // `typesDir` is resolved by the schema; the fallback is for hand-constructed options
+  const typesDir = nuxt.options.typesDir || nuxt.options.buildDir
+
   const include = new Set<string>(['./nuxt.d.ts'])
   const nodeInclude = new Set<string>(['./nuxt.node.d.ts'])
   const sharedInclude = new Set<string>(['./nuxt.shared.d.ts'])
@@ -284,8 +287,8 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
   const legacyExclude = new Set<string>()
 
   if (nuxt.options.typescript.includeWorkspace && nuxt.options.workspaceDir !== nuxt.options.srcDir) {
-    include.add(join(relative(nuxt.options.buildDir, nuxt.options.workspaceDir), '**/*'))
-    legacyInclude.add(join(relative(nuxt.options.buildDir, nuxt.options.workspaceDir), '**/*'))
+    include.add(join(relative(typesDir, nuxt.options.workspaceDir), '**/*'))
+    legacyInclude.add(join(relative(typesDir, nuxt.options.workspaceDir), '**/*'))
   }
 
   const layerDirs = getLayerDirectories(nuxt)
@@ -297,25 +300,25 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
     // we only need to exclude node_modules directories if they are
     // being included automatically by being inside the source directory
     if (!sourceDirs.some(srcDir => dir.startsWith(srcDir))) {
-      exclude.add(relativeWithDot(nuxt.options.buildDir, dir))
+      exclude.add(relativeWithDot(typesDir, dir))
     }
-    nodeExclude.add(relativeWithDot(nuxt.options.buildDir, dir))
-    legacyExclude.add(relativeWithDot(nuxt.options.buildDir, dir))
+    nodeExclude.add(relativeWithDot(typesDir, dir))
+    legacyExclude.add(relativeWithDot(typesDir, dir))
   }
 
   // nitro generate output: https://github.com/nuxt/nuxt/blob/main/packages/nitro-server/src/index.ts
   // + nitro generate .data in development when kv storage is used
   for (const dir of ['dist', '.data']) {
-    exclude.add(relativeWithDot(nuxt.options.buildDir, resolve(nuxt.options.rootDir, dir)))
-    nodeExclude.add(relativeWithDot(nuxt.options.buildDir, resolve(nuxt.options.rootDir, dir)))
-    legacyExclude.add(relativeWithDot(nuxt.options.buildDir, resolve(nuxt.options.rootDir, dir)))
+    exclude.add(relativeWithDot(typesDir, resolve(nuxt.options.rootDir, dir)))
+    nodeExclude.add(relativeWithDot(typesDir, resolve(nuxt.options.rootDir, dir)))
+    legacyExclude.add(relativeWithDot(typesDir, resolve(nuxt.options.rootDir, dir)))
   }
 
   const rootDirWithSlash = withTrailingSlash(nuxt.options.rootDir)
   for (const dirs of layerDirs) {
     if (!dirs.app.startsWith(rootDirWithSlash) || dirs.root === rootDirWithSlash || dirs.app.includes('node_modules')) {
-      const rootGlob = join(relativeWithDot(nuxt.options.buildDir, dirs.root), '**/*')
-      const paths = resolveLayerPaths(dirs, nuxt.options.buildDir)
+      const rootGlob = join(relativeWithDot(typesDir, dirs.root), '**/*')
+      const paths = resolveLayerPaths(dirs, typesDir)
       for (const path of paths.nuxt) {
         include.add(path)
         legacyInclude.add(path)
@@ -359,7 +362,7 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
   const modulePaths = await resolveNuxtModule(rootDirWithSlash, moduleEntryPaths)
 
   for (const path of modulePaths) {
-    const relative = relativeWithDot(nuxt.options.buildDir, path)
+    const relative = relativeWithDot(typesDir, path)
     if (!path.includes('node_modules') && path.startsWith(rootDirWithSlash)) {
       include.add(join(relative, 'runtime'))
       include.add(join(relative, 'dist/runtime'))
@@ -506,7 +509,7 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
     ? undefined
     // eslint-disable-next-line @typescript-eslint/no-deprecated
     : tsConfig.compilerOptions!.baseUrl
-  const basePath = baseUrl ? resolve(nuxt.options.buildDir, baseUrl) : nuxt.options.buildDir
+  const basePath = baseUrl ? resolve(typesDir, baseUrl) : typesDir
 
   tsConfig.compilerOptions ||= {}
   tsConfig.compilerOptions.paths ||= {}
@@ -533,13 +536,13 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
       }
     }
 
-    const relativePath = relativeWithDot(nuxt.options.buildDir, absolutePath)
+    const relativePath = relativeWithDot(typesDir, absolutePath)
     if (stats?.isDirectory() || aliases[alias]!.endsWith('/')) {
       tsConfig.compilerOptions.paths[alias] = [relativePath]
       tsConfig.compilerOptions.paths[`${alias}/*`] = [`${relativePath}/*`]
     } else {
       const path = stats?.isFile()
-        ? await getPathSubstitution(absolutePath, nuxt.options.buildDir)
+        ? await getPathSubstitution(absolutePath, typesDir)
         // non-existent file probably shouldn't be resolved
         : aliases[alias]!
 
@@ -595,27 +598,27 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
         if (!isAbsolute(path)) { return path }
         const stats = await fsp.stat(path).catch(() => null /* file does not exist */)
         if (stats?.isFile()) {
-          return getPathSubstitution(path, nuxt.options.buildDir)
+          return getPathSubstitution(path, typesDir)
         }
         // A declaration file next to the target wins over a directory of the same name, which is
         // how `#app/types` resolves to `types.ts` rather than the `types/` directory beside it.
         const resolved = await resolveExtensionlessTarget(path)
         if (resolved) {
-          return relativeWithDot(nuxt.options.buildDir, resolved)
+          return relativeWithDot(typesDir, resolved)
         }
-        return relativeWithDot(nuxt.options.buildDir, path)
+        return relativeWithDot(typesDir, path)
       })))]
     }
 
     tsConfig.compilerOptions!.paths = sortTsPaths(
       tsConfig.compilerOptions!.paths,
       nonRootLayerDirs,
-      nuxt.options.buildDir,
+      typesDir,
       nuxt.options.typescript?.hoist ?? [],
     )
 
-    tsConfig.include = [...new Set(tsConfig.include!.map(p => isAbsolute(p) ? relativeWithDot(nuxt.options.buildDir, p) : p))]
-    tsConfig.exclude = [...new Set(tsConfig.exclude!.map(p => isAbsolute(p) ? relativeWithDot(nuxt.options.buildDir, p) : p))]
+    tsConfig.include = [...new Set(tsConfig.include!.map(p => isAbsolute(p) ? relativeWithDot(typesDir, p) : p))]
+    tsConfig.exclude = [...new Set(tsConfig.exclude!.map(p => isAbsolute(p) ? relativeWithDot(typesDir, p) : p))]
   }
 
   await Promise.all([
@@ -626,7 +629,7 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
   ])
 
   const declaration = [
-    ...references.map(ref => renderReference(ref, nuxt.options.buildDir)),
+    ...references.map(ref => renderReference(ref, typesDir)),
     ...declarations,
     '',
     'export {}',
@@ -634,14 +637,14 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
   ].join('\n')
 
   const nodeDeclaration = [
-    ...nodeReferences.map(ref => renderReference(ref, nuxt.options.buildDir)),
+    ...nodeReferences.map(ref => renderReference(ref, typesDir)),
     '',
     'export {}',
     '',
   ].join('\n')
 
   const sharedDeclaration = [
-    ...sharedReferences.map(ref => renderReference(ref, nuxt.options.buildDir)),
+    ...sharedReferences.map(ref => renderReference(ref, typesDir)),
     '',
     'export {}',
     '',
@@ -661,16 +664,18 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
 export async function writeTypes (nuxt: Nuxt): Promise<void> {
   const { tsConfig, nodeTsConfig, nodeDeclaration, declaration, legacyTsConfig, sharedDeclaration, sharedTsConfig } = await _generateTypes(nuxt)
 
-  const appTsConfigPath = resolve(nuxt.options.buildDir, 'tsconfig.app.json')
-  const legacyTsConfigPath = resolve(nuxt.options.buildDir, 'tsconfig.json')
-  const nodeTsConfigPath = resolve(nuxt.options.buildDir, 'tsconfig.node.json')
-  const sharedTsConfigPath = resolve(nuxt.options.buildDir, 'tsconfig.shared.json')
+  const typesDir = nuxt.options.typesDir || nuxt.options.buildDir
 
-  const declarationPath = resolve(nuxt.options.buildDir, 'nuxt.d.ts')
-  const nodeDeclarationPath = resolve(nuxt.options.buildDir, 'nuxt.node.d.ts')
-  const sharedDeclarationPath = resolve(nuxt.options.buildDir, 'nuxt.shared.d.ts')
+  const appTsConfigPath = resolve(typesDir, 'tsconfig.app.json')
+  const legacyTsConfigPath = resolve(typesDir, 'tsconfig.json')
+  const nodeTsConfigPath = resolve(typesDir, 'tsconfig.node.json')
+  const sharedTsConfigPath = resolve(typesDir, 'tsconfig.shared.json')
 
-  await fsp.mkdir(nuxt.options.buildDir, { recursive: true })
+  const declarationPath = resolve(typesDir, 'nuxt.d.ts')
+  const nodeDeclarationPath = resolve(typesDir, 'nuxt.node.d.ts')
+  const sharedDeclarationPath = resolve(typesDir, 'nuxt.shared.d.ts')
+
+  await fsp.mkdir(typesDir, { recursive: true })
   await Promise.all([
     writeIfChanged(appTsConfigPath, JSON.stringify(tsConfig, null, 2)),
     writeIfChanged(legacyTsConfigPath, JSON.stringify(legacyTsConfig, null, 2)),

--- a/packages/kit/test/load-nuxt-config.spec.ts
+++ b/packages/kit/test/load-nuxt-config.spec.ts
@@ -186,6 +186,31 @@ describe('loadNuxtConfig', () => {
     })
   })
 
+  it('should keep typesDir at the default build directory when the build directory is relocated', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'nuxt-types-dir-'))
+    await mkdir(join(tempDir, '.nuxt'), { recursive: true })
+
+    try {
+      const config = await loadNuxtConfig({ cwd: tempDir, overrides: { dev: false } })
+      expect(config.buildDir).toBe(join(tempDir, 'node_modules/.cache/nuxt/.nuxt'))
+      expect(config.typesDir).toBe(join(tempDir, '.nuxt'))
+    } finally {
+      await rm(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('should default typesDir to a custom build directory', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'nuxt-types-dir-'))
+    await writeFile(join(tempDir, 'nuxt.config.ts'), 'export default defineNuxtConfig({ buildDir: \'build\' })\n')
+
+    try {
+      const config = await loadNuxtConfig({ cwd: tempDir })
+      expect(config.typesDir).toBe(join(tempDir, 'build'))
+    } finally {
+      await rm(tempDir, { recursive: true, force: true })
+    }
+  })
+
   it('should preserve and resolve a custom env name', async () => {
     const cwd = fileURLToPath(new URL('./layer-fixture', import.meta.url)).replace(/\\/g, '/')
     const config = await loadNuxtConfig({ cwd, envName: 'staging' })

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -130,6 +130,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
   }
 
   const mockProxy = resolveModulePath('mocked-exports/proxy', { from: import.meta.url })
+  const typesDir = nuxt.options.typesDir || nuxt.options.buildDir
 
   const nitroConfig: NitroConfig = defu(nuxt.options.nitro, {
     debug: nuxt.options.debug ? nuxt.options.debug.nitro : false,
@@ -224,8 +225,8 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
     },
     typescript: {
       generateTsConfig: true,
-      tsconfigPath: join(nuxt.options.buildDir, 'tsconfig.server.json'),
-      generatedTypesDir: join(nuxt.options.buildDir, 'types/nitro'),
+      tsconfigPath: join(typesDir, 'tsconfig.server.json'),
+      generatedTypesDir: join(typesDir, 'types/nitro'),
       tsConfig: {
         compilerOptions: {
           lib: ['esnext', 'webworker', 'dom.iterable'],
@@ -236,20 +237,20 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
           allowArbitraryExtensions: true,
         },
         include: [
-          join(nuxt.options.buildDir, 'types/nitro-nuxt.d.ts'),
+          join(typesDir, 'types/nitro-nuxt.d.ts'),
           ...modules.flatMap((m) => {
-            const moduleDir = relativeWithDot(nuxt.options.buildDir, m)
+            const moduleDir = relativeWithDot(typesDir, m)
             return [
               join(moduleDir, 'runtime/server'),
               join(moduleDir, 'dist/runtime/server'),
             ]
           }),
-          ...layerDirs.map(dirs => relativeWithDot(nuxt.options.buildDir, join(dirs.server, '**/*'))),
-          ...layerDirs.map(dirs => relativeWithDot(nuxt.options.buildDir, join(dirs.shared, '**/*.d.ts'))),
+          ...layerDirs.map(dirs => relativeWithDot(typesDir, join(dirs.server, '**/*'))),
+          ...layerDirs.map(dirs => relativeWithDot(typesDir, join(dirs.shared, '**/*.d.ts'))),
         ],
         exclude: [
-          ...nuxt.options.modulesDir.map(m => relativeWithDot(nuxt.options.buildDir, m)),
-          relativeWithDot(nuxt.options.buildDir, resolve(nuxt.options.rootDir, 'dist')),
+          ...nuxt.options.modulesDir.map(m => relativeWithDot(typesDir, m)),
+          relativeWithDot(typesDir, resolve(nuxt.options.rootDir, 'dist')),
         ],
       },
     },
@@ -674,7 +675,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
 
   // TODO: extract to shared utility?
   const excludedAlias = [/^@vue\/.*$/, 'vue', /vue-router/, 'vite/client', '#imports', 'vue-demi', /^#app/, '~', '@', '~~', '@@']
-  const basePath = nitroConfig.typescript!.tsConfig!.compilerOptions?.baseUrl ? resolve(nuxt.options.buildDir, nitroConfig.typescript!.tsConfig!.compilerOptions?.baseUrl) : nuxt.options.buildDir
+  const basePath = nitroConfig.typescript!.tsConfig!.compilerOptions?.baseUrl ? resolve(typesDir, nitroConfig.typescript!.tsConfig!.compilerOptions?.baseUrl) : typesDir
   const aliases = nitroConfig.alias!
   const tsConfig = nitroConfig.typescript!.tsConfig!
   tsConfig.compilerOptions ||= {}
@@ -911,7 +912,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
   // ensure Nitro types only apply to server directory and not the whole root directory
   nitro.hooks.hook('types:extend', (types) => {
     types.tsConfig ||= {}
-    const rootDirGlob = relativeWithDot(nuxt.options.buildDir, join(nuxt.options.rootDir, '**/*'))
+    const rootDirGlob = relativeWithDot(typesDir, join(nuxt.options.rootDir, '**/*'))
     types.tsConfig.include = types.tsConfig.include?.filter(i => i !== rootDirGlob)
   })
 
@@ -922,9 +923,9 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
     }
     // Exclude nitro output dir from typescript
     opts.tsConfig.exclude ||= []
-    opts.tsConfig.exclude.push(relative(nuxt.options.buildDir, resolve(nuxt.options.rootDir, nitro.options.output.dir)))
-    opts.tsConfig.exclude.push(relative(nuxt.options.buildDir, resolve(nuxt.options.rootDir, nuxt.options.serverDir)))
-    opts.references.push({ path: resolve(nuxt.options.buildDir, 'types/nitro.d.ts') })
+    opts.tsConfig.exclude.push(relative(typesDir, resolve(nuxt.options.rootDir, nitro.options.output.dir)))
+    opts.tsConfig.exclude.push(relative(typesDir, resolve(nuxt.options.rootDir, nuxt.options.serverDir)))
+    opts.references.push({ path: resolve(typesDir, 'types/nitro.d.ts') })
 
     // ensure aliases shared between nuxt + nitro are included in shared tsconfig
     opts.sharedTsConfig.compilerOptions ||= {}

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -141,6 +141,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
   }
 
   const mockProxy = resolveModulePath('mocked-exports/proxy', { from: import.meta.url })
+  const typesDir = nuxt.options.typesDir || nuxt.options.buildDir
 
   // `nuxt.options.nitro.typescript.tsConfig` is a portal onto `typescript.serverTsConfig`,
   // so this baseline sits under whichever of the two the user set. `types`, `paths` and
@@ -276,8 +277,8 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
     },
     typescript: {
       generateTsConfig: true,
-      tsconfigPath: join(nuxt.options.buildDir, 'tsconfig.server.json'),
-      generatedTypesDir: join(nuxt.options.buildDir, 'types/nitro'),
+      tsconfigPath: join(typesDir, 'tsconfig.server.json'),
+      generatedTypesDir: join(typesDir, 'types/nitro'),
       tsConfig: {
         compilerOptions: {
           lib: ['esnext', 'webworker', 'dom.iterable'],
@@ -288,20 +289,20 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
           allowArbitraryExtensions: true,
         },
         include: [
-          join(nuxt.options.buildDir, 'types/nitro-nuxt.d.ts'),
+          join(typesDir, 'types/nitro-nuxt.d.ts'),
           ...modules.flatMap((m) => {
-            const moduleDir = relativeWithDot(nuxt.options.buildDir, m)
+            const moduleDir = relativeWithDot(typesDir, m)
             return [
               join(moduleDir, 'runtime/server'),
               join(moduleDir, 'dist/runtime/server'),
             ]
           }),
-          ...layerDirs.map(dirs => relativeWithDot(nuxt.options.buildDir, join(dirs.server, '**/*'))),
-          ...layerDirs.map(dirs => relativeWithDot(nuxt.options.buildDir, join(dirs.shared, '**/*.d.ts'))),
+          ...layerDirs.map(dirs => relativeWithDot(typesDir, join(dirs.server, '**/*'))),
+          ...layerDirs.map(dirs => relativeWithDot(typesDir, join(dirs.shared, '**/*.d.ts'))),
         ],
         exclude: [
-          ...nuxt.options.modulesDir.map(m => relativeWithDot(nuxt.options.buildDir, m)),
-          relativeWithDot(nuxt.options.buildDir, resolve(nuxt.options.rootDir, 'dist')),
+          ...nuxt.options.modulesDir.map(m => relativeWithDot(typesDir, m)),
+          relativeWithDot(typesDir, resolve(nuxt.options.rootDir, 'dist')),
         ],
       },
     },
@@ -809,7 +810,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
   const isV5OrHigher = nuxt.options.future.compatibilityVersion >= 5
   // eslint-disable-next-line @typescript-eslint/no-deprecated
   const baseUrl = isV5OrHigher ? undefined : nitroConfig.typescript!.tsConfig!.compilerOptions?.baseUrl
-  const basePath = baseUrl ? resolve(nuxt.options.buildDir, baseUrl) : nuxt.options.buildDir
+  const basePath = baseUrl ? resolve(typesDir, baseUrl) : typesDir
   const aliases = nitroConfig.alias!
   const importPaths = nuxt.options.modulesDir.map(d => pathToFileURL(withTrailingSlash(d)))
   const tsConfig = nitroConfig.typescript!.tsConfig!
@@ -1086,19 +1087,20 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
   // ensure Nitro types only apply to server directory and not the whole root directory
   nitro.hooks.hook('types:extend', (types) => {
     types.tsConfig ||= {}
-    const rootDirGlob = relativeWithDot(nuxt.options.buildDir, join(nuxt.options.rootDir, '**/*'))
+    const rootDirGlob = relativeWithDot(typesDir, join(nuxt.options.rootDir, '**/*'))
     types.tsConfig.include = types.tsConfig.include?.filter(i => i !== rootDirGlob)
   })
 
   // Add typed route responses
   nuxt.hook('prepare:types', async (opts) => {
-    if (!nuxt.options.dev || nuxt.options.experimental.nitroViteEnvironment) {
-      await writeTypes(nitro)
-    }
+    // in the legacy dev path Nitro's own watcher writes these again once handlers have
+    // been scanned, but the project `tsconfig.json` references `tsconfig.server.json`,
+    // so it has to exist before anything resolves the references
+    await writeTypes(nitro)
     // Exclude nitro output dir from typescript
     opts.tsConfig.exclude ||= []
-    opts.tsConfig.exclude.push(relative(nuxt.options.buildDir, resolve(nuxt.options.rootDir, nitro.options.output.dir)))
-    opts.tsConfig.exclude.push(relative(nuxt.options.buildDir, resolve(nuxt.options.rootDir, nuxt.options.serverDir)))
+    opts.tsConfig.exclude.push(relative(typesDir, resolve(nuxt.options.rootDir, nitro.options.output.dir)))
+    opts.tsConfig.exclude.push(relative(typesDir, resolve(nuxt.options.rootDir, nuxt.options.serverDir)))
     opts.references.push({ path: resolve(nuxt.options.rootDir, nitroConfig.typescript!.generatedTypesDir!, 'nitro.d.ts') })
 
     // ensure aliases shared between nuxt + nitro are included in shared tsconfig

--- a/packages/nuxt/src/core/builder.ts
+++ b/packages/nuxt/src/core/builder.ts
@@ -1,7 +1,8 @@
+import { existsSync } from 'node:fs'
 import type { EventType } from '@parcel/watcher'
 import type { FSWatcher } from 'chokidar'
 import { watch as chokidarWatch } from 'chokidar'
-import { createIsIgnored, directoryToURL, getLayerDirectories, importModule, isIgnored, useNuxt } from '@nuxt/kit'
+import { createIsIgnored, directoryToURL, getLayerDirectories, importModule, isIgnored, useNuxt, writeTypes } from '@nuxt/kit'
 import { debounce } from 'perfect-debounce'
 import { dirname, join, normalize, relative, resolve } from 'pathe'
 
@@ -64,6 +65,11 @@ export async function build (nuxt: Nuxt): Promise<void> {
   if (nuxt.options._prepare) {
     nuxt.hook('prepare:types', () => nuxt.close())
     return
+  }
+
+  // vite/rolldown requires a `tsconfig.json` to exist on disk
+  if (!nuxt.options._prepare && !existsSync(join(nuxt.options.typesDir || nuxt.options.buildDir, 'tsconfig.json'))) {
+    await writeTypes(nuxt)
   }
 
   if (nuxt.options.dev && !nuxt.options.test) {

--- a/packages/nuxt/src/core/builder.ts
+++ b/packages/nuxt/src/core/builder.ts
@@ -1,7 +1,8 @@
+import { existsSync } from 'node:fs'
 import type { EventType } from '@parcel/watcher'
 import type { FSWatcher } from 'chokidar'
 import { watch as chokidarWatch } from 'chokidar'
-import { createIsIgnored, directoryToURL, getAddDependencyCommand, getLayerDirectories, importModule, isIgnored, recoverThrottledChanges, useNuxt } from '@nuxt/kit'
+import { createIsIgnored, directoryToURL, getAddDependencyCommand, getLayerDirectories, importModule, isIgnored, recoverThrottledChanges, useNuxt, writeTypes } from '@nuxt/kit'
 import { buildDiagnostics } from '@nuxt/kit/internal'
 import { debounce } from 'perfect-debounce'
 import { dirname, join, normalize, relative, resolve } from 'pathe'
@@ -14,6 +15,8 @@ import { cleanupCaches, getVueHash } from './cache.ts'
 import type { Nuxt, NuxtBuilder, NuxtHooks } from 'nuxt/schema'
 
 export async function build (nuxt: Nuxt): Promise<void> {
+  await ensureGeneratedTsConfigs(nuxt)
+
   nuxt._perf?.startPhase('app:generate')
   const app = createApp(nuxt)
   nuxt.apps.default = app
@@ -146,6 +149,26 @@ export async function build (nuxt: Nuxt): Promise<void> {
   if (!nuxt.options.dev) {
     await nuxt.callHook('close', nuxt)
   }
+}
+
+const generatedTsConfigs = ['tsconfig.json', 'tsconfig.app.json', 'tsconfig.server.json', 'tsconfig.node.json', 'tsconfig.shared.json']
+
+/**
+ * The project `tsconfig.json` references the generated configurations. Tools that
+ * resolve them (such as tsconfck, which Vite uses to load compiler options) throw if
+ * a referenced project is missing and cache that failure for the lifetime of the
+ * process, so a bundler that starts before typegen has run keeps failing until it is
+ * restarted.
+ *
+ * Typegen normally runs before the build, so this only generates types when a
+ * referenced configuration is genuinely missing. A stub is not enough: whatever is on
+ * disk when the bundler first reads it is the configuration it uses for the rest of
+ * the session.
+ */
+async function ensureGeneratedTsConfigs (nuxt: Nuxt) {
+  if (nuxt.options._prepare) { return }
+  if (generatedTsConfigs.every(name => existsSync(join(nuxt.options.typesDir || nuxt.options.buildDir, name)))) { return }
+  await writeTypes(nuxt).catch(() => {})
 }
 
 const watchEvents: Record<EventType, 'add' | 'addDir' | 'change' | 'unlink' | 'unlinkDir'> = {

--- a/packages/nuxt/test/load-nuxt.test.ts
+++ b/packages/nuxt/test/load-nuxt.test.ts
@@ -251,7 +251,7 @@ describe('loadNuxt', () => {
     const aliasPath = compilerOptions.paths?.['#probe/base-url']?.[0]
     await nuxt.close()
 
-    expect(aliasPath).toBe(resolve(nuxt.options.buildDir, expectedAlias))
+    expect(aliasPath).toBe(resolve(nuxt.options.typesDir, expectedAlias))
     expect(Reflect.get(compilerOptions, 'baseUrl')).toBe(expectedBaseUrl)
   })
 

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -79,6 +79,14 @@ export default defineResolvers({
       return resolve(rootDir, val && typeof val === 'string' ? val : '.nuxt')
     },
   },
+  typesDir: {
+    $resolve: async (val, get) => {
+      if (val && typeof val === 'string') {
+        return resolve(await get('rootDir'), val)
+      }
+      return get('buildDir')
+    },
+  },
   appId: {
     $resolve: val => val && typeof val === 'string' ? val : 'nuxt-app',
   },

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -645,6 +645,11 @@ export interface ConfigSchema {
   buildDir: string
 
   /**
+   * The directory in which Nuxt-generated types and `tsconfig.json` files are located.
+   */
+  typesDir: string
+
+  /**
    * For multi-app projects, the unique id of the Nuxt application.
    *
    * Defaults to `nuxt-app`.

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -669,6 +669,18 @@ export interface ConfigSchema {
   buildDir: string
 
   /**
+   * Define the directory where generated types and `tsconfig.json` files will be placed.
+   *
+   * This defaults to your `buildDir`, and is separate from it so that the configurations
+   * referenced by your project `tsconfig.json` stay in place even when Nuxt builds
+   * elsewhere (as it does when building a project that has already been run in
+   * development).
+   *
+   * If a relative path is specified, it will be relative to your `rootDir`.
+   */
+  typesDir: string
+
+  /**
    * For multi-app projects, the unique id of the Nuxt application.
    *
    * Defaults to `nuxt-app`.


### PR DESCRIPTION
resolves https://github.com/nuxt/nuxt/issues/29098

### 📚 Description

when running `vitest` or build in CI, types may not yet exist and this means we can omit running a `nuxt prepare` step before 

additionally, nitro-server skipped writing types until `build:done`, so it was possible to miss `tsconfig.server.json`.