### PR TITLE
fix(nuxt): correct type inference for useAsyncData with transform + getCachedData

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -71,7 +71,7 @@ export interface AsyncDataOptions<
    * An `undefined` return value will trigger a fetch.
    * Default is `key => nuxt.isHydrating ? nuxt.payload.data[key] : nuxt.static.data[key]` which only caches data when payloadExtraction is enabled.
    */
-  getCachedData?: (key: string, nuxtApp: NuxtApp, context: { cause: AsyncDataRefreshCause }) => NoInfer<DataT> | undefined
+  getCachedData?: (key: string, nuxtApp: NuxtApp, context: { cause: AsyncDataRefreshCause }) => NoInfer<DataT | undefined>
   /**
    * A function that can be used to alter handler function result after resolving.
    * Do not use it along with the `pick` option.


### PR DESCRIPTION
Fixes incorrect type inference in `useAsyncData` when both `transform` and `getCachedData` are used together. Previously, the handler return type was constrained to match `getCachedData`'s return type, which is wrong: the handler should return raw data, then `transform` produces the cached/displayed type.

The fix wraps `undefined` inside the `NoInfer` for `getCachedData`'s return type so that the union with `undefined` does not bleed back into the handler inference.

Repro from #29567 now type-checks correctly without needing explicit type annotations on `transform`.

Fixes #29567