### PR TITLE
fix(nuxt): render component-less parent routes during client-side nav

### DIFF
--- a/packages/nuxt/src/pages/runtime/page.ts
+++ b/packages/nuxt/src/pages/runtime/page.ts
@@ -264,12 +264,16 @@ function haveParentRoutesRendered (fork: RouteLocationNormalizedLoaded | null, n
   if (!fork) { return false }
 
   const index = newRoute.matched.findIndex(m => m.components?.default === Component?.type)
-  if (!index || index === -1) { return false }
+  if (index === -1) { return false }
+
+  // Parent routes without a component are transparent — Vue Router renders the child directly
+  // at the parent's depth (see #34967), so they don't contribute a "parent render" above us.
+  const newParents = newRoute.matched.slice(0, index).filter(m => m.components?.default)
+  if (!newParents.length) { return false }
+  const forkParents = fork.matched.filter(m => m.components?.default)
 
   // we only care whether the parent route components have had to rerender
-  return newRoute.matched.slice(0, index)
-    .some(
-      (c, i) => c.components?.default !== fork.matched[i]?.components?.default) ||
+  return newParents.some((c, i) => c.components?.default !== forkParents[i]?.components?.default) ||
     (Component && generateRouteKey({ route: newRoute, Component }) !== generateRouteKey({ route: fork, Component }))
 }
 

--- a/test/nuxt/nuxt-page.test.ts
+++ b/test/nuxt/nuxt-page.test.ts
@@ -737,6 +737,7 @@ describe('NuxtPage should render child routes when the parent route omits its co
 
     router.addRoute({
       // parent route deliberately has no component (added via `pages:extend` without `file`)
+      name: 'parent-34967',
       path: '/parent-34967',
       children: [
         {
@@ -752,7 +753,8 @@ describe('NuxtPage should render child routes when the parent route omits its co
   })
 
   afterEach(() => {
-    router.clearRoutes()
+    router.removeRoute('index-34967')
+    router.removeRoute('parent-34967')
   })
 
   it('renders the child after client-side navigation into a parent without a component', async () => {

--- a/test/nuxt/nuxt-page.test.ts
+++ b/test/nuxt/nuxt-page.test.ts
@@ -731,7 +731,7 @@ describe('NuxtPage should render child routes when the parent route omits its co
       path: '/index-34967',
       component: defineComponent({
         name: 'index-34967',
-        setup: () => () => h('div', { 'data-testid': 'index-34967' }, 'Index'),
+        render: () => h('div', { 'data-testid': 'index-34967' }, 'Index'),
       }),
     })
 
@@ -744,7 +744,7 @@ describe('NuxtPage should render child routes when the parent route omits its co
           path: 'child',
           component: defineComponent({
             name: 'child-34967',
-            setup: () => () => h('div', { 'data-testid': 'child-34967' }, 'Child'),
+            render: () => h('div', { 'data-testid': 'child-34967' }, 'Child'),
           }),
         },
       ],
@@ -752,8 +752,7 @@ describe('NuxtPage should render child routes when the parent route omits its co
   })
 
   afterEach(() => {
-    router.removeRoute('index-34967')
-    router.removeRoute('child-34967')
+    router.clearRoutes()
   })
 
   it('renders the child after client-side navigation into a parent without a component', async () => {

--- a/test/nuxt/nuxt-page.test.ts
+++ b/test/nuxt/nuxt-page.test.ts
@@ -717,6 +717,65 @@ describe('nuxtApp._route should follow the router on tree-narrowing navigations'
   })
 })
 
+// https://github.com/nuxt/nuxt/issues/34967
+describe('NuxtPage should render child routes when the parent route omits its component', () => {
+  let router: ReturnType<typeof useRouter>
+  let nuxtApp: ReturnType<typeof useNuxtApp>
+
+  beforeEach(() => {
+    router = useRouter()
+    nuxtApp = useNuxtApp()
+
+    router.addRoute({
+      name: 'index-34967',
+      path: '/index-34967',
+      component: defineComponent({
+        name: 'index-34967',
+        setup: () => () => h('div', { 'data-testid': 'index-34967' }, 'Index'),
+      }),
+    })
+
+    router.addRoute({
+      // parent route deliberately has no component (added via `pages:extend` without `file`)
+      path: '/parent-34967',
+      children: [
+        {
+          name: 'child-34967',
+          path: 'child',
+          component: defineComponent({
+            name: 'child-34967',
+            setup: () => () => h('div', { 'data-testid': 'child-34967' }, 'Child'),
+          }),
+        },
+      ],
+    })
+  })
+
+  afterEach(() => {
+    router.removeRoute('index-34967')
+    router.removeRoute('child-34967')
+  })
+
+  it('renders the child after client-side navigation into a parent without a component', async () => {
+    const el = await mountSuspended({
+      setup: () => () => h(NuxtLayout, {}, { default: () => h(NuxtPage) }),
+    })
+
+    await navigateTo('/index-34967')
+    await flushPromises()
+    expect(el.html()).toContain('Index')
+    expect(nuxtApp._route.path).toBe('/index-34967')
+
+    await navigateTo('/parent-34967/child')
+    await flushPromises()
+    expect(nuxtApp._route.path).toBe('/parent-34967/child')
+    expect(el.html()).toContain('Child')
+    expect(el.html()).not.toContain('Index')
+
+    el.unmount()
+  })
+})
+
 describe('NuxtPage should work with keepalive options', () => {
   let visits = 0
   let router: ReturnType<typeof useRouter>


### PR DESCRIPTION
### 🔗 Linked issue

resolves  #34967

### 📚 Description

this bug was introduced in #21823 - some time ago! - in Nuxt v3.6.2...