### PR TITLE
fix(schema): resolve Vite cache directory from workspace

### DIFF
--- a/packages/schema/src/config/vite.ts
+++ b/packages/schema/src/config/vite.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto'
+import { existsSync } from 'node:fs'
 import { relative, resolve } from 'pathe'
 import { defineResolvers } from '../utils/definition.ts'
 
@@ -117,15 +117,18 @@ export default defineResolvers({
           return val
         }
 
-        const [rootDir, workspaceDir] = await Promise.all([get('rootDir'), get('workspaceDir')])
-        const base = resolve(workspaceDir, 'node_modules/.cache/vite')
-        const relativeRoot = relative(workspaceDir, rootDir).replaceAll('\\', '/')
-        if (!relativeRoot || relativeRoot === '.') {
-          return base
+        const rootDir = await get('rootDir')
+        if (existsSync(resolve(rootDir, 'node_modules'))) {
+          return resolve(rootDir, 'node_modules/.cache/vite')
         }
 
-        const suffix = createHash('sha256').update(relativeRoot).digest('hex').slice(0, 8)
-        return resolve(base, suffix)
+        const workspaceDir = await get('workspaceDir')
+        const relativeRoot = relative(workspaceDir, rootDir)
+        if (!relativeRoot || relativeRoot.startsWith('..')) {
+          return resolve(rootDir, 'node_modules/.cache/vite')
+        }
+
+        return resolve(workspaceDir, 'node_modules/.cache/vite', relativeRoot)
       },
     },
   },

--- a/packages/schema/src/config/vite.ts
+++ b/packages/schema/src/config/vite.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { relative, resolve } from 'pathe'
 import { defineResolvers } from '../utils/definition.ts'
 
@@ -118,11 +119,12 @@ export default defineResolvers({
 
         const [rootDir, workspaceDir] = await Promise.all([get('rootDir'), get('workspaceDir')])
         const base = resolve(workspaceDir, 'node_modules/.cache/vite')
-        if (rootDir === workspaceDir) {
+        const relativeRoot = relative(workspaceDir, rootDir).replaceAll('\\', '/')
+        if (!relativeRoot || relativeRoot === '.') {
           return base
         }
 
-        const suffix = relative(workspaceDir, rootDir).replace(/[^\w.-]+/g, '_') || 'app'
+        const suffix = createHash('sha256').update(relativeRoot).digest('hex').slice(0, 8)
         return resolve(base, suffix)
       },
     },

--- a/packages/schema/src/config/vite.ts
+++ b/packages/schema/src/config/vite.ts
@@ -122,7 +122,7 @@ export default defineResolvers({
           return base
         }
 
-        const suffix = relative(workspaceDir, rootDir).replace(/[^a-zA-Z0-9._-]+/g, '_') || 'app'
+        const suffix = relative(workspaceDir, rootDir).replace(/[^\w.-]+/g, '_') || 'app'
         return resolve(base, suffix)
       },
     },

--- a/packages/schema/src/config/vite.ts
+++ b/packages/schema/src/config/vite.ts
@@ -1,4 +1,4 @@
-import { resolve } from 'pathe'
+import { relative, resolve } from 'pathe'
 import { defineResolvers } from '../utils/definition.ts'
 
 export default defineResolvers({
@@ -111,7 +111,20 @@ export default defineResolvers({
       },
     },
     cacheDir: {
-      $resolve: async (val, get) => typeof val === 'string' ? val : resolve(await get('rootDir'), 'node_modules/.cache/vite'),
+      $resolve: async (val, get) => {
+        if (typeof val === 'string') {
+          return val
+        }
+
+        const [rootDir, workspaceDir] = await Promise.all([get('rootDir'), get('workspaceDir')])
+        const base = resolve(workspaceDir, 'node_modules/.cache/vite')
+        if (rootDir === workspaceDir) {
+          return base
+        }
+
+        const suffix = relative(workspaceDir, rootDir).replace(/[^a-zA-Z0-9._-]+/g, '_') || 'app'
+        return resolve(base, suffix)
+      },
     },
   },
 })

--- a/packages/schema/test/vite-cache-dir.spec.ts
+++ b/packages/schema/test/vite-cache-dir.spec.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { describe, expect, it, vi } from 'vitest'
 import { applyDefaults } from 'untyped'
 import { resolve } from 'pathe'
@@ -9,6 +10,10 @@ vi.mock('node:fs', () => ({
   existsSync: (id: string) => id.endsWith('app'),
 }))
 
+function cacheSuffix (relativeRoot: string) {
+  return createHash('sha256').update(relativeRoot.replaceAll('\\', '/')).digest('hex').slice(0, 8)
+}
+
 describe('vite.cacheDir', () => {
   it('resolves under workspaceDir when rootDir matches workspaceDir', async () => {
     const result = await applyDefaults(NuxtConfigSchema, {
@@ -19,13 +24,28 @@ describe('vite.cacheDir', () => {
     expect(result.vite.cacheDir).toBe(resolve('/project', 'node_modules/.cache/vite'))
   })
 
-  it('appends a per-app suffix when rootDir is nested under workspaceDir', async () => {
+  it('appends a hashed per-app suffix when rootDir is nested under workspaceDir', async () => {
     const result = await applyDefaults(NuxtConfigSchema, {
       rootDir: '/project/src',
       workspaceDir: '/project',
     }) as unknown as NuxtOptions
 
-    expect(result.vite.cacheDir).toBe(resolve('/project', 'node_modules/.cache/vite', 'src'))
+    expect(result.vite.cacheDir).toBe(resolve('/project', 'node_modules/.cache/vite', cacheSuffix('src')))
+  })
+
+  it('uses distinct hashes for relative paths that would collide when sanitised', async () => {
+    const slash = await applyDefaults(NuxtConfigSchema, {
+      rootDir: '/project/apps/foo',
+      workspaceDir: '/project',
+    }) as unknown as NuxtOptions
+    const underscore = await applyDefaults(NuxtConfigSchema, {
+      rootDir: '/project/apps_foo',
+      workspaceDir: '/project',
+    }) as unknown as NuxtOptions
+
+    expect(slash.vite.cacheDir).toBe(resolve('/project', 'node_modules/.cache/vite', cacheSuffix('apps/foo')))
+    expect(underscore.vite.cacheDir).toBe(resolve('/project', 'node_modules/.cache/vite', cacheSuffix('apps_foo')))
+    expect(slash.vite.cacheDir).not.toBe(underscore.vite.cacheDir)
   })
 
   it('respects an explicit vite.cacheDir', async () => {

--- a/packages/schema/test/vite-cache-dir.spec.ts
+++ b/packages/schema/test/vite-cache-dir.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest'
+import { applyDefaults } from 'untyped'
+import { resolve } from 'pathe'
+
+import { NuxtConfigSchema } from '../src/index.ts'
+import type { NuxtOptions } from '../src/index.ts'
+
+vi.mock('node:fs', () => ({
+  existsSync: (id: string) => id.endsWith('app'),
+}))
+
+describe('vite.cacheDir', () => {
+  it('resolves under workspaceDir when rootDir matches workspaceDir', async () => {
+    const result = await applyDefaults(NuxtConfigSchema, {
+      rootDir: '/project',
+      workspaceDir: '/project',
+    }) as unknown as NuxtOptions
+
+    expect(result.vite.cacheDir).toBe(resolve('/project', 'node_modules/.cache/vite'))
+  })
+
+  it('appends a per-app suffix when rootDir is nested under workspaceDir', async () => {
+    const result = await applyDefaults(NuxtConfigSchema, {
+      rootDir: '/project/src',
+      workspaceDir: '/project',
+    }) as unknown as NuxtOptions
+
+    expect(result.vite.cacheDir).toBe(resolve('/project', 'node_modules/.cache/vite', 'src'))
+  })
+
+  it('respects an explicit vite.cacheDir', async () => {
+    const result = await applyDefaults(NuxtConfigSchema, {
+      rootDir: '/project/src',
+      workspaceDir: '/project',
+      vite: { cacheDir: '/custom/cache' },
+    }) as unknown as NuxtOptions
+
+    expect(result.vite.cacheDir).toBe('/custom/cache')
+  })
+})

--- a/packages/schema/test/vite-cache-dir.spec.ts
+++ b/packages/schema/test/vite-cache-dir.spec.ts
@@ -1,4 +1,3 @@
-import { createHash } from 'node:crypto'
 import { describe, expect, it, vi } from 'vitest'
 import { applyDefaults } from 'untyped'
 import { resolve } from 'pathe'
@@ -6,55 +5,67 @@ import { resolve } from 'pathe'
 import { NuxtConfigSchema } from '../src/index.ts'
 import type { NuxtOptions } from '../src/index.ts'
 
+const existingPaths = new Set<string>()
+
 vi.mock('node:fs', () => ({
-  existsSync: (id: string) => id.endsWith('app'),
+  existsSync: (id: string) => existingPaths.has(id),
 }))
 
-function cacheSuffix (relativeRoot: string) {
-  return createHash('sha256').update(relativeRoot.replaceAll('\\', '/')).digest('hex').slice(0, 8)
+async function resolveCacheDir (config: { rootDir: string, workspaceDir?: string, vite?: { cacheDir?: string } }) {
+  const result = await applyDefaults(NuxtConfigSchema, config) as unknown as NuxtOptions
+  return result.vite.cacheDir
 }
 
 describe('vite.cacheDir', () => {
   it('resolves under workspaceDir when rootDir matches workspaceDir', async () => {
-    const result = await applyDefaults(NuxtConfigSchema, {
+    expect(await resolveCacheDir({
       rootDir: '/project',
       workspaceDir: '/project',
-    }) as unknown as NuxtOptions
-
-    expect(result.vite.cacheDir).toBe(resolve('/project', 'node_modules/.cache/vite'))
+    })).toBe(resolve('/project', 'node_modules/.cache/vite'))
   })
 
-  it('appends a hashed per-app suffix when rootDir is nested under workspaceDir', async () => {
-    const result = await applyDefaults(NuxtConfigSchema, {
+  it('resolves under workspaceDir when nested rootDir has no node_modules', async () => {
+    expect(await resolveCacheDir({
       rootDir: '/project/src',
       workspaceDir: '/project',
-    }) as unknown as NuxtOptions
-
-    expect(result.vite.cacheDir).toBe(resolve('/project', 'node_modules/.cache/vite', cacheSuffix('src')))
+    })).toBe(resolve('/project', 'node_modules/.cache/vite/src'))
   })
 
-  it('uses distinct hashes for relative paths that would collide when sanitised', async () => {
-    const slash = await applyDefaults(NuxtConfigSchema, {
+  it('keeps per-app caches distinct for multiple apps in a workspace', async () => {
+    expect(await resolveCacheDir({
       rootDir: '/project/apps/foo',
       workspaceDir: '/project',
-    }) as unknown as NuxtOptions
-    const underscore = await applyDefaults(NuxtConfigSchema, {
+    })).toBe(resolve('/project', 'node_modules/.cache/vite/apps/foo'))
+    expect(await resolveCacheDir({
       rootDir: '/project/apps_foo',
       workspaceDir: '/project',
-    }) as unknown as NuxtOptions
+    })).toBe(resolve('/project', 'node_modules/.cache/vite/apps_foo'))
+  })
 
-    expect(slash.vite.cacheDir).toBe(resolve('/project', 'node_modules/.cache/vite', cacheSuffix('apps/foo')))
-    expect(underscore.vite.cacheDir).toBe(resolve('/project', 'node_modules/.cache/vite', cacheSuffix('apps_foo')))
-    expect(slash.vite.cacheDir).not.toBe(underscore.vite.cacheDir)
+  it('resolves under rootDir when it has its own node_modules', async () => {
+    existingPaths.add(resolve('/project/apps/foo', 'node_modules'))
+    try {
+      expect(await resolveCacheDir({
+        rootDir: '/project/apps/foo',
+        workspaceDir: '/project',
+      })).toBe(resolve('/project/apps/foo', 'node_modules/.cache/vite'))
+    } finally {
+      existingPaths.clear()
+    }
+  })
+
+  it('resolves under rootDir when workspaceDir is not an ancestor', async () => {
+    expect(await resolveCacheDir({
+      rootDir: '/project/src',
+      workspaceDir: '/project/src/nested',
+    })).toBe(resolve('/project/src', 'node_modules/.cache/vite'))
   })
 
   it('respects an explicit vite.cacheDir', async () => {
-    const result = await applyDefaults(NuxtConfigSchema, {
+    expect(await resolveCacheDir({
       rootDir: '/project/src',
       workspaceDir: '/project',
       vite: { cacheDir: '/custom/cache' },
-    }) as unknown as NuxtOptions
-
-    expect(result.vite.cacheDir).toBe('/custom/cache')
+    })).toBe('/custom/cache')
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #20527

### 📚 Description

Updates the default Vite `cacheDir` to resolve from `workspaceDir` instead of `rootDir`.

Previously, running Nuxt with a nested root (for example `nuxt dev ./src`) created a ghost cache directory at `src/node_modules/.cache/vite`. The cache is now stored under the workspace `node_modules`.

When `rootDir` differs from `workspaceDir`, a suffix derived from the relative root path is appended so apps in the same workspace keep isolated Vite caches.

Explicit `vite.cacheDir` values are still respected.

### ✅ Testing

Added unit tests in `packages/schema/test/vite-cache-dir.spec.ts` covering:

- `rootDir === workspaceDir` → `workspaceDir/node_modules/.cache/vite`
- nested `rootDir` (e.g. `./src`) → `workspaceDir/node_modules/.cache/vite/<suffix>`
- explicit `vite.cacheDir` override is preserved

```bash
pnpm exec vitest run packages/schema/test/vite-cache-dir.spec.ts --project unit