### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -415,8 +415,10 @@ export function createNuxtApp (options: CreateOptions): NuxtApp {
     // Listen to chunk load errors
     if (chunkErrorEvent) {
       window.addEventListener(chunkErrorEvent, (event) => {
-        nuxtApp.callHook('app:chunkError', { error: (event as Event & { payload: Error }).payload })
-        if (event.payload.message.includes('Unable to preload CSS')) {
+        const payload = (event as Event & { payload?: Error }).payload
+        if (!payload) return
+        nuxtApp.callHook('app:chunkError', { error: payload })
+        if (payload.message.includes('Unable to preload CSS')) {
           event.preventDefault()
         }
       })

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -416,7 +416,7 @@ export function createNuxtApp (options: CreateOptions): NuxtApp {
     if (chunkErrorEvent) {
       window.addEventListener(chunkErrorEvent, (event) => {
         const payload = (event as Event & { payload?: Error }).payload
-        if (!payload) return
+        if (!payload) { return }
         nuxtApp.callHook('app:chunkError', { error: payload })
         if (payload.message.includes('Unable to preload CSS')) {
           event.preventDefault()


### PR DESCRIPTION
Fixes #35150

Why
The `chunkErrorEvent` listener in `packages/nuxt/src/app/nuxt.ts` directly dereferences `event.payload.message` without guarding against a missing payload. When a `vite:preloadError` event is dispatched without a payload set, this causes an unhandled `TypeError: Cannot read properties of undefined (reading "message")` that crashes the error handler.

Changes
Extract `payload` with a `payload?: Error` type and return early if it is undefined before calling hooks or accessing `.message`.

Updated component: `packages/nuxt/src/app/nuxt.ts`

Testing
Dispatching `new Event("vite:preloadError", { cancelable: true })` without a payload no longer throws. The defensive guard exits early before any hook call or property access.

Surface area
- Runtime / App
- Bug fix
- Good first issue