### PR TITLE
docs: add hints for Nuxt/Vite internals

### DIFF
--- a/docs/3.guide/1.concepts/7.esm.md
+++ b/docs/3.guide/1.concepts/7.esm.md
@@ -132,6 +132,10 @@ export default defineNuxtConfig({
 
 You may find that you _also_ need to add other packages that are being imported by these libraries.
 
+::read-more{to="/docs/guide/recipes/build-tooling#transpiling-dependencies-with-buildtranspile"}
+Learn more about `build.transpile` and how it relates to Vite's `optimizeDeps`.
+::
+
 ### Aliasing Libraries
 
 In some cases, you may also need to manually alias the library to the CJS version, for example:

--- a/docs/3.guide/5.recipes/2.vite-plugin.md
+++ b/docs/3.guide/5.recipes/2.vite-plugin.md
@@ -108,3 +108,7 @@ If you're writing code that needs to access resolved Vite configuration, you sho
 ::read-more{to="/docs/4.x/api/kit/builder#addviteplugin"}
 Read more about `addVitePlugin` in the Nuxt Kit documentation.
 ::
+
+::read-more{to="/docs/guide/recipes/build-tooling"}
+Learn about dependency pre-bundling, transpilation, and other Vite internals in Nuxt.
+::

--- a/docs/3.guide/5.recipes/5.build-tooling.md
+++ b/docs/3.guide/5.recipes/5.build-tooling.md
@@ -89,7 +89,7 @@ export default defineNuxtConfig({
 ```
 
 ::important
-When a dependency is added to `build.transpile`, Nuxt also automatically excludes it from Vite's `optimizeDeps` pre-bundling. This is because transpiled dependencies are processed by the bundler directly and don't need to be pre-bundled.
+When a dependency is added to `build.transpile` as a string, Nuxt also automatically excludes it from Vite's `optimizeDeps` pre-bundling. RegExp entries in `build.transpile` are not propagated to `optimizeDeps.exclude`. This is because string-resolved transpiled dependencies are processed by the bundler directly and don't need to be pre-bundled.
 ::
 
 ### `build.transpile` vs. `vite.optimizeDeps`
@@ -99,7 +99,7 @@ These two options solve different problems:
 | Feature | `build.transpile` | `vite.optimizeDeps.include` |
 |---|---|---|
 | **Purpose** | Transpile source code through the build pipeline | Pre-bundle dependencies for faster dev startup |
-| **When to use** | Library has ESM/CJS issues, or needs build transforms | Dev server reloads when discovering new deps |
+| **When to use** | Library has ESM/CJS issues, or needs to use build transforms | Dev server reloads when discovering new deps |
 | **Applies in production** | Yes | No (dev only) |
 | **Handles CJS-to-ESM conversion** | Yes (via bundler) | Yes (via esbuild) |
 

--- a/docs/3.guide/5.recipes/5.build-tooling.md
+++ b/docs/3.guide/5.recipes/5.build-tooling.md
@@ -1,0 +1,259 @@
+---
+navigation.title: 'Build Tooling'
+title: Working with Nuxt and Vite Internals
+description: Learn how to handle dependency optimization, transpilation, virtual modules, and auto-import transforms in Nuxt.
+---
+
+Nuxt manages a lot of build complexity under the hood through its integration with Vite (or webpack). When adding external dependencies, Vite plugins, or writing modules, you may need to understand how these internals work together.
+
+This guide covers the most common scenarios where you need to interact with the build pipeline directly.
+
+## Dependency Pre-Bundling with `vite.optimizeDeps`
+
+Vite [pre-bundles dependencies](https://vite.dev/guide/dep-pre-bundling.html) during development to convert CommonJS/UMD modules to ESM and to reduce the number of HTTP requests. Nuxt configures sensible defaults, but sometimes you need to step in.
+
+### When to Use `include`
+
+If Vite discovers new dependencies at runtime, it triggers a full page reload. This can be disruptive during development. To avoid it, you can pre-bundle known dependencies:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  vite: {
+    optimizeDeps: {
+      include: [
+        'some-cjs-library',
+        'another-library > nested-dep',
+      ],
+    },
+  },
+})
+```
+
+::tip
+Nuxt will log a helpful hint in the terminal when it detects new dependencies at runtime, including a ready-to-copy `optimizeDeps.include` snippet. Keep an eye on the dev server output.
+::
+
+The `>` syntax lets you pre-bundle a nested dependency that is imported by another package. This is useful when a deeply nested CJS dependency causes reload loops.
+
+### When to Use `exclude`
+
+Use `exclude` to prevent a dependency from being pre-bundled. This is typically needed when a dependency is already a valid ESM module and pre-bundling would break it (for example, due to special import semantics):
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  vite: {
+    optimizeDeps: {
+      exclude: [
+        'my-esm-only-package',
+      ],
+    },
+  },
+})
+```
+
+::note
+`vue-demi` is excluded from pre-bundling by default in Nuxt.
+::
+
+## Transpiling Dependencies with `build.transpile`
+
+The [`build.transpile`](/docs/api/nuxt-config#transpile) option tells Nuxt to transpile specific dependencies with the bundler's pipeline. This is needed when a package ships code that isn't compatible with the current environment.
+
+### Common Use Cases
+
+- A library ships `.esm.js` files that Node.js cannot parse natively (see the [ESM guide](/docs/guide/concepts/esm#transpiling-libraries))
+- A library uses modern syntax that needs to be compiled for broader compatibility
+- You want Nuxt's auto-imports or build transforms to apply inside a third-party package
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  build: {
+    transpile: [
+      'my-library',
+      /shared-utils/,
+    ],
+  },
+})
+```
+
+You can pass strings, regular expressions, or functions:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  build: {
+    transpile: [
+      ({ isDev }) => !isDev && 'my-prod-only-dep',
+    ],
+  },
+})
+```
+
+::important
+When a dependency is added to `build.transpile`, Nuxt also automatically excludes it from Vite's `optimizeDeps` pre-bundling. This is because transpiled dependencies are processed by the bundler directly and don't need to be pre-bundled.
+::
+
+### `build.transpile` vs. `vite.optimizeDeps`
+
+These two options solve different problems:
+
+| Feature | `build.transpile` | `vite.optimizeDeps.include` |
+|---|---|---|
+| **Purpose** | Transpile source code through the build pipeline | Pre-bundle dependencies for faster dev startup |
+| **When to use** | Library has ESM/CJS issues, or needs build transforms | Dev server reloads when discovering new deps |
+| **Applies in production** | Yes | No (dev only) |
+| **Handles CJS-to-ESM conversion** | Yes (via bundler) | Yes (via esbuild) |
+
+In most cases, if a library causes issues in both dev and production, `build.transpile` is the right choice. If the issue is only dev-time reload loops, `vite.optimizeDeps.include` is sufficient.
+
+## Aliases and Virtual Modules
+
+Nuxt uses aliases to map import paths to specific files or directories. This is how imports like `#app`, `#imports`, and `~` work internally.
+
+### Adding Custom Aliases
+
+You can define your own aliases in `nuxt.config.ts`:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  alias: {
+    '#my-utils': '../shared/utils',
+  },
+})
+```
+
+These aliases are resolved at build time and work across both client and server builds.
+
+### Virtual Modules in Nuxt Modules
+
+If you're authoring a module, you can register virtual files using `addTemplate`. These files exist only in memory and can be imported via the `#build` prefix:
+
+```ts [modules/my-module.ts]
+import { addTemplate, defineNuxtModule } from '@nuxt/kit'
+
+export default defineNuxtModule({
+  setup() {
+    addTemplate({
+      filename: 'my-config.mjs',
+      getContents: () => 'export const config = { enabled: true }',
+    })
+  },
+})
+```
+
+The file can then be imported as `#build/my-config.mjs` in the application.
+
+For server-only virtual modules, use `addServerTemplate` instead -- these are added to Nitro's virtual filesystem:
+
+```ts [modules/my-module.ts]
+import { addServerTemplate, defineNuxtModule } from '@nuxt/kit'
+
+export default defineNuxtModule({
+  setup() {
+    addServerTemplate({
+      filename: 'my-server-config.mjs',
+      getContents: () => 'export const secret = process.env.MY_SECRET',
+    })
+  },
+})
+```
+
+::read-more{to="/docs/guide/modules/recipes-advanced#add-virtual-files"}
+Read more about virtual files in module recipes.
+::
+
+## Auto-Import Transforms
+
+Nuxt's auto-import system works by transforming your source files at build time. The transform plugin scans `.vue`, `.js`, `.ts`, and other supported files for usage of auto-imported functions, then injects the corresponding `import` statements.
+
+### How Transform Inclusion Works
+
+By default, the auto-import transform:
+- **Processes** all Vue and JavaScript/TypeScript files in your project
+- **Skips** files inside `node_modules` (except for `#imports` references)
+- Can be extended or restricted using `imports.transform.include` and `imports.transform.exclude`
+
+### Extending Transforms to External Packages
+
+If a third-party library or local package needs access to Nuxt's auto-imports (like `useRuntimeConfig` or `useState`), you need to explicitly include it in the transform:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  imports: {
+    transform: {
+      include: [/my-local-package/],
+    },
+  },
+})
+```
+
+This is especially relevant for monorepo setups where shared packages need to use Nuxt composables.
+
+::warning
+Including a package in `imports.transform.include` only injects import statements -- it doesn't make the composables available at runtime. The package must still be in a context where Nuxt's runtime is loaded (e.g., it must be part of the app bundle, not a standalone script).
+::
+
+### Excluding Files from Transforms
+
+If the auto-import transform interferes with certain files (for example, files that define their own variables with the same names as Nuxt composables), you can exclude them:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  imports: {
+    transform: {
+      exclude: [/special-file\.ts/],
+    },
+  },
+})
+```
+
+## Adding Nitro Event Handlers from Modules
+
+If you're writing a Nuxt module that needs to add server API routes or middleware, use the `addServerHandler` utility from `@nuxt/kit`:
+
+```ts [modules/my-module.ts]
+import { addServerHandler, createResolver, defineNuxtModule } from '@nuxt/kit'
+
+export default defineNuxtModule({
+  setup() {
+    const resolver = createResolver(import.meta.url)
+
+    addServerHandler({
+      route: '/api/_my-module/health',
+      handler: resolver.resolve('./runtime/server/api/health.get'),
+    })
+  },
+})
+```
+
+The handler file uses Nitro's event handler format:
+
+```ts [modules/my-module/runtime/server/api/health.get.ts]
+export default defineEventHandler(() => {
+  return { status: 'ok' }
+})
+```
+
+::tip
+Prefix your module's routes (e.g., `/api/_my-module/`) to avoid conflicts with user-defined routes.
+::
+
+For server middleware that runs on every request:
+
+```ts [modules/my-module.ts]
+import { addServerHandler, createResolver, defineNuxtModule } from '@nuxt/kit'
+
+export default defineNuxtModule({
+  setup() {
+    const resolver = createResolver(import.meta.url)
+
+    addServerHandler({
+      middleware: true,
+      handler: resolver.resolve('./runtime/server/middleware/logger'),
+    })
+  },
+})
+```
+
+::read-more{to="/docs/guide/modules/recipes-basics#add-server-routes"}
+Read more about adding server routes from modules.
+::

--- a/docs/3.guide/5.recipes/5.build-tooling.md
+++ b/docs/3.guide/5.recipes/5.build-tooling.md
@@ -131,7 +131,7 @@ If you're authoring a module, you can register virtual files using `addTemplate`
 import { addTemplate, defineNuxtModule } from '@nuxt/kit'
 
 export default defineNuxtModule({
-  setup() {
+  setup () {
     addTemplate({
       filename: 'my-config.mjs',
       getContents: () => 'export const config = { enabled: true }',
@@ -148,7 +148,7 @@ For server-only virtual modules, use `addServerTemplate` instead -- these are ad
 import { addServerTemplate, defineNuxtModule } from '@nuxt/kit'
 
 export default defineNuxtModule({
-  setup() {
+  setup () {
     addServerTemplate({
       filename: 'my-server-config.mjs',
       getContents: () => 'export const secret = process.env.MY_SECRET',
@@ -214,7 +214,7 @@ If you're writing a Nuxt module that needs to add server API routes or middlewar
 import { addServerHandler, createResolver, defineNuxtModule } from '@nuxt/kit'
 
 export default defineNuxtModule({
-  setup() {
+  setup () {
     const resolver = createResolver(import.meta.url)
 
     addServerHandler({
@@ -243,7 +243,7 @@ For server middleware that runs on every request:
 import { addServerHandler, createResolver, defineNuxtModule } from '@nuxt/kit'
 
 export default defineNuxtModule({
-  setup() {
+  setup () {
     const resolver = createResolver(import.meta.url)
 
     addServerHandler({


### PR DESCRIPTION
Closes #29103

Adds a new recipe page (`docs/3.guide/5.recipes/5.build-tooling.md`) covering the Nuxt/Vite internals that developers commonly need when adding external dependencies or authoring modules:

- **Dependency pre-bundling** (`vite.optimizeDeps`) — when to use `include`/`exclude`, nested dep syntax, and how Nuxt logs hints for missing deps
- **Transpilation** (`build.transpile`) — common use cases, string/regex/function patterns, and a comparison table vs `optimizeDeps`
- **Aliases and virtual modules** — custom aliases, `addTemplate`, and `addServerTemplate` for module authors
- **Auto-import transforms** — how `imports.transform.include`/`exclude` work, with monorepo examples
- **Nitro event handlers from modules** — `addServerHandler` for API routes and middleware

Also adds cross-references from the existing ESM guide and Vite plugin recipe to the new page.

Let me know if anything needs tweaking!