### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -191,7 +191,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
     renderer: {
       handler: resolve(distDir, 'runtime/handlers/renderer'),
     },
-    baseURL: nuxt.options.app.baseURL,
+    baseURL: nuxt.options.app.baseURL.replace(/^\.\//, '/') || '/',
     virtual: {
       '#internal/nuxt.config.mjs': () => nuxt.vfs['#build/nuxt.config.mjs'] || '',
       '#internal/nuxt/app-config': () => nuxt.vfs['#build/app.config.mjs']?.replace(/\/\*\* client \*\*\/[\s\S]*\/\*\* client-end \*\*\//, '') || '',

--- a/packages/schema/src/config/nitro.ts
+++ b/packages/schema/src/config/nitro.ts
@@ -23,12 +23,6 @@ export default defineResolvers({
         const runtimeConfig = await get('runtimeConfig')
         return {
           ...runtimeConfig,
-          app: {
-            ...runtimeConfig.app,
-            baseURL: runtimeConfig.app.baseURL.startsWith('./')
-              ? runtimeConfig.app.baseURL.slice(1)
-              : runtimeConfig.app.baseURL,
-          },
           nitro: {
             envPrefix: 'NUXT_',
             ...runtimeConfig.nitro,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1382,6 +1382,12 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/nuxt
 
+  test/fixtures/relative-base-url:
+    dependencies:
+      nuxt:
+        specifier: workspace:*
+        version: link:../../../packages/nuxt
+
   test/fixtures/runtime-compiler:
     dependencies:
       nuxt:

--- a/test/fixtures/relative-base-url/app.vue
+++ b/test/fixtures/relative-base-url/app.vue
@@ -1,0 +1,3 @@
+<template>
+  <NuxtPage />
+</template>

--- a/test/fixtures/relative-base-url/assets/main.css
+++ b/test/fixtures/relative-base-url/assets/main.css
@@ -1,0 +1,3 @@
+.relative-base-url-fixture {
+  color: #00dc82;
+}

--- a/test/fixtures/relative-base-url/nuxt.config.ts
+++ b/test/fixtures/relative-base-url/nuxt.config.ts
@@ -1,0 +1,14 @@
+import { isNuxtPrepare, projectSuffix, withMatrix } from '../../matrix'
+
+export default withMatrix({
+  ...(isNuxtPrepare ? {} : { buildDir: `.nuxt-${projectSuffix}` }),
+  app: {
+    baseURL: './',
+  },
+  css: ['~/assets/main.css'],
+  nitro: {
+    output: {
+      dir: `.output-${projectSuffix}`,
+    },
+  },
+})

--- a/test/fixtures/relative-base-url/package.json
+++ b/test/fixtures/relative-base-url/package.json
@@ -1,0 +1,13 @@
+{
+  "private": true,
+  "name": "fixture-relative-base-url",
+  "scripts": {
+    "build": "nuxt build"
+  },
+  "dependencies": {
+    "nuxt": "workspace:*"
+  },
+  "engines": {
+    "node": "^22.19.0 || ^24.11.0 || >=26.0.0"
+  }
+}

--- a/test/fixtures/relative-base-url/pages/index.vue
+++ b/test/fixtures/relative-base-url/pages/index.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="relative-base-url-fixture">
+    relative base url fixture
+  </div>
+</template>

--- a/test/fixtures/relative-base-url/tsconfig.json
+++ b/test/fixtures/relative-base-url/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./.nuxt/tsconfig.app.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.server.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.shared.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.node.json"
+    }
+  ]
+}

--- a/test/relative-base-url.test.ts
+++ b/test/relative-base-url.test.ts
@@ -1,0 +1,28 @@
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { beforeAll, describe, expect, it } from 'vitest'
+import { exec } from 'tinyexec'
+import { join } from 'pathe'
+import { builder, isBuilt, projectSuffix } from './matrix'
+
+describe.skipIf(builder !== 'vite' || !isBuilt)('relative baseURL', () => {
+  const rootDir = fileURLToPath(new URL('./fixtures/relative-base-url', import.meta.url))
+  const outputDir = join(rootDir, `.output-${projectSuffix}`)
+
+  beforeAll(async () => {
+    const result = await exec('pnpm', ['nuxt', 'generate', rootDir])
+    if (result.exitCode !== 0) {
+      throw new Error(`nuxt generate failed:\n${result.stderr}\n${result.stdout}`)
+    }
+  }, 120 * 1000)
+
+  it('renders relative build asset paths for generated HTML', async () => {
+    const html = await readFile(join(outputDir, 'public/index.html'), 'utf-8')
+    const assetUrls = [...html.matchAll(/(?:href|src)="([^"]*\/_nuxt\/[^"]+)"/g)].map(match => match[1])
+
+    expect(assetUrls.length).toBeGreaterThan(0)
+    for (const url of assetUrls) {
+      expect(url).toMatch(/^\.\/_nuxt\//)
+    }
+  })
+})


### PR DESCRIPTION
### Summary

Preserves `app.baseURL: './'` in runtime config so generated asset URLs stay relative, while normalizing Nitro's own base URL to `/` for static prerender routing.

Adds a fixture that runs `nuxt generate` and verifies generated HTML uses `./_nuxt/...` for build assets.

### Tests

- `pnpm --filter @nuxt/schema build`
- `pnpm --filter @nuxt/nitro-server build`
- `node_modules/.bin/vitest run --project fixtures:vite-built-default-manifest-on test/relative-base-url.test.ts`
- `node_modules/.bin/eslint packages/schema/src/config/nitro.ts packages/nitro-server/src/index.ts test/relative-base-url.test.ts test/fixtures/relative-base-url/nuxt.config.ts test/fixtures/relative-base-url/app.vue test/fixtures/relative-base-url/pages/index.vue --cache`
- `git diff --check`

Closes #28474