### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/packages/vite/src/plugins/ssr-styles.ts
+++ b/packages/vite/src/plugins/ssr-styles.ts
@@ -105,6 +105,11 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
   const cssMap: Record<string, { files: string[], inBundle?: boolean, cssIds?: Set<string> }> = {}
   // Track emitted CSS chunk refs globally to avoid duplicate emissions across transform calls.
   const emittedFileRefs: Record<string, string> = {}
+  // Keep emitted style chunk names unique across transform calls. Pages with
+  // the same basename (for example `pages/foo/[slug].vue` and
+  // `pages/bar/[slug].vue`) otherwise both start from `*-styles-1.mjs`, which
+  // can collide in rolldown/vite output.
+  let styleCtr = 0
 
   const options = {
     shouldInline: nuxt.options.features.inlineStyles,
@@ -342,7 +347,6 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
             const emittedIds = new Set<string>()
             const idFilename = filename(id)
 
-            let styleCtr = 0
             const ids = clientCSSMap[id] || []
             for (const file of ids) {
               if (emittedIds.has(file)) { continue }

--- a/test/fixtures/inline-styles/nuxt.config.ts
+++ b/test/fixtures/inline-styles/nuxt.config.ts
@@ -12,5 +12,8 @@ export default withMatrix({
     output: {
       dir: `.output-${projectSuffix}`,
     },
+    prerender: {
+      routes: ['/bar/test', '/foo/test'],
+    },
   },
 })

--- a/test/fixtures/inline-styles/pages/bar/[slug].vue
+++ b/test/fixtures/inline-styles/pages/bar/[slug].vue
@@ -1,0 +1,11 @@
+<template>
+  <main class="page-bar-slug">
+    bar slug
+  </main>
+</template>
+
+<style scoped>
+.page-bar-slug {
+  --inline-page-bar-slug-token: bar;
+}
+</style>

--- a/test/fixtures/inline-styles/pages/foo/[slug].vue
+++ b/test/fixtures/inline-styles/pages/foo/[slug].vue
@@ -1,0 +1,11 @@
+<template>
+  <main class="page-foo-slug">
+    foo slug
+  </main>
+</template>
+
+<style scoped>
+.page-foo-slug {
+  --inline-page-foo-slug-token: foo;
+}
+</style>

--- a/test/inline-styles.test.ts
+++ b/test/inline-styles.test.ts
@@ -31,6 +31,18 @@ describe.skipIf(builder !== 'vite' || !isBuilt)('inline styles', () => {
     expect(cssLinks, page).toEqual([])
   })
 
+  // https://github.com/nuxt/nuxt/issues/35423
+  it.each([
+    ['bar/test', '--inline-page-bar-slug-token:bar'],
+    ['foo/test', '--inline-page-foo-slug-token:foo'],
+  ])('inlines CSS for duplicate page basenames (%s)', async (route, token) => {
+    const html = await readFile(join(outputDir, 'public', route, 'index.html'), 'utf-8')
+    expect(html).toContain(token)
+
+    const cssLinks = [...html.matchAll(/<link [^>]*rel="stylesheet"[^>]*href="([^"]+)"/g)].map(m => m[1]!)
+    expect(cssLinks).toEqual([])
+  })
+
   // https://github.com/nuxt/nuxt/issues/31558
   it('inlines CSS for a non-island child of a server component', async () => {
     const html = await readFile(join(outputDir, 'public', 'index.html'), 'utf-8')


### PR DESCRIPTION
Fixes #35423

### 🔗 Linked issue

#35423

### 📚 Description

This keeps the SSR inline-style virtual chunk counter at plugin scope so pages with the same basename, like `pages/foo/[slug].vue` and `pages/bar/[slug].vue`, do not both emit the same `*-styles-1.mjs` name.

I added an inline-styles fixture that prerenders both duplicate-basename routes and asserts their scoped CSS is present inline without stylesheet links.

AI assistance was used to prepare this change; I reviewed and validated the implementation and tests.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated tests where applicable.

### 🧪 Tests

- `pnpm exec vitest run --project 'fixtures:vite-built-*' test/inline-styles.test.ts -t 'duplicate page basenames' --reporter dot`
- `pnpm exec eslint packages/vite/src/plugins/ssr-styles.ts test/inline-styles.test.ts test/fixtures/inline-styles/nuxt.config.ts test/fixtures/inline-styles/pages/bar/[slug].vue test/fixtures/inline-styles/pages/foo/[slug].vue`
- `git diff --check HEAD~1..HEAD`
