### PR TITLE
docs: clarify favicon does not use cdnURL by default

### DIFF
--- a/docs/1.getting-started/08.seo-meta.md
+++ b/docs/1.getting-started/08.seo-meta.md
@@ -34,7 +34,7 @@ export default defineNuxtConfig({
 ```
 
 ::note
-When you set [`app.cdnURL`](/docs/4.x/api/nuxt-config#cdnurl), your [`public/`](/docs/4.x/directory-structure/public) assets (including `favicon.ico`) are served from that CDN — Nuxt resolves public assets against `cdnURL`, falling back to `app.baseURL`. A static `app.head` link such as the `href: '/favicon.ico'` above is a literal path and does **not** incorporate this resolution. To point the favicon at the resolved location, build the `href` from runtime config with [`useHead()`](/docs/4.x/api/composables/use-head) in `app.vue`:
+When you set [`app.cdnURL`](/docs/4.x/api/nuxt-config#cdnurl), assets in your [`public/`](/docs/4.x/directory-structure/public) directory (including `favicon.ico`) are served from that CDN. Nuxt resolves public assets against `cdnURL`, falling back to `app.baseURL`. However, a static `app.head` link such as `href: '/favicon.ico'` above is a literal path and is **not** resolved against `cdnURL`. To point the favicon at the resolved location, build the `href` from runtime config with [`useHead()`](/docs/4.x/api/composables/use-head) in `app.vue`:
 
 ```vue [app/app.vue]
 <script setup lang="ts">

--- a/docs/1.getting-started/08.seo-meta.md
+++ b/docs/1.getting-started/08.seo-meta.md
@@ -33,6 +33,19 @@ export default defineNuxtConfig({
 })
 ```
 
+::note
+Files in the [`public/`](/docs/4.x/directory-structure/public) directory (such as `favicon.ico`) are served from your app's base URL, not from [`app.cdnURL`](/docs/4.x/api/nuxt-config#cdnurl). If you host these files on a CDN, reference the full URL in the `href`. Because `app.head` in your config cannot read runtime values, set it with [`useHead()`](/docs/4.x/api/composables/use-head) in `app.vue`:
+
+```ts [app/app.vue]
+const { cdnURL } = useRuntimeConfig().app
+useHead({
+  link: [
+    { rel: 'icon', type: 'image/x-icon', href: `${cdnURL || '/'}favicon.ico` },
+  ],
+})
+```
+::
+
 You can also provide any of the keys listed below in [Types](/docs/4.x/getting-started/seo-meta#types).
 
 ### Defaults Tags

--- a/docs/1.getting-started/08.seo-meta.md
+++ b/docs/1.getting-started/08.seo-meta.md
@@ -34,15 +34,17 @@ export default defineNuxtConfig({
 ```
 
 ::note
-Files in the [`public/`](/docs/4.x/directory-structure/public) directory (such as `favicon.ico`) are served from your app's base URL, not from [`app.cdnURL`](/docs/4.x/api/nuxt-config#cdnurl). If you host these files on a CDN, reference the full URL in the `href`. Because `app.head` in your config cannot read runtime values, set it with [`useHead()`](/docs/4.x/api/composables/use-head) in `app.vue`:
+When you set [`app.cdnURL`](/docs/4.x/api/nuxt-config#cdnurl), your [`public/`](/docs/4.x/directory-structure/public) assets (including `favicon.ico`) are served from that CDN — Nuxt resolves public assets against `cdnURL`, falling back to `app.baseURL`. A static `app.head` link such as the `href: '/favicon.ico'` above is a literal path and does **not** incorporate this resolution. To point the favicon at the resolved location, build the `href` from runtime config with [`useHead()`](/docs/4.x/api/composables/use-head) in `app.vue`:
 
-```ts [app/app.vue]
-const { cdnURL } = useRuntimeConfig().app
+```vue [app/app.vue]
+<script setup lang="ts">
+const { cdnURL, baseURL } = useRuntimeConfig().app
 useHead({
   link: [
-    { rel: 'icon', type: 'image/x-icon', href: `${cdnURL || '/'}favicon.ico` },
+    { rel: 'icon', type: 'image/x-icon', href: `${cdnURL || baseURL}favicon.ico` },
   ],
 })
+</script>
 ```
 ::
 


### PR DESCRIPTION
### 🔗 Linked issue

Resolves: #23297 

### 📚 Description

It is already possible to consider the favicon as `cdnURL` - by default It is maybe not the right way. I updated the docs for users they wanna do that. 

### Tests
I tested this with the playground (build/generate) and it looks like this:
<img width="716" height="72" alt="image" src="https://github.com/user-attachments/assets/004c4977-bcbf-49e9-a452-ffac82935848" />
<img width="433" height="153" alt="image" src="https://github.com/user-attachments/assets/c13b8cc4-9444-450f-b7b3-b9c7e0d20f3b" />

