### PR TITLE
fix(nuxt): make islands hash backwards-compatible

### DIFF
--- a/packages/nuxt/src/app/island-hash.ts
+++ b/packages/nuxt/src/app/island-hash.ts
@@ -34,8 +34,8 @@ export function serializeIslandProps (props: Record<string, any> | null | undefi
 /**
  * Compute the `hashId` segment embedded in an island URL (`/__nuxt_island/<Name>_<hashId>.json`).
  *
- * The hash binds the response to the requested `(name, serializedProps, context, source)` tuple,
- * so the server can reject requests whose URL hash does not match the supplied query/body.
+ * The hash binds the response to the requested `(name, props, context, source)` tuple, so the
+ * server can reject requests whose URL hash does not match the supplied query/body.
  *
  * @internal
  */
@@ -45,5 +45,13 @@ export function computeIslandHash (
   context: Record<string, any>,
   source: string | undefined,
 ): string {
-  return hash([name, serializedProps, context, source]).replace(/[-_]/g, '')
+  let parsed: unknown
+  // The server hashes attacker-controllable query input before validating, so a malformed
+  // string must not throw here; fall back to the raw value (matching the hash on both ends).
+  try {
+    parsed = JSON.parse(serializedProps)
+  } catch {
+    parsed = serializedProps
+  }
+  return hash([name, parsed, context, source]).replace(/[-_]/g, '')
 }

--- a/packages/nuxt/test/island-hash.test.ts
+++ b/packages/nuxt/test/island-hash.test.ts
@@ -64,8 +64,29 @@ describe('computeIslandHash', () => {
     const name = 'PureComponent'
     const serializedProps = '{"count":3,"label":"hi"}'
     const context = { url: '/foo' }
-    const expected = hash([name, serializedProps, context, undefined]).replace(/[-_]/g, '')
+    const expected = hash([name, JSON.parse(serializedProps), context, undefined]).replace(/[-_]/g, '')
     expect(computeIslandHash(name, serializedProps, context, undefined)).toBe(expected)
+  })
+
+  // External island clients (e.g. `@nuxtjs/og-image`) hash the plain props object and send
+  // `JSON.stringify(props)`; that hash must still validate when the round-trip is identity.
+  it('matches a client that hashes the props object directly', () => {
+    const name = 'OgImageCommunityNuxtSeoSatori'
+    const props = { title: 'Hello World' }
+    const objectHash = hash([name, props, {}, undefined]).replace(/[-_]/g, '')
+    expect(computeIslandHash(name, JSON.stringify(props), {}, undefined)).toBe(objectHash)
+  })
+
+  // #35349
+  it('is stable across the JSON round-trip for dropped values', () => {
+    const serialized = serializeIslandProps({ label: 'hi', onClick: () => {}, missing: undefined })
+    const objectHash = hash(['X', { label: 'hi' }, {}, undefined]).replace(/[-_]/g, '')
+    expect(computeIslandHash('X', serialized, {}, undefined)).toBe(objectHash)
+  })
+
+  // The server hashes attacker-controllable query input before validating it.
+  it('does not throw on malformed serialized props', () => {
+    expect(() => computeIslandHash('X', '{"a":1', {}, undefined)).not.toThrow()
   })
 
   it('changes when props change', () => {

--- a/test/server-components.test.ts
+++ b/test/server-components.test.ts
@@ -500,6 +500,20 @@ describe('hash binding', () => {
     expect(res.status).toBe(200)
   })
 
+  // External island clients (e.g. `@nuxtjs/og-image`) build the URL hash from the props object
+  // and send `JSON.stringify(props)`. `computeIslandHash` over the serialized string and the
+  // client's object hash converge (asserted in island-hash.test.ts); here we send the raw
+  // `JSON.stringify(props)` the external client emits rather than `serializeIslandProps`.
+  it('accepts a request whose props were serialized by an external client', async () => {
+    const name = 'PureComponent'
+    const props = { bool: false, number: 1, str: 's', obj: {} }
+    const hashId = computeIslandHash(name, JSON.stringify(props), {}, undefined)
+    const res = await fetch(withQuery(`/__nuxt_island/${name}_${hashId}.json`, {
+      props: JSON.stringify(props),
+    }))
+    expect(res.status).toBe(200)
+  })
+
   it('rejects a request whose URL hash was computed over different props', async () => {
     // Compute a valid hash for one set of props, then swap the actual query props.
     const url = islandURL('PureComponent', {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

spotted a regression [in nuxt/ecosystem-ci with nuxt-og-image](https://github.com/nuxt/ecosystem-ci/actions/runs/28221089324/job/83602342942) (which was computing its own islands hash)

this adapts the recent hash bugfixes so they are backwards compatible with nuxt-og-image, or any other code that relied on the hash methodology