### PR TITLE
fix(vite): invalidate lazily-created SSR modules on render

### DIFF
--- a/packages/vite/src/plugins/vite-node.ts
+++ b/packages/vite/src/plugins/vite-node.ts
@@ -252,6 +252,19 @@ export function ViteNodePlugin (nuxt: Nuxt): VitePlugin | undefined {
       // See https://github.com/nuxt/nuxt/issues/30169.
       let lastSeenTimestamp = 0
 
+      // Files the watcher saw change but couldn't map to an SSR module yet:
+      // the SSR graph is populated lazily by `fetchModule` on render, so a
+      // file in an extended layer often isn't present at watch time and never
+      // gets its SSR timestamp advanced by Vite's HMR. We resolve these against
+      // the (now-populated) SSR graph at render time and invalidate them along
+      // with their importers, so an edit to e.g. a sibling-layer component
+      // reaches the page that renders it.
+      //
+      // The value counts down the renders a file may stay unresolved before we
+      // give up on it, so files that are never SSR-relevant don't accumulate.
+      const pendingChangedFiles = new Map<string, number>()
+      const PENDING_CHANGED_FILE_RENDERS = 2
+
       function collectInvalidatedSsrModules (ssrServer: ViteDevServer) {
         const ssrModuleGraph = ssrServer.environments.ssr.moduleGraph
         let maxSeen = lastSeenTimestamp
@@ -265,6 +278,21 @@ export function ViteNodePlugin (nuxt: Nuxt): VitePlugin | undefined {
           }
         }
         lastSeenTimestamp = maxSeen
+
+        for (const [file, remaining] of pendingChangedFiles) {
+          const mods = ssrModuleGraph.getModulesByFile(file)
+          if (mods?.size) {
+            for (const mod of mods) {
+              ssrModuleGraph.invalidateModule(mod)
+            }
+            markInvalidates(mods)
+            pendingChangedFiles.delete(file)
+          } else if (remaining <= 1) {
+            pendingChangedFiles.delete(file)
+          } else {
+            pendingChangedFiles.set(file, remaining - 1)
+          }
+        }
       }
 
       function resolveServer (ssrServer: ViteDevServer) {
@@ -302,7 +330,9 @@ export function ViteNodePlugin (nuxt: Nuxt): VitePlugin | undefined {
 
       clientServer.watcher.on('all', (_event, file) => {
         invalidates.add(file)
-        markInvalidates(clientServer.moduleGraph.getModulesByFile(normalize(file)))
+        const normalized = normalize(file)
+        markInvalidates(clientServer.moduleGraph.getModulesByFile(normalized))
+        pendingChangedFiles.set(normalized, PENDING_CHANGED_FILE_RENDERS)
       })
     },
     async buildEnd () {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

fixes an issue detected in the flakiness of test suite - previously whether we invalidated modules in dev ssr was dependent on _order_ - ie when vite had detected them. this pr collects info about changes so we can invalidate them lazily.