### PR TITLE
fix(nitro): correct app type reference to generated nitro types

### DIFF
--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -939,7 +939,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
     opts.tsConfig.exclude ||= []
     opts.tsConfig.exclude.push(relative(nuxt.options.buildDir, resolve(nuxt.options.rootDir, nitro.options.output.dir)))
     opts.tsConfig.exclude.push(relative(nuxt.options.buildDir, resolve(nuxt.options.rootDir, nuxt.options.serverDir)))
-    opts.references.push({ path: resolve(nuxt.options.buildDir, 'types/nitro.d.ts') })
+    opts.references.push({ path: join(nitroConfig.typescript!.generatedTypesDir!, 'nitro.d.ts') })
 
     // ensure aliases shared between nuxt + nitro are included in shared tsconfig
     opts.sharedTsConfig.compilerOptions ||= {}


### PR DESCRIPTION
Correct the app type reference to Nitro generated types so `.nuxt/nuxt.d.ts` points at the entry written under configured `nitro.typescript.generatedTypesDir`.

With Nitro 3, Nuxt configures `generatedTypesDir` as `.nuxt/types/nitro`, so Nitro writes the entry at `.nuxt/types/nitro/nitro.d.ts` instead of the old `.nuxt/types/nitro.d.ts` path.