### PR TITLE
ci: fix lychee dynamic composable exclude

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -49,7 +49,7 @@ exclude = [
   "https://nuxt.new/c/v4",
   "https://nuxt.new/s/v4",
   "https://www.npmjs.com/",
-  "https://nuxt.com/docs/4.x/api/composables/$%7BkebabCase(factory.name)%7D/",
+  'https://nuxt\.com/docs/4\.x/api/composables/\$%7BkebabCase\(factory\.name\)%7D.*',
   # TODO: fix upstream API issues
   "https://nuxt.com/modules",
   # single-quotes are required for regexp


### PR DESCRIPTION
This PR fixes the link-checker CI pipeline failure currently occurring on the main branch.

### Root Cause

The Nuxt compiler source contains a dynamic documentation URL using a template literal:

```ts
`https://nuxt.com/docs/4.x/api/composables/${kebabCase(factory.name)}`
```

Because `lychee` parses files statically, it evaluates the raw string:

```text
https://nuxt.com/docs/4.x/api/composables/$%7BkebabCase(factory.name)%7D/
```

Since this exact path does not exist on the Nuxt website, `lychee` reports a `404 Not Found` error.

The existing exclusion rule in `lychee.toml` was written as a strict string literal with a trailing slash (`...%7D/`), but the parsed source URL does not always include the trailing slash, causing the exclusion rule to be bypassed.

### Fix

Updated the `lychee.toml` exclusion rule to use a regular expression (`.*` suffix) instead of a strict string match.

This ensures the dynamic URL is consistently excluded by the link checker regardless of whether a trailing slash is appended.

---

## How to verify the fix locally

If you have the `lychee` CLI installed, you can validate the fix locally before merging.

### 1. Reproduce the failure on `main`

```bash
git checkout origin/main -- lychee.toml
lychee --config lychee.toml packages/nuxt/src/compiler/runtime/index.ts
```

Expected result:

```text
[packages/nuxt/src/compiler/runtime/index.ts]:
   [404] https://nuxt.com/docs/4.x/api/composables/$%7BkebabCase(factory.name)%7D/ (at 24:118) | Rejected status code: 404 Not Found

🔍 1 Total (in 1s 375ms) 🔗 1 Unique ✅ 0 OK 🚫 1 Error
```

### 2. Verify the fix from this PR (with verbose logging)

```bash
git restore --source HEAD lychee.toml
lychee --config lychee.toml --verbose packages/nuxt/src/compiler/runtime/index.ts
```

Expected result:

```text
[EXCLUDED] https://nuxt.com/docs/4.x/api/composables/$%7BkebabCase(factory.name)%7D/ (at 24:118) | This is due to your 'exclude' values

🔍 1 Total (in 1ms) 🔗 1 Unique ✅ 0 OK 🚫 0 Errors 👻 1 Excluded
```

### Related Issues

Follow-up to maintainer feedback regarding CI failures in #35090.