### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/docs/1.getting-started/17.testing.md
+++ b/docs/1.getting-started/17.testing.md
@@ -161,10 +161,12 @@ You can of course opt for any test structure, but keeping the Nuxt runtime envir
 
 #### TypeScript Support in Tests
 
-By default, test files in `test/nuxt/` and `tests/nuxt/` directories are included in the [Nuxt app TypeScript context](/docs/4.x/guide/concepts/typescript#how-nuxt-uses-project-references). That means they will recognise Nuxt aliases (like `~/`, `@/`, `#imports`) and TypeScript will be aware of auto-imports that work in your Nuxt app.
+By default, only test files in `test/nuxt/` and `tests/nuxt/` directories are included in the [Nuxt app TypeScript context](/docs/4.x/guide/concepts/typescript#how-nuxt-uses-project-references). That means they will recognise Nuxt aliases (like `~/`, `@/`, `#imports`) and TypeScript will be aware of auto-imports that work in your Nuxt app.
+
+Test files in other directories (e.g., `tests/utils.test.ts`, `test/unit/helpers.spec.ts`) are **not** included in the Nuxt app TypeScript context by default. This is intentional — most unit tests should not depend on Nuxt runtime features like auto-imports or composables.
 
 ::tip
-This matches the recommended structure where only tests that need the Nuxt runtime environment are placed in these directories. Unit tests in other directories like `test/unit/` can be added manually if needed.
+If your tests use Nuxt-specific features (aliases, auto-imports, composables), place them in `test/nuxt/` or `tests/nuxt/`. For plain unit tests that don't need the Nuxt runtime, they can live anywhere but won't have Nuxt type support automatically.
 ::
 
 ##### Adding other test directories

--- a/docs/4.api/6.nuxt-config.md
+++ b/docs/4.api/6.nuxt-config.md
@@ -1556,6 +1556,20 @@ TypeScript comes with certain checks to give you more safety and analysis of you
 
 You can extend the generated `.nuxt/tsconfig.app.json` TypeScript configuration using this option.
 
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  typescript: {
+    tsConfig: {
+      include: [
+        // Include test files outside test[s]/nuxt/ in typechecking
+        '../tests/unit/**/*',
+        '../tests/e2e/**/*',
+      ],
+    },
+  },
+})
+```
+
 **See**: [tsconfig.json information](/docs/4.x/directory-structure/tsconfig)
 
 ### `typeCheck`


### PR DESCRIPTION
## Description

Improves documentation to clearly explain that only `test/nuxt/` and `tests/nuxt/` directories are included in the Nuxt app TypeScript context by default.

## Changes

### `docs/1.getting-started/17.testing.md`
- Clarified that test files outside `test[s]/nuxt/` are **not** automatically included
- Added explanation of when to use each directory structure
- Updated the tip to be more explicit about the design decision

### `docs/4.api/6.nuxt-config.md`
- Added concrete code example for `typescript.tsConfig` showing how to include custom test directories

## Why

Users were confused about why their test files in `tests/` (outside `tests/nuxt/`) weren't getting Nuxt type support (aliases, auto-imports). The maintainer confirmed this is intentional and a documentation issue — the docs should explain the expected workflow.

Fixes #34756