### PR TITLE
refactor(nuxt): use jiti `fsCache` instead of deprecated `cache`

### DIFF
--- a/packages/nuxt/src/core/schema.ts
+++ b/packages/nuxt/src/core/schema.ts
@@ -21,7 +21,7 @@ export default defineNuxtModule({
 
     // Initialize untyped/jiti loader
     const _resolveSchema = createJiti(fileURLToPath(import.meta.url), {
-      cache: false,
+      fsCache: false,
       transformOptions: {
         babel: {
           plugins: [untypedPlugin],


### PR DESCRIPTION
### 📚 Description

`jiti` deprecated the `cache` option in favour of `fsCache` (filesystem source cache); both are equivalent, so this is a behaviour-preserving rename.
