### PR TITLE
fix(nuxt): evict stale forwarded prefetch hints and fix key mismatch

### DIFF
--- a/packages/nuxt/src/app/plugins/payload.client.ts
+++ b/packages/nuxt/src/app/plugins/payload.client.ts
@@ -8,7 +8,7 @@ import { injectHead } from '../composables/head'
 
 import { appManifest as isAppManifestEnabled, prefetchPreloadTags, purgeCachedData } from '#build/nuxt.config.mjs'
 
-// track the active head entry per URL for forwarded preload hints
+// track the active head entry per path for forwarded preload hints
 interface ActiveHeadEntryLike { dispose: () => void }
 const forwardedPrefetchEntries = new Map<string, ActiveHeadEntryLike>()
 
@@ -17,16 +17,18 @@ const plugin: Plugin & ObjectPlugin = defineNuxtPlugin({
   setup (nuxtApp) {
     // Load payload after middleware & once final route is resolved
     const staticKeysToRemove = new Set<string>()
-    useRouter().beforeResolve(async (to, from) => {
-      if (to.path === from.path) { return }
-      if (prefetchPreloadTags) {
-        // drop forwarded `rel="prefetch" hints so they don't linger indefinitely.
-        const entry = forwardedPrefetchEntries.get(to.path)
-        if (entry) {
+    const router = useRouter()
+    if (prefetchPreloadTags) {
+      // drop forwarded `rel="prefetch" hints so they don't linger indefinitely.
+      router.afterEach(() => {
+        for (const entry of forwardedPrefetchEntries.values()) {
           entry.dispose()
-          forwardedPrefetchEntries.delete(to.path)
         }
-      }
+        forwardedPrefetchEntries.clear()
+      })
+    }
+    router.beforeResolve(async (to, from) => {
+      if (to.path === from.path) { return }
       const payload = await loadPayload(to.path)
       if (!payload) { return }
       if (purgeCachedData) {
@@ -48,11 +50,11 @@ const plugin: Plugin & ObjectPlugin = defineNuxtPlugin({
       // Load payload into cache
       const head = prefetchPreloadTags ? injectHead(nuxtApp) : null
       nuxtApp.hooks.hook('link:prefetch', async (url) => {
-        const { hostname } = new URL(url, window.location.href)
+        const { hostname, pathname } = new URL(url, window.location.href)
         if (hostname !== window.location.hostname) { return }
         // TODO: use preloadPayload instead once we can support preloading islands too
         const payload = await loadPayload(url).catch(() => { console.warn('[nuxt] Error preloading payload for', url) })
-        if (head && payload?.prefetchLinks?.length && !forwardedPrefetchEntries.has(url)) {
+        if (head && payload?.prefetchLinks?.length && !forwardedPrefetchEntries.has(pathname)) {
           const entry = head.push({
             link: payload.prefetchLinks.map((link: Record<string, string | boolean>) => {
               // downgrade preload (and modulepreload) to prefetch
@@ -60,7 +62,7 @@ const plugin: Plugin & ObjectPlugin = defineNuxtPlugin({
               return { ...rest, rel: 'prefetch' }
             }),
           })
-          forwardedPrefetchEntries.set(url, entry)
+          forwardedPrefetchEntries.set(pathname, entry)
         }
       })
       // `navigator.connection` (Network Information API) is widely supported in

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -2221,6 +2221,24 @@ describe.skipIf(isDev || isWindows)('prefetching', () => {
     await page.close()
   })
 
+  it.skipIf(!isTestingAppManifest)('should evict forwarded prefetch hints for routes that are never visited', async () => {
+    const { page } = await renderPage()
+
+    await gotoPath(page, '/prefetch')
+    await page.waitForFunction(
+      () => Array.from(document.head.querySelectorAll('link[rel="prefetch"]'))
+        .some(l => (l as HTMLLinkElement).href.endsWith('/public.svg')),
+    )
+
+    await page.evaluate(() => (window.useNuxtApp!() as unknown as { $router: { push: (to: string) => void } }).$router.push('/'))
+    await page.waitForFunction(
+      () => !Array.from(document.head.querySelectorAll('link[rel="prefetch"]'))
+        .some(l => (l as HTMLLinkElement).href.endsWith('/public.svg')),
+    )
+
+    await page.close()
+  })
+
   it('should not prefetch certain dynamic imports by default', async () => {
     const html = await $fetch<string>('/auth')
     // should not prefetch global components


### PR DESCRIPTION
### 🔗 Linked issue

resolves #35212

### 📚 Description

this cleans up the head after navigation - otherwise the DOM can grow indefinitely with prefetch links