### PR TITLE
fix(nuxt): handle errors fetching app manifest

### DIFF
--- a/packages/nuxt/src/app/composables/manifest.ts
+++ b/packages/nuxt/src/app/composables/manifest.ts
@@ -32,6 +32,12 @@ function fetchManifest (): Promise<NuxtAppManifest> {
   } else {
     _manifest = $fetch<NuxtAppManifest>(buildAssetsURL(`builds/meta/${useRuntimeConfig().app.buildId}.json`), {
       responseType: 'json',
+    }).then((res) => {
+      // handle errors fetching manifest, e.g. from an improperly configured proxy
+      if (!res || typeof res !== 'object' || !Array.isArray((res as NuxtAppManifest).prerendered)) {
+        throw new Error('[nuxt] Received malformed app manifest. Ensure that `builds/meta/*.json` is served as JSON by your hosting/proxy and not rewritten to an HTML fallback.')
+      }
+      return res
     })
   }
   manifest = _manifest

--- a/packages/nuxt/src/app/composables/payload.ts
+++ b/packages/nuxt/src/app/composables/payload.ts
@@ -113,8 +113,13 @@ async function _isPrerenderedInManifest (url: string) {
     return false
   }
   url = url === '/' ? url : url.replace(/\/$/, '')
-  const manifest = await getAppManifest()
-  return manifest.prerendered.includes(url)
+  try {
+    const manifest = await getAppManifest()
+    return manifest.prerendered.includes(url)
+  } catch {
+    // handle errors fetching manifest
+    return false
+  }
 }
 
 /**


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/35042

### 📚 Description

this adds a bit of defensive handling of fetching the app manifest, similar to #34555