### PR TITLE
docs: add nodeTsConfig and sharedTsConfig options

### DIFF
--- a/docs/4.api/6.nuxt-config.md
+++ b/docs/4.api/6.nuxt-config.md
@@ -313,7 +313,7 @@ This can be overridden with `definePageMeta` on an individual page.
 - **Type**: `boolean`
 - **Default:** `false`
 
-**See**: [Nuxt View Transition API docs](https://nuxt.com/docs/4.x/getting-started/transitions#view-transitions-api-experimental)
+**See**: [Nuxt View Transition API docs](/docs/4.x/getting-started/transitions#view-transitions-api-experimental)
 
 ## appConfig
 
@@ -506,7 +506,7 @@ Any components in the directories configured here can be used throughout your pa
 }
 ```
 
-**See**: [`app/components/` directory documentation](https://nuxt.com/docs/4.x/directory-structure/app/components)
+**See**: [`app/components/` directory documentation](/docs/4.x/directory-structure/app/components)
 
 ## css
 
@@ -837,7 +837,7 @@ Any file in `app/pages/`, `app/layouts/`, `app/middleware/`, and `public/` direc
 
 Configure how Nuxt auto-imports composables into your application.
 
-**See**: [Nuxt documentation](https://nuxt.com/docs/4.x/directory-structure/app/composables)
+**See**: [Nuxt documentation](/docs/4.x/directory-structure/app/composables)
 
 ### `dirs`
 
@@ -1159,7 +1159,7 @@ and these plugins do not need to be listed in `nuxt.config` unless you
 need to customize their order. All plugins are deduplicated by their src path.
 ::
 
-**See**: [`app/plugins/` directory documentation](https://nuxt.com/docs/4.x/directory-structure/app/plugins)
+**See**: [`app/plugins/` directory documentation](/docs/4.x/directory-structure/app/plugins)
 
 **Example**:
 ```ts
@@ -1320,7 +1320,7 @@ Each handler accepts the following options:
 
 - **Type**: `array`
 
-**See**: [`server/` directory documentation](https://nuxt.com/docs/4.x/directory-structure/server)
+**See**: [`server/` directory documentation](/docs/4.x/directory-structure/server)
 
 ::callout
 **Note**: Files from `server/api`, `server/middleware` and `server/routes` will be automatically registered by Nuxt.
@@ -1521,6 +1521,18 @@ Include parent workspace in the Nuxt project. Mostly useful for themes and modul
 - **Type**: `boolean`
 - **Default:** `false`
 
+### `nodeTsConfig`
+
+You can extend the generated `.nuxt/tsconfig.node.json` TypeScript configuration using this option.
+
+**See**: [tsconfig.json information](/docs/4.x/directory-structure/tsconfig)
+
+### `sharedTsConfig`
+
+You can extend the generated `.nuxt/tsconfig.shared.json` TypeScript configuration using this option.
+
+**See**: [tsconfig.json information](/docs/4.x/directory-structure/tsconfig)
+
 ### `shim`
 
 Generate a `*.vue` shim.
@@ -1542,7 +1554,9 @@ TypeScript comes with certain checks to give you more safety and analysis of you
 
 ### `tsConfig`
 
-You can extend the generated TypeScript configurations (`.nuxt/tsconfig.app.json`, `.nuxt/tsconfig.server.json`, etc.) using this option.
+You can extend the generated `.nuxt/tsconfig.app.json` TypeScript configuration using this option.
+
+**See**: [tsconfig.json information](/docs/4.x/directory-structure/tsconfig)
 
 ### `typeCheck`
 
@@ -1553,7 +1567,7 @@ If set to true, this will type check in development. You can restrict this to bu
 - **Type**: `boolean`
 - **Default:** `false`
 
-**See**: [Nuxt TypeScript docs](https://nuxt.com/docs/4.x/guide/concepts/typescript)
+**See**: [Nuxt TypeScript docs](/docs/4.x/guide/concepts/typescript)
 
 ## unhead
 


### PR DESCRIPTION
### 🔗 Linked issue


#34756 

### 📚 Description

Add missing config options for `typescript` in nuxt.config.ts - as also mentioned in https://nuxt.com/docs/5.x/directory-structure/tsconfig

Removed explicit nuxt.com domain, links are now relative. They do still have hardcoded `4.x` in the path.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
