### PR TITLE
fix(nuxt): dedupe `getCachedData` for concurrent callers sharing a key

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -702,7 +702,7 @@ export type DebouncedReturn<ArgumentsT extends unknown[], ReturnT> = ((...args: 
   isPending: () => boolean
 }
 
-export type CreatedAsyncData<ResT, NuxtErrorDataT = unknown, DataT = ResT, DefaultT = undefined> = Omit<_AsyncData<DataT | DefaultT, (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>)>, 'clear' | 'refresh'> & { _off: () => void, _hash?: Record<string, string | undefined>, _default: () => unknown, _init: boolean, _initialCachedData?: DataT | undefined, _deps: number, _execute: DebouncedReturn<[opts?: AsyncDataExecuteOptions | undefined], void>, _abortController?: AbortController }
+export type CreatedAsyncData<ResT, NuxtErrorDataT = unknown, DataT = ResT, DefaultT = undefined> = Omit<_AsyncData<DataT | DefaultT, (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>)>, 'clear' | 'refresh'> & { _off: () => void, _hash?: Record<string, string | undefined>, _default: () => unknown, _init: boolean, _deps: number, _execute: DebouncedReturn<[opts?: AsyncDataExecuteOptions | undefined], void>, _abortController?: AbortController }
 
 function buildAsyncData<
   ResT,

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -365,9 +365,14 @@ export const createUseAsyncData = defineKeyedFunctionFactory({
       // Create or use a shared asyncData entity
       function createInitialFetch () {
         const initialFetchOptions: AsyncDataExecuteOptions = { cause: 'initial', dedupe: opts.dedupe }
-        if (!nuxtApp._asyncData[key.value]?._init) {
+        const existing = nuxtApp._asyncData[key.value]
+        if (!existing?._init) {
           initialFetchOptions.cachedData = opts.getCachedData!(key.value, nuxtApp, { cause: 'initial' })
           nuxtApp._asyncData[key.value] = buildAsyncData(nuxtApp, key.value, _handler, opts, initialFetchOptions.cachedData)
+          nuxtApp._asyncData[key.value]!._initialCachedData = initialFetchOptions.cachedData
+        } else {
+          // reuse the cache lookup performed by the first concurrent caller
+          initialFetchOptions.cachedData = existing._initialCachedData
         }
         return () => nuxtApp._asyncData[key.value]!.execute(initialFetchOptions)
       }
@@ -697,7 +702,7 @@ export type DebouncedReturn<ArgumentsT extends unknown[], ReturnT> = ((...args: 
   isPending: () => boolean
 }
 
-export type CreatedAsyncData<ResT, NuxtErrorDataT = unknown, DataT = ResT, DefaultT = undefined> = Omit<_AsyncData<DataT | DefaultT, (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>)>, 'clear' | 'refresh'> & { _off: () => void, _hash?: Record<string, string | undefined>, _default: () => unknown, _init: boolean, _deps: number, _execute: DebouncedReturn<[opts?: AsyncDataExecuteOptions | undefined], void>, _abortController?: AbortController }
+export type CreatedAsyncData<ResT, NuxtErrorDataT = unknown, DataT = ResT, DefaultT = undefined> = Omit<_AsyncData<DataT | DefaultT, (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>)>, 'clear' | 'refresh'> & { _off: () => void, _hash?: Record<string, string | undefined>, _default: () => unknown, _init: boolean, _initialCachedData?: DataT | undefined, _deps: number, _execute: DebouncedReturn<[opts?: AsyncDataExecuteOptions | undefined], void>, _abortController?: AbortController }
 
 function buildAsyncData<
   ResT,

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -680,6 +680,7 @@ function clearNuxtDataByKey (nuxtApp: NuxtApp, key: string): void {
       nuxtApp._asyncData[key]!.pending.value = false
     }
     nuxtApp._asyncData[key]!.status.value = 'idle'
+    nuxtApp._asyncData[key]!._initialCachedData = undefined
   }
 
   if (key in nuxtApp._asyncDataPromises) {

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -145,6 +145,8 @@ interface _NuxtApp {
     _hash?: Record<string, string | undefined>
     /** @internal */
     _abortController?: AbortController
+    /** @internal */
+    _initialCachedData?: unknown
   } | undefined>
 
   /** @internal */

--- a/test/nuxt/use-async-data.test.ts
+++ b/test/nuxt/use-async-data.test.ts
@@ -1453,4 +1453,22 @@ describe('useAsyncData', () => {
       router.removeRoute('v-once-other')
     }
   })
+
+  // https://github.com/nuxt/nuxt/issues/31576
+  it('should call getCachedData only once when concurrent useAsyncData calls share a key', async () => {
+    const key = `dedupe-getCachedData-${++counter}`
+    const getCachedData = vi.fn((_key: string, nuxtApp: NuxtApp) => nuxtApp.payload.data[_key])
+    const promiseFn = vi.fn(() => Promise.resolve('value'))
+
+    const promises = Array.from({ length: 10 }, () =>
+      useAsyncData(key, promiseFn, { getCachedData, dedupe: 'defer' }),
+    )
+    await Promise.all(promises)
+
+    expect(getCachedData).toHaveBeenCalledTimes(1)
+    expect(promiseFn).toHaveBeenCalledTimes(1)
+    for (const p of promises) {
+      expect((await p).data.value).toBe('value')
+    }
+  })
 })

--- a/test/nuxt/use-async-data.test.ts
+++ b/test/nuxt/use-async-data.test.ts
@@ -1471,4 +1471,27 @@ describe('useAsyncData', () => {
       expect((await p).data.value).toBe('value')
     }
   })
+
+  it('should re-fetch after clearNuxtData rather than serving the cached lookup from a previous call', async () => {
+    const key = `clear-getCachedData-${++counter}`
+    const nuxtApp = useNuxtApp()
+    nuxtApp.payload.data[key] = 'initial-payload'
+
+    let fetchCount = 0
+    const handler = () => {
+      fetchCount++
+      return Promise.resolve(`fresh-${fetchCount}`)
+    }
+    const getCachedData = (k: string, app: NuxtApp) => app.payload.data[k]
+
+    const { data: first } = await useAsyncData(key, handler, { getCachedData })
+    expect(first.value).toBe('initial-payload')
+    expect(fetchCount).toBe(0)
+
+    clearNuxtData(key)
+
+    const { data: second } = await useAsyncData(key, handler, { getCachedData })
+    expect(fetchCount).toBe(1)
+    expect(second.value).toBe('fresh-1')
+  })
 })


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/31576

### 📚 Description

when several `useAsyncData` or `useFetch` calls share a key in the same tick, `getCachedData` ends up running once per caller even though the fetch itself is deduped.

so this PR caches the first caller's lookup on the async data slot and reuses it for the rest.