### PR TITLE
fix(nitro): add `useRuntimeConfig` import

### DIFF
--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -175,6 +175,10 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
               from: resolve(distDir, 'runtime/utils/config'),
               priority: -1,
             },
+            {
+              name: 'useRuntimeConfig',
+              from: 'nitro/runtime-config',
+            },
           ],
           exclude: [...excludePattern, /[\\/]\.git[\\/]/],
         },


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Aims to fix `[MISSING_EXPORT] Error: "useRuntimeConfig" is not exported by "#imports"` rolldown error occuring for e.g. nuxt/scripts and nuxt/image.