### PR TITLE
perf(nuxt): index scanned components by name to avoid quadratic lookup

### DIFF
--- a/packages/nuxt/src/components/module.ts
+++ b/packages/nuxt/src/components/module.ts
@@ -181,7 +181,7 @@ export default defineNuxtModule<ComponentsOptions>({
     nuxt.hook('app:templates', async (app) => {
       const newComponents = await scanComponents(componentDirs, nuxt.options.srcDir!)
       await nuxt.callHook('components:extend', newComponents)
-      const modesByName = new Map<string, Set<string>>()
+      const modesByName = new Map<string, Set<string | undefined>>()
       for (const component of newComponents) {
         let modes = modesByName.get(component.pascalName)
         if (!modes) {

--- a/packages/nuxt/src/components/module.ts
+++ b/packages/nuxt/src/components/module.ts
@@ -181,13 +181,22 @@ export default defineNuxtModule<ComponentsOptions>({
     nuxt.hook('app:templates', async (app) => {
       const newComponents = await scanComponents(componentDirs, nuxt.options.srcDir!)
       await nuxt.callHook('components:extend', newComponents)
+      const modesByName = new Map<string, Set<string>>()
+      for (const component of newComponents) {
+        let modes = modesByName.get(component.pascalName)
+        if (!modes) {
+          modes = new Set()
+          modesByName.set(component.pascalName, modes)
+        }
+        modes.add(component.mode)
+      }
       // add server placeholder for .client components server side. issue: #7085
       for (const component of newComponents) {
         if (!(component as any /* untyped internal property */)._scanned && !(component.filePath in nuxt.vfs) && isAbsolute(component.filePath) && !existsSync(component.filePath)) {
           // attempt to resolve component path
           component.filePath = resolveModulePath(resolveAlias(component.filePath), { try: true, extensions: nuxt.options.extensions }) ?? component.filePath
         }
-        if (component.mode === 'client' && !newComponents.some(c => c.pascalName === component.pascalName && c.mode === 'server')) {
+        if (component.mode === 'client' && !modesByName.get(component.pascalName)?.has('server')) {
           newComponents.push({
             ...component,
             _raw: true,
@@ -195,8 +204,9 @@ export default defineNuxtModule<ComponentsOptions>({
             filePath: serverPlaceholderPath,
             chunkName: 'components/' + component.kebabName,
           })
+          modesByName.get(component.pascalName)!.add('server')
         }
-        if (component.mode === 'server' && !nuxt.options.ssr && !newComponents.some(other => other.pascalName === component.pascalName && other.mode === 'client')) {
+        if (component.mode === 'server' && !nuxt.options.ssr && !modesByName.get(component.pascalName)?.has('client')) {
           logger.warn(`Using server components with \`ssr: false\` is not supported with auto-detected component islands. If you need to use server component \`${component.pascalName}\`, set \`experimental.componentIslands\` to \`true\`.`)
         }
       }

--- a/packages/nuxt/src/components/scan.ts
+++ b/packages/nuxt/src/components/scan.ts
@@ -24,10 +24,13 @@ export async function scanComponents (dirs: ComponentsDir[], srcDir: string): Pr
   // All scanned components
   const components: Component[] = []
 
+  // Index into `components` by pascal name to avoid a linear scan per file
+  const componentsByName = new Map<string, Array<{ component: Component, index: number }>>()
+
   // Keep resolved path to avoid duplicates
   const filePaths = new Set<string>()
 
-  // All scanned paths
+  // All scanned paths (with trailing slash)
   const scannedPaths: string[] = []
 
   for (const dir of dirs) {
@@ -57,7 +60,7 @@ export async function scanComponents (dirs: ComponentsDir[], srcDir: string): Pr
     for (const _file of files) {
       const filePath = join(dir.path, _file)
 
-      if (scannedPaths.find(d => filePath.startsWith(withTrailingSlash(d))) || isIgnored(filePath)) {
+      if (scannedPaths.some(d => filePath.startsWith(d)) || isIgnored(filePath)) {
         continue
       }
 
@@ -144,15 +147,18 @@ export async function scanComponents (dirs: ComponentsDir[], srcDir: string): Pr
       }
 
       const validModes = new Set(['all', component.mode])
-      const existingComponent = components.find(c => c.pascalName === component.pascalName && validModes.has(c.mode))
+      const existingEntries = componentsByName.get(component.pascalName)
+      const existingEntry = existingEntries?.find(e => validModes.has(e.component.mode))
       // Ignore component if component is already defined (with same mode)
-      if (existingComponent) {
+      if (existingEntry) {
+        const existingComponent = existingEntry.component
         const existingPriority = existingComponent.priority ?? 0
         const newPriority = component.priority ?? 0
 
         // Replace component if priority is higher
         if (newPriority > existingPriority) {
-          components.splice(components.indexOf(existingComponent), 1, component)
+          components[existingEntry.index] = component
+          existingEntry.component = component
         }
         // Warn if a user-defined (or prioritized) component conflicts with a previously scanned component
         if (newPriority > 0 && newPriority === existingPriority) {
@@ -162,9 +168,15 @@ export async function scanComponents (dirs: ComponentsDir[], srcDir: string): Pr
         continue
       }
 
+      const entry = { component, index: components.length }
+      if (existingEntries) {
+        existingEntries.push(entry)
+      } else {
+        componentsByName.set(component.pascalName, [entry])
+      }
       components.push(component)
     }
-    scannedPaths.push(dir.path)
+    scannedPaths.push(withTrailingSlash(dir.path))
   }
 
   return components

--- a/packages/nuxt/src/components/scan.ts
+++ b/packages/nuxt/src/components/scan.ts
@@ -30,7 +30,7 @@ export async function scanComponents (dirs: ComponentsDir[], srcDir: string): Pr
   // Keep resolved path to avoid duplicates
   const filePaths = new Set<string>()
 
-  // All scanned paths (with trailing slash)
+  // All scanned paths
   const scannedPaths: string[] = []
 
   for (const dir of dirs) {
@@ -146,9 +146,8 @@ export async function scanComponents (dirs: ComponentsDir[], srcDir: string): Pr
         continue
       }
 
-      const validModes = new Set(['all', component.mode])
       const existingEntries = componentsByName.get(component.pascalName)
-      const existingEntry = existingEntries?.find(e => validModes.has(e.component.mode))
+      const existingEntry = existingEntries?.find(e => e.component.mode === 'all' || e.component.mode === component.mode)
       // Ignore component if component is already defined (with same mode)
       if (existingEntry) {
         const existingComponent = existingEntry.component


### PR DESCRIPTION
### 📚 Description

`scanComponents` looked up duplicates with `components.find()` plus `indexOf`/`splice` for every scanned file, which is `O(n^2)` in the number of components and re-runs on every watch event in dev. 

Maintain a `Map` keyed by pascal name alongside the result array instead, and precompute trailing-slash scanned paths rather than recomputing them for every file.
