### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/docs/4.api/6.nuxt-config.md
+++ b/docs/4.api/6.nuxt-config.md
@@ -1607,6 +1607,30 @@ Configuration that will be passed directly to Vite.
 **See**: [Vite configuration docs](https://vite.dev/config/) for more information.
 Please note that not all vite options are supported in Nuxt.
 
+Use `$client` and `$server` to pass Vite options to only one build environment.
+Options outside these blocks remain shared by both environments.
+
+```ts
+export default defineNuxtConfig({
+  vite: {
+    $client: {
+      build: {
+        rollupOptions: {
+          output: {
+            chunkFileNames: '_nuxt/[name].[hash].js',
+          },
+        },
+      },
+    },
+    $server: {
+      build: {
+        sourcemap: true,
+      },
+    },
+  },
+})
+```
+
 ### `build`
 
 #### `assetsDir`


### PR DESCRIPTION
### 🔗 Linked issue

resolves #30997

### 📚 Description

Documents the `vite.$client` and `vite.$server` environment override blocks in the Nuxt configuration reference, including a small example showing client-only and server-only Vite options.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated documentation where necessary.

### ✅ Verification

- `git diff --check`