### PR TITLE
fix(nuxt): type auto-imported $fetch with nitro's $Fetch

### DIFF
--- a/packages/nuxt/src/build-stub-fetch.d.ts
+++ b/packages/nuxt/src/build-stub-fetch.d.ts
@@ -3,4 +3,4 @@
  * `tsconfig.build.json` while emitting this package's declarations. Matches
  * the `dollarFetchTypeTemplate` in `./core/templates.ts`.
  */
-export { $fetch } from 'ofetch'
+export declare const $fetch: import('nitro/types').$Fetch

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -544,7 +544,10 @@ export const dollarFetchClientTemplate: NuxtTemplate = {
 export const dollarFetchTypeTemplate: NuxtTemplate = {
   filename: 'fetch.d.ts',
   getContents () {
-    return 'export { $fetch } from \'ofetch\'\n'
+    // type as nitro's route-aware `$Fetch` (matching the runtime cast in
+    // `#app/composables/fetch`) so typed API routes are inferred, rather
+    // than ofetch's plain `$fetch` which returns `Promise<any>`
+    return 'export declare const $fetch: import(\'nitro/types\').$Fetch\n'
   },
 }
 

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -544,9 +544,6 @@ export const dollarFetchClientTemplate: NuxtTemplate = {
 export const dollarFetchTypeTemplate: NuxtTemplate = {
   filename: 'fetch.d.ts',
   getContents () {
-    // type as nitro's route-aware `$Fetch` (matching the runtime cast in
-    // `#app/composables/fetch`) so typed API routes are inferred, rather
-    // than ofetch's plain `$fetch` which returns `Promise<any>`
     return 'export declare const $fetch: import(\'nitro/types\').$Fetch\n'
   },
 }

--- a/test/fixtures/basic-types/app/app-types.ts
+++ b/test/fixtures/basic-types/app/app-types.ts
@@ -2,7 +2,8 @@ import { describe, expectTypeOf, it } from 'vitest'
 import type { Ref, SlotsType } from 'vue'
 import type { NavigationFailure, RouteLocationNormalized, RouteLocationRaw, Router, useRouter as vueUseRouter } from 'vue-router'
 
-import { $fetch } from 'ofetch'
+import type { $Fetch, NitroFetchRequest } from 'nitro/types'
+import { $fetch } from '#build/fetch'
 import type { AppConfig, NuxtConfig as NuxtConfigFromAt, NuxtHooks as NuxtHooksFromAt } from '@nuxt/schema'
 import type { NuxtConfig as NuxtConfigFromNuxt, NuxtHooks as NuxtHooksFromNuxt } from 'nuxt/schema'
 import { defineNuxtConfig } from 'nuxt/config'
@@ -52,6 +53,13 @@ defineNuxtConfig({
 })
 
 describe('API routes', () => {
+  it('types the auto-imported $fetch with nitro routes', () => {
+    // https://github.com/nuxt/nuxt/pull/35582 regression: `$fetch` was typed as
+    // ofetch's plain `$fetch`, returning `Promise<any>` for every request
+    expectTypeOf($fetch).toEqualTypeOf<$Fetch<unknown, NitroFetchRequest>>()
+    expectTypeOf($fetch('/api/other')).toEqualTypeOf<Promise<unknown>>()
+  })
+
   // TODO: https://github.com/nitrojs/nitro/issues/2758
   it('generates types for routes', () => {
     // expectTypeOf($fetch('/api/hello')).toEqualTypeOf<Promise<string>>()
@@ -130,6 +138,12 @@ describe('API routes', () => {
     // expectTypeOf(useFetch('/api/union').data).toEqualTypeOf<Ref<{ type: 'a', foo: string } | { type: 'b', baz: string } | DefaultAsyncDataValue>>()
     // expectTypeOf(useFetch('/api/union', { pick: ['type'] }).data).toEqualTypeOf<Ref<{ type: 'a' } | { type: 'b' } | DefaultAsyncDataValue>>()
     expectTypeOf(useFetch('/api/other').data).toEqualTypeOf<Ref<unknown>>()
+    // TODO: https://github.com/nitrojs/nitro/issues/2758
+    // https://github.com/nuxt/nuxt/issues/22488 — dynamic + static handlers on the same prefix
+    // const dynamicId = String(Math.random())
+    // expectTypeOf(useFetch(`/api/posts/${dynamicId}`).data).toEqualTypeOf<Ref<number | string | DefaultAsyncDataValue>>()
+    // expectTypeOf(useFetch('/api/posts/static').data).toEqualTypeOf<Ref<string | DefaultAsyncDataValue>>()
+    // expectTypeOf($fetch(`/api/posts/${dynamicId}`)).toEqualTypeOf<Promise<number | string>>()
     expectTypeOf(useFetch<TestResponse>('/test').data).toEqualTypeOf<Ref<TestResponse | DefaultAsyncDataValue>>()
     expectTypeOf(useFetch<TestResponse>('/test', { method: 'POST' }).data).toEqualTypeOf<Ref<TestResponse | DefaultAsyncDataValue>>()
 

--- a/test/fixtures/basic-types/server/api/posts/[id].get.ts
+++ b/test/fixtures/basic-types/server/api/posts/[id].get.ts
@@ -1,0 +1,1 @@
+export default defineEventHandler(() => 42)

--- a/test/fixtures/basic-types/server/api/posts/static.get.ts
+++ b/test/fixtures/basic-types/server/api/posts/static.get.ts
@@ -1,0 +1,1 @@
+export default defineEventHandler(() => 'static')


### PR DESCRIPTION
Since #35582, the auto-imported `$fetch` is typed by the `fetch.d.ts` template as ofetch's plain `$fetch`, so every call returns `Promise<any>` with no typed-route inference. This types it as nitro's route-aware `$Fetch`, matching the runtime cast in `#app/composables/fetch`.

- emit `export declare const $fetch: import('nitro/types').$Fetch` from `dollarFetchTypeTemplate`
- keep `build-stub-fetch.d.ts` in sync with the template
- add active fixture tests pinning `$fetch`'s type and `Promise<unknown>` for unmatched routes
- add the #22488 repro (dynamic + static handlers on one prefix) with union assertions, commented pending nitrojs/nitro#2758

While investigating #22488 I found the remaining blocker is upstream: nitro's generated `nitro-imports.d.ts` emits import paths like `.../node_modules/nitro/h3` (package dir joined with the exports subpath), which doesn't exist on disk. TS can't resolve it and `skipLibCheck` hides the error, so `defineEventHandler` becomes `any` and poisons all `InternalApi` route types. With that patched locally plus this fix, `$fetch(`/api/posts/${id}`)` correctly infers `Promise<number | string>`.

🔗 Linked issue: #22488