### PR TITLE
ci: correct renovate bot name in workflow

### DIFF
--- a/.github/workflows/agent-scan.yml
+++ b/.github/workflows/agent-scan.yml
@@ -30,7 +30,7 @@ jobs:
         uses: MatteoGabriele/agentscan-action@a584774dd15cabe6df4c6ab45fc43514a3b56b2d
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          skip-members: "dependabot,renovate"
+          skip-members: "dependabot,renovate[bot]"
           agent-scan-comment: false
           cache-path: .agentscan-cache
       - name: Label flagged PR


### PR DESCRIPTION
### 🔗 Linked issue

see #34681 

### 📚 Description

Adds the correct name of the renovate bot to "renovate[bot]"