### PR TITLE
fix(nuxt): await in-lifght template generation when closing nuxt

### DIFF
--- a/packages/nuxt/src/core/builder.ts
+++ b/packages/nuxt/src/core/builder.ts
@@ -16,6 +16,14 @@ export async function build (nuxt: Nuxt): Promise<void> {
   const app = createApp(nuxt)
   nuxt.apps.default = app
 
+  let closing = false
+  const writes = new Set<Promise<unknown>>()
+  const track = async <T> (run: () => Promise<T>) => {
+    if (closing) { return }
+    const p = run()
+    writes.add(p)
+    try { await p } finally { writes.delete(p) }
+  }
   const generateApp = debounce(() => _generateApp(nuxt, app), undefined, { leading: true })
   await generateApp()
   nuxt._perf?.endPhase('app:generate')
@@ -31,6 +39,11 @@ export async function build (nuxt: Nuxt): Promise<void> {
       }
       watch(nuxt)
     }
+    nuxt.hook('close', async () => {
+      closing = true
+      generateApp.cancel()
+      await Promise.allSettled(writes)
+    })
     nuxt.hook('builder:watch', async (event, relativePath) => {
       // Unset mainComponent and errorComponent if app or error component is changed
       if (event === 'add' || event === 'unlink') {
@@ -49,12 +62,12 @@ export async function build (nuxt: Nuxt): Promise<void> {
       }
 
       // Recompile app templates
-      await generateApp()
+      await track(() => generateApp())
     })
     nuxt.hook('builder:generateApp', (options) => {
       // Bypass debounce if we are selectively invalidating templates
-      if (options) { return _generateApp(nuxt, app, options) }
-      return generateApp()
+      if (options) { return track(() => _generateApp(nuxt, app, options)) }
+      return track(() => generateApp())
     })
   }
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

thought this was a flaky test, and it turns out not... but on the other hand it's unlikely to actually bite anyone.

still... 🤷