### PR TITLE
fix(nuxt): only force suspense remount after first resolve

### DIFF
--- a/packages/nuxt/src/pages/runtime/page.ts
+++ b/packages/nuxt/src/pages/runtime/page.ts
@@ -68,6 +68,7 @@ export default defineComponent({
 
     const done = nuxtApp.deferHydration()
     let isSuspensePending = false
+    let hasResolvedOnce = false
     let suspenseKey = 0
     if (import.meta.client && nuxtApp.isHydrating) {
       const removeErrorHook = nuxtApp.hooks.hookOnce('app:error', done)
@@ -154,9 +155,9 @@ export default defineComponent({
                 })
               }
 
-              // force suspense remount and restart async tracking
-              // if suspense is already pending and page key changed
-              if (isSuspensePending && previousPageKey !== key) {
+              // remount suspense on rapid navigation, but not before the first resolve:
+              // tearing down a never-resolved suspensible Suspense strands its parent. See #28425, #34683.
+              if (isSuspensePending && previousPageKey !== key && hasResolvedOnce) {
                 suspenseKey++
               }
 
@@ -193,6 +194,7 @@ export default defineComponent({
                   },
                   onResolve: async () => {
                     isSuspensePending = false
+                    hasResolvedOnce = true
                     try {
                       await nextTick()
                       nuxtApp._route.sync?.()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1378,6 +1378,16 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
 
+  test/fixtures/suspense-layout:
+    dependencies:
+      nuxt:
+        specifier: workspace:*
+        version: link:../../../packages/nuxt
+    devDependencies:
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+
 packages:
 
   '@actions/core@3.0.0':
@@ -9195,6 +9205,9 @@ packages:
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
 
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+
   ultrahtml@1.6.0:
     resolution: {integrity: sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw==}
 
@@ -11248,7 +11261,7 @@ snapshots:
       remark-stringify: 11.0.0
       scule: 1.3.0
       shiki: 4.0.2
-      ufo: 1.6.3
+      ufo: 1.6.4
       unified: 11.0.5
       unist-builder: 4.0.0
       unist-util-visit: 5.1.0
@@ -18407,6 +18420,8 @@ snapshots:
   uc.micro@2.1.0: {}
 
   ufo@1.6.3: {}
+
+  ufo@1.6.4: {}
 
   ultrahtml@1.6.0: {}
 

--- a/test/e2e/suspense-layout.test.ts
+++ b/test/e2e/suspense-layout.test.ts
@@ -1,0 +1,64 @@
+import { fileURLToPath } from 'node:url'
+import { isWindows } from 'std-env'
+import { join } from 'pathe'
+import { expect, test } from './test-utils'
+import { isDev } from '../matrix'
+
+/**
+ * Regression coverage for two interacting suspense bugs:
+ *  - #34683: `await navigateTo()` from a page in layout A to a page in layout B
+ *    leaves the URL updated but the DOM stuck on the old page.
+ *  - #28425: rapid navigation between `useAsyncData`-bound pages within the same
+ *    layout must not get stuck. Prior to the fix for #34683 a coarser gate would
+ *    have re-introduced this regression for layout-wrapped apps.
+ */
+
+const fixtureDir = fileURLToPath(new URL('../fixtures/suspense-layout', import.meta.url))
+
+test.describe.configure({ mode: isDev ? 'serial' : 'parallel' })
+
+test.use({
+  nuxt: {
+    rootDir: fixtureDir,
+    dev: isDev,
+    server: true,
+    browser: true,
+    setupTimeout: (isWindows ? 360 : 120) * 1000,
+    nuxtConfig: {
+      buildDir: isDev ? join(fixtureDir, '.nuxt', 'test', Math.random().toString(36).slice(2, 8)) : undefined,
+    },
+  },
+})
+
+test.describe('Suspense navigation with layout change', () => {
+  test('completes when redirect crosses layout boundary (#34683)', async ({ page, goto }) => {
+    await goto('/')
+
+    await expect(page.getByTestId('index-title')).toBeVisible()
+    await expect(page.getByTestId('alternate-layout')).toBeVisible()
+
+    await page.getByTestId('link-redirect').click()
+
+    await expect(page.getByTestId('target-content')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByTestId('default-layout')).toBeVisible()
+    await expect(page.getByTestId('index-title')).not.toBeVisible()
+
+    expect(page).toHaveNoErrorsOrWarnings()
+  })
+
+  test('rapid navigation across useAsyncData pages settles on final route (#28425)', async ({ page, goto }) => {
+    await goto('/asyncdata/p0')
+    await expect(page.getByTestId('asyncdata-p0')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByTestId('default-layout')).toBeVisible()
+
+    await page.getByTestId('link-async-p1').dispatchEvent('click')
+    await page.getByTestId('link-async-p2').dispatchEvent('click')
+    await page.getByTestId('link-async-p3').dispatchEvent('click')
+
+    await page.waitForFunction(() => window.useNuxtApp?.()._route.path === '/asyncdata/p3')
+    await expect(page.getByTestId('asyncdata-p3')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByTestId('default-layout')).toBeVisible()
+
+    expect(page).toHaveNoErrorsOrWarnings()
+  })
+})

--- a/test/fixtures/suspense-layout/app.vue
+++ b/test/fixtures/suspense-layout/app.vue
@@ -1,0 +1,5 @@
+<template>
+  <NuxtLayout>
+    <NuxtPage />
+  </NuxtLayout>
+</template>

--- a/test/fixtures/suspense-layout/layouts/alternate.vue
+++ b/test/fixtures/suspense-layout/layouts/alternate.vue
@@ -1,0 +1,5 @@
+<template>
+  <div data-testid="alternate-layout">
+    <slot />
+  </div>
+</template>

--- a/test/fixtures/suspense-layout/layouts/default.vue
+++ b/test/fixtures/suspense-layout/layouts/default.vue
@@ -1,0 +1,6 @@
+<template>
+  <div data-testid="default-layout">
+    <header>Default Layout</header>
+    <slot />
+  </div>
+</template>

--- a/test/fixtures/suspense-layout/nuxt.config.ts
+++ b/test/fixtures/suspense-layout/nuxt.config.ts
@@ -1,0 +1,7 @@
+import { withMatrix } from '../../matrix'
+
+export default withMatrix({
+  routeRules: {
+    '/': { appLayout: 'alternate' },
+  },
+})

--- a/test/fixtures/suspense-layout/package.json
+++ b/test/fixtures/suspense-layout/package.json
@@ -1,0 +1,16 @@
+{
+  "private": true,
+  "name": "fixture-suspense-layout",
+  "scripts": {
+    "build": "nuxt build"
+  },
+  "dependencies": {
+    "nuxt": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "5.9.3"
+  },
+  "engines": {
+    "node": "^20.19.0 || >=22.12.0"
+  }
+}

--- a/test/fixtures/suspense-layout/pages/asyncdata/[slug].vue
+++ b/test/fixtures/suspense-layout/pages/asyncdata/[slug].vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+const route = useRoute()
+const { data } = await useAsyncData(`asyncdata-${route.params.slug}`, async () => {
+  await new Promise(resolve => setTimeout(resolve, 200))
+  return { slug: route.params.slug }
+}, { watch: [() => route.params.slug] })
+</script>
+
+<template>
+  <div :data-testid="`asyncdata-${data?.slug}`">
+    <p>Async slug: {{ data?.slug }}</p>
+    <NuxtLink
+      to="/asyncdata/p1"
+      data-testid="link-async-p1"
+    >
+      p1
+    </NuxtLink>
+    <NuxtLink
+      to="/asyncdata/p2"
+      data-testid="link-async-p2"
+    >
+      p2
+    </NuxtLink>
+    <NuxtLink
+      to="/asyncdata/p3"
+      data-testid="link-async-p3"
+    >
+      p3
+    </NuxtLink>
+  </div>
+</template>

--- a/test/fixtures/suspense-layout/pages/index.vue
+++ b/test/fixtures/suspense-layout/pages/index.vue
@@ -1,0 +1,19 @@
+<template>
+  <div>
+    <h1 data-testid="index-title">
+      Index Page
+    </h1>
+    <NuxtLink
+      to="/redirect"
+      data-testid="link-redirect"
+    >
+      Go via redirect
+    </NuxtLink>
+    <NuxtLink
+      to="/asyncdata/p0"
+      data-testid="link-async-start"
+    >
+      Async p0
+    </NuxtLink>
+  </div>
+</template>

--- a/test/fixtures/suspense-layout/pages/redirect.vue
+++ b/test/fixtures/suspense-layout/pages/redirect.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+await navigateTo('/target')
+</script>
+
+<template>
+  <div data-testid="redirect-page">
+    Redirecting...
+  </div>
+</template>

--- a/test/fixtures/suspense-layout/pages/target.vue
+++ b/test/fixtures/suspense-layout/pages/target.vue
@@ -1,0 +1,5 @@
+<template>
+  <div data-testid="target-content">
+    Target Page
+  </div>
+</template>

--- a/test/fixtures/suspense-layout/tsconfig.json
+++ b/test/fixtures/suspense-layout/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./.nuxt/tsconfig.app.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.server.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.shared.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.node.json"
+    }
+  ]
+}


### PR DESCRIPTION
### 🔗 Linked issue

closes https://github.com/nuxt/nuxt/pull/34684
resolves https://github.com/nuxt/nuxt/issues/34683

### 📚 Description

this aims to resolve issues with 'stuck' layouts by only tearing down a Suspense that has resolved successfully - which is a more minimal fix than https://github.com/nuxt/nuxt/pull/34684 which effectively reverts https://github.com/nuxt/nuxt/pull/33991 when used with layouts

(previously the issue was that a torn-down Suspense would strand any parent Suspense with `suspensible`)