### PR TITLE
docs: add a note for a workaround to issue 22351

### DIFF
--- a/docs/1.getting-started/14.layers.md
+++ b/docs/1.getting-started/14.layers.md
@@ -46,7 +46,7 @@ export default defineNuxtConfig({
 ```
 
 ::note
-Extending from a **local** layer whose directory name contains a `.` (for example `base.v2`) currently fails to resolve. As a workaround, add a trailing slash to the path:
+Extending from a **local** layer whose directory name contains a `.` (for example `base.v2`) currently fails to resolve with the error `Cannot find module`. As a workaround, add a trailing slash to the path:
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({

--- a/docs/1.getting-started/14.layers.md
+++ b/docs/1.getting-started/14.layers.md
@@ -45,6 +45,19 @@ export default defineNuxtConfig({
 })
 ```
 
+::note
+Extending from a **local** layer whose directory name contains a `.` (for example `base.v2`) currently fails to resolve. As a workaround, add a trailing slash to the path:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  extends: [
+    './base.v2/', // note the trailing slash
+  ],
+})
+```
+
+::
+
 You can also pass an authentication token if you are extending from a private GitHub repository:
 
 ```ts [nuxt.config.ts]


### PR DESCRIPTION
### 🔗 Linked issue

This issue #22351 is reproduceable with 4.4.8.  This PR does not close the issue but it adds a note to the docs with a workaround.

### 📚 Description

Using a directory name with a dot (.) in layers creates the error `Cannot find module `. 
There is a workaround using a trailing slash. This little note will hopefully help users to understand why and how. 

This note should be removed when #22351 is actually solved. 

