### PR TITLE
fix(nuxt): stop client $fetch touching window on import

### DIFF
--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -552,10 +552,23 @@ export const dollarFetchTemplate: NuxtTemplate = {
 export const dollarFetchClientTemplate: NuxtTemplate = {
   filename: 'fetch.client.mjs',
   getContents () {
+    // Defer baseURL() until the first request so node Vitest can import modules
+    // that auto-import $fetch without touching nitro.client's bare `window`
+    // (https://github.com/nuxt/nuxt/issues/35801). Use createFetch + _$fetch.native
+    // so globalThis.fetch stays dynamic the same way _$fetch.create() did.
     return [
-      'import { $fetch as _$fetch } from \'ofetch\'',
+      'import { $fetch as _$fetch, createFetch } from \'ofetch\'',
       'import { baseURL } from \'#internal/nuxt/paths\'',
-      'export const $fetch = import.meta.test ? globalThis.$fetch || _$fetch.create({ baseURL: baseURL() }) : /*#__PURE__*/ _$fetch.create({ baseURL: /*#__PURE__*/ baseURL() })',
+      'export const $fetch = import.meta.test && globalThis.$fetch',
+      '  ? globalThis.$fetch',
+      '  : /*#__PURE__*/ createFetch({',
+      '      fetch: _$fetch.native,',
+      '      defaults: {',
+      '        get baseURL () {',
+      '          return baseURL()',
+      '        },',
+      '      },',
+      '    })',
     ].join('\n')
   },
 }

--- a/packages/nuxt/test/templates.test.ts
+++ b/packages/nuxt/test/templates.test.ts
@@ -7,7 +7,12 @@ import { resolve } from 'pathe'
 // it does in production; otherwise the test would see partially-initialised
 // exports and crash before any assertions run.
 import '../src/core/app.ts'
-import { appConfigTemplate, publicPathTemplate } from '../src/core/templates.ts'
+import {
+  appConfigTemplate,
+  dollarFetchClientTemplate,
+  dollarFetchTemplate,
+  publicPathTemplate,
+} from '../src/core/templates.ts'
 
 import type { Nuxt, NuxtApp } from 'nuxt/schema'
 
@@ -51,5 +56,94 @@ describe('publicPathTemplate', () => {
 
     expect(contents).not.toMatch(/runtime-config/)
     expect(contents).toMatch(/getAppConfig = \(\) => \(/)
+  })
+})
+
+describe('dollarFetchClientTemplate', () => {
+  it('defers baseURL() until first request and keeps dynamic globalThis.fetch via _$fetch.native', async () => {
+    const contents = await dollarFetchClientTemplate.getContents!({ nuxt: makeNuxt(), app: makeApp(), options: {} })
+
+    expect(contents).toMatch(/import \{ \$fetch as _\$fetch, createFetch \} from ['"]ofetch['"]/)
+    expect(contents).toMatch(/fetch:\s*_\$fetch\.native/)
+    expect(contents).toMatch(/get baseURL\s*\(\)\s*\{/)
+    expect(contents).toMatch(/\/\*#__PURE__\*\//)
+    expect(contents).toMatch(/import\.meta\.test && globalThis\.\$fetch/)
+    // Eager baseURL() at create time is what broke node Vitest (#35801).
+    expect(contents).not.toMatch(/baseURL:\s*(?:\/\*#__PURE__\*\/\s*)?baseURL\(\)/)
+  })
+
+  it('initialises in Node without touching baseURL until a request runs', async () => {
+    const contents = await dollarFetchClientTemplate.getContents!({ nuxt: makeNuxt(), app: makeApp(), options: {} })
+    expect(contents).toContain('createFetch')
+
+    let baseURLCalls = 0
+    const baseURL = () => {
+      baseURLCalls++
+      return 'http://example.test'
+    }
+
+    const { $fetch: _$fetch, createFetch } = await import('ofetch')
+    // Mirror the generated createFetch path (import.meta.test false / no globalThis.$fetch).
+    const $fetch = createFetch({
+      fetch: _$fetch.native,
+      defaults: {
+        get baseURL () {
+          return baseURL()
+        },
+      },
+    })
+
+    expect(baseURLCalls).toBe(0)
+
+    const hadWindow = 'window' in globalThis
+    const previousWindow = (globalThis as { window?: unknown }).window
+    if (hadWindow) {
+      // @ts-expect-error intentional Node smoke
+      delete globalThis.window
+    }
+
+    try {
+      expect(baseURLCalls).toBe(0)
+
+      let fetchedUrl = ''
+      const previousFetch = globalThis.fetch
+      globalThis.fetch = ((input: RequestInfo | URL) => {
+        fetchedUrl = String(input)
+        return Promise.resolve(new Response('{}', { headers: { 'content-type': 'application/json' } }))
+      }) as typeof globalThis.fetch
+
+      try {
+        await $fetch('/api/ping')
+        expect(baseURLCalls).toBe(1)
+        expect(fetchedUrl).toBe('http://example.test/api/ping')
+
+        // After init, replacing globalThis.fetch must still be observed (native wrapper).
+        globalThis.fetch = ((input: RequestInfo | URL) => {
+          fetchedUrl = `replaced:${String(input)}`
+          return Promise.resolve(new Response('{}', { headers: { 'content-type': 'application/json' } }))
+        }) as typeof globalThis.fetch
+
+        await $fetch('/api/again')
+        expect(fetchedUrl).toBe('replaced:http://example.test/api/again')
+        expect(baseURLCalls).toBe(2)
+      } finally {
+        globalThis.fetch = previousFetch
+      }
+    } finally {
+      if (hadWindow) {
+        (globalThis as { window?: unknown }).window = previousWindow
+      }
+    }
+  })
+})
+
+describe('dollarFetchTemplate', () => {
+  it('keeps eager server seeding with createFetch and nitro fetch', async () => {
+    const contents = await dollarFetchTemplate.getContents!({ nuxt: makeNuxt(), app: makeApp(), options: {} })
+
+    expect(contents).toMatch(/import \{ createFetch \} from ['"]ofetch['"]/)
+    expect(contents).toMatch(/import \{ fetch \} from ['"]nitro['"]/)
+    expect(contents).toMatch(/defaults:\s*\{\s*baseURL:\s*baseURL\(\)\s*\}/)
+    expect(contents).toMatch(/if\s*\(!globalThis\.\$fetch\)/)
   })
 })


### PR DESCRIPTION
Fixes the node Vitest crash from #35801.

After #35581, `$fetch` comes from `#build/fetch`. With `@nuxt/test-utils` that is `fetch.client.mjs` (`ssr: false`). Creating the ofetch instance called `baseURL()` immediately, which pulled `nitro.client`'s `useRuntimeConfig` and hit bare `window`.

I changed only the client template: `createFetch` with a `defaults` getter for `baseURL`, and `fetch: _$fetch.native` so `globalThis.fetch` still updates after import. Left server fetch / setup and `nitro.client` alone.

Checked with `pnpm exec vitest run packages/nuxt/test/templates.test.ts` and eslint on the two touched files.

Fixes #35801