### PR TITLE
fix(nuxt): avoid syncing route too early when reused page remounts

### DIFF
--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -7,7 +7,8 @@ import { isSamePath, withoutBase } from 'ufo'
 import type { NuxtApp, Plugin, RouteMiddleware } from 'nuxt/app'
 import type { PageMeta } from '../composables'
 
-import { toArray } from '../utils'
+import { generateRouteKey, toArray } from '../utils'
+import type { RouterViewSlotProps } from '../utils'
 
 import { getRouteRules } from '#app/composables/manifest'
 import { defineNuxtPlugin, useRuntimeConfig } from '#app/nuxt'
@@ -117,7 +118,14 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
       const lastTo = to.matched.at(-1)?.components?.default
       const lastFrom = from.matched.at(-1)?.components?.default
       if (lastTo === lastFrom) {
-        syncCurrentRoute()
+        // Only sync eagerly when the reused page is not remounted (unchanged key). When the key
+        // changes (e.g. catch-all/param navigation) the page remounts and `Suspense.onResolve`
+        // syncs the route once it resolves; syncing here would update it too early (#33107).
+        const toKey = generateRouteKey({ route: to, Component: { type: lastTo } } as RouterViewSlotProps)
+        const fromKey = generateRouteKey({ route: from, Component: { type: lastFrom } } as RouterViewSlotProps)
+        if (toKey === fromKey) {
+          syncCurrentRoute()
+        }
         return
       }
       if (to.matched.length < from.matched.length && to.matched.every((m, i) => m.components?.default === from.matched[i]?.components?.default)) {

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -92,7 +92,7 @@ describe.skipIf(isStubbed || process.env.SKIP_BUNDLE_SIZE === 'true' || process.
     const serverDir = join(pagesRootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!_libs'], serverDir, pagesRootDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"281k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"282k"`)
 
     const modules = await analyzeSizes(['_libs/**/*'], serverDir, pagesRootDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"491k"`)

--- a/test/nuxt/nuxt-page.test.ts
+++ b/test/nuxt/nuxt-page.test.ts
@@ -954,3 +954,95 @@ describe('NuxtPage should not emit page:finish before the page:start hook chain 
     el.unmount()
   })
 })
+
+describe('NuxtPage route sync when leaf component is reused (#33107)', () => {
+  let router: ReturnType<typeof useRouter>
+  let nuxtApp: ReturnType<typeof useNuxtApp>
+  let resolvers: Array<() => void>
+
+  beforeEach(() => {
+    router = useRouter()
+    nuxtApp = useNuxtApp()
+    resolvers = []
+
+    // A single component matched by two different paths (like a catch-all or `[id]` page)
+    router.addRoute({
+      name: 'items',
+      path: '/items/:id',
+      component: defineComponent({
+        name: 'items',
+        async setup () {
+          const route = useRoute()
+          await new Promise<void>((resolve) => { resolvers.push(resolve) })
+          return () => h('div', { 'data-testid': 'item-page' }, `item:${route.params.id}`)
+        },
+      }),
+    })
+  })
+
+  afterEach(() => {
+    router.removeRoute('items')
+  })
+
+  it('does not update the route read outside <NuxtPage> before a param navigation to the same component resolves', async () => {
+    const el = await mountSuspended({
+      setup () {
+        // read outside the page's `<RouteProvider>`, so this resolves to the deferred `nuxtApp._route`
+        const route = useRoute()
+        return () => h('div', [
+          h('span', { 'data-testid': 'outer-path' }, route.path),
+          h(NuxtPage),
+        ])
+      },
+    })
+
+    await navigateTo('/items/a')
+    resolvers.at(-1)!()
+    await new Promise<void>(resolve => nuxtApp.hooks.hookOnce('page:finish', () => resolve()))
+    await flushPromises()
+
+    expect(el.get('[data-testid="outer-path"]').text()).toBe('/items/a')
+    expect(el.get('[data-testid="item-page"]').text()).toBe('item:a')
+
+    await navigateTo('/items/b')
+    await flushPromises()
+
+    expect(el.get('[data-testid="outer-path"]').text()).toBe('/items/a')
+    expect(el.get('[data-testid="item-page"]').text()).toBe('item:a')
+
+    resolvers.at(-1)!()
+    await new Promise<void>(resolve => nuxtApp.hooks.hookOnce('page:finish', () => resolve()))
+    await flushPromises()
+
+    expect(el.get('[data-testid="outer-path"]').text()).toBe('/items/b')
+    expect(el.get('[data-testid="item-page"]').text()).toBe('item:b')
+
+    el.unmount()
+  })
+
+  it('still syncs the route immediately on a query-only navigation that does not remount the page (#34918)', async () => {
+    const el = await mountSuspended({
+      setup () {
+        const route = useRoute()
+        return () => h('div', [
+          h('span', { 'data-testid': 'outer-full-path' }, route.fullPath),
+          h(NuxtPage),
+        ])
+      },
+    })
+
+    await navigateTo('/items/a')
+    resolvers.at(-1)!()
+    await new Promise<void>(resolve => nuxtApp.hooks.hookOnce('page:finish', () => resolve()))
+    await flushPromises()
+
+    expect(el.get('[data-testid="outer-full-path"]').text()).toBe('/items/a')
+
+    await navigateTo('/items/a?page=2')
+    await flushPromises()
+
+    expect(el.get('[data-testid="outer-full-path"]').text()).toBe('/items/a?page=2')
+
+    el.unmount()
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #33107

### 📚 Description

When a leaf component is reused across a navigation, the router plugin syncs the internal `_route` immediately so `useRoute` updates even though no `<Suspense>` boundary resolves (added in #34918 for navigating up the route tree).

That is only correct when the page key is unchanged. For catch-all and param routes (e.g. `/items/1` → `/items/2`) the key changes, `<NuxtPage>` remounts the page, and `Suspense.onResolve` syncs the route once the new page has resolved — so the eager sync updates `useRoute()` *before* the page content has changed.

This gates the eager sync on the generated route key being unchanged; when it changes, the (delayed, correct) `Suspense.onResolve` sync is left to do the work.

Added two runtime tests: one asserting the route read outside `<NuxtPage>` does not update before a param navigation to the same component resolves, and one asserting a query-only navigation (same key, no remount) still syncs immediately (guards #34918).
