### PR TITLE
refactor(nuxt): resolve builder earlier + skip watcher for `nuxt prepare`

### DIFF
--- a/packages/nuxt/src/core/builder.ts
+++ b/packages/nuxt/src/core/builder.ts
@@ -20,30 +20,32 @@ export async function build (nuxt: Nuxt): Promise<void> {
   await generateApp()
   nuxt._perf?.endPhase('app:generate')
 
-  const builder = await resolveBuilder(nuxt)
+  const builder = nuxt.options._prepare ? undefined : await resolveBuilder(nuxt)
 
   if (nuxt.options.dev) {
-    watch(nuxt)
-    nuxt.hook('builder:watch', async (event, relativePath) => {
-      // Unset mainComponent and errorComponent if app or error component is changed
-      if (event === 'add' || event === 'unlink') {
-        const path = resolve(nuxt.options.srcDir, relativePath)
-        for (const dirs of getLayerDirectories(nuxt)) {
-          const relativePath = relative(dirs.app, path)
-          if (/^app\./i.test(relativePath)) {
-            app.mainComponent = undefined
-            break
-          }
-          if (/^error\./i.test(relativePath)) {
-            app.errorComponent = undefined
-            break
+    if (!nuxt.options._prepare) {
+      watch(nuxt)
+      nuxt.hook('builder:watch', async (event, relativePath) => {
+        // Unset mainComponent and errorComponent if app or error component is changed
+        if (event === 'add' || event === 'unlink') {
+          const path = resolve(nuxt.options.srcDir, relativePath)
+          for (const dirs of getLayerDirectories(nuxt)) {
+            const relativePath = relative(dirs.app, path)
+            if (/^app\./i.test(relativePath)) {
+              app.mainComponent = undefined
+              break
+            }
+            if (/^error\./i.test(relativePath)) {
+              app.errorComponent = undefined
+              break
+            }
           }
         }
-      }
 
-      // Recompile app templates
-      await generateApp()
-    })
+        // Recompile app templates
+        await generateApp()
+      })
+    }
     nuxt.hook('builder:generateApp', (options) => {
       // Bypass debounce if we are selectively invalidating templates
       if (options) { return _generateApp(nuxt, app, options) }
@@ -76,7 +78,7 @@ export async function build (nuxt: Nuxt): Promise<void> {
   }
 
   nuxt._perf?.startPhase('build:bundle')
-  await builder.bundle(nuxt)
+  await builder?.bundle(nuxt)
   nuxt._perf?.endPhase('build:bundle')
 
   // release hooks that will never fire again.

--- a/packages/nuxt/src/core/builder.ts
+++ b/packages/nuxt/src/core/builder.ts
@@ -20,6 +20,8 @@ export async function build (nuxt: Nuxt): Promise<void> {
   await generateApp()
   nuxt._perf?.endPhase('app:generate')
 
+  const builder = await resolveBuilder(nuxt)
+
   if (nuxt.options.dev) {
     watch(nuxt)
     nuxt.hook('builder:watch', async (event, relativePath) => {
@@ -74,7 +76,7 @@ export async function build (nuxt: Nuxt): Promise<void> {
   }
 
   nuxt._perf?.startPhase('build:bundle')
-  await bundle(nuxt)
+  await builder.bundle(nuxt)
   nuxt._perf?.endPhase('build:bundle')
 
   // release hooks that will never fire again.
@@ -244,21 +246,23 @@ async function createParcelWatcher () {
   }
 }
 
-async function bundle (nuxt: Nuxt) {
-  try {
-    const { bundle } = typeof nuxt.options.builder === 'string'
-      ? await loadBuilder(nuxt, nuxt.options.builder)
-      : nuxt.options.builder
+async function resolveBuilder (nuxt: Nuxt): Promise<NuxtBuilder> {
+  const source = typeof nuxt.options.builder === 'string'
+    ? await loadBuilder(nuxt, nuxt.options.builder)
+    : nuxt.options.builder
 
-    await bundle(nuxt)
-  } catch (error: any) {
-    await nuxt.callHook('build:error', error)
-
-    if (error.toString().includes('Cannot find module \'@nuxt/webpack-builder\'')) {
-      throw new Error('Could not load `@nuxt/webpack-builder`. You may need to add it to your project dependencies, following the steps in `https://github.com/nuxt/framework/pull/2812`.')
-    }
-
-    throw error
+  // Wrap `bundle` so the `build:error` hook fires for any builder, including
+  // user-supplied ones, without each caller having to remember to do it.
+  return {
+    ...source,
+    async bundle (nuxt) {
+      try {
+        await source.bundle(nuxt)
+      } catch (error: any) {
+        await nuxt.callHook('build:error', error)
+        throw error
+      }
+    },
   }
 }
 
@@ -269,7 +273,10 @@ async function loadBuilder (nuxt: Nuxt, builder: string): Promise<NuxtBuilder> {
       return await import(builder)
     }
     return await importModule(builder, { url: [new URL(import.meta.url), directoryToURL(nuxt.options.rootDir)] })
-  } catch (err) {
+  } catch (err: any) {
+    if (builder === '@nuxt/webpack-builder' && err?.toString?.().includes('Cannot find module \'@nuxt/webpack-builder\'')) {
+      throw new Error('Could not load `@nuxt/webpack-builder`. You may need to add it to your project dependencies, following the steps in `https://github.com/nuxt/framework/pull/2812`.', { cause: err })
+    }
     throw new Error(`Loading \`${builder}\` builder failed. You can read more about the nuxt \`builder\` option at: \`https://nuxt.com/docs/4.x/api/nuxt-config#builder\``, { cause: err })
   }
 }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this  moves the builder resolution before we start prep for it (most importantly, before we start watchers 👀)