### PR TITLE
test: add scroll behavior tests for fixed page key with scrollToTop

### DIFF
--- a/docs/4.api/3.utils/define-page-meta.md
+++ b/docs/4.api/3.utils/define-page-meta.md
@@ -151,7 +151,7 @@ interface PageMeta {
 
   - **Type**: `boolean | (to: RouteLocationNormalized, from: RouteLocationNormalized) => boolean`
 
-    Tell Nuxt to scroll to the top before rendering the page or not. Navigation is independent from rendering, so scroll behavior is always triggered even when the page doesn't re-render (e.g. when using a fixed [`key`](#key)). Set `scrollToTop: false` to disable scrolling in such cases. If you want to overwrite the default scroll behavior of Nuxt, you can do so in `~/router.options.ts` (see [custom routing](/docs/4.x/guide/recipes/custom-routing#using-routeroptions)) for more info.
+    Tell Nuxt to scroll to the top before rendering the page or not. Navigation is independent from rendering, so scroll behavior is always triggered even when the page doesn't re-render (e.g. when using a fixed `key`). Set `scrollToTop: false` to disable scrolling in such cases. If you want to overwrite the default scroll behavior of Nuxt, you can do so in `~/router.options.ts` (see [custom routing](/docs/4.x/guide/recipes/custom-routing#using-routeroptions)) for more info.
 
   **`[key: string]`**
 

--- a/docs/4.api/3.utils/define-page-meta.md
+++ b/docs/4.api/3.utils/define-page-meta.md
@@ -151,7 +151,7 @@ interface PageMeta {
 
   - **Type**: `boolean | (to: RouteLocationNormalized, from: RouteLocationNormalized) => boolean`
 
-    Tell Nuxt to scroll to the top before rendering the page or not. Navigation is independent from rendering, so scroll behavior is always triggered even when the page doesn't re-render (e.g. when using a fixed `key`). Set `scrollToTop: false` to disable scrolling in such cases. If you want to overwrite the default scroll behavior of Nuxt, you can do so in `~/router.options.ts` (see [custom routing](/docs/4.x/guide/recipes/custom-routing#using-routeroptions)) for more info.
+    Tell Nuxt to scroll to the top before rendering the page or not. Navigation is independent from rendering, so scroll behavior is always triggered even when the page doesn't re-render (e.g. when using a fixed [`key`](/docs/4.x/api/utils/define-page-meta#key)). Set `scrollToTop: false` to disable scrolling in such cases. If you want to overwrite the default scroll behavior of Nuxt, you can do so in `~/router.options.ts` (see [custom routing](/docs/4.x/guide/recipes/custom-routing#using-routeroptions)) for more info.
 
   **`[key: string]`**
 

--- a/docs/4.api/3.utils/define-page-meta.md
+++ b/docs/4.api/3.utils/define-page-meta.md
@@ -151,7 +151,7 @@ interface PageMeta {
 
   - **Type**: `boolean | (to: RouteLocationNormalized, from: RouteLocationNormalized) => boolean`
 
-    Tell Nuxt to scroll to the top before rendering the page or not. If you want to overwrite the default scroll behavior of Nuxt, you can do so in `~/router.options.ts` (see [custom routing](/docs/4.x/guide/recipes/custom-routing#using-routeroptions)) for more info.
+    Tell Nuxt to scroll to the top before rendering the page or not. Navigation is independent from rendering, so scroll behavior is always triggered even when the page doesn't re-render (e.g. when using a fixed [`key`](#key)). Set `scrollToTop: false` to disable scrolling in such cases. If you want to overwrite the default scroll behavior of Nuxt, you can do so in `~/router.options.ts` (see [custom routing](/docs/4.x/guide/recipes/custom-routing#using-routeroptions)) for more info.
 
   **`[key: string]`**
 

--- a/packages/nuxt/src/pages/runtime/router.options.ts
+++ b/packages/nuxt/src/pages/runtime/router.options.ts
@@ -9,7 +9,7 @@ type ScrollPosition = Awaited<ReturnType<RouterScrollBehavior>>
 
 // Default router options
 // https://router.vuejs.org/api/interfaces/routeroptions
-export default <RouterConfig> {
+export default <RouterConfig>{
   scrollBehavior (to, from, savedPosition) {
     const nuxtApp = useNuxtApp()
     // @ts-expect-error untyped, nuxt-injected option
@@ -75,14 +75,12 @@ function _calculatePosition (
     return savedPosition
   }
 
-  const isPageNavigation = isChangingPage(to, from)
-
   // Scroll to the element specified in the URL hash, if present
   if (to.hash) {
     return {
       el: to.hash,
       top: _getHashElementScrollMarginTop(to.hash),
-      behavior: isPageNavigation ? defaultHashScrollBehaviour : 'instant',
+      behavior: isChangingPage(to, from) ? defaultHashScrollBehaviour : 'instant',
     }
   }
 

--- a/test/nuxt/router.options.test.ts
+++ b/test/nuxt/router.options.test.ts
@@ -60,7 +60,7 @@ describe('scrollBehavior of router options with global transition', () => {
     await navigateTo('/')
     await flushPromises()
     vi.clearAllMocks()
-    scrollTo = vi.spyOn(globalThis, 'scrollTo').mockImplementation(() => {})
+    scrollTo = vi.spyOn(globalThis, 'scrollTo').mockImplementation(() => { })
   })
 
   afterAll(() => {
@@ -222,7 +222,7 @@ describe('scrollBehavior with cross-layout transitions (#34196)', () => {
     await navigateTo('/')
     await flushPromises()
     vi.clearAllMocks()
-    scrollTo = vi.spyOn(globalThis, 'scrollTo').mockImplementation(() => {})
+    scrollTo = vi.spyOn(globalThis, 'scrollTo').mockImplementation(() => { })
   })
 
   afterAll(() => {
@@ -299,9 +299,9 @@ describe('scrollBehavior with scrollToTop and fixed page key', () => {
     await flushPromises()
   })
 
-  beforeEach(async () => {
+  beforeEach(() => {
     vi.clearAllMocks()
-    scrollTo = vi.spyOn(globalThis, 'scrollTo').mockImplementation(() => {})
+    scrollTo = vi.spyOn(globalThis, 'scrollTo').mockImplementation(() => { })
   })
 
   afterAll(() => {

--- a/test/nuxt/router.options.test.ts
+++ b/test/nuxt/router.options.test.ts
@@ -261,6 +261,84 @@ describe('scrollBehavior with cross-layout transitions (#34196)', () => {
   })
 })
 
+describe('scrollBehavior with scrollToTop and fixed page key', () => {
+  let router: ReturnType<typeof useRouter>
+  let nuxtApp: ReturnType<typeof useNuxtApp>
+
+  let wrapper: VueWrapper<unknown>
+  let scrollTo: ReturnType<typeof vi.spyOn>
+  const cleanups: Array<() => void> = []
+
+  const pageLoadingEnd = vi.fn()
+
+  const FixedKeyPage = defineComponent({ setup: () => () => h('div', 'Fixed key page') })
+
+  beforeAll(async () => {
+    router = useRouter()
+    nuxtApp = useNuxtApp()
+
+    cleanups.push(router.addRoute({
+      name: 'fixed-key-scroll-top',
+      path: '/fixed-key-scroll-top/:id',
+      meta: { key: 'fixed-key-scroll-top', scrollToTop: true },
+      component: FixedKeyPage,
+    }))
+
+    cleanups.push(router.addRoute({
+      name: 'fixed-key-no-scroll-top',
+      path: '/fixed-key-no-scroll-top/:id',
+      meta: { key: 'fixed-key-no-scroll-top', scrollToTop: false },
+      component: FixedKeyPage,
+    }))
+
+    cleanups.push(nuxtApp.hook('page:loading:end', pageLoadingEnd))
+
+    wrapper = await mountSuspended(defineComponent({
+      setup: () => () => h(NuxtPage),
+    }))
+    await flushPromises()
+  })
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    scrollTo = vi.spyOn(globalThis, 'scrollTo').mockImplementation(() => {})
+  })
+
+  afterAll(() => {
+    wrapper.unmount()
+    for (const cleanup of cleanups) {
+      cleanup()
+    }
+  })
+
+  it.each(['push', 'replace'] as const)('should not scroll to top on router.%s when page key is unchanged and scrollToTop is false', async (method) => {
+    await navigateTo('/fixed-key-no-scroll-top/1')
+    await flushPromises()
+    await expect.poll(() => pageLoadingEnd.mock.calls.length).toBeGreaterThan(0)
+    vi.clearAllMocks()
+
+    await router[method]('/fixed-key-no-scroll-top/2')
+    await flushPromises()
+    await expect.poll(() => pageLoadingEnd.mock.calls.length).toBeGreaterThan(0)
+
+    expect(scrollTo).not.toHaveBeenCalled()
+  })
+
+  // https://github.com/nuxt/nuxt/issues/31654
+  it.each(['push', 'replace'] as const)('should scroll to top on router.%s when page key is unchanged but scrollToTop is true', async (method) => {
+    await navigateTo('/fixed-key-scroll-top/1')
+    await flushPromises()
+    await expect.poll(() => pageLoadingEnd.mock.calls.length).toBeGreaterThan(0)
+    vi.clearAllMocks()
+
+    await router[method]('/fixed-key-scroll-top/2')
+    await flushPromises()
+    await expect.poll(() => pageLoadingEnd.mock.calls.length).toBeGreaterThan(0)
+
+    expect(scrollTo).toHaveBeenCalledWith({ left: 0, top: 0 })
+  })
+})
+
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
 
 const NestedPageParent = defineComponent({


### PR DESCRIPTION
## Summary
- Add tests covering scroll behavior when navigating (`push`/`replace`) between routes with a fixed page key (`definePageMeta({ key })`) combined with `scrollToTop` meta option
- Tests verify `scrollToTop: true` scrolls to top and `scrollToTop: false` preserves scroll position

Closes https://github.com/nuxt/nuxt/issues/31654

## Test plan
- [x] `pnpm exec vitest run test/nuxt/router.options.test.ts` — all 20 tests pass