### PR TITLE
refactor(kit,vite,webpack,nitro,schema): `ssrStyles` build output => lazy code provider

### DIFF
--- a/docs/4.api/5.kit/14.builder.md
+++ b/docs/4.api/5.kit/14.builder.md
@@ -347,7 +347,7 @@ function setBuildOutput<K extends keyof NuxtBuildOutputs> (key: K, provider: Nux
 
 **`key`**: The build output key. One of `serverEntry`, `clientManifest`, `clientPrecomputed`, `ssrStyles`, `entryChunkName` or `entryIds`.
 
-**`provider`**: The value for that key. For every key except `ssrStyles` this is a (possibly async) function returning the module body as a string, read lazily when the server build resolves the corresponding `nuxt/*` import. For `ssrStyles` it is an absolute path to the emitted per-component styles map, or `undefined` when the build produces no inline styles.
+**`provider`**: The value for that key: a (possibly async) function returning the module body as a string, read lazily when the server build resolves the corresponding `nuxt/*` import.
 
 ### Examples
 
@@ -360,6 +360,6 @@ setBuildOutput('serverEntry', () => `export { default } from ${JSON.stringify(se
 // Provide the serialized client manifest.
 setBuildOutput('clientManifest', () => `export default ${serializedManifest}`)
 
-// Point `nuxt/styles` at the emitted styles map (a path, not code).
-setBuildOutput('ssrStyles', resolve(serverDir, 'styles.mjs'))
+// Re-export the emitted per-component styles map for `nuxt/styles`.
+setBuildOutput('ssrStyles', () => `export { default } from ${JSON.stringify(pathToFileURL(resolve(serverDir, 'styles.mjs')).href)}`)
 ```

--- a/packages/kit/src/build.ts
+++ b/packages/kit/src/build.ts
@@ -1,6 +1,6 @@
 import type { Configuration as WebpackConfig, WebpackPluginInstance } from 'webpack'
 import type { UserConfig as ViteConfig, Plugin as VitePlugin } from 'vite'
-import type { NuxtBuildOutputs } from '@nuxt/schema'
+import type { Nuxt, NuxtBuildOutputs } from '@nuxt/schema'
 import { useNuxt } from './context.ts'
 import { toArray } from './utils.ts'
 import { resolveAlias } from './resolve.ts'
@@ -235,7 +235,6 @@ export function addBuildPlugin (pluginFactory: AddBuildPluginFactory, options?: 
 /**
  * Set the build output for the given key. See {@link NuxtBuildOutputs}.
  */
-export function setBuildOutput<K extends keyof NuxtBuildOutputs> (key: K, provider: NuxtBuildOutputs[K]): void {
-  const nuxt = useNuxt()
+export function setBuildOutput<K extends keyof NuxtBuildOutputs> (key: K, provider: NuxtBuildOutputs[K], nuxt: Nuxt = useNuxt()): void {
   nuxt.buildOutputs[key] = provider
 }

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -519,15 +519,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
     if (specifier === 'nuxt/entry-chunk' || specifier === 'nuxt/entry-ids') {
       continue // already registered above in the virtual block
     }
-    nitroConfig.virtual![specifier] = () => {
-      const provider = nuxt.buildOutputs[key]
-      if (key === 'ssrStyles') {
-        return provider
-          ? `export { default } from ${JSON.stringify(pathToFileURL(provider as string).href)}`
-          : 'export default {}'
-      }
-      return (provider as () => string | Promise<string>)()
-    }
+    nitroConfig.virtual![specifier] = () => nuxt.buildOutputs[key]()
   }
 
   const nitroDecoratorSetup = new WeakMap<NitroConfig, Promise<void>>()

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -81,7 +81,7 @@ export function createNuxt (options: NuxtOptions): Nuxt {
     vfs: {},
     apps: {},
     buildOutputs: {
-      ssrStyles: undefined,
+      ssrStyles: () => 'export default {}',
       serverEntry: () => `export default () => { throw new Error('[nuxt] nuxt/entry was not replaced by a builder. Ensure a Nuxt builder (Vite, Webpack, or Rspack) is configured.') }`,
       clientManifest: () => 'export default {}',
       clientPrecomputed: () => 'export default undefined',

--- a/packages/schema/src/types/nuxt.ts
+++ b/packages/schema/src/types/nuxt.ts
@@ -89,15 +89,17 @@ export interface NuxtApp {
 /**
  * Build artifacts consumed by the Nitro server runtime via `nuxt/*` subpath imports.
  *
- * Builders populate this with the `setBuildOutput()` kit helper. Function-valued
- * keys return the module body as a string; `ssrStyles` is an absolute path to an
- * emitted module whose own imports resolve relative to its location.
+ * Builders populate this with the `setBuildOutput()` kit helper. Each key is a
+ * (possibly async) function returning the module body as a string.
  */
 export interface NuxtBuildOutputs {
   /** Module body re-exporting the SSR app entry. */
   serverEntry: () => string | Promise<string>
-  /** Path to the emitted per-component SSR styles map, or `undefined` when no inline styles are produced. */
-  ssrStyles: string | undefined
+  /**
+   * Module body for the per-component SSR styles map. Defaults to
+   * `export default {}` when the build produces no inline styles.
+   */
+  ssrStyles: () => string | Promise<string>
   /** Serialized client manifest for `vue-bundle-renderer`. */
   clientManifest: () => string | Promise<string>
   /** Serialized precomputed client dependency data for `vue-bundle-renderer`. */

--- a/packages/vite/src/plugins/ssr-styles.ts
+++ b/packages/vite/src/plugins/ssr-styles.ts
@@ -1,3 +1,4 @@
+import { pathToFileURL } from 'node:url'
 import type { Plugin } from 'vite'
 import { dirname, relative, resolve } from 'pathe'
 import { genArrayFromRaw, genImport, genObjectFromRawEntries } from 'knitwork'
@@ -100,7 +101,7 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
       }
     }
 
-    setBuildOutput('entryIds', () => `export default ${JSON.stringify(Array.from(entryIds))}`)
+    setBuildOutput('entryIds', () => `export default ${JSON.stringify(Array.from(entryIds))}`, nuxt)
   })
 
   const cssMap: Record<string, { files: string[], inBundle?: boolean, cssIds?: Set<string> }> = {}
@@ -156,7 +157,8 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
         enforce: 'pre',
         buildStart () {
           if (this.environment.name === 'ssr') {
-            setBuildOutput('ssrStyles', resolve(this.environment.config.build.outDir, 'styles.mjs'))
+            const stylesPath = resolve(this.environment.config.build.outDir, 'styles.mjs')
+            setBuildOutput('ssrStyles', () => `export { default } from ${JSON.stringify(pathToFileURL(stylesPath).href)}`, nuxt)
           }
         },
         resolveId: {

--- a/packages/webpack/src/plugins/ssr-styles.ts
+++ b/packages/webpack/src/plugins/ssr-styles.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
+import { pathToFileURL } from 'node:url'
 import process from 'node:process'
 import { isAbsolute, normalize, relative, resolve } from 'pathe'
 import { withTrailingSlash } from 'ufo'
@@ -344,10 +345,11 @@ export class SSRStylesPlugin {
       ].join('\n')
 
       compilation.emitAsset('styles.mjs', new rawSource(stylesSource))
-      setBuildOutput('ssrStyles', resolve(this.nuxt.options.buildDir, 'dist/server/styles.mjs'))
+      const stylesPath = resolve(this.nuxt.options.buildDir, 'dist/server/styles.mjs')
+      setBuildOutput('ssrStyles', () => `export { default } from ${JSON.stringify(pathToFileURL(stylesPath).href)}`, this.nuxt)
 
       const entryIds = Array.from(this.chunksWithInlinedCSS).filter(id => entryModules.has(id))
-      setBuildOutput('entryIds', () => `export default ${JSON.stringify(entryIds)}`)
+      setBuildOutput('entryIds', () => `export default ${JSON.stringify(entryIds)}`, this.nuxt)
     })
   }
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this makes it consistent with the rest of the build outputs, and this is also what we need for the vite environment api