### PR TITLE
🌸 welcomed pr from carbon-based creature 🌸

### DIFF
--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -84,6 +84,9 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
 
   const isIgnored = createIsIgnored(nuxt)
   const serverEntry = nuxt.options.ssr ? entry : await resolvePath(resolve(nuxt.options.appDir, 'entry-spa'))
+  const assetFileNames: vite.Rolldown.OutputOptions['assetFileNames'] = nuxt.options.dev
+    ? undefined
+    : chunk => withoutLeadingSlash(join(nuxt.options.app.buildAssetsDir, `${sanitizeFilePath(filename(chunk.names[0]!))}.[hash].[ext]`))
   const config: vite.InlineConfig = mergeConfig(
     {
       base: nuxt.options.dev
@@ -176,14 +179,19 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
             },
             sanitizeFileName: sanitizeFilePath,
             // https://github.com/vitejs/vite/blob/main/packages/vite/src/node/build.ts#L464-L478
-            assetFileNames: nuxt.options.dev
-              ? undefined
-              : chunk => withoutLeadingSlash(join(nuxt.options.app.buildAssetsDir, `${sanitizeFilePath(filename(chunk.names[0]!))}.[hash].[ext]`)),
+            assetFileNames,
           },
         },
 
         // TODO: https://github.com/rolldown/rolldown/issues/5799 for ignored fn
         watch: { exclude: [...nuxt.options.ignore, /[\\/]node_modules[\\/]/] },
+      },
+      worker: {
+        rolldownOptions: {
+          output: {
+            assetFileNames,
+          },
+        },
       },
       plugins: [
         // per-plugin timing when profiling is enabled

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2061,6 +2061,12 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/nuxt
 
+  test/fixtures/vite-worker-assets:
+    dependencies:
+      nuxt:
+        specifier: workspace:*
+        version: link:../../../packages/nuxt
+
 packages:
 
   '@ampproject/remapping@2.3.0':

--- a/test/fixtures/vite-worker-assets/app/app.vue
+++ b/test/fixtures/vite-worker-assets/app/app.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import wasmUrl from './shared.wasm?url'
+
+if (import.meta.client) {
+  new Worker(new URL('./worker.ts', import.meta.url), { type: 'module' })
+}
+</script>
+
+<template>
+  <div>{{ wasmUrl }}</div>
+</template>

--- a/test/fixtures/vite-worker-assets/app/shared.wasm
+++ b/test/fixtures/vite-worker-assets/app/shared.wasm
@@ -1,0 +1,1 @@
+wasm fixture

--- a/test/fixtures/vite-worker-assets/app/worker.ts
+++ b/test/fixtures/vite-worker-assets/app/worker.ts
@@ -1,0 +1,3 @@
+import wasmUrl from './shared.wasm?url'
+
+self.postMessage(wasmUrl)

--- a/test/fixtures/vite-worker-assets/nuxt.config.ts
+++ b/test/fixtures/vite-worker-assets/nuxt.config.ts
@@ -1,0 +1,9 @@
+import { withMatrix } from '../../matrix'
+
+export default withMatrix({
+  vite: {
+    build: {
+      assetsInlineLimit: 0,
+    },
+  },
+})

--- a/test/fixtures/vite-worker-assets/package.json
+++ b/test/fixtures/vite-worker-assets/package.json
@@ -1,0 +1,13 @@
+{
+  "private": true,
+  "name": "fixture-vite-worker-assets",
+  "scripts": {
+    "build": "nuxt build"
+  },
+  "dependencies": {
+    "nuxt": "workspace:*"
+  },
+  "engines": {
+    "node": "^22.19.0 || ^24.11.0 || >=26.0.0"
+  }
+}

--- a/test/fixtures/vite-worker-assets/tsconfig.json
+++ b/test/fixtures/vite-worker-assets/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./.nuxt/tsconfig.json"
+}

--- a/test/vite-worker-assets.test.ts
+++ b/test/vite-worker-assets.test.ts
@@ -1,0 +1,30 @@
+import { readdir } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { isWindows } from 'std-env'
+import { join } from 'pathe'
+import { setup, useTestContext } from '@nuxt/test-utils/e2e'
+
+import { runsOnceInMatrix } from './matrix'
+
+const rootDir = fileURLToPath(new URL('./fixtures/vite-worker-assets', import.meta.url))
+
+if (runsOnceInMatrix) {
+  await setup({
+    rootDir,
+    dev: false,
+    build: true,
+    server: false,
+    browser: false,
+    setupTimeout: (isWindows ? 360 : 120) * 1000,
+  })
+}
+
+describe.skipIf(!runsOnceInMatrix)('Vite worker assets', () => {
+  it('emits an asset shared with a worker only once', async () => {
+    // @ts-expect-error ssssh! untyped secret property
+    const publicDir = useTestContext().nuxt._nitro.options.output.publicDir
+    const files = await readdir(join(publicDir, '_nuxt'))
+    expect(files.filter(file => file.endsWith('.wasm'))).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
### Linked issue

Resolves #22966

### Description

Nuxt gives regular build assets a custom filename pattern, while Vite workers were still using the default one. Importing the same file from the app and a worker therefore wrote two copies with different names.

This passes the existing `assetFileNames` callback to the worker build as well. Both builds now resolve the shared asset to one output file.

The new fixture imports one WASM file from the app and a worker. It produces two files before this change and one after it.

### Tests

- `vitest run test/vite-worker-assets.test.ts --project fixtures:vite-built-default-manifest-on`
- targeted ESLint on the changed source and fixture files
- `pnpm --filter @nuxt/vite-builder build`
- `pnpm typecheck`
