### PR TITLE
fix(nuxt,vite): use consumer instead of name for applyToEnvironment hook

### DIFF
--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -137,7 +137,7 @@ addVitePlugin(() => ({
     }
   },
   applyToEnvironment (environment) {
-    return environment.name === 'client'
+    return environment.config.consumer === 'client'
   },
 }))
 ```
@@ -173,7 +173,7 @@ addVitePlugin(() => ({
     }
   },
   applyToEnvironment (environment) {
-    return environment.name === 'client'
+    return environment.config.consumer === 'client'
   },
 }))
 ```

--- a/docs/3.guide/5.recipes/2.vite-plugin.md
+++ b/docs/3.guide/5.recipes/2.vite-plugin.md
@@ -93,7 +93,7 @@ export default defineNuxtModule({
     addVitePlugin(() => ({
       name: 'my-client-plugin',
       applyToEnvironment (environment) {
-        return environment.name === 'client'
+        return environment.config.consumer === 'client'
       },
       // Plugin configuration
     }))

--- a/docs/4.api/5.kit/14.builder.md
+++ b/docs/4.api/5.kit/14.builder.md
@@ -56,7 +56,7 @@ export default defineNuxtModule({
     addVitePlugin(() => ({
       name: 'my-client-plugin',
       applyToEnvironment (environment) {
-        return environment.name === 'client'
+        return environment.config.consumer === 'client'
       },
       configEnvironment (name, config) {
         // This only affects the client environment
@@ -183,7 +183,7 @@ export default defineNuxtModule({
     addVitePlugin(() => ({
       name: 'my-client-plugin',
       applyToEnvironment (environment) {
-        return environment.name === 'client'
+        return environment.config.consumer === 'client'
       },
       // ... rest of your client-only plugin
     }))

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -841,7 +841,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
   if (nuxt.options.vue.runtimeCompiler) {
     addVitePlugin({
       name: 'nuxt:vue:runtime-compiler',
-      applyToEnvironment: environment => environment.name === 'client',
+      applyToEnvironment: environment => environment.config.consumer === 'client',
       enforce: 'pre',
       resolveId (id, importer) {
         if (id === 'vue') {

--- a/packages/nuxt/src/components/plugins/islands-transform.ts
+++ b/packages/nuxt/src/components/plugins/islands-transform.ts
@@ -211,7 +211,7 @@ export const ComponentsChunkPlugin = (options: ChunkPluginOptions): Plugin[] => 
     {
       name: 'nuxt:components-chunk:client',
       apply: () => !options.dev,
-      applyToEnvironment: environment => environment.name === 'client',
+      applyToEnvironment: environment => environment.config.consumer === 'client',
       buildStart () {
         for (const c of options.getComponents()) {
           if (!c.filePath || c.mode === 'server') {

--- a/packages/nuxt/src/head/module.ts
+++ b/packages/nuxt/src/head/module.ts
@@ -187,7 +187,7 @@ export default defineNuxtModule<NuxtOptions['unhead']>({
 
       addVitePlugin({
         name: 'nuxt:streaming-iife-chunk',
-        applyToEnvironment: (env: any) => env.name === 'client',
+        applyToEnvironment: (env: any) => env.config.consumer === 'client',
 
         buildStart () {
           if (nuxt.options.dev) { return }

--- a/packages/vite/src/plugins/analyze.ts
+++ b/packages/vite/src/plugins/analyze.ts
@@ -33,7 +33,7 @@ export async function AnalyzePlugin (nuxt: Nuxt): Promise<Plugin | undefined> {
       config = _config
     },
     applyToEnvironment (environment) {
-      if (environment.name !== 'client') {
+      if (environment.config.consumer !== 'client') {
         return false
       }
       return [

--- a/packages/vite/src/plugins/dev-style-ssr.ts
+++ b/packages/vite/src/plugins/dev-style-ssr.ts
@@ -12,7 +12,7 @@ export function DevStyleSSRPlugin (options: DevStyleSSRPluginOptions): Plugin {
     name: 'nuxt:dev-style-ssr',
     apply: 'serve',
     enforce: 'post',
-    applyToEnvironment: environment => environment.name === 'client',
+    applyToEnvironment: environment => environment.config.consumer === 'client',
     transform (code, id) {
       if (!isCSS(id) || !code.includes('import.meta.hot')) {
         return

--- a/packages/vite/src/plugins/environments.ts
+++ b/packages/vite/src/plugins/environments.ts
@@ -56,7 +56,7 @@ export function EnvironmentsPlugin (nuxt: Nuxt): Plugin {
       }
     },
     applyToEnvironment (environment) {
-      if (environment.name === 'client') {
+      if (environment.config.consumer === 'client') {
         return [
           ...nuxt.options.experimental.clientNodeCompat ? [NodeCompatAliasPlugin()] : [],
           {

--- a/packages/vite/src/plugins/module-preload-polyfill.ts
+++ b/packages/vite/src/plugins/module-preload-polyfill.ts
@@ -9,7 +9,7 @@ export function ModulePreloadPolyfillPlugin (): Plugin {
   let entry: string
   return {
     name: 'nuxt:module-preload-polyfill',
-    applyToEnvironment: environment => environment.name === 'client',
+    applyToEnvironment: environment => environment.config.consumer === 'client',
     configResolved (config) {
       try {
         isDisabled = config.build.modulePreload === false || config.build.modulePreload.polyfill === false

--- a/packages/vite/src/plugins/optimize-deps-hint.ts
+++ b/packages/vite/src/plugins/optimize-deps-hint.ts
@@ -158,7 +158,7 @@ export function OptimizeDepsHintPlugin (nuxt: Nuxt): Plugin {
   return {
     name: 'nuxt:optimize-deps-hint',
     apply: 'serve',
-    applyToEnvironment: environment => environment.name === 'client',
+    applyToEnvironment: environment => environment.config.consumer === 'client',
 
     resolveId: {
       order: 'pre',

--- a/packages/vite/src/plugins/runtime-paths.ts
+++ b/packages/vite/src/plugins/runtime-paths.ts
@@ -9,7 +9,7 @@ export function RuntimePathsPlugin (): Plugin {
   return {
     name: 'nuxt:runtime-paths-dep',
     enforce: 'post',
-    applyToEnvironment: environment => environment.name === 'client',
+    applyToEnvironment: environment => environment.config.consumer === 'client',
     transform (code, id, meta?: unknown) {
       const { pathname, search } = parseModuleId(id)
 

--- a/packages/vite/src/plugins/ssr-styles.ts
+++ b/packages/vite/src/plugins/ssr-styles.ts
@@ -177,7 +177,7 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
           },
         },
         generateBundle (outputOptions) {
-          if (environment.name === 'client') { return }
+          if (environment.config.consumer === 'client') { return }
 
           const emitted: Record<string, string> = {}
           const usedNames = new Set<string>()
@@ -253,7 +253,7 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
             clientCSSMap[chunk.facadeModuleId!] ||= new Set()
           }
           let chunkCSSSources: Set<string> | undefined
-          if (environment.name === 'client' && chunk.facadeModuleId) {
+          if (environment.config.consumer === 'client' && chunk.facadeModuleId) {
             const chunkSrc = relativeToSrcDir(chunk.facadeModuleId)
             if (chunkSrc) {
               chunkCSSSources = cssSourcesByChunkSrc.get(chunkSrc)
@@ -266,7 +266,7 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
           for (const moduleId of [chunk.facadeModuleId, ...chunk.moduleIds].filter(Boolean) as string[]) {
             // 'Teleport' CSS chunks that made it into the bundle on the client side
             // to be inlined on server rendering
-            if (environment.name === 'client') {
+            if (environment.config.consumer === 'client') {
               const moduleMap = clientCSSMap[moduleId] ||= new Set()
               if (isCSS(moduleId)) {
                 chunkCSSSources?.add(stripQuery(moduleId))
@@ -301,14 +301,14 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
         transform: {
           filter: {
             id: {
-              include: environment.name === 'client'
+              include: environment.config.consumer === 'client'
                 ? new RegExp('^' + escapeStringRegexp(entry) + '$')
                 : undefined,
-              exclude: environment.name === 'client' ? [] : [/\?.*macro=/, /\?.*nuxt_component=/],
+              exclude: environment.config.consumer === 'client' ? [] : [/\?.*macro=/, /\?.*nuxt_component=/],
             },
           },
           async handler (code, id, meta?: unknown) {
-            if (environment.name === 'client') {
+            if (environment.config.consumer === 'client') {
               // We will either teleport global CSS to the 'entry' chunk on the server side
               // or include it here in the client build so it is emitted in the CSS.
               if (id === entry && (options.shouldInline === true || (typeof options.shouldInline === 'function' && options.shouldInline(id)))) {

--- a/packages/vite/src/plugins/stable-entry.ts
+++ b/packages/vite/src/plugins/stable-entry.ts
@@ -21,7 +21,7 @@ export function StableEntryPlugin (nuxt: Nuxt): Plugin {
     name: 'nuxt:stable-entry',
     apply: () => !nuxt.options.dev && nuxt.options.experimental.entryImportMap,
     applyToEnvironment (environment) {
-      if (environment.name !== 'client') {
+      if (environment.config.consumer !== 'client') {
         return false
       }
       if (environment.config.build.target) {

--- a/packages/vite/src/plugins/type-check.ts
+++ b/packages/vite/src/plugins/type-check.ts
@@ -9,7 +9,7 @@ export function TypeCheckPlugin (nuxt: Nuxt): Plugin {
   let entry: string
   return {
     name: 'nuxt:type-check',
-    applyToEnvironment: environment => environment.name === 'client' && !environment.config.isProduction,
+    applyToEnvironment: environment => environment.config.consumer === 'client' && !environment.config.isProduction,
     apply: () => {
       return !nuxt.options.test && nuxt.options.typescript.typeCheck === true
     },

--- a/packages/vite/test/optimize-deps-hint.test.ts
+++ b/packages/vite/test/optimize-deps-hint.test.ts
@@ -177,11 +177,11 @@ describe('OptimizeDepsHintPlugin', () => {
     expect(plugin.apply).toBe('serve')
   })
 
-  it('applies only to client environment', () => {
+  it('applies only to client-consumer environments', () => {
     const plugin = OptimizeDepsHintPlugin(createNuxt()) as any
-    expect(plugin.applyToEnvironment({ name: 'client' })).toBe(true)
-    expect(plugin.applyToEnvironment({ name: 'server' })).toBe(false)
-    expect(plugin.applyToEnvironment({ name: 'ssr' })).toBe(false)
+    expect(plugin.applyToEnvironment({ name: 'client', config: { consumer: 'client' } })).toBe(true)
+    expect(plugin.applyToEnvironment({ name: 'ssr', config: { consumer: 'server' } })).toBe(false)
+    expect(plugin.applyToEnvironment({ name: 'custom', config: { consumer: 'client' } })).toBe(true)
   })
 
   it('early returns when no optimizer', () => {


### PR DESCRIPTION
…nment

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

NEeds also the same change for V4 if we're using any vite env API

**context**: 

I'm currently working on providing vite-based tools (spoiler: Storybook) within a single dev server using environment API. This would allow users to get tools within a single dev server, alongside the app, without having to start another dev server/process which would take RAM, CPU, load another file watcher etc...

When creating an environment that has another name which clones the user config. Nuxt plugins doesn't runs in the second client environment, even if it is consumed by a browser. 

why ? Because most meta-frameworks do `environment.name === 'client'` instead of `environment.config.consumer === 'client'`.

When the plugin container a plugin `applyToEnvironment` hook, the hook receives:

```ts
{
  name: 'second-client',
   config: [
     consumer: 'client' // can be cleint or server
  }
}
```

and `applyToEnvironment` returns `false`: the plugin won't run.

The fix is to simply migrate every `environment.name === 'client'` to `environment.config.consumer === 'client'`.


<img width="990" height="727" alt="image" src="https://github.com/user-attachments/assets/c6d96b0e-f5ea-4549-8ff6-9ae2aaba3068" />


### What about server ? 

I didn't migrate `environment.name === 'server'` because most of the time, we actually do want to apply plugins for only the Vite Dev Server environmeent.

But this needs to get a discussion within the vite ecosystem




<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
