### PR TITLE
fix(nuxt): avoid restoring error page title after error is cleared

### DIFF
--- a/packages/nuxt/src/head/runtime/install-client-head.ts
+++ b/packages/nuxt/src/head/runtime/install-client-head.ts
@@ -30,6 +30,15 @@ export function installClientHead (nuxtApp: NuxtApp, head: ClientHead): void {
   // unpause the DOM once the mount suspense is resolved
   nuxtApp.hooks.hook('app:suspense:resolve', syncHead)
 
+  // when hydrating a server-rendered error page, the initial document title belongs
+  // to the error, so unhead must not restore it once the error is cleared
+  const removeTitleResetHook = head.hooks?.hook('dom:rendered', () => {
+    removeTitleResetHook?.()
+    if (nuxtApp.payload.error && head._dom) {
+      head._dom._t = ''
+    }
+  })
+
   // Defer head-entry disposal during a page transition.
   const originalPush = head.push.bind(head)
   head.push = ((input: Parameters<typeof head.push>[0], options?: Parameters<typeof head.push>[1]) => {

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -40,7 +40,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
   it('does not ship payload revival machinery in a spa build', async () => {
     const clientStats = await analyzeSizes(['**/*.js'], join(spaRootDir, '.output/public'), spaRootDir)
 
-    expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"101k"`)
+    expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"102k"`)
 
     const contents = await Promise.all(
       (await glob(['**/*.js'], { cwd: join(spaRootDir, '.output/public') }))


### PR DESCRIPTION
### 📚 Description

when going from a server-rendered error page to another page (e.g. by clicking on `go back home`), the title would remain `404 - Page not found: /test | Nuxt` if the destination page didn't provide its own title

not sure if reaching into the unhead internals like this is OK from Nuxt's side, though, but then again unhead can't know that the title was from the error page...
could there be other cases where we should not reset to the server-side title, or should we instead not worry about this at all in Nuxt?