### PR TITLE
fix(vite): inline CSS for lazy components imported from `#components`

### DIFF
--- a/packages/vite/src/plugins/ssr-styles.ts
+++ b/packages/vite/src/plugins/ssr-styles.ts
@@ -49,14 +49,27 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
       }
     }
 
+    // Build an index of manifest entries by their source path so we can look
+    // up chunks matched to the source paths tracked in `chunksWithInlinedCSS`.
+    const manifestBySrc = new Map<string, { chunk: (typeof manifest)[string], key: string }>()
+    for (const [key, chunk] of Object.entries(manifest)) {
+      if (chunk.src) {
+        manifestBySrc.set(chunk.src, { chunk, key })
+      }
+    }
+
     for (const id of chunksWithInlinedCSS) {
-      const chunk = manifest[id]
-      if (!chunk) {
+      const entry = manifestBySrc.get(id)
+      if (!entry) {
         continue
       }
+      const { chunk } = entry
       if (chunk.isEntry && chunk.src) {
         entryIds.add(chunk.src)
       } else {
+        if (chunk.src) {
+          entryIds.add(chunk.src)
+        }
         chunk.css &&= []
       }
       // Rolldown may split a component into a facade chunk (with no CSS) and
@@ -275,7 +288,7 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
 
             const relativePath = relativeToSrcDir(stripQuery(moduleId))
             if (relativePath in cssMap) {
-              cssMap[relativePath]!.inBundle = cssMap[relativePath]!.inBundle ?? ((isVue(moduleId) && !!relativePath) || isEntry)
+              cssMap[relativePath]!.inBundle = cssMap[relativePath]!.inBundle ?? ((isVue(stripQuery(moduleId)) && !!relativePath) || isEntry)
             }
           }
 

--- a/packages/vite/src/plugins/ssr-styles.ts
+++ b/packages/vite/src/plugins/ssr-styles.ts
@@ -49,27 +49,14 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
       }
     }
 
-    // Build an index of manifest entries by their source path so we can look
-    // up chunks matched to the source paths tracked in `chunksWithInlinedCSS`.
-    const manifestBySrc = new Map<string, { chunk: (typeof manifest)[string], key: string }>()
-    for (const [key, chunk] of Object.entries(manifest)) {
-      if (chunk.src) {
-        manifestBySrc.set(chunk.src, { chunk, key })
-      }
-    }
-
     for (const id of chunksWithInlinedCSS) {
-      const entry = manifestBySrc.get(id)
-      if (!entry) {
+      const chunk = manifest[id]
+      if (!chunk) {
         continue
       }
-      const { chunk } = entry
       if (chunk.isEntry && chunk.src) {
         entryIds.add(chunk.src)
       } else {
-        if (chunk.src) {
-          entryIds.add(chunk.src)
-        }
         chunk.css &&= []
       }
       // Rolldown may split a component into a facade chunk (with no CSS) and

--- a/test/fixtures/inline-styles/components/WithLazyStyles.css
+++ b/test/fixtures/inline-styles/components/WithLazyStyles.css
@@ -1,0 +1,3 @@
+.lazy-css-import {
+  --inline-lazy-import-token: lazy-import;
+}

--- a/test/fixtures/inline-styles/components/WithLazyStyles.vue
+++ b/test/fixtures/inline-styles/components/WithLazyStyles.vue
@@ -1,5 +1,7 @@
 <template>
-  <div class="lazy-css-import">styled content</div>
+  <div class="lazy-css-import">
+    styled content
+  </div>
 </template>
 
 <style src="./WithLazyStyles.css"></style>

--- a/test/fixtures/inline-styles/components/WithLazyStyles.vue
+++ b/test/fixtures/inline-styles/components/WithLazyStyles.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="lazy-css-import">styled content</div>
+</template>
+
+<style src="./WithLazyStyles.css"></style>

--- a/test/fixtures/inline-styles/pages/lazy-import.vue
+++ b/test/fixtures/inline-styles/pages/lazy-import.vue
@@ -5,5 +5,5 @@
 </template>
 
 <script setup lang="ts">
-import { LazyWithLazyStyles } from '#components';
+import { LazyWithLazyStyles } from '#components'
 </script>

--- a/test/fixtures/inline-styles/pages/lazy-import.vue
+++ b/test/fixtures/inline-styles/pages/lazy-import.vue
@@ -1,0 +1,9 @@
+<template>
+  <main>
+    <lazy-with-lazy-styles hydrate-never />
+  </main>
+</template>
+
+<script setup lang="ts">
+import { LazyWithLazyStyles } from '#components';
+</script>

--- a/test/inline-styles.test.ts
+++ b/test/inline-styles.test.ts
@@ -39,8 +39,12 @@ describe.skipIf(builder !== 'vite' || !isBuilt)('inline styles', () => {
 
   // https://github.com/nuxt/nuxt/issues/35188
   it('inlines CSS for a lazy component explicitly imported from #components', async () => {
+    // Check the style is in the HTML
     const html = await readFile(join(outputDir, 'public', 'lazy-import/index.html'), 'utf-8')
     expect(html).toContain('--inline-lazy-import-token:lazy-import')
+    // Ensure there are no linked stylesheets
+    const cssLinks = [...html.matchAll(/<link [^>]*rel="stylesheet"[^>]*href="([^"]+)"/g)].map(m => m[1]!)
+    expect(cssLinks).toEqual([])
   })
 
   // https://github.com/nuxt/nuxt/issues/27417

--- a/test/inline-styles.test.ts
+++ b/test/inline-styles.test.ts
@@ -37,6 +37,12 @@ describe.skipIf(builder !== 'vite' || !isBuilt)('inline styles', () => {
     expect(html).toContain('--island-child-token:child')
   })
 
+  // https://github.com/nuxt/nuxt/issues/35188
+  it('inlines CSS for a lazy component explicitly imported from #components', async () => {
+    const html = await readFile(join(outputDir, 'public', 'lazy-import/index.html'), 'utf-8')
+    expect(html).toContain('--inline-lazy-import-token:lazy-import')
+  })
+
   // https://github.com/nuxt/nuxt/issues/27417
   // https://github.com/nuxt/nuxt/issues/35065
   it.each([


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

resolves https://github.com/nuxt/nuxt/issues/35188

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

When the component was imported from `#components`, the manifest Id was appended with a query string which then caused the `isVue` check to fail. 

For full disclosure, AI was used to produce this fix. I asked it to produce a test to confirm the bug. I implemented the fix it suggested, and then the test passed. 


<details>

<summary>AI Analysis</summary>


## Problem

When using `features.inlineStyles`, styles of lazy components (e.g., `LazyMyComponent` from `#components`) are rendered as `<link rel="stylesheet">` instead of being inlined as `<style>` tags.

## Root Cause

In `packages/vite/src/plugins/ssr-styles.ts`, the `renderChunk` hook sets an `inBundle` flag to track which modules have CSS that should be inlined:

```ts
cssMap[relativePath]!.inBundle = cssMap[relativePath]!.inBundle ??
  ((isVue(moduleId) && !!relativePath) || isEntry)
```

Nuxt wraps lazy components with a `?nuxt_component=async&...` query string. When Vite/Rolldown includes these modules in SSR chunks, the module IDs are:

```
WithLazyStyles.vue?nuxt_component=async&nuxt_component_name=WithLazyStyles&nuxt_component_export=default
```

`isVue(id)` checks `id.endsWith('.vue')`, but the string ends with `nuxt_component_export=default`, so it returns `false`.

Since `??` only replaces `null`/`undefined` (not `false`), `inBundle` is set to `false` on first encounter and stays `false` — even when the bare `.vue` module ID appears later in the iteration. `generateBundle` then skips this entry because `!inBundle`, and the CSS is never emitted as an inline style module.

## Fix

Strip the query string before the `isVue` check:

```diff
- cssMap[relativePath]!.inBundle = cssMap[relativePath]!.inBundle ?? ((isVue(moduleId) && !!relativePath) || isEntry)
+ cssMap[relativePath]!.inBundle = cssMap[relativePath]!.inBundle ?? ((isVue(stripQuery(moduleId)) && !!relativePath) || isEntry)
```

`stripQuery(moduleId)` removes the `?nuxt_component=...` query, producing `WithLazyStyles.vue`, which correctly passes `isVue` and sets `inBundle = true`.

## Files Changed

- `packages/vite/src/plugins/ssr-styles.ts` — One-line fix: `isVue(stripQuery(moduleId))` instead of `isVue(moduleId)`
- `test/inline-styles.test.ts` — New test case: `inlines CSS for a lazy component explicitly imported from #components`
- `test/fixtures/inline-styles/` — New fixture: `WithLazyStyles.vue`, `WithLazyStyles.css`, `lazy-import.vue`

## Verification

All 28 inline-styles tests pass across all 4 vite-built project configurations.


</details>



<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
