### PR TITLE
Refactor useRuntimeConfig() to omit event parameter

### DIFF
--- a/docs/4.api/2.composables/use-runtime-config.md
+++ b/docs/4.api/2.composables/use-runtime-config.md
@@ -56,7 +56,7 @@ To access runtime config, we can use `useRuntimeConfig()` composable:
 
 ```ts [server/api/test.ts]
 export default defineEventHandler(async (event) => {
-  const config = useRuntimeConfig(event)
+  const config = useRuntimeConfig()
 
   // Access public variables
   const result = await $fetch(`/test`, {
@@ -132,7 +132,7 @@ And then access the new CDN url using `config.app.cdnURL`.
 
 ```ts [server/api/foo.ts]
 export default defineEventHandler((event) => {
-  const config = useRuntimeConfig(event)
+  const config = useRuntimeConfig()
 
   // Access cdnURL universally
   const cdnURL = config.app.cdnURL


### PR DESCRIPTION
Updated useRuntimeConfig() calls to remove event parameter.

### 🔗 Linked issue

Resolves #35366

### 📚 Description

The event parameter in useRuntimeConfig is no longer needed and will not be used. To ensure nobody is using it anymore it should not be included in the documentation