### PR TITLE
docs: clarify NuxtLink componentName is the internal (devtools) name

### DIFF
--- a/docs/4.api/1.components/4.nuxt-link.md
+++ b/docs/4.api/1.components/4.nuxt-link.md
@@ -340,7 +340,7 @@ export default defineNuxtLink({
 })
 ```
 
-You can then use `<MyNuxtLink />` component as usual with your new defaults.
+The component is auto-imported by its file name, so you can use `<MyNuxtLink />` as usual with your new defaults. `componentName` only sets the component's internal name (as shown in Vue DevTools); it does not change how the component is used in templates.
 
 ### `defineNuxtLink` Signature
 
@@ -361,7 +361,7 @@ interface NuxtLinkOptions {
 function defineNuxtLink (options: NuxtLinkOptions): Component {}
 ```
 
-- `componentName`: A name for the component. Default is `NuxtLink`.
+- `componentName`: The component's internal name, as shown in Vue DevTools. It does not change the name used in templates (that comes from the component's file name). Default is `NuxtLink`.
 - `externalRelAttribute`: A default `rel` attribute value applied on external links. Defaults to `"noopener noreferrer"`. Set it to `""` to disable
 - `activeClass`: A default class to apply on active links. Works the same as [Vue Router's `linkActiveClass` option](https://router.vuejs.org/api/interfaces/routeroptions#linkActiveClass-). Defaults to Vue Router's default (`"router-link-active"`)
 - `exactActiveClass`: A default class to apply on exact active links. Works the same as [Vue Router's `linkExactActiveClass` option](https://router.vuejs.org/api/interfaces/routeroptions#linkExactActiveClass-). Defaults to Vue Router's default (`"router-link-exact-active"`)


### PR DESCRIPTION
### 🔗 Linked issue

Resolves: #26718

closes  #35629

### 📚 Description

The docs fix clarifies that `componentName` is the internal/DevTools name and the template name is derived from the filename
