### PR TITLE
fix(nuxt): keep explicit route name when reusing a file via pages:extend 🤖🤖🤖

### DIFF
--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -163,6 +163,13 @@ export async function augmentPages (routes: NuxtPage[], vfs: Record<string, stri
     if (route.file && !ctx.pagesToSkip?.has(route.file)) {
       const fileContent = vfs[route.file] ?? fs.readFileSync(ctx.fullyResolvedPaths?.has(route.file) ? route.file : await resolvePath(route.file), 'utf-8')
       const routeMeta = getRouteMeta(fileContent, route.file, ctx.extraExtractionKeys)
+      // A route that reuses a file already claimed by an earlier route (e.g. an extra
+      // route pushed via `pages:extend`) keeps its own explicit identity; the file's
+      // `definePageMeta` name/path belong to the owner route, not to borrowers.
+      if (ctx.augmentedPages.has(route.file)) {
+        delete routeMeta.name
+        delete routeMeta.path
+      }
       if (route.meta) {
         routeMeta.meta = defu({}, routeMeta.meta, route.meta)
       }
@@ -372,6 +379,8 @@ function normalizeComponentWithName (page: NuxtPage, isSyncImport: boolean | und
 
 export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = new Set(), options: NormalizeRoutesOptions): { imports: Set<string>, routes: string } {
   const nuxt = useNuxt()
+  // Files claimed by an earlier route at this level; later routes reusing them are borrowers.
+  const claimedFiles = new Set<string>()
   return {
     imports: metaImports,
     routes: genArrayFromRaw(routes.map((page) => {
@@ -412,6 +421,8 @@ export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = 
       }
 
       const file = normalize(page.file)
+      const isBorrowedFile = claimedFiles.has(file)
+      claimedFiles.add(file)
       const pageImportName = genSafeVariableName(filename(file) + hash(file).replace(/-/g, '_'))
       const metaImportName = pageImportName + 'Meta'
       metaImports.add(genImport(`${file}?macro=true`, [{ name: 'default', as: metaImportName }]))
@@ -422,7 +433,11 @@ export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = 
 
       const isSyncImport = page._sync && page.mode !== 'client'
       const pageImport = isSyncImport ? pageImportName : genDynamicImport(file)
-      const metaRouteName = `${metaImportName}?.name ?? ${route.name}`
+      // A borrowed file's `definePageMeta` name belongs to the route that owns the file, so a
+      // route reusing it (e.g. pushed via `pages:extend`) keeps its own explicit name instead.
+      const metaRouteName = isBorrowedFile && route.name
+        ? route.name
+        : `${metaImportName}?.name ?? ${route.name}`
 
       // we use this to validate that a server page is rendering the correct url
       const islandKey = page.mode === 'server' && page.file
@@ -451,7 +466,7 @@ export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = 
 
       const metaRoute: NormalizedRoute = {
         name: metaRouteName,
-        path: `${metaImportName}?.path ?? ${route.path}`,
+        path: isBorrowedFile && route.path ? route.path : `${metaImportName}?.path ?? ${route.path}`,
         props: `${metaImportName}?.props ?? ${route.props ?? false}`,
         meta: `${metaImportName} || {}`,
         alias: `${metaImportName}?.alias || []`,

--- a/packages/nuxt/test/pages.test.ts
+++ b/packages/nuxt/test/pages.test.ts
@@ -464,6 +464,38 @@ describe('page:extends', () => {
       },
     ])
   })
+
+  it('should not override an explicit name when a route reuses another route\'s file (#27358)', async () => {
+    const files: NuxtPage[] = [
+      { name: 'test', path: '/test', file: `pages/test.vue` },
+      { name: 'testExtend', path: '/testExtend', file: `pages/test.vue` },
+    ]
+    const vfs = {
+      'pages/test.vue': `<script setup lang="ts">definePageMeta({ name: 'test' })</script>`,
+    } as Record<string, string>
+    await augmentPages(files, vfs)
+    expect(files[1]!.name).toBe('testExtend')
+    expect(files[1]!.path).toBe('/testExtend')
+  })
+
+  it('should generate the explicit name for a route reusing another route\'s file (#27358)', () => {
+    const pages: NuxtPage[] = [
+      { name: 'test', path: '/test', file: `pages/test.vue` },
+      { name: 'testExtend', path: '/testExtend', file: `pages/test.vue` },
+    ]
+    const { routes } = normalizeRoutes(pages, new Set(), {
+      clientComponentRuntime: '<client>',
+      serverComponentRuntime: '<server>',
+      overrideMeta: false,
+    })
+    const owner: any = (routes as any)[0]
+    const borrower: any = (routes as any)[1]
+    // the file owner keeps the runtime `definePageMeta` name override
+    expect(owner.name).toContain('Meta?.name ??')
+    // the borrowing route uses its own explicit name, not the file's meta name
+    expect(borrower.name).not.toContain('Meta?.name')
+    expect(borrower.name).toContain('testExtend')
+  })
 })
 
 const pagesDir = 'pages'


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #27358

### 📚 Description

Pushing an extra route through `pages:extend` whose `file` reuses another page produced two routes with the **same name**: the file's `definePageMeta({ name })` overrode the explicitly-provided route name. The two routes then collided on their vue-router name, so the original scanned route became unreachable and disappeared from devtools.

A file's `definePageMeta` identity should belong to the route that owns the file. A later route reusing the same file now keeps its own explicit `name`/`path`.

I reproduced this on `main` against all three `experimental.scanPageMeta` values. The bug hit two of them through two different code paths, so both are addressed:

- **`'after-resolve'` (default) & `true`** — `augmentPages` merged the file's meta over the reusing route's explicit name (`Object.assign(route, routeMeta)`). It now drops `name`/`path` from the merged meta when the file was already claimed by an earlier route.
- **`false`** — the generated router config emitted `…Meta?.name ?? name`, so the file's runtime meta name won. Borrowing routes now emit their own explicit `name`/`path`, while the owner route keeps the `definePageMeta` override — so `definePageMeta({ name })` still overrides the filename-derived name for normal pages.

Minimal repro:

```ts
// pages/test.vue -> definePageMeta({ name: 'test' })
// nuxt.config.ts
hooks: {
  'pages:extend' (pages) {
    pages.push({ name: 'testExtend', path: '/testExtend', file: '~/pages/test.vue' })
  },
}
// before: both routes are named "test" -> /test is lost
// after:  "test" and "testExtend" coexist
```

### ✅ Tests

Added two unit tests in `packages/nuxt/test/pages.test.ts` covering both the augmentation path and the generated router config. `pnpm vitest run --project unit` passes (1067 tests).

---

Drafted with AI assistance (opting into the agent fast-track per `CONTRIBUTING.md`). I've reviewed every line and can walk through the reasoning.
