### PR TITLE
fix(nuxt): defer head DOM updates until page transition finishes

### DIFF
--- a/packages/nuxt/src/head/runtime/plugins/unhead.ts
+++ b/packages/nuxt/src/head/runtime/plugins/unhead.ts
@@ -1,4 +1,5 @@
 import { createHead as createClientHead, renderDOMHead } from '@unhead/vue/client'
+import type { ActiveHeadEntry } from '@unhead/vue'
 import { defineNuxtPlugin } from '#app/nuxt'
 
 // @ts-expect-error virtual file
@@ -26,19 +27,28 @@ export default defineNuxtPlugin({
       // wait for new page before unpausing dom updates (triggered after suspense resolved)
       nuxtApp.hooks.hook('page:finish', () => {
         // app:suspense:resolve hook will unpause the DOM
-        if (nuxtApp.isHydrating) { return }
-        // hold DOM updates until any in-flight page transition finishes
-        const transitionPromise = nuxtApp['~transitionPromise']
-        if (transitionPromise) {
-          transitionPromise.then(syncHead)
-        } else {
-          syncHead()
-        }
+        if (!nuxtApp.isHydrating) { syncHead() }
       })
       // unpause on error
       nuxtApp.hooks.hook('app:error', syncHead)
       // unpause the DOM once the mount suspense is resolved
       nuxtApp.hooks.hook('app:suspense:resolve', syncHead)
+
+      // Defer head-entry disposal during a page transition.
+      const originalPush = head.push.bind(head)
+      head.push = ((input: Parameters<typeof head.push>[0], options?: Parameters<typeof head.push>[1]) => {
+        const entry = originalPush(input, options) as ActiveHeadEntry<typeof input>
+        const originalDispose = entry.dispose.bind(entry)
+        entry.dispose = () => {
+          const transitionPromise = nuxtApp['~transitionPromise']
+          if (transitionPromise) {
+            transitionPromise.then(originalDispose)
+          } else {
+            originalDispose()
+          }
+        }
+        return entry
+      }) as typeof head.push
     }
   },
 })

--- a/packages/nuxt/src/head/runtime/plugins/unhead.ts
+++ b/packages/nuxt/src/head/runtime/plugins/unhead.ts
@@ -26,7 +26,14 @@ export default defineNuxtPlugin({
       // wait for new page before unpausing dom updates (triggered after suspense resolved)
       nuxtApp.hooks.hook('page:finish', () => {
         // app:suspense:resolve hook will unpause the DOM
-        if (!nuxtApp.isHydrating) { syncHead() }
+        if (nuxtApp.isHydrating) { return }
+        // hold DOM updates until any in-flight page transition finishes
+        const transitionPromise = nuxtApp['~transitionPromise']
+        if (transitionPromise) {
+          transitionPromise.then(syncHead)
+        } else {
+          syncHead()
+        }
       })
       // unpause on error
       nuxtApp.hooks.hook('app:error', syncHead)

--- a/test/fixtures/server-components/app/pages/page-transition-style/blue.vue
+++ b/test/fixtures/server-components/app/pages/page-transition-style/blue.vue
@@ -19,4 +19,3 @@ useHead({
     </NuxtLink>
   </div>
 </template>
-

--- a/test/fixtures/server-components/app/pages/page-transition-style/blue.vue
+++ b/test/fixtures/server-components/app/pages/page-transition-style/blue.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+definePageMeta({
+  pageTransition: { name: 'page', mode: 'out-in' },
+})
+
+useHead({
+  style: [{ innerHTML: '.bg-blue { background-color: rgb(0, 0, 255); }' }],
+})
+</script>
+
+<template>
+  <div class="bg-blue blue-page">
+    <h1>blue</h1>
+    <NuxtLink
+      id="to-red"
+      to="/page-transition-style/red"
+    >
+      to red
+    </NuxtLink>
+  </div>
+</template>
+

--- a/test/fixtures/server-components/app/pages/page-transition-style/red.vue
+++ b/test/fixtures/server-components/app/pages/page-transition-style/red.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+definePageMeta({
+  pageTransition: { name: 'page', mode: 'out-in' },
+})
+
+useHead({
+  style: [{ innerHTML: '.bg-red { background-color: rgb(255, 0, 0); }' }],
+})
+</script>
+
+<template>
+  <div class="bg-red red-page">
+    <h1>red</h1>
+    <NuxtLink
+      id="to-blue"
+      to="/page-transition-style/blue"
+    >
+      to blue
+    </NuxtLink>
+  </div>
+</template>
+
+<style>
+.page-leave-active,
+.page-enter-active {
+  transition: opacity 500ms;
+}
+.page-leave-to,
+.page-enter-from {
+  opacity: 0;
+}
+</style>

--- a/test/server-components.test.ts
+++ b/test/server-components.test.ts
@@ -484,6 +484,46 @@ describe.skipIf(isDev || isWebpack)('regressions', () => {
 
     await page.close()
   })
+
+  // https://github.com/nuxt/nuxt/issues/32537
+  it('keeps a leaving page\'s useHead styles applied throughout pageTransition leave', async () => {
+    const { page } = await renderPage('/page-transition-style/red')
+
+    const redLocator = page.locator('.red-page')
+    await redLocator.waitFor()
+    expect(await redLocator.evaluate(el => getComputedStyle(el).backgroundColor)).toBe('rgb(255, 0, 0)')
+
+    // While the leaving page's <Transition> still has its DOM mounted, the
+    // `useHead({ style })` entry registered by red.vue must still be present in
+    // <head> — otherwise the leaving DIV becomes unstyled mid-animation. Sample
+    // the computed background-color across the leave window (rAF) starting from
+    // the click; before the fix unhead's debounced render fires within ~20ms of
+    // click, dropping the style and turning the bg transparent.
+    await page.evaluate(() => {
+      const w = window as unknown as { __samples?: Array<{ bg: string | null, hasLeave: boolean | null }> }
+      w.__samples = []
+      const start = performance.now()
+      const tick = () => {
+        const el = document.querySelector('.red-page')
+        w.__samples!.push({
+          bg: el ? getComputedStyle(el).backgroundColor : null,
+          hasLeave: el ? el.classList.contains('page-leave-active') : null,
+        })
+        if (performance.now() - start < 400) { requestAnimationFrame(tick) }
+      }
+      ;(document.querySelector('#to-blue') as HTMLAnchorElement).click()
+      requestAnimationFrame(tick)
+    })
+
+    await page.locator('.blue-page').waitFor()
+
+    const samples = await page.evaluate(() => (window as unknown as { __samples: Array<{ bg: string | null, hasLeave: boolean | null }> }).__samples)
+    const leaveSamples = samples.filter(s => s.hasLeave)
+    expect(leaveSamples.length).toBeGreaterThan(0)
+    expect(leaveSamples.every(s => s.bg === 'rgb(255, 0, 0)')).toBe(true)
+
+    await page.close()
+  })
 })
 
 function normaliseIslandResult (result: NuxtIslandResponse) {

--- a/test/server-components.test.ts
+++ b/test/server-components.test.ts
@@ -509,7 +509,7 @@ describe.skipIf(isDev || isWebpack)('regressions', () => {
           bg: el ? getComputedStyle(el).backgroundColor : null,
           hasLeave: el ? el.classList.contains('page-leave-active') : null,
         })
-        if (performance.now() - start < 400) { requestAnimationFrame(tick) }
+        if (performance.now() - start < 600) { requestAnimationFrame(tick) }
       }
       ;(document.querySelector('#to-blue') as HTMLAnchorElement).click()
       requestAnimationFrame(tick)


### PR DESCRIPTION
### 🔗 Linked issue

resolves #32537

### 📚 Description

currently we manually sync head when `page:finish` is called, which includes removing old head entries (e.g. inline styles, in the linked issue). in that particular case, the styles are still needed.

we can resolve the linked issue by deferring the head updates until after the page transition finishes - but I'd appreciate thought on whether this would cause any unexpected issues 🙏 