### PR TITLE
fix(nuxt): adjust `setPageLayout` props type to allow passing arrays of objects

### DIFF
--- a/packages/nuxt/src/pages/runtime/utils.ts
+++ b/packages/nuxt/src/pages/runtime/utils.ts
@@ -10,17 +10,17 @@ type SerializablePrimitive = string | number | boolean | null | undefined
 /** JSON-serializable value (non-recursive definition to avoid excessive type depth) */
 export type SerializableValue = SerializablePrimitive | SerializablePrimitive[] | Record<string, unknown>
 
+export type MaybeArray<T> = T | T[]
+
 /** Constrains T to only contain serializable properties. Non-serializable properties become `never`. */
 // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-export type MakeSerializableObject<T> = T extends Function | symbol ? never : {
-  [K in keyof T]: T[K] extends SerializablePrimitive
-    ? T[K]
-    : T[K] extends (infer U)[]
-      ? U extends SerializablePrimitive ? T[K] : never
-      : T[K] extends Record<string, unknown>
+export type MakeSerializableObject<T> = T extends Function | symbol
+  ? never
+  : {
+      [K in keyof T]: T[K] extends MaybeArray<SerializablePrimitive | Record<string, unknown>>
         ? T[K]
         : never
-}
+    }
 
 const ROUTE_KEY_PARENTHESES_RE = /(:\w+)\([^)]+\)/g
 const ROUTE_KEY_SYMBOLS_RE = /(:\w+)[?+*]/g

--- a/packages/nuxt/src/pages/runtime/utils.ts
+++ b/packages/nuxt/src/pages/runtime/utils.ts
@@ -10,14 +10,14 @@ type SerializablePrimitive = string | number | boolean | null | undefined
 export type MaybeArray<T> = T | T[]
 
 /** JSON-serializable value (non-recursive definition to avoid excessive type depth) */
-export type SerializableValue = MaybeArray<SerializablePrimitive | Record<string, unknown>>
+export type SerializableValue = MaybeArray<SerializablePrimitive | Record<string, SerializablePrimitive>>
 
 /** Constrains T to only contain serializable properties. Non-serializable properties become `never`. */
 // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
 export type MakeSerializableObject<T> = T extends Function | symbol
   ? never
   : {
-      [K in keyof T]: T[K] extends MaybeArray<SerializablePrimitive | Record<string, unknown>>
+      [K in keyof T]: T[K] extends SerializableValue
         ? T[K]
         : never
     }

--- a/packages/nuxt/src/pages/runtime/utils.ts
+++ b/packages/nuxt/src/pages/runtime/utils.ts
@@ -7,10 +7,10 @@ export type RouterViewSlotProps = Parameters<RouterViewSlot>[0]
 
 type SerializablePrimitive = string | number | boolean | null | undefined
 
-/** JSON-serializable value (non-recursive definition to avoid excessive type depth) */
-export type SerializableValue = SerializablePrimitive | SerializablePrimitive[] | Record<string, unknown>
-
 export type MaybeArray<T> = T | T[]
+
+/** JSON-serializable value (non-recursive definition to avoid excessive type depth) */
+export type SerializableValue = MaybeArray<SerializablePrimitive | Record<string, unknown>>
 
 /** Constrains T to only contain serializable properties. Non-serializable properties become `never`. */
 // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/34847

### 📚 Description

... also took the opportunity to simplify the `MakeSerializableObject` type.