### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/docs/4.api/2.composables/use-async-data.md
+++ b/docs/4.api/2.composables/use-async-data.md
@@ -232,34 +232,32 @@ If you have not fetched data on the server (for example, with `server: false`), 
 ```ts [Signature]
 export type AsyncDataHandler<ResT> = (nuxtApp: NuxtApp, options: { signal: AbortSignal }) => Promise<ResT>
 
-export function useAsyncData<DataT, DataE> (
-  handler: AsyncDataHandler<DataT>,
-  options?: AsyncDataOptions<DataT>,
+export function useAsyncData<ResT, DataT = ResT, DataE = Error> (
+  handler: AsyncDataHandler<ResT>,
+  options?: AsyncDataOptions<ResT, DataT>,
 ): AsyncData<DataT, DataE>
-export function useAsyncData<DataT, DataE> (
+
+export function useAsyncData<ResT, DataT = ResT, DataE = Error> (
   key: MaybeRefOrGetter<string>,
-  handler: AsyncDataHandler<DataT>,
-  options?: AsyncDataOptions<DataT>,
+  handler: AsyncDataHandler<ResT>,
+  options?: AsyncDataOptions<ResT, DataT>,
 ): Promise<AsyncData<DataT, DataE>>
 
-type AsyncDataOptions<DataT> = {
+type AsyncDataOptions<ResT, DataT = ResT> = {
   server?: boolean
   lazy?: boolean
   immediate?: boolean
   deep?: boolean
   dedupe?: 'cancel' | 'defer'
-  default?: () => DataT | Ref<DataT> | null
-  transform?: (input: DataT) => DataT | Promise<DataT>
+  default?: () => DataT | Ref<DataT>
+  transform?: (input: ResT) => DataT | Promise<DataT>
   pick?: string[]
-  watch?: MultiWatchSources | false
-  getCachedData?: (key: string, nuxtApp: NuxtApp, ctx: AsyncDataRequestContext) => DataT | undefined
+  watch?: MultiWatchSources
+  getCachedData?: (key: string, nuxtApp: NuxtApp, context: { cause: AsyncDataRefreshCause }) => DataT | undefined
   timeout?: number
 }
 
-type AsyncDataRequestContext = {
-  /** The reason for this data request */
-  cause: 'initial' | 'refresh:manual' | 'refresh:hook' | 'watch'
-}
+type AsyncDataRefreshCause = 'initial' | 'refresh:hook' | 'refresh:manual' | 'watch'
 
 type AsyncData<DataT, ErrorT> = {
   data: Ref<DataT | undefined>
@@ -273,8 +271,9 @@ type AsyncData<DataT, ErrorT> = {
 
 interface AsyncDataExecuteOptions {
   dedupe?: 'cancel' | 'defer'
-  timeout?: number
+  cause?: AsyncDataRefreshCause
   signal?: AbortSignal
+  timeout?: number
 }
 
 type AsyncDataRequestStatus = 'idle' | 'pending' | 'success' | 'error'


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #23114 (follow-up to #34807)

### 📚 Description

Complete fix for all type signature inaccuracies in the `useAsyncData` docs type block, as discussed with @danielroe in #34807.

Changes against source (`packages/nuxt/src/app/composables/asyncData.ts`):

| # | What | Why |
|---|------|-----|
| 1 | `useAsyncData` generics: `<DataT, DataE>` → `<ResT, DataT = ResT, DataE = Error>` | Source distinguishes `ResT` (handler response) from `DataT` (transformed data) |
| 2 | Handler param: `AsyncDataHandler<DataT>` → `AsyncDataHandler<ResT>` | Handler returns `ResT`, not `DataT` |
| 3 | Options generic: `AsyncDataOptions<DataT>` → `AsyncDataOptions<ResT, DataT>` | Matches source L98-103 |
| 4 | `default`: remove `\| null` | Not in source (L68) |
| 5 | `transform`: input `DataT` → `ResT` | Transform converts `ResT` to `DataT` (L114, L19) |
| 6 | `watch`: remove `\| false` | Not in source type (L77) |
| 7 | `getCachedData`: `ctx: AsyncDataRequestContext` → `context: { cause: AsyncDataRefreshCause }` | Matches source (L109, L128); `AsyncDataRequestContext` doesn't exist |
| 8 | Replace `AsyncDataRequestContext` type with `AsyncDataRefreshCause` | Matches source export (L47) |
| 9 | `AsyncDataExecuteOptions`: add `cause?: AsyncDataRefreshCause` | Present in source (L144), not `@internal` |