### PR TITLE
feat(schema,nuxt): add configurable `unhead.templateParams` option

### DIFF
--- a/packages/nuxt/src/head/module.ts
+++ b/packages/nuxt/src/head/module.ts
@@ -116,12 +116,13 @@ export default defineNuxtModule<NuxtOptions['unhead']>({
         const lines: string[] = []
         // v4 parity with v2 defaults: restore the plugin set that unhead v3 no
         // longer auto-loads (DeprecationsPlugin, PromisesPlugin, TemplateParamsPlugin,
-        // AliasSortingPlugin). v5 keeps TemplateParamsPlugin because %s / %siteName
-        // / %separator title interpolation is a core Nuxt SEO idiom; other plugins
-        // must be registered explicitly.
+        // AliasSortingPlugin). v5 omits TemplateParamsPlugin by default (aligning
+        // with unhead v3); enable `%s` / `%siteName` / `%separator` title
+        // interpolation via `unhead.templateParams: true`.
+        const templateParamsEnabled = options.templateParams !== false
         if (!isV5) {
           lines.push(`import { legacyPlugins } from ${JSON.stringify(unheadLegacy)};`)
-        } else {
+        } else if (templateParamsEnabled) {
           lines.push(`import { TemplateParamsPlugin } from ${JSON.stringify(unheadPlugins)};`)
         }
         lines.push(`export default {`)
@@ -129,7 +130,8 @@ export default defineNuxtModule<NuxtOptions['unhead']>({
         if (disableCapoSorting) {
           lines.push(`  disableCapoSorting: true,`)
         }
-        lines.push(`  plugins: ${isV5 ? '[TemplateParamsPlugin]' : 'legacyPlugins'},`)
+        const v5Plugins = templateParamsEnabled ? '[TemplateParamsPlugin]' : '[]'
+        lines.push(`  plugins: ${isV5 ? v5Plugins : 'legacyPlugins'},`)
         lines.push(`}`)
         return lines.join('\n')
       },

--- a/packages/schema/src/config/app.ts
+++ b/packages/schema/src/config/app.ts
@@ -186,6 +186,14 @@ export default defineResolvers({
       },
     },
     vite: {},
+    templateParams: {
+      // v5 aligns with unhead v3, which no longer auto-loads `TemplateParamsPlugin`.
+      // v4/legacy keeps it for back-compat. An explicit boolean always wins.
+      $resolve: async (val, get) => {
+        if (typeof val === 'boolean') { return val }
+        return (await get('future.compatibilityVersion') as number) < 5
+      },
+    },
     renderSSRHeadOptions: {
       $resolve: (val: unknown) => ({
         omitLineBreaks: true,

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -421,6 +421,27 @@ export interface ConfigSchema {
     renderSSRHeadOptions: RenderSSRHeadOptions
 
     /**
+     * Enable the `TemplateParamsPlugin` to resolve template params like `%s`, `%separator`, and `%site.name` in head tags.
+     *
+     * Defaults to `false` on `compatibilityVersion: 5` (aligning with unhead v3, which no
+     * longer auto-loads the plugin) and `true` on v4/legacy.
+     *
+     * @default false
+     *
+     * @example
+     * ```ts
+     * export default defineNuxtConfig({
+     *  unhead: {
+     *   templateParams: true,
+     *  },
+     * })
+     * ```
+     *
+     * @see https://unhead.unjs.io/docs/head/guides/plugins/template-params
+     */
+    templateParams: boolean
+
+    /**
      * Options for the `@unhead/vue/vite` build plugin. Provides tree-shaking, `useSeoMeta` transform,
      * minification, and validation.
      *


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### 📚 Description

Adds a configurable `unhead.templateParams` option controlling unhead's `TemplateParamsPlugin`.

The plugin resolves `%s` / `%siteName` / `%separator` title interpolation in head tags. unhead v3 no longer auto-loads it. This makes the behaviour configurable and compat-version aware:

- **`compatibilityVersion: 5`** — defaults to `false`, aligning with unhead v3 (no auto-load).
- **v4 / legacy** — defaults to `true`, kept for back-compat via `legacyPlugins`.
- An explicit boolean always wins:

```ts
export default defineNuxtConfig({
  unhead: {
    templateParams: true, // force-enable on v5
  },
})
```

When disabled on v5, the `TemplateParamsPlugin` import and registration are skipped from the generated `unhead.config.mjs`.

Extracted from the SSR streaming branch so it can be reviewed independently.