### PR TITLE
fix(nuxt): unwrap getter `body` in `useFetch`

### DIFF
--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -358,7 +358,12 @@ export const createUseFetch: CreateUseFetch = defineKeyedFunctionFactory<CreateU
       const asyncData = useAsyncData<_ResT, ErrorT, DataT, PickKeys, DefaultT>(key, (_, { signal }) => {
         const _$fetch: $Fetch<unknown, NitroFetchRequest> = fetchOptions.$fetch || $fetch
 
-        return _$fetch(_request.value, { signal, ..._fetchOptions } as any) as Promise<_ResT>
+        const resolvedOptions = { signal, ..._fetchOptions } as Record<string, unknown>
+        if (typeof resolvedOptions.body === 'function') {
+          resolvedOptions.body = toValue(resolvedOptions.body as () => unknown)
+        }
+
+        return _$fetch(_request.value, resolvedOptions as any) as Promise<_ResT>
       }, _asyncDataOptions)
 
       return asyncData

--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -19,7 +19,7 @@ export type FetchResult<ReqT extends NitroFetchRequest, M extends AvailableRoute
 
 type ComputedOptions<T extends Record<string, any>> = {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-  [K in keyof T]: T[K] extends Function ? T[K] : ComputedOptions<T[K]> | Ref<T[K]> | T[K]
+  [K in keyof T]: T[K] extends Function ? T[K] : ComputedOptions<T[K]> | MaybeRefOrGetter<T[K]>
 }
 
 interface NitroFetchOptions<R extends NitroFetchRequest, M extends AvailableRouterMethod<R> = AvailableRouterMethod<R>, DataT = any> extends Omit<FetchOptions<_ResponseType, DataT>, 'cache'> {
@@ -52,6 +52,8 @@ export interface UseFetchOptionsWithTransform<
 > extends Omit<UseFetchOptions<ResT, DataT, PickKeys, DefaultT, R, M>, 'transform'> {
   transform: _Transform<ResT, DataT>
 }
+
+const MAYBE_REF_OR_GETTER_OPTION_KEYS = ['method', 'baseURL', 'query', 'params', 'body', 'headers'] as const
 
 function generateOptionSegments<_ResT, DataT, DefaultT> (opts: UseFetchOptions<_ResT, DataT, any, DefaultT, any, any>) {
   const segments: Array<string | undefined | Record<string, string>> = [
@@ -359,8 +361,10 @@ export const createUseFetch: CreateUseFetch = defineKeyedFunctionFactory<CreateU
         const _$fetch: $Fetch<unknown, NitroFetchRequest> = fetchOptions.$fetch || $fetch
 
         const resolvedOptions = { signal, ..._fetchOptions } as Record<string, unknown>
-        if (typeof resolvedOptions.body === 'function') {
-          resolvedOptions.body = toValue(resolvedOptions.body as () => unknown)
+        for (const key of MAYBE_REF_OR_GETTER_OPTION_KEYS) {
+          if (typeof resolvedOptions[key] === 'function') {
+            resolvedOptions[key] = toValue(resolvedOptions[key] as () => unknown)
+          }
         }
 
         return _$fetch(_request.value, resolvedOptions as any) as Promise<_ResT>

--- a/test/fixtures/basic-types/app/app-types.ts
+++ b/test/fixtures/basic-types/app/app-types.ts
@@ -160,6 +160,46 @@ describe('API routes', () => {
       },
     })
   })
+
+  // https://github.com/nuxt/nuxt/issues/35341
+  it('accepts MaybeRefOrGetter for documented option fields', () => {
+    const method = ref<'POST'>('POST')
+    const base = ref('/api')
+    const search = ref('x')
+    const state = reactive({ name: 'a' })
+
+    for (const useFn of [useFetch, useLazyFetch]) {
+      useFn('/x', {
+        method,
+        baseURL: base,
+        query: { q: search },
+        params: { q: search },
+        headers: { 'x-test': search },
+        body: state,
+      })
+      useFn('/x', {
+        method: computed(() => method.value),
+        baseURL: computed(() => base.value),
+        query: computed(() => ({ q: search.value })),
+        params: computed(() => ({ q: search.value })),
+        headers: computed(() => ({ 'x-test': search.value })),
+        body: computed(() => ({ ...state })),
+      })
+      useFn('/x', {
+        method: () => method.value,
+        baseURL: () => base.value,
+        query: () => ({ q: search.value }),
+        params: () => ({ q: search.value }),
+        headers: () => ({ 'x-test': search.value }),
+        body: () => ({ ...state }),
+      })
+    }
+
+    // @ts-expect-error wrong shape: number is not a method
+    useFetch('/x', { method: 123 })
+    // @ts-expect-error wrong shape: getter must return a method
+    useFetch('/x', { method: () => 123 })
+  })
 })
 
 describe('nitro compatible APIs', () => {

--- a/test/nuxt/use-fetch.test.ts
+++ b/test/nuxt/use-fetch.test.ts
@@ -182,15 +182,29 @@ describe('useFetch', () => {
   })
 
   // https://github.com/nuxt/nuxt/issues/35341
-  it('should send the unwrapped value when body is a getter', async () => {
-    registerEndpoint('/api/body-getter', defineEventHandler(async event => ({ body: await event.req.json() })))
+  it('should send unwrapped values when options are getters', async () => {
+    registerEndpoint('/api/getter-options', defineEventHandler(async event => ({
+      method: event.req.method,
+      url: event.req.url,
+      header: event.req.headers.get('x-test'),
+      body: event.req.method === 'POST' ? await event.req.json() : null,
+    })))
 
     const state = reactive({ name: 'userquin' })
-    const { data } = await useFetch<{ body: { name: string } }>('/api/body-getter', {
-      method: 'POST',
+    const method = ref<'POST'>('POST')
+    const search = ref('hello')
+
+    const { data } = await useFetch<{ method: string, url: string, header: string | null, body: { name: string } | null }>('/api/getter-options', {
+      method: () => method.value,
+      baseURL: () => '',
+      query: () => ({ q: search.value }),
+      headers: () => ({ 'x-test': 'yes' }),
       body: () => ({ ...state }),
     })
 
+    expect(data.value?.method).toBe('POST')
+    expect(data.value?.url).toContain('q=hello')
+    expect(data.value?.header).toBe('yes')
     expect(data.value?.body).toEqual({ name: 'userquin' })
   })
 

--- a/test/nuxt/use-fetch.test.ts
+++ b/test/nuxt/use-fetch.test.ts
@@ -181,6 +181,19 @@ describe('useFetch', () => {
     }
   })
 
+  // https://github.com/nuxt/nuxt/issues/35341
+  it('should send the unwrapped value when body is a getter', async () => {
+    registerEndpoint('/api/body-getter', defineEventHandler(async event => ({ body: await event.req.json() })))
+
+    const state = reactive({ name: 'userquin' })
+    const { data } = await useFetch<{ body: { name: string } }>('/api/body-getter', {
+      method: 'POST',
+      body: () => ({ ...state }),
+    })
+
+    expect(data.value?.body).toEqual({ name: 'userquin' })
+  })
+
   it('should produce different keys for FormData with duplicate keys or different files', async () => {
     registerEndpoint('/api/formdata-keys', defineEventHandler(() => ({ ok: true })))
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves #35341

### 📚 Description

we omitted to unwrap `body` (reactive isn't enough in this case, unlike the other object-shaped items in fetch options)