### PR TITLE
fix(nuxt): remove dev error overlay when error is cleared

### DIFF
--- a/packages/nuxt/src/app/composables/error.ts
+++ b/packages/nuxt/src/app/composables/error.ts
@@ -77,6 +77,12 @@ export const clearError = async (options: { redirect?: string } = {}): Promise<v
   }
 
   error.value = undefined
+
+  if (import.meta.dev && import.meta.client) {
+    for (const el of document.querySelectorAll('nuxt-error-overlay')) {
+      el.remove()
+    }
+  }
 }
 
 /** @since 3.0.0 */


### PR DESCRIPTION
### 📚 Description

I noticed we don't remove the error overlay when clicking on the `go back home` button on the error page.

<img width="438" height="348" alt="image" src="https://github.com/user-attachments/assets/1162a4b4-18c7-4dfc-a1ea-8186ce118990" />
