### PR TITLE
fix(nuxt): prefer our own builder/server deps

### DIFF
--- a/packages/nuxt/src/core/builder.ts
+++ b/packages/nuxt/src/core/builder.ts
@@ -264,7 +264,11 @@ async function bundle (nuxt: Nuxt) {
 
 async function loadBuilder (nuxt: Nuxt, builder: string): Promise<NuxtBuilder> {
   try {
-    return await importModule(builder, { url: [directoryToURL(nuxt.options.rootDir), new URL(import.meta.url)] })
+    // prefer our own dependency tree before walking up from rootDir
+    if (builder === '@nuxt/vite-builder') {
+      return await import(builder)
+    }
+    return await importModule(builder, { url: [new URL(import.meta.url), directoryToURL(nuxt.options.rootDir)] })
   } catch (err) {
     throw new Error(`Loading \`${builder}\` builder failed. You can read more about the nuxt \`builder\` option at: \`https://nuxt.com/docs/4.x/api/nuxt-config#builder\``, { cause: err })
   }

--- a/packages/nuxt/src/core/server.ts
+++ b/packages/nuxt/src/core/server.ts
@@ -18,7 +18,11 @@ export async function bundleServer (nuxt: Nuxt) {
 
 async function loadServerBuilder (nuxt: Nuxt, builder = '@nuxt/nitro-server'): Promise<NuxtBuilder> {
   try {
-    return await importModule(builder, { url: [directoryToURL(nuxt.options.rootDir), new URL(import.meta.url)] })
+    // prefer our own dependency tree before walking up from rootDir
+    if (builder === '@nuxt/nitro-server') {
+      return await import(builder)
+    }
+    return await importModule(builder, { url: [new URL(import.meta.url), directoryToURL(nuxt.options.rootDir)] })
   } catch (err) {
     throw new Error(`Loading \`${builder}\` server builder failed. You can read more about the nuxt \`server.builder\` option at: \`https://nuxt.com/docs/4.x/api/nuxt-config#builder-1\``, { cause: err })
   }


### PR DESCRIPTION
### 🔗 Linked issue

resolves #34164

### 📚 Description

we had a couple of issues, from #34164 to  https://github.com/nuxt/nuxt/issues/33606 that were a bit misleading - the issue was that mixed nuxt dependencies were being loaded - e.g. a `@nuxt/nitro-server` or `@nuxt/vite-builder` that didn't match the installed nuxt version, and this was possible because we were directly resolving it from `rootDir` rather than as a dependency of nuxt.

this will still be possible for non-default builders (webpack/rspack) but for the common case, this footgun is removed.