### PR TITLE
fix(rspack,webpack): require loopback host when missing same-origin signals

### DIFF
--- a/packages/webpack/src/utils/same-origin.ts
+++ b/packages/webpack/src/utils/same-origin.ts
@@ -1,0 +1,36 @@
+const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1'])
+
+function firstHeader (value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value
+}
+
+function isLoopbackHost (host: string | undefined): boolean {
+  if (!host) { return false }
+  const withoutPort = host.replace(/:\d+$/, '')
+  const hostname = withoutPort.replace(/^\[|\]$/g, '').toLowerCase()
+  return LOOPBACK_HOSTNAMES.has(hostname)
+}
+
+export function isSameOriginRequest (req: { headers: Record<string, string | string[] | undefined> }): boolean {
+  const site = firstHeader(req.headers['sec-fetch-site'])
+  if (site !== undefined) {
+    return site === 'same-origin' || site === 'none'
+  }
+
+  const initiator = firstHeader(req.headers.origin) || firstHeader(req.headers.referer)
+  if (!initiator) {
+    // A request with no `Sec-Fetch-Site`, `Origin`, or `Referer` is only safe to
+    // allow when the dev server is loopback-bound: a browser-originated request
+    // can reach a non-loopback bind (e.g. `nuxt dev --host`) with all three
+    // headers absent if the attacker page is on a non-trustworthy origin
+    // (drops `Sec-Fetch-*`), uses a non-CORS `<script>` (no `Origin`), and sets
+    // `Referrer-Policy: no-referrer` (drops `Referer`).
+    return isLoopbackHost(firstHeader(req.headers.host))
+  }
+
+  try {
+    return new URL(initiator).host === firstHeader(req.headers.host)
+  } catch {
+    return false
+  }
+}

--- a/packages/webpack/src/webpack.ts
+++ b/packages/webpack/src/webpack.ts
@@ -15,6 +15,7 @@ import { DynamicBasePlugin } from './plugins/dynamic-base.ts'
 import { ChunkErrorPlugin } from './plugins/chunk.ts'
 import { SSRStylesPlugin } from './plugins/ssr-styles.ts'
 import { createMFS } from './utils/mfs.ts'
+import { isSameOriginRequest } from './utils/same-origin.ts'
 import { client, server } from './configs/index.ts'
 import { applyPresets, createWebpackConfigContext } from './utils/config.ts'
 
@@ -165,30 +166,6 @@ function wdmToH3Handler (devMiddleware: webpackDevMiddleware.API<IncomingMessage
     })
     return body
   })
-}
-
-// `Sec-Fetch-Site` is not sent in every context, so fall back to comparing the
-// initiator (`Origin` / `Referer`) host against the request's `Host`.
-function isSameOriginRequest (req: { headers: Record<string, string | string[] | undefined> }): boolean {
-  const site = firstHeader(req.headers['sec-fetch-site'])
-  if (site !== undefined) {
-    return site === 'same-origin' || site === 'none'
-  }
-
-  const initiator = firstHeader(req.headers.origin) || firstHeader(req.headers.referer)
-  if (!initiator) {
-    return true
-  }
-
-  try {
-    return new URL(initiator).host === firstHeader(req.headers.host)
-  } catch {
-    return false
-  }
-}
-
-function firstHeader (value: string | string[] | undefined): string | undefined {
-  return Array.isArray(value) ? value[0] : value
 }
 
 async function compile (compiler: Compiler) {

--- a/packages/webpack/test/same-origin.test.ts
+++ b/packages/webpack/test/same-origin.test.ts
@@ -8,23 +8,23 @@ function req (headers: Record<string, string | string[] | undefined>) {
 describe('isSameOriginRequest', () => {
   describe('with Sec-Fetch-Site present', () => {
     it('allows same-origin', () => {
-      expect(isSameOriginRequest(req({ 'sec-fetch-site': 'same-origin', host: 'localhost:3000' }))).toBe(true)
+      expect(isSameOriginRequest(req({ 'sec-fetch-site': 'same-origin', 'host': 'localhost:3000' }))).toBe(true)
     })
 
     it('allows direct browser navigation (none)', () => {
-      expect(isSameOriginRequest(req({ 'sec-fetch-site': 'none', host: 'localhost:3000' }))).toBe(true)
+      expect(isSameOriginRequest(req({ 'sec-fetch-site': 'none', 'host': 'localhost:3000' }))).toBe(true)
     })
 
     it('rejects cross-site', () => {
-      expect(isSameOriginRequest(req({ 'sec-fetch-site': 'cross-site', host: 'localhost:3000' }))).toBe(false)
+      expect(isSameOriginRequest(req({ 'sec-fetch-site': 'cross-site', 'host': 'localhost:3000' }))).toBe(false)
     })
 
     it('rejects same-site (subdomain)', () => {
-      expect(isSameOriginRequest(req({ 'sec-fetch-site': 'same-site', host: 'localhost:3000' }))).toBe(false)
+      expect(isSameOriginRequest(req({ 'sec-fetch-site': 'same-site', 'host': 'localhost:3000' }))).toBe(false)
     })
 
     it('handles array-form header values', () => {
-      expect(isSameOriginRequest(req({ 'sec-fetch-site': ['cross-site', 'same-origin'], host: 'localhost:3000' }))).toBe(false)
+      expect(isSameOriginRequest(req({ 'sec-fetch-site': ['cross-site', 'same-origin'], 'host': 'localhost:3000' }))).toBe(false)
     })
   })
 

--- a/packages/webpack/test/same-origin.test.ts
+++ b/packages/webpack/test/same-origin.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import { isSameOriginRequest } from '../src/utils/same-origin'
+
+function req (headers: Record<string, string | string[] | undefined>) {
+  return { headers }
+}
+
+describe('isSameOriginRequest', () => {
+  describe('with Sec-Fetch-Site present', () => {
+    it('allows same-origin', () => {
+      expect(isSameOriginRequest(req({ 'sec-fetch-site': 'same-origin', host: 'localhost:3000' }))).toBe(true)
+    })
+
+    it('allows direct browser navigation (none)', () => {
+      expect(isSameOriginRequest(req({ 'sec-fetch-site': 'none', host: 'localhost:3000' }))).toBe(true)
+    })
+
+    it('rejects cross-site', () => {
+      expect(isSameOriginRequest(req({ 'sec-fetch-site': 'cross-site', host: 'localhost:3000' }))).toBe(false)
+    })
+
+    it('rejects same-site (subdomain)', () => {
+      expect(isSameOriginRequest(req({ 'sec-fetch-site': 'same-site', host: 'localhost:3000' }))).toBe(false)
+    })
+
+    it('handles array-form header values', () => {
+      expect(isSameOriginRequest(req({ 'sec-fetch-site': ['cross-site', 'same-origin'], host: 'localhost:3000' }))).toBe(false)
+    })
+  })
+
+  describe('without Sec-Fetch-Site, with Origin or Referer', () => {
+    it('allows when Origin host matches Host', () => {
+      expect(isSameOriginRequest(req({ origin: 'http://192.168.0.31:3000', host: '192.168.0.31:3000' }))).toBe(true)
+    })
+
+    it('rejects when Origin host differs from Host', () => {
+      expect(isSameOriginRequest(req({ origin: 'http://evil.lan', host: '192.168.0.31:3000' }))).toBe(false)
+    })
+
+    it('allows when Referer host matches Host', () => {
+      expect(isSameOriginRequest(req({ referer: 'http://192.168.0.31:3000/some/page', host: '192.168.0.31:3000' }))).toBe(true)
+    })
+
+    it('rejects the GHSA-6m52-m754-pw2g shape (LAN attacker, Referer present)', () => {
+      expect(isSameOriginRequest(req({ referer: 'http://evil.lan/', host: '192.168.0.31:3000' }))).toBe(false)
+    })
+
+    it('rejects unparseable initiators', () => {
+      expect(isSameOriginRequest(req({ origin: 'not a url', host: '192.168.0.31:3000' }))).toBe(false)
+    })
+  })
+
+  describe('GHSA-x6qj-4h56-5rj5: no Sec-Fetch-Site, no Origin, no Referer', () => {
+    it('allows when the dev server is loopback-bound (localhost)', () => {
+      expect(isSameOriginRequest(req({ host: 'localhost:3000' }))).toBe(true)
+    })
+
+    it('allows when the dev server is loopback-bound (127.0.0.1)', () => {
+      expect(isSameOriginRequest(req({ host: '127.0.0.1:3000' }))).toBe(true)
+    })
+
+    it('allows when the dev server is loopback-bound (IPv6 ::1)', () => {
+      expect(isSameOriginRequest(req({ host: '[::1]:3000' }))).toBe(true)
+    })
+
+    it('rejects when the dev server is bound to a non-loopback LAN address', () => {
+      expect(isSameOriginRequest(req({ host: '192.168.0.31:3000' }))).toBe(false)
+    })
+
+    it('rejects when the dev server is bound to 0.0.0.0 served via a LAN Host header', () => {
+      expect(isSameOriginRequest(req({ host: '10.0.0.5:3000' }))).toBe(false)
+    })
+
+    it('rejects when the Host header is absent', () => {
+      expect(isSameOriginRequest(req({}))).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this tightens up and adds tests for non-same-origin requests to the webpack/rspack dev servers