### PR TITLE
fix(vite): shorter socket name for macOs with tmp fallback

### DIFF
--- a/packages/vite/src/plugins/vite-node.ts
+++ b/packages/vite/src/plugins/vite-node.ts
@@ -6,6 +6,7 @@ import os from 'node:os'
 import fs from 'node:fs' // For sync operations like unlinkSync if needed during setup
 import { pathToFileURL } from 'node:url'
 import { Buffer } from 'node:buffer'
+import { randomUUID } from 'node:crypto'
 import { dirname, isAbsolute, join, normalize } from 'pathe'
 import { directoryToURL, resolveAlias, tryUseNuxt, useNitro } from '@nuxt/kit'
 import type { EnvironmentModuleNode, ModuleNode, PluginContainer, ViteDevServer, Plugin as VitePlugin } from 'vite'
@@ -130,17 +131,33 @@ export interface SocketPathInfo {
 }
 
 // only exported for tests
-export function pickSocketPath (platform: NodeJS.Platform): SocketPathInfo {
-  const uniqueSuffix = `${process.pid}-${Date.now()}`
-  const socketName = `nuxt-vite-node-${uniqueSuffix}`
+export function pickSocketPath (platform: NodeJS.Platform, tmpdir: string = os.tmpdir()): SocketPathInfo {
+  const socketName = 'nuxt-vite.sock'
+  // The socket needs its own 0700 directory to gate access on macOS/BSD.
+  // See https://github.com/advisories/GHSA-534h-c3cw-v3h9
+  // enough randomness to avoid collisions between concurrent dev servers and
+  // short enough to avoid hitting the socket path length limit when combined
+  // with the temp directory path.
+  const socketDir = `nuxt-vite-${randomUUID().slice(0, 8)}`
 
   if (platform === 'win32') {
-    return { socketPath: join(String.raw`\\.\pipe`, socketName) }
+    return { socketPath: join(String.raw`\\.\pipe`, socketDir) }
   }
-  // place the socket inside a freshly-created 0700 directory to gate access.
-  const parentDir = fs.mkdtempSync(join(os.tmpdir(), 'nuxt-vite-node-'))
+
+  // macOS's per-user $TMPDIR can be too long so fall back to /tmp when the
+  // full path exceeds the limit
+  const base = Buffer.byteLength(join(tmpdir, socketDir, socketName)) >
+    (platform === 'linux' ? 108 : /* macOS */ 104)
+    ? '/tmp'
+    : tmpdir
+
+  // AF_UNIX connect needs +x on every parent; non-recursive mkdir never adopts
+  // a pre-existing directory.
+  const parentDir = join(base, socketDir)
+  fs.mkdirSync(parentDir, { mode: 0o700 })
   fs.chmodSync(parentDir, 0o700)
-  return { socketPath: join(parentDir, `${socketName}.sock`), parentDir }
+
+  return { socketPath: join(parentDir, socketName), parentDir }
 }
 
 function generateSocketPath (): SocketPathInfo {
@@ -350,7 +367,7 @@ function createViteNodeSocketServer (nuxt: Nuxt, ssrServer: ViteDevServer, clien
                     errorData.frame = await ssrServer.environments.client.transformRequest(request.payload.moduleId)
                       .then(res => `${err.message || ''}\n${res?.code}`).catch(() => undefined)
                   } catch {
-                  // Ignore transform errors
+                    // Ignore transform errors
                   }
                 }
                 throw { data: errorData, message: err.message || 'Error fetching module' } satisfies ErrorPartial
@@ -464,7 +481,7 @@ function createViteNodeSocketServer (nuxt: Nuxt, ssrServer: ViteDevServer, clien
 
   listenAndRestrict(server, currentSocketPath)
 
-  server.on('error', () => {})
+  server.on('error', () => { })
 
   return server
 }

--- a/packages/vite/src/plugins/vite-node.ts
+++ b/packages/vite/src/plugins/vite-node.ts
@@ -132,7 +132,7 @@ export interface SocketPathInfo {
 
 // only exported for tests
 export function pickSocketPath (platform: NodeJS.Platform, tmpdir: string = os.tmpdir()): SocketPathInfo {
-  const socketName = 'nuxt-vite.sock'
+  const socketName = 'nuxt.sock'
   // The socket needs its own 0700 directory to gate access on macOS/BSD.
   // See https://github.com/advisories/GHSA-534h-c3cw-v3h9
   // enough randomness to avoid collisions between concurrent dev servers and

--- a/packages/vite/src/plugins/vite-node.ts
+++ b/packages/vite/src/plugins/vite-node.ts
@@ -133,28 +133,26 @@ export interface SocketPathInfo {
 // only exported for tests
 export function pickSocketPath (platform: NodeJS.Platform, tmpdir: string = os.tmpdir()): SocketPathInfo {
   const socketName = 'nuxt.sock'
-  // The socket needs its own 0700 directory to gate access on macOS/BSD.
-  // See https://github.com/advisories/GHSA-534h-c3cw-v3h9
-  // enough randomness to avoid collisions between concurrent dev servers and
-  // short enough to avoid hitting the socket path length limit when combined
-  // with the temp directory path.
-  const socketDir = `nuxt-vite-${randomUUID().slice(0, 8)}`
+  const socketDir = `nuxt-vite-`
 
   if (platform === 'win32') {
-    return { socketPath: join(String.raw`\\.\pipe`, socketDir) }
+  // enough randomness to avoid collisions and being predictable
+    return { socketPath: join(String.raw`\\.\pipe`, socketDir + randomUUID().slice(0, 8)) }
   }
+
+  // creates a random suffix and avoids collisions
+  let parentDir = fs.mkdtempSync(join(tmpdir, socketDir))
 
   // macOS's per-user $TMPDIR can be too long so fall back to /tmp when the
   // full path exceeds the limit
-  const base = Buffer.byteLength(join(tmpdir, socketDir, socketName)) >
-    (platform === 'linux' ? 108 : /* macOS */ 104)
-    ? '/tmp'
-    : tmpdir
+  if (Buffer.byteLength(join(parentDir, socketName)) >
+    (platform === 'linux' ? 108 : /* macOS */ 104)) {
+    parentDir = join('/tmp', socketDir + randomUUID().slice(0, 8))
+    // The socket needs its own 0700 directory to gate access on macOS/BSD.
+    // See https://github.com/advisories/GHSA-534h-c3cw-v3h9
+    fs.mkdirSync(parentDir, { mode: 0o700 })
+  }
 
-  // AF_UNIX connect needs +x on every parent; non-recursive mkdir never adopts
-  // a pre-existing directory.
-  const parentDir = join(base, socketDir)
-  fs.mkdirSync(parentDir, { mode: 0o700 })
   fs.chmodSync(parentDir, 0o700)
 
   return { socketPath: join(parentDir, socketName), parentDir }

--- a/packages/vite/test/vite-node.test.ts
+++ b/packages/vite/test/vite-node.test.ts
@@ -2,6 +2,8 @@ import fs from 'node:fs'
 import net from 'node:net'
 import os from 'node:os'
 import process from 'node:process'
+import { Buffer } from 'node:buffer'
+import { join } from 'pathe'
 import { afterEach, describe, expect, it } from 'vitest'
 import { listenAndRestrict, pickSocketPath } from '../src/plugins/vite-node.ts'
 
@@ -50,6 +52,20 @@ describe('pickSocketPath', () => {
     const { parentDir } = trackedPick()
     const stat = fs.statSync(parentDir!)
     expect(stat.mode & 0o777).toBe(0o700)
+  })
+
+  it('falls back to /tmp and stays within the `sun_path` limit when $TMPDIR is too long', { skip: process.platform === 'win32' }, () => {
+    const max = process.platform === 'linux' ? 108 : 104
+    const longTmpdir = fs.mkdtempSync(join(os.tmpdir(), 'x'.repeat(80)))
+    createdDirs.push(longTmpdir)
+
+    const { socketPath, parentDir } = pickSocketPath(process.platform, longTmpdir)
+    if (parentDir) {
+      createdDirs.push(parentDir)
+    }
+
+    expect(parentDir?.startsWith('/tmp/')).toBe(true)
+    expect(Buffer.byteLength(socketPath)).toBeLessThanOrEqual(max)
   })
 })
 


### PR DESCRIPTION
Fix #35253
Closes #35257
Closes #35262

- kept `nuxt-vite` as the name because it's descriptive
- added the randomness only to the folder, not the file for shortness


<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
