### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -388,8 +388,8 @@ export const clientConfigTemplate: NuxtTemplate = {
     return [
       'export const useRuntimeConfig = () => ',
       (!nuxt.options.future.multiApp
-        ? 'window?.__NUXT__?.config || window?.useNuxtApp?.().payload?.config'
-        : `window?.__NUXT__?.[${appId}]?.config || window?.useNuxtApp?.(${appId}).payload?.config`)
+        ? 'typeof window !== \'undefined\' && (window.__NUXT__?.config || window.useNuxtApp?.().payload?.config)'
+        : `typeof window !== 'undefined' && (window.__NUXT__?.[${appId}]?.config || window.useNuxtApp?.(${appId}).payload?.config)`)
         || {},
     ].join('\n')
   },


### PR DESCRIPTION
Refs #35801.

Since #35790 (drop ofetch from client bundle when unused), `$fetch` auto-import crashes node-environment Vitest tests with `ReferenceError: window is not defined`.

The `nitro.client.mjs` stub generated for client-side `useRuntimeConfig` reads `window?.__NUXT__?.config`. Optional chaining (`?.`) protects against `null` or `undefined`, but not against an undeclared variable — in Node.js without jsdom, `window` is never declared, so `window?.` throws a `ReferenceError` rather than returning `undefined`.

The `dollarFetchClientTemplate` in `fetch.client.mjs` calls `baseURL()` → `useRuntimeConfig()` → the stub whenever `globalThis.$fetch` is falsy (which it is in node test environments), triggering the error.

Fix: replace `window?.` with a `typeof window !== 'undefined'` guard in both the standard and multi-app variants of the `nitro.client.mjs` template. The guard evaluates to `false` when `window` is undeclared (returning `undefined` from `useRuntimeConfig()`), which ofetch handles gracefully.