### PR TITLE
fix(nuxt): detect recursive SSR fetches

### DIFF
--- a/packages/nitro-server/src/runtime/handlers/island.ts
+++ b/packages/nitro-server/src/runtime/handlers/island.ts
@@ -14,6 +14,7 @@ import { tracingChannelNuxt } from '#internal/nuxt.config.mjs'
 import { createSSRContext, rethrowWithResponseHeaders, returnRenderResponse } from '../utils/renderer/app'
 import { getSSRRenderer } from '../utils/renderer/build-files'
 import { renderInlineStyles } from '../utils/renderer/inline-styles'
+import { renderWithRenderStack } from '../utils/render-stack'
 import { getClientIslandResponse, getServerComponentHTML, getSlotIslandResponse } from '../utils/renderer/islands'
 import { useStorage } from 'nitro/storage'
 import type { Storage } from 'unstorage'
@@ -47,9 +48,9 @@ export default {
       // Render app
       const renderer = await getSSRRenderer()
 
-      const renderResult = await (tracingChannelNuxt
+      const renderResult = await renderWithRenderStack(event, () => tracingChannelNuxt
         ? traceAsync('nuxt.island', { event, ssrContext, islandContext }, () => renderer.renderToString(ssrContext))
-        : renderer.renderToString(ssrContext)
+        : renderer.renderToString(ssrContext),
       ).catch(async (err) => {
         if (ssrContext['~renderResponse'] && (err as Error)?.message === 'skipping render') {
           return {} as Awaited<ReturnType<typeof renderer.renderToString>>

--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -18,11 +18,12 @@ import type { NuxtPayload, NuxtRenderHTMLContext, NuxtSSRContext } from 'nuxt/ap
 import { traceAsync } from '#app/internal/tracing'
 
 import { APP_ROOT_CLOSE_TAG, APP_ROOT_OPEN_TAG, getRenderer, getServerApp } from '../utils/renderer/build-files'
-import { payloadCache, prerenderRenderingURLs } from '../utils/cache'
+import { payloadCache } from '../utils/cache'
 
 import { renderPayloadJsonScript, renderPayloadResponse, splitPayload } from '../utils/renderer/payload'
 import { createSSRContext, rethrowWithResponseHeaders, returnRenderResponse, setSSRError } from '../utils/renderer/app'
 import { renderInlineStyles } from '../utils/renderer/inline-styles'
+import { renderWithRenderStack } from '../utils/render-stack'
 import { renderStreamedIslandTeleports, replaceIslandTeleports } from '../utils/renderer/islands'
 // @ts-expect-error virtual file
 import { renderSSRHeadOptions } from '#internal/unhead.config.mjs'
@@ -82,24 +83,7 @@ export default {
       })
     }
 
-    // During prerender, refuse to recurse into a URL that is already rendering
-    // higher in the same call chain. Without this, a `useFetch`/`$fetch` against
-    // the in-flight URL (typically from route middleware) silently deadlocks the
-    // build. See https://github.com/nuxt/nuxt/issues/33871.
-    if (import.meta.prerender && prerenderRenderingURLs) {
-      const renderingURL = event.url.pathname + event.url.search
-      const stack = prerenderRenderingURLs.getStore()
-      if (stack?.includes(renderingURL)) {
-        const chain = [...stack, renderingURL].filter(url => !url.startsWith('/__nuxt_error')).map(url => `"${url}"`).join(' -> ')
-        throw new HTTPError({
-          status: 508,
-          statusText: `Loop detected while prerendering "${renderingURL}" (${chain}). Check for \`useFetch\`/\`$fetch\` calls targeting a URL that is currently being rendered.`,
-        })
-      }
-      return prerenderRenderingURLs.run([...(stack || []), renderingURL], () => renderRoute(event, ssrError)).catch(error => rethrowWithResponseHeaders(event, error))
-    }
-
-    return renderRoute(event, ssrError).catch(error => rethrowWithResponseHeaders(event, error))
+    return renderWithRenderStack(event, () => renderRoute(event, ssrError)).catch(error => rethrowWithResponseHeaders(event, error))
   },
 }
 

--- a/packages/nitro-server/src/runtime/utils/cache.ts
+++ b/packages/nitro-server/src/runtime/utils/cache.ts
@@ -1,6 +1,6 @@
-import { AsyncLocalStorage } from 'node:async_hooks'
 import type { Storage } from 'unstorage'
 import { useStorage } from 'nitro/storage'
+import { renderingURLs } from './render-stack'
 // @ts-expect-error virtual file
 import { NUXT_RUNTIME_PAYLOAD_EXTRACTION, NUXT_SHARED_DATA } from '#internal/nuxt/nitro-config.mjs'
 
@@ -11,11 +11,7 @@ export interface CachedResponse {
   headers: Record<string, string>
 }
 
-/**
- * Stack of URLs currently rendering in the active async context (oldest first).
- * A repeated entry signals a render cycle.
- */
-export const prerenderRenderingURLs: AsyncLocalStorage<readonly string[]> | null = import.meta.prerender ? new AsyncLocalStorage() : null
+export const prerenderRenderingURLs = import.meta.prerender ? renderingURLs : null
 
 export const payloadCache: Storage<CachedResponse> | null = import.meta.prerender
   ? useStorage<CachedResponse>('internal:nuxt:prerender:payload')

--- a/packages/nitro-server/src/runtime/utils/render-stack.ts
+++ b/packages/nitro-server/src/runtime/utils/render-stack.ts
@@ -1,0 +1,39 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+import { HTTPError } from 'nitro/h3'
+import type { H3Event } from 'nitro/h3'
+
+/**
+ * Stack of URLs currently rendering in the active async context (oldest first).
+ * A repeated entry signals a render cycle.
+ */
+export const renderingURLs: AsyncLocalStorage<readonly string[]> = new AsyncLocalStorage()
+
+function withoutSearch (url: string) {
+  const searchIndex = url.indexOf('?')
+  return searchIndex === -1 ? url : url.slice(0, searchIndex)
+}
+
+export async function renderWithRenderStack<T> (event: H3Event, render: () => Promise<T>): Promise<T> {
+  // Refuse to recurse into a URL that is already rendering higher in the same
+  // call chain. Without this, a `useFetch`/`$fetch` against an app-rendered URL
+  // can repeatedly re-enter the renderer until the server runs out of memory.
+  const renderingURL = event.url.pathname + event.url.search
+  const stack = renderingURLs.getStore()
+  if (stack?.includes(renderingURL)) {
+    const renderingPath = event.url.pathname
+    const chain = [...stack, renderingURL]
+      .map(withoutSearch)
+      .filter(url => !url.startsWith('/__nuxt_error'))
+      .map(url => `"${url}"`)
+      .join(' -> ')
+    const rendering = import.meta.prerender ? 'prerendering' : 'rendering'
+    const message = `Loop detected while ${rendering} "${renderingPath}" (${chain}). Check for \`useFetch\`/\`$fetch\` calls targeting a URL that is currently being rendered.`
+    throw new HTTPError({
+      status: 508,
+      statusText: message,
+      message,
+    })
+  }
+  const result = await renderingURLs.run([...(stack || []), renderingURL], render)
+  return result
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1385,6 +1385,12 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/nuxt
 
+  test/fixtures/recursive-fetch:
+    dependencies:
+      nuxt:
+        specifier: workspace:*
+        version: link:../../../packages/nuxt
+
   test/fixtures/runtime-compiler:
     dependencies:
       nuxt:

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -58,7 +58,7 @@ describe.skipIf(isStubbed || process.env.SKIP_BUNDLE_SIZE === 'true' || process.
     const serverDir = join(rootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!_libs'], serverDir, rootDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"70.2k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"71.3k"`)
 
     const modules = await analyzeSizes(['_libs/**/*'], serverDir, rootDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"482k"`)
@@ -92,7 +92,7 @@ describe.skipIf(isStubbed || process.env.SKIP_BUNDLE_SIZE === 'true' || process.
     const serverDir = join(pagesRootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!_libs'], serverDir, pagesRootDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"172k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"174k"`)
 
     const modules = await analyzeSizes(['_libs/**/*'], serverDir, pagesRootDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"483k"`)

--- a/test/fixtures/recursive-fetch/app.vue
+++ b/test/fixtures/recursive-fetch/app.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+interface FetchErrorLike {
+  response?: {
+    status?: number
+    statusText?: string
+  }
+  status?: number
+  statusText?: string
+  message?: string
+  data?: unknown
+}
+
+const result = useState('recursive-fetch-result', () => 'not run')
+
+function getErrorMessage (error: FetchErrorLike) {
+  if (typeof error.data === 'object' && error.data && 'message' in error.data) {
+    return String(error.data.message)
+  }
+  if (typeof error.data === 'string') {
+    if (error.data.includes('Loop detected')) {
+      return `Loop detected while rendering${error.data.includes('recursive-fetch-target') ? ' /recursive-fetch-target' : ''}`
+    }
+    return error.data
+  }
+  return error.response?.statusText || error.statusText || error.message || 'unknown error'
+}
+
+if (import.meta.server) {
+  const url = useRequestURL()
+
+  if (url.pathname === '/') {
+    const apiResult = await $fetch('/api/ping')
+
+    try {
+      await $fetch('/recursive-fetch-target')
+      result.value = `api: ${apiResult}; recursive fetch unexpectedly succeeded`
+    } catch (error) {
+      const fetchError = error as FetchErrorLike
+      const status = fetchError.response?.status || fetchError.status || 'unknown'
+      result.value = `api: ${apiResult}; recursive fetch status: ${status}; ${getErrorMessage(fetchError)}`
+    }
+  } else if (url.pathname === '/recursive-fetch-target') {
+    await $fetch('/recursive-fetch-target')
+    result.value = 'recursive target unexpectedly rendered'
+  }
+}
+</script>
+
+<template>
+  <div>{{ result }}</div>
+</template>

--- a/test/fixtures/recursive-fetch/nuxt.config.ts
+++ b/test/fixtures/recursive-fetch/nuxt.config.ts
@@ -1,0 +1,5 @@
+export default defineNuxtConfig({
+  pages: false,
+  devtools: { enabled: false },
+  compatibilityDate: 'latest',
+})

--- a/test/fixtures/recursive-fetch/package.json
+++ b/test/fixtures/recursive-fetch/package.json
@@ -1,0 +1,10 @@
+{
+  "private": true,
+  "name": "fixture-recursive-fetch",
+  "dependencies": {
+    "nuxt": "workspace:*"
+  },
+  "engines": {
+    "node": "^22.19.0 || ^24.11.0 || >=26.0.0"
+  }
+}

--- a/test/fixtures/recursive-fetch/server/api/ping.ts
+++ b/test/fixtures/recursive-fetch/server/api/ping.ts
@@ -1,0 +1,3 @@
+import { defineEventHandler } from 'h3'
+
+export default defineEventHandler(() => 'pong')

--- a/test/recursive-fetch.test.ts
+++ b/test/recursive-fetch.test.ts
@@ -1,0 +1,46 @@
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { isWindows } from 'std-env'
+import { $fetch, fetch, setup } from '@nuxt/test-utils/e2e'
+
+import { isDev } from './matrix'
+
+const isMatrixRun = !!process.env.TEST_BUILDER
+const skipForMatrix = isMatrixRun && !(
+  process.env.TEST_BUILDER === 'vite'
+  && process.env.TEST_CONTEXT === 'default'
+  && process.env.TEST_MANIFEST === 'manifest-on'
+)
+
+if (!skipForMatrix) {
+  await setup({
+    rootDir: fileURLToPath(new URL('./fixtures/recursive-fetch', import.meta.url)),
+    dev: isDev,
+    server: true,
+    browser: false,
+    setupTimeout: (isWindows ? 360 : 120) * 1000,
+  })
+}
+
+describe.skipIf(skipForMatrix)('recursive SSR fetch detection', () => {
+  it('fails recursive rendered internal fetches with 508 instead of recursing', async () => {
+    const html = await $fetch<string>('/')
+
+    expect(html).toContain('api: pong')
+    expect(html).toContain('recursive fetch status: 508')
+    expect(html).toContain('Loop detected while rendering')
+    expect(html).toContain('/recursive-fetch-target')
+  })
+
+  it('redacts query strings from recursive fetch error messages', async () => {
+    const secret = 'super-secret-token'
+    const response = await fetch(`/recursive-fetch-target?token=${secret}`)
+    const text = await response.text()
+
+    expect(response.status).toBe(508)
+    expect(text).toContain('Loop detected while rendering')
+    expect(text).toContain('/recursive-fetch-target')
+    expect(text).not.toContain(secret)
+    expect(text).not.toContain('token=')
+  })
+})


### PR DESCRIPTION
###  Linked issue

Fixes #14178

###  Description

This adds render-chain detection for runtime SSR requests so an internal fetch that re-enters a URL already being rendered fails with a bounded 508 error instead of recursively rendering until the server runs out of memory.

- Adds a shared render stack helper used by page SSR and island SSR.
- Keeps prerender loop detection on the same async-local render chain.
- Redacts query strings from the client-facing loop-detection error message while preserving full URL matching internally.
- Adds a focused fixture that verifies normal internal API fetches still work while recursive app-rendered fetches fail with 508 in dev and built modes.
- Updates bundle-size snapshots for the added runtime helper.

###  Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated tests accordingly.

###  Tests

- `pnpm eslint packages/nitro-server/src/runtime/handlers/renderer.ts packages/nitro-server/src/runtime/handlers/island.ts packages/nitro-server/src/runtime/utils/cache.ts packages/nitro-server/src/runtime/utils/render-stack.ts test/recursive-fetch.test.ts test/fixtures/recursive-fetch/app.vue test/fixtures/recursive-fetch/nuxt.config.ts test/fixtures/recursive-fetch/server/api/ping.ts test/bundle.test.ts`
- `pnpm vitest run test/recursive-fetch.test.ts --project fixtures:vite-dev-default-manifest-on`
- `pnpm vitest run test/recursive-fetch.test.ts --project fixtures:vite-built-default-manifest-on`
- `pnpm vitest run test/bundle.test.ts --project bundle`
- `pnpm vitest run test/basic.test.ts --project fixtures:vite-built-default-manifest-on -t 'prerenders pages whose middleware calls'`
- `pnpm vitest run test/basic.test.ts --project fixtures:vite-built-default-manifest-on -t 'prerenders parallel pages'`
- `pnpm vitest run test/server-components.test.ts --project fixtures:vite-built-default-manifest-on -t 'renders components with route'`
- `pnpm --filter @nuxt/nitro-server build`
