### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/packages/nuxt/src/app/composables/ready.ts
+++ b/packages/nuxt/src/app/composables/ready.ts
@@ -9,6 +9,6 @@ export const onNuxtReady = (callback: () => any): void => {
   if (nuxtApp.isHydrating) {
     nuxtApp.hooks.hookOnce('app:suspense:resolve', () => { requestIdleCallback(() => callback()) })
   } else {
-    requestIdleCallback(() => callback())
+    callback()
   }
 }


### PR DESCRIPTION
## PR Type
Bug fix

## Description
\onNuxtReady()\ unconditionally wraps the callback in \equestIdleCallback()\, even when the app is already fully loaded. This can cause multi-second delays for \efreshNuxtData()\ when continuous UI work keeps the browser from reaching idle state.

**Issue:** #35312

**Fix:** Call the callback directly when the app is already ready, instead of deferring via \equestIdleCallback\. The deferral is only needed during hydration where we hook into \pp:suspense:resolve\.

## Checklist
- [x] Bug fix (non-breaking change)