### PR TITLE
feat(nuxt): add granular build output flags

### DIFF
--- a/docs/4.api/6.nuxt-config.md
+++ b/docs/4.api/6.nuxt-config.md
@@ -361,6 +361,44 @@ export default defineNuxtConfig({
 })
 ```
 
+### `client`
+
+Whether to build the client bundle and copy public assets into the output directory in production builds.
+
+Set this to `false` for server-only production builds when client assets are deployed separately. The dev server always builds the client bundle.
+
+- **Type**: `boolean`
+- **Default:** `true`
+
+**Example**:
+```ts
+export default defineNuxtConfig({
+  build: {
+    client: false,
+  },
+})
+```
+
+### `server`
+
+Whether to build the Vue server renderer bundle in production builds.
+
+Set this to `false` when you only need the Nitro server output without server-side rendering. The dev server always builds the server renderer.
+
+- **Type**: `boolean`
+- **Default:** `true`
+
+**Example**:
+```ts
+export default defineNuxtConfig({
+  build: {
+    server: false,
+  },
+})
+```
+
+When both `build.client` and `build.server` are `false`, Nuxt only generates the Nitro output and skips the client bundle, public assets, and Vue server renderer.
+
 ### `templates`
 
 It is recommended to use `addTemplate` from `@nuxt/kit` instead of this option.

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -49,6 +49,11 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
   }
 
   const rootDirWithSlash = withTrailingSlash(nuxt.options.rootDir)
+  const buildClient = nuxt.options.dev || nuxt.options.build.client !== false
+  const buildServer = nuxt.options.dev || nuxt.options.build.server !== false
+  if (!buildClient && !buildServer) {
+    logger.warn('Both `build.client` and `build.server` are disabled. Nuxt will only generate Nitro output without client assets or Vue server renderer.')
+  }
 
   const moduleEntryPaths: string[] = []
   for (const m of nuxt.options._installedModules) {
@@ -238,20 +243,22 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
         ],
       },
     },
-    publicAssets: [
-      nuxt.options.dev
-        ? {
-            dir: resolve(nuxt.options.buildDir, 'dist/client'),
-            maxAge: 0,
-          }
-        : {
-            dir: join(nuxt.options.buildDir, 'dist/client', nuxt.options.app.buildAssetsDir),
-            maxAge: 31536000 /* 1 year */,
-            baseURL: nuxt.options.app.buildAssetsDir,
-            ignore: false,
-          },
-      ...layerPublicAssetsDirs,
-    ],
+    publicAssets: buildClient
+      ? [
+          nuxt.options.dev
+            ? {
+                dir: resolve(nuxt.options.buildDir, 'dist/client'),
+                maxAge: 0,
+              }
+            : {
+                dir: join(nuxt.options.buildDir, 'dist/client', nuxt.options.app.buildAssetsDir),
+                maxAge: 31536000 /* 1 year */,
+                baseURL: nuxt.options.app.buildAssetsDir,
+                ignore: false,
+              },
+          ...layerPublicAssetsDirs,
+        ]
+      : [],
     prerender: {
       ignoreUnprefixedPublicAssets: true,
       failOnError: true,
@@ -333,7 +340,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
   }
 
   // add error handler
-  if (!nitroConfig.errorHandler && (nuxt.options.dev || !nuxt.options.experimental.noVueServer)) {
+  if (!nitroConfig.errorHandler && (nuxt.options.dev || (buildServer && !nuxt.options.experimental.noVueServer))) {
     nitroConfig.errorHandler = resolve(distDir, 'runtime/handlers/error')
   }
 
@@ -437,20 +444,22 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
     nitroConfig.prerender.ignore ||= []
     nitroConfig.prerender.ignore.push(joinURL(nuxt.options.app.baseURL, manifestPrefix))
 
-    nitroConfig.publicAssets!.unshift(
-      // build manifest
-      {
-        dir: join(tempDir, 'meta'),
-        maxAge: 31536000 /* 1 year */,
-        baseURL: joinURL(manifestPrefix, 'meta'),
-      },
-      // latest build
-      {
-        dir: tempDir,
-        maxAge: 1,
-        baseURL: manifestPrefix,
-      },
-    )
+    if (buildClient) {
+      nitroConfig.publicAssets!.unshift(
+        // build manifest
+        {
+          dir: join(tempDir, 'meta'),
+          maxAge: 31536000 /* 1 year */,
+          baseURL: joinURL(manifestPrefix, 'meta'),
+        },
+        // latest build
+        {
+          dir: tempDir,
+          maxAge: 1,
+          baseURL: manifestPrefix,
+        },
+      )
+    }
 
     nuxt.options.alias['#app-manifest'] = join(tempDir, `meta/${buildId}.json`)
 
@@ -507,7 +516,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
 
   // Add fallback server for `ssr: false`
   const FORWARD_SLASH_RE = /\//g
-  if (!nuxt.options.ssr) {
+  if (!nuxt.options.ssr || !buildServer) {
     nitroConfig.virtual!['#build/dist/server/server.mjs'] = 'export default () => {}'
     // In case a non-normalized absolute path is called for on Windows
     if (process.platform === 'win32') {
@@ -515,7 +524,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
     }
   }
 
-  if (nuxt.options.dev || !nuxt.options.ssr) {
+  if (nuxt.options.dev || !nuxt.options.ssr || !buildServer) {
     nitroConfig.virtual!['#build/dist/server/styles.mjs'] = 'export default {}'
     // In case a non-normalized absolute path is called for on Windows
     if (process.platform === 'win32') {
@@ -671,6 +680,10 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
 
   // Extend nitro config with hook
   await nuxt.callHook('nitro:config', nitroConfig)
+  if (!buildClient) {
+    nitroConfig.noPublicDir = true
+    nitroConfig.publicAssets = []
+  }
 
   if (nitroConfig.static && nuxt.options.dev) {
     nitroConfig.routeRules ||= {}
@@ -852,14 +865,18 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
     for (const hook of ['webpack:config', 'rspack:config'] as const) {
       nuxt.hook(hook, (configuration) => {
         const clientConfig = configuration.find(config => config.name === 'client')
-        if (!clientConfig!.resolve) { clientConfig!.resolve!.alias = {} }
-        if (Array.isArray(clientConfig!.resolve!.alias)) {
-          clientConfig!.resolve!.alias.push({
+        if (!clientConfig) {
+          return
+        }
+        clientConfig.resolve ||= {}
+        clientConfig.resolve.alias ||= {}
+        if (Array.isArray(clientConfig.resolve.alias)) {
+          clientConfig.resolve.alias.push({
             name: 'vue',
             alias: 'vue/dist/vue.esm-bundler',
           })
         } else {
-          clientConfig!.resolve!.alias!.vue = 'vue/dist/vue.esm-bundler'
+          clientConfig.resolve.alias.vue = 'vue/dist/vue.esm-bundler'
         }
       })
     }
@@ -906,7 +923,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
     })
   }
 
-  if (!nuxt.options.dev && nuxt.options.experimental.noVueServer) {
+  if (!nuxt.options.dev && (!buildServer || nuxt.options.experimental.noVueServer)) {
     nitro.hooks.hook('rollup:before', (nitro) => {
       if (nitro.options.preset === 'nitro-prerender') {
         nitro.options.errorHandler = resolve(distDir, 'runtime/handlers/error')

--- a/packages/nuxt/test/build-options.test.ts
+++ b/packages/nuxt/test/build-options.test.ts
@@ -1,0 +1,168 @@
+import { existsSync } from 'node:fs'
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { randomUUID } from 'node:crypto'
+
+import { findWorkspaceDir } from 'pkg-types'
+import { join } from 'pathe'
+import { afterEach, describe, expect, it } from 'vitest'
+import { build, loadNuxt } from 'nuxt'
+
+type Builder = 'vite' | 'webpack' | 'rspack'
+
+const repoRoot = await findWorkspaceDir()
+const fixtureRoots: string[] = []
+
+describe('build options', { sequential: true }, () => {
+  afterEach(async () => {
+    await Promise.all(fixtureRoots.splice(0).map(root => rm(root, { recursive: true, force: true })))
+  })
+
+  it('skips client bundle and public assets with build.client: false', async () => {
+    const { rootDir, buildLog } = await createFixture({
+      build: {
+        client: false,
+      },
+    })
+
+    await buildFixture(rootDir)
+
+    expect(await readFile(buildLog, 'utf8')).toBe('server\n')
+    expect(existsSync(join(rootDir, '.nuxt/dist/server/server.mjs'))).toBe(true)
+    expect(existsSync(join(rootDir, '.nuxt/dist/client'))).toBe(false)
+    expect(existsSync(join(rootDir, '.output/server'))).toBe(true)
+    expect(existsSync(join(rootDir, '.output/server/_virtual/client.precomputed.mjs'))).toBe(true)
+    expect(existsSync(join(rootDir, '.output/public'))).toBe(false)
+    expect(existsSync(join(rootDir, '.output/public/_nuxt'))).toBe(false)
+    expect(existsSync(join(rootDir, '.output/public/skip-me.txt'))).toBe(false)
+  }, 60_000)
+
+  it.each(['webpack', 'rspack'] as const)('skips client bundle and public assets with build.client: false for %s', async (builder) => {
+    const { rootDir, buildLog } = await createFixture({
+      builder,
+      build: {
+        client: false,
+      },
+    })
+
+    await buildFixture(rootDir)
+
+    expect(await readFile(buildLog, 'utf8')).toBe('server\n')
+    expect(existsSync(join(rootDir, '.nuxt/dist/server/server.mjs'))).toBe(true)
+    expect(existsSync(join(rootDir, '.nuxt/dist/client'))).toBe(false)
+    expect(existsSync(join(rootDir, '.output/server'))).toBe(true)
+    expect(existsSync(join(rootDir, '.output/server/_virtual/client.precomputed.mjs'))).toBe(true)
+    expect(existsSync(join(rootDir, '.output/public'))).toBe(false)
+    expect(existsSync(join(rootDir, '.output/public/_nuxt'))).toBe(false)
+    expect(existsSync(join(rootDir, '.output/public/skip-me.txt'))).toBe(false)
+  }, 60_000)
+
+  it.each(['webpack', 'rspack'] as const)('skips client bundle with vue.runtimeCompiler for %s', async (builder) => {
+    const { rootDir, buildLog } = await createFixture({
+      builder,
+      build: {
+        client: false,
+      },
+      runtimeCompiler: true,
+    })
+
+    await buildFixture(rootDir)
+
+    expect(await readFile(buildLog, 'utf8')).toBe('server\n')
+    expect(existsSync(join(rootDir, '.nuxt/dist/client'))).toBe(false)
+    expect(existsSync(join(rootDir, '.output/server'))).toBe(true)
+  }, 60_000)
+
+  it('skips Vue server renderer bundle with build.server: false', async () => {
+    const { rootDir, buildLog } = await createFixture({
+      build: {
+        server: false,
+      },
+    })
+
+    await buildFixture(rootDir)
+
+    expect(await readFile(buildLog, 'utf8')).toBe('client\n')
+    expect(existsSync(join(rootDir, '.nuxt/dist/client'))).toBe(true)
+    expect(existsSync(join(rootDir, '.nuxt/dist/server/server.mjs'))).toBe(false)
+    expect(existsSync(join(rootDir, '.output/server'))).toBe(true)
+    expect(existsSync(join(rootDir, '.output/public/_nuxt'))).toBe(true)
+    expect(existsSync(join(rootDir, '.output/public/skip-me.txt'))).toBe(true)
+  }, 60_000)
+
+  it.each(['webpack', 'rspack'] as const)('skips Vue server renderer bundle with build.server: false for %s', async (builder) => {
+    const { rootDir, buildLog } = await createFixture({
+      builder,
+      build: {
+        server: false,
+      },
+    })
+
+    await buildFixture(rootDir)
+
+    expect(await readFile(buildLog, 'utf8')).toBe('client\n')
+    expect(existsSync(join(rootDir, '.nuxt/dist/client'))).toBe(true)
+    expect(existsSync(join(rootDir, '.nuxt/dist/server/server.mjs'))).toBe(false)
+    expect(existsSync(join(rootDir, '.output/server'))).toBe(true)
+    expect(existsSync(join(rootDir, '.output/public/_nuxt'))).toBe(true)
+    expect(existsSync(join(rootDir, '.output/public/skip-me.txt'))).toBe(true)
+  }, 60_000)
+})
+
+async function createFixture (config: { build: { client?: boolean, server?: boolean }, builder?: Builder, runtimeCompiler?: boolean }) {
+  const rootDir = join(repoRoot, 'node_modules/.fixture', `build-options-${randomUUID()}`)
+  const buildLog = join(rootDir, 'build.log')
+  fixtureRoots.push(rootDir)
+
+  await mkdir(join(rootDir, 'server/api'), { recursive: true })
+  await mkdir(join(rootDir, 'public'), { recursive: true })
+
+  await writeFile(join(rootDir, 'app.vue'), '<template><div>Build options fixture</div></template>\n')
+  await writeFile(join(rootDir, 'server/api/ping.get.ts'), 'export default defineEventHandler(() => "pong")\n')
+  await writeFile(join(rootDir, 'public/skip-me.txt'), 'this should not be copied by server-only builds\n')
+  await writeFile(join(rootDir, 'package.json'), JSON.stringify({ type: 'module', dependencies: { nuxt: 'workspace:*' } }))
+  await writeFile(join(rootDir, 'nuxt.config.ts'), `
+import { appendFileSync } from 'node:fs'
+
+export default defineNuxtConfig({
+  builder: ${JSON.stringify(config.builder || 'vite')},
+  build: ${JSON.stringify(config.build)},
+  compatibilityDate: 'latest',
+  devtools: { enabled: false },
+  experimental: {
+    appManifest: false,
+  },
+  hooks: {
+    'vite:extendConfig' (_config, env) {
+      appendFileSync(${JSON.stringify(buildLog)}, env.isClient ? 'client\\n' : 'server\\n')
+    },
+    'webpack:config' (configs) {
+      appendFileSync(${JSON.stringify(buildLog)}, configs.map(config => config.name).join(',') + '\\n')
+    },
+    'rspack:config' (configs) {
+      appendFileSync(${JSON.stringify(buildLog)}, configs.map(config => config.name).join(',') + '\\n')
+    },
+  },
+  typescript: {
+    typeCheck: false,
+  },
+  vue: {
+    runtimeCompiler: ${JSON.stringify(config.runtimeCompiler || false)},
+  },
+})
+`)
+
+  return { rootDir, buildLog }
+}
+
+async function buildFixture (rootDir: string) {
+  const nuxt = await loadNuxt({
+    cwd: rootDir,
+    overrides: {
+      dev: false,
+      test: true,
+    },
+    ready: true,
+  })
+
+  await build(nuxt)
+}

--- a/packages/schema/src/config/build.ts
+++ b/packages/schema/src/config/build.ts
@@ -43,6 +43,8 @@ export default defineResolvers({
     },
   },
   build: {
+    client: true,
+    server: true,
     transpile: {
       $resolve: (val) => {
         const transpile: Array<string | RegExp | ((ctx: { isClient?: boolean, isServer?: boolean, isDev: boolean }) => string | RegExp | false)> = []

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -459,16 +459,34 @@ export interface ConfigSchema {
    * Shared build configuration.
    */
   build: {
-  /**
-   * If you want to transpile specific dependencies with Babel, you can add them here. Each item in transpile can be a package name, a function, a string or regex object matching the dependency's file name.
-   *
-   * You can also use a function to conditionally transpile. The function will receive an object ({ isDev, isServer, isClient, isModern, isLegacy }).
-   *
-   * @example
-   * ```js
-   * transpile: [({ isLegacy }) => isLegacy && 'ky']
-   * ```
-   */
+    /**
+     * Whether to build the client bundle and copy public assets into the output directory in production builds.
+     *
+     * Set this to `false` for server-only production builds when client assets are deployed separately. The dev server always builds the client bundle.
+     *
+     * @default true
+     */
+    client: boolean
+
+    /**
+     * Whether to build the Vue server renderer bundle in production builds.
+     *
+     * Set this to `false` when you only need the Nitro server output without server-side rendering. The dev server always builds the server renderer.
+     *
+     * @default true
+     */
+    server: boolean
+
+    /**
+     * If you want to transpile specific dependencies with Babel, you can add them here. Each item in transpile can be a package name, a function, a string or regex object matching the dependency's file name.
+     *
+     * You can also use a function to conditionally transpile. The function will receive an object ({ isDev, isServer, isClient, isModern, isLegacy }).
+     *
+     * @example
+     * ```js
+     * transpile: [({ isLegacy }) => isLegacy && 'ky']
+     * ```
+     */
     transpile: Array<string | RegExp | ((ctx: { isClient?: boolean, isServer?: boolean, isDev: boolean }) => string | RegExp | false)>
 
     /**

--- a/packages/vite/src/plugins/client-manifest.ts
+++ b/packages/vite/src/plugins/client-manifest.ts
@@ -25,6 +25,36 @@ export function ClientManifestPlugin (nuxt: Nuxt): Plugin {
     'client.manifest.mjs': () => manifestCode,
   }
 
+  async function updateManifest (clientManifest: ViteClientManifest) {
+    const manifestEntries = Object.values(clientManifest)
+
+    const buildAssetsDir = withTrailingSlash(withoutLeadingSlash(nuxt.options.app.buildAssetsDir))
+    const BASE_RE = new RegExp(`^${escapeRE(buildAssetsDir)}`)
+
+    for (const entry of manifestEntries) {
+      entry.file &&= entry.file.replace(BASE_RE, '')
+      for (const item of ['css', 'assets'] as const) {
+        entry[item] &&= entry[item].map((i: string) => i.replace(BASE_RE, ''))
+      }
+    }
+
+    if (disableCssCodeSplit) {
+      for (const entry of manifestEntries) {
+        if (entry.file?.endsWith('.css')) {
+          clientManifest[key]!.css ||= []
+          ;(clientManifest[key]!.css as string[]).push(entry.file)
+          break
+        }
+      }
+    }
+
+    const manifest = normalizeViteManifest(clientManifest)
+    await nuxt.callHook('build:manifest', manifest)
+
+    precomputedCode = 'export default ' + serialize(precomputeDependencies(manifest))
+    manifestCode = 'export default ' + serialize(manifest)
+  }
+
   const nitro = useNitro()
   nitro.options.virtual ||= {}
   nitro.options._config.virtual ||= {}
@@ -70,34 +100,10 @@ export function ClientManifestPlugin (nuxt: Nuxt): Plugin {
       const clientDist = resolve(nuxt.options.buildDir, 'dist/client')
 
       const manifestFile = resolve(clientDist, 'manifest.json')
-      const clientManifest = nuxt.options.dev ? devClientManifest : JSON.parse(readFileSync(manifestFile, 'utf-8')) as ViteClientManifest
-      const manifestEntries = Object.values(clientManifest)
-
-      const buildAssetsDir = withTrailingSlash(withoutLeadingSlash(nuxt.options.app.buildAssetsDir))
-      const BASE_RE = new RegExp(`^${escapeRE(buildAssetsDir)}`)
-
-      for (const entry of manifestEntries) {
-        entry.file &&= entry.file.replace(BASE_RE, '')
-        for (const item of ['css', 'assets'] as const) {
-          entry[item] &&= entry[item].map((i: string) => i.replace(BASE_RE, ''))
-        }
-      }
-
-      if (disableCssCodeSplit) {
-        for (const entry of manifestEntries) {
-          if (entry.file?.endsWith('.css')) {
-            clientManifest[key]!.css ||= []
-            ;(clientManifest[key]!.css as string[]).push(entry.file)
-            break
-          }
-        }
-      }
-
-      const manifest = normalizeViteManifest(clientManifest)
-      await nuxt.callHook('build:manifest', manifest)
-
-      precomputedCode = 'export default ' + serialize(precomputeDependencies(manifest))
-      manifestCode = 'export default ' + serialize(manifest)
+      const clientManifest = nuxt.options.build.client === false && !nuxt.options.dev
+        ? {}
+        : nuxt.options.dev ? devClientManifest : JSON.parse(readFileSync(manifestFile, 'utf-8')) as ViteClientManifest
+      await updateManifest(clientManifest)
 
       if (!nuxt.options.dev) {
         if (nuxt.options.experimental.buildCache) {

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -43,6 +43,8 @@ import { PerfPlugin } from './plugins/perf.ts'
 export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
   const useAsyncEntry = nuxt.options.experimental.asyncEntry || nuxt.options.dev
   const entry = await resolvePath(resolve(nuxt.options.appDir, useAsyncEntry ? 'entry.async' : 'entry'))
+  const buildClient = nuxt.options.dev || nuxt.options.build.client !== false
+  const buildServer = nuxt.options.dev || nuxt.options.build.server !== false
 
   nuxt.options.modulesDir.push(distDir)
 
@@ -112,7 +114,9 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
       builder: {
         async buildApp (builder) {
           // run serially to preserve the order of client, server builds
-          const environments = Object.values(builder.environments)
+          const environments = Object.values(builder.environments).filter(environment =>
+            environment.name === 'client' ? buildClient : environment.name === 'ssr' ? buildServer : true,
+          )
           for (const environment of environments) {
             logger.restoreAll()
             nuxt._perf?.startPhase(`vite:${environment.name}`)
@@ -252,7 +256,10 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
   config.customLogger = createViteLogger(config, { onNewDeps: callbacks?.onNewDeps, onStaleDep: callbacks?.onStaleDep })
   config.configFile = false
 
-  for (const environment of ['client', 'ssr']) {
+  for (const environment of [
+    ...(buildClient ? ['client'] as const : []),
+    ...(buildServer ? ['ssr'] as const : []),
+  ]) {
     const environments = { [environment]: config.environments![environment]! }
     const strippedConfig = { ...config, environments } as ViteConfig
     const ctx = { isServer: environment === 'ssr', isClient: environment === 'client' }

--- a/packages/webpack/src/webpack.ts
+++ b/packages/webpack/src/webpack.ts
@@ -25,7 +25,16 @@ import { builder, webpack } from '#builder'
 // const plugins: string[] = []
 
 export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
-  const webpackConfigs = await Promise.all([client, ...(nuxt.options.ssr ? [server] : [])].map(async (preset) => {
+  const buildClient = nuxt.options.dev || nuxt.options.build.client !== false
+  const buildServer = nuxt.options.dev || nuxt.options.build.server !== false
+  if (!buildClient) {
+    registerEmptyClientManifest()
+  }
+  const presets = [
+    ...(buildClient ? [client] : []),
+    ...(nuxt.options.ssr && buildServer ? [server] : []),
+  ]
+  const webpackConfigs = await Promise.all(presets.map(async (preset) => {
     const ctx = createWebpackConfigContext(nuxt)
     ctx.userConfig = defu(nuxt.options.webpack[`$${preset.name as 'client' | 'server'}`], ctx.userConfig)
     await applyPresets(ctx, preset)
@@ -93,6 +102,16 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
   for (const c of compilers) {
     await compile(c)
   }
+}
+
+function registerEmptyClientManifest () {
+  const nitro = useNitro()
+  nitro.options.virtual ||= {}
+  nitro.options._config.virtual ||= {}
+  nitro.options.virtual['#build/dist/server/client.manifest.mjs'] ||= 'export default undefined'
+  nitro.options.virtual['#build/dist/server/client.precomputed.mjs'] ||= 'export default undefined'
+  nitro.options._config.virtual['#build/dist/server/client.manifest.mjs'] ||= 'export default undefined'
+  nitro.options._config.virtual['#build/dist/server/client.precomputed.mjs'] ||= 'export default undefined'
 }
 
 async function createDevMiddleware (compiler: Compiler) {


### PR DESCRIPTION
### Summary

- add `build.client` and `build.server` config flags, defaulting to `true`
- allow production builds to skip client bundle/public output for server-only deployments
- allow production builds to skip the Vue server renderer bundle while preserving Nitro/client output
- cover Vite, Webpack, and Rspack paths, including a `vue.runtimeCompiler` regression case

Resolves #14669.

### Tests

- `CI=1 pnpm vitest run --project unit packages/nuxt/test/build-options.test.ts`
- `CI=1 pnpm exec eslint docs/4.api/6.nuxt-config.md packages/schema/src/config/build.ts packages/schema/src/types/schema.ts packages/vite/src/vite.ts packages/vite/src/plugins/client-manifest.ts packages/webpack/src/webpack.ts packages/nitro-server/src/index.ts packages/nuxt/test/build-options.test.ts`
- `CI=1 pnpm --filter @nuxt/schema --filter @nuxt/nitro-server --filter @nuxt/vite-builder --filter @nuxt/webpack-builder --filter nuxt build`
- `CI=1 pnpm test:unit`
