### PR TITLE
feat(nuxt): support `enabled: false` in defineNuxtPlugin to disable plugins at build time

### DIFF
--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -246,6 +246,10 @@ export interface PluginMeta {
    * It overrides the value of `enforce` and is used to sort plugins.
    */
   order?: number
+  /**
+   * Whether the plugin is enabled or disabled. When set to `false`, the plugin will not be included in the build.
+   */
+  enabled?: boolean
 }
 
 export interface PluginEnvContext {

--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -230,6 +230,35 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
   app.middleware = uniqueBy(await resolvePaths(nuxt, app.middleware, 'path'), 'name')
   app.plugins = uniqueBy(await resolvePaths(nuxt, app.plugins, 'src'), 'src')
   app.configs = [...new Set(app.configs)]
+
+  // Filter out disabled plugins, including those disabled via plugin metadata
+  app.plugins = await filterDisabledPlugins(nuxt, app.plugins)
+}
+
+async function filterDisabledPlugins (nuxt: Nuxt, plugins: NuxtPlugin[]) {
+  const result: NuxtPlugin[] = []
+
+  for (const plugin of plugins) {
+    if (plugin.enabled === false) {
+      continue
+    }
+    if (plugin.enabled === true || !plugin.src) {
+      result.push(plugin)
+      continue
+    }
+
+    try {
+      const code = nuxt.vfs[plugin.src] ?? await fsp.readFile(plugin.src, 'utf-8')
+      const meta = extractMetadata(code, /\.[jt]sx$/.test(plugin.src) ? 'tsx' : 'ts')
+      if (meta.enabled !== false) {
+        result.push(plugin)
+      }
+    } catch {
+      result.push(plugin)
+    }
+  }
+
+  return result
 }
 
 function resolvePaths<Item extends Record<string, any>> (nuxt: Nuxt, items: Item[], key: { [K in keyof Item]: Item[K] extends string ? K : never }[keyof Item]) {

--- a/packages/nuxt/src/core/plugins/plugin-metadata.ts
+++ b/packages/nuxt/src/core/plugins/plugin-metadata.ts
@@ -98,6 +98,7 @@ const keys: Record<ExtractedMetaKey, string> = {
   enforce: 'enforce',
   dependsOn: 'dependsOn',
   parallel: 'parallel',
+  enabled: 'enabled',
 }
 function isMetadataKey (key: string | ESTree.IdentifierName): key is ExtractedMetaKey {
   return typeof key !== 'string' ? key.name in keys : key in keys

--- a/packages/nuxt/test/app.test.ts
+++ b/packages/nuxt/test/app.test.ts
@@ -4,6 +4,7 @@ import { afterAll, describe, expect, it } from 'vitest'
 import { dirname, join, resolve } from 'pathe'
 import { findWorkspaceDir } from 'pkg-types'
 import { createApp, resolveApp } from '../src/core/app.ts'
+import { clientPluginTemplate, serverPluginTemplate } from '../src/core/templates.ts'
 import { loadNuxt } from '../src/index.ts'
 
 const repoRoot = await findWorkspaceDir()
@@ -81,6 +82,37 @@ describe('resolveApp', () => {
         "templates": [],
       }
     `)
+  })
+
+  it('filters plugins disabled via runtime defineNuxtPlugin metadata', async () => {
+    const app = await getResolvedApp([
+      {
+        name: 'app/plugins/disabled-plugin.ts',
+        contents: `export default defineNuxtPlugin({\n  enabled: false,\n  setup (nuxtApp) {\n    nuxtApp.provide('disabledViaDefinition', 'should not be available')\n  },\n})`,
+      },
+    ])
+
+    expect(app.plugins.some(plugin => plugin.src.includes('disabled-plugin.ts'))).toBe(false)
+  })
+
+  it('filters disabled plugins before plugin template generation', async () => {
+    const rootDir = resolve(repoRoot, 'node_modules/.fixture', randomUUID())
+    await mkdir(join(rootDir, 'app/plugins'), { recursive: true })
+    await writeFile(join(rootDir, 'nuxt.config.ts'), 'export default {}')
+    await writeFile(join(rootDir, 'app/plugins/disabled-plugin.ts'), 'export default defineNuxtPlugin({ enabled: false, setup () {} })')
+
+    const nuxt = await loadNuxt({ cwd: rootDir })
+    const app = createApp(nuxt)
+    await resolveApp(nuxt, app)
+
+    const clientContents = await clientPluginTemplate.getContents({ nuxt, app } as any)
+    const serverContents = await serverPluginTemplate.getContents({ nuxt, app } as any)
+
+    expect(clientContents).not.toContain('disabled-plugin.ts')
+    expect(serverContents).not.toContain('disabled-plugin.ts')
+
+    await nuxt.close()
+    await rm(rootDir, { recursive: true, force: true })
   })
 
   it('resolves layouts and middleware correctly', async () => {

--- a/packages/schema/src/types/nuxt.ts
+++ b/packages/schema/src/types/nuxt.ts
@@ -20,6 +20,10 @@ export interface NuxtPlugin {
    */
   order?: number
   /**
+   * Whether the plugin is enabled or disabled. When set to `false`, the plugin will not be included in the build.
+   */
+  enabled?: boolean
+  /**
    * @internal
    */
   name?: string

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -354,7 +354,8 @@ export interface ConfigSchema {
    * An array of nuxt app plugins.
    *
    * Each plugin can be a string (which can be an absolute or relative path to a file). If it ends with `.client` or `.server` then it will be automatically loaded only in the appropriate context.
-   * It can also be an object with `src` and `mode` keys.
+   * It can also be an object with `src` and `mode` keys. 
+   * The `enabled` property can be used to conditionally disable a plugin from being included in the build.
    *
    * @note Plugins are also auto-registered from the `~/plugins` directory
    * and these plugins do not need to be listed in `nuxt.config` unless you
@@ -370,7 +371,8 @@ export interface ConfigSchema {
    *   '~/plugins/baz.js', // both client & server
    *   { src: '~/plugins/both-sides.js' },
    *   { src: '~/plugins/client-only.js', mode: 'client' }, // only on client side
-   *   { src: '~/plugins/server-only.js', mode: 'server' } // only on server side
+   *   { src: '~/plugins/server-only.js', mode: 'server' }, // only on server side
+   *   { src: '~/plugins/disabled-plugin.js', enabled: false } // plugin is disabled
    * ]
    * ```
    */

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1547,6 +1547,12 @@ describe('plugins', () => {
     expect(html).toContain('asyncPlugin: Async plugin works! 123')
     expect(html).toContain('useFetch works!')
   })
+
+  it('disabled plugins should not be available', async () => {
+    const html = await $fetch<string>('/disabled-plugins')
+    expect(html).toContain('disabledViaDefinition: Not available (expected)')
+    expect(html).toContain('disabledViaConfig: Not available (expected)')
+  })
 })
 
 describe('layouts', () => {

--- a/test/fixtures/basic/app/pages/disabled-plugins.vue
+++ b/test/fixtures/basic/app/pages/disabled-plugins.vue
@@ -1,0 +1,15 @@
+<template>
+  <div>
+    <div v-if="disabledViaDefinition === undefined">disabledViaDefinition: Not available (expected)</div>
+    <div v-else>disabledViaDefinition: {{ disabledViaDefinition }}</div>
+    
+    <div v-if="disabledViaConfig === undefined">disabledViaConfig: Not available (expected)</div>
+    <div v-else>disabledViaConfig: {{ disabledViaConfig }}</div>
+  </div>
+</template>
+
+<script setup lang="ts">
+const { $disabledViaDefinition, $disabledViaConfig } = useNuxtApp()
+const disabledViaDefinition = $disabledViaDefinition
+const disabledViaConfig = $disabledViaConfig
+</script>

--- a/test/fixtures/basic/app/plugins/can-be-disabled-via-config.ts
+++ b/test/fixtures/basic/app/plugins/can-be-disabled-via-config.ts
@@ -1,0 +1,6 @@
+export default defineNuxtPlugin({
+  name: 'can-be-disabled-via-config',
+  setup(nuxtApp) {
+    nuxtApp.provide('disabledViaConfig', 'This can be disabled via config')
+  },
+})

--- a/test/fixtures/basic/app/plugins/disabled-via-definition.ts
+++ b/test/fixtures/basic/app/plugins/disabled-via-definition.ts
@@ -1,0 +1,7 @@
+export default defineNuxtPlugin({
+  name: 'disabled-via-definition',
+  enabled: false,
+  setup(nuxtApp) {
+    nuxtApp.provide('disabledViaDefinition', 'This should not be available')
+  },
+})

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -216,6 +216,9 @@ export default withMatrix({
       '~~/postcss/plugin': {},
     },
   },
+  plugins: [
+    { src: '~/plugins/can-be-disabled-via-config.ts', enabled: false },
+  ],
   telemetry: false, // for testing telemetry types - it is auto-disabled in tests
   hooks: {
     'webpack:config' (configs) {


### PR DESCRIPTION
### 🔗 Linked issue
Resolves #34822 

### 📚 Description
This feature adds `enabled: false` support to `defineNuxtPlugin()` and Nuxt's plugin configuration, so plugins can be kept in the codebase without activating them. No need to delete files, rename directories or have commented-out code. 

Two ways to disable a plugin:
1. Definition-level (directly in plugin file):
```ts
export default defineNuxtPlugin({
    name: 'my-analytics-plugin',
    enabled: false,
    setup(nuxtApp) {
       // Plugin logic won't execute or be bundled
    },
})
```
2. Configuration-level in `nuxt.config.ts`:
```ts
plugins: [
  { src: '~/plugins/analytics.ts', enabled: false }
]
```
When `enabled: false` is set, Nuxt's build scanner reads the value statically at build time and omits the plugin from `.nuxt/plugins.mjs` entirely.