### PR TITLE
ci: unlink issues from autoclosed PRs

### DIFF
--- a/.github/workflows/agent-scan.yml
+++ b/.github/workflows/agent-scan.yml
@@ -86,6 +86,14 @@ jobs:
               core.info('Possible-bot comment already exists - skipping comment.')
             }
 
+            const unlinkIssues = body => body?.replace(
+              /\b(close[sd]?|fix(?:e[sd])?|resolve[sd]?)(\s*:?\s*)(?=(?:[\w.-]+\/[\w.-]+)?#\d+|https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/issues\/\d+)/gi,
+              (_, keyword, separator) => {
+                const refs = keyword === keyword.toUpperCase() ? 'REFS' : keyword[0] === keyword[0].toUpperCase() ? 'Refs' : 'refs'
+                return `${refs}${separator}`
+              },
+            )
+
             if (shouldClose && issue.state === 'open' && !alreadyCommented) {
               await github.rest.pulls.update({
                 owner: context.repo.owner,
@@ -93,6 +101,7 @@ jobs:
                 pull_number: prNumber,
                 state: 'closed',
                 title: '🚨 unwelcome pr from bot 🚨',
+                body: unlinkIssues(issue.body),
               })
             }
 

--- a/.github/workflows/agent-scan.yml
+++ b/.github/workflows/agent-scan.yml
@@ -87,7 +87,7 @@ jobs:
             }
 
             const unlinkIssues = body => body?.replace(
-              /\b(close[sd]?|fix(?:e[sd])?|resolve[sd]?)(\s*:?\s*)(?=(?:[\w.-]+\/[\w.-]+)?#\d+|https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/issues\/\d+)/gi,
+              /\b(close[sd]?|fix(?:e[sd])?|resolve[sd]?)(\s*:?\s*)(?=(?:[\w.-]+\/[\w.-]+)?#\d+|GH-\d+|https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/issues\/\d+)/gi,
               (_, keyword, separator) => {
                 const refs = keyword === keyword.toUpperCase() ? 'REFS' : keyword[0] === keyword[0].toUpperCase() ? 'Refs' : 'refs'
                 return `${refs}${separator}`


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

autoclosing PRs doesn't auto unlink theses PRs from issues which results in a lot of noises when it comes to triaging issues or trying to taking on issues that doesn't have a PR yet.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
