### PR TITLE
ci: update workflows to use renamed type labels

### DIFF
--- a/.github/workflows/issue-labelled.yml
+++ b/.github/workflows/issue-labelled.yml
@@ -19,8 +19,8 @@ jobs:
             const label = context.payload.label.name;
 
             const issueTypes = {
-              'bug': 'Bug',
-              'enhancement': 'Enhancement'
+              '🐛 bug': 'Bug',
+              '✨ enhancement': 'Enhancement'
             };
 
             const issueType = issueTypes[label];

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -46,14 +46,14 @@ jobs:
 
             // Select label based on the type in PR title
             const pullRequestTypeToLabelName = {
-              chore: 'chore',
-              ci: 'chore',
-              docs: 'documentation',
-              feat: 'enhancement',
-              fix: 'bug',
-              perf: 'performance',
-              refactor: 'refactor',
-              test: 'test'
+              chore: '🧹 p1-chore',
+              ci: '🧹 p1-chore',
+              docs: '📚 documentation',
+              feat: '✨ enhancement',
+              fix: '🐛 bug',
+              perf: '⚡ performance',
+              refactor: '♻️ refactor',
+              test: '🧪 test'
             }
 
             for (const [pullRequestType, labelName] of Object.entries(


### PR DESCRIPTION
## Summary

- The type labels (`bug`, `enhancement`, `documentation`, `performance`, `refactor`, `test`) were renamed with emoji prefixes (`🐛 bug`, `✨ enhancement`, etc.), and the bare `chore` label was deleted.
- `label-pr.yml` and `issue-labelled.yml` still referenced the old names, so PR auto-labeling and issue-type conversion silently stopped working for newly opened issues/PRs.
- This PR updates the maps in both workflows to the new label names. `chore:` and `ci:` PR title prefixes now map to `🧹 p1-chore`.