### PR TITLE
fix(nuxt): `NuxtLink` custom component name

### DIFF
--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -619,7 +619,7 @@ async function initNuxt (nuxt: Nuxt) {
 
   // Add <NuxtLink>
   addComponent({
-    name: 'NuxtLink',
+    name: nuxt.options.experimental.defaults.nuxtLink.componentName || 'NuxtLink',
     priority: 10, // built-in that we do not expect the user to override
     filePath: resolve(nuxt.options.appDir, 'components/nuxt-link'),
   })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1392,6 +1392,12 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/nuxt
 
+  test/fixtures/nuxt-link-component-name:
+    dependencies:
+      nuxt:
+        specifier: workspace:*
+        version: link:../../../packages/nuxt
+
   test/fixtures/runtime-compiler:
     dependencies:
       nuxt:

--- a/test/fixtures/nuxt-link-component-name/app/app.vue
+++ b/test/fixtures/nuxt-link-component-name/app/app.vue
@@ -1,0 +1,10 @@
+<template>
+  <div>
+    <NuxtLinkDefault
+      to="/about"
+      data-testid="renamed-link"
+    >
+      go to about
+    </NuxtLinkDefault>
+  </div>
+</template>

--- a/test/fixtures/nuxt-link-component-name/nuxt.config.ts
+++ b/test/fixtures/nuxt-link-component-name/nuxt.config.ts
@@ -1,0 +1,13 @@
+import { withMatrix } from '../../matrix'
+
+// Regression fixture for nuxt/nuxt#26718: `experimental.defaults.nuxtLink.componentName`
+// must rename the auto-imported NuxtLink component (registration honours the option).
+export default withMatrix({
+  experimental: {
+    defaults: {
+      nuxtLink: {
+        componentName: 'NuxtLinkDefault',
+      },
+    },
+  },
+})

--- a/test/fixtures/nuxt-link-component-name/package.json
+++ b/test/fixtures/nuxt-link-component-name/package.json
@@ -1,0 +1,13 @@
+{
+  "private": true,
+  "name": "fixture-nuxt-link-component-name",
+  "scripts": {
+    "build": "nuxt build"
+  },
+  "dependencies": {
+    "nuxt": "workspace:*"
+  },
+  "engines": {
+    "node": "^22.19.0 || ^24.11.0 || >=26.0.0"
+  }
+}

--- a/test/fixtures/nuxt-link-component-name/tsconfig.json
+++ b/test/fixtures/nuxt-link-component-name/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./.nuxt/tsconfig.app.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.server.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.shared.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.node.json"
+    }
+  ]
+}

--- a/test/nuxt-link-component-name.test.ts
+++ b/test/nuxt-link-component-name.test.ts
@@ -1,0 +1,25 @@
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { isWindows } from 'std-env'
+import { $fetch, setup } from '@nuxt/test-utils/e2e'
+
+import { isDev } from './matrix'
+
+await setup({
+  rootDir: fileURLToPath(new URL('./fixtures/nuxt-link-component-name', import.meta.url)),
+  dev: isDev,
+  server: true,
+  browser: false,
+  setupTimeout: (isWindows ? 360 : 120) * 1000,
+})
+
+describe('experimental.defaults.nuxtLink.componentName (#26718)', () => {
+  it('registers the auto-imported NuxtLink under the configured name', async () => {
+    const html = await $fetch<string>('/')
+    // <NuxtLinkDefault> only resolves (and renders an <a>) if the registration
+    // honoured `componentName`; otherwise the component is unresolved.
+    expect(html).toContain('data-testid="renamed-link"')
+    expect(html).toContain('href="/about"')
+    expect(html).toContain('go to about')
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

Fixes: #26718 

### 📚 Description

It was not possible to change the component name of `NuxtLink`.

### Test
Added fixture tests to test a custom `NuxtLink` name.
