### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -20,15 +20,15 @@ export type _Transform<Input = any, Output = any> = (input: Input) => Output | P
 
 export type AsyncDataHandler<ResT> = (nuxtApp: NuxtApp, options: { signal: AbortSignal }) => Promise<ResT>
 
-export type PickFrom<T, K extends Array<string>> = T extends Array<any>
+export type PickFrom<T, K extends Array<string>> = [KeysOf<T>] extends [K]
   ? T
-  : T extends Record<string, any>
-    ? keyof T extends K[number]
-      ? T // Exact same keys as the target, skip Pick
-      : K[number] extends never
+  : T extends Array<any>
+    ? T
+    : T extends Record<string, any>
+      ? K[number] extends never
         ? T
         : Pick<T, K[number]>
-    : T
+      : T
 
 export type KeysOf<T> = Array<
   T extends T // Include all keys of union types, not just common keys

--- a/test/fixtures/basic-types/app/app-types.ts
+++ b/test/fixtures/basic-types/app/app-types.ts
@@ -160,6 +160,25 @@ describe('API routes', () => {
       },
     })
   })
+
+  it('preserves constrained generic response fields', () => {
+    interface ApiResponse {
+      id: string
+    }
+
+    function assertUseFetchGeneric<T extends ApiResponse> () {
+      const { data } = useFetch<T>('/api/v1/users')
+      expectTypeOf(data.value!.id).toEqualTypeOf<string>()
+    }
+
+    function assertUseAsyncDataGeneric<T extends ApiResponse> () {
+      const { data } = useAsyncData<T>('api-generics', () => $fetch('/test'))
+      expectTypeOf(data.value!.id).toEqualTypeOf<string>()
+    }
+
+    assertUseFetchGeneric()
+    assertUseAsyncDataGeneric()
+  })
 })
 
 describe('nitro compatible APIs', () => {


### PR DESCRIPTION
### Summary

Preserves constrained generic response fields when `useFetch<T>` or `useAsyncData<T>` is called without a `pick` option.

`PickFrom<T, KeysOf<T>>` now returns `T` before trying to apply `Pick`, which keeps generic `T extends ...` fields accessible while preserving explicit pick narrowing.

### Tests

- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter nuxt build`
- `pnpm --filter fixture-basic-types test:types`
- `node_modules/.bin/eslint packages/nuxt/src/app/composables/asyncData.ts test/fixtures/basic-types/app/app-types.ts --cache`
- `git diff --check`

Closes #28030