### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/docs/3.guide/1.concepts/8.typescript.md
+++ b/docs/3.guide/1.concepts/8.typescript.md
@@ -99,6 +99,21 @@ Similarly:
 - For the `server` context, place the augmentation file in the `server/` directory.
 - For types that are **shared between the app and server**, place the file in the `shared/` directory.
 
+If you keep files outside these directories, include them explicitly in the matching generated TypeScript configuration:
+
+<!-- @case-police-ignore tsConfig -->
+```ts twoslash [nuxt.config.ts]
+export default defineNuxtConfig({
+  typescript: {
+    tsConfig: {
+      include: ['../test/other-nuxt-context/**/*'],
+    },
+  },
+})
+```
+
+Use `typescript.tsConfig` for files that rely on the Nuxt app context, such as auto-imports and aliases. For example, `test/nuxt/` and `tests/nuxt/` are included by default, but other test directories that use the Nuxt runtime need to be added manually. Use `typescript.nodeTsConfig` for Node-only files, and `typescript.sharedTsConfig` for files that should be available in both app and server contexts.
+
 ::read-more{to="/docs/4.x/guide/modules/recipes-advanced#extend-typescript-config"}
 Read more about augmenting specific type contexts from **files outside those contexts** in the Module Author Guide.
 ::

--- a/docs/4.api/6.nuxt-config.md
+++ b/docs/4.api/6.nuxt-config.md
@@ -1544,6 +1544,20 @@ TypeScript comes with certain checks to give you more safety and analysis of you
 
 You can extend the generated TypeScript configurations (`.nuxt/tsconfig.app.json`, `.nuxt/tsconfig.server.json`, etc.) using this option.
 
+Files outside Nuxt's standard type contexts are not type-checked automatically. Add them to the appropriate generated config with `include` when they need Nuxt app types:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  typescript: {
+    tsConfig: {
+      include: ['../test/other-nuxt-context/**/*'],
+    },
+  },
+})
+```
+
+For tests, `test/nuxt/` and `tests/nuxt/` are included by default. Add other test directories manually only when they need the Nuxt app context. Use `nodeTsConfig` for Node-only files and `sharedTsConfig` for files shared between app and server contexts.
+
 ### `typeCheck`
 
 Enable build-time type checking.


### PR DESCRIPTION
### Summary
- documented how to include custom files in the matching generated TypeScript config
- clarified that `typescript.tsConfig` is for files that need the Nuxt app context
- noted that `test/nuxt/` and `tests/nuxt/` are already included by default

Closes #34756

### Checks
- `node_modules/.bin/markdownlint --ignore-path=.gitignore docs/3.guide/1.concepts/8.typescript.md docs/4.api/6.nuxt-config.md`
- `node_modules/.bin/case-police docs/3.guide/1.concepts/8.typescript.md docs/4.api/6.nuxt-config.md`
- `node_modules/.bin/eslint docs/3.guide/1.concepts/8.typescript.md docs/4.api/6.nuxt-config.md --cache`
- `git diff --check`