### PR TITLE
feat(nitro): warn in dev when noScripts routes rely on client JS

### DIFF
--- a/docs/errors/e8007.md
+++ b/docs/errors/e8007.md
@@ -1,0 +1,28 @@
+---
+title: 'NUXT_E8007'
+description: 'A route relies on client-side JavaScript but noScripts will strip scripts in production.'
+navigation: false
+---
+
+# E8007
+
+With `features.noScripts: 'production'` (the default when `noScripts` is enabled), scripts are only stripped from rendered HTML in production builds. In development the page still ships JavaScript, so behaviour that depends on it (lazy hydration strategies, `nuxt-client` components inside server components) appears to work in dev and then silently breaks after deployment.
+
+This warning is emitted during development when a rendered route uses one of these features.
+
+## Resolution
+
+Either remove the client-side dependency from the affected route, or scope script stripping to the routes that are genuinely static using the `noScripts` route rule (which applies in development too, so any breakage is visible immediately):
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  routeRules: {
+    '/static/**': { noScripts: true },
+  },
+})
+```
+
+Alternatively, set `features.noScripts: 'all'` to strip scripts in development as well, making the production behaviour observable in dev.
+
+::read-more{to="/docs/guide/going-further/features#noscripts"}
+::

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -219,6 +219,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
           `export const NUXT_NO_SSR = ${nuxt.options.ssr === false}`,
           `export const NUXT_EARLY_HINTS = ${nuxt.options.experimental.writeEarlyHints !== false}`,
           `export const NUXT_NO_SCRIPTS = ${nuxt.options.features.noScripts === 'all' || (!!nuxt.options.features.noScripts && !nuxt.options.dev)}`,
+          `export const NUXT_NO_SCRIPTS_PROD = ${nuxt.options.features.noScripts === 'production'}`,
           `export const NUXT_INLINE_STYLES = ${!!nuxt.options.features.inlineStyles}`,
           `export const PARSE_ERROR_DATA = ${!!nuxt.options.experimental.parseErrorData}`,
           `export const NUXT_ASYNC_CONTEXT = ${!!nuxt.options.experimental.asyncContext}`,

--- a/packages/nitro-server/src/runtime/diagnostics.ts
+++ b/packages/nitro-server/src/runtime/diagnostics.ts
@@ -54,5 +54,9 @@ export const serverDiagnostics = /* #__PURE__ */ defineDiagnostics({
       fix: 'Use the `pick` or `transform` options of `useAsyncData`/`useFetch` to strip out data the client does not need.',
       docs: false,
     },
+    NUXT_E8007: {
+      why: (p: { path: string, reasons: string }) => `\`${p.path}\` relies on client-side JavaScript, but \`features.noScripts: 'production'\` will strip scripts from this route in production:\n  - ${p.reasons}`,
+      fix: 'Remove the client-side dependency from this route, or scope script stripping with the `noScripts` route rule instead of enabling it globally.',
+    },
   },
 })

--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -26,8 +26,9 @@ import { patchDevClientCss } from '../utils/renderer/dev-css'
 import { renderInlineStyles } from '../utils/renderer/inline-styles'
 import { renderStreamedIslandTeleports, replaceIslandTeleports } from '../utils/renderer/islands'
 import { serverDiagnostics } from '../diagnostics'
+import { warnNoScriptsClientReliance } from '../utils/renderer/no-scripts'
 import { renderSSRHeadOptions } from '#internal/unhead.config.mjs'
-import { NUXT_ASYNC_CONTEXT, NUXT_EARLY_HINTS, NUXT_INLINE_STYLES, NUXT_NO_SCRIPTS, NUXT_PAYLOAD_EXTRACTION, NUXT_PAYLOAD_INLINE, NUXT_RUNTIME_PAYLOAD_EXTRACTION, NUXT_SSR_STREAMING, NUXT_SSR_STREAMING_BOT_RE, PARSE_ERROR_DATA } from '#internal/nuxt/nitro-config.mjs'
+import { NUXT_ASYNC_CONTEXT, NUXT_EARLY_HINTS, NUXT_INLINE_STYLES, NUXT_NO_SCRIPTS, NUXT_NO_SCRIPTS_PROD, NUXT_PAYLOAD_EXTRACTION, NUXT_PAYLOAD_INLINE, NUXT_RUNTIME_PAYLOAD_EXTRACTION, NUXT_SSR_STREAMING, NUXT_SSR_STREAMING_BOT_RE, PARSE_ERROR_DATA } from '#internal/nuxt/nitro-config.mjs'
 import { appHead, appTeleportAttrs, appTeleportTag, componentIslands, componentIslandsActive, tracingChannelNuxt } from '#internal/nuxt.config.mjs'
 import entryIds from 'nuxt/entry-ids'
 import { entryFileName } from 'nuxt/entry-chunk'
@@ -258,6 +259,10 @@ async function renderRoute (event: H3Event, ssrError?: (NuxtPayload['error'] & {
   }
 
   const NO_SCRIPTS = NUXT_NO_SCRIPTS || !!routeOptions?.noScripts
+
+  if (import.meta.dev && NUXT_NO_SCRIPTS_PROD && !NO_SCRIPTS && !ssrError) {
+    warnNoScriptsClientReliance(ssrContext, event.url.pathname)
+  }
 
   // Setup head
   const { styles, scripts } = getRequestDependencies(ssrContext, renderer.rendererContext)
@@ -787,6 +792,10 @@ async function renderStreamedResponse (ctx: {
 
         await enqueueChunk(controller, encoder.encode(closingHtml))
         controller.close()
+
+        if (import.meta.dev && NUXT_NO_SCRIPTS_PROD && !NO_SCRIPTS && !ssrError) {
+          warnNoScriptsClientReliance(ssrContext, event.url.pathname)
+        }
 
         if (committedSnapshot) {
           const currentHeaders = Array.from(event.res.headers.entries()).sort().map(([k, v]) => `${k}: ${v}`).join('\n')

--- a/packages/nitro-server/src/runtime/utils/renderer/no-scripts.ts
+++ b/packages/nitro-server/src/runtime/utils/renderer/no-scripts.ts
@@ -1,0 +1,30 @@
+import type { NuxtSSRContext } from '#app/types'
+import { serverDiagnostics } from '../../diagnostics'
+
+const SSR_CLIENT_TELEPORT_RE = /^uid=[^;]*;client=/
+
+export function detectClientScriptReliance (ssrContext: NuxtSSRContext): string[] {
+  const reasons: string[] = []
+  if (ssrContext['~lazyHydratedModules']?.size) {
+    reasons.push('it uses lazy hydration strategies, which require client-side JavaScript to hydrate')
+  }
+  if (ssrContext.teleports) {
+    for (const key in ssrContext.teleports) {
+      if (SSR_CLIENT_TELEPORT_RE.test(key)) {
+        reasons.push('it renders a server component with a `nuxt-client` child, which requires client-side JavaScript to hydrate')
+        break
+      }
+    }
+  }
+  return reasons
+}
+
+const warnedPaths = new Set<string>()
+
+export function warnNoScriptsClientReliance (ssrContext: NuxtSSRContext, path: string): void {
+  if (warnedPaths.has(path)) { return }
+  const reasons = detectClientScriptReliance(ssrContext)
+  if (!reasons.length) { return }
+  warnedPaths.add(path)
+  serverDiagnostics.NUXT_E8007({ path, reasons: reasons.join('\n  - ') })
+}

--- a/packages/nitro-server/test/no-scripts.test.ts
+++ b/packages/nitro-server/test/no-scripts.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { NuxtSSRContext } from 'nuxt/app'
+
+import { detectClientScriptReliance, warnNoScriptsClientReliance } from '../src/runtime/utils/renderer/no-scripts.ts'
+
+function ssrContext (context: Partial<NuxtSSRContext> = {}) {
+  return context as unknown as NuxtSSRContext
+}
+
+describe('detectClientScriptReliance', () => {
+  it('returns no reasons for a static render', () => {
+    expect(detectClientScriptReliance(ssrContext())).toEqual([])
+    expect(detectClientScriptReliance(ssrContext({
+      'teleports': { 'island-fallback=default': '<p>fallback</p>' },
+      '~lazyHydratedModules': new Set(),
+    }))).toEqual([])
+  })
+
+  it('detects lazy hydrated modules', () => {
+    const reasons = detectClientScriptReliance(ssrContext({ '~lazyHydratedModules': new Set(['components/Counter.vue']) }))
+    expect(reasons).toHaveLength(1)
+    expect(reasons[0]).toContain('lazy hydration')
+  })
+
+  it('detects nuxt-client components within server components', () => {
+    const reasons = detectClientScriptReliance(ssrContext({
+      teleports: { 'uid=v-0-1;client=Counter': '<p>client component</p>' },
+    }))
+    expect(reasons).toHaveLength(1)
+    expect(reasons[0]).toContain('nuxt-client')
+  })
+
+  it('collects multiple reasons', () => {
+    const reasons = detectClientScriptReliance(ssrContext({
+      'teleports': { 'uid=v-0-1;client=Counter': '<p>client component</p>' },
+      '~lazyHydratedModules': new Set(['components/Counter.vue']),
+    }))
+    expect(reasons).toHaveLength(2)
+  })
+})
+
+describe('warnNoScriptsClientReliance', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('warns once per path and stays silent without signals', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    warnNoScriptsClientReliance(ssrContext(), '/static')
+    expect(warn).not.toHaveBeenCalled()
+
+    const context = ssrContext({ '~lazyHydratedModules': new Set(['components/Counter.vue']) })
+    warnNoScriptsClientReliance(context, '/interactive')
+    expect(warn).toHaveBeenCalledOnce()
+    expect(warn.mock.calls[0]![0]).toContain('/interactive')
+    expect(warn.mock.calls[0]![0]).toContain('NUXT_E8007')
+
+    warnNoScriptsClientReliance(context, '/interactive')
+    expect(warn).toHaveBeenCalledOnce()
+  })
+})

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -105,7 +105,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(pagesRootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs'], serverDir, pagesRootDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"346k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"347k"`)
 
     const packages = getVendorPackages(await glob(['_libs/**/*'], { cwd: serverDir }))
     expect(packages).toMatchInlineSnapshot(`


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this adds another warning in dev mode - this time for use of lazy hydration + teleports, which won't work as expected.