### PR TITLE
fix(vite): do not process css files with decorator transform

### DIFF
--- a/packages/vite/src/plugins/decorators.ts
+++ b/packages/vite/src/plugins/decorators.ts
@@ -33,7 +33,7 @@ export function DecoratorsPlugin (nuxt: Nuxt): Plugin {
 
         id: {
           // Restrict transform to JavaScript/TypeScript and Vue files only
-          include: [/\.(ts|js|tsx|jsx)$/],
+          include: [/\.(ts|js|tsx|jsx|vue)$/],
 
           // Explicitly exclude non-JS assets and Vue sub-blocks
           // (e.g. <style> or <template> in SFCs)
@@ -43,6 +43,7 @@ export function DecoratorsPlugin (nuxt: Nuxt): Plugin {
             /\.sass$/,
             /\.less$/,
             /\.styl$/,
+            /\.vue\?.*\btype=(?:style|template)\b/,
           ],
         },
       },

--- a/packages/vite/src/plugins/decorators.ts
+++ b/packages/vite/src/plugins/decorators.ts
@@ -27,11 +27,22 @@ export function DecoratorsPlugin (nuxt: Nuxt): Plugin {
     },
     transform: {
       filter: {
-        // Only run on files containing @ (a prerequisite for decorator syntax)
+        // Only run on files that may contain decorator syntax
+        // (JS/TS/Vue files) and that include "@" as a quick check
         code: '@',
-        // Exclude Vue style and template blocks
+      
         id: {
+          // Restrict transform to JavaScript/TypeScript and Vue files only
+          include: [/\.(ts|js|tsx|jsx|vue)$/],
+      
+          // Explicitly exclude non-JS assets and Vue sub-blocks
+          // (e.g. <style> or <template> in SFCs)
           exclude: [
+            /\.css$/,
+            /\.scss$/,
+            /\.sass$/,
+            /\.less$/,
+            /\.styl$/,
             /\.vue\?.*\btype=(?:style|template)\b/,
           ],
         },

--- a/packages/vite/src/plugins/decorators.ts
+++ b/packages/vite/src/plugins/decorators.ts
@@ -30,11 +30,11 @@ export function DecoratorsPlugin (nuxt: Nuxt): Plugin {
         // Only run on files that may contain decorator syntax
         // (JS/TS/Vue files) and that include "@" as a quick check
         code: '@',
-      
+
         id: {
           // Restrict transform to JavaScript/TypeScript and Vue files only
-          include: [/\.(ts|js|tsx|jsx|vue)$/],
-      
+          include: [/\.(ts|js|tsx|jsx)$/],
+
           // Explicitly exclude non-JS assets and Vue sub-blocks
           // (e.g. <style> or <template> in SFCs)
           exclude: [
@@ -43,7 +43,6 @@ export function DecoratorsPlugin (nuxt: Nuxt): Plugin {
             /\.sass$/,
             /\.less$/,
             /\.styl$/,
-            /\.vue\?.*\btype=(?:style|template)\b/,
           ],
         },
       },

--- a/packages/vite/test/decorators.test.ts
+++ b/packages/vite/test/decorators.test.ts
@@ -31,12 +31,13 @@ function matchesFilter (
 describe('DecoratorsPlugin transform filter', () => {
   const nuxt = {
     options: {
-      experimental: { decorators: true },
+      experimental: { decorators: true } as Nuxt['options']['experimental'],
       rootDir: '/tmp',
       modulesDir: [],
     },
   }
 
+  // @ts-expect-error - we only need nuxt.options.experimental.decorators, rootDir, and modulesDir for this test
   const plugin = DecoratorsPlugin(nuxt as Nuxt)
 
   if (typeof plugin.transform !== 'object' || !plugin.transform?.filter) {

--- a/packages/vite/test/decorators.test.ts
+++ b/packages/vite/test/decorators.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import type { Nuxt } from '@nuxt/schema'
+import { DecoratorsPlugin } from '../src/plugins/decorators'
+
+function matchesFilter (
+  filter: {
+    code?: string
+    id?: {
+      include?: RegExp[]
+      exclude?: RegExp[]
+    }
+  },
+  code: string,
+  id: string,
+) {
+  if (filter.code && !code.includes(filter.code)) {
+    return false
+  }
+
+  if (filter.id?.include?.length && !filter.id.include.some(re => re.test(id))) {
+    return false
+  }
+
+  if (filter.id?.exclude?.some(re => re.test(id))) {
+    return false
+  }
+
+  return true
+}
+
+describe('DecoratorsPlugin transform filter', () => {
+  const nuxt = {
+    options: {
+      experimental: { decorators: true },
+      rootDir: '/tmp',
+      modulesDir: [],
+    },
+  }
+
+  const plugin = DecoratorsPlugin(nuxt as Nuxt)
+
+  if (typeof plugin.transform !== 'object' || !plugin.transform?.filter) {
+    throw new Error('Expected object-based transform with filter')
+  }
+
+  const filter = plugin.transform.filter as {
+    code?: string
+    id?: {
+      include?: RegExp[]
+      exclude?: RegExp[]
+    }
+  }
+
+  it('matches TypeScript files containing decorator syntax', () => {
+    expect(matchesFilter(filter, '@sealed class A {}', '/src/example.ts')).toBe(true)
+  })
+
+  it('does not match CSS files', () => {
+    expect(matchesFilter(filter, '@import "./base.css";', '/src/styles.css')).toBe(false)
+    expect(matchesFilter(filter, '@import "./base.scss";', '/src/styles.scss')).toBe(false)
+  })
+})


### PR DESCRIPTION
The decorators plugin was previously applying the Babel transform to any file containing '@', including CSS and other non-JS assets. This caused errors with Tailwind directives like @layer and @import.

This commit restricts the transform to JS/TS/Vue files only, excluding CSS, Sass, Less, Stylus, and Vue style/template blocks.

### 🔗 Linked issue

#34768 

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

Previously, enabling `experimental.decorators` in Nuxt applied
the decorators transform to all files containing '@', including CSS files.
This caused parsing errors with Tailwind directives like @layer/@import.

This PR updates the plugin filter to:
- Include only JS/JSX/TS/TSX