### PR TITLE
refactor(nuxt): remove `config.cjs` file in `require` export

### DIFF
--- a/packages/nuxt/config.cjs
+++ b/packages/nuxt/config.cjs
@@ -1,7 +1,0 @@
-function defineNuxtConfig (config) {
-  return config
-}
-
-module.exports = {
-  defineNuxtConfig,
-}

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -20,7 +20,7 @@
     "./config": {
       "types": "./config.d.ts",
       "import": "./config.js",
-      "require": "./config.cjs"
+      "require": "./config.js"
     },
     "./schema": "./schema.js",
     "./kit": "./kit.js",


### PR DESCRIPTION

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

Since Node v22.0.0 or v20.17.0 node allows for loading ECMAScript modules using `require()` if the module doesn't contain a top level await and neareast `package.json` has `"type": "module"`. Both conditions are met by nuxt, so this change isn't a breaking change.

Source: https://nodejs.org/api/modules.html

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
