### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/packages/schema/src/config/vite.ts
+++ b/packages/schema/src/config/vite.ts
@@ -71,6 +71,7 @@ export default defineResolvers({
     vueJsx: {
       $resolve: async (val, get) => {
         return {
+          defineComponentName: ['defineComponent', 'defineNuxtComponent'],
           // TODO: investigate type divergence between types for @vue/compiler-core and @vue/babel-plugin-jsx
           isCustomElement: (await get('vue')).compilerOptions?.isCustomElement as undefined | ((tag: string) => boolean),
           ...typeof val === 'object' ? val : {},

--- a/packages/schema/test/vite.spec.ts
+++ b/packages/schema/test/vite.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest'
+import { applyDefaults } from 'untyped'
+
+import { NuxtConfigSchema } from '../src/index.ts'
+import type { NuxtOptions } from '../src/index.ts'
+
+vi.mock('node:fs', () => ({
+  existsSync: (id: string) => id.endsWith('app'),
+}))
+
+describe('vite.vueJsx defaults', () => {
+  it('enables HMR for defineNuxtComponent in TSX files', async () => {
+    const result = await applyDefaults(NuxtConfigSchema, {})
+
+    expect((result as unknown as NuxtOptions).vite.vueJsx?.defineComponentName).toEqual([
+      'defineComponent',
+      'defineNuxtComponent',
+    ])
+  })
+
+  it('respects a user-defined component name list', async () => {
+    const result = await applyDefaults(NuxtConfigSchema, {
+      vite: {
+        vueJsx: {
+          defineComponentName: ['defineCustomComponent'],
+        },
+      },
+    })
+
+    expect((result as unknown as NuxtOptions).vite.vueJsx?.defineComponentName).toEqual([
+      'defineCustomComponent',
+    ])
+  })
+})


### PR DESCRIPTION
## Summary\n\n- Add  to Nuxt's default \n- Keep user-provided  lists authoritative\n- Add schema coverage for the default and override behavior\n\nFixes #35465.\n\n## Testing\n\n- Scope: 8 of 30 workspace projects
packages/ui-templates build$ vite build
packages/ui-templates build: vite v8.1.0 building client environment for production...
packages/ui-templates build: [2K
packages/ui-templates build: transforming...✓ 13 modules transformed.
packages/ui-templates build: rendering chunks...
packages/ui-templates build: Processing error-404
packages/ui-templates build: [32mInlined 3.41 kB (31% of original 10.92 kB) of assets/styles-Bmd_x4Hz.css.[39m
packages/ui-templates build: Time 8ms
packages/ui-templates build: Processing error-500
packages/ui-templates build: [32mInlined 2.98 kB (27% of original 10.92 kB) of assets/styles-Bmd_x4Hz.css.[39m
packages/ui-templates build: Time 4ms
packages/ui-templates build: Processing loading
packages/ui-templates build: [32mInlined 510 bytes (51% of original 999 bytes) of inline CSS.[39m
packages/ui-templates build: [32mInlined 3.54 kB (32% of original 10.92 kB) of assets/styles-Bmd_x4Hz.css.[39m
packages/ui-templates build: Time 8ms
packages/ui-templates build: Processing welcome
packages/ui-templates build: [32mInlined 6.80 kB (62% of original 10.92 kB) of assets/styles-Bmd_x4Hz.css.[39m
packages/ui-templates build: Time 4ms
packages/ui-templates build: Processing spa-loading-icon
packages/ui-templates build: computing gzip size...
packages/ui-templates build: dist/index.html                              0.74 kB │ gzip: 0.45 kB
packages/ui-templates build: dist/templates/spa-loading-icon/index.html   0.74 kB │ gzip: 0.43 kB
packages/ui-templates build: dist/templates/error-500/index.html          0.91 kB │ gzip: 0.51 kB
packages/ui-templates build: dist/templates/error-404/index.html          1.12 kB │ gzip: 0.59 kB
packages/ui-templates build: dist/templates/loading/index.html            8.59 kB │ gzip: 3.57 kB
packages/ui-templates build: dist/templates/welcome/index.html           18.84 kB │ gzip: 5.55 kB
packages/ui-templates build: dist/assets/styles-Bmd_x4Hz.css             11.18 kB │ gzip: 3.27 kB
packages/ui-templates build: dist/assets/styles-CBwjpsHb.js               0.69 kB │ gzip: 0.39 kB
packages/ui-templates build: ✓ built in 452ms
packages/ui-templates build: Done
packages/schema build$ tsdown
packages/schema build: ℹ tsdown v0.22.3 powered by rolldown v1.1.3
packages/schema build: ℹ config file: /Users/barry/Documents/Codex/2026-06-14/github-issue-pr/work/nuxt/packages/schema/tsdown.config.ts 
packages/schema build: ℹ entry: src/index.ts, src/builder-env.ts
packages/schema build: ℹ target: node14.18.0
packages/schema build: ℹ tsconfig: ../../tsconfig.json
packages/schema build: ℹ Build start
packages/schema build: ℹ Cleaning 4 files
packages/schema build: ℹ dist/index.mjs           46.84 kB │ gzip: 13.64 kB
packages/schema build: ℹ dist/builder-env.mjs      0.10 kB │ gzip:  0.10 kB
packages/schema build: ℹ dist/index.d.mts        110.68 kB │ gzip: 30.82 kB
packages/schema build: ℹ dist/builder-env.d.mts   10.43 kB │ gzip:  2.77 kB
packages/schema build: ℹ 4 files, total: 168.06 kB
packages/schema build: ✔ Build complete in 103ms
packages/schema build: Done
packages/kit build$ tsdown
packages/kit build: ℹ tsdown v0.22.3 powered by rolldown v1.1.3
packages/kit build: ℹ config file: /Users/barry/Documents/Codex/2026-06-14/github-issue-pr/work/nuxt/packages/kit/tsdown.config.ts 
packages/kit build: ℹ entry: src/index.ts
packages/kit build: ℹ target: node18.12.0
packages/kit build: ℹ tsconfig: ../../tsconfig.json
packages/kit build: ℹ Build start
packages/kit build: ℹ Cleaning 2 files
packages/kit build: ℹ dist/index.mjs    82.69 kB │ gzip: 21.18 kB
packages/kit build: ℹ dist/index.d.mts  27.37 kB │ gzip:  7.19 kB
packages/kit build: ℹ 2 files, total: 110.06 kB
packages/kit build: ✔ Build complete in 86ms
packages/kit build: Done
packages/nuxt build$ tsdown
packages/nitro-server build$ tsdown
packages/nitro-server build: ℹ tsdown v0.22.3 powered by rolldown v1.1.3
packages/nuxt build: ℹ tsdown v0.22.3 powered by rolldown v1.1.3
packages/nitro-server build: ℹ config file: /Users/barry/Documents/Codex/2026-06-14/github-issue-pr/work/nuxt/packages/nitro-server/tsdown.config.ts 
packages/nitro-server build: ℹ entry: src/index.ts, src/h3.ts
packages/nitro-server build: ℹ target: node22.19.0
packages/nitro-server build: ℹ tsconfig: ../../tsconfig.json
packages/nitro-server build: ℹ entry: src/runtime/handlers/error.ts, src/runtime/handlers/island.ts, src/runtime/handlers/renderer.ts, src/runtime/middleware/base-url.ts, src/runtime/middleware/no-ssr.ts, src/runtime/plugins/dev-server-logs.ts, src/runtime/templates/error-500.ts, src/runtime/utils/app-config.ts, src/runtime/utils/cache-driver.mjs, src/runtime/utils/cache.ts, src/runtime/utils/config.ts, src/runtime/utils/dev.ts, src/runtime/utils/error.ts, src/runtime/utils/paths.ts, src/runtime/utils/renderer/app.ts, src/runtime/utils/renderer/build-files.ts, src/runtime/utils/renderer/inline-styles.ts, src/runtime/utils/renderer/islands.ts, src/runtime/utils/renderer/payload.ts
packages/nitro-server build: ℹ target: node22.19.0
packages/nitro-server build: ℹ tsconfig: ../../tsconfig.json
packages/nitro-server build: ℹ Build start
packages/nitro-server build: ℹ Cleaning 36 files
packages/nitro-server build: ℹ dist/runtime/utils/dev.mjs                      27.89 kB │ gzip: 7.08 kB
packages/nitro-server build: ℹ dist/runtime/handlers/renderer.mjs              25.09 kB │ gzip: 6.23 kB
packages/nitro-server build: ℹ dist/runtime/handlers/island.mjs                 5.97 kB │ gzip: 2.04 kB
packages/nitro-server build: ℹ dist/runtime/templates/error-500.mjs             5.05 kB │ gzip: 2.06 kB
packages/nitro-server build: ℹ dist/runtime/utils/renderer/islands.mjs          4.33 kB │ gzip: 1.39 kB
packages/nitro-server build: ℹ dist/runtime/utils/renderer/build-files.mjs      3.72 kB │ gzip: 1.20 kB
packages/nitro-server build: ℹ dist/runtime/handlers/error.mjs                  3.45 kB │ gzip: 1.28 kB
packages/nitro-server build: ℹ dist/runtime/plugins/dev-server-logs.mjs         3.27 kB │ gzip: 1.44 kB
packages/nitro-server build: ℹ dist/runtime/utils/renderer/app.mjs              2.14 kB │ gzip: 0.90 kB
packages/nitro-server build: ℹ dist/runtime/utils/cache.mjs                     1.91 kB │ gzip: 0.69 kB
packages/nitro-server build: ℹ dist/runtime/utils/renderer/payload.mjs          1.88 kB │ gzip: 0.85 kB
packages/nitro-server build: ℹ dist/runtime/utils/cache-driver.mjs              1.12 kB │ gzip: 0.55 kB
packages/nitro-server build: ℹ dist/runtime/utils/error.mjs                     0.82 kB │ gzip: 0.42 kB
packages/nitro-server build: ℹ dist/runtime/middleware/base-url.mjs             0.82 kB │ gzip: 0.45 kB
packages/nitro-server build: ℹ dist/runtime/utils/app-config.mjs                0.76 kB │ gzip: 0.35 kB
packages/nitro-server build: ℹ dist/runtime/utils/paths.mjs                     0.66 kB │ gzip: 0.29 kB
packages/nitro-server build: ℹ dist/runtime/utils/renderer/inline-styles.mjs    0.50 kB │ gzip: 0.30 kB
packages/nitro-server build: ℹ dist/runtime/middleware/no-ssr.mjs               0.30 kB │ gzip: 0.21 kB
packages/nitro-server build: ℹ dist/runtime/utils/config.mjs                    0.12 kB │ gzip: 0.11 kB
packages/nitro-server build: ℹ dist/runtime/nuxt/src/app/island-hash.mjs        0.67 kB │ gzip: 0.41 kB
packages/nitro-server build: ℹ dist/runtime/nuxt/src/app/internal/tracing.mjs   0.57 kB │ gzip: 0.32 kB
packages/nitro-server build: ℹ 21 files, total: 91.06 kB
packages/nitro-server build: ✔ Build complete in 61ms
packages/nitro-server build: src/runtime/handlers/renderer.ts (38:34) [33m[UNRESOLVED_IMPORT] [0mCould not resolve '#internal/streaming-iife-chunk.mjs' in src/runtime/handlers/renderer.ts
packages/nitro-server build:     [38;5;246m╭[0m[38;5;246m─[0m[38;5;246m[[0m src/runtime/handlers/renderer.ts:38:35 [38;5;246m][0m
packages/nitro-server build:     [38;5;246m│[0m
packages/nitro-server build:  [38;5;246m38 │[0m [38;5;249mi[0m[38;5;249mm[0m[38;5;249mp[0m[38;5;249mo[0m[38;5;249mr[0m[38;5;249mt[0m[38;5;249m [0m[38;5;249m{[0m[38;5;249m [0m[38;5;249mi[0m[38;5;249mi[0m[38;5;249mf[0m[38;5;249me[0m[38;5;249mC[0m[38;5;249mh[0m[38;5;249mu[0m[38;5;249mn[0m[38;5;249mk[0m[38;5;249mF[0m[38;5;249mi[0m[38;5;249ml[0m[38;5;249me[0m[38;5;249mN[0m[38;5;249ma[0m[38;5;249mm[0m[38;5;249me[0m[38;5;249m [0m[38;5;249m}[0m[38;5;249m [0m[38;5;249mf[0m[38;5;249mr[0m[38;5;249mo[0m[38;5;249mm[0m[38;5;249m [0m'#internal/streaming-iife-chunk.mjs'
packages/nitro-server build:  [38;5;240m   │[0m                                   ──────────────────┬─────────────────  
packages/nitro-server build:  [38;5;240m   │[0m                                                     ╰─────────────────── Module not found, treating it as an external dependency
packages/nitro-server build: [38;5;246m────╯[0m
packages/nitro-server build: src/runtime/handlers/renderer.ts (70:20) [33m[UNRESOLVED_IMPORT] [0mCould not resolve '#internal/nuxt/island-renderer.mjs' in src/runtime/handlers/renderer.ts
packages/nitro-server build:     [38;5;246m╭[0m[38;5;246m─[0m[38;5;246m[[0m src/runtime/handlers/renderer.ts:70:21 [38;5;246m][0m
packages/nitro-server build:     [38;5;246m│[0m
packages/nitro-server build:  [38;5;246m70 │[0m [38;5;249m [0m[38;5;249m [0m[38;5;249m [0m[38;5;249m [0m[38;5;249m [0m[38;5;249m [0m[38;5;249mr[0m[38;5;249me[0m[38;5;249mt[0m[38;5;249mu[0m[38;5;249mr[0m[38;5;249mn[0m[38;5;249m [0m[38;5;249mi[0m[38;5;249mm[0m[38;5;249mp[0m[38;5;249mo[0m[38;5;249mr[0m[38;5;249mt[0m[38;5;249m([0m'#internal/nuxt/island-renderer.mjs'[38;5;249m)[0m[38;5;249m.[0m[38;5;249mt[0m[38;5;249mh[0m[38;5;249me[0m[38;5;249mn[0m[38;5;249m([0m[38;5;249mr[0m[38;5;249m [0m[38;5;249m=[0m[38;5;249m>[0m[38;5;249m [0m[38;5;249mr[0m[38;5;249m.[0m[38;5;249md[0m[38;5;249me[0m[38;5;249mf[0m[38;5;249ma[0m[38;5;249mu[0m[38;5;249ml[0m[38;5;249mt[0m[38;5;249m.[0m[38;5;249mf[0m[38;5;249me[0m[38;5;249mt[0m[38;5;249mc[0m[38;5;249mh[0m[38;5;249m([0m[38;5;249mr[0m[38;5;249me[0m[38;5;249mq[0m[38;5;249mu[0m[38;5;249me[0m[38;5;249ms[0m[38;5;249mt[0m[38;5;249m)[0m[38;5;249m)[0m
packages/nitro-server build:  [38;5;240m   │[0m                     ──────────────────┬─────────────────  
packages/nitro-server build:  [38;5;240m   │[0m                                       ╰─────────────────── Module not found, treating it as an external dependency
packages/nitro-server build: [38;5;246m────╯[0m
packages/nitro-server build: ℹ dist/index.mjs    42.86 kB │ gzip: 12.33 kB
packages/nitro-server build: ℹ dist/h3.mjs        0.29 kB │ gzip:  0.14 kB
packages/nitro-server build: ℹ dist/index.d.mts  11.12 kB │ gzip:  2.19 kB
packages/nitro-server build: ℹ dist/h3.d.mts      0.34 kB │ gzip:  0.16 kB
packages/nitro-server build: ℹ 4 files, total: 54.61 kB
packages/nitro-server build: ✔ Build complete in 64ms
packages/nitro-server build: Done
packages/nuxt build: ℹ config file: /Users/barry/Documents/Codex/2026-06-14/github-issue-pr/work/nuxt/packages/nuxt/tsdown.config.ts 
packages/nuxt build: ℹ entry: src/index.ts
packages/nuxt build: ℹ target: node22.19.0
packages/nuxt build: ℹ tsconfig: ../../tsconfig.json
packages/nuxt build: ℹ entry: src/app/config.ts, src/app/entry-spa.ts, src/app/entry.async.ts, src/app/entry.ts, src/app/index.ts, src/app/island-hash.ts, src/app/nuxt.ts, src/app/types.ts, src/app/utils.ts, src/app/compat/capi.ts, src/app/compat/idle-callback.ts, src/app/compat/interval.ts, src/app/compat/vue-demi.ts, src/app/components/client-fallback.client.ts, src/app/components/client-fallback.server.ts, src/app/components/client-only.ts, src/app/components/dev-only.ts, src/app/components/index.ts, src/app/components/injections.ts, src/app/components/island-renderer.ts, src/app/components/nuxt-announcer.ts, src/app/components/nuxt-island.ts, src/app/components/nuxt-layout.ts, src/app/components/nuxt-link.ts, src/app/components/nuxt-loading-indicator.ts, src/app/components/nuxt-route-announcer.ts, src/app/components/nuxt-stubs.ts, src/app/components/nuxt-teleport-island-component.ts, src/app/components/nuxt-teleport-island-slot.ts, src/app/components/route-provider.ts, src/app/components/server-placeholder.ts, src/app/components/test-component-wrapper.ts, src/app/components/utils.ts, src/app/internal/tracing.ts, src/app/composables/announcer.ts, src/app/composables/asyncContext.ts, src/app/composables/asyncData.ts, src/app/composables/chunk.ts, src/app/composables/component.ts, src/app/composables/cookie.ts, src/app/composables/error.ts, src/app/composables/fetch.ts, src/app/composables/head.ts, src/app/composables/hydrate.ts, src/app/composables/id.ts, src/app/composables/index.ts, src/app/composables/lazy-hydration.ts, src/app/composables/loading-indicator.ts, src/app/composables/manifest.ts, src/app/composables/once.ts, src/app/composables/pages.ts, src/app/composables/payload.ts, src/app/composables/preload.ts, src/app/composables/preview.ts, src/app/composables/ready.ts, src/app/composables/route-announcer.ts, src/app/composables/router.ts, src/app/composables/runtime-hook.ts, src/app/composables/script-stubs.ts, src/app/composables/ssr.ts, src/app/composables/state.ts, src/app/composables/url.ts, src/app/middleware/route-rules.ts, src/app/types/augments.ts, src/app/plugins/browser-devtools-timing.client.ts, src/app/plugins/check-if-layout-used.ts, src/app/plugins/check-outdated-build.client.ts, src/app/plugins/chunk-reload-crawler.client.ts, src/app/plugins/chunk-reload-immediate.client.ts, src/app/plugins/chunk-reload.client.ts, src/app/plugins/cross-origin-prefetch.client.ts, src/app/plugins/debug-hooks.ts, src/app/plugins/dev-server-logs.ts, src/app/plugins/navigation-repaint.client.ts, src/app/plugins/payload.client.ts, src/app/plugins/prefetch-preload-tags.server.ts, src/app/plugins/preload.server.ts, src/app/plugins/restore-state.client.ts, src/app/plugins/revive-payload.client.ts, src/app/plugins/revive-payload.server.ts, src/app/plugins/router.ts, src/app/plugins/utils.ts, src/app/plugins/view-transitions.client.ts, src/app/plugins/warn.dev.server.ts, src/compiler/runtime/index.ts, src/components/runtime/client-component.ts, src/components/runtime/lazy-hydrated-component.ts, src/components/runtime/server-component.ts, src/head/runtime/components.ts, src/head/runtime/composables.ts, src/head/runtime/install-client-head.ts, src/head/runtime/island-head.ts, src/head/runtime/types.ts, src/pages/runtime/component-stub.ts, src/pages/runtime/composables.ts, src/pages/runtime/index.ts, src/pages/runtime/page-placeholder.ts, src/pages/runtime/page.ts, src/pages/runtime/router.options.ts, src/pages/runtime/utils.ts, src/pages/runtime/validate.ts, src/head/runtime/plugins/unhead-stream.client.ts, src/head/runtime/plugins/unhead.client.ts, src/head/runtime/plugins/unhead.server.ts, src/pages/runtime/plugins/check-if-page-unused.ts, src/pages/runtime/plugins/prefetch.client.ts, src/pages/runtime/plugins/prerender.server.ts, src/pages/runtime/plugins/router.ts
packages/nuxt build: ℹ target: node22.19.0
packages/nuxt build: ℹ tsconfig: ../../tsconfig.json
packages/nuxt build: ℹ Build start
packages/nuxt build: ℹ dist/index.mjs    322.50 kB │ gzip: 80.30 kB
packages/nuxt build: ℹ dist/index.d.mts    0.39 kB │ gzip:  0.21 kB
packages/nuxt build: ℹ 2 files, total: 322.89 kB
packages/nuxt build: ✔ Build complete in 136ms
packages/nuxt build: ℹ dist/app/composables/asyncData.js                        19.80 kB │ gzip: 5.21 kB
packages/nuxt build: ℹ dist/app/components/nuxt-link.js                         13.49 kB │ gzip: 4.00 kB
packages/nuxt build: ℹ dist/app/components/nuxt-island.js                       11.12 kB │ gzip: 3.47 kB
packages/nuxt build: ℹ dist/app/nuxt.js                                         10.49 kB │ gzip: 3.27 kB
packages/nuxt build: ℹ dist/pages/runtime/plugins/router.js                     10.34 kB │ gzip: 3.03 kB
packages/nuxt build: ℹ dist/app/composables/router.js                            9.31 kB │ gzip: 3.24 kB
packages/nuxt build: ℹ dist/pages/runtime/page.js                                8.82 kB │ gzip: 2.54 kB
packages/nuxt build: ℹ dist/app/composables/cookie.js                            8.11 kB │ gzip: 2.58 kB
packages/nuxt build: ℹ dist/head/runtime/components.js                           7.64 kB │ gzip: 1.92 kB
packages/nuxt build: ℹ dist/app/plugins/router.js                                6.99 kB │ gzip: 2.35 kB
packages/nuxt build: ℹ dist/app/composables/payload.js                           6.08 kB │ gzip: 2.04 kB
packages/nuxt build: ℹ dist/app/components/nuxt-layout.js                        5.75 kB │ gzip: 1.87 kB
packages/nuxt build: ℹ dist/app/components/utils.js                              5.56 kB │ gzip: 2.17 kB
packages/nuxt build: ℹ dist/app/composables/script-stubs.js                      5.13 kB │ gzip: 0.99 kB
packages/nuxt build: ℹ dist/app/components/client-only.js                        4.55 kB │ gzip: 1.55 kB
packages/nuxt build: ℹ dist/app/composables/fetch.js                             4.37 kB │ gzip: 1.66 kB
packages/nuxt build: ℹ dist/app/index.js                                         3.71 kB │ gzip: 0.95 kB
packages/nuxt build: ℹ dist/app/composables/loading-indicator.js                 3.63 kB │ gzip: 1.17 kB
packages/nuxt build: ℹ dist/app/composables/ssr.js                               3.25 kB │ gzip: 1.28 kB
packages/nuxt build: ℹ dist/app/plugins/view-transitions.client.js               3.22 kB │ gzip: 1.01 kB
packages/nuxt build: ℹ dist/components/runtime/lazy-hydrated-component.js        2.87 kB │ gzip: 0.91 kB
packages/nuxt build: ℹ dist/app/composables/component.js                         2.71 kB │ gzip: 1.08 kB
packages/nuxt build: ℹ dist/app/entry.js                                         2.71 kB │ gzip: 0.99 kB
packages/nuxt build: ℹ dist/app/composables/index.js                             2.58 kB │ gzip: 0.71 kB
packages/nuxt build: ℹ dist/app/composables/error.js                             2.46 kB │ gzip: 1.01 kB
packages/nuxt build: ℹ dist/components/runtime/client-component.js               2.40 kB │ gzip: 0.94 kB
packages/nuxt build: ℹ dist/app/plugins/payload.client.js                        2.24 kB │ gzip: 0.89 kB
packages/nuxt build: ℹ dist/app/components/client-fallback.server.js             2.23 kB │ gzip: 0.92 kB
packages/nuxt build: ℹ dist/components/runtime/server-component.js               2.07 kB │ gzip: 0.80 kB
packages/nuxt build: ℹ dist/pages/runtime/router.options.js                      2.03 kB │ gzip: 0.80 kB
packages/nuxt build: ℹ dist/head/runtime/composables.js                          2.00 kB │ gzip: 0.57 kB
packages/nuxt build: ℹ dist/app/composables/preload.js                           1.99 kB │ gzip: 0.74 kB
packages/nuxt build: ℹ dist/app/config.js                                        1.97 kB │ gzip: 0.75 kB
packages/nuxt build: ℹ dist/app/components/nuxt-loading-indicator.js             1.85 kB │ gzip: 0.79 kB
packages/nuxt build: ℹ dist/app/composables/preview.js                           1.77 kB │ gzip: 0.70 kB
packages/nuxt build: ℹ dist/app/composables/state.js                             1.76 kB │ gzip: 0.73 kB
packages/nuxt build: ℹ dist/app/composables/route-announcer.js                   1.74 kB │ gzip: 0.65 kB
packages/nuxt build: ℹ dist/app/composables/manifest.js                          1.70 kB │ gzip: 0.78 kB
packages/nuxt build: ℹ dist/app/plugins/revive-payload.client.js                 1.67 kB │ gzip: 0.74 kB
packages/nuxt build: ℹ dist/app/plugins/dev-server-logs.js                       1.67 kB │ gzip: 0.80 kB
packages/nuxt build: ℹ dist/pages/runtime/composables.js                         1.51 kB │ gzip: 0.79 kB
packages/nuxt build: ℹ dist/app/island-hash.js                                   1.50 kB │ gzip: 0.74 kB
packages/nuxt build: ℹ dist/app/composables/announcer.js                         1.50 kB │ gzip: 0.60 kB
packages/nuxt build: ℹ dist/app/components/nuxt-teleport-island-slot.js          1.49 kB │ gzip: 0.63 kB
packages/nuxt build: ℹ dist/app/components/route-provider.js                     1.49 kB │ gzip: 0.68 kB
packages/nuxt build: ℹ dist/pages/runtime/plugins/prerender.server.js            1.49 kB │ gzip: 0.65 kB
packages/nuxt build: ℹ dist/app/composables/once.js                              1.43 kB │ gzip: 0.63 kB
packages/nuxt build: ℹ dist/app/components/island-renderer.js                    1.40 kB │ gzip: 0.66 kB
packages/nuxt build: ℹ dist/app/components/nuxt-teleport-island-component.js     1.40 kB │ gzip: 0.63 kB
packages/nuxt build: ℹ dist/app/plugins/revive-payload.server.js                 1.40 kB │ gzip: 0.54 kB
packages/nuxt build: ℹ dist/app/components/nuxt-route-announcer.js               1.39 kB │ gzip: 0.63 kB
packages/nuxt build: ℹ dist/app/components/nuxt-announcer.js                     1.35 kB │ gzip: 0.62 kB
packages/nuxt build: ℹ dist/app/components/client-fallback.client.js             1.33 kB │ gzip: 0.57 kB
packages/nuxt build: ℹ dist/pages/runtime/plugins/prefetch.client.js             1.26 kB │ gzip: 0.54 kB
packages/nuxt build: ℹ dist/app/composables/chunk.js                             1.22 kB │ gzip: 0.56 kB
packages/nuxt build: ℹ dist/app/utils.js                                         1.20 kB │ gzip: 0.57 kB
packages/nuxt build: ℹ dist/app/plugins/check-outdated-build.client.js           1.18 kB │ gzip: 0.56 kB
packages/nuxt build: ℹ dist/app/components/test-component-wrapper.js             1.18 kB │ gzip: 0.63 kB
packages/nuxt build: ℹ dist/app/plugins/cross-origin-prefetch.client.js          1.18 kB │ gzip: 0.59 kB
packages/nuxt build: ℹ dist/pages/runtime/utils.js                               1.13 kB │ gzip: 0.56 kB
packages/nuxt build: ℹ dist/app/plugins/prefetch-preload-tags.server.js          1.12 kB │ gzip: 0.55 kB
packages/nuxt build: ℹ dist/pages/runtime/plugins/check-if-page-unused.js        1.11 kB │ gzip: 0.59 kB
packages/nuxt build: ℹ dist/app/plugins/check-if-layout-used.js                  1.06 kB │ gzip: 0.55 kB
packages/nuxt build: ℹ dist/head/runtime/install-client-head.js                  1.02 kB │ gzip: 0.45 kB
packages/nuxt build: ℹ dist/app/plugins/chunk-reload.client.js                   1.00 kB │ gzip: 0.47 kB
packages/nuxt build: ℹ dist/app/plugins/chunk-reload-immediate.client.js         0.90 kB │ gzip: 0.45 kB
packages/nuxt build: ℹ dist/app/plugins/navigation-repaint.client.js             0.89 kB │ gzip: 0.50 kB
packages/nuxt build: ℹ dist/compiler/runtime/index.js                            0.87 kB │ gzip: 0.49 kB
packages/nuxt build: ℹ dist/pages/runtime/validate.js                            0.72 kB │ gzip: 0.40 kB
packages/nuxt build: ℹ dist/app/composables/hydrate.js                           0.72 kB │ gzip: 0.39 kB
packages/nuxt build: ℹ dist/app/middleware/route-rules.js                        0.67 kB │ gzip: 0.36 kB
packages/nuxt build: ℹ dist/app/plugins/browser-devtools-timing.client.js        0.60 kB │ gzip: 0.35 kB
packages/nuxt build: ℹ dist/app/plugins/chunk-reload-crawler.client.js           0.60 kB │ gzip: 0.34 kB
packages/nuxt build: ℹ dist/app/compat/interval.js                               0.57 kB │ gzip: 0.36 kB
packages/nuxt build: ℹ dist/head/runtime/plugins/unhead-stream.client.js         0.57 kB │ gzip: 0.29 kB
packages/nuxt build: ℹ dist/app/internal/tracing.js                              0.57 kB │ gzip: 0.31 kB
packages/nuxt build: ℹ dist/app/compat/idle-callback.js                          0.54 kB │ gzip: 0.29 kB
packages/nuxt build: ℹ dist/app/plugins/restore-state.client.js                  0.52 kB │ gzip: 0.32 kB
packages/nuxt build: ℹ dist/app/composables/runtime-hook.js                      0.52 kB │ gzip: 0.32 kB
packages/nuxt build: ℹ dist/app/components/nuxt-stubs.js                         0.50 kB │ gzip: 0.31 kB
packages/nuxt build: ℹ dist/head/runtime/plugins/unhead.server.js                0.49 kB │ gzip: 0.29 kB
packages/nuxt build: ℹ dist/app/compat/capi.js                                   0.48 kB │ gzip: 0.28 kB
packages/nuxt build: ℹ dist/app/composables/ready.js                             0.48 kB │ gzip: 0.28 kB
packages/nuxt build: ℹ dist/head/runtime/plugins/unhead.client.js                0.46 kB │ gzip: 0.27 kB
packages/nuxt build: ℹ dist/app/plugins/preload.server.js                        0.45 kB │ gzip: 0.28 kB
packages/nuxt build: ℹ dist/pages/runtime/page-placeholder.js                    0.45 kB │ gzip: 0.30 kB
packages/nuxt build: ℹ dist/app/components/server-placeholder.js                 0.43 kB │ gzip: 0.25 kB
packages/nuxt build: ℹ dist/head/runtime/island-head.js                          0.39 kB │ gzip: 0.26 kB
packages/nuxt build: ℹ dist/app/composables/asyncContext.js                      0.38 kB │ gzip: 0.24 kB
packages/nuxt build: ℹ dist/app/components/dev-only.js                           0.37 kB │ gzip: 0.24 kB
packages/nuxt build: ℹ dist/app/plugins/debug-hooks.js                           0.35 kB │ gzip: 0.24 kB
packages/nuxt build: ℹ dist/app/composables/url.js                               0.34 kB │ gzip: 0.24 kB
packages/nuxt build: ℹ dist/app/plugins/warn.dev.server.js                       0.32 kB │ gzip: 0.24 kB
packages/nuxt build: ℹ dist/app/composables/head.js                              0.26 kB │ gzip: 0.13 kB
packages/nuxt build: ℹ dist/app/plugins/utils.js                                 0.26 kB │ gzip: 0.21 kB
packages/nuxt build: ℹ dist/app/entry.async.js                                   0.25 kB │ gzip: 0.16 kB
packages/nuxt build: ℹ dist/app/compat/vue-demi.js                               0.24 kB │ gzip: 0.17 kB
packages/nuxt build: ℹ dist/app/components/injections.js                         0.19 kB │ gzip: 0.14 kB
packages/nuxt build: ℹ dist/app/composables/id.js                                0.17 kB │ gzip: 0.14 kB
packages/nuxt build: ℹ dist/app/composables/lazy-hydration.js                    0.16 kB │ gzip: 0.14 kB
packages/nuxt build: ℹ dist/pages/runtime/component-stub.js                      0.14 kB │ gzip: 0.11 kB
packages/nuxt build: ℹ dist/app/composables/pages.js                             0.13 kB │ gzip: 0.11 kB
packages/nuxt build: ℹ dist/app/entry-spa.js                                     0.12 kB │ gzip: 0.11 kB
packages/nuxt build: ℹ dist/pages/runtime/index.js                               0.11 kB │ gzip: 0.09 kB
packages/nuxt build: ℹ dist/app/components/index.js                              0.08 kB │ gzip: 0.07 kB
packages/nuxt build: ℹ dist/app/types.js                                         0.01 kB │ gzip: 0.03 kB
packages/nuxt build: ℹ dist/app/types/augments.js                                0.01 kB │ gzip: 0.03 kB
packages/nuxt build: ℹ dist/head/runtime/types.js                                0.01 kB │ gzip: 0.03 kB
packages/nuxt build: ℹ dist/app/components/welcome.vue                          25.01 kB │ gzip: 7.78 kB
packages/nuxt build: ℹ dist/app/components/nuxt-time.vue                         5.98 kB │ gzip: 1.70 kB
packages/nuxt build: ℹ dist/app/components/error-404.vue                         5.50 kB │ gzip: 2.13 kB
packages/nuxt build: ℹ dist/app/components/error-500.vue                         4.87 kB │ gzip: 1.93 kB
packages/nuxt build: ℹ dist/app/components/nuxt-root.vue                         3.35 kB │ gzip: 1.29 kB
packages/nuxt build: ℹ dist/app/components/nuxt-error-page.vue                   1.57 kB │ gzip: 0.75 kB
packages/nuxt build: ℹ dist/app/components/nuxt-time.d.vue.ts                    1.53 kB │ gzip: 0.56 kB
packages/nuxt build: ℹ dist/app/components/error-404.d.vue.ts                    1.36 kB │ gzip: 0.32 kB
packages/nuxt build: ℹ dist/app/components/error-500.d.vue.ts                    1.36 kB │ gzip: 0.32 kB
packages/nuxt build: ℹ dist/_virtual/_rolldown/runtime.js                        1.10 kB │ gzip: 0.54 kB
packages/nuxt build: ℹ dist/app/components/nuxt-error-boundary.vue               1.00 kB │ gzip: 0.49 kB
packages/nuxt build: ℹ dist/app/components/nuxt-error-boundary.d.vue.ts          0.88 kB │ gzip: 0.38 kB
packages/nuxt build: ℹ dist/app/components/welcome.d.vue.ts                      0.79 kB │ gzip: 0.27 kB
packages/nuxt build: ℹ dist/app/components/nuxt-error-page.d.vue.ts              0.49 kB │ gzip: 0.23 kB
packages/nuxt build: ℹ dist/app/components/nuxt-root.d.vue.ts                    0.37 kB │ gzip: 0.19 kB
packages/nuxt build: ℹ dist/pages/runtime/app.d.vue.ts                           0.37 kB │ gzip: 0.19 kB
packages/nuxt build: ℹ dist/pages/runtime/app.vue                                0.10 kB │ gzip: 0.08 kB
packages/nuxt build: ℹ dist/app/nuxt.d.ts                                       10.97 kB │ gzip: 3.21 kB
packages/nuxt build: ℹ dist/app/composables/asyncData.d.ts                      10.37 kB │ gzip: 2.39 kB
packages/nuxt build: ℹ dist/app/composables/fetch.d.ts                           6.96 kB │ gzip: 1.27 kB
packages/nuxt build: ℹ dist/app/index.d.ts                                       5.52 kB │ gzip: 1.39 kB
packages/nuxt build: ℹ dist/app/composables/router.d.ts                          4.49 kB │ gzip: 1.64 kB
packages/nuxt build: ℹ dist/app/components/nuxt-link.d.ts                        4.40 kB │ gzip: 1.57 kB
packages/nuxt build: ℹ dist/app/composables/script-stubs.d.ts                    3.96 kB │ gzip: 0.71 kB
packages/nuxt build: ℹ dist/app/composables/index.d.ts                           3.35 kB │ gzip: 0.90 kB
packages/nuxt build: ℹ dist/head/runtime/components.d.ts                         3.19 kB │ gzip: 0.99 kB
packages/nuxt build: ℹ dist/pages/runtime/composables.d.ts                       3.16 kB │ gzip: 1.36 kB
packages/nuxt build: ℹ dist/app/types.d.ts                                       2.82 kB │ gzip: 1.07 kB
packages/nuxt build: ℹ dist/app/components/utils.d.ts                            2.63 kB │ gzip: 1.12 kB
packages/nuxt build: ℹ dist/app/plugins/router.d.ts                              2.30 kB │ gzip: 0.86 kB
packages/nuxt build: ℹ dist/app/composables/lazy-hydration.d.ts                  1.98 kB │ gzip: 0.43 kB
packages/nuxt build: ℹ dist/app/composables/ssr.d.ts                             1.90 kB │ gzip: 0.81 kB
packages/nuxt build: ℹ dist/app/types/augments.d.ts                              1.87 kB │ gzip: 0.67 kB
packages/nuxt build: ℹ dist/app/composables/error.d.ts                           1.73 kB │ gzip: 0.70 kB
packages/nuxt build: ℹ dist/components/runtime/lazy-hydrated-component.d.ts      1.62 kB │ gzip: 0.49 kB
packages/nuxt build: ℹ dist/head/runtime/composables.d.ts                        1.51 kB │ gzip: 0.44 kB
packages/nuxt build: ℹ dist/app/composables/cookie.d.ts                          1.47 kB │ gzip: 0.65 kB
packages/nuxt build: ℹ dist/app/composables/preview.d.ts                         1.45 kB │ gzip: 0.59 kB
packages/nuxt build: ℹ dist/app/composables/payload.d.ts                         1.43 kB │ gzip: 0.52 kB
packages/nuxt build: ℹ dist/pages/runtime/utils.d.ts                             1.38 kB │ gzip: 0.67 kB
packages/nuxt build: ℹ dist/app/island-hash.d.ts                                 1.29 kB │ gzip: 0.61 kB
packages/nuxt build: ℹ dist/app/composables/loading-indicator.d.ts               1.26 kB │ gzip: 0.55 kB
packages/nuxt build: ℹ dist/pages/runtime/page.d.ts                              1.16 kB │ gzip: 0.52 kB
packages/nuxt build: ℹ dist/app/composables/state.d.ts                           1.11 kB │ gzip: 0.58 kB
packages/nuxt build: ℹ dist/app/composables/preload.d.ts                         1.02 kB │ gzip: 0.41 kB
packages/nuxt build: ℹ dist/head/runtime/types.d.ts                              0.95 kB │ gzip: 0.47 kB
packages/nuxt build: ℹ dist/app/composables/chunk.d.ts                           0.95 kB │ gzip: 0.52 kB
packages/nuxt build: ℹ dist/app/internal/tracing.d.ts                            0.91 kB │ gzip: 0.49 kB
packages/nuxt build: ℹ dist/app/composables/announcer.d.ts                       0.87 kB │ gzip: 0.42 kB
packages/nuxt build: ℹ dist/app/components/client-only.d.ts                      0.84 kB │ gzip: 0.41 kB
packages/nuxt build: ℹ dist/app/composables/manifest.d.ts                        0.76 kB │ gzip: 0.35 kB
packages/nuxt build: ℹ dist/app/components/nuxt-teleport-island-component.d.ts   0.73 kB │ gzip: 0.35 kB
packages/nuxt build: ℹ dist/app/composables/route-announcer.d.ts                 0.72 kB │ gzip: 0.35 kB
packages/nuxt build: ℹ dist/app/components/nuxt-island.d.ts                      0.71 kB │ gzip: 0.38 kB
packages/nuxt build: ℹ dist/app/components/client-fallback.client.d.ts           0.69 kB │ gzip: 0.32 kB
packages/nuxt build: ℹ dist/app/components/client-fallback.server.d.ts           0.69 kB │ gzip: 0.32 kB
packages/nuxt build: ℹ dist/app/composables/once.d.ts                            0.67 kB │ gzip: 0.38 kB
packages/nuxt build: ℹ dist/app/composables/runtime-hook.d.ts                    0.64 kB │ gzip: 0.36 kB
packages/nuxt build: ℹ dist/app/components/nuxt-layout.d.ts                      0.63 kB │ gzip: 0.31 kB
packages/nuxt build: ℹ dist/app/config.d.ts                                      0.63 kB │ gzip: 0.33 kB
packages/nuxt build: ℹ dist/app/components/route-provider.d.ts                   0.62 kB │ gzip: 0.30 kB
packages/nuxt build: ℹ dist/components/runtime/server-component.d.ts             0.61 kB │ gzip: 0.28 kB
packages/nuxt build: ℹ dist/app/components/nuxt-teleport-island-slot.d.ts        0.60 kB │ gzip: 0.33 kB
packages/nuxt build: ℹ dist/app/composables/hydrate.d.ts                         0.57 kB │ gzip: 0.35 kB
packages/nuxt build: ℹ dist/app/components/nuxt-announcer.d.ts                   0.52 kB │ gzip: 0.29 kB
packages/nuxt build: ℹ dist/app/components/nuxt-route-announcer.d.ts             0.52 kB │ gzip: 0.29 kB
packages/nuxt build: ℹ dist/app/components/nuxt-loading-indicator.d.ts           0.51 kB │ gzip: 0.28 kB
packages/nuxt build: ℹ dist/compiler/runtime/index.d.ts                          0.49 kB │ gzip: 0.29 kB
packages/nuxt build: ℹ dist/app/components/injections.d.ts                       0.43 kB │ gzip: 0.23 kB
packages/nuxt build: ℹ dist/app/utils.d.ts                                       0.40 kB │ gzip: 0.24 kB
packages/nuxt build: ℹ dist/app/components/dev-only.d.ts                         0.39 kB │ gzip: 0.26 kB
packages/nuxt build: ℹ dist/app/compat/vue-demi.d.ts                             0.36 kB │ gzip: 0.20 kB
packages/nuxt build: ℹ dist/app/components/island-renderer.d.ts                  0.33 kB │ gzip: 0.21 kB
packages/nuxt build: ℹ dist/head/runtime/island-head.d.ts                        0.32 kB │ gzip: 0.24 kB
packages/nuxt build: ℹ dist/pages/runtime/page-placeholder.d.ts                  0.32 kB │ gzip: 0.22 kB
packages/nuxt build: ℹ dist/app/composables/head.d.ts                            0.31 kB │ gzip: 0.15 kB
packages/nuxt build: ℹ dist/head/runtime/install-client-head.d.ts                0.31 kB │ gzip: 0.20 kB
packages/nuxt build: ℹ dist/app/composables/component.d.ts                       0.29 kB │ gzip: 0.18 kB
packages/nuxt build: ℹ dist/app/compat/capi.d.ts                                 0.29 kB │ gzip: 0.19 kB
packages/nuxt build: ℹ dist/pages/runtime/index.d.ts                             0.29 kB │ gzip: 0.17 kB
packages/nuxt build: ℹ dist/app/components/index.d.ts                            0.27 kB │ gzip: 0.17 kB
packages/nuxt build: ℹ dist/app/entry.d.ts                                       0.25 kB │ gzip: 0.19 kB
packages/nuxt build: ℹ dist/app/components/test-component-wrapper.d.ts           0.24 kB │ gzip: 0.17 kB
packages/nuxt build: ℹ dist/app/compat/idle-callback.d.ts                        0.24 kB │ gzip: 0.14 kB
packages/nuxt build: ℹ dist/components/runtime/client-component.d.ts             0.24 kB │ gzip: 0.17 kB
packages/nuxt build: ℹ dist/app/composables/url.d.ts                             0.23 kB │ gzip: 0.19 kB
packages/nuxt build: ℹ dist/pages/runtime/plugins/router.d.ts                    0.22 kB │ gzip: 0.16 kB
packages/nuxt build: ℹ dist/app/components/server-placeholder.d.ts               0.21 kB │ gzip: 0.16 kB
packages/nuxt build: ℹ dist/app/composables/pages.d.ts                           0.21 kB │ gzip: 0.14 kB
packages/nuxt build: ℹ dist/app/plugins/browser-devtools-timing.client.d.ts      0.20 kB │ gzip: 0.16 kB
packages/nuxt build: ℹ dist/app/plugins/chunk-reload-immediate.client.d.ts       0.20 kB │ gzip: 0.16 kB
packages/nuxt build: ℹ dist/pages/runtime/plugins/check-if-page-unused.d.ts      0.20 kB │ gzip: 0.16 kB
packages/nuxt build: ℹ dist/app/composables/asyncContext.d.ts                    0.20 kB │ gzip: 0.17 kB
packages/nuxt build: ℹ dist/app/plugins/cross-origin-prefetch.client.d.ts        0.20 kB │ gzip: 0.16 kB
packages/nuxt build: ℹ dist/app/plugins/prefetch-preload-tags.server.d.ts        0.20 kB │ gzip: 0.16 kB
packages/nuxt build: ℹ dist/head/runtime/plugins/unhead-stream.client.d.ts       0.20 kB │ gzip: 0.16 kB
packages/nuxt build: ℹ dist/app/plugins/check-outdated-build.client.d.ts         0.20 kB │ gzip: 0.16 kB
packages/nuxt build: ℹ dist/app/plugins/chunk-reload-crawler.client.d.ts         0.20 kB │ gzip: 0.16 kB
packages/nuxt build: ℹ dist/app/middleware/route-rules.d.ts                      0.20 kB │ gzip: 0.15 kB
packages/nuxt build: ℹ dist/app/plugins/navigation-repaint.client.d.ts           0.20 kB │ gzip: 0.16 kB
packages/nuxt build: ℹ dist/pages/runtime/plugins/prerender.server.d.ts          0.20 kB │ gzip: 0.15 kB
packages/nuxt build: ℹ dist/pages/runtime/plugins/prefetch.client.d.ts           0.20 kB │ gzip: 0.15 kB
packages/nuxt build: ℹ dist/app/components/nuxt-stubs.d.ts                       0.19 kB │ gzip: 0.14 kB
packages/nuxt build: ℹ dist/app/plugins/view-transitions.client.d.ts             0.19 kB │ gzip: 0.15 kB
packages/nuxt build: ℹ dist/app/plugins/revive-payload.client.d.ts               0.19 kB │ gzip: 0.15 kB
packages/nuxt build: ℹ dist/app/plugins/revive-payload.server.d.ts               0.19 kB │ gzip: 0.15 kB
packages/nuxt build: ℹ dist/head/runtime/plugins/unhead.client.d.ts              0.19 kB │ gzip: 0.15 kB
packages/nuxt build: ℹ dist/head/runtime/plugins/unhead.server.d.ts              0.19 kB │ gzip: 0.15 kB
packages/nuxt build: ℹ dist/app/plugins/check-if-layout-used.d.ts                0.19 kB │ gzip: 0.15 kB
packages/nuxt build: ℹ dist/app/plugins/restore-state.client.d.ts                0.19 kB │ gzip: 0.15 kB
packages/nuxt build: ℹ dist/pages/runtime/validate.d.ts                          0.19 kB │ gzip: 0.15 kB
packages/nuxt build: ℹ dist/app/plugins/chunk-reload.client.d.ts                 0.19 kB │ gzip: 0.15 kB
packages/nuxt build: ℹ dist/app/composables/id.d.ts                              0.19 kB │ gzip: 0.15 kB
packages/nuxt build: ℹ dist/app/plugins/dev-server-logs.d.ts                     0.19 kB │ gzip: 0.15 kB
packages/nuxt build: ℹ dist/app/plugins/warn.dev.server.d.ts                     0.19 kB │ gzip: 0.15 kB
packages/nuxt build: ℹ dist/app/plugins/payload.client.d.ts                      0.18 kB │ gzip: 0.15 kB
packages/nuxt build: ℹ dist/app/plugins/preload.server.d.ts                      0.18 kB │ gzip: 0.15 kB
packages/nuxt build: ℹ dist/app/plugins/debug-hooks.d.ts                         0.18 kB │ gzip: 0.15 kB
packages/nuxt build: ℹ dist/pages/runtime/router.options.d.ts                    0.17 kB │ gzip: 0.14 kB
packages/nuxt build: ℹ dist/app/entry.async.d.ts                                 0.17 kB │ gzip: 0.14 kB
packages/nuxt build: ℹ dist/app/composables/ready.d.ts                           0.15 kB │ gzip: 0.15 kB
packages/nuxt build: ℹ dist/app/plugins/utils.d.ts                               0.14 kB │ gzip: 0.13 kB
packages/nuxt build: ℹ dist/app/compat/interval.d.ts                             0.13 kB │ gzip: 0.12 kB
packages/nuxt build: ℹ dist/pages/runtime/component-stub.d.ts                    0.12 kB │ gzip: 0.12 kB
packages/nuxt build: ℹ dist/app/entry-spa.d.ts                                   0.11 kB │ gzip: 0.12 kB
packages/nuxt build: ℹ dist/app/components/nuxt-time.vue.d.ts                    1.53 kB │ gzip: 0.56 kB
packages/nuxt build: ℹ dist/app/components/error-404.vue.d.ts                    1.36 kB │ gzip: 0.32 kB
packages/nuxt build: ℹ dist/app/components/error-500.vue.d.ts                    1.36 kB │ gzip: 0.32 kB
packages/nuxt build: ℹ dist/app/components/nuxt-error-boundary.vue.d.ts          0.88 kB │ gzip: 0.38 kB
packages/nuxt build: ℹ dist/app/components/welcome.vue.d.ts                      0.79 kB │ gzip: 0.27 kB
packages/nuxt build: ℹ dist/app/components/nuxt-error-page.vue.d.ts              0.49 kB │ gzip: 0.23 kB
packages/nuxt build: ℹ dist/app/components/nuxt-root.vue.d.ts                    0.37 kB │ gzip: 0.19 kB
packages/nuxt build: ℹ dist/pages/runtime/app.vue.d.ts                           0.37 kB │ gzip: 0.19 kB
packages/nuxt build: ℹ 241 files, total: 421.05 kB
packages/nuxt build: ✔ Build complete in 301ms
packages/nuxt build: Done
packages/webpack build$ tsdown
packages/rspack build$ tsdown
packages/vite build$ tsdown
packages/rspack build: ℹ tsdown v0.22.3 powered by rolldown v1.1.3
packages/webpack build: ℹ tsdown v0.22.3 powered by rolldown v1.1.3
packages/vite build: ℹ tsdown v0.22.3 powered by rolldown v1.1.3
packages/rspack build: ℹ config file: /Users/barry/Documents/Codex/2026-06-14/github-issue-pr/work/nuxt/packages/rspack/tsdown.config.ts 
packages/vite build: ℹ config file: /Users/barry/Documents/Codex/2026-06-14/github-issue-pr/work/nuxt/packages/vite/tsdown.config.ts 
packages/webpack build: ℹ config file: /Users/barry/Documents/Codex/2026-06-14/github-issue-pr/work/nuxt/packages/webpack/tsdown.config.ts 
packages/rspack build: ℹ entry: src/index.ts, src/loaders/vue-module-identifier.ts
packages/vite build: ℹ entry: src/index, src/vite-node, src/vite-node-entry, src/vite-node-runner, src/fix-stacktrace
packages/webpack build: ℹ entry: src/index.ts, src/loaders/vue-module-identifier.ts
packages/rspack build: ℹ target: node22.12.0
packages/rspack build: ℹ tsconfig: ../../tsconfig.json
packages/vite build: ℹ target: node22.18.0
packages/vite build: ℹ tsconfig: ../../tsconfig.json
packages/rspack build: ℹ Build start
packages/webpack build: ℹ target: node22.12.0
packages/webpack build: ℹ tsconfig: ../../tsconfig.json
packages/vite build: ℹ Build start
packages/webpack build: ℹ Build start
packages/vite build: ℹ Cleaning 10 files
packages/rspack build: ℹ Cleaning 5 files
packages/webpack build: ℹ Cleaning 5 files
packages/rspack build: ℹ dist/index.mjs                            58.94 kB │ gzip: 16.22 kB
packages/rspack build: ℹ dist/loaders/vue-module-identifier.mjs     0.73 kB │ gzip:  0.40 kB
packages/rspack build: ℹ dist/index.d.mts                           0.43 kB │ gzip:  0.26 kB
packages/rspack build: ℹ dist/loaders/vue-module-identifier.d.mts   0.30 kB │ gzip:  0.20 kB
packages/rspack build: ℹ 4 files, total: 60.41 kB
packages/webpack build: ℹ dist/index.mjs                            58.67 kB │ gzip: 16.20 kB
packages/webpack build: ℹ dist/loaders/vue-module-identifier.mjs     0.72 kB │ gzip:  0.39 kB
packages/webpack build: ℹ dist/index.d.mts                           0.42 kB │ gzip:  0.25 kB
packages/webpack build: ℹ dist/loaders/vue-module-identifier.d.mts   0.29 kB │ gzip:  0.19 kB
packages/webpack build: ℹ 4 files, total: 60.10 kB
packages/webpack build: ✔ Build complete in 53ms
packages/rspack build: ✔ Build complete in 54ms
packages/webpack build: Done
packages/rspack build: Done
packages/vite build: ℹ dist/index.mjs               86.21 kB │ gzip: 22.89 kB
packages/vite build: ℹ dist/vite-node.mjs            8.49 kB │ gzip:  2.62 kB
packages/vite build: ℹ dist/vite-node-runner.mjs     1.97 kB │ gzip:  0.85 kB
packages/vite build: ℹ dist/vite-node-entry.mjs      0.94 kB │ gzip:  0.47 kB
packages/vite build: ℹ dist/fix-stacktrace.mjs       0.38 kB │ gzip:  0.26 kB
packages/vite build: ℹ dist/vite-node.d.mts          1.18 kB │ gzip:  0.53 kB
packages/vite build: ℹ dist/index.d.mts              0.92 kB │ gzip:  0.44 kB
packages/vite build: ℹ dist/vite-node-entry.d.mts    0.19 kB │ gzip:  0.16 kB
packages/vite build: ℹ dist/fix-stacktrace.d.mts     0.17 kB │ gzip:  0.15 kB
packages/vite build: ℹ dist/vite-node-runner.d.mts   0.17 kB │ gzip:  0.14 kB
packages/vite build: ℹ 10 files, total: 100.62 kB
packages/vite build: ✔ Build complete in 69ms
packages/vite build: Done
[nuxt] ℹ Running with compatibility version 5
│
◆  Types generated in .nuxt.\n- 
 RUN  v4.1.9 /Users/barry/Documents/Codex/2026-06-14/github-issue-pr/work/nuxt


 Test Files  1 passed (1)
      Tests  2 passed (2)
   Start at  11:53:42
   Duration  252ms (transform 108ms, setup 144ms, import 39ms, tests 6ms, environment 0ms)\n- \n- \n\n## Notes\n\nAI-assisted implementation; manually reviewed the diff and local verification output before opening this PR.