### PR TITLE
docs: clarify useRequestFetch for SSR internal fetch context

### DIFF
--- a/docs/1.getting-started/10.data-fetching.md
+++ b/docs/1.getting-started/10.data-fetching.md
@@ -119,6 +119,17 @@ async function getCurrentUser () {
 You can also use [`useRequestFetch`](/docs/4.x/api/composables/use-request-fetch) to proxy headers to the call automatically.
 ::
 
+::note
+When you call an internal API in SSR with `useAsyncData` and `$fetch`, request context-specific data (like Cloudflare bindings or request-scoped context) may not be available in the same way as with `useFetch`. In these cases, prefer [`useRequestFetch`](/docs/4.x/api/composables/use-request-fetch) inside your `useAsyncData` handler.
+
+```vue
+<script setup lang="ts">
+const requestFetch = useRequestFetch()
+const { data } = await useAsyncData('hello', () => requestFetch('/api/hello'))
+</script>
+```
+::
+
 ::caution
 Be very careful before proxying headers to an external API and just include headers that you need. Not all headers are safe to be bypassed and might introduce unwanted behavior. Here is a list of common headers that are NOT to be proxied:
 

--- a/packages/nuxt/src/compiler/runtime/index.ts
+++ b/packages/nuxt/src/compiler/runtime/index.ts
@@ -19,7 +19,7 @@ export function defineKeyedFunctionFactory<T extends Function> (factory: ObjectF
     if (import.meta.dev) {
       throw new Error(
         `[nuxt:compiler] \`${factory.name}\` is a compiler macro that is only usable inside ` +
-        'the directories scanned by the Nuxt compiler as an exported function and imported statically. Learn more: `https://nuxt.com/docs/guide/going-further/compiler`',
+        'the directories scanned by the Nuxt compiler as an exported function and imported statically. Learn more: `https://nuxt.com/docs/4.x/guide/going-further/compiler`',
       )
     }
     throw new Error(`[nuxt] \`${factory.name}\` is a compiler macro and cannot be called at runtime.`)

--- a/packages/nuxt/test/compiler.test.ts
+++ b/packages/nuxt/test/compiler.test.ts
@@ -31,7 +31,7 @@ describe('defineKeyedFunctionFactory', () => {
       factory: fn,
     })
 
-    expect(() => factory('a', 1)).toThrowErrorMatchingInlineSnapshot(`[Error: [nuxt:compiler] \`createUseFetch\` is a compiler macro that is only usable inside the directories scanned by the Nuxt compiler as an exported function and imported statically. Learn more: \`https://nuxt.com/docs/guide/going-further/compiler\`]`)
+    expect(() => factory('a', 1)).toThrowErrorMatchingInlineSnapshot(`[Error: [nuxt:compiler] \`createUseFetch\` is a compiler macro that is only usable inside the directories scanned by the Nuxt compiler as an exported function and imported statically. Learn more: \`https://nuxt.com/docs/4.x/guide/going-further/compiler\`]`)
 
     vi.unstubAllGlobals()
   })


### PR DESCRIPTION
🔗 Linked issue
resolves #30433

📚 Description
This updates the data-fetching docs to explain when useAsyncData + $fetch can lose request-scoped context during SSR (for example on Cloudflare).
It adds a clear recommendation and example for using useRequestFetch for internal server calls that depend on request context.