### PR TITLE
docs: add accessible routing guide

### DIFF
--- a/docs/3.guide/2.best-practices/accessibility.md
+++ b/docs/3.guide/2.best-practices/accessibility.md
@@ -34,11 +34,11 @@ For updates that are not route changes (validation, toasts, loading copy), use [
 
 ## Links and `<NuxtLink>`
 
-Use [`<NuxtLink>`](/docs/4.x/api/components/nuxt-link) or [`<RouterLink>`](https://router.vuejs.org/guide/) for in-app navigation so the DOM keeps a normal `<a href="...">` and tab order.
+Use [`<NuxtLink>`](/docs/4.x/api/components/nuxt-link) or [`<RouterLink>`](https://router.vuejs.org/guide/) for in-app navigation, so the DOM keeps a normal `<a href="...">` and tab order.
 
 Avoid using `@click` on a `div` (or similar) plus `navigateTo` as a stand-in for a link unless you add `role`, keyboard handling, and focus styles yourself. [`<NuxtLink>`](/docs/4.x/api/components/nuxt-link) already does the right thing.
 
-For external URLs, `<NuxtLink>` applies `rel` and `target` where appropriate. Use [`external`](/docs/4.x/api/components/nuxt-link#handling-static-file-and-cross-app-links) for files under `/public` or another app on the same origin so the browser handles navigation outside Vue Router.
+For external URLs, `<NuxtLink>` applies `rel` and `target` where appropriate. Use [`external`](/docs/4.x/api/components/nuxt-link#handling-static-file-and-cross-app-links) for files under `/public` or another app on the same origin, so the browser handles navigation outside Vue Router.
 
 ### Active item
 

--- a/docs/3.guide/2.best-practices/accessibility.md
+++ b/docs/3.guide/2.best-practices/accessibility.md
@@ -58,7 +58,7 @@ After a few navigations, tab from the skip link through the nav into `<main>` an
 
 ## Scroll
 
-[`scrollBehaviorType`](/docs/4.x/guide/recipes/custom-routing#router-options) and [`router.options.ts`](/docs/4.x/guide/recipes/custom-routing#router-options) configure scroll on navigation (for example smooth scrolling to a hash).
+[`scrollBehaviorType`](/docs/4.x/guide/recipes/custom-routing#scroll-behavior-for-hash-links) and [`router.options.ts`](/docs/4.x/guide/recipes/custom-routing#router-options) configure scroll on navigation (for example smooth scrolling to a hash).
 
 ::read-more{to="/docs/4.x/guide/recipes/custom-routing"}
 ::

--- a/docs/3.guide/2.best-practices/accessibility.md
+++ b/docs/3.guide/2.best-practices/accessibility.md
@@ -25,7 +25,7 @@ The route announcer in the next section reacts when that title updates (through 
 
 1. Add [`<NuxtRouteAnnouncer>`](/docs/4.x/api/components/nuxt-route-announcer) in `app.vue` or the root layout (Nuxt v3.12+).
 2. Keep the document title aligned with the active route.
-3. Use [`useRouteAnnouncer`](/docs/4.x/api/composables/use-route-announcer) when you need a custom announcement or `polite` / `assertive` urgency.
+3. Use [`useRouteAnnouncer`](/docs/4.x/api/composables/use-route-announcer) when you need a custom announcement or to control `politeness` (`polite`, `assertive`, or `off`).
 
 For updates that are not route changes (validation, toasts, loading copy), use [`<NuxtAnnouncer>`](/docs/4.x/api/components/nuxt-announcer) with [`useAnnouncer`](/docs/4.x/api/composables/use-announcer).
 

--- a/docs/3.guide/2.best-practices/accessibility.md
+++ b/docs/3.guide/2.best-practices/accessibility.md
@@ -1,0 +1,68 @@
+---
+navigation.title: Accessibility
+title: Accessible routing and navigation
+description: Patterns for navigation, route announcements, links, and focus in Nuxt apps.
+---
+
+In SPAs, changing the route does not reload the document, so keyboard and screen reader users depend on clear titles, landmarks, and real links. This guide covers **navigation in Nuxt**. Broader WCAG topics (color, forms, and similar) sit outside this page; use the references below as a starting point.
+
+## Further reading
+
+- [Web Accessibility Initiative (WAI)](https://www.w3.org/WAI/)
+- [MDN: Accessibility](https://developer.mozilla.org/en-US/docs/Web/Accessibility)
+- [Understanding WCAG 2](https://www.w3.org/WAI/WCAG21/Understanding/)
+
+## Page titles
+
+Set a **document title** that changes when the view changes.
+
+- Use [`useHead`](/docs/4.x/api/composables/use-head) and, where it helps, [`titleTemplate`](/docs/4.x/getting-started/seo-meta#dynamic-title) in [`app.vue`](/docs/4.x/directory-structure/app/app).
+- Store per-route data in [`definePageMeta`](/docs/4.x/directory-structure/app/pages#page-metadata) (for example `title`) and read it from [`useRoute`](/docs/4.x/api/composables/use-route) in a layout to build the final `<title>`.
+
+The route announcer in the next section reacts when that title updates (through Unhead). If the title string does not change between navigations, users may not hear that the page changed.
+
+## Route announcements
+
+1. Add [`<NuxtRouteAnnouncer>`](/docs/4.x/api/components/nuxt-route-announcer) in `app.vue` or the root layout (Nuxt v3.12+).
+2. Keep the document title aligned with the active route.
+3. Use [`useRouteAnnouncer`](/docs/4.x/api/composables/use-route-announcer) when you need a custom announcement or `polite` / `assertive` urgency.
+
+For updates that are not route changes (validation, toasts, loading copy), use [`<NuxtAnnouncer>`](/docs/4.x/api/components/nuxt-announcer) with [`useAnnouncer`](/docs/4.x/api/composables/use-announcer).
+
+::read-more{to="/docs/4.x/api/components/nuxt-route-announcer"}
+::
+
+## Links and `<NuxtLink>`
+
+Use [`<NuxtLink>`](/docs/4.x/api/components/nuxt-link) or [`<RouterLink>`](https://router.vuejs.org/guide/) for in-app navigation so the DOM keeps a normal `<a href="...">` and tab order.
+
+Avoid using `@click` on a `div` (or similar) plus `navigateTo` as a stand-in for a link unless you add `role`, keyboard handling, and focus styles yourself. [`<NuxtLink>`](/docs/4.x/api/components/nuxt-link) already does the right thing.
+
+For external URLs, `<NuxtLink>` applies `rel` and `target` where appropriate. Use [`external`](/docs/4.x/api/components/nuxt-link#handling-static-file-and-cross-app-links) for files under `/public` or another app on the same origin so the browser handles navigation outside Vue Router.
+
+### Active item
+
+Vue Router’s [`ariaCurrentValue`](https://router.vuejs.org/api/interfaces/routerlinkprops#ariaCurrentValue-) is supported on internal [`<NuxtLink>`](/docs/4.x/api/components/nuxt-link#routerlink). Set it when the active row in nav or breadcrumbs should expose `aria-current`.
+
+## Focus
+
+After client navigation, focus typically remains on the element that triggered the change. That is expected for Vue Router; Nuxt does not move focus for you.
+
+- Wrap primary content in a single [`<main>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main) with a stable `id`.
+- Put a skip link at the top of [`app.vue`](/docs/4.x/directory-structure/app/app) (first tab stop) that sends focus into `#main`.
+- Optional: in a [client plugin](/docs/4.x/directory-structure/app/plugins), register `router.afterEach` and call `focus()` on the main region when that fits your UX. Non-tabbable elements need `tabindex="-1"` for programmatic focus; do not break the tab order for sequential keyboard users.
+
+::tip
+After a few navigations, tab from the skip link through the nav into `<main>` and confirm focus behaves as you expect.
+::
+
+## Scroll
+
+[`scrollBehaviorType`](/docs/4.x/guide/recipes/custom-routing#router-options) and [`router.options.ts`](/docs/4.x/guide/recipes/custom-routing#router-options) configure scroll on navigation (for example smooth scrolling to a hash).
+
+::read-more{to="/docs/4.x/guide/recipes/custom-routing"}
+::
+
+## `nuxt/a11y` module
+
+The [`nuxt/a11y`](https://github.com/nuxt/a11y) module adds more helpers on top of core APIs. Nuxt already includes [`<NuxtRouteAnnouncer>`](/docs/4.x/api/components/nuxt-route-announcer) and related composables, so the module is optional.

--- a/docs/3.guide/2.best-practices/accessibility.md
+++ b/docs/3.guide/2.best-practices/accessibility.md
@@ -10,7 +10,7 @@ In SPAs, changing the route does not reload the document, so keyboard and screen
 
 - [Web Accessibility Initiative (WAI)](https://www.w3.org/WAI/)
 - [MDN: Accessibility](https://developer.mozilla.org/en-US/docs/Web/Accessibility)
-- [Understanding WCAG 2](https://www.w3.org/WAI/WCAG21/Understanding/)
+- [Understanding WCAG 2.1](https://www.w3.org/WAI/WCAG21/Understanding/)
 
 ## Page titles
 
@@ -34,7 +34,7 @@ For updates that are not route changes (validation, toasts, loading copy), use [
 
 ## Links and `<NuxtLink>`
 
-Use [`<NuxtLink>`](/docs/4.x/api/components/nuxt-link) or [`<RouterLink>`](https://router.vuejs.org/guide/) for in-app navigation, so the DOM keeps a normal `<a href="...">` and tab order.
+Use [`<NuxtLink>`](/docs/4.x/api/components/nuxt-link) or [`<RouterLink>`](https://router.vuejs.org/guide/) for in-app navigation, so the DOM keeps a normal `<a href="...">` and tab order. For prefetching behavior and related configuration, see the [Links section](/docs/4.x/guide/best-practices/performance#links) of the performance guide.
 
 Avoid using `@click` on a `div` (or similar) plus `navigateTo` as a stand-in for a link unless you add `role`, keyboard handling, and focus styles yourself. [`<NuxtLink>`](/docs/4.x/api/components/nuxt-link) already does the right thing.
 

--- a/docs/3.guide/2.best-practices/accessibility.md
+++ b/docs/3.guide/2.best-practices/accessibility.md
@@ -8,6 +8,10 @@ Most of what makes an app accessible is not specific to Nuxt: color contrast, fo
 
 What Nuxt does change is navigation. Once your app has hydrated, it routes on the client, so the document is never reloaded and the browser no longer announces a new page or resets focus for you. Nuxt ships with features that fill some of that gap, and a few conventions cover the rest. This guide outlines best practices for handling that.
 
+::tip
+[`@nuxt/a11y`](https://github.com/nuxt/a11y) surfaces accessibility problems in your components while you develop, alongside the practices below. It is in alpha, so expect its API to change.
+::
+
 ## Route Announcements
 
 Screen readers announce a full page load by themselves, but they have no way of knowing that a client-side navigation happened. [`<NuxtRouteAnnouncer>`](/docs/4.x/api/components/nuxt-route-announcer) solves this by rendering a hidden live region and writing the new page title into it after every navigation:

--- a/docs/3.guide/2.best-practices/accessibility.md
+++ b/docs/3.guide/2.best-practices/accessibility.md
@@ -1,68 +1,151 @@
 ---
-navigation.title: Accessibility
-title: Accessible routing and navigation
-description: Patterns for navigation, route announcements, links, and focus in Nuxt apps.
+navigation.title: 'Accessibility'
+title: Nuxt accessibility
+description: Best practices for accessibility in Nuxt apps.
 ---
 
-In SPAs, changing the route does not reload the document, so keyboard and screen reader users depend on clear titles, landmarks, and real links. This guide covers **navigation in Nuxt**. Broader WCAG topics (color, forms, and similar) sit outside this page; use the references below as a starting point.
+Most of what makes an app accessible is not specific to Nuxt: color contrast, form semantics, and ARIA work the same here as in any Vue or plain HTML application, and the [resources](#useful-resources) at the end of this guide cover them well.
 
-## Further reading
+What Nuxt does change is navigation. Once your app has hydrated, it routes on the client, so the document is never reloaded and the browser no longer announces a new page or resets focus for you. Nuxt ships with features that fill some of that gap, and a few conventions cover the rest. This guide outlines best practices for handling that.
+
+## Route Announcements
+
+Screen readers announce a full page load by themselves, but they have no way of knowing that a client-side navigation happened. [`<NuxtRouteAnnouncer>`](/docs/4.x/api/components/nuxt-route-announcer) solves this by rendering a hidden live region and writing the new page title into it after every navigation:
+
+```vue [app.vue]
+<template>
+  <NuxtRouteAnnouncer />
+  <NuxtPage />
+</template>
+```
+
+The announcer reads the title that Unhead rendered, so it is only as useful as your titles are. If two routes share the same `<title>`, users hear nothing on the way between them.
+
+When you need to announce something else, or to change how urgently it is announced, use [`useRouteAnnouncer`](/docs/4.x/api/composables/use-route-announcer):
+
+```vue [app/pages/search.vue]
+<script setup lang="ts">
+const { set } = useRouteAnnouncer()
+const { data: results } = await useFetch('/api/search')
+
+watch(results, (results) => {
+  set(`${results?.length ?? 0} results found`)
+})
+</script>
+```
+
+:read-more{title="NuxtRouteAnnouncer" to="/docs/4.x/api/components/nuxt-route-announcer"}
+
+For in-page updates that are not navigations, such as form validation or toasts, use [`<NuxtAnnouncer>`](/docs/4.x/api/components/nuxt-announcer) with [`useAnnouncer`](/docs/4.x/api/composables/use-announcer) instead.
+
+## Page Titles
+
+Because the route announcer follows the document title, giving every route a distinct title is the single most valuable thing you can do. Set a global template in `app.vue` and let each page fill in its own part:
+
+```vue [app.vue]
+<script setup lang="ts">
+useHead({
+  titleTemplate: title => title ? `${title} - Nuxt` : 'Nuxt',
+})
+</script>
+```
+
+```vue [app/pages/about.vue]
+<script setup lang="ts">
+useHead({
+  title: 'About us',
+})
+</script>
+```
+
+If your titles come from route metadata rather than from the page itself, you can read [`definePageMeta`](/docs/4.x/directory-structure/app/pages#page-metadata) values from [`useRoute`](/docs/4.x/api/composables/use-route) in a layout.
+
+:read-more{title="SEO and Meta" to="/docs/4.x/getting-started/seo-meta#dynamic-title"}
+
+## Links
+
+Use [`<NuxtLink>`](/docs/4.x/api/components/nuxt-link) for in-app navigation. It renders a real `<a href="...">`, which means it is focusable, appears in the tab order, and works with middle-click and "open in new tab", all of which you would have to reimplement on a `<div>` with a `@click` handler calling `navigateTo`.
+
+```vue
+<template>
+  <NuxtLink to="/about">About page</NuxtLink>
+</template>
+```
+
+In a menu or a set of breadcrumbs, the link matching the current route already exposes `aria-current="page"`, so assistive technology can tell which item you are on. Where a different token describes the relationship better, such as a step in a multi-page form, set [`ariaCurrentValue`](/docs/4.x/api/components/nuxt-link#routerlink):
+
+```vue
+<template>
+  <NuxtLink
+    to="/checkout/payment"
+    aria-current-value="step"
+  >Payment</NuxtLink>
+</template>
+```
+
+Links to files in your `public/` directory, or to another app on the same origin, are not routes that Vue Router knows about. Mark them as [`external`](/docs/4.x/api/components/nuxt-link#handling-static-file-and-cross-app-links) so the browser performs a real navigation instead of failing to match a route.
+
+:read-more{title="NuxtLink" to="/docs/4.x/api/components/nuxt-link"}
+
+## Focus Management
+
+After a client-side navigation, focus stays where it was, which is usually the link the user just activated. Vue Router does not move it and neither does Nuxt, so a keyboard user can end up tabbing through the whole header again to reach the content that just changed.
+
+A skip link as the first tab stop of your app is the conventional fix, and it helps on the initial page load too:
+
+```vue [app.vue]
+<template>
+  <a
+    class="skip-link"
+    href="#main"
+  >Skip to main content</a>
+  <AppHeader />
+  <main
+    id="main"
+    tabindex="-1"
+  >
+    <NuxtPage />
+  </main>
+</template>
+
+<style>
+.skip-link {
+  position: absolute;
+  left: -9999px;
+}
+.skip-link:focus {
+  position: static;
+}
+</style>
+```
+
+`<main>` is not focusable on its own, so it needs `tabindex="-1"` to accept focus from the skip link or from a script. Use `-1` rather than a positive value, which would move the element in the tab order and surprise everyone else.
+
+If it suits your app, you can go further and move focus to the main region after every navigation from a plugin:
+
+```ts [app/plugins/focus-main.client.ts]
+export default defineNuxtPlugin(() => {
+  useRouter().afterEach((to, from) => {
+    if (to.path === from.path) {
+      return
+    }
+    nextTick(() => document.getElementById('main')?.focus())
+  })
+})
+```
+
+::tip
+Navigate around your app with the keyboard alone. Tabbing from the skip link into `<main>` after a couple of navigations will surface most focus problems quickly.
+::
+
+## Scroll Behavior
+
+Nuxt scrolls to the top on a new route, restores the previous position when the user goes back, and scrolls to hash targets. If you need something different, such as smooth scrolling or a different offset, configure [`scrollBehaviorType`](/docs/4.x/guide/recipes/custom-routing#scroll-behavior-for-hash-links) or write your own `scrollBehavior` in [`router.options.ts`](/docs/4.x/guide/recipes/custom-routing#router-options). Bear in mind that smooth scrolling should respect the user's `prefers-reduced-motion` setting.
+
+:read-more{title="Custom routing" to="/docs/4.x/guide/recipes/custom-routing"}
+
+## Useful Resources
 
 - [Web Accessibility Initiative (WAI)](https://www.w3.org/WAI/)
 - [MDN: Accessibility](https://developer.mozilla.org/en-US/docs/Web/Accessibility)
 - [Understanding WCAG 2.1](https://www.w3.org/WAI/WCAG21/Understanding/)
-
-## Page titles
-
-Set a **document title** that changes when the view changes.
-
-- Use [`useHead`](/docs/4.x/api/composables/use-head) and, where it helps, [`titleTemplate`](/docs/4.x/getting-started/seo-meta#dynamic-title) in [`app.vue`](/docs/4.x/directory-structure/app/app).
-- Store per-route data in [`definePageMeta`](/docs/4.x/directory-structure/app/pages#page-metadata) (for example `title`) and read it from [`useRoute`](/docs/4.x/api/composables/use-route) in a layout to build the final `<title>`.
-
-The route announcer in the next section reacts when that title updates (through Unhead). If the title string does not change between navigations, users may not hear that the page changed.
-
-## Route announcements
-
-1. Add [`<NuxtRouteAnnouncer>`](/docs/4.x/api/components/nuxt-route-announcer) in `app.vue` or the root layout (Nuxt v3.12+).
-2. Keep the document title aligned with the active route.
-3. Use [`useRouteAnnouncer`](/docs/4.x/api/composables/use-route-announcer) when you need a custom announcement or to control `politeness` (`polite`, `assertive`, or `off`).
-
-For updates that are not route changes (validation, toasts, loading copy), use [`<NuxtAnnouncer>`](/docs/4.x/api/components/nuxt-announcer) with [`useAnnouncer`](/docs/4.x/api/composables/use-announcer).
-
-::read-more{to="/docs/4.x/api/components/nuxt-route-announcer"}
-::
-
-## Links and `<NuxtLink>`
-
-Use [`<NuxtLink>`](/docs/4.x/api/components/nuxt-link) or [`<RouterLink>`](https://router.vuejs.org/guide/) for in-app navigation, so the DOM keeps a normal `<a href="...">` and tab order. For prefetching behavior and related configuration, see the [Links section](/docs/4.x/guide/best-practices/performance#links) of the performance guide.
-
-Avoid using `@click` on a `div` (or similar) plus `navigateTo` as a stand-in for a link unless you add `role`, keyboard handling, and focus styles yourself. [`<NuxtLink>`](/docs/4.x/api/components/nuxt-link) already does the right thing.
-
-For external URLs, `<NuxtLink>` applies `rel` and `target` where appropriate. Use [`external`](/docs/4.x/api/components/nuxt-link#handling-static-file-and-cross-app-links) for files under `/public` or another app on the same origin, so the browser handles navigation outside Vue Router.
-
-### Active item
-
-Vue Router’s [`ariaCurrentValue`](https://router.vuejs.org/api/interfaces/routerlinkprops#ariaCurrentValue-) is supported on internal [`<NuxtLink>`](/docs/4.x/api/components/nuxt-link#routerlink). Set it when the active row in nav or breadcrumbs should expose `aria-current`.
-
-## Focus
-
-After client navigation, focus typically remains on the element that triggered the change. That is expected for Vue Router; Nuxt does not move focus for you.
-
-- Wrap primary content in a single [`<main>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main) with a stable `id`.
-- Put a skip link at the top of [`app.vue`](/docs/4.x/directory-structure/app/app) (first tab stop) that sends focus into `#main`.
-- Optional: in a [client plugin](/docs/4.x/directory-structure/app/plugins), register `router.afterEach` and call `focus()` on the main region when that fits your UX. Non-tabbable elements need `tabindex="-1"` for programmatic focus; do not break the tab order for sequential keyboard users.
-
-::tip
-After a few navigations, tab from the skip link through the nav into `<main>` and confirm focus behaves as you expect.
-::
-
-## Scroll
-
-[`scrollBehaviorType`](/docs/4.x/guide/recipes/custom-routing#scroll-behavior-for-hash-links) and [`router.options.ts`](/docs/4.x/guide/recipes/custom-routing#router-options) configure scroll on navigation (for example smooth scrolling to a hash).
-
-::read-more{to="/docs/4.x/guide/recipes/custom-routing"}
-::
-
-## `nuxt/a11y` module
-
-The [`nuxt/a11y`](https://github.com/nuxt/a11y) module adds more helpers on top of core APIs. Nuxt already includes [`<NuxtRouteAnnouncer>`](/docs/4.x/api/components/nuxt-route-announcer) and related composables, so the module is optional.

--- a/docs/4.api/1.components/12.nuxt-route-announcer.md
+++ b/docs/4.api/1.components/12.nuxt-route-announcer.md
@@ -13,6 +13,10 @@ links:
 This component is available in Nuxt v3.12+.
 ::
 
+::read-more{to="/docs/4.x/guide/best-practices/accessibility"}
+Read more about accessible routing, titles, and focus with the route announcer.
+::
+
 ## Usage
 
 Add `<NuxtRouteAnnouncer/>` in your [`app.vue`](/docs/4.x/directory-structure/app/app) or [`app/layouts/`](/docs/4.x/directory-structure/app/layouts) to enhance accessibility by informing assistive technologies about page title changes. This ensures that navigational changes are announced to users relying on screen readers.

--- a/docs/4.api/1.components/12.nuxt-route-announcer.md
+++ b/docs/4.api/1.components/12.nuxt-route-announcer.md
@@ -17,6 +17,10 @@ This component is available in Nuxt v3.12+.
 Read more about accessible routing, titles, and focus with the route announcer.
 ::
 
+::read-more{to="/docs/4.x/guide/best-practices/performance"}
+Read more about built-in performance features for navigation and routing.
+::
+
 ## Usage
 
 Add `<NuxtRouteAnnouncer/>` in your [`app.vue`](/docs/4.x/directory-structure/app/app) or [`app/layouts/`](/docs/4.x/directory-structure/app/layouts) to enhance accessibility by informing assistive technologies about page title changes. This ensures that navigational changes are announced to users relying on screen readers.
@@ -47,7 +51,7 @@ You can pass custom HTML or components through the route announcer's default slo
 ## Props
 
 - `atomic`: Controls if screen readers only announce changes or the entire content. Set to true for full content readouts on updates, false for changes only. (default `false`)
-- `politeness`: Sets the urgency for screen reader announcements: `off` (disable the announcement), `polite` (waits for silence), or `assertive` (interrupts immediately). (default `polite`)
+- `politeness`: Sets how screen readers prioritize announcements (`polite`, `assertive`, or `off`). (default `polite`)
 
 ::callout
 This component is optional. :br

--- a/docs/4.api/1.components/12.nuxt-route-announcer.md
+++ b/docs/4.api/1.components/12.nuxt-route-announcer.md
@@ -13,13 +13,7 @@ links:
 This component is available in Nuxt v3.12+.
 ::
 
-::read-more{to="/docs/4.x/guide/best-practices/accessibility"}
-Read more about accessible routing, titles, and focus with the route announcer.
-::
-
-::read-more{to="/docs/4.x/guide/best-practices/performance"}
-Read more about built-in performance features for navigation and routing.
-::
+:read-more{title="Nuxt accessibility" to="/docs/4.x/guide/best-practices/accessibility#route-announcements"}
 
 ## Usage
 
@@ -51,7 +45,7 @@ You can pass custom HTML or components through the route announcer's default slo
 ## Props
 
 - `atomic`: Controls if screen readers only announce changes or the entire content. Set to true for full content readouts on updates, false for changes only. (default `false`)
-- `politeness`: Sets how screen readers prioritize announcements (`polite`, `assertive`, or `off`). (default `polite`)
+- `politeness`: Sets the urgency for screen reader announcements: `off` (disable the announcement), `polite` (waits for silence), or `assertive` (interrupts immediately). (default `polite`)
 
 ::callout
 This component is optional. :br

--- a/docs/4.api/1.components/4.nuxt-link.md
+++ b/docs/4.api/1.components/4.nuxt-link.md
@@ -12,6 +12,10 @@ links:
 `<NuxtLink>` is a drop-in replacement for both Vue Router's `<RouterLink>` component and HTML's `<a>` tag. It intelligently determines whether the link is _internal_ or _external_ and renders it accordingly with available optimizations (prefetching, default attributes, etc.)
 ::
 
+::read-more{to="/docs/4.x/guide/best-practices/performance#links"}
+Read more about `<NuxtLink>` prefetching and related performance options.
+::
+
 ::read-more{to="/docs/4.x/guide/best-practices/accessibility"}
 Read more about accessible navigation with `<NuxtLink>`.
 ::

--- a/docs/4.api/1.components/4.nuxt-link.md
+++ b/docs/4.api/1.components/4.nuxt-link.md
@@ -12,6 +12,10 @@ links:
 `<NuxtLink>` is a drop-in replacement for both Vue Router's `<RouterLink>` component and HTML's `<a>` tag. It intelligently determines whether the link is _internal_ or _external_ and renders it accordingly with available optimizations (prefetching, default attributes, etc.)
 ::
 
+::read-more{to="/docs/4.x/guide/best-practices/accessibility"}
+Read more about accessible navigation with `<NuxtLink>`.
+::
+
 ## Internal Routing
 
 In this example, we use `<NuxtLink>` component to link to another page of the application.

--- a/docs/4.api/1.components/4.nuxt-link.md
+++ b/docs/4.api/1.components/4.nuxt-link.md
@@ -12,13 +12,7 @@ links:
 `<NuxtLink>` is a drop-in replacement for both Vue Router's `<RouterLink>` component and HTML's `<a>` tag. It intelligently determines whether the link is _internal_ or _external_ and renders it accordingly with available optimizations (prefetching, default attributes, etc.)
 ::
 
-::read-more{to="/docs/4.x/guide/best-practices/performance#links"}
-Read more about `<NuxtLink>` prefetching and related performance options.
-::
-
-::read-more{to="/docs/4.x/guide/best-practices/accessibility"}
-Read more about accessible navigation with `<NuxtLink>`.
-::
+:read-more{title="Nuxt accessibility" to="/docs/4.x/guide/best-practices/accessibility#links"}
 
 ## Internal Routing
 

--- a/docs/4.api/2.composables/use-route-announcer.md
+++ b/docs/4.api/2.composables/use-route-announcer.md
@@ -18,6 +18,10 @@ This composable is available in Nuxt v3.12+.
 A composable which observes the page title changes and updates the announcer message accordingly. Used by [`<NuxtRouteAnnouncer>`](/docs/4.x/api/components/nuxt-route-announcer) and controllable.
 It hooks into Unhead's `dom:rendered` hook to read the page's title and set it as the announcer message.
 
+::read-more{to="/docs/4.x/guide/best-practices/accessibility"}
+Read more about page titles, focus, and route announcements.
+::
+
 ## Parameters
 
 - `politeness`: Sets the urgency for screen reader announcements: `off` (disable the announcement), `polite` (waits for silence), or `assertive` (interrupts immediately).  (default `polite`).

--- a/docs/4.api/2.composables/use-route-announcer.md
+++ b/docs/4.api/2.composables/use-route-announcer.md
@@ -22,9 +22,13 @@ It hooks into Unhead's `dom:rendered` hook to read the page's title and set it a
 Read more about page titles, focus, and route announcements.
 ::
 
+::read-more{to="/docs/4.x/guide/best-practices/performance"}
+Read more about built-in performance features for navigation and routing.
+::
+
 ## Parameters
 
-- `politeness`: Sets the urgency for screen reader announcements: `off` (disable the announcement), `polite` (waits for silence), or `assertive` (interrupts immediately).  (default `polite`).
+- `politeness`: Sets how screen readers prioritize announcements (`polite`, `assertive`, or `off`). (default `polite`).
 
 ## Properties
 
@@ -36,13 +40,13 @@ Read more about page titles, focus, and route announcements.
 ### `politeness`
 
 - **type**: `Ref<string>`
-- **description**: Screen reader announcement urgency level `off`, `polite`, or `assertive`
+- **description**: Screen reader announcement priority (`politeness`): `off`, `polite`, or `assertive`
 
 ## Methods
 
 ### `set(message, politeness = "polite")`
 
-Sets the message to announce with its urgency level.
+Sets the message to announce with the given `politeness` level.
 
 ### `polite(message)`
 

--- a/docs/4.api/2.composables/use-route-announcer.md
+++ b/docs/4.api/2.composables/use-route-announcer.md
@@ -18,17 +18,11 @@ This composable is available in Nuxt v3.12+.
 A composable which observes the page title changes and updates the announcer message accordingly. Used by [`<NuxtRouteAnnouncer>`](/docs/4.x/api/components/nuxt-route-announcer) and controllable.
 It hooks into Unhead's `dom:rendered` hook to read the page's title and set it as the announcer message.
 
-::read-more{to="/docs/4.x/guide/best-practices/accessibility"}
-Read more about page titles, focus, and route announcements.
-::
-
-::read-more{to="/docs/4.x/guide/best-practices/performance"}
-Read more about built-in performance features for navigation and routing.
-::
+:read-more{title="Nuxt accessibility" to="/docs/4.x/guide/best-practices/accessibility#route-announcements"}
 
 ## Parameters
 
-- `politeness`: Sets how screen readers prioritize announcements (`polite`, `assertive`, or `off`). (default `polite`).
+- `politeness`: Sets the urgency for screen reader announcements: `off` (disable the announcement), `polite` (waits for silence), or `assertive` (interrupts immediately).  (default `polite`).
 
 ## Properties
 
@@ -40,13 +34,13 @@ Read more about built-in performance features for navigation and routing.
 ### `politeness`
 
 - **type**: `Ref<string>`
-- **description**: Screen reader announcement priority (`politeness`): `off`, `polite`, or `assertive`
+- **description**: Screen reader announcement urgency level `off`, `polite`, or `assertive`
 
 ## Methods
 
 ### `set(message, politeness = "polite")`
 
-Sets the message to announce with the given `politeness` level.
+Sets the message to announce with its urgency level.
 
 ### `polite(message)`
 


### PR DESCRIPTION
Fixes https://github.com/nuxt/nuxt/issues/23375

Add a Best Practices page on titles, route announcer, NuxtLink, focus, and scroll. 
Link to it from NuxtRouteAnnouncer, NuxtLink, and useRouteAnnouncer.