### PR TITLE
feat(schema): case-sensitive routing by default in v5

### DIFF
--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -59,6 +59,7 @@ export default defineNuxtConfig({
 When you set your `future.compatibilityVersion` to `5`, defaults throughout your Nuxt configuration will change to opt in to Nuxt v5 behavior, including:
 
 - **Vite Environment API**: Uses the new [Vite Environment API](/docs/4.x/getting-started/upgrade#migration-to-vite-environment-api) for improved build configuration
+- **Case-sensitive routing**: Page routes [match URL casing exactly](/docs/4.x/getting-started/upgrade#case-sensitive-routing), consistent with Nitro
 - **Normalized Page Names**: Page component names will [match their route names](/docs/4.x/getting-started/upgrade#normalized-page-component-names) for consistent `<KeepAlive>` behavior
 - **`clearNuxtState` resets to defaults**: `clearNuxtState` will [reset state to its initial value](/docs/4.x/getting-started/upgrade#respect-defaults-when-clearing-usestate) instead of setting it to `undefined`
 - **Non-async `callHook`**: [`callHook` may return `void`](/docs/4.x/getting-started/upgrade#non-async-callhook) instead of always returning a `Promise`
@@ -71,6 +72,28 @@ This section is subject to change until the final release, so please check back 
 ::
 
 Breaking or significant changes will be noted below along with migration steps for backward/forward compatibility.
+
+### Case-Sensitive Routing
+
+🚦 **Impact Level**: Minimal
+
+#### What Changed
+
+With `compatibilityVersion: 5`, page routes match URLs case-sensitively, consistent with Nitro. For example, `/About` no longer matches `pages/about.vue`.
+
+#### Migration Steps
+
+Update links to use the same casing as their page routes. To keep case-insensitive matching:
+
+```ts twoslash [nuxt.config.ts]
+export default defineNuxtConfig({
+  router: {
+    options: {
+      sensitive: false,
+    },
+  },
+})
+```
 
 ### Migration to Vite Environment API
 

--- a/docs/3.guide/5.recipes/1.custom-routing.md
+++ b/docs/3.guide/5.recipes/1.custom-routing.md
@@ -137,6 +137,10 @@ export default defineNuxtConfig({
 })
 ```
 
+::note
+Since Nuxt 5, routing is **case-sensitive** by default (`sensitive: true`), which matches the behaviour of the Nitro server. Set `router.options.sensitive` to `false` to opt back into `vue-router`'s case-insensitive matching.
+::
+
 ### Hash Mode (SPA)
 
 You can enable hash history in SPA mode using the `hashMode` [config](/docs/4.x/api/nuxt-config#router). In this mode, router uses a hash character (#) before the actual URL that is internally passed. When enabled, the **URL is never sent to the server** and **SSR is not supported**.

--- a/docs/3.guide/5.recipes/1.custom-routing.md
+++ b/docs/3.guide/5.recipes/1.custom-routing.md
@@ -138,7 +138,7 @@ export default defineNuxtConfig({
 ```
 
 ::note
-Since Nuxt 5, routing is **case-sensitive** by default (`sensitive: true`), which matches the behaviour of the Nitro server. Set `router.options.sensitive` to `false` to opt back into `vue-router`'s case-insensitive matching.
+With `future.compatibilityVersion: 5`, routing is case-sensitive by default to match Nitro. Set `router.options.sensitive` to `false` to opt out.
 ::
 
 ### Hash Mode (SPA)

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -393,8 +393,9 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
       })
       return `
       import { defu } from 'defu'
+      import routerOptions from '#build/router.options.mjs'
       const matcher = ${matcher}
-      export default (path) => defu({}, ...matcher('', typeof path === 'string' ? path.toLowerCase() : path).map(r => r.data).reverse())
+      export default (path) => defu({}, ...matcher('', typeof path === 'string' && !routerOptions.sensitive ? path.toLowerCase() : path).map(r => r.data).reverse())
       `
     },
   })

--- a/packages/nuxt/src/app/composables/manifest.ts
+++ b/packages/nuxt/src/app/composables/manifest.ts
@@ -68,7 +68,7 @@ export function getRouteRules (url: string): Record<string, any>
 export function getRouteRules (arg: string | H3Event | { path: string }) {
   const path = typeof arg === 'string' ? arg : 'url' in arg ? arg.url.pathname : arg.path
   try {
-    return routeRulesMatcher(path.toLowerCase())
+    return routeRulesMatcher(path)
   } catch (e) {
     manifestDiagnostics.NUXT_E5003({ path, cause: e })
     return {}

--- a/packages/schema/src/config/router.ts
+++ b/packages/schema/src/config/router.ts
@@ -7,8 +7,6 @@ export default defineResolvers({
       scrollBehaviorType: 'auto',
       sensitive: {
         $resolve: async (val, get) => {
-          // vue-router is case-insensitive by default, which is at variance with nitro.
-          // Default to case-sensitive routing to avoid a class of bugs (breaking change in v5).
           return typeof val === 'boolean' ? val : (await get('future.compatibilityVersion')) >= 5
         },
       },

--- a/packages/schema/src/config/router.ts
+++ b/packages/schema/src/config/router.ts
@@ -5,6 +5,13 @@ export default defineResolvers({
     options: {
       hashMode: false,
       scrollBehaviorType: 'auto',
+      sensitive: {
+        $resolve: async (val, get) => {
+          // vue-router is case-insensitive by default, which is at variance with nitro.
+          // Default to case-sensitive routing to avoid a class of bugs (breaking change in v5).
+          return typeof val === 'boolean' ? val : (await get('future.compatibilityVersion')) >= 5
+        },
+      },
     },
   },
 })

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1765,7 +1765,7 @@ export interface ConfigSchema {
    * @note Only JSON serializable options should be passed by Nuxt config.
    * For more control, you can use `app/router.options.ts` file.
    *
-   * @note `sensitive` (case-sensitive routing) defaults to `true` with compatibilityVersion >= 5.
+   * @note `sensitive` defaults to `true` with `future.compatibilityVersion >= 5`.
    *
    * @see [Vue Router documentation](https://router.vuejs.org/api/interfaces/routeroptions)
    */

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1765,6 +1765,8 @@ export interface ConfigSchema {
    * @note Only JSON serializable options should be passed by Nuxt config.
    * For more control, you can use `app/router.options.ts` file.
    *
+   * @note `sensitive` (case-sensitive routing) defaults to `true` with compatibilityVersion >= 5.
+   *
    * @see [Vue Router documentation](https://router.vuejs.org/api/interfaces/routeroptions)
    */
     options: RouterConfigSerializable

--- a/packages/schema/test/router.spec.ts
+++ b/packages/schema/test/router.spec.ts
@@ -14,8 +14,8 @@ describe('router.options.sensitive default', () => {
     expect((result as unknown as NuxtOptions).router.options.sensitive).toBe(true)
   })
 
-  it('defaults to `false` for v3', async () => {
-    const result = await applyDefaults(NuxtConfigSchema, { future: { compatibilityVersion: 3 } })
+  it('defaults to `false` when compatibilityVersion is 4', async () => {
+    const result = await applyDefaults(NuxtConfigSchema, { future: { compatibilityVersion: 4 } })
     expect((result as unknown as NuxtOptions).router.options.sensitive).toBe(false)
   })
 
@@ -24,8 +24,8 @@ describe('router.options.sensitive default', () => {
     expect((result as unknown as NuxtOptions).router.options.sensitive).toBe(false)
   })
 
-  it('respects an explicit `true` value in v3', async () => {
-    const result = await applyDefaults(NuxtConfigSchema, { future: { compatibilityVersion: 3 }, router: { options: { sensitive: true } } })
+  it('respects an explicit `true` value in v4', async () => {
+    const result = await applyDefaults(NuxtConfigSchema, { future: { compatibilityVersion: 4 }, router: { options: { sensitive: true } } })
     expect((result as unknown as NuxtOptions).router.options.sensitive).toBe(true)
   })
 })

--- a/packages/schema/test/router.spec.ts
+++ b/packages/schema/test/router.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest'
+import { applyDefaults } from 'untyped'
+
+import { NuxtConfigSchema } from '../src/index.ts'
+import type { NuxtOptions } from '../src/index.ts'
+
+vi.mock('node:fs', () => ({
+  existsSync: (id: string) => id.endsWith('app'),
+}))
+
+describe('router.options.sensitive default', () => {
+  it('defaults to `true` when compatibilityVersion is 5', async () => {
+    const result = await applyDefaults(NuxtConfigSchema, { future: { compatibilityVersion: 5 } })
+    expect((result as unknown as NuxtOptions).router.options.sensitive).toBe(true)
+  })
+
+  it('defaults to `false` for v3', async () => {
+    const result = await applyDefaults(NuxtConfigSchema, { future: { compatibilityVersion: 3 } })
+    expect((result as unknown as NuxtOptions).router.options.sensitive).toBe(false)
+  })
+
+  it('respects an explicit `false` value in v5', async () => {
+    const result = await applyDefaults(NuxtConfigSchema, { future: { compatibilityVersion: 5 }, router: { options: { sensitive: false } } })
+    expect((result as unknown as NuxtOptions).router.options.sensitive).toBe(false)
+  })
+
+  it('respects an explicit `true` value in v3', async () => {
+    const result = await applyDefaults(NuxtConfigSchema, { future: { compatibilityVersion: 3 }, router: { options: { sensitive: true } } })
+    expect((result as unknown as NuxtOptions).router.options.sensitive).toBe(true)
+  })
+})

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -581,14 +581,17 @@ describe.skipIf(!isTestingAppManifest)('app manifests', () => {
       }
     `)
   })
-  it('matches case-insensitively to mirror vue-router defaults', () => {
-    expect(getRouteRules({ path: '/Pre/spa/thing' })).toMatchObject({
-      prerender: true,
-      ssr: false,
-    })
-    expect(getRouteRules({ path: '/PRE/test' })).toMatchObject({
-      redirect: '/',
-    })
+  it('matches route-rule casing consistently with vue-router', () => {
+    const spaRules = getRouteRules({ path: '/Pre/spa/thing' })
+    const redirectRules = getRouteRules({ path: '/PRE/test' })
+
+    if (process.env.PROJECT === 'nuxt-legacy') {
+      expect(spaRules).toMatchObject({ prerender: true, ssr: false })
+      expect(redirectRules).toMatchObject({ redirect: '/' })
+    } else {
+      expect(spaRules).not.toHaveProperty('prerender')
+      expect(redirectRules).not.toHaveProperty('redirect')
+    }
   })
 })
 
@@ -665,6 +668,12 @@ describe('routing utilities: `navigateTo`', () => {
   function waitForPageChange () {
     return vi.waitFor(() => new Promise<void>(resolve => nuxtApp.hooks.hookOnce('page:finish', () => resolve())))
   }
+
+  it('matches routes with compatibility-version casing', () => {
+    router.addRoute({ name: 'case-sensitive-test', path: '/case-sensitive-test', component: defineComponent({}) })
+    expect(router.resolve('/Case-Sensitive-Test').name === 'case-sensitive-test').toBe(process.env.PROJECT === 'nuxt-legacy')
+    router.removeRoute('case-sensitive-test')
+  })
 
   it('navigateTo should disallow navigation to external URLs by default', () => {
     expect(() => navigateTo('https://test.com')).toThrowErrorMatchingInlineSnapshot('[NUXT_E2001: NUXT_E2001]')


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
Resolves #35252
### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
In `packages/schema/src/config/router.ts,` sensitive now defaults to `true`, but only on Nuxt 5 (compatibilityVersion >= 5). On `v3/v4` it stays `false,` so nothing breaks for existing projects. Anyone can still override it.

Updated also the docs to reflect that (migration, and some notes)


I'm not sure about the docs (needed or not ? too verbose or not) nor the tests, a review may be needed.


<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
