### PR TITLE
docs: document nuxt-client caveat for non-SFC components

### DIFF
--- a/docs/2.directory-structure/1.app/1.components.md
+++ b/docs/2.directory-structure/1.app/1.components.md
@@ -524,6 +524,10 @@ You can partially hydrate a component by setting a `nuxt-client` attribute on th
 This only works within a server component. Slots for client components are working only with `experimental.componentIsland.selectiveClient` set to `'deep'` and since they are rendered server-side, they are not interactive once client-side.
 ::
 
+::warning
+Use `nuxt-client` only on local `.vue` SFCs. Built-ins like [`<NuxtLink>`](/docs/4.x/api/components/nuxt-link) skip the islands transform. After client navigation you may see `Failed to locate Teleport target`, or the link disappears with no error. Wrap the built-in in your own `.vue` file and put `nuxt-client` on that wrapper, or drop `nuxt-client` from the built-in. See [#29251](https://github.com/nuxt/nuxt/issues/29251) and [#26002](https://github.com/nuxt/nuxt/issues/26002).
+::
+
 #### Server Component Context
 
 When rendering a server-only or island component, `<NuxtIsland>` makes a fetch request which comes back with a `NuxtIslandResponse`. (This is an internal request if rendered on the server, or a request that you can see in the network tab if it's rendering on client-side navigation.)

--- a/docs/3.guide/6.going-further/1.experimental-features.md
+++ b/docs/3.guide/6.going-further/1.experimental-features.md
@@ -346,6 +346,10 @@ export default defineNuxtConfig({
 
 :read-more{to="/docs/4.x/directory-structure/app/components#server-components"}
 
+::note
+Skip `nuxt-client` on non-SFC components such as [`<NuxtLink>`](/docs/4.x/api/components/nuxt-link). See [Client components within server components](/docs/4.x/directory-structure/app/components#client-components-within-server-components).
+::
+
 ::read-more{icon="i-simple-icons-github" to="https://github.com/nuxt/nuxt/issues/19772" target="_blank"}
 You can follow the server components roadmap on GitHub.
 ::

--- a/docs/4.api/1.components/11.teleports.md
+++ b/docs/4.api/1.components/11.teleports.md
@@ -7,10 +7,6 @@ description: The <Teleport> component teleports a component to a different locat
 The `to` target of [`<Teleport>`](https://vuejs.org/guide/built-ins/teleport) expects a CSS selector string or an actual DOM node. Nuxt currently has SSR support for teleports to `#teleports` only, with client-side support for other targets using a `<ClientOnly>` wrapper.
 ::
 
-::note
-Island `nuxt-client` teleports are not body teleports to `#teleports`. See [Client components within server components](/docs/4.x/directory-structure/app/components#client-components-within-server-components) for the selective-client caveat.
-::
-
 ## Body Teleport
 
 ```vue

--- a/docs/4.api/1.components/11.teleports.md
+++ b/docs/4.api/1.components/11.teleports.md
@@ -7,6 +7,10 @@ description: The <Teleport> component teleports a component to a different locat
 The `to` target of [`<Teleport>`](https://vuejs.org/guide/built-ins/teleport) expects a CSS selector string or an actual DOM node. Nuxt currently has SSR support for teleports to `#teleports` only, with client-side support for other targets using a `<ClientOnly>` wrapper.
 ::
 
+::note
+Island `nuxt-client` teleports are not body teleports to `#teleports`. See [Client components within server components](/docs/4.x/directory-structure/app/components#client-components-within-server-components) for the selective-client caveat.
+::
+
 ## Body Teleport
 
 ```vue


### PR DESCRIPTION
With selectiveClient, `nuxt-client` only works on local `.vue` SFCs.

If you put it on something like `<NuxtLink>`, the islands transform skips it. After client navigation you can get `Failed to locate Teleport target`, or the link just disappears.

Docs now warn about that, show the SFC wrapper workaround, and link from Teleports + experimental features.

Fixes #29251
Refs #26002 (real fix for non-SFC still needed there)