### PR TITLE
feat(nuxt): inline critical CSS with beasties

### DIFF
--- a/docs/3.guide/6.going-further/1.features.md
+++ b/docs/3.guide/6.going-further/1.features.md
@@ -39,6 +39,24 @@ export default defineNuxtConfig({
 })
 ```
 
+### criticalStyles
+
+Inlines the critical CSS of your remaining stylesheets and lazy-loads the rest, powered by [`beasties`](https://github.com/danielroe/beasties). It processes the fully rendered HTML, so it applies to prerendered and server-rendered (non-streamed) responses. It is disabled in development and when `ssr` is `false`, and is skipped for non-server-rendered routes (`ssr: false`) since critical CSS must be derived from server-rendered markup.
+
+This composes with [`inlineStyles`](#inlinestyles): that feature inlines component CSS, while this one optimises any stylesheets that remain (such as global CSS). Styles already inlined by `inlineStyles` are left untouched unless you set `reduceInlineStyles: true`.
+
+It is most beneficial for prerendered or cached routes: for on-demand SSR it re-reads your stylesheets on each response, and it has no effect when stylesheets are served from an external origin (for example via `app.cdnURL`).
+
+Pass `true` to enable with defaults, or an object to forward [options to `beasties`](https://github.com/danielroe/beasties#usage). Options are serialized at build time, so only JSON-serializable values are forwarded — use string selectors in `allowRules` (a `RegExp` or function option is not passed through).
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  features: {
+    criticalStyles: true, // or an object of `beasties` options
+  },
+})
+```
+
 ### noScripts
 
 Turn off rendering of Nuxt scripts and JavaScript resource hints. Can also be configured granularly within `routeRules`.

--- a/packages/nitro-server/package.json
+++ b/packages/nitro-server/package.json
@@ -35,6 +35,7 @@
     "@nuxt/kit": "workspace:*",
     "@unhead/vue": "^3.1.6",
     "@vue/shared": "3.5.38",
+    "beasties": "^0.4.2",
     "consola": "^3.4.2",
     "defu": "^6.1.7",
     "destr": "^2.0.5",

--- a/packages/nitro-server/src/critical-styles.test.ts
+++ b/packages/nitro-server/src/critical-styles.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from 'vitest'
+import Beasties from 'beasties'
+import type { Options as BeastiesOptions } from 'beasties'
+import { resolveBeastiesOptions } from './runtime/utils/renderer/critical-styles-options.ts'
+
+// These tests exercise every `beasties` option that has an observable effect, run directly
+// (no Nuxt build) so the whole `criticalStyles` option surface is covered cheaply. The most
+// important guarantee is that our defaults never prune styles emitted by `features.inlineStyles`.
+
+const SHEET = '.used{--used-token:1}.unused{--unused-token:1}'
+
+function run (html: string, options: boolean | BeastiesOptions = true, sheets: Record<string, string> = { '/main.css': SHEET }) {
+  class TestBeasties extends Beasties {
+    override getCssAsset (href: string) {
+      return sheets[href]
+    }
+
+    writeFile () {
+      return Promise.resolve()
+    }
+  }
+  return new TestBeasties(resolveBeastiesOptions(options)).process(html)
+}
+
+const doc = (head = '', body = '<div class="used"></div>') => `<!DOCTYPE html><html><head>${head}</head><body>${body}</body></html>`
+const LINK = '<link rel="stylesheet" href="/main.css">'
+const styleBlocks = (html: string) => [...html.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/g)].map(m => m[1]!)
+
+describe('resolveBeastiesOptions defaults', () => {
+  it('forces silent logging and disabled inline-style reduction', () => {
+    expect(resolveBeastiesOptions(true)).toMatchObject({ logLevel: 'silent', reduceInlineStyles: false })
+  })
+
+  it('merges and lets user options win over defaults', () => {
+    expect(resolveBeastiesOptions({ reduceInlineStyles: true, preload: 'swap' })).toMatchObject({
+      logLevel: 'silent',
+      reduceInlineStyles: true,
+      preload: 'swap',
+    })
+  })
+
+  it('treats false/true as an empty option set', () => {
+    expect(resolveBeastiesOptions(false)).toEqual({ logLevel: 'silent', reduceInlineStyles: false })
+  })
+})
+
+describe('default behaviour', () => {
+  it('inlines critical rules and drops non-critical ones', async () => {
+    const out = await run(doc(LINK))
+    expect(styleBlocks(out).join('')).toContain('--used-token')
+    expect(out).not.toContain('--unused-token')
+  })
+
+  it('does not prune pre-existing inline styles (inlineStyles safety)', async () => {
+    // `.keep` is absent from the DOM; with our `reduceInlineStyles: false` default it must survive.
+    const out = await run(doc(LINK + '<style>.keep{--keep-token:1}</style>'))
+    expect(out).toContain('--keep-token')
+  })
+})
+
+describe('reduceInlineStyles', () => {
+  it('prunes inline styles for absent selectors when explicitly enabled', async () => {
+    const out = await run(doc('<style>.keep{--keep-token:1}</style>'), { reduceInlineStyles: true })
+    expect(out).not.toContain('--keep-token')
+  })
+})
+
+describe('external', () => {
+  it('skips external stylesheets when disabled', async () => {
+    const out = await run(doc(LINK), { external: false })
+    expect(out).not.toContain('--used-token')
+    expect(out).toMatch(/<link [^>]*rel="stylesheet"/)
+  })
+})
+
+describe('allowRules', () => {
+  it('force-includes matched selectors that are not in the DOM', async () => {
+    const out = await run(doc(LINK), { allowRules: ['.unused'] })
+    expect(styleBlocks(out).join('')).toContain('--unused-token')
+  })
+})
+
+describe('inlineThreshold', () => {
+  it('inlines the whole sheet when it is below the threshold', async () => {
+    const out = await run(doc(LINK), { inlineThreshold: 10_000 })
+    expect(styleBlocks(out).join('')).toContain('--unused-token')
+  })
+})
+
+describe('pruneSource', () => {
+  it('still inlines critical CSS without throwing', async () => {
+    const out = await run(doc(LINK), { pruneSource: true })
+    expect(styleBlocks(out).join('')).toContain('--used-token')
+  })
+})
+
+describe('mergeStylesheets', () => {
+  const sheets = { '/a.css': '.used{--a-token:1}', '/b.css': '.second{--b-token:1}' }
+  const twoLinks = doc('<link rel="stylesheet" href="/a.css"><link rel="stylesheet" href="/b.css">', '<div class="used"></div><div class="second"></div>')
+
+  it('merges inlined stylesheets into a single tag by default', async () => {
+    const out = await run(twoLinks, true, sheets)
+    expect(styleBlocks(out)).toHaveLength(1)
+  })
+
+  it('keeps stylesheets separate when disabled', async () => {
+    const out = await run(twoLinks, { mergeStylesheets: false }, sheets)
+    expect(styleBlocks(out).length).toBeGreaterThan(1)
+  })
+})
+
+describe('preload strategy', () => {
+  it('default converts the link to a preload', async () => {
+    const out = await run(doc(LINK))
+    expect(out).toMatch(/<link [^>]*rel="preload"[^>]*as="style"/)
+  })
+
+  it('"swap" flips rel on load', async () => {
+    const out = await run(doc(LINK), { preload: 'swap' })
+    expect(out).toContain('this.rel=\'stylesheet\'')
+  })
+
+  it('"media" uses the print-media swap', async () => {
+    const out = await run(doc(LINK), { preload: 'media' })
+    expect(out).toMatch(/media="print"/)
+  })
+
+  it('"js" injects a loader script', async () => {
+    const out = await run(doc(LINK), { preload: 'js' })
+    expect(out).toContain('$loadcss')
+  })
+
+  it('"body" moves the stylesheet into the body', async () => {
+    const out = await run(doc(LINK), { preload: 'body' })
+    const bodyStart = out.indexOf('<body')
+    expect(out.indexOf('rel="stylesheet"')).toBeGreaterThan(bodyStart)
+  })
+})
+
+describe('noscriptFallback', () => {
+  it('adds a noscript fallback by default for js-based strategies', async () => {
+    const out = await run(doc(LINK), { preload: 'swap' })
+    expect(out).toContain('<noscript>')
+  })
+
+  it('omits the noscript fallback when disabled', async () => {
+    const out = await run(doc(LINK), { preload: 'swap', noscriptFallback: false })
+    expect(out).not.toContain('<noscript>')
+  })
+})
+
+describe('keyframes', () => {
+  const sheets = { '/main.css': '.used{animation:spin 1s}@keyframes spin{from{opacity:0}to{opacity:1}}@keyframes ghost{from{opacity:0}to{opacity:1}}' }
+
+  it('keeps only critical keyframes by default', async () => {
+    const out = await run(doc(LINK), true, sheets)
+    const css = styleBlocks(out).join('')
+    expect(css).toContain('@keyframes spin')
+    expect(css).not.toContain('@keyframes ghost')
+  })
+
+  it('drops all keyframes when set to "none"', async () => {
+    const out = await run(doc(LINK), { keyframes: 'none' }, sheets)
+    expect(styleBlocks(out).join('')).not.toContain('@keyframes spin')
+  })
+
+  it('keeps all keyframes when set to "all"', async () => {
+    const out = await run(doc(LINK), { keyframes: 'all' }, sheets)
+    expect(styleBlocks(out).join('')).toContain('@keyframes ghost')
+  })
+})
+
+describe('fonts', () => {
+  const sheets = { '/main.css': '@font-face{font-family:Test;src:url(/t.woff2)}.used{font-family:Test}' }
+
+  it('inlines critical @font-face when inlineFonts is enabled', async () => {
+    const out = await run(doc(LINK), { inlineFonts: true }, sheets)
+    expect(styleBlocks(out).join('')).toContain('@font-face')
+  })
+})
+
+describe('compress', () => {
+  const sheets = { '/main.css': '.used { --used-token: 1 }' }
+
+  it('minifies inlined CSS by default', async () => {
+    const out = await run(doc(LINK), true, sheets)
+    expect(styleBlocks(out).join('')).toContain('--used-token:1')
+  })
+
+  it('preserves formatting when disabled', async () => {
+    const out = await run(doc(LINK), { compress: false }, sheets)
+    expect(styleBlocks(out).join('')).toMatch(/--used-token:\s+1/)
+  })
+})
+
+describe('safeParser', () => {
+  it('tolerates malformed CSS without throwing', async () => {
+    const sheets = { '/main.css': '.used{--used-token:1}.broken{color:}' }
+    await expect(run(doc(LINK), true, sheets)).resolves.toContain('--used-token')
+  })
+})

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -115,6 +115,12 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
     }
   }
 
+  // Only pull `beasties` into the bundle when critical CSS inlining is enabled.
+  nuxt.options.nitro.virtual ||= {}
+  nuxt.options.nitro.virtual['#internal/nuxt/critical-styles.mjs'] = () => nuxt.options.features.criticalStyles
+    ? `export { renderCriticalStyles } from ${JSON.stringify(resolve(distDir, 'runtime/utils/renderer/critical-styles'))}`
+    : `export const renderCriticalStyles = (html) => html`
+
   const mockProxy = resolveModulePath('mocked-exports/proxy', { from: import.meta.url })
 
   const nitroConfig: NitroConfig = defu(nuxt.options.nitro, {
@@ -186,6 +192,8 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
           `export const NUXT_EARLY_HINTS = ${nuxt.options.experimental.writeEarlyHints !== false}`,
           `export const NUXT_NO_SCRIPTS = ${nuxt.options.features.noScripts === 'all' || (!!nuxt.options.features.noScripts && !nuxt.options.dev)}`,
           `export const NUXT_INLINE_STYLES = ${!!nuxt.options.features.inlineStyles}`,
+          `export const NUXT_CRITICAL_STYLES = ${JSON.stringify(nuxt.options.features.criticalStyles ?? false)}`,
+          `export const NUXT_CLIENT_DIR = ${JSON.stringify(resolve(nuxt.options.buildDir, 'dist/client'))}`,
           `export const PARSE_ERROR_DATA = ${!!nuxt.options.experimental.parseErrorData}`,
           `export const NUXT_ASYNC_CONTEXT = ${!!nuxt.options.experimental.asyncContext}`,
           `export const NUXT_SHARED_DATA = ${!!nuxt.options.experimental.sharedPrerenderData}`,

--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -27,7 +27,7 @@ import { renderStreamedIslandTeleports, replaceIslandTeleports } from '../utils/
 // @ts-expect-error virtual file
 import { renderSSRHeadOptions } from '#internal/unhead.config.mjs'
 // @ts-expect-error virtual file
-import { NUXT_ASYNC_CONTEXT, NUXT_EARLY_HINTS, NUXT_INLINE_STYLES, NUXT_NO_SCRIPTS, NUXT_PAYLOAD_EXTRACTION, NUXT_PAYLOAD_INLINE, NUXT_RUNTIME_PAYLOAD_EXTRACTION, NUXT_SSR_STREAMING, NUXT_SSR_STREAMING_BOT_RE, PARSE_ERROR_DATA } from '#internal/nuxt/nitro-config.mjs'
+import { NUXT_ASYNC_CONTEXT, NUXT_CRITICAL_STYLES, NUXT_EARLY_HINTS, NUXT_INLINE_STYLES, NUXT_NO_SCRIPTS, NUXT_PAYLOAD_EXTRACTION, NUXT_PAYLOAD_INLINE, NUXT_RUNTIME_PAYLOAD_EXTRACTION, NUXT_SSR_STREAMING, NUXT_SSR_STREAMING_BOT_RE, PARSE_ERROR_DATA } from '#internal/nuxt/nitro-config.mjs'
 // @ts-expect-error virtual file
 import { appHead, appTeleportAttrs, appTeleportTag, componentIslands, componentIslandsActive, tracingChannelNuxt } from '#internal/nuxt.config.mjs'
 // @ts-expect-error virtual file
@@ -382,7 +382,16 @@ async function renderRoute (event: H3Event, ssrError?: (NuxtPayload['error'] & {
   event.res.headers.set('content-type', 'text/html;charset=utf-8')
   event.res.headers.set('x-powered-by', 'Nuxt')
 
-  return new FastResponse(renderHTMLDocument(htmlContext), event.res)
+  let html = renderHTMLDocument(htmlContext)
+  // Skip the SPA shell: critical CSS must be derived from server-rendered markup.
+  // Loaded on demand so `beasties` is never bundled into the hot path when disabled.
+  if (NUXT_CRITICAL_STYLES && !ssrContext.noSSR) {
+    // @ts-expect-error virtual file
+    const { renderCriticalStyles } = await import('#internal/nuxt/critical-styles.mjs')
+    html = await renderCriticalStyles(html, NUXT_CRITICAL_STYLES).catch(() => html)
+  }
+
+  return new FastResponse(html, event.res)
 }
 
 async function renderStreamedResponse (ctx: {

--- a/packages/nitro-server/src/runtime/utils/renderer/critical-styles-options.ts
+++ b/packages/nitro-server/src/runtime/utils/renderer/critical-styles-options.ts
@@ -1,0 +1,10 @@
+import type { Options as BeastiesOptions } from 'beasties'
+
+export function resolveBeastiesOptions (options: boolean | BeastiesOptions): BeastiesOptions {
+  return {
+    logLevel: 'silent',
+    // Leave styles already inlined by `features.inlineStyles` untouched so the two compose safely.
+    reduceInlineStyles: false,
+    ...(typeof options === 'object' && options ? options : {}),
+  }
+}

--- a/packages/nitro-server/src/runtime/utils/renderer/critical-styles.ts
+++ b/packages/nitro-server/src/runtime/utils/renderer/critical-styles.ts
@@ -1,0 +1,48 @@
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'pathe'
+import Beasties from 'beasties'
+import type { Options as BeastiesOptions } from 'beasties'
+import { serverFetch } from 'nitro/app'
+import { baseURL } from '../paths'
+import { resolveBeastiesOptions } from './critical-styles-options'
+// @ts-expect-error virtual file
+import { NUXT_CLIENT_DIR } from '#internal/nuxt/nitro-config.mjs'
+
+let beasties: Beasties | undefined
+
+class NuxtBeasties extends Beasties {
+  // Resolve stylesheets without assuming where public assets live: read from the
+  // prerender output on disk, and from the running server otherwise.
+  override async getCssAsset (href: string): Promise<string | undefined> {
+    // Only same-origin, non-protocol-relative paths; hrefs come from build-generated links.
+    if (typeof href !== 'string' || href[0] !== '/' || href[1] === '/') {
+      return undefined
+    }
+    const path = href.replace(/\?.*$/, '')
+    let css: string | undefined
+    if (import.meta.prerender) {
+      const base = baseURL()
+      const rel = base !== '/' && path.startsWith(base) ? path.slice(base.length) : path
+      const file = resolve(NUXT_CLIENT_DIR, rel.replace(/^\/+/, ''))
+      if (file !== NUXT_CLIENT_DIR && !file.startsWith(NUXT_CLIENT_DIR + '/')) {
+        return undefined
+      }
+      css = await readFile(file, 'utf-8').catch(() => undefined)
+    } else {
+      const res = await serverFetch(path).catch(() => undefined)
+      css = res?.ok ? await res.text() : undefined
+    }
+    // Never inline content that could break out of the `<style>` context.
+    return css && !/<\/style/i.test(css) ? css : undefined
+  }
+
+  // Critical CSS is computed in-memory; never let `pruneSource` write sheets back to disk.
+  writeFile (): Promise<void> {
+    return Promise.resolve()
+  }
+}
+
+export function renderCriticalStyles (html: string, options: boolean | BeastiesOptions): Promise<string> {
+  beasties ||= new NuxtBeasties(resolveBeastiesOptions(options))
+  return beasties.process(html)
+}

--- a/packages/nitro-server/tsdown.config.ts
+++ b/packages/nitro-server/tsdown.config.ts
@@ -29,6 +29,7 @@ export default defineConfig([
         '#internal/nuxt/app-config',
         '#internal/nuxt/entry-ids.mjs',
         '#internal/nuxt/nitro-config.mjs',
+        '#internal/nuxt/critical-styles.mjs',
         '#internal/unhead.config.mjs',
         '#internal/unhead-options.mjs',
         '#spa-template',

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -47,6 +47,7 @@
     "@vue/compiler-sfc": "3.5.38",
     "@vue/language-core": "3.3.5",
     "autoprefixer": "10.5.2",
+    "beasties": "0.4.2",
     "c12": "3.3.4",
     "chokidar": "5.0.0",
     "compatx": "0.2.0",

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -37,6 +37,17 @@ export default defineResolvers({
         return val ?? ((id?: string) => !!id && id.includes('.vue'))
       },
     },
+    criticalStyles: {
+      async $resolve (val, get) {
+        if (val !== true && (typeof val !== 'object' || val === null)) {
+          return false
+        }
+        if ((await get('dev')) || (await get('ssr')) === false) {
+          return false
+        }
+        return val
+      },
+    },
     devLogs: {
       async $resolve (val, get) {
         if (typeof val === 'boolean' || val === 'silent') {

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -15,6 +15,7 @@ import type { CorsOptions, H3CorsOptions } from 'h3'
 import type { NuxtLinkOptions } from 'nuxt/app'
 import type { FetchOptions } from 'ofetch'
 import type { Options as AutoprefixerOptions } from 'autoprefixer'
+import type { Options as BeastiesOptions } from 'beasties'
 import type { Options as CssnanoOptions } from 'cssnano'
 import type { TSConfig } from 'pkg-types'
 import type { RawVueCompilerOptions } from '@vue/language-core'
@@ -1052,6 +1053,17 @@ export interface ConfigSchema {
    * You can also pass a function that receives the path of a Vue component and returns a boolean indicating whether to inline the styles for that component.
    */
     inlineStyles: boolean | ((id?: string) => boolean)
+
+    /**
+     * Inline critical CSS and lazy-load the rest of your stylesheets when rendering HTML, powered by [`beasties`](https://github.com/danielroe/beasties).
+     *
+     * Pass `true` to enable with defaults, or an object to forward options to `beasties`. Options are serialized at build time, so only JSON-serializable values are forwarded (use string selectors in `allowRules`).
+     *
+     * This processes the fully rendered HTML document, so it applies to prerendered and (buffered) server-rendered responses, but not to streamed responses. It is disabled in development, when `ssr` is `false`, and for non-server-rendered (`ssr: false`) routes.
+     *
+     * It composes with `inlineStyles`: that feature inlines component CSS, while this one inlines the critical part of any remaining external stylesheets and lazy-loads the rest. Styles already inlined by `inlineStyles` are left untouched unless you opt in via `reduceInlineStyles`.
+     */
+    criticalStyles: boolean | BeastiesOptions
 
     /**
      * Stream server logs to the client as you are developing. These logs can be handled in the `dev:ssr-logs` hook.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -338,10 +338,13 @@ importers:
         version: link:../kit
       '@unhead/vue':
         specifier: ^3.1.6
-        version: 3.1.6(@rspack/core@2.0.8)(crossws@0.4.5(srvx@0.11.17))(esbuild@0.28.1)(lightningcss@1.32.0)(rolldown@1.1.3)(rollup@4.62.2)(typescript@6.0.3)(vite@8.1.0)(vue@3.5.38(typescript@6.0.3))(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0))
+        version: 3.1.6(@rspack/core@2.0.8)(crossws@0.4.5(srvx@0.11.17))(esbuild@0.28.1)(lightningcss@1.32.0)(rolldown@1.1.3)(rollup@4.62.2)(typescript@6.0.3)(vite@8.1.0)(vue@3.5.38(typescript@6.0.3))(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
       '@vue/shared':
         specifier: 3.5.38
         version: 3.5.38
+      beasties:
+        specifier: ^0.4.2
+        version: 0.4.2
       consola:
         specifier: ^3.4.2
         version: 3.4.2
@@ -365,7 +368,7 @@ importers:
         version: 1.1.0
       impound:
         specifier: ^1.1.5
-        version: 1.1.5(@rspack/core@2.0.8)(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0))
+        version: 1.1.5(@rspack/core@2.0.8)(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
       klona:
         specifier: ^2.0.6
         version: 2.0.6
@@ -853,6 +856,9 @@ importers:
       autoprefixer:
         specifier: 10.5.2
         version: 10.5.2(postcss@8.5.15)
+      beasties:
+        specifier: 0.4.2
+        version: 0.4.2
       c12:
         specifier: 3.3.4
         version: 3.3.4(magicast@0.5.3)
@@ -1332,6 +1338,12 @@ importers:
   test/fixtures/basic-types/_local-modules/hook-augmenting-module: {}
 
   test/fixtures/build-assets-dir-collision:
+    dependencies:
+      nuxt:
+        specifier: workspace:*
+        version: link:../../../packages/nuxt
+
+  test/fixtures/critical-styles:
     dependencies:
       nuxt:
         specifier: workspace:*
@@ -10181,6 +10193,25 @@ snapshots:
       - vite
       - webpack
 
+  '@devframes/hub@0.5.4(@rspack/core@2.0.8)(devframe@0.5.4(@rspack/core@2.0.8)(crossws@0.4.5(srvx@0.11.17))(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(typescript@6.0.3)(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)))(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))':
+    dependencies:
+      birpc: 4.0.0
+      devframe: 0.5.4(@rspack/core@2.0.8)(crossws@0.4.5(srvx@0.11.17))(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(typescript@6.0.3)(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0))
+      nostics: 0.2.0(@rspack/core@2.0.8)(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      tinyexec: 1.2.4
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rspack/core'
+      - bun-types-no-globals
+      - esbuild
+      - rolldown
+      - rollup
+      - unloader
+      - vite
+      - webpack
+
   '@devframes/hub@0.5.4(@rspack/core@2.0.8)(devframe@0.5.4(@rspack/core@2.0.8)(crossws@0.4.5(srvx@0.11.17))(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(typescript@6.0.3)(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)))(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0))':
     dependencies:
       birpc: 4.0.0
@@ -12241,6 +12272,33 @@ snapshots:
       - unloader
       - utf-8-validate
 
+  '@unhead/bundler@3.1.6(@rspack/core@2.0.8)(crossws@0.4.5(srvx@0.11.17))(esbuild@0.28.1)(lightningcss@1.32.0)(rolldown@1.1.3)(rollup@4.62.2)(typescript@6.0.3)(unhead@3.1.6(@rspack/core@2.0.8)(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)))(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))':
+    dependencies:
+      '@vitejs/devtools-kit': 0.3.3(@rspack/core@2.0.8)(crossws@0.4.5(srvx@0.11.17))(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(typescript@6.0.3)(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
+      magic-string: 0.30.21
+      oxc-parser: 0.137.0
+      oxc-walker: 1.0.0(@rspack/core@2.0.8)(esbuild@0.28.1)(oxc-parser@0.137.0)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
+      ufo: 1.6.4
+      unhead: 3.1.6(@rspack/core@2.0.8)(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0))
+      unplugin: 3.2.0(@rspack/core@2.0.8)(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
+    optionalDependencies:
+      esbuild: 0.28.1
+      lightningcss: 1.32.0
+      rolldown: 1.1.3
+      vite: 8.1.0(@types/node@24.13.2)(@vitejs/devtools@0.3.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
+      webpack: 5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@modelcontextprotocol/sdk'
+      - '@rspack/core'
+      - bufferutil
+      - bun-types-no-globals
+      - crossws
+      - rollup
+      - typescript
+      - unloader
+      - utf-8-validate
+
   '@unhead/bundler@3.1.6(@rspack/core@2.0.8)(crossws@0.4.5(srvx@0.11.17))(esbuild@0.28.1)(lightningcss@1.32.0)(rolldown@1.1.3)(rollup@4.62.2)(typescript@6.0.3)(unhead@3.1.6(@rspack/core@2.0.8)(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)))(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0))':
     dependencies:
       '@vitejs/devtools-kit': 0.3.3(@rspack/core@2.0.8)(crossws@0.4.5(srvx@0.11.17))(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(typescript@6.0.3)(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0))
@@ -12278,6 +12336,32 @@ snapshots:
     optionalDependencies:
       vite: 8.1.0(@types/node@24.13.2)(@vitejs/devtools@0.3.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
       webpack: 5.107.2(cssnano@8.0.2(postcss@8.5.15))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@modelcontextprotocol/sdk'
+      - '@rspack/core'
+      - '@unhead/cli'
+      - bufferutil
+      - bun-types-no-globals
+      - crossws
+      - esbuild
+      - lightningcss
+      - rolldown
+      - rollup
+      - typescript
+      - unloader
+      - utf-8-validate
+
+  '@unhead/vue@3.1.6(@rspack/core@2.0.8)(crossws@0.4.5(srvx@0.11.17))(esbuild@0.28.1)(lightningcss@1.32.0)(rolldown@1.1.3)(rollup@4.62.2)(typescript@6.0.3)(vite@8.1.0)(vue@3.5.38(typescript@6.0.3))(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))':
+    dependencies:
+      '@unhead/bundler': 3.1.6(@rspack/core@2.0.8)(crossws@0.4.5(srvx@0.11.17))(esbuild@0.28.1)(lightningcss@1.32.0)(rolldown@1.1.3)(rollup@4.62.2)(typescript@6.0.3)(unhead@3.1.6(@rspack/core@2.0.8)(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)))(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
+      hookable: 6.1.1
+      unhead: 3.1.6(@rspack/core@2.0.8)(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
+      unplugin: 3.2.0(@rspack/core@2.0.8)(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
+      vue: 3.5.38(typescript@6.0.3)
+    optionalDependencies:
+      vite: 8.1.0(@types/node@24.13.2)(@vitejs/devtools@0.3.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
+      webpack: 5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@modelcontextprotocol/sdk'
@@ -12577,6 +12661,32 @@ snapshots:
       devframe: 0.5.4(@rspack/core@2.0.8)(crossws@0.4.5(srvx@0.11.17))(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(typescript@6.0.3)(vite@8.1.0)(webpack@5.107.2(cssnano@8.0.2(postcss@8.5.15))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
       mlly: 1.8.2
       nostics: 0.3.0(@rspack/core@2.0.8)(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0)(webpack@5.107.2(cssnano@8.0.2(postcss@8.5.15))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      tinyexec: 1.2.4
+      vite: 8.1.0(@types/node@24.13.2)(@vitejs/devtools@0.3.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@modelcontextprotocol/sdk'
+      - '@rspack/core'
+      - bufferutil
+      - bun-types-no-globals
+      - crossws
+      - esbuild
+      - rolldown
+      - rollup
+      - typescript
+      - unloader
+      - utf-8-validate
+      - webpack
+
+  '@vitejs/devtools-kit@0.3.3(@rspack/core@2.0.8)(crossws@0.4.5(srvx@0.11.17))(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(typescript@6.0.3)(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))':
+    dependencies:
+      '@devframes/hub': 0.5.4(@rspack/core@2.0.8)(devframe@0.5.4(@rspack/core@2.0.8)(crossws@0.4.5(srvx@0.11.17))(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(typescript@6.0.3)(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)))(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
+      birpc: 4.0.0
+      devframe: 0.5.4(@rspack/core@2.0.8)(crossws@0.4.5(srvx@0.11.17))(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(typescript@6.0.3)(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
+      mlly: 1.8.2
+      nostics: 0.3.0(@rspack/core@2.0.8)(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
       pathe: 2.0.3
       perfect-debounce: 2.1.0
       tinyexec: 1.2.4
@@ -13963,6 +14073,32 @@ snapshots:
       - vite
       - webpack
 
+  devframe@0.5.4(@rspack/core@2.0.8)(crossws@0.4.5(srvx@0.11.17))(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(typescript@6.0.3)(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)):
+    dependencies:
+      '@valibot/to-json-schema': 1.7.0(valibot@1.4.1(typescript@6.0.3))
+      birpc: 4.0.0
+      cac: 7.0.0
+      h3: 2.0.1-rc.22(crossws@0.4.5(srvx@0.11.17))
+      mrmime: 2.0.1
+      nostics: 0.2.0(@rspack/core@2.0.8)(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
+      pathe: 2.0.3
+      valibot: 1.4.1(typescript@6.0.3)
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rspack/core'
+      - bufferutil
+      - bun-types-no-globals
+      - crossws
+      - esbuild
+      - rolldown
+      - rollup
+      - typescript
+      - unloader
+      - utf-8-validate
+      - vite
+      - webpack
+
   devframe@0.5.4(@rspack/core@2.0.8)(crossws@0.4.5(srvx@0.11.17))(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(typescript@6.0.3)(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)):
     dependencies:
       '@valibot/to-json-schema': 1.7.0(valibot@1.4.1(typescript@6.0.3))
@@ -15030,6 +15166,24 @@ snapshots:
 
   import-without-cache@0.4.0: {}
 
+  impound@1.1.5(@rspack/core@2.0.8)(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      es-module-lexer: 2.1.0
+      pathe: 2.0.3
+      unplugin: 3.2.0(@rspack/core@2.0.8)(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
+      unplugin-utils: 0.3.1
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rspack/core'
+      - bun-types-no-globals
+      - esbuild
+      - rolldown
+      - rollup
+      - unloader
+      - vite
+      - webpack
+
   impound@1.1.5(@rspack/core@2.0.8)(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -15554,6 +15708,23 @@ snapshots:
       regexp-tree: 0.1.27
       type-level-regexp: 0.1.17
       unplugin: 3.2.0(@rspack/core@2.0.8)(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0)(webpack@5.107.2(cssnano@8.0.2(postcss@8.5.15))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rspack/core'
+      - bun-types-no-globals
+      - esbuild
+      - rolldown
+      - rollup
+      - unloader
+      - vite
+      - webpack
+
+  magic-regexp@0.11.0(@rspack/core@2.0.8)(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)):
+    dependencies:
+      magic-string: 0.30.21
+      regexp-tree: 0.1.27
+      type-level-regexp: 0.1.17
+      unplugin: 3.2.0(@rspack/core@2.0.8)(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@rspack/core'
@@ -16363,6 +16534,22 @@ snapshots:
       - vite
       - webpack
 
+  nostics@0.2.0(@rspack/core@2.0.8)(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)):
+    dependencies:
+      magic-string: 0.30.21
+      oxc-parser: 0.132.0
+      unplugin: 3.2.0(@rspack/core@2.0.8)(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rspack/core'
+      - bun-types-no-globals
+      - esbuild
+      - rolldown
+      - rollup
+      - unloader
+      - vite
+      - webpack
+
   nostics@0.2.0(@rspack/core@2.0.8)(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)):
     dependencies:
       magic-string: 0.30.21
@@ -16384,6 +16571,22 @@ snapshots:
       magic-string: 0.30.21
       oxc-parser: 0.132.0
       unplugin: 3.2.0(@rspack/core@2.0.8)(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0)(webpack@5.107.2(cssnano@8.0.2(postcss@8.5.15))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rspack/core'
+      - bun-types-no-globals
+      - esbuild
+      - rolldown
+      - rollup
+      - unloader
+      - vite
+      - webpack
+
+  nostics@0.3.0(@rspack/core@2.0.8)(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)):
+    dependencies:
+      magic-string: 0.30.21
+      oxc-parser: 0.132.0
+      unplugin: 3.2.0(@rspack/core@2.0.8)(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@rspack/core'
@@ -16704,6 +16907,22 @@ snapshots:
   oxc-walker@1.0.0(@rspack/core@2.0.8)(esbuild@0.28.1)(oxc-parser@0.137.0)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0)(webpack@5.107.2(cssnano@8.0.2(postcss@8.5.15))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)):
     dependencies:
       magic-regexp: 0.11.0(@rspack/core@2.0.8)(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0)(webpack@5.107.2(cssnano@8.0.2(postcss@8.5.15))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
+    optionalDependencies:
+      oxc-parser: 0.137.0
+      rolldown: 1.1.3
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rspack/core'
+      - bun-types-no-globals
+      - esbuild
+      - rollup
+      - unloader
+      - vite
+      - webpack
+
+  oxc-walker@1.0.0(@rspack/core@2.0.8)(esbuild@0.28.1)(oxc-parser@0.137.0)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)):
+    dependencies:
+      magic-regexp: 0.11.0(@rspack/core@2.0.8)(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
     optionalDependencies:
       oxc-parser: 0.137.0
       rolldown: 1.1.3
@@ -18388,6 +18607,22 @@ snapshots:
     dependencies:
       hookable: 6.1.1
       unplugin: 3.2.0(@rspack/core@2.0.8)(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0)(webpack@5.107.2(cssnano@8.0.2(postcss@8.5.15))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
+    optionalDependencies:
+      vite: 8.1.0(@types/node@24.13.2)(@vitejs/devtools@0.3.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rspack/core'
+      - bun-types-no-globals
+      - esbuild
+      - rolldown
+      - rollup
+      - unloader
+      - webpack
+
+  unhead@3.1.6(@rspack/core@2.0.8)(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)):
+    dependencies:
+      hookable: 6.1.1
+      unplugin: 3.2.0(@rspack/core@2.0.8)(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0)(webpack@5.107.2(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15))
     optionalDependencies:
       vite: 8.1.0(@types/node@24.13.2)(@vitejs/devtools@0.3.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
     transitivePeerDependencies:

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -58,7 +58,7 @@ describe.skipIf(isStubbed || process.env.SKIP_BUNDLE_SIZE === 'true' || process.
     const serverDir = join(rootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!_libs'], serverDir, rootDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"70.2k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"70.3k"`)
 
     const modules = await analyzeSizes(['_libs/**/*'], serverDir, rootDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"482k"`)
@@ -92,7 +92,7 @@ describe.skipIf(isStubbed || process.env.SKIP_BUNDLE_SIZE === 'true' || process.
     const serverDir = join(pagesRootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!_libs'], serverDir, pagesRootDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"172k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"173k"`)
 
     const modules = await analyzeSizes(['_libs/**/*'], serverDir, pagesRootDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"483k"`)

--- a/test/critical-styles.test.ts
+++ b/test/critical-styles.test.ts
@@ -1,0 +1,96 @@
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { beforeAll, describe, expect, it } from 'vitest'
+import { exec } from 'tinyexec'
+import { join } from 'pathe'
+import { builder, isBuilt, projectSuffix } from './matrix'
+
+describe.skipIf(builder !== 'vite' || !isBuilt)('critical styles', () => {
+  const rootDir = fileURLToPath(new URL('./fixtures/critical-styles', import.meta.url))
+
+  async function generate (mode: '' | 'true' | 'options') {
+    const result = await exec('pnpm', ['nuxt', 'generate', rootDir], {
+      nodeOptions: { env: { ...process.env, NUXT_TEST_CRITICAL: mode } },
+    })
+    if (result.exitCode !== 0) {
+      throw new Error(`nuxt generate (mode=${mode || 'off'}) failed:\n${result.stderr}\n${result.stdout}`)
+    }
+  }
+
+  const readOutput = (suffix: string) => readFile(join(rootDir, `.output-${projectSuffix}${suffix}`, 'public', 'index.html'), 'utf-8')
+
+  const readOutputPage = (suffix: string, page: string) => readFile(join(rootDir, `.output-${projectSuffix}${suffix}`, 'public', page, 'index.html'), 'utf-8')
+
+  let enabledHtml = ''
+  let enabledSpaHtml = ''
+  let optionsHtml = ''
+  let disabledHtml = ''
+
+  beforeAll(async () => {
+    await generate('true')
+    await generate('options')
+    await generate('')
+    enabledHtml = await readOutput('-critical')
+    enabledSpaHtml = await readOutputPage('-critical', 'spa')
+    optionsHtml = await readOutput('-options')
+    disabledHtml = await readOutput('')
+  }, 360 * 1000)
+
+  const inlinedCss = (html: string) => [...html.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/g)].map(m => m[1]!).join('')
+
+  describe('with criticalStyles disabled', () => {
+    it('still inlines component styles via inlineStyles', () => {
+      expect(inlinedCss(disabledHtml)).toMatch(/--component-token:\s*present/)
+    })
+
+    it('keeps the global stylesheet render-blocking', () => {
+      expect(disabledHtml).toMatch(/<link [^>]*rel="stylesheet"/)
+      expect(disabledHtml).not.toMatch(/rel="preload"[^>]*as="style"/)
+      // the global CSS is external, so its critical rule is not inlined
+      expect(inlinedCss(disabledHtml)).not.toContain('--global-critical')
+    })
+  })
+
+  describe('with criticalStyles enabled', () => {
+    it('inlines the critical rules of the global stylesheet and lazy-loads it', () => {
+      const css = inlinedCss(enabledHtml)
+      // rule matching the rendered DOM is inlined
+      expect(css).toMatch(/--global-critical:\s*present/)
+      // rule with no matching element is not inlined (stays in the lazy-loaded sheet)
+      expect(css).not.toContain('--global-noncritical')
+      // the render-blocking link is converted to a lazy preload
+      expect(enabledHtml).toMatch(/<link [^>]*rel="preload"[^>]*as="style"/)
+    })
+
+    it('composes with inlineStyles without dropping inlined component styles', () => {
+      // component styles inlined by inlineStyles remain intact
+      expect(inlinedCss(enabledHtml)).toMatch(/--component-token:\s*present/)
+    })
+
+    it('does not prune component styles for elements absent from the server DOM (hydration safety)', () => {
+      // `.client-only` is not server-rendered, but its styles must survive for post-hydration use
+      expect(enabledHtml).not.toContain('class="client-only"')
+      expect(inlinedCss(enabledHtml)).toMatch(/--hydration-token:\s*present/)
+    })
+  })
+
+  describe('with a non-server-rendered (ssr: false) route', () => {
+    it('does not run beasties on the SPA shell', () => {
+      // critical CSS must come from server-rendered markup, so the SPA shell is left untouched
+      expect(enabledSpaHtml).toMatch(/<link [^>]*rel="stylesheet"/)
+      expect(enabledSpaHtml).not.toMatch(/rel="preload"[^>]*as="style"/)
+      expect(inlinedCss(enabledSpaHtml)).not.toContain('--global-critical')
+    })
+  })
+
+  describe('with criticalStyles as an options object', () => {
+    it('forwards beasties options to override behaviour', () => {
+      const css = inlinedCss(optionsHtml)
+      // normal critical rule is still inlined
+      expect(css).toMatch(/--global-critical:\s*present/)
+      // `allowRules: ['.global-unused']` forces a rule with no matching element to inline,
+      // the opposite of the default behaviour — proving the options object reaches beasties
+      expect(css).toMatch(/--global-noncritical:\s*present/)
+    })
+  })
+})

--- a/test/fixtures/critical-styles/app.vue
+++ b/test/fixtures/critical-styles/app.vue
@@ -1,0 +1,7 @@
+<template>
+  <div class="global-used">
+    critical styles fixture
+    <ComponentCritical />
+    <HiddenStyles />
+  </div>
+</template>

--- a/test/fixtures/critical-styles/assets/global.css
+++ b/test/fixtures/critical-styles/assets/global.css
@@ -1,0 +1,9 @@
+.global-used {
+  --global-critical: present;
+  color: #ff0000;
+}
+
+.global-unused {
+  --global-noncritical: present;
+  color: #00ff00;
+}

--- a/test/fixtures/critical-styles/components/ComponentCritical.vue
+++ b/test/fixtures/critical-styles/components/ComponentCritical.vue
@@ -1,0 +1,11 @@
+<template>
+  <div class="component-shown">
+    shown during SSR
+  </div>
+</template>
+
+<style scoped>
+.component-shown {
+  --component-token: present;
+}
+</style>

--- a/test/fixtures/critical-styles/components/HiddenStyles.vue
+++ b/test/fixtures/critical-styles/components/HiddenStyles.vue
@@ -1,0 +1,20 @@
+<script setup>
+// Rendered component, but this element is absent from the server DOM. Its styles
+// must survive so they are present once the element appears after hydration.
+const show = ref(false)
+</script>
+
+<template>
+  <div
+    v-if="show"
+    class="client-only"
+  >
+    shown after hydration
+  </div>
+</template>
+
+<style scoped>
+.client-only {
+  --hydration-token: present;
+}
+</style>

--- a/test/fixtures/critical-styles/nuxt.config.ts
+++ b/test/fixtures/critical-styles/nuxt.config.ts
@@ -1,0 +1,30 @@
+import { isNuxtPrepare, projectSuffix, withMatrix } from '../../matrix'
+
+const mode = process.env.NUXT_TEST_CRITICAL
+
+// `options` exercises the object form (forwarded to beasties); `true` the boolean form.
+const criticalStyles = mode === 'options'
+  ? { allowRules: ['.global-unused'] }
+  : mode === 'true'
+
+const outputSuffix = mode === 'options' ? '-options' : mode === 'true' ? '-critical' : ''
+
+export default withMatrix({
+  css: ['~/assets/global.css'],
+  buildDir: isNuxtPrepare ? undefined : `.nuxt-${projectSuffix}`,
+  routeRules: {
+    '/spa': { ssr: false },
+  },
+  sourcemap: false,
+  features: {
+    criticalStyles,
+  },
+  nitro: {
+    output: {
+      dir: `.output-${projectSuffix}${outputSuffix}`,
+    },
+    prerender: {
+      routes: ['/spa'],
+    },
+  },
+})

--- a/test/fixtures/critical-styles/package.json
+++ b/test/fixtures/critical-styles/package.json
@@ -1,0 +1,13 @@
+{
+  "private": true,
+  "name": "fixture-critical-styles",
+  "scripts": {
+    "build": "nuxt build"
+  },
+  "dependencies": {
+    "nuxt": "workspace:*"
+  },
+  "engines": {
+    "node": "^22.19.0 || ^24.11.0 || >=26.0.0"
+  }
+}

--- a/test/fixtures/critical-styles/tsconfig.json
+++ b/test/fixtures/critical-styles/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./.nuxt/tsconfig.app.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.server.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.shared.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.node.json"
+    }
+  ]
+}


### PR DESCRIPTION
What

Adds an opt-in features.criticalStyles option that inlines the critical CSS, powered by beasties.

Closes #35250.

Why

Render-blocking stylesheets delay first paint. This inlines only the CSS actually used by the server-rendered markup and defers the rest, without a headless browser.

How

- New features.criticalStyles: boolean | BeastiesOptions — disabled by default, and in dev / when ssr is false.
- Runs beasties over the assembled HTML in the buffered renderer; skipped for streamed and non-server-rendered (SPA) responses, since critical CSS must come from server-rendered markup.
- Composes with inlineStyles: component CSS stays inlined (beasties does not prune it, via the default reduceInlineStyles: false); this optimises the remaining external stylesheets.
- Stylesheets are read from the client build output on disk during prerendering, or from the running server at runtime.
- beasties is only bundled into the server build when the feature is enabled (via a conditional virtual + dynamic import), so there's no cost when it's off.

Tests

- Unit tests covering every beasties option (incl. the inlineStyles-safety guarantee).
- Integration tests (nuxt generate) for enabled / disabled / options-object, composition with inlineStyles, hydration safety, and the ssr: false SPA case.