### PR TITLE
refactor: migrate consumers to new single-arg error utils API

### DIFF
--- a/docs/1.getting-started/12.error-handling.md
+++ b/docs/1.getting-started/12.error-handling.md
@@ -206,11 +206,12 @@ Module authors can create their own scoped error utilities using `createErrorUti
 import { createErrorUtils } from '@nuxt/kit'
 
 const errorUtils = createErrorUtils({
-  module: 'my-module',
+  prefix: 'my-module',
   docsBase: 'https://my-module.dev/errors',
 })
 
-errorUtils.warn('Something is wrong.', {
+errorUtils.warn({
+  message: 'Something is wrong.',
   code: '001',
   fix: 'Check your configuration.',
 })

--- a/docs/3.guide/4.modules/4.recipes-advanced.md
+++ b/docs/3.guide/4.modules/4.recipes-advanced.md
@@ -254,16 +254,16 @@ Create a file in your module (e.g. `errors.ts`) that initializes the utilities:
 import { createErrorUtils } from '@nuxt/kit'
 
 export const errorUtils = createErrorUtils({
-  module: 'my-module',
+  prefix: 'my-module',
   docsBase: 'https://my-module.dev/errors',
 })
 ```
 
-The `module` value is uppercased and used as the error tag prefix (e.g. `[MY-MODULE_001]`). The optional `docsBase` is combined with each error code to auto-generate a documentation URL.
+The `prefix` value is uppercased and used as the error tag prefix (e.g. `[MY-MODULE_001]`). The optional `docsBase` is combined with each error code to auto-generate a documentation URL.
 
 ### Returned Utilities
 
-`createErrorUtils` returns an object with four methods, all sharing the same signature `(message, opts)`:
+`createErrorUtils` returns an object with four methods, all sharing the same signature `(info)` where `info` is an `ErrorInfo` object:
 
 | Method | Behavior |
 | --- | --- |
@@ -272,23 +272,31 @@ The `module` value is uppercased and used as the error tag prefix (e.g. `[MY-MOD
 | `errorUtils.error` | Logs an error via `consola` (without throwing). |
 | `errorUtils.format` | Returns the formatted string without logging or throwing. |
 
-### Options
+### ErrorInfo
 
-The second argument to each method accepts:
+Each method accepts a single `ErrorInfo` argument:
 
 ```ts
-interface ErrorOptions {
+interface ErrorInfo {
+  /** The error message */
+  message: string
   /** Error code, e.g. '001'. Combined with the module prefix for the tag. */
   code: string
-  /** Why the error occurred. */
+  /** The error tag prefix (overrides the one set in createErrorUtils). */
+  codePrefix?: string
+  /** Why the error occurred — the underlying reason, shown on its own line below the message. */
   why?: string
   /** A concrete suggestion for how to fix the issue. */
   fix?: string
+  /** A hint to the user about the error. */
+  hint?: string
   /** A documentation URL (overrides the auto-generated one from docsBase). */
   docs?: string
+  /** The location of source file that caused the error. */
+  source?: { file: string, line?: number, column?: number }
   /** The underlying error that caused this one. */
   cause?: unknown
-  /** Extra key-value context (only shown when an AI agent is detected). */
+  /** Extra key-value context (only shown when the formatError implementation handles it). */
   context?: Record<string, unknown>
 }
 ```
@@ -302,14 +310,16 @@ import { errorUtils } from './errors'
 export default defineNuxtModule({
   setup (options, nuxt) {
     if (!options.apiKey) {
-      return errorUtils.throw('Missing required `apiKey` option.', {
+      return errorUtils.throw({
+        message: 'Missing required `apiKey` option.',
         code: '001',
         fix: 'Set `myModule.apiKey` in your `nuxt.config`.',
       })
     }
 
     if (options.deprecated) {
-      errorUtils.warn('The `deprecated` option will be removed in the next major version.', {
+      errorUtils.warn({
+        message: 'The `deprecated` option will be removed in the next major version.',
         code: '002',
         fix: 'Use the `replacement` option instead.',
       })

--- a/packages/kit/src/compatibility.ts
+++ b/packages/kit/src/compatibility.ts
@@ -81,7 +81,7 @@ export async function checkNuxtCompatibility (constraints: NuxtCompatibility, nu
 export async function assertNuxtCompatibility (constraints: NuxtCompatibility, nuxt: Nuxt = useNuxt()): Promise<true> {
   const issues = await checkNuxtCompatibility(constraints, nuxt)
   if (issues.length) {
-    buildErrorUtils.throw('Nuxt compatibility issues found:\n' + issues.toString(), { code: ErrorCodes.B8004, fix: 'Update the module to support the current Nuxt version, or check if a newer version of the module is available.' })
+    buildErrorUtils.throw({ message: 'Nuxt compatibility issues found:\n' + issues.toString(), code: ErrorCodes.B8004, fix: 'Update the module to support the current Nuxt version, or check if a newer version of the module is available.' })
   }
   return true
 }
@@ -126,7 +126,7 @@ const NUXT_VERSION_RE = /^v/g
 export function getNuxtVersion (nuxt: Nuxt | any = useNuxt() /* TODO: LegacyNuxt */): string {
   const rawVersion = nuxt?._version || nuxt?.version || nuxt?.constructor?.version
   if (typeof rawVersion !== 'string') {
-    buildErrorUtils.throw('Cannot determine nuxt version! Is current instance passed?', { code: ErrorCodes.B8005, fix: 'Pass a valid Nuxt instance to `getNuxtVersion()`, or ensure `useNuxt()` is available in the current context.' })
+    buildErrorUtils.throw({ message: 'Cannot determine nuxt version! Is current instance passed?', code: ErrorCodes.B8005, fix: 'Pass a valid Nuxt instance to `getNuxtVersion()`, or ensure `useNuxt()` is available in the current context.' })
   }
   return rawVersion.replace(NUXT_VERSION_RE, '')
 }

--- a/packages/kit/src/components.ts
+++ b/packages/kit/src/components.ts
@@ -66,7 +66,7 @@ function addComponents (addedComponents: Component[]) {
         // but we warn if they are equal.
         if (newPriority === existingPriority) {
           const name = existingComponent.pascalName || existingComponent.kebabName
-          buildErrorUtils.warn(`Overriding ${name} component. You can specify a \`priority\` option when calling \`addComponent\` to avoid this warning.`, { code: ErrorCodes.B3012, fix: 'Specify a `priority` option when calling `addComponent` to avoid this warning.' })
+          buildErrorUtils.warn({ message: `Overriding ${name} component. You can specify a \`priority\` option when calling \`addComponent\` to avoid this warning.`, code: ErrorCodes.B3012, fix: 'Specify a `priority` option when calling `addComponent` to avoid this warning.' })
         }
         components.splice(existingComponentIndex, 1, component)
       } else {

--- a/packages/kit/src/context.ts
+++ b/packages/kit/src/context.ts
@@ -33,7 +33,7 @@ export function useNuxt (): Nuxt {
   // eslint-disable-next-line @typescript-eslint/no-deprecated
   const instance = asyncNuxtStorage.tryUse() || nuxtCtx.tryUse()
   if (!instance) {
-    return buildErrorUtils.throw('Nuxt instance is unavailable!', { code: ErrorCodes.B8001, fix: 'Ensure this is called within a Nuxt module `setup()` function, or inside a `nuxt.hook()` callback.' })
+    return buildErrorUtils.throw({ message: 'Nuxt instance is unavailable!', code: ErrorCodes.B8001, fix: 'Ensure this is called within a Nuxt module `setup()` function, or inside a `nuxt.hook()` callback.' })
   }
   return instance
 }

--- a/packages/kit/src/dependency.ts
+++ b/packages/kit/src/dependency.ts
@@ -53,7 +53,7 @@ export async function ensureDependencyInstalled (names: string | string[], optio
   }
 
   const formattedNames = missing.map(n => `\`${n}\``).join(', ')
-  buildErrorUtils.warn(`Missing ${missing.length === 1 ? 'package' : 'packages'}: ${formattedNames}`, { code: ErrorCodes.B5010, fix: `Run \`npm install ${missing.join(' ')}\` to install ${missing.length === 1 ? 'it' : 'them'}.` })
+  buildErrorUtils.warn({ message: `Missing ${missing.length === 1 ? 'package' : 'packages'}: ${formattedNames}`, code: ErrorCodes.B5010, fix: `Run \`npm install ${missing.join(' ')}\` to install ${missing.length === 1 ? 'it' : 'them'}.` })
 
   if (isCI) {
     return Array.isArray(names) ? missing : false
@@ -87,7 +87,7 @@ export async function ensureDependencyInstalled (names: string | string[], optio
     logger.success(`Installed ${formattedNames}`)
     return true
   } catch (err) {
-    buildErrorUtils.error('Failed to install dependencies.', { code: ErrorCodes.B1004, fix: `Try installing manually with \`npm install ${missing.join(' ')}\`.`, cause: err })
+    buildErrorUtils.error({ message: 'Failed to install dependencies.', code: ErrorCodes.B1004, fix: `Try installing manually with \`npm install ${missing.join(' ')}\`.`, cause: err })
     return Array.isArray(names) ? missing : false
   }
 }

--- a/packages/kit/src/errors.ts
+++ b/packages/kit/src/errors.ts
@@ -1,9 +1,9 @@
 import { colors } from 'consola/utils'
 import { isAgent } from 'std-env'
 import { createErrorUtils as createErrorUtilsBase, renderFrame, wrapLine } from '../../shared/src/error.ts'
-import type { ErrorUtils, ErrorUtilsOptions, FrameConnectors } from '../../shared/src/error.ts'
+import type { ErrorInfo, ErrorUtils, ErrorUtilsOptions, FrameConnectors } from '../../shared/src/error.ts'
 
-export type { ErrorOptions, ErrorUtils, ErrorUtilsOptions } from '../../shared/src/error.ts'
+export type { ErrorInfo, ErrorUtils, ErrorUtilsOptions } from '../../shared/src/error.ts'
 
 const connectors: FrameConnectors = {
   mid: colors.dim('├▶'),
@@ -15,32 +15,58 @@ const connectors: FrameConnectors = {
 // eslint-disable-next-line no-control-regex
 const stripAnsi = (s: string) => s.replace(/\x1B\[[0-9;]*m/g, '')
 
+const wrapOpts = { pipe: `\n${connectors.pipe}  `, stripAnsi }
+
+function resolveDocsUrl (code: string, docsBase: ErrorUtilsOptions['docsBase']): string | undefined {
+  return typeof docsBase === 'function'
+    ? docsBase(code)
+    : docsBase
+      ? `${docsBase}/${code}`
+      : undefined
+}
+
+function resolveCode (code: string, codePrefix: string | undefined): string {
+  return codePrefix ? `${codePrefix}_${code}` : code
+}
+
 export function createErrorUtils (options: ErrorUtilsOptions): ErrorUtils {
   return createErrorUtilsBase({
-    // the default formatter is used to format the error message
-    formatError: (message: string, opts): string => {
+    formatError: (item: ErrorInfo, opts: ErrorUtilsOptions): string => {
       const lines: string[] = []
 
-      if (opts.why) {
-        lines.push(wrapLine(opts.why, { pipe: `\n${connectors.pipe}  `, stripAnsi }))
+      if (item.why) {
+        lines.push(wrapLine(item.why, wrapOpts))
       }
 
-      if (opts.docsUrl) {
-        lines.push(wrapLine(`${colors.bold('see:')} ${colors.underline(opts.docsUrl)}`, { pipe: `\n${connectors.pipe}  `, stripAnsi }))
+      const docsUrl = item.docs || resolveDocsUrl(item.code, opts.docsBase)
+      if (docsUrl) {
+        lines.push(wrapLine(`${colors.bold('see:')} ${colors.underline(docsUrl)}`, wrapOpts))
       }
 
-      if (opts.fix) {
-        lines.push(wrapLine(`${colors.bold('fix:')} ${opts.fix}`, { pipe: `\n${connectors.pipe}  `, stripAnsi }))
+      if (item.fix) {
+        lines.push(wrapLine(`${colors.bold('fix:')} ${item.fix}`, wrapOpts))
       }
 
-      let result = `${colors.bold(`[${opts.prefix}_${opts.code}]`)} ${message}`
+      if (item.hint) {
+        lines.push(wrapLine(`${colors.bold('hint:')} ${item.hint}`, wrapOpts))
+      }
+
+      if (item.source) {
+        const loc = item.source.line != null
+          ? `${item.source.file}:${item.source.line}${item.source.column != null ? `:${item.source.column}` : ''}`
+          : item.source.file
+        lines.push(wrapLine(`${colors.bold('source:')} ${loc}`, wrapOpts))
+      }
+
+      const code = resolveCode(item.code, item.codePrefix || opts.prefix)
+      let result = `${colors.bold(`[${code}]`)} ${item.message}`
 
       if (lines.length > 0) {
         result += '\n' + renderFrame(lines, connectors)
       }
 
-      if (isAgent && opts.context) {
-        const entries = Object.entries(opts.context)
+      if (isAgent && item.context) {
+        const entries = Object.entries(item.context)
           .map(([k, v]) => `  ${k}: ${typeof v === 'string' ? v : JSON.stringify(v)}`)
           .join('\n')
         result += `\n\nDiagnostic context:\n${entries}`

--- a/packages/kit/src/index.ts
+++ b/packages/kit/src/index.ts
@@ -40,7 +40,7 @@ export { addServerHandler, addDevServerHandler, addServerPlugin, addPrerenderRou
 export { addTemplate, addServerTemplate, addTypeTemplate, normalizeTemplate, updateTemplates, writeTypes } from './template.ts'
 export { logger, useLogger } from './logger.ts'
 export { createErrorUtils } from './errors.ts'
-export type { ErrorUtils, ErrorUtilsOptions, ErrorOptions } from './errors.ts'
+export type { ErrorInfo, ErrorUtils, ErrorUtilsOptions } from './errors.ts'
 export * as ErrorCodes from './error-codes.ts'
 
 // Dependencies

--- a/packages/kit/src/layout.ts
+++ b/packages/kit/src/layout.ts
@@ -17,10 +17,11 @@ export function addLayout (template: NuxtTemplate | string, name?: string): void
   nuxt.hook('app:templates', (app) => {
     if (layoutName in app.layouts) {
       const relativePath = reverseResolveAlias(app.layouts[layoutName]!.file, { ...nuxt?.options.alias || {}, ...strippedAtAliases }).pop() || app.layouts[layoutName]!.file
-      return buildErrorUtils.warn(
-        `Not overriding \`${layoutName}\` (provided by \`${relativePath}\`) with \`${src || filename}\`.`,
-        { code: ErrorCodes.B4014, fix: 'Rename one of the layouts, or remove the duplicate layout registration.' },
-      )
+      return buildErrorUtils.warn({
+        message: `Not overriding \`${layoutName}\` (provided by \`${relativePath}\`) with \`${src || filename}\`.`,
+        code: ErrorCodes.B4014,
+        fix: 'Rename one of the layouts, or remove the duplicate layout registration.',
+      })
     }
     app.layouts[layoutName] = {
       file: join('#build', filename),

--- a/packages/kit/src/loader/nuxt.ts
+++ b/packages/kit/src/loader/nuxt.ts
@@ -31,7 +31,7 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
   }, '')
 
   if (!resolvedPath) {
-    buildErrorUtils.throw(`Cannot find any nuxt version from ${opts.cwd}`, { code: ErrorCodes.B8006, fix: 'Run `npm install nuxt` in your project directory to install Nuxt.' })
+    buildErrorUtils.throw({ message: `Cannot find any nuxt version from ${opts.cwd}`, code: ErrorCodes.B8006, fix: 'Run `npm install nuxt` in your project directory to install Nuxt.' })
   }
   const { loadNuxt } = await import(pathToFileURL(resolvedPath).href).then(r => interopDefault(r)) as typeof import('nuxt')
   const nuxt = await loadNuxt(opts)

--- a/packages/kit/src/module/define.ts
+++ b/packages/kit/src/module/define.ts
@@ -87,7 +87,7 @@ function _defineNuxtModule<
   // Module format is always a simple function
   async function normalizedModule (inlineOptions: Partial<TOptions>, nuxt = tryUseNuxt()!): Promise<ModuleSetupReturn> {
     if (!nuxt) {
-      buildErrorUtils.throw(`Cannot use \`${module.meta.name || 'module'}\` outside of Nuxt context.`, { code: ErrorCodes.B8012, fix: 'Ensure this module is registered in the `modules` array of `nuxt.config`, not called directly.' })
+      buildErrorUtils.throw({ message: `Cannot use \`${module.meta.name || 'module'}\` outside of Nuxt context.`, code: ErrorCodes.B8012, fix: 'Ensure this module is registered in the `modules` array of `nuxt.config`, not called directly.' })
     }
 
     // Avoid duplicate installs
@@ -110,7 +110,7 @@ function _defineNuxtModule<
           error.name = 'ModuleCompatibilityError'
           throw error
         }
-        buildErrorUtils.warn(errorMessage, { code: ErrorCodes.B8013, fix: 'Update the module to a version that supports the current Nuxt version, or set `experimental.enforceModuleCompatibility` to `true` to make this a fatal error.' })
+        buildErrorUtils.warn({ message: errorMessage, code: ErrorCodes.B8013, fix: 'Update the module to a version that supports the current Nuxt version, or set `experimental.enforceModuleCompatibility` to `true` to make this a fatal error.' })
         return
       }
     }
@@ -138,7 +138,7 @@ function _defineNuxtModule<
 
     // Measure setup time
     if (setupTime > 5000 && uniqueKey !== '@nuxt/telemetry') {
-      buildErrorUtils.warn(`Slow module \`${moduleName}\` took \`${setupTime}ms\` to setup.`, { code: ErrorCodes.B8014, fix: 'Consider deferring expensive operations to a later hook (e.g., `build:before`) to reduce startup time.' })
+      buildErrorUtils.warn({ message: `Slow module \`${moduleName}\` took \`${setupTime}ms\` to setup.`, code: ErrorCodes.B8014, fix: 'Consider deferring expensive operations to a later hook (e.g., `build:before`) to reduce startup time.' })
     } else if (nuxt.options.debug && nuxt.options.debug.modules) {
       logger.info(`Module \`${moduleName}\` took \`${setupTime}ms\` to setup.`)
     }

--- a/packages/kit/src/module/install.ts
+++ b/packages/kit/src/module/install.ts
@@ -287,7 +287,7 @@ export async function loadNuxtModuleInstance (nuxtModule: string | NuxtModule, n
   }
 
   if (typeof nuxtModule !== 'string') {
-    return buildErrorUtils.throw(`Nuxt module should be a function or a string to import. Received: \`${nuxtModule}\`.`, { code: ErrorCodes.B8015, fix: 'Pass a module function or a string package name to the `modules` array in `nuxt.config`.', context: { received: typeof nuxtModule } })
+    return buildErrorUtils.throw({ message: `Nuxt module should be a function or a string to import. Received: \`${nuxtModule}\`.`, code: ErrorCodes.B8015, fix: 'Pass a module function or a string package name to the `modules` array in `nuxt.config`.', context: { received: typeof nuxtModule } })
   }
 
   const jiti = createJiti(nuxt.options.rootDir, { alias: nuxt.options.alias })
@@ -309,7 +309,7 @@ export async function loadNuxtModuleInstance (nuxtModule: string | NuxtModule, n
     const resolvedNuxtModule = await jiti.import<NuxtModule<any>>(src, { default: true })
 
     if (typeof resolvedNuxtModule !== 'function') {
-      return buildErrorUtils.throw(`Nuxt module should be a function: \`${nuxtModule}\`.`, { code: ErrorCodes.B8016, fix: 'Ensure the module has a default export that is a function. Use `defineNuxtModule()` to create a valid module.' })
+      return buildErrorUtils.throw({ message: `Nuxt module should be a function: \`${nuxtModule}\`.`, code: ErrorCodes.B8016, fix: 'Ensure the module has a default export that is a function. Use `defineNuxtModule()` to create a valid module.' })
     }
 
     // nuxt-module-builder generates a module.json with metadata including the version
@@ -322,19 +322,19 @@ export async function loadNuxtModuleInstance (nuxtModule: string | NuxtModule, n
   } catch (error: unknown) {
     const code = (error as Error & { code?: string }).code
     if (code === 'ERR_PACKAGE_PATH_NOT_EXPORTED' || code === 'ERR_UNSUPPORTED_DIR_IMPORT' || code === 'ENOTDIR') {
-      return buildErrorUtils.throw(`Could not load \`${nuxtModule}\`. Is it installed?`, { code: ErrorCodes.B8017, fix: `Run \`npm install ${nuxtModule}\` to install it.` })
+      return buildErrorUtils.throw({ message: `Could not load \`${nuxtModule}\`. Is it installed?`, code: ErrorCodes.B8017, fix: `Run \`npm install ${nuxtModule}\` to install it.` })
     }
     if (code === 'MODULE_NOT_FOUND' || code === 'ERR_MODULE_NOT_FOUND') {
       const module = MissingModuleMatcher.exec((error as Error).message)?.[1]
       // verify that it's missing the nuxt module otherwise it may be a sub dependency of the module itself
       // i.e. module is importing a module that is missing
       if (module && !module.includes(nuxtModule as string)) {
-        return buildErrorUtils.throw(`Error while importing module \`${nuxtModule}\`: ${error}`, { code: ErrorCodes.B8018, fix: 'A sub-dependency of this module is missing. Install it, or check that the module is compatible with the current environment.' })
+        return buildErrorUtils.throw({ message: `Error while importing module \`${nuxtModule}\`: ${error}`, code: ErrorCodes.B8018, fix: 'A sub-dependency of this module is missing. Install it, or check that the module is compatible with the current environment.' })
       }
     }
   }
 
-  return buildErrorUtils.throw(`Could not load \`${nuxtModule}\`. Is it installed?`, { code: ErrorCodes.B8017, fix: `Run \`npm install ${nuxtModule}\` to install it.` })
+  return buildErrorUtils.throw({ message: `Could not load \`${nuxtModule}\`. Is it installed?`, code: ErrorCodes.B8017, fix: `Run \`npm install ${nuxtModule}\` to install it.` })
 }
 
 // --- Internal ---
@@ -380,10 +380,11 @@ async function callLifecycleHooks (nuxtModule: NuxtModule<any, Partial<any>, fal
       )
     }
   } catch (e) {
-    buildErrorUtils.error(
-      `Error while executing ${!previousVersion ? 'install' : 'upgrade'} hook for module \`${meta.name}\`: ${e}`,
-      { code: ErrorCodes.B8019, fix: 'Check the module\'s install/upgrade hook implementation, or report this issue to the module author.' },
-    )
+    buildErrorUtils.error({
+      message: `Error while executing ${!previousVersion ? 'install' : 'upgrade'} hook for module \`${meta.name}\`: ${e}`,
+      code: ErrorCodes.B8019,
+      fix: 'Check the module\'s install/upgrade hook implementation, or report this issue to the module author.',
+    })
   }
 }
 

--- a/packages/kit/src/nitro.ts
+++ b/packages/kit/src/nitro.ts
@@ -82,7 +82,7 @@ export function addPrerenderRoutes (routes: string | string[]): void {
 export function useNitro (): Nitro {
   const nuxt = useNuxt()
   if (!(nuxt as any)._nitro) {
-    buildErrorUtils.throw('Nitro is not initialized yet. You can call `useNitro()` only after `ready` hook.', { code: ErrorCodes.B8003, fix: 'Move your `useNitro()` call inside a hook that runs after initialization, such as `nuxt.hook(\'ready\', () => { ... })`.' })
+    buildErrorUtils.throw({ message: 'Nitro is not initialized yet. You can call `useNitro()` only after `ready` hook.', code: ErrorCodes.B8003, fix: 'Move your `useNitro()` call inside a hook that runs after initialization, such as `nuxt.hook(\'ready\', () => { ... })`.' })
   }
   return (nuxt as any)._nitro
 }

--- a/packages/kit/src/nuxt-errors.ts
+++ b/packages/kit/src/nuxt-errors.ts
@@ -4,7 +4,7 @@ import { logger } from './logger.ts'
 export * as ErrorCodes from './error-codes.ts'
 
 export const buildErrorUtils = createErrorUtils({
-  module: 'NUXT',
+  prefix: 'NUXT',
   docsBase: 'https://nuxt.com/e',
   logger,
 })

--- a/packages/kit/src/pages.ts
+++ b/packages/kit/src/pages.ts
@@ -54,7 +54,7 @@ export function addRouteMiddleware (input: NuxtMiddleware | NuxtMiddleware[], op
         if (options.override === true) {
           app.middleware[find] = { ...middleware }
         } else {
-          buildErrorUtils.warn(`'${middleware.name}' middleware already exists at '${foundPath}'. You can set \`override: true\` to replace it.`, { code: ErrorCodes.B4013, fix: 'Set `override: true` to replace it.' })
+          buildErrorUtils.warn({ message: `'${middleware.name}' middleware already exists at '${foundPath}'. You can set \`override: true\` to replace it.`, code: ErrorCodes.B4013, fix: 'Set `override: true` to replace it.' })
         }
       } else if (options.prepend === true) {
         app.middleware.unshift({ ...middleware })

--- a/packages/kit/src/plugin.ts
+++ b/packages/kit/src/plugin.ts
@@ -27,7 +27,7 @@ export function normalizePlugin (plugin: NuxtPlugin | string): NuxtPlugin {
   }
 
   if (!plugin.src) {
-    buildErrorUtils.throw('Invalid plugin. src option is required: ' + JSON.stringify(plugin), { code: ErrorCodes.B2011, fix: 'Pass a string path or an object with a `src` property to `addPlugin()`.' })
+    buildErrorUtils.throw({ message: 'Invalid plugin. src option is required: ' + JSON.stringify(plugin), code: ErrorCodes.B2011, fix: 'Pass a string path or an object with a `src` property to `addPlugin()`.' })
   }
 
   // Normalize full path to plugin

--- a/packages/kit/src/resolve.ts
+++ b/packages/kit/src/resolve.ts
@@ -106,7 +106,7 @@ export interface Resolver {
  */
 export function createResolver (base: string | URL): Resolver {
   if (!base) {
-    buildErrorUtils.throw('`base` argument is missing for createResolver(base)!', { code: ErrorCodes.B8002, fix: 'Pass `import.meta.url` or a directory path as the `base` argument to `createResolver()`.' })
+    buildErrorUtils.throw({ message: '`base` argument is missing for createResolver(base)!', code: ErrorCodes.B8002, fix: 'Pass `import.meta.url` or a directory path as the `base` argument to `createResolver()`.' })
   }
 
   base = base.toString()

--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -77,7 +77,7 @@ export function addTypeTemplate<T> (_template: NuxtTypeTemplate<T>, context?: { 
   const template = addTemplate(_template)
 
   if (!template.filename.endsWith('.d.ts')) {
-    buildErrorUtils.throw(`Invalid type template filename: "${template.filename}"`, { code: ErrorCodes.B8007, fix: 'Rename the template filename to end with `.d.ts`.', context: { template: template.filename } })
+    buildErrorUtils.throw({ message: `Invalid type template filename: "${template.filename}"`, code: ErrorCodes.B8007, fix: 'Rename the template filename to end with `.d.ts`.', context: { template: template.filename } })
   }
 
   // Add template to types reference
@@ -124,7 +124,7 @@ export function addTypeTemplate<T> (_template: NuxtTypeTemplate<T>, context?: { 
  */
 export function normalizeTemplate<T> (template: NuxtTemplate<T> | string, buildDir?: string): ResolvedNuxtTemplate<T> {
   if (!template) {
-    buildErrorUtils.throw('Invalid template: ' + JSON.stringify(template), { code: ErrorCodes.B8008, fix: 'Pass a valid template object or a string path to `addTemplate()`.', context: { template: JSON.stringify(template) } })
+    buildErrorUtils.throw({ message: 'Invalid template: ' + JSON.stringify(template), code: ErrorCodes.B8008, fix: 'Pass a valid template object or a string path to `addTemplate()`.', context: { template: JSON.stringify(template) } })
   }
 
   // Normalize
@@ -137,7 +137,7 @@ export function normalizeTemplate<T> (template: NuxtTemplate<T> | string, buildD
   // Use src if provided
   if (template.src) {
     if (!existsSync(template.src)) {
-      buildErrorUtils.throw('Template not found: ' + template.src, { code: ErrorCodes.B8009, fix: 'Check that the `src` path exists and is an absolute path or resolvable from the module directory.', context: { template: template.src } })
+      buildErrorUtils.throw({ message: 'Template not found: ' + template.src, code: ErrorCodes.B8009, fix: 'Check that the `src` path exists and is an absolute path or resolvable from the module directory.', context: { template: template.src } })
     }
     if (!template.filename) {
       const srcPath = parse(template.src)
@@ -146,11 +146,11 @@ export function normalizeTemplate<T> (template: NuxtTemplate<T> | string, buildD
   }
 
   if (!template.src && !template.getContents) {
-    buildErrorUtils.throw('Invalid template. Either `getContents` or `src` should be provided: ' + JSON.stringify(template), { code: ErrorCodes.B8010, fix: 'Add a `getContents` function or a `src` path to the template object.', context: { template: template.filename || template.src } })
+    buildErrorUtils.throw({ message: 'Invalid template. Either `getContents` or `src` should be provided: ' + JSON.stringify(template), code: ErrorCodes.B8010, fix: 'Add a `getContents` function or a `src` path to the template object.', context: { template: template.filename || template.src } })
   }
 
   if (!template.filename) {
-    return buildErrorUtils.throw('Invalid template. `filename` must be provided: ' + JSON.stringify(template), { code: ErrorCodes.B8011, fix: 'Add a `filename` property to the template object, or provide a `src` path (the filename will be derived from it).', context: { template: JSON.stringify(template) } })
+    return buildErrorUtils.throw({ message: 'Invalid template. `filename` must be provided: ' + JSON.stringify(template), code: ErrorCodes.B8011, fix: 'Add a `filename` property to the template object, or provide a `src` path (the filename will be derived from it).', context: { template: JSON.stringify(template) } })
   }
 
   // Always write declaration files

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -549,7 +549,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
     })
 
     if (result !== true) {
-      buildErrorUtils.warn(`Install ${result.map(d => `\`${d}\``).join(' and ')} to enable decorator support.`, { code: ErrorCodes.B7010, fix: `Run \`npm install -D ${result.join(' ')}\` to install the required Babel decorator dependencies.` })
+      buildErrorUtils.warn({ message: `Install ${result.map(d => `\`${d}\``).join(' and ')} to enable decorator support.`, code: ErrorCodes.B7010, fix: `Run \`npm install -D ${result.join(' ')}\` to install the required Babel decorator dependencies.` })
     }
 
     if (result === true) {
@@ -712,7 +712,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
 
   // For full-static output, ensure payload extraction is not disabled
   if (nitro.options.static && nuxt.options.experimental.payloadExtraction === false) {
-    buildErrorUtils.warn('Payload extraction is recommended for full-static output.', { code: ErrorCodes.B7015, fix: 'Enable it by setting `experimental.payloadExtraction` to `true` or `\'client\'`.' })
+    buildErrorUtils.warn({ message: 'Payload extraction is recommended for full-static output.', code: ErrorCodes.B7015, fix: 'Enable it by setting `experimental.payloadExtraction` to `true` or `\'client\'`.' })
   }
 
   // Trigger Nitro reload when SPA loading template changes
@@ -1060,7 +1060,7 @@ async function spaLoadingTemplate (nuxt: Nuxt) {
   }
 
   if (nuxt.options.spaLoadingTemplate) {
-    buildErrorUtils.warn(`Could not load custom \`spaLoadingTemplate\` path as it does not exist: \`${nuxt.options.spaLoadingTemplate}\`.`, { code: ErrorCodes.B7016, fix: 'Check that the `spaLoadingTemplate` path in `nuxt.config` points to an existing HTML file, or set it to `true` to use the default template.' })
+    buildErrorUtils.warn({ message: `Could not load custom \`spaLoadingTemplate\` path as it does not exist: \`${nuxt.options.spaLoadingTemplate}\`.`, code: ErrorCodes.B7016, fix: 'Check that the `spaLoadingTemplate` path in `nuxt.config` points to an existing HTML file, or set it to `true` to use the default template.' })
   }
 
   return ''

--- a/packages/nitro-server/src/nuxt-errors.ts
+++ b/packages/nitro-server/src/nuxt-errors.ts
@@ -3,6 +3,6 @@ import { createErrorUtils } from '@nuxt/kit'
 export { ErrorCodes } from '@nuxt/kit'
 
 export const buildErrorUtils = createErrorUtils({
-  module: 'NUXT',
+  prefix: 'NUXT',
   docsBase: 'https://nuxt.com/e',
 })

--- a/packages/nuxt/src/app/compat/interval.ts
+++ b/packages/nuxt/src/app/compat/interval.ts
@@ -14,5 +14,5 @@ export const setInterval: typeof globalThis.setInterval = import.meta.client
         })
       }
 
-      runtimeErrorUtils.warn('`setInterval` should not be used on the server.', { code: E1004, fix: 'Consider wrapping it with an `onNuxtReady`, `onBeforeMount` or `onMounted` lifecycle hook, or ensure you only call it in the browser by checking `import.meta.client`.' })
+      runtimeErrorUtils.warn({ message: '`setInterval` should not be used on the server.', code: E1004, fix: 'Consider wrapping it with an `onNuxtReady`, `onBeforeMount` or `onMounted` lifecycle hook, or ensure you only call it in the browser by checking `import.meta.client`.' })
     }) as any

--- a/packages/nuxt/src/app/components/client-fallback.server.ts
+++ b/packages/nuxt/src/app/components/client-fallback.server.ts
@@ -70,7 +70,7 @@ const NuxtClientFallbackServer = defineComponent({
       return { ssrFailed, ssrVNodes }
     } catch (ssrError) {
       if (import.meta.dev) {
-        runtimeErrorUtils.warn('SSR rendering failed inside `<NuxtClientFallback>`, falling back to client-side rendering:', { code: E4006, fix: 'Fix the SSR error in the wrapped component. The client-side fallback will be used until then.', cause: ssrError })
+        runtimeErrorUtils.warn({ message: 'SSR rendering failed inside `<NuxtClientFallback>`, falling back to client-side rendering:', code: E4006, fix: 'Fix the SSR error in the wrapped component. The client-side fallback will be used until then.', cause: ssrError })
       }
       error.value = true
       ctx.emit('ssr-error', ssrError)

--- a/packages/nuxt/src/app/components/island-renderer.ts
+++ b/packages/nuxt/src/app/components/island-renderer.ts
@@ -32,7 +32,7 @@ export default defineComponent({
     }
 
     onErrorCaptured((e) => {
-      runtimeErrorUtils.warn('Error in island component.', { code: E4012, fix: 'Check the server component for runtime errors in its `setup()` or template.', cause: e })
+      runtimeErrorUtils.warn({ message: 'Error in island component.', code: E4012, fix: 'Check the server component for runtime errors in its `setup()` or template.', cause: e })
     })
 
     return () => createVNode(component || 'span', { ...props.context.props, 'data-island-uid': '' })

--- a/packages/nuxt/src/app/components/nuxt-island.ts
+++ b/packages/nuxt/src/app/components/nuxt-island.ts
@@ -137,7 +137,7 @@ export default defineComponent({
         while (currentEl) {
           if (isEndFragment(currentEl)) {
             if (startEl !== currentEl.previousSibling) {
-              runtimeErrorUtils.warn(`Server component "${props.name}" must have a single root element. (HTML comments are considered elements as well.)`, { code: E4005, fix: 'Wrap the server component\'s template in a single root element (e.g., a `<div>`).' })
+              runtimeErrorUtils.warn({ message: `Server component "${props.name}" must have a single root element. (HTML comments are considered elements as well.)`, code: E4005, fix: 'Wrap the server component\'s template in a single root element (e.g., a `<div>`).' })
             }
             break
           } else if (!isStartFragment(currentEl) && isFirstElement) {
@@ -220,7 +220,7 @@ export default defineComponent({
         return result
       } catch (e: any) {
         if (r.status !== 200) {
-          runtimeErrorUtils.throw(`Failed to parse island response for \`${props.name}\` (HTTP ${r.status}): ${e.message}`, { code: E4012, fix: 'Check that the server component endpoint is returning valid HTML. The server may have returned an error page.' })
+          runtimeErrorUtils.throw({ message: `Failed to parse island response for \`${props.name}\` (HTTP ${r.status}): ${e.message}`, code: E4012, fix: 'Check that the server component endpoint is returning valid HTML. The server may have returned an error page.' })
         }
         throw e
       }

--- a/packages/nuxt/src/app/components/nuxt-layout.ts
+++ b/packages/nuxt/src/app/components/nuxt-layout.ts
@@ -66,7 +66,7 @@ export default defineComponent({
       let layout = unref(props.name) ?? route?.meta.layout as string ?? routeRulesMatcher(route?.path).appLayout ?? 'default'
       if (layout && !(layout in layouts)) {
         if (import.meta.dev && layout !== 'default') {
-          runtimeErrorUtils.warn(`Invalid layout \`${layout}\` selected. Available layouts: ${Object.keys(layouts).join(', ') || 'none'}.`, {
+          runtimeErrorUtils.warn({ message: `Invalid layout \`${layout}\` selected. Available layouts: ${Object.keys(layouts).join(', ') || 'none'}.`,
             code: E4001,
             fix: `Create a \`layouts/${layout}.vue\` file, or use one of the available layouts.`,
           })
@@ -210,12 +210,12 @@ const LayoutProvider = defineComponent({
         nextTick(() => {
           if (['#comment', '#text'].includes(vnode?.el?.nodeName)) {
             if (name) {
-              runtimeErrorUtils.warn(`\`${name}\` layout does not have a single root node and will cause errors when navigating between routes.`, {
+              runtimeErrorUtils.warn({ message: `\`${name}\` layout does not have a single root node and will cause errors when navigating between routes.`,
                 code: E4002,
                 fix: 'Wrap the layout\'s template in a single root element (e.g., a `<div>`).',
               })
             } else {
-              runtimeErrorUtils.warn('`<NuxtLayout>` needs to be passed a single root node in its default slot.', {
+              runtimeErrorUtils.warn({ message: '`<NuxtLayout>` needs to be passed a single root node in its default slot.',
                 code: E4003,
                 fix: 'Wrap the content inside `<NuxtLayout>` in a single root element.',
               })

--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -140,7 +140,7 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
 
   function checkPropConflicts (props: NuxtLinkProps, main: keyof NuxtLinkProps, sub: keyof NuxtLinkProps): void {
     if (import.meta.dev && props[main] !== undefined && props[sub] !== undefined) {
-      runtimeErrorUtils.warn(`[${componentName}] \`${main}\` and \`${sub}\` cannot be used together. \`${sub}\` will be ignored.`, { code: E4010, fix: `Remove the \`${sub}\` prop and use only \`${main}\`.` })
+      runtimeErrorUtils.warn({ message: `[${componentName}] \`${main}\` and \`${sub}\` cannot be used together. \`${sub}\` will be ignored.`, code: E4010, fix: `Remove the \`${sub}\` prop and use only \`${main}\`.` })
     }
   }
 
@@ -383,7 +383,7 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
         await Promise.all([
           nuxtApp.hooks.callHook('link:prefetch', normalizedPath)?.catch((err) => {
             if (import.meta.dev) {
-              runtimeErrorUtils.warn(`Failed to prefetch \`${normalizedPath}\`.`, { code: E2010, fix: 'This may be a transient network error. Check that the target route exists and is accessible.', cause: err })
+              runtimeErrorUtils.warn({ message: `Failed to prefetch \`${normalizedPath}\`.`, code: E2010, fix: 'This may be a transient network error. Check that the target route exists and is accessible.', cause: err })
             }
           }),
           !import.meta.dev && !isExternal.value && !hasTarget.value && preloadRouteComponents(to.value as string, router).catch(() => {}),
@@ -421,7 +421,7 @@ export function defineNuxtLink (options: NuxtLinkOptions) {
       if (import.meta.dev && import.meta.server && !props.custom) {
         const isNuxtLinkChild = inject(NuxtLinkDevKeySymbol, false)
         if (isNuxtLinkChild) {
-          runtimeErrorUtils.warn('[NuxtLink] You can\'t nest one <a> inside another <a>. This will cause a hydration error on client-side.', { code: E4009, fix: 'Pass the `custom` prop to take full control of the markup.' })
+          runtimeErrorUtils.warn({ message: '[NuxtLink] You can\'t nest one <a> inside another <a>. This will cause a hydration error on client-side.', code: E4009, fix: 'Pass the `custom` prop to take full control of the markup.' })
         } else {
           provide(NuxtLinkDevKeySymbol, true)
         }

--- a/packages/nuxt/src/app/components/nuxt-root.vue
+++ b/packages/nuxt/src/app/components/nuxt-root.vue
@@ -54,7 +54,7 @@ provide(PageRouteSymbol, useRoute())
 // vue:setup hook
 const results = nuxtApp.hooks.callHookWith(hooks => hooks.map(hook => hook()), 'vue:setup', [])
 if (import.meta.dev && results && results.some(i => i && 'then' in i)) {
-  runtimeErrorUtils.warn('Error in `vue:setup`. Callbacks must be synchronous.', { code: E1012, fix: 'Remove `async` from your `vue:setup` hook callback, or move async logic into `onMounted` or a plugin.' })
+  runtimeErrorUtils.warn({ message: 'Error in `vue:setup`. Callbacks must be synchronous.', code: E1012, fix: 'Remove `async` from your `vue:setup` hook callback, or move async logic into `onMounted` or a plugin.' })
 }
 
 // error handling
@@ -63,10 +63,10 @@ const error = useError()
 const abortRender = import.meta.server && error.value && !nuxtApp.ssrContext.error
 const BOT_RE = /bot\b|chrome-lighthouse|facebookexternalhit|google\b/i
 onErrorCaptured((err, target, info) => {
-  nuxtApp.hooks.callHook('vue:error', err, target, info)?.catch(hookError => runtimeErrorUtils.warn('Error in `vue:error` hook.', { code: E1009, fix: 'Check your `vue:error` hook handler for uncaught exceptions.', cause: hookError }))
+  nuxtApp.hooks.callHook('vue:error', err, target, info)?.catch(hookError => runtimeErrorUtils.warn({ message: 'Error in `vue:error` hook.', code: E1009, fix: 'Check your `vue:error` hook handler for uncaught exceptions.', cause: hookError }))
   if (import.meta.client && BOT_RE.test(navigator.userAgent)) {
     nuxtApp.hooks.callHook('app:error', err)
-    runtimeErrorUtils.warn(`Not rendering error page for bot with user agent \`${navigator.userAgent}\`.`, { code: E1010, fix: 'This is expected behavior — bot user agents receive the raw error instead of the error page.', cause: err })
+    runtimeErrorUtils.warn({ message: `Not rendering error page for bot with user agent \`${navigator.userAgent}\`.`, code: E1010, fix: 'This is expected behavior — bot user agents receive the raw error instead of the error page.', cause: err })
     return false
   }
   if (import.meta.server || (isNuxtError(err) && (err.fatal || err.unhandled))) {

--- a/packages/nuxt/src/app/components/route-provider.ts
+++ b/packages/nuxt/src/app/components/route-provider.ts
@@ -39,7 +39,7 @@ export const defineRouteProvider = (name = 'RouteProvider') => defineComponent({
         nextTick(() => {
           if (['#comment', '#text'].includes(vnode?.el?.nodeName)) {
             const filename = (vnode?.type as any)?.__file
-            runtimeErrorUtils.warn(`\`${filename}\` does not have a single root node and will cause errors when navigating between routes.`, {
+            runtimeErrorUtils.warn({ message: `\`${filename}\` does not have a single root node and will cause errors when navigating between routes.`,
               code: E4004,
               fix: 'Wrap the page component\'s template in a single root element (e.g., a `<div>`).',
             })

--- a/packages/nuxt/src/app/components/test-component-wrapper.ts
+++ b/packages/nuxt/src/app/components/test-component-wrapper.ts
@@ -24,7 +24,7 @@ export default (url: string) => defineComponent({
     }
     const path = resolve(query.path as string)
     if (!path.startsWith(devRootDir)) {
-      runtimeErrorUtils.throw(`Cannot access path outside of project root directory: \`${path}\`.`, { code: E4008, fix: 'Use a path within the project root directory for the test component wrapper.' })
+      runtimeErrorUtils.throw({ message: `Cannot access path outside of project root directory: \`${path}\`.`, code: E4008, fix: 'Use a path within the project root directory for the test component wrapper.' })
     }
     const comp = await import(/* @vite-ignore */ path as string).then(r => r.default)
     return () => [

--- a/packages/nuxt/src/app/components/utils.ts
+++ b/packages/nuxt/src/app/components/utils.ts
@@ -89,7 +89,7 @@ export function vforToArray (source: any): any[] {
     return source.split('')
   } else if (typeof source === 'number') {
     if (import.meta.dev && !Number.isInteger(source)) {
-      runtimeErrorUtils.warn(`The v-for range expects an integer value but got ${source}.`, { code: E4013, fix: 'Use `Math.floor()` or `Math.round()` to convert the value to an integer.' })
+      runtimeErrorUtils.warn({ message: `The v-for range expects an integer value but got ${source}.`, code: E4013, fix: 'Use `Math.floor()` or `Math.round()` to convert the value to an integer.' })
     }
     const array: number[] = []
     for (let i = 0; i < source; i++) {

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -221,10 +221,10 @@ export const createUseAsyncData = defineKeyedFunctionFactory({
       // Validate arguments
       const key = computed(() => toValue(_key))
       if (!key.value || typeof key.value !== 'string') {
-        runtimeErrorUtils.throw('[useAsyncData] key must be a non-empty string.', { code: E7011, fix: 'Pass a non-empty string as the first argument to `useAsyncData()`.' })
+        runtimeErrorUtils.throw({ message: '[useAsyncData] key must be a non-empty string.', code: E7011, fix: 'Pass a non-empty string as the first argument to `useAsyncData()`.' })
       }
       if (typeof _handler !== 'function') {
-        runtimeErrorUtils.throw('[useAsyncData] handler must be a function.', { code: E7012, fix: 'Pass a function as the handler argument, e.g. `useAsyncData(\'key\', () => $fetch(\'/api/data\'))`.' })
+        runtimeErrorUtils.throw({ message: '[useAsyncData] handler must be a function.', code: E7012, fix: 'Pass a function as the handler argument, e.g. `useAsyncData(\'key\', () => $fetch(\'/api/data\'))`.' })
       }
 
       const shouldFactoryOptionsOverride = typeof options === 'function'
@@ -286,7 +286,7 @@ export const createUseAsyncData = defineKeyedFunctionFactory({
           warnings.push(`mismatching \`deep\` option`)
         }
         if (warnings.length) {
-          runtimeErrorUtils.warn(`[${functionName}] Incompatible options detected for "${key.value}":\n${warnings.map(w => `- ${w}`).join('\n')}`, {
+          runtimeErrorUtils.warn({ message: `[${functionName}] Incompatible options detected for "${key.value}":\n${warnings.map(w => `- ${w}`).join('\n')}`,
             code: E3004,
             fix: 'You can use a different key or move the call to a composable to ensure the options are shared across calls.',
           })
@@ -331,7 +331,7 @@ export const createUseAsyncData = defineKeyedFunctionFactory({
           instance.sp = []
         }
         if (import.meta.dev && !nuxtApp.isHydrating && !nuxtApp._processingMiddleware /* internal flag */ && (!instance || instance?.isMounted)) {
-          runtimeErrorUtils.warn(`[${functionName}] Component is already mounted.`, { code: E3003, fix: 'Use `$fetch()` for requests triggered after mount (e.g., in event handlers), or call `useAsyncData`/`useFetch` in the `setup()` function.' })
+          runtimeErrorUtils.warn({ message: `[${functionName}] Component is already mounted.`, code: E3003, fix: 'Use `$fetch()` for requests triggered after mount (e.g., in event handlers), or call `useAsyncData`/`useFetch` in the `setup()` function.' })
         }
         if (instance && !instance._nuxtOnBeforeMountCbs) {
           instance._nuxtOnBeforeMountCbs = []
@@ -667,7 +667,7 @@ function buildAsyncData<
       const opts = _opts && newValue === undefined && typeof _opts === 'object' ? _opts : {}
       if (import.meta.dev && newValue !== undefined && (!_opts || typeof _opts !== 'object')) {
         // @ts-expect-error private property
-        runtimeErrorUtils.warn(`[${options._functionName}] \`execute\` was passed directly to \`watch\`, which causes unintended behavior.`, { code: E3005, fix: 'Wrap the call: `watch(source, () => execute())` instead of `watch(source, execute)`.' })
+        runtimeErrorUtils.warn({ message: `[${options._functionName}] \`execute\` was passed directly to \`watch\`, which causes unintended behavior.`, code: E3005, fix: 'Wrap the call: `watch(source, () => execute())` instead of `watch(source, execute)`.' })
       }
       if (nuxtApp._asyncDataPromises[key]) {
         if ((opts.dedupe ?? options.dedupe) === 'defer') {
@@ -732,7 +732,7 @@ function buildAsyncData<
             const caller = getUserCaller()
             const explanation = caller ? ` (used at ${caller.source}:${caller.line}:${caller.column})` : ''
             // @ts-expect-error private property
-            runtimeErrorUtils.warn(`\`${options._functionName || 'useAsyncData'}${explanation}\` must return a value (it should not be \`undefined\`) or the request may be duplicated on the client side.`, { code: E3006, fix: 'Return a value from the handler function (e.g., `return null` instead of returning nothing).' })
+            runtimeErrorUtils.warn({ message: `\`${options._functionName || 'useAsyncData'}${explanation}\` must return a value (it should not be \`undefined\`) or the request may be duplicated on the client side.`, code: E3006, fix: 'Return a value from the handler function (e.g., `return null` instead of returning nothing).' })
           }
 
           nuxtApp.payload.data[key] = result

--- a/packages/nuxt/src/app/composables/component.ts
+++ b/packages/nuxt/src/app/composables/component.ts
@@ -44,7 +44,7 @@ async function runLegacyAsyncData (res: Record<string, any> | Promise<Record<str
       })
     }
   } else if (import.meta.dev) {
-    runtimeErrorUtils.warn('asyncData should return an object.', { code: E3007, fix: 'Return a plain object from the `asyncData()` function, e.g. `asyncData() { return { key: value } }`.', cause: data })
+    runtimeErrorUtils.warn({ message: 'asyncData should return an object.', code: E3007, fix: 'Return a plain object from the `asyncData()` function, e.g. `asyncData() { return { key: value } }`.', cause: data })
   }
 }
 

--- a/packages/nuxt/src/app/composables/cookie.ts
+++ b/packages/nuxt/src/app/composables/cookie.ts
@@ -106,7 +106,7 @@ export function useCookie<T = string | null | undefined> (name: string, _opts?: 
       : ref<T | undefined>(cookieValue)
 
   if (import.meta.dev && hasExpired) {
-    runtimeErrorUtils.warn(`Not setting cookie \`${name}\` as it has already expired.`, { code: E7005, fix: 'Update the `expires` or `maxAge` option to a future date.' })
+    runtimeErrorUtils.warn({ message: `Not setting cookie \`${name}\` as it has already expired.`, code: E7005, fix: 'Update the `expires` or `maxAge` option to a future date.' })
   }
 
   if (import.meta.client) {
@@ -203,7 +203,7 @@ export function useCookie<T = string | null | undefined> (name: string, _opts?: 
         if (isEqual(cookie.value, nuxtApp._cookies[name])) { return }
         // warn in dev mode
         if (import.meta.dev) {
-          runtimeErrorUtils.warn(`Cookie \`${name}\` was previously set to \`${opts.encode(nuxtApp._cookies[name] as any)}\` and is being overridden to \`${opts.encode(cookie.value as any)}\`. This may cause unexpected issues.`, { code: E7006, fix: 'Avoid setting the same cookie from multiple places during SSR, or use a single `useCookie()` composable shared across components.' })
+          runtimeErrorUtils.warn({ message: `Cookie \`${name}\` was previously set to \`${opts.encode(nuxtApp._cookies[name] as any)}\` and is being overridden to \`${opts.encode(cookie.value as any)}\`. This may cause unexpected issues.`, code: E7006, fix: 'Avoid setting the same cookie from multiple places during SSR, or use a single `useCookie()` composable shared across components.' })
         }
       }
       nuxtApp._cookies[name] = cookie.value

--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -79,7 +79,7 @@ function generateOptionSegments<_ResT, DataT, DefaultT> (opts: UseFetchOptions<_
       try {
         segments.push(hash(value))
       } catch {
-        runtimeErrorUtils.warn('[useFetch] Failed to hash body.', { code: E3002, fix: 'Pass a serializable value (plain object, string, FormData) as the request body, or provide an explicit `key` to `useFetch`.', cause: value })
+        runtimeErrorUtils.warn({ message: '[useFetch] Failed to hash body.', code: E3002, fix: 'Pass a serializable value (plain object, string, FormData) as the request body, or provide an explicit `key` to `useFetch`.', cause: value })
       }
     }
   }
@@ -182,7 +182,7 @@ export const createUseFetch = defineKeyedFunctionFactory({
       const key = computed(() => toValue(fetchOptions.key) || ('$f' + hash([autoKey, typeof _request.value === 'string' ? _request.value : '', ...generateOptionSegments(fetchOptions)])))
 
       if (!fetchOptions.baseURL && typeof _request.value === 'string' && (_request.value[0] === '/' && _request.value[1] === '/')) {
-        runtimeErrorUtils.throw(`[useFetch] The request URL must not start with "//" (received \`${_request.value}\`).`, {
+        runtimeErrorUtils.throw({ message: `[useFetch] The request URL must not start with "//" (received \`${_request.value}\`).`,
           code: E3001,
           fix: 'Use an absolute URL with a protocol or a relative path instead.',
         })

--- a/packages/nuxt/src/app/composables/manifest.ts
+++ b/packages/nuxt/src/app/composables/manifest.ts
@@ -25,7 +25,7 @@ let manifest: Promise<NuxtAppManifest> | undefined
 
 function fetchManifest (): Promise<NuxtAppManifest> {
   if (!isAppManifestEnabled) {
-    runtimeErrorUtils.throw('App manifest is not enabled.', { code: E5001, fix: 'Set `experimental.appManifest: true` in your `nuxt.config`.' })
+    runtimeErrorUtils.throw({ message: 'App manifest is not enabled.', code: E5001, fix: 'Set `experimental.appManifest: true` in your `nuxt.config`.' })
   }
   let _manifest: Promise<NuxtAppManifest>
   if (import.meta.server) {
@@ -43,7 +43,7 @@ function fetchManifest (): Promise<NuxtAppManifest> {
     if (manifest === _manifest) {
       manifest = undefined
     }
-    runtimeErrorUtils.warn('Error fetching app manifest.', { code: E5002, fix: 'Check that your server is running and the manifest endpoint is accessible. This may be a transient network issue.', cause: e })
+    runtimeErrorUtils.warn({ message: 'Error fetching app manifest.', code: E5002, fix: 'Check that your server is running and the manifest endpoint is accessible. This may be a transient network issue.', cause: e })
   })
   return _manifest
 }
@@ -51,7 +51,7 @@ function fetchManifest (): Promise<NuxtAppManifest> {
 /** @since 3.7.4 */
 export function getAppManifest (): Promise<NuxtAppManifest> {
   if (!isAppManifestEnabled) {
-    runtimeErrorUtils.throw('App manifest is not enabled.', { code: E5001, fix: 'Set `experimental.appManifest: true` in your `nuxt.config`.' })
+    runtimeErrorUtils.throw({ message: 'App manifest is not enabled.', code: E5001, fix: 'Set `experimental.appManifest: true` in your `nuxt.config`.' })
   }
   return manifest || fetchManifest()
 }
@@ -66,7 +66,7 @@ export function getRouteRules (arg: string | H3Event | { path: string }) {
   try {
     return routeRulesMatcher(path)
   } catch (e) {
-    runtimeErrorUtils.warn(`Error matching route rules for path \`${path}\`.`, { code: E5003, fix: 'Check your `routeRules` in `nuxt.config` for invalid patterns.', cause: e })
+    runtimeErrorUtils.warn({ message: `Error matching route rules for path \`${path}\`.`, code: E5003, fix: 'Check your `routeRules` in `nuxt.config` for invalid patterns.', cause: e })
     return {}
   }
 }

--- a/packages/nuxt/src/app/composables/once.ts
+++ b/packages/nuxt/src/app/composables/once.ts
@@ -24,10 +24,10 @@ export async function callOnce (...args: any[]): Promise<void> {
   if (typeof args[0] !== 'string') { args.unshift(autoKey) }
   const [_key, fn, options] = args as [string, (() => any | Promise<any>), CallOnceOptions | undefined]
   if (!_key || typeof _key !== 'string') {
-    runtimeErrorUtils.throw('[callOnce] key must be a string: ' + _key, { code: E7010, fix: 'Pass a string key as the first argument to `callOnce()`, e.g. `callOnce(\'myKey\', () => { ... })`.' })
+    runtimeErrorUtils.throw({ message: '[callOnce] key must be a string: ' + _key, code: E7010, fix: 'Pass a string key as the first argument to `callOnce()`, e.g. `callOnce(\'myKey\', () => { ... })`.' })
   }
   if (fn !== undefined && typeof fn !== 'function') {
-    runtimeErrorUtils.throw(`[callOnce] \`fn\` must be a function, but got \`${typeof fn}\`.`, {
+    runtimeErrorUtils.throw({ message: `[callOnce] \`fn\` must be a function, but got \`${typeof fn}\`.`,
       code: E7008,
       fix: 'Pass a function as the second argument: `callOnce(\'key\', () => { ... })`.',
     })

--- a/packages/nuxt/src/app/composables/payload.ts
+++ b/packages/nuxt/src/app/composables/payload.ts
@@ -71,7 +71,7 @@ const filename = '_payload.json'
 async function _getPayloadURL (url: string, opts: LoadPayloadOptions = {}) {
   const u = new URL(url, 'http://localhost')
   if (u.host !== 'localhost' || hasProtocol(u.pathname, { acceptRelative: true })) {
-    runtimeErrorUtils.throw('Payload URL must not include hostname: ' + url, { code: E7001, fix: 'Use a relative path (e.g., `/page`) instead of a full URL with hostname.' })
+    runtimeErrorUtils.throw({ message: 'Payload URL must not include hostname: ' + url, code: E7001, fix: 'Use a relative path (e.g., `/page`) instead of a full URL with hostname.' })
   }
   const config = useRuntimeConfig()
   const hash = opts.hash || (opts.fresh || import.meta.dev ? Date.now() : config.app.buildId)
@@ -86,13 +86,13 @@ async function _importPayload (payloadURL: string) {
     const res = await fetch(payloadURL, import.meta.dev ? {} : { cache: 'force-cache' })
     if (!res.ok) {
       if (import.meta.dev) {
-        runtimeErrorUtils.warn(`Cannot load payload \`${payloadURL}\`: ${res.status} ${res.statusText}`, { code: E7002, fix: 'Ensure the payload file is generated and accessible. This may be caused by a prerendering issue or a server misconfiguration.' })
+        runtimeErrorUtils.warn({ message: `Cannot load payload \`${payloadURL}\`: ${res.status} ${res.statusText}`, code: E7002, fix: 'Ensure the payload file is generated and accessible. This may be caused by a prerendering issue or a server misconfiguration.' })
       }
       return null
     }
     return await parsePayload(await res.text())
   } catch (err) {
-    runtimeErrorUtils.warn('Cannot load payload ' + payloadURL, { code: E7002, fix: 'Check your network connection and server configuration. The payload file may not be accessible.', cause: err })
+    runtimeErrorUtils.warn({ message: 'Cannot load payload ' + payloadURL, code: E7002, fix: 'Check your network connection and server configuration. The payload file may not be accessible.', cause: err })
   }
   return null
 }
@@ -209,7 +209,7 @@ export function definePayloadReviver (
   revive: (data: any) => any | undefined,
 ) {
   if (import.meta.dev && getCurrentInstance()) {
-    runtimeErrorUtils.warn('[definePayloadReviver] This function must be called in a Nuxt plugin that is `unshift`ed to the beginning of the Nuxt plugins array.', { code: E7004, fix: 'Move this call into a Nuxt plugin file and ensure the plugin is registered early in the plugin order.' })
+    runtimeErrorUtils.warn({ message: '[definePayloadReviver] This function must be called in a Nuxt plugin that is `unshift`ed to the beginning of the Nuxt plugins array.', code: E7004, fix: 'Move this call into a Nuxt plugin file and ensure the plugin is registered early in the plugin order.' })
   }
   if (import.meta.client) {
     useNuxtApp()._payloadRevivers[name] = revive

--- a/packages/nuxt/src/app/composables/preload.ts
+++ b/packages/nuxt/src/app/composables/preload.ts
@@ -70,7 +70,7 @@ export async function preloadRouteComponents (to: RouteLocationRaw, router: Rout
     const promise = Promise.resolve((component as () => unknown)())
       .catch((err) => {
         if (import.meta.dev) {
-          runtimeErrorUtils.warn(`Failed to preload route component for \`${path}\`:`, { code: E2011, fix: 'Check that the page component exists and can be imported. This may be a network issue or a missing chunk.', cause: err })
+          runtimeErrorUtils.warn({ message: `Failed to preload route component for \`${path}\`:`, code: E2011, fix: 'Check that the page component exists and can be imported. This may be a network issue or a missing chunk.', cause: err })
         }
       })
       .finally(() => promises.splice(promises.indexOf(promise), 1))

--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -24,7 +24,7 @@ export const useRoute: typeof _useRoute = () => {
   if (import.meta.dev && !getCurrentInstance() && isProcessingMiddleware()) {
     const middleware = useNuxtApp()._processingMiddleware
     const trace = getUserTrace().map(({ source, line, column }) => `at ${source}:${line}:${column}`).join('\n')
-    runtimeErrorUtils.warn(`\`useRoute\` was called within middleware${typeof middleware === 'string' ? ` (\`${middleware}\`)` : ''}. This may lead to misleading results. Instead, use the (to, from) arguments passed to the middleware to access the new and old routes.` + ('\n' + trace), {
+    runtimeErrorUtils.warn({ message: `\`useRoute\` was called within middleware${typeof middleware === 'string' ? ` (\`${middleware}\`)` : ''}. This may lead to misleading results. Instead, use the (to, from) arguments passed to the middleware to access the new and old routes.` + ('\n' + trace),
       code: E2005,
       fix: 'Use the `to` and `from` arguments passed to the middleware function instead of `useRoute()`.',
     })
@@ -75,7 +75,7 @@ export const addRouteMiddleware: AddRouteMiddleware = (name: string | RouteMiddl
   const global = options.global || typeof name !== 'string'
   const mw = typeof name !== 'string' ? name : middleware
   if (!mw) {
-    runtimeErrorUtils.warn('No route middleware passed to `addRouteMiddleware`.', { code: E2006, fix: 'Pass a middleware function as the second argument: `addRouteMiddleware(\'name\', (to, from) => { ... })`.', cause: name })
+    runtimeErrorUtils.warn({ message: 'No route middleware passed to `addRouteMiddleware`.', code: E2006, fix: 'Pass a middleware function as the second argument: `addRouteMiddleware(\'name\', (to, from) => { ... })`.', cause: name })
     return
   }
   if (global) {
@@ -166,14 +166,14 @@ export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: Na
   const isExternal = options?.external || isExternalHost
   if (isExternal) {
     if (!options?.external) {
-      runtimeErrorUtils.throw(`Navigating to external URL \`${toPath}\` is not allowed by default.`, {
+      runtimeErrorUtils.throw({ message: `Navigating to external URL \`${toPath}\` is not allowed by default.`,
         code: E2001,
         fix: `Use \`navigateTo('${toPath}', { external: true })\` to allow external navigation.`,
       })
     }
     const { protocol } = new URL(toPath, import.meta.client ? window.location.href : 'http://localhost')
     if (protocol && isScriptProtocol(protocol)) {
-      runtimeErrorUtils.throw(`Cannot navigate to URL \`${toPath}\` with \`${protocol}\` protocol.`, { code: E2002, fix: 'Script protocols (e.g., `javascript:`) are blocked for security. Use a valid `http:` or `https:` URL.' })
+      runtimeErrorUtils.throw({ message: `Cannot navigate to URL \`${toPath}\` with \`${protocol}\` protocol.`, code: E2002, fix: 'Script protocols (e.g., `javascript:`) are blocked for security. Use a valid `http:` or `https:` URL.' })
     }
   }
 
@@ -263,7 +263,7 @@ export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: Na
  */
 export const abortNavigation = (err?: string | Partial<NuxtError>) => {
   if (import.meta.dev && !isProcessingMiddleware()) {
-    runtimeErrorUtils.throw('`abortNavigation()` is only usable inside a route middleware handler.', {
+    runtimeErrorUtils.throw({ message: '`abortNavigation()` is only usable inside a route middleware handler.',
       code: E2003,
       fix: 'Move this call inside a route middleware defined with `defineNuxtRouteMiddleware()` or `addRouteMiddleware()`.',
     })
@@ -288,7 +288,7 @@ export const setPageLayout = <Layout extends keyof NuxtLayouts>(layout: unknown 
   const nuxtApp = useNuxtApp()
   if (import.meta.server) {
     if (import.meta.dev && getCurrentInstance() && nuxtApp.payload.state._layout !== layout) {
-      runtimeErrorUtils.warn('`setPageLayout` should not be called to change the layout on the server within a component as this will cause hydration errors.', {
+      runtimeErrorUtils.warn({ message: '`setPageLayout` should not be called to change the layout on the server within a component as this will cause hydration errors.',
         code: E2007,
         fix: 'Call `setPageLayout` in a route middleware or plugin instead of inside a component\'s `setup()`.',
       })
@@ -297,7 +297,7 @@ export const setPageLayout = <Layout extends keyof NuxtLayouts>(layout: unknown 
     nuxtApp.payload.state._layoutProps = props
   }
   if (import.meta.dev && nuxtApp.isHydrating && nuxtApp.payload.serverRendered && nuxtApp.payload.state._layout !== layout) {
-    runtimeErrorUtils.warn('`setPageLayout` should not be called to change the layout during hydration as this will cause hydration errors.', {
+    runtimeErrorUtils.warn({ message: '`setPageLayout` should not be called to change the layout during hydration as this will cause hydration errors.',
       code: E2008,
       fix: 'Set the layout in `definePageMeta` or in a route middleware before hydration occurs.',
     })

--- a/packages/nuxt/src/app/composables/ssr.ts
+++ b/packages/nuxt/src/app/composables/ssr.ts
@@ -73,7 +73,7 @@ export function useResponseHeader (header: string) {
     if (import.meta.dev) {
       return computed({
         get: () => undefined,
-        set: () => runtimeErrorUtils.warn('Setting response headers is not supported in the browser.', { code: E5004, fix: 'Guard this code with `import.meta.server` or move it to a server-only context.' }),
+        set: () => runtimeErrorUtils.warn({ message: 'Setting response headers is not supported in the browser.', code: E5004, fix: 'Guard this code with `import.meta.server` or move it to a server-only context.' }),
       })
     }
     return ref()
@@ -120,7 +120,7 @@ export function onPrehydrate (callback: string | ((el: HTMLElement) => void), ke
   if (import.meta.client) { return }
 
   if (typeof callback !== 'string') {
-    runtimeErrorUtils.throw('To transform a callback into a string, `onPrehydrate` must be processed by the Nuxt build pipeline.', { code: E1006, fix: 'If it is called in a third-party library, add the library to `build.transpile`.' })
+    runtimeErrorUtils.throw({ message: 'To transform a callback into a string, `onPrehydrate` must be processed by the Nuxt build pipeline.', code: E1006, fix: 'If it is called in a third-party library, add the library to `build.transpile`.' })
   }
 
   const vm = getCurrentInstance()

--- a/packages/nuxt/src/app/composables/state.ts
+++ b/packages/nuxt/src/app/composables/state.ts
@@ -22,10 +22,10 @@ export function useState<T> (...args: any): Ref<T> {
   if (typeof args[0] !== 'string') { args.unshift(autoKey) }
   const [_key, init] = args as [string, (() => T | Ref<T>)]
   if (!_key || typeof _key !== 'string') {
-    runtimeErrorUtils.throw('[useState] key must be a string: ' + _key, { code: E7009, fix: 'Pass a string key as the first argument to `useState()`, e.g. `useState(\'myKey\', () => initialValue)`.' })
+    runtimeErrorUtils.throw({ message: '[useState] key must be a string: ' + _key, code: E7009, fix: 'Pass a string key as the first argument to `useState()`, e.g. `useState(\'myKey\', () => initialValue)`.' })
   }
   if (init !== undefined && typeof init !== 'function') {
-    runtimeErrorUtils.throw(`[useState] \`init\` must be a function, but got \`${typeof init}\`.`, {
+    runtimeErrorUtils.throw({ message: `[useState] \`init\` must be a function, but got \`${typeof init}\`.`,
       code: E7007,
       fix: 'Wrap the initial value in a function: `useState(\'key\', () => value)` instead of `useState(\'key\', value)`.',
     })

--- a/packages/nuxt/src/app/entry.ts
+++ b/packages/nuxt/src/app/entry.ts
@@ -105,7 +105,7 @@ if (import.meta.client) {
   }
 
   vueAppPromise = entry().catch((error: unknown) => {
-    runtimeErrorUtils.warn('Error while mounting app.', { code: E1011, fix: 'Check your plugins and app initialization code for unhandled errors.', cause: error })
+    runtimeErrorUtils.warn({ message: 'Error while mounting app.', code: E1011, fix: 'Check your plugins and app initialization code for unhandled errors.', cause: error })
     throw error
   })
 }

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -420,7 +420,7 @@ export function createNuxtApp (options: CreateOptions): NuxtApp {
 
     // Log errors captured when running plugins, in the `app:created` and `app:beforeMount` hooks
     // as well as when mounting the app.
-    const unreg = nuxtApp.hook('app:error', (...args) => { runtimeErrorUtils.warn('Error caught during app initialization.', { code: E1005, fix: 'Check your plugins, `app:created`, and `app:beforeMount` hooks for unhandled errors.', cause: args[0] }) })
+    const unreg = nuxtApp.hook('app:error', (...args) => { runtimeErrorUtils.warn({ message: 'Error caught during app initialization.', code: E1005, fix: 'Check your plugins, `app:created`, and `app:beforeMount` hooks for unhandled errors.', cause: args[0] }) })
     nuxtApp.hook('app:mounted', unreg)
   }
 
@@ -581,9 +581,9 @@ export function useNuxtApp (id?: string): NuxtApp {
 
   if (!nuxtAppInstance) {
     if (import.meta.dev) {
-      runtimeErrorUtils.throw('A composable that requires access to the Nuxt instance was called outside of a plugin, Nuxt hook, Nuxt middleware, or Vue setup function. This is probably not a Nuxt bug.', { code: E1001, fix: 'Move this call inside a Vue `setup()` function, a Nuxt plugin, or a Nuxt middleware.' })
+      runtimeErrorUtils.throw({ message: 'A composable that requires access to the Nuxt instance was called outside of a plugin, Nuxt hook, Nuxt middleware, or Vue setup function. This is probably not a Nuxt bug.', code: E1001, fix: 'Move this call inside a Vue `setup()` function, a Nuxt plugin, or a Nuxt middleware.' })
     } else {
-      runtimeErrorUtils.throw('Nuxt instance unavailable.', { code: E1001 })
+      runtimeErrorUtils.throw({ message: 'Nuxt instance unavailable.', code: E1001 })
     }
   }
 
@@ -621,7 +621,7 @@ function wrappedConfig (runtimeConfig: Record<string, unknown>) {
       if (typeof p === 'string' && p !== 'public' && !(p in target) && !p.startsWith('__v') /* vue check for reactivity, e.g. `__v_isRef` */) {
         if (!loggedKeys.has(p)) {
           loggedKeys.add(p)
-          runtimeErrorUtils.warn(`Could not access \`${p}\`. The only available runtime config keys on the client side are ${keys.join(', ')} and ${lastKey}.`, { code: E1003, fix: `Move \`${p}\` under \`runtimeConfig.public\` in \`nuxt.config\` to make it available on the client side.` })
+          runtimeErrorUtils.warn({ message: `Could not access \`${p}\`. The only available runtime config keys on the client side are ${keys.join(', ')} and ${lastKey}.`, code: E1003, fix: `Move \`${p}\` under \`runtimeConfig.public\` in \`nuxt.config\` to make it available on the client side.` })
         }
       }
       return Reflect.get(target, p, receiver)

--- a/packages/nuxt/src/app/plugins/check-if-layout-used.ts
+++ b/packages/nuxt/src/app/plugins/check-if-layout-used.ts
@@ -15,7 +15,7 @@ export default defineNuxtPlugin({
 
     function checkIfLayoutUsed () {
       if (!error.value && !nuxtApp._isNuxtLayoutUsed && Object.keys(layouts).length > 0) {
-        runtimeErrorUtils.warn('Your project has layouts but the `<NuxtLayout />` component has not been used.', {
+        runtimeErrorUtils.warn({ message: 'Your project has layouts but the `<NuxtLayout />` component has not been used.',
           code: E4007,
           fix: 'Add `<NuxtLayout>` to your `app.vue`, or set `pages: false` in `nuxt.config` if you don\'t need layouts.',
         })

--- a/packages/nuxt/src/app/plugins/payload.client.ts
+++ b/packages/nuxt/src/app/plugins/payload.client.ts
@@ -39,7 +39,7 @@ export default defineNuxtPlugin({
         const { hostname } = new URL(url, window.location.href)
         if (hostname === window.location.hostname) {
           // TODO: use preloadPayload instead once we can support preloading islands too
-          await loadPayload(url).catch(() => { runtimeErrorUtils.warn('Error preloading payload for ' + url, { code: E7003, fix: 'This is usually a transient network error. The payload will be fetched on navigation instead.' }) })
+          await loadPayload(url).catch(() => { runtimeErrorUtils.warn({ message: 'Error preloading payload for ' + url, code: E7003, fix: 'This is usually a transient network error. The payload will be fetched on navigation instead.' }) })
         }
       })
       if (isAppManifestEnabled && navigator.connection?.effectiveType !== 'slow-2g') {

--- a/packages/nuxt/src/app/plugins/router.ts
+++ b/packages/nuxt/src/app/plugins/router.ts
@@ -156,7 +156,7 @@ export default defineNuxtPlugin<{ route: Route, router: Router }>({
         }
       } catch (err) {
         if (import.meta.dev && !hooks.error.length) {
-          runtimeErrorUtils.warn('No error handlers registered to handle middleware errors. You can register an error handler with `router.onError()`.', { code: E2009, fix: 'Register an error handler with `router.onError()` or add error handling within your middleware.', cause: err })
+          runtimeErrorUtils.warn({ message: 'No error handlers registered to handle middleware errors. You can register an error handler with `router.onError()`.', code: E2009, fix: 'Register an error handler with `router.onError()` or add error handling within your middleware.', cause: err })
         }
         for (const handler of hooks.error) {
           await handler(err)

--- a/packages/nuxt/src/app/utils.ts
+++ b/packages/nuxt/src/app/utils.ts
@@ -26,7 +26,7 @@ const distURL = import.meta.url.replace(/\/app\/.*$/, '/')
 type Trace = { source: string, line?: number, column?: number }
 
 export const runtimeErrorUtils = /* @__PURE__ */ createErrorUtils({
-  module: 'NUXT',
+  prefix: 'NUXT',
   docsBase: DOCS_BASE,
   // TODO: implement the formatter and logger to forward them to the server side
 })

--- a/packages/nuxt/src/compiler/module.ts
+++ b/packages/nuxt/src/compiler/module.ts
@@ -128,11 +128,11 @@ export default defineNuxtModule<Partial<NuxtCompilerOptions>>({
             try {
               await plugin.scan.call(pluginScanThisContext, { id: filePath, code: contents, nuxt, autoImportsToSources })
             } catch (e) {
-              buildErrorUtils.error(`Plugin \`${plugin.name}\` failed to scan file \`${filePath}\`.`, { code: ErrorCodes.B1005, fix: 'Check the file for syntax errors, or report this issue to the plugin author.', context: { plugin: plugin.name, file: filePath }, cause: e })
+              buildErrorUtils.error({ message: `Plugin \`${plugin.name}\` failed to scan file \`${filePath}\`.`, code: ErrorCodes.B1005, fix: 'Check the file for syntax errors, or report this issue to the plugin author.', context: { plugin: plugin.name, file: filePath }, cause: e })
             }
           }))
         } catch (e) {
-          buildErrorUtils.error(`Cannot read file \`${filePath}\`.`, { code: ErrorCodes.B1006, fix: 'Check that the file exists and has correct permissions.', context: { file: filePath }, cause: e })
+          buildErrorUtils.error({ message: `Cannot read file \`${filePath}\`.`, code: ErrorCodes.B1006, fix: 'Check that the file exists and has correct permissions.', context: { file: filePath }, cause: e })
         }
       }
 
@@ -141,7 +141,7 @@ export default defineNuxtModule<Partial<NuxtCompilerOptions>>({
         try {
           await plugin.afterScan(nuxt)
         } catch (e) {
-          buildErrorUtils.error(`Error in \`afterScan\` hook of plugin \`${plugin.name}\`.`, { code: ErrorCodes.B1007, fix: 'Check the plugin implementation or report this issue to the plugin author.', context: { plugin: plugin.name }, cause: e })
+          buildErrorUtils.error({ message: `Error in \`afterScan\` hook of plugin \`${plugin.name}\`.`, code: ErrorCodes.B1007, fix: 'Check the plugin implementation or report this issue to the plugin author.', context: { plugin: plugin.name }, cause: e })
         }
       }))
     }

--- a/packages/nuxt/src/compiler/plugins/keyed-function-factories.ts
+++ b/packages/nuxt/src/compiler/plugins/keyed-function-factories.ts
@@ -141,7 +141,7 @@ function createFactoryProcessor (
     for (const parsedFactoryCall of parsedFactoryCalls) {
       const factoryMeta = getFactoryByLocalName(parsedFactoryCall.factoryName)
       if (!factoryMeta) {
-        buildErrorUtils.error(`No factory function found for \`${parsedFactoryCall.functionName}\` in file \`${filePath}\`. This is a Nuxt bug.`, { code: ErrorCodes.B1008, fix: 'Please report this issue at https://github.com/nuxt/nuxt/issues with the file contents.', context: { function: parsedFactoryCall.functionName, file: filePath } })
+        buildErrorUtils.error({ message: `No factory function found for \`${parsedFactoryCall.functionName}\` in file \`${filePath}\`. This is a Nuxt bug.`, code: ErrorCodes.B1008, fix: 'Please report this issue at https://github.com/nuxt/nuxt/issues with the file contents.', context: { function: parsedFactoryCall.functionName, file: filePath } })
         continue
       }
 

--- a/packages/nuxt/src/compiler/plugins/keyed-functions.ts
+++ b/packages/nuxt/src/compiler/plugins/keyed-functions.ts
@@ -62,7 +62,7 @@ function buildKeyedFunctionsState (keyedFunctions: KeyedFunction[]) {
       const sourcesToFunctionMeta = namesToSourcesToFunctionMeta.get(functionName)
       const existingEntry = sourcesToFunctionMeta?.get(fnSource)
       if (existingEntry?.source && existingEntry.source === fnSource) {
-        buildErrorUtils.warn(`Duplicate keyed function name \`${functionName}\`${functionName !== f.name ? ` defined as \`${f.name}\`` : ''} with ${f.source ? `the same source \`${f.source}\`` : 'no source'} found. Overwriting the existing entry.`, { code: ErrorCodes.B1009, fix: 'Ensure each keyed function has a unique name, or use a different source to distinguish them.', context: { functionName, source: f.source } })
+        buildErrorUtils.warn({ message: `Duplicate keyed function name \`${functionName}\`${functionName !== f.name ? ` defined as \`${f.name}\`` : ''} with ${f.source ? `the same source \`${f.source}\`` : 'no source'} found. Overwriting the existing entry.`, code: ErrorCodes.B1009, fix: 'Ensure each keyed function has a unique name, or use a different source to distinguish them.', context: { functionName, source: f.source } })
       }
     }
 

--- a/packages/nuxt/src/compiler/runtime/index.ts
+++ b/packages/nuxt/src/compiler/runtime/index.ts
@@ -19,10 +19,7 @@ export interface ObjectFactory<T extends Function> {
 // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
 export function defineKeyedFunctionFactory<T extends Function> (factory: ObjectFactory<T>): T {
   const placeholder = function () {
-    runtimeErrorUtils.throw(
-      `\`${factory.name}\` is a compiler macro and cannot be called at runtime.`,
-      { code: E1007, fix: 'It is only usable inside the directories scanned by the Nuxt compiler as an exported function and imported statically.' },
-    )
+    runtimeErrorUtils.throw({ message: `\`${factory.name}\` is a compiler macro and cannot be called at runtime.`, code: E1007, fix: 'It is only usable inside the directories scanned by the Nuxt compiler as an exported function and imported statically.' })
   }
 
   return Object.defineProperty(placeholder, '__nuxt_factory', {

--- a/packages/nuxt/src/components/module.ts
+++ b/packages/nuxt/src/components/module.ts
@@ -101,7 +101,7 @@ export default defineNuxtModule<ComponentsOptions>({
 
         const present = isDirectorySync(dirPath)
         if (!present && !DEFAULT_COMPONENTS_DIRS_RE.test(dirOptions.path)) {
-          buildErrorUtils.warn(`Components directory not found: \`${dirPath}\`. If this is intentional, you can remove it from \`components.dirs\` in your \`nuxt.config\`.`, { code: ErrorCodes.B3001, fix: 'If this is intentional, you can remove it from `components.dirs` in your `nuxt.config`.', context: { dirPath } })
+          buildErrorUtils.warn({ message: `Components directory not found: \`${dirPath}\`. If this is intentional, you can remove it from \`components.dirs\` in your \`nuxt.config\`.`, code: ErrorCodes.B3001, fix: 'If this is intentional, you can remove it from `components.dirs` in your `nuxt.config`.', context: { dirPath } })
         }
 
         const dirs = dirPath.includes('node_modules') ? libraryComponentDirs : userComponentDirs
@@ -199,7 +199,7 @@ export default defineNuxtModule<ComponentsOptions>({
           })
         }
         if (component.mode === 'server' && !nuxt.options.ssr && !newComponents.some(other => other.pascalName === component.pascalName && other.mode === 'client')) {
-          buildErrorUtils.warn(`Using server component \`${component.pascalName}\` with \`ssr: false\` is not supported with auto-detected component islands.`, {
+          buildErrorUtils.warn({ message: `Using server component \`${component.pascalName}\` with \`ssr: false\` is not supported with auto-detected component islands.`,
             code: ErrorCodes.B3002,
             fix: 'Set `experimental.componentIslands` to `true` in your `nuxt.config`, or convert the component to a client component.',
             context: {

--- a/packages/nuxt/src/components/plugins/islands-transform.ts
+++ b/packages/nuxt/src/components/plugins/islands-transform.ts
@@ -125,9 +125,9 @@ export const IslandsTransformPlugin = (options: ServerOnlyComponentTransformPlug
 
         if (hasNuxtClient) {
           if (!options.selectiveClient) {
-            buildErrorUtils.warn(`The \`nuxt-client\` attribute and client components within islands are only supported when \`experimental.componentIslands.selectiveClient\` is enabled. file: \`${id}\``, { code: ErrorCodes.B3007, fix: 'Set `experimental.componentIslands.selectiveClient` to `true` in your `nuxt.config`.', context: { file: id } })
+            buildErrorUtils.warn({ message: `The \`nuxt-client\` attribute and client components within islands are only supported when \`experimental.componentIslands.selectiveClient\` is enabled. file: \`${id}\``, code: ErrorCodes.B3007, fix: 'Set `experimental.componentIslands.selectiveClient` to `true` in your `nuxt.config`.', context: { file: id } })
           } else if (!isVite) {
-            buildErrorUtils.warn(`The \`nuxt-client\` attribute and client components within islands are only supported with Vite. file: \`${id}\``, { code: ErrorCodes.B3007, fix: 'Switch to the Vite builder by setting `builder: \'vite\'` in your `nuxt.config`.', context: { file: id } })
+            buildErrorUtils.warn({ message: `The \`nuxt-client\` attribute and client components within islands are only supported with Vite. file: \`${id}\``, code: ErrorCodes.B3007, fix: 'Switch to the Vite builder by setting `builder: \'vite\'` in your `nuxt.config`.', context: { file: id } })
           }
         }
 

--- a/packages/nuxt/src/components/plugins/lazy-hydration-transform.ts
+++ b/packages/nuxt/src/components/plugins/lazy-hydration-transform.ts
@@ -94,7 +94,7 @@ export const LazyHydrationTransformPlugin = (options: LoaderOptions) => createUn
               const prop = camelCase(isDynamic ? attr.slice(1) : attr)
               if (prop in hydrationStrategyMap) {
                 if (strategy) {
-                  buildErrorUtils.warn(`Multiple hydration strategies are not supported in the same component \`<${node.name}>\` in \`${id}\`.`, { code: ErrorCodes.B3005, fix: 'Use only one hydration strategy attribute (e.g., `hydrate-on-visible` or `hydrate-on-idle`) per component.', context: { component: node.name, file: id } })
+                  buildErrorUtils.warn({ message: `Multiple hydration strategies are not supported in the same component \`<${node.name}>\` in \`${id}\`.`, code: ErrorCodes.B3005, fix: 'Use only one hydration strategy attribute (e.g., `hydrate-on-visible` or `hydrate-on-idle`) per component.', context: { component: node.name, file: id } })
                 } else {
                   strategy = hydrationStrategyMap[prop as keyof typeof hydrationStrategyMap]
                 }
@@ -104,8 +104,8 @@ export const LazyHydrationTransformPlugin = (options: LoaderOptions) => createUn
             if (strategy && !/^(?:Lazy|lazy-)/.test(node.name)) {
               if (node.name !== 'template' && (nuxt?.options.dev || nuxt?.options.test)) {
                 const relativePath = resolveToAlias(id, nuxt)
-                buildErrorUtils.warn(`Component \`<${node.name}>\` (used in \`${relativePath}\`) has lazy-hydration props but is not declared as a lazy component.\n` +
-                  `Rename it to \`<Lazy${pascalCase(node.name)} />\` or remove the lazy-hydration props to avoid unexpected behavior.`, { code: ErrorCodes.B3006, fix: `Rename it to \`<Lazy${pascalCase(node.name)} />\` or remove the lazy-hydration props.` })
+                buildErrorUtils.warn({ message: `Component \`<${node.name}>\` (used in \`${relativePath}\`) has lazy-hydration props but is not declared as a lazy component.\n` +
+                  `Rename it to \`<Lazy${pascalCase(node.name)} />\` or remove the lazy-hydration props to avoid unexpected behavior.`, code: ErrorCodes.B3006, fix: `Rename it to \`<Lazy${pascalCase(node.name)} />\` or remove the lazy-hydration props.` })
               }
               return
             }

--- a/packages/nuxt/src/components/plugins/loader.ts
+++ b/packages/nuxt/src/components/plugins/loader.ts
@@ -66,7 +66,7 @@ export const LoaderPlugin = (options: LoaderOptions) => createUnplugin(() => {
           const internalInstall = ((component as any)._internal_install) as string
           if (internalInstall && nuxt?.options.test === false) {
             if (!nuxt.options.dev) {
-              buildErrorUtils.throw(`\`${resolveToAlias(id, nuxt)}\` is using \`${component.pascalName}\` which requires \`${internalInstall}\`.`, {
+              buildErrorUtils.throw({ message: `\`${resolveToAlias(id, nuxt)}\` is using \`${component.pascalName}\` which requires \`${internalInstall}\`.`,
                 code: ErrorCodes.B3004,
                 fix: `Run \`npx nuxt add ${internalInstall}\` to install it.`,
                 context: { file: id, component: component.pascalName, requiredModule: internalInstall },
@@ -83,7 +83,7 @@ export const LoaderPlugin = (options: LoaderOptions) => createUnplugin(() => {
             imports.add(genImport(options.serverComponentRuntime, [{ name: 'createServerComponent' }]))
             imports.add(`const ${identifier} = createServerComponent(${JSON.stringify(component.pascalName)})`)
             if (!options.experimentalComponentIslands) {
-              buildErrorUtils.warn(`Standalone server components (\`${name}\`) are not yet supported without enabling \`experimental.componentIslands\`.`, { code: ErrorCodes.B3003, fix: 'Set `experimental.componentIslands` to `true` in your `nuxt.config`.', context: { component: name } })
+              buildErrorUtils.warn({ message: `Standalone server components (\`${name}\`) are not yet supported without enabling \`experimental.componentIslands\`.`, code: ErrorCodes.B3003, fix: 'Set `experimental.componentIslands` to `true` in your `nuxt.config`.', context: { component: name } })
             }
             return identifier
           }

--- a/packages/nuxt/src/components/plugins/transform.ts
+++ b/packages/nuxt/src/components/plugins/transform.ts
@@ -114,7 +114,7 @@ export function TransformPlugin (nuxt: Nuxt, options: TransformPluginOptions) {
               map: null,
             }
           } else {
-            buildErrorUtils.throw(`Unknown component mode: ${mode}, this might be an internal bug of Nuxt.`, { code: ErrorCodes.B1019, fix: 'If you are a module author, ensure the component `mode` is set to `client`, `server`, or `all`. Otherwise, please report this issue.' })
+            buildErrorUtils.throw({ message: `Unknown component mode: ${mode}, this might be an internal bug of Nuxt.`, code: ErrorCodes.B1019, fix: 'If you are a module author, ensure the component `mode` is set to `client`, `server`, or `all`. Otherwise, please report this issue.' })
           }
         },
       },

--- a/packages/nuxt/src/components/scan.ts
+++ b/packages/nuxt/src/components/scan.ts
@@ -48,7 +48,7 @@ export async function scanComponents (dirs: ComponentsDir[], srcDir: string): Pr
             const nuxt = useNuxt()
             const original = resolveToAlias(dir.path, nuxt)
             const corrected = resolveToAlias(join(dirname(dir.path), sibling), nuxt)
-            buildErrorUtils.warn(`Components not scanned from \`${corrected}\`. Did you mean to name the directory \`${original}\` instead?`, { code: ErrorCodes.B3008, fix: `Rename the directory from \`${basename(corrected)}\` to \`${basename(original)}\` to match the expected casing.`, context: { scannedPath: corrected, expectedPath: original } })
+            buildErrorUtils.warn({ message: `Components not scanned from \`${corrected}\`. Did you mean to name the directory \`${original}\` instead?`, code: ErrorCodes.B3008, fix: `Rename the directory from \`${basename(corrected)}\` to \`${basename(original)}\` to match the expected casing.`, context: { scannedPath: corrected, expectedPath: original } })
             break
           }
         }
@@ -100,7 +100,7 @@ export async function scanComponents (dirs: ComponentsDir[], srcDir: string): Pr
       const pascalName = pascalCase(componentNameSegments)
 
       if (LAZY_COMPONENT_NAME_REGEX.test(pascalName)) {
-        buildErrorUtils.warn(`The component \`${pascalName}\` (in \`${filePath}\`) is using the reserved "Lazy" prefix used for dynamic imports, which may cause it to break at runtime.`, { code: ErrorCodes.B3009, fix: 'Rename the component to avoid the `Lazy` prefix.', context: { component: pascalName, filePath } })
+        buildErrorUtils.warn({ message: `The component \`${pascalName}\` (in \`${filePath}\`) is using the reserved "Lazy" prefix used for dynamic imports, which may cause it to break at runtime.`, code: ErrorCodes.B3009, fix: 'Rename the component to avoid the `Lazy` prefix.', context: { component: pascalName, filePath } })
       }
 
       if (resolvedNames.has(pascalName + suffix) || resolvedNames.has(pascalName)) {
@@ -140,7 +140,7 @@ export async function scanComponents (dirs: ComponentsDir[], srcDir: string): Pr
 
       // Ignore files like `~/components/index.vue` which end up not having a name at all
       if (!pascalName) {
-        buildErrorUtils.warn(`Component did not resolve to a file name in \`${resolveToAlias(filePath)}\`.`, { code: ErrorCodes.B3010, fix: 'Rename the component file to something other than `index` (e.g., `MyComponent.vue`).', context: { filePath } })
+        buildErrorUtils.warn({ message: `Component did not resolve to a file name in \`${resolveToAlias(filePath)}\`.`, code: ErrorCodes.B3010, fix: 'Rename the component file to something other than `index` (e.g., `MyComponent.vue`).', context: { filePath } })
         continue
       }
 
@@ -172,9 +172,9 @@ export async function scanComponents (dirs: ComponentsDir[], srcDir: string): Pr
 }
 
 function warnAboutDuplicateComponent (componentName: string, filePath: string, duplicatePath: string) {
-  buildErrorUtils.warn(`Two component files resolving to the same name \`${componentName}\`:\n` +
+  buildErrorUtils.warn({ message: `Two component files resolving to the same name \`${componentName}\`:\n` +
     `\n - ${filePath}` +
-    `\n - ${duplicatePath}`, {
+    `\n - ${duplicatePath}`,
     code: ErrorCodes.B3011,
     fix: 'Rename one of the files or adjust the `components.dirs` prefix settings in your `nuxt.config`.',
   })

--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -67,7 +67,7 @@ export async function generateApp (nuxt: Nuxt, app: NuxtApp, options: { filter?:
     const start = performance.now()
     const oldContents = nuxt.vfs[fullPath]
     const contents = await compileTemplate(template, templateContext).catch((e) => {
-      buildErrorUtils.error(`Could not compile template \`${template.filename}\`.`, {
+      buildErrorUtils.error({ message: `Could not compile template \`${template.filename}\`.`,
         code: ErrorCodes.B1001,
         fix: template.src ? `Check the template source file at \`${template.src}\` for syntax errors.` : 'Check the `getContents` function of this template for errors.',
         context: {
@@ -133,7 +133,7 @@ async function compileTemplate<T> (template: NuxtTemplate<T>, ctx: { nuxt: Nuxt,
     try {
       return await fsp.readFile(template.src, 'utf-8')
     } catch (err) {
-      buildErrorUtils.error(`Error reading template from \`${template.src}\`.`, { code: ErrorCodes.B1002, fix: 'Check that the template `src` path exists and is readable.' })
+      buildErrorUtils.error({ message: `Error reading template from \`${template.src}\`.`, code: ErrorCodes.B1002, fix: 'Check that the template `src` path exists and is readable.' })
       throw err
     }
   }
@@ -141,7 +141,7 @@ async function compileTemplate<T> (template: NuxtTemplate<T>, ctx: { nuxt: Nuxt,
     return template.getContents({ ...ctx, options: template.options! })
   }
 
-  return buildErrorUtils.throw('Invalid template. Templates must have either `src` or `getContents`.', {
+  return buildErrorUtils.throw({ message: 'Invalid template. Templates must have either `src` or `getContents`.',
     code: ErrorCodes.B1003,
     fix: 'Add a `getContents` function or a `src` path to the `addTemplate()` call.',
     context: { template },
@@ -173,7 +173,7 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
       const name = getNameFromPath(file, dirs.appLayouts)
       if (!name) {
         // Ignore files like `~/layouts/index.vue` which end up not having a name at all
-        buildErrorUtils.warn(`No layout name could be resolved for \`${resolveToAlias(file, nuxt)}\` (\`index\` is ignored for the purpose of creating a layout name).`, { code: ErrorCodes.B4009, fix: 'Rename the layout file to something other than `index` (e.g., `layouts/default.vue`).' })
+        buildErrorUtils.warn({ message: `No layout name could be resolved for \`${resolveToAlias(file, nuxt)}\` (\`index\` is ignored for the purpose of creating a layout name).`, code: ErrorCodes.B4009, fix: 'Rename the layout file to something other than `index` (e.g., `layouts/default.vue`).' })
         continue
       }
       layouts[name] ||= { name, file }
@@ -191,7 +191,7 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
       const name = getNameFromPath(file)
       if (!name) {
         // Ignore files like `~/middleware/index.vue` which end up not having a name at all
-        buildErrorUtils.warn(`No middleware name could be resolved for \`${resolveToAlias(file, nuxt)}\` (\`index\` is ignored for the purpose of creating a middleware name).`, { code: ErrorCodes.B4010, fix: 'Rename the middleware file to something other than `index` (e.g., `middleware/auth.ts`).' })
+        buildErrorUtils.warn({ message: `No middleware name could be resolved for \`${resolveToAlias(file, nuxt)}\` (\`index\` is ignored for the purpose of creating a middleware name).`, code: ErrorCodes.B4010, fix: 'Rename the middleware file to something other than `index` (e.g., `middleware/auth.ts`).' })
         continue
       }
       middleware.push({ name, path: file, global: hasSuffix(file, '.global') })
@@ -274,9 +274,9 @@ export async function annotatePlugins (nuxt: Nuxt, plugins: NuxtPlugin[]) {
     } catch (e) {
       const relativePluginSrc = relative(nuxt.options.rootDir, plugin.src)
       if ((e as Error).message === 'Invalid plugin metadata') {
-        buildErrorUtils.warn(`Failed to parse static properties from plugin \`${relativePluginSrc}\`, falling back to non-optimized runtime meta.`, { code: ErrorCodes.B2010, fix: 'Use an object literal with static values as the second argument to `defineNuxtPlugin()`.', docs: 'https://nuxt.com/docs/4.x/directory-structure/app/plugins#object-syntax-plugins' })
+        buildErrorUtils.warn({ message: `Failed to parse static properties from plugin \`${relativePluginSrc}\`, falling back to non-optimized runtime meta.`, code: ErrorCodes.B2010, fix: 'Use an object literal with static values as the second argument to `defineNuxtPlugin()`.', docs: 'https://nuxt.com/docs/4.x/directory-structure/app/plugins#object-syntax-plugins' })
       } else {
-        buildErrorUtils.warn(`Failed to parse static properties from plugin \`${relativePluginSrc}\`.`, { code: ErrorCodes.B2010, fix: 'Check the plugin file for syntax errors or unsupported constructs in the metadata.', cause: e })
+        buildErrorUtils.warn({ message: `Failed to parse static properties from plugin \`${relativePluginSrc}\`.`, code: ErrorCodes.B2010, fix: 'Check the plugin file for syntax errors or unsupported constructs in the metadata.', cause: e })
       }
       _plugins.push(plugin)
     }
@@ -291,7 +291,7 @@ export function checkForCircularDependencies (_plugins: Array<NuxtPlugin & Omit<
   for (const plugin of _plugins) {
     // Make sure dependency plugins are registered
     if (plugin.dependsOn && plugin.dependsOn.some(name => !pluginNames.has(name))) {
-      buildErrorUtils.error(`Plugin \`${plugin.name}\` depends on \`${plugin.dependsOn.filter(name => !pluginNames.has(name)).join(', ')}\` but they are not registered.`, {
+      buildErrorUtils.error({ message: `Plugin \`${plugin.name}\` depends on \`${plugin.dependsOn.filter(name => !pluginNames.has(name)).join(', ')}\` but they are not registered.`,
         code: ErrorCodes.B2008,
         fix: 'Register the missing dependency plugins, or remove them from the `dependsOn` array.',
         context: { pluginSrc: plugin.src, registeredPlugins: [...pluginNames] },
@@ -304,7 +304,7 @@ export function checkForCircularDependencies (_plugins: Array<NuxtPlugin & Omit<
   }
   const checkDeps = (name: string, visited: string[] = []): string[] => {
     if (visited.includes(name)) {
-      buildErrorUtils.error(`Circular dependency detected in plugins: ${visited.join(' -> ')} -> ${name}`, {
+      buildErrorUtils.error({ message: `Circular dependency detected in plugins: ${visited.join(' -> ')} -> ${name}`,
         code: ErrorCodes.B2009,
         fix: 'Restructure the plugin `dependsOn` declarations to break the cycle.',
         context: { dependencyGraph: deps },

--- a/packages/nuxt/src/core/builder.ts
+++ b/packages/nuxt/src/core/builder.ts
@@ -70,7 +70,7 @@ export async function build (nuxt: Nuxt): Promise<void> {
   if (nuxt.options.dev && !nuxt.options.test) {
     nuxt.hooks.hookOnce('build:done', () => {
       checkForExternalConfigurationFiles()
-        .catch(e => buildErrorUtils.warn('Problem checking for external configuration files.', { code: ErrorCodes.B1014, fix: 'This is likely a transient file system error. If it persists, check file permissions in your project root.', cause: e }))
+        .catch(e => buildErrorUtils.warn({ message: 'Problem checking for external configuration files.', code: ErrorCodes.B1014, fix: 'This is likely a transient file system error. If it persists, check file permissions in your project root.', cause: e }))
     })
   }
 
@@ -240,7 +240,7 @@ async function createParcelWatcher () {
     }
     return true
   } catch {
-    buildErrorUtils.warn('Falling back to `chokidar-granular` as `@parcel/watcher` cannot be resolved in your project.', { code: ErrorCodes.B1015, fix: 'Install `@parcel/watcher` for better performance: `npm install -D @parcel/watcher`.' })
+    buildErrorUtils.warn({ message: 'Falling back to `chokidar-granular` as `@parcel/watcher` cannot be resolved in your project.', code: ErrorCodes.B1015, fix: 'Install `@parcel/watcher` for better performance: `npm install -D @parcel/watcher`.' })
     return false
   }
 }
@@ -256,7 +256,7 @@ async function bundle (nuxt: Nuxt) {
     await nuxt.callHook('build:error', error)
 
     if (error.toString().includes('Cannot find module \'@nuxt/webpack-builder\'')) {
-      buildErrorUtils.throw('Could not load `@nuxt/webpack-builder`. You may need to add it to your project dependencies.', { code: ErrorCodes.B1016, docs: 'https://nuxt.com/docs/4.x/api/nuxt-config#builder', fix: 'Run `npm install -D @nuxt/webpack-builder` to install it.' })
+      buildErrorUtils.throw({ message: 'Could not load `@nuxt/webpack-builder`. You may need to add it to your project dependencies.', code: ErrorCodes.B1016, docs: 'https://nuxt.com/docs/4.x/api/nuxt-config#builder', fix: 'Run `npm install -D @nuxt/webpack-builder` to install it.' })
     }
 
     throw error
@@ -267,7 +267,7 @@ async function loadBuilder (nuxt: Nuxt, builder: string): Promise<NuxtBuilder> {
   try {
     return await importModule(builder, { url: [directoryToURL(nuxt.options.rootDir), new URL(import.meta.url)] })
   } catch (err) {
-    return buildErrorUtils.throw(`Loading \`${builder}\` builder failed.`, {
+    return buildErrorUtils.throw({ message: `Loading \`${builder}\` builder failed.`,
       code: ErrorCodes.B1017,
       fix: `Run \`npm install ${builder}\` to install it.`,
       docs: 'https://nuxt.com/docs/4.x/api/nuxt-config#builder',

--- a/packages/nuxt/src/core/cache.ts
+++ b/packages/nuxt/src/core/cache.ts
@@ -254,7 +254,7 @@ async function readFileWithMeta (dir: string, fileName: string, count = 0): Prom
       if (count < 5) {
         return await readFileWithMeta(dir, fileName, count + 1)
       }
-      buildErrorUtils.warn(`Failed to read file \`${fileName}\` as it changed during read.`, { code: ErrorCodes.B1010, fix: 'The file was modified while being read. This is usually caused by a concurrent process writing to the file. Try restarting the build.' })
+      buildErrorUtils.warn({ message: `Failed to read file \`${fileName}\` as it changed during read.`, code: ErrorCodes.B1010, fix: 'The file was modified while being read. This is usually caused by a concurrent process writing to the file. Try restarting the build.' })
       return
     }
 
@@ -267,7 +267,7 @@ async function readFileWithMeta (dir: string, fileName: string, count = 0): Prom
       },
     }
   } catch (err) {
-    buildErrorUtils.warn(`Failed to read file \`${fileName}\`.`, { code: ErrorCodes.B1011, fix: 'Check that the file exists and is readable, or try clearing the build cache with `nuxi clean`.', cause: err })
+    buildErrorUtils.warn({ message: `Failed to read file \`${fileName}\`.`, code: ErrorCodes.B1011, fix: 'Check that the file exists and is readable, or try clearing the build cache with `nuxi clean`.', cause: err })
   } finally {
     await fd?.close()
   }
@@ -287,7 +287,7 @@ async function restoreCacheFromFile (cwd: string, cacheFile: string) {
 
       // Prevent path traversal attacks
       if (!filePath.startsWith(resolvedCwd)) {
-        buildErrorUtils.warn(`Skipping unsafe cache path: ${file.name}`, { code: ErrorCodes.B1012, fix: 'This cache file has a path that escapes the project directory (possible path traversal). Delete the cache with `nuxi clean` and rebuild.', context: { path: file.name } })
+        buildErrorUtils.warn({ message: `Skipping unsafe cache path: ${file.name}`, code: ErrorCodes.B1012, fix: 'This cache file has a path that escapes the project directory (possible path traversal). Delete the cache with `nuxi clean` and rebuild.', context: { path: file.name } })
         continue
       }
 
@@ -307,7 +307,7 @@ async function restoreCacheFromFile (cwd: string, cacheFile: string) {
       fd = await open(filePath, 'w')
       await fd.writeFile(file.data!)
     } catch (err) {
-      buildErrorUtils.error(`Failed to restore cached file \`${file.name}\`.`, { code: ErrorCodes.B1013, fix: 'Try clearing the build cache with `nuxi clean` and rebuilding from scratch.', cause: err })
+      buildErrorUtils.error({ message: `Failed to restore cached file \`${file.name}\`.`, code: ErrorCodes.B1013, fix: 'Try clearing the build cache with `nuxi clean` and rebuilding from scratch.', cause: err })
     } finally {
       await fd?.close()
     }

--- a/packages/nuxt/src/core/external-config-files.ts
+++ b/packages/nuxt/src/core/external-config-files.ts
@@ -17,11 +17,11 @@ export async function checkForExternalConfigurationFiles () {
 
   const foundOneExternalConfig = warningMessages.length === 1
   if (foundOneExternalConfig) {
-    buildErrorUtils.warn(warningMessages[0]!, { code: ErrorCodes.B5004, fix: 'Move the configuration into `nuxt.config.ts` and delete the external config file.' })
+    buildErrorUtils.warn({ message: warningMessages[0]!, code: ErrorCodes.B5004, fix: 'Move the configuration into `nuxt.config.ts` and delete the external config file.' })
   } else {
     const warningsAsList = warningMessages.map(message => `- ${message}`).join('\n')
     const warning = `Found multiple external configuration files: \n\n${warningsAsList}`
-    buildErrorUtils.warn(warning, { code: ErrorCodes.B5004, fix: 'Move these configurations into `nuxt.config.ts` and delete the external config files.' })
+    buildErrorUtils.warn({ message: warning, code: ErrorCodes.B5004, fix: 'Move these configurations into `nuxt.config.ts` and delete the external config files.' })
   }
 }
 

--- a/packages/nuxt/src/core/features.ts
+++ b/packages/nuxt/src/core/features.ts
@@ -20,7 +20,7 @@ export async function installNuxtModule (name: string, options?: { rootDir?: str
     }
   }
 
-  buildErrorUtils.warn(`Package \`${name}\` is missing.`, { code: ErrorCodes.B5011, fix: `Run \`npx nuxt add ${name}\` to install it.` })
+  buildErrorUtils.warn({ message: `Package \`${name}\` is missing.`, code: ErrorCodes.B5011, fix: `Run \`npx nuxt add ${name}\` to install it.` })
 
   if (isCI) {
     return false
@@ -29,7 +29,7 @@ export async function installNuxtModule (name: string, options?: { rootDir?: str
   // When running inside an AI coding agent, skip the interactive prompt
   // but log the exact command needed so the agent can act on it.
   if (isAgent) {
-    buildErrorUtils.warn(`Package \`${name}\` is required but not installed.`, { code: ErrorCodes.B5012, fix: `Run \`npx nuxt add ${name}\` to install it.` })
+    buildErrorUtils.warn({ message: `Package \`${name}\` is required but not installed.`, code: ErrorCodes.B5012, fix: `Run \`npx nuxt add ${name}\` to install it.` })
     return false
   }
 
@@ -52,7 +52,7 @@ export async function installNuxtModule (name: string, options?: { rootDir?: str
     logger.success(`Installed \`${name}\`.`)
     return true
   } catch (err) {
-    buildErrorUtils.error(`Failed to install \`${name}\`.`, {
+    buildErrorUtils.error({ message: `Failed to install \`${name}\`.`,
       code: ErrorCodes.B1004,
       fix: `Try installing manually with \`npm install ${name}\`.`,
       context: {

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -185,12 +185,12 @@ async function initNuxt (nuxt: Nuxt) {
 
     if (nuxt.options.dev && hasTTY && !isCI && !isAgent && !nuxt.options.test && !warnedAboutCompatDate) {
       warnedAboutCompatDate = true
-      buildErrorUtils.warn(`No \`compatibilityDate\` is set in \`nuxt.config\`. Using \`${fallbackCompatibilityDate}\` as fallback.`, { code: ErrorCodes.B5001, fix: `Add \`compatibilityDate: '${formatDate('latest')}'\` to your \`nuxt.config.ts\`.`, docs: 'https://nitro.build/deploy#compatibility-date' })
+      buildErrorUtils.warn({ message: `No \`compatibilityDate\` is set in \`nuxt.config\`. Using \`${fallbackCompatibilityDate}\` as fallback.`, code: ErrorCodes.B5001, fix: `Add \`compatibilityDate: '${formatDate('latest')}'\` to your \`nuxt.config.ts\`.`, docs: 'https://nitro.build/deploy#compatibility-date' })
     }
 
     if (nuxt.options.dev && isAgent && !warnedAboutCompatDate) {
       warnedAboutCompatDate = true
-      buildErrorUtils.warn(`No \`compatibilityDate\` is set in \`nuxt.config\`. Using \`${fallbackCompatibilityDate}\` as fallback.`, { code: ErrorCodes.B5001, fix: `Add \`compatibilityDate: '${formatDate('latest')}'\` to your \`nuxt.config.ts\`.`, docs: 'https://nitro.build/deploy#compatibility-date' })
+      buildErrorUtils.warn({ message: `No \`compatibilityDate\` is set in \`nuxt.config\`. Using \`${fallbackCompatibilityDate}\` as fallback.`, code: ErrorCodes.B5001, fix: `Add \`compatibilityDate: '${formatDate('latest')}'\` to your \`nuxt.config.ts\`.`, docs: 'https://nitro.build/deploy#compatibility-date' })
     }
   }
 
@@ -849,7 +849,7 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
       searchPaths: options.modulesDir,
       from: import.meta.url,
     })) {
-      buildErrorUtils.warn(`Failed to install \`@nuxt/webpack-builder\` in \`${options.rootDir}\`.`, { code: ErrorCodes.B5002, fix: 'Install it manually with `npm install -D @nuxt/webpack-builder`, or change the `builder` option to `vite` in `nuxt.config`.' })
+      buildErrorUtils.warn({ message: `Failed to install \`@nuxt/webpack-builder\` in \`${options.rootDir}\`.`, code: ErrorCodes.B5002, fix: 'Install it manually with `npm install -D @nuxt/webpack-builder`, or change the `builder` option to `vite` in `nuxt.config`.' })
     }
   }
 
@@ -887,7 +887,7 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
   const allowedKeys = new Set(['baseURL', 'buildAssetsDir', 'cdnURL', 'buildId'])
   for (const key in options.runtimeConfig.app) {
     if (!allowedKeys.has(key)) {
-      buildErrorUtils.warn(`The \`app\` namespace is reserved for Nuxt and is exposed to the browser. Please move \`runtimeConfig.app.${key}\` to a different namespace.`, { code: ErrorCodes.B5003, fix: 'Move the key to `runtimeConfig.public` or a custom namespace.' })
+      buildErrorUtils.warn({ message: `The \`app\` namespace is reserved for Nuxt and is exposed to the browser. Please move \`runtimeConfig.app.${key}\` to a different namespace.`, code: ErrorCodes.B5003, fix: 'Move the key to `runtimeConfig.public` or a custom namespace.' })
       delete options.runtimeConfig.app[key]
     }
   }

--- a/packages/nuxt/src/core/plugins/plugin-metadata.ts
+++ b/packages/nuxt/src/core/plugins/plugin-metadata.ts
@@ -61,7 +61,7 @@ export function extractMetadata (code: string, loader = 'ts' as 'ts' | 'tsx') {
     const metaArg = node.arguments[1]
     if (metaArg) {
       if (metaArg.type !== 'ObjectExpression') {
-        return buildErrorUtils.throw(`Invalid plugin metadata: the second argument to \`${name}\` must be an object literal, but got \`${metaArg.type}\`.`, { code: ErrorCodes.B2001, fix: 'Pass an object literal as the second argument, e.g. `defineNuxtPlugin(() => {}, { name: \'my-plugin\' })`.' })
+        return buildErrorUtils.throw({ message: `Invalid plugin metadata: the second argument to \`${name}\` must be an object literal, but got \`${metaArg.type}\`.`, code: ErrorCodes.B2001, fix: 'Pass an object literal as the second argument, e.g. `defineNuxtPlugin(() => {}, { name: \'my-plugin\' })`.' })
       }
       meta = extractMetaFromObject(metaArg.properties)
     }
@@ -93,7 +93,7 @@ function extractMetaFromObject (properties: Array<ObjectPropertyKind>) {
   const meta: PluginMeta = {}
   for (const property of properties) {
     if (property.type === 'SpreadElement' || !('name' in property.key)) {
-      return buildErrorUtils.throw('Invalid plugin metadata: spread elements and computed keys are not supported in plugin options.', { code: ErrorCodes.B2002, fix: 'Use static properties instead.' })
+      return buildErrorUtils.throw({ message: 'Invalid plugin metadata: spread elements and computed keys are not supported in plugin options.', code: ErrorCodes.B2002, fix: 'Use static properties instead.' })
     }
     const propertyKey = property.key.name
     if (!isMetadataKey(propertyKey)) { continue }
@@ -105,7 +105,7 @@ function extractMetaFromObject (properties: Array<ObjectPropertyKind>) {
     }
     if (propertyKey === 'dependsOn' && property.value.type === 'ArrayExpression') {
       if (property.value.elements.some(e => !e || e.type !== 'Literal' || typeof e.value !== 'string')) {
-        buildErrorUtils.throw('Invalid plugin metadata: `dependsOn` must be an array of string literals.', { code: ErrorCodes.B2003, fix: 'Use string literals in the `dependsOn` array, e.g. `dependsOn: [\'my-plugin\']`.' })
+        buildErrorUtils.throw({ message: 'Invalid plugin metadata: `dependsOn` must be an array of string literals.', code: ErrorCodes.B2003, fix: 'Use string literals in the `dependsOn` array, e.g. `dependsOn: [\'my-plugin\']`.' })
       }
       meta[propertyKey] = property.value.elements.map(e => (e as Literal)!.value as NuxtAppLiterals['pluginName'])
     }
@@ -122,7 +122,7 @@ export const RemovePluginMetadataPlugin = (nuxt: Nuxt) => createUnplugin(() => {
       if (!plugin) { return }
 
       if (!code.trim()) {
-        buildErrorUtils.warn(`Plugin \`${plugin.src}\` has no content.`, { code: ErrorCodes.B2004, fix: 'Add content to the plugin file, or remove it from the `plugins/` directory.', context: { src: plugin.src } })
+        buildErrorUtils.warn({ message: `Plugin \`${plugin.src}\` has no content.`, code: ErrorCodes.B2004, fix: 'Add content to the plugin file, or remove it from the `plugins/` directory.', context: { src: plugin.src } })
 
         return {
           code: 'export default () => {}',
@@ -133,7 +133,7 @@ export const RemovePluginMetadataPlugin = (nuxt: Nuxt) => createUnplugin(() => {
       const exports = findExports(code)
       const defaultExport = exports.find(e => e.type === 'default' || e.name === 'default')
       if (!defaultExport) {
-        buildErrorUtils.warn(`Plugin \`${plugin.src}\` has no default export and will be ignored at build time. Add \`export default defineNuxtPlugin(() => {})\` to your plugin.`, { code: ErrorCodes.B2005, fix: 'Add `export default defineNuxtPlugin(() => {})` to your plugin.', context: { src: plugin.src } })
+        buildErrorUtils.warn({ message: `Plugin \`${plugin.src}\` has no default export and will be ignored at build time. Add \`export default defineNuxtPlugin(() => {})\` to your plugin.`, code: ErrorCodes.B2005, fix: 'Add `export default defineNuxtPlugin(() => {})` to your plugin.', context: { src: plugin.src } })
         return {
           code: 'export default () => {}',
           map: null,
@@ -174,12 +174,12 @@ export const RemovePluginMetadataPlugin = (nuxt: Nuxt) => createUnplugin(() => {
           }
         })
       } catch (e) {
-        buildErrorUtils.error(`Error parsing plugin \`${plugin.src}\`.`, { code: ErrorCodes.B2006, fix: 'Check the plugin file for syntax errors.', cause: e })
+        buildErrorUtils.error({ message: `Error parsing plugin \`${plugin.src}\`.`, code: ErrorCodes.B2006, fix: 'Check the plugin file for syntax errors.', cause: e })
         return
       }
 
       if (!wrapped) {
-        buildErrorUtils.warn(`Plugin \`${plugin.src}\` is not wrapped in \`defineNuxtPlugin\`. It is advised to wrap your plugins as in the future this may enable enhancements.`, { code: ErrorCodes.B2007, fix: 'Wrap your plugin with `defineNuxtPlugin` — in the future this may enable enhancements.', context: { src: plugin.src } })
+        buildErrorUtils.warn({ message: `Plugin \`${plugin.src}\` is not wrapped in \`defineNuxtPlugin\`. It is advised to wrap your plugins as in the future this may enable enhancements.`, code: ErrorCodes.B2007, fix: 'Wrap your plugin with `defineNuxtPlugin` — in the future this may enable enhancements.', context: { src: plugin.src } })
       }
 
       if (s.hasChanged()) {

--- a/packages/nuxt/src/core/schema.ts
+++ b/packages/nuxt/src/core/schema.ts
@@ -77,7 +77,7 @@ export default defineNuxtModule({
           }
           return
         } catch {
-          buildErrorUtils.warn('Falling back to `chokidar` as `@parcel/watcher` cannot be resolved in your project.', { code: ErrorCodes.B5009, fix: 'Install `@parcel/watcher` for better file watching: `npm install -D @parcel/watcher`.' })
+          buildErrorUtils.warn({ message: 'Falling back to `chokidar` as `@parcel/watcher` cannot be resolved in your project.', code: ErrorCodes.B5009, fix: 'Install `@parcel/watcher` for better file watching: `npm install -D @parcel/watcher`.' })
         }
       }
 
@@ -115,7 +115,7 @@ export default defineNuxtModule({
             // TODO: fix type for second argument of `import`
             loadedConfig = await _resolveSchema.import(filePath, { default: true }) as SchemaDefinition
           } catch (err) {
-            buildErrorUtils.warn(`Unable to load Nuxt schema from \`${filePath}\`. Ensure the file exports a valid schema definition.`, { code: ErrorCodes.B5005, fix: 'Check that `nuxt.schema` exports a valid object with `defineNuxtSchema()` or as a plain object.', cause: err })
+            buildErrorUtils.warn({ message: `Unable to load Nuxt schema from \`${filePath}\`. Ensure the file exports a valid schema definition.`, code: ErrorCodes.B5005, fix: 'Check that `nuxt.schema` exports a valid object with `defineNuxtSchema()` or as a plain object.', cause: err })
             continue
           }
           schemaDefs.push(loadedConfig)

--- a/packages/nuxt/src/core/server.ts
+++ b/packages/nuxt/src/core/server.ts
@@ -21,7 +21,7 @@ async function loadServerBuilder (nuxt: Nuxt, builder = '@nuxt/nitro-server'): P
   try {
     return await importModule(builder, { url: [directoryToURL(nuxt.options.rootDir), new URL(import.meta.url)] })
   } catch (err) {
-    return buildErrorUtils.throw(`Loading \`${builder}\` server builder failed.`, {
+    return buildErrorUtils.throw({ message: `Loading \`${builder}\` server builder failed.`,
       code: ErrorCodes.B1018,
       fix: `Run \`npm install ${builder}\` to install it.`,
       docs: 'https://nuxt.com/docs/4.x/api/nuxt-config#builder-1',

--- a/packages/nuxt/src/core/utils/error-format.ts
+++ b/packages/nuxt/src/core/utils/error-format.ts
@@ -1,9 +1,9 @@
 import { createErrorUtils } from '@nuxt/kit'
 
 export { ErrorCodes } from '@nuxt/kit'
-export type { ErrorOptions as NuxtErrorOptions } from '@nuxt/kit'
+export type { ErrorInfo as NuxtErrorOptions } from '@nuxt/kit'
 
 export const buildErrorUtils = createErrorUtils({
-  module: 'NUXT',
+  prefix: 'NUXT',
   docsBase: 'https://nuxt.com/e',
 })

--- a/packages/nuxt/src/head/plugins/unhead-imports.ts
+++ b/packages/nuxt/src/head/plugins/unhead-imports.ts
@@ -67,7 +67,7 @@ export const UnheadImportsPlugin = (options: UnheadImportsPluginOptions) => crea
         if (importsFromUnhead.length) {
           // warn if user has imported from @unhead/vue themselves
           if (!normalize(id).includes('node_modules')) {
-            buildErrorUtils.warn(`You are importing from \`${UnheadVue}\` in \`./${relative(normalize(options.rootDir), normalize(id))}\`. Please import from \`#imports\` instead for full type safety.`, { code: ErrorCodes.B6001, fix: 'Import from `#imports` instead for full type safety.' })
+            buildErrorUtils.warn({ message: `You are importing from \`${UnheadVue}\` in \`./${relative(normalize(options.rootDir), normalize(id))}\`. Please import from \`#imports\` instead for full type safety.`, code: ErrorCodes.B6001, fix: 'Import from `#imports` instead for full type safety.' })
           }
           s.prepend(`${genImport('#app/composables/head', toImports(importsFromUnhead))}\n`)
         }

--- a/packages/nuxt/src/head/runtime/components.ts
+++ b/packages/nuxt/src/head/runtime/components.ts
@@ -262,7 +262,7 @@ export const Title = defineComponent({
       input.title = defaultSlot?.[0]?.children ? String(defaultSlot?.[0]?.children) : undefined
       if (import.meta.dev) {
         if (defaultSlot && (defaultSlot.length > 1 || (defaultSlot[0] && typeof defaultSlot[0].children !== 'string'))) {
-          runtimeErrorUtils.warn('`<Title>` can take only one string in its default slot.', { code: E6002 })
+          runtimeErrorUtils.warn({ message: '`<Title>` can take only one string in its default slot.', code: E6002 })
         }
       }
       update()
@@ -336,7 +336,7 @@ export const Style = defineComponent({
       const textContent = slots.default?.()?.[0]?.children
       if (textContent) {
         if (import.meta.dev && typeof textContent !== 'string') {
-          runtimeErrorUtils.warn('`<Style>` can only take a string in its default slot.', { code: E6003 })
+          runtimeErrorUtils.warn({ message: '`<Style>` can only take a string in its default slot.', code: E6003 })
         }
         input.style![idx] = style
         style.textContent = textContent

--- a/packages/nuxt/src/head/runtime/composables.ts
+++ b/packages/nuxt/src/head/runtime/composables.ts
@@ -23,7 +23,7 @@ export function injectHead (nuxtApp?: NuxtApp): VueHeadClient {
       const head = inject<VueHeadClient>(headSymbol)
       // should not be possible
       if (!head) {
-        runtimeErrorUtils.throw('[unhead] Missing Unhead instance.', {
+        runtimeErrorUtils.throw({ message: '[unhead] Missing Unhead instance.',
           code: E6001,
           fix: 'Ensure `useHead()` is called inside a component `setup()` function, a Nuxt plugin, or Nuxt middleware.',
         })

--- a/packages/nuxt/src/imports/module.ts
+++ b/packages/nuxt/src/imports/module.ts
@@ -164,7 +164,7 @@ export default defineNuxtModule<Partial<ImportsOptions>>({
             const value = i.as || i.name
             if (nuxtImports.has(value) && (!i.priority || i.priority >= 0 /* default priority */)) {
               const relativePath = isAbsolute(i.from) ? `${resolveToAlias(i.from, nuxt)}` : i.from
-              buildErrorUtils.error(`\`${value}\` is an auto-imported function that is in use by Nuxt. Overriding it will likely cause issues.`, {
+              buildErrorUtils.error({ message: `\`${value}\` is an auto-imported function that is in use by Nuxt. Overriding it will likely cause issues.`,
                 code: ErrorCodes.B6002,
                 fix: `Rename \`${value}\` in \`${relativePath}\` to avoid conflicting with the built-in Nuxt auto-import.`,
                 context: {

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -170,7 +170,7 @@ export default defineNuxtModule({
 
     nuxt.hook('app:templates', (app) => {
       if (!nuxt.options.ssr && app.pages?.some(p => p.mode === 'server')) {
-        buildErrorUtils.warn('Using server pages with `ssr: false` is not supported with auto-detected component islands. Set `experimental.componentIslands` to `true`.', { code: ErrorCodes.B4008, fix: 'Set `experimental.componentIslands` to `true`.' })
+        buildErrorUtils.warn({ message: 'Using server pages with `ssr: false` is not supported with auto-detected component islands. Set `experimental.componentIslands` to `true`.', code: ErrorCodes.B4008, fix: 'Set `experimental.componentIslands` to `true`.' })
       }
     })
 
@@ -395,7 +395,7 @@ export default defineNuxtModule({
           nuxt.apps.default!.pages = await augmentAndResolvePages(pages, pagesCtx.trackedFiles, nuxt)
         } catch (err) {
           // Fallback: full rebuild on unexpected tree error
-          buildErrorUtils.warn(`Incremental route update failed for \`${event}\` on \`${path}\`, performing full rebuild.`, { code: ErrorCodes.B4012, fix: 'This is usually harmless — the full rebuild will recover. If it happens repeatedly, check for unusual file naming in `pages/`.', cause: err })
+          buildErrorUtils.warn({ message: `Incremental route update failed for \`${event}\` on \`${path}\`, performing full rebuild.`, code: ErrorCodes.B4012, fix: 'This is usually harmless — the full rebuild will recover. If it happens repeatedly, check for unusual file naming in `pages/`.', cause: err })
           nuxt.apps.default!.pages = await resolvePagesRoutes(options.pattern, nuxt)
         }
       } else if (shouldAlwaysRegenerate || updateTemplatePaths.some(dir => path.startsWith(dir))) {

--- a/packages/nuxt/src/pages/plugins/page-meta.ts
+++ b/packages/nuxt/src/pages/plugins/page-meta.ts
@@ -111,7 +111,7 @@ export const PageMetaPlugin = (options: PageMetaPluginOptions = {}) => createUnp
           if (!code) {
             s.append(options.dev ? (CODE_DEV_EMPTY + CODE_HMR) : CODE_EMPTY)
             const { pathname } = parseModuleId(id)
-            buildErrorUtils.error(`The file \`${pathname}\` is not a valid page as it has no content.`, { code: ErrorCodes.B4001, fix: 'Add a `<template>` block to the page file, or remove the empty file from the `pages/` directory.' })
+            buildErrorUtils.error({ message: `The file \`${pathname}\` is not a valid page as it has no content.`, code: ErrorCodes.B4001, fix: 'Add a `<template>` block to the page file, or remove the empty file from the `pages/` directory.' })
           } else {
             s.overwrite(0, code.length, options.dev ? (CODE_DEV_EMPTY + CODE_HMR) : CODE_EMPTY)
           }
@@ -194,7 +194,7 @@ export const PageMetaPlugin = (options: PageMetaPluginOptions = {}) => createUnp
                   if (node.type === 'AwaitExpression') {
                     const filePath = id.replace(/\?.+$/, '')
                     const snippet = code.slice(node.start, Math.min(node.end, node.start + 80))
-                    buildErrorUtils.throw(`Await expressions are not supported in \`definePageMeta\`. File: \`${filePath}\``, {
+                    buildErrorUtils.throw({ message: `Await expressions are not supported in \`definePageMeta\`. File: \`${filePath}\``,
                       code: ErrorCodes.B4002,
                       fix: 'Move the `await` outside of variables referenced in `definePageMeta`, or use a static value instead.',
                       context: { codeSnippet: snippet, offset: node.start },
@@ -342,7 +342,7 @@ export const PageMetaPlugin = (options: PageMetaPluginOptions = {}) => createUnp
         })
 
         if (instances > 1) {
-          buildErrorUtils.throw(`Multiple \`definePageMeta\` calls are not supported. File: \`${id.replace(/\?.+$/, '')}\``, {
+          buildErrorUtils.throw({ message: `Multiple \`definePageMeta\` calls are not supported. File: \`${id.replace(/\?.+$/, '')}\``,
             code: ErrorCodes.B4003,
             fix: 'Merge all `definePageMeta()` calls into a single call.',
             context: { callCount: instances },

--- a/packages/nuxt/src/pages/runtime/composables.ts
+++ b/packages/nuxt/src/pages/runtime/composables.ts
@@ -68,7 +68,7 @@ declare module 'vue-router' {
 }
 
 const warnRuntimeUsage = (method: string) => {
-  runtimeErrorUtils.warn(`${method}() is a compiler-hint helper that is only usable inside the script block of a single file component which is also a page. Its arguments should be compiled away and passing it at runtime has no effect.`, { code: E1007, fix: `Move the \`${method}()\` call into the \`<script setup>\` block of a page component in the \`pages/\` directory.` })
+  runtimeErrorUtils.warn({ message: `${method}() is a compiler-hint helper that is only usable inside the script block of a single file component which is also a page. Its arguments should be compiled away and passing it at runtime has no effect.`, code: E1007, fix: `Move the \`${method}()\` call into the \`<script setup>\` block of a page component in the \`pages/\` directory.` })
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/nuxt/src/pages/runtime/page-placeholder.ts
+++ b/packages/nuxt/src/pages/runtime/page-placeholder.ts
@@ -8,7 +8,7 @@ export default defineComponent({
   name: 'NuxtPage',
   setup (_, props) {
     if (import.meta.dev) {
-      runtimeErrorUtils.warn(`No pages found. \`<NuxtPage>\` requires at least one page component in the \`${devPagesDir}/\` directory.`, { code: E4014, fix: `Create an \`index.vue\` file inside the \`${devPagesDir}/\` directory.` })
+      runtimeErrorUtils.warn({ message: `No pages found. \`<NuxtPage>\` requires at least one page component in the \`${devPagesDir}/\` directory.`, code: E4014, fix: `Create an \`index.vue\` file inside the \`${devPagesDir}/\` directory.` })
     }
     return () => props.slots.default?.()
   },

--- a/packages/nuxt/src/pages/runtime/plugins/check-if-page-unused.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/check-if-page-unused.ts
@@ -12,7 +12,7 @@ export default defineNuxtPlugin({
 
     function checkIfPageUnused () {
       if (!error.value && !nuxtApp._isNuxtPageUsed) {
-        runtimeErrorUtils.warn('Your project has pages but the `<NuxtPage />` component has not been used. You might be using the `<RouterView />` component instead, which will not work correctly in Nuxt.', { code: E4011, fix: 'You can set `pages: false` in `nuxt.config` if you do not wish to use the Nuxt `vue-router` integration.' })
+        runtimeErrorUtils.warn({ message: 'Your project has pages but the `<NuxtPage />` component has not been used. You might be using the `<RouterView />` component instead, which will not work correctly in Nuxt.', code: E4011, fix: 'You can set `pages: false` in `nuxt.config` if you do not wish to use the Nuxt `vue-router` integration.' })
       }
     }
 

--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -226,12 +226,12 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
 
           if (!middleware) {
             if (import.meta.dev) {
-              runtimeErrorUtils.throw(`Unknown route middleware: '${entry}'. Valid middleware: ${Object.keys(namedMiddleware).map(mw => `'${mw}'`).join(', ')}.`, {
+              runtimeErrorUtils.throw({ message: `Unknown route middleware: '${entry}'. Valid middleware: ${Object.keys(namedMiddleware).map(mw => `'${mw}'`).join(', ')}.`,
                 code: E2004,
                 fix: `Create a \`middleware/${entry}.ts\` file, or check the middleware name for typos.`,
               })
             }
-            runtimeErrorUtils.throw(`Unknown route middleware: '${entry}'.`, { code: E2004 })
+            runtimeErrorUtils.throw({ message: `Unknown route middleware: '${entry}'.`, code: E2004 })
           }
 
           try {

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -47,11 +47,11 @@ export function createPagesContext (options: PagesContextOptions = {}): PagesCon
   const treeOptions: BuildTreeOptions = {
     roots: options.roots,
     modes,
-    warn: msg => buildErrorUtils.warn(msg, { code: ErrorCodes.B4011, fix: 'Check the page file naming and directory structure for issues.' }),
+    warn: msg => buildErrorUtils.warn({ message: msg, code: ErrorCodes.B4011, fix: 'Check the page file naming and directory structure for issues.' }),
   }
   const emitOptions: VueRouterEmitOptions = {
     onDuplicateRouteName: (_name, file, existingFile) => {
-      buildErrorUtils.warn(`Route name generated for \`${file}\` is the same as \`${existingFile}\`. You may wish to set a custom name using \`definePageMeta\` within the page file.`, { code: ErrorCodes.B4004, fix: 'Set a custom name using `definePageMeta` within one of the page files.', context: { file, existingFile } })
+      buildErrorUtils.warn({ message: `Route name generated for \`${file}\` is the same as \`${existingFile}\`. You may wish to set a custom name using \`definePageMeta\` within the page file.`, code: ErrorCodes.B4004, fix: 'Set a custom name using `definePageMeta` within one of the page files.', context: { file, existingFile } })
     },
     attrs: { mode: modes },
   }
@@ -257,7 +257,7 @@ export function getRouteMeta (contents: string, absolutePath: string, extraExtra
         const transformed = transformSync(absolutePath, script.code.slice(node.start, node.end), { lang: script.loader })
         if (transformed.errors.length) {
           for (const error of transformed.errors) {
-            buildErrorUtils.warn(`Error while transforming \`${fnName}()\`` + error.codeframe, { code: ErrorCodes.B4007, fix: 'Fix the syntax error shown above in the page file.' })
+            buildErrorUtils.warn({ message: `Error while transforming \`${fnName}()\`` + error.codeframe, code: ErrorCodes.B4007, fix: 'Fix the syntax error shown above in the page file.' })
           }
           return
         }
@@ -268,14 +268,14 @@ export function getRouteMeta (contents: string, absolutePath: string, extraExtra
       }
 
       if (pageExtractArgument?.type !== 'ObjectExpression') {
-        buildErrorUtils.warn(`\`${fnName}\` must be called with an object literal (reading \`${absolutePath}\`), found ${pageExtractArgument?.type} instead.`, { code: ErrorCodes.B4005, fix: `Pass a plain object literal to \`${fnName}()\`, e.g. \`${fnName}({ ... })\`. Variables and function calls are not supported.`, context: { file: absolutePath, receivedType: pageExtractArgument?.type } })
+        buildErrorUtils.warn({ message: `\`${fnName}\` must be called with an object literal (reading \`${absolutePath}\`), found ${pageExtractArgument?.type} instead.`, code: ErrorCodes.B4005, fix: `Pass a plain object literal to \`${fnName}()\`, e.g. \`${fnName}({ ... })\`. Variables and function calls are not supported.`, context: { file: absolutePath, receivedType: pageExtractArgument?.type } })
         return
       }
 
       if (fnName === 'defineRouteRules') {
         const { value, serializable } = isSerializable(code, pageExtractArgument)
         if (!serializable) {
-          buildErrorUtils.warn(`\`${fnName}\` must be called with a serializable object literal (reading \`${absolutePath}\`).`, { code: ErrorCodes.B4006, fix: 'Use only JSON-serializable values (strings, numbers, booleans, arrays, plain objects) in `defineRouteRules()`.', context: { file: absolutePath } })
+          buildErrorUtils.warn({ message: `\`${fnName}\` must be called with a serializable object literal (reading \`${absolutePath}\`).`, code: ErrorCodes.B4006, fix: 'Use only JSON-serializable values (strings, numbers, booleans, arrays, plain objects) in `defineRouteRules()`.', context: { file: absolutePath } })
           return
         }
 

--- a/packages/shared/src/error.ts
+++ b/packages/shared/src/error.ts
@@ -196,11 +196,11 @@ function resolveCode (code: string, codePrefix: string | undefined): string {
  * @example
  * ```ts
  * const errorUtils = createErrorUtils({
- *   module: 'pinia',
+ *   prefix: 'pinia',
  *   docsBase: 'https://pinia.vuejs.org/errors',
  * })
  *
- * errorUtils.warn('Store not found.', { code: '001', fix: 'Call defineStore() first.' })
+ * errorUtils.warn({ message: 'Store not found.', code: '001', fix: 'Call defineStore() first.' })
  * // Output: [PINIA_001] Store not found.
  * //         ├▶ see: https://pinia.vuejs.org/errors/001
  * //         ╰▶ fix: Call defineStore() first.

--- a/packages/shared/src/error.ts
+++ b/packages/shared/src/error.ts
@@ -73,15 +73,27 @@ export function renderFrame (lines: string[], connectors?: FrameConnectors): str
 
 // --- createErrorUtils ---
 
-export interface ErrorOptions {
+export interface ErrorInfo {
+  /** The error tag prefix */
+  codePrefix?: string
   /** Error code (e.g., 'B1001'). Combined with the module prefix to form the error tag. */
   code: string
+  /** The error message */
+  message: string
   /** Why the error occurred — the underlying reason, shown on its own line below the message */
   why?: string
   /** A concrete suggestion for how to fix the issue */
   fix?: string
+  /** A hint to the user about the error */
+  hint?: string
   /** A documentation URL (overrides code-derived URL) */
   docs?: string
+  /** The location of source file that caused the error */
+  source?: {
+    file: string
+    line?: number
+    column?: number
+  }
   /** The underlying error that caused this one */
   cause?: unknown
   /** Extra context to include (only shown when the formatError implementation handles it) */
@@ -94,64 +106,85 @@ export interface ErrorUtilsOptions {
    *
    * The value is uppercased automatically.
    *
-   * @example 'pinia'  // → [PINIA_001]
+   * @example 'PINIA'  // → [PINIA_001]
    * @example 'NUXT'   // → [NUXT_B1001]
    */
-  module: string
+  prefix: string
   /**
    * Base URL for auto-generating docs links from error codes.
    *
    * When set, the docs URL for a given code defaults to `${docsBase}/${code}`.
    * When omitted, no docs link is shown unless `opts.docs` is provided per-call.
    */
-  docsBase?: string
+  docsBase?: string | ((code?: string) => string | undefined)
   /**
    * Custom error formatting function. Receives the resolved prefix, docs URL,
-   * and all error options. Controls the entire rendering of the formatted message.
+   * and all error info. Controls the entire rendering of the formatted message.
    *
    * Default: plain Unicode frame with `wrapLine` / `renderFrame`.
    */
-  formatError?: (message: string, opts: ErrorOptions & { prefix: string, docsUrl?: string }) => string
+  formatError?: (item: ErrorInfo, options: ErrorUtilsOptions) => string
   /** Logger for warn/error methods. Default: console. */
-  logger?: { error: (...args: any[]) => void, warn: (...args: any[]) => void }
+  logger?: {
+    error: (...args: any[]) => void
+    warn: (...args: any[]) => void
+  }
 }
 
 export interface ErrorUtils {
   /** Format an error/warning message with error code, fix, docs link, and optional diagnostic context. */
-  format: (message: string, opts: ErrorOptions) => string
+  format: (item: ErrorInfo) => string
   /** Throw an error with an error code, fix, and context. Sets structured fields on the Error object. */
-  throw: (message: string, opts: ErrorOptions) => never
+  throw: (item: ErrorInfo) => never
   /** Log a warning with error code, fix, and context. */
-  warn: (message: string, opts: ErrorOptions) => void
+  warn: (item: ErrorInfo) => void
   /** Log an error with error code, fix, and context (without throwing). */
-  error: (message: string, opts: ErrorOptions) => void
+  error: (item: ErrorInfo) => void
 }
 
 /**
  * Default plain-text error formatter using Unicode box-drawing frames.
  */
-function defaultFormatError (message: string, opts: ErrorOptions & { prefix: string, docsUrl?: string }): string {
+function defaultFormatError (item: ErrorInfo, options: ErrorUtilsOptions): string {
   const lines: string[] = []
 
-  if (opts.why) {
-    lines.push(wrapLine(opts.why))
+  if (item.why) {
+    lines.push(wrapLine(`why: ${item.why}`))
   }
 
-  if (opts.docsUrl) {
-    lines.push(wrapLine(`see: ${opts.docsUrl}`))
+  const docs = resolveDocsUrl(item.code, options.docsBase)
+  if (docs) {
+    lines.push(wrapLine(`see: ${docs}`))
+  }
+  if (item.fix) {
+    lines.push(wrapLine(`fix: ${item.fix}`))
+  }
+  if (item.hint) {
+    lines.push(wrapLine(`hint: ${item.hint}`))
+  }
+  if (item.source) {
+    lines.push(wrapLine(`source: ${item.source.file}:${item.source.line}:${item.source.column}`))
   }
 
-  if (opts.fix) {
-    lines.push(wrapLine(`fix: ${opts.fix}`))
-  }
-
-  let result = `[${opts.prefix}_${opts.code}] ${message}`
+  let result = `[${resolveCode(item.code, item.codePrefix)}] ${item.message}`
 
   if (lines.length > 0) {
     result += '\n' + renderFrame(lines)
   }
 
   return result
+}
+
+function resolveDocsUrl (code: string, docsBase: ErrorUtilsOptions['docsBase']): string | undefined {
+  return typeof docsBase === 'function'
+    ? docsBase(code)
+    : docsBase
+      ? `${docsBase}/${code}`
+      : undefined
+}
+
+function resolveCode (code: string, codePrefix: string | undefined): string {
+  return codePrefix ? `${codePrefix}_${code}` : code
 }
 
 /**
@@ -174,46 +207,43 @@ function defaultFormatError (message: string, opts: ErrorOptions & { prefix: str
  * ```
  */
 export function createErrorUtils (options: ErrorUtilsOptions): ErrorUtils {
-  const prefix = options.module.toUpperCase()
   const _formatError = options.formatError ?? defaultFormatError
   const _logger = options.logger ?? console
 
-  function resolveDocsUrl (code: string, docs?: string): string | undefined {
-    return docs || (options.docsBase ? `${options.docsBase}/${code}` : undefined)
+  function format (item: ErrorInfo): string {
+    return _formatError(item, options)
   }
 
-  function format (message: string, opts: ErrorOptions): string {
-    return _formatError(message, { ...opts, prefix, docsUrl: resolveDocsUrl(opts.code, opts.docs) })
-  }
-
-  function throwError (message: string, opts: ErrorOptions): never {
-    const err = new Error(`[${prefix}_${opts.code}] ${message}`, { cause: opts.cause })
-    ;(err as any).code = `${prefix}_${opts.code}`
+  function throwError (item: ErrorInfo): never {
+    const err = new Error(`[${resolveCode(item.code, item.codePrefix)}] ${item.message}`, { cause: item.cause })
+    ;(err as any).code = resolveCode(item.code, item.codePrefix)
 
     // Structured fields for HTML error page rendering
-    if (opts.fix) { (err as any).fix = opts.fix }
-    if (opts.why) { (err as any).why = opts.why }
-    const docsURL = resolveDocsUrl(opts.code, opts.docs)
-    if (docsURL) { (err as any).docsUrl = docsURL }
+    if (item.fix) { (err as any).fix = item.fix }
+    if (item.why) { (err as any).why = item.why }
+    if (item.hint) { (err as any).hint = item.hint }
+    if (item.source) { (err as any).source = item.source }
+    const docsURL = resolveDocsUrl(item.code, item.docs)
+    if (docsURL) { (err as any).docs = docsURL }
 
-    error(message, opts)
+    error(item)
 
     throw err
   }
 
-  function warn (message: string, opts: ErrorOptions): void {
-    if (opts.cause) {
-      _logger.warn(format(message, opts), opts.cause)
+  function warn (item: ErrorInfo): void {
+    if (item.cause) {
+      _logger.warn(format(item), item.cause)
     } else {
-      _logger.warn(format(message, opts))
+      _logger.warn(format(item))
     }
   }
 
-  function error (message: string, opts: ErrorOptions): void {
-    if (opts.cause) {
-      _logger.error(format(message, opts), opts.cause)
+  function error (item: ErrorInfo): void {
+    if (item.cause) {
+      _logger.error(format(item), item.cause)
     } else {
-      _logger.error(format(message, opts))
+      _logger.error(format(item))
     }
   }
 

--- a/packages/vite/src/css.ts
+++ b/packages/vite/src/css.ts
@@ -59,5 +59,5 @@ async function resolvePostcssPlugin (jiti: ReturnType<typeof createJiti>, plugin
     }
   }
 
-  buildErrorUtils.warn(`Could not load postcss plugin \`${pluginName}\`.`, { code: ErrorCodes.B7007, fix: `Run \`npm install -D ${pluginName}\` to install the PostCSS plugin.`, context: { pluginName } })
+  buildErrorUtils.warn({ message: `Could not load postcss plugin \`${pluginName}\`.`, code: ErrorCodes.B7007, fix: `Run \`npm install -D ${pluginName}\` to install the PostCSS plugin.`, context: { pluginName } })
 }

--- a/packages/vite/src/nuxt-errors.ts
+++ b/packages/vite/src/nuxt-errors.ts
@@ -3,6 +3,6 @@ import { createErrorUtils } from '@nuxt/kit'
 export { ErrorCodes } from '@nuxt/kit'
 
 export const buildErrorUtils = createErrorUtils({
-  module: 'NUXT',
+  prefix: 'NUXT',
   docsBase: 'https://nuxt.com/e',
 })

--- a/packages/vite/src/plugins/analyze.ts
+++ b/packages/vite/src/plugins/analyze.ts
@@ -21,7 +21,7 @@ export async function AnalyzePlugin (nuxt: Nuxt): Promise<Plugin | undefined> {
     searchPaths: nuxt.options.modulesDir,
     from: import.meta.url,
   })) {
-    buildErrorUtils.warn('Skipping bundle analysis.', { code: ErrorCodes.B7001, fix: 'Run `npm install -D rollup-plugin-visualizer` to enable bundle analysis.' })
+    buildErrorUtils.warn({ message: 'Skipping bundle analysis.', code: ErrorCodes.B7001, fix: 'Run `npm install -D rollup-plugin-visualizer` to enable bundle analysis.' })
     return
   }
 

--- a/packages/vite/src/plugins/decorators.ts
+++ b/packages/vite/src/plugins/decorators.ts
@@ -19,7 +19,7 @@ export function DecoratorsPlugin (nuxt: Nuxt): Plugin {
       })
 
       if (result !== true) {
-        buildErrorUtils.warn(`Install ${result.map(d => `\`${d}\``).join(' and ')} to enable decorator support.`, { code: ErrorCodes.B7009, fix: `Run \`npm install -D ${result.join(' ')}\` to install the required Babel decorator dependencies.` })
+        buildErrorUtils.warn({ message: `Install ${result.map(d => `\`${d}\``).join(' and ')} to enable decorator support.`, code: ErrorCodes.B7009, fix: `Run \`npm install -D ${result.join(' ')}\` to install the required Babel decorator dependencies.` })
         return false
       }
 

--- a/packages/vite/src/plugins/optimize-deps-hint.ts
+++ b/packages/vite/src/plugins/optimize-deps-hint.ts
@@ -132,7 +132,7 @@ export function OptimizeDepsHintPlugin (nuxt: Nuxt): Plugin {
           `Update your \`nuxt.config.ts\`:\n\n` +
           configBlock(getSnippetDeps()),
         )
-        buildErrorUtils.warn(parts.join('\n\n'), { code: ErrorCodes.B7002, fix: 'Update the `vite.optimizeDeps.include` array in your `nuxt.config.ts` with the values shown above.' })
+        buildErrorUtils.warn({ message: parts.join('\n\n'), code: ErrorCodes.B7002, fix: 'Update the `vite.optimizeDeps.include` array in your `nuxt.config.ts` with the values shown above.' })
       }
     }, 3000)
   }

--- a/packages/vite/src/plugins/vite-node.ts
+++ b/packages/vite/src/plugins/vite-node.ts
@@ -368,7 +368,7 @@ function createViteNodeSocketServer (nuxt: Nuxt, ssrServer: ViteDevServer, clien
       const requiredSize = writeOffset + additionalBytes
 
       if (requiredSize > MAX_BUFFER_SIZE) {
-        buildErrorUtils.throw(`Buffer size limit exceeded: ${requiredSize} > ${MAX_BUFFER_SIZE}`, { code: ErrorCodes.B7012, fix: 'This is an internal limit. If you are sending large payloads through the ViteNode socket, consider reducing the payload size.' })
+        buildErrorUtils.throw({ message: `Buffer size limit exceeded: ${requiredSize} > ${MAX_BUFFER_SIZE}`, code: ErrorCodes.B7012, fix: 'This is an internal limit. If you are sending large payloads through the ViteNode socket, consider reducing the payload size.' })
       }
 
       if (requiredSize > buffer.length) {
@@ -440,7 +440,7 @@ function createViteNodeSocketServer (nuxt: Nuxt, ssrServer: ViteDevServer, clien
 
   const currentSocketPath = config.socketPath
   if (!currentSocketPath) {
-    buildErrorUtils.throw('Socket path not configured for ViteNodeSocketServer.', { code: ErrorCodes.B7013, fix: 'This is likely an internal Nuxt bug. Please report it at https://github.com/nuxt/nuxt/issues.' })
+    buildErrorUtils.throw({ message: 'Socket path not configured for ViteNodeSocketServer.', code: ErrorCodes.B7013, fix: 'This is likely an internal Nuxt bug. Please report it at https://github.com/nuxt/nuxt/issues.' })
   }
 
   // Clean up existing socket file (Unix only)

--- a/packages/vite/src/plugins/vue-jsx.ts
+++ b/packages/vite/src/plugins/vue-jsx.ts
@@ -42,7 +42,7 @@ export function VueJsxPlugin (nuxt: Nuxt, options?: Options): Plugin[] {
 
     if (!result) {
       installFailed = true
-      buildErrorUtils.warn('Install `@vitejs/plugin-vue-jsx` to enable JSX support.', { code: ErrorCodes.B7008, fix: 'Run `npm install -D @vitejs/plugin-vue-jsx` to install it.' })
+      buildErrorUtils.warn({ message: 'Install `@vitejs/plugin-vue-jsx` to enable JSX support.', code: ErrorCodes.B7008, fix: 'Run `npm install -D @vitejs/plugin-vue-jsx` to install it.' })
       return undefined
     }
 

--- a/packages/vite/src/utils/config.ts
+++ b/packages/vite/src/utils/config.ts
@@ -12,7 +12,7 @@ export function resolveClientEntry (config: ResolvedConfig) {
     }
   }
 
-  return buildErrorUtils.throw(`No client entry found in \`rollupOptions.input\`. Expected an \`entry\` key or a string input. Received: ${JSON.stringify(input)}`, { code: ErrorCodes.B7005, fix: 'Set `vite.build.rollupOptions.input` to a string or an object with an `entry` key in your `nuxt.config`.' })
+  return buildErrorUtils.throw({ message: `No client entry found in \`rollupOptions.input\`. Expected an \`entry\` key or a string input. Received: ${JSON.stringify(input)}`, code: ErrorCodes.B7005, fix: 'Set `vite.build.rollupOptions.input` to a string or an object with an `entry` key in your `nuxt.config`.' })
 }
 
 export function resolveServerEntry (config: ResolvedConfig) {
@@ -26,5 +26,5 @@ export function resolveServerEntry (config: ResolvedConfig) {
     }
   }
 
-  return buildErrorUtils.throw(`No server entry found in \`rollupOptions.input\`. Expected a \`server\` key or a string input. Received: ${JSON.stringify(input)}`, { code: ErrorCodes.B7006, fix: 'Set `vite.build.rollupOptions.input` to a string or an object with a `server` key in your `nuxt.config`.' })
+  return buildErrorUtils.throw({ message: `No server entry found in \`rollupOptions.input\`. Expected a \`server\` key or a string input. Received: ${JSON.stringify(input)}`, code: ErrorCodes.B7006, fix: 'Set `vite.build.rollupOptions.input` to a string or an object with a `server` key in your `nuxt.config`.' })
 }

--- a/packages/vite/test/optimize-deps-hint.test.ts
+++ b/packages/vite/test/optimize-deps-hint.test.ts
@@ -22,11 +22,11 @@ vi.mock('@nuxt/kit', async (importOriginal) => {
       const utils = mod.createErrorUtils(options)
       return {
         ...utils,
-        warn: (message: string, opts: any) => {
-          mockLogger.warn(utils.format(message, opts))
+        warn: (item: any) => {
+          mockLogger.warn(utils.format(item))
         },
-        error: (message: string, opts: any) => {
-          mockLogger.error(utils.format(message, opts))
+        error: (item: any) => {
+          mockLogger.error(utils.format(item))
         },
       }
     },

--- a/packages/webpack/src/nuxt-errors.ts
+++ b/packages/webpack/src/nuxt-errors.ts
@@ -3,6 +3,6 @@ import { createErrorUtils } from '@nuxt/kit'
 export { ErrorCodes } from '@nuxt/kit'
 
 export const buildErrorUtils = createErrorUtils({
-  module: 'NUXT',
+  prefix: 'NUXT',
   docsBase: 'https://nuxt.com/e',
 })

--- a/packages/webpack/src/plugins/vue/server.ts
+++ b/packages/webpack/src/plugins/vue/server.ts
@@ -37,7 +37,8 @@ export default class VueSSRServerPlugin {
         const entryAssets = entryInfo.assets!.filter((asset: { name: string }) => isJS(asset.name))
 
         if (entryAssets.length > 1) {
-          buildErrorUtils.throw('Server-side bundle should have one single entry file.', {
+          buildErrorUtils.throw({
+            message: 'Server-side bundle should have one single entry file.',
             code: ErrorCodes.B7003,
             fix: 'Avoid using `optimization.splitChunks` in the server config.',
           })
@@ -45,7 +46,7 @@ export default class VueSSRServerPlugin {
 
         const [entry] = entryAssets
         if (!entry || typeof entry.name !== 'string') {
-          return buildErrorUtils.throw(`Entry "${entryName}" not found. Did you specify the correct entry option?`, { code: ErrorCodes.B7004, fix: `Check that the \`entry\` option in your webpack configuration points to an existing file. Expected entry name: \`${entryName}\`.` })
+          return buildErrorUtils.throw({ message: `Entry "${entryName}" not found. Did you specify the correct entry option?`, code: ErrorCodes.B7004, fix: `Check that the \`entry\` option in your webpack configuration points to an existing file. Expected entry name: \`${entryName}\`.` })
         }
 
         const bundle = {

--- a/packages/webpack/src/plugins/vue/util.ts
+++ b/packages/webpack/src/plugins/vue/util.ts
@@ -9,7 +9,7 @@ import type { Compiler } from 'webpack'
 
 export const validate = (compiler: Compiler) => {
   if (compiler.options.target !== 'node') {
-    buildErrorUtils.warn('webpack config `target` should be "node".', { code: ErrorCodes.B5007, fix: 'Set `target: "node"` in your webpack server configuration.' })
+    buildErrorUtils.warn({ message: 'webpack config `target` should be "node".', code: ErrorCodes.B5007, fix: 'Set `target: "node"` in your webpack server configuration.' })
   }
 
   if (!compiler.options.externals) {

--- a/packages/webpack/src/utils/config.ts
+++ b/packages/webpack/src/utils/config.ts
@@ -56,7 +56,7 @@ export function fileName (ctx: WebpackConfigContext, key: string) {
   if (typeof fileName === 'string' && ctx.options.dev) {
     const hash = /\[(chunkhash|contenthash|hash)(?::\d+)?\]/.exec(fileName)
     if (hash) {
-      buildErrorUtils.warn(`Do not use \`${hash[1]}\` in dev mode to prevent a memory leak.`, { code: ErrorCodes.B5006, fix: 'Remove the hash option from your webpack config to prevent a memory leak.' })
+      buildErrorUtils.warn({ message: `Do not use \`${hash[1]}\` in dev mode to prevent a memory leak.`, code: ErrorCodes.B5006, fix: 'Remove the hash option from your webpack config to prevent a memory leak.' })
     }
   }
 

--- a/packages/webpack/src/utils/postcss.ts
+++ b/packages/webpack/src/utils/postcss.ts
@@ -61,7 +61,7 @@ export async function getPostcssConfig (nuxt: Nuxt) {
       }
 
       if (typeof pluginFn !== 'function') {
-        buildErrorUtils.warn(`Could not import PostCSS plugin \`${pluginName}\`. Please report this as a bug.`, { code: ErrorCodes.B7011, fix: `Run \`npm install -D ${pluginName}\` to install it, or report this issue at https://github.com/nuxt/nuxt/issues.` })
+        buildErrorUtils.warn({ message: `Could not import PostCSS plugin \`${pluginName}\`. Please report this as a bug.`, code: ErrorCodes.B7011, fix: `Run \`npm install -D ${pluginName}\` to install it, or report this issue at https://github.com/nuxt/nuxt/issues.` })
       }
     }
 

--- a/packages/webpack/src/webpack.ts
+++ b/packages/webpack/src/webpack.ts
@@ -218,7 +218,7 @@ async function compile (compiler: Compiler) {
   const stats = await new Promise<Stats>((resolve, reject) => compiler.run((err, stats) => err ? reject(err) : resolve(stats!)))
 
   if (stats.hasErrors()) {
-    buildErrorUtils.throw(`Webpack \`${compiler.options.name}\` build failed with errors:\n\n${stats.toString('errors-only')}`, { code: ErrorCodes.B7014, fix: 'Fix the build errors listed above. If the errors are unclear, try running `nuxi clean` and rebuilding.' })
+    buildErrorUtils.throw({ message: `Webpack \`${compiler.options.name}\` build failed with errors:\n\n${stats.toString('errors-only')}`, code: ErrorCodes.B7014, fix: 'Fix the build errors listed above. If the errors are unclear, try running `nuxi clean` and rebuilding.' })
   }
 }
 


### PR DESCRIPTION
## Summary

- Redesigns the `ErrorInfo` interface (formerly `ErrorOptions`) to use a single-object argument pattern: `errorUtils.warn({ message, code, fix })` instead of the old two-arg `errorUtils.warn(message, { code, fix })`
- Renames `ErrorUtilsOptions.module` to `ErrorUtilsOptions.prefix` across all packages
- Adds support for new `hint` and `source` fields in the kit's colored error formatter
- Migrates all ~110 call sites across 94 files (kit, nuxt, vite, webpack, nitro-server)
- Updates documentation in error-handling guide and advanced module recipes to reflect the new API

## Test plan

- [x] `pnpm typecheck` passes (no new errors)
- [ ] Verify error output formatting in terminal with `hint` and `source` fields
- [ ] Run `pnpm test` to check for runtime regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)