### PR TITLE
fix(vite): use short vite-node socket filename to fit AF_UNIX path limit

### DIFF
--- a/packages/vite/src/plugins/vite-node.ts
+++ b/packages/vite/src/plugins/vite-node.ts
@@ -131,16 +131,14 @@ export interface SocketPathInfo {
 
 // only exported for tests
 export function pickSocketPath (platform: NodeJS.Platform): SocketPathInfo {
-  const uniqueSuffix = `${process.pid}-${Date.now()}`
-  const socketName = `nuxt-vite-node-${uniqueSuffix}`
-
   if (platform === 'win32') {
-    return { socketPath: join(String.raw`\\.\pipe`, socketName) }
+    return { socketPath: join(String.raw`\\.\pipe`, `nuxt-vite-node-${process.pid}-${Date.now()}`) }
   }
-  // place the socket inside a freshly-created 0700 directory to gate access.
+  // the unique 0700 mkdtemp directory gates access and guarantees uniqueness,
+  // so the socket file uses a short name - AF_UNIX paths are capped at 104 bytes on macOS.
   const parentDir = fs.mkdtempSync(join(os.tmpdir(), 'nuxt-vite-node-'))
   fs.chmodSync(parentDir, 0o700)
-  return { socketPath: join(parentDir, `${socketName}.sock`), parentDir }
+  return { socketPath: join(parentDir, 'node.sock'), parentDir }
 }
 
 function generateSocketPath (): SocketPathInfo {

--- a/packages/vite/test/vite-node.test.ts
+++ b/packages/vite/test/vite-node.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs'
 import net from 'node:net'
 import os from 'node:os'
+import { basename } from 'node:path'
 import process from 'node:process'
 import { afterEach, describe, expect, it } from 'vitest'
 import { listenAndRestrict, pickSocketPath } from '../src/plugins/vite-node.ts'
@@ -50,6 +51,11 @@ describe('pickSocketPath', () => {
     const { parentDir } = trackedPick()
     const stat = fs.statSync(parentDir!)
     expect(stat.mode & 0o777).toBe(0o700)
+  })
+
+  it('uses a short socket filename to stay within the AF_UNIX length limit', () => {
+    const { socketPath } = trackedPick('darwin')
+    expect(basename(socketPath).length).toBeLessThanOrEqual(16)
   })
 })
 


### PR DESCRIPTION
### 🔗 Linked issue

Fixes: #35258 

### 📚 Description

These's a char limit (104 on macOS, 108 on linux) that throws an error. The unique name of the `.sock` is over 39 chars long. Now it is shorter. Because each socket lives in its own unique folder, the short name will break nothing.

### Tests
added one test to check the shorter name if not **win**
