### PR TITLE
fix(nuxt): support template attributes in lazy hydration transform

### DIFF
--- a/packages/nuxt/src/components/plugins/lazy-hydration-transform.ts
+++ b/packages/nuxt/src/components/plugins/lazy-hydration-transform.ts
@@ -15,7 +15,7 @@ interface LoaderOptions {
 }
 
 const SCRIPT_RE = /(?<=<script[^>]*>)[\s\S]*?(?=<\/script>)/gi
-const TEMPLATE_RE = /<template>([\s\S]*)<\/template>/
+const TEMPLATE_RE = /<template\b[^>]*>([\s\S]*?)<\/template>/
 const hydrationStrategyMap = {
   hydrateOnIdle: 'Idle',
   hydrateOnVisible: 'Visible',
@@ -26,7 +26,7 @@ const hydrationStrategyMap = {
   hydrateNever: 'Never',
 }
 
-const TEMPLATE_WITH_LAZY_HYDRATION_RE = /<template>[\s\S]*\b(?:hydrate-on-idle|hydrateOnIdle|hydrate-on-visible|hydrateOnVisible|hydrate-on-interaction|hydrateOnInteraction|hydrate-on-media-query|hydrateOnMediaQuery|hydrate-after|hydrateAfter|hydrate-when|hydrateWhen|hydrate-never|hydrateNever)\b[\s\S]*<\/template>/
+const TEMPLATE_WITH_LAZY_HYDRATION_RE = /<template\b[^>]*>[\s\S]*?(?:hydrate-on-idle|hydrateOnIdle|hydrate-on-visible|hydrateOnVisible|hydrate-on-interaction|hydrateOnInteraction|hydrate-on-media-query|hydrateOnMediaQuery|hydrate-after|hydrateAfter|hydrate-when|hydrateWhen|hydrate-never|hydrateNever)[\s\S]*?<\/template>/
 
 export const LazyHydrationTransformPlugin = (options: LoaderOptions) => createUnplugin(() => {
   const exclude = options.transform?.exclude || []

--- a/packages/nuxt/test/component-loader.test.ts
+++ b/packages/nuxt/test/component-loader.test.ts
@@ -292,6 +292,18 @@ export default {
     const result = await transform(sfc, '/pages/index.vue').then(r => r.split('\n'))
     expect(result.join('\n')).toContain(component)
   })
+
+  it('should correctly resolve lazy hydration components in templates with attributes', async () => {
+    const sfc = `
+    <template data-test="lazy-hydration">
+      <LazyMyComponent hydrate-on-visible />
+    </template>
+    `
+
+    const result = await transform(sfc, '/pages/index.vue')
+
+    expect(result).toContain('createLazyVisibleComponent')
+  })
 })
 const components = ([{ name: 'MyComponent', filePath: '/components/MyComponent.vue' }] as AddComponentOptions[]).map(opts => ({
   export: opts.export || 'default',


### PR DESCRIPTION
The lazy hydration transform previously matched `<template>` tags exactly, which did not match valid template tags containing attributes.

This updates the template matching regular expressions to support template attributes such as:

```vue
<template data-test="example">
```

and:

```vue
<template lang="pug">
```

This change improves template matching robustness, but does not fully add pug lazy hydration support since the transform still parses raw template content as HTML.

### Tests

* Added coverage for templates with attributes
* `pnpm vitest packages/nuxt/test/component-loader.test.ts`
