### PR TITLE
fix(nuxt): prevent sibling-directory traversal in test component wrapper

### DIFF
--- a/packages/nuxt/src/app/components/test-component-wrapper.ts
+++ b/packages/nuxt/src/app/components/test-component-wrapper.ts
@@ -1,6 +1,6 @@
 import { defineComponent, h } from 'vue'
 import { parseQuery } from 'vue-router'
-import { resolve } from 'pathe'
+import { isAbsolute, relative, resolve } from 'pathe'
 // @ts-expect-error virtual file
 import { devRootDir } from '#build/nuxt.config.mjs'
 
@@ -21,7 +21,8 @@ export default (url: string) => defineComponent({
       }
     }
     const path = resolve(query.path as string)
-    if (!path.startsWith(devRootDir)) {
+    const rel = relative(devRootDir, path)
+    if (rel.startsWith('..') || isAbsolute(rel)) {
       throw new Error(`[nuxt] Cannot access path outside of project root directory: \`${path}\`.`)
     }
     const comp = await import(/* @vite-ignore */ path as string).then(r => r.default)


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

we didn't test by path separator so we previously might be able to access a similarly named path, e.g. `/Users/daniel/code/nuxt` and `/Users/daniel/code/nuxt-old`