### PR TITLE
docs(nuxt): document runtime config env name workarounds

### DIFF
--- a/docs/3.guide/6.going-further/10.runtime-config.md
+++ b/docs/3.guide/6.going-further/10.runtime-config.md
@@ -87,6 +87,81 @@ export default defineNuxtConfig({
 })
 ```
 
+### Custom Environment Variable Names
+
+By default, only environment variables with the `NUXT_` prefix override runtime config at runtime. Nitro also recognizes the `NITRO_` prefix internally. This limits overrides to keys you declare in `nuxt.config` and keeps arbitrary environment variables out of your application code.
+
+If your deployment already exposes variables with different names (for example `DATABASE_URL` from a platform integration, or keys in a shared `.env` file), use one of the options below.
+
+#### Custom Env Prefix
+
+Set [`runtimeConfig.nitro.envPrefix`](/docs/4.x/api/nuxt-config#runtimeconfig) to the prefix your environment already uses. Keys still map with `_` separators and case changes, but the required prefix changes from `NUXT_`.
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  runtimeConfig: {
+    nitro: {
+      envPrefix: 'CUSTOM_',
+    },
+    public: {
+      someKey: '',
+    },
+  },
+})
+```
+
+```ini [.env]
+CUSTOM_PUBLIC_SOME_KEY=from-shared-env
+```
+
+::read-more{to="https://stackblitz.com/edit/nuxt-23714?file=.env,nuxt.config.ts" title="StackBlitz example"}
+See a working example from the Nuxt team (linked from [#23714](https://github.com/nuxt/nuxt/issues/23714)).
+::
+
+#### Env Expansion (Experimental)
+
+Enable [`nitro.experimental.envExpansion`](/docs/4.x/api/nuxt-config#nitro) to resolve `{{VAR_NAME}}` placeholders inside runtime config string values at runtime. This reads the referenced environment variable names directly, without a `NUXT_` prefix.
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  nitro: {
+    experimental: {
+      envExpansion: true,
+    },
+  },
+  runtimeConfig: {
+    databaseUrl: '{{DATABASE_URL}}',
+  },
+})
+```
+
+```ini [.env]
+DATABASE_URL=postgres://...
+```
+
+At runtime, `useRuntimeConfig().databaseUrl` resolves to the value of `DATABASE_URL`.
+
+::warning
+Env expansion is experimental and opt-in. Only reference variables in runtime config keys you have already declared in `nuxt.config`.
+::
+
+You can also enable env expansion by setting the `NITRO_ENV_EXPANSION` environment variable when starting the server.
+
+#### Server-Only Environment Variables
+
+If a variable is only needed on the server and does not need to flow through `useRuntimeConfig()`, read `process.env` directly in server routes, server plugins, or Nitro plugins. Values used only in server code are not exposed to the client bundle.
+
+```ts [server/api/db-status.get.ts]
+export default defineEventHandler(() => {
+  const url = process.env.DATABASE_URL
+  return { connected: Boolean(url) }
+})
+```
+
+::note
+Assigning `process.env.MY_VAR` to a `runtimeConfig` default in `nuxt.config` is evaluated at build time. It is not updated when the environment changes at runtime. Prefer `NUXT_` overrides, a custom env prefix, env expansion, or direct `process.env` access on the server.
+::
+
 ## Reading
 
 ### Vue App


### PR DESCRIPTION
### 🔗 Linked issue

Refs #23714

### 📚 Description

Runtime config only picks up `NUXT_`-prefixed env vars by default. People on #23714 wanted to reuse names like `DATABASE_URL` from a shared `.env`.

I added a runtime config guide section for `runtimeConfig.nitro.envPrefix`, env expansion with `{{VAR}}` when `nitro.experimental.envExpansion` is on, and reading `process.env` in server routes when you do not need `useRuntimeConfig()`.