### PR TITLE
ci: add agent-scan workflow

### DIFF
--- a/.github/workflows/agent-scan.yml
+++ b/.github/workflows/agent-scan.yml
@@ -33,7 +33,7 @@ jobs:
           skip-members: "dependabot,renovate"
           agent-scan-comment: false
       - name: Label flagged PR
-        if: contains(fromJSON('["automation","suspicious"]'), steps.agentscan.outputs.classification)
+        if: contains(fromJSON('["automation","suspicious"]'), steps.agentscan.outputs.classification) && !contains(steps.agentscan.outputs.community-flagged, 'true')
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
@@ -45,6 +45,22 @@ jobs:
               repo: context.repo.repo,
               issue_number: prNumber,
               labels: ['possible bot'],
+            });
+
+            await github.rest.issues.addComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: [
+                "We've flagged this as a potential contribution without a human behind it. We welcome the thoughtful use of AI tools when contributing to Nuxt, but ask all contributors to follow [two core principles](https://roe.dev/blog/using-ai-in-open-source):",
+                '',
+                '1. **Never let an LLM speak for you** - all comments, issues, and PR descriptions should be written in your own words, reflecting your own understanding.',
+                '2. **Never let an LLM think for you** - only submit contributions you fully understand and can explain.',
+                '',
+                'Please review our [AI-assisted contribution guidelines](https://nuxt.com/docs/community/contribution#ai-assisted-contributions) and update this contribution if needed.',
+                '',
+                'If this was flagged in error, we apologise! 😳 Just let us know. 🙏',
+                ].join('\n'),
             });
       - name: Close community flagged accounts
         if: steps.agentscan.outputs.community-flagged == 'true'
@@ -59,4 +75,3 @@ jobs:
               pull_number: prNumber,
               state: 'closed',
             });
-

--- a/.github/workflows/agent-scan.yml
+++ b/.github/workflows/agent-scan.yml
@@ -1,23 +1,30 @@
 name: agent-scan
 
 on:
-  issues:
-    types:
-        - opened
-        - reopened
   pull_request_target:
     types:
-        - opened
-        - reopened
+      - opened
+      - reopened
+
+concurrency:
+  group: agent-scan-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 permissions:
-  contents: write
+  issues: write
+  pull-requests: write
 
 jobs:
   agentscan:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - name: Cache AgentScan analysis
+        uses: actions/cache@v4
+        with:
+          path: .agentscan-cache
+          key: agentscan-cache-${{ github.actor }}
+          restore-keys: agentscan-cache-
       - name: AgentScan
         id: agentscan
         uses: MatteoGabriele/agentscan-action@a584774dd15cabe6df4c6ab45fc43514a3b56b2d
@@ -25,12 +32,13 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           skip-members: "dependabot,renovate"
           agent-scan-comment: false
-      - name: Apply label and close PR if automation detected
-        if: steps.agentscan.outputs.classification == 'automation'
+      - name: Label flagged PR
+        if: contains(fromJSON('["automation","suspicious"]'), steps.agentscan.outputs.classification)
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const prNumber = context.payload.pull_request.number;
+            const classification = '${{ steps.agentscan.outputs.classification }}';
 
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
@@ -38,6 +46,12 @@ jobs:
               issue_number: prNumber,
               labels: ['possible bot'],
             });
+      - name: Close community flagged accounts
+        if: steps.agentscan.outputs.community-flagged == 'true'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
 
             await github.rest.pulls.update({
               owner: context.repo.owner,
@@ -45,16 +59,4 @@ jobs:
               pull_number: prNumber,
               state: 'closed',
             });
-      - name: Apply label if suspicious activity detected
-        if: steps.agentscan.outputs.classification == 'suspicious'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        with:
-          script: |
-            const prNumber = context.payload.pull_request.number;
 
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              labels: ['possible bot'],
-            });

--- a/.github/workflows/agent-scan.yml
+++ b/.github/workflows/agent-scan.yml
@@ -1,0 +1,60 @@
+name: agent-scan
+
+on:
+  issues:
+    types:
+        - opened
+        - reopened
+  pull_request_target:
+    types:
+        - opened
+        - reopened
+
+permissions:
+  contents: write
+
+jobs:
+  agentscan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - name: AgentScan
+        id: agentscan
+        uses: MatteoGabriele/agentscan-action@a584774dd15cabe6df4c6ab45fc43514a3b56b2d
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          skip-members: "dependabot,renovate"
+          agent-scan-comment: false
+      - name: Apply label and close PR if automation detected
+        if: steps.agentscan.outputs.classification == 'automation'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              labels: ['possible bot'],
+            });
+
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+              state: 'closed',
+            });
+      - name: Apply label if suspicious activity detected
+        if: steps.agentscan.outputs.classification == 'suspicious'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              labels: ['possible bot'],
+            });

--- a/.github/workflows/agent-scan.yml
+++ b/.github/workflows/agent-scan.yml
@@ -46,22 +46,6 @@ jobs:
               issue_number: prNumber,
               labels: ['possible bot'],
             });
-
-            await github.rest.issues.addComments({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-                body: [
-                "We've flagged this as a potential contribution without a human behind it. We welcome the thoughtful use of AI tools when contributing to Nuxt, but ask all contributors to follow [two core principles](https://roe.dev/blog/using-ai-in-open-source):",
-                '',
-                '1. **Never let an LLM speak for you** - all comments, issues, and PR descriptions should be written in your own words, reflecting your own understanding.',
-                '2. **Never let an LLM think for you** - only submit contributions you fully understand and can explain.',
-                '',
-                'Please review our [AI-assisted contribution guidelines](https://nuxt.com/docs/community/contribution#ai-assisted-contributions) and update this contribution if needed.',
-                '',
-                'If this was flagged in error, we apologise! 😳 Just let us know. 🙏',
-                ].join('\n'),
-            });
       - name: Close community flagged accounts
         if: steps.agentscan.outputs.community-flagged == 'true'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0

--- a/.github/workflows/agent-scan.yml
+++ b/.github/workflows/agent-scan.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Cache AgentScan analysis
-        uses: actions/cache@v4
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
         with:
           path: .agentscan-cache
           key: agentscan-cache-${{ github.actor }}
@@ -32,6 +32,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           skip-members: "dependabot,renovate"
           agent-scan-comment: false
+          cache-path: .agentscan-cache
       - name: Label flagged PR
         if: contains(fromJSON('["automation","suspicious"]'), steps.agentscan.outputs.classification) && !contains(steps.agentscan.outputs.community-flagged, 'true')
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This PR adds agent-scan to auto-close confirmed automated accounts by community and apply "possible bot" label for accounts labeled as suspiscious or as automated.
I think we should maybe close PRs flagged as automated (no community-flag needed) by agent-scan


cc @MatteoGabriele @cernymatej 
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
