### PR TITLE
fix(nitro): add json extension to payload cache items

### DIFF
--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -124,8 +124,8 @@ async function renderRoute (event: H3Event, ssrError: (NuxtPayload['error'] & { 
     const url = ssrContext.url.substring(0, ssrContext.url.lastIndexOf('/')) || '/'
     ssrContext.url = url
 
-    if (import.meta.prerender && await payloadCache!.hasItem(url)) {
-      return returnResponse(event, await payloadCache!.getItem(url) as Partial<RenderResponse>)
+    if (import.meta.prerender && await payloadCache!.hasItem(url + '.json')) {
+      return returnResponse(event, await payloadCache!.getItem(url + '.json') as Partial<RenderResponse>)
     }
   }
 
@@ -192,7 +192,7 @@ async function renderRoute (event: H3Event, ssrError: (NuxtPayload['error'] & { 
     // Hint nitro to prerender payload for this route
     event.res.headers.append('x-nitro-prerender', joinURL(ssrContext.url.replace(/\?.*$/, ''), PAYLOAD_FILENAME))
     // Use same ssr context to generate payload for this route
-    await payloadCache!.setItem(ssrContext.url === '/' ? '/' : ssrContext.url.replace(/\/$/, ''), renderPayloadResponse(ssrContext))
+    await payloadCache!.setItem((ssrContext.url === '/' ? '/' : ssrContext.url.replace(/\/$/, '')) + '.json', renderPayloadResponse(ssrContext))
   }
 
   const NO_SCRIPTS = NUXT_NO_SCRIPTS || !!routeOptions?.noScripts

--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -182,7 +182,7 @@ async function renderRoute (event: H3Event, ssrError: (NuxtPayload['error'] & { 
   if (isRenderingPayload) {
     const response = renderPayloadResponse(ssrContext)
     if (import.meta.prerender) {
-      await payloadCache!.setItem(ssrContext.url, response)
+      await payloadCache!.setItem(ssrContext.url + '.json', response)
     }
 
     return returnResponse(event, response)


### PR DESCRIPTION
This fixes #34961 which is caused by the url being used as is to store the cache items. The problem is urls can have nesting (eg: `/mypath`, `/mypath/mysubpath`)


### 🔗 Linked issue
resolves #34961 
https://github.com/unjs/unstorage/issues/775

### 📚 Description
This fixes #34961 which is caused by the url being used as is to store the cache items. The problem is urls can have content at each nesting level (eg: `/mypath`, `/mypath/mysubpath`) but a filesystem cannot

Since the fs driver does not differentiate between folders and files. This means `/mypath` becomes a file with the cache content and when you try to write `/mypath/mysubpath` it fails because `/mypath` is a file and not a directory.

With this PR there is no conflict issue because
`/mypath` will store as `/mypath.json`
`/mypath/mysubpath` will store as `/mypath/mysubpath.json`

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.


If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->

This should be backported to both 3.x and 4.x as this issue is wrecking havock on both versions since this feature was introduced.

I am not sure if the cache would be cleared automatically after a new build, so anyone affected might need to clear the cache directory manually.

Another option would be to use the sha-256 hash of the url as the cache key as is done in the other cache driver. This would avoid the issue of the cache needing to be cleared as well. And will avoid any kind of issues with fs path normalization.
