### PR TITLE
fix(nuxt): drop prefetch hints for never-hydrated chunks

### DIFF
--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -327,13 +327,26 @@ async function renderRoute (event: H3Event, ssrError?: (NuxtPayload['error'] & {
     const dependencyOptions = ssrContext['~lazyHydratedModules']?.size
       ? { exclude: ssrContext['~lazyHydratedModules'] }
       : undefined
-    const stylesheetHrefs = new Set(link.map(l => l.href))
-    ssrContext.head.push({
-      link: [
-        ...getPreloadLinks(ssrContext, renderer.rendererContext, dependencyOptions) as Link[],
-        ...getPrefetchLinks(ssrContext, renderer.rendererContext, dependencyOptions) as Link[],
-      ].filter(l => !stylesheetHrefs.has(l.href)),
-    })
+    // exclude hrefs already linked as stylesheets, plus never-hydrated chunks which the client can never fetch
+    const excludeHrefs = new Set(link.map(l => l.href))
+    for (const id of ssrContext['~neverHydratedModules'] ?? []) {
+      const file = renderer.rendererContext.manifest?.[id]?.file
+      if (file) {
+        excludeHrefs.add(renderer.rendererContext.buildAssetsURL(file))
+      }
+    }
+    const hints: Link[] = []
+    for (const l of getPreloadLinks(ssrContext, renderer.rendererContext, dependencyOptions) as Link[]) {
+      if (!excludeHrefs.has(l.href)) {
+        hints.push(l)
+      }
+    }
+    for (const l of getPrefetchLinks(ssrContext, renderer.rendererContext, dependencyOptions) as Link[]) {
+      if (!excludeHrefs.has(l.href)) {
+        hints.push(l)
+      }
+    }
+    ssrContext.head.push({ link: hints })
     // 5. Payloads
     ssrContext.head.push({
       script: _PAYLOAD_INLINE

--- a/packages/nuxt/src/app/types.ts
+++ b/packages/nuxt/src/app/types.ts
@@ -166,6 +166,8 @@ export interface NuxtSSRContext extends SSRContext {
   ['~preloadManifest']?: boolean
   /** @internal */
   ['~lazyHydratedModules']?: Set<string>
+  /** @internal */
+  ['~neverHydratedModules']?: Set<string>
 }
 
 export interface NuxtIslandSlotResponse {

--- a/packages/nuxt/src/components/runtime/lazy-hydrated-component.ts
+++ b/packages/nuxt/src/components/runtime/lazy-hydrated-component.ts
@@ -25,6 +25,11 @@ function defineLazyComponent<P extends ComponentObjectPropsOptions, Props extend
           // but keep them in modules so CSS links are still rendered
           ssrContext!['~lazyHydratedModules'] ||= new Set()
           ssrContext!['~lazyHydratedModules'].add(id)
+          if (never) {
+            // never-hydrated chunks are also excluded from prefetch hints, as they can never be needed
+            ssrContext!['~neverHydratedModules'] ||= new Set()
+            ssrContext!['~neverHydratedModules'].add(id)
+          }
         })
       }
       // wrap the async component in a second component to avoid loading the chunk too soon


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

while working on https://github.com/nuxt/nuxt/issues/35768, spotted that we were adding prefetch hints for never-hydrated chunks. these chunks are never used by design, so this is strictly wrong.

I've also taken the opportunity to slightly improve iterations when constructing the link array