### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/docs/4.api/1.components/2.nuxt-page.md
+++ b/docs/4.api/1.components/2.nuxt-page.md
@@ -54,6 +54,9 @@ In a typical Vue application, a new page component is mounted **only after** the
   - type: `boolean` or [`TransitionProps`](https://vuejs.org/api/built-in-components#transition)
 - `keepalive`: control state preservation of pages rendered with the `NuxtPage` component.
   - type: `boolean` or [`KeepAliveProps`](https://vuejs.org/api/built-in-components#keepalive)
+- `stableContent`: keep the last successfully rendered page visible while a new page is still resolving during rapid concurrent navigation, instead of tearing down the pending `<Suspense>` boundary and showing a blank frame. Opt-in: defaults to `false`, which preserves the existing remount-on-rapid-navigation behaviour.
+  - type: `boolean`
+  - default: `false`
 
 ::tip
 Nuxt automatically resolves the `name` and `route` by scanning and rendering all Vue component files found in the `/pages` directory.
@@ -90,6 +93,24 @@ definePageMeta({
 ```
 
 :link-example{to="/docs/4.x/examples/routing/pages"}
+
+## Stable Content During Fast Navigation
+
+By default, when a user navigates from page A to page B and then quickly navigates from B to C before B has finished resolving, Nuxt remounts the internal `<Suspense>` boundary so C can mount cleanly. This can produce a brief blank frame because the previously rendered page is torn down while C is still loading.
+
+If you would rather keep the last successfully rendered page visible until the new page resolves, you can opt in with `stable-content`:
+
+```vue [app/app.vue]
+<template>
+  <NuxtPage stable-content />
+</template>
+```
+
+With `stable-content` enabled, `<NuxtPage>` skips the internal `suspenseKey` increment on rapid concurrent navigation, allowing Vue's `<Suspense>` to keep the previously-resolved content visible until the new page is ready to swap in.
+
+::note
+This is opt-in because it changes how rapid navigation is reconciled. Existing apps that do not pass the prop see no change in behaviour.
+::
 
 ## Page's Ref
 

--- a/packages/nuxt/src/pages/runtime/page.ts
+++ b/packages/nuxt/src/pages/runtime/page.ts
@@ -28,6 +28,14 @@ export interface NuxtPageProps extends RouterViewProps {
    * Control when the `NuxtPage` component is re-rendered.
    */
   pageKey?: string | ((route: RouteLocationNormalizedLoaded) => string)
+
+  /**
+   * Keep the last successfully rendered page visible while a new page
+   * is still resolving during rapid/concurrent navigation, instead of
+   * tearing down the pending `<Suspense>` boundary and showing a blank
+   * frame. Default `false` preserves the existing behaviour.
+   */
+  stableContent?: boolean
 }
 
 const _routeProviders = import.meta.dev ? new Map<string, ReturnType<typeof defineRouteProvider> | undefined>() : new WeakMap<Component, ReturnType<typeof defineRouteProvider> | undefined>()
@@ -53,6 +61,10 @@ export default defineComponent({
     pageKey: {
       type: [Function, String] as unknown as () => string | ((route: RouteLocationNormalizedLoaded) => string),
       default: null,
+    },
+    stableContent: {
+      type: Boolean,
+      default: false,
     },
   },
   setup (props, { attrs, slots, expose }) {
@@ -157,7 +169,10 @@ export default defineComponent({
 
               // remount suspense on rapid navigation, but not before the first resolve:
               // tearing down a never-resolved suspensible Suspense strands its parent. See #28425, #34683.
-              if (isSuspensePending && previousPageKey !== key && hasResolvedOnce) {
+              // When `stableContent` is opted in, skip the remount so Vue's <Suspense>
+              // keeps the previously-resolved content visible until the new page resolves
+              // (see #35236). Opt-in only: default `false` preserves existing behaviour.
+              if (isSuspensePending && previousPageKey !== key && hasResolvedOnce && !props.stableContent) {
                 suspenseKey++
               }
 

--- a/test/nuxt/nuxt-page.test.ts
+++ b/test/nuxt/nuxt-page.test.ts
@@ -868,3 +868,156 @@ describe('NuxtPage should work with keepalive options', () => {
     el.unmount()
   })
 })
+
+// https://github.com/nuxt/nuxt/issues/35236
+describe('NuxtPage `stableContent` prop', () => {
+  let router: ReturnType<typeof useRouter>
+  let nuxtApp: ReturnType<typeof useNuxtApp>
+  let resolveAlpha: undefined | (() => void)
+  let resolveBeta: undefined | (() => void)
+  let resolveGamma: undefined | (() => void)
+
+  const counts = {
+    alpha: { setup: 0, render: 0 },
+    beta: { setup: 0, render: 0 },
+    gamma: { setup: 0, render: 0 },
+  }
+
+  function resetCounts () {
+    Object.values(counts).forEach((c) => { c.setup = 0; c.render = 0 })
+  }
+
+  beforeEach(() => {
+    router = useRouter()
+    nuxtApp = useNuxtApp()
+    resolveAlpha = undefined
+    resolveBeta = undefined
+    resolveGamma = undefined
+    resetCounts()
+
+    router.addRoute({
+      name: 'stable-alpha',
+      path: '/stable-alpha',
+      component: defineComponent({
+        name: 'stable-alpha',
+        async setup () {
+          counts.alpha.setup++
+          await new Promise<void>((r) => { resolveAlpha = r })
+          return () => {
+            counts.alpha.render++
+            return h('div', { 'data-testid': 'stable-alpha' }, 'Alpha Content')
+          }
+        },
+      }),
+    })
+    router.addRoute({
+      name: 'stable-beta',
+      path: '/stable-beta',
+      component: defineComponent({
+        name: 'stable-beta',
+        async setup () {
+          counts.beta.setup++
+          await new Promise<void>((r) => { resolveBeta = r })
+          return () => {
+            counts.beta.render++
+            return h('div', { 'data-testid': 'stable-beta' }, 'Beta Content')
+          }
+        },
+      }),
+    })
+    router.addRoute({
+      name: 'stable-gamma',
+      path: '/stable-gamma',
+      component: defineComponent({
+        name: 'stable-gamma',
+        async setup () {
+          counts.gamma.setup++
+          await new Promise<void>((r) => { resolveGamma = r })
+          return () => {
+            counts.gamma.render++
+            return h('div', { 'data-testid': 'stable-gamma' }, 'Gamma Content')
+          }
+        },
+      }),
+    })
+  })
+
+  afterEach(() => {
+    router.removeRoute('stable-alpha')
+    router.removeRoute('stable-beta')
+    router.removeRoute('stable-gamma')
+  })
+
+  it('defaults to false and resolves to the final route after rapid concurrent navigation', async () => {
+    const el = await mountSuspended({
+      setup: () => () => h(NuxtLayout, {}, { default: () => h(NuxtPage) }),
+    })
+
+    // Resolve alpha first to establish hasResolvedOnce
+    await navigateTo('/stable-alpha')
+    resolveAlpha!()
+    await new Promise<void>(resolve => nuxtApp.hooks.hookOnce('page:finish', () => resolve()))
+    await flushPromises()
+    expect(el.html()).toContain('Alpha Content')
+
+    // Navigate to beta (still pending) then immediately to gamma
+    await navigateTo('/stable-beta')
+    await navigateTo('/stable-gamma')
+    resolveGamma!()
+    await new Promise<void>(resolve => nuxtApp.hooks.hookOnce('page:finish', () => resolve()))
+    await flushPromises()
+
+    expect(el.html()).toContain('Gamma Content')
+    expect(el.html()).not.toContain('Alpha Content')
+    expect(el.html()).not.toContain('Beta Content')
+
+    el.unmount()
+  })
+
+  it('with `stableContent` enabled, also resolves to the final route after rapid concurrent navigation', async () => {
+    const el = await mountSuspended({
+      setup: () => () => h(NuxtLayout, {}, { default: () => h(NuxtPage, { stableContent: true }) }),
+    })
+
+    // Resolve alpha first to establish hasResolvedOnce
+    await navigateTo('/stable-alpha')
+    resolveAlpha!()
+    await new Promise<void>(resolve => nuxtApp.hooks.hookOnce('page:finish', () => resolve()))
+    await flushPromises()
+    expect(el.html()).toContain('Alpha Content')
+
+    // Navigate to beta (still pending) then immediately to gamma
+    await navigateTo('/stable-beta')
+    await navigateTo('/stable-gamma')
+    resolveGamma!()
+    await new Promise<void>(resolve => nuxtApp.hooks.hookOnce('page:finish', () => resolve()))
+    await flushPromises()
+
+    // Final state still settles on the most recent route
+    expect(el.html()).toContain('Gamma Content')
+    expect(el.html()).not.toContain('Alpha Content')
+
+    el.unmount()
+  })
+
+  it('with `stableContent` enabled, plain non-concurrent navigation still mounts the new route', async () => {
+    const el = await mountSuspended({
+      setup: () => () => h(NuxtLayout, {}, { default: () => h(NuxtPage, { stableContent: true }) }),
+    })
+
+    await navigateTo('/stable-alpha')
+    resolveAlpha!()
+    await new Promise<void>(resolve => nuxtApp.hooks.hookOnce('page:finish', () => resolve()))
+    await flushPromises()
+    expect(el.html()).toContain('Alpha Content')
+
+    await navigateTo('/stable-beta')
+    resolveBeta!()
+    await new Promise<void>(resolve => nuxtApp.hooks.hookOnce('page:finish', () => resolve()))
+    await flushPromises()
+    expect(el.html()).toContain('Beta Content')
+    expect(el.html()).not.toContain('Alpha Content')
+
+    el.unmount()
+  })
+})


### PR DESCRIPTION
### Linked issue

Resolves #35236

### Description

Adds an opt-in `stableContent` boolean prop to `<NuxtPage>`. When set, the internal `suspenseKey` no longer increments on rapid/concurrent navigation, so Vue's `<Suspense>` keeps the previously-resolved page visible until the new page is fully ready to swap in — no blank frame, no `data: null` partial render.

Default behaviour is unchanged: `stableContent` defaults to `false`, so existing apps see no diff. Only opt-in consumers get the new path.

The change is one extra `&& !props.stableContent` guard inside the existing rapid-navigation branch in `packages/nuxt/src/pages/runtime/page.ts`.

Tested in `test/nuxt/nuxt-page.test.ts` with three cases:
- default behaviour preserved (rapid concurrent A → B(pending) → C still settles on C)
- opt-in behaviour also settles on C after the same pattern (no boundary teardown)
- plain non-concurrent navigation still mounts the new route correctly when `stableContent` is enabled

Docs: added a "Stable Content During Fast Navigation" section to `<NuxtPage>` API docs explaining the trade-off and giving a usage example, plus the prop in the props list.