### PR TITLE
fix(nuxt): ensure `page:start` finishes before `page:finish` starts

### DIFF
--- a/packages/nuxt/src/pages/runtime/page.ts
+++ b/packages/nuxt/src/pages/runtime/page.ts
@@ -71,6 +71,8 @@ export default defineComponent({
     const done = nuxtApp.deferHydration()
     let isSuspensePending = false
     let hasResolvedOnce = false
+    let pageStartPromise: ReturnType<typeof nuxtApp.callHook>
+
     let suspenseKey = 0
     if (import.meta.client && nuxtApp.isHydrating) {
       const removeErrorHook = nuxtApp.hooks.hookOnce('app:error', done)
@@ -230,7 +232,7 @@ export default defineComponent({
                         nuxtApp['~transitionFinish'] = resolve
                       })
                     }
-                    nuxtApp.callHook('page:start', routeProps.Component)
+                    pageStartPromise = nuxtApp.callHook('page:start', routeProps.Component)
                   },
                   onResolve: async () => {
                     isSuspensePending = false
@@ -238,6 +240,7 @@ export default defineComponent({
                     try {
                       await nextTick()
                       nuxtApp._route.sync?.()
+                      await pageStartPromise
                       await nuxtApp.callHook('page:finish', routeProps.Component)
                       if (!pageLoadingEndHookAlreadyCalled && !willRenderAnotherChild) {
                         pageLoadingEndHookAlreadyCalled = true

--- a/test/nuxt/nuxt-page.test.ts
+++ b/test/nuxt/nuxt-page.test.ts
@@ -901,3 +901,56 @@ describe('NuxtPage should work with keepalive options', () => {
     el.unmount()
   })
 })
+
+// https://github.com/nuxt/nuxt/issues/35348
+describe('NuxtPage should not emit page:finish before the page:start hook chain settles', () => {
+  let router: ReturnType<typeof useRouter>
+  let nuxtApp: ReturnType<typeof useNuxtApp>
+
+  beforeEach(() => {
+    router = useRouter()
+    nuxtApp = useNuxtApp()
+
+    router.addRoute({
+      name: 'race-35348',
+      path: '/race-35348',
+      component: defineComponent({
+        name: 'race-35348',
+        async setup () {
+          await Promise.resolve()
+          return () => h('div', { 'data-testid': 'race-35348' }, 'Race')
+        },
+      }),
+    })
+  })
+
+  afterEach(() => {
+    router.removeRoute('race-35348')
+  })
+
+  it('awaits a slow async page:start callback before firing page:finish', async () => {
+    const el = await mountSuspended({
+      setup: () => () => h(NuxtLayout, {}, { default: () => h(NuxtPage) }),
+    })
+
+    const order: string[] = []
+    const removeStart = nuxtApp.hooks.hook('page:start', async () => {
+      order.push('start:enter')
+      await new Promise<void>(resolve => setTimeout(resolve, 50))
+      order.push('start:exit')
+    })
+    const removeFinish = nuxtApp.hooks.hook('page:finish', () => {
+      order.push('finish')
+    })
+
+    await navigateTo('/race-35348')
+    await new Promise<void>(resolve => nuxtApp.hooks.hookOnce('page:finish', () => resolve()))
+    await flushPromises()
+
+    expect(order).toEqual(['start:enter', 'start:exit', 'finish'])
+
+    removeStart()
+    removeFinish()
+    el.unmount()
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

resolves #35348

### 📚 Description

if a `page:start` callback was slow, but suspense was fast, it was possible to enter a deadlock state 😬