### PR TITLE
feat(nuxt): log template write paths when debugging

### DIFF
--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -99,6 +99,9 @@ export async function generateApp (nuxt: Nuxt, app: NuxtApp, options: { filter?:
     if (template.modified && template.write) {
       dirs.add(dirname(fullPath))
       writes.push(() => writeFileSync(fullPath, contents, 'utf8'))
+      if (nuxt.options.debug && nuxt.options.debug.templates) {
+        logger.info(`Writing \`${template.filename}\` to \`${fullPath}\``)
+      }
     }
   }
 


### PR DESCRIPTION
### 🔗 Linked issue

Closes #24768

### 📚 Description

Adds a simple debug log for writing templates if the respective debug option is enabled.