### PR TITLE
fix(rspack,webpack): strip invalid webpack PURE annotations

### DIFF
--- a/packages/webpack/src/plugins/strip-invalid-pure-annotations.ts
+++ b/packages/webpack/src/plugins/strip-invalid-pure-annotations.ts
@@ -1,0 +1,49 @@
+import type { Compiler, WebpackPluginInstance } from 'webpack'
+import { isJS } from './vue/util.ts'
+
+const STUB_MARKER = '/* unused pure expression or super */'
+const INVALID_ANNOTATION_RE = /\/\* @__PURE__ \*\/(?= \(\/\* unused pure expression or super \*\/ null && \()/g
+const PURE_ANNOTATION_REPLACEMENT = ' '.repeat('/* @__PURE__ */'.length)
+
+/**
+ * Replace any orphaned `/* @__PURE__ *\/` that webpack and rspack leave in
+ * front of their dead-code stubs with whitespace of equal length. Exported
+ * for unit testing.
+ */
+export function stripInvalidPureAnnotations (code: string): string {
+  if (!code.includes(STUB_MARKER)) { return code }
+  return code.replace(INVALID_ANNOTATION_RE, PURE_ANNOTATION_REPLACEMENT)
+}
+
+/**
+ * Strip the `/* @__PURE__ *\/` annotation that webpack and rspack leave in
+ * front of their `(/* unused pure expression or super *\/ null && (...))`
+ * stubs for unused exports. When Nitro re-bundles the SSR output through
+ * Rolldown, that pass rejects the annotation position and emits a noisy
+ * `INVALID_ANNOTATION` warning. The stub still evaluates to `null && (...)`,
+ * so dropping the orphaned annotation is safe.
+ *
+ * The replacement is the same length as the original comment so column
+ * positions (and therefore the emitted sourcemap) stay aligned.
+ */
+export class StripInvalidPureAnnotationsPlugin implements WebpackPluginInstance {
+  apply (compiler: Compiler) {
+    compiler.hooks.compilation.tap('StripInvalidPureAnnotationsPlugin', (compilation) => {
+      compilation.hooks.processAssets.tap({
+        name: 'StripInvalidPureAnnotationsPlugin',
+        stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_INLINE,
+      }, (assets) => {
+        for (const [filename, asset] of Object.entries(assets)) {
+          if (!isJS(filename)) { continue }
+
+          const source = asset.source()
+          const code = typeof source === 'string' ? source : source.toString()
+          const replaced = stripInvalidPureAnnotations(code)
+          if (replaced === code) { continue }
+
+          assets[filename] = new compiler.webpack.sources.RawSource(replaced)
+        }
+      })
+    })
+  }
+}

--- a/packages/webpack/src/presets/base.ts
+++ b/packages/webpack/src/presets/base.ts
@@ -14,6 +14,7 @@ import WarningIgnorePlugin from '../plugins/warning-ignore.ts'
 import type { WebpackConfigContext } from '../utils/config.ts'
 import { applyPresets, fileName } from '../utils/config.ts'
 import { RollupCompatDynamicImportPlugin } from '../plugins/rollup-compat-dynamic-import.ts'
+import { StripInvalidPureAnnotationsPlugin } from '../plugins/strip-invalid-pure-annotations.ts'
 
 import { WebpackBarPlugin, builder, webpack } from '#builder'
 
@@ -129,6 +130,7 @@ function basePlugins (ctx: WebpackConfigContext) {
   // Emit explicit dynamic import statements for rollup compatibility
   if (ctx.isServer && !ctx.isDev) {
     ctx.config.plugins.push(new RollupCompatDynamicImportPlugin())
+    ctx.config.plugins.push(new StripInvalidPureAnnotationsPlugin())
   }
 }
 

--- a/packages/webpack/test/strip-invalid-pure-annotations.test.ts
+++ b/packages/webpack/test/strip-invalid-pure-annotations.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { stripInvalidPureAnnotations } from '../src/plugins/strip-invalid-pure-annotations'
+
+describe('stripInvalidPureAnnotations', () => {
+  it('strips the orphan annotation that webpack and rspack leave on unused-export stubs', () => {
+    const input = 'const LayoutMetaSymbol = /* @__PURE__ */ (/* unused pure expression or super */ null && (Symbol("layout-meta")));'
+    const out = stripInvalidPureAnnotations(input)
+    expect(out).not.toContain('/* @__PURE__ */ (/* unused pure expression or super */')
+    expect(out).toContain('(/* unused pure expression or super */ null && (Symbol("layout-meta")))')
+    expect(out.length).toBe(input.length)
+  })
+
+  it('leaves stubs without a leading annotation untouched', () => {
+    const input = 'const definePayloadPlugin = (/* unused pure expression or super */ null && (defineNuxtPlugin));'
+    expect(stripInvalidPureAnnotations(input)).toBe(input)
+  })
+
+  it('leaves legitimate /* @__PURE__ */ annotations untouched', () => {
+    const input = 'const x = /* @__PURE__ */ foo(); const y = /* @__PURE__ */ new Bar();'
+    expect(stripInvalidPureAnnotations(input)).toBe(input)
+  })
+
+  it('returns the input as-is when no stub marker is present', () => {
+    const input = 'console.log("nothing to do here")'
+    expect(stripInvalidPureAnnotations(input)).toBe(input)
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

webpack/rspack produce invalid PURE annotations which rolldown noisily complains about in nitro v3; this strips these expressions