### PR TITLE
fix(nitro): render `error.vue` for direct `/__nuxt_error` visits

### DIFF
--- a/packages/nitro-server/src/runtime/handlers/error.ts
+++ b/packages/nitro-server/src/runtime/handlers/error.ts
@@ -45,8 +45,9 @@ export default <NitroErrorHandler> async function errorhandler (error, event, { 
   // and content-security-policy (would disable JS execution in the error page)
   mergeHeaders(headers, new Headers(defaultRes.headers), new Set(), IGNORED_ERROR_HEADERS)
 
-  // Skip SSR error rendering if we're already inside one, to avoid recursion.
-  const isRenderingError = (event as H3Event).url?.pathname.startsWith('/__nuxt_error') || !!(event as H3Event).context.nuxt?.['~rendering-error']
+  // Recursion guard: only the internal error-render fetch sets this flag, so a
+  // direct `/__nuxt_error` request renders `error.vue` instead of the fallback (#20623).
+  const isRenderingError = !!(event as H3Event).context.nuxt?.['~rendering-error']
 
   if (!isRenderingError) {
     const eventContext = (event as H3Event).context

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1369,6 +1369,16 @@ describe('errors', () => {
     expect(error).not.toHaveProperty('url')
   })
 
+  it('renders the custom error page for a direct visit to the error route (#20623)', async () => {
+    const res = await fetch('/__nuxt_error', {
+      headers: {
+        accept: 'text/html',
+      },
+    })
+    expect(res.status).toBe(404)
+    expect(await res.text()).toContain('This is the error page 😱')
+  })
+
   it('should not recursively throw an error when there is an error rendering the error page', async () => {
     const res = await $fetch<string>('/', {
       headers: {


### PR DESCRIPTION
### 🔗 Linked issue

Fixes: #20623

### 📚 Description

The guard distinguished between "internal error render" and "external direct access" based on the URL. But both use `/__nuxt_error`; the fix switches to using the context flag that only the internal render sets, ensuring that external access renders `error.vue` normally.

### Tests
Added one test