### PR TITLE
build(nuxt): remove `.ts` file extension from `runtime/` imports

### DIFF
--- a/packages/nuxt/src/app/compat/interval.ts
+++ b/packages/nuxt/src/app/compat/interval.ts
@@ -1,5 +1,5 @@
 import { createError } from '../composables/error'
-import { appDiagnostics } from '../diagnostics/core.ts'
+import { appDiagnostics } from '../diagnostics/core'
 
 const intervalError = '[nuxt] `setInterval` should not be used on the server. Consider wrapping it with an `onNuxtReady`, `onBeforeMount` or `onMounted` lifecycle hook, or ensure you only call it in the browser by checking `import.meta.client`.'
 

--- a/packages/nuxt/src/app/components/client-fallback.server.ts
+++ b/packages/nuxt/src/app/components/client-fallback.server.ts
@@ -5,7 +5,7 @@ import { ssrInterpolate, ssrRenderAttrs, ssrRenderSlot, ssrRenderVNode } from 'v
 import { isPromise } from '@vue/shared'
 import { useState } from '../composables/state'
 import { createBuffer, sanitizeTag } from './utils'
-import { renderDiagnostics } from '../diagnostics/render.ts'
+import { renderDiagnostics } from '../diagnostics/render'
 
 interface NuxtClientFallbackProps {
   fallbackTag?: string

--- a/packages/nuxt/src/app/components/island-renderer.ts
+++ b/packages/nuxt/src/app/components/island-renderer.ts
@@ -4,7 +4,7 @@ import { viewDepthKey } from 'vue-router'
 
 import { createError } from '../composables/error'
 import { useRoute } from '../composables/router'
-import { renderDiagnostics } from '../diagnostics/render.ts'
+import { renderDiagnostics } from '../diagnostics/render'
 
 import { islandComponents, pageIslandRoutes } from '#build/components.islands.mjs'
 

--- a/packages/nuxt/src/app/components/nuxt-island.ts
+++ b/packages/nuxt/src/app/components/nuxt-island.ts
@@ -12,7 +12,7 @@ import { prerenderRoutes, useRequestEvent } from '../composables/ssr'
 import { injectHead } from '../composables/head'
 import { getFragmentHTML, isEndFragment, isStartFragment } from './utils'
 import { getIslandHash, serializeIslandProps } from '../island-hash'
-import { renderDiagnostics } from '../diagnostics/render.ts'
+import { renderDiagnostics } from '../diagnostics/render'
 
 import { appBaseURL, remoteComponentIslands, selectiveClient } from '#build/nuxt.config.mjs'
 

--- a/packages/nuxt/src/app/components/nuxt-layout.ts
+++ b/packages/nuxt/src/app/components/nuxt-layout.ts
@@ -7,7 +7,7 @@ import type { NuxtLayouts, PageMeta } from '../../pages/runtime/composables'
 import { resolveLayoutName } from '../composables/layout'
 import { useRoute, useRouter } from '../composables/router'
 import { useNuxtApp } from '../nuxt'
-import { renderDiagnostics } from '../diagnostics/render.ts'
+import { renderDiagnostics } from '../diagnostics/render'
 import { _mergeTransitionProps, _wrapInTransition } from './utils'
 import { LayoutMetaSymbol, LayoutSymbol, PageRouteSymbol } from './injections'
 

--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -20,8 +20,8 @@ import { encodeRoutePath, navigateTo, resolveRouteObject, useRouter } from '../c
 import { useNuxtApp, useRuntimeConfig } from '../nuxt'
 import type { NuxtApp } from '../nuxt'
 import { cancelIdleCallback, requestIdleCallback } from '../compat/idle-callback'
-import { renderDiagnostics } from '../diagnostics/render.ts'
-import { navigationDiagnostics } from '../diagnostics/navigation.ts'
+import { renderDiagnostics } from '../diagnostics/render'
+import { navigationDiagnostics } from '../diagnostics/navigation'
 
 import { nuxtLinkDefaults } from '#build/nuxt.config.mjs'
 

--- a/packages/nuxt/src/app/components/route-provider.ts
+++ b/packages/nuxt/src/app/components/route-provider.ts
@@ -1,7 +1,7 @@
 import { defineComponent, h, nextTick, onMounted, provide, shallowReactive } from 'vue'
 import type { DefineSetupFnComponent, Ref, VNode } from 'vue'
 import type { RouteLocationNormalizedLoaded } from 'vue-router'
-import { renderDiagnostics } from '../diagnostics/render.ts'
+import { renderDiagnostics } from '../diagnostics/render'
 import { PageRouteSymbol } from './injections'
 
 interface RouteProviderProps {

--- a/packages/nuxt/src/app/components/test-component-wrapper.ts
+++ b/packages/nuxt/src/app/components/test-component-wrapper.ts
@@ -2,7 +2,7 @@ import { defineComponent, h } from 'vue'
 import type { DefineSetupFnComponent } from 'vue'
 import { parseQuery } from 'vue-router'
 import { isAbsolute, relative, resolve } from 'pathe'
-import { renderDiagnostics } from '../diagnostics/render.ts'
+import { renderDiagnostics } from '../diagnostics/render'
 import { devRootDir } from '#build/nuxt.config.mjs'
 
 const testComponentWrapper = (url: string): DefineSetupFnComponent<{}> => defineComponent({

--- a/packages/nuxt/src/app/components/utils.ts
+++ b/packages/nuxt/src/app/components/utils.ts
@@ -4,7 +4,7 @@ import { defu } from 'defu'
 // eslint-disable-next-line
 import { isString, isPromise, isArray, isObject } from '@vue/shared'
 import type { RouteLocationNormalized } from 'vue-router'
-import { renderDiagnostics } from '../diagnostics/render.ts'
+import { renderDiagnostics } from '../diagnostics/render'
 import { START_LOCATION } from '#build/pages'
 
 /**

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -11,7 +11,7 @@ import { createError } from './error'
 import { onNuxtReady } from './ready'
 import { traceAsync } from '../internal/tracing'
 import { defineKeyedFunctionFactory } from '../../compiler/runtime'
-import { dataDiagnostics } from '../diagnostics/data.ts'
+import { dataDiagnostics } from '../diagnostics/data'
 
 import { asyncDataDefaults, granularCachedData, pendingWhenIdle, purgeCachedData, tracingChannelNuxt } from '#build/nuxt.config.mjs'
 

--- a/packages/nuxt/src/app/composables/chunk.ts
+++ b/packages/nuxt/src/app/composables/chunk.ts
@@ -1,6 +1,6 @@
 import { isScriptProtocol } from 'ufo'
 import { useNuxtApp } from '../nuxt'
-import { navigationDiagnostics } from '../diagnostics/navigation.ts'
+import { navigationDiagnostics } from '../diagnostics/navigation'
 
 export interface ReloadNuxtAppOptions {
   /**

--- a/packages/nuxt/src/app/composables/component.ts
+++ b/packages/nuxt/src/app/composables/component.ts
@@ -7,7 +7,7 @@ import { useHead } from './head'
 import { useAsyncData } from './asyncData'
 import { useRoute } from './router'
 import { createError } from './error'
-import { dataDiagnostics } from '../diagnostics/data.ts'
+import { dataDiagnostics } from '../diagnostics/data'
 
 export const NuxtComponentIndicator = '__nuxt_component'
 

--- a/packages/nuxt/src/app/composables/cookie.ts
+++ b/packages/nuxt/src/app/composables/cookie.ts
@@ -8,7 +8,7 @@ import { isEqual } from 'ohash'
 import { klona } from 'klona'
 import { useNuxtApp } from '../nuxt'
 import { useRequestEvent } from './ssr'
-import { stateDiagnostics } from '../diagnostics/state.ts'
+import { stateDiagnostics } from '../diagnostics/state'
 
 import { cookieStore } from '#build/nuxt.config.mjs'
 

--- a/packages/nuxt/src/app/composables/error.ts
+++ b/packages/nuxt/src/app/composables/error.ts
@@ -6,7 +6,7 @@ import type { NuxtApp, NuxtPayload } from '../nuxt'
 import type { NuxtError as _NuxtErrorContract } from '../types'
 import { isBotUserAgent } from '../utils'
 import { useRouter } from './router'
-import { appDiagnostics } from '../diagnostics/core.ts'
+import { appDiagnostics } from '../diagnostics/core'
 
 export const NUXT_ERROR_SIGNATURE = '__nuxt_error' as const
 

--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -6,7 +6,7 @@ import { isPlainObject } from '@vue/shared'
 import { hashKey } from '../utils/hash'
 import type { AsyncData, AsyncDataOptions, KeysOf, MultiWatchSources, PickFrom, _Transform } from './asyncData'
 import { useAsyncData } from './asyncData'
-import { dataDiagnostics } from '../diagnostics/data.ts'
+import { dataDiagnostics } from '../diagnostics/data'
 import type { NuxtError } from './error'
 import { defineKeyedFunctionFactory } from '../../compiler/runtime'
 

--- a/packages/nuxt/src/app/composables/manifest.ts
+++ b/packages/nuxt/src/app/composables/manifest.ts
@@ -1,7 +1,7 @@
 import type { H3Event } from '@nuxt/nitro-server/h3'
 import type { $Fetch, NitroRouteRules } from 'nitro/types'
 import { useRuntimeConfig } from '../nuxt'
-import { manifestDiagnostics } from '../diagnostics/manifest.ts'
+import { manifestDiagnostics } from '../diagnostics/manifest'
 import { appManifest as isAppManifestEnabled } from '#build/nuxt.config.mjs'
 import { buildAssetsURL } from '#internal/nuxt/paths'
 import { $fetch as _$fetch } from '#build/fetch'

--- a/packages/nuxt/src/app/composables/once.ts
+++ b/packages/nuxt/src/app/composables/once.ts
@@ -1,6 +1,6 @@
 import { useRouter } from './router'
 import { useNuxtApp } from '../nuxt'
-import { stateDiagnostics } from '../diagnostics/state.ts'
+import { stateDiagnostics } from '../diagnostics/state'
 
 type CallOnceOptions = {
   mode?: 'navigation' | 'render'

--- a/packages/nuxt/src/app/composables/payload.ts
+++ b/packages/nuxt/src/app/composables/payload.ts
@@ -8,7 +8,7 @@ import { useHead } from './head'
 
 import { useRoute } from './router'
 import { getAppManifest, getRouteRules } from './manifest'
-import { stateDiagnostics } from '../diagnostics/state.ts'
+import { stateDiagnostics } from '../diagnostics/state'
 
 import { appId, appManifest, multiApp, payloadExtraction } from '#build/nuxt.config.mjs'
 

--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -11,7 +11,7 @@ import { PageRouteSymbol } from '../components/injections'
 import type { NuxtError } from './error'
 import { createError, showError } from './error'
 import { getUserTrace } from '../utils'
-import { navigationDiagnostics } from '../diagnostics/navigation.ts'
+import { navigationDiagnostics } from '../diagnostics/navigation'
 import type { MakeSerializableObject } from '../../pages/runtime/utils'
 
 /** @since 3.0.0 */

--- a/packages/nuxt/src/app/composables/ssr.ts
+++ b/packages/nuxt/src/app/composables/ssr.ts
@@ -6,7 +6,7 @@ import { $fetch } from '#build/fetch'
 import type { NuxtApp } from '../nuxt'
 import { useNuxtApp } from '../nuxt'
 import { toArray } from '../utils'
-import { appDiagnostics } from '../diagnostics/core.ts'
+import { appDiagnostics } from '../diagnostics/core'
 import { useHead } from './head'
 
 /** @since 3.0.0 */

--- a/packages/nuxt/src/app/composables/state.ts
+++ b/packages/nuxt/src/app/composables/state.ts
@@ -2,7 +2,7 @@ import { isRef, toRef } from 'vue'
 import type { Ref } from 'vue'
 import { useNuxtApp } from '../nuxt'
 import { toArray } from '../utils'
-import { stateDiagnostics } from '../diagnostics/state.ts'
+import { stateDiagnostics } from '../diagnostics/state'
 
 import { useStateDefaults } from '#build/nuxt.config.mjs'
 

--- a/packages/nuxt/src/app/diagnostics/core.ts
+++ b/packages/nuxt/src/app/diagnostics/core.ts
@@ -1,5 +1,5 @@
 import { defineDiagnostics, defineProdDiagnostics } from 'nostics'
-import { docsBase, prodReporters, reporters } from './_shared.ts'
+import { docsBase, prodReporters, reporters } from './_shared'
 
 /**
  * E1xxx

--- a/packages/nuxt/src/app/diagnostics/data.ts
+++ b/packages/nuxt/src/app/diagnostics/data.ts
@@ -1,5 +1,5 @@
 import { defineDiagnostics, defineProdDiagnostics } from 'nostics'
-import { docsBase, prodReporters, reporters } from './_shared.ts'
+import { docsBase, prodReporters, reporters } from './_shared'
 
 /**
  * E3xxx

--- a/packages/nuxt/src/app/diagnostics/head.ts
+++ b/packages/nuxt/src/app/diagnostics/head.ts
@@ -1,5 +1,5 @@
 import { defineDiagnostics, defineProdDiagnostics } from 'nostics'
-import { docsBase, prodReporters, reporters } from './_shared.ts'
+import { docsBase, prodReporters, reporters } from './_shared'
 
 /**
  * E6xxx

--- a/packages/nuxt/src/app/diagnostics/manifest.ts
+++ b/packages/nuxt/src/app/diagnostics/manifest.ts
@@ -1,5 +1,5 @@
 import { defineDiagnostics, defineProdDiagnostics } from 'nostics'
-import { docsBase, prodReporters, reporters } from './_shared.ts'
+import { docsBase, prodReporters, reporters } from './_shared'
 
 /**
  * E5xxx

--- a/packages/nuxt/src/app/diagnostics/navigation.ts
+++ b/packages/nuxt/src/app/diagnostics/navigation.ts
@@ -1,5 +1,5 @@
 import { defineDiagnostics, defineProdDiagnostics } from 'nostics'
-import { docsBase, prodReporters, reporters } from './_shared.ts'
+import { docsBase, prodReporters, reporters } from './_shared'
 
 /**
  * E2xxx

--- a/packages/nuxt/src/app/diagnostics/render.ts
+++ b/packages/nuxt/src/app/diagnostics/render.ts
@@ -1,5 +1,5 @@
 import { defineDiagnostics, defineProdDiagnostics } from 'nostics'
-import { docsBase, prodReporters, reporters } from './_shared.ts'
+import { docsBase, prodReporters, reporters } from './_shared'
 
 /**
  * E4xxx

--- a/packages/nuxt/src/app/diagnostics/state.ts
+++ b/packages/nuxt/src/app/diagnostics/state.ts
@@ -1,5 +1,5 @@
 import { defineDiagnostics, defineProdDiagnostics } from 'nostics'
-import { docsBase, prodReporters, reporters } from './_shared.ts'
+import { docsBase, prodReporters, reporters } from './_shared'
 
 /**
  * E7xxx

--- a/packages/nuxt/src/app/entry.ts
+++ b/packages/nuxt/src/app/entry.ts
@@ -8,7 +8,7 @@ import { applyPlugins, createNuxtApp } from './nuxt'
 import type { CreateOptions, NuxtSSRContext } from './nuxt'
 
 import { createError } from './composables/error'
-import { appDiagnostics } from './diagnostics/core.ts'
+import { appDiagnostics } from './diagnostics/core'
 
 import '#build/css'
 import plugins from '#build/plugins'

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -19,7 +19,7 @@ import type { RouteAnnouncer } from './composables/route-announcer'
 import type { NuxtAnnouncer } from './composables/announcer'
 import type { AppConfig, AppConfigInput, RuntimeConfig } from 'nuxt/schema'
 
-import { appDiagnostics } from './diagnostics/core.ts'
+import { appDiagnostics } from './diagnostics/core'
 import { appId, asyncCallHook, chunkErrorEvent, componentIslands, hasIslandOptOutPlugins, hasParallelPlugins, hasPluginDependencies, hasPluginHooks, multiApp, tracingChannelNuxt } from '#build/nuxt.config.mjs'
 
 export type { NuxtPayload, NuxtSSRContext, PluginMeta } from './types'

--- a/packages/nuxt/src/app/plugins/check-if-layout-used.ts
+++ b/packages/nuxt/src/app/plugins/check-if-layout-used.ts
@@ -3,7 +3,7 @@ import { defineNuxtPlugin } from '../nuxt'
 import type { ObjectPlugin, Plugin } from '../nuxt'
 import { onNuxtReady } from '../composables/ready'
 import { useError } from '../composables/error'
-import { renderDiagnostics } from '../diagnostics/render.ts'
+import { renderDiagnostics } from '../diagnostics/render'
 
 import layouts from '#build/layouts'
 

--- a/packages/nuxt/src/app/plugins/payload.client.ts
+++ b/packages/nuxt/src/app/plugins/payload.client.ts
@@ -5,7 +5,7 @@ import { onNuxtReady } from '../composables/ready'
 import { useRouter } from '../composables/router'
 import { getAppManifest } from '../composables/manifest'
 import { injectHead } from '../composables/head'
-import { stateDiagnostics } from '../diagnostics/state.ts'
+import { stateDiagnostics } from '../diagnostics/state'
 
 import { appManifest as isAppManifestEnabled, prefetchPreloadTags, purgeCachedData } from '#build/nuxt.config.mjs'
 

--- a/packages/nuxt/src/app/plugins/router.ts
+++ b/packages/nuxt/src/app/plugins/router.ts
@@ -7,7 +7,7 @@ import type { ObjectPlugin, Plugin } from '../nuxt'
 import { getRouteRules } from '../composables/manifest'
 import { clearError, showError } from '../composables/error'
 import { navigateTo } from '../composables/router'
-import { navigationDiagnostics } from '../diagnostics/navigation.ts'
+import { navigationDiagnostics } from '../diagnostics/navigation'
 
 import { globalMiddleware } from '#build/middleware'
 

--- a/packages/nuxt/src/compiler/runtime/index.ts
+++ b/packages/nuxt/src/compiler/runtime/index.ts
@@ -1,4 +1,4 @@
-import { appDiagnostics } from '../../app/diagnostics/core.ts'
+import { appDiagnostics } from '../../app/diagnostics/core'
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
 export interface ObjectFactory<T extends Function> {

--- a/packages/nuxt/src/head/runtime/components.ts
+++ b/packages/nuxt/src/head/runtime/components.ts
@@ -18,7 +18,7 @@ import type {
   Target,
 } from './types'
 import { useHead } from '#app/composables/head'
-import { unheadDiagnostics } from '../../app/diagnostics/head.ts'
+import { unheadDiagnostics } from '../../app/diagnostics/head'
 
 interface HeadComponents {
   base?: UnheadBase | null

--- a/packages/nuxt/src/head/runtime/composables.ts
+++ b/packages/nuxt/src/head/runtime/composables.ts
@@ -9,7 +9,7 @@ import {
 } from '@unhead/vue'
 import { useNuxtApp } from '#app/nuxt'
 import type { NuxtApp } from '#app/nuxt'
-import { unheadDiagnostics } from '../../app/diagnostics/head.ts'
+import { unheadDiagnostics } from '../../app/diagnostics/head'
 
 /**
  * Injects the head client from the Nuxt context or Vue inject.

--- a/packages/nuxt/src/pages/runtime/composables.ts
+++ b/packages/nuxt/src/pages/runtime/composables.ts
@@ -5,7 +5,7 @@ import { useRoute } from 'vue-router'
 import type { NitroRouteConfig } from 'nitro/types'
 import type { NuxtError } from '#app/composables/error'
 import { useNuxtApp } from '#app/nuxt'
-import { appDiagnostics } from '../../app/diagnostics/core.ts'
+import { appDiagnostics } from '../../app/diagnostics/core'
 import type { SerializableValue } from './utils'
 
 // Generated at runtime to be extended

--- a/packages/nuxt/src/pages/runtime/page-placeholder.ts
+++ b/packages/nuxt/src/pages/runtime/page-placeholder.ts
@@ -1,6 +1,6 @@
 import { defineComponent } from 'vue'
 import type { DefineSetupFnComponent, SlotsType, VNode } from 'vue'
-import { renderDiagnostics } from '../../app/diagnostics/render.ts'
+import { renderDiagnostics } from '../../app/diagnostics/render'
 import { devPagesDir } from '#build/nuxt.config.mjs'
 
 type PagePlaceholderSlots = SlotsType<{

--- a/packages/nuxt/src/pages/runtime/plugins/check-if-page-unused.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/check-if-page-unused.ts
@@ -5,7 +5,7 @@ import type { ObjectPlugin, Plugin } from '#app/nuxt'
 import { onNuxtReady } from '#app/composables/ready'
 import { useError } from '#app/composables/error'
 import { useRouter } from '#app/composables/router'
-import { renderDiagnostics } from '../../../app/diagnostics/render.ts'
+import { renderDiagnostics } from '../../../app/diagnostics/render'
 
 export function findUnrenderedNestedPage (route: RouteLocationNormalizedLoaded): { parent: RouteRecordNormalized, child: RouteRecordNormalized } | undefined {
   let parent: RouteRecordNormalized | undefined

--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -14,7 +14,7 @@ import { getRouteRules } from '#app/composables/manifest'
 import { defineNuxtPlugin, useRuntimeConfig } from '#app/nuxt'
 import { _showErrorUnlessCrawler, clearError, createError, isNuxtError, showError, useError } from '#app/composables/error'
 import { navigateTo } from '#app/composables/router'
-import { navigationDiagnostics } from '../../../app/diagnostics/navigation.ts'
+import { navigationDiagnostics } from '../../../app/diagnostics/navigation'
 
 import _routes, { handleHotUpdate } from '#build/routes'
 import routerOptions, { hashMode } from '#build/router.options.mjs'


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Found while building on windows. Maybe also a rolldown issue. 

When building, it  seems like rolldown preserves the file extension in the build. 

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
