### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/packages/schema/src/config/vite.ts
+++ b/packages/schema/src/config/vite.ts
@@ -71,6 +71,7 @@ export default defineResolvers({
     vueJsx: {
       $resolve: async (val, get) => {
         return {
+          defineComponentName: ['defineComponent', 'defineNuxtComponent'],
           // TODO: investigate type divergence between types for @vue/compiler-core and @vue/babel-plugin-jsx
           isCustomElement: (await get('vue')).compilerOptions?.isCustomElement as undefined | ((tag: string) => boolean),
           ...typeof val === 'object' ? val : {},

--- a/packages/schema/test/vite.spec.ts
+++ b/packages/schema/test/vite.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest'
+import { applyDefaults } from 'untyped'
+
+import { NuxtConfigSchema } from '../src/index.ts'
+import type { NuxtOptions } from '../src/index.ts'
+
+vi.mock('node:fs', () => ({
+  existsSync: (id: string) => id.endsWith('app'),
+}))
+
+describe('vite.vueJsx defaults', () => {
+  it('enables HMR for defineNuxtComponent in TSX files', async () => {
+    const result = await applyDefaults(NuxtConfigSchema, {})
+
+    expect((result as unknown as NuxtOptions).vite.vueJsx?.defineComponentName).toEqual([
+      'defineComponent',
+      'defineNuxtComponent',
+    ])
+  })
+
+  it('respects a user-defined component name list', async () => {
+    const result = await applyDefaults(NuxtConfigSchema, {
+      vite: {
+        vueJsx: {
+          defineComponentName: ['defineCustomComponent'],
+        },
+      },
+    })
+
+    expect((result as unknown as NuxtOptions).vite.vueJsx?.defineComponentName).toEqual([
+      'defineCustomComponent',
+    ])
+  })
+})


### PR DESCRIPTION
## Summary

- Add defineNuxtComponent to Nuxt's default vite.vueJsx.defineComponentName
- Keep user-provided vite.vueJsx.defineComponentName lists authoritative
- Add schema coverage for the default and override behavior

Fixes #35465.

## Testing

- corepack pnpm dev:prepare
- corepack pnpm vitest run --project unit packages/schema/test/vite.spec.ts
- corepack pnpm eslint packages/schema/src/config/vite.ts packages/schema/test/vite.spec.ts
- git diff --check

## Notes

AI-assisted implementation; manually reviewed the diff and local verification output before opening this PR.