### PR TITLE
fix(vite): set define for `NODE_ENV` and `__VUE_PROD_DEVTOOLS__`

### DIFF
--- a/packages/schema/src/config/vite.ts
+++ b/packages/schema/src/config/vite.ts
@@ -13,6 +13,7 @@ export default defineResolvers({
       $resolve: async (_val, get) => {
         const [isDev, isTest, isDebug] = await Promise.all([get('dev'), get('test'), get('debug')])
         return {
+          '__VUE_PROD_DEVTOOLS__': false,
           '__VUE_PROD_HYDRATION_MISMATCH_DETAILS__': Boolean(isDebug && (isDebug === true || isDebug.hydration)),
           'process.dev': isDev,
           'import.meta.dev': isDev,

--- a/packages/vite/src/shared/server.ts
+++ b/packages/vite/src/shared/server.ts
@@ -58,6 +58,7 @@ export function ssrEnvironment (nuxt: Nuxt, serverEntry: string) {
       },
     },
     define: {
+      'process.env.NODE_ENV': JSON.stringify(nuxt.options.vite.mode),
       'process.server': true,
       'process.client': false,
       'process.browser': false,

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -92,10 +92,10 @@ describe.skipIf(isStubbed || process.env.SKIP_BUNDLE_SIZE === 'true' || process.
     const serverDir = join(pagesRootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!_libs'], serverDir, pagesRootDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"282k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"172k"`)
 
     const modules = await analyzeSizes(['_libs/**/*'], serverDir, pagesRootDir)
-    expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"491k"`)
+    expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"483k"`)
 
     const packages = modules.files
       .map(m => m.replace('_libs/', '').replace(/\.mjs$/, ''))
@@ -107,11 +107,9 @@ describe.skipIf(isStubbed || process.env.SKIP_BUNDLE_SIZE === 'true' || process.
         "destr",
         "devalue",
         "h3+rou3+srvx",
-        "hookable",
         "ocache+ohash",
         "ofetch",
         "pathe",
-        "perfect-debounce",
         "scule",
         "ufo",
         "uncrypto",


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

spotted in https://github.com/nuxt/nuxt/pull/35439 - this addresses a regression in tree-shaking a number of things from the nitro build, including vue devtools