### PR TITLE
docs: recommend status over pending in data fetching

### DIFF
--- a/docs/1.getting-started/10.data-fetching.md
+++ b/docs/1.getting-started/10.data-fetching.md
@@ -546,8 +546,6 @@ const id = ref(null)
 const { data, status } = useLazyFetch(() => `/api/users/${id.value}`, {
   immediate: false,
 })
-
-const pending = computed(() => status.value === 'pending')
 </script>
 
 <template>
@@ -556,14 +554,14 @@ const pending = computed(() => status.value === 'pending')
     <input
       v-model="id"
       type="number"
-      :disabled="pending"
+      :disabled="status === 'pending'"
     >
 
     <div v-if="status === 'idle'">
       Type a user ID
     </div>
 
-    <div v-else-if="pending">
+    <div v-else-if="status === 'pending'">
       Loading ...
     </div>
 

--- a/docs/3.guide/6.going-further/1.experimental-features.md
+++ b/docs/3.guide/6.going-further/1.experimental-features.md
@@ -915,9 +915,11 @@ export default defineNuxtConfig({
 
 ## pendingWhenIdle
 
-For `useAsyncData` and `useFetch`, whether `pending` should be `true` when data has not yet started to be fetched.
+`pendingWhenIdle` controls the `pending` ref returned by `useAsyncData` and `useFetch`.
 
-This flag is disabled by default, but you can enable this feature:
+When `pendingWhenIdle` is `false` (the default), `pending` is `true` while a request is in flight and matches `status === 'pending'`. While `status` is `idle`, `pending` stays `false`. You can see this with `{ immediate: false }`, or with `{ server: false }` during server rendering.
+
+Set `pendingWhenIdle: true` so `pending` is also `true` when `status` is `idle`. Use `status` when your loading UI needs to distinguish `idle` from an in-flight request.
 
 ```ts twoslash [nuxt.config.ts]
 export default defineNuxtConfig({

--- a/docs/3.guide/6.going-further/1.experimental-features.md
+++ b/docs/3.guide/6.going-further/1.experimental-features.md
@@ -919,7 +919,7 @@ export default defineNuxtConfig({
 
 When `pendingWhenIdle` is `false` (the default), `pending` is `true` while a request is in flight and matches `status === 'pending'`. While `status` is `idle`, `pending` stays `false`. You can see this with `{ immediate: false }`, or with `{ server: false }` during server rendering.
 
-Set `pendingWhenIdle: true` so `pending` is also `true` when `status` is `idle`. Use `status` when your loading UI needs to distinguish `idle` from an in-flight request.
+Set `pendingWhenIdle: true` so `pending` is also `true` when `status` is `idle` and no cached data is available. Use `status` when your loading UI needs to distinguish `idle` from an in-flight request.
 
 ```ts twoslash [nuxt.config.ts]
 export default defineNuxtConfig({

--- a/docs/4.api/2.composables/use-async-data.md
+++ b/docs/4.api/2.composables/use-async-data.md
@@ -18,7 +18,7 @@ Within your pages, components, and plugins you can use useAsyncData to get acces
 
 ```vue [app/pages/index.vue]
 <script setup lang="ts">
-const { data, status, pending, error, refresh, clear } = await useAsyncData(
+const { data, status, error, refresh, clear } = await useAsyncData(
   'mountains',
   (_nuxtApp, { signal }) => $fetch('https://api.nuxtjs.dev/mountains', { signal }),
 )
@@ -34,7 +34,7 @@ You do not need to `await` `useAsyncData`. On the server, Nuxt waits for the pro
 ::
 
 ::note
-`data`, `status`, `pending` and `error` are Vue refs and they should be accessed with `.value` when used within the `<script setup>`, while `refresh`/`execute` and `clear` are plain functions.
+`data`, `status`, and `error` are Vue refs. Access their values with `.value` in `<script setup>`. `refresh`/`execute` and `clear` are plain functions.
 ::
 
 ### Watch Parameters
@@ -244,7 +244,7 @@ You can use `useLazyAsyncData` to have the same behavior as `lazy: true` with `u
 
 ### Shared State and Option Consistency
 
-When using the same key for multiple `useAsyncData` calls, they will share the same `data`, `error`, `status` and `pending` refs. This ensures consistency across components but requires option consistency.
+When multiple `useAsyncData` calls use the same key, they share the same `data`, `error`, `status`, and `pending` refs. Keep the options listed below consistent across these calls.
 
 The following options **must be consistent** across all calls with the same key:
 - `handler` function
@@ -294,8 +294,8 @@ If you have not fetched data on the server (for example, with `server: false`), 
 | `refresh` | `(opts?: AsyncDataExecuteOptions) => Promise<void>` | Function to manually refresh the data. By default, Nuxt waits until a `refresh` is finished before it can be executed again.                                      |
 | `execute` | `(opts?: AsyncDataExecuteOptions) => Promise<void>` | Alias for `refresh`.                                                                                                                                              |
 | `error`   | `Ref<ErrorT \| undefined>`                          | Error object if the asynchronous function threw an error.                                                                                                         |
-| `status`  | `Ref<'idle' \| 'pending' \| 'success' \| 'error'>`  | Status of the asynchronous function call. See below for possible values.                                                                                          |
-| `pending` | `Ref<boolean>`                                      | Boolean flag indicating whether the current call is in progress.                                                                                                  |
+| `status`  | `Ref<'idle' \| 'pending' \| 'success' \| 'error'>`  | Status of the asynchronous function call. Use it to distinguish `idle`, `pending`, `success`, and `error`.                                                        |
+| `pending` | `Ref<boolean>`                                      | `true` while a request is in flight. With [`experimental.pendingWhenIdle`](/docs/4.x/guide/going-further/experimental-features#pendingwhenidle), it is also `true` before the request starts. |
 | `clear`   | `() => void`                                        | Resets `data` to `undefined` (or the value of `options.default()` if provided), `error` to `undefined`, set `status` to `idle`, and cancels any pending calls.    |
 
 ::tip

--- a/docs/4.api/2.composables/use-async-data.md
+++ b/docs/4.api/2.composables/use-async-data.md
@@ -18,7 +18,7 @@ Within your pages, components, and plugins you can use useAsyncData to get acces
 
 ```vue [app/pages/index.vue]
 <script setup lang="ts">
-const { data, status, error, refresh, clear } = await useAsyncData(
+const { data, status, pending, error, refresh, clear } = await useAsyncData(
   'mountains',
   (_nuxtApp, { signal }) => $fetch('https://api.nuxtjs.dev/mountains', { signal }),
 )
@@ -34,7 +34,7 @@ You do not need to `await` `useAsyncData`. On the server, Nuxt waits for the pro
 ::
 
 ::note
-`data`, `status`, and `error` are Vue refs. Access their values with `.value` in `<script setup>`. `refresh`/`execute` and `clear` are plain functions.
+`data`, `status`, `pending`, and `error` are Vue refs. Access their values with `.value` in `<script setup>`. `refresh`/`execute` and `clear` are plain functions.
 ::
 
 ### Watch Parameters
@@ -295,7 +295,7 @@ If you have not fetched data on the server (for example, with `server: false`), 
 | `execute` | `(opts?: AsyncDataExecuteOptions) => Promise<void>` | Alias for `refresh`.                                                                                                                                              |
 | `error`   | `Ref<ErrorT \| undefined>`                          | Error object if the asynchronous function threw an error.                                                                                                         |
 | `status`  | `Ref<'idle' \| 'pending' \| 'success' \| 'error'>`  | Status of the asynchronous function call. Use it to distinguish `idle`, `pending`, `success`, and `error`.                                                        |
-| `pending` | `Ref<boolean>`                                      | `true` while a request is in flight. With [`experimental.pendingWhenIdle`](/docs/4.x/guide/going-further/experimental-features#pendingwhenidle), it is also `true` before the request starts. |
+| `pending` | `Ref<boolean>`                                      | `true` while a request is in flight. With [`experimental.pendingWhenIdle`](/docs/4.x/guide/going-further/experimental-features#pendingwhenidle), it is also `true` when `status` is `idle` and no cached data is available. |
 | `clear`   | `() => void`                                        | Resets `data` to `undefined` (or the value of `options.default()` if provided), `error` to `undefined`, set `status` to `idle`, and cancels any pending calls.    |
 
 ::tip

--- a/docs/4.api/2.composables/use-fetch.md
+++ b/docs/4.api/2.composables/use-fetch.md
@@ -262,8 +262,8 @@ If you have not fetched data on the server (for example, with `server: false`), 
 | `refresh` | `(opts?: AsyncDataExecuteOptions) => Promise<void>` | Function to manually refresh the data. By default, Nuxt waits until a `refresh` is finished before it can be executed again.                                      |
 | `execute` | `(opts?: AsyncDataExecuteOptions) => Promise<void>` | Alias for `refresh`.                                                                                                                                              |
 | `error`   | `Ref<ErrorT \| undefined>`                          | Error object if the data fetching failed.                                                                                                                         |
-| `status`  | `Ref<'idle' \| 'pending' \| 'success' \| 'error'>`  | Status of the data request. See below for possible values.                                                                                                        |
-| `pending` | `Ref<boolean>`                                      | Boolean flag indicating whether the current request is in progress.                                                                                               |
+| `status`  | `Ref<'idle' \| 'pending' \| 'success' \| 'error'>`  | Status of the data request. Use it to distinguish `idle`, `pending`, `success`, and `error`.                                                                      |
+| `pending` | `Ref<boolean>`                                      | `true` while a request is in flight. With [`experimental.pendingWhenIdle`](/docs/4.x/guide/going-further/experimental-features#pendingwhenidle), it is also `true` before the request starts. |
 | `clear`   | `() => void`                                        | Resets `data` to `undefined` (or the value of `options.default()` if provided), `error` to `undefined`, set `status` to `idle`, and cancels any pending requests. |
 
 ::tip

--- a/docs/4.api/2.composables/use-fetch.md
+++ b/docs/4.api/2.composables/use-fetch.md
@@ -263,7 +263,7 @@ If you have not fetched data on the server (for example, with `server: false`), 
 | `execute` | `(opts?: AsyncDataExecuteOptions) => Promise<void>` | Alias for `refresh`.                                                                                                                                              |
 | `error`   | `Ref<ErrorT \| undefined>`                          | Error object if the data fetching failed.                                                                                                                         |
 | `status`  | `Ref<'idle' \| 'pending' \| 'success' \| 'error'>`  | Status of the data request. Use it to distinguish `idle`, `pending`, `success`, and `error`.                                                                      |
-| `pending` | `Ref<boolean>`                                      | `true` while a request is in flight. With [`experimental.pendingWhenIdle`](/docs/4.x/guide/going-further/experimental-features#pendingwhenidle), it is also `true` before the request starts. |
+| `pending` | `Ref<boolean>`                                      | `true` while a request is in flight. With [`experimental.pendingWhenIdle`](/docs/4.x/guide/going-further/experimental-features#pendingwhenidle), it is also `true` when `status` is `idle` and no cached data is available. |
 | `clear`   | `() => void`                                        | Resets `data` to `undefined` (or the value of `options.default()` if provided), `error` to `undefined`, set `status` to `idle`, and cancels any pending requests. |
 
 ::tip

--- a/docs/4.api/2.composables/use-lazy-async-data.md
+++ b/docs/4.api/2.composables/use-lazy-async-data.md
@@ -36,7 +36,7 @@ const { status, data: posts } = await useLazyAsyncData('posts', () => $fetch('/a
 </template>
 ```
 
-When using `useLazyAsyncData`, navigation will occur before fetching is complete. This means you must handle `pending` and `error` states directly within your component's template.
+`useLazyAsyncData` lets navigation continue while it fetches data. Check `status === 'pending'` and `status === 'error'` in your component's template before using the result.
 
 ::warning
 `useLazyAsyncData` is a reserved function name transformed by the compiler, so you should not name your own function `useLazyAsyncData`.
@@ -75,8 +75,8 @@ export function useLazyAsyncData<ResT, DataE = unknown, DataT = ResT> (
 
 ```vue [app/pages/index.vue]
 <script setup lang="ts">
-/* Navigation will occur before fetching is complete.
-  Handle 'pending' and 'error' states directly within your component's template
+/* useLazyAsyncData lets navigation continue before the fetch completes.
+  Handle loading and error states in the template.
 */
 const { status, data: count } = await useLazyAsyncData('count', () => $fetch('/api/count'))
 

--- a/docs/4.api/2.composables/use-lazy-async-data.md
+++ b/docs/4.api/2.composables/use-lazy-async-data.md
@@ -87,8 +87,14 @@ watch(count, (newCount) => {
 </script>
 
 <template>
-  <div>
-    {{ status === 'pending' ? 'Loading' : count }}
+  <div v-if="status === 'pending'">
+    Loading
+  </div>
+  <div v-else-if="status === 'error'">
+    Error loading count
+  </div>
+  <div v-else>
+    {{ count }}
   </div>
 </template>
 ```

--- a/docs/4.api/2.composables/use-lazy-fetch.md
+++ b/docs/4.api/2.composables/use-lazy-fetch.md
@@ -23,6 +23,9 @@ const { status, data: posts } = await useLazyFetch('/api/posts')
   <div v-if="status === 'pending'">
     Loading ...
   </div>
+  <div v-else-if="status === 'error'">
+    Error loading posts
+  </div>
   <div v-else>
     <div v-for="post in posts">
       <!-- do something -->
@@ -36,7 +39,7 @@ const { status, data: posts } = await useLazyFetch('/api/posts')
 ::
 
 ::warning
-Awaiting `useLazyFetch` initializes the call but does not wait for the data. During client-side navigation, check `status === 'pending'` in your component's template before using the result.
+Awaiting `useLazyFetch` initializes the call but does not wait for the data. During client-side navigation, check `status === 'pending'` and `status === 'error'` in your component's template before using the result.
 ::
 
 ::warning
@@ -100,6 +103,9 @@ watch(posts, (newPosts) => {
 <template>
   <div v-if="status === 'pending'">
     Loading ...
+  </div>
+  <div v-else-if="status === 'error'">
+    Error loading posts
   </div>
   <div v-else>
     <div v-for="post in posts">

--- a/docs/4.api/2.composables/use-lazy-fetch.md
+++ b/docs/4.api/2.composables/use-lazy-fetch.md
@@ -36,7 +36,7 @@ const { status, data: posts } = await useLazyFetch('/api/posts')
 ::
 
 ::warning
-Awaiting `useLazyFetch` only ensures the call is initialized. On client-side navigation, data may not be immediately available, and you must handle the `pending` state in your component's template.
+Awaiting `useLazyFetch` initializes the call but does not wait for the data. During client-side navigation, check `status === 'pending'` in your component's template before using the result.
 ::
 
 ::warning
@@ -75,20 +75,20 @@ Returns the same `AsyncData` object as [`useFetch`](/docs/4.x/api/composables/us
 | `refresh` | `(opts?: AsyncDataExecuteOptions) => Promise<void>` | Function to manually refresh the data.                                                                           |
 | `execute` | `(opts?: AsyncDataExecuteOptions) => Promise<void>` | Alias for `refresh`.                                                                                             |
 | `error`   | `Ref<ErrorT \| undefined>`                          | Error object if the data fetching failed.                                                                        |
-| `status`  | `Ref<'idle' \| 'pending' \| 'success' \| 'error'>`  | Status of the data request.                                                                                      |
-| `pending` | `Ref<boolean>`                                      | Boolean flag indicating whether the current request is in progress.                                              |
+| `status`  | `Ref<'idle' \| 'pending' \| 'success' \| 'error'>`  | Status of the data request. Use it to distinguish `idle`, `pending`, `success`, and `error`.                     |
+| `pending` | `Ref<boolean>`                                      | `true` while a request is in flight. See [`useFetch`](/docs/4.x/api/composables/use-fetch#return-values).        |
 | `clear`   | `() => void`                                        | Resets `data` to `undefined`, `error` to `undefined`, sets `status` to `idle`, and cancels any pending requests. |
 
 :read-more{to="/docs/4.x/api/composables/use-fetch#return-values"}
 
 ## Example
 
-### Handling Pending State
+### Handling Loading State
 
 ```vue [app/pages/index.vue]
 <script setup lang="ts">
-/* Navigation will occur before fetching is complete.
- * Handle 'pending' and 'error' states directly within your component's template
+/* useLazyFetch lets navigation continue before the fetch completes.
+ * Handle loading and error states in the template.
  */
 const { status, data: posts } = await useLazyFetch('/api/posts')
 watch(posts, (newPosts) => {


### PR DESCRIPTION
This makes the data fetching docs lead with `status` instead of `pending`.

The `useFetch` and `useAsyncData` pages already mentioned `status` in a note, but their main examples and prose still destructured `pending`, and the getting-started guide wrapped it in an extra `computed`. That is confusing for new readers, since `status` is the more capable ref: it tells you whether a request is `idle`, `pending`, `success`, or `error`, while `pending` is just a boolean.

What changed:

- `useAsyncData` and `useFetch` usage examples and Return Values now lead with `status`. `pending` stays documented as part of the public API, with its exact meaning (`true` while a request is in flight, plus the `experimental.pendingWhenIdle` variant).
- The reactive-URL example in the data fetching guide compares `status === 'pending'` directly instead of aliasing it through a `computed`.
- The `useLazyFetch` and `useLazyAsyncData` pages now point readers at `status` for loading and error handling.
- The `pendingWhenIdle` experimental flag description spells out how it changes the `pending` ref relative to `status`.

I deliberately avoided calling `pending` deprecated or adding runtime warnings, since the source still exposes it without a `@deprecated` annotation and `compatibilityVersion: 5` does not change its behavior. This covers the documentation part of #26560; the deprecation registry and console warnings it also asks for would need a separate decision from the team.

Refs #26560