### PR TITLE
fix(nuxt): detach in-flight promise on `useAsyncData` teardown

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -924,6 +924,10 @@ function buildAsyncData<
       if (nuxtApp._asyncData[key]?._init) {
         nuxtApp._asyncData[key]._init = false
       }
+      // detach any in-flight promise
+      if (nuxtApp._asyncDataPromises[key]) {
+        delete nuxtApp._asyncDataPromises[key]
+      }
       // TODO: disable in v4 in favour of custom caching strategies
       if (purgeCachedData && !hasCustomGetCachedData) {
         nextTick(() => {

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -924,8 +924,8 @@ function buildAsyncData<
       if (nuxtApp._asyncData[key]?._init) {
         nuxtApp._asyncData[key]._init = false
       }
-      // detach any in-flight promise
       if (nuxtApp._asyncDataPromises[key]) {
+        asyncData._abortController?.abort(new DOMException('AsyncData request cancelled by unmount', 'AbortError'))
         delete nuxtApp._asyncDataPromises[key]
       }
       // TODO: disable in v4 in favour of custom caching strategies

--- a/test/nuxt/use-async-data.test.ts
+++ b/test/nuxt/use-async-data.test.ts
@@ -744,6 +744,50 @@ describe('useAsyncData', () => {
     expect(comp2.html()).toMatchInlineSnapshot(`"<div>second</div>"`)
   })
 
+  // https://github.com/nuxt/nuxt/issues/35322
+  it('should not leave a new subscriber stuck at idle when the previous subscriber unregisters during an in-flight deferred request', async () => {
+    const key = `stranded-idle-${++counter}`
+
+    let resolveHandler: ((value: string) => void) | undefined
+    const promiseFn = vi.fn(() => new Promise<string>((resolve) => {
+      resolveHandler = resolve
+    }))
+
+    const scopeA = effectScope()
+    let resultA!: ReturnType<typeof useAsyncData>
+    scopeA.run(() => {
+      resultA = useAsyncData(key, promiseFn, { dedupe: 'defer', immediate: true })
+    })
+
+    const nuxtApp = useNuxtApp()
+    expect(promiseFn).toHaveBeenCalledTimes(1)
+    expect(nuxtApp._asyncDataPromises[key]).toBeDefined()
+    expect(nuxtApp._asyncData[key]!.status.value).toBe('pending')
+
+    scopeA.stop()
+
+    const scopeB = effectScope()
+    let resultB!: ReturnType<typeof useAsyncData>
+    scopeB.run(() => {
+      resultB = useAsyncData(key, promiseFn, { dedupe: 'defer', immediate: true })
+    })
+
+    expect(nuxtApp._asyncData[key]!._init).toBe(true)
+
+    resolveHandler!('resolved')
+    await flushPromises()
+    await nextTick()
+    await flushPromises()
+
+    expect(nuxtApp._asyncData[key]!.status.value).toBe('success')
+    expect(nuxtApp._asyncData[key]!.data.value).toBe('resolved')
+    expect(resultB.status.value).toBe('success')
+    expect(resultB.data.value).toBe('resolved')
+
+    resultA.clear()
+    scopeB.stop()
+  })
+
   it('should be synced with useNuxtData', async () => {
     const { data: nuxtData } = useNuxtData('nuxtdata-sync')
     const promise = useAsyncData('nuxtdata-sync', () => Promise.resolve('test'), { default: () => 'default' })

--- a/test/nuxt/use-async-data.test.ts
+++ b/test/nuxt/use-async-data.test.ts
@@ -788,7 +788,7 @@ describe('useAsyncData', () => {
     scopeB.stop()
   })
 
-  it('should abort the in-flight request when the last subscriber unmounts', async () => {
+  it('should abort the in-flight request when the last subscriber unmounts', () => {
     const key = `abort-on-unmount-${++counter}`
 
     let capturedSignal: AbortSignal | undefined

--- a/test/nuxt/use-async-data.test.ts
+++ b/test/nuxt/use-async-data.test.ts
@@ -788,6 +788,32 @@ describe('useAsyncData', () => {
     scopeB.stop()
   })
 
+  it('should abort the in-flight request when the last subscriber unmounts', async () => {
+    const key = `abort-on-unmount-${++counter}`
+
+    let capturedSignal: AbortSignal | undefined
+    const promiseFn = vi.fn((_nuxtApp, { signal }: { signal: AbortSignal }) => {
+      capturedSignal = signal
+      return new Promise<string>(() => {})
+    })
+
+    const scope = effectScope()
+    scope.run(() => {
+      useAsyncData(key, promiseFn, { dedupe: 'defer', immediate: true })
+    })
+
+    const nuxtApp = useNuxtApp()
+    expect(promiseFn).toHaveBeenCalledTimes(1)
+    expect(capturedSignal).toBeDefined()
+    expect(capturedSignal!.aborted).toBe(false)
+    expect(nuxtApp._asyncDataPromises[key]).toBeDefined()
+
+    scope.stop()
+
+    expect(capturedSignal!.aborted).toBe(true)
+    expect(nuxtApp._asyncDataPromises[key]).toBeUndefined()
+  })
+
   it('should be synced with useNuxtData', async () => {
     const { data: nuxtData } = useNuxtData('nuxtdata-sync')
     const promise = useAsyncData('nuxtdata-sync', () => Promise.resolve('test'), { default: () => 'default' })


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/35322

### 📚 Description

when detaching an in-flight asyncData request, it could end up 'stuck' by future request being deduped onto it

this makes sure we detach the promise