### PR TITLE
docs: add warning about routing in server components

### DIFF
--- a/docs/2.directory-structure/1.app/1.components.md
+++ b/docs/2.directory-structure/1.app/1.components.md
@@ -539,6 +539,12 @@ This means:
 Route middleware does not run when rendering island components. Middleware is a routing concept that applies to pages, not components, and is not designed to control component rendering.
 ::
 
+::important
+`useRoute()` and other `vue-router` composables do not track the current page route inside a server (island) component. The island is rendered in its own isolated Vue app keyed only on its props (and any explicit context), which is what keeps islands cacheable independently of the page they are rendered on. Inside an island, `useRoute()` will reflect the island's own request, not the page the user is on.
+
+If an island needs information about the current route, pass it in explicitly &mdash; either as props from the parent component, or via the `context` prop on `<NuxtIsland>` (read inside the island from `nuxtApp.ssrContext.islandContext`).
+::
+
 Within an island component, you can access its island context through `nuxtApp.ssrContext.islandContext`. Note that while island components are still marked as experimental, the format of this context may change.
 
 ::note


### PR DESCRIPTION
### 🔗 Linked issue

resolves #27949

### 📚 Description

this adds a warning that server components do not have access to the current page route