### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/docs/1.getting-started/16.deployment.md
+++ b/docs/1.getting-started/16.deployment.md
@@ -138,6 +138,17 @@ export default defineNuxtConfig({
 NITRO_PRESET=node-server nuxt build
 ```
 
+::note
+When deploying to the Bun runtime, use the `bun` Nitro preset before building:
+
+```bash [Terminal]
+NITRO_PRESET=bun nuxt build
+bun run .output/server/index.mjs
+```
+
+You can also set `nitro.preset` to `'bun'` in your Nuxt configuration.
+::
+
 🔎 Check [the Nitro deployment](https://nitro.build/deploy) for all possible deployment presets and providers.
 
 ## CDN Proxy


### PR DESCRIPTION
Fixes #25802

## Summary
- Document the `bun` Nitro preset in the deployment presets section.
- Show the `NITRO_PRESET=bun nuxt build` flow and the Bun command for running the built server.

## Verification
- `npx --yes markdownlint-cli@0.48.0 --ignore-path .gitignore docs/1.getting-started/16.deployment.md`
- `npx --yes case-police@2.2.1 docs/1.getting-started/16.deployment.md`
- `git diff --check`