### PR TITLE
docs: clarify `getCachedData` behavior across navigation scenarios

### DIFF
--- a/docs/4.api/2.composables/use-async-data.md
+++ b/docs/4.api/2.composables/use-async-data.md
@@ -164,13 +164,18 @@ The `handler` function should be **side-effect free** to ensure predictable beha
     If you want to always reuse cached data during client-side navigation (regardless of `payloadExtraction`), provide a custom `getCachedData` function:
     ```ts
     const { data } = await useAsyncData('mountains', () => $fetch('/api/mountains'), {
-      getCachedData: (key, nuxtApp) => nuxtApp.payload.data[key],
+      getCachedData: (key, nuxtApp, ctx) => {
+        if (ctx.cause === 'refresh:manual' || ctx.cause === 'refresh:hook') {
+          return undefined
+        }
+        return nuxtApp.payload.data[key]
+      }
     })
     ```
-    This keeps the data in `payload.data` and reuses it as long as the app is alive.
+    This keeps the data in `payload.data` and reuses it during navigation, while still allowing `refresh()` to re-fetch when called manually.
 
     ::warning
-    When using a custom `getCachedData` that always returns cached data, the fetch will never be re-executed automatically. You must call `refresh()` manually to update the data.
+    When using a custom `getCachedData` that returns cached data unconditionally (without checking `ctx.cause`), calling `refresh()` will have no effect since the cached value will still be returned.
     ::
   - `pick`: only pick specified keys in this array from the `handler` function result
   - `watch`: watch reactive sources to auto-refresh

--- a/docs/4.api/2.composables/use-async-data.md
+++ b/docs/4.api/2.composables/use-async-data.md
@@ -155,6 +155,23 @@ The `handler` function should be **side-effect free** to ensure predictable beha
       : nuxtApp.static.data[key]
     ```
     Which only caches data when `experimental.payloadExtraction` of `nuxt.config` is enabled.
+
+    The default caching behavior depends on how the user navigates to the page:
+    - **Hard reload or direct access (SSR):** During hydration, data is retrieved from `nuxtApp.payload.data[key]`, so the fetch is not repeated on the client.
+    - **Client-side navigation with `payloadExtraction` enabled:** Data is retrieved from `nuxtApp.static.data[key]` (pre-extracted during generation), avoiding a new fetch.
+    - **Client-side navigation without `payloadExtraction`:** `nuxtApp.static.data[key]` will be `undefined`, so the fetch will be executed again.
+
+    If you want to always reuse cached data during client-side navigation (regardless of `payloadExtraction`), provide a custom `getCachedData` function:
+    ```ts
+    const { data } = await useAsyncData('mountains', () => $fetch('/api/mountains'), {
+      getCachedData: (key, nuxtApp) => nuxtApp.payload.data[key]
+    })
+    ```
+    This keeps the data in `payload.data` and reuses it as long as the app is alive.
+
+    ::warning
+    When using a custom `getCachedData` that always returns cached data, the fetch will never be re-executed automatically. You must call `refresh()` manually to update the data.
+    ::
   - `pick`: only pick specified keys in this array from the `handler` function result
   - `watch`: watch reactive sources to auto-refresh
   - `deep`: return data in a deep ref object. It is `false` by default to return data in a shallow ref object, which can improve performance if your data does not need to be deeply reactive.

--- a/docs/4.api/2.composables/use-async-data.md
+++ b/docs/4.api/2.composables/use-async-data.md
@@ -169,7 +169,7 @@ The `handler` function should be **side-effect free** to ensure predictable beha
           return undefined
         }
         return nuxtApp.payload.data[key]
-      }
+      },
     })
     ```
     This keeps the data in `payload.data` and reuses it during navigation, while still allowing `refresh()` to re-fetch when called manually.

--- a/docs/4.api/2.composables/use-async-data.md
+++ b/docs/4.api/2.composables/use-async-data.md
@@ -175,7 +175,7 @@ The `handler` function should be **side-effect free** to ensure predictable beha
     This keeps the data in `payload.data` and reuses it during navigation, while still allowing `refresh()` to re-fetch when called manually.
 
     ::warning
-    When using a custom `getCachedData` that returns cached data unconditionally (without checking `ctx.cause`), calling `refresh()` will have no effect since the cached value will still be returned.
+    When using a custom `getCachedData` that returns cached data unconditionally (without checking `ctx.cause`), calling `refresh()` will have no effect since the cached value will still be returned. If you also use the `watch` option, make sure to also return `undefined` when `ctx.cause === 'watch'`, otherwise watched source changes will not trigger a re-fetch.
     ::
   - `pick`: only pick specified keys in this array from the `handler` function result
   - `watch`: watch reactive sources to auto-refresh

--- a/docs/4.api/2.composables/use-async-data.md
+++ b/docs/4.api/2.composables/use-async-data.md
@@ -164,7 +164,7 @@ The `handler` function should be **side-effect free** to ensure predictable beha
     If you want to always reuse cached data during client-side navigation (regardless of `payloadExtraction`), provide a custom `getCachedData` function:
     ```ts
     const { data } = await useAsyncData('mountains', () => $fetch('/api/mountains'), {
-      getCachedData: (key, nuxtApp) => nuxtApp.payload.data[key]
+      getCachedData: (key, nuxtApp) => nuxtApp.payload.data[key],
     })
     ```
     This keeps the data in `payload.data` and reuses it as long as the app is alive.


### PR DESCRIPTION
### 🔗 Linked issue

N/A — This is a documentation improvement based on a common source of confusion around `getCachedData` behavior.

### 📚 Description

The current documentation for `useAsyncData`'s `getCachedData` option mentions that it only caches data when `experimental.payloadExtraction` is enabled, but doesn't explain what that means in practice across different navigation scenarios.

This PR adds:

- A breakdown of the three main scenarios: hard reload (SSR hydration), client-side navigation with `payloadExtraction` enabled, and client-side navigation without it
- A practical example of a custom `getCachedData` function that always reuses cached data from `payload.data`
- A warning clarifying that a custom `getCachedData` that always returns cached data will prevent automatic refetching, requiring manual `refresh()` calls to update data
