### PR TITLE
fix(nuxt): amend cleanup command in NUXT_B7014 error message

### DIFF
--- a/packages/kit/src/diagnostics/bundler.ts
+++ b/packages/kit/src/diagnostics/bundler.ts
@@ -73,7 +73,7 @@ export const bundlerDiagnostics = /* #__PURE__ */ defineDiagnostics({
     },
     NUXT_B7014: {
       why: (p: { name: string }) => `The webpack \`${p.name}\` build failed with errors.`,
-      fix: 'Fix the build errors listed above. If the errors are unclear, try running `nuxi clean` and rebuilding.',
+      fix: 'Fix the build errors listed above. If the errors are unclear, try running `nuxi cleanup` and rebuilding.',
       docs: false,
     },
     NUXT_B7015: {


### PR DESCRIPTION


### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

The command is [cleanup](https://github.com/nuxt/cli/blob/169edb5690d3bcc5efd49b0b37fb7f5bd3e9616c/packages/nuxi/src/commands/cleanup.ts#L11), not clean

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
