### PR TITLE
fix(nuxt): apply `unctx` transform marker through `magic-string`

### DIFF
--- a/packages/nuxt/src/core/plugins/unctx.ts
+++ b/packages/nuxt/src/core/plugins/unctx.ts
@@ -36,8 +36,9 @@ export const UnctxTransformPlugin = (options: UnctxTransformPluginOptions) => cr
         if (!shouldTransform(code)) { return }
         const result = transform(code)
         if (result) {
+          result.magicString.prepend(TRANSFORM_MARKER)
           return {
-            code: TRANSFORM_MARKER + result.code,
+            code: result.magicString.toString(),
             map: options.sourcemap
               ? result.magicString.generateMap({ hires: true })
               : undefined,


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/35479

### 📚 Description

this resolves https://github.com/nuxt/nuxt/issues/35479 by using magic string to make the change, so the generated sourcemap is aware of it