### PR TITLE
fix(vite): preserve backslash separators in windows named pipe path

### DIFF
--- a/packages/vite/src/plugins/vite-node.ts
+++ b/packages/vite/src/plugins/vite-node.ts
@@ -7,6 +7,7 @@ import fs from 'node:fs' // For sync operations like unlinkSync if needed during
 import { pathToFileURL } from 'node:url'
 import { Buffer } from 'node:buffer'
 import { randomUUID } from 'node:crypto'
+import { win32 as pathWin32 } from 'node:path'
 import { dirname, isAbsolute, join, normalize } from 'pathe'
 import { directoryToURL, resolveAlias, tryUseNuxt, useNitro } from '@nuxt/kit'
 import type { EnvironmentModuleNode, ModuleNode, PluginContainer, ViteDevServer, Plugin as VitePlugin } from 'vite'
@@ -136,8 +137,9 @@ export function pickSocketPath (platform: NodeJS.Platform, tmpdir: string = os.t
   const socketDir = `nuxt-vite-`
 
   if (platform === 'win32') {
-  // enough randomness to avoid collisions and being predictable
-    return { socketPath: join(String.raw`\\.\pipe`, socketDir + randomUUID().slice(0, 8)) }
+    // use `node:path/win32` so the `\\.\pipe\...` separators stay as backslashes
+    // (for deno compatibility) plus enough randomness to avoid collisions and being predictable
+    return { socketPath: pathWin32.join(String.raw`\\.\pipe`, socketDir + randomUUID().slice(0, 8)) }
   }
 
   // creates a random suffix and avoids collisions

--- a/packages/vite/test/vite-node.test.ts
+++ b/packages/vite/test/vite-node.test.ts
@@ -4,7 +4,7 @@ import os from 'node:os'
 import process from 'node:process'
 import { Buffer } from 'node:buffer'
 import { join } from 'pathe'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { listenAndRestrict, pickSocketPath } from '../src/plugins/vite-node.ts'
 
 const createdDirs: string[] = []
@@ -44,7 +44,7 @@ describe('pickSocketPath', () => {
   it('uses a named pipe on Windows', () => {
     const { socketPath, parentDir } = pickSocketPath('win32')
     expect(socketPath.startsWith('\0')).toBe(false)
-    expect(socketPath).toContain('/pipe/')
+    expect(socketPath.startsWith('\\\\.\\pipe\\')).toBe(true)
     expect(parentDir).toBeUndefined()
   })
 
@@ -93,5 +93,22 @@ describe('listenAndRestrict', () => {
     const stat = fs.statSync(socketPath)
     expect(stat.mode & 0o077).toBe(0)
     server.close()
+  })
+
+  it.runIf(process.platform === 'win32')('binds on a Windows named pipe without attempting chmod', async () => {
+    const { socketPath } = pickSocketPath('win32')
+    const chmodSpy = vi.spyOn(fs, 'chmodSync')
+    const server = net.createServer()
+    try {
+      await new Promise<void>((resolve, reject) => {
+        server.once('listening', () => resolve())
+        server.once('error', reject)
+        listenAndRestrict(server, socketPath)
+      })
+      expect(chmodSpy).not.toHaveBeenCalledWith(socketPath, expect.anything())
+    } finally {
+      chmodSpy.mockRestore()
+      await new Promise<void>(resolve => server.close(() => resolve()))
+    }
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/cli/pull/1331

### 📚 Description

uncovered in a renovate PR, deno doesn't tolerate normalised forward slashes in a named pipe path