### PR TITLE
ci: run knip in default and production modes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,9 @@ jobs:
           - name: Knip
             run: vp run lint:knip
 
+          - name: Knip (production)
+            run: vp run lint:knip:production
+
           - name: Test (nuxt runtime)
             run: vp run test:runtime
 

--- a/knip.json
+++ b/knip.json
@@ -4,10 +4,7 @@
   "rules": {
     "duplicates": "off"
   },
-  "ignoreExportsUsedInFile": {
-    "interface": true,
-    "type": true
-  },
+  "ignoreExportsUsedInFile": true,
   "ignoreDependencies": [
     "bing",
     "uno.css",
@@ -34,15 +31,15 @@
     ".": {
       "entry": [
         "scripts/*",
-        "test/e2e/global.setup.ts",
-        "test/e2e/global.teardown.ts",
+        "test/*.ts",
+        "test/e2e/*.ts",
         "test/runtime/app/**/*.ts",
         "test/mocks/app-config.ts"
       ]
     },
     "test/fixtures/*": {
       "entry": [
-        "**/*.{js,ts,mjs,vue}"
+        "**/*.{js,ts,mjs,vue}!"
       ],
       "paths": {
         "~~/*": ["./*"],
@@ -51,7 +48,7 @@
     },
     "packages/nitro-server": {
       "entry": [
-        "src/runtime/**/*.{js,ts,mjs}"
+        "src/runtime/**/*.{js,ts,mjs}!"
       ],
       "ignoreDependencies": [
         "mocked-exports",
@@ -82,15 +79,17 @@
     },
     "packages/nuxt": {
       "entry": [
-        "src/app/**/*.{ts,vue}",
-        "src/*/runtime/**/*.{ts,js,vue}",
-        "src/core/templates.ts",
+        "src/app/**/*.{ts,vue}!",
+        "src/*/runtime/**/*.{ts,js,vue}!",
+        "src/core/templates.ts!",
         "meta.d.ts",
+        "test/**/*.ts",
         "test/**/*-fixture/**/*.{js,ts,mjs,vue}"
       ],
       "ignoreDependencies": [
         "@dxup/nuxt",
         "@nuxt/devtools",
+        "@nuxt/telemetry!",
         "@nuxt/vite-builder"
       ]
     },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lint:docs": "markdownlint --ignore-path=.gitignore ./docs && case-police 'docs/**/*.md' *.md && eslint docs --cache",
     "lint:docs:fix": "markdownlint --ignore-path=.gitignore ./docs --fix && case-police 'docs/**/*.md' *.md --fix && eslint docs --cache --fix",
     "lint:knip": "knip",
+    "lint:knip:production": "knip --production",
     "play": "nuxt dev playground",
     "play:build": "nuxt build playground",
     "play:generate": "nuxt generate playground",


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

following on https://github.com/nuxt/nuxt/pull/35742, this configures knip to run with `knip --production` as well