### PR TITLE
fix(nuxt)!: require 'source' for keyed functions

### DIFF
--- a/packages/nuxt/src/compiler/module.ts
+++ b/packages/nuxt/src/compiler/module.ts
@@ -60,6 +60,7 @@ export default defineNuxtModule<Partial<NuxtCompilerOptions>>({
         alias: nuxt.options.alias,
         getAutoImports: () => unimport?.getImports() || Promise.resolve([]),
         appDir: nuxt.options.appDir,
+        requireSource: nuxt.options.future.compatibilityVersion >= 5,
         dev: nuxt.options.dev,
       }))
     })

--- a/packages/nuxt/src/compiler/module.ts
+++ b/packages/nuxt/src/compiler/module.ts
@@ -51,16 +51,14 @@ export default defineNuxtModule<Partial<NuxtCompilerOptions>>({
       // Maintained as a mutable list so HMR can add/remove entries
       normalizedKeyedFunctions = await Promise.all(nuxt.options.optimization.keyedComposables.map(async ({ source, ...rest }) => ({
         ...rest,
-        source: typeof source === 'string' ? await resolvePath(source, { fallbackToOriginal: true }) : source,
+        source: await resolvePath(source, { fallbackToOriginal: true }),
       })))
 
       addBuildPlugin(KeyedFunctionsPlugin({
         keyedFunctions: normalizedKeyedFunctions,
         getKeyedFunctions: () => normalizedKeyedFunctions,
         alias: nuxt.options.alias,
-        getAutoImports: () => unimport?.getImports() || Promise.resolve([]),
         appDir: nuxt.options.appDir,
-        requireSource: nuxt.options.future.compatibilityVersion >= 5,
         dev: nuxt.options.dev,
       }))
     })

--- a/packages/nuxt/src/compiler/plugins/keyed-functions.ts
+++ b/packages/nuxt/src/compiler/plugins/keyed-functions.ts
@@ -23,6 +23,14 @@ interface KeyedFunctionsOptions {
   getAutoImports: () => Promise<Import[]>
   // TODO: remove in Nuxt 5
   appDir: string
+  /**
+   * Whether `source` is required for every keyed function. When enabled, keyed functions
+   * registered without a `source` (or with a `RegExp` source) are no longer matched.
+   *
+   * Enabled by default with `compatibilityVersion: 5`.
+   */
+  // TODO: remove in Nuxt 5 (always behave as if `true`)
+  requireSource: boolean
   dev?: boolean
 }
 
@@ -193,14 +201,16 @@ export const KeyedFunctionsPlugin = (options: KeyedFunctionsOptions) => createUn
               }
             }
 
-            const backwardsCompatibleFnMeta = sourcesToMetas.get('') // functions without a source or with a regex fall under ''
-            if (backwardsCompatibleFnMeta?.source === undefined) {
-              const autoImportResolvedSource = stripExtension(resolveAlias(autoImportsToSources.get(localName) ?? ''))
-              if (autoImportResolvedSource === source) {
+            if (!options.requireSource) {
+              const backwardsCompatibleFnMeta = sourcesToMetas.get('') // functions without a source or with a regex fall under ''
+              if (backwardsCompatibleFnMeta?.source === undefined) {
+                const autoImportResolvedSource = stripExtension(resolveAlias(autoImportsToSources.get(localName) ?? ''))
+                if (autoImportResolvedSource === source) {
+                  return backwardsCompatibleFnMeta
+                }
+              } else if (backwardsCompatibleFnMeta.source instanceof RegExp && backwardsCompatibleFnMeta.source.test(source)) {
                 return backwardsCompatibleFnMeta
               }
-            } else if (backwardsCompatibleFnMeta.source instanceof RegExp && backwardsCompatibleFnMeta.source.test(source)) {
-              return backwardsCompatibleFnMeta
             }
 
             return
@@ -325,13 +335,13 @@ export const KeyedFunctionsPlugin = (options: KeyedFunctionsOptions) => createUn
                 && (
                   // the function is imported from the correct source when `source` is specified
                   (typeof fnMeta.source === 'string' && (stripExtension(fnMeta.source) === importSourceResolved))
-                  // TODO: remove the checks below in Nuxt 5
-                  // or the function is auto-imported when there is no source specified
-                  || (!fnMeta.source && stripExtension(_resolvePath(autoImportsToSources.get(parsedCall.name) ?? '')) === importSourceResolved)
-                  // or the specified function's source RegExp matches the import source
-                  || (fnMeta.source instanceof RegExp && fnMeta.source.test(importSourceResolved))
                   // or the function is from the Nuxt source (`#app` barrel export, for example)
                   || (typeof fnMeta.source === 'string' && fnMeta.source.startsWith(options.appDir))
+                  // TODO: remove the checks below in Nuxt 5
+                  // or the function is auto-imported when there is no source specified
+                  || (!options.requireSource && !fnMeta.source && stripExtension(_resolvePath(autoImportsToSources.get(parsedCall.name) ?? '')) === importSourceResolved)
+                  // or the specified function's source RegExp matches the import source
+                  || (!options.requireSource && fnMeta.source instanceof RegExp && fnMeta.source.test(importSourceResolved))
                 )
               )
               // or the function is defined in the current file, and we're considering the root level scope declaration

--- a/packages/nuxt/src/compiler/plugins/keyed-functions.ts
+++ b/packages/nuxt/src/compiler/plugins/keyed-functions.ts
@@ -10,7 +10,6 @@ import { ScopeTracker, type ScopeTrackerNode, parseAndWalk, walk } from 'oxc-wal
 import { buildDiagnostics, resolveAlias } from '@nuxt/kit'
 import type { KeyedFunction } from '@nuxt/schema'
 import type { ESTree } from 'rolldown/utils'
-import type { Import } from 'unimport'
 
 import { MACRO_QUERY_RE, NUXT_LIB_RE, STYLE_QUERY_RE, isWhitespace, stripExtension } from '../../utils.ts'
 import { type FunctionCallMetadata, parseStaticExportIdentifiers, parseStaticFunctionCall, processImports } from '../../core/utils/parse-utils.ts'
@@ -20,17 +19,7 @@ interface KeyedFunctionsOptions {
   getKeyedFunctions?: () => KeyedFunction[]
   alias: Record<string, string>
   // TODO: remove in Nuxt 5
-  getAutoImports: () => Promise<Import[]>
-  // TODO: remove in Nuxt 5
   appDir: string
-  /**
-   * Whether `source` is required for every keyed function. When enabled, keyed functions
-   * registered without a `source` (or with a `RegExp` source) are no longer matched.
-   *
-   * Enabled by default with `compatibilityVersion: 5`.
-   */
-  // TODO: remove in Nuxt 5 (always behave as if `true`)
-  requireSource: boolean
   dev?: boolean
 }
 
@@ -38,9 +27,6 @@ const stringTypes: Array<string | undefined> = ['Literal', 'TemplateLiteral']
 const SUPPORTED_EXT_RE = /^[^?]*\.(?:m?[jt]sx?|vue)(?:$|\?)/
 const SCRIPT_RE = /(?<=<script[^>]*>)[\s\S]*?(?=<\/script>)/i
 const NUXT_INJECTED_MARKER = '/* nuxt-injected */'
-
-// TODO: remove in Nuxt 5
-type BackwardsCompatibleKeyedFunction = Omit<KeyedFunction, 'source'> & { source?: KeyedFunction['source'] | RegExp }
 
 /**
  * Builds the lookup state from a list of keyed functions.
@@ -50,13 +36,13 @@ type BackwardsCompatibleKeyedFunction = Omit<KeyedFunction, 'source'> & { source
  * name mappings separately. The `source`s have resolved aliases and are without extensions.
  */
 function buildKeyedFunctionsState (keyedFunctions: KeyedFunction[]) {
-  const namesToSourcesToFunctionMeta = new Map<string, Map<string, BackwardsCompatibleKeyedFunction>>()
+  const namesToSourcesToFunctionMeta = new Map<string, Map<string, KeyedFunction>>()
   // filenames (without extension) of files that have a `default` keyed function export
   const defaultExportSources = new Set<string>()
 
   for (const f of keyedFunctions) {
     let functionName = f.name
-    const fnSource = typeof f.source === 'string' ? stripExtension(f.source) : ''
+    const fnSource = stripExtension(f.source)
 
     if (f.name === 'default') {
       const parsedSource = parse(f.source)
@@ -80,8 +66,7 @@ function buildKeyedFunctionsState (keyedFunctions: KeyedFunction[]) {
 
     sourcesToFunctionMeta.set(fnSource, {
       ...f,
-      // TODO: use only `fnSource` in Nuxt 5
-      source: typeof f.source === 'string' ? fnSource : f.source,
+      source: fnSource,
     })
   }
 
@@ -89,10 +74,7 @@ function buildKeyedFunctionsState (keyedFunctions: KeyedFunction[]) {
   const sources = new Set<string>()
   for (const sourcesToFunctionMeta of namesToSourcesToFunctionMeta.values()) {
     for (const f of sourcesToFunctionMeta.values()) {
-      // TODO: remove check in Nuxt 5 (keeping it at the moment for the case when there is a RegExp in `source`)
-      if (f.source && typeof f.source === 'string') {
-        sources.add(f.source)
-      }
+      sources.add(f.source)
     }
   }
 
@@ -132,7 +114,7 @@ export const KeyedFunctionsPlugin = (options: KeyedFunctionsOptions) => createUn
         // In production, use the static regex for performance.
         ...(!options.dev && { code: { include: state.codeIncludeRE } }),
       },
-      async handler (code, _id, meta?: unknown) {
+      handler (code, _id, meta?: unknown) {
         const { namesToSourcesToFunctionMeta, sources } = getState()
 
         // In dev mode, do an early return if no known composable names appear in the code
@@ -164,15 +146,11 @@ export const KeyedFunctionsPlugin = (options: KeyedFunctionsOptions) => createUn
           }
         }
 
-        const autoImports = await options.getAutoImports()
-        // auto-imported name -> source (without alias resolution and with extension)
-        const autoImportsToSources = new Map<string, string>(autoImports.map(i => [i.as || i.name, i.from]))
-
         /**
          * @param localName the local name of the function to get the meta for
          * @param source the resolved source of the function to get the meta for (needs to be WITHOUT EXTENSION)
          */
-        function getFunctionMetaByLocalName (localName: string, source: string): BackwardsCompatibleKeyedFunction | undefined {
+        function getFunctionMetaByLocalName (localName: string, source: string): KeyedFunction | undefined {
           if (!localName) { return }
           // check exports (higher priority)
           const exportedName = localNamesToExportedName.get(localName)
@@ -186,7 +164,6 @@ export const KeyedFunctionsPlugin = (options: KeyedFunctionsOptions) => createUn
               ? camelCase(parse(directImport.source).name)
               : directImport.originalName
 
-            // TODO: remove auto-import checks in Nuxt 5
             const sourcesToMetas = namesToSourcesToFunctionMeta.get(functionName)
             if (!sourcesToMetas) { return }
 
@@ -198,18 +175,6 @@ export const KeyedFunctionsPlugin = (options: KeyedFunctionsOptions) => createUn
               for (const [fnSource, meta] of sourcesToMetas) {
                 if (meta.name !== functionName || !fnSource.startsWith(options.appDir)) { continue }
                 return meta
-              }
-            }
-
-            if (!options.requireSource) {
-              const backwardsCompatibleFnMeta = sourcesToMetas.get('') // functions without a source or with a regex fall under ''
-              if (backwardsCompatibleFnMeta?.source === undefined) {
-                const autoImportResolvedSource = stripExtension(resolveAlias(autoImportsToSources.get(localName) ?? ''))
-                if (autoImportResolvedSource === source) {
-                  return backwardsCompatibleFnMeta
-                }
-              } else if (backwardsCompatibleFnMeta.source instanceof RegExp && backwardsCompatibleFnMeta.source.test(source)) {
-                return backwardsCompatibleFnMeta
               }
             }
 
@@ -270,7 +235,7 @@ export const KeyedFunctionsPlugin = (options: KeyedFunctionsOptions) => createUn
         function processKeyedFunction (
           walkContext: ThisParameterType<NonNullable<Parameters<typeof walk>[1]['enter']>>, // TODO: export type from `oxc-walker`
           node: ESTree.Node,
-          handler: (ctx: { parsedCall: FunctionCallMetadata, fnMeta: BackwardsCompatibleKeyedFunction }) => void,
+          handler: (ctx: { parsedCall: FunctionCallMetadata, fnMeta: KeyedFunction }) => void,
         ) {
           if (node.type !== 'CallExpression' && node.type !== 'ChainExpression') { return }
           const parsedCall = parseStaticFunctionCall(node, LOCAL_FUNCTION_NAMES_RE)
@@ -333,15 +298,11 @@ export const KeyedFunctionsPlugin = (options: KeyedFunctionsOptions) => createUn
                   )
                 )
                 && (
-                  // the function is imported from the correct source when `source` is specified
-                  (typeof fnMeta.source === 'string' && (stripExtension(fnMeta.source) === importSourceResolved))
+                  // the function is imported from the correct source
+                  stripExtension(fnMeta.source) === importSourceResolved
+                  // TODO: remove in Nuxt 5
                   // or the function is from the Nuxt source (`#app` barrel export, for example)
-                  || (typeof fnMeta.source === 'string' && fnMeta.source.startsWith(options.appDir))
-                  // TODO: remove the checks below in Nuxt 5
-                  // or the function is auto-imported when there is no source specified
-                  || (!options.requireSource && !fnMeta.source && stripExtension(_resolvePath(autoImportsToSources.get(parsedCall.name) ?? '')) === importSourceResolved)
-                  // or the specified function's source RegExp matches the import source
-                  || (!options.requireSource && fnMeta.source instanceof RegExp && fnMeta.source.test(importSourceResolved))
+                  || fnMeta.source.startsWith(options.appDir)
                 )
               )
               // or the function is defined in the current file, and we're considering the root level scope declaration
@@ -402,14 +363,14 @@ export const KeyedFunctionsPlugin = (options: KeyedFunctionsOptions) => createUn
                 case 'useState':
                   if (
                     stringTypes.includes(parsedCall.callExpression.arguments[0]?.type)
-                    && typeof fnMeta.source === 'string' && stripExtension(fnMeta.source) === stripExtension(resolveAlias('#app/composables/state', options.alias))
+                    && stripExtension(fnMeta.source) === stripExtension(resolveAlias('#app/composables/state', options.alias))
                   ) { return }
                   break
                 case 'useFetch':
                 case 'useLazyFetch':
                   if (
                     stringTypes.includes(parsedCall.callExpression.arguments[1]?.type)
-                    && typeof fnMeta.source === 'string' && stripExtension(fnMeta.source) === stripExtension(resolveAlias('#app/composables/fetch', options.alias))
+                    && stripExtension(fnMeta.source) === stripExtension(resolveAlias('#app/composables/fetch', options.alias))
                   ) { return }
                   break
 
@@ -417,7 +378,7 @@ export const KeyedFunctionsPlugin = (options: KeyedFunctionsOptions) => createUn
                 case 'useLazyAsyncData':
                   if (
                     stringTypes.includes(parsedCall.callExpression.arguments[0]?.type)
-                    && typeof fnMeta.source === 'string' && stripExtension(fnMeta.source) === stripExtension(resolveAlias('#app/composables/asyncData', options.alias))
+                    && stripExtension(fnMeta.source) === stripExtension(resolveAlias('#app/composables/asyncData', options.alias))
                   ) { return }
                   break
               }

--- a/packages/nuxt/test/keyed-functions.test.ts
+++ b/packages/nuxt/test/keyed-functions.test.ts
@@ -15,6 +15,7 @@ describe('keyed functions plugin - reactive getter (dev mode)', () => {
       alias: {},
       getAutoImports: () => Promise.resolve([]),
       appDir: '/nuxt/dist/app/',
+      requireSource: false,
       dev: true,
     }).raw({}, {} as any) as {
       transform: { handler: (code: string, id: string) => Promise<{ code: string } | null> }
@@ -53,6 +54,7 @@ useNewComposable()
       alias: {},
       getAutoImports: () => Promise.resolve([]),
       appDir: '/nuxt/dist/app/',
+      requireSource: false,
       dev: true,
     }).raw({}, {} as any) as {
       transform: { handler: (code: string, id: string) => Promise<{ code: string } | null> }
@@ -81,6 +83,7 @@ useExisting()
       alias: {},
       getAutoImports: () => Promise.resolve([]),
       appDir: '/nuxt/dist/app/',
+      requireSource: false,
       dev: false,
     }).raw({}, {} as any) as {
       transform: { filter: { code?: { include: RegExp } }, handler: (code: string, id: string) => Promise<{ code: string } | null> }
@@ -151,7 +154,7 @@ describe('keyed functions plugin', () => {
     },
   ]
 
-  const transformPlugin = KeyedFunctionsPlugin({ keyedFunctions, alias: {}, getAutoImports: () => Promise.resolve(autoImports), appDir: '/nuxt/dist/app/' }).raw({}, {} as any) as { transform: { handler: (code: string, id: string) => Promise<{ code: string } | null> } }
+  const transformPlugin = KeyedFunctionsPlugin({ keyedFunctions, alias: {}, getAutoImports: () => Promise.resolve(autoImports), appDir: '/nuxt/dist/app/', requireSource: false }).raw({}, {} as any) as { transform: { handler: (code: string, id: string) => Promise<{ code: string } | null> } }
 
   it('should add hash when there is none already provided', async () => {
     const code = `
@@ -238,7 +241,7 @@ useRenamedDefault()`
 
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
-    KeyedFunctionsPlugin({ keyedFunctions, alias: {}, getAutoImports: () => Promise.resolve(autoImports), appDir: '/nuxt/dist/app/' }).raw({}, {} as any)
+    KeyedFunctionsPlugin({ keyedFunctions, alias: {}, getAutoImports: () => Promise.resolve(autoImports), appDir: '/nuxt/dist/app/', requireSource: false }).raw({}, {} as any)
 
     expect(warn).toHaveBeenCalledWith(expect.stringMatching(
       /Duplicate keyed function name `useKeyTwo`.* with the same source `#app` found\. Overwriting the existing entry\./,
@@ -883,6 +886,34 @@ pkg.app.useKey()
           useRegexKey('$HJiaryoL2y' /* nuxt-injected */)"
     `)
   })
+
+  describe('with `requireSource`', () => {
+    const strictPlugin = KeyedFunctionsPlugin({ keyedFunctions, alias: {}, getAutoImports: () => Promise.resolve(autoImports), appDir: '/nuxt/dist/app/', requireSource: true }).raw({}, {} as any) as { transform: { handler: (code: string, id: string) => Promise<{ code: string } | null> } }
+
+    it('should still inject keys for functions with a matching source', async () => {
+      const code = `
+import { useKey } from '#app'
+useKey()
+    `
+      expect((await strictPlugin.transform.handler(code, 'plugin.ts'))?.code).toContain('/* nuxt-injected */')
+    })
+
+    it('should not inject keys for auto-imported functions without a source', async () => {
+      const code = `
+    import { useAutoImported } from '#app'
+    useAutoImported()
+    `
+      expect(await strictPlugin.transform.handler(code, 'plugin.ts')).toBeUndefined()
+    })
+
+    it('should not inject keys for regex-matched function sources', async () => {
+      const code = `
+    import { useRegexKey } from 'some-regex-matched-source'
+    useRegexKey()
+    `
+      expect(await strictPlugin.transform.handler(code, 'plugin.ts')).toBeUndefined()
+    })
+  })
 })
 
 describe('core keyed functions', () => {
@@ -898,7 +929,7 @@ describe('core keyed functions', () => {
     { name: 'useLazyAsyncData', argumentLength: 3, source: '#app/composables/asyncData' },
     { name: 'useLazyFetch', argumentLength: 3, source: '#app/composables/fetch' },
   ]
-  const transformPlugin = KeyedFunctionsPlugin({ keyedFunctions, alias: {}, getAutoImports: () => Promise.resolve([]), appDir: '/nuxt/dist/app/' }).raw({}, {} as any) as { transform: { handler: (code: string, id: string) => Promise<{ code: string } | null> } }
+  const transformPlugin = KeyedFunctionsPlugin({ keyedFunctions, alias: {}, getAutoImports: () => Promise.resolve([]), appDir: '/nuxt/dist/app/', requireSource: false }).raw({}, {} as any) as { transform: { handler: (code: string, id: string) => Promise<{ code: string } | null> } }
 
   it('should detect string type keys and not add a hash', async () => {
     const code = `

--- a/packages/nuxt/test/keyed-functions.test.ts
+++ b/packages/nuxt/test/keyed-functions.test.ts
@@ -1,7 +1,6 @@
 import type { KeyedFunction } from '@nuxt/schema'
 import { describe, expect, it, vi } from 'vitest'
 import { KeyedFunctionsPlugin } from '../src/compiler/plugins/keyed-functions'
-import type { Import } from 'unimport'
 
 describe('keyed functions plugin - reactive getter (dev mode)', () => {
   it('should pick up dynamically added keyed functions', async () => {
@@ -13,9 +12,7 @@ describe('keyed functions plugin - reactive getter (dev mode)', () => {
       keyedFunctions,
       getKeyedFunctions: () => keyedFunctions,
       alias: {},
-      getAutoImports: () => Promise.resolve([]),
       appDir: '/nuxt/dist/app/',
-      requireSource: false,
       dev: true,
     }).raw({}, {} as any) as {
       transform: { handler: (code: string, id: string) => Promise<{ code: string } | null> }
@@ -52,9 +49,7 @@ useNewComposable()
       keyedFunctions,
       getKeyedFunctions: () => keyedFunctions,
       alias: {},
-      getAutoImports: () => Promise.resolve([]),
       appDir: '/nuxt/dist/app/',
-      requireSource: false,
       dev: true,
     }).raw({}, {} as any) as {
       transform: { handler: (code: string, id: string) => Promise<{ code: string } | null> }
@@ -81,9 +76,7 @@ useExisting()
       keyedFunctions,
       getKeyedFunctions: () => keyedFunctions,
       alias: {},
-      getAutoImports: () => Promise.resolve([]),
       appDir: '/nuxt/dist/app/',
-      requireSource: false,
       dev: false,
     }).raw({}, {} as any) as {
       transform: { filter: { code?: { include: RegExp } }, handler: (code: string, id: string) => Promise<{ code: string } | null> }
@@ -132,29 +125,9 @@ describe('keyed functions plugin', () => {
       source: 'composables/use-default-key.ts',
       argumentLength: 1,
     },
-    // TODO: remove entries without source in Nuxt 5
-    // @ts-expect-error - `source` wasn't required before
-    {
-      name: 'useAutoImported',
-      argumentLength: 1,
-    },
-    {
-      name: 'useRegexKey',
-      argumentLength: 1,
-      // @ts-expect-error - regex was supported before
-      source: /regex/,
-    },
   ]
 
-  const autoImports: Import[] = [
-    {
-      from: '#app',
-      name: 'useAutoImported',
-      as: 'useAutoImported',
-    },
-  ]
-
-  const transformPlugin = KeyedFunctionsPlugin({ keyedFunctions, alias: {}, getAutoImports: () => Promise.resolve(autoImports), appDir: '/nuxt/dist/app/', requireSource: false }).raw({}, {} as any) as { transform: { handler: (code: string, id: string) => Promise<{ code: string } | null> } }
+  const transformPlugin = KeyedFunctionsPlugin({ keyedFunctions, alias: {}, appDir: '/nuxt/dist/app/' }).raw({}, {} as any) as { transform: { handler: (code: string, id: string) => Promise<{ code: string } | null> } }
 
   it('should add hash when there is none already provided', async () => {
     const code = `
@@ -241,7 +214,7 @@ useRenamedDefault()`
 
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
-    KeyedFunctionsPlugin({ keyedFunctions, alias: {}, getAutoImports: () => Promise.resolve(autoImports), appDir: '/nuxt/dist/app/', requireSource: false }).raw({}, {} as any)
+    KeyedFunctionsPlugin({ keyedFunctions, alias: {}, appDir: '/nuxt/dist/app/' }).raw({}, {} as any)
 
     expect(warn).toHaveBeenCalledWith(expect.stringMatching(
       /Duplicate keyed function name `useKeyTwo`.* with the same source `#app` found\. Overwriting the existing entry\./,
@@ -861,59 +834,6 @@ pkg.app.useKey()
 
     expect((await transformPlugin.transform.handler(code, 'plugin.ts'))?.code.trim()).toMatchInlineSnapshot(`undefined`)
   })
-
-  // backwards compatibility
-  it('should inject keys for auto-imported functions', async () => {
-    const code = `
-    import { useAutoImported } from '#app'
-    useAutoImported()
-    `
-
-    expect((await transformPlugin.transform.handler(code, 'plugin.ts'))?.code.trim()).toMatchInlineSnapshot(`
-      "import { useAutoImported } from '#app'
-          useAutoImported('$HJiaryoL2y' /* nuxt-injected */)"
-    `)
-  })
-
-  it('should inject keys for regex-matched function sources', async () => {
-    const code = `
-    import { useRegexKey } from 'some-regex-matched-source'
-    useRegexKey()
-    `
-
-    expect((await transformPlugin.transform.handler(code, 'plugin.ts'))?.code.trim()).toMatchInlineSnapshot(`
-      "import { useRegexKey } from 'some-regex-matched-source'
-          useRegexKey('$HJiaryoL2y' /* nuxt-injected */)"
-    `)
-  })
-
-  describe('with `requireSource`', () => {
-    const strictPlugin = KeyedFunctionsPlugin({ keyedFunctions, alias: {}, getAutoImports: () => Promise.resolve(autoImports), appDir: '/nuxt/dist/app/', requireSource: true }).raw({}, {} as any) as { transform: { handler: (code: string, id: string) => Promise<{ code: string } | null> } }
-
-    it('should still inject keys for functions with a matching source', async () => {
-      const code = `
-import { useKey } from '#app'
-useKey()
-    `
-      expect((await strictPlugin.transform.handler(code, 'plugin.ts'))?.code).toContain('/* nuxt-injected */')
-    })
-
-    it('should not inject keys for auto-imported functions without a source', async () => {
-      const code = `
-    import { useAutoImported } from '#app'
-    useAutoImported()
-    `
-      expect(await strictPlugin.transform.handler(code, 'plugin.ts')).toBeUndefined()
-    })
-
-    it('should not inject keys for regex-matched function sources', async () => {
-      const code = `
-    import { useRegexKey } from 'some-regex-matched-source'
-    useRegexKey()
-    `
-      expect(await strictPlugin.transform.handler(code, 'plugin.ts')).toBeUndefined()
-    })
-  })
 })
 
 describe('core keyed functions', () => {
@@ -929,7 +849,7 @@ describe('core keyed functions', () => {
     { name: 'useLazyAsyncData', argumentLength: 3, source: '#app/composables/asyncData' },
     { name: 'useLazyFetch', argumentLength: 3, source: '#app/composables/fetch' },
   ]
-  const transformPlugin = KeyedFunctionsPlugin({ keyedFunctions, alias: {}, getAutoImports: () => Promise.resolve([]), appDir: '/nuxt/dist/app/', requireSource: false }).raw({}, {} as any) as { transform: { handler: (code: string, id: string) => Promise<{ code: string } | null> } }
+  const transformPlugin = KeyedFunctionsPlugin({ keyedFunctions, alias: {}, appDir: '/nuxt/dist/app/' }).raw({}, {} as any) as { transform: { handler: (code: string, id: string) => Promise<{ code: string } | null> } }
 
   it('should detect string type keys and not add a hash', async () => {
     const code = `


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/28642

### 📚 Description

this is a promised breaking change for v5 (which we don't think will affect many people! maybe some module authors)

but basically requires `source` to be passed when defining custom keyed composables

opened as a PR but if all looks good I'll cherry-pick the commits as the first one can be backported to 4.x