### PR TITLE
perf(vite,webpack): use vfs for manifest + vite node server

### DIFF
--- a/packages/vite/src/plugins/client-manifest.ts
+++ b/packages/vite/src/plugins/client-manifest.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs'
-import { rm } from 'node:fs/promises'
+import { mkdir, rm, writeFile } from 'node:fs/promises'
 
 import { relative, resolve } from 'pathe'
 import { withTrailingSlash, withoutLeadingSlash } from 'ufo'
@@ -100,6 +100,13 @@ export function ClientManifestPlugin (nuxt: Nuxt): Plugin {
       manifestCode = 'export default ' + serialize(manifest)
 
       if (!nuxt.options.dev) {
+        if (nuxt.options.experimental.buildCache) {
+          const serverDist = resolve(nuxt.options.buildDir, 'dist/server')
+          await mkdir(serverDist, { recursive: true })
+          await writeFile(resolve(serverDist, 'client.manifest.mjs'), manifestCode, 'utf8')
+          await writeFile(resolve(serverDist, 'client.precomputed.mjs'), precomputedCode, 'utf8')
+        }
+
         await rm(manifestFile, { force: true })
       }
     },

--- a/packages/vite/src/plugins/client-manifest.ts
+++ b/packages/vite/src/plugins/client-manifest.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs'
-import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { rm } from 'node:fs/promises'
 
 import { relative, resolve } from 'pathe'
 import { withTrailingSlash, withoutLeadingSlash } from 'ufo'
@@ -8,6 +8,7 @@ import { normalizeViteManifest, precomputeDependencies } from 'vue-bundle-render
 import { serialize } from 'seroval'
 import type { Manifest as RendererManifest } from 'vue-bundle-renderer'
 import type { Plugin, Manifest as ViteClientManifest } from 'vite'
+import { useNitro } from '@nuxt/kit'
 import type { Nuxt } from '@nuxt/schema'
 import { resolveClientEntry } from '../utils/config.ts'
 
@@ -15,6 +16,24 @@ export function ClientManifestPlugin (nuxt: Nuxt): Plugin {
   let clientEntry: string
   let key: string
   let disableCssCodeSplit: boolean
+
+  let precomputedCode = 'export default undefined'
+  let manifestCode: string
+
+  const vfs = {
+    'client.precomputed.mjs': () => precomputedCode,
+    'client.manifest.mjs': () => manifestCode,
+  }
+
+  const nitro = useNitro()
+  nitro.options.virtual ||= {}
+  nitro.options._config.virtual ||= {}
+
+  for (const key in vfs) {
+    const filename = `#build/dist/server/${key}`
+    nitro.options.virtual[filename] ||= vfs[key as keyof typeof vfs] as () => string
+    nitro.options._config.virtual[filename] ||= vfs[key as keyof typeof vfs] as () => string
+  }
 
   return {
     name: 'nuxt:client-manifest',
@@ -47,9 +66,8 @@ export function ClientManifestPlugin (nuxt: Nuxt): Plugin {
             },
       }
 
-      // Write client manifest for use in vue-bundle-renderer
+      // expose client manifest for use in vue-bundle-renderer
       const clientDist = resolve(nuxt.options.buildDir, 'dist/client')
-      const serverDist = resolve(nuxt.options.buildDir, 'dist/server')
 
       const manifestFile = resolve(clientDist, 'manifest.json')
       const clientManifest = nuxt.options.dev ? devClientManifest : JSON.parse(readFileSync(manifestFile, 'utf-8')) as ViteClientManifest
@@ -65,8 +83,6 @@ export function ClientManifestPlugin (nuxt: Nuxt): Plugin {
         }
       }
 
-      await mkdir(serverDist, { recursive: true })
-
       if (disableCssCodeSplit) {
         for (const entry of manifestEntries) {
           if (entry.file?.endsWith('.css')) {
@@ -79,9 +95,9 @@ export function ClientManifestPlugin (nuxt: Nuxt): Plugin {
 
       const manifest = normalizeViteManifest(clientManifest)
       await nuxt.callHook('build:manifest', manifest)
-      const precomputed = precomputeDependencies(manifest)
-      await writeFile(resolve(serverDist, 'client.manifest.mjs'), 'export default ' + serialize(manifest), 'utf8')
-      await writeFile(resolve(serverDist, 'client.precomputed.mjs'), 'export default ' + serialize(precomputed), 'utf8')
+
+      precomputedCode = 'export default ' + serialize(precomputeDependencies(manifest))
+      manifestCode = 'export default ' + serialize(manifest)
 
       if (!nuxt.options.dev) {
         await rm(manifestFile, { force: true })

--- a/packages/vite/src/plugins/vite-node.ts
+++ b/packages/vite/src/plugins/vite-node.ts
@@ -1,5 +1,5 @@
 import process from 'node:process'
-import { mkdir, unlink, writeFile } from 'node:fs/promises'
+import { unlink } from 'node:fs/promises'
 import type { Socket } from 'node:net'
 import net from 'node:net'
 import os from 'node:os'
@@ -7,7 +7,7 @@ import fs from 'node:fs' // For sync operations like unlinkSync if needed during
 import { pathToFileURL } from 'node:url'
 import { Buffer } from 'node:buffer'
 import { isAbsolute, join, normalize } from 'pathe'
-import { directoryToURL, resolveAlias, tryUseNuxt } from '@nuxt/kit'
+import { directoryToURL, resolveAlias, tryUseNuxt, useNitro } from '@nuxt/kit'
 import type { EnvironmentModuleNode, ModuleNode, PluginContainer, ViteDevServer, Plugin as VitePlugin } from 'vite'
 import { getQuery } from 'ufo'
 import type { FetchResult } from 'vite-node'
@@ -179,7 +179,11 @@ function useInvalidates () {
   }
 }
 
-export function ViteNodePlugin (nuxt: Nuxt): VitePlugin {
+export function ViteNodePlugin (nuxt: Nuxt): VitePlugin | undefined {
+  if (!nuxt.options.dev) {
+    return
+  }
+
   let socketServer: net.Server | undefined
   const socketPath = generateSocketPath()
   const { invalidates, markInvalidate, markInvalidates } = useInvalidates()
@@ -195,6 +199,27 @@ export function ViteNodePlugin (nuxt: Nuxt): VitePlugin {
         // Error is ignored if the file doesn't exist or cannot be unlinked
       }
     }
+  }
+
+  const nitro = useNitro()
+
+  const runnerResolvedPath = resolveModulePath('#vite-node-runner', { from: import.meta.url })
+  const serverResolvedPath = resolveModulePath('#vite-node-entry', { from: import.meta.url })
+  const fetchResolvedPath = resolveModulePath('#vite-node', { from: import.meta.url })
+
+  const vfs = {
+    'server.mjs': `export { default } from ${JSON.stringify(pathToFileURL(serverResolvedPath).href)}`,
+    'runner.mjs': `export { default } from ${JSON.stringify(pathToFileURL(runnerResolvedPath).href)}`,
+    'client.manifest.mjs': `import { viteNodeFetch } from ${JSON.stringify(pathToFileURL(fetchResolvedPath))};export default () => viteNodeFetch.getManifest()`,
+  }
+
+  nitro.options.virtual ||= {}
+  nitro.options._config.virtual ||= {}
+
+  for (const key in vfs) {
+    const filename = `#build/dist/server/${key}`
+    nitro.options.virtual[filename] = vfs[key as keyof typeof vfs]
+    nitro.options._config.virtual[filename] = vfs[key as keyof typeof vfs]
   }
 
   return {
@@ -502,24 +527,4 @@ export type ViteNodeServerOptions = {
   baseRetryDelay?: number
   maxRetryDelay?: number
   requestTimeout?: number
-}
-
-export async function writeDevServer (nuxt: Nuxt): Promise<void> {
-  const runnerResolvedPath = resolveModulePath('#vite-node-runner', { from: import.meta.url })
-  const serverResolvedPath = resolveModulePath('#vite-node-entry', { from: import.meta.url })
-  const fetchResolvedPath = resolveModulePath('#vite-node', { from: import.meta.url })
-
-  const serverDist = join(nuxt.options.buildDir, 'dist/server')
-
-  await mkdir(serverDist, { recursive: true })
-
-  await Promise.all([
-    writeFile(join(serverDist, 'server.mjs'), `export { default } from ${JSON.stringify(pathToFileURL(serverResolvedPath).href)}`),
-    writeFile(join(serverDist, 'runner.mjs'), `export { default } from ${JSON.stringify(pathToFileURL(runnerResolvedPath).href)}`),
-    writeFile(join(serverDist, 'client.precomputed.mjs'), `export default undefined`),
-    writeFile(join(serverDist, 'client.manifest.mjs'), `
-import { viteNodeFetch } from ${JSON.stringify(pathToFileURL(fetchResolvedPath))}
-export default () => viteNodeFetch.getManifest()
-    `),
-  ])
 }

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -34,7 +34,7 @@ import { VitePluginCheckerPlugin } from './plugins/vite-plugin-checker.ts'
 import { AnalyzePlugin } from './plugins/analyze.ts'
 import { DevServerPlugin } from './plugins/dev-server.ts'
 import { EnvironmentsPlugin } from './plugins/environments.ts'
-import { ViteNodePlugin, writeDevServer } from './plugins/vite-node.ts'
+import { ViteNodePlugin } from './plugins/vite-node.ts'
 import { ClientManifestPlugin } from './plugins/client-manifest.ts'
 import { ResolveDeepImportsPlugin } from './plugins/resolve-deep-imports.ts'
 import { ResolveExternalsPlugin } from './plugins/resolved-externals.ts'
@@ -272,8 +272,6 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
     await server.environments.ssr.pluginContainer.buildStart({})
   }, 'Vite dev server built')
   nuxt._perf?.endPhase('vite:dev-server')
-
-  await writeDevServer(nuxt)
 }
 
 async function withLogs (fn: () => Promise<unknown>, message: string, enabled = true) {

--- a/packages/webpack/src/plugins/vue/client.ts
+++ b/packages/webpack/src/plugins/vue/client.ts
@@ -3,15 +3,14 @@
  * https://github.com/vuejs/vue/blob/dev/src/server/webpack-plugin/client.js
  */
 
-import { mkdir, writeFile } from 'node:fs/promises'
-
 import { normalizeWebpackManifest, precomputeDependencies } from 'vue-bundle-renderer'
-import { join, normalize, relative, resolve } from 'pathe'
+import { normalize, relative, resolve } from 'pathe'
 import { hash } from 'ohash'
 import { serialize } from 'seroval'
 
 import type { Nuxt } from '@nuxt/schema'
 import type { Compilation, Compiler } from 'webpack'
+import { useNitro } from '@nuxt/kit'
 
 import { isCSS, isHotUpdate, isJS } from './util.ts'
 
@@ -22,10 +21,27 @@ interface PluginOptions {
 export default class VueSSRClientPlugin {
   serverDist: string
   nuxt: Nuxt
+  precomputedCode = 'export default undefined'
+  manifestCode?: string
+
+  vfs = {
+    'client.precomputed.mjs': () => this.precomputedCode,
+    'client.manifest.mjs': () => this.manifestCode,
+  }
 
   constructor (options: PluginOptions) {
     this.serverDist = resolve(options.nuxt.options.buildDir, 'dist/server')
     this.nuxt = options.nuxt
+
+    const nitro = useNitro()
+    nitro.options.virtual ||= {}
+    nitro.options._config.virtual ||= {}
+
+    for (const key in this.vfs) {
+      const filename = `#build/dist/server/${key}`
+      nitro.options.virtual[filename] = this.vfs[key as keyof typeof this.vfs] as () => string
+      nitro.options._config.virtual[filename] = this.vfs[key as keyof typeof this.vfs] as () => string
+    }
   }
 
   private getRelativeModuleId (identifier: string, context: string): string {
@@ -138,13 +154,8 @@ export default class VueSSRClientPlugin {
 
       const manifest = normalizeWebpackManifest(webpackManifest as any)
       await this.nuxt.callHook('build:manifest', manifest)
-
-      await mkdir(this.serverDist, { recursive: true })
-
-      const precomputed = precomputeDependencies(manifest)
-      await writeFile(join(this.serverDist, `client.manifest.json`), JSON.stringify(manifest, null, 2))
-      await writeFile(join(this.serverDist, 'client.manifest.mjs'), 'export default ' + serialize(manifest), 'utf8')
-      await writeFile(join(this.serverDist, 'client.precomputed.mjs'), 'export default ' + serialize(precomputed), 'utf8')
+      this.precomputedCode = 'export default ' + serialize(precomputeDependencies(manifest))
+      this.manifestCode = 'export default ' + serialize(manifest)
 
       // assets[this.options.filename] = {
       //   source: () => src,

--- a/packages/webpack/src/plugins/vue/client.ts
+++ b/packages/webpack/src/plugins/vue/client.ts
@@ -3,8 +3,10 @@
  * https://github.com/vuejs/vue/blob/dev/src/server/webpack-plugin/client.js
  */
 
+import { mkdir, writeFile } from 'node:fs/promises'
+
 import { normalizeWebpackManifest, precomputeDependencies } from 'vue-bundle-renderer'
-import { normalize, relative, resolve } from 'pathe'
+import { join, normalize, relative, resolve } from 'pathe'
 import { hash } from 'ohash'
 import { serialize } from 'seroval'
 
@@ -156,6 +158,12 @@ export default class VueSSRClientPlugin {
       await this.nuxt.callHook('build:manifest', manifest)
       this.precomputedCode = 'export default ' + serialize(precomputeDependencies(manifest))
       this.manifestCode = 'export default ' + serialize(manifest)
+
+      if (!this.nuxt.options.dev && this.nuxt.options.experimental.buildCache) {
+        await mkdir(this.serverDist, { recursive: true })
+        await writeFile(join(this.serverDist, 'client.manifest.mjs'), this.manifestCode, 'utf8')
+        await writeFile(join(this.serverDist, 'client.precomputed.mjs'), this.precomputedCode, 'utf8')
+      }
 
       // assets[this.options.filename] = {
       //   source: () => src,


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this is a twin fix.

first, it is a performance improvement and general stability improvement as it doesn't require writing files to the file system before a nitro build (you might have noticed issues with a dev server failing to load when a build ran at the same time, for example)

second, it's preparatory work for moving nitro to use the vite environment api (where these files will be loaded via vfs rather than via the actual fs as a build output)