### PR TITLE
fix(vite): inline css imported from non-vue js modules

### DIFF
--- a/packages/vite/src/plugins/ssr-styles.ts
+++ b/packages/vite/src/plugins/ssr-styles.ts
@@ -260,8 +260,12 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
                   const parentMap = clientCSSMap[parent] ||= new Set()
                   parentMap.add(moduleId)
                 }
-                // This is required to track CSS in entry chunk
-                if (isEntry && chunk.facadeModuleId) {
+                // Track CSS in the chunk's facade so it gets inlined alongside the
+                // owning Vue component (or the entry chunk) at SSR time. Without this
+                // step, CSS imported as a side effect from a non-Vue JS module
+                // is never attributed to a `.vue` ancestor that the SSR renderer can
+                // ask for via `ssrContext.modules`
+                if (chunk.facadeModuleId && (isEntry || isVue(chunk.facadeModuleId))) {
                   const facadeMap = clientCSSMap[chunk.facadeModuleId] ||= new Set()
                   facadeMap.add(moduleId)
                 }
@@ -371,7 +375,7 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
             if (!SUPPORTED_FILES_RE.test(pathname)) { return }
 
             for (const i of findStaticImports(code)) {
-              if (!i.specifier.endsWith('.css') && !STYLE_QUERY_RE.test(i.specifier)) { continue }
+              if (!IS_CSS_RE.test(i.specifier) && !STYLE_QUERY_RE.test(i.specifier)) { continue }
 
               const resolved = await this.resolve(i.specifier, id)
               if (!resolved) { continue }

--- a/test/fixtures/inline-styles/assets/css-from-js-module.css
+++ b/test/fixtures/inline-styles/assets/css-from-js-module.css
@@ -1,0 +1,3 @@
+:root {
+  --inline-js-module-token: js-module;
+}

--- a/test/fixtures/inline-styles/assets/preprocessor-from-script.pcss
+++ b/test/fixtures/inline-styles/assets/preprocessor-from-script.pcss
@@ -1,0 +1,3 @@
+:root {
+  --inline-preprocessor-from-script-token: preprocessor-from-script;
+}

--- a/test/fixtures/inline-styles/components/JSModuleComponentWrapper.vue
+++ b/test/fixtures/inline-styles/components/JSModuleComponentWrapper.vue
@@ -1,0 +1,7 @@
+<script setup>
+import JSModuleComponent from './js-module-component.js'
+</script>
+
+<template>
+  <JSModuleComponent />
+</template>

--- a/test/fixtures/inline-styles/components/PreprocessorFromScript.vue
+++ b/test/fixtures/inline-styles/components/PreprocessorFromScript.vue
@@ -1,0 +1,11 @@
+<template>
+  <span class="preprocessor-from-script" />
+</template>
+
+<script>
+import '~/assets/preprocessor-from-script.pcss'
+
+export default {
+  name: 'PreprocessorFromScript',
+}
+</script>

--- a/test/fixtures/inline-styles/components/js-module-component.js
+++ b/test/fixtures/inline-styles/components/js-module-component.js
@@ -1,0 +1,8 @@
+import '~/assets/css-from-js-module.css'
+
+import { h } from 'vue'
+
+export default {
+  name: 'JSModuleComponent',
+  render: () => h('span', { class: 'js-module-component' }),
+}

--- a/test/fixtures/inline-styles/pages/js-imported-css.vue
+++ b/test/fixtures/inline-styles/pages/js-imported-css.vue
@@ -1,0 +1,6 @@
+<template>
+  <main>
+    <PreprocessorFromScript />
+    <JSModuleComponentWrapper />
+  </main>
+</template>

--- a/test/inline-styles.test.ts
+++ b/test/inline-styles.test.ts
@@ -36,4 +36,15 @@ describe.skipIf(builder !== 'vite' || !isBuilt)('inline styles', () => {
     const html = await readFile(join(outputDir, 'public', 'index.html'), 'utf-8')
     expect(html).toContain('--island-child-token:child')
   })
+
+  // https://github.com/nuxt/nuxt/issues/27417
+  it.each([
+    ['preprocessor extension imported from <script>', '--inline-preprocessor-from-script-token:preprocessor-from-script'],
+    ['CSS imported as a side effect from a non-Vue JS module', '--inline-js-module-token:js-module'],
+  ])('inlines CSS for %s', async (_, token) => {
+    const html = await readFile(join(outputDir, 'public', 'js-imported-css/index.html'), 'utf-8')
+    expect(html).toContain(token)
+    const cssLinks = [...html.matchAll(/<link [^>]*rel="stylesheet"[^>]*href="([^"]+)"/g)].map(m => m[1]!)
+    expect(cssLinks).toEqual([])
+  })
 })


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/27417


### 📚 Description

 CSS imported as a side effect from a non-Vue JS module (third-party libs built with `vite-plugin-lib-inject-css`, or any local `.js`/`.ts` helper that does `import './foo.css'`) wasn't being inlined.

... and same for preprocessor extensions (`.less`, `.scss`, `.pcss`, …) imported from a `<script>`.

so this PR:

- widens coverage to include other css-like extensions
- extends the existing `clientCSSMap` propagation in `renderChunk` to fire for any Vue facade chunk, not just the entry