### PR TITLE
perf(nuxt,vite): reuse vite watcher via `experimental.watcher`

### DIFF
--- a/docs/3.guide/6.going-further/1.experimental-features.md
+++ b/docs/3.guide/6.going-further/1.experimental-features.md
@@ -394,10 +394,17 @@ performance in large projects or on Windows platforms.
 
 You can also set this to `chokidar` to watch all files in your source directory.
 
+Set to `'builder'` to reuse the active builder's own file watcher (for example,
+Vite's `server.watcher`) instead of starting a second one. This reduces the
+number of file watchers active in dev mode and becomes the default when
+`future.compatibilityVersion` is `5`. If the active builder does not implement
+its own watcher (currently webpack and rspack), Nuxt logs a warning and falls
+back to its default selection.
+
 ```ts twoslash [nuxt.config.ts]
 export default defineNuxtConfig({
   experimental: {
-    watcher: 'chokidar-granular', // 'chokidar' or 'parcel' are also options
+    watcher: 'chokidar-granular', // 'chokidar', 'parcel' or 'builder' are also options
   },
 })
 ```

--- a/packages/nuxt/src/core/builder.ts
+++ b/packages/nuxt/src/core/builder.ts
@@ -23,29 +23,34 @@ export async function build (nuxt: Nuxt): Promise<void> {
   const builder = nuxt.options._prepare ? undefined : await resolveBuilder(nuxt)
 
   if (nuxt.options.dev) {
-    if (!nuxt.options._prepare) {
+    if (nuxt.options.experimental.watcher === 'builder' && builder?.setupWatcher) {
+      await builder.setupWatcher(nuxt)
+    } else {
+      if (nuxt.options.experimental.watcher === 'builder') {
+        logger.warn('`experimental.watcher: "builder"` is set but the active builder does not implement `setupWatcher`. Falling back to the default file watcher.')
+      }
       watch(nuxt)
-      nuxt.hook('builder:watch', async (event, relativePath) => {
-        // Unset mainComponent and errorComponent if app or error component is changed
-        if (event === 'add' || event === 'unlink') {
-          const path = resolve(nuxt.options.srcDir, relativePath)
-          for (const dirs of getLayerDirectories(nuxt)) {
-            const relativePath = relative(dirs.app, path)
-            if (/^app\./i.test(relativePath)) {
-              app.mainComponent = undefined
-              break
-            }
-            if (/^error\./i.test(relativePath)) {
-              app.errorComponent = undefined
-              break
-            }
+    }
+    nuxt.hook('builder:watch', async (event, relativePath) => {
+      // Unset mainComponent and errorComponent if app or error component is changed
+      if (event === 'add' || event === 'unlink') {
+        const path = resolve(nuxt.options.srcDir, relativePath)
+        for (const dirs of getLayerDirectories(nuxt)) {
+          const relativePath = relative(dirs.app, path)
+          if (/^app\./i.test(relativePath)) {
+            app.mainComponent = undefined
+            break
+          }
+          if (/^error\./i.test(relativePath)) {
+            app.errorComponent = undefined
+            break
           }
         }
+      }
 
-        // Recompile app templates
-        await generateApp()
-      })
-    }
+      // Recompile app templates
+      await generateApp()
+    })
     nuxt.hook('builder:generateApp', (options) => {
       // Bypass debounce if we are selectively invalidating templates
       if (options) { return _generateApp(nuxt, app, options) }

--- a/packages/nuxt/test/builder.test.ts
+++ b/packages/nuxt/test/builder.test.ts
@@ -54,4 +54,45 @@ describe('builder:watch', { sequential: true }, async () => {
       'test',
     ])
   })
+
+  it('should restart Nuxt when a file is added with builder strategy', async () => {
+    const rootDir = join(tmpDir, 'project')
+    const nuxt = await loadNuxt({
+      cwd: rootDir,
+      ready: true,
+      overrides: {
+        experimental: { watcher: 'builder' },
+        dev: true,
+        watch: ['test', join(rootDir, 'other'), resolve(rootDir, '../higher')],
+      },
+    })
+    const targets = new Set(['../higher', 'other', 'test'])
+    const seenAdds = new Set<string>()
+    let resolveAll: () => void
+    const allSeen = new Promise<void>((resolve) => { resolveAll = resolve })
+
+    nuxt.hook('builder:watch', (event, path) => {
+      if (event !== 'add') { return }
+      const rel = relative(rootDir, path)
+      if (targets.has(rel) && !seenAdds.has(rel)) {
+        seenAdds.add(rel)
+        if (seenAdds.size === targets.size) { resolveAll() }
+      }
+    })
+
+    await build(nuxt)
+
+    writeFileSync(resolve(rootDir, '../higher'), 'something')
+    writeFileSync(join(rootDir, 'test'), 'something')
+    writeFileSync(join(rootDir, 'other'), 'something')
+    await allSeen
+
+    await nuxt.close()
+
+    expect.soft([...seenAdds].sort()).toStrictEqual([
+      '../higher',
+      'other',
+      'test',
+    ])
+  })
 })

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -126,10 +126,13 @@ export default defineResolvers({
     checkOutdatedBuildInterval: 1000 * 60 * 60,
     watcher: {
       $resolve: async (val, get) => {
-        const validOptions = new Set(['chokidar', 'parcel', 'chokidar-granular'] as const)
+        const validOptions = new Set(['chokidar', 'parcel', 'chokidar-granular', 'builder'] as const)
         type WatcherOption = typeof validOptions extends Set<infer Option> ? Option : never
         if (typeof val === 'string' && validOptions.has(val as WatcherOption)) {
           return val as WatcherOption
+        }
+        if ((await get('future.compatibilityVersion')) >= 5) {
+          return 'builder' as const
         }
         const [srcDir, rootDir] = await Promise.all([get('srcDir'), get('rootDir')])
         if (srcDir === rootDir) {

--- a/packages/schema/src/types/config.ts
+++ b/packages/schema/src/types/config.ts
@@ -79,6 +79,15 @@ export interface DefineNuxtConfig<Config extends UserInputConfig = NuxtConfig> e
 
 export interface NuxtBuilder {
   bundle: (nuxt: Nuxt) => Promise<void>
+  /**
+   * Optional. If provided and the user opts in via `experimental.watcher: 'builder'`,
+   * Nuxt will call this instead of starting its own file watcher in dev mode,
+   * allowing the builder to reuse its own watcher.
+   *
+   * The builder is expected to register its own `nuxt.hook('close', ...)` to
+   * clean up any resources it allocates.
+   */
+  setupWatcher?: (nuxt: Nuxt) => Promise<void> | void
 }
 
 // Normalized Nuxt options available as `nuxt.options.*`

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1209,13 +1209,15 @@ export interface ConfigSchema {
      * You can set this instead to `parcel` to use `@parcel/watcher`, which may improve performance in large projects or on Windows platforms.
      * You can also set this to `chokidar` to watch all files in your source directory.
      *
+     * Set to `'builder'` to reuse the active builder's own file watcher (e.g. Vite's `server.watcher`) instead of starting a second one. If the active builder does not provide a watcher, Nuxt falls back to its default selection.
+     *
      * @see [chokidar](https://github.com/paulmillr/chokidar)
      *
      * @see [@parcel/watcher](https://github.com/parcel-bundler/watcher)
      *
-     * @default 'chokidar-granular' if `srcDir` is the same as `rootDir`, otherwise 'chokidar'
+     * @default 'builder' if `future.compatibilityVersion` >= 5, otherwise 'chokidar-granular' if `srcDir` is the same as `rootDir`, otherwise 'chokidar'
      */
-    watcher: 'chokidar' | 'parcel' | 'chokidar-granular'
+    watcher: 'chokidar' | 'parcel' | 'chokidar-granular' | 'builder'
 
     /**
      * Enable native async context to be accessible for nested composables

--- a/packages/schema/test/experimental.spec.ts
+++ b/packages/schema/test/experimental.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest'
+import { applyDefaults } from 'untyped'
+
+import { NuxtConfigSchema } from '../src/index.ts'
+import type { NuxtOptions } from '../src/index.ts'
+
+vi.mock('node:fs', () => ({
+  existsSync: (id: string) => id.endsWith('app'),
+}))
+
+describe('experimental.watcher default', () => {
+  it('defaults to `builder` when compatibilityVersion is 5', async () => {
+    const result = await applyDefaults(NuxtConfigSchema, { future: { compatibilityVersion: 5 } })
+    expect((result as unknown as NuxtOptions).experimental.watcher).toBe('builder')
+  })
+
+  it('defaults to `chokidar-granular` for v3-style layout (srcDir === rootDir)', async () => {
+    const result = await applyDefaults(NuxtConfigSchema, { future: { compatibilityVersion: 3 }, srcDir: '/test', rootDir: '/test' })
+    expect((result as unknown as NuxtOptions).experimental.watcher).toBe('chokidar-granular')
+  })
+
+  it('defaults to `chokidar` for v3 when srcDir differs from rootDir', async () => {
+    const result = await applyDefaults(NuxtConfigSchema, { future: { compatibilityVersion: 3 }, srcDir: 'src/', rootDir: '/test' })
+    expect((result as unknown as NuxtOptions).experimental.watcher).toBe('chokidar')
+  })
+
+  it('respects an explicit string value', async () => {
+    const result = await applyDefaults(NuxtConfigSchema, { future: { compatibilityVersion: 5 }, experimental: { watcher: 'parcel' } })
+    expect((result as unknown as NuxtOptions).experimental.watcher).toBe('parcel')
+  })
+})

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -2,6 +2,7 @@ import type { ViteConfig } from 'nuxt/schema'
 import type { EnvironmentOptions } from 'vite'
 
 export { bundle } from './vite.ts'
+export { setupWatcher } from './watcher.ts'
 
 declare module 'nuxt/schema' {
   interface ViteOptions extends ViteConfig {

--- a/packages/vite/src/watcher.ts
+++ b/packages/vite/src/watcher.ts
@@ -1,0 +1,51 @@
+import type { Nuxt, NuxtBuilder } from '@nuxt/schema'
+import { createIsIgnored, getLayerDirectories } from '@nuxt/kit'
+import { normalize, resolve } from 'pathe'
+
+/**
+ * Reuse Vite's `server.watcher` (chokidar) to drive `builder:watch` instead of
+ * spinning up a second FS watcher in Nuxt core. Only active in `dev` mode.
+ */
+export const setupWatcher: NonNullable<NuxtBuilder['setupWatcher']> = (nuxt: Nuxt) => {
+  if (!nuxt.options.dev) { return }
+
+  const isIgnored = createIsIgnored(nuxt)
+
+  const extraPaths = new Set<string>()
+  for (const layer of getLayerDirectories(nuxt)) {
+    extraPaths.add(layer.app)
+    if (!layer.server.startsWith(layer.app.replace(/\/?$/, '/'))) {
+      extraPaths.add(layer.server)
+    }
+  }
+
+  const srcDir = nuxt.options.srcDir.replace(/\/?$/, '/')
+  for (const pattern of nuxt.options.watch) {
+    if (typeof pattern !== 'string') { continue }
+    const path = resolve(nuxt.options.srcDir, pattern)
+    if (!path.startsWith(srcDir)) {
+      extraPaths.add(path)
+    }
+  }
+
+  nuxt.hook('vite:serverCreated', async (server, { isClient }) => {
+    // remove in nuxt v5
+    if (!isClient) { return }
+
+    const watcher = server.watcher
+
+    watcher.on('all', (event, path) => {
+      const normalized = normalize(path)
+      if (isIgnored(normalized)) { return }
+      nuxt.callHook('builder:watch', event, normalized)
+    })
+
+    if (extraPaths.size) {
+      // Wait for chokidar to finish enumerating the extra paths so that file
+      // events arrive reliably once the dev server is up.
+      const ready = new Promise<void>(resolve => watcher.once('ready', resolve))
+      watcher.add([...extraPaths])
+      await ready
+    }
+  })
+}


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this is a performance optimisation to reduce resource usage by nuxt. (vite also creates a chokidar-based watcher, and this PR allows nuxt to piggy-back on this.)