### PR TITLE
test: reproduce duplicate CSS in shared chunks

### DIFF
--- a/packages/nitro-server/src/runtime/diagnostics.ts
+++ b/packages/nitro-server/src/runtime/diagnostics.ts
@@ -21,7 +21,7 @@ const docsBase = (code: string): string =>
 
 export const serverDiagnostics = /* #__PURE__ */ defineDiagnostics({
   docsBase,
-  // eslint-disable-next-line 
+  // eslint-disable-next-line
   reporters: [/* #__PURE__ */ (createConsoleReporter(import.meta.dev && process.env.NODE_ENV !== 'test' ? { formatter: ansiFormatter(colors) } : undefined))] as const,
   codes: {
     NUXT_E8001: {

--- a/test/fixtures/inline-styles/components/SharedBox.vue
+++ b/test/fixtures/inline-styles/components/SharedBox.vue
@@ -1,0 +1,9 @@
+<template>
+  <div class="shared-box" />
+</template>
+
+<style>
+.shared-box {
+  --inline-shared-box-token: shared-box;
+}
+</style>

--- a/test/fixtures/inline-styles/pages/shared-a.vue
+++ b/test/fixtures/inline-styles/pages/shared-a.vue
@@ -1,0 +1,6 @@
+<template>
+  <main>
+    shared a
+    <SharedBox />
+  </main>
+</template>

--- a/test/fixtures/inline-styles/pages/shared-b.vue
+++ b/test/fixtures/inline-styles/pages/shared-b.vue
@@ -1,0 +1,6 @@
+<template>
+  <main>
+    shared b
+    <SharedBox />
+  </main>
+</template>

--- a/test/inline-styles.test.ts
+++ b/test/inline-styles.test.ts
@@ -31,6 +31,17 @@ describe.skipIf(builder !== 'vite' || !isBuilt)('inline styles', () => {
     expect(cssLinks, page).toEqual([])
   })
 
+  // https://github.com/nuxt/nuxt/issues/35255
+  it.fails('drops duplicate stylesheet links for fully inlined CSS in a shared chunk', async () => {
+    for (const page of ['shared-a', 'shared-b']) {
+      const html = await readFile(join(outputDir, 'public', page, 'index.html'), 'utf-8')
+      expect(html, page).toContain('--inline-shared-box-token:shared-box')
+
+      const cssLinks = [...html.matchAll(/<link [^>]*rel="stylesheet"[^>]*href="([^"]+)"/g)].map(m => m[1]!)
+      expect(cssLinks, page).toEqual([])
+    }
+  })
+
   // https://github.com/nuxt/nuxt/issues/31558
   it('inlines CSS for a non-island child of a server component', async () => {
     const html = await readFile(join(outputDir, 'public', 'index.html'), 'utf-8')


### PR DESCRIPTION
### 🔗 Linked issue
https://github.com/nuxt/nuxt/issues/35255
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
This issue occurs when a shared chunk is generated. Since a proper fix will likely require further investigation, this PR first adds a failing regression test using `it.fails` to capture the current behavior.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
