### PR TITLE
fix(kit): honor nested local layer order

### DIFF
--- a/docs/1.getting-started/14.layers.md
+++ b/docs/1.getting-started/14.layers.md
@@ -141,6 +141,10 @@ export default defineNuxtConfig({
 
 Both `~~/...` (recommended) and `~/...` alias forms as well as relative paths (`./layers/admin`) are supported. Any layer in `~~/layers` that you do not list keeps its alphabetical auto-scan order, ranked below the layers you list in `extends`.
 
+::note
+When a local layer in `~~/layers` extends another, Nuxt ranks the extending layer above its base, even if your root `extends` lists the base first. Plugin registration follows the same chain.
+::
+
 ### When to Use Each
 
 - **`~~/layers` directory** - Use for local layers that are part of your project

--- a/docs/2.directory-structure/1.app/1.plugins.md
+++ b/docs/2.directory-structure/1.app/1.plugins.md
@@ -86,7 +86,7 @@ Nuxt does statically pre-load any hook listeners when using object-syntax, allow
 
 ## Registration Order
 
-You can control the order in which plugins are registered by prefixing with 'alphabetical' numbering to the file names.
+Within a single `plugins/` directory, you can control registration order by prefixing file names with alphabetical numbering.
 
 ```bash [Directory structure]
 plugins/
@@ -101,6 +101,12 @@ This is useful in situations where you have a plugin that depends on another plu
 ::note
 In case you're new to 'alphabetical' numbering, remember that filenames are sorted as strings, not as numeric values. For example, `10.myPlugin.ts` would come before `2.myOtherPlugin.ts`. This is why the example prefixes single digit numbers with `0`.
 ::
+
+### Layers
+
+When you use [layers](/docs/4.x/getting-started/layers), Nuxt registers plugins in extend-chain order: base layers first, then layers that extend them, then your project plugins. Number prefixes sort files within one `plugins/` directory. They do not sort plugins globally across layers.
+
+Plugins with the same [`enforce`](#object-syntax-plugins) or `order` keep that chain order. Set `enforce` to `pre`, `default`, or `post`, or set an explicit `order`, when a plugin must run in a different band. To define your own sequence, reorder `app.plugins` in the [`app:resolve`](/docs/4.x/api/advanced/hooks#app-hooks-runtime) hook.
 
 ## Loading Strategy
 

--- a/packages/kit/src/loader/config.ts
+++ b/packages/kit/src/loader/config.ts
@@ -47,6 +47,9 @@ export async function loadNuxtConfig (opts: LoadNuxtConfigOptions): Promise<Nuxt
   // priority). Used to reorder the auto-scanned layers so ordering can be driven from
   // `nuxt.config` without renaming directories.
   const extendsLocalLayerOrder: string[] = []
+  // Nested local-layer extends (depender → dependency). Prevents a base layer from
+  // outranking a layer that extends it (#34691).
+  const localLayerExtendEdges: Array<[depender: string, dependency: string]> = []
 
   // populate process.env before the schema imports its env-based defaults
   if (opts.dotenv !== false) {
@@ -93,6 +96,16 @@ export async function loadNuxtConfig (opts: LoadNuxtConfigOptions): Promise<Nuxt
         // (not the auto-scan `_extends` injection) so they can be reordered afterwards
         if (base === rootCwd && !autoScanSources.has(source) && localLayerDirs.has(layerDir)) {
           extendsLocalLayerOrder.push(layerDir)
+        }
+        if (base !== rootCwd) {
+          try {
+            const dependerDir = canonicalLayerDir(base)
+            if (localLayerDirs.has(dependerDir) && localLayerDirs.has(layerDir) && dependerDir !== layerDir) {
+              localLayerExtendEdges.push([dependerDir, layerDir])
+            }
+          } catch {
+            // ignore unreadable base paths
+          }
         }
         if (seenLayerDirs.has(layerDir)) {
           // Empty layer so the repeat contributes nothing to the merge; a nullish
@@ -189,11 +202,10 @@ export async function loadNuxtConfig (opts: LoadNuxtConfigOptions): Promise<Nuxt
     _layers.push(layer)
   }
 
-  // Reorder auto-scanned local layers to follow the order they are listed in `extends`
-  // (first entry = highest priority); unlisted local layers keep their alphabetical order
-  // below the listed ones. Other layers are left untouched.
-  if (extendsLocalLayerOrder.length) {
-    reorderLocalLayersByExtends(_layers, extendsLocalLayerOrder, localLayerDirs)
+  // Reorder auto-scanned local layers to follow root `extends` (first entry = highest
+  // priority). Nested extends then rank each depender above its base (#34691).
+  if (extendsLocalLayerOrder.length || localLayerExtendEdges.length) {
+    reorderLocalLayersByExtends(_layers, extendsLocalLayerOrder, localLayerDirs, localLayerExtendEdges)
   }
 
   ;(nuxtConfig as any)._layers = _layers
@@ -241,14 +253,14 @@ function resolveLayerExtendsAlias (source: string, rootDir: string): string | un
 
 /**
  * Reorder local layers (from the `~~/layers/` directory) in place to match the order they are
- * listed in `extends` (first entry = highest priority). Listed layers come first in that order;
- * unlisted local layers keep their existing alphabetical order after them. Non-local layers keep
- * their positions.
+ * listed in `extends` (first entry = highest priority). Unlisted local layers keep their
+ * alphabetical order after them. Nested extends rank each depender above its base (#34691).
  */
 function reorderLocalLayersByExtends (
   layers: ConfigLayer<NuxtConfig, ConfigLayerMeta>[],
   extendsOrder: string[],
   localLayerDirs: Set<string>,
+  extendEdges: Array<[depender: string, dependency: string]>,
 ) {
   const layerDir = (layer: ConfigLayer<NuxtConfig, ConfigLayerMeta>) => {
     const dir = withoutTrailingSlash(layer.config?.rootDir ?? layer.cwd ?? '')
@@ -279,8 +291,32 @@ function reorderLocalLayersByExtends (
     })
     .map(entry => entry.layer)
 
+  const orderedDirs = orderedLocalLayers.map(layerDir)
+  const layerByDir = new Map(orderedDirs.map((dir, index) => [dir, orderedLocalLayers[index]!]))
+  const dependers = new Map(orderedDirs.map(dir => [dir, new Set<string>()]))
+  for (const [depender, dependency] of extendEdges) {
+    if (dependers.has(depender) && dependers.has(dependency)) {
+      dependers.get(dependency)!.add(depender)
+    }
+  }
+
+  const pending = new Set(orderedDirs)
+  let constrained: ConfigLayer<NuxtConfig, ConfigLayerMeta>[] = []
+  while (pending.size) {
+    const next = orderedDirs.find(dir =>
+      pending.has(dir) && ![...dependers.get(dir)!].some(depender => pending.has(depender)),
+    )
+    // A cycle cannot satisfy every constraint, so preserve the preferred input order.
+    if (!next) {
+      constrained = orderedLocalLayers
+      break
+    }
+    constrained.push(layerByDir.get(next)!)
+    pending.delete(next)
+  }
+
   localSlots.forEach((slot, index) => {
-    layers[slot] = orderedLocalLayers[index]!
+    layers[slot] = constrained[index]!
   })
 }
 

--- a/packages/kit/test/layer-extend-chain-fixture/layers/layer-a/nuxt.config.ts
+++ b/packages/kit/test/layer-extend-chain-fixture/layers/layer-a/nuxt.config.ts
@@ -1,0 +1,1 @@
+export default defineNuxtConfig({})

--- a/packages/kit/test/layer-extend-chain-fixture/layers/layer-b/nuxt.config.ts
+++ b/packages/kit/test/layer-extend-chain-fixture/layers/layer-b/nuxt.config.ts
@@ -1,0 +1,3 @@
+export default defineNuxtConfig({
+  extends: ['../layer-a'],
+})

--- a/packages/kit/test/layer-extend-chain-fixture/nuxt.config.ts
+++ b/packages/kit/test/layer-extend-chain-fixture/nuxt.config.ts
@@ -1,0 +1,3 @@
+export default defineNuxtConfig({
+  extends: ['./layers/layer-a', './layers/layer-b'],
+})

--- a/packages/kit/test/load-nuxt-config.spec.ts
+++ b/packages/kit/test/load-nuxt-config.spec.ts
@@ -131,6 +131,16 @@ describe('loadNuxtConfig', () => {
     }
   })
 
+  it('should rank a nested local extend above its base when root extends lists the base first (#34691)', async () => {
+    const cwd = fileURLToPath(new URL('./layer-extend-chain-fixture', import.meta.url)).replace(/\\/g, '/')
+    const config = await loadNuxtConfig({ cwd })
+    expect(config._layers.map(l => basename(l.cwd!))).toEqual([
+      'layer-extend-chain-fixture',
+      'layer-b',
+      'layer-a',
+    ])
+  })
+
   describe('with .env file', () => {
     let tempDir: string
 

--- a/packages/nuxt/test/app.test.ts
+++ b/packages/nuxt/test/app.test.ts
@@ -169,6 +169,31 @@ describe('resolveApp', () => {
     `)
   })
 
+  it('resolves plugins in nested local layer order (#34691)', async () => {
+    const app = await getResolvedApp([
+      'layers/layer-a/plugins/01.first.ts',
+      'layers/layer-a/nuxt.config.ts',
+      'layers/layer-b/plugins/70.second.ts',
+      {
+        name: 'layers/layer-b/nuxt.config.ts',
+        contents: 'export default defineNuxtConfig({ extends: [\'../layer-a\'] })',
+      },
+      {
+        name: 'nuxt.config.ts',
+        contents: 'export default defineNuxtConfig({ extends: [\'./layers/layer-a\', \'./layers/layer-b\'] })',
+      },
+    ])
+
+    const plugins = app.plugins
+      .filter(p => !('getContents' in p) && p.src.includes('<rootDir>/layers/'))
+      .map(p => p.src)
+
+    expect(plugins).toEqual([
+      '<rootDir>/layers/layer-a/plugins/01.first.ts',
+      '<rootDir>/layers/layer-b/plugins/70.second.ts',
+    ])
+  })
+
   it('resolves layer middleware in correct order', async () => {
     const app = await getResolvedApp([
       // layer 1


### PR DESCRIPTION
Keep nested local layer dependencies ahead of their base layers when the root `extends` order conflicts with the dependency chain.

If the root config listed layer A before layer B while B extended A, `reorderLocalLayersByExtends` ranked A above B. Plugin discovery reverses that list, so a plugin in B could run before its provider in A. The loader now records nested local-layer edges and applies them after the root order, while preserving root priority for unrelated layers and the original order for cycles.

The documentation now explains how layer order and filename prefixes affect plugin registration.

Fixes #34691