### PR TITLE
perf(nitro): load inline style chunks concurrently

### DIFF
--- a/packages/nitro-server/src/runtime/utils/renderer/inline-styles.ts
+++ b/packages/nitro-server/src/runtime/utils/renderer/inline-styles.ts
@@ -4,8 +4,6 @@ import { getSSRStyles } from './build-files'
 export async function renderInlineStyles (usedModules: Set<string> | string[]): Promise<Style[]> {
   const styleMap = await getSSRStyles()
   const inlinedStyles = new Set<string>()
-  // each entry dynamically imports a style chunk: load them concurrently
-  // (order is preserved by Promise.all so deduplication stays deterministic)
   const promises: Promise<string[]>[] = []
   for (const mod of usedModules) {
     if (mod in styleMap && styleMap[mod]) {

--- a/packages/nitro-server/src/runtime/utils/renderer/inline-styles.ts
+++ b/packages/nitro-server/src/runtime/utils/renderer/inline-styles.ts
@@ -4,11 +4,17 @@ import { getSSRStyles } from './build-files'
 export async function renderInlineStyles (usedModules: Set<string> | string[]): Promise<Style[]> {
   const styleMap = await getSSRStyles()
   const inlinedStyles = new Set<string>()
+  // each entry dynamically imports a style chunk: load them concurrently
+  // (order is preserved by Promise.all so deduplication stays deterministic)
+  const promises: Promise<string[]>[] = []
   for (const mod of usedModules) {
     if (mod in styleMap && styleMap[mod]) {
-      for (const style of await styleMap[mod]()) {
-        inlinedStyles.add(style)
-      }
+      promises.push(styleMap[mod]())
+    }
+  }
+  for (const styles of await Promise.all(promises)) {
+    for (const style of styles) {
+      inlinedStyles.add(style)
     }
   }
   return Array.from(inlinedStyles).map(style => ({ innerHTML: style }))

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -58,7 +58,7 @@ describe.skipIf(isStubbed || process.env.SKIP_BUNDLE_SIZE === 'true' || process.
     const serverDir = join(rootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!_libs'], serverDir, rootDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"70.2k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"70.3k"`)
 
     const modules = await analyzeSizes(['_libs/**/*'], serverDir, rootDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"482k"`)


### PR DESCRIPTION
### 📚 Description

`renderInlineStyles` awaited each style chunk import sequentially, so a page using N modules paid N serial dynamic imports on first render (most visible on serverless cold starts). 

Kick off all imports first and await them together; `Promise.all` preserves input order, so the deduplicated output is unchanged.

### ⚡ Bench

 **Cold start** (real uncached ESM chunk imports — first render, e.g. serverless cold start)                                                                                                                                     
                                                                                                                                                                                                                                    
  | Scenario | Old | New | Delta |                                                                                                                                                                                                  
  |---|---|---|---|                                                                                                                                                                                                                 
  | 4 chunks | 0.44 ms/render | 0.31 ms/render | −31% |                                                                                                                                                                             
  | 16 chunks | 0.98 ms/render | 0.87 ms/render | −11% |                                                                                                                                                                            
  | 48 chunks | 2.55 ms/render | 2.04 ms/render | −20% |                                                                                                                                                                            
                                                                                                                                                                                                                                    
  **Warm** (imports cached — every request after the first)                                                                                                                                                                        
                                                                                                                                                                                                                                    
  | Scenario | Old | New | Delta |                                                                                                                                                                                                  
  |---|---|---|---|                                                                                                                                                                                                                 
  | 4 chunks | 8.0 µs/render | 8.0 µs/render | ±0% |                                                                                                                                                                                
  | 16 chunks | 27.8 µs/render | 26.5 µs/render | −5% |                                                                                                                                                                             
  | 48 chunks | 80.6 µs/render | 78.8 µs/render | −2% |          
