### PR TITLE
fix(kit): improve TS extension stripping/substitutions

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -30,6 +30,7 @@ export default createConfigForNuxt({
         'packages/nuxt/src/app/components/error-*.vue',
         'packages/nuxt/src/core/runtime/nitro/templates/error-*',
         'packages/nitro-server/src/runtime/templates/error-*',
+        'packages/kit/test/types-fixture/**',
       ],
     },
     {

--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -224,7 +224,37 @@ export function resolveLayerPaths (dirs: LayerDirectories, projectBuildDir: stri
   }
 }
 
-const EXTENSION_RE = /\b(?:\.d\.[cm]?ts|\.\w+)$/g
+// TS's `paths` substitution has two branches: an extension on the substitution
+// goes straight to `tryFile` on the literal path (no sibling lookup), while an
+// extensionless substitution goes through `tryAddingExtensions` whose
+// extensionless arm only retries `.ts / .tsx / .d.ts / .js / .jsx`. To make
+// `paths` aliases resolve to the right declarations:
+//   - extensions in that retry list are stripped (TS retries them itself);
+//   - `.d.mts` / `.d.cts` are preserved (the literal-file branch loads them);
+//   - `.mjs` / `.cjs` / `.mts` / `.cts` are checked against their on-disk
+//     siblings (see `getPathSubstitution`).
+// https://github.com/microsoft/TypeScript/blob/v5.6.3/src/compiler/moduleNameResolver.ts
+const STRIPPABLE_EXT_RE = /\b\.(?:d\.ts|tsx?|jsx?)$/
+const RUNTIME_EXT_RE = /\.([cm])(?:ts|js)$/
+
+async function getPathSubstitution (absolutePath: string, buildDir: string): Promise<string> {
+  const stripped = absolutePath.replace(STRIPPABLE_EXT_RE, '')
+  if (stripped !== absolutePath) {
+    return relativeWithDot(buildDir, stripped)
+  }
+  const runtimeMatch = absolutePath.match(RUNTIME_EXT_RE)
+  if (runtimeMatch) {
+    const base = absolutePath.slice(0, -runtimeMatch[0]!.length)
+    if (await fsp.stat(`${base}.d.ts`).then(s => s.isFile(), () => false)) {
+      return relativeWithDot(buildDir, base)
+    }
+    const declaration = `${base}.d.${runtimeMatch[1]}ts`
+    if (await fsp.stat(declaration).then(s => s.isFile(), () => false)) {
+      return relativeWithDot(buildDir, declaration)
+    }
+  }
+  return relativeWithDot(buildDir, absolutePath)
+}
 // Exclude bridge alias types to support Volar
 const excludedAlias = [/^@vue\/.*$/, /^#internal\/nuxt/]
 
@@ -531,8 +561,7 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
       tsConfig.compilerOptions.paths[`${alias}/*`] = [`${relativePath}/*`]
     } else {
       const path = stats?.isFile()
-        // remove extension
-        ? relativePath.replace(EXTENSION_RE, '')
+        ? await getPathSubstitution(absolutePath, nuxt.options.buildDir)
         // non-existent file probably shouldn't be resolved
         : aliases[alias]!
 
@@ -578,7 +607,9 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
       tsConfig.compilerOptions!.paths[alias] = [...new Set(await Promise.all(paths.map(async (path: string) => {
         if (!isAbsolute(path)) { return path }
         const stats = await fsp.stat(path).catch(() => null /* file does not exist */)
-        return relativeWithDot(nuxt.options.buildDir, stats?.isFile() ? path.replace(EXTENSION_RE, '') /* remove extension */ : path)
+        return stats?.isFile()
+          ? getPathSubstitution(path, nuxt.options.buildDir)
+          : relativeWithDot(nuxt.options.buildDir, path)
       })))]
     }
 

--- a/packages/kit/test/generate-types.spec.ts
+++ b/packages/kit/test/generate-types.spec.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import type { Nuxt, NuxtConfig } from '@nuxt/schema'
 import { defu } from 'defu'
@@ -6,6 +7,8 @@ import { findWorkspaceDir } from 'pkg-types'
 import { loadNuxtConfig } from '../src/loader/config.ts'
 import { _generateTypes, resolveLayerPaths } from '../src/template.ts'
 import { getLayerDirectories } from 'nuxt/kit'
+
+const typesFixtureDir = fileURLToPath(new URL('./types-fixture', import.meta.url))
 
 type DeepPartial<T> = {
   [P in keyof T]?: T[P] extends Record<string, any> ? DeepPartial<T[P]> : T[P]
@@ -85,6 +88,52 @@ describe('tsConfig generation', () => {
     expect(legacyTsConfig.exclude).toContain('my-custom-exclude')
     // but computed app-only paths must still be absent
     expect(legacyTsConfig.exclude).not.toContain('../nuxt.config.*')
+  })
+
+  it('should rewrite `paths` substitutions so TS resolves them to declarations', async () => {
+    const fixtureAliases = {
+      'nitro/h3': `${typesFixtureDir}/h3.d.mts`,
+      'nitro/h3-cjs': `${typesFixtureDir}/h3.d.cts`,
+      'nitro/util-ts': `${typesFixtureDir}/util.ts`,
+      'nitro/cjs-src': `${typesFixtureDir}/cjs-src.cts`,
+      'nitro/runtime-with-dts': `${typesFixtureDir}/runtime.mjs`,
+      'nitro/h3-runtime': `${typesFixtureDir}/h3-runtime.mjs`,
+      'nitro/cache-lonely': `${typesFixtureDir}/cache.mjs`,
+    }
+    const nuxt = mockNuxtWithOptions({ alias: fixtureAliases })
+    nuxt.callHook = ((name: string, ctx: unknown) => {
+      if (name === 'prepare:types') {
+        const { tsConfig } = ctx as { tsConfig: { compilerOptions: { paths: Record<string, string[]> } } }
+        for (const [alias, target] of Object.entries(fixtureAliases)) {
+          tsConfig.compilerOptions.paths[`${alias}-hooked`] = [target]
+        }
+      }
+      return Promise.resolve()
+    }) as Nuxt['callHook']
+
+    const { tsConfig } = await _generateTypes(nuxt)
+    const paths = tsConfig.compilerOptions?.paths ?? {}
+
+    const expectations: Record<string, RegExp> = {
+      // declaration files are preserved as-is
+      'nitro/h3': /\/h3\.d\.mts$/,
+      'nitro/h3-cjs': /\/h3\.d\.cts$/,
+      // `.ts` is in TS's extensionless retry list; strip so a sibling `.d.ts` could be found
+      'nitro/util-ts': /\/util$/,
+      // `.cts` is not in the retry list and has no declaration sibling; preserved literally
+      'nitro/cjs-src': /\/cjs-src\.cts$/,
+      // `.mjs` with a sibling `.d.ts` strips so TS retries `.d.ts`
+      'nitro/runtime-with-dts': /\/runtime$/,
+      // `.mjs` with a sibling `.d.mts` rewrites to the declaration directly
+      'nitro/h3-runtime': /\/h3-runtime\.d\.mts$/,
+      // `.mjs` with no declarations is preserved literally (TS7016 beats TS2307)
+      'nitro/cache-lonely': /\/cache\.mjs$/,
+    }
+
+    for (const [alias, pattern] of Object.entries(expectations)) {
+      expect(paths[alias]?.[0], `alias-loop substitution for ${alias}`).toMatch(pattern)
+      expect(paths[`${alias}-hooked`]?.[0], `resolveConfig substitution for ${alias}-hooked`).toMatch(pattern)
+    }
   })
 
   it('should add #build after #components to paths', async () => {

--- a/packages/kit/test/types-fixture/cache.mjs
+++ b/packages/kit/test/types-fixture/cache.mjs
@@ -1,0 +1,1 @@
+export const cache = {}

--- a/packages/kit/test/types-fixture/cjs-src.cts
+++ b/packages/kit/test/types-fixture/cjs-src.cts
@@ -1,0 +1,1 @@
+export const cjsSrc: number = 1

--- a/packages/kit/test/types-fixture/h3-runtime.d.mts
+++ b/packages/kit/test/types-fixture/h3-runtime.d.mts
@@ -1,0 +1,1 @@
+export declare const h3Runtime: number

--- a/packages/kit/test/types-fixture/h3-runtime.mjs
+++ b/packages/kit/test/types-fixture/h3-runtime.mjs
@@ -1,0 +1,1 @@
+export const h3Runtime = 1

--- a/packages/kit/test/types-fixture/h3.d.cts
+++ b/packages/kit/test/types-fixture/h3.d.cts
@@ -1,0 +1,1 @@
+export declare const defineEventHandler: (handler: any) => any

--- a/packages/kit/test/types-fixture/h3.d.mts
+++ b/packages/kit/test/types-fixture/h3.d.mts
@@ -1,0 +1,1 @@
+export declare const defineEventHandler: (handler: any) => any

--- a/packages/kit/test/types-fixture/runtime.d.ts
+++ b/packages/kit/test/types-fixture/runtime.d.ts
@@ -1,0 +1,1 @@
+export declare const runtime: number

--- a/packages/kit/test/types-fixture/runtime.mjs
+++ b/packages/kit/test/types-fixture/runtime.mjs
@@ -1,0 +1,1 @@
+export const runtime = 1

--- a/packages/kit/test/types-fixture/util.ts
+++ b/packages/kit/test/types-fixture/util.ts
@@ -1,0 +1,1 @@
+export const util = 1

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -49,6 +49,7 @@
     "**/dist/**",
     "**/.nuxt/**",
     "packages/nuxt/src/app/types/**",
+    "packages/kit/test/types-fixture/**",
     "packages/nuxt/meta.d.ts",
     "**/nuxt.d.ts",
     "**/examples/**",


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nitrojs/nitro/pull/4297

### 📚 Description

spotted this when testing nuxt v5 nightly - `../node_modules/nitro/h3` isn't valid when `h3.mjs` and `h3.d.mts` are the extensions

https://stackblitz.com/edit/node-4mtandbr