### PR TITLE
fix(nuxt): fix type inference in `useAsyncData` with `transform` and `getCachedData`

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -71,7 +71,7 @@ export interface AsyncDataOptions<
    * An `undefined` return value will trigger a fetch.
    * Default is `key => nuxt.isHydrating ? nuxt.payload.data[key] : nuxt.static.data[key]` which only caches data when payloadExtraction is enabled.
    */
-  getCachedData?: (key: string, nuxtApp: NuxtApp, context: { cause: AsyncDataRefreshCause }) => NoInfer<DataT> | undefined
+  getCachedData?: (key: string, nuxtApp: NuxtApp, context: { cause: AsyncDataRefreshCause }) => NoInfer<DataT | undefined>
   /**
    * A function that can be used to alter handler function result after resolving.
    * Do not use it along with the `pick` option.

--- a/test/fixtures/basic-types/app/app-types.ts
+++ b/test/fixtures/basic-types/app/app-types.ts
@@ -622,6 +622,21 @@ describe('composables', () => {
       getCachedData: () => ({ bar: 2 }),
     })
   })
+
+  it('correctly infers types when using transform with getCachedData', () => {
+    // should not error: handler returns { foo: string }, transform narrows to string
+    const { data } = useAsyncData(
+      'test',
+      () => Promise.resolve({ foo: 'hello' }),
+      {
+        transform: response => response.foo,
+        getCachedData: (key: string) => {
+          return useNuxtApp().payload.data[key] as string ?? undefined
+        },
+      },
+    )
+    expectTypeOf(data).toEqualTypeOf<Ref<string | DefaultAsyncDataValue>>()
+  })
 })
 
 describe('app config', () => {


### PR DESCRIPTION
## Summary

- Moves `undefined` inside the `NoInfer` wrapper for `getCachedData`'s return type (`NoInfer<DataT> | undefined` → `NoInfer<DataT | undefined>`)
- This prevents TypeScript from incorrectly inferring `DataT` from the `getCachedData` return type when used together with `transform`
- Adds a type test for the `transform` + `getCachedData` combination

## Context

When `useAsyncData` is used with both `transform` and `getCachedData`, TypeScript incorrectly infers `DataT` from the `getCachedData` return type instead of from `transform`. This happens because `undefined` sits outside `NoInfer`, giving TypeScript a "crack" to perform inference through the union.

By wrapping the entire return type as `NoInfer<DataT | undefined>`, inference is fully blocked on this parameter, and TypeScript correctly infers `DataT` from the `transform` function.

Closes #29567

## Test plan

- [x] Added type test in `test/fixtures/basic-types/app/app-types.ts` verifying `transform` + `getCachedData` infers correctly
- [x] Existing `getCachedData` type tests still pass (error cases preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)