### PR TITLE
fix(nuxt): render client components in nested server components

### DIFF
--- a/packages/nitro-server/src/runtime/utils/renderer/islands.ts
+++ b/packages/nitro-server/src/runtime/utils/renderer/islands.ts
@@ -38,7 +38,7 @@ export function getClientIslandResponse (ssrContext: NuxtSSRContext): NuxtIsland
     // when theres no matching teleport for the component UID, we use the teleport key (includes both island and component UID)
     if (!html && ssrContext.teleports) {
       for (const [key, value] of Object.entries(ssrContext.teleports)) {
-        const [, componentUid] = key.match(SSR_CLIENT_TELEPORT_MARKER) ?? []
+        const [, , componentUid] = key.match(SSR_CLIENT_TELEPORT_MARKER) ?? []
         if (componentUid === clientUid) {
           html = value.replaceAll('<!--teleport start anchor-->', '')
           break

--- a/packages/nitro-server/src/runtime/utils/renderer/islands.ts
+++ b/packages/nitro-server/src/runtime/utils/renderer/islands.ts
@@ -35,8 +35,7 @@ export function getClientIslandResponse (ssrContext: NuxtSSRContext): NuxtIsland
     // remove teleport anchor to avoid hydration issues
     let html = ssrContext.teleports?.[clientUid]?.replaceAll('<!--teleport start anchor-->', '') || ''
 
-    // nested islands use a teleport key containing both the island and component UID.
-    // we need to find that one instead of the component UID alone
+    // when theres no matching teleport for the component UID, we use the teleport key (includes both island and component UID)
     if (!html && ssrContext.teleports) {
       for (const [key, value] of Object.entries(ssrContext.teleports)) {
         if (key.match(SSR_CLIENT_TELEPORT_MARKER)?.[2] === clientUid) {

--- a/packages/nitro-server/src/runtime/utils/renderer/islands.ts
+++ b/packages/nitro-server/src/runtime/utils/renderer/islands.ts
@@ -38,7 +38,8 @@ export function getClientIslandResponse (ssrContext: NuxtSSRContext): NuxtIsland
     // when theres no matching teleport for the component UID, we use the teleport key (includes both island and component UID)
     if (!html && ssrContext.teleports) {
       for (const [key, value] of Object.entries(ssrContext.teleports)) {
-        if (key.match(SSR_CLIENT_TELEPORT_MARKER)?.[2] === clientUid) {
+        const [, componentUid] = key.match(SSR_CLIENT_TELEPORT_MARKER) ?? []
+        if (componentUid === clientUid) {
           html = value.replaceAll('<!--teleport start anchor-->', '')
           break
         }

--- a/packages/nitro-server/src/runtime/utils/renderer/islands.ts
+++ b/packages/nitro-server/src/runtime/utils/renderer/islands.ts
@@ -33,7 +33,19 @@ export function getClientIslandResponse (ssrContext: NuxtSSRContext): NuxtIsland
 
   for (const [clientUid, component] of Object.entries(ssrContext.islandContext.components)) {
     // remove teleport anchor to avoid hydration issues
-    const html = ssrContext.teleports?.[clientUid]?.replaceAll('<!--teleport start anchor-->', '') || ''
+    let html = ssrContext.teleports?.[clientUid]?.replaceAll('<!--teleport start anchor-->', '') || ''
+
+    // nested islands use a teleport key containing both the island and component UID.
+    // we need to find that one instead of the component UID alone
+    if (!html && ssrContext.teleports) {
+      for (const [key, value] of Object.entries(ssrContext.teleports)) {
+        if (key.match(SSR_CLIENT_TELEPORT_MARKER)?.[2] === clientUid) {
+          html = value.replaceAll('<!--teleport start anchor-->', '')
+          break
+        }
+      }
+    }
+
     response[clientUid] = {
       ...component,
       html,

--- a/packages/nuxt/src/app/components/nuxt-island.ts
+++ b/packages/nuxt/src/app/components/nuxt-island.ts
@@ -257,6 +257,17 @@ const NuxtIsland = defineComponent({
         payloads.slots = res.slots || {}
         payloads.components = res.components || {}
 
+        if (import.meta.server && res.components && Object.keys(res.components).length) {
+          const parentIslandContext = nuxtApp.ssrContext?.islandContext
+
+          // parent response needs to keep the nested islands UID
+          if (parentIslandContext) {
+            for (const [id, { html: _, ...component }] of Object.entries(res.components)) {
+              parentIslandContext.components[id] = { ...component, uid: uid.value }
+            }
+          }
+        }
+
         if (selectiveClient && import.meta.client) {
           if (canLoadClientComponent.value && res.components) {
             await loadComponents(props.source, res.components)
@@ -343,22 +354,22 @@ const NuxtIsland = defineComponent({
               if (import.meta.server) {
                 if (payloads.components) {
                   for (const [id, info] of Object.entries(payloads.components)) {
-                    const { html, slots } = info
+                    const { html, slots, uid: targetUID = uid.value } = info
                     let replaced = html.replaceAll('data-island-uid', `data-island-uid="${uid.value}"`)
                     for (const slot in slots) {
                       replaced = replaced.replaceAll(`data-island-slot="${slot}">`, full => full + slots[slot])
                     }
-                    teleports.push(createVNode(Teleport, { to: `uid=${uid.value};client=${id}` }, {
+                    teleports.push(createVNode(Teleport, { to: `uid=${targetUID};client=${id}` }, {
                       default: () => [createStaticVNode(replaced, 1)],
                     }))
                   }
                 }
               } else if (canLoadClientComponent.value && payloads.components) {
                 for (const [id, info] of Object.entries(payloads.components)) {
-                  const { props, slots } = info
+                  const { props, slots, uid: targetUID = uid.value } = info
                   const component = components!.get(id)!
                   // use different selectors for even and odd teleportKey to force trigger the teleport
-                  const vnode = createVNode(Teleport, { to: `${isKeyOdd ? 'div' : ''}[data-island-uid='${uid.value}'][data-island-component="${id}"]` }, {
+                  const vnode = createVNode(Teleport, { to: `${isKeyOdd ? 'div' : ''}[data-island-uid='${targetUID}'][data-island-component="${id}"]` }, {
                     default: () => {
                       return [h(component, props, Object.fromEntries(Object.entries(slots || {}).map(([k, v]) => ([k, () => createStaticVNode(`<div style="display: contents" data-island-uid data-island-slot="${k}">${v}</div>`, 1),
                       ]))))]

--- a/packages/nuxt/src/app/types.ts
+++ b/packages/nuxt/src/app/types.ts
@@ -178,6 +178,7 @@ export interface NuxtIslandClientResponse {
   props: unknown
   chunk: string
   slots?: Record<string, string>
+  uid?: string
 }
 
 export interface NuxtIslandContext {

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -89,7 +89,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(pagesRootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!_libs'], serverDir, pagesRootDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"82.4k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"82.7k"`)
 
     const modules = await analyzeSizes(['_libs/**/*'], serverDir, pagesRootDir)
     expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"232k"`)

--- a/test/server-components.test.ts
+++ b/test/server-components.test.ts
@@ -580,7 +580,7 @@ describe('page-island middleware', () => {
 
 describe.skipIf(isDev || isWebpack)('regressions', () => {
   // https://github.com/nuxt/nuxt/issues/26527
-  it.fails('renders <Counter nuxt-client /> when nested two levels deep in server components', async () => {
+  it('renders <Counter nuxt-client /> when nested two levels deep in server components', async () => {
     const { page } = await renderPage('/nested-nuxt-client')
 
     await page.locator('.server-inner-counter .sugar-counter button').waitFor({ timeout: 5_000 })


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #26527

### 📚 Description

This PR fixes a bug where client components inside nested server components would fail to resolve correctly across nested SSR contexts. There were a few issues with how Nuxt handles nested server islands:

1. The parent context would not receive the metadata of the client component.
2. The parent context would not know the island UID of the client component placeholder.
3. On Nitro's side, even with metadata being passed up the context tree, it could not find the component HTML by the nested component UID alone.

When Nuxt renders an island, it now passes metadata for nested client components, including the originating island UID, up to the parent context. This allows both SSR and the client-side Teleport to target the correct placeholder.
