### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/packages/vite/src/plugins/vite-node.ts
+++ b/packages/vite/src/plugins/vite-node.ts
@@ -138,9 +138,9 @@ export function pickSocketPath (platform: NodeJS.Platform): SocketPathInfo {
     return { socketPath: join(String.raw`\\.\pipe`, socketName) }
   }
   // place the socket inside a freshly-created 0700 directory to gate access.
-  const parentDir = fs.mkdtempSync(join(os.tmpdir(), 'nuxt-vite-node-'))
+  const parentDir = fs.mkdtempSync(join(os.tmpdir(), 'nvn-'))
   fs.chmodSync(parentDir, 0o700)
-  return { socketPath: join(parentDir, `${socketName}.sock`), parentDir }
+  return { socketPath: join(parentDir, 's.sock'), parentDir }
 }
 
 function generateSocketPath (): SocketPathInfo {


### PR DESCRIPTION
Fixes #35253. Shortens the two path components added in 4.4.7 to stay under the 104-byte sun_path limit on macOS. mkdtemp prefix: nuxt-vite-node- to nvn-. Socket filename: nuxt-vite-node-pid-ts.sock to s.sock. The parent dir is already uniquely named by mkdtemp so the socket file needs no extra identity.