### PR TITLE
fix(nitro): keep internal server imports when nitro auto-imports are disabled

### DIFF
--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -117,6 +117,29 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
 
   const mockProxy = resolveModulePath('mocked-exports/proxy', { from: import.meta.url })
 
+  // Nuxt's internal server imports (the `defineAppConfig` shim and asset-URL helpers). These must
+  // stay available even when Nitro auto-imports are disabled (`nitroAutoImports: false`, the v5
+  // default), since `app.config.ts` is bundled into the server build.
+  const nitroInternalImports = [
+    {
+      as: '__buildAssetsURL',
+      name: 'buildAssetsURL',
+      from: resolve(distDir, 'runtime/utils/paths'),
+    },
+    {
+      as: '__publicAssetsURL',
+      name: 'publicAssetsURL',
+      from: resolve(distDir, 'runtime/utils/paths'),
+    },
+    {
+      // TODO: Remove after https://github.com/nitrojs/nitro/issues/1049
+      as: 'defineAppConfig',
+      name: 'defineAppConfig',
+      from: resolve(distDir, 'runtime/utils/config'),
+      priority: -1,
+    },
+  ]
+
   const nitroConfig: NitroConfig = defu(nuxt.options.nitro, {
     debug: nuxt.options.debug ? nuxt.options.debug.nitro : false,
     rootDir: nuxt.options.rootDir,
@@ -133,7 +156,14 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
       version: nuxtPkg.version || nitroBuilder.version,
     },
     imports: nuxt.options.experimental.nitroAutoImports === false
-      ? false
+      ? {
+          // Auto-imports are disabled, but keep Nuxt's internal imports (`nitroInternalImports`).
+          autoImport: nuxt.options.imports.autoImport as boolean,
+          dirs: [],
+          presets: [],
+          imports: nitroInternalImports,
+          exclude: [...excludePattern, /[\\/]\.git[\\/]/],
+        }
       : {
           autoImport: nuxt.options.imports.autoImport as boolean,
           dirs: [...sharedDirs],
@@ -143,25 +173,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
                 await getH3ImportsPreset(),
               ]
             : [],
-          imports: [
-            {
-              as: '__buildAssetsURL',
-              name: 'buildAssetsURL',
-              from: resolve(distDir, 'runtime/utils/paths'),
-            },
-            {
-              as: '__publicAssetsURL',
-              name: 'publicAssetsURL',
-              from: resolve(distDir, 'runtime/utils/paths'),
-            },
-            {
-              // TODO: Remove after https://github.com/nitrojs/nitro/issues/1049
-              as: 'defineAppConfig',
-              name: 'defineAppConfig',
-              from: resolve(distDir, 'runtime/utils/config'),
-              priority: -1,
-            },
-          ],
+          imports: nitroInternalImports,
           exclude: [...excludePattern, /[\\/]\.git[\\/]/],
         },
     // TODO: support for bundle analyser: https://github.com/nitrojs/nitro/pull/3628

--- a/packages/nuxt/test/nitro-app-config.test.ts
+++ b/packages/nuxt/test/nitro-app-config.test.ts
@@ -1,0 +1,61 @@
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+
+import { join } from 'pathe'
+import { findWorkspaceDir } from 'pkg-types'
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { build, loadNuxt } from 'nuxt'
+import type { NitroConfig } from 'nitro/types'
+
+describe('nitro app config', { sequential: true, timeout: 120_000 }, async () => {
+  const workspaceDir = await findWorkspaceDir()
+  const tmpDir = join(workspaceDir, '.test/nitro-app-config')
+
+  beforeEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+    await mkdir(join(tmpDir, 'project/node_modules'), { recursive: true })
+    await writeFile(join(tmpDir, 'project/app.vue'), '<template><div>hello</div></template>')
+    await writeFile(join(tmpDir, 'project/app.config.ts'), 'export default defineAppConfig({ foo: \'bar\' })\n')
+  })
+
+  afterAll(async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  // Under compatibilityVersion 5 `nitroAutoImports` defaults to `false`, which previously dropped
+  // every Nitro import — including the `defineAppConfig` shim — breaking servers that bundle `app.config.ts`.
+  it('keeps `defineAppConfig` available to Nitro when auto-imports are disabled', async () => {
+    const rootDir = join(tmpDir, 'project')
+
+    let nitroImports: NitroConfig['imports']
+    const nuxt = await loadNuxt({
+      cwd: rootDir,
+      overrides: {
+        dev: false,
+        workspaceDir: tmpDir,
+        future: { compatibilityVersion: 5 },
+        hooks: {
+          'nitro:config' (nitroConfig) {
+            nitroImports = nitroConfig.imports
+          },
+        },
+      },
+    })
+
+    try {
+      await build(nuxt)
+    } finally {
+      await nuxt.close()
+    }
+
+    // sanity check that we are exercising the disabled-auto-imports path
+    expect(nuxt.options.experimental.nitroAutoImports).toBe(false)
+
+    // the Nitro imports must remain enabled (not `false`) so the app-config shims are injected
+    expect(nitroImports).not.toBe(false)
+    const importNames = (typeof nitroImports === 'object' ? nitroImports.imports : undefined)?.map(i => i.as ?? i.name)
+    // `useAppConfig` is restored alongside `defineAppConfig` because the `imports` object is now
+    // truthy (it is pushed when `serverAppConfig` is enabled)
+    expect(importNames).toContain('defineAppConfig')
+    expect(importNames).toContain('useAppConfig')
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #34142

### 📚 Description

This keeps the Nitro `imports` object enabled with Nuxt's internal imports (the `defineAppConfig` shim and the asset-URL helpers) and **no** user-facing presets when `nitroAutoImports` is disabled. Because the `imports` object is now truthy, `useAppConfig` is also restored (it is pushed when `serverAppConfig` is enabled). 

Let me know what you think.