### PR TITLE
docs: require a single root element

### DIFF
--- a/docs/1.getting-started/09.transitions.md
+++ b/docs/1.getting-started/09.transitions.md
@@ -8,6 +8,10 @@ navigation.icon: i-lucide-toggle-right
 Nuxt leverages Vue's [`<Transition>`](https://vuejs.org/guide/built-ins/transition#the-transition-component) component to apply transitions between pages and layouts.
 ::
 
+::important
+Because Nuxt uses Vue's `<Transition>` component, a page or layout you want to animate must have a **single root element**. A page or layout with multiple root elements (a fragment) cannot be animated, so the transition will not run and navigating between routes may error. Nuxt warns about this in development. Wrap the template in a single root element (for example a `<div>`).
+::
+
 ## Page Transitions
 
 You can enable page transitions to apply an automatic transition for all your [pages](/docs/4.x/directory-structure/app/pages).


### PR DESCRIPTION
### 🔗 Linked issue

Fixes: #25748 

### 📚 Description

For VUE's Transition we need **one single root element**. Nuxt already warns us if we have more then one. This is only a documentation update