### PR TITLE
feat(nuxt,schema,vite): add experimental `cleanupRouteStyles` option

### DIFF
--- a/docs/3.guide/6.going-further/1.experimental-features.md
+++ b/docs/3.guide/6.going-further/1.experimental-features.md
@@ -988,6 +988,22 @@ To use this feature, you need to:
 Learn more about **@dxup/nuxt**.
 ::
 
+## cleanupRouteStyles
+
+Disables stylesheets belonging to pages and layouts that are no longer rendered after client-side navigation.
+
+By default, once the CSS for a lazy-loaded page or layout chunk has been added to the document it stays there for the lifetime of the app, so global (non-scoped) styles from a previously visited route can leak into other routes ([#22817](https://github.com/nuxt/nuxt/issues/22817)). When this option is enabled, Nuxt emits a map of page and layout stylesheets at build time and toggles the `disabled` property of their `<link>` tags on navigation, so only the current route's styles apply.
+
+```ts twoslash [nuxt.config.ts]
+export default defineNuxtConfig({
+  experimental: {
+    cleanupRouteStyles: true,
+  },
+})
+```
+
+This is only supported with the Vite builder in production builds, and works best with `features.inlineStyles: false` (inlined styles from the initially rendered route cannot be cleaned up). Styles for layouts rendered via an explicit `<NuxtLayout name="...">` prop (rather than route metadata or route rules) are not tracked and are never disabled.
+
 ## ssrStreaming
 
 Enables SSR streaming to dramatically improve Time to First Byte (TTFB). When enabled, the server sends the HTML shell (including `<head>`, styles, preload hints, and entry scripts) immediately, then streams the rendered body content progressively using Vue's `renderToWebStream`.

--- a/packages/nuxt/src/app/plugins/cleanup-route-styles.client.ts
+++ b/packages/nuxt/src/app/plugins/cleanup-route-styles.client.ts
@@ -1,0 +1,89 @@
+import type { RouteLocationNormalized } from 'vue-router'
+import { defineNuxtPlugin, useRuntimeConfig } from '../nuxt'
+import type { ObjectPlugin, Plugin } from '../nuxt'
+import { useRouter } from '../composables/router'
+import { resolveLayoutName } from '../composables/layout'
+import { buildAssetsURL } from '#internal/nuxt/paths'
+
+interface RouteStylesMap {
+  layouts: Record<string, string[]>
+  pages: Record<string, string[]>
+}
+
+/**
+ * Disables stylesheets belonging to pages/layouts that are no longer rendered
+ * after a client-side navigation, using the `route-styles.json` map emitted by
+ * the `nuxt:route-styles-map` vite plugin. Links are toggled via `disabled`
+ * (never removed) so vite's preload helper does not need to re-inject them.
+ */
+const plugin: Plugin & ObjectPlugin = defineNuxtPlugin({
+  name: 'nuxt:cleanup-route-styles',
+  setup (nuxtApp) {
+    const router = useRouter()
+    const config = useRuntimeConfig()
+
+    let map: RouteStylesMap | false | undefined
+    let managed: Set<string>
+    let loading: Promise<void> | undefined
+    const loadMap = () => loading ||= (async () => {
+      let loaded: RouteStylesMap | false = false
+      try {
+        const res = await fetch(buildAssetsURL('route-styles.json') + '?' + config.app.buildId)
+        if (res.ok) {
+          loaded = await res.json() as RouteStylesMap
+        }
+      } catch {
+        // if the map cannot be loaded the plugin is a no-op
+      }
+      map = loaded
+      managed = new Set(loaded ? [...Object.values(loaded.layouts), ...Object.values(loaded.pages)].flat() : [])
+    })()
+
+    function activeStyles (route: RouteLocationNormalized) {
+      const active = new Set<string>()
+      if (!map) { return active }
+      const layout = resolveLayoutName(route)
+      for (const file of (layout && map.layouts[layout]) || []) {
+        active.add(file)
+      }
+      for (const record of route.matched) {
+        if (typeof record.name === 'string') {
+          for (const file of map.pages[record.name] || []) {
+            active.add(file)
+          }
+        }
+      }
+      return active
+    }
+
+    function toggleStyles (route: RouteLocationNormalized, { disable }: { disable: boolean }) {
+      const active = activeStyles(route)
+      for (const link of document.querySelectorAll<HTMLLinkElement>('link[rel="stylesheet"]')) {
+        const file = link.href.split('/').pop()?.replace(/\?.*$/, '')
+        if (!file || !managed.has(file)) { continue }
+        if (active.has(file)) {
+          link.disabled = false
+        } else if (disable) {
+          link.disabled = true
+        }
+      }
+    }
+
+    // Re-enable the incoming route's styles before the DOM updates to avoid a
+    // flash of unstyled content when returning to a previously visited route.
+    router.beforeResolve(async (to) => {
+      if (nuxtApp.isHydrating) { return }
+      await loadMap()
+      if (map) {
+        toggleStyles(to, { disable: false })
+      }
+    })
+
+    nuxtApp.hook('page:finish', () => {
+      if (nuxtApp.isHydrating || !map) { return }
+      toggleStyles(router.currentRoute.value, { disable: true })
+    })
+  },
+})
+
+export default plugin

--- a/packages/nuxt/src/app/plugins/cleanup-route-styles.client.ts
+++ b/packages/nuxt/src/app/plugins/cleanup-route-styles.client.ts
@@ -22,42 +22,24 @@ const plugin: Plugin & ObjectPlugin = defineNuxtPlugin({
     const router = useRouter()
     const config = useRuntimeConfig()
 
-    let map: RouteStylesMap | false | undefined
-    let managed: Set<string>
-    let loading: Promise<void> | undefined
-    const loadMap = () => loading ||= (async () => {
-      let loaded: RouteStylesMap | false = false
-      try {
-        const res = await fetch(buildAssetsURL('route-styles.json') + '?' + config.app.buildId)
-        if (res.ok) {
-          loaded = await res.json() as RouteStylesMap
-        }
-      } catch {
-        // if the map cannot be loaded the plugin is a no-op
-      }
-      map = loaded
-      managed = new Set(loaded ? [...Object.values(loaded.layouts), ...Object.values(loaded.pages)].flat() : [])
-    })()
+    interface LoadedStyles { map: RouteStylesMap, managed: Set<string> }
 
-    function activeStyles (route: RouteLocationNormalized) {
-      const active = new Set<string>()
-      if (!map) { return active }
+    // resolves to undefined (and the plugin no-ops) if the map cannot be loaded
+    let styles: Promise<LoadedStyles | undefined> | undefined
+    const loadStyles = () => styles ||= fetch(buildAssetsURL('route-styles.json') + '?' + config.app.buildId)
+      .then(async (res) => {
+        if (!res.ok) { return }
+        const map = await res.json() as RouteStylesMap
+        return { map, managed: new Set([...Object.values(map.layouts), ...Object.values(map.pages)].flat()) }
+      })
+      .catch(() => undefined)
+
+    function toggleStyles ({ map, managed }: LoadedStyles, route: RouteLocationNormalized, { disable }: { disable: boolean }) {
       const layout = resolveLayoutName(route)
-      for (const file of (layout && map.layouts[layout]) || []) {
-        active.add(file)
-      }
-      for (const record of route.matched) {
-        if (typeof record.name === 'string') {
-          for (const file of map.pages[record.name] || []) {
-            active.add(file)
-          }
-        }
-      }
-      return active
-    }
-
-    function toggleStyles (route: RouteLocationNormalized, { disable }: { disable: boolean }) {
-      const active = activeStyles(route)
+      const active = new Set([
+        ...(layout && map.layouts[layout]) || [],
+        ...route.matched.flatMap(record => (typeof record.name === 'string' && map.pages[record.name]) || []),
+      ])
       for (const link of document.querySelectorAll<HTMLLinkElement>('link[rel="stylesheet"]')) {
         const file = link.href.split('/').pop()?.replace(/\?.*$/, '')
         if (!file || !managed.has(file)) { continue }
@@ -73,15 +55,17 @@ const plugin: Plugin & ObjectPlugin = defineNuxtPlugin({
     // flash of unstyled content when returning to a previously visited route.
     router.beforeResolve(async (to) => {
       if (nuxtApp.isHydrating) { return }
-      await loadMap()
-      if (map) {
-        toggleStyles(to, { disable: false })
+      const loaded = await loadStyles()
+      if (loaded) {
+        toggleStyles(loaded, to, { disable: false })
       }
     })
 
-    nuxtApp.hook('page:finish', () => {
-      if (nuxtApp.isHydrating || !map) { return }
-      toggleStyles(router.currentRoute.value, { disable: true })
+    nuxtApp.hook('page:finish', async () => {
+      const loaded = !nuxtApp.isHydrating && await styles
+      if (loaded) {
+        toggleStyles(loaded, router.currentRoute.value, { disable: true })
+      }
     })
   },
 })

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -751,6 +751,11 @@ async function initNuxt (nuxt: Nuxt) {
     addPlugin(resolve(nuxt.options.appDir, 'plugins/cross-origin-prefetch.client'))
   }
 
+  // Add experimental cleanup of styles from unmounted pages/layouts
+  if (nuxt.options.experimental.cleanupRouteStyles && !nuxt.options.dev && nuxt.options.builder === '@nuxt/vite-builder') {
+    addPlugin(resolve(nuxt.options.appDir, 'plugins/cleanup-route-styles.client'))
+  }
+
   // Add experimental page reload support
   if (nuxt.options.experimental.emitRouteChunkError === 'automatic') {
     addPlugin(resolve(nuxt.options.appDir, 'plugins/chunk-reload.client'))

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -263,6 +263,7 @@ export default defineResolvers({
         return typeof val === 'boolean' ? val : (await get('future.compatibilityVersion')) < 5
       },
     },
+    cleanupRouteStyles: false,
     ssrStreaming: {
       $resolve (val) {
         // Indexing crawlers only; `chrome-lighthouse` is intentionally absent

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1619,6 +1619,24 @@ export interface ConfigSchema {
     nitroAutoImports: boolean
 
     /**
+     * Disable stylesheets belonging to unmounted pages and layouts after client-side navigation.
+     *
+     * By default, CSS for a lazy-loaded page or layout chunk stays in the document forever
+     * once loaded, so global (non-scoped) styles from a previously visited route can leak
+     * into other routes. When enabled, Nuxt emits a map of page/layout stylesheets at build
+     * time and toggles the `disabled` property of their `<link>` tags on navigation so only
+     * the current route's styles apply.
+     *
+     * Only supported with the Vite builder in production builds. Works best with
+     * `features.inlineStyles: false`. Styles for layouts rendered via
+     * `<NuxtLayout name="...">` (rather than route metadata) are not tracked.
+     *
+     * @default false
+     * @see https://github.com/nuxt/nuxt/issues/22817
+     */
+    cleanupRouteStyles: boolean
+
+    /**
      * Enable SSR streaming to improve Time to First Byte (TTFB).
      *
      * When enabled, the server sends the HTML shell (head, styles, preload hints)

--- a/packages/vite/src/plugins/route-styles-map.ts
+++ b/packages/vite/src/plugins/route-styles-map.ts
@@ -3,8 +3,6 @@ import { joinURL, withoutLeadingSlash } from 'ufo'
 import { normalize } from 'pathe'
 import type { Nuxt, NuxtPage } from '@nuxt/schema'
 
-const QUERY_RE = /\?.+$/
-
 /**
  * Emits `<buildAssetsDir>/route-styles.json`, mapping each layout name and page
  * (route name) to the basenames of the CSS assets its chunk graph owns, excluding
@@ -23,46 +21,34 @@ export function RouteStylesMapPlugin (nuxt: Nuxt): Plugin | undefined {
       const chunksByFacade = new Map<string, Rollup.OutputChunk>()
       for (const chunk of chunks) {
         if (chunk.facadeModuleId) {
-          chunksByFacade.set(normalize(chunk.facadeModuleId.replace(QUERY_RE, '')), chunk)
+          chunksByFacade.set(normalize(chunk.facadeModuleId.replace(/\?.+$/, '')), chunk)
         }
       }
 
       // CSS owned by a chunk = its own emitted CSS + that of its static import graph,
       // mirroring the set vite's preload helper injects when the chunk is loaded.
-      const cssCache = new Map<string, Set<string>>()
-      const collectCss = (chunk: Rollup.OutputChunk, seen = new Set<string>()): Set<string> => {
-        const cached = cssCache.get(chunk.fileName)
-        if (cached) { return cached }
+      const collectCss = (chunk: Rollup.OutputChunk, css = new Set<string>(), seen = new Set<string>()): Set<string> => {
+        if (seen.has(chunk.fileName)) { return css }
         seen.add(chunk.fileName)
-        const css = new Set<string>()
         for (const file of chunk.viteMetadata?.importedCss || []) {
           css.add(file.split('/').pop()!)
         }
         for (const imported of chunk.imports) {
           const importedChunk = chunksByFileName.get(imported)
-          if (importedChunk && !seen.has(imported)) {
-            for (const file of collectCss(importedChunk, seen)) {
-              css.add(file)
-            }
-          }
+          if (importedChunk) { collectCss(importedChunk, css, seen) }
         }
-        cssCache.set(chunk.fileName, css)
         return css
       }
 
       const entryCss = new Set<string>()
       for (const chunk of chunks) {
-        if (chunk.isEntry) {
-          for (const file of collectCss(chunk)) {
-            entryCss.add(file)
-          }
-        }
+        if (chunk.isEntry) { collectCss(chunk, entryCss) }
       }
 
       const cssForFile = (file?: string | null) => {
         const chunk = file && chunksByFacade.get(normalize(file))
         if (!chunk) { return }
-        const css = [...collectCss(chunk)].filter(file => !entryCss.has(file))
+        const css = [...collectCss(chunk)].filter(name => !entryCss.has(name))
         return css.length ? css : undefined
       }
 

--- a/packages/vite/src/plugins/route-styles-map.ts
+++ b/packages/vite/src/plugins/route-styles-map.ts
@@ -1,0 +1,93 @@
+import type { Plugin, Rollup } from 'vite'
+import { joinURL, withoutLeadingSlash } from 'ufo'
+import { normalize } from 'pathe'
+import type { Nuxt, NuxtPage } from '@nuxt/schema'
+
+const QUERY_RE = /\?.+$/
+
+/**
+ * Emits `<buildAssetsDir>/route-styles.json`, mapping each layout name and page
+ * (route name) to the basenames of the CSS assets its chunk graph owns, excluding
+ * CSS also owned by the entry. Used by the `cleanup-route-styles.client` plugin to
+ * disable stylesheets of unmounted routes after navigation.
+ */
+export function RouteStylesMapPlugin (nuxt: Nuxt): Plugin | undefined {
+  if (nuxt.options.dev || !nuxt.options.experimental.cleanupRouteStyles) { return }
+
+  return {
+    name: 'nuxt:route-styles-map',
+    applyToEnvironment: environment => environment.name === 'client',
+    generateBundle (_options, bundle) {
+      const chunks = Object.values(bundle).filter((c): c is Rollup.OutputChunk => c.type === 'chunk')
+      const chunksByFileName = new Map(chunks.map(c => [c.fileName, c]))
+      const chunksByFacade = new Map<string, Rollup.OutputChunk>()
+      for (const chunk of chunks) {
+        if (chunk.facadeModuleId) {
+          chunksByFacade.set(normalize(chunk.facadeModuleId.replace(QUERY_RE, '')), chunk)
+        }
+      }
+
+      // CSS owned by a chunk = its own emitted CSS + that of its static import graph,
+      // mirroring the set vite's preload helper injects when the chunk is loaded.
+      const cssCache = new Map<string, Set<string>>()
+      const collectCss = (chunk: Rollup.OutputChunk, seen = new Set<string>()): Set<string> => {
+        const cached = cssCache.get(chunk.fileName)
+        if (cached) { return cached }
+        seen.add(chunk.fileName)
+        const css = new Set<string>()
+        for (const file of chunk.viteMetadata?.importedCss || []) {
+          css.add(file.split('/').pop()!)
+        }
+        for (const imported of chunk.imports) {
+          const importedChunk = chunksByFileName.get(imported)
+          if (importedChunk && !seen.has(imported)) {
+            for (const file of collectCss(importedChunk, seen)) {
+              css.add(file)
+            }
+          }
+        }
+        cssCache.set(chunk.fileName, css)
+        return css
+      }
+
+      const entryCss = new Set<string>()
+      for (const chunk of chunks) {
+        if (chunk.isEntry) {
+          for (const file of collectCss(chunk)) {
+            entryCss.add(file)
+          }
+        }
+      }
+
+      const cssForFile = (file?: string | null) => {
+        const chunk = file && chunksByFacade.get(normalize(file))
+        if (!chunk) { return }
+        const css = [...collectCss(chunk)].filter(file => !entryCss.has(file))
+        return css.length ? css : undefined
+      }
+
+      const layouts: Record<string, string[]> = {}
+      for (const layout of Object.values(nuxt.apps.default?.layouts || {})) {
+        const css = cssForFile(layout.file)
+        if (css) { layouts[layout.name] = css }
+      }
+
+      const pages: Record<string, string[]> = {}
+      const flattenPages = (toFlatten?: NuxtPage[]): NuxtPage[] =>
+        toFlatten?.flatMap(p => [p, ...flattenPages(p.children)]) ?? []
+      for (const page of flattenPages(nuxt.apps.default?.pages)) {
+        // ponytail: routes without a generated name (e.g. parents of nested routes)
+        // are left unmanaged - their styles are simply never disabled
+        if (!page.name) { continue }
+        const css = cssForFile(page.file)
+        if (css) { pages[page.name] = css }
+      }
+
+      this.emitFile({
+        type: 'asset',
+        fileName: withoutLeadingSlash(joinURL(nuxt.options.app.buildAssetsDir, 'route-styles.json')),
+        source: JSON.stringify({ layouts, pages }),
+      })
+    },
+  }
+}

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -19,6 +19,7 @@ import { OptimizeDepsHintPlugin, optimizerCallbacks, userOptimizeDepsInclude } f
 
 import { VueJsxPlugin } from './plugins/vue-jsx.ts'
 import { SSRStylesPlugin } from './plugins/ssr-styles.ts'
+import { RouteStylesMapPlugin } from './plugins/route-styles-map.ts'
 import { PublicDirsPlugin } from './plugins/public-dirs.ts'
 import { ReplacePlugin } from './plugins/replace.ts'
 import { LayerDepOptimizePlugin } from './plugins/layer-dep-optimize.ts'
@@ -204,6 +205,7 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
         ReplacePlugin(),
         LayerDepOptimizePlugin(nuxt),
         SSRStylesPlugin(nuxt),
+        RouteStylesMapPlugin(nuxt),
         EnvironmentsPlugin(nuxt),
         // Add type-checking
         VitePluginCheckerPlugin(nuxt),

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,8 +13,8 @@ const e2eMatrix = [
 ] as const
 
 const devOnlyTests = ['**/hmr.test.ts']
-const builtOnlyTests = ['**/spa-preloader-*.test.ts', '**/server-page-css.test.ts', '**/chunk-error.test.ts']
-const viteOnlyTests = ['**/server-page-css.test.ts']
+const builtOnlyTests = ['**/spa-preloader-*.test.ts', '**/server-page-css.test.ts', '**/chunk-error.test.ts', '**/css-cleanup.test.ts']
+const viteOnlyTests = ['**/server-page-css.test.ts', '**/css-cleanup.test.ts']
 const rspackExcludedTests = ['**/chunk-error.test.ts']
 
 function testIgnoreForProject (entry: typeof e2eMatrix[number]) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1363,6 +1363,12 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
 
+  test/fixtures/css-cleanup:
+    dependencies:
+      nuxt:
+        specifier: workspace:*
+        version: link:../../../packages/nuxt
+
   test/fixtures/dynamic-paths:
     dependencies:
       '@nuxt/rspack-builder':

--- a/test/e2e/css-cleanup.test.ts
+++ b/test/e2e/css-cleanup.test.ts
@@ -1,0 +1,45 @@
+import { fileURLToPath } from 'node:url'
+import { isWindows } from 'std-env'
+import { expect, test } from './test-utils'
+
+test.use({
+  nuxt: {
+    rootDir: fileURLToPath(new URL('../fixtures/css-cleanup', import.meta.url)),
+    setupTimeout: (isWindows ? 360 : 120) * 1000,
+  },
+})
+
+const BLUE = 'rgb(0, 0, 255)'
+const RED = 'rgb(255, 0, 0)'
+
+test.describe('css cleanup on navigation (#22817)', () => {
+  test('css from a previously visited layout does not leak into the current route', async ({ page, goto }) => {
+    await goto('/')
+    await expect(page.locator('.box')).toHaveCSS('border-top-color', BLUE)
+
+    await page.click('a[href="/other"]')
+    await expect(page.locator('.legacy-page')).toBeVisible()
+    await expect(page.locator('.legacy-page')).toHaveCSS('color', RED)
+
+    await page.click('a[href="/"]')
+    await expect(page.locator('.box')).toBeVisible()
+    await expect(page.locator('.box')).toHaveCSS('border-top-color', BLUE)
+
+    // navigating forward again must restore the disabled styles
+    await page.click('a[href="/other"]')
+    await expect(page.locator('.legacy-page')).toBeVisible()
+    await expect(page.locator('.legacy-page')).toHaveCSS('color', RED)
+  })
+
+  test('prefetching a link does not apply css from the unvisited route', async ({ page, goto }) => {
+    // resolves once the legacy layout's css chunk has been fetched (triggered by NuxtLink prefetch)
+    const legacyCssFetched = page.waitForResponse(async response =>
+      response.url().includes('.css') && (await response.text().catch(() => '')).includes('red'), { timeout: 15_000 },
+    ).catch(() => null)
+
+    await goto('/prefetch')
+    await legacyCssFetched
+
+    await expect(page.locator('.box')).toHaveCSS('border-top-color', BLUE)
+  })
+})

--- a/test/e2e/css-cleanup.test.ts
+++ b/test/e2e/css-cleanup.test.ts
@@ -18,16 +18,13 @@ test.describe('css cleanup on navigation (#22817)', () => {
     await expect(page.locator('.box')).toHaveCSS('border-top-color', BLUE)
 
     await page.click('a[href="/other"]')
-    await expect(page.locator('.legacy-page')).toBeVisible()
     await expect(page.locator('.legacy-page')).toHaveCSS('color', RED)
 
     await page.click('a[href="/"]')
-    await expect(page.locator('.box')).toBeVisible()
     await expect(page.locator('.box')).toHaveCSS('border-top-color', BLUE)
 
     // navigating forward again must restore the disabled styles
     await page.click('a[href="/other"]')
-    await expect(page.locator('.legacy-page')).toBeVisible()
     await expect(page.locator('.legacy-page')).toHaveCSS('color', RED)
   })
 

--- a/test/fixtures/css-cleanup/app/app.vue
+++ b/test/fixtures/css-cleanup/app/app.vue
@@ -1,0 +1,5 @@
+<template>
+  <NuxtLayout>
+    <NuxtPage />
+  </NuxtLayout>
+</template>

--- a/test/fixtures/css-cleanup/app/layouts/default.vue
+++ b/test/fixtures/css-cleanup/app/layouts/default.vue
@@ -1,0 +1,11 @@
+<template>
+  <div>
+    <slot />
+  </div>
+</template>
+
+<style>
+.box {
+  border: 3px solid blue;
+}
+</style>

--- a/test/fixtures/css-cleanup/app/layouts/legacy.vue
+++ b/test/fixtures/css-cleanup/app/layouts/legacy.vue
@@ -1,0 +1,15 @@
+<template>
+  <div>
+    <slot />
+  </div>
+</template>
+
+<style>
+.box {
+  border: 3px solid red;
+}
+
+.legacy-page {
+  color: red;
+}
+</style>

--- a/test/fixtures/css-cleanup/app/pages/index.vue
+++ b/test/fixtures/css-cleanup/app/pages/index.vue
@@ -1,0 +1,13 @@
+<template>
+  <div>
+    <div class="box">
+      blue box
+    </div>
+    <NuxtLink
+      to="/other"
+      no-prefetch
+    >
+      to other
+    </NuxtLink>
+  </div>
+</template>

--- a/test/fixtures/css-cleanup/app/pages/other.vue
+++ b/test/fixtures/css-cleanup/app/pages/other.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+definePageMeta({
+  layout: 'legacy',
+})
+</script>
+
+<template>
+  <div class="legacy-page">
+    legacy page
+    <NuxtLink
+      to="/"
+      no-prefetch
+    >
+      go back
+    </NuxtLink>
+  </div>
+</template>

--- a/test/fixtures/css-cleanup/app/pages/prefetch.vue
+++ b/test/fixtures/css-cleanup/app/pages/prefetch.vue
@@ -1,0 +1,10 @@
+<template>
+  <div>
+    <div class="box">
+      blue box
+    </div>
+    <NuxtLink to="/other">
+      prefetching link to other
+    </NuxtLink>
+  </div>
+</template>

--- a/test/fixtures/css-cleanup/nuxt.config.ts
+++ b/test/fixtures/css-cleanup/nuxt.config.ts
@@ -1,0 +1,8 @@
+export default defineNuxtConfig({
+  features: {
+    inlineStyles: false,
+  },
+  experimental: {
+    cleanupRouteStyles: true,
+  },
+})

--- a/test/fixtures/css-cleanup/package.json
+++ b/test/fixtures/css-cleanup/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "fixture-css-cleanup",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "nuxt": "workspace:*"
+  },
+  "engines": {
+    "node": "^22.19.0 || ^24.11.0 || >=26.0.0"
+  }
+}


### PR DESCRIPTION
Adds an opt-in experimental option that disables stylesheets from unmounted pages/layouts after client-side navigation, so global (non-scoped) styles from a previously visited route no longer leak into other routes.

Resolves #22817

- Adds `experimental.cleanupRouteStyles` (default `false`; vite builder, production builds only)
- New vite plugin emits `_nuxt/route-styles.json` mapping layout names / route names to the CSS assets their chunk graph owns (entry CSS excluded)
- New client plugin toggles `link.disabled` on managed stylesheets: re-enables incoming route styles in `beforeResolve` (avoids FOUC), disables stale ones on `page:finish`
- Links are disabled rather than removed, since vite's preload helper will not re-inject a link it has already loaded
- New `css-cleanup` fixture + e2e test covering the A→B→A leak, the re-enable path (A→B→A→B), and documenting that prefetch no longer applies CSS from unvisited routes (second bug in #22817)

Known limitations (documented on the flag): dev mode and webpack/rspack are untouched, `<NuxtLayout name>` prop overrides are not tracked, unnamed parent routes are left unmanaged, and inlined initial-route styles (`features.inlineStyles`) cannot be cleaned up.