### PR TITLE
fix(nuxt): normalize island props before hashing

### DIFF
--- a/packages/nuxt/src/app/island-hash.ts
+++ b/packages/nuxt/src/app/island-hash.ts
@@ -14,7 +14,7 @@ export function filterIslandProps (props: Record<string, any> | null | undefined
   if (!props) { return {} }
   const out: Record<string, any> = {}
   for (const key in props) {
-    if (!key.startsWith('data-v-')) {
+    if (!key.startsWith('data-v-') && props[key] !== undefined) {
       out[key] = props[key]
     }
   }

--- a/packages/nuxt/src/app/island-hash.ts
+++ b/packages/nuxt/src/app/island-hash.ts
@@ -14,10 +14,7 @@ export function filterIslandProps (props: Record<string, any> | null | undefined
   if (!props) { return {} }
   const out: Record<string, any> = {}
   for (const key in props) {
-    if (typeof props[key] === 'function') {
-      throw new TypeError(`Invalid island prop "${key}": functions cannot be serialized`)
-    }
-    if (!key.startsWith('data-v-') && props[key] !== undefined) {
+    if (!key.startsWith('data-v-') && props[key] !== undefined && typeof props[key] !== 'function') {
       out[key] = props[key]
     }
   }

--- a/packages/nuxt/src/app/island-hash.ts
+++ b/packages/nuxt/src/app/island-hash.ts
@@ -14,6 +14,9 @@ export function filterIslandProps (props: Record<string, any> | null | undefined
   if (!props) { return {} }
   const out: Record<string, any> = {}
   for (const key in props) {
+    if (typeof props[key] === 'function') {
+      throw new TypeError(`Invalid island prop "${key}": functions cannot be serialized`)
+    }
     if (!key.startsWith('data-v-') && props[key] !== undefined) {
       out[key] = props[key]
     }

--- a/packages/nuxt/test/island-hash.test.ts
+++ b/packages/nuxt/test/island-hash.test.ts
@@ -31,8 +31,8 @@ describe('filterIslandProps', () => {
   })
 
   // #35349
-  it('throw on function values', () => {
-    expect(() => filterIslandProps({ heading: () => {}, label: 'hi' })).toThrow()
+  it('strips function values', () => {
+    expect(filterIslandProps({ heading: () => {}, label: 'hi' })).toEqual({ label: 'hi' })
   })
 
   it('strips `undefined` values', () => {

--- a/packages/nuxt/test/island-hash.test.ts
+++ b/packages/nuxt/test/island-hash.test.ts
@@ -31,6 +31,10 @@ describe('filterIslandProps', () => {
   })
 
   // #35349
+  it('throw on function values', () => {
+    expect(() => filterIslandProps({ heading: () => {}, label: 'hi' })).toThrow()
+  })
+
   it('strips `undefined` values', () => {
     expect(filterIslandProps({ heading: undefined, label: 'hi' })).toEqual({ label: 'hi' })
   })

--- a/packages/nuxt/test/island-hash.test.ts
+++ b/packages/nuxt/test/island-hash.test.ts
@@ -29,6 +29,11 @@ describe('filterIslandProps', () => {
     // Only the prefix is stripped — keys like `extra-data-v-x` are legitimate.
     expect(filterIslandProps({ 'extra-data-v-x': 1, 'data-v-x': 2 })).toEqual({ 'extra-data-v-x': 1 })
   })
+
+  // #35349
+  it('strips `undefined` values', () => {
+    expect(filterIslandProps({ heading: undefined, label: 'hi' })).toEqual({ label: 'hi' })
+  })
 })
 
 describe('computeIslandHash', () => {


### PR DESCRIPTION
### 🔗 Linked issue

Close https://github.com/nuxt/nuxt/issues/35349

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

PR to prevent passing undefined and function values to ohash

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
