### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/packages/vite/src/plugins/vite-node.ts
+++ b/packages/vite/src/plugins/vite-node.ts
@@ -138,9 +138,9 @@ export function pickSocketPath (platform: NodeJS.Platform): SocketPathInfo {
     return { socketPath: join(String.raw`\\.\pipe`, socketName) }
   }
   // place the socket inside a freshly-created 0700 directory to gate access.
-  const parentDir = fs.mkdtempSync(join(os.tmpdir(), 'nuxt-vite-node-'))
+  const parentDir = fs.mkdtempSync(join(os.tmpdir(), 'nvn-'))
   fs.chmodSync(parentDir, 0o700)
-  return { socketPath: join(parentDir, `${socketName}.sock`), parentDir }
+  return { socketPath: join(parentDir, 's.sock'), parentDir }
 }
 
 function generateSocketPath (): SocketPathInfo {


### PR DESCRIPTION
I traced issue #35253 myself and the cause is clear: the 4.4.7 change wraps the socket file in a mkdtemp subdirectory, adding ~22 extra characters to an already-long macOS TMPDIR path and pushing it past the 104-byte sun_path limit that AF_UNIX sockets enforce on macOS.

The fix shortens the two path components:
- mkdtemp prefix: \
uxt-vite-node-\ (16 chars) to \
vn-\ (4 chars)
- socket filename: \
uxt-vite-node-{pid}-{ts}.sock\ to \s.sock\ — safe because each socket already lives in its own unique temp directory from mkdtemp

Before: \/var/folders/xx/.../T/nuxt-vite-node-aBcDeF/nuxt-vite-node-12345-1700000000000.sock\ (110+ bytes)
After: \/var/folders/xx/.../T/nvn-aBcDeF/s.sock\ (~78 bytes)

The CodSpeed 13% regression on loadNuxt is a false positive — the report itself flags 'Different runtime environments detected' and a string rename in pickSocketPath cannot affect Nuxt load time.