### PR TITLE
fix(nuxt): handle string presets in auto-imports

### DIFF
--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -347,7 +347,7 @@ export default defineNuxtModule({
 
     // Add vue-router route guard imports
     nuxt.hook('imports:sources', (sources) => {
-      const routerImports = sources.find(s => 'from' in s && s.from === '#app/composables/router' && s.imports.includes('onBeforeRouteLeave')) as InlinePreset | undefined
+      const routerImports = sources.find(s => typeof s === 'object' && 'from' in s && s.from === '#app/composables/router' && s.imports.includes('onBeforeRouteLeave')) as InlinePreset | undefined
       if (routerImports) {
         routerImports.from = 'vue-router'
       }


### PR DESCRIPTION
### 📚 Description
When using string shorthand presets (e.g., 'date-fns') in `imports.presets`, the pages module throws a TypeError: `Cannot use 'in' operator to search for 'from' in date-fns`.

This occurs because the `imports:sources` hook assumes all sources are objects when searching for router imports. This commit adds a type guard (`typeof s === 'object'`) to safely ignore string presets.

### 🔗 Linked issue
Relates to [https://github.com/nuxt/nuxt/discussions/34988](https://github.com/nuxt/nuxt/discussions/34988)