### PR TITLE
ci: check internal docs links on pull requests and all links weekly

### DIFF
--- a/.github/workflows/docs-check-links.yml
+++ b/.github/workflows/docs-check-links.yml
@@ -9,6 +9,10 @@ on:
       - main
       - 4.x
       - 3.x
+  schedule:
+    # weekly full check of all links, including external ones
+    - cron: '0 0 * * 1'
+  workflow_dispatch:
 
 # Remove default permissions of GITHUB_TOKEN for security
 # https://docs.github.com/en/actions/tutorials/authenticate-with-github_token
@@ -17,6 +21,7 @@ permissions: {}
 jobs:
   link-checker:
     runs-on: ubuntu-24.04-arm
+    if: github.event_name != 'schedule' || github.repository == 'nuxt/nuxt'
     steps:
       # Cache lychee results (e.g. to avoid hitting rate limits)
       - name: Restore lychee cache
@@ -31,7 +36,27 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Lychee link checker
+      # on pull requests, only check internal docs links to avoid
+      # failures caused by flaky external sites
+      - name: Lychee link checker (internal links)
+        if: github.event_name == 'pull_request'
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
+        with:
+          # arguments with file types to check
+          args: >-
+            '-c=lychee.toml'
+            --exclude '^https?://'
+            --include 'https://nuxt\.com/docs'
+            './docs/**/*.md'
+            './docs/**/*.html'
+          # fail the action on broken links
+          fail: true
+        env:
+          # to be used in case rate limits are surpassed
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Lychee link checker (all links)
+        if: github.event_name != 'pull_request'
         uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
         with:
           # arguments with file types to check

--- a/docs/1.getting-started/10.data-fetching.md
+++ b/docs/1.getting-started/10.data-fetching.md
@@ -832,5 +832,3 @@ const author = computed(() => data.value?.[1])
 ```
 
 :video-accordion{title="Watch a video from Vue School on parallel data fetching" videoId="1024262536" platform="vimeo"}
-
-[broken link test](/docs/4.x/api/composables/use-fetch)

--- a/docs/1.getting-started/10.data-fetching.md
+++ b/docs/1.getting-started/10.data-fetching.md
@@ -833,4 +833,4 @@ const author = computed(() => data.value?.[1])
 
 :video-accordion{title="Watch a video from Vue School on parallel data fetching" videoId="1024262536" platform="vimeo"}
 
-[broken link test](/docs/4.x/api/composables/this-page-does-not-exist)
+[broken link test](/docs/4.x/api/composables/use-fetch)

--- a/docs/1.getting-started/10.data-fetching.md
+++ b/docs/1.getting-started/10.data-fetching.md
@@ -832,3 +832,5 @@ const author = computed(() => data.value?.[1])
 ```
 
 :video-accordion{title="Watch a video from Vue School on parallel data fetching" videoId="1024262536" platform="vimeo"}
+
+[broken link test](/docs/4.x/api/composables/this-page-does-not-exist)


### PR DESCRIPTION
### 📚 Description

I noticed that our docs link check often failed for external websites, like vue docs.
<img width="1065" height="34" alt="image" src="https://github.com/user-attachments/assets/c347d2f2-313c-4f71-a713-cf6073c0806a" />

this PR changes the action to run only on internal links in PRs, and checks the external links weekly (hoping we can resolve some issues with rate limiting)