### PR TITLE
fix(nuxt): respect saved scroll position on same-page back navigation from hash

### DIFF
--- a/packages/nuxt/src/pages/runtime/router.options.ts
+++ b/packages/nuxt/src/pages/runtime/router.options.ts
@@ -18,7 +18,7 @@ export default <RouterConfig>{
     // Hash routes on the same page, no page hook is fired so resolve here
     if (to.path.replace(/\/$/, '') === from.path.replace(/\/$/, '')) {
       if (from.hash && !to.hash) {
-        return { left: 0, top: 0 }
+        return savedPosition ?? { left: 0, top: 0 }
       }
       if (to.hash) {
         return { el: to.hash, top: _getHashElementScrollMarginTop(to.hash), behavior: hashScrollBehaviour }


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/35588

### 📚 Description

In a scenario of same-page back navigation from a hash, we now first check whether there is a saved position before falling back to `{ left: 0, top: 0 }`.

port of https://github.com/nuxt/nuxt/pull/35608 to the 4.x branch