### PR TITLE
fix(nitro): dedupe island renders when prerendering

### DIFF
--- a/packages/nitro-server/src/runtime/handlers/island.ts
+++ b/packages/nitro-server/src/runtime/handlers/island.ts
@@ -29,15 +29,15 @@ export const islandPropCache: Storage<string> | null = import.meta.prerender ? u
 const ISLAND_SUFFIX_RE = /\.json(?:\?.*)?$/
 const ISLAND_PATH_PREFIX = '/__nuxt_island/'
 
-/** A render that produced a `Response` of its own (redirect, abort, ...), which is bound to the request that made it. */
+/** A response produced by the render itself (redirect, abort, ...), bound to the request that made it. */
 interface RawIslandResponse { raw: Response }
 
 type IslandRenderResult = NuxtIslandResponse | RawIslandResponse
 
 /**
- * Renders in flight, keyed by island path. Prerendering requests the same island from
- * every page that embeds it, so without this those renders duplicate work and race to
- * write the same cache entry (which fails the build with `EPERM` on Windows).
+ * Renders in flight, keyed by island path, so that pages prerendered in parallel share a
+ * single render of an island they both embed instead of racing to write its cache entry
+ * (which fails the build with `EPERM` on Windows).
  */
 const inFlightIslands: Map<string, Promise<IslandRenderResult>> | null = import.meta.prerender ? new Map() : null
 
@@ -62,11 +62,10 @@ export default {
         })
       }
 
-      // Only a render holding no claim of its own may wait on another, or two nested
-      // island renders could end up awaiting each other's claim and hang the build.
+      // Only a render holding no claim of its own may wait on another, or two nested island
+      // renders could await each other's claim and hang the build.
       if (!stack?.some(url => url.startsWith(ISLAND_PATH_PREFIX))) {
-        // A raw response belongs to the request that produced it, so it cannot be shared;
-        // fall through and render our own.
+        // a raw response cannot be shared, so fall through and render our own
         const shared = await inFlightIslands!.get(islandPath)
         if (shared && !('raw' in shared)) {
           return toResponse(event, shared)
@@ -97,12 +96,12 @@ function prerenderIsland (event: H3Event, islandPath: string): Promise<IslandRen
     const result = await renderIsland(event)
     if (!('raw' in result)) {
       await islandCache!.setItem(islandPath, result)
-      // Without the props entry, a later request for the bare path hashes empty props and is rejected.
+      // without the props entry, a later request for the bare path hashes empty props and is rejected
       await islandPropCache!.setItem(islandPath, islandPath + event.url.search + event.url.hash)
     }
     return result
   }).finally(() => {
-    // a waiter that received a raw response claims the path while we are still
+    // a waiter that received a raw response can claim the path while we are still
     // registered, so only retire our own entry
     if (inFlightIslands!.get(islandPath) === promise) {
       inFlightIslands!.delete(islandPath)

--- a/packages/nitro-server/src/runtime/handlers/island.ts
+++ b/packages/nitro-server/src/runtime/handlers/island.ts
@@ -16,6 +16,7 @@ import { renderInlineStyles } from '../utils/renderer/inline-styles'
 import { getClientIslandResponse, getServerComponentHTML, getSlotIslandResponse } from '../utils/renderer/islands'
 import { patchDevClientCss } from '../utils/renderer/dev-css'
 import { recordDevClientCss } from '../utils/renderer/dev-client-css'
+import { prerenderRenderingURLs } from '../utils/cache'
 import { useStorage } from 'nitro/storage'
 import type { Storage } from 'unstorage'
 
@@ -23,173 +24,185 @@ export const islandCache: Storage<NuxtIslandResponse> | null = import.meta.prere
 export const islandPropCache: Storage<string> | null = import.meta.prerender ? useStorage<string>('internal:nuxt:prerender:island-props') : null
 
 const ISLAND_SUFFIX_RE = /\.json(?:\?.*)?$/
+const ISLAND_PATH_PREFIX = '/__nuxt_island/'
 
-// Prerendering fetches the same island from every page that embeds it, so
-// without this those renders race to write the same cache entry.
-const inFlightIslands: Map<string, Promise<NuxtIslandResponse>> | null = import.meta.prerender ? new Map() : null
+/** A render that produced a `Response` of its own (redirect, abort, ...), which is bound to the request that made it. */
+interface RawIslandResponse { raw: Response }
+
+type IslandRenderResult = NuxtIslandResponse | RawIslandResponse
+
+/**
+ * Renders in flight, keyed by island path. Prerendering requests the same island from
+ * every page that embeds it, so without this those renders duplicate work and race to
+ * write the same cache entry (which fails the build with `EPERM` on Windows).
+ */
+const inFlightIslands: Map<string, Promise<IslandRenderResult>> | null = import.meta.prerender ? new Map() : null
 
 export default {
   async fetch (request: Request): Promise<Response> {
     const event = new H3Event(request)
-    const islandPath = event.url.pathname
-    let inFlight: Promise<NuxtIslandResponse> | undefined
-    let resolveIsland: ((response: NuxtIslandResponse) => void) | undefined
-    let rejectIsland: ((reason: unknown) => void) | undefined
     try {
       event.res.headers.set('content-type', 'application/json;charset=utf-8')
       event.res.headers.set('x-powered-by', 'Nuxt')
 
-      if (import.meta.prerender) {
-        let pending = inFlightIslands!.get(islandPath)
-        while (pending) {
-          // same result as a cache hit, hooks included
-          const islandResponse = await pending.catch(() => null)
-          if (islandResponse) {
-            return new FastResponse(JSON.stringify(islandResponse), event.res)
-          }
-          // that render failed: follow whoever claimed it next instead of
-          // every waiter starting its own
-          const next = inFlightIslands!.get(islandPath)
-          if (!next || next === pending) {
-            break
-          }
-          pending = next
-        }
-        // set before the first `await`, or a concurrent request slips past
-        inFlight = new Promise<NuxtIslandResponse>((resolve, reject) => {
-          resolveIsland = resolve
-          rejectIsland = reject
+      if (!import.meta.prerender) {
+        return toResponse(event, await renderIsland(event))
+      }
+
+      const islandPath = event.url.pathname
+      const stack = prerenderRenderingURLs!.getStore()
+      if (stack?.includes(islandPath)) {
+        const chain = [...stack, islandPath].map(url => `"${url}"`).join(' -> ')
+        throw new HTTPError({
+          status: 508,
+          statusText: `Loop detected while prerendering island "${islandPath}" (${chain}).`,
         })
-        inFlight.catch(() => {})
-        inFlightIslands!.set(islandPath, inFlight)
       }
 
-      if (import.meta.prerender && await islandCache!.hasItem(islandPath)) {
-        const cached = await islandCache!.getItem(islandPath)
-        if (cached) {
-          resolveIsland?.(cached)
-          return new FastResponse(JSON.stringify(cached), event.res)
+      // Only a render holding no claim of its own may wait on another, or two nested
+      // island renders could end up awaiting each other's claim and hang the build.
+      if (!stack?.some(url => url.startsWith(ISLAND_PATH_PREFIX))) {
+        // A raw response belongs to the request that produced it, so it cannot be shared;
+        // fall through and render our own.
+        const shared = await inFlightIslands!.get(islandPath)
+        if (shared && !('raw' in shared)) {
+          return toResponse(event, shared)
         }
       }
 
-      const islandContext = await getIslandContext(event)
-
-      const ssrContext = {
-        ...createSSRContext(event),
-        islandContext,
-        noSSR: false,
-        url: islandContext.url,
-      }
-
-      // Render app
-      const renderer = await getSSRRenderer()
-
-      const renderResult = await (tracingChannelNuxt
-        ? traceAsync('nuxt.island', { event, ssrContext, islandContext }, () => renderer.renderToString(ssrContext))
-        : renderer.renderToString(ssrContext)
-      ).catch(async (err) => {
-        if (ssrContext['~renderResponse'] && (err as Error)?.message === 'skipping render') {
-          return {} as Awaited<ReturnType<typeof renderer.renderToString>>
-        }
-        await ssrContext.nuxt?.hooks.callHook('app:error', err)
-        throw err
-      })
-
-      // Fire `app:rendered` before checking `~renderResponse` (matches `renderer.ts`), so
-      // anything hooking into it, like `useCookie`, will still work on redirect/reject.
-      await ssrContext.nuxt?.hooks.callHook('app:rendered', { ssrContext, renderResult })
-
-      if (ssrContext['~renderResponse']) {
-        // not shareable: it carries this request's own response
-        rejectIsland?.(new Error('island rendered a raw response'))
-        return returnRenderResponse(event, ssrContext['~renderResponse'])
-      }
-
-      // Handle errors
-      if (ssrContext.payload?.error) {
-        throw ssrContext.payload.error
-      }
-
-      const inlinedStyles = await renderInlineStyles(ssrContext.modules ?? [])
-
-      if (inlinedStyles.length) {
-        ssrContext.head.push({ style: inlinedStyles })
-      }
-
-      if (import.meta.dev) {
-        // refresh  per-request CSS from the builder's module graph post-render
-        await recordDevClientCss(event)
-        // ... and patch it into the manifest.
-        patchDevClientCss(event, renderer.rendererContext)
-        const { styles } = getRequestDependencies(ssrContext, renderer.rendererContext)
-
-        const link: Link[] = []
-        for (const resource of Object.values(styles)) {
-          // Do not add links to resources that are inlined (vite v5+)
-          if ('inline' in getURLQuery(resource.file)) {
-            continue
-          }
-          // Add CSS links in <head> for CSS files
-          // - in dev mode when rendering an island and the file has scoped styles and is not a page
-          if (resource.file.includes('scoped') && !resource.file.includes('pages/')) {
-            link.push({ rel: 'stylesheet', href: renderer.rendererContext.buildAssetsURL(resource.file), crossorigin: '' })
-          }
-        }
-        if (link.length) {
-          ssrContext.head.push({ link })
-        }
-      }
-
-      const islandHead: SerializableHead = {}
-      for (const entry of ssrContext.head.entries.values()) {
-        for (const [key, value] of Object.entries(walkResolver(entry.input, VueResolver) as SerializableHead)) {
-          const currentValue = islandHead[key as keyof SerializableHead]
-          if (Array.isArray(currentValue)) {
-            currentValue.push(...value)
-          } else {
-            islandHead[key as keyof SerializableHead] = value
-          }
-        }
-      }
-
-      const islandResponse: NuxtIslandResponse = {
-        id: islandContext.id,
-        head: islandHead,
-        html: getServerComponentHTML(renderResult.html),
-        components: getClientIslandResponse(ssrContext),
-        slots: getSlotIslandResponse(ssrContext),
-      }
-
-      await useNitroHooks().callHook('render:island', islandResponse, { event, islandContext })
-
-      resolveIsland?.(islandResponse)
-
-      if (import.meta.prerender) {
-        const requestUrl = islandPath + event.url.search + event.url.hash
-        // independent: without the props entry a later request for the bare
-        // path hashes empty props and is rejected
-        await islandCache!.setItem(islandPath, islandResponse).catch(warnCacheFailure)
-        await islandPropCache!.setItem(islandPath, requestUrl).catch(warnCacheFailure)
-      }
-      return new FastResponse(JSON.stringify(islandResponse), event.res)
+      return toResponse(event, await prerenderIsland(event, islandPath))
     } catch (error) {
-      rejectIsland?.(error)
       rethrowWithResponseHeaders(event, error)
-    } finally {
-      // only the render that claimed it may retire it, or a waiter returning
-      // early reopens the race
-      if (inFlight && inFlightIslands?.get(islandPath) === inFlight) {
-        inFlightIslands.delete(islandPath)
-      }
     }
   },
 }
 
-function warnCacheFailure (error: unknown) {
-  console.warn('[nuxt] could not cache island render:', error)
+function toResponse (event: H3Event, result: IslandRenderResult): Response {
+  return 'raw' in result
+    ? returnRenderResponse(event, result.raw)
+    : new FastResponse(JSON.stringify(result), event.res)
 }
 
-const ISLAND_PATH_PREFIX = '/__nuxt_island/'
+function prerenderIsland (event: H3Event, islandPath: string): Promise<IslandRenderResult> {
+  const stack = prerenderRenderingURLs!.getStore()
+  const promise: Promise<IslandRenderResult> = prerenderRenderingURLs!.run([...(stack || []), islandPath], async () => {
+    const cached = await islandCache!.getItem(islandPath)
+    if (cached) {
+      return cached
+    }
+
+    const result = await renderIsland(event)
+    if (!('raw' in result)) {
+      await islandCache!.setItem(islandPath, result)
+      // Without the props entry, a later request for the bare path hashes empty props and is rejected.
+      await islandPropCache!.setItem(islandPath, islandPath + event.url.search + event.url.hash)
+    }
+    return result
+  }).finally(() => {
+    // a waiter that received a raw response claims the path while we are still
+    // registered, so only retire our own entry
+    if (inFlightIslands!.get(islandPath) === promise) {
+      inFlightIslands!.delete(islandPath)
+    }
+  })
+
+  inFlightIslands!.set(islandPath, promise)
+
+  return promise
+}
+
+async function renderIsland (event: H3Event): Promise<IslandRenderResult> {
+  const islandContext = await getIslandContext(event)
+
+  const ssrContext = {
+    ...createSSRContext(event),
+    islandContext,
+    noSSR: false,
+    url: islandContext.url,
+  }
+
+  // Render app
+  const renderer = await getSSRRenderer()
+
+  const renderResult = await (tracingChannelNuxt
+    ? traceAsync('nuxt.island', { event, ssrContext, islandContext }, () => renderer.renderToString(ssrContext))
+    : renderer.renderToString(ssrContext)
+  ).catch(async (err) => {
+    if (ssrContext['~renderResponse'] && (err as Error)?.message === 'skipping render') {
+      return {} as Awaited<ReturnType<typeof renderer.renderToString>>
+    }
+    await ssrContext.nuxt?.hooks.callHook('app:error', err)
+    throw err
+  })
+
+  // Fire `app:rendered` before checking `~renderResponse` (matches `renderer.ts`), so
+  // anything hooking into it, like `useCookie`, will still work on redirect/reject.
+  await ssrContext.nuxt?.hooks.callHook('app:rendered', { ssrContext, renderResult })
+
+  if (ssrContext['~renderResponse']) {
+    return { raw: ssrContext['~renderResponse'] }
+  }
+
+  // Handle errors
+  if (ssrContext.payload?.error) {
+    throw ssrContext.payload.error
+  }
+
+  const inlinedStyles = await renderInlineStyles(ssrContext.modules ?? [])
+
+  if (inlinedStyles.length) {
+    ssrContext.head.push({ style: inlinedStyles })
+  }
+
+  if (import.meta.dev) {
+    // refresh  per-request CSS from the builder's module graph post-render
+    await recordDevClientCss(event)
+    // ... and patch it into the manifest.
+    patchDevClientCss(event, renderer.rendererContext)
+    const { styles } = getRequestDependencies(ssrContext, renderer.rendererContext)
+
+    const link: Link[] = []
+    for (const resource of Object.values(styles)) {
+      // Do not add links to resources that are inlined (vite v5+)
+      if ('inline' in getURLQuery(resource.file)) {
+        continue
+      }
+      // Add CSS links in <head> for CSS files
+      // - in dev mode when rendering an island and the file has scoped styles and is not a page
+      if (resource.file.includes('scoped') && !resource.file.includes('pages/')) {
+        link.push({ rel: 'stylesheet', href: renderer.rendererContext.buildAssetsURL(resource.file), crossorigin: '' })
+      }
+    }
+    if (link.length) {
+      ssrContext.head.push({ link })
+    }
+  }
+
+  const islandHead: SerializableHead = {}
+  for (const entry of ssrContext.head.entries.values()) {
+    for (const [key, value] of Object.entries(walkResolver(entry.input, VueResolver) as SerializableHead)) {
+      const currentValue = islandHead[key as keyof SerializableHead]
+      if (Array.isArray(currentValue)) {
+        currentValue.push(...value)
+      } else {
+        islandHead[key as keyof SerializableHead] = value
+      }
+    }
+  }
+
+  const islandResponse: NuxtIslandResponse = {
+    id: islandContext.id,
+    head: islandHead,
+    html: getServerComponentHTML(renderResult.html),
+    components: getClientIslandResponse(ssrContext),
+    slots: getSlotIslandResponse(ssrContext),
+  }
+
+  await useNitroHooks().callHook('render:island', islandResponse, { event, islandContext })
+
+  return islandResponse
+}
+
 const VALID_COMPONENT_NAME_RE = /^[a-z][\w.-]*$/i
 
 async function getIslandContext (event: H3Event): Promise<NuxtIslandContext> {

--- a/packages/nitro-server/src/runtime/handlers/island.ts
+++ b/packages/nitro-server/src/runtime/handlers/island.ts
@@ -24,16 +24,52 @@ export const islandPropCache: Storage<string> | null = import.meta.prerender ? u
 
 const ISLAND_SUFFIX_RE = /\.json(?:\?.*)?$/
 
+// Prerendering fetches the same island from every page that embeds it, so
+// without this those renders race to write the same cache entry.
+const inFlightIslands: Map<string, Promise<NuxtIslandResponse>> | null = import.meta.prerender ? new Map() : null
+
 export default {
   async fetch (request: Request): Promise<Response> {
     const event = new H3Event(request)
+    const islandPath = event.url.pathname
+    let inFlight: Promise<NuxtIslandResponse> | undefined
+    let resolveIsland: ((response: NuxtIslandResponse) => void) | undefined
+    let rejectIsland: ((reason: unknown) => void) | undefined
     try {
       event.res.headers.set('content-type', 'application/json;charset=utf-8')
       event.res.headers.set('x-powered-by', 'Nuxt')
 
-      const islandPath = event.url.pathname
+      if (import.meta.prerender) {
+        let pending = inFlightIslands!.get(islandPath)
+        while (pending) {
+          // same result as a cache hit, hooks included
+          const islandResponse = await pending.catch(() => null)
+          if (islandResponse) {
+            return new FastResponse(JSON.stringify(islandResponse), event.res)
+          }
+          // that render failed: follow whoever claimed it next instead of
+          // every waiter starting its own
+          const next = inFlightIslands!.get(islandPath)
+          if (!next || next === pending) {
+            break
+          }
+          pending = next
+        }
+        // set before the first `await`, or a concurrent request slips past
+        inFlight = new Promise<NuxtIslandResponse>((resolve, reject) => {
+          resolveIsland = resolve
+          rejectIsland = reject
+        })
+        inFlight.catch(() => {})
+        inFlightIslands!.set(islandPath, inFlight)
+      }
+
       if (import.meta.prerender && await islandCache!.hasItem(islandPath)) {
-        return new FastResponse(JSON.stringify(await islandCache!.getItem(islandPath)), event.res)
+        const cached = await islandCache!.getItem(islandPath)
+        if (cached) {
+          resolveIsland?.(cached)
+          return new FastResponse(JSON.stringify(cached), event.res)
+        }
       }
 
       const islandContext = await getIslandContext(event)
@@ -64,6 +100,8 @@ export default {
       await ssrContext.nuxt?.hooks.callHook('app:rendered', { ssrContext, renderResult })
 
       if (ssrContext['~renderResponse']) {
+        // not shareable: it carries this request's own response
+        rejectIsland?.(new Error('island rendered a raw response'))
         return returnRenderResponse(event, ssrContext['~renderResponse'])
       }
 
@@ -124,16 +162,31 @@ export default {
 
       await useNitroHooks().callHook('render:island', islandResponse, { event, islandContext })
 
+      resolveIsland?.(islandResponse)
+
       if (import.meta.prerender) {
         const requestUrl = islandPath + event.url.search + event.url.hash
-        await islandCache!.setItem(islandPath, islandResponse)
-        await islandPropCache!.setItem(islandPath, requestUrl)
+        // independent: without the props entry a later request for the bare
+        // path hashes empty props and is rejected
+        await islandCache!.setItem(islandPath, islandResponse).catch(warnCacheFailure)
+        await islandPropCache!.setItem(islandPath, requestUrl).catch(warnCacheFailure)
       }
       return new FastResponse(JSON.stringify(islandResponse), event.res)
     } catch (error) {
+      rejectIsland?.(error)
       rethrowWithResponseHeaders(event, error)
+    } finally {
+      // only the render that claimed it may retire it, or a waiter returning
+      // early reopens the race
+      if (inFlight && inFlightIslands?.get(islandPath) === inFlight) {
+        inFlightIslands.delete(islandPath)
+      }
     }
   },
+}
+
+function warnCacheFailure (error: unknown) {
+  console.warn('[nuxt] could not cache island render:', error)
 }
 
 const ISLAND_PATH_PREFIX = '/__nuxt_island/'

--- a/packages/nitro-server/src/runtime/handlers/island.ts
+++ b/packages/nitro-server/src/runtime/handlers/island.ts
@@ -66,7 +66,10 @@ export default {
       // renders could await each other's claim and hang the build.
       if (!stack?.some(url => url.startsWith(ISLAND_PATH_PREFIX))) {
         // a raw response cannot be shared, so fall through and render our own
-        const shared = await inFlightIslands!.get(islandPath)
+        const shared = await inFlightIslands!.get(islandPath)?.catch((error: any) => {
+          // `rethrowWithResponseHeaders` mutates the error it is given, so rethrow a copy
+          throw new HTTPError({ status: error?.status, statusText: error?.statusText, message: error?.message, cause: error })
+        })
         if (shared && !('raw' in shared)) {
           return toResponse(event, shared)
         }

--- a/test/fixtures/server-components/app/components/islands/PrerenderDedupe.vue
+++ b/test/fixtures/server-components/app/components/islands/PrerenderDedupe.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+const renderId = Math.random().toString(36).slice(2)
+</script>
+
+<template>
+  <div id="prerender-dedupe">
+    {{ renderId }}
+  </div>
+</template>

--- a/test/fixtures/server-components/app/pages/prerender/island-a.vue
+++ b/test/fixtures/server-components/app/pages/prerender/island-a.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    <PrerenderDedupe />
+  </div>
+</template>

--- a/test/fixtures/server-components/app/pages/prerender/island-b.vue
+++ b/test/fixtures/server-components/app/pages/prerender/island-b.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    <PrerenderDedupe />
+  </div>
+</template>

--- a/test/fixtures/server-components/nuxt.config.ts
+++ b/test/fixtures/server-components/nuxt.config.ts
@@ -12,6 +12,8 @@ export default withMatrix({
     prerender: {
       routes: [
         '/prefetch/server-components',
+        '/prerender/island-a',
+        '/prerender/island-b',
       ],
     },
   },

--- a/test/server-components.test.ts
+++ b/test/server-components.test.ts
@@ -475,6 +475,17 @@ describe('component islands', () => {
     await page.locator('#server-page').waitFor()
   })
 
+  it.skipIf(isDev)('should render an island shared by prerendered pages only once', async () => {
+    const [a, b] = await Promise.all([
+      $fetch<string>('/prerender/island-a'),
+      $fetch<string>('/prerender/island-b'),
+    ])
+    const renderId = (html: string) => html.match(/id="prerender-dedupe"[^>]*>([^<]*)</)?.[1]?.trim()
+
+    expect(renderId(a)).toBeTruthy()
+    expect(renderId(a)).toBe(renderId(b))
+  })
+
   it('should show error on 404 error for server pages during client navigation', async () => {
     const { page } = await renderPage('/')
     await page.click('[href="/server-components/lost-page"]')


### PR DESCRIPTION
### 🔗 Linked issue

None

### 📚 Description

During prerendering, every page embedding a server-only island fetches `/__nuxt_island/<island>json`, so the same island is rendered concurrently once per page if it is part of multiple pages. Each render attempt writes the same cache entry.

On Windows those overlapping writes hit `EPERM` and failed the build (this happened to ~8 of 22 Windows-only CI failures over the last weeks).

This PR fixes it by adding a map to track current render attempts so a concurrent request for an island already rendering awaits the running render process instead of creating a new one.
That way, the duplicate work and the race condition is removed.

We use a similar approach for shared prerendering already.

Note: This *should* reduce flakiness for windows builds 🎉 