### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -709,10 +709,14 @@ export async function refreshNuxtData (keys?: string | string[]): Promise<void> 
     return Promise.resolve()
   }
 
-  await new Promise<void>(resolve => onNuxtReady(resolve))
+  const nuxtApp = useNuxtApp()
+
+  if (nuxtApp.isHydrating) {
+    await new Promise<void>(resolve => onNuxtReady(resolve))
+  }
 
   const _keys = keys ? toArray(keys) : undefined
-  await useNuxtApp().hooks.callHookParallel('app:data:refresh', _keys)
+  await nuxtApp.hooks.callHookParallel('app:data:refresh', _keys)
 }
 
 /** @since 3.0.0 */

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -22,6 +22,7 @@ import { useAnnouncer } from '#app/composables/announcer'
 import { encodeRoutePath, encodeURL, resolveRouteObject } from '#app/composables/router'
 import { useRuntimeHook } from '#app/composables/runtime-hook'
 import { shouldLoadPayload } from '#app/composables/payload'
+import { requestIdleCallback } from '#app/compat/idle-callback'
 import { NuxtPage } from '#components'
 
 import { isTestingAppManifest } from '../matrix'
@@ -999,6 +1000,29 @@ describe('defineNuxtComponent', () => {
     await refreshNuxtData()
 
     expect(wrapper.html()).toMatchInlineSnapshot(`"<div>1</div>"`)
+  })
+
+  it('should refresh data without waiting for idle time after hydration', async () => {
+    const idleCallback = vi.mocked(requestIdleCallback)
+    const idleImplementation = idleCallback.getMockImplementation()
+    const nuxtApp = useNuxtApp()
+    const isHydrating = nuxtApp.isHydrating
+    const refresh = vi.fn()
+    const removeHook = nuxtApp.hooks.hook('app:data:refresh', refresh)
+
+    idleCallback.mockImplementation(() => 0)
+    idleCallback.mockClear()
+    nuxtApp.isHydrating = false
+
+    try {
+      await refreshNuxtData('test-key')
+      expect(refresh).toHaveBeenCalledWith(['test-key'])
+      expect(idleCallback).not.toHaveBeenCalled()
+    } finally {
+      removeHook()
+      nuxtApp.isHydrating = isHydrating
+      idleCallback.mockImplementation(idleImplementation!)
+    }
   })
 
   it.todo('should support Options API head')

--- a/test/setup-runtime.ts
+++ b/test/setup-runtime.ts
@@ -2,6 +2,6 @@ import { vi } from 'vitest'
 
 vi.mock('#app/compat/idle-callback', () => ({
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-  requestIdleCallback: (cb: Function) => cb(),
+  requestIdleCallback: vi.fn((cb: Function) => cb()),
   cancelIdleCallback: () => {},
 }))


### PR DESCRIPTION
### Linked issue

Closes #35312

### Description

`refreshNuxtData()` now only waits for `onNuxtReady()` while Nuxt is still hydrating. Once hydration has finished, it calls the `app:data:refresh` hook immediately instead of waiting for an idle callback.

This keeps the existing hydration guard but avoids delaying user-triggered refreshes from interactions such as modals or portals.

### Tests

- `pnpm vitest run --project nuxt test/nuxt/composables.test.ts -t "should refresh data without waiting for idle time after hydration"`
- `pnpm vitest run --project nuxt test/nuxt/composables.test.ts`
- `pnpm vitest run --project nuxt test/nuxt/use-async-data.test.ts`
- `pnpm eslint packages/nuxt/src/app/composables/asyncData.ts test/nuxt/composables.test.ts test/setup-runtime.ts`
- `pnpm typecheck`