### PR TITLE
chore: add .github/settings.yml and restructure labels

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,214 @@
+# https://github.com/apps/settings
+# https://github.com/repository-settings/app
+# NOTE: Color values are quoted to avoid YAML misinterpreting hex as numbers
+
+repository:
+  name: nuxt
+  description: The Full-Stack Vue Framework.
+  homepage: https://nuxt.com
+  topics: "static-site-generator, node, framework, vue, universal, ssr, nuxt, full-stack, server-rendering, csr, hybrid, hacktoberfest, ssg"
+
+labels:
+  - name: ⚠️ breaking change
+    color: "d746a6"
+
+  - name: ⛔️ can be closed
+    color: "484893"
+
+  - name: ✨ good reproduction
+    color: "fbca04"
+
+  - name: 🍰 p2-nice-to-have
+    color: "0e8a16"
+
+  - name: 🔥 p5-urgent
+    color: "b60205"
+
+  - name: 🔨 p3-minor
+    color: "fbca04"
+
+  - name: 🧷 edge release
+    color: "bfdadc"
+    description: This PR will be released via the edge channel.
+
+  - name: 🧹 p1-chore
+    color: "fef2c0"
+
+  - name: ❌ won't do
+    color: "705b27"
+
+  - name: ❗ p4-important
+    color: "d93f0b"
+
+  - name: 2.x
+    color: "d4c5f9"
+
+  - name: 3.x
+    color: "29bc7f"
+
+  - name: 4.x
+    color: "3b01a5"
+
+  - name: 5.x
+    color: "006b75"
+
+  - name: a11y
+    color: "872ba1"
+
+  - name: agentscan:automated-account
+    color: "ededed"
+
+  - name: agentscan:mixed-signals
+    color: "ededed"
+
+  - name: app
+    color: "17512d"
+
+  - name: available soon
+    color: "6de8b0"
+
+  - name: bug
+    color: "d73a4a"
+
+  - name: bun
+    color: "312773"
+
+  - name: chore
+    color: "d0f1a9"
+
+  - name: cli
+    color: "09f665"
+
+  - name: closed-by-bot
+    color: "ededed"
+
+  - name: components
+    color: "05b979"
+
+  - name: dependencies
+    color: "0366d6"
+    description: Pull requests that update a dependency file
+
+  - name: discussion
+    color: "538de2"
+
+  - name: documentation
+    color: "5319e7"
+
+  - name: dx
+    color: "c39d69"
+
+  - name: enhancement
+    color: "8def37"
+
+  - name: example
+    color: "fbca04"
+
+  - name: experiment
+    color: "8cd9cd"
+
+  - name: external
+    color: "861ade"
+
+  - name: good first issue
+    color: "fbca04"
+
+  - name: hacktoberfest-accepted
+    color: "c9f53d"
+
+  - name: inline styles
+    color: "68af97"
+
+  - name: javascript
+    color: "168700"
+    description: Pull requests that update javascript code
+
+  - name: jsx
+    color: "6d36c6"
+
+  - name: kit
+    color: "60e14c"
+
+  - name: layers
+    color: "006b75"
+
+  - name: needs details
+    color: "493824"
+
+  - name: needs reproduction
+    color: "fbca04"
+
+  - name: nitro
+    color: "bfd4f2"
+
+  - name: pages
+    color: "00dfb5"
+
+  - name: pending triage
+    color: "e99695"
+
+  - name: performance
+    color: "e84b77"
+
+  - name: possible bot
+    color: "342f98"
+
+  - name: possible regression
+    color: "b90a42"
+
+  - name: postcss
+    color: "c7650e"
+
+  - name: question
+    color: "cc317c"
+
+  - name: refactor
+    color: "173a12"
+
+  - name: rolldown-vite
+    color: "aaaaaa"
+
+  - name: rspack
+    color: "aaaaaa"
+
+  - name: schema
+    color: "1d76db"
+
+  - name: server components
+    color: "839413"
+
+  - name: spam
+    color: "aaaaaa"
+
+  - name: stale
+    color: "ffffff"
+
+  - name: suspense
+    color: "c70109"
+
+  - name: test
+    color: "1db6e0"
+
+  - name: types
+    color: "2875c3"
+
+  - name: ui-templates
+    color: "bfd4f2"
+
+  - name: upstream
+    color: "e8a36d"
+
+  - name: upstream-bug
+    color: "b60205"
+
+  - name: vite
+    color: "3574d1"
+
+  - name: webpack
+    color: "650c6f"
+
+  - name: windows
+    color: "c681fd"
+
+  - name: workaround available
+    color: "11376d"

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,6 +1,8 @@
 # https://github.com/apps/settings
 # https://github.com/repository-settings/app
 # NOTE: Color values are quoted to avoid YAML misinterpreting hex as numbers
+# NOTE: After pushing for the first time replace name with new_name value and remove
+# the new_name property
 
 repository:
   name: nuxt
@@ -9,206 +11,248 @@ repository:
   topics: "static-site-generator, node, framework, vue, universal, ssr, nuxt, full-stack, server-rendering, csr, hybrid, hacktoberfest, ssg"
 
 labels:
-  - name: ⚠️ breaking change
-    color: "d746a6"
-
-  - name: ⛔️ can be closed
-    color: "484893"
-
-  - name: ✨ good reproduction
-    color: "fbca04"
+  # Priority
+  - name: 🧹 p1-chore
+    color: "#fef2c0"
+    description: Low priority maintenance task
 
   - name: 🍰 p2-nice-to-have
-    color: "0e8a16"
-
-  - name: 🔥 p5-urgent
-    color: "b60205"
+    color: "#0e8a16"
+    description: Nice to have, not blocking
 
   - name: 🔨 p3-minor
-    color: "fbca04"
-
-  - name: 🧷 edge release
-    color: "bfdadc"
-    description: This PR will be released via the edge channel.
-
-  - name: 🧹 p1-chore
-    color: "fef2c0"
-
-  - name: ❌ won't do
-    color: "705b27"
+    color: "#fbca04"
+    description: Minor issue, should be fixed
 
   - name: ❗ p4-important
-    color: "d93f0b"
+    color: "#d93f0b"
+    description: Important issue, should be addressed soon
 
-  - name: 2.x
-    color: "d4c5f9"
+  - name: 🔥 p5-urgent
+    color: "#b60205"
+    description: Urgent issue, needs immediate attention
 
-  - name: 3.x
-    color: "29bc7f"
-
-  - name: 4.x
-    color: "3b01a5"
-
-  - name: 5.x
-    color: "006b75"
-
-  - name: a11y
-    color: "872ba1"
-
-  - name: agentscan:automated-account
-    color: "ededed"
-
-  - name: agentscan:mixed-signals
-    color: "ededed"
-
-  - name: app
-    color: "17512d"
-
-  - name: available soon
-    color: "6de8b0"
-
+  # Type
   - name: bug
-    color: "d73a4a"
-
-  - name: bun
-    color: "312773"
-
-  - name: chore
-    color: "d0f1a9"
-
-  - name: cli
-    color: "09f665"
-
-  - name: closed-by-bot
-    color: "ededed"
-
-  - name: components
-    color: "05b979"
-
-  - name: dependencies
-    color: "0366d6"
-    description: Pull requests that update a dependency file
-
-  - name: discussion
-    color: "538de2"
-
-  - name: documentation
-    color: "5319e7"
-
-  - name: dx
-    color: "c39d69"
+    color: "#d73a4a"
+    description: Something isn't working as expected
 
   - name: enhancement
-    color: "8def37"
+    color: "#8def37"
+    description: New feature or improvement to existing functionality
 
-  - name: example
-    color: "fbca04"
-
-  - name: experiment
-    color: "8cd9cd"
-
-  - name: external
-    color: "861ade"
-
-  - name: good first issue
-    color: "fbca04"
-
-  - name: hacktoberfest-accepted
-    color: "c9f53d"
-
-  - name: inline styles
-    color: "68af97"
-
-  - name: javascript
-    color: "168700"
-    description: Pull requests that update javascript code
-
-  - name: jsx
-    color: "6d36c6"
-
-  - name: kit
-    color: "60e14c"
-
-  - name: layers
-    color: "006b75"
-
-  - name: needs details
-    color: "493824"
-
-  - name: needs reproduction
-    color: "fbca04"
-
-  - name: nitro
-    color: "bfd4f2"
-
-  - name: pages
-    color: "00dfb5"
-
-  - name: pending triage
-    color: "e99695"
+  - name: documentation
+    color: "#5319e7"
+    description: Documentation improvements or additions
 
   - name: performance
-    color: "e84b77"
+    color: "#e84b77"
+    description: Performance degradation or optimization opportunity
 
-  - name: possible bot
-    color: "342f98"
-
-  - name: possible regression
-    color: "b90a42"
-
-  - name: postcss
-    color: "c7650e"
-
-  - name: question
-    color: "cc317c"
+  - name: dx
+    color: "#c39d69"
+    description: Developer experience improvement
 
   - name: refactor
-    color: "173a12"
-
-  - name: rolldown-vite
-    color: "aaaaaa"
-
-  - name: rspack
-    color: "aaaaaa"
-
-  - name: schema
-    color: "1d76db"
-
-  - name: server components
-    color: "839413"
-
-  - name: spam
-    color: "aaaaaa"
-
-  - name: stale
-    color: "ffffff"
-
-  - name: suspense
-    color: "c70109"
+    color: "#173a12"
+    description: Code restructuring without behavior change
 
   - name: test
-    color: "1db6e0"
+    color: "#1db6e0"
+    description: Test additions or improvements
 
-  - name: types
-    color: "2875c3"
+  # Status / Triage
+  - name: ⚠️ breaking change
+    color: "#d746a6"
+    description: Introduces a breaking change in behavior or API
 
-  - name: ui-templates
-    color: "bfd4f2"
+  - name: ✨ good reproduction
+    color: "#fbca04"
+    description: Issue includes a clear, minimal reproduction
 
-  - name: upstream
-    color: "e8a36d"
+  - name: 🧷 edge release
+    color: "#bfdadc"
+    description: This PR will be released via the edge channel
 
-  - name: upstream-bug
-    color: "b60205"
+  - name: ❌ won't do
+    color: "#705b27"
+    description: Intentionally not planned or out of scope
 
-  - name: vite
-    color: "3574d1"
+  - name: needs details
+    color: "#493824"
+    description: Issue lacks sufficient information to investigate
 
-  - name: webpack
-    color: "650c6f"
+  - name: needs reproduction
+    color: "#fbca04"
+    description: Requires a minimal reproduction to investigate
 
-  - name: windows
-    color: "c681fd"
+  - name: pending triage
+    color: "#e99695"
+    description: Awaiting initial review and categorization
+
+  - name: possible regression
+    color: "#b90a42"
+    description: May have been caused by a recent change
 
   - name: workaround available
-    color: "11376d"
+    color: "#11376d"
+    description: A temporary workaround exists for this issue
+
+  - name: external
+    color: "#861ade"
+    description: Issue originates outside the Nuxt codebase
+
+  - name: good first issue
+    color: "#fbca04"
+    description: Approachable for newcomers to the project
+
+  - name: hacktoberfest-accepted
+    color: "#c9f53d"
+    description: Accepted contribution for Hacktoberfest
+
+  # Scope (Nuxt-specific feature areas)
+  - name: cli
+    new_name: scope:cli
+    color: "#09f665"
+    description: Nuxt CLI (nuxi)
+
+  - name: components
+    new_name: scope:components
+    color: "#05b979"
+    description: Component auto-imports and resolution
+
+  - name: kit
+    new_name: scope:kit
+    color: "#60e14c"
+    description: Nuxt Kit module utilities
+
+  - name: layers
+    new_name: scope:layers
+    color: "#006b75"
+    description: Nuxt layers and extends
+
+  - name: nitro
+    new_name: scope:nitro
+    color: "#bfd4f2"
+    description: Nitro server engine integration
+
+  - name: pages
+    new_name: scope:pages
+    color: "#00dfb5"
+    description: File-based routing and pages directory
+
+  - name: schema
+    new_name: scope:schema
+    color: "#1d76db"
+    description: Nuxt config schema and validation
+
+  - name: server components
+    new_name: scope:server-components
+    color: "#839413"
+    description: Server-only components (.server.vue)
+
+  - name: suspense
+    new_name: scope:suspense
+    color: "#c70109"
+    description: Suspense and async data loading
+
+  # Bundler
+  - name: vite
+    new_name: bundler:vite
+    color: "#3574d1"
+    description: Vite bundler integration
+
+  - name: webpack
+    new_name: bundler:webpack
+    color: "#650c6f"
+    description: Webpack bundler integration
+
+  - name: rspack
+    new_name: bundler:rspack
+    color: "#aaaaaa"
+    description: Rspack bundler integration
+
+  - name: rolldown-vite
+    new_name: bundler:rolldown-vite
+    color: "#aaaaaa"
+    description: Rolldown-powered Vite integration
+
+  - name: postcss
+    color: "#c7650e"
+    description: PostCSS processing and plugins
+
+  # Platform / Runtime
+  - name: windows
+    new_name: platform:windows
+    color: "#c681fd"
+    description: Windows-specific issue
+
+  - name: bun
+    new_name: platform:bun
+    color: "#312773"
+    description: Bun runtime compatibility
+
+  # Cross-cutting
+  - name: a11y
+    color: "#872ba1"
+    description: Accessibility
+
+  - name: inline styles
+    color: "#68af97"
+    description: Inline styles and CSS handling
+
+  - name: jsx
+    color: "#6d36c6"
+    description: JSX/TSX support
+
+  - name: types
+    color: "#2875c3"
+    description: TypeScript types and type inference
+
+  - name: ui-templates
+    color: "#bfd4f2"
+    description: Starter templates and scaffolding
+
+  # Upstream
+  - name: upstream-bug
+    new_name: upstream
+    color: "#b60205"
+    description: Issue caused by a dependency or upstream project
+
+  # Version
+  - name: 2.x
+    color: "#d4c5f9"
+    description: Nuxt 2 specific
+
+  - name: 3.x
+    color: "#29bc7f"
+    description: Nuxt 3 specific
+
+  - name: 4.x
+    color: "#3b01a5"
+    description: Nuxt 4 specific
+
+  - name: 5.x
+    color: "#006b75"
+    description: Nuxt 5 specific
+
+  # Automation
+  - name: agentscan:automated-account
+    color: "#ededed"
+    description: Flagged as an automated account by agentscan
+
+  - name: agentscan:mixed-signals
+    color: "#ededed"
+    description: Flagged as suspicious by agentscan
+
+  - name: closed-by-bot
+    color: "#ededed"
+    description: Automatically closed by a bot
+
+  - name: spam
+    color: "#aaaaaa"
+    description: Spam or off-topic content
+
+  - name: dependencies
+    color: "#0366d6"
+    description: Pull requests that update a dependency file

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,4 @@
 * @danielroe
+
+# Repo settings can escalate to admin — restrict reviewers
+.github/settings.yml @danielroe @posva @antfu @atinux


### PR DESCRIPTION
## Changes

- Add `.github/settings.yml` to manage repo settings as code
- Add `CODEOWNERS` entry for `.github/settings.yml`
- **Labels** (67 → 55):
  - Removed 12: `question`, `javascript`, `possible bot`, `chore`, `discussion`, `app`, `upstream` (merged), `⛔️ can be closed`, `available soon`, `stale`, `example`, `experiment`
  - Renamed 16 with prefixes: `scope:*` (9), `bundler:*` (4), `platform:*` (2), `upstream-bug` → `upstream`
  - Added descriptions to all labels
- **Repo settings**: codifies current config (squash-only merges, auto-delete branches, etc.)

## Security Note

Anyone with push access can modify `.github/settings.yml` to escalate themselves to admin. To prevent this:

1. Enable **branch protection** on `main` with "Require review from Code Owners" (Settings > Rules > Rulesets, or Settings > Branches > Branch protection rules)
2. The `CODEOWNERS` entry restricts `.github/settings.yml` reviews to `@danielroe @posva @antfu @atinux`

Without branch protection + code owner reviews enabled, the CODEOWNERS rule is advisory only.

## Test plan

- [ ] Verify labels match current repo state (minus intentional removals)
- [x] Confirm `new_name` renames work correctly on a test repo (tested in npm-posva and pinia-plugin-debounce)
- [ ] After merge: update `new_name` entries to use the new name directly
- [ ] Enable branch protection with "Require review from Code Owners" (must be done by admin and the real question is do we want that?)