### PR TITLE
fix(vite): use file URLs for dev virtual imports on Windows 🤖🤖🤖

### DIFF
--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -1,5 +1,6 @@
 import { existsSync } from 'node:fs'
 import { performance } from 'node:perf_hooks'
+import { pathToFileURL } from 'node:url'
 import { createBuilder, createServer, mergeConfig } from 'vite'
 import type * as vite from 'vite'
 import { basename, dirname, join, resolve } from 'pathe'
@@ -49,10 +50,10 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
   // Register Nitro plugin to fix SSR error stacktraces in dev mode
   if (nuxt.options.dev) {
     const nitro = useNitro()
-    nitro.options.virtual['#internal/nitro/ssr-stacktrace'] = `export { default } from ${JSON.stringify(resolve(distDir, 'fix-stacktrace'))}`
+    nitro.options.virtual['#internal/nitro/ssr-stacktrace'] = `export { default } from ${JSON.stringify(pathToFileURL(resolve(distDir, 'fix-stacktrace')).href)}`
     nitro.options.plugins.push('#internal/nitro/ssr-stacktrace')
     nitro.options.alias['#vite-node'] = resolve(distDir, 'vite-node')
-    nitro.options.virtual['#internal/nuxt/vite-node-runner.mjs'] = () => `export { default } from ${JSON.stringify(resolve(distDir, 'vite-node-runner'))}`
+    nitro.options.virtual['#internal/nuxt/vite-node-runner.mjs'] = () => `export { default } from ${JSON.stringify(pathToFileURL(resolve(distDir, 'vite-node-runner')).href)}`
   }
 
   let allowDirs = [


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #35491

### ❓ Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Other

### 📚 Description

This updates the Vite builder dev virtual imports for `#internal/nitro/ssr-stacktrace` and `#internal/nuxt/vite-node-runner.mjs` to emit `file://` URLs instead of raw absolute filesystem paths.

On Windows, raw absolute paths such as `C:/...` are parsed by Node's ESM loader as a `c:` URL scheme and fail with `ERR_UNSUPPORTED_ESM_URL_SCHEME`. Converting the resolved paths through `pathToFileURL(...).href` keeps the generated specifiers valid across platforms.

### ✅ Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the tests accordingly. (N/A: direct generated-specifier fix, validated with package build.)
- [x] I have updated the documentation accordingly. (N/A)

### 🧪 Testing

- `git diff --check`
- `pnpm exec eslint packages/vite/src/vite.ts`
- `pnpm --filter @nuxt/vite-builder build`

## Full disclosure
PR was written and published by a bot, but the issue is real and i have verified the small fix that breaks development on windows machines.
