### PR TITLE
fix(nuxt): run middleware for page islands

### DIFF
--- a/packages/nitro-server/src/runtime/handlers/island.ts
+++ b/packages/nitro-server/src/runtime/handlers/island.ts
@@ -40,15 +40,25 @@ const handler: ReturnType<typeof defineEventHandler> = defineEventHandler(async 
 
   const renderResult = await renderer.renderToString(ssrContext).catch(async (err) => {
     if (ssrContext['~renderResponse'] && (err as Error)?.message === 'skipping render') {
-      return undefined
+      return {} as Awaited<ReturnType<typeof renderer.renderToString>>
     }
     await ssrContext.nuxt?.hooks.callHook('app:error', err)
     throw err
   })
 
-  // honour redirects / explicit responses queued by page middleware
+  // Fire `app:rendered` before checking `~renderResponse` (matches `renderer.ts`), so
+  // anything hooking into it, like `useCookie`, will still work on redirect/reject.
+  await ssrContext.nuxt?.hooks.callHook('app:rendered', { ssrContext, renderResult })
+
   if (ssrContext['~renderResponse']) {
-    return returnIslandResponse(event, ssrContext['~renderResponse'])
+    const response = ssrContext['~renderResponse']
+    if (response.status && response.status >= 400) {
+      throw new HTTPError({
+        status: response.status,
+        statusText: response.statusText,
+      })
+    }
+    return returnIslandResponse(event, response)
   }
 
   // Handle errors
@@ -56,13 +66,7 @@ const handler: ReturnType<typeof defineEventHandler> = defineEventHandler(async 
     throw ssrContext.payload.error
   }
 
-  if (!renderResult) {
-    throw new HTTPError({ status: 500, statusText: 'Island render failed' })
-  }
-
   const inlinedStyles = await renderInlineStyles(ssrContext.modules ?? [])
-
-  await ssrContext.nuxt?.hooks.callHook('app:rendered', { ssrContext, renderResult })
 
   if (inlinedStyles.length) {
     ssrContext.head.push({ style: inlinedStyles })

--- a/packages/nitro-server/src/runtime/handlers/island.ts
+++ b/packages/nitro-server/src/runtime/handlers/island.ts
@@ -39,13 +39,25 @@ const handler: ReturnType<typeof defineEventHandler> = defineEventHandler(async 
   const renderer = await getSSRRenderer()
 
   const renderResult = await renderer.renderToString(ssrContext).catch(async (err) => {
+    if (ssrContext['~renderResponse'] && (err as Error)?.message === 'skipping render') {
+      return undefined
+    }
     await ssrContext.nuxt?.hooks.callHook('app:error', err)
     throw err
   })
 
+  // honour redirects / explicit responses queued by page middleware
+  if (ssrContext['~renderResponse']) {
+    return returnIslandResponse(event, ssrContext['~renderResponse'])
+  }
+
   // Handle errors
   if (ssrContext.payload?.error) {
     throw ssrContext.payload.error
+  }
+
+  if (!renderResult) {
+    throw new HTTPError({ status: 500, statusText: 'Island render failed' })
   }
 
   const inlinedStyles = await renderInlineStyles(ssrContext.modules ?? [])
@@ -108,6 +120,19 @@ const handler: ReturnType<typeof defineEventHandler> = defineEventHandler(async 
 })
 
 export default handler
+
+function returnIslandResponse (event: H3Event, response: Partial<RenderResponse>) {
+  for (const header in response.headers || {}) {
+    event.res.headers.set(header, response.headers![header]!)
+  }
+  if (response.status) {
+    event.res.status = response.status
+  }
+  if (response.statusText) {
+    event.res.statusText = response.statusText
+  }
+  return response.body
+}
 
 const ISLAND_PATH_PREFIX = '/__nuxt_island/'
 const VALID_COMPONENT_NAME_RE = /^[a-z][\w.-]*$/i

--- a/packages/nuxt/src/components/runtime/server-component.ts
+++ b/packages/nuxt/src/components/runtime/server-component.ts
@@ -37,8 +37,8 @@ export const createServerComponent = (name: string) => {
 }
 
 /* @__NO_SIDE_EFFECTS__ */
-export const createIslandPage = (name: string) => {
-  return defineComponent({
+export const createIslandPage = (name: string, islandKey?: string) => {
+  const component = defineComponent({
     name,
     inheritAttrs: false,
     props: { lazy: Boolean },
@@ -72,4 +72,10 @@ export const createIslandPage = (name: string) => {
       }
     },
   })
+
+  // we use this to validate that a server page is rendering the correct url
+  if (import.meta.server && islandKey) {
+    (component as any).__nuxt_island = islandKey
+  }
+  return component
 }

--- a/packages/nuxt/src/components/templates.ts
+++ b/packages/nuxt/src/components/templates.ts
@@ -1,5 +1,6 @@
 import { isAbsolute, join, relative, resolve } from 'pathe'
 import { genDynamicImport, genDynamicTypeImport, genObjectKey } from 'knitwork'
+import { hash } from 'ohash'
 import { distDir } from '../dirs.ts'
 import type { NuxtApp, NuxtPluginTemplate, NuxtTemplate } from 'nuxt/schema'
 
@@ -79,7 +80,7 @@ export const componentsIslandsTemplate: NuxtTemplate = {
   filename: 'components.islands.mjs',
   getContents ({ app, nuxt }) {
     if (!nuxt.options.experimental.componentIslands) {
-      return 'export const islandComponents = {}'
+      return 'export const islandComponents = {}\nexport const pageIslandRoutes = {}'
     }
 
     const components = app.components
@@ -90,9 +91,14 @@ export const componentsIslandsTemplate: NuxtTemplate = {
       (component.mode === 'server' && !components.some(c => c.pascalName === component.pascalName && c.mode === 'client')),
     )
 
-    const pageExports = pages?.filter(p => (p.mode === 'server' && p.file && p.name)).map((p) => {
+    const serverPages = pages?.filter(p => (p.mode === 'server' && p.file && p.name)) || []
+    const pageExports = serverPages.map((p) => {
       return `"page_${p.name}": defineAsyncComponent(${genDynamicImport(p.file!)}.then(c => c.default || c))`
-    }) || []
+    })
+    // map each `page_<name>` to a stable, opaque marker derived from the page's file path.
+    const pageIslandRoutes = serverPages.map((p) => {
+      return `  "page_${p.name}": ${JSON.stringify(hash(relative(nuxt.options.rootDir, p.file!)))}`
+    })
 
     return [
       'import { defineAsyncComponent } from \'vue\'',
@@ -104,6 +110,9 @@ export const componentsIslandsTemplate: NuxtTemplate = {
           return `  "${c.pascalName}": defineAsyncComponent(${genDynamicImport(c.filePath, { comment })}.then(c => ${exp}))`
         },
       ).concat(pageExports).join(',\n'),
+      '}',
+      'export const pageIslandRoutes = import.meta.client ? {} : {',
+      pageIslandRoutes.join(',\n'),
       '}',
     ].join('\n')
   },

--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -18,6 +18,8 @@ import _routes, { handleHotUpdate } from '#build/routes'
 import routerOptions, { hashMode } from '#build/router.options.mjs'
 // @ts-expect-error virtual file
 import { globalMiddleware, namedMiddleware } from '#build/middleware'
+// @ts-expect-error virtual file
+import { pageIslandRoutes } from '#build/components.islands.mjs'
 
 // https://github.com/vuejs/router/blob/4a0cc8b9c1e642cdf47cc007fa5bbebde70afc66/packages/router/src/history/html5.ts#L37
 function createCurrentLocation (
@@ -140,7 +142,9 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
     }
 
     const error = useError()
-    if (import.meta.client || !nuxtApp.ssrContext?.islandContext) {
+    // we only skip redirect handlers for component islands, not page islands
+    const isServerPage = import.meta.server && nuxtApp.ssrContext?.islandContext?.name?.startsWith('page_')
+    if (import.meta.client || !nuxtApp.ssrContext?.islandContext || isServerPage) {
       router.afterEach(async (to, _from, failure) => {
         delete nuxtApp._processingMiddleware
 
@@ -188,8 +192,8 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
 
     syncCurrentRoute()
 
-    if (import.meta.server && nuxtApp.ssrContext?.islandContext) {
-      // We're in an island context, and don't need to handle middleware or redirections
+    if (import.meta.server && nuxtApp.ssrContext?.islandContext && !isServerPage) {
+      // we don't need to handle middleware or redirections for non-page islands
       return { provide: { router } }
     }
 
@@ -202,7 +206,7 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
       }
       nuxtApp._processingMiddleware = true
 
-      if (import.meta.client || !nuxtApp.ssrContext?.islandContext) {
+      if (import.meta.client || !nuxtApp.ssrContext?.islandContext || isServerPage) {
         type MiddlewareDef = string | RouteMiddleware
         const middlewareEntries = new Set<MiddlewareDef>([...globalMiddleware, ...nuxtApp._middleware.global])
         for (const component of to.matched) {
@@ -271,6 +275,23 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
         }
       }
     })
+
+    if (isServerPage) {
+      // validate that a server page is rendering the correct url
+      router.beforeResolve((to) => {
+        const expected = pageIslandRoutes[nuxtApp.ssrContext!.islandContext!.name]
+        const actual = to.matched.find(m => (m.components?.default as any)?.__nuxt_island)
+          ?.components?.default as any
+        if (!expected || expected !== actual?.__nuxt_island) {
+          nuxtApp.ssrContext!['~renderResponse'] = {
+            status: 400,
+            statusText: 'Invalid island request path',
+            body: '',
+          }
+          return false
+        }
+      })
+    }
 
     router.onError(async () => {
       delete nuxtApp._processingMiddleware

--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -286,7 +286,6 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
           nuxtApp.ssrContext!['~renderResponse'] = {
             status: 400,
             statusText: 'Invalid island request path',
-            body: '',
           }
           return false
         }

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -1,7 +1,7 @@
 import { runInNewContext } from 'node:vm'
 import fs from 'node:fs'
 
-import { normalize } from 'pathe'
+import { normalize, relative } from 'pathe'
 import { joinURL } from 'ufo'
 import { getLayerDirectories, resolveFiles, resolvePath, useNuxt } from '@nuxt/kit'
 import { genArrayFromRaw, genDynamicImport, genImport, genSafeVariableName } from 'knitwork'
@@ -342,9 +342,9 @@ interface NormalizeRoutesOptions {
   clientComponentRuntime: string
 }
 
-function normalizeComponent (page: NuxtPage, pageImport: string, routeName: string | undefined): string {
+function normalizeComponent (page: NuxtPage, pageImport: string, routeName: string | undefined, islandKey: string | undefined): string {
   if (page.mode === 'server') {
-    return `() => createIslandPage(${routeName})`
+    return `() => createIslandPage(${routeName}, ${islandKey})`
   }
   if (page.mode === 'client') {
     return `() => createClientPage(${pageImport})`
@@ -352,13 +352,13 @@ function normalizeComponent (page: NuxtPage, pageImport: string, routeName: stri
   return pageImport
 }
 
-function normalizeComponentWithName (page: NuxtPage, isSyncImport: boolean | undefined, pageImportName: string, pageImport: string, routeName: string | undefined, metaRouteName: string): string {
+function normalizeComponentWithName (page: NuxtPage, isSyncImport: boolean | undefined, pageImportName: string, pageImport: string, routeName: string | undefined, metaRouteName: string, islandKey: string | undefined): string {
   if (isSyncImport) {
     return `Object.assign(${pageImportName}, { __name: ${metaRouteName} })`
   }
   // Server components already receive the name via createIslandPage(name)
   if (page.mode === 'server') {
-    return `() => createIslandPage(${routeName})`
+    return `() => createIslandPage(${routeName}, ${islandKey})`
   }
   // Client components return a processed component (not a module with .default)
   if (page.mode === 'client') {
@@ -381,6 +381,7 @@ export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = 
           metaFiltered[key] = page.meta![key]
         }
       }
+
       const skipAlias = toArray(page.alias).every(val => !val)
 
       const route: NormalizedRoute = {
@@ -420,9 +421,14 @@ export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = 
       const pageImport = isSyncImport ? pageImportName : genDynamicImport(file)
       const metaRouteName = `${metaImportName}?.name ?? ${route.name}`
 
+      // we use this to validate that a server page is rendering the correct url
+      const islandKey = page.mode === 'server' && page.file
+        ? JSON.stringify(hash(relative(nuxt.options.rootDir, page.file)))
+        : undefined
+
       const component = nuxt.options.experimental.normalizePageNames
-        ? normalizeComponentWithName(page, isSyncImport, pageImportName, pageImport, route.name, metaRouteName)
-        : normalizeComponent(page, pageImport, route.name)
+        ? normalizeComponentWithName(page, isSyncImport, pageImportName, pageImport, route.name, metaRouteName, islandKey)
+        : normalizeComponent(page, pageImport, route.name, islandKey)
 
       const metaRoute: NormalizedRoute = {
         name: metaRouteName,
@@ -437,9 +443,9 @@ export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = 
       if (page.mode === 'server') {
         metaImports.add(`
 let _createIslandPage
-async function createIslandPage (name) {
+async function createIslandPage (name, islandKey) {
   _createIslandPage ||= await import(${JSON.stringify(options?.serverComponentRuntime)}).then(r => r.createIslandPage)
-  return _createIslandPage(name)
+  return _createIslandPage(name, islandKey)
 };`)
       } else if (page.mode === 'client') {
         metaImports.add(`

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -344,7 +344,7 @@ interface NormalizeRoutesOptions {
 
 function normalizeComponent (page: NuxtPage, pageImport: string, routeName: string | undefined, islandKey: string | undefined): string {
   if (page.mode === 'server') {
-    return `() => createIslandPage(${routeName}, ${islandKey})`
+    return `() => createIslandPage(${routeName}, import.meta.server ? ${islandKey} : undefined)`
   }
   if (page.mode === 'client') {
     return `() => createClientPage(${pageImport})`
@@ -358,7 +358,7 @@ function normalizeComponentWithName (page: NuxtPage, isSyncImport: boolean | und
   }
   // Server components already receive the name via createIslandPage(name)
   if (page.mode === 'server') {
-    return `() => createIslandPage(${routeName}, ${islandKey})`
+    return `() => createIslandPage(${routeName}, import.meta.server ? ${islandKey} : undefined)`
   }
   // Client components return a processed component (not a module with .default)
   if (page.mode === 'client') {

--- a/test/fixtures/server-components/app/middleware/island-auth.ts
+++ b/test/fixtures/server-components/app/middleware/island-auth.ts
@@ -1,3 +1,4 @@
 export default defineNuxtRouteMiddleware(() => {
+  useCookie('island-auth-marker').value = 'set-from-island-middleware'
   return navigateTo('/login', { redirectCode: 302 })
 })

--- a/test/fixtures/server-components/app/middleware/island-auth.ts
+++ b/test/fixtures/server-components/app/middleware/island-auth.ts
@@ -1,0 +1,3 @@
+export default defineNuxtRouteMiddleware(() => {
+  return navigateTo('/login', { redirectCode: 302 })
+})

--- a/test/fixtures/server-components/app/pages/gated-server-page.server.vue
+++ b/test/fixtures/server-components/app/pages/gated-server-page.server.vue
@@ -1,0 +1,11 @@
+<template>
+  <div id="gated-server-page">
+    SUPER-SECRET-PAGE-ISLAND-BODY
+  </div>
+</template>
+
+<script setup lang="ts">
+definePageMeta({
+  middleware: 'island-auth',
+})
+</script>

--- a/test/server-components.test.ts
+++ b/test/server-components.test.ts
@@ -474,6 +474,18 @@ describe('hash binding', () => {
     }))
     expect(res.status).toBe(200)
   })
+
+  it('rejects a request whose URL hash was computed over different props', async () => {
+    // Compute a valid hash for one set of props, then swap the actual query props.
+    const url = islandURL('PureComponent', {
+      props: { bool: false, number: 1, str: 's', obj: {} },
+    })
+    const tampered = url.replace(/props=[^&]+/, 'props=' + encodeURIComponent(JSON.stringify({
+      bool: true, number: 999, str: '<script>x</script>', obj: { evil: true },
+    })))
+    const res = await fetch(tampered)
+    expect(res.status).toBe(400)
+  })
 })
 
 describe('page-island middleware', () => {

--- a/test/server-components.test.ts
+++ b/test/server-components.test.ts
@@ -486,6 +486,20 @@ describe('hash binding', () => {
     const res = await fetch(tampered)
     expect(res.status).toBe(400)
   })
+
+  it('rejects a request with a fabricated hash', async () => {
+    const res = await fetch(withQuery('/__nuxt_island/PureComponent_deadbeefcafef00d.json', {
+      props: JSON.stringify({ bool: false, number: 1, str: 's', obj: {} }),
+    }))
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects a request with no hash segment in the URL', async () => {
+    const res = await fetch(withQuery('/__nuxt_island/PureComponent.json', {
+      props: JSON.stringify({ bool: false, number: 1, str: 's', obj: {} }),
+    }))
+    expect(res.status).toBe(400)
+  })
 })
 
 describe('page-island middleware', () => {

--- a/test/server-components.test.ts
+++ b/test/server-components.test.ts
@@ -474,31 +474,38 @@ describe('hash binding', () => {
     }))
     expect(res.status).toBe(200)
   })
+})
 
-  it('rejects a request whose URL hash was computed over different props', async () => {
-    // Compute a valid hash for one set of props, then swap the actual query props.
-    const url = islandURL('PureComponent', {
-      props: { bool: false, number: 1, str: 's', obj: {} },
-    })
-    const tampered = url.replace(/props=[^&]+/, 'props=' + encodeURIComponent(JSON.stringify({
-      bool: true, number: 999, str: '<script>x</script>', obj: { evil: true },
-    })))
-    const res = await fetch(tampered)
-    expect(res.status).toBe(400)
+describe('page-island middleware', () => {
+  it('runs page middleware and honours redirects for `page_*` islands', async () => {
+    const res = await fetch(islandURL('page_gated-server-page', {
+      context: { url: '/gated-server-page' },
+    }), { redirect: 'manual' })
+    // page middleware calls `navigateTo('/login', { redirectCode: 302 })`
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toContain('/login')
+    const body = await res.text()
+    expect(body).not.toContain('SUPER-SECRET-PAGE-ISLAND-BODY')
   })
 
-  it('rejects a request with a fabricated hash', async () => {
-    const res = await fetch(withQuery('/__nuxt_island/PureComponent_deadbeefcafef00d.json', {
-      props: JSON.stringify({ bool: false, number: 1, str: 's', obj: {} }),
+  it('still renders unguarded `page_*` islands', async () => {
+    const res = await fetch(islandURL('page_server-page', {
+      context: { url: '/server-page' },
     }))
-    expect(res.status).toBe(400)
+    expect(res.status).toBe(200)
+    const body = await res.json() as NuxtIslandResponse
+    expect(body.html).toContain('Hello this is a server page')
   })
 
-  it('rejects a request with no hash segment in the URL', async () => {
-    const res = await fetch(withQuery('/__nuxt_island/PureComponent.json', {
-      props: JSON.stringify({ bool: false, number: 1, str: 's', obj: {} }),
-    }))
+  it('rejects a `page_*` island whose url routes to a different page', async () => {
+    // Forging `page_gated-server-page` with `url=/server-page` would render the gated
+    // page's HTML while running the (empty) middleware for the unguarded page.
+    const res = await fetch(islandURL('page_gated-server-page', {
+      context: { url: '/server-page' },
+    }), { redirect: 'manual' })
     expect(res.status).toBe(400)
+    const body = await res.text()
+    expect(body).not.toContain('SUPER-SECRET-PAGE-ISLAND-BODY')
   })
 })
 

--- a/test/server-components.test.ts
+++ b/test/server-components.test.ts
@@ -512,6 +512,8 @@ describe('page-island middleware', () => {
     expect(res.headers.get('location')).toContain('/login')
     const body = await res.text()
     expect(body).not.toContain('SUPER-SECRET-PAGE-ISLAND-BODY')
+    // this asserts the island handler fires `app:rendered` even when middleware short-circuits response
+    expect(res.headers.get('set-cookie')).toContain('island-auth-marker=set-from-island-middleware')
   })
 
   it('still renders unguarded `page_*` islands', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/19772

### 📚 Description

up to now, server components are exempt from middleware. this is by design and is called out in the docs.

but it may be counter intuitive for users when this comes to _server pages_. so this PR adds a new hash comparison for server pages to ensure that the route that the page is rendering matches the route component the server page is meant to server - and then runs middleware and handles redirections for server pages.