### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/packages/nitro-server/src/augments.ts
+++ b/packages/nitro-server/src/augments.ts
@@ -9,6 +9,7 @@ declare module 'nitro/types' {
     baseURL: string
     buildAssetsDir: string
     cdnURL: string
+    crossOrigin: '' | 'anonymous' | 'use-credentials'
   }
   interface NitroRouteRules {
     ssr?: boolean

--- a/packages/nitro-server/src/runtime/handlers/island.ts
+++ b/packages/nitro-server/src/runtime/handlers/island.ts
@@ -12,6 +12,7 @@ import type { NuxtIslandContext, NuxtIslandResponse } from 'nuxt/app'
 import { islandCache, islandPropCache } from '../utils/cache'
 import { createSSRContext } from '../utils/renderer/app'
 import { getSSRRenderer } from '../utils/renderer/build-files'
+import { normalizeCrossOrigin } from '../utils/renderer/cross-origin'
 import { renderInlineStyles } from '../utils/renderer/inline-styles'
 import { getClientIslandResponse, getServerComponentHTML, getSlotIslandResponse } from '../utils/renderer/islands'
 
@@ -74,6 +75,7 @@ const handler: ReturnType<typeof defineEventHandler> = defineEventHandler(async 
 
   if (import.meta.dev) {
     const { styles } = getRequestDependencies(ssrContext, renderer.rendererContext)
+    const crossOrigin = normalizeCrossOrigin(ssrContext.runtimeConfig.app.crossOrigin)
 
     const link: Link[] = []
     for (const resource of Object.values(styles)) {
@@ -84,7 +86,7 @@ const handler: ReturnType<typeof defineEventHandler> = defineEventHandler(async 
       // Add CSS links in <head> for CSS files
       // - in dev mode when rendering an island and the file has scoped styles and is not a page
       if (resource.file.includes('scoped') && !resource.file.includes('pages/')) {
-        link.push({ rel: 'stylesheet', href: renderer.rendererContext.buildAssetsURL(resource.file), crossorigin: '' })
+        link.push({ rel: 'stylesheet', href: renderer.rendererContext.buildAssetsURL(resource.file), crossorigin: crossOrigin })
       }
     }
     if (link.length) {

--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -23,6 +23,7 @@ import { renderPayloadJsonScript, renderPayloadResponse, splitPayload } from '..
 import { createSSRContext, setSSRError } from '../utils/renderer/app'
 import { renderInlineStyles } from '../utils/renderer/inline-styles'
 import { renderStreamedIslandTeleports, replaceIslandTeleports } from '../utils/renderer/islands'
+import { applyCrossOriginToLinkHeader, normalizeCrossOrigin, renderCrossOriginAttr, withCrossOrigin } from '../utils/renderer/cross-origin'
 // @ts-expect-error virtual file
 import { renderSSRHeadOptions } from '#internal/unhead.config.mjs'
 // @ts-expect-error virtual file
@@ -140,6 +141,7 @@ async function renderRoute (event: H3Event, ssrError: (NuxtPayload['error'] & { 
   }
 
   const payloadURL = _PAYLOAD_EXTRACTION ? joinURL(ssrContext.runtimeConfig.app.cdnURL || ssrContext.runtimeConfig.app.baseURL, ssrContext.url.replace(/\?.*$/, ''), PAYLOAD_FILENAME) + '?' + ssrContext.runtimeConfig.app.buildId : undefined
+  const crossOrigin = normalizeCrossOrigin(ssrContext.runtimeConfig.app.crossOrigin)
 
   // Render app
   const renderer = await getRenderer(ssrContext)
@@ -148,7 +150,7 @@ async function renderRoute (event: H3Event, ssrError: (NuxtPayload['error'] & { 
   if (NUXT_EARLY_HINTS && !isRenderingPayload && !import.meta.prerender) {
     const { link } = renderResourceHeaders({}, renderer.rendererContext)
     if (link) {
-      writeEarlyHints(event, { link })
+      writeEarlyHints(event, { link: applyCrossOriginToLinkHeader(link, crossOrigin) })
     }
   }
 
@@ -185,7 +187,7 @@ async function renderRoute (event: H3Event, ssrError: (NuxtPayload['error'] & { 
   if (renderRouteResult instanceof Promise) { await renderRouteResult }
 
   if (NUXT_SSR_STREAMING && canStream && renderRouteContext.prefersStream) {
-    return renderStreamedResponse({ event, ssrContext, renderer, routeOptions, ssrError, _PAYLOAD_EXTRACTION: _PAYLOAD_EXTRACTION!, _PAYLOAD_INLINE, payloadURL })
+    return renderStreamedResponse({ event, ssrContext, renderer, routeOptions, ssrError, _PAYLOAD_EXTRACTION: _PAYLOAD_EXTRACTION!, _PAYLOAD_INLINE, payloadURL, crossOrigin })
   }
 
   const _rendered = await renderer.renderToString(ssrContext).catch(async (error) => {
@@ -289,7 +291,7 @@ async function renderRoute (event: H3Event, ssrError: (NuxtPayload['error'] & { 
     // Add CSS links in <head> for CSS files
     // - in production
     // - in dev mode when not rendering an island
-    link.push({ rel: 'stylesheet', href: renderer.rendererContext.buildAssetsURL(resource.file), crossorigin: '' })
+    link.push({ rel: 'stylesheet', href: renderer.rendererContext.buildAssetsURL(resource.file), crossorigin: crossOrigin })
   }
 
   if (link.length) {
@@ -306,10 +308,10 @@ async function renderRoute (event: H3Event, ssrError: (NuxtPayload['error'] & { 
       }
     }
     ssrContext.head.push({
-      link: getPreloadLinks(ssrContext, renderer.rendererContext) as Link[],
+      link: withCrossOrigin(getPreloadLinks(ssrContext, renderer.rendererContext) as Link[], crossOrigin),
     })
     ssrContext.head.push({
-      link: getPrefetchLinks(ssrContext, renderer.rendererContext) as Link[],
+      link: withCrossOrigin(getPrefetchLinks(ssrContext, renderer.rendererContext) as Link[], crossOrigin),
     })
     // 5. Payloads
     ssrContext.head.push({
@@ -337,7 +339,7 @@ async function renderRoute (event: H3Event, ssrError: (NuxtPayload['error'] & { 
         // if we are rendering script tag payloads that import an async payload
         // we need to ensure this resolves before executing the Nuxt entry
         tagPosition: 'head',
-        crossorigin: '',
+        crossorigin: crossOrigin,
       })),
     })
   }
@@ -380,14 +382,15 @@ async function renderStreamedResponse (ctx: {
   _PAYLOAD_EXTRACTION: boolean
   _PAYLOAD_INLINE: boolean
   payloadURL: string | undefined
+  crossOrigin: ReturnType<typeof normalizeCrossOrigin>
 }): Promise<ReadableStream<Uint8Array> | RenderResponse['body']> {
-  const { event, ssrContext, renderer, routeOptions, ssrError, _PAYLOAD_EXTRACTION, _PAYLOAD_INLINE, payloadURL } = ctx
+  const { event, ssrContext, renderer, routeOptions, ssrError, _PAYLOAD_EXTRACTION, _PAYLOAD_INLINE, payloadURL, crossOrigin } = ctx
   const NO_SCRIPTS = NUXT_NO_SCRIPTS || !!routeOptions?.noScripts
 
   // 1. Set HTTP Link headers with entry-point preload hints (fastest resource hinting)
   const { link: linkHeader } = renderResourceHeaders({}, renderer.rendererContext)
   if (linkHeader) {
-    event.res.headers.append('link', linkHeader)
+    event.res.headers.append('link', applyCrossOriginToLinkHeader(linkHeader, crossOrigin))
   }
 
   // 2. Pre-compute entry-point inline styles for the shell
@@ -405,7 +408,7 @@ async function renderStreamedResponse (ctx: {
   const shellLinks: Link[] = []
   for (const resource of Object.values(entryStyles)) {
     if (import.meta.dev && 'inline' in getURLQuery(resource.file)) { continue }
-    shellLinks.push({ rel: 'stylesheet', href: renderer.rendererContext.buildAssetsURL(resource.file), crossorigin: '' })
+    shellLinks.push({ rel: 'stylesheet', href: renderer.rendererContext.buildAssetsURL(resource.file), crossorigin: crossOrigin })
   }
   if (shellLinks.length) {
     ssrContext.head.push({ link: shellLinks })
@@ -446,10 +449,10 @@ async function renderStreamedResponse (ctx: {
   // Entry preload/prefetch links
   if (!NO_SCRIPTS) {
     ssrContext.head.push({
-      link: getPreloadLinks({}, renderer.rendererContext) as Link[],
+      link: withCrossOrigin(getPreloadLinks({}, renderer.rendererContext) as Link[], crossOrigin),
     })
     ssrContext.head.push({
-      link: getPrefetchLinks({}, renderer.rendererContext) as Link[],
+      link: withCrossOrigin(getPrefetchLinks({}, renderer.rendererContext) as Link[], crossOrigin),
     })
   }
 
@@ -461,15 +464,19 @@ async function renderStreamedResponse (ctx: {
         src: renderer.rendererContext.buildAssetsURL(resource.file),
         defer: resource.module ? null : true,
         tagPosition: 'head',
-        crossorigin: '',
+        crossorigin: crossOrigin,
       })),
     })
   }
 
   // Preload streaming IIFE script (production only - in dev we inline it)
   if (!NO_SCRIPTS && !import.meta.dev && iifeChunkFileName) {
+    const iifeLink: Link = { rel: 'preload', as: 'script', href: buildAssetsURL(iifeChunkFileName) }
+    if (crossOrigin) {
+      iifeLink.crossorigin = crossOrigin
+    }
     ssrContext.head.push({
-      link: [{ rel: 'preload', as: 'script', href: buildAssetsURL(iifeChunkFileName) }],
+      link: [iifeLink],
     })
   }
 
@@ -519,7 +526,8 @@ async function renderStreamedResponse (ctx: {
   let iifeScript = ''
   if (!NO_SCRIPTS) {
     if (!import.meta.dev && iifeChunkFileName) {
-      iifeScript = `<script async${nonceAttr} src="${buildAssetsURL(iifeChunkFileName)}"></script>`
+      const crossOriginAttr = crossOrigin ? renderCrossOriginAttr(crossOrigin) : ''
+      iifeScript = `<script async${nonceAttr} src="${buildAssetsURL(iifeChunkFileName)}"${crossOriginAttr}></script>`
     } else {
       iifeScript = `<script${nonceAttr}>${streamingIifeCode}</script>`
     }
@@ -643,7 +651,7 @@ async function renderStreamedResponse (ctx: {
       if (emittedStyles.has(resource.file)) { continue }
       if (import.meta.dev && 'inline' in getURLQuery(resource.file)) { continue }
       emittedStyles.add(resource.file)
-      tags += `<link rel="stylesheet" crossorigin href="${renderer.rendererContext.buildAssetsURL(resource.file)}">`
+      tags += `<link rel="stylesheet"${renderCrossOriginAttr(crossOrigin)} href="${renderer.rendererContext.buildAssetsURL(resource.file)}">`
     }
     return tags
   }

--- a/packages/nitro-server/src/runtime/utils/renderer/cross-origin.ts
+++ b/packages/nitro-server/src/runtime/utils/renderer/cross-origin.ts
@@ -1,0 +1,27 @@
+import type { Link } from '@unhead/vue/types'
+
+export type AssetCrossOrigin = '' | 'anonymous' | 'use-credentials'
+
+export function normalizeCrossOrigin (value: unknown): AssetCrossOrigin {
+  return value === 'anonymous' || value === 'use-credentials' ? value : ''
+}
+
+export function withCrossOrigin<T extends Link> (links: T[], crossOrigin: AssetCrossOrigin): T[] {
+  for (const link of links) {
+    if (link.crossorigin != null) {
+      link.crossorigin = crossOrigin
+    }
+  }
+  return links
+}
+
+export function renderCrossOriginAttr (crossOrigin: AssetCrossOrigin): string {
+  return crossOrigin ? ` crossorigin="${crossOrigin}"` : ' crossorigin'
+}
+
+export function applyCrossOriginToLinkHeader (header: string, crossOrigin: AssetCrossOrigin): string {
+  if (!crossOrigin) {
+    return header
+  }
+  return header.replace(/;\s*crossorigin(?:=(?:"[^"]*"|[^,;]+))?/gi, `; crossorigin=${crossOrigin}`)
+}

--- a/packages/nitro-server/src/templates.ts
+++ b/packages/nitro-server/src/templates.ts
@@ -27,6 +27,7 @@ declare module 'nitro/types' {
     baseURL: string
     buildAssetsDir: string
     cdnURL: string
+    crossOrigin: '' | 'anonymous' | 'use-credentials'
   }
   interface NitroRuntimeConfig extends RuntimeConfig {}
   interface NitroRouteConfig {

--- a/packages/nitro-server/test/cross-origin.test.ts
+++ b/packages/nitro-server/test/cross-origin.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { applyCrossOriginToLinkHeader, normalizeCrossOrigin, renderCrossOriginAttr, withCrossOrigin } from '../src/runtime/utils/renderer/cross-origin'
+
+describe('renderer cross-origin helpers', () => {
+  it('normalizes supported crossOrigin values', () => {
+    expect(normalizeCrossOrigin('anonymous')).toBe('anonymous')
+    expect(normalizeCrossOrigin('use-credentials')).toBe('use-credentials')
+    expect(normalizeCrossOrigin('invalid')).toBe('')
+    expect(normalizeCrossOrigin(undefined)).toBe('')
+  })
+
+  it('updates generated bundle-renderer links that already require crossorigin', () => {
+    const links = withCrossOrigin([
+      { rel: 'modulepreload', crossorigin: '', href: '/_nuxt/app.js' },
+      { rel: 'preload', crossorigin: null, href: '/_nuxt/app.woff2' },
+      { rel: 'stylesheet', crossorigin: '', href: '/_nuxt/app.css' },
+    ], 'use-credentials')
+
+    expect(links).toEqual([
+      { rel: 'modulepreload', crossorigin: 'use-credentials', href: '/_nuxt/app.js' },
+      { rel: 'preload', crossorigin: null, href: '/_nuxt/app.woff2' },
+      { rel: 'stylesheet', crossorigin: 'use-credentials', href: '/_nuxt/app.css' },
+    ])
+  })
+
+  it('renders the HTML crossorigin attribute without changing the default output', () => {
+    expect(renderCrossOriginAttr('')).toBe(' crossorigin')
+    expect(renderCrossOriginAttr('use-credentials')).toBe(' crossorigin="use-credentials"')
+  })
+
+  it('updates crossorigin in HTTP link headers', () => {
+    const header = '</_nuxt/app.js>; rel="modulepreload"; crossorigin, </_nuxt/app.css>; rel="preload"; as="style"; crossorigin=anonymous'
+
+    expect(applyCrossOriginToLinkHeader(header, 'use-credentials')).toBe('</_nuxt/app.js>; rel="modulepreload"; crossorigin=use-credentials, </_nuxt/app.css>; rel="preload"; as="style"; crossorigin=use-credentials')
+    expect(applyCrossOriginToLinkHeader(header, '')).toBe(header)
+  })
+})

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -880,7 +880,7 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
   }
 
   // warn if user is using reserved namespaces
-  const allowedKeys = new Set(['baseURL', 'buildAssetsDir', 'cdnURL', 'buildId'])
+  const allowedKeys = new Set(['baseURL', 'buildAssetsDir', 'cdnURL', 'crossOrigin', 'buildId'])
   for (const key in options.runtimeConfig.app) {
     if (!allowedKeys.has(key)) {
       logger.warn(`The \`app\` namespace is reserved for Nuxt and is exposed to the browser. Please move \`runtimeConfig.app.${key}\` to a different namespace.`)

--- a/packages/schema/src/config/app.ts
+++ b/packages/schema/src/config/app.ts
@@ -51,6 +51,13 @@ export default defineResolvers({
       },
     },
 
+    crossOrigin: {
+      $resolve: (val) => {
+        const crossOrigin = process.env.NUXT_APP_CROSS_ORIGIN || val
+        return crossOrigin === 'anonymous' || crossOrigin === 'use-credentials' ? crossOrigin : ''
+      },
+    },
+
     head: {
       $resolve: (_val) => {
         const val: Partial<NuxtAppConfig['head']> = _val && typeof _val === 'object' ? _val : {}

--- a/packages/schema/src/config/common.ts
+++ b/packages/schema/src/config/common.ts
@@ -299,6 +299,7 @@ export default defineResolvers({
           baseURL: app.baseURL,
           buildAssetsDir: app.buildAssetsDir,
           cdnURL: app.cdnURL,
+          crossOrigin: app.crossOrigin,
         },
       })
     },

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -182,6 +182,15 @@ export interface ConfigSchema {
     cdnURL: string
 
     /**
+     * Set the default `crossorigin` attribute value for generated Nuxt build asset tags.
+     *
+     * This applies to server-rendered script, stylesheet, modulepreload and prefetch tags for build assets.
+     *
+     * @default ""
+     */
+    crossOrigin: '' | 'anonymous' | 'use-credentials'
+
+    /**
      * Set default configuration for `<head>` on every page.
      *
      * @example

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1334,6 +1334,12 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/nuxt
 
+  test/fixtures/cross-origin:
+    dependencies:
+      nuxt:
+        specifier: workspace:*
+        version: link:../../../packages/nuxt
+
   test/fixtures/external-vue-resolution:
     dependencies:
       nuxt:

--- a/test/cross-origin.test.ts
+++ b/test/cross-origin.test.ts
@@ -1,0 +1,35 @@
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { isWindows } from 'std-env'
+import { $fetch, fetch, setup } from '@nuxt/test-utils/e2e'
+import { builder, isBuilt } from './matrix'
+
+if (builder === 'vite' && isBuilt) {
+  await setup({
+    rootDir: fileURLToPath(new URL('./fixtures/cross-origin', import.meta.url)),
+    dev: false,
+    server: true,
+    browser: false,
+    setupTimeout: (isWindows ? 360 : 120) * 1000,
+  })
+}
+
+describe.skipIf(builder !== 'vite' || !isBuilt)('build asset crossOrigin', () => {
+  it('renders configured crossorigin for CDN build assets', async () => {
+    const html = await $fetch<string>('/')
+    const assetTags = [...html.matchAll(/<(?:link|script)[^>]+(?:href|src)="https:\/\/cdn\.example\.com\/_nuxt\/[^"]+"[^>]*>/g)].map(match => match[0])
+
+    expect(assetTags.length).toBeGreaterThan(0)
+    for (const tag of assetTags) {
+      expect(tag).toContain('crossorigin="use-credentials"')
+    }
+  })
+
+  it('renders configured crossorigin in resource link headers', async () => {
+    const response = await fetch('/')
+    const linkHeader = response.headers.get('link') || ''
+
+    expect(linkHeader).toContain('https://cdn.example.com/_nuxt/')
+    expect(linkHeader).toContain('crossorigin=use-credentials')
+  })
+})

--- a/test/fixtures/cross-origin/app.vue
+++ b/test/fixtures/cross-origin/app.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="cross-origin-fixture">
+    cross origin fixture
+  </div>
+</template>

--- a/test/fixtures/cross-origin/assets/main.css
+++ b/test/fixtures/cross-origin/assets/main.css
@@ -1,0 +1,3 @@
+.cross-origin-fixture {
+  color: #00dc82;
+}

--- a/test/fixtures/cross-origin/nuxt.config.ts
+++ b/test/fixtures/cross-origin/nuxt.config.ts
@@ -1,0 +1,12 @@
+import { withMatrix } from '../../matrix'
+
+export default withMatrix({
+  app: {
+    cdnURL: 'https://cdn.example.com/',
+    crossOrigin: 'use-credentials',
+  },
+  css: ['~/assets/main.css'],
+  experimental: {
+    ssrStreaming: true,
+  },
+})

--- a/test/fixtures/cross-origin/package.json
+++ b/test/fixtures/cross-origin/package.json
@@ -1,0 +1,13 @@
+{
+  "private": true,
+  "name": "fixture-cross-origin",
+  "scripts": {
+    "build": "nuxt build"
+  },
+  "dependencies": {
+    "nuxt": "workspace:*"
+  },
+  "engines": {
+    "node": "^22.19.0 || ^24.11.0 || >=26.0.0"
+  }
+}

--- a/test/fixtures/cross-origin/tsconfig.json
+++ b/test/fixtures/cross-origin/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./.nuxt/tsconfig.app.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.server.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.shared.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.node.json"
+    }
+  ]
+}


### PR DESCRIPTION
### Summary

- add `app.crossOrigin` to configure Nuxt build asset crossorigin output
- apply it to server-rendered stylesheet, script, modulepreload/prefetch tags and resource link headers
- cover the helper behavior and a built Vite fixture using `app.cdnURL` with `use-credentials`

Closes #30003

### Tests

- `node_modules/.bin/vitest run --project unit packages/nitro-server/test/cross-origin.test.ts`
- `node_modules/.bin/vitest run --project fixtures:vite-built-default-manifest-on test/cross-origin.test.ts`
- `node_modules/.bin/eslint packages/nitro-server/src/runtime/utils/renderer/cross-origin.ts packages/nitro-server/src/runtime/handlers/renderer.ts packages/nitro-server/src/runtime/handlers/island.ts packages/nitro-server/test/cross-origin.test.ts test/cross-origin.test.ts test/fixtures/cross-origin/nuxt.config.ts packages/schema/src/config/app.ts packages/schema/src/config/common.ts packages/schema/src/types/schema.ts packages/nuxt/src/core/nuxt.ts packages/nitro-server/src/augments.ts packages/nitro-server/src/templates.ts --cache`
- `git diff --check`
- `pnpm --filter @nuxt/schema build`
- `pnpm --filter @nuxt/nitro-server build`