### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/packages/nuxt/src/app/plugins/payload.client.ts
+++ b/packages/nuxt/src/app/plugins/payload.client.ts
@@ -18,6 +18,15 @@ const plugin: Plugin & ObjectPlugin = defineNuxtPlugin({
   setup (nuxtApp) {
     // Load payload after middleware & once final route is resolved
     const staticKeysToRemove = new Set<string>()
+    useRouter().afterEach(() => {
+      // Evict all stale prefetch entries after navigation commits.
+      // Prefetch hints for other routes are no longer needed once a navigation has committed.
+      for (const entry of forwardedPrefetchEntries.values()) {
+        entry.dispose()
+      }
+      forwardedPrefetchEntries.clear()
+    })
+
     useRouter().beforeResolve(async (to, from) => {
       if (to.path === from.path) { return }
       if (prefetchPreloadTags) {
@@ -53,7 +62,9 @@ const plugin: Plugin & ObjectPlugin = defineNuxtPlugin({
         if (hostname !== window.location.hostname) { return }
         // TODO: use preloadPayload instead once we can support preloading islands too
         const payload = await loadPayload(url).catch(() => { console.warn('[nuxt] Error preloading payload for', url) })
-        if (head && payload?.prefetchLinks?.length && !forwardedPrefetchEntries.has(url)) {
+        if (head && payload?.prefetchLinks?.length) {
+          const urlPath = new URL(url, window.location.href).pathname
+          if (forwardedPrefetchEntries.has(urlPath)) { return }
           const entry = head.push({
             link: payload.prefetchLinks.map((link: Record<string, string | boolean>) => {
               // downgrade preload (and modulepreload) to prefetch
@@ -61,7 +72,7 @@ const plugin: Plugin & ObjectPlugin = defineNuxtPlugin({
               return { ...rest, rel: 'prefetch' }
             }),
           })
-          forwardedPrefetchEntries.set(url, entry)
+          forwardedPrefetchEntries.set(urlPath, entry)
         }
       })
       if (isAppManifestEnabled && navigator.connection?.effectiveType !== 'slow-2g') {


### PR DESCRIPTION
Fixes nuxt/nuxt#35212

Two issues in payload.client.ts:
1. Key mismatch: entries were stored with the full URL (which may include query strings or hash), but looked up using to.path (path only). This caused prefetch entries for URLs with query params to never be deleted. Fix: normalize to pathname on insert using new URL(url).pathname.
2. Memory leak: the Map was only pruned when the user actually navigated to a prefetched route. Prefetched-but-never-visited routes accumulated indefinitely. Fix: clear all entries in afterEach so stale prefetch hints are evicted after every navigation commit.