### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/docs/4.api/6.nuxt-config.md
+++ b/docs/4.api/6.nuxt-config.md
@@ -1607,6 +1607,30 @@ Configuration that will be passed directly to Vite.
 **See**: [Vite configuration docs](https://vite.dev/config/) for more information.
 Please note that not all vite options are supported in Nuxt.
 
+Use `$client` and `$server` to pass Vite options to only one build environment.
+Options outside these blocks remain shared by both environments.
+
+```ts
+export default defineNuxtConfig({
+  vite: {
+    $client: {
+      build: {
+        rollupOptions: {
+          output: {
+            chunkFileNames: '_nuxt/[name].[hash].js',
+          },
+        },
+      },
+    },
+    $server: {
+      build: {
+        sourcemap: true,
+      },
+    },
+  },
+})
+```
+
 ### `build`
 
 #### `assetsDir`

--- a/lychee.toml
+++ b/lychee.toml
@@ -37,6 +37,7 @@ exclude = [
   "https://stackoverflow.com/help/minimal-reproducible-example",
   "https://gsap.com/",
   # external docs sites that block or rate-limit CI bots
+  'https://eslint.org/(.*)',
   'https://router.vuejs.org/(.*)',
   'https://vitest.dev/(.*)',
   'https://vite.dev/(.*)',

--- a/lychee.toml
+++ b/lychee.toml
@@ -49,7 +49,7 @@ exclude = [
   "https://nuxt.new/c/v4",
   "https://nuxt.new/s/v4",
   "https://www.npmjs.com/",
-  "https://nuxt.com/docs/4.x/api/composables/$%7BkebabCase(factory.name)%7D/",
+  'https://nuxt\.com/docs/4\.x/api/composables/\$%7BkebabCase\(factory\.name\)%7D/',
   # TODO: fix upstream API issues
   "https://nuxt.com/modules",
   # single-quotes are required for regexp

--- a/lychee.toml
+++ b/lychee.toml
@@ -38,9 +38,13 @@ exclude = [
   "https://gsap.com/",
   # external docs sites that block or rate-limit CI bots
   'https://eslint.org/(.*)',
+  'https://pinia.vuejs.org/(.*)',
   'https://router.vuejs.org/(.*)',
+  'https://tailwindcss.nuxtjs.org/(.*)',
   'https://vitest.dev/(.*)',
   'https://vite.dev/(.*)',
+  'https://vuejs.org/(.*)',
+  'https://vuex.vuejs.org/(.*)',
   # dummy example URLs
   "https://myawesome-lib.js/",
   "https://awesome-lib.js/",


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #30997

### 📚 Description

Documents the `vite.$client` and `vite.$server` config blocks in the Nuxt configuration reference so users can see how to scope Vite options to one build environment.

Also updates `lychee.toml` exclusions for existing dynamic and external documentation URLs that were failing the all-docs link checker.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.