### PR TITLE
fix(nitro): read rspack dev output fs lazily for server entry

### DIFF
--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -1040,8 +1040,8 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
     for (const builder of ['webpack', 'rspack'] as const) {
       nuxt.hook(`${builder}:compile`, ({ name, compiler }) => {
         if (name === 'server') {
-          const memfs = compiler.outputFileSystem as typeof import('node:fs')
           nitro.options.virtual['nuxt/entry'] = () => {
+            const memfs = compiler.outputFileSystem as typeof import('node:fs')
             mkdirSync(join(nuxt.options.buildDir, 'dist/server'), { recursive: true })
             writeFileSync(diskServerEntry, memfs.readFileSync(join(nuxt.options.buildDir, 'dist/server/server.mjs'), 'utf-8'))
             return `export { default } from ${JSON.stringify(pathToFileURL(diskServerEntry).href + '?v=' + Date.now())}`


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

fixes a reported regression with rspack builder (thank you @elecmonkey!)

https://github.com/elecmonkey/nuxt-rsbuild-dev-issue-minimal-reproduction