### PR TITLE
feat(pages): warn when pages:extend adds duplicate routes

### DIFF
--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -147,6 +147,7 @@ export async function augmentAndResolve (pages: NuxtPage[], trackedFiles: Set<st
     augmentedPages?.clear()
   }
 
+    warnAboutDuplicatePageRoutes(pages)
   await nuxt.callHook('pages:resolved', pages)
 
   return pages


### PR DESCRIPTION
Closes #24174

## Summary

Adds a warning when `pages:extend` hook registers a route that resolves to the same path as an existing route.

## Changes

- Added `warnAboutDuplicatePageRoutes()` helper in `packages/nuxt/src/pages/utils.ts`
- Called after all `pages:extend` hooks run, before `pages:resolved`
- Logs a warning with the duplicate path and suggests using `pages.splice` to remove the duplicate