### PR TITLE
docs: add guide for canonical URLs

### DIFF
--- a/docs/1.getting-started/08.seo-meta.md
+++ b/docs/1.getting-started/08.seo-meta.md
@@ -390,3 +390,174 @@ The example below shows how you might enable Google Fonts using either the `link
   ```
 
 ::
+
+## Canonical URLs
+
+### Why Canonical URLs
+
+Search engines treat URLs as separate pages when the same content is available at more than one address. Common duplicates include trailing-slash variants (`/about` and `/about/`), www vs non-www hosts, http vs https, and URLs that differ only by query parameters such as UTM tags. A canonical URL tells crawlers which address you prefer. See [Google's guidance on consolidating duplicate URLs](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls).
+
+### Set a Canonical URL with `useHead`
+
+A canonical URL is a `<link rel="canonical">` tag, not a meta tag. [`useSeoMeta`](/docs/4.x/api/composables/use-seo-meta) does not set it. Use [`useHead`](/docs/4.x/api/composables/use-head) instead:
+
+```vue twoslash [app/app.vue]
+<script setup lang="ts">
+useHead({
+  link: [
+    { rel: 'canonical', href: 'https://example.com/about' },
+  ],
+})
+</script>
+```
+
+You can still set `ogUrl` with `useSeoMeta` so Open Graph consumers receive a matching URL:
+
+```vue twoslash [app/pages/about.vue]
+<script setup lang="ts">
+useSeoMeta({
+  ogUrl: 'https://example.com/about',
+})
+</script>
+```
+
+### Dynamic Canonical URLs and Site URL
+
+Nuxt does not ship a built-in `siteUrl` option. Store your origin in [`runtimeConfig`](/docs/4.x/guide/going-further/runtime-config) and build the canonical href from the current route:
+
+```ts twoslash [nuxt.config.ts]
+export default defineNuxtConfig({
+  runtimeConfig: {
+    public: {
+      siteUrl: process.env.NUXT_PUBLIC_SITE_URL || 'https://example.com',
+    },
+  },
+})
+```
+
+```vue twoslash [app/layouts/default.vue]
+<script setup lang="ts">
+const route = useRoute()
+const { siteUrl } = useRuntimeConfig().public
+
+useHead({
+  link: [
+    {
+      rel: 'canonical',
+      href: () => `${siteUrl}${route.path}`,
+    },
+  ],
+})
+</script>
+```
+
+To reuse the same logic across pages, extract a composable:
+
+```ts twoslash [app/composables/useCanonical.ts]
+export function useCanonical (path?: string) {
+  const route = useRoute()
+  const { siteUrl } = useRuntimeConfig().public
+
+  useHead({
+    link: [
+      {
+        rel: 'canonical',
+        href: () => `${siteUrl}${path ?? route.path}`,
+      },
+    ],
+  })
+}
+```
+
+```vue twoslash [app/pages/about.vue]
+<script setup lang="ts">
+useCanonical()
+</script>
+```
+
+::note
+Pass a custom `path` when a page should canonicalize to a different URL than `route.path`. For example, a paginated list can point to the first page.
+::
+
+### Trailing Slashes and Duplicate URLs
+
+Trailing-slash mismatches are a frequent source of duplicate URLs. Prefer one style and keep internal links, redirects, sitemaps, and canonical tags aligned.
+
+**1. Align `<NuxtLink>` hrefs.** Set a default with [`experimental.defaults.nuxtLink.trailingSlash`](/docs/4.x/api/components/nuxt-link#overwriting-defaults):
+
+```ts twoslash [nuxt.config.ts]
+export default defineNuxtConfig({
+  experimental: {
+    defaults: {
+      nuxtLink: {
+        trailingSlash: 'remove', // or 'append'
+      },
+    },
+  },
+})
+```
+
+**2. Redirect to the preferred URL with an HTTP 301.** A global route middleware can strip (or append) trailing slashes during server-side rendering:
+
+```ts [app/middleware/redirect-trailing-slash.global.ts]
+export default defineNuxtRouteMiddleware((to) => {
+  if (to.path !== '/' && to.path.endsWith('/')) {
+    const { path, query, hash } = to
+    const nextPath = path.replace(/\/+$/, '') || '/'
+    return navigateTo({ path: nextPath, query, hash }, { redirectCode: 301 })
+  }
+})
+```
+
+::warning
+On SPA-only apps, or when your host rewrites static files before Nuxt runs, this middleware may perform a client-side navigation instead of a true HTTP 301. Prefer host-level redirects when you need a guaranteed server response. Use a canonical tag as a fallback when you cannot redirect.
+::
+
+**3. Keep the canonical tag as a safety net.** When both `/about` and `/about/` return `200`, the canonical href should point at the preferred version so crawlers can consolidate signals.
+
+### Static Sites and Deployment
+
+Static hosts often map `/about` to `/about/index.html` and redirect one form to the other. That redirect can disagree with your `<NuxtLink>` hrefs and with your canonical tag, which confuses crawlers and can block indexing.
+
+If you prefer URLs without trailing slashes, disable Nitro's subfolder index generation:
+
+```ts twoslash [nuxt.config.ts]
+export default defineNuxtConfig({
+  nitro: {
+    prerender: {
+      autoSubfolderIndex: false,
+    },
+  },
+})
+```
+
+For Cloudflare Pages and similar hosts, see [route matching for Cloudflare](https://nuxt.com/deploy/cloudflare#route-matching).
+
+::important
+Point the canonical `href` at a URL that returns `200`, not at a URL that redirects.
+::
+
+### Internationalization and Alternate URLs
+
+For multilingual sites, pair the canonical tag with `hreflang` alternate links so each locale points at itself as canonical and lists its peers:
+
+```vue twoslash [app/layouts/default.vue]
+<script setup lang="ts">
+const { siteUrl } = useRuntimeConfig().public
+
+useHead({
+  link: [
+    { rel: 'canonical', href: `${siteUrl}/en/about` },
+    { rel: 'alternate', hreflang: 'en', href: `${siteUrl}/en/about` },
+    { rel: 'alternate', hreflang: 'fr', href: `${siteUrl}/fr/about` },
+    { rel: 'alternate', hreflang: 'x-default', href: `${siteUrl}/en/about` },
+  ],
+})
+</script>
+```
+
+If you use [`@nuxtjs/i18n`](https://nuxt.com/modules/i18n), prefer that module's locale helpers so alternate URLs stay in sync with your routing strategy.
+
+### When to Use the Nuxt SEO Module
+
+You can set canonical tags with the patterns above. If you need a shared `siteUrl`, trailing-slash policy, sitemap, robots, and Schema.org tags that stay consistent, use the [Nuxt SEO module](https://nuxt.com/modules/seo). The module centralizes those concerns so your app and other modules read the same site config.

--- a/docs/1.getting-started/08.seo-meta.md
+++ b/docs/1.getting-started/08.seo-meta.md
@@ -425,7 +425,7 @@ useSeoMeta({
 
 Nuxt does not ship a built-in `siteUrl` option. Store your origin in [`runtimeConfig`](/docs/4.x/guide/going-further/runtime-config) and build the canonical href from the current route:
 
-```ts twoslash [nuxt.config.ts]
+```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   runtimeConfig: {
     public: {
@@ -469,7 +469,7 @@ export function useCanonical (path?: string) {
 }
 ```
 
-```vue twoslash [app/pages/about.vue]
+```vue [app/pages/about.vue]
 <script setup lang="ts">
 useCanonical()
 </script>
@@ -539,9 +539,9 @@ Point the canonical `href` at a URL that returns `200`, not at a URL that redire
 
 ### Internationalization and Alternate URLs
 
-For multilingual sites, pair the canonical tag with `hreflang` alternate links so each locale points at itself as canonical and lists its peers:
+For multilingual sites, pair the canonical tag with `hreflang` alternate links so each locale points at itself as canonical and lists its peers. This page-level example shows the link shape for one translated page:
 
-```vue twoslash [app/layouts/default.vue]
+```vue twoslash [app/pages/about.vue]
 <script setup lang="ts">
 const { siteUrl } = useRuntimeConfig().public
 
@@ -556,7 +556,7 @@ useHead({
 </script>
 ```
 
-If you use [`@nuxtjs/i18n`](https://nuxt.com/modules/i18n), prefer that module's locale helpers so alternate URLs stay in sync with your routing strategy.
+If you use [`@nuxtjs/i18n`](https://nuxt.com/modules/i18n), prefer that module's locale helpers in a shared layout so alternate URLs stay in sync with the current route and locale strategy.
 
 ### When to Use the Nuxt SEO Module
 

--- a/docs/1.getting-started/08.seo-meta.md
+++ b/docs/1.getting-started/08.seo-meta.md
@@ -401,20 +401,15 @@ Search engines treat URLs as separate pages when the same content is available a
 
 A canonical URL is a `<link rel="canonical">` tag, not a meta tag. [`useSeoMeta`](/docs/4.x/api/composables/use-seo-meta) does not set it. Use [`useHead`](/docs/4.x/api/composables/use-head) instead:
 
-```vue twoslash [app/app.vue]
+```vue twoslash [app/pages/about.vue]
 <script setup lang="ts">
 useHead({
   link: [
     { rel: 'canonical', href: 'https://example.com/about' },
   ],
 })
-</script>
-```
 
-You can still set `ogUrl` with `useSeoMeta` so Open Graph consumers receive a matching URL:
-
-```vue twoslash [app/pages/about.vue]
-<script setup lang="ts">
+// Keep Open Graph URL in sync when you also set social meta
 useSeoMeta({
   ogUrl: 'https://example.com/about',
 })
@@ -435,12 +430,12 @@ export default defineNuxtConfig({
 })
 ```
 
-Normalize `route.path` to your preferred trailing-slash policy before building the href (here: no trailing slash, matching the examples below). Otherwise `/about` and `/about/` can emit different canonical URLs.
+Normalize `route.path` to your preferred trailing-slash policy before building the href (here: no trailing slash, matching the examples below). Otherwise `/about` and `/about/` can emit different canonical URLs. Strip trailing slashes from `siteUrl` as well so `https://example.com/` does not produce `https://example.com//about`.
 
 ```vue twoslash [app/layouts/default.vue]
 <script setup lang="ts">
 const route = useRoute()
-const { siteUrl } = useRuntimeConfig().public
+const siteUrl = String(useRuntimeConfig().public.siteUrl).replace(/\/+$/, '')
 
 const canonicalPath = computed(() => route.path.replace(/\/+$/, '') || '/')
 
@@ -455,12 +450,12 @@ useHead({
 </script>
 ```
 
-To set the tag once for the whole app on the server (where crawlers read the first HTML response), use a server-only plugin:
+To set the tag once for the whole app and keep it updated on client-side navigations, register a shared plugin (not `.server`-only):
 
-```ts twoslash [app/plugins/canonical.server.ts]
+```ts twoslash [app/plugins/canonical.ts]
 export default defineNuxtPlugin(() => {
   const route = useRoute()
-  const { siteUrl } = useRuntimeConfig().public
+  const siteUrl = String(useRuntimeConfig().public.siteUrl).replace(/\/+$/, '')
 
   const canonicalPath = computed(() => route.path.replace(/\/+$/, '') || '/')
 
@@ -543,7 +538,7 @@ For multilingual sites, pair the canonical tag with `hreflang` alternate links s
 
 ```vue twoslash [app/pages/about.vue]
 <script setup lang="ts">
-const { siteUrl } = useRuntimeConfig().public
+const siteUrl = String(useRuntimeConfig().public.siteUrl).replace(/\/+$/, '')
 
 useHead({
   link: [

--- a/docs/1.getting-started/08.seo-meta.md
+++ b/docs/1.getting-started/08.seo-meta.md
@@ -435,48 +435,48 @@ export default defineNuxtConfig({
 })
 ```
 
+Normalize `route.path` to your preferred trailing-slash policy before building the href (here: no trailing slash, matching the examples below). Otherwise `/about` and `/about/` can emit different canonical URLs.
+
 ```vue twoslash [app/layouts/default.vue]
 <script setup lang="ts">
 const route = useRoute()
 const { siteUrl } = useRuntimeConfig().public
 
+const canonicalPath = computed(() => route.path.replace(/\/+$/, '') || '/')
+
 useHead({
   link: [
     {
       rel: 'canonical',
-      href: () => `${siteUrl}${route.path}`,
+      href: () => `${siteUrl}${canonicalPath.value}`,
     },
   ],
 })
 </script>
 ```
 
-To reuse the same logic across pages, extract a composable:
+To set the tag once for the whole app on the server (where crawlers read the first HTML response), use a server-only plugin:
 
-```ts twoslash [app/composables/useCanonical.ts]
-export function useCanonical (path?: string) {
+```ts twoslash [app/plugins/canonical.server.ts]
+export default defineNuxtPlugin(() => {
   const route = useRoute()
   const { siteUrl } = useRuntimeConfig().public
+
+  const canonicalPath = computed(() => route.path.replace(/\/+$/, '') || '/')
 
   useHead({
     link: [
       {
         rel: 'canonical',
-        href: () => `${siteUrl}${path ?? route.path}`,
+        href: () => `${siteUrl}${canonicalPath.value}`,
       },
     ],
   })
-}
-```
-
-```vue [app/pages/about.vue]
-<script setup lang="ts">
-useCanonical()
-</script>
+})
 ```
 
 ::note
-Pass a custom `path` when a page should canonicalize to a different URL than `route.path`. For example, a paginated list can point to the first page.
+To canonicalize to a URL other than the current route (for example a paginated list pointing at the first page), call `useHead` on that page with an explicit `canonical` `href`.
 ::
 
 ### Trailing Slashes and Duplicate URLs
@@ -556,7 +556,7 @@ useHead({
 </script>
 ```
 
-If you use [`@nuxtjs/i18n`](https://nuxt.com/modules/i18n), prefer that module's locale helpers in a shared layout so alternate URLs stay in sync with the current route and locale strategy.
+If you use [`@nuxtjs/i18n`](https://nuxt.com/modules/i18n), prefer that module's locale helpers in a shared layout, so alternate URLs stay in sync with the current route and locale strategy.
 
 ### When to Use the Nuxt SEO Module
 


### PR DESCRIPTION
Adds a Canonical URLs section to the SEO and Meta getting-started page.

Issue #18809 asked for docs and examples. Canonical is a link tag, so `useSeoMeta` does not set it, and trailing-slash / SSG setups still produce duplicate URLs. The section covers `useHead`, building the href from `runtimeConfig.public.siteUrl`, aligning `NuxtLink` trailing slashes, a 301 middleware when the host supports it, and a canonical tag when it does not. It also covers `autoSubfolderIndex` for static hosts and points to `@nuxtjs/i18n` and the Nuxt SEO module for a fuller stack.

I considered a separate recipes page. Keeping this on the SEO page matches where readers already look for head and meta guidance.

Fixes #18809