### PR TITLE
ci: warm windows dependency cache on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,25 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
+  # Warm the Windows dependency cache on main
+  # Without this job every Windows job cold-installs all deps
+  warm-windows-cache:
+    needs: changes
+    if: needs.changes.outputs.src == 'true' && github.event_name == 'push' && github.ref_name == 'main'
+    runs-on: windows-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1.15.0
+        with:
+          node-version: 22
+          cache: true
+
   codeql:
     if: github.event_name != 'merge_group' && !(github.event_name == 'push' && (contains(github.event.head_commit.message, 'v3.') || contains(github.event.head_commit.message, 'v4.') || contains(github.event.head_commit.message, 'v5.')))
     runs-on: ubuntu-latest


### PR DESCRIPTION
### 🔗 Linked issue

None!

### 📚 Description

Windows jobs only run in the merge queue and for PRs, where `setup-vp`'s dependency cache is scoped to throwaway branches.

As a result every Windows job cold-installed the full dependency tree (~1m of the `setup-vp` step).

This PR adds `setup-vp` on windows-latest on push to main so the cache is properly populated, saving valuable time in the PRs.