### PR TITLE
fix(nuxt): correct async data type inference when using `transform` with `getCachedData`

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -46,7 +46,7 @@ export type NoInfer<T> = [T][T extends any ? 0 : never]
 
 export type AsyncDataRefreshCause = 'initial' | 'refresh:hook' | 'refresh:manual' | 'watch'
 
-export interface AsyncDataOptions<
+interface BaseAsyncDataOptions<
   ResT,
   DataT = ResT,
   PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
@@ -66,17 +66,6 @@ export interface AsyncDataOptions<
    * a factory function to set the default value of the data, before the async function resolves - useful with the `lazy: true` or `immediate: false` options
    */
   default?: () => DefaultT | Ref<DefaultT>
-  /**
-   * Provide a function which returns cached data.
-   * An `undefined` return value will trigger a fetch.
-   * Default is `key => nuxt.isHydrating ? nuxt.payload.data[key] : nuxt.static.data[key]` which only caches data when payloadExtraction is enabled.
-   */
-  getCachedData?: (key: string, nuxtApp: NuxtApp, context: { cause: AsyncDataRefreshCause }) => NoInfer<DataT> | undefined
-  /**
-   * A function that can be used to alter handler function result after resolving.
-   * Do not use it along with the `pick` option.
-   */
-  transform?: _Transform<ResT, DataT>
   /**
    * Only pick specified keys in this array from the handler function result.
    * Do not use it along with the `transform` option.
@@ -104,6 +93,44 @@ export interface AsyncDataOptions<
    * A timeout in milliseconds after which the request will be aborted if it has not resolved yet.
    */
   timeout?: number
+}
+
+export interface AsyncDataOptions<
+  ResT,
+  DataT = ResT,
+  PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
+  DefaultT = undefined,
+> extends BaseAsyncDataOptions<ResT, DataT, PickKeys, DefaultT> {
+  /**
+   * Provide a function which returns cached data.
+   * An `undefined` return value will trigger a fetch.
+   * Default is `key => nuxt.isHydrating ? nuxt.payload.data[key] : nuxt.static.data[key]` which only caches data when payloadExtraction is enabled.
+   */
+  getCachedData?: (key: string, nuxtApp: NuxtApp, context: { cause: AsyncDataRefreshCause }) => NoInfer<DataT> | undefined
+  /**
+   * A function that can be used to alter handler function result after resolving.
+   * Do not use it along with the `pick` option.
+   */
+  transform?: _Transform<ResT, DataT>
+}
+
+export interface AsyncDataOptionsWithTransform<
+  ResT,
+  DataT = ResT,
+  PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
+  DefaultT = undefined,
+> extends BaseAsyncDataOptions<ResT, DataT, PickKeys, DefaultT> {
+  /**
+   * Provide a function which returns cached data.
+   * An `undefined` return value will trigger a fetch.
+   * Default is `key => nuxt.isHydrating ? nuxt.payload.data[key] : nuxt.static.data[key]` which only caches data when payloadExtraction is enabled.
+   */
+  getCachedData?: (key: string, nuxtApp: NuxtApp, context: { cause: AsyncDataRefreshCause }) => NoInfer<DataT | undefined>
+  /**
+   * A function that can be used to alter handler function result after resolving.
+   * Do not use it along with the `pick` option.
+   */
+  transform: _Transform<ResT, DataT>
 }
 
 export interface AsyncDataExecuteOptions {
@@ -162,6 +189,26 @@ export const createUseAsyncData = defineKeyedFunctionFactory({
       DefaultT = undefined,
     > (
       handler: AsyncDataHandler<ResT>,
+      opts: AsyncDataOptionsWithTransform<ResT, DataT, PickKeys, DefaultT>,
+    ): AsyncData<PickFrom<DataT, PickKeys> | DefaultT, (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>) | undefined>
+    function useAsyncData<
+      ResT,
+      NuxtErrorDataT = unknown,
+      DataT = ResT,
+      PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
+      DefaultT = DataT,
+    > (
+      handler: AsyncDataHandler<ResT>,
+      opts: AsyncDataOptionsWithTransform<ResT, DataT, PickKeys, DefaultT>,
+    ): AsyncData<PickFrom<DataT, PickKeys> | DefaultT, (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>) | undefined>
+    function useAsyncData<
+      ResT,
+      NuxtErrorDataT = unknown,
+      DataT = ResT,
+      PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
+      DefaultT = undefined,
+    > (
+      handler: AsyncDataHandler<ResT>,
       opts?: AsyncDataOptions<ResT, DataT, PickKeys, DefaultT>,
     ): AsyncData<PickFrom<DataT, PickKeys> | DefaultT, (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>) | undefined>
     function useAsyncData<
@@ -181,6 +228,28 @@ export const createUseAsyncData = defineKeyedFunctionFactory({
      * @param handler An asynchronous function that must return a truthy value (for example, it should not be `undefined` or `null`) or the request may be duplicated on the client side.
      * @param opts customize the behavior of useAsyncData
      */
+    function useAsyncData<
+      ResT,
+      NuxtErrorDataT = unknown,
+      DataT = ResT,
+      PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
+      DefaultT = undefined,
+    > (
+      key: MaybeRefOrGetter<string>,
+      handler: AsyncDataHandler<ResT>,
+      opts: AsyncDataOptionsWithTransform<ResT, DataT, PickKeys, DefaultT>,
+    ): AsyncData<PickFrom<DataT, PickKeys> | DefaultT, (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>) | undefined>
+    function useAsyncData<
+      ResT,
+      NuxtErrorDataT = unknown,
+      DataT = ResT,
+      PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
+      DefaultT = DataT,
+    > (
+      key: MaybeRefOrGetter<string>,
+      handler: AsyncDataHandler<ResT>,
+      opts: AsyncDataOptionsWithTransform<ResT, DataT, PickKeys, DefaultT>,
+    ): AsyncData<PickFrom<DataT, PickKeys> | DefaultT, (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>) | undefined>
     function useAsyncData<
       ResT,
       NuxtErrorDataT = unknown,

--- a/packages/nuxt/src/app/composables/index.ts
+++ b/packages/nuxt/src/app/composables/index.ts
@@ -1,6 +1,6 @@
 export { defineNuxtComponent } from './component'
 export { useAsyncData, useLazyAsyncData, useNuxtData, refreshNuxtData, clearNuxtData } from './asyncData'
-export type { AsyncDataOptions, AsyncData, AsyncDataRequestStatus } from './asyncData'
+export type { AsyncDataOptions, AsyncDataOptionsWithTransform, AsyncData, AsyncDataRequestStatus } from './asyncData'
 export { useHydration } from './hydrate'
 export { callOnce } from './once'
 export { useState, clearNuxtState } from './state'

--- a/test/fixtures/basic-types/app/app-types.ts
+++ b/test/fixtures/basic-types/app/app-types.ts
@@ -622,6 +622,20 @@ describe('composables', () => {
       getCachedData: () => ({ bar: 2 }),
     })
   })
+
+  it('infers transformed data independently from typed cached data', () => {
+    const asyncData = useAsyncData(
+      () => Promise.resolve({
+        foo: 'bar',
+      }),
+      {
+        transform: data => data.foo,
+        getCachedData: () => 'bar',
+      },
+    )
+
+    expectTypeOf(asyncData.data).toEqualTypeOf<Ref<string | DefaultAsyncDataValue>>()
+  })
 })
 
 describe('app config', () => {


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/29567

### 📚 Description

No, I am *not* an another bot attempting to solve this issue... I promise 🤞 