### PR TITLE
docs: explain static fallback pages

### DIFF
--- a/docs/1.getting-started/16.deployment.md
+++ b/docs/1.getting-started/16.deployment.md
@@ -80,6 +80,25 @@ There are two ways to deploy a Nuxt application to any static hosting services:
 - Static site generation (SSG) with `ssr: true` pre-renders routes of your application at build time. (This is the default behavior when running `nuxt generate`.) It will also generate `/200.html` and `/404.html` single-page app fallback pages, which can render dynamic routes or 404 errors on the client (though you may need to configure this on your static host).
 - Alternatively, you can prerender your site with `ssr: false` (static single-page app). This will produce HTML pages with an empty `<div id="__nuxt"></div>` where your Vue app would normally be rendered. You will lose many SEO benefits of prerendering your site, so it is suggested instead to use [`<ClientOnly>`](/docs/4.x/api/components/client-only) to wrap the portions of your site that cannot be server rendered (if any).
 
+### Static Fallback Pages
+
+Nuxt can generate two fallback pages for static hosts:
+
+- `200.html` is the single-page app fallback. Configure your host to serve it for unmatched routes when you want client-side routing to handle the URL.
+- `404.html` is the not-found fallback. Configure your host to serve it for routes that should keep a 404 status.
+
+`nuxt generate` and `nuxt build --prerender` generate these files automatically. If you use `nuxt build` with route rules to prerender selected routes, add the fallback page explicitly:
+
+```ts twoslash [nuxt.config.ts]
+export default defineNuxtConfig({
+  routeRules: {
+    '/200.html': { prerender: true },
+  },
+})
+```
+
+Some providers use `200.html`, some use `404.html`, and some let you configure both. Check your hosting provider's static fallback or rewrite settings after deployment.
+
 :read-more{title="Nuxt prerendering" to="/docs/4.x/getting-started/prerendering"}
 
 ### Client-side Only Rendering

--- a/docs/3.guide/1.concepts/1.rendering.md
+++ b/docs/3.guide/1.concepts/1.rendering.md
@@ -124,7 +124,7 @@ This will produce three files:
 - `200.html`
 - `404.html`
 
-The `200.html` and `404.html` might be useful for the hosting provider you are using.
+The `200.html` file is intended for static hosts that need a success-status fallback for client-side routing. The `404.html` file is intended for static hosts that serve a not-found page while preserving a 404 status. Which file you should use depends on your hosting provider's fallback or rewrite settings.
 
 #### Skipping Client Fallback Generation
 


### PR DESCRIPTION
### Linked issue

Resolves #23055

### Description

Adds documentation explaining the purpose of static fallback pages (`200.html` and `404.html`).

Changes include:

- Added a "Static Fallback Pages" section to the deployment guide.
- Explained when `200.html` and `404.html` should be used on static hosts.
- Added an example showing how to explicitly prerender `/200.html` when using route rules.
- Clarified the purpose of both fallback files in the rendering concepts documentation.

Docs-only change.