### PR TITLE
fix(nuxt): pass nuxt `rootDir` to typed-router context

### DIFF
--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -247,8 +247,6 @@ export default defineNuxtModule({
       const declarationFile = resolve(nuxt.options.buildDir, 'types/typed-router.d.ts')
 
       const typedRouterOptions: TypedRouterOptions = {
-        // Keys in the generated DTS must be relative to rootDir (matching the
-        // sfc-typed-router Volar plugin), not the default process.cwd().
         root: nuxt.options.rootDir,
         routesFolder: [],
         dts: declarationFile,

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -247,6 +247,9 @@ export default defineNuxtModule({
       const declarationFile = resolve(nuxt.options.buildDir, 'types/typed-router.d.ts')
 
       const typedRouterOptions: TypedRouterOptions = {
+        // Keys in the generated DTS must be relative to rootDir (matching the
+        // sfc-typed-router Volar plugin), not the default process.cwd().
+        root: nuxt.options.rootDir,
         routesFolder: [],
         dts: declarationFile,
         logs: nuxt.options.debug && nuxt.options.debug.router,

--- a/test/typed-router.test.ts
+++ b/test/typed-router.test.ts
@@ -16,4 +16,29 @@ describe('typed router integration', () => {
     // Ensure params are not duplicated
     expect(typedRouterDts).not.toMatch(/\{\s*id:\s*ParamValue<\w+>,\s*id:\s*ParamValue<\w+>\s*\}/)
   })
+
+  // The keys in `_RouteFileInfoMap` are consumed by the `sfc-typed-router` Volar
+  // plugin, which resolves each SFC via `relative(rootDir, file)`. If they are
+  // generated relative to `process.cwd()` instead, they only match when
+  // `process.cwd() === rootDir`; otherwise `useRoute()` in a page silently falls
+  // back to `keyof RouteNamedMap`.
+  describe('generates _RouteFileInfoMap keys relative to rootDir, not process.cwd()', () => {
+    const readTypedRouterDts = () => readFileSync(resolve(rootDir, '.nuxt/types/typed-router.d.ts'), 'utf8')
+
+    it('when prepared from a different cwd (nuxt prepare <rootDir>)', async () => {
+      await x('nuxt', ['prepare', rootDir])
+      const dts = readTypedRouterDts()
+      // rootDir-relative key present
+      expect(dts).toMatch(/'app\/pages\/page\.vue':/)
+      // never cwd-relative (the regression prefixed keys with the fixture path)
+      expect(dts).not.toMatch(/'[^']*fixtures\/basic-types\/[^']*\.vue':/)
+    })
+
+    it('when prepared with cwd === rootDir', async () => {
+      await x('nuxt', ['prepare'], { nodeOptions: { cwd: rootDir } })
+      const dts = readTypedRouterDts()
+      expect(dts).toMatch(/'app\/pages\/page\.vue':/)
+      expect(dts).not.toMatch(/'[^']*fixtures\/basic-types\/[^']*\.vue':/)
+    })
+  })
 })


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #35564

### 📚 Description

With `experimental.typedPages`, the `sfc-typed-router` Volar plugin rewrites a bare `useRoute()` in a page to infer that page's route name. This breaks when Nuxt is prepared with `process.cwd()` different from `nuxt.options.rootDir` (e.g. `nuxt prepare --cwd <subdir>` from a parent directory, common in monorepos): `useRoute().name` falls back to the full `keyof RouteNamedMap` union.

**Root cause:** `packages/nuxt/src/pages/module.ts` builds the typed-router context without a `root`, so `resolveOptions` (from `vue-router/unplugin`) defaults it to `process.cwd()`. The generated `_RouteFileInfoMap` keys are then `process.cwd()`-relative, while the Volar plugin resolves files via `relative(nuxt.options.rootDir, file)`. When the two differ, no key matches.

**Fix:** pass `root: nuxt.options.rootDir` into `typedRouterOptions`, so the DTS keys and the plugin both use `rootDir` regardless of `process.cwd()`.

Minimal standalone reproduction with 3 demos (same-dir ✅, subdir ❌, subdir + this patch ✅): https://github.com/Anoesj/nuxt-typedpages-cwd-rootdir-bug

### 🧪 Regression test

`test/typed-router.test.ts` gains two cases asserting the `_RouteFileInfoMap` keys are `rootDir`-relative:

- **prepared from a different cwd** (`nuxt prepare <rootDir>`) — the case that regressed (red before this fix, green after)
- **prepared with `cwd === rootDir`** — control (green either way)

cc @posva: this touches the `sfc-typed-router` typed-router integration you authored. Feedback welcome.
