### PR TITLE
docs: clarify nitro dependency and imports from `#imports` in upgrade guide

### DIFF
--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -228,7 +228,9 @@ The sections below highlight changes that are most relevant to Nuxt application 
 
 #### Package and Import Path Changes
 
-The `nitropack` package has been renamed to `nitro`. All import paths have changed:
+The `nitropack` package has been renamed to `nitro`.
+You now also need to install `nitro` as a seperate dev-dependency.
+Moreover, all import paths have changed:
 
 | Before | After |
 |---|---|
@@ -348,6 +350,7 @@ If you define redirect route rules, the property name has changed:
 - **Nitro plugin imports**: Use `import { definePlugin } from 'nitro'` for explicit imports (auto-imports still work).
 - **Runtime hooks**: `nitroApp.hooks.hook('beforeResponse', ...)` and `nitroApp.hooks.hook('afterResponse', ...)` have been replaced by `nitroApp.hooks.hook('response', ...)`.
 - **`getRouteRules()` from `nitro/app`**: On the server, the Nitro helper changed from `getRouteRules(event)` to `getRouteRules(method, pathname)`, which returns `{ routeRules }`.
+- **Imports from `#imports`** have to be replaced by explicit imports from `nitro/*`, for example, use `import { useRuntimeConfig } from "nitro/runtime-config"` over `import { useRuntimeConfig } from "#imports"`.
 
 ### Removal of `experimental.externalVue`
 

--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -229,7 +229,28 @@ The sections below highlight changes that are most relevant to Nuxt application 
 #### Package and Import Path Changes
 
 The `nitropack` package has been renamed to `nitro`.
-You now also need to install `nitro` as a seperate dev-dependency.
+You now also need to install `nitro` as a separate dev-dependency:
+
+::code-group{sync="pm"}
+
+```bash [npm]
+npm install -D nitro
+```
+
+```bash [yarn]
+yarn add -D nitro
+```
+
+```bash [pnpm]
+pnpm add -D nitro
+```
+
+```bash [bun]
+bun add -D nitro
+```
+
+::
+
 Moreover, all import paths have changed:
 
 | Before | After |


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Two small improvements in the upgrade guide:
- Currently, the guide mentions that one should use imports now from `nitro`. This only works if `nitro` is also installed as a dev-dependency, so this is added as a first step.
- Imports from `#imports` no longer work (see eg https://github.com/nuxt/nuxt/issues/34142#issuecomment-3791192527 and https://github.com/nuxt/nuxt/issues/34282), so module authors need to replace those by direct imports from `nitro`.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
