### PR TITLE
fix(vite): don't strip buildAssetsDir from vite-node SSR ids

### DIFF
--- a/packages/vite/src/plugins/vite-node.ts
+++ b/packages/vite/src/plugins/vite-node.ts
@@ -236,7 +236,7 @@ export function ViteNodePlugin (nuxt: Nuxt): VitePlugin | undefined {
           socketPath,
           root: nuxt.options.srcDir,
           entryPath: resolveServerEntry(ssrServer.config),
-          base: ssrServer.config.base || '/_nuxt/',
+          base: '/',
           maxRetryAttempts: nuxt.options.vite.viteNode?.maxRetryAttempts,
           baseRetryDelay: nuxt.options.vite.viteNode?.baseRetryDelay,
           maxRetryDelay: nuxt.options.vite.viteNode?.maxRetryDelay,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1320,6 +1320,12 @@ importers:
 
   test/fixtures/basic-types/_local-modules/hook-augmenting-module: {}
 
+  test/fixtures/build-assets-dir-collision:
+    dependencies:
+      nuxt:
+        specifier: workspace:*
+        version: link:../../../packages/nuxt
+
   test/fixtures/hmr:
     dependencies:
       nuxt:

--- a/test/build-assets-dir-collision.test.ts
+++ b/test/build-assets-dir-collision.test.ts
@@ -1,0 +1,24 @@
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { isWindows } from 'std-env'
+import { $fetch, setup } from '@nuxt/test-utils/e2e'
+
+import { builder, isDev } from './matrix'
+
+if (builder === 'vite') {
+  await setup({
+    rootDir: fileURLToPath(new URL('./fixtures/build-assets-dir-collision', import.meta.url)),
+    dev: isDev,
+    server: true,
+    browser: false,
+    setupTimeout: (isWindows ? 360 : 120) * 1000,
+  })
+}
+
+describe.skipIf(builder !== 'vite')('buildAssetsDir collision with source dir (#24035)', () => {
+  it('renders without crashing on SSR', async () => {
+    const html = await $fetch<string>('/')
+    expect(html).toContain('data-testid="hello"')
+    expect(html).toContain('hello world')
+  })
+})

--- a/test/fixtures/build-assets-dir-collision/app/abc/main.css
+++ b/test/fixtures/build-assets-dir-collision/app/abc/main.css
@@ -1,0 +1,1 @@
+.regression-marker { color: rebeccapurple; }

--- a/test/fixtures/build-assets-dir-collision/app/app.vue
+++ b/test/fixtures/build-assets-dir-collision/app/app.vue
@@ -1,0 +1,9 @@
+<template>
+  <div data-testid="hello">
+    hello {{ msg }}
+  </div>
+</template>
+
+<script setup>
+const msg = 'world'
+</script>

--- a/test/fixtures/build-assets-dir-collision/nuxt.config.ts
+++ b/test/fixtures/build-assets-dir-collision/nuxt.config.ts
@@ -1,0 +1,9 @@
+import { withMatrix } from '../../matrix'
+
+// Regression fixture for nuxt/nuxt#24035: `buildAssetsDir` ('abc') collides
+// with a source directory of the same name that contains a CSS file
+// referenced via the `@/` alias.
+export default withMatrix({
+  app: { buildAssetsDir: 'abc' },
+  css: ['@/abc/main.css'],
+})

--- a/test/fixtures/build-assets-dir-collision/package.json
+++ b/test/fixtures/build-assets-dir-collision/package.json
@@ -1,0 +1,13 @@
+{
+  "private": true,
+  "name": "fixture-build-assets-dir-collision",
+  "scripts": {
+    "build": "nuxt build"
+  },
+  "dependencies": {
+    "nuxt": "workspace:*"
+  },
+  "engines": {
+    "node": "^20.19.0 || >=22.12.0"
+  }
+}

--- a/test/fixtures/build-assets-dir-collision/tsconfig.json
+++ b/test/fixtures/build-assets-dir-collision/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./.nuxt/tsconfig.app.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.server.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.shared.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.node.json"
+    }
+  ]
+}


### PR DESCRIPTION
### 🔗 Linked issue

resolves #24035

### 📚 Description

`vite-node` strips `base` from any module id it receives... but vite's SSR transform never prepends base to URLs, so the strip is unnecessary for SSR ids....