### PR TITLE
fix(nitro): reject non-object island props

### DIFF
--- a/packages/nitro-server/src/runtime/handlers/island.ts
+++ b/packages/nitro-server/src/runtime/handlers/island.ts
@@ -305,7 +305,11 @@ async function getIslandContext (event: H3Event): Promise<NuxtIslandContext> {
   }
 
   // Strip `data-v-*` scoped-style markers so the hashed and rendered prop sets match.
-  const parsedProps = filterIslandProps(destr<Record<string, any> | null | undefined>(serializedProps) || {})
+  const parsed = destr(serializedProps)
+  if (parsed !== null && (typeof parsed !== 'object' || Array.isArray(parsed))) {
+    throw new HTTPError({ status: 400, statusText: 'Invalid island request props' })
+  }
+  const parsedProps = filterIslandProps(parsed || {})
 
   // Bind the response to the URL: a request whose URL-resident `hashId` does not match
   // the actual (name, props, context) is rejected.

--- a/packages/nitro-server/src/runtime/handlers/island.ts
+++ b/packages/nitro-server/src/runtime/handlers/island.ts
@@ -306,10 +306,10 @@ async function getIslandContext (event: H3Event): Promise<NuxtIslandContext> {
 
   // Strip `data-v-*` scoped-style markers so the hashed and rendered prop sets match.
   const parsed = destr(serializedProps)
-  if (parsed !== null && (typeof parsed !== 'object' || Array.isArray(parsed))) {
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
     throw new HTTPError({ status: 400, statusText: 'Invalid island request props' })
   }
-  const parsedProps = filterIslandProps(parsed || {})
+  const parsedProps = filterIslandProps(parsed)
 
   // Bind the response to the URL: a request whose URL-resident `hashId` does not match
   // the actual (name, props, context) is rejected.

--- a/test/server-components.test.ts
+++ b/test/server-components.test.ts
@@ -620,6 +620,24 @@ describe('hash binding', () => {
     }))
     expect(res.status).toBe(400)
   })
+
+  it('rejects array props even when the hash matches their indexed form', async () => {
+    const name = 'PureComponent'
+    const hashId = getIslandHash({ name, props: { 0: 3, 1: 0, 2: 3 } })
+    const res = await fetch(withQuery(`/__nuxt_island/${name}_${hashId}.json`, {
+      props: JSON.stringify([3, 0, 3]),
+    }))
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects primitive props', async () => {
+    const name = 'PureComponent'
+    const hashId = getIslandHash({ name, props: {} })
+    const res = await fetch(withQuery(`/__nuxt_island/${name}_${hashId}.json`, {
+      props: 'false',
+    }))
+    expect(res.status).toBe(400)
+  })
 })
 
 describe('denial-of-service protections', () => {

--- a/test/server-components.test.ts
+++ b/test/server-components.test.ts
@@ -638,6 +638,15 @@ describe('hash binding', () => {
     }))
     expect(res.status).toBe(400)
   })
+
+  it('rejects null props', async () => {
+    const name = 'PureComponent'
+    const hashId = getIslandHash({ name, props: {} })
+    const res = await fetch(withQuery(`/__nuxt_island/${name}_${hashId}.json`, {
+      props: 'null',
+    }))
+    expect(res.status).toBe(400)
+  })
 })
 
 describe('denial-of-service protections', () => {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

spotted by @43081j - thank you!

we can avoid an implicit coercion to object in for... in