### PR TITLE
fix(vite): invalidate stale SSR virtual modules on render

### DIFF
--- a/packages/vite/src/plugins/vite-node.ts
+++ b/packages/vite/src/plugins/vite-node.ts
@@ -281,13 +281,43 @@ export function ViteNodePlugin (nuxt: Nuxt): VitePlugin | undefined {
 
         for (const [file, remaining] of pendingChangedFiles) {
           const mods = ssrModuleGraph.getModulesByFile(file)
-          if (mods?.size) {
-            for (const mod of mods) {
-              ssrModuleGraph.invalidateModule(mod)
+          if (!mods?.size) {
+            if (remaining <= 1) {
+              pendingChangedFiles.delete(file)
+            } else {
+              pendingChangedFiles.set(file, remaining - 1)
             }
-            markInvalidates(mods)
-            pendingChangedFiles.delete(file)
-          } else if (remaining <= 1) {
+            continue
+          }
+
+          // A `handleHotUpdate` hook reacting to this edit invalidates virtual
+          // modules only in the client graph (`server.moduleGraph`), so the SSR
+          // copy keeps serving a stale evaluation. Re-evaluate any virtual
+          // module the changed file imports. The SSR graph fills lazily, so the
+          // import may not exist yet on the first render; stay pending until it
+          // surfaces or the countdown runs out.
+          // See https://github.com/nuxt/nuxt/issues/30169.
+          let invalidatedVirtual = false
+          const seen = new Set<EnvironmentModuleNode>()
+          const invalidateVirtualImports = (mod: EnvironmentModuleNode) => {
+            for (const imported of mod.importedModules) {
+              if (seen.has(imported)) { continue }
+              seen.add(imported)
+              if (imported.id?.startsWith('\0')) {
+                ssrModuleGraph.invalidateModule(imported)
+                markInvalidate(imported)
+                invalidatedVirtual = true
+              }
+              invalidateVirtualImports(imported)
+            }
+          }
+          for (const mod of mods) {
+            invalidateVirtualImports(mod)
+            ssrModuleGraph.invalidateModule(mod)
+          }
+          markInvalidates(mods)
+
+          if (invalidatedVirtual || remaining <= 1) {
             pendingChangedFiles.delete(file)
           } else {
             pendingChangedFiles.set(file, remaining - 1)


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

another hmr fix - for virtual modules in the SSR environment, this time...