### PR TITLE
fix(nitro): pass event data to `isValid` in dev clipboard-copy listener

### DIFF
--- a/packages/nitro-server/src/runtime/utils/dev.ts
+++ b/packages/nitro-server/src/runtime/utils/dev.ts
@@ -88,7 +88,7 @@ const parentStorageBridge = (nonce: string) => /* js */ `
 
   // Handle clipboard copy from iframe
   window.addEventListener('message', function(e) {
-    if (isValid(e) && e.data.type === 'clipboard-copy') {
+    if (isValid(e.data) && e.data.type === 'clipboard-copy') {
       navigator.clipboard.writeText(e.data.text).catch(function() {});
     }
   });


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this adds a missing `.data` before calling `isValid`