### PR TITLE
feat(nuxt): support named views via filename convention

### DIFF
--- a/docs/2.directory-structure/1.app/1.pages.md
+++ b/docs/2.directory-structure/1.app/1.pages.md
@@ -230,6 +230,41 @@ definePageMeta({
 
 :link-example{to="/docs/4.x/examples/routing/pages"}
 
+## Named Views
+
+A single route can render into multiple `<NuxtPage>` outlets in a parent component by giving each outlet a `name` and providing a sibling page file for each name.
+
+Use the `name@view.vue` filename convention to declare a named view alongside the default route file:
+
+```bash [Directory Structure]
+-| pages/
+---| parent/
+-----| child.vue
+-----| child@sidebar.vue
+---| parent.vue
+```
+
+Then render each outlet by name from the parent:
+
+```vue [pages/parent.vue]
+<template>
+  <div>
+    <NuxtPage />
+    <aside>
+      <NuxtPage name="sidebar" />
+    </aside>
+  </div>
+</template>
+```
+
+When the user navigates to `/parent/child`, `child.vue` renders into the default `<NuxtPage />` and `child@sidebar.vue` renders into `<NuxtPage name="sidebar" />`. Outlets without a matching named view are left empty.
+
+::note
+`definePageMeta` is read from the default route file only. Meta declared inside a `name@view.vue` sibling has no effect on the route.
+::
+
+:read-more{title="Named Views" to="https://router.vuejs.org/guide/essentials/named-views.html" target="_blank"}
+
 ## Route Groups
 
 In some cases, you may want to group a set of routes together in a way which doesn't affect file-based routing. For this purpose, you can put files in a folder which is wrapped in parentheses - `(` and `)`.

--- a/docs/4.api/1.components/2.nuxt-page.md
+++ b/docs/4.api/1.components/2.nuxt-page.md
@@ -44,7 +44,7 @@ In a typical Vue application, a new page component is mounted **only after** the
 
 ## Props
 
-- `name`: tells `<RouterView>` to render the component with the corresponding name in the matched route record's components option.
+- `name`: tells `<RouterView>` to render the component with the corresponding name in the matched route record's components option. See [Named Views](/docs/4.x/directory-structure/app/pages#named-views) for the `name@view.vue` filename convention.
   - type: `string`
 - `route`: route location that has all of its components resolved.
   - type: `RouteLocationNormalized`

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -430,6 +430,22 @@ export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = 
         ? normalizeComponentWithName(page, isSyncImport, pageImportName, pageImport, route.name, metaRouteName, islandKey)
         : normalizeComponent(page, pageImport, route.name, islandKey)
 
+      // Named views from the `name@view.vue` filename convention. The scanner
+      // emits `components: { default: <file>, <view>: <file> }`.
+      // https://router.vuejs.org/guide/essentials/named-views.html
+      let componentsObject: string | undefined
+      if (page.components) {
+        const viewEntries: string[] = []
+        for (const viewName in page.components) {
+          if (viewName === 'default') { continue }
+          const viewFile = normalize(page.components[viewName]!)
+          viewEntries.push(`${JSON.stringify(viewName)}: ${genDynamicImport(viewFile)}`)
+        }
+        if (viewEntries.length > 0) {
+          componentsObject = `{ default: ${component}, ${viewEntries.join(', ')} }`
+        }
+      }
+
       const metaRoute: NormalizedRoute = {
         name: metaRouteName,
         path: `${metaImportName}?.path ?? ${route.path}`,
@@ -438,6 +454,9 @@ export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = 
         alias: `${metaImportName}?.alias || []`,
         redirect: `${metaImportName}?.redirect`,
         component,
+      }
+      if (componentsObject) {
+        metaRoute.components = componentsObject
       }
 
       if (page.mode === 'server') {

--- a/packages/nuxt/test/__snapshots__/pages-override-meta-disabled.test.ts.snap
+++ b/packages/nuxt/test/__snapshots__/pages-override-meta-disabled.test.ts.snap
@@ -662,6 +662,29 @@
       "redirect": "mockMeta?.redirect",
     },
   ],
+  "should preserve named views from the `name@view.vue` filename convention": [
+    {
+      "alias": "mockMeta?.alias || []",
+      "children": [
+        {
+          "alias": "mockMeta?.alias || []",
+          "component": "() => import("pages/foo/bar.vue")",
+          "components": "{ default: () => import("pages/foo/bar.vue"), "left": () => import("pages/foo/bar@left.vue") }",
+          "meta": "mockMeta || {}",
+          "name": "mockMeta?.name ?? "foo-bar"",
+          "path": "mockMeta?.path ?? "bar"",
+          "props": "mockMeta?.props ?? false",
+          "redirect": "mockMeta?.redirect",
+        },
+      ],
+      "component": "() => import("pages/foo.vue")",
+      "meta": "mockMeta || {}",
+      "name": "mockMeta?.name ?? "foo"",
+      "path": "mockMeta?.path ?? "/foo"",
+      "props": "mockMeta?.props ?? false",
+      "redirect": "mockMeta?.redirect",
+    },
+  ],
   "should properly override route name if definePageMeta name override is defined.": [
     {
       "alias": "mockMeta?.alias || []",

--- a/packages/nuxt/test/__snapshots__/pages-override-meta-enabled.test.ts.snap
+++ b/packages/nuxt/test/__snapshots__/pages-override-meta-enabled.test.ts.snap
@@ -415,6 +415,21 @@
       "path": ""/:a1_1a()"",
     },
   ],
+  "should preserve named views from the `name@view.vue` filename convention": [
+    {
+      "children": [
+        {
+          "component": "() => import("pages/foo/bar.vue")",
+          "components": "{ default: () => import("pages/foo/bar.vue"), "left": () => import("pages/foo/bar@left.vue") }",
+          "name": ""foo-bar"",
+          "path": ""bar"",
+        },
+      ],
+      "component": "() => import("pages/foo.vue")",
+      "name": ""foo"",
+      "path": ""/foo"",
+    },
+  ],
   "should properly override route name if definePageMeta name override is defined.": [
     {
       "component": "() => import("pages/index.vue")",

--- a/packages/nuxt/test/nitro-ssr-routes.test.ts
+++ b/packages/nuxt/test/nitro-ssr-routes.test.ts
@@ -78,6 +78,8 @@ describe('nitro-ssr-routes', () => {
         "/about",
         "/about",
         "/about",
+        "/foo",
+        "/foo/bar",
       ]
     `)
   })

--- a/packages/nuxt/test/pages.test.ts
+++ b/packages/nuxt/test/pages.test.ts
@@ -238,6 +238,58 @@ describe('pages:generateRoutesFromFiles', () => {
     })
   })
 
+  describe('pages:namedViews', () => {
+    it('emits a `components` map alongside `component` when the scanner reports named views', () => {
+      const pages: NuxtPage[] = [
+        {
+          name: 'foo-bar',
+          path: 'bar',
+          file: '/pages/foo/bar.vue',
+          components: {
+            default: '/pages/foo/bar.vue',
+            left: '/pages/foo/bar@left.vue',
+          },
+        } as unknown as NuxtPage,
+      ]
+
+      const { routes } = normalizeRoutes(pages, new Set(), {
+        clientComponentRuntime: '<client>',
+        serverComponentRuntime: '<server>',
+        overrideMeta: false,
+      })
+
+      const r0: any = (routes as any)[0]
+      expect(r0.component).toBeTruthy()
+      expect(r0.components).toBeTruthy()
+      expect(r0.components).toContain('default:')
+      expect(r0.components).toContain('"left":')
+      expect(r0.components).toContain('/pages/foo/bar@left.vue')
+    })
+
+    it('does not emit `components` when only the default view is present', () => {
+      const pages: NuxtPage[] = [
+        {
+          name: 'foo-bar',
+          path: 'bar',
+          file: '/pages/foo/bar.vue',
+          components: {
+            default: '/pages/foo/bar.vue',
+          },
+        } as unknown as NuxtPage,
+      ]
+
+      const { routes } = normalizeRoutes(pages, new Set(), {
+        clientComponentRuntime: '<client>',
+        serverComponentRuntime: '<server>',
+        overrideMeta: false,
+      })
+
+      const r0: any = (routes as any)[0]
+      expect(r0.component).toBeTruthy()
+      expect(r0.components).toBeUndefined()
+    })
+  })
+
   it('should consistently normalize routes when overriding meta', async () => {
     const sorted = sortNormalizedResults(normalizedOverrideMetaResults)
     await expect(sorted).toMatchFileSnapshot('./__snapshots__/pages-override-meta-enabled.test.ts.snap')
@@ -1174,6 +1226,33 @@ export const pageTests: Array<{
                 children: [],
               },
             ],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    description: 'should preserve named views from the `name@view.vue` filename convention',
+    files: [
+      { path: `${pagesDir}/foo.vue` },
+      { path: `${pagesDir}/foo/bar.vue` },
+      { path: `${pagesDir}/foo/bar@left.vue` },
+    ],
+    output: [
+      {
+        name: 'foo',
+        path: '/foo',
+        file: `${pagesDir}/foo.vue`,
+        children: [
+          {
+            name: 'foo-bar',
+            path: 'bar',
+            file: `${pagesDir}/foo/bar.vue`,
+            children: [],
+            components: {
+              default: `${pagesDir}/foo/bar.vue`,
+              left: `${pagesDir}/foo/bar@left.vue`,
+            },
           },
         ],
       },

--- a/packages/schema/src/types/hooks.ts
+++ b/packages/schema/src/types/hooks.ts
@@ -29,6 +29,13 @@ export interface NuxtPage {
   path: string
   props?: RouteRecordRaw['props']
   file?: string
+  /**
+   * Named view files keyed by view name, including `default`. Populated by the
+   * page scanner from the `name@view.vue` filename convention. When set, the
+   * keys are wired up to vue-router's [`components`](https://router.vuejs.org/guide/essentials/named-views.html)
+   * option so multiple `<NuxtPage name="..." />` outlets can render.
+   */
+  components?: Record<string, string>
   meta?: Record<string, any>
   alias?: string[] | string
   redirect?: RouteLocationRaw


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/34813 (thank you @mukundshah for your work on it!)

### 📚 Description

this adds support for named views via `~/pages/path@viewname.vue`. this has been supported since we switched to use https://github.com/unjs/unrouting

With:

```
pages/
 foo.vue
 foo/
   bar.vue
   bar@left.vue
```

and `pages/foo.vue`:

```vue
<template>
 <NuxtPage name="left" />
 <NuxtPage />
</template>
```

The child route now serializes as:

```js
{
 path: 'bar',
 component: () => import('~/pages/foo/bar.vue'),
 components: {
   default: () => import('~/pages/foo/bar.vue'),
   left: () => import('~/pages/foo/bar@left.vue'),
 },
}
```

so both outlets render. Before this change, `components` was dropped during `normalizeRoutes` and only the default `<NuxtPage />` rendered...

note that:

 - `definePageMeta` inside a `*@view.vue` file is ignored rather than merged with the default view
 - per-view mode (client/server) isn't supported - the parent page's mode applies only to the default view