### PR TITLE
fix(vite): only consider CSS inlined when styles are actually emitted

### DIFF
--- a/packages/vite/src/plugins/ssr-styles.ts
+++ b/packages/vite/src/plugins/ssr-styles.ts
@@ -21,9 +21,6 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
   if (nuxt.options.dev) { return }
 
   const chunksWithInlinedCSS = new Set<string>()
-  // CSS source module ids (with `?...` query stripped) whose styles were
-  // successfully inlined into the SSR response
-  const inlinedCSSModuleIds = new Set<string>()
   // For each output chunk that originates from a source file, the set of CSS
   // source module ids (no query) vite/rolldown bundled into that chunk's CSS
   // asset. Keyed by the manifest source path (`chunk.src`).
@@ -32,10 +29,25 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
 
   const stripQuery = (id: string) => id.replace(QUERY_RE, '')
 
+  // CSS source module ids (with `?...` query stripped) whose styles will be
+  // inlined into the SSR response. Built up in `build:manifest` from the
+  // components whose styles are actually emitted as inline `<style>` tags
+  // (i.e. those with `inBundle && files.length`). We can't populate this set
+  // during `transform` because at that point we don't yet know which
+  // components will actually have inline styles emitted.
+  const inlinedCSSModuleIds = new Set<string>()
+
   // Remove CSS entries for files that will have inlined styles
   const nitro = useNitro()
   nuxt.hook('build:manifest', (manifest) => {
     const entryIds = new Set<string>()
+
+    for (const { cssIds, files, inBundle } of Object.values(cssMap)) {
+      if (!cssIds || !inBundle || !files.length) { continue }
+      for (const cssId of cssIds) {
+        inlinedCSSModuleIds.add(cssId)
+      }
+    }
 
     for (const id of chunksWithInlinedCSS) {
       const chunk = manifest[id]
@@ -90,7 +102,7 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
     nitro.options._config.virtual['#internal/nuxt/entry-ids.mjs'] = nitro.options.virtual['#internal/nuxt/entry-ids.mjs']
   })
 
-  const cssMap: Record<string, { files: string[], inBundle?: boolean }> = {}
+  const cssMap: Record<string, { files: string[], inBundle?: boolean, cssIds?: Set<string> }> = {}
   // Track emitted CSS chunk refs globally to avoid duplicate emissions across transform calls.
   const emittedFileRefs: Record<string, string> = {}
 
@@ -298,7 +310,6 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
                     continue
                   }
                   idClientCSSMap.add(resolved.id)
-                  inlinedCSSModuleIds.add(stripQuery(resolved.id))
                 }
                 if (s.hasChanged()) {
                   return {
@@ -322,6 +333,7 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
 
             const relativeId = relativeToSrcDir(id)
             const idMap = cssMap[relativeId] ||= { files: [] }
+            const idCssIds = idMap.cssIds ||= new Set()
 
             const emittedIds = new Set<string>()
             const idFilename = filename(id)
@@ -341,7 +353,7 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
                 continue
               }
               emittedIds.add(file)
-              inlinedCSSModuleIds.add(stripQuery(resolved.id))
+              idCssIds.add(stripQuery(resolved.id))
 
               // Reuse ref from a previous emission of the same file to avoid rolldown
               // returning incorrect refs when the same chunk ID is emitted multiple times
@@ -377,7 +389,7 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
               }
 
               if (emittedIds.has(resolved.id)) { continue }
-              inlinedCSSModuleIds.add(stripQuery(resolved.id))
+              idCssIds.add(stripQuery(resolved.id))
 
               // Reuse ref from a previous emission of the same file
               const resolvedInlineId = res.id


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

follow-up to #34950

the dedupe added there populated `inlinedCSSModuleIds` during the server transform for any module whose CSS imports could be resolved - including modules whose styles never actually reach the SSR response (e.g. ambient CSS imports in .ts files like `FunctionalComponent.ts`).

their chunk's bundled CSS link was then wrongly dropped.

(this seems to have surfaced due to a rolldown/vite change as this originally passed in CI)