### PR TITLE
fix(nuxt): warn when an imports preset `from` cannot be resolved

### DIFF
--- a/packages/kit/src/diagnostics/head.ts
+++ b/packages/kit/src/diagnostics/head.ts
@@ -31,5 +31,10 @@ export const headDiagnostics = /* #__PURE__ */ defineDiagnostics({
       fix: 'Remove `experimental.headNext` from your `nuxt.config`, or set `unhead.legacy: true` to opt out temporarily.',
       docs: false,
     },
+    NUXT_B6005: {
+      why: (p: { name: string, from: string }) => `Could not resolve \`${p.from}\` used by the auto-import \`${p.name}\`.`,
+      fix: 'Check the `from` path in `imports.presets` (or the module that registered this import). Auto-imports from an unresolvable module are silently skipped and can surface as unrelated type errors elsewhere.',
+      docs: false,
+    },
   },
 })

--- a/packages/nuxt/src/imports/module.ts
+++ b/packages/nuxt/src/imports/module.ts
@@ -208,6 +208,8 @@ function addDeclarationTemplates (ctx: Pick<Unimport, 'getImports' | 'generateTy
   const resolvedImportPathMap = new Map<string, string>()
   const r = (i: Import) => resolvedImportPathMap.get(i.typeFrom || i.from)
 
+  const warnedUnresolvedSources = new Set<string>()
+
   const SUPPORTED_EXTENSION_RE = new RegExp(`\\.(?:${nuxt.options.extensions.map(i => i.replace('.', '')).join('|')})$`)
 
   async function cacheImportPaths (imports: Import[]) {
@@ -217,6 +219,13 @@ function addDeclarationTemplates (ctx: Pick<Unimport, 'getImports' | 'generateTy
     const aliasedPaths = new Map(importSource.map(from => [from, resolveAlias(from)] as const))
     const bareSpecifiers = importSource.filter(from => !isAbsolute(aliasedPaths.get(from)!))
     const resolved = new Map(await resolveTypePaths(bareSpecifiers, nuxt.options.modulesDir))
+
+    for (const from of bareSpecifiers) {
+      if (resolved.has(from) || warnedUnresolvedSources.has(from)) { continue }
+      warnedUnresolvedSources.add(from)
+      const name = imports.find(i => (i.typeFrom || i.from) === from)
+      headDiagnostics.NUXT_B6005({ name: name ? (name.as || name.name) : from, from })
+    }
 
     await Promise.all(importSource.map(async (from) => {
       let path = aliasedPaths.get(from)!

--- a/packages/nuxt/src/imports/module.ts
+++ b/packages/nuxt/src/imports/module.ts
@@ -4,6 +4,7 @@ import { isAbsolute, join, normalize, relative, resolve } from 'pathe'
 import type { Import, InlinePreset, Unimport } from 'unimport'
 import { createUnimport, scanDirExports, toExports, toTypeDeclarationFile, toTypeReExports } from 'unimport'
 import escapeRE from 'escape-string-regexp'
+import { resolveModulePath } from 'exsolve'
 
 import { isDirectory, logger, resolveToAlias } from '../utils.ts'
 import { TransformPlugin } from './transform.ts'
@@ -220,8 +221,13 @@ function addDeclarationTemplates (ctx: Pick<Unimport, 'getImports' | 'generateTy
     const bareSpecifiers = importSource.filter(from => !isAbsolute(aliasedPaths.get(from)!))
     const resolved = new Map(await resolveTypePaths(bareSpecifiers, nuxt.options.modulesDir))
 
-    for (const from of bareSpecifiers) {
-      if (resolved.has(from) || warnedUnresolvedSources.has(from)) { continue }
+    for (const from of importSource) {
+      if (warnedUnresolvedSources.has(from)) { continue }
+      const aliased = aliasedPaths.get(from)!
+      if (isAbsolute(aliased)) {
+        const isInBuildDir = !relative(nuxt.options.buildDir, aliased).startsWith('..')
+        if (isInBuildDir || resolveModulePath(aliased, { try: true, extensions: nuxt.options.extensions, suffixes: ['', '/index'] })) { continue }
+      } else if (resolved.has(from)) { continue }
       warnedUnresolvedSources.add(from)
       const name = imports.find(i => (i.typeFrom || i.from) === from)
       headDiagnostics.NUXT_B6005({ name: name ? (name.as || name.name) : from, from })

--- a/packages/nuxt/test/imports-preset-fixture/app/app.vue
+++ b/packages/nuxt/test/imports-preset-fixture/app/app.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>hi</div>
+</template>

--- a/packages/nuxt/test/imports-preset-fixture/app/utils/existing.ts
+++ b/packages/nuxt/test/imports-preset-fixture/app/utils/existing.ts
@@ -1,0 +1,3 @@
+export function existingUtil () {
+  return true
+}

--- a/packages/nuxt/test/imports-preset-fixture/nuxt.config.ts
+++ b/packages/nuxt/test/imports-preset-fixture/nuxt.config.ts
@@ -1,0 +1,11 @@
+export default defineNuxtConfig({
+  imports: {
+    presets: [
+      {
+        from: 'nuxt/dist/composables/router',
+        imports: ['NavigateToOptions'],
+        type: true,
+      },
+    ],
+  },
+})

--- a/packages/nuxt/test/imports-preset-fixture/nuxt.config.ts
+++ b/packages/nuxt/test/imports-preset-fixture/nuxt.config.ts
@@ -6,6 +6,14 @@ export default defineNuxtConfig({
         imports: ['NavigateToOptions'],
         type: true,
       },
+      {
+        from: '~/utils/missing',
+        imports: ['missingUtil'],
+      },
+      {
+        from: '~/utils/existing',
+        imports: ['existingUtil'],
+      },
     ],
   },
 })

--- a/packages/nuxt/test/imports-preset-resolution.test.ts
+++ b/packages/nuxt/test/imports-preset-resolution.test.ts
@@ -1,13 +1,14 @@
 import { fileURLToPath } from 'node:url'
 import { normalize } from 'pathe'
 import { withoutTrailingSlash } from 'ufo'
+import type { MockInstance } from 'vitest'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { buildNuxt } from '@nuxt/kit'
 import { loadNuxt } from '../src/index.ts'
 
 const fixtureDir = withoutTrailingSlash(normalize(fileURLToPath(new URL('./imports-preset-fixture', import.meta.url))))
 
-let warn: ReturnType<typeof vi.spyOn>
+let warn: MockInstance<typeof console.warn>
 
 beforeEach(() => {
   warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
@@ -37,5 +38,7 @@ describe('imports preset resolution', () => {
 
     const messages = warn.mock.calls.map(call => call.join(' '))
     expect(messages.some(message => message.includes('NUXT_B6005') && message.includes('nuxt/dist/composables/router'))).toBe(true)
+    expect(messages.some(message => message.includes('NUXT_B6005') && message.includes('utils/missing'))).toBe(true)
+    expect(messages.some(message => message.includes('utils/existing'))).toBe(false)
   })
 })

--- a/packages/nuxt/test/imports-preset-resolution.test.ts
+++ b/packages/nuxt/test/imports-preset-resolution.test.ts
@@ -1,16 +1,20 @@
 import { fileURLToPath } from 'node:url'
 import { normalize } from 'pathe'
 import { withoutTrailingSlash } from 'ufo'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { buildNuxt } from '@nuxt/kit'
 import { loadNuxt } from '../src/index.ts'
 
 const fixtureDir = withoutTrailingSlash(normalize(fileURLToPath(new URL('./imports-preset-fixture', import.meta.url))))
 
-const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+let warn: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
 
 afterEach(() => {
-  warn.mockClear()
+  warn.mockRestore()
 })
 
 describe('imports preset resolution', () => {

--- a/packages/nuxt/test/imports-preset-resolution.test.ts
+++ b/packages/nuxt/test/imports-preset-resolution.test.ts
@@ -1,0 +1,37 @@
+import { fileURLToPath } from 'node:url'
+import { normalize } from 'pathe'
+import { withoutTrailingSlash } from 'ufo'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { buildNuxt } from '@nuxt/kit'
+import { loadNuxt } from '../src/index.ts'
+
+const fixtureDir = withoutTrailingSlash(normalize(fileURLToPath(new URL('./imports-preset-fixture', import.meta.url))))
+
+const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+afterEach(() => {
+  warn.mockClear()
+})
+
+describe('imports preset resolution', () => {
+  it('warns when a preset `from` cannot be resolved', async () => {
+    const nuxt = await loadNuxt({
+      cwd: fixtureDir,
+      ready: true,
+      overrides: {
+        builder: {
+          bundle: () => {
+            nuxt.hooks.removeAllHooks()
+            return Promise.resolve()
+          },
+        },
+      },
+    })
+
+    await buildNuxt(nuxt)
+    await nuxt.close()
+
+    const messages = warn.mock.calls.map(call => call.join(' '))
+    expect(messages.some(message => message.includes('NUXT_B6005') && message.includes('nuxt/dist/composables/router'))).toBe(true)
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/35798

### 📚 Description

this improves dx when someone adds an invalid path in `from`