### PR TITLE
perf(nuxt): re-parse transformed file once in tree-shake plugin

### DIFF
--- a/packages/nuxt/src/components/plugins/tree-shake.ts
+++ b/packages/nuxt/src/components/plugins/tree-shake.ts
@@ -179,9 +179,9 @@ function removeImportDeclaration (ast: ESTree.Program, importName: string, magic
 }
 
 /**
- * collect the identifiers referenced within the setup function and the ssrRender function
- * ImportDeclarations and VariableDeclarations are ignored
- * a component whose name is not in the returned set is not called anywhere
+ * return the set of identifiers referenced inside the setup function and the ssrRender function.
+ * identifiers inside variable declarations are skipped, so a component's own declaration does not count as a reference.
+ * a component whose name is absent from this set is not used anywhere and can be removed.
  */
 function getSetupReferencedNames (code: string, id: string): Set<string> {
   const names = new Set<string>()

--- a/packages/nuxt/src/components/plugins/tree-shake.ts
+++ b/packages/nuxt/src/components/plugins/tree-shake.ts
@@ -39,12 +39,12 @@ export const TreeShakeTemplatePlugin = (options: TreeShakeTemplatePluginOptions)
           regexpMap.set(components, [new RegExp(`(${clientOnlyComponents.join('|')})`), new RegExp(`^(${clientOnlyComponents.map(c => `(?:(?:_unref\\()?(?:_component_)?(?:Lazy|lazy_)?${c}\\)?)`).join('|')})$`), clientOnlyComponents])
         }
 
-        const s = rolldownString(code, id, meta)
-
         const [COMPONENTS_RE, COMPONENTS_IDENTIFIERS_RE] = regexpMap.get(components)!
         if (!COMPONENTS_RE.test(code)) { return }
 
-        const componentsToRemoveSet = new Set<string>()
+        const s = rolldownString(code, id, meta)
+
+        const candidateNames = new Set<string>()
 
         // remove client only components or components called in ClientOnly default slot
         const { program: ast } = parseAndWalk(code, id, (node) => {
@@ -65,24 +65,28 @@ export const TreeShakeTemplatePlugin = (options: TreeShakeTemplatePluginOptions)
             for (const slot of slotsToRemove) {
               s.remove(slot.start, slot.end + 1)
               const removedCode = `({${code.slice(slot.start, slot.end + 1)}})`
-              const currentState = s.toString()
 
               parseAndWalk(removedCode, id, (node) => {
                 if (!isSsrRender(node)) { return }
                 const name = getComponentName(node)
-                if (!name) { return }
-
-                // detect if the component is called else where
-                const nameToRemove = isComponentNotCalledInSetup(currentState, id, name)
-                if (nameToRemove) {
-                  componentsToRemoveSet.add(nameToRemove)
+                if (name) {
+                  candidateNames.add(name)
                 }
               })
             }
           }
         })
 
-        const componentsToRemove = [...componentsToRemoveSet]
+        // detect which candidates are still called elsewhere with a single re-parse of the transformed code
+        const componentsToRemove: string[] = []
+        if (candidateNames.size) {
+          const referencedNames = getSetupReferencedNames(s.toString(), id)
+          for (const name of candidateNames) {
+            if (!referencedNames.has(name)) {
+              componentsToRemove.push(name)
+            }
+          }
+        }
         const removedNodes = new WeakSet<ESTree.Node>()
 
         for (const componentName of componentsToRemove) {
@@ -175,31 +179,34 @@ function removeImportDeclaration (ast: ESTree.Program, importName: string, magic
 }
 
 /**
- * detect if the component is called else where
+ * collect the identifiers referenced within the setup function and the ssrRender function
  * ImportDeclarations and VariableDeclarations are ignored
- * return the name of the component if is not called
+ * a component whose name is not in the returned set is not called anywhere
  */
-function isComponentNotCalledInSetup (code: string, id: string, name: string): string | void {
-  if (!name) { return }
-  let found = false
+function getSetupReferencedNames (code: string, id: string): Set<string> {
+  const names = new Set<string>()
   parseAndWalk(code, id, function (node) {
     if ((node.type === 'Property' && node.key.type === 'Identifier' && node.value.type === 'FunctionExpression' && node.key.name === 'setup') || (node.type === 'FunctionDeclaration' && (node.id?.name === '_sfc_ssrRender' || node.id?.name === 'ssrRender'))) {
       // walk through the setup function node or the ssrRender function
       walk(node, {
         enter (node) {
-          if (found || node.type === 'VariableDeclaration') {
+          if (node.type === 'VariableDeclaration') {
             this.skip()
-          } else if (node.type === 'Identifier' && node.name === name) {
-            found = true
+          } else if (node.type === 'Identifier') {
+            names.add(node.name)
           } else if (node.type === 'MemberExpression') {
             // dev only with $setup or _ctx
-            found = (node.property.type === 'Literal' && node.property.value === name) || (node.property.type === 'Identifier' && node.property.name === name)
+            if (node.property.type === 'Literal' && typeof node.property.value === 'string') {
+              names.add(node.property.value)
+            } else if (node.property.type === 'Identifier') {
+              names.add(node.property.name)
+            }
           }
         },
       })
     }
   })
-  if (!found) { return name }
+  return names
 }
 
 /**

--- a/packages/nuxt/test/components-tree-shake.test.ts
+++ b/packages/nuxt/test/components-tree-shake.test.ts
@@ -212,4 +212,27 @@ describe('treeshake client only in ssr', () => {
     expect(treeshaken).toContain('resolveComponent("AppIcon")')
     expect(treeshaken).not.toContain('caret-up')
   })
+
+  it('should not treeshake a reused component referenced via member expression', async () => {
+    const treeshaken = await treeshake(`import { resolveComponent as _resolveComponent, withCtx as _withCtx, createVNode as _createVNode } from "vue"
+    import { ssrRenderComponent as _ssrRenderComponent, ssrRenderAttrs as _ssrRenderAttrs } from "vue/server-renderer"
+
+    export function ssrRender(_ctx, _push, _parent, _attrs, $props, $setup, $data, $options) {
+      _push(\`<div\${_ssrRenderAttrs(_attrs)}>\`)
+      _push(_ssrRenderComponent($setup["Reused"], null, null, _parent))
+      _push(_ssrRenderComponent($setup["ClientOnly"], null, {
+        default: _withCtx((_, _push, _parent, _scopeId) => {
+          if (_push) {
+            _push(_ssrRenderComponent($setup["Reused"], null, null, _parent, _scopeId))
+          } else {
+            return [_createVNode($setup["Reused"])]
+          }
+        }),
+        _: 1 /* STABLE */
+      }, _parent))
+      _push(\`</div>\`)
+    }`)
+
+    expect(treeshaken).toContain('$setup["Reused"], null, null, _parent))')
+  })
 })


### PR DESCRIPTION
### 📚 Description

The template tree-shake transform serialised the whole magic string and re-parsed the entire file for every component found in every removed slot (`S` slots x `C` components = `S`x`C` full oxc parses per file). 

Collect candidate names first, then check them against a single parse of the final transformed state. 

Also skip allocating the magic string for files without any client-only component.
