### PR TITLE
docs: recommend error.data for client error metadata

### DIFF
--- a/docs/4.api/3.utils/create-error.md
+++ b/docs/4.api/3.utils/create-error.md
@@ -52,4 +52,10 @@ export default eventHandler(() => {
 
 In API routes, using `createError` by passing an object with a short `statusText` is recommended because it can be accessed on the client side. Otherwise, a `message` passed to `createError` on an API route will not propagate to the client. Alternatively, you can use the `data` property to pass data back to the client. In any case, always consider avoiding to put dynamic user input to the message to avoid potential security issues.
 
+::tip
+For app-specific client logic, prefer reading values from `error.data` (for example, `error.data.code` or `error.data.statusMessage`) instead of relying only on `error.statusText`.
+
+The HTTP status text can be normalized or rewritten by proxies and can differ between environments, while `data` is part of the serialized response payload.
+::
+
 :read-more{to="/docs/4.x/getting-started/error-handling"}

--- a/packages/nuxt/src/compiler/runtime/index.ts
+++ b/packages/nuxt/src/compiler/runtime/index.ts
@@ -19,7 +19,7 @@ export function defineKeyedFunctionFactory<T extends Function> (factory: ObjectF
     if (import.meta.dev) {
       throw new Error(
         `[nuxt:compiler] \`${factory.name}\` is a compiler macro that is only usable inside ` +
-        'the directories scanned by the Nuxt compiler as an exported function and imported statically. Learn more: `https://nuxt.com/docs/guide/going-further/compiler`',
+        'the directories scanned by the Nuxt compiler as an exported function and imported statically. Learn more: `https://nuxt.com/docs/4.x/guide/going-further/compiler`',
       )
     }
     throw new Error(`[nuxt] \`${factory.name}\` is a compiler macro and cannot be called at runtime.`)

--- a/packages/nuxt/test/compiler.test.ts
+++ b/packages/nuxt/test/compiler.test.ts
@@ -31,7 +31,7 @@ describe('defineKeyedFunctionFactory', () => {
       factory: fn,
     })
 
-    expect(() => factory('a', 1)).toThrowErrorMatchingInlineSnapshot(`[Error: [nuxt:compiler] \`createUseFetch\` is a compiler macro that is only usable inside the directories scanned by the Nuxt compiler as an exported function and imported statically. Learn more: \`https://nuxt.com/docs/guide/going-further/compiler\`]`)
+    expect(() => factory('a', 1)).toThrowErrorMatchingInlineSnapshot(`[Error: [nuxt:compiler] \`createUseFetch\` is a compiler macro that is only usable inside the directories scanned by the Nuxt compiler as an exported function and imported statically. Learn more: \`https://nuxt.com/docs/4.x/guide/going-further/compiler\`]`)
 
     vi.unstubAllGlobals()
   })


### PR DESCRIPTION
🔗 Linked issue
resolves #26016

📚 Description
This clarifies error-handling docs to recommend reading app-specific metadata from error.data on the client.
It explains that HTTP status text can vary across environments and proxies, while response payload data is more stable for app logic.