### PR TITLE
feat(nuxt): warn when multiple routes resolve to the same path

### DIFF
--- a/packages/nuxt/src/pages/runtime/composables.ts
+++ b/packages/nuxt/src/pages/runtime/composables.ts
@@ -53,6 +53,12 @@ export interface PageMeta {
   props?: RouteRecordRaw['props']
   /** Set to `false` to avoid scrolling to top on page navigations */
   scrollToTop?: boolean | ((to: RouteLocationNormalizedLoaded, from: RouteLocationNormalizedLoaded) => boolean)
+  /**
+   * Silence the "multiple routes resolve to the same path" warning when a
+   * collision with another route is intentional (e.g. a module deliberately
+   * overriding a page).
+   */
+  allowDuplicatePath?: boolean
 }
 
 declare module 'vue-router' {

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -157,11 +157,19 @@ export function warnDuplicateRoutePaths (pages: NuxtPage[], parentPath = '') {
   const seen = new Map<string, NuxtPage>()
   for (const route of pages) {
     const fullPath = route.path.startsWith('/') ? route.path : joinURL(parentPath, route.path)
-    const existing = seen.get(route.path)
-    if (existing) {
-      logger.warn(`Multiple routes resolve to the same path \`${fullPath || '/'}\`${existing.file && route.file ? ` (\`${existing.file}\` and \`${route.file}\`)` : ''}. Only one will be matched, so you may wish to ensure each route has a unique path.`)
-    } else {
-      seen.set(route.path, route)
+    // Only routes that render their own component can shadow each other. Redirect-only
+    // routes, route groups and other component-less entries deliberately share a path and
+    // should not warn. Server/client variants of the same page also legitimately collide.
+    // `meta.allowDuplicatePath` opts a route out where the collision is intentional (e.g. a
+    // module deliberately overriding a page).
+    if ((route.file || route.components) && !route.meta?.allowDuplicatePath) {
+      const key = `${route.path}\0${route.mode ?? 'all'}`
+      const existing = seen.get(key)
+      if (existing) {
+        logger.warn(`Multiple routes resolve to the same path \`${fullPath || '/'}\`${existing.file && route.file ? ` (\`${existing.file}\` and \`${route.file}\`)` : ''}. Only one will be matched, so you may wish to ensure each route has a unique path. Set \`meta.allowDuplicatePath\` on a route to silence this warning if the collision is intentional.`)
+      } else {
+        seen.set(key, route)
+      }
     }
     if (route.children?.length) {
       warnDuplicateRoutePaths(route.children, fullPath)

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -123,6 +123,7 @@ export async function augmentAndResolve (pages: NuxtPage[], trackedFiles: Set<st
 
   if (shouldAugment === false) {
     await nuxt.callHook('pages:extend', pages)
+    warnDuplicateRoutePaths(pages)
     return pages
   }
 
@@ -145,9 +146,27 @@ export async function augmentAndResolve (pages: NuxtPage[], trackedFiles: Set<st
     augmentedPages?.clear()
   }
 
+  warnDuplicateRoutePaths(pages)
+
   await nuxt.callHook('pages:resolved', pages)
 
   return pages
+}
+
+export function warnDuplicateRoutePaths (pages: NuxtPage[], parentPath = '') {
+  const seen = new Map<string, NuxtPage>()
+  for (const route of pages) {
+    const fullPath = route.path.startsWith('/') ? route.path : joinURL(parentPath, route.path)
+    const existing = seen.get(route.path)
+    if (existing) {
+      logger.warn(`Multiple routes resolve to the same path \`${fullPath || '/'}\`${existing.file && route.file ? ` (\`${existing.file}\` and \`${route.file}\`)` : ''}. Only one will be matched, so you may wish to ensure each route has a unique path.`)
+    } else {
+      seen.set(route.path, route)
+    }
+    if (route.children?.length) {
+      warnDuplicateRoutePaths(route.children, fullPath)
+    }
+  }
 }
 
 interface AugmentPagesContext {

--- a/packages/nuxt/test/pages.test.ts
+++ b/packages/nuxt/test/pages.test.ts
@@ -1,7 +1,8 @@
 import type { TestAPI } from 'vitest'
 import { describe, expect, it, vi } from 'vitest'
 import type { RouteLocationNormalizedLoaded } from 'vue-router'
-import { type PagesContextOptions, augmentPages, createPagesContext, normalizeRoutes, pathToNitroGlob } from '../src/pages/utils.ts'
+import { type PagesContextOptions, augmentPages, createPagesContext, normalizeRoutes, pathToNitroGlob, warnDuplicateRoutePaths } from '../src/pages/utils.ts'
+import { logger } from '../src/utils.ts'
 import type { RouterViewSlotProps } from '../src/pages/runtime/utils.ts'
 import { generateRouteKey } from '../src/pages/runtime/utils.ts'
 import type { NuxtPage } from 'nuxt/schema'
@@ -463,6 +464,55 @@ describe('page:extends', () => {
         meta: { [DYNAMIC_META_KEY]: new Set(['meta']), snap: true },
       },
     ])
+  })
+})
+
+describe('pages:warnDuplicateRoutePaths', () => {
+  it('warns when sibling routes resolve to the same path', () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+    warnDuplicateRoutePaths([
+      { path: '/test', file: 'pages/test.vue' },
+      { path: '/test', file: 'modules/runtime/pages/test.vue' },
+    ])
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(warn.mock.calls[0]![0]).toContain('/test')
+    expect(warn.mock.calls[0]![0]).toContain('pages/test.vue')
+    expect(warn.mock.calls[0]![0]).toContain('modules/runtime/pages/test.vue')
+    warn.mockRestore()
+  })
+
+  it('warns for nested sibling routes using the resolved full path', () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+    warnDuplicateRoutePaths([
+      {
+        path: '/parent',
+        file: 'pages/parent.vue',
+        children: [
+          { path: 'child', file: 'pages/parent/child.vue' },
+          { path: 'child', file: 'modules/runtime/pages/child.vue' },
+        ],
+      },
+    ])
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(warn.mock.calls[0]![0]).toContain('/parent/child')
+    warn.mockRestore()
+  })
+
+  it('does not warn when all routes have unique paths', () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+    warnDuplicateRoutePaths([
+      { path: '/', file: 'pages/index.vue' },
+      { path: '/about', file: 'pages/about.vue' },
+      {
+        path: '/parent',
+        file: 'pages/parent.vue',
+        children: [
+          { path: 'child', file: 'pages/parent/child.vue' },
+        ],
+      },
+    ])
+    expect(warn).not.toHaveBeenCalled()
+    warn.mockRestore()
   })
 })
 

--- a/packages/nuxt/test/pages.test.ts
+++ b/packages/nuxt/test/pages.test.ts
@@ -523,6 +523,46 @@ describe('pages:warnDuplicateRoutePaths', () => {
     expect(duplicateWarnings(warn)).toHaveLength(0)
     warn.mockRestore()
   })
+
+  it('does not warn when a redirect-only route shares a path with a page', () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+    warnDuplicateRoutePaths([
+      { path: '/test', redirect: '/other' },
+      { path: '/test', file: 'pages/test.vue' },
+    ])
+    expect(duplicateWarnings(warn)).toHaveLength(0)
+    warn.mockRestore()
+  })
+
+  it('does not warn for server/client variants of the same page', () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+    warnDuplicateRoutePaths([
+      { path: '/test', file: 'pages/test.vue', mode: 'server' },
+      { path: '/test', file: 'pages/test.vue', mode: 'client' },
+    ])
+    expect(duplicateWarnings(warn)).toHaveLength(0)
+    warn.mockRestore()
+  })
+
+  it('still warns when two rendering routes share both path and mode', () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+    warnDuplicateRoutePaths([
+      { path: '/test', file: 'pages/test.vue', mode: 'client' },
+      { path: '/test', file: 'modules/runtime/pages/test.vue', mode: 'client' },
+    ])
+    expect(duplicateWarnings(warn)).toHaveLength(1)
+    warn.mockRestore()
+  })
+
+  it('does not warn when a colliding route opts out via meta.allowDuplicatePath', () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+    warnDuplicateRoutePaths([
+      { path: '/test', file: 'pages/test.vue' },
+      { path: '/test', file: 'modules/runtime/pages/test.vue', meta: { allowDuplicatePath: true } },
+    ])
+    expect(duplicateWarnings(warn)).toHaveLength(0)
+    warn.mockRestore()
+  })
 })
 
 const pagesDir = 'pages'

--- a/packages/nuxt/test/pages.test.ts
+++ b/packages/nuxt/test/pages.test.ts
@@ -468,16 +468,24 @@ describe('page:extends', () => {
 })
 
 describe('pages:warnDuplicateRoutePaths', () => {
+  const DUPLICATE_PATH_WARNING = 'Multiple routes resolve to the same path'
+  function duplicateWarnings (warn: ReturnType<typeof vi.spyOn>) {
+    return (warn.mock.calls as unknown[][])
+      .map((call): string => String(call[0]))
+      .filter(message => message.includes(DUPLICATE_PATH_WARNING))
+  }
+
   it('warns when sibling routes resolve to the same path', () => {
     const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {})
     warnDuplicateRoutePaths([
       { path: '/test', file: 'pages/test.vue' },
       { path: '/test', file: 'modules/runtime/pages/test.vue' },
     ])
-    expect(warn).toHaveBeenCalledTimes(1)
-    expect(warn.mock.calls[0]![0]).toContain('/test')
-    expect(warn.mock.calls[0]![0]).toContain('pages/test.vue')
-    expect(warn.mock.calls[0]![0]).toContain('modules/runtime/pages/test.vue')
+    const warnings = duplicateWarnings(warn)
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toContain('/test')
+    expect(warnings[0]).toContain('pages/test.vue')
+    expect(warnings[0]).toContain('modules/runtime/pages/test.vue')
     warn.mockRestore()
   })
 
@@ -493,8 +501,9 @@ describe('pages:warnDuplicateRoutePaths', () => {
         ],
       },
     ])
-    expect(warn).toHaveBeenCalledTimes(1)
-    expect(warn.mock.calls[0]![0]).toContain('/parent/child')
+    const warnings = duplicateWarnings(warn)
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toContain('/parent/child')
     warn.mockRestore()
   })
 
@@ -511,7 +520,7 @@ describe('pages:warnDuplicateRoutePaths', () => {
         ],
       },
     ])
-    expect(warn).not.toHaveBeenCalled()
+    expect(duplicateWarnings(warn)).toHaveLength(0)
     warn.mockRestore()
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #24174

### 📚 Description

When a route is added via `pages:extend` (for example by a module) with a path that already exists, vue-router silently keeps only one match, so the "losing" page disappears with no indication of why. As discussed in #24174, it is reasonable to warn when multiple pages resolve to the same path.
