### PR TITLE
feat: make runtime test type globs configurable

### DIFF
--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -187,12 +187,11 @@ export function resolveLayerPaths (dirs: LayerDirectories, projectBuildDir: stri
   const relativeSharedDir = relativeWithDot(projectBuildDir, dirs.shared)
   const topLevelTestPaths = ['test', 'tests']
     .filter(dir => existsSync(resolve(dirs.root, dir)))
-    .map(dir => join(relativeRootDir, `${dir}/*`))
+    .map(dir => join(relativeRootDir, `${dir}/**/*`))
   return {
     nuxt: [
       join(relativeSrcDir, '**/*'),
       join(relativeModulesDir, `*/runtime/**/*`),
-      ...topLevelTestPaths,
       join(relativeRootDir, `test/nuxt/**/*`),
       join(relativeRootDir, `tests/nuxt/**/*`),
       join(relativeRootDir, `layers/*/app/**/*`),
@@ -204,6 +203,7 @@ export function resolveLayerPaths (dirs: LayerDirectories, projectBuildDir: stri
       join(relativeRootDir, `layers/*/modules/*/runtime/server/**/*`),
     ],
     node: [
+      ...topLevelTestPaths,
       join(relativeModulesDir, `*.*`),
       join(relativeRootDir, `nuxt.config.*`),
       join(relativeRootDir, `.config/nuxt.*`),

--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -1,4 +1,4 @@
-import { existsSync, promises as fsp } from 'node:fs'
+import { existsSync, promises as fsp, readdirSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { basename, isAbsolute, join, normalize, parse, relative, resolve } from 'pathe'
 import { hash } from 'ohash'
@@ -181,20 +181,34 @@ interface LayerPaths {
 }
 
 const DEFAULT_RUNTIME_TEST_GLOBS = ['test/nuxt/**/*', 'tests/nuxt/**/*']
+const TOP_LEVEL_RUNTIME_TEST_GLOB_RE = /^tests?\/\*\*\/\*$/
 
 export function resolveLayerPaths (dirs: LayerDirectories, projectBuildDir: string, runtimeTestGlobs: string[] = DEFAULT_RUNTIME_TEST_GLOBS): LayerPaths {
   const relativeRootDir = relativeWithDot(projectBuildDir, dirs.root)
   const relativeSrcDir = relativeWithDot(projectBuildDir, dirs.app)
   const relativeModulesDir = relativeWithDot(projectBuildDir, dirs.modules)
   const relativeSharedDir = relativeWithDot(projectBuildDir, dirs.shared)
-  const runtimeTestRootDirs = new Set(runtimeTestGlobs
+  const normalizedRuntimeTestGlobs = runtimeTestGlobs
     .map(pattern => pattern.replace(/^[./\\]+/, '').replaceAll('\\', '/'))
-    .filter(pattern => /^(test|tests)\/\*\*\/\*$/.test(pattern))
+  const runtimeTestRootDirs = new Set(normalizedRuntimeTestGlobs
+    .filter(pattern => TOP_LEVEL_RUNTIME_TEST_GLOB_RE.test(pattern))
     .map(pattern => pattern.slice(0, pattern.indexOf('/'))))
-  const topLevelTestPaths = ['test', 'tests']
-    .filter(dir => existsSync(resolve(dirs.root, dir)) && !runtimeTestRootDirs.has(dir))
-    .map(dir => join(relativeRootDir, `${dir}/**/*`))
-  const runtimeTestPaths = runtimeTestGlobs.map(pattern => join(relativeRootDir, pattern))
+  const topLevelTestPaths = ['test', 'tests'].flatMap((dir) => {
+    const testDir = resolve(dirs.root, dir)
+    if (!existsSync(testDir) || runtimeTestRootDirs.has(dir)) {
+      return []
+    }
+
+    return readdirSync(testDir, { withFileTypes: true })
+      .filter((entry) => {
+        const entryPattern = `${dir}/${entry.name}`
+        return !normalizedRuntimeTestGlobs.some(pattern => pattern === entryPattern || pattern.startsWith(`${entryPattern}/`))
+      })
+      .map(entry => entry.isDirectory()
+        ? join(relativeRootDir, `${dir}/${entry.name}/**/*`)
+        : join(relativeRootDir, `${dir}/${entry.name}`))
+  })
+  const runtimeTestPaths = normalizedRuntimeTestGlobs.map(pattern => join(relativeRootDir, pattern))
   return {
     nuxt: [
       join(relativeSrcDir, '**/*'),

--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -185,13 +185,14 @@ export function resolveLayerPaths (dirs: LayerDirectories, projectBuildDir: stri
   const relativeSrcDir = relativeWithDot(projectBuildDir, dirs.app)
   const relativeModulesDir = relativeWithDot(projectBuildDir, dirs.modules)
   const relativeSharedDir = relativeWithDot(projectBuildDir, dirs.shared)
-  const testPaths = ['test', 'tests']
+  const topLevelTestPaths = ['test', 'tests']
     .filter(dir => existsSync(resolve(dirs.root, dir)))
-    .map(dir => join(relativeRootDir, `${dir}/**/*`))
+    .map(dir => join(relativeRootDir, `${dir}/*`))
   return {
     nuxt: [
       join(relativeSrcDir, '**/*'),
       join(relativeModulesDir, `*/runtime/**/*`),
+      ...topLevelTestPaths,
       join(relativeRootDir, `test/nuxt/**/*`),
       join(relativeRootDir, `tests/nuxt/**/*`),
       join(relativeRootDir, `layers/*/app/**/*`),
@@ -203,7 +204,6 @@ export function resolveLayerPaths (dirs: LayerDirectories, projectBuildDir: stri
       join(relativeRootDir, `layers/*/modules/*/runtime/server/**/*`),
     ],
     node: [
-      ...testPaths,
       join(relativeModulesDir, `*.*`),
       join(relativeRootDir, `nuxt.config.*`),
       join(relativeRootDir, `.config/nuxt.*`),

--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -180,20 +180,26 @@ interface LayerPaths {
   globalDeclarations: string[]
 }
 
-export function resolveLayerPaths (dirs: LayerDirectories, projectBuildDir: string): LayerPaths {
+const DEFAULT_RUNTIME_TEST_GLOBS = ['test/nuxt/**/*', 'tests/nuxt/**/*']
+
+export function resolveLayerPaths (dirs: LayerDirectories, projectBuildDir: string, runtimeTestGlobs: string[] = DEFAULT_RUNTIME_TEST_GLOBS): LayerPaths {
   const relativeRootDir = relativeWithDot(projectBuildDir, dirs.root)
   const relativeSrcDir = relativeWithDot(projectBuildDir, dirs.app)
   const relativeModulesDir = relativeWithDot(projectBuildDir, dirs.modules)
   const relativeSharedDir = relativeWithDot(projectBuildDir, dirs.shared)
+  const runtimeTestRootDirs = new Set(runtimeTestGlobs
+    .map(pattern => pattern.replace(/^[./\\]+/, '').replaceAll('\\', '/'))
+    .filter(pattern => /^(test|tests)\/\*\*\/\*$/.test(pattern))
+    .map(pattern => pattern.split('/')[0]!))
   const topLevelTestPaths = ['test', 'tests']
-    .filter(dir => existsSync(resolve(dirs.root, dir)))
+    .filter(dir => existsSync(resolve(dirs.root, dir)) && !runtimeTestRootDirs.has(dir))
     .map(dir => join(relativeRootDir, `${dir}/**/*`))
+  const runtimeTestPaths = runtimeTestGlobs.map(pattern => join(relativeRootDir, pattern))
   return {
     nuxt: [
       join(relativeSrcDir, '**/*'),
       join(relativeModulesDir, `*/runtime/**/*`),
-      join(relativeRootDir, `test/nuxt/**/*`),
-      join(relativeRootDir, `tests/nuxt/**/*`),
+      ...runtimeTestPaths,
       join(relativeRootDir, `layers/*/app/**/*`),
       join(relativeRootDir, `layers/*/modules/*/runtime/**/*`),
     ],
@@ -284,7 +290,7 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
   for (const dirs of layerDirs) {
     if (!dirs.app.startsWith(rootDirWithSlash) || dirs.root === rootDirWithSlash || dirs.app.includes('node_modules')) {
       const rootGlob = join(relativeWithDot(nuxt.options.buildDir, dirs.root), '**/*')
-      const paths = resolveLayerPaths(dirs, nuxt.options.buildDir)
+      const paths = resolveLayerPaths(dirs, nuxt.options.buildDir, nuxt.options.typescript.runtimeTestGlobs)
       for (const path of paths.nuxt) {
         include.add(path)
         legacyInclude.add(path)

--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -189,6 +189,8 @@ export function resolveLayerPaths (dirs: LayerDirectories, projectBuildDir: stri
     nuxt: [
       join(relativeSrcDir, '**/*'),
       join(relativeModulesDir, `*/runtime/**/*`),
+      join(relativeRootDir, `test/**/*`),
+      join(relativeRootDir, `tests/**/*`),
       join(relativeRootDir, `test/nuxt/**/*`),
       join(relativeRootDir, `tests/nuxt/**/*`),
       join(relativeRootDir, `layers/*/app/**/*`),

--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -185,12 +185,13 @@ export function resolveLayerPaths (dirs: LayerDirectories, projectBuildDir: stri
   const relativeSrcDir = relativeWithDot(projectBuildDir, dirs.app)
   const relativeModulesDir = relativeWithDot(projectBuildDir, dirs.modules)
   const relativeSharedDir = relativeWithDot(projectBuildDir, dirs.shared)
+  const testPaths = ['test', 'tests']
+    .filter(dir => existsSync(resolve(dirs.root, dir)))
+    .map(dir => join(relativeRootDir, `${dir}/**/*`))
   return {
     nuxt: [
       join(relativeSrcDir, '**/*'),
       join(relativeModulesDir, `*/runtime/**/*`),
-      join(relativeRootDir, `test/**/*`),
-      join(relativeRootDir, `tests/**/*`),
       join(relativeRootDir, `test/nuxt/**/*`),
       join(relativeRootDir, `tests/nuxt/**/*`),
       join(relativeRootDir, `layers/*/app/**/*`),
@@ -202,6 +203,7 @@ export function resolveLayerPaths (dirs: LayerDirectories, projectBuildDir: stri
       join(relativeRootDir, `layers/*/modules/*/runtime/server/**/*`),
     ],
     node: [
+      ...testPaths,
       join(relativeModulesDir, `*.*`),
       join(relativeRootDir, `nuxt.config.*`),
       join(relativeRootDir, `.config/nuxt.*`),

--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -190,7 +190,7 @@ export function resolveLayerPaths (dirs: LayerDirectories, projectBuildDir: stri
   const runtimeTestRootDirs = new Set(runtimeTestGlobs
     .map(pattern => pattern.replace(/^[./\\]+/, '').replaceAll('\\', '/'))
     .filter(pattern => /^(test|tests)\/\*\*\/\*$/.test(pattern))
-    .map(pattern => pattern.split('/')[0]!))
+    .map(pattern => pattern.slice(0, pattern.indexOf('/'))))
   const topLevelTestPaths = ['test', 'tests']
     .filter(dir => existsSync(resolve(dirs.root, dir)) && !runtimeTestRootDirs.has(dir))
     .map(dir => join(relativeRootDir, `${dir}/**/*`))

--- a/packages/kit/test/generate-types.spec.ts
+++ b/packages/kit/test/generate-types.spec.ts
@@ -180,6 +180,38 @@ describe('resolveLayerPaths', () => {
       await fsp.rm(rootDir, { recursive: true, force: true })
     }
   })
+
+  it('should allow custom runtime test globs', async () => {
+    const rootDir = await fsp.mkdtemp(join(tmpdir(), 'nuxt-layer-paths-'))
+    await Promise.all([
+      fsp.mkdir(join(rootDir, 'app')),
+      fsp.mkdir(join(rootDir, 'modules')),
+      fsp.mkdir(join(rootDir, 'public')),
+      fsp.mkdir(join(rootDir, 'server')),
+      fsp.mkdir(join(rootDir, 'shared')),
+      fsp.mkdir(join(rootDir, 'test')),
+    ])
+
+    try {
+      const paths = resolveLayerPaths({
+        root: rootDir,
+        server: join(rootDir, 'server'),
+        app: join(rootDir, 'app'),
+        appLayouts: join(rootDir, 'app/layouts'),
+        appMiddleware: join(rootDir, 'app/middleware'),
+        appPages: join(rootDir, 'app/pages'),
+        appPlugins: join(rootDir, 'app/plugins'),
+        modules: join(rootDir, 'modules'),
+        shared: join(rootDir, 'shared'),
+        public: join(rootDir, 'public'),
+      }, join(rootDir, '.nuxt'), ['test/**/*'])
+
+      expect(paths.nuxt).toContain('../test/**/*')
+      expect(paths.node).not.toContain('../test/**/*')
+    } finally {
+      await fsp.rm(rootDir, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('resolveLayerPaths with workspace config', async () => {
@@ -271,7 +303,46 @@ describe('writeTypes', async () => {
       await nuxt?.close()
       await fsp.rm(testFile, { force: true })
       await fsp.rm(buildDir, { recursive: true, force: true })
-      await fsp.rmdir(testDir).catch(() => undefined)
+      await fsp.rm(testDir, { recursive: true, force: true }).catch(() => undefined)
+    }
+  })
+
+  it('should allow opting top-level runtime tests into the app project', async () => {
+    const fixtureDir = join(repoRoot, 'test/fixtures/minimal-types')
+    const buildDir = join(fixtureDir, '.nuxt')
+    const testDir = join(fixtureDir, 'test')
+    const testFile = join(testDir, 'utils.test.ts')
+    const normalizedTestFile = normalize(testFile)
+    let nuxt: Awaited<ReturnType<typeof loadNuxt>> | undefined
+
+    await fsp.mkdir(testDir, { recursive: true })
+    await fsp.writeFile(testFile, 'const a: number = "asdf";')
+
+    try {
+      nuxt = await loadNuxt({
+        cwd: fixtureDir,
+        ready: false,
+        overrides: {
+          typescript: {
+            runtimeTestGlobs: ['test/**/*'],
+          },
+        },
+      })
+      await writeTypes(nuxt)
+
+      const parseProject = (configName: string) => {
+        const configPath = join(buildDir, configName)
+        const config = ts.readConfigFile(configPath, ts.sys.readFile)
+        return ts.parseJsonConfigFileContent(config.config, ts.sys, buildDir).fileNames
+      }
+
+      expect(parseProject('tsconfig.app.json').map(normalize)).toContain(normalizedTestFile)
+      expect(parseProject('tsconfig.node.json').map(normalize)).not.toContain(normalizedTestFile)
+    } finally {
+      await nuxt?.close()
+      await fsp.rm(testFile, { force: true })
+      await fsp.rm(buildDir, { recursive: true, force: true })
+      await fsp.rm(testDir, { recursive: true, force: true }).catch(() => undefined)
     }
   })
 })

--- a/packages/kit/test/generate-types.spec.ts
+++ b/packages/kit/test/generate-types.spec.ts
@@ -115,7 +115,7 @@ describe('tsConfig generation', () => {
 })
 
 describe('resolveLayerPaths', () => {
-  it('should include existing top-level test directories in node type paths', async () => {
+  it('should include existing top-level test directories in nuxt type paths', async () => {
     const rootDir = await fsp.mkdtemp(join(tmpdir(), 'nuxt-layer-paths-'))
     await Promise.all([
       fsp.mkdir(join(rootDir, 'app')),
@@ -141,10 +141,10 @@ describe('resolveLayerPaths', () => {
         public: join(rootDir, 'public'),
       }, join(rootDir, '.nuxt'))
 
-      expect(paths.node).toContain('../test/**/*')
-      expect(paths.node).toContain('../tests/**/*')
-      expect(paths.nuxt).not.toContain('../test/**/*')
-      expect(paths.nuxt).not.toContain('../tests/**/*')
+      expect(paths.nuxt).toContain('../test/*')
+      expect(paths.nuxt).toContain('../tests/*')
+      expect(paths.node).not.toContain('../test/*')
+      expect(paths.node).not.toContain('../tests/*')
     } finally {
       await fsp.rm(rootDir, { recursive: true, force: true })
     }
@@ -174,8 +174,8 @@ describe('resolveLayerPaths', () => {
         public: join(rootDir, 'public'),
       }, join(rootDir, '.nuxt'))
 
-      expect(paths.node).not.toContain('../test/**/*')
-      expect(paths.node).not.toContain('../tests/**/*')
+      expect(paths.nuxt).not.toContain('../test/*')
+      expect(paths.nuxt).not.toContain('../tests/*')
     } finally {
       await fsp.rm(rootDir, { recursive: true, force: true })
     }
@@ -204,6 +204,16 @@ describe('resolveLayerPaths with workspace config', async () => {
       '../layers/*/server/**/*',
       '../layers/*/modules/*/runtime/server/**/*',
     ])
+    expect(paths.nuxt).toEqual(expect.arrayContaining([
+      '../app/**/*',
+      '../custom-modules/*/runtime/**/*',
+      '../test/*',
+      '../test/nuxt/**/*',
+      '../tests/nuxt/**/*',
+      '../layers/*/app/**/*',
+      '../layers/*/modules/*/runtime/**/*',
+    ]))
+    expect(paths.nuxt).not.toContain('../tests/*')
     expect(paths.node).toEqual(expect.arrayContaining([
       '../custom-modules/*.*',
       '../nuxt.config.*',
@@ -211,14 +221,6 @@ describe('resolveLayerPaths with workspace config', async () => {
       '../layers/*/nuxt.config.*',
       '../layers/*/.config/nuxt.*',
       '../layers/*/modules/**/*',
-    ]))
-    expect(paths.nuxt).toEqual(expect.arrayContaining([
-      '../app/**/*',
-      '../custom-modules/*/runtime/**/*',
-      '../test/nuxt/**/*',
-      '../tests/nuxt/**/*',
-      '../layers/*/app/**/*',
-      '../layers/*/modules/*/runtime/**/*',
     ]))
     expect(paths.shared).toEqual([
       '../custom-shared/**/*',
@@ -240,7 +242,7 @@ describe('resolveLayerPaths with workspace config', async () => {
 describe('writeTypes', async () => {
   const repoRoot = await findWorkspaceDir()
 
-  it('should include top-level test files in the node project without adding them to the app project', async () => {
+  it('should include top-level test files in the app project', async () => {
     const fixtureDir = join(repoRoot, 'test/fixtures/minimal-types')
     const buildDir = join(fixtureDir, '.nuxt')
     const testDir = join(fixtureDir, 'tests')
@@ -261,8 +263,8 @@ describe('writeTypes', async () => {
         return ts.parseJsonConfigFileContent(config.config, ts.sys, buildDir).fileNames
       }
 
-      expect(parseProject('tsconfig.node.json').map(normalize)).toContain(normalizedTestFile)
-      expect(parseProject('tsconfig.app.json').map(normalize)).not.toContain(normalizedTestFile)
+      expect(parseProject('tsconfig.app.json').map(normalize)).toContain(normalizedTestFile)
+      expect(parseProject('tsconfig.node.json').map(normalize)).not.toContain(normalizedTestFile)
     } finally {
       await fsp.rm(testFile, { force: true })
       await fsp.rm(buildDir, { recursive: true, force: true })

--- a/packages/kit/test/generate-types.spec.ts
+++ b/packages/kit/test/generate-types.spec.ts
@@ -115,7 +115,7 @@ describe('tsConfig generation', () => {
 })
 
 describe('resolveLayerPaths', () => {
-  it('should include existing top-level test directories in nuxt type paths', async () => {
+  it('should include existing top-level test directories in node type paths', async () => {
     const rootDir = await fsp.mkdtemp(join(tmpdir(), 'nuxt-layer-paths-'))
     await Promise.all([
       fsp.mkdir(join(rootDir, 'app')),
@@ -141,10 +141,10 @@ describe('resolveLayerPaths', () => {
         public: join(rootDir, 'public'),
       }, join(rootDir, '.nuxt'))
 
-      expect(paths.nuxt).toContain('../test/*')
-      expect(paths.nuxt).toContain('../tests/*')
-      expect(paths.node).not.toContain('../test/*')
-      expect(paths.node).not.toContain('../tests/*')
+      expect(paths.node).toContain('../test/**/*')
+      expect(paths.node).toContain('../tests/**/*')
+      expect(paths.nuxt).not.toContain('../test/**/*')
+      expect(paths.nuxt).not.toContain('../tests/**/*')
     } finally {
       await fsp.rm(rootDir, { recursive: true, force: true })
     }
@@ -174,8 +174,8 @@ describe('resolveLayerPaths', () => {
         public: join(rootDir, 'public'),
       }, join(rootDir, '.nuxt'))
 
-      expect(paths.nuxt).not.toContain('../test/*')
-      expect(paths.nuxt).not.toContain('../tests/*')
+      expect(paths.node).not.toContain('../test/**/*')
+      expect(paths.node).not.toContain('../tests/**/*')
     } finally {
       await fsp.rm(rootDir, { recursive: true, force: true })
     }
@@ -207,14 +207,13 @@ describe('resolveLayerPaths with workspace config', async () => {
     expect(paths.nuxt).toEqual(expect.arrayContaining([
       '../app/**/*',
       '../custom-modules/*/runtime/**/*',
-      '../test/*',
       '../test/nuxt/**/*',
       '../tests/nuxt/**/*',
       '../layers/*/app/**/*',
       '../layers/*/modules/*/runtime/**/*',
     ]))
-    expect(paths.nuxt).not.toContain('../tests/*')
     expect(paths.node).toEqual(expect.arrayContaining([
+      '../test/**/*',
       '../custom-modules/*.*',
       '../nuxt.config.*',
       '../.config/nuxt.*',
@@ -222,6 +221,9 @@ describe('resolveLayerPaths with workspace config', async () => {
       '../layers/*/.config/nuxt.*',
       '../layers/*/modules/**/*',
     ]))
+    expect(paths.nuxt).not.toContain('../test/**/*')
+    expect(paths.nuxt).not.toContain('../tests/**/*')
+    expect(paths.node).not.toContain('../tests/**/*')
     expect(paths.shared).toEqual([
       '../custom-shared/**/*',
       '../custom-modules/*/shared/**/*',
@@ -242,7 +244,7 @@ describe('resolveLayerPaths with workspace config', async () => {
 describe('writeTypes', async () => {
   const repoRoot = await findWorkspaceDir()
 
-  it('should include top-level test files in the app project', async () => {
+  it('should include top-level test files in the node project without adding them to the app project', async () => {
     const fixtureDir = join(repoRoot, 'test/fixtures/minimal-types')
     const buildDir = join(fixtureDir, '.nuxt')
     const testDir = join(fixtureDir, 'tests')
@@ -263,8 +265,8 @@ describe('writeTypes', async () => {
         return ts.parseJsonConfigFileContent(config.config, ts.sys, buildDir).fileNames
       }
 
-      expect(parseProject('tsconfig.app.json').map(normalize)).toContain(normalizedTestFile)
-      expect(parseProject('tsconfig.node.json').map(normalize)).not.toContain(normalizedTestFile)
+      expect(parseProject('tsconfig.node.json').map(normalize)).toContain(normalizedTestFile)
+      expect(parseProject('tsconfig.app.json').map(normalize)).not.toContain(normalizedTestFile)
     } finally {
       await nuxt?.close()
       await fsp.rm(testFile, { force: true })

--- a/packages/kit/test/generate-types.spec.ts
+++ b/packages/kit/test/generate-types.spec.ts
@@ -1,10 +1,15 @@
+import { promises as fsp } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { describe, expect, it } from 'vitest'
 import type { Nuxt, NuxtConfig } from '@nuxt/schema'
 import { defu } from 'defu'
+import { join, normalize } from 'pathe'
 import { findWorkspaceDir } from 'pkg-types'
+import ts from 'typescript'
 
 import { loadNuxtConfig } from '../src/loader/config.ts'
-import { _generateTypes, resolveLayerPaths } from '../src/template.ts'
+import { loadNuxt } from '../src/loader/nuxt.ts'
+import { _generateTypes, resolveLayerPaths, writeTypes } from '../src/template.ts'
 import { getLayerDirectories } from 'nuxt/kit'
 
 type DeepPartial<T> = {
@@ -110,22 +115,70 @@ describe('tsConfig generation', () => {
 })
 
 describe('resolveLayerPaths', () => {
-  it('should include top-level test directories in nuxt type paths', () => {
-    const paths = resolveLayerPaths({
-      root: '/my-app',
-      server: '/my-app/server',
-      app: '/my-app/app',
-      appLayouts: '/my-app/app/layouts',
-      appMiddleware: '/my-app/app/middleware',
-      appPages: '/my-app/app/pages',
-      appPlugins: '/my-app/app/plugins',
-      modules: '/my-app/modules',
-      shared: '/my-app/shared',
-      public: '/my-app/public',
-    }, '/my-app/.nuxt')
+  it('should include existing top-level test directories in node type paths', async () => {
+    const rootDir = await fsp.mkdtemp(join(tmpdir(), 'nuxt-layer-paths-'))
+    await Promise.all([
+      fsp.mkdir(join(rootDir, 'app')),
+      fsp.mkdir(join(rootDir, 'modules')),
+      fsp.mkdir(join(rootDir, 'public')),
+      fsp.mkdir(join(rootDir, 'server')),
+      fsp.mkdir(join(rootDir, 'shared')),
+      fsp.mkdir(join(rootDir, 'test')),
+      fsp.mkdir(join(rootDir, 'tests')),
+    ])
 
-    expect(paths.nuxt).toContain('../test/**/*')
-    expect(paths.nuxt).toContain('../tests/**/*')
+    try {
+      const paths = resolveLayerPaths({
+        root: rootDir,
+        server: join(rootDir, 'server'),
+        app: join(rootDir, 'app'),
+        appLayouts: join(rootDir, 'app/layouts'),
+        appMiddleware: join(rootDir, 'app/middleware'),
+        appPages: join(rootDir, 'app/pages'),
+        appPlugins: join(rootDir, 'app/plugins'),
+        modules: join(rootDir, 'modules'),
+        shared: join(rootDir, 'shared'),
+        public: join(rootDir, 'public'),
+      }, join(rootDir, '.nuxt'))
+
+      expect(paths.node).toContain('../test/**/*')
+      expect(paths.node).toContain('../tests/**/*')
+      expect(paths.nuxt).not.toContain('../test/**/*')
+      expect(paths.nuxt).not.toContain('../tests/**/*')
+    } finally {
+      await fsp.rm(rootDir, { recursive: true, force: true })
+    }
+  })
+
+  it('should skip missing top-level test directories', async () => {
+    const rootDir = await fsp.mkdtemp(join(tmpdir(), 'nuxt-layer-paths-'))
+    await Promise.all([
+      fsp.mkdir(join(rootDir, 'app')),
+      fsp.mkdir(join(rootDir, 'modules')),
+      fsp.mkdir(join(rootDir, 'public')),
+      fsp.mkdir(join(rootDir, 'server')),
+      fsp.mkdir(join(rootDir, 'shared')),
+    ])
+
+    try {
+      const paths = resolveLayerPaths({
+        root: rootDir,
+        server: join(rootDir, 'server'),
+        app: join(rootDir, 'app'),
+        appLayouts: join(rootDir, 'app/layouts'),
+        appMiddleware: join(rootDir, 'app/middleware'),
+        appPages: join(rootDir, 'app/pages'),
+        appPlugins: join(rootDir, 'app/plugins'),
+        modules: join(rootDir, 'modules'),
+        shared: join(rootDir, 'shared'),
+        public: join(rootDir, 'public'),
+      }, join(rootDir, '.nuxt'))
+
+      expect(paths.node).not.toContain('../test/**/*')
+      expect(paths.node).not.toContain('../tests/**/*')
+    } finally {
+      await fsp.rm(rootDir, { recursive: true, force: true })
+    }
   })
 })
 
@@ -146,46 +199,74 @@ describe('resolveLayerPaths with workspace config', async () => {
     })
     const [layer] = getLayerDirectories({ options: nuxtOptions } as Nuxt)
     const paths = resolveLayerPaths(layer!, nuxtOptions.buildDir)
-    expect(paths).toMatchInlineSnapshot(`
-      {
-        "globalDeclarations": [
-          "../*.d.ts",
-          "../layers/*/*.d.ts",
-        ],
-        "nitro": [
-          "../custom-modules/*/runtime/server/**/*",
-          "../layers/*/server/**/*",
-          "../layers/*/modules/*/runtime/server/**/*",
-        ],
-        "node": [
-          "../custom-modules/*.*",
-          "../nuxt.config.*",
-          "../.config/nuxt.*",
-          "../layers/*/nuxt.config.*",
-          "../layers/*/.config/nuxt.*",
-          "../layers/*/modules/**/*",
-        ],
-        "nuxt": [
-          "../app/**/*",
-          "../custom-modules/*/runtime/**/*",
-          "../test/**/*",
-          "../tests/**/*",
-          "../test/nuxt/**/*",
-          "../tests/nuxt/**/*",
-          "../layers/*/app/**/*",
-          "../layers/*/modules/*/runtime/**/*",
-        ],
-        "shared": [
-          "../custom-shared/**/*",
-          "../custom-modules/*/shared/**/*",
-          "../layers/*/shared/**/*",
-        ],
-        "sharedDeclarations": [
-          "../custom-shared/**/*.d.ts",
-          "../custom-modules/*/shared/**/*.d.ts",
-          "../layers/*/shared/**/*.d.ts",
-        ],
+    expect(paths.nitro).toEqual([
+      '../custom-modules/*/runtime/server/**/*',
+      '../layers/*/server/**/*',
+      '../layers/*/modules/*/runtime/server/**/*',
+    ])
+    expect(paths.node).toEqual(expect.arrayContaining([
+      '../custom-modules/*.*',
+      '../nuxt.config.*',
+      '../.config/nuxt.*',
+      '../layers/*/nuxt.config.*',
+      '../layers/*/.config/nuxt.*',
+      '../layers/*/modules/**/*',
+    ]))
+    expect(paths.nuxt).toEqual(expect.arrayContaining([
+      '../app/**/*',
+      '../custom-modules/*/runtime/**/*',
+      '../test/nuxt/**/*',
+      '../tests/nuxt/**/*',
+      '../layers/*/app/**/*',
+      '../layers/*/modules/*/runtime/**/*',
+    ]))
+    expect(paths.shared).toEqual([
+      '../custom-shared/**/*',
+      '../custom-modules/*/shared/**/*',
+      '../layers/*/shared/**/*',
+    ])
+    expect(paths.sharedDeclarations).toEqual([
+      '../custom-shared/**/*.d.ts',
+      '../custom-modules/*/shared/**/*.d.ts',
+      '../layers/*/shared/**/*.d.ts',
+    ])
+    expect(paths.globalDeclarations).toEqual([
+      '../*.d.ts',
+      '../layers/*/*.d.ts',
+    ])
+  })
+})
+
+describe('writeTypes', async () => {
+  const repoRoot = await findWorkspaceDir()
+
+  it('should include top-level test files in the node project without adding them to the app project', async () => {
+    const fixtureDir = join(repoRoot, 'test/fixtures/minimal-types')
+    const buildDir = join(fixtureDir, '.nuxt')
+    const testDir = join(fixtureDir, 'tests')
+    const testFile = join(testDir, 'utils.test.ts')
+    const normalizedTestFile = normalize(testFile)
+
+    await fsp.mkdir(testDir, { recursive: true })
+    await fsp.writeFile(testFile, 'const a: number = "asdf";')
+
+    try {
+      const nuxt = await loadNuxt({ cwd: fixtureDir, ready: false })
+      await writeTypes(nuxt)
+      await nuxt.close()
+
+      const parseProject = (configName: string) => {
+        const configPath = join(buildDir, configName)
+        const config = ts.readConfigFile(configPath, ts.sys.readFile)
+        return ts.parseJsonConfigFileContent(config.config, ts.sys, buildDir).fileNames
       }
-    `)
+
+      expect(parseProject('tsconfig.node.json').map(normalize)).toContain(normalizedTestFile)
+      expect(parseProject('tsconfig.app.json').map(normalize)).not.toContain(normalizedTestFile)
+    } finally {
+      await fsp.rm(testFile, { force: true })
+      await fsp.rm(buildDir, { recursive: true, force: true })
+      await fsp.rmdir(testDir).catch(() => undefined)
+    }
   })
 })

--- a/packages/kit/test/generate-types.spec.ts
+++ b/packages/kit/test/generate-types.spec.ts
@@ -109,13 +109,19 @@ describe('tsConfig generation', () => {
   })
 })
 
-describe('resolveLayerPaths', async () => {
+describe('resolveLayerPaths', () => {
   it('should include top-level test directories in nuxt type paths', () => {
     const paths = resolveLayerPaths({
       root: '/my-app',
+      server: '/my-app/server',
       app: '/my-app/app',
+      appLayouts: '/my-app/app/layouts',
+      appMiddleware: '/my-app/app/middleware',
+      appPages: '/my-app/app/pages',
+      appPlugins: '/my-app/app/plugins',
       modules: '/my-app/modules',
       shared: '/my-app/shared',
+      public: '/my-app/public',
     }, '/my-app/.nuxt')
 
     expect(paths.nuxt).toContain('../test/**/*')
@@ -163,8 +169,8 @@ describe('resolveLayerPaths with workspace config', async () => {
           "../app/**/*",
           "../custom-modules/*/runtime/**/*",
           "../test/**/*",
-          "../test/nuxt/**/*",
           "../tests/**/*",
+          "../test/nuxt/**/*",
           "../tests/nuxt/**/*",
           "../layers/*/app/**/*",
           "../layers/*/modules/*/runtime/**/*",

--- a/packages/kit/test/generate-types.spec.ts
+++ b/packages/kit/test/generate-types.spec.ts
@@ -123,8 +123,14 @@ describe('resolveLayerPaths', () => {
       fsp.mkdir(join(rootDir, 'public')),
       fsp.mkdir(join(rootDir, 'server')),
       fsp.mkdir(join(rootDir, 'shared')),
-      fsp.mkdir(join(rootDir, 'test')),
-      fsp.mkdir(join(rootDir, 'tests')),
+      fsp.mkdir(join(rootDir, 'test'), { recursive: true }),
+      fsp.mkdir(join(rootDir, 'tests'), { recursive: true }),
+      fsp.mkdir(join(rootDir, 'test/nuxt'), { recursive: true }),
+      fsp.mkdir(join(rootDir, 'tests/nuxt'), { recursive: true }),
+    ])
+    await Promise.all([
+      fsp.writeFile(join(rootDir, 'test', 'unit.test.ts'), ''),
+      fsp.writeFile(join(rootDir, 'tests', 'helpers.ts'), ''),
     ])
 
     try {
@@ -141,10 +147,12 @@ describe('resolveLayerPaths', () => {
         public: join(rootDir, 'public'),
       }, join(rootDir, '.nuxt'))
 
-      expect(paths.node).toContain('../test/**/*')
-      expect(paths.node).toContain('../tests/**/*')
-      expect(paths.nuxt).not.toContain('../test/**/*')
-      expect(paths.nuxt).not.toContain('../tests/**/*')
+      expect(paths.node).toContain('../test/unit.test.ts')
+      expect(paths.node).toContain('../tests/helpers.ts')
+      expect(paths.node).not.toContain('../test/nuxt/**/*')
+      expect(paths.node).not.toContain('../tests/nuxt/**/*')
+      expect(paths.nuxt).not.toContain('../test/unit.test.ts')
+      expect(paths.nuxt).not.toContain('../tests/helpers.ts')
     } finally {
       await fsp.rm(rootDir, { recursive: true, force: true })
     }
@@ -189,8 +197,9 @@ describe('resolveLayerPaths', () => {
       fsp.mkdir(join(rootDir, 'public')),
       fsp.mkdir(join(rootDir, 'server')),
       fsp.mkdir(join(rootDir, 'shared')),
-      fsp.mkdir(join(rootDir, 'test')),
+      fsp.mkdir(join(rootDir, 'test'), { recursive: true }),
     ])
+    await fsp.writeFile(join(rootDir, 'test', 'unit.test.ts'), '')
 
     try {
       const paths = resolveLayerPaths({
@@ -245,7 +254,7 @@ describe('resolveLayerPaths with workspace config', async () => {
       '../layers/*/modules/*/runtime/**/*',
     ]))
     expect(paths.node).toEqual(expect.arrayContaining([
-      '../test/**/*',
+      '../test/basic.test.ts',
       '../custom-modules/*.*',
       '../nuxt.config.*',
       '../.config/nuxt.*',
@@ -343,6 +352,38 @@ describe('writeTypes', async () => {
       await fsp.rm(testFile, { force: true })
       await fsp.rm(buildDir, { recursive: true, force: true })
       await fsp.rm(testDir, { recursive: true, force: true }).catch(() => undefined)
+    }
+  })
+
+  it('should keep default nuxt runtime test files in the app project', async () => {
+    const fixtureDir = join(repoRoot, 'test/fixtures/minimal-types')
+    const buildDir = join(fixtureDir, '.nuxt')
+    const testDir = join(fixtureDir, 'test/nuxt')
+    const testFile = join(testDir, 'runtime.test.ts')
+    const normalizedTestFile = normalize(testFile)
+    let nuxt: Awaited<ReturnType<typeof loadNuxt>> | undefined
+
+    await fsp.mkdir(testDir, { recursive: true })
+    await fsp.writeFile(testFile, 'const a: number = "asdf";')
+
+    try {
+      nuxt = await loadNuxt({ cwd: fixtureDir, ready: false })
+      await writeTypes(nuxt)
+
+      const parseProject = (configName: string) => {
+        const configPath = join(buildDir, configName)
+        const config = ts.readConfigFile(configPath, ts.sys.readFile)
+        return ts.parseJsonConfigFileContent(config.config, ts.sys, buildDir).fileNames
+      }
+
+      expect(parseProject('tsconfig.app.json').map(normalize)).toContain(normalizedTestFile)
+      expect(parseProject('tsconfig.node.json').map(normalize)).not.toContain(normalizedTestFile)
+    } finally {
+      await nuxt?.close()
+      await fsp.rm(testFile, { force: true })
+      await fsp.rm(buildDir, { recursive: true, force: true })
+      await fsp.rm(testDir, { recursive: true, force: true }).catch(() => undefined)
+      await fsp.rm(join(fixtureDir, 'test'), { recursive: true, force: true }).catch(() => undefined)
     }
   })
 })

--- a/packages/kit/test/generate-types.spec.ts
+++ b/packages/kit/test/generate-types.spec.ts
@@ -110,6 +110,20 @@ describe('tsConfig generation', () => {
 })
 
 describe('resolveLayerPaths', async () => {
+  it('should include top-level test directories in nuxt type paths', () => {
+    const paths = resolveLayerPaths({
+      root: '/my-app',
+      app: '/my-app/app',
+      modules: '/my-app/modules',
+      shared: '/my-app/shared',
+    }, '/my-app/.nuxt')
+
+    expect(paths.nuxt).toContain('../test/**/*')
+    expect(paths.nuxt).toContain('../tests/**/*')
+  })
+})
+
+describe('resolveLayerPaths with workspace config', async () => {
   const repoRoot = await findWorkspaceDir()
 
   it('should respect custom nuxt options', async () => {
@@ -148,7 +162,9 @@ describe('resolveLayerPaths', async () => {
         "nuxt": [
           "../app/**/*",
           "../custom-modules/*/runtime/**/*",
+          "../test/**/*",
           "../test/nuxt/**/*",
+          "../tests/**/*",
           "../tests/nuxt/**/*",
           "../layers/*/app/**/*",
           "../layers/*/modules/*/runtime/**/*",

--- a/packages/kit/test/generate-types.spec.ts
+++ b/packages/kit/test/generate-types.spec.ts
@@ -248,14 +248,14 @@ describe('writeTypes', async () => {
     const testDir = join(fixtureDir, 'tests')
     const testFile = join(testDir, 'utils.test.ts')
     const normalizedTestFile = normalize(testFile)
+    let nuxt: Awaited<ReturnType<typeof loadNuxt>> | undefined
 
     await fsp.mkdir(testDir, { recursive: true })
     await fsp.writeFile(testFile, 'const a: number = "asdf";')
 
     try {
-      const nuxt = await loadNuxt({ cwd: fixtureDir, ready: false })
+      nuxt = await loadNuxt({ cwd: fixtureDir, ready: false })
       await writeTypes(nuxt)
-      await nuxt.close()
 
       const parseProject = (configName: string) => {
         const configPath = join(buildDir, configName)
@@ -266,6 +266,7 @@ describe('writeTypes', async () => {
       expect(parseProject('tsconfig.app.json').map(normalize)).toContain(normalizedTestFile)
       expect(parseProject('tsconfig.node.json').map(normalize)).not.toContain(normalizedTestFile)
     } finally {
+      await nuxt?.close()
       await fsp.rm(testFile, { force: true })
       await fsp.rm(buildDir, { recursive: true, force: true })
       await fsp.rmdir(testDir).catch(() => undefined)

--- a/packages/schema/src/config/typescript.ts
+++ b/packages/schema/src/config/typescript.ts
@@ -35,6 +35,7 @@ export default defineResolvers({
     },
     includeWorkspace: false,
     typeCheck: false,
+    runtimeTestGlobs: ['test/nuxt/**/*', 'tests/nuxt/**/*'],
     tsConfig: {},
     shim: false,
   },

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1758,6 +1758,13 @@ export interface ConfigSchema {
     typeCheck: boolean | 'build'
 
     /**
+     * Glob patterns that should be type-checked in the Nuxt app project.
+     *
+     * This is useful for Nuxt runtime tests that need Nuxt auto-imports and aliases outside the default `test/nuxt/` and `tests/nuxt/` directories.
+     */
+    runtimeTestGlobs: Array<string>
+
+    /**
      * You can extend the generated `.nuxt/tsconfig.app.json` (and legacy `.nuxt/tsconfig.json`) using this option.
      */
     tsConfig: 0 extends 1 & RawVueCompilerOptions ? TSConfig : TSConfig & { vueCompilerOptions?: RawVueCompilerOptions }


### PR DESCRIPTION
Fixes #34756

This supersedes #35087 with a configurable approach.

## What changed

- keep the default Nuxt runtime test patterns as `test/nuxt/**/*` and `tests/nuxt/**/*`
- add a new `typescript.runtimeTestGlobs` option so projects can opt other test locations into the Nuxt app type context
- avoid simultaneously including top-level `test/**/*` / `tests/**/*` in the node type project when those directories are explicitly opted into the app project
- add tests covering both the default behavior and the configurable override

## Why

Some projects place Nuxt runtime tests outside `test/nuxt/`, for example directly under `test/`. Making the runtime test globs configurable preserves the safer default while allowing those setups to opt into Nuxt auto-imports, aliases and runtime types when needed.

## Verification

- `pnpm vitest run packages/kit/test/generate-types.spec.ts`
