### PR TITLE
perf(kit): parallelise module load + cache jiti instances

### DIFF
--- a/packages/kit/src/loader/config.ts
+++ b/packages/kit/src/loader/config.ts
@@ -34,6 +34,8 @@ export async function loadNuxtConfig (opts: LoadNuxtConfigOptions): Promise<Nuxt
     .sort((a, b) => b.localeCompare(a))
   opts.overrides = defu(opts.overrides, { _extends: localLayers })
 
+  const schemaPromise = loadNuxtSchema(opts.cwd || process.cwd())
+
   const { configFile, layers = [], cwd, config: nuxtConfig, meta } = await withDefineNuxtConfig(
     () => loadConfig<NuxtConfig>({
       name: 'nuxt',
@@ -65,7 +67,7 @@ export async function loadNuxtConfig (opts: LoadNuxtConfigOptions): Promise<Nuxt
     nuxtConfig.buildDir = join(nuxtConfig.rootDir!, 'node_modules/.cache/nuxt/.nuxt')
   }
 
-  const NuxtConfigSchema = await loadNuxtSchema(nuxtConfig.rootDir || cwd || process.cwd())
+  const NuxtConfigSchema = await schemaPromise
 
   const layerSchemaKeys = ['future', 'srcDir', 'rootDir', 'serverDir', 'dir']
   const layerSchema = Object.create(null)

--- a/packages/kit/src/module/install.ts
+++ b/packages/kit/src/module/install.ts
@@ -48,6 +48,13 @@ export async function installModules (modulesToInstall: Map<ModuleToInstall, Rec
   const resolvedModules: Array<ResolvedModule> = []
   // allow moduleDependencies to reference modules by their meta.name
   const modulesByMetaName = new Map<string, ModuleToInstall>()
+
+  // preload known modules in parallel
+  const moduleLoadCache = new Map<ModuleToInstall, Promise<{ nuxtModule: NuxtModule<any>, buildTimeModuleMeta: ModuleMeta, resolvedModulePath?: string }>>()
+  for (const [key] of modulesToInstall) {
+    moduleLoadCache.set(key, loadNuxtModuleInstance(key, nuxt))
+  }
+
   const inlineConfigKeys = new Set(
     await Promise.all([...modulesToInstall].map(async ([mod]) => {
       if (typeof mod === 'string') { return }
@@ -66,7 +73,8 @@ export async function installModules (modulesToInstall: Map<ModuleToInstall, Rec
   let error: Error | undefined
   const dependencyMap = new Map<ModuleToInstall, string>()
   for (const [key, options] of modulesToInstall) {
-    const res = await loadNuxtModuleInstance(key, nuxt).catch((err) => {
+    const loadPromise = moduleLoadCache.get(key) || loadNuxtModuleInstance(key, nuxt)
+    const res = await loadPromise.catch((err) => {
       if (dependencyMap.has(key) && typeof key === 'string') {
         (err as Error).cause = `Could not resolve \`${key}\` (specified as a dependency of ${dependencyMap.get(key)!}).`
       }
@@ -275,6 +283,18 @@ export function resolveModuleWithOptions (
   }
 }
 
+let _jitiCache: WeakMap<Nuxt, ReturnType<typeof createJiti>> | undefined
+
+function getSharedJiti (nuxt: Nuxt): ReturnType<typeof createJiti> {
+  _jitiCache ||= new WeakMap()
+  let jiti = _jitiCache.get(nuxt)
+  if (!jiti) {
+    jiti = createJiti(nuxt.options.rootDir, { alias: nuxt.options.alias })
+    _jitiCache.set(nuxt, jiti)
+  }
+  return jiti
+}
+
 export async function loadNuxtModuleInstance (nuxtModule: string | NuxtModule, nuxt: Nuxt = useNuxt()): Promise<{ nuxtModule: NuxtModule<any>, buildTimeModuleMeta: ModuleMeta, resolvedModulePath?: string }> {
   let buildTimeModuleMeta: ModuleMeta = {}
 
@@ -289,7 +309,7 @@ export async function loadNuxtModuleInstance (nuxtModule: string | NuxtModule, n
     throw new TypeError(`Nuxt module should be a function or a string to import. Received: ${nuxtModule}.`)
   }
 
-  const jiti = createJiti(nuxt.options.rootDir, { alias: nuxt.options.alias })
+  const jiti = getSharedJiti(nuxt)
 
   // Import if input is string
   nuxtModule = resolveAlias(nuxtModule, nuxt.options.alias)


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

in testing this improves startup performance by about ~10%, when loading three modules (I tried with eslint, fonts + image).