### PR TITLE
fix(vite): avoid emitted ssr styles file name collisions

### DIFF
--- a/packages/vite/src/plugins/ssr-styles.ts
+++ b/packages/vite/src/plugins/ssr-styles.ts
@@ -351,7 +351,7 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
             const emittedIds = new Set<string>()
             let chunkNamePrefix = chunkNamePrefixes.get(relativeId)
             if (chunkNamePrefix === undefined) {
-              const baseName = filename(id)
+              const baseName = filename(id) || 'styles'
               chunkNamePrefix = baseName
               for (let i = 2; usedChunkNamePrefixes.has(chunkNamePrefix); i++) {
                 chunkNamePrefix = `${baseName}-${i}`

--- a/packages/vite/src/plugins/ssr-styles.ts
+++ b/packages/vite/src/plugins/ssr-styles.ts
@@ -177,18 +177,24 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
           if (environment.name === 'client') { return }
 
           const emitted: Record<string, string> = {}
+          const usedNames = new Set<string>()
           for (const [file, { files, inBundle }] of Object.entries(cssMap)) {
             // File has been tree-shaken out of build (or there are no styles to inline)
             if (!files.length || !inBundle) { continue }
-            const fileName = filename(file)
+            const baseName = filename(file)
+            let assetName = `${baseName}-styles.mjs`
+            for (let i = 2; usedNames.has(assetName); i++) {
+              assetName = `${baseName}-styles-${i}.mjs`
+            }
+            usedNames.add(assetName)
             const base = typeof outputOptions.assetFileNames === 'string'
               ? outputOptions.assetFileNames
               : outputOptions.assetFileNames({
                   type: 'asset',
-                  name: `${fileName}-styles.mjs`,
-                  names: [`${fileName}-styles.mjs`],
-                  originalFileName: `${fileName}-styles.mjs`,
-                  originalFileNames: [`${fileName}-styles.mjs`],
+                  name: assetName,
+                  names: [assetName],
+                  originalFileName: assetName,
+                  originalFileNames: [assetName],
                   source: '',
                 })
 
@@ -210,7 +216,7 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
             }
             emitted[file] = this.emitFile({
               type: 'asset',
-              name: `${fileName}-styles.mjs`,
+              name: assetName,
               source: [
                 ...importStatements,
                 `export default ${genArrayFromRaw([...exportNames])}`,
@@ -340,7 +346,7 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
             const idCssIds = idMap.cssIds ||= new Set()
 
             const emittedIds = new Set<string>()
-            const idFilename = filename(id)
+            const chunkNamePrefix = filename(relativeId.replace(/[\\/]/g, '-')) || filename(id)
 
             let styleCtr = 0
             const ids = clientCSSMap[id] || []
@@ -366,7 +372,7 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
               if (!ref) {
                 ref = this.emitFile({
                   type: 'chunk',
-                  name: `${idFilename}-styles-${++styleCtr}.mjs`,
+                  name: `${chunkNamePrefix}-styles-${++styleCtr}.mjs`,
                   id: fileInline,
                 })
                 emittedFileRefs[resolvedInlineId] = ref
@@ -401,7 +407,7 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
               if (!ref) {
                 ref = this.emitFile({
                   type: 'chunk',
-                  name: `${idFilename}-styles-${++styleCtr}.mjs`,
+                  name: `${chunkNamePrefix}-styles-${++styleCtr}.mjs`,
                   id: resolvedIdInline,
                 })
                 emittedFileRefs[resolvedInlineId] = ref

--- a/packages/vite/src/plugins/ssr-styles.ts
+++ b/packages/vite/src/plugins/ssr-styles.ts
@@ -105,6 +105,9 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
   const cssMap: Record<string, { files: string[], inBundle?: boolean, cssIds?: Set<string> }> = {}
   // Track emitted CSS chunk refs globally to avoid duplicate emissions across transform calls.
   const emittedFileRefs: Record<string, string> = {}
+  // map for source file to a unique chunk-name prefix
+  const chunkNamePrefixes = new Map<string, string>()
+  const usedChunkNamePrefixes = new Set<string>()
 
   const options = {
     shouldInline: nuxt.options.features.inlineStyles,
@@ -346,7 +349,16 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
             const idCssIds = idMap.cssIds ||= new Set()
 
             const emittedIds = new Set<string>()
-            const chunkNamePrefix = filename(relativeId.replace(/[\\/]/g, '-')) || filename(id)
+            let chunkNamePrefix = chunkNamePrefixes.get(relativeId)
+            if (chunkNamePrefix === undefined) {
+              const baseName = filename(id)
+              chunkNamePrefix = baseName
+              for (let i = 2; usedChunkNamePrefixes.has(chunkNamePrefix); i++) {
+                chunkNamePrefix = `${baseName}-${i}`
+              }
+              usedChunkNamePrefixes.add(chunkNamePrefix)
+              chunkNamePrefixes.set(relativeId, chunkNamePrefix)
+            }
 
             let styleCtr = 0
             const ids = clientCSSMap[id] || []

--- a/test/fixtures/inline-styles/pages/first/shared-name.vue
+++ b/test/fixtures/inline-styles/pages/first/shared-name.vue
@@ -1,0 +1,11 @@
+<template>
+  <main class="page-first-shared">
+    first shared-name page
+  </main>
+</template>
+
+<style scoped>
+.page-first-shared {
+  --inline-first-shared-token: first-shared;
+}
+</style>

--- a/test/fixtures/inline-styles/pages/second/shared-name.vue
+++ b/test/fixtures/inline-styles/pages/second/shared-name.vue
@@ -1,0 +1,11 @@
+<template>
+  <main class="page-second-shared">
+    second shared-name page
+  </main>
+</template>
+
+<style scoped>
+.page-second-shared {
+  --inline-second-shared-token: second-shared;
+}
+</style>

--- a/test/inline-styles.test.ts
+++ b/test/inline-styles.test.ts
@@ -47,6 +47,18 @@ describe.skipIf(builder !== 'vite' || !isBuilt)('inline styles', () => {
     expect(cssLinks).toEqual([])
   })
 
+  // https://github.com/nuxt/nuxt/issues/35423
+  it.each([
+    ['first', '--inline-first-shared-token:first-shared', '--inline-second-shared-token:second-shared'],
+    ['second', '--inline-second-shared-token:second-shared', '--inline-first-shared-token:first-shared'],
+  ])('inlines the correct CSS for %s when two pages share a basename', async (dir, expectedToken, otherToken) => {
+    const html = await readFile(join(outputDir, 'public', dir, 'shared-name', 'index.html'), 'utf-8')
+    expect(html).toContain(expectedToken)
+    expect(html).not.toContain(otherToken)
+    const cssLinks = [...html.matchAll(/<link [^>]*rel="stylesheet"[^>]*href="([^"]+)"/g)].map(m => m[1]!)
+    expect(cssLinks).toEqual([])
+  })
+
   // https://github.com/nuxt/nuxt/issues/27417
   // https://github.com/nuxt/nuxt/issues/35065
   it.each([


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/35423

### 📚 Description

this solves two issues that only reproduced on vite 8 due to a change in mapping ref <> filename:

1. wrong chunk imported (when there was a collision of file names)
2. aggregator asset being deduped

