### PR TITLE
docs: add example for components dir pattern option

### DIFF
--- a/docs/2.directory-structure/1.app/1.components.md
+++ b/docs/2.directory-structure/1.app/1.components.md
@@ -356,6 +356,25 @@ export default defineNuxtConfig({
 Any nested directories need to be added first as they are scanned in order.
 ::
 
+Each directory entry also accepts `pattern` and `ignore` glob options, which control which files are scanned within `path`. This is useful when your components live in nested folders that don't follow the default layout, such as a domain-driven structure:
+
+```ts twoslash [nuxt.config.ts]
+export default defineNuxtConfig({
+  components: [
+    // ~/domains/blog/components/PostCard.vue => <PostCard />
+    {
+      path: '~/domains',
+      pattern: '*/components/**',
+      pathPrefix: false,
+    },
+  ],
+})
+```
+
+::note
+If `pattern` is specified, the `extensions` option has no effect, so make sure your pattern matches the file extensions you want to scan.
+::
+
 ## npm Packages
 
 If you want to auto-import components from an npm package, you can use [`addComponent`](/docs/4.x/api/kit/components#addcomponent) in a [local module](/docs/4.x/directory-structure/modules) to register them.


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/26209

### 📚 Description

examples of components dir glob `pattern` option (and mention of `ignore`).