### PR TITLE
fix(nuxt): propagate unexpected errors from `isDirectorySync`

### DIFF
--- a/packages/nuxt/src/utils.ts
+++ b/packages/nuxt/src/utils.ts
@@ -12,7 +12,13 @@ export async function isDirectory (path: string) {
 }
 
 export function isDirectorySync (path: string) {
-  try { return statSync(path).isDirectory() } catch { return false }
+  try {
+    return statSync(path, { throwIfNoEntry: false })?.isDirectory() ?? false
+  } catch (err) {
+    // ENOTDIR should be treated as "not a directory" instead of an error
+    if ((err as NodeJS.ErrnoException).code === 'ENOTDIR') { return false }
+    throw err
+  }
 }
 
 const LEADING_DOT_RE = /^\.+/g

--- a/packages/nuxt/test/utils.test.ts
+++ b/packages/nuxt/test/utils.test.ts
@@ -1,0 +1,37 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { isDirectorySync } from '../src/utils.ts'
+
+describe('isDirectorySync', () => {
+  let dir: string
+  let file: string
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), 'nuxt-isdir'))
+    file = join(dir, 'testfile.txt')
+    writeFileSync(file, '')
+  })
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('returns true for an existing directory', () => {
+    expect(isDirectorySync(dir)).toBe(true)
+  })
+
+  it('returns false for an existing file', () => {
+    expect(isDirectorySync(file)).toBe(false)
+  })
+
+  it('returns false for a non-existent path (ENOENT)', () => {
+    expect(isDirectorySync(join(dir, 'nope'))).toBe(false)
+  })
+
+  it('returns false when a path segment is a file, not a directory (ENOTDIR)', () => {
+    expect(isDirectorySync(join(file, 'child'))).toBe(false)
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

Resolves: #34755

### 📚 Description

`isDirectorySync` currently swallows every error from `statSync` and returns `false`. That's fine for "the path doesn't exist", but it also masks real problems like permission errors or disk I/O issues - they show up as a misleading "directory not found" warning.

### Tests
- Added unit tests for `isDirectorySync`
