### PR TITLE
feat(nuxt): stage async page navigations before view transitions

### DIFF
--- a/packages/nuxt/src/app/components/route-provider.ts
+++ b/packages/nuxt/src/app/components/route-provider.ts
@@ -73,11 +73,8 @@ export const defineRouteProvider = (name = 'RouteProvider'): RouteProviderCompon
       if (!props.vnode) {
         return props.vnode
       }
-      if (import.meta.dev && import.meta.client) {
-        vnode = h(props.vnode, { ref: props.vnodeRef })
-      } else {
-        vnode = h(props.vnode, { ref: props.vnodeRef })
-      }
+
+      vnode = h(props.vnode, { ref: props.vnodeRef })
 
       return props.stage
         ? h(ViewTransitionStage, { session: props.stage }, { default: () => vnode })

--- a/packages/nuxt/src/app/components/route-provider.ts
+++ b/packages/nuxt/src/app/components/route-provider.ts
@@ -4,6 +4,8 @@ import type { RouteLocationNormalizedLoaded, RouteRecordNormalized } from 'vue-r
 import { renderDiagnostics } from '../diagnostics/render'
 import { trackRenderedRecord } from '../diagnostics/rendered-records'
 import { PageRouteSymbol } from './injections'
+import { ViewTransitionStage } from './view-transition-stage'
+import type { PendingViewTransition } from '../view-transitions'
 
 interface RouteProviderProps {
   route: RouteLocationNormalizedLoaded
@@ -13,6 +15,7 @@ interface RouteProviderProps {
   trackRootNodes?: boolean
   /** the matched route record this provider renders, used by dev-only render diagnostics */
   routeRecord?: RouteRecordNormalized
+  stage?: PendingViewTransition
 }
 
 export type RouteProviderComponent = DefineSetupFnComponent<RouteProviderProps>
@@ -29,6 +32,7 @@ export const defineRouteProvider = (name = 'RouteProvider'): RouteProviderCompon
     renderKey: String,
     trackRootNodes: Boolean,
     routeRecord: Object as () => RouteRecordNormalized,
+    stage: Object as () => PendingViewTransition,
   },
   setup (props) {
     // Prevent reactivity when the page will be rerendered in a different suspense fork
@@ -71,10 +75,13 @@ export const defineRouteProvider = (name = 'RouteProvider'): RouteProviderCompon
       }
       if (import.meta.dev && import.meta.client) {
         vnode = h(props.vnode, { ref: props.vnodeRef })
-        return vnode
+      } else {
+        vnode = h(props.vnode, { ref: props.vnodeRef })
       }
 
-      return h(props.vnode, { ref: props.vnodeRef })
+      return props.stage
+        ? h(ViewTransitionStage, { session: props.stage }, { default: () => vnode })
+        : vnode
     }
   },
 }) as unknown as RouteProviderComponent

--- a/packages/nuxt/src/app/components/view-transition-stage.ts
+++ b/packages/nuxt/src/app/components/view-transition-stage.ts
@@ -1,0 +1,50 @@
+import { Fragment, Suspense, defineComponent, h } from 'vue'
+import type { PropType } from 'vue'
+import type { PendingViewTransition } from '../view-transitions'
+import { markPendingViewTransitionReady, preparePendingViewTransition } from '../view-transitions'
+
+/**
+ * waits before the new page replaces the old one.
+ *
+ * while the destination loads in the sibling Suspense below, this keeps the current
+ * page visible. Once Nuxt and the browser are ready to animate the change, the swap
+ * can proceed. This component itself renders nothing on screen.
+ *
+ * @internal
+ */
+const ViewTransitionGate = defineComponent({
+  name: 'NuxtViewTransitionGate',
+  props: {
+    session: {
+      type: Object as PropType<PendingViewTransition>,
+      required: true,
+    },
+  },
+  async setup (props) {
+    await preparePendingViewTransition(props.session)
+    return () => null
+  },
+})
+
+export const ViewTransitionStage = defineComponent({
+  name: 'NuxtViewTransitionStage',
+  props: {
+    session: {
+      type: Object as PropType<PendingViewTransition>,
+      required: true,
+    },
+  },
+  setup (props, { slots }) {
+    return () => h(Fragment, [
+      // This is mounted before the inner boundary so the outer Suspense stays
+      // pending even when the destination page resolves synchronously.
+      h(ViewTransitionGate, { session: props.session }),
+      h(Suspense, {
+        suspensible: false,
+        onResolve: () => markPendingViewTransitionReady(props.session),
+      }, {
+        default: () => slots.default?.(),
+      }),
+    ])
+  },
+})

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -17,6 +17,7 @@ import { traceAsync } from './internal/tracing'
 import type { LoadingIndicator } from './composables/loading-indicator'
 import type { RouteAnnouncer } from './composables/route-announcer'
 import type { NuxtAnnouncer } from './composables/announcer'
+import type { PendingViewTransition } from './view-transitions'
 import type { AppConfig, AppConfigInput, RuntimeConfig } from 'nuxt/schema'
 
 import { appDiagnostics } from './diagnostics/core'
@@ -164,6 +165,9 @@ interface _NuxtApp {
   '~transitionPromise'?: Promise<void>
   /** @internal */
   '~transitionFinish'?: () => void
+
+  /** @internal */
+  '_pendingViewTransition'?: PendingViewTransition
 
   /** @internal */
   '_announcer'?: NuxtAnnouncer

--- a/packages/nuxt/src/app/plugins/view-transitions.client.ts
+++ b/packages/nuxt/src/app/plugins/view-transitions.client.ts
@@ -3,6 +3,7 @@ import { useRouter } from '../composables/router'
 import { defineNuxtPlugin } from '../nuxt'
 import type { ObjectPlugin, Plugin } from '../nuxt'
 import type { ViewTransitionPageOptions } from 'nuxt/schema'
+import { cancelPendingViewTransition, createPendingViewTransition, supersedePendingViewTransition } from '../view-transitions'
 import { appViewTransition as defaultViewTransition } from '#build/nuxt.config.mjs'
 
 const plugin: Plugin & ObjectPlugin = defineNuxtPlugin((nuxtApp) => {
@@ -10,21 +11,25 @@ const plugin: Plugin & ObjectPlugin = defineNuxtPlugin((nuxtApp) => {
     return
   }
 
-  let transition: undefined | ViewTransition
   let hasUAVisualTransition = false
-  let finishTransition: undefined | (() => void)
-  let abortTransition: undefined | (() => void)
 
   const resetTransitionState = () => {
-    transition = undefined
-    hasUAVisualTransition = false
-    abortTransition = undefined
-    finishTransition = undefined
+    delete nuxtApp._pendingViewTransition
+  }
+
+  const cancelTransition = () => {
+    const session = nuxtApp._pendingViewTransition
+    if (session) {
+      cancelPendingViewTransition(session)
+    }
+    resetTransitionState()
   }
 
   window.addEventListener('popstate', (event) => {
     hasUAVisualTransition = event.hasUAVisualTransition
-    if (hasUAVisualTransition) { transition?.skipTransition() }
+    if (hasUAVisualTransition) {
+      cancelTransition()
+    }
   })
 
   const router = useRouter()
@@ -40,7 +45,26 @@ const plugin: Plugin & ObjectPlugin = defineNuxtPlugin((nuxtApp) => {
   }
 
   router.beforeResolve(async (to, from) => {
-    if (to.matched.length === 0) { return }
+    const previousSession = nuxtApp._pendingViewTransition
+    let supersededSession: typeof previousSession
+    if (previousSession) {
+      if (previousSession.status === 'claimed' || previousSession.status === 'preparing' || previousSession.status === 'ready') {
+        supersedePendingViewTransition(previousSession)
+        supersededSession = previousSession
+      } else if (previousSession.status === 'armed') {
+        // NuxtPage never claimed it, so discard the session instead of superseding.
+        cancelTransition()
+      } else if (previousSession.status === 'committing') {
+        // wait for the browser to commit the previous session before starting a new one
+        await previousSession.committed
+      }
+      resetTransitionState()
+    }
+
+    if (to.matched.length === 0) {
+      hasUAVisualTransition = false
+      return
+    }
 
     const toViewTransitionOptions = normalizeViewTransitionOptions(to.meta.viewTransition)
     const fromViewTransitionOptions = normalizeViewTransitionOptions(from.meta.viewTransition)
@@ -52,8 +76,11 @@ const plugin: Plugin & ObjectPlugin = defineNuxtPlugin((nuxtApp) => {
       viewTransitionMode === false ||
       prefersNoTransition ||
       hasUAVisualTransition ||
-      !isChangingPage(to, from)
+      !isChangingPage(to, from) ||
+      // Skip when the layout changes as view transitions only support page swaps for now
+      to.meta.layout !== from.meta.layout
     ) {
+      hasUAVisualTransition = false
       return
     }
 
@@ -67,58 +94,50 @@ const plugin: Plugin & ObjectPlugin = defineNuxtPlugin((nuxtApp) => {
       []
     const viewTransitionFromTypes = resolveViewTransitionTypes(fromViewTransitionOptions.fromTypes) ?? []
     const viewTransitionToTypes = resolveViewTransitionTypes(toViewTransitionOptions.toTypes) ?? []
-
-    const allTypes = [
+    const session = createPendingViewTransition(to, from, [
       ...viewTransitionBaseTypes,
       ...viewTransitionFromTypes,
       ...viewTransitionToTypes,
-    ]
-
-    const promise = new Promise<void>((resolve, reject) => {
-      finishTransition = resolve
-      abortTransition = reject
-    })
-
-    let changeRoute: () => void
-    const ready = new Promise<void>(resolve => (changeRoute = resolve))
-
-    const update = () => {
-      changeRoute()
-      return promise
+    ])
+    if (supersededSession) {
+      session.superseded = [supersededSession]
     }
 
-    // Use the object form (Level 2) only when types are specified,
-    // falling back to the callback form (Level 1) for broader browser support.
-    transition = allTypes.length > 0
-      ? document.startViewTransition!({ update, types: allTypes })
-      : document.startViewTransition!(update)
+    session.start = () => {
+      if (nuxtApp._pendingViewTransition !== session || session.status !== 'ready') {
+        return
+      }
 
-    transition.finished.catch(() => {}).finally(resetTransitionState)
+      try {
+        const update = async () => {
+          if (session.status === 'cancelled') { return }
+          session.status = 'committing'
+          session.resolveGate()
+          await session.committed
+        }
+        session.transition = session.types.length > 0
+          ? document.startViewTransition!({ update, types: session.types })
+          : document.startViewTransition!(update)
 
-    await nuxtApp.callHook('page:view-transition:start', transition)
+        // Existing consumers can still customize or skip the native transition.
+        void nuxtApp.callHook('page:view-transition:start', session.transition)
+        session.transition.ready.catch(() => {})
+        session.transition.finished.catch(() => {}).finally(() => {
+          session.status = 'finished'
+        })
+      } catch {
+        // commit the staged branch if the browser rejects starting a transition
+        session.status = 'committing'
+        session.resolveGate()
+      }
+    }
 
-    return ready
+    nuxtApp._pendingViewTransition = session
   })
 
-  router.onError(() => {
-    abortTransition?.()
-    resetTransitionState()
-  })
-
-  nuxtApp.hook('app:error', () => {
-    abortTransition?.()
-    resetTransitionState()
-  })
-
-  nuxtApp.hook('vue:error', () => {
-    abortTransition?.()
-    resetTransitionState()
-  })
-
-  nuxtApp.hook('page:finish', () => {
-    finishTransition?.()
-    resetTransitionState()
-  })
+  router.onError(cancelTransition)
+  nuxtApp.hook('app:error', cancelTransition)
+  nuxtApp.hook('vue:error', cancelTransition)
 })
 
 export default plugin

--- a/packages/nuxt/src/app/view-transitions.ts
+++ b/packages/nuxt/src/app/view-transitions.ts
@@ -110,6 +110,10 @@ export function claimPendingViewTransition (nuxtApp: NuxtApp, route: RouteLocati
 }
 
 export function preparePendingViewTransition (session: PendingViewTransition): Promise<void> {
+  if (session.status === 'cancelled' || session.status === 'finished') {
+    return session.gate
+  }
+
   session.status = 'preparing'
 
   // resolve the gates of any superseded sessions

--- a/packages/nuxt/src/app/view-transitions.ts
+++ b/packages/nuxt/src/app/view-transitions.ts
@@ -1,0 +1,159 @@
+import type { RouteLocationNormalizedLoaded } from 'vue-router'
+import type { NuxtApp } from './nuxt'
+
+/**
+ * Lifecycle stage of a staged page navigation.
+ *
+ * - `armed`: Session created in `router.beforeResolve`, waiting for `<NuxtPage>` to claim it
+ * - `claimed`: `<NuxtPage>` attached the session to a render branch
+ * - `preparing`: Destination page is loading in the hidden stage
+ * - `ready`: Destination resolved, the pending view transition may call `documentstartViewTransition()`
+ * - `committing`: Browser `update` callback opened the gate and the visible page swap is in progress
+ * - `finished`: Browser transition completed
+ * - `cancelled`: Navigation was aborted or superseded by a newer session
+ *
+ * @internal
+ */
+export type PendingViewTransitionStatus =
+  | 'armed'
+  | 'claimed'
+  | 'preparing'
+  | 'ready'
+  | 'committing'
+  | 'finished'
+  | 'cancelled'
+
+/** @internal */
+export interface PendingViewTransition {
+  /** Monotonic session id. */
+  id: number
+  /** Destination route. */
+  to: RouteLocationNormalizedLoaded
+  /** Source route. */
+  from: RouteLocationNormalizedLoaded
+  /** View transition types for `document.startViewTransition()`. */
+  types: string[]
+  /** Current lifecycle stage. */
+  status: PendingViewTransitionStatus
+  /** `<NuxtPage>` branch that claimed this session. */
+  owner?: object
+  /** Browser `ViewTransition` instance, once started. */
+  transition?: ViewTransition
+  /** Starts the native view transition after the destination is ready. */
+  start?: () => void
+  /** Superseded sessions whose gates release after the replacement stage mounts. */
+  superseded?: PendingViewTransition[]
+  /** Blocks the visible swap until the browser captures the old page. */
+  gate: Promise<void>
+  /** Opens {@link PendingViewTransition.gate gate}. */
+  resolveGate: () => void
+  /** Signals that Vue finished rendering the committed destination page. */
+  resolveCommitted: () => void
+  /** Awaited by the browser `update` callback until outer Suspense resolves. */
+  committed: Promise<void>
+}
+
+let transitionId = 0
+
+/**
+ * Creates a new PendingViewTransition object to track the state of an in-progress view transition.
+ * @internal
+ */
+export function createPendingViewTransition (to: RouteLocationNormalizedLoaded, from: RouteLocationNormalizedLoaded, types: string[]): PendingViewTransition {
+  let resolveGate: () => void
+  let resolveCommitted: () => void
+
+  const gate = new Promise<void>((resolve) => {
+    resolveGate = resolve
+  })
+  const committed = new Promise<void>((resolve) => {
+    resolveCommitted = resolve
+  })
+
+  return {
+    id: ++transitionId,
+    to,
+    from,
+    types,
+    status: 'armed',
+    // keep the gate alive until the browser has captured the old page
+    resolveGate: resolveGate!,
+    resolveCommitted: resolveCommitted!,
+    committed,
+    gate,
+  }
+}
+
+/**
+ * claims the pending view transition session for the given route
+ * @internal
+ */
+export function claimPendingViewTransition (nuxtApp: NuxtApp, route: RouteLocationNormalizedLoaded, owner: object): PendingViewTransition | undefined {
+  const session = nuxtApp._pendingViewTransition
+
+  // exit early if no valid session matches the route
+  if (!session || session.status === 'cancelled' || session.to.fullPath !== route.fullPath) {
+    return
+  }
+
+  // if the session is armed, claim it by attaching the owner
+  if (session.status === 'armed') {
+    session.owner = owner
+    session.status = 'claimed'
+    return session
+  }
+
+  // if the session is already claimed by the same owner, return the session
+  if (session.owner === owner) {
+    return session
+  }
+}
+
+export function preparePendingViewTransition (session: PendingViewTransition): Promise<void> {
+  session.status = 'preparing'
+
+  // resolve the gates of any superseded sessions
+  for (const superseded of session.superseded || []) {
+    superseded.resolveGate()
+  }
+
+  // clear the superseded sessions
+  session.superseded = undefined
+  return session.gate
+}
+
+export function markPendingViewTransitionReady (session: PendingViewTransition): void {
+  // exit early if the session is not preparing
+  if (session.status !== 'preparing') { return }
+  session.status = 'ready'
+  session.start?.()
+}
+
+/**
+ * commits the pending view transition session
+ * @internal
+ */
+export function commitPendingViewTransition (session: PendingViewTransition): void {
+  if (session.status === 'cancelled' || session.status === 'finished') { return }
+  session.resolveCommitted()
+}
+
+export function cancelPendingViewTransition (session: PendingViewTransition): void {
+  if (session.status === 'cancelled' || session.status === 'finished') { return }
+  session.status = 'cancelled'
+  session.transition?.skipTransition()
+  session.resolveGate()
+  session.resolveCommitted()
+}
+
+/**
+ * cancels the pending view transition session and releases the gate
+ * @internal
+ */
+export function supersedePendingViewTransition (session: PendingViewTransition): void {
+  if (session.status === 'cancelled' || session.status === 'finished') { return }
+  session.status = 'cancelled'
+  session.transition?.skipTransition()
+  // Replacement releases this gate after Vue discards the old branch; releasing here would commit a stale route.
+  session.resolveCommitted()
+}

--- a/packages/nuxt/src/pages/runtime/page.ts
+++ b/packages/nuxt/src/pages/runtime/page.ts
@@ -10,6 +10,7 @@ import { useNuxtApp } from '#app/nuxt'
 import { useRouter } from '#app/composables/router'
 import { _mergeTransitionProps, _wrapInTransition } from '#app/components/utils'
 import { LayoutMetaSymbol, PageRouteSymbol } from '#app/components/injections'
+import { claimPendingViewTransition, commitPendingViewTransition } from '#app/view-transitions'
 import { appKeepalive as defaultKeepaliveConfig, appPageTransition as defaultPageTransition } from '#build/nuxt.config.mjs'
 
 export interface NuxtPageProps extends RouterViewProps {
@@ -59,6 +60,7 @@ export default defineComponent({
     const pageRef = ref()
     const forkRoute = inject(PageRouteSymbol, null)
     const keepAliveInclude = new Set<string>()
+    const viewTransitionOwner = {}
 
     let previousPageKey: string | undefined | false
 
@@ -158,15 +160,22 @@ export default defineComponent({
                 })
               }
 
+              const stagedSession = import.meta.client && !nuxtApp.isHydrating
+                ? claimPendingViewTransition(nuxtApp, routeProps.route, viewTransitionOwner)
+                : undefined
+
               // remount suspense on rapid navigation, but not before the first resolve:
               // tearing down a never-resolved suspensible Suspense strands its parent. See #28425, #34683.
-              if (isSuspensePending && previousPageKey !== key && hasResolvedOnce) {
+              // staged transitions instead replace the existing pending branch so
+              // the currently visible page remains mounted.
+              if (isSuspensePending && previousPageKey !== key && hasResolvedOnce && !stagedSession) {
                 suspenseKey++
               }
 
               previousPageKey = key
 
-              const hasTransition = !!(props.transition ?? routeProps.route.meta.pageTransition ?? defaultPageTransition)
+              // the native transition owns this navigations visual commit.
+              const hasTransition = !stagedSession && !!(props.transition ?? routeProps.route.meta.pageTransition ?? defaultPageTransition)
               const transitionProps = hasTransition && _mergeTransitionProps([
                 props.transition,
                 routeProps.route.meta.pageTransition,
@@ -249,6 +258,9 @@ export default defineComponent({
                         await nuxtApp.callHook('page:loading:end')
                       }
                     } finally {
+                      if (stagedSession) {
+                        commitPendingViewTransition(stagedSession)
+                      }
                       done()
                     }
                   },
@@ -262,6 +274,7 @@ export default defineComponent({
                       trackRootNodes: hasTransition,
                       vnodeRef: pageRef,
                       routeRecord: import.meta.dev ? routeProps.route.matched.find(m => m.components?.default === routeProps.Component.type) : undefined,
+                      stage: stagedSession,
                     }
 
                     if (!keepaliveConfig) {

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -55,7 +55,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
   it('default client bundle size (pages)', async () => {
     const clientStats = await analyzeSizes(['**/*.js'], join(pagesRootDir, '.output/public'), pagesRootDir)
 
-    expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"182k"`)
+    expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"183k"`)
 
     const files = clientStats!.files.map(f => f.replace(/\..*\.js/, '.js'))
 
@@ -103,7 +103,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(pagesRootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs'], serverDir, pagesRootDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"313k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"314k"`)
 
     const packages = getVendorPackages(await glob(['_libs/**/*'], { cwd: serverDir }))
     expect(packages).toMatchInlineSnapshot(`

--- a/test/nuxt/view-transition-stage.test.ts
+++ b/test/nuxt/view-transition-stage.test.ts
@@ -1,0 +1,148 @@
+import { Suspense, defineComponent, h, nextTick, ref, shallowRef } from 'vue'
+import { flushPromises, mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+
+import { ViewTransitionStage } from '#app/components/view-transition-stage'
+import { claimPendingViewTransition, createPendingViewTransition, supersedePendingViewTransition } from '#app/view-transitions'
+
+describe('view transition stage', () => {
+  it('keeps the stage claimed by the same page through the commit render', () => {
+    const route = { fullPath: '/destination' } as any
+    const session = createPendingViewTransition(route, { fullPath: '/' } as any, [])
+    const nuxtApp = { _pendingViewTransition: session } as any
+    const owner = {}
+
+    expect(claimPendingViewTransition(nuxtApp, route, owner)).toBe(session)
+    expect(session.status).toBe('claimed')
+
+    session.status = 'committing'
+
+    expect(claimPendingViewTransition(nuxtApp, route, owner)).toBe(session)
+    expect(claimPendingViewTransition(nuxtApp, route, {})).toBeUndefined()
+  })
+
+  it('prepares the destination before releasing the visible Suspense commit', async () => {
+    let resolveDestination: () => void
+    const destination = new Promise<void>((resolve) => { resolveDestination = resolve })
+    const showDestination = ref(false)
+    const session = createPendingViewTransition(
+      { fullPath: '/destination' } as any,
+      { fullPath: '/' } as any,
+      [],
+    )
+    const startTransition = vi.fn()
+    session.start = startTransition
+
+    const Destination = defineComponent({
+      async setup () {
+        await destination
+        return () => h('p', { 'data-testid': 'destination' }, 'Destination')
+      },
+    })
+    const OldPage = defineComponent({
+      setup () {
+        const count = ref(0)
+        return () => h('button', { onClick: () => { count.value++ } }, String(count.value))
+      },
+    })
+    const App = defineComponent({
+      setup () {
+        return () => h(Suspense, null, {
+          default: () => showDestination.value
+            ? h(ViewTransitionStage, { key: 'destination', session }, { default: () => h(Destination) })
+            : h(OldPage),
+        })
+      },
+    })
+
+    const wrapper = mount(App)
+    await nextTick()
+    expect(wrapper.get('button').text()).toBe('0')
+
+    showDestination.value = true
+    await nextTick()
+    await nextTick()
+
+    await wrapper.get('button').trigger('click')
+    expect(wrapper.get('button').text()).toBe('1')
+    expect(wrapper.find('[data-testid="destination"]').exists()).toBe(false)
+
+    resolveDestination!()
+    await flushPromises()
+
+    expect(startTransition).toHaveBeenCalledOnce()
+    expect(wrapper.get('button').text()).toBe('1')
+    expect(wrapper.find('[data-testid="destination"]').exists()).toBe(false)
+
+    session.status = 'committing'
+    session.resolveGate()
+    await flushPromises()
+
+    expect(wrapper.find('button').exists()).toBe(false)
+    expect(wrapper.get('[data-testid="destination"]').text()).toBe('Destination')
+  })
+
+  it('discards a pending destination when a newer navigation starts', async () => {
+    let resolveSlow: () => void
+    let resolveMedium: () => void
+    const slowReady = new Promise<void>((resolve) => { resolveSlow = resolve })
+    const mediumReady = new Promise<void>((resolve) => { resolveMedium = resolve })
+    const slowSession = createPendingViewTransition({ fullPath: '/slow' } as any, { fullPath: '/' } as any, [])
+    const mediumSession = createPendingViewTransition({ fullPath: '/medium' } as any, { fullPath: '/slow' } as any, [])
+    slowSession.start = vi.fn()
+    mediumSession.start = vi.fn()
+
+    const SlowPage = defineComponent({
+      async setup () {
+        await slowReady
+        return () => h('p', { 'data-testid': 'slow' }, 'Slow')
+      },
+    })
+    const MediumPage = defineComponent({
+      async setup () {
+        await mediumReady
+        return () => h('p', { 'data-testid': 'medium' }, 'Medium')
+      },
+    })
+    const current = shallowRef<{ key: string, session: typeof slowSession, component: typeof SlowPage }>()
+    const OldPage = defineComponent({ setup: () => () => h('p', { 'data-testid': 'old' }, 'Old') })
+    const App = defineComponent({
+      setup () {
+        return () => h(Suspense, null, {
+          default: () => current.value
+            ? h(ViewTransitionStage, { key: current.value.key, session: current.value.session }, { default: () => h(current.value!.component) })
+            : h(OldPage),
+        })
+      },
+    })
+
+    const wrapper = mount(App)
+    await nextTick()
+
+    current.value = { key: 'slow', session: slowSession, component: SlowPage }
+    await flushPromises()
+    expect(wrapper.get('[data-testid="old"]').text()).toBe('Old')
+
+    supersedePendingViewTransition(slowSession)
+    mediumSession.superseded = [slowSession]
+    current.value = { key: 'medium', session: mediumSession, component: MediumPage }
+    await flushPromises()
+
+    resolveMedium!()
+    await flushPromises()
+    expect(mediumSession.start).toHaveBeenCalledOnce()
+    expect(slowSession.start).not.toHaveBeenCalled()
+
+    mediumSession.status = 'committing'
+    mediumSession.resolveGate()
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="slow"]').exists()).toBe(false)
+    expect(wrapper.get('[data-testid="medium"]').text()).toBe('Medium')
+
+    resolveSlow!()
+    await flushPromises()
+    expect(wrapper.find('[data-testid="slow"]').exists()).toBe(false)
+    expect(wrapper.get('[data-testid="medium"]').text()).toBe('Medium')
+  })
+})

--- a/test/nuxt/view-transition-stage.test.ts
+++ b/test/nuxt/view-transition-stage.test.ts
@@ -3,7 +3,7 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
 
 import { ViewTransitionStage } from '#app/components/view-transition-stage'
-import { claimPendingViewTransition, createPendingViewTransition, supersedePendingViewTransition } from '#app/view-transitions'
+import { claimPendingViewTransition, createPendingViewTransition, preparePendingViewTransition, supersedePendingViewTransition } from '#app/view-transitions'
 
 describe('view transition stage', () => {
   it('keeps the stage claimed by the same page through the commit render', () => {
@@ -19,6 +19,15 @@ describe('view transition stage', () => {
 
     expect(claimPendingViewTransition(nuxtApp, route, owner)).toBe(session)
     expect(claimPendingViewTransition(nuxtApp, route, {})).toBeUndefined()
+  })
+
+  it('does not revive a cancelled session during preparation', () => {
+    const session = createPendingViewTransition({ fullPath: '/destination' } as any, { fullPath: '/' } as any, [])
+    supersedePendingViewTransition(session)
+
+    preparePendingViewTransition(session)
+
+    expect(session.status).toBe('cancelled')
   })
 
   it('prepares the destination before releasing the visible Suspense commit', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #21280 and may also help related view-transition + async navigation issues.

### 📚 Description

This adds a staging mechanic for Nuxt when `experimental.viewTransition` is enabled.

Before `document.startViewTransition()` was called before the resolve to the new page which means the DOM was frozen and became unresponsive until the new route was fetched and the transition could be finished. This caused a few side effects like the one described in #21280 where the page loader could not be rendered as the DOM was frozen into a static image. On top it meant the UX was really bad with view transitions enabled because a long-running route could mean that the page would be unresponsive for multiple seconds.

The new staged-based solution prepares the destination page first while it keeps the old page alive. For that we have three layers - an outer `Suspense` for the current page and hook logic, a transition gate that controls when to swap to the next page and an inner suspense that is responsible for preparing the next page in the background.

While the new page resolves inside the inner suspense, the old page continues to stay active. New requests dismiss the running transition session & starts a new one to avoid rendering multiple pages at once or throwing away a valid page with an invalid one.

I tested this locally with the playground where I added multiple routes, including nested routes, to make sure that it works, see the video below.

https://github.com/user-attachments/assets/d4ffc5ea-44ab-4158-80d6-4264718cef36

**Note** - since I'm quite new to the Nuxt + SSR stuff I'd really love to have some eyes on it to see if I did something really stupid here that could be done in a better way.