### PR TITLE
docs: add Nuxt Schema concepts page

### DIFF
--- a/docs/3.guide/1.concepts/2.nuxt-lifecycle.md
+++ b/docs/3.guide/1.concepts/2.nuxt-lifecycle.md
@@ -5,6 +5,8 @@ description: "Understanding the lifecycle of Nuxt applications can help you gain
 
 The goal of this chapter is to provide a high-level overview of the different parts of the framework, their execution order, and how they work together.
 
+For a map of Nuxt contexts (modules, Nitro, the Vue app, the browser, and `shared/`) before you dig into request order, see the [Nuxt Schema](/docs/4.x/guide/concepts/nuxt-schema).
+
 ## Server Lifecycle
 
 On the server, the following steps are executed for every initial request to your application:

--- a/docs/3.guide/1.concepts/6.nuxt-schema.md
+++ b/docs/3.guide/1.concepts/6.nuxt-schema.md
@@ -1,0 +1,69 @@
+---
+title: 'Nuxt Schema'
+description: 'A high-level map of Nuxt contexts (modules, Nitro, the Vue app, the browser, and shared code) and how configuration ties them together.'
+---
+
+Nuxt apps run across several contexts at once: build-time modules, the Nitro server, the Vue application (including SSR), the browser, and optional shared utilities. Each context has its own entry points and limits on what you can import. Module, server, app, and shared code also map to separate TypeScript projects under `.nuxt/`.
+
+This page is a mental model for those boundaries. For the step-by-step order of plugins, middleware, and rendering on a request, see the [Nuxt lifecycle](/docs/4.x/guide/concepts/nuxt-lifecycle).
+
+## The Schema
+
+The diagram below groups the main contexts around the resolved Nuxt configuration. Use it to decide where a feature belongs before you reach for a hook or a custom path.
+
+![High-level Nuxt schema showing module, server, app, browser, and shared contexts](/assets/docs/concepts/nuxt-schema/overview-light.svg){class="dark:hidden w-full"}
+![High-level Nuxt schema showing module, server, app, browser, and shared contexts](/assets/docs/concepts/nuxt-schema/overview-dark.svg){class="hidden dark:block w-full"}
+
+::callout{icon="i-lucide-pencil"}
+The diagram started from community work in [issue #32973](https://github.com/nuxt/nuxt/issues/32973); labels were refreshed to match current Nuxt docs. Treat it as a learning aid and confirm details against the linked pages below.
+::
+
+## Contexts
+
+### Module Context
+
+[Nuxt modules](/docs/4.x/guide/concepts/modules) run when you start Nuxt in development or build for production. They extend the resolved configuration: templates, builders, runtime hooks, and integrations.
+
+Module code runs in a Node.js build context (`.nuxt/tsconfig.node.json`). Prefer the [Nuxt Kit](/docs/4.x/api/kit/modules) utilities when you author modules.
+
+### Server Context (Nitro)
+
+The [server engine](/docs/4.x/guide/concepts/server-engine) (Nitro) owns `server/` routes, middleware, and plugins. It can use Node and server-only APIs. Types for this context live under `.nuxt/tsconfig.server.json`.
+
+Nitro can read private [runtime config](/docs/4.x/guide/going-further/runtime-config). Values under `runtimeConfig` that are not in `public` must stay on the server.
+
+### App Context
+
+Your Vue application under `app/` runs during SSR and in the browser after hydration. App plugins, pages, components, and composables such as [`useAsyncData`](/docs/4.x/api/composables/use-async-data) and [`useFetch`](/docs/4.x/api/composables/use-fetch) belong here. Types use `.nuxt/tsconfig.app.json`.
+
+On the client, only `runtimeConfig.public` (and internal `runtimeConfig.app`) is available.
+
+### Browser Context
+
+After hydration, the same app code runs against `window` and `document`. Use `import.meta.client` (or `.client` plugins) when logic must not run during SSR.
+
+### Shared Context
+
+The [`shared/`](/docs/4.x/directory-structure/shared) directory holds platform-agnostic utilities and types used by both the Vue app and Nitro (`.nuxt/tsconfig.shared.json`). Do not import Vue, Nitro, Node filesystem, or database clients from `shared/`.
+
+## Configuration
+
+Nuxt merges `nuxt.config`, layers, and modules into one resolved configuration that drives every context above.
+
+| Concern | Where it applies |
+| --- | --- |
+| Build / module options | Module and build (Node) context |
+| `runtimeConfig.public` | App and server; safe to expose to the browser |
+| Private `runtimeConfig` | Server only |
+| Generated `.nuxt/tsconfig.*.json` | Per-context TypeScript [project references](/docs/4.x/guide/concepts/typescript#project-references) |
+
+:read-more{to="/docs/4.x/directory-structure/nuxt-config"}
+
+## Related Documentation
+
+- [Nuxt Lifecycle](/docs/4.x/guide/concepts/nuxt-lifecycle): execution order on server and client
+- [Rendering Modes](/docs/4.x/guide/concepts/rendering): universal, client-side, and hybrid rendering
+- [Modules](/docs/4.x/guide/concepts/modules): extending Nuxt at build time
+- [Server Engine](/docs/4.x/guide/concepts/server-engine): Nitro and the API layer
+- [`shared/`](/docs/4.x/directory-structure/shared): code shared between app and server
+- [Runtime Config](/docs/4.x/guide/going-further/runtime-config): public vs private configuration

--- a/docs/3.guide/1.concepts/6.nuxt-schema.md
+++ b/docs/3.guide/1.concepts/6.nuxt-schema.md
@@ -53,7 +53,7 @@ Nuxt merges `nuxt.config`, layers, and modules into one resolved configuration t
 | Concern | Where it applies |
 | --- | --- |
 | Build / module options | Module and build (Node) context |
-| `runtimeConfig.public` | App and server; safe to expose to the browser |
+| `runtimeConfig.public` | App and server; exposed to the browser, so only intentionally non-sensitive values belong here |
 | Private `runtimeConfig` | Server only |
 | Generated `.nuxt/tsconfig.*.json` | Per-context TypeScript [project references](/docs/4.x/guide/concepts/typescript#project-references) |
 


### PR DESCRIPTION
Add a Nuxt Schema guide page that maps module, Nitro, app, browser, and shared contexts, with a pointer from the lifecycle docs.

Issue #32973 asked for an overview diagram of how these contexts fit together. The page uses light/dark SVGs (labels refreshed from the community Excalidraw).

Companion assets PR: https://github.com/nuxt/nuxt.com/pull/2337

Refs #32973