### PR TITLE
feat(nuxt): prefetch server page islands via `<NuxtLink>`

### DIFF
--- a/packages/nuxt/src/components/runtime/server-component.ts
+++ b/packages/nuxt/src/components/runtime/server-component.ts
@@ -2,9 +2,14 @@ import { defineComponent, getCurrentInstance, h, ref } from 'vue'
 import type { DefineSetupFnComponent } from 'vue'
 import NuxtIsland from '#app/components/nuxt-island'
 import { useRoute } from '#app/composables/router'
-import { isPrerendered } from '#app/composables/payload'
+import { isPrerendered, shouldLoadPayload } from '#app/composables/payload'
 import { createError, showError } from '#app/composables/error'
 import { useNuxtApp } from '#app/nuxt'
+import type { NuxtApp } from '#app/nuxt'
+import { getIslandHash } from '#app/island-hash'
+import type { NuxtIslandResponse } from '#app/types'
+import { $fetch } from '#build/fetch'
+import { payloadExtraction } from '#build/nuxt.config.mjs'
 
 interface ServerComponentProps {
   lazy?: boolean
@@ -89,5 +94,36 @@ export const createIslandPage = (name: string, islandKey?: string): IslandPageTy
   if (import.meta.server && islandKey) {
     (component as any).__nuxt_island = islandKey
   }
+  if (import.meta.client) {
+    (component as any).__nuxt_prefetch = (nuxtApp: NuxtApp, route: { path: string, fullPath: string }) => prefetchIslandPage(nuxtApp, name, route)
+  }
   return component as unknown as IslandPageType
+}
+
+const inflightIslandPrefetches = import.meta.client ? new Set<string>() : undefined
+
+async function prefetchIslandPage (nuxtApp: NuxtApp, name: string, route: { path: string, fullPath: string }) {
+  const [prerendered, willLoadPayload] = await nuxtApp.runWithContext(() => Promise.all([
+    isPrerendered(route.path),
+    payloadExtraction ? shouldLoadPayload(route.path) : false,
+  ]))
+  // if the payload for the target route will be prefetched, reviving it already
+  // triggers the island fetch (see the `Island` reviver in `revive-payload.client.ts`)
+  if (willLoadPayload) { return }
+  const url = prerendered ? route.path : route.fullPath.replace(/#.*$/, '')
+  const islandName = `page_${name}`
+  const key = `${islandName}_${getIslandHash({ name: islandName, props: '{}', context: { url } })}`
+  if (inflightIslandPrefetches!.has(key) || nuxtApp.payload.data[key]) { return }
+  inflightIslandPrefetches!.add(key)
+  try {
+    const result = await $fetch<NuxtIslandResponse>(`/__nuxt_island/${key}.json`, {
+      query: { url },
+      responseType: 'json',
+    })
+    nuxtApp.payload.data[key] ||= result
+  } catch {
+    // a failed prefetch is not fatal; the island will be fetched again on mount
+  } finally {
+    inflightIslandPrefetches!.delete(key)
+  }
 }

--- a/packages/nuxt/src/pages/runtime/plugins/prefetch.client.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/prefetch.client.ts
@@ -6,6 +6,7 @@ import { useRouter } from '#app/composables/router'
 import layouts from '#build/layouts'
 import { namedMiddleware } from '#build/middleware'
 import { _loadAsyncComponent } from '#app/composables/preload'
+import { componentIslands } from '#build/nuxt.config.mjs'
 
 const plugin: Plugin & ObjectPlugin = defineNuxtPlugin({
   name: 'nuxt:prefetch',
@@ -40,6 +41,17 @@ const plugin: Plugin & ObjectPlugin = defineNuxtPlugin({
 
       if (typeof layout === 'string' && layout in layouts) {
         _loadAsyncComponent(layouts[layout])
+      }
+
+      if (componentIslands) {
+        for (const record of route.matched) {
+          const component = record.components?.default
+          if (typeof component === 'function') {
+            Promise.resolve((component as () => unknown)())
+              .then((c: any) => (c?.default || c)?.__nuxt_prefetch?.(nuxtApp, route))
+              .catch(() => {})
+          }
+        }
       }
     })
   },

--- a/packages/nuxt/src/pages/runtime/plugins/prefetch.client.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/prefetch.client.ts
@@ -23,7 +23,7 @@ const plugin: Plugin & ObjectPlugin = defineNuxtPlugin({
       })
     })
     // Prefetch layouts & middleware
-    nuxtApp.hooks.hook('link:prefetch', (url) => {
+    nuxtApp.hooks.hook('link:prefetch', async (url) => {
       if (hasProtocol(url)) { return }
       const route = router.resolve(url)
       if (!route) { return }
@@ -44,14 +44,13 @@ const plugin: Plugin & ObjectPlugin = defineNuxtPlugin({
       }
 
       if (componentIslands) {
-        for (const record of route.matched) {
+        await Promise.all(route.matched.map((record) => {
           const component = record.components?.default
-          if (typeof component === 'function') {
-            Promise.resolve((component as () => unknown)())
-              .then((c: any) => (c?.default || c)?.__nuxt_prefetch?.(nuxtApp, route))
-              .catch(() => {})
-          }
-        }
+          if (typeof component !== 'function') { return }
+          return Promise.resolve((component as () => unknown)())
+            .then((c: any) => (c?.default || c)?.__nuxt_prefetch?.(nuxtApp, route))
+            .catch(() => {})
+        }))
       }
     })
   },

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -55,7 +55,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
   it('default client bundle size (pages)', async () => {
     const clientStats = await analyzeSizes(['**/*.js'], join(pagesRootDir, '.output/public'), pagesRootDir)
 
-    expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"179k"`)
+    expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"180k"`)
 
     const files = clientStats!.files.map(f => f.replace(/\..*\.js/, '.js'))
 

--- a/test/server-components.test.ts
+++ b/test/server-components.test.ts
@@ -234,7 +234,7 @@ describe('server components/islands', () => {
     expect(html.match(/Hello this is a server page/g)).toHaveLength(1)
   })
 
-  itFailsIf(builder === 'webpack' && isDev)('/server-page - island response is prefetched by NuxtLink', async () => {
+  it('/server-page - island response is prefetched by NuxtLink', async () => {
     const { page, requests } = await renderPage('/')
     await page.waitForLoadState('networkidle')
 

--- a/test/server-components.test.ts
+++ b/test/server-components.test.ts
@@ -229,6 +229,25 @@ describe('server components/islands', () => {
     expect(html.match(/Hello this is a server page/g)).toHaveLength(1)
   })
 
+  it('/server-page - should ship island html only once in the initial response', async () => {
+    const html = await $fetch<string>('/server-page')
+    expect(html.match(/Hello this is a server page/g)).toHaveLength(1)
+  })
+
+  itFailsIf(builder === 'webpack' && isDev)('/server-page - island response is prefetched by NuxtLink', async () => {
+    const { page, requests } = await renderPage('/')
+    await page.waitForLoadState('networkidle')
+
+    expect(requests.some(req => req.startsWith('/__nuxt_island/page_server-page'))).toBe(true)
+    requests.length = 0
+
+    await page.getByText('to server page').click()
+    await page.waitForFunction(() => !!document.head.querySelector('meta[name="author"][content="Nuxt"]'))
+
+    expect(requests.some(req => req.startsWith('/__nuxt_island/page_server-page'))).toBe(false)
+    await page.close()
+  })
+
   it('/server-page-with-nuxtpage/child renders the parent server page with the child route', async () => {
     const html = await $fetch<string>('/server-page-with-nuxtpage/child')
     expect(html).toContain('id="server-page-with-nuxtpage"')


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

we fetch JS chunks of pages. in the case of server pages (with the exception of _prerendered_ server pages), this is not the case, meaning that the island component can't be fetched until we navigate

this PR adds support for prefetching server page islands in the same way we prefetch JS chunks for pages we link to