### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/packages/nitro-server/src/runtime/utils/cache-driver.mjs
+++ b/packages/nitro-server/src/runtime/utils/cache-driver.mjs
@@ -1,6 +1,8 @@
 // @ts-check
 
 import crypto from 'node:crypto'
+import { mkdir, rename, rm, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
 import fsDriver from 'unstorage/drivers/fs-lite'
 import lruCache from 'unstorage/drivers/lru-cache'
 
@@ -15,18 +17,36 @@ function normalizeFsKey (item) {
 }
 
 /**
- * @param {{ base?: string }} opts
+ * @param {string} path
+ * @param {string | Uint8Array} value
+ */
+async function writeAtomically (path, value) {
+  const temporaryPath = `${path}.${crypto.randomUUID()}.tmp`
+  await mkdir(dirname(path), { recursive: true })
+  try {
+    await writeFile(temporaryPath, value, 'utf8')
+    await rename(temporaryPath, path)
+  } catch (error) {
+    await rm(temporaryPath, { force: true })
+    throw error
+  }
+}
+
+/**
+ * @param {{ base?: string, readOnly?: boolean }} options
  * @returns {import('unstorage').Driver} An unstorage driver that uses both LRU cache and file system, with LRU as the primary and file system as the fallback.
  */
-export default function cacheDriver (opts) {
-  const fs = fsDriver({ base: opts.base })
+export default function cacheDriver (options) {
+  const fs = fsDriver({ base: options.base })
   const lru = lruCache({ max: 1000 })
 
   return {
     ...fs, // fall back to file system - only the bottom three methods are used in renderer
-    async setItem (key, value, opts) {
-      await fs.setItem?.(normalizeFsKey(key), value, opts)
-      await lru.setItem?.(key, value, opts)
+    async setItem (key, value, setOptions) {
+      if (!options.readOnly) {
+        await writeAtomically(join(options.base, normalizeFsKey(key)), value)
+      }
+      await lru.setItem?.(key, value, setOptions)
     },
     async hasItem (key, opts) {
       return await lru.hasItem(key, opts) || await fs.hasItem(normalizeFsKey(key), opts)

--- a/packages/nitro-server/test/cache-driver.test.ts
+++ b/packages/nitro-server/test/cache-driver.test.ts
@@ -1,0 +1,31 @@
+import { mkdtemp, readdir, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import cacheDriver from '../src/runtime/utils/cache-driver.mjs'
+
+describe('prerender cache driver', () => {
+  const temporaryDirectories: string[] = []
+
+  afterEach(async () => {
+    await Promise.all(temporaryDirectories.splice(0).map(directory => rm(directory, { recursive: true, force: true })))
+  })
+
+  it('reads an atomically persisted value after it has been evicted from the LRU', async () => {
+    const base = await mkdtemp(join(tmpdir(), 'nuxt-prerender-cache-'))
+    temporaryDirectories.push(base)
+    const cache = cacheDriver({ base })
+
+    await cache.setItem('payload:page', 'first value')
+    await cache.setItem('payload:page', 'updated value')
+    for (let index = 0; index < 1000; index++) {
+      await cache.setItem(`payload:filler-${index}`, String(index))
+    }
+
+    expect(await cache.getItem('payload:page')).toBe('updated value')
+    expect(await readdir(base)).toHaveLength(1001)
+    expect((await readdir(base)).some(name => name.endsWith('.tmp'))).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- write prerender-cache files to a unique sibling temporary file before replacing the cached file
- keep the LRU update after the on-disk replacement, so a cache hit is not exposed until its fallback file is complete
- cover the disk fallback after LRU eviction and verify that temporary files are cleaned up

## Root cause

`unstorage`'s `fs-lite` driver writes directly to the destination path. When prerender cache entries are rewritten while another render falls back from the LRU to the file store, a reader can observe the file after truncation and before the write completes. The renderer then receives no cached payload and returns without a response.

Writing and renaming within the same directory makes the completed replacement visible as one filesystem operation, while preserving the existing normalized cache-key layout.

Fixes #35590.

## Validation

- `corepack pnpm@11.13.0 exec vitest run --project unit packages/nitro-server/test/cache-driver.test.ts`
- `corepack pnpm@11.13.0 exec eslint packages/nitro-server/src/runtime/utils/cache-driver.mjs packages/nitro-server/test/cache-driver.test.ts`
- `corepack pnpm@11.13.0 --filter @nuxt/nitro-server build`
- `corepack pnpm@11.13.0 dev:prepare`
- `git diff --check`
