### PR TITLE
fix(nuxt): prefetch custom links rendering a single element

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -400,7 +400,7 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
       // Prefetching
       const prefetched = shallowRef(false)
       const el = import.meta.server ? undefined : ref<HTMLElement | null>(null)
-      const elRef = import.meta.server ? undefined : (ref: any) => { el!.value = props.custom ? ref?.$el?.nextElementSibling : ref?.$el }
+      const elRef = import.meta.server ? undefined : (ref: any) => { el!.value = props.custom ? resolveCustomLinkEl(ref?.$el) : ref?.$el }
 
       function shouldPrefetch (mode: 'visibility' | 'interaction') {
         if (import.meta.server) { return }
@@ -601,6 +601,16 @@ function applyTrailingSlashBehavior (to: string, trailingSlash: NuxtLinkOptions[
 }
 
 // --- Prefetching utils ---
+
+// `custom` RouterLink renders a single-node slot as the element itself, but a
+// fragment behind a marker (comment/text) node. So `$el` is either the element
+// or the marker preceding it (#14897, #19375). Resolve the element in both cases.
+export function resolveCustomLinkEl (root: Node | null | undefined): HTMLElement | null {
+  return (root && root.nodeType === 1 /* Node.ELEMENT_NODE */
+    ? root
+    : (root as NonDocumentTypeChildNode | null)?.nextElementSibling ?? null) as HTMLElement | null
+}
+
 type CallbackFn = () => void
 type ObserveFn = (element: Element, callback: CallbackFn) => () => void
 

--- a/packages/nuxt/test/nuxt-link.test.ts
+++ b/packages/nuxt/test/nuxt-link.test.ts
@@ -3,7 +3,7 @@ import type { RouteLocation, RouteLocationRaw } from 'vue-router'
 import { ref } from 'vue'
 import { withQuery } from 'ufo'
 import type { NuxtLinkOptions, NuxtLinkProps } from '../src/app/components/nuxt-link.ts'
-import { defineNuxtLink } from '../src/app/components/nuxt-link.ts'
+import { defineNuxtLink, resolveCustomLinkEl } from '../src/app/components/nuxt-link.ts'
 import { useRuntimeConfig } from '../src/app/nuxt.ts'
 
 // mocks `useRuntimeConfig()`
@@ -412,6 +412,29 @@ describe('nuxt-link:propsOrAttributes', () => {
         expect(nuxtLink({ to: '/to/', external: true }, removeSlashOptions).props.href).toBe('/to')
       })
     })
+  })
+})
+
+describe('nuxt-link:resolveCustomLinkEl', () => {
+  const ELEMENT_NODE = 1
+  const TEXT_NODE = 3
+  const COMMENT_NODE = 8
+
+  it('returns the root when it is already an element (single-vnode `custom` slot)', () => {
+    const a = { nodeType: ELEMENT_NODE, tagName: 'A', nextElementSibling: null }
+    expect(resolveCustomLinkEl(a as unknown as Node)).toBe(a)
+  })
+
+  it('returns the next element sibling when the root is a marker node (fragment `custom` slot)', () => {
+    const a = { nodeType: ELEMENT_NODE, tagName: 'A' }
+    expect(resolveCustomLinkEl({ nodeType: COMMENT_NODE, nextElementSibling: a } as unknown as Node)).toBe(a)
+    expect(resolveCustomLinkEl({ nodeType: TEXT_NODE, nextElementSibling: a } as unknown as Node)).toBe(a)
+  })
+
+  it('returns `null` when there is no resolvable element', () => {
+    expect(resolveCustomLinkEl(null)).toBe(null)
+    expect(resolveCustomLinkEl(undefined)).toBe(null)
+    expect(resolveCustomLinkEl({ nodeType: TEXT_NODE, nextElementSibling: null } as unknown as Node)).toBe(null)
   })
 })
 

--- a/test/nuxt/components.test.ts
+++ b/test/nuxt/components.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import { flushPromises } from '@vue/test-utils'
+import { createSSRApp, h } from 'vue'
 
 import { nuxtLinkDefaults } from '#build/nuxt.config.mjs'
 
@@ -70,6 +71,33 @@ describe('nuxt-link:prefetch', () => {
     await observer.trigger()
     expect(nuxtApp.hooks.callHook).not.toHaveBeenCalled()
   })
+
+  it('should prefetch custom links rendering a single element on visibility', async () => {
+    const component = defineNuxtLink(nuxtLinkDefaults)
+    const nuxtApp = useNuxtApp()
+    const router = useRouter()
+    nuxtApp.hooks.callHook = vi.fn(() => Promise.resolve())
+
+    // hydrate existing markup so `$el` is the `<a>` itself. a single-root custom slot
+    // has no fragment marker, and a fresh mount would add one that masks the bug (#14897/#19375)
+    const container = document.createElement('div')
+    container.innerHTML = '<a href="/to">link</a>'
+    document.body.appendChild(container)
+
+    const { observer } = useMockObserver()
+
+    createSSRApp({
+      setup: () => () => h(component, { to: '/to', custom: true }, { default: ({ href }: { href: string }) => h('a', { href }, 'link') }),
+    }).use(router).mount(container)
+
+    await vi.waitFor(() => expect(observer.observed()?.tagName).toBe('A'))
+
+    expect(nuxtApp.hooks.callHook).not.toHaveBeenCalled()
+    await observer.trigger()
+    expect(nuxtApp.hooks.callHook).toHaveBeenCalledTimes(1)
+
+    container.remove()
+  })
 })
 
 describe('nuxt-link:hash-focus', () => {
@@ -120,6 +148,7 @@ function useMockObserver () {
     observe = (_el: HTMLElement) => { el = _el }
 
     trigger = () => callback?.([{ target: el, isIntersecting: true }])
+    observed = () => el
     unobserve = () => {}
     disconnect = () => {}
   }


### PR DESCRIPTION
Custom NuxtLinks that render a single element don't prefetch on visibility after SSR. The observer never gets attached, so the route only loads on click.

We resolve the element to observe like this:

```ts
el!.value = props.custom ? ref?.$el?.nextElementSibling : ref?.$el
```

The `nextElementSibling` assumes the custom slot renders a fragment, so `RouterLink.$el` is a leading marker node and the actual element is its next sibling. But vue-router renders a single-root slot directly via `preferSingleVNode`, so `$el` is the `<a>` itself and `nextElementSibling` is `null`. No observe, no prefetch.

So anything wrapping NuxtLink in `custom` mode is affected. On the Nuxt UI docs template for instance the whole sidebar stops prefetching, only the one plain NuxtLink does.

Fixed by using `$el` directly when it's already an element and only falling back to `nextElementSibling` for the fragment case.

One gotcha while testing: this doesn't repro in a plain client mount, because Vue sticks a text node in front of the element and the old code resolves it by accident. It only breaks after hydration when `$el` is the real `<a>`, so the test hydrates pre-rendered markup instead of mounting from scratch. There's also a small unit test pinning the resolution logic on its own.
