### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/packages/nuxt/src/components/plugins/lazy-hydration-transform.ts
+++ b/packages/nuxt/src/components/plugins/lazy-hydration-transform.ts
@@ -1,6 +1,6 @@
 import { createUnplugin } from 'unplugin'
 import { generateTransform, rolldownString } from 'rolldown-string'
-import { camelCase, pascalCase } from 'scule'
+import { camelCase, kebabCase, pascalCase } from 'scule'
 
 import { tryUseNuxt } from '@nuxt/kit'
 import { parse, walk } from 'ultrahtml'
@@ -15,7 +15,10 @@ interface LoaderOptions {
 }
 
 const SCRIPT_RE = /(?<=<script[^>]*>)[\s\S]*?(?=<\/script>)/gi
-const TEMPLATE_RE = /<template>([\s\S]*)<\/template>/
+const TEMPLATE_RE = /<template(?<attrs>[^>]*)>(?<content>[\s\S]*)<\/template>/
+const PUG_LANG_RE = /\blang\s*=\s*(?:"pug"|'pug'|pug)(?=\s|$)/
+const PUG_LINE_RE = /.*(?:\r?\n|$)/g
+const PUG_TAG_RE = /^(\s*)([a-z][\w-]*)(?=[\s(.#]|$)/i
 const hydrationStrategyMap = {
   hydrateOnIdle: 'Idle',
   hydrateOnVisible: 'Visible',
@@ -26,7 +29,8 @@ const hydrationStrategyMap = {
   hydrateNever: 'Never',
 }
 
-const TEMPLATE_WITH_LAZY_HYDRATION_RE = /<template>[\s\S]*\b(?:hydrate-on-idle|hydrateOnIdle|hydrate-on-visible|hydrateOnVisible|hydrate-on-interaction|hydrateOnInteraction|hydrate-on-media-query|hydrateOnMediaQuery|hydrate-after|hydrateAfter|hydrate-when|hydrateWhen|hydrate-never|hydrateNever)\b[\s\S]*<\/template>/
+const hydrationStrategyAttrs = Object.entries(hydrationStrategyMap).flatMap(([prop, strategy]) => [[prop, strategy], [kebabCase(prop), strategy]] as const)
+const TEMPLATE_WITH_LAZY_HYDRATION_RE = /<template(?:\s[^>]*)?>[\s\S]*\b(?:hydrate-on-idle|hydrateOnIdle|hydrate-on-visible|hydrateOnVisible|hydrate-on-interaction|hydrateOnInteraction|hydrate-on-media-query|hydrateOnMediaQuery|hydrate-after|hydrateAfter|hydrate-when|hydrateWhen|hydrate-never|hydrateNever)\b[\s\S]*<\/template>/
 
 export const LazyHydrationTransformPlugin = (options: LoaderOptions) => createUnplugin(() => {
   const exclude = options.transform?.exclude || []
@@ -46,19 +50,20 @@ export const LazyHydrationTransformPlugin = (options: LoaderOptions) => createUn
       return isVue(id)
     },
     transform: {
-      filter: {
-        code: { include: TEMPLATE_WITH_LAZY_HYDRATION_RE },
-      },
-
       async handler (code, id, meta?: unknown) {
-        // change <LazyMyComponent hydrate-on-idle /> to <LazyIdleMyComponent hydrate-on-idle />
-        const { 0: template, index: offset = 0 } = code.match(TEMPLATE_RE) || {}
-        if (!template) {
+        if (!TEMPLATE_WITH_LAZY_HYDRATION_RE.test(code)) {
           return
         }
-        try {
-          const ast = parse(template)
 
+        // change <LazyMyComponent hydrate-on-idle /> to <LazyIdleMyComponent hydrate-on-idle />
+        const templateMatch = code.match(TEMPLATE_RE)
+        if (!templateMatch?.groups) {
+          return
+        }
+        const { 0: template, index: offset = 0 } = templateMatch
+        const { attrs = '', content = '' } = templateMatch.groups
+
+        try {
           const scopeTracker = new ScopeTracker({ preserveExitedScopes: true })
           for (const { 0: script } of code.matchAll(SCRIPT_RE)) {
             if (!script) { continue }
@@ -70,6 +75,20 @@ export const LazyHydrationTransformPlugin = (options: LoaderOptions) => createUn
           const s = rolldownString(code, id, meta)
 
           const components = new Set(options.getComponents().map(c => c.pascalName))
+          if (PUG_LANG_RE.test(attrs)) {
+            transformPugTemplate({
+              components,
+              content,
+              contentOffset: offset + template.indexOf('>') + 1,
+              id,
+              nuxt,
+              s,
+              scopeTracker,
+            })
+            return generateTransform(s, id)
+          }
+
+          const ast = parse(template)
           await walk(ast, (node) => {
             if (node.type !== 1 /* ELEMENT_NODE */) {
               return
@@ -129,3 +148,62 @@ export const LazyHydrationTransformPlugin = (options: LoaderOptions) => createUn
     },
   }
 })
+
+function transformPugTemplate (ctx: {
+  components: Set<string>
+  content: string
+  contentOffset: number
+  id: string
+  nuxt: ReturnType<typeof tryUseNuxt>
+  s: ReturnType<typeof rolldownString>
+  scopeTracker: ScopeTracker
+}) {
+  for (const match of ctx.content.matchAll(PUG_LINE_RE)) {
+    const line = match[0]
+    if (!line) { continue }
+
+    const tagMatch = PUG_TAG_RE.exec(line)
+    if (!tagMatch) { continue }
+
+    const [, indent, name] = tagMatch
+    if (ctx.scopeTracker.getDeclaration(name)) {
+      continue
+    }
+
+    const pascalName = pascalCase(name.replace(/^(?:Lazy|lazy-)/, ''))
+    if (!ctx.components.has(pascalName)) {
+      continue
+    }
+
+    const strategy = getPugHydrationStrategy(line)
+    if (strategy && !/^(?:Lazy|lazy-)/.test(name)) {
+      if (name !== 'template' && (ctx.nuxt?.options.dev || ctx.nuxt?.options.test)) {
+        const relativePath = resolveToAlias(ctx.id, ctx.nuxt)
+        logger.warn(`Component \`<${name}>\` (used in \`${relativePath}\`) has lazy-hydration props but is not declared as a lazy component.\n` +
+          `Rename it to \`<Lazy${pascalCase(name)} />\` or remove the lazy-hydration props to avoid unexpected behavior.`)
+      }
+      continue
+    }
+
+    if (strategy) {
+      const newName = 'Lazy' + strategy + pascalName
+      const start = ctx.contentOffset + match.index + indent.length
+      ctx.s.overwrite(start, start + name.length, newName)
+    }
+  }
+}
+
+function getPugHydrationStrategy (line: string) {
+  let strategy: string | undefined
+  for (const [attr, value] of hydrationStrategyAttrs) {
+    const pattern = new RegExp(String.raw`(?:^|[\s(:,])(?::|v-bind:)?${attr}(?=$|[\s=),])`)
+    if (!pattern.test(line)) { continue }
+
+    if (strategy) {
+      logger.warn(`Multiple hydration strategies are not supported in the same component`)
+    } else {
+      strategy = value
+    }
+  }
+  return strategy
+}

--- a/packages/nuxt/test/component-loader.test.ts
+++ b/packages/nuxt/test/component-loader.test.ts
@@ -292,6 +292,27 @@ export default {
     const result = await transform(sfc, '/pages/index.vue').then(r => r.split('\n'))
     expect(result.join('\n')).toContain(component)
   })
+
+  it('should correctly resolve lazy hydration components in pug templates', async () => {
+    const sfc = `
+    <template lang="pug">
+      div
+        LazyMyComponent(:hydrate-on-visible="{ threshold: 0.2 }")
+        LazyMyComponent(hydrate-never)
+        LazyMyComponent(:hydrateAfter="3000")
+    </template>
+    `
+    const result = await transform(sfc, '/pages/index.vue').then(r => r.split('\n'))
+    const imports = result.filter(l => l.startsWith('import'))
+    expect(imports.join('\n')).toContain('createLazyNeverComponent')
+    expect(imports.join('\n')).toContain('createLazyTimeComponent')
+    expect(imports.join('\n')).toContain('createLazyVisibleComponent')
+
+    const code = result.join('\n')
+    expect(code).toContain('__nuxt_component_0_lazy_visible')
+    expect(code).toContain('__nuxt_component_0_lazy_never')
+    expect(code).toContain('__nuxt_component_0_lazy_time')
+  })
 })
 const components = ([{ name: 'MyComponent', filePath: '/components/MyComponent.vue' }] as AddComponentOptions[]).map(opts => ({
   export: opts.export || 'default',
@@ -324,7 +345,7 @@ function normalizeCode (code: string) {
 async function transform (code: string, filename: string) {
   const bundle = await rolldown({
     input: filename,
-    external: id => id !== filename,
+    external: id => id !== filename && !id.startsWith(filename + '?'),
     plugins: [
       {
         name: 'entry',


### PR DESCRIPTION
## Summary

- Added a pug-template path for the lazy hydration transform before Vue compiles the SFC.
- Renames lazy component tags with hydration props in `<template lang="pug">` so the component loader imports the matching lazy hydration wrapper.
- Added component-loader coverage for pug templates with visible, never, and time-based hydration strategies.

Closes #31604

## Checks

- `node_modules/.bin/vitest run --project unit packages/nuxt/test/component-loader.test.ts`
- `node_modules/.bin/eslint packages/nuxt/src/components/plugins/lazy-hydration-transform.ts packages/nuxt/test/component-loader.test.ts --cache`
- `git diff --check`