### PR TITLE
docs: remove @nuxt/hints from core modules roadmap

### DIFF
--- a/docs/5.community/6.roadmap.md
+++ b/docs/5.community/6.roadmap.md
@@ -42,7 +42,6 @@ In addition to the Nuxt framework, there are modules that are vital for the ecos
 |----------------------------------------|--------------|--------------|-------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Auth Utils                             | Planned      | 4.x, 5.x     | `nuxt/auth-utils` to be announced               | The temporary repository [atinux/nuxt-auth-utils](https://github.com/atinux/nuxt-auth-utils) is available while awaiting its official integration into Nuxt via RFC. |
 | [a11y](https://github.com/nuxt/a11y)   | Public Alpha | 3.x, 4.x     | [nuxt/a11y](https://github.com/nuxt/a11y).      | Real-time accessibility feedback and automated testing in your browser during development (see [nuxt/nuxt#23255](https://github.com/nuxt/nuxt/issues/23255)).        |
-| [Hints](https://github.com/nuxt/hints) | Public Alpha | 4.x, 5.x     | [nuxt/hints](https://github.com/nuxt/hints)     | Guidance and suggestions for enhancing development practices.                                                                                                        |
 
 ## Release Cycle
 


### PR DESCRIPTION
### 📚 Description

Similarly to https://github.com/nuxt/nuxt/pull/34835, [`@nuxt/hints`](https://nuxt.com/modules/hints) has reached a stable version. 🎉 
