### PR TITLE
chore(deps): unpin `@vue/shared`

### DIFF
--- a/packages/nitro-server/package.json
+++ b/packages/nitro-server/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@nuxt/kit": "workspace:*",
     "@unhead/vue": "^3.1.8",
-    "@vue/shared": "3.5.39",
+    "@vue/shared": "^3.5.39",
     "consola": "^3.4.2",
     "defu": "^6.1.7",
     "destr": "^2.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -338,7 +338,7 @@ importers:
         specifier: ^3.1.8
         version: 3.1.8(@rspack/core@2.1.3(@swc/helpers@0.5.23))(crossws@0.4.6(srvx@0.11.22))(esbuild@0.28.1)(lightningcss@1.32.0)(rolldown@1.1.5)(rollup@4.62.2)(typescript@7.0.2)(vite@8.1.4)(vue@3.5.39(typescript@7.0.2))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.32.0))
       '@vue/shared':
-        specifier: 3.5.39
+        specifier: ^3.5.39
         version: 3.5.39
       consola:
         specifier: ^3.4.2


### PR DESCRIPTION
## Summary

- allow `@nuxt/nitro-server` to receive compatible `@vue/shared` updates
- keep the currently resolved `3.5.39` version in the lockfile
- leave `@nuxt/ui-templates` pinned

## Validation

- `corepack pnpm install --lockfile-only --frozen-lockfile=false`
- pnpm lockfile supply-chain policy check

---

*This pull request was created with assistance from a code agent.*