### PR TITLE
fix(nitro): export empty styles object with `ssr: false`

### DIFF
--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -537,7 +537,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
     }
   }
 
-  if (nuxt.options.dev) {
+  if (nuxt.options.dev || !nuxt.options.ssr) {
     nitroConfig.virtual!['#build/dist/server/styles.mjs'] = 'export default {}'
     // In case a non-normalized absolute path is called for on Windows
     if (process.platform === 'win32') {


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/35190

### 📚 Description

this writes a stub `styles.mjs` when `ssr: false` to avoid issues importing `styles.mjs` when it hasn't been emitted