### PR TITLE
perf(nuxt): skip payload revival plugin when `ssr: false`

### DIFF
--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -774,7 +774,6 @@ async function initNuxt (nuxt: Nuxt) {
   }
 
   // Add support for custom types in JSON payload
-  addPlugin(resolve(nuxt.options.appDir, 'plugins/revive-payload.client'))
   addPlugin(resolve(nuxt.options.appDir, 'plugins/revive-payload.server'))
 
   addRouteMiddleware({
@@ -860,6 +859,10 @@ export default defineNuxtPlugin({
   // Init nitro
   await bundleServer(nuxt)
   nuxt._perf?.startPhase('ready')
+
+  if (nuxt.options.ssr !== false) {
+    addPlugin(resolve(nuxt.options.appDir, 'plugins/revive-payload.client'))
+  }
 
   // Add prerender payload support
   if (nuxt.options.experimental.payloadExtraction) {

--- a/packages/nuxt/test/app.test.ts
+++ b/packages/nuxt/test/app.test.ts
@@ -43,6 +43,10 @@ describe('resolveApp', () => {
         "plugins": [
           {
             "mode": "client",
+            "src": "<repoRoot>/packages/nuxt/src/app/plugins/revive-payload.client.ts",
+          },
+          {
+            "mode": "client",
             "src": "<repoRoot>/packages/nuxt/src/app/plugins/navigation-repaint.client.ts",
           },
           {
@@ -52,10 +56,6 @@ describe('resolveApp', () => {
           {
             "mode": "server",
             "src": "<repoRoot>/packages/nuxt/src/app/plugins/revive-payload.server.ts",
-          },
-          {
-            "mode": "client",
-            "src": "<repoRoot>/packages/nuxt/src/app/plugins/revive-payload.client.ts",
           },
           {
             "filename": "components.plugin.mjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2014,6 +2014,12 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/nuxt
 
+  test/fixtures/spa:
+    dependencies:
+      nuxt:
+        specifier: workspace:*
+        version: link:../../../packages/nuxt
+
   test/fixtures/spa-loader:
     dependencies:
       nuxt:

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -9,11 +9,13 @@ import { join } from 'pathe'
 describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM_CI)('minimal nuxt application', () => {
   const rootDir = fileURLToPath(new URL('./fixtures/minimal', import.meta.url))
   const pagesRootDir = fileURLToPath(new URL('./fixtures/minimal-pages', import.meta.url))
+  const spaRootDir = fileURLToPath(new URL('./fixtures/spa', import.meta.url))
 
   beforeAll(async () => {
     await Promise.all([
       exec('pnpm', ['nuxt', 'build', rootDir]),
       exec('pnpm', ['nuxt', 'build', pagesRootDir]),
+      exec('pnpm', ['nuxt', 'build', spaRootDir]),
     ])
   }, 120 * 1000)
 
@@ -33,6 +35,21 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
         "_nuxt/entry.js",
       ]
     `)
+  })
+
+  it('does not ship payload revival machinery in a spa build', async () => {
+    const clientStats = await analyzeSizes(['**/*.js'], join(spaRootDir, '.output/public'), spaRootDir)
+
+    expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"101k"`)
+
+    const contents = await Promise.all(
+      (await glob(['**/*.js'], { cwd: join(spaRootDir, '.output/public') }))
+        .map(file => fsp.readFile(join(spaRootDir, '.output/public', file), 'utf8')),
+    )
+    const bundle = contents.join('\n')
+
+    expect(bundle).not.toContain('nuxt:revive-payload:client')
+    expect(bundle).not.toContain('EmptyShallowRef')
   })
 
   it('default client bundle size (pages)', async () => {

--- a/test/fixtures/spa/app.vue
+++ b/test/fixtures/spa/app.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import { componentNames } from '#components'
+
+// prevent treeshaking of #components import
+defineExpose({ componentNames })
+
+// @ts-expect-error this is not usable outside a pages directory
+definePageMeta({
+  // this should be fully tree-shaken out
+  title: 'jet common fruit chose bright planning exercise herself position wealth stiff known prepare listen leader eleven found boat dollar eye come author won thought pony biggest feel organized die vast class ask cost ball wrong chicken origin model little properly dangerous dull corner jar mighty solution pilot city locate guide gradually affect curve about snake single silly against fireplace money another involved origin sport where thin stop question go stretch although arrow rush mixture fallen power pay fifteen layers play slightly heavy built needed sing sentence diagram quarter yesterday list faster been having construction curious shoe',
+})
+</script>
+
+<template>
+  <div>Hello World!</div>
+</template>

--- a/test/fixtures/spa/error.vue
+++ b/test/fixtures/spa/error.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>Error page</div>
+</template>

--- a/test/fixtures/spa/nuxt.config.ts
+++ b/test/fixtures/spa/nuxt.config.ts
@@ -1,0 +1,31 @@
+export default defineNuxtConfig({
+  $production: {
+    vite: {
+      $client: {
+        build: {
+          rolldownOptions: {
+            output: {
+              chunkFileNames: '_nuxt/[name].js',
+              entryFileNames: '_nuxt/[name].js',
+            },
+          },
+        },
+      },
+    },
+  },
+  ssr: false,
+  pages: false,
+  devtools: { enabled: false },
+  sourcemap: false,
+  compatibilityDate: 'latest',
+  nitro: {
+    minify: true,
+  },
+  typescript: {
+    typeCheck: 'build',
+  },
+  // The bundle-size test runs under vitest, so `nuxt build` would otherwise
+  // inherit `test: true` and skip production-only stripping (e.g. diagnostics
+  // `why`/`fix` text). Force it off so we measure the real shipped bundle.
+  test: false,
+})

--- a/test/fixtures/spa/package.json
+++ b/test/fixtures/spa/package.json
@@ -1,0 +1,13 @@
+{
+  "private": true,
+  "name": "fixture-spa",
+  "scripts": {
+    "build": "nuxt build"
+  },
+  "dependencies": {
+    "nuxt": "workspace:*"
+  },
+  "engines": {
+    "node": "^22.19.0 || ^24.11.0 || >=26.0.0"
+  }
+}

--- a/test/fixtures/spa/tsconfig.json
+++ b/test/fixtures/spa/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./.nuxt/tsconfig.app.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.server.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.shared.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.node.json"
+    }
+  ]
+}


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

in spa mode, we don't need to revive a payload so we can avoid the extra client-side bytes of devalue, etc.