### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -557,6 +557,7 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
   }))
 
   const declarations: string[] = []
+  const userTsConfigExclude = [...nuxt.options.typescript?.tsConfig?.exclude ?? []]
 
   await nuxt.callHook('prepare:types', { references, declarations, tsConfig, nodeTsConfig, nodeReferences, sharedTsConfig, sharedReferences })
 
@@ -564,7 +565,7 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
   const legacyTsConfig: TSConfig = defu({}, {
     ...tsConfig,
     include: [...tsConfig.include, ...legacyInclude],
-    exclude: [...tsConfig.exclude, ...legacyExclude],
+    exclude: [...userTsConfigExclude, ...legacyExclude],
   })
 
   async function resolveConfig (tsConfig: TSConfig) {

--- a/packages/kit/test/generate-types.spec.ts
+++ b/packages/kit/test/generate-types.spec.ts
@@ -70,6 +70,21 @@ describe('tsConfig generation', () => {
     `)
   })
 
+  it('should only add explicit user excludes to legacy tsconfig', async () => {
+    const { legacyTsConfig } = await _generateTypes(mockNuxtWithOptions({
+      typescript: {
+        tsConfig: {
+          exclude: ['../generated/**/*'],
+        },
+      },
+    }))
+
+    expect(legacyTsConfig.exclude).toContain('../generated/**/*')
+    expect(legacyTsConfig.exclude).not.toContain('../nuxt.config.*')
+    expect(legacyTsConfig.exclude).not.toContain('../modules/*.*')
+    expect(legacyTsConfig.exclude).not.toContain('../layers/*/modules/**/*')
+  })
+
   it('should add #build after #components to paths', async () => {
     const { tsConfig } = await _generateTypes(mockNuxtWithOptions({
       alias: {


### PR DESCRIPTION
Closes #35146

### Summary
- build the legacy tsconfig exclude list from explicit `typescript.tsConfig.exclude` entries
- keep app/node tsconfig default excludes out of the legacy tsconfig
- add regression coverage for explicit user excludes and app-only excludes

### Tests
- `pnpm vitest run packages/kit/test/generate-types.spec.ts`
- `pnpm eslint packages/kit/src/template.ts packages/kit/test/generate-types.spec.ts`