### PR TITLE
fix(nuxt): validate `<ClientOnly>` fallback tag name

### DIFF
--- a/packages/nuxt/src/app/components/client-fallback.client.ts
+++ b/packages/nuxt/src/app/components/client-fallback.client.ts
@@ -1,11 +1,7 @@
 import { Fragment, createElementBlock, defineComponent, h, onMounted, shallowRef, useId } from 'vue'
 import type { DefineSetupFnComponent, SlotsType, VNode } from 'vue'
 import { useState } from '../composables/state'
-
-const VALID_TAG_RE = /^[a-z][a-z0-9-]*$/i
-function sanitizeTag (tag: string, fallback: string): string {
-  return VALID_TAG_RE.test(tag) ? tag : fallback
-}
+import { sanitizeTag } from './utils'
 
 interface NuxtClientFallbackProps {
   fallbackTag?: string

--- a/packages/nuxt/src/app/components/client-fallback.server.ts
+++ b/packages/nuxt/src/app/components/client-fallback.server.ts
@@ -4,12 +4,7 @@ import { ssrInterpolate, ssrRenderAttrs, ssrRenderSlot, ssrRenderVNode } from 'v
 
 import { isPromise } from '@vue/shared'
 import { useState } from '../composables/state'
-import { createBuffer } from './utils'
-
-const VALID_TAG_RE = /^[a-z][a-z0-9-]*$/i
-function sanitizeTag (tag: string, fallback: string): string {
-  return VALID_TAG_RE.test(tag) ? tag : fallback
-}
+import { createBuffer, sanitizeTag } from './utils'
 
 interface NuxtClientFallbackProps {
   fallbackTag?: string

--- a/packages/nuxt/src/app/components/client-only.ts
+++ b/packages/nuxt/src/app/components/client-only.ts
@@ -3,7 +3,7 @@ import type { Component, ComponentInternalInstance, ComponentOptions, DefineSetu
 import { isPromise } from '@vue/shared'
 import { useNuxtApp } from '../nuxt'
 import ServerPlaceholder from './server-placeholder'
-import { elToStaticVNode } from './utils'
+import { elToStaticVNode, sanitizeTag } from './utils'
 
 // @ts-expect-error virtual file
 import { clientNodePlaceholder } from '#build/nuxt.config.mjs'
@@ -71,7 +71,7 @@ const ClientOnly = defineComponent({
       const slot = slots.fallback || slots.placeholder
       if (slot) { return h(slot) }
       const fallbackStr = props.fallback || props.placeholder || ''
-      const fallbackTag = props.fallbackTag || props.placeholderTag || 'span'
+      const fallbackTag = sanitizeTag(props.fallbackTag || props.placeholderTag, 'span')
       return createElementBlock(fallbackTag, attrs, fallbackStr)
     }
   },

--- a/packages/nuxt/src/app/components/utils.ts
+++ b/packages/nuxt/src/app/components/utils.ts
@@ -47,6 +47,12 @@ export function isChangingPage (to: RouteLocationNormalized, from: RouteLocation
   return true
 }
 
+const VALID_TAG_RE = /^[a-z][a-z0-9-]*$/i
+/** Return `tag` if it is a safe HTML tag name, otherwise `fallback`. */
+export function sanitizeTag (tag: string | undefined, fallback: string): string {
+  return tag && VALID_TAG_RE.test(tag) ? tag : fallback
+}
+
 export type SSRBuffer = SSRBufferItem[] & { hasAsync?: boolean }
 export type SSRBufferItem = string | SSRBuffer | Promise<SSRBuffer>
 

--- a/test/nuxt/client-only.test.ts
+++ b/test/nuxt/client-only.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import type { ComponentOptions } from 'vue'
-import { Suspense, defineComponent, h, toDisplayString, useAttrs } from 'vue'
+import { Suspense, createSSRApp, defineComponent, h, toDisplayString, useAttrs } from 'vue'
+import { renderToString } from 'vue/server-renderer'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import { flushPromises, mount } from '@vue/test-utils'
 
@@ -79,6 +80,36 @@ describe('client-only', () => {
     })
     const wrapper = await mountSuspended(component)
     expect(wrapper.html()).toMatchInlineSnapshot(`"<div class="test" id="test">client-only</div>"`)
+  })
+})
+
+describe('client-only SSR fallback tag', () => {
+  const renderFallback = (props: Record<string, unknown>) => {
+    const app = createSSRApp(defineComponent({
+      setup: () => () => h(ClientOnly, props, { default: () => [] }),
+    }))
+    return renderToString(app)
+  }
+
+  it('renders a valid `fallbackTag` verbatim', async () => {
+    expect(await renderFallback({ fallbackTag: 'div', fallback: 'x' })).toBe('<div>x</div>')
+    expect(await renderFallback({ fallbackTag: 'section', fallback: 'x' })).toBe('<section>x</section>')
+    expect(await renderFallback({ fallbackTag: 'my-element', fallback: 'x' })).toBe('<my-element>x</my-element>')
+  })
+
+  it('replaces a malicious `fallbackTag` with `span`', async () => {
+    expect(await renderFallback({ fallbackTag: 'img src=x onerror=alert(1)', fallback: 'x' })).toBe('<span>x</span>')
+    expect(await renderFallback({ fallbackTag: '<script>', fallback: 'x' })).toBe('<span>x</span>')
+  })
+
+  it('falls back to `span` when `fallbackTag` is empty or undefined', async () => {
+    expect(await renderFallback({ fallback: 'x' })).toBe('<span>x</span>')
+    expect(await renderFallback({ fallbackTag: '', fallback: 'x' })).toBe('<span>x</span>')
+  })
+
+  it('also sanitises `placeholderTag`', async () => {
+    expect(await renderFallback({ placeholderTag: 'aside', placeholder: 'x' })).toBe('<aside>x</aside>')
+    expect(await renderFallback({ placeholderTag: 'img src=x onerror=alert(1)', placeholder: 'x' })).toBe('<span>x</span>')
   })
 })
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

equalise behaviour with other fallbacks