### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -363,10 +363,10 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
 
   const useDecorators = Boolean(nuxt.options.experimental?.decorators)
 
-  const userExclude = nuxt.options.typescript?.tsConfig?.exclude ?? []
+  const userExclude = nuxt.options.typescript?.appTsConfig?.exclude ?? nuxt.options.typescript?.tsConfig?.exclude ?? []
 
   // https://www.totaltypescript.com/tsconfig-cheat-sheet
-  const tsConfig: TSConfig = defu(nuxt.options.typescript?.tsConfig, {
+  const tsConfig: TSConfig = defu(nuxt.options.typescript?.appTsConfig, nuxt.options.typescript?.tsConfig, {
     compilerOptions: {
       /* Base options: */
       esModuleInterop: true,
@@ -419,7 +419,7 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
   } satisfies TSConfig)
 
   // This describes the environment where we load `nuxt.config.ts` (and modules)
-  const nodeTsConfig: TSConfig = defu(nuxt.options.typescript?.nodeTsConfig, {
+  const nodeTsConfig: TSConfig = defu(nuxt.options.typescript?.nodeTsConfig, nuxt.options.typescript?.tsConfig, {
     compilerOptions: {
       /* Base options: */
       esModuleInterop: tsConfig.compilerOptions?.esModuleInterop,
@@ -455,7 +455,7 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
   } satisfies TSConfig)
 
   // This describes the environment where we load `nuxt.config.ts` (and modules)
-  const sharedTsConfig: TSConfig = defu(nuxt.options.typescript?.sharedTsConfig, {
+  const sharedTsConfig: TSConfig = defu(nuxt.options.typescript?.sharedTsConfig, nuxt.options.typescript?.tsConfig, {
     compilerOptions: {
       /* Base options: */
       esModuleInterop: tsConfig.compilerOptions?.esModuleInterop,

--- a/packages/kit/test/generate-types.spec.ts
+++ b/packages/kit/test/generate-types.spec.ts
@@ -79,12 +79,47 @@ describe('tsConfig generation', () => {
   })
 
   it('should propagate user-defined excludes to legacy tsconfig', async () => {
-    const { legacyTsConfig } = await _generateTypes(mockNuxtWithOptions({
+    const { legacyTsConfig: globalLegacyTsConfig } = await _generateTypes(mockNuxtWithOptions({
       typescript: { tsConfig: { exclude: ['my-custom-exclude'] } },
     }))
-    expect(legacyTsConfig.exclude).toContain('my-custom-exclude')
+    expect(globalLegacyTsConfig.exclude).toContain('my-custom-exclude')
+    expect(globalLegacyTsConfig.exclude).not.toContain('../nuxt.config.*')
+
+    const { legacyTsConfig: appLegacyTsConfig } = await _generateTypes(mockNuxtWithOptions({
+      typescript: {
+        tsConfig: { exclude: ['my-custom-exclude'] },
+        appTsConfig: { exclude: ['my-custom-app-exclude'] },
+      },
+    }))
+    expect(appLegacyTsConfig.exclude).toContain('my-custom-app-exclude')
+    expect(appLegacyTsConfig.exclude).not.toContain('my-custom-exclude')
     // but computed app-only paths must still be absent
-    expect(legacyTsConfig.exclude).not.toContain('../nuxt.config.*')
+    expect(appLegacyTsConfig.exclude).not.toContain('../nuxt.config.*')
+  })
+
+  it('should apply global and context-specific tsconfig options', async () => {
+    const { nodeTsConfig, sharedTsConfig, tsConfig } = await _generateTypes(mockNuxtWithOptions({
+      typescript: {
+        tsConfig: { compilerOptions: { exactOptionalPropertyTypes: true, noUnusedLocals: true } },
+        appTsConfig: { compilerOptions: { noUnusedLocals: false } },
+        nodeTsConfig: { compilerOptions: { noUnusedParameters: true } },
+        sharedTsConfig: { compilerOptions: { noUnusedLocals: false } },
+      },
+    }))
+
+    expect(tsConfig.compilerOptions).toMatchObject({
+      exactOptionalPropertyTypes: true,
+      noUnusedLocals: false,
+    })
+    expect(nodeTsConfig.compilerOptions).toMatchObject({
+      exactOptionalPropertyTypes: true,
+      noUnusedLocals: true,
+      noUnusedParameters: true,
+    })
+    expect(sharedTsConfig.compilerOptions).toMatchObject({
+      exactOptionalPropertyTypes: true,
+      noUnusedLocals: false,
+    })
   })
 
   it('should add #build after #components to paths', async () => {

--- a/packages/nitro-server/src/augments.ts
+++ b/packages/nitro-server/src/augments.ts
@@ -4,6 +4,13 @@ import type { LogObject } from 'consola'
 import type { NuxtIslandContext, NuxtIslandResponse, NuxtRenderChunkContext, NuxtRenderCloseContext, NuxtRenderHTMLContext, NuxtRenderRouteContext } from 'nuxt/app'
 import type { HookResult, RuntimeConfig, TSReference } from 'nuxt/schema'
 
+type NuxtNitroConfig = Omit<NitroConfig, 'typescript'> & {
+  typescript?: Omit<NonNullable<NitroConfig['typescript']>, 'tsConfig'> & {
+    /** @deprecated Use `typescript.serverTsConfig` instead. This option will be removed in Nuxt v5. */
+    tsConfig?: NonNullable<NitroConfig['typescript']>['tsConfig']
+  }
+}
+
 declare module 'nitro/types' {
   interface NitroRuntimeConfigApp {
     baseURL: string
@@ -129,7 +136,7 @@ declare module '@nuxt/schema' {
   }
 
   interface NuxtConfig {
-    nitro?: NitroConfig
+    nitro?: NuxtNitroConfig
   }
 
   interface RuntimeConfig {
@@ -236,7 +243,7 @@ declare module 'nuxt/schema' {
   }
 
   interface NuxtConfig {
-    nitro?: NitroConfig
+    nitro?: NuxtNitroConfig
   }
 
   interface RuntimeConfig {

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -901,6 +901,9 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
   }
   createPortalProperties(options.devServerHandlers, options, ['nitro.devHandlers', 'devServerHandlers'])
 
+  nitroOptions.typescript ||= {}
+  createPortalProperties(defu(options.typescript.serverTsConfig, nitroOptions.typescript.tsConfig, options.typescript.tsConfig), options, ['nitro.typescript.tsConfig', 'typescript.serverTsConfig'])
+
   // prevent replacement of options.nitro
   Object.defineProperties(options, {
     nitro: {

--- a/packages/nuxt/test/load-nuxt.test.ts
+++ b/packages/nuxt/test/load-nuxt.test.ts
@@ -168,6 +168,27 @@ describe('loadNuxt', () => {
 
     await nuxt.close()
   })
+
+  it('syncs server tsconfig options with nitro tsconfig options', async () => {
+    const nuxt = await loadNuxt({
+      cwd: repoRoot,
+      ready: false,
+      overrides: {
+        typescript: {
+          tsConfig: { compilerOptions: { exactOptionalPropertyTypes: true } },
+          serverTsConfig: { compilerOptions: { noUnusedLocals: true } },
+        },
+      },
+    })
+
+    expect(nuxt.options.typescript.serverTsConfig).toBe(nuxt.options.nitro.typescript?.tsConfig)
+    expect(nuxt.options.nitro.typescript?.tsConfig?.compilerOptions).toMatchObject({
+      exactOptionalPropertyTypes: true,
+      noUnusedLocals: true,
+    })
+
+    await nuxt.close()
+  })
 })
 
 const pagesDetectionTests: [test: string, overrides: NuxtConfig, result: NuxtConfig['pages']][] = [

--- a/packages/schema/src/config/typescript.ts
+++ b/packages/schema/src/config/typescript.ts
@@ -36,6 +36,8 @@ export default defineResolvers({
     includeWorkspace: false,
     typeCheck: false,
     tsConfig: {},
+    appTsConfig: {},
+    serverTsConfig: {},
     shim: false,
   },
 })

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1808,9 +1808,19 @@ export interface ConfigSchema {
     typeCheck: boolean | 'build'
 
     /**
-     * You can extend the generated `.nuxt/tsconfig.app.json` (and legacy `.nuxt/tsconfig.json`) using this option.
+     * You can extend all generated Nuxt TypeScript configurations using this option.
      */
     tsConfig: 0 extends 1 & RawVueCompilerOptions ? TSConfig : TSConfig & { vueCompilerOptions?: RawVueCompilerOptions }
+
+    /**
+     * You can extend the generated `.nuxt/tsconfig.app.json` (and legacy `.nuxt/tsconfig.json`) using this option.
+     */
+    appTsConfig: 0 extends 1 & RawVueCompilerOptions ? TSConfig : TSConfig & { vueCompilerOptions?: RawVueCompilerOptions }
+
+    /**
+     * You can extend the generated Nitro server TypeScript configuration using this option.
+     */
+    serverTsConfig: TSConfig
 
     /**
      * You can extend the generated `.nuxt/tsconfig.node.json` using this option.


### PR DESCRIPTION
Closes #33678

### Summary
- added `typescript.appTsConfig` and `typescript.serverTsConfig`
- used `typescript.tsConfig` as the base for app, node, shared, and Nitro server TypeScript configs
- synced `typescript.serverTsConfig` with the legacy `nitro.typescript.tsConfig` option and marked the legacy Nuxt config type as deprecated

### Tests
- `corepack pnpm vitest run packages/kit/test/generate-types.spec.ts packages/nuxt/test/load-nuxt.test.ts`
- `corepack pnpm eslint packages/schema/src/config/typescript.ts packages/schema/src/types/schema.ts packages/kit/src/template.ts packages/kit/test/generate-types.spec.ts packages/nuxt/src/core/nuxt.ts packages/nuxt/test/load-nuxt.test.ts packages/nitro-server/src/augments.ts --no-cache`
- `corepack pnpm exec vue-tsc -p packages/nuxt/tsconfig.build.json --noEmit`
- `corepack pnpm --filter @nuxt/schema build`
- `corepack pnpm --filter @nuxt/nitro-server build`
- `git diff --check`