### PR TITLE
ci: error handling for webhook triggers

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -18,5 +18,6 @@ jobs:
     runs-on: ubuntu-slim
 
     steps:
-      - if: ${{ github.repository_owner == 'nuxt' && github.event_name == 'push' }}
-        run: curl "${{ secrets.DOCS_WEBHOOK }}"
+      - name: trigger docs deployment
+        if: ${{ github.repository_owner == 'nuxt' && github.event_name == 'push' }}
+        run: curl -fsS --max-time 30 --retry 3 --retry-delay 5 --retry-connrefused "${{ secrets.DOCS_WEBHOOK }}"

--- a/.github/workflows/notify-nuxt-website.yml
+++ b/.github/workflows/notify-nuxt-website.yml
@@ -17,4 +17,4 @@ jobs:
     steps:
       - name: trigger nuxt website deployment
         if: ${{ github.repository_owner == 'nuxt' }}
-        run: curl "${{ secrets.NUXT_WEBSITE_WEBHOOK_URL }}"
+        run: curl -fsS --max-time 30 --retry 3 --retry-delay 5 --retry-connrefused "${{ secrets.NUXT_WEBSITE_WEBHOOK_URL }}"


### PR DESCRIPTION
### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

Failed curl requests still return a `0` exit code, so any errors will fail silenty and the action will succeed. This PR add some basic error handling as well as a time limit and hiding the progress meter.

| Flag | Purpose |
|---|---|
| [`-f`](https://curl.se/docs/manpage.html#-f) | Fail the step on HTTP ≥ 400 (currently silently succeeds) |
| [`-s`](https://curl.se/docs/manpage.html#-s) [`-S`](https://curl.se/docs/manpage.html#-S) | Silent (no progress meter) but still show errors |
| [`--max-time 30`](https://curl.se/docs/manpage.html#--max-time) | Bound the request — prevents a hung target from blocking CI forever |
| [`--retry 3`](https://curl.se/docs/manpage.html#--retry) [`--retry-delay 5`](https://curl.se/docs/manpage.html#--retry-delay) [`--retry-connrefused`](https://curl.se/docs/manpage.html#--retry-connrefused) | Survive transient failures and cold-start delays |

I'm not sure how the webhook behaves, but if it returns an error message, we may want [`--fail-with-body`](https://curl.se/docs/manpage.html#--fail-with-body) instead of `-f`
<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
