### PR TITLE
fix(nitro,nuxt,vite): dedupe and normalise global css links in dev

### DIFF
--- a/packages/nitro-server/src/vite.ts
+++ b/packages/nitro-server/src/vite.ts
@@ -25,15 +25,17 @@ const DEV_CLIENT_CSS_SEED = 'nuxt:dev-client-css:seed'
  * so this is eventually consistent rather than a strict per-request subset
  * (which nothing tracks).
  */
-function collectSsrGraphCss (moduleGraph: EnvironmentModuleGraph): string[] {
-  const css = new Set<string>()
+function collectSsrGraphCss (moduleGraph: EnvironmentModuleGraph): { urls: string[], files: Set<string> } {
+  const urls = new Set<string>()
+  const files = new Set<string>()
   for (const [mod, node] of moduleGraph.urlToModuleMap.entries()) {
     if (!IS_CSS_RE.test(mod) || 'raw' in getQuery(mod)) { continue }
     const importers = node.importers
     if (importers?.size && [...importers].every(i => i.url && 'raw' in getQuery(i.url))) { continue }
-    css.add(mod)
+    urls.add(mod)
+    if (node.file) { files.add(node.file) }
   }
-  return [...css]
+  return { urls: [...urls], files }
 }
 
 /**
@@ -41,13 +43,13 @@ function collectSsrGraphCss (moduleGraph: EnvironmentModuleGraph): string[] {
  * styles are always present in the dev SSR manifest, even before the ssr graph
  * has loaded the component that imports them.
  */
-function collectGlobalCss (nuxt: Nuxt): string[] {
-  const out: string[] = []
+function resolveGlobalCss (nuxt: Nuxt): Array<{ file: string, url: string }> {
+  const out = new Map<string, string>()
   for (const entry of nuxt.options.css) {
     if (typeof entry !== 'string') { continue }
     const resolved = resolveAlias(entry, nuxt.options.alias)
     if (isAbsolute(resolved)) {
-      out.push(resolved)
+      out.set(resolved, toFsUrl(resolved))
       continue
     }
     const fromModules = resolveModulePath(resolved, {
@@ -55,10 +57,25 @@ function collectGlobalCss (nuxt: Nuxt): string[] {
       from: nuxt.options.modulesDir.map(d => directoryToURL(d)),
     })
     if (fromModules) {
-      out.push('/@fs' + fromModules.replace(/^(?!\/)/, '/'))
+      out.set(fromModules, toFsUrl(fromModules))
     }
   }
-  return out
+  return Array.from(out, ([file, url]) => ({ file, url }))
+}
+
+function toFsUrl (path: string): string {
+  return '/@fs' + path.replace(/^(?!\/)/, '/')
+}
+
+/**
+ * Union of the CSS the ssr graph has loaded and the globally-registered CSS,
+ * with global entries the graph already covers dropped: the graph url and the
+ * `/@fs/...` url for the same file are different strings that would otherwise
+ * both be emitted as `<link>` tags.
+ */
+function collectDevCss (nuxt: Nuxt, moduleGraph: EnvironmentModuleGraph): string[] {
+  const { urls, files } = collectSsrGraphCss(moduleGraph)
+  return [...urls, ...resolveGlobalCss(nuxt).filter(e => !files.has(e.file)).map(e => e.url)]
 }
 
 /**
@@ -76,9 +93,9 @@ export function setupNitroViteEnvironment (nuxt: Nuxt & { _nitro?: Nitro }, nitr
   // the latest set and serves it, unioned with the globally-registered CSS.
   if (nuxt.options.dev) {
     nuxt.options.vite.plugins ||= []
-    nuxt.options.vite.plugins.push(DevClientCssPlugin())
+    nuxt.options.vite.plugins.push(DevClientCssPlugin(nuxt))
 
-    const globalCssCode = JSON.stringify(collectGlobalCss(nuxt))
+    const globalCssCode = JSON.stringify(resolveGlobalCss(nuxt).map(e => e.url))
     // The virtual is evaluated once per importer in the ssr runner, so the
     // cache lives on a worker-scoped `globalThis` property shared across those
     // instances rather than a module-local binding. On eval the worker asks
@@ -86,13 +103,15 @@ export function setupNitroViteEnvironment (nuxt: Nuxt & { _nitro?: Nitro }, nitr
     // already holds without waiting for a new transform.
     nitro.options.virtual['#internal/nuxt/dev-client-css'] = () => [
       `const globalCss = ${globalCssCode}`,
-      `const store = (globalThis.__nuxtDevClientCss__ ??= { css: [] })`,
+      `const store = (globalThis.__nuxtDevClientCss__ ??= { css: null })`,
       `if (import.meta.hot) {`,
       `  import.meta.hot.on(${JSON.stringify(DEV_CLIENT_CSS_EVENT)}, (css) => { store.css = css || [] })`,
       `  import.meta.hot.send(${JSON.stringify(DEV_CLIENT_CSS_SEED)})`,
       `}`,
+      // the pushed set already includes the global CSS, deduplicated against
+      // the ssr graph; `globalCss` only covers the window before the first push
       'export function getDevClientCss () {',
-      '  return [...new Set([...globalCss, ...store.css])]',
+      '  return [...new Set(store.css ?? globalCss)]',
       '}',
     ].join('\n')
   }
@@ -292,14 +311,14 @@ function NuxtBuildOutputsPlugin (nuxt: Nuxt & { _nitro?: Nitro }): VitePlugin {
  * Dev-only: push the CSS the ssr module graph has loaded to the ssr
  * module-runner worker over the env hot channel.
  */
-function DevClientCssPlugin (): VitePlugin {
+function DevClientCssPlugin (nuxt: Nuxt): VitePlugin {
   let push: (() => void) | undefined
   return {
     name: 'nuxt:dev-client-css',
     configureServer (server) {
       const env = server.environments.ssr
       if (!env) { return }
-      push = () => env.hot.send(DEV_CLIENT_CSS_EVENT, collectSsrGraphCss(env.moduleGraph))
+      push = () => env.hot.send(DEV_CLIENT_CSS_EVENT, collectDevCss(nuxt, env.moduleGraph))
       env.hot.on(DEV_CLIENT_CSS_SEED, push)
     },
     transform: {

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -3,11 +3,11 @@ import { existsSync } from 'node:fs'
 import { rm } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import { AsyncLocalStorage } from 'node:async_hooks'
-import { join, normalize, relative, resolve } from 'pathe'
+import { isAbsolute, join, normalize, relative, resolve } from 'pathe'
 import { createDebugger, createHooks } from 'hookable'
 import ignore from 'ignore'
 import type { LoadNuxtOptions } from '@nuxt/kit'
-import { addBuildPlugin, addComponent, addPlugin, addPluginTemplate, addRouteMiddleware, addTypeTemplate, addVitePlugin, configDiagnostics, ensureDependencyInstalled, getLayerDirectories, installModules, loadNuxtConfig, nuxtCtx, resolveFiles, resolveIgnorePatterns, resolveModuleWithOptions, resolveTypePaths, runWithNuxtContext } from '@nuxt/kit'
+import { addBuildPlugin, addComponent, addPlugin, addPluginTemplate, addRouteMiddleware, addTypeTemplate, addVitePlugin, configDiagnostics, ensureDependencyInstalled, getLayerDirectories, installModules, loadNuxtConfig, nuxtCtx, resolveAlias, resolveFiles, resolveIgnorePatterns, resolveModuleWithOptions, resolveTypePaths, runWithNuxtContext } from '@nuxt/kit'
 import type { PackageJson } from 'pkg-types'
 import { readPackageJSON } from 'pkg-types'
 import { hash } from 'ohash'
@@ -732,6 +732,8 @@ async function initNuxt (nuxt: Nuxt) {
   nuxt.options.css = nuxt.options.css
     .filter((value, index, array) => !array.includes(value, index + 1))
 
+  warnUnresolvableGlobalCss(nuxt)
+
   // Add <NuxtIsland>
   if (nuxt.options.experimental.componentIslands) {
     addComponent({
@@ -1213,4 +1215,29 @@ async function resolveTypescriptPaths (nuxt: Nuxt): Promise<Record<string, [stri
 
 function withTrailingSlash (dir: string) {
   return dir.replace(/[^/]$/, '$&/')
+}
+
+const RELATIVE_CSS_ENTRY_RE = /^\.{1,2}\//
+/**
+ * Warn about `css` entries that cannot resolve, which otherwise fail silently:
+ * the dev server emits a `<link>` to a URL nothing serves, and production
+ * builds drop the styles entirely.
+ */
+function warnUnresolvableGlobalCss (nuxt: Nuxt) {
+  for (const entry of nuxt.options.css) {
+    if (typeof entry !== 'string') { continue }
+
+    if (RELATIVE_CSS_ENTRY_RE.test(entry)) {
+      const asAlias = '~/' + relative(nuxt.options.srcDir, resolve(nuxt.options.rootDir, entry))
+      logger.warn(`\`css\` entries are resolved as module ids, not relative to \`nuxt.config\`. Replace \`${entry}\` with ${existsSync(resolve(nuxt.options.rootDir, entry)) ? `\`${asAlias}\`` : 'an aliased or absolute path'}.`)
+      continue
+    }
+
+    // build-dir entries are generated later in startup, and bare specifiers may
+    // be resolved by builder-specific aliases, so neither can be checked here
+    const resolved = resolveAlias(entry, nuxt.options.alias)
+    if (isAbsolute(resolved) && !resolved.startsWith(nuxt.options.buildDir) && !existsSync(resolved)) {
+      logger.warn(`\`css\` entry \`${entry}\` could not be found${resolved === entry ? '' : ` (resolved to \`${resolved}\`)`}.`)
+    }
+  }
 }

--- a/packages/vite/src/plugins/vite-node.ts
+++ b/packages/vite/src/plugins/vite-node.ts
@@ -8,17 +8,17 @@ import { pathToFileURL } from 'node:url'
 import { Buffer } from 'node:buffer'
 import { randomUUID } from 'node:crypto'
 import { win32 as pathWin32 } from 'node:path'
-import { dirname, isAbsolute, join, normalize } from 'pathe'
-import { bundlerDiagnostics, directoryToURL, resolveAlias, setBuildOutput, tryUseNuxt, useNitro } from '@nuxt/kit'
+import { dirname, join, normalize } from 'pathe'
+import { bundlerDiagnostics, setBuildOutput, tryUseNuxt, useNitro } from '@nuxt/kit'
 import type { EnvironmentModuleNode, ModuleNode, PluginContainer, ViteDevServer, Plugin as VitePlugin } from 'vite'
-import { getQuery } from 'ufo'
 import type { FetchResult } from 'vite-node'
 import { normalizeViteManifest } from 'vue-bundle-renderer'
 import type { Manifest } from 'vue-bundle-renderer'
 import type { Nuxt } from '@nuxt/schema'
 import { resolveModulePath } from 'exsolve'
 
-import { isCSS, toVirtualId } from '../utils/index.ts'
+import { toVirtualId } from '../utils/index.ts'
+import { collectDevCss } from '../utils/css.ts'
 import { resolveClientEntry, resolveServerEntry } from '../utils/config.ts'
 import type { ErrorPartial } from '../types.ts'
 
@@ -67,46 +67,14 @@ export interface ViteNodeFetch {
 }
 
 function getManifest (nuxt: Nuxt, viteServer: ViteDevServer, clientEntry: string) {
-  const css = new Set<string>()
-  const ssrServer = viteServer.environments.ssr
-
-  // Collect CSS from module graph (already loaded modules)
-  for (const key of ssrServer.moduleGraph.urlToModuleMap.keys()) {
-    if (isCSS(key)) {
-      const query = getQuery(key)
-      if ('raw' in query) { continue }
-      const importers = ssrServer.moduleGraph.urlToModuleMap.get(key)?.importers
-      if (importers && [...importers].every(i => i.id && 'raw' in getQuery(i.id))) {
-        continue
-      }
-      css.add(key)
-    }
-  }
-
-  // Add global CSS from config as fallback to prevent FOUC
-  // This ensures CSS is in manifest even if moduleGraph isn't populated yet
-  for (const globalCss of nuxt.options.css) {
-    if (typeof globalCss === 'string') {
-      let resolved: string | undefined = resolveAlias(globalCss, nuxt.options.alias)
-
-      // Resolve bare module specifiers to absolute paths
-      if (!isAbsolute(resolved)) {
-        resolved = resolveModulePath(resolved, {
-          try: true,
-          from: nuxt.options.modulesDir.map(d => directoryToURL(d)),
-        })
-        if (!resolved) { continue }
-        css.add('/@fs' + resolved.replace(/^(?!\/)/, '/'))
-      } else {
-        css.add(resolved)
-      }
-    }
-  }
+  // global CSS is included as a fallback to prevent FOUC before the ssr module
+  // graph is populated
+  const css = collectDevCss(nuxt, viteServer.environments.ssr.moduleGraph)
 
   const manifest = normalizeViteManifest({
     '@vite/client': {
       file: '@vite/client',
-      css: [...css],
+      css,
       module: true,
       isEntry: true,
     },

--- a/packages/vite/src/utils/css.ts
+++ b/packages/vite/src/utils/css.ts
@@ -2,22 +2,33 @@ import { isAbsolute } from 'pathe'
 import { directoryToURL, resolveAlias } from '@nuxt/kit'
 import type { Nuxt } from '@nuxt/schema'
 import { resolveModulePath } from 'exsolve'
+import { getQuery } from 'ufo'
+import type { EnvironmentModuleGraph } from 'vite'
+
+import { isCSS } from './index.ts'
 
 /**
- * Resolve the global CSS entries from `nuxt.options.css` to dev-server URLs
- * (`/@fs/...` for files outside the root, absolute paths otherwise).
+ * Convert an absolute file path to the dev-server URL Vite serves it from.
+ */
+function toFsUrl (path: string): string {
+  return '/@fs' + path.replace(/^(?!\/)/, '/')
+}
+
+/**
+ * Resolve the global CSS entries from `nuxt.options.css` to `/@fs/...`
+ * dev-server URLs, paired with the absolute path they resolved to.
  *
  * Used to seed the dev SSR client manifest so globally-registered styles are
  * always inlined, even before the ssr module graph has loaded the component
  * that imports them.
  */
-export function collectGlobalCss (nuxt: Nuxt): string[] {
-  const out: string[] = []
+export function resolveGlobalCss (nuxt: Nuxt): Array<{ file: string, url: string }> {
+  const out = new Map<string, string>()
   for (const entry of nuxt.options.css) {
     if (typeof entry !== 'string') { continue }
     const resolved = resolveAlias(entry, nuxt.options.alias)
     if (isAbsolute(resolved)) {
-      out.push(resolved)
+      out.set(resolved, toFsUrl(resolved))
       continue
     }
     const fromModules = resolveModulePath(resolved, {
@@ -25,8 +36,36 @@ export function collectGlobalCss (nuxt: Nuxt): string[] {
       from: nuxt.options.modulesDir.map(d => directoryToURL(d)),
     })
     if (fromModules) {
-      out.push('/@fs' + fromModules.replace(/^(?!\/)/, '/'))
+      out.set(fromModules, toFsUrl(fromModules))
     }
   }
-  return out
+  return Array.from(out, ([file, url]) => ({ file, url }))
+}
+
+export function collectGlobalCss (nuxt: Nuxt): string[] {
+  return resolveGlobalCss(nuxt).map(entry => entry.url)
+}
+
+/**
+ * Union of the CSS the ssr module graph has loaded and the globally-registered
+ * CSS, with global entries the graph already covers dropped: the graph url and
+ * the `/@fs/...` url for the same file are different strings that would
+ * otherwise both be emitted as `<link>` tags.
+ */
+export function collectDevCss (nuxt: Nuxt, moduleGraph: EnvironmentModuleGraph): string[] {
+  const urls = new Set<string>()
+  const files = new Set<string>()
+  for (const [url, node] of moduleGraph.urlToModuleMap.entries()) {
+    if (!isCSS(url) || 'raw' in getQuery(url)) { continue }
+    const importers = node.importers
+    if (importers?.size && [...importers].every(i => i.id && 'raw' in getQuery(i.id))) { continue }
+    urls.add(url)
+    if (node.file) { files.add(node.file) }
+  }
+
+  for (const entry of resolveGlobalCss(nuxt)) {
+    if (!files.has(entry.file)) { urls.add(entry.url) }
+  }
+
+  return [...urls]
 }

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1546,6 +1546,12 @@ describe.runIf(isDev && !isWebpack)('css links', () => {
     expect(html).not.toContain('inline-only.css')
     expect(html).toContain('assets/plugin.css')
   })
+
+  it('should emit a single link for globally-registered css', async () => {
+    const html = await $fetch<string>('/')
+    const links = html.match(/<link[^>]+global\.css[^>]*>/g) || []
+    expect(links).toHaveLength(1)
+  })
 })
 
 describe.skipIf(isDev)('module identifiers', () => {


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/35831

### 📚 Description

reported in https://github.com/nuxt/nuxt/issues/35831 - we were emitting the same css twice (once normalised with `/@fs` path, once without