### PR TITLE
fix(nitro): break recursive rendering deadlocks during prerender

### DIFF
--- a/packages/nitro-server/src/runtime/handlers/error.ts
+++ b/packages/nitro-server/src/runtime/handlers/error.ts
@@ -46,11 +46,12 @@ export default <NitroErrorHandler> async function errorhandler (error, event, { 
   mergeHeaders(headers, new Headers(defaultRes.headers), new Set(), IGNORED_ERROR_HEADERS)
 
   // Skip SSR error rendering if we're already inside one, to avoid recursion.
-  const isRenderingError = (event as H3Event).url?.pathname.startsWith('/__nuxt_error') || !!event.context.nuxt?.['~rendering-error']
+  const isRenderingError = (event as H3Event).url?.pathname.startsWith('/__nuxt_error') || !!(event as H3Event).context.nuxt?.['~rendering-error']
 
   if (!isRenderingError) {
-    event.context.nuxt ||= {}
-    event.context.nuxt['~rendering-error'] = true
+    const eventContext = (event as H3Event).context
+    eventContext.nuxt ||= {}
+    eventContext.nuxt['~rendering-error'] = true
   }
 
   // HTML response (via SSR)

--- a/packages/nitro-server/src/runtime/handlers/error.ts
+++ b/packages/nitro-server/src/runtime/handlers/error.ts
@@ -45,11 +45,12 @@ export default <NitroErrorHandler> async function errorhandler (error, event, { 
   // and content-security-policy (would disable JS execution in the error page)
   mergeHeaders(headers, new Headers(defaultRes.headers), new Set(), IGNORED_ERROR_HEADERS)
 
-  // Detect to avoid recursion in SSR rendering of errors
-  const isRenderingError = (event as H3Event).url?.pathname.startsWith('/__nuxt_error') || !!event.req.headers.get('x-nuxt-error')
+  // Skip SSR error rendering if we're already inside one, to avoid recursion.
+  const isRenderingError = (event as H3Event).url?.pathname.startsWith('/__nuxt_error') || !!event.context.nuxt?.['~rendering-error']
 
   if (!isRenderingError) {
-    event.req.headers.set('x-nuxt-error', 'true')
+    event.context.nuxt ||= {}
+    event.context.nuxt['~rendering-error'] = true
   }
 
   // HTML response (via SSR)
@@ -62,6 +63,7 @@ export default <NitroErrorHandler> async function errorhandler (error, event, { 
     {
       nuxt: {
         '~internal': true,
+        '~rendering-error': true,
       },
     },
   ).catch(() => null)

--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -52,7 +52,7 @@ const PAYLOAD_FILENAME = '_payload.json'
 
 let entryPath: string
 
-const handler: ReturnType<typeof defineEventHandler> = defineEventHandler(async (event) => {
+const handler: ReturnType<typeof defineEventHandler> = defineEventHandler((event) => {
   // Whether we're rendering an error page
   const ssrError = event.url.pathname.startsWith('/__nuxt_error')
     ? getQuery<NuxtPayload['error'] & { url: string }>(event)

--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -65,13 +65,18 @@ const handler: ReturnType<typeof defineEventHandler> = defineEventHandler((event
     })
   }
 
+  // During prerender, refuse to recurse into a URL that is already rendering
+  // higher in the same call chain. Without this, a `useFetch`/`$fetch` against
+  // the in-flight URL (typically from route middleware) silently deadlocks the
+  // build. See https://github.com/nuxt/nuxt/issues/33871.
   if (import.meta.prerender && prerenderRenderingURLs) {
     const renderingURL = event.url.pathname + event.url.search
     const stack = prerenderRenderingURLs.getStore()
     if (stack?.includes(renderingURL)) {
+      const chain = [...stack, renderingURL].map(url => `"${url}"`).join(' -> ')
       throw new HTTPError({
         status: 508,
-        statusText: `Loop detected while prerendering "${renderingURL}". A request was made to this URL while the same URL was already being rendered in the same call chain (commonly caused by calling \`useFetch\`/\`$fetch\` in route middleware against a path that is not handled at build time).`,
+        statusText: `Loop detected while prerendering "${renderingURL}" (${chain}). Check for \`useFetch\`/\`$fetch\` calls targeting a URL that is currently being rendered.`,
       })
     }
     return prerenderRenderingURLs.run([...(stack || []), renderingURL], () => renderRoute(event, ssrError))

--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -13,7 +13,7 @@ import { relative } from 'pathe'
 import type { NuxtPayload, NuxtRenderHTMLContext, NuxtSSRContext } from 'nuxt/app'
 
 import { getRenderer } from '../utils/renderer/build-files'
-import { payloadCache } from '../utils/cache'
+import { payloadCache, prerenderRenderingURLs } from '../utils/cache'
 
 import { renderPayloadJsonScript, renderPayloadResponse, splitPayload } from '../utils/renderer/payload'
 import { createSSRContext, setSSRError } from '../utils/renderer/app'
@@ -65,6 +65,22 @@ const handler: ReturnType<typeof defineEventHandler> = defineEventHandler(async 
     })
   }
 
+  if (import.meta.prerender && prerenderRenderingURLs) {
+    const renderingURL = event.url.pathname + event.url.search
+    const stack = prerenderRenderingURLs.getStore()
+    if (stack?.includes(renderingURL)) {
+      throw new HTTPError({
+        status: 508,
+        statusText: `Loop detected while prerendering "${renderingURL}". A request was made to this URL while the same URL was already being rendered in the same call chain (commonly caused by calling \`useFetch\`/\`$fetch\` in route middleware against a path that is not handled at build time).`,
+      })
+    }
+    return prerenderRenderingURLs.run([...(stack || []), renderingURL], () => renderRoute(event, ssrError))
+  }
+
+  return renderRoute(event, ssrError)
+})
+
+async function renderRoute (event: H3Event, ssrError: (NuxtPayload['error'] & { url: string }) | null) {
   // Initialize ssr context
   const ssrContext: NuxtSSRContext = createSSRContext(event)
 
@@ -303,7 +319,7 @@ const handler: ReturnType<typeof defineEventHandler> = defineEventHandler(async 
   event.res.headers.set('x-powered-by', 'Nuxt')
 
   return renderHTMLDocument(htmlContext)
-})
+}
 
 export default handler
 

--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -363,6 +363,8 @@ declare module 'srvx' {
       'noSSR'?: boolean
       /** @internal */
       '~internal'?: boolean
+      /** @internal */
+      '~rendering-error'?: boolean
     }
   }
 }

--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -73,7 +73,7 @@ const handler: ReturnType<typeof defineEventHandler> = defineEventHandler((event
     const renderingURL = event.url.pathname + event.url.search
     const stack = prerenderRenderingURLs.getStore()
     if (stack?.includes(renderingURL)) {
-      const chain = [...stack, renderingURL].map(url => `"${url}"`).join(' -> ')
+      const chain = [...stack, renderingURL].filter(url => !url.startsWith('/__nuxt_error')).map(url => `"${url}"`).join(' -> ')
       throw new HTTPError({
         status: 508,
         statusText: `Loop detected while prerendering "${renderingURL}" (${chain}). Check for \`useFetch\`/\`$fetch\` calls targeting a URL that is currently being rendered.`,

--- a/packages/nitro-server/src/runtime/utils/cache.ts
+++ b/packages/nitro-server/src/runtime/utils/cache.ts
@@ -5,11 +5,8 @@ import { useStorage } from 'nitro/storage'
 import { NUXT_RUNTIME_PAYLOAD_EXTRACTION, NUXT_SHARED_DATA } from '#internal/nuxt/nitro-config.mjs'
 
 /**
- * Async-context-scoped stack of URLs the current request is rendering, oldest
- * first. Maintained by the renderer handler. A given URL appears more than
- * once in the stack only if a recursive render of it is in progress, which
- * indicates a cycle (e.g. `useFetch` in middleware against the URL it is
- * currently rendering). See https://github.com/nuxt/nuxt/issues/33871
+ * Stack of URLs currently rendering in the active async context (oldest first).
+ * A repeated entry signals a render cycle.
  */
 export const prerenderRenderingURLs: AsyncLocalStorage<readonly string[]> | null = import.meta.prerender ? new AsyncLocalStorage() : null
 
@@ -23,9 +20,8 @@ export const islandPropCache: Storage | null = import.meta.prerender ? useStorag
 export const sharedPrerenderPromises: Map<string, Promise<any>> | null = import.meta.prerender && NUXT_SHARED_DATA ? new Map<string, Promise<any>>() : null
 
 const sharedPrerenderKeys = new Set<string>()
-// Render-chain (snapshot of `prerenderRenderingURLs.getStore()`) captured when
-// each pending shared promise was inserted. Used to detect cycles where a
-// `get()` from inside that chain would create a cyclic await.
+// Render chain in flight when each pending shared promise was inserted,
+// used to detect cyclic awaits in `get()`.
 const sharedPrerenderChains: Map<string, readonly string[]> | null = import.meta.prerender && NUXT_SHARED_DATA ? new Map() : null
 
 interface SharedPrerenderCache {
@@ -38,11 +34,7 @@ export const sharedPrerenderCache: SharedPrerenderCache | null = import.meta.pre
       get<T = unknown> (key: string): Promise<T> | undefined {
         if (!sharedPrerenderKeys.has(key)) { return }
 
-        // Detect recursive prerender cycles where returning the cached pending
-        // promise would create a cyclic await: if any URL the cached promise
-        // is part of the chain for is also in the requestor's current chain,
-        // the cached promise's resolution may depend on the requestor.
-        // See https://github.com/nuxt/nuxt/issues/33871
+        // Skip a pending entry whose render chain overlaps the caller's.
         const currentChain = prerenderRenderingURLs?.getStore()
         const setChain = sharedPrerenderChains?.get(key)
         if (currentChain?.length && setChain?.length && setChain.some(url => currentChain.includes(url))) {
@@ -61,8 +53,7 @@ export const sharedPrerenderCache: SharedPrerenderCache | null = import.meta.pre
           const resolved = await value
           await useStorage('internal:nuxt:prerender:shared').setItem(key, resolved as any)
         } catch {
-          // Errors are surfaced via the original promise (returned to the caller
-          // through `get`); the shared cache itself only persists resolved values.
+          // Rejections propagate through the original promise; only resolved values are persisted.
         } finally {
           sharedPrerenderPromises!.delete(key)
           sharedPrerenderChains?.delete(key)

--- a/packages/nitro-server/src/runtime/utils/cache.ts
+++ b/packages/nitro-server/src/runtime/utils/cache.ts
@@ -1,7 +1,17 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
 import type { Storage, StorageValue } from 'unstorage'
 import { useStorage } from 'nitro/storage'
 // @ts-expect-error virtual file
 import { NUXT_RUNTIME_PAYLOAD_EXTRACTION, NUXT_SHARED_DATA } from '#internal/nuxt/nitro-config.mjs'
+
+/**
+ * Async-context-scoped stack of URLs the current request is rendering, oldest
+ * first. Maintained by the renderer handler. A given URL appears more than
+ * once in the stack only if a recursive render of it is in progress, which
+ * indicates a cycle (e.g. `useFetch` in middleware against the URL it is
+ * currently rendering). See https://github.com/nuxt/nuxt/issues/33871
+ */
+export const prerenderRenderingURLs: AsyncLocalStorage<readonly string[]> | null = import.meta.prerender ? new AsyncLocalStorage() : null
 
 export const payloadCache: Storage | null = import.meta.prerender
   ? useStorage<StorageValue>('internal:nuxt:prerender:payload')
@@ -13,6 +23,10 @@ export const islandPropCache: Storage | null = import.meta.prerender ? useStorag
 export const sharedPrerenderPromises: Map<string, Promise<any>> | null = import.meta.prerender && NUXT_SHARED_DATA ? new Map<string, Promise<any>>() : null
 
 const sharedPrerenderKeys = new Set<string>()
+// Render-chain (snapshot of `prerenderRenderingURLs.getStore()`) captured when
+// each pending shared promise was inserted. Used to detect cycles where a
+// `get()` from inside that chain would create a cyclic await.
+const sharedPrerenderChains: Map<string, readonly string[]> | null = import.meta.prerender && NUXT_SHARED_DATA ? new Map() : null
 
 interface SharedPrerenderCache {
   get<T = unknown>(key: string): Promise<T> | undefined
@@ -22,16 +36,37 @@ interface SharedPrerenderCache {
 export const sharedPrerenderCache: SharedPrerenderCache | null = import.meta.prerender && NUXT_SHARED_DATA
   ? {
       get<T = unknown> (key: string): Promise<T> | undefined {
-        if (sharedPrerenderKeys.has(key)) {
-          return sharedPrerenderPromises!.get(key) ?? useStorage('internal:nuxt:prerender:shared').getItem(key) as Promise<T>
+        if (!sharedPrerenderKeys.has(key)) { return }
+
+        // Detect recursive prerender cycles where returning the cached pending
+        // promise would create a cyclic await: if any URL the cached promise
+        // is part of the chain for is also in the requestor's current chain,
+        // the cached promise's resolution may depend on the requestor.
+        // See https://github.com/nuxt/nuxt/issues/33871
+        const currentChain = prerenderRenderingURLs?.getStore()
+        const setChain = sharedPrerenderChains?.get(key)
+        if (currentChain?.length && setChain?.length && setChain.some(url => currentChain.includes(url))) {
+          return
         }
+        return sharedPrerenderPromises!.get(key) ?? useStorage('internal:nuxt:prerender:shared').getItem(key) as Promise<T>
       },
       async set<T> (key: string, value: Promise<T>): Promise<void> {
         sharedPrerenderKeys.add(key)
         sharedPrerenderPromises!.set(key, value)
-        useStorage('internal:nuxt:prerender:shared').setItem(key, await value as any)
-        // free up memory after the promise is resolved
-          .finally(() => sharedPrerenderPromises!.delete(key))
+        const chain = prerenderRenderingURLs?.getStore()
+        if (chain?.length) {
+          sharedPrerenderChains!.set(key, chain)
+        }
+        try {
+          const resolved = await value
+          await useStorage('internal:nuxt:prerender:shared').setItem(key, resolved as any)
+        } catch {
+          // Errors are surfaced via the original promise (returned to the caller
+          // through `get`); the shared cache itself only persists resolved values.
+        } finally {
+          sharedPrerenderPromises!.delete(key)
+          sharedPrerenderChains?.delete(key)
+        }
       },
     }
   : null

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -669,6 +669,12 @@ describe('pages', () => {
     expect(b).toContain('loop-shared-b ok')
   })
 
+  // https://github.com/nuxt/nuxt/issues/33871 - bare $fetch path (no useFetch / shared cache).
+  it.skipIf(isDev)('prerenders pages whose middleware calls $fetch against the same URL', async () => {
+    const html = await $fetch<string>('/prerender/loop-bare-fetch')
+    expect(html).toContain('loop-bare-fetch ok')
+  })
+
   it('renders unicode routes correctly', async () => {
     const html = await $fetch('/random/日本語')
     expect(html).toContain('Japanese random route')

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -653,6 +653,22 @@ describe('pages', () => {
     expect(html).toContain('should be prerendered: true')
   })
 
+  // https://github.com/nuxt/nuxt/issues/33871
+  it.skipIf(isDev)('prerenders pages whose middleware calls useFetch against the same URL', async () => {
+    const html = await $fetch<string>('/prerender/loop-self')
+    expect(html).toContain('loop-self ok')
+  })
+
+  // https://github.com/nuxt/nuxt/issues/33871
+  it.skipIf(isDev)('prerenders parallel pages whose middleware shares a useFetch key against an unhandled URL', async () => {
+    const [a, b] = await Promise.all([
+      $fetch<string>('/prerender/loop-shared-a'),
+      $fetch<string>('/prerender/loop-shared-b'),
+    ])
+    expect(a).toContain('loop-shared-a ok')
+    expect(b).toContain('loop-shared-b ok')
+  })
+
   it('renders unicode routes correctly', async () => {
     const html = await $fetch('/random/日本語')
     expect(html).toContain('Japanese random route')

--- a/test/fixtures/basic/app/middleware/prerender-loop.global.ts
+++ b/test/fixtures/basic/app/middleware/prerender-loop.global.ts
@@ -1,13 +1,25 @@
 export default defineNuxtRouteMiddleware(async (to) => {
   // Regression for https://github.com/nuxt/nuxt/issues/33871
-  // The build used to silently fail when middleware called `useFetch` against
-  // a path that fell through to the renderer during prerender (creating a
-  // recursive render of the same URL). Both code paths (`sharedPrerenderData`
-  // dedup hit and miss) need to succeed.
+  // The build used to silently fail when a fetch during prerender caused the
+  // renderer to recurse into itself for the same URL. Three shapes are
+  // covered:
+  //  - `useFetch` self-recursion (exercises both renderer guard and shared
+  //    cache cycle detection)
+  //  - `useFetch` with a shared key from sibling prerendered pages (exercises
+  //    the parallel `sharedPrerenderData` path)
+  //  - bare `$fetch` self-recursion (exercises the renderer guard alone, no
+  //    `~sharedPrerenderCache` involvement)
   if (to.path === '/prerender/loop-self') {
     await useFetch('/prerender/loop-self')
   }
   if (to.path === '/prerender/loop-shared-a' || to.path === '/prerender/loop-shared-b') {
     await useFetch('/prerender/loop-shared-target', { key: 'prerender-loop-shared' })
+  }
+  if (to.path === '/prerender/loop-bare-fetch') {
+    try {
+      await $fetch('/prerender/loop-bare-fetch')
+    } catch {
+      // expected: 508 Loop Detected from the renderer guard
+    }
   }
 })

--- a/test/fixtures/basic/app/middleware/prerender-loop.global.ts
+++ b/test/fixtures/basic/app/middleware/prerender-loop.global.ts
@@ -1,0 +1,13 @@
+export default defineNuxtRouteMiddleware(async (to) => {
+  // Regression for https://github.com/nuxt/nuxt/issues/33871
+  // The build used to silently fail when middleware called `useFetch` against
+  // a path that fell through to the renderer during prerender (creating a
+  // recursive render of the same URL). Both code paths (`sharedPrerenderData`
+  // dedup hit and miss) need to succeed.
+  if (to.path === '/prerender/loop-self') {
+    await useFetch('/prerender/loop-self')
+  }
+  if (to.path === '/prerender/loop-shared-a' || to.path === '/prerender/loop-shared-b') {
+    await useFetch('/prerender/loop-shared-target', { key: 'prerender-loop-shared' })
+  }
+})

--- a/test/fixtures/basic/app/middleware/prerender-loop.global.ts
+++ b/test/fixtures/basic/app/middleware/prerender-loop.global.ts
@@ -1,14 +1,6 @@
+// Regression fixtures for https://github.com/nuxt/nuxt/issues/33871: prerender
+// must not deadlock when a fetch re-enters a URL already in the render chain.
 export default defineNuxtRouteMiddleware(async (to) => {
-  // Regression for https://github.com/nuxt/nuxt/issues/33871
-  // The build used to silently fail when a fetch during prerender caused the
-  // renderer to recurse into itself for the same URL. Three shapes are
-  // covered:
-  //  - `useFetch` self-recursion (exercises both renderer guard and shared
-  //    cache cycle detection)
-  //  - `useFetch` with a shared key from sibling prerendered pages (exercises
-  //    the parallel `sharedPrerenderData` path)
-  //  - bare `$fetch` self-recursion (exercises the renderer guard alone, no
-  //    `~sharedPrerenderCache` involvement)
   if (to.path === '/prerender/loop-self') {
     await useFetch('/prerender/loop-self')
   }
@@ -19,7 +11,7 @@ export default defineNuxtRouteMiddleware(async (to) => {
     try {
       await $fetch('/prerender/loop-bare-fetch')
     } catch {
-      // expected: 508 Loop Detected from the renderer guard
+      // 508 Loop Detected — the renderer breaks the cycle so the build can finish.
     }
   }
 })

--- a/test/fixtures/basic/app/pages/prerender/loop-bare-fetch.vue
+++ b/test/fixtures/basic/app/pages/prerender/loop-bare-fetch.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>loop-bare-fetch ok</div>
+</template>

--- a/test/fixtures/basic/app/pages/prerender/loop-self.vue
+++ b/test/fixtures/basic/app/pages/prerender/loop-self.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>loop-self ok</div>
+</template>

--- a/test/fixtures/basic/app/pages/prerender/loop-shared-a.vue
+++ b/test/fixtures/basic/app/pages/prerender/loop-shared-a.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>loop-shared-a ok</div>
+</template>

--- a/test/fixtures/basic/app/pages/prerender/loop-shared-b.vue
+++ b/test/fixtures/basic/app/pages/prerender/loop-shared-b.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>loop-shared-b ok</div>
+</template>


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/33871

### 📚 Description

when a global route middleware called `useFetch` (or made a fetch request) that was resolved by a path that made the same request. in this instance, the build silently exited with code 0 and the affected page was missing from the output.

the issue was a cyclic await with `sharedPrenderData`

this PR detects these cyclical renders when prerendering, and throws a 508 error.

