### PR TITLE
docs: note provide/inject limit in server components

### DIFF
--- a/docs/4.api/1.components/8.nuxt-island.md
+++ b/docs/4.api/1.components/8.nuxt-island.md
@@ -81,6 +81,10 @@ export default defineNuxtPlugin((nuxtApp) => {
 
 - **`useId` does not work in interactive components inside islands.** A component loaded with the [`nuxt-client` attribute](/docs/4.x/guide/concepts/server-components#selective-hydration-with-nuxt-client) is server-rendered inside the island's app but hydrated by the main client app, so `useId` returns different values on the server and on the client, causing a hydration mismatch.
 
+### `provide` / `inject` across the island boundary
+
+Each island is rendered in its own Vue app, so `provide` and `inject` do not cross the island boundary. A value provided by the parent app is not available inside the island, and a value provided inside the island is not available outside it. Pass the data as props, or expose it through a [Nuxt plugin](/docs/4.x/directory-structure/app/plugins) that runs in both contexts.
+
 ## Slots
 
 Slots can be passed to an island component if declared.


### PR DESCRIPTION
### 🔗 Linked issue

resolves #22751

### 📚 Description

Standalone `.server` components render outside the main Vue tree. `provide` from a parent page does not reach them, and values provided inside the island stay inside it.

I added a warning in the components guide (Server Component Context) and a known limitation on the NuxtIsland page. Props or a Nuxt plugin that runs in both contexts are the workarounds.