### PR TITLE
fix(nuxt): add '#imports/server' alias for server-only auto-imports 🤖🤖🤖

### DIFF
--- a/docs/3.guide/1.concepts/3.auto-imports.md
+++ b/docs/3.guide/1.concepts/3.auto-imports.md
@@ -127,6 +127,18 @@ const double = computed(() => count.value * 2)
 </script>
 ```
 
+Server-only auto-imports (for example, utilities registered by modules with [`addServerImports`](/docs/4.x/api/kit/nitro#addserverimports) or [`addServerImportsDir`](/docs/4.x/api/kit/nitro#addserverimportsdir)) are exposed under the `#imports/server` alias instead. Use it in your server files to make these imports explicit while keeping them resolvable during type-checking:
+
+```ts [server/api/example.ts]
+import { useMyServerUtil } from '#imports/server'
+
+export default defineEventHandler(() => useMyServerUtil())
+```
+
+::note
+Prefer `#imports/server` over `#imports` in server files when importing server-only utilities. Because server routes are also type-checked in the app context (to infer endpoint response types), importing server-only members from `#imports` can fail type-checking, as they are not part of the app context's `#imports`.
+::
+
 ### Disabling Auto-imports
 
 If you want to disable auto-importing composables and utilities, you can set `imports.autoImport` to `false` in the `nuxt.config` file.

--- a/docs/3.guide/4.modules/5.recipes-advanced.md
+++ b/docs/3.guide/4.modules/5.recipes-advanced.md
@@ -241,3 +241,7 @@ This is required because Nuxt infers the return types of your server endpoints t
 ::warning
 This can cause issues when using **server-only types** in your route files. For example, if a module creates a server-only virtual file using [`addServerTemplate`](/docs/4.x/api/kit/templates#addservertemplate) and you declare types for it in `tsconfig.server.json`, those type declarations will only be available in the server context. When the app context type-checks your server routes, it won't recognize these server-only types and will report errors.  To resolve this, you unfortunately need to declare such types in the app context as well.
 ::
+
+::note
+Server-only auto-imports registered with [`addServerImports`](/docs/4.x/api/kit/nitro#addserverimports) or [`addServerImportsDir`](/docs/4.x/api/kit/nitro#addserverimportsdir) are exempt from this limitation when imported explicitly from the `#imports/server` alias, which resolves in both the server and app contexts. Prefer `#imports/server` over `#imports` for server-only utilities in server files.
+::

--- a/docs/4.api/5.kit/11.nitro.md
+++ b/docs/4.api/5.kit/11.nitro.md
@@ -301,6 +301,10 @@ function addPrerenderRoutes (routes: string | string[]): void
 
 Add imports to the server. It makes your imports available in Nitro without the need to import them manually.
 
+::note
+In addition to being auto-imported, the registered utilities can be explicitly imported from the `#imports/server` alias (for example, `import { myUtil } from '#imports/server'`). Prefer this over `#imports` in server files: it keeps server-only utilities resolvable when server routes are type-checked in the app context.
+::
+
 ::warning
 If you want to provide a utility that works in both server and client contexts and is usable in the [`shared/`](/docs/4.x/directory-structure/shared) directory, the function must be imported from the same source file for both [`addImports`](/docs/4.x/api/kit/autoimports#addimports) and `addServerImports` and should have identical signature. That source file should not import anything context-specific (i.e., Nitro context, Nuxt app context) or else it might cause errors during type-checking.
 ::

--- a/packages/kit/test/generate-types.spec.ts
+++ b/packages/kit/test/generate-types.spec.ts
@@ -183,6 +183,27 @@ describe('tsConfig generation', () => {
       ],
     })
   })
+
+  it('should map `#imports/server` to its own path, distinct from `#imports`', async () => {
+    const { tsConfig } = await _generateTypes(mockNuxtWithOptions({
+      alias: {
+        '#imports': './imports',
+        '#imports/server': './imports-server',
+      },
+    }))
+
+    // `#imports` has no wildcard entry, so it only matches the bare specifier and does not
+    // shadow `#imports/server` (regression test for https://github.com/nuxt/nuxt/issues/33979).
+    expect(tsConfig.compilerOptions?.paths).toMatchObject({
+      '#imports': [
+        './imports',
+      ],
+      '#imports/server': [
+        './imports-server',
+      ],
+    })
+    expect(tsConfig.compilerOptions?.paths?.['#imports/*']).toBeUndefined()
+  })
 })
 
 describe('resolveLayerPaths', async () => {

--- a/packages/nuxt/src/imports/module.ts
+++ b/packages/nuxt/src/imports/module.ts
@@ -121,6 +121,30 @@ export default defineNuxtModule<Partial<ImportsOptions>>({
     })
     nuxt.options.alias['#imports'] = join(nuxt.options.buildDir, 'imports')
 
+    // Support for importing server-only auto-imports from '#imports/server'
+    // (added via `addServerImports`/`addServerImportsDir`) in a way that resolves
+    // in both the app and server type-checking contexts. See nuxt#33979.
+    addTemplate({
+      filename: 'imports-server.mjs',
+      getContents: async () => toExports(await useNitro().unimport?.getImports() ?? []),
+    })
+    addTypeTemplate({
+      filename: 'imports-server.d.ts',
+      getContents: async ({ nuxt }) => toExports(await useNitro().unimport?.getImports() ?? [], nuxt.options.buildDir, true, { declaration: true }),
+    })
+    // The extensionless path works for the app bundler (Vite/webpack try extensions
+    // automatically) and for the app tsconfig (TypeScript tries .d.ts automatically).
+    nuxt.options.alias['#imports/server'] = join(nuxt.options.buildDir, 'imports-server')
+
+    // Rolldown (used by Nitro for the server bundle) is strict: it matches an alias
+    // but fails if the resolved path has no extension and the file does not exist at
+    // that exact path. Override the alias inside Nitro's config to point to the actual
+    // .mjs file so rolldown can load it.
+    nuxt.hook('nitro:config', (nitroConfig) => {
+      nitroConfig.alias ||= {}
+      nitroConfig.alias['#imports/server'] = join(nuxt.options.buildDir, 'imports-server.mjs')
+    })
+
     // Transform to inject imports in production mode
     addBuildPlugin(TransformPlugin({
       ctx: {

--- a/packages/nuxt/src/imports/module.ts
+++ b/packages/nuxt/src/imports/module.ts
@@ -122,8 +122,6 @@ export default defineNuxtModule<Partial<ImportsOptions>>({
     nuxt.options.alias['#imports'] = join(nuxt.options.buildDir, 'imports')
 
     // Support for importing server-only auto-imports from '#imports/server'
-    // (added via `addServerImports`/`addServerImportsDir`) in a way that resolves
-    // in both the app and server type-checking contexts. See nuxt#33979.
     addTemplate({
       filename: 'imports-server.mjs',
       getContents: async () => toExports(await useNitro().unimport?.getImports() ?? []),
@@ -132,14 +130,9 @@ export default defineNuxtModule<Partial<ImportsOptions>>({
       filename: 'imports-server.d.ts',
       getContents: async ({ nuxt }) => toExports(await useNitro().unimport?.getImports() ?? [], nuxt.options.buildDir, true, { declaration: true }),
     })
-    // The extensionless path works for the app bundler (Vite/webpack try extensions
-    // automatically) and for the app tsconfig (TypeScript tries .d.ts automatically).
     nuxt.options.alias['#imports/server'] = join(nuxt.options.buildDir, 'imports-server')
 
-    // Rolldown (used by Nitro for the server bundle) is strict: it matches an alias
-    // but fails if the resolved path has no extension and the file does not exist at
-    // that exact path. Override the alias inside Nitro's config to point to the actual
-    // .mjs file so rolldown can load it.
+    // Override the alias inside Nitro's config to point to the actual .mjs file.
     nuxt.hook('nitro:config', (nitroConfig) => {
       nitroConfig.alias ||= {}
       nitroConfig.alias['#imports/server'] = join(nuxt.options.buildDir, 'imports-server.mjs')

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -57,6 +57,17 @@ describe('server api', () => {
       }
     `)
   })
+
+  it('should resolve explicit imports from #imports/server', async () => {
+    const res = await $fetch('/api/imports-server')
+    expect(res).toMatchInlineSnapshot(`
+      {
+        "autoImported": "utils",
+        "fromServerDir": "test-utils",
+        "thisIs": "serverAutoImported",
+      }
+    `)
+  })
 })
 
 describe('route rules', () => {

--- a/test/fixtures/basic-types/modules/auto-registered/index.ts
+++ b/test/fixtures/basic-types/modules/auto-registered/index.ts
@@ -1,4 +1,4 @@
-import { addServerHandler, createResolver, defineNuxtModule } from 'nuxt/kit'
+import { addServerHandler, addServerImports, createResolver, defineNuxtModule } from 'nuxt/kit'
 
 export default defineNuxtModule({
   meta: {
@@ -11,5 +11,18 @@ export default defineNuxtModule({
       handler: resolver.resolve('./runtime/handler'),
       route: '/auto-registered-module',
     })
+
+    // Server-only auto-imports, importable from `#imports/server`
+    // https://github.com/nuxt/nuxt/issues/33979
+    addServerImports([
+      {
+        from: resolver.resolve('./runtime/some-server-import'),
+        name: 'serverAutoImported',
+      },
+      {
+        from: resolver.resolve('./runtime/some-server-import'),
+        name: 'someServerUtil',
+      },
+    ])
   },
 })

--- a/test/fixtures/basic-types/modules/auto-registered/runtime/some-server-import.ts
+++ b/test/fixtures/basic-types/modules/auto-registered/runtime/some-server-import.ts
@@ -1,0 +1,5 @@
+export function serverAutoImported () {
+  return 'serverAutoImported' as const
+}
+
+export const someServerUtil = 'utils' as const

--- a/test/fixtures/basic-types/server/api/imports-server.ts
+++ b/test/fixtures/basic-types/server/api/imports-server.ts
@@ -1,0 +1,10 @@
+// Regression test for https://github.com/nuxt/nuxt/issues/33979
+import { serverAutoImported, someServerUtil } from '#imports/server'
+
+const _result: string = serverAutoImported()
+const _util: string = someServerUtil
+
+// @ts-expect-error `serverAutoImported` returns the literal 'serverAutoImported'
+const _wrong: number = serverAutoImported()
+
+export default defineEventHandler(() => ({ result: _result, util: _util }))

--- a/test/fixtures/basic/server/api/imports-server.ts
+++ b/test/fixtures/basic/server/api/imports-server.ts
@@ -1,0 +1,10 @@
+// Explicit imports of server-only auto-imports via `#imports/server`
+import { autoimportedFunction, someUtils, testUtils } from '#imports/server'
+
+export default defineEventHandler(() => {
+  return {
+    thisIs: autoimportedFunction(),
+    autoImported: someUtils,
+    fromServerDir: testUtils,
+  }
+})


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #33979

### 📚 Description

Faced the similar issue (described by [cernymatej](https://github.com/cernymatej)) with my project and decided to find a universal fix for it.

This adds a dedicated #imports/server alias. Its declarations are generated from Nitro's unimport instance and the alias is mapped in both the app and server tsconfig paths, so server-only imports resolve in both contexts.

I went with #imports/server rather than #imports/nitro since 'server' is the convention used elsewhere in the repo, and it keeps the name tool-agnostic. Server-only utilities can now be imported explicitly from #imports/server.