### PR TITLE
test: force disable `test` mode for bundle size tests

### DIFF
--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -23,7 +23,7 @@ describe.skipIf(isStubbed || process.env.SKIP_BUNDLE_SIZE === 'true' || process.
   it('default client bundle size', async () => {
     const clientStats = await analyzeSizes(['**/*.js'], join(rootDir, '.output/public'), rootDir)
 
-    expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"119k"`)
+    expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"118k"`)
 
     const files = clientStats!.files.map(f => f.replace(/\..*\.js/, '.js'))
 
@@ -58,7 +58,7 @@ describe.skipIf(isStubbed || process.env.SKIP_BUNDLE_SIZE === 'true' || process.
     const serverDir = join(rootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!_libs'], serverDir, rootDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"70.3k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"69.0k"`)
 
     const modules = await analyzeSizes(['_libs/**/*'], serverDir, rootDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"499k"`)
@@ -92,7 +92,7 @@ describe.skipIf(isStubbed || process.env.SKIP_BUNDLE_SIZE === 'true' || process.
     const serverDir = join(pagesRootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!_libs'], serverDir, pagesRootDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"172k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"171k"`)
 
     const modules = await analyzeSizes(['_libs/**/*'], serverDir, pagesRootDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"500k"`)

--- a/test/fixtures/minimal-pages/nuxt.config.ts
+++ b/test/fixtures/minimal-pages/nuxt.config.ts
@@ -25,5 +25,6 @@ export default defineNuxtConfig({
   typescript: {
     typeCheck: isStubbed ? false : 'build',
   },
+  // eslint-disable-next-line nuxt/no-nuxt-config-test-key
   test: false,
 })

--- a/test/fixtures/minimal-pages/nuxt.config.ts
+++ b/test/fixtures/minimal-pages/nuxt.config.ts
@@ -25,4 +25,5 @@ export default defineNuxtConfig({
   typescript: {
     typeCheck: isStubbed ? false : 'build',
   },
+  test: false,
 })

--- a/test/fixtures/minimal/nuxt.config.ts
+++ b/test/fixtures/minimal/nuxt.config.ts
@@ -26,5 +26,6 @@ export default defineNuxtConfig({
   typescript: {
     typeCheck: isStubbed ? false : 'build',
   },
+  // eslint-disable-next-line nuxt/no-nuxt-config-test-key
   test: false,
 })

--- a/test/fixtures/minimal/nuxt.config.ts
+++ b/test/fixtures/minimal/nuxt.config.ts
@@ -26,4 +26,5 @@ export default defineNuxtConfig({
   typescript: {
     typeCheck: isStubbed ? false : 'build',
   },
+  test: false,
 })


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/pull/35429/changes#r3572024111

### 📚 Description

this splits out an improvement from https://github.com/nuxt/nuxt/pull/35429, making sure we disable test mode when measuring nuxt bundle size