### PR TITLE
refactor(nuxt,schema): rename `keyedComposables` config to `keyedFunctions` with compatibilityVersion 5

### DIFF
--- a/packages/nuxt/src/compiler/module.ts
+++ b/packages/nuxt/src/compiler/module.ts
@@ -30,9 +30,16 @@ export default defineNuxtModule<Partial<NuxtCompilerOptions>>({
     let normalizedKeyedFunctions: KeyedFunction[] = []
 
     nuxt.hook('build:before', async () => {
+      // TODO: remove the merge with the deprecated option in Nuxt 5
+      const keyedFunctionFactories = [
+        ...nuxt.options.optimization.keyedFunctionFactories,
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
+        ...nuxt.options.optimization.keyedComposableFactories,
+      ]
+
       // Replace keyed function factory compiler macro placeholders with actual factories.
       addBuildPlugin(KeyedFunctionFactoriesPlugin({
-        factories: nuxt.options.optimization.keyedComposableFactories,
+        factories: keyedFunctionFactories,
         alias: nuxt.options.alias,
         getAutoImports: () => unimport?.getImports() || Promise.resolve([]),
       }))
@@ -40,16 +47,23 @@ export default defineNuxtModule<Partial<NuxtCompilerOptions>>({
       // Scan user composables directories for factory-created keyed functions
       if (_options.scan) {
         const scanPlugin = KeyedFunctionFactoriesScanPlugin({
-          factories: nuxt.options.optimization.keyedComposableFactories,
+          factories: keyedFunctionFactories,
           alias: nuxt.options.alias,
         })
         scanResult = scanPlugin.result
         await runScanPlugins([scanPlugin])
       }
 
+      // TODO: remove the merge with the deprecated option in Nuxt 5
+      const keyedFunctions = [
+        ...nuxt.options.optimization.keyedFunctions,
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
+        ...nuxt.options.optimization.keyedComposables,
+      ]
+
       // Add keys for useFetch, useAsyncData, etc.
       // Maintained as a mutable list so HMR can add/remove entries
-      normalizedKeyedFunctions = await Promise.all(nuxt.options.optimization.keyedComposables.map(async ({ source, ...rest }) => ({
+      normalizedKeyedFunctions = await Promise.all(keyedFunctions.map(async ({ source, ...rest }) => ({
         ...rest,
         source: typeof source === 'string' ? await resolvePath(source, { fallbackToOriginal: true }) : source,
       })))

--- a/packages/nuxt/src/compiler/plugins/keyed-function-factories.ts
+++ b/packages/nuxt/src/compiler/plugins/keyed-function-factories.ts
@@ -373,7 +373,7 @@ export const KeyedFunctionFactoriesScanPlugin = (options: KeyedFunctionFactories
     },
     afterScan: (nuxt) => {
       for (const functions of fileResults.values()) {
-        nuxt.options.optimization.keyedComposables.push(...functions)
+        nuxt.options.optimization.keyedFunctions.push(...functions)
       }
     },
   }

--- a/packages/nuxt/test/keyed-function-factories.test.ts
+++ b/packages/nuxt/test/keyed-function-factories.test.ts
@@ -19,7 +19,7 @@ function createMockNuxt (): Nuxt {
         '#app': '/nuxt/app',
       },
       optimization: {
-        keyedComposables: [],
+        keyedFunctions: [],
       },
     },
   } satisfies DeepPartial<Nuxt>) as unknown as Nuxt
@@ -80,7 +80,7 @@ describe('keyed function factories scan plugin', () => {
 
     await callScanPlugin('fetch.ts', code, mockNuxt)
 
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot(`
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot(`
       [
         {
           "argumentLength": 3,
@@ -105,7 +105,7 @@ describe('keyed function factories scan plugin', () => {
     // check that it converts to camel case from kebab case file name
     await callScanPlugin('@/composables/use-my-api.ts', code, mockNuxt)
 
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot(`
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot(`
       [
         {
           "argumentLength": 3,
@@ -124,7 +124,7 @@ describe('keyed function factories scan plugin', () => {
 
     await callScanPlugin('@/composables/use-my-api.ts', code, mockNuxt)
 
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot(`
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot(`
       [
         {
           "argumentLength": 3,
@@ -154,7 +154,7 @@ describe('keyed function factories scan plugin', () => {
 
     await callScanPlugin('fetch.ts', code, mockNuxt)
 
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot(`
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot(`
       [
         {
           "argumentLength": 3,
@@ -174,7 +174,7 @@ describe('keyed function factories scan plugin', () => {
     await callScanPlugin('file1.ts', code, mockNuxt)
     await callScanPlugin('file2.ts', code, mockNuxt)
 
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot(`
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot(`
       [
         {
           "argumentLength": 3,
@@ -198,7 +198,7 @@ describe('keyed function factories scan plugin', () => {
 
     await callScanPlugin('fetch.ts', code, mockNuxt)
 
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot('[]')
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot('[]')
   })
 
   it('should collect functions created by renamed factories ', async () => {
@@ -209,7 +209,7 @@ describe('keyed function factories scan plugin', () => {
 
     await callScanPlugin('fetch.ts', code, mockNuxt)
 
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot(`
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot(`
       [
         {
           "argumentLength": 3,
@@ -227,7 +227,7 @@ describe('keyed function factories scan plugin', () => {
 
     await callScanPlugin('fetch.ts', code, mockNuxt)
 
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot(`
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot(`
       [
         {
           "argumentLength": 3,
@@ -250,7 +250,7 @@ describe('keyed function factories scan plugin', () => {
 
     await callScanPlugin('fetch.ts', code, mockNuxt, { autoImportsToSources })
 
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot('[]')
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot('[]')
   })
 
   it('should not collect functions created by auto-imported factories when there are no auto-imports', async () => {
@@ -260,7 +260,7 @@ describe('keyed function factories scan plugin', () => {
 
     await callScanPlugin('fetch.ts', code, mockNuxt, { autoImportsToSources: new Map() })
 
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot('[]')
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot('[]')
   })
 
   it('should collect functions when factory is imported with or without an extension', async () => {
@@ -272,7 +272,7 @@ describe('keyed function factories scan plugin', () => {
     `
 
     await callScanPlugin('file.ts', code, mockNuxt)
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot(`
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot(`
       [
         {
           "argumentLength": 3,
@@ -296,7 +296,7 @@ describe('keyed function factories scan plugin', () => {
 
     await callScanPlugin('fetch.ts', code, mockNuxt)
 
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot(`
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot(`
       [
         {
           "argumentLength": 3,
@@ -313,7 +313,7 @@ describe('keyed function factories scan plugin', () => {
     export const useFetch = factories['createUseFetch']()
   `
     await callScanPlugin('fetch.ts', code, mockNuxt)
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot(`
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot(`
       [
         {
           "argumentLength": 3,
@@ -334,7 +334,7 @@ describe('keyed function factories scan plugin', () => {
     export const useFifthFetch = factories['createUseFetch']?.()
   `
     await callScanPlugin('fetch.ts', code, mockNuxt)
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot(`
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot(`
       [
         {
           "argumentLength": 3,
@@ -374,7 +374,7 @@ describe('keyed function factories scan plugin', () => {
 
     await callScanPlugin('fetch.ts', code, mockNuxt)
 
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot('[]')
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot('[]')
   })
 
   it('should collect function when accessed through one of multiple namespaces of the correct source', async () => {
@@ -387,7 +387,7 @@ describe('keyed function factories scan plugin', () => {
 
     await callScanPlugin('fetch.ts', code, mockNuxt)
 
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot(`
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot(`
       [
         {
           "argumentLength": 3,
@@ -412,7 +412,7 @@ describe('keyed function factories scan plugin', () => {
 
     await callScanPlugin('fetch.ts', code, mockNuxt)
 
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot('[]')
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot('[]')
   })
 
   it('should collect functions when factory is imported both normally and via *', async () => {
@@ -425,7 +425,7 @@ describe('keyed function factories scan plugin', () => {
 
     await callScanPlugin('fetch.ts', code, mockNuxt)
 
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot(`
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot(`
       [
         {
           "argumentLength": 3,
@@ -452,7 +452,7 @@ describe('keyed function factories scan plugin', () => {
       autoImportsToSources: new Map(),
     })
 
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot('[]')
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot('[]')
   })
 
   it('should collect functions from default export of factories accessed via a namespace', async () => {
@@ -463,7 +463,7 @@ describe('keyed function factories scan plugin', () => {
 
     await callScanPlugin('useFetch.ts', code, mockNuxt)
 
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot(`
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot(`
       [
         {
           "argumentLength": 3,
@@ -482,7 +482,7 @@ describe('keyed function factories scan plugin', () => {
     export const useFetch2 = createUseFetch()
   `
     await callScanPlugin('fetch.ts', code, mockNuxt)
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot(`[]`)
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot(`[]`)
   })
 
   it('does not collect when factory is pulled out of a namespace via destructuring', async () => {
@@ -492,7 +492,7 @@ describe('keyed function factories scan plugin', () => {
     export const useFetch = createUseFetch()
   `
     await callScanPlugin('fetch.ts', code, mockNuxt)
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot('[]')
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot('[]')
   })
 
   it('does not collect when factory is assigned to an alias variable before calling', async () => {
@@ -502,7 +502,7 @@ describe('keyed function factories scan plugin', () => {
     export const useFetch = mk()
   `
     await callScanPlugin('fetch.ts', code, mockNuxt)
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot('[]')
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot('[]')
   })
 
   it('should ignore type-only named import', async () => {
@@ -512,7 +512,7 @@ describe('keyed function factories scan plugin', () => {
     export const useFetch = createUseFetch()
   `
     await callScanPlugin('fetch.ts', code, mockNuxt)
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot(`[]`)
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot(`[]`)
   })
 
   it('should ignore type-modified specifier', async () => {
@@ -522,7 +522,7 @@ describe('keyed function factories scan plugin', () => {
     export const useFetch = createUseFetch()
   `
     await callScanPlugin('fetch.ts', code, mockNuxt)
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot(`[]`)
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot(`[]`)
   })
 
   it('should ignore type-only namespace import', async () => {
@@ -532,7 +532,7 @@ describe('keyed function factories scan plugin', () => {
     export const useFetch = factories.createUseFetch()
   `
     await callScanPlugin('fetch.ts', code, mockNuxt)
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot(`[]`)
+    expect(mockNuxt.options.optimization.keyedFunctions).toMatchInlineSnapshot(`[]`)
   })
 })
 
@@ -673,8 +673,8 @@ describe('keyed function factories scan plugin per-file tracking', () => {
 
     plugin.afterScan?.(nuxt)
 
-    expect(nuxt.options.optimization.keyedComposables).toHaveLength(2)
-    expect(nuxt.options.optimization.keyedComposables.map(k => k.name)).toEqual(['useApiFetch', 'useOtherFetch'])
+    expect(nuxt.options.optimization.keyedFunctions).toHaveLength(2)
+    expect(nuxt.options.optimization.keyedFunctions.map(k => k.name)).toEqual(['useApiFetch', 'useOtherFetch'])
   })
 })
 

--- a/packages/schema/src/config/build.ts
+++ b/packages/schema/src/config/build.ts
@@ -4,6 +4,21 @@ import type { Nuxt } from '../types/nuxt.ts'
 import { defineResolvers } from '../utils/definition.ts'
 import { schemaDiagnostics } from '../diagnostics.ts'
 
+const KEYED_FUNCTION_DEFAULTS = [
+  { name: 'callOnce', argumentLength: 3, source: '#app/composables/once' },
+  { name: 'defineNuxtComponent', argumentLength: 2, source: '#app/composables/component' },
+  { name: 'useState', argumentLength: 2, source: '#app/composables/state' },
+  { name: 'useFetch', argumentLength: 3, source: '#app/composables/fetch' },
+  { name: 'useAsyncData', argumentLength: 3, source: '#app/composables/asyncData' },
+  { name: 'useLazyAsyncData', argumentLength: 3, source: '#app/composables/asyncData' },
+  { name: 'useLazyFetch', argumentLength: 3, source: '#app/composables/fetch' },
+]
+
+const KEYED_FUNCTION_FACTORY_DEFAULTS = [
+  { name: 'createUseFetch', source: '#app/composables/fetch', argumentLength: 3 },
+  { name: 'createUseAsyncData', source: '#app/composables/asyncData', argumentLength: 3 },
+]
+
 export default defineResolvers({
   builder: {
     $resolve: (val) => {
@@ -74,32 +89,41 @@ export default defineResolvers({
     },
   },
   optimization: {
+    keyedFunctions: {
+      $resolve: async (val, get) => [
+        ...(await get('future.compatibilityVersion')) >= 5 ? KEYED_FUNCTION_DEFAULTS : [],
+        ...Array.isArray(val) ? val : [],
+      ].filter(Boolean),
+    },
     keyedComposables: {
-      $resolve: val => [
-        { name: 'callOnce', argumentLength: 3, source: '#app/composables/once' },
-        { name: 'defineNuxtComponent', argumentLength: 2, source: '#app/composables/component' },
-        { name: 'useState', argumentLength: 2, source: '#app/composables/state' },
-        { name: 'useFetch', argumentLength: 3, source: '#app/composables/fetch' },
-        { name: 'useAsyncData', argumentLength: 3, source: '#app/composables/asyncData' },
-        { name: 'useLazyAsyncData', argumentLength: 3, source: '#app/composables/asyncData' },
-        { name: 'useLazyFetch', argumentLength: 3, source: '#app/composables/fetch' },
+      $resolve: async (val, get) => {
+        const isV5 = (await get('future.compatibilityVersion')) >= 5
+        if (isV5 && Array.isArray(val) && val.length > 0) {
+          schemaDiagnostics.NUXT_B5016({ option: 'optimization.keyedComposables', replacement: 'optimization.keyedFunctions' })
+        }
+        return [
+          ...isV5 ? [] : KEYED_FUNCTION_DEFAULTS,
+          ...Array.isArray(val) ? val : [],
+        ].filter(Boolean)
+      },
+    },
+    keyedFunctionFactories: {
+      $resolve: async (val, get) => [
+        ...(await get('future.compatibilityVersion')) >= 5 ? KEYED_FUNCTION_FACTORY_DEFAULTS : [],
         ...Array.isArray(val) ? val : [],
       ].filter(Boolean),
     },
     keyedComposableFactories: {
-      $resolve: val => [
-        {
-          name: 'createUseFetch',
-          source: '#app/composables/fetch',
-          argumentLength: 3,
-        },
-        {
-          name: 'createUseAsyncData',
-          source: '#app/composables/asyncData',
-          argumentLength: 3,
-        },
-        ...Array.isArray(val) ? val : [],
-      ].filter(Boolean),
+      $resolve: async (val, get) => {
+        const isV5 = (await get('future.compatibilityVersion')) >= 5
+        if (isV5 && Array.isArray(val) && val.length > 0) {
+          schemaDiagnostics.NUXT_B5016({ option: 'optimization.keyedComposableFactories', replacement: 'optimization.keyedFunctionFactories' })
+        }
+        return [
+          ...isV5 ? [] : KEYED_FUNCTION_FACTORY_DEFAULTS,
+          ...Array.isArray(val) ? val : [],
+        ].filter(Boolean)
+      },
     },
     treeShake: {
       composables: {

--- a/packages/schema/src/diagnostics.ts
+++ b/packages/schema/src/diagnostics.ts
@@ -34,5 +34,10 @@ export const schemaDiagnostics = /* #__PURE__ */ defineDiagnostics({
       fix: 'Use a known preset name, or pass a function to `postcss.order`.',
       docs: false,
     },
+    NUXT_B5016: {
+      why: (p: { option: string, replacement: string }) => `\`${p.option}\` is deprecated.`,
+      fix: (p: { option: string, replacement: string }) => `Use \`${p.replacement}\` instead.`,
+      docs: false,
+    },
   },
 })

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -512,11 +512,23 @@ export interface ConfigSchema {
      * The key will be unique based on the location of the function being invoked within the file.
      *
      */
+    keyedFunctions: KeyedFunction[]
+    /**
+     * Functions to inject a key for.
+     *
+     * @deprecated Use `optimization.keyedFunctions` instead.
+     */
     keyedComposables: KeyedFunction[]
     /**
      * Factories for functions that should be registered for automatic key injection.
      *
-     * @see keyedComposables
+     * @see keyedFunctions
+     */
+    keyedFunctionFactories: KeyedFunctionFactory[]
+    /**
+     * Factories for functions that should be registered for automatic key injection.
+     *
+     * @deprecated Use `optimization.keyedFunctionFactories` instead.
      */
     keyedComposableFactories: KeyedFunctionFactory[]
 

--- a/packages/schema/test/optimization.spec.ts
+++ b/packages/schema/test/optimization.spec.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { applyDefaults } from 'untyped'
+
+import { NuxtConfigSchema } from '../src/index.ts'
+import type { NuxtOptions } from '../src/index.ts'
+
+describe('optimization keyed function options', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it.each([4, 5] as const)('supports both the new and the deprecated options with compatibilityVersion %i', async (compatibilityVersion) => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const result = await applyDefaults(NuxtConfigSchema, {
+      future: { compatibilityVersion },
+      optimization: {
+        keyedFunctions: [{ name: 'useCustom', source: '~/composables/custom', argumentLength: 2 }],
+        keyedComposables: [{ name: 'useLegacy', source: '~/composables/legacy', argumentLength: 2 }],
+        keyedFunctionFactories: [{ name: 'createUseCustom', source: '~/composables/custom', argumentLength: 2 }],
+        keyedComposableFactories: [{ name: 'createUseLegacy', source: '~/composables/legacy', argumentLength: 2 }],
+      },
+    }) as unknown as NuxtOptions
+
+    expect(result.optimization.keyedFunctions.map(f => f.name)).toContain('useCustom')
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    expect(result.optimization.keyedComposables.map(f => f.name)).toContain('useLegacy')
+    expect(result.optimization.keyedFunctionFactories.map(f => f.name)).toContain('createUseCustom')
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    expect(result.optimization.keyedComposableFactories.map(f => f.name)).toContain('createUseLegacy')
+  })
+
+  it('warns when the deprecated options are provided with compatibilityVersion 5', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await applyDefaults(NuxtConfigSchema, {
+      future: { compatibilityVersion: 5 },
+      optimization: {
+        keyedComposables: [{ name: 'useLegacy', source: '~/composables/legacy', argumentLength: 2 }],
+        keyedComposableFactories: [{ name: 'createUseLegacy', source: '~/composables/legacy', argumentLength: 2 }],
+      },
+    })
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('`optimization.keyedComposables` is deprecated'))
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('`optimization.keyedComposableFactories` is deprecated'))
+  })
+
+  it('does not warn about the deprecated options with compatibilityVersion 4', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await applyDefaults(NuxtConfigSchema, {
+      future: { compatibilityVersion: 4 },
+      optimization: {
+        keyedComposables: [{ name: 'useLegacy', source: '~/composables/legacy', argumentLength: 2 }],
+        keyedComposableFactories: [{ name: 'createUseLegacy', source: '~/composables/legacy', argumentLength: 2 }],
+      },
+    })
+
+    expect(warn).not.toHaveBeenCalled()
+  })
+})

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -121,10 +121,10 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(pagesRootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs', '!node_modules'], serverDir, pagesRootDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"166k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"144k"`)
 
     const modules = await analyzeSizes(['node_modules/**/*'], serverDir, pagesRootDir)
-    expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"1565k"`)
+    expect.soft(roundToKilobytes(modules.totalBytes)).toMatchInlineSnapshot(`"1898k"`)
 
     const packages = modules.files
       .filter(m => m.endsWith('package.json'))
@@ -136,22 +136,30 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
         "@vue/compiler-core",
         "@vue/compiler-dom",
         "@vue/compiler-ssr",
+        "@vue/devtools-api",
+        "@vue/devtools-kit",
+        "@vue/devtools-kit/node_modules/hookable",
+        "@vue/devtools-shared",
         "@vue/reactivity",
         "@vue/runtime-core",
         "@vue/runtime-dom",
         "@vue/server-renderer",
         "@vue/shared",
+        "birpc",
         "devalue",
         "entities",
         "entities/dist/commonjs",
         "estree-walker",
         "hookable",
         "nostics",
+        "perfect-debounce",
         "source-map-js",
         "ufo",
         "unhead",
+        "unhead/node_modules/hookable",
         "vue",
         "vue-bundle-renderer",
+        "vue-router",
       ]
     `)
   })

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -139,7 +139,7 @@ export default withMatrix({
     ],
   },
   optimization: {
-    keyedComposables: [
+    keyedFunctions: [
       {
         name: 'useCustomKeyedComposable',
         source: '~/other-composables-folder/custom-keyed-composable',


### PR DESCRIPTION
### 📚 Description

this is a port of https://github.com/nuxt/nuxt/pull/35761 to the `v4` branch, adding the `compatibilityVersion: 5` guard for the breaking change. I've marked the existing options as `@deprecated`, which should be fine for the next minor release.

> [!WARNING]
> this is NOT to be ever merged to main; targeting `4.x`