### PR TITLE
fix(nuxt): suppress spurious slot warning in `NuxtPage` during nav

### DIFF
--- a/packages/nuxt/src/pages/runtime/page.ts
+++ b/packages/nuxt/src/pages/runtime/page.ts
@@ -1,4 +1,4 @@
-import { Fragment, Suspense, defineComponent, h, inject, nextTick, onBeforeUnmount, ref, watch } from 'vue'
+import { Fragment, Suspense, createCommentVNode, defineComponent, h, inject, isVNode, nextTick, onBeforeUnmount, ref, watch } from 'vue'
 import type { AllowedComponentProps, Component, ComponentCustomProps, ComponentPublicInstance, KeepAliveProps, Slot, TransitionProps, VNode, VNodeProps } from 'vue'
 import { RouterView } from 'vue-router'
 import type { RouteLocationNormalized, RouteLocationNormalizedLoaded, RouterViewProps } from 'vue-router'
@@ -103,7 +103,7 @@ export default defineComponent({
 
     return () => {
       return h(RouterView, { name: props.name, route: props.route, ...attrs }, {
-        default: import.meta.server
+        default: markStableSlot(import.meta.server
           ? (routeProps: RouterViewSlotProps) => {
               return h(Suspense, { suspensible: true }, {
                 default () {
@@ -237,7 +237,7 @@ export default defineComponent({
                 )).default()
 
               return vnode
-            },
+            }),
       })
     }
   },
@@ -282,6 +282,22 @@ function hasChildrenRoutes (fork: RouteLocationNormalizedLoaded | null, newRoute
 
   const index = newRoute.matched.findIndex(m => m.components?.default === Component?.type)
   return index < newRoute.matched.length - 1
+}
+
+// Flag the slot as precompiled (`_n`) so Vue skips its slot wrapper, which is what emits the
+// dev-only "slot invoked outside render" warning. The warning otherwise misfires when a page
+// using top-level `await` (e.g. `navigateTo()`) re-renders before Vue's `withAsyncContext`
+// cleanup clears `currentInstance`. We replicate Vue's array coercion here so vue-router's
+// `slotContent.length` path still works. See #34683.
+function markStableSlot<T extends (routeProps: RouterViewSlotProps) => VNode | VNode[] | null | undefined> (fn: T): T {
+  const wrapped = ((routeProps: RouterViewSlotProps) => {
+    const result = fn(routeProps)
+    if (Array.isArray(result)) { return result }
+    if (result == null || !isVNode(result)) { return [createCommentVNode()] }
+    return [result]
+  }) as unknown as T
+  ;(wrapped as any)._n = true
+  return wrapped
 }
 
 function normalizeSlot (slot: Slot, data: RouterViewSlotProps) {

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -92,7 +92,7 @@ describe.skipIf(isStubbed || process.env.SKIP_BUNDLE_SIZE === 'true' || process.
     const serverDir = join(pagesRootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!_libs'], serverDir, pagesRootDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"278k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"279k"`)
 
     const modules = await analyzeSizes(['_libs/**/*'], serverDir, pagesRootDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"489k"`)

--- a/test/e2e/suspense-layout.test.ts
+++ b/test/e2e/suspense-layout.test.ts
@@ -25,8 +25,7 @@ test.use({
 })
 
 test.describe('Suspense navigation with layout change', () => {
-  test('completes when redirect crosses layout boundary (#34683)', async ({ page, goto, isDev }) => {
-    test.fixme(isDev, 'Vue dev-only warning surfaces a separate suspense/layout bug; passes in built mode')
+  test('completes when redirect crosses layout boundary (#34683)', async ({ page, goto }) => {
     await goto('/')
 
     await expect(page.getByTestId('index-title')).toBeVisible()


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

uncovered in a test, we can suppress this (invalid, as far as I can tell) warning by marking the slot as precompiled