### PR TITLE
fix(nuxt): refresh data immediately after hydration

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -710,10 +710,13 @@ export async function refreshNuxtData (keys?: string | string[]): Promise<void> 
     return Promise.resolve()
   }
 
-  await new Promise<void>(resolve => onNuxtReady(resolve))
+  const nuxtApp = useNuxtApp()
+  if (nuxtApp.isHydrating) {
+    await new Promise<void>(resolve => onNuxtReady(resolve))
+  }
 
   const _keys = keys ? toArray(keys) : undefined
-  await useNuxtApp().hooks.callHookParallel('app:data:refresh', _keys)
+  await nuxtApp.hooks.callHookParallel('app:data:refresh', _keys)
 }
 
 /** @since 3.0.0 */

--- a/test/nuxt/refresh-nuxt-data.test.ts
+++ b/test/nuxt/refresh-nuxt-data.test.ts
@@ -1,0 +1,36 @@
+/// <reference path="../fixtures/basic/.nuxt/nuxt.d.ts" />
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { requestIdleCallback } from '#app/compat/idle-callback'
+import { refreshNuxtData } from '#app/composables/asyncData'
+import { useNuxtApp } from '#app/nuxt'
+
+vi.mock('#app/compat/idle-callback', () => ({
+  requestIdleCallback: vi.fn(),
+  cancelIdleCallback: vi.fn(),
+}))
+
+describe('refreshNuxtData', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should refresh immediately when nuxt is already hydrated', async () => {
+    const nuxtApp = useNuxtApp()
+    nuxtApp.isHydrating = false
+    const onRefresh = vi.fn()
+    const removeHook = nuxtApp.hooks.hook('app:data:refresh', onRefresh)
+
+    try {
+      const refresh = refreshNuxtData('key')
+      await Promise.resolve()
+
+      expect(onRefresh).toHaveBeenCalledWith(['key'])
+      expect(vi.mocked(requestIdleCallback)).not.toHaveBeenCalled()
+      await refresh
+    } finally {
+      removeHook()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- Skip the `onNuxtReady()` idle callback gate in `refreshNuxtData()` once the app has finished hydrating.
- Preserve the existing hydration-time wait before refreshing async data.
- Add a regression test proving hydrated refreshes call `app:data:refresh` without scheduling `requestIdleCallback()`.

Fixes #35312.

## Tests

- `pnpm --filter nuxt build`
- `pnpm exec vitest run --project nuxt test/nuxt/refresh-nuxt-data.test.ts`
- `pnpm exec vitest run --project nuxt test/nuxt/use-async-data.test.ts`
- `pnpm exec eslint packages/nuxt/src/app/composables/asyncData.ts test/nuxt/refresh-nuxt-data.test.ts`

## Notes

- I did not use the full `test/nuxt/composables.test.ts` file as validation because the clean baseline in this nested Windows checkout has unrelated routing failures resolving `vue-router` from the parent workspace.