### PR TITLE
docs: add guidance on memory usage during nuxt build

### DIFF
--- a/docs/1.getting-started/16.deployment.md
+++ b/docs/1.getting-started/16.deployment.md
@@ -10,6 +10,8 @@ A Nuxt application can be deployed on a Node.js server, pre-rendered for static 
 If you are looking for a list of cloud providers that support Nuxt, see the [Hosting providers](/deploy) section.
 ::
 
+:read-more{title="Build Memory Usage" to="/docs/4.x/guide/best-practices/build-memory"}
+
 ## Node.js Server
 
 Discover the Node.js server preset with Nitro to deploy on any Node hosting.

--- a/docs/3.guide/2.best-practices/build-memory.md
+++ b/docs/3.guide/2.best-practices/build-memory.md
@@ -65,7 +65,7 @@ When Node.js throws `FATAL ERROR: Reached heap limit` and the machine has free R
 NODE_OPTIONS='--max-old-space-size=8192' npx nuxt build
 ```
 
-Exit code `137` means the OS killed the process. A larger heap limit does not add physical RAM. `--expose-gc` only exposes `global.gc()`; it does not free objects the build still holds.
+Exit code `137` means the process received SIGKILL. The OOM killer is one possible cause, not proof of memory exhaustion by itself. Check runner or container logs (for example dmesg or the host's OOM killer messages) before diagnosing a memory problem. A larger heap limit does not add physical RAM. `--expose-gc` only exposes `global.gc()`; it does not free objects the build still holds.
 
 If a very large dependency (for example Puppeteer) lands in the client graph, [`nuxt analyze`](/docs/4.x/api/commands/analyze) can show that. For most apps, prerender work matters more than the module graph.
 
@@ -94,13 +94,13 @@ On Linux, peak RSS for the timed command:
 /usr/bin/time -v npx nuxt build
 ```
 
-For retained allocations, use a heap profile:
+For allocation profiling, use a sampled heap profile:
 
 ```bash [Terminal]
 NODE_OPTIONS='--heap-prof' npx nuxt build
 ```
 
-Open the `.heapprofile` in Chrome DevTools. Profiling adds overhead, so size CI from normal builds.
+Open the `.heapprofile` in Chrome DevTools. Profiling adds overhead, so size CI from normal builds. When the build dies near the heap limit and you need a snapshot of the heap at that moment, prefer [`--heapsnapshot-near-heap-limit`](https://nodejs.org/api/cli.html#--heapsnapshot-near-heap-limitmax_count) instead of `--heap-prof`.
 
 You can also log RSS and heap at build hooks in the main process:
 
@@ -125,6 +125,6 @@ export default defineNuxtConfig({
 
 These hooks miss peaks between stages and memory in child processes.
 
-[`nuxt build --profile`](/docs/4.x/api/commands/build) reports RSS and heap deltas for build stages and writes a CPU profile. Use it to find slow stages; it does not produce a retained-allocation heap profile.
+[`nuxt build --profile`](/docs/4.x/api/commands/build) reports RSS and heap deltas for build stages and writes a CPU profile. Use it to find slow stages; it does not produce a sampled heap profile.
 
 When you open an OOM issue, include Nuxt and Node.js versions, peak RSS, runner RAM, sourcemap settings, prerender route count, preset, and major module versions.

--- a/docs/3.guide/2.best-practices/build-memory.md
+++ b/docs/3.guide/2.best-practices/build-memory.md
@@ -10,7 +10,7 @@ Nuxt does not publish a fixed memory budget. Peak usage depends on your source, 
 
 ## Examples From the Community
 
-These Nuxt 4.x peaks were reported in [nuxt/nuxt#34849](https://github.com/nuxt/nuxt/issues/34849):
+These peaks were reported in [nuxt/nuxt#34849](https://github.com/nuxt/nuxt/issues/34849) on Nuxt 4.4.x (before Vite 8). Treat them as historical planning anchors, not current limits. Peaks may be lower after Nuxt 4.5+.
 
 | Project | Peak during `nuxt build` |
 | --- | --- |
@@ -18,7 +18,7 @@ These Nuxt 4.x peaks were reported in [nuxt/nuxt#34849](https://github.com/nuxt/
 | Large app (421k LOC + 82k lines of i18n JSON) | ~10–11 GB |
 | Large app with client/server sourcemaps and thousands of prerendered routes | 12+ GB |
 
-Use them as planning anchors, not as official limits. Runtime memory after deploy is a different number. Do not size production hosts from build peaks.
+Runtime memory after deploy is a different number. Do not size production hosts from build peaks.
 
 ## What Uses Memory
 
@@ -96,9 +96,9 @@ This helps when Node throws `FATAL ERROR: Reached heap limit` and the host still
 - Drop unused modules; prefer focused imports over full barrels.
 - Use [`nuxt analyze`](/docs/4.x/api/commands/analyze) to spot unexpected client chunks (useful for the graph, not a full heap profile).
 
-### Nuxt 5 and Rolldown
+### Nuxt 4.5 and Rolldown
 
-Nuxt 5 uses [Rolldown](https://rolldown.rs) via Vite 8 for the client pipeline. Nitro still builds the server separately, so a faster client build alone does not guarantee a lower total peak. Measure again after upgrading. See [Migration to Vite 8](/docs/4.x/getting-started/upgrade#migration-to-vite-8).
+Nuxt 4.5 uses [Rolldown](https://rolldown.rs) via Vite 8 for the client pipeline. Nitro still builds the server separately, so a faster client build alone does not guarantee a lower total peak. Measure again after upgrading. See [Migration to Vite 8](/docs/4.x/getting-started/upgrade#migration-to-vite-8).
 
 ## Sizing CI
 

--- a/docs/3.guide/2.best-practices/build-memory.md
+++ b/docs/3.guide/2.best-practices/build-memory.md
@@ -1,0 +1,150 @@
+---
+navigation.title: 'Build Memory Usage'
+title: Build Memory Usage
+description: How to understand and reduce memory use during `nuxt build`, and how to size CI runners.
+---
+
+`nuxt build` often needs more memory than the running app. The build creates client and server bundles, runs Nitro, and may prerender routes. Module graphs, transforms, sourcemaps, and generated HTML all live in memory for part of that process.
+
+Nuxt does not publish a fixed memory budget. Peak usage depends on your source, dependencies, config, Node.js version, and preset. Measure your own build in CI before you pick a runner size.
+
+## Examples From the Community
+
+These Nuxt 4.x peaks were reported in [nuxt/nuxt#34849](https://github.com/nuxt/nuxt/issues/34849):
+
+| Project | Peak during `nuxt build` |
+| --- | --- |
+| Minimal app with `@nuxt/ui` | ~3.5–4 GB |
+| Large app (421k LOC + 82k lines of i18n JSON) | ~10–11 GB |
+| Large app with client/server sourcemaps and thousands of prerendered routes | 12+ GB |
+
+Use them as planning anchors, not as official limits. Runtime memory after deploy is a different number. Do not size production hosts from build peaks.
+
+## What Uses Memory
+
+- **Sourcemaps.** Server maps are on by default (`sourcemap.server: true`). Client maps add more.
+- **Prerendering.** Each route renders HTML and payload data; concurrency multiplies that cost.
+- **Large graphs.** Big locale JSON, generated code, and heavy modules increase what Vite/Rollup/Nitro must parse.
+- **Nitro minify.** Minifying a large server bundle can spike near the end of the build.
+
+Dependency upgrades can change the graph. In the same issue, builds started OOMing on 8 GB runners after `@nuxt/ui` 4.6.1, and other projects using Reka UI-based kits (`@nuxt/ui`, `shadcn-vue`) reported high peaks. Treat those as leads: compare the same app before and after the lockfile change.
+
+## Ways to Reduce Memory
+
+Change one setting at a time and compare peak RSS on identical builds.
+
+### Turn Off Sourcemaps You Do Not Ship
+
+```ts twoslash [nuxt.config.ts]
+export default defineNuxtConfig({
+  sourcemap: {
+    server: false,
+    client: false,
+  },
+})
+```
+
+See [`sourcemap`](/docs/4.x/api/nuxt-config#sourcemap) and [Debugging](/docs/4.x/guide/going-further/debugging#sourcemaps).
+
+### Disable Nitro `minify` if the Heap Is Tight
+
+```ts twoslash [nuxt.config.ts]
+export default defineNuxtConfig({
+  nitro: {
+    minify: false,
+  },
+})
+```
+
+One large project saw about 1 GB less peak after turning off server sourcemaps and minification together. Test each option on your own bundle.
+
+### Limit Prerender Work
+
+Prefer ISR/SWR for large dynamic sections instead of prerendering every URL:
+
+```ts twoslash [nuxt.config.ts]
+export default defineNuxtConfig({
+  routeRules: {
+    '/blog/**': { isr: 3600 },
+    '/admin/**': { prerender: false },
+  },
+  nitro: {
+    prerender: {
+      concurrency: 2,
+      crawlLinks: false,
+      routes: ['/', '/sitemap.xml'],
+    },
+  },
+})
+```
+
+Lower `concurrency` trades build time for less parallel memory use. See [Prerendering](/docs/4.x/getting-started/prerendering) and [Nitro prerender options](https://nitro.build/config#prerender).
+
+### Raise the Node Heap When the Machine Has RAM
+
+```bash [Terminal]
+NODE_OPTIONS='--max-old-space-size=8192' nuxt build
+```
+
+This helps when Node throws `FATAL ERROR: Reached heap limit` and the host still has free memory. Exit code `137` usually means the OS killed the process. A larger V8 heap does not add physical RAM.
+
+`--expose-gc` only exposes `global.gc()`. It does not free objects the build still holds.
+
+### Shrink What the Bundler Sees
+
+- Lazy-load i18n locales when your module supports it.
+- Drop unused modules; prefer focused imports over full barrels.
+- Use [`nuxt analyze`](/docs/4.x/api/commands/analyze) to spot unexpected client chunks (useful for the graph, not a full heap profile).
+
+### Nuxt 5 and Rolldown
+
+Nuxt 5 uses [Rolldown](https://rolldown.rs) via Vite 8 for the client pipeline. Nitro still builds the server separately, so a faster client build alone does not guarantee a lower total peak. Measure again after upgrading. See [Migration to Vite 8](/docs/4.x/getting-started/upgrade#migration-to-vite-8).
+
+## Sizing CI
+
+Pick a runner with more free memory than your measured peak, leaving room for the OS and package manager. Stock GitHub-hosted runners (~7 GB usable) sit at the edge for apps with UI kits or heavy prerender. Move to a larger runner or cut workload when peaks approach the limit. Swap can avoid an abrupt kill but slows the build a lot.
+
+Re-measure after Nuxt, Node, or major module upgrades on the same project and runner. That is the clearest signal of a regression.
+
+## How to Measure
+
+Peak RSS for the whole process (Linux, GNU time):
+
+```bash [Terminal]
+/usr/bin/time -v npx nuxt build
+```
+
+Heap profile when you need retained allocations:
+
+```bash [Terminal]
+NODE_OPTIONS='--heap-prof' npx nuxt build
+```
+
+Open the `.heapprofile` in Chrome DevTools. Profiling adds overhead, so size CI from normal builds.
+
+Optional stage logs in the main process:
+
+```ts [nuxt.config.ts]
+function reportMemory (stage: string) {
+  const { heapUsed, rss } = process.memoryUsage()
+  const toMiB = (bytes: number) => Math.round(bytes / 1024 / 1024)
+  console.log(`[memory] ${stage}: RSS ${toMiB(rss)} MiB, heap ${toMiB(heapUsed)} MiB`)
+}
+
+export default defineNuxtConfig({
+  hooks: {
+    'build:before' () {
+      reportMemory('build:before')
+    },
+    'build:done' () {
+      reportMemory('build:done')
+    },
+  },
+})
+```
+
+These hooks miss peaks between stages and memory in child processes.
+
+[`nuxt build --profile`](/docs/4.x/api/commands/build) writes a CPU profile. It helps find a slow stage; it does not profile heap.
+
+When you open an OOM issue, include Nuxt and Node versions, peak RSS, runner RAM, sourcemap settings, prerender route count, preset, and major module versions.

--- a/docs/3.guide/2.best-practices/build-memory.md
+++ b/docs/3.guide/2.best-practices/build-memory.md
@@ -90,15 +90,7 @@ This helps when Node throws `FATAL ERROR: Reached heap limit` and the host still
 
 `--expose-gc` only exposes `global.gc()`. It does not free objects the build still holds.
 
-### Shrink What the Bundler Sees
-
-- Lazy-load i18n locales when your module supports it.
-- Drop unused modules; prefer focused imports over full barrels.
-- Use [`nuxt analyze`](/docs/4.x/api/commands/analyze) to spot unexpected client chunks (useful for the graph, not a full heap profile).
-
-### Nuxt 4.5 and Rolldown
-
-Nuxt 4.5 uses [Rolldown](https://rolldown.rs) via Vite 8 for the client pipeline. Nitro still builds the server separately, so a faster client build alone does not guarantee a lower total peak. Measure again after upgrading. See [Migration to Vite 8](/docs/4.x/getting-started/upgrade#migration-to-vite-8).
+If a very large dependency (for example Puppeteer) lands in the client graph, [`nuxt analyze`](/docs/4.x/api/commands/analyze) can show that. For most apps, prerendering dominates peak memory more than the module graph.
 
 ## Sizing CI
 

--- a/docs/3.guide/2.best-practices/build-memory.md
+++ b/docs/3.guide/2.best-practices/build-memory.md
@@ -25,7 +25,7 @@ Use them as planning anchors, not as official limits. Runtime memory after deplo
 - **Sourcemaps.** Server maps are on by default (`sourcemap.server: true`). Client maps add more.
 - **Prerendering.** Each route renders HTML and payload data; concurrency multiplies that cost.
 - **Large graphs.** Big locale JSON, generated code, and heavy modules increase what Vite/Rollup/Nitro must parse.
-- **Nitro minify.** Minifying a large server bundle can spike near the end of the build.
+- **Nitro minification.** Minifying a large server bundle can spike near the end of the build.
 
 Dependency upgrades can change the graph. In the same issue, builds started OOMing on 8 GB runners after `@nuxt/ui` 4.6.1, and other projects using Reka UI-based kits (`@nuxt/ui`, `shadcn-vue`) reported high peaks. Treat those as leads: compare the same app before and after the lockfile change.
 
@@ -83,7 +83,7 @@ Lower `concurrency` trades build time for less parallel memory use. See [Prerend
 ### Raise the Node Heap When the Machine Has RAM
 
 ```bash [Terminal]
-NODE_OPTIONS='--max-old-space-size=8192' nuxt build
+NODE_OPTIONS='--max-old-space-size=8192' npx nuxt build
 ```
 
 This helps when Node throws `FATAL ERROR: Reached heap limit` and the host still has free memory. Exit code `137` usually means the OS killed the process. A larger V8 heap does not add physical RAM.
@@ -102,13 +102,13 @@ Nuxt 5 uses [Rolldown](https://rolldown.rs) via Vite 8 for the client pipeline. 
 
 ## Sizing CI
 
-Pick a runner with more free memory than your measured peak, leaving room for the OS and package manager. Stock GitHub-hosted runners (~7 GB usable) sit at the edge for apps with UI kits or heavy prerender. Move to a larger runner or cut workload when peaks approach the limit. Swap can avoid an abrupt kill but slows the build a lot.
+Pick a runner with more free memory than your measured peak, leaving room for the OS and package manager. Standard GitHub-hosted `macos-latest` runners have about 7 GB of RAM. Standard `ubuntu-latest` runners have 16 GB for public repositories and 8 GB for private repositories. Move to a larger runner or cut workload when peaks approach the limit. Swap can avoid an abrupt kill but slows the build a lot.
 
 Re-measure after Nuxt, Node, or major module upgrades on the same project and runner. That is the clearest signal of a regression.
 
 ## How to Measure
 
-Peak RSS for the whole process (Linux, GNU time):
+Peak RSS for the timed command (Linux, GNU time):
 
 ```bash [Terminal]
 /usr/bin/time -v npx nuxt build
@@ -145,6 +145,6 @@ export default defineNuxtConfig({
 
 These hooks miss peaks between stages and memory in child processes.
 
-[`nuxt build --profile`](/docs/4.x/api/commands/build) writes a CPU profile. It helps find a slow stage; it does not profile heap.
+[`nuxt build --profile`](/docs/4.x/api/commands/build) reports RSS and heap deltas for build stages and writes a CPU profile. It helps identify slow stages but does not produce a retained-allocation heap profile.
 
 When you open an OOM issue, include Nuxt and Node versions, peak RSS, runner RAM, sourcemap settings, prerender route count, preset, and major module versions.

--- a/docs/3.guide/2.best-practices/build-memory.md
+++ b/docs/3.guide/2.best-practices/build-memory.md
@@ -4,63 +4,17 @@ title: Build Memory Usage
 description: How to understand and reduce memory use during `nuxt build`, and how to size CI runners.
 ---
 
-`nuxt build` often needs more memory than the running app. The build creates client and server bundles, runs Nitro, and may prerender routes. Module graphs, transforms, sourcemaps, and generated HTML all live in memory for part of that process.
+`nuxt build` often needs more memory than the running app. You generate client and server bundles, run Nitro, and may prerender routes. Graphs, transforms, sourcemaps, and HTML stay in memory for parts of that work.
 
-Nuxt does not publish a fixed memory budget. Peak usage depends on your source, dependencies, config, Node.js version, and preset. Measure your own build in CI before you pick a runner size.
+Nuxt does not publish a fixed memory budget. Peak usage depends on your app, dependencies, config, Node.js version, and preset. Measure a real build on your CI runner before you pick machine size. Runtime memory after deploy is a separate number; do not size production hosts from build peaks.
 
-## Examples From the Community
+Reports in [nuxt/nuxt#34849](https://github.com/nuxt/nuxt/issues/34849) (Nuxt 4.4.x, before Vite 8) show peaks from a few gigabytes into double digits on large prerendered sites. Those numbers age quickly after Nuxt and Vite upgrades, so treat them as context and re-measure your own project.
 
-These peaks were reported in [nuxt/nuxt#34849](https://github.com/nuxt/nuxt/issues/34849) on Nuxt 4.4.x (before Vite 8). Treat them as historical planning anchors, not current limits. Peaks may be lower after Nuxt 4.5+.
+## Reducing Peak Memory
 
-| Project | Peak during `nuxt build` |
-| --- | --- |
-| Minimal app with `@nuxt/ui` | ~3.5–4 GB |
-| Large app (421k LOC + 82k lines of i18n JSON) | ~10–11 GB |
-| Large app with client/server sourcemaps and thousands of prerendered routes | 12+ GB |
+Prerendering dominates for most apps: each route holds HTML and payload data, and higher concurrency multiplies that cost. Sourcemaps (server maps are on by default), Nitro minification of a large server bundle, and very large client dependencies can push the peak further. Change one setting at a time and compare peak RSS on identical builds.
 
-Runtime memory after deploy is a different number. Do not size production hosts from build peaks.
-
-## What Uses Memory
-
-- **Sourcemaps.** Server maps are on by default (`sourcemap.server: true`). Client maps add more.
-- **Prerendering.** Each route renders HTML and payload data; concurrency multiplies that cost.
-- **Large graphs.** Big locale JSON, generated code, and heavy modules increase what Vite/Rollup/Nitro must parse.
-- **Nitro minification.** Minifying a large server bundle can spike near the end of the build.
-
-Dependency upgrades can change the graph. In the same issue, builds started OOMing on 8 GB runners after `@nuxt/ui` 4.6.1, and other projects using Reka UI-based kits (`@nuxt/ui`, `shadcn-vue`) reported high peaks. Treat those as leads: compare the same app before and after the lockfile change.
-
-## Ways to Reduce Memory
-
-Change one setting at a time and compare peak RSS on identical builds.
-
-### Turn Off Sourcemaps You Do Not Ship
-
-```ts twoslash [nuxt.config.ts]
-export default defineNuxtConfig({
-  sourcemap: {
-    server: false,
-    client: false,
-  },
-})
-```
-
-See [`sourcemap`](/docs/4.x/api/nuxt-config#sourcemap) and [Debugging](/docs/4.x/guide/going-further/debugging#sourcemaps).
-
-### Disable Nitro `minify` if the Heap Is Tight
-
-```ts twoslash [nuxt.config.ts]
-export default defineNuxtConfig({
-  nitro: {
-    minify: false,
-  },
-})
-```
-
-One large project saw about 1 GB less peak after turning off server sourcemaps and minification together. Test each option on your own bundle.
-
-### Limit Prerender Work
-
-Prefer ISR/SWR for large dynamic sections instead of prerendering every URL:
+Start with prerender work. Prefer ISR or SWR for large dynamic sections, skip prerender where you do not need static HTML, lower `concurrency`, and avoid crawling every link:
 
 ```ts twoslash [nuxt.config.ts]
 export default defineNuxtConfig({
@@ -80,33 +34,67 @@ export default defineNuxtConfig({
 
 Lower `concurrency` trades build time for less parallel memory use. See [Prerendering](/docs/4.x/getting-started/prerendering) and [Nitro prerender options](https://nitro.build/config#prerender).
 
-### Raise the Node Heap When the Machine Has RAM
+Turn off sourcemaps you do not ship:
+
+```ts twoslash [nuxt.config.ts]
+export default defineNuxtConfig({
+  sourcemap: {
+    server: false,
+    client: false,
+  },
+})
+```
+
+See [`sourcemap`](/docs/4.x/api/nuxt-config#sourcemap) and [Debugging](/docs/4.x/guide/going-further/debugging#sourcemaps).
+
+If the heap spikes near the end of the build, disable Nitro minification:
+
+```ts twoslash [nuxt.config.ts]
+export default defineNuxtConfig({
+  nitro: {
+    minify: false,
+  },
+})
+```
+
+One large project saw about 1 GB less peak after turning off server sourcemaps and minification together. Test each option on your own bundle.
+
+When Node.js throws `FATAL ERROR: Reached heap limit` and the machine has free RAM, raise the V8 heap:
 
 ```bash [Terminal]
 NODE_OPTIONS='--max-old-space-size=8192' npx nuxt build
 ```
 
-This helps when Node throws `FATAL ERROR: Reached heap limit` and the host still has free memory. Exit code `137` usually means the OS killed the process. A larger V8 heap does not add physical RAM.
+Exit code `137` means the OS killed the process. A larger heap limit does not add physical RAM. `--expose-gc` only exposes `global.gc()`; it does not free objects the build still holds.
 
-`--expose-gc` only exposes `global.gc()`. It does not free objects the build still holds.
+If a very large dependency (for example Puppeteer) lands in the client graph, [`nuxt analyze`](/docs/4.x/api/commands/analyze) can show that. For most apps, prerender work matters more than the module graph.
 
-If a very large dependency (for example Puppeteer) lands in the client graph, [`nuxt analyze`](/docs/4.x/api/commands/analyze) can show that. For most apps, prerendering dominates peak memory more than the module graph.
+## CI Runners
 
-## Sizing CI
+Pick a runner with more free memory than your measured peak, and leave room for the OS and package manager. Standard GitHub-hosted `macos-latest` runners have about 7 GB of RAM. Standard `ubuntu-latest` runners have 16 GB for public repositories and 8 GB for private repositories. Move to a larger runner or cut workload when peaks approach the limit.
 
-Pick a runner with more free memory than your measured peak, leaving room for the OS and package manager. Standard GitHub-hosted `macos-latest` runners have about 7 GB of RAM. Standard `ubuntu-latest` runners have 16 GB for public repositories and 8 GB for private repositories. Move to a larger runner or cut workload when peaks approach the limit. Swap can avoid an abrupt kill but slows the build a lot.
+If GitHub Actions kills the build for memory, add swap before `nuxt build`. The job gets slower under swap, but you finish instead of running out of memory:
 
-Re-measure after Nuxt, Node, or major module upgrades on the same project and runner. That is the clearest signal of a regression.
+```yaml [.github/workflows/ci.yml]
+- name: Add swap space
+  run: |
+    sudo fallocate -l 6G /mnt/swapfile
+    sudo chmod 600 /mnt/swapfile
+    sudo mkswap /mnt/swapfile
+    sudo swapon /mnt/swapfile
+```
 
-## How to Measure
+Re-measure after Nuxt, Node.js, or major module upgrades on the same project and runner.
 
-Peak RSS for the timed command (Linux, GNU time):
+## Measuring
+
+On Linux, peak RSS for the timed command:
 
 ```bash [Terminal]
 /usr/bin/time -v npx nuxt build
 ```
 
-Heap profile when you need retained allocations:
+For retained allocations, use a heap profile:
 
 ```bash [Terminal]
 NODE_OPTIONS='--heap-prof' npx nuxt build
@@ -114,7 +102,7 @@ NODE_OPTIONS='--heap-prof' npx nuxt build
 
 Open the `.heapprofile` in Chrome DevTools. Profiling adds overhead, so size CI from normal builds.
 
-Optional stage logs in the main process:
+You can also log RSS and heap at build hooks in the main process:
 
 ```ts [nuxt.config.ts]
 function reportMemory (stage: string) {
@@ -137,6 +125,6 @@ export default defineNuxtConfig({
 
 These hooks miss peaks between stages and memory in child processes.
 
-[`nuxt build --profile`](/docs/4.x/api/commands/build) reports RSS and heap deltas for build stages and writes a CPU profile. It helps identify slow stages but does not produce a retained-allocation heap profile.
+[`nuxt build --profile`](/docs/4.x/api/commands/build) reports RSS and heap deltas for build stages and writes a CPU profile. Use it to find slow stages; it does not produce a retained-allocation heap profile.
 
-When you open an OOM issue, include Nuxt and Node versions, peak RSS, runner RAM, sourcemap settings, prerender route count, preset, and major module versions.
+When you open an OOM issue, include Nuxt and Node.js versions, peak RSS, runner RAM, sourcemap settings, prerender route count, preset, and major module versions.

--- a/docs/3.guide/2.best-practices/performance.md
+++ b/docs/3.guide/2.best-practices/performance.md
@@ -6,6 +6,8 @@ description: Best practices for improving performance of Nuxt apps.
 
 Nuxt comes with built-in features designed to improve your application's performance and contribute to better [Core Web Vitals](https://web.dev/articles/vitals). There are also multiple Nuxt core modules that assist in improving performance in specific areas. This guide outlines best practices to optimize performance of your Nuxt application.
 
+For heap size and OOM during `nuxt build`, see [Build Memory Usage](/docs/4.x/guide/best-practices/build-memory).
+
 ## Built-in Features
 
 Nuxt offers several built-in features that help you optimize performance of your website. Understanding how these features work is crucial for achieving blazingly-fast performance.

--- a/docs/4.api/4.commands/build.md
+++ b/docs/4.api/4.commands/build.md
@@ -46,3 +46,5 @@ This command sets `process.env.NODE_ENV` to `production`.
 ::note
 `--prerender` will always set the `preset` to `static`
 ::
+
+:read-more{title="Build Memory Usage" to="/docs/4.x/guide/best-practices/build-memory"}


### PR DESCRIPTION
People keep OOMing on `nuxt build` in CI, but the docs never said how much memory a build can take or what to change first.

This adds a best-practices page with community peaks from #34849, the main memory drivers (sourcemaps, prerender, minify, graph size), practical knobs, CI sizing notes, and how to measure RSS/heap. Linked from the build command, deployment, and runtime performance pages.

Fixes #34849