### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/docs/4.api/2.composables/use-async-data.md
+++ b/docs/4.api/2.composables/use-async-data.md
@@ -232,24 +232,24 @@ If you have not fetched data on the server (for example, with `server: false`), 
 ```ts [Signature]
 export type AsyncDataHandler<ResT> = (nuxtApp: NuxtApp, options: { signal: AbortSignal }) => Promise<ResT>
 
-export function useAsyncData<DataT, DataE> (
-  handler: AsyncDataHandler<DataT>,
-  options?: AsyncDataOptions<DataT>,
+export function useAsyncData<ResT, DataT = ResT, DataE = unknown> (
+  handler: AsyncDataHandler<ResT>,
+  options?: AsyncDataOptions<ResT, DataT>,
 ): AsyncData<DataT, DataE>
-export function useAsyncData<DataT, DataE> (
+export function useAsyncData<ResT, DataT = ResT, DataE = unknown> (
   key: MaybeRefOrGetter<string>,
-  handler: AsyncDataHandler<DataT>,
-  options?: AsyncDataOptions<DataT>,
+  handler: AsyncDataHandler<ResT>,
+  options?: AsyncDataOptions<ResT, DataT>,
 ): Promise<AsyncData<DataT, DataE>>
 
-type AsyncDataOptions<DataT> = {
+type AsyncDataOptions<ResT, DataT = ResT> = {
   server?: boolean
   lazy?: boolean
   immediate?: boolean
   deep?: boolean
   dedupe?: 'cancel' | 'defer'
   default?: () => DataT | Ref<DataT> | null
-  transform?: (input: DataT) => DataT | Promise<DataT>
+  transform?: (input: ResT) => DataT | Promise<DataT>
   pick?: string[]
   watch?: MultiWatchSources | false
   getCachedData?: (key: string, nuxtApp: NuxtApp, ctx: AsyncDataRequestContext) => DataT | undefined

--- a/docs/4.api/2.composables/use-fetch.md
+++ b/docs/4.api/2.composables/use-fetch.md
@@ -126,12 +126,12 @@ searchQuery.value = 'new search'
 ## Type
 
 ```ts [Signature]
-export function useFetch<DataT, ErrorT> (
+export function useFetch<ResT, DataT = ResT, ErrorT = FetchError> (
   url: string | Request | Ref<string | Request> | (() => string | Request),
-  options?: UseFetchOptions<DataT>,
+  options?: UseFetchOptions<ResT, DataT>,
 ): Promise<AsyncData<DataT, ErrorT>>
 
-type UseFetchOptions<DataT> = {
+type UseFetchOptions<ResT, DataT = ResT> = {
   key?: MaybeRefOrGetter<string>
   method?: MaybeRefOrGetter<string>
   query?: MaybeRefOrGetter<SearchParams>
@@ -148,7 +148,7 @@ type UseFetchOptions<DataT> = {
   dedupe?: 'cancel' | 'defer'
   timeout?: number
   default?: () => DataT
-  transform?: (input: DataT) => DataT | Promise<DataT>
+  transform?: (input: ResT) => DataT | Promise<DataT>
   pick?: string[]
   $fetch?: typeof globalThis.$fetch
   watch?: MultiWatchSources | false


### PR DESCRIPTION
### Summary
- updated the documented `AsyncDataOptions` type so `transform` receives the raw handler result type and returns the transformed data type
- mirrored the same `transform` type shape in the documented `UseFetchOptions` type, which extends async data options

Closes #23114

### Checks
- `node_modules/.bin/markdownlint --ignore-path=.gitignore docs/4.api/2.composables/use-async-data.md docs/4.api/2.composables/use-fetch.md`
- `node_modules/.bin/case-police docs/4.api/2.composables/use-async-data.md docs/4.api/2.composables/use-fetch.md`
- `node_modules/.bin/eslint docs/4.api/2.composables/use-async-data.md docs/4.api/2.composables/use-fetch.md --cache`
- `git diff --check`