### PR TITLE
ci: use vite-plus to manage pnpm

### DIFF
--- a/.github/workflows/autofix-docs.yml
+++ b/.github/workflows/autofix-docs.yml
@@ -24,12 +24,12 @@ jobs:
           cache: true
 
       - name: Build Nuxt
-        run: pnpm build
+        run: vp run build
 
       - name: Lint (docs)
-        run: pnpm lint:docs:fix
+        run: vp run lint:docs:fix
 
       - name: Typecheck (docs)
-        run: pnpm typecheck:docs
+        run: vp run typecheck:docs
 
       - uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a # v1.3.4

--- a/.github/workflows/autofix-docs.yml
+++ b/.github/workflows/autofix-docs.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: voidzero-dev/setup-vp@10c4be84517f21333b81092e67a344be1b09a202 # v1.15.0
+      - uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1.15.0
         with:
           node-version: lts
           cache: true

--- a/.github/workflows/autofix-docs.yml
+++ b/.github/workflows/autofix-docs.yml
@@ -18,14 +18,10 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: voidzero-dev/setup-vp@10c4be84517f21333b81092e67a344be1b09a202 # v1.15.0
         with:
-          node-version: lts/*
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install
+          node-version: lts
+          cache: true
 
       - name: Build Nuxt
         run: pnpm build

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -27,36 +27,36 @@ jobs:
           cache: true
 
       - name: Check engine ranges, peer dependency ranges and installed versions
-        run: pnpm test:engines:fix
+        run: vp run test:engines:fix
         continue-on-error: true
 
       - name: Build (stub)
-        run: pnpm dev:prepare
+        run: vp run dev:prepare
 
       - name: Test (nuxt runtime)
-        run: pnpm test:runtime -u
+        run: vp run test:runtime -u
 
       - name: Test (unit)
-        run: pnpm test:unit -u
+        run: vp run test:unit -u
 
       - name: Lint (code)
-        run: pnpm lint:fix
+        run: vp run lint:fix
 
       - name: Build
-        run: pnpm build
+        run: vp run build
 
       - name: Assert bundle size (renovate)
         if: ${{ contains(github.head_ref, 'renovate') }}
-        run: pnpm vitest run bundle
+        run: vp exec vitest run bundle
 
       - name: Update bundle size (renovate)
         if: failure()
         run: |
-          pnpm vitest run bundle -u
-          pnpm dedupe
+          vp exec vitest run bundle -u
+          vp dedupe
 
       - name: Update bundle size
         if: ${{ !contains(github.head_ref, 'renovate') }}
-        run: pnpm vitest run bundle -u
+        run: vp exec vitest run bundle -u
 
       - uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a # v1.3.4

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: voidzero-dev/setup-vp@10c4be84517f21333b81092e67a344be1b09a202 # v1.15.0
+      - uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1.15.0
         with:
           node-version: lts
           cache: true

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -21,14 +21,10 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: voidzero-dev/setup-vp@10c4be84517f21333b81092e67a344be1b09a202 # v1.15.0
         with:
-          node-version: lts/*
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install
+          node-version: lts
+          cache: true
 
       - name: Check engine ranges, peer dependency ranges and installed versions
         run: pnpm test:engines:fix

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -27,14 +27,10 @@ jobs:
         # zizmor: ignore[artipacked] scripts/update-changelog.ts runs `git push` and requires the persisted token
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: voidzero-dev/setup-vp@10c4be84517f21333b81092e67a344be1b09a202 # v1.15.0
         with:
-          node-version: current
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install
+          node-version: latest
+          cache: true
 
       - run: node ./scripts/update-changelog.ts
         env:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -27,7 +27,7 @@ jobs:
         # zizmor: ignore[artipacked] scripts/update-changelog.ts runs `git push` and requires the persisted token
         with:
           fetch-depth: 0
-      - uses: voidzero-dev/setup-vp@10c4be84517f21333b81092e67a344be1b09a202 # v1.15.0
+      - uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1.15.0
         with:
           node-version: latest
           cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,13 +87,13 @@ jobs:
           cache: true
 
       - name: Build (stub)
-        run: pnpm dev:prepare
+        run: vp run dev:prepare
 
       - name: Typecheck
-        run: pnpm typecheck
+        run: vp run typecheck
 
       - name: Build
-        run: pnpm build
+        run: vp run build
 
       - name: Cache dist
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -183,12 +183,12 @@ jobs:
           path: packages
 
       - name: Test (types)
-        run: pnpm test:types
+        run: vp run test:types
         env:
           MODULE_RESOLUTION: ${{ matrix.module }}
 
       - name: Typecheck (docs)
-        run: pnpm typecheck:docs
+        run: vp run typecheck:docs
 
       - name: Cancel workflow on failure
         if: failure() && github.event_name == 'merge_group'
@@ -216,19 +216,19 @@ jobs:
           cache: true
 
       - name: Build (stub)
-        run: pnpm dev:prepare
+        run: vp run dev:prepare
 
       - name: Lint
-        run: pnpm lint
+        run: vp run lint
 
       - name: Test (nuxt runtime)
-        run: pnpm test:runtime
+        run: vp run test:runtime
 
       - name: Test (unit)
-        run: pnpm test:unit
+        run: vp run test:unit
 
       - name: Check built types
-        run: pnpm test:attw
+        run: vp run test:attw
 
       - name: Cancel workflow on failure
         if: failure() && github.event_name == 'merge_group'
@@ -262,7 +262,7 @@ jobs:
           path: packages
 
       - name: Check bundle size
-        run: pnpm vitest run bundle
+        run: vp exec vitest run bundle
 
       - name: Cancel workflow on failure
         if: failure() && github.event_name == 'merge_group'
@@ -292,12 +292,12 @@ jobs:
           path: packages
 
       - name: Prepare test fixtures
-        run: pnpm test:prepare
+        run: vp run test:prepare
 
       - name: Run benchmarks
         uses: CodSpeedHQ/action@f99becdce5e5d51fd556489ebef684f4ecfd6286 # v4.18.5
         with:
-          run: pnpm vitest bench
+          run: vp exec vitest bench
           token: ${{ secrets.CODSPEED_TOKEN }}
           mode: simulation
 
@@ -338,7 +338,7 @@ jobs:
           cache: true
 
       - name: Install Playwright
-        run: pnpm playwright-core install chromium
+        run: vp exec playwright-core install chromium
 
       - name: Restore dist cache
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -347,10 +347,10 @@ jobs:
           path: packages
 
       - name: Prepare test fixtures
-        run: pnpm test:prepare
+        run: vp run test:prepare
 
       - name: Test (fixtures)
-        run: pnpm vitest run ${{ matrix.projects }}
+        run: vp exec vitest run ${{ matrix.projects }}
 
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         if: github.event_name != 'push' && matrix.os == 'ubuntu-24.04-arm'
@@ -390,7 +390,7 @@ jobs:
           cache: true
 
       - name: Install Playwright
-        run: pnpm playwright-core install chromium
+        run: vp exec playwright-core install chromium
 
       - name: Restore dist cache
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -399,10 +399,10 @@ jobs:
           path: packages
 
       - name: Prepare test fixtures
-        run: pnpm test:prepare
+        run: vp run test:prepare
 
       - name: Test (e2e)
-        run: pnpm test:e2e
+        run: vp run test:e2e
 
       - name: Cancel workflow on failure
         if: failure() && github.event_name == 'merge_group'
@@ -505,4 +505,4 @@ jobs:
           name: dist
           path: packages
 
-      - run: pnpm pkg-pr-new publish --compact --pnpm './packages/kit' './packages/nitro-server' './packages/nuxt' './packages/rspack' './packages/schema' './packages/vite' './packages/webpack' # zizmor: ignore[use-trusted-publishing] pkg-pr-new uses GitHub OIDC trusted publishing internally; no npm token is required in this step
+      - run: vp exec pkg-pr-new publish --compact --pnpm './packages/kit' './packages/nitro-server' './packages/nuxt' './packages/rspack' './packages/schema' './packages/vite' './packages/webpack' # zizmor: ignore[use-trusted-publishing] pkg-pr-new uses GitHub OIDC trusted publishing internally; no npm token is required in this step

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: voidzero-dev/setup-vp@10c4be84517f21333b81092e67a344be1b09a202 # v1.15.0
+      - uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1.15.0
         with:
           node-version: lts
           cache: true
@@ -171,7 +171,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: voidzero-dev/setup-vp@10c4be84517f21333b81092e67a344be1b09a202 # v1.15.0
+      - uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1.15.0
         with:
           node-version: lts
           cache: true
@@ -210,7 +210,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: voidzero-dev/setup-vp@10c4be84517f21333b81092e67a344be1b09a202 # v1.15.0
+      - uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1.15.0
         with:
           node-version: lts
           cache: true
@@ -250,7 +250,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: voidzero-dev/setup-vp@10c4be84517f21333b81092e67a344be1b09a202 # v1.15.0
+      - uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1.15.0
         with:
           node-version: lts
           cache: true
@@ -280,7 +280,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: voidzero-dev/setup-vp@10c4be84517f21333b81092e67a344be1b09a202 # v1.15.0
+      - uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1.15.0
         with:
           node-version: lts
           cache: true
@@ -332,7 +332,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: voidzero-dev/setup-vp@10c4be84517f21333b81092e67a344be1b09a202 # v1.15.0
+      - uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1.15.0
         with:
           node-version: 22
           cache: true
@@ -384,7 +384,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: voidzero-dev/setup-vp@10c4be84517f21333b81092e67a344be1b09a202 # v1.15.0
+      - uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1.15.0
         with:
           node-version: 22
           cache: true
@@ -466,7 +466,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: voidzero-dev/setup-vp@10c4be84517f21333b81092e67a344be1b09a202 # v1.15.0
+      - uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1.15.0
         with:
           node-version: latest
           cache: true
@@ -494,7 +494,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: voidzero-dev/setup-vp@10c4be84517f21333b81092e67a344be1b09a202 # v1.15.0
+      - uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1.15.0
         with:
           node-version: lts
           cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,14 +81,10 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: voidzero-dev/setup-vp@10c4be84517f21333b81092e67a344be1b09a202 # v1.15.0
         with:
-          node-version: lts/*
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install
+          node-version: lts
+          cache: true
 
       - name: Build (stub)
         run: pnpm dev:prepare
@@ -175,14 +171,10 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: voidzero-dev/setup-vp@10c4be84517f21333b81092e67a344be1b09a202 # v1.15.0
         with:
-          node-version: lts/*
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install
+          node-version: lts
+          cache: true
 
       - name: Restore dist cache
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -218,14 +210,10 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: voidzero-dev/setup-vp@10c4be84517f21333b81092e67a344be1b09a202 # v1.15.0
         with:
-          node-version: lts/*
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install
+          node-version: lts
+          cache: true
 
       - name: Build (stub)
         run: pnpm dev:prepare
@@ -262,14 +250,10 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: voidzero-dev/setup-vp@10c4be84517f21333b81092e67a344be1b09a202 # v1.15.0
         with:
-          node-version: lts/*
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install
+          node-version: lts
+          cache: true
 
       - name: Restore dist cache
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -296,14 +280,10 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: voidzero-dev/setup-vp@10c4be84517f21333b81092e67a344be1b09a202 # v1.15.0
         with:
-          node-version: lts/*
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install
+          node-version: lts
+          cache: true
 
       - name: Restore dist cache
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -352,14 +332,10 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: voidzero-dev/setup-vp@10c4be84517f21333b81092e67a344be1b09a202 # v1.15.0
         with:
-          node-version: 'lts/-1'
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install
+          node-version: 22
+          cache: true
 
       - name: Install Playwright
         run: pnpm playwright-core install chromium
@@ -408,14 +384,10 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: voidzero-dev/setup-vp@10c4be84517f21333b81092e67a344be1b09a202 # v1.15.0
         with:
-          node-version: 'lts/-1'
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install
+          node-version: 22
+          cache: true
 
       - name: Install Playwright
         run: pnpm playwright-core install chromium
@@ -494,14 +466,10 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: voidzero-dev/setup-vp@10c4be84517f21333b81092e67a344be1b09a202 # v1.15.0
         with:
-          node-version: current
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install
+          node-version: latest
+          cache: true
 
       - name: Restore dist cache
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -526,14 +494,10 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: voidzero-dev/setup-vp@10c4be84517f21333b81092e67a344be1b09a202 # v1.15.0
         with:
-          node-version: lts/*
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install
+          node-version: lts
+          cache: true
 
       - name: Restore dist cache
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,13 +34,13 @@ jobs:
           cache: true
 
       - name: Build (stub)
-        run: pnpm dev:prepare
+        run: vp run dev:prepare
 
       - name: Lint (docs)
-        run: pnpm lint:docs
+        run: vp run lint:docs
 
       - name: Build Nuxt
-        run: pnpm build
+        run: vp run build
 
       - name: Typecheck (docs)
-        run: pnpm typecheck:docs
+        run: vp run typecheck:docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,14 +28,10 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: voidzero-dev/setup-vp@10c4be84517f21333b81092e67a344be1b09a202 # v1.15.0
         with:
-          node-version: lts/*
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install
+          node-version: lts
+          cache: true
 
       - name: Build (stub)
         run: pnpm dev:prepare

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: voidzero-dev/setup-vp@10c4be84517f21333b81092e67a344be1b09a202 # v1.15.0
+      - uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1.15.0
         with:
           node-version: lts
           cache: true

--- a/.github/workflows/lint-monorepo.yml
+++ b/.github/workflows/lint-monorepo.yml
@@ -33,14 +33,10 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: voidzero-dev/setup-vp@10c4be84517f21333b81092e67a344be1b09a202 # v1.15.0
         with:
-          node-version: lts/*
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install
+          node-version: lts
+          cache: true
 
       - name: Lint monorepo
         run: pnpm sherif -r multiple-dependency-versions

--- a/.github/workflows/lint-monorepo.yml
+++ b/.github/workflows/lint-monorepo.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: voidzero-dev/setup-vp@10c4be84517f21333b81092e67a344be1b09a202 # v1.15.0
+      - uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1.15.0
         with:
           node-version: lts
           cache: true

--- a/.github/workflows/lint-monorepo.yml
+++ b/.github/workflows/lint-monorepo.yml
@@ -39,7 +39,7 @@ jobs:
           cache: true
 
       - name: Lint monorepo
-        run: pnpm sherif -r multiple-dependency-versions
+        run: vp exec sherif -r multiple-dependency-versions
 
       - name: Check engine ranges, peer dependency ranges and installed versions
-        run: pnpm test:engines
+        run: vp run test:engines

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: voidzero-dev/setup-vp@10c4be84517f21333b81092e67a344be1b09a202 # v1.15.0
+      - uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1.15.0
         with:
           node-version: latest
           registry-url: "https://registry.npmjs.org/"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           cache: false
 
       - name: Build (stub)
-        run: pnpm dev:prepare
+        run: vp run dev:prepare
 
       - name: 🛠 Build and release project
         run: node scripts/release.ts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,15 +23,11 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: voidzero-dev/setup-vp@10c4be84517f21333b81092e67a344be1b09a202 # v1.15.0
         with:
-          node-version: current
+          node-version: latest
           registry-url: "https://registry.npmjs.org/"
-          package-manager-cache: false
-
-      - name: 📦 Install dependencies
-        run: pnpm install
+          cache: false
 
       - name: Build (stub)
         run: pnpm dev:prepare


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

it's a pain that `pnpm/action-setup` has broken all our auto-updates and this moves away from using it to using vite-plus. let's see what the perf difference might be.