### PR TITLE
docs: clarify SSR header forwarding after Nitro v3

### DIFF
--- a/docs/1.getting-started/10.data-fetching.md
+++ b/docs/1.getting-started/10.data-fetching.md
@@ -136,8 +136,9 @@ async function getCurrentUser () {
 ```
 
 ::caution
-Be careful before proxying headers to an external API. Include only the headers you need. Not all headers are safe to forward and some can cause unwanted behavior. Common headers that you should **not** proxy:
+Be careful before proxying headers to an external API. Include only the headers you need. Treat `cookie` and `authorization` as sensitive: exclude them by default, and forward them only when you intentionally call a specifically trusted API. Not all headers are safe to forward and some can cause unwanted behavior. Common headers that you should **not** proxy:
 
+- `cookie`, `authorization`
 - `host`, `accept`
 - `content-length`, `content-md5`, `content-type`
 - `x-forwarded-host`, `x-forwarded-port`, `x-forwarded-proto`

--- a/docs/1.getting-started/10.data-fetching.md
+++ b/docs/1.getting-started/10.data-fetching.md
@@ -109,22 +109,23 @@ Read more about `$fetch`.
 
 ### Pass Client Headers to the API
 
-When calling `useFetch` on the server, Nuxt will use [`useRequestFetch`](/docs/4.x/api/composables/use-request-fetch) to proxy client headers and cookies (with the exception of headers not meant to be forwarded, like `host`).
+During SSR, neither `$fetch` nor `useFetch` attaches the browser's cookies or other request headers to internal API calls. Pass the headers you need with [`useRequestHeaders`](/docs/4.x/api/composables/use-request-headers).
 
-```vue
+```vue [app/pages/index.vue]
 <script setup lang="ts">
-const { data } = await useFetch('/api/echo')
+const { data } = await useFetch('/api/echo', {
+  headers: useRequestHeaders(['cookie']),
+})
 </script>
 ```
 
-```ts
-// /api/echo.ts
+```ts [server/api/echo.ts]
 export default defineEventHandler(event => parseCookies(event))
 ```
 
-Alternatively, the example below shows how to use [`useRequestHeaders`](/docs/4.x/api/composables/use-request-headers) to access and send cookies to the API from a server-side request (originating on the client). Using an isomorphic `$fetch` call, we ensure that the API endpoint has access to the same `cookie` header originally sent by the user's browser. This is only necessary if you aren't using `useFetch`.
+The same pattern works with `$fetch` inside `useAsyncData`:
 
-```vue
+```vue [app/pages/me.vue]
 <script setup lang="ts">
 const headers = useRequestHeaders(['cookie'])
 
@@ -134,12 +135,8 @@ async function getCurrentUser () {
 </script>
 ```
 
-::tip
-You can also use [`useRequestFetch`](/docs/4.x/api/composables/use-request-fetch) to proxy headers to the call automatically.
-::
-
 ::caution
-Be very careful before proxying headers to an external API and just include headers that you need. Not all headers are safe to be bypassed and might introduce unwanted behavior. Here is a list of common headers that are NOT to be proxied:
+Be careful before proxying headers to an external API. Include only the headers you need. Not all headers are safe to forward and some can cause unwanted behavior. Common headers that you should **not** proxy:
 
 - `host`, `accept`
 - `content-length`, `content-md5`, `content-type`
@@ -174,8 +171,8 @@ This composable is a wrapper around the [`useAsyncData`](/docs/4.x/api/composabl
 The `useAsyncData` composable is responsible for wrapping async logic and returning the result once it is resolved.
 
 ::tip
-`useFetch(url)` is nearly equivalent to `useAsyncData(url, () => event.$fetch(url))`. :br
-It's developer experience sugar for the most common use case. (You can find out more about `event.fetch` at [`useRequestFetch`](/docs/4.x/api/composables/use-request-fetch).)
+`useFetch(url)` is nearly equivalent to `useAsyncData(url, () => $fetch(url))`. :br
+It is developer experience sugar for the most common use case.
 ::
 
 :video-accordion{title="Watch a video from Alexander Lichter to dig deeper into the difference between useFetch and useAsyncData" videoId="0X-aOpSGabA"}
@@ -613,15 +610,13 @@ For finer control, the `status` variable can be:
 
 ## Passing Headers and Cookies
 
-When we call `$fetch` in the browser, user headers like `cookie` will be directly sent to the API.
+When you call `$fetch` or `useFetch` in the browser, the browser sends headers such as `cookie` to the API.
 
-Normally, during server-side-rendering, due to security considerations, the `$fetch` wouldn't include the user's browser cookies, nor pass on cookies from the fetch response.
+During SSR, `$fetch` and `useFetch` do not include the user's browser cookies, and they do not pass cookies from the fetch response back to the client. Forward request headers with [`useRequestHeaders`](/docs/4.x/api/composables/use-request-headers) as shown in [Pass Client Headers to the API](/docs/4.x/getting-started/data-fetching#pass-client-headers-to-the-api).
 
-However, when calling `useFetch` with a relative URL on the server, Nuxt will use [`useRequestFetch`](/docs/4.x/api/composables/use-request-fetch) to proxy headers and cookies (with the exception of headers not meant to be forwarded, like `host`).
+### Pass Cookies From Server-Side API Calls on SSR Response
 
-### Pass Cookies From Server-side API Calls on SSR Response
-
- If you want to pass on/proxy cookies in the other direction, from an internal request back to the client, you will need to handle this yourself.
+If you want to proxy cookies in the other direction, from an internal request back to the client, you need to handle this yourself.
 
 ```ts [app/composables/fetch.ts]
 import type { H3Event } from 'h3'
@@ -640,9 +635,9 @@ export const fetchWithCookie = async (event: H3Event, url: string) => {
 }
 ```
 
-```vue
+```vue [app/pages/index.vue]
 <script setup lang="ts">
-// This composable will automatically pass cookies to the client
+// This composable will pass Set-Cookie headers from the API back to the client
 const event = useRequestEvent()
 
 const { data: result } = await useAsyncData(() => fetchWithCookie(event!, '/api/with-cookie'))

--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -251,6 +251,22 @@ See the full Nitro v3 migration guide for all breaking changes.
 
 The sections below highlight changes that are most relevant to Nuxt application developers and module authors.
 
+#### SSR Cookie and Header Forwarding
+
+`useRequestFetch` and relative `useFetch` calls no longer forward browser cookies or other request headers during SSR. Pass the headers you need with [`useRequestHeaders`](/docs/4.x/api/composables/use-request-headers):
+
+```vue [app/pages/index.vue]
+<script setup lang="ts">
+const { data } = await useFetch('/api/me', {
+  headers: useRequestHeaders(['cookie']),
+})
+</script>
+```
+
+::read-more{to="/docs/4.x/getting-started/data-fetching#pass-client-headers-to-the-api"}
+See Pass Client Headers to the API for details.
+::
+
 #### Package and Import Path Changes
 
 The `nitropack` package has been renamed to `nitro`. All import paths have changed:

--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -253,7 +253,7 @@ The sections below highlight changes that are most relevant to Nuxt application 
 
 #### SSR Cookie and Header Forwarding
 
-`useRequestFetch` and relative `useFetch` calls no longer forward browser cookies or other request headers during SSR. Pass the headers you need with [`useRequestHeaders`](/docs/4.x/api/composables/use-request-headers):
+During SSR, `useFetch` does not automatically forward browser cookies or other request headers for relative or absolute URLs. `useRequestFetch` is an alias of `$fetch` and does not add that forwarding either. Pass the headers you need with [`useRequestHeaders`](/docs/4.x/api/composables/use-request-headers):
 
 ```vue [app/pages/index.vue]
 <script setup lang="ts">

--- a/docs/4.api/2.composables/use-request-fetch.md
+++ b/docs/4.api/2.composables/use-request-fetch.md
@@ -1,6 +1,6 @@
 ---
 title: 'useRequestFetch'
-description: 'Forward the request context and headers for server-side fetch requests with the useRequestFetch composable.'
+description: 'Access the same $fetch instance used during server-side rendering with useRequestFetch.'
 minimalVersion: "3.2"
 links:
   - label: Source
@@ -9,45 +9,22 @@ links:
     size: xs
 ---
 
-You can use `useRequestFetch` to forward the request context and headers when making server-side fetch requests.
+`useRequestFetch` returns the same [`$fetch`](/docs/4.x/api/utils/dollarfetch) instance Nuxt uses during SSR. It does **not** forward browser cookies or other request headers for you.
 
-When making a client-side fetch request, the browser automatically sends the necessary headers.
-However, when making a request during server-side rendering, due to security considerations, we need to forward the headers manually.
-
-::note
-Headers that are **not meant to be forwarded** will **not be included** in the request. These headers include, for example:
-`transfer-encoding`, `connection`, `keep-alive`, `upgrade`, `expect`, `host`, `accept`
-::
-
-::tip
-The [`useFetch`](/docs/4.x/api/composables/use-fetch) composable uses `useRequestFetch` under the hood to automatically forward the request context and headers.
-::
-
-::code-group
+During SSR, forward the headers you need with [`useRequestHeaders`](/docs/4.x/api/composables/use-request-headers):
 
 ```vue [app/pages/index.vue]
 <script setup lang="ts">
-// This will forward the user's headers to the `/api/cookies` event handler
-// Result: { cookies: { foo: 'bar' } }
-const requestFetch = useRequestFetch()
-const { data: forwarded } = await useAsyncData(() => requestFetch('/api/cookies'))
-
-// This will NOT forward anything
-// Result: { cookies: {} }
-const { data: notForwarded } = await useAsyncData((_nuxtApp, { signal }) => $fetch('/api/cookies', { signal }))
+const { data } = await useAsyncData(() => $fetch('/api/cookies', {
+  headers: useRequestHeaders(['cookie']),
+}))
 </script>
 ```
 
-```ts [server/api/cookies.ts]
-export default defineEventHandler((event) => {
-  const cookies = parseCookies(event)
-
-  return { cookies }
-})
-```
-
+::read-more{to="/docs/4.x/getting-started/data-fetching#pass-client-headers-to-the-api"}
+See Pass Client Headers to the API for more detail.
 ::
 
 ::tip
-In the browser during client-side navigation, `useRequestFetch` will behave just like regular [`$fetch`](/docs/4.x/api/utils/dollarfetch).
+In the browser during client-side navigation, `useRequestFetch` behaves like regular [`$fetch`](/docs/4.x/api/utils/dollarfetch).
 ::

--- a/docs/4.api/2.composables/use-request-headers.md
+++ b/docs/4.api/2.composables/use-request-headers.md
@@ -24,9 +24,9 @@ In the browser, `useRequestHeaders` will return an empty object.
 
 ## Example
 
-We can use `useRequestHeaders` to access and proxy the initial request's `authorization` header to any future internal requests during SSR.
+During SSR, `$fetch` and `useFetch` do not attach browser cookies or other request headers to internal API calls. Use `useRequestHeaders` to pass the headers you need.
 
-The example below adds the `authorization` request header to an isomorphic `$fetch` call.
+The example below forwards the `authorization` header with `useFetch`. Use the same pattern for `cookie` when your API route reads session cookies.
 
 ```vue [app/pages/some-page.vue]
 <script setup lang="ts">
@@ -35,3 +35,7 @@ const { data } = await useFetch('/api/confidential', {
 })
 </script>
 ```
+
+::read-more{to="/docs/4.x/getting-started/data-fetching#pass-client-headers-to-the-api"}
+See Pass Client Headers to the API for cookie examples and guidance on external APIs.
+::

--- a/docs/4.api/3.utils/$fetch.md
+++ b/docs/4.api/3.utils/$fetch.md
@@ -66,9 +66,9 @@ If you use `$fetch` to call an (external) HTTPS URL with a self-signed certifica
 
 ### Passing Headers and Cookies
 
-When we call `$fetch` in the browser, user headers like `cookie` will be directly sent to the API.
+When you call `$fetch` in the browser, the browser sends headers such as `cookie` to the API.
 
-However, during Server-Side Rendering, due to security risks such as **Server-Side Request Forgery (SSRF)** or **Authentication Misuse**, the `$fetch` wouldn't include the user's browser cookies, nor pass on cookies from the fetch response.
+During SSR, `$fetch` does not include the user's browser cookies, and it does not pass cookies from the fetch response back to the client. This limits risks such as **Server-Side Request Forgery (SSRF)** and authentication misuse.
 
 ::code-group
 
@@ -87,14 +87,15 @@ export default defineEventHandler((event) => {
 ```
 ::
 
-If you need to forward headers and cookies on the server, you must manually pass them:
+Forward the headers you need with [`useRequestHeaders`](/docs/4.x/api/composables/use-request-headers):
 
 ```vue [app/pages/index.vue]
 <script setup lang="ts">
-// This will forward the user's headers and cookies to `/api/cookies`
-const requestFetch = useRequestFetch()
-const { data } = await useAsyncData(() => requestFetch('/api/cookies'))
+// This forwards the cookie header to `/api/cookies` during SSR
+const { data } = await useAsyncData(() => $fetch('/api/cookies', {
+  headers: useRequestHeaders(['cookie']),
+}))
 </script>
 ```
 
-However, when calling `useFetch` with a relative URL on the server, Nuxt will use [`useRequestFetch`](/docs/4.x/api/composables/use-request-fetch) to proxy headers and cookies (with the exception of headers not meant to be forwarded, like `host`).
+The same approach works with [`useFetch`](/docs/4.x/api/composables/use-fetch). See [Pass Client Headers to the API](/docs/4.x/getting-started/data-fetching#pass-client-headers-to-the-api).

--- a/docs/4.api/3.utils/$fetch.md
+++ b/docs/4.api/3.utils/$fetch.md
@@ -68,7 +68,7 @@ If you use `$fetch` to call an (external) HTTPS URL with a self-signed certifica
 
 When you call `$fetch` in the browser, the browser sends headers such as `cookie` to the API.
 
-During SSR, `$fetch` does not include the user's browser cookies, and it does not pass cookies from the fetch response back to the client. This limits risks such as **Server-Side Request Forgery (SSRF)** and authentication misuse.
+During SSR, `$fetch` does not include the user's browser cookies, and it does not pass cookies from the fetch response back to the client. That limits credential leakage and authentication misuse. To reduce **Server-Side Request Forgery (SSRF)** risk, validate or allow-list request destinations instead of treating missing cookies as an SSRF control.
 
 ::code-group
 


### PR DESCRIPTION
During SSR, `$fetch` and `useFetch` do not forward browser cookies or other request headers. Pass only what your route needs with `useRequestHeaders`.

After Nitro v3 (#33005), `useRequestFetch` is an alias of `$fetch`. The previous docs described automatic proxying for relative `useFetch` and `useRequestFetch`, which no longer matches runtime behavior.

Pages touched: Getting Started data-fetching and upgrade; API `$fetch`, `useRequestFetch`, and `useRequestHeaders`.

Refs #18927
Refs #24813