### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -136,6 +136,7 @@ export async function augmentAndResolve (pages: NuxtPage[], trackedFiles: Set<st
       ...extraPageMetaExtractionKeys,
     ]),
     fullyResolvedPaths: trackedFiles,
+    warnAboutMissingNuxtPage: nuxt.options.dev,
   }
   if (shouldAugment === 'after-resolve') {
     await nuxt.callHook('pages:extend', pages)
@@ -157,13 +158,27 @@ interface AugmentPagesContext {
   pagesToSkip?: Set<string>
   augmentedPages?: Set<string>
   extraExtractionKeys?: Set<string>
+  warnAboutMissingNuxtPage?: boolean
+  warnedMissingNuxtPage?: Set<string>
 }
+
+const NUXT_PAGE_RE = /<(?:NuxtPage|nuxt-page)(?=[\s/>])/i
 
 export async function augmentPages (routes: NuxtPage[], vfs: Record<string, string>, ctx: AugmentPagesContext = {}) {
   ctx.augmentedPages ??= new Set()
+  ctx.warnedMissingNuxtPage ??= new Set()
   for (const route of routes) {
     if (route.file && !ctx.pagesToSkip?.has(route.file)) {
       const fileContent = vfs[route.file] ?? fs.readFileSync(ctx.fullyResolvedPaths?.has(route.file) ? route.file : await resolvePath(route.file), 'utf-8')
+      if (
+        ctx.warnAboutMissingNuxtPage
+        && route.children?.length
+        && !NUXT_PAGE_RE.test(fileContent)
+        && !ctx.warnedMissingNuxtPage.has(route.file)
+      ) {
+        logger.warn(`[nuxt] \`${route.file}\` has child routes but does not use \`<NuxtPage />\`. Add \`<NuxtPage />\` to the parent page to render child routes.`)
+        ctx.warnedMissingNuxtPage.add(route.file)
+      }
       const routeMeta = getRouteMeta(fileContent, route.file, ctx.extraExtractionKeys)
       if (route.meta) {
         routeMeta.meta = defu({}, routeMeta.meta, route.meta)

--- a/packages/nuxt/test/pages.test.ts
+++ b/packages/nuxt/test/pages.test.ts
@@ -7,6 +7,7 @@ import { generateRouteKey } from '../src/pages/runtime/utils.ts'
 import type { NuxtPage } from 'nuxt/schema'
 import { useNuxt } from '@nuxt/kit'
 import type { InputFile } from 'unrouting'
+import { logger } from '../src/utils.ts'
 
 vi.mock('@nuxt/kit', async (original) => {
   const mod = await original<typeof import('@nuxt/kit')>()
@@ -119,6 +120,56 @@ describe('pages:generateRoutesFromFiles', () => {
       }
     })
   }
+
+  describe('pages:missing NuxtPage warning', () => {
+    it('warns when a parent page has child routes but does not render NuxtPage', async () => {
+      const warn = vi.spyOn(logger, 'warn').mockImplementation(() => undefined)
+      const routes = generateRoutesFromFiles([
+        { path: `${pagesDir}/parent.vue` },
+        { path: `${pagesDir}/parent/child.vue` },
+      ])
+
+      await augmentPages(routes, {
+        [`${pagesDir}/parent.vue`]: '<template><div>Parent</div></template>',
+        [`${pagesDir}/parent/child.vue`]: '<template><div>Child</div></template>',
+      }, { warnAboutMissingNuxtPage: true })
+
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('`pages/parent.vue` has child routes but does not use `<NuxtPage />`'))
+      warn.mockRestore()
+    })
+
+    it('does not warn when a parent page renders NuxtPage', async () => {
+      const warn = vi.spyOn(logger, 'warn').mockImplementation(() => undefined)
+      const routes = generateRoutesFromFiles([
+        { path: `${pagesDir}/parent.vue` },
+        { path: `${pagesDir}/parent/child.vue` },
+      ])
+
+      await augmentPages(routes, {
+        [`${pagesDir}/parent.vue`]: '<template><div><NuxtPage /></div></template>',
+        [`${pagesDir}/parent/child.vue`]: '<template><div>Child</div></template>',
+      }, { warnAboutMissingNuxtPage: true })
+
+      expect(warn).not.toHaveBeenCalled()
+      warn.mockRestore()
+    })
+
+    it('does not warn when a parent page renders nuxt-page in kebab-case', async () => {
+      const warn = vi.spyOn(logger, 'warn').mockImplementation(() => undefined)
+      const routes = generateRoutesFromFiles([
+        { path: `${pagesDir}/parent.vue` },
+        { path: `${pagesDir}/parent/child.vue` },
+      ])
+
+      await augmentPages(routes, {
+        [`${pagesDir}/parent.vue`]: '<template><div><nuxt-page /></div></template>',
+        [`${pagesDir}/parent/child.vue`]: '<template><div>Child</div></template>',
+      }, { warnAboutMissingNuxtPage: true })
+
+      expect(warn).not.toHaveBeenCalled()
+      warn.mockRestore()
+    })
+  })
 
   it('should consistently normalize routes', async () => {
     // Sort each test case's routes array for order-independent comparison


### PR DESCRIPTION
## Summary
- added a dev-only warning when a parent page has child routes but does not render `<NuxtPage />`
- detected both `<NuxtPage />` and `<nuxt-page />` usage to avoid false positives
- covered the warning and non-warning cases in pages tests

## Tests
- `corepack pnpm vitest run packages/nuxt/test/pages.test.ts`
- `corepack pnpm eslint packages/nuxt/src/pages/utils.ts packages/nuxt/test/pages.test.ts --no-cache`
- `git diff --check`

Closes #25077