### PR TITLE
fix(nuxt): preserve query parameters in payload extraction for cached routes

### DIFF
--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -102,13 +102,14 @@ const handler: ReturnType<typeof defineEventHandler> = defineEventHandler(async 
   if (isRenderingPayload) {
     const parsed = new URL(ssrContext.url, 'http://localhost')
     const url = parsed.pathname.substring(0, parsed.pathname.lastIndexOf('/')) || '/'
-
+    
+    // Remove the build hash from query params, keep original route query params
     parsed.searchParams.delete('_b')
     const search = parsed.searchParams.toString()
-    const fullUrl = search ? url + '?' + search : url
-    ssrContext.url = fullUrl
+    const routeUrl = search ? url + '?' + search : url
+    ssrContext.url = routeUrl
 
-    event._path = event.node.req.url = fullUrl
+    event._path = event.node.req.url = routeUrl
 
     if (import.meta.prerender && await payloadCache!.hasItem(url)) {
       return returnResponse(event, await payloadCache!.getItem(url) as Partial<RenderResponse>)

--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -102,14 +102,12 @@ const handler: ReturnType<typeof defineEventHandler> = defineEventHandler(async 
   if (isRenderingPayload) {
     const parsed = new URL(ssrContext.url, 'http://localhost')
     const url = parsed.pathname.substring(0, parsed.pathname.lastIndexOf('/')) || '/'
-    
+
     // Remove the build hash from query params, keep original route query params
     parsed.searchParams.delete('_b')
     const search = parsed.searchParams.toString()
     const routeUrl = search ? url + '?' + search : url
     ssrContext.url = routeUrl
-
-    event._path = event.node.req.url = routeUrl
 
     if (import.meta.prerender && await payloadCache!.hasItem(url)) {
       return returnResponse(event, await payloadCache!.getItem(url) as Partial<RenderResponse>)
@@ -318,7 +316,7 @@ export default handler
 function _buildPayloadURL (ssrContext: NuxtSSRContext): string {
   const parsed = new URL(ssrContext.url, 'http://localhost')
   const base = joinURL(ssrContext.runtimeConfig.app.cdnURL || ssrContext.runtimeConfig.app.baseURL, parsed.pathname, PAYLOAD_FILENAME)
-
+  // Use a named `_b` param for the build hash so it can be cleanly separated from route query params
   parsed.searchParams.set('_b', ssrContext.runtimeConfig.app.buildId)
   return base + '?' + parsed.searchParams.toString()
 }

--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -100,8 +100,15 @@ const handler: ReturnType<typeof defineEventHandler> = defineEventHandler(async 
 
   const isRenderingPayload = (_PAYLOAD_EXTRACTION || (import.meta.dev && routeOptions.prerender)) && PAYLOAD_URL_RE.test(ssrContext.url)
   if (isRenderingPayload) {
-    const url = ssrContext.url.substring(0, ssrContext.url.lastIndexOf('/')) || '/'
-    ssrContext.url = url
+    const parsed = new URL(ssrContext.url, 'http://localhost')
+    const url = parsed.pathname.substring(0, parsed.pathname.lastIndexOf('/')) || '/'
+
+    parsed.searchParams.delete('_b')
+    const search = parsed.searchParams.toString()
+    const fullUrl = search ? url + '?' + search : url
+    ssrContext.url = fullUrl
+
+    event._path = event.node.req.url = fullUrl
 
     if (import.meta.prerender && await payloadCache!.hasItem(url)) {
       return returnResponse(event, await payloadCache!.getItem(url) as Partial<RenderResponse>)
@@ -112,7 +119,7 @@ const handler: ReturnType<typeof defineEventHandler> = defineEventHandler(async 
     ssrContext.noSSR = true
   }
 
-  const payloadURL = _PAYLOAD_EXTRACTION ? joinURL(ssrContext.runtimeConfig.app.cdnURL || ssrContext.runtimeConfig.app.baseURL, ssrContext.url.replace(/\?.*$/, ''), PAYLOAD_FILENAME) + '?' + ssrContext.runtimeConfig.app.buildId : undefined
+  const payloadURL = _PAYLOAD_EXTRACTION ? _buildPayloadURL(ssrContext) : undefined
 
   // Render app
   const renderer = await getRenderer(ssrContext)
@@ -306,6 +313,14 @@ const handler: ReturnType<typeof defineEventHandler> = defineEventHandler(async 
 })
 
 export default handler
+
+function _buildPayloadURL (ssrContext: NuxtSSRContext): string {
+  const parsed = new URL(ssrContext.url, 'http://localhost')
+  const base = joinURL(ssrContext.runtimeConfig.app.cdnURL || ssrContext.runtimeConfig.app.baseURL, parsed.pathname, PAYLOAD_FILENAME)
+
+  parsed.searchParams.set('_b', ssrContext.runtimeConfig.app.buildId)
+  return base + '?' + parsed.searchParams.toString()
+}
 
 function normalizeChunks (chunks: (string | undefined)[]) {
   const result: string[] = []

--- a/packages/nuxt/src/app/composables/payload.ts
+++ b/packages/nuxt/src/app/composables/payload.ts
@@ -75,7 +75,11 @@ async function _getPayloadURL (url: string, opts: LoadPayloadOptions = {}) {
   const hash = opts.hash || (opts.fresh || import.meta.dev ? Date.now() : config.app.buildId)
   const cdnURL = config.app.cdnURL
   const baseOrCdnURL = cdnURL && await isPrerendered(url) ? cdnURL : config.app.baseURL
-  return joinURL(baseOrCdnURL, u.pathname, filename + (hash ? `?${hash}` : ''))
+  const base = joinURL(baseOrCdnURL, u.pathname, filename)
+
+  if (hash) { u.searchParams.set('_b', String(hash)) }
+  const search = u.searchParams.toString()
+  return base + (search ? `?${search}` : '')
 }
 
 async function _importPayload (payloadURL: string) {
@@ -118,6 +122,10 @@ async function _isPrerenderedInManifest (url: string) {
  * @internal
  */
 export async function shouldLoadPayload (url = useRoute().path) {
+  if (hasProtocol(url, { acceptRelative: false })) {
+    return false
+  }
+
   const rules = getRouteRules({ path: url })
   if (rules.ssr === false) {
     return false

--- a/packages/nuxt/src/app/composables/payload.ts
+++ b/packages/nuxt/src/app/composables/payload.ts
@@ -122,6 +122,7 @@ async function _isPrerenderedInManifest (url: string) {
  * @internal
  */
 export async function shouldLoadPayload (url = useRoute().path) {
+  // Skip payload loading for absolute URLs (e.g. cross-origin links)
   if (hasProtocol(url, { acceptRelative: false })) {
     return false
   }


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #34496

### 📚 Description

When using `routeRules` with `cache` or `isr`/`swr`, payload extraction breaks for routes that depend on query parameters. For example, `/items?id=1` and `/items?id=2` both resolve to the same `_payload.json`, causing hydration mismatches because the client gets the wrong data.

It looks like this was introduced in #33467 which extended payload extraction to ISR/SWR cached routes, but the URL construction never accounted for query params.

Someone in the issue mentioned `payloadExtraction: 'client'` as a partial fix, but I can confirm it still doesn't work in 3.21.3. The server-side payload URL still strips query params regardless of that setting.

#### What I changed

The root cause is that the build hash was a bare unnamed query parameter (`?abc123`), making it impossible to tell apart from actual route query params. I introduced a named `_b` parameter instead, so the payload URL becomes `/items/_payload.json?id=1&_b=abc123` rather than `/items/_payload.json?abc123`.

**renderer.ts**: Uses `_b` named param for the build hash. The `isRenderingPayload` handler now parses the URL properly with `URLSearchParams.delete('_b')` to reconstruct the original page URL with query params intact. Extracted a `_buildPayloadURL` helper to keep it clean.

**payload.ts**: Same `_b` approach on the client side for `_getPayloadURL`. Also added an early return in `shouldLoadPayload` for absolute URLs. The `payload: true` route rule from #33467 was causing it to try preloading payloads for full URLs like `https://example.com/page` from `<NuxtLink>` elements, which always failed.

#### Open question
I chose `_b` as the named parameter for the build hash since it's short and unlikely to collide with real query params, but I'm open to a different name or approach if the team has concerns about changing the payload URL format.

