### PR TITLE
test: reproduce nested lazy component chunk-error crash

### DIFF
--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1344,6 +1344,31 @@ describe('errors', () => {
 
     await expectNoClientErrors('/error/error-boundary')
   })
+
+  // Regression test for https://github.com/nuxt/nuxt/issues/29624
+  // A lazy component whose dynamic import rejects (as happens after a redeploy
+  // when the previous chunk no longer exists) should be handled gracefully
+  // instead of crashing the app.
+  it.runIf(!isDev && builder !== 'rspack')('should handle chunk loading errors in nested lazy components', async () => {
+    const { page, consoleLogs, pageErrors } = await renderPage()
+    await page.goto(url('/'))
+    await page.waitForFunction(() => window.useNuxtApp?.()._route.fullPath === '/' && !window.useNuxtApp?.().isHydrating)
+    consoleLogs.length = 0
+    pageErrors.length = 0
+
+    await page.locator('#to-lazy-chunk-error').click()
+    await page.waitForURL(url('/lazy-chunk-error'))
+
+    // Give Nuxt a moment to react to the rejected dynamic import.
+    await page.waitForTimeout(500)
+
+    const logs = consoleLogs.map(c => c.text).join('\n')
+    const errors = pageErrors.map(e => e.message).join('\n')
+
+    expect(logs + '\n' + errors).toContain('caught chunk load error')
+
+    await page.close()
+  })
 })
 
 describe('navigate external', () => {

--- a/test/fixtures/basic/app/pages/index.vue
+++ b/test/fixtures/basic/app/pages/index.vue
@@ -39,6 +39,13 @@
       Chunk error
     </NuxtLink>
     <NuxtLink
+      id="to-lazy-chunk-error"
+      no-prefetch
+      to="/lazy-chunk-error"
+    >
+      Lazy chunk error
+    </NuxtLink>
+    <NuxtLink
       id="to-client-only-components"
       to="/client-only-components"
     >

--- a/test/fixtures/basic/app/pages/lazy-chunk-error.vue
+++ b/test/fixtures/basic/app/pages/lazy-chunk-error.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import { defineAsyncComponent } from 'vue'
+
+// Simulates what the browser throws when a dynamically imported module cannot be fetched
+// after a redeploy (chunk file no longer exists).
+const LazyBroken = defineAsyncComponent(() => Promise.reject(
+  new TypeError(
+    'Failed to fetch dynamically imported module: ' + (import.meta.client ? window.location.origin : '') + '/_nuxt/missing-chunk-after-redeploy.js',
+  ),
+))
+</script>
+
+<template>
+  <div>
+    <p>Lazy chunk error page</p>
+    <ClientOnly>
+      <LazyBroken />
+    </ClientOnly>
+  </div>
+</template>


### PR DESCRIPTION
WIP. Adds a failing regression test for #29624.

Verified failure for nested lazy components inside a page — `app:chunkError` never fires and the rejection surfaces as an unhandled page error. Still needs a fix and manual review.