### PR TITLE
refactor(nitro): move to `fetch` handler in renderer

### DIFF
--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -97,7 +97,6 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
 
   if (nuxt.options.experimental.componentIslands) {
     const islandHandlerPath = JSON.stringify(resolve(distDir, 'runtime/handlers/island'))
-    const h3Path = JSON.stringify(resolve(distDir, 'h3'))
     const ISLAND_RENDERER_KEY = '#internal/nuxt/island-renderer.mjs'
 
     nuxt.options.nitro.virtual ||= {}
@@ -106,12 +105,8 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
       if (nuxt.options.dev || nuxt.options.experimental.componentIslands !== 'auto' || nuxt.apps.default?.pages?.some(p => p.mode === 'server') || nuxt.apps.default?.components?.some(c => c.mode === 'server' && !nuxt.apps.default?.components.some(other => other.pascalName === c.pascalName && other.mode === 'client'))) {
         return `export { default } from ${islandHandlerPath}`
       }
-      return `import { defineEventHandler } from ${h3Path}; export default defineEventHandler(() => {});`
+      return `export default { fetch: () => undefined }`
     }
-    nuxt.options.serverHandlers.push({
-      route: '/__nuxt_island/**',
-      handler: ISLAND_RENDERER_KEY,
-    })
 
     if (!nuxt.options.ssr && nuxt.options.experimental.componentIslands !== 'auto') {
       nuxt.options.ssr = true

--- a/packages/nitro-server/src/runtime/handlers/island.ts
+++ b/packages/nitro-server/src/runtime/handlers/island.ts
@@ -11,7 +11,7 @@ import type { NuxtIslandContext, NuxtIslandResponse } from 'nuxt/app'
 import { traceAsync } from '#app/internal/tracing'
 // @ts-expect-error virtual file
 import { tracingChannelNuxt } from '#internal/nuxt.config.mjs'
-import { createSSRContext, mergeHeaders, rethrowWithResponseHeaders } from '../utils/renderer/app'
+import { createSSRContext, mergeHeaders, rethrowWithResponseHeaders, returnRenderResponse } from '../utils/renderer/app'
 import { getSSRRenderer } from '../utils/renderer/build-files'
 import { renderInlineStyles } from '../utils/renderer/inline-styles'
 import { getClientIslandResponse, getServerComponentHTML, getSlotIslandResponse } from '../utils/renderer/islands'
@@ -63,14 +63,7 @@ export default {
       await ssrContext.nuxt?.hooks.callHook('app:rendered', { ssrContext, renderResult })
 
       if (ssrContext['~renderResponse']) {
-        const response = ssrContext['~renderResponse']
-        if (response.status && response.status >= 400) {
-          throw new HTTPError({
-            status: response.status,
-            statusText: response.statusText,
-          })
-        }
-        return returnIslandResponse(event, response)
+        return returnRenderResponse(event, ssrContext['~renderResponse'])
       }
 
       // Handle errors
@@ -136,15 +129,6 @@ export default {
       rethrowWithResponseHeaders(event, error)
     }
   },
-}
-
-function returnIslandResponse (event: H3Event, response: Response): Response {
-  const headers = mergeHeaders(new Headers(event.res.headers), response.headers)
-  return new FastResponse(response.body, {
-    status: response.status,
-    statusText: response.statusText,
-    headers,
-  })
 }
 
 const ISLAND_PATH_PREFIX = '/__nuxt_island/'

--- a/packages/nitro-server/src/runtime/handlers/island.ts
+++ b/packages/nitro-server/src/runtime/handlers/island.ts
@@ -7,7 +7,7 @@ import { VueResolver, walkResolver } from '@unhead/vue/utils'
 import { getRequestDependencies } from 'vue-bundle-renderer/runtime'
 import { getQuery as getURLQuery } from 'ufo'
 import { FastResponse } from 'srvx'
-import { computeIslandHash, filterIslandProps } from '#app/island-hash'
+import { computeIslandHash } from '#app/island-hash'
 import type { NuxtIslandContext, NuxtIslandResponse } from 'nuxt/app'
 import { traceAsync } from '#app/internal/tracing'
 // @ts-expect-error virtual file

--- a/packages/nitro-server/src/runtime/handlers/island.ts
+++ b/packages/nitro-server/src/runtime/handlers/island.ts
@@ -12,7 +12,7 @@ import type { NuxtIslandContext, NuxtIslandResponse } from 'nuxt/app'
 import { traceAsync } from '#app/internal/tracing'
 // @ts-expect-error virtual file
 import { tracingChannelNuxt } from '#internal/nuxt.config.mjs'
-import { createSSRContext } from '../utils/renderer/app'
+import { createSSRContext, rethrowWithResponseHeaders } from '../utils/renderer/app'
 import { getSSRRenderer } from '../utils/renderer/build-files'
 import { renderInlineStyles } from '../utils/renderer/inline-styles'
 import { getClientIslandResponse, getServerComponentHTML, getSlotIslandResponse } from '../utils/renderer/islands'
@@ -27,112 +27,115 @@ const ISLAND_SUFFIX_RE = /\.json(?:\?.*)?$/
 export default {
   async fetch (request: Request): Promise<Response> {
     const event = new H3Event(request)
+    try {
+      event.res.headers.set('content-type', 'application/json;charset=utf-8')
+      event.res.headers.set('x-powered-by', 'Nuxt')
 
-    event.res.headers.set('content-type', 'application/json;charset=utf-8')
-    event.res.headers.set('x-powered-by', 'Nuxt')
-
-    const islandPath = event.url.pathname
-    if (import.meta.prerender && await islandCache!.hasItem(islandPath)) {
-      return new FastResponse(JSON.stringify(await islandCache!.getItem(islandPath)), event.res)
-    }
-
-    const islandContext = await getIslandContext(event)
-
-    const ssrContext = {
-      ...createSSRContext(event),
-      islandContext,
-      noSSR: false,
-      url: islandContext.url,
-    }
-
-    // Render app
-    const renderer = await getSSRRenderer()
-
-    const renderResult = await (tracingChannelNuxt
-      ? traceAsync('nuxt.island', { event, ssrContext, islandContext }, () => renderer.renderToString(ssrContext))
-      : renderer.renderToString(ssrContext)
-    ).catch(async (err) => {
-      if (ssrContext['~renderResponse'] && (err as Error)?.message === 'skipping render') {
-        return {} as Awaited<ReturnType<typeof renderer.renderToString>>
+      const islandPath = event.url.pathname
+      if (import.meta.prerender && await islandCache!.hasItem(islandPath)) {
+        return new FastResponse(JSON.stringify(await islandCache!.getItem(islandPath)), event.res)
       }
-      await ssrContext.nuxt?.hooks.callHook('app:error', err)
-      throw err
-    })
 
-    // Fire `app:rendered` before checking `~renderResponse` (matches `renderer.ts`), so
-    // anything hooking into it, like `useCookie`, will still work on redirect/reject.
-    await ssrContext.nuxt?.hooks.callHook('app:rendered', { ssrContext, renderResult })
+      const islandContext = await getIslandContext(event)
 
-    if (ssrContext['~renderResponse']) {
-      const response = ssrContext['~renderResponse']
-      if (response.status && response.status >= 400) {
-        throw new HTTPError({
-          status: response.status,
-          statusText: response.statusText,
-        })
+      const ssrContext = {
+        ...createSSRContext(event),
+        islandContext,
+        noSSR: false,
+        url: islandContext.url,
       }
-      return returnIslandResponse(event, response)
-    }
 
-    // Handle errors
-    if (ssrContext.payload?.error) {
-      throw ssrContext.payload.error
-    }
+      // Render app
+      const renderer = await getSSRRenderer()
 
-    const inlinedStyles = await renderInlineStyles(ssrContext.modules ?? [])
-
-    if (inlinedStyles.length) {
-      ssrContext.head.push({ style: inlinedStyles })
-    }
-
-    if (import.meta.dev) {
-      const { styles } = getRequestDependencies(ssrContext, renderer.rendererContext)
-
-      const link: Link[] = []
-      for (const resource of Object.values(styles)) {
-        // Do not add links to resources that are inlined (vite v5+)
-        if ('inline' in getURLQuery(resource.file)) {
-          continue
+      const renderResult = await (tracingChannelNuxt
+        ? traceAsync('nuxt.island', { event, ssrContext, islandContext }, () => renderer.renderToString(ssrContext))
+        : renderer.renderToString(ssrContext)
+      ).catch(async (err) => {
+        if (ssrContext['~renderResponse'] && (err as Error)?.message === 'skipping render') {
+          return {} as Awaited<ReturnType<typeof renderer.renderToString>>
         }
-        // Add CSS links in <head> for CSS files
-        // - in dev mode when rendering an island and the file has scoped styles and is not a page
-        if (resource.file.includes('scoped') && !resource.file.includes('pages/')) {
-          link.push({ rel: 'stylesheet', href: renderer.rendererContext.buildAssetsURL(resource.file), crossorigin: '' })
-        }
-      }
-      if (link.length) {
-        ssrContext.head.push({ link })
-      }
-    }
+        await ssrContext.nuxt?.hooks.callHook('app:error', err)
+        throw err
+      })
 
-    const islandHead: SerializableHead = {}
-    for (const entry of ssrContext.head.entries.values()) {
-      for (const [key, value] of Object.entries(walkResolver(entry.input, VueResolver) as SerializableHead)) {
-        const currentValue = islandHead[key as keyof SerializableHead]
-        if (Array.isArray(currentValue)) {
-          currentValue.push(...value)
-        } else {
-          islandHead[key as keyof SerializableHead] = value
+      // Fire `app:rendered` before checking `~renderResponse` (matches `renderer.ts`), so
+      // anything hooking into it, like `useCookie`, will still work on redirect/reject.
+      await ssrContext.nuxt?.hooks.callHook('app:rendered', { ssrContext, renderResult })
+
+      if (ssrContext['~renderResponse']) {
+        const response = ssrContext['~renderResponse']
+        if (response.status && response.status >= 400) {
+          throw new HTTPError({
+            status: response.status,
+            statusText: response.statusText,
+          })
+        }
+        return returnIslandResponse(event, response)
+      }
+
+      // Handle errors
+      if (ssrContext.payload?.error) {
+        throw ssrContext.payload.error
+      }
+
+      const inlinedStyles = await renderInlineStyles(ssrContext.modules ?? [])
+
+      if (inlinedStyles.length) {
+        ssrContext.head.push({ style: inlinedStyles })
+      }
+
+      if (import.meta.dev) {
+        const { styles } = getRequestDependencies(ssrContext, renderer.rendererContext)
+
+        const link: Link[] = []
+        for (const resource of Object.values(styles)) {
+          // Do not add links to resources that are inlined (vite v5+)
+          if ('inline' in getURLQuery(resource.file)) {
+            continue
+          }
+          // Add CSS links in <head> for CSS files
+          // - in dev mode when rendering an island and the file has scoped styles and is not a page
+          if (resource.file.includes('scoped') && !resource.file.includes('pages/')) {
+            link.push({ rel: 'stylesheet', href: renderer.rendererContext.buildAssetsURL(resource.file), crossorigin: '' })
+          }
+        }
+        if (link.length) {
+          ssrContext.head.push({ link })
         }
       }
-    }
 
-    const islandResponse: NuxtIslandResponse = {
-      id: islandContext.id,
-      head: islandHead,
-      html: getServerComponentHTML(renderResult.html),
-      components: getClientIslandResponse(ssrContext),
-      slots: getSlotIslandResponse(ssrContext),
-    }
+      const islandHead: SerializableHead = {}
+      for (const entry of ssrContext.head.entries.values()) {
+        for (const [key, value] of Object.entries(walkResolver(entry.input, VueResolver) as SerializableHead)) {
+          const currentValue = islandHead[key as keyof SerializableHead]
+          if (Array.isArray(currentValue)) {
+            currentValue.push(...value)
+          } else {
+            islandHead[key as keyof SerializableHead] = value
+          }
+        }
+      }
 
-    await useNitroHooks().callHook('render:island', islandResponse, { event, islandContext })
+      const islandResponse: NuxtIslandResponse = {
+        id: islandContext.id,
+        head: islandHead,
+        html: getServerComponentHTML(renderResult.html),
+        components: getClientIslandResponse(ssrContext),
+        slots: getSlotIslandResponse(ssrContext),
+      }
 
-    if (import.meta.prerender) {
-      const requestUrl = islandPath + event.url.search + event.url.hash
-      await islandCache!.setItem(islandPath, islandResponse)
-      await islandPropCache!.setItem(islandPath, requestUrl)
+      await useNitroHooks().callHook('render:island', islandResponse, { event, islandContext })
+
+      if (import.meta.prerender) {
+        const requestUrl = islandPath + event.url.search + event.url.hash
+        await islandCache!.setItem(islandPath, islandResponse)
+        await islandPropCache!.setItem(islandPath, requestUrl)
+      }
+      return new FastResponse(JSON.stringify(islandResponse), event.res)
+    } catch (error) {
+      rethrowWithResponseHeaders(event, error)
     }
-    return new FastResponse(JSON.stringify(islandResponse), event.res)
   },
 }
 

--- a/packages/nitro-server/src/runtime/handlers/island.ts
+++ b/packages/nitro-server/src/runtime/handlers/island.ts
@@ -2,12 +2,12 @@ import { useNitroHooks } from 'nitro/app'
 import type { RenderResponse } from 'nitro/types'
 import type { Link, SerializableHead } from '@unhead/vue/types'
 import { destr } from 'destr'
-import type { H3Event } from 'nitro/h3'
-import { HTTPError, defineEventHandler, getQuery, readBody } from 'nitro/h3'
+import { H3Event, HTTPError, getQuery, readBody } from 'nitro/h3'
 import { VueResolver, walkResolver } from '@unhead/vue/utils'
 import { getRequestDependencies } from 'vue-bundle-renderer/runtime'
 import { getQuery as getURLQuery } from 'ufo'
-import { computeIslandHash } from '#app/island-hash'
+import { FastResponse } from 'srvx'
+import { computeIslandHash, filterIslandProps } from '#app/island-hash'
 import type { NuxtIslandContext, NuxtIslandResponse } from 'nuxt/app'
 import { traceAsync } from '#app/internal/tracing'
 // @ts-expect-error virtual file
@@ -19,124 +19,124 @@ import { getClientIslandResponse, getServerComponentHTML, getSlotIslandResponse 
 import { useStorage } from 'nitro/storage'
 import type { Storage } from 'unstorage'
 
-export const islandCache: Storage<string> | null = import.meta.prerender ? useStorage<string>('internal:nuxt:prerender:island') : null
+export const islandCache: Storage<NuxtIslandResponse> | null = import.meta.prerender ? useStorage<NuxtIslandResponse>('internal:nuxt:prerender:island') : null
 export const islandPropCache: Storage<string> | null = import.meta.prerender ? useStorage<string>('internal:nuxt:prerender:island-props') : null
 
 const ISLAND_SUFFIX_RE = /\.json(?:\?.*)?$/
 
-const handler: ReturnType<typeof defineEventHandler> = defineEventHandler(async (event) => {
-  event.res.headers.set('content-type', 'application/json;charset=utf-8')
-  event.res.headers.set('x-powered-by', 'Nuxt')
+export default {
+  async fetch (request: Request): Promise<Response> {
+    const event = new H3Event(request)
 
-  const islandPath = event.url.pathname
-  if (import.meta.prerender && await islandCache!.hasItem(islandPath)) {
-    return await islandCache!.getItem(islandPath) || undefined
-  }
+    event.res.headers.set('content-type', 'application/json;charset=utf-8')
+    event.res.headers.set('x-powered-by', 'Nuxt')
 
-  const islandContext = await getIslandContext(event)
-
-  const ssrContext = {
-    ...createSSRContext(event),
-    islandContext,
-    noSSR: false,
-    url: islandContext.url,
-  }
-
-  // Render app
-  const renderer = await getSSRRenderer()
-
-  const renderResult = await (tracingChannelNuxt
-    ? traceAsync('nuxt.island', { event, ssrContext, islandContext }, () => renderer.renderToString(ssrContext))
-    : renderer.renderToString(ssrContext)
-  ).catch(async (err) => {
-    if (ssrContext['~renderResponse'] && (err as Error)?.message === 'skipping render') {
-      return {} as Awaited<ReturnType<typeof renderer.renderToString>>
+    const islandPath = event.url.pathname
+    if (import.meta.prerender && await islandCache!.hasItem(islandPath)) {
+      return new FastResponse(JSON.stringify(await islandCache!.getItem(islandPath)), event.res)
     }
-    await ssrContext.nuxt?.hooks.callHook('app:error', err)
-    throw err
-  })
 
-  // Fire `app:rendered` before checking `~renderResponse` (matches `renderer.ts`), so
-  // anything hooking into it, like `useCookie`, will still work on redirect/reject.
-  await ssrContext.nuxt?.hooks.callHook('app:rendered', { ssrContext, renderResult })
+    const islandContext = await getIslandContext(event)
 
-  if (ssrContext['~renderResponse']) {
-    const response = ssrContext['~renderResponse']
-    if (response.status && response.status >= 400) {
-      throw new HTTPError({
-        status: response.status,
-        statusText: response.statusText,
-      })
+    const ssrContext = {
+      ...createSSRContext(event),
+      islandContext,
+      noSSR: false,
+      url: islandContext.url,
     }
-    return returnIslandResponse(event, response)
-  }
 
-  // Handle errors
-  if (ssrContext.payload?.error) {
-    throw ssrContext.payload.error
-  }
+    // Render app
+    const renderer = await getSSRRenderer()
 
-  const inlinedStyles = await renderInlineStyles(ssrContext.modules ?? [])
-
-  if (inlinedStyles.length) {
-    ssrContext.head.push({ style: inlinedStyles })
-  }
-
-  if (import.meta.dev) {
-    const { styles } = getRequestDependencies(ssrContext, renderer.rendererContext)
-
-    const link: Link[] = []
-    for (const resource of Object.values(styles)) {
-      // Do not add links to resources that are inlined (vite v5+)
-      if ('inline' in getURLQuery(resource.file)) {
-        continue
+    const renderResult = await (tracingChannelNuxt
+      ? traceAsync('nuxt.island', { event, ssrContext, islandContext }, () => renderer.renderToString(ssrContext))
+      : renderer.renderToString(ssrContext)
+    ).catch(async (err) => {
+      if (ssrContext['~renderResponse'] && (err as Error)?.message === 'skipping render') {
+        return {} as Awaited<ReturnType<typeof renderer.renderToString>>
       }
-      // Add CSS links in <head> for CSS files
-      // - in dev mode when rendering an island and the file has scoped styles and is not a page
-      if (resource.file.includes('scoped') && !resource.file.includes('pages/')) {
-        link.push({ rel: 'stylesheet', href: renderer.rendererContext.buildAssetsURL(resource.file), crossorigin: '' })
-      }
-    }
-    if (link.length) {
-      ssrContext.head.push({ link })
-    }
-  }
+      await ssrContext.nuxt?.hooks.callHook('app:error', err)
+      throw err
+    })
 
-  const islandHead: SerializableHead = {}
-  for (const entry of ssrContext.head.entries.values()) {
-    for (const [key, value] of Object.entries(walkResolver(entry.input, VueResolver) as SerializableHead)) {
-      const currentValue = islandHead[key as keyof SerializableHead]
-      if (Array.isArray(currentValue)) {
-        currentValue.push(...value)
-      } else {
-        islandHead[key as keyof SerializableHead] = value
+    // Fire `app:rendered` before checking `~renderResponse` (matches `renderer.ts`), so
+    // anything hooking into it, like `useCookie`, will still work on redirect/reject.
+    await ssrContext.nuxt?.hooks.callHook('app:rendered', { ssrContext, renderResult })
+
+    if (ssrContext['~renderResponse']) {
+      const response = ssrContext['~renderResponse']
+      if (response.status && response.status >= 400) {
+        throw new HTTPError({
+          status: response.status,
+          statusText: response.statusText,
+        })
+      }
+      return returnIslandResponse(event, response)
+    }
+
+    // Handle errors
+    if (ssrContext.payload?.error) {
+      throw ssrContext.payload.error
+    }
+
+    const inlinedStyles = await renderInlineStyles(ssrContext.modules ?? [])
+
+    if (inlinedStyles.length) {
+      ssrContext.head.push({ style: inlinedStyles })
+    }
+
+    if (import.meta.dev) {
+      const { styles } = getRequestDependencies(ssrContext, renderer.rendererContext)
+
+      const link: Link[] = []
+      for (const resource of Object.values(styles)) {
+        // Do not add links to resources that are inlined (vite v5+)
+        if ('inline' in getURLQuery(resource.file)) {
+          continue
+        }
+        // Add CSS links in <head> for CSS files
+        // - in dev mode when rendering an island and the file has scoped styles and is not a page
+        if (resource.file.includes('scoped') && !resource.file.includes('pages/')) {
+          link.push({ rel: 'stylesheet', href: renderer.rendererContext.buildAssetsURL(resource.file), crossorigin: '' })
+        }
+      }
+      if (link.length) {
+        ssrContext.head.push({ link })
       }
     }
-  }
 
-  const islandResponse: NuxtIslandResponse = {
-    id: islandContext.id,
-    head: islandHead,
-    html: getServerComponentHTML(renderResult.html),
-    components: getClientIslandResponse(ssrContext),
-    slots: getSlotIslandResponse(ssrContext),
-  }
+    const islandHead: SerializableHead = {}
+    for (const entry of ssrContext.head.entries.values()) {
+      for (const [key, value] of Object.entries(walkResolver(entry.input, VueResolver) as SerializableHead)) {
+        const currentValue = islandHead[key as keyof SerializableHead]
+        if (Array.isArray(currentValue)) {
+          currentValue.push(...value)
+        } else {
+          islandHead[key as keyof SerializableHead] = value
+        }
+      }
+    }
 
-  await useNitroHooks().callHook('render:island', islandResponse, { event, islandContext })
+    const islandResponse: NuxtIslandResponse = {
+      id: islandContext.id,
+      head: islandHead,
+      html: getServerComponentHTML(renderResult.html),
+      components: getClientIslandResponse(ssrContext),
+      slots: getSlotIslandResponse(ssrContext),
+    }
 
-  const islandResponseString = JSON.stringify(islandResponse)
+    await useNitroHooks().callHook('render:island', islandResponse, { event, islandContext })
 
-  if (import.meta.prerender) {
-    const requestUrl = islandPath + event.url.search + event.url.hash
-    await islandCache!.setItem(islandPath, islandResponseString)
-    await islandPropCache!.setItem(islandPath, requestUrl)
-  }
-  return islandResponseString
-})
+    if (import.meta.prerender) {
+      const requestUrl = islandPath + event.url.search + event.url.hash
+      await islandCache!.setItem(islandPath, islandResponse)
+      await islandPropCache!.setItem(islandPath, requestUrl)
+    }
+    return new FastResponse(JSON.stringify(islandResponse), event.res)
+  },
+}
 
-export default handler
-
-function returnIslandResponse (event: H3Event, response: Partial<RenderResponse>): string | undefined {
+function returnIslandResponse (event: H3Event, response: Partial<RenderResponse>): Response {
   for (const header in response.headers || {}) {
     event.res.headers.set(header, response.headers![header]!)
   }
@@ -146,7 +146,7 @@ function returnIslandResponse (event: H3Event, response: Partial<RenderResponse>
   if (response.statusText) {
     event.res.statusText = response.statusText
   }
-  return response.body
+  return new FastResponse(response.body, event.res)
 }
 
 const ISLAND_PATH_PREFIX = '/__nuxt_island/'

--- a/packages/nitro-server/src/runtime/handlers/island.ts
+++ b/packages/nitro-server/src/runtime/handlers/island.ts
@@ -11,7 +11,7 @@ import type { NuxtIslandContext, NuxtIslandResponse } from 'nuxt/app'
 import { traceAsync } from '#app/internal/tracing'
 // @ts-expect-error virtual file
 import { tracingChannelNuxt } from '#internal/nuxt.config.mjs'
-import { createSSRContext, rethrowWithResponseHeaders } from '../utils/renderer/app'
+import { createSSRContext, mergeHeaders, rethrowWithResponseHeaders } from '../utils/renderer/app'
 import { getSSRRenderer } from '../utils/renderer/build-files'
 import { renderInlineStyles } from '../utils/renderer/inline-styles'
 import { getClientIslandResponse, getServerComponentHTML, getSlotIslandResponse } from '../utils/renderer/islands'
@@ -139,14 +139,7 @@ export default {
 }
 
 function returnIslandResponse (event: H3Event, response: Response): Response {
-  const headers = new Headers(event.res.headers)
-  for (const [name, value] of response.headers) {
-    if (name === 'set-cookie') { continue }
-    headers.set(name, value)
-  }
-  for (const cookie of response.headers.getSetCookie()) {
-    headers.append('set-cookie', cookie)
-  }
+  const headers = mergeHeaders(new Headers(event.res.headers), response.headers)
   return new FastResponse(response.body, {
     status: response.status,
     statusText: response.statusText,

--- a/packages/nitro-server/src/runtime/handlers/island.ts
+++ b/packages/nitro-server/src/runtime/handlers/island.ts
@@ -11,7 +11,7 @@ import type { NuxtIslandContext, NuxtIslandResponse } from 'nuxt/app'
 import { traceAsync } from '#app/internal/tracing'
 // @ts-expect-error virtual file
 import { tracingChannelNuxt } from '#internal/nuxt.config.mjs'
-import { createSSRContext, mergeHeaders, rethrowWithResponseHeaders, returnRenderResponse } from '../utils/renderer/app'
+import { createSSRContext, rethrowWithResponseHeaders, returnRenderResponse } from '../utils/renderer/app'
 import { getSSRRenderer } from '../utils/renderer/build-files'
 import { renderInlineStyles } from '../utils/renderer/inline-styles'
 import { getClientIslandResponse, getServerComponentHTML, getSlotIslandResponse } from '../utils/renderer/islands'

--- a/packages/nitro-server/src/runtime/handlers/island.ts
+++ b/packages/nitro-server/src/runtime/handlers/island.ts
@@ -1,5 +1,4 @@
 import { useNitroHooks } from 'nitro/app'
-import type { RenderResponse } from 'nitro/types'
 import type { Link, SerializableHead } from '@unhead/vue/types'
 import { destr } from 'destr'
 import { H3Event, HTTPError, getQuery, readBody } from 'nitro/h3'
@@ -139,17 +138,20 @@ export default {
   },
 }
 
-function returnIslandResponse (event: H3Event, response: Partial<RenderResponse>): Response {
-  for (const header in response.headers || {}) {
-    event.res.headers.set(header, response.headers![header]!)
+function returnIslandResponse (event: H3Event, response: Response): Response {
+  const headers = new Headers(event.res.headers)
+  for (const [name, value] of response.headers) {
+    if (name === 'set-cookie') { continue }
+    headers.set(name, value)
   }
-  if (response.status) {
-    event.res.status = response.status
+  for (const cookie of response.headers.getSetCookie()) {
+    headers.append('set-cookie', cookie)
   }
-  if (response.statusText) {
-    event.res.statusText = response.statusText
-  }
-  return new FastResponse(response.body, event.res)
+  return new FastResponse(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  })
 }
 
 const ISLAND_PATH_PREFIX = '/__nuxt_island/'

--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -823,7 +823,7 @@ async function renderStreamedResponse (ctx: {
   event.res.headers.set('content-type', 'text/html;charset=utf-8')
   event.res.headers.set('x-powered-by', 'Nuxt')
 
-  return outputStream
+  return new FastResponse(outputStream, event.res)
 }
 
 function normalizeChunks (chunks: (string | undefined)[]) {

--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -226,7 +226,7 @@ async function renderRoute (event: H3Event, ssrError?: (NuxtPayload['error'] & {
   if (appRenderedResult instanceof Promise) { await appRenderedResult }
 
   if (ssrContext['~renderResponse']) {
-    return new FastResponse(ssrContext['~renderResponse'].body, ssrContext['~renderResponse'])
+    return ssrContext['~renderResponse']
   }
 
   // Handle errors
@@ -503,7 +503,7 @@ async function renderStreamedResponse (ctx: {
       // Drop any preload `Link` header that targeted the streamed entry - the
       // redirect/response we are about to send does not need them.
       event.res.headers.delete('link')
-      return new FastResponse(ssrContext['~renderResponse'].body, ssrContext['~renderResponse'])
+      return ssrContext['~renderResponse']
     }
     const r = ssrContext.nuxt?.hooks.callHook('app:error', error)
     if (r instanceof Promise) { await r }
@@ -511,7 +511,7 @@ async function renderStreamedResponse (ctx: {
   }
   if (ssrContext['~renderResponse']) {
     event.res.headers.delete('link')
-    return new FastResponse(ssrContext['~renderResponse'].body, ssrContext['~renderResponse'])
+    return ssrContext['~renderResponse']
   }
 
   // 5. Render the shell head (atomically renders and clears entries pushed
@@ -590,7 +590,7 @@ async function renderStreamedResponse (ctx: {
     event.res.headers.delete('link')
     const response = ssrContext['~renderResponse'] as NuxtSSRContext['~renderResponse']
     if (response) {
-      return new FastResponse(response.body, response)
+      return response
     }
     const _err = (!ssrError && ssrContext.payload?.error) || error
     const r = ssrContext.nuxt?.hooks.callHook('app:error', _err)
@@ -602,7 +602,7 @@ async function renderStreamedResponse (ctx: {
   if (response) {
     reader.cancel().catch(() => {})
     event.res.headers.delete('link')
-    return new FastResponse(response.body, response)
+    return response
   }
 
   if (ssrContext.payload?.error && !ssrError) {

--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -1,8 +1,9 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
 import { getPrefetchLinks, getPreloadLinks, getRequestDependencies, renderResourceHeaders } from 'vue-bundle-renderer/runtime'
 import { renderToWebStream } from 'vue/server-renderer'
-import type { H3Event } from 'nitro/h3'
-import { HTTPError, defineEventHandler, getQuery, writeEarlyHints } from 'nitro/h3'
+import type { ServerRequest } from 'nitro/types'
+import { H3Event, HTTPError, getQuery, writeEarlyHints } from 'nitro/h3'
+import { FastResponse } from 'srvx'
 import { getQuery as getURLQuery, joinURL } from 'ufo'
 import { propsToString, renderSSRHead } from '@unhead/vue/server'
 import type { SSRHeadPayload } from '@unhead/vue/server'
@@ -52,7 +53,7 @@ const HAS_APP_TELEPORTS = !!(appTeleportTag && appTeleportAttrs.id)
 const APP_TELEPORT_OPEN_TAG = HAS_APP_TELEPORTS ? `<${appTeleportTag}${propsToString(appTeleportAttrs)}>` : ''
 const APP_TELEPORT_CLOSE_TAG = HAS_APP_TELEPORTS ? `</${appTeleportTag}>` : ''
 
-const PAYLOAD_URL_RE = /^[^?]*\/_payload.json(?:\?.*)?$/
+export const PAYLOAD_URL_RE = /^[^?]*\/_payload.json(?:\?.*)?$/
 const PAYLOAD_FILENAME = '_payload.json'
 
 let entryPath: string
@@ -60,40 +61,59 @@ let entryPath: string
 // Bot detection regex for SSR streaming.
 const SSR_BOT_RE: RegExp = NUXT_SSR_STREAMING_BOT_RE
 
-const handler: ReturnType<typeof defineEventHandler> = defineEventHandler((event) => {
-  // Whether we're rendering an error page
-  const ssrError = event.url.pathname.startsWith('/__nuxt_error')
-    ? getQuery<NuxtPayload['error'] & { url: string }>(event)
-    : undefined
+export default {
+  fetch (request: ServerRequest) {
+    const event = new H3Event(request)
 
-  if (ssrError && !event.context.nuxt?.['~rendering-error'] /* allow internal fetch from the error handler */) {
-    throw new HTTPError({
-      status: 404,
-      statusText: 'Page Not Found: /__nuxt_error',
-    })
-  }
+    // Whether we're rendering an error page
+    const ssrError = event.url.pathname.startsWith('/__nuxt_error')
+      ? getQuery<NuxtPayload['error'] & { url: string }>(event)
+      : undefined
 
-  // During prerender, refuse to recurse into a URL that is already rendering
-  // higher in the same call chain. Without this, a `useFetch`/`$fetch` against
-  // the in-flight URL (typically from route middleware) silently deadlocks the
-  // build. See https://github.com/nuxt/nuxt/issues/33871.
-  if (import.meta.prerender && prerenderRenderingURLs) {
-    const renderingURL = event.url.pathname + event.url.search
-    const stack = prerenderRenderingURLs.getStore()
-    if (stack?.includes(renderingURL)) {
-      const chain = [...stack, renderingURL].filter(url => !url.startsWith('/__nuxt_error')).map(url => `"${url}"`).join(' -> ')
+    if (ssrError && !event.context.nuxt?.['~rendering-error'] /* allow internal fetch from the error handler */) {
       throw new HTTPError({
-        status: 508,
-        statusText: `Loop detected while prerendering "${renderingURL}" (${chain}). Check for \`useFetch\`/\`$fetch\` calls targeting a URL that is currently being rendered.`,
+        status: 404,
+        statusText: 'Page Not Found: /__nuxt_error',
       })
     }
-    return prerenderRenderingURLs.run([...(stack || []), renderingURL], () => renderRoute(event, ssrError))
+
+    // During prerender, refuse to recurse into a URL that is already rendering
+    // higher in the same call chain. Without this, a `useFetch`/`$fetch` against
+    // the in-flight URL (typically from route middleware) silently deadlocks the
+    // build. See https://github.com/nuxt/nuxt/issues/33871.
+    if (import.meta.prerender && prerenderRenderingURLs) {
+      const renderingURL = event.url.pathname + event.url.search
+      const stack = prerenderRenderingURLs.getStore()
+      if (stack?.includes(renderingURL)) {
+        const chain = [...stack, renderingURL].filter(url => !url.startsWith('/__nuxt_error')).map(url => `"${url}"`).join(' -> ')
+        throw new HTTPError({
+          status: 508,
+          statusText: `Loop detected while prerendering "${renderingURL}" (${chain}). Check for \`useFetch\`/\`$fetch\` calls targeting a URL that is currently being rendered.`,
+        })
+      }
+      return prerenderRenderingURLs.run([...(stack || []), renderingURL], () => renderRoute(event, ssrError)).catch(error => rethrowWithResponseHeaders(event, error))
+    }
+
+    return renderRoute(event, ssrError).catch(error => rethrowWithResponseHeaders(event, error))
+  },
+}
+
+// The renderer mints its own `H3Event`, so response headers set during render
+// (e.g. `Set-Cookie` from `useCookie`) live on this event rather than the one
+// Nitro's error handler inspects. When the render throws, forward them onto the
+// error so the error response still carries them.
+function rethrowWithResponseHeaders (event: H3Event, error: any): never {
+  const setCookies = event.res.headers.getSetCookie()
+  if (!setCookies.length) { throw error }
+  const headers = error.headers instanceof Headers ? error.headers : new Headers(error.headers)
+  for (const cookie of setCookies) {
+    headers.append('set-cookie', cookie)
   }
+  error.headers = headers
+  throw error
+}
 
-  return renderRoute(event, ssrError)
-})
-
-async function renderRoute (event: H3Event, ssrError?: (NuxtPayload['error'] & { url: string })): Promise<ReadableStream<Uint8Array> | Response | string | undefined> {
+async function renderRoute (event: H3Event, ssrError?: (NuxtPayload['error'] & { url: string })): Promise<ReadableStream<Uint8Array> | Response> {
   // Initialize ssr context
   const ssrContext: NuxtSSRContext = createSSRContext(event)
 
@@ -136,7 +156,8 @@ async function renderRoute (event: H3Event, ssrError?: (NuxtPayload['error'] & {
 
     if (import.meta.prerender && await payloadCache!.hasItem(url + '.json')) {
       event.res.headers.set('content-type', 'application/json')
-      return returnResponse(event, await payloadCache!.getItem(url + '.json') || undefined)
+      const response = await payloadCache!.getItem(url + '.json') || undefined
+      return new FastResponse(response?.body, response)
     }
   }
 
@@ -215,7 +236,7 @@ async function renderRoute (event: H3Event, ssrError?: (NuxtPayload['error'] & {
   if (appRenderedResult instanceof Promise) { await appRenderedResult }
 
   if (ssrContext['~renderResponse']) {
-    return returnResponse(event, ssrContext['~renderResponse'])
+    return new FastResponse(ssrContext['~renderResponse'].body, ssrContext['~renderResponse'])
   }
 
   // Handle errors
@@ -230,7 +251,7 @@ async function renderRoute (event: H3Event, ssrError?: (NuxtPayload['error'] & {
       await payloadCache!.setItem(ssrContext.url + '.json', response)
     }
 
-    return returnResponse(event, response)
+    return new FastResponse(response.body, response)
   }
 
   if (_PAYLOAD_EXTRACTION && import.meta.prerender) {
@@ -373,10 +394,8 @@ async function renderRoute (event: H3Event, ssrError?: (NuxtPayload['error'] & {
   event.res.headers.set('content-type', 'text/html;charset=utf-8')
   event.res.headers.set('x-powered-by', 'Nuxt')
 
-  return renderHTMLDocument(htmlContext)
+  return new FastResponse(renderHTMLDocument(htmlContext), event.res)
 }
-
-export default handler
 
 async function renderStreamedResponse (ctx: {
   event: H3Event
@@ -387,7 +406,7 @@ async function renderStreamedResponse (ctx: {
   _PAYLOAD_EXTRACTION: boolean
   _PAYLOAD_INLINE: boolean
   payloadURL: string | undefined
-}): Promise<ReadableStream<Uint8Array> | Response | string | undefined> {
+}): Promise<ReadableStream<Uint8Array> | Response> {
   const { event, ssrContext, renderer, routeOptions, ssrError, _PAYLOAD_EXTRACTION, _PAYLOAD_INLINE, payloadURL } = ctx
   const NO_SCRIPTS = NUXT_NO_SCRIPTS || !!routeOptions?.noScripts
 
@@ -494,7 +513,7 @@ async function renderStreamedResponse (ctx: {
       // Drop any preload `Link` header that targeted the streamed entry - the
       // redirect/response we are about to send does not need them.
       event.res.headers.delete('link')
-      return returnResponse(event, ssrContext['~renderResponse'])
+      return new FastResponse(ssrContext['~renderResponse'].body, ssrContext['~renderResponse'])
     }
     const r = ssrContext.nuxt?.hooks.callHook('app:error', error)
     if (r instanceof Promise) { await r }
@@ -502,7 +521,7 @@ async function renderStreamedResponse (ctx: {
   }
   if (ssrContext['~renderResponse']) {
     event.res.headers.delete('link')
-    return returnResponse(event, ssrContext['~renderResponse'])
+    return new FastResponse(ssrContext['~renderResponse'].body, ssrContext['~renderResponse'])
   }
 
   // 5. Render the shell head (atomically renders and clears entries pushed
@@ -581,7 +600,7 @@ async function renderStreamedResponse (ctx: {
     event.res.headers.delete('link')
     const response = ssrContext['~renderResponse'] as NuxtSSRContext['~renderResponse']
     if (response) {
-      return returnResponse(event, response)
+      return new FastResponse(response.body, response)
     }
     const _err = (!ssrError && ssrContext.payload?.error) || error
     const r = ssrContext.nuxt?.hooks.callHook('app:error', _err)
@@ -593,7 +612,7 @@ async function renderStreamedResponse (ctx: {
   if (response) {
     reader.cancel().catch(() => {})
     event.res.headers.delete('link')
-    return returnResponse(event, response)
+    return new FastResponse(response.body, response)
   }
 
   if (ssrContext.payload?.error && !ssrError) {
@@ -886,22 +905,4 @@ function stripInlineOnlyPayloadFields (payload: NuxtSSRContext['payload']): Nuxt
   if (!payload.prefetchLinks) { return payload }
   const { prefetchLinks: _, ...rest } = payload
   return rest
-}
-
-function returnResponse (event: H3Event, response: NuxtSSRContext['~renderResponse']): string | undefined {
-  if (!response) {
-    return
-  }
-
-  for (const header in response.headers || {}) {
-    event.res.headers.set(header, response.headers![header]!)
-  }
-  if (response.status) {
-    event.res.status = response.status
-  }
-  if (response.statusText) {
-    event.res.statusText = response.statusText
-  }
-
-  return response.body
 }

--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -21,7 +21,7 @@ import { APP_ROOT_CLOSE_TAG, APP_ROOT_OPEN_TAG, getRenderer, getServerApp } from
 import { payloadCache, prerenderRenderingURLs } from '../utils/cache'
 
 import { renderPayloadJsonScript, renderPayloadResponse, splitPayload } from '../utils/renderer/payload'
-import { createSSRContext, rethrowWithResponseHeaders, setSSRError } from '../utils/renderer/app'
+import { createSSRContext, rethrowWithResponseHeaders, returnRenderResponse, setSSRError } from '../utils/renderer/app'
 import { renderInlineStyles } from '../utils/renderer/inline-styles'
 import { renderStreamedIslandTeleports, replaceIslandTeleports } from '../utils/renderer/islands'
 // @ts-expect-error virtual file
@@ -226,7 +226,7 @@ async function renderRoute (event: H3Event, ssrError?: (NuxtPayload['error'] & {
   if (appRenderedResult instanceof Promise) { await appRenderedResult }
 
   if (ssrContext['~renderResponse']) {
-    return ssrContext['~renderResponse']
+    return returnRenderResponse(event, ssrContext['~renderResponse'])
   }
 
   // Handle errors
@@ -501,7 +501,7 @@ async function renderStreamedResponse (ctx: {
       // Drop any preload `Link` header that targeted the streamed entry - the
       // redirect/response we are about to send does not need them.
       event.res.headers.delete('link')
-      return ssrContext['~renderResponse']
+      return returnRenderResponse(event, ssrContext['~renderResponse'])
     }
     const r = ssrContext.nuxt?.hooks.callHook('app:error', error)
     if (r instanceof Promise) { await r }
@@ -509,7 +509,7 @@ async function renderStreamedResponse (ctx: {
   }
   if (ssrContext['~renderResponse']) {
     event.res.headers.delete('link')
-    return ssrContext['~renderResponse']
+    return returnRenderResponse(event, ssrContext['~renderResponse'])
   }
 
   // 5. Render the shell head (atomically renders and clears entries pushed
@@ -588,7 +588,7 @@ async function renderStreamedResponse (ctx: {
     event.res.headers.delete('link')
     const response = ssrContext['~renderResponse'] as NuxtSSRContext['~renderResponse']
     if (response) {
-      return response
+      return returnRenderResponse(event, response)
     }
     const _err = (!ssrError && ssrContext.payload?.error) || error
     const r = ssrContext.nuxt?.hooks.callHook('app:error', _err)
@@ -600,7 +600,7 @@ async function renderStreamedResponse (ctx: {
   if (response) {
     reader.cancel().catch(() => {})
     event.res.headers.delete('link')
-    return response
+    return returnRenderResponse(event, response)
   }
 
   if (ssrContext.payload?.error && !ssrError) {

--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -21,7 +21,7 @@ import { APP_ROOT_CLOSE_TAG, APP_ROOT_OPEN_TAG, getRenderer, getServerApp } from
 import { payloadCache, prerenderRenderingURLs } from '../utils/cache'
 
 import { renderPayloadJsonScript, renderPayloadResponse, splitPayload } from '../utils/renderer/payload'
-import { createSSRContext, setSSRError } from '../utils/renderer/app'
+import { createSSRContext, rethrowWithResponseHeaders, setSSRError } from '../utils/renderer/app'
 import { renderInlineStyles } from '../utils/renderer/inline-styles'
 import { renderStreamedIslandTeleports, replaceIslandTeleports } from '../utils/renderer/islands'
 // @ts-expect-error virtual file
@@ -65,6 +65,11 @@ export default {
   fetch (request: ServerRequest) {
     const event = new H3Event(request)
 
+    if (componentIslands && event.url.pathname.startsWith('/__nuxt_island/')) {
+      // @ts-expect-error virtual file
+      return import('#internal/nuxt/island-renderer.mjs').then(r => r.default.fetch(request))
+    }
+
     // Whether we're rendering an error page
     const ssrError = event.url.pathname.startsWith('/__nuxt_error')
       ? getQuery<NuxtPayload['error'] & { url: string }>(event)
@@ -96,21 +101,6 @@ export default {
 
     return renderRoute(event, ssrError).catch(error => rethrowWithResponseHeaders(event, error))
   },
-}
-
-// The renderer mints its own `H3Event`, so response headers set during render
-// (e.g. `Set-Cookie` from `useCookie`) live on this event rather than the one
-// Nitro's error handler inspects. When the render throws, forward them onto the
-// error so the error response still carries them.
-function rethrowWithResponseHeaders (event: H3Event, error: any): never {
-  const setCookies = event.res.headers.getSetCookie()
-  if (!setCookies.length) { throw error }
-  const headers = error.headers instanceof Headers ? error.headers : new Headers(error.headers)
-  for (const cookie of setCookies) {
-    headers.append('set-cookie', cookie)
-  }
-  error.headers = headers
-  throw error
 }
 
 async function renderRoute (event: H3Event, ssrError?: (NuxtPayload['error'] & { url: string })): Promise<ReadableStream<Uint8Array> | Response> {

--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -53,7 +53,7 @@ const HAS_APP_TELEPORTS = !!(appTeleportTag && appTeleportAttrs.id)
 const APP_TELEPORT_OPEN_TAG = HAS_APP_TELEPORTS ? `<${appTeleportTag}${propsToString(appTeleportAttrs)}>` : ''
 const APP_TELEPORT_CLOSE_TAG = HAS_APP_TELEPORTS ? `</${appTeleportTag}>` : ''
 
-export const PAYLOAD_URL_RE = /^[^?]*\/_payload.json(?:\?.*)?$/
+const PAYLOAD_URL_RE = /^[^?]*\/_payload.json(?:\?.*)?$/
 const PAYLOAD_FILENAME = '_payload.json'
 
 let entryPath: string

--- a/packages/nitro-server/src/runtime/utils/cache.ts
+++ b/packages/nitro-server/src/runtime/utils/cache.ts
@@ -1,9 +1,15 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
 import type { Storage } from 'unstorage'
 import { useStorage } from 'nitro/storage'
-import type { RenderResponse } from 'nitro/types'
 // @ts-expect-error virtual file
 import { NUXT_RUNTIME_PAYLOAD_EXTRACTION, NUXT_SHARED_DATA } from '#internal/nuxt/nitro-config.mjs'
+
+export interface CachedResponse {
+  body: string
+  status: number
+  statusText: string
+  headers: Record<string, string>
+}
 
 /**
  * Stack of URLs currently rendering in the active async context (oldest first).
@@ -11,10 +17,10 @@ import { NUXT_RUNTIME_PAYLOAD_EXTRACTION, NUXT_SHARED_DATA } from '#internal/nux
  */
 export const prerenderRenderingURLs: AsyncLocalStorage<readonly string[]> | null = import.meta.prerender ? new AsyncLocalStorage() : null
 
-export const payloadCache: Storage<RenderResponse> | null = import.meta.prerender
-  ? useStorage<RenderResponse>('internal:nuxt:prerender:payload')
+export const payloadCache: Storage<CachedResponse> | null = import.meta.prerender
+  ? useStorage<CachedResponse>('internal:nuxt:prerender:payload')
   : NUXT_RUNTIME_PAYLOAD_EXTRACTION
-    ? useStorage<RenderResponse>('cache:nuxt:payload')
+    ? useStorage<CachedResponse>('cache:nuxt:payload')
     : null
 export const sharedPrerenderPromises: Map<string, Promise<any>> | null = import.meta.prerender && NUXT_SHARED_DATA ? new Map<string, Promise<any>>() : null
 

--- a/packages/nitro-server/src/runtime/utils/renderer/app.ts
+++ b/packages/nitro-server/src/runtime/utils/renderer/app.ts
@@ -42,6 +42,8 @@ export function setSSRError (ssrContext: NuxtSSRContext, error: NuxtPayload['err
   ssrContext.url = url.pathname + url.search + url.hash
 }
 
+// Layer `overlay` onto `base`, overwriting per header except `set-cookie`,
+// which is appended so cookies from both sides survive.
 export function mergeHeaders (base: Headers, overlay: Headers): Headers {
   for (const [name, value] of overlay) {
     if (name === 'set-cookie') { continue }

--- a/packages/nitro-server/src/runtime/utils/renderer/app.ts
+++ b/packages/nitro-server/src/runtime/utils/renderer/app.ts
@@ -41,3 +41,19 @@ export function setSSRError (ssrContext: NuxtSSRContext, error: NuxtPayload['err
   const url = new URL(error.url)
   ssrContext.url = url.pathname + url.search + url.hash
 }
+
+// TODO: rethink this before nuxt v5
+export function rethrowWithResponseHeaders (event: H3Event, error: any): never {
+  const resHeaders = event.res.headers
+  const setCookies = resHeaders.getSetCookie()
+  const headers = error.headers instanceof Headers ? error.headers : new Headers(error.headers)
+  for (const [name, value] of resHeaders) {
+    if (name === 'set-cookie') { continue }
+    headers.set(name, value)
+  }
+  for (const cookie of setCookies) {
+    headers.append('set-cookie', cookie)
+  }
+  error.headers = headers
+  throw error
+}

--- a/packages/nitro-server/src/runtime/utils/renderer/app.ts
+++ b/packages/nitro-server/src/runtime/utils/renderer/app.ts
@@ -42,18 +42,19 @@ export function setSSRError (ssrContext: NuxtSSRContext, error: NuxtPayload['err
   ssrContext.url = url.pathname + url.search + url.hash
 }
 
+export function mergeHeaders (base: Headers, overlay: Headers): Headers {
+  for (const [name, value] of overlay) {
+    if (name === 'set-cookie') { continue }
+    base.set(name, value)
+  }
+  for (const cookie of overlay.getSetCookie()) {
+    base.append('set-cookie', cookie)
+  }
+  return base
+}
+
 // TODO: rethink this before nuxt v5
 export function rethrowWithResponseHeaders (event: H3Event, error: any): never {
-  const resHeaders = event.res.headers
-  const setCookies = resHeaders.getSetCookie()
-  const headers = error.headers instanceof Headers ? error.headers : new Headers(error.headers)
-  for (const [name, value] of resHeaders) {
-    if (name === 'set-cookie') { continue }
-    headers.set(name, value)
-  }
-  for (const cookie of setCookies) {
-    headers.append('set-cookie', cookie)
-  }
-  error.headers = headers
+  error.headers = mergeHeaders(error.headers instanceof Headers ? error.headers : new Headers(error.headers), event.res.headers)
   throw error
 }

--- a/packages/nitro-server/src/runtime/utils/renderer/app.ts
+++ b/packages/nitro-server/src/runtime/utils/renderer/app.ts
@@ -1,4 +1,5 @@
 import type { H3Event } from 'nitro/h3'
+import { FastResponse } from 'srvx'
 import { useRuntimeConfig } from 'nitro/runtime-config'
 import { createHead } from '@unhead/vue/server'
 import type { NuxtPayload, NuxtSSRContext } from 'nuxt/app'
@@ -53,6 +54,15 @@ export function mergeHeaders (base: Headers, overlay: Headers): Headers {
     base.append('set-cookie', cookie)
   }
   return base
+}
+
+export function returnRenderResponse (event: H3Event, response: Response): Response {
+  const headers = mergeHeaders(new Headers(event.res.headers), response.headers)
+  return new FastResponse(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  })
 }
 
 // TODO: rethink this before nuxt v5

--- a/packages/nitro-server/src/runtime/utils/renderer/payload.ts
+++ b/packages/nitro-server/src/runtime/utils/renderer/payload.ts
@@ -1,15 +1,15 @@
-import type { RenderResponse } from 'nitro/types'
 import { stringify, uneval } from 'devalue'
 import type { Script } from '@unhead/vue'
 
 import type { NuxtPayload, NuxtSSRContext } from 'nuxt/app'
+import type { CachedResponse } from '../cache'
 
 // @ts-expect-error virtual file
 import { appId, multiApp } from '#internal/nuxt.config.mjs'
 // @ts-expect-error virtual file
 import { NUXT_NO_SSR } from '#internal/nuxt/nitro-config.mjs'
 
-export function renderPayloadResponse (ssrContext: NuxtSSRContext): RenderResponse {
+export function renderPayloadResponse (ssrContext: NuxtSSRContext): CachedResponse {
   return {
     body: encodeForwardSlashes(stringify(splitPayload(ssrContext).payload, ssrContext['~payloadReducers'])),
     status: ssrContext.event.res.status || 200,

--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -220,11 +220,13 @@ export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: Na
         const encodedHeader = encodeURL(location, isExternalHost)
         const encodedLoc = encodeForHtmlAttr(encodedHeader)
 
-        nuxtApp.ssrContext!['~renderResponse'] = {
-          status: sanitizeStatusCode(options?.redirectCode || 302, 302),
-          body: `<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=${encodedLoc}"></head></html>`,
-          headers: { location: encodedHeader },
-        }
+        nuxtApp.ssrContext!['~renderResponse'] = new Response(
+          `<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=${encodedLoc}"></head></html>`,
+          {
+            status: sanitizeStatusCode(options?.redirectCode || 302, 302),
+            headers: { location: encodedHeader },
+          },
+        )
         return response
       }
 

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -9,7 +9,6 @@ import { getContext } from 'unctx'
 import type { UseContext } from 'unctx'
 import type { SSRContext, createRenderer } from 'vue-bundle-renderer/runtime'
 import type { H3Event } from '@nuxt/nitro-server/h3'
-import type { RenderResponse } from 'nitro/types'
 import type { LogObject } from 'consola'
 import type { UseHeadInput, VueHeadClient } from '@unhead/vue/types'
 import type { SSRHeadPayload } from '@unhead/vue/server'
@@ -78,7 +77,7 @@ export interface NuxtSSRContext extends SSRContext {
   teleports?: Record<string, string>
   islandContext?: NuxtIslandContext
   /** @internal */
-  ['~renderResponse']?: Partial<Omit<RenderResponse, 'body'>> & { body?: string }
+  ['~renderResponse']?: Response
   /** @internal */
   ['~payloadReducers']: Record<string, (data: any) => any>
   /** @internal */

--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -287,10 +287,10 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
         const actual = to.matched.find(m => (m.components?.default as any)?.__nuxt_island)
           ?.components?.default as any
         if (!expected || expected !== actual?.__nuxt_island) {
-          nuxtApp.ssrContext!['~renderResponse'] = {
+          nuxtApp.ssrContext!['~renderResponse'] = new Response(null, {
             status: 400,
             statusText: 'Invalid island request path',
-          }
+          })
           return false
         }
       })

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1227,6 +1227,13 @@ describe('navigate', () => {
     expect(await res.text()).toMatchInlineSnapshot('"<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=/navigate-some-path"></head></html>"')
   })
 
+  it('preserves cookies set during render on a redirect response', async () => {
+    const res = await fetch('/cookie-then-redirect', { redirect: 'manual' })
+    expect(res.status).toEqual(302)
+    expect(res.headers.get('location')).toEqual('/')
+    expect(res.headers.get('set-cookie')).toContain('set-before-redirect=redirected')
+  })
+
   it('should not overwrite headers', async () => {
     const { headers, status } = await fetch('/navigate-to-external', { redirect: 'manual' })
 

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -92,7 +92,7 @@ describe.skipIf(isStubbed || process.env.SKIP_BUNDLE_SIZE === 'true' || process.
     const serverDir = join(pagesRootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!_libs'], serverDir, pagesRootDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"280k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"281k"`)
 
     const modules = await analyzeSizes(['_libs/**/*'], serverDir, pagesRootDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"490k"`)

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -58,7 +58,7 @@ describe.skipIf(isStubbed || process.env.SKIP_BUNDLE_SIZE === 'true' || process.
     const serverDir = join(rootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!_libs'], serverDir, rootDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"69.7k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"70.0k"`)
 
     const modules = await analyzeSizes(['_libs/**/*'], serverDir, rootDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"480k"`)

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -58,7 +58,7 @@ describe.skipIf(isStubbed || process.env.SKIP_BUNDLE_SIZE === 'true' || process.
     const serverDir = join(rootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!_libs'], serverDir, rootDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"69.8k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"70.1k"`)
 
     const modules = await analyzeSizes(['_libs/**/*'], serverDir, rootDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"481k"`)

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -58,7 +58,7 @@ describe.skipIf(isStubbed || process.env.SKIP_BUNDLE_SIZE === 'true' || process.
     const serverDir = join(rootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!_libs'], serverDir, rootDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"69.9k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"69.8k"`)
 
     const modules = await analyzeSizes(['_libs/**/*'], serverDir, rootDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"480k"`)

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -58,7 +58,7 @@ describe.skipIf(isStubbed || process.env.SKIP_BUNDLE_SIZE === 'true' || process.
     const serverDir = join(rootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!_libs'], serverDir, rootDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"70.0k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"69.9k"`)
 
     const modules = await analyzeSizes(['_libs/**/*'], serverDir, rootDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"480k"`)
@@ -92,7 +92,7 @@ describe.skipIf(isStubbed || process.env.SKIP_BUNDLE_SIZE === 'true' || process.
     const serverDir = join(pagesRootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!_libs'], serverDir, pagesRootDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"279k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"280k"`)
 
     const modules = await analyzeSizes(['_libs/**/*'], serverDir, pagesRootDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"489k"`)

--- a/test/fixtures/basic/app/pages/cookie-then-redirect.vue
+++ b/test/fixtures/basic/app/pages/cookie-then-redirect.vue
@@ -1,0 +1,9 @@
+<template>
+  <div>You should not see me</div>
+</template>
+
+<script setup lang="ts">
+const cookie = useCookie('set-before-redirect')
+cookie.value = 'redirected'
+await navigateTo('/', { redirectCode: 302 })
+</script>


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

in preparation for using nitro environments, this makes the ssr renderer a fetch handler rather than an event handler