### PR TITLE
fix(nuxt): prevent server-only page island from recursing via `<NuxtPage>`

### DIFF
--- a/packages/nuxt/src/app/components/island-renderer.ts
+++ b/packages/nuxt/src/app/components/island-renderer.ts
@@ -1,14 +1,18 @@
 import type { DefineSetupFnComponent, defineAsyncComponent } from 'vue'
-import { createVNode, defineComponent, onErrorCaptured } from 'vue'
+import { computed, createVNode, defineComponent, onErrorCaptured, provide } from 'vue'
+import { viewDepthKey } from 'vue-router'
 
 import { createError } from '../composables/error'
+import { useRoute } from '../composables/router'
 
 // @ts-expect-error virtual file
-import { islandComponents } from '#build/components.islands.mjs'
+import { islandComponents, pageIslandRoutes } from '#build/components.islands.mjs'
 
 interface IslandRendererProps {
   context: { name: string, props?: Record<string, any> }
 }
+
+const PAGE_ISLAND_PREFIX = 'page_'
 
 const IslandRenderer = defineComponent({
   name: 'IslandRenderer',
@@ -26,6 +30,17 @@ const IslandRenderer = defineComponent({
         status: 404,
         statusText: `Island component not found: ${props.context.name}`,
       })
+    }
+
+    // A `.server.vue` page rendered as an island mounts the SFC directly here,
+    // bypassing the `<RouterView>` chain that would normally set view depth.
+    if (props.context.name.startsWith(PAGE_ISLAND_PREFIX)) {
+      const expectedIslandKey = pageIslandRoutes[props.context.name]
+      const route = useRoute()
+      provide(viewDepthKey, computed(() => {
+        const depth = route.matched.findIndex(m => (m.components?.default as any)?.__nuxt_island === expectedIslandKey)
+        return depth === -1 ? 0 : depth + 1
+      }))
     }
 
     onErrorCaptured((e) => {

--- a/test/fixtures/server-components/app/pages/server-page-with-nuxtpage.server.vue
+++ b/test/fixtures/server-components/app/pages/server-page-with-nuxtpage.server.vue
@@ -1,0 +1,6 @@
+<template>
+  <section id="server-page-with-nuxtpage">
+    Parent body
+    <NuxtPage />
+  </section>
+</template>

--- a/test/fixtures/server-components/app/pages/server-page-with-nuxtpage/child.vue
+++ b/test/fixtures/server-components/app/pages/server-page-with-nuxtpage/child.vue
@@ -1,0 +1,5 @@
+<template>
+  <article id="server-page-with-nuxtpage-child">
+    Child body
+  </article>
+</template>

--- a/test/server-components.test.ts
+++ b/test/server-components.test.ts
@@ -177,6 +177,19 @@ describe('server components/islands', () => {
     expect(await page.innerHTML('head')).toContain('<meta name="author" content="Nuxt">')
     await page.close()
   })
+
+  it('/server-page-with-nuxtpage/child renders the parent server page with the child route', async () => {
+    const html = await $fetch<string>('/server-page-with-nuxtpage/child')
+    expect(html).toContain('id="server-page-with-nuxtpage"')
+    expect(html).toContain('id="server-page-with-nuxtpage-child"')
+    expect(html).toContain('Child body')
+  })
+
+  it('/server-page-with-nuxtpage renders the parent without recursing into itself', async () => {
+    const html = await $fetch<string>('/server-page-with-nuxtpage')
+    expect(html).toContain('id="server-page-with-nuxtpage"')
+    expect(html).toContain('Parent body')
+  })
 })
 
 describe('component islands', () => {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

the depth marker wasn't being injected for server pages, leading to infinite loops 😱 

hopefully no-one encountered it as there was no report, but ... this fixes it 😓 