### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/docs/1.getting-started/10.data-fetching.md
+++ b/docs/1.getting-started/10.data-fetching.md
@@ -541,7 +541,7 @@ const pending = computed(() => status.value === 'pending')
     >
 
     <div v-if="status === 'idle'">
-      Type an user ID
+      Type a user ID
     </div>
 
     <div v-else-if="pending">

--- a/docs/3.guide/2.best-practices/performance.md
+++ b/docs/3.guide/2.best-practices/performance.md
@@ -218,7 +218,7 @@ To improve performance, we need to first know how to measure it, starting with m
 
 ### Nuxi Analyze
 
-[This](/docs/4.x/api/commands/analyze) command of `nuxi` allows to analyze the production bundle or your Nuxt application. It leverages `vite-bundle-visualizer` (similar to `webpack-bundle-analyzer`) to generate a visual representation of your application's bundle, making it easier to identify which components take up the most space.
+[This](/docs/4.x/api/commands/analyze) command of `nuxi` allows you to analyze the production bundle of your Nuxt application. It leverages `vite-bundle-visualizer` (similar to `webpack-bundle-analyzer`) to generate a visual representation of your application's bundle, making it easier to identify which components take up the most space.
 
 When you see a large block in the visualization, it often signals an opportunity for optimization—whether by splitting it into smaller parts, implementing lazy loading, or replacing it with a more efficient alternative, especially for third-party libraries.
 


### PR DESCRIPTION

**Repo:** nuxt/nuxt (⭐ 55000)
**Type:** docs
**Files changed:** 2
**Lines:** +2/-2

## What
Two small grammar fixes in the docs:
- `docs/1.getting-started/10.data-fetching.md`: "Type an user ID" → "Type a user ID" (incorrect article — "user" begins with a consonant /j/ sound).
- `docs/3.guide/2.best-practices/performance.md`: "allows to analyze the production bundle or your Nuxt application" → "allows you to analyze the production bundle of your Nuxt application" (missing object after "allows" and "or" → "of" typo).

## Why
Both phrases appear in user-facing documentation pages. The first is a grammatical error in a code example caption that readers see when learning data-fetching; the second includes both a missing object after "allows" and a likely typo (`or` for `of`) that changes the meaning of the sentence describing `nuxi analyze`. No issue reference; spotted via grep for common doc grammar patterns.

## Testing
Pure documentation strings, no code paths affected. Verified diff is exactly 4 lines (+2/-2) and that no markdown structure is altered.

## Risk
Low — docs-only, no behavioral change.
