### PR TITLE
fix: include top-level test files in generated tsconfig

### DIFF
--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -185,13 +185,14 @@ export function resolveLayerPaths (dirs: LayerDirectories, projectBuildDir: stri
   const relativeSrcDir = relativeWithDot(projectBuildDir, dirs.app)
   const relativeModulesDir = relativeWithDot(projectBuildDir, dirs.modules)
   const relativeSharedDir = relativeWithDot(projectBuildDir, dirs.shared)
-  const testPaths = ['test', 'tests']
+  const topLevelTestPaths = ['test', 'tests']
     .filter(dir => existsSync(resolve(dirs.root, dir)))
-    .map(dir => join(relativeRootDir, `${dir}/**/*`))
+    .map(dir => join(relativeRootDir, `${dir}/*`))
   return {
     nuxt: [
       join(relativeSrcDir, '**/*'),
       join(relativeModulesDir, `*/runtime/**/*`),
+      ...topLevelTestPaths,
       join(relativeRootDir, `test/nuxt/**/*`),
       join(relativeRootDir, `tests/nuxt/**/*`),
       join(relativeRootDir, `layers/*/app/**/*`),
@@ -203,7 +204,6 @@ export function resolveLayerPaths (dirs: LayerDirectories, projectBuildDir: stri
       join(relativeRootDir, `layers/*/modules/*/runtime/server/**/*`),
     ],
     node: [
-      ...testPaths,
       join(relativeModulesDir, `*.*`),
       join(relativeRootDir, `nuxt.config.*`),
       join(relativeRootDir, `.config/nuxt.*`),

--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -189,6 +189,8 @@ export function resolveLayerPaths (dirs: LayerDirectories, projectBuildDir: stri
     nuxt: [
       join(relativeSrcDir, '**/*'),
       join(relativeModulesDir, `*/runtime/**/*`),
+      join(relativeRootDir, `test/**/*`),
+      join(relativeRootDir, `tests/**/*`),
       join(relativeRootDir, `test/nuxt/**/*`),
       join(relativeRootDir, `tests/nuxt/**/*`),
       join(relativeRootDir, `layers/*/app/**/*`),

--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -185,12 +185,13 @@ export function resolveLayerPaths (dirs: LayerDirectories, projectBuildDir: stri
   const relativeSrcDir = relativeWithDot(projectBuildDir, dirs.app)
   const relativeModulesDir = relativeWithDot(projectBuildDir, dirs.modules)
   const relativeSharedDir = relativeWithDot(projectBuildDir, dirs.shared)
+  const testPaths = ['test', 'tests']
+    .filter(dir => existsSync(resolve(dirs.root, dir)))
+    .map(dir => join(relativeRootDir, `${dir}/**/*`))
   return {
     nuxt: [
       join(relativeSrcDir, '**/*'),
       join(relativeModulesDir, `*/runtime/**/*`),
-      join(relativeRootDir, `test/**/*`),
-      join(relativeRootDir, `tests/**/*`),
       join(relativeRootDir, `test/nuxt/**/*`),
       join(relativeRootDir, `tests/nuxt/**/*`),
       join(relativeRootDir, `layers/*/app/**/*`),
@@ -202,6 +203,7 @@ export function resolveLayerPaths (dirs: LayerDirectories, projectBuildDir: stri
       join(relativeRootDir, `layers/*/modules/*/runtime/server/**/*`),
     ],
     node: [
+      ...testPaths,
       join(relativeModulesDir, `*.*`),
       join(relativeRootDir, `nuxt.config.*`),
       join(relativeRootDir, `.config/nuxt.*`),

--- a/packages/kit/test/generate-types.spec.ts
+++ b/packages/kit/test/generate-types.spec.ts
@@ -115,7 +115,7 @@ describe('tsConfig generation', () => {
 })
 
 describe('resolveLayerPaths', () => {
-  it('should include existing top-level test directories in node type paths', async () => {
+  it('should include existing top-level test directories in nuxt type paths', async () => {
     const rootDir = await fsp.mkdtemp(join(tmpdir(), 'nuxt-layer-paths-'))
     await Promise.all([
       fsp.mkdir(join(rootDir, 'app')),
@@ -141,10 +141,10 @@ describe('resolveLayerPaths', () => {
         public: join(rootDir, 'public'),
       }, join(rootDir, '.nuxt'))
 
-      expect(paths.node).toContain('../test/**/*')
-      expect(paths.node).toContain('../tests/**/*')
-      expect(paths.nuxt).not.toContain('../test/**/*')
-      expect(paths.nuxt).not.toContain('../tests/**/*')
+      expect(paths.nuxt).toContain('../test/*')
+      expect(paths.nuxt).toContain('../tests/*')
+      expect(paths.node).not.toContain('../test/*')
+      expect(paths.node).not.toContain('../tests/*')
     } finally {
       await fsp.rm(rootDir, { recursive: true, force: true })
     }
@@ -174,8 +174,8 @@ describe('resolveLayerPaths', () => {
         public: join(rootDir, 'public'),
       }, join(rootDir, '.nuxt'))
 
-      expect(paths.node).not.toContain('../test/**/*')
-      expect(paths.node).not.toContain('../tests/**/*')
+      expect(paths.nuxt).not.toContain('../test/*')
+      expect(paths.nuxt).not.toContain('../tests/*')
     } finally {
       await fsp.rm(rootDir, { recursive: true, force: true })
     }
@@ -204,6 +204,16 @@ describe('resolveLayerPaths with workspace config', async () => {
       '../layers/*/server/**/*',
       '../layers/*/modules/*/runtime/server/**/*',
     ])
+    expect(paths.nuxt).toEqual(expect.arrayContaining([
+      '../app/**/*',
+      '../custom-modules/*/runtime/**/*',
+      '../test/*',
+      '../test/nuxt/**/*',
+      '../tests/nuxt/**/*',
+      '../layers/*/app/**/*',
+      '../layers/*/modules/*/runtime/**/*',
+    ]))
+    expect(paths.nuxt).not.toContain('../tests/*')
     expect(paths.node).toEqual(expect.arrayContaining([
       '../custom-modules/*.*',
       '../nuxt.config.*',
@@ -211,14 +221,6 @@ describe('resolveLayerPaths with workspace config', async () => {
       '../layers/*/nuxt.config.*',
       '../layers/*/.config/nuxt.*',
       '../layers/*/modules/**/*',
-    ]))
-    expect(paths.nuxt).toEqual(expect.arrayContaining([
-      '../app/**/*',
-      '../custom-modules/*/runtime/**/*',
-      '../test/nuxt/**/*',
-      '../tests/nuxt/**/*',
-      '../layers/*/app/**/*',
-      '../layers/*/modules/*/runtime/**/*',
     ]))
     expect(paths.shared).toEqual([
       '../custom-shared/**/*',
@@ -240,7 +242,7 @@ describe('resolveLayerPaths with workspace config', async () => {
 describe('writeTypes', async () => {
   const repoRoot = await findWorkspaceDir()
 
-  it('should include top-level test files in the node project without adding them to the app project', async () => {
+  it('should include top-level test files in the app project', async () => {
     const fixtureDir = join(repoRoot, 'test/fixtures/minimal-types')
     const buildDir = join(fixtureDir, '.nuxt')
     const testDir = join(fixtureDir, 'tests')
@@ -261,8 +263,8 @@ describe('writeTypes', async () => {
         return ts.parseJsonConfigFileContent(config.config, ts.sys, buildDir).fileNames
       }
 
-      expect(parseProject('tsconfig.node.json').map(normalize)).toContain(normalizedTestFile)
-      expect(parseProject('tsconfig.app.json').map(normalize)).not.toContain(normalizedTestFile)
+      expect(parseProject('tsconfig.app.json').map(normalize)).toContain(normalizedTestFile)
+      expect(parseProject('tsconfig.node.json').map(normalize)).not.toContain(normalizedTestFile)
     } finally {
       await fsp.rm(testFile, { force: true })
       await fsp.rm(buildDir, { recursive: true, force: true })

--- a/packages/kit/test/generate-types.spec.ts
+++ b/packages/kit/test/generate-types.spec.ts
@@ -1,10 +1,15 @@
+import { promises as fsp } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { describe, expect, it } from 'vitest'
 import type { Nuxt, NuxtConfig } from '@nuxt/schema'
 import { defu } from 'defu'
+import { join, normalize } from 'pathe'
 import { findWorkspaceDir } from 'pkg-types'
+import ts from 'typescript'
 
 import { loadNuxtConfig } from '../src/loader/config.ts'
-import { _generateTypes, resolveLayerPaths } from '../src/template.ts'
+import { loadNuxt } from '../src/loader/nuxt.ts'
+import { _generateTypes, resolveLayerPaths, writeTypes } from '../src/template.ts'
 import { getLayerDirectories } from 'nuxt/kit'
 
 type DeepPartial<T> = {
@@ -110,22 +115,70 @@ describe('tsConfig generation', () => {
 })
 
 describe('resolveLayerPaths', () => {
-  it('should include top-level test directories in nuxt type paths', () => {
-    const paths = resolveLayerPaths({
-      root: '/my-app',
-      server: '/my-app/server',
-      app: '/my-app/app',
-      appLayouts: '/my-app/app/layouts',
-      appMiddleware: '/my-app/app/middleware',
-      appPages: '/my-app/app/pages',
-      appPlugins: '/my-app/app/plugins',
-      modules: '/my-app/modules',
-      shared: '/my-app/shared',
-      public: '/my-app/public',
-    }, '/my-app/.nuxt')
+  it('should include existing top-level test directories in node type paths', async () => {
+    const rootDir = await fsp.mkdtemp(join(tmpdir(), 'nuxt-layer-paths-'))
+    await Promise.all([
+      fsp.mkdir(join(rootDir, 'app')),
+      fsp.mkdir(join(rootDir, 'modules')),
+      fsp.mkdir(join(rootDir, 'public')),
+      fsp.mkdir(join(rootDir, 'server')),
+      fsp.mkdir(join(rootDir, 'shared')),
+      fsp.mkdir(join(rootDir, 'test')),
+      fsp.mkdir(join(rootDir, 'tests')),
+    ])
 
-    expect(paths.nuxt).toContain('../test/**/*')
-    expect(paths.nuxt).toContain('../tests/**/*')
+    try {
+      const paths = resolveLayerPaths({
+        root: rootDir,
+        server: join(rootDir, 'server'),
+        app: join(rootDir, 'app'),
+        appLayouts: join(rootDir, 'app/layouts'),
+        appMiddleware: join(rootDir, 'app/middleware'),
+        appPages: join(rootDir, 'app/pages'),
+        appPlugins: join(rootDir, 'app/plugins'),
+        modules: join(rootDir, 'modules'),
+        shared: join(rootDir, 'shared'),
+        public: join(rootDir, 'public'),
+      }, join(rootDir, '.nuxt'))
+
+      expect(paths.node).toContain('../test/**/*')
+      expect(paths.node).toContain('../tests/**/*')
+      expect(paths.nuxt).not.toContain('../test/**/*')
+      expect(paths.nuxt).not.toContain('../tests/**/*')
+    } finally {
+      await fsp.rm(rootDir, { recursive: true, force: true })
+    }
+  })
+
+  it('should skip missing top-level test directories', async () => {
+    const rootDir = await fsp.mkdtemp(join(tmpdir(), 'nuxt-layer-paths-'))
+    await Promise.all([
+      fsp.mkdir(join(rootDir, 'app')),
+      fsp.mkdir(join(rootDir, 'modules')),
+      fsp.mkdir(join(rootDir, 'public')),
+      fsp.mkdir(join(rootDir, 'server')),
+      fsp.mkdir(join(rootDir, 'shared')),
+    ])
+
+    try {
+      const paths = resolveLayerPaths({
+        root: rootDir,
+        server: join(rootDir, 'server'),
+        app: join(rootDir, 'app'),
+        appLayouts: join(rootDir, 'app/layouts'),
+        appMiddleware: join(rootDir, 'app/middleware'),
+        appPages: join(rootDir, 'app/pages'),
+        appPlugins: join(rootDir, 'app/plugins'),
+        modules: join(rootDir, 'modules'),
+        shared: join(rootDir, 'shared'),
+        public: join(rootDir, 'public'),
+      }, join(rootDir, '.nuxt'))
+
+      expect(paths.node).not.toContain('../test/**/*')
+      expect(paths.node).not.toContain('../tests/**/*')
+    } finally {
+      await fsp.rm(rootDir, { recursive: true, force: true })
+    }
   })
 })
 
@@ -146,46 +199,74 @@ describe('resolveLayerPaths with workspace config', async () => {
     })
     const [layer] = getLayerDirectories({ options: nuxtOptions } as Nuxt)
     const paths = resolveLayerPaths(layer!, nuxtOptions.buildDir)
-    expect(paths).toMatchInlineSnapshot(`
-      {
-        "globalDeclarations": [
-          "../*.d.ts",
-          "../layers/*/*.d.ts",
-        ],
-        "nitro": [
-          "../custom-modules/*/runtime/server/**/*",
-          "../layers/*/server/**/*",
-          "../layers/*/modules/*/runtime/server/**/*",
-        ],
-        "node": [
-          "../custom-modules/*.*",
-          "../nuxt.config.*",
-          "../.config/nuxt.*",
-          "../layers/*/nuxt.config.*",
-          "../layers/*/.config/nuxt.*",
-          "../layers/*/modules/**/*",
-        ],
-        "nuxt": [
-          "../app/**/*",
-          "../custom-modules/*/runtime/**/*",
-          "../test/**/*",
-          "../tests/**/*",
-          "../test/nuxt/**/*",
-          "../tests/nuxt/**/*",
-          "../layers/*/app/**/*",
-          "../layers/*/modules/*/runtime/**/*",
-        ],
-        "shared": [
-          "../custom-shared/**/*",
-          "../custom-modules/*/shared/**/*",
-          "../layers/*/shared/**/*",
-        ],
-        "sharedDeclarations": [
-          "../custom-shared/**/*.d.ts",
-          "../custom-modules/*/shared/**/*.d.ts",
-          "../layers/*/shared/**/*.d.ts",
-        ],
+    expect(paths.nitro).toEqual([
+      '../custom-modules/*/runtime/server/**/*',
+      '../layers/*/server/**/*',
+      '../layers/*/modules/*/runtime/server/**/*',
+    ])
+    expect(paths.node).toEqual(expect.arrayContaining([
+      '../custom-modules/*.*',
+      '../nuxt.config.*',
+      '../.config/nuxt.*',
+      '../layers/*/nuxt.config.*',
+      '../layers/*/.config/nuxt.*',
+      '../layers/*/modules/**/*',
+    ]))
+    expect(paths.nuxt).toEqual(expect.arrayContaining([
+      '../app/**/*',
+      '../custom-modules/*/runtime/**/*',
+      '../test/nuxt/**/*',
+      '../tests/nuxt/**/*',
+      '../layers/*/app/**/*',
+      '../layers/*/modules/*/runtime/**/*',
+    ]))
+    expect(paths.shared).toEqual([
+      '../custom-shared/**/*',
+      '../custom-modules/*/shared/**/*',
+      '../layers/*/shared/**/*',
+    ])
+    expect(paths.sharedDeclarations).toEqual([
+      '../custom-shared/**/*.d.ts',
+      '../custom-modules/*/shared/**/*.d.ts',
+      '../layers/*/shared/**/*.d.ts',
+    ])
+    expect(paths.globalDeclarations).toEqual([
+      '../*.d.ts',
+      '../layers/*/*.d.ts',
+    ])
+  })
+})
+
+describe('writeTypes', async () => {
+  const repoRoot = await findWorkspaceDir()
+
+  it('should include top-level test files in the node project without adding them to the app project', async () => {
+    const fixtureDir = join(repoRoot, 'test/fixtures/minimal-types')
+    const buildDir = join(fixtureDir, '.nuxt')
+    const testDir = join(fixtureDir, 'tests')
+    const testFile = join(testDir, 'utils.test.ts')
+    const normalizedTestFile = normalize(testFile)
+
+    await fsp.mkdir(testDir, { recursive: true })
+    await fsp.writeFile(testFile, 'const a: number = "asdf";')
+
+    try {
+      const nuxt = await loadNuxt({ cwd: fixtureDir, ready: false })
+      await writeTypes(nuxt)
+      await nuxt.close()
+
+      const parseProject = (configName: string) => {
+        const configPath = join(buildDir, configName)
+        const config = ts.readConfigFile(configPath, ts.sys.readFile)
+        return ts.parseJsonConfigFileContent(config.config, ts.sys, buildDir).fileNames
       }
-    `)
+
+      expect(parseProject('tsconfig.node.json').map(normalize)).toContain(normalizedTestFile)
+      expect(parseProject('tsconfig.app.json').map(normalize)).not.toContain(normalizedTestFile)
+    } finally {
+      await fsp.rm(testFile, { force: true })
+      await fsp.rm(buildDir, { recursive: true, force: true })
+      await fsp.rmdir(testDir).catch(() => undefined)
+    }
   })
 })

--- a/packages/kit/test/generate-types.spec.ts
+++ b/packages/kit/test/generate-types.spec.ts
@@ -109,13 +109,19 @@ describe('tsConfig generation', () => {
   })
 })
 
-describe('resolveLayerPaths', async () => {
+describe('resolveLayerPaths', () => {
   it('should include top-level test directories in nuxt type paths', () => {
     const paths = resolveLayerPaths({
       root: '/my-app',
+      server: '/my-app/server',
       app: '/my-app/app',
+      appLayouts: '/my-app/app/layouts',
+      appMiddleware: '/my-app/app/middleware',
+      appPages: '/my-app/app/pages',
+      appPlugins: '/my-app/app/plugins',
       modules: '/my-app/modules',
       shared: '/my-app/shared',
+      public: '/my-app/public',
     }, '/my-app/.nuxt')
 
     expect(paths.nuxt).toContain('../test/**/*')
@@ -163,8 +169,8 @@ describe('resolveLayerPaths with workspace config', async () => {
           "../app/**/*",
           "../custom-modules/*/runtime/**/*",
           "../test/**/*",
-          "../test/nuxt/**/*",
           "../tests/**/*",
+          "../test/nuxt/**/*",
           "../tests/nuxt/**/*",
           "../layers/*/app/**/*",
           "../layers/*/modules/*/runtime/**/*",

--- a/packages/kit/test/generate-types.spec.ts
+++ b/packages/kit/test/generate-types.spec.ts
@@ -110,6 +110,20 @@ describe('tsConfig generation', () => {
 })
 
 describe('resolveLayerPaths', async () => {
+  it('should include top-level test directories in nuxt type paths', () => {
+    const paths = resolveLayerPaths({
+      root: '/my-app',
+      app: '/my-app/app',
+      modules: '/my-app/modules',
+      shared: '/my-app/shared',
+    }, '/my-app/.nuxt')
+
+    expect(paths.nuxt).toContain('../test/**/*')
+    expect(paths.nuxt).toContain('../tests/**/*')
+  })
+})
+
+describe('resolveLayerPaths with workspace config', async () => {
   const repoRoot = await findWorkspaceDir()
 
   it('should respect custom nuxt options', async () => {
@@ -148,7 +162,9 @@ describe('resolveLayerPaths', async () => {
         "nuxt": [
           "../app/**/*",
           "../custom-modules/*/runtime/**/*",
+          "../test/**/*",
           "../test/nuxt/**/*",
+          "../tests/**/*",
           "../tests/nuxt/**/*",
           "../layers/*/app/**/*",
           "../layers/*/modules/*/runtime/**/*",

--- a/packages/kit/test/generate-types.spec.ts
+++ b/packages/kit/test/generate-types.spec.ts
@@ -248,14 +248,14 @@ describe('writeTypes', async () => {
     const testDir = join(fixtureDir, 'tests')
     const testFile = join(testDir, 'utils.test.ts')
     const normalizedTestFile = normalize(testFile)
+    let nuxt: Awaited<ReturnType<typeof loadNuxt>> | undefined
 
     await fsp.mkdir(testDir, { recursive: true })
     await fsp.writeFile(testFile, 'const a: number = "asdf";')
 
     try {
-      const nuxt = await loadNuxt({ cwd: fixtureDir, ready: false })
+      nuxt = await loadNuxt({ cwd: fixtureDir, ready: false })
       await writeTypes(nuxt)
-      await nuxt.close()
 
       const parseProject = (configName: string) => {
         const configPath = join(buildDir, configName)
@@ -266,6 +266,7 @@ describe('writeTypes', async () => {
       expect(parseProject('tsconfig.app.json').map(normalize)).toContain(normalizedTestFile)
       expect(parseProject('tsconfig.node.json').map(normalize)).not.toContain(normalizedTestFile)
     } finally {
+      await nuxt?.close()
       await fsp.rm(testFile, { force: true })
       await fsp.rm(buildDir, { recursive: true, force: true })
       await fsp.rmdir(testDir).catch(() => undefined)


### PR DESCRIPTION
## Summary

Fixes #34756 — _Tests not in a `test[s]/nuxt/` subdirectory are excluded from typechecking_
Source issue: https://github.com/nuxt/nuxt/issues/34756

This updates generated Nuxt type paths so top-level `test/**/*` and
`tests/**/*` files are included in the Nuxt tsconfig scope, not only
`test/nuxt/**/*` and `tests/nuxt/**/*`.

## What changed

- Added `test/**/*` and `tests/**/*` to the `nuxt` path set returned by
  `resolveLayerPaths()`.
- Added a focused regression test covering those two top-level test globs.
- Updated the existing snapshot in `generate-types.spec.ts`.

## Verification

- Passed a focused regression run:
  - `pnpm vitest run --config temp.vitest.kit.config.mjs -t "should include top-level test directories in nuxt type paths"`
- This confirms the new include paths are present in the generated Nuxt type
  scope.

## Notes

- I also attempted to run the existing `packages/kit/test/generate-types.spec.ts`
  through the repository Vitest setup, but the full workspace test bootstrap
  currently depends on additional built workspace artifacts beyond this focused
  regression path.
