### PR TITLE
fix(kit): `noUncheckedSideEffectImports` (v5) + disable `libReplacement`

### DIFF
--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -63,6 +63,7 @@ When you set your `future.compatibilityVersion` to `5`, defaults throughout your
 - **`clearNuxtState` resets to defaults**: `clearNuxtState` will [reset state to its initial value](/docs/4.x/getting-started/upgrade#respect-defaults-when-clearing-usestate) instead of setting it to `undefined`
 - **Non-async `callHook`**: [`callHook` may return `void`](/docs/4.x/getting-started/upgrade#non-async-callhook) instead of always returning a `Promise`
 - **Comment node placeholders**: Client-only components use [comment nodes instead of `<div>`](/docs/4.x/getting-started/upgrade#client-only-comment-placeholders) as SSR placeholders, fixing a scoped styles hydration issue
+- **Stricter side-effect imports**: The generated `tsconfig.json` enables [`noUncheckedSideEffectImports`](/docs/4.x/getting-started/upgrade#stricter-side-effect-imports) to match the TypeScript 7 default
 - Other Nuxt 5 improvements and changes as they become available
 
 ::note
@@ -524,3 +525,41 @@ export default defineNuxtConfig({
   },
 })
 ```
+
+### Stricter Side-Effect Imports
+
+🚦 **Impact Level**: Minimal
+
+#### What Changed
+
+With `compatibilityVersion: 5`, Nuxt's generated `tsconfig.json` enables [`noUncheckedSideEffectImports`](https://www.typescriptlang.org/tsconfig/#noUncheckedSideEffectImports). This is a default in TypeScript 7, so adopting it early keeps your project aligned ahead of that upgrade.
+
+With this option on, a side-effect-only import (`import './setup'`) that TypeScript cannot resolve to a module is now a type error, whereas it was previously ignored. This only affects type-checking (`nuxt typecheck` and your editor), not runtime behavior.
+
+#### Reasons for Change
+
+Unresolved side-effect imports were silently ignored, so a typo or a deleted file could pass type-checking. Flagging them catches these mistakes and matches the TypeScript 7 default.
+
+#### Migration Steps
+
+If type-checking now errors on a side-effect import of a non-code asset (for example `import '~/assets/styles.css'`), add an ambient module declaration so TypeScript knows the import is valid:
+
+```ts [types.d.ts]
+declare module '*.css' {}
+```
+
+::tip
+You can revert to the previous behavior by disabling the option in your `nuxt.config`:
+
+```ts twoslash [nuxt.config.ts]
+export default defineNuxtConfig({
+  typescript: {
+    tsConfig: {
+      compilerOptions: {
+        noUncheckedSideEffectImports: false,
+      },
+    },
+  },
+})
+```
+::

--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -551,6 +551,8 @@ declare module '*.css' {}
 ::tip
 You can revert to the previous behavior by disabling the option in your `nuxt.config`:
 
+<!-- @case-police-ignore tsConfig -->
+
 ```ts twoslash [nuxt.config.ts]
 export default defineNuxtConfig({
   typescript: {

--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -367,6 +367,8 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
 
   const useDecorators = Boolean(nuxt.options.experimental?.decorators)
 
+  const isV5OrHigher = (nuxt.options.future?.compatibilityVersion ?? 4) >= 5
+
   const userExclude = nuxt.options.typescript?.tsConfig?.exclude ?? []
 
   // https://www.totaltypescript.com/tsconfig-cheat-sheet
@@ -388,6 +390,11 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
       noUncheckedIndexedAccess: true,
       forceConsistentCasingInFileNames: true,
       noImplicitOverride: true,
+      ...isV5OrHigher
+        ? {
+            noUncheckedSideEffectImports: true,
+          }
+        : {},
       /* Decorator support */
       ...useDecorators
         ? {
@@ -405,6 +412,7 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
         'dom.iterable',
         'webworker',
       ],
+      libReplacement: false,
       /* JSX support for Vue */
       jsx: 'preserve',
       jsxImportSource: 'vue',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,6 +27,7 @@
       "dom",
       "dom.iterable"
     ],
+    "libReplacement": false,
     "paths": {
       "#app": [
         "./packages/nuxt/src/app/index"


### PR DESCRIPTION
### 📚 Description

these are upcoming defaults for ts v7.

- `libReplacement` is safe - purely performance - and worth enabling for everyone
- `noUncheckedSideEffectImports` is stricter and better but it _might_ break someone's project so this is gated behind `compatibilityVersion`