### PR TITLE
refactor(nuxt): delete cleared keys in `clearNuxtData` & `clearNuxtState`

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -668,13 +668,8 @@ export function clearNuxtData (keys?: string | string[] | ((key: string) => bool
 }
 
 function clearNuxtDataByKey (nuxtApp: NuxtApp, key: string): void {
-  if (key in nuxtApp.payload.data) {
-    nuxtApp.payload.data[key] = undefined
-  }
-
-  if (key in nuxtApp.payload._errors) {
-    nuxtApp.payload._errors[key] = undefined
-  }
+  delete nuxtApp.payload.data[key]
+  delete nuxtApp.payload._errors[key]
 
   if (nuxtApp._asyncData[key]) {
     nuxtApp._asyncData[key]!.data.value = unref(nuxtApp._asyncData[key]!._default())
@@ -686,9 +681,7 @@ function clearNuxtDataByKey (nuxtApp: NuxtApp, key: string): void {
     nuxtApp._asyncData[key]!._initialCachedData = undefined
   }
 
-  if (key in nuxtApp._asyncDataPromises) {
-    nuxtApp._asyncDataPromises[key] = undefined
-  }
+  delete nuxtApp._asyncDataPromises[key]
 }
 
 function pick (obj: Record<string, any>, keys: string[]) {

--- a/packages/nuxt/src/app/composables/state.ts
+++ b/packages/nuxt/src/app/composables/state.ts
@@ -83,7 +83,7 @@ export function clearNuxtState (
       if (reset && nuxtApp._state[key]) {
         nuxtApp.payload.state[key] = nuxtApp._state[key]._default()
       } else {
-        nuxtApp.payload.state[key] = undefined
+        delete nuxtApp.payload.state[key]
       }
     }
   }

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -396,6 +396,17 @@ describe('clearNuxtState', () => {
     delete nuxtApp.payload.state._layout
     delete nuxtApp.payload.state._layoutProps
   })
+
+  it('removes the key from payload.state rather than setting it to undefined', () => {
+    const nuxtApp = useNuxtApp()
+    const key = 'clearNuxtState-test'
+    useState(key, () => 'test')
+    expect(`$s${key}` in nuxtApp.payload.state).toBe(true)
+
+    clearNuxtState(key, { reset: false })
+
+    expect(`$s${key}` in nuxtApp.payload.state).toBe(false)
+  })
 })
 
 describe('url', () => {

--- a/test/nuxt/use-async-data.test.ts
+++ b/test/nuxt/use-async-data.test.ts
@@ -278,6 +278,18 @@ describe('useAsyncData', () => {
     vi.useRealTimers()
   })
 
+  it('removes the key from payload.data and _asyncDataPromises on clear', async () => {
+    const nuxtApp = useNuxtApp()
+    await useAsyncData(uniqueKey, () => Promise.resolve('test'))
+
+    expect(uniqueKey in nuxtApp.payload.data).toBe(true)
+
+    clearNuxtData(uniqueKey)
+
+    expect(uniqueKey in nuxtApp.payload.data).toBe(false)
+    expect(uniqueKey in nuxtApp._asyncDataPromises).toBe(false)
+  })
+
   it('should have correct status for previously fetched requests', async () => {
     vi.useFakeTimers()
 


### PR DESCRIPTION
### 📚 Description

I noticed that one of my composables, which used dynamic `useState` keys, left them in the state after calling `clearNuxtState`. After investigating, I found that we're just setting it to `undefined`. I've looked through the code briefly and couldn't find a case where deleting the key would break something. The tests also passed locally, so I figured I'd open a PR.

Please let me know if you're aware of any cases where this could break. If such a case exists, I'll revert the changes and add a regression test instead.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
