### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/docs/3.guide/6.going-further/1.experimental-features.md
+++ b/docs/3.guide/6.going-further/1.experimental-features.md
@@ -158,6 +158,20 @@ export default defineNuxtConfig({
 })
 ```
 
+## restorePayloadRoute
+
+Controls whether Nuxt uses the server-rendered payload route during hydration when it differs from the browser URL.
+
+This is enabled by default to avoid hydration mismatches when a prerendered or cached page is loaded from another URL. You can disable it if your deployment intentionally serves the same Nuxt response from multiple external URLs and the visible browser URL must be preserved.
+
+```ts twoslash [nuxt.config.ts]
+export default defineNuxtConfig({
+  experimental: {
+    restorePayloadRoute: false,
+  },
+})
+```
+
 ## inlineRouteRules
 
 Define route rules at the page level using [`defineRouteRules`](/docs/4.x/api/utils/define-route-rules).

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -555,6 +555,7 @@ export const nuxtConfigTemplate: NuxtTemplate = {
       `export const componentIslands = ${shouldEnableComponentIslands}`,
       `export const componentIslandsActive = ${componentIslandsActive}`,
       `export const payloadExtraction = ${payloadExtraction}`,
+      `export const restorePayloadRoute = ${!!ctx.nuxt.options.experimental.restorePayloadRoute}`,
       `export const prefetchPreloadTags = ${!!ctx.nuxt.options.experimental.prefetchPreloadTags}`,
       `export const cookieStore = ${!!ctx.nuxt.options.experimental.cookieStore}`,
       `export const appManifest = ${!!ctx.nuxt.options.experimental.appManifest}`,

--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -2,12 +2,12 @@ import { isReadonly, reactive, shallowReactive, shallowRef } from 'vue'
 import type { Ref } from 'vue'
 import type { RouteLocationNormalizedLoadedGeneric, Router, RouterScrollBehavior } from 'vue-router'
 import { START_LOCATION, createMemoryHistory, createRouter, createWebHashHistory, createWebHistory } from 'vue-router'
-import { isSamePath, withoutBase } from 'ufo'
+import { isSamePath } from 'ufo'
 
 import type { NuxtApp, Plugin, RouteMiddleware } from 'nuxt/app'
 import type { PageMeta } from '../composables'
 
-import { toArray } from '../utils'
+import { createCurrentLocation, toArray } from '../utils'
 
 import { getRouteRules } from '#app/composables/manifest'
 import { defineNuxtPlugin, useRuntimeConfig } from '#app/nuxt'
@@ -20,29 +20,8 @@ import routerOptions, { hashMode } from '#build/router.options.mjs'
 import { globalMiddleware, namedMiddleware } from '#build/middleware'
 // @ts-expect-error virtual file
 import { pageIslandRoutes } from '#build/components.islands.mjs'
-
-// https://github.com/vuejs/router/blob/4a0cc8b9c1e642cdf47cc007fa5bbebde70afc66/packages/router/src/history/html5.ts#L37
-function createCurrentLocation (
-  base: string,
-  location: Location,
-  renderedPath?: string,
-): string {
-  const { pathname, search, hash } = location
-  // allows hash bases like #, /#, #/, #!, #!/, /#!/, or even /folder#end
-  const hashPos = base.indexOf('#')
-  if (hashPos > -1) {
-    const slicePos = hash.includes(base.slice(hashPos))
-      ? base.slice(hashPos).length
-      : 1
-    let pathFromHash = hash.slice(slicePos)
-    // prepend the starting slash to hash so the url starts with /#
-    if (pathFromHash[0] !== '/') { pathFromHash = '/' + pathFromHash }
-    return withoutBase(pathFromHash, '')
-  }
-  const displayedPath = withoutBase(pathname, base)
-  const path = !renderedPath || isSamePath(displayedPath, renderedPath) ? displayedPath : renderedPath
-  return path + (path.includes('?') ? '' : search) + hash
-}
+// @ts-expect-error virtual file
+import { restorePayloadRoute } from '#build/nuxt.config.mjs'
 
 const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
   name: 'nuxt:router',
@@ -106,7 +85,7 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
 
     const initialURL = import.meta.server
       ? nuxtApp.ssrContext!.url
-      : createCurrentLocation(routerBase, window.location, nuxtApp.payload.path)
+      : createCurrentLocation(routerBase, window.location, restorePayloadRoute ? nuxtApp.payload.path : undefined)
 
     // Allows suspending the route object until page navigation completes
     const _route = shallowRef(router.currentRoute.value)

--- a/packages/nuxt/src/pages/runtime/utils.ts
+++ b/packages/nuxt/src/pages/runtime/utils.ts
@@ -1,6 +1,7 @@
 import { KeepAlive, h } from 'vue'
 import type { VNode } from 'vue'
 import type { RouteLocationMatched, RouteLocationNormalizedLoaded, RouterView } from 'vue-router'
+import { isSamePath, withoutBase } from 'ufo'
 
 type InstanceOf<T> = T extends new (...args: any[]) => infer R ? R : never
 type RouterViewSlot = Exclude<InstanceOf<typeof RouterView>['$slots']['default'], undefined>
@@ -46,4 +47,27 @@ export const wrapInKeepAlive = (props: any, children: any): { default: () => VNo
 /** @since 3.9.0 */
 export function toArray<T> (value: T | T[]): T[] {
   return Array.isArray(value) ? value : [value]
+}
+
+// https://github.com/vuejs/router/blob/4a0cc8b9c1e642cdf47cc007fa5bbebde70afc66/packages/router/src/history/html5.ts#L37
+export function createCurrentLocation (
+  base: string,
+  location: Pick<Location, 'pathname' | 'search' | 'hash'>,
+  renderedPath?: string,
+): string {
+  const { pathname, search, hash } = location
+  // allows hash bases like #, /#, #/, #!, #!/, /#!/, or even /folder#end
+  const hashPos = base.indexOf('#')
+  if (hashPos > -1) {
+    const slicePos = hash.includes(base.slice(hashPos))
+      ? base.slice(hashPos).length
+      : 1
+    let pathFromHash = hash.slice(slicePos)
+    // prepend the starting slash to hash so the url starts with /#
+    if (pathFromHash[0] !== '/') { pathFromHash = '/' + pathFromHash }
+    return withoutBase(pathFromHash, '')
+  }
+  const displayedPath = withoutBase(pathname, base)
+  const path = !renderedPath || isSamePath(displayedPath, renderedPath) ? displayedPath : renderedPath
+  return path + (path.includes('?') ? '' : search) + hash
 }

--- a/packages/nuxt/test/pages.test.ts
+++ b/packages/nuxt/test/pages.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import type { RouteLocationNormalizedLoaded } from 'vue-router'
 import { type PagesContextOptions, augmentPages, createPagesContext, normalizeRoutes, pathToNitroGlob } from '../src/pages/utils.ts'
 import type { RouterViewSlotProps } from '../src/pages/runtime/utils.ts'
-import { generateRouteKey } from '../src/pages/runtime/utils.ts'
+import { createCurrentLocation, generateRouteKey } from '../src/pages/runtime/utils.ts'
 import type { NuxtPage } from 'nuxt/schema'
 import { useNuxt } from '@nuxt/kit'
 import type { InputFile } from 'unrouting'
@@ -30,6 +30,18 @@ export function generateRoutesFromFiles (files: InputFile[], options: PagesConte
   ctx.rebuild(files)
   return ctx.emit()
 }
+
+describe('createCurrentLocation', () => {
+  const location = (pathname: string, search = '', hash = '') => ({ pathname, search, hash })
+
+  it('uses the server-rendered route when the browser URL differs from the payload route', () => {
+    expect(createCurrentLocation('/', location('/cached-url', '?tab=1', '#top'), '/rendered-url')).toBe('/rendered-url?tab=1#top')
+  })
+
+  it('preserves the browser URL when no payload route is provided', () => {
+    expect(createCurrentLocation('/', location('/cached-url', '?tab=1', '#top'))).toBe('/cached-url?tab=1#top')
+  })
+})
 
 describe('pages:generateRoutesFromFiles', () => {
   vi.mock('knitwork', async (original) => {

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -91,6 +91,7 @@ export default defineResolvers({
     },
     templateRouteInjection: true,
     restoreState: false,
+    restorePayloadRoute: true,
     noVueServer: false,
     payloadExtraction: {
       $resolve: async (val, get) => {

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1124,6 +1124,16 @@ export interface ConfigSchema {
     restoreState: boolean
 
     /**
+     * Whether to restore the server-rendered payload route during hydration when it differs from the browser URL.
+     *
+     * This avoids hydration mismatches when a prerendered or cached page is loaded from another URL.
+     * You can disable it if your deployment intentionally serves the same Nuxt response from multiple external URLs.
+     *
+     * @default true
+     */
+    restorePayloadRoute: boolean
+
+    /**
      * Disable vue server renderer endpoint within nitro.
      *
      * @default false

--- a/packages/schema/test/experimental.spec.ts
+++ b/packages/schema/test/experimental.spec.ts
@@ -29,3 +29,15 @@ describe('experimental.watcher default', () => {
     expect((result as unknown as NuxtOptions).experimental.watcher).toBe('parcel')
   })
 })
+
+describe('experimental.restorePayloadRoute', () => {
+  it('defaults to enabled', async () => {
+    const result = await applyDefaults(NuxtConfigSchema, {})
+    expect((result as unknown as NuxtOptions).experimental.restorePayloadRoute).toBe(true)
+  })
+
+  it('can be disabled', async () => {
+    const result = await applyDefaults(NuxtConfigSchema, { experimental: { restorePayloadRoute: false } })
+    expect((result as unknown as NuxtOptions).experimental.restorePayloadRoute).toBe(false)
+  })
+})

--- a/test/nuxt/nuxt-island.test.ts
+++ b/test/nuxt/nuxt-island.test.ts
@@ -44,6 +44,7 @@ vi.mock('#build/nuxt.config.mjs', () => {
     appViewTransition: false,
     componentIslands: true,
     payloadExtraction: false,
+    restorePayloadRoute: true,
     cookieStore: false,
     appManifest: false,
     remoteComponentIslands: true,


### PR DESCRIPTION
Summary:
- Added `experimental.restorePayloadRoute`, enabled by default.
- Used it to control whether the pages router restores `payload.path` during hydration.
- Documented the opt-out for deployments that intentionally serve the same Nuxt response from multiple external URLs.
- Added unit coverage for the current-location helper and schema defaults.

Tests:
- `node_modules/.bin/vitest run --project unit packages/schema/test/experimental.spec.ts packages/nuxt/test/pages.test.ts`
- `pnpm --filter @nuxt/schema build`
- `pnpm --dir packages/nuxt exec tsdown --logLevel error --report false`
- `node_modules/.bin/eslint packages/schema/src/config/experimental.ts packages/schema/src/types/schema.ts packages/schema/test/experimental.spec.ts packages/nuxt/src/core/templates.ts packages/nuxt/src/pages/runtime/plugins/router.ts packages/nuxt/src/pages/runtime/utils.ts packages/nuxt/test/pages.test.ts test/nuxt/nuxt-island.test.ts --cache`
- `git diff --check`

Closes #21716