### PR TITLE
fix(nitro): assign `noSSR` before deciding payload extraction

### DIFF
--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -108,6 +108,10 @@ async function renderRoute (event: H3Event, ssrError: (NuxtPayload['error'] & { 
   // Get route options (for `ssr: false`, `isr`, `cache` and `noScripts`)
   const routeOptions = getRouteRules(event.req.method, event.url.pathname).routeRules || {}
 
+  if (!routeOptions?.ssr) {
+    ssrContext.noSSR = true
+  }
+
   // Whether we are prerendering route or using ISR/SWR caching
   const _PAYLOAD_EXTRACTION = !ssrContext.noSSR && (
     (import.meta.prerender && NUXT_PAYLOAD_EXTRACTION)
@@ -125,10 +129,6 @@ async function renderRoute (event: H3Event, ssrError: (NuxtPayload['error'] & { 
     if (import.meta.prerender && await payloadCache!.hasItem(url + '.json')) {
       return returnResponse(event, await payloadCache!.getItem(url + '.json') as Partial<RenderResponse>)
     }
-  }
-
-  if (!routeOptions?.ssr) {
-    ssrContext.noSSR = true
   }
 
   const payloadURL = _PAYLOAD_EXTRACTION ? joinURL(ssrContext.runtimeConfig.app.cdnURL || ssrContext.runtimeConfig.app.baseURL, ssrContext.url.replace(/\?.*$/, ''), PAYLOAD_FILENAME) + '?' + ssrContext.runtimeConfig.app.buildId : undefined

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -108,6 +108,15 @@ describe('route rules', () => {
     expect(html).toContain('Custom Layout')
   })
 
+  it('should not extract payload for `ssr: false` routes with useAsyncData (#34279)', async () => {
+    const html = await $fetch<string>('/route-rules/spa-async-data')
+    const { attrs } = parseData(html)
+    expect(attrs['data-ssr']).toEqual('false')
+    expect(attrs['data-src']).toBeUndefined()
+    expect(html).not.toContain('/route-rules/spa-async-data/_payload.json')
+    await expectNoClientErrors('/route-rules/spa-async-data')
+  })
+
   it('should not generate payload route rules for non-wildcard ssr: false routes', () => {
     // @ts-expect-error untyped internal property
     const routeRules = useTestContext().nuxt._nitro.options.routeRules

--- a/test/fixtures/basic/app/pages/route-rules/spa-async-data.vue
+++ b/test/fixtures/basic/app/pages/route-rules/spa-async-data.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+// regression test for #34279: useAsyncData on an `ssr: false` route should
+// not trigger payload extraction during prerender
+const { data } = useAsyncData('spa-async-data', () => Promise.resolve({ ok: true }))
+</script>
+
+<template>
+  <div>spa-async-data: {{ data }}</div>
+</template>

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -175,6 +175,7 @@ export default withMatrix({
     ],
     routeRules: {
       '/route-rules/spa': { ssr: false },
+      '/route-rules/spa-async-data': { ssr: false },
       '/redirect/catchall': { ssr: false },
       '/head-spa': { ssr: false },
       '/route-rules/middleware': { appMiddleware: 'route-rules-middleware' },


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/34279
related: #34327

### 📚 Description

this was a regression from #33467 which reordered the renderer and calculated `_PAYLOAD_EXTRACTION` before evaluting noSSR....