### PR TITLE
fix(nuxt): return global route for `useRoute` in detached effect scope

### DIFF
--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -1,4 +1,5 @@
-import { getCurrentInstance, hasInjectionContext, inject, onScopeDispose } from 'vue'
+import { getCurrentInstance, getCurrentScope, hasInjectionContext, inject, onScopeDispose } from 'vue'
+import type { ComponentInternalInstance, EffectScope } from 'vue'
 import type { NavigationFailure, NavigationGuard, RouteLocationNormalized, RouteLocationRaw, Router, useRoute as _useRoute, useRouter as _useRouter } from 'vue-router'
 import { sanitizeStatusCode } from '@nuxt/nitro-server/h3'
 import { decodePath, encodePath, hasProtocol, isScriptProtocol, joinURL, parseQuery, parseURL, withQuery } from 'ufo'
@@ -18,6 +19,22 @@ export const useRouter: typeof _useRouter = () => {
   return useNuxtApp()?.$router as unknown as Router
 }
 
+/**
+ * Whether the current effect scope is (a descendant of) the component instance's scope.
+ * A detached scope (e.g. `createSharedComposable`) outlives the component, so the
+ * per-page route injected there would freeze after navigation (#18903).
+ */
+function isScopeWithinInstance (instance: ComponentInternalInstance): boolean {
+  // `scope`/`parent` are internal, but stable across vue versions
+  const instanceScope = (instance as ComponentInternalInstance & { scope: EffectScope }).scope
+  let scope: (EffectScope & { parent?: EffectScope }) | undefined = getCurrentScope()
+  while (scope) {
+    if (scope === instanceScope) { return true }
+    scope = scope.parent
+  }
+  return false
+}
+
 /** @since 3.0.0 */
 export const useRoute: typeof _useRoute = (() => {
   if (import.meta.dev && !getCurrentInstance() && isProcessingMiddleware()) {
@@ -26,7 +43,10 @@ export const useRoute: typeof _useRoute = (() => {
     navigationDiagnostics.NUXT_E2005({ middleware: typeof middleware === 'string' ? middleware : undefined, trace })
   }
   if (hasInjectionContext()) {
-    return inject(PageRouteSymbol, useNuxtApp()._route)
+    const instance = getCurrentInstance()
+    if (!instance || isScopeWithinInstance(instance)) {
+      return inject(PageRouteSymbol, useNuxtApp()._route)
+    }
   }
   return useNuxtApp()._route
 }) as unknown as typeof _useRoute

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -54,7 +54,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(rootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!_libs'], serverDir, rootDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"38.2k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"38.4k"`)
 
     const modules = await analyzeSizes(['_libs/**/*'], serverDir, rootDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"232k"`)
@@ -89,7 +89,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(pagesRootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!_libs'], serverDir, pagesRootDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"82.2k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"82.4k"`)
 
     const modules = await analyzeSizes(['_libs/**/*'], serverDir, pagesRootDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"232k"`)

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -21,6 +21,7 @@ import { useLoadingIndicator } from '#app/composables/loading-indicator'
 import { useRouteAnnouncer } from '#app/composables/route-announcer'
 import { useAnnouncer } from '#app/composables/announcer'
 import { encodeRoutePath, encodeURL, resolveRouteObject } from '#app/composables/router'
+import { PageRouteSymbol } from '#app/components/injections'
 import { useRuntimeHook } from '#app/composables/runtime-hook'
 import { shouldLoadPayload } from '#app/composables/payload'
 import { NuxtPage } from '#components'
@@ -941,6 +942,35 @@ describe('routing utilities: `useRoute`', () => {
 
     el.unmount()
     router.removeRoute('parent-test')
+  })
+
+  it('should return the global route in a detached effect scope', async () => {
+    const pageRoute = shallowReactive({ path: '/page-route' }) as unknown as ReturnType<typeof useRoute>
+    let injectedRoute: ReturnType<typeof useRoute>
+    let childScopeRoute: ReturnType<typeof useRoute>
+    let detachedScopeRoute: ReturnType<typeof useRoute>
+
+    const el = await mountSuspended(defineComponent({
+      setup () {
+        provide(PageRouteSymbol, pageRoute)
+        return () => h(defineComponent({
+          setup () {
+            injectedRoute = useRoute()
+            childScopeRoute = effectScope().run(() => useRoute())!
+            detachedScopeRoute = effectScope(true).run(() => useRoute())!
+            return () => h('div')
+          },
+        }))
+      },
+    }))
+
+    expect(injectedRoute!).toBe(pageRoute)
+    expect(childScopeRoute!).toBe(pageRoute)
+    expect(detachedScopeRoute!).toBe(nuxtApp._route)
+
+    el.unmount()
+    // mounting without registered routes raises a 404 error
+    await clearError()
   })
 })
 

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -21,7 +21,6 @@ import { useLoadingIndicator } from '#app/composables/loading-indicator'
 import { useRouteAnnouncer } from '#app/composables/route-announcer'
 import { useAnnouncer } from '#app/composables/announcer'
 import { encodeRoutePath, encodeURL, resolveRouteObject } from '#app/composables/router'
-import { PageRouteSymbol } from '#app/components/injections'
 import { useRuntimeHook } from '#app/composables/runtime-hook'
 import { shouldLoadPayload } from '#app/composables/payload'
 import { NuxtPage } from '#components'
@@ -944,33 +943,50 @@ describe('routing utilities: `useRoute`', () => {
     router.removeRoute('parent-test')
   })
 
-  it('should return the global route in a detached effect scope', async () => {
-    const pageRoute = shallowReactive({ path: '/page-route' }) as unknown as ReturnType<typeof useRoute>
+  it('should update a route created in a detached scope across navigation', async () => {
+    // minimal `createSharedComposable` from the reproduction in #18903
+    let sharedRoute: ReturnType<typeof useRoute> | undefined
+    const useSharedRoute = () => (sharedRoute ||= effectScope(true).run(() => useRoute())!)
+
     let injectedRoute: ReturnType<typeof useRoute>
     let childScopeRoute: ReturnType<typeof useRoute>
-    let detachedScopeRoute: ReturnType<typeof useRoute>
 
-    const el = await mountSuspended(defineComponent({
-      setup () {
-        provide(PageRouteSymbol, pageRoute)
-        return () => h(defineComponent({
-          setup () {
-            injectedRoute = useRoute()
-            childScopeRoute = effectScope().run(() => useRoute())!
-            detachedScopeRoute = effectScope(true).run(() => useRoute())!
-            return () => h('div')
-          },
-        }))
-      },
-    }))
+    router.addRoute({
+      name: 'shared-a',
+      path: '/shared-a',
+      component: defineComponent({
+        template: '<div />',
+        setup: () => {
+          injectedRoute = useRoute()
+          childScopeRoute = effectScope().run(() => useRoute())!
+          useSharedRoute()
+        },
+      }),
+    })
+    router.addRoute({
+      name: 'shared-b',
+      path: '/shared-b',
+      component: defineComponent({ template: '<div />' }),
+    })
 
-    expect(injectedRoute!).toBe(pageRoute)
-    expect(childScopeRoute!).toBe(pageRoute)
-    expect(detachedScopeRoute!).toBe(nuxtApp._route)
+    const el = await mountSuspended({ setup: () => () => h(NuxtPage) })
+
+    await navigateTo('/shared-a')
+    await waitForPageChange()
+    expect(sharedRoute!.name).toBe('shared-a')
+
+    await navigateTo('/shared-b?q=test')
+    await waitForPageChange()
+    // the detached scope outlives the page, so it follows the current route
+    expect(sharedRoute!.name).toBe('shared-b')
+    expect(sharedRoute!.query).toMatchObject({ q: 'test' })
+    // routes obtained within the page's own scope stay frozen at that page's route
+    expect(injectedRoute!.name).toBe('shared-a')
+    expect(childScopeRoute!.name).toBe('shared-a')
 
     el.unmount()
-    // mounting without registered routes raises a 404 error
-    await clearError()
+    router.removeRoute('shared-a')
+    router.removeRoute('shared-b')
   })
 })
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves #18903

### 📚 Description

`useRoute()` called inside a detached effect scope (e.g. VueUse's `createSharedComposable`) injects the per-page route provided by `RouteProvider`, which freezes once its page fork is no longer active — so the shared composable's route never updates after navigation.

- `useRoute` now checks whether the current effect scope is (a descendant of) the component's scope
- Detached scopes fall back to the always-current `useNuxtApp()._route`, matching vue-router behaviour
- Normal setup calls and child scopes are unchanged and still receive the per-page route
- Adds a unit test covering all three cases (fails on `main`)
