### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/docs/3.guide/5.recipes/2.vite-plugin.md
+++ b/docs/3.guide/5.recipes/2.vite-plugin.md
@@ -68,6 +68,24 @@ import config from '~/data/hello.yaml'
 
 ::
 
+## Handling Plugin Dependencies
+
+Some Vite plugins load extra runtime dependencies, transform non-standard files, or expect specific dependencies to be pre-bundled during development.
+
+If a plugin dependency needs to be included in or excluded from Vite's dependency pre-bundling, configure [`vite.optimizeDeps`](/docs/4.x/api/nuxt-config#optimizedeps) in `nuxt.config.ts`:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  vite: {
+    optimizeDeps: {
+      include: ['my-plugin/runtime'],
+    },
+  },
+})
+```
+
+If a plugin or one of its runtime dependencies needs to be transformed by Nuxt before it runs, add it to [`build.transpile`](/docs/4.x/api/nuxt-config#transpile) instead.
+
 ## Using Vite Plugins in Nuxt Modules
 
 If you're developing a Nuxt module and need to add Vite plugins, you should use the [`addVitePlugin`](/docs/4.x/api/kit/builder#addviteplugin) utility:


### PR DESCRIPTION
### Description

Adds a short dependency-handling section to the Vite plugin guide, covering when to use `vite.optimizeDeps` for development pre-bundling and `build.transpile` for dependencies that need Nuxt transformation.

Refs #29103.

### Validation

- `git diff --check`
- Confirmed the guide contains the new `vite.optimizeDeps` and `build.transpile` guidance.
