### PR TITLE
chore: use consistent `[nuxt]` prefix in console warnings

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-layout.ts
+++ b/packages/nuxt/src/app/components/nuxt-layout.ts
@@ -64,7 +64,7 @@ export default defineComponent({
       let layout = unref(props.name) ?? route?.meta.layout as string ?? routeRulesMatcher(route?.path).appLayout ?? 'default'
       if (layout && !(layout in layouts)) {
         if (import.meta.dev && layout !== 'default') {
-          console.warn(`Invalid layout \`${layout}\` selected.`)
+          console.warn(`[nuxt] Invalid layout \`${layout}\` selected.`)
         }
         if (props.fallback) {
           layout = unref(props.fallback)

--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -278,13 +278,13 @@ export const setPageLayout = <Layout extends keyof NuxtLayouts>(layout: unknown 
   const nuxtApp = useNuxtApp()
   if (import.meta.server) {
     if (import.meta.dev && getCurrentInstance() && nuxtApp.payload.state._layout !== layout) {
-      console.warn('[warn] [nuxt] `setPageLayout` should not be called to change the layout on the server within a component as this will cause hydration errors.')
+      console.warn('[nuxt] `setPageLayout` should not be called to change the layout on the server within a component as this will cause hydration errors.')
     }
     nuxtApp.payload.state._layout = layout
     nuxtApp.payload.state._layoutProps = props
   }
   if (import.meta.dev && nuxtApp.isHydrating && nuxtApp.payload.serverRendered && nuxtApp.payload.state._layout !== layout) {
-    console.warn('[warn] [nuxt] `setPageLayout` should not be called to change the layout during hydration as this will cause hydration errors.')
+    console.warn('[nuxt] `setPageLayout` should not be called to change the layout during hydration as this will cause hydration errors.')
   }
   const inMiddleware = isProcessingMiddleware()
   if (inMiddleware || import.meta.server || nuxtApp.isHydrating) {


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 📚 Description

Three `console.warn` calls in the Nuxt runtime used inconsistent prefix formatting:

- `setPageLayout` warnings in `router.ts` used `[warn] [nuxt]` — the `[warn]` is redundant since `console.warn` already marks the message as a warning. Every other warning in the runtime uses just `[nuxt]`.
- The invalid layout warning in `nuxt-layout.ts` had no `[nuxt]` prefix at all, making it harder to identify as a Nuxt warning in the console.

This aligns all three to the standard `[nuxt]` prefix used throughout the rest of the codebase.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>