### PR TITLE
fix(kit): avoid excluding node-context files in legacy tsconfig

### DIFF
--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -363,6 +363,8 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
 
   const useDecorators = Boolean(nuxt.options.experimental?.decorators)
 
+  const userExclude = nuxt.options.typescript?.tsConfig?.exclude ?? []
+
   // https://www.totaltypescript.com/tsconfig-cheat-sheet
   const tsConfig: TSConfig = defu(nuxt.options.typescript?.tsConfig, {
     compilerOptions: {
@@ -564,7 +566,7 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
   const legacyTsConfig: TSConfig = defu({}, {
     ...tsConfig,
     include: [...tsConfig.include, ...legacyInclude],
-    exclude: [...tsConfig.exclude, ...legacyExclude],
+    exclude: [...userExclude, ...legacyExclude],
   })
 
   async function resolveConfig (tsConfig: TSConfig) {

--- a/packages/kit/test/generate-types.spec.ts
+++ b/packages/kit/test/generate-types.spec.ts
@@ -70,6 +70,23 @@ describe('tsConfig generation', () => {
     `)
   })
 
+  it('should not exclude node-context paths from legacy tsconfig', async () => {
+    const { legacyTsConfig } = await _generateTypes(mockNuxt)
+    // nuxt.config.* and .config/nuxt.* are intentionally in legacyInclude (node context)
+    // and must NOT be excluded by the legacy tsconfig
+    expect(legacyTsConfig.include).toEqual(expect.arrayContaining(['../nuxt.config.*', '../.config/nuxt.*']))
+    expect(legacyTsConfig.exclude).not.toEqual(expect.arrayContaining(['../nuxt.config.*', '../.config/nuxt.*']))
+  })
+
+  it('should propagate user-defined excludes to legacy tsconfig', async () => {
+    const { legacyTsConfig } = await _generateTypes(mockNuxtWithOptions({
+      typescript: { tsConfig: { exclude: ['my-custom-exclude'] } },
+    }))
+    expect(legacyTsConfig.exclude).toContain('my-custom-exclude')
+    // but computed app-only paths must still be absent
+    expect(legacyTsConfig.exclude).not.toContain('../nuxt.config.*')
+  })
+
   it('should add #build after #components to paths', async () => {
     const { tsConfig } = await _generateTypes(mockNuxtWithOptions({
       alias: {


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #35146

### 📚 Description

#35079 started propagating typescript.tsConfig.exclude into the legacy .nuxt/tsconfig.json, but it also ended up pulling in some app-specific excludes that shouldn't be there.

The legacy tsconfig is still supposed to include things like nuxt.config.* and .config/nuxt.*, but those paths were also ending up in exclude, so they disappeared entirely.
This keeps the user-defined exclude propagation from #35079 while avoiding the computed app-only excludes.

Also adds a couple of regression tests around the legacy tsconfig behavior.