### PR TITLE
fix(nuxt): propagate `useFetch`/`useAsyncData` factory types

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -186,7 +186,7 @@ export const createUseAsyncData = defineKeyedFunctionFactory({
       NuxtErrorDataT = unknown,
       DataT = ResT,
       PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
-      DefaultT = undefined,
+      DefaultT = [undefined] extends [FDefaultT] ? undefined : FDefaultT,
     > (
       handler: AsyncDataHandler<ResT>,
       opts: AsyncDataOptionsWithTransform<ResT, DataT, PickKeys, DefaultT>,
@@ -196,7 +196,7 @@ export const createUseAsyncData = defineKeyedFunctionFactory({
       NuxtErrorDataT = unknown,
       DataT = ResT,
       PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
-      DefaultT = DataT,
+      DefaultT = [undefined] extends [FDefaultT] ? DataT : FDefaultT,
     > (
       handler: AsyncDataHandler<ResT>,
       opts: AsyncDataOptionsWithTransform<ResT, DataT, PickKeys, DefaultT>,
@@ -204,9 +204,9 @@ export const createUseAsyncData = defineKeyedFunctionFactory({
     function useAsyncData<
       ResT,
       NuxtErrorDataT = unknown,
-      DataT = ResT,
-      PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
-      DefaultT = undefined,
+      DataT = [unknown] extends [FDataT] ? ResT : FDataT,
+      PickKeys extends KeysOf<DataT> = [Array<never>] extends [FPickKeys] ? KeysOf<DataT> : FPickKeys,
+      DefaultT = [undefined] extends [FDefaultT] ? undefined : FDefaultT,
     > (
       handler: AsyncDataHandler<ResT>,
       opts?: AsyncDataOptions<ResT, DataT, PickKeys, DefaultT>,
@@ -214,9 +214,9 @@ export const createUseAsyncData = defineKeyedFunctionFactory({
     function useAsyncData<
       ResT,
       NuxtErrorDataT = unknown,
-      DataT = ResT,
-      PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
-      DefaultT = DataT,
+      DataT = [unknown] extends [FDataT] ? ResT : FDataT,
+      PickKeys extends KeysOf<DataT> = [Array<never>] extends [FPickKeys] ? KeysOf<DataT> : FPickKeys,
+      DefaultT = [undefined] extends [FDefaultT] ? DataT : FDefaultT,
     > (
       handler: AsyncDataHandler<ResT>,
       opts?: AsyncDataOptions<ResT, DataT, PickKeys, DefaultT>,
@@ -233,7 +233,7 @@ export const createUseAsyncData = defineKeyedFunctionFactory({
       NuxtErrorDataT = unknown,
       DataT = ResT,
       PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
-      DefaultT = undefined,
+      DefaultT = [undefined] extends [FDefaultT] ? undefined : FDefaultT,
     > (
       key: MaybeRefOrGetter<string>,
       handler: AsyncDataHandler<ResT>,
@@ -244,7 +244,7 @@ export const createUseAsyncData = defineKeyedFunctionFactory({
       NuxtErrorDataT = unknown,
       DataT = ResT,
       PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
-      DefaultT = DataT,
+      DefaultT = [undefined] extends [FDefaultT] ? DataT : FDefaultT,
     > (
       key: MaybeRefOrGetter<string>,
       handler: AsyncDataHandler<ResT>,
@@ -253,9 +253,9 @@ export const createUseAsyncData = defineKeyedFunctionFactory({
     function useAsyncData<
       ResT,
       NuxtErrorDataT = unknown,
-      DataT = ResT,
-      PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
-      DefaultT = undefined,
+      DataT = [unknown] extends [FDataT] ? ResT : FDataT,
+      PickKeys extends KeysOf<DataT> = [Array<never>] extends [FPickKeys] ? KeysOf<DataT> : FPickKeys,
+      DefaultT = [undefined] extends [FDefaultT] ? undefined : FDefaultT,
     > (
       key: MaybeRefOrGetter<string>,
       handler: AsyncDataHandler<ResT>,
@@ -264,9 +264,9 @@ export const createUseAsyncData = defineKeyedFunctionFactory({
     function useAsyncData<
       ResT,
       NuxtErrorDataT = unknown,
-      DataT = ResT,
-      PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
-      DefaultT = DataT,
+      DataT = [unknown] extends [FDataT] ? ResT : FDataT,
+      PickKeys extends KeysOf<DataT> = [Array<never>] extends [FPickKeys] ? KeysOf<DataT> : FPickKeys,
+      DefaultT = [undefined] extends [FDefaultT] ? DataT : FDefaultT,
     > (
       key: MaybeRefOrGetter<string>,
       handler: AsyncDataHandler<ResT>,

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -205,22 +205,22 @@ export const createUseAsyncData = defineKeyedFunctionFactory({
       ResT,
       NuxtErrorDataT = unknown,
       DataT = [unknown] extends [FDataT] ? ResT : FDataT,
-      PickKeys extends KeysOf<DataT> = [Array<never>] extends [FPickKeys] ? KeysOf<DataT> : FPickKeys,
+      PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
       DefaultT = [undefined] extends [FDefaultT] ? undefined : FDefaultT,
     > (
       handler: AsyncDataHandler<ResT>,
       opts?: AsyncDataOptions<ResT, DataT, PickKeys, DefaultT>,
-    ): AsyncData<PickFrom<DataT, PickKeys> | DefaultT, (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>) | undefined>
+    ): AsyncData<PickFrom<DataT, [Array<never>] extends [FPickKeys] ? PickKeys : FPickKeys & KeysOf<DataT>> | DefaultT, (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>) | undefined>
     function useAsyncData<
       ResT,
       NuxtErrorDataT = unknown,
       DataT = [unknown] extends [FDataT] ? ResT : FDataT,
-      PickKeys extends KeysOf<DataT> = [Array<never>] extends [FPickKeys] ? KeysOf<DataT> : FPickKeys,
+      PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
       DefaultT = [undefined] extends [FDefaultT] ? DataT : FDefaultT,
     > (
       handler: AsyncDataHandler<ResT>,
       opts?: AsyncDataOptions<ResT, DataT, PickKeys, DefaultT>,
-    ): AsyncData<PickFrom<DataT, PickKeys> | DefaultT, (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>) | undefined>
+    ): AsyncData<PickFrom<DataT, [Array<never>] extends [FPickKeys] ? PickKeys : FPickKeys & KeysOf<DataT>> | DefaultT, (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>) | undefined>
     /**
      * Provides access to data that resolves asynchronously in an SSR-friendly composable.
      * See {@link https://nuxt.com/docs/4.x/api/composables/use-async-data}
@@ -254,24 +254,24 @@ export const createUseAsyncData = defineKeyedFunctionFactory({
       ResT,
       NuxtErrorDataT = unknown,
       DataT = [unknown] extends [FDataT] ? ResT : FDataT,
-      PickKeys extends KeysOf<DataT> = [Array<never>] extends [FPickKeys] ? KeysOf<DataT> : FPickKeys,
+      PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
       DefaultT = [undefined] extends [FDefaultT] ? undefined : FDefaultT,
     > (
       key: MaybeRefOrGetter<string>,
       handler: AsyncDataHandler<ResT>,
       opts?: AsyncDataOptions<ResT, DataT, PickKeys, DefaultT>,
-    ): AsyncData<PickFrom<DataT, PickKeys> | DefaultT, (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>) | undefined>
+    ): AsyncData<PickFrom<DataT, [Array<never>] extends [FPickKeys] ? PickKeys : FPickKeys & KeysOf<DataT>> | DefaultT, (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>) | undefined>
     function useAsyncData<
       ResT,
       NuxtErrorDataT = unknown,
       DataT = [unknown] extends [FDataT] ? ResT : FDataT,
-      PickKeys extends KeysOf<DataT> = [Array<never>] extends [FPickKeys] ? KeysOf<DataT> : FPickKeys,
+      PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
       DefaultT = [undefined] extends [FDefaultT] ? DataT : FDefaultT,
     > (
       key: MaybeRefOrGetter<string>,
       handler: AsyncDataHandler<ResT>,
       opts?: AsyncDataOptions<ResT, DataT, PickKeys, DefaultT>,
-    ): AsyncData<PickFrom<DataT, PickKeys> | DefaultT, (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>) | undefined>
+    ): AsyncData<PickFrom<DataT, [Array<never>] extends [FPickKeys] ? PickKeys : FPickKeys & KeysOf<DataT>> | DefaultT, (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>) | undefined>
     function useAsyncData<
       ResT,
       NuxtErrorDataT = unknown,

--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -153,12 +153,12 @@ export const createUseFetch = defineKeyedFunctionFactory({
       Method extends AvailableRouterMethod<ReqT> = ResT extends void ? 'get' extends AvailableRouterMethod<ReqT> ? 'get' : AvailableRouterMethod<ReqT> : AvailableRouterMethod<ReqT>,
       _ResT = ResT extends void ? FetchResult<ReqT, Method> : ResT,
       DataT = [unknown] extends [FDataT] ? _ResT : FDataT,
-      PickKeys extends KeysOf<DataT> = [Array<never>] extends [FPickKeys] ? KeysOf<DataT> : FPickKeys,
+      PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
       DefaultT = [undefined] extends [FDefaultT] ? undefined : FDefaultT,
     > (
       request: Ref<ReqT> | ReqT | (() => ReqT),
       opts?: UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, ReqT, Method>,
-    ): AsyncData<PickFrom<DataT, PickKeys> | DefaultT, ErrorT | undefined>
+    ): AsyncData<PickFrom<DataT, [Array<never>] extends [FPickKeys] ? PickKeys : FPickKeys & KeysOf<DataT>> | DefaultT, ErrorT | undefined>
     function useFetch<
       ResT = void,
       ErrorT = FetchError,
@@ -166,12 +166,12 @@ export const createUseFetch = defineKeyedFunctionFactory({
       Method extends AvailableRouterMethod<ReqT> = ResT extends void ? 'get' extends AvailableRouterMethod<ReqT> ? 'get' : AvailableRouterMethod<ReqT> : AvailableRouterMethod<ReqT>,
       _ResT = ResT extends void ? FetchResult<ReqT, Method> : ResT,
       DataT = [unknown] extends [FDataT] ? _ResT : FDataT,
-      PickKeys extends KeysOf<DataT> = [Array<never>] extends [FPickKeys] ? KeysOf<DataT> : FPickKeys,
+      PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
       DefaultT = [undefined] extends [FDefaultT] ? DataT : FDefaultT,
     > (
       request: Ref<ReqT> | ReqT | (() => ReqT),
       opts?: UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, ReqT, Method>,
-    ): AsyncData<PickFrom<DataT, PickKeys> | DefaultT, ErrorT | undefined>
+    ): AsyncData<PickFrom<DataT, [Array<never>] extends [FPickKeys] ? PickKeys : FPickKeys & KeysOf<DataT>> | DefaultT, ErrorT | undefined>
     function useFetch<
       ResT = void,
       ErrorT = FetchError,

--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -5,7 +5,7 @@ import { computed, reactive, toValue, watch } from 'vue'
 import { hash } from 'ohash'
 
 import { isPlainObject } from '@vue/shared'
-import type { AsyncData, AsyncDataOptions, KeysOf, MultiWatchSources, PickFrom } from './asyncData'
+import type { AsyncData, AsyncDataOptions, KeysOf, MultiWatchSources, PickFrom, _Transform } from './asyncData'
 import { useAsyncData } from './asyncData'
 import { defineKeyedFunctionFactory } from '../../compiler/runtime'
 
@@ -40,6 +40,17 @@ export interface UseFetchOptions<
   key?: MaybeRefOrGetter<string>
   $fetch?: $Fetch
   watch?: MultiWatchSources | false
+}
+
+export interface UseFetchOptionsWithTransform<
+  ResT,
+  DataT = ResT,
+  PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
+  DefaultT = undefined,
+  R extends NitroFetchRequest = string & {},
+  M extends AvailableRouterMethod<R> = AvailableRouterMethod<R>,
+> extends Omit<UseFetchOptions<ResT, DataT, PickKeys, DefaultT, R, M>, 'transform'> {
+  transform: _Transform<ResT, DataT>
 }
 
 function generateOptionSegments<_ResT, DataT, DefaultT> (opts: UseFetchOptions<_ResT, DataT, any, DefaultT, any, any>) {
@@ -117,7 +128,33 @@ export const createUseFetch = defineKeyedFunctionFactory({
       _ResT = ResT extends void ? FetchResult<ReqT, Method> : ResT,
       DataT = _ResT,
       PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
-      DefaultT = undefined,
+      DefaultT = [undefined] extends [FDefaultT] ? undefined : FDefaultT,
+    > (
+      request: Ref<ReqT> | ReqT | (() => ReqT),
+      opts: UseFetchOptionsWithTransform<_ResT, DataT, PickKeys, DefaultT, ReqT, Method>,
+    ): AsyncData<PickFrom<DataT, PickKeys> | DefaultT, ErrorT | undefined>
+    function useFetch<
+      ResT = void,
+      ErrorT = FetchError,
+      ReqT extends NitroFetchRequest = NitroFetchRequest,
+      Method extends AvailableRouterMethod<ReqT> = ResT extends void ? 'get' extends AvailableRouterMethod<ReqT> ? 'get' : AvailableRouterMethod<ReqT> : AvailableRouterMethod<ReqT>,
+      _ResT = ResT extends void ? FetchResult<ReqT, Method> : ResT,
+      DataT = _ResT,
+      PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
+      DefaultT = [undefined] extends [FDefaultT] ? DataT : FDefaultT,
+    > (
+      request: Ref<ReqT> | ReqT | (() => ReqT),
+      opts: UseFetchOptionsWithTransform<_ResT, DataT, PickKeys, DefaultT, ReqT, Method>,
+    ): AsyncData<PickFrom<DataT, PickKeys> | DefaultT, ErrorT | undefined>
+    function useFetch<
+      ResT = void,
+      ErrorT = FetchError,
+      ReqT extends NitroFetchRequest = NitroFetchRequest,
+      Method extends AvailableRouterMethod<ReqT> = ResT extends void ? 'get' extends AvailableRouterMethod<ReqT> ? 'get' : AvailableRouterMethod<ReqT> : AvailableRouterMethod<ReqT>,
+      _ResT = ResT extends void ? FetchResult<ReqT, Method> : ResT,
+      DataT = [unknown] extends [FDataT] ? _ResT : FDataT,
+      PickKeys extends KeysOf<DataT> = [Array<never>] extends [FPickKeys] ? KeysOf<DataT> : FPickKeys,
+      DefaultT = [undefined] extends [FDefaultT] ? undefined : FDefaultT,
     > (
       request: Ref<ReqT> | ReqT | (() => ReqT),
       opts?: UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, ReqT, Method>,
@@ -128,9 +165,9 @@ export const createUseFetch = defineKeyedFunctionFactory({
       ReqT extends NitroFetchRequest = NitroFetchRequest,
       Method extends AvailableRouterMethod<ReqT> = ResT extends void ? 'get' extends AvailableRouterMethod<ReqT> ? 'get' : AvailableRouterMethod<ReqT> : AvailableRouterMethod<ReqT>,
       _ResT = ResT extends void ? FetchResult<ReqT, Method> : ResT,
-      DataT = _ResT,
-      PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
-      DefaultT = DataT,
+      DataT = [unknown] extends [FDataT] ? _ResT : FDataT,
+      PickKeys extends KeysOf<DataT> = [Array<never>] extends [FPickKeys] ? KeysOf<DataT> : FPickKeys,
+      DefaultT = [undefined] extends [FDefaultT] ? DataT : FDefaultT,
     > (
       request: Ref<ReqT> | ReqT | (() => ReqT),
       opts?: UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, ReqT, Method>,

--- a/test/fixtures/basic-types/app/app-types.ts
+++ b/test/fixtures/basic-types/app/app-types.ts
@@ -661,6 +661,103 @@ describe('composables', () => {
 
     expectTypeOf(asyncData.data).toEqualTypeOf<Ref<string | DefaultAsyncDataValue>>()
   })
+
+  it('propagates factory transform type through createUseAsyncData (#35128)', () => {
+    interface Foo { a: number, b: string }
+
+    // defaults mode
+    const useFooData = createUseAsyncData({
+      transform: (res: Foo) => ({ count: res.a }),
+    })
+    const r1 = useFooData('key', () => Promise.resolve({ a: 1, b: 'x' } as Foo))
+    expectTypeOf(r1.data).toEqualTypeOf<Ref<{ count: number } | DefaultAsyncDataValue>>()
+
+    const r1NoKey = useFooData(() => Promise.resolve({ a: 1, b: 'x' } as Foo))
+    expectTypeOf(r1NoKey.data).toEqualTypeOf<Ref<{ count: number } | DefaultAsyncDataValue>>()
+
+    // override mode (function form)
+    const useFooDataOverride = createUseAsyncData(() => ({
+      transform: (res: Foo) => ({ count: res.a }),
+    }))
+    const r2 = useFooDataOverride('key', () => Promise.resolve({ a: 1, b: 'x' } as Foo))
+    expectTypeOf(r2.data).toEqualTypeOf<Ref<{ count: number } | DefaultAsyncDataValue>>()
+
+    // no factory transform: falls back to handler return type
+    const useBareData = createUseAsyncData({})
+    const r3 = useBareData('key', () => Promise.resolve({ a: 1, b: 'x' } as Foo))
+    expectTypeOf(r3.data).toEqualTypeOf<Ref<Foo | DefaultAsyncDataValue>>()
+
+    // caller transform still wins over factory transform default
+    const r4 = useFooData('key', () => Promise.resolve({ a: 1, b: 'x' } as Foo), {
+      transform: res => res.b,
+    })
+    expectTypeOf(r4.data).toEqualTypeOf<Ref<string | DefaultAsyncDataValue>>()
+  })
+
+  it('propagates factory transform type through createUseFetch (#35128)', () => {
+    interface Foo { a: number, b: string }
+
+    // defaults mode
+    const useFooFetch = createUseFetch({
+      transform: (res: Foo) => ({ count: res.a }),
+    })
+    const r1 = useFooFetch<Foo>('/api/foo')
+    expectTypeOf(r1.data).toEqualTypeOf<Ref<{ count: number } | DefaultAsyncDataValue>>()
+
+    // override mode (function form)
+    const useFooFetchOverride = createUseFetch(() => ({
+      transform: (res: Foo) => ({ count: res.a }),
+    }))
+    const r2 = useFooFetchOverride<Foo>('/api/foo')
+    expectTypeOf(r2.data).toEqualTypeOf<Ref<{ count: number } | DefaultAsyncDataValue>>()
+
+    // no factory transform: falls back to fetch result type
+    const useBareFetch = createUseFetch({})
+    const r3 = useBareFetch<Foo>('/api/foo')
+    expectTypeOf(r3.data).toEqualTypeOf<Ref<Foo | DefaultAsyncDataValue>>()
+
+    // caller transform overrides factory transform default
+    // (only works without an explicit `ResT` generic, due to microsoft/TypeScript#14400)
+    const r4 = useFooFetch('/api/foo', { transform: (res: Foo) => res.b })
+    expectTypeOf(r4.data).toEqualTypeOf<Ref<string | DefaultAsyncDataValue>>()
+  })
+
+  it('propagates factory `default` / `pick` types through createUseAsyncData / createUseFetch (#35128)', () => {
+    interface Foo { a: number, b: string }
+
+    // createUseAsyncData: factory `default` widens the returned data type
+    const useWithDefault = createUseAsyncData({ default: () => 'fallback' as const })
+    const d1 = useWithDefault('k', () => Promise.resolve({ a: 1, b: 'x' } as Foo))
+    expectTypeOf(d1.data.value).toEqualTypeOf<Foo | 'fallback'>()
+
+    // factory transform + default together: data is the transform output (or factory default)
+    const useWithBoth = createUseAsyncData({
+      transform: (res: Foo) => ({ count: res.a }),
+      default: () => ({ count: 0 }),
+    })
+    const d2 = useWithBoth('k', () => Promise.resolve({ a: 1, b: 'x' } as Foo))
+    expectTypeOf(d2.data.value).toEqualTypeOf<{ count: number }>()
+
+    // factory pick narrows the returned data type.
+    // The factory `pick` option doesn't infer FPickKeys (array literals widen to `string[]`),
+    // so the user passes it explicitly as a generic.
+    const useWithPick = createUseAsyncData<Foo, Foo, ['a']>({ pick: ['a'] })
+    const d3 = useWithPick('k', () => Promise.resolve({ a: 1, b: 'x' } as Foo))
+    expectTypeOf(d3.data.value).toEqualTypeOf<Pick<Foo, 'a'> | undefined>()
+
+    // createUseFetch: factory `default` widens the returned data type
+    const useFetchWithDefault = createUseFetch({ default: () => 'fallback' as const })
+    const f1 = useFetchWithDefault<Foo>('/api/foo')
+    expectTypeOf(f1.data.value).toEqualTypeOf<Foo | 'fallback'>()
+
+    // createUseFetch: factory transform + default
+    const useFetchBoth = createUseFetch({
+      transform: (res: Foo) => ({ count: res.a }),
+      default: () => ({ count: 0 }),
+    })
+    const f2 = useFetchBoth<Foo>('/api/foo')
+    expectTypeOf(f2.data.value).toEqualTypeOf<{ count: number }>()
+  })
 })
 
 describe('app config', () => {


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/35128

### 📚 Description

this addresses a missing piece in #32300 - we didn't propagate the `transform`, `default` and `pick` types through the factory