### PR TITLE
fix(vite): drop redundant css link when entry styles are inlined

### DIFF
--- a/packages/vite/src/plugins/ssr-styles.ts
+++ b/packages/vite/src/plugins/ssr-styles.ts
@@ -21,7 +21,16 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
   if (nuxt.options.dev) { return }
 
   const chunksWithInlinedCSS = new Set<string>()
+  // CSS source module ids (with `?...` query stripped) whose styles were
+  // successfully inlined into the SSR response
+  const inlinedCSSModuleIds = new Set<string>()
+  // For each output chunk that originates from a source file, the set of CSS
+  // source module ids (no query) vite/rolldown bundled into that chunk's CSS
+  // asset. Keyed by the manifest source path (`chunk.src`).
+  const cssSourcesByChunkSrc = new Map<string, Set<string>>()
   const clientCSSMap: Record<string, Set<string>> = {}
+
+  const stripQuery = (id: string) => id.replace(QUERY_RE, '')
 
   // Remove CSS entries for files that will have inlined styles
   const nitro = useNitro()
@@ -54,6 +63,25 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
             }
           }
         }
+      }
+    }
+
+    // Drop a chunk's bundled CSS link when every CSS source module bundled into
+    // that chunk has already been inlined as a `<style>` tag during SSR. This
+    // prevents duplicate styles when `inlineStyles` is enabled. (#30435)
+    for (const chunk of Object.values(manifest)) {
+      if (!chunk.css?.length || !chunk.src) { continue }
+      const cssSources = cssSourcesByChunkSrc.get(chunk.src)
+      if (!cssSources?.size) { continue }
+      let allInlined = true
+      for (const cssId of cssSources) {
+        if (!inlinedCSSModuleIds.has(cssId)) {
+          allInlined = false
+          break
+        }
+      }
+      if (allInlined) {
+        chunk.css = []
       }
     }
 
@@ -195,12 +223,24 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
           if (isEntry) {
             clientCSSMap[chunk.facadeModuleId!] ||= new Set()
           }
+          let chunkCSSSources: Set<string> | undefined
+          if (environment.name === 'client' && chunk.facadeModuleId) {
+            const chunkSrc = relativeToSrcDir(chunk.facadeModuleId)
+            if (chunkSrc) {
+              chunkCSSSources = cssSourcesByChunkSrc.get(chunkSrc)
+              if (!chunkCSSSources) {
+                chunkCSSSources = new Set()
+                cssSourcesByChunkSrc.set(chunkSrc, chunkCSSSources)
+              }
+            }
+          }
           for (const moduleId of [chunk.facadeModuleId, ...chunk.moduleIds].filter(Boolean) as string[]) {
             // 'Teleport' CSS chunks that made it into the bundle on the client side
             // to be inlined on server rendering
             if (environment.name === 'client') {
               const moduleMap = clientCSSMap[moduleId] ||= new Set()
               if (isCSS(moduleId)) {
+                chunkCSSSources?.add(stripQuery(moduleId))
                 // Vue files can (also) be their own entrypoints as they are tracked separately
                 if (isVue(moduleId)) {
                   moduleMap.add(moduleId)
@@ -255,6 +295,7 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
                     continue
                   }
                   idClientCSSMap.add(resolved.id)
+                  inlinedCSSModuleIds.add(stripQuery(resolved.id))
                 }
                 if (s.hasChanged()) {
                   return {
@@ -297,6 +338,7 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
                 continue
               }
               emittedIds.add(file)
+              inlinedCSSModuleIds.add(stripQuery(resolved.id))
 
               // Reuse ref from a previous emission of the same file to avoid rolldown
               // returning incorrect refs when the same chunk ID is emitted multiple times
@@ -332,6 +374,7 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
               }
 
               if (emittedIds.has(resolved.id)) { continue }
+              inlinedCSSModuleIds.add(stripQuery(resolved.id))
 
               // Reuse ref from a previous emission of the same file
               const resolvedInlineId = res.id

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1332,6 +1332,12 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/nuxt
 
+  test/fixtures/inline-styles-dedupe:
+    dependencies:
+      nuxt:
+        specifier: workspace:*
+        version: link:../../../packages/nuxt
+
   test/fixtures/lazy-hydration:
     dependencies:
       nuxt:

--- a/test/fixtures/inline-styles-dedupe/app.vue
+++ b/test/fixtures/inline-styles-dedupe/app.vue
@@ -1,0 +1,11 @@
+<template>
+  <div class="dedupe-app">
+    <NuxtPage />
+  </div>
+</template>
+
+<style scoped>
+.dedupe-app {
+  --inline-app-token: app;
+}
+</style>

--- a/test/fixtures/inline-styles-dedupe/nuxt.config.ts
+++ b/test/fixtures/inline-styles-dedupe/nuxt.config.ts
@@ -10,8 +10,10 @@ const projectSuffix = [
   process.env.TEST_MANIFEST,
 ].filter(Boolean).join('-') || 'default'
 
+const isPrepare = process.argv.slice(2).includes('prepare')
+
 export default withMatrix({
-  buildDir: `.nuxt-${projectSuffix}`,
+  ...(isPrepare ? {} : { buildDir: `.nuxt-${projectSuffix}` }),
   sourcemap: false,
   nitro: {
     output: {

--- a/test/fixtures/inline-styles-dedupe/nuxt.config.ts
+++ b/test/fixtures/inline-styles-dedupe/nuxt.config.ts
@@ -1,0 +1,21 @@
+import { withMatrix } from '../../matrix'
+
+// Regression for https://github.com/nuxt/nuxt/issues/30435: when every CSS
+// module bundled into a chunk's CSS asset has also been inlined as a `<style>`
+// tag during SSR, the duplicate stylesheet `<link>` should be dropped.
+const projectSuffix = [
+  process.env.TEST_BUILDER,
+  process.env.TEST_ENV,
+  process.env.TEST_CONTEXT,
+  process.env.TEST_MANIFEST,
+].filter(Boolean).join('-') || 'default'
+
+export default withMatrix({
+  buildDir: `.nuxt-${projectSuffix}`,
+  sourcemap: false,
+  nitro: {
+    output: {
+      dir: `.output-${projectSuffix}`,
+    },
+  },
+})

--- a/test/fixtures/inline-styles-dedupe/package.json
+++ b/test/fixtures/inline-styles-dedupe/package.json
@@ -6,5 +6,8 @@
   },
   "dependencies": {
     "nuxt": "workspace:*"
+  },
+  "engines": {
+    "node": "^20.19.0 || >=22.12.0"
   }
 }

--- a/test/fixtures/inline-styles-dedupe/package.json
+++ b/test/fixtures/inline-styles-dedupe/package.json
@@ -1,0 +1,10 @@
+{
+  "private": true,
+  "name": "fixture-inline-styles-dedupe",
+  "scripts": {
+    "build": "nuxt build"
+  },
+  "dependencies": {
+    "nuxt": "workspace:*"
+  }
+}

--- a/test/fixtures/inline-styles-dedupe/pages/about.vue
+++ b/test/fixtures/inline-styles-dedupe/pages/about.vue
@@ -1,0 +1,11 @@
+<template>
+  <main class="page-about">
+    about page
+  </main>
+</template>
+
+<style scoped>
+.page-about {
+  --inline-page-about-token: about;
+}
+</style>

--- a/test/fixtures/inline-styles-dedupe/pages/index.vue
+++ b/test/fixtures/inline-styles-dedupe/pages/index.vue
@@ -1,0 +1,11 @@
+<template>
+  <main class="page-index">
+    index page
+  </main>
+</template>
+
+<style scoped>
+.page-index {
+  --inline-page-index-token: index;
+}
+</style>

--- a/test/fixtures/inline-styles-dedupe/tsconfig.json
+++ b/test/fixtures/inline-styles-dedupe/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./.nuxt/tsconfig.app.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.server.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.shared.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.node.json"
+    }
+  ]
+}

--- a/test/inline-styles.test.ts
+++ b/test/inline-styles.test.ts
@@ -1,0 +1,38 @@
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { beforeAll, describe, expect, it } from 'vitest'
+import { exec } from 'tinyexec'
+import { join } from 'pathe'
+import { builder, isBuilt } from './matrix'
+
+describe.skipIf(builder !== 'vite' || !isBuilt)('inline styles dedupe (#30435)', () => {
+  const rootDir = fileURLToPath(new URL('./fixtures/inline-styles-dedupe', import.meta.url))
+
+  beforeAll(async () => {
+    const result = await exec('pnpm', ['nuxt', 'generate', rootDir])
+    if (result.exitCode !== 0) {
+      throw new Error(`nuxt generate failed:\n${result.stderr}\n${result.stdout}`)
+    }
+  }, 120 * 1000)
+
+  const projectSuffix = [
+    process.env.TEST_BUILDER,
+    process.env.TEST_ENV,
+    process.env.TEST_CONTEXT,
+    process.env.TEST_MANIFEST,
+  ].filter(Boolean).join('-') || 'default'
+  const outputDir = join(rootDir, `.output-${projectSuffix}`)
+
+  it.each([
+    ['/', 'index', '--inline-app-token:app', '--inline-page-index-token:index'],
+    ['/about', 'about', '--inline-app-token:app', '--inline-page-about-token:about'],
+  ])('drops duplicate stylesheet links for %s when its CSS is fully inlined', async (route, page, ...tokens) => {
+    const html = await readFile(join(outputDir, 'public', route === '/' ? 'index.html' : `${page}/index.html`), 'utf-8')
+    for (const token of tokens) {
+      expect(html, page).toContain(token)
+    }
+
+    const cssLinks = [...html.matchAll(/<link [^>]*rel="stylesheet"[^>]*href="([^"]+)"/g)].map(m => m[1]!)
+    expect(cssLinks, page).toEqual([])
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

resolves #30435
closes https://github.com/nuxt/nuxt/pull/34008

### 📚 Description

previously, when inlining styles, the entry chunk css would still be listed in `chunk.css`, duplicating styles

this pr drops `chunk.css` if every module in that chunk has been inlined. it differs from https://github.com/nuxt/nuxt/pull/34008 not changing the behaviour of `resolveId` (ie side effect behaviour), and handling non-entry chunks where every CSS source is inlined

thoughts welcome @onmax 🙏 