### PR TITLE
fix(nuxt): generate layout types even when pages module is disabled

### DIFF
--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -195,6 +195,35 @@ export default defineNuxtModule({
       }
     })
 
+    // layouts can be used without pages (e.g. `<NuxtLayout>`), so always generate their types
+    addTypeTemplate({
+      filename: 'types/layouts.d.ts',
+      getContents: ({ app }) => {
+        return [
+          'import type { ComputedRef, MaybeRef } from \'vue\'',
+          '',
+          'type ComponentProps<T> = T extends new(...args: any) => { $props: infer P } ? NonNullable<P>',
+          '  : T extends (props: infer P, ...args: any) => any ? P',
+          '  : {}',
+          '',
+          'declare module \'nuxt/app\' {',
+          '  interface NuxtLayouts {',
+          ...Object.values(app.layouts).map(layout => `    ${genObjectKey(layout.name)}: ComponentProps<${genInlineTypeImport(layout.file)}>`),
+          '  }',
+          '  export type LayoutKey = keyof NuxtLayouts extends never ? string : keyof NuxtLayouts',
+          '  interface PageMeta {',
+          '    layout?: MaybeRef<LayoutKey | false> | ComputedRef<LayoutKey | false> | {',
+          '      [K in LayoutKey]: {',
+          '        name?: MaybeRef<K | false> | ComputedRef<K | false>',
+          '        props?: NuxtLayouts[K]',
+          '      }',
+          '    }[LayoutKey]',
+          '  }',
+          '}',
+        ].join('\n')
+      },
+    })
+
     if (!options.enabled) {
       addPlugin(resolve(distDir, 'app/plugins/router'))
       addTemplate({
@@ -717,34 +746,6 @@ export default defineNuxtModule({
         ].join('\n')
       },
     }, { nuxt: true, nitro: true, node: true })
-
-    addTypeTemplate({
-      filename: 'types/layouts.d.ts',
-      getContents: ({ app }) => {
-        return [
-          'import type { ComputedRef, MaybeRef } from \'vue\'',
-          '',
-          'type ComponentProps<T> = T extends new(...args: any) => { $props: infer P } ? NonNullable<P>',
-          '  : T extends (props: infer P, ...args: any) => any ? P',
-          '  : {}',
-          '',
-          'declare module \'nuxt/app\' {',
-          '  interface NuxtLayouts {',
-          ...Object.values(app.layouts).map(layout => `    ${genObjectKey(layout.name)}: ComponentProps<${genInlineTypeImport(layout.file)}>`),
-          '  }',
-          '  export type LayoutKey = keyof NuxtLayouts extends never ? string : keyof NuxtLayouts',
-          '  interface PageMeta {',
-          '    layout?: MaybeRef<LayoutKey | false> | ComputedRef<LayoutKey | false> | {',
-          '      [K in LayoutKey]: {',
-          '        name?: MaybeRef<K | false> | ComputedRef<K | false>',
-          '        props?: NuxtLayouts[K]',
-          '      }',
-          '    }[LayoutKey]',
-          '  }',
-          '}',
-        ].join('\n')
-      },
-    })
 
     // add page meta types if enabled
     if (nuxt.options.experimental.viewTransition) {

--- a/packages/nuxt/test/load-nuxt.test.ts
+++ b/packages/nuxt/test/load-nuxt.test.ts
@@ -207,4 +207,10 @@ describe('pages detection', () => {
     expect(nuxt.options.pages).toMatchObject(result)
     await nuxt.close()
   })
+
+  it('generates layout types even when pages are disabled', async () => {
+    const nuxt = await loadNuxt({ cwd: pagesFixtureDir, overrides: { pages: false }, ready: true })
+    expect(nuxt.options.build.templates.some(t => t.filename === 'types/layouts.d.ts')).toBe(true)
+    await nuxt.close()
+  })
 })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #24222

### 📚 Description

`types/layouts.d.ts` was registered after the pages module's early return, so projects without a pages directory never got `LayoutKey` or the `NuxtLayouts` augmentation — even though layouts work without pages via `<NuxtLayout>`, `useLayout` and `setPageLayout`.

- Move the `types/layouts.d.ts` template registration above the `!options.enabled` early return (template content unchanged)
- With no layouts, the existing `keyof NuxtLayouts extends never ? string : ...` fallback yields `LayoutKey = string`
- Add a regression test asserting the template is registered with `pages: false`