### PR TITLE
doc: fix available in version number for NuxtAnnouncer

### DIFF
--- a/docs/4.api/1.components/14.nuxt-announcer.md
+++ b/docs/4.api/1.components/14.nuxt-announcer.md
@@ -9,7 +9,7 @@ links:
 ---
 
 ::important
-This component is available in Nuxt v3.17+.
+This component is available in Nuxt v4.4.2+.
 ::
 
 ## Usage

--- a/docs/4.api/2.composables/use-announcer.md
+++ b/docs/4.api/2.composables/use-announcer.md
@@ -9,7 +9,7 @@ links:
 ---
 
 ::important
-This composable is available in Nuxt v3.17+.
+This composable is available in Nuxt v4.4.2+.
 ::
 
 ## Description


### PR DESCRIPTION
The current documentation mentions that the new **NuxtAnnouncer** component and **useAnnouncer** composable are available in Nuxt v3.17+, however these APIs are only available in the latest(v4.4.2) and subsequent releases.

Here is the release docs when NuxtAnnoucer was published https://github.com/nuxt/nuxt/releases/tag/v4.4.0