### PR TITLE
fix(kit): resolve layer aliases against each layer in generated tsconfig

### DIFF
--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -543,6 +543,35 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
     }
   }
 
+  // The `~`/`@`/`~~`/`@@` aliases are resolved relative to each layer's own
+  // directory at build/dev time (see `LayerAliasingPlugin`), so an import like
+  // `@/components/Foo.vue` inside an extended layer points at that layer's
+  // source. `tsConfig.paths` can't resolve relative to the importer, so we add
+  // each extended layer's directory as a fallback candidate (ordered by layer
+  // priority) to keep type-checking in sync.
+  // https://github.com/nuxt/nuxt/issues/35373
+  //
+  // The project layer (index 0) is skipped: its alias is already emitted by the
+  // alias loop above (from `nuxt.options.alias`, honouring any user override),
+  // so single-layer projects keep byte-identical output.
+  const layerAliasDirKeys = { '~': 'app', '@': 'app', '~~': 'root', '@@': 'root' } as const
+  for (const alias in layerAliasDirKeys) {
+    if (!(alias in tsConfig.compilerOptions.paths)) { continue }
+    const dirKey = layerAliasDirKeys[alias as keyof typeof layerAliasDirKeys]
+    const hasGlob = `${alias}/*` in tsConfig.compilerOptions.paths
+    for (let i = 1; i < layerDirs.length; i++) {
+      const override = nuxt.options._layers[i]?.config?.alias?.[alias]
+      const absoluteDir = override ? resolve(layerDirs[i]!.root, override) : layerDirs[i]![dirKey]
+      // Emit relative paths directly so `resolveConfig` skips a redundant
+      // `fs.stat` on each (these are always directories).
+      const dir = relativeWithDot(nuxt.options.buildDir, absoluteDir)
+      tsConfig.compilerOptions.paths[alias]!.push(dir)
+      if (hasGlob) {
+        tsConfig.compilerOptions.paths[`${alias}/*`]!.push(`${dir}/*`)
+      }
+    }
+  }
+
   const references: TSReference[] = []
   const nodeReferences: TSReference[] = []
   const sharedReferences: TSReference[] = []

--- a/packages/kit/test/generate-types.spec.ts
+++ b/packages/kit/test/generate-types.spec.ts
@@ -1,5 +1,8 @@
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { fileURLToPath } from 'node:url'
-import { describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { join } from 'pathe'
 import type { Nuxt, NuxtConfig } from '@nuxt/schema'
 import { defu } from 'defu'
 import { findWorkspaceDir } from 'pkg-types'
@@ -49,6 +52,145 @@ describe('tsConfig generation', () => {
         ],
       }
     `)
+  })
+
+  it('should resolve layer aliases (`~`/`@`/`~~`/`@@`) against every layer, ordered by priority', async () => {
+    // #35373: aliases must fall back to each extended layer's own directory.
+    const nuxt = {
+      options: {
+        rootDir: '/my-app',
+        srcDir: '/my-app',
+        alias: {
+          '~': '/my-app',
+          '@': '/my-app',
+          '~~': '/my-app',
+          '@@': '/my-app',
+        },
+        typescript: { includeWorkspace: false },
+        buildDir: '/my-app/.nuxt',
+        modulesDir: ['/my-app/node_modules', '/node_modules'],
+        modules: [],
+        extensions: ['.ts', '.mjs', '.js'],
+        _layers: [
+          { config: { rootDir: '/my-app', srcDir: '/my-app' } },
+          { config: { rootDir: '/base', srcDir: '/base' } },
+        ],
+        _installedModules: [],
+        _modules: [],
+      },
+      callHook: () => {},
+    } satisfies DeepPartial<Nuxt> as unknown as Nuxt
+
+    const { tsConfig } = await _generateTypes(nuxt)
+    expect(tsConfig.compilerOptions?.paths).toMatchInlineSnapshot(`
+      {
+        "@": [
+          "..",
+          "../../base",
+        ],
+        "@@": [
+          "..",
+          "../../base",
+        ],
+        "~": [
+          "..",
+          "../../base",
+        ],
+        "~~": [
+          "..",
+          "../../base",
+        ],
+      }
+    `)
+  })
+
+  it('should honour a per-layer alias override when adding layer fallbacks', async () => {
+    // A layer's own `alias` override resolves relative to that layer's root.
+    const nuxt = {
+      options: {
+        rootDir: '/my-app',
+        srcDir: '/my-app',
+        alias: { '~': '/my-app', '@': '/my-app', '~~': '/my-app', '@@': '/my-app' },
+        typescript: { includeWorkspace: false },
+        buildDir: '/my-app/.nuxt',
+        modulesDir: ['/my-app/node_modules', '/node_modules'],
+        modules: [],
+        extensions: ['.ts', '.mjs', '.js'],
+        _layers: [
+          { config: { rootDir: '/my-app', srcDir: '/my-app' } },
+          { config: { rootDir: '/base', srcDir: '/base', alias: { '@': './custom-src' } } },
+        ],
+        _installedModules: [],
+        _modules: [],
+      },
+      callHook: () => {},
+    } satisfies DeepPartial<Nuxt> as unknown as Nuxt
+
+    const { tsConfig } = await _generateTypes(nuxt)
+    expect(tsConfig.compilerOptions?.paths?.['@']).toEqual(['..', '../../base/custom-src'])
+    expect(tsConfig.compilerOptions?.paths?.['~']).toEqual(['..', '../../base'])
+  })
+
+  it('should leave single-layer alias paths byte-identical (no self-duplication)', async () => {
+    const { tsConfig } = await _generateTypes(mockNuxt)
+    expect(tsConfig.compilerOptions?.paths).toMatchInlineSnapshot(`
+      {
+        "some-custom-alias": [
+          "../some-alias",
+        ],
+        "~": [
+          "..",
+        ],
+      }
+    `)
+  })
+
+  describe('with layer directories on disk', () => {
+    // #35373: alias targets exist on disk, so glob (`@/*`) fallbacks are emitted.
+    let root: string
+    beforeAll(() => {
+      root = mkdtempSync(join(tmpdir(), 'nuxt-layer-alias-'))
+      for (const dir of ['my-app/app', 'my-app/.nuxt', 'base/app']) {
+        mkdirSync(join(root, dir), { recursive: true })
+      }
+    })
+    afterAll(() => rmSync(root, { recursive: true, force: true }))
+
+    it('should add every layer directory (with glob) for layer aliases', async () => {
+      const appSrc = join(root, 'my-app/app') + '/'
+      const appRoot = join(root, 'my-app') + '/'
+      const nuxt = {
+        options: {
+          rootDir: join(root, 'my-app'),
+          srcDir: join(root, 'my-app/app'),
+          alias: { '~': appSrc, '@': appSrc, '~~': appRoot, '@@': appRoot },
+          typescript: { includeWorkspace: false },
+          buildDir: join(root, 'my-app/.nuxt'),
+          modulesDir: [join(root, 'my-app/node_modules')],
+          modules: [],
+          extensions: ['.ts', '.mjs', '.js'],
+          _layers: [
+            { config: { rootDir: join(root, 'my-app'), srcDir: join(root, 'my-app/app') } },
+            { config: { rootDir: join(root, 'base'), srcDir: join(root, 'base/app') } },
+          ],
+          _installedModules: [],
+          _modules: [],
+        },
+        callHook: () => {},
+      } satisfies DeepPartial<Nuxt> as unknown as Nuxt
+
+      const { tsConfig } = await _generateTypes(nuxt)
+      const paths = tsConfig.compilerOptions?.paths ?? {}
+
+      expect(paths['@']).toEqual(['../app', '../../base/app'])
+      expect(paths['@/*']).toEqual(['../app/*', '../../base/app/*'])
+      expect(paths['~']).toEqual(['../app', '../../base/app'])
+      expect(paths['~/*']).toEqual(['../app/*', '../../base/app/*'])
+      expect(paths['~~']).toEqual(['..', '../../base'])
+      expect(paths['~~/*']).toEqual(['../*', '../../base/*'])
+      expect(paths['@@']).toEqual(['..', '../../base'])
+      expect(paths['@@/*']).toEqual(['../*', '../../base/*'])
+    })
   })
 
   it('should add exclude for module paths', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1361,6 +1361,24 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/nuxt
 
+  test/fixtures/layer-types:
+    dependencies:
+      nuxt:
+        specifier: workspace:*
+        version: link:../../../packages/nuxt
+
+  test/fixtures/layer-types-base:
+    dependencies:
+      nuxt:
+        specifier: workspace:*
+        version: link:../../../packages/nuxt
+
+  test/fixtures/layer-types-nested:
+    dependencies:
+      nuxt:
+        specifier: workspace:*
+        version: link:../../../packages/nuxt
+
   test/fixtures/lazy-hydration:
     dependencies:
       nuxt:

--- a/test/fixtures/layer-types-base/app/components/Button.vue
+++ b/test/fixtures/layer-types-base/app/components/Button.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+defineProps<{ label: string }>()
+</script>
+
+<template>
+  <button>{{ label }}</button>
+</template>

--- a/test/fixtures/layer-types-base/app/components/HelloWorld.vue
+++ b/test/fixtures/layer-types-base/app/components/HelloWorld.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+// #35373: all four layer aliases must resolve against this layer's own dir.
+import ButtonAt from '@/components/Button.vue'
+import ButtonTilde from '~/components/Button.vue'
+import ButtonRootTilde from '~~/app/components/Button.vue'
+import ButtonRootAt from '@@/app/components/Button.vue'
+</script>
+
+<template>
+  <ButtonAt label="@" />
+  <ButtonTilde label="~" />
+  <ButtonRootTilde label="~~" />
+  <ButtonRootAt label="@@" />
+</template>

--- a/test/fixtures/layer-types-base/app/components/UsesComposable.vue
+++ b/test/fixtures/layer-types-base/app/components/UsesComposable.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+// #35373: `@/` subpath import from an extended layer, with type flow.
+import { useLayerMessage } from '@/composables/useLayerMessage'
+
+const { message } = useLayerMessage()
+const upper: string = message.toUpperCase()
+</script>
+
+<template>
+  <div>{{ upper }}</div>
+</template>

--- a/test/fixtures/layer-types-base/app/composables/useLayerMessage.ts
+++ b/test/fixtures/layer-types-base/app/composables/useLayerMessage.ts
@@ -1,0 +1,3 @@
+export function useLayerMessage (): { message: string } {
+  return { message: 'hello from base layer' }
+}

--- a/test/fixtures/layer-types-base/nuxt.config.ts
+++ b/test/fixtures/layer-types-base/nuxt.config.ts
@@ -1,0 +1,15 @@
+export default defineNuxtConfig({
+  extends: ['../layer-types-nested'],
+  compatibilityDate: 'latest',
+  nitro: {
+    typescript: {
+      tsConfig: {
+        compilerOptions: {
+          paths: {
+            '#app/internal/*': ['../../../../packages/nuxt/dist/app/internal/*'],
+          },
+        },
+      },
+    },
+  },
+})

--- a/test/fixtures/layer-types-base/package.json
+++ b/test/fixtures/layer-types-base/package.json
@@ -1,0 +1,14 @@
+{
+  "private": true,
+  "name": "fixture-layer-types-base",
+  "scripts": {
+    "build": "nuxt build",
+    "test:types": "nuxt prepare && npx vue-tsc -b --noEmit"
+  },
+  "dependencies": {
+    "nuxt": "workspace:*"
+  },
+  "engines": {
+    "node": "^22.19.0 || ^24.11.0 || >=26.0.0"
+  }
+}

--- a/test/fixtures/layer-types-base/tsconfig.json
+++ b/test/fixtures/layer-types-base/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./.nuxt/tsconfig.app.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.server.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.shared.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.node.json"
+    }
+  ]
+}

--- a/test/fixtures/layer-types-nested/app/components/NestedConsumer.vue
+++ b/test/fixtures/layer-types-nested/app/components/NestedConsumer.vue
@@ -1,0 +1,8 @@
+<script setup lang="ts">
+// #35373: `@` in a transitively-extended layer must resolve to this layer.
+import NestedWidget from '@/components/NestedWidget.vue'
+</script>
+
+<template>
+  <NestedWidget :count="1" />
+</template>

--- a/test/fixtures/layer-types-nested/app/components/NestedWidget.vue
+++ b/test/fixtures/layer-types-nested/app/components/NestedWidget.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+defineProps<{ count: number }>()
+</script>
+
+<template>
+  <div>{{ count }}</div>
+</template>

--- a/test/fixtures/layer-types-nested/nuxt.config.ts
+++ b/test/fixtures/layer-types-nested/nuxt.config.ts
@@ -1,0 +1,14 @@
+export default defineNuxtConfig({
+  compatibilityDate: 'latest',
+  nitro: {
+    typescript: {
+      tsConfig: {
+        compilerOptions: {
+          paths: {
+            '#app/internal/*': ['../../../../packages/nuxt/dist/app/internal/*'],
+          },
+        },
+      },
+    },
+  },
+})

--- a/test/fixtures/layer-types-nested/package.json
+++ b/test/fixtures/layer-types-nested/package.json
@@ -1,0 +1,14 @@
+{
+  "private": true,
+  "name": "fixture-layer-types-nested",
+  "scripts": {
+    "build": "nuxt build",
+    "test:types": "nuxt prepare && npx vue-tsc -b --noEmit"
+  },
+  "dependencies": {
+    "nuxt": "workspace:*"
+  },
+  "engines": {
+    "node": "^22.19.0 || ^24.11.0 || >=26.0.0"
+  }
+}

--- a/test/fixtures/layer-types-nested/tsconfig.json
+++ b/test/fixtures/layer-types-nested/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./.nuxt/tsconfig.app.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.server.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.shared.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.node.json"
+    }
+  ]
+}

--- a/test/fixtures/layer-types/app/app.vue
+++ b/test/fixtures/layer-types/app/app.vue
@@ -1,0 +1,7 @@
+<template>
+  <div>
+    <HelloWorld />
+    <UsesComposable />
+    <NestedConsumer />
+  </div>
+</template>

--- a/test/fixtures/layer-types/nuxt.config.ts
+++ b/test/fixtures/layer-types/nuxt.config.ts
@@ -1,0 +1,15 @@
+export default defineNuxtConfig({
+  extends: ['../layer-types-base'],
+  compatibilityDate: 'latest',
+  nitro: {
+    typescript: {
+      tsConfig: {
+        compilerOptions: {
+          paths: {
+            '#app/internal/*': ['../../../../packages/nuxt/dist/app/internal/*'],
+          },
+        },
+      },
+    },
+  },
+})

--- a/test/fixtures/layer-types/package.json
+++ b/test/fixtures/layer-types/package.json
@@ -1,0 +1,14 @@
+{
+  "private": true,
+  "name": "fixture-layer-types",
+  "scripts": {
+    "build": "nuxt build",
+    "test:types": "nuxt prepare && npx vue-tsc -b --noEmit"
+  },
+  "dependencies": {
+    "nuxt": "workspace:*"
+  },
+  "engines": {
+    "node": "^22.19.0 || ^24.11.0 || >=26.0.0"
+  }
+}

--- a/test/fixtures/layer-types/tsconfig.json
+++ b/test/fixtures/layer-types/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./.nuxt/tsconfig.app.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.server.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.shared.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.node.json"
+    }
+  ]
+}


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #35373

### 🐞 Description

`~`/`@`/`~~`/`@@` were mapped only to the top app's directory in the generated tsconfig `paths`, so importing e.g. `@/components/Button.vue` from an extended layer failed `nuxt typecheck` with `TS2307` — even though dev/build resolve it per-layer via %