### PR TITLE
docs(nuxt): document CMS dynamic page routing patterns

### DIFF
--- a/docs/2.directory-structure/1.app/1.pages.md
+++ b/docs/2.directory-structure/1.app/1.pages.md
@@ -156,6 +156,8 @@ Navigating to `/hello/world` would render:
 <p>["hello", "world"]</p>
 ```
 
+For CMS-driven slugs where an API picks the page component, see [Dynamic Pages From a CMS](/docs/4.x/guide/recipes/custom-routing#dynamic-pages-from-a-cms).
+
 ## Nested Routes
 
 It is possible to display [nested routes](https://router.vuejs.org/guide/essentials/nested-routes) with `<NuxtPage>`.

--- a/docs/3.guide/5.recipes/1.custom-routing.md
+++ b/docs/3.guide/5.recipes/1.custom-routing.md
@@ -13,7 +13,9 @@ Using [router options](/docs/4.x/guide/recipes/custom-routing#router-options), y
 
 If it returns `null` or `undefined`, Nuxt will fall back to the default routes (useful to modify input array).
 
-```ts [router.options.ts]
+The `routes` function may be asynchronous and return a `Promise`. Use that when you need runtime data (for example an API response) before you finalize the route table.
+
+```ts [app/router.options.ts]
 import type { RouterConfig } from '@nuxt/schema'
 
 export default {
@@ -25,6 +27,24 @@ export default {
       component: () => import('~/pages/home.vue'),
     },
   ],
+} satisfies RouterConfig
+```
+
+```ts [app/router.options.ts]
+import type { RouterConfig } from '@nuxt/schema'
+
+export default {
+  routes: async (_routes) => {
+    const paths = await $fetch<string[]>('/api/cms-extra-paths')
+    return [
+      ..._routes,
+      ...paths.map(path => ({
+        name: `cms-${path}`,
+        path,
+        component: () => import('~/pages/cms-page.vue'),
+      })),
+    ]
+  },
 } satisfies RouterConfig
 ```
 
@@ -78,6 +98,87 @@ If you plan to add a whole set of pages related with a specific functionality, y
 The [Nuxt kit](/docs/4.x/guide/going-further/kit) provides a few ways [to add routes](/docs/4.x/api/kit/pages):
 - [`extendPages`](/docs/4.x/api/kit/pages#extendpages) (callback: pages => void)
 - [`extendRouteRules`](/docs/4.x/api/kit/pages#extendrouterules) (route: string, rule: NitroRouteConfig, options: ExtendRouteRulesOptions)
+
+## Dynamic Pages From a CMS
+
+When a CMS owns the slug and the Vue page type is unknown until you call an API, file-based routes alone are not enough. You still want Nuxt page features (SSR, layouts, middleware, meta) without baking every CMS URL into the build.
+
+Build-time route lists do not fit this case: editors can create or rename pages without a redeploy. Resolve the page type at request (or navigation) time instead.
+
+### Catch-all Page (Recommended)
+
+Keep a single [catch-all route](/docs/4.x/directory-structure/app/pages#catch-all-route) as the entrypoint. Fetch which page component to use, then render it with a dynamic component. Put the real page Vue files outside `app/pages` (or filter them out of the router; see below) so they are not reachable as their own file routes.
+
+`app/pages/[...slug].vue` matches nested paths; it does not match `/`. If the CMS also owns the homepage, add `app/pages/index.vue` with the same resolution logic, or use a named catch-all only under a prefix.
+
+```vue [app/pages/[...slug\\].vue]
+<script setup lang="ts">
+const route = useRoute()
+
+const pageComponents = {
+  'page-home': defineAsyncComponent(() => import('~/components/pages/home.vue')),
+  'page-article': defineAsyncComponent(() => import('~/components/pages/article.vue')),
+}
+
+const { data } = await useAsyncData(
+  `cms-page:${route.path}`,
+  () => $fetch<{ type: keyof typeof pageComponents }>('/api/cms/page-type', {
+    query: { path: route.path },
+  }),
+  { watch: [() => route.path] },
+)
+
+const pageComponent = computed(() => {
+  const type = data.value?.type
+  return type && type in pageComponents ? pageComponents[type] : null
+})
+
+if (!pageComponent.value) {
+  throw createError({ statusCode: 404, statusMessage: 'Page not found' })
+}
+</script>
+
+<template>
+  <component
+    :is="pageComponent"
+    :key="route.path"
+  />
+</template>
+```
+
+Each page component can fetch its own data with `useAsyncData` or `useFetch`. The catch-all is a coarse entrypoint; that is intentional when the CMS defines the URL space.
+
+### Filter or Override Scanned Routes
+
+If you keep templates under `app/pages` for colocation but must not expose them as direct routes, filter or replace the scanned list in `app/router.options.ts`:
+
+```ts [app/router.options.ts]
+import type { RouterConfig } from '@nuxt/schema'
+
+export default {
+  routes: (_routes) => {
+    return _routes.filter(route => route.name !== 'product-template')
+  },
+} satisfies RouterConfig
+```
+
+For runtime conditions (feature flags, A/B templates, a small set of known CMS paths), return routes from an `async` `routes` function as shown under [Router Config](/docs/4.x/guide/recipes/custom-routing#router-config).
+
+### Adding Routes in a Plugin
+
+You can call [`router.addRoute`](/docs/4.x/api/composables/use-router) from a plugin after an API lookup, then navigate to the new route. This works when you want to cache path → page type across client navigations.
+
+Trade-offs:
+
+- Until you call `addRoute`, Vue Router may not resolve `<NuxtLink>` targets for those paths (warnings or failed navigation). A catch-all that throws `createError` with status `404` is a common stand-in for unknown URLs.
+- A fetch inside `router.beforeEach` runs during navigation, after Nuxt plugins have already initialized. It does not overlap with plugin setup on the first request.
+- If the same path can map to different components (for example by auth or role), invalidating or replacing a cached `addRoute` entry is awkward. Prefer the catch-all pattern when the backend must decide the component on every visit.
+
+### SEO and Sitemaps
+
+The page-type request can run during SSR, so the first HTML response matches a normal Nuxt page. Crawlers that read the initial HTML are not blocked by this pattern.
+
+Automatic sitemaps are different: Nuxt and SEO modules do not know CMS URLs unless you supply them. Generate the URL list from your CMS or backend and feed it to your sitemap setup.
 
 ## Router Options
 

--- a/docs/3.guide/5.recipes/1.custom-routing.md
+++ b/docs/3.guide/5.recipes/1.custom-routing.md
@@ -35,15 +35,20 @@ import type { RouterConfig } from '@nuxt/schema'
 
 export default {
   routes: async (_routes) => {
-    const paths = await $fetch<string[]>('/api/cms-extra-paths')
-    return [
-      ..._routes,
-      ...paths.map(path => ({
-        name: `cms-${path}`,
-        path,
-        component: () => import('~/pages/cms-page.vue'),
-      })),
-    ]
+    try {
+      const paths = await $fetch<string[]>('/api/cms-extra-paths')
+      return [
+        ..._routes,
+        ...paths.map(path => ({
+          name: `cms-${path}`,
+          path,
+          component: () => import('~/pages/cms-page.vue'),
+        })),
+      ]
+    } catch {
+      // Keep scanned routes if the CMS endpoint is unavailable
+      return _routes
+    }
   },
 } satisfies RouterConfig
 ```
@@ -109,6 +114,8 @@ Build-time route lists do not fit this case: editors can create or rename pages 
 
 Keep a single [catch-all route](/docs/4.x/directory-structure/app/pages#catch-all-route) as the entrypoint. Fetch which page component to use, then render it with a dynamic component. Put the real page Vue files outside `app/pages` (or filter them out of the router; see below) so they are not reachable as their own file routes.
 
+Page-level features (layouts, middleware, and `definePageMeta`) belong to the catch-all route. Components loaded from `components/pages` do not receive them automatically. Project CMS metadata and behavior through the catch-all with [`useHead`](/docs/4.x/api/composables/use-head), [`setPageLayout`](/docs/4.x/api/utils/set-page-layout), and any required middleware.
+
 `app/pages/[...slug].vue` matches nested paths; it does not match `/`. If the CMS also owns the homepage, add `app/pages/index.vue` with the same resolution logic, or use a named catch-all only under a prefix.
 
 ```vue [app/pages/[...slug\\].vue]
@@ -118,11 +125,13 @@ const route = useRoute()
 const pageComponents = {
   'page-home': defineAsyncComponent(() => import('~/components/pages/home.vue')),
   'page-article': defineAsyncComponent(() => import('~/components/pages/article.vue')),
-}
+} as const
 
-const { data } = await useAsyncData(
+type PageType = keyof typeof pageComponents
+
+const { data, error, status } = await useAsyncData(
   `cms-page:${route.path}`,
-  () => $fetch<{ type: keyof typeof pageComponents }>('/api/cms/page-type', {
+  () => $fetch<{ type: string }>('/api/cms/page-type', {
     query: { path: route.path },
   }),
   { watch: [() => route.path] },
@@ -130,12 +139,34 @@ const { data } = await useAsyncData(
 
 const pageComponent = computed(() => {
   const type = data.value?.type
-  return type && type in pageComponents ? pageComponents[type] : null
+  return type && Object.hasOwn(pageComponents, type)
+    ? pageComponents[type as PageType]
+    : null
 })
 
-if (!pageComponent.value) {
-  throw createError({ statusCode: 404, statusMessage: 'Page not found' })
+function assertResolvedPage () {
+  if (status.value === 'pending') {
+    return
+  }
+
+  if (error.value) {
+    throw createError(error.value)
+  }
+
+  if (status.value === 'success' && !pageComponent.value) {
+    throw createError({ statusCode: 404, statusMessage: 'Page not found' })
+  }
 }
+
+assertResolvedPage()
+
+watch([status, data, error], () => {
+  try {
+    assertResolvedPage()
+  } catch (err) {
+    showError(err)
+  }
+})
 </script>
 
 <template>

--- a/docs/3.guide/5.recipes/1.custom-routing.md
+++ b/docs/3.guide/5.recipes/1.custom-routing.md
@@ -129,12 +129,13 @@ const pageComponents = {
 
 type PageType = keyof typeof pageComponents
 
+const cmsPageKey = computed(() => `cms-page:${route.path}`)
+
 const { data, error, status } = await useAsyncData(
-  `cms-page:${route.path}`,
+  cmsPageKey,
   () => $fetch<{ type: string }>('/api/cms/page-type', {
     query: { path: route.path },
   }),
-  { watch: [() => route.path] },
 )
 
 const pageComponent = computed(() => {


### PR DESCRIPTION
## Summary

Documents how to resolve CMS-owned slugs to Vue page components without baking every URL into the build.

- Document that `routes` in `app/router.options` may be async (already supported in types/runtime).
- Add **Dynamic Pages From a CMS**: recommended catch-all + `useAsyncData` + `defineAsyncComponent`, route filtering, plugin `addRoute` trade-offs, SEO vs sitemap notes from the issue thread.
- Link from the pages catch-all section.

Fixes #27643