### PR TITLE
fix(nitro): mark `@babel/plugin-syntax-typescript` as optional peer dep

### DIFF
--- a/packages/nitro-server/package.json
+++ b/packages/nitro-server/package.json
@@ -31,7 +31,6 @@
     "test:attw": "attw --pack"
   },
   "dependencies": {
-    "@babel/plugin-syntax-typescript": "^7.28.6",
     "@nuxt/kit": "workspace:*",
     "@unhead/vue": "^2.1.15",
     "@vue/shared": "3.5.34",
@@ -60,11 +59,15 @@
   },
   "peerDependencies": {
     "@babel/plugin-proposal-decorators": "^7.25.0",
+    "@babel/plugin-syntax-typescript": "^7.25.0",
     "@rollup/plugin-babel": "^6.0.0 || ^7.0.0",
     "nuxt": "workspace:^"
   },
   "peerDependenciesMeta": {
     "@babel/plugin-proposal-decorators": {
+      "optional": true
+    },
+    "@babel/plugin-syntax-typescript": {
       "optional": true
     },
     "@rollup/plugin-babel": {
@@ -73,6 +76,7 @@
   },
   "devDependencies": {
     "@babel/plugin-proposal-decorators": "7.29.0",
+    "@babel/plugin-syntax-typescript": "7.28.6",
     "@nuxt/schema": "workspace:*",
     "@rollup/plugin-babel": "7.0.0",
     "hookable": "6.1.1",

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -536,7 +536,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
 
   // Add decorator support via Babel when experimental.decorators is enabled.
   if (nuxt.options.experimental.decorators) {
-    const nitroDecoratorDeps = ['@rollup/plugin-babel', '@babel/plugin-proposal-decorators']
+    const nitroDecoratorDeps = ['@rollup/plugin-babel', '@babel/plugin-proposal-decorators', '@babel/plugin-syntax-typescript']
     const result = await ensureDependencyInstalled(nitroDecoratorDeps, {
       rootDir: nuxt.options.rootDir,
       searchPaths: nuxt.options.modulesDir,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -337,9 +337,6 @@ importers:
 
   packages/nitro-server:
     dependencies:
-      '@babel/plugin-syntax-typescript':
-        specifier: ^7.28.6
-        version: 7.28.6(@babel/core@7.29.0)
       '@nuxt/kit':
         specifier: workspace:*
         version: link:../kit
@@ -419,6 +416,9 @@ importers:
       '@babel/plugin-proposal-decorators':
         specifier: 7.29.0
         version: 7.29.0(@babel/core@7.29.0)
+      '@babel/plugin-syntax-typescript':
+        specifier: 7.28.6
+        version: 7.28.6(@babel/core@7.29.0)
       '@nuxt/schema':
         specifier: workspace:*
         version: link:../schema


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

spotted that this ended up pulling `@babel/core` in via a peer dep