### PR TITLE
fix(nuxt): tolerate missing dirs in parcel watcher

### DIFF
--- a/packages/nuxt/src/core/builder.ts
+++ b/packages/nuxt/src/core/builder.ts
@@ -236,8 +236,14 @@ async function createParcelWatcher () {
     // eslint-disable-next-line no-console
     console.time('[nuxt] builder:parcel:watch')
   }
+  let subscribe: typeof import('@parcel/watcher').subscribe
   try {
-    const { subscribe } = await importModule<typeof import('@parcel/watcher')>('@parcel/watcher', { url: [nuxt.options.rootDir, ...nuxt.options.modulesDir].map(d => directoryToURL(d)) })
+    ({ subscribe } = await importModule<typeof import('@parcel/watcher')>('@parcel/watcher', { url: [nuxt.options.rootDir, ...nuxt.options.modulesDir].map(d => directoryToURL(d)) }))
+  } catch {
+    logger.warn('Falling back to `chokidar-granular` as `@parcel/watcher` cannot be resolved in your project.')
+    return false
+  }
+  try {
     const pathsToWatch = resolvePathsToWatch(nuxt, { parentDirectories: true })
     for (const dir of pathsToWatch) {
       if (!await isDirectory(dir)) { continue }
@@ -260,8 +266,8 @@ async function createParcelWatcher () {
       console.timeEnd('[nuxt] builder:parcel:watch')
     }
     return true
-  } catch {
-    logger.warn('Falling back to `chokidar-granular` as `@parcel/watcher` cannot be resolved in your project.')
+  } catch (error) {
+    logger.warn('Falling back to `chokidar-granular` as `@parcel/watcher` failed to set up watchers.', error)
     return false
   }
 }

--- a/packages/nuxt/src/utils.ts
+++ b/packages/nuxt/src/utils.ts
@@ -8,7 +8,14 @@ export function toArray<T> (value: T | T[]): T[] {
 }
 
 export async function isDirectory (path: string) {
-  return (await fsp.lstat(path)).isDirectory()
+  try {
+    return (await fsp.lstat(path)).isDirectory()
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code
+    // A missing path (ENOENT) or a non-directory ancestor (ENOTDIR) is simply not a directory
+    if (code === 'ENOENT' || code === 'ENOTDIR') { return false }
+    throw err
+  }
 }
 
 export function isDirectorySync (path: string) {

--- a/packages/nuxt/test/utils.test.ts
+++ b/packages/nuxt/test/utils.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
-import { isDirectorySync } from '../src/utils.ts'
+import { isDirectory, isDirectorySync } from '../src/utils.ts'
 
 describe('isDirectorySync', () => {
   let dir: string
@@ -33,5 +33,36 @@ describe('isDirectorySync', () => {
 
   it('returns false when a path segment is a file, not a directory (ENOTDIR)', () => {
     expect(isDirectorySync(join(file, 'child'))).toBe(false)
+  })
+})
+
+describe('isDirectory', () => {
+  let dir: string
+  let file: string
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), 'nuxt-isdir'))
+    file = join(dir, 'testfile.txt')
+    writeFileSync(file, '')
+  })
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('returns true for an existing directory', async () => {
+    expect(await isDirectory(dir)).toBe(true)
+  })
+
+  it('returns false for an existing file', async () => {
+    expect(await isDirectory(file)).toBe(false)
+  })
+
+  it('returns false for a non-existent path (ENOENT)', async () => {
+    expect(await isDirectory(join(dir, 'nope'))).toBe(false)
+  })
+
+  it('returns false when a path segment is a file, not a directory (ENOTDIR)', async () => {
+    expect(await isDirectory(join(file, 'child'))).toBe(false)
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/35569

### 📚 Description

directories that don't exist now just return `false` rather than throwing an error