### PR TITLE
fix(vite): resolve vite `clientServer` with `ssr: false`

### DIFF
--- a/packages/vite/src/plugins/vite-node.ts
+++ b/packages/vite/src/plugins/vite-node.ts
@@ -252,8 +252,6 @@ export function ViteNodePlugin (nuxt: Nuxt): VitePlugin | undefined {
         socketServer = createViteNodeSocketServer(nuxt, ssrServer, clientServer, invalidates, viteNodeServerOptions)
       }
 
-      // since #34666 the SPA renderer also fetches the manifest via vite-node IPC,
-      // but `vite:serverCreated` never fires server-side in SPA — init via client
       if (nuxt.options.experimental.viteEnvironmentApi || !nuxt.options.ssr) {
         resolveServer(clientServer)
       } else {

--- a/packages/vite/src/plugins/vite-node.ts
+++ b/packages/vite/src/plugins/vite-node.ts
@@ -237,7 +237,8 @@ export function ViteNodePlugin (nuxt: Nuxt): VitePlugin | undefined {
         const viteNodeServerOptions = {
           socketPath,
           root: nuxt.options.srcDir,
-          entryPath: resolveServerEntry(ssrServer.config),
+          // skip in SPA — no SSR input, only used on SSR render path
+          entryPath: nuxt.options.ssr ? resolveServerEntry(ssrServer.config) : '',
           base: ssrServer.config.base || '/_nuxt/',
           maxRetryAttempts: nuxt.options.vite.viteNode?.maxRetryAttempts,
           baseRetryDelay: nuxt.options.vite.viteNode?.baseRetryDelay,
@@ -252,7 +253,9 @@ export function ViteNodePlugin (nuxt: Nuxt): VitePlugin | undefined {
         socketServer = createViteNodeSocketServer(nuxt, ssrServer, clientServer, invalidates, viteNodeServerOptions)
       }
 
-      if (nuxt.options.experimental.viteEnvironmentApi) {
+      // since #34666 the SPA renderer also fetches the manifest via vite-node IPC,
+      // but `vite:serverCreated` never fires server-side in SPA — init via client
+      if (nuxt.options.experimental.viteEnvironmentApi || !nuxt.options.ssr) {
         resolveServer(clientServer)
       } else {
         nuxt.hook('vite:serverCreated', (ssrServer, ctx) => ctx.isServer ? resolveServer(ssrServer) : undefined)

--- a/packages/vite/src/plugins/vite-node.ts
+++ b/packages/vite/src/plugins/vite-node.ts
@@ -237,8 +237,7 @@ export function ViteNodePlugin (nuxt: Nuxt): VitePlugin | undefined {
         const viteNodeServerOptions = {
           socketPath,
           root: nuxt.options.srcDir,
-          // skip in SPA — no SSR input, only used on SSR render path
-          entryPath: nuxt.options.ssr ? resolveServerEntry(ssrServer.config) : '',
+          entryPath: resolveServerEntry(ssrServer.config),
           base: ssrServer.config.base || '/_nuxt/',
           maxRetryAttempts: nuxt.options.vite.viteNode?.maxRetryAttempts,
           baseRetryDelay: nuxt.options.vite.viteNode?.baseRetryDelay,


### PR DESCRIPTION
### 🔗 Linked issue

resolves #34957

### 📚 Description

I think that since issue #34666, the SPA renderer also retrieves the client manifest, which is why it crashes. The fix initializes the IPC directly against the client-server when `ssr: false`.
I think the branch 4.x is the right place.
