### PR TITLE
fix(kit): don't exclude layer module runtime files from app tsconfig

### DIFF
--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -205,7 +205,8 @@ export function resolveLayerPaths (dirs: LayerDirectories, projectBuildDir: stri
       join(relativeRootDir, `.config/nuxt.*`),
       join(relativeRootDir, `layers/*/nuxt.config.*`),
       join(relativeRootDir, `layers/*/.config/nuxt.*`),
-      join(relativeRootDir, `layers/*/modules/**/*`),
+      join(relativeRootDir, `layers/*/modules/*.*`),
+      join(relativeRootDir, `layers/*/modules/*/*.*`),
     ],
     shared: [
       join(relativeSharedDir, `**/*`),

--- a/packages/kit/test/generate-types.spec.ts
+++ b/packages/kit/test/generate-types.spec.ts
@@ -68,9 +68,19 @@ describe('tsConfig generation', () => {
         "../.config/nuxt.*",
         "../layers/*/nuxt.config.*",
         "../layers/*/.config/nuxt.*",
-        "../layers/*/modules/**/*",
+        "../layers/*/modules/*.*",
+        "../layers/*/modules/*/*.*",
       ]
     `)
+  })
+
+  it('should not exclude layer module runtime files from app tsconfig', async () => {
+    const { tsConfig } = await _generateTypes(mockNuxt)
+    // a module living in `layers/*/modules/<name>/runtime/**` is part of the app/runtime
+    // context; the node-context glob must not be broad enough to exclude it
+    // https://github.com/nuxt/nuxt/issues/35310
+    expect(tsConfig.include).toEqual(expect.arrayContaining(['../layers/*/modules/*/runtime/**/*']))
+    expect(tsConfig.exclude).not.toEqual(expect.arrayContaining(['../layers/*/modules/**/*']))
   })
 
   it('should not exclude node-context paths from legacy tsconfig', async () => {
@@ -209,7 +219,8 @@ describe('resolveLayerPaths', async () => {
           "../.config/nuxt.*",
           "../layers/*/nuxt.config.*",
           "../layers/*/.config/nuxt.*",
-          "../layers/*/modules/**/*",
+          "../layers/*/modules/*.*",
+          "../layers/*/modules/*/*.*",
         ],
         "nuxt": [
           "../app/**/*",


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/35310

### 📚 Description

this narrows the node-context glob to only the module entry surface (single-file modules at `layers/*/modules/*.*` - and folder-module top-level files at `layers/*/modules/*/*.*`), matching how we scan for local modules