### PR TITLE
docs: explain Vite HMR config behind proxies

### DIFF
--- a/docs/3.guide/6.going-further/9.debugging.md
+++ b/docs/3.guide/6.going-further/9.debugging.md
@@ -81,6 +81,35 @@ If you prefer your usual browser extensions, add this to the _chrome_ configurat
 "userDataDir": false,
 ```
 
+### Vite HMR with Reverse Proxies or Containers
+
+If your app is running behind Docker, nginx, or another reverse proxy, you may need to configure `vite.server.hmr` explicitly.
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  vite: {
+    server: {
+      hmr: {
+        protocol: 'ws',
+        host: 'localhost',
+        port: 3000,
+        clientPort: 3000,
+        path: 'hmr/',
+      },
+      allowedHosts: ['localhost'],
+    },
+  },
+})
+```
+
+If Nuxt's dev server still overrides your Vite HMR settings, you can disable that behavior:
+
+```bash [Terminal]
+NUXI_DISABLE_VITE_HMR=1 nuxt dev
+```
+
+The `clientPort` option is especially important when browser and server ports differ.
+
 ### Example JetBrains IDEs Debug Configuration
 
 You can also debug your Nuxt app in JetBrains IDEs such as IntelliJ IDEA, WebStorm, or PhpStorm.

--- a/packages/nuxt/src/compiler/runtime/index.ts
+++ b/packages/nuxt/src/compiler/runtime/index.ts
@@ -19,7 +19,7 @@ export function defineKeyedFunctionFactory<T extends Function> (factory: ObjectF
     if (import.meta.dev) {
       throw new Error(
         `[nuxt:compiler] \`${factory.name}\` is a compiler macro that is only usable inside ` +
-        'the directories scanned by the Nuxt compiler as an exported function and imported statically. Learn more: `https://nuxt.com/docs/guide/going-further/compiler`',
+        'the directories scanned by the Nuxt compiler as an exported function and imported statically. Learn more: `https://nuxt.com/docs/4.x/guide/going-further/compiler`',
       )
     }
     throw new Error(`[nuxt] \`${factory.name}\` is a compiler macro and cannot be called at runtime.`)

--- a/packages/nuxt/test/compiler.test.ts
+++ b/packages/nuxt/test/compiler.test.ts
@@ -31,7 +31,7 @@ describe('defineKeyedFunctionFactory', () => {
       factory: fn,
     })
 
-    expect(() => factory('a', 1)).toThrowErrorMatchingInlineSnapshot(`[Error: [nuxt:compiler] \`createUseFetch\` is a compiler macro that is only usable inside the directories scanned by the Nuxt compiler as an exported function and imported statically. Learn more: \`https://nuxt.com/docs/guide/going-further/compiler\`]`)
+    expect(() => factory('a', 1)).toThrowErrorMatchingInlineSnapshot(`[Error: [nuxt:compiler] \`createUseFetch\` is a compiler macro that is only usable inside the directories scanned by the Nuxt compiler as an exported function and imported statically. Learn more: \`https://nuxt.com/docs/4.x/guide/going-further/compiler\`]`)
 
     vi.unstubAllGlobals()
   })


### PR DESCRIPTION
🔗 Linked issue
resolves #25335

📚 Description
This adds practical HMR troubleshooting guidance for reverse-proxy and container setups.
It documents recommended vite.server.hmr options and includes the NUXI_DISABLE_VITE_HMR fallback when Nuxt-side HMR overrides custom config.