### PR TITLE
feat(nuxt,schema,vite): add experimental cleanupRouteStyles option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,17 +225,47 @@ jobs:
           - name: Lint
             run: vp run lint
 
-          - name: Knip
-            run: vp run lint:knip
-
-          - name: Knip (production)
-            run: vp run lint:knip:production
-
           - name: Test (nuxt runtime)
             run: vp run test:runtime
 
           - name: Test (unit)
             run: vp run test:unit
+
+      - name: Cancel workflow on failure
+        if: failure() && github.event_name == 'merge_group'
+        run: gh run cancel ${{ github.run_id }} --repo ${{ github.repository }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+  # Runs on pull requests too (unlike the `lint` job) so knip regressions surface
+  # before the merge queue.
+  knip:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 15
+    permissions:
+      actions: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1.15.0
+        with:
+          node-version: lts
+          cache: true
+
+      - name: Prepare
+        run: vp run dev:prepare
+
+      - parallel:
+          - name: Knip
+            run: vp run lint:knip
+
+          - name: Knip (production)
+            run: vp run lint:knip:production
 
       - name: Cancel workflow on failure
         if: failure() && github.event_name == 'merge_group'
@@ -404,6 +434,7 @@ jobs:
       - codeql
       - typecheck
       - lint-and-test
+      - knip
       - test-size
       - test-fixtures
       - test-e2e
@@ -417,6 +448,7 @@ jobs:
             "${{ needs.codeql.result }}" \
             "${{ needs.typecheck.result }}" \
             "${{ needs.lint-and-test.result }}" \
+            "${{ needs.knip.result }}" \
             "${{ needs.test-size.result }}" \
             "${{ needs.test-fixtures.result }}" \
             "${{ needs.test-e2e.result }}" \

--- a/docs/3.guide/6.going-further/1.experimental-features.md
+++ b/docs/3.guide/6.going-further/1.experimental-features.md
@@ -988,6 +988,22 @@ To use this feature, you need to:
 Learn more about **@dxup/nuxt**.
 ::
 
+## cleanupRouteStyles
+
+Cleans up stylesheets belonging to pages and layouts that are no longer rendered after a client-side navigation.
+
+By default, once the CSS for a lazy-loaded page or layout chunk has been added to the document it stays there for the lifetime of the app, so global (non-scoped) styles from a previously visited route can leak into other routes, and the document keeps accumulating one stylesheet per page/layout ever visited in the session ([#22817](https://github.com/nuxt/nuxt/issues/22817)). When this option is enabled, Nuxt emits a map of page/layout stylesheets at build time and adds/removes their `<link>` tags on navigation, so only the current route's styles are present in the document.
+
+```ts twoslash [nuxt.config.ts]
+export default defineNuxtConfig({
+  experimental: {
+    cleanupRouteStyles: true,
+  },
+})
+```
+
+This is only supported with the Vite builder in production builds, and works best with `features.inlineStyles: false` (inlined styles from the initially rendered route cannot be cleaned up). Styles for layouts rendered via an explicit `<NuxtLayout name="...">` prop (rather than route metadata or route rules) are not tracked and are never removed.
+
 ## ssrStreaming
 
 Enables SSR streaming to dramatically improve Time to First Byte (TTFB). When enabled, the server sends the HTML shell (including `<head>`, styles, preload hints, and entry scripts) immediately, then streams the rendered body content progressively using Vue's `renderToWebStream`.

--- a/knip.json
+++ b/knip.json
@@ -89,7 +89,7 @@
       "ignoreDependencies": [
         "@dxup/nuxt",
         "@nuxt/devtools",
-        "@nuxt/telemetry!",
+        "@nuxt/telemetry",
         "@nuxt/vite-builder"
       ]
     },

--- a/packages/nuxt/src/app/plugins/cleanup-route-styles.client.ts
+++ b/packages/nuxt/src/app/plugins/cleanup-route-styles.client.ts
@@ -1,0 +1,96 @@
+import type { RouteLocationNormalized } from 'vue-router'
+import { defineNuxtPlugin, useRuntimeConfig } from '../nuxt'
+import type { ObjectPlugin, Plugin } from '../nuxt'
+import { useRouter } from '../composables/router'
+import { resolveLayoutName } from '../composables/layout'
+import { buildAssetsURL } from '#internal/nuxt/paths'
+
+interface RouteStylesMap {
+  layouts: Record<string, string[]>
+  pages: Record<string, string[]>
+}
+
+function waitForStylesheet (link: HTMLLinkElement) {
+  // an already-loaded (e.g. cached) stylesheet may never fire `load` again
+  if (link.sheet) { return }
+  return new Promise<void>((resolve) => {
+    link.addEventListener('load', () => resolve(), { once: true })
+    link.addEventListener('error', () => resolve(), { once: true })
+  })
+}
+
+/**
+ * Cleans up stylesheets belonging to pages/layouts that are no longer rendered
+ * after a client-side navigation, using the `route-styles.json` map emitted by
+ * the `nuxt:route-styles-map` vite plugin.
+ *
+ * Unlike toggling a stylesheet's `disabled` flag, this actually detaches the
+ * `<link>` element for a route that's no longer active, so the document head
+ * doesn't accumulate one stylesheet per page/layout ever visited in the
+ * session. Vite's own dynamic-import machinery only injects a chunk's `<link>`
+ * the first time it is imported, so this plugin re-creates the element itself
+ * on any subsequent visit, ahead of the route's DOM update to avoid a flash of
+ * unstyled content.
+ */
+const plugin: Plugin & ObjectPlugin = defineNuxtPlugin({
+  name: 'nuxt:cleanup-route-styles',
+  setup (nuxtApp) {
+    const router = useRouter()
+    const config = useRuntimeConfig()
+
+    interface LoadedStyles { map: RouteStylesMap, managed: Set<string> }
+
+    // resolves to undefined (and the plugin no-ops) if the map cannot be loaded
+    let styles: Promise<LoadedStyles | undefined> | undefined
+    const loadStyles = () => styles ||= fetch(buildAssetsURL('route-styles.json') + '?' + config.app.buildId)
+      .then(async (res) => {
+        if (!res.ok) { return }
+        const map = await res.json() as RouteStylesMap
+        return { map, managed: new Set([...Object.values(map.layouts), ...Object.values(map.pages)].flat()) }
+      })
+      .catch(() => undefined)
+
+    function activeStyles ({ map }: LoadedStyles, route: RouteLocationNormalized) {
+      const layout = resolveLayoutName(route)
+      return new Set([
+        ...(layout && map.layouts[layout]) || [],
+        ...route.matched.flatMap(record => (typeof record.name === 'string' && map.pages[record.name]) || []),
+      ])
+    }
+
+    function findLink (file: string) {
+      for (const link of document.querySelectorAll<HTMLLinkElement>('link[rel="stylesheet"]')) {
+        if (link.href.split('/').pop()?.replace(/\?.*$/, '') === file) { return link }
+      }
+    }
+
+    // Ensure the incoming route's styles are present before the DOM updates,
+    // to avoid a flash of unstyled content when returning to a previously
+    // visited page/layout whose stylesheet we had removed.
+    router.beforeResolve(async (to) => {
+      if (nuxtApp.isHydrating) { return }
+      const loaded = await loadStyles()
+      if (!loaded) { return }
+      await Promise.all([...activeStyles(loaded, to)].map((file) => {
+        if (findLink(file)) { return }
+        const link = document.createElement('link')
+        link.rel = 'stylesheet'
+        link.href = buildAssetsURL(file)
+        document.head.append(link)
+        return waitForStylesheet(link)
+      }))
+    })
+
+    nuxtApp.hook('page:finish', async () => {
+      const loaded = !nuxtApp.isHydrating && await styles
+      if (!loaded) { return }
+      const active = activeStyles(loaded, router.currentRoute.value)
+      for (const file of loaded.managed) {
+        if (active.has(file)) { continue }
+        findLink(file)?.remove()
+      }
+    })
+  },
+})
+
+export default plugin

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -747,6 +747,11 @@ async function initNuxt (nuxt: Nuxt) {
     addPlugin(resolve(nuxt.options.appDir, 'plugins/cross-origin-prefetch.client'))
   }
 
+  // Add experimental cleanup of styles from unmounted pages/layouts
+  if (nuxt.options.experimental.cleanupRouteStyles && !nuxt.options.dev && nuxt.options.builder === '@nuxt/vite-builder') {
+    addPlugin(resolve(nuxt.options.appDir, 'plugins/cleanup-route-styles.client'))
+  }
+
   // Add experimental page reload support
   if (nuxt.options.experimental.emitRouteChunkError === 'automatic') {
     addPlugin(resolve(nuxt.options.appDir, 'plugins/chunk-reload.client'))

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -263,6 +263,7 @@ export default defineResolvers({
         return typeof val === 'boolean' ? val : (await get('future.compatibilityVersion')) < 5
       },
     },
+    cleanupRouteStyles: false,
     ssrStreaming: {
       $resolve (val) {
         // Indexing crawlers only; `chrome-lighthouse` is intentionally absent

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1619,6 +1619,30 @@ export interface ConfigSchema {
     nitroAutoImports: boolean
 
     /**
+     * Clean up stylesheets belonging to pages and layouts that are no longer
+     * rendered after a client-side navigation.
+     *
+     * By default, once the CSS for a lazy-loaded page or layout chunk has been
+     * added to the document it stays there for the lifetime of the app, so
+     * global (non-scoped) styles from a previously visited route can leak into
+     * other routes, and the document keeps accumulating one stylesheet per
+     * page/layout ever visited in the session ([#22817](https://github.com/nuxt/nuxt/issues/22817)).
+     * When this option is enabled, Nuxt emits a map of page/layout stylesheets
+     * at build time and adds/removes their `<link>` tags on navigation, so only
+     * the current route's styles are present in the document.
+     *
+     * Only supported with the Vite builder in production builds. Works best
+     * with `features.inlineStyles: false` (inlined styles from the initially
+     * rendered route cannot be cleaned up). Styles for layouts rendered via an
+     * explicit `<NuxtLayout name="...">` prop (rather than route metadata or
+     * route rules) are not tracked and are never removed.
+     *
+     * @default false
+     * @see https://github.com/nuxt/nuxt/issues/22817
+     */
+    cleanupRouteStyles: boolean
+
+    /**
      * Enable SSR streaming to improve Time to First Byte (TTFB).
      *
      * When enabled, the server sends the HTML shell (head, styles, preload hints)

--- a/packages/vite/src/plugins/route-styles-map.ts
+++ b/packages/vite/src/plugins/route-styles-map.ts
@@ -1,0 +1,81 @@
+import type { Plugin, Rollup } from 'vite'
+import { joinURL, withoutLeadingSlash } from 'ufo'
+import { normalize } from 'pathe'
+import type { Nuxt, NuxtPage } from '@nuxt/schema'
+
+/**
+ * Emits `route-styles.json` into the client build assets, mapping each layout
+ * name and page (route name) to the basenames of the CSS assets owned by its
+ * chunk graph, excluding CSS also owned by an entry chunk (which is always
+ * active and never cleaned up). Consumed by `cleanup-route-styles.client` to
+ * know which stylesheets belong to a page/layout that is no longer rendered
+ * after a client-side navigation (#22817).
+ */
+export function RouteStylesMapPlugin (nuxt: Nuxt): Plugin | undefined {
+  if (nuxt.options.dev || !nuxt.options.experimental.cleanupRouteStyles) { return }
+
+  return {
+    name: 'nuxt:route-styles-map',
+    applyToEnvironment: environment => environment.name === 'client',
+    generateBundle (_options, bundle) {
+      const chunks = Object.values(bundle).filter((c): c is Rollup.OutputChunk => c.type === 'chunk')
+      const chunksByFileName = new Map(chunks.map(c => [c.fileName, c]))
+      const chunksByFacade = new Map<string, Rollup.OutputChunk>()
+      for (const chunk of chunks) {
+        if (chunk.facadeModuleId) {
+          chunksByFacade.set(normalize(chunk.facadeModuleId.replace(/\?.+$/, '')), chunk)
+        }
+      }
+
+      // CSS owned by a chunk = its own emitted CSS plus that of its static import
+      // graph - the same set vite's dynamic-import helper injects the first time
+      // the chunk is loaded.
+      const collectCss = (chunk: Rollup.OutputChunk, css = new Set<string>(), seen = new Set<string>()): Set<string> => {
+        if (seen.has(chunk.fileName)) { return css }
+        seen.add(chunk.fileName)
+        for (const file of chunk.viteMetadata?.importedCss || []) {
+          css.add(file.split('/').pop()!)
+        }
+        for (const imported of chunk.imports) {
+          const importedChunk = chunksByFileName.get(imported)
+          if (importedChunk) { collectCss(importedChunk, css, seen) }
+        }
+        return css
+      }
+
+      const entryCss = new Set<string>()
+      for (const chunk of chunks) {
+        if (chunk.isEntry) { collectCss(chunk, entryCss) }
+      }
+
+      const cssOwnedByFile = (file?: string | null) => {
+        const chunk = file && chunksByFacade.get(normalize(file))
+        if (!chunk) { return }
+        const css = [...collectCss(chunk)].filter(name => !entryCss.has(name))
+        return css.length ? css : undefined
+      }
+
+      const layouts: Record<string, string[]> = {}
+      for (const layout of Object.values(nuxt.apps.default?.layouts || {})) {
+        const css = cssOwnedByFile(layout.file)
+        if (css) { layouts[layout.name] = css }
+      }
+
+      const flattenPages = (pages?: NuxtPage[]): NuxtPage[] => pages?.flatMap(p => [p, ...flattenPages(p.children)]) ?? []
+      const pages: Record<string, string[]> = {}
+      for (const page of flattenPages(nuxt.apps.default?.pages)) {
+        // routes without a generated name (e.g. parents of nested routes) are
+        // left unmanaged - their styles are simply never cleaned up
+        if (!page.name) { continue }
+        const css = cssOwnedByFile(page.file)
+        if (css) { pages[page.name] = css }
+      }
+
+      this.emitFile({
+        type: 'asset',
+        fileName: withoutLeadingSlash(joinURL(nuxt.options.app.buildAssetsDir, 'route-styles.json')),
+        source: JSON.stringify({ layouts, pages }),
+      })
+    },
+  }
+}

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -19,6 +19,7 @@ import { OptimizeDepsHintPlugin, optimizerCallbacks, userOptimizeDepsInclude } f
 
 import { VueJsxPlugin } from './plugins/vue-jsx.ts'
 import { SSRStylesPlugin } from './plugins/ssr-styles.ts'
+import { RouteStylesMapPlugin } from './plugins/route-styles-map.ts'
 import { PublicDirsPlugin } from './plugins/public-dirs.ts'
 import { ReplacePlugin } from './plugins/replace.ts'
 import { LayerDepOptimizePlugin } from './plugins/layer-dep-optimize.ts'
@@ -204,6 +205,7 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
         ReplacePlugin(),
         LayerDepOptimizePlugin(nuxt),
         SSRStylesPlugin(nuxt),
+        RouteStylesMapPlugin(nuxt),
         EnvironmentsPlugin(nuxt),
         // Add type-checking
         VitePluginCheckerPlugin(nuxt),

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,8 +13,8 @@ const e2eMatrix = [
 ] as const
 
 const devOnlyTests = ['**/hmr.test.ts']
-const builtOnlyTests = ['**/spa-preloader-*.test.ts', '**/server-page-css.test.ts', '**/chunk-error.test.ts']
-const viteOnlyTests = ['**/server-page-css.test.ts']
+const builtOnlyTests = ['**/spa-preloader-*.test.ts', '**/server-page-css.test.ts', '**/chunk-error.test.ts', '**/css-cleanup.test.ts']
+const viteOnlyTests = ['**/server-page-css.test.ts', '**/css-cleanup.test.ts']
 const rspackExcludedTests = ['**/chunk-error.test.ts']
 
 function testIgnoreForProject (entry: typeof e2eMatrix[number]) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -323,9 +323,6 @@ catalogs:
     '@vue/compiler-core':
       specifier: 3.5.40
       version: 3.5.40
-    '@vue/devtools-api':
-      specifier: 8.1.5
-      version: 8.1.5
     '@vue/language-core':
       specifier: 3.3.7
       version: 3.3.7
@@ -1831,7 +1828,7 @@ importers:
         version: link:../../../packages/nuxt
     devDependencies:
       '@vue/devtools-api':
-        specifier: catalog:dev
+        specifier: 8.1.5
         version: 8.1.5
       defu:
         specifier: catalog:build

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1886,6 +1886,12 @@ importers:
         specifier: catalog:dev
         version: 6.0.3
 
+  test/fixtures/css-cleanup:
+    dependencies:
+      nuxt:
+        specifier: workspace:*
+        version: link:../../../packages/nuxt
+
   test/fixtures/dynamic-paths:
     dependencies:
       '@nuxt/rspack-builder':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -420,8 +420,8 @@ catalogs:
       specifier: 1.2.4
       version: 1.2.4
     tsdown:
-      specifier: 0.22.9
-      version: 0.22.9
+      specifier: 0.22.11
+      version: 0.22.11
     typescript:
       specifier: 6.0.3
       version: 6.0.3
@@ -850,7 +850,7 @@ importers:
         version: 2.13.4(@rspack/core@2.1.4(@swc/helpers@0.5.23))(oxc-parser@0.140.0)(rolldown@1.2.0)(srvx@0.11.22)(supports-color@10.2.2)(vite@8.1.5)(webpack@5.108.4(cssnano@8.0.2(postcss@8.5.19))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19))
       tsdown:
         specifier: catalog:dev
-        version: 0.22.9(@arethetypeswrong/core@0.18.5)(@vitejs/devtools@0.3.1)(oxc-resolver@11.21.3)(publint@0.3.21)(typescript@7.0.2)(vue-tsc@3.3.7(typescript@7.0.2))
+        version: 0.22.11(@arethetypeswrong/core@0.18.5)(@vitejs/devtools@0.3.1)(oxc-resolver@11.21.3)(publint@0.3.21)(typescript@7.0.2)(vue-tsc@3.3.7(typescript@7.0.2))
       unimport:
         specifier: catalog:build
         version: 6.3.1(@rspack/core@2.1.4(@swc/helpers@0.5.23))(esbuild@0.28.1)(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup@4.62.2)(vite@8.1.5)(webpack@5.108.4(cssnano@8.0.2(postcss@8.5.19))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19))
@@ -968,7 +968,7 @@ importers:
         version: link:../nuxt
       tsdown:
         specifier: catalog:dev
-        version: 0.22.9(@arethetypeswrong/core@0.18.5)(@vitejs/devtools@0.3.1)(oxc-resolver@11.21.3)(publint@0.3.21)(typescript@7.0.2)(vue-tsc@3.3.7(typescript@7.0.2))
+        version: 0.22.11(@arethetypeswrong/core@0.18.5)(@vitejs/devtools@0.3.1)(oxc-resolver@11.21.3)(publint@0.3.21)(typescript@7.0.2)(vue-tsc@3.3.7(typescript@7.0.2))
       vitest:
         specifier: catalog:dev
         version: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.0)(vite@8.1.5)
@@ -1173,7 +1173,7 @@ importers:
         version: 3.5.40
       tsdown:
         specifier: catalog:dev
-        version: 0.22.9(@arethetypeswrong/core@0.18.5)(@vitejs/devtools@0.3.1)(oxc-resolver@11.21.3)(publint@0.3.21)(typescript@6.0.3)(vue-tsc@3.3.7(typescript@6.0.3))
+        version: 0.22.11(@arethetypeswrong/core@0.18.5)(@vitejs/devtools@0.3.1)(oxc-resolver@11.21.3)(publint@0.3.21)(typescript@6.0.3)(vue-tsc@3.3.7(typescript@6.0.3))
       typescript:
         specifier: catalog:dev
         version: 6.0.3
@@ -1336,7 +1336,7 @@ importers:
         version: 4.62.2
       tsdown:
         specifier: catalog:dev
-        version: 0.22.9(@arethetypeswrong/core@0.18.5)(@vitejs/devtools@0.3.1)(oxc-resolver@11.21.3)(publint@0.3.21)(typescript@6.0.3)(vue-tsc@3.3.7(typescript@6.0.3))
+        version: 0.22.11(@arethetypeswrong/core@0.18.5)(@vitejs/devtools@0.3.1)(oxc-resolver@11.21.3)(publint@0.3.21)(typescript@6.0.3)(vue-tsc@3.3.7(typescript@6.0.3))
       vue:
         specifier: 3.5.40
         version: 3.5.40(typescript@6.0.3)
@@ -1445,7 +1445,7 @@ importers:
         version: 1.3.0
       tsdown:
         specifier: catalog:dev
-        version: 0.22.9(@arethetypeswrong/core@0.18.5)(@vitejs/devtools@0.3.1)(oxc-resolver@11.21.3)(publint@0.3.21)(typescript@7.0.2)(vue-tsc@3.3.7(typescript@7.0.2))
+        version: 0.22.11(@arethetypeswrong/core@0.18.5)(@vitejs/devtools@0.3.1)(oxc-resolver@11.21.3)(publint@0.3.21)(typescript@7.0.2)(vue-tsc@3.3.7(typescript@7.0.2))
       unctx:
         specifier: catalog:build
         version: 3.0.0(magic-string@1.0.0)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(@rspack/core@2.1.4(@swc/helpers@0.5.23))(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.62.2)(vite@8.1.5)(webpack@5.108.4(cssnano@8.0.2(postcss@8.5.19))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19)))
@@ -1641,7 +1641,7 @@ importers:
         version: 7.0.1(rolldown@1.2.0)(rollup@4.62.2)
       tsdown:
         specifier: catalog:dev
-        version: 0.22.9(@arethetypeswrong/core@0.18.5)(@vitejs/devtools@0.3.1)(oxc-resolver@11.21.3)(publint@0.3.21)(typescript@7.0.2)(vue-tsc@3.3.7(typescript@7.0.2))
+        version: 0.22.11(@arethetypeswrong/core@0.18.5)(@vitejs/devtools@0.3.1)(oxc-resolver@11.21.3)(publint@0.3.21)(typescript@7.0.2)(vue-tsc@3.3.7(typescript@7.0.2))
       vue:
         specifier: 3.5.40
         version: 3.5.40(typescript@7.0.2)
@@ -1804,7 +1804,7 @@ importers:
         version: 4.62.2
       tsdown:
         specifier: catalog:dev
-        version: 0.22.9(@arethetypeswrong/core@0.18.5)(@vitejs/devtools@0.3.1)(oxc-resolver@11.21.3)(publint@0.3.21)(typescript@6.0.3)(vue-tsc@3.3.7(typescript@6.0.3))
+        version: 0.22.11(@arethetypeswrong/core@0.18.5)(@vitejs/devtools@0.3.1)(oxc-resolver@11.21.3)(publint@0.3.21)(typescript@6.0.3)(vue-tsc@3.3.7(typescript@6.0.3))
       vue:
         specifier: 3.5.40
         version: 3.5.40(typescript@6.0.3)
@@ -7940,8 +7940,8 @@ packages:
     resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
     engines: {node: '>= 0.4'}
 
-  obug@2.1.3:
-    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
     engines: {node: '>=12.20.0'}
 
   ocache@0.1.5:
@@ -9451,14 +9451,14 @@ packages:
       '@typescript/native-preview':
         optional: true
 
-  tsdown@0.22.9:
-    resolution: {integrity: sha512-/0QEjQEhOU1t1YxOIAGzFN7bIssd8P0pBpkOmNLCQi3c5UtrcMF5bvq3f30xHJNW9QCA9aUNcNAorMr2CTd6Lg==}
+  tsdown@0.22.11:
+    resolution: {integrity: sha512-BERdQpqAltv3vYGC0pE4n+mRGPIN91T/on+Ud73bYRkbptknelFm27tJgBBUz4RJ5d3VNeVH90HfjBo1Ouj8yQ==}
     engines: {node: ^22.18.0 || >=24.11.0}
     hasBin: true
     peerDependencies:
       '@arethetypeswrong/core': ^0.18.1
-      '@tsdown/css': 0.22.9
-      '@tsdown/exe': 0.22.9
+      '@tsdown/css': 0.22.11
+      '@tsdown/exe': 0.22.11
       '@vitejs/devtools': '*'
       publint: ^0.3.8
       tsx: '*'
@@ -10451,7 +10451,7 @@ snapshots:
       gensync: 1.0.0-beta.2
       import-meta-resolve: 4.2.0
       json5: 2.2.3
-      obug: 2.1.3
+      obug: 2.1.4
       semver: 7.8.5
 
   '@babel/generator@7.29.7':
@@ -10700,7 +10700,7 @@ snapshots:
       '@babel/parser': 8.0.0
       '@babel/template': 8.0.0
       '@babel/types': 8.0.0
-      obug: 2.1.3
+      obug: 2.1.4
 
   '@babel/types@7.29.7':
     dependencies:
@@ -13403,7 +13403,7 @@ snapshots:
       h3: 2.0.1-rc.22(crossws@0.4.6(srvx@0.11.22))
       mlly: 1.8.2
       nostics: 0.2.0(@rspack/core@2.1.4(@swc/helpers@0.5.23))(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.62.2)(vite@8.1.5)(webpack@5.108.4(cssnano@8.0.2(postcss@8.5.19))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19))
-      obug: 2.1.3
+      obug: 2.1.4
       pathe: 2.0.3
       perfect-debounce: 2.1.0
       tinyexec: 1.2.4
@@ -13455,7 +13455,7 @@ snapshots:
       h3: 2.0.1-rc.22(crossws@0.4.6(srvx@0.11.22))
       mlly: 1.8.2
       nostics: 0.2.0(@rspack/core@2.1.4(@swc/helpers@0.5.23))(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.62.2)(vite@8.1.5)(webpack@5.108.4(cssnano@8.0.2(postcss@8.5.19))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19))
-      obug: 2.1.3
+      obug: 2.1.4
       pathe: 2.0.3
       perfect-debounce: 2.1.0
       tinyexec: 1.2.4
@@ -13542,7 +13542,7 @@ snapshots:
       istanbul-lib-report: 3.0.1
       istanbul-reports: 3.2.0
       magicast: 0.5.3
-      obug: 2.1.3
+      obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.0
       vitest: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.0)(vite@8.1.5)
@@ -17270,7 +17270,7 @@ snapshots:
       has-symbols: 1.1.0
       object-keys: 1.1.1
 
-  obug@2.1.3: {}
+  obug@2.1.4: {}
 
   ocache@0.1.5:
     dependencies:
@@ -18335,7 +18335,7 @@ snapshots:
     dependencies:
       dts-resolver: 3.0.0(oxc-resolver@11.21.3)
       get-tsconfig: 5.0.0-beta.5
-      obug: 2.1.3
+      obug: 2.1.4
       rolldown: 1.2.0
       yuku-ast: 0.1.7
       yuku-codegen: 0.6.3
@@ -18350,7 +18350,7 @@ snapshots:
     dependencies:
       dts-resolver: 3.0.0(oxc-resolver@11.21.3)
       get-tsconfig: 5.0.0-beta.5
-      obug: 2.1.3
+      obug: 2.1.4
       rolldown: 1.2.0
       yuku-ast: 0.1.7
       yuku-codegen: 0.6.3
@@ -18971,7 +18971,7 @@ snapshots:
     transitivePeerDependencies:
       - tslib
 
-  tsdown@0.22.9(@arethetypeswrong/core@0.18.5)(@vitejs/devtools@0.3.1)(oxc-resolver@11.21.3)(publint@0.3.21)(typescript@6.0.3)(vue-tsc@3.3.7(typescript@6.0.3)):
+  tsdown@0.22.11(@arethetypeswrong/core@0.18.5)(@vitejs/devtools@0.3.1)(oxc-resolver@11.21.3)(publint@0.3.21)(typescript@6.0.3)(vue-tsc@3.3.7(typescript@6.0.3)):
     dependencies:
       ansis: 4.3.1
       cac: 7.0.0
@@ -18979,7 +18979,7 @@ snapshots:
       empathic: 2.0.1
       hookable: 6.1.1
       import-without-cache: 0.4.0
-      obug: 2.1.3
+      obug: 2.1.4
       picomatch: 4.0.5
       rolldown: 1.2.0
       rolldown-plugin-dts: 0.27.9(oxc-resolver@11.21.3)(rolldown@1.2.0)(typescript@6.0.3)(vue-tsc@3.3.7(typescript@6.0.3))
@@ -18999,7 +18999,7 @@ snapshots:
       - oxc-resolver
       - vue-tsc
 
-  tsdown@0.22.9(@arethetypeswrong/core@0.18.5)(@vitejs/devtools@0.3.1)(oxc-resolver@11.21.3)(publint@0.3.21)(typescript@7.0.2)(vue-tsc@3.3.7(typescript@7.0.2)):
+  tsdown@0.22.11(@arethetypeswrong/core@0.18.5)(@vitejs/devtools@0.3.1)(oxc-resolver@11.21.3)(publint@0.3.21)(typescript@7.0.2)(vue-tsc@3.3.7(typescript@7.0.2)):
     dependencies:
       ansis: 4.3.1
       cac: 7.0.0
@@ -19007,7 +19007,7 @@ snapshots:
       empathic: 2.0.1
       hookable: 6.1.1
       import-without-cache: 0.4.0
-      obug: 2.1.3
+      obug: 2.1.4
       picomatch: 4.0.5
       rolldown: 1.2.0
       rolldown-plugin-dts: 0.27.9(oxc-resolver@11.21.3)(rolldown@1.2.0)(typescript@7.0.2)(vue-tsc@3.3.7(typescript@7.0.2))
@@ -19430,7 +19430,7 @@ snapshots:
     dependencies:
       cac: 7.0.0
       es-module-lexer: 2.1.0
-      obug: 2.1.3
+      obug: 2.1.4
       pathe: 2.0.3
       vite: 8.1.5(@types/node@24.13.3)(@vitejs/devtools@0.3.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -19468,7 +19468,7 @@ snapshots:
       '@vitejs/devtools-kit': 0.3.4(@rspack/core@2.1.4(@swc/helpers@0.5.23))(crossws@0.4.6(srvx@0.11.22))(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.62.2)(typescript@6.0.3)(vite@8.1.5)(webpack@5.108.4(cssnano@8.0.2(postcss@8.5.19))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19))
       ansis: 4.3.1
       error-stack-parser-es: 1.0.5
-      obug: 2.1.3
+      obug: 2.1.4
       ohash: 2.0.11
       open: 11.0.0
       perfect-debounce: 2.1.0
@@ -19557,7 +19557,7 @@ snapshots:
       es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
-      obug: 2.1.3
+      obug: 2.1.4
       pathe: 2.0.3
       picomatch: 4.0.5
       std-env: 4.2.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -219,7 +219,6 @@ catalogs:
     '@vitejs/plugin-vue-jsx': 5.1.6
     '@vitest/coverage-v8': 4.1.10
     '@vue/compiler-core': 3.5.40
-    '@vue/devtools-api': 8.1.5
     '@vue/language-core': 3.3.7
     '@vue/test-utils': 2.4.11
     acorn: 8.17.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -252,7 +252,7 @@ catalogs:
     sherif: 1.13.0
     svgo: 4.0.2
     tinyexec: 1.2.4
-    tsdown: 0.22.9
+    tsdown: 0.22.11
     typescript: 6.0.3
     unocss: 66.7.5
     vitest: 4.1.10

--- a/test/e2e/css-cleanup.test.ts
+++ b/test/e2e/css-cleanup.test.ts
@@ -1,0 +1,53 @@
+import { fileURLToPath } from 'node:url'
+import { isWindows } from 'std-env'
+import { expect, test } from './test-utils'
+
+test.use({
+  nuxt: {
+    rootDir: fileURLToPath(new URL('../fixtures/css-cleanup', import.meta.url)),
+    setupTimeout: (isWindows ? 360 : 120) * 1000,
+  },
+})
+
+const BLUE = 'rgb(0, 0, 255)'
+const RED = 'rgb(255, 0, 0)'
+
+async function findStylesheetHref (page: import('@playwright/test').Page, contains: string) {
+  const hrefs = await page.locator('link[rel="stylesheet"]').evaluateAll(links => links.map(l => (l as HTMLLinkElement).href))
+  for (const href of hrefs) {
+    const css = await (await page.request.get(href)).text()
+    if (css.includes(contains)) { return href }
+  }
+}
+
+test.describe('css cleanup on navigation (#22817)', () => {
+  test('css from a previously visited layout does not leak into the current route', async ({ page, goto }) => {
+    await goto('/')
+    await expect(page.locator('.box')).toHaveCSS('border-top-color', BLUE)
+
+    await page.click('a[href="/other"]')
+    await expect(page.locator('.legacy-page')).toHaveCSS('color', RED)
+
+    await page.click('a[href="/"]')
+    await expect(page.locator('.box')).toHaveCSS('border-top-color', BLUE)
+
+    // navigating forward again must restore the removed styles
+    await page.click('a[href="/other"]')
+    await expect(page.locator('.legacy-page')).toHaveCSS('color', RED)
+  })
+
+  test('removes (not just disables) the <link> for a stylesheet that is no longer active', async ({ page, goto }) => {
+    await goto('/')
+
+    await page.click('a[href="/other"]')
+    await expect(page.locator('.legacy-page')).toHaveCSS('color', RED)
+    const legacyHref = await findStylesheetHref(page, '.legacy-page')
+    expect(legacyHref).toBeTruthy()
+
+    await page.click('a[href="/"]')
+    await expect(page.locator('.box')).toHaveCSS('border-top-color', BLUE)
+
+    const hrefsAfterReturn = await page.locator('link[rel="stylesheet"]').evaluateAll(links => links.map(l => (l as HTMLLinkElement).href))
+    expect(hrefsAfterReturn).not.toContain(legacyHref)
+  })
+})

--- a/test/fixtures/basic/package.json
+++ b/test/fixtures/basic/package.json
@@ -10,7 +10,7 @@
     "nuxt": "workspace:*"
   },
   "devDependencies": {
-    "@vue/devtools-api": "catalog:dev",
+    "@vue/devtools-api": "8.1.5",
     "defu": "catalog:build",
     "postcss": "catalog:build",
     "ufo": "catalog:build",

--- a/test/fixtures/css-cleanup/app/app.vue
+++ b/test/fixtures/css-cleanup/app/app.vue
@@ -1,0 +1,5 @@
+<template>
+  <NuxtLayout>
+    <NuxtPage />
+  </NuxtLayout>
+</template>

--- a/test/fixtures/css-cleanup/app/layouts/default.vue
+++ b/test/fixtures/css-cleanup/app/layouts/default.vue
@@ -1,0 +1,11 @@
+<template>
+  <div>
+    <slot />
+  </div>
+</template>
+
+<style>
+.box {
+  border: 3px solid blue;
+}
+</style>

--- a/test/fixtures/css-cleanup/app/layouts/legacy.vue
+++ b/test/fixtures/css-cleanup/app/layouts/legacy.vue
@@ -1,0 +1,15 @@
+<template>
+  <div>
+    <slot />
+  </div>
+</template>
+
+<style>
+.box {
+  border: 3px solid red;
+}
+
+.legacy-page {
+  color: red;
+}
+</style>

--- a/test/fixtures/css-cleanup/app/pages/index.vue
+++ b/test/fixtures/css-cleanup/app/pages/index.vue
@@ -1,0 +1,13 @@
+<template>
+  <div>
+    <div class="box">
+      blue box
+    </div>
+    <NuxtLink
+      to="/other"
+      no-prefetch
+    >
+      to other
+    </NuxtLink>
+  </div>
+</template>

--- a/test/fixtures/css-cleanup/app/pages/other.vue
+++ b/test/fixtures/css-cleanup/app/pages/other.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+definePageMeta({
+  layout: 'legacy',
+})
+</script>
+
+<template>
+  <div class="legacy-page">
+    legacy page
+    <NuxtLink
+      to="/"
+      no-prefetch
+    >
+      go back
+    </NuxtLink>
+  </div>
+</template>

--- a/test/fixtures/css-cleanup/nuxt.config.ts
+++ b/test/fixtures/css-cleanup/nuxt.config.ts
@@ -1,0 +1,8 @@
+export default defineNuxtConfig({
+  features: {
+    inlineStyles: false,
+  },
+  experimental: {
+    cleanupRouteStyles: true,
+  },
+})

--- a/test/fixtures/css-cleanup/package.json
+++ b/test/fixtures/css-cleanup/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "fixture-css-cleanup",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "nuxt": "workspace:*"
+  },
+  "engines": {
+    "node": "^22.19.0 || ^24.11.0 || >=26.0.0"
+  }
+}


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #22817

## Summary

Adds an opt-in experimental option that removes stylesheets belonging to unmounted pages/layouts after client-side navigation, so global (non-scoped) styles from a previously visited route no longer leak into other routes.

### 📚 Description

- Adds `experimental.cleanupRouteStyles` (default `false`; vite builder, production builds only)
- New vite plugin emits `_nuxt/route-styles.json`, mapping layout names / route names to the CSS assets their chunk graph owns (entry CSS excluded, since it's always active)
- New client plugin manages the lifecycle of managed `<link>` stylesheets:
  - `beforeResolve`: creates (and awaits load of) any `<link>` owned by the incoming route that isn't already present, before the DOM updates — avoids a flash of unstyled content
  - `page:finish`: removes `<link>` elements owned by the outgoing route/layout that are no longer active
- Links are fully **removed and re-created**, not just toggled via `disabled`. Vite's own dynamic-import machinery only injects a chunk's stylesheet the first time it's imported, so this plugin takes over on any later visit. Removing (rather than disabling) also means the document doesn't keep accumulating one stylesheet per page/layout ever visited in a session, which was part of the original complaint in #22817 in addition to the incorrect-styles bug.
- New `css-cleanup` fixture + e2e test covering the A→B→A leak and the re-enable path (A→B→A→B), and asserting the stale `<link>` is actually removed from the DOM (not just disabled)

## Known limitations (documented on the flag)

Dev mode and webpack/rspack are untouched, `<NuxtLayout name>` prop overrides are not tracked, unnamed parent routes are left unmanaged, and inlined initial-route styles (`features.inlineStyles`) cannot be cleaned up.

## Test plan

- [x] `pnpm run typecheck` passes
- [x] `pnpm eslint` passes on changed files
- [x] Manually built the fixture and drove it with Playwright: confirmed only the active route's stylesheet is present in `<head>` at any time, the previous route's `<link>` is fully removed (not disabled) on navigation, and revisiting a route recreates its stylesheet correctly with no FOUC
- [x] New e2e test added at `test/e2e/css-cleanup.test.ts`