### PR TITLE
fix(nuxt): avoid idle wait when refreshing data after hydration

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -710,10 +710,13 @@ export async function refreshNuxtData (keys?: string | string[]): Promise<void> 
     return Promise.resolve()
   }
 
-  await new Promise<void>(resolve => onNuxtReady(resolve))
+  const nuxtApp = useNuxtApp()
+  if (nuxtApp.isHydrating) {
+    await new Promise<void>(resolve => onNuxtReady(resolve))
+  }
 
   const _keys = keys ? toArray(keys) : undefined
-  await useNuxtApp().hooks.callHookParallel('app:data:refresh', _keys)
+  await nuxtApp.hooks.callHookParallel('app:data:refresh', _keys)
 }
 
 /** @since 3.0.0 */

--- a/test/nuxt/use-async-data.test.ts
+++ b/test/nuxt/use-async-data.test.ts
@@ -9,6 +9,7 @@ import { flushPromises } from '@vue/test-utils'
 import { Transition } from 'vue'
 
 import type { NuxtApp } from '#app/nuxt'
+import * as idleCallback from '#app/compat/idle-callback'
 import { clearNuxtData, refreshNuxtData, useAsyncData, useLazyAsyncData, useNuxtData } from '#app/composables/asyncData'
 import { NuxtPage } from '#components'
 
@@ -191,6 +192,27 @@ describe('useAsyncData', () => {
     expect(data.data.value).toBeUndefined()
     await refreshNuxtData(uniqueKey)
     expect(data.data.value).toMatchInlineSnapshot('"test"')
+  })
+
+  it('should not wait for idle callback when refreshing after hydration', async () => {
+    const nuxtApp = useNuxtApp()
+    const isHydrating = nuxtApp.isHydrating
+    const requestIdleCallbackSpy = vi.spyOn(idleCallback, 'requestIdleCallback')
+
+    try {
+      nuxtApp.isHydrating = false
+      await useAsyncData(uniqueKey, () => Promise.resolve('test'))
+      clearNuxtData(uniqueKey)
+      const data = useNuxtData(uniqueKey)
+
+      await refreshNuxtData(uniqueKey)
+
+      expect(data.data.value).toMatchInlineSnapshot('"test"')
+      expect(requestIdleCallbackSpy).not.toHaveBeenCalled()
+    } finally {
+      nuxtApp.isHydrating = isHydrating
+      requestIdleCallbackSpy.mockRestore()
+    }
   })
 
   it('should allow overriding requests', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #35312

### 📚 Description

`refreshNuxtData()` currently waits for `onNuxtReady()` before calling the internal `app:data:refresh` hook.

That is useful while the app is still hydrating, but after hydration has finished, `onNuxtReady()` schedules the callback through `requestIdleCallback()`. In interaction-heavy UI contexts such as modals or portals, the browser may delay idle callbacks for a long time, so `refreshNuxtData(key)` can appear to hang before the actual data refresh even starts.

This changes `refreshNuxtData()` so it only waits for `onNuxtReady()` while `nuxtApp.isHydrating` is true. Once hydration is complete, it calls `app:data:refresh` immediately.

A regression test was added to ensure `refreshNuxtData()` does not wait for `requestIdleCallback()` after hydration.

### ✅ Tests

- `pnpm build:stub`
- `pnpm vitest run test/nuxt/use-async-data.test.ts --project nuxt --testNamePattern "refresh"`
- `pnpm vitest run test/nuxt/use-async-data.test.ts --project nuxt-legacy --testNamePattern "refresh"`
- `pnpm vitest run test/nuxt/composables.test.ts --project nuxt --project nuxt-legacy --testNamePattern "onNuxtReady|Options API refreshNuxtData"`
- `pnpm eslint packages/nuxt/src/app/composables/asyncData.ts test/nuxt/use-async-data.test.ts`
