### PR TITLE
docs: fill gaps in API minimalVersion badges after #34485

### DIFF
--- a/docs/4.api/1.components/13.nuxt-time.md
+++ b/docs/4.api/1.components/13.nuxt-time.md
@@ -1,6 +1,7 @@
 ---
 title: '<NuxtTime>'
 description: 'The <NuxtTime> component displays time in a locale-friendly format with server-client consistency.'
+minimalVersion: "3.17"
 links:
   - label: Source
     icon: i-simple-icons-github

--- a/docs/4.api/1.components/14.nuxt-announcer.md
+++ b/docs/4.api/1.components/14.nuxt-announcer.md
@@ -1,7 +1,7 @@
 ---
 title: '<NuxtAnnouncer>'
 description: 'The <NuxtAnnouncer> component adds a hidden element to announce dynamic content changes to assistive technologies.'
-minimalVersion: "3.17"
+minimalVersion: "4.4"
 links:
   - label: Source
     icon: i-simple-icons-github

--- a/docs/4.api/2.composables/use-announcer.md
+++ b/docs/4.api/2.composables/use-announcer.md
@@ -1,7 +1,7 @@
 ---
 title: 'useAnnouncer'
 description: A composable for announcing messages to screen readers.
-minimalVersion: "3.17"
+minimalVersion: "4.4"
 links:
   - label: Source
     icon: i-simple-icons-github

--- a/docs/4.api/2.composables/use-nuxt-app.md
+++ b/docs/4.api/2.composables/use-nuxt-app.md
@@ -136,7 +136,7 @@ Nuxt exposes the following properties through `ssrContext`:
 
   It is also possible to use more advanced types, such as `ref`, `reactive`, `shallowRef`, `shallowReactive` and `NuxtError`.
 
-#### Custom Reducer/Reviver
+#### Custom Reducer/Reviver :badge[v3.4]{color="info" size="xs" class="align-middle"}
 
   Since [Nuxt v3.4](https://nuxt.com/blog/v3-4#payload-enhancements), it is possible to define your own reducer/reviver for types that are not supported by Nuxt.
 

--- a/docs/4.api/3.utils/define-lazy-hydration-component.md
+++ b/docs/4.api/3.utils/define-lazy-hydration-component.md
@@ -1,6 +1,7 @@
 ---
 title: 'defineLazyHydrationComponent'
 description: 'Define a lazy hydration component with a specific strategy.'
+minimalVersion: "3.18"
 links:
   - label: Source
     icon: i-simple-icons-github

--- a/docs/4.api/4.commands/build.md
+++ b/docs/4.api/4.commands/build.md
@@ -36,7 +36,7 @@ The `build` command creates a `.output` directory with all your application, ser
 | `--dotenv`                           |         | Path to `.env` file to load, relative to the root directory                                                                                          |
 | `--envName`                          |         | The environment to use when resolving configuration overrides (default is `production` when building, and `development` when running the dev server) |
 | `-e, --extends=<layer-name>`         |         | Extend from a Nuxt layer                                                                                                                             |
-| `--profile`                          |         | Profile performance (v4.4+). Writes a V8 CPU profile and JSON report on exit. Use `--profile=verbose` for a full console report.                     |
+| `--profile` :badge[v4.4]{color="info" size="xs" class="align-middle"} |         | Profile performance. Writes a V8 CPU profile and JSON report on exit. Use `--profile=verbose` for a full console report.                             |
 <!--/build-opts-->
 
 ::note

--- a/docs/4.api/4.commands/dev.md
+++ b/docs/4.api/4.commands/dev.md
@@ -45,7 +45,7 @@ The `dev` command starts a development server with hot module replacement at [ht
 | `--qr`                               |         | Display The QR code of public URL when available                                                                                                     |
 | `--public`                           |         | Listen to all network interfaces                                                                                                                     |
 | `--tunnel`                           |         | Open a tunnel using https://github.com/unjs/untun                                                                                                    |
-| `--profile`                          |         | Profile performance (v4.4+). Writes a V8 CPU profile and JSON report on exit. Use `--profile=verbose` for a full console report.                     |
+| `--profile` :badge[v4.4]{color="info" size="xs" class="align-middle"} |         | Profile performance. Writes a V8 CPU profile and JSON report on exit. Use `--profile=verbose` for a full console report.                             |
 | `--sslCert`                          |         | (DEPRECATED) Use `--https.cert` instead.                                                                                                             |
 | `--sslKey`                           |         | (DEPRECATED) Use `--https.key` instead.                                                                                                              |
 <!--/dev-opts-->

--- a/docs/4.api/4.commands/generate.md
+++ b/docs/4.api/4.commands/generate.md
@@ -35,7 +35,7 @@ The `generate` command pre-renders every route of your application and stores th
 | `--dotenv`                           |         | Path to `.env` file to load, relative to the root directory                                                                                          |
 | `--envName`                          |         | The environment to use when resolving configuration overrides (default is `production` when building, and `development` when running the dev server) |
 | `-e, --extends=<layer-name>`         |         | Extend from a Nuxt layer                                                                                                                             |
-| `--profile`                          |         | Profile performance (v4.4+). Writes a V8 CPU profile and JSON report on exit. Use `--profile=verbose` for a full console report.                     |
+| `--profile` :badge[v4.4]{color="info" size="xs" class="align-middle"} |         | Profile performance. Writes a V8 CPU profile and JSON report on exit. Use `--profile=verbose` for a full console report.                             |
 <!--/generate-opts-->
 
 ::read-more{to="/docs/4.x/getting-started/deployment#static-hosting"}

--- a/docs/4.api/5.kit/11.app-config.md
+++ b/docs/4.api/5.kit/11.app-config.md
@@ -1,6 +1,7 @@
 ---
 title: App Config
 description: Nuxt Kit provides a set of utilities to help you access and modify Nuxt app configuration.
+minimalVersion: "4.5"
 links:
   - label: Source
     icon: i-simple-icons-github

--- a/packages/nuxt/src/app/composables/announcer.ts
+++ b/packages/nuxt/src/app/composables/announcer.ts
@@ -52,7 +52,7 @@ function createAnnouncer (opts: NuxtAnnouncerOpts = {}): NuxtAnnouncer {
 
 /**
  * Composable for announcing messages to screen readers
- * @since 3.17.0
+ * @since 4.4.2
  * @example
  * const { polite, assertive } = useAnnouncer()
  * polite('Item saved successfully')


### PR DESCRIPTION
Follow-up to #34485 for API pages that still lacked `minimalVersion` / `:badge`, plus a wrong Announcer version.

`useAnnouncer` / `<NuxtAnnouncer>` landed in #34318 (docs prose fixed to v4.4.2+ in #34852), but frontmatter still said `3.17` and `@since` matched that. This moves both to 4.4 / 4.4.2.

Also adds page-level `minimalVersion` where the version is already known from prose or `@since`:
- `<NuxtTime>` → 3.17
- `defineLazyHydrationComponent` → 3.18
- Kit `updateAppConfig` → 4.5

Inline badges for features newer than the parent page:
- Custom Reducer/Reviver on `useNuxtApp` → v3.4
- `--profile` on `dev` / `build` / `generate` → v4.4

Core APIs from Nuxt 3.0 stay without page badges, same as #34485.

Refs #34485