### PR TITLE
refactor: unified createLog API with shared package

### DIFF
--- a/packages/kit/src/error-codes.ts
+++ b/packages/kit/src/error-codes.ts
@@ -15,228 +15,551 @@
  *   B8xxx  Kit API
  */
 
+import type { ErrorDefinition } from '../../shared/src/log.ts'
+
 // ---------- B1xxx: Build / compilation ----------
 /** Could not compile template */
-export const B1001 = 'B1001'
+export const B1001: ErrorDefinition = {
+  code: 'B1001',
+  message: 'Could not compile template {template}.',
+}
 /** Error reading template */
-export const B1002 = 'B1002'
+export const B1002: ErrorDefinition = {
+  code: 'B1002',
+  message: 'Error reading template {template}.',
+}
 /** Invalid template (missing src or getContents) */
-export const B1003 = 'B1003'
+export const B1003: ErrorDefinition = {
+  code: 'B1003',
+  message: 'Invalid template: missing `src` or `getContents`.',
+}
 /** Failed to install package */
-export const B1004 = 'B1004'
+export const B1004: ErrorDefinition = {
+  code: 'B1004',
+  message: 'Failed to install {name}.',
+}
 /** Compiler plugin failed to scan a file */
-export const B1005 = 'B1005'
+export const B1005: ErrorDefinition = {
+  code: 'B1005',
+  message: 'Plugin {plugin} failed to scan file {file}.',
+}
 /** Compiler plugin failed to read a file */
-export const B1006 = 'B1006'
+export const B1006: ErrorDefinition = {
+  code: 'B1006',
+  message: 'Cannot read file {file}.',
+}
 /** Compiler plugin afterScan hook error */
-export const B1007 = 'B1007'
+export const B1007: ErrorDefinition = {
+  code: 'B1007',
+  message: 'Error in `afterScan` hook of plugin {plugin}.',
+}
 /** No factory function found for keyed function (internal bug) */
-export const B1008 = 'B1008'
+export const B1008: ErrorDefinition = {
+  code: 'B1008',
+  message: 'No factory function found for `{function}` in file {file}. This is a Nuxt bug.',
+}
 /** Duplicate keyed function name */
-export const B1009 = 'B1009'
+export const B1009: ErrorDefinition = {
+  code: 'B1009',
+  message: 'Duplicate keyed function name `{functionName}`.',
+}
 /** Failed to read file (changed during read) */
-export const B1010 = 'B1010'
+export const B1010: ErrorDefinition = {
+  code: 'B1010',
+  message: 'Failed to read file {file} (file changed during read).',
+}
 /** Failed to read file (I/O error) */
-export const B1011 = 'B1011'
+export const B1011: ErrorDefinition = {
+  code: 'B1011',
+  message: 'Failed to read file {file}.',
+}
 /** Skipping unsafe cache path */
-export const B1012 = 'B1012'
+export const B1012: ErrorDefinition = {
+  code: 'B1012',
+  message: 'Skipping unsafe cache path {path}.',
+}
 /** Failed to restore cached file */
-export const B1013 = 'B1013'
+export const B1013: ErrorDefinition = {
+  code: 'B1013',
+  message: 'Failed to restore cached file {file}.',
+}
 /** Problem checking for external configuration files */
-export const B1014 = 'B1014'
+export const B1014: ErrorDefinition = {
+  code: 'B1014',
+  message: 'Problem checking for external configuration files.',
+}
 /** Falling back to chokidar-granular (parcel/watcher unavailable) */
-export const B1015 = 'B1015'
+export const B1015: ErrorDefinition = {
+  code: 'B1015',
+  message: 'Falling back to `chokidar-granular` watcher as `@parcel/watcher` is unavailable.',
+}
 /** Could not load @nuxt/webpack-builder */
-export const B1016 = 'B1016'
+export const B1016: ErrorDefinition = {
+  code: 'B1016',
+  message: 'Could not load `@nuxt/webpack-builder`.',
+  fix: 'Run `npm install -D @nuxt/webpack-builder` to install it.',
+}
 /** Loading builder failed */
-export const B1017 = 'B1017'
+export const B1017: ErrorDefinition = {
+  code: 'B1017',
+  message: 'Loading builder failed: {builder}.',
+}
 /** Loading server builder failed */
-export const B1018 = 'B1018'
+export const B1018: ErrorDefinition = {
+  code: 'B1018',
+  message: 'Loading server builder failed.',
+}
 /** Unknown component mode (internal bug) */
-export const B1019 = 'B1019'
+export const B1019: ErrorDefinition = {
+  code: 'B1019',
+  message: 'Unknown component mode: {mode}. This is a Nuxt bug.',
+}
 
 // ---------- B2xxx: Plugins ----------
 /** Invalid plugin metadata: not an object literal */
-export const B2001 = 'B2001'
+export const B2001: ErrorDefinition = {
+  code: 'B2001',
+  message: 'Invalid plugin metadata: not an object literal.',
+}
 /** Invalid plugin metadata: spread elements or computed keys */
-export const B2002 = 'B2002'
+export const B2002: ErrorDefinition = {
+  code: 'B2002',
+  message: 'Invalid plugin metadata: spread elements or computed keys are not supported.',
+}
 /** Invalid plugin metadata: dependsOn must be string array */
-export const B2003 = 'B2003'
+export const B2003: ErrorDefinition = {
+  code: 'B2003',
+  message: 'Invalid plugin metadata: `dependsOn` must be a string array.',
+}
 /** Plugin has no content */
-export const B2004 = 'B2004'
+export const B2004: ErrorDefinition = {
+  code: 'B2004',
+  message: 'Plugin {plugin} has no content.',
+}
 /** Plugin has no default export */
-export const B2005 = 'B2005'
+export const B2005: ErrorDefinition = {
+  code: 'B2005',
+  message: 'Plugin {plugin} has no default export.',
+}
 /** Error parsing plugin */
-export const B2006 = 'B2006'
+export const B2006: ErrorDefinition = {
+  code: 'B2006',
+  message: 'Error parsing plugin {plugin}.',
+}
 /** Plugin not wrapped in defineNuxtPlugin */
-export const B2007 = 'B2007'
+export const B2007: ErrorDefinition = {
+  code: 'B2007',
+  message: 'Plugin {plugin} is not wrapped in `defineNuxtPlugin`.',
+}
 /** Plugin depends on unregistered plugins */
-export const B2008 = 'B2008'
+export const B2008: ErrorDefinition = {
+  code: 'B2008',
+  message: 'Plugin {plugin} depends on unregistered plugins: {dependencies}.',
+}
 /** Circular dependency detected in plugins */
-export const B2009 = 'B2009'
+export const B2009: ErrorDefinition = {
+  code: 'B2009',
+  message: 'Circular dependency detected in plugins.',
+}
 /** Failed to parse plugin static properties */
-export const B2010 = 'B2010'
+export const B2010: ErrorDefinition = {
+  code: 'B2010',
+  message: 'Failed to parse static properties of plugin {plugin}.',
+}
 /** Invalid plugin: src option is required */
-export const B2011 = 'B2011'
+export const B2011: ErrorDefinition = {
+  code: 'B2011',
+  message: 'Invalid plugin: `src` option is required.',
+}
 
 // ---------- B3xxx: Components ----------
 /** Components directory not found */
-export const B3001 = 'B3001'
+export const B3001: ErrorDefinition = {
+  code: 'B3001',
+  message: 'Components directory not found: {directory}.',
+}
 /** Server components with ssr:false requires componentIslands */
-export const B3002 = 'B3002'
+export const B3002: ErrorDefinition = {
+  code: 'B3002',
+  message: 'Server components with `ssr: false` require `componentIslands` to be enabled.',
+}
 /** Standalone server components require componentIslands */
-export const B3003 = 'B3003'
+export const B3003: ErrorDefinition = {
+  code: 'B3003',
+  message: 'Standalone server components require `componentIslands` to be enabled.',
+}
 /** Component requires module installation */
-export const B3004 = 'B3004'
+export const B3004: ErrorDefinition = {
+  code: 'B3004',
+  message: 'Component {component} requires module installation.',
+}
 /** Multiple hydration strategies on same component */
-export const B3005 = 'B3005'
+export const B3005: ErrorDefinition = {
+  code: 'B3005',
+  message: 'Multiple hydration strategies detected on the same component.',
+}
 /** Lazy-hydration on non-lazy component */
-export const B3006 = 'B3006'
+export const B3006: ErrorDefinition = {
+  code: 'B3006',
+  message: 'Lazy hydration strategy used on non-lazy component.',
+}
 /** nuxt-client attribute requires selectiveClient or Vite */
-export const B3007 = 'B3007'
+export const B3007: ErrorDefinition = {
+  code: 'B3007',
+  message: '`nuxt-client` attribute requires `selectiveClient` feature or Vite.',
+}
 /** Component name typo (case-sensitive directory) */
-export const B3008 = 'B3008'
+export const B3008: ErrorDefinition = {
+  code: 'B3008',
+  message: 'Component name {component} may be a typo (case-sensitive directory).',
+}
 /** Reserved "Lazy" prefix on component */
-export const B3009 = 'B3009'
+export const B3009: ErrorDefinition = {
+  code: 'B3009',
+  message: 'Component {component} uses the reserved `Lazy` prefix.',
+}
 /** Component did not resolve to a file name */
-export const B3010 = 'B3010'
+export const B3010: ErrorDefinition = {
+  code: 'B3010',
+  message: 'Component {component} did not resolve to a file name.',
+}
 /** Duplicate component name */
-export const B3011 = 'B3011'
+export const B3011: ErrorDefinition = {
+  code: 'B3011',
+  message: 'Two component files resolving to the same name {component}.',
+}
 /** Overriding component without priority */
-export const B3012 = 'B3012'
+export const B3012: ErrorDefinition = {
+  code: 'B3012',
+  message: 'Overriding component {component} without setting a priority.',
+}
 
 // ---------- B4xxx: Pages / routing ----------
 /** Page file has no content */
-export const B4001 = 'B4001'
+export const B4001: ErrorDefinition = {
+  code: 'B4001',
+  message: 'Page file {file} has no content.',
+}
 /** Await in definePageMeta */
-export const B4002 = 'B4002'
+export const B4002: ErrorDefinition = {
+  code: 'B4002',
+  message: '`await` is not allowed inside `definePageMeta`.',
+}
 /** Multiple definePageMeta calls */
-export const B4003 = 'B4003'
+export const B4003: ErrorDefinition = {
+  code: 'B4003',
+  message: 'Multiple `definePageMeta` calls detected in {file}.',
+}
 /** Duplicate route name */
-export const B4004 = 'B4004'
+export const B4004: ErrorDefinition = {
+  code: 'B4004',
+  message: 'Route name generated for `{file}` is the same as `{existingFile}`.',
+  fix: 'Set a custom name using `definePageMeta` within one of the page files.',
+}
 /** definePageMeta must be called with object literal */
-export const B4005 = 'B4005'
+export const B4005: ErrorDefinition = {
+  code: 'B4005',
+  message: '`{fnName}` must be called with an object literal.',
+}
 /** definePageMeta must be called with serializable literal */
-export const B4006 = 'B4006'
+export const B4006: ErrorDefinition = {
+  code: 'B4006',
+  message: '`{fnName}` must be called with a serializable object literal.',
+}
 /** Error transforming page macro */
-export const B4007 = 'B4007'
+export const B4007: ErrorDefinition = {
+  code: 'B4007',
+  message: 'Error while transforming `{fnName}()`.',
+}
 /** Server pages with ssr:false requires componentIslands */
-export const B4008 = 'B4008'
+export const B4008: ErrorDefinition = {
+  code: 'B4008',
+  message: 'Server pages with `ssr: false` require `componentIslands` to be enabled.',
+}
 /** No layout name could be resolved */
-export const B4009 = 'B4009'
+export const B4009: ErrorDefinition = {
+  code: 'B4009',
+  message: 'No layout name could be resolved for {file}.',
+}
 /** No middleware name could be resolved */
-export const B4010 = 'B4010'
+export const B4010: ErrorDefinition = {
+  code: 'B4010',
+  message: 'No middleware name could be resolved for {file}.',
+}
 /** Generic page tree warning (from unplugin-vue-router) */
-export const B4011 = 'B4011'
+export const B4011: ErrorDefinition = {
+  code: 'B4011',
+  message: '{message}',
+}
 /** Incremental route update failed */
-export const B4012 = 'B4012'
+export const B4012: ErrorDefinition = {
+  code: 'B4012',
+  message: 'Incremental route update failed.',
+}
 /** Middleware already exists (name conflict) */
-export const B4013 = 'B4013'
+export const B4013: ErrorDefinition = {
+  code: 'B4013',
+  message: 'Middleware {name} already exists.',
+}
 /** Not overriding existing layout */
-export const B4014 = 'B4014'
+export const B4014: ErrorDefinition = {
+  code: 'B4014',
+  message: 'Not overriding existing layout {name}.',
+}
 
 // ---------- B5xxx: Configuration ----------
 /** Missing compatibilityDate */
-export const B5001 = 'B5001'
+export const B5001: ErrorDefinition = {
+  code: 'B5001',
+  message: 'No `compatibilityDate` is set in your Nuxt config.',
+  fix: 'Add `compatibilityDate` to your config to opt-in to new defaults.',
+}
 /** Failed to install webpack builder */
-export const B5002 = 'B5002'
+export const B5002: ErrorDefinition = {
+  code: 'B5002',
+  message: 'Failed to install `@nuxt/webpack-builder`.',
+}
 /** Reserved runtimeConfig.app namespace */
-export const B5003 = 'B5003'
+export const B5003: ErrorDefinition = {
+  code: 'B5003',
+  message: '`runtimeConfig.app` is reserved for Nuxt internal use.',
+}
 /** External config file not supported */
-export const B5004 = 'B5004'
+export const B5004: ErrorDefinition = {
+  code: 'B5004',
+  message: 'External config file `{file}` is not supported.',
+}
 /** Unable to load schema */
-export const B5005 = 'B5005'
+export const B5005: ErrorDefinition = {
+  code: 'B5005',
+  message: 'Unable to load schema.',
+}
 /** Webpack hash in dev mode causes memory leak */
-export const B5006 = 'B5006'
+export const B5006: ErrorDefinition = {
+  code: 'B5006',
+  message: 'Webpack `hash` in dev mode may cause a memory leak.',
+}
 /** Webpack target should be "node" */
-export const B5007 = 'B5007'
+export const B5007: ErrorDefinition = {
+  code: 'B5007',
+  message: 'Webpack target should be `node`.',
+}
 /** Unknown PostCSS order preset */
-export const B5008 = 'B5008'
+export const B5008: ErrorDefinition = {
+  code: 'B5008',
+  message: 'Unknown PostCSS order preset: {preset}.',
+}
 /** Falling back to chokidar for schema watching */
-export const B5009 = 'B5009'
+export const B5009: ErrorDefinition = {
+  code: 'B5009',
+  message: 'Falling back to `chokidar` for schema watching.',
+}
 /** Missing packages (dependency check) */
-export const B5010 = 'B5010'
+export const B5010: ErrorDefinition = {
+  code: 'B5010',
+  message: 'Missing packages: {packages}.',
+}
 /** Package is missing (module install) */
-export const B5011 = 'B5011'
+export const B5011: ErrorDefinition = {
+  code: 'B5011',
+  message: 'Package {name} is missing.',
+}
 /** Run command to install missing package */
-export const B5012 = 'B5012'
+export const B5012: ErrorDefinition = {
+  code: 'B5012',
+  message: 'Run `npx nuxt add {name}` to install it.',
+}
 
 // ---------- B6xxx: Head / imports ----------
 /** Importing from @unhead/vue instead of #imports */
-export const B6001 = 'B6001'
+export const B6001: ErrorDefinition = {
+  code: 'B6001',
+  message: 'Importing from `@unhead/vue` instead of `#imports`.',
+  fix: 'Use `import { ... } from \'#imports\'` instead.',
+}
 /** Auto-import name conflict with Nuxt built-in */
-export const B6002 = 'B6002'
+export const B6002: ErrorDefinition = {
+  code: 'B6002',
+  message: 'Auto-import name conflict with Nuxt built-in: {name}.',
+}
 
 // ---------- B7xxx: Webpack / Vite bundler ----------
 /** Bundle analysis requires rollup-plugin-visualizer */
-export const B7001 = 'B7001'
+export const B7001: ErrorDefinition = {
+  code: 'B7001',
+  message: 'Bundle analysis requires `rollup-plugin-visualizer`.',
+  fix: 'Run `npm install -D rollup-plugin-visualizer` to install it.',
+}
 /** Vite optimizeDeps stale */
-export const B7002 = 'B7002'
+export const B7002: ErrorDefinition = {
+  code: 'B7002',
+  message: 'Vite `optimizeDeps` may be stale.',
+}
 /** Server bundle should have one entry file */
-export const B7003 = 'B7003'
+export const B7003: ErrorDefinition = {
+  code: 'B7003',
+  message: 'Server bundle should have exactly one entry file.',
+}
 /** Webpack entry not found */
-export const B7004 = 'B7004'
+export const B7004: ErrorDefinition = {
+  code: 'B7004',
+  message: 'Webpack entry not found: {entry}.',
+}
 /** No client entry in rollupOptions */
-export const B7005 = 'B7005'
+export const B7005: ErrorDefinition = {
+  code: 'B7005',
+  message: 'No client entry found in `rollupOptions.input`.',
+}
 /** No server entry in rollupOptions */
-export const B7006 = 'B7006'
+export const B7006: ErrorDefinition = {
+  code: 'B7006',
+  message: 'No server entry found in `rollupOptions.input`.',
+}
 /** Could not load PostCSS plugin (vite) */
-export const B7007 = 'B7007'
+export const B7007: ErrorDefinition = {
+  code: 'B7007',
+  message: 'Could not load PostCSS plugin `{pluginName}`.',
+}
 /** Install @vitejs/plugin-vue-jsx for JSX support */
-export const B7008 = 'B7008'
+export const B7008: ErrorDefinition = {
+  code: 'B7008',
+  message: 'Install `@vitejs/plugin-vue-jsx` to enable JSX support.',
+  fix: 'Run `npm install -D @vitejs/plugin-vue-jsx` to install it.',
+}
 /** Install packages for decorator support */
-export const B7009 = 'B7009'
+export const B7009: ErrorDefinition = {
+  code: 'B7009',
+  message: 'Install packages for decorator support.',
+}
 /** Install packages for decorator support (nitro) */
-export const B7010 = 'B7010'
+export const B7010: ErrorDefinition = {
+  code: 'B7010',
+  message: 'Install packages for decorator support (nitro).',
+}
 /** Could not import PostCSS plugin (webpack) */
-export const B7011 = 'B7011'
+export const B7011: ErrorDefinition = {
+  code: 'B7011',
+  message: 'Could not import PostCSS plugin `{pluginName}`.',
+}
 /** Buffer size limit exceeded (ViteNode) */
-export const B7012 = 'B7012'
+export const B7012: ErrorDefinition = {
+  code: 'B7012',
+  message: 'Buffer size limit exceeded: {requiredSize} > {maxSize}.',
+}
 /** Socket path not configured (ViteNode) */
-export const B7013 = 'B7013'
+export const B7013: ErrorDefinition = {
+  code: 'B7013',
+  message: 'Socket path not configured for ViteNodeSocketServer.',
+}
 /** Webpack build failed */
-export const B7014 = 'B7014'
+export const B7014: ErrorDefinition = {
+  code: 'B7014',
+  message: 'Webpack build failed.',
+}
 /** Payload extraction recommended for full-static output */
-export const B7015 = 'B7015'
+export const B7015: ErrorDefinition = {
+  code: 'B7015',
+  message: 'Payload extraction is recommended for full-static output.',
+}
 /** Custom spaLoadingTemplate not found */
-export const B7016 = 'B7016'
+export const B7016: ErrorDefinition = {
+  code: 'B7016',
+  message: 'Custom `spaLoadingTemplate` not found: {path}.',
+}
 
 // ---------- B8xxx: Kit API ----------
 /** Nuxt instance is unavailable */
-export const B8001 = 'B8001'
+export const B8001: ErrorDefinition = {
+  code: 'B8001',
+  message: 'Nuxt instance is unavailable.',
+}
 /** `base` argument missing for createResolver */
-export const B8002 = 'B8002'
+export const B8002: ErrorDefinition = {
+  code: 'B8002',
+  message: '`base` argument is missing for `createResolver`.',
+}
 /** Nitro not initialized yet */
-export const B8003 = 'B8003'
+export const B8003: ErrorDefinition = {
+  code: 'B8003',
+  message: 'Nitro is not initialized yet. Use the `ready` hook to access Nitro.',
+}
 /** Nuxt compatibility issues found */
-export const B8004 = 'B8004'
+export const B8004: ErrorDefinition = {
+  code: 'B8004',
+  message: 'Nuxt compatibility issues found.',
+}
 /** Cannot determine nuxt version */
-export const B8005 = 'B8005'
+export const B8005: ErrorDefinition = {
+  code: 'B8005',
+  message: 'Cannot determine Nuxt version.',
+}
 /** Cannot find any nuxt version from cwd */
-export const B8006 = 'B8006'
+export const B8006: ErrorDefinition = {
+  code: 'B8006',
+  message: 'Cannot find any Nuxt version from current working directory.',
+}
 /** Invalid type template: filename must end with .d.ts */
-export const B8007 = 'B8007'
+export const B8007: ErrorDefinition = {
+  code: 'B8007',
+  message: 'Invalid type template: filename must end with `.d.ts`.',
+}
 /** Invalid template (falsy value) */
-export const B8008 = 'B8008'
+export const B8008: ErrorDefinition = {
+  code: 'B8008',
+  message: 'Invalid template: received a falsy value.',
+}
 /** Template not found (src does not exist) */
-export const B8009 = 'B8009'
+export const B8009: ErrorDefinition = {
+  code: 'B8009',
+  message: 'Template not found: `{src}` does not exist.',
+}
 /** Invalid template: neither getContents nor src provided */
-export const B8010 = 'B8010'
+export const B8010: ErrorDefinition = {
+  code: 'B8010',
+  message: 'Invalid template: neither `getContents` nor `src` provided.',
+}
 /** Invalid template: filename must be provided */
-export const B8011 = 'B8011'
+export const B8011: ErrorDefinition = {
+  code: 'B8011',
+  message: 'Invalid template: `filename` must be provided.',
+}
 /** Cannot use module outside of Nuxt context */
-export const B8012 = 'B8012'
+export const B8012: ErrorDefinition = {
+  code: 'B8012',
+  message: 'Cannot use module outside of Nuxt context.',
+}
 /** Module disabled due to incompatibility */
-export const B8013 = 'B8013'
+export const B8013: ErrorDefinition = {
+  code: 'B8013',
+  message: 'Module {name} disabled due to incompatibility.',
+}
 /** Slow module setup time */
-export const B8014 = 'B8014'
+export const B8014: ErrorDefinition = {
+  code: 'B8014',
+  message: 'Module {name} took a long time to set up ({time}ms).',
+}
 /** Nuxt module should be a function or string */
-export const B8015 = 'B8015'
+export const B8015: ErrorDefinition = {
+  code: 'B8015',
+  message: 'Nuxt module should be a function or string.',
+}
 /** Nuxt module should be a function */
-export const B8016 = 'B8016'
+export const B8016: ErrorDefinition = {
+  code: 'B8016',
+  message: 'Nuxt module should be a function: {module}.',
+}
 /** Could not load module */
-export const B8017 = 'B8017'
+export const B8017: ErrorDefinition = {
+  code: 'B8017',
+  message: 'Could not load module {name}.',
+}
 /** Error while importing module */
-export const B8018 = 'B8018'
+export const B8018: ErrorDefinition = {
+  code: 'B8018',
+  message: 'Error while importing module {name}.',
+}
 /** Error in module install/upgrade hook */
-export const B8019 = 'B8019'
+export const B8019: ErrorDefinition = {
+  code: 'B8019',
+  message: 'Error in module {action} hook for {name}.',
+}

--- a/packages/kit/src/index.ts
+++ b/packages/kit/src/index.ts
@@ -42,6 +42,8 @@ export { logger, useLogger } from './logger.ts'
 export { createBuildErrorUtils } from './errors.ts'
 export type { BuildErrorUtilsOptions, NuxtErrorOptions } from './errors.ts'
 export * as ErrorCodes from './error-codes.ts'
+export { createLog, nuxtBuildLog, formatDiagnostic } from './log.ts'
+export type { CreateLogOptions, Diagnostic, EmitContext, ErrorDefinition, Log } from './log.ts'
 
 // Dependencies
 export { ensureDependencyInstalled } from './dependency.ts'

--- a/packages/kit/src/log.ts
+++ b/packages/kit/src/log.ts
@@ -1,0 +1,39 @@
+import { colors } from 'consola/utils'
+import { isAgent, isDebug } from 'std-env'
+import { logger } from './logger.ts'
+import * as errorCodes from './error-codes.ts'
+
+import { createLog } from '../../shared/src/log.ts'
+import type { Diagnostic } from '../../shared/src/log.ts'
+
+export { createLog, interpolate, resolve } from '../../shared/src/log.ts'
+export type { CreateLogOptions, Diagnostic, EmitContext, ErrorDefinition, Log } from '../../shared/src/log.ts'
+
+export function formatDiagnostic (prefix: string, diag: Diagnostic, verbose: boolean): string {
+  const lines = [`[${prefix}_${diag.code}] ${diag.message}`]
+
+  if (diag.fix) { lines.push(` → ${colors.bold('fix:')} ` + diag.fix) }
+  if (diag.hint) { lines.push(` → ${colors.bold('hint:')} ` + diag.hint) }
+  if (diag.why) { lines.push(` → ${colors.bold('why:')} ` + diag.why) }
+  if (diag.url) { lines.push(` → ${colors.bold('url:')} ` + diag.url) }
+  if (verbose && diag.debug) {
+    const entries = Object.entries(diag.debug)
+      .map(([k, v]) => `  ${k}: ${typeof v === 'string' ? v : JSON.stringify(v)}`)
+      .join('\n')
+    lines.push(` → ${colors.bold('debug:')} ` + entries)
+  }
+  return lines.join('\n')
+}
+
+const verbose = isDebug || isAgent
+
+export const nuxtBuildLog = createLog({
+  prefix: 'NUXT',
+  verbose,
+  docs: code => `https://nuxt.com/e/${code}`,
+  errors: errorCodes,
+  onEmit (diag) {
+    const msg = formatDiagnostic('NUXT', diag, verbose)
+    if (diag.cause) { logger.warn(msg, diag.cause) } else { logger.warn(msg) }
+  },
+})

--- a/packages/nuxt/src/app/error-codes.ts
+++ b/packages/nuxt/src/app/error-codes.ts
@@ -14,140 +14,341 @@
  *   E7xxx  Payload / serialization
  */
 
+import type { ErrorDefinition } from '../../../shared/src/log.ts'
+
 // ---------- E1xxx: Core / instance ----------
 /** A composable was called outside of a valid Nuxt context */
-export const E1001 = 'E1001'
+export const E1001: ErrorDefinition = {
+  code: 'E1001',
+  message: 'A composable that requires access to the Nuxt instance was called outside of a plugin, Nuxt hook, Nuxt middleware, or Vue setup function.',
+  fix: 'Ensure the composable is called within a valid Nuxt context.',
+}
 /** Client-side runtime config key not available */
-export const E1003 = 'E1003'
+export const E1003: ErrorDefinition = {
+  code: 'E1003',
+  message: 'Could not find runtime config key `{key}` on the client side.',
+  hint: 'Only keys within `runtimeConfig.public` are accessible on the client.',
+}
 /** `setInterval` used on server */
-export const E1004 = 'E1004'
+export const E1004: ErrorDefinition = {
+  code: 'E1004',
+  message: '`setInterval` was called on the server, which may cause memory leaks.',
+  fix: 'Wrap in a client-only guard or use `onNuxtReady`.',
+}
 /** Error during app initialization */
-export const E1005 = 'E1005'
+export const E1005: ErrorDefinition = {
+  code: 'E1005',
+  message: 'Error during app initialization.',
+}
 /** `onPrehydrate` not processed by build pipeline */
-export const E1006 = 'E1006'
+export const E1006: ErrorDefinition = {
+  code: 'E1006',
+  message: '`onPrehydrate` was not processed by the build pipeline.',
+}
 /** Compiler-hint helper called at runtime */
-export const E1007 = 'E1007'
+export const E1007: ErrorDefinition = {
+  code: 'E1007',
+  message: '`{helper}` is a compiler hint and should not be called at runtime.',
+}
 /** Skipping render: a response was already set by middleware or a plugin. */
-export const E1008 = 'E1008'
+export const E1008: ErrorDefinition = {
+  code: 'E1008',
+  message: 'Skipping render: a response was already set by middleware or a plugin.',
+}
 /** Error in `vue:error` hook. */
-export const E1009 = 'E1009'
+export const E1009: ErrorDefinition = {
+  code: 'E1009',
+  message: 'Error in `vue:error` hook.',
+}
 /** Not rendering error page for bot */
-export const E1010 = 'E1010'
+export const E1010: ErrorDefinition = {
+  code: 'E1010',
+  message: 'Not rendering error page for bot.',
+}
 /** Error while mounting app. */
-export const E1011 = 'E1011'
+export const E1011: ErrorDefinition = {
+  code: 'E1011',
+  message: 'Error while mounting app.',
+}
 /** `vue:setup` callbacks must be synchronous */
-export const E1012 = 'E1012'
+export const E1012: ErrorDefinition = {
+  code: 'E1012',
+  message: '`vue:setup` callbacks must be synchronous.',
+}
 
 // ---------- E2xxx: Navigation / routing ----------
 /** Navigating to an external URL without `external: true` */
-export const E2001 = 'E2001'
+export const E2001: ErrorDefinition = {
+  code: 'E2001',
+  message: 'Navigating to an external URL is not allowed by default.',
+  fix: 'Use `navigateTo(url, { external: true })` to allow external navigation.',
+}
 /** Navigation to URL with dangerous protocol */
-export const E2002 = 'E2002'
+export const E2002: ErrorDefinition = {
+  code: 'E2002',
+  message: 'Navigation to URL with `{protocol}` protocol is blocked.',
+}
 /** `abortNavigation()` called outside middleware */
-export const E2003 = 'E2003'
+export const E2003: ErrorDefinition = {
+  code: 'E2003',
+  message: '`abortNavigation()` was called outside of a route middleware.',
+}
 /** Unknown route middleware */
-export const E2004 = 'E2004'
+export const E2004: ErrorDefinition = {
+  code: 'E2004',
+  message: 'Unknown route middleware: `{name}`.',
+  hint: 'Ensure the middleware is registered using `addRouteMiddleware` or placed in the `middleware/` directory.',
+}
 /** `useRoute` called within middleware (misleading results) */
-export const E2005 = 'E2005'
+export const E2005: ErrorDefinition = {
+  code: 'E2005',
+  message: '`useRoute` within middleware may return a misleading result.',
+  fix: 'Use the `to` and `from` arguments passed to the middleware instead.',
+}
 /** No middleware passed to `addRouteMiddleware` */
-export const E2006 = 'E2006'
+export const E2006: ErrorDefinition = {
+  code: 'E2006',
+  message: 'No middleware function passed to `addRouteMiddleware`.',
+}
 /** `setPageLayout` called on server within component */
-export const E2007 = 'E2007'
+export const E2007: ErrorDefinition = {
+  code: 'E2007',
+  message: '`setPageLayout` should not be called on the server within a component setup function.',
+}
 /** `setPageLayout` called during hydration */
-export const E2008 = 'E2008'
+export const E2008: ErrorDefinition = {
+  code: 'E2008',
+  message: '`setPageLayout` should not be called during hydration.',
+}
 /** No error handlers for middleware errors */
-export const E2009 = 'E2009'
+export const E2009: ErrorDefinition = {
+  code: 'E2009',
+  message: 'No error handlers available for middleware error.',
+}
 /** Failed to prefetch link */
-export const E2010 = 'E2010'
+export const E2010: ErrorDefinition = {
+  code: 'E2010',
+  message: 'Failed to prefetch component for link: {to}.',
+}
 /** Failed to preload route component */
-export const E2011 = 'E2011'
+export const E2011: ErrorDefinition = {
+  code: 'E2011',
+  message: 'Failed to preload route component: {component}.',
+}
 
 // ---------- E3xxx: Data fetching ----------
 /** `useFetch` URL starts with "//" */
-export const E3001 = 'E3001'
+export const E3001: ErrorDefinition = {
+  code: 'E3001',
+  message: '`useFetch` URL should not start with `//`.',
+  fix: 'Use a fully qualified URL or a path starting with `/`.',
+}
 /** `useFetch` failed to hash body */
-export const E3002 = 'E3002'
+export const E3002: ErrorDefinition = {
+  code: 'E3002',
+  message: 'Failed to hash `useFetch` request body.',
+}
 /** Component already mounted — use `$fetch` instead */
-export const E3003 = 'E3003'
+export const E3003: ErrorDefinition = {
+  code: 'E3003',
+  message: '`{composable}` should not be called after the component is already mounted.',
+  fix: 'Use `$fetch` directly for data fetching after component mount.',
+}
 /** Incompatible `useAsyncData` options */
-export const E3004 = 'E3004'
+export const E3004: ErrorDefinition = {
+  code: 'E3004',
+  message: 'Incompatible `useAsyncData` options.',
+}
 /** Do not pass `execute` directly to `watch` */
-export const E3005 = 'E3005'
+export const E3005: ErrorDefinition = {
+  code: 'E3005',
+  message: 'Do not pass `execute` or `refresh` directly to `watch`.',
+  fix: 'Use `() => execute()` or `() => refresh()` as the watcher callback.',
+}
 /** `useAsyncData` handler returned `undefined` */
-export const E3006 = 'E3006'
+export const E3006: ErrorDefinition = {
+  code: 'E3006',
+  message: '`useAsyncData` handler must not return `undefined`.',
+}
 /** asyncData should return an object */
-export const E3007 = 'E3007'
+export const E3007: ErrorDefinition = {
+  code: 'E3007',
+  message: '`asyncData` should return an object.',
+}
 
 // ---------- E4xxx: Components / layouts ----------
 /** Invalid layout selected */
-export const E4001 = 'E4001'
+export const E4001: ErrorDefinition = {
+  code: 'E4001',
+  message: 'Invalid layout `{layout}` selected.',
+}
 /** Layout does not have single root node */
-export const E4002 = 'E4002'
+export const E4002: ErrorDefinition = {
+  code: 'E4002',
+  message: 'Layout `{layout}` does not have a single root node and will cause errors on page transitions.',
+  fix: 'Wrap the layout content in a single `<div>` or `<template>` root.',
+}
 /** `<NuxtLayout>` needs single root node in slot */
-export const E4003 = 'E4003'
+export const E4003: ErrorDefinition = {
+  code: 'E4003',
+  message: '`<NuxtLayout>` needs a single root node in its default slot.',
+}
 /** Page does not have single root node */
-export const E4004 = 'E4004'
+export const E4004: ErrorDefinition = {
+  code: 'E4004',
+  message: 'Page `{page}` does not have a single root node and will cause errors on page transitions.',
+  fix: 'Wrap the page content in a single `<div>` or `<template>` root.',
+}
 /** Server component must have single root element */
-export const E4005 = 'E4005'
+export const E4005: ErrorDefinition = {
+  code: 'E4005',
+  message: 'Server component must have a single root element.',
+}
 /** SSR fallback in `<NuxtClientFallback>` */
-export const E4006 = 'E4006'
+export const E4006: ErrorDefinition = {
+  code: 'E4006',
+  message: 'SSR error in `<NuxtClientFallback>`, rendering fallback content.',
+}
 /** Layouts exist but `<NuxtLayout>` not used */
-export const E4007 = 'E4007'
+export const E4007: ErrorDefinition = {
+  code: 'E4007',
+  message: 'Layouts are defined but `<NuxtLayout>` is not used in `app.vue`.',
+  fix: 'Add `<NuxtLayout>` to your `app.vue` template.',
+}
 /** Cannot access path outside project root (test wrapper) */
-export const E4008 = 'E4008'
+export const E4008: ErrorDefinition = {
+  code: 'E4008',
+  message: 'Cannot access path `{path}` outside of the project root.',
+}
 /** Nested `<a>` tags inside `<NuxtLink>` */
-export const E4009 = 'E4009'
+export const E4009: ErrorDefinition = {
+  code: 'E4009',
+  message: 'Nested `<a>` tags inside `<NuxtLink>` are not allowed.',
+}
 /** `<NuxtLink>` conflicting props */
-export const E4010 = 'E4010'
+export const E4010: ErrorDefinition = {
+  code: 'E4010',
+  message: '`<NuxtLink>` has conflicting `to` and `href` props.',
+}
 /** Pages exist but `<NuxtPage>` not used */
-export const E4011 = 'E4011'
+export const E4011: ErrorDefinition = {
+  code: 'E4011',
+  message: 'Pages are defined but `<NuxtPage>` is not used in `app.vue`.',
+  fix: 'Add `<NuxtPage>` to your `app.vue` template.',
+}
 /** Island component error */
-export const E4012 = 'E4012'
+export const E4012: ErrorDefinition = {
+  code: 'E4012',
+  message: 'Error rendering island component `{component}`.',
+}
 /** v-for range expects integer */
-export const E4013 = 'E4013'
+export const E4013: ErrorDefinition = {
+  code: 'E4013',
+  message: '`v-for` range expects an integer value.',
+}
 /** No pages directory found (placeholder) */
-export const E4014 = 'E4014'
+export const E4014: ErrorDefinition = {
+  code: 'E4014',
+  message: 'No pages directory found.',
+}
 
 // ---------- E5xxx: Configuration / manifest ----------
 /** App manifest not enabled */
-export const E5001 = 'E5001'
+export const E5001: ErrorDefinition = {
+  code: 'E5001',
+  message: 'App manifest is not enabled.',
+}
 /** Error fetching app manifest */
-export const E5002 = 'E5002'
+export const E5002: ErrorDefinition = {
+  code: 'E5002',
+  message: 'Error fetching app manifest.',
+}
 /** Error matching route rules */
-export const E5003 = 'E5003'
+export const E5003: ErrorDefinition = {
+  code: 'E5003',
+  message: 'Error matching route rules for {path}.',
+}
 /** Setting response headers not supported in browser */
-export const E5004 = 'E5004'
+export const E5004: ErrorDefinition = {
+  code: 'E5004',
+  message: 'Setting response headers is not supported in the browser.',
+}
 
 // ---------- E6xxx: Head / SEO ----------
 /** Missing Unhead instance */
-export const E6001 = 'E6001'
+export const E6001: ErrorDefinition = {
+  code: 'E6001',
+  message: 'Missing Unhead instance. Ensure `@unhead/vue` is installed and configured.',
+}
 /** `<Title>` slot must be a single string */
-export const E6002 = 'E6002'
+export const E6002: ErrorDefinition = {
+  code: 'E6002',
+  message: '`<Title>` component slot must contain a single text node.',
+}
 /** `<Style>` slot must be a string */
-export const E6003 = 'E6003'
+export const E6003: ErrorDefinition = {
+  code: 'E6003',
+  message: '`<Style>` component slot must contain a single text node.',
+}
 
 // ---------- E7xxx: Payload / serialization ----------
 /** Payload URL must not include hostname */
-export const E7001 = 'E7001'
+export const E7001: ErrorDefinition = {
+  code: 'E7001',
+  message: 'Payload URL must not include a hostname.',
+}
 /** Cannot load payload */
-export const E7002 = 'E7002'
+export const E7002: ErrorDefinition = {
+  code: 'E7002',
+  message: 'Cannot load payload for {url}.',
+}
 /** Error preloading payload */
-export const E7003 = 'E7003'
+export const E7003: ErrorDefinition = {
+  code: 'E7003',
+  message: 'Error preloading payload for {url}.',
+}
 /** `definePayloadReviver` called in wrong context */
-export const E7004 = 'E7004'
+export const E7004: ErrorDefinition = {
+  code: 'E7004',
+  message: '`definePayloadReviver` was called in the wrong context.',
+}
 /** Cookie already expired */
-export const E7005 = 'E7005'
+export const E7005: ErrorDefinition = {
+  code: 'E7005',
+  message: 'Cookie `{name}` has already expired.',
+}
 /** Cookie being overridden */
-export const E7006 = 'E7006'
+export const E7006: ErrorDefinition = {
+  code: 'E7006',
+  message: 'Cookie `{name}` is being overridden.',
+}
 /** `useState` init must be a function */
-export const E7007 = 'E7007'
+export const E7007: ErrorDefinition = {
+  code: 'E7007',
+  message: '`useState` initial value must be a function: `useState(key, () => value)`.',
+}
 /** `callOnce` fn must be a function */
-export const E7008 = 'E7008'
+export const E7008: ErrorDefinition = {
+  code: 'E7008',
+  message: '`callOnce` second argument must be a function.',
+}
 /** `useState` key must be a string */
-export const E7009 = 'E7009'
+export const E7009: ErrorDefinition = {
+  code: 'E7009',
+  message: '`useState` key must be a string.',
+}
 /** `callOnce` key must be a string */
-export const E7010 = 'E7010'
+export const E7010: ErrorDefinition = {
+  code: 'E7010',
+  message: '`callOnce` key must be a string.',
+}
 /** `useAsyncData` key must be a string */
-export const E7011 = 'E7011'
+export const E7011: ErrorDefinition = {
+  code: 'E7011',
+  message: '`useAsyncData` key must be a string.',
+}
 /** `useAsyncData` handler must be a function */
-export const E7012 = 'E7012'
+export const E7012: ErrorDefinition = {
+  code: 'E7012',
+  message: '`useAsyncData` handler must be a function.',
+}

--- a/packages/nuxt/src/app/log.ts
+++ b/packages/nuxt/src/app/log.ts
@@ -1,0 +1,34 @@
+import { createLog } from '../../../shared/src/log.ts'
+import type { Diagnostic } from '../../../shared/src/log.ts'
+import * as errorCodes from './error-codes'
+import { tryUseNuxtApp } from './nuxt'
+
+export type { CreateLogOptions, Diagnostic, EmitContext, Log } from '../../../shared/src/log.ts'
+export { createLog, interpolate, resolve } from '../../../shared/src/log.ts'
+
+export const nuxtRuntimeLog = createLog({
+  prefix: 'NUXT',
+  verbose: false,
+  docs: code => `https://nuxt.com/e/${code}`,
+  // TODO: make it tree-shakable
+  errors: errorCodes,
+  onEmit (diag: Diagnostic) {
+    if (import.meta.client) {
+      // Browser: print for the user via console
+      const parts = [`[NUXT_${diag.code}]`]
+      if (diag.message) { parts.push(diag.message) }
+      if (diag.fix) { parts.push(diag.fix) }
+      if (diag.url) { parts.push(`See: ${diag.url}`) }
+      console.warn(parts.join(' '))
+    }
+    if (import.meta.server) {
+      // SSR: do NOT use console (would get intercepted by dev:ssr-logs)
+      // Explicitly forward structured Diagnostic object to server
+      const nuxtApp = tryUseNuxtApp()
+      if (nuxtApp?.ssrContext) {
+        (nuxtApp.ssrContext as any)._diagnostics ??= []
+        ;(nuxtApp.ssrContext as any)._diagnostics.push(diag)
+      }
+    }
+  },
+})

--- a/packages/shared/src/log.ts
+++ b/packages/shared/src/log.ts
@@ -1,0 +1,113 @@
+export type ErrorDefinition = {
+  code: string
+  message?: string
+  fix?: string
+  hint?: string
+  why?: string
+  docs?: string
+}
+
+export type EmitContext = Omit<ErrorDefinition, 'code'> & {
+  data?: Record<string, unknown>
+  debug?: Record<string, unknown>
+  cause?: Error
+  stack?: string | boolean
+}
+
+export type Diagnostic = {
+  code: string
+  message?: string
+  fix?: string
+  hint?: string
+  why?: string
+  docs?: string
+  url?: string
+  data?: Record<string, unknown>
+  debug?: Record<string, unknown>
+  cause?: Error
+  stack?: string
+}
+
+export interface CreateLogOptions {
+  prefix: string
+  verbose: boolean
+  docs?: (code: string) => string
+  errors?: Record<string, ErrorDefinition>
+  onEmit?: (diag: Diagnostic) => void
+}
+
+export function interpolate(template: string, data?: Record<string, unknown>): string {
+  if (!data) { return template }
+  return template.replace(/\{(\w+)\}/g, (_, key) => {
+    const val = data[key]
+    return val !== undefined ? String(val) : `{${key}}`
+  })
+}
+
+function interpolateOptional(template: string | undefined, data?: Record<string, unknown>): string | undefined {
+  if (!template) { return template }
+  return interpolate(template, data)
+}
+
+export function resolve(options: CreateLogOptions, code: string, ctx?: EmitContext): Diagnostic {
+  const def = options.errors?.[code]
+  const data = ctx?.data
+
+  const message = interpolateOptional(ctx?.message ?? def?.message, data)
+  const fix = interpolateOptional(ctx?.fix ?? def?.fix, data)
+  const hint = interpolateOptional(ctx?.hint ?? def?.hint, data)
+  const why = interpolateOptional(ctx?.why ?? def?.why, data)
+  const docs = ctx?.docs ?? def?.docs
+  const url = docs ?? options.docs?.(code)
+
+  let stack: string | undefined
+  if (typeof ctx?.stack === 'string') {
+    stack = ctx.stack
+  }
+
+  return {
+    code,
+    message,
+    fix,
+    hint,
+    why,
+    docs,
+    url,
+    data,
+    debug: options.verbose ? ctx?.debug : undefined,
+    cause: ctx?.cause,
+    stack,
+  }
+}
+
+export interface Log {
+  emit: (code: string, ctx?: EmitContext) => void
+  fatal: (code: string, ctx?: EmitContext) => never
+  resolve: (code: string, ctx?: EmitContext) => Diagnostic
+}
+
+export function createLog(options: CreateLogOptions): Log {
+  function _resolve(code: string, ctx?: EmitContext): Diagnostic {
+    return resolve(options, code, ctx)
+  }
+
+  function emit(code: string, ctx?: EmitContext): void {
+    const diag = _resolve(code, ctx)
+    options.onEmit?.(diag)
+  }
+
+  function fatal(code: string, ctx?: EmitContext): never {
+    const diag = _resolve(code, ctx)
+    options.onEmit?.(diag)
+
+    const msg = diag.message
+      ? `[${options.prefix}_${code}] ${diag.message}`
+      : `[${options.prefix}_${code}]`
+    const err = new Error(msg, { cause: ctx?.cause })
+    ;(err as any).code = `${options.prefix}_${code}`
+    ;(err as any).diagnostic = diag
+    throw err
+  }
+
+  return { emit, fatal, resolve: _resolve }
+}

--- a/packages/shared/src/log.ts
+++ b/packages/shared/src/log.ts
@@ -1,19 +1,28 @@
 export type ErrorDefinition = {
   code: string
   message?: string
+  /** A concrete suggestion for how to fix the issue */
   fix?: string
+  /** A hint to help the user understand the issue */
   hint?: string
+  /** Why the issue occurred — the underlying reason */
   why?: string
+  /** A documentation URL (overrides code-derived URL) */
   docs?: string
 }
 
 export type EmitContext = Omit<ErrorDefinition, 'code'> & {
+  /** Extra data to be interpolated into the message/fix/hint/why */
   data?: Record<string, unknown>
+  /** Extra debug data included in the diagnostic only when verbose mode is enabled */
   debug?: Record<string, unknown>
-  cause?: Error
+  /** The original error that caused this diagnostic */
+  cause?: unknown
+  /** Stack trace: string to use as-is, or boolean to control automatic capture */
   stack?: string | boolean
 }
 
+/** The final diagnostic object that is emitted */
 export type Diagnostic = {
   code: string
   message?: string
@@ -21,22 +30,46 @@ export type Diagnostic = {
   hint?: string
   why?: string
   docs?: string
-  url?: string
   data?: Record<string, unknown>
   debug?: Record<string, unknown>
-  cause?: Error
+  cause?: unknown
   stack?: string
 }
 
-export interface CreateLogOptions {
+export interface CreateLogOptions<Errors extends Record<string, ErrorDefinition>> {
+  /**
+   * Module identifier used as the error tag prefix.
+   * The value is uppercased automatically.
+   *
+   * @example 'NUXT'   // → [NUXT_B1001]
+   * @example 'pinia'  // → [PINIA_001]
+   */
   prefix: string
+  /**
+   * When true, includes `debug` data in diagnostics.
+   * Typically set to `isDebug || isAgent` from `std-env`.
+   */
   verbose: boolean
+  /**
+   * Base URL generator for auto-generating docs links from error codes.
+   *
+   * @example (code) => `https://nuxt.com/e/${code}`
+   */
   docs?: (code: string) => string
-  errors?: Record<string, ErrorDefinition>
+  /** Error definitions keyed by error code (e.g., `{ B1001: { code: 'B1001', ... } }`) */
+  errors?: Errors
+  /**
+   * Called when a diagnostic is emitted via `emit()` or `fatal()`.
+   * Build-time: prints via consola. Runtime: forwards to server or console.
+   */
   onEmit?: (diag: Diagnostic) => void
 }
 
-export function interpolate(template: string, data?: Record<string, unknown>): string {
+/**
+ * Replace `{key}` placeholders in a template string with values from `data`.
+ * Unmatched keys are left as-is.
+ */
+export function interpolate (template: string, data?: Record<string, unknown>): string {
   if (!data) { return template }
   return template.replace(/\{(\w+)\}/g, (_, key) => {
     const val = data[key]
@@ -44,12 +77,21 @@ export function interpolate(template: string, data?: Record<string, unknown>): s
   })
 }
 
-function interpolateOptional(template: string | undefined, data?: Record<string, unknown>): string | undefined {
+function interpolateOptional (template: string | undefined, data?: Record<string, unknown>): string | undefined {
   if (!template) { return template }
   return interpolate(template, data)
 }
 
-export function resolve(options: CreateLogOptions, code: string, ctx?: EmitContext): Diagnostic {
+/**
+ * Resolve an error code and optional emit context into a full `Diagnostic` object.
+ *
+ * - Looks up the `ErrorDefinition` from `options.errors[code]`
+ * - Merges with `EmitContext` overrides (context wins over definition)
+ * - Interpolates all string fields (`message`, `fix`, `hint`, `why`) with `ctx.data`
+ * - Computes `url` from `options.docs(code)` unless overridden
+ * - Includes `debug` data only when `options.verbose` is true
+ */
+export function resolve<Errors extends Record<string, ErrorDefinition>> (options: CreateLogOptions<Errors>, code: keyof Errors, ctx?: EmitContext): Diagnostic {
   const def = options.errors?.[code]
   const data = ctx?.data
 
@@ -58,7 +100,7 @@ export function resolve(options: CreateLogOptions, code: string, ctx?: EmitConte
   const hint = interpolateOptional(ctx?.hint ?? def?.hint, data)
   const why = interpolateOptional(ctx?.why ?? def?.why, data)
   const docs = ctx?.docs ?? def?.docs
-  const url = docs ?? options.docs?.(code)
+  const url = docs ?? options.docs?.(code as string)
 
   let stack: string | undefined
   if (typeof ctx?.stack === 'string') {
@@ -66,13 +108,12 @@ export function resolve(options: CreateLogOptions, code: string, ctx?: EmitConte
   }
 
   return {
-    code,
+    code: code as string,
     message,
     fix,
     hint,
     why,
     docs,
-    url,
     data,
     debug: options.verbose ? ctx?.debug : undefined,
     cause: ctx?.cause,
@@ -80,34 +121,55 @@ export function resolve(options: CreateLogOptions, code: string, ctx?: EmitConte
   }
 }
 
-export interface Log {
-  emit: (code: string, ctx?: EmitContext) => void
-  fatal: (code: string, ctx?: EmitContext) => never
-  resolve: (code: string, ctx?: EmitContext) => Diagnostic
+export interface Log<Errors extends Record<string, ErrorDefinition>> {
+  /** Emit a diagnostic (warn-level). Calls `onEmit` with the resolved diagnostic. */
+  emit: (code: keyof Errors, ctx?: EmitContext) => Diagnostic
+  /** Emit a diagnostic then throw an Error with `.code` and `.diagnostic` attached. */
+  throw: (code: keyof Errors, ctx?: EmitContext) => never
+  /** Resolve a diagnostic without emitting it. */
+  resolve: (code: keyof Errors, ctx?: EmitContext) => Diagnostic
 }
 
-export function createLog(options: CreateLogOptions): Log {
-  function _resolve(code: string, ctx?: EmitContext): Diagnostic {
-    return resolve(options, code, ctx)
+/**
+ * Create a set of diagnostic utilities scoped to a specific module.
+ *
+ * @example
+ * ```ts
+ * const log = createLog({
+ *   prefix: 'NUXT',
+ *   verbose: isDebug || isAgent,
+ *   docs: (code) => `https://nuxt.com/e/${code}`,
+ *   errors: errorCodes,
+ *   onEmit(diag) { logger.warn(formatDiagnostic('NUXT', diag, verbose)) },
+ * })
+ *
+ * log.emit('B1001', { data: { template: 'my-template' } })
+ * log.fatal('B1001', { data: { template: 'my-template' } })
+ * ```
+ */
+export function createLog<Errors extends Record<string, ErrorDefinition>> (options: CreateLogOptions<Errors>): Log<Errors> {
+  function _resolve (code: keyof Errors, ctx?: EmitContext): Diagnostic {
+    return resolve<Errors>(options, code, ctx)
   }
 
-  function emit(code: string, ctx?: EmitContext): void {
+  function emit (code: keyof Errors, ctx?: EmitContext): Diagnostic {
     const diag = _resolve(code, ctx)
     options.onEmit?.(diag)
+    return diag
   }
 
-  function fatal(code: string, ctx?: EmitContext): never {
+  function fatal (code: keyof Errors, ctx?: EmitContext): never {
     const diag = _resolve(code, ctx)
     options.onEmit?.(diag)
 
     const msg = diag.message
-      ? `[${options.prefix}_${code}] ${diag.message}`
-      : `[${options.prefix}_${code}]`
+      ? `[${options.prefix}_${code as string}] ${diag.message}`
+      : `[${options.prefix}_${code as string}]`
     const err = new Error(msg, { cause: ctx?.cause })
-    ;(err as any).code = `${options.prefix}_${code}`
+    ;(err as any).code = `${options.prefix}_${code as string}`
     ;(err as any).diagnostic = diag
     throw err
   }
 
-  return { emit, fatal, resolve: _resolve }
+  return { emit, throw: fatal, resolve: _resolve }
 }

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}


### PR DESCRIPTION
## Summary

- Introduces `packages/shared/src/log.ts` — a pure, environment-agnostic `createLog()` factory with typed `ErrorDefinition`, `EmitContext`, and `Diagnostic` types, plus `{placeholder}` interpolation
- Adds `packages/kit/src/log.ts` with `nuxtBuildLog` singleton (prints via consola, verbose in debug/agent mode) and `formatDiagnostic()` 
- Adds `packages/nuxt/src/app/log.ts` with `nuxtRuntimeLog` (console.warn on client, forwards structured Diagnostic to server via ssrContext on SSR)
- Migrates all ~97 call sites across kit, nuxt, vite, webpack, and nitro-server from `throwBuildError`/`warnBuild`/`errorBuild`/`throwError`/`runtimeWarn` to `nuxtBuildLog.emit()`/`.throw()` and `nuxtRuntimeLog.emit()`/`.throw()`
- Converts all 118 error codes (B-codes + E-codes) from plain strings to `ErrorDefinition` objects with `message`, `fix`, `hint` fields while preserving JSDoc for IDE DX
- Removes `packages/kit/src/errors.ts`, `nuxt-errors.ts` files, `error-format.ts`, and old runtime error utils from `utils.ts`

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] `pnpm test` in kit and nuxt packages
- [ ] Verify `nuxtBuildLog.emit('B1001', { data: { template: 'test' } })` produces formatted output with code, message, fix, and docs URL
- [ ] Verify `nuxtBuildLog.throw('B1001')` throws with `.code = 'NUXT_B1001'` and `.diagnostic`
- [ ] Verify runtime diagnostics forward to server during SSR and print via console.warn in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)