### PR TITLE
perf(vite): build plugin hook filter for unhead plugins

### DIFF
--- a/packages/nuxt/src/head/module.ts
+++ b/packages/nuxt/src/head/module.ts
@@ -3,12 +3,40 @@ import { pathToFileURL } from 'node:url'
 import { resolve } from 'pathe'
 import { addBuildPlugin, addComponent, addPlugin, addTemplate, addVitePlugin, defineNuxtModule, directoryToURL, useLogger } from '@nuxt/kit'
 import type { NuxtOptions } from '@nuxt/schema'
+import type { Plugin } from 'vite'
 import { resolveModulePath } from 'exsolve'
 import { streamingIifeCode } from 'unhead/stream/iife'
 import { distDir } from '../dirs.ts'
 import { UnheadImportsPlugin } from './plugins/unhead-imports.ts'
 
 const components = ['NoScript', 'Link', 'Base', 'Title', 'Meta', 'Style', 'Head', 'Html', 'Body']
+
+const unheadTransformCodeFilters: Record<string, RegExp> = {
+  'unhead:minify-transform': /\buse(?:Server)?Head\b/,
+  'unhead:use-seo-meta-transform': /\buse(?:Server)?SeoMeta\b/,
+}
+
+export function addUnheadTransformCodeFilters (plugins: Plugin[]) {
+  for (const plugin of plugins) {
+    const code = unheadTransformCodeFilters[plugin.name]
+    if (!code || !plugin.transform) { continue }
+
+    if (typeof plugin.transform === 'function') {
+      plugin.transform = {
+        filter: { code },
+        handler: plugin.transform,
+      }
+    } else if (!plugin.transform.filter?.code) {
+      plugin.transform = {
+        ...plugin.transform,
+        filter: {
+          ...plugin.transform.filter,
+          code,
+        },
+      }
+    }
+  }
+}
 
 export default defineNuxtModule<NuxtOptions['unhead']>({
   meta: {
@@ -71,7 +99,7 @@ export default defineNuxtModule<NuxtOptions['unhead']>({
       addVitePlugin(async () => {
         const { Unhead } = await import('@unhead/vue/vite')
         const viteOptions = options.vite || {}
-        return Unhead({
+        const plugins = Unhead({
           validate: !nuxt.options.test,
           minify: {
             js: rolldownURL
@@ -93,6 +121,9 @@ export default defineNuxtModule<NuxtOptions['unhead']>({
           },
           ...viteOptions,
         })
+
+        addUnheadTransformCodeFilters(plugins)
+        return plugins
       })
     }
 

--- a/packages/nuxt/test/head-module.test.ts
+++ b/packages/nuxt/test/head-module.test.ts
@@ -1,0 +1,57 @@
+import type { Plugin } from 'vite'
+import { describe, expect, it } from 'vitest'
+import { Unhead } from '@unhead/vue/vite'
+import { addUnheadTransformCodeFilters } from '../src/head/module.ts'
+
+function getCodeFilter (plugins: Plugin[], name: string) {
+  const plugin = plugins.find(plugin => plugin.name === name)
+  if (!plugin || typeof plugin.transform !== 'object') {
+    throw new TypeError(`Expected ${name} to have an object transform hook`)
+  }
+  return plugin.transform.filter?.code
+}
+
+describe('Unhead transform code filters', () => {
+  it('allows the Unhead transforms to process their composables', () => {
+    const plugins = Unhead({
+      minify: {
+        js: source => Promise.resolve(source),
+      },
+    })
+
+    addUnheadTransformCodeFilters(plugins)
+
+    const headFilter = getCodeFilter(plugins, 'unhead:minify-transform')
+    expect(headFilter).toBeInstanceOf(RegExp)
+    expect((headFilter as RegExp).test('useHead({})')).toBe(true)
+    expect((headFilter as RegExp).test('useServerHead({})')).toBe(true)
+
+    const seoMetaFilter = getCodeFilter(plugins, 'unhead:use-seo-meta-transform')
+    expect(seoMetaFilter).toBeInstanceOf(RegExp)
+    expect((seoMetaFilter as RegExp).test('useSeoMeta({})')).toBe(true)
+    expect((seoMetaFilter as RegExp).test('useServerSeoMeta({})')).toBe(true)
+  })
+
+  it('adds a filter to object hooks without replacing their metadata', () => {
+    const handler = () => null
+    const plugin = {
+      name: 'unhead:minify-transform',
+      transform: {
+        order: 'post' as const,
+        filter: { id: /\.vue$/ },
+        handler,
+      },
+    } satisfies Plugin
+
+    addUnheadTransformCodeFilters([plugin])
+
+    expect(plugin.transform).toMatchObject({
+      order: 'post',
+      filter: {
+        id: /\.vue$/,
+        code: /\buse(?:Server)?Head\b/,
+      },
+      handler,
+    })
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/e18e/ecosystem-issues/issues/171

### 📚 Description

Adds transform hook filters for unhead plugins, reducing rust<>js overhead for rolldown and build time. 