### PR TITLE
fix(nuxt): emit auto-import paths as files, not directories

### DIFF
--- a/packages/nuxt/src/imports/module.ts
+++ b/packages/nuxt/src/imports/module.ts
@@ -229,7 +229,7 @@ function addDeclarationTemplates (ctx: Pick<Unimport, 'getImports' | 'generateTy
 
           if (!dir || !name) { return r }
           const subpath = await lookupNodeModuleSubpath(r)
-          return join(dir, name, subpath || '')
+          return subpath && subpath !== './' ? join(dir, name, subpath) : r
         }) ?? path
       }
 


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nitrojs/nitro/pull/4333
https://github.com/nuxt/nuxt/issues/35248

### 📚 Description

this pairs with https://github.com/nitrojs/nitro/pull/4333 - we had the same issue elsewhere in nuxt