### PR TITLE
fix(vite): ensure leading slash in `/@fs` URLs for Windows

### DIFF
--- a/packages/vite/src/plugins/vite-node.ts
+++ b/packages/vite/src/plugins/vite-node.ts
@@ -95,7 +95,7 @@ function getManifest (nuxt: Nuxt, viteServer: ViteDevServer, clientEntry: string
           from: nuxt.options.modulesDir.map(d => directoryToURL(d)),
         })
         if (!resolved) { continue }
-        css.add('/@fs' + (resolved.startsWith('/') ? resolved : '/' + resolved))
+        css.add('/@fs' + resolved.replace(/^(?!\/)/, '/'))
       } else {
         css.add(resolved)
       }

--- a/packages/vite/src/plugins/vite-node.ts
+++ b/packages/vite/src/plugins/vite-node.ts
@@ -95,7 +95,7 @@ function getManifest (nuxt: Nuxt, viteServer: ViteDevServer, clientEntry: string
           from: nuxt.options.modulesDir.map(d => directoryToURL(d)),
         })
         if (!resolved) { continue }
-        css.add('/@fs' + resolved)
+        css.add('/@fs' + (resolved.startsWith('/') ? resolved : '/' + resolved))
       } else {
         css.add(resolved)
       }


### PR DESCRIPTION
### 🔗 Linked issue

Fixes: #34766 

### 📚 Description

Because of the fix (from me.... 😒) #34303.... 

Instead of generating a valid path in `getManifest` such as:
`/@fs/D:/project/.../style.css`

Nuxt may emit:
`/@fsD:/project/.../style.css`

That malformed URL returns 404 in development. The fix is simple check if path isn't starting with "/", add one slash.
