### PR TITLE
perf(nuxt): batch-resolve typescript hoist paths with cached base roots

### DIFF
--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -39,7 +39,7 @@ import { runtimeDependencies } from '../../meta.js'
 import pkg from '../../package.json' with { type: 'json' }
 import { scriptsStubsPreset } from '../imports/presets.ts'
 import { logger } from '../utils.ts'
-import { resolveTypePath } from './utils/types.ts'
+import { resolveTypePaths } from './utils/types.ts'
 import { createImportProtectionPatterns } from './plugins/import-protection.ts'
 import { UnctxTransformPlugin } from './plugins/unctx.ts'
 import { TreeShakeComposablesPlugin } from './plugins/tree-shake.ts'
@@ -1063,29 +1063,44 @@ async function resolveModules (nuxt: Nuxt) {
 const NESTED_PKG_RE = /^[^@]+\//
 async function resolveTypescriptPaths (nuxt: Nuxt): Promise<Record<string, [string]>> {
   nuxt.options.typescript.hoist ||= []
-  const paths = Object.fromEntries(await Promise.all(nuxt.options.typescript.hoist.map(async (pkg) => {
-    const [_pkg = pkg, _subpath] = NESTED_PKG_RE.test(pkg) ? pkg.split('/') : [pkg]
-    const subpath = _subpath ? '/' + _subpath : ''
+
+  const packagesToResolve: string[] = []
+  const nightlyAliases = new Map<string, string>() // nightly -> original
+
+  for (const pkg of nuxt.options.typescript.hoist) {
+    const [_pkg = pkg] = NESTED_PKG_RE.test(pkg) ? pkg.split('/') : [pkg]
 
     // ignore packages that exist in `package.json` as these can be resolved by TypeScript
-    if (nuxt._dependencies?.has(_pkg) && !(_pkg in nightlies)) { return [] }
+    if (nuxt._dependencies?.has(_pkg) && !(_pkg in nightlies)) { continue }
 
     // deduplicate types for nightly releases
     if (_pkg in nightlies) {
       const nightly = nightlies[_pkg as keyof typeof nightlies]
-      const path = await resolveTypePath(nightly + subpath, subpath, nuxt.options.modulesDir)
-      if (path) {
-        return [[pkg, [path]], [nightly + subpath, [path]]]
-      }
+      const nightlyPkg = pkg.replace(_pkg, nightly)
+      packagesToResolve.push(nightlyPkg)
+      nightlyAliases.set(nightlyPkg, pkg)
     }
 
-    const path = await resolveTypePath(_pkg + subpath, subpath, nuxt.options.modulesDir)
-    if (path) {
-      return [[pkg, [path]]]
-    }
+    packagesToResolve.push(pkg)
+  }
 
-    return []
-  })).then(r => r.flat()))
+  const resolved = await resolveTypePaths(packagesToResolve, nuxt.options.modulesDir)
+
+  const paths: Record<string, [string]> = {}
+  const nightlyResolved = new Set<string>() // track which originals were resolved via nightly
+
+  for (const [pkg, path] of resolved) {
+    if (nightlyAliases.has(pkg)) {
+      // This is a nightly resolution - map to both the original and nightly name
+      const original = nightlyAliases.get(pkg)!
+      paths[original] = [path]
+      paths[pkg] = [path]
+      nightlyResolved.add(original)
+    } else if (!nightlyResolved.has(pkg)) {
+      // Only use direct resolution if nightly didn't already resolve
+      paths[pkg] = [path]
+    }
+  }
 
   return paths
 }

--- a/packages/nuxt/src/core/utils/types.ts
+++ b/packages/nuxt/src/core/utils/types.ts
@@ -1,21 +1,61 @@
 import { resolvePackageJSON } from 'pkg-types'
 import { resolveModulePath } from 'exsolve'
 import { dirname } from 'pathe'
-import { directoryToURL, tryUseNuxt } from '@nuxt/kit'
+import { directoryToURL } from '@nuxt/kit'
 
-export async function resolveTypePath (path: string, subpath: string, searchPaths = tryUseNuxt()?.options.modulesDir) {
+const TYPE_RESOLVE_OPTIONS = {
+  conditions: ['types', 'import', 'require'] as string[],
+  extensions: ['.js', '.mjs', '.cjs', '.ts', '.mts', '.cts'],
+}
+
+const rootCache = new Map<string, Promise<string | undefined>>()
+
+function resolveRoot (basePkg: string, from: Array<string | URL> | undefined): Promise<string | undefined> {
+  if (rootCache.has(basePkg)) {
+    return rootCache.get(basePkg)!
+  }
+  const promise = _resolveRoot(basePkg, from)
+  rootCache.set(basePkg, promise)
+  return promise
+}
+
+async function _resolveRoot (basePkg: string, from: Array<string | URL> | undefined): Promise<string | undefined> {
   try {
-    const r = resolveModulePath(path, {
-      from: searchPaths?.map(d => directoryToURL(d)),
-      conditions: ['types', 'import', 'require'],
-      extensions: ['.js', '.mjs', '.cjs', '.ts', '.mts', '.cts'],
-    })
-    if (subpath) {
-      return r.replace(/(?:\.d)?\.[mc]?[jt]s$/, '')
-    }
+    const r = resolveModulePath(basePkg, { from, ...TYPE_RESOLVE_OPTIONS })
     const rootPath = await resolvePackageJSON(r)
     return dirname(rootPath)
   } catch {
-    return null
+    return undefined
   }
+}
+
+const NESTED_RE = /^[^@]+\//
+
+export async function resolveTypePaths (packages: string[], searchPaths: string[]): Promise<Array<[string, string]>> {
+  const results: Array<[string, string]> = []
+
+  const from = searchPaths.map(d => directoryToURL(d))
+
+  await Promise.allSettled(packages.map(async (pkg) => {
+    const [basePkg = pkg, sub] = NESTED_RE.test(pkg) ? pkg.split('/') : [pkg]
+    const subpath = sub ? '/' + sub : ''
+
+    const root = await resolveRoot(basePkg, from)
+    if (!root) {
+      return
+    }
+
+    if (!subpath) {
+      return results.push([pkg, root])
+    }
+
+    const r = resolveModulePath(pkg, {
+      from: directoryToURL(root),
+      ...TYPE_RESOLVE_OPTIONS,
+    })
+
+    results.push([pkg, r.replace(/(?:\.d)?\.[mc]?[jt]s$/, '')])
+  }))
+
+  return results
 }

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -10,7 +10,7 @@ import type { NitroRouteConfig } from 'nitro/types'
 import { defu } from 'defu'
 import { isEqual } from 'ohash'
 import { distDir } from '../dirs.ts'
-import { resolveTypePath } from '../core/utils/types.ts'
+import { resolveTypePaths } from '../core/utils/types.ts'
 import { logger } from '../utils.ts'
 import picomatch from 'picomatch'
 import { resolvePagesRoutes as _resolvePagesRoutes, augmentAndResolve, createPagesContext, defaultExtractionKeys, normalizeRoutes, resolveRoutePaths, toRou3Patterns } from './utils.ts'
@@ -120,7 +120,7 @@ export default defineNuxtModule({
     }
 
     nuxt.options.alias['#vue-router'] = 'vue-router'
-    const routerPath = await resolveTypePath('vue-router', '', nuxt.options.modulesDir) || 'vue-router'
+    const routerPath = (await resolveTypePaths(['vue-router'], nuxt.options.modulesDir))[0]?.[1] || 'vue-router'
     nuxt.hook('prepare:types', ({ tsConfig }) => {
       tsConfig.compilerOptions ||= {}
       tsConfig.compilerOptions.paths ||= {}

--- a/packages/nuxt/test/resolve-type-paths.test.ts
+++ b/packages/nuxt/test/resolve-type-paths.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('exsolve', () => ({
+  resolveModulePath: vi.fn(),
+}))
+
+vi.mock('pkg-types', () => ({
+  resolvePackageJSON: vi.fn(),
+}))
+
+const { resolveModulePath } = await import('exsolve')
+const { resolvePackageJSON } = await import('pkg-types')
+
+const mockedResolveModulePath = vi.mocked(resolveModulePath)
+const mockedResolvePackageJSON = vi.mocked(resolvePackageJSON)
+
+// Re-import resolveTypePaths for each test to reset the module-level rootCache
+function freshImport () {
+  vi.resetModules()
+
+  // Re-setup mocks after module reset (they get cleared too)
+  vi.doMock('exsolve', () => ({ resolveModulePath: mockedResolveModulePath }))
+  vi.doMock('pkg-types', () => ({ resolvePackageJSON: mockedResolvePackageJSON }))
+
+  return import('../src/core/utils/types.ts')
+}
+
+describe('resolveTypePaths', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('resolves a base package to its root directory', async () => {
+    const { resolveTypePaths } = await freshImport()
+
+    mockedResolveModulePath.mockReturnValue('/node_modules/vue/dist/vue.mjs')
+    mockedResolvePackageJSON.mockResolvedValue('/node_modules/vue/package.json')
+
+    const results = await resolveTypePaths(['vue'], ['/project/node_modules'])
+
+    expect(results).toEqual([['vue', '/node_modules/vue']])
+  })
+
+  it('resolves a subpath entry via the base package root', async () => {
+    const { resolveTypePaths } = await freshImport()
+
+    mockedResolveModulePath.mockImplementation((path) => {
+      if (path === 'nitro') { return '/node_modules/nitro/dist/index.mjs' }
+      if (path === 'nitro/app') { return '/node_modules/nitro/dist/app.d.mts' }
+      throw new Error('MODULE_NOT_FOUND')
+    })
+    mockedResolvePackageJSON.mockResolvedValue('/node_modules/nitro/package.json')
+
+    const results = await resolveTypePaths(['nitro/app'], ['/project/node_modules'])
+
+    expect(results).toEqual([['nitro/app', '/node_modules/nitro/dist/app']])
+  })
+
+  it('caches base package root across multiple subpath entries', async () => {
+    const { resolveTypePaths } = await freshImport()
+
+    mockedResolveModulePath.mockImplementation((path) => {
+      if (path === 'nitro') { return '/node_modules/nitro/dist/index.mjs' }
+      if (path === 'nitro/app') { return '/node_modules/nitro/dist/app.d.mts' }
+      if (path === 'nitro/builder') { return '/node_modules/nitro/dist/builder.d.mts' }
+      throw new Error('MODULE_NOT_FOUND')
+    })
+    mockedResolvePackageJSON.mockResolvedValue('/node_modules/nitro/package.json')
+
+    const results = await resolveTypePaths(['nitro/app', 'nitro/builder'], ['/project/node_modules'])
+
+    expect(results).toHaveLength(2)
+    expect(results).toContainEqual(['nitro/app', '/node_modules/nitro/dist/app'])
+    expect(results).toContainEqual(['nitro/builder', '/node_modules/nitro/dist/builder'])
+
+    // resolvePackageJSON called only once (for the base 'nitro', then cached)
+    expect(mockedResolvePackageJSON).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips subpath entries when base package cannot be resolved', async () => {
+    const { resolveTypePaths } = await freshImport()
+
+    mockedResolveModulePath.mockImplementation(() => {
+      throw new Error('MODULE_NOT_FOUND')
+    })
+
+    const results = await resolveTypePaths(['missing/app', 'missing/builder'], ['/project/node_modules'])
+
+    expect(results).toEqual([])
+  })
+
+  it('handles a mix of base packages and subpath entries', async () => {
+    const { resolveTypePaths } = await freshImport()
+
+    mockedResolveModulePath.mockImplementation((path) => {
+      const map: Record<string, string> = {
+        'vue': '/node_modules/vue/dist/vue.mjs',
+        'nitro': '/node_modules/nitro/dist/index.mjs',
+        'nitro/app': '/node_modules/nitro/dist/app.d.mts',
+        'nitro/types': '/node_modules/nitro/dist/types.d.mts',
+      }
+      if (typeof path === 'string' && path in map) { return map[path]! }
+      throw new Error('MODULE_NOT_FOUND')
+    })
+
+    // eslint-disable-next-line require-await
+    mockedResolvePackageJSON.mockImplementation(async (r) => {
+      if (r?.includes('vue')) { return '/node_modules/vue/package.json' }
+      if (r?.includes('nitro')) { return '/node_modules/nitro/package.json' }
+      throw new Error('not found')
+    })
+
+    const results = await resolveTypePaths(['vue', 'nitro/app', 'nitro/types'], ['/project/node_modules'])
+
+    expect(results).toHaveLength(3)
+    expect(results).toContainEqual(['vue', '/node_modules/vue'])
+    expect(results).toContainEqual(['nitro/app', '/node_modules/nitro/dist/app'])
+    expect(results).toContainEqual(['nitro/types', '/node_modules/nitro/dist/types'])
+  })
+
+  it('strips various type extensions from subpath resolutions', async () => {
+    const { resolveTypePaths } = await freshImport()
+
+    mockedResolveModulePath.mockImplementation((path) => {
+      if (path === 'nitro') { return '/node_modules/nitro/dist/index.mjs' }
+      if (path === 'nitro/app') { return '/node_modules/nitro/dist/app.d.mts' }
+      throw new Error('MODULE_NOT_FOUND')
+    })
+    mockedResolvePackageJSON.mockResolvedValue('/node_modules/nitro/package.json')
+
+    const results = await resolveTypePaths(['nitro/app'], ['/project/node_modules'])
+
+    // .d.mts should be stripped
+    expect(results[0]![1]).toBe('/node_modules/nitro/dist/app')
+  })
+
+  it('handles resolution errors gracefully for individual packages', async () => {
+    const { resolveTypePaths } = await freshImport()
+
+    mockedResolveModulePath.mockImplementation((path) => {
+      if (path === 'vue') { return '/node_modules/vue/dist/vue.mjs' }
+      throw new Error('MODULE_NOT_FOUND')
+    })
+    mockedResolvePackageJSON.mockResolvedValue('/node_modules/vue/package.json')
+
+    const results = await resolveTypePaths(['vue', 'nonexistent'], ['/project/node_modules'])
+
+    // vue resolves, nonexistent is silently skipped
+    expect(results).toEqual([['vue', '/node_modules/vue']])
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

for packages with multiple subpaths, like nitro, we were doing the costly initial lookup (of nitro) multiple times in succession. this caches base paths and uses that for the subsequent subpath lookup