### PR TITLE
chore: bump node version

### DIFF
--- a/packages/vite/src/plugins/vite-node.ts
+++ b/packages/vite/src/plugins/vite-node.ts
@@ -135,7 +135,7 @@ function generateSocketPath () {
   // Linux: abstract namespace
   if (process.platform === 'linux') {
     const nodeMajor = Number.parseInt(process.versions.node.split('.')[0]!, 10)
-    if (nodeMajor >= 20 && provider !== 'stackblitz') {
+    if (nodeMajor >= 22 && provider !== 'stackblitz') {
       // We avoid abstract sockets in Docker due to performance issues
       let isDocker = false
 


### PR DESCRIPTION
Node v20 is now EOL. I think we can bump it maybe.