### PR TITLE
perf(vite): skip unnecessary decorator transforms

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -37,6 +37,7 @@
     "exsolve": "^1.0.8",
     "get-port-please": "^3.2.0",
     "jiti": "^2.7.0",
+    "js-tokens": "^9.0.1",
     "knitwork": "^1.3.0",
     "mlly": "^1.8.2",
     "mocked-exports": "^0.1.1",

--- a/packages/vite/src/plugins/decorators.ts
+++ b/packages/vite/src/plugins/decorators.ts
@@ -1,8 +1,41 @@
 import type { Plugin } from 'vite'
 import { ensureDependencyInstalled, logger } from '@nuxt/kit'
 import type { Nuxt } from '@nuxt/schema'
+import jsTokens from 'js-tokens'
 
 const BABEL_DECORATOR_DEPS = ['@babel/plugin-proposal-decorators', '@babel/plugin-syntax-jsx'] as const
+
+export function hasDecoratorSyntax (code: string, jsx = false) {
+  const tokens = jsx ? jsTokens(code, { jsx: true }) : jsTokens(code)
+
+  for (const token of tokens) {
+    if (!token.value.includes('@')) {
+      continue
+    }
+
+    switch (token.type) {
+      case 'HashbangComment':
+      case 'SingleLineComment':
+      case 'TemplateHead':
+      case 'TemplateMiddle':
+        continue
+      case 'MultiLineComment':
+      case 'StringLiteral':
+      case 'NoSubstitutionTemplate':
+      case 'TemplateTail':
+      case 'JSXString':
+        // An unclosed token can consume code that follows it. Let Babel parse
+        // ambiguous input instead of potentially hiding a real decorator.
+        if (token.closed) {
+          continue
+        }
+    }
+
+    return true
+  }
+
+  return false
+}
 
 export function DecoratorsPlugin (nuxt: Nuxt): Plugin {
   let transformSync: typeof import('@babel/core').transformSync
@@ -50,6 +83,10 @@ export function DecoratorsPlugin (nuxt: Nuxt): Plugin {
       handler (code, id) {
         // Skip uncompiled SFC markup (raw .vue files not yet processed by @vitejs/plugin-vue)
         if (id.includes('.vue') && code.trimStart().startsWith('<')) {
+          return
+        }
+
+        if (!hasDecoratorSyntax(code, /\.[jt]sx(?:$|\?)/.test(id))) {
           return
         }
 

--- a/packages/vite/test/decorators.test.ts
+++ b/packages/vite/test/decorators.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { Nuxt } from '@nuxt/schema'
-import { DecoratorsPlugin } from '../src/plugins/decorators'
+import { DecoratorsPlugin, hasDecoratorSyntax } from '../src/plugins/decorators'
 
 function matchesFilter (
   filter: {
@@ -59,5 +59,63 @@ describe('DecoratorsPlugin transform filter', () => {
   it('does not match CSS files', () => {
     expect(matchesFilter(filter, '@import "./base.css";', '/src/styles.css')).toBe(false)
     expect(matchesFilter(filter, '@import "./base.scss";', '/src/styles.scss')).toBe(false)
+  })
+})
+
+describe('hasDecoratorSyntax', () => {
+  it.each([
+    '@sealed class Example {}',
+    'class Example { @logged method () {} }',
+    'const Example = @sealed class {}',
+    'const value = `${@sealed class {}}`',
+    'const pattern = /\'/; @sealed class Example {}',
+    'const pattern = /[`"\']/; @sealed class Example {}',
+    'const pattern = /contact@example\\.com/; @sealed class Example {}',
+    String.raw`const pattern = /https?:\/\/example\.com\/\/*/; @sealed class Example {}`,
+    'if (value) /[\'"]/.test(value)\n@sealed class Example {}',
+    'const ratio = left / right / divisor\n@sealed class Example {}',
+    'class Example { #pattern = /\'/; @logged method () {} }',
+    'const value = source?.property ?? /\'/\n@sealed class Example {}',
+    'const value = `outer@text${`inner${@sealed class {}}`}`',
+    'foo! / bar; @sealed class Example { value = /x/ }',
+  ])('detects decorators in %s', (code) => {
+    expect(hasDecoratorSyntax(code)).toBe(true)
+  })
+
+  it.each([
+    'import value from "@scope/package"',
+    '// @ts-expect-error\nconst value = true',
+    '/* @deprecated */\nconst value = true',
+    'const value = "@scope/package"',
+    'const value = `contact@example.com`',
+    'const value = `contact@${domain}`',
+    '#!/usr/bin/env node\nconst value = true // contact@example.com',
+  ])('ignores non-decorator usage in %s', (code) => {
+    expect(hasDecoratorSyntax(code)).toBe(false)
+  })
+
+  it.each([
+    'const value = /@scope\\/package/',
+    'const value = /[`"\'@]/',
+    String.raw`const value = /https?:\/\/user@example\.com\/\/*/`,
+  ])('conservatively checks regular expressions containing at signs in %s', (code) => {
+    expect(hasDecoratorSyntax(code)).toBe(true)
+  })
+
+  it('handles decorators and non-decorator at signs in JSX', () => {
+    expect(hasDecoratorSyntax('const value = <p title="contact@example.com" />', true)).toBe(false)
+    expect(hasDecoratorSyntax('const value = <p>contact@example.com</p>', true)).toBe(true)
+    expect(hasDecoratorSyntax('const value = <p>{@sealed class Example {}}</p>', true)).toBe(true)
+  })
+
+  it('does not hide decorators after ambiguous TSX syntax', () => {
+    expect(hasDecoratorSyntax('const identity = <T,>(value: T) => value\n@sealed class Example {}', true)).toBe(true)
+  })
+
+  it('conservatively handles unclosed literals', () => {
+    expect(hasDecoratorSyntax('const value = "contact@example.com')).toBe(true)
+    expect(hasDecoratorSyntax('const value = /contact@example.com')).toBe(true)
+    expect(hasDecoratorSyntax('const value = `contact@example.com')).toBe(true)
+    expect(hasDecoratorSyntax('/* contact@example.com')).toBe(true)
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1015,6 +1015,9 @@ importers:
       jiti:
         specifier: ^2.7.0
         version: 2.7.0
+      js-tokens:
+        specifier: ^9.0.1
+        version: 9.0.1
       knitwork:
         specifier: ^1.3.0
         version: 1.3.0


### PR DESCRIPTION
### 📚 Description

This PR skips the Babel decorator transforms when `@` only appears in comments, strings, or template text (so, when no real decorator was detected).

After experiments with a simple lexer I added `js-tokens` with a conservative fallback in case there is ambiguous or malformed syntax.