### PR TITLE
fix(nuxt): preserve explicit `useFetch` method inference

### DIFF
--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -110,19 +110,6 @@ type FetchFactoryDataT<FDataT, _ResT> = [unknown] extends [FDataT] ? _ResT : FDa
 type FetchFactoryDefaultT<FDefaultT, Fallback> = [undefined] extends [FDefaultT] ? Fallback : FDefaultT
 type FetchFactoryPickKeys<FPickKeys, PickKeys, DataT> = [Array<never>] extends [FPickKeys] ? PickKeys : FPickKeys & KeysOf<DataT>
 export interface UseFetch<FDataT = unknown, FPickKeys extends KeysOf<FDataT> = never[], FDefaultT = undefined> {
-  // Auto-key, no options (runtime default = GET)
-  <
-    ResT = void,
-    ErrorT = NuxtError<unknown>,
-    ReqT extends NitroFetchRequest = NitroFetchRequest,
-    const Method extends 'get' = 'get',
-    _ResT = ResT extends void ? FetchResult<ReqT, Method & AvailableRouterMethod<ReqT>> : ResT,
-    DataT = FetchFactoryDataT<FDataT, _ResT>,
-    PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
-    DefaultT = FetchFactoryDefaultT<FDefaultT, undefined>,
-  >(
-    request: Ref<ReqT> | ReqT | (() => ReqT),
-  ): AsyncData<PickFrom<DataT, FetchFactoryPickKeys<FPickKeys, PickKeys, DataT>> | DefaultT, ErrorT | undefined>
   // Auto-key, opts with transform, default = undefined
   <
     ResT = void,

--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -39,7 +39,8 @@ export interface UseFetchOptions<
   DefaultT = undefined,
   R extends NitroFetchRequest = string & {},
   M extends AvailableRouterMethod<R> = AvailableRouterMethod<R>,
-> extends Omit<AsyncDataOptions<ResT, DataT, PickKeys, DefaultT>, 'watch'>, Omit<ComputedFetchOptions<R, M, DataT>, 'timeout'> {
+> extends Omit<AsyncDataOptions<ResT, DataT, PickKeys, DefaultT>, 'watch'>, Omit<ComputedFetchOptions<R, M, DataT>, 'method' | 'timeout'> {
+  method?: MaybeRefOrGetter<M>
   key?: MaybeRefOrGetter<string>
   $fetch?: $Fetch
   watch?: MultiWatchSources | false

--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -135,7 +135,7 @@ export interface UseFetch<FDataT = unknown, FPickKeys extends KeysOf<FDataT> = n
     DefaultT = FetchFactoryDefaultT<FDefaultT, undefined>,
   >(
     request: Ref<ReqT> | ReqT | (() => ReqT),
-    opts?: UseFetchOptionsWithTransform<_ResT, DataT, PickKeys, DefaultT, ReqT, Method>,
+    opts: UseFetchOptionsWithTransform<_ResT, DataT, PickKeys, DefaultT, ReqT, Method>,
   ): AsyncData<PickFrom<DataT, PickKeys> | DefaultT, ErrorT | undefined>
   // Auto-key, opts with transform, default = DataT
   <
@@ -149,7 +149,7 @@ export interface UseFetch<FDataT = unknown, FPickKeys extends KeysOf<FDataT> = n
     DefaultT = FetchFactoryDefaultT<FDefaultT, DataT>,
   >(
     request: Ref<ReqT> | ReqT | (() => ReqT),
-    opts?: UseFetchOptionsWithTransform<_ResT, DataT, PickKeys, DefaultT, ReqT, Method>,
+    opts: UseFetchOptionsWithTransform<_ResT, DataT, PickKeys, DefaultT, ReqT, Method>,
   ): AsyncData<PickFrom<DataT, PickKeys> | DefaultT, ErrorT | undefined>
   // Auto-key, default = undefined
   <

--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -39,9 +39,8 @@ export interface UseFetchOptions<
   DefaultT = undefined,
   R extends NitroFetchRequest = string & {},
   M extends AvailableRouterMethod<R> = AvailableRouterMethod<R>,
-> extends Omit<AsyncDataOptions<ResT, DataT, PickKeys, DefaultT>, 'watch'>, Omit<ComputedFetchOptions<R, M, DataT>, 'method' | 'timeout'> {
+> extends Omit<AsyncDataOptions<ResT, DataT, PickKeys, DefaultT>, 'watch'>, Omit<ComputedFetchOptions<R, M, DataT>, 'timeout'> {
   key?: MaybeRefOrGetter<string>
-  method?: MaybeRefOrGetter<M>
   $fetch?: $Fetch
   watch?: MultiWatchSources | false
 }

--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -134,7 +134,7 @@ export interface UseFetch<FDataT = unknown, FPickKeys extends KeysOf<FDataT> = n
     DefaultT = FetchFactoryDefaultT<FDefaultT, undefined>,
   >(
     request: Ref<ReqT> | ReqT | (() => ReqT),
-    opts: UseFetchOptionsWithTransform<_ResT, DataT, PickKeys, DefaultT, ReqT, Method>,
+    opts?: UseFetchOptionsWithTransform<_ResT, DataT, PickKeys, DefaultT, ReqT, Method>,
   ): AsyncData<PickFrom<DataT, PickKeys> | DefaultT, ErrorT | undefined>
   // Auto-key, opts with transform, default = DataT
   <
@@ -148,7 +148,7 @@ export interface UseFetch<FDataT = unknown, FPickKeys extends KeysOf<FDataT> = n
     DefaultT = FetchFactoryDefaultT<FDefaultT, DataT>,
   >(
     request: Ref<ReqT> | ReqT | (() => ReqT),
-    opts: UseFetchOptionsWithTransform<_ResT, DataT, PickKeys, DefaultT, ReqT, Method>,
+    opts?: UseFetchOptionsWithTransform<_ResT, DataT, PickKeys, DefaultT, ReqT, Method>,
   ): AsyncData<PickFrom<DataT, PickKeys> | DefaultT, ErrorT | undefined>
   // Auto-key, default = undefined
   <
@@ -162,7 +162,7 @@ export interface UseFetch<FDataT = unknown, FPickKeys extends KeysOf<FDataT> = n
     DefaultT = FetchFactoryDefaultT<FDefaultT, undefined>,
   >(
     request: Ref<ReqT> | ReqT | (() => ReqT),
-    opts: UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, ReqT, Method>,
+    opts?: UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, ReqT, Method>,
   ): AsyncData<PickFrom<DataT, FetchFactoryPickKeys<FPickKeys, PickKeys, DataT>> | DefaultT, ErrorT | undefined>
   // Auto-key, default = DataT
   <
@@ -176,7 +176,7 @@ export interface UseFetch<FDataT = unknown, FPickKeys extends KeysOf<FDataT> = n
     DefaultT = FetchFactoryDefaultT<FDefaultT, DataT>,
   >(
     request: Ref<ReqT> | ReqT | (() => ReqT),
-    opts: UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, ReqT, Method>,
+    opts?: UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, ReqT, Method>,
   ): AsyncData<PickFrom<DataT, FetchFactoryPickKeys<FPickKeys, PickKeys, DataT>> | DefaultT, ErrorT | undefined>
   // Explicit auto-key as positional arg
   <
@@ -190,7 +190,7 @@ export interface UseFetch<FDataT = unknown, FPickKeys extends KeysOf<FDataT> = n
     DefaultT = undefined,
   >(
     request: Ref<ReqT> | ReqT | (() => ReqT),
-    arg1: string | UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, ReqT, Method>,
+    arg1?: string | UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, ReqT, Method>,
     arg2?: string,
   ): AsyncData<PickFrom<DataT, PickKeys> | DefaultT, ErrorT | undefined>
 }

--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -109,12 +109,25 @@ type FetchFactoryDataT<FDataT, _ResT> = [unknown] extends [FDataT] ? _ResT : FDa
 type FetchFactoryDefaultT<FDefaultT, Fallback> = [undefined] extends [FDefaultT] ? Fallback : FDefaultT
 type FetchFactoryPickKeys<FPickKeys, PickKeys, DataT> = [Array<never>] extends [FPickKeys] ? PickKeys : FPickKeys & KeysOf<DataT>
 export interface UseFetch<FDataT = unknown, FPickKeys extends KeysOf<FDataT> = never[], FDefaultT = undefined> {
+  // Auto-key, no options (runtime default = GET)
+  <
+    ResT = void,
+    ErrorT = NuxtError<unknown>,
+    ReqT extends NitroFetchRequest = NitroFetchRequest,
+    const Method extends 'get' = 'get',
+    _ResT = ResT extends void ? FetchResult<ReqT, Method & AvailableRouterMethod<ReqT>> : ResT,
+    DataT = FetchFactoryDataT<FDataT, _ResT>,
+    PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
+    DefaultT = FetchFactoryDefaultT<FDefaultT, undefined>,
+  >(
+    request: Ref<ReqT> | ReqT | (() => ReqT),
+  ): AsyncData<PickFrom<DataT, FetchFactoryPickKeys<FPickKeys, PickKeys, DataT>> | DefaultT, ErrorT | undefined>
   // Auto-key, opts with transform, default = undefined
   <
     ResT = void,
     ErrorT = NuxtError<unknown>,
     ReqT extends NitroFetchRequest = NitroFetchRequest,
-    Method extends AvailableRouterMethod<ReqT> = ResT extends void ? 'get' extends AvailableRouterMethod<ReqT> ? 'get' : AvailableRouterMethod<ReqT> : AvailableRouterMethod<ReqT>,
+    const Method extends AvailableRouterMethod<ReqT> = ResT extends void ? 'get' extends AvailableRouterMethod<ReqT> ? 'get' : AvailableRouterMethod<ReqT> : AvailableRouterMethod<ReqT>,
     _ResT = ResT extends void ? FetchResult<ReqT, Method> : ResT,
     DataT = _ResT,
     PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
@@ -128,7 +141,7 @@ export interface UseFetch<FDataT = unknown, FPickKeys extends KeysOf<FDataT> = n
     ResT = void,
     ErrorT = NuxtError<unknown>,
     ReqT extends NitroFetchRequest = NitroFetchRequest,
-    Method extends AvailableRouterMethod<ReqT> = ResT extends void ? 'get' extends AvailableRouterMethod<ReqT> ? 'get' : AvailableRouterMethod<ReqT> : AvailableRouterMethod<ReqT>,
+    const Method extends AvailableRouterMethod<ReqT> = ResT extends void ? 'get' extends AvailableRouterMethod<ReqT> ? 'get' : AvailableRouterMethod<ReqT> : AvailableRouterMethod<ReqT>,
     _ResT = ResT extends void ? FetchResult<ReqT, Method> : ResT,
     DataT = _ResT,
     PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
@@ -142,42 +155,42 @@ export interface UseFetch<FDataT = unknown, FPickKeys extends KeysOf<FDataT> = n
     ResT = void,
     ErrorT = NuxtError<unknown>,
     ReqT extends NitroFetchRequest = NitroFetchRequest,
-    Method extends AvailableRouterMethod<ReqT> = ResT extends void ? 'get' extends AvailableRouterMethod<ReqT> ? 'get' : AvailableRouterMethod<ReqT> : AvailableRouterMethod<ReqT>,
+    const Method extends AvailableRouterMethod<ReqT> = ResT extends void ? 'get' extends AvailableRouterMethod<ReqT> ? 'get' : AvailableRouterMethod<ReqT> : AvailableRouterMethod<ReqT>,
     _ResT = ResT extends void ? FetchResult<ReqT, Method> : ResT,
     DataT = FetchFactoryDataT<FDataT, _ResT>,
     PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
     DefaultT = FetchFactoryDefaultT<FDefaultT, undefined>,
   >(
     request: Ref<ReqT> | ReqT | (() => ReqT),
-    opts?: UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, ReqT, Method>,
+    opts: UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, ReqT, Method>,
   ): AsyncData<PickFrom<DataT, FetchFactoryPickKeys<FPickKeys, PickKeys, DataT>> | DefaultT, ErrorT | undefined>
   // Auto-key, default = DataT
   <
     ResT = void,
     ErrorT = NuxtError<unknown>,
     ReqT extends NitroFetchRequest = NitroFetchRequest,
-    Method extends AvailableRouterMethod<ReqT> = ResT extends void ? 'get' extends AvailableRouterMethod<ReqT> ? 'get' : AvailableRouterMethod<ReqT> : AvailableRouterMethod<ReqT>,
+    const Method extends AvailableRouterMethod<ReqT> = ResT extends void ? 'get' extends AvailableRouterMethod<ReqT> ? 'get' : AvailableRouterMethod<ReqT> : AvailableRouterMethod<ReqT>,
     _ResT = ResT extends void ? FetchResult<ReqT, Method> : ResT,
     DataT = FetchFactoryDataT<FDataT, _ResT>,
     PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
     DefaultT = FetchFactoryDefaultT<FDefaultT, DataT>,
   >(
     request: Ref<ReqT> | ReqT | (() => ReqT),
-    opts?: UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, ReqT, Method>,
+    opts: UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, ReqT, Method>,
   ): AsyncData<PickFrom<DataT, FetchFactoryPickKeys<FPickKeys, PickKeys, DataT>> | DefaultT, ErrorT | undefined>
   // Explicit auto-key as positional arg
   <
     ResT = void,
     ErrorT = NuxtError<unknown>,
     ReqT extends NitroFetchRequest = NitroFetchRequest,
-    Method extends AvailableRouterMethod<ReqT> = ResT extends void ? 'get' extends AvailableRouterMethod<ReqT> ? 'get' : AvailableRouterMethod<ReqT> : AvailableRouterMethod<ReqT>,
+    const Method extends AvailableRouterMethod<ReqT> = ResT extends void ? 'get' extends AvailableRouterMethod<ReqT> ? 'get' : AvailableRouterMethod<ReqT> : AvailableRouterMethod<ReqT>,
     _ResT = ResT extends void ? FetchResult<ReqT, Method> : ResT,
     DataT = _ResT,
     PickKeys extends KeysOf<DataT> = KeysOf<DataT>,
     DefaultT = undefined,
   >(
     request: Ref<ReqT> | ReqT | (() => ReqT),
-    arg1?: string | UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, ReqT, Method>,
+    arg1: string | UseFetchOptions<_ResT, DataT, PickKeys, DefaultT, ReqT, Method>,
     arg2?: string,
   ): AsyncData<PickFrom<DataT, PickKeys> | DefaultT, ErrorT | undefined>
 }
@@ -186,7 +199,7 @@ export interface CreateUseFetch {
   <
     FResT = void,
     FReqT extends NitroFetchRequest = NitroFetchRequest,
-    FMethod extends AvailableRouterMethod<FReqT> = FResT extends void ? 'get' extends AvailableRouterMethod<FReqT> ? 'get' : AvailableRouterMethod<FReqT> : AvailableRouterMethod<FReqT>,
+    const FMethod extends AvailableRouterMethod<FReqT> = FResT extends void ? 'get' extends AvailableRouterMethod<FReqT> ? 'get' : AvailableRouterMethod<FReqT> : AvailableRouterMethod<FReqT>,
     F_ResT = FResT extends void ? FetchResult<FReqT, FMethod> : FResT,
     FDataT = F_ResT,
     FPickKeys extends KeysOf<FDataT> = KeysOf<FDataT>,
@@ -207,7 +220,7 @@ export const createUseFetch: CreateUseFetch = defineKeyedFunctionFactory<CreateU
   factory<
     FResT = void,
     FReqT extends NitroFetchRequest = NitroFetchRequest,
-    FMethod extends AvailableRouterMethod<FReqT> = FResT extends void ? 'get' extends AvailableRouterMethod<FReqT> ? 'get' : AvailableRouterMethod<FReqT> : AvailableRouterMethod<FReqT>,
+    const FMethod extends AvailableRouterMethod<FReqT> = FResT extends void ? 'get' extends AvailableRouterMethod<FReqT> ? 'get' : AvailableRouterMethod<FReqT> : AvailableRouterMethod<FReqT>,
     F_ResT = FResT extends void ? FetchResult<FReqT, FMethod> : FResT,
     FDataT = F_ResT,
     FPickKeys extends KeysOf<FDataT> = KeysOf<FDataT>,

--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -40,8 +40,8 @@ export interface UseFetchOptions<
   R extends NitroFetchRequest = string & {},
   M extends AvailableRouterMethod<R> = AvailableRouterMethod<R>,
 > extends Omit<AsyncDataOptions<ResT, DataT, PickKeys, DefaultT>, 'watch'>, Omit<ComputedFetchOptions<R, M, DataT>, 'method' | 'timeout'> {
-  method?: MaybeRefOrGetter<M>
   key?: MaybeRefOrGetter<string>
+  method?: MaybeRefOrGetter<M>
   $fetch?: $Fetch
   watch?: MultiWatchSources | false
 }

--- a/test/fixtures/basic-types/app/app-types.ts
+++ b/test/fixtures/basic-types/app/app-types.ts
@@ -28,9 +28,6 @@ declare module 'nitro/types' {
       get: { method: 'get' }
       post: { method: 'post' }
     }
-    '/api/method-inference/post-only': {
-      post: { method: 'post' }
-    }
   }
 }
 
@@ -139,8 +136,6 @@ describe('API routes', () => {
     const transformedPostFetch = useFetch('/api/method-inference', { method: 'post', transform: data => data })
     const defaultedPostFetch = useFetch('/api/method-inference', { method: 'post', default: () => ({ method: 'post' as const }) })
     const keyedPostFetch = useFetch('/api/method-inference', { method: 'post' }, 'key')
-    const explicitResponseFetch = useFetch<{ explicit: true }>('/api/method-inference')
-    const postOnlyFetch = useFetch('/api/method-inference/post-only')
     const usePostFetch = createUseFetch<void, '/api/method-inference', 'post'>({ method: 'post' })
     const factoryFetch = usePostFetch('/api/method-inference')
 
@@ -149,8 +144,6 @@ describe('API routes', () => {
     expectTypeOf<FetchMethod<typeof transformedPostFetch>>().toEqualTypeOf<'post'>()
     expectTypeOf<FetchMethod<typeof defaultedPostFetch>>().toEqualTypeOf<'post'>()
     expectTypeOf<FetchMethod<typeof keyedPostFetch>>().toEqualTypeOf<'post'>()
-    expectTypeOf(explicitResponseFetch.data).toEqualTypeOf<Ref<{ explicit: true } | DefaultAsyncDataValue>>()
-    expectTypeOf(postOnlyFetch.data).toEqualTypeOf<Ref<unknown>>()
     expectTypeOf<FetchMethod<typeof factoryFetch>>().toEqualTypeOf<'post'>()
 
     // expectTypeOf(useFetch('/api/hello').data).toEqualTypeOf<Ref<string | DefaultAsyncDataValue>>()

--- a/test/fixtures/basic-types/app/app-types.ts
+++ b/test/fixtures/basic-types/app/app-types.ts
@@ -18,10 +18,6 @@ type DefaultAsyncDataValue = undefined
 
 interface TestResponse { message: string }
 
-type FetchMethod<T> = T extends { data: Ref<infer Data> }
-  ? NonNullable<Data> extends { method: infer Method } ? Method : never
-  : never
-
 declare module 'nitro/types' {
   interface InternalApi {
     '/api/method-inference': {
@@ -131,20 +127,12 @@ describe('API routes', () => {
 
   // TODO: https://github.com/nitrojs/nitro/issues/2758
   it('works with useFetch', () => {
-    const defaultFetch = useFetch('/api/method-inference')
-    const postFetch = useLazyFetch('/api/method-inference', { method: 'post' })
-    const transformedPostFetch = useFetch('/api/method-inference', { method: 'post', transform: data => data })
-    const defaultedPostFetch = useFetch('/api/method-inference', { method: 'post', default: () => ({ method: 'post' as const }) })
-    const keyedPostFetch = useFetch('/api/method-inference', { method: 'post' }, 'key')
-    const usePostFetch = createUseFetch<void, '/api/method-inference', 'post'>({ method: 'post' })
-    const factoryFetch = usePostFetch('/api/method-inference')
-
-    expectTypeOf<FetchMethod<typeof defaultFetch>>().toEqualTypeOf<'get'>()
-    expectTypeOf<FetchMethod<typeof postFetch>>().toEqualTypeOf<'post'>()
-    expectTypeOf<FetchMethod<typeof transformedPostFetch>>().toEqualTypeOf<'post'>()
-    expectTypeOf<FetchMethod<typeof defaultedPostFetch>>().toEqualTypeOf<'post'>()
-    expectTypeOf<FetchMethod<typeof keyedPostFetch>>().toEqualTypeOf<'post'>()
-    expectTypeOf<FetchMethod<typeof factoryFetch>>().toEqualTypeOf<'post'>()
+    expectTypeOf(useFetch('/api/method-inference').data.value!.method).toEqualTypeOf<'get'>()
+    expectTypeOf(useLazyFetch('/api/method-inference', { method: 'post' }).data.value!.method).toEqualTypeOf<'post'>()
+    expectTypeOf(useFetch('/api/method-inference', { method: 'post', transform: data => data }).data.value!.method).toEqualTypeOf<'post'>()
+    expectTypeOf(useFetch('/api/method-inference', { method: 'post', default: () => ({ method: 'post' as const }) }).data.value!.method).toEqualTypeOf<'post'>()
+    expectTypeOf(useFetch('/api/method-inference', { method: 'post' }, 'key').data.value!.method).toEqualTypeOf<'post'>()
+    expectTypeOf(createUseFetch<void, '/api/method-inference', 'post'>({ method: 'post' })('/api/method-inference').data.value!.method).toEqualTypeOf<'post'>()
 
     // expectTypeOf(useFetch('/api/hello').data).toEqualTypeOf<Ref<string | DefaultAsyncDataValue>>()
     // expectTypeOf(useFetch('/api/hey').data).toEqualTypeOf<Ref<{ foo: string, baz: string } | DefaultAsyncDataValue>>()

--- a/test/fixtures/basic-types/app/app-types.ts
+++ b/test/fixtures/basic-types/app/app-types.ts
@@ -18,15 +18,6 @@ type DefaultAsyncDataValue = undefined
 
 interface TestResponse { message: string }
 
-declare module 'nitro/types' {
-  interface InternalApi {
-    '/api/method-inference': {
-      get: { method: 'get' }
-      post: { method: 'post' }
-    }
-  }
-}
-
 declare module 'nuxt/app' {
   interface NuxtLayouts {
     withFunction: {
@@ -127,13 +118,6 @@ describe('API routes', () => {
 
   // TODO: https://github.com/nitrojs/nitro/issues/2758
   it('works with useFetch', () => {
-    expectTypeOf(useFetch('/api/method-inference').data.value!.method).toEqualTypeOf<'get'>()
-    expectTypeOf(useLazyFetch('/api/method-inference', { method: 'post' }).data.value!.method).toEqualTypeOf<'post'>()
-    expectTypeOf(useFetch('/api/method-inference', { method: 'post', transform: data => data }).data.value!.method).toEqualTypeOf<'post'>()
-    expectTypeOf(useFetch('/api/method-inference', { method: 'post', default: () => ({ method: 'post' as const }) }).data.value!.method).toEqualTypeOf<'post'>()
-    expectTypeOf(useFetch('/api/method-inference', { method: 'post' }, 'key').data.value!.method).toEqualTypeOf<'post'>()
-    expectTypeOf(createUseFetch<void, '/api/method-inference', 'post'>({ method: 'post' })('/api/method-inference').data.value!.method).toEqualTypeOf<'post'>()
-
     // expectTypeOf(useFetch('/api/hello').data).toEqualTypeOf<Ref<string | DefaultAsyncDataValue>>()
     // expectTypeOf(useFetch('/api/hey').data).toEqualTypeOf<Ref<{ foo: string, baz: string } | DefaultAsyncDataValue>>()
     // expectTypeOf(useFetch('/api/hey', { method: 'GET' }).data).toEqualTypeOf<Ref<{ foo: string, baz: string } | DefaultAsyncDataValue>>()

--- a/test/fixtures/basic-types/app/app-types.ts
+++ b/test/fixtures/basic-types/app/app-types.ts
@@ -18,6 +18,22 @@ type DefaultAsyncDataValue = undefined
 
 interface TestResponse { message: string }
 
+type FetchMethod<T> = T extends { data: Ref<infer Data> }
+  ? NonNullable<Data> extends { method: infer Method } ? Method : never
+  : never
+
+declare module 'nitro/types' {
+  interface InternalApi {
+    '/api/method-inference': {
+      get: { method: 'get' }
+      post: { method: 'post' }
+    }
+    '/api/method-inference/post-only': {
+      post: { method: 'post' }
+    }
+  }
+}
+
 declare module 'nuxt/app' {
   interface NuxtLayouts {
     withFunction: {
@@ -118,6 +134,25 @@ describe('API routes', () => {
 
   // TODO: https://github.com/nitrojs/nitro/issues/2758
   it('works with useFetch', () => {
+    const defaultFetch = useFetch('/api/method-inference')
+    const postFetch = useLazyFetch('/api/method-inference', { method: 'post' })
+    const transformedPostFetch = useFetch('/api/method-inference', { method: 'post', transform: data => data })
+    const defaultedPostFetch = useFetch('/api/method-inference', { method: 'post', default: () => ({ method: 'post' as const }) })
+    const keyedPostFetch = useFetch('/api/method-inference', { method: 'post' }, 'key')
+    const explicitResponseFetch = useFetch<{ explicit: true }>('/api/method-inference')
+    const postOnlyFetch = useFetch('/api/method-inference/post-only')
+    const usePostFetch = createUseFetch<void, '/api/method-inference', 'post'>({ method: 'post' })
+    const factoryFetch = usePostFetch('/api/method-inference')
+
+    expectTypeOf<FetchMethod<typeof defaultFetch>>().toEqualTypeOf<'get'>()
+    expectTypeOf<FetchMethod<typeof postFetch>>().toEqualTypeOf<'post'>()
+    expectTypeOf<FetchMethod<typeof transformedPostFetch>>().toEqualTypeOf<'post'>()
+    expectTypeOf<FetchMethod<typeof defaultedPostFetch>>().toEqualTypeOf<'post'>()
+    expectTypeOf<FetchMethod<typeof keyedPostFetch>>().toEqualTypeOf<'post'>()
+    expectTypeOf(explicitResponseFetch.data).toEqualTypeOf<Ref<{ explicit: true } | DefaultAsyncDataValue>>()
+    expectTypeOf(postOnlyFetch.data).toEqualTypeOf<Ref<unknown>>()
+    expectTypeOf<FetchMethod<typeof factoryFetch>>().toEqualTypeOf<'post'>()
+
     // expectTypeOf(useFetch('/api/hello').data).toEqualTypeOf<Ref<string | DefaultAsyncDataValue>>()
     // expectTypeOf(useFetch('/api/hey').data).toEqualTypeOf<Ref<{ foo: string, baz: string } | DefaultAsyncDataValue>>()
     // expectTypeOf(useFetch('/api/hey', { method: 'GET' }).data).toEqualTypeOf<Ref<{ foo: string, baz: string } | DefaultAsyncDataValue>>()


### PR DESCRIPTION
## Summary

- preserve explicit method literals with `const Method` type parameters
- expose `method` directly on `UseFetchOptions` for inference

## Motivation

Nuxt 4.5 can widen resolved `useFetch` methods such as `"post"` to `string`. dxup relies on the method literal to support go to definition for Nitro routes, so keeping this inference precise allows that navigation to continue working.

---

*This pull request was created with assistance from a code agent.*