### PR TITLE
docs: add VS Code Deno debug launch example

### DIFF
--- a/docs/3.guide/6.going-further/9.debugging.md
+++ b/docs/3.guide/6.going-further/9.debugging.md
@@ -34,6 +34,35 @@ Note that the Node.js and Chrome processes need to be run on the same platform. 
 
 It is possible to debug your Nuxt app in your IDE while you are developing it.
 
+### Example VS Code Debug Configuration (Deno Runtime)
+
+If you run Nuxt with Deno, use a Node-compatible debug adapter (`pwa-node`) and launch Deno directly.
+
+```json5
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "pwa-node",
+      "request": "launch",
+      "name": "server: deno",
+      "cwd": "${workspaceFolder}",
+      "runtimeExecutable": "deno",
+      "runtimeArgs": [
+        "run",
+        "--inspect-wait=127.0.0.1:9229",
+        "--allow-all",
+        "npm:nuxt/nuxi",
+        "dev"
+      ],
+      "outputCapture": "std"
+    }
+  ]
+}
+```
+
+If breakpoints are not hit, verify sourcemaps are enabled and restart the debug session after Nuxt recompiles.
+
 ### Example VS Code Debug Configuration
 
 You may need to update the config below with a path to your web browser. For more information, visit the [VS Code documentation about debug configuration](https://code.visualstudio.com/docs/debugtest/debugging#_launch-configurations).

--- a/packages/nuxt/src/compiler/runtime/index.ts
+++ b/packages/nuxt/src/compiler/runtime/index.ts
@@ -19,7 +19,7 @@ export function defineKeyedFunctionFactory<T extends Function> (factory: ObjectF
     if (import.meta.dev) {
       throw new Error(
         `[nuxt:compiler] \`${factory.name}\` is a compiler macro that is only usable inside ` +
-        'the directories scanned by the Nuxt compiler as an exported function and imported statically. Learn more: `https://nuxt.com/docs/guide/going-further/compiler`',
+        'the directories scanned by the Nuxt compiler as an exported function and imported statically. Learn more: `https://nuxt.com/docs/4.x/guide/going-further/compiler`',
       )
     }
     throw new Error(`[nuxt] \`${factory.name}\` is a compiler macro and cannot be called at runtime.`)

--- a/packages/nuxt/test/compiler.test.ts
+++ b/packages/nuxt/test/compiler.test.ts
@@ -31,7 +31,7 @@ describe('defineKeyedFunctionFactory', () => {
       factory: fn,
     })
 
-    expect(() => factory('a', 1)).toThrowErrorMatchingInlineSnapshot(`[Error: [nuxt:compiler] \`createUseFetch\` is a compiler macro that is only usable inside the directories scanned by the Nuxt compiler as an exported function and imported statically. Learn more: \`https://nuxt.com/docs/guide/going-further/compiler\`]`)
+    expect(() => factory('a', 1)).toThrowErrorMatchingInlineSnapshot(`[Error: [nuxt:compiler] \`createUseFetch\` is a compiler macro that is only usable inside the directories scanned by the Nuxt compiler as an exported function and imported statically. Learn more: \`https://nuxt.com/docs/4.x/guide/going-further/compiler\`]`)
 
     vi.unstubAllGlobals()
   })


### PR DESCRIPTION
🔗 Linked issue
resolves #30266

📚 Description
This adds a VS Code launch configuration example for debugging Nuxt when running through Deno.
It also includes a short note on sourcemaps and session restart behavior so breakpoints bind more reliably.