### PR TITLE
feat(nuxt): add `relativeCompact` prop to `<NuxtTime>`

### DIFF
--- a/docs/4.api/1.components/13.nuxt-time.md
+++ b/docs/4.api/1.components/13.nuxt-time.md
@@ -119,6 +119,34 @@ Due to `style` being a reserved prop, `relativeStyle` prop is used instead.
 
 This would output something like: "3 days ago" or "last Friday" depending on the `numeric` setting.
 
+### `relativeCompact`
+
+- Type: `boolean`
+- Required: `false`
+- Default: `false`
+
+When enabled, displays only the numeric value with its unit abbreviation, stripping directional text like "ago" or "in". This produces compact timestamps commonly seen in social UIs. Can be combined with `relative-style` to control the unit display format:
+
+```vue
+<template>
+  <!-- Shows "5m" instead of "5m ago" -->
+  <NuxtTime
+    :datetime="Date.now() - 5 * 60 * 1000"
+    relative
+    relative-compact
+    relative-style="narrow"
+  />
+
+  <!-- Shows "5 min" instead of "5 min ago" -->
+  <NuxtTime
+    :datetime="Date.now() - 5 * 60 * 1000"
+    relative
+    relative-compact
+    relative-style="short"
+  />
+</template>
+```
+
 ## Examples
 
 ### Basic Usage

--- a/packages/nuxt/src/app/components/nuxt-time.vue
+++ b/packages/nuxt/src/app/components/nuxt-time.vue
@@ -31,12 +31,14 @@ export interface NuxtTimeProps {
   relative?: boolean
   numeric?: 'always' | 'auto'
   relativeStyle?: 'long' | 'short' | 'narrow'
+  relativeCompact?: boolean
 
   title?: boolean | string
 }
 
 const props = withDefaults(defineProps<NuxtTimeProps>(), {
   hour12: undefined,
+  relativeCompact: undefined,
 })
 
 const el = getCurrentInstance()?.vnode.el
@@ -62,7 +64,7 @@ if (import.meta.client && props.relative) {
 }
 
 const formatter = computed(() => {
-  const { locale: propsLocale, relative, relativeStyle, ...rest } = props
+  const { locale: propsLocale, relative, relativeStyle, relativeCompact, ...rest } = props
   if (relative) {
     return new Intl.RelativeTimeFormat(_locale ?? propsLocale, { ...rest, style: relativeStyle })
   }
@@ -96,6 +98,15 @@ const formattedDate = computed(() => {
   const { unit, seconds } = units.find(({ seconds, threshold }) => Math.abs(diffInSeconds / seconds) < threshold) || units[units.length - 1]!
 
   const value = diffInSeconds / seconds
+
+  if (props.relativeCompact) {
+    return new Intl.NumberFormat(_locale ?? props.locale, {
+      style: 'unit',
+      unit,
+      unitDisplay: props.relativeStyle || 'long',
+    }).format(Math.abs(Math.round(value)))
+  }
+
   return (formatter.value as Intl.RelativeTimeFormat).format(Math.round(value), unit)
 })
 
@@ -132,7 +143,7 @@ if (import.meta.server) {
       return
     }
 
-    const options: Intl.DateTimeFormatOptions & Intl.RelativeTimeFormatOptions & { locale?: Intl.LocalesArgument, relative?: boolean } = {}
+    const options: Intl.DateTimeFormatOptions & Intl.RelativeTimeFormatOptions & { locale?: Intl.LocalesArgument, relative?: boolean, relativeCompact?: boolean } = {}
     for (const name of el.getAttributeNames()) {
       if (name.startsWith('data-')) {
         let optionName = name.slice(5).split('-').map(toCamelCase).join('') as keyof (Intl.DateTimeFormatOptions & Intl.RelativeTimeFormatOptions)
@@ -162,8 +173,16 @@ if (import.meta.server) {
       ]
       const { unit, seconds } = units.find(({ seconds, threshold }) => Math.abs(diffInSeconds / seconds) < threshold) || units[units.length - 1]!
       const value = diffInSeconds / seconds
-      const formatter = new Intl.RelativeTimeFormat(options.locale, options)
-      el.textContent = formatter.format(Math.round(value), unit)
+      if (options.relativeCompact) {
+        el.textContent = new Intl.NumberFormat(options.locale, {
+          style: 'unit',
+          unit,
+          unitDisplay: options.style || 'long',
+        }).format(Math.abs(Math.round(value)))
+      } else {
+        const formatter = new Intl.RelativeTimeFormat(options.locale, options)
+        el.textContent = formatter.format(Math.round(value), unit)
+      }
     } else {
       const formatter = new Intl.DateTimeFormat(options.locale, options)
       el.textContent = formatter.format(date)

--- a/test/nuxt/nuxt-time.test.ts
+++ b/test/nuxt/nuxt-time.test.ts
@@ -78,6 +78,25 @@ describe('<NuxtTime>', () => {
     )
   })
 
+  it('should display compact relative time with relativeCompact', async () => {
+    const datetime = Date.now() - 5 * 60 * 1000
+    const thing = await mountSuspended(
+      defineComponent({
+        render: () =>
+          h(NuxtTime, {
+            datetime,
+            relative: true,
+            locale: 'en-GB',
+            relativeStyle: 'narrow',
+            relativeCompact: true,
+          }),
+      }),
+    )
+    expect(thing.html()).toMatchInlineSnapshot(
+      `"<time datetime="${new Date(datetime).toISOString()}">5m</time>"`,
+    )
+  })
+
   it('should display datetime in title', async () => {
     const datetime = Date.now() - 5 * 60 * 1000
     const thing = await mountSuspended(
@@ -166,6 +185,53 @@ describe('<NuxtTime>', () => {
     expect(thing.html()).toEqual(
       `<time data-locale="en-GB" data-relative="true" data-title="test" datetime="${new Date(datetime).toISOString()}" title="test" ssr="true" data-prehydrate-id="${id}">${description}</time>`,
     )
+
+    vi.restoreAllMocks()
+  })
+
+  it('should generate correct hydrateable code with relativeCompact', async () => {
+    const datetime = Date.now() - 25 * 60 * 60 * 1000
+    const thing = await mountSuspended(
+      defineComponent({
+        render: () =>
+          h(NuxtTime, {
+            ssr: true,
+            datetime,
+            relative: true,
+            locale: 'en-GB',
+            relativeStyle: 'narrow',
+            relativeCompact: true,
+          }),
+      }),
+    )
+
+    const html = thing.html()
+    expect(html).toContain('data-relative-compact="true"')
+    expect(html).toContain('data-relative-style="narrow"')
+
+    const id = html.match(/data-prehydrate-id="([^"]+)"/)?.[1]
+    expect(id).toBeDefined()
+
+    expect(thing.element.textContent).toBe('1d')
+
+    vi.spyOn(document, 'querySelectorAll').mockImplementation((selector) => {
+      if (selector === `[data-prehydrate-id*="${id}"]`) {
+        return [thing.element] as any
+      }
+      return []
+    })
+
+    const head = injectHead()
+    const prehydrateEntry = [...head.entries.values()].find(
+      // @ts-expect-error untyped internal
+      e => e.input?.script?.[0]?.innerHTML?.includes('_nuxtTimeNow'),
+    )
+    expect(prehydrateEntry).toBeDefined()
+    // @ts-expect-error untyped internal
+    const fn = new Function(prehydrateEntry!.input.script[0].innerHTML)
+    fn()
+
+    expect(thing.element.textContent).toBe('1d')
 
     vi.restoreAllMocks()
   })


### PR DESCRIPTION
## Summary

Adds a `relativeCompact` boolean prop to `<NuxtTime>` that strips directional text ("ago"/"in") from relative time output, producing compact timestamps commonly seen in social UIs (Reddit, GitHub, Bluesky).

```vue
<NuxtTime :datetime="oldDate" relative relative-compact relative-style="narrow" />
<!-- "5m" instead of "5m ago" -->
```

Closes #34731

## Deviations from the original issue

- **Prop name**: Uses `relativeCompact` (boolean) instead of `relativeParts="value"`. A boolean is simpler and more discoverable, and the name better describes the output rather than referencing an implementation detail.
- **Independent of `relativeStyle`**: The original issue coupled the behavior with `relative-style="narrow"`. This implementation keeps `relativeCompact` separate so users can combine it with any style (`narrow` → "5m", `short` → "5 min", `long` → "5 minutes").
- **Implementation approach**: Uses `Intl.NumberFormat` with `style: 'unit'` instead of `Intl.RelativeTimeFormat.formatToParts()`. The `formatToParts()` API bundles unit abbreviations and directional text into the same literal part (e.g. `{type:"literal", value:"y ago"}`), making type-based filtering insufficient. `Intl.NumberFormat` cleanly produces the desired output across all locales.

## Changes

- `packages/nuxt/src/app/components/nuxt-time.vue` — Added `relativeCompact` prop, formatting logic in both `formattedDate` computed and `onPrehydrate` script
- `test/nuxt/nuxt-time.test.ts` — Client-side rendering test and prehydration round-trip test
- `docs/4.api/1.components/13.nuxt-time.md` — Prop documentation with usage examples

## Test plan

- [x] Existing NuxtTime tests pass (30/30)
- [x] New client-side test: `relativeCompact` with `relativeStyle="narrow"` produces "5m"
- [x] New prehydration test: verifies `data-relative-compact="true"` attribute serialization, script execution, and consistent "1d" output