### PR TITLE
fix(nuxt): correct island transform for server pages and 'deep' mode

### DIFF
--- a/packages/nuxt/src/components/module.ts
+++ b/packages/nuxt/src/components/module.ts
@@ -16,7 +16,7 @@ import { TreeShakeTemplatePlugin } from './plugins/tree-shake.ts'
 import { ComponentNamePlugin } from './plugins/component-names.ts'
 import { LazyHydrationTransformPlugin } from './plugins/lazy-hydration-transform.ts'
 import { LazyHydrationMacroTransformPlugin } from './plugins/lazy-hydration-macro-transform.ts'
-import type { Component, ComponentsDir, ComponentsOptions } from 'nuxt/schema'
+import type { Component, ComponentsDir, ComponentsOptions, NuxtPage } from 'nuxt/schema'
 
 const isPureObjectOrString = (val: unknown): val is object | string => (!Array.isArray(val) && typeof val === 'object') || typeof val === 'string'
 const SLASH_SEPARATOR_RE = /[\\/]/
@@ -258,7 +258,23 @@ export default defineNuxtModule<ComponentsOptions>({
         },
       }, { server: false })
 
-      addBuildPlugin(IslandsTransformPlugin({ getComponents, selectiveClient }), { client: false, prepend: true })
+      function getServerPages (): string[] {
+        const paths: string[] = []
+        function visit (pages: NuxtPage[]) {
+          for (const page of pages) {
+            if (page.mode === 'server' && page.file) {
+              paths.push(normalize(page.file))
+            }
+            if (page.children?.length) { visit(page.children) }
+          }
+        }
+        for (const app of Object.values(nuxt.apps)) {
+          if (app.pages) { visit(app.pages) }
+        }
+        return paths
+      }
+
+      addBuildPlugin(IslandsTransformPlugin({ getComponents, getServerPages, selectiveClient }), { client: false, prepend: true })
 
       if (selectiveClient && nuxt.options.builder === '@nuxt/vite-builder') {
         addVitePlugin(() => ComponentsChunkPlugin({ dev: nuxt.options.dev, getComponents }))

--- a/packages/nuxt/src/components/plugins/islands-transform.ts
+++ b/packages/nuxt/src/components/plugins/islands-transform.ts
@@ -10,6 +10,13 @@ import { isVue, parseModuleId } from '../../core/utils/index.ts'
 interface ServerOnlyComponentTransformPluginOptions {
   getComponents: () => Component[]
   /**
+   * Returns the resolved file paths of pages that should be rendered as islands
+   * (i.e. `pages/*.server.vue`). These need the same `<slot>` / `nuxt-client`
+   * transform as island components, but they live in the pages registry rather
+   * than the components registry.
+   */
+  getServerPages?: () => string[]
+  /**
    * allow using `nuxt-client` attribute on components
    */
   selectiveClient?: boolean | 'deep'
@@ -36,13 +43,8 @@ export const IslandsTransformPlugin = (options: ServerOnlyComponentTransformPlug
     transformInclude (id) {
       if (!isVue(id)) { return false }
       if (isVite && options.selectiveClient === 'deep') { return true }
-      const components = options.getComponents()
-
-      const islands = components.filter(component =>
-        component.island || (component.mode === 'server' && !components.some(c => c.pascalName === component.pascalName && c.mode === 'client')),
-      )
       const { pathname } = parseModuleId(normalize(id))
-      return islands.some(c => c.filePath === pathname)
+      return isIslandFile(pathname, options)
     },
     transform: {
       filter: {
@@ -55,6 +57,9 @@ export const IslandsTransformPlugin = (options: ServerOnlyComponentTransformPlug
         if (!template) { return }
         const startingIndex = template.index || 0
         const s = new MagicString(code)
+
+        const { pathname } = parseModuleId(normalize(id))
+        const isIsland = isIslandFile(pathname, options)
 
         if (!SCRIPT_RE.test(code)) {
           s.prepend('<script setup>' + IMPORT_CODE + '</script>')
@@ -72,6 +77,7 @@ export const IslandsTransformPlugin = (options: ServerOnlyComponentTransformPlug
             return
           }
           if (node.name === 'slot') {
+            if (!isIsland) { return }
             const { attributes, children, loc } = node
 
             const slotName = attributes.name ?? 'default'
@@ -144,6 +150,16 @@ export const IslandsTransformPlugin = (options: ServerOnlyComponentTransformPlug
     },
   }
 })
+
+function isIslandFile (pathname: string, options: ServerOnlyComponentTransformPluginOptions): boolean {
+  const components = options.getComponents()
+  const isIslandComponent = components.some(component =>
+    component.filePath === pathname &&
+    (component.island || (component.mode === 'server' && !components.some(c => c.pascalName === component.pascalName && c.mode === 'client'))),
+  )
+  if (isIslandComponent) { return true }
+  return options.getServerPages?.().includes(pathname) ?? false
+}
 
 /**
  * extract attributes from a node

--- a/packages/nuxt/test/island-transform.test.ts
+++ b/packages/nuxt/test/island-transform.test.ts
@@ -4,7 +4,7 @@ import { IslandsTransformPlugin } from '../src/components/plugins/islands-transf
 import { normalizeLineEndings } from './utils.ts'
 
 const getComponents = () => [{
-  filePath: '/root/hello.server.vue',
+  filePath: 'hello.server.vue',
   mode: 'server',
   pascalName: 'HelloWorld',
   island: true,
@@ -21,9 +21,10 @@ const pluginWebpack = IslandsTransformPlugin({
   selectiveClient: true,
 }).raw({}, { framework: 'webpack', webpack: { compiler: {} as any } }) as { transform: { handler: (code: string, id: string) => { code: string } | null } }
 
-const viteTransform = async (source: string, id: string, selectiveClient = false) => {
+async function viteTransform (source: string, id: string, selectiveClient: boolean | 'deep' = false, getServerPages: () => string[] = () => []) {
   const vitePlugin = IslandsTransformPlugin({
     getComponents,
+    getServerPages,
     selectiveClient,
   }).raw({}, { framework: 'vite' }) as { transform: { handler: (code: string, id: string) => { code: string } | null } }
 
@@ -229,7 +230,7 @@ withDefaults(defineProps<{ things?: any[]; somethingElse?: string }>(), {
       <slot v-else-if="test" />
       <slot v-else />
       </template>
-      `, 'WithVif.vue', true)
+      `, 'hello.server.vue', true)
 
       expect(normalizeLineEndings(result)).toMatchInlineSnapshot(`
         "<script setup lang="ts">
@@ -474,6 +475,66 @@ withDefaults(defineProps<{ things?: any[]; somethingElse?: string }>(), {
 
         expect(spyOnWarn).toHaveBeenCalledWith('The `nuxt-client` attribute and client components within islands are only supported with Vite. file: hello.server.vue')
       })
+    })
+  })
+
+  // https://github.com/nuxt/nuxt/issues/30005
+  describe('selectiveClient: "deep" with non-island components', () => {
+    it('does not wrap <slot/> in NuxtTeleportSsrSlot for non-island Vue files', async () => {
+      const source = `<script setup lang="ts">
+defineProps<{ to: string }>()
+</script>
+
+<template>
+<a :href="to"><slot /></a>
+</template>
+`
+      const result = await viteTransform(source, 'components/Link.vue', 'deep')
+      // Link.vue is a regular component (not registered as an island);
+      // its <slot/> must remain a normal Vue slot so its contents render.
+      expect(result).toContain('<a :href="to"><slot /></a>')
+      expect(result).not.toContain('<NuxtTeleportSsrSlot')
+    })
+
+    it('still wraps <slot/> in NuxtTeleportSsrSlot for island components in deep mode', async () => {
+      const source = `<template>
+<div><slot /></div>
+</template>
+`
+      const result = await viteTransform(source, 'hello.server.vue', 'deep')
+      expect(result).toContain('<NuxtTeleportSsrSlot')
+    })
+
+    it('still wraps nuxt-client on non-island components in deep mode', async () => {
+      const source = `<template>
+<div><HelloWorld nuxt-client /></div>
+</template>
+
+<script setup lang="ts">
+import HelloWorld from './HelloWorld.vue'
+</script>
+`
+      const result = await viteTransform(source, 'components/Wrapper.vue', 'deep')
+      // The nuxt-client wrapping is the whole point of `'deep'` mode and
+      // must keep working for non-island files.
+      expect(result).toContain('<NuxtTeleportIslandComponent :nuxt-client=')
+    })
+  })
+
+  // https://github.com/nuxt/nuxt/issues/30016
+  describe('selectiveClient: true with island pages', () => {
+    it('wraps nuxt-client used directly inside a server page', async () => {
+      const source = `<template>
+<div><InteractiveButton nuxt-client /></div>
+</template>
+
+<script setup lang="ts">
+import InteractiveButton from '~/components/InteractiveButton.vue'
+</script>
+`
+      const pageFile = 'pages/index.server.vue'
+      const result = await viteTransform(source, pageFile, true, () => [pageFile])
+      expect(result).toContain('<NuxtTeleportIslandComponent :nuxt-client=')
     })
   })
 })

--- a/test/server-components.test.ts
+++ b/test/server-components.test.ts
@@ -461,7 +461,7 @@ describe('component islands', () => {
   })
 })
 
-describe.skipIf(isDev || isWebpack)('regressions (expected failures)', () => {
+describe.skipIf(isDev || isWebpack)('regressions', () => {
   // https://github.com/nuxt/nuxt/issues/26527
   it.fails('renders <Counter nuxt-client /> when nested two levels deep in server components', async () => {
     const { page } = await renderPage('/nested-nuxt-client')
@@ -476,7 +476,7 @@ describe.skipIf(isDev || isWebpack)('regressions (expected failures)', () => {
   })
 
   // https://github.com/nuxt/nuxt/issues/32251
-  it.fails('does not produce hydration mismatches with selectiveClient: "deep" on slot-using components', async () => {
+  it('does not produce hydration mismatches with selectiveClient: "deep" on slot-using components', async () => {
     const { page, consoleLogs } = await renderPage('/selective-client-slots')
 
     await page.locator('#slotted').waitFor()


### PR DESCRIPTION
### 🔗 Linked issue

resolves #30016
resolves #30005
resolves #32251

### 📚 Description

this adds support for the `nuxt-client` directive in server pages, and also stops the island transform from wrapping `<slot/>` in `NuxtTeleportSsrSlot` for non-island components in 'deep' mode.