### PR TITLE
fix(nuxt): encode html-significant characters in external redirect body

### DIFF
--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -127,7 +127,18 @@ export interface NavigateToOptions {
   open?: OpenOptions
 }
 
-const URL_QUOTE_RE = /"/g
+const HTML_ATTR_UNSAFE_RE = /[&"'<>]/g
+const HTML_ATTR_ENCODE_MAP: Record<string, string> = {
+  '&': '%26',
+  '"': '%22',
+  '\'': '%27',
+  '<': '%3C',
+  '>': '%3E',
+}
+function encodeForHtmlAttr (value: string): string {
+  return value.replace(HTML_ATTR_UNSAFE_RE, c => HTML_ATTR_ENCODE_MAP[c]!)
+}
+
 /**
  * A helper that aids in programmatic navigation within your Nuxt application.
  *
@@ -201,7 +212,7 @@ export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: Na
       const redirect = async function (response: any) {
         // TODO: consider deprecating in favour of `app:rendered` and removing
         await nuxtApp.callHook('app:redirected')
-        const encodedLoc = location.replace(URL_QUOTE_RE, '%22')
+        const encodedLoc = encodeForHtmlAttr(location)
         const encodedHeader = encodeURL(location, isExternalHost)
 
         nuxtApp.ssrContext!['~renderResponse'] = {

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1220,6 +1220,20 @@ describe('navigate', () => {
     expect(status).toEqual(302)
     expect(headers.get('location') || '').toEqual(encodeURI('/cœur') + '?redirected=' + encodeURIComponent('https://google.com'))
   })
+
+  it('encodes HTML-significant characters in external redirect body', async () => {
+    const res = await fetch('/navigate-to-external-encode', { redirect: 'manual' })
+    const body = await res.text()
+    expect(res.status).toEqual(302)
+    expect(res.headers.get('location')).not.toContain('<')
+    expect(res.headers.get('location')).not.toContain('>')
+    const content = body.match(/content="0; url=([^"]*)"/)?.[1] ?? ''
+    expect(content).not.toMatch(/[<>&"']/)
+    expect(content).toContain('%3C')
+    expect(content).toContain('%3E')
+    expect(content).toContain('%26')
+    expect(content).toContain('%27')
+  })
 })
 
 describe('preserves current instance', () => {

--- a/test/fixtures/basic/app/pages/navigate-to-external-encode.vue
+++ b/test/fixtures/basic/app/pages/navigate-to-external-encode.vue
@@ -1,0 +1,7 @@
+<template>
+  <div>You should not see me</div>
+</template>
+
+<script setup lang="ts">
+await navigateTo('https://example.com/x><img src=x>&"\'', { external: true })
+</script>


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

handles additional html-significant characters