### PR TITLE
fix(nuxt): reset `NuxtErrorBoundary` error on navigation

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-error-boundary.vue
+++ b/packages/nuxt/src/app/components/nuxt-error-boundary.vue
@@ -12,8 +12,9 @@
 </template>
 
 <script setup lang="ts">
-import { onErrorCaptured, shallowRef } from 'vue'
+import { onErrorCaptured, shallowRef, watch } from 'vue'
 import { useNuxtApp } from '../nuxt'
+import { useRouter } from '../composables/router'
 import { onNuxtReady } from '../composables/ready'
 
 defineOptions({
@@ -58,6 +59,11 @@ if (import.meta.client) {
 
     return false
   })
+
+  // Recover the boundary on navigation. Uses the router's current route, not
+  // `useRoute()` (Suspense-synced, so stale while a page is erroring) (#15781).
+  const router = useRouter()
+  watch(() => router.currentRoute.value.fullPath, () => { clearError() })
 }
 
 defineExpose({ error, clearError })

--- a/test/nuxt/error-boundary.test.ts
+++ b/test/nuxt/error-boundary.test.ts
@@ -79,6 +79,6 @@ describe('NuxtErrorBoundary', () => {
     expect(el.html()).toContain('default')
 
     el.unmount()
-    vi.resetAllMocks()
+    vi.restoreAllMocks()
   })
 })

--- a/test/nuxt/error-boundary.test.ts
+++ b/test/nuxt/error-boundary.test.ts
@@ -48,4 +48,37 @@ describe('NuxtErrorBoundary', () => {
     el.unmount()
     vi.resetAllMocks()
   })
+
+  it('clears the error on navigation (#15781)', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    let thrown = false
+    const el = mount({
+      setup () {
+        return () => h('div', {}, h(NuxtErrorBoundary, {}, {
+          default: () => h(defineComponent({
+            setup () {
+              if (!thrown) {
+                thrown = true
+                throw new Error('test error')
+              }
+              return () => h('span', 'default')
+            },
+          })),
+          error: (
+            { error }: Parameters<InstanceType<typeof NuxtErrorBoundary>['$slots']['error']>[0],
+          ) => h('span', error.toString()),
+        }))
+      },
+    })
+    await nextTick()
+    expect(el.html()).toContain('Error: test error')
+
+    // Navigating away should reset the boundary error -> default slot renders again.
+    await useRouter().push('/?navigated=1')
+    await nextTick()
+    expect(el.html()).toContain('default')
+
+    el.unmount()
+    vi.resetAllMocks()
+  })
 })


### PR DESCRIPTION
### 🔗 Linked issue

Fixes: #15781 

### 📚 Description

Now we trigger `clearError() over `router.currentRoute` and all works as expected.

### Tests
Added a test for this
