### PR TITLE
fix(kit,nuxt): pass error as `cause` when we re-throw

### DIFF
--- a/packages/kit/src/module/define.ts
+++ b/packages/kit/src/module/define.ts
@@ -125,7 +125,7 @@ function _defineNuxtModule<
     const moduleName = uniqueKey || module.meta.name || '<no name>'
     nuxt._perf?.startPhase(`module:${moduleName}`)
     const start = performance.now()
-    let res = {} as ModuleSetupReturn
+    let res: ModuleSetupReturn
     try {
       res = await module.setup?.call(null as any, _options, nuxt) ?? {}
     } finally {

--- a/packages/kit/src/module/install.ts
+++ b/packages/kit/src/module/install.ts
@@ -341,14 +341,14 @@ export async function loadNuxtModuleInstance (nuxtModule: string | NuxtModule, n
   } catch (error: unknown) {
     const code = (error as Error & { code?: string }).code
     if (code === 'ERR_PACKAGE_PATH_NOT_EXPORTED' || code === 'ERR_UNSUPPORTED_DIR_IMPORT' || code === 'ENOTDIR') {
-      throw new TypeError(`Could not load \`${nuxtModule}\`. Is it installed?`)
+      throw new TypeError(`Could not load \`${nuxtModule}\`. Is it installed?`, { cause: error })
     }
     if (code === 'MODULE_NOT_FOUND' || code === 'ERR_MODULE_NOT_FOUND') {
       const module = MissingModuleMatcher.exec((error as Error).message)?.[1]
       // verify that it's missing the nuxt module otherwise it may be a sub dependency of the module itself
       // i.e. module is importing a module that is missing
       if (module && !module.includes(nuxtModule as string)) {
-        throw new TypeError(`Error while importing module \`${nuxtModule}\`: ${error}`)
+        throw new TypeError(`Error while importing module \`${nuxtModule}\`: ${error}`, { cause: error })
       }
     }
   }

--- a/packages/nuxt/src/app/components/nuxt-island.ts
+++ b/packages/nuxt/src/app/components/nuxt-island.ts
@@ -237,7 +237,7 @@ const NuxtIsland = defineComponent({
         return result
       } catch (e: any) {
         if (r.status !== 200) {
-          throw new Error(e.toString(), { cause: r })
+          throw new Error(e.toString(), { cause: e })
         }
         throw e
       }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

flagged up in https://github.com/nuxt/nuxt/pull/35369 in eslint config improvements