### PR TITLE
feat(nuxt): add #routes and #layouts importmap aliases

### DIFF
--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -196,7 +196,11 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
       '#internal/nuxt/app-config': () => nuxt.vfs['#build/app.config.mjs']?.replace(/\/\*\* client \*\*\/[\s\S]*\/\*\* client-end \*\*\//, '') || '',
       '#spa-template': async () => `export const template = ${JSON.stringify(await spaLoadingTemplate(nuxt))}`,
       // this will be overridden in vite plugin
-      '#internal/entry-chunk.mjs': () => `export const entryFileName = undefined`,
+      '#internal/entry-chunk.mjs': () => [
+        `export const entryFileName = undefined`,
+        `export const routesFileName = undefined`,
+        `export const layoutsFileName = undefined`,
+      ].join('\n'),
       '#internal/nuxt/entry-ids.mjs': () => `export default []`,
       '#internal/nuxt/nitro-config.mjs': () => {
         const hasCachedRoutes = nitro.routing.routeRules.routes.some(r => r.data.isr || r.data.cache)

--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -28,7 +28,7 @@ import { appHead, appTeleportAttrs, appTeleportTag, componentIslands } from '#in
 // @ts-expect-error virtual file
 import entryIds from '#internal/nuxt/entry-ids.mjs'
 // @ts-expect-error virtual file
-import { entryFileName } from '#internal/entry-chunk.mjs'
+import { entryFileName, layoutsFileName, routesFileName } from '#internal/entry-chunk.mjs'
 // @ts-expect-error virtual file
 import { buildAssetsURL, publicAssetsURL } from '#internal/nuxt/paths'
 import type { AppConfig } from '@nuxt/schema'
@@ -50,7 +50,12 @@ const APP_TELEPORT_CLOSE_TAG = HAS_APP_TELEPORTS ? `</${appTeleportTag}>` : ''
 const PAYLOAD_URL_RE = /^[^?]*\/_payload.json(?:\?.*)?$/
 const PAYLOAD_FILENAME = '_payload.json'
 
-let entryPath: string
+const stableImports: Array<[alias: string, fileName: string | undefined]> = [
+  ['#entry', entryFileName],
+  ['#routes', routesFileName],
+  ['#layouts', layoutsFileName],
+]
+let cachedStableImportPaths: Record<string, string> | undefined
 
 const handler: ReturnType<typeof defineEventHandler> = defineEventHandler((event) => {
   // Whether we're rendering an error page
@@ -201,30 +206,39 @@ async function renderRoute (event: H3Event, ssrError: (NuxtPayload['error'] & { 
   const { styles, scripts } = getRequestDependencies(ssrContext, renderer.rendererContext)
 
   // 0. Add import map for stable chunk hashes
-  if (entryFileName && !NO_SCRIPTS) {
-    let path = entryPath
-    if (!path) {
-      path = buildAssetsURL(entryFileName) as string
-      if (ssrContext.runtimeConfig.app.cdnURL || /^(?:\/|\.+\/)/.test(path)) {
-        // cache absolute entry path
-        entryPath = path
-      } else {
-        // TODO: provide support for relative paths in assets as well
-        // relativise path
-        path = relative(event.url.pathname.replace(/\/[^/]+$/, '/'), joinURL('/', path))
-        if (!/^(?:\/|\.+\/)/.test(path)) {
-          path = `./${path}`
+  if (!NO_SCRIPTS) {
+    let imports = cachedStableImportPaths
+    if (!imports) {
+      imports = {}
+      let allAbsolute = true
+      for (const [alias, fileName] of stableImports) {
+        if (!fileName) { continue }
+        let path = buildAssetsURL(fileName) as string
+        if (!ssrContext.runtimeConfig.app.cdnURL && !/^(?:\/|\.+\/)/.test(path)) {
+          allAbsolute = false
+          // TODO: provide support for relative paths in assets as well
+          // relativise path
+          path = relative(event.url.pathname.replace(/\/[^/]+$/, '/'), joinURL('/', path))
+          if (!/^(?:\/|\.+\/)/.test(path)) {
+            path = `./${path}`
+          }
         }
+        imports[alias] = path
+      }
+      if (allAbsolute) {
+        cachedStableImportPaths = imports
       }
     }
-    ssrContext.head.push({
-      script: [{
-        tagPosition: 'head',
-        tagPriority: -2,
-        type: 'importmap',
-        innerHTML: JSON.stringify({ imports: { '#entry': path } }),
-      }],
-    }, headEntryOptions)
+    if (Object.keys(imports).length) {
+      ssrContext.head.push({
+        script: [{
+          tagPosition: 'head',
+          tagPriority: -2,
+          type: 'importmap',
+          innerHTML: JSON.stringify({ imports }),
+        }],
+      }, headEntryOptions)
+    }
   }
   // 1. Preload payloads and app manifest
   // Skip preload when inlining full payload in HTML (no separate fetch needed for initial load)

--- a/packages/vite/src/plugins/stable-entry.ts
+++ b/packages/vite/src/plugins/stable-entry.ts
@@ -2,21 +2,44 @@ import { useNitro } from '@nuxt/kit'
 import type { Nuxt } from '@nuxt/schema'
 import escapeStringRegexp from 'escape-string-regexp'
 import MagicString from 'magic-string'
-import { basename } from 'pathe'
+import { basename, resolve } from 'pathe'
 import { withoutLeadingSlash } from 'ufo'
 import type { Plugin } from 'vite'
 import { toArray } from '../utils/index.ts'
 
+interface StableAlias {
+  alias: string
+  chunkName: string
+  exportName: string
+}
+
 export function StableEntryPlugin (nuxt: Nuxt): Plugin {
   let sourcemap: boolean
-  let entryFileName: string | undefined
+
+  const routesPath = resolve(nuxt.options.buildDir, 'routes.mjs')
+  const layoutsPath = resolve(nuxt.options.buildDir, 'layouts.mjs')
+
+  const aliases: StableAlias[] = [
+    { alias: '#entry', chunkName: 'entry', exportName: 'entryFileName' },
+    { alias: '#routes', chunkName: 'routes', exportName: 'routesFileName' },
+    { alias: '#layouts', chunkName: 'layouts', exportName: 'layoutsFileName' },
+  ]
+
+  const fileNames: Record<string, string | undefined> = {}
+  for (const a of aliases) {
+    fileNames[a.exportName] = undefined
+  }
+
+  const renderVirtual = () => aliases
+    .map(a => `export const ${a.exportName} = ${JSON.stringify(fileNames[a.exportName])}`)
+    .join('\n')
 
   const nitro = useNitro()
 
   nitro.options.virtual ||= {}
   nitro.options._config.virtual ||= {}
 
-  nitro.options._config.virtual['#internal/entry-chunk.mjs'] = nitro.options.virtual['#internal/entry-chunk.mjs'] = () => `export const entryFileName = ${JSON.stringify(entryFileName)}`
+  nitro.options._config.virtual['#internal/entry-chunk.mjs'] = nitro.options.virtual['#internal/entry-chunk.mjs'] = renderVirtual
 
   return {
     name: 'nuxt:stable-entry',
@@ -24,6 +47,31 @@ export function StableEntryPlugin (nuxt: Nuxt): Plugin {
       sourcemap = !!config.build.sourcemap
     },
     apply: () => !nuxt.options.dev && nuxt.options.experimental.entryImportMap,
+    configEnvironment (name) {
+      if (name !== 'client') { return }
+      if (nuxt.options.dev || !nuxt.options.experimental.entryImportMap) { return }
+      return {
+        build: {
+          rolldownOptions: {
+            output: {
+              codeSplitting: {
+                groups: [
+                  {
+                    name: (id: string) => {
+                      const path = normalizeVirtualId(id)
+                      if (path === routesPath) { return 'routes' }
+                      if (path === layoutsPath) { return 'layouts' }
+                      return null
+                    },
+                    priority: 100,
+                  },
+                ],
+              },
+            },
+          },
+        },
+      }
+    },
     applyToEnvironment (environment) {
       if (environment.name !== 'client') {
         return false
@@ -39,14 +87,22 @@ export function StableEntryPlugin (nuxt: Nuxt): Plugin {
         .some(output => typeof output?.entryFileNames === 'string' && output?.entryFileNames.includes('[hash]'))
     },
     renderChunk (code, chunk, _options, meta) {
-      const entry = Object.values(meta.chunks).find(chunk => chunk.isEntry && chunk.name === 'entry')?.fileName
-      if (!entry || !chunk.imports.includes(entry)) {
+      const targets: Array<{ alias: string, fileName: string }> = []
+      for (const { alias, chunkName } of aliases) {
+        const target = Object.values(meta.chunks).find(c => c.name === chunkName)
+        if (!target || target.fileName === chunk.fileName) { continue }
+        if (!chunk.imports.includes(target.fileName)) { continue }
+        targets.push({ alias, fileName: target.fileName })
+      }
+      if (targets.length === 0) {
         return
       }
 
-      const filename = new RegExp(`(?<=['"])[\\./]*${escapeStringRegexp(basename(entry))}`, 'g')
       const s = new MagicString(code)
-      s.replaceAll(filename, '#entry')
+      for (const { alias, fileName } of targets) {
+        const filename = new RegExp(`(?<=['"])[\\./]*${escapeStringRegexp(basename(fileName))}`, 'g')
+        s.replaceAll(filename, alias)
+      }
 
       if (s.hasChanged()) {
         return {
@@ -56,12 +112,14 @@ export function StableEntryPlugin (nuxt: Nuxt): Plugin {
       }
     },
     writeBundle (_options, bundle) {
-      let entry = Object.values(bundle).find(chunk => chunk.type === 'chunk' && chunk.isEntry && chunk.name === 'entry')?.fileName
       const prefix = withoutLeadingSlash(nuxt.options.app.buildAssetsDir)
-      if (entry?.startsWith(prefix)) {
-        entry = entry.slice(prefix.length)
+      for (const { chunkName, exportName } of aliases) {
+        let file = Object.values(bundle).find(c => c.type === 'chunk' && c.name === chunkName)?.fileName
+        if (file?.startsWith(prefix)) {
+          file = file.slice(prefix.length)
+        }
+        fileNames[exportName] = file
       }
-      entryFileName = entry
     },
   }
 }
@@ -75,6 +133,14 @@ const supportedEnvironments = {
   ios: 16.4,
   opera: 75,
   safari: 16.4,
+}
+
+const VIRTUAL_PREFIX_RE = /^\/?virtual:nuxt:/
+function normalizeVirtualId (id: string) {
+  if (VIRTUAL_PREFIX_RE.test(id)) {
+    id = decodeURIComponent(id.replace(VIRTUAL_PREFIX_RE, ''))
+  }
+  return id.replace(/\?.*$/, '')
 }
 
 function isSupported (target: string) {

--- a/packages/vite/src/plugins/stable-entry.ts
+++ b/packages/vite/src/plugins/stable-entry.ts
@@ -14,6 +14,14 @@ interface StableAlias {
 }
 
 export function StableEntryPlugin (nuxt: Nuxt): Plugin {
+  const enabled = !nuxt.options.dev && nuxt.options.experimental.entryImportMap
+  if (!enabled) {
+    return {
+      name: 'nuxt:stable-entry',
+      apply: () => false,
+    }
+  }
+
   let sourcemap: boolean
   const stablePreloadFiles = new Set<string>()
 
@@ -47,10 +55,9 @@ export function StableEntryPlugin (nuxt: Nuxt): Plugin {
     configResolved (config) {
       sourcemap = !!config.build.sourcemap
     },
-    apply: () => !nuxt.options.dev && nuxt.options.experimental.entryImportMap,
+    apply: () => true,
     configEnvironment (name, config) {
       if (name !== 'client') { return }
-      if (nuxt.options.dev || !nuxt.options.experimental.entryImportMap) { return }
       const modulePreload = config.build?.modulePreload
       const resolveDependencies = typeof modulePreload === 'object' ? modulePreload.resolveDependencies : undefined
       if (modulePreload !== false) {

--- a/packages/vite/src/plugins/stable-entry.ts
+++ b/packages/vite/src/plugins/stable-entry.ts
@@ -143,7 +143,7 @@ export function StableEntryPlugin (nuxt: Nuxt): Plugin {
       for (const { chunkName, exportName } of aliases) {
         let file = Object.values(bundle).find(c => c.type === 'chunk' && c.name === chunkName)?.fileName
         if (file?.startsWith(prefix)) {
-          file = file.slice(prefix.length)
+          file = file.slice(prefix.length).replace(/^[\\/]+/, '')
         }
         fileNames[exportName] = file
       }
@@ -162,7 +162,7 @@ const supportedEnvironments = {
   safari: 16.4,
 }
 
-const VIRTUAL_PREFIX_RE = /^\/?virtual:nuxt:/
+const VIRTUAL_PREFIX_RE = /^\0?\/?virtual:nuxt:/
 function normalizeVirtualId (id: string) {
   if (VIRTUAL_PREFIX_RE.test(id)) {
     id = decodeURIComponent(id.replace(VIRTUAL_PREFIX_RE, ''))

--- a/packages/vite/src/plugins/stable-entry.ts
+++ b/packages/vite/src/plugins/stable-entry.ts
@@ -111,7 +111,7 @@ export function StableEntryPlugin (nuxt: Nuxt): Plugin {
       for (const { alias, chunkName } of aliases) {
         const target = Object.values(meta.chunks).find(c => c.name === chunkName)
         if (!target || target.fileName === chunk.fileName) { continue }
-        if (!chunk.imports.includes(target.fileName)) { continue }
+        if (!chunk.imports.includes(target.fileName) && !chunk.dynamicImports.includes(target.fileName)) { continue }
         targets.push({ alias, fileName: target.fileName })
       }
       if (targets.length === 0) {

--- a/packages/vite/src/plugins/stable-entry.ts
+++ b/packages/vite/src/plugins/stable-entry.ts
@@ -2,7 +2,7 @@ import { useNitro } from '@nuxt/kit'
 import type { Nuxt } from '@nuxt/schema'
 import escapeStringRegexp from 'escape-string-regexp'
 import MagicString from 'magic-string'
-import { basename, resolve } from 'pathe'
+import { basename, dirname, relative, resolve } from 'pathe'
 import { withoutLeadingSlash } from 'ufo'
 import type { Plugin } from 'vite'
 import { toArray } from '../utils/index.ts'
@@ -102,9 +102,9 @@ export function StableEntryPlugin (nuxt: Nuxt): Plugin {
           return false
         }
       }
-      // only apply plugin if the entry file name is hashed
+      // only apply plugin if any relevant output filename pattern is hashed
       return toArray(environment.config.build.rolldownOptions?.output)
-        .some(output => typeof output?.entryFileNames === 'string' && output?.entryFileNames.includes('[hash]'))
+        .some(output => [output?.entryFileNames, output?.chunkFileNames].some(pattern => typeof pattern === 'string' && pattern.includes('[hash]')))
     },
     renderChunk (code, chunk, _options, meta) {
       const targets: Array<{ alias: string, fileName: string }> = []
@@ -120,7 +120,9 @@ export function StableEntryPlugin (nuxt: Nuxt): Plugin {
 
       const s = new MagicString(code)
       for (const { alias, fileName } of targets) {
-        const filename = new RegExp(`(?<=['"])[\\./]*${escapeStringRegexp(basename(fileName))}`, 'g')
+        const specifier = relative(dirname(chunk.fileName), fileName)
+        const normalisedSpecifier = specifier.startsWith('.') ? specifier : `./${specifier}`
+        const filename = new RegExp(`(?<=['"])${escapeStringRegexp(normalisedSpecifier)}`, 'g')
         s.replaceAll(filename, alias)
       }
 

--- a/packages/vite/src/plugins/stable-entry.ts
+++ b/packages/vite/src/plugins/stable-entry.ts
@@ -15,6 +15,7 @@ interface StableAlias {
 
 export function StableEntryPlugin (nuxt: Nuxt): Plugin {
   let sourcemap: boolean
+  const stablePreloadFiles = new Set<string>()
 
   const routesPath = resolve(nuxt.options.buildDir, 'routes.mjs')
   const layoutsPath = resolve(nuxt.options.buildDir, 'layouts.mjs')
@@ -47,9 +48,21 @@ export function StableEntryPlugin (nuxt: Nuxt): Plugin {
       sourcemap = !!config.build.sourcemap
     },
     apply: () => !nuxt.options.dev && nuxt.options.experimental.entryImportMap,
-    configEnvironment (name) {
+    configEnvironment (name, config) {
       if (name !== 'client') { return }
       if (nuxt.options.dev || !nuxt.options.experimental.entryImportMap) { return }
+      const modulePreload = config.build?.modulePreload
+      const resolveDependencies = typeof modulePreload === 'object' ? modulePreload.resolveDependencies : undefined
+      if (modulePreload !== false) {
+        config.build ||= {}
+        config.build.modulePreload = {
+          ...typeof modulePreload === 'object' ? modulePreload : {},
+          resolveDependencies: (filename, deps, context) => {
+            const resolvedDeps = resolveDependencies ? resolveDependencies(filename, deps, context) : deps
+            return resolvedDeps.filter(dep => !isStablePreloadDependency(dep, stablePreloadFiles))
+          },
+        }
+      }
       return {
         build: {
           rolldownOptions: {
@@ -111,6 +124,20 @@ export function StableEntryPlugin (nuxt: Nuxt): Plugin {
         }
       }
     },
+    generateBundle: {
+      order: 'pre',
+      handler (_options, bundle) {
+        stablePreloadFiles.clear()
+        for (const { chunkName } of aliases) {
+          if (chunkName === 'entry') { continue }
+          const target = Object.values(bundle).find(c => c.type === 'chunk' && c.name === chunkName)
+          if (target?.type === 'chunk') {
+            stablePreloadFiles.add(target.fileName)
+            stablePreloadFiles.add(basename(target.fileName))
+          }
+        }
+      },
+    },
     writeBundle (_options, bundle) {
       const prefix = withoutLeadingSlash(nuxt.options.app.buildAssetsDir)
       for (const { chunkName, exportName } of aliases) {
@@ -141,6 +168,10 @@ function normalizeVirtualId (id: string) {
     id = decodeURIComponent(id.replace(VIRTUAL_PREFIX_RE, ''))
   }
   return id.replace(/\?.*$/, '')
+}
+
+function isStablePreloadDependency (dep: string, aliases: Set<string>) {
+  return aliases.has(dep) || aliases.has(dep.replace(/^\.\//, '')) || aliases.has(basename(dep))
 }
 
 function isSupported (target: string) {

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -2265,6 +2265,8 @@ describe.skipIf(isDev)('dynamic paths', () => {
 
     const html = await $fetch<string>('/')
     expect(html).toContain('<script type="importmap">{"imports":{"#entry":"./assets')
+    expect(html).toMatch(/"#routes":"\.\/assets/)
+    expect(html).toMatch(/"#layouts":"\.\/assets/)
   })
 
   it('restore server', async () => {


### PR DESCRIPTION
At the moment, the import map only covers #entry (via https://github.com/nuxt/nuxt/pull/33075) which is already a great step to stabilise chunks.

This PR follows up and also stabilizes references to the routes and layouts manifest chunks. When only a layout, page, or route definition changes, the entry chunk filename now stays stable because those manifests are referenced via alias rather than by hash.

To accomplish that, Rolldown's `output.codeSplitting.groups` is used to give routes.mjs and layouts.mjs deterministic chunk names so they can be located in `writeBundle` and be rewritten in `renderChunk`. This is a deliberate trade-off as the number of chunks/files is increased by that (and should be double checked in real world projects)!