### PR TITLE
feat(nitro,nuxt): improvements when rendering with `noScripts`

### DIFF
--- a/docs/3.guide/5.recipes/5.mostly-static-sites.md
+++ b/docs/3.guide/5.recipes/5.mostly-static-sites.md
@@ -35,6 +35,24 @@ Read more about exactly what `noScripts` omits, and the app-wide `features.noScr
 A `noScripts` page does not hydrate. Nothing on it is interactive: no `@click` handlers, no `<NuxtLink>` prefetching (links still work as plain `<a>` tags), no client-side navigation away from the page. Only use it on routes where that is what you want.
 ::
 
+## Navigating to and from Script-Free Routes
+
+Because a `noScripts` page has no client-side router, every navigation to or from one is a full-page load. Nuxt handles both directions of that for you:
+
+- Navigating **from** a scripted route **to** a `noScripts` route (with `navigateTo`, `<NuxtLink>`, or `router.push`) triggers a document load, so the target is served script-free by the server rather than rendered by the client-side router.
+- Because those routes are never rendered on the client, their page components are dropped from the client bundle when the route rules covering them can be resolved at build time.
+- Both scripted and script-free pages emit a declarative [speculation rules](https://developer.mozilla.org/en-US/docs/Web/API/Speculation_Rules_API) tag so supporting browsers prefetch and prerender the target before the user follows a link. This runs no JavaScript on the page itself, and the rules are scoped to your page routes, so a link to a server route such as `/logout` is never speculatively fetched.
+
+With [experimental view transitions](/docs/4.x/getting-started/transitions#view-transitions-api-experimental) enabled, these pages also opt into cross-document view transitions, so a full-page navigation animates rather than flashing:
+
+```ts twoslash [nuxt.config.ts]
+export default defineNuxtConfig({
+  experimental: {
+    viewTransition: true,
+  },
+})
+```
+
 ## Islands for Server-Rendered Widgets
 
 Some parts of a static page still benefit from being components with real logic behind them: rendered markdown, syntax-highlighted code, CMS content. Use [server components](/docs/4.x/guide/concepts/server-components) for these. They render on the server, and their dependencies never reach the client bundle:
@@ -96,7 +114,7 @@ export default defineNuxtConfig({
 })
 ```
 
-- content routes ship plain HTML and CSS
+- content routes ship plain HTML and CSS, and navigation to them is a speculatively prefetched document load
 - islands (`.server.vue` components) handle server-rendered widgets everywhere, keeping heavy dependencies out of the client bundle
 - the few interactive routes keep scripts, with `hydrate-on-visible` / `hydrate-on-idle` / `hydrate-never` limiting how much work the browser does up front
 

--- a/docs/3.guide/6.going-further/1.features.md
+++ b/docs/3.guide/6.going-further/1.features.md
@@ -49,7 +49,7 @@ Possible values:
 - `'production'` (or `true`, which is normalized to `'production'`): scripts are omitted in production builds only, so hot module replacement and other development features keep working in `nuxt dev`.
 - `'all'`: scripts are omitted in both development and production.
 
-Pages served without scripts navigate with full page loads. To keep navigation fast, Nuxt emits a [speculation rules](https://developer.mozilla.org/en-US/docs/Web/API/Speculation_Rules_API) tag on these pages so supporting browsers prefetch and prerender same-origin link targets before the user follows a link. The tag is declarative JSON and executes no JavaScript.
+Pages served without scripts navigate with full-page loads. To keep navigation fast, Nuxt emits a [speculation rules](https://developer.mozilla.org/en-US/docs/Web/API/Speculation_Rules_API) tag on these pages so supporting browsers prefetch and prerender same-origin link targets before the user follows a link. The tag is declarative JSON and executes no JavaScript.
 
 Client-side navigation *to* a route covered by a `noScripts` route rule triggers a full document load instead, so the route is actually served without scripts rather than being rendered by the client-side router. Pages whose routes are known at build time to be covered by such a rule are also excluded from the client bundle entirely.
 

--- a/docs/3.guide/6.going-further/1.features.md
+++ b/docs/3.guide/6.going-further/1.features.md
@@ -49,7 +49,7 @@ Possible values:
 - `'production'` (or `true`, which is normalized to `'production'`): scripts are omitted in production builds only, so hot module replacement and other development features keep working in `nuxt dev`.
 - `'all'`: scripts are omitted in both development and production.
 
-Pages served without scripts navigate with full-page loads. To keep navigation fast, Nuxt emits a [speculation rules](https://developer.mozilla.org/en-US/docs/Web/API/Speculation_Rules_API) tag on these pages so supporting browsers prefetch and prerender same-origin link targets before the user follows a link. The tag is declarative JSON and executes no JavaScript.
+Pages served without scripts navigate with full-page loads. To keep navigation fast, Nuxt emits a [speculation rules](https://developer.mozilla.org/en-US/docs/Web/API/Speculation_Rules_API) tag on these pages so supporting browsers prefetch and prerender the targets before the user follows a link. The tag is declarative JSON and executes no JavaScript. The rules are scoped to your page routes (which are safe to `GET`) rather than every same-origin link, so a link to a server route such as `/logout` is never speculatively fetched. A catch-all page (for example `pages/[...slug].vue`) matches every path, which widens this back to all same-origin links.
 
 Client-side navigation *to* a route covered by a `noScripts` route rule triggers a full document load instead, so the route is actually served without scripts rather than being rendered by the client-side router. Pages whose routes are known at build time to be covered by such a rule are also excluded from the client bundle entirely.
 

--- a/docs/3.guide/6.going-further/1.features.md
+++ b/docs/3.guide/6.going-further/1.features.md
@@ -51,6 +51,8 @@ Possible values:
 
 Pages served without scripts navigate with full page loads. To keep navigation fast, Nuxt emits a [speculation rules](https://developer.mozilla.org/en-US/docs/Web/API/Speculation_Rules_API) tag on these pages so supporting browsers prefetch and prerender same-origin link targets before the user follows a link. The tag is declarative JSON and executes no JavaScript.
 
+Client-side navigation *to* a route covered by a `noScripts` route rule triggers a full document load instead, so the route is actually served without scripts rather than being rendered by the client-side router. Pages whose routes are known at build time to be covered by such a rule are also excluded from the client bundle entirely.
+
 Scripted pages emit their own speculation rules tag scoped to the `noScripts` route patterns, so browsers can prefetch and prerender those targets before a full-page navigation to them.
 
 ```ts [nuxt.config.ts]

--- a/docs/3.guide/6.going-further/1.features.md
+++ b/docs/3.guide/6.going-further/1.features.md
@@ -49,6 +49,10 @@ Possible values:
 - `'production'` (or `true`, which is normalized to `'production'`): scripts are omitted in production builds only, so hot module replacement and other development features keep working in `nuxt dev`.
 - `'all'`: scripts are omitted in both development and production.
 
+Pages served without scripts navigate with full page loads. To keep navigation fast, Nuxt emits a [speculation rules](https://developer.mozilla.org/en-US/docs/Web/API/Speculation_Rules_API) tag on these pages so supporting browsers prefetch and prerender same-origin link targets before the user follows a link. The tag is declarative JSON and executes no JavaScript.
+
+Scripted pages emit their own speculation rules tag scoped to the `noScripts` route patterns, so browsers can prefetch and prerender those targets before a full-page navigation to them.
+
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   features: {

--- a/docs/3.guide/6.going-further/1.features.md
+++ b/docs/3.guide/6.going-further/1.features.md
@@ -53,7 +53,7 @@ Pages served without scripts navigate with full page loads. To keep navigation f
 
 Client-side navigation *to* a route covered by a `noScripts` route rule triggers a full document load instead, so the route is actually served without scripts rather than being rendered by the client-side router. Pages whose routes are known at build time to be covered by such a rule are also excluded from the client bundle entirely.
 
-Scripted pages emit their own speculation rules tag scoped to the `noScripts` route patterns, so browsers can prefetch and prerender those targets before a full-page navigation to them.
+Scripted pages emit their own speculation rules tag scoped to the `noScripts` route patterns, so browsers can prefetch and prerender those targets before a full-page navigation to them. When view transitions are enabled, these pages also opt into declarative cross-document view transitions to animate the navigation.
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({

--- a/packages/nitro-server/package.json
+++ b/packages/nitro-server/package.json
@@ -61,6 +61,7 @@
     "std-env": "catalog:build",
     "ufo": "catalog:app-runtime",
     "unctx": "catalog:app-runtime",
+    "unrouting": "catalog:build",
     "unstorage": "catalog:nitro-runtime",
     "vue": "catalog:app-runtime",
     "vue-bundle-renderer": "catalog:app-runtime",

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -386,7 +386,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
   nitroConfig.ignore ||= []
   nitroConfig.ignore.push(...resolveIgnorePatterns(nitroConfig.serverDir))
 
-  const validManifestKeys = ['prerender', 'redirect', 'appMiddleware', 'appLayout', 'cache', 'isr', 'swr', 'ssr']
+  const validManifestKeys = ['prerender', 'redirect', 'appMiddleware', 'appLayout', 'cache', 'isr', 'swr', 'ssr', 'noScripts']
 
   addTemplate({
     filename: 'route-rules.mjs',

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -229,6 +229,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
           `export const NUXT_NO_SCRIPTS = ${nuxt.options.features.noScripts === 'all' || (!!nuxt.options.features.noScripts && !nuxt.options.dev)}`,
           `export const NUXT_NO_SCRIPTS_PROD = ${nuxt.options.features.noScripts === 'production'}`,
           `export const NUXT_INLINE_STYLES = ${!!nuxt.options.features.inlineStyles}`,
+          `export const NUXT_VIEW_TRANSITIONS = ${!!(nuxt.options.app.viewTransition && typeof nuxt.options.app.viewTransition === 'object' && nuxt.options.app.viewTransition.enabled)}`,
           `export const NUXT_NO_SCRIPTS_PATTERNS = ${JSON.stringify(noScriptsPatterns)}`,
           `export const PARSE_ERROR_DATA = ${!!nuxt.options.experimental.parseErrorData}`,
           `export const NUXT_ASYNC_CONTEXT = ${!!nuxt.options.experimental.asyncContext}`,

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -223,6 +223,10 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
         const noScriptsPatterns = [...new Set(nitro.routing.routeRules.routes
           .filter(r => r.data.noScripts)
           .map(r => rou3PatternToURLPattern(r.route).pattern))]
+        // `href_matches` patterns for every page route, provided by the pages
+        // module; pages served without scripts scope their blanket speculation
+        // rules to these (safe-to-GET) same-origin navigations
+        const pagePatterns = (nitro.options as { _noScriptsPagePatterns?: string[] })._noScriptsPagePatterns ?? []
         return [
           `export const NUXT_NO_SSR = ${nuxt.options.ssr === false}`,
           `export const NUXT_EARLY_HINTS = ${nuxt.options.experimental.writeEarlyHints !== false}`,
@@ -231,6 +235,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
           `export const NUXT_INLINE_STYLES = ${!!nuxt.options.features.inlineStyles}`,
           `export const NUXT_VIEW_TRANSITIONS = ${!!(nuxt.options.app.viewTransition && typeof nuxt.options.app.viewTransition === 'object' && nuxt.options.app.viewTransition.enabled)}`,
           `export const NUXT_NO_SCRIPTS_PATTERNS = ${JSON.stringify(noScriptsPatterns)}`,
+          `export const NUXT_PAGE_PATTERNS = ${JSON.stringify(pagePatterns)}`,
           `export const PARSE_ERROR_DATA = ${!!nuxt.options.experimental.parseErrorData}`,
           `export const NUXT_ASYNC_CONTEXT = ${!!nuxt.options.experimental.asyncContext}`,
           `export const NUXT_SHARED_DATA = ${!!nuxt.options.experimental.sharedPrerenderData}`,

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -15,6 +15,7 @@ import escapeRE from 'escape-string-regexp'
 import { defu } from 'defu'
 import { defineEventHandler } from 'nitro/h3'
 import { isWindows } from 'std-env'
+import { rou3PatternToURLPattern } from 'unrouting'
 import { ImpoundPlugin } from 'impound'
 import { resolveModulePath } from 'exsolve'
 import { runtimeDependencies } from 'nitro/meta'
@@ -215,12 +216,20 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
       '#internal/streaming-iife-chunk.mjs': () => `export const iifeChunkFileName = undefined`,
       '#internal/nuxt/nitro-config.mjs': () => {
         const hasCachedRoutes = nitro.routing.routeRules.routes.some(r => r.data.isr || r.data.cache)
+        // `href_matches` patterns (URLPattern syntax) for routes served under a
+        // `noScripts` route rule, so scripted documents can speculatively
+        // prefetch/prerender the full-page navigation the client router forces
+        // to them.
+        const noScriptsPatterns = [...new Set(nitro.routing.routeRules.routes
+          .filter(r => r.data.noScripts)
+          .map(r => rou3PatternToURLPattern(r.route).pattern))]
         return [
           `export const NUXT_NO_SSR = ${nuxt.options.ssr === false}`,
           `export const NUXT_EARLY_HINTS = ${nuxt.options.experimental.writeEarlyHints !== false}`,
           `export const NUXT_NO_SCRIPTS = ${nuxt.options.features.noScripts === 'all' || (!!nuxt.options.features.noScripts && !nuxt.options.dev)}`,
           `export const NUXT_NO_SCRIPTS_PROD = ${nuxt.options.features.noScripts === 'production'}`,
           `export const NUXT_INLINE_STYLES = ${!!nuxt.options.features.inlineStyles}`,
+          `export const NUXT_NO_SCRIPTS_PATTERNS = ${JSON.stringify(noScriptsPatterns)}`,
           `export const PARSE_ERROR_DATA = ${!!nuxt.options.experimental.parseErrorData}`,
           `export const NUXT_ASYNC_CONTEXT = ${!!nuxt.options.experimental.asyncContext}`,
           `export const NUXT_SHARED_DATA = ${!!nuxt.options.experimental.sharedPrerenderData}`,

--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -28,7 +28,7 @@ import { renderStreamedIslandTeleports, replaceIslandTeleports } from '../utils/
 import { serverDiagnostics } from '../diagnostics'
 import { warnNoScriptsClientReliance } from '../utils/renderer/no-scripts'
 import { renderSSRHeadOptions } from '#internal/unhead.config.mjs'
-import { NUXT_ASYNC_CONTEXT, NUXT_EARLY_HINTS, NUXT_INLINE_STYLES, NUXT_NO_SCRIPTS, NUXT_NO_SCRIPTS_PATTERNS, NUXT_NO_SCRIPTS_PROD, NUXT_PAYLOAD_EXTRACTION, NUXT_PAYLOAD_INLINE, NUXT_RUNTIME_PAYLOAD_EXTRACTION, NUXT_SSR_STREAMING, NUXT_SSR_STREAMING_BOT_RE, NUXT_VIEW_TRANSITIONS, PARSE_ERROR_DATA } from '#internal/nuxt/nitro-config.mjs'
+import { NUXT_ASYNC_CONTEXT, NUXT_EARLY_HINTS, NUXT_INLINE_STYLES, NUXT_NO_SCRIPTS, NUXT_NO_SCRIPTS_PATTERNS, NUXT_NO_SCRIPTS_PROD, NUXT_PAGE_PATTERNS, NUXT_PAYLOAD_EXTRACTION, NUXT_PAYLOAD_INLINE, NUXT_RUNTIME_PAYLOAD_EXTRACTION, NUXT_SSR_STREAMING, NUXT_SSR_STREAMING_BOT_RE, NUXT_VIEW_TRANSITIONS, PARSE_ERROR_DATA } from '#internal/nuxt/nitro-config.mjs'
 import { appHead, appTeleportAttrs, appTeleportTag, componentIslands, componentIslandsActive, tracingChannelNuxt } from '#internal/nuxt.config.mjs'
 import entryIds from 'nuxt/entry-ids'
 import { entryFileName } from 'nuxt/entry-chunk'
@@ -871,7 +871,10 @@ async function renderStreamedResponse (ctx: {
  */
 function pushNoScriptsHints (ssrContext: NuxtSSRContext, noScripts: boolean) {
   if (noScripts) {
-    pushSpeculationRulesScript(ssrContext, ['/*'])
+    // scope to same-origin page routes (safe to GET) so we do not prefetch or
+    // prerender non-idempotent server routes; fall back to a blanket rule when
+    // there are no pages to enumerate (e.g. pages disabled)
+    pushSpeculationRulesScript(ssrContext, NUXT_PAGE_PATTERNS.length ? NUXT_PAGE_PATTERNS : ['/*'])
   } else if (NUXT_NO_SCRIPTS_PATTERNS.length) {
     pushSpeculationRulesScript(ssrContext, NUXT_NO_SCRIPTS_PATTERNS)
   } else {

--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -28,7 +28,7 @@ import { renderStreamedIslandTeleports, replaceIslandTeleports } from '../utils/
 import { serverDiagnostics } from '../diagnostics'
 import { warnNoScriptsClientReliance } from '../utils/renderer/no-scripts'
 import { renderSSRHeadOptions } from '#internal/unhead.config.mjs'
-import { NUXT_ASYNC_CONTEXT, NUXT_EARLY_HINTS, NUXT_INLINE_STYLES, NUXT_NO_SCRIPTS, NUXT_NO_SCRIPTS_PATTERNS, NUXT_NO_SCRIPTS_PROD, NUXT_PAYLOAD_EXTRACTION, NUXT_PAYLOAD_INLINE, NUXT_RUNTIME_PAYLOAD_EXTRACTION, NUXT_SSR_STREAMING, NUXT_SSR_STREAMING_BOT_RE, PARSE_ERROR_DATA } from '#internal/nuxt/nitro-config.mjs'
+import { NUXT_ASYNC_CONTEXT, NUXT_EARLY_HINTS, NUXT_INLINE_STYLES, NUXT_NO_SCRIPTS, NUXT_NO_SCRIPTS_PATTERNS, NUXT_NO_SCRIPTS_PROD, NUXT_PAYLOAD_EXTRACTION, NUXT_PAYLOAD_INLINE, NUXT_RUNTIME_PAYLOAD_EXTRACTION, NUXT_SSR_STREAMING, NUXT_SSR_STREAMING_BOT_RE, NUXT_VIEW_TRANSITIONS, PARSE_ERROR_DATA } from '#internal/nuxt/nitro-config.mjs'
 import { appHead, appTeleportAttrs, appTeleportTag, componentIslands, componentIslandsActive, tracingChannelNuxt } from '#internal/nuxt.config.mjs'
 import entryIds from 'nuxt/entry-ids'
 import { entryFileName } from 'nuxt/entry-chunk'
@@ -269,8 +269,14 @@ async function renderRoute (event: H3Event, ssrError?: (NuxtPayload['error'] & {
 
   if (NO_SCRIPTS) {
     pushSpeculationRules(ssrContext)
+    if (NUXT_VIEW_TRANSITIONS) {
+      pushCrossDocumentViewTransition(ssrContext)
+    }
   } else if (NUXT_NO_SCRIPTS_PATTERNS.length) {
     pushNoScriptsLinkHints(ssrContext)
+    if (NUXT_VIEW_TRANSITIONS) {
+      pushCrossDocumentViewTransition(ssrContext)
+    }
   }
 
   // 0. Add import map for stable chunk hashes
@@ -431,8 +437,14 @@ async function renderStreamedResponse (ctx: {
 
   if (NO_SCRIPTS) {
     pushSpeculationRules(ssrContext)
+    if (NUXT_VIEW_TRANSITIONS) {
+      pushCrossDocumentViewTransition(ssrContext)
+    }
   } else if (NUXT_NO_SCRIPTS_PATTERNS.length) {
     pushNoScriptsLinkHints(ssrContext)
+    if (NUXT_VIEW_TRANSITIONS) {
+      pushCrossDocumentViewTransition(ssrContext)
+    }
   }
 
   // 1. Set HTTP Link headers with entry-point preload hints (fastest resource hinting)
@@ -861,6 +873,21 @@ async function renderStreamedResponse (ctx: {
   event.res.headers.set('x-powered-by', 'Nuxt')
 
   return new FastResponse(outputStream, event.res)
+}
+
+/**
+ * Pages served without scripts navigate with full page loads. When view
+ * transitions are enabled, opting into same-origin cross-document view
+ * transitions declaratively animates those navigations without a client
+ * runtime (the client-side `startViewTransition` plugin is not shipped).
+ */
+function pushCrossDocumentViewTransition (ssrContext: NuxtSSRContext) {
+  ssrContext.head.push({
+    style: [{
+      tagPosition: 'head',
+      innerHTML: '@view-transition{navigation:auto}',
+    }],
+  })
 }
 
 /**

--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -267,17 +267,7 @@ async function renderRoute (event: H3Event, ssrError?: (NuxtPayload['error'] & {
   // Setup head
   const { styles, scripts } = getRequestDependencies(ssrContext, renderer.rendererContext)
 
-  if (NO_SCRIPTS) {
-    pushSpeculationRules(ssrContext)
-    if (NUXT_VIEW_TRANSITIONS) {
-      pushCrossDocumentViewTransition(ssrContext)
-    }
-  } else if (NUXT_NO_SCRIPTS_PATTERNS.length) {
-    pushNoScriptsLinkHints(ssrContext)
-    if (NUXT_VIEW_TRANSITIONS) {
-      pushCrossDocumentViewTransition(ssrContext)
-    }
-  }
+  pushNoScriptsHints(ssrContext, NO_SCRIPTS)
 
   // 0. Add import map for stable chunk hashes
   if (entryFileName && !NO_SCRIPTS) {
@@ -435,17 +425,7 @@ async function renderStreamedResponse (ctx: {
   const { event, ssrContext, renderer, routeOptions, ssrError, _PAYLOAD_EXTRACTION, _PAYLOAD_INLINE, payloadURL } = ctx
   const NO_SCRIPTS = NUXT_NO_SCRIPTS || !!routeOptions?.noScripts
 
-  if (NO_SCRIPTS) {
-    pushSpeculationRules(ssrContext)
-    if (NUXT_VIEW_TRANSITIONS) {
-      pushCrossDocumentViewTransition(ssrContext)
-    }
-  } else if (NUXT_NO_SCRIPTS_PATTERNS.length) {
-    pushNoScriptsLinkHints(ssrContext)
-    if (NUXT_VIEW_TRANSITIONS) {
-      pushCrossDocumentViewTransition(ssrContext)
-    }
-  }
+  pushNoScriptsHints(ssrContext, NO_SCRIPTS)
 
   // 1. Set HTTP Link headers with entry-point preload hints (fastest resource hinting)
   const { link: linkHeader } = renderResourceHeaders({}, renderer.rendererContext)
@@ -876,51 +856,39 @@ async function renderStreamedResponse (ctx: {
 }
 
 /**
- * Pages served without scripts navigate with full page loads. When view
- * transitions are enabled, opting into same-origin cross-document view
- * transitions declaratively animates those navigations without a client
- * runtime (the client-side `startViewTransition` plugin is not shipped).
+ * Routes served without scripts navigate with full-page loads. This emits the
+ * declarative navigation hints that speed those up, on both the pages served
+ * without scripts (a blanket rule over same-origin links) and scripted pages
+ * that may link to them (rules scoped to the `noScripts` route patterns):
+ *
+ * - speculation rules, so supporting browsers prefetch and prerender the
+ *   target ahead of the navigation;
+ * - when view transitions are enabled, an opt-in to same-origin cross-document
+ *   view transitions, animating the navigation without a client runtime (the
+ *   client-side `startViewTransition` plugin is not shipped).
+ *
+ * Both tags are declarative and execute no JavaScript.
  */
-function pushCrossDocumentViewTransition (ssrContext: NuxtSSRContext) {
-  ssrContext.head.push({
-    style: [{
-      tagPosition: 'head',
-      innerHTML: '@view-transition{navigation:auto}',
-    }],
-  })
+function pushNoScriptsHints (ssrContext: NuxtSSRContext, noScripts: boolean) {
+  if (noScripts) {
+    pushSpeculationRulesScript(ssrContext, ['/*'])
+  } else if (NUXT_NO_SCRIPTS_PATTERNS.length) {
+    pushSpeculationRulesScript(ssrContext, NUXT_NO_SCRIPTS_PATTERNS)
+  } else {
+    return
+  }
+  if (NUXT_VIEW_TRANSITIONS) {
+    ssrContext.head.push({
+      style: [{
+        tagPosition: 'head',
+        innerHTML: '@view-transition{navigation:auto}',
+      }],
+    })
+  }
 }
 
-/**
- * Pages served without scripts navigate with full page loads. Speculation
- * rules let supporting browsers prefetch and prerender same-origin link
- * targets ahead of the navigation, so following a link is near-instant
- * despite the absence of a client-side router. The tag is declarative JSON
- * and executes no JavaScript.
- */
-function pushSpeculationRules (ssrContext: NuxtSSRContext) {
-  ssrContext.head.push({
-    script: [{
-      tagPosition: 'head',
-      // unhead's script type union does not yet include 'speculationrules'
-      type: 'speculationrules' as any,
-      // unhead v3 JSON-stringifies object innerHTML for <script> tags
-      innerHTML: {
-        prefetch: [{ where: { href_matches: '/*' }, eagerness: 'moderate' }],
-        prerender: [{ where: { href_matches: '/*' }, eagerness: 'moderate' }],
-      },
-    }],
-  })
-}
-
-/**
- * Scripted pages navigate to `noScripts` routes with a full document load (the
- * client router forces it). Emitting speculation rules scoped to the `noScripts`
- * route patterns lets supporting browsers prefetch and prerender those targets
- * ahead of the navigation, without over-prefetching the rest of the app. The tag
- * is declarative JSON and executes no JavaScript.
- */
-function pushNoScriptsLinkHints (ssrContext: NuxtSSRContext) {
-  const rules = (NUXT_NO_SCRIPTS_PATTERNS as string[]).map((href_matches: string) => ({ where: { href_matches }, eagerness: 'moderate' }))
+function pushSpeculationRulesScript (ssrContext: NuxtSSRContext, patterns: string[]) {
+  const rules = patterns.map(href_matches => ({ where: { href_matches }, eagerness: 'moderate' }))
   ssrContext.head.push({
     script: [{
       tagPosition: 'head',

--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -28,7 +28,7 @@ import { renderStreamedIslandTeleports, replaceIslandTeleports } from '../utils/
 import { serverDiagnostics } from '../diagnostics'
 import { warnNoScriptsClientReliance } from '../utils/renderer/no-scripts'
 import { renderSSRHeadOptions } from '#internal/unhead.config.mjs'
-import { NUXT_ASYNC_CONTEXT, NUXT_EARLY_HINTS, NUXT_INLINE_STYLES, NUXT_NO_SCRIPTS, NUXT_NO_SCRIPTS_PROD, NUXT_PAYLOAD_EXTRACTION, NUXT_PAYLOAD_INLINE, NUXT_RUNTIME_PAYLOAD_EXTRACTION, NUXT_SSR_STREAMING, NUXT_SSR_STREAMING_BOT_RE, PARSE_ERROR_DATA } from '#internal/nuxt/nitro-config.mjs'
+import { NUXT_ASYNC_CONTEXT, NUXT_EARLY_HINTS, NUXT_INLINE_STYLES, NUXT_NO_SCRIPTS, NUXT_NO_SCRIPTS_PATTERNS, NUXT_NO_SCRIPTS_PROD, NUXT_PAYLOAD_EXTRACTION, NUXT_PAYLOAD_INLINE, NUXT_RUNTIME_PAYLOAD_EXTRACTION, NUXT_SSR_STREAMING, NUXT_SSR_STREAMING_BOT_RE, PARSE_ERROR_DATA } from '#internal/nuxt/nitro-config.mjs'
 import { appHead, appTeleportAttrs, appTeleportTag, componentIslands, componentIslandsActive, tracingChannelNuxt } from '#internal/nuxt.config.mjs'
 import entryIds from 'nuxt/entry-ids'
 import { entryFileName } from 'nuxt/entry-chunk'
@@ -267,6 +267,12 @@ async function renderRoute (event: H3Event, ssrError?: (NuxtPayload['error'] & {
   // Setup head
   const { styles, scripts } = getRequestDependencies(ssrContext, renderer.rendererContext)
 
+  if (NO_SCRIPTS) {
+    pushSpeculationRules(ssrContext)
+  } else if (NUXT_NO_SCRIPTS_PATTERNS.length) {
+    pushNoScriptsLinkHints(ssrContext)
+  }
+
   // 0. Add import map for stable chunk hashes
   if (entryFileName && !NO_SCRIPTS) {
     let path = entryPath
@@ -422,6 +428,12 @@ async function renderStreamedResponse (ctx: {
 }): Promise<ReadableStream<Uint8Array> | Response> {
   const { event, ssrContext, renderer, routeOptions, ssrError, _PAYLOAD_EXTRACTION, _PAYLOAD_INLINE, payloadURL } = ctx
   const NO_SCRIPTS = NUXT_NO_SCRIPTS || !!routeOptions?.noScripts
+
+  if (NO_SCRIPTS) {
+    pushSpeculationRules(ssrContext)
+  } else if (NUXT_NO_SCRIPTS_PATTERNS.length) {
+    pushNoScriptsLinkHints(ssrContext)
+  }
 
   // 1. Set HTTP Link headers with entry-point preload hints (fastest resource hinting)
   const { link: linkHeader } = renderResourceHeaders({}, renderer.rendererContext)
@@ -849,6 +861,51 @@ async function renderStreamedResponse (ctx: {
   event.res.headers.set('x-powered-by', 'Nuxt')
 
   return new FastResponse(outputStream, event.res)
+}
+
+/**
+ * Pages served without scripts navigate with full page loads. Speculation
+ * rules let supporting browsers prefetch and prerender same-origin link
+ * targets ahead of the navigation, so following a link is near-instant
+ * despite the absence of a client-side router. The tag is declarative JSON
+ * and executes no JavaScript.
+ */
+function pushSpeculationRules (ssrContext: NuxtSSRContext) {
+  ssrContext.head.push({
+    script: [{
+      tagPosition: 'head',
+      // unhead's script type union does not yet include 'speculationrules'
+      type: 'speculationrules' as any,
+      // unhead v3 JSON-stringifies object innerHTML for <script> tags
+      innerHTML: {
+        prefetch: [{ where: { href_matches: '/*' }, eagerness: 'moderate' }],
+        prerender: [{ where: { href_matches: '/*' }, eagerness: 'moderate' }],
+      },
+    }],
+  })
+}
+
+/**
+ * Scripted pages navigate to `noScripts` routes with a full document load (the
+ * client router forces it). Emitting speculation rules scoped to the `noScripts`
+ * route patterns lets supporting browsers prefetch and prerender those targets
+ * ahead of the navigation, without over-prefetching the rest of the app. The tag
+ * is declarative JSON and executes no JavaScript.
+ */
+function pushNoScriptsLinkHints (ssrContext: NuxtSSRContext) {
+  const rules = (NUXT_NO_SCRIPTS_PATTERNS as string[]).map((href_matches: string) => ({ where: { href_matches }, eagerness: 'moderate' }))
+  ssrContext.head.push({
+    script: [{
+      tagPosition: 'head',
+      // unhead's script type union does not yet include 'speculationrules'
+      type: 'speculationrules' as any,
+      // unhead v3 JSON-stringifies object innerHTML for <script> tags
+      innerHTML: {
+        prefetch: rules,
+        prerender: rules,
+      },
+    }],
+  })
 }
 
 function buildPayloadURL (ssrContext: NuxtSSRContext): string {

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -13,6 +13,7 @@ import { isEqual } from 'ohash'
 import { distDir } from '../dirs.ts'
 import { logger, toArray } from '../utils.ts'
 import picomatch from 'picomatch'
+import { vueRouterToRou3 } from 'unrouting'
 import { resolvePagesRoutes as _resolvePagesRoutes, augmentAndResolve, createPagesContext, normalizeRoutes, relativizeToParent, resolvePageMetaExtractionKeys, resolveRoutePaths, toRou3Patterns } from './utils.ts'
 import type { PagesContext } from './utils.ts'
 import { globRouteRulesFromPages, removePagesRules } from './route-rules.ts'
@@ -30,6 +31,17 @@ const RELATIVE_WITH_DOT_RE = /^([^.])/
 
 function relativeWithDot (from: string, to: string) {
   return relative(from, to).replace(RELATIVE_WITH_DOT_RE, './$1') || '.'
+}
+
+// Unlikely to collide with a real exact route rule, so matching it surfaces only
+// the wildcard rules that apply across a glob region.
+const NO_SCRIPTS_PROBE_SEGMENT = '__nuxt_no_scripts_probe__'
+
+// Concretises a rou3 route pattern into a matchable path by replacing catch-alls
+// (`**`, `**:name`) and params (`*`, `:name`) with a literal segment.
+const ROUTE_WILDCARD_RE = /\*\*(?::\w+)?|\*|:\w+/g
+function globToProbePath (route: string): string {
+  return route.replace(ROUTE_WILDCARD_RE, NO_SCRIPTS_PROBE_SEGMENT)
 }
 
 export const pagesImportPresets: InlinePreset[] = [
@@ -714,13 +726,43 @@ export default defineNuxtModule({
     function markNoScriptsPages (pages: NuxtPage[]) {
       const nitro = nitroForNoScripts
       if (!nitro || !('routing' in nitro)) { return }
-      // returns `null` for paths that cannot be matched against route rules at
-      // build time (dynamic segments, wildcards, relative child paths)
+      const routeRules = nitro.routing.routeRules
+      const effectiveNoScripts = (path: string) =>
+        !!defu({} as Record<string, any>, ...routeRules.matchAll('', path).reverse()).noScripts
+      // Whether a rou3 pattern is *always* served without scripts. A fully
+      // static pattern is matched directly. A dynamic one serves a subset of
+      // the region below its first dynamic segment (`/products/*` and
+      // `/products/*/reviews` both live under `/products`), so it is only safe
+      // to drop when that whole region resolves to `noScripts` with no more
+      // specific rule carving out a scripted exception.
+      function patternIsNoScripts (pattern: string): boolean {
+        if (!pattern.includes(':') && !pattern.includes('*')) {
+          const normalized = pattern.length > 1 ? pattern.replace(/\/$/, '') : pattern
+          return effectiveNoScripts(normalized)
+        }
+        const segments = pattern.split('/')
+        const dynamicAt = segments.findIndex(segment => segment.includes(':') || segment.includes('*'))
+        const prefix = segments.slice(0, dynamicAt).join('/') || '/'
+        const probe = (prefix === '/' ? '' : prefix) + '/' + NO_SCRIPTS_PROBE_SEGMENT
+        if (!effectiveNoScripts(probe)) { return false }
+        const within = prefix === '/' ? '/' : prefix + '/'
+        for (const { route } of routeRules.routes) {
+          if (route !== prefix && !route.startsWith(within)) { continue }
+          if (!effectiveNoScripts(globToProbePath(route))) { return false }
+        }
+        return true
+      }
+      // Whether a page reachable at `path` is *always* served without scripts.
+      // `unrouting` collapses the compiled Vue Router path into one or more rou3
+      // patterns (dynamic params become catch-alls, finite alternations expand
+      // into concrete paths); the page is safe to drop only when every one of
+      // them is. Returns `null` when it cannot be determined statically (e.g. a
+      // relative child path with no leading slash).
       function isNoScriptsPath (path: string): boolean | null {
-        if (!path.startsWith('/') || path.includes(':') || path.includes('*')) { return null }
-        const normalized = path.length > 1 ? path.replace(/\/$/, '') : path
-        const rules = defu({} as Record<string, any>, ...nitro!.routing.routeRules.matchAll('', normalized).reverse())
-        return !!rules.noScripts
+        if (!path.startsWith('/')) { return null }
+        const { patterns } = vueRouterToRou3(path, { collapse: true })
+        if (!patterns.length) { return null }
+        return patterns.every(patternIsNoScripts)
       }
       for (const page of pages) {
         if (page.children?.length) {

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -13,7 +13,7 @@ import { isEqual } from 'ohash'
 import { distDir } from '../dirs.ts'
 import { logger, toArray } from '../utils.ts'
 import picomatch from 'picomatch'
-import { vueRouterToRou3 } from 'unrouting'
+import { rou3PatternToURLPattern, vueRouterToRou3 } from 'unrouting'
 import { resolvePagesRoutes as _resolvePagesRoutes, augmentAndResolve, createPagesContext, normalizeRoutes, relativizeToParent, resolvePageMetaExtractionKeys, resolveRoutePaths, toRou3Patterns } from './utils.ts'
 import type { PagesContext } from './utils.ts'
 import { globRouteRulesFromPages, removePagesRules } from './route-rules.ts'
@@ -585,6 +585,19 @@ export default defineNuxtModule({
     }
 
     nuxt.hook('nitro:build:before', () => warnPublicAssetConflicts())
+
+    // Expose the URLPattern of every page route so pages served without scripts
+    // can scope their speculation rules to same-origin *page* navigations, which
+    // are safe to GET, instead of a blanket rule that could prefetch/prerender
+    // non-idempotent server routes (`~/server/routes/*`). A catch-all page
+    // (`[...slug]`) widens this back to a blanket `*`.
+    nuxt.hook('nitro:build:before', (nitro) => {
+      const patterns = new Set<string>()
+      for (const route of toRou3Patterns(nuxt.apps.default?.pages || [])) {
+        patterns.add(rou3PatternToURLPattern(route).pattern)
+      }
+      ;(nitro.options as { _noScriptsPagePatterns?: string[] })._noScriptsPagePatterns = [...patterns]
+    })
 
     nuxt.hook('nitro:build:before', (nitro) => {
       if (nuxt.options.dev || nuxt.options.router.options.hashMode) { return }

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -736,7 +736,7 @@ export default defineNuxtModule({
     nuxt.hook('nitro:init', (nitro) => {
       nitroForNoScripts = nitro
     })
-    function markNoScriptsPages (pages: NuxtPage[], prefix = '/') {
+    function markNoScriptsPages (pages: NuxtPage[]) {
       const nitro = nitroForNoScripts
       if (!nitro || !('routing' in nitro)) { return }
       const routeRules = nitro.routing.routeRules
@@ -775,21 +775,31 @@ export default defineNuxtModule({
         if (!patterns.length) { return null }
         return patterns.every(patternIsNoScripts)
       }
-      for (const page of pages) {
-        // child paths are relative to the parent, so resolve them against the
-        // accumulated prefix before matching against route rules
-        const path = page.path.startsWith('/') ? page.path : joinURL(prefix, page.path)
-        if (page.children?.length) {
-          markNoScriptsPages(page.children, path)
-          continue
+      // A page is only safe to drop from the client bundle when every path it
+      // can be reached by is served without scripts. If any alias resolves to a
+      // scripted route (or cannot be checked statically), keep the component so
+      // client-side navigation to that alias still renders it. A parent page
+      // renders for all of its descendants, so it additionally requires the
+      // whole subtree below it to be script-free. Returns whether that holds for
+      // every page passed in.
+      function markPages (pages: NuxtPage[], prefix: string): boolean {
+        let allNoScripts = true
+        for (const page of pages) {
+          // child paths are relative to the parent, so resolve them against the
+          // accumulated prefix before matching against route rules
+          const path = page.path.startsWith('/') ? page.path : joinURL(prefix, page.path)
+          const aliases = toArray(page.alias || []).map(alias => alias.startsWith('/') ? alias : joinURL(prefix, alias))
+          let noScripts = [path, ...aliases].every(path => isNoScriptsPath(path) === true)
+          if (page.children?.length) {
+            noScripts = markPages(page.children, path) && noScripts
+          }
+          page._noScripts = noScripts
+          allNoScripts &&= noScripts
         }
-        // A page is only safe to drop from the client bundle when every path it
-        // can be reached by is served without scripts. If any alias resolves to
-        // a scripted route (or cannot be checked statically), keep the component
-        // so client-side navigation to that alias still renders it.
-        const aliases = toArray(page.alias || []).map(alias => alias.startsWith('/') ? alias : joinURL(prefix, alias))
-        page._noScripts = [path, ...aliases].every(path => isNoScriptsPath(path) === true)
+        return allNoScripts
       }
+
+      markPages(pages, '/')
     }
 
     // Add routes template

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -723,7 +723,7 @@ export default defineNuxtModule({
     nuxt.hook('nitro:init', (nitro) => {
       nitroForNoScripts = nitro
     })
-    function markNoScriptsPages (pages: NuxtPage[]) {
+    function markNoScriptsPages (pages: NuxtPage[], prefix = '/') {
       const nitro = nitroForNoScripts
       if (!nitro || !('routing' in nitro)) { return }
       const routeRules = nitro.routing.routeRules
@@ -756,25 +756,26 @@ export default defineNuxtModule({
       // `unrouting` collapses the compiled Vue Router path into one or more rou3
       // patterns (dynamic params become catch-alls, finite alternations expand
       // into concrete paths); the page is safe to drop only when every one of
-      // them is. Returns `null` when it cannot be determined statically (e.g. a
-      // relative child path with no leading slash).
+      // them is. Returns `null` when it cannot be determined statically.
       function isNoScriptsPath (path: string): boolean | null {
-        if (!path.startsWith('/')) { return null }
         const { patterns } = vueRouterToRou3(path, { collapse: true })
         if (!patterns.length) { return null }
         return patterns.every(patternIsNoScripts)
       }
       for (const page of pages) {
+        // child paths are relative to the parent, so resolve them against the
+        // accumulated prefix before matching against route rules
+        const path = page.path.startsWith('/') ? page.path : joinURL(prefix, page.path)
         if (page.children?.length) {
-          markNoScriptsPages(page.children)
+          markNoScriptsPages(page.children, path)
           continue
         }
         // A page is only safe to drop from the client bundle when every path it
         // can be reached by is served without scripts. If any alias resolves to
         // a scripted route (or cannot be checked statically), keep the component
         // so client-side navigation to that alias still renders it.
-        const paths = [page.path, ...toArray(page.alias || [])]
-        page._noScripts = paths.every(path => isNoScriptsPath(path) === true)
+        const aliases = toArray(page.alias || []).map(alias => alias.startsWith('/') ? alias : joinURL(prefix, alias))
+        page._noScripts = [path, ...aliases].every(path => isNoScriptsPath(path) === true)
       }
     }
 

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -11,7 +11,7 @@ import type { Nitro, NitroRouteConfig } from 'nitro/types'
 import { defu } from 'defu'
 import { isEqual } from 'ohash'
 import { distDir } from '../dirs.ts'
-import { logger } from '../utils.ts'
+import { logger, toArray } from '../utils.ts'
 import picomatch from 'picomatch'
 import { resolvePagesRoutes as _resolvePagesRoutes, augmentAndResolve, createPagesContext, normalizeRoutes, relativizeToParent, resolvePageMetaExtractionKeys, resolveRoutePaths, toRou3Patterns } from './utils.ts'
 import type { PagesContext } from './utils.ts'
@@ -703,6 +703,39 @@ export default defineNuxtModule({
     const serverComponentRuntime = await findPath(join(distDir, 'components/runtime/server-component')) ?? join(distDir, 'components/runtime/server-component')
     const clientComponentRuntime = await findPath(join(distDir, 'components/runtime/client-component')) ?? join(distDir, 'components/runtime/client-component')
 
+    // Routes served under a `noScripts` route rule need no client-side component
+    // chunk; client-side navigation to them loads the full document (see the
+    // guard in `runtime/plugins/router.ts`, which uses the compiled route-rules
+    // matcher shipped for the app manifest)
+    let nitroForNoScripts: Nitro | undefined
+    nuxt.hook('nitro:init', (nitro) => {
+      nitroForNoScripts = nitro
+    })
+    function markNoScriptsPages (pages: NuxtPage[]) {
+      const nitro = nitroForNoScripts
+      if (!nitro || !('routing' in nitro)) { return }
+      // returns `null` for paths that cannot be matched against route rules at
+      // build time (dynamic segments, wildcards, relative child paths)
+      function isNoScriptsPath (path: string): boolean | null {
+        if (!path.startsWith('/') || path.includes(':') || path.includes('*')) { return null }
+        const normalized = path.length > 1 ? path.replace(/\/$/, '') : path
+        const rules = defu({} as Record<string, any>, ...nitro!.routing.routeRules.matchAll('', normalized).reverse())
+        return !!rules.noScripts
+      }
+      for (const page of pages) {
+        if (page.children?.length) {
+          markNoScriptsPages(page.children)
+          continue
+        }
+        // A page is only safe to drop from the client bundle when every path it
+        // can be reached by is served without scripts. If any alias resolves to
+        // a scripted route (or cannot be checked statically), keep the component
+        // so client-side navigation to that alias still renders it.
+        const paths = [page.path, ...toArray(page.alias || [])]
+        page._noScripts = paths.every(path => isNoScriptsPath(path) === true)
+      }
+    }
+
     // Add routes template
     addTemplate({
       filename: 'routes.mjs',
@@ -710,6 +743,7 @@ export default defineNuxtModule({
       dependsOn: nuxt.options.experimental.scanPageMeta ? ['pages'] : [],
       getContents ({ app }) {
         if (!app.pages) { return ROUTES_HMR_CODE + 'export default []' }
+        markNoScriptsPages(app.pages)
         const { routes, imports } = normalizeRoutes(app.pages, new Set(), {
           serverComponentRuntime,
           clientComponentRuntime,

--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -226,7 +226,7 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
       router.beforeEach((to) => {
         if (nuxtApp.isHydrating) { return }
         if ((_routeRulesMatcher(to.path) as { noScripts?: boolean }).noScripts) {
-          window.location.assign(to.fullPath)
+          window.location.assign(router.resolve(to.fullPath).href)
           return false
         }
       })

--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -16,6 +16,7 @@ import { navigateTo } from '#app/composables/router'
 import { navigationDiagnostics } from '../../../app/diagnostics/navigation'
 
 import _routes, { handleHotUpdate } from '#build/routes'
+import _routeRulesMatcher from '#build/route-rules.mjs'
 import routerOptions, { hashMode } from '#build/router.options.mjs'
 import { globalMiddleware, namedMiddleware } from '#build/middleware'
 import { pageIslandRoutes } from '#build/components.islands.mjs'
@@ -216,6 +217,19 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
       if (import.meta.client && !nuxtApp.isHydrating && to.fullPath !== createCurrentLocation(routerBase, window.location)) {
         history.push(to.fullPath)
       }
+    }
+
+    // Routes served under a `noScripts` route rule must be loaded as full
+    // documents: a client-side navigation would render them with (and keep
+    // alive) the JavaScript they are meant to be served without
+    if (import.meta.client) {
+      router.beforeEach((to) => {
+        if (nuxtApp.isHydrating) { return }
+        if ((_routeRulesMatcher(to.path) as { noScripts?: boolean }).noScripts) {
+          window.location.assign(to.fullPath)
+          return false
+        }
+      })
     }
 
     const initialLayout = nuxtApp.payload.state._layout

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -451,9 +451,6 @@ interface NormalizeRoutesOptions {
 }
 
 function normalizeComponent (page: NuxtPage, pageImport: string, routeName: string | undefined, islandKey: string | undefined): string {
-  if (page._noScripts) {
-    return `import.meta.server ? ${pageImport} : () => Promise.resolve(_noScriptsPageStub)`
-  }
   if (page.mode === 'server') {
     return `() => createIslandPage(${routeName}, import.meta.server ? ${islandKey} : undefined)`
   }
@@ -464,9 +461,6 @@ function normalizeComponent (page: NuxtPage, pageImport: string, routeName: stri
 }
 
 function normalizeComponentWithName (page: NuxtPage, isSyncImport: boolean | undefined, pageImportName: string, pageImport: string, routeName: string | undefined, metaRouteName: string, islandKey: string | undefined): string {
-  if (page._noScripts && !isSyncImport) {
-    return `import.meta.server ? ${pageImport}.then((m) => Object.assign(m.default, { __name: ${metaRouteName} })) : () => Promise.resolve(_noScriptsPageStub)`
-  }
   if (isSyncImport) {
     return `Object.assign(${pageImportName}, { __name: ${metaRouteName} })`
   }
@@ -527,11 +521,14 @@ export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = 
       const metaImportName = pageImportName + 'Meta'
       const metaImport = genImport(`${file}?macro=true`, [{ name: 'default', as: metaImportName }])
 
-      if (page._sync) {
+      // A statically imported page would be linked into the client bundle even
+      // when its component is never referenced there, so `noScripts` pages fall
+      // back to a dynamic import that can be dropped
+      if (page._sync && !page._noScripts) {
         metaImports.add(genImport(file, [{ name: 'default', as: pageImportName }]))
       }
 
-      const isSyncImport = page._sync && page.mode !== 'client'
+      const isSyncImport = page._sync && page.mode !== 'client' && !page._noScripts
       const pageImport = isSyncImport ? pageImportName : genDynamicImport(file)
       // Mirror whatever the route's own `name` resolves to below, so that a name extracted at
       // build time does not pull in the macro module purely to set `__name`. That import is the
@@ -546,9 +543,21 @@ export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = 
         ? JSON.stringify(hash(relative(nuxt.options.rootDir, page.file)))
         : undefined
 
-      const component = nuxt.options.experimental.normalizePageNames
+      // A route served without scripts has no client-side component: navigating
+      // to it performs a document load (see the guard in
+      // `runtime/plugins/router.ts`), and the stub only recovers the correct
+      // document if the route is somehow reached anyway
+      const onlyOnServer = (loader: string) => page._noScripts
+        ? `import.meta.server ? ${loader} : () => Promise.resolve(_noScriptsPageStub)`
+        : loader
+
+      if (page._noScripts) {
+        metaImports.add('\nconst _noScriptsPageStub = { mounted: () => window.location.reload(), render: () => null };')
+      }
+
+      const component = onlyOnServer(nuxt.options.experimental.normalizePageNames
         ? normalizeComponentWithName(page, isSyncImport, pageImportName, pageImport, route.name, metaRouteName, islandKey)
-        : normalizeComponent(page, pageImport, route.name, islandKey)
+        : normalizeComponent(page, pageImport, route.name, islandKey))
 
       // Named views from the `name@view.vue` filename convention. The scanner
       // emits `components: { default: <file>, <view>: <file> }`.
@@ -559,12 +568,7 @@ export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = 
         for (const viewName in page.components) {
           if (viewName === 'default') { continue }
           const viewFile = normalize(page.components[viewName]!)
-          // no-scripts routes drop their client chunk, so named views are
-          // stubbed alongside the default component (see `normalizeComponent`)
-          const viewImport = page._noScripts
-            ? `import.meta.server ? ${genDynamicImport(viewFile)} : () => Promise.resolve(_noScriptsPageStub)`
-            : genDynamicImport(viewFile)
-          viewEntries.push(`${JSON.stringify(viewName)}: ${viewImport}`)
+          viewEntries.push(`${JSON.stringify(viewName)}: ${onlyOnServer(genDynamicImport(viewFile))}`)
         }
         if (viewEntries.length > 0) {
           componentsObject = `{ default: ${component}, ${viewEntries.join(', ')} }`
@@ -582,13 +586,6 @@ export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = 
       }
       if (componentsObject) {
         metaRoute.components = componentsObject
-      }
-
-      if (page._noScripts) {
-        // never reached when the no-scripts router guard forces a document
-        // load; reloading recovers the script-free document if it is
-        metaImports.add(`
-const _noScriptsPageStub = { mounted: () => window.location.reload(), render: () => null };`)
       }
 
       if (page.mode === 'server') {

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -559,7 +559,12 @@ export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = 
         for (const viewName in page.components) {
           if (viewName === 'default') { continue }
           const viewFile = normalize(page.components[viewName]!)
-          viewEntries.push(`${JSON.stringify(viewName)}: ${genDynamicImport(viewFile)}`)
+          // no-scripts routes drop their client chunk, so named views are
+          // stubbed alongside the default component (see `normalizeComponent`)
+          const viewImport = page._noScripts
+            ? `import.meta.server ? ${genDynamicImport(viewFile)} : () => Promise.resolve(_noScriptsPageStub)`
+            : genDynamicImport(viewFile)
+          viewEntries.push(`${JSON.stringify(viewName)}: ${viewImport}`)
         }
         if (viewEntries.length > 0) {
           componentsObject = `{ default: ${component}, ${viewEntries.join(', ')} }`

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -451,6 +451,9 @@ interface NormalizeRoutesOptions {
 }
 
 function normalizeComponent (page: NuxtPage, pageImport: string, routeName: string | undefined, islandKey: string | undefined): string {
+  if (page._noScripts) {
+    return `import.meta.server ? ${pageImport} : () => Promise.resolve(_noScriptsPageStub)`
+  }
   if (page.mode === 'server') {
     return `() => createIslandPage(${routeName}, import.meta.server ? ${islandKey} : undefined)`
   }
@@ -461,6 +464,9 @@ function normalizeComponent (page: NuxtPage, pageImport: string, routeName: stri
 }
 
 function normalizeComponentWithName (page: NuxtPage, isSyncImport: boolean | undefined, pageImportName: string, pageImport: string, routeName: string | undefined, metaRouteName: string, islandKey: string | undefined): string {
+  if (page._noScripts && !isSyncImport) {
+    return `import.meta.server ? ${pageImport}.then((m) => Object.assign(m.default, { __name: ${metaRouteName} })) : () => Promise.resolve(_noScriptsPageStub)`
+  }
   if (isSyncImport) {
     return `Object.assign(${pageImportName}, { __name: ${metaRouteName} })`
   }
@@ -571,6 +577,13 @@ export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = 
       }
       if (componentsObject) {
         metaRoute.components = componentsObject
+      }
+
+      if (page._noScripts) {
+        // never reached when the no-scripts router guard forces a document
+        // load; reloading recovers the script-free document if it is
+        metaImports.add(`
+const _noScriptsPageStub = { mounted: () => window.location.reload(), render: () => null };`)
       }
 
       if (page.mode === 'server') {

--- a/packages/schema/src/types/hooks.ts
+++ b/packages/schema/src/types/hooks.ts
@@ -57,6 +57,13 @@ export interface NuxtPage {
   mode?: 'client' | 'server' | 'all'
   /** @internal */
   _sync?: boolean
+  /**
+   * The page is served by a `noScripts` route rule: its component is excluded
+   * from the client bundle and client-side navigation to it triggers a full
+   * document load.
+   * @internal
+   */
+  _noScripts?: boolean
 }
 
 export type NuxtMiddleware = {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,8 +13,8 @@ const e2eMatrix = [
 ] as const
 
 const devOnlyTests = ['**/hmr.test.ts']
-const builtOnlyTests = ['**/spa-preloader-*.test.ts', '**/server-page-css.test.ts', '**/chunk-error.test.ts']
-const viteOnlyTests = ['**/server-page-css.test.ts']
+const builtOnlyTests = ['**/spa-preloader-*.test.ts', '**/server-page-css.test.ts', '**/chunk-error.test.ts', '**/no-scripts.test.ts']
+const viteOnlyTests = ['**/server-page-css.test.ts', '**/no-scripts.test.ts']
 const rspackExcludedTests = ['**/chunk-error.test.ts']
 
 function testIgnoreForProject (entry: typeof e2eMatrix[number]) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1989,6 +1989,16 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/nuxt
 
+  test/fixtures/no-scripts:
+    dependencies:
+      nuxt:
+        specifier: workspace:*
+        version: link:../../../packages/nuxt
+    devDependencies:
+      typescript:
+        specifier: catalog:dev
+        version: 6.0.3
+
   test/fixtures/nuxt-time:
     dependencies:
       nuxt:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -956,6 +956,9 @@ importers:
       unctx:
         specifier: catalog:app-runtime
         version: 3.0.0(magic-string@1.1.0)(oxc-parser@0.141.0)(rolldown@1.2.0)(unplugin@3.3.0(@rspack/core@2.1.5(@swc/helpers@0.5.23))(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.62.3)(vite@8.1.5)(webpack@5.109.0(cssnano@8.0.2(postcss@8.5.23))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.23)))
+      unrouting:
+        specifier: catalog:build
+        version: 0.2.2
       unstorage:
         specifier: catalog:nitro-runtime
         version: 2.0.0-alpha.7(chokidar@5.0.0)(db0@0.3.4)(ioredis@5.10.1(supports-color@10.2.2))(lru-cache@11.5.2)(ofetch@1.5.1)

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -97,7 +97,11 @@ describe('route rules', () => {
 
   it('test noScript routeRules', async () => {
     const html = await $fetch<string>('/no-scripts')
-    expect(html).not.toContain('<script')
+    // no executable scripts are shipped; the only `<script>` permitted is the
+    // declarative speculation-rules JSON, which runs no JavaScript
+    const scripts = html.match(/<script[^>]*>/g) ?? []
+    expect(scripts.some(tag => tag.includes('type="speculationrules"'))).toBe(true)
+    expect(scripts.every(tag => tag.includes('type="speculationrules"'))).toBe(true)
   })
 
   it('client-side navigation should redirect if hash included', async () => {

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -152,6 +152,9 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     expect(bundle).not.toContain('no-scripts-page')
     expect(bundle).not.toContain('product-page')
 
+    // a nested child route (relative path resolved against its parent)
+    expect(bundle).not.toContain('dashstatsheading')
+
     // a page whose canonical path is `noScripts` but which has a scripted alias
     // keeps its component so the alias can still render client-side
     expect(bundle).toContain('aliased-page')

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -152,8 +152,10 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     expect(bundle).not.toContain('no-scripts-page')
     expect(bundle).not.toContain('product-page')
 
-    // a nested child route (relative path resolved against its parent)
+    // a nested child route (relative path resolved against its parent), and the
+    // parent shell it renders inside
     expect(bundle).not.toContain('dashstatsheading')
+    expect(bundle).not.toContain('dash-page')
 
     // the default and named views of a `noScripts` route are both stubbed
     expect(bundle).not.toContain('report-default')

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -134,6 +134,30 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
   })
 })
 
+describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM_CI)('noScripts route rules', () => {
+  const rootDir = fileURLToPath(new URL('./fixtures/no-scripts', import.meta.url))
+
+  beforeAll(async () => {
+    await exec('pnpm', ['nuxt', 'build', rootDir])
+  }, 120 * 1000)
+
+  it('drops components of noScripts pages from the client bundle', async () => {
+    const dir = join(rootDir, '.output/public')
+    const bundle = (await Promise.all(
+      (await glob(['**/*.js'], { cwd: dir })).map(file => fsp.readFile(join(dir, file), 'utf8')),
+    )).join('\n')
+
+    // a flat and a dynamic-param page, both covered by a `noScripts` rule, are
+    // replaced by the reload stub, so their component markers never ship
+    expect(bundle).not.toContain('no-scripts-page')
+    expect(bundle).not.toContain('product-page')
+
+    // a page whose canonical path is `noScripts` but which has a scripted alias
+    // keeps its component so the alias can still render client-side
+    expect(bundle).toContain('aliased-page')
+  })
+})
+
 // we strip packages that are small enough rolldown might inline them
 // depending on humidity or the time of day
 const MERGE_BOUNDARY_PACKAGES = new Set(['unctx'])

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -155,6 +155,10 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     // a nested child route (relative path resolved against its parent)
     expect(bundle).not.toContain('dashstatsheading')
 
+    // the default and named views of a `noScripts` route are both stubbed
+    expect(bundle).not.toContain('report-default')
+    expect(bundle).not.toContain('report-aux')
+
     // a page whose canonical path is `noScripts` but which has a scripted alias
     // keeps its component so the alias can still render client-side
     expect(bundle).toContain('aliased-page')

--- a/test/e2e/no-scripts.test.ts
+++ b/test/e2e/no-scripts.test.ts
@@ -23,11 +23,15 @@ test.describe('noScripts route rules', () => {
     expect(html).not.toContain('__NUXT_DATA__')
   })
 
-  test('emits blanket speculation rules and a view transition on a noScripts route', async ({ fetch }) => {
+  test('scopes noScripts-page speculation rules to page routes and emits a view transition', async ({ fetch }) => {
     const html = await (await fetch('/no-scripts')).text()
 
     expect(html).toContain('type="speculationrules"')
-    expect(html).toContain('"href_matches":"/*"')
+    // scoped to same-origin page routes (safe to GET), never a blanket `/*`
+    // that could reach non-idempotent server routes
+    expect(html).toContain('"href_matches":"/report"')
+    expect(html).toContain('"href_matches":"/products/:id"')
+    expect(html).not.toContain('"href_matches":"/*"')
     expect(html).toContain('@view-transition{navigation:auto}')
   })
 

--- a/test/e2e/no-scripts.test.ts
+++ b/test/e2e/no-scripts.test.ts
@@ -1,0 +1,102 @@
+import { fileURLToPath } from 'node:url'
+import { isWindows } from 'std-env'
+import { expect, test } from './test-utils'
+
+const fixtureDir = fileURLToPath(new URL('../fixtures/no-scripts', import.meta.url))
+
+test.use({
+  nuxt: {
+    rootDir: fixtureDir,
+    server: true,
+    browser: true,
+    setupTimeout: (isWindows ? 360 : 120) * 1000,
+  },
+})
+
+test.describe('noScripts route rules', () => {
+  test('serves a noScripts route without any scripts', async ({ fetch }) => {
+    const html = await (await fetch('/no-scripts')).text()
+
+    expect(html).toContain('No scripts page')
+    expect(html).not.toContain('type="module"')
+    expect(html).not.toContain('type="importmap"')
+    expect(html).not.toContain('__NUXT_DATA__')
+  })
+
+  test('emits blanket speculation rules and a view transition on a noScripts route', async ({ fetch }) => {
+    const html = await (await fetch('/no-scripts')).text()
+
+    expect(html).toContain('type="speculationrules"')
+    expect(html).toContain('"href_matches":"/*"')
+    expect(html).toContain('@view-transition{navigation:auto}')
+  })
+
+  test('serves a dynamic-param route under a noScripts glob without any scripts', async ({ fetch }) => {
+    const html = await (await fetch('/products/123')).text()
+
+    expect(html).toContain('Product 123')
+    expect(html).not.toContain('type="module"')
+    expect(html).not.toContain('__NUXT_DATA__')
+  })
+
+  test('emits speculation rules scoped to noScripts patterns on a scripted page', async ({ fetch }) => {
+    const html = await (await fetch('/')).text()
+
+    // scripted pages keep their client runtime
+    expect(html).toContain('type="module"')
+
+    expect(html).toContain('type="speculationrules"')
+    expect(html).toContain('"href_matches":"/no-scripts"')
+    expect(html).toContain('"href_matches":"/no-scripts/*"')
+    expect(html).toContain('"href_matches":"/aliased"')
+    expect(html).toContain('"href_matches":"/products/*"')
+    // scoped, never the blanket rule the noScripts pages themselves emit
+    expect(html).not.toContain('"href_matches":"/*"')
+    expect(html).toContain('@view-transition{navigation:auto}')
+  })
+
+  test('client-side navigation to a dynamic-param noScripts route triggers a full document load', async ({ page, goto }) => {
+    await goto('/')
+    await page.evaluate(() => { (window as any).__marker = 'kept' })
+
+    await page.click('#link-product')
+    await page.waitForURL(url => url.pathname === '/products/123')
+    await page.locator('#product-page').waitFor()
+
+    expect(await page.evaluate(() => (window as any).__marker)).toBeUndefined()
+    expect(await page.evaluate(() => (window as any).useNuxtApp)).toBeUndefined()
+  })
+
+  test('client-side navigation to a noScripts route triggers a full document load', async ({ page, goto }) => {
+    await goto('/')
+    await page.evaluate(() => { (window as any).__marker = 'kept' })
+
+    await page.click('#link-no-scripts')
+    await page.waitForURL(url => url.pathname === '/no-scripts')
+    await page.locator('#no-scripts-page').waitFor()
+
+    // a full document load discards the marker set on the previous document
+    expect(await page.evaluate(() => (window as any).__marker)).toBeUndefined()
+    // and the destination genuinely ships no client runtime
+    expect(await page.evaluate(() => (window as any).useNuxtApp)).toBeUndefined()
+  })
+
+  test('a non-noScripts alias of a noScripts page still renders client-side', async ({ page, goto }) => {
+    await goto('/')
+    await page.evaluate(() => { (window as any).__marker = 'kept' })
+
+    // the alias is not covered by a route rule, so navigation stays a SPA transition
+    await page.click('#link-aliased-alt')
+    await page.waitForURL(url => url.pathname === '/aliased-alt')
+    await page.locator('#aliased-page').waitFor()
+    expect(await page.evaluate(() => (window as any).__marker)).toBe('kept')
+
+    // the canonical path is served without scripts, so it forces a document load
+    await goto('/')
+    await page.evaluate(() => { (window as any).__marker = 'kept' })
+    await page.click('#link-aliased')
+    await page.waitForURL(url => url.pathname === '/aliased')
+    await page.locator('#aliased-page').waitFor()
+    expect(await page.evaluate(() => (window as any).__marker)).toBeUndefined()
+  })
+})

--- a/test/fixtures/no-scripts/app.vue
+++ b/test/fixtures/no-scripts/app.vue
@@ -1,0 +1,3 @@
+<template>
+  <NuxtPage />
+</template>

--- a/test/fixtures/no-scripts/app/pages/aliased.vue
+++ b/test/fixtures/no-scripts/app/pages/aliased.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+definePageMeta({
+  alias: ['/aliased-alt'],
+})
+</script>
+
+<template>
+  <h1 id="aliased-page">
+    Aliased page
+  </h1>
+</template>

--- a/test/fixtures/no-scripts/app/pages/dash.vue
+++ b/test/fixtures/no-scripts/app/pages/dash.vue
@@ -1,0 +1,5 @@
+<template>
+  <div id="dash-page">
+    <NuxtPage />
+  </div>
+</template>

--- a/test/fixtures/no-scripts/app/pages/dash/stats.vue
+++ b/test/fixtures/no-scripts/app/pages/dash/stats.vue
@@ -1,0 +1,5 @@
+<template>
+  <h1 id="dashstatsheading">
+    Dashboard stats
+  </h1>
+</template>

--- a/test/fixtures/no-scripts/app/pages/index.vue
+++ b/test/fixtures/no-scripts/app/pages/index.vue
@@ -1,0 +1,29 @@
+<template>
+  <div>
+    <h1>Scripted index</h1>
+    <NuxtLink
+      id="link-no-scripts"
+      to="/no-scripts"
+    >
+      No scripts
+    </NuxtLink>
+    <NuxtLink
+      id="link-aliased"
+      to="/aliased"
+    >
+      Aliased (noScripts)
+    </NuxtLink>
+    <NuxtLink
+      id="link-aliased-alt"
+      to="/aliased-alt"
+    >
+      Aliased alt (scripted)
+    </NuxtLink>
+    <NuxtLink
+      id="link-product"
+      to="/products/123"
+    >
+      Product 123
+    </NuxtLink>
+  </div>
+</template>

--- a/test/fixtures/no-scripts/app/pages/no-scripts.vue
+++ b/test/fixtures/no-scripts/app/pages/no-scripts.vue
@@ -1,0 +1,13 @@
+<template>
+  <div>
+    <h1 id="no-scripts-page">
+      No scripts page
+    </h1>
+    <NuxtLink
+      id="link-home"
+      to="/"
+    >
+      Home
+    </NuxtLink>
+  </div>
+</template>

--- a/test/fixtures/no-scripts/app/pages/products/[id].vue
+++ b/test/fixtures/no-scripts/app/pages/products/[id].vue
@@ -1,0 +1,5 @@
+<template>
+  <h1 id="product-page">
+    Product {{ $route.params.id }}
+  </h1>
+</template>

--- a/test/fixtures/no-scripts/app/pages/report.vue
+++ b/test/fixtures/no-scripts/app/pages/report.vue
@@ -1,0 +1,5 @@
+<template>
+  <h1 id="report-default">
+    Report
+  </h1>
+</template>

--- a/test/fixtures/no-scripts/app/pages/report@aux.vue
+++ b/test/fixtures/no-scripts/app/pages/report@aux.vue
@@ -1,0 +1,5 @@
+<template>
+  <aside id="report-aux">
+    Report aux view
+  </aside>
+</template>

--- a/test/fixtures/no-scripts/nuxt.config.ts
+++ b/test/fixtures/no-scripts/nuxt.config.ts
@@ -1,0 +1,14 @@
+export default defineNuxtConfig({
+  devtools: { enabled: false },
+  routeRules: {
+    '/no-scripts': { noScripts: true },
+    '/no-scripts/**': { noScripts: true },
+    // canonical path is served without scripts, but the `/aliased-alt` alias is not
+    '/aliased': { noScripts: true },
+    '/products/**': { noScripts: true },
+  },
+  experimental: {
+    viewTransition: true,
+  },
+  compatibilityDate: 'latest',
+})

--- a/test/fixtures/no-scripts/nuxt.config.ts
+++ b/test/fixtures/no-scripts/nuxt.config.ts
@@ -7,6 +7,7 @@ export default defineNuxtConfig({
     '/aliased': { noScripts: true },
     '/products/**': { noScripts: true },
     '/dash/**': { noScripts: true },
+    '/report': { noScripts: true },
   },
   experimental: {
     viewTransition: true,

--- a/test/fixtures/no-scripts/nuxt.config.ts
+++ b/test/fixtures/no-scripts/nuxt.config.ts
@@ -6,6 +6,7 @@ export default defineNuxtConfig({
     // canonical path is served without scripts, but the `/aliased-alt` alias is not
     '/aliased': { noScripts: true },
     '/products/**': { noScripts: true },
+    '/dash/**': { noScripts: true },
   },
   experimental: {
     viewTransition: true,

--- a/test/fixtures/no-scripts/package.json
+++ b/test/fixtures/no-scripts/package.json
@@ -1,0 +1,16 @@
+{
+  "private": true,
+  "name": "fixture-no-scripts",
+  "scripts": {
+    "build": "nuxt build"
+  },
+  "dependencies": {
+    "nuxt": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "catalog:dev"
+  },
+  "engines": {
+    "node": "^22.19.0 || ^24.11.0 || >=26.0.0"
+  }
+}

--- a/test/fixtures/no-scripts/tsconfig.json
+++ b/test/fixtures/no-scripts/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./.nuxt/tsconfig.app.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.server.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.shared.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.node.json"
+    }
+  ]
+}


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/27937

### 📚 Description

this is three separate features designed to improve the way setting `noScripts` works for Nuxt:

1. **hard reload on navigation.** when part of your app uses `noScripts`, a client-side navigation _to_ a route covered by a `noScripts` route rule is upgraded to a full document load, so it doesn't load that page via JS.

2. **speculation rules** to speed up these MPA navigations:
     - on a page served without scripts (globally or via a route rule), a blanket rule for same-origin links
     - on a scripted page, rules scoped to the app's `noScripts` route patterns (via https://github.com/unjs/unrouting/pull/167), emitted up front so a later hard-reload navigation to them is already prefetched/prerendered

3. **declarative cross-document view transitions** (a `@view-transition` style tag) under the same two conditions as above, when `viewTransition` support is enabled (globally or locally).

additionally, we tree-shake out pages if they are fully covered by a `noScripts` route rule