### PR TITLE
fix(nuxt): serialize island payloads for components with underscores in keys

### DIFF
--- a/packages/nuxt/src/app/plugins/utils.ts
+++ b/packages/nuxt/src/app/plugins/utils.ts
@@ -1,4 +1,4 @@
-const VALID_ISLAND_KEY_RE = /^[a-z][a-z\d-]*_[a-z\d]+$/i
+const VALID_ISLAND_KEY_RE = /^[a-z][\w-]*_[a-z\d]+$/i
 export function isValidIslandKey (key: unknown): key is string {
   return typeof key === 'string' && VALID_ISLAND_KEY_RE.test(key) && key.length <= 100
 }

--- a/packages/nuxt/test/plugin-utils.test.ts
+++ b/packages/nuxt/test/plugin-utils.test.ts
@@ -15,6 +15,10 @@ describe('isValidIslandKey util', () => {
     expect(isValidIslandKey('Component-Name_hash123')).toBe(true)
     const sampleHash = hash({ props: randomUUID() }).replace(/[-_]/g, '')
     expect(isValidIslandKey('ComponentName_' + sampleHash)).toBe(true)
+    // island pages and components with underscores in their names
+    expect(isValidIslandKey('page_server-page_' + sampleHash)).toBe(true)
+    expect(isValidIslandKey('Component_Name_hash123')).toBe(true)
+    expect(isValidIslandKey('Component__hash123')).toBe(true)
   })
 
   it('should reject invalid island keys', () => {
@@ -46,6 +50,7 @@ describe('isValidIslandKey util', () => {
     expect(isValidIslandKey('../../Component_hash123')).toBe(false)
     expect(isValidIslandKey('Component_../hash123')).toBe(false)
     expect(isValidIslandKey('Component_../../hash123')).toBe(false)
+    expect(isValidIslandKey('page_server-page_hash.json')).toBe(false)
 
     // URL/protocol attempts
     expect(isValidIslandKey('http://evil.com_hash123')).toBe(false)
@@ -54,9 +59,6 @@ describe('isValidIslandKey util', () => {
 
     const longKey = 'A'.repeat(95) + '_' + 'B'.repeat(10)
     expect(isValidIslandKey(longKey)).toBe(false)
-
-    expect(isValidIslandKey('Component_Name_hash123')).toBe(false)
-    expect(isValidIslandKey('Component__hash123')).toBe(false)
   })
 
   it('should handle edge cases', () => {

--- a/test/server-components.test.ts
+++ b/test/server-components.test.ts
@@ -224,6 +224,11 @@ describe('server components/islands', () => {
     await page.close()
   })
 
+  it('/server-page - should ship island html only once in the initial response', async () => {
+    const html = await $fetch<string>('/server-page')
+    expect(html.match(/Hello this is a server page/g)).toHaveLength(1)
+  })
+
   it('/server-page-with-nuxtpage/child renders the parent server page with the child route', async () => {
     const html = await $fetch<string>('/server-page-with-nuxtpage/child')
     expect(html).toContain('id="server-page-with-nuxtpage"')


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

#33069 introduced a bug by preventing server pages from being serialised (that is, benefiting from the serialiser that _exempted_ them from the payload).

in other words, server pages shipped their html twice. this PR fixes that