### PR TITLE
docs: add examples for typescript.tsConfig and typescript.nodeTsConfi…

### DIFF
--- a/docs/3.guide/1.concepts/8.typescript.md
+++ b/docs/3.guide/1.concepts/8.typescript.md
@@ -109,13 +109,12 @@ By default, Nuxt only type-checks files within its standard directories (such as
 
 To include these files, you need to extend the relevant TypeScript configuration in your Nuxt config. The configuration you choose depends on the context your files require:
 
-- **Nuxt app context** — For files that import from Vue, Nuxt, or use auto-imported composables (e.g., test files using `mount()` or `useNuxtApp()`). Extend [`typescript.tsConfig`](/docs/4.x/api/nuxt-config#tsconfig).
+- **Nuxt app context** — For files that import from Vue, Nuxt, or use auto-imported composables (e.g., test files using `mount()` or `useNuxtApp()`). Extend [`typescript.TSConfig`](/docs/4.x/api/nuxt-config#tsconfig).
 - **Node context** — For files that only use plain TypeScript/Node.js APIs and do not depend on Nuxt-specific features (e.g., build scripts, configuration utilities). Extend [`typescript.nodeTsConfig`](/docs/4.x/api/nuxt-config#nodetsconfig).
 
 ::read-more{to="/docs/4.x/getting-started/testing#typescript-support-in-tests"}
 For test-specific examples, see TypeScript Support in Tests.
 ::
-
 
 ## Strict Checks
 

--- a/docs/3.guide/1.concepts/8.typescript.md
+++ b/docs/3.guide/1.concepts/8.typescript.md
@@ -103,6 +103,20 @@ Similarly:
 Read more about augmenting specific type contexts from **files outside those contexts** in the Module Author Guide.
 ::
 
+## Including Custom Files in Type-Checking
+
+By default, Nuxt only type-checks files within its standard directories (such as `app/`, `server/`, and `shared/`). If you have custom files in other directories — for example, test files in a `tests/` directory at your project root — they will not be automatically included in type-checking.
+
+To include these files, you need to extend the relevant TypeScript configuration in your Nuxt config. The configuration you choose depends on the context your files require:
+
+- **Nuxt app context** — For files that import from Vue, Nuxt, or use auto-imported composables (e.g., test files using `mount()` or `useNuxtApp()`). Extend [`typescript.tsConfig`](/docs/4.x/api/nuxt-config#tsconfig).
+- **Node context** — For files that only use plain TypeScript/Node.js APIs and do not depend on Nuxt-specific features (e.g., build scripts, configuration utilities). Extend [`typescript.nodeTsConfig`](/docs/4.x/api/nuxt-config#nodetsconfig).
+
+::read-more{to="/docs/4.x/getting-started/testing#typescript-support-in-tests"}
+For test-specific examples, see TypeScript Support in Tests.
+::
+
+
 ## Strict Checks
 
 TypeScript comes with certain checks to give you more safety and analysis of your program.

--- a/docs/3.guide/1.concepts/8.typescript.md
+++ b/docs/3.guide/1.concepts/8.typescript.md
@@ -109,11 +109,14 @@ By default, Nuxt only type-checks files within its standard directories (such as
 
 To include these files, you need to extend the relevant TypeScript configuration in your Nuxt config. The configuration you choose depends on the context your files require:
 
-- **Nuxt app context** — For files that import from Vue, Nuxt, or use auto-imported composables (e.g., test files using `mount()` or `useNuxtApp()`). Extend [`typescript.TSConfig`](/docs/4.x/api/nuxt-config#tsconfig).
+<!-- @case-police-ignore tsConfig -->
+- **Nuxt app context** — For files that import from Vue, Nuxt, or use auto-imported composables (e.g., test files using `mount()` or `useNuxtApp()`). Extend [`typescript.tsConfig`](/docs/4.x/api/nuxt-config#tsconfig).
 - **Node context** — For files that only use plain TypeScript/Node.js APIs and do not depend on Nuxt-specific features (e.g., build scripts, configuration utilities). Extend [`typescript.nodeTsConfig`](/docs/4.x/api/nuxt-config#nodetsconfig).
 
+You add these files by providing glob patterns to the `include` option in the relevant configuration.
+
 ::read-more{to="/docs/4.x/getting-started/testing#typescript-support-in-tests"}
-For test-specific examples, see TypeScript Support in Tests.
+For test-specific examples, see TypeScript support in tests.
 ::
 
 ## Strict Checks

--- a/docs/4.api/6.nuxt-config.md
+++ b/docs/4.api/6.nuxt-config.md
@@ -1544,6 +1544,36 @@ TypeScript comes with certain checks to give you more safety and analysis of you
 
 You can extend the generated TypeScript configurations (`.nuxt/tsconfig.app.json`, `.nuxt/tsconfig.server.json`, etc.) using this option.
 
+Use this option to include files that depend on the **Nuxt app context** (e.g., test files that import Vue or Nuxt composables).
+
+**Example**:
+```ts
+export default defineNuxtConfig({
+  typescript: {
+    tsConfig: {
+      include: ['../tests/**/*.ts'],
+    },
+  },
+})
+```
+
+### `nodeTsConfig`
+
+You can extend the Node TypeScript configuration (`.nuxt/tsconfig.node.json`) using this option.
+
+Use this option to include files that only depend on a **Node context** and do not use any Nuxt-specific features.
+
+**Example**:
+```ts
+export default defineNuxtConfig({
+  typescript: {
+    nodeTsConfig: {
+      include: ['../scripts/**/*.ts'],
+    },
+  },
+})
+```
+
 ### `typeCheck`
 
 Enable build-time type checking.

--- a/docs/4.api/6.nuxt-config.md
+++ b/docs/4.api/6.nuxt-config.md
@@ -1544,7 +1544,9 @@ TypeScript comes with certain checks to give you more safety and analysis of you
 
 You can extend the generated TypeScript configurations (`.nuxt/tsconfig.app.json`, `.nuxt/tsconfig.server.json`, etc.) using this option.
 
-Use this option to include files that depend on the **Nuxt app context** (e.g., test files that import Vue or Nuxt composables).
+#### `include`
+
+Use the `include` option to add glob patterns for files that depend on the **Nuxt app context** — for example, test files that import Vue or Nuxt composables. Patterns are resolved relative to the generated `.nuxt/` directory (e.g., `../tests/**/*.ts` refers to a `tests/` folder at your project root).
 
 **Example**:
 ```ts
@@ -1561,7 +1563,9 @@ export default defineNuxtConfig({
 
 You can extend the Node TypeScript configuration (`.nuxt/tsconfig.node.json`) using this option.
 
-Use this option to include files that only depend on a **Node context** and do not use any Nuxt-specific features.
+#### `include`
+
+Use the `include` option to add glob patterns for files that only depend on a **Node context** and do not use any Nuxt-specific features — for example, build scripts or configuration utilities. Patterns are resolved relative to the generated `.nuxt/` directory (e.g., `../scripts/**/*.ts` refers to a `scripts/` folder at your project root).
 
 **Example**:
 ```ts


### PR DESCRIPTION
### 🔗 Linked issue

resolves #34756

### 📚 Description

Adds documentation for how to include custom files in type-checking, as requested by @danielroe in the issue.

**Changes:**

- **`docs/4.api/6.nuxt-config.md`** — Added usage examples for `typescript.tsConfig` and `typescript.nodeTsConfig`, with guidance on when to use each option.

- **`docs/3.guide/1.concepts/8.typescript.md`** — Added a new "Including Custom Files in Type-Checking" section after`## Project References`, explaining that files outside standard directories (e.g., `tests/`) are not type-checked by default and how to include them using the relevant config option, with links to the API reference.
