### PR TITLE
perf(nuxt): reduce dev pages startup work

### DIFF
--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -307,9 +307,9 @@ export default defineNuxtModule({
 
       const context = createRoutesContext(resolveOptions(typedRouterOptions))
       await mkdir(dirname(declarationFile), { recursive: true })
-      await context.scanPages(false)
 
       if (nuxt.options._prepare || !nuxt.options.dev) {
+        await context.scanPages(false)
         // TODO: could we generate this from context instead?
         const dts = await readFile(declarationFile, 'utf-8')
         addTemplate({

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -9,7 +9,6 @@ import { hash } from 'ohash'
 import { defu } from 'defu'
 import { klona } from 'klona'
 import { parseAndWalk } from 'oxc-walker'
-import { parseSync, transformSync } from 'rolldown/utils'
 import type { ESTree } from 'rolldown/utils'
 import { addFile, buildTree, compileParsePath, removeFile, toVueRouter4 } from 'unrouting'
 import type { BuildTreeOptions, InputFile, RouteTree, VueRouterEmitOptions } from 'unrouting'
@@ -197,9 +196,30 @@ export function extractScriptContent (sfc: string) {
   return contents
 }
 
-const PAGE_EXTRACT_RE = /(definePageMeta|defineRouteRules)\([\s\S]*?\)/g
+const PAGE_META_MACRO_NAMES = ['definePageMeta', 'defineRouteRules'] as const
+// Cheap pre-scan only. The AST walk below validates call expressions so this
+// intentionally matches macro names, not JavaScript/TypeScript call syntax.
+const PAGE_EXTRACT_RE = new RegExp(`\\b(${PAGE_META_MACRO_NAMES.join('|')})\\b`, 'g')
 export const defaultExtractionKeys = ['name', 'path', 'props', 'alias', 'redirect', 'middleware'] as const
 const DYNAMIC_META_KEY = '__nuxt_dynamic_meta_key' as const
+
+type StaticExpressionWrapper = ESTree.Node & { expression: ESTree.Node }
+
+const STATIC_EXPRESSION_WRAPPERS = new Set([
+  'ParenthesizedExpression',
+  'TSAsExpression',
+  'TSNonNullExpression',
+  'TSSatisfiesExpression',
+  'TSTypeAssertion',
+])
+
+function unwrapStaticExpression (node: ESTree.Node | undefined): ESTree.Node | undefined {
+  let current = node
+  while (current && STATIC_EXPRESSION_WRAPPERS.has(current.type)) {
+    current = (current as StaticExpressionWrapper).expression
+  }
+  return current
+}
 
 const pageContentsCache: Record<string, string> = {}
 const extractCache: Record<string, Partial<Record<keyof NuxtPage, any>>> = {}
@@ -246,24 +266,8 @@ export function getRouteMeta (contents: string, absolutePath: string, extraExtra
       if (fnName in found === false || found[fnName] !== false) { return }
       found[fnName] = true
 
-      let code = script.code
-      let pageExtractArgument = node.expression.arguments[0]
-
-      // TODO: always true because `extractScriptContent` only detects ts/tsx loader
-      if (/tsx?/.test(script.loader)) {
-        // slice, transform and parse the `define...` macro node to avoid parsing the whole file
-        const transformed = transformSync(absolutePath, script.code.slice(node.start, node.end), { lang: script.loader, tsconfig: false })
-        if (transformed.errors.length) {
-          for (const error of transformed.errors) {
-            logger.warn(`Error while transforming \`${fnName}()\`\n` + error.message)
-          }
-          return
-        }
-
-        // we already know that the first statement is a call expression
-        pageExtractArgument = ((parseSync('', transformed.code, { lang: 'js' }).program.body[0]! as ESTree.ExpressionStatement).expression as ESTree.CallExpression).arguments[0]
-        code = transformed.code
-      }
+      const code = script.code
+      const pageExtractArgument = unwrapStaticExpression(node.expression.arguments[0])
 
       if (pageExtractArgument?.type !== 'ObjectExpression') {
         logger.warn(`\`${fnName}\` must be called with an object literal (reading \`${absolutePath}\`), found ${pageExtractArgument?.type} instead.`)
@@ -537,6 +541,8 @@ export function resolveRoutePaths (page: NuxtPage, parent = '/'): string[] {
 }
 
 export function isSerializable (code: string, node: ESTree.Node): { value?: any, serializable: boolean } {
+  node = unwrapStaticExpression(node) || node
+
   if (node.type === 'Literal') {
     if (typeof node.value === 'string' || typeof node.value === 'number' || typeof node.value === 'boolean' || node.value === null) {
       return { value: node.value, serializable: true }

--- a/packages/nuxt/test/page-metadata.test.ts
+++ b/packages/nuxt/test/page-metadata.test.ts
@@ -219,6 +219,8 @@ definePageMeta({ name: 'bar' })
     definePageMeta({
       name: 'name-from-page-meta' as PageName,
       path: ('/some-custom-path') as const,
+      alias: <string>'/some-alias',
+      redirect: '/some-redirect'!,
       props: <{ foo: string }>{
         foo: 'bar' satisfies string,
       },
@@ -228,8 +230,36 @@ definePageMeta({ name: 'bar' })
 
     expect(meta).toMatchInlineSnapshot(`
       {
+        "alias": "/some-alias",
         "name": "name-from-page-meta",
         "path": "/some-custom-path",
+        "props": {
+          "foo": "bar",
+        },
+        "redirect": "/some-redirect",
+      }
+    `)
+  })
+
+  it('should extract metadata from typed macro calls', () => {
+    const meta = getRouteMeta(`
+    <script setup lang="ts">
+    interface PageMeta {
+      name: string
+    }
+
+    definePageMeta<PageMeta>({
+      name: 'name-from-page-meta',
+      props: {
+        foo: 'bar',
+      },
+    });
+    </script>
+    `, filePath)
+
+    expect(meta).toMatchInlineSnapshot(`
+      {
+        "name": "name-from-page-meta",
         "props": {
           "foo": "bar",
         },


### PR DESCRIPTION
### 📚 Description

This PR reduces page-related work during `nuxt dev`.

* It skips an early typed-router page scan in normal dev mode. Dev still scans pages during `app:templatesGenerated`.
* It also removes the `page-meta` TypeScript transform path and instead unwraps TS AST nodes directly, so static `definePageMeta` values using `as`, `satisfies`, etc. can still be extracted without the extra transform.
  * My first approach was with a huge regex and Rolldown's transform
  * But the walking was way more performant!