### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/docs/1.getting-started/03.configuration.md
+++ b/docs/1.getting-started/03.configuration.md
@@ -30,7 +30,7 @@ You don't have to use TypeScript to build an application with Nuxt. However, it 
 
 ### Environment Overrides
 
-You can configure fully typed, per-environment overrides in your nuxt.config
+You can configure fully typed, per-environment overrides in your `nuxt.config`.
 
 ```ts twoslash [nuxt.config.ts]
 export default defineNuxtConfig({
@@ -50,7 +50,7 @@ export default defineNuxtConfig({
 })
 ```
 
-To select an environment when running a Nuxt CLI command, simply pass the name to the `--envName` flag, like so: `nuxt build --envName staging`.
+To select an environment when running a Nuxt CLI command, pass the name to the `--envName` flag: `nuxt build --envName staging`.
 
 To learn more about the mechanism behind these overrides, please refer to the `c12` documentation on [environment-specific configuration](https://github.com/unjs/c12?tab=readme-ov-file#environment-specific-configuration).
 


### PR DESCRIPTION
Fixes minor grammar issues in the Nuxt configuration documentation:

- Added missing period and backtick formatting to environment overrides sentence
- Removed redundant word 'simply' from CLI flag example

Small doc improvements, no functional changes.