### PR TITLE
refactor(nuxt,schema): rename `keyedComposables` config to `keyedFunctions`

### DIFF
--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -588,3 +588,75 @@ export default defineNuxtConfig({
 })
 ```
 ::
+
+### Renamed Keyed Function Options
+
+🚦 **Impact Level**: Minimal
+
+#### What Changed
+
+The options for registering functions for automatic key injection have been renamed:
+
+- `optimization.keyedComposables` is now `optimization.keyedFunctions`
+- `optimization.keyedComposableFactories` is now `optimization.keyedFunctionFactories`
+
+The old option names have been removed and are no longer recognized.
+
+#### Reasons for Change
+
+Automatic key injection is not limited to composables. The new names align the configuration with the correct terminology to avoid confusion.
+
+#### Migration Steps
+
+Rename the options in your `nuxt.config`:
+
+```diff
+  export default defineNuxtConfig({
+    optimization: {
+-     keyedComposables: [
++     keyedFunctions: [
+        { name: 'useMyState', source: '~/composables/state', argumentLength: 2 },
+      ],
+    },
+  })
+```
+
+If you author a module that registers keyed functions at runtime, update it as well:
+
+```diff
+- nuxt.options.optimization.keyedComposables.push({
++ nuxt.options.optimization.keyedFunctions.push({
+    name: 'useMyState',
+    source: resolver.resolve('./runtime/composables/state'),
+    argumentLength: 2,
+  })
+```
+
+:read-more{to="/docs/4.x/guide/modules/recipes-basics#add-keyed-functions"}
+
+### Required `source` for Keyed Functions
+
+🚦 **Impact Level**: Minimal
+
+#### What Changed
+
+Every keyed function registered via `optimization.keyedFunctions` must now specify a `source`. Previously, `source` was optional and could also be a `RegExp`. Entries without a string `source` are no longer matched, and no key will be injected for them.
+
+#### Reasons for Change
+
+When an entry had no `source`, Nuxt fell back to matching any auto-imported function with the same name, which could match functions from unintended modules. Requiring an explicit source path makes key injection unambiguous and faster, because Nuxt no longer needs to search through all auto-imports to find a match.
+
+#### Migration Steps
+
+Add a `source` to any keyed function entries that lack one, and replace `RegExp` sources with the resolved path to the defining file. You can use Nuxt aliases (`~` or `@`) or an npm package path:
+
+```diff
+  export default defineNuxtConfig({
+    optimization: {
+      keyedFunctions: [
+-       { name: 'useMyState', argumentLength: 2 },
++       { name: 'useMyState', source: '~/composables/state', argumentLength: 2 },
+      ],
+    },
+  })
+```

--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -600,7 +600,7 @@ The options for registering functions for automatic key injection have been rena
 - `optimization.keyedComposables` is now `optimization.keyedFunctions`
 - `optimization.keyedComposableFactories` is now `optimization.keyedFunctionFactories`
 
-The old option names have been removed and are no longer recognized.
+The old option names are deprecated. They continue to work for now (entries registered with them are merged with the new options), but Nuxt logs a deprecation warning when they are used, and they will be removed in a future major version.
 
 #### Reasons for Change
 

--- a/docs/3.guide/4.modules/3.recipes-basics.md
+++ b/docs/3.guide/4.modules/3.recipes-basics.md
@@ -210,7 +210,7 @@ When a function is registered, Nuxt’s compiler automatically injects a unique 
 The injected key is a hash derived from the file path and call location.
 ::
 
-Use the `keyedComposables` option to register your function:
+Use the `keyedFunctions` option to register your function:
 
 ```ts
 import { createResolver, defineNuxtModule } from '@nuxt/kit'
@@ -219,7 +219,7 @@ export default defineNuxtModule({
   setup (options, nuxt) {
     const resolver = createResolver(import.meta.url)
 
-    nuxt.options.optimization.keyedComposables.push({
+    nuxt.options.optimization.keyedFunctions.push({
       name: 'useMyState',
       source: resolver.resolve('./runtime/composables/state'),
       argumentLength: 2,
@@ -228,7 +228,7 @@ export default defineNuxtModule({
 })
 ```
 
-The `keyedComposables` configuration accepts an array of objects with the following properties:
+The `keyedFunctions` configuration accepts an array of objects with the following properties:
 
 | Property         | Type     | Description                                                                                                                |
 |------------------|----------|----------------------------------------------------------------------------------------------------------------------------|

--- a/docs/4.api/6.nuxt-config.md
+++ b/docs/4.api/6.nuxt-config.md
@@ -1010,7 +1010,7 @@ Options passed directly to the transformer from `unctx` that preserves async con
 ]
 ```
 
-### `keyedComposables`
+### `keyedFunctions`
 
 Functions to inject a key for.
 

--- a/packages/nuxt/src/compiler/module.ts
+++ b/packages/nuxt/src/compiler/module.ts
@@ -30,9 +30,16 @@ export default defineNuxtModule<Partial<NuxtCompilerOptions>>({
     let normalizedKeyedFunctions: KeyedFunction[] = []
 
     nuxt.hook('build:before', async () => {
+      // TODO: remove the merge in Nuxt 6
+      const keyedFunctionFactories = [
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
+        ...nuxt.options.optimization.keyedComposableFactories,
+        ...nuxt.options.optimization.keyedFunctionFactories,
+      ]
+
       // Replace keyed function factory compiler macro placeholders with actual factories.
       addBuildPlugin(KeyedFunctionFactoriesPlugin({
-        factories: nuxt.options.optimization.keyedFunctionFactories,
+        factories: keyedFunctionFactories,
         alias: nuxt.options.alias,
         getAutoImports: () => unimport?.getImports() || Promise.resolve([]),
       }))
@@ -40,16 +47,23 @@ export default defineNuxtModule<Partial<NuxtCompilerOptions>>({
       // Scan user composables directories for factory-created keyed functions
       if (_options.scan) {
         const scanPlugin = KeyedFunctionFactoriesScanPlugin({
-          factories: nuxt.options.optimization.keyedFunctionFactories,
+          factories: keyedFunctionFactories,
           alias: nuxt.options.alias,
         })
         scanResult = scanPlugin.result
         await runScanPlugins([scanPlugin])
       }
 
+      // TODO: remove the merge in Nuxt 6
+      const keyedFunctions = [
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
+        ...nuxt.options.optimization.keyedComposables,
+        ...nuxt.options.optimization.keyedFunctions,
+      ]
+
       // Add keys for useFetch, useAsyncData, etc.
       // Maintained as a mutable list so HMR can add/remove entries
-      normalizedKeyedFunctions = await Promise.all(nuxt.options.optimization.keyedFunctions.map(async ({ source, ...rest }) => ({
+      normalizedKeyedFunctions = await Promise.all(keyedFunctions.map(async ({ source, ...rest }) => ({
         ...rest,
         source: await resolvePath(source, { fallbackToOriginal: true }),
       })))

--- a/packages/nuxt/src/compiler/module.ts
+++ b/packages/nuxt/src/compiler/module.ts
@@ -32,7 +32,7 @@ export default defineNuxtModule<Partial<NuxtCompilerOptions>>({
     nuxt.hook('build:before', async () => {
       // Replace keyed function factory compiler macro placeholders with actual factories.
       addBuildPlugin(KeyedFunctionFactoriesPlugin({
-        factories: nuxt.options.optimization.keyedComposableFactories,
+        factories: nuxt.options.optimization.keyedFunctionFactories,
         alias: nuxt.options.alias,
         getAutoImports: () => unimport?.getImports() || Promise.resolve([]),
       }))
@@ -40,7 +40,7 @@ export default defineNuxtModule<Partial<NuxtCompilerOptions>>({
       // Scan user composables directories for factory-created keyed functions
       if (_options.scan) {
         const scanPlugin = KeyedFunctionFactoriesScanPlugin({
-          factories: nuxt.options.optimization.keyedComposableFactories,
+          factories: nuxt.options.optimization.keyedFunctionFactories,
           alias: nuxt.options.alias,
         })
         scanResult = scanPlugin.result
@@ -49,7 +49,7 @@ export default defineNuxtModule<Partial<NuxtCompilerOptions>>({
 
       // Add keys for useFetch, useAsyncData, etc.
       // Maintained as a mutable list so HMR can add/remove entries
-      normalizedKeyedFunctions = await Promise.all(nuxt.options.optimization.keyedComposables.map(async ({ source, ...rest }) => ({
+      normalizedKeyedFunctions = await Promise.all(nuxt.options.optimization.keyedFunctions.map(async ({ source, ...rest }) => ({
         ...rest,
         source: await resolvePath(source, { fallbackToOriginal: true }),
       })))

--- a/packages/nuxt/src/compiler/plugins/keyed-function-factories.ts
+++ b/packages/nuxt/src/compiler/plugins/keyed-function-factories.ts
@@ -373,7 +373,7 @@ export const KeyedFunctionFactoriesScanPlugin = (options: KeyedFunctionFactories
     },
     afterScan: (nuxt) => {
       for (const functions of fileResults.values()) {
-        nuxt.options.optimization.keyedComposables.push(...functions)
+        nuxt.options.optimization.keyedFunctions.push(...functions)
       }
     },
   }

--- a/packages/nuxt/test/keyed-function-factories.test.ts
+++ b/packages/nuxt/test/keyed-function-factories.test.ts
@@ -19,7 +19,7 @@ function createMockNuxt (): Nuxt {
         '#app': '/nuxt/app',
       },
       optimization: {
-        keyedComposables: [],
+        keyedFunctions: [],
       },
     },
   } satisfies DeepPartial<Nuxt>) as unknown as Nuxt
@@ -80,7 +80,7 @@ describe('keyed function factories scan plugin', () => {
 
     await callScanPlugin('fetch.ts', code, mockNuxt)
 
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot(`
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot(`
       [
         {
           "argumentLength": 3,
@@ -105,7 +105,7 @@ describe('keyed function factories scan plugin', () => {
     // check that it converts to camel case from kebab case file name
     await callScanPlugin('@/composables/use-my-api.ts', code, mockNuxt)
 
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot(`
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot(`
       [
         {
           "argumentLength": 3,
@@ -124,7 +124,7 @@ describe('keyed function factories scan plugin', () => {
 
     await callScanPlugin('@/composables/use-my-api.ts', code, mockNuxt)
 
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot(`
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot(`
       [
         {
           "argumentLength": 3,
@@ -154,7 +154,7 @@ describe('keyed function factories scan plugin', () => {
 
     await callScanPlugin('fetch.ts', code, mockNuxt)
 
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot(`
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot(`
       [
         {
           "argumentLength": 3,
@@ -174,7 +174,7 @@ describe('keyed function factories scan plugin', () => {
     await callScanPlugin('file1.ts', code, mockNuxt)
     await callScanPlugin('file2.ts', code, mockNuxt)
 
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot(`
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot(`
       [
         {
           "argumentLength": 3,
@@ -198,7 +198,7 @@ describe('keyed function factories scan plugin', () => {
 
     await callScanPlugin('fetch.ts', code, mockNuxt)
 
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot('[]')
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot('[]')
   })
 
   it('should collect functions created by renamed factories ', async () => {
@@ -209,7 +209,7 @@ describe('keyed function factories scan plugin', () => {
 
     await callScanPlugin('fetch.ts', code, mockNuxt)
 
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot(`
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot(`
       [
         {
           "argumentLength": 3,
@@ -227,7 +227,7 @@ describe('keyed function factories scan plugin', () => {
 
     await callScanPlugin('fetch.ts', code, mockNuxt)
 
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot(`
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot(`
       [
         {
           "argumentLength": 3,
@@ -250,7 +250,7 @@ describe('keyed function factories scan plugin', () => {
 
     await callScanPlugin('fetch.ts', code, mockNuxt, { autoImportsToSources })
 
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot('[]')
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot('[]')
   })
 
   it('should not collect functions created by auto-imported factories when there are no auto-imports', async () => {
@@ -260,7 +260,7 @@ describe('keyed function factories scan plugin', () => {
 
     await callScanPlugin('fetch.ts', code, mockNuxt, { autoImportsToSources: new Map() })
 
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot('[]')
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot('[]')
   })
 
   it('should collect functions when factory is imported with or without an extension', async () => {
@@ -272,7 +272,7 @@ describe('keyed function factories scan plugin', () => {
     `
 
     await callScanPlugin('file.ts', code, mockNuxt)
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot(`
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot(`
       [
         {
           "argumentLength": 3,
@@ -296,7 +296,7 @@ describe('keyed function factories scan plugin', () => {
 
     await callScanPlugin('fetch.ts', code, mockNuxt)
 
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot(`
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot(`
       [
         {
           "argumentLength": 3,
@@ -313,7 +313,7 @@ describe('keyed function factories scan plugin', () => {
     export const useFetch = factories['createUseFetch']()
   `
     await callScanPlugin('fetch.ts', code, mockNuxt)
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot(`
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot(`
       [
         {
           "argumentLength": 3,
@@ -334,7 +334,7 @@ describe('keyed function factories scan plugin', () => {
     export const useFifthFetch = factories['createUseFetch']?.()
   `
     await callScanPlugin('fetch.ts', code, mockNuxt)
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot(`
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot(`
       [
         {
           "argumentLength": 3,
@@ -374,7 +374,7 @@ describe('keyed function factories scan plugin', () => {
 
     await callScanPlugin('fetch.ts', code, mockNuxt)
 
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot('[]')
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot('[]')
   })
 
   it('should collect function when accessed through one of multiple namespaces of the correct source', async () => {
@@ -387,7 +387,7 @@ describe('keyed function factories scan plugin', () => {
 
     await callScanPlugin('fetch.ts', code, mockNuxt)
 
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot(`
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot(`
       [
         {
           "argumentLength": 3,
@@ -412,7 +412,7 @@ describe('keyed function factories scan plugin', () => {
 
     await callScanPlugin('fetch.ts', code, mockNuxt)
 
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot('[]')
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot('[]')
   })
 
   it('should collect functions when factory is imported both normally and via *', async () => {
@@ -425,7 +425,7 @@ describe('keyed function factories scan plugin', () => {
 
     await callScanPlugin('fetch.ts', code, mockNuxt)
 
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot(`
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot(`
       [
         {
           "argumentLength": 3,
@@ -452,7 +452,7 @@ describe('keyed function factories scan plugin', () => {
       autoImportsToSources: new Map(),
     })
 
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot('[]')
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot('[]')
   })
 
   it('should collect functions from default export of factories accessed via a namespace', async () => {
@@ -463,7 +463,7 @@ describe('keyed function factories scan plugin', () => {
 
     await callScanPlugin('useFetch.ts', code, mockNuxt)
 
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot(`
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot(`
       [
         {
           "argumentLength": 3,
@@ -482,7 +482,7 @@ describe('keyed function factories scan plugin', () => {
     export const useFetch2 = createUseFetch()
   `
     await callScanPlugin('fetch.ts', code, mockNuxt)
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot(`[]`)
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot(`[]`)
   })
 
   it('does not collect when factory is pulled out of a namespace via destructuring', async () => {
@@ -492,7 +492,7 @@ describe('keyed function factories scan plugin', () => {
     export const useFetch = createUseFetch()
   `
     await callScanPlugin('fetch.ts', code, mockNuxt)
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot('[]')
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot('[]')
   })
 
   it('does not collect when factory is assigned to an alias variable before calling', async () => {
@@ -502,7 +502,7 @@ describe('keyed function factories scan plugin', () => {
     export const useFetch = mk()
   `
     await callScanPlugin('fetch.ts', code, mockNuxt)
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot('[]')
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot('[]')
   })
 
   it('should ignore type-only named import', async () => {
@@ -512,7 +512,7 @@ describe('keyed function factories scan plugin', () => {
     export const useFetch = createUseFetch()
   `
     await callScanPlugin('fetch.ts', code, mockNuxt)
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot(`[]`)
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot(`[]`)
   })
 
   it('should ignore type-modified specifier', async () => {
@@ -522,7 +522,7 @@ describe('keyed function factories scan plugin', () => {
     export const useFetch = createUseFetch()
   `
     await callScanPlugin('fetch.ts', code, mockNuxt)
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot(`[]`)
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot(`[]`)
   })
 
   it('should ignore type-only namespace import', async () => {
@@ -532,7 +532,7 @@ describe('keyed function factories scan plugin', () => {
     export const useFetch = factories.createUseFetch()
   `
     await callScanPlugin('fetch.ts', code, mockNuxt)
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot(`[]`)
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot(`[]`)
   })
 })
 
@@ -673,8 +673,8 @@ describe('keyed function factories scan plugin per-file tracking', () => {
 
     plugin.afterScan?.(nuxt)
 
-    expect(nuxt.options.optimization.keyedComposables).toHaveLength(2)
-    expect(nuxt.options.optimization.keyedComposables.map(k => k.name)).toEqual(['useApiFetch', 'useOtherFetch'])
+    expect(nuxt.options.optimization.keyedFunctions).toHaveLength(2)
+    expect(nuxt.options.optimization.keyedFunctions.map(k => k.name)).toEqual(['useApiFetch', 'useOtherFetch'])
   })
 })
 

--- a/packages/schema/src/config/build.ts
+++ b/packages/schema/src/config/build.ts
@@ -74,7 +74,7 @@ export default defineResolvers({
     },
   },
   optimization: {
-    keyedComposables: {
+    keyedFunctions: {
       $resolve: val => [
         { name: 'callOnce', argumentLength: 3, source: '#app/composables/once' },
         { name: 'defineNuxtComponent', argumentLength: 2, source: '#app/composables/component' },
@@ -86,7 +86,7 @@ export default defineResolvers({
         ...Array.isArray(val) ? val : [],
       ].filter(Boolean),
     },
-    keyedComposableFactories: {
+    keyedFunctionFactories: {
       $resolve: val => [
         {
           name: 'createUseFetch',

--- a/packages/schema/src/config/build.ts
+++ b/packages/schema/src/config/build.ts
@@ -1,8 +1,24 @@
 import { defu } from 'defu'
 import { join } from 'pathe'
 import type { Nuxt } from '../types/nuxt.ts'
+import type { KeyedFunction, KeyedFunctionFactory } from '../types/compiler.ts'
 import { defineResolvers } from '../utils/definition.ts'
 import { schemaDiagnostics } from '../diagnostics.ts'
+
+const KEYED_FUNCTION_DEFAULTS: KeyedFunction[] = [
+  { name: 'callOnce', argumentLength: 3, source: '#app/composables/once' },
+  { name: 'defineNuxtComponent', argumentLength: 2, source: '#app/composables/component' },
+  { name: 'useState', argumentLength: 2, source: '#app/composables/state' },
+  { name: 'useFetch', argumentLength: 3, source: '#app/composables/fetch' },
+  { name: 'useAsyncData', argumentLength: 3, source: '#app/composables/asyncData' },
+  { name: 'useLazyAsyncData', argumentLength: 3, source: '#app/composables/asyncData' },
+  { name: 'useLazyFetch', argumentLength: 3, source: '#app/composables/fetch' },
+]
+
+const KEYED_FUNCTION_FACTORY_DEFAULTS: KeyedFunctionFactory[] = [
+  { name: 'createUseFetch', source: '#app/composables/fetch', argumentLength: 3 },
+  { name: 'createUseAsyncData', source: '#app/composables/asyncData', argumentLength: 3 },
+]
 
 export default defineResolvers({
   builder: {
@@ -75,31 +91,40 @@ export default defineResolvers({
   },
   optimization: {
     keyedFunctions: {
-      $resolve: val => [
-        { name: 'callOnce', argumentLength: 3, source: '#app/composables/once' },
-        { name: 'defineNuxtComponent', argumentLength: 2, source: '#app/composables/component' },
-        { name: 'useState', argumentLength: 2, source: '#app/composables/state' },
-        { name: 'useFetch', argumentLength: 3, source: '#app/composables/fetch' },
-        { name: 'useAsyncData', argumentLength: 3, source: '#app/composables/asyncData' },
-        { name: 'useLazyAsyncData', argumentLength: 3, source: '#app/composables/asyncData' },
-        { name: 'useLazyFetch', argumentLength: 3, source: '#app/composables/fetch' },
+      $resolve: async (val, get) => [
+        ...(await get('future.compatibilityVersion')) >= 5 ? KEYED_FUNCTION_DEFAULTS : [],
         ...Array.isArray(val) ? val : [],
       ].filter(Boolean),
     },
+    keyedComposables: {
+      $resolve: async (val, get) => {
+        const isV5 = (await get('future.compatibilityVersion')) >= 5
+        if (isV5 && Array.isArray(val) && val.length > 0) {
+          schemaDiagnostics.NUXT_B5016({ option: 'optimization.keyedComposables', replacement: 'optimization.keyedFunctions' })
+        }
+        return [
+          ...isV5 ? [] : KEYED_FUNCTION_DEFAULTS,
+          ...Array.isArray(val) ? val : [],
+        ].filter(Boolean)
+      },
+    },
     keyedFunctionFactories: {
-      $resolve: val => [
-        {
-          name: 'createUseFetch',
-          source: '#app/composables/fetch',
-          argumentLength: 3,
-        },
-        {
-          name: 'createUseAsyncData',
-          source: '#app/composables/asyncData',
-          argumentLength: 3,
-        },
+      $resolve: async (val, get) => [
+        ...(await get('future.compatibilityVersion')) >= 5 ? KEYED_FUNCTION_FACTORY_DEFAULTS : [],
         ...Array.isArray(val) ? val : [],
       ].filter(Boolean),
+    },
+    keyedComposableFactories: {
+      $resolve: async (val, get) => {
+        const isV5 = (await get('future.compatibilityVersion')) >= 5
+        if (isV5 && Array.isArray(val) && val.length > 0) {
+          schemaDiagnostics.NUXT_B5016({ option: 'optimization.keyedComposableFactories', replacement: 'optimization.keyedFunctionFactories' })
+        }
+        return [
+          ...isV5 ? [] : KEYED_FUNCTION_FACTORY_DEFAULTS,
+          ...Array.isArray(val) ? val : [],
+        ].filter(Boolean)
+      },
     },
     treeShake: {
       composables: {

--- a/packages/schema/src/diagnostics.ts
+++ b/packages/schema/src/diagnostics.ts
@@ -34,5 +34,10 @@ export const schemaDiagnostics = /* #__PURE__ */ defineDiagnostics({
       fix: 'Use a known preset name, or pass a function to `postcss.order`.',
       docs: false,
     },
+    NUXT_B5016: {
+      why: (p: { option: string, replacement: string }) => `\`${p.option}\` is deprecated.`,
+      fix: (p: { option: string, replacement: string }) => `Use \`${p.replacement}\` instead.`,
+      docs: false,
+    },
   },
 })

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -514,11 +514,23 @@ export interface ConfigSchema {
      */
     keyedFunctions: KeyedFunction[]
     /**
+     * Functions to inject a key for.
+     *
+     * @deprecated Use `optimization.keyedFunctions` instead.
+     */
+    keyedComposables: KeyedFunction[]
+    /**
      * Factories for functions that should be registered for automatic key injection.
      *
      * @see keyedFunctions
      */
     keyedFunctionFactories: KeyedFunctionFactory[]
+    /**
+     * Factories for functions that should be registered for automatic key injection.
+     *
+     * @deprecated Use `optimization.keyedFunctionFactories` instead.
+     */
+    keyedComposableFactories: KeyedFunctionFactory[]
 
     /**
      * Tree shake code from specific builds.

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -512,13 +512,13 @@ export interface ConfigSchema {
      * The key will be unique based on the location of the function being invoked within the file.
      *
      */
-    keyedComposables: KeyedFunction[]
+    keyedFunctions: KeyedFunction[]
     /**
      * Factories for functions that should be registered for automatic key injection.
      *
-     * @see keyedComposables
+     * @see keyedFunctions
      */
-    keyedComposableFactories: KeyedFunctionFactory[]
+    keyedFunctionFactories: KeyedFunctionFactory[]
 
     /**
      * Tree shake code from specific builds.

--- a/packages/schema/test/optimization.spec.ts
+++ b/packages/schema/test/optimization.spec.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { applyDefaults } from 'untyped'
+
+import { NuxtConfigSchema } from '../src/index.ts'
+import type { NuxtOptions } from '../src/index.ts'
+
+describe('optimization keyed function options', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it.each([4, 5] as const)('supports both the new and the deprecated options with compatibilityVersion %i', async (compatibilityVersion) => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const result = await applyDefaults(NuxtConfigSchema, {
+      future: { compatibilityVersion },
+      optimization: {
+        keyedFunctions: [{ name: 'useCustom', source: '~/composables/custom', argumentLength: 2 }],
+        keyedComposables: [{ name: 'useLegacy', source: '~/composables/legacy', argumentLength: 2 }],
+        keyedFunctionFactories: [{ name: 'createUseCustom', source: '~/composables/custom', argumentLength: 2 }],
+        keyedComposableFactories: [{ name: 'createUseLegacy', source: '~/composables/legacy', argumentLength: 2 }],
+      },
+    }) as unknown as NuxtOptions
+
+    expect(result.optimization.keyedFunctions.map(f => f.name)).toContain('useCustom')
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    expect(result.optimization.keyedComposables.map(f => f.name)).toContain('useLegacy')
+    expect(result.optimization.keyedFunctionFactories.map(f => f.name)).toContain('createUseCustom')
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    expect(result.optimization.keyedComposableFactories.map(f => f.name)).toContain('createUseLegacy')
+  })
+
+  it('warns when the deprecated options are provided with compatibilityVersion 5', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await applyDefaults(NuxtConfigSchema, {
+      future: { compatibilityVersion: 5 },
+      optimization: {
+        keyedComposables: [{ name: 'useLegacy', source: '~/composables/legacy', argumentLength: 2 }],
+        keyedComposableFactories: [{ name: 'createUseLegacy', source: '~/composables/legacy', argumentLength: 2 }],
+      },
+    })
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('`optimization.keyedComposables` is deprecated'))
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('`optimization.keyedComposableFactories` is deprecated'))
+  })
+
+  it('does not warn about the deprecated options with compatibilityVersion 4', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await applyDefaults(NuxtConfigSchema, {
+      future: { compatibilityVersion: 4 },
+      optimization: {
+        keyedComposables: [{ name: 'useLegacy', source: '~/composables/legacy', argumentLength: 2 }],
+        keyedComposableFactories: [{ name: 'createUseLegacy', source: '~/composables/legacy', argumentLength: 2 }],
+      },
+    })
+
+    expect(warn).not.toHaveBeenCalled()
+  })
+})

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -139,7 +139,7 @@ export default withMatrix({
     ],
   },
   optimization: {
-    keyedComposables: [
+    keyedFunctions: [
       {
         name: 'useCustomKeyedComposable',
         source: '~/other-composables-folder/custom-keyed-composable',


### PR DESCRIPTION
### 📚 Description

this renames the config options `keyedComposables` and `keyedComposableFactories` to use the term "function" instead for correctness

this is one of the planned deprecations for Nuxt 5

I also documented the change from https://github.com/nuxt/nuxt/pull/35640 in the migration guide