### PR TITLE
feat(nuxt,nitro): auto-import types from `app/types` and `server/types` directories

### DIFF
--- a/docs/2.directory-structure/1.app/1.utils.md
+++ b/docs/2.directory-structure/1.app/1.utils.md
@@ -47,3 +47,7 @@ The way `app/utils/` auto-imports work and are scanned is identical to the [`app
 These utils are only available within the Vue part of your app. :br
 Only `server/utils` are auto-imported in the [`server/`](/docs/4.x/directory-structure/server#server-utilities) directory.
 ::
+
+::tip
+Types can be auto-imported the same way. Put app-only types in `app/types/`, server-only types in [`server/types/`](/docs/4.x/directory-structure/server#server-types), and types shared between both in [`shared/types/`](/docs/4.x/directory-structure/shared).
+::

--- a/docs/2.directory-structure/1.server.md
+++ b/docs/2.directory-structure/1.server.md
@@ -166,6 +166,26 @@ Auto-imports and other types are different for the `server/` directory, as it is
 
 By default, Nuxt 4 generates a [`tsconfig.json`](/docs/4.x/directory-structure/tsconfig) which includes a project reference covering the `server/` folder which ensures accurate typings.
 
+Types placed in `~~/server/types/` are auto-imported in the server context only, so you can reference them in server routes, middleware, plugins, and utilities without importing them. Types that are also needed in the Vue app belong in [`shared/types/`](/docs/4.x/directory-structure/shared) instead.
+
+```ts twoslash [server/types/todo.ts]
+export interface Todo {
+  id: string
+  title: string
+  completed: boolean
+}
+```
+
+```ts [server/api/todos.get.ts]
+import { defineEventHandler } from 'nitro/h3'
+
+export default defineEventHandler((): Todo[] => {
+  return []
+})
+```
+
+Only files directly in `server/types/` are scanned; files in nested subdirectories are not auto-imported, matching how [`shared/types/`](/docs/4.x/directory-structure/shared#how-files-are-scanned) works.
+
 ## Recipes
 
 ### Route Parameters

--- a/docs/2.directory-structure/1.shared.md
+++ b/docs/2.directory-structure/1.shared.md
@@ -31,6 +31,8 @@ Server-only code (such as Node APIs, Nitro utilities, or server route handlers) 
 
 `import type` is erased at compile time and does not pull runtime code into the other bundle, so importing only types across the boundary may appear to work. Even so, keep shared types (such as API response types) in `shared/types/`, where they are auto-imported in both contexts. This keeps the boundary clear, avoids accidentally turning a type import into a value import later, and matches Nuxt's separate [type contexts](/docs/4.x/guide/concepts/typescript#project-references) for app, server, and shared code.
 
+Types that are only used in one context can live next to that context instead: `app/types/` is auto-imported in the Vue app only, and [`server/types/`](/docs/4.x/directory-structure/server#server-types) is auto-imported in the Nitro server only. Use `shared/types/` when a type is needed in both.
+
 :video-accordion{title="Watch a video from Vue School on sharing utils and types between app and server" videoId="nnAR-MO3q5M"}
 
 ## Usage

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -67,7 +67,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
 
   addTemplate(nitroSchemaTemplate)
 
-  const sharedDirs = new Set<string>()
+  const importDirs = new Set<string>()
   if (nuxt.options.nitro.imports !== false && nuxt.options.imports.scan !== false) {
     for (const layer of nuxt.options._layers) {
       // Layer disabled scanning for itself
@@ -75,8 +75,9 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
         continue
       }
 
-      sharedDirs.add(resolve(layer.config.rootDir, layer.config.dir?.shared ?? 'shared', 'utils'))
-      sharedDirs.add(resolve(layer.config.rootDir, layer.config.dir?.shared ?? 'shared', 'types'))
+      importDirs.add(resolve(layer.config.rootDir, layer.config.dir?.shared ?? 'shared', 'utils'))
+      importDirs.add(resolve(layer.config.rootDir, layer.config.dir?.shared ?? 'shared', 'types'))
+      importDirs.add(resolve(layer.config.serverDir ?? resolve(layer.config.rootDir, 'server'), 'types'))
     }
   }
 
@@ -163,7 +164,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
       ? false
       : {
           autoImport: nuxt.options.imports.autoImport as boolean,
-          dirs: [...sharedDirs],
+          dirs: [...importDirs],
           presets: nuxt.options.experimental.nitroAutoImports
             ? [
                 ...v2ImportsPreset,

--- a/packages/nuxt/src/imports/module.ts
+++ b/packages/nuxt/src/imports/module.ts
@@ -59,6 +59,7 @@ export default defineNuxtModule<Partial<ImportsOptions>>({
         composablesDirs.push(
           resolve(layer.config.srcDir, 'composables'),
           resolve(layer.config.srcDir, 'utils'),
+          resolve(layer.config.srcDir, 'types'),
           resolve(layer.config.rootDir, layer.config.dir?.shared ?? 'shared', 'utils'),
           resolve(layer.config.rootDir, layer.config.dir?.shared ?? 'shared', 'types'),
         )

--- a/packages/nuxt/test/shared-dir-config.test.ts
+++ b/packages/nuxt/test/shared-dir-config.test.ts
@@ -8,20 +8,36 @@ const repoRoot = await findWorkspaceDir()
 const fixtureDir = join(repoRoot, 'test/fixtures/basic')
 
 describe('loadNuxt', () => {
-  it('adds shared directories for layers to nitro auto-imports in v4', async () => {
+  it('adds shared and server type directories for layers to nitro auto-imports in v4', async () => {
     const importDirs = await getNitroImportDirs()
+    // `shared/types` is available in both contexts, `server/types` is server-only (#35763)
     expect(normalizePaths(importDirs)).toMatchInlineSnapshot(`
       [
         "<rootDir>/shared/utils",
         "<rootDir>/shared/types",
+        "<rootDir>/server/types",
         "<rootDir>/extends/bar/shared/utils",
         "<rootDir>/extends/bar/shared/types",
+        "<rootDir>/extends/bar/server/types",
         "<rootDir>/layers/bar/shared/utils",
         "<rootDir>/layers/bar/shared/types",
+        "<rootDir>/layers/bar/server/types",
         "<rootDir>/extends/node_modules/foo/shared/utils",
         "<rootDir>/extends/node_modules/foo/shared/types",
+        "<rootDir>/extends/node_modules/foo/server/types",
       ]
     `)
+  })
+
+  it('adds app and shared type directories for layers to app auto-imports, but not server-only ones (#35763)', async () => {
+    const composablesDirs = await getAppImportDirs()
+    const normalized = normalizePaths(composablesDirs)
+    // `app/types` (srcDir/types) is auto-imported in the app context
+    expect(normalized).toContain('<rootDir>/app/types')
+    // `shared/types` is available in both contexts
+    expect(normalized).toContain('<rootDir>/shared/types')
+    // `server/types` is server-only and must NOT leak into the app context
+    expect(normalized).not.toContain('<rootDir>/server/types')
   })
 })
 
@@ -51,4 +67,22 @@ async function getNitroImportDirs (overrides?: NuxtConfig) {
   })
   await nuxt.close()
   return importDirs
+}
+
+async function getAppImportDirs (overrides?: NuxtConfig) {
+  let composablesDirs: unknown[] = []
+  const nuxt = await loadNuxt({
+    cwd: fixtureDir,
+    ready: true,
+    overrides: {
+      ...overrides,
+      hooks: {
+        'imports:dirs' (dirs) {
+          composablesDirs = [...dirs]
+        },
+      },
+    },
+  })
+  await nuxt.close()
+  return composablesDirs
 }

--- a/packages/nuxt/test/shared-dir-config.test.ts
+++ b/packages/nuxt/test/shared-dir-config.test.ts
@@ -39,6 +39,13 @@ describe('loadNuxt', () => {
     // `server/types` is server-only and must NOT leak into the app context
     expect(normalized).not.toContain('<rootDir>/server/types')
   })
+
+  it('does not register server type directories when nitro auto-imports are opted out', async () => {
+    const importDirs = await getNitroImportDirs({ experimental: { nitroAutoImports: false } })
+    // `nitro.imports` is disabled entirely, so no directories (incl. `server/types`) are scanned
+    expect(normalizePaths(importDirs)).not.toContain('<rootDir>/server/types')
+    expect(importDirs).toHaveLength(0)
+  })
 })
 
 function normalizePaths (arr: unknown[]) {


### PR DESCRIPTION
### 🔗 Linked issue

Resolves: #35763 

### 📚 Description

Now types (flat) in `app/types` are auto-imported by Nuxt. Also `server/types`. This let you make a more clear structure if needed. 
The flag `experimental.nitroAutoImports === false` disables the nitro `server/types` auto-import, too.

### Tests
Added tests

### Docs
Docs are updated on three places