### PR TITLE
fix(schema): normalise slashes in `app.buildAssetsDir`

### DIFF
--- a/packages/schema/src/config/app.ts
+++ b/packages/schema/src/config/app.ts
@@ -43,10 +43,9 @@ export default defineResolvers({
     },
     buildAssetsDir: {
       $resolve: (val) => {
-        if (typeof val === 'string') {
-          return val
-        }
-        return process.env.NUXT_APP_BUILD_ASSETS_DIR || '/_nuxt/'
+        const dir = typeof val === 'string' ? val : (process.env.NUXT_APP_BUILD_ASSETS_DIR || '/_nuxt/')
+        // normalised so consumers can compare it directly against request paths
+        return dir.replace(/^\/?/, '/').replace(/\/?$/, '/')
       },
     },
 

--- a/test/build-assets-dir-collision.test.ts
+++ b/test/build-assets-dir-collision.test.ts
@@ -1,7 +1,7 @@
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import { isWindows } from 'std-env'
-import { $fetch, setup } from '@nuxt/test-utils/e2e'
+import { $fetch, fetch, setup } from '@nuxt/test-utils/e2e'
 
 import { isDev, runsOncePerEnvInMatrix } from './matrix'
 
@@ -20,5 +20,11 @@ describe.skipIf(!runsOncePerEnvInMatrix)('buildAssetsDir collision with source d
     const html = await $fetch<string>('/')
     expect(html).toContain('data-testid="hello"')
     expect(html).toContain('hello world')
+  })
+
+  it.runIf(isDev)('serves a plain 404 for the build assets dir root when `buildAssetsDir` has no slashes', async () => {
+    const res = await fetch('/abc/')
+    expect(res.status).toBe(404)
+    expect(await res.text()).toBe('Not Found')
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

resolves nuxt/cli#369 

### 📚 Description

small dx papercut for direct request of the buildAssetsDir (only in vite)