### PR TITLE
fix(kit): include all tests in typechecking paths

### DIFF
--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -1,4 +1,4 @@
-import { existsSync, promises as fsp } from 'node:fs'
+import { existsSync, promises as fsp, readdirSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { basename, isAbsolute, join, normalize, parse, relative, resolve } from 'pathe'
 import { hash } from 'ohash'
@@ -180,6 +180,27 @@ interface LayerPaths {
   globalDeclarations: string[]
 }
 
+function getNonNuxtTestPaths (dirs: LayerDirectories, relativeRootDir: string): string[] {
+  const paths: string[] = []
+  for (const dirName of ['test', 'tests']) {
+    const dirPath = resolve(dirs.root, dirName)
+    if (existsSync(dirPath)) {
+      paths.push(join(relativeRootDir, `${dirName}/*`))
+      try {
+        const subdirs = readdirSync(dirPath, { withFileTypes: true })
+        for (const subdir of subdirs) {
+          if (subdir.isDirectory() && subdir.name !== 'nuxt') {
+            paths.push(join(relativeRootDir, `${dirName}/${subdir.name}/**/*`))
+          }
+        }
+      } catch {
+        // Silently ignore
+      }
+    }
+  }
+  return paths
+}
+
 export function resolveLayerPaths (dirs: LayerDirectories, projectBuildDir: string): LayerPaths {
   const relativeRootDir = relativeWithDot(projectBuildDir, dirs.root)
   const relativeSrcDir = relativeWithDot(projectBuildDir, dirs.app)
@@ -200,6 +221,7 @@ export function resolveLayerPaths (dirs: LayerDirectories, projectBuildDir: stri
       join(relativeRootDir, `layers/*/modules/*/runtime/server/**/*`),
     ],
     node: [
+      ...getNonNuxtTestPaths(dirs, relativeRootDir),
       join(relativeModulesDir, `*.*`),
       join(relativeRootDir, `nuxt.config.*`),
       join(relativeRootDir, `.config/nuxt.*`),

--- a/packages/kit/test/generate-types.spec.ts
+++ b/packages/kit/test/generate-types.spec.ts
@@ -138,6 +138,12 @@ describe('resolveLayerPaths', async () => {
           "../layers/*/modules/*/runtime/server/**/*",
         ],
         "node": [
+          "../test/*",
+          "../test/e2e/**/*",
+          "../test/fixtures/**/*",
+          "../test/fixtures-temp/**/*",
+          "../test/mocks/**/*",
+          "../test/runtime/**/*",
           "../custom-modules/*.*",
           "../nuxt.config.*",
           "../.config/nuxt.*",


### PR DESCRIPTION
### 🔗 Related Issue
Closes #34756

### Context
Currently, Nuxt only tracks test files nested under `test/nuxt/` or `tests/nuxt/` directories for application-wide TypeScript typechecking. Any test files placed directly under the root `test/` or `tests/` folders (such as `tests/utils.test.ts`) were excluded, which caused commands like `nuxi typecheck` to falsely succeed even when those test files contained TypeScript compilation errors.

### Solution
1. Modified the `resolveLayerPaths` helper in `packages/kit/src/template.ts` to track all files recursively under `test/**/*` and `tests/**/*` instead of only matching `test/nuxt/**/*` and `tests/nuxt/**/*`.
2. Updated the inline snapshot expectations in `packages/kit/test/generate-types.spec.ts`.