### PR TITLE
docs: clarify that `onPrehydrate` callback runs in the browser

### DIFF
--- a/docs/4.api/2.composables/on-prehydrate.md
+++ b/docs/4.api/2.composables/on-prehydrate.md
@@ -20,7 +20,7 @@ This is an advanced utility and should be used with care. For example, [`nuxt-ti
 
 ## Usage
 
-Call `onPrehydrate` in the setup function of a Vue component (e.g., in `<script setup>`) or in a plugin. It only has an effect when called on the server and will not be included in your client build.
+Call `onPrehydrate` in the setup function of a Vue component (e.g., in `<script setup>`) or in a plugin. The call itself only has an effect when made on the server and is stripped from your client build. The callback you pass, however, is serialized and inlined into the HTML, so it runs in the **browser** immediately before Nuxt hydrates — which is why it can access browser globals like `window` and the DOM.
 
 ## Type
 

--- a/docs/4.api/3.utils/create-error.md
+++ b/docs/4.api/3.utils/create-error.md
@@ -50,6 +50,6 @@ export default eventHandler(() => {
 })
 ```
 
-In API routes, using `createError` by passing an object with a short `statusText` is recommended because it can be accessed on the client side. Otherwise, a `message` passed to `createError` on an API route will not propagate to the client. Alternatively, you can use the `data` property to pass data back to the client. In any case, always consider avoiding to put dynamic user input to the message to avoid potential security issues.
+In API routes, using `createError` by passing an object with a short `statusText` is recommended because it can be accessed on the client side. Otherwise, a `message` passed to `createError` on an API route will not propagate to the client. Alternatively, you can use the `data` property to pass data back to the client. When handling the error with `useFetch`, the custom data is available at `error.value.data.data`. In any case, always consider avoiding to put dynamic user input to the message to avoid potential security issues.
 
 :read-more{to="/docs/4.x/getting-started/error-handling"}


### PR DESCRIPTION
### 🔗 Linked issue

Closes #29862

### 📚 Description

The `onPrehydrate` docs state that it *"only has an effect when it is called on the server,"* right next to an example that calls `console.log(window)`. A user reasonably read this as "the callback runs on the server" and concluded the example must be wrong, since `window` doesn't exist there.