### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/packages/nuxt/src/app/components/utils.ts
+++ b/packages/nuxt/src/app/components/utils.ts
@@ -18,6 +18,7 @@ export const _wrapInTransition = (props: any, children: any): { default: () => V
 const ROUTE_KEY_PARENTHESES_RE = /(:\w+)\([^)]+\)/g
 const ROUTE_KEY_SYMBOLS_RE = /(:\w+)[?+*]/g
 const ROUTE_KEY_NORMAL_RE = /:\w+/g
+const ROUTE_RECORD_PARAM_RE = /:(\w+)(?:\([^)]*\))?[?+*]?/g
 // TODO: consider refactoring into single utility
 // See https://github.com/nuxt/nuxt/blob/main/packages/nuxt/src/pages/runtime/utils.ts#L8-L19
 function generateRouteKey (route: RouteLocationNormalized) {
@@ -45,6 +46,49 @@ export function isChangingPage (to: RouteLocationNormalized, from: RouteLocation
     return false
   }
   return true
+}
+
+/**
+ * Utility used within router guards
+ * return true if navigation keeps the same parent page and only changes a nested page
+ */
+export function isChangingOnlyNestedPage (to: RouteLocationNormalized, from: RouteLocationNormalized): boolean {
+  if (to === from || from === START_LOCATION) { return false }
+
+  let commonDepth = 0
+  const maxDepth = Math.min(to.matched.length, from.matched.length)
+  for (let index = 0; index < maxDepth; index++) {
+    const toMatched = to.matched[index]
+    const fromMatched = from.matched[index]
+
+    if (toMatched !== fromMatched) { break }
+    if (hasRouteRecordParamChanged(toMatched.path, to.params, from.params)) { break }
+
+    commonDepth++
+  }
+
+  return commonDepth > 0 && (to.matched.length > commonDepth || from.matched.length > commonDepth)
+}
+
+function hasRouteRecordParamChanged (
+  path: string,
+  toParams: RouteLocationNormalized['params'],
+  fromParams: RouteLocationNormalized['params'],
+) {
+  for (const param of getRouteRecordParamKeys(path)) {
+    if (normalizeRouteParam(toParams[param]) !== normalizeRouteParam(fromParams[param])) {
+      return true
+    }
+  }
+  return false
+}
+
+function getRouteRecordParamKeys (path: string) {
+  return Array.from(path.matchAll(ROUTE_RECORD_PARAM_RE), match => match[1]!)
+}
+
+function normalizeRouteParam (value: RouteLocationNormalized['params'][string]) {
+  return Array.isArray(value) ? value.join('/') : value
 }
 
 export type SSRBuffer = SSRBufferItem[] & { hasAsync?: boolean }

--- a/packages/nuxt/src/pages/runtime/router.options.ts
+++ b/packages/nuxt/src/pages/runtime/router.options.ts
@@ -2,7 +2,7 @@ import { START_LOCATION } from 'vue-router'
 import type { RouteLocationNormalized, RouterScrollBehavior } from 'vue-router'
 import type { RouterConfig } from 'nuxt/schema'
 import { useNuxtApp } from '#app/nuxt'
-import { isChangingPage } from '#app/components/utils'
+import { isChangingOnlyNestedPage, isChangingPage } from '#app/components/utils'
 import { useRouter } from '#app/composables/router'
 
 type ScrollPosition = Awaited<ReturnType<RouterScrollBehavior>>
@@ -30,6 +30,10 @@ export default <RouterConfig>{
     const routeAllowsScrollToTop = typeof to.meta.scrollToTop === 'function' ? to.meta.scrollToTop(to, from) : to.meta.scrollToTop
 
     if (routeAllowsScrollToTop === false) { return false }
+
+    if (routeAllowsScrollToTop !== true && !savedPosition && !to.hash && isChangingOnlyNestedPage(to, from)) {
+      return false
+    }
 
     if (from === START_LOCATION) {
       return _calculatePosition(to, from, savedPosition, hashScrollBehaviour)

--- a/test/nuxt/router.options.test.ts
+++ b/test/nuxt/router.options.test.ts
@@ -339,6 +339,108 @@ describe('scrollBehavior with scrollToTop and fixed page key', () => {
   })
 })
 
+describe('scrollBehavior with nested pages', () => {
+  let router: ReturnType<typeof useRouter>
+  let nuxtApp: ReturnType<typeof useNuxtApp>
+
+  let wrapper: VueWrapper<unknown>
+  let scrollTo: ReturnType<typeof vi.spyOn>
+  const cleanups: Array<() => void> = []
+
+  const pageLoadingEnd = vi.fn()
+
+  beforeAll(async () => {
+    router = useRouter()
+    nuxtApp = useNuxtApp()
+
+    cleanups.push(router.addRoute({
+      name: 'nested-scroll',
+      path: '/nested-scroll',
+      component: NestedPageParent,
+      children: [
+        { path: 'one', component: defineComponent({ setup: () => () => h('div', 'Nested one') }) },
+        { path: 'two', component: defineComponent({ setup: () => () => h('div', 'Nested two') }) },
+        {
+          path: 'force/:id',
+          meta: { scrollToTop: true },
+          component: defineComponent({ setup: () => () => h('div', 'Nested force') }),
+        },
+      ],
+    }))
+
+    cleanups.push(router.addRoute({
+      name: 'nested-scroll-param',
+      path: '/nested-scroll-param/:parentId',
+      component: NestedPageParent,
+      children: [
+        { path: ':childId', component: defineComponent({ setup: () => () => h('div', 'Nested param') }) },
+      ],
+    }))
+
+    cleanups.push(nuxtApp.hook('page:loading:end', pageLoadingEnd))
+
+    wrapper = await mountSuspended(defineComponent({
+      setup: () => () => h(NuxtPage),
+    }))
+    await flushPromises()
+  })
+
+  beforeEach(async () => {
+    await navigateTo('/')
+    await flushPromises()
+    vi.clearAllMocks()
+    scrollTo = vi.spyOn(globalThis, 'scrollTo').mockImplementation(() => { })
+  })
+
+  afterAll(() => {
+    wrapper.unmount()
+    for (const cleanup of cleanups) {
+      cleanup()
+    }
+  })
+
+  async function waitForNavigation () {
+    await flushPromises()
+    await expect.poll(() => pageLoadingEnd.mock.calls.length).toBeGreaterThan(0)
+  }
+
+  it('should keep window scroll when only the nested page changes', async () => {
+    await navigateTo('/nested-scroll/one')
+    await waitForNavigation()
+    await expect.poll(() => scrollTo.mock.calls.length).toBeGreaterThan(0)
+    vi.clearAllMocks()
+
+    await navigateTo('/nested-scroll/two')
+    await waitForNavigation()
+
+    expect(scrollTo).not.toHaveBeenCalled()
+  })
+
+  it('should scroll to top when a parent page param changes', async () => {
+    await navigateTo('/nested-scroll-param/one/a')
+    await waitForNavigation()
+    await expect.poll(() => scrollTo.mock.calls.length).toBeGreaterThan(0)
+    vi.clearAllMocks()
+
+    await navigateTo('/nested-scroll-param/two/a')
+    await waitForNavigation()
+
+    expect(scrollTo).toHaveBeenCalledWith({ left: 0, top: 0 })
+  })
+
+  it('should scroll to top on nested page changes when explicitly enabled', async () => {
+    await navigateTo('/nested-scroll/force/one')
+    await waitForNavigation()
+    await expect.poll(() => scrollTo.mock.calls.length).toBeGreaterThan(0)
+    vi.clearAllMocks()
+
+    await navigateTo('/nested-scroll/force/two')
+    await waitForNavigation()
+
+    expect(scrollTo).toHaveBeenCalledWith({ left: 0, top: 0 })
+  })
+})
+
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
 
 const NestedPageParent = defineComponent({


### PR DESCRIPTION
## Summary

- Preserve the window scroll position when navigation only changes a nested page under the same parent route.
- Keep scrolling to top when a parent route param changes or when `scrollToTop: true` explicitly requests it.
- Added router scroll behavior coverage for nested page changes, parent param changes, and explicit nested scroll opt-in.

Closes #31638

## Checks

- `node_modules/.bin/vitest run --project nuxt --project nuxt-legacy test/nuxt/router.options.test.ts`
- `node_modules/.bin/eslint . --cache`
- `git diff --check`