### PR TITLE
fix(nuxt): expose prefetch for custom links

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -426,7 +426,7 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
         ])
       }
 
-      if (import.meta.client) {
+      if (import.meta.client && !props.custom) {
         checkPropConflicts(props, 'noPrefetch', 'prefetch')
         if (shouldPrefetch('visibility')) {
           const nuxtApp = useNuxtApp()
@@ -490,11 +490,23 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
             routerLinkProps.rel = props.rel || undefined
           }
 
+          const routerLinkSlots = props.custom
+            ? {
+                default: (slotProps: Record<string, unknown>) => slots.default?.({
+                  ...slotProps,
+                  prefetch,
+                  rel: props.rel || null,
+                  target: props.target || null,
+                  isExternal: false,
+                }),
+              }
+            : slots.default
+
           // Internal link
           return h(
             resolveComponent('RouterLink'),
             routerLinkProps,
-            slots.default,
+            routerLinkSlots,
           )
         }
 

--- a/test/nuxt/components.test.ts
+++ b/test/nuxt/components.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import { flushPromises } from '@vue/test-utils'
+import { h } from 'vue'
 
 import { nuxtLinkDefaults } from '#build/nuxt.config.mjs'
 
@@ -69,6 +70,45 @@ describe('nuxt-link:prefetch', () => {
 
     await observer.trigger()
     expect(nuxtApp.hooks.callHook).not.toHaveBeenCalled()
+  })
+
+  it('should not prefetch custom links on visibility', async () => {
+    const component = defineNuxtLink(nuxtLinkDefaults)
+    const nuxtApp = useNuxtApp()
+    nuxtApp.hooks.callHook = vi.fn(() => Promise.resolve())
+
+    const { observer } = useMockObserver()
+    await mountSuspended(component, {
+      props: { to: '/to', custom: true },
+      slots: {
+        default: ({ href, navigate }: { href: string, navigate: (e?: MouseEvent) => Promise<void> }) =>
+          h('a', { href, onClick: navigate }, 'to'),
+      },
+    })
+
+    await observer.trigger()
+    expect(nuxtApp.hooks.callHook).not.toHaveBeenCalled()
+  })
+
+  it('should expose prefetch to custom links', async () => {
+    const component = defineNuxtLink(nuxtLinkDefaults)
+    const nuxtApp = useNuxtApp()
+    nuxtApp.hooks.callHook = vi.fn(() => Promise.resolve())
+    let prefetch: ((nuxtApp?: ReturnType<typeof useNuxtApp>) => Promise<void>) | undefined
+
+    await mountSuspended(component, {
+      props: { to: '/to', custom: true },
+      slots: {
+        default: (slotProps: { href: string, navigate: (e?: MouseEvent) => Promise<void>, prefetch?: typeof prefetch }) => {
+          prefetch = slotProps.prefetch
+          return h('a', { href: slotProps.href, onClick: slotProps.navigate }, 'to')
+        },
+      },
+    })
+
+    expect(prefetch).toEqual(expect.any(Function))
+    await prefetch?.(nuxtApp)
+    expect(nuxtApp.hooks.callHook).toHaveBeenCalledTimes(1)
   })
 })
 


### PR DESCRIPTION
## Summary
- stop NuxtLink from attaching the automatic visibility observer when `custom` is enabled
- wrap internal RouterLink custom slots so they keep RouterLink props while also receiving Nuxt `prefetch`
- add runtime tests for no automatic custom-link visibility prefetching and manual custom-link prefetching

## Motivation
This follows the discussion in #35493, especially https://github.com/nuxt/nuxt/pull/35493#issuecomment-4845043732 and https://github.com/nuxt/nuxt/pull/35493#issuecomment-4845059841.

The existing render path already skipped interaction prefetch handlers for custom links, so this makes visibility prefetching follow the same contract: consumers using `custom` own when to call `prefetch`.

The `routerLinkSlots` wrapper is needed for internal custom links because those are rendered through Vue Router. Without wrapping the slot, the consumer only receives RouterLink slot props, so Nuxt UI would not have a Nuxt `prefetch` function to call manually after the automatic observer is removed. The wrapper preserves RouterLink props and injects Nuxt-specific custom slot props such as `prefetch`.

## Tests
- `./node_modules/.bin/vitest run --project nuxt test/nuxt/components.test.ts`
- `./node_modules/.bin/vitest run --project unit packages/nuxt/test/nuxt-link.test.ts`
- `./node_modules/.bin/eslint packages/nuxt/src/app/components/nuxt-link.ts test/nuxt/components.test.ts`