### PR TITLE
docs: edit for clarity and grammar

### DIFF
--- a/docs/4.api/5.kit/12.resolving.md
+++ b/docs/4.api/5.kit/12.resolving.md
@@ -8,11 +8,11 @@ links:
     size: xs
 ---
 
-Sometimes you need to resolve a paths: relative to the current module, with unknown name or extension. For example, you may want to add a plugin that is located in the same directory as the module. To handle this cases, nuxt provides a set of utilities to resolve paths. `resolvePath` and `resolveAlias` are used to resolve paths relative to the current module. `findPath` is used to find first existing file in given paths. `createResolver` is used to create resolver relative to base path.
+Sometimes you need to resolve a path relative to the current module without knowing the name or extension. For example, you may want to add a plugin that is located in the same directory as the module. To handle these cases, Nuxt provides a set of utilities to resolve paths. `resolvePath` and `resolveAlias` are used to resolve paths relative to the current module. `findPath` is used to find the first existing file in a given set of paths. `createResolver` is used to create a resolver relative to the base path.
 
 ## `resolvePath`
 
-Resolves full path to a file or directory respecting Nuxt alias and extensions options. If path could not be resolved, normalized input path will be returned.
+Resolves the full path to a file or directory, respecting Nuxt alias and extensions options. If a path could not be resolved, a normalized input path will be returned.
 
 ### Usage
 
@@ -115,7 +115,7 @@ function resolveAlias (path: string, alias?: Record<string, string>): string
 
 ## `findPath`
 
-Try to resolve first existing file in given paths.
+Try to resolve first existing file in a given set of paths.
 
 ### Usage
 


### PR DESCRIPTION
Corrected grammar and improved clarity in the documentation regarding path resolution utilities in Nuxt.

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This was already fixed on 3.x, but didn't carry over to 4.x (or probably 5.x). See: https://github.com/nuxt/nuxt/pull/34093/changes

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
