### PR TITLE
refactor(nitro): stringify island responses and tighten types

### DIFF
--- a/packages/nitro-server/src/runtime/handlers/island.ts
+++ b/packages/nitro-server/src/runtime/handlers/island.ts
@@ -12,11 +12,15 @@ import type { NuxtIslandContext, NuxtIslandResponse } from 'nuxt/app'
 import { traceAsync } from '#app/internal/tracing'
 // @ts-expect-error virtual file
 import { tracingChannelNuxt } from '#internal/nuxt.config.mjs'
-import { islandCache, islandPropCache } from '../utils/cache'
 import { createSSRContext } from '../utils/renderer/app'
 import { getSSRRenderer } from '../utils/renderer/build-files'
 import { renderInlineStyles } from '../utils/renderer/inline-styles'
 import { getClientIslandResponse, getServerComponentHTML, getSlotIslandResponse } from '../utils/renderer/islands'
+import { useStorage } from 'nitro/storage'
+import type { Storage } from 'unstorage'
+
+export const islandCache: Storage<string> | null = import.meta.prerender ? useStorage<string>('internal:nuxt:prerender:island') : null
+export const islandPropCache: Storage<string> | null = import.meta.prerender ? useStorage<string>('internal:nuxt:prerender:island-props') : null
 
 const ISLAND_SUFFIX_RE = /\.json(?:\?.*)?$/
 
@@ -26,7 +30,7 @@ const handler: ReturnType<typeof defineEventHandler> = defineEventHandler(async 
 
   const islandPath = event.url.pathname
   if (import.meta.prerender && await islandCache!.hasItem(islandPath)) {
-    return islandCache!.getItem(islandPath) as Promise<Partial<RenderResponse>>
+    return await islandCache!.getItem(islandPath) || undefined
   }
 
   const islandContext = await getIslandContext(event)
@@ -120,17 +124,19 @@ const handler: ReturnType<typeof defineEventHandler> = defineEventHandler(async 
 
   await useNitroHooks().callHook('render:island', islandResponse, { event, islandContext })
 
+  const islandResponseString = JSON.stringify(islandResponse)
+
   if (import.meta.prerender) {
     const requestUrl = islandPath + event.url.search + event.url.hash
-    await islandCache!.setItem(islandPath, islandResponse)
+    await islandCache!.setItem(islandPath, islandResponseString)
     await islandPropCache!.setItem(islandPath, requestUrl)
   }
-  return islandResponse
+  return islandResponseString
 })
 
 export default handler
 
-function returnIslandResponse (event: H3Event, response: Partial<RenderResponse>) {
+function returnIslandResponse (event: H3Event, response: Partial<RenderResponse>): string | undefined {
   for (const header in response.headers || {}) {
     event.res.headers.set(header, response.headers![header]!)
   }

--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -1,7 +1,6 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
 import { getPrefetchLinks, getPreloadLinks, getRequestDependencies, renderResourceHeaders } from 'vue-bundle-renderer/runtime'
 import { renderToWebStream } from 'vue/server-renderer'
-import type { RenderResponse } from 'nitro/types'
 import type { H3Event } from 'nitro/h3'
 import { HTTPError, defineEventHandler, getQuery, writeEarlyHints } from 'nitro/h3'
 import { getQuery as getURLQuery, joinURL } from 'ufo'
@@ -65,7 +64,7 @@ const handler: ReturnType<typeof defineEventHandler> = defineEventHandler((event
   // Whether we're rendering an error page
   const ssrError = event.url.pathname.startsWith('/__nuxt_error')
     ? getQuery<NuxtPayload['error'] & { url: string }>(event)
-    : null
+    : undefined
 
   if (ssrError && !event.context.nuxt?.['~rendering-error'] /* allow internal fetch from the error handler */) {
     throw new HTTPError({
@@ -94,7 +93,7 @@ const handler: ReturnType<typeof defineEventHandler> = defineEventHandler((event
   return renderRoute(event, ssrError)
 })
 
-async function renderRoute (event: H3Event, ssrError: (NuxtPayload['error'] & { url: string }) | null) {
+async function renderRoute (event: H3Event, ssrError?: (NuxtPayload['error'] & { url: string })): Promise<ReadableStream<Uint8Array> | Response | string | undefined> {
   // Initialize ssr context
   const ssrContext: NuxtSSRContext = createSSRContext(event)
 
@@ -136,7 +135,8 @@ async function renderRoute (event: H3Event, ssrError: (NuxtPayload['error'] & { 
     ssrContext.url = url
 
     if (import.meta.prerender && await payloadCache!.hasItem(url + '.json')) {
-      return returnResponse(event, await payloadCache!.getItem(url + '.json') as Partial<RenderResponse>)
+      event.res.headers.set('content-type', 'application/json')
+      return returnResponse(event, await payloadCache!.getItem(url + '.json') || undefined)
     }
   }
 
@@ -383,11 +383,11 @@ async function renderStreamedResponse (ctx: {
   ssrContext: NuxtSSRContext
   renderer: Awaited<ReturnType<typeof getRenderer>>
   routeOptions: ReturnType<typeof getRouteRules>['routeRules']
-  ssrError: (NuxtPayload['error'] & { url: string }) | null
+  ssrError?: (NuxtPayload['error'] & { url: string })
   _PAYLOAD_EXTRACTION: boolean
   _PAYLOAD_INLINE: boolean
   payloadURL: string | undefined
-}): Promise<ReadableStream<Uint8Array> | RenderResponse['body']> {
+}): Promise<ReadableStream<Uint8Array> | Response | string | undefined> {
   const { event, ssrContext, renderer, routeOptions, ssrError, _PAYLOAD_EXTRACTION, _PAYLOAD_INLINE, payloadURL } = ctx
   const NO_SCRIPTS = NUXT_NO_SCRIPTS || !!routeOptions?.noScripts
 
@@ -579,8 +579,9 @@ async function renderStreamedResponse (ctx: {
   } catch (error) {
     reader.releaseLock()
     event.res.headers.delete('link')
-    if (ssrContext['~renderResponse']) {
-      return returnResponse(event, ssrContext['~renderResponse'])
+    const response = ssrContext['~renderResponse'] as NuxtSSRContext['~renderResponse']
+    if (response) {
+      return returnResponse(event, response)
     }
     const _err = (!ssrError && ssrContext.payload?.error) || error
     const r = ssrContext.nuxt?.hooks.callHook('app:error', _err)
@@ -588,10 +589,11 @@ async function renderStreamedResponse (ctx: {
     throw _err
   }
 
-  if (ssrContext['~renderResponse']) {
+  const response = ssrContext['~renderResponse'] as NuxtSSRContext['~renderResponse']
+  if (response) {
     reader.cancel().catch(() => {})
     event.res.headers.delete('link')
-    return returnResponse(event, ssrContext['~renderResponse'])
+    return returnResponse(event, response)
   }
 
   if (ssrContext.payload?.error && !ssrError) {
@@ -886,7 +888,11 @@ function stripInlineOnlyPayloadFields (payload: NuxtSSRContext['payload']): Nuxt
   return rest
 }
 
-function returnResponse (event: H3Event, response: Partial<RenderResponse>) {
+function returnResponse (event: H3Event, response: NuxtSSRContext['~renderResponse']): string | undefined {
+  if (!response) {
+    return
+  }
+
   for (const header in response.headers || {}) {
     event.res.headers.set(header, response.headers![header]!)
   }

--- a/packages/nitro-server/src/runtime/utils/cache.ts
+++ b/packages/nitro-server/src/runtime/utils/cache.ts
@@ -1,6 +1,7 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
-import type { Storage, StorageValue } from 'unstorage'
+import type { Storage } from 'unstorage'
 import { useStorage } from 'nitro/storage'
+import type { RenderResponse } from 'nitro/types'
 // @ts-expect-error virtual file
 import { NUXT_RUNTIME_PAYLOAD_EXTRACTION, NUXT_SHARED_DATA } from '#internal/nuxt/nitro-config.mjs'
 
@@ -10,13 +11,11 @@ import { NUXT_RUNTIME_PAYLOAD_EXTRACTION, NUXT_SHARED_DATA } from '#internal/nux
  */
 export const prerenderRenderingURLs: AsyncLocalStorage<readonly string[]> | null = import.meta.prerender ? new AsyncLocalStorage() : null
 
-export const payloadCache: Storage | null = import.meta.prerender
-  ? useStorage<StorageValue>('internal:nuxt:prerender:payload')
+export const payloadCache: Storage<RenderResponse> | null = import.meta.prerender
+  ? useStorage<RenderResponse>('internal:nuxt:prerender:payload')
   : NUXT_RUNTIME_PAYLOAD_EXTRACTION
-    ? useStorage<StorageValue>('cache:nuxt:payload')
+    ? useStorage<RenderResponse>('cache:nuxt:payload')
     : null
-export const islandCache: Storage | null = import.meta.prerender ? useStorage<StorageValue>('internal:nuxt:prerender:island') : null
-export const islandPropCache: Storage | null = import.meta.prerender ? useStorage<StorageValue>('internal:nuxt:prerender:island-props') : null
 export const sharedPrerenderPromises: Map<string, Promise<any>> | null = import.meta.prerender && NUXT_SHARED_DATA ? new Map<string, Promise<any>>() : null
 
 const sharedPrerenderKeys = new Set<string>()

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -78,7 +78,7 @@ export interface NuxtSSRContext extends SSRContext {
   teleports?: Record<string, string>
   islandContext?: NuxtIslandContext
   /** @internal */
-  ['~renderResponse']?: Partial<RenderResponse>
+  ['~renderResponse']?: Partial<Omit<RenderResponse, 'body'>> & { body?: string }
   /** @internal */
   ['~payloadReducers']: Record<string, (data: any) => any>
   /** @internal */


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

an `any` from nitro's RenderResponse type was poisoning quite a lot of our type safety here. this fixes that and also tightens types for our island cache.