### PR TITLE
fix(nuxt): add `head.push` for client side

### DIFF
--- a/packages/nuxt/src/head/runtime/install-client-head.ts
+++ b/packages/nuxt/src/head/runtime/install-client-head.ts
@@ -2,10 +2,15 @@ import type { createHead as createClientHead } from '@unhead/vue/client'
 import type { ActiveHeadEntry } from '@unhead/vue'
 import type { NuxtApp } from '#app/nuxt'
 
+// @ts-expect-error virtual file
+import { appHead } from '#build/nuxt.config.mjs'
+
 type ClientHead = ReturnType<typeof createClientHead>
 
 export function installClientHead (nuxtApp: NuxtApp, head: ClientHead): void {
-  // nuxt.config appHead is set server-side within the renderer
+  // re-push server-only `app.head` so `titleTemplate` survives hydration (#35468)
+  head.push(appHead)
+
   nuxtApp.vueApp.use(head)
 
   // pause dom updates until page is ready and between page transitions

--- a/packages/nuxt/src/head/runtime/plugins/unhead.client.ts
+++ b/packages/nuxt/src/head/runtime/plugins/unhead.client.ts
@@ -5,12 +5,16 @@ import type { ObjectPlugin, Plugin } from '#app/nuxt'
 
 // @ts-expect-error virtual file
 import unheadOptions from '#build/unhead-options.mjs'
+// @ts-expect-error virtual file
+import { appHead } from '#build/nuxt.config.mjs'
 
 const plugin: Plugin & ObjectPlugin = defineNuxtPlugin({
   name: 'nuxt:head',
   enforce: 'pre',
   setup (nuxtApp) {
     const head = createClientHead(unheadOptions)
+    // unhead v3's client head no longer inherits the server-only appHead, so re-push `app.head`
+    head.push(appHead)
     installClientHead(nuxtApp, head)
   },
 })

--- a/packages/nuxt/src/head/runtime/plugins/unhead.client.ts
+++ b/packages/nuxt/src/head/runtime/plugins/unhead.client.ts
@@ -5,16 +5,12 @@ import type { ObjectPlugin, Plugin } from '#app/nuxt'
 
 // @ts-expect-error virtual file
 import unheadOptions from '#build/unhead-options.mjs'
-// @ts-expect-error virtual file
-import { appHead } from '#build/nuxt.config.mjs'
 
 const plugin: Plugin & ObjectPlugin = defineNuxtPlugin({
   name: 'nuxt:head',
   enforce: 'pre',
   setup (nuxtApp) {
     const head = createClientHead(unheadOptions)
-    // unhead v3's client head no longer inherits the server-only appHead, so re-push `app.head`
-    head.push(appHead)
     installClientHead(nuxtApp, head)
   },
 })

--- a/test/fixtures/runtime-compiler/nuxt.config.ts
+++ b/test/fixtures/runtime-compiler/nuxt.config.ts
@@ -2,6 +2,14 @@ import { withMatrix } from '../../matrix'
 
 // https://nuxt.com/docs/4.x/api/nuxt-config
 export default withMatrix({
+  // default title/description so unhead's client-side dev validation (#35468)
+  // has no missing-title/description warnings on these title-less test pages
+  app: {
+    head: {
+      title: 'Nuxt Runtime Compiler',
+      meta: [{ name: 'description', content: 'Runtime compiler test fixture' }],
+    },
+  },
   vue: {
     runtimeCompiler: true,
   },

--- a/test/fixtures/suspense-layout/nuxt.config.ts
+++ b/test/fixtures/suspense-layout/nuxt.config.ts
@@ -1,6 +1,14 @@
 import { withMatrix } from '../../matrix'
 
 export default withMatrix({
+  // default title/description so unhead's client-side dev validation (#35468)
+  // has no missing-title/description warnings on these title-less test pages
+  app: {
+    head: {
+      title: 'Suspense Layout',
+      meta: [{ name: 'description', content: 'Suspense layout test fixture' }],
+    },
+  },
   routeRules: {
     '/': { appLayout: 'alternate' },
   },

--- a/test/fixtures/suspense/nuxt.config.ts
+++ b/test/fixtures/suspense/nuxt.config.ts
@@ -1,3 +1,12 @@
 import { withMatrix } from '../../matrix'
 
-export default withMatrix({})
+export default withMatrix({
+  // default title/description so unhead's client-side dev validation (#35468)
+  // has no missing-title/description warnings on these title-less test pages
+  app: {
+    head: {
+      title: 'Suspense',
+      meta: [{ name: 'description', content: 'Suspense test fixture' }],
+    },
+  },
+})


### PR DESCRIPTION
### 🔗 Linked issue

Fixes: #35468

### 📚 Description

**unhead v3** must be added on client side (`head.push`). After that the Nuxt shows the tab-title correctly

### Tests
Because e2e tests fails I added a head object to the fixture tests - `unhead` checks it and throws warnings because missing head title and meta.
