### PR TITLE
fix(nuxt): preserve `.d.mts`/`.d.cts` in `resolveTypePaths`

### DIFF
--- a/docs/4.api/5.kit/12.resolving.md
+++ b/docs/4.api/5.kit/12.resolving.md
@@ -8,11 +8,11 @@ links:
     size: xs
 ---
 
-Sometimes you need to resolve a paths: relative to the current module, with unknown name or extension. For example, you may want to add a plugin that is located in the same directory as the module. To handle this cases, nuxt provides a set of utilities to resolve paths. `resolvePath` and `resolveAlias` are used to resolve paths relative to the current module. `findPath` is used to find first existing file in given paths. `createResolver` is used to create resolver relative to base path.
+Sometimes you need to resolve a path relative to the current module without knowing the name or extension. For example, you may want to add a plugin that is located in the same directory as the module. To handle these cases, Nuxt provides a set of utilities to resolve paths. `resolvePath` and `resolveAlias` are used to resolve paths relative to the current module. `findPath` is used to find the first existing file in a given set of paths. `createResolver` is used to create a resolver relative to the base path.
 
 ## `resolvePath`
 
-Resolves full path to a file or directory respecting Nuxt alias and extensions options. If path could not be resolved, normalized input path will be returned.
+Resolves the full path to a file or directory, respecting Nuxt alias and extensions options. If a path could not be resolved, a normalized input path will be returned.
 
 ### Usage
 
@@ -115,7 +115,7 @@ function resolveAlias (path: string, alias?: Record<string, string>): string
 
 ## `findPath`
 
-Try to resolve first existing file in given paths.
+Try to resolve first existing file in a given set of paths.
 
 ### Usage
 

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -16,11 +16,6 @@ import type { NuxtOptions, NuxtTemplate } from 'nuxt/schema'
 import type { Nitro } from 'nitro/types'
 
 const defuPath = resolveModulePath('defu', { try: true, from: import.meta.url }) ?? 'defu'
-const nitroServerPath = resolveModulePath('@nuxt/nitro-server', { try: true, from: import.meta.url })
-const runtimeConfigPath = resolveModulePath('nitro/runtime-config', {
-  try: true,
-  from: nitroServerPath ? [nitroServerPath, import.meta.url] : import.meta.url,
-}) ?? 'nitro/runtime-config'
 
 export const vueShim: NuxtTemplate = {
   filename: 'types/vue-shim.d.ts',
@@ -465,7 +460,7 @@ export const publicPathTemplate: NuxtTemplate = {
   getContents ({ nuxt }) {
     return [
       'import { joinRelativeURL } from \'ufo\'',
-      !nuxt.options.dev && `import { useRuntimeConfig } from ${JSON.stringify(runtimeConfigPath)}`,
+      !nuxt.options.dev && 'import { useRuntimeConfig } from \'nitro/runtime-config\'',
 
       nuxt.options.dev
         ? `const getAppConfig = () => (${JSON.stringify(nuxt.options.app)})`

--- a/packages/nuxt/src/core/utils/types.ts
+++ b/packages/nuxt/src/core/utils/types.ts
@@ -1,3 +1,4 @@
+import { promises as fsp } from 'node:fs'
 import { resolvePackageJSON } from 'pkg-types'
 import { resolveModulePath } from 'exsolve'
 import { dirname } from 'pathe'
@@ -31,6 +32,33 @@ async function _resolveRoot (basePkg: string, from: Array<string | URL> | undefi
 
 const NESTED_RE = /^[^@]+\//
 
+// TS's `paths` substitution only retries `.ts / .tsx / .d.ts / .js / .jsx`
+// when the substitution is extensionless, so `.d.mts` / `.d.cts` are preserved
+// and `.mjs` / `.cjs` / `.mts` / `.cts` are rewritten to a sibling declaration
+// when one exists.
+// https://github.com/microsoft/TypeScript/blob/v5.6.3/src/compiler/moduleNameResolver.ts
+const STRIPPABLE_EXT_RE = /\b\.(?:d\.ts|tsx?|jsx?)$/
+const RUNTIME_EXT_RE = /\.([cm])(?:ts|js)$/
+
+async function resolveDeclarationPath (absolutePath: string): Promise<string> {
+  const stripped = absolutePath.replace(STRIPPABLE_EXT_RE, '')
+  if (stripped !== absolutePath) {
+    return stripped
+  }
+  const runtimeMatch = absolutePath.match(RUNTIME_EXT_RE)
+  if (runtimeMatch) {
+    const base = absolutePath.slice(0, -runtimeMatch[0]!.length)
+    if (await fsp.stat(`${base}.d.ts`).then(s => s.isFile(), () => false)) {
+      return base
+    }
+    const declaration = `${base}.d.${runtimeMatch[1]}ts`
+    if (await fsp.stat(declaration).then(s => s.isFile(), () => false)) {
+      return declaration
+    }
+  }
+  return absolutePath
+}
+
 export async function resolveTypePaths (packages: string[], searchPaths: string[]): Promise<Array<[string, string]>> {
   const results: Array<[string, string]> = []
 
@@ -54,7 +82,7 @@ export async function resolveTypePaths (packages: string[], searchPaths: string[
       ...TYPE_RESOLVE_OPTIONS,
     })
 
-    results.push([pkg, r.replace(/(?:\.d)?\.[mc]?[jt]s$/, '')])
+    results.push([pkg, await resolveDeclarationPath(r)])
   }))
 
   return results

--- a/packages/nuxt/test/resolve-type-paths.test.ts
+++ b/packages/nuxt/test/resolve-type-paths.test.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('exsolve', () => ({
@@ -53,7 +54,7 @@ describe('resolveTypePaths', () => {
 
     const results = await resolveTypePaths(['nitro/app'], ['/project/node_modules'])
 
-    expect(results).toEqual([['nitro/app', '/node_modules/nitro/dist/app']])
+    expect(results).toEqual([['nitro/app', '/node_modules/nitro/dist/app.d.mts']])
   })
 
   it('caches base package root across multiple subpath entries', async () => {
@@ -70,8 +71,8 @@ describe('resolveTypePaths', () => {
     const results = await resolveTypePaths(['nitro/app', 'nitro/builder'], ['/project/node_modules'])
 
     expect(results).toHaveLength(2)
-    expect(results).toContainEqual(['nitro/app', '/node_modules/nitro/dist/app'])
-    expect(results).toContainEqual(['nitro/builder', '/node_modules/nitro/dist/builder'])
+    expect(results).toContainEqual(['nitro/app', '/node_modules/nitro/dist/app.d.mts'])
+    expect(results).toContainEqual(['nitro/builder', '/node_modules/nitro/dist/builder.d.mts'])
 
     // resolvePackageJSON called only once (for the base 'nitro', then cached)
     expect(mockedResolvePackageJSON).toHaveBeenCalledTimes(1)
@@ -114,24 +115,42 @@ describe('resolveTypePaths', () => {
 
     expect(results).toHaveLength(3)
     expect(results).toContainEqual(['vue', '/node_modules/vue'])
-    expect(results).toContainEqual(['nitro/app', '/node_modules/nitro/dist/app'])
-    expect(results).toContainEqual(['nitro/types', '/node_modules/nitro/dist/types'])
+    expect(results).toContainEqual(['nitro/app', '/node_modules/nitro/dist/app.d.mts'])
+    expect(results).toContainEqual(['nitro/types', '/node_modules/nitro/dist/types.d.mts'])
   })
 
-  it('strips various type extensions from subpath resolutions', async () => {
+  it('preserves `.d.mts` / `.d.cts` declaration extensions on subpath resolutions', async () => {
     const { resolveTypePaths } = await freshImport()
 
     mockedResolveModulePath.mockImplementation((path) => {
       if (path === 'nitro') { return '/node_modules/nitro/dist/index.mjs' }
-      if (path === 'nitro/app') { return '/node_modules/nitro/dist/app.d.mts' }
+      if (path === 'nitro/h3') { return '/node_modules/nitro/dist/h3.d.mts' }
+      if (path === 'nitro/h3-cjs') { return '/node_modules/nitro/dist/h3.d.cts' }
       throw new Error('MODULE_NOT_FOUND')
     })
     mockedResolvePackageJSON.mockResolvedValue('/node_modules/nitro/package.json')
 
-    const results = await resolveTypePaths(['nitro/app'], ['/project/node_modules'])
+    const results = await resolveTypePaths(['nitro/h3', 'nitro/h3-cjs'], ['/project/node_modules'])
 
-    // .d.mts should be stripped
-    expect(results[0]![1]).toBe('/node_modules/nitro/dist/app')
+    expect(results).toContainEqual(['nitro/h3', '/node_modules/nitro/dist/h3.d.mts'])
+    expect(results).toContainEqual(['nitro/h3-cjs', '/node_modules/nitro/dist/h3.d.cts'])
+  })
+
+  it('strips extensions in TS\'s extensionless retry list', async () => {
+    const { resolveTypePaths } = await freshImport()
+
+    mockedResolveModulePath.mockImplementation((path) => {
+      if (path === 'nitro') { return '/node_modules/nitro/dist/index.mjs' }
+      if (path === 'nitro/util-ts') { return '/node_modules/nitro/dist/util.ts' }
+      if (path === 'nitro/runtime-dts') { return '/node_modules/nitro/dist/runtime.d.ts' }
+      throw new Error('MODULE_NOT_FOUND')
+    })
+    mockedResolvePackageJSON.mockResolvedValue('/node_modules/nitro/package.json')
+
+    const results = await resolveTypePaths(['nitro/util-ts', 'nitro/runtime-dts'], ['/project/node_modules'])
+
+    expect(results).toContainEqual(['nitro/util-ts', '/node_modules/nitro/dist/util'])
+    expect(results).toContainEqual(['nitro/runtime-dts', '/node_modules/nitro/dist/runtime'])
   })
 
   it('handles resolution errors gracefully for individual packages', async () => {
@@ -147,5 +166,30 @@ describe('resolveTypePaths', () => {
 
     // vue resolves, nonexistent is silently skipped
     expect(results).toEqual([['vue', '/node_modules/vue']])
+  })
+
+  it('rewrites `.mjs` to its declaration sibling when one exists', async () => {
+    const { resolveTypePaths } = await freshImport()
+
+    const typesFixtureDir = fileURLToPath(new URL('../../kit/test/types-fixture', import.meta.url))
+
+    mockedResolveModulePath.mockImplementation((path) => {
+      if (path === 'nitro') { return `${typesFixtureDir}/cache.mjs` }
+      if (path === 'nitro/h3-runtime') { return `${typesFixtureDir}/h3-runtime.mjs` }
+      if (path === 'nitro/runtime-with-dts') { return `${typesFixtureDir}/runtime.mjs` }
+      if (path === 'nitro/cache-lonely') { return `${typesFixtureDir}/cache.mjs` }
+      throw new Error('MODULE_NOT_FOUND')
+    })
+    mockedResolvePackageJSON.mockResolvedValue('/node_modules/nitro/package.json')
+
+    const results = await resolveTypePaths(
+      ['nitro/h3-runtime', 'nitro/runtime-with-dts', 'nitro/cache-lonely'],
+      ['/project/node_modules'],
+    )
+
+    const map = Object.fromEntries(results)
+    expect(map['nitro/h3-runtime']).toBe(`${typesFixtureDir}/h3-runtime.d.mts`)
+    expect(map['nitro/runtime-with-dts']).toBe(`${typesFixtureDir}/runtime`)
+    expect(map['nitro/cache-lonely']).toBe(`${typesFixtureDir}/cache.mjs`)
   })
 })

--- a/packages/nuxt/test/templates.test.ts
+++ b/packages/nuxt/test/templates.test.ts
@@ -40,16 +40,10 @@ describe('appConfigTemplate', () => {
 })
 
 describe('publicPathTemplate', () => {
-  it('emits an absolute path for `nitro/runtime-config` in production builds', async () => {
+  it('imports `useRuntimeConfig` from the bare `nitro/runtime-config` specifier in production builds', async () => {
     const contents = await publicPathTemplate.getContents!({ nuxt: makeNuxt(), app: makeApp(), options: {} })
 
-    expect(contents).not.toMatch(/from ['"]nitro\/runtime-config['"]/)
-    const match = contents.match(/import \{ useRuntimeConfig \} from ["']([^"']+)["']/)
-    expect(match, 'expected resolved `useRuntimeConfig` import').toBeTruthy()
-    const resolved = match![1]!
-    expect(resolve(resolved)).toBe(resolved)
-    expect(existsSync(resolved)).toBe(true)
-    expect(resolved).toMatch(/runtime-config/)
+    expect(contents).toMatch(/import \{ useRuntimeConfig \} from ['"]nitro\/runtime-config['"]/)
   })
 
   it('omits the runtime-config import entirely in dev mode', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this ports https://github.com/nuxt/nuxt/pull/35233 to a parallel location in `nuxt` itself - missed this in the previous PR