### PR TITLE
docs: clarify module dependency resolution

### DIFF
--- a/docs/4.api/5.kit/13.resolving.md
+++ b/docs/4.api/5.kit/13.resolving.md
@@ -1,6 +1,6 @@
 ---
 title: Resolving
-description: Nuxt Kit provides a set of utilities to help you resolve paths. These functions allow you to resolve paths relative to the current module, with unknown name or extension.
+description: Nuxt Kit provides utilities to resolve paths from the Nuxt root directory or a custom base.
 links:
   - label: Source
     icon: i-simple-icons-github
@@ -8,7 +8,7 @@ links:
     size: xs
 ---
 
-Sometimes you need to resolve a path relative to the current module without knowing the name or extension. For example, you may want to add a plugin that is located in the same directory as the module. To handle these cases, Nuxt provides a set of utilities to resolve paths. `resolvePath` and `resolveAlias` are used to resolve paths relative to the current module. `findPath` is used to find the first existing file in a given set of paths. `createResolver` is used to create a resolver relative to the base path.
+Sometimes you need to resolve a path without knowing its name or extension. For example, you may want to add a plugin that is located in the same directory as a module. To handle these cases, Nuxt provides a set of utilities to resolve paths. `resolvePath` resolves paths from the Nuxt root directory by default, while `resolveAlias` applies configured aliases. `findPath` finds the first existing file in a given set of paths. `createResolver` creates a resolver relative to a base path.
 
 ## `resolvePath`
 
@@ -46,6 +46,10 @@ function resolvePath (path: string, options?: ResolvePathOptions): Promise<strin
 | `extensions`         | `string[]`                          | `false`  | The file extensions to try. Default is Nuxt configured extensions.                                                           |
 | `virtual`            | `boolean`                           | `false`  | Whether to resolve files that exist in the Nuxt VFS (for example, as a Nuxt template).                                       |
 | `fallbackToOriginal` | `boolean`                           | `false`  | Whether to fallback to the original path if the resolved path does not exist instead of returning the normalized input path. |
+
+::note
+`resolvePath` follows standard module resolution and does not search dependencies nested inside other packages. To resolve a dependency declared by your Nuxt module, use `createResolver(import.meta.url).resolvePath()`. This makes resolution independent of whether the package manager hoists the dependency.
+::
 
 ### Example
 


### PR DESCRIPTION
### 🔗 Linked issue

Closes #15721

### 📚 Description

Clarifies that `resolvePath` resolves modules from the Nuxt root directory by default and follows standard module resolution rules.

It does not search dependencies nested inside other packages, which may appear accessible depending on package-manager hoisting. Nuxt module authors should use `createResolver(import.meta.url).resolvePath()` to resolve their own declared dependencies consistently.

I have also updated the introductory description to distinguish root-relative resolution from resolution using a custom base.
