### PR TITLE
fix(kit): respect `type` option in `findPath`

### DIFF
--- a/packages/kit/src/resolve.test.ts
+++ b/packages/kit/src/resolve.test.ts
@@ -53,4 +53,8 @@ describe('findPath', () => {
   it('should find paths correctly', async () => {
     expect(await findPath(resolve(nuxt.options.buildDir, 'my-template'), { virtual: true })).toBe(resolve(nuxt.options.buildDir, 'my-template.mjs'))
   })
+
+  it('should resolve a directory with the dir type option', async () => {
+    expect(await findPath(nuxt.options.rootDir, { type: 'dir' })).toBe(resolve(nuxt.options.rootDir))
+  })
 })

--- a/packages/kit/src/resolve.ts
+++ b/packages/kit/src/resolve.ts
@@ -68,13 +68,14 @@ export async function resolvePath (path: string, opts: ResolvePathOptions = {}):
  */
 export async function findPath (paths: string | string[], opts?: ResolvePathOptions, pathType: PathType = 'file'): Promise<string | null> {
   for (const path of toArray(paths)) {
+    // TODO: this is for backwards compatibility, remove the `pathType` argument in Nuxt 5
+    const type = opts?.type || pathType
     const res = await _resolvePathGranularly(path, {
       ...opts,
-      // TODO: this is for backwards compatibility, remove the `pathType` argument in Nuxt 5
-      type: opts?.type || pathType,
+      type,
     })
 
-    if (!res.type || (pathType && res.type !== pathType)) {
+    if (!res.type || res.type !== type) {
       continue
     }
 


### PR DESCRIPTION
### 📚 Description

`findPath(path, { type: "dir" })` always returned null. Resolution used the effective type (`opts.type || pathType`) but the guard compared against the positional `pathType` argument, which defaults to "file". Compare against the resolved type instead.
