### PR TITLE
feat(nuxt): add IDE hover docs for built-in components

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -50,6 +50,7 @@ exclude = [
   "https://nuxt.new/s/v4",
   "https://www.npmjs.com/",
   'https://nuxt\.com/docs/4\.x/api/composables/\$%7BkebabCase\(factory\.name\)%7D.*',
+  'https://nuxt\.com/docs/4\.x/api/components/\$%7Bslug%7D',
   'https://nuxt\.com/docs/4\.x/errors/\$%7B.*',
   # TODO: fix upstream API issues
   "https://nuxt.com/modules",

--- a/packages/nuxt/src/components/builtin-metadata.ts
+++ b/packages/nuxt/src/components/builtin-metadata.ts
@@ -1,0 +1,49 @@
+import type { ComponentMeta } from 'nuxt/schema'
+
+export type BuiltinComponentName =
+  | 'ClientOnly'
+  | 'DevOnly'
+  | 'NuxtClientFallback'
+  | 'NuxtPage'
+  | 'NuxtLayout'
+  | 'NuxtLink'
+  | 'NuxtLoadingIndicator'
+  | 'NuxtErrorBoundary'
+  | 'NuxtWelcome'
+  | 'NuxtIsland'
+  | 'NuxtImg'
+  | 'NuxtPicture'
+  | 'NuxtRouteAnnouncer'
+  | 'NuxtTime'
+  | 'NuxtAnnouncer'
+
+type BuiltinComponentMeta = Required<Pick<ComponentMeta, 'description' | 'docsUrl'>>
+
+function defineBuiltinMeta (slug: string, description: string): BuiltinComponentMeta {
+  return {
+    description,
+    docsUrl: `https://nuxt.com/docs/4.x/api/components/${slug}`,
+  }
+}
+
+export const BUILTIN_COMPONENT_META = {
+  ClientOnly: defineBuiltinMeta('client-only', 'Renders its default slot only on the client, with an optional server fallback.'),
+  DevOnly: defineBuiltinMeta('dev-only', 'Renders its content only during development.'),
+  NuxtClientFallback: defineBuiltinMeta('nuxt-client-fallback', 'Renders its content on the client when a child fails during server-side rendering.'),
+  NuxtPage: defineBuiltinMeta('nuxt-page', 'Renders the current page from the `pages/` directory.'),
+  NuxtLayout: defineBuiltinMeta('nuxt-layout', 'Renders the selected layout around pages or error content.'),
+  NuxtLink: defineBuiltinMeta('nuxt-link', 'A drop-in replacement for Vue Router\'s `<RouterLink>` and the HTML `<a>` element.'),
+  NuxtLoadingIndicator: defineBuiltinMeta('nuxt-loading-indicator', 'Displays a progress bar during page navigation.'),
+  NuxtErrorBoundary: defineBuiltinMeta('nuxt-error-boundary', 'Catches client-side errors from its default slot and renders an error slot.'),
+  NuxtWelcome: defineBuiltinMeta('nuxt-welcome', 'Displays the welcome screen used by new Nuxt projects.'),
+  NuxtIsland: defineBuiltinMeta('nuxt-island', 'Renders a non-interactive server component without shipping client-side JavaScript.'),
+  NuxtImg: defineBuiltinMeta('nuxt-img', 'Renders an optimized image through the Nuxt Image module.'),
+  NuxtPicture: defineBuiltinMeta('nuxt-picture', 'Renders responsive optimized images through the Nuxt Image module.'),
+  NuxtRouteAnnouncer: defineBuiltinMeta('nuxt-route-announcer', 'Announces route changes to assistive technologies using the current page title.'),
+  NuxtTime: defineBuiltinMeta('nuxt-time', 'Formats dates and times consistently across server and client using the user\'s locale.'),
+  NuxtAnnouncer: defineBuiltinMeta('nuxt-announcer', 'Announces dynamic content changes to assistive technologies.'),
+} as const satisfies Record<BuiltinComponentName, BuiltinComponentMeta>
+
+export function getBuiltinComponentMeta (name: BuiltinComponentName): ComponentMeta {
+  return { ...BUILTIN_COMPONENT_META[name] }
+}

--- a/packages/nuxt/src/components/templates.ts
+++ b/packages/nuxt/src/components/templates.ts
@@ -2,7 +2,13 @@ import { isAbsolute, join, relative, resolve } from 'pathe'
 import { genDynamicImport, genDynamicTypeImport, genObjectKey } from 'knitwork'
 import { hash } from 'ohash'
 import { distDir } from '../dirs.ts'
-import type { NuxtApp, NuxtPluginTemplate, NuxtTemplate } from 'nuxt/schema'
+import type { ComponentMeta, NuxtApp, NuxtPluginTemplate, NuxtTemplate } from 'nuxt/schema'
+
+type ResolvedComponentType = {
+  pascalName: string
+  type: string
+  meta?: ComponentMeta
+}
 
 type ImportMagicCommentsOptions = {
   chunkName: string
@@ -119,9 +125,32 @@ export const componentsIslandsTemplate: NuxtTemplate = {
 }
 
 const NON_VUE_RE = /\b\.(?!vue)\w+$/g
+
+function escapeJsDocText (value: string) {
+  return value.replace(/\*\//g, '* /')
+}
+
+function renderComponentJsDoc (meta?: ComponentMeta, options: { indent?: string, lazyName?: string } = {}) {
+  if (!meta?.description && !meta?.docsUrl) {
+    return ''
+  }
+  const indent = options.indent || ''
+  const sections: string[] = []
+  if (options.lazyName) {
+    sections.push(`Lazy-loaded version of \`<${options.lazyName}>\`.`)
+  }
+  if (meta?.description) {
+    sections.push(escapeJsDocText(meta.description))
+  }
+  if (meta?.docsUrl) {
+    sections.push(`@see ${escapeJsDocText(meta.docsUrl)}`)
+  }
+  return `${indent}/**\n${indent} * ${sections.join(`\n${indent} *\n${indent} * `)}\n${indent} */\n`
+}
+
 function resolveComponentTypes (app: NuxtApp, baseDir: string, dynamic: boolean) {
   const serverPlaceholderPath = resolve(distDir, 'app/components/server-placeholder')
-  const componentTypes: Array<[string, string]> = []
+  const componentTypes: ResolvedComponentType[] = []
   for (const c of app.components) {
     if (c.island) {
       continue
@@ -139,7 +168,7 @@ function resolveComponentTypes (app: NuxtApp, baseDir: string, dynamic: boolean)
         type = `IslandComponent<${type}>`
       }
     }
-    componentTypes.push([c.pascalName, type])
+    componentTypes.push({ pascalName: c.pascalName, type, meta: c.meta })
   }
 
   return componentTypes
@@ -182,8 +211,8 @@ import type { DefineComponent, SlotsType } from 'vue'
 ${nuxt.options.experimental.componentIslands ? islandType : ''}
 ${hydrationTypes}
 
-${componentTypes.map(([pascalName, type]) => `export const ${pascalName}: ${type}`).join('\n')}
-${componentTypes.map(([pascalName, type]) => `export const Lazy${pascalName}: LazyComponent<${type}>`).join('\n')}
+${componentTypes.map(({ pascalName, type, meta }) => `${renderComponentJsDoc(meta)}export const ${pascalName}: ${type}`).join('\n')}
+${componentTypes.map(({ pascalName, type, meta }) => `${renderComponentJsDoc(meta, { lazyName: pascalName })}export const Lazy${pascalName}: LazyComponent<${type}>`).join('\n')}
 
 export const componentNames: string[]
 `
@@ -199,8 +228,8 @@ import type { DefineComponent, SlotsType } from 'vue'
 ${nuxt.options.experimental.componentIslands ? islandType : ''}
 ${hydrationTypes}
 interface _GlobalComponents {
-${componentTypes.map(([pascalName, type]) => `  ${genObjectKey(pascalName)}: ${type}`).join('\n')}
-${componentTypes.map(([pascalName, type]) => `  ${genObjectKey(`Lazy${pascalName}`)}: LazyComponent<${type}>`).join('\n')}
+${componentTypes.map(({ pascalName, type, meta }) => `${renderComponentJsDoc(meta, { indent: '  ' })}  ${genObjectKey(pascalName)}: ${type}`).join('\n')}
+${componentTypes.map(({ pascalName, type, meta }) => `${renderComponentJsDoc(meta, { indent: '  ', lazyName: pascalName })}  ${genObjectKey(`Lazy${pascalName}`)}: LazyComponent<${type}>`).join('\n')}
 }
 
 declare module 'vue' {

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -30,6 +30,7 @@ import metaModule from '../head/module.ts'
 import componentsModule from '../components/module.ts'
 import importsModule from '../imports/module.ts'
 import compilerModule from '../compiler/module.ts'
+import { getBuiltinComponentMeta } from '../components/builtin-metadata.ts'
 
 import { restoreCachedBuildId } from './cache.ts'
 import { distDir, pkgDir } from '../dirs.ts'
@@ -579,6 +580,7 @@ async function initNuxt (nuxt: Nuxt) {
       name: 'NuxtWelcome',
       priority: 10, // built-in that we do not expect the user to override
       filePath: resolve(nuxt.options.appDir, 'components/welcome'),
+      meta: getBuiltinComponentMeta('NuxtWelcome'),
     })
   }
 
@@ -586,6 +588,7 @@ async function initNuxt (nuxt: Nuxt) {
     name: 'NuxtLayout',
     priority: 10, // built-in that we do not expect the user to override
     filePath: resolve(nuxt.options.appDir, 'components/nuxt-layout'),
+    meta: getBuiltinComponentMeta('NuxtLayout'),
   })
 
   // Add <NuxtErrorBoundary>
@@ -593,6 +596,7 @@ async function initNuxt (nuxt: Nuxt) {
     name: 'NuxtErrorBoundary',
     priority: 10, // built-in that we do not expect the user to override
     filePath: resolve(nuxt.options.appDir, 'components/nuxt-error-boundary'),
+    meta: getBuiltinComponentMeta('NuxtErrorBoundary'),
   })
 
   // Add <ClientOnly>
@@ -600,6 +604,7 @@ async function initNuxt (nuxt: Nuxt) {
     name: 'ClientOnly',
     priority: 10, // built-in that we do not expect the user to override
     filePath: resolve(nuxt.options.appDir, 'components/client-only'),
+    meta: getBuiltinComponentMeta('ClientOnly'),
   })
 
   // Add <DevOnly>
@@ -607,6 +612,7 @@ async function initNuxt (nuxt: Nuxt) {
     name: 'DevOnly',
     priority: 10, // built-in that we do not expect the user to override
     filePath: resolve(nuxt.options.appDir, 'components/dev-only'),
+    meta: getBuiltinComponentMeta('DevOnly'),
   })
 
   // Add <ServerPlaceholder>
@@ -621,6 +627,7 @@ async function initNuxt (nuxt: Nuxt) {
     name: 'NuxtLink',
     priority: 10, // built-in that we do not expect the user to override
     filePath: resolve(nuxt.options.appDir, 'components/nuxt-link'),
+    meta: getBuiltinComponentMeta('NuxtLink'),
   })
 
   // Add <NuxtLoadingIndicator>
@@ -628,6 +635,7 @@ async function initNuxt (nuxt: Nuxt) {
     name: 'NuxtLoadingIndicator',
     priority: 10, // built-in that we do not expect the user to override
     filePath: resolve(nuxt.options.appDir, 'components/nuxt-loading-indicator'),
+    meta: getBuiltinComponentMeta('NuxtLoadingIndicator'),
   })
 
   // Add <NuxtTime>
@@ -635,6 +643,7 @@ async function initNuxt (nuxt: Nuxt) {
     name: 'NuxtTime',
     priority: 10, // built-in that we do not expect the user to override
     filePath: resolve(nuxt.options.appDir, 'components/nuxt-time.vue'),
+    meta: getBuiltinComponentMeta('NuxtTime'),
   })
 
   // Add <NuxtRouteAnnouncer>
@@ -643,6 +652,7 @@ async function initNuxt (nuxt: Nuxt) {
     priority: 10, // built-in that we do not expect the user to override
     filePath: resolve(nuxt.options.appDir, 'components/nuxt-route-announcer'),
     mode: 'client',
+    meta: getBuiltinComponentMeta('NuxtRouteAnnouncer'),
   })
 
   // Add <NuxtAnnouncer>
@@ -651,6 +661,7 @@ async function initNuxt (nuxt: Nuxt) {
     priority: 10, // built-in that we do not expect the user to override
     filePath: resolve(nuxt.options.appDir, 'components/nuxt-announcer'),
     mode: 'client',
+    meta: getBuiltinComponentMeta('NuxtAnnouncer'),
   })
 
   // Add <NuxtClientFallback>
@@ -661,6 +672,7 @@ async function initNuxt (nuxt: Nuxt) {
       priority: 10, // built-in that we do not expect the user to override
       filePath: resolve(nuxt.options.appDir, 'components/client-fallback.client'),
       mode: 'client',
+      meta: getBuiltinComponentMeta('NuxtClientFallback'),
     })
 
     addComponent({
@@ -669,16 +681,18 @@ async function initNuxt (nuxt: Nuxt) {
       priority: 10, // built-in that we do not expect the user to override
       filePath: resolve(nuxt.options.appDir, 'components/client-fallback.server'),
       mode: 'server',
+      meta: getBuiltinComponentMeta('NuxtClientFallback'),
     })
   }
 
   // Add stubs for <NuxtImg> and <NuxtPicture>
-  for (const name of ['NuxtImg', 'NuxtPicture']) {
+  for (const name of ['NuxtImg', 'NuxtPicture'] as const) {
     addComponent({
       name,
       export: name,
       priority: -1,
       filePath: resolve(nuxt.options.appDir, 'components/nuxt-stubs'),
+      meta: getBuiltinComponentMeta(name),
       // @ts-expect-error TODO: refactor to @nuxt/cli
       _internal_install: '@nuxt/image',
     })
@@ -728,6 +742,7 @@ async function initNuxt (nuxt: Nuxt) {
       name: 'NuxtIsland',
       priority: 10, // built-in that we do not expect the user to override
       filePath: resolve(nuxt.options.appDir, 'components/nuxt-island'),
+      meta: getBuiltinComponentMeta('NuxtIsland'),
     })
   }
 

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -18,6 +18,7 @@ import { globRouteRulesFromPages, removePagesRules } from './route-rules.ts'
 import { collectStaticPageRoutes, getAssetPathsForRoute } from './public-assets.ts'
 import { PageMetaPlugin } from './plugins/page-meta.ts'
 import { toVirtualId } from '../core/plugins/virtual.ts'
+import { getBuiltinComponentMeta } from '../components/builtin-metadata.ts'
 import { RouteInjectionPlugin } from './plugins/route-injection.ts'
 import type { Nuxt, NuxtPage } from 'nuxt/schema'
 import type { InlinePreset } from 'unimport'
@@ -233,6 +234,7 @@ export default defineNuxtModule({
         name: 'NuxtPage',
         priority: 10, // built-in that we do not expect the user to override
         filePath: resolve(distDir, 'pages/runtime/page-placeholder'),
+        meta: getBuiltinComponentMeta('NuxtPage'),
       })
       // Prerender index if pages integration is not enabled
       nuxt.hook('nitro:init', (nitro) => {
@@ -767,6 +769,7 @@ export default defineNuxtModule({
       name: 'NuxtPage',
       priority: 10, // built-in that we do not expect the user to override
       filePath: resolve(distDir, 'pages/runtime/page'),
+      meta: getBuiltinComponentMeta('NuxtPage'),
     })
   },
 })

--- a/packages/nuxt/test/components-templates.test.ts
+++ b/packages/nuxt/test/components-templates.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest'
+
+import { componentsDeclarationTemplate, componentsTypeTemplate } from '../src/components/templates.ts'
+import { BUILTIN_COMPONENT_META, getBuiltinComponentMeta } from '../src/components/builtin-metadata.ts'
+import type { Component, ComponentMeta } from '@nuxt/schema'
+import type { Nuxt, NuxtApp } from 'nuxt/schema'
+
+function makeNuxt (): Nuxt {
+  return {
+    options: {
+      rootDir: '/root',
+      buildDir: '/root/.nuxt',
+      experimental: { typescriptPlugin: false, componentIslands: false },
+    },
+  } as unknown as Nuxt
+}
+
+function makeComponent (overrides: Partial<Component> & Pick<Component, 'pascalName' | 'filePath'>): Component {
+  return {
+    kebabName: overrides.pascalName.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase(),
+    chunkName: `components/${overrides.pascalName}`,
+    export: 'default',
+    shortPath: overrides.filePath,
+    prefetch: false,
+    preload: false,
+    mode: 'all',
+    priority: 10,
+    meta: {},
+    ...overrides,
+  }
+}
+
+async function renderTemplates (components: Component[]) {
+  const app = { components, pages: [] } as unknown as NuxtApp
+  const nuxt = makeNuxt()
+  const declaration = await componentsDeclarationTemplate.getContents!({ app, nuxt, options: {} })
+  const types = await componentsTypeTemplate.getContents!({ app, nuxt, options: {} })
+  return { declaration, types }
+}
+
+describe('component type templates', () => {
+  it('emits JSDoc from component meta for declaration and GlobalComponents entries', async () => {
+    const docsUrl = 'https://nuxt.com/docs/4.x/api/components/nuxt-layout'
+    const { declaration, types } = await renderTemplates([
+      makeComponent({
+        pascalName: 'NuxtLayout',
+        filePath: '/root/app/components/nuxt-layout',
+        meta: {
+          description: 'Renders the selected layout around pages or error content.',
+          docsUrl,
+        },
+      }),
+      makeComponent({
+        pascalName: 'PlainThing',
+        filePath: '/root/components/PlainThing.vue',
+      }),
+    ])
+
+    const layoutJsDoc = [
+      '/**',
+      ' * Renders the selected layout around pages or error content.',
+      ' *',
+      ` * @see ${docsUrl}`,
+      ' */',
+    ].join('\n')
+    const lazyLayoutJsDoc = [
+      '/**',
+      ' * Lazy-loaded version of `<NuxtLayout>`.',
+      ' *',
+      ' * Renders the selected layout around pages or error content.',
+      ' *',
+      ` * @see ${docsUrl}`,
+      ' */',
+    ].join('\n')
+    const indentJsDoc = (jsDoc: string) => jsDoc.split('\n').map(line => `  ${line}`).join('\n')
+
+    expect(declaration).toContain(`${layoutJsDoc}\nexport const NuxtLayout:`)
+    expect(declaration).toContain(`${lazyLayoutJsDoc}\nexport const LazyNuxtLayout:`)
+    expect(types).toContain(`${indentJsDoc(layoutJsDoc)}\n  NuxtLayout:`)
+    expect(types).toContain(`${indentJsDoc(lazyLayoutJsDoc)}\n  LazyNuxtLayout:`)
+
+    expect(declaration).toMatch(/export const PlainThing:/)
+    expect(declaration).not.toMatch(/\/\*\*[\s\S]*\*\/\nexport const PlainThing:/)
+    expect(declaration).not.toMatch(/\/\*\*[\s\S]*\*\/\nexport const LazyPlainThing:/)
+    expect(types).not.toMatch(/\/\*\*[\s\S]*\*\/\n {2}PlainThing:/)
+    expect(types).not.toMatch(/\/\*\*[\s\S]*\*\/\n {2}LazyPlainThing:/)
+  })
+
+  it('escapes comment terminators in component meta', async () => {
+    const { declaration, types } = await renderTemplates([
+      makeComponent({
+        pascalName: 'UnsafeDocs',
+        filePath: '/root/components/UnsafeDocs.vue',
+        meta: {
+          description: 'Ends early */ still documented',
+          docsUrl: 'https://example.com/*/docs',
+        },
+      }),
+    ])
+
+    expect(declaration).toContain('Ends early * / still documented')
+    expect(declaration).toContain('@see https://example.com/* /docs')
+    expect(declaration).not.toContain('Ends early */ still documented')
+    expect(types).toContain('Ends early * / still documented')
+    expect(types).not.toMatch(/\*\/\nexport const UnsafeDocs:/)
+  })
+})
+
+describe('builtin component metadata', () => {
+  const expectedNames = [
+    'ClientOnly',
+    'DevOnly',
+    'NuxtClientFallback',
+    'NuxtPage',
+    'NuxtLayout',
+    'NuxtLink',
+    'NuxtLoadingIndicator',
+    'NuxtErrorBoundary',
+    'NuxtWelcome',
+    'NuxtIsland',
+    'NuxtImg',
+    'NuxtPicture',
+    'NuxtRouteAnnouncer',
+    'NuxtTime',
+    'NuxtAnnouncer',
+  ] as const
+
+  it('covers exactly the public built-in components with unique docs URLs', () => {
+    expect(Object.keys(BUILTIN_COMPONENT_META).sort()).toEqual([...expectedNames].sort())
+
+    const docsUrls = Object.values(BUILTIN_COMPONENT_META).map(meta => meta.docsUrl)
+    expect(new Set(docsUrls).size).toBe(docsUrls.length)
+
+    for (const name of expectedNames) {
+      const meta = getBuiltinComponentMeta(name)
+      expect(meta.description?.trim().length).toBeGreaterThan(0)
+      expect(meta.description).toMatch(/[.!?]$/)
+      expect(meta.description).not.toMatch(/^Nuxt provides\b/)
+      expect(meta.docsUrl).toMatch(/^https:\/\/nuxt\.com\/docs\/4\.x\/api\/components\//)
+    }
+  })
+
+  it('returns typed hover metadata for NuxtLayout', () => {
+    const meta: ComponentMeta = getBuiltinComponentMeta('NuxtLayout')
+    expect(meta).toEqual({
+      description: 'Renders the selected layout around pages or error content.',
+      docsUrl: 'https://nuxt.com/docs/4.x/api/components/nuxt-layout',
+    })
+  })
+})

--- a/packages/schema/src/types/components.ts
+++ b/packages/schema/src/types/components.ts
@@ -2,6 +2,14 @@ import type { CompilerScanDir } from './compiler.ts'
 import type { AugmentProperty, VueExtension } from '../utils/definition.ts'
 
 export interface ComponentMeta {
+  /**
+   * Short description shown as IDE hover documentation for the component.
+   */
+  description?: string
+  /**
+   * Documentation URL rendered as a `@see` tag in generated component types.
+   */
+  docsUrl?: string
   [key: string]: unknown
 }
 


### PR DESCRIPTION
### 🔗 Linked issue

Fixes https://github.com/nuxt/nuxt/issues/32330

### 📚 Description

Hovering a built-in like `<NuxtLayout>` in a Vue template currently shows almost nothing useful. Those components are registered in `GlobalComponents`, but the generated `.d.ts` files never included JSDoc.

This wires short descriptions and docs URLs onto the public built-ins (via `ComponentMeta`), then emits them when we generate `components.d.ts` / `types/components.d.ts`. Lazy variants get an extra line so the hover still makes sense.

I kept the copy short and IDE-oriented rather than pulling Markdown from nuxt.com at build time. Head tags / internal helpers stay without docs on purpose.

After `nuxt prepare`, hovering built-ins looks like this:

**NuxtLayout**

<img width="560" alt="IDE hover for NuxtLayout" src="https://github.com/user-attachments/assets/1b9250d5-f9a0-4d52-a3ee-95d292ca47cf" />


**NuxtPage**

<img width="560" alt="IDE hover for NuxtPage" src="https://github.com/user-attachments/assets/38edc651-c89c-4b71-8e24-9154e052faa6" />

**NuxtLink**

<img width="560" alt="IDE hover for NuxtLink" src="https://github.com/user-attachments/assets/f56cfde0-3940-4d51-ab86-87558366608f" />

**ClientOnly**

<img width="560" alt="IDE hover for ClientOnly" src="https://github.com/user-attachments/assets/867921ab-1038-4154-a620-0f66ff560755" />