### PR TITLE
test: run matrix-independent suites once across the fixture matrix

### DIFF
--- a/test/build-assets-dir-collision.test.ts
+++ b/test/build-assets-dir-collision.test.ts
@@ -3,9 +3,9 @@ import { describe, expect, it } from 'vitest'
 import { isWindows } from 'std-env'
 import { $fetch, setup } from '@nuxt/test-utils/e2e'
 
-import { builder, isDev } from './matrix'
+import { isDev, runsOncePerEnvInMatrix } from './matrix'
 
-if (builder === 'vite') {
+if (runsOncePerEnvInMatrix) {
   await setup({
     rootDir: fileURLToPath(new URL('./fixtures/build-assets-dir-collision', import.meta.url)),
     dev: isDev,
@@ -15,7 +15,7 @@ if (builder === 'vite') {
   })
 }
 
-describe.skipIf(builder !== 'vite')('buildAssetsDir collision with source dir (#24035)', () => {
+describe.skipIf(!runsOncePerEnvInMatrix)('buildAssetsDir collision with source dir (#24035)', () => {
   it('renders without crashing on SSR', async () => {
     const html = await $fetch<string>('/')
     expect(html).toContain('data-testid="hello"')

--- a/test/external-vue-resolution.test.ts
+++ b/test/external-vue-resolution.test.ts
@@ -1,17 +1,9 @@
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import { exec } from 'tinyexec'
+import { runsOnceInMatrix } from './matrix'
 
-// only run once across the fixture matrix
-const isMatrixRun = !!process.env.TEST_BUILDER
-const skipForMatrix = isMatrixRun && !(
-  process.env.TEST_BUILDER === 'vite'
-  && process.env.TEST_ENV === 'built'
-  && process.env.TEST_CONTEXT === 'default'
-  && process.env.TEST_MANIFEST === 'manifest-on'
-)
-
-describe.skipIf(skipForMatrix)('SSR vite resolve conditions', () => {
+describe.skipIf(!runsOnceInMatrix)('SSR vite resolve conditions', () => {
   const rootDir = fileURLToPath(new URL('./fixtures/external-vue-resolution', import.meta.url))
 
   it('resolves `vue` and `vue-router` from nuxt runtime files', async () => {

--- a/test/inline-styles.test.ts
+++ b/test/inline-styles.test.ts
@@ -3,9 +3,9 @@ import { fileURLToPath } from 'node:url'
 import { beforeAll, describe, expect, it } from 'vitest'
 import { exec } from 'tinyexec'
 import { join } from 'pathe'
-import { builder, isBuilt, projectSuffix } from './matrix'
+import { projectSuffix, runsOnceInMatrix } from './matrix'
 
-describe.skipIf(builder !== 'vite' || !isBuilt)('inline styles', () => {
+describe.skipIf(!runsOnceInMatrix)('inline styles', () => {
   const rootDir = fileURLToPath(new URL('./fixtures/inline-styles', import.meta.url))
 
   beforeAll(async () => {

--- a/test/matrix.ts
+++ b/test/matrix.ts
@@ -24,6 +24,22 @@ export const projectSuffix = [
   process.env.TEST_MANIFEST,
 ].filter(Boolean).join('-') || 'default'
 
+const isMatrixRun = !!process.env.TEST_BUILDER
+const isCanonicalCombo = builder === 'vite' && !asyncContext && isTestingAppManifest
+
+/**
+ * True in exactly one fixture-matrix project (vite/built/default/manifest-on), and always true
+ * outside the matrix. Guard suites that do not depend on any matrix axis with
+ * `describe.skipIf(!runsOnceInMatrix)` so they run a single time instead of once per project.
+ */
+export const runsOnceInMatrix = !isMatrixRun || (isCanonicalCombo && isBuilt)
+
+/**
+ * Like `runsOnceInMatrix` but keeps the dev/built axis: true in exactly one dev project and one
+ * built project.
+ */
+export const runsOncePerEnvInMatrix = !isMatrixRun || isCanonicalCombo
+
 export const isNuxtPrepare = process.argv.slice(2).includes('prepare')
 
 export function withMatrix (config: NuxtConfig) {

--- a/test/typed-router.test.ts
+++ b/test/typed-router.test.ts
@@ -3,12 +3,14 @@ import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { x } from 'tinyexec'
 import { describe, expect, it } from 'vitest'
+import { runsOnceInMatrix } from './matrix'
 
 const rootDir = fileURLToPath(new URL('./fixtures/basic-types', import.meta.url))
 
-describe('typed router integration', () => {
+describe.skipIf(!runsOnceInMatrix)('typed router integration', () => {
   it('does not duplicate params in RouteNamedMap when a child route overrides the path with an absolute path', async () => {
-    await x('nuxt', ['prepare', rootDir])
+    const r = await x('nuxt', ['prepare', rootDir])
+    expect(r.exitCode, r.stderr).toBe(0)
     const typedRouterDtsFile = resolve(rootDir, '.nuxt/types/typed-router.d.ts')
     const typedRouterDts = readFileSync(typedRouterDtsFile, 'utf8')
     // Check for the route definition (accommodates both single-line and multi-line formatting)
@@ -26,7 +28,8 @@ describe('typed router integration', () => {
     const readTypedRouterDts = () => readFileSync(resolve(rootDir, '.nuxt/types/typed-router.d.ts'), 'utf8')
 
     it('when prepared from a different cwd (nuxt prepare <rootDir>)', async () => {
-      await x('nuxt', ['prepare', rootDir])
+      const r = await x('nuxt', ['prepare', rootDir])
+      expect(r.exitCode, r.stderr).toBe(0)
       const dts = readTypedRouterDts()
       // rootDir-relative key present
       expect(dts).toMatch(/'app\/pages\/page\.vue':/)
@@ -35,7 +38,8 @@ describe('typed router integration', () => {
     })
 
     it('when prepared with cwd === rootDir', async () => {
-      await x('nuxt', ['prepare'], { nodeOptions: { cwd: rootDir } })
+      const r = await x('nuxt', ['prepare'], { nodeOptions: { cwd: rootDir } })
+      expect(r.exitCode, r.stderr).toBe(0)
       const dts = readTypedRouterDts()
       expect(dts).toMatch(/'app\/pages\/page\.vue':/)
       expect(dts).not.toMatch(/'[^']*fixtures\/basic-types\/[^']*\.vue':/)


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this makes test suites a little stabler by extracting some fixtures that don't need to be tested across bundlers/experimental options

cc: @posva 