### PR TITLE
docs: add note with alternatives to using remote layers

### DIFF
--- a/docs/3.guide/6.going-further/7.layers.md
+++ b/docs/3.guide/6.going-further/7.layers.md
@@ -146,6 +146,12 @@ export default defineNuxtConfig({
 })
 ```
 
+::note
+We recommend avoiding remote layers in favor of publishing the layer's contents as an npm package (public or private, e.g. via [GitHub Packages](https://docs.github.com/en/packages/learn-github-packages/introduction-to-github-packages)).
+
+Alternatively, you could also add any remote git URL directly as a dependency with your package manager (npm, pnpm, yarn, etc.).
+::
+
 ::tip
 If you want to extend a private remote source, you need to add the environment variable `GIGET_AUTH=<token>` to provide a token.
 ::

--- a/docs/3.guide/6.going-further/7.layers.md
+++ b/docs/3.guide/6.going-further/7.layers.md
@@ -149,7 +149,7 @@ export default defineNuxtConfig({
 ::note
 We recommend avoiding remote layers in favor of publishing the layer's contents as an npm package (public or private, e.g. via [GitHub Packages](https://docs.github.com/en/packages/learn-github-packages/introduction-to-github-packages)).
 
-Alternatively, you could also add any remote git URL directly as a dependency with your package manager (npm, pnpm, yarn, etc.).
+Alternatively, you could also add any [remote git URL directly as a dependency](https://docs.npmjs.com/cli/v12/configuring-npm/package-json#git-urls-as-dependencies).
 ::
 
 ::tip

--- a/docs/3.guide/6.going-further/7.layers.md
+++ b/docs/3.guide/6.going-further/7.layers.md
@@ -147,9 +147,9 @@ export default defineNuxtConfig({
 ```
 
 ::note
-We recommend avoiding remote layers in favor of publishing the layer's contents as an npm package (public or private, e.g. via [GitHub Packages](https://docs.github.com/en/packages/learn-github-packages/introduction-to-github-packages)).
+We recommend publishing your layer's contents as an npm package (public or private, for example via [GitHub Packages](https://docs.github.com/en/packages/learn-github-packages/introduction-to-github-packages)) rather than relying on a remote layer.
 
-Alternatively, you could also add any [remote git URL directly as a dependency](https://docs.npmjs.com/cli/v12/configuring-npm/package-json#git-urls-as-dependencies).
+Alternatively, you can add a [remote git URL directly as a dependency](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#git-urls-as-dependencies).
 ::
 
 ::tip


### PR DESCRIPTION
### 🔗 Linked issue

Closes #33145

### 📚 Description

This PR adds a note to our docs mentioning a couple alternatives to using remote layers. It is the result of trying to add support to allow users to mark them as `required: true` to prevent the silent fail reported in #33145.

Given the lack of repro and issues encountered along the way, adding a note to our docs seemed like good enough for now.

Replaces #35653