### PR TITLE
fix(schema,rspack,webpack): respect configured `test` option

### DIFF
--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -57,7 +57,6 @@
     "postcss-url": "^10.1.3",
     "pug-plain-loader": "^1.1.0",
     "seroval": "^1.5.1",
-    "std-env": "^4.0.0",
     "time-fix-plugin": "^2.0.7",
     "tinyglobby": "^0.2.15",
     "ts-checker-rspack-plugin": "^1.3.0",

--- a/packages/schema/src/config/build.ts
+++ b/packages/schema/src/config/build.ts
@@ -1,6 +1,5 @@
 import { defu } from 'defu'
 import { join } from 'pathe'
-import { isTest } from 'std-env'
 import type { Nuxt } from '../types/nuxt.ts'
 import { defineResolvers } from '../utils/definition.ts'
 
@@ -36,11 +35,11 @@ export default defineResolvers({
     },
   },
   logLevel: {
-    $resolve: (val) => {
+    $resolve: async (val, get) => {
       if (val && typeof val === 'string' && !['silent', 'info', 'verbose'].includes(val)) {
         console.warn(`Invalid \`logLevel\` option: \`${val}\`. Must be one of: \`silent\`, \`info\`, \`verbose\`.`)
       }
-      return val && typeof val === 'string' ? val as 'silent' | 'info' | 'verbose' : (isTest ? 'silent' : 'info')
+      return val && typeof val === 'string' ? val as 'silent' | 'info' | 'verbose' : (await get('test') ? 'silent' : 'info')
     },
   },
   build: {

--- a/packages/schema/src/config/vite.ts
+++ b/packages/schema/src/config/vite.ts
@@ -1,5 +1,4 @@
 import { resolve } from 'pathe'
-import { isTest } from 'std-env'
 import { defineResolvers } from '../utils/definition.ts'
 
 export default defineResolvers({
@@ -12,7 +11,7 @@ export default defineResolvers({
     },
     define: {
       $resolve: async (_val, get) => {
-        const [isDev, isDebug] = await Promise.all([get('dev'), get('debug')])
+        const [isDev, isTest, isDebug] = await Promise.all([get('dev'), get('test'), get('debug')])
         return {
           '__VUE_PROD_HYDRATION_MISMATCH_DETAILS__': Boolean(isDebug && (isDebug === true || isDebug.hydration)),
           'process.dev': isDev,

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -58,7 +58,6 @@
     "postcss-url": "^10.1.3",
     "pug-plain-loader": "^1.1.0",
     "seroval": "^1.5.1",
-    "std-env": "^4.0.0",
     "time-fix-plugin": "^2.0.7",
     "tinyglobby": "^0.2.15",
     "ufo": "^1.6.3",

--- a/packages/webpack/src/presets/base.ts
+++ b/packages/webpack/src/presets/base.ts
@@ -8,7 +8,6 @@ import FriendlyErrorsWebpackPlugin from '@nuxt/friendly-errors-webpack-plugin'
 import escapeRegExp from 'escape-string-regexp'
 import { joinURL } from 'ufo'
 import type { NuxtOptions } from '@nuxt/schema'
-import { isTest } from 'std-env'
 import { defu } from 'defu'
 import type { WarningFilter } from '../plugins/warning-ignore.ts'
 import WarningIgnorePlugin from '../plugins/warning-ignore.ts'
@@ -233,12 +232,12 @@ function getEnv (ctx: WebpackConfigContext) {
     '__NUXT_ASYNC_CONTEXT__': ctx.options.experimental.asyncContext,
     'process.env.VUE_ENV': JSON.stringify(ctx.name),
     'process.dev': ctx.options.dev,
-    'process.test': isTest,
+    'process.test': ctx.nuxt.options.test,
     'process.browser': ctx.isClient,
     'process.client': ctx.isClient,
     'process.server': ctx.isServer,
     'import.meta.dev': ctx.options.dev,
-    'import.meta.test': isTest,
+    'import.meta.test': ctx.nuxt.options.test,
     'import.meta.browser': ctx.isClient,
     'import.meta.client': ctx.isClient,
     'import.meta.server': ctx.isServer,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -750,9 +750,6 @@ importers:
       seroval:
         specifier: ^1.5.1
         version: 1.5.2
-      std-env:
-        specifier: ^4.0.0
-        version: 4.0.0
       time-fix-plugin:
         specifier: ^2.0.7
         version: 2.0.7(webpack@5.106.1(esbuild@0.27.4))
@@ -1218,9 +1215,6 @@ importers:
       seroval:
         specifier: ^1.5.1
         version: 1.5.2
-      std-env:
-        specifier: ^4.0.0
-        version: 4.0.0
       time-fix-plugin:
         specifier: ^2.0.7
         version: 2.0.7(webpack@5.106.1(esbuild@0.27.4))


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this ensures we can override various test options by setting `test` in nuxt itself (which is done by nuxt/test-utils, for example)