### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/docs/4.api/2.composables/use-async-data.md
+++ b/docs/4.api/2.composables/use-async-data.md
@@ -232,24 +232,24 @@ If you have not fetched data on the server (for example, with `server: false`), 
 ```ts [Signature]
 export type AsyncDataHandler<ResT> = (nuxtApp: NuxtApp, options: { signal: AbortSignal }) => Promise<ResT>
 
-export function useAsyncData<DataT, DataE> (
-  handler: AsyncDataHandler<DataT>,
-  options?: AsyncDataOptions<DataT>,
+export function useAsyncData<ResT, DataT = ResT, DataE = Error> (
+  handler: AsyncDataHandler<ResT>,
+  options?: AsyncDataOptions<ResT, DataT>,
 ): AsyncData<DataT, DataE>
-export function useAsyncData<DataT, DataE> (
+export function useAsyncData<ResT, DataT = ResT, DataE = Error> (
   key: MaybeRefOrGetter<string>,
-  handler: AsyncDataHandler<DataT>,
-  options?: AsyncDataOptions<DataT>,
+  handler: AsyncDataHandler<ResT>,
+  options?: AsyncDataOptions<ResT, DataT>,
 ): Promise<AsyncData<DataT, DataE>>
 
-type AsyncDataOptions<DataT> = {
+type AsyncDataOptions<ResT, DataT = ResT> = {
   server?: boolean
   lazy?: boolean
   immediate?: boolean
   deep?: boolean
   dedupe?: 'cancel' | 'defer'
-  default?: () => DataT | Ref<DataT> | null
-  transform?: (input: DataT) => DataT | Promise<DataT>
+  default?: () => DataT | Ref<DataT>
+  transform?: (input: ResT) => DataT | Promise<DataT>
   pick?: string[]
   watch?: MultiWatchSources | false
   getCachedData?: (key: string, nuxtApp: NuxtApp, ctx: AsyncDataRequestContext) => DataT | undefined

--- a/docs/4.api/2.composables/use-async-data.md
+++ b/docs/4.api/2.composables/use-async-data.md
@@ -232,24 +232,24 @@ If you have not fetched data on the server (for example, with `server: false`), 
 ```ts [Signature]
 export type AsyncDataHandler<ResT> = (nuxtApp: NuxtApp, options: { signal: AbortSignal }) => Promise<ResT>
 
-export function useAsyncData<ResT, DataT = ResT, DataE = Error> (
-  handler: AsyncDataHandler<ResT>,
-  options?: AsyncDataOptions<ResT, DataT>,
+export function useAsyncData<DataT, DataE> (
+  handler: AsyncDataHandler<DataT>,
+  options?: AsyncDataOptions<DataT>,
 ): AsyncData<DataT, DataE>
-export function useAsyncData<ResT, DataT = ResT, DataE = Error> (
+export function useAsyncData<DataT, DataE> (
   key: MaybeRefOrGetter<string>,
-  handler: AsyncDataHandler<ResT>,
-  options?: AsyncDataOptions<ResT, DataT>,
+  handler: AsyncDataHandler<DataT>,
+  options?: AsyncDataOptions<DataT>,
 ): Promise<AsyncData<DataT, DataE>>
 
-type AsyncDataOptions<ResT, DataT = ResT> = {
+type AsyncDataOptions<DataT> = {
   server?: boolean
   lazy?: boolean
   immediate?: boolean
   deep?: boolean
   dedupe?: 'cancel' | 'defer'
-  default?: () => DataT | Ref<DataT>
-  transform?: (input: ResT) => DataT | Promise<DataT>
+  default?: () => DataT | Ref<DataT> | null
+  transform?: (input: DataT) => DataT | Promise<DataT>
   pick?: string[]
   watch?: MultiWatchSources | false
   getCachedData?: (key: string, nuxtApp: NuxtApp, ctx: AsyncDataRequestContext) => DataT | undefined

--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -365,7 +365,7 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
 
   // https://www.totaltypescript.com/tsconfig-cheat-sheet
   const globalTsConfig = nuxt.options.typescript?.tsConfig || {}
-  defu(nuxt.options.typescript?.appTsConfig, globalTsConfig, {
+  const tsConfig: TSConfig = defu(nuxt.options.typescript?.appTsConfig, globalTsConfig, {
     compilerOptions: {
       /* Base options: */
       esModuleInterop: true,

--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -364,7 +364,8 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
   const useDecorators = Boolean(nuxt.options.experimental?.decorators)
 
   // https://www.totaltypescript.com/tsconfig-cheat-sheet
-  const tsConfig: TSConfig = defu(nuxt.options.typescript?.tsConfig, {
+  const globalTsConfig = nuxt.options.typescript?.tsConfig || {}
+  defu(nuxt.options.typescript?.appTsConfig, globalTsConfig, {
     compilerOptions: {
       /* Base options: */
       esModuleInterop: true,
@@ -416,7 +417,7 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
   } satisfies TSConfig)
 
   // This describes the environment where we load `nuxt.config.ts` (and modules)
-  const nodeTsConfig: TSConfig = defu(nuxt.options.typescript?.nodeTsConfig, {
+  const nodeTsConfig: TSConfig = defu(nuxt.options.typescript?.nodeTsConfig, globalTsConfig, {
     compilerOptions: {
       /* Base options: */
       esModuleInterop: tsConfig.compilerOptions?.esModuleInterop,

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -256,7 +256,11 @@ async function initNuxt (nuxt: Nuxt) {
   nuxt.hook('nitro:config', async (nitroConfig) => {
     paths ||= await resolveTypescriptPaths(nuxt)
     nitroConfig.typescript = defu(nitroConfig.typescript, {
-      tsConfig: { compilerOptions: { paths: { ...paths } } },
+      tsConfig: defu(
+        nuxt.options.typescript?.serverTsConfig,
+        nuxt.options.typescript?.tsConfig,
+        { compilerOptions: { paths: { ...paths } } },
+      ),
     })
   })
 

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -8,7 +8,7 @@ import { createDebugger, createHooks } from 'hookable'
 import ignore from 'ignore'
 import type { LoadNuxtOptions } from '@nuxt/kit'
 import { addBuildPlugin, addComponent, addPlugin, addPluginTemplate, addRouteMiddleware, addTypeTemplate, addVitePlugin, ensureDependencyInstalled, getLayerDirectories, installModules, loadNuxtConfig, nuxtCtx, resolveFiles, resolveIgnorePatterns, resolveModuleWithOptions, runWithNuxtContext } from '@nuxt/kit'
-import type { PackageJson } from 'pkg-types'
+import type { PackageJson, TSConfig } from 'pkg-types'
 import { readPackageJSON } from 'pkg-types'
 import { hash } from 'ohash'
 import { consola } from 'consola'
@@ -260,7 +260,7 @@ async function initNuxt (nuxt: Nuxt) {
         nuxt.options.typescript?.serverTsConfig,
         nuxt.options.typescript?.tsConfig,
         { compilerOptions: { paths: { ...paths } } },
-      ),
+      ) as TSConfig,
     })
   })
 

--- a/packages/schema/src/config/typescript.ts
+++ b/packages/schema/src/config/typescript.ts
@@ -36,6 +36,8 @@ export default defineResolvers({
     includeWorkspace: false,
     typeCheck: false,
     tsConfig: {},
+    appTsConfig: {},
+    serverTsConfig: {},
     shim: false,
   },
 })

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1753,7 +1753,8 @@ export interface ConfigSchema {
     typeCheck: boolean | 'build'
 
     /**
-     * You can extend the generated `.nuxt/tsconfig.app.json` (and legacy `.nuxt/tsconfig.json`) using this option.
+     * You can extend all generated tsconfig files using this option.
+     * Use `appTsConfig`, `serverTsConfig`, `nodeTsConfig` or `sharedTsConfig` to customize specific environments.
      */
     tsConfig: 0 extends 1 & RawVueCompilerOptions ? TSConfig : TSConfig & { vueCompilerOptions?: RawVueCompilerOptions }
 
@@ -1766,6 +1767,18 @@ export interface ConfigSchema {
      * You can extend the generated `.nuxt/tsconfig.shared.json` using this option.
      */
     sharedTsConfig: TSConfig
+
+    /**
+     *  You can extend the generated `.nuxt/tsconfig.app.json` using this option.
+     * This takes precedence over options set in `tsConfig` for the app environment.
+     */
+    appTsConfig: TSConfig
+
+    /**
+     * You can extend the generated Nitro server tsconfig using this option.
+     * This takes precedence over options set in `tsConfig` for the server environment.
+     */
+    serverTsConfig: TSConfig
 
     /**
      * Generate a `*.vue` shim.


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #33678

### 📚 Description

Since Nuxt adopted TS Project References, users have to duplicate the same compiler options (e.g. `noUncheckedIndexedAccess`, `verbatimModuleSyntax`) across `tsConfig`, `nodeTsConfig`, and `sharedTsConfig`. This PR makes `typescript.tsConfig` act as a global base that propagates to all environments, and adds `appTsConfig` / `serverTsConfig` for per-environment overrides.

**Changes:**

- `typescript.tsConfig` now applies to all generated tsconfigs (app, node, shared, server) as the global base
- Added `typescript.appTsConfig` for app-specific overrides (`tsconfig.app.json`)
- Added `typescript.serverTsConfig` for Nitro server-specific overrides
- Merge priority: per-environment config > global `tsConfig` > hardcoded defaults

**Files changed:**

- `packages/schema/src/config/typescript.ts` — added default values
- `packages/schema/src/types/schema.ts` — added type definitions and updated JSDoc
- `packages/kit/src/template.ts` — inserted global tsConfig into defu merge chain
- `packages/nuxt/src/core/nuxt.ts` — propagated serverTsConfig to Nitro

**Usage example:**

```ts
export default defineNuxtConfig({

  typescript: {

    // Applies to ALL environments

    tsConfig: {

      compilerOptions: {

        noUncheckedIndexedAccess: true,

      }

    },

    // App-only override

    appTsConfig: {

      compilerOptions: { lib: ['ESNext', 'DOM'] }

    },

    // Server-only override

    serverTsConfig: {

      compilerOptions: { lib: ['ESNext'] }

    },

  }

})