### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -416,7 +416,7 @@ export function createNuxtApp (options: CreateOptions): NuxtApp {
     if (chunkErrorEvent) {
       window.addEventListener(chunkErrorEvent, (event) => {
         nuxtApp.callHook('app:chunkError', { error: (event as Event & { payload: Error }).payload })
-        if (event.payload.message.includes('Unable to preload CSS')) {
+        if (event.payload?.message?.includes('Unable to preload CSS')) {
           event.preventDefault()
         }
       })


### PR DESCRIPTION
### 🔍 Problem

If a `vite:preloadError` event is dispatched without a `payload` (e.g., from a browser extension or test harness), the chunk error listener in `packages/nuxt/src/app/nuxt.ts` throws:

```
TypeError: e.payload is undefined
```

The `payload` field is set by Vite's preload helper but is not part of the standard `Event` interface, so any non-Vite dispatch trips the listener.

### 🩹 Fix

Use optional chaining (`?.`) to defensively access `event.payload.message` before calling `.includes()`. This silently ignores events without a payload, matching the expected defensive behavior.

Closes #35150