### PR TITLE
feat(nuxt): type `preloadComponents` and `NuxtIsland` name

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-island.ts
+++ b/packages/nuxt/src/app/components/nuxt-island.ts
@@ -5,7 +5,7 @@ import type { ActiveHeadEntry, SerializableHead } from '@unhead/vue'
 import { randomUUID } from 'uncrypto'
 import { joinURL } from 'ufo'
 
-import type { NuxtIslandResponse } from '../types'
+import type { NuxtAppLiterals, NuxtIslandResponse } from '../types'
 import { useNuxtApp } from '../nuxt'
 import { createError } from '../composables/error'
 import { prerenderRoutes, useRequestEvent } from '../composables/ssr'
@@ -48,7 +48,7 @@ async function loadComponents (source = appBaseURL, paths: NuxtIslandResponse['c
 }
 
 interface NuxtIslandProps {
-  name: string
+  name: NuxtAppLiterals['islandName']
   lazy?: boolean
   props?: Record<string, any>
   context?: Record<string, any>

--- a/packages/nuxt/src/app/composables/preload.ts
+++ b/packages/nuxt/src/app/composables/preload.ts
@@ -1,5 +1,6 @@
 import type { Component } from 'vue'
 import type { RouteLocationRaw, Router } from 'vue-router'
+import type { NuxtAppLiterals } from '../types'
 import { useNuxtApp } from '../nuxt'
 import { toArray } from '../utils'
 import { useRouter } from './router'
@@ -9,7 +10,7 @@ import { useRouter } from './router'
  * @param components Pascal-cased name or names of components to prefetch
  * @since 3.0.0
  */
-export const preloadComponents = async (components: string | string[]): Promise<void> => {
+export const preloadComponents = async (components: NuxtAppLiterals['componentName'] | Array<NuxtAppLiterals['componentName']>): Promise<void> => {
   if (import.meta.server) { return }
   const nuxtApp = useNuxtApp()
 
@@ -27,7 +28,7 @@ export const preloadComponents = async (components: string | string[]): Promise<
  * @param components Pascal-cased name or names of components to prefetch
  * @since 3.0.0
  */
-export const prefetchComponents = (components: string | string[]): Promise<void> | undefined => {
+export const prefetchComponents = (components: NuxtAppLiterals['componentName'] | Array<NuxtAppLiterals['componentName']>): Promise<void> | undefined => {
   if (import.meta.server) { return }
 
   // TODO

--- a/packages/nuxt/src/components/templates.ts
+++ b/packages/nuxt/src/components/templates.ts
@@ -1,5 +1,5 @@
 import { isAbsolute, join, relative, resolve } from 'pathe'
-import { genDynamicImport, genDynamicTypeImport, genObjectKey } from 'knitwork'
+import { genDynamicImport, genDynamicTypeImport, genObjectKey, genString } from 'knitwork'
 import { hash } from 'ohash'
 import { distDir } from '../dirs.ts'
 import type { ComponentMeta, NuxtApp, NuxtPluginTemplate, NuxtTemplate } from 'nuxt/schema'
@@ -237,6 +237,21 @@ export const componentsTypeTemplate = {
   filename: 'types/components.d.ts' as const,
   getContents: ({ app, nuxt }) => {
     const componentTypes = resolveComponentTypes(app, join(nuxt.options.buildDir, 'types'), nuxt.options.experimental.typescriptPlugin)
+    const globalComponentNames = new Set<string>()
+    const islandComponentNames = new Set<string>()
+    for (const component of app.components) {
+      if (component.global) {
+        globalComponentNames.add(component.pascalName)
+        globalComponentNames.add(`Lazy${component.pascalName}`)
+      }
+      if (nuxt.options.experimental.componentIslands && (component.island || (component.mode === 'server' && !app.components.some(c => c.pascalName === component.pascalName && c.mode === 'client')))) {
+        islandComponentNames.add(component.pascalName)
+      }
+    }
+    const literals = [
+      globalComponentNames.size ? `    componentName: ${[...globalComponentNames].map(name => genString(name)).join(' | ')}` : '',
+      islandComponentNames.size ? `    islandName: ${[...islandComponentNames].map(name => genString(name)).join(' | ')}` : '',
+    ].filter(Boolean)
     return `
 import type { DefineComponent, SlotsType } from 'vue'
 ${nuxt.options.experimental.componentIslands ? islandType : ''}
@@ -249,7 +264,15 @@ ${componentTypes.map(({ pascalName, type, meta }) => `${renderComponentJsDoc(met
 declare module 'vue' {
   export interface GlobalComponents extends _GlobalComponents { }
 }
-
+${literals.length
+      ? `
+declare module '#app' {
+  interface NuxtAppLiterals {
+${literals.join('\n')}
+  }
+}
+`
+      : ''}
 export {}
 `
   },

--- a/test/fixtures/basic-types/app/app-types.ts
+++ b/test/fixtures/basic-types/app/app-types.ts
@@ -10,9 +10,9 @@ import { defineNuxtConfig } from 'nuxt/config'
 import { callWithNuxt, isVue3 } from '#app'
 import type { NuxtError, PageMeta } from '#app'
 import type { NavigateToOptions } from '#app/composables/router'
-import { LazyWithTypes, NuxtLayout, NuxtLink, NuxtPage, ServerComponent, WithTypes } from '#components'
+import { LazyWithTypes, NuxtIsland, NuxtLayout, NuxtLink, NuxtPage, ServerComponent, WithTypes } from '#components'
 import type { IslandComponent, LazyComponent } from '#components'
-import { useRouter } from '#imports'
+import { prefetchComponents, preloadComponents, useRouter } from '#imports'
 
 type DefaultAsyncDataErrorValue = undefined
 type DefaultAsyncDataValue = undefined
@@ -544,6 +544,19 @@ describe('components', () => {
 
   it('include fallback slot in server components', () => {
     expectTypeOf(ServerComponent.slots).toEqualTypeOf<SlotsType<{ fallback: { error: unknown } }> | undefined>()
+  })
+
+  it('types preloadComponents/prefetchComponents against global component names', () => {
+    expectTypeOf(preloadComponents).parameter(0).toEqualTypeOf<'GlobalComponent' | 'LazyGlobalComponent' | Array<'GlobalComponent' | 'LazyGlobalComponent'>>()
+    expectTypeOf(prefetchComponents).parameter(0).toEqualTypeOf<'GlobalComponent' | 'LazyGlobalComponent' | Array<'GlobalComponent' | 'LazyGlobalComponent'>>()
+    // @ts-expect-error not a global component
+    void preloadComponents('WithTypes')
+  })
+
+  it('types NuxtIsland name against island component names', () => {
+    h(NuxtIsland, { name: 'ServerComponent' })
+    // @ts-expect-error not an island component
+    h(NuxtIsland, { name: 'WithTypes' })
   })
 })
 

--- a/test/fixtures/basic-types/app/components/GlobalComponent.global.vue
+++ b/test/fixtures/basic-types/app/components/GlobalComponent.global.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    Hello from global component!
+  </div>
+</template>


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

we can add some additional type safety for `preloadComponents` arguments and `NuxtIsland` props by exposing possible components + islands as a literal type 💪 