### PR TITLE
fix(nuxt): restore deferred query route before page is mounted

### DIFF
--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -192,8 +192,8 @@ interface _NuxtApp {
     sync?: () => void
   }
   /**
-   * Restores the real route after a prerendered page hydrates against the query-less payload
-   * route. Called by `<NuxtPage>` as its `Suspense` resolves, before mounted hooks flush.
+   * Restore the real route after a prerendered page hydrates against the query-less
+   * payload route. Called by `<NuxtPage>` as its `Suspense` resolves, before mounted hooks flush.
    * @internal
    */
   '~restoreDeferredRoute'?: () => void | Promise<void>

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -191,6 +191,12 @@ interface _NuxtApp {
   '_route': RouteLocationNormalizedLoaded & {
     sync?: () => void
   }
+  /**
+   * Restores the real route after a prerendered page hydrates against the query-less payload
+   * route. Called by `<NuxtPage>` as its `Suspense` resolves, before mounted hooks flush.
+   * @internal
+   */
+  '~restoreDeferredRoute'?: () => void | Promise<void>
 
   /** @internal */
   '_islandPromises'?: Record<string, Promise<any>>

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -196,7 +196,7 @@ interface _NuxtApp {
    * payload route. Called by `<NuxtPage>` as its `Suspense` resolves, before mounted hooks flush.
    * @internal
    */
-  '~restoreDeferredRoute'?: () => void | Promise<void>
+  '~restoreDeferredRoute'?: () => void
 
   /** @internal */
   '_islandPromises'?: Record<string, Promise<any>>

--- a/packages/nuxt/src/pages/runtime/page.ts
+++ b/packages/nuxt/src/pages/runtime/page.ts
@@ -237,8 +237,6 @@ export default defineComponent({
                   onResolve: async () => {
                     isSuspensePending = false
                     hasResolvedOnce = true
-                    // Restore the real route (kept query-less for the hydration render) before the
-                    // page's mounted hooks flush, so its query is present in `onMounted`.
                     if (import.meta.client && nuxtApp.isHydrating) {
                       nuxtApp['~restoreDeferredRoute']?.()
                     }

--- a/packages/nuxt/src/pages/runtime/page.ts
+++ b/packages/nuxt/src/pages/runtime/page.ts
@@ -237,6 +237,11 @@ export default defineComponent({
                   onResolve: async () => {
                     isSuspensePending = false
                     hasResolvedOnce = true
+                    // Restore the real route (kept query-less for the hydration render) before the
+                    // page's mounted hooks flush, so its query is present in `onMounted`.
+                    if (import.meta.client && nuxtApp.isHydrating) {
+                      nuxtApp['~restoreDeferredRoute']?.()
+                    }
                     try {
                       await nextTick()
                       nuxtApp._route.sync?.()

--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -326,33 +326,27 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
         if (pluginNavigatedAway) {
           // we don't need to push the previous route
         } else if (hasDeferredRoute) {
-          // First apply the route that was prerendered to avoid hydration mismatches,
-          // then restore the actual resolved initial route once the page has hydrated.
+          // Hydrate against the query-less prerendered route to avoid a mismatch, then restore the
+          // real route once the page has hydrated.
           const payloadRoute = router.resolve(nuxtApp.payload.path!)
           if ('name' in payloadRoute) {
             payloadRoute.name = undefined
           }
           await router.replace({ ...payloadRoute, force: true })
 
-          let restored = false
-          const restoreDeferredRoute = async () => {
-            if (restored) { return }
-            restored = true
+          const restoreDeferredRoute = () => {
+            if (!nuxtApp['~restoreDeferredRoute']) { return }
             nuxtApp['~restoreDeferredRoute'] = undefined
-            // Activate the real route synchronously (before the page's mounted hooks flush) so its
-            // query is correct in `onMounted`; `router.replace` would only resolve a tick later. The
-            // page hydrated against the query-less payload route, so this is not a hydration mismatch.
-            // Resolve fresh (not the name-stripped `resolvedInitialRoute`) so `route.name` is correct.
+            // Assign synchronously: `router.replace` only finalises `currentRoute` a microtask
+            // later, after mounted hooks flush. Resolve fresh so `route.name` survives.
             ;(router.currentRoute as Ref<RouteLocationNormalizedLoadedGeneric>).value = router.resolve(initialURL) as RouteLocationNormalizedLoadedGeneric
             syncCurrentRoute()
-            // Reconcile vue-router history and the browser URL; failures target the already-rendered
-            // route, so there is nothing to surface.
-            await router.replace({ ...resolvedInitialRoute, force: true }).catch(() => {})
+            return router.replace({ ...resolvedInitialRoute, force: true }).catch(() => {})
           }
-          // `<NuxtPage>`'s `Suspense.onResolve` calls this before mounted hooks flush; fall
-          // back to `app:suspense:resolve` when there is no page (e.g. `<NuxtPage>`) to render.
+          // `<NuxtPage>` calls this before its mounted hooks flush; the hook is the fallback when
+          // there is no page to render.
           nuxtApp['~restoreDeferredRoute'] = restoreDeferredRoute
-          nuxtApp.hooks.hookOnce('app:suspense:resolve', restoreDeferredRoute)
+          nuxtApp.hooks.hookOnce('app:suspense:resolve', () => nuxtApp['~restoreDeferredRoute']?.())
         } else {
           await router.replace({
             ...resolvedInitialRoute,

--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -349,12 +349,12 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
             // later, after mounted hooks flush. Resolve fresh so `route.name` survives.
             ;(router.currentRoute as Ref<RouteLocationNormalizedLoadedGeneric>).value = router.resolve(initialURL) as RouteLocationNormalizedLoadedGeneric
             syncCurrentRoute()
-            return router.replace({ ...resolvedInitialRoute, force: true }).catch(() => {})
+            router.replace({ ...resolvedInitialRoute, force: true }).catch(() => {})
           }
           // `<NuxtPage>` calls this before its mounted hooks flush; the hook is the fallback when
           // there is no page to render.
           nuxtApp['~restoreDeferredRoute'] = restoreDeferredRoute
-          nuxtApp.hooks.hookOnce('app:suspense:resolve', () => nuxtApp['~restoreDeferredRoute']?.())
+          nuxtApp.hooks.hookOnce('app:suspense:resolve', restoreDeferredRoute)
         } else {
           await router.replace({
             ...resolvedInitialRoute,

--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -327,16 +327,32 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
           // we don't need to push the previous route
         } else if (hasDeferredRoute) {
           // First apply the route that was prerendered to avoid hydration mismatches,
-          // then replace it after hydration with the actual resolved initial route
+          // then restore the actual resolved initial route once the page has hydrated.
           const payloadRoute = router.resolve(nuxtApp.payload.path!)
           if ('name' in payloadRoute) {
             payloadRoute.name = undefined
           }
           await router.replace({ ...payloadRoute, force: true })
 
-          nuxtApp.hooks.hookOnce('app:suspense:resolve', async () => {
-            await router.replace({ ...resolvedInitialRoute, force: true })
-          })
+          let restored = false
+          const restoreDeferredRoute = async () => {
+            if (restored) { return }
+            restored = true
+            nuxtApp['~restoreDeferredRoute'] = undefined
+            // Activate the real route synchronously (before the page's mounted hooks flush) so its
+            // query is correct in `onMounted`; `router.replace` would only resolve a tick later. The
+            // page hydrated against the query-less payload route, so this is not a hydration mismatch.
+            // Resolve fresh (not the name-stripped `resolvedInitialRoute`) so `route.name` is correct.
+            ;(router.currentRoute as Ref<RouteLocationNormalizedLoadedGeneric>).value = router.resolve(initialURL) as RouteLocationNormalizedLoadedGeneric
+            syncCurrentRoute()
+            // Reconcile vue-router history and the browser URL; failures target the already-rendered
+            // route, so there is nothing to surface.
+            await router.replace({ ...resolvedInitialRoute, force: true }).catch(() => {})
+          }
+          // `<NuxtPage>`'s `Suspense.onResolve` calls this before mounted hooks flush; fall
+          // back to `app:suspense:resolve` when there is no page (e.g. `<NuxtPage>`) to render.
+          nuxtApp['~restoreDeferredRoute'] = restoreDeferredRoute
+          nuxtApp.hooks.hookOnce('app:suspense:resolve', restoreDeferredRoute)
         } else {
           await router.replace({
             ...resolvedInitialRoute,

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -736,6 +736,10 @@ describe('pages', () => {
     expect(await page.evaluate(() => window.useNuxtApp?.()._route.query.active)).toBe('true')
     expect(await page.$eval('div', e => getComputedStyle(e).color)).toBe('rgb(255, 0, 0)')
 
+    // the query should already be restored by the time the page is mounted, so
+    // `onMounted` reads the real query rather than the prerendered empty one
+    expect(await page.innerText('#mounted-query')).toBe('true')
+
     await page.close()
   })
 

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -37,7 +37,7 @@ describe.skipIf(isStubbed || process.env.SKIP_BUNDLE_SIZE === 'true' || process.
   it('default client bundle size (pages)', async () => {
     const clientStats = await analyzeSizes(['**/*.js'], join(pagesRootDir, '.output/public'), pagesRootDir)
 
-    expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"176k"`)
+    expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"177k"`)
 
     const files = clientStats!.files.map(f => f.replace(/\..*\.js/, '.js'))
 

--- a/test/fixtures/basic/app/pages/prerender/query-reactivity.vue
+++ b/test/fixtures/basic/app/pages/prerender/query-reactivity.vue
@@ -1,9 +1,16 @@
 <script setup lang="ts">
 const route = useRoute()
+// Capture the query as seen in `onMounted` to guard against it being restored
+// too late on a prerendered page.
+const mountedQuery = ref('pending')
+onMounted(() => {
+  mountedQuery.value = String(route.query.active)
+})
 </script>
 
 <template>
   <div :style="{ color: route.query.active === 'true' ? 'red' : 'blue' }">
     Query: {{ route.query.active }}
+    <span id="mounted-query">{{ mountedQuery }}</span>
   </div>
 </template>


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #34651

### 📚 Description

On a prerendered (SSG) page whose URL carries a query (e.g. `/products?active=true`), Nuxt hydrates against the query-less prerendered markup and restores the real route afterwards. That restore ran in the `app:suspense:resolve` hook, which fires **after** the page's `onMounted`, so `useRoute().query` was still empty during `onMounted` (and `<script setup>`). This broke common patterns such as reading the query on mount.

`<NuxtPage>`'s `Suspense` `onResolve` runs synchronously when the page resolves — **before** the buffered mounted hooks flush. We restore the real route there instead: `router.currentRoute` is set synchronously (then history/URL are reconciled via `router.replace`) so the query is present in `onMounted`, while the hydration render itself stays query-less (no hydration mismatch). When no `<NuxtPage>` is rendered, it falls back to `app:suspense:resolve` as before.