### PR TITLE
fix(nuxt): correct default export detection in plugin metadata

### DIFF
--- a/packages/nuxt/src/core/plugins/plugin-metadata.ts
+++ b/packages/nuxt/src/core/plugins/plugin-metadata.ts
@@ -153,7 +153,7 @@ export const RemovePluginMetadataPlugin = (nuxt: Nuxt) => createUnplugin(() => {
       }
 
       const exports = findExports(code)
-      const defaultExport = exports.find(e => e.type === 'default' || e.name === 'default')
+      const defaultExport = exports.find(e => e.type === 'default' || e.names.includes('default'))
       if (!defaultExport) {
         pluginDiagnostics.NUXT_B2005({ src: plugin.src })
         return {

--- a/packages/nuxt/src/core/plugins/plugin-metadata.ts
+++ b/packages/nuxt/src/core/plugins/plugin-metadata.ts
@@ -153,7 +153,7 @@ export const RemovePluginMetadataPlugin = (nuxt: Nuxt) => createUnplugin(() => {
       }
 
       const exports = findExports(code)
-      const defaultExport = exports.find(e => e.type === 'default' || e.names.includes('default'))
+      const defaultExport = exports.find(e => e.type === 'default' || e.name === 'default' || e.names?.includes('default'))
       if (!defaultExport) {
         pluginDiagnostics.NUXT_B2005({ src: plugin.src })
         return {

--- a/packages/nuxt/src/core/plugins/plugin-metadata.ts
+++ b/packages/nuxt/src/core/plugins/plugin-metadata.ts
@@ -153,7 +153,7 @@ export const RemovePluginMetadataPlugin = (nuxt: Nuxt) => createUnplugin(() => {
       }
 
       const exports = findExports(code)
-      const defaultExport = exports.find(e => e.type === 'default' || e.name === 'default' || e.names?.includes('default'))
+      const defaultExport = exports.find(e => e.type === 'default' || e.names.includes('default'))
       if (!defaultExport) {
         pluginDiagnostics.NUXT_B2005({ src: plugin.src })
         return {


### PR DESCRIPTION
### 🔗 Linked issue

fixes https://github.com/nuxt/nuxt/issues/35664 


### 📚 Description

The `packages\nuxt\src\pages\runtime\plugins\check-if-page-unused.ts` has multiple named export. 
When looking up the exports in `packages\nuxt\src\core\plugins\plugin-metadata.ts`  plugins with multiple exports do not have the `name` field on the export. Only the `names` field is set with all available exports. 
<img width="1002" height="230" alt="image" src="https://github.com/user-attachments/assets/7cd24891-7a4f-453a-9396-470b87c49422" />

Checking all export names fixes this. 

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
