### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/docs/4.api/6.nuxt-config.md
+++ b/docs/4.api/6.nuxt-config.md
@@ -1607,6 +1607,30 @@ Configuration that will be passed directly to Vite.
 **See**: [Vite configuration docs](https://vite.dev/config/) for more information.
 Please note that not all vite options are supported in Nuxt.
 
+Use `$client` and `$server` to pass Vite options to only one build environment.
+Options outside these blocks remain shared by both environments.
+
+```ts
+export default defineNuxtConfig({
+  vite: {
+    $client: {
+      build: {
+        rollupOptions: {
+          output: {
+            chunkFileNames: '_nuxt/[name].[hash].js',
+          },
+        },
+      },
+    },
+    $server: {
+      build: {
+        sourcemap: true,
+      },
+    },
+  },
+})
+```
+
 ### `build`
 
 #### `assetsDir`


### PR DESCRIPTION
### Summary

- document the `vite.$client` and `vite.$server` environment-specific config blocks
- add a Nuxt config example showing client-only and server-only Vite options

Closes #30997

### Validation

- `git diff --check upstream/main...HEAD`

I could not run the full docs lint locally because this sparse checkout does not have dependencies installed.