### PR TITLE
fix(nuxt): auto-import `$fetch` where possible

### DIFF
--- a/internal.d.ts
+++ b/internal.d.ts
@@ -1,0 +1,4 @@
+// force importing from '#build/fetch.mjs' explicitly within nuxt
+declare global {
+  var $fetch: undefined
+}

--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -153,7 +153,7 @@ export function normalizeTemplate<T> (template: NuxtTemplate<T> | string, buildD
   }
 
   // Always write declaration files
-  if (template.filename.endsWith('.d.ts')) {
+  if (template.filename.endsWith('.d.ts') || template.filename.endsWith('.d.mts') || template.filename.endsWith('.d.cts')) {
     template.write = true
   }
 

--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -7,7 +7,8 @@ import { hash } from 'ohash'
 import { isPlainObject } from '@vue/shared'
 import { useRequestFetch } from './ssr'
 // @ts-expect-error virtual file
-import { $fetch } from '#build/fetch.mjs'
+import { $fetch as _$fetch } from '#build/fetch.mjs'
+const $fetch = _$fetch as $Fetch
 import type { AsyncData, AsyncDataOptions, KeysOf, MultiWatchSources, PickFrom, _Transform } from './asyncData'
 import { useAsyncData } from './asyncData'
 import type { NuxtError } from './error'
@@ -42,7 +43,7 @@ export interface UseFetchOptions<
   M extends AvailableRouterMethod<R> = AvailableRouterMethod<R>,
 > extends Omit<AsyncDataOptions<ResT, DataT, PickKeys, DefaultT>, 'watch'>, Omit<ComputedFetchOptions<R, M, DataT>, 'timeout'> {
   key?: MaybeRefOrGetter<string>
-  $fetch?: typeof globalThis.$fetch
+  $fetch?: $Fetch
   watch?: MultiWatchSources | false
 }
 

--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -6,6 +6,8 @@ import { hash } from 'ohash'
 
 import { isPlainObject } from '@vue/shared'
 import { useRequestFetch } from './ssr'
+// @ts-expect-error virtual file
+import { $fetch } from '#build/fetch.mjs'
 import type { AsyncData, AsyncDataOptions, KeysOf, MultiWatchSources, PickFrom, _Transform } from './asyncData'
 import { useAsyncData } from './asyncData'
 import type { NuxtError } from './error'
@@ -360,7 +362,7 @@ export const createUseFetch: CreateUseFetch = defineKeyedFunctionFactory<CreateU
       }
 
       const asyncData = useAsyncData<_ResT, ErrorT, DataT, PickKeys, DefaultT>(key, (_, { signal }) => {
-        let _$fetch: H3Event$Fetch | $Fetch<unknown, NitroFetchRequest> = fetchOptions.$fetch || globalThis.$fetch
+        let _$fetch: H3Event$Fetch | $Fetch<unknown, NitroFetchRequest> = fetchOptions.$fetch || $fetch
 
         // Use fetch with request context and headers for server direct API calls
         if (import.meta.server && !fetchOptions.$fetch) {

--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -8,7 +8,6 @@ import { isPlainObject } from '@vue/shared'
 import { useRequestFetch } from './ssr'
 // @ts-expect-error virtual file
 import { $fetch as _$fetch } from '#build/fetch.mjs'
-const $fetch = _$fetch as $Fetch
 import type { AsyncData, AsyncDataOptions, KeysOf, MultiWatchSources, PickFrom, _Transform } from './asyncData'
 import { useAsyncData } from './asyncData'
 import type { NuxtError } from './error'
@@ -16,6 +15,8 @@ import { defineKeyedFunctionFactory } from '../../compiler/runtime'
 
 // @ts-expect-error virtual file
 import { alwaysRunFetchOnKeyChange, fetchDefaults } from '#build/nuxt.config.mjs'
+
+const $fetch = _$fetch as $Fetch
 
 // support uppercase methods, detail: https://github.com/nuxt/nuxt/issues/22313
 type AvailableRouterMethod<R extends NitroFetchRequest> = _AvailableRouterMethod<R> | Uppercase<_AvailableRouterMethod<R>>

--- a/packages/nuxt/src/app/composables/manifest.ts
+++ b/packages/nuxt/src/app/composables/manifest.ts
@@ -1,12 +1,13 @@
 import type { H3Event } from '@nuxt/nitro-server/h3'
-import type { NitroRouteRules } from 'nitropack/types'
+import type { $Fetch, NitroRouteRules } from 'nitropack/types'
 import { useRuntimeConfig } from '../nuxt'
 // @ts-expect-error virtual file
 import { appManifest as isAppManifestEnabled } from '#build/nuxt.config.mjs'
 // @ts-expect-error virtual file
 import { buildAssetsURL } from '#internal/nuxt/paths'
 // @ts-expect-error virtual file
-import { $fetch } from '#build/fetch.mjs'
+import { $fetch as _$fetch } from '#build/fetch.mjs'
+const $fetch = _$fetch as $Fetch
 // @ts-expect-error virtual file
 import _routeRulesMatcher from '#build/route-rules.mjs'
 

--- a/packages/nuxt/src/app/composables/manifest.ts
+++ b/packages/nuxt/src/app/composables/manifest.ts
@@ -7,9 +7,10 @@ import { appManifest as isAppManifestEnabled } from '#build/nuxt.config.mjs'
 import { buildAssetsURL } from '#internal/nuxt/paths'
 // @ts-expect-error virtual file
 import { $fetch as _$fetch } from '#build/fetch.mjs'
-const $fetch = _$fetch as $Fetch
 // @ts-expect-error virtual file
 import _routeRulesMatcher from '#build/route-rules.mjs'
+
+const $fetch = _$fetch as $Fetch
 
 const routeRulesMatcher = _routeRulesMatcher as (path: string) => NitroRouteRules
 

--- a/packages/nuxt/src/app/composables/manifest.ts
+++ b/packages/nuxt/src/app/composables/manifest.ts
@@ -6,6 +6,8 @@ import { appManifest as isAppManifestEnabled } from '#build/nuxt.config.mjs'
 // @ts-expect-error virtual file
 import { buildAssetsURL } from '#internal/nuxt/paths'
 // @ts-expect-error virtual file
+import { $fetch } from '#build/fetch.mjs'
+// @ts-expect-error virtual file
 import _routeRulesMatcher from '#build/route-rules.mjs'
 
 const routeRulesMatcher = _routeRulesMatcher as (path: string) => NitroRouteRules

--- a/packages/nuxt/src/app/composables/ssr.ts
+++ b/packages/nuxt/src/app/composables/ssr.ts
@@ -4,12 +4,13 @@ import { computed, getCurrentInstance, ref } from 'vue'
 import type { $Fetch, H3Event$Fetch } from 'nitropack/types'
 // @ts-expect-error virtual file
 import { $fetch as _$fetch } from '#build/fetch.mjs'
-const $fetch = _$fetch as $Fetch
 
 import type { NuxtApp } from '../nuxt'
 import { useNuxtApp } from '../nuxt'
 import { toArray } from '../utils'
 import { useHead } from './head'
+
+const $fetch = _$fetch as $Fetch
 
 /** @since 3.0.0 */
 export function useRequestEvent (nuxtApp?: NuxtApp): H3Event | undefined {

--- a/packages/nuxt/src/app/composables/ssr.ts
+++ b/packages/nuxt/src/app/composables/ssr.ts
@@ -2,6 +2,8 @@ import type { H3Event } from '@nuxt/nitro-server/h3'
 import { setResponseStatus as _setResponseStatus, appendHeader, getRequestHeader, getRequestHeaders, getResponseHeader, removeResponseHeader, setResponseHeader } from '@nuxt/nitro-server/h3'
 import { computed, getCurrentInstance, ref } from 'vue'
 import type { H3Event$Fetch } from 'nitropack/types'
+// @ts-expect-error virtual file
+import { $fetch } from '#build/fetch.mjs'
 
 import type { NuxtApp } from '../nuxt'
 import { useNuxtApp } from '../nuxt'
@@ -44,9 +46,9 @@ export function useRequestHeader (header: string): string | null | undefined {
 /** @since 3.2.0 */
 export function useRequestFetch (): H3Event$Fetch | typeof globalThis.$fetch {
   if (import.meta.client) {
-    return globalThis.$fetch
+    return $fetch
   }
-  return useRequestEvent()?.$fetch || globalThis.$fetch
+  return useRequestEvent()?.$fetch || $fetch
 }
 
 /** @since 3.0.0 */

--- a/packages/nuxt/src/app/composables/ssr.ts
+++ b/packages/nuxt/src/app/composables/ssr.ts
@@ -1,9 +1,10 @@
 import type { H3Event } from '@nuxt/nitro-server/h3'
 import { setResponseStatus as _setResponseStatus, appendHeader, getRequestHeader, getRequestHeaders, getResponseHeader, removeResponseHeader, setResponseHeader } from '@nuxt/nitro-server/h3'
 import { computed, getCurrentInstance, ref } from 'vue'
-import type { H3Event$Fetch } from 'nitropack/types'
+import type { $Fetch, H3Event$Fetch } from 'nitropack/types'
 // @ts-expect-error virtual file
-import { $fetch } from '#build/fetch.mjs'
+import { $fetch as _$fetch } from '#build/fetch.mjs'
+const $fetch = _$fetch as $Fetch
 
 import type { NuxtApp } from '../nuxt'
 import { useNuxtApp } from '../nuxt'
@@ -44,7 +45,7 @@ export function useRequestHeader (header: string): string | null | undefined {
 }
 
 /** @since 3.2.0 */
-export function useRequestFetch (): H3Event$Fetch | typeof globalThis.$fetch {
+export function useRequestFetch (): H3Event$Fetch | $Fetch {
   if (import.meta.client) {
     return $fetch
   }

--- a/packages/nuxt/src/app/entry.ts
+++ b/packages/nuxt/src/app/entry.ts
@@ -1,7 +1,6 @@
 import { createApp, createSSRApp, nextTick } from 'vue'
 import type { App } from 'vue'
 
-// This file must be imported first as we set globalThis.$fetch via this import
 // @ts-expect-error virtual file
 import '#build/fetch.mjs'
 // @ts-expect-error virtual file

--- a/packages/nuxt/src/app/plugins/check-outdated-build.client.ts
+++ b/packages/nuxt/src/app/plugins/check-outdated-build.client.ts
@@ -1,4 +1,4 @@
-import type { FetchError } from 'ofetch'
+import type { $Fetch, FetchError } from 'ofetch'
 import { defineNuxtPlugin } from '../nuxt'
 import type { ObjectPlugin, Plugin } from '../nuxt'
 import { getAppManifest } from '../composables/manifest'
@@ -9,7 +9,8 @@ import { buildAssetsURL } from '#internal/nuxt/paths'
 // @ts-expect-error virtual file
 import { outdatedBuildInterval } from '#build/nuxt.config.mjs'
 // @ts-expect-error virtual file
-import { $fetch } from '#build/fetch.mjs'
+import { $fetch as _$fetch } from '#build/fetch.mjs'
+const $fetch = _$fetch as $Fetch
 
 const plugin: Plugin & ObjectPlugin = defineNuxtPlugin((nuxtApp) => {
   if (import.meta.test) { return }

--- a/packages/nuxt/src/app/plugins/check-outdated-build.client.ts
+++ b/packages/nuxt/src/app/plugins/check-outdated-build.client.ts
@@ -8,6 +8,8 @@ import { onNuxtReady } from '../composables/ready'
 import { buildAssetsURL } from '#internal/nuxt/paths'
 // @ts-expect-error virtual file
 import { outdatedBuildInterval } from '#build/nuxt.config.mjs'
+// @ts-expect-error virtual file
+import { $fetch } from '#build/fetch.mjs'
 
 const plugin: Plugin & ObjectPlugin = defineNuxtPlugin((nuxtApp) => {
   if (import.meta.test) { return }

--- a/packages/nuxt/src/app/plugins/check-outdated-build.client.ts
+++ b/packages/nuxt/src/app/plugins/check-outdated-build.client.ts
@@ -10,6 +10,7 @@ import { buildAssetsURL } from '#internal/nuxt/paths'
 import { outdatedBuildInterval } from '#build/nuxt.config.mjs'
 // @ts-expect-error virtual file
 import { $fetch as _$fetch } from '#build/fetch.mjs'
+
 const $fetch = _$fetch as $Fetch
 
 const plugin: Plugin & ObjectPlugin = defineNuxtPlugin((nuxtApp) => {

--- a/packages/nuxt/src/app/plugins/revive-payload.client.ts
+++ b/packages/nuxt/src/app/plugins/revive-payload.client.ts
@@ -9,6 +9,7 @@ import type { ObjectPlugin, Plugin } from '../nuxt'
 import { componentIslands } from '#build/nuxt.config.mjs'
 // @ts-expect-error virtual file
 import { $fetch as _$fetch } from '#build/fetch.mjs'
+
 const $fetch = _$fetch as $Fetch
 
 function parseRevivedData (data: string) {

--- a/packages/nuxt/src/app/plugins/revive-payload.client.ts
+++ b/packages/nuxt/src/app/plugins/revive-payload.client.ts
@@ -6,6 +6,8 @@ import type { ObjectPlugin, Plugin } from '../nuxt'
 
 // @ts-expect-error Virtual file.
 import { componentIslands } from '#build/nuxt.config.mjs'
+// @ts-expect-error virtual file
+import { $fetch } from '#build/fetch.mjs'
 
 function parseRevivedData (data: string) {
   try {

--- a/packages/nuxt/src/app/plugins/revive-payload.client.ts
+++ b/packages/nuxt/src/app/plugins/revive-payload.client.ts
@@ -1,3 +1,4 @@
+import type { $Fetch } from 'ofetch'
 import { reactive, ref, shallowReactive, shallowRef } from 'vue'
 import { definePayloadReviver, getNuxtClientPayload } from '../composables/payload'
 import { createError } from '../composables/error'
@@ -7,7 +8,8 @@ import type { ObjectPlugin, Plugin } from '../nuxt'
 // @ts-expect-error Virtual file.
 import { componentIslands } from '#build/nuxt.config.mjs'
 // @ts-expect-error virtual file
-import { $fetch } from '#build/fetch.mjs'
+import { $fetch as _$fetch } from '#build/fetch.mjs'
+const $fetch = _$fetch as $Fetch
 
 function parseRevivedData (data: string) {
   try {

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -487,14 +487,23 @@ export const dollarFetchTemplate: NuxtTemplate = {
   filename: 'fetch.mjs',
   getContents () {
     return [
-      'import { $fetch } from \'ofetch\'',
+      'import { $fetch as _$fetch } from \'ofetch\'',
       'import { baseURL } from \'#internal/nuxt/paths\'',
       'if (!globalThis.$fetch) {',
-      '  globalThis.$fetch = $fetch.create({',
+      '  globalThis.$fetch = _$fetch.create({',
       '    baseURL: baseURL()',
       '  })',
       '}',
+      'export const $fetch = globalThis.$fetch',
     ].join('\n')
+  },
+}
+
+export const dollarFetchTypeTemplate: NuxtTemplate = {
+  filename: 'fetch.d.mts',
+  write: true,
+  getContents () {
+    return 'export { $fetch } from \'ofetch\'\n'
   },
 }
 

--- a/packages/nuxt/src/imports/presets.ts
+++ b/packages/nuxt/src/imports/presets.ts
@@ -54,6 +54,10 @@ const granularAppPresets: InlinePreset[] = [
     from: '#app/composables/fetch',
   },
   {
+    imports: ['$fetch'],
+    from: '#build/fetch.mjs',
+  },
+  {
     imports: ['useCookie', 'refreshCookie'],
     from: '#app/composables/cookie',
   },

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -179,6 +179,7 @@ describe('pages', () => {
     // composables auto import
     expect(html).toContain('Composable | foo: auto imported from ~/composables/foo.ts')
     expect(html).toContain('Composable | bar: auto imported from ~/utils/useBar.ts')
+    expect(html).toContain('Composable | customFetch: function')
     expect(html).toContain('Composable | template: auto imported from ~/composables/template.ts')
     expect(html).toContain('Composable | star: auto imported from ~/composables/nested/bar.ts via star export')
     // should import components

--- a/test/fixtures/basic/app/pages/index.vue
+++ b/test/fixtures/basic/app/pages/index.vue
@@ -7,6 +7,7 @@
     <div>RuntimeConfig | testConfig: {{ config.public.testConfig }}</div>
     <div>Composable | foo: {{ foo }}</div>
     <div>Composable | bar: {{ bar }}</div>
+    <div>Composable | customFetch: {{ typeof customFetch }}</div>
     <div>Composable | template: {{ templateAutoImport }}</div>
     <div>Composable | star: {{ useNestedBar() }}</div>
     <DevOnly>Some dev-only info</DevOnly>

--- a/test/fixtures/basic/app/utils/globalFetch.ts
+++ b/test/fixtures/basic/app/utils/globalFetch.ts
@@ -1,0 +1,1 @@
+export const customFetch = $fetch.create({})


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/35580

### 📚 Description

reported by @DamianGlowala, rolldown has a different output format from rollup and it's possible for `$fetch` not to have been set by the time it's used in a top-level `$fetch.create`

reproduction: https://github.com/DamianGlowala/nuxt-4.x-nightly-vite-8-repro

this moves `$fetch` to being auto-imported in user code, and explicitly imported within `nuxt/app`, while still keeping the `globalThis.$fetch` assignment