### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/packages/nuxt/src/app/plugins/router.ts
+++ b/packages/nuxt/src/app/plugins/router.ts
@@ -251,6 +251,9 @@ const plugin: Plugin<{ route: Route, router: Router }> & ObjectPlugin<{ route: R
           const middlewareEntries = new Set<RouteGuard>([...globalMiddleware, ...nuxtApp._middleware.global])
 
           const routeRules = getRouteRules({ path: to.path })
+          if (routeRules.appLayout && !to.meta.layout) {
+            to.meta.layout = routeRules.appLayout
+          }
           if (routeRules.appMiddleware) {
             for (const key in routeRules.appMiddleware) {
               const guard = nuxtApp._middleware.named[key] as RouteGuard | undefined

--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -219,6 +219,10 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
 
         const routeRules = getRouteRules({ path: to.path })
 
+        if (routeRules.appLayout && !to.meta.layout) {
+          to.meta.layout = routeRules.appLayout
+        }
+
         if (routeRules.appMiddleware) {
           for (const key in routeRules.appMiddleware) {
             if (routeRules.appMiddleware[key]) {


### PR DESCRIPTION
When using the `appLayout` experimental feature (configured via route rules), `route.meta.layout` was undefined even though the layout was correctly resolved at render time by `<NuxtLayout>` fallback to `routeRulesMatcher`. This meant any code reading `route.meta.layout` directly would get `undefined`.

This fix sets `to.meta.layout` from `routeRules.appLayout` (if not already set by the page `definePageMeta`) in the `beforeEach` navigation guard, in both `pages/runtime/plugins/router.ts` and `app/plugins/router.ts`.

Closes #34305