### PR TITLE
fix(nuxt): detect infinite redirects in route middleware

### DIFF
--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -226,6 +226,14 @@ export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: Na
       // We wait to perform the redirect last in case any other middleware will intercept the redirect
       // and redirect somewhere else instead.
       if (!isExternal && inMiddleware) {
+        if (nuxtApp._processingMiddlewareRoute?.fullPath === fullPath) {
+          throw createError({
+            statusCode: 500,
+            fatal: true,
+            statusMessage: `Infinite redirect detected to "${fullPath}"`,
+          })
+        }
+
         router.afterEach(final => final.fullPath === fullPath ? redirect(false) : undefined)
         return to
       }

--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -93,6 +93,15 @@ const isProcessingMiddleware = () => {
   return false
 }
 
+const isMiddlewareSelfRedirect = (fullPath: string) => {
+  try {
+    return useNuxtApp()._processingMiddlewareRoute?.fullPath === fullPath
+  } catch {
+    return false
+  }
+  return false
+}
+
 // Conditional types, either one or other
 type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never }
 type XOR<T, U> = (T | U) extends object ? (Without<T, U> & U) | (Without<U, T> & T) : T | U
@@ -226,7 +235,7 @@ export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: Na
       // We wait to perform the redirect last in case any other middleware will intercept the redirect
       // and redirect somewhere else instead.
       if (!isExternal && inMiddleware) {
-        if (nuxtApp._processingMiddlewareRoute?.fullPath === fullPath) {
+        if (isMiddlewareSelfRedirect(fullPath)) {
           throw createError({
             statusCode: 500,
             fatal: true,

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -177,6 +177,9 @@ interface _NuxtApp {
   '_processingMiddleware'?: string | boolean
 
   /** @internal */
+  '_processingMiddlewareRoute'?: RouteLocationNormalizedLoaded
+
+  /** @internal */
   '_once': {
     [key: string]: Promise<any>
   }

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -177,7 +177,7 @@ interface _NuxtApp {
   '_processingMiddleware'?: string | boolean
 
   /** @internal */
-  '_processingMiddlewareRoute'?: RouteLocationNormalizedLoaded
+  '_processingMiddlewareRoute'?: Pick<RouteLocationNormalizedLoaded, 'fullPath'>
 
   /** @internal */
   '_once': {

--- a/packages/nuxt/src/app/plugins/router.ts
+++ b/packages/nuxt/src/app/plugins/router.ts
@@ -5,7 +5,7 @@ import { HTTPError } from '@nuxt/nitro-server/h3'
 import { defineNuxtPlugin, useRuntimeConfig } from '../nuxt'
 import type { ObjectPlugin, Plugin } from '../nuxt'
 import { getRouteRules } from '../composables/manifest'
-import { clearError, showError } from '../composables/error'
+import { clearError, isNuxtError, showError } from '../composables/error'
 import { navigateTo } from '../composables/router'
 
 // @ts-expect-error virtual file
@@ -268,7 +268,29 @@ const plugin: Plugin<{ route: Route, router: Router }> & ObjectPlugin<{ route: R
             if (import.meta.dev) {
               nuxtApp._processingMiddleware = (middleware as any)._path || true
             }
-            const result = await nuxtApp.runWithContext(() => middleware(to, from))
+
+            let result: Awaited<ReturnType<RouteGuard>>
+
+            try {
+              if (import.meta.server) {
+                nuxtApp._processingMiddlewareRoute = to
+              }
+
+              result = await nuxtApp.runWithContext(() => middleware(to, from))
+            } catch (err: unknown) {
+              // Let fatal middleware errors go through the same SSR error handling path
+              // as errors returned from middleware.
+              if (import.meta.server && isNuxtError(err) && err.fatal) {
+                result = err
+              } else {
+                throw err
+              }
+            } finally {
+              if (import.meta.server) {
+                delete nuxtApp._processingMiddlewareRoute
+              }
+            }
+
             if (import.meta.server) {
               if (result === false || result instanceof Error) {
                 const error = result || new HTTPError({

--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -1,6 +1,6 @@
 import { isReadonly, reactive, shallowReactive, shallowRef } from 'vue'
 import type { Ref } from 'vue'
-import type { RouteLocationNormalizedLoadedGeneric, Router, RouterScrollBehavior } from 'vue-router'
+import type { RouteLocationNormalizedLoadedGeneric, RouteLocationRaw, Router, RouterScrollBehavior } from 'vue-router'
 import { START_LOCATION, createMemoryHistory, createRouter, createWebHashHistory, createWebHistory } from 'vue-router'
 import { isSamePath, withoutBase } from 'ufo'
 
@@ -42,6 +42,10 @@ function createCurrentLocation (
   const displayedPath = withoutBase(pathname, base)
   const path = !renderedPath || isSamePath(displayedPath, renderedPath) ? displayedPath : renderedPath
   return path + (path.includes('?') ? '' : search) + hash
+}
+
+function isRouteLocation (route: unknown): route is RouteLocationRaw {
+  return typeof route === 'string' || (route !== null && typeof route === 'object' && !isNuxtError(route) && !(route instanceof Error))
 }
 
 const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
@@ -260,9 +264,27 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
               return result
             }
             if (result) {
-              if (isNuxtError(result) && result.fatal) {
-                await nuxtApp.runWithContext(() => showError(result))
+              if (isNuxtError(result)) {
+                if (result.fatal) {
+                  await nuxtApp.runWithContext(() => showError(result))
+                }
+
+                return result
               }
+
+              if (isRouteLocation(result)) {
+                const resolved = router.resolve(result)
+
+                if (resolved.fullPath === to.fullPath) {
+                  // If the middleware returned the same route, we likely had a redirect loop
+                  throw createError({
+                    status: 500,
+                    fatal: true,
+                    statusMessage: `Infinite redirect detected to "${to.fullPath}"`,
+                  })
+                }
+              }
+
               return result
             }
           } catch (err: any) {

--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -247,6 +247,11 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
             if (import.meta.dev) {
               nuxtApp._processingMiddleware = (middleware as any)._path || (typeof entry === 'string' ? entry : true)
             }
+
+            if (import.meta.server) {
+              nuxtApp._processingMiddlewareRoute = to
+            }
+
             const result = await nuxtApp.runWithContext(() => middleware(to, from))
             if (import.meta.server || (!nuxtApp.payload.serverRendered && nuxtApp.isHydrating)) {
               if (result === false || result instanceof Error) {
@@ -293,6 +298,10 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
               await nuxtApp.runWithContext(() => showError(error))
             }
             return error
+          } finally {
+            if (import.meta.server) {
+              delete nuxtApp._processingMiddlewareRoute
+            }
           }
         }
       }

--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -1,6 +1,6 @@
 import { isReadonly, reactive, shallowReactive, shallowRef } from 'vue'
 import type { Ref } from 'vue'
-import type { RouteLocationNormalizedLoadedGeneric, RouteLocationRaw, Router, RouterScrollBehavior } from 'vue-router'
+import type { RouteLocationNormalizedLoadedGeneric, Router, RouterScrollBehavior } from 'vue-router'
 import { START_LOCATION, createMemoryHistory, createRouter, createWebHashHistory, createWebHistory } from 'vue-router'
 import { isSamePath, withoutBase } from 'ufo'
 
@@ -42,10 +42,6 @@ function createCurrentLocation (
   const displayedPath = withoutBase(pathname, base)
   const path = !renderedPath || isSamePath(displayedPath, renderedPath) ? displayedPath : renderedPath
   return path + (path.includes('?') ? '' : search) + hash
-}
-
-function isRouteLocation (route: unknown): route is RouteLocationRaw {
-  return typeof route === 'string' || (route !== null && typeof route === 'object' && !isNuxtError(route) && !(route instanceof Error))
 }
 
 const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
@@ -269,27 +265,9 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
               return result
             }
             if (result) {
-              if (isNuxtError(result)) {
-                if (result.fatal) {
-                  await nuxtApp.runWithContext(() => showError(result))
-                }
-
-                return result
+              if (isNuxtError(result) && result.fatal) {
+                await nuxtApp.runWithContext(() => showError(result))
               }
-
-              if (isRouteLocation(result)) {
-                const resolved = router.resolve(result)
-
-                if (resolved.fullPath === to.fullPath) {
-                  // If the middleware returned the same route, we likely had a redirect loop
-                  throw createError({
-                    status: 500,
-                    fatal: true,
-                    statusMessage: `Infinite redirect detected to "${to.fullPath}"`,
-                  })
-                }
-              }
-
               return result
             }
           } catch (err: any) {

--- a/test/basic-no-pages.test.ts
+++ b/test/basic-no-pages.test.ts
@@ -1,0 +1,23 @@
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { fetch, setup } from '@nuxt/test-utils/e2e'
+
+import { isDev } from './matrix'
+
+await setup({
+  rootDir: fileURLToPath(new URL('./fixtures/basic', import.meta.url)),
+  dev: isDev,
+  server: true,
+  browser: false,
+  setupTimeout: 120 * 1000,
+  nuxtConfig: {
+    pages: false,
+  },
+})
+
+describe('app router without pages', () => {
+  it('returns 500 when there is an infinite middleware redirect', async () => {
+    const { status } = await fetch('/catchall/redirect-infinite', { redirect: 'manual' })
+    expect(status).toEqual(500)
+  })
+})

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -298,7 +298,7 @@ describe('pages', () => {
     await serverPage.close()
   })
 
-  it.runIf(isDev)('returns 500 when there is an infinite redirect', async () => {
+  it('returns 500 when there is an infinite redirect', async () => {
     const { status } = await fetch('/catchall/redirect-infinite', { redirect: 'manual' })
     expect(status).toEqual(500)
   })


### PR DESCRIPTION
### 🔗 Linked issue

resolves #34850

### 📚 Description

This PR adds a guard against infinite redirects returned from route middleware.

Previously, middleware could keep redirecting to the same resolved route. In dev this was already caught by Vue Router, but in built/prerendered scenarios it could continue redirecting and cause the process to hang or run out of memory.

The change resolves middleware redirect targets and checks whether the middleware is redirecting to the same `fullPath` that is currently being processed. In that case, Nuxt now throws a 500 error instead of continuing the redirect loop.

The existing infinite redirect test was also updated to run outside dev mode, so this regression is covered for built fixtures as well.