### PR TITLE
fix(rspack,webpack): use async entry in dev to avoid circular import

### DIFF
--- a/packages/webpack/src/presets/base.ts
+++ b/packages/webpack/src/presets/base.ts
@@ -31,7 +31,7 @@ export async function base (ctx: WebpackConfigContext) {
 function baseConfig (ctx: WebpackConfigContext) {
   ctx.config = defu({}, {
     name: ctx.name,
-    entry: { app: [resolve(ctx.options.appDir, ctx.options.experimental.asyncEntry ? 'entry.async' : 'entry')] },
+    entry: { app: [resolve(ctx.options.appDir, (ctx.options.experimental.asyncEntry || ctx.isDev) ? 'entry.async' : 'entry')] },
     module: {
       rules: [],
       // Nuxt resolves some virtual module exports lazily (e.g. `?inline` CSS), so missing exports


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

fixes a circular import causing flaky tests, e.g.:
- https://github.com/nuxt/nuxt/actions/runs/29406871905/job/87334514159
- https://github.com/vitejs/vite-ecosystem-ci/actions/runs/29396303584/job/87290475564

we do the same thing for vite already:

https://github.com/nuxt/nuxt/blob/10a1d39232428040561d9f5e943f61613360a1c4/packages/vite/src/vite.ts#L47