### PR TITLE
docs: add migration for nitro autoimports in V5

### DIFF
--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -363,7 +363,7 @@ Auto imports have been removed in favor of explicit imports to improve code clar
 
 #### Migration Steps
 
-You can add imports from `#imports`
+You can add imports from `#imports`, or you can import them directly from the specific packages.
 
 ```diff
 + import { defineEventHandler } from '#imports'

--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -354,9 +354,26 @@ If you define redirect route rules, the property name has changed:
 
 🚦 **Impact Level**: Minimal
 
+#### What changed
+
 Nitro auto-imports are disabled by default in V5.
 
-You can re-enable V4 behavior by setting `experimental.nitroAutoImports` to `true` in your config.
+#### Reason for change
+
+Auto imports has been removed in favor of explicit imports to improve code clarity and reduce ambiguity. As noted in [Nitro](https://github.com/nitrojs/nitro/issues/2232), it became difficult to determine whether a utility originated from H3, Nitro, or Nuxt, IDE support was inconsistent, and many users and frameworks prefer explicit over magical conventions.
+
+#### Migration Steps
+
+You can add imports from `#imports`
+
+```diff
++ import { defineEventHandler } from '#imports'
+
+export default defineEventHandler(() => {
+})
+```
+
+You can re-enable Nuxt V4 behavior by setting `experimental.nitroAutoImports` to `true` in your config.
 
 ### Removal of `experimental.externalVue`
 

--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -349,7 +349,6 @@ If you define redirect route rules, the property name has changed:
 - **Runtime hooks**: `nitroApp.hooks.hook('beforeResponse', ...)` and `nitroApp.hooks.hook('afterResponse', ...)` have been replaced by `nitroApp.hooks.hook('response', ...)`.
 - **`getRouteRules()` from `nitro/app`**: On the server, the Nitro helper changed from `getRouteRules(event)` to `getRouteRules(method, pathname)`, which returns `{ routeRules }`.
 
-
 ### Nitro auto-imports are disabled by default
 
 🚦 **Impact Level**: Minimal

--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -359,7 +359,7 @@ Nitro auto-imports are disabled by default in V5.
 
 #### Reason for change
 
-Auto imports has been removed in favor of explicit imports to improve code clarity and reduce ambiguity. As noted in [Nitro](https://github.com/nitrojs/nitro/issues/2232), it became difficult to determine whether a utility originated from H3, Nitro, or Nuxt, IDE support was inconsistent, and many users and frameworks prefer explicit over magical conventions.
+Auto imports have been removed in favor of explicit imports to improve code clarity and reduce ambiguity. As noted in [this Nitro issue](https://github.com/nitrojs/nitro/issues/2232), it became difficult to determine whether a utility originated from H3, Nitro, or Nuxt. IDE support was inconsistent, and many users and frameworks prefer explicit imports over magical conventions.
 
 #### Migration Steps
 

--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -349,6 +349,15 @@ If you define redirect route rules, the property name has changed:
 - **Runtime hooks**: `nitroApp.hooks.hook('beforeResponse', ...)` and `nitroApp.hooks.hook('afterResponse', ...)` have been replaced by `nitroApp.hooks.hook('response', ...)`.
 - **`getRouteRules()` from `nitro/app`**: On the server, the Nitro helper changed from `getRouteRules(event)` to `getRouteRules(method, pathname)`, which returns `{ routeRules }`.
 
+
+### Nitro auto-imports are disabled by default
+
+🚦 **Impact Level**: Minimal
+
+Nitro auto-imports are disabled by default in V5.
+
+You can re-enable V4 behavior by setting `experimental.nitroAutoImports` to `true` in your config.
+
 ### Removal of `experimental.externalVue`
 
 🚦 **Impact Level**: Minimal


### PR DESCRIPTION
### 🔗 Linked issue


close #34641


<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This is a documentation update on `experimental.nitroAutoImports` being disabled in V5 by default. 


<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
