### PR TITLE
docs: set `NODE_ENV` to `production` in deployment examples

### DIFF
--- a/docs/1.getting-started/16.deployment.md
+++ b/docs/1.getting-started/16.deployment.md
@@ -23,10 +23,14 @@ Discover the Node.js server preset with Nitro to deploy on any Node hosting.
 When running `nuxt build` with the Node server preset, the result will be an entry point that launches a ready-to-run Node server.
 
 ```bash [Terminal]
-node .output/server/index.mjs
+NODE_ENV=production node .output/server/index.mjs
 ```
 
 This will launch your production Nuxt server that listens on port 3000 by default.
+
+::important
+Set `NODE_ENV=production` when running the server. Some dependencies (notably Vue Router) only strip development-only warnings when this is set, so leaving it unset can flood your logs with messages like `[Vue Router warn]: No match found for location with path …` on unmatched routes.
+::
 
 It respects the following runtime environment variables:
 
@@ -49,6 +53,9 @@ module.exports = {
       exec_mode: 'cluster',
       instances: 'max',
       script: './.output/server/index.mjs',
+      env: {
+        NODE_ENV: 'production',
+      },
     },
   ],
 }

--- a/docs/2.directory-structure/2.env.md
+++ b/docs/2.directory-structure/2.env.md
@@ -49,7 +49,7 @@ Since `.env` files are not used in production, you must explicitly set environme
 
 * You can pass the environment variables as arguments using the terminal:
 
-   `$ DATABASE_HOST=mydatabaseconnectionstring node .output/server/index.mjs`
+   `$ NODE_ENV=production DATABASE_HOST=mydatabaseconnectionstring node .output/server/index.mjs`
 
 * You can set environment variables in shell configuration files like `.bashrc` or `.profile`.
 
@@ -66,7 +66,7 @@ For local production preview purpose, we recommend using [`nuxt preview`](/docs/
 Or you could pass the environment variables as arguments using the terminal. For example, on Linux or macOS:
 
 ```bash [Terminal]
-DATABASE_HOST=mydatabaseconnectionstring node .output/server/index.mjs
+NODE_ENV=production DATABASE_HOST=mydatabaseconnectionstring node .output/server/index.mjs
 ```
 
 Note that for a purely static site, it is not possible to set runtime configuration config after your project is prerendered.

--- a/docs/4.api/4.commands/preview.md
+++ b/docs/4.api/4.commands/preview.md
@@ -40,5 +40,5 @@ The `preview` command starts a server to preview your Nuxt application after run
 This command sets `process.env.NODE_ENV` to `production`. To override, define `NODE_ENV` in a `.env` file or as command-line argument.
 
 ::note
-For convenience, in preview mode, your [`.env`](/docs/4.x/directory-structure/env) file will be loaded into `process.env`. (However, in production you will need to ensure your environment variables are set yourself. For example, with Node.js 20+ you could do this by running `node --env-file .env .output/server/index.mjs` to start your server.)
+For convenience, in preview mode, your [`.env`](/docs/4.x/directory-structure/env) file will be loaded into `process.env`. (However, in production you will need to ensure your environment variables are set yourself. For example, with Node.js 20+ you could do this by running `NODE_ENV=production node --env-file .env .output/server/index.mjs` to start your server.)
 ::

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -147,7 +147,7 @@ export interface ConfigSchema {
    *
    * @example
    * ```bash
-   * NUXT_APP_BASE_URL=/prefix/ node .output/server/index.mjs
+   * NUXT_APP_BASE_URL=/prefix/ NODE_ENV=production node .output/server/index.mjs
    * ```
    */
     baseURL: string
@@ -175,7 +175,7 @@ export interface ConfigSchema {
      *
      * @example
      * ```bash
-     * NUXT_APP_CDN_URL=https://mycdn.org/ node .output/server/index.mjs
+     * NUXT_APP_CDN_URL=https://mycdn.org/ NODE_ENV=production node .output/server/index.mjs
      * ```
      */
     cdnURL: string


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/26947

### 📚 Description

`vue-router` currently shows some warnings (like 404 warnings) if `NODE_ENV` isn't explicitly set to `production`

cc: @pi0 - in case you'd be willing to do a `process.env.NODE_ENV` replacement step when tracing external deps