### PR TITLE
fix(vite): prefix public asset virtuals with null byte

### DIFF
--- a/packages/vite/src/plugins/public-dirs.ts
+++ b/packages/vite/src/plugins/public-dirs.ts
@@ -6,8 +6,8 @@ import { generateTransform, rolldownString } from 'rolldown-string'
 import { isCSSRequest } from 'vite'
 import type { Plugin } from 'vite'
 
-const PREFIX = 'virtual:public?'
-const PREFIX_RE = /^virtual:public\?/
+const PREFIX = '\0virtual:public?'
+const PREFIX_RE = /^\0virtual:public\?/
 const CSS_URL_RE = /url\((\/[^)]+)\)/g
 const CSS_URL_SINGLE_RE = /url\(\/[^)]+\)/
 const RENDER_CHUNK_RE = /(?<= = )['"`]/

--- a/packages/vite/test/public-dirs.test.ts
+++ b/packages/vite/test/public-dirs.test.ts
@@ -25,7 +25,8 @@ afterAll(() => {
 })
 
 describe('PublicDirsPlugin', () => {
-  const [, plugin] = PublicDirsPlugin({})
+  const plugins = PublicDirsPlugin({})
+  const plugin = plugins[1]!
   const resolveId = typeof plugin.resolveId === 'function' ? plugin.resolveId : plugin.resolveId!.handler
   const load = typeof plugin.load === 'function' ? plugin.load : plugin.load!.handler
 

--- a/packages/vite/test/public-dirs.test.ts
+++ b/packages/vite/test/public-dirs.test.ts
@@ -1,0 +1,47 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+
+const publicDir = join(tmpdir(), `nuxt-public-dirs-test-${Date.now()}`)
+
+vi.mock('@nuxt/kit', () => ({
+  useNitro: () => ({
+    options: {
+      publicAssets: [{ baseURL: '/', dir: publicDir }],
+    },
+  }),
+}))
+
+const { PublicDirsPlugin } = await import('../src/plugins/public-dirs')
+
+beforeAll(() => {
+  mkdirSync(publicDir, { recursive: true })
+  writeFileSync(join(publicDir, 'logo.svg'), '<svg/>')
+})
+
+afterAll(() => {
+  rmSync(publicDir, { recursive: true, force: true })
+})
+
+describe('PublicDirsPlugin', () => {
+  const [, plugin] = PublicDirsPlugin({})
+  const resolveId = typeof plugin.resolveId === 'function' ? plugin.resolveId : plugin.resolveId!.handler
+  const load = typeof plugin.load === 'function' ? plugin.load : plugin.load!.handler
+
+  it('resolves public asset ids with a `\\0` prefix so Vite skips its fs deny check', () => {
+    // see https://github.com/nuxt/nuxt/issues/35107 — Vite 7.3.2+ denies transform of
+    // ids containing `.svg`/`?url`/`?raw`/`?inline` unless they start with `\0`
+    const resolved = (resolveId as any).call({}, '/logo.svg', undefined, {})
+    expect(resolved).toBeTypeOf('string')
+    expect(resolved.startsWith('\0')).toBe(true)
+    expect(resolved).toBe('\0virtual:public?' + encodeURIComponent('/logo.svg'))
+  })
+
+  it('loads the resolved virtual id back into a publicAssetsURL import', () => {
+    const id = '\0virtual:public?' + encodeURIComponent('/logo.svg')
+    const result = (load as any).call({}, id)
+    expect(result).toContain('publicAssetsURL')
+    expect(result).toContain(JSON.stringify('/logo.svg'))
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/35107

### 📚 Description

small fix to address a regression in vite