### PR TITLE
fix(vite): strip queries in css inline styles map

### DIFF
--- a/packages/vite/src/plugins/ssr-styles.ts
+++ b/packages/vite/src/plugins/ssr-styles.ts
@@ -273,7 +273,7 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
               continue
             }
 
-            const relativePath = relativeToSrcDir(moduleId)
+            const relativePath = relativeToSrcDir(stripQuery(moduleId))
             if (relativePath in cssMap) {
               cssMap[relativePath]!.inBundle = cssMap[relativePath]!.inBundle ?? ((isVue(moduleId) && !!relativePath) || isEntry)
             }
@@ -332,7 +332,7 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
               if (options.shouldInline === false || (typeof options.shouldInline === 'function' && !options.shouldInline(id))) { return }
             }
 
-            const relativeId = relativeToSrcDir(id)
+            const relativeId = relativeToSrcDir(stripQuery(id))
             const idMap = cssMap[relativeId] ||= { files: [] }
             const idCssIds = idMap.cssIds ||= new Set()
 

--- a/test/fixtures/inline-styles/assets/script-setup-css.css
+++ b/test/fixtures/inline-styles/assets/script-setup-css.css
@@ -1,0 +1,3 @@
+.script-setup-css {
+  --inline-script-setup-css-token: script-setup-css;
+}

--- a/test/fixtures/inline-styles/components/ScriptSetupCss.vue
+++ b/test/fixtures/inline-styles/components/ScriptSetupCss.vue
@@ -1,0 +1,7 @@
+<script setup>
+import '~/assets/script-setup-css.css'
+</script>
+
+<template>
+  <span class="script-setup-css" />
+</template>

--- a/test/fixtures/inline-styles/pages/js-imported-css.vue
+++ b/test/fixtures/inline-styles/pages/js-imported-css.vue
@@ -2,5 +2,6 @@
   <main>
     <PreprocessorFromScript />
     <JSModuleComponentWrapper />
+    <ScriptSetupCss />
   </main>
 </template>

--- a/test/inline-styles.test.ts
+++ b/test/inline-styles.test.ts
@@ -38,9 +38,11 @@ describe.skipIf(builder !== 'vite' || !isBuilt)('inline styles', () => {
   })
 
   // https://github.com/nuxt/nuxt/issues/27417
+  // https://github.com/nuxt/nuxt/issues/35065
   it.each([
     ['preprocessor extension imported from <script>', '--inline-preprocessor-from-script-token:preprocessor-from-script'],
     ['CSS imported as a side effect from a non-Vue JS module', '--inline-js-module-token:js-module'],
+    ['CSS imported from <script setup>', '--inline-script-setup-css-token:script-setup-css'],
   ])('inlines CSS for %s', async (_, token) => {
     const html = await readFile(join(outputDir, 'public', 'js-imported-css/index.html'), 'utf-8')
     expect(html).toContain(token)


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/35065

### 📚 Description

missed this when implementing #35020 (it shouldn't have _broken_ anyone but just didn't work properly)