### PR TITLE
test: isolate `buildDir` per matrix project for shared fixtures

### DIFF
--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -3,9 +3,10 @@ import type { NuxtPage } from 'nuxt/schema'
 import { defu } from 'defu'
 import { createUnplugin } from 'unplugin'
 import { withoutLeadingSlash } from 'ufo'
-import { withMatrix } from '../../matrix'
+import { isNuxtPrepare, projectSuffix, withMatrix } from '../../matrix'
 
 export default withMatrix({
+  ...(isNuxtPrepare ? {} : { buildDir: `.nuxt-${projectSuffix}` }),
   appId: 'nuxt-app-basic',
   extends: [
     './extends/node_modules/foo',

--- a/test/fixtures/inline-styles-dedupe/nuxt.config.ts
+++ b/test/fixtures/inline-styles-dedupe/nuxt.config.ts
@@ -1,19 +1,10 @@
-import { withMatrix } from '../../matrix'
+import { isNuxtPrepare, projectSuffix, withMatrix } from '../../matrix'
 
 // Regression for https://github.com/nuxt/nuxt/issues/30435: when every CSS
 // module bundled into a chunk's CSS asset has also been inlined as a `<style>`
 // tag during SSR, the duplicate stylesheet `<link>` should be dropped.
-const projectSuffix = [
-  process.env.TEST_BUILDER,
-  process.env.TEST_ENV,
-  process.env.TEST_CONTEXT,
-  process.env.TEST_MANIFEST,
-].filter(Boolean).join('-') || 'default'
-
-const isPrepare = process.argv.slice(2).includes('prepare')
-
 export default withMatrix({
-  ...(isPrepare ? {} : { buildDir: `.nuxt-${projectSuffix}` }),
+  ...(isNuxtPrepare ? {} : { buildDir: `.nuxt-${projectSuffix}` }),
   sourcemap: false,
   nitro: {
     output: {

--- a/test/fixtures/server-components/nuxt.config.ts
+++ b/test/fixtures/server-components/nuxt.config.ts
@@ -1,6 +1,7 @@
-import { withMatrix } from '../../matrix'
+import { isNuxtPrepare, projectSuffix, withMatrix } from '../../matrix'
 
 export default withMatrix({
+  ...(isNuxtPrepare ? {} : { buildDir: `.nuxt-${projectSuffix}` }),
   experimental: {
     componentIslands: {
       selectiveClient: 'deep',

--- a/test/inline-styles.test.ts
+++ b/test/inline-styles.test.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from 'node:url'
 import { beforeAll, describe, expect, it } from 'vitest'
 import { exec } from 'tinyexec'
 import { join } from 'pathe'
-import { builder, isBuilt } from './matrix'
+import { builder, isBuilt, projectSuffix } from './matrix'
 
 describe.skipIf(builder !== 'vite' || !isBuilt)('inline styles dedupe (#30435)', () => {
   const rootDir = fileURLToPath(new URL('./fixtures/inline-styles-dedupe', import.meta.url))
@@ -15,12 +15,6 @@ describe.skipIf(builder !== 'vite' || !isBuilt)('inline styles dedupe (#30435)',
     }
   }, 120 * 1000)
 
-  const projectSuffix = [
-    process.env.TEST_BUILDER,
-    process.env.TEST_ENV,
-    process.env.TEST_CONTEXT,
-    process.env.TEST_MANIFEST,
-  ].filter(Boolean).join('-') || 'default'
   const outputDir = join(rootDir, `.output-${projectSuffix}`)
 
   it.each([

--- a/test/matrix.ts
+++ b/test/matrix.ts
@@ -14,6 +14,18 @@ export const isTestingAppManifest = process.env.TEST_MANIFEST !== 'manifest-off'
 export const asyncContext = process.env.TEST_CONTEXT === 'async'
 export const typescriptBundlerResolution = process.env.MODULE_RESOLUTION !== 'node'
 
+/**
+ * Suffix identifying the current matrix combination.
+ */
+export const projectSuffix = [
+  process.env.TEST_BUILDER,
+  process.env.TEST_ENV,
+  process.env.TEST_CONTEXT,
+  process.env.TEST_MANIFEST,
+].filter(Boolean).join('-') || 'default'
+
+export const isNuxtPrepare = process.argv.slice(2).includes('prepare')
+
 export function withMatrix (config: NuxtConfig) {
   return defu(config, {
     builder,

--- a/test/prepare.ts
+++ b/test/prepare.ts
@@ -5,15 +5,23 @@ import { glob } from 'tinyglobby'
 import { exec } from 'tinyexec'
 
 async function initTesting () {
+  const fixturesDir = fileURLToPath(new URL('./fixtures', import.meta.url))
   const dirs = await glob(['*'], {
     onlyDirectories: true,
-    cwd: fileURLToPath(new URL('./fixtures', import.meta.url)),
+    cwd: fixturesDir,
+    absolute: true,
+  })
+
+  const stalePerProjectDirs = await glob(['*/.nuxt-*', '*/.output-*'], {
+    onlyDirectories: true,
+    cwd: fixturesDir,
     absolute: true,
   })
 
   await Promise.all([
     // clear nuxt build files
     ...dirs.map(dir => rm(`${dir}/.nuxt`, { force: true, recursive: true })),
+    ...stalePerProjectDirs.map(dir => rm(dir, { force: true, recursive: true })),
     // clear vite cache
     ...dirs.map(dir => rm(`${dir}/node_modules/.cache`, { force: true, recursive: true })),
   ])


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this aims to reduce a persistent flake on windows in dev mode