### PR TITLE
fix(nuxt): reject prototype-chain keys in the island registry

### DIFF
--- a/packages/nuxt/src/app/components/island-renderer.ts
+++ b/packages/nuxt/src/app/components/island-renderer.ts
@@ -19,7 +19,10 @@ const IslandRenderer = defineComponent({
     },
   },
   setup (props) {
-    const component = islandComponents[props.context.name] as ReturnType<typeof defineAsyncComponent>
+    const name = props.context.name
+    const component = Object.hasOwn(islandComponents, name)
+      ? islandComponents[name] as ReturnType<typeof defineAsyncComponent>
+      : undefined
 
     if (!component) {
       throw createError({

--- a/packages/nuxt/src/components/templates.ts
+++ b/packages/nuxt/src/components/templates.ts
@@ -80,7 +80,7 @@ export const componentsIslandsTemplate: NuxtTemplate = {
   filename: 'components.islands.mjs',
   getContents ({ app, nuxt }) {
     if (!nuxt.options.experimental.componentIslands) {
-      return 'export const islandComponents = {}\nexport const pageIslandRoutes = {}'
+      return 'export const islandComponents = Object.create(null)\nexport const pageIslandRoutes = Object.create(null)'
     }
 
     const components = app.components
@@ -102,7 +102,7 @@ export const componentsIslandsTemplate: NuxtTemplate = {
 
     return [
       'import { defineAsyncComponent } from \'vue\'',
-      'export const islandComponents = import.meta.client ? {} : {',
+      'export const islandComponents = import.meta.client ? Object.create(null) : Object.assign(Object.create(null), {',
       islands.map(
         (c) => {
           const exp = c.export === 'default' ? 'c.default || c' : `c['${c.export}']`
@@ -110,10 +110,10 @@ export const componentsIslandsTemplate: NuxtTemplate = {
           return `  "${c.pascalName}": defineAsyncComponent(${genDynamicImport(c.filePath, { comment })}.then(c => ${exp}))`
         },
       ).concat(pageExports).join(',\n'),
-      '}',
-      'export const pageIslandRoutes = import.meta.client ? {} : {',
+      '})',
+      'export const pageIslandRoutes = import.meta.client ? Object.create(null) : Object.assign(Object.create(null), {',
       pageIslandRoutes.join(',\n'),
-      '}',
+      '})',
     ].join('\n')
   },
 }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this guards access to a `/__nuxt_island/constructor_<hash>.json?props=`. there is no exploitable impact but it would have returned something like:

```json
{
   "id": "<hash>",
   "head": {},
   "html": "[object Object]",
   "components": {},
   "slots": {}
 }
```

that's a bug, so we can fix defensively here.

thanks to Anthropic (ANT-2026-Z015ZRWK) for reporting.