### PR TITLE
docs: document server components without default scan

### DIFF
--- a/docs/2.directory-structure/1.app/1.components.md
+++ b/docs/2.directory-structure/1.app/1.components.md
@@ -509,11 +509,60 @@ Now you can register server-only components with the `.server` suffix and use th
     <!--
       this will automatically be rendered on the server, meaning your markdown parsing + highlighting
       libraries are not included in your client bundle.
-     -->
+    -->
     <HighlightedMarkdown markdown="# Headline" />
   </div>
 </template>
 ```
+
+::note
+This feature only works with Nuxt auto-imports and `#components` imports. Explicitly importing these components from their real paths does not convert them into server-only components.
+::
+
+#### Without Default Component Scan
+
+If you disable the default `~/components` scan with `components: []` or `components: { dirs: [] }`, Nuxt does not register `.server` files from that directory. Use a local module with [`addComponent`](/docs/4.x/api/kit/components#addcomponent), or keep one scanned directory.
+
+```ts [modules/register-server-components.ts]
+import { addComponent, createResolver, defineNuxtModule } from '@nuxt/kit'
+
+export default defineNuxtModule({
+  setup () {
+    const { resolve } = createResolver(import.meta.url)
+    addComponent({
+      name: 'ExampleComponent',
+      filePath: resolve('../components/ExampleComponent.server.vue'),
+    })
+  },
+})
+```
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  experimental: {
+    componentIslands: true,
+  },
+  components: [],
+  modules: ['./modules/register-server-components'],
+})
+```
+
+Nuxt infers `mode: 'server'` from the `.server.vue` suffix. You can also set `mode: 'server'` or `island: true` explicitly.
+
+To scan only one directory:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  experimental: {
+    componentIslands: true,
+  },
+  components: [
+    { path: '~/components/server' },
+  ],
+})
+```
+
+Put `.server.vue` files in that directory. Nuxt registers them as server-only components.
 
 Server-only components use [`<NuxtIsland>`](/docs/4.x/api/components/nuxt-island) under the hood, meaning that `lazy` prop and `#fallback` slot are both passed down to it.
 

--- a/docs/3.guide/1.concepts/3.auto-imports.md
+++ b/docs/3.guide/1.concepts/3.auto-imports.md
@@ -169,7 +169,7 @@ Nuxt also automatically imports components from your `~/components` directory, a
 
 :read-more{to="/docs/4.x/directory-structure/app/components"}
 
-To disable auto-importing components from your own `~/components` directory, you can set `components.dirs` to an empty array (though note that this will not affect components added by modules).
+To disable auto-importing components from your own `~/components` directory, set `components.dirs` to an empty array (or use `components: []`). Modules can still register components. For server-only components when the default scan is off, see [Without Default Component Scan](/docs/4.x/directory-structure/app/components#without-default-component-scan).
 
 ```ts twoslash [nuxt.config.ts]
 export default defineNuxtConfig({

--- a/docs/4.api/5.kit/5.components.md
+++ b/docs/4.api/5.kit/5.components.md
@@ -144,3 +144,19 @@ export default defineNuxtModule({
   },
 })
 ```
+
+When the default `~/components` scan is disabled, register a server-only component with a `.server.vue` path (or set `mode: 'server'` or `island: true`):
+
+```ts [modules/example.ts]
+import { addComponent, createResolver, defineNuxtModule } from '@nuxt/kit'
+
+export default defineNuxtModule({
+  setup () {
+    const { resolve } = createResolver(import.meta.url)
+    addComponent({
+      name: 'ExampleComponent',
+      filePath: resolve('./runtime/components/ExampleComponent.server.vue'),
+    })
+  },
+})
+```


### PR DESCRIPTION
Document how to register `.server` components when the default component scan is disabled.

With `components: []` or `components: { dirs: [] }`, Nuxt does not scan `~/components`, so `.server.vue` files are not registered. The docs now show registration via `addComponent` in a local module, or a single scanned directory. Kit docs include a matching `addComponent` example.

No API change.

Fixes #30507