### PR TITLE
fix(nitro): do not add import condition for ssr resolve conditions

### DIFF
--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -780,7 +780,9 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
     configEnvironment (name, config) {
       if (name === 'ssr') {
         config.resolve ||= {}
-        config.resolve.conditions = [...nitro.options.exportConditions || [], 'import']
+        config.resolve.conditions = [...nitro.options.exportConditions || []]
+        // TODO: remove in v5
+        config.resolve.conditions = config.resolve.conditions.filter(c => c !== 'import')
       }
     },
   })


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

fixed a module resolution [issue](https://github.com/nuxt/test-utils/issues/1635) (thanks to the vitest team for the investigation [here](https://github.com/vitest-dev/vitest/issues/10012)). 
modified ssr `resolve.conditions` to exclude `import`. this is already resolved in nitro-v3 the [pr](https://github.com/nitrojs/nitro/pull/4029).
added an `import` filter, but it can be removed once nitropack supports it or upon full migration to nitro-v3.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
