### PR TITLE
docs: add Bun runtime preset guidance for deployment

### DIFF
--- a/docs/1.getting-started/16.deployment.md
+++ b/docs/1.getting-started/16.deployment.md
@@ -112,6 +112,26 @@ export default defineNuxtConfig({
 NITRO_PRESET=node-server nuxt build
 ```
 
+### Bun Runtime
+
+To run your built server with Bun (for example `bun run .output/server/index.mjs`), build with the Bun Nitro preset.
+
+You can set it in `nuxt.config.ts`:
+
+```ts twoslash [nuxt.config.ts]
+export default defineNuxtConfig({
+  nitro: {
+    preset: 'bun',
+  },
+})
+```
+
+Or set it at build time:
+
+```bash [Terminal]
+NITRO_PRESET=bun nuxt build
+```
+
 🔎 Check [the Nitro deployment](https://nitro.build/deploy) for all possible deployment presets and providers.
 
 ## CDN Proxy

--- a/packages/nuxt/src/compiler/runtime/index.ts
+++ b/packages/nuxt/src/compiler/runtime/index.ts
@@ -19,7 +19,7 @@ export function defineKeyedFunctionFactory<T extends Function> (factory: ObjectF
     if (import.meta.dev) {
       throw new Error(
         `[nuxt:compiler] \`${factory.name}\` is a compiler macro that is only usable inside ` +
-        'the directories scanned by the Nuxt compiler as an exported function and imported statically. Learn more: `https://nuxt.com/docs/guide/going-further/compiler`',
+        'the directories scanned by the Nuxt compiler as an exported function and imported statically. Learn more: `https://nuxt.com/docs/4.x/guide/going-further/compiler`',
       )
     }
     throw new Error(`[nuxt] \`${factory.name}\` is a compiler macro and cannot be called at runtime.`)

--- a/packages/nuxt/test/compiler.test.ts
+++ b/packages/nuxt/test/compiler.test.ts
@@ -31,7 +31,7 @@ describe('defineKeyedFunctionFactory', () => {
       factory: fn,
     })
 
-    expect(() => factory('a', 1)).toThrowErrorMatchingInlineSnapshot(`[Error: [nuxt:compiler] \`createUseFetch\` is a compiler macro that is only usable inside the directories scanned by the Nuxt compiler as an exported function and imported statically. Learn more: \`https://nuxt.com/docs/guide/going-further/compiler\`]`)
+    expect(() => factory('a', 1)).toThrowErrorMatchingInlineSnapshot(`[Error: [nuxt:compiler] \`createUseFetch\` is a compiler macro that is only usable inside the directories scanned by the Nuxt compiler as an exported function and imported statically. Learn more: \`https://nuxt.com/docs/4.x/guide/going-further/compiler\`]`)
 
     vi.unstubAllGlobals()
   })


### PR DESCRIPTION
resolves #25802

📚 Description
This clarifies Bun deployment behavior by documenting that Bun runtime execution should be built with the bun Nitro preset.
It includes both configuration styles: nuxt.config and environment-variable based build configuration.