### PR TITLE
feat: add support for custom templates

### DIFF
--- a/docs/4.api/4.commands/add.md
+++ b/docs/4.api/4.commands/add.md
@@ -110,3 +110,60 @@ npx nuxt add api hello
 # Generates `layers/subscribe/nuxt.config.ts`
 npx nuxt add layer subscribe
 ```
+
+## Extending Templates
+
+You can extend the available templates using the `templates:extend` hook, for example in a module or plugin. This allows adding new template types or overriding built-in ones.
+
+Custom templates receive the same `args` as built-in templates. All CLI flags — including modifier flags like `--client`, `--server`, `--mode`, `--method`, `--global` — flow through to the template generator via the `args` parameter.
+
+### Adding a new template
+
+```ts
+import { defineNuxtModule } from '@nuxt/kit'
+
+export default defineNuxtModule({
+  setup (_, nuxt) {
+    nuxt.hook('templates:extend', (templates) => {
+      templates.model = ({ name, args, nuxtOptions }) => ({
+        path: `${nuxtOptions.srcDir}/models/${name}${args.type ? `.${args.type}` : ''}.ts`,
+        contents: `
+export interface ${name} {
+  id: string
+  createdAt: Date
+  updatedAt: Date
+}
+`,
+      })
+    })
+  },
+})
+```
+
+Then generate it with:
+
+```bash [Terminal]
+npx nuxt add model User
+npx nuxt add model User --type=query
+```
+
+### Overriding an existing template
+
+```ts
+import { defineNuxtModule } from '@nuxt/kit'
+
+export default defineNuxtModule({
+  setup (_, nuxt) {
+    nuxt.hook('templates:extend', (templates) => {
+      templates.component = ({ name, args, nuxtOptions }) => ({
+        path: `${nuxtOptions.srcDir}/components/${name}${args.mode ? `.${args.mode}` : ''}.vue`,
+        contents: `
+<template>
+  <div>{{ ${name} }}</div>
+</template>
+`,
+      })
+    })
+  },
+})
+```

--- a/packages/schema/src/types/hooks.ts
+++ b/packages/schema/src/types/hooks.ts
@@ -8,7 +8,7 @@ import type { Compiler, Configuration, Stats } from 'webpack'
 import type { Schema, SchemaDefinition } from 'untyped'
 import type { RouteLocationRaw, RouteRecordRaw } from 'vue-router'
 import type { RawVueCompilerOptions } from '@vue/language-core'
-import type { ViteConfig } from './config.ts'
+import type { NuxtOptions, ViteConfig } from './config.ts'
 import type { NuxtCompatibility, NuxtCompatibilityIssues } from './compatibility.ts'
 import type { Component, ComponentsOptions } from './components.ts'
 import type { Nuxt, NuxtApp, ResolvedNuxtTemplate } from './nuxt.ts'
@@ -85,6 +85,19 @@ export interface NuxtAnalyzeMeta {
   analyzeDir: string
   buildDir: string
   outDir: string
+}
+
+/**
+ * Template generator for nuxi scaffolding templates.
+ * Used by the `templates:extend` hook to add or override code generation templates.
+ */
+export type TemplateGenerator = (options: {
+  name: string
+  args: Record<string, unknown>
+  nuxtOptions: NuxtOptions
+}) => {
+  path: string
+  contents: string
 }
 
 /**
@@ -294,6 +307,15 @@ export interface NuxtHooks {
    * @returns Promise
    */
   'listen': (listenerServer: HttpServer | HttpsServer, listener: any) => HookResult
+  /**
+   * Allows extending nuxi `add-template` code generation templates.
+   *
+   * The `templates` object maps template names to generator functions. Modules
+   * can add new entries or override existing ones by mutating the object.
+   * @param templates The `templates` record to mutate
+   * @returns Promise
+   */
+  'templates:extend': (templates: Record<string, TemplateGenerator>) => HookResult
 
   // Schema
   /**


### PR DESCRIPTION
**This PR is a proposal rather than final implementation.**

### 🔗 Linked issue

Resolves https://github.com/nuxt/cli/issues/56

### 📚 Description

This PR introduces another Nuxt hook that can be triggered for gathering custom file templates from client modules instead of being hard-coded to a limited set of files (e.g. component, module, etc).
