### PR TITLE
feat(nuxt): warn when public files override application routes

### DIFF
--- a/packages/kit/src/diagnostics/pages.ts
+++ b/packages/kit/src/diagnostics/pages.ts
@@ -76,5 +76,10 @@ export const pageDiagnostics = /* #__PURE__ */ defineDiagnostics({
       fix: 'Rename one of the layouts, or remove the duplicate layout registration.',
       docs: false,
     },
+    NUXT_B4015: {
+      why: (p: { asset: string, route: string, page?: string }) => `The public asset \`${p.asset}\` is served at \`${p.route}\` and overrides the page route${p.page ? ` defined in \`${p.page}\`` : ''}.`,
+      fix: 'Rename or move the public asset, change its public asset base URL, or remove the conflicting page.',
+      docs: false,
+    },
   },
 })

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync } from 'node:fs'
+import { existsSync, readdirSync, statSync } from 'node:fs'
 import { mkdir, readFile } from 'node:fs/promises'
 import { addBuildPlugin, addComponent, addPlugin, addTemplate, addTypeTemplate, defineNuxtModule, findPath, getLayerDirectories, isIgnored, pageDiagnostics, resolvePath, resolveTypePaths, useNitro } from '@nuxt/kit'
 import { dirname, join, relative, resolve } from 'pathe'
@@ -6,7 +6,7 @@ import { genImport, genInlineTypeImport, genObjectFromRawEntries, genObjectKey, 
 import { joinURL } from 'ufo'
 import { createRoutesContext, resolveOptions } from 'vue-router/unplugin'
 import type { EditableTreeNode, Options as TypedRouterOptions } from 'vue-router/unplugin'
-import type { NitroRouteConfig } from 'nitro/types'
+import type { Nitro, NitroRouteConfig } from 'nitro/types'
 import { defu } from 'defu'
 import { isEqual } from 'ohash'
 import { distDir } from '../dirs.ts'
@@ -15,6 +15,7 @@ import picomatch from 'picomatch'
 import { resolvePagesRoutes as _resolvePagesRoutes, augmentAndResolve, createPagesContext, defaultExtractionKeys, normalizeRoutes, resolveRoutePaths, toRou3Patterns } from './utils.ts'
 import type { PagesContext } from './utils.ts'
 import { globRouteRulesFromPages, removePagesRules } from './route-rules.ts'
+import { collectStaticPageRoutes, getAssetPathsForRoute } from './public-assets.ts'
 import { PageMetaPlugin } from './plugins/page-meta.ts'
 import { toVirtualId } from '../core/plugins/virtual.ts'
 import { RouteInjectionPlugin } from './plugins/route-injection.ts'
@@ -457,6 +458,41 @@ export default defineNuxtModule({
       prerenderRoutes.clear()
       processPages(pages)
     })
+
+    const warnedConflicts = new Set<string>()
+    let publicAssets: Nitro['options']['publicAssets'] = []
+    nuxt.hook('nitro:init', (nitro) => {
+      const clientBuildDir = resolve(nuxt.options.buildDir, 'dist/client')
+      publicAssets = nitro.options.publicAssets.filter(asset => resolve(asset.dir) !== clientBuildDir)
+    })
+
+    const warnPublicAssetConflicts = () => {
+      // Public directories can be large, so check only paths matching known routes.
+      for (const [route, page] of collectStaticPageRoutes(nuxt.apps.default?.pages || [])) {
+        for (const asset of publicAssets) {
+          for (const path of getAssetPathsForRoute(route, asset.baseURL) || []) {
+            const file = resolve(asset.dir, path)
+            try {
+              if (!statSync(file, { throwIfNoEntry: false })?.isFile()) { continue }
+            } catch {
+              continue
+            }
+
+            const key = `${file}:${route}`
+            if (warnedConflicts.has(key)) { continue }
+            warnedConflicts.add(key)
+
+            pageDiagnostics.NUXT_B4015({
+              asset: relative(nuxt.options.rootDir, file),
+              route,
+              page: page && relative(nuxt.options.rootDir, page),
+            })
+          }
+        }
+      }
+    }
+
+    nuxt.hook('nitro:build:before', () => warnPublicAssetConflicts())
 
     nuxt.hook('nitro:build:before', (nitro) => {
       if (nuxt.options.dev || nuxt.options.router.options.hashMode) { return }

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -463,7 +463,10 @@ export default defineNuxtModule({
     let publicAssets: Nitro['options']['publicAssets'] = []
     nuxt.hook('nitro:init', (nitro) => {
       const clientBuildDir = resolve(nuxt.options.buildDir, 'dist/client')
-      publicAssets = nitro.options.publicAssets.filter(asset => resolve(asset.dir) !== clientBuildDir)
+      publicAssets = nitro.options.publicAssets.filter((asset) => {
+        const dir = resolve(asset.dir)
+        return dir !== clientBuildDir && !dir.startsWith(clientBuildDir + '/')
+      })
     })
 
     const warnPublicAssetConflicts = () => {

--- a/packages/nuxt/src/pages/public-assets.ts
+++ b/packages/nuxt/src/pages/public-assets.ts
@@ -1,0 +1,53 @@
+import { joinURL, withLeadingSlash, withoutTrailingSlash } from 'ufo'
+import type { NuxtPage } from 'nuxt/schema'
+
+const INDEX_HTML_SUFFIX = '/index.html'
+
+export function normalizeRoute (path: string) {
+  return withoutTrailingSlash(withLeadingSlash(path)) || '/'
+}
+
+/**
+ * Map static page routes and aliases to their source files.
+ * Dynamic routes are intentionally excluded to avoid noisy warnings.
+ */
+export function collectStaticPageRoutes (pages: NuxtPage[], parent = '/', routes = new Map<string, string | undefined>()) {
+  for (const page of pages) {
+    const route = normalizeRoute(joinURL(parent, page.path))
+
+    if (!route.includes(':')) {
+      routes.set(route, page.file)
+    }
+
+    const aliases = Array.isArray(page.alias) ? page.alias : page.alias ? [page.alias] : []
+    for (const alias of aliases) {
+      const resolved = normalizeRoute(alias.startsWith('/') ? alias : joinURL(parent, alias))
+      if (!resolved.includes(':')) {
+        routes.set(resolved, page.file)
+      }
+    }
+
+    if (page.children) {
+      collectStaticPageRoutes(page.children, route, routes)
+    }
+  }
+
+  return routes
+}
+
+/**
+ * Return asset paths that Nitro can serve for a route, relative to the asset directory.
+ */
+export function getAssetPathsForRoute (route: string, baseURL = '/') {
+  const base = normalizeRoute(baseURL)
+
+  if (base !== '/' && route !== base && !route.startsWith(base + '/')) {
+    return undefined
+  }
+
+  const relativeRoute = route.slice(base === '/' ? 1 : base.length + 1)
+
+  return relativeRoute
+    ? [relativeRoute, relativeRoute + INDEX_HTML_SUFFIX]
+    : [INDEX_HTML_SUFFIX.slice(1)]
+}

--- a/packages/nuxt/test/public-assets.test.ts
+++ b/packages/nuxt/test/public-assets.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import { collectStaticPageRoutes, getAssetPathsForRoute } from '../src/pages/public-assets.ts'
+import type { NuxtPage } from 'nuxt/schema'
+
+describe('collectStaticPageRoutes', () => {
+  it('collects top-level and nested routes', () => {
+    const pages: NuxtPage[] = [
+      { path: '/', file: 'pages/index.vue' },
+      {
+        path: '/docs',
+        file: 'pages/docs.vue',
+        children: [
+          { path: 'getting-started', file: 'pages/docs/getting-started.vue' },
+        ],
+      },
+    ]
+
+    expect([...collectStaticPageRoutes(pages)]).toMatchInlineSnapshot(`
+      [
+        [
+          "/",
+          "pages/index.vue",
+        ],
+        [
+          "/docs",
+          "pages/docs.vue",
+        ],
+        [
+          "/docs/getting-started",
+          "pages/docs/getting-started.vue",
+        ],
+      ]
+    `)
+  })
+
+  it('skips dynamic and catch-all routes', () => {
+    const pages: NuxtPage[] = [
+      { path: '/:slug', file: 'pages/[slug].vue' },
+      { path: '/:slug(.*)*', file: 'pages/[...slug].vue' },
+      { path: '/about', file: 'pages/about.vue' },
+    ]
+
+    expect([...collectStaticPageRoutes(pages).keys()]).toStrictEqual(['/about'])
+  })
+
+  it('collects static aliases', () => {
+    const pages: NuxtPage[] = [
+      { path: '/about', file: 'pages/about.vue', alias: ['/about-us', '/:legacy'] },
+      { path: '/docs', file: 'pages/docs.vue', children: [{ path: 'intro', file: 'pages/docs/intro.vue', alias: 'start' }] },
+    ]
+
+    expect([...collectStaticPageRoutes(pages).keys()]).toStrictEqual([
+      '/about',
+      '/about-us',
+      '/docs',
+      '/docs/intro',
+      '/docs/start',
+    ])
+  })
+})
+
+describe('getAssetPathsForRoute', () => {
+  it.each([
+    ['/', '/', ['index.html']],
+    ['/docs', '/', ['docs', 'docs/index.html']],
+    ['/docs/intro', '/', ['docs/intro', 'docs/intro/index.html']],
+    ['/about.html', '/', ['about.html', 'about.html/index.html']],
+    // routes are only shadowed by assets served under their own base URL
+    ['/nested', '/nested', ['index.html']],
+    ['/nested/docs', '/nested', ['docs', 'docs/index.html']],
+    ['/other', '/nested', undefined],
+    ['/nested-sibling', '/nested', undefined],
+  ])('resolves %s (base %s)', (route, baseURL, expected) => {
+    expect(getAssetPathsForRoute(route, baseURL)).toStrictEqual(expected)
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
Resolves #31103

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->

Adds a warning for conflicting `public/` assets and application routes. 