### PR TITLE
fix(nuxt): match deduplicated `resolveComponent` calls in jsx blocks

### DIFF
--- a/packages/nuxt/src/components/plugins/loader.ts
+++ b/packages/nuxt/src/components/plugins/loader.ts
@@ -22,9 +22,13 @@ interface LoaderOptions {
 }
 
 // Match both:
-// 1. _resolveComponent("ComponentName") - Vue's component resolution
+// 1. _resolveComponent("ComponentName") - Vue's component resolution.
+//    `\d*` allows for deduplicated forms (e.g. `_resolveComponent2`) emitted by
+//    `@vue/compiler-sfc` when the same helper is imported more than once in a
+//    single SFC, which happens when a `<script setup lang="[jt]sx">` block
+//    references components from the template (nuxt/nuxt#30929).
 // 2. h(ComponentName, ...) - JSX h() calls with PascalCase component identifiers
-const REPLACE_COMPONENT_TO_DIRECT_IMPORT_RE = /(?<=[\s(=;])_?resolveComponent\s*\(\s*(?<quote>["'`])(?<lazy>lazy-|Lazy(?=[A-Z]))?(?<modifier>Idle|Visible|idle-|visible-|Interaction|interaction-|MediaQuery|media-query-|If|if-|Never|never-|Time|time-)?(?<name>[^'"`]*)\k<quote>[^)]*\)|(?<=\bh\s*\(\s*)(?<hLazy>lazy-|Lazy(?=[A-Z]))?(?<hModifier>Idle|Visible|idle-|visible-|Interaction|interaction-|MediaQuery|media-query-|If|if-|Never|never-|Time|time-)?(?<hName>[A-Z][\w$]*)\b/g
+const REPLACE_COMPONENT_TO_DIRECT_IMPORT_RE = /(?<=[\s(=;])_?resolveComponent\d*\s*\(\s*(?<quote>["'`])(?<lazy>lazy-|Lazy(?=[A-Z]))?(?<modifier>Idle|Visible|idle-|visible-|Interaction|interaction-|MediaQuery|media-query-|If|if-|Never|never-|Time|time-)?(?<name>[^'"`]*)\k<quote>[^)]*\)|(?<=\bh\s*\(\s*)(?<hLazy>lazy-|Lazy(?=[A-Z]))?(?<hModifier>Idle|Visible|idle-|visible-|Interaction|interaction-|MediaQuery|media-query-|If|if-|Never|never-|Time|time-)?(?<hName>[A-Z][\w$]*)\b/g
 
 export const LoaderPlugin = (options: LoaderOptions) => createUnplugin(() => {
   const exclude = options.transform?.exclude || []

--- a/packages/nuxt/test/component-loader.test.ts
+++ b/packages/nuxt/test/component-loader.test.ts
@@ -109,6 +109,31 @@ function _tracer(line, column, vnode) { return _tracerRecordPosition("app.vue", 
     `)
   })
 
+  it('should auto-import deduplicated _resolveComponent calls (#30929)', async () => {
+    // Mimics what `@vue/compiler-sfc` emits for an SFC whose `<script setup lang="jsx">`
+    // block calls `resolveComponent` (via JSX) and whose `<template>` also calls
+    // `resolveComponent`: the second import is suffixed (`_resolveComponent2`) and
+    // the JSX-site is rewritten to `_createVNode(_resolveComponent2("MyComponent"), …)`.
+    const content = `import { resolveComponent as _resolveComponent, createVNode as _createVNode, resolveComponent as _resolveComponent2, createVNode as _createVNode2 } from "vue";
+export default {
+  __name: 'app',
+  setup(__props) {
+    const Jsx = _createVNode2(_resolveComponent2("MyComponent"), null, null);
+    return (_ctx, _cache) => {
+      const _component_OtherComponent = _resolveComponent("OtherComponent");
+      return _createVNode(_component_OtherComponent);
+    };
+  }
+};
+`
+    const code = await ((plugin.raw({}, { framework: 'vite' }) as { transform: (code: string, id: string) => { code: string } | null }).transform(
+      content,
+      '/app.vue?vue&type=script&setup=true&lang.jsx',
+    ))
+    expect(code?.code).toContain('import { default as __nuxt_component_0 } from "/components/MyComponent.vue"')
+    expect(code?.code).toContain('_createVNode2(__nuxt_component_0, null, null)')
+  })
+
   it('should auto-import JSX components with h() calls', async () => {
     const component = `
     import { h } from 'vue'


### PR DESCRIPTION
### 🔗 Linked issue

resolves #30929

### 📚 Description

this updates our regexp to handle `_resolveComponent2` etc. which can sometimes be generated by the vue compiler, e.g. in jsx blocks