### PR TITLE
docs: fix many typos

### DIFF
--- a/docs/1.getting-started/10.data-fetching.md
+++ b/docs/1.getting-started/10.data-fetching.md
@@ -541,7 +541,7 @@ const pending = computed(() => status.value === 'pending')
     >
 
     <div v-if="status === 'idle'">
-      Type an user ID
+      Type a user ID
     </div>
 
     <div v-else-if="pending">

--- a/docs/3.guide/2.best-practices/performance.md
+++ b/docs/3.guide/2.best-practices/performance.md
@@ -218,7 +218,7 @@ To improve performance, we need to first know how to measure it, starting with m
 
 ### Nuxi Analyze
 
-[This](/docs/4.x/api/commands/analyze) command of `nuxi` allows to analyze the production bundle or your Nuxt application. It leverages `vite-bundle-visualizer` (similar to `webpack-bundle-analyzer`) to generate a visual representation of your application's bundle, making it easier to identify which components take up the most space.
+[This](/docs/4.x/api/commands/analyze) command of `nuxi` allows you to analyze the production bundle of your Nuxt application. It leverages `vite-bundle-visualizer` (similar to `webpack-bundle-analyzer`) to generate a visual representation of your application's bundle, making it easier to identify which components take up the most space.
 
 When you see a large block in the visualization, it often signals an opportunity for optimization—whether by splitting it into smaller parts, implementing lazy loading, or replacing it with a more efficient alternative, especially for third-party libraries.
 

--- a/docs/4.api/5.kit/7.pages.md
+++ b/docs/4.api/5.kit/7.pages.md
@@ -65,7 +65,7 @@ You can read more about Nitro route rules in the [Nitro documentation](https://n
 ::
 
 ::tip{icon="i-lucide-video" to="https://vueschool.io/lessons/adding-route-rules-and-route-middlewares?friend=nuxt" target="_blank"}
-Watch Vue School video about adding route rules and route middelwares.
+Watch Vue School video about adding route rules and route middlewares.
 ::
 
 ### Usage
@@ -116,7 +116,7 @@ function extendRouteRules (route: string, rule: NitroRouteConfig, options?: Exte
 About route rules configurations, you can get more detail in [Hybrid Rendering > Route Rules](/docs/4.x/guide/concepts/rendering#route-rules).
 ::
 
-**options**: A object to pass to the route configuration. If `override` is set to `true`, it will override the existing route configuration.
+**options**: An object to pass to the route configuration. If `override` is set to `true`, it will override the existing route configuration.
 
 | Name       | Type      | Default | Description                                  |
 | ---------- | --------- | ------- | -------------------------------------------- |
@@ -133,7 +133,7 @@ Read more about route middlewares in the [Route middleware documentation](/docs/
 ::
 
 ::tip{icon="i-lucide-video" to="https://vueschool.io/lessons/adding-route-rules-and-route-middlewares?friend=nuxt" target="_blank"}
-Watch Vue School video about adding route rules and route middelwares.
+Watch Vue School video about adding route rules and route middlewares.
 ::
 
 ### Usage


### PR DESCRIPTION
### 📚 Description

Fix "middelwares" -> "middlewares" (route rules tip, x2), "A object" -> "An object", "an user ID" -> "a user ID", and the nuxi analyze sentence ("allows you to analyze the production bundle of your Nuxt application")
