### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/docs/4.api/2.composables/use-request-fetch.md
+++ b/docs/4.api/2.composables/use-request-fetch.md
@@ -22,6 +22,11 @@ Headers that are **not meant to be forwarded** will **not be included** in the r
 The [`useFetch`](/docs/4.x/api/composables/use-fetch) composable uses `useRequestFetch` under the hood to automatically forward the request context and headers.
 ::
 
+::note
+This also applies to request-scoped runtime context on server presets such as Cloudflare Workers and Cloudflare Pages.
+For example, if an internal server route reads Cloudflare bindings from `event.context`, call it with `useRequestFetch` inside [`useAsyncData`](/docs/4.x/api/composables/use-async-data), or use [`useFetch`](/docs/4.x/api/composables/use-fetch) with a relative URL, so the route receives the current request event context.
+::
+
 ::code-group
 
 ```vue [app/pages/index.vue]

--- a/docs/4.api/3.utils/$fetch.md
+++ b/docs/4.api/3.utils/$fetch.md
@@ -97,4 +97,8 @@ const { data } = await useAsyncData(() => requestFetch('/api/cookies'))
 </script>
 ```
 
+The same applies to request-scoped runtime context.
+For example, on Cloudflare Workers or Cloudflare Pages, server routes that read Cloudflare bindings from `event.context` need the current request context forwarded.
+Use `useRequestFetch` inside `useAsyncData`, or call the relative route with `useFetch`, instead of calling the route with `$fetch` directly.
+
 However, when calling `useFetch` with a relative URL on the server, Nuxt will use [`useRequestFetch`](/docs/4.x/api/composables/use-request-fetch) to proxy headers and cookies (with the exception of headers not meant to be forwarded, like `host`).


### PR DESCRIPTION
## Summary

- Documented that Cloudflare Workers/Pages request context needs `useRequestFetch` or relative `useFetch` when an internal route is called from `useAsyncData`.
- Clarified the same limitation on the `$fetch` page alongside the existing headers and cookies guidance.

Closes #30433

## Checks

- `node_modules/.bin/markdownlint --ignore-path=.gitignore docs/4.api/2.composables/use-request-fetch.md docs/4.api/3.utils/$fetch.md`
- `node_modules/.bin/case-police docs/4.api/2.composables/use-request-fetch.md docs/4.api/3.utils/$fetch.md`
- `node_modules/.bin/eslint docs/4.api/2.composables/use-request-fetch.md docs/4.api/3.utils/$fetch.md --cache`
- `git diff --check`