### PR TITLE
ci: only run benchmark tests in Nuxt org

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,7 +288,7 @@ jobs:
 
   test-benchmark:
     runs-on: ubuntu-latest
-    if: github.event_name != 'merge_group'
+    if: github.event_name != 'merge_group' && github.repository_owner == 'nuxt'
     needs:
       - build
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

Syncing my fork of Nuxt would trigger the CI. The 'Run Benchmarks' step keep failing due to me not having the `CODSPEED_TOKEN` set. 
https://github.com/nuxt/nuxt/blob/8cebb6e3c3f59542d6dc02e33ba82a09d49315ed/.github/workflows/ci.yml#L317

<img width="588" height="818" alt="Screenshot 2026-06-22 at 9 12 30 pm" src="https://github.com/user-attachments/assets/21f1e02e-3da1-4461-9e5b-81bf509d58c2" />

This PR skips the job if it's not in the Nuxt org, as in other jobs.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
