### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/packages/nuxt/src/pages/runtime/router.options.ts
+++ b/packages/nuxt/src/pages/runtime/router.options.ts
@@ -4,6 +4,7 @@ import type { RouterConfig } from 'nuxt/schema'
 import { useNuxtApp } from '#app/nuxt'
 import { isChangingPage } from '#app/components/utils'
 import { useRouter } from '#app/composables/router'
+import { generateRouteRecordKey } from './utils'
 
 type ScrollPosition = Awaited<ReturnType<RouterScrollBehavior>>
 
@@ -32,6 +33,13 @@ export default <RouterConfig>{
 
     if (routeAllowsScrollToTop === false) { return false }
 
+    // Changing only a nested page leaves every page above it mounted, so scrolling the window
+    // would move a parent page the user never navigated away from (#31638). An explicit
+    // `scrollToTop`, a restored position or a hash target still take precedence.
+    if (routeAllowsScrollToTop !== true && !savedPosition && !to.hash && isChangingOnlyChildPage(to, from)) {
+      return false
+    }
+
     if (from === START_LOCATION) {
       return _calculatePosition(to, from, savedPosition, hashScrollBehaviour)
     }
@@ -59,6 +67,26 @@ export default <RouterConfig>{
       })
     })
   },
+}
+
+/**
+ * Return `true` if navigation only rerenders pages nested below the leaf route, leaving every
+ * page component above it mounted. This mirrors the parent-rerender check `<NuxtPage>` uses to
+ * decide whether it has to rerender (see `haveParentRoutesRendered` in `./page`).
+ */
+function isChangingOnlyChildPage (to: RouteLocationNormalized, from: RouteLocationNormalized): boolean {
+  // Parent routes without a component are transparent — vue-router renders the child directly
+  // at the parent's depth (see #34967), so they don't contribute a page render above us.
+  const toParents = to.matched.slice(0, -1).filter(m => m.components?.default)
+  const fromParents = from.matched.slice(0, -1).filter(m => m.components?.default)
+
+  if (!toParents.length || toParents.length !== fromParents.length) { return false }
+
+  return toParents.every((match, index) => {
+    const fromMatch = fromParents[index]!
+    return match.components?.default === fromMatch.components?.default &&
+      generateRouteRecordKey(to, match) === generateRouteRecordKey(from, fromMatch)
+  })
 }
 
 function _getHashElementScrollMarginTop (selector: string): number {

--- a/packages/nuxt/src/pages/runtime/utils.ts
+++ b/packages/nuxt/src/pages/runtime/utils.ts
@@ -33,6 +33,15 @@ const interpolatePath = (route: RouteLocationNormalizedLoaded, match: RouteLocat
     .replace(ROUTE_KEY_NORMAL_RE, r => (route.params as Record<string, unknown>)[r.slice(1)]?.toString() || '')
 }
 
+/**
+ * Resolve the key of a single matched route record, so a record can be compared across two
+ * route locations without needing the component rendered at its depth.
+ */
+export const generateRouteRecordKey = (route: RouteLocationNormalizedLoaded, match: RouteLocationMatched): string | false | undefined => {
+  const source = match.meta.key ?? interpolatePath(route, match)
+  return typeof source === 'function' ? source(route) : source
+}
+
 export const generateRouteKey = (routeProps: RouterViewSlotProps, override?: string | ((route: RouteLocationNormalizedLoaded) => string)): string | false | undefined => {
   const matchedRoute = routeProps.route.matched.find(m => m.components?.default === routeProps.Component.type)
   const source = override ?? matchedRoute?.meta.key ?? (matchedRoute && interpolatePath(routeProps.route, matchedRoute))

--- a/test/nuxt/router.options.test.ts
+++ b/test/nuxt/router.options.test.ts
@@ -339,6 +339,154 @@ describe('scrollBehavior with scrollToTop and fixed page key', () => {
   })
 })
 
+// https://github.com/nuxt/nuxt/issues/31638
+describe('scrollBehavior with nested pages', () => {
+  let router: ReturnType<typeof useRouter>
+  let nuxtApp: ReturnType<typeof useNuxtApp>
+
+  let wrapper: VueWrapper<unknown>
+  let scrollTo: ReturnType<typeof vi.spyOn>
+  const cleanups: Array<() => void> = []
+
+  const pageLoadingEnd = vi.fn()
+
+  const NestedChildA = defineComponent({ setup: () => () => h('div', 'Nested child A') })
+  const NestedChildB = defineComponent({ setup: () => () => h('div', [h('div', { id: 'target' }, 'Nested child B')]) })
+  const NestedDynamicChild = defineComponent({ setup: () => () => h('div', 'Nested dynamic child') })
+
+  beforeAll(async () => {
+    router = useRouter()
+    nuxtApp = useNuxtApp()
+
+    // A static parent page (`pages/nested-scroll.vue`) hosting sibling children.
+    cleanups.push(router.addRoute({
+      name: 'nested-scroll',
+      path: '/nested-scroll',
+      component: NestedPageParent,
+      children: [
+        { path: 'a', component: NestedChildA },
+        { path: 'b', component: NestedChildB },
+        { path: 'day/:day', component: NestedDynamicChild },
+        { path: 'opt-in/:id', meta: { scrollToTop: true }, component: NestedDynamicChild },
+      ],
+    }))
+
+    // A parent page that owns a route param (`pages/nested-scroll-param/[parentId].vue`),
+    // so changing that param does rerender the parent.
+    cleanups.push(router.addRoute({
+      name: 'nested-scroll-param',
+      path: '/nested-scroll-param/:parentId',
+      component: NestedPageParent,
+      children: [
+        { path: ':childId', component: NestedDynamicChild },
+      ],
+    }))
+
+    cleanups.push(nuxtApp.hook('page:loading:end', pageLoadingEnd))
+
+    // attached to the document so `scrollBehavior` can resolve hash targets via `querySelector`
+    wrapper = await mountSuspended(defineComponent({
+      setup: () => () => h(NuxtPage),
+    }), { attachTo: document.body })
+    await flushPromises()
+  })
+
+  beforeEach(async () => {
+    await navigateTo('/')
+    await flushPromises()
+    vi.clearAllMocks()
+    scrollTo = vi.spyOn(globalThis, 'scrollTo').mockImplementation(() => { })
+  })
+
+  afterAll(() => {
+    wrapper.unmount()
+    for (const cleanup of cleanups) {
+      cleanup()
+    }
+  })
+
+  // `scrollBehavior` resolves on `page:loading:end` and then defers one animation frame,
+  // so give that deferred decision a chance to run before asserting.
+  async function settleNavigation () {
+    await flushPromises()
+    await expect.poll(() => pageLoadingEnd.mock.calls.length).toBeGreaterThan(0)
+    await sleep(50)
+    await flushPromises()
+  }
+
+  async function enterRoute (path: string) {
+    await navigateTo(path)
+    await settleNavigation()
+    await expect.poll(() => scrollTo.mock.calls.length).toBeGreaterThan(0)
+    vi.clearAllMocks()
+  }
+
+  it('should not scroll to top when only the nested child page changes', async () => {
+    await enterRoute('/nested-scroll/a')
+
+    await navigateTo('/nested-scroll/b')
+    await settleNavigation()
+
+    expect(scrollTo).not.toHaveBeenCalled()
+  })
+
+  it('should not scroll to top when only a nested child param changes', async () => {
+    await enterRoute('/nested-scroll/day/monday')
+
+    await navigateTo('/nested-scroll/day/tuesday')
+    await settleNavigation()
+
+    expect(scrollTo).not.toHaveBeenCalled()
+  })
+
+  it('should scroll to top when a param owned by the parent page changes', async () => {
+    await enterRoute('/nested-scroll-param/one/a')
+
+    await navigateTo('/nested-scroll-param/two/a')
+    await settleNavigation()
+
+    expect(scrollTo).toHaveBeenCalledWith({ left: 0, top: 0 })
+  })
+
+  it('should scroll to top when navigating from a top-level page into a nested page', async () => {
+    await enterRoute('/about')
+
+    await navigateTo('/nested-scroll/a')
+    await settleNavigation()
+
+    expect(scrollTo).toHaveBeenCalledWith({ left: 0, top: 0 })
+  })
+
+  it('should scroll to top on a nested change when the child opts in with scrollToTop', async () => {
+    await enterRoute('/nested-scroll/opt-in/1')
+
+    await navigateTo('/nested-scroll/opt-in/2')
+    await settleNavigation()
+
+    expect(scrollTo).toHaveBeenCalledWith({ left: 0, top: 0 })
+  })
+
+  it('should still scroll to a hash target when only the nested page changes', async () => {
+    await enterRoute('/nested-scroll/a')
+
+    await navigateTo('/nested-scroll/b#target')
+    await settleNavigation()
+
+    // vue-router resolves `{ el }` to coordinates before scrolling; `behavior` is only set on
+    // the hash branch, so it distinguishes this from a plain scroll to top.
+    expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ behavior: 'auto' }))
+  })
+
+  it('should leave non-nested navigation behaviour unchanged', async () => {
+    await enterRoute('/about')
+
+    await navigateTo('/')
+    await settleNavigation()
+
+    expect(scrollTo).toHaveBeenCalledWith({ left: 0, top: 0 })
+  })
+})
+
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
 
 const NestedPageParent = defineComponent({


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/31638

### 📚 Description

Navigating between sibling child routes always scrolled the window to the top, even though the parent page stays mounted and only the inner `<NuxtPage>` swaps its child — so a page the user never navigated away from jumps to the top.

`scrollBehavior` had no notion of route depth: once `to.path !== from.path` and `scrollToTop` was unset, it always returned `{ left: 0, top: 0 }`.

It now skips that when every matched record above the leaf is unchanged — same component and same resolved key, so a param owned by the parent still scrolls to top. Records without a component are ignored, matching `haveParentRoutesRendered` (#34967). `savedPosition`, a hash target, and an explicit `scrollToTop: true` all still take precedence.

`generateRouteRecordKey` is added to `pages/runtime/utils.ts` so a record's key (`meta.key`, otherwise its interpolated path) can be resolved without the component rendered at that depth, reusing the existing `interpolatePath`.

Tests cover the two reported cases plus guards that pass with and without the fix: a parent-owned param change, entering a nested route from a top-level page, an explicit `scrollToTop: true` child, a hash target, and non-nested navigation.

One open question from the issue thread: @danielroe also suggested tracking the nested element and scrolling *that* to the top when the nested page has its own scrollable content. This PR implements the simpler behaviour — preserve the window scroll — which matches the issue title and "it shouldn't be necessary to scroll a parent page if only the child page is rerendering". Happy to rework it if you'd prefer the nested-element approach.

---

Disclosure: this change was implemented with AI assistance (Claude Code). Flagging it explicitly per the AI-assisted contribution guidelines, since the analysis and first draft of this description came from that session rather than solely from me.
