### PR TITLE
feat(rspack): use rsbuild dev server in middleware mode

### DIFF
--- a/packages/nitro-server/src/legacy.ts
+++ b/packages/nitro-server/src/legacy.ts
@@ -24,8 +24,7 @@ export function setupLegacyDevAndBuild (nuxt: Nuxt & { _nitro?: Nitro }, nitro: 
     for (const builder of ['webpack', 'rspack'] as const) {
       nuxt.hook(`${builder}:compile`, ({ name, compiler }) => {
         if (name === 'server') {
-          const memfs = compiler.outputFileSystem as typeof import('node:fs')
-          nitro.options.virtual['nuxt/entry'] = () => memfs.readFileSync(join(nuxt.options.buildDir, 'dist/server/server.mjs'), 'utf-8')
+          nitro.options.virtual['nuxt/entry'] = () => (compiler.outputFileSystem as typeof import('node:fs')).readFileSync(join(nuxt.options.buildDir, 'dist/server/server.mjs'), 'utf-8')
         }
       })
       nuxt.hook(`${builder}:compiled`, () => {

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -69,14 +69,11 @@
     "url-loader": "^4.1.1",
     "vue-bundle-renderer": "^2.3.1",
     "webpack-bundle-analyzer": "^5.3.0",
-    "webpack-dev-middleware": "^8.0.3",
-    "webpack-hot-middleware": "^2.26.1",
     "webpackbar": "^7.0.0"
   },
   "devDependencies": {
     "@nuxt/schema": "workspace:*",
     "@types/webpack-bundle-analyzer": "4.7.0",
-    "@types/webpack-hot-middleware": "2.25.12",
     "h3": "1.15.11",
     "h3-next": "npm:h3@2.0.1-rc.22",
     "rollup": "4.62.2",

--- a/packages/webpack/src/configs/client.ts
+++ b/packages/webpack/src/configs/client.ts
@@ -9,7 +9,7 @@ import { defineEnv } from 'unenv'
 import type { WebpackConfigContext } from '../utils/config.ts'
 import { applyPresets } from '../utils/config.ts'
 import { nuxt } from '../presets/nuxt.ts'
-import { TsCheckerPlugin, webpack } from '#builder'
+import { TsCheckerPlugin, builder, webpack } from '#builder'
 
 export async function client (ctx: WebpackConfigContext) {
   ctx.name = 'client'
@@ -76,6 +76,14 @@ function clientHMR (ctx: WebpackConfigContext) {
     return
   }
 
+  ctx.config.plugins ||= []
+  ctx.config.plugins.push(new webpack.HotModuleReplacementPlugin())
+
+  // Rsbuild's dev server injects its own HMR client
+  if (builder === 'rspack') {
+    return
+  }
+
   const clientOptions = ctx.userConfig.hotMiddleware?.client || {}
   const hotMiddlewareClientOptions = {
     reload: true,
@@ -94,9 +102,6 @@ function clientHMR (ctx: WebpackConfigContext) {
     // https://github.com/webpack/webpack-hot-middleware#config
     `webpack-hot-middleware/client?${hotMiddlewareClientOptionsStr}`,
   )
-
-  ctx.config.plugins ||= []
-  ctx.config.plugins.push(new webpack.HotModuleReplacementPlugin())
 }
 
 function clientOptimization (ctx: WebpackConfigContext) {

--- a/packages/webpack/src/webpack.ts
+++ b/packages/webpack/src/webpack.ts
@@ -1,5 +1,3 @@
-import type { Server as HttpServer } from 'node:http'
-import type { Http2SecureServer } from 'node:http2'
 import pify from 'pify'
 import type { H3Event as H3V1Event } from 'h3'
 import type { H3Event as H3V2Event } from 'h3-next'
@@ -157,9 +155,8 @@ function createRsbuildInstance (configs: Configuration[], nuxt: Nuxt) {
         ? {
             server: { middlewareMode: true },
             dev: {
-              // Keep the HMR socket under the build-assets dir so Nuxt's dev
-              // server leaves the upgrade for Rsbuild instead of proxying it
-              // to Nitro (it ignores upgrades below the build-assets path).
+              // keep the HMR socket under the build-assets dir so
+              // the upgrade won't be forwarded to nitro
               client: {
                 path: joinURL(nuxt.options.app.baseURL, nuxt.options.app.buildAssetsDir, 'rsbuild-hmr'),
               },
@@ -210,11 +207,15 @@ async function startRsbuildDevServer (rsbuild: Awaited<ReturnType<NonNullable<ty
 
   nuxt.hook('close', () => devServer.close())
 
-  // The HMR websocket rides on Nuxt's dev server rather than a port of its own.
-  nuxt.hook('listen', (server: HttpServer | Http2SecureServer) => {
-    devServer.connectWebSocket({ server })
-    devServer.afterListen()
-  })
+  // Attach the HMR websocket to the nuxt dev server, so it shares the
+  // app's port and TLS certificate rather than needing a second server.
+  const listener = nuxt._devServerListener
+  if (listener) {
+    devServer.connectWebSocket({ server: listener })
+    await devServer.afterListen()
+  } else {
+    logger.warn('Could not find the Nuxt dev server to attach Rspack HMR to; hot module replacement will be disabled.')
+  }
 
   await nuxt.callHook('server:devHandler', rsbuildToH3Handler(devServer.middlewares), { cors: () => true })
 

--- a/packages/webpack/src/webpack.ts
+++ b/packages/webpack/src/webpack.ts
@@ -1,9 +1,10 @@
+import type { Server as HttpServer } from 'node:http'
+import type { Http2SecureServer } from 'node:http2'
 import pify from 'pify'
 import type { H3Event as H3V1Event } from 'h3'
 import type { H3Event as H3V2Event } from 'h3-next'
+import type webpackDevMiddleware from 'webpack-dev-middleware'
 import type { IncomingMessage, MultiWatching, ServerResponse } from 'webpack-dev-middleware'
-import webpackDevMiddleware from 'webpack-dev-middleware'
-import webpackHotMiddleware from 'webpack-hot-middleware'
 import type { Compiler, Configuration, Stats, Watching } from 'webpack'
 import { defu } from 'defu'
 import type { Nuxt, NuxtBuilder } from '@nuxt/schema'
@@ -49,9 +50,6 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
 
   await nuxt.callHook(`${builder}:config`, webpackConfigs)
 
-  // Initialize shared MFS for dev
-  const mfs = nuxt.options.dev ? createMFS() : null
-
   // In dev the SSR entry is served from the in-memory bundle via the builder compile hook.
   if (nuxt.options.ssr && !nuxt.options.dev) {
     const serverEntryFile = pathToFileURL(resolve(nuxt.options.buildDir, 'dist/server/server.mjs')).href
@@ -73,10 +71,31 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
 
   await nuxt.callHook(`${builder}:configResolved`, webpackConfigs)
 
-  // Configure compilers
-  const compilers = builder === 'rspack' && createRsbuild
-    ? await createRsbuildCompilers(webpackConfigs, nuxt)
-    : webpackConfigs.map(config => webpack(config))
+  // Rsbuild owns the dev server (middleware mode) and, in production, the
+  // compiler lifecycle. Everything else falls back to plain webpack.
+  if (builder === 'rspack' && createRsbuild) {
+    const rsbuild = await createRsbuildInstance(webpackConfigs, nuxt)
+
+    if (nuxt.options.dev) {
+      await startRsbuildDevServer(rsbuild, nuxt)
+      return
+    }
+
+    const compilers = await getRsbuildCompilers(rsbuild)
+    nuxt.hook('close', async () => {
+      for (const compiler of compilers) {
+        await new Promise(resolve => compiler.close(resolve))
+      }
+    })
+    for (const c of compilers) {
+      await compile(c)
+    }
+    return
+  }
+
+  // Initialize shared MFS for dev
+  const mfs = nuxt.options.dev ? createMFS() : null
+  const compilers = webpackConfigs.map(config => webpack(config))
 
   // In dev, write files in memory FS
   if (nuxt.options.dev) {
@@ -102,13 +121,21 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
   }
 }
 
-async function createRsbuildCompilers (configs: Configuration[], nuxt: Nuxt): Promise<Compiler[]> {
+function createRsbuildInstance (configs: Configuration[], nuxt: Nuxt) {
   // One rsbuild environment per Nuxt bundle (client → web, server → node)
   const environments: Record<string, unknown> = {}
   for (const config of configs) {
+    const isServer = config.name === 'server'
+    // Rsbuild's dev server only injects its HMR client into `web` compilers.
+    if (nuxt.options.dev && !isServer) {
+      config.target ??= 'web'
+    }
     environments[config.name!] = {
       output: {
-        target: config.name === 'server' ? 'node' : 'web',
+        target: isServer ? 'node' : 'web',
+        // The dev server serves assets from `<distPath>/<url after publicPath>`,
+        // so point it at the same directory the compiler writes to.
+        distPath: { root: config.output!.path as string },
       },
       tools: {
         // Nuxt generates the full rspack configuration itself, so the
@@ -118,7 +145,7 @@ async function createRsbuildCompilers (configs: Configuration[], nuxt: Nuxt): Pr
     }
   }
 
-  const rsbuild = await createRsbuild!({
+  return createRsbuild!({
     callerName: 'nuxt',
     cwd: nuxt.options.rootDir,
     config: {
@@ -126,18 +153,106 @@ async function createRsbuildCompilers (configs: Configuration[], nuxt: Nuxt): Pr
       mode: nuxt.options.dev ? 'development' : 'production',
       logLevel: 'silent',
       environments,
+      ...nuxt.options.dev
+        ? {
+            server: { middlewareMode: true },
+            dev: {
+              // Keep the HMR socket under the build-assets dir so Nuxt's dev
+              // server leaves the upgrade for Rsbuild instead of proxying it
+              // to Nitro (it ignores upgrades below the build-assets path).
+              client: {
+                path: joinURL(nuxt.options.app.baseURL, nuxt.options.app.buildAssetsDir, 'rsbuild-hmr'),
+              },
+            },
+          }
+        : {},
     },
   })
+}
 
+async function getRsbuildCompilers (rsbuild: Awaited<ReturnType<NonNullable<typeof createRsbuild>>>): Promise<Compiler[]> {
   // Returns a MultiCompiler when more than one environment is configured
   const compiler = await rsbuild.createCompiler()
   return ('compilers' in compiler ? compiler.compilers : [compiler]) as Compiler[]
+}
+
+async function startRsbuildDevServer (rsbuild: Awaited<ReturnType<NonNullable<typeof createRsbuild>>>, nuxt: Nuxt) {
+  // Nitro reads the server bundle from the compiler's in-memory output, so the
+  // build must not be considered ready until every compiler has emitted once.
+  const firstCompiles: Array<Promise<void>> = []
+
+  rsbuild.onAfterCreateCompiler(({ compiler }) => {
+    const compilers = ('compilers' in compiler ? compiler.compilers : [compiler]) as Compiler[]
+    for (const c of compilers) {
+      const name = c.options.name!
+      nuxt.callHook(`${builder}:compile`, { name, compiler: c })
+
+      let settled = false
+      firstCompiles.push(new Promise<void>((resolve, reject) => {
+        c.hooks.done.tap('load-resources', (stats) => {
+          nuxt.callHook(`${builder}:compiled`, { name, compiler: c, stats: stats as Stats })
+          if (!settled) {
+            settled = true
+            resolve()
+          }
+        })
+        c.hooks.failed.tap('nuxt-errorlog', (err) => {
+          if (!settled) {
+            settled = true
+            reject(err)
+          }
+        })
+      }))
+    }
+  })
+
+  const devServer = await rsbuild.createDevServer()
+
+  nuxt.hook('close', () => devServer.close())
+
+  // The HMR websocket rides on Nuxt's dev server rather than a port of its own.
+  nuxt.hook('listen', (server: HttpServer | Http2SecureServer) => {
+    devServer.connectWebSocket({ server })
+    devServer.afterListen()
+  })
+
+  await nuxt.callHook('server:devHandler', rsbuildToH3Handler(devServer.middlewares), { cors: () => true })
+
+  await Promise.all(firstCompiles)
+}
+
+function rsbuildToH3Handler (middlewares: (req: IncomingMessage, res: ServerResponse, next: (err?: unknown) => void) => void) {
+  return defineEventHandler(async (event) => {
+    const { req, res } = 'runtime' in event ? event.runtime!.node! : event.node
+    if (!isSameOriginRequest(req)) {
+      res!.statusCode = 403
+      res!.end('Forbidden')
+      return
+    }
+    await new Promise<void>((resolve) => {
+      let settled = false
+      const done = () => {
+        if (!settled) {
+          settled = true
+          resolve()
+        }
+      }
+      // Middlewares that serve a response end it without calling `next`, so also
+      // settle when the response finishes; `next` means Nuxt should handle it.
+      res!.on('finish', done)
+      res!.on('close', done)
+      middlewares(req as IncomingMessage, res as ServerResponse, () => done())
+    })
+  })
 }
 
 async function createDevMiddleware (compiler: Compiler) {
   const nuxt = useNuxt()
 
   logger.debug('Creating webpack middleware...')
+
+  const { default: webpackDevMiddleware } = await import('webpack-dev-middleware')
+  const { default: webpackHotMiddleware } = await import('webpack-hot-middleware')
 
   // Create webpack dev middleware
   const devMiddleware = webpackDevMiddleware(compiler, {

--- a/packages/webpack/src/webpack.ts
+++ b/packages/webpack/src/webpack.ts
@@ -5,7 +5,7 @@ import type { H3Event as H3V1Event } from 'h3'
 import type { H3Event as H3V2Event } from 'h3-next'
 import type webpackDevMiddleware from 'webpack-dev-middleware'
 import type { IncomingMessage, MultiWatching, ServerResponse } from 'webpack-dev-middleware'
-import type { Compiler, Configuration, Stats, Watching } from 'webpack'
+import type { Compiler, Configuration, MultiCompiler, Stats, Watching } from 'webpack'
 import { defu } from 'defu'
 import type { Nuxt, NuxtBuilder } from '@nuxt/schema'
 import { pathToFileURL } from 'node:url'
@@ -181,7 +181,7 @@ async function startRsbuildDevServer (rsbuild: Awaited<ReturnType<NonNullable<ty
   // build must not be considered ready until every compiler has emitted once.
   const firstCompiles: Array<Promise<void>> = []
 
-  rsbuild.onAfterCreateCompiler(({ compiler }) => {
+  rsbuild.onAfterCreateCompiler(({ compiler }: { compiler: Compiler | MultiCompiler }) => {
     const compilers = ('compilers' in compiler ? compiler.compilers : [compiler]) as Compiler[]
     for (const c of compilers) {
       const name = c.options.name!

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -771,12 +771,6 @@ importers:
       webpack-bundle-analyzer:
         specifier: ^5.3.0
         version: 5.3.0
-      webpack-dev-middleware:
-        specifier: ^8.0.3
-        version: 8.0.3(tslib@2.8.1)(webpack@5.108.4(cssnano@8.0.2(postcss@8.5.19))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19))
-      webpack-hot-middleware:
-        specifier: ^2.26.1
-        version: 2.26.1
       webpackbar:
         specifier: ^7.0.0
         version: 7.0.0(@rspack/core@2.1.3(@swc/helpers@0.5.23))(webpack@5.108.4(cssnano@8.0.2(postcss@8.5.19))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19))
@@ -787,9 +781,6 @@ importers:
       '@types/webpack-bundle-analyzer':
         specifier: 4.7.0
         version: 4.7.0(cssnano@8.0.2(postcss@8.5.19))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19)
-      '@types/webpack-hot-middleware':
-        specifier: 2.25.12
-        version: 2.25.12(cssnano@8.0.2(postcss@8.5.19))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19)
       h3:
         specifier: 1.15.11
         version: 1.15.11

--- a/test/fixtures/hmr/nuxt.config.ts
+++ b/test/fixtures/hmr/nuxt.config.ts
@@ -1,4 +1,4 @@
-import { withMatrix } from '../../matrix'
+import { builder, withMatrix } from '../../matrix'
 import { virtualCounterPlugin } from './vite/virtual-counter-plugin'
 
 export default withMatrix({
@@ -7,7 +7,10 @@ export default withMatrix({
     nitroAutoImports: true,
     inlineRouteRules: true,
   },
-  vite: {
-    plugins: [virtualCounterPlugin()],
-  },
+  // `virtual:hmr-counter` is a Vite plugin module and the regression it guards
+  // (#30169) is Vite-only. webpack/Rspack don't resolve the `virtual:` scheme,
+  // so exclude the page there rather than ship a bespoke scheme handler.
+  ...builder === 'vite'
+    ? { vite: { plugins: [virtualCounterPlugin()] } }
+    : { ignore: ['**/virtual-module.vue'] },
 })


### PR DESCRIPTION
### 🔗 Linked issue

follow-on from https://github.com/nuxt/nuxt/pull/35489

### 📚 Description

this migrates us to use the rsbuild dev server rather than `webpack-dev-middleware` and `webpack-hot-middleware`