### PR TITLE
fix(nitro): write prerender cache files atomically

### DIFF
--- a/packages/nitro-server/src/runtime/utils/cache-driver.mjs
+++ b/packages/nitro-server/src/runtime/utils/cache-driver.mjs
@@ -1,6 +1,8 @@
 // @ts-check
 
 import crypto from 'node:crypto'
+import { mkdir, rename, unlink, writeFile } from 'node:fs/promises'
+import { dirname, join, resolve } from 'node:path'
 import fsDriver from 'unstorage/drivers/fs-lite'
 import lruCache from 'unstorage/drivers/lru-cache'
 
@@ -15,17 +17,37 @@ function normalizeFsKey (item) {
 }
 
 /**
+ * Write `value` to `path` atomically so a concurrent reader never observes a
+ * truncated file: the payload is written to a unique sibling and renamed over
+ * the destination, which is a single filesystem operation.
+ * @param {string} path
+ * @param {string} value
+ */
+async function atomicWrite (path, value) {
+  await mkdir(dirname(path), { recursive: true })
+  const tmp = `${path}.${crypto.randomBytes(8).toString('hex')}.tmp`
+  try {
+    await writeFile(tmp, value, 'utf8')
+    await rename(tmp, path)
+  } catch (error) {
+    await unlink(tmp).catch(() => {})
+    throw error
+  }
+}
+
+/**
  * @param {{ base?: string }} opts
  * @returns {import('unstorage').Driver} An unstorage driver that uses both LRU cache and file system, with LRU as the primary and file system as the fallback.
  */
 export default function cacheDriver (opts) {
   const fs = fsDriver({ base: opts.base })
   const lru = lruCache({ max: 1000 })
+  const base = resolve(opts.base || '.')
 
   return {
     ...fs, // fall back to file system - only the bottom three methods are used in renderer
     async setItem (key, value, opts) {
-      await fs.setItem?.(normalizeFsKey(key), value, opts)
+      await atomicWrite(join(base, normalizeFsKey(key)), value)
       await lru.setItem?.(key, value, opts)
     },
     async hasItem (key, opts) {

--- a/packages/nitro-server/test/cache-driver.test.ts
+++ b/packages/nitro-server/test/cache-driver.test.ts
@@ -1,0 +1,39 @@
+import { mkdtemp, readdir, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import cacheDriver from '../src/runtime/utils/cache-driver.mjs'
+
+describe('cache-driver', () => {
+  let base: string
+
+  beforeEach(async () => {
+    base = await mkdtemp(join(tmpdir(), 'nuxt-cache-driver-'))
+  })
+
+  afterEach(async () => {
+    await rm(base, { recursive: true, force: true })
+  })
+
+  it('falls back to the on-disk store when the entry is not in the LRU', async () => {
+    const writer = cacheDriver({ base })
+    await writer.setItem!('/_payload.json', 'payload', {})
+
+    const reader = cacheDriver({ base })
+    expect(await reader.hasItem('/_payload.json', {})).toBe(true)
+    expect(await reader.getItem('/_payload.json', {})).toBe('payload')
+  })
+
+  it('leaves no temporary files behind after writing', async () => {
+    const driver = cacheDriver({ base })
+    await driver.setItem!('/_payload.json', 'payload', {})
+    await driver.setItem!('/_payload.json', 'updated', {})
+
+    const files = await readdir(base)
+    expect(files.some(file => file.endsWith('.tmp'))).toBe(false)
+    expect(files).toHaveLength(1)
+
+    const reader = cacheDriver({ base })
+    expect(await reader.getItem('/_payload.json', {})).toBe('updated')
+  })
+})

--- a/packages/nitro-server/test/cache-driver.test.ts
+++ b/packages/nitro-server/test/cache-driver.test.ts
@@ -1,7 +1,8 @@
+import { promises as fsp } from 'node:fs'
 import { mkdtemp, readdir, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import cacheDriver from '../src/runtime/utils/cache-driver.mjs'
 
 describe('cache-driver', () => {
@@ -35,5 +36,42 @@ describe('cache-driver', () => {
 
     const reader = cacheDriver({ base })
     expect(await reader.getItem('/_payload.json', {})).toBe('updated')
+  })
+
+  it('never exposes a partially written payload to concurrent readers', async () => {
+    const oldValue = 'old-complete-payload'
+    const newValue = 'new-complete-payload'
+
+    const writer = cacheDriver({ base })
+    await writer.setItem!('/_payload.json', oldValue, {})
+
+    const originalWriteFile = fsp.writeFile
+    let releaseWrite!: () => void
+    const writeStalled = new Promise<void>((resolve) => { releaseWrite = resolve })
+    let partialWritten!: () => void
+    const partialOnDisk = new Promise<void>((resolve) => { partialWritten = resolve })
+
+    // simulate a nonatomic write interrupted midway
+    const spy = vi.spyOn(fsp, 'writeFile').mockImplementation(async (path, data, options) => {
+      await originalWriteFile.call(fsp, path, String(data).slice(0, Math.floor(String(data).length / 2)), options as never)
+      partialWritten()
+      await writeStalled
+      return originalWriteFile.call(fsp, path, data, options as never)
+    })
+
+    try {
+      const write = writer.setItem!('/_payload.json', newValue, {})
+      await Promise.race([partialOnDisk, write])
+
+      const reader = cacheDriver({ base })
+      const observed = await reader.getItem('/_payload.json', {})
+      expect([oldValue, newValue, null]).toContain(observed)
+
+      releaseWrite()
+      await write
+    } finally {
+      releaseWrite()
+      spy.mockRestore()
+    }
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/35590

### 📚 Description

it was previously possible to read a file that was being written, as the file system operations in our payload cache weren't atomic.

this replaces the previous approach with an atomic approach (tmp file + renmae) which should resolve the issue