### PR TITLE
feat(nuxt): add async data `minDuration` option

### DIFF
--- a/docs/4.api/2.composables/use-async-data.md
+++ b/docs/4.api/2.composables/use-async-data.md
@@ -166,6 +166,7 @@ type AsyncDataOptions<ResT, DataT = ResT> = {
   watch?: MultiWatchSources
   getCachedData?: (key: string, nuxtApp: NuxtApp, ctx: AsyncDataRequestContext) => DataT | undefined
   timeout?: number
+  minDelay?: number
   enabled?: MaybeRefOrGetter<boolean>
 }
 
@@ -187,6 +188,7 @@ type AsyncData<DataT, ErrorT> = {
 interface AsyncDataExecuteOptions {
   dedupe?: 'cancel' | 'defer'
   timeout?: number
+  minDelay?: number
   signal?: AbortSignal
 }
 
@@ -211,6 +213,7 @@ The `handler` function should be **side-effect free** to ensure predictable beha
 | `immediate`                                                               | `boolean`                                   | `true`     | If false, prevents function from being called immediately.                                                                                                                                                                                                                           |
 | `default`                                                                 | `() => DataT`                               | -          | Factory for default value of `data` before async resolves.                                                                                                                                                                                                                           |
 | `timeout` :badge[v4.2]{color="info" size="xs" class="align-middle"}       | `number`                                    | -          | A number in milliseconds to wait before timing out the call (defaults to `undefined`, which means no timeout)                                                                                                                                                                        |
+| `minDelay` :badge[v5.0]{color="info" size="xs" class="align-middle"}      | `number`                                    | -          | A minimum duration in milliseconds the call is guaranteed to take before its result (or error) surfaces. Client-only (skipped during SSR); aborts are not delayed. Defaults to `undefined` (no minimum).              |
 | `transform`                                                               | `(input: DataT) => DataT \| Promise<DataT>` | -          | Function to transform the result after resolving.                                                                                                                                                                                                                                    |
 | `getCachedData` :badge[v3.8]{color="info" size="xs" class="align-middle"} | `(key, nuxtApp, ctx) => DataT \| undefined` | -          | Function to return cached data. See below for default.                                                                                                                                                                                                                               |
 | `pick`                                                                    | `string[]`                                  | -          | Only pick specified keys from the result.                                                                                                                                                                                                                                            |

--- a/docs/4.api/2.composables/use-async-data.md
+++ b/docs/4.api/2.composables/use-async-data.md
@@ -166,7 +166,7 @@ type AsyncDataOptions<ResT, DataT = ResT> = {
   watch?: MultiWatchSources
   getCachedData?: (key: string, nuxtApp: NuxtApp, ctx: AsyncDataRequestContext) => DataT | undefined
   timeout?: number
-  minDelay?: number
+  minDuration?: number
   enabled?: MaybeRefOrGetter<boolean>
 }
 
@@ -188,7 +188,7 @@ type AsyncData<DataT, ErrorT> = {
 interface AsyncDataExecuteOptions {
   dedupe?: 'cancel' | 'defer'
   timeout?: number
-  minDelay?: number
+  minDuration?: number
   signal?: AbortSignal
 }
 
@@ -213,7 +213,7 @@ The `handler` function should be **side-effect free** to ensure predictable beha
 | `immediate`                                                               | `boolean`                                   | `true`     | If false, prevents function from being called immediately.                                                                                                                                                                                                                           |
 | `default`                                                                 | `() => DataT`                               | -          | Factory for default value of `data` before async resolves.                                                                                                                                                                                                                           |
 | `timeout` :badge[v4.2]{color="info" size="xs" class="align-middle"}       | `number`                                    | -          | A number in milliseconds to wait before timing out the call (defaults to `undefined`, which means no timeout)                                                                                                                                                                        |
-| `minDelay` :badge[v5.0]{color="info" size="xs" class="align-middle"}      | `number`                                    | -          | A minimum duration in milliseconds the call is guaranteed to take before its result (or error) surfaces. Client-only (skipped during SSR); aborts are not delayed. Defaults to `undefined` (no minimum).              |
+| `minDuration` :badge[v5.0]{color="info" size="xs" class="align-middle"}      | `number`                                    | -          | A minimum duration in milliseconds the call is guaranteed to take before its result (or error) surfaces. Client-only (skipped during SSR); aborts are not delayed. Defaults to `undefined` (no minimum).              |
 | `transform`                                                               | `(input: DataT) => DataT \| Promise<DataT>` | -          | Function to transform the result after resolving.                                                                                                                                                                                                                                    |
 | `getCachedData` :badge[v3.8]{color="info" size="xs" class="align-middle"} | `(key, nuxtApp, ctx) => DataT \| undefined` | -          | Function to return cached data. See below for default.                                                                                                                                                                                                                               |
 | `pick`                                                                    | `string[]`                                  | -          | Only pick specified keys from the result.                                                                                                                                                                                                                                            |

--- a/docs/4.api/2.composables/use-fetch.md
+++ b/docs/4.api/2.composables/use-fetch.md
@@ -169,6 +169,7 @@ type UseFetchOptions<ResT, DataT = ResT> = {
   deep?: boolean
   dedupe?: 'cancel' | 'defer'
   timeout?: number
+  minDelay?: number
   enabled?: MaybeRefOrGetter<boolean>
   default?: () => DataT | Ref<DataT>
   transform?: (input: ResT) => DataT | Promise<DataT>
@@ -195,6 +196,7 @@ type AsyncData<DataT, ErrorT> = {
 interface AsyncDataExecuteOptions {
   dedupe?: 'cancel' | 'defer'
   timeout?: number
+  minDelay?: number
   signal?: AbortSignal
 }
 
@@ -222,6 +224,7 @@ type AsyncDataRequestStatus = 'idle' | 'pending' | 'success' | 'error'
 | `immediate`                                                               | `boolean`                                                               | `true`     | If false, prevents request from firing immediately.                                                                                                                                                                                                                                |
 | `default`                                                                 | `() => DataT`                                                           | -          | Factory for default value of `data` before async resolves.                                                                                                                                                                                                                         |
 | `timeout` :badge[v4.2]{color="info" size="xs" class="align-middle"}       | `number`                                                                | -          | A number in milliseconds to wait before timing out the request (defaults to `undefined`, which means no timeout)                                                                                                                                                                   |
+| `minDelay` :badge[v5.0]{color="info" size="xs" class="align-middle"}      | `number`                                                                | -          | A minimum duration in milliseconds the request is guaranteed to take before its result (or error) surfaces. Client-only (skipped during SSR); aborts are not delayed. Defaults to `undefined` (no minimum).         |
 | `transform`                                                               | `(input: DataT) => DataT \| Promise<DataT>`                             | -          | Function to transform the result after resolving.                                                                                                                                                                                                                                  |
 | `getCachedData` :badge[v3.8]{color="info" size="xs" class="align-middle"} | `(key, nuxtApp, ctx) => DataT \| undefined`                             | -          | Function to return cached data. See below for default.                                                                                                                                                                                                                             |
 | `pick`                                                                    | `string[]`                                                              | -          | Only pick specified keys from the result.                                                                                                                                                                                                                                          |

--- a/docs/4.api/2.composables/use-fetch.md
+++ b/docs/4.api/2.composables/use-fetch.md
@@ -169,7 +169,7 @@ type UseFetchOptions<ResT, DataT = ResT> = {
   deep?: boolean
   dedupe?: 'cancel' | 'defer'
   timeout?: number
-  minDelay?: number
+  minDuration?: number
   enabled?: MaybeRefOrGetter<boolean>
   default?: () => DataT | Ref<DataT>
   transform?: (input: ResT) => DataT | Promise<DataT>
@@ -196,7 +196,7 @@ type AsyncData<DataT, ErrorT> = {
 interface AsyncDataExecuteOptions {
   dedupe?: 'cancel' | 'defer'
   timeout?: number
-  minDelay?: number
+  minDuration?: number
   signal?: AbortSignal
 }
 
@@ -224,7 +224,7 @@ type AsyncDataRequestStatus = 'idle' | 'pending' | 'success' | 'error'
 | `immediate`                                                               | `boolean`                                                               | `true`     | If false, prevents request from firing immediately.                                                                                                                                                                                                                                |
 | `default`                                                                 | `() => DataT`                                                           | -          | Factory for default value of `data` before async resolves.                                                                                                                                                                                                                         |
 | `timeout` :badge[v4.2]{color="info" size="xs" class="align-middle"}       | `number`                                                                | -          | A number in milliseconds to wait before timing out the request (defaults to `undefined`, which means no timeout)                                                                                                                                                                   |
-| `minDelay` :badge[v5.0]{color="info" size="xs" class="align-middle"}      | `number`                                                                | -          | A minimum duration in milliseconds the request is guaranteed to take before its result (or error) surfaces. Client-only (skipped during SSR); aborts are not delayed. Defaults to `undefined` (no minimum).         |
+| `minDuration` :badge[v5.0]{color="info" size="xs" class="align-middle"}      | `number`                                                                | -          | A minimum duration in milliseconds the request is guaranteed to take before its result (or error) surfaces. Client-only (skipped during SSR); aborts are not delayed. Defaults to `undefined` (no minimum).         |
 | `transform`                                                               | `(input: DataT) => DataT \| Promise<DataT>`                             | -          | Function to transform the result after resolving.                                                                                                                                                                                                                                  |
 | `getCachedData` :badge[v3.8]{color="info" size="xs" class="align-middle"} | `(key, nuxtApp, ctx) => DataT \| undefined`                             | -          | Function to return cached data. See below for default.                                                                                                                                                                                                                             |
 | `pick`                                                                    | `string[]`                                                              | -          | Only pick specified keys from the result.                                                                                                                                                                                                                                          |

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -95,6 +95,15 @@ interface BaseAsyncDataOptions<
    */
   timeout?: number
   /**
+   * An artificial minimum duration in milliseconds that the request is guaranteed to take before its
+   * result (or error) surfaces.
+   *
+   * The delay only applies on the client (it is skipped during SSR/prerendering) and does not delay
+   * aborts — cancelling the request (via `dedupe: 'cancel'`, `clear()`, `timeout`, or `enabled: false`)
+   * settles immediately and clears the pending timer.
+   */
+  minDelay?: number
+  /**
    * Controls whether to run the async function
    * @default true
    */
@@ -155,6 +164,8 @@ export interface AsyncDataExecuteOptions {
   signal?: AbortSignal
 
   timeout?: number
+
+  minDelay?: number
 }
 
 export interface _AsyncData<DataT, ErrorT> {
@@ -866,7 +877,27 @@ function buildAsyncData<
               reject(reason instanceof Error ? reason : new DOMException(String(reason ?? 'Aborted'), 'AbortError'))
             }, { once: true, signal: cleanupController.signal })
 
-            return Promise.resolve(handler(nuxtApp, { signal: mergedSignal })).then(resolve, reject)
+            const handlerPromise = Promise.resolve(handler(nuxtApp, { signal: mergedSignal }))
+
+            const minDelay = opts.minDelay ?? options.minDelay
+
+            if (import.meta.client && typeof minDelay === 'number' && minDelay > 0) {
+              const minDelayPromise = new Promise<void>((resolveDelay) => {
+                const timer = setTimeout(resolveDelay, minDelay)
+                
+                cleanupController.signal.addEventListener('abort', () => {
+                  clearTimeout(timer)
+                  resolveDelay()
+                }, { once: true })
+              })
+
+              return handlerPromise.then(
+                result => minDelayPromise.then(() => resolve(result)),
+                error => minDelayPromise.then(() => reject(error)),
+              )
+            }
+
+            return handlerPromise.then(resolve, reject)
           } catch (err) {
             reject(err)
           }

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -102,7 +102,7 @@ interface BaseAsyncDataOptions<
    * aborts — cancelling the request (via `dedupe: 'cancel'`, `clear()`, `timeout`, or `enabled: false`)
    * settles immediately and clears the pending timer.
    */
-  minDelay?: number
+  minDuration?: number
   /**
    * Controls whether to run the async function
    * @default true
@@ -165,7 +165,7 @@ export interface AsyncDataExecuteOptions {
 
   timeout?: number
 
-  minDelay?: number
+  minDuration?: number
 }
 
 export interface _AsyncData<DataT, ErrorT> {
@@ -879,11 +879,11 @@ function buildAsyncData<
 
             const handlerPromise = Promise.resolve(handler(nuxtApp, { signal: mergedSignal }))
 
-            const minDelay = opts.minDelay ?? options.minDelay
+            const minDuration = opts.minDuration ?? options.minDuration
 
-            if (import.meta.client && typeof minDelay === 'number' && minDelay > 0) {
-              const minDelayPromise = new Promise<void>((resolveDelay) => {
-                const timer = setTimeout(resolveDelay, minDelay)
+            if (import.meta.client && typeof minDuration === 'number' && minDuration > 0) {
+              const minDurationPromise = new Promise<void>((resolveDelay) => {
+                const timer = setTimeout(resolveDelay, minDuration)
 
                 cleanupController.signal.addEventListener('abort', () => {
                   clearTimeout(timer)
@@ -892,8 +892,8 @@ function buildAsyncData<
               })
 
               return handlerPromise.then(
-                result => minDelayPromise.then(() => resolve(result)),
-                error => minDelayPromise.then(() => reject(error)),
+                result => minDurationPromise.then(() => resolve(result)),
+                error => minDurationPromise.then(() => reject(error)),
               )
             }
 

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -884,7 +884,7 @@ function buildAsyncData<
             if (import.meta.client && typeof minDelay === 'number' && minDelay > 0) {
               const minDelayPromise = new Promise<void>((resolveDelay) => {
                 const timer = setTimeout(resolveDelay, minDelay)
-                
+
                 cleanupController.signal.addEventListener('abort', () => {
                   clearTimeout(timer)
                   resolveDelay()

--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -308,6 +308,7 @@ export const createUseFetch: CreateUseFetch = defineKeyedFunctionFactory<CreateU
         deep,
         dedupe,
         timeout,
+        minDelay,
         enabled,
         ...fetchOptions
       } = {
@@ -341,6 +342,7 @@ export const createUseFetch: CreateUseFetch = defineKeyedFunctionFactory<CreateU
         deep,
         dedupe,
         timeout,
+        minDelay,
         enabled,
         watch: watchSources === false ? [] : [...(watchSources || []), _fetchOptions],
       }

--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -308,7 +308,7 @@ export const createUseFetch: CreateUseFetch = defineKeyedFunctionFactory<CreateU
         deep,
         dedupe,
         timeout,
-        minDelay,
+        minDuration,
         enabled,
         ...fetchOptions
       } = {
@@ -342,7 +342,7 @@ export const createUseFetch: CreateUseFetch = defineKeyedFunctionFactory<CreateU
         deep,
         dedupe,
         timeout,
-        minDelay,
+        minDuration,
         enabled,
         watch: watchSources === false ? [] : [...(watchSources || []), _fetchOptions],
       }

--- a/test/nuxt/use-async-data.test.ts
+++ b/test/nuxt/use-async-data.test.ts
@@ -1233,6 +1233,66 @@ describe('useAsyncData', () => {
     vi.useRealTimers()
   })
 
+  it('should enforce a minimum delay before the result surfaces', async () => {
+    vi.useFakeTimers()
+    const promiseFn = vi.fn(() => Promise.resolve('value'))
+    const { status, data } = useAsyncData('min-delay-success', promiseFn, { minDelay: 1000 })
+    expect(status.value).toBe('pending')
+    // the handler has already resolved, but the minimum delay keeps the state pending
+    await flushPromises()
+    expect(status.value).toBe('pending')
+    expect(data.value).toBeUndefined()
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(status.value).toBe('success')
+    expect(data.value).toBe('value')
+    vi.useRealTimers()
+  })
+
+  it('should enforce the minimum delay before an error surfaces', async () => {
+    vi.useFakeTimers()
+    const promiseFn = vi.fn(() => Promise.reject(new Error('boom')))
+    const { status, error } = useAsyncData('min-delay-error', promiseFn, { minDelay: 1000 })
+    expect(status.value).toBe('pending')
+    await flushPromises()
+    expect(status.value).toBe('pending')
+    expect(error.value).toBeUndefined()
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(status.value).toBe('error')
+    expect(error.value).toBeTruthy()
+    vi.useRealTimers()
+  })
+
+  it('should not delay aborts while waiting for the minimum delay', async () => {
+    vi.useFakeTimers()
+    let aborted = false
+    const promiseFn = vi.fn((_: any, { signal }: { signal: AbortSignal }) => {
+      signal.addEventListener('abort', () => { aborted = true })
+      return Promise.resolve('value')
+    })
+    const { status, clear } = useAsyncData('min-delay-abort', promiseFn, { minDelay: 1000 })
+    await flushPromises()
+    // still waiting on the minimum delay
+    expect(status.value).toBe('pending')
+    clear()
+    await flushPromises()
+    // the abort settles immediately without waiting out the remaining delay
+    expect(status.value).toBe('idle')
+    expect(aborted).toBe(true)
+    vi.useRealTimers()
+  })
+
+  it('should allow overriding minDelay per execute call', async () => {
+    vi.useFakeTimers()
+    const promiseFn = vi.fn(() => Promise.resolve('value'))
+    const { status, execute } = useAsyncData('min-delay-override', promiseFn, { immediate: false, minDelay: 1000 })
+    expect(status.value).toBe('idle')
+    execute({ minDelay: 0 })
+    await flushPromises()
+    // the per-call override disables the configured floor, so it resolves without advancing timers
+    expect(status.value).toBe('success')
+    vi.useRealTimers()
+  })
+
   it('should handle already-aborted signal', async () => {
     const controller = new AbortController()
     controller.abort(new DOMException('Already aborted', 'AbortError'))

--- a/test/nuxt/use-async-data.test.ts
+++ b/test/nuxt/use-async-data.test.ts
@@ -1236,7 +1236,7 @@ describe('useAsyncData', () => {
   it('should enforce a minimum delay before the result surfaces', async () => {
     vi.useFakeTimers()
     const promiseFn = vi.fn(() => Promise.resolve('value'))
-    const { status, data } = useAsyncData('min-delay-success', promiseFn, { minDelay: 1000 })
+    const { status, data } = useAsyncData('min-delay-success', promiseFn, { minDuration: 1000 })
     expect(status.value).toBe('pending')
     // the handler has already resolved, but the minimum delay keeps the state pending
     await flushPromises()
@@ -1251,7 +1251,7 @@ describe('useAsyncData', () => {
   it('should enforce the minimum delay before an error surfaces', async () => {
     vi.useFakeTimers()
     const promiseFn = vi.fn(() => Promise.reject(new Error('boom')))
-    const { status, error } = useAsyncData('min-delay-error', promiseFn, { minDelay: 1000 })
+    const { status, error } = useAsyncData('min-delay-error', promiseFn, { minDuration: 1000 })
     expect(status.value).toBe('pending')
     await flushPromises()
     expect(status.value).toBe('pending')
@@ -1269,7 +1269,7 @@ describe('useAsyncData', () => {
       signal.addEventListener('abort', () => { aborted = true })
       return Promise.resolve('value')
     })
-    const { status, clear } = useAsyncData('min-delay-abort', promiseFn, { minDelay: 1000 })
+    const { status, clear } = useAsyncData('min-delay-abort', promiseFn, { minDuration: 1000 })
     await flushPromises()
     // still waiting on the minimum delay
     expect(status.value).toBe('pending')
@@ -1281,12 +1281,12 @@ describe('useAsyncData', () => {
     vi.useRealTimers()
   })
 
-  it('should allow overriding minDelay per execute call', async () => {
+  it('should allow overriding minDuration per execute call', async () => {
     vi.useFakeTimers()
     const promiseFn = vi.fn(() => Promise.resolve('value'))
-    const { status, execute } = useAsyncData('min-delay-override', promiseFn, { immediate: false, minDelay: 1000 })
+    const { status, execute } = useAsyncData('min-delay-override', promiseFn, { immediate: false, minDuration: 1000 })
     expect(status.value).toBe('idle')
-    execute({ minDelay: 0 })
+    execute({ minDuration: 0 })
     await flushPromises()
     // the per-call override disables the configured floor, so it resolves without advancing timers
     expect(status.value).toBe('success')


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/15181

### 📚 Description

Adds `minDuration` option to async data to enforce artificial minimum number of ms before the handler promise resolves or rejects. Handler promise might resolve prior to min delay, it's non-blocking in this aspect.

Suggestions regarding the naming + client-only behavior much welcome (couldn't find a reason to add this delay on SSR; it's most useful for the non-immediate client-side calls).