### PR TITLE
feat(nuxt): support reactive keys in `useNuxtData`

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -687,7 +687,7 @@ export function useNuxtData<DataT = any> (key: MaybeRefOrGetter<string>): { data
         }
       })
     }
-  })
+  }, { immediate: true })
 
   return {
     data: computed({

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -1,4 +1,4 @@
-import { computed, getCurrentInstance, getCurrentScope, inject, isRef, isShallow, nextTick, onBeforeMount, onScopeDispose, onServerPrefetch, onUnmounted, queuePostFlushCb, ref, shallowRef, toRef, toValue, unref, watch } from 'vue'
+import { computed, getCurrentInstance, getCurrentScope, inject, isRef, isShallow, nextTick, onBeforeMount, onScopeDispose, onServerPrefetch, onUnmounted, onWatcherCleanup, queuePostFlushCb, ref, shallowRef, toRef, toValue, unref, watch } from 'vue'
 import type { ComputedRef, MaybeRefOrGetter, MultiWatchSources, Ref } from 'vue'
 import { debounce } from 'perfect-debounce'
 import { hash } from 'ohash'
@@ -666,19 +666,20 @@ function _isAutoKeyNeeded (keyOrFetcher: string | MaybeRefOrGetter<string> | (()
 }
 
 /** @since 3.1.0 */
-export function useNuxtData<DataT = any> (key: string): { data: Ref<DataT | undefined> } {
+export function useNuxtData<DataT = any> (key: MaybeRefOrGetter<string>): { data: Ref<DataT | undefined> } {
   const nuxtApp = useNuxtApp()
 
-  // Initialize value when key is not already set
-  if (!(key in nuxtApp.payload.data)) {
-    nuxtApp.payload.data[key] = undefined
-  }
+  watch(() => toValue(key), (keyValue) => { 
+    // Initialize value when key is not already set
+    if (!(keyValue in nuxtApp.payload.data)) {
+      nuxtApp.payload.data[keyValue] = undefined
+    }
 
-  if (nuxtApp._asyncData[key]) {
-    const data = nuxtApp._asyncData[key]
-    data._deps++
-    if (getCurrentScope()) {
-      onScopeDispose(() => {
+    if (nuxtApp._asyncData[keyValue]) {
+      const data = nuxtApp._asyncData[keyValue]
+      data._deps++
+
+      onWatcherCleanup(() => { 
         data._deps--
         // clean up memory when it no longer is needed
         if (data._deps === 0) {
@@ -686,18 +687,20 @@ export function useNuxtData<DataT = any> (key: string): { data: Ref<DataT | unde
         }
       })
     }
-  }
+  })
 
   return {
     data: computed({
       get () {
-        return nuxtApp._asyncData[key]?.data.value ?? nuxtApp.payload.data[key]
+        const keyValue = toValue(key)
+        return nuxtApp._asyncData[keyValue]?.data.value ?? nuxtApp.payload.data[keyValue]
       },
       set (value) {
-        if (nuxtApp._asyncData[key]) {
-          nuxtApp._asyncData[key]!.data.value = value
+        const keyValue = toValue(key)
+        if (nuxtApp._asyncData[keyValue]) {
+          nuxtApp._asyncData[keyValue]!.data.value = value
         } else {
-          nuxtApp.payload.data[key] = value
+          nuxtApp.payload.data[keyValue] = value
         }
       },
     }),

--- a/test/nuxt/use-async-data.test.ts
+++ b/test/nuxt/use-async-data.test.ts
@@ -215,6 +215,51 @@ describe('useAsyncData', () => {
     }
   })
 
+  it('should accept reactive key', async () => {
+    const key = ref(uniqueKey)
+    const { data } = useNuxtData(key)
+    
+    // Set initial data
+    useNuxtApp().payload.data[uniqueKey] = 'initial'
+    expect(data.value).toBe('initial')
+    
+    // Change key
+    key.value = `${uniqueKey}-2`
+    await flushPromises()
+    expect(data.value).toBeUndefined()
+    
+    // Set data for new key
+    useNuxtApp().payload.data[`${uniqueKey}-2`] = 'updated'
+    expect(data.value).toBe('updated')
+    
+    // Change back to original key
+    key.value = uniqueKey
+    await flushPromises()
+    expect(data.value).toBe('initial')
+    
+    clearNuxtData([uniqueKey, `${uniqueKey}-2`])
+  })
+
+  it('should work with useAsyncData and reactive key', async () => {
+    const key = ref(uniqueKey)
+    
+    // Fetch data with initial key
+    const { data: asyncData } = await useAsyncData(key, () => Promise.resolve('async-data'))
+    const { data: nuxtData } = useNuxtData(key)
+    
+    expect(asyncData.value).toBe('async-data')
+    expect(nuxtData.value).toBe('async-data')
+    
+    // Change key
+    const newKey = `${uniqueKey}-new`
+    key.value = newKey
+    await flushPromises()
+    
+    expect(nuxtData.value).toBeUndefined()
+    
+    clearNuxtData([uniqueKey, newKey])
+  })
+
   it('should allow overriding requests', async () => {
     vi.useFakeTimers()
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This pull request enhances the `useNuxtData` composable to support reactive keys, enabling dynamic data binding when the key changes. It also adds comprehensive tests to ensure correct behavior with reactive keys and integration with `useAsyncData`.

**Enhancements to `useNuxtData` for Reactive Keys:**

- `useNuxtData` now accepts a `MaybeRefOrGetter<string>` as the key, allowing the key to be a ref or computed value, not just a static string. The composable watches for key changes and updates the data reference accordingly.
- The implementation uses `watch` and `toValue` to reactively track key changes, ensuring that the correct data is accessed and updated when the key changes.
- Dependency cleanup is improved by using `onWatcherCleanup` (from Vue 3.4+) instead of `onScopeDispose`, ensuring proper memory management when the key changes or the watcher is disposed. 

**Testing Improvements:**

- Added tests to verify `useNuxtData` works correctly with reactive keys, including switching keys and ensuring data is updated or reset as expected.
- Added integration tests to confirm that `useNuxtData` and `useAsyncData` work together seamlessly when using reactive keys.
