### PR TITLE
fix(nuxt): guard `querySelectorAll` for non-element island fragment root

### DIFF
--- a/packages/nuxt/src/app/components/utils.ts
+++ b/packages/nuxt/src/app/components/utils.ts
@@ -132,7 +132,7 @@ export function getFragmentHTML (element: RendererNode | null, withoutSlots = fa
     }
     if (withoutSlots) {
       const clone = element.cloneNode(true)
-      clone.querySelectorAll('[data-island-slot]').forEach((n: Element) => { n.innerHTML = '' })
+      clone.querySelectorAll?.('[data-island-slot]').forEach((n: Element) => { n.innerHTML = '' })
       return [clone.outerHTML]
     }
     return [element.outerHTML]

--- a/test/nuxt/island-fragment-html.test.ts
+++ b/test/nuxt/island-fragment-html.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import { getFragmentHTML } from '../../packages/nuxt/src/app/components/utils'
+
+describe('getFragmentHTML', () => {
+  it('purges island slots from an element when withoutSlots is set', () => {
+    const el = document.createElement('div')
+    el.innerHTML = '<span data-island-slot="default">slot content</span>'
+
+    expect(getFragmentHTML(el, true)).toEqual([
+      '<div><span data-island-slot="default"></span></div>',
+    ])
+  })
+
+  // https://github.com/nuxt/nuxt/issues/31509 — a nested server component can
+  // leave `vnode.el` pointing at a node without `querySelectorAll` (e.g. a text
+  // or comment node), which used to throw `clone.querySelectorAll is not a function`.
+  it('does not throw for a non-element node when withoutSlots is set', () => {
+    const text = document.createTextNode('nested server component')
+    expect(() => getFragmentHTML(text, true)).not.toThrow()
+
+    const comment = document.createComment('anchor')
+    expect(() => getFragmentHTML(comment, true)).not.toThrow()
+  })
+})


### PR DESCRIPTION
Part of the Nuxtathon

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
Resolves #31509

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

Nested server components can leave `vnode.el` pointing at a non-element node (text/comment), whose clone has no `querySelectorAll`, throwing `clone.querySelectorAll is not a function`. Guard the call with optional chaining, matching the existing guard in `getFragmentChildren`.

PS: `test/nuxt/island-fragment-html.test.ts` was generated with a LLM

<img width="1493" height="723" alt="image" src="https://github.com/user-attachments/assets/f671eaa0-f87d-4532-b135-60bca9a5c7e9" />


<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
