### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -362,6 +362,7 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
   hasTypescriptVersionWithModulePreserve ??= true
 
   const useDecorators = Boolean(nuxt.options.experimental?.decorators)
+  const userTsConfigExclude = [...(nuxt.options.typescript?.tsConfig?.exclude ?? [])]
 
   // https://www.totaltypescript.com/tsconfig-cheat-sheet
   const tsConfig: TSConfig = defu(nuxt.options.typescript?.tsConfig, {
@@ -564,7 +565,7 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
   const legacyTsConfig: TSConfig = defu({}, {
     ...tsConfig,
     include: [...tsConfig.include, ...legacyInclude],
-    exclude: [...tsConfig.exclude, ...legacyExclude],
+    exclude: [...userTsConfigExclude, ...legacyExclude],
   })
 
   async function resolveConfig (tsConfig: TSConfig) {

--- a/packages/kit/test/generate-types.spec.ts
+++ b/packages/kit/test/generate-types.spec.ts
@@ -70,6 +70,25 @@ describe('tsConfig generation', () => {
     `)
   })
 
+  it('should only add explicit user excludes to the legacy tsconfig', async () => {
+    const { tsConfig, legacyTsConfig } = await _generateTypes(mockNuxtWithOptions({
+      typescript: {
+        tsConfig: {
+          exclude: ['../explicit-exclude'],
+        },
+      },
+    }))
+
+    expect(tsConfig.exclude).toContain('../nuxt.config.*')
+    expect(tsConfig.exclude).toContain('../modules/*.*')
+
+    expect(legacyTsConfig.include).toContain('../nuxt.config.*')
+    expect(legacyTsConfig.include).toContain('../modules/*.*')
+    expect(legacyTsConfig.exclude).toContain('../explicit-exclude')
+    expect(legacyTsConfig.exclude).not.toContain('../nuxt.config.*')
+    expect(legacyTsConfig.exclude).not.toContain('../modules/*.*')
+  })
+
   it('should add #build after #components to paths', async () => {
     const { tsConfig } = await _generateTypes(mockNuxtWithOptions({
       alias: {


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #35146

### 📚 Description

The generated app tsconfig needs Nuxt's internal exclude patterns, but the legacy `.nuxt/tsconfig.json` also includes config files and module files for backward compatibility. Since it copied the resolved app `tsConfig.exclude`, those files could be present in both `include` and `exclude`.

This keeps explicit `typescript.tsConfig.exclude` values flowing into the legacy config without copying the generated app-only excludes.

### 🧪 Tests

- `pnpm dev:prepare`
- `pnpm vitest run --project unit packages/kit/test/generate-types.spec.ts -t "should only add explicit user excludes to the legacy tsconfig"`
- `pnpm vitest run --project unit packages/kit/test/generate-types.spec.ts`
- `pnpm vitest run --project unit packages/kit/test`
- `pnpm exec eslint packages/kit/src/template.ts packages/kit/test/generate-types.spec.ts`
- `pnpm typecheck`
- `pnpm test:unit`
- `pnpm lint`
- `git diff --check`