### PR TITLE
docs: clarify nitro auto-imports with compatibilityVersion 5

### DIFF
--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -237,7 +237,24 @@ The `nitropack` package has been renamed to `nitro`. All import paths have chang
 | `nitropack/runtime` | `nitro` |
 | `h3` (for server utilities) | `nitro/h3` |
 
-Auto-imports within server routes (`defineEventHandler`, `getQuery`, `readBody`, `useRuntimeConfig`, etc.) continue to work without changes.
+By default, auto-imports within server routes (`defineEventHandler`, `getQuery`, `readBody`, `useRuntimeConfig`, etc.) continue to work without changes.
+
+#### Nitro Auto-Imports with `compatibilityVersion: 5`
+
+When you enable `future.compatibilityVersion: 5`, Nitro auto-imports are disabled by default.
+
+If you rely on server utility auto-imports, you have two options:
+
+- Re-enable V4 behavior with `experimental.nitroAutoImports: true`.
+- Add explicit imports from `nitro/h3`.
+
+```ts
+export default defineNuxtConfig({
+  experimental: {
+    nitroAutoImports: true,
+  },
+})
+```
 
 If you have explicit imports in server code, update them:
 

--- a/docs/3.guide/6.going-further/7.layers.md
+++ b/docs/3.guide/6.going-further/7.layers.md
@@ -111,7 +111,7 @@ This means your project files will override any layer, and `~~/layers/custom` wi
 
 ## Starter Template
 
-To get started you can initialize a layer with the [nuxt/starter/layer template](https://github.com/nuxt/starter/tree/layer). This will create a basic structure you can build upon. Execute this command within the terminal to get started:
+To get started you can initialize a layer with the Nuxt layer starter template. This will create a basic structure you can build upon. Execute this command within the terminal to get started:
 
 ```bash [Terminal]
 npm create nuxt -- --template layer nuxt-layer

--- a/packages/nuxt/src/compiler/runtime/index.ts
+++ b/packages/nuxt/src/compiler/runtime/index.ts
@@ -19,7 +19,7 @@ export function defineKeyedFunctionFactory<T extends Function> (factory: ObjectF
     if (import.meta.dev) {
       throw new Error(
         `[nuxt:compiler] \`${factory.name}\` is a compiler macro that is only usable inside ` +
-        'the directories scanned by the Nuxt compiler as an exported function and imported statically. Learn more: `https://nuxt.com/docs/guide/going-further/compiler`',
+        'the directories scanned by the Nuxt compiler as an exported function and imported statically. Learn more: `https://nuxt.com/docs/4.x/api/composables/create-use-fetch`',
       )
     }
     throw new Error(`[nuxt] \`${factory.name}\` is a compiler macro and cannot be called at runtime.`)

--- a/packages/nuxt/test/compiler.test.ts
+++ b/packages/nuxt/test/compiler.test.ts
@@ -31,7 +31,7 @@ describe('defineKeyedFunctionFactory', () => {
       factory: fn,
     })
 
-    expect(() => factory('a', 1)).toThrowErrorMatchingInlineSnapshot(`[Error: [nuxt:compiler] \`createUseFetch\` is a compiler macro that is only usable inside the directories scanned by the Nuxt compiler as an exported function and imported statically. Learn more: \`https://nuxt.com/docs/guide/going-further/compiler\`]`)
+    expect(() => factory('a', 1)).toThrowErrorMatchingInlineSnapshot(`[Error: [nuxt:compiler] \`createUseFetch\` is a compiler macro that is only usable inside the directories scanned by the Nuxt compiler as an exported function and imported statically. Learn more: \`https://nuxt.com/docs/4.x/api/composables/create-use-fetch\`]`)
 
     vi.unstubAllGlobals()
   })

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1467,7 +1467,7 @@ export interface ConfigSchema {
      * </template>
      * ```
      *
-      * @see PR #26468
+     * @see PR #26468
      */
     lazyHydration: boolean
 

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1467,7 +1467,7 @@ export interface ConfigSchema {
      * </template>
      * ```
      *
-     * @see [PR #26468](https://github.com/nuxt/nuxt/pull/26468)
+    * @see PR #26468
      */
     lazyHydration: boolean
 

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1467,7 +1467,7 @@ export interface ConfigSchema {
      * </template>
      * ```
      *
-    * @see PR #26468
+      * @see PR #26468
      */
     lazyHydration: boolean
 


### PR DESCRIPTION
### 🔗 Linked issue

Closes #34641

### 📚 Description

Document Nitro auto-import behavior when using `future.compatibilityVersion: 5`.

This adds migration guidance that Nitro auto-imports are disabled by default with compatibility v5 and explains two options:
- enable `experimental.nitroAutoImports: true`
- add explicit imports from `nitro/h3`
