### PR TITLE
fix(nuxt): handle missing payload in chunkError listener

### DIFF
--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -416,7 +416,7 @@ export function createNuxtApp (options: CreateOptions): NuxtApp {
     if (chunkErrorEvent) {
       window.addEventListener(chunkErrorEvent, (event) => {
         nuxtApp.callHook('app:chunkError', { error: (event as Event & { payload: Error }).payload })
-        if (event.payload.message.includes('Unable to preload CSS')) {
+        if (event.payload?.message?.includes('Unable to preload CSS')) {
           event.preventDefault()
         }
       })


### PR DESCRIPTION
When a chunk fails to load, the browser fires the chunkError event.
If the event has no payload — or a payload without a `message`
property — the current listener throws a TypeError before it can do
anything useful:

  TypeError: Cannot read properties of undefined (reading 'message')

The fix is optional chaining so the CSS-preload check short-circuits
safely when payload or message is absent:

```diff
-  if (event.payload.message.includes('Unable to preload CSS')) {
+  if (event.payload?.message?.includes('Unable to preload CSS')) {
```

When payload and message are both present the behaviour is unchanged.

Closes #35150