### PR TITLE
chore: ignore pnpm cyclic workspace deps warn

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,6 +25,7 @@ shellEmulator: true
 
 verifyDepsBeforeRun: install
 
+ignoreWorkspaceCycles: true
 
 overrides:
   "@nuxt/kit": "workspace:*"


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This avoids logging a pnpm cyclic workspace dependencies warning every time deps are installed, see https://github.com/nuxt/nuxt/actions/runs/25486254427/job/74786919409?pr=34995#step:5:9 as an example.