### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -13,7 +13,7 @@ import { distDir } from '../dirs.ts'
 import { resolveTypePaths } from '../core/utils/types.ts'
 import { logger } from '../utils.ts'
 import picomatch from 'picomatch'
-import { resolvePagesRoutes as _resolvePagesRoutes, augmentAndResolve, createPagesContext, defaultExtractionKeys, normalizeRoutes, resolveRoutePaths, toRou3Patterns } from './utils.ts'
+import { resolvePagesRoutes as _resolvePagesRoutes, augmentAndResolve, createPagesContext, defaultExtractionKeys, findPageServerRouteCollisions, normalizeRoutes, resolveRoutePaths, toRou3Patterns } from './utils.ts'
 import type { PagesContext } from './utils.ts'
 import { globRouteRulesFromPages, removePagesRules } from './route-rules.ts'
 import { PageMetaPlugin } from './plugins/page-meta.ts'
@@ -455,6 +455,37 @@ export default defineNuxtModule({
 
       prerenderRoutes.clear()
       processPages(pages)
+    })
+
+    nuxt.hook('nitro:init', (nitro) => {
+      let lastWarningKey = ''
+      const warnPageServerRouteCollisions = (pages = nuxt.apps.default?.pages || []) => {
+        const serverRoutes = nitro.routing.routes.routes
+          .flatMap(route => Array.isArray(route.data) ? route.data : [route.data])
+          .filter(route => route.handler !== nitro.options.renderer?.handler)
+        const collisions = findPageServerRouteCollisions(pages, serverRoutes)
+        if (!collisions.length) {
+          lastWarningKey = ''
+          return
+        }
+
+        const warningKey = collisions
+          .map(collision => `${collision.method}:${collision.serverRoute}:${collision.pageRoute}`)
+          .join('\n')
+        if (warningKey === lastWarningKey) {
+          return
+        }
+        lastWarningKey = warningKey
+
+        const formattedCollisions = collisions.slice(0, 5)
+          .map(collision => `\`${collision.method} ${collision.serverRoute}\` -> \`${collision.pageRoute}\``)
+          .join(', ')
+        const remaining = collisions.length > 5 ? ` and ${collisions.length - 5} more` : ''
+        logger.warn(`[nuxt] Server routes overlap with page routes and will take precedence: ${formattedCollisions}${remaining}.`)
+      }
+
+      warnPageServerRouteCollisions()
+      nuxt.hook('pages:resolved', warnPageServerRouteCollisions)
     })
 
     nuxt.hook('nitro:build:before', (nitro) => {

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -605,3 +605,139 @@ export function toRou3Patterns (pages: NuxtPage[], prefix = '/'): string[] {
   }
   return routes
 }
+
+export interface ServerRouteLike {
+  route?: string
+  method?: string
+  middleware?: boolean
+}
+
+export interface PageServerRouteCollision {
+  pageRoute: string
+  serverRoute: string
+  method: 'ALL' | 'GET' | 'HEAD'
+}
+
+const PAGE_BLOCKING_SERVER_ROUTE_METHODS = new Set(['', 'GET', 'HEAD'])
+
+export function findPageServerRouteCollisions (pages: NuxtPage[], serverRoutes: ServerRouteLike[]): PageServerRouteCollision[] {
+  const pageRoutes = toRou3Patterns(pages)
+    .filter(route => route && !route.startsWith('/**'))
+    .map(route => ({
+      route,
+      regexp: rou3PatternToRegExp(route),
+      sample: rou3PatternToSamplePath(route),
+    }))
+
+  const collisions: PageServerRouteCollision[] = []
+  const seen = new Set<string>()
+  for (const serverRoute of serverRoutes) {
+    if (serverRoute.middleware || !serverRoute.route) {
+      continue
+    }
+
+    const method = (serverRoute.method || '').toUpperCase()
+    if (!PAGE_BLOCKING_SERVER_ROUTE_METHODS.has(method)) {
+      continue
+    }
+
+    const server = {
+      route: serverRoute.route,
+      regexp: rou3PatternToRegExp(serverRoute.route),
+      sample: rou3PatternToSamplePath(serverRoute.route),
+    }
+
+    for (const page of pageRoutes) {
+      if (!page.regexp.test(server.sample) && !server.regexp.test(page.sample)) {
+        continue
+      }
+
+      const collision = {
+        pageRoute: page.route,
+        serverRoute: server.route,
+        method: method ? method as 'GET' | 'HEAD' : 'ALL' as const,
+      }
+      const key = `${collision.method}:${collision.serverRoute}:${collision.pageRoute}`
+      if (seen.has(key)) {
+        continue
+      }
+      seen.add(key)
+      collisions.push(collision)
+    }
+  }
+
+  return collisions
+}
+
+function rou3PatternToSamplePath (route: string) {
+  const segments = route.split('/').filter(Boolean).map((segment) => {
+    if (segment.startsWith('**')) {
+      return '__wildcard__'
+    }
+    return segment
+      .replace(/:[\w-]+(?:\([^)]*\))?[?+*]?/g, '__param__')
+      .replace(/\*/g, '__wildcard__')
+  })
+
+  return '/' + segments.join('/')
+}
+
+function rou3PatternToRegExp (route: string) {
+  const segments = route.split('/').filter(Boolean)
+  let source = '^'
+  for (const segment of segments) {
+    if (segment === '**') {
+      source += '(?:/.*)?'
+      continue
+    }
+    if (segment.startsWith('**')) {
+      source += '/.+'
+      continue
+    }
+
+    source += '/' + segmentToRegExp(segment)
+  }
+
+  return new RegExp(source + '/?$')
+}
+
+function segmentToRegExp (segment: string) {
+  let source = ''
+  for (let i = 0; i < segment.length; i++) {
+    const char = segment[i]!
+    if (char === ':') {
+      i++
+      while (i < segment.length && /[\w-]/.test(segment[i]!)) {
+        i++
+      }
+      if (segment[i] === '(') {
+        let depth = 1
+        i++
+        while (i < segment.length && depth > 0) {
+          if (segment[i] === '(') {
+            depth++
+          } else if (segment[i] === ')') {
+            depth--
+          }
+          i++
+        }
+      }
+      if (['?', '+', '*'].includes(segment[i]!)) {
+        i++
+      }
+      i--
+      source += '[^/]+'
+      continue
+    }
+    if (char === '*') {
+      source += '[^/]*'
+      continue
+    }
+    source += escapeRE(char)
+  }
+  return source
+}
+
+function escapeRE (value: string) {
+  return value.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&')
+}

--- a/packages/nuxt/test/pages.test.ts
+++ b/packages/nuxt/test/pages.test.ts
@@ -1,7 +1,7 @@
 import type { TestAPI } from 'vitest'
 import { describe, expect, it, vi } from 'vitest'
 import type { RouteLocationNormalizedLoaded } from 'vue-router'
-import { type PagesContextOptions, augmentPages, createPagesContext, normalizeRoutes, pathToNitroGlob } from '../src/pages/utils.ts'
+import { type PagesContextOptions, augmentPages, createPagesContext, findPageServerRouteCollisions, normalizeRoutes, pathToNitroGlob } from '../src/pages/utils.ts'
 import type { RouterViewSlotProps } from '../src/pages/runtime/utils.ts'
 import { generateRouteKey } from '../src/pages/runtime/utils.ts'
 import type { NuxtPage } from 'nuxt/schema'
@@ -425,6 +425,46 @@ const pathToNitroGlobTests = {
 describe('pages:pathToNitroGlob', () => {
   it.each(Object.entries(pathToNitroGlobTests))('should convert %s to %s', (path, expected) => {
     expect(pathToNitroGlob(path)).to.equal(expected)
+  })
+})
+
+describe('pages:serverRouteCollisions', () => {
+  const pages = [
+    { path: '/', file: 'pages/index.vue' },
+    { path: '/about', file: 'pages/about.vue' },
+    { path: '/blog/:slug', file: 'pages/blog/[slug].vue' },
+    { path: '/docs/**:slug', file: 'pages/docs/[...slug].vue' },
+  ] as NuxtPage[]
+
+  it('detects GET, HEAD, and all-method server routes that overlap pages', () => {
+    expect(findPageServerRouteCollisions(pages, [
+      { route: '/about', method: 'GET' },
+      { route: '/blog/hello', method: 'HEAD' },
+      { route: '/docs/**' },
+    ])).toEqual([
+      { pageRoute: '/about', serverRoute: '/about', method: 'GET' },
+      { pageRoute: '/blog/:slug', serverRoute: '/blog/hello', method: 'HEAD' },
+      { pageRoute: '/docs/**:slug', serverRoute: '/docs/**', method: 'ALL' },
+    ])
+  })
+
+  it('detects dynamic server routes that overlap static pages', () => {
+    expect(findPageServerRouteCollisions(pages, [
+      { route: '/:slug', method: 'GET' },
+    ])).toEqual([
+      { pageRoute: '/about', serverRoute: '/:slug', method: 'GET' },
+    ])
+  })
+
+  it('ignores non-rendering methods, middleware, and global page catchalls', () => {
+    expect(findPageServerRouteCollisions([
+      { path: '/**:slug', file: 'pages/[...slug].vue' },
+      { path: '/about', file: 'pages/about.vue' },
+    ] as NuxtPage[], [
+      { route: '/about', method: 'POST' },
+      { route: '/about', method: 'GET', middleware: true },
+      { route: '/only-catchall', method: 'GET' },
+    ])).toEqual([])
   })
 })
 


### PR DESCRIPTION
### Summary
- warned when GET/HEAD/all-method server routes overlap resolved page routes
- ignored non-rendering methods, middleware, global page catchalls, and Nuxt's internal renderer route
- added unit coverage for static, dynamic, and wildcard route collisions

Closes #25709

### Tests
- pnpm vitest packages/nuxt/test/pages.test.ts --run
- pnpm eslint packages/nuxt/src/pages/module.ts packages/nuxt/src/pages/utils.ts packages/nuxt/test/pages.test.ts
- git diff --check