### PR TITLE
docs(shared): explain why Vue/Nitro imports are restricted

### DIFF
--- a/docs/2.directory-structure/1.shared.md
+++ b/docs/2.directory-structure/1.shared.md
@@ -13,6 +13,10 @@ The `shared/` directory is available in Nuxt v3.14+.
 
 ::important
 Code in the `shared/` directory cannot import any Vue or Nitro code.
+
+This is because the Vue app and Nitro server are built as **separate bundles** with different runtime environments. Vue code depends on the browser DOM and Vue's reactivity system, while Nitro code runs in a server context (Node.js, edge workers, etc.). Importing from one environment into the other would pull in incompatible dependencies, break tree-shaking, and cause runtime errors — for example, Vue composables like `useNuxtApp()` or `ref()` require a Vue runtime context that doesn't exist on the server, and Nitro utilities like `useStorage()` depend on server-only APIs.
+
+Use the `shared/` directory only for pure, environment-agnostic code such as utility functions, type definitions, and constants.
 ::
 
 :video-accordion{title="Watch a video from Vue School on sharing utils and types between app and server" videoId="nnAR-MO3q5M"}


### PR DESCRIPTION
## Summary
- Added a clear explanation for **why** the `shared/` directory cannot import Vue or Nitro code
- The current docs state the restriction but don't explain the reasoning, which can lead users to ignore the warning

The explanation covers:
- Separate build bundles with different runtime targets (browser vs Node.js/edge)
- Incompatible dependencies and broken tree-shaking
- Missing runtime contexts (Vue reactivity system vs server-only APIs)
- Recommendation to use `shared/` only for pure, environment-agnostic code

Closes #30862