### PR TITLE
feat(kit): add support for custom export conditions in module resolution

### DIFF
--- a/docs/4.api/5.kit/12.resolving.md
+++ b/docs/4.api/5.kit/12.resolving.md
@@ -46,6 +46,8 @@ function resolvePath (path: string, options?: ResolvePathOptions): Promise<strin
 | `extensions`         | `string[]`                          | `false`  | The file extensions to try. Default is Nuxt configured extensions.                                                           |
 | `virtual`            | `boolean`                           | `false`  | Whether to resolve files that exist in the Nuxt VFS (for example, as a Nuxt template).                                       |
 | `fallbackToOriginal` | `boolean`                           | `false`  | Whether to fallback to the original path if the resolved path does not exist instead of returning the normalized input path. |
+| `conditions`         | `string[]`                          | `false`  | Conditions to apply when resolving package exports. Default is `["node", "import"]`. |
+| `type`               | `'file'` \| `'dir'`                 | `false`  | Whether to resolve a file or a directory. Default is `file`. |
 
 ### Examples
 

--- a/packages/kit/src/internal/esm.ts
+++ b/packages/kit/src/internal/esm.ts
@@ -11,6 +11,13 @@ export interface ResolveModuleOptions {
   url?: URL | URL[]
   /** @default ['.js', '.mjs', '.cjs', '.ts', '.mts', '.cts'] */
   extensions?: string[]
+  /**
+   * Conditions to apply when resolving package exports.
+   * @default ['node', 'import']
+   *
+   * Conditions are applied without order.
+   */
+  conditions?: string[]
 }
 
 export function directoryToURL (dir: string): URL {
@@ -39,6 +46,7 @@ export function resolveModule (id: string, options?: ResolveModuleOptions): stri
     // eslint-disable-next-line @typescript-eslint/no-deprecated
     from: options?.url ?? options?.paths ?? [import.meta.url],
     extensions: options?.extensions ?? ['.js', '.mjs', '.cjs', '.ts', '.mts', '.cts'],
+    conditions: options?.conditions,
   })
 }
 

--- a/packages/kit/src/resolve.test.ts
+++ b/packages/kit/src/resolve.test.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url'
 import { stat } from 'node:fs/promises'
 import { describe, expect, it } from 'vitest'
 import { resolve } from 'pathe'
@@ -19,10 +20,18 @@ const nuxt = await loadNuxt({
     ],
   },
 })
+const conditionsFixtureDir = fileURLToPath(new URL('../test/conditions-fixture/', import.meta.url))
 
 describe('resolvePath', () => {
   it('should resolve paths correctly', async () => {
     expect(await resolvePath('.nuxt/app.config')).toBe(resolve('.nuxt/app.config.mjs'))
+  })
+
+  it('should use custom export conditions', async () => {
+    expect(await resolvePath('conditional-package', {
+      cwd: conditionsFixtureDir,
+      conditions: ['custom-kit'],
+    })).toBe(resolve(conditionsFixtureDir, 'custom.js'))
   })
 })
 

--- a/packages/kit/src/resolve.ts
+++ b/packages/kit/src/resolve.ts
@@ -38,6 +38,13 @@ export interface ResolvePathOptions {
    */
   fallbackToOriginal?: boolean
   /**
+   * Conditions to apply when resolving package exports.
+   * @default ['node', 'import']
+   *
+   * Conditions are applied without order.
+   */
+  conditions?: string[]
+  /**
    * The type of the path to be resolved.
    * @default 'file'
    */
@@ -237,6 +244,7 @@ async function _resolvePathGranularly (path: string, opts: RequirePicked<Resolve
       try: true,
       suffixes: ['', 'index'],
       from: [cwd, ...modulesDir].map(d => directoryToURL(d)),
+      conditions: opts.conditions,
     })
     if (resolvedModulePath) {
       return {

--- a/packages/kit/test/conditions-fixture/custom.js
+++ b/packages/kit/test/conditions-fixture/custom.js
@@ -1,0 +1,1 @@
+export const marker = 'custom-kit'

--- a/packages/kit/test/conditions-fixture/default.js
+++ b/packages/kit/test/conditions-fixture/default.js
@@ -1,0 +1,1 @@
+export const marker = 'default'

--- a/packages/kit/test/conditions-fixture/package.json
+++ b/packages/kit/test/conditions-fixture/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "conditional-package",
+  "type": "module",
+  "exports": {
+    ".": {
+      "custom-kit": "./custom.js",
+      "import": "./default.js"
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -338,6 +338,8 @@ importers:
         specifier: 5.106.2
         version: 5.106.2(esbuild@0.27.4)
 
+  packages/kit/test/conditions-fixture: {}
+
   packages/nitro-server:
     dependencies:
       '@babel/plugin-syntax-typescript':


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Expose the `conditions` options of exsolve to the resolve methods of `kit`. This is mostly handy if you want to resolve a css file instead of the default node/import type.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
