### PR TITLE
fix(kit): resolve `moduleDependencies` by `meta.name` for string module entries

### DIFF
--- a/packages/kit/src/module/install.ts
+++ b/packages/kit/src/module/install.ts
@@ -57,12 +57,19 @@ export async function installModules (modulesToInstall: Map<ModuleToInstall, Rec
 
   const inlineConfigKeys = new Set(
     await Promise.all([...modulesToInstall].map(async ([mod]) => {
-      if (typeof mod === 'string') { return }
-      const meta = await Promise.resolve(mod.getMeta?.())
-      if (meta?.name) {
+      let meta: ModuleMeta | undefined
+      if (typeof mod === 'string') {
+        const loaded = await moduleLoadCache.get(mod)?.catch(() => undefined)
+        meta = await loaded?.nuxtModule.getMeta?.()
+      } else {
+        meta = await Promise.resolve(mod.getMeta?.())
+      }
+
+      if (!meta) { return }
+      if (meta.name) {
         modulesByMetaName.set(meta.name, mod)
       }
-      if (meta?.configKey) {
+      if (meta.configKey) {
         if (meta.configKey !== meta.name) {
           modulesByMetaName.set(meta.configKey, mod)
         }

--- a/packages/kit/test/module.test.ts
+++ b/packages/kit/test/module.test.ts
@@ -260,6 +260,33 @@ export default Object.assign((options) => {
     })
   })
 
+  it('should resolve moduleDependencies by meta.name for scanned local modules', async () => {
+    const localTempDir = join(tempDir, 'scanned')
+    const modulesDir = join(localTempDir, 'modules')
+    await mkdir(modulesDir, { recursive: true })
+
+    await writeFile(join(modulesDir, 'local-dep.mjs'), `
+export default Object.assign(() => {}, {
+  getMeta: () => ({ name: 'local-dep' }),
+})
+    `)
+
+    await writeFile(join(modulesDir, 'consumer.mjs'), `
+export default Object.assign(() => {}, {
+  getMeta: () => ({ name: 'consumer' }),
+  getModuleDependencies: () => ({ 'local-dep': {} }),
+})
+    `)
+
+    try {
+      nuxt = await loadNuxt({ cwd: localTempDir })
+      const installed = nuxt.options._installedModules?.filter(m => m.meta?.name === 'local-dep') ?? []
+      expect(installed).toHaveLength(1)
+    } finally {
+      await rm(localTempDir, { recursive: true, force: true })
+    }
+  })
+
   it('should not load a module from disk if it is present inline', async () => {
     nuxt = await loadNuxt({
       cwd: tempDir,


### PR DESCRIPTION
### 🔗 Linked issue
https://github.com/nuxt/nuxt/issues/34253

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
The original PR https://github.com/nuxt/nuxt/pull/34263 didn't add full support for specifying module deps by `meta.name`.
I assume that it was probably intentional to skip the string modules, but I'm not sure why.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
