### PR TITLE
feat: provide `nuxt/devtools` and `nuxt/devtools-kit` alias

### DIFF
--- a/packages/nuxt/devtools-kit.d.ts
+++ b/packages/nuxt/devtools-kit.d.ts
@@ -1,0 +1,1 @@
+export * from '@nuxt/devtools-kit'

--- a/packages/nuxt/devtools-kit.js
+++ b/packages/nuxt/devtools-kit.js
@@ -1,1 +1,1 @@
-export * from "@nuxt/devtools-kit";
+export * from '@nuxt/devtools-kit'

--- a/packages/nuxt/devtools-kit.js
+++ b/packages/nuxt/devtools-kit.js
@@ -1,0 +1,1 @@
+export * from "@nuxt/devtools-kit";

--- a/packages/nuxt/devtools.d.ts
+++ b/packages/nuxt/devtools.d.ts
@@ -1,0 +1,1 @@
+export * from '@nuxt/devtools'

--- a/packages/nuxt/devtools.js
+++ b/packages/nuxt/devtools.js
@@ -1,1 +1,1 @@
-export * from "@nuxt/devtools";
+export * from '@nuxt/devtools'

--- a/packages/nuxt/devtools.js
+++ b/packages/nuxt/devtools.js
@@ -1,0 +1,1 @@
+export * from "@nuxt/devtools";

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -27,6 +27,8 @@
     },
     "./schema": "./schema.js",
     "./kit": "./kit.js",
+    "./devtools": "./devtools.js",
+    "./devtools-kit": "./devtools-kit.js",
     "./meta": "./meta.js",
     "./app": "./dist/app/index.js",
     "./package.json": "./package.json"
@@ -45,6 +47,8 @@
     "dist",
     "config.*",
     "kit.*",
+    "devtools.*",
+    "devtools-kit.*",
     "meta.*",
     "schema.*"
   ],


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Similar to `nuxt/kit`, also devtools and devtools-kit are now exposed under `nuxt`. This makes it possible to easily use those modules in a type-safe manner in custom nuxt modules (in a nuxt project, not as standalone module packages), without the need to manually install them.


<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
