### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/packages/vite/src/utils/config.ts
+++ b/packages/vite/src/utils/config.ts
@@ -23,6 +23,9 @@ export function resolveServerEntry (config: ResolvedConfig) {
     if (!Array.isArray(input) && input.server) {
       return input.server
     }
+    if (!Array.isArray(input) && input.entry) {
+      return input.entry
+    }
   }
 
   throw new Error('No entry found in rolldownOptions.input')


### PR DESCRIPTION
## Summary

When `ssr: false` is set, `resolveServer` is called with the client Vite server config. The client build input is `{ entry: '...' }` rather than `{ server: '...' }`, causing `resolveServerEntry` to throw `No entry found in rolldownOptions.input` and crash the dev server.

`resolveClientEntry` already handles `input.entry`; this PR mirrors that handling in `resolveServerEntry`.

```diff
 if (!Array.isArray(input) && input.server) {
   return input.server
 }
+if (!Array.isArray(input) && input.entry) {
+  return input.entry
+}
```

Closes #35466