### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/packages/nitro-server/src/runtime/utils/dev.test.ts
+++ b/packages/nitro-server/src/runtime/utils/dev.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { generateErrorOverlayHTML } from './dev'
+
+describe('generateErrorOverlayHTML', () => {
+  it('emits a storage bridge without Object.hasOwn', () => {
+    const overlay = generateErrorOverlayHTML('<html><head></head><body></body></html>')
+    const base64HTML = overlay.match(/iframe\.src = 'data:text\/html;base64,([^']+)'/)?.[1]
+
+    expect(base64HTML).toBeTruthy()
+
+    const iframeHTML = Buffer.from(base64HTML!, 'base64').toString('utf8')
+    expect(iframeHTML).toContain('Object.prototype.hasOwnProperty.call(memoryStore, key)')
+    expect(iframeHTML).not.toContain('Object.hasOwn(')
+  })
+})

--- a/packages/nitro-server/src/runtime/utils/dev.ts
+++ b/packages/nitro-server/src/runtime/utils/dev.ts
@@ -11,7 +11,7 @@ const iframeStorageBridge = (nonce: string) => /* js */ `
 
   const mockStorage = {
     getItem(key) {
-      return Object.hasOwn(memoryStore, key)
+      return Object.prototype.hasOwnProperty.call(memoryStore, key)
         ? memoryStore[key]
         : null;
     },


### PR DESCRIPTION
Resolves #33916

### Description

The dev error overlay storage bridge currently emits `Object.hasOwn(memoryStore, key)`. That API is missing in older Safari/iOS versions, so the bridge can throw before it reads from the iframe's local storage mirror.

`memoryStore` uses a null prototype, so this switches the check to `Object.prototype.hasOwnProperty.call(memoryStore, key)`. That keeps the null-prototype safety and avoids depending on `Object.hasOwn` in browser runtime code.

### Tests

- `pnpm install --frozen-lockfile`
- `pnpm dev:prepare`
- `pnpm vitest run --project unit packages/nitro-server/src/runtime/utils/dev.test.ts`
- `pnpm eslint packages/nitro-server/src/runtime/utils/dev.ts packages/nitro-server/src/runtime/utils/dev.test.ts`

I used AI assistance while preparing this change, then reviewed the diff and test results myself.