### PR TITLE
fix(nuxt): keep nested layout on deferred route during suspended layout switch

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-layout.ts
+++ b/packages/nuxt/src/app/components/nuxt-layout.ts
@@ -181,6 +181,12 @@ const LayoutProvider = defineComponent({
     const injectedRoute = inject(PageRouteSymbol)
     const isNotWithinNuxtPage = injectedRoute && injectedRoute === useRoute()
 
+    // The enclosing layout chain, if this layout is nested inside another `<NuxtLayout>`.
+    // When the eager route no longer selects that enclosing layout, this layout is being
+    // re-rendered in the old suspense fork while the destination page is still pending, so
+    // it must keep reading the deferred route rather than jumping ahead to the eager one (#32904).
+    const enclosingLayout = inject(LayoutMetaSymbol, null)
+
     if (isNotWithinNuxtPage) {
       // this route updates immediately
       const vueRouterRoute = useVueRouterRoute() as ReturnType<typeof useRoute>
@@ -192,7 +198,9 @@ const LayoutProvider = defineComponent({
           get: () => {
             // we want to use the eager route if we are rendering a layout for the first time
             // and only swap back to the lazy route if the route has already changed from the first render
-            return props.isRenderingNewLayout(props.name) ? vueRouterRoute[key] : injectedRoute[key]
+            const useEagerRoute = props.isRenderingNewLayout(props.name) &&
+              (!enclosingLayout || enclosingLayout.isCurrent(vueRouterRoute))
+            return useEagerRoute ? vueRouterRoute[key] : injectedRoute[key]
           },
         })
       }

--- a/test/nuxt/nuxt-layout-nested-route-sync.test.ts
+++ b/test/nuxt/nuxt-layout-nested-route-sync.test.ts
@@ -91,7 +91,7 @@ describe('NuxtLayout nested layout route sync (#32904)', () => {
     }
   })
 
-  it.fails('does not update inner nested layout route before the suspended destination page resolves', async () => {
+  it('does not update inner nested layout route before the suspended destination page resolves', async () => {
     const nuxtApp = useNuxtApp()
 
     await navigateTo('/x-a')

--- a/test/nuxt/nuxt-layout-nested-route-sync.test.ts
+++ b/test/nuxt/nuxt-layout-nested-route-sync.test.ts
@@ -83,6 +83,7 @@ describe('NuxtLayout nested layout route sync (#32904)', () => {
   })
 
   afterAll(() => {
+    el.unmount()
     for (const layout of addedLayouts) {
       delete layouts[layout]
     }

--- a/test/nuxt/nuxt-layout-nested-route-sync.test.ts
+++ b/test/nuxt/nuxt-layout-nested-route-sync.test.ts
@@ -1,0 +1,117 @@
+/// <reference path="../fixtures/basic/.nuxt/nuxt.d.ts" />
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import type { VueWrapper } from '@vue/test-utils'
+import { flushPromises } from '@vue/test-utils'
+import { NuxtLayout, NuxtPage } from '#components'
+import layouts from '#build/layouts.mjs'
+import { useRoute } from '#app/composables/router'
+
+describe('NuxtLayout nested layout route sync (#32904)', () => {
+  let router: ReturnType<typeof useRouter>
+  let resolveDeferredPage: () => void
+  let el: VueWrapper
+
+  const addedLayouts = ['x-full', 'x-default', 'x-secondary']
+  const addedPages = ['x-a', 'x-b']
+
+  beforeAll(async () => {
+    router = useRouter()
+
+    layouts['x-full'] = defineComponent({
+      setup (_, ctx) {
+        const route = useRoute()
+        return () => h('div', {}, [
+          h('span', { 'data-testid': 'full-route' }, String(route.name)),
+          ...ctx.slots.default?.() || [],
+        ])
+      },
+    })
+
+    layouts['x-default'] = defineComponent({
+      setup (_, ctx) {
+        const route = useRoute()
+        return () => h(NuxtLayout, { name: 'x-full' }, {
+          default: () => [
+            h('span', { 'data-testid': 'default-route' }, String(route.name)),
+            ...ctx.slots.default?.() || [],
+          ],
+        })
+      },
+    })
+
+    layouts['x-secondary'] = defineComponent({
+      setup (_, ctx) {
+        const route = useRoute()
+        return () => h('div', {}, [
+          h('span', { 'data-testid': 'secondary-route' }, String(route.name)),
+          ...ctx.slots.default?.() || [],
+        ])
+      },
+    })
+
+    router.addRoute({
+      name: 'x-a',
+      path: '/x-a',
+      // @ts-expect-error dynamically-added layout is not typed
+      meta: { layout: 'x-default' },
+      component: defineComponent({
+        setup () {
+          return () => h('div', { 'data-testid': 'page-a' }, 'A')
+        },
+      }),
+    })
+
+    router.addRoute({
+      name: 'x-b',
+      path: '/x-b',
+      // @ts-expect-error dynamically-added layout is not typed
+      meta: { layout: 'x-secondary' },
+      component: defineComponent({
+        async setup () {
+          await new Promise<void>((resolve) => {
+            resolveDeferredPage = resolve
+          })
+          return () => h('div', { 'data-testid': 'page-b' }, 'B')
+        },
+      }),
+    })
+
+    el = await mountSuspended({ setup: () => () => h(NuxtLayout, {}, { default: () => h(NuxtPage) }) })
+  })
+
+  afterAll(() => {
+    for (const layout of addedLayouts) {
+      delete layouts[layout]
+    }
+    for (const page of addedPages) {
+      router.removeRoute(page)
+    }
+  })
+
+  it.fails('does not update inner nested layout route before the suspended destination page resolves', async () => {
+    const nuxtApp = useNuxtApp()
+
+    await navigateTo('/x-a')
+    await flushPromises()
+
+    expect.soft(el.get('[data-testid="full-route"]').text()).toBe('x-a')
+    expect.soft(el.get('[data-testid="default-route"]').text()).toBe('x-a')
+
+    await navigateTo('/x-b')
+    await flushPromises()
+
+    expect.soft(el.get('[data-testid="default-route"]').text()).toBe('x-a')
+    expect.soft(el.get('[data-testid="page-a"]').text()).toBe('A')
+    expect(el.get('[data-testid="full-route"]').text()).toBe('x-a')
+
+    resolveDeferredPage()
+    await new Promise<void>(resolve => nuxtApp.hooks.hookOnce('page:finish', () => resolve()))
+    await flushPromises()
+
+    expect.soft(el.get('[data-testid="secondary-route"]').text()).toBe('x-b')
+    expect.soft(el.get('[data-testid="page-b"]').text()).toBe('B')
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

resolves #32904

### 📚 Description

adds a regression test for #32904 (developed when investigating/reviewing https://github.com/nuxt/nuxt/pull/35440)

... and then resolves by detecting when we are in a nested layout context... ✅ 