### PR TITLE
feat(nuxt): add `useLayout` composable for accessing the resolved route layout

### DIFF
--- a/docs/4.api/2.composables/use-layout.md
+++ b/docs/4.api/2.composables/use-layout.md
@@ -1,0 +1,42 @@
+---
+title: "useLayout"
+description: useLayout returns the layout resolved for the current route.
+links:
+  - label: Source
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/nuxt/blob/main/packages/nuxt/src/app/composables/layout.ts
+    size: xs
+---
+
+::important
+This composable is available in Nuxt v4.5+.
+::
+
+## Description
+
+`useLayout` returns a computed ref with the layout resolved for the current route, using the same chain as [`<NuxtLayout>`](/docs/4.x/api/components/nuxt-layout): the page's `layout` meta first, then the `appLayout` set via [route rules](/docs/4.x/guide/concepts/rendering#hybrid-rendering), then `'default'`.
+
+Within a rendered `<NuxtLayout>` it reflects the enclosing layout; outside of one (for example in `app.vue`) it returns the layout that would be resolved for the current route.
+
+Unlike reading `route.meta.layout` directly, this accounts for a layout set through route rules and stays in sync as the route changes.
+
+## Example
+
+```vue [app.vue]
+<script setup lang="ts">
+const layout = useLayout();
+</script>
+
+<template>
+  <div>
+    <CommandPalette v-if="layout !== 'minimal'" />
+    <NuxtLayout>
+      <NuxtPage />
+    </NuxtLayout>
+  </div>
+</template>
+```
+
+## Return Values
+
+A read-only computed ref resolving to the layout name (a `string`), or `false` when the layout is disabled.

--- a/docs/4.api/2.composables/use-layout.md
+++ b/docs/4.api/2.composables/use-layout.md
@@ -24,7 +24,7 @@ Unlike reading `route.meta.layout` directly, this accounts for a layout set thro
 
 ```vue [app.vue]
 <script setup lang="ts">
-const layout = useLayout();
+const layout = useLayout()
 </script>
 
 <template>

--- a/packages/nuxt/src/app/components/injections.ts
+++ b/packages/nuxt/src/app/components/injections.ts
@@ -1,4 +1,4 @@
-import type { InjectionKey } from 'vue'
+import type { ComputedRef, InjectionKey } from 'vue'
 import type { RouteLocationNormalizedLoaded } from 'vue-router'
 
 export interface LayoutMeta {
@@ -6,5 +6,7 @@ export interface LayoutMeta {
 }
 
 export const LayoutMetaSymbol: InjectionKey<LayoutMeta> = Symbol('layout-meta')
+
+export const LayoutSymbol: InjectionKey<Readonly<ComputedRef<string | false>>> = Symbol('layout')
 
 export const PageRouteSymbol: InjectionKey<RouteLocationNormalizedLoaded> = Symbol('route')

--- a/packages/nuxt/src/app/components/nuxt-layout.ts
+++ b/packages/nuxt/src/app/components/nuxt-layout.ts
@@ -1,21 +1,18 @@
 import type { DefineComponent, ExtractPublicPropTypes, MaybeRef, PropType, VNode } from 'vue'
 import { Suspense, computed, defineComponent, h, inject, mergeProps, nextTick, onMounted, provide, shallowReactive, shallowRef, unref } from 'vue'
 import type { RouteLocationNormalizedLoaded } from 'vue-router'
-import type { NitroRouteRules } from 'nitro/types'
 
 import type { NuxtLayouts, PageMeta } from '../../pages/runtime/composables'
 
+import { resolveLayoutName } from '../composables/layout'
 import { useRoute, useRouter } from '../composables/router'
 import { useNuxtApp } from '../nuxt'
 import { _mergeTransitionProps, _wrapInTransition } from './utils'
-import { LayoutMetaSymbol, PageRouteSymbol } from './injections'
+import { LayoutMetaSymbol, LayoutSymbol, PageRouteSymbol } from './injections'
 
 import { useRoute as useVueRouterRoute } from '#build/pages'
 import layouts from '#build/layouts'
 import { appLayoutTransition as defaultLayoutTransition } from '#build/nuxt.config.mjs'
-import _routeRulesMatcher from '#build/route-rules.mjs'
-
-const routeRulesMatcher = _routeRulesMatcher as (path: string) => NitroRouteRules
 
 const LayoutLoader = defineComponent({
   name: 'LayoutLoader',
@@ -58,7 +55,7 @@ export default defineComponent({
 
     const layout = computed(() => {
       type LayoutName = keyof NuxtLayouts | false | 'default'
-      let layout: LayoutName = unref(props.name as LayoutName) ?? route?.meta.layout as string ?? routeRulesMatcher(route?.path).appLayout ?? 'default'
+      let layout = resolveLayoutName(route, props.name) as LayoutName
       if (layout && !(layout in layouts)) {
         if (import.meta.dev && layout !== 'default') {
           console.warn(`[nuxt] Invalid layout \`${layout}\` selected.`)
@@ -69,6 +66,8 @@ export default defineComponent({
       }
       return layout
     })
+
+    provide(LayoutSymbol, layout)
 
     const layoutRef = shallowRef()
     context.expose({ layoutRef })
@@ -170,7 +169,7 @@ const LayoutProvider = defineComponent({
     if (props.shouldProvide) {
       provide(LayoutMetaSymbol, {
         // When name=false, always return true so NuxtPage doesn't skip rendering
-        isCurrent: (route: RouteLocationNormalizedLoaded) => name === false || name === (route.meta.layout ?? routeRulesMatcher(route.path).appLayout ?? 'default'),
+        isCurrent: (route: RouteLocationNormalizedLoaded) => name === false || name === resolveLayoutName(route),
       })
     }
 

--- a/packages/nuxt/src/app/composables/index.ts
+++ b/packages/nuxt/src/app/composables/index.ts
@@ -26,6 +26,8 @@ export { useRequestURL } from './url'
 export { usePreviewMode } from './preview'
 // eslint-disable-next-line @typescript-eslint/no-deprecated
 export { useId } from './id'
+export { useLayout } from './layout'
+export type { LayoutName } from './layout'
 export { useRouteAnnouncer } from './route-announcer'
 export type { Politeness } from './route-announcer'
 export { useAnnouncer } from './announcer'

--- a/packages/nuxt/src/app/composables/layout.ts
+++ b/packages/nuxt/src/app/composables/layout.ts
@@ -1,0 +1,35 @@
+import type { ComputedRef } from 'vue'
+import { computed, inject, unref } from 'vue'
+import type { NitroRouteRules } from 'nitro/types'
+import type { RouteLocationNormalizedLoaded } from 'vue-router'
+
+import type { NuxtLayouts } from '../../pages/runtime/composables'
+import { LayoutSymbol } from '../components/injections'
+import { useRoute } from './router'
+
+import _routeRulesMatcher from '#build/route-rules.mjs'
+
+const routeRulesMatcher = _routeRulesMatcher as (path: string) => NitroRouteRules
+
+export type LayoutName = keyof NuxtLayouts | 'default' | false
+
+export function resolveLayoutName (route: Pick<RouteLocationNormalizedLoaded, 'meta' | 'path'> | undefined, name?: unknown): LayoutName {
+  return (unref(name) as LayoutName | null | undefined) ?? route?.meta.layout as LayoutName ?? routeRulesMatcher(route?.path ?? '/').appLayout as LayoutName ?? 'default'
+}
+
+/**
+ * Returns the layout rendered for the current route, resolved through the same chain as
+ * `<NuxtLayout>` (page `layout` meta, then the route rules `appLayout`, then `default`).
+ *
+ * Within a rendered `<NuxtLayout>` it reflects the enclosing layout; outside of one it
+ * returns the layout that would be resolved for the current route.
+ * @since 4.5.0
+ */
+export function useLayout (): Readonly<ComputedRef<LayoutName>> {
+  const injected = inject(LayoutSymbol, null)
+  if (injected) {
+    return injected
+  }
+  const route = useRoute()
+  return computed(() => resolveLayoutName(route))
+}

--- a/packages/nuxt/src/app/composables/layout.ts
+++ b/packages/nuxt/src/app/composables/layout.ts
@@ -28,7 +28,7 @@ export function resolveLayoutName (route: Pick<RouteLocationNormalizedLoaded, 'm
 export function useLayout (): Readonly<ComputedRef<LayoutName>> {
   const injected = inject(LayoutSymbol, null)
   if (injected) {
-    return injected
+    return injected as Readonly<ComputedRef<LayoutName>>
   }
   const route = useRoute()
   return computed(() => resolveLayoutName(route))

--- a/packages/nuxt/src/imports/presets.ts
+++ b/packages/nuxt/src/imports/presets.ts
@@ -102,6 +102,10 @@ const granularAppPresets: InlinePreset[] = [
     from: '#app/composables/preview',
   },
   {
+    imports: ['useLayout'],
+    from: '#app/composables/layout',
+  },
+  {
     imports: ['useRouteAnnouncer'],
     from: '#app/composables/route-announcer',
   },

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -108,6 +108,7 @@ describe('route rules', () => {
   it('should set layout defined in routeRules config', async () => {
     const html = await $fetch<string>('/route-rules/layout')
     expect(html).toContain('Custom Layout')
+    expect(html).toContain('useLayout: custom')
   })
 
   it('should not extract payload for `ssr: false` routes with useAsyncData (#34279)', async () => {

--- a/test/fixtures/basic/app/pages/route-rules/layout.vue
+++ b/test/fixtures/basic/app/pages/route-rules/layout.vue
@@ -1,5 +1,10 @@
+<script setup lang="ts">
+const layout = useLayout()
+</script>
+
 <template>
   <div>
     <div>Should use layout set in route-rules</div>
+    <div>useLayout: {{ layout }}</div>
   </div>
 </template>

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -130,6 +130,7 @@ describe('composables', () => {
       'useRouter',
       'useSeoMeta',
       'usePreviewMode',
+      'useLayout',
     ]
     expect(Object.keys(composables).sort()).toEqual([...new Set([...testedComposables, ...skippedComposables])].sort())
   })

--- a/test/nuxt/use-layout.test.ts
+++ b/test/nuxt/use-layout.test.ts
@@ -1,0 +1,38 @@
+/// <reference path="../fixtures/basic/.nuxt/nuxt.d.ts" />
+
+import { describe, expect, it } from 'vitest'
+import { defineComponent, h } from 'vue'
+import type { RouteLocationNormalizedLoaded } from 'vue-router'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { resolveLayoutName, useLayout } from '#app/composables/layout'
+
+function route (path: string, meta: Record<string, unknown> = {}) {
+  return { path, meta } as unknown as RouteLocationNormalizedLoaded
+}
+
+describe('resolveLayoutName', () => {
+  it('defaults to `default` when nothing is defined', () => {
+    expect(resolveLayoutName(route('/'))).toBe('default')
+  })
+
+  it('resolves the layout defined in route meta', () => {
+    expect(resolveLayoutName(route('/', { layout: 'from-meta' }))).toBe('from-meta')
+  })
+
+  it('prefers an explicit name over route meta', () => {
+    expect(resolveLayoutName(route('/', { layout: 'from-meta' }), 'explicit')).toBe('explicit')
+  })
+
+  it('keeps the layout disabled when set to `false`', () => {
+    expect(resolveLayoutName(route('/', { layout: false }))).toBe(false)
+  })
+})
+
+describe('useLayout', () => {
+  it('falls back to the layout resolved for the current route', async () => {
+    const wrapper = await mountSuspended(defineComponent({
+      setup: () => () => h('div', useLayout().value as string),
+    }))
+    expect(wrapper.text()).toBe('default')
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

resolves #34305

### 📚 Description

[I think it's the wrong approach/feature](https://github.com/nuxt/nuxt/issues/34305#issuecomment-4074762342) to write current layout on `route.meta.layout`, so instead if we expose the logic for detecting the layout of a current route, we can allow people to get this in a better way...