### PR TITLE
fix(kit): respect `tsConfig.exclude` in legacy `tsconfig.json`

### DIFF
--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -491,6 +491,7 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
   tsConfig.compilerOptions ||= {}
   tsConfig.compilerOptions.paths ||= {}
   tsConfig.include ||= []
+  tsConfig.exclude ||= []
 
   const importPaths = nuxt.options.modulesDir.map(d => directoryToURL(d))
 
@@ -556,7 +557,7 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
   const legacyTsConfig: TSConfig = defu({}, {
     ...tsConfig,
     include: [...tsConfig.include, ...legacyInclude],
-    exclude: [...legacyExclude],
+    exclude: [...tsConfig.exclude, ...legacyExclude],
   })
 
   async function resolveConfig (tsConfig: TSConfig) {


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/35078

### 📚 Description

When customising the generated tsconfigs, the `exclude` field is not forwarded to the legacy `.nuxt/tsconfig.json` - unlike the `include` field. Passing it to  `legacyConfig` fixes it. I suppose this was a miss ? 


#### Before
[Reproduction ](https://stackblitz.com/edit/github-xrteraid?file=.nuxt%2Ftsconfig.app.json)


<img width="1854" height="790" alt="image" src="https://github.com/user-attachments/assets/ad39c6dd-26c9-4043-b241-14ccb59948f0" />

#### After
Tested with local build of nuxt/kit 

https://github.com/user-attachments/assets/aed9a60d-bb7f-4ccd-98fd-9c72fa71ae90
