### PR TITLE
fix(nuxt): prevent stuck navigation across layouts

### DIFF
--- a/packages/nuxt/src/pages/runtime/page.ts
+++ b/packages/nuxt/src/pages/runtime/page.ts
@@ -156,7 +156,9 @@ export default defineComponent({
 
               // force suspense remount and restart async tracking
               // if suspense is already pending and page key changed
-              if (isSuspensePending && previousPageKey !== key) {
+              // skip when inside a layout - destroying a suspensible child suspense
+              // while pending leaves the parent layout suspense permanently stuck
+              if (isSuspensePending && previousPageKey !== key && !_layoutMeta) {
                 suspenseKey++
               }
 

--- a/test/e2e/suspense-layout.test.ts
+++ b/test/e2e/suspense-layout.test.ts
@@ -1,0 +1,45 @@
+import { fileURLToPath } from 'node:url'
+import { isWindows } from 'std-env'
+import { join } from 'pathe'
+import { expect, test } from './test-utils'
+import { isDev } from '../matrix'
+
+/**
+ * This test verifies that navigation completes when a page redirects via
+ * `await navigateTo()` across a layout boundary.
+ */
+
+const fixtureDir = fileURLToPath(new URL('../fixtures/suspense-layout', import.meta.url))
+
+test.describe.configure({ mode: isDev ? 'serial' : 'parallel' })
+
+test.use({
+  nuxt: {
+    rootDir: fixtureDir,
+    dev: isDev,
+    server: true,
+    browser: true,
+    setupTimeout: (isWindows ? 360 : 120) * 1000,
+    nuxtConfig: {
+      buildDir: isDev ? join(fixtureDir, '.nuxt', 'test', Math.random().toString(36).slice(2, 8)) : undefined,
+    },
+  },
+})
+
+test.describe('Suspense navigation with layout change', () => {
+  test('should complete navigation when redirect crosses layout boundary', async ({ page, goto }) => {
+    await goto('/')
+
+    await expect(page.getByTestId('home-title')).toBeVisible()
+    await expect(page.getByTestId('alternate-layout')).toBeVisible()
+
+    await page.getByTestId('btn-redirect').click()
+
+    // Old page content should disappear after redirect across layout boundary
+    await expect(page.getByTestId('home-title')).not.toBeVisible({ timeout: 10_000 })
+    await expect(page.getByTestId('target-content')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByTestId('default-layout')).toBeVisible()
+
+    expect(page).toHaveNoErrorsOrWarnings()
+  })
+})

--- a/test/fixtures/suspense-layout/app.vue
+++ b/test/fixtures/suspense-layout/app.vue
@@ -1,0 +1,7 @@
+<template>
+  <div>
+    <NuxtLayout>
+      <NuxtPage />
+    </NuxtLayout>
+  </div>
+</template>

--- a/test/fixtures/suspense-layout/layouts/alternate.vue
+++ b/test/fixtures/suspense-layout/layouts/alternate.vue
@@ -1,0 +1,5 @@
+<template>
+  <div data-testid="alternate-layout">
+    <slot />
+  </div>
+</template>

--- a/test/fixtures/suspense-layout/layouts/default.vue
+++ b/test/fixtures/suspense-layout/layouts/default.vue
@@ -1,0 +1,5 @@
+<template>
+  <div data-testid="default-layout">
+    <slot />
+  </div>
+</template>

--- a/test/fixtures/suspense-layout/nuxt.config.ts
+++ b/test/fixtures/suspense-layout/nuxt.config.ts
@@ -1,0 +1,3 @@
+import { withMatrix } from '../../matrix'
+
+export default withMatrix({})

--- a/test/fixtures/suspense-layout/package.json
+++ b/test/fixtures/suspense-layout/package.json
@@ -1,0 +1,16 @@
+{
+  "private": true,
+  "name": "fixture-suspense-layout",
+  "scripts": {
+    "build": "nuxt build"
+  },
+  "dependencies": {
+    "nuxt": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "latest"
+  },
+  "engines": {
+    "node": "^20.19.0 || >=22.12.0"
+  }
+}

--- a/test/fixtures/suspense-layout/pages/index.vue
+++ b/test/fixtures/suspense-layout/pages/index.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+definePageMeta({ layout: 'alternate' })
+</script>
+
+<template>
+  <div>
+    <h2 data-testid="home-title">Home</h2>
+    <NuxtLink to="/redirect" data-testid="btn-redirect">
+      Navigate with redirect
+    </NuxtLink>
+  </div>
+</template>

--- a/test/fixtures/suspense-layout/pages/redirect.vue
+++ b/test/fixtures/suspense-layout/pages/redirect.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+await navigateTo('/target')
+</script>
+
+<template>
+  <div data-testid="redirect-page">Redirecting...</div>
+</template>

--- a/test/fixtures/suspense-layout/pages/target.vue
+++ b/test/fixtures/suspense-layout/pages/target.vue
@@ -1,0 +1,3 @@
+<template>
+  <div data-testid="target-content">Target reached</div>
+</template>

--- a/test/fixtures/suspense-layout/tsconfig.json
+++ b/test/fixtures/suspense-layout/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./.nuxt/tsconfig.json"
+}


### PR DESCRIPTION
### 🔗 Linked issue

resolves #34683

### 📚 Description

PR #33991 introduced a Suspense remount during rapid navigation. This breaks when a page redirects via `await navigateTo()` and the source and target pages use different layouts: the old page stays visible and navigation never completes.

The fix skips the remount when `NuxtPage` is inside a `NuxtLayout`, letting Vue handle the transition naturally. The original rapid-navigation fix still works for pages without a layout.