### PR TITLE
ci: correct dependabot bot name in workflow

### DIFF
--- a/.github/workflows/agent-scan.yml
+++ b/.github/workflows/agent-scan.yml
@@ -30,7 +30,7 @@ jobs:
         uses: MatteoGabriele/agentscan-action@a584774dd15cabe6df4c6ab45fc43514a3b56b2d
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          skip-members: "dependabot,renovate[bot]"
+          skip-members: "dependabot[bot],renovate[bot]"
           agent-scan-comment: false
           cache-path: .agentscan-cache
       - name: Label flagged PR


### PR DESCRIPTION
### 🔗 Linked issue
see #34708 

### 📚 Description
Change the name of dependabot to dependabot[bot].
I've finally found its actual name [here](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-on-actions#restrictions-when-dependabot-triggers-events) in the docs. Before, I was getting 404s from dependabot[bot], but it might have been a hiccup. I apologize for the double PR 🙏 