### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/docs/3.guide/6.going-further/1.experimental-features.md
+++ b/docs/3.guide/6.going-further/1.experimental-features.md
@@ -206,10 +206,11 @@ export default defineNuxtConfig({
 
 ## payloadExtraction
 
-Controls how payload data is delivered for prerendered and cached (ISR/SWR) pages.
+Controls how payload data is delivered for prerendered, cached (ISR/SWR), and server-rendered pages.
 
 - `'client'` - Payload is inlined in HTML for the initial server render, and extracted to `_payload.json` files for client-side navigation. This avoids a separate network request on initial load while still enabling efficient client-side navigation.
 - `true` - Payload is extracted to a separate `_payload.json` file for both the initial server render and client-side navigation.
+- `'always'` - Payload is inlined in HTML for the initial server render, and `_payload.json` files are available for all server-rendered routes during client-side navigation.
 - `false` - Payload extraction is disabled entirely. Payload is always inlined in HTML and no `_payload.json` files are generated.
 
 The default is `true`, or `'client'` when `compatibilityVersion: 5` is set.

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -212,8 +212,9 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
           `export const NUXT_ASYNC_CONTEXT = ${!!nuxt.options.experimental.asyncContext}`,
           `export const NUXT_SHARED_DATA = ${!!nuxt.options.experimental.sharedPrerenderData}`,
           `export const NUXT_PAYLOAD_EXTRACTION = ${nuxt.options.experimental.payloadExtraction !== false}`,
+          `export const NUXT_PAYLOAD_EXTRACTION_ALWAYS = ${nuxt.options.experimental.payloadExtraction === 'always'}`,
           `export const NUXT_PAYLOAD_INLINE = ${nuxt.options.experimental.payloadExtraction !== true}`,
-          `export const NUXT_RUNTIME_PAYLOAD_EXTRACTION = ${hasCachedRoutes}`,
+          `export const NUXT_RUNTIME_PAYLOAD_EXTRACTION = ${hasCachedRoutes || nuxt.options.experimental.payloadExtraction === 'always'}`,
           `export const NUXT_SSR_STREAMING = ${!!(typeof nuxt.options.experimental.ssrStreaming === 'object' && nuxt.options.experimental.ssrStreaming.enabled)}`,
           `export const NUXT_SSR_STREAMING_BOT_RE = ${typeof nuxt.options.experimental.ssrStreaming === 'object' && nuxt.options.experimental.ssrStreaming.botRegex instanceof RegExp ? String(nuxt.options.experimental.ssrStreaming.botRegex) : '/^$/'}`,
         ].join('\n')
@@ -720,7 +721,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
 
   // For full-static output, ensure payload extraction is not disabled
   if (nuxt.options.ssr && nitro.options.static && nuxt.options.experimental.payloadExtraction === false) {
-    logger.warn('Payload extraction is recommended for full-static output. You can enable it by setting `experimental.payloadExtraction` to `true` or `\'client\'`.')
+    logger.warn('Payload extraction is recommended for full-static output. You can enable it by setting `experimental.payloadExtraction` to `true`, `\'client\'`, or `\'always\'`.')
   }
 
   // Trigger Nitro reload when SPA loading template changes

--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -26,7 +26,7 @@ import { renderStreamedIslandTeleports, replaceIslandTeleports } from '../utils/
 // @ts-expect-error virtual file
 import { renderSSRHeadOptions } from '#internal/unhead.config.mjs'
 // @ts-expect-error virtual file
-import { NUXT_ASYNC_CONTEXT, NUXT_EARLY_HINTS, NUXT_INLINE_STYLES, NUXT_NO_SCRIPTS, NUXT_PAYLOAD_EXTRACTION, NUXT_PAYLOAD_INLINE, NUXT_RUNTIME_PAYLOAD_EXTRACTION, NUXT_SSR_STREAMING, NUXT_SSR_STREAMING_BOT_RE, PARSE_ERROR_DATA } from '#internal/nuxt/nitro-config.mjs'
+import { NUXT_ASYNC_CONTEXT, NUXT_EARLY_HINTS, NUXT_INLINE_STYLES, NUXT_NO_SCRIPTS, NUXT_PAYLOAD_EXTRACTION, NUXT_PAYLOAD_EXTRACTION_ALWAYS, NUXT_PAYLOAD_INLINE, NUXT_RUNTIME_PAYLOAD_EXTRACTION, NUXT_SSR_STREAMING, NUXT_SSR_STREAMING_BOT_RE, PARSE_ERROR_DATA } from '#internal/nuxt/nitro-config.mjs'
 // @ts-expect-error virtual file
 import { appHead, appTeleportAttrs, appTeleportTag, componentIslands, componentIslandsActive } from '#internal/nuxt.config.mjs'
 // @ts-expect-error virtual file
@@ -120,13 +120,13 @@ async function renderRoute (event: H3Event, ssrError: (NuxtPayload['error'] & { 
     ssrContext.noSSR = true
   }
 
-  // Whether we are prerendering route or using ISR/SWR caching
+  // Whether we are prerendering route, using ISR/SWR caching, or always extracting payloads
   const _PAYLOAD_EXTRACTION = !ssrContext.noSSR && (
     (import.meta.prerender && NUXT_PAYLOAD_EXTRACTION)
-    || (NUXT_RUNTIME_PAYLOAD_EXTRACTION && (routeOptions.isr || routeOptions.cache))
+    || (NUXT_RUNTIME_PAYLOAD_EXTRACTION && (NUXT_PAYLOAD_EXTRACTION_ALWAYS || routeOptions.isr || routeOptions.cache))
   )
 
-  // When NUXT_PAYLOAD_INLINE is true (payloadExtraction: 'client'), we inline the full payload
+  // When NUXT_PAYLOAD_INLINE is true (payloadExtraction: 'client' | 'always'), we inline the full payload
   const _PAYLOAD_INLINE = !_PAYLOAD_EXTRACTION || NUXT_PAYLOAD_INLINE
 
   const isRenderingPayload = (_PAYLOAD_EXTRACTION || (import.meta.dev && routeOptions.prerender)) && PAYLOAD_URL_RE.test(ssrContext.url)
@@ -314,7 +314,7 @@ async function renderRoute (event: H3Event, ssrError: (NuxtPayload['error'] & { 
     // 5. Payloads
     ssrContext.head.push({
       script: _PAYLOAD_INLINE
-        // Inline full payload in HTML (payloadExtraction: 'client' | false, or non-cached route)
+        // Inline full payload in HTML (payloadExtraction: 'client' | 'always' | false, or non-cached route)
         // `prefetchLinks` is only consumed when *another* page prefetches this URL via
         // _payload.json, so we drop it from the inline payload to avoid the duplication.
         ? renderPayloadJsonScript({ ssrContext, data: stripInlineOnlyPayloadFields(ssrContext.payload) })

--- a/packages/nuxt/src/app/composables/payload.ts
+++ b/packages/nuxt/src/app/composables/payload.ts
@@ -10,7 +10,7 @@ import { useRoute } from './router'
 import { getAppManifest, getRouteRules } from './manifest'
 
 // @ts-expect-error virtual import
-import { appId, appManifest, multiApp, payloadExtraction } from '#build/nuxt.config.mjs'
+import { appId, appManifest, multiApp, payloadExtraction, payloadExtractionAlways } from '#build/nuxt.config.mjs'
 
 interface LoadPayloadOptions {
   fresh?: boolean
@@ -136,6 +136,10 @@ export async function shouldLoadPayload (url: string = useRoute().path): Promise
   }
 
   if (rules.payload) {
+    return true
+  }
+
+  if (payloadExtractionAlways) {
     return true
   }
 

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -549,12 +549,14 @@ export const nuxtConfigTemplate: NuxtTemplate = {
     const nitro = useNitro() as Nitro
 
     const hasCachedRoutes = nitro.routing.routeRules.routes.some(r => r.data.isr || r.data.cache)
-    const payloadExtraction = !!ctx.nuxt.options.experimental.payloadExtraction && (nitro.options.static || hasCachedRoutes || (nitro.options.prerender.routes && nitro.options.prerender.routes.length > 0) || nitro.routing.routeRules.routes.some(r => r.data.prerender))
+    const payloadExtractionAlways = ctx.nuxt.options.experimental.payloadExtraction === 'always'
+    const payloadExtraction = !!ctx.nuxt.options.experimental.payloadExtraction && (payloadExtractionAlways || nitro.options.static || hasCachedRoutes || (nitro.options.prerender.routes && nitro.options.prerender.routes.length > 0) || nitro.routing.routeRules.routes.some(r => r.data.prerender))
     return [
       ...Object.entries(ctx.nuxt.options.app).map(([k, v]) => `export const ${camelCase('app-' + k)} = ${JSON.stringify(v)}`),
       `export const componentIslands = ${shouldEnableComponentIslands}`,
       `export const componentIslandsActive = ${componentIslandsActive}`,
       `export const payloadExtraction = ${payloadExtraction}`,
+      `export const payloadExtractionAlways = ${payloadExtractionAlways}`,
       `export const prefetchPreloadTags = ${!!ctx.nuxt.options.experimental.prefetchPreloadTags}`,
       `export const cookieStore = ${!!ctx.nuxt.options.experimental.cookieStore}`,
       `export const appManifest = ${!!ctx.nuxt.options.experimental.appManifest}`,

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -95,7 +95,7 @@ export default defineResolvers({
     payloadExtraction: {
       $resolve: async (val, get) => {
         if ((await get('ssr')) === false) { return false }
-        if (val === 'client' || typeof val === 'boolean') { return val }
+        if (val === 'client' || val === 'always' || typeof val === 'boolean') { return val }
         return (await get('future.compatibilityVersion')) >= 5 ? 'client' as const : true
       },
     },

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1131,19 +1131,21 @@ export interface ConfigSchema {
     noVueServer: boolean
 
     /**
-     * Controls how payload data is delivered for prerendered and cached (ISR/SWR) pages.
+     * Controls how payload data is delivered for prerendered, cached (ISR/SWR), and server-rendered pages.
      *
      * - `'client'` - Payload is inlined in HTML for the initial server render, and extracted to
      *   `_payload.json` files for client-side navigation. This avoids a separate request on
      *   initial load while still enabling efficient client-side navigation.
      * - `true` - Payload is extracted to a separate `_payload.json` file for both the initial
      *   server render and client-side navigation.
+     * - `'always'` - Payload is inlined in HTML for the initial server render, and `_payload.json`
+     *   files are available for all server-rendered routes during client-side navigation.
      * - `false` - Payload extraction is disabled entirely. Payload is always inlined in HTML and
      *   no `_payload.json` files are generated.
      *
      * `@default` true (or 'client' when compatibilityVersion >= 5)
      */
-    payloadExtraction: 'client' | boolean | undefined
+    payloadExtraction: 'client' | 'always' | boolean | undefined
 
     /**
      * Whether to enable the experimental `<NuxtClientFallback>` component for rendering content on the client if there's an error in SSR.

--- a/packages/schema/test/experimental.spec.ts
+++ b/packages/schema/test/experimental.spec.ts
@@ -29,3 +29,10 @@ describe('experimental.watcher default', () => {
     expect((result as unknown as NuxtOptions).experimental.watcher).toBe('parcel')
   })
 })
+
+describe('experimental.payloadExtraction', () => {
+  it('allows enabling payloads for all server-rendered routes', async () => {
+    const result = await applyDefaults(NuxtConfigSchema, { experimental: { payloadExtraction: 'always' } })
+    expect((result as unknown as NuxtOptions).experimental.payloadExtraction).toBe('always')
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1382,6 +1382,12 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/nuxt
 
+  test/fixtures/payload-extraction-always:
+    dependencies:
+      nuxt:
+        specifier: workspace:*
+        version: link:../../../packages/nuxt
+
   test/fixtures/runtime-compiler:
     dependencies:
       nuxt:

--- a/test/fixtures/payload-extraction-always/app.vue
+++ b/test/fixtures/payload-extraction-always/app.vue
@@ -1,0 +1,3 @@
+<template>
+  <NuxtPage />
+</template>

--- a/test/fixtures/payload-extraction-always/nuxt.config.ts
+++ b/test/fixtures/payload-extraction-always/nuxt.config.ts
@@ -1,0 +1,7 @@
+import { withMatrix } from '../../matrix'
+
+export default withMatrix({
+  experimental: {
+    payloadExtraction: 'always',
+  },
+})

--- a/test/fixtures/payload-extraction-always/package.json
+++ b/test/fixtures/payload-extraction-always/package.json
@@ -1,0 +1,13 @@
+{
+  "private": true,
+  "name": "fixture-payload-extraction-always",
+  "scripts": {
+    "build": "nuxt build"
+  },
+  "dependencies": {
+    "nuxt": "workspace:*"
+  },
+  "engines": {
+    "node": "^22.19.0 || ^24.11.0 || >=26.0.0"
+  }
+}

--- a/test/fixtures/payload-extraction-always/pages/users.vue
+++ b/test/fixtures/payload-extraction-always/pages/users.vue
@@ -1,0 +1,11 @@
+<script setup>
+const { data } = await useAsyncData('users', () => Promise.resolve([
+  {
+    name: 'Ada',
+  },
+]))
+</script>
+
+<template>
+  <pre>{{ data }}</pre>
+</template>

--- a/test/fixtures/payload-extraction-always/tsconfig.json
+++ b/test/fixtures/payload-extraction-always/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./.nuxt/tsconfig.app.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.server.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.shared.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.node.json"
+    }
+  ]
+}

--- a/test/nuxt/nuxt-island.test.ts
+++ b/test/nuxt/nuxt-island.test.ts
@@ -44,6 +44,7 @@ vi.mock('#build/nuxt.config.mjs', () => {
     appViewTransition: false,
     componentIslands: true,
     payloadExtraction: false,
+    payloadExtractionAlways: false,
     cookieStore: false,
     appManifest: false,
     remoteComponentIslands: true,

--- a/test/payload-extraction-always.test.ts
+++ b/test/payload-extraction-always.test.ts
@@ -1,0 +1,25 @@
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { $fetch, setup } from '@nuxt/test-utils/e2e'
+import { isDev } from './matrix'
+import { parsePayload } from './utils'
+
+await setup({
+  rootDir: fileURLToPath(new URL('./fixtures/payload-extraction-always', import.meta.url)),
+  dev: isDev,
+  server: true,
+  setupTimeout: 120 * 1000,
+})
+
+describe.skipIf(isDev)('payloadExtraction always', () => {
+  it('renders payloads for non-prerendered server routes', async () => {
+    const payload = await $fetch<string>('/users/_payload.json', { responseType: 'text' })
+    const data = parsePayload(payload)
+
+    expect(data.data.users).toEqual([
+      {
+        name: 'Ada',
+      },
+    ])
+  })
+})


### PR DESCRIPTION
Summary:
- Added `experimental.payloadExtraction: 'always'` as an accepted config value.
- Enabled runtime `_payload.json` rendering for all server-rendered routes in this mode.
- Let client payload loading skip prerender manifest gating when payload extraction is always enabled.
- Added fixture coverage for a non-prerendered SSR route payload.

Tests:
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter nuxt build`
- `pnpm --filter @nuxt/schema build`
- `pnpm --filter @nuxt/nitro-server build`
- `node_modules/.bin/vitest run --project unit packages/schema/test/experimental.spec.ts`
- `node_modules/.bin/vitest run --project fixtures:vite-built-default-manifest-on test/payload-extraction-always.test.ts`
- `node_modules/.bin/eslint packages/schema/src/config/experimental.ts packages/schema/src/types/schema.ts packages/schema/test/experimental.spec.ts packages/nitro-server/src/index.ts packages/nitro-server/src/runtime/handlers/renderer.ts packages/nuxt/src/core/templates.ts packages/nuxt/src/app/composables/payload.ts test/nuxt/nuxt-island.test.ts test/payload-extraction-always.test.ts test/fixtures/payload-extraction-always/nuxt.config.ts test/fixtures/payload-extraction-always/app.vue test/fixtures/payload-extraction-always/pages/users.vue --cache`
- `git diff --check`

Closes #29847