### PR TITLE
feat(kit): expose resolved config snapshot and diff helper

### DIFF
--- a/packages/kit/src/index.ts
+++ b/packages/kit/src/index.ts
@@ -5,8 +5,8 @@ export { getDirectory, installModule, installModules, loadNuxtModuleInstance, no
 export { getNuxtModuleVersion, hasNuxtModule, hasNuxtModuleCompatibility } from './module/compatibility.ts'
 
 // Loader
-export { loadNuxtConfig } from './loader/config.ts'
-export type { LoadNuxtConfigOptions } from './loader/config.ts'
+export { diffNuxtConfig, loadNuxtConfig } from './loader/config.ts'
+export type { LoadNuxtConfigOptions, NuxtConfigDiffEntry, ResolvedNuxtConfigContext } from './loader/config.ts'
 export { extendNuxtSchema } from './loader/schema.ts'
 export { buildNuxt, loadNuxt } from './loader/nuxt.ts'
 export type { LoadNuxtOptions } from './loader/nuxt.ts'

--- a/packages/kit/src/loader/config.ts
+++ b/packages/kit/src/loader/config.ts
@@ -8,15 +8,63 @@ import type { NuxtConfig, NuxtOptions } from '@nuxt/schema'
 import { glob } from 'tinyglobby'
 import { createDefu, defu } from 'defu'
 import { klona } from 'klona/full'
+import { diff } from 'ohash/utils'
 import { basename, dirname, join, normalize, relative, resolve } from 'pathe'
 import { resolveModuleURL } from 'exsolve'
 import { withTrailingSlash, withoutTrailingSlash } from 'ufo'
 
 import { directoryToURL } from '../internal/esm.ts'
 
+/**
+ * Context handed to `onConfigResolved` after configuration has loaded successfully.
+ */
+export interface ResolvedNuxtConfigContext {
+  /**
+   * User configuration merged across all layers, with no schema defaults applied and with
+   * `overrides`, `defaults` and `defaultConfig` from the load options excluded, so repeated
+   * loads of an unchanged project produce an unchanged snapshot. Two snapshots from separate
+   * `loadNuxtConfig` calls can be compared with `diffNuxtConfig`.
+   */
+  rawConfig: NuxtConfig
+  /** Resolved config layers, highest priority first. */
+  layers: ConfigLayer<NuxtConfig, ConfigLayerMeta>[]
+  /** Absolute path of the root `nuxt.config` file, if one was found. */
+  configFile?: string
+  /** Directory the configuration was loaded from. */
+  cwd: string
+}
+
 export interface LoadNuxtConfigOptions extends Omit<LoadConfigOptions<NuxtConfig>, 'overrides'> {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
   overrides?: Exclude<LoadConfigOptions<NuxtConfig>['overrides'], Promise<any> | Function>
+  /**
+   * Called once, awaited, after configuration has loaded successfully. Callers watching config
+   * files themselves can keep the previous `rawConfig` and pass both snapshots to
+   * `diffNuxtConfig` to find out which keys changed. Not called if loading throws.
+   */
+  onConfigResolved?: (context: ResolvedNuxtConfigContext) => void | Promise<void>
+}
+
+/** A single difference between two resolved Nuxt configurations. */
+export interface NuxtConfigDiffEntry {
+  /** Dot-separated path of the changed value, such as `modules` or `runtimeConfig.public.foo`. */
+  key: string
+  type: 'added' | 'changed' | 'removed'
+  newValue?: unknown
+  oldValue?: unknown
+}
+
+/**
+ * Compare two `rawConfig` snapshots (as provided to `onConfigResolved`) and return the
+ * differences between them.
+ */
+export function diffNuxtConfig (oldConfig: NuxtConfig, newConfig: NuxtConfig): NuxtConfigDiffEntry[] {
+  return diff(oldConfig, newConfig).map(entry => ({
+    key: entry.key,
+    type: entry.type,
+    newValue: entry.newValue?.value,
+    oldValue: entry.oldValue?.value,
+  }))
 }
 
 const merger = createDefu((obj, key, value) => {
@@ -121,6 +169,15 @@ export async function loadNuxtConfig (opts: LoadNuxtConfigOptions): Promise<Nuxt
   const { configFile, layers = [], cwd, meta } = resolved
   const nuxtConfig = klona(resolved.config)
 
+  // Merge of the layers c12 produced, minus the synthetic layer it creates for `overrides`, so
+  // caller-supplied `overrides`/`defaults` never appear as user configuration. Taken before the
+  // layer directories below are normalised, so schema defaults stay out of the snapshot.
+  const rawConfig = opts.onConfigResolved
+    ? merger({}, ...layers
+      .filter(layer => layer.config && layer.config !== opts.overrides)
+      .map(layer => layer.config!)) as NuxtConfig
+    : undefined
+
   // Fill config
   nuxtConfig.rootDir ||= cwd
   nuxtConfig._nuxtConfigFile = configFile
@@ -210,7 +267,18 @@ export async function loadNuxtConfig (opts: LoadNuxtConfigOptions): Promise<Nuxt
   }
 
   // Resolve and apply defaults
-  return await applyDefaults(NuxtConfigSchema, nuxtConfig as NuxtConfig & Record<string, JSValue>) as unknown as NuxtOptions
+  const options = await applyDefaults(NuxtConfigSchema, nuxtConfig as NuxtConfig & Record<string, JSValue>) as unknown as NuxtOptions
+
+  if (opts.onConfigResolved) {
+    await opts.onConfigResolved({
+      rawConfig: rawConfig!,
+      layers: _layers,
+      configFile,
+      cwd: cwd!,
+    })
+  }
+
+  return options
 }
 
 /**

--- a/packages/kit/test/load-nuxt-config.test.ts
+++ b/packages/kit/test/load-nuxt-config.test.ts
@@ -4,7 +4,10 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { join } from 'pathe'
 import { findWorkspaceDir } from 'pkg-types'
 
-import { loadNuxtConfig } from '../src/loader/config.ts'
+import type { NuxtConfig } from '@nuxt/schema'
+
+import type { ResolvedNuxtConfigContext } from '../src/loader/config.ts'
+import { diffNuxtConfig, loadNuxtConfig } from '../src/loader/config.ts'
 
 const repoRoot = await findWorkspaceDir()
 
@@ -88,5 +91,138 @@ describe('loadNuxtConfig layer identity canonicalisation', () => {
     } finally {
       process.chdir(originalCwd)
     }
+  })
+})
+
+describe('loadNuxtConfig onConfigResolved', () => {
+  const tempDir = join(repoRoot, 'temp', 'config-resolved')
+
+  beforeAll(async () => {
+    await mkdir(tempDir, { recursive: true })
+  })
+
+  afterAll(async () => {
+    await rm(tempDir, { recursive: true, force: true })
+  })
+
+  it('should receive the merged config before defaults are applied', async () => {
+    await writeFile(
+      join(tempDir, 'nuxt.config.ts'),
+      'export default defineNuxtConfig({ ssr: false, modules: [] })',
+    )
+    const contexts: ResolvedNuxtConfigContext[] = []
+    await loadNuxtConfig({ cwd: tempDir, onConfigResolved: ctx => void contexts.push(ctx) })
+
+    expect(contexts).toHaveLength(1)
+    const [context] = contexts
+    expect(context!.rawConfig).toMatchObject({ ssr: false, modules: [] })
+    expect(context!.cwd).toBe(tempDir)
+    expect(context!.configFile).toBe(join(tempDir, 'nuxt.config.ts'))
+    expect(context!.layers.length).toBeGreaterThan(0)
+  })
+
+  it('should provide snapshots that can be diffed between loads', async () => {
+    await writeFile(
+      join(tempDir, 'nuxt.config.ts'),
+      'export default defineNuxtConfig({ ssr: true, telemetry: false })',
+    )
+    let first: NuxtConfig | undefined
+    await loadNuxtConfig({ cwd: tempDir, onConfigResolved: ctx => void (first = ctx.rawConfig) })
+
+    await writeFile(
+      join(tempDir, 'nuxt.config.ts'),
+      'export default defineNuxtConfig({ ssr: false, telemetry: false, modules: [\'a\'] })',
+    )
+    let second: NuxtConfig | undefined
+    await loadNuxtConfig({ cwd: tempDir, onConfigResolved: ctx => void (second = ctx.rawConfig) })
+
+    const entries = diffNuxtConfig(first!, second!)
+    expect(entries.map(entry => entry.key).sort()).toEqual(['modules', 'ssr'])
+    expect(entries.find(entry => entry.key === 'ssr')).toMatchObject({ type: 'changed', oldValue: true, newValue: false })
+  })
+
+  it('should not be required', async () => {
+    await writeFile(join(tempDir, 'nuxt.config.ts'), 'export default defineNuxtConfig({ ssr: false })')
+    const config = await loadNuxtConfig({ cwd: tempDir })
+    expect(config.ssr).toBe(false)
+  })
+
+  it('should exclude `overrides` and `defaults` supplied by the caller', async () => {
+    await writeFile(
+      join(tempDir, 'nuxt.config.ts'),
+      'export default defineNuxtConfig({ ssr: true })',
+    )
+    let baseline: NuxtConfig | undefined
+    await loadNuxtConfig({ cwd: tempDir, onConfigResolved: ctx => void (baseline = ctx.rawConfig) })
+
+    let withExtras: NuxtConfig | undefined
+    await loadNuxtConfig({
+      cwd: tempDir,
+      overrides: { dev: true },
+      defaults: { devServer: { cors: { origin: ['http://localhost:3000'] } } },
+      onConfigResolved: ctx => void (withExtras = ctx.rawConfig),
+    })
+
+    expect(diffNuxtConfig(baseline!, withExtras!)).toEqual([])
+    expect(withExtras).not.toHaveProperty('dev')
+    expect(withExtras).not.toHaveProperty('devServer')
+  })
+
+  it('should not report changes for functions and other non-plain values in an unchanged config', async () => {
+    await writeFile(
+      join(tempDir, 'nuxt.config.ts'),
+      [
+        'export default defineNuxtConfig({',
+        '  hooks: { \'build:done\': () => \'noop\' },',
+        '  modules: [{ setup () {} }],',
+        '  ignore: [/^ignored/.source],',
+        '  vite: { define: { WHEN: new Date(0).toISOString() } },',
+        '})',
+      ].join('\n'),
+    )
+    const snapshots: NuxtConfig[] = []
+    const load = () => loadNuxtConfig({ cwd: tempDir, onConfigResolved: ctx => void snapshots.push(ctx.rawConfig) })
+    await load()
+    await load()
+
+    expect(diffNuxtConfig(snapshots[0]!, snapshots[1]!)).toEqual([])
+  })
+
+  it('should fire once with `extends` layers', async () => {
+    await mkdir(join(tempDir, 'layers', 'base'), { recursive: true })
+    await writeFile(
+      join(tempDir, 'layers', 'base', 'nuxt.config.ts'),
+      'export default defineNuxtConfig({ css: [\'base.css\'] })',
+    )
+    await writeFile(
+      join(tempDir, 'nuxt.config.ts'),
+      'export default defineNuxtConfig({ extends: [\'./layers/base\'], css: [\'app.css\'] })',
+    )
+    const snapshots: NuxtConfig[] = []
+    const config = await loadNuxtConfig({ cwd: tempDir, onConfigResolved: ctx => void snapshots.push(ctx.rawConfig) })
+
+    expect(snapshots).toHaveLength(1)
+    expect(snapshots[0]!.css).toEqual(config.css)
+    await rm(join(tempDir, 'layers'), { recursive: true, force: true })
+  })
+
+  it('should not fire when config loading throws', async () => {
+    await writeFile(join(tempDir, 'nuxt.config.ts'), 'throw new Error(\'broken config\')')
+    let called = false
+    await expect(loadNuxtConfig({ cwd: tempDir, onConfigResolved: () => void (called = true) })).rejects.toThrow()
+    expect(called).toBe(false)
+  })
+
+  it('should be awaited before resolving', async () => {
+    await writeFile(join(tempDir, 'nuxt.config.ts'), 'export default defineNuxtConfig({})')
+    let done = false
+    await loadNuxtConfig({
+      cwd: tempDir,
+      onConfigResolved: async () => {
+        await new Promise(resolve => setTimeout(resolve, 20))
+        done = true
+      },
+    })
+    expect(done).toBe(true)
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

inspired by c12's watchConfig, which sadly doesn't fit the nuxt/cli architecture, this exposes an `onConfigResolved` hook and `diffNuxtConfig` function which nuxt/cli can use to skip a reload, or print what changed when reloading 🔥