### PR TITLE
docs: document disabling code-splitting with `codeSplitting: false`

### DIFF
--- a/docs/1.getting-started/07.routing.md
+++ b/docs/1.getting-started/07.routing.md
@@ -12,10 +12,12 @@ Code-splitting is enabled by default and is recommended for most apps. If you ha
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   vite: {
-    build: {
-      rollupOptions: {
-        output: {
-          codeSplitting: false,
+    $client: {
+      build: {
+        rolldownOptions: {
+          output: {
+            codeSplitting: false,
+          },
         },
       },
     },

--- a/docs/1.getting-started/07.routing.md
+++ b/docs/1.getting-started/07.routing.md
@@ -6,6 +6,26 @@ navigation.icon: i-lucide-milestone
 
 One core feature of Nuxt is the file system router. Every Vue file inside the [`app/pages/`](/docs/4.x/directory-structure/app/pages) directory creates a corresponding URL (or route) that displays the contents of the file. By using dynamic imports for each page, Nuxt leverages code-splitting to ship the minimum amount of JavaScript for the requested route.
 
+::note
+Code-splitting is enabled by default and is recommended for most apps. If you have a specific reason to ship a single bundle instead, you can disable it in your [`nuxt.config`](/docs/4.x/api/nuxt-config):
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  vite: {
+    build: {
+      rollupOptions: {
+        output: {
+          codeSplitting: false,
+        },
+      },
+    },
+  },
+})
+```
+
+This ships all JavaScript in a single file. It is rarely beneficial — it usually increases the initial download, even on slow connections — so only disable code-splitting if you have measured that it helps your case.
+::
+
 ## Pages
 
 Nuxt routing is based on [vue-router](https://router.vuejs.org) and generates the routes from every component created in the [`app/pages/` directory](/docs/4.x/directory-structure/app/pages), based on their filename.


### PR DESCRIPTION
### 🔗 Linked issue

Resolves: #24539 

### 📚 Description

Updated docs. How to disabling code splitting was not documented in the docs. Now it is :-) `inlineDynamicImports: true` is deprecated since we use **rolldown**. So `codeSplitting: false` is the right way.

Tested it also in the playground.
