### PR TITLE
ci: skip entire job, not just step

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -16,6 +16,6 @@ permissions: {}
 jobs:
   deploy-docs:
     runs-on: ubuntu-slim
-    if: ${{ github.repository_owner == 'nuxt' && github.event_name == 'push' }}
+    if: ${{ github.repository_owner == 'nuxt' }}
     steps:
       - run: curl "${{ secrets.DOCS_WEBHOOK }}"

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -16,7 +16,6 @@ permissions: {}
 jobs:
   deploy-docs:
     runs-on: ubuntu-slim
-
+    if: ${{ github.repository_owner == 'nuxt' && github.event_name == 'push' }}
     steps:
-      - if: ${{ github.repository_owner == 'nuxt' && github.event_name == 'push' }}
-        run: curl "${{ secrets.DOCS_WEBHOOK }}"
+      - run: curl "${{ secrets.DOCS_WEBHOOK }}"

--- a/.github/workflows/notify-nuxt-website.yml
+++ b/.github/workflows/notify-nuxt-website.yml
@@ -14,7 +14,7 @@ permissions: {}
 jobs:
   notify:
     runs-on: ubuntu-slim
+    if: ${{ github.repository_owner == 'nuxt' }}
     steps:
       - name: trigger nuxt website deployment
-        if: ${{ github.repository_owner == 'nuxt' }}
         run: curl "${{ secrets.NUXT_WEBSITE_WEBHOOK_URL }}"


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

Follow on from #35377

### 📚 Description

Rather than running the job and skipping the step, we can skip the job entirely. It should then show as 'skipped' instead of 'success' with the skipped step.

https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idif



<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
