### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/packages/vite/src/plugins/vue-jsx.ts
+++ b/packages/vite/src/plugins/vue-jsx.ts
@@ -46,7 +46,10 @@ export function VueJsxPlugin (nuxt: Nuxt, options?: Options): Plugin[] {
     }
 
     const { default: viteJsxPlugin } = await import('@vitejs/plugin-vue-jsx')
-    resolvedPlugin = viteJsxPlugin(options)
+    resolvedPlugin = viteJsxPlugin({
+      defineComponentName: ['defineComponent', 'defineNuxtComponent'],
+      ...options,
+    })
 
     // Replay configResolved so the real plugin captures HMR/sourcemap state
     if (resolvedConfig && typeof resolvedPlugin.configResolved === 'function') {


### PR DESCRIPTION
## Description

Adds `defineNuxtComponent` to the default `defineComponentName` list in the Vue JSX plugin wrapper. This ensures that `.tsx` pages using `defineNuxtComponent` receive HMR infrastructure (`__hmrId` and `import.meta.hot.accept()`) injected by `@vitejs/plugin-vue-jsx`.

## Problem

When using `.tsx` pages with `defineNuxtComponent`, HMR does not work because `@vitejs/plugin-vue-jsx` only recognizes `defineComponent` as a component definition. The plugin uses `defineComponentName` to determine which function calls should receive HMR support, and `defineNuxtComponent` was not included in the default list.

## Fix

Updated `packages/vite/src/plugins/vue-jsx.ts` to include `'defineNuxtComponent'` in the default `defineComponentName` array. User-provided options still take precedence via the spread operator.

## Reproduction

StackBlitz: https://stackblitz.com/edit/github-qnkavbga

1. Create a `.tsx` page using `defineNuxtComponent`
2. Run `nuxt dev`
3. Edit the file — browser requires full reload instead of hot-updating

Fixes #35465