### PR TITLE
refactor(kit,nuxt,vite): use `es2023` array methods

### DIFF
--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -346,7 +346,7 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
   }
 
   const nestedModulesDirs: string[] = []
-  for (const dir of [...nuxt.options.modulesDir].sort()) {
+  for (const dir of nuxt.options.modulesDir.toSorted()) {
     const withSlash = withTrailingSlash(dir)
     if (nestedModulesDirs.every(d => !d.startsWith(withSlash))) {
       nestedModulesDirs.push(withSlash)

--- a/packages/nuxt/src/app/utils.ts
+++ b/packages/nuxt/src/app/utils.ts
@@ -15,7 +15,7 @@ export function getUserTrace (): Trace[] {
 
   const trace = captureStackTrace()
   const start = trace.findIndex(entry => !entry.source.startsWith(distURL))
-  const end = [...trace].reverse().findIndex(entry => !entry.source.includes('node_modules') && !entry.source.startsWith(distURL))
+  const end = trace.toReversed().findIndex(entry => !entry.source.includes('node_modules') && !entry.source.startsWith(distURL))
   if (start === -1 || end === -1) {
     return []
   }

--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -139,7 +139,7 @@ async function compileTemplate<T> (template: NuxtTemplate<T>, ctx: { nuxt: Nuxt,
 export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
   // resolve layer
   const layerDirs = getLayerDirectories(nuxt)
-  const reversedLayerDirs = [...layerDirs].reverse()
+  const reversedLayerDirs = layerDirs.toReversed()
 
   // Resolve main (app.vue)
   app.mainComponent ||= await findPath(layerDirs.flatMap(d => [join(d.app, 'App'), join(d.app, 'app')]))
@@ -202,7 +202,7 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
   }
 
   // Add back plugins not specified in layers or user config
-  for (const p of [...nuxt.options.plugins].reverse()) {
+  for (const p of nuxt.options.plugins.toReversed()) {
     const plugin = normalizePlugin(p)
     if (!plugins.some(p => p.src === plugin.src)) {
       plugins.unshift(plugin)
@@ -210,7 +210,7 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
   }
 
   // Normalize and de-duplicate plugins and middleware
-  middleware = uniqueBy(await resolvePaths(nuxt, [...middleware].reverse(), 'path'), 'name').reverse()
+  middleware = uniqueBy(await resolvePaths(nuxt, middleware.toReversed(), 'path'), 'name').reverse()
   plugins = uniqueBy(await resolvePaths(nuxt, plugins, 'src'), 'src')
 
   // Resolve app.config

--- a/packages/nuxt/src/core/cache.ts
+++ b/packages/nuxt/src/core/cache.ts
@@ -327,7 +327,7 @@ async function writeCache (cwd: string, sources: string | string[], cacheFile: s
 function getCacheDir (nuxt: Nuxt) {
   let cacheDir = join(nuxt.options.workspaceDir, 'node_modules')
   if (!existsSync(cacheDir)) {
-    for (const dir of [...nuxt.options.modulesDir].sort((a, b) => a.length - b.length)) {
+    for (const dir of nuxt.options.modulesDir.toSorted((a, b) => a.length - b.length)) {
       if (existsSync(dir)) {
         cacheDir = dir
         break

--- a/packages/nuxt/src/core/perf.ts
+++ b/packages/nuxt/src/core/perf.ts
@@ -366,7 +366,7 @@ export class NuxtPerfProfiler {
         }
       }),
       slowHooks: this.#computeSlowHooks(new Set(allPhases.map(p => p.name))),
-      modules: [...this.#modules].sort((a, b) => b.setupTime - a.setupTime),
+      modules: this.#modules.toSorted((a, b) => b.setupTime - a.setupTime),
       bundlerPlugins: [...this.#bundlerPluginTimings.entries()]
         .map(([name, hookMap]) => {
           const hooks: Record<string, PluginHookTiming> = {}
@@ -617,7 +617,7 @@ export class NuxtPerfProfiler {
     const emitPluginSpans = (spans: typeof viteSpans, label: string, baseTid: number) => {
       if (spans.length === 0) { return }
       // Sort by start time for lane allocation
-      const sorted = [...spans].sort((a, b) => a.startTime - b.startTime)
+      const sorted = spans.toSorted((a, b) => a.startTime - b.startTime)
       // Each lane tracks when it becomes free (end time in ms)
       const laneEnds: number[] = []
 

--- a/packages/nuxt/test/pages.test.ts
+++ b/packages/nuxt/test/pages.test.ts
@@ -48,19 +48,19 @@ describe('pages:generateRoutesFromFiles', () => {
   const enUSComparator = new Intl.Collator('en-US')
   function sortRoutes (routes: NuxtPage[]) {
     for (const route of routes) {
-      route.children &&= sortRoutes([...route.children])
+      route.children &&= sortRoutes(route.children)
     }
-    return [...routes].sort((a, b) => enUSComparator.compare(b.path, a.path))
+    return routes.toSorted((a, b) => enUSComparator.compare(b.path, a.path))
   }
 
   // Sort normalized route arrays by their serialized path for order-independent snapshots
   function sortNormalizedArray (arr: any[]): any[] {
-    return [...arr].map((item: any) => {
+    return arr.map((item) => {
       if (item && typeof item === 'object' && item.children) {
         return { ...item, children: sortNormalizedArray(item.children) }
       }
       return item
-    }).sort((a: any, b: any) => {
+    }).sort((a, b) => {
       const aPath = typeof a === 'string' ? a : JSON.stringify(a)
       const bPath = typeof b === 'string' ? b : JSON.stringify(b)
       return enUSComparator.compare(bPath, aPath)

--- a/packages/vite/src/plugins/layer-dep-optimize.ts
+++ b/packages/vite/src/plugins/layer-dep-optimize.ts
@@ -20,8 +20,7 @@ export function LayerDepOptimizePlugin (nuxt: Nuxt): Plugin | undefined {
 
   if (layerDirs.length > 0) {
     // Reverse so longest/most specific directories are searched first
-    layerDirs.sort().reverse()
-    const dirs = [...layerDirs]
+    const dirs = layerDirs.toSorted().reverse()
     return {
       name: 'nuxt:optimize-layer-deps',
       enforce: 'pre',

--- a/packages/vite/src/plugins/optimize-deps-hint.ts
+++ b/packages/vite/src/plugins/optimize-deps-hint.ts
@@ -6,7 +6,7 @@ import { colorize } from 'consola/utils'
 
 export function formatIncludeSnippet (deps: string[], cjsDeps?: Set<string>): string {
   if (!deps.length) { return '[]' }
-  const lines = [...deps].sort().map((d) => {
+  const lines = deps.toSorted().map((d) => {
     const comment = cjsDeps?.has(d) ? ' // CJS' : ''
     return `        '${d}',${comment}`
   })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,7 @@
     "noEmit": true,
     /* If your code runs in the DOM: */
     "lib": [
-      "es2022",
+      "es2023",
       "webworker",
       "dom",
       "dom.iterable"


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This uses ES2023 array methods wherever appropriate while keeping the target unchanged (ES2022) and removes array cloning in places where it seemed unnecessary.