### PR TITLE
fix(nuxt): escape props in `<NuxtClientFallback>` ssr output

### DIFF
--- a/packages/nuxt/src/app/components/client-fallback.server.ts
+++ b/packages/nuxt/src/app/components/client-fallback.server.ts
@@ -1,6 +1,6 @@
 import { defineComponent, getCurrentInstance, onErrorCaptured, shallowRef, useId } from 'vue'
 import type { DefineSetupFnComponent, SlotsType, VNode } from 'vue'
-import { ssrRenderAttrs, ssrRenderSlot, ssrRenderVNode } from 'vue/server-renderer'
+import { ssrInterpolate, ssrRenderAttrs, ssrRenderSlot, ssrRenderVNode } from 'vue/server-renderer'
 
 import { isPromise } from '@vue/shared'
 import { useState } from '../composables/state'
@@ -100,7 +100,7 @@ const NuxtClientFallbackServer = defineComponent({
       } else {
         const content = ctx.placeholder || ctx.fallback
         const tag = sanitizeTag(ctx.placeholderTag || ctx.fallbackTag, 'div')
-        push(`<${tag}${ssrRenderAttrs(ctx.$attrs)}>${content}</${tag}>`)
+        push(`<${tag}${ssrRenderAttrs(ctx.$attrs)}>${ssrInterpolate(content)}</${tag}>`)
       }
     } else {
       // push Fragment markup

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -558,6 +558,12 @@ describe('pages', () => {
     expect(html).not.toContain('Sugar Counter 12 x 0 = 0')
     // ensure NuxtClientFallback is being rendered with its fallback tag and attributes
     expect(html).toContain('<span class="break-in-ssr">this failed to render</span>')
+
+    const xssHtml = await $fetch<string>('/client-fallback', {
+      query: { unsafe: '<script>alert(1)</script>' },
+    })
+    expect(xssHtml).not.toContain('<section class="escaped-fallback"><script>alert(1)</script></section>')
+    expect(xssHtml).toContain('<section class="escaped-fallback">&lt;script&gt;alert(1)&lt;/script&gt;</section>')
     // ensure Fallback slot is being rendered server side
     expect(html).toContain('Hello world !')
     // ensure fallback is rendered when an async component throws inside a wrapping component

--- a/test/fixtures/basic/app/pages/client-fallback.vue
+++ b/test/fixtures/basic/app/pages/client-fallback.vue
@@ -65,6 +65,13 @@
           </div>
         </template>
       </NuxtClientFallback>
+      <NuxtClientFallback
+        fallback-tag="section"
+        class="escaped-fallback"
+        :fallback="unsafe"
+      >
+        <BreakInSetup />
+      </NuxtClientFallback>
     </div>
     <button
       id="increment-count"
@@ -77,4 +84,6 @@
 
 <script setup>
 const multiplier = ref(0)
+const route = useRoute()
+const unsafe = computed(() => String(route.query.unsafe ?? ''))
 </script>


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

we [already document](https://nuxt.com/docs/api/components/nuxt-client-fallback) that fallback/placeholder are not to be trusted, but for the avoidance of doubt, we can add some hardening here