### PR TITLE
docs: remove optional note about passing event to useRuntimeConfig

### DIFF
--- a/docs/2.directory-structure/1.server.md
+++ b/docs/2.directory-structure/1.server.md
@@ -349,10 +349,6 @@ NUXT_GITHUB_TOKEN='<my-super-token>'
 ```
 ::
 
-::note
-Giving the `event` as argument to `useRuntimeConfig` is optional, but it is recommended to pass it to get the runtime config overwritten by [environment variables](/docs/4.x/guide/going-further/runtime-config#environment-variables) at runtime for server routes.
-::
-
 ### Request Cookies
 
 ```ts [server/api/cookies.ts]

--- a/docs/3.guide/6.going-further/10.runtime-config.md
+++ b/docs/3.guide/6.going-further/10.runtime-config.md
@@ -146,10 +146,6 @@ export default defineEventHandler(async (event) => {
 })
 ```
 
-::note
-Giving the `event` as argument to `useRuntimeConfig` is optional, but it is recommended to pass it to get the runtime config overwritten by [environment variables](/docs/4.x/guide/going-further/runtime-config#environment-variables) at runtime for server routes.
-::
-
 ## Typing Runtime Config
 
 Nuxt tries to automatically generate a typescript interface from provided runtime config using [unjs/untyped](https://github.com/unjs/untyped).

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -8,7 +8,7 @@ import { createHooks } from 'hookable'
 import { getContext } from 'unctx'
 import type { UseContext } from 'unctx'
 import type { SSRContext, createRenderer } from 'vue-bundle-renderer/runtime'
-import type { EventHandlerRequest, H3Event } from '@nuxt/nitro-server/h3'
+import type { H3Event } from '@nuxt/nitro-server/h3'
 import type { RenderResponse } from 'nitro/types'
 import type { LogObject } from 'consola'
 import type { UseHeadInput, VueHeadClient } from '@unhead/vue/types'
@@ -642,7 +642,7 @@ export function useNuxtApp (id?: string): NuxtApp {
 
 /** @since 3.0.0 */
 /* @__NO_SIDE_EFFECTS__ */
-export function useRuntimeConfig (_event?: H3Event<EventHandlerRequest>): RuntimeConfig {
+export function useRuntimeConfig (): RuntimeConfig {
   return useNuxtApp().$config
 }
 

--- a/packages/nuxt/src/imports/module.ts
+++ b/packages/nuxt/src/imports/module.ts
@@ -298,7 +298,7 @@ function addDeclarationTemplates (ctx: Pick<Unimport, 'getImports' | 'generateTy
       // Utilities that exist in both Nuxt and Nitro contexts but with different implementations.
       // These are safe to use in the shared context.
       const handCraftedDeclarations = `
-  const useRuntimeConfig: (event?: import('h3').H3Event) => import('nuxt/schema').RuntimeConfig
+  const useRuntimeConfig: () => import('nuxt/schema').RuntimeConfig
   const useAppConfig: () => import('nuxt/schema').AppConfig
   const defineAppConfig: <C extends import('nuxt/schema').AppConfigInput>(config: C) => C
   const createError: typeof import('h3')['createError']

--- a/test/fixtures/basic-types/app/app-types.ts
+++ b/test/fixtures/basic-types/app/app-types.ts
@@ -1,7 +1,6 @@
 import { describe, expectTypeOf, it } from 'vitest'
 import type { Ref, SlotsType } from 'vue'
 import type { NavigationFailure, RouteLocationNormalized, RouteLocationRaw, Router, useRouter as vueUseRouter } from 'vue-router'
-import type { H3Event } from 'h3'
 
 import { $fetch } from 'ofetch'
 import type { AppConfig, NuxtConfig as NuxtConfigFromAt, NuxtHooks as NuxtHooksFromAt } from '@nuxt/schema'
@@ -204,7 +203,7 @@ describe('API routes', () => {
 
 describe('nitro compatible APIs', () => {
   it('useRuntimeConfig', () => {
-    useRuntimeConfig({} as H3Event)
+    useRuntimeConfig()
   })
 })
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

Follow on from #35367 targeted at main

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

Nitro v3 no longer needs the `event` param. This is already documented [here](https://nuxt.com/docs/5.x/getting-started/upgrade#useruntimeconfig-no-longer-accepts-event) and [here](https://nuxt.com/docs/5.x/api/composables/use-runtime-config#usage). However, there were still a few leftover instances of `useRuntimeConfig` with the event param. There were also a couple of note blocks that reference the old v3/4 behaviour. 

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
