### PR TITLE
fix(nuxt): preserve constrained inline route rules

### DIFF
--- a/packages/nuxt/src/pages/route-rules.ts
+++ b/packages/nuxt/src/pages/route-rules.ts
@@ -1,14 +1,14 @@
 import type { NuxtPage } from '@nuxt/schema'
 import type { NitroRouteConfig } from 'nitro/types'
 
-import { pathToNitroGlob } from './utils.ts'
+import { pathToNitroGlobs } from './utils.ts'
 
 export function globRouteRulesFromPages (pages: NuxtPage[], paths = {} as { [glob: string]: NitroRouteConfig }, prefix = '') {
   for (const page of pages) {
     if (page.rules) {
       if (Object.keys(page.rules).length) {
-        const glob = pathToNitroGlob(prefix + page.path)
-        if (glob) {
+        const globs = pathToNitroGlobs(prefix + page.path)
+        for (const glob of globs || []) {
           paths[glob] = page.rules
         }
       }

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -520,7 +520,32 @@ async function createClientPage(loader) {
   }
 }
 
+// Convert the first dynamic route segment and anything after it into a Nitro wildcard.
+// For example: `/blog/:slug` -> `/blog/**`.
 const PATH_TO_NITRO_GLOB_RE = /\/[^:/]*:\w.*$/
+// Match simple constrained params that can be expanded into concrete paths.
+// For example: `/:locale(de|fr)/blog` -> `/de/blog` and `/fr/blog`.
+const CONSTRAINED_PARAM_SEGMENT_RE = /\/:[\w-]+\(([^()]+)\)(?=\/|$)/
+// Do not expand arbitrary regex constraints, only literal path segment alternatives.
+// For example: `de|fr` is expanded, but `[a-z]{2}` is left untouched.
+const SIMPLE_PARAM_ALTERNATIVE_RE = /^[\w-]+$/
+
+function expandRouteParamAlternatives (path: string): string[] {
+  const match = path.match(CONSTRAINED_PARAM_SEGMENT_RE)
+  if (!match || typeof match.index !== 'number') {
+    return [path]
+  }
+
+  const alternatives = match[1]!.split('|')
+  if (!alternatives.every(alternative => SIMPLE_PARAM_ALTERNATIVE_RE.test(alternative))) {
+    return [path]
+  }
+
+  const prefix = path.slice(0, match.index)
+  const suffix = path.slice(match.index + match[0]!.length)
+  return alternatives.flatMap(alternative => expandRouteParamAlternatives(`${prefix}/${alternative}${suffix}`))
+}
+
 export function pathToNitroGlob (path: string) {
   if (!path) {
     return null
@@ -531,6 +556,17 @@ export function pathToNitroGlob (path: string) {
   }
 
   return path.replace(PATH_TO_NITRO_GLOB_RE, '/**')
+}
+
+export function pathToNitroGlobs (path: string) {
+  const globs = new Set<string>()
+  for (const expandedPath of expandRouteParamAlternatives(path)) {
+    const glob = pathToNitroGlob(expandedPath)
+    if (glob) {
+      globs.add(glob)
+    }
+  }
+  return globs.size ? [...globs] : null
 }
 
 export function resolveRoutePaths (page: NuxtPage, parent = '/'): string[] {

--- a/packages/nuxt/test/pages.test.ts
+++ b/packages/nuxt/test/pages.test.ts
@@ -1,7 +1,7 @@
 import type { TestAPI } from 'vitest'
 import { describe, expect, it, vi } from 'vitest'
 import type { RouteLocationNormalizedLoaded } from 'vue-router'
-import { type PagesContextOptions, augmentPages, createPagesContext, normalizeRoutes, pathToNitroGlob } from '../src/pages/utils.ts'
+import { type PagesContextOptions, augmentPages, createPagesContext, normalizeRoutes, pathToNitroGlob, pathToNitroGlobs } from '../src/pages/utils.ts'
 import type { RouterViewSlotProps } from '../src/pages/runtime/utils.ts'
 import { generateRouteKey } from '../src/pages/runtime/utils.ts'
 import type { NuxtPage } from 'nuxt/schema'
@@ -425,6 +425,14 @@ const pathToNitroGlobTests = {
 describe('pages:pathToNitroGlob', () => {
   it.each(Object.entries(pathToNitroGlobTests))('should convert %s to %s', (path, expected) => {
     expect(pathToNitroGlob(path)).to.equal(expected)
+  })
+})
+
+describe('pages:pathToNitroGlobs', () => {
+  it('expands simple constrained route params before converting dynamic segments to globs', () => {
+    expect(pathToNitroGlobs('/:locale(de)/account/verify')).toEqual(['/de/account/verify'])
+    expect(pathToNitroGlobs('/:locale(de|fr)/privacy-policy')).toEqual(['/de/privacy-policy', '/fr/privacy-policy'])
+    expect(pathToNitroGlobs('/:locale(de|fr)/blog/:slug')).toEqual(['/de/blog/**', '/fr/blog/**'])
   })
 })
 

--- a/packages/nuxt/test/pages.test.ts
+++ b/packages/nuxt/test/pages.test.ts
@@ -432,6 +432,7 @@ describe('pages:pathToNitroGlobs', () => {
   it('expands simple constrained route params before converting dynamic segments to globs', () => {
     expect(pathToNitroGlobs('/:locale(de)/account/verify')).toEqual(['/de/account/verify'])
     expect(pathToNitroGlobs('/:locale(de|fr)/privacy-policy')).toEqual(['/de/privacy-policy', '/fr/privacy-policy'])
+    expect(pathToNitroGlobs('/:locale(en-US|pt_BR)/about')).toEqual(['/en-US/about', '/pt_BR/about'])
     expect(pathToNitroGlobs('/:locale(de|fr)/blog/:slug')).toEqual(['/de/blog/**', '/fr/blog/**'])
   })
 })

--- a/packages/nuxt/test/route-rules.test.ts
+++ b/packages/nuxt/test/route-rules.test.ts
@@ -1,3 +1,4 @@
+import type { NuxtPage } from '@nuxt/schema'
 import { describe, expect, it } from 'vitest'
 
 import { globRouteRulesFromPages, removePagesRules } from '../src/pages/route-rules.ts'
@@ -66,7 +67,7 @@ describe('routeRules from page meta', () => {
   })
 
   it('expands constrained params from parent route records', () => {
-    const pages = [
+    const pages: NuxtPage[] = [
       {
         path: '/:locale(en-US|pt_BR)',
         children: [
@@ -75,7 +76,7 @@ describe('routeRules from page meta', () => {
             children: [
               {
                 path: 'verify',
-                rules: { robots: false },
+                rules: { prerender: true },
               },
             ],
           },
@@ -88,9 +89,9 @@ describe('routeRules from page meta', () => {
     ]
 
     expect(globRouteRulesFromPages(pages)).toEqual({
-      '/en-US/account/verify': { robots: false },
+      '/en-US/account/verify': { prerender: true },
       '/en-US/blog/**': { swr: 60 },
-      '/pt_BR/account/verify': { robots: false },
+      '/pt_BR/account/verify': { prerender: true },
       '/pt_BR/blog/**': { swr: 60 },
     })
   })

--- a/packages/nuxt/test/route-rules.test.ts
+++ b/packages/nuxt/test/route-rules.test.ts
@@ -65,6 +65,36 @@ describe('routeRules from page meta', () => {
     })
   })
 
+  it('expands constrained params from parent route records', () => {
+    const pages = [
+      {
+        path: '/:locale(en-US|pt_BR)',
+        children: [
+          {
+            path: 'account',
+            children: [
+              {
+                path: 'verify',
+                rules: { robots: false },
+              },
+            ],
+          },
+          {
+            path: 'blog/:slug',
+            rules: { swr: 60 },
+          },
+        ],
+      },
+    ]
+
+    expect(globRouteRulesFromPages(pages)).toEqual({
+      '/en-US/account/verify': { robots: false },
+      '/en-US/blog/**': { swr: 60 },
+      '/pt_BR/account/verify': { robots: false },
+      '/pt_BR/blog/**': { swr: 60 },
+    })
+  })
+
   it('removes route rules from pages', () => {
     const pages = getPages()
     removePagesRules(pages)

--- a/packages/nuxt/test/route-rules.test.ts
+++ b/packages/nuxt/test/route-rules.test.ts
@@ -40,6 +40,31 @@ describe('routeRules from page meta', () => {
     })
   })
 
+  it('does not collapse constrained params to a global rule', () => {
+    const pages = [
+      {
+        path: '/:locale(de)/account/verify',
+        rules: { robots: false },
+      },
+      {
+        path: '/:locale(de|fr)/privacy-policy',
+        rules: { robots: false },
+      },
+      {
+        path: '/:locale(de|fr)/blog/:slug',
+        rules: { swr: 60 },
+      },
+    ]
+
+    expect(globRouteRulesFromPages(pages)).toEqual({
+      '/de/account/verify': { robots: false },
+      '/de/blog/**': { swr: 60 },
+      '/de/privacy-policy': { robots: false },
+      '/fr/blog/**': { swr: 60 },
+      '/fr/privacy-policy': { robots: false },
+    })
+  })
+
   it('removes route rules from pages', () => {
     const pages = getPages()
     removePagesRules(pages)


### PR DESCRIPTION
### 🔗 Linked issue

Related to https://github.com/nuxt-modules/sitemap/issues/626

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Inline route rules currently collapse constrained route params like `/:locale(de)/account/verify` to `/**`. That can turn page-level rules from i18n compact routes, for example `defineRouteRules({ robots: false })`, into global Nitro route rules.

This expands simple constrained params before converting dynamic route segments to Nitro globs, so `/:locale(de|fr)/privacy-policy` becomes `/de/privacy-policy` and `/fr/privacy-policy` instead of `/**`.

### ✅ Verification

- `pnpm vitest run packages/nuxt/test/route-rules.test.ts packages/nuxt/test/pages.test.ts`
- `pnpm eslint packages/nuxt/src/pages/utils.ts packages/nuxt/src/pages/route-rules.ts packages/nuxt/test/pages.test.ts packages/nuxt/test/route-rules.test.ts`
- `pnpm eslint . --cache --ignore-pattern GPT_FINDINGS.md --ignore-pattern CLAUDE_FINDINGS.md`
- `pnpm build`

`pnpm lint && pnpm typecheck && pnpm build` could not complete locally because `pnpm lint` picks up pre-existing untracked `GPT_FINDINGS.md`, and `pnpm typecheck` fails outside this diff with `packages/nuxt/src/app/types/augments.ts(39,7): error TS2451: Cannot redeclare block-scoped variable '$fetch'.`