### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -231,8 +231,8 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
 
         const routeRules = getRouteRules({ path: to.path })
 
-        if (routeRules.appLayout && to.meta.layout == null) {
-          to.meta.layout = routeRules.appLayout as Exclude<PageMeta['layout'], Ref | false>
+        if (routeRules.appLayout !== undefined && to.meta.layout == null) {
+          to.meta.layout = routeRules.appLayout as Exclude<PageMeta['layout'], Ref>
         }
 
         if (routeRules.appMiddleware) {

--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -231,6 +231,10 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
 
         const routeRules = getRouteRules({ path: to.path })
 
+        if (routeRules.appLayout && to.meta.layout == null) {
+          to.meta.layout = routeRules.appLayout as Exclude<PageMeta['layout'], Ref | false>
+        }
+
         if (routeRules.appMiddleware) {
           for (const key in routeRules.appMiddleware) {
             if (routeRules.appMiddleware[key]) {

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -106,6 +106,7 @@ describe('route rules', () => {
   it('should set layout defined in routeRules config', async () => {
     const html = await $fetch<string>('/route-rules/layout')
     expect(html).toContain('Custom Layout')
+    expect(html).toContain('data-testid="route-meta-layout">custom</div>')
   })
 
   it('should not extract payload for `ssr: false` routes with useAsyncData (#34279)', async () => {

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -92,7 +92,7 @@ describe.skipIf(isStubbed || process.env.SKIP_BUNDLE_SIZE === 'true' || process.
     const serverDir = join(pagesRootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!_libs'], serverDir, pagesRootDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"172k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"173k"`)
 
     const modules = await analyzeSizes(['_libs/**/*'], serverDir, pagesRootDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"483k"`)

--- a/test/fixtures/basic/app/pages/route-rules/layout.vue
+++ b/test/fixtures/basic/app/pages/route-rules/layout.vue
@@ -1,5 +1,9 @@
 <template>
   <div>
     <div>Should use layout set in route-rules</div>
+    <div data-testid="route-meta-layout">{{ route.meta.layout }}</div>
   </div>
 </template>
+<script setup lang="ts">
+const route = useRoute()
+</script>

--- a/test/fixtures/basic/app/pages/route-rules/layout.vue
+++ b/test/fixtures/basic/app/pages/route-rules/layout.vue
@@ -1,9 +1,12 @@
 <template>
   <div>
     <div>Should use layout set in route-rules</div>
-    <div data-testid="route-meta-layout">{{ route.meta.layout }}</div>
+    <div data-testid="route-meta-layout">
+      {{ route.meta.layout }}
+    </div>
   </div>
 </template>
+
 <script setup lang="ts">
 const route = useRoute()
 </script>


### PR DESCRIPTION
### Linked issue

closes #34305

### Description

When `appLayout` is set via route rules, `route.meta.layout` was left `undefined` even though the `NuxtLayout` component correctly resolved and rendered the layout. This caused inconsistencies for middleware, plugins, and components that check `route.meta.layout`.

**Root cause:** The `NuxtLayout` component has a fallback chain (line 64 of `nuxt-layout.ts`) that correctly resolves the layout from `routeRulesMatcher`, but `route.meta.layout` itself was never populated with the route rules' `appLayout` value.

**Fix:** In the router's `beforeEach` hook, after fetching route rules, set `to.meta.layout` from `routeRules.appLayout` when the page hasn't explicitly defined a layout via `definePageMeta`. This mirrors the existing pattern for `appMiddleware` in the same hook.

The condition `to.meta.layout == null` ensures:
- Pages with explicit layout keep their explicit layout
- Pages with `layout: false` keep layout disabled
- Pages without any layout definition get the route rules' `appLayout`

### Changes

- `packages/nuxt/src/pages/runtime/plugins/router.ts` — Populate `route.meta.layout` from route rules' `appLayout`
- `test/fixtures/basic/app/pages/route-rules/layout.vue` — Verify `route.meta.layout` in SSR output
- `test/basic.test.ts` — Assert `route.meta.layout` equals the configured `appLayout` value
