### PR TITLE
fix(nuxt): guard against -1 when unregistering a router hook

### DIFF
--- a/packages/nuxt/src/app/plugins/router.ts
+++ b/packages/nuxt/src/app/plugins/router.ts
@@ -118,7 +118,10 @@ const plugin: Plugin<{ route: Route, router: Router }> & ObjectPlugin<{ route: R
 
     const registerHook = <T extends keyof RouterHooks> (hook: T, guard: RouterHooks[T]) => {
       hooks[hook].push(guard)
-      return () => hooks[hook].splice(hooks[hook].indexOf(guard), 1)
+      return () => {
+        const index = hooks[hook].indexOf(guard)
+        if (index !== -1) { hooks[hook].splice(index, 1) }
+      }
     }
     const baseURL = useRuntimeConfig().app.baseURL
 

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -58,7 +58,7 @@ describe.skipIf(isStubbed || process.env.SKIP_BUNDLE_SIZE === 'true' || process.
     const serverDir = join(rootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!_libs'], serverDir, rootDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"69.6k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"69.7k"`)
 
     const modules = await analyzeSizes(['_libs/**/*'], serverDir, rootDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"480k"`)


### PR DESCRIPTION
### 📚 Description

In the bundled `no-vue-router` router (used when `pages: false`), the unsubscribe returned by hooks like `beforeEach` or `afterEach` removes the last hook when `indexOf` returns -1, e.g. when a double-unsubscribe or an unsubscribe after the guard was already removed happens.

This PR fixes it.
