### PR TITLE
docs: work around upstream bun bug

### DIFF
--- a/docs/1.getting-started/02.installation.md
+++ b/docs/1.getting-started/02.installation.md
@@ -50,7 +50,7 @@ pnpm create nuxt@latest <project-name> -t v3
 ```
 
 ```bash [bun]
-bun create nuxt@latest <project-name> -t v3
+bunx nuxi@latest init <project-name> -t v3
 ```
 
 ```bash [deno]

--- a/docs/1.getting-started/02.installation.md
+++ b/docs/1.getting-started/02.installation.md
@@ -50,7 +50,9 @@ pnpm create nuxt@latest <project-name> -t v3
 ```
 
 ```bash [bun]
-bunx nuxi@latest init <project-name> -t v3
+# you can use this when https://github.com/oven-sh/bun/issues/29087 is resolved
+# bun create nuxt@latest <project-name> -t v3
+bunx create-nuxt@latest init <project-name> -t v3
 ```
 
 ```bash [deno]


### PR DESCRIPTION
Fixes #32854

`bun create` intercepts the `-t` flag before passing it to the create script, resulting in an `Invalid Argument '-t'` error. Replacing it with `bunx nuxi@latest init` bypasses this issue while keeping the same `-t v3` flag, making it consistent with the other package managers.