### PR TITLE
feat(schema): enable `typedPages` with `compatibilityVersion: 5`

### DIFF
--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -67,6 +67,7 @@ When you set your `future.compatibilityVersion` to `5`, defaults throughout your
 - **Stricter side-effect imports**: The generated `tsconfig.json` enables [`noUncheckedSideEffectImports`](/docs/4.x/getting-started/upgrade#stricter-side-effect-imports) to match the TypeScript 7 default
 - **Vue Options API disabled**: The [Options API is compiled out of the client bundle](/docs/4.x/getting-started/upgrade#vue-options-api-disabled-by-default) to reduce its size
 - **`process.*` type augmentation removed**: TypeScript no longer exposes [deprecated `process.*` flags](/docs/4.x/getting-started/upgrade#process-type-augmentation-removed) on `NodeJS.Process`
+- **Typed pages**: [`experimental.typedPages`](/docs/4.x/getting-started/upgrade#typed-pages-enabled-by-default) is enabled by default for type-checked routing
 - Other Nuxt 5 improvements and changes as they become available
 
 ::note
@@ -647,3 +648,33 @@ export default defineNuxtConfig({
 ::note
 `defineNuxtComponent` is unaffected: its `asyncData` and `head` options are handled through `setup()` rather than the Vue Options API, so it works regardless of this flag.
 ::
+
+### Typed Pages Enabled by Default
+
+🚦 **Impact Level**: Minimal
+
+#### What Changed
+
+With `compatibilityVersion: 5`, `experimental.typedPages` is enabled by default. Nuxt generates typed route names and paths from your `pages/` directory, so composables like `useRoute`, `navigateTo`, `<NuxtLink>` and `router.push` are type-checked against your actual routes.
+
+#### Reasons for Change
+
+Typed routing catches broken links and stale route names at type-check time rather than at runtime, and it is now native to `vue-router`, so it is a sensible default.
+
+#### Migration Steps
+
+If you reference routes that don't exist (for example a typo in a `to` prop, or a route defined dynamically outside the `pages/` directory), type-checking will now error. Fix the reference, or extend the generated route types for routes you add at runtime.
+
+::tip
+You can test this feature early by setting `future.compatibilityVersion: 5` (see [Testing Nuxt 5](/docs/4.x/getting-started/upgrade#testing-nuxt-5)) or by enabling it explicitly with `experimental.typedPages: true`.
+::
+
+Alternatively, you can opt out and revert to the previous behavior with:
+
+```ts twoslash [nuxt.config.ts]
+export default defineNuxtConfig({
+  experimental: {
+    typedPages: false,
+  },
+})
+```

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -131,7 +131,14 @@ export default defineResolvers({
       },
     },
     localLayerAliases: true,
-    typedPages: false,
+    typedPages: {
+      $resolve: async (val, get) => {
+        if (typeof val === 'boolean') {
+          return val
+        }
+        return (await get('future.compatibilityVersion')) >= 5
+      },
+    },
     appManifest: true,
     checkOutdatedBuildInterval: 1000 * 60 * 60,
     watcher: {

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1213,6 +1213,8 @@ export interface ConfigSchema {
     /**
      * Enable the new experimental typed router using vue-router.
      *
+     * This is enabled by default with compatibility version 5.
+     *
      * @default false
      */
     typedPages: boolean


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

typed routing is now native to `vue-router` and I think we can safely enable it by default 💪 