### PR TITLE
perf(nuxt): drop `ofetch` from the client bundle when `$fetch` is unused

### DIFF
--- a/packages/nuxt/src/app/composables/manifest.ts
+++ b/packages/nuxt/src/app/composables/manifest.ts
@@ -1,13 +1,10 @@
 import type { H3Event } from '@nuxt/nitro-server/h3'
-import type { $Fetch, NitroRouteRules } from 'nitro/types'
+import type { NitroRouteRules } from 'nitro/types'
 import { useRuntimeConfig } from '../nuxt'
 import { manifestDiagnostics } from '../diagnostics/manifest'
 import { appManifest as isAppManifestEnabled } from '#build/nuxt.config.mjs'
 import { buildAssetsURL } from '#internal/nuxt/paths'
-import { $fetch as _$fetch } from '#build/fetch'
 import _routeRulesMatcher from '#build/route-rules.mjs'
-
-const $fetch = _$fetch as $Fetch
 
 const routeRulesMatcher = _routeRulesMatcher as (path: string) => NitroRouteRules
 
@@ -30,15 +27,25 @@ function fetchManifest (): Promise<NuxtAppManifest> {
   if (import.meta.server) {
     _manifest = import(/* webpackIgnore: true */ /* @vite-ignore */ '#app-manifest') as unknown as Promise<NuxtAppManifest>
   } else {
-    _manifest = $fetch<NuxtAppManifest>(buildAssetsURL(`builds/meta/${useRuntimeConfig().app.buildId}.json`), {
-      responseType: 'json',
-    }).then((res) => {
-      // handle errors fetching manifest, e.g. from an improperly configured proxy
-      if (!res || typeof res !== 'object' || !Array.isArray((res as NuxtAppManifest).prerendered)) {
-        throw manifestDiagnostics.NUXT_E5004()
-      }
-      return res
-    })
+    // Low priority so this background warm-up does not contend with LCP-critical resources.
+    _manifest = fetch(buildAssetsURL(`builds/meta/${useRuntimeConfig().app.buildId}.json`), { priority: 'low' })
+      .then((res) => {
+        // native `fetch` resolves non-2xx responses; surface them with a `status` so callers
+        // (e.g. the outdated-build check) can distinguish a missing manifest from a bad payload
+        if (!res.ok) {
+          const error = new Error(`[nuxt] Could not fetch app manifest: ${res.status} ${res.statusText}`) as Error & { status: number }
+          error.status = res.status
+          throw error
+        }
+        return res.json()
+      })
+      .then((res: NuxtAppManifest) => {
+        // handle errors fetching manifest, e.g. from an improperly configured proxy
+        if (!res || typeof res !== 'object' || !Array.isArray(res.prerendered)) {
+          throw manifestDiagnostics.NUXT_E5004()
+        }
+        return res
+      })
   }
   manifest = _manifest
   _manifest.catch((e) => {

--- a/packages/nuxt/src/app/entry.ts
+++ b/packages/nuxt/src/app/entry.ts
@@ -1,7 +1,7 @@
 import { createApp, createSSRApp, nextTick } from 'vue'
 import type { App } from 'vue'
 
-import '#build/fetch'
+import '#build/fetch-setup'
 import '#build/global-polyfills.mjs'
 
 import { applyPlugins, createNuxtApp } from './nuxt'

--- a/packages/nuxt/src/app/plugins/check-outdated-build.client.ts
+++ b/packages/nuxt/src/app/plugins/check-outdated-build.client.ts
@@ -1,4 +1,3 @@
-import type { FetchError } from 'ofetch'
 import { defineNuxtPlugin } from '../nuxt'
 import type { ObjectPlugin, Plugin } from '../nuxt'
 import { getAppManifest } from '../composables/manifest'
@@ -6,7 +5,6 @@ import type { NuxtAppManifestMeta } from '../composables/manifest'
 import { onNuxtReady } from '../composables/ready'
 import { buildAssetsURL } from '#internal/nuxt/paths'
 import { outdatedBuildInterval } from '#build/nuxt.config.mjs'
-import { $fetch } from '#build/fetch'
 
 const plugin: Plugin & ObjectPlugin = defineNuxtPlugin((nuxtApp) => {
   if (import.meta.test) { return }
@@ -18,7 +16,7 @@ const plugin: Plugin & ObjectPlugin = defineNuxtPlugin((nuxtApp) => {
     try {
       currentManifest = await getAppManifest()
     } catch (e) {
-      const err = e as FetchError | Error
+      const err = e as { status?: number } & Error
       // The build is already outdated but the manifest was not cached
       if (!('status' in err && (err.status === 404 || err.status === 403))) {
         throw err
@@ -27,7 +25,9 @@ const plugin: Plugin & ObjectPlugin = defineNuxtPlugin((nuxtApp) => {
     if (timeout) { clearTimeout(timeout) }
     timeout = setTimeout(getLatestManifest, outdatedBuildInterval)
     try {
-      const meta = await $fetch<NuxtAppManifestMeta>(buildAssetsURL('builds/latest.json') + `?${Date.now()}`)
+      const res = await fetch(buildAssetsURL('builds/latest.json') + `?${Date.now()}`, { priority: 'low' })
+      if (!res.ok) { return }
+      const meta = await res.json() as NuxtAppManifestMeta
       if (meta.id !== currentManifest?.id) {
         // There is a newer build which we will let the user handle
         nuxtApp.hooks.callHook('app:manifest:update', meta)

--- a/packages/nuxt/src/app/plugins/revive-payload.client.ts
+++ b/packages/nuxt/src/app/plugins/revive-payload.client.ts
@@ -1,14 +1,11 @@
 import { reactive, ref, shallowReactive, shallowRef } from 'vue'
+import { joinURL, withQuery } from 'ufo'
 import { definePayloadReviver, getNuxtClientPayload } from '../composables/payload'
 import { createError } from '../composables/error'
-import { defineNuxtPlugin, useNuxtApp } from '../nuxt'
-import type { $Fetch } from 'ofetch'
+import { defineNuxtPlugin, useNuxtApp, useRuntimeConfig } from '../nuxt'
 import type { ObjectPlugin, Plugin } from '../nuxt'
 
 import { componentIslands } from '#build/nuxt.config.mjs'
-import { $fetch as _$fetch } from '#build/fetch'
-
-const $fetch = _$fetch as $Fetch
 
 function parseRevivedData (data: string) {
   try {
@@ -32,9 +29,12 @@ if (componentIslands) {
   revivers.push(['Island', ({ key, params, result }: any) => {
     const nuxtApp = useNuxtApp()
     if (!nuxtApp.isHydrating) {
-      nuxtApp.payload.data[key] ||= $fetch(`/__nuxt_island/${key}.json`, {
-        responseType: 'json',
-        ...params ? { params } : {},
+      const url = withQuery(joinURL(useRuntimeConfig().app.baseURL ?? '', `/__nuxt_island/${key}.json`), params ?? {})
+      nuxtApp.payload.data[key] ||= fetch(url).then((r) => {
+        if (!r.ok) {
+          throw createError({ status: r.status, statusText: r.statusText })
+        }
+        return r.json()
       }).then((r) => {
         nuxtApp.payload.data[key] = r
         return r

--- a/packages/nuxt/src/build-stubs.d.ts
+++ b/packages/nuxt/src/build-stubs.d.ts
@@ -26,6 +26,9 @@ declare module '#build/fetch.server.mjs' {
   const $fetch: import('nitro/types').$Fetch
   export { $fetch }
 }
+declare module '#build/fetch-setup'
+declare module '#build/fetch-setup.client.mjs'
+declare module '#build/fetch-setup.server.mjs'
 
 declare module '#build/global-polyfills.mjs'
 declare module '#build/island-renderer'

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -555,7 +555,7 @@ export const dollarFetchClientTemplate: NuxtTemplate = {
     return [
       'import { $fetch as _$fetch } from \'ofetch\'',
       'import { baseURL } from \'#internal/nuxt/paths\'',
-      'export const $fetch = /*#__PURE__*/ _$fetch.create({ baseURL: baseURL() })',
+      'export const $fetch = /*#__PURE__*/ _$fetch.create({ baseURL: /*#__PURE__*/ baseURL() })',
     ].join('\n')
   },
 }

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -555,7 +555,7 @@ export const dollarFetchClientTemplate: NuxtTemplate = {
     return [
       'import { $fetch as _$fetch } from \'ofetch\'',
       'import { baseURL } from \'#internal/nuxt/paths\'',
-      'export const $fetch = /*#__PURE__*/ _$fetch.create({ baseURL: /*#__PURE__*/ baseURL() })',
+      'export const $fetch = import.meta.test ? globalThis.$fetch || _$fetch.create({ baseURL: baseURL() }) : /*#__PURE__*/ _$fetch.create({ baseURL: /*#__PURE__*/ baseURL() })',
     ].join('\n')
   },
 }

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -555,14 +555,23 @@ export const dollarFetchClientTemplate: NuxtTemplate = {
     return [
       'import { $fetch as _$fetch } from \'ofetch\'',
       'import { baseURL } from \'#internal/nuxt/paths\'',
-      'if (!globalThis.$fetch) {',
-      '  globalThis.$fetch = _$fetch.create({',
-      '    baseURL: baseURL()',
-      '  })',
-      '}',
-      'export const $fetch = globalThis.$fetch',
+      'export const $fetch = /*#__PURE__*/ _$fetch.create({ baseURL: baseURL() })',
     ].join('\n')
   },
+}
+
+// `#build/fetch-setup` is imported for its side effects as the first import in the app entry.
+// On the server it seeds `globalThis.$fetch` before any other module evaluates. On the client
+// `$fetch` is an auto-import, so this stays empty to keep a static entry import from pulling
+// `ofetch` into bundles that never use `$fetch`.
+export const dollarFetchSetupServerTemplate: NuxtTemplate = {
+  filename: 'fetch-setup.server.mjs',
+  getContents: () => 'import \'#build/fetch\'\n',
+}
+
+export const dollarFetchSetupClientTemplate: NuxtTemplate = {
+  filename: 'fetch-setup.client.mjs',
+  getContents: () => 'export {}\n',
 }
 
 export const dollarFetchTypeTemplate: NuxtTemplate = {

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -1,5 +1,6 @@
 import { fileURLToPath } from 'node:url'
 import fsp from 'node:fs/promises'
+import { gzipSync } from 'node:zlib'
 import { beforeAll, describe, expect, it } from 'vitest'
 import { exec } from 'tinyexec'
 import { glob } from 'tinyglobby'
@@ -19,7 +20,11 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
   it('default client bundle size', async () => {
     const clientStats = await analyzeSizes(['**/*.js'], join(rootDir, '.output/public'), rootDir)
 
-    expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"120k"`)
+    expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"114k"`)
+    expect.soft(roundToKilobytes(clientStats!.gzipBytes)).toMatchInlineSnapshot(`"42.7k"`)
+
+    const entry = await fsp.readFile(join(rootDir, '.output/public', clientStats!.files.find(f => f.startsWith('_nuxt/entry'))!), 'utf8')
+    expect(entry).not.toContain('[ofetch] global.fetch is not supported')
 
     const files = clientStats!.files.map(f => f.replace(/\..*\.js/, '.js'))
 
@@ -33,7 +38,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
   it('default client bundle size (pages)', async () => {
     const clientStats = await analyzeSizes(['**/*.js'], join(pagesRootDir, '.output/public'), pagesRootDir)
 
-    expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"180k"`)
+    expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"181k"`)
 
     const files = clientStats!.files.map(f => f.replace(/\..*\.js/, '.js'))
 
@@ -127,6 +132,7 @@ async function analyzeSizes (pattern: string[], rootDir: string, projectDir: str
   const files: string[] = await glob(pattern, { cwd: rootDir })
   const stripPatterns = getStripPatterns(projectDir)
   let totalBytes = 0
+  let gzipBytes = 0
   for (const file of files) {
     const path = join(rootDir, file)
     const isSymlink = (await fsp.lstat(path).catch(() => null))?.isSymbolicLink()
@@ -138,9 +144,10 @@ async function analyzeSizes (pattern: string[], rootDir: string, projectDir: str
         normalized = normalized.replaceAll(pattern, '')
       }
       totalBytes += Buffer.byteLength(normalized)
+      gzipBytes += gzipSync(normalized).byteLength
     }
   }
-  return { files, totalBytes }
+  return { files, totalBytes, gzipBytes }
 }
 
 // Strip strings that vary by host or by build invocation but don't represent real bundle


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this is an easy win - for some minimal apps without `useFetch`, `$fetch` is genuinely unused, but we still register it with `globalThis.$fetch`.

this allows us to save about 6Kb on the client bundle of a minimal app.