### PR TITLE
perf(nuxt): skip island-renderer chunk when no islands used

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-root.vue
+++ b/packages/nuxt/src/app/components/nuxt-root.vue
@@ -26,12 +26,7 @@ import { useRoute, useRouter } from '../composables/router'
 import { PageRouteSymbol } from '../components/injections'
 import AppComponent from '#build/app-component.mjs'
 import ErrorComponent from '#build/error-component.mjs'
-// @ts-expect-error virtual file
-import { componentIslands } from '#build/nuxt.config.mjs'
-
-const IslandRenderer = import.meta.server && componentIslands
-  ? defineAsyncComponent(() => import('./island-renderer').then(r => r.default || r))
-  : () => null
+import IslandRenderer from '#build/island-renderer.mjs'
 
 const nuxtApp = useNuxtApp()
 const onResolve = nuxtApp.deferHydration()

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -12,7 +12,7 @@ import { useNitro } from '@nuxt/kit'
 
 import { annotatePlugins, checkForCircularDependencies, hasIslandOptOutPlugins, hasParallelPlugins, hasPluginDependencies, hasPluginHooks, sortPluginsByDependsOn } from './app.ts'
 import { EXTENSION_RE } from './utils/index.ts'
-import type { NuxtOptions, NuxtTemplate } from 'nuxt/schema'
+import type { NuxtApp, NuxtOptions, NuxtTemplate } from 'nuxt/schema'
 import type { Nitro } from 'nitro/types'
 
 const defuPath = resolveModulePath('defu', { try: true, from: import.meta.url }) ?? 'defu'
@@ -50,6 +50,20 @@ export const rootComponentTemplate: NuxtTemplate = {
 export const errorComponentTemplate: NuxtTemplate = {
   filename: 'error-component.mjs',
   getContents: ctx => genExport(ctx.app.errorComponent!, ['default']),
+}
+export const islandRendererTemplate: NuxtTemplate = {
+  filename: 'island-renderer.mjs',
+  getContents (ctx) {
+    if (!shouldEnableComponentIslands(ctx.nuxt, ctx.app)) {
+      return 'export default () => null'
+    }
+
+    const islandRenderer = resolve(ctx.nuxt.options.appDir, 'components/island-renderer')
+    return [
+      'import { defineAsyncComponent } from \'vue\'',
+      `export default import.meta.server ? defineAsyncComponent(() => import(${JSON.stringify(islandRenderer)}).then(r => r.default || r)) : () => null`,
+    ].join('\n')
+  },
 }
 // TODO: Use an alias
 export const testComponentWrapperTemplate: NuxtTemplate = {
@@ -529,6 +543,20 @@ export const dollarFetchClientTemplate: NuxtTemplate = {
   },
 }
 
+function hasActiveComponentIslands (ctx: { nuxt: { options: NuxtOptions }, app: NuxtApp }) {
+  return ctx.nuxt.options.experimental.componentIslands && (
+    ctx.nuxt.options.experimental.componentIslands !== 'auto' ||
+    ctx.app.pages?.some(p => p.mode === 'server') ||
+    ctx.app.components?.some(c => c.mode === 'server' && !ctx.app.components!.some(other => other.pascalName === c.pascalName && other.mode === 'client'))
+  )
+}
+
+function shouldEnableComponentIslands (nuxt: { options: NuxtOptions }, app: NuxtApp) {
+  return nuxt.options.experimental.componentIslands && (
+    nuxt.options.dev || hasActiveComponentIslands({ nuxt, app })
+  )
+}
+
 // Allow direct access to specific exposed nuxt.config
 export const nuxtConfigTemplate: NuxtTemplate = {
   filename: 'nuxt.config.mjs',
@@ -545,24 +573,15 @@ export const nuxtConfigTemplate: NuxtTemplate = {
       baseURL: undefined,
       headers: undefined,
     }
-    // Whether island components are genuinely used by the app (server pages /
-    // server components, or islands explicitly enabled). This excludes the
-    // dev-only inflation below.
-    const componentIslandsActive = ctx.nuxt.options.experimental.componentIslands && (
-      ctx.nuxt.options.experimental.componentIslands !== 'auto' || ctx.app.pages?.some(p => p.mode === 'server') || ctx.app.components?.some(c => c.mode === 'server' && !ctx.app.components.some(other => other.pascalName === c.pascalName && other.mode === 'client'))
-    )
-    // In dev the islands handler is always wired up so Vite generates the
-    // islands module graph for HMR, regardless of actual island usage.
-    const shouldEnableComponentIslands = ctx.nuxt.options.experimental.componentIslands && (
-      ctx.nuxt.options.dev || componentIslandsActive
-    )
+    const componentIslandsActive = hasActiveComponentIslands(ctx)
+    const componentIslands = shouldEnableComponentIslands(ctx.nuxt, ctx.app)
     const nitro = useNitro() as Nitro
 
     const hasCachedRoutes = nitro.routing.routeRules.routes.some(r => r.data.isr || r.data.cache)
     const payloadExtraction = !!ctx.nuxt.options.experimental.payloadExtraction && (nitro.options.static || hasCachedRoutes || (nitro.options.prerender.routes && nitro.options.prerender.routes.length > 0) || nitro.routing.routeRules.routes.some(r => r.data.prerender))
     return [
       ...Object.entries(ctx.nuxt.options.app).map(([k, v]) => `export const ${camelCase('app-' + k)} = ${JSON.stringify(v)}`),
-      `export const componentIslands = ${shouldEnableComponentIslands}`,
+      `export const componentIslands = ${componentIslands}`,
       `export const componentIslandsActive = ${componentIslandsActive}`,
       `export const payloadExtraction = ${payloadExtraction}`,
       `export const prefetchPreloadTags = ${!!ctx.nuxt.options.experimental.prefetchPreloadTags}`,

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -55,13 +55,14 @@ export const islandRendererTemplate: NuxtTemplate = {
   filename: 'island-renderer.mjs',
   getContents (ctx) {
     if (!shouldEnableComponentIslands(ctx.nuxt, ctx.app)) {
-      return 'export default () => null'
+      return 'const IslandRenderer = () => null\nexport default IslandRenderer'
     }
 
     const islandRenderer = resolve(ctx.nuxt.options.appDir, 'components/island-renderer')
     return [
       'import { defineAsyncComponent } from \'vue\'',
-      `export default import.meta.server ? defineAsyncComponent(() => ${genDynamicImport(islandRenderer, { wrapper: false })}.then(r => r.default || r)) : () => null`,
+      `const IslandRenderer = import.meta.server ? defineAsyncComponent(() => ${genDynamicImport(islandRenderer, { wrapper: false })}.then(r => r.default || r)) : () => null`,
+      'export default IslandRenderer',
     ].join('\n')
   },
 }

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -61,7 +61,7 @@ export const islandRendererTemplate: NuxtTemplate = {
     const islandRenderer = resolve(ctx.nuxt.options.appDir, 'components/island-renderer')
     return [
       'import { defineAsyncComponent } from \'vue\'',
-      `export default import.meta.server ? defineAsyncComponent(() => import(${JSON.stringify(islandRenderer)}).then(r => r.default || r)) : () => null`,
+      `export default import.meta.server ? defineAsyncComponent(() => ${genDynamicImport(islandRenderer, { wrapper: false })}.then(r => r.default || r)) : () => null`,
     ].join('\n')
   },
 }

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -58,7 +58,7 @@ describe.skipIf(isStubbed || process.env.SKIP_BUNDLE_SIZE === 'true' || process.
     const serverDir = join(rootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!_libs'], serverDir, rootDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"70.3k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"70.2k"`)
 
     const modules = await analyzeSizes(['_libs/**/*'], serverDir, rootDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"482k"`)

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -58,7 +58,7 @@ describe.skipIf(isStubbed || process.env.SKIP_BUNDLE_SIZE === 'true' || process.
     const serverDir = join(rootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!_libs'], serverDir, rootDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"70.2k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"70.3k"`)
 
     const modules = await analyzeSizes(['_libs/**/*'], serverDir, rootDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"482k"`)


### PR DESCRIPTION
### 🔗 Linked issue

None (perf gainzzz)

### 📚 Description

This PR uses a generated `#build/island-renderer.mjs` template for the island renderer.

In default `auto` mode with no server components or server pages, the template exports a `null` component, so Vite never pulls `app/components/island-renderer` and its async chunk into the SSR build.

### Bench

Local stats (15 interleaved runs):

- vite:ssr: −56% (~ −125 ms)
- total build: −8% (~ −140 ms)

This can vary by app of course and will only applied w/o islands.
