### PR TITLE
perf(nuxt): add `vue.optionsApi` and disable it for v5+

### DIFF
--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -65,6 +65,7 @@ When you set your `future.compatibilityVersion` to `5`, defaults throughout your
 - **Non-async `callHook`**: [`callHook` may return `void`](/docs/4.x/getting-started/upgrade#non-async-callhook) instead of always returning a `Promise`
 - **Comment node placeholders**: Client-only components use [comment nodes instead of `<div>`](/docs/4.x/getting-started/upgrade#client-only-comment-placeholders) as SSR placeholders, fixing a scoped styles hydration issue
 - **Stricter side-effect imports**: The generated `tsconfig.json` enables [`noUncheckedSideEffectImports`](/docs/4.x/getting-started/upgrade#stricter-side-effect-imports) to match the TypeScript 7 default
+- **Vue Options API disabled**: The [Options API is compiled out of the client bundle](/docs/4.x/getting-started/upgrade#vue-options-api-disabled-by-default) to reduce its size
 - Other Nuxt 5 improvements and changes as they become available
 
 ::note
@@ -587,4 +588,32 @@ export default defineNuxtConfig({
   },
 })
 ```
+::
+
+### Vue Options API Disabled by Default
+
+🚦 **Impact Level**: Minimal
+
+#### What Changed
+
+With `compatibilityVersion: 5`, Nuxt sets Vue's [`__VUE_OPTIONS_API__`](https://vuejs.org/api/compile-time-flags#VUE_OPTIONS_API) feature flag to `false`, which compiles Vue's Options API runtime out of the client bundle.
+
+#### Reasons for Change
+
+The Options API runtime ships in every client bundle even though most Nuxt applications are written with the Composition API and `<script setup>`. Dropping it shrinks the client bundle (around 6 kB minified / 2 kB gzipped on a minimal app).
+
+#### Migration Steps
+
+If any of your components (or a dependency's components) use the Options API (`export default { data() {}, methods: {}, ... }`), re-enable it in your `nuxt.config`:
+
+```ts twoslash [nuxt.config.ts]
+export default defineNuxtConfig({
+  vue: {
+    optionsApi: true,
+  },
+})
+```
+
+::note
+`defineNuxtComponent` is unaffected: its `asyncData` and `head` options are handled through `setup()` rather than the Vue Options API, so it works regardless of this flag.
 ::

--- a/packages/schema/src/config/app.ts
+++ b/packages/schema/src/config/app.ts
@@ -21,6 +21,13 @@ export default defineResolvers({
         return typeof val === 'boolean' ? val : false
       },
     },
+    optionsApi: {
+      async $resolve (val, get) {
+        if (typeof val === 'boolean') { return val }
+        // Options API support is compiled out of the client bundle from v5 onwards.
+        return (await get('future.compatibilityVersion')) < 5
+      },
+    },
     propsDestructure: true,
 
     config: {},

--- a/packages/schema/src/config/vite.ts
+++ b/packages/schema/src/config/vite.ts
@@ -14,8 +14,9 @@ export default defineResolvers({
     },
     define: {
       $resolve: async (_val, get) => {
-        const [isDev, isTest, isDebug] = await Promise.all([get('dev'), get('test'), get('debug')])
+        const [isDev, isTest, isDebug, optionsApi] = await Promise.all([get('dev'), get('test'), get('debug'), get('vue').then(v => v.optionsApi)])
         return {
+          '__VUE_OPTIONS_API__': Boolean(optionsApi),
           '__VUE_PROD_DEVTOOLS__': false,
           '__VUE_PROD_HYDRATION_MISMATCH_DETAILS__': Boolean(isDebug && (isDebug === true || isDebug.hydration)),
           'process.dev': isDev,

--- a/packages/schema/src/config/vite.ts
+++ b/packages/schema/src/config/vite.ts
@@ -14,7 +14,8 @@ export default defineResolvers({
     },
     define: {
       $resolve: async (_val, get) => {
-        const [isDev, isTest, isDebug, optionsApi] = await Promise.all([get('dev'), get('test'), get('debug'), get('vue').then(v => v.optionsApi)])
+        const [isDev, isTest, isDebug] = await Promise.all([get('dev'), get('test'), get('debug')])
+        const optionsApi = (await get('vue')).optionsApi
         return {
           '__VUE_OPTIONS_API__': Boolean(optionsApi),
           '__VUE_PROD_DEVTOOLS__': false,

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -113,6 +113,16 @@ export interface ConfigSchema {
     runtimeCompiler: boolean
 
     /**
+     * Include support for the Vue Options API in the client bundle.
+     *
+     * Disabling this compiles out Vue's Options API runtime (via the `__VUE_OPTIONS_API__` feature
+     * flag), shrinking the client bundle for apps that only use the Composition API / `<script setup>`.
+     *
+     * Defaults to `false` when `future.compatibilityVersion` is `5` or higher, otherwise `true`.
+     */
+    optionsApi: boolean
+
+    /**
      * Enable reactive destructure for `defineProps`
      */
     propsDestructure: boolean

--- a/packages/webpack/src/presets/vue.ts
+++ b/packages/webpack/src/presets/vue.ts
@@ -43,9 +43,8 @@ export function vue (ctx: WebpackConfigContext) {
 
   // Feature flags
   // https://github.com/vuejs/core/tree/main/packages/vue#bundler-build-feature-flags
-  // TODO: Provide options to toggle
   ctx.config.plugins!.push(new webpack.DefinePlugin({
-    '__VUE_OPTIONS_API__': 'true',
+    '__VUE_OPTIONS_API__': String(ctx.nuxt.options.vue.optionsApi),
     '__VUE_PROD_DEVTOOLS__': 'false',
     '__VUE_PROD_HYDRATION_MISMATCH_DETAILS__': ctx.nuxt.options.debug && ctx.nuxt.options.debug.hydration,
   }))

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -20,8 +20,8 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
   it('default client bundle size', async () => {
     const clientStats = await analyzeSizes(['**/*.js'], join(rootDir, '.output/public'), rootDir)
 
-    expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"114k"`)
-    expect.soft(roundToKilobytes(clientStats!.gzipBytes)).toMatchInlineSnapshot(`"42.7k"`)
+    expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"108k"`)
+    expect.soft(roundToKilobytes(clientStats!.gzipBytes)).toMatchInlineSnapshot(`"40.1k"`)
 
     const entry = await fsp.readFile(join(rootDir, '.output/public', clientStats!.files.find(f => f.startsWith('_nuxt/entry'))!), 'utf8')
     expect(entry).not.toContain('[ofetch] global.fetch is not supported')
@@ -38,7 +38,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
   it('default client bundle size (pages)', async () => {
     const clientStats = await analyzeSizes(['**/*.js'], join(pagesRootDir, '.output/public'), pagesRootDir)
 
-    expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"181k"`)
+    expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"177k"`)
 
     const files = clientStats!.files.map(f => f.replace(/\..*\.js/, '.js'))
 

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -113,6 +113,7 @@ export default withMatrix({
   },
   css: ['~/assets/global.css'],
   vue: {
+    optionsApi: true,
     compilerOptions: {
       isCustomElement: (tag) => {
         return tag === 'custom-component'

--- a/test/fixtures/runtime-compiler/nuxt.config.ts
+++ b/test/fixtures/runtime-compiler/nuxt.config.ts
@@ -12,6 +12,7 @@ export default withMatrix({
   },
   vue: {
     runtimeCompiler: true,
+    optionsApi: true,
   },
   experimental: {
     nitroAutoImports: true,


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

as most users of Nuxt are probably using `<script setup>` rather than the Options API, this disables Options API use by default.

it's straightforward to re-enable if you are using it, and it saves ~6/7kB for people who aren't:

```ts
export default defineNuxtConfig({
  vue: {
    optionsApi: true
  }
})
```