### PR TITLE
fix(vite): avoid filtering out dirs with shared prefix from `allowDirs`

### DIFF
--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -70,9 +70,9 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
     ]),
   ].filter(d => d && existsSync(d))
 
-  for (const dir of allowDirs) {
-    allowDirs = allowDirs.filter(d => !d.startsWith(dir) || d === dir)
-  }
+  allowDirs = allowDirs.filter(d =>
+    !allowDirs.some(other => other !== d && d.startsWith(other + '/')),
+  )
 
   const { $client, $server, ...viteConfig } = nuxt.options.vite
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

similar to https://github.com/nuxt/nuxt/pull/35110, this ensures we're not wrongly filtering dirs with similar prefix. so `['/srv/app', '/srv/app-shared', '/srv/app/deep']` should not filter out `/srv/app-shared`.