### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/docs/4.api/2.composables/use-async-data.md
+++ b/docs/4.api/2.composables/use-async-data.md
@@ -232,24 +232,24 @@ If you have not fetched data on the server (for example, with `server: false`), 
 ```ts [Signature]
 export type AsyncDataHandler<ResT> = (nuxtApp: NuxtApp, options: { signal: AbortSignal }) => Promise<ResT>
 
-export function useAsyncData<DataT, DataE> (
-  handler: AsyncDataHandler<DataT>,
-  options?: AsyncDataOptions<DataT>,
+export function useAsyncData<ResT, DataT = ResT, DataE = Error> (
+  handler: AsyncDataHandler<ResT>,
+  options?: AsyncDataOptions<ResT, DataT>,
 ): AsyncData<DataT, DataE>
-export function useAsyncData<DataT, DataE> (
+export function useAsyncData<ResT, DataT = ResT, DataE = Error> (
   key: MaybeRefOrGetter<string>,
-  handler: AsyncDataHandler<DataT>,
-  options?: AsyncDataOptions<DataT>,
+  handler: AsyncDataHandler<ResT>,
+  options?: AsyncDataOptions<ResT, DataT>,
 ): Promise<AsyncData<DataT, DataE>>
 
-type AsyncDataOptions<DataT> = {
+type AsyncDataOptions<ResT, DataT = ResT> = {
   server?: boolean
   lazy?: boolean
   immediate?: boolean
   deep?: boolean
   dedupe?: 'cancel' | 'defer'
-  default?: () => DataT | Ref<DataT> | null
-  transform?: (input: DataT) => DataT | Promise<DataT>
+  default?: () => DataT | Ref<DataT>
+  transform?: (input: ResT) => DataT | Promise<DataT>
   pick?: string[]
   watch?: MultiWatchSources | false
   getCachedData?: (key: string, nuxtApp: NuxtApp, ctx: AsyncDataRequestContext) => DataT | undefined


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #23114

### 📚 Description

The `AsyncDataOptions` type signature in the `useAsyncData` docs doesn't match the actual source code in `packages/nuxt/src/app/composables/asyncData.ts`.

**What was wrong:**

- `transform` was typed as `(input: DataT) => DataT | Promise<DataT>`, which implies the input and output must be the same type. The actual type is `_Transform<ResT, DataT>`, meaning it takes the raw response type (`ResT`) and returns a (possibly different) data type (`DataT`). This is the whole point of `transform`.
- `AsyncDataOptions` only had a single generic `<DataT>`, but the source uses `<ResT, DataT = ResT, ...>`.
- `default` had an extra `| null` that doesn't exist in the source.

This has caused real confusion in the community (see johannschopplich/nuxt-api-party#49).

**What this PR does:**

- Adds `ResT` generic to `AsyncDataOptions` and `useAsyncData` signatures
- Fixes `transform` type to `(input: ResT) => DataT | Promise<DataT>`
- Removes the extra `| null` from `default`

Advanced generics (`PickKeys`, `DefaultT`) are intentionally omitted to keep the docs readable while remaining accurate.

**Note:** A previous PR (#30349) attempted to fix this by removing the types entirely and linking to GitHub. It was closed because maintainers preferred keeping the types in the docs (see [danielroe's comment](https://github.com/nuxt/nuxt/pull/30349#issuecomment-2571425834)). This PR takes the correct approach by fixing the types in place.