### PR TITLE
fix(nuxt): apply `isScriptProtocol` guard to `navigateTo` open option

### DIFF
--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -156,6 +156,11 @@ export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: Na
 
   // Early open handler
   if (import.meta.client && options?.open) {
+    const { protocol } = new URL(toPath, window.location.href)
+    if (protocol && isScriptProtocol(protocol)) {
+      throw new Error(`Cannot navigate to a URL with '${protocol}' protocol.`)
+    }
+
     const { target = '_blank', windowFeatures = {} } = options.open
 
     const features: string[] = []

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -638,6 +638,32 @@ describe('routing utilities: `navigateTo`', () => {
       expect(() => navigateTo(url, { external: true })).toThrow(`Cannot navigate to a URL with '${protocol}:' protocol.`)
     }
   })
+  it('navigateTo should disallow opening data/script URLs via the `open` option', () => {
+    const open = vi.spyOn(window, 'open').mockImplementation(() => null)
+    try {
+      const urls = [
+        ['javascript:alert("hi")', 'javascript'],
+        ['data:alert("hi")', 'data'],
+        ['vbscript:alert("hi")', 'vbscript'],
+        ['\0javascript:alert("hi")', 'javascript'],
+      ]
+      for (const [url, protocol] of urls) {
+        expect(() => navigateTo(url, { open: { target: '_blank' } })).toThrow(`Cannot navigate to a URL with '${protocol}:' protocol.`)
+      }
+      expect(open).not.toHaveBeenCalled()
+    } finally {
+      open.mockRestore()
+    }
+  })
+  it('navigateTo should still allow opening safe URLs via the `open` option', () => {
+    const open = vi.spyOn(window, 'open').mockImplementation(() => null)
+    try {
+      expect(() => navigateTo('https://example.com', { open: { target: '_blank' } })).not.toThrow()
+      expect(open).toHaveBeenCalledWith('https://example.com', '_blank', '')
+    } finally {
+      open.mockRestore()
+    }
+  })
   it('reloadNuxtApp should disallow paths with data/script URLs', () => {
     const urls = [
       ['javascript:alert("hi")', 'javascript'],


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

browsers guard against calling `window.open`

`navigateTo(url, { external: true })` rejects script protocol urls (like `javascript:`) via `isScriptProtocol`, but the `open` branch returns early and skips that check.

this duplicates the existing check in this branch so both reject with the same error.