### PR TITLE
fix(kit): read `.env` before resolving nuxt schema

### DIFF
--- a/packages/kit/src/loader/config.ts
+++ b/packages/kit/src/loader/config.ts
@@ -3,7 +3,7 @@ import process from 'node:process'
 import type { JSValue } from 'untyped'
 import { applyDefaults } from 'untyped'
 import type { ConfigLayer, ConfigLayerMeta, LoadConfigOptions } from 'c12'
-import { loadConfig } from 'c12'
+import { loadConfig, setupDotenv } from 'c12'
 import type { NuxtConfig, NuxtOptions } from '@nuxt/schema'
 import { glob } from 'tinyglobby'
 import { createDefu, defu } from 'defu'
@@ -34,6 +34,14 @@ export async function loadNuxtConfig (opts: LoadNuxtConfigOptions): Promise<Nuxt
     .sort((a, b) => b.localeCompare(a))
   opts.overrides = defu(opts.overrides, { _extends: localLayers })
 
+  // populate process.env before the schema imports its env-based defaults
+  if (opts.dotenv !== false) {
+    await setupDotenv({
+      cwd: opts.cwd || process.cwd(),
+      ...(typeof opts.dotenv === 'object' ? opts.dotenv : {}),
+    })
+  }
+
   const schemaPromise = loadNuxtSchema(opts.cwd || process.cwd())
 
   const { configFile, layers = [], cwd, config: nuxtConfig, meta } = await withDefineNuxtConfig(
@@ -42,11 +50,11 @@ export async function loadNuxtConfig (opts: LoadNuxtConfigOptions): Promise<Nuxt
       configFile: 'nuxt.config',
       rcFile: '.nuxtrc',
       extend: { extendKey: ['theme', '_extends', 'extends'] },
-      dotenv: true,
       globalRc: true,
       // @ts-expect-error TODO: fix type in c12, it should accept createDefu directly
       merger,
       ...opts,
+      dotenv: false, // already loaded above
     }),
   )
 

--- a/packages/kit/test/load-nuxt-config.spec.ts
+++ b/packages/kit/test/load-nuxt-config.spec.ts
@@ -46,15 +46,16 @@ describe('loadNuxtConfig', () => {
     `)
   })
 
-  describe('with .env file', () => {
-    const envKeys = ['NUXT_PORT', 'NUXT_HOST', 'NITRO_PORT', 'NITRO_HOST', 'PORT', 'HOST'] as const
+  describe('with NUXT_PORT/NUXT_HOST env vars', () => {
+    const envKeys = ['NUXT_PORT', 'NUXT_HOST'] as const
     const original: Record<string, string | undefined> = {}
 
     beforeEach(() => {
       for (const key of envKeys) {
         original[key] = process.env[key]
-        delete process.env[key]
       }
+      process.env.NUXT_PORT = '3005'
+      process.env.NUXT_HOST = '0.0.0.0'
     })
 
     afterEach(() => {
@@ -67,8 +68,11 @@ describe('loadNuxtConfig', () => {
       }
     })
 
-    it('should apply NUXT_PORT and NUXT_HOST from .env to devServer defaults', async () => {
-      const cwd = fileURLToPath(new URL('./dotenv-fixture', import.meta.url)).replace(/\\/g, '/')
+    // Regression test for #34955: env vars must be read at applyDefaults time,
+    // not at schema module-import time, since the schema is loaded in parallel
+    // with c12's loadConfig (which populates process.env from .env).
+    it('should apply NUXT_PORT and NUXT_HOST env vars to devServer defaults', async () => {
+      const cwd = fileURLToPath(new URL('./layer-fixture', import.meta.url)).replace(/\\/g, '/')
       const config = await loadNuxtConfig({ cwd })
       expect(config.devServer.port).toBe(3005)
       expect(config.devServer.host).toBe('0.0.0.0')

--- a/packages/kit/test/load-nuxt-config.spec.ts
+++ b/packages/kit/test/load-nuxt-config.spec.ts
@@ -1,8 +1,10 @@
 import process from 'node:process'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import { fileURLToPath } from 'node:url'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import { loadNuxtConfig } from '@nuxt/kit'
-import { basename } from 'pathe'
+import { basename, join } from 'pathe'
 
 describe('loadNuxtConfig', () => {
   it('should add named aliases for local layers', async () => {
@@ -46,34 +48,37 @@ describe('loadNuxtConfig', () => {
     `)
   })
 
-  describe('with NUXT_PORT/NUXT_HOST env vars', () => {
-    const envKeys = ['NUXT_PORT', 'NUXT_HOST'] as const
-    const original: Record<string, string | undefined> = {}
+  describe('with .env file', () => {
+    let tempDir: string
 
-    beforeEach(() => {
-      for (const key of envKeys) {
-        original[key] = process.env[key]
-      }
-      process.env.NUXT_PORT = '3005'
-      process.env.NUXT_HOST = '0.0.0.0'
+    beforeAll(async () => {
+      tempDir = await mkdtemp(join(tmpdir(), 'nuxt-loadConfig-'))
+      await writeFile(join(tempDir, '.env'), 'NUXT_PORT=3005\nNUXT_HOST=0.0.0.0\n')
     })
 
-    afterEach(() => {
-      for (const key of envKeys) {
-        if (original[key] === undefined) {
-          delete process.env[key]
-        } else {
-          process.env[key] = original[key]
+    afterAll(async () => {
+      delete process.env.NUXT_PORT
+      delete process.env.NUXT_HOST
+      vi.restoreAllMocks()
+      await rm(tempDir, { recursive: true, force: true })
+    })
+
+    it('should apply NUXT_PORT and NUXT_HOST from .env to devServer defaults', async () => {
+      vi.resetModules()
+      // delay c12 so the schema import wins the race (#34955 repro)
+      vi.doMock('c12', async () => {
+        const actual = await vi.importActual<typeof import('c12')>('c12')
+        return {
+          ...actual,
+          loadConfig: async (opts: Parameters<typeof actual.loadConfig>[0]) => {
+            await new Promise(resolve => setTimeout(resolve, 50))
+            return actual.loadConfig(opts)
+          },
         }
-      }
-    })
+      })
 
-    // Regression test for #34955: env vars must be read at applyDefaults time,
-    // not at schema module-import time, since the schema is loaded in parallel
-    // with c12's loadConfig (which populates process.env from .env).
-    it('should apply NUXT_PORT and NUXT_HOST env vars to devServer defaults', async () => {
-      const cwd = fileURLToPath(new URL('./layer-fixture', import.meta.url)).replace(/\\/g, '/')
-      const config = await loadNuxtConfig({ cwd })
+      const { loadNuxtConfig } = await import('@nuxt/kit')
+      const config = await loadNuxtConfig({ cwd: tempDir })
       expect(config.devServer.port).toBe(3005)
       expect(config.devServer.host).toBe('0.0.0.0')
     })

--- a/packages/kit/test/load-nuxt-config.spec.ts
+++ b/packages/kit/test/load-nuxt-config.spec.ts
@@ -1,5 +1,6 @@
+import process from 'node:process'
 import { fileURLToPath } from 'node:url'
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { loadNuxtConfig } from '@nuxt/kit'
 import { basename } from 'pathe'
 
@@ -43,5 +44,34 @@ describe('loadNuxtConfig', () => {
         "a",
       ]
     `)
+  })
+
+  describe('with .env file', () => {
+    const envKeys = ['NUXT_PORT', 'NUXT_HOST', 'NITRO_PORT', 'NITRO_HOST', 'PORT', 'HOST'] as const
+    const original: Record<string, string | undefined> = {}
+
+    beforeEach(() => {
+      for (const key of envKeys) {
+        original[key] = process.env[key]
+        delete process.env[key]
+      }
+    })
+
+    afterEach(() => {
+      for (const key of envKeys) {
+        if (original[key] === undefined) {
+          delete process.env[key]
+        } else {
+          process.env[key] = original[key]
+        }
+      }
+    })
+
+    it('should apply NUXT_PORT and NUXT_HOST from .env to devServer defaults', async () => {
+      const cwd = fileURLToPath(new URL('./dotenv-fixture', import.meta.url)).replace(/\\/g, '/')
+      const config = await loadNuxtConfig({ cwd })
+      expect(config.devServer.port).toBe(3005)
+      expect(config.devServer.host).toBe('0.0.0.0')
+    })
   })
 })

--- a/packages/schema/src/config/dev.ts
+++ b/packages/schema/src/config/dev.ts
@@ -5,22 +5,8 @@ import { template as loadingTemplate } from '../../../ui-templates/dist/template
 export default defineResolvers({
   devServer: {
     https: false,
-    port: {
-      $resolve: (val) => {
-        if (typeof val === 'number' || typeof val === 'string') {
-          return Number(val)
-        }
-        return Number(process.env.NUXT_PORT || process.env.NITRO_PORT || process.env.PORT || 3000)
-      },
-    },
-    host: {
-      $resolve: (val) => {
-        if (typeof val === 'string') {
-          return val
-        }
-        return process.env.NUXT_HOST || process.env.NITRO_HOST || process.env.HOST || undefined
-      },
-    },
+    port: Number(process.env.NUXT_PORT || process.env.NITRO_PORT || process.env.PORT || 3000),
+    host: process.env.NUXT_HOST || process.env.NITRO_HOST || process.env.HOST || undefined,
     url: 'http://localhost:3000',
     loadingTemplate,
     cors: {

--- a/packages/schema/src/config/dev.ts
+++ b/packages/schema/src/config/dev.ts
@@ -5,8 +5,22 @@ import { template as loadingTemplate } from '../../../ui-templates/dist/template
 export default defineResolvers({
   devServer: {
     https: false,
-    port: Number(process.env.NUXT_PORT || process.env.NITRO_PORT || process.env.PORT || 3000),
-    host: process.env.NUXT_HOST || process.env.NITRO_HOST || process.env.HOST || undefined,
+    port: {
+      $resolve: (val) => {
+        if (typeof val === 'number' || typeof val === 'string') {
+          return Number(val)
+        }
+        return Number(process.env.NUXT_PORT || process.env.NITRO_PORT || process.env.PORT || 3000)
+      },
+    },
+    host: {
+      $resolve: (val) => {
+        if (typeof val === 'string') {
+          return val
+        }
+        return process.env.NUXT_HOST || process.env.NITRO_HOST || process.env.HOST || undefined
+      },
+    },
     url: 'http://localhost:3000',
     loadingTemplate,
     cors: {


### PR DESCRIPTION
### 🔗 Linked issue

Fixes: #34955 

### 📚 Description

Since #34842, the `@nuxt/schema` module runs in parallel to **c12's** `loadConfig` and was therefore evaluated before `.env` was loaded into `process.env`. Now we loading `NUXT_PORT/NUXT_HOST` with `$resolve` to fix this.

Yes, I could write it with less code, but I wanted to use the same schema like in **app.ts** (`NUXT_APP_BASE_URL` e.g.)

### Tests
- Test host and port