### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/packages/vite/src/plugins/vue-jsx.ts
+++ b/packages/vite/src/plugins/vue-jsx.ts
@@ -46,7 +46,15 @@ export function VueJsxPlugin (nuxt: Nuxt, options?: Options): Plugin[] {
     }
 
     const { default: viteJsxPlugin } = await import('@vitejs/plugin-vue-jsx')
-    resolvedPlugin = viteJsxPlugin(options)
+    // Ensure `defineNuxtComponent` is included in the HMR component-name list
+    // so that .tsx pages using it receive hot-module replacement automatically.
+    resolvedPlugin = viteJsxPlugin({
+      ...options,
+      defineComponentName: Array.from(new Set([
+        ...(options?.defineComponentName ?? ['defineComponent']),
+        'defineNuxtComponent',
+      ])),
+    })
 
     // Replay configResolved so the real plugin captures HMR/sourcemap state
     if (resolvedConfig && typeof resolvedPlugin.configResolved === 'function') {


### PR DESCRIPTION
Fixes #35465

## What

In `packages/vite/src/plugins/vue-jsx.ts`, when initializing `@vitejs/plugin-vue-jsx`, we now automatically include `'defineNuxtComponent'` in the `defineComponentName` option alongside the default `'defineComponent'`.

This ensures that `.tsx` pages using `defineNuxtComponent` receive hot-module replacement (HMR) automatically, without requiring users to manually configure `vite.vueJsx.defineComponentName` in `nuxt.config.ts`.

The `defineComponentName` list is built by spreading any user-provided names first (defaulting to `['defineComponent']`) and then appending `'defineNuxtComponent'`, using `Set` to deduplicate if the user has already added it manually.

## Why

`@vitejs/plugin-vue-jsx` only injects HMR infrastructure for components whose factory function name appears in `defineComponentName` (default: `['defineComponent']`). Since `defineNuxtComponent` is not in that list, the plugin silently skips HMR setup for `.tsx` files using it, requiring a full page reload on every edit.

Because `defineNuxtComponent` is a first-class Nuxt API, it should work with HMR out of the box for `.tsx` pages.

This PR was opened by an automated OSS contribution bot.