### PR TITLE
fix(nuxt): only pull in `vue-router` when there are island pages

### DIFF
--- a/packages/nuxt/src/app/components/island-renderer.ts
+++ b/packages/nuxt/src/app/components/island-renderer.ts
@@ -1,12 +1,11 @@
 import type { DefineSetupFnComponent, defineAsyncComponent } from 'vue'
-import { computed, createVNode, defineComponent, onErrorCaptured, provide } from 'vue'
-import { viewDepthKey } from 'vue-router'
+import { createVNode, defineComponent, onErrorCaptured } from 'vue'
 
 import { createError } from '../composables/error'
 import { useRoute } from '../composables/router'
 import { renderDiagnostics } from '../diagnostics/render'
 
-import { islandComponents, pageIslandRoutes } from '#build/components.islands.mjs'
+import { islandComponents, pageIslandRoutes, providePageIslandDepth } from '#build/components.islands.mjs'
 
 interface IslandRendererProps {
   context: { name: string, props?: Record<string, any> }
@@ -38,12 +37,7 @@ const IslandRenderer = defineComponent({
     // A `.server.vue` page rendered as an island mounts the SFC directly here,
     // bypassing the `<RouterView>` chain that would normally set view depth.
     if (props.context.name.startsWith(PAGE_ISLAND_PREFIX)) {
-      const expectedIslandKey = pageIslandRoutes[props.context.name]
-      const route = useRoute()
-      provide(viewDepthKey, computed(() => {
-        const depth = route.matched.findIndex(m => (m.components?.default as any)?.__nuxt_island === expectedIslandKey)
-        return depth === -1 ? 0 : depth + 1
-      }))
+      providePageIslandDepth(useRoute(), pageIslandRoutes[props.context.name])
     }
 
     onErrorCaptured((e) => {

--- a/packages/nuxt/src/components/templates.ts
+++ b/packages/nuxt/src/components/templates.ts
@@ -86,7 +86,7 @@ export const componentsIslandsTemplate: NuxtTemplate = {
   filename: 'components.islands.mjs',
   getContents ({ app, nuxt }) {
     if (!nuxt.options.experimental.componentIslands) {
-      return 'export const islandComponents = Object.create(null)\nexport const pageIslandRoutes = Object.create(null)'
+      return 'export const islandComponents = Object.create(null)\nexport const pageIslandRoutes = Object.create(null)\nexport const providePageIslandDepth = () => {}'
     }
 
     const components = app.components
@@ -120,6 +120,20 @@ export const componentsIslandsTemplate: NuxtTemplate = {
       'export const pageIslandRoutes = import.meta.client ? Object.create(null) : Object.assign(Object.create(null), {',
       pageIslandRoutes.join(',\n'),
       '})',
+      // Only pull `vue-router` (and its devtools chain) into the server bundle
+      // when the app actually has server page islands to render.
+      serverPages.length
+        ? [
+            'import { computed, provide } from \'vue\'',
+            'import { viewDepthKey } from \'vue-router\'',
+            'export const providePageIslandDepth = import.meta.client ? () => {} : (route, expectedIslandKey) => {',
+            '  provide(viewDepthKey, computed(() => {',
+            '    const depth = route.matched.findIndex(m => m.components?.default?.__nuxt_island === expectedIslandKey)',
+            '    return depth === -1 ? 0 : depth + 1',
+            '  }))',
+            '}',
+          ].join('\n')
+        : 'export const providePageIslandDepth = () => {}',
     ].join('\n')
   },
 }

--- a/packages/nuxt/test/components-islands-template.test.ts
+++ b/packages/nuxt/test/components-islands-template.test.ts
@@ -49,4 +49,30 @@ describe('componentsIslandsTemplate', () => {
     expect(contents).toContain('"1thing": defineAsyncComponent(')
     expect(() => Parser.parse(contents, { ecmaVersion: 'latest', sourceType: 'module' })).not.toThrow()
   })
+
+  it('does not import vue-router when there are no server page islands', async () => {
+    const app = {
+      components: [makeComponent({})],
+      pages: [],
+    } as unknown as NuxtApp
+
+    const contents = await componentsIslandsTemplate.getContents!({ app, nuxt: makeNuxt(), options: {} })
+
+    expect(contents).not.toContain('vue-router')
+    expect(contents).toContain('export const providePageIslandDepth')
+    expect(() => Parser.parse(contents, { ecmaVersion: 'latest', sourceType: 'module' })).not.toThrow()
+  })
+
+  it('imports vue-router only when server page islands exist', async () => {
+    const app = {
+      components: [makeComponent({})],
+      pages: [{ name: 'home', mode: 'server', file: '/root/pages/index.server.vue', path: '/' }],
+    } as unknown as NuxtApp
+
+    const contents = await componentsIslandsTemplate.getContents!({ app, nuxt: makeNuxt(), options: {} })
+
+    expect(contents).toContain('import { viewDepthKey } from \'vue-router\'')
+    expect(contents).toContain('export const providePageIslandDepth')
+    expect(() => Parser.parse(contents, { ecmaVersion: 'latest', sourceType: 'module' })).not.toThrow()
+  })
 })


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

spotted the regression in https://github.com/danielroe/roe.dev/pull/1917