### PR TITLE
feat(nuxt): add `serialize` option to keep async data out of payload

### DIFF
--- a/docs/3.guide/6.going-further/1.experimental-features.md
+++ b/docs/3.guide/6.going-further/1.experimental-features.md
@@ -896,6 +896,20 @@ export default defineNuxtConfig({
 See PR #31373 for implementation details.
 ::
 
+## stripNeverHydratedData
+
+Apply [`serialize: false`](/docs/4.x/api/composables/use-async-data#params) by default to `useAsyncData` and `useFetch` calls made within components lazily hydrated with `hydrate-never`, keeping their data out of the `__NUXT_DATA__` payload. Since these components never hydrate on the client, their data is not needed for hydration.
+
+```ts twoslash [nuxt.config.ts]
+export default defineNuxtConfig({
+  experimental: {
+    stripNeverHydratedData: true,
+  },
+})
+```
+
+An explicit `serialize` option always takes precedence. If the same key is shared with components that do hydrate, keep the `serialize` option consistent across calls (Nuxt warns about mismatches in development).
+
 ## headNext
 
 Use head optimisations:

--- a/docs/4.api/2.composables/use-async-data.md
+++ b/docs/4.api/2.composables/use-async-data.md
@@ -167,6 +167,7 @@ type AsyncDataOptions<ResT, DataT = ResT> = {
   getCachedData?: (key: string, nuxtApp: NuxtApp, ctx: AsyncDataRequestContext) => DataT | undefined
   timeout?: number
   enabled?: MaybeRefOrGetter<boolean>
+  serialize?: boolean
 }
 
 type AsyncDataRequestContext = {
@@ -218,6 +219,7 @@ The `handler` function should be **side-effect free** to ensure predictable beha
 | `deep` :badge[v3.8]{color="info" size="xs" class="align-middle"}          | `boolean`                                   | `false`    | Return data in a deep ref object. Defaults to `false` for improved performance (shallow ref object).                                                                                                                                                                                 |
 | `dedupe` :badge[v3.9]{color="info" size="xs" class="align-middle"}        | `'cancel' \| 'defer'`                       | `'cancel'` | Policy when triggering an execution more than once at a time.                                                                                                                                                                                                                        |
 | `enabled` :badge[v4.5]{color="info" size="xs" class="align-middle"}       | `boolean`                                   | `true`     | Barrier that gates whether the `handler` may run. While `false`, every execution is blocked (initial fetch, `execute`/`refresh`, and watch triggers), and switching `true` → `false` cancels any in-flight request without clearing `data`. Re-enabling does not refetch on its own. |
+| `serialize` :badge[v4.6]{color="info" size="xs" class="align-middle"}     | `boolean`                                   | `true`     | Whether to store resolved data in the Nuxt payload (`__NUXT_DATA__`). When `false`, server-fetched data is kept out of the payload and the client will refetch after hydration if a component renders it. Pair with [lazy hydration](/docs/4.x/guide/best-practices/performance#lazy-hydration) to avoid hydration mismatches and unnecessary client fetches. |
 
 ::note
 All options can be given a `computed` or `ref` value. These will be watched and new requests made automatically with any new values if they are updated.
@@ -261,6 +263,7 @@ The following options **can differ** without triggering warnings:
 - `dedupe`
 - `watch`
 - `enabled`
+- `serialize`
 
 ```ts [app/pages/index.vue]
 // ❌ This will trigger a development warning

--- a/docs/4.api/2.composables/use-fetch.md
+++ b/docs/4.api/2.composables/use-fetch.md
@@ -170,6 +170,7 @@ type UseFetchOptions<ResT, DataT = ResT> = {
   dedupe?: 'cancel' | 'defer'
   timeout?: number
   enabled?: MaybeRefOrGetter<boolean>
+  serialize?: boolean
   default?: () => DataT | Ref<DataT>
   transform?: (input: ResT) => DataT | Promise<DataT>
   pick?: string[]
@@ -229,6 +230,7 @@ type AsyncDataRequestStatus = 'idle' | 'pending' | 'success' | 'error'
 | `deep` :badge[v3.8]{color="info" size="xs" class="align-middle"}          | `boolean`                                                               | `false`    | Return data in a deep ref object. Defaults to `false` for improved performance (shallow ref object).                                                                                                                                                                               |
 | `dedupe` :badge[v3.9]{color="info" size="xs" class="align-middle"}        | `'cancel' \| 'defer'`                                                   | `'cancel'` | Avoid fetching same key more than once at a time.                                                                                                                                                                                                                                  |
 | `enabled` :badge[v4.5]{color="info" size="xs" class="align-middle"}       | `boolean`                                                               | `true`     | Barrier that gates whether the request may run. While `false`, every execution is blocked (initial fetch, `execute`/`refresh`, and watch triggers), and switching `true` → `false` cancels any in-flight request without clearing `data`. Re-enabling does not refetch on its own. |
+| `serialize` :badge[v4.6]{color="info" size="xs" class="align-middle"}     | `boolean`                                                               | `true`     | Whether to store resolved data in the Nuxt payload (`__NUXT_DATA__`). When `false`, server-fetched data is kept out of the payload and the client will refetch after hydration if a component renders it. Pair with [lazy hydration](/docs/4.x/guide/best-practices/performance#lazy-hydration) to avoid hydration mismatches and unnecessary client fetches. |
 | `$fetch` :badge[v3.2]{color="info" size="xs" class="align-middle"}        | `typeof globalThis.$fetch`                                              | -          | Custom $fetch implementation. See [Custom useFetch in Nuxt](/docs/4.x/guide/recipes/custom-usefetch)                                                                                                                                                                               |
 
 ::note

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -13,7 +13,9 @@ import { traceAsync } from '../internal/tracing'
 import { defineKeyedFunctionFactory } from '../../compiler/runtime'
 import { dataDiagnostics } from '../diagnostics/data'
 
-import { asyncDataDefaults, granularCachedData, pendingWhenIdle, purgeCachedData, tracingChannelNuxt } from '#build/nuxt.config.mjs'
+import { neverHydratedSymbol } from './lazy-hydration'
+
+import { asyncDataDefaults, granularCachedData, pendingWhenIdle, purgeCachedData, stripNeverHydratedData, tracingChannelNuxt } from '#build/nuxt.config.mjs'
 
 export type AsyncDataRequestStatus = 'idle' | 'pending' | 'success' | 'error'
 
@@ -401,6 +403,10 @@ export const createUseAsyncData: CreateUseAsyncData = defineKeyedFunctionFactory
       opts.dedupe ??= 'cancel'
       opts.enabled ??= true
 
+      if (import.meta.server && stripNeverHydratedData && opts.serialize === undefined && getCurrentInstance() && inject(neverHydratedSymbol, false)) {
+        opts.serialize = false
+      }
+
       // assign overrides from factory
       if (shouldFactoryOptionsOverride) {
         for (const key in factoryOptions) {
@@ -417,7 +423,7 @@ export const createUseAsyncData: CreateUseAsyncData = defineKeyedFunctionFactory
         if (values.handler !== currentData._hash?.handler) {
           warnings.push(`different handler`)
         }
-        for (const opt of ['transform', 'pick', 'getCachedData'] as const) {
+        for (const opt of ['transform', 'pick', 'getCachedData', 'serialize'] as const) {
           if (values[opt] !== currentData._hash![opt]) {
             warnings.push(`different \`${opt}\` option`)
           }
@@ -992,6 +998,7 @@ function createHash (_handler: AsyncDataHandler<unknown>, options: Partial<Recor
     transform: options.transform ? hashFunction(options.transform as (...args: any[]) => any) : undefined,
     pick: options.pick ? hashKey(options.pick) : undefined,
     getCachedData: options.getCachedData ? hashFunction(options.getCachedData as (...args: any[]) => any) : undefined,
+    serialize: String(options.serialize ?? true),
   }
 }
 function mergeAbortSignals (signals: Array<AbortSignal | null | undefined>, cleanupSignal: AbortSignal, timeout?: number): AbortSignal {

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -99,6 +99,14 @@ interface BaseAsyncDataOptions<
    * @default true
    */
   enabled?: MaybeRefOrGetter<boolean>
+  /**
+   * Whether to store resolved data in the Nuxt payload (and therefore serialize it into `__NUXT_DATA__` when server-rendered).
+   * When `false`, data fetched on the server is kept out of the payload entirely and the client will refetch
+   * after hydration if a component renders it. Pair with lazy hydration (e.g. `hydrate-never`) to avoid
+   * hydration mismatches and unnecessary client fetches.
+   * @default true
+   */
+  serialize?: boolean
 }
 
 export interface AsyncDataOptions<
@@ -832,7 +840,10 @@ function buildAsyncData<
       if (granularCachedData || opts.cause === 'initial' || nuxtApp.isHydrating) {
         const cachedData = 'cachedData' in opts ? opts.cachedData : options.getCachedData!(key, nuxtApp, { cause: opts.cause ?? 'refresh:manual' })
         if (cachedData !== undefined) {
-          nuxtApp.payload.data[key] = asyncData.data.value = cachedData as DataT
+          if (options.serialize !== false) {
+            nuxtApp.payload.data[key] = cachedData
+          }
+          asyncData.data.value = cachedData as DataT
           asyncData.error.value = undefined
           asyncData.status.value = 'success'
           return Promise.resolve(cachedData)
@@ -891,7 +902,9 @@ function buildAsyncData<
             dataDiagnostics.NUXT_E3006({ fn: options._functionName || 'useAsyncData', sources: caller ? [`${caller.source}:${caller.line}:${caller.column}`] : undefined })
           }
 
-          nuxtApp.payload.data[key] = result
+          if (options.serialize !== false) {
+            nuxtApp.payload.data[key] = result
+          }
 
           asyncData.data.value = result
           asyncData.error.value = undefined

--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -309,6 +309,7 @@ export const createUseFetch: CreateUseFetch = defineKeyedFunctionFactory<CreateU
         dedupe,
         timeout,
         enabled,
+        serialize,
         ...fetchOptions
       } = {
         ...(typeof options === 'function' ? {} : factoryOptions),
@@ -342,6 +343,7 @@ export const createUseFetch: CreateUseFetch = defineKeyedFunctionFactory<CreateU
         dedupe,
         timeout,
         enabled,
+        serialize,
         watch: watchSources === false ? [] : [...(watchSources || []), _fetchOptions],
       }
 

--- a/packages/nuxt/src/app/composables/lazy-hydration.ts
+++ b/packages/nuxt/src/app/composables/lazy-hydration.ts
@@ -1,4 +1,6 @@
-import type { AsyncComponentLoader, Component, ComponentPublicInstance, DefineComponent } from 'vue'
+import type { AsyncComponentLoader, Component, ComponentPublicInstance, DefineComponent, InjectionKey } from 'vue'
+
+export const neverHydratedSymbol: InjectionKey<boolean> = Symbol.for('nuxt:never-hydrated')
 
 type LazyHydrationComponent<T extends Component, Props> = T & DefineComponent<Props, {}, {}, {}, {}, {}, {}, { hydrated: () => void }>
 

--- a/packages/nuxt/src/build-stub-nuxt-config.d.ts
+++ b/packages/nuxt/src/build-stub-nuxt-config.d.ts
@@ -45,6 +45,7 @@ export {
   anyValue as remoteComponentIslands,
   anyValue as selectiveClient,
   anyValue as spaLoadingTemplateOutside,
+  anyValue as stripNeverHydratedData,
   anyValue as tracingChannelNuxt,
   anyValue as useStateDefaults,
   anyValue as vueAppRootContainer,

--- a/packages/nuxt/src/components/runtime/lazy-hydrated-component.ts
+++ b/packages/nuxt/src/components/runtime/lazy-hydrated-component.ts
@@ -1,6 +1,7 @@
-import { defineAsyncComponent, defineComponent, h, hydrateOnIdle, hydrateOnInteraction, hydrateOnMediaQuery, hydrateOnVisible, mergeProps } from 'vue'
+import { defineAsyncComponent, defineComponent, h, hydrateOnIdle, hydrateOnInteraction, hydrateOnMediaQuery, hydrateOnVisible, mergeProps, provide } from 'vue'
 import type { AsyncComponentLoader, ComponentObjectPropsOptions, DefineSetupFnComponent, ExtractPropTypes, HydrationStrategy } from 'vue'
 import { useNuxtApp } from '#app/nuxt'
+import { neverHydratedSymbol } from '#app/composables/lazy-hydration'
 
 type LazyHydrationEmits = {
   hydrated: () => void
@@ -8,13 +9,16 @@ type LazyHydrationEmits = {
 
 type LazyComponentFactory<Props extends Record<string, any>> = (id: string, loader: AsyncComponentLoader) => DefineSetupFnComponent<Props, LazyHydrationEmits>
 
-function defineLazyComponent<P extends ComponentObjectPropsOptions, Props extends Record<string, any> = ExtractPropTypes<P>> (props: P, defineStrategy: (props: ExtractPropTypes<P>) => HydrationStrategy | undefined): LazyComponentFactory<Props> {
+function defineLazyComponent<P extends ComponentObjectPropsOptions, Props extends Record<string, any> = ExtractPropTypes<P>> (props: P, defineStrategy: (props: ExtractPropTypes<P>) => HydrationStrategy | undefined, never = false): LazyComponentFactory<Props> {
   return (id: string, loader: AsyncComponentLoader) => defineComponent({
     inheritAttrs: false,
     props,
     emits: ['hydrated'],
     setup (props, ctx) {
       if (import.meta.server) {
+        if (never) {
+          provide(neverHydratedSymbol, true)
+        }
         const nuxtApp = useNuxtApp()
         nuxtApp.hook('app:rendered', ({ ssrContext }) => {
           // track lazy hydrated components so prefetch/preload tags are not rendered for them
@@ -133,4 +137,5 @@ export const createLazyNeverComponent: LazyComponentFactory<LazyNeverProps> = de
   },
 },
 () => hydrateNever,
+true,
 )

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -635,6 +635,7 @@ export const nuxtConfigTemplate: NuxtTemplate = {
       `export const spaLoadingTemplateOutside = ${ctx.nuxt.options.experimental.spaLoadingTemplateLocation === 'body'}`,
       `export const purgeCachedData = ${!!ctx.nuxt.options.experimental.purgeCachedData}`,
       `export const granularCachedData = ${!!ctx.nuxt.options.experimental.granularCachedData}`,
+      `export const stripNeverHydratedData = ${!!ctx.nuxt.options.experimental.stripNeverHydratedData}`,
       `export const pendingWhenIdle = ${!!ctx.nuxt.options.experimental.pendingWhenIdle}`,
       `export const alwaysRunFetchOnKeyChange = ${!!ctx.nuxt.options.experimental.alwaysRunFetchOnKeyChange}`,
       `export const asyncCallHook = ${!!ctx.nuxt.options.experimental.asyncCallHook}`,

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -236,6 +236,7 @@ export default defineResolvers({
         return typeof val === 'boolean' ? val : true
       },
     },
+    stripNeverHydratedData: false,
     alwaysRunFetchOnKeyChange: {
       $resolve: (val) => {
         return typeof val === 'boolean' ? val : false

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1548,6 +1548,14 @@ export interface ConfigSchema {
     granularCachedData: boolean
 
     /**
+     * Apply `serialize: false` by default to `useAsyncData` and `useFetch` calls made within components lazily hydrated with `hydrate-never`, keeping their data out of the `__NUXT_DATA__` payload.
+     *
+     * An explicit `serialize` option always takes precedence. Note that data shared with other components via a common key follows the options of whichever call creates the shared entry first.
+     * @default false
+     */
+    stripNeverHydratedData: boolean
+
+    /**
      * Whether to run `useFetch` when the key changes, even if it is set to `immediate: false` and it has not been triggered yet.
      *
      * `useFetch` and `useAsyncData` will always run when the key changes if `immediate: true` or if it has been already triggered.

--- a/test/nuxt/dev/diagnostics.dev.test.ts
+++ b/test/nuxt/dev/diagnostics.dev.test.ts
@@ -72,6 +72,17 @@ describe('useAsyncData diagnostics (dev)', () => {
     warn.mockClear()
     count++
 
+    await mountWithAsyncData(`${uniqueKey}-${count}`, () => Promise.resolve('test'), { serialize: false })
+    expect(warn).not.toHaveBeenCalled()
+    await mountWithAsyncData(`${uniqueKey}-${count}`, () => Promise.resolve('test'))
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringMatching(
+        new RegExp(`\\[NUXT_E3004\\] Incompatible options detected for "${uniqueKey}-${count}":\n- different \`serialize\` option\n├▶ fix: You can use a different key or move the call to a composable to ensure the options are shared across calls.\n╰▶ sources: .*:\\d+:\\d+`),
+      ))
+
+    warn.mockClear()
+    count++
+
     await mountWithAsyncData(`${uniqueKey}-${count}`, () => Promise.resolve('test'))
     expect(warn).not.toHaveBeenCalled()
     await mountWithAsyncData(`${uniqueKey}-${count}`, () => Promise.resolve('bob'))

--- a/test/nuxt/use-async-data.test.ts
+++ b/test/nuxt/use-async-data.test.ts
@@ -295,6 +295,25 @@ describe('useAsyncData', () => {
     vi.useRealTimers()
   })
 
+  it('does not write resolved data to the payload with `serialize: false`', async () => {
+    const nuxtApp = useNuxtApp()
+    const { data } = await useAsyncData(uniqueKey, () => Promise.resolve('test'), { serialize: false })
+
+    expect(data.value).toBe('test')
+    expect(uniqueKey in nuxtApp.payload.data).toBe(false)
+  })
+
+  it('does not write cached data to the payload with `serialize: false`', async () => {
+    const nuxtApp = useNuxtApp()
+    const { data } = await useAsyncData(uniqueKey, () => Promise.resolve('fetched'), {
+      serialize: false,
+      getCachedData: () => 'cached',
+    })
+
+    expect(data.value).toBe('cached')
+    expect(uniqueKey in nuxtApp.payload.data).toBe(false)
+  })
+
   it('removes the key from payload.data and _asyncDataPromises on clear', async () => {
     const nuxtApp = useNuxtApp()
     await useAsyncData(uniqueKey, () => Promise.resolve('test'))

--- a/test/nuxt/use-fetch.test.ts
+++ b/test/nuxt/use-fetch.test.ts
@@ -64,6 +64,14 @@ describe('useFetch', () => {
     expect.soft(getPayloadEntries()).toBe(baseCount + 3)
   })
 
+  it('does not write resolved data to the payload with `serialize: false`', async () => {
+    const nuxtApp = useNuxtApp()
+    const { data } = await useFetch('/api/test', { key: 'serialize-false', serialize: false })
+
+    expect(data.value).toBeDefined()
+    expect('serialize-false' in nuxtApp.payload.data).toBe(false)
+  })
+
   it('should work with reactive keys', async () => {
     registerEndpoint('/api/initial', defineEventHandler(() => ({ url: '/api/initial' })))
     registerEndpoint('/api/updated', defineEventHandler(() => ({ url: '/api/updated' })))


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

another perf focused PR, similar to https://github.com/nuxt/nuxt/pull/35777, this one aims to allow users to opt-out of payload serialisation for useAsyncData/useFetch when needed (_probably_ only with lazy hydration)

you can opt-in to automatically detect and enable this feature for useAsyncData/useFetch used within a component tree of a `hydrate-never` components with:

```ts
export default defineNuxtConfig({
  experimental: {
    stripNeverHydratedData: true
  }
})
```