### PR TITLE
fix(nuxt): re-run `getCachedData` after initial fetch

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -370,10 +370,12 @@ export const createUseAsyncData = defineKeyedFunctionFactory({
           initialFetchOptions.cachedData = opts.getCachedData!(key.value, nuxtApp, { cause: 'initial' })
           nuxtApp._asyncData[key.value] = buildAsyncData(nuxtApp, key.value, _handler, opts, initialFetchOptions.cachedData)
           nuxtApp._asyncData[key.value]!._initialCachedData = initialFetchOptions.cachedData
-        } else {
-          // reuse the cache lookup performed by the first concurrent caller
+        } else if (nuxtApp._asyncDataPromises[key.value]) {
+          // reuse the cache lookup performed by the first concurrent caller while their fetch is still in flight
           initialFetchOptions.cachedData = existing._initialCachedData
         }
+        // otherwise let execute() perform a fresh getCachedData lookup so subscribers that mount
+        // after the initial fetch has settled still go through getCachedData (#35116)
         return () => nuxtApp._asyncData[key.value]!.execute(initialFetchOptions)
       }
 

--- a/test/nuxt/use-async-data.test.ts
+++ b/test/nuxt/use-async-data.test.ts
@@ -1494,4 +1494,40 @@ describe('useAsyncData', () => {
     expect(fetchCount).toBe(1)
     expect(second.value).toBe('fresh-1')
   })
+
+  // https://github.com/nuxt/nuxt/issues/35116
+  it('should call getCachedData for a useLazyAsyncData subscriber that mounts after the initial fetch settled', async () => {
+    const key = `late-subscriber-getCachedData-lazy-${++counter}`
+    const getCachedData = vi.fn((_key: string, nuxtApp: NuxtApp) => nuxtApp.payload.data[_key])
+    const promiseFn = vi.fn(() => Promise.resolve('value'))
+
+    const persistentComponent = defineComponent({
+      setup () {
+        useLazyAsyncData(key, promiseFn, { getCachedData })
+        return () => h('div')
+      },
+    })
+    const lateComponent = defineComponent({
+      setup () {
+        useLazyAsyncData(key, promiseFn, { getCachedData })
+        return () => h('div')
+      },
+    })
+
+    const persistent = await mountSuspended(persistentComponent)
+    await flushPromises()
+    expect(promiseFn).toHaveBeenCalledTimes(1)
+    const callsAfterFirst = getCachedData.mock.calls.length
+
+    const late = await mountSuspended(lateComponent)
+    await flushPromises()
+
+    // the late subscriber must consult getCachedData...
+    expect(getCachedData.mock.calls.length).toBeGreaterThan(callsAfterFirst)
+    // ...and must reuse the cached payload rather than re-running the handler
+    expect(promiseFn).toHaveBeenCalledTimes(1)
+
+    late.unmount()
+    persistent.unmount()
+  })
 })


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/35116

### 📚 Description

this addresses a regression from #34999 which cached the first caller's `getCachedData` lookup on `_initialCachedData` and unconditionally reused it for every subsequent caller, including ones that mounted long after the initial fetch had settle

now we check if the promise is still in-flight