### PR TITLE
fix(nuxt): use client-side navigation for links inside islands

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -531,7 +531,7 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
 
             if (import.meta.server && useNuxtApp().ssrContext?.islandContext) {
               // marks internal links within island HTML for client-side navigation
-              routerLinkProps['data-internal'] = ''
+              routerLinkProps['data-internal'] = props.replace ? 'replace' : ''
             }
           }
 

--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -23,7 +23,7 @@ import { cancelIdleCallback, requestIdleCallback } from '../compat/idle-callback
 import { renderDiagnostics } from '../diagnostics/render'
 import { navigationDiagnostics } from '../diagnostics/navigation'
 
-import { nuxtLinkDefaults } from '#build/nuxt.config.mjs'
+import { componentIslands, nuxtLinkDefaults } from '#build/nuxt.config.mjs'
 
 import { hashMode } from '#build/router.options.mjs'
 import type { NuxtLinkOptions } from '../types'
@@ -529,9 +529,13 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
             }
             routerLinkProps.rel = props.rel || undefined
 
-            if (import.meta.server && useNuxtApp().ssrContext?.islandContext) {
+            if (import.meta.server && componentIslands && useNuxtApp().ssrContext?.islandContext) {
               // marks internal links within island HTML for client-side navigation
-              routerLinkProps['data-internal'] = props.replace ? 'replace' : ''
+              const flags: string[] = []
+              if (props.replace) { flags.push('replace') }
+              const prefetchOnVisibility = typeof props.prefetchOn === 'string' ? props.prefetchOn === 'visibility' : (props.prefetchOn?.visibility ?? options.prefetchOn?.visibility)
+              if (prefetchOnVisibility && (props.prefetch ?? options.prefetch) !== false && props.noPrefetch !== true) { flags.push('prefetch') }
+              routerLinkProps['data-internal'] = flags.join(' ')
             }
           }
 
@@ -613,7 +617,8 @@ function applyTrailingSlashBehavior (to: string, trailingSlash: NuxtLinkOptions[
 type CallbackFn = () => void
 type ObserveFn = (element: Element, callback: CallbackFn) => () => void
 
-function useObserver (): { observe: ObserveFn } | undefined {
+/** @internal */
+export function useObserver (): { observe: ObserveFn } | undefined {
   if (import.meta.server) { return }
 
   const nuxtApp = useNuxtApp()
@@ -653,7 +658,8 @@ function useObserver (): { observe: ObserveFn } | undefined {
 }
 
 const IS_2G_RE = /2g/
-function isSlowConnection () {
+/** @internal */
+export function isSlowConnection () {
   if (import.meta.server) { return }
 
   // https://developer.mozilla.org/en-US/docs/Web/API/Navigator/connection

--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -505,7 +505,7 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
         })
 
         if (!isExternal.value && !hasTarget.value && !isHashLinkWithoutHashMode(to.value)) {
-          const routerLinkProps: RouterLinkProps & VNodeProps & AllowedComponentProps & AnchorHTMLAttributes = {
+          const routerLinkProps: RouterLinkProps & VNodeProps & AllowedComponentProps & AnchorHTMLAttributes & { 'data-internal'?: string } = {
             ref: elRef,
             to: to.value,
             activeClass: props.activeClass || options.activeClass,
@@ -528,6 +528,11 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
               }
             }
             routerLinkProps.rel = props.rel || undefined
+
+            if (import.meta.server && useNuxtApp().ssrContext?.islandContext) {
+              // marks internal links within island HTML for client-side navigation
+              routerLinkProps['data-internal'] = ''
+            }
           }
 
           // Internal link

--- a/packages/nuxt/src/app/plugins/island-link-navigation.client.ts
+++ b/packages/nuxt/src/app/plugins/island-link-navigation.client.ts
@@ -1,18 +1,20 @@
 import { defineNuxtPlugin } from '../nuxt'
 import type { ObjectPlugin, Plugin } from '../nuxt'
 import { useRouter } from '../composables/router'
+import { onNuxtReady } from '../composables/ready'
+import { preloadRouteComponents } from '../composables/preload'
+import { isSlowConnection, useObserver } from '../components/nuxt-link'
+
+import { componentIslands } from '#build/nuxt.config.mjs'
 
 const plugin: Plugin & ObjectPlugin = defineNuxtPlugin({
   name: 'nuxt:island-link-navigation',
-  setup () {
+  setup (nuxtApp) {
+    if (!componentIslands) { return }
+
     const router = useRouter()
 
-    function onClick (e: MouseEvent) {
-      if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.altKey || e.ctrlKey || e.shiftKey) { return }
-
-      const anchor = (e.target as Element | null)?.closest('a')
-      if (!anchor || !anchor.hasAttribute('data-internal') || anchor.hasAttribute('download')) { return }
-
+    function resolveInternalLink (anchor: HTMLAnchorElement) {
       const href = anchor.getAttribute('href')
       if (!href || href.startsWith('#')) { return }
 
@@ -32,10 +34,20 @@ const plugin: Plugin & ObjectPlugin = defineNuxtPlugin({
       }
 
       const route = router.resolve(path + url.search + url.hash)
-      if (!route.matched.length) { return }
+      if (route.matched.length) { return route }
+    }
+
+    function onClick (e: MouseEvent) {
+      if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.altKey || e.ctrlKey || e.shiftKey) { return }
+
+      const anchor = (e.target as Element | null)?.closest('a')
+      if (!anchor || !anchor.hasAttribute('data-internal') || anchor.hasAttribute('download')) { return }
+
+      const route = resolveInternalLink(anchor)
+      if (!route) { return }
 
       e.preventDefault()
-      if (anchor.getAttribute('data-internal') === 'replace') {
+      if (anchor.getAttribute('data-internal')!.split(' ').includes('replace')) {
         router.replace(route.fullPath)
       } else {
         router.push(route.fullPath)
@@ -43,6 +55,58 @@ const plugin: Plugin & ObjectPlugin = defineNuxtPlugin({
     }
 
     document.addEventListener('click', onClick)
+
+    if (isSlowConnection()) { return }
+
+    const unobservers = new Map<Element, () => void>()
+
+    function observeAnchors (root: Element) {
+      const observer = useObserver()
+      if (!observer) { return }
+
+      const selector = 'a[data-internal~="prefetch"]'
+      const anchors = [...root.querySelectorAll<HTMLAnchorElement>(selector)]
+      if (root.matches(selector)) { anchors.push(root as HTMLAnchorElement) }
+
+      for (const anchor of anchors) {
+        if (unobservers.has(anchor)) { continue }
+        const unobserve = observer.observe(anchor, () => {
+          unobservers.get(anchor)?.()
+          unobservers.delete(anchor)
+          const route = resolveInternalLink(anchor)
+          if (!route) { return }
+          nuxtApp.hooks.callHook('link:prefetch', route.fullPath)?.catch(() => {})
+          if (!import.meta.dev) {
+            preloadRouteComponents(route.fullPath, router).catch(() => {})
+          }
+        })
+        unobservers.set(anchor, unobserve)
+      }
+    }
+
+    function unobserveAnchors (root: Element) {
+      for (const [anchor, unobserve] of unobservers) {
+        if (root.contains(anchor)) {
+          unobserve()
+          unobservers.delete(anchor)
+        }
+      }
+    }
+
+    onNuxtReady(() => {
+      observeAnchors(document.body)
+      const mutationObserver = new MutationObserver((mutations) => {
+        for (const mutation of mutations) {
+          for (const node of mutation.removedNodes) {
+            if (node.nodeType === 1) { unobserveAnchors(node as Element) }
+          }
+          for (const node of mutation.addedNodes) {
+            if (node.nodeType === 1) { observeAnchors(node as Element) }
+          }
+        }
+      })
+      mutationObserver.observe(document.body, { childList: true, subtree: true })
+    })
   },
 })
 

--- a/packages/nuxt/src/app/plugins/island-link-navigation.client.ts
+++ b/packages/nuxt/src/app/plugins/island-link-navigation.client.ts
@@ -11,7 +11,7 @@ const plugin: Plugin & ObjectPlugin = defineNuxtPlugin({
       if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.altKey || e.ctrlKey || e.shiftKey) { return }
 
       const anchor = (e.target as Element | null)?.closest('a')
-      if (!anchor || !anchor.hasAttribute('data-internal')) { return }
+      if (!anchor || !anchor.hasAttribute('data-internal') || anchor.hasAttribute('download')) { return }
 
       const href = anchor.getAttribute('href')
       if (!href || href.startsWith('#')) { return }
@@ -35,7 +35,11 @@ const plugin: Plugin & ObjectPlugin = defineNuxtPlugin({
       if (!route.matched.length) { return }
 
       e.preventDefault()
-      router.push(route.fullPath)
+      if (anchor.getAttribute('data-internal') === 'replace') {
+        router.replace(route.fullPath)
+      } else {
+        router.push(route.fullPath)
+      }
     }
 
     document.addEventListener('click', onClick)

--- a/packages/nuxt/src/app/plugins/island-link-navigation.client.ts
+++ b/packages/nuxt/src/app/plugins/island-link-navigation.client.ts
@@ -1,0 +1,45 @@
+import { defineNuxtPlugin } from '../nuxt'
+import type { ObjectPlugin, Plugin } from '../nuxt'
+import { useRouter } from '../composables/router'
+
+const plugin: Plugin & ObjectPlugin = defineNuxtPlugin({
+  name: 'nuxt:island-link-navigation',
+  setup () {
+    const router = useRouter()
+
+    function onClick (e: MouseEvent) {
+      if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.altKey || e.ctrlKey || e.shiftKey) { return }
+
+      const anchor = (e.target as Element | null)?.closest('a')
+      if (!anchor || !anchor.hasAttribute('data-internal')) { return }
+
+      const href = anchor.getAttribute('href')
+      if (!href || href.startsWith('#')) { return }
+
+      const url = new URL(anchor.href, window.location.href)
+      if (url.origin !== window.location.origin) { return }
+
+      let path = url.pathname
+      const base = (router.options.history.base || '').replace(/\/$/, '')
+      if (base) {
+        if (path === base) {
+          path = '/'
+        } else if (path.startsWith(base + '/')) {
+          path = path.slice(base.length)
+        } else {
+          return
+        }
+      }
+
+      const route = router.resolve(path + url.search + url.hash)
+      if (!route.matched.length) { return }
+
+      e.preventDefault()
+      router.push(route.fullPath)
+    }
+
+    document.addEventListener('click', onClick)
+  },
+})
+
+export default plugin

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -749,6 +749,10 @@ async function initNuxt (nuxt: Nuxt) {
 
   // Route chunk errors require route-level chunks and client-side navigation
   const pagesEnabled = nuxt.options.pages !== false && (nuxt.options.pages as { enabled?: boolean } | undefined)?.enabled !== false
+  // Handle client-side navigation for links rendered inside server component islands
+  if (pagesEnabled && nuxt.options.experimental.componentIslands) {
+    addPlugin(resolve(nuxt.options.appDir, 'plugins/island-link-navigation.client'))
+  }
   // Add experimental page reload support
   if (pagesEnabled && nuxt.options.experimental.emitRouteChunkError === 'automatic') {
     addPlugin(resolve(nuxt.options.appDir, 'plugins/chunk-reload.client'))

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -55,7 +55,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
   it('default client bundle size (pages)', async () => {
     const clientStats = await analyzeSizes(['**/*.js'], join(pagesRootDir, '.output/public'), pagesRootDir)
 
-    expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"177k"`)
+    expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"179k"`)
 
     const files = clientStats!.files.map(f => f.replace(/\..*\.js/, '.js'))
 

--- a/test/fixtures/server-components/app/pages/server-page.server.vue
+++ b/test/fixtures/server-components/app/pages/server-page.server.vue
@@ -2,9 +2,16 @@
   <div id="server-page">
     Hello this is a server page
     <NuxtLink
+      id="island-link-home"
       to="/"
     >
       to home
+    </NuxtLink>
+    <NuxtLink
+      id="island-link-server-page"
+      to="/server-page-with-nuxtpage"
+    >
+      to other server page
     </NuxtLink>
   </div>
 </template>

--- a/test/fixtures/server-components/app/pages/server-page.server.vue
+++ b/test/fixtures/server-components/app/pages/server-page.server.vue
@@ -13,6 +13,13 @@
     >
       to other server page
     </NuxtLink>
+    <NuxtLink
+      id="island-link-replace"
+      to="/server-page-with-nuxtpage"
+      replace
+    >
+      replace with other server page
+    </NuxtLink>
   </div>
 </template>
 

--- a/test/fixtures/server-components/app/plugins/link-prefetch-spy.client.ts
+++ b/test/fixtures/server-components/app/plugins/link-prefetch-spy.client.ts
@@ -1,0 +1,5 @@
+export default defineNuxtPlugin((nuxtApp) => {
+  const prefetched: string[] = []
+  ;(window as any).__prefetchedLinks = prefetched
+  nuxtApp.hooks.hook('link:prefetch', (link) => { prefetched.push(link) })
+})

--- a/test/server-components.test.ts
+++ b/test/server-components.test.ts
@@ -202,6 +202,12 @@ describe('server components/islands', () => {
     await page.close()
   })
 
+  it('/server-page - island links are prefetched when visible', async () => {
+    const { page } = await renderPage('/server-page')
+    await page.waitForFunction(() => (window as any).__prefetchedLinks?.includes('/server-page-with-nuxtpage'))
+    await page.close()
+  })
+
   it('/server-page - island links with `replace` do not add a history entry', async () => {
     const { page } = await renderPage('/')
     await page.getByText('to server page').click()

--- a/test/server-components.test.ts
+++ b/test/server-components.test.ts
@@ -184,7 +184,7 @@ describe('server components/islands', () => {
     await page.close()
   })
 
-  itFailsIf(builder === 'webpack' && isDev)('/server-page - links inside islands use client-side navigation', async () => {
+  it('/server-page - links inside islands use client-side navigation', async () => {
     const { page } = await renderPage('/server-page')
     await page.evaluate(() => { (window as any).__islandNavMarker = true })
 

--- a/test/server-components.test.ts
+++ b/test/server-components.test.ts
@@ -202,6 +202,20 @@ describe('server components/islands', () => {
     await page.close()
   })
 
+  it('/server-page - island links with `replace` do not add a history entry', async () => {
+    const { page } = await renderPage('/')
+    await page.getByText('to server page').click()
+    await page.locator('#island-link-replace').waitFor()
+    await page.click('#island-link-replace')
+    await page.locator('#server-page-with-nuxtpage').waitFor()
+
+    await page.goBack()
+    await page.locator('#islands').waitFor()
+    expect(page.url().endsWith('/')).toBe(true)
+
+    await page.close()
+  })
+
   it('/server-page-with-nuxtpage/child renders the parent server page with the child route', async () => {
     const html = await $fetch<string>('/server-page-with-nuxtpage/child')
     expect(html).toContain('id="server-page-with-nuxtpage"')

--- a/test/server-components.test.ts
+++ b/test/server-components.test.ts
@@ -162,6 +162,10 @@ describe('server components/islands', () => {
     expect(html).toContain('plugin-style')
     // #34482 - title should be composed with titleTemplate
     expect(html).toContain('<title>Server Page - Fixture</title>')
+    expect(html).toContain('data-internal')
+
+    const clientPageHtml = await $fetch<string>('/')
+    expect(clientPageHtml).not.toContain('data-internal')
   })
 
   itFailsIf(builder === 'webpack' && isDev)('/server-page - should preserve title after hydration', async () => {
@@ -177,6 +181,24 @@ describe('server components/islands', () => {
     await page.waitForLoadState('networkidle')
 
     expect(await page.innerHTML('head')).toContain('<meta name="author" content="Nuxt">')
+    await page.close()
+  })
+
+  itFailsIf(builder === 'webpack' && isDev)('/server-page - links inside islands use client-side navigation', async () => {
+    const { page } = await renderPage('/server-page')
+    await page.evaluate(() => { (window as any).__islandNavMarker = true })
+
+    await page.click('#island-link-server-page')
+    await page.locator('#server-page-with-nuxtpage').waitFor()
+    expect(page.url()).toContain('/server-page-with-nuxtpage')
+    expect(await page.evaluate(() => (window as any).__islandNavMarker)).toBe(true)
+
+    await page.goBack()
+    await page.locator('#island-link-home').waitFor()
+    await page.click('#island-link-home')
+    await page.locator('#islands').waitFor()
+    expect(await page.evaluate(() => (window as any).__islandNavMarker)).toBe(true)
+
     await page.close()
   })
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

previously links within islands required manual handling - they would force reload the entire page, even though there _was_ an instantiated router ready to handle them.

this adds a small layer when component islands are enabled, which listens to link clicks on `<a data-internal>` elements (only emitted in server islands)