### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/packages/nitro-server/src/runtime/handlers/island.ts
+++ b/packages/nitro-server/src/runtime/handlers/island.ts
@@ -11,7 +11,7 @@ import { computeIslandHash } from '#app/island-hash'
 import type { NuxtIslandContext, NuxtIslandResponse } from 'nuxt/app'
 import { traceAsync } from '#app/internal/tracing'
 // @ts-expect-error virtual file
-import { tracingChannelNuxt } from '#internal/nuxt.config.mjs'
+import { appCrossOrigin, tracingChannelNuxt } from '#internal/nuxt.config.mjs'
 import { createSSRContext } from '../utils/renderer/app'
 import { getSSRRenderer } from '../utils/renderer/build-files'
 import { renderInlineStyles } from '../utils/renderer/inline-styles'
@@ -94,7 +94,7 @@ const handler: ReturnType<typeof defineEventHandler> = defineEventHandler(async 
       // Add CSS links in <head> for CSS files
       // - in dev mode when rendering an island and the file has scoped styles and is not a page
       if (resource.file.includes('scoped') && !resource.file.includes('pages/')) {
-        link.push({ rel: 'stylesheet', href: renderer.rendererContext.buildAssetsURL(resource.file), crossorigin: '' })
+        link.push({ rel: 'stylesheet', href: renderer.rendererContext.buildAssetsURL(resource.file), crossorigin: appCrossOrigin })
       }
     }
     if (link.length) {

--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -28,7 +28,7 @@ import { renderSSRHeadOptions } from '#internal/unhead.config.mjs'
 // @ts-expect-error virtual file
 import { NUXT_ASYNC_CONTEXT, NUXT_EARLY_HINTS, NUXT_INLINE_STYLES, NUXT_NO_SCRIPTS, NUXT_PAYLOAD_EXTRACTION, NUXT_PAYLOAD_INLINE, NUXT_RUNTIME_PAYLOAD_EXTRACTION, NUXT_SSR_STREAMING, NUXT_SSR_STREAMING_BOT_RE, PARSE_ERROR_DATA } from '#internal/nuxt/nitro-config.mjs'
 // @ts-expect-error virtual file
-import { appHead, appTeleportAttrs, appTeleportTag, componentIslands, componentIslandsActive, tracingChannelNuxt } from '#internal/nuxt.config.mjs'
+import { appCrossOrigin, appHead, appTeleportAttrs, appTeleportTag, componentIslands, componentIslandsActive, tracingChannelNuxt } from '#internal/nuxt.config.mjs'
 // @ts-expect-error virtual file
 import entryIds from '#internal/nuxt/entry-ids.mjs'
 // @ts-expect-error virtual file
@@ -287,17 +287,17 @@ async function renderRoute (event: H3Event, ssrError?: (NuxtPayload['error'] & {
     ssrContext.head.push({ style: inlinedStyles })
   }
 
-  const link: Link[] = []
-  for (const resource of Object.values(styles)) {
-    // Do not add links to resources that are inlined (vite v5+)
-    if (import.meta.dev && 'inline' in getURLQuery(resource.file)) {
-      continue
-    }
-    // Add CSS links in <head> for CSS files
-    // - in production
-    // - in dev mode when not rendering an island
-    link.push({ rel: 'stylesheet', href: renderer.rendererContext.buildAssetsURL(resource.file), crossorigin: '' })
-  }
+        const link: Link[] = []
+        for (const resource of Object.values(styles)) {
+          // Do not add links to resources that are inlined (vite v5+)
+          if (import.meta.dev && 'inline' in getURLQuery(resource.file)) {
+            continue
+          }
+          // Add CSS links in <head> for CSS files
+          // - in production
+          // - in dev mode when not rendering an island
+          link.push({ rel: 'stylesheet', href: renderer.rendererContext.buildAssetsURL(resource.file), crossorigin: appCrossOrigin })
+        }
 
   if (link.length) {
     ssrContext.head.push({ link })
@@ -342,7 +342,7 @@ async function renderRoute (event: H3Event, ssrError?: (NuxtPayload['error'] & {
         // if we are rendering script tag payloads that import an async payload
         // we need to ensure this resolves before executing the Nuxt entry
         tagPosition: 'head',
-        crossorigin: '',
+        crossorigin: appCrossOrigin,
       })),
     })
   }
@@ -410,7 +410,7 @@ async function renderStreamedResponse (ctx: {
   const shellLinks: Link[] = []
   for (const resource of Object.values(entryStyles)) {
     if (import.meta.dev && 'inline' in getURLQuery(resource.file)) { continue }
-    shellLinks.push({ rel: 'stylesheet', href: renderer.rendererContext.buildAssetsURL(resource.file), crossorigin: '' })
+    shellLinks.push({ rel: 'stylesheet', href: renderer.rendererContext.buildAssetsURL(resource.file), crossorigin: appCrossOrigin })
   }
   if (shellLinks.length) {
     ssrContext.head.push({ link: shellLinks })
@@ -466,7 +466,7 @@ async function renderStreamedResponse (ctx: {
         src: renderer.rendererContext.buildAssetsURL(resource.file),
         defer: resource.module ? null : true,
         tagPosition: 'head',
-        crossorigin: '',
+        crossorigin: appCrossOrigin,
       })),
     })
   }
@@ -650,7 +650,7 @@ async function renderStreamedResponse (ctx: {
       if (emittedStyles.has(resource.file)) { continue }
       if (import.meta.dev && 'inline' in getURLQuery(resource.file)) { continue }
       emittedStyles.add(resource.file)
-      tags += `<link rel="stylesheet" crossorigin href="${renderer.rendererContext.buildAssetsURL(resource.file)}">`
+      tags += `<link rel="stylesheet" crossorigin="${appCrossOrigin || 'anonymous'}" href="${renderer.rendererContext.buildAssetsURL(resource.file)}">`
     }
     return tags
   }

--- a/packages/schema/src/config/app.ts
+++ b/packages/schema/src/config/app.ts
@@ -51,6 +51,15 @@ export default defineResolvers({
       },
     },
 
+    crossOrigin: {
+      $resolve: (val) => {
+        if (val === 'anonymous' || val === 'use-credentials') {
+          return val
+        }
+        return ''
+      },
+    },
+
     head: {
       $resolve: (_val) => {
         const val: Partial<NuxtAppConfig['head']> = _val && typeof _val === 'object' ? _val : {}

--- a/packages/schema/src/types/config.ts
+++ b/packages/schema/src/types/config.ts
@@ -169,6 +169,8 @@ export interface NuxtAppConfig {
   pageTransition: boolean | Serializable<TransitionProps>
   viewTransition?: ViewTransitionOptions['enabled'] | ViewTransitionOptions
   keepalive: boolean | Serializable<KeepAliveProps>
+  /** Cross-origin attribute to set on rendered CSS and preload links */
+  crossOrigin: '' | 'anonymous' | 'use-credentials'
 }
 
 export interface AppConfig {

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -182,6 +182,24 @@ export interface ConfigSchema {
     cdnURL: string
 
     /**
+     * The `crossorigin` attribute to set on rendered CSS stylesheet links and
+     * preload/prefetch links for assets. Set to `'anonymous'` (default empty)
+     * or `'use-credentials'` if your CDN requires credentials.
+     *
+     * @default ''
+     *
+     * @example
+     * ```ts
+     * export default defineNuxtConfig({
+     *   app: {
+     *     crossOrigin: 'use-credentials'
+     *   }
+     * })
+     * ```
+     */
+    crossOrigin: '' | 'anonymous' | 'use-credentials'
+
+    /**
      * Set default configuration for `<head>` on every page.
      *
      * @example


### PR DESCRIPTION
## Problem

When serving static assets from a CDN that requires credentials (e.g. behind Cloudflare Under Attack Mode), theres no way to set `crossorigin="use-credentials"` on rendered stylesheet and preload links. The attribute is hardcoded to an empty string.

## Solution

Added a new `app.crossOrigin` config option that flows through to the renderer. Users can set it to `"anonymous"`, `"use-credentials"`, or leave it empty (default) for backward compatibility.

## Changes

- `packages/schema/src/types/config.ts`: Add `crossOrigin` to `NuxtAppConfig` interface
- `packages/schema/src/types/schema.ts`: Add typed schema entry with JSDoc + example
- `packages/schema/src/config/app.ts`: Add default resolver
- `packages/nitro-server/src/runtime/handlers/renderer.ts`: Use `appCrossOrigin` instead of hardcoded empty string
- `packages/nitro-server/src/runtime/handlers/island.ts`: Same change for island rendering

## Usage

```ts
export default defineNuxtConfig({
  app: {
    crossOrigin: "use-credentials"
  }
})
```

## Testing

- Existing tests should continue to pass (default is empty string, same as before)
- Manual: set config, verify crossorigin attribute on stylesheet/preload links

Closes #30003