### PR TITLE
fix(nuxt): trigger HMR for pages with non-inlined SFC scripts

### DIFF
--- a/packages/nuxt/src/pages/plugins/page-meta.ts
+++ b/packages/nuxt/src/pages/plugins/page-meta.ts
@@ -347,8 +347,18 @@ export const PageMetaPlugin = (options: PageMetaPluginOptions = {}) => createUnp
           if (options.routesId && options.isPage?.(file)) {
             const macroModule = server.moduleGraph.getModuleById(file + '?macro=true')
             const routesModule = server.moduleGraph.getModuleById(options.routesId)
+            // #30709
+            const scriptModules: typeof modules = []
+            if (modules.some(m => m.id && SCRIPT_MACRO_RE.test(m.id))) {
+              for (const mod of server.moduleGraph.getModulesByFile(file) || []) {
+                if (mod.id && SCRIPT_RE.test(mod.id) && !MACRO_QUERY_RE.test(mod.id)) {
+                  scriptModules.push(mod)
+                }
+              }
+            }
             return [
               ...modules,
+              ...scriptModules,
               ...macroModule ? [macroModule] : [],
               ...routesModule ? [routesModule] : [],
             ]
@@ -368,6 +378,8 @@ function rewriteQuery (id: string) {
 }
 
 const MACRO_QUERY_RE = /[?&]macro=true(?:&|$)/
+const SCRIPT_RE = /[?&]type=script\b/
+const SCRIPT_MACRO_RE = /[?&]macro=true&.*[?&]type=script\b/
 const TYPE_PARAM_RE = /[?&]type=([^?&]+)/
 const LANG_PARAM_RE = /[?&]lang=([^?&]+)/
 function parseMacroQuery (id: string) {


### PR DESCRIPTION
### 🔗 Linked issue

fix #30709 

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description


SFC transformation result from the reproduction

```js
import { createHotContext as __vite__createHotContext } from "/_nuxt/@vite/client";import.meta.hot = __vite__createHotContext("/pages/page1.vue");import { default as __nuxt_component_0 } from "/_nuxt/@fs/D:/repo/nuxt/packages/nuxt/src/app/components/nuxt-link.ts";
import { recordPosition as _tracerRecordPosition } from "/_nuxt/@fs/D:/repo/nuxt/node_modules/.pnpm/vite-plugin-vue-tracer@1.4._677752a3a0b2664c7408f2681515d362/node_modules/vite-plugin-vue-tracer/dist/client/record.mjs?v=7c030bdd"
import _sfc_main from "/_nuxt/pages/page1.vue?t=1784454875233&vue&type=script&setup=true&lang.jsx"
export * from "/_nuxt/pages/page1.vue?t=1784454875233&vue&type=script&setup=true&lang.jsx"
import { createElementVNode as _createElementVNode, toDisplayString as _toDisplayString, createTextVNode as _createTextVNode, resolveComponent as _resolveComponent, withCtx as _withCtx, createVNode as _createVNode, openBlock as _openBlock, createElementBlock as _createElementBlock } from "/_nuxt/@fs/D:/repo/nuxt/node_modules/.pnpm/vue@3.5.40_typescript@7.0.2/node_modules/vue/dist/vue.runtime.esm-bundler.js?v=7c030bdd"

function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
  const _component_NuxtLink = __nuxt_component_0

  return (_openBlock(), _tracer(2,2,_createElementBlock("div", null, [
    _cache[1] || (_cache[1] = _tracer(3,4,_createElementVNode("h1", null, "HRM does not work", -1 /* CACHED */))),
    _tracer(4,4,_createElementVNode("div", null, _toDisplayString($setup.text))),
    _tracer(5,4,_createVNode(_component_NuxtLink, { to: "/" }, {
      default: _withCtx(() => [...(_cache[0] || (_cache[0] = [
        _createTextVNode("index", -1 /* CACHED */)
      ]))]),
      _: 1 /* STABLE */
    }))
  ])))
}



_sfc_main.__hmrId = "4c856a8c"
typeof __VUE_HMR_RUNTIME__ !== 'undefined' && __VUE_HMR_RUNTIME__.createRecord(_sfc_main.__hmrId, _sfc_main)
import.meta.hot.on('file-changed', ({ file }) => {
  __VUE_HMR_RUNTIME__.CHANGED_FILE = file
})
import.meta.hot.accept(mod => {
  if (!mod) return
  const { default: updated, _rerender_only } = mod
  if (_rerender_only) {
    __VUE_HMR_RUNTIME__.rerender(updated.__hmrId, updated.render)
  } else {
    __VUE_HMR_RUNTIME__.reload(updated.__hmrId, updated)
  }
})
import _export_sfc from "/_nuxt/@id/__x00__plugin-vue:export-helper"
export default /*#__PURE__*/_export_sfc(_sfc_main, [['render',_sfc_render],['__file',"D:/repo/nuxt/test/fixtures/basic/app/pages/page1.vue"]])
function _tracer(line, column, vnode) { return _tracerRecordPosition("test/fixtures/basic/app/pages/page1.vue", line, column, vnode) }
```

feels like more of a vite/vue bug but the file has two `type=script` modules: the real one and Nuxt's `?macro=true` one. plugin-vue's `handleHotUpdate` picks the macro module, which self-accepts, so the update never reaches the actual component.


<img width="1270" height="265" alt="image" src="https://github.com/user-attachments/assets/6cf155f2-97d6-4212-8797-c2d103b5821e" />


<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
