### PR TITLE
fix(nuxt): sync `_route` when navigating up the route tree

### DIFF
--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -110,9 +110,15 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
     const _route = shallowRef(router.currentRoute.value)
     const syncCurrentRoute = () => { _route.value = router.currentRoute.value }
     router.afterEach((to, from) => {
-      // We won't trigger suspense if the component is reused between routes
-      // so we need to update the route manually
-      if (to.matched.at(-1)?.components?.default === from.matched.at(-1)?.components?.default) {
+      // `_route` is usually re-synced by `<NuxtPage>`'s `Suspense.onResolve`. When no Suspense
+      // remounts (leaf component reused, or navigating up the tree) we sync manually.
+      const lastTo = to.matched.at(-1)?.components?.default
+      const lastFrom = from.matched.at(-1)?.components?.default
+      if (lastTo === lastFrom) {
+        syncCurrentRoute()
+        return
+      }
+      if (to.matched.length < from.matched.length && to.matched.every((m, i) => m.components?.default === from.matched[i]?.components?.default)) {
         syncCurrentRoute()
       }
     })

--- a/test/nuxt/nuxt-page.test.ts
+++ b/test/nuxt/nuxt-page.test.ts
@@ -650,6 +650,73 @@ describe('NuxtPage render counts with synchronous components', () => {
   })
 })
 
+// Navigating up the tree (e.g. /a/b/c -> /a/b) doesn't remount any Suspense, so `_route`
+// has to be synced from `router.afterEach` rather than `<NuxtPage>`'s `Suspense.onResolve`.
+describe('nuxtApp._route should follow the router on tree-narrowing navigations', () => {
+  let router: ReturnType<typeof useRouter>
+  let nuxtApp: ReturnType<typeof useNuxtApp>
+
+  beforeEach(() => {
+    router = useRouter()
+    nuxtApp = useNuxtApp()
+
+    router.addRoute({
+      name: 'narrowing-parent',
+      path: '/narrowing-parent',
+      component: defineComponent({
+        name: 'narrowing-parent',
+        setup: () => () => h('div', [h('span', 'Parent'), h(NuxtPage)]),
+      }),
+      children: [
+        {
+          name: 'narrowing-child',
+          path: 'child',
+          component: defineComponent({
+            name: 'narrowing-child',
+            setup: () => () => h('div', [h('span', 'Child'), h(NuxtPage)]),
+          }),
+          children: [
+            {
+              name: 'narrowing-grandchild',
+              path: 'grandchild',
+              component: defineComponent({
+                name: 'narrowing-grandchild',
+                setup: () => () => h('div', 'Grandchild'),
+              }),
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  afterEach(() => {
+    router.removeRoute('narrowing-parent')
+  })
+
+  it('should sync _route when navigating from a leaf back to its parent', async () => {
+    const el = await mountSuspended({
+      setup () {
+        return () => h(NuxtLayout, {}, { default: () => h(NuxtPage) })
+      },
+    })
+
+    await navigateTo('/narrowing-parent/child/grandchild')
+    await flushPromises()
+    expect(nuxtApp._route.path).toBe('/narrowing-parent/child/grandchild')
+
+    await navigateTo('/narrowing-parent/child')
+    await flushPromises()
+    expect(nuxtApp._route.path).toBe('/narrowing-parent/child')
+
+    await navigateTo('/narrowing-parent')
+    await flushPromises()
+    expect(nuxtApp._route.path).toBe('/narrowing-parent')
+
+    el.unmount()
+  })
+})
+
 describe('NuxtPage should work with keepalive options', () => {
   let visits = 0
   let router: ReturnType<typeof useRouter>


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this handles decreasing depth in nested routes, when otherwise the route would not update (because suspense does not resolve)

encountered in https://github.com/nuxt/nuxt/pull/34899.