### PR TITLE
fix(nuxt): skip plugin initialization during server-side error render

### DIFF
--- a/packages/nuxt/src/app/entry.ts
+++ b/packages/nuxt/src/app/entry.ts
@@ -34,8 +34,8 @@ if (import.meta.server) {
     const isErrorRender = !!(
       ssrContext?.payload?.error ||
       ssrContext?.error
-    );
-    
+    )
+
     try {
       if (!isErrorRender) {
         await applyPlugins(nuxt, plugins)

--- a/packages/nuxt/src/app/entry.ts
+++ b/packages/nuxt/src/app/entry.ts
@@ -31,8 +31,15 @@ if (import.meta.server) {
 
     const nuxt = createNuxtApp({ vueApp, ssrContext })
 
+    const isErrorRender = !!(
+      ssrContext?.payload?.error ||
+      ssrContext?.error
+    );
+    
     try {
-      await applyPlugins(nuxt, plugins)
+      if (!isErrorRender) {
+        await applyPlugins(nuxt, plugins)
+      }
       await nuxt.hooks.callHook('app:created', vueApp)
     } catch (error) {
       await nuxt.hooks.callHook('app:error', error)

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -58,7 +58,7 @@ describe.skipIf(isStubbed || process.env.SKIP_BUNDLE_SIZE === 'true' || process.
     const serverDir = join(rootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!_libs'], serverDir, rootDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"69.7k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"69.8k"`)
 
     const modules = await analyzeSizes(['_libs/**/*'], serverDir, rootDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"480k"`)


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #20909 

### 📚 Description

When a server-only plugin calls $fetch() for a server route and that route throws, Nuxt would still initialize plugins during the server error render. That caused the plugin to run again while rendering the error response, leading to an infinite recursion loop.

### Fix

- Detect server-side error renders in entry.ts.

- Skip applyPlugins(nuxt, plugins) when ssrContext.payload.error or ssrContext.error is present

- Preserve normal hook invocation and error handling for error rendering
