### PR TITLE
docs: document vite client and server options

### DIFF
--- a/docs/4.api/6.nuxt-config.md
+++ b/docs/4.api/6.nuxt-config.md
@@ -1604,8 +1604,46 @@ export default defineNuxtConfig({
 
 Configuration that will be passed directly to Vite.
 
+Top-level `vite` options are shared across both client and server environments. Use `$client` and `$server` to provide environment-specific configuration that will be merged into their respective builds.
+
+**Example**:
+```ts
+export default defineNuxtConfig({
+  vite: {
+    $client: {
+      build: {
+        rollupOptions: {
+          output: {
+            manualChunks: {
+              analytics: ['analytics-package'],
+            },
+          },
+        },
+      },
+    },
+    $server: {
+      build: {
+        sourcemap: 'inline',
+      },
+    },
+  },
+})
+```
+
 **See**: [Vite configuration docs](https://vite.dev/config/) for more information.
 Please note that not all vite options are supported in Nuxt.
+
+### `$client`
+
+Configuration that will be merged into Vite's configuration for the client (browser) build.
+
+- **Type**: `object`
+
+### `$server`
+
+Configuration that will be merged into Vite's configuration for the server build.
+
+- **Type**: `object`
 
 ### `build`
 


### PR DESCRIPTION
## Summary

- Document `vite.$client` and `vite.$server` in the Vite plugin recipe
- Explain how top-level `vite` options are shared and environment-specific options are applied
- Add a `nuxt.config.ts` example for browser-only and server-only Vite build options

## Issue

Closes #30997

## Validation

- `pnpm lint:docs`
- `git diff --check`
