### PR TITLE
fix(nuxt): clean up load/error listeners in preloadPayload

### DIFF
--- a/packages/nuxt/src/app/composables/payload.ts
+++ b/packages/nuxt/src/app/composables/payload.ts
@@ -55,8 +55,14 @@ export function preloadPayload (url: string, opts: LoadPayloadOptions = {}): Pro
       linkEl.href = payloadURL
       document.head.appendChild(linkEl)
       return new Promise<void>((resolve, reject) => {
-        linkEl.addEventListener('load', () => resolve())
-        linkEl.addEventListener('error', () => reject())
+        const cleanup = () => {
+          linkEl.removeEventListener('load', onLoad)
+          linkEl.removeEventListener('error', onError)
+        }
+        const onLoad = () => { cleanup(); resolve() }
+        const onError = () => { cleanup(); reject() }
+        linkEl.addEventListener('load', onLoad)
+        linkEl.addEventListener('error', onError)
       })
     }
   })


### PR DESCRIPTION
### 📚 Description

The `link` element created for payload preloading kept its `load`/`error` listeners forever, causing a possible small leak.

This PR removes both once either fires so the GC can clean them up.
