### PR TITLE
docs: document Nuxt nitro.prerender defaults

### DIFF
--- a/docs/4.api/6.nuxt-config.md
+++ b/docs/4.api/6.nuxt-config.md
@@ -956,6 +956,28 @@ Configuration for Nitro.
 
 **See**: [Nitro configuration docs](https://nitro.build/config)
 
+Nuxt merges your `nitro` options with its own defaults. Most keys match Nitro. The `prerender` keys below differ from [Nitro's defaults](https://nitro.build/config#prerender).
+
+### `prerender`
+
+Options for static prerendering. See the [prerendering guide](/docs/4.x/getting-started/prerendering) and [Nitro prerender docs](https://nitro.build/config#prerender).
+
+Nuxt sets these defaults (values in your `nuxt.config` still take precedence):
+
+| Option | Nuxt default | Nitro default |
+| --- | --- | --- |
+| `failOnError` | `true` | `false` |
+| `concurrency` | four times `os.cpus().length`, or `4` if that value is `0` | `1` |
+| `routes` | Values from legacy `generate.routes` (usually `[]`) | `[]` |
+
+Nuxt also sets `ignoreUnprefixedPublicAssets` to `true`.
+
+With `failOnError: true`, a failed prerendered route fails the build. Set `nitro.prerender.failOnError` to `false` if you want Nitro's default behavior.
+
+Prefer `nitro.prerender.routes` over the legacy `generate.routes` option. Nuxt still copies `generate.routes` into `nitro.prerender.routes` for compatibility.
+
+Other `prerender` options (`autoSubfolderIndex`, `crawlLinks`, `interval`, `retry`, and so on) keep Nitro's defaults unless you override them.
+
 ### `routeRules`
 
 - **Type**: `object`

--- a/docs/4.api/6.nuxt-config.md
+++ b/docs/4.api/6.nuxt-config.md
@@ -974,7 +974,7 @@ Nuxt also sets `ignoreUnprefixedPublicAssets` to `true`.
 
 With `failOnError: true`, a failed prerendered route fails the build. Set `nitro.prerender.failOnError` to `false` if you want Nitro's default behavior.
 
-Prefer `nitro.prerender.routes` over the legacy `generate.routes` option. Nuxt still copies `generate.routes` into `nitro.prerender.routes` for compatibility.
+Prefer `nitro.prerender.routes` for new configuration. The legacy `generate.routes` option remains supported: Nuxt seeds `nitro.prerender.routes` from it and merges those entries into the final prerender route list alongside routes from page discovery, `crawlLinks`, and other prerender sources.
 
 Other `prerender` options (`autoSubfolderIndex`, `crawlLinks`, `interval`, `retry`, and so on) keep Nitro's defaults unless you override them.
 


### PR DESCRIPTION
Nuxt overrides several Nitro `prerender` defaults (`failOnError`, `concurrency`, and legacy `generate.routes`). The nuxt-config page only linked to Nitro docs, so those overrides were invisible when debugging static generation.

This adds a `prerender` subsection under `nitro` with the Nuxt defaults from `@nuxt/nitro-server`, and notes which options still follow Nitro.

Fixes #30067