### PR TITLE
fix(vite): preserve server-origin errors and surface them via Youch

### DIFF
--- a/packages/vite/src/vite-node-runner.ts
+++ b/packages/vite/src/vite-node-runner.ts
@@ -47,7 +47,7 @@ function buildViteError (errorData: any, id: string): Error {
   // description by a blank line. Split on that boundary so we can show the
   // clean one-liner as the heading and feed the frame text to `hint` below.
   const rawMessage: string = errorData.message || ''
-  const [headRaw, ...frameTail] = rawMessage.split(/\r?\n\s*\r?\n/)
+  const [headRaw, ...frameTail] = rawMessage.split(/\r?\n\s*\n/)
   const reason = (headRaw || '')
     .split(/\r?\n/)[0]!
     .replace(/^\[@?[\w\-/:]+\]\s*/, '')

--- a/packages/vite/src/vite-node-runner.ts
+++ b/packages/vite/src/vite-node-runner.ts
@@ -48,9 +48,8 @@ function buildViteError (errorData: any, id: string): Error {
   // clean one-liner as the heading and feed the frame text to `hint` below.
   const rawMessage: string = errorData.message || ''
   const [headRaw, ...frameTail] = rawMessage.split(/\r?\n\s*\n/)
-  const reason = (headRaw || '')
-    .split(/\r?\n/)[0]!
-    .replace(/^\[@?[\w\-/:]+\]\s*/, '')
+  const reason = ((headRaw || '').split(/\r?\n/)[0] ?? '')
+    .replace(/^\[@?[\w.\-/:]+\]\s*/, '')
     .trim()
   const messageFrame = frameTail.length ? frameTail.join('\n\n').trim() : ''
 

--- a/packages/vite/src/vite-node-runner.ts
+++ b/packages/vite/src/vite-node-runner.ts
@@ -3,7 +3,6 @@ import { ViteNodeRunner } from 'vite-node/client'
 import { consola } from 'consola'
 import { viteNodeFetch, viteNodeOptions } from '#vite-node'
 import process from 'node:process'
-import type { ErrorPartial } from './types'
 
 const runner: ViteNodeRunner = createRunner()
 
@@ -17,63 +16,63 @@ function createRunner () {
     fetchModule (id) {
       id = id.replace(/\/\//g, '/') // TODO: fix in vite-node
       return viteNodeFetch.fetchModule(id).catch((err) => {
-        const errorData = err?.data?.data
+        const errorData = err?.data
         if (!errorData) {
           throw err
         }
-        let _err
+        let built: Error
         try {
-          const { message, stack } = formatViteError(errorData, id)
-          _err = {
-            statusText: 'Vite Error',
-            message,
-            stack,
-          } satisfies ErrorPartial
-        } catch (formatError) {
-          consola.warn('Internal nuxt error while formatting vite-node error. Please report this!', formatError)
+          built = buildViteError(errorData, id)
+        } catch (buildErr) {
+          consola.warn('Internal nuxt error while formatting vite-node error. Please report this!', buildErr)
           const message = `[vite-node] [TransformError] ${errorData?.message || '-'}`
           consola.error(message, errorData)
-          throw {
+          built = Object.assign(new Error(message), {
             statusText: 'Vite Error',
-            message,
+            statusMessage: 'Vite Error',
             stack: `${message}\nat ${id}\n` + (errorData?.stack || ''),
-          } satisfies ErrorPartial
+          })
         }
-        throw _err
+        throw built
       })
     },
   })
 }
 
-function formatViteError (errorData: any, id: string) {
-  const errorCode = errorData.name || errorData.reasonCode || errorData.code
-  const frame = errorData.frame || errorData.source || errorData.pluginCode
+function buildViteError (errorData: any, id: string): Error {
+  const loc = (errorData.id || id || '').replace(process.cwd(), '.')
 
-  const getLocId = (locObj: { file?: string, id?: string, url?: string } = {}) => locObj.file || locObj.id || locObj.url || id || ''
-  const getLocPos = (locObj: { line?: string, column?: string } = {}) => locObj.line ? `${locObj.line}:${locObj.column || 0}` : ''
-  const locId = getLocId(errorData.loc) || getLocId(errorData.location) || getLocId(errorData.input) || getLocId(errorData)
-  const locPos = getLocPos(errorData.loc) || getLocPos(errorData.location) || getLocPos(errorData.input) || getLocPos(errorData)
-  const loc = locId.replace(process.cwd(), '.') + (locPos ? `:${locPos}` : '')
+  // `err.message` from some compilers (notably @vue/compiler-sfc) embeds a
+  // `[scope/plugin]` prefix plus a code frame, separated from the real
+  // description by a blank line. Split on that boundary so we can show the
+  // clean one-liner as the heading and feed the frame text to `hint` below.
+  const rawMessage: string = errorData.message || ''
+  const [headRaw, ...frameTail] = rawMessage.split(/\r?\n\s*\r?\n/)
+  const reason = (headRaw || '')
+    .split(/\r?\n/)[0]!
+    .replace(/^\[@?[\w\-/:]+\]\s*/, '')
+    .trim()
+  const messageFrame = frameTail.length ? frameTail.join('\n\n').trim() : ''
 
-  const message = [
-    '[vite-node]',
-    errorData.plugin && `[plugin:${errorData.plugin}]`,
-    errorCode && `[${errorCode}]`,
-    loc,
-    errorData.reason && `: ${errorData.reason}`,
-    frame && `<br><pre>${frame.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')}</pre><br>`,
-  ].filter(Boolean).join(' ')
+  const message = reason ? `${loc} — ${reason}` : (rawMessage || loc)
 
-  const stack = [
-    message,
-    `at ${loc}`,
-    errorData.stack,
-  ].filter(Boolean).join('\n')
+  const error = Object.assign(new Error(message), {
+    name: 'ViteError',
+    statusText: 'Vite Error',
+    statusMessage: 'Vite Error',
+    code: errorData.code,
+    // Youch renders `hint` as a styled callout alongside the main message —
+    // a natural home for the code frame.
+    hint: errorData.frame || messageFrame || undefined,
+  })
 
-  return {
-    message,
-    stack,
+  // Prefer the server-side stack so Youch's stack viewer points at the real
+  // origin (compiler-sfc → plugin-vue → Vite) rather than this runner.
+  if (errorData.stack) {
+    error.stack = errorData.stack
   }
+
+  return error
 }
 
 export default runner

--- a/packages/vite/src/vite-node.ts
+++ b/packages/vite/src/vite-node.ts
@@ -144,10 +144,13 @@ function connectSocket (): Promise<Socket> {
               if (requestHandlers) {
                 const { resolve: resolveRequest, reject: rejectRequest } = requestHandlers
                 if (response.type === 'error') {
-                  const err: Error & { stack?: string, data?: unknown, status?: number, statusCode?: number } = new Error(response.error.message)
-                  err.stack = response.error.stack
+                  const err: Error & { stack?: string, data?: unknown, status?: number, statusCode?: number, _fromServer?: boolean } = new Error(response.error.message)
+                  if (response.error.stack) {
+                    err.stack = response.error.stack
+                  }
                   err.data = response.error.data
                   err.statusCode = err.status = response.error.status || response.error.statusCode
+                  err._fromServer = true
                   rejectRequest(err)
                 } else {
                   resolveRequest(response.data)
@@ -261,6 +264,10 @@ async function sendRequest<T extends keyof ViteNodeRequestMap> (type: T, payload
       })
     } catch (error) {
       lastError = error
+      // Don't retry application-level errors from the server
+      if (error && typeof error === 'object' && '_fromServer' in error) {
+        break
+      }
       if (requestAttempt < MAX_RETRY_ATTEMPTS) {
         const delay = calculateRetryDelay(requestAttempt)
         await new Promise(resolve => setTimeout(resolve, delay))


### PR DESCRIPTION
### 🔗 Linked issue

resolves #34593
closes https://github.com/nuxt/nuxt/pull/34728
closes https://github.com/nuxt/nuxt/pull/34771
closes https://github.com/nuxt/nuxt/pull/34615

### 📚 Description

When we have a syntax error on the server side that would cause Vite to retry the request, it would end up with an IPC connection close error that is not meaningful to users. This issue can be simply reproduced by putting the following code in the app.vue. Reported by @atinux

```vue
<script setup>
export function foo () {}
</script>

<template>
  <div>Hello</div>
</template>
```

This PR fixes that behavior by:
1. Making Vite able to differentiate between errors originating from the server and those from user land.
2. Making server-side errors look much nicer on the error page.

#### Before 
<img width="2484" height="1998" alt="CleanShot 2026-04-17 at 10 43 17@2x" src="https://github.com/user-attachments/assets/e0cf17bc-47bf-4ae6-ab14-36437c003def" />


#### After

<img width="2544" height="2494" alt="CleanShot 2026-04-17 at 10 41 41@2x" src="https://github.com/user-attachments/assets/fcc7c2a6-98d2-4c87-8cce-3b98ee2d4790" />
<img width="1260" height="616" alt="CleanShot 2026-04-17 at 10 41 55@2x" src="https://github.com/user-attachments/assets/3b2f152b-85bb-48e5-888b-971b58a8992f" />
