### PR TITLE
fix(nuxt): preserve plugin navigation during app boot

### DIFF
--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -180,6 +180,10 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
       ? router.resolve(initialURL)
       : router.currentRoute.value
 
+    // snapshot the starting route so a plugin that calls `navigateTo`
+    // during `applyPlugins` is not clobbered later on
+    const prePluginRoutePath = import.meta.client ? router.currentRoute.value.fullPath : ''
+
     // Detect if we're hydrating a prerendered page that doesn't match the current URL
     // (for example, if the browser URL has different query params than the
     // prerendered payload).
@@ -316,7 +320,12 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
           resolvedInitialRoute.name = undefined
         }
 
-        if (hasDeferredRoute) {
+        // respect a plugin that navigated away during boot
+        const pluginNavigatedAway = import.meta.client && router.currentRoute.value.fullPath !== prePluginRoutePath
+
+        if (pluginNavigatedAway) {
+          // we don't need to push the previous route
+        } else if (hasDeferredRoute) {
           // First apply the route that was prerendered to avoid hydration mismatches,
           // then replace it after hydration with the actual resolved initial route
           const payloadRoute = router.resolve(nuxtApp.payload.path!)

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -215,6 +215,17 @@ describe('pages', () => {
     expect(headers.get('location')).toEqual('/')
   })
 
+  // https://github.com/nuxt/nuxt/issues/28174
+  // https://github.com/nuxt/nuxt/issues/28966
+  it('respects `navigateTo` called from a plugin during SPA boot', async () => {
+    const { page, pageErrors } = await renderPage('')
+    await page.goto(url('/spa-plugin-redirect/login'))
+    await page.waitForFunction(() => window.useNuxtApp?.()._route.fullPath === '/spa-plugin-redirect/protected')
+    expect(await page.getByTestId('spa-plugin-redirect-page').textContent()).toContain('protected')
+    expect(pageErrors).toEqual([])
+    await page.close()
+  })
+
   it('allows routes to be added dynamically', async () => {
     const html = await $fetch<string>('/add-route-test')
     expect(html).toContain('Hello Nuxt 3!')

--- a/test/fixtures/basic/app/pages/spa-plugin-redirect/login.vue
+++ b/test/fixtures/basic/app/pages/spa-plugin-redirect/login.vue
@@ -1,0 +1,5 @@
+<template>
+  <div data-testid="spa-plugin-redirect-page">
+    login
+  </div>
+</template>

--- a/test/fixtures/basic/app/pages/spa-plugin-redirect/protected.vue
+++ b/test/fixtures/basic/app/pages/spa-plugin-redirect/protected.vue
@@ -1,0 +1,5 @@
+<template>
+  <div data-testid="spa-plugin-redirect-page">
+    protected
+  </div>
+</template>

--- a/test/fixtures/basic/app/plugins/spa-plugin-redirect.client.ts
+++ b/test/fixtures/basic/app/plugins/spa-plugin-redirect.client.ts
@@ -1,0 +1,5 @@
+export default defineNuxtPlugin(async () => {
+  if (useRoute().path === '/spa-plugin-redirect/login') {
+    await navigateTo('/spa-plugin-redirect/protected')
+  }
+})

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -182,6 +182,7 @@ export default withMatrix({
       '/route-rules/middleware': { appMiddleware: 'route-rules-middleware' },
       '/route-rules/layout': { appLayout: 'custom' },
       '/hydration/spa-redirection/**': { ssr: false },
+      '/spa-plugin-redirect/**': { ssr: false },
       '/no-scripts': { noScripts: true },
       '/prerender/**': { prerender: true },
       '/route-rules/redirect': { redirect: '/' },


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/28174
resolves https://github.com/nuxt/nuxt/issues/28966

### 📚 Description

we push the initial route after running plugins, but this can clobber any plugin which navigates. that's to be avoided in general as it leads to hydration issues, but in some cases (like `ssr: false`) it's acceptable and it makes sense to respect this.