### PR TITLE
feat(nitro): allow auto-imports in module runtime

### DIFF
--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -11,7 +11,7 @@ import { joinURL, withTrailingSlash } from 'ufo'
 import nuxtPkg from 'nuxt/package.json' with { type: 'json' }
 import { build, copyPublicAssets, createDevServer, createNitro, prepare, prerender, writeTypes } from 'nitro/builder'
 import type { Nitro, NitroConfig, NitroRouteRules } from 'nitro/types'
-import { addPlugin, addTemplate, addVitePlugin, createIsIgnored, ensureDependencyInstalled, findPath, getDirectory, getLayerDirectories, logger, resolveAlias, resolveIgnorePatterns, resolveNuxtModule } from '@nuxt/kit'
+import { addPlugin, addTemplate, addVitePlugin, createIsIgnored, ensureDependencyInstalled, findPath, getDirectory, getLayerDirectories, logger, resolveAlias, resolveIgnorePatterns, resolveNuxtModule, resolvePath } from '@nuxt/kit'
 import escapeRE from 'escape-string-regexp'
 import { defu } from 'defu'
 import { defineEventHandler, dynamicEventHandler, handleCors } from 'nitro/h3'
@@ -23,7 +23,7 @@ import { runtimeDependencies } from 'nitro/meta'
 import './augments.ts'
 
 import nitroBuilder from '../package.json' with { type: 'json' }
-import { distDir, getLayerNodeModulesExcludePattern, getSsrResolveConditions, toArray } from './utils.ts'
+import { distDir, getNodeModulePackageRoot, getNodeModulesExcludePattern, getSsrResolveConditions, toArray } from './utils.ts'
 import { template as defaultSpaLoadingTemplate } from '../../ui-templates/dist/templates/spa-loading-icon.ts'
 // TODO: figure out a good way to share this
 import { createImportProtectionPatterns } from '../../nuxt/src/core/plugins/import-protection.ts'
@@ -39,7 +39,6 @@ const logLevelMapReverse = {
 export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
   // Resolve config
   const layerDirs = getLayerDirectories(nuxt)
-  const excludePattern = [getLayerNodeModulesExcludePattern(layerDirs.map(dirs => dirs.root))]
 
   const layerPublicAssetsDirs: Array<{ dir: string, maxAge: number }> = []
   for (const dirs of layerDirs) {
@@ -59,6 +58,25 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
   }
 
   const modules = await resolveNuxtModule(rootDirWithSlash, moduleEntryPaths)
+  const modulePackageRoots = await Promise.all(moduleEntryPaths.map(async (path) => {
+    // `modules` is kept for existing template generation below, but it can
+    // collapse node_modules entries to a parent directory. Resolve the original
+    // installed entry path so this allow-list is scoped to the package root.
+    const resolvedPath = path.startsWith(rootDirWithSlash)
+      ? path
+      : await resolvePath(path, { alias: nuxt.options.alias, cwd: rootDirWithSlash, fallbackToOriginal: true })
+    return getNodeModulePackageRoot(resolvedPath)
+  }))
+  const moduleRootsInNodeModules = new Set<string>()
+  for (const packageRoot of modulePackageRoots) {
+    if (packageRoot) {
+      moduleRootsInNodeModules.add(packageRoot)
+    }
+  }
+  const excludePattern = [getNodeModulesExcludePattern([
+    ...layerDirs.map(dirs => dirs.root),
+    ...moduleRootsInNodeModules,
+  ])]
 
   addTemplate(nitroSchemaTemplate)
 

--- a/packages/nitro-server/src/utils.test.ts
+++ b/packages/nitro-server/src/utils.test.ts
@@ -1,32 +1,34 @@
 import { describe, expect, it } from 'vitest'
-import { getLayerNodeModulesExcludePattern } from './utils.ts'
+import { getLayerNodeModulesExcludePattern, getNodeModulePackageRoot, getNodeModulesExcludePattern } from './utils.ts'
 
-describe('getLayerNodeModulesExcludePattern', () => {
+describe('getNodeModulesExcludePattern', () => {
   it('falls back to a bare node_modules pattern when no layers live in node_modules', () => {
-    const re = getLayerNodeModulesExcludePattern(['/proj/'])
+    const re = getNodeModulesExcludePattern(['/proj/'])
     expect(re.test('/proj/node_modules/anything/x.ts')).toBe(true)
     expect(re.test('/proj/app/x.ts')).toBe(false)
   })
 
   it('does not exclude files belonging to a flat-installed layer', () => {
-    const re = getLayerNodeModulesExcludePattern(['/proj/node_modules/foo/'])
+    const re = getNodeModulesExcludePattern(['/proj/node_modules/foo/'])
     expect(re.test('/proj/node_modules/foo/server/api/x.ts')).toBe(false)
     expect(re.test('/proj/node_modules/other/x.ts')).toBe(true)
   })
 
   it('does not exclude files belonging to layers nested inside another layer (npm)', () => {
-    const re = getLayerNodeModulesExcludePattern([
+    const re = getNodeModulesExcludePattern([
       '/proj/node_modules/a/',
       '/proj/node_modules/a/node_modules/b/',
     ])
     expect(re.test('/proj/node_modules/a/server/x.ts')).toBe(false)
     expect(re.test('/proj/node_modules/a/node_modules/b/server/x.ts')).toBe(false)
     expect(re.test('/proj/node_modules/a/node_modules/other/x.ts')).toBe(true)
+    expect(re.test('/proj/node_modules/a/node_modules/b/node_modules/c/x.ts')).toBe(true)
     expect(re.test('/proj/node_modules/other/x.ts')).toBe(true)
+    expect(re.test('/other/node_modules/b/x.ts')).toBe(true)
   })
 
   it('does not exclude files belonging to a layer installed via pnpm', () => {
-    const re = getLayerNodeModulesExcludePattern([
+    const re = getNodeModulesExcludePattern([
       '/proj/node_modules/.pnpm/foo@1/node_modules/foo/',
     ])
     expect(re.test('/proj/node_modules/.pnpm/foo@1/node_modules/foo/server/x.ts')).toBe(false)
@@ -35,14 +37,14 @@ describe('getLayerNodeModulesExcludePattern', () => {
   })
 
   it('protects every node_modules boundary in a pnpm layer path', () => {
-    const re = getLayerNodeModulesExcludePattern([
+    const re = getNodeModulesExcludePattern([
       '/proj/node_modules/.pnpm/foo@1/node_modules/foo/',
     ])
     expect(re.source).toContain('.pnpm')
   })
 
   it('handles multiple pnpm-installed layers', () => {
-    const re = getLayerNodeModulesExcludePattern([
+    const re = getNodeModulesExcludePattern([
       '/proj/node_modules/.pnpm/foo@1/node_modules/foo/',
       '/proj/node_modules/.pnpm/bar@1/node_modules/bar/',
     ])
@@ -52,14 +54,51 @@ describe('getLayerNodeModulesExcludePattern', () => {
   })
 
   it('escapes regex metacharacters in package names', () => {
-    const re = getLayerNodeModulesExcludePattern(['/proj/node_modules/@scope/foo.bar/'])
+    const re = getNodeModulesExcludePattern(['/proj/node_modules/@scope/foo.bar/'])
     expect(re.test('/proj/node_modules/@scope/foo.bar/server/x.ts')).toBe(false)
     expect(re.test('/proj/node_modules/@scope/fooxbar/server/x.ts')).toBe(true)
   })
 
   it('strips a trailing slash on the layer root before walking', () => {
-    const withSlash = getLayerNodeModulesExcludePattern(['/proj/node_modules/foo/'])
-    const withoutSlash = getLayerNodeModulesExcludePattern(['/proj/node_modules/foo'])
+    const withSlash = getNodeModulesExcludePattern(['/proj/node_modules/foo/'])
+    const withoutSlash = getNodeModulesExcludePattern(['/proj/node_modules/foo'])
     expect(withSlash.source).toBe(withoutSlash.source)
+  })
+
+  it('does not allow packages with the same prefix', () => {
+    const re = getNodeModulesExcludePattern(['/proj/node_modules/foo/'])
+    expect(re.test('/proj/node_modules/foo/server/api/x.ts')).toBe(false)
+    expect(re.test('/proj/node_modules/foobar/server/api/x.ts')).toBe(true)
+  })
+})
+
+describe('getLayerNodeModulesExcludePattern', () => {
+  it('keeps the layer-specific helper as a compatibility wrapper', () => {
+    const re = getLayerNodeModulesExcludePattern(['/proj/node_modules/foo/'])
+    expect(re.source).toBe(getNodeModulesExcludePattern(['/proj/node_modules/foo/']).source)
+  })
+})
+
+describe('getNodeModulePackageRoot', () => {
+  it('extracts flat-installed package roots', () => {
+    expect(getNodeModulePackageRoot('/proj/node_modules/foo/dist/module.mjs')).toBe('/proj/node_modules/foo')
+  })
+
+  it('extracts scoped package roots', () => {
+    expect(getNodeModulePackageRoot('/proj/node_modules/@scope/foo/dist/module.mjs')).toBe('/proj/node_modules/@scope/foo')
+  })
+
+  it('extracts pnpm package roots from the last node_modules segment', () => {
+    expect(getNodeModulePackageRoot('/proj/node_modules/.pnpm/foo@1/node_modules/foo/dist/module.mjs')).toBe('/proj/node_modules/.pnpm/foo@1/node_modules/foo')
+  })
+
+  it('normalizes windows-style paths', () => {
+    expect(getNodeModulePackageRoot('C:\\proj\\node_modules\\@scope\\foo\\dist\\module.mjs')).toBe('C:/proj/node_modules/@scope/foo')
+  })
+
+  it('skips local, store-only, and malformed package paths', () => {
+    expect(getNodeModulePackageRoot('/proj/modules/foo/index.ts')).toBeUndefined()
+    expect(getNodeModulePackageRoot('/proj/node_modules/.pnpm/foo@1')).toBeUndefined()
+    expect(getNodeModulePackageRoot('/proj/node_modules/@scope')).toBeUndefined()
   })
 })

--- a/packages/nitro-server/src/utils.ts
+++ b/packages/nitro-server/src/utils.ts
@@ -6,36 +6,70 @@ export function toArray<T> (value: T | T[]): T[] {
   return Array.isArray(value) ? value : [value]
 }
 
-const NODE_MODULES_RE = /\/node_modules\//g
+const NODE_MODULES_SEGMENT = '/node_modules/'
+const NODE_MODULES_PATTERN = 'node_modules\\/'
+
+function normalizeNodeModulesPath (path: string): string {
+  return path.replace(/\\/g, '/').replace(/\/+$/, '')
+}
+
+export function getNodeModulePackageRoot (path: string): string | undefined {
+  const normalized = normalizeNodeModulesPath(path)
+  const nodeModulesIndex = normalized.lastIndexOf(NODE_MODULES_SEGMENT)
+  if (nodeModulesIndex === -1) {
+    return
+  }
+
+  // Nitro can safely auto-import from Nuxt-owned package roots, but not from
+  // arbitrary files under node_modules. Treat the resolved package root as the
+  // allow-list boundary and keep unrelated package subtrees excluded.
+  const packagePath = normalized.slice(nodeModulesIndex + NODE_MODULES_SEGMENT.length)
+  const [name, subname] = packagePath.split('/')
+  if (!name || name === '.pnpm') {
+    return
+  }
+
+  const packageName = name.startsWith('@')
+    ? subname && `${name}/${subname}`
+    : name
+
+  if (!packageName) {
+    return
+  }
+
+  return normalized.slice(0, nodeModulesIndex + NODE_MODULES_SEGMENT.length + packageName.length)
+}
 
 /**
  * Build the regex Nitro uses to skip transforming files under `node_modules`,
- * while still transforming files that belong to layers that happen to live
- * inside a `node_modules` directory.
+ * while still transforming files that belong to Nuxt layers or modules that
+ * happen to live inside a `node_modules` directory.
  *
- * Layer paths can contain multiple `/node_modules/` segments (nested npm
- * installs; pnpm's `.pnpm/<id>/node_modules/<name>` store). The exclude
- * pattern is `node_modules/(?!<alts>)` evaluated at every `node_modules/`
- * boundary, so we push the suffix at each boundary to make the lookahead
- * fail wherever the layer's own files live.
+ * Allowed roots can contain multiple `/node_modules/` segments (nested npm
+ * installs; pnpm's `.pnpm/<id>/node_modules/<name>` store). Match the complete
+ * allowed root instead of only the package name suffix, otherwise a nested
+ * package like `a/node_modules/b` could accidentally allow an unrelated
+ * `node_modules/b` tree elsewhere.
  */
-export function getLayerNodeModulesExcludePattern (layerRoots: Iterable<string>): RegExp {
-  const excludePaths: string[] = []
-  for (const layerRoot of layerRoots) {
-    const root = layerRoot.replace(/\/$/, '')
-    NODE_MODULES_RE.lastIndex = 0
-    let match: RegExpExecArray | null
-    while ((match = NODE_MODULES_RE.exec(root))) {
-      const suffix = root.slice(match.index + match[0].length)
-      if (suffix) {
-        excludePaths.push(escapeRE(suffix))
-      }
-      NODE_MODULES_RE.lastIndex = match.index + 1
+export function getNodeModulesExcludePattern (allowedRoots: Iterable<string>): RegExp {
+  const allowedRootPatterns = new Set<string>()
+  for (const allowedRoot of allowedRoots) {
+    const root = normalizeNodeModulesPath(allowedRoot)
+    if (root.includes(NODE_MODULES_SEGMENT)) {
+      allowedRootPatterns.add(`${escapeRE(root)}(?:\\/(?!(?:${NODE_MODULES_PATTERN}|.*\\/${NODE_MODULES_PATTERN})).*)?`)
     }
   }
-  return excludePaths.length
-    ? new RegExp(`node_modules\\/(?!${excludePaths.join('|')})`)
-    : /node_modules/
+
+  if (!allowedRootPatterns.size) {
+    return /node_modules/
+  }
+
+  const allowedRootAlternatives = [...allowedRootPatterns].map(pattern => `${pattern}$`).join('|')
+  return new RegExp(`^(?!${allowedRootAlternatives}).*${NODE_MODULES_PATTERN}`)
+}
+
+export function getLayerNodeModulesExcludePattern (layerRoots: Iterable<string>): RegExp {
+  return getNodeModulesExcludePattern(layerRoots)
 }
 
 /**

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -150,6 +150,31 @@ describe('modules', () => {
     const result = await $fetch<string>('/auto-registered-module-late')
     expect(result).toEqual('handler added from nitro:config hook')
   })
+
+  it('should auto-import Nitro utilities in modules installed under node_modules (#15621)', async () => {
+    const result = await $fetch('/nitro-auto-import-module')
+    expect(result).toEqual({
+      handler: 'nitro-auto-import-module',
+      routeRules: true,
+    })
+  })
+
+  it('should keep unrelated node_modules excluded from Nitro auto-imports (#15621)', () => {
+    const ctx = useTestContext()
+    const nuxt = ctx.nuxt
+    if (!nuxt) {
+      throw new Error('Nuxt test context is not initialized')
+    }
+    // @ts-expect-error internal test assertion
+    const exclude = nuxt._nitro.options.imports.exclude as Array<RegExp | string>
+    const isExcluded = (path: string) => exclude.some(pattern =>
+      pattern instanceof RegExp ? pattern.test(path) : path.includes(pattern),
+    )
+
+    expect(isExcluded(join(nuxt.options.rootDir, 'extends/node_modules/unrelated-package/runtime/server-handler.ts'))).toBe(true)
+    expect(isExcluded(join(nuxt.options.rootDir, 'extends/node_modules/nitro-auto-import-module/runtime/server-handler.ts'))).toBe(false)
+    expect(isExcluded(join(nuxt.options.rootDir, 'extends/node_modules/foo/server/api/foo.ts'))).toBe(false)
+  })
 })
 
 describe('pages', () => {

--- a/test/fixtures/basic/extends/node_modules/foo/server/api/foo.ts
+++ b/test/fixtures/basic/extends/node_modules/foo/server/api/foo.ts
@@ -1,3 +1,4 @@
-import { eventHandler } from 'h3'
-
-export default eventHandler(() => 'foo')
+export default defineEventHandler((event) => {
+  getRouteRules(event.req.method, event.url.pathname)
+  return 'foo'
+})

--- a/test/fixtures/basic/extends/node_modules/foo/server/middleware/foo.ts
+++ b/test/fixtures/basic/extends/node_modules/foo/server/middleware/foo.ts
@@ -1,6 +1,3 @@
-// TODO: add back TypeScript and auto-importing once Nitro supports it
-import { eventHandler } from 'h3'
-
-export default eventHandler((event) => {
+export default defineEventHandler((event) => {
   event.res.headers.set('injected-header', 'foo')
 })

--- a/test/fixtures/basic/extends/node_modules/nitro-auto-import-module/index.ts
+++ b/test/fixtures/basic/extends/node_modules/nitro-auto-import-module/index.ts
@@ -1,0 +1,15 @@
+import { addServerHandler, createResolver, defineNuxtModule } from 'nuxt/kit'
+
+export default defineNuxtModule({
+  meta: {
+    name: 'nitro-auto-import-module',
+  },
+  setup () {
+    const resolver = createResolver(import.meta.url)
+
+    addServerHandler({
+      handler: resolver.resolve('./runtime/server-handler'),
+      route: '/nitro-auto-import-module',
+    })
+  },
+})

--- a/test/fixtures/basic/extends/node_modules/nitro-auto-import-module/runtime/server-handler.ts
+++ b/test/fixtures/basic/extends/node_modules/nitro-auto-import-module/runtime/server-handler.ts
@@ -1,0 +1,6 @@
+export default defineEventHandler((event) => {
+  return {
+    handler: 'nitro-auto-import-module',
+    routeRules: Boolean(getRouteRules(event.req.method, event.url.pathname).routeRules),
+  }
+})

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -33,6 +33,7 @@ export default withMatrix({
     '~~/custom-modules/subpath',
     './modules/test',
     '~~/modules/example',
+    './extends/node_modules/nitro-auto-import-module',
     function (_, nuxt) {
       // Virtual CSS modules only work with Vite, not with webpack/rspack
       if (typeof nuxt.options.builder === 'string' && (nuxt.options.builder.includes('webpack') || nuxt.options.builder.includes('rspack'))) { return }


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #15621.

### 📚 Description

Allows Nuxt-owned module and layer runtime files under `node_modules` to receive Nitro auto-import transforms while keeping unrelated `node_modules` excluded.

This extends the existing layer allow-listing logic to installed module package roots and adds regression coverage for:
- Nitro auto-imports in a module runtime handler under `node_modules`
- layer server route/middleware files under `node_modules`
- unrelated `node_modules` paths remaining excluded in actual Nitro config
- scoped, pnpm, malformed, and prefix-collision package root cases

### ✅ Checks

- [x] `pnpm dev:prepare`
- [x] `pnpm test:prepare`
- [x] `pnpm exec vitest run --project unit packages/nitro-server/src/utils.test.ts`
- [x] `pnpm exec vitest run --project 'fixtures:vite-built-default-manifest-on' test/basic.test.ts -t 'Nitro auto-import|auto-import Nitro|extends foo/server'`
- [x] `pnpm exec eslint --no-warn-ignored <changed files>`
- [x] `pnpm typecheck`
- [x] `git diff --check`
