### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/packages/nuxt/src/core/plugins/unctx.ts
+++ b/packages/nuxt/src/core/plugins/unctx.ts
@@ -34,8 +34,12 @@ export const UnctxTransformPlugin = (options: UnctxTransformPluginOptions) => cr
         if (!transformer.shouldTransform(code)) { return }
         const result = transformer.transform(code)
         if (result) {
+          // prepend the marker through the MagicString instance (rather than
+          // string-concatenating it onto `result.code`) so the sourcemap generated
+          // below accounts for the extra line it introduces
+          result.magicString.prepend(TRANSFORM_MARKER)
           return {
-            code: TRANSFORM_MARKER + result.code,
+            code: result.magicString.toString(),
             map: options.sourcemap
               ? result.magicString.generateMap({ hires: true })
               : undefined,

--- a/packages/nuxt/test/unctx-transform.test.ts
+++ b/packages/nuxt/test/unctx-transform.test.ts
@@ -50,7 +50,89 @@ describe('unctx transform in nuxt', () => {
       })"
     `)
   })
+
+  it('should generate a sourcemap that accounts for the prepended transform marker line', async () => {
+    // regression test for https://github.com/nuxt/nuxt/issues/35479: the marker
+    // used to be string-concatenated onto `result.code` *after* the sourcemap had
+    // already been generated from `result.magicString`, so every mapping was off
+    // by (at least) the single line the marker itself adds.
+    const code = [
+      'export default defineNuxtRouteMiddleware(async (to, from) => {',
+      '  await Promise.resolve()',
+      '  return',
+      '})',
+      '',
+    ].join('\n')
+
+    const { code: transformedCode, map } = await transformWithSourcemap(code)
+    const sourceLines = code.split('\n')
+    const generatedLines = transformedCode.split('\n')
+
+    const generatedLineIndex = generatedLines.findIndex(line => line.includes('Promise.resolve()'))
+    const originalLineIndex = sourceLines.findIndex(line => line.includes('Promise.resolve()'))
+    expect(generatedLineIndex).toBeGreaterThanOrEqual(0)
+    expect(originalLineIndex).toBeGreaterThanOrEqual(0)
+
+    const mappedLineIndex = findMappedOriginalLine(map!.mappings, generatedLineIndex)
+    expect(mappedLineIndex).not.toBeNull()
+    expect(sourceLines[mappedLineIndex!]).toContain('Promise.resolve()')
+  })
 })
+
+function transformWithSourcemap (code: string) {
+  const transformerOptions = {
+    helperModule: 'unctx',
+    asyncFunctions: ['defineNuxtPlugin', 'defineNuxtRouteMiddleware'],
+    objectDefinitions: {
+      defineNuxtComponent: ['asyncData', 'setup'],
+      defineNuxtPlugin: ['setup'],
+      definePageMeta: ['middleware', 'validate'],
+    },
+  }
+  const plugin = UnctxTransformPlugin({ sourcemap: true, transformerOptions }).raw({}, {} as any) as any
+  return Promise.resolve(plugin.transform.handler(code)) as Promise<{ code: string, map: { mappings: string } }>
+}
+
+// Decodes a sourcemap `mappings` string just enough to answer: "which original
+// line does a given (0-indexed) generated line's first segment map to?". Source
+// line deltas are relative and accumulate across *every* segment in the whole
+// mappings string (not reset per generated line), so we must walk all of them
+// in order to keep the running total in sync, even though we only report the
+// value as of the first segment on the line we care about.
+function findMappedOriginalLine (mappings: string, generatedLine: number): number | null {
+  const base64Chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+  let sourceLine = 0
+  for (const [lineIndex, line] of mappings.split(';').entries()) {
+    if (!line) { continue }
+    let firstSegmentSourceLine: number | null = null
+    for (const segment of line.split(',')) {
+      if (!segment) { continue }
+      const fields: number[] = []
+      let value = 0
+      let shift = 0
+      for (const char of segment) {
+        const digit = base64Chars.indexOf(char)
+        value += (digit & 31) << shift
+        if (digit & 32) {
+          shift += 5
+        } else {
+          fields.push(value & 1 ? -(value >> 1) : value >> 1)
+          value = 0
+          shift = 0
+        }
+      }
+      // segment fields are [generatedColumn, sourceIndex, sourceLine, sourceColumn, ...]
+      if (fields.length >= 3) {
+        sourceLine += fields[2]!
+        firstSegmentSourceLine ??= sourceLine
+      }
+    }
+    if (lineIndex === generatedLine) {
+      return firstSegmentSourceLine
+    }
+  }
+  return null
+}
 
 function transform (code: string, id = 'app.vue') {
   const transformerOptions = {


### PR DESCRIPTION
## What

Fixes #35479.

Sourcemaps for files processed by the unctx transform (any `defineNuxtPlugin`/`defineNuxtRouteMiddleware`/etc. with `await`) were shifted, causing devtools breakpoints and step-through to resolve to the wrong source line.

## Why

In `UnctxTransformPlugin` (`packages/nuxt/src/core/plugins/unctx.ts`):

```js
return {
  code: TRANSFORM_MARKER + result.code,
  map: options.sourcemap
    ? result.magicString.generateMap({ hires: true })
    : undefined,
}
```

`TRANSFORM_MARKER` (`/* _processed_nuxt_unctx_transform */\n`) is string-concatenated onto `result.code`, adding one physical line to the emitted output. But the sourcemap is generated from `result.magicString`, which never had the marker applied to it — so the map doesn't know about that extra line, and every mapping ends up off by (at least) one line.

## Fix

Prepend the marker through `MagicString.prepend()` instead, so the map is generated from a `MagicString` instance that already reflects the extra line:

```js
result.magicString.prepend(TRANSFORM_MARKER)
return {
  code: result.magicString.toString(),
  map: options.sourcemap
    ? result.magicString.generateMap({ hires: true })
    : undefined,
}
```

## Testing

Added a regression test that runs the transform with `sourcemap: true`, decodes the resulting `mappings` VLQ string, and checks that the generated line containing the transformed `Promise.resolve()` call still maps back to the original source line containing `Promise.resolve()`.

Confirmed the new test fails on the original code (mapping resolves to the wrong line, e.g. `return` instead of `await Promise.resolve()`) and passes with the fix. Ran the full `pnpm test:unit` suite locally (1064 passed) and `eslint` on the changed files — all clean.