### PR TITLE
fix(nuxt): improve page meta extraction + performance

### DIFF
--- a/packages/kit/src/diagnostics/pages.ts
+++ b/packages/kit/src/diagnostics/pages.ts
@@ -41,6 +41,11 @@ export const pageDiagnostics = /* #__PURE__ */ defineDiagnostics({
       fix: 'Use only JSON-serializable values (strings, numbers, booleans, arrays, plain objects) in `defineRouteRules()`.',
       docs: false,
     },
+    NUXT_B4007: {
+      why: (p: { fnName: string, file: string }) => `\`${p.fnName}\` is called conditionally or used as an expression in \`${p.file}\`, but it is a compiler macro that is extracted at build time and always applies.`,
+      fix: (p: { fnName: string }) => `Call \`${p.fnName}({ ... })\` once, as a statement at the top level of the \`<script setup>\` block.`,
+      docs: false,
+    },
     NUXT_B4008: {
       why: 'Server pages with `ssr: false` are not supported while component islands are auto-detected.',
       fix: 'Set `experimental.componentIslands` to `true`.',

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -12,7 +12,7 @@ import { isEqual } from 'ohash'
 import { distDir } from '../dirs.ts'
 import { logger } from '../utils.ts'
 import picomatch from 'picomatch'
-import { resolvePagesRoutes as _resolvePagesRoutes, augmentAndResolve, createPagesContext, defaultExtractionKeys, normalizeRoutes, relativizeToParent, resolveRoutePaths, toRou3Patterns } from './utils.ts'
+import { resolvePagesRoutes as _resolvePagesRoutes, augmentAndResolve, createPagesContext, normalizeRoutes, relativizeToParent, resolvePageMetaExtractionKeys, resolveRoutePaths, toRou3Patterns } from './utils.ts'
 import type { PagesContext } from './utils.ts'
 import { globRouteRulesFromPages, removePagesRules } from './route-rules.ts'
 import { collectStaticPageRoutes, getAssetPathsForRoute } from './public-assets.ts'
@@ -640,11 +640,7 @@ export default defineNuxtModule({
     })
 
     // Extract macros from pages
-    const extraPageMetaExtractionKeys = nuxt.options?.experimental?.extraPageMetaExtractionKeys || []
-    const extractedKeys = [
-      ...defaultExtractionKeys,
-      ...extraPageMetaExtractionKeys,
-    ]
+    const extractedKeys = [...resolvePageMetaExtractionKeys(nuxt.options.experimental.extraPageMetaExtractionKeys)]
 
     nuxt.hook('modules:done', () => {
       addBuildPlugin(PageMetaPlugin({

--- a/packages/nuxt/src/pages/plugins/page-meta.ts
+++ b/packages/nuxt/src/pages/plugins/page-meta.ts
@@ -8,7 +8,7 @@ import type { ScopeTrackerNode } from 'oxc-walker'
 
 import { pageDiagnostics } from '@nuxt/kit'
 import { parseModuleId } from '../../core/utils/plugins.ts'
-import { isSerializable } from '../utils.ts'
+import { classifyPageMetaProperty } from '../utils.ts'
 import type { ESTree, ParserOptions } from 'rolldown/utils'
 
 interface PageMetaPluginOptions {
@@ -45,6 +45,8 @@ if (import.meta.webpackHot) {
 }`
 
 export const PageMetaPlugin = (options: PageMetaPluginOptions = {}) => createUnplugin(() => {
+  const extractedKeys = new Set(options.extractedKeys)
+
   return {
     name: 'nuxt:pages-macros-transform',
     enforce: 'post',
@@ -249,34 +251,35 @@ export const PageMetaPlugin = (options: PageMetaPluginOptions = {}) => createUnp
 
               for (let i = 0; i < meta.properties.length; i++) {
                 const prop = meta.properties[i]!
-                if (prop.type !== 'Property' || prop.key.type !== 'Identifier') {
+                const classification = classifyPageMetaProperty(metaCode, prop, extractedKeys)
+
+                // The route record now carries the value, so drop it here to keep the two in step.
+                if (classification.kind === 'extract') {
+                  omitProp(prop, i)
                   continue
                 }
 
-                if (options.extractedKeys?.includes(prop.key.name)) {
-                  const { serializable } = isSerializable(metaCode, prop.value)
-                  if (serializable) {
-                    omitProp(prop, i)
-                  }
-                } else if (prop.key.name === 'layout' && prop.value.type === 'ObjectExpression') {
-                  for (const layoutProp of prop.value.properties) {
-                    if (layoutProp.type !== 'Property' || layoutProp.key.type !== 'Identifier') {
-                      continue
-                    }
-                    if (layoutProp.key.name === 'name') {
-                      m.appendLeft(
-                        prop.start - meta.start,
-                        `layout: ${code.slice(layoutProp.value.start, layoutProp.value.end)},\n`,
-                      )
-                    } else if (layoutProp.key.name === 'props') {
-                      m.appendLeft(
-                        prop.start - meta.start,
-                        `layoutProps: ${code.slice(layoutProp.value.start, layoutProp.value.end)},\n`,
-                      )
-                    }
-                  }
-                  omitProp(prop, i)
+                if (classification.kind !== 'reshape') {
+                  continue
                 }
+
+                for (const layoutProp of classification.node.properties) {
+                  if (layoutProp.type !== 'Property' || layoutProp.key.type !== 'Identifier') {
+                    continue
+                  }
+                  if (layoutProp.key.name === 'name') {
+                    m.appendLeft(
+                      prop.start - meta.start,
+                      `layout: ${code.slice(layoutProp.value.start, layoutProp.value.end)},\n`,
+                    )
+                  } else if (layoutProp.key.name === 'props') {
+                    m.appendLeft(
+                      prop.start - meta.start,
+                      `layoutProps: ${code.slice(layoutProp.value.start, layoutProp.value.end)},\n`,
+                    )
+                  }
+                }
+                omitProp(prop, i)
               }
             }
 

--- a/packages/nuxt/src/pages/plugins/page-meta.ts
+++ b/packages/nuxt/src/pages/plugins/page-meta.ts
@@ -251,7 +251,7 @@ export const PageMetaPlugin = (options: PageMetaPluginOptions = {}) => createUnp
 
               for (let i = 0; i < meta.properties.length; i++) {
                 const prop = meta.properties[i]!
-                const classification = classifyPageMetaProperty(metaCode, prop, extractedKeys)
+                const classification = classifyPageMetaProperty(prop, extractedKeys)
 
                 // The route record now carries the value, so drop it here to keep the two in step.
                 if (classification.kind === 'extract') {

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -301,7 +301,7 @@ export function getRouteMeta (contents: string, absolutePath: string, extraExtra
 
       if (fnName === 'definePageMeta') {
         for (const key of extractionKeys) {
-          const property = pageExtractArgument.properties.find((property): property is ESTree.ObjectProperty => property.type === 'Property' && property.key.type === 'Identifier' && property.key.name === key)
+          const property = pageExtractArgument.properties.find((property): property is ESTree.ObjectProperty => property.type === 'Property' && !property.computed && property.key.type === 'Identifier' && property.key.name === key)
           if (!property) { continue }
 
           const { value, serializable } = isSerializable(code, property.value)
@@ -320,12 +320,10 @@ export function getRouteMeta (contents: string, absolutePath: string, extraExtra
         }
 
         for (const property of pageExtractArgument.properties) {
-          if (property.type !== 'Property') {
-            continue
-          }
-          const isIdentifierOrLiteral = property.key.type === 'Literal' || property.key.type === 'Identifier'
-          if (!isIdentifierOrLiteral) {
-            continue
+          const isIdentifierOrLiteral = property.type === 'Property' && (property.key.type === 'Literal' || property.key.type === 'Identifier')
+          if (!isIdentifierOrLiteral || property.computed) {
+            dynamicProperties.add('meta')
+            break
           }
           const name = property.key.type === 'Identifier' ? property.key.name : String(property.value)
           if (!extractionKeys.has(name as keyof NuxtPage)) {
@@ -333,13 +331,21 @@ export function getRouteMeta (contents: string, absolutePath: string, extraExtra
             break
           }
         }
-
-        if (dynamicProperties.size) {
-          extractedData.meta ??= {}
-          extractedData.meta[DYNAMIC_META_KEY] = dynamicProperties
-        }
       }
     })
+
+    // A macro we could not resolve to a call expression may still contribute meta at runtime,
+    // so treat the whole object as dynamic rather than assuming there is nothing to extract.
+    for (const macro in found) {
+      if (!found[macro]) {
+        dynamicProperties.add('meta')
+      }
+    }
+
+    if (dynamicProperties.size) {
+      extractedData.meta ??= {}
+      extractedData.meta[DYNAMIC_META_KEY] = dynamicProperties
+    }
   }
 
   extractCache[absolutePath] = extractedData

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -434,7 +434,7 @@ export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = 
       const file = normalize(page.file)
       const pageImportName = genSafeVariableName(filename(file) + hash(file).replace(/-/g, '_'))
       const metaImportName = pageImportName + 'Meta'
-      metaImports.add(genImport(`${file}?macro=true`, [{ name: 'default', as: metaImportName }]))
+      const metaImport = genImport(`${file}?macro=true`, [{ name: 'default', as: metaImportName }])
 
       if (page._sync) {
         metaImports.add(genImport(file, [{ name: 'default', as: pageImportName }]))
@@ -442,7 +442,11 @@ export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = 
 
       const isSyncImport = page._sync && page.mode !== 'client'
       const pageImport = isSyncImport ? pageImportName : genDynamicImport(file)
-      const metaRouteName = `${metaImportName}?.name ?? ${route.name}`
+      // When every key of `definePageMeta` was extracted at build time the macro module cannot
+      // contribute anything, so referencing it here would make the browser request one module
+      // per page before the router can be created.
+      const canResolveNameStatically = !!options?.overrideMeta && !markedDynamic.has('name') && route.name !== undefined
+      const metaRouteName = canResolveNameStatically ? route.name : `${metaImportName}?.name ?? ${route.name}`
 
       // we use this to validate that a server page is rendering the correct url
       const islandKey = page.mode === 'server' && page.file
@@ -532,6 +536,14 @@ async function createClientPage(loader) {
 
         if (route.redirect != null) {
           metaRoute.redirect = route.redirect
+        }
+      }
+
+      for (const key in metaRoute) {
+        if (key === 'children') { continue }
+        if (metaRoute[key as keyof NormalizedRoute]?.includes(metaImportName)) {
+          metaImports.add(metaImport)
+          break
         }
       }
 

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -464,11 +464,13 @@ export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = 
 
       const isSyncImport = page._sync && page.mode !== 'client'
       const pageImport = isSyncImport ? pageImportName : genDynamicImport(file)
-      // When every key of `definePageMeta` was extracted at build time the macro module cannot
-      // contribute anything, so referencing it here would make the browser request one module
-      // per page before the router can be created.
-      const canResolveNameStatically = !!options?.overrideMeta && !markedDynamic.has('name') && route.name !== undefined
-      const metaRouteName = canResolveNameStatically ? route.name : `${metaImportName}?.name ?? ${route.name}`
+      // Mirror whatever the route's own `name` resolves to below, so that a name extracted at
+      // build time does not pull in the macro module purely to set `__name`. That import is the
+      // only static import in the route table, so keeping it costs one browser request per page
+      // before the router can be created.
+      const metaRouteName = options?.overrideMeta && !markedDynamic.has('name')
+        ? route.name ?? `${metaImportName}?.name`
+        : `${metaImportName}?.name ?? ${route.name}`
 
       // we use this to validate that a server page is rendering the correct url
       const islandKey = page.mode === 'server' && page.file

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -235,6 +235,68 @@ function unwrapStaticExpression (node: ESTree.Node | undefined): ESTree.Node | u
   return current
 }
 
+/**
+ * The keys of `definePageMeta` whose values are read at build time, given the user's
+ * `experimental.extraPageMetaExtractionKeys`.
+ *
+ * Both halves of the macro pipeline have to agree on this set: `getRouteMeta` reads these keys
+ * into the route record, and `PageMetaPlugin` removes them from the macro module.
+ */
+export function resolvePageMetaExtractionKeys (extraKeys: Iterable<string> = []): Set<keyof NuxtPage> {
+  return new Set<keyof NuxtPage>([...defaultExtractionKeys, ...extraKeys as Iterable<keyof NuxtPage>])
+}
+
+/**
+ * How a single `definePageMeta` property reaches the route record.
+ *
+ * - `extract` - the value is statically known, so it is written into the route record and removed
+ *   from the macro module.
+ * - `reshape` - the macro transform rewrites the property into keys the route record cannot
+ *   express (`layout: { name, props }` becomes `layout` plus `layoutProps`), so it is resolved by
+ *   the macro module instead.
+ * - `runtime` - the value can only be resolved by evaluating the macro module. `key` is set when
+ *   the property key itself is statically known.
+ */
+export type PageMetaProperty =
+  | { kind: 'extract', key: keyof NuxtPage, value: any }
+  | { kind: 'reshape', key: keyof NuxtPage, node: ESTree.ObjectExpression }
+  | { kind: 'runtime', key?: keyof NuxtPage }
+
+/**
+ * Classify a property of a `definePageMeta` object literal.
+ *
+ * A property may only be removed from the macro module when it is also extracted into the route
+ * record, and vice versa, or its value is lost. Both sides call this so that the two cannot
+ * drift apart.
+ */
+export function classifyPageMetaProperty (code: string, property: ESTree.ObjectPropertyKind, extractionKeys: ReadonlySet<string>): PageMetaProperty {
+  // Spreads, computed keys, getters and methods cannot be resolved without evaluating the module.
+  if (property.type !== 'Property' || property.computed || property.kind !== 'init' || property.method) {
+    return { kind: 'runtime' }
+  }
+
+  let key: keyof NuxtPage
+  if (property.key.type === 'Identifier') {
+    key = property.key.name as keyof NuxtPage
+  } else if (property.key.type === 'Literal' && (typeof property.key.value === 'string' || typeof property.key.value === 'number')) {
+    key = String(property.key.value) as keyof NuxtPage
+  } else {
+    return { kind: 'runtime' }
+  }
+
+  const value = unwrapStaticExpression(property.value)
+  if (key === 'layout' && value?.type === 'ObjectExpression') {
+    return { kind: 'reshape', key, node: value }
+  }
+
+  if (!extractionKeys.has(key)) {
+    return { kind: 'runtime', key }
+  }
+
+  const serialized = isSerializable(code, property.value)
+  return serialized.serializable ? { kind: 'extract', key, value: serialized.value } : { kind: 'runtime', key }
+}
+
 const pageContentsCache: Record<string, string> = {}
 const extractCache: Record<string, Partial<Record<keyof NuxtPage, any>>> = {}
 export function getRouteMeta (contents: string, absolutePath: string, extraExtractionKeys: Set<string> = new Set()): Partial<Record<keyof NuxtPage, any>> {
@@ -257,7 +319,7 @@ export function getRouteMeta (contents: string, absolutePath: string, extraExtra
 
   const extractedData: Partial<Record<keyof NuxtPage, any>> = {}
 
-  const extractionKeys = new Set<keyof NuxtPage>([...defaultExtractionKeys, ...extraExtractionKeys as Set<keyof NuxtPage>])
+  const extractionKeys = resolvePageMetaExtractionKeys(extraExtractionKeys)
 
   for (const script of scriptBlocks) {
     const found: Record<string, boolean> = {}
@@ -305,36 +367,43 @@ export function getRouteMeta (contents: string, absolutePath: string, extraExtra
       }
 
       if (fnName === 'definePageMeta') {
-        for (const key of extractionKeys) {
-          const property = pageExtractArgument.properties.find((property): property is ESTree.ObjectProperty => property.type === 'Property' && !property.computed && property.key.type === 'Identifier' && property.key.name === key)
-          if (!property) { continue }
+        const classified = new Map<keyof NuxtPage, PageMetaProperty>()
+        let hasRuntimeProperty = false
 
-          const { value, serializable } = isSerializable(code, property.value)
-          if (!serializable) {
-            logger.debug(`Skipping extraction of \`${key}\` metadata as it is not JSON-serializable (reading \`${absolutePath}\`).`)
+        for (const property of pageExtractArgument.properties) {
+          const classification = classifyPageMetaProperty(code, property, extractionKeys)
+          if (classification.key === undefined || !extractionKeys.has(classification.key)) {
+            hasRuntimeProperty = true
+            continue
+          }
+          // Duplicate keys keep the first classification, matching the previous lookup.
+          if (!classified.has(classification.key)) {
+            classified.set(classification.key, classification)
+          }
+        }
+
+        for (const key of extractionKeys) {
+          const classification = classified.get(key)
+          if (!classification) { continue }
+
+          if (classification.kind !== 'extract') {
+            logger.debug(classification.kind === 'reshape'
+              ? `Skipping extraction of \`${key}\` metadata as the \`definePageMeta\` macro rewrites it (reading \`${absolutePath}\`).`
+              : `Skipping extraction of \`${key}\` metadata as it is not JSON-serializable (reading \`${absolutePath}\`).`)
             dynamicProperties.add(extraExtractionKeys.has(key) ? 'meta' : key)
             continue
           }
 
           if (extraExtractionKeys.has(key)) {
             extractedData.meta ??= {}
-            extractedData.meta[key] = value
+            extractedData.meta[key] = classification.value
           } else {
-            extractedData[key] = value
+            extractedData[key] = classification.value
           }
         }
 
-        for (const property of pageExtractArgument.properties) {
-          const isIdentifierOrLiteral = property.type === 'Property' && (property.key.type === 'Literal' || property.key.type === 'Identifier')
-          if (!isIdentifierOrLiteral || property.computed) {
-            dynamicProperties.add('meta')
-            break
-          }
-          const name = property.key.type === 'Identifier' ? property.key.name : String(property.value)
-          if (!extractionKeys.has(name as keyof NuxtPage)) {
-            dynamicProperties.add('meta')
-            break
-          }
+        if (hasRuntimeProperty) {
+          dynamicProperties.add('meta')
         }
       }
     })

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -213,7 +213,7 @@ function extractScriptContent (sfc: string) {
 const PAGE_META_MACRO_NAMES = new Set(['definePageMeta', 'defineRouteRules'])
 // Cheap pre-scan only, to skip parsing scripts that cannot contain a macro. The AST walk below
 // is what actually identifies calls.
-const PAGE_EXTRACT_RE = new RegExp(`\\b(?:${[...PAGE_META_MACRO_NAMES].join('|')})\\b`)
+const HAS_PAGE_MACRO_RE = new RegExp(`\\b(?:${[...PAGE_META_MACRO_NAMES].join('|')})\\b`)
 export const defaultExtractionKeys = ['name', 'path', 'props', 'alias', 'redirect', 'middleware'] as const
 const DYNAMIC_META_KEY = '__nuxt_dynamic_meta_key' as const
 
@@ -251,16 +251,19 @@ export function resolvePageMetaExtractionKeys (extraKeys: Iterable<string> = [])
  *
  * - `extract` - the value is statically known, so it is written into the route record and removed
  *   from the macro module.
+ * - `dynamic` - an extracted key whose value needs evaluating, so that one route field falls back
+ *   to the macro module.
  * - `reshape` - the macro transform rewrites the property into keys the route record cannot
- *   express (`layout: { name, props }` becomes `layout` plus `layoutProps`), so it is resolved by
- *   the macro module instead.
- * - `runtime` - the value can only be resolved by evaluating the macro module. `key` is set when
- *   the property key itself is statically known.
+ *   express (`layout: { name, props }` becomes `layout` plus `layoutProps`), so the macro module
+ *   resolves it.
+ * - `runtime` - the property is not extracted at all, so the whole meta object falls back to the
+ *   macro module.
  */
 export type PageMetaProperty =
-  | { kind: 'extract', key: keyof NuxtPage, value: any }
-  | { kind: 'reshape', key: keyof NuxtPage, node: ESTree.ObjectExpression }
-  | { kind: 'runtime', key?: keyof NuxtPage }
+  | { kind: 'extract', key: string, value: any }
+  | { kind: 'dynamic', key: string }
+  | { kind: 'reshape', key: string, node: ESTree.ObjectExpression }
+  | { kind: 'runtime' }
 
 /**
  * Classify a property of a `definePageMeta` object literal.
@@ -269,17 +272,17 @@ export type PageMetaProperty =
  * record, and vice versa, or its value is lost. Both sides call this so that the two cannot
  * drift apart.
  */
-export function classifyPageMetaProperty (code: string, property: ESTree.ObjectPropertyKind, extractionKeys: ReadonlySet<string>): PageMetaProperty {
+export function classifyPageMetaProperty (property: ESTree.ObjectPropertyKind, extractionKeys: ReadonlySet<string>): PageMetaProperty {
   // Spreads, computed keys, getters and methods cannot be resolved without evaluating the module.
   if (property.type !== 'Property' || property.computed || property.kind !== 'init' || property.method) {
     return { kind: 'runtime' }
   }
 
-  let key: keyof NuxtPage
+  let key: string
   if (property.key.type === 'Identifier') {
-    key = property.key.name as keyof NuxtPage
+    key = property.key.name
   } else if (property.key.type === 'Literal' && (typeof property.key.value === 'string' || typeof property.key.value === 'number')) {
-    key = String(property.key.value) as keyof NuxtPage
+    key = String(property.key.value)
   } else {
     return { kind: 'runtime' }
   }
@@ -290,11 +293,11 @@ export function classifyPageMetaProperty (code: string, property: ESTree.ObjectP
   }
 
   if (!extractionKeys.has(key)) {
-    return { kind: 'runtime', key }
+    return { kind: 'runtime' }
   }
 
-  const serialized = isSerializable(code, property.value)
-  return serialized.serializable ? { kind: 'extract', key, value: serialized.value } : { kind: 'runtime', key }
+  const serialized = isSerializable(property.value)
+  return serialized.serializable ? { kind: 'extract', key, value: serialized.value } : { kind: 'dynamic', key }
 }
 
 const pageContentsCache: Record<string, string> = {}
@@ -320,26 +323,25 @@ export function getRouteMeta (contents: string, absolutePath: string, extraExtra
   const extractedData: Partial<Record<keyof NuxtPage, any>> = {}
 
   const extractionKeys = resolvePageMetaExtractionKeys(extraExtractionKeys)
+  const dynamicProperties = new Set<keyof NuxtPage>()
 
   for (const script of scriptBlocks) {
-    if (!PAGE_EXTRACT_RE.test(script.code)) { continue }
+    if (!HAS_PAGE_MACRO_RE.test(script.code)) { continue }
 
-    const code = script.code
-    const dynamicProperties = new Set<keyof NuxtPage>()
     const macroCalls: Array<{ fnName: string, node: ESTree.CallExpression }> = []
 
-    const { program } = parseAndWalk(code, absolutePath.replace(/\.\w+$/, '.' + script.loader), (node) => {
+    const { program } = parseAndWalk(script.code, absolutePath.replace(/\.\w+$/, '.' + script.loader), (node) => {
       if (node.type === 'CallExpression' && node.callee.type === 'Identifier' && PAGE_META_MACRO_NAMES.has(node.callee.name)) {
         macroCalls.push({ fnName: node.callee.name, node })
       }
     })
 
-    const topLevelCalls = new Set<number>()
+    const topLevelCalls = new Set<ESTree.Node>()
     for (const statement of program.body) {
       if (statement.type !== 'ExpressionStatement') { continue }
       const expression = unwrapStaticExpression(statement.expression)
       if (expression?.type === 'CallExpression') {
-        topLevelCalls.add(expression.start)
+        topLevelCalls.add(expression)
       }
     }
 
@@ -349,11 +351,11 @@ export function getRouteMeta (contents: string, absolutePath: string, extraExtra
       // The macros are extracted whatever position they appear in, so a call that is not a
       // top-level statement (nested in a condition, or used as an expression) does not mean what
       // it looks like it means.
-      if (!topLevelCalls.has(node.start)) {
+      if (!topLevelCalls.has(node)) {
         pageDiagnostics.NUXT_B4007({ fnName, file: absolutePath })
       }
 
-      // The macro transform only keeps the first call per macro (and errors on a second
+      // The macro transform reads the first call per macro (and errors on a second
       // `definePageMeta`), so read the same one.
       if (extractedMacros.has(fnName)) { continue }
       extractedMacros.add(fnName)
@@ -370,7 +372,7 @@ export function getRouteMeta (contents: string, absolutePath: string, extraExtra
       }
 
       if (fnName === 'defineRouteRules') {
-        const { value, serializable } = isSerializable(code, argument)
+        const { value, serializable } = isSerializable(argument)
         if (!serializable) {
           pageDiagnostics.NUXT_B4006({ fnName, file: absolutePath })
           continue
@@ -380,29 +382,29 @@ export function getRouteMeta (contents: string, absolutePath: string, extraExtra
         continue
       }
 
-      const classified = new Map<keyof NuxtPage, PageMetaProperty>()
+      const classified = new Map<string, Extract<PageMetaProperty, { kind: 'extract' | 'dynamic' }>>()
       let hasRuntimeProperty = false
 
       for (const property of argument.properties) {
-        const classification = classifyPageMetaProperty(code, property, extractionKeys)
-        if (classification.key === undefined || !extractionKeys.has(classification.key)) {
-          hasRuntimeProperty = true
+        const classification = classifyPageMetaProperty(property, extractionKeys)
+        if (classification.kind === 'extract' || classification.kind === 'dynamic') {
+          // A duplicate key keeps its first occurrence.
+          if (!classified.has(classification.key)) {
+            classified.set(classification.key, classification)
+          }
           continue
         }
-        // Duplicate keys keep the first classification, matching the previous lookup.
-        if (!classified.has(classification.key)) {
-          classified.set(classification.key, classification)
-        }
+        hasRuntimeProperty = true
       }
 
+      // Iterating the key set rather than the properties keeps the emitted order of `meta` keys
+      // independent of the order they were written in.
       for (const key of extractionKeys) {
         const classification = classified.get(key)
         if (!classification) { continue }
 
-        if (classification.kind !== 'extract') {
-          logger.debug(classification.kind === 'reshape'
-            ? `Skipping extraction of \`${key}\` metadata as the \`definePageMeta\` macro rewrites it (reading \`${absolutePath}\`).`
-            : `Skipping extraction of \`${key}\` metadata as it is not JSON-serializable (reading \`${absolutePath}\`).`)
+        if (classification.kind === 'dynamic') {
+          logger.debug(`Skipping extraction of \`${key}\` metadata as it is not JSON-serializable (reading \`${absolutePath}\`).`)
           dynamicProperties.add(extraExtractionKeys.has(key) ? 'meta' : key)
           continue
         }
@@ -419,11 +421,11 @@ export function getRouteMeta (contents: string, absolutePath: string, extraExtra
         dynamicProperties.add('meta')
       }
     }
+  }
 
-    if (dynamicProperties.size) {
-      extractedData.meta ??= {}
-      extractedData.meta[DYNAMIC_META_KEY] = dynamicProperties
-    }
+  if (dynamicProperties.size) {
+    extractedData.meta ??= {}
+    extractedData.meta[DYNAMIC_META_KEY] = dynamicProperties
   }
 
   extractCache[absolutePath] = extractedData
@@ -666,7 +668,7 @@ export function relativizeToParent (parentFullPath: string, childPath: string): 
   return childSegments.slice(parentSegments.length).join('/')
 }
 
-export function isSerializable (code: string, node: ESTree.Node): { value?: any, serializable: boolean } {
+export function isSerializable (node: ESTree.Node): { value?: any, serializable: boolean } {
   node = unwrapStaticExpression(node) || node
 
   if (node.type === 'Literal') {
@@ -691,7 +693,7 @@ export function isSerializable (code: string, node: ESTree.Node): { value?: any,
       if (!element || element.type === 'SpreadElement') {
         return { serializable: false }
       }
-      const { serializable, value } = isSerializable(code, element)
+      const { serializable, value } = isSerializable(element)
       if (!serializable) {
         return { serializable: false }
       }
@@ -714,7 +716,7 @@ export function isSerializable (code: string, node: ESTree.Node): { value?: any,
       } else {
         return { serializable: false }
       }
-      const { serializable, value: propertyValue } = isSerializable(code, property.value)
+      const { serializable, value: propertyValue } = isSerializable(property.value)
       if (!serializable) {
         return { serializable: false }
       }

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -271,8 +271,13 @@ export function getRouteMeta (contents: string, absolutePath: string, extraExtra
     }
 
     const dynamicProperties = new Set<keyof NuxtPage>()
+    const macroCalls: Array<{ fnName: string, start: number }> = []
 
-    parseAndWalk(script.code, absolutePath.replace(/\.\w+$/, '.' + script.loader), (node) => {
+    const { program } = parseAndWalk(script.code, absolutePath.replace(/\.\w+$/, '.' + script.loader), (node) => {
+      if (node.type === 'CallExpression' && node.callee.type === 'Identifier' && node.callee.name in found) {
+        macroCalls.push({ fnName: node.callee.name, start: node.start })
+      }
+
       if (node.type !== 'ExpressionStatement' || node.expression.type !== 'CallExpression' || node.expression.callee.type !== 'Identifier') { return }
 
       // function name is one of the extracted macro functions and not yet found
@@ -333,6 +338,23 @@ export function getRouteMeta (contents: string, absolutePath: string, extraExtra
         }
       }
     })
+
+    // Compiler macros are extracted whatever position they appear in, so a call that is not a
+    // top-level statement (nested in a condition or used as an expression) does not mean what it
+    // looks like it means.
+    const topLevelCalls = new Set<number>()
+    for (const statement of program.body) {
+      if (statement.type !== 'ExpressionStatement') { continue }
+      const expression = unwrapStaticExpression(statement.expression)
+      if (expression?.type === 'CallExpression') {
+        topLevelCalls.add(expression.start)
+      }
+    }
+
+    for (const { fnName, start } of macroCalls) {
+      if (topLevelCalls.has(start)) { continue }
+      pageDiagnostics.NUXT_B4007({ fnName, file: absolutePath })
+    }
 
     // A macro we could not resolve to a call expression may still contribute meta at runtime,
     // so treat the whole object as dynamic rather than assuming there is nothing to extract.

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -289,7 +289,14 @@ export function classifyPageMetaProperty (property: ESTree.ObjectPropertyKind, e
 
   const value = unwrapStaticExpression(property.value)
   if (key === 'layout' && value?.type === 'ObjectExpression') {
-    return { kind: 'reshape', key, node: value }
+    // Only `{ name, props }` can be rewritten into `layout` + `layoutProps`. Any other shape
+    // (spreads, computed keys, unknown keys) has no equivalent, so leave the object untouched
+    // rather than silently dropping parts of it.
+    const reshapable = value.properties.every(subProperty =>
+      subProperty.type === 'Property' && !subProperty.computed && subProperty.kind === 'init' && !subProperty.method
+      && subProperty.key.type === 'Identifier' && (subProperty.key.name === 'name' || subProperty.key.name === 'props'),
+    )
+    return reshapable ? { kind: 'reshape', key, node: value } : { kind: 'runtime' }
   }
 
   if (!extractionKeys.has(key)) {
@@ -388,10 +395,8 @@ export function getRouteMeta (contents: string, absolutePath: string, extraExtra
       for (const property of argument.properties) {
         const classification = classifyPageMetaProperty(property, extractionKeys)
         if (classification.kind === 'extract' || classification.kind === 'dynamic') {
-          // A duplicate key keeps its first occurrence.
-          if (!classified.has(classification.key)) {
-            classified.set(classification.key, classification)
-          }
+          // A duplicate key keeps its last occurrence, mirroring object-literal evaluation.
+          classified.set(classification.key, classification)
           continue
         }
         hasRuntimeProperty = true

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -210,10 +210,10 @@ function extractScriptContent (sfc: string) {
   return contents
 }
 
-const PAGE_META_MACRO_NAMES = ['definePageMeta', 'defineRouteRules'] as const
-// Cheap pre-scan only. The AST walk below validates call expressions so this
-// intentionally matches macro names, not JavaScript/TypeScript call syntax.
-const PAGE_EXTRACT_RE = new RegExp(`\\b(${PAGE_META_MACRO_NAMES.join('|')})\\b`, 'g')
+const PAGE_META_MACRO_NAMES = new Set(['definePageMeta', 'defineRouteRules'])
+// Cheap pre-scan only, to skip parsing scripts that cannot contain a macro. The AST walk below
+// is what actually identifies calls.
+const PAGE_EXTRACT_RE = new RegExp(`\\b(?:${[...PAGE_META_MACRO_NAMES].join('|')})\\b`)
 export const defaultExtractionKeys = ['name', 'path', 'props', 'alias', 'redirect', 'middleware'] as const
 const DYNAMIC_META_KEY = '__nuxt_dynamic_meta_key' as const
 
@@ -322,95 +322,18 @@ export function getRouteMeta (contents: string, absolutePath: string, extraExtra
   const extractionKeys = resolvePageMetaExtractionKeys(extraExtractionKeys)
 
   for (const script of scriptBlocks) {
-    const found: Record<string, boolean> = {}
-    // properties track which macros need to be extracted
-    for (const macro of script.code.matchAll(PAGE_EXTRACT_RE)) {
-      found[macro[1]!] = false
-    }
+    if (!PAGE_EXTRACT_RE.test(script.code)) { continue }
 
-    if (Object.keys(found).length === 0) {
-      continue
-    }
-
+    const code = script.code
     const dynamicProperties = new Set<keyof NuxtPage>()
-    const macroCalls: Array<{ fnName: string, start: number }> = []
+    const macroCalls: Array<{ fnName: string, node: ESTree.CallExpression }> = []
 
-    const { program } = parseAndWalk(script.code, absolutePath.replace(/\.\w+$/, '.' + script.loader), (node) => {
-      if (node.type === 'CallExpression' && node.callee.type === 'Identifier' && node.callee.name in found) {
-        macroCalls.push({ fnName: node.callee.name, start: node.start })
-      }
-
-      if (node.type !== 'ExpressionStatement' || node.expression.type !== 'CallExpression' || node.expression.callee.type !== 'Identifier') { return }
-
-      // function name is one of the extracted macro functions and not yet found
-      const fnName = node.expression.callee.name
-      if (fnName in found === false || found[fnName] !== false) { return }
-      found[fnName] = true
-
-      const code = script.code
-      const pageExtractArgument = unwrapStaticExpression(node.expression.arguments[0])
-
-      if (pageExtractArgument?.type !== 'ObjectExpression') {
-        pageDiagnostics.NUXT_B4005({ fnName, file: absolutePath, receivedType: String(pageExtractArgument?.type) })
-        return
-      }
-
-      if (fnName === 'defineRouteRules') {
-        const { value, serializable } = isSerializable(code, pageExtractArgument)
-        if (!serializable) {
-          pageDiagnostics.NUXT_B4006({ fnName, file: absolutePath })
-          return
-        }
-
-        extractedData.rules = value
-        return
-      }
-
-      if (fnName === 'definePageMeta') {
-        const classified = new Map<keyof NuxtPage, PageMetaProperty>()
-        let hasRuntimeProperty = false
-
-        for (const property of pageExtractArgument.properties) {
-          const classification = classifyPageMetaProperty(code, property, extractionKeys)
-          if (classification.key === undefined || !extractionKeys.has(classification.key)) {
-            hasRuntimeProperty = true
-            continue
-          }
-          // Duplicate keys keep the first classification, matching the previous lookup.
-          if (!classified.has(classification.key)) {
-            classified.set(classification.key, classification)
-          }
-        }
-
-        for (const key of extractionKeys) {
-          const classification = classified.get(key)
-          if (!classification) { continue }
-
-          if (classification.kind !== 'extract') {
-            logger.debug(classification.kind === 'reshape'
-              ? `Skipping extraction of \`${key}\` metadata as the \`definePageMeta\` macro rewrites it (reading \`${absolutePath}\`).`
-              : `Skipping extraction of \`${key}\` metadata as it is not JSON-serializable (reading \`${absolutePath}\`).`)
-            dynamicProperties.add(extraExtractionKeys.has(key) ? 'meta' : key)
-            continue
-          }
-
-          if (extraExtractionKeys.has(key)) {
-            extractedData.meta ??= {}
-            extractedData.meta[key] = classification.value
-          } else {
-            extractedData[key] = classification.value
-          }
-        }
-
-        if (hasRuntimeProperty) {
-          dynamicProperties.add('meta')
-        }
+    const { program } = parseAndWalk(code, absolutePath.replace(/\.\w+$/, '.' + script.loader), (node) => {
+      if (node.type === 'CallExpression' && node.callee.type === 'Identifier' && PAGE_META_MACRO_NAMES.has(node.callee.name)) {
+        macroCalls.push({ fnName: node.callee.name, node })
       }
     })
 
-    // Compiler macros are extracted whatever position they appear in, so a call that is not a
-    // top-level statement (nested in a condition or used as an expression) does not mean what it
-    // looks like it means.
     const topLevelCalls = new Set<number>()
     for (const statement of program.body) {
       if (statement.type !== 'ExpressionStatement') { continue }
@@ -420,15 +343,79 @@ export function getRouteMeta (contents: string, absolutePath: string, extraExtra
       }
     }
 
-    for (const { fnName, start } of macroCalls) {
-      if (topLevelCalls.has(start)) { continue }
-      pageDiagnostics.NUXT_B4007({ fnName, file: absolutePath })
-    }
+    const extractedMacros = new Set<string>()
 
-    // A macro we could not resolve to a call expression may still contribute meta at runtime,
-    // so treat the whole object as dynamic rather than assuming there is nothing to extract.
-    for (const macro in found) {
-      if (!found[macro]) {
+    for (const { fnName, node } of macroCalls) {
+      // The macros are extracted whatever position they appear in, so a call that is not a
+      // top-level statement (nested in a condition, or used as an expression) does not mean what
+      // it looks like it means.
+      if (!topLevelCalls.has(node.start)) {
+        pageDiagnostics.NUXT_B4007({ fnName, file: absolutePath })
+      }
+
+      // The macro transform only keeps the first call per macro (and errors on a second
+      // `definePageMeta`), so read the same one.
+      if (extractedMacros.has(fnName)) { continue }
+      extractedMacros.add(fnName)
+
+      const argument = unwrapStaticExpression(node.arguments[0])
+
+      if (argument?.type !== 'ObjectExpression') {
+        pageDiagnostics.NUXT_B4005({ fnName, file: absolutePath, receivedType: String(argument?.type) })
+        if (fnName === 'definePageMeta') {
+          // The macro module resolves the object at runtime, so the route record cannot own it.
+          dynamicProperties.add('meta')
+        }
+        continue
+      }
+
+      if (fnName === 'defineRouteRules') {
+        const { value, serializable } = isSerializable(code, argument)
+        if (!serializable) {
+          pageDiagnostics.NUXT_B4006({ fnName, file: absolutePath })
+          continue
+        }
+
+        extractedData.rules = value
+        continue
+      }
+
+      const classified = new Map<keyof NuxtPage, PageMetaProperty>()
+      let hasRuntimeProperty = false
+
+      for (const property of argument.properties) {
+        const classification = classifyPageMetaProperty(code, property, extractionKeys)
+        if (classification.key === undefined || !extractionKeys.has(classification.key)) {
+          hasRuntimeProperty = true
+          continue
+        }
+        // Duplicate keys keep the first classification, matching the previous lookup.
+        if (!classified.has(classification.key)) {
+          classified.set(classification.key, classification)
+        }
+      }
+
+      for (const key of extractionKeys) {
+        const classification = classified.get(key)
+        if (!classification) { continue }
+
+        if (classification.kind !== 'extract') {
+          logger.debug(classification.kind === 'reshape'
+            ? `Skipping extraction of \`${key}\` metadata as the \`definePageMeta\` macro rewrites it (reading \`${absolutePath}\`).`
+            : `Skipping extraction of \`${key}\` metadata as it is not JSON-serializable (reading \`${absolutePath}\`).`)
+          dynamicProperties.add(extraExtractionKeys.has(key) ? 'meta' : key)
+          continue
+        }
+
+        if (extraExtractionKeys.has(key)) {
+          extractedData.meta ??= {}
+          extractedData.meta[key] = classification.value
+        } else {
+          extractedData[key] = classification.value
+        }
+      }
+
+      if (hasRuntimeProperty) {
         dynamicProperties.add('meta')
       }
     }
@@ -632,12 +619,10 @@ async function createClientPage(loader) {
         }
       }
 
-      for (const key in metaRoute) {
-        if (key === 'children') { continue }
-        if (metaRoute[key as keyof NormalizedRoute]?.includes(metaImportName)) {
-          metaImports.add(metaImport)
-          break
-        }
+      // Nested routes reference their own macro modules, so they are excluded here.
+      const { children, ...ownFields } = metaRoute
+      if (Object.values(ownFields).some(field => field?.includes(metaImportName))) {
+        metaImports.add(metaImport)
       }
 
       return metaRoute

--- a/packages/nuxt/test/is-serializable.test.ts
+++ b/packages/nuxt/test/is-serializable.test.ts
@@ -4,18 +4,16 @@ import type { ESTree } from 'rolldown/utils'
 
 import { isSerializable } from '../src/pages/utils.ts'
 
-function parseExpression (source: string): { code: string, node: ESTree.Expression } {
+function parseExpression (source: string): ESTree.Expression {
   // Parse as a variable initialiser so a leading `{` isn't ambiguous with a block, and we get the
   // raw expression node rather than a ParenthesizedExpression wrapper.
-  const code = `const __x = ${source}`
-  const ast = parseSync('test.js', code, { lang: 'js' })
+  const ast = parseSync('test.js', `const __x = ${source}`, { lang: 'js' })
   const decl = ast.program.body[0] as ESTree.VariableDeclaration
-  return { code, node: decl.declarations[0]!.init as ESTree.Expression }
+  return decl.declarations[0]!.init as ESTree.Expression
 }
 
 function check (source: string) {
-  const { code, node } = parseExpression(source)
-  return isSerializable(code, node)
+  return isSerializable(parseExpression(source))
 }
 
 describe('isSerializable', () => {

--- a/packages/nuxt/test/page-metadata.test.ts
+++ b/packages/nuxt/test/page-metadata.test.ts
@@ -6,7 +6,7 @@ import { klona } from 'klona'
 import { parse as toAst } from 'acorn'
 
 import { PageMetaPlugin } from '../src/pages/plugins/page-meta.ts'
-import { getRouteMeta, normalizeRoutes } from '../src/pages/utils.ts'
+import { augmentPages, getRouteMeta, normalizeRoutes } from '../src/pages/utils.ts'
 import type { NuxtPage } from '../schema.ts'
 
 const filePath = '/app/pages/index.vue'
@@ -647,6 +647,38 @@ describe('normalizeRoutes', () => {
       overrideMeta: true,
     })
     expect(imports).toEqual(new Set())
+  })
+
+  it('should import the macro module for a route whose name was stripped as a duplicate', async () => {
+    const vfs = { [filePath]: `<script setup>definePageMeta({ name: 'from-macro', alias: ['/some-alias'] })</script>` }
+    const pages: NuxtPage[] = [
+      { path: '/', file: filePath },
+      { path: '/duplicate', file: filePath },
+    ]
+    await augmentPages(pages, vfs, { fullyResolvedPaths: new Set([filePath]) })
+
+    const { routes, imports } = normalizeRoutes(pages, new Set(), {
+      clientComponentRuntime: '<client-component-runtime>',
+      serverComponentRuntime: '<server-component-runtime>',
+      overrideMeta: true,
+    })
+    expect(imports.size).toBe(1)
+    expect(routes).toMatchInlineSnapshot(`
+      "[
+        {
+          name: "from-macro",
+          path: "/",
+          alias: ["/some-alias"],
+          component: () => import("/app/pages/index.vue")
+        },
+        {
+          name: indexndqPXFtP262szLmLJV4PriPTgAg5k_7f05QyTfosBXQMeta?.name,
+          path: "/duplicate",
+          alias: ["/some-alias"],
+          component: () => import("/app/pages/index.vue")
+        }
+      ]"
+    `)
   })
 
   it('should import the macro module when metadata is not statically analysable', () => {

--- a/packages/nuxt/test/page-metadata.test.ts
+++ b/packages/nuxt/test/page-metadata.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { MockedFunction } from 'vitest'
 import { compileScript, parse } from '@vue/compiler-sfc'
+import { pageDiagnostics } from '@nuxt/kit'
 import { klona } from 'klona'
 import { parse as toAst } from 'acorn'
 
@@ -485,6 +486,79 @@ definePageMeta({ name: 'bar' })
         },
       }
     `)
+  })
+})
+
+describe('page metadata macro position', () => {
+  let warn: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    warn = vi.spyOn(pageDiagnostics, 'NUXT_B4007').mockReturnValue(undefined as never)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should not warn when the macros are called at the top level', () => {
+    getRouteMeta(`
+    <script setup>
+    definePageMeta({ name: 'some-custom-name' })
+    defineRouteRules({ prerender: true })
+    </script>
+    `, '/app/pages/top-level.vue')
+
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('should not warn when a macro call is wrapped in parentheses or type assertions', () => {
+    getRouteMeta(`
+    <script setup lang="ts">
+    ;(definePageMeta({ name: 'some-custom-name' }))
+    </script>
+    `, '/app/pages/wrapped.vue')
+
+    getRouteMeta(`
+    <script setup lang="ts">
+    definePageMeta({ name: 'some-custom-name' }) as void
+    </script>
+    `, '/app/pages/asserted.vue')
+
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('should warn when a macro is called conditionally', () => {
+    getRouteMeta(`
+    <script setup>
+    if (condition) {
+      definePageMeta({ name: 'some-custom-name' })
+    }
+    </script>
+    `, '/app/pages/conditional.vue')
+
+    expect(warn).toHaveBeenCalledWith({ fnName: 'definePageMeta', file: '/app/pages/conditional.vue' })
+  })
+
+  it('should warn when a macro is used as an expression', () => {
+    getRouteMeta(`
+    <script setup>
+    void definePageMeta({ name: 'some-custom-name' })
+    </script>
+    `, '/app/pages/expression.vue')
+
+    expect(warn).toHaveBeenCalledWith({ fnName: 'definePageMeta', file: '/app/pages/expression.vue' })
+  })
+
+  it('should warn when a macro is called inside a function', () => {
+    getRouteMeta(`
+    <script setup>
+    function setup () {
+      defineRouteRules({ prerender: true })
+    }
+    </script>
+    `, '/app/pages/nested.vue')
+
+    expect(warn).toHaveBeenCalledWith({ fnName: 'defineRouteRules', file: '/app/pages/nested.vue' })
   })
 })
 

--- a/packages/nuxt/test/page-metadata.test.ts
+++ b/packages/nuxt/test/page-metadata.test.ts
@@ -1308,6 +1308,33 @@ definePageMeta(meta)
       })
     })
 
+    it('should keep an object layout with sub-properties that cannot be reshaped', () => {
+      const sfc = `
+<script setup lang="ts">
+const shared = { name: 'admin' }
+definePageMeta({ layout: { ...shared, props: { collapsed: true } } })
+</script>
+      `
+      const macro = macroModule(sfc, extractionKeys)
+      expect(macro).toContain('...shared')
+      expect(macro).not.toContain('layoutProps')
+      expect(getRouteMeta(sfc, '/app/pages/layout-spread.vue')).toEqual({
+        meta: { __nuxt_dynamic_meta_key: new Set(['meta']) },
+      })
+    })
+
+    it('should extract the last occurrence of a duplicate key', () => {
+      const sfc = `
+<script setup lang="ts">
+definePageMeta({ name: 'first', name: 'last' })
+</script>
+      `
+      const macro = macroModule(sfc, extractionKeys)
+      expect(macro).not.toContain('first')
+      expect(macro).not.toContain('last')
+      expect(getRouteMeta(sfc, '/app/pages/duplicate.vue')).toEqual({ name: 'last' })
+    })
+
     it('should keep a getter whose name collides with an extracted key', () => {
       const sfc = `
 <script setup lang="ts">

--- a/packages/nuxt/test/page-metadata.test.ts
+++ b/packages/nuxt/test/page-metadata.test.ts
@@ -427,6 +427,64 @@ definePageMeta({ name: 'bar' })
       }
     `)
   })
+  it('should mark metadata as dynamic when properties are spread', () => {
+    const meta = getRouteMeta(`
+    <script setup>
+    definePageMeta({
+      ...common,
+    })
+    </script>
+    `, filePath)
+
+    expect(meta).toMatchInlineSnapshot(`
+      {
+        "meta": {
+          "__nuxt_dynamic_meta_key": Set {
+            "meta",
+          },
+        },
+      }
+    `)
+  })
+
+  it('should mark metadata as dynamic when keys are computed', () => {
+    const meta = getRouteMeta(`
+    <script setup>
+    definePageMeta({
+      [name]: 'some-custom-name',
+    })
+    </script>
+    `, filePath)
+
+    expect(meta).toMatchInlineSnapshot(`
+      {
+        "meta": {
+          "__nuxt_dynamic_meta_key": Set {
+            "meta",
+          },
+        },
+      }
+    `)
+  })
+
+  it('should mark metadata as dynamic when the macro is not called as a statement', () => {
+    const meta = getRouteMeta(`
+    <script setup>
+    const meta = { name: 'some-custom-name' }
+    if (condition) { void definePageMeta(meta) }
+    </script>
+    `, filePath)
+
+    expect(meta).toMatchInlineSnapshot(`
+      {
+        "meta": {
+          "__nuxt_dynamic_meta_key": Set {
+            "meta",
+          },
+        },
+      }
+    `)
+  })
 })
 
 describe('normalizeRoutes', () => {

--- a/packages/nuxt/test/page-metadata.test.ts
+++ b/packages/nuxt/test/page-metadata.test.ts
@@ -427,6 +427,7 @@ definePageMeta({ name: 'bar' })
       }
     `)
   })
+
   it('should mark metadata as dynamic when properties are spread', () => {
     const meta = getRouteMeta(`
     <script setup>
@@ -532,6 +533,66 @@ describe('normalizeRoutes', () => {
       ]",
       }
     `)
+  })
+
+  it('should not import the macro module when all metadata was extracted', () => {
+    const page: NuxtPage = { path: '/', file: filePath }
+    Object.assign(page, getRouteMeta(`
+      <script setup>
+      definePageMeta({
+        name: 'some-custom-name',
+        alias: ['/some-alias'],
+      })
+      </script>
+      `, filePath))
+
+    const { routes, imports } = normalizeRoutes([page], new Set(), {
+      clientComponentRuntime: '<client-component-runtime>',
+      serverComponentRuntime: '<server-component-runtime>',
+      overrideMeta: true,
+    })
+    expect(imports).toEqual(new Set())
+    expect(routes).toMatchInlineSnapshot(`
+      "[
+        {
+          name: "some-custom-name",
+          path: "/",
+          alias: ["/some-alias"],
+          component: () => import("/app/pages/index.vue")
+        }
+      ]"
+    `)
+  })
+
+  it('should not import the macro module for pages without page metadata', () => {
+    const page: NuxtPage = { path: '/', name: 'index', file: filePath }
+
+    const { imports } = normalizeRoutes([page], new Set(), {
+      clientComponentRuntime: '<client-component-runtime>',
+      serverComponentRuntime: '<server-component-runtime>',
+      overrideMeta: true,
+    })
+    expect(imports).toEqual(new Set())
+  })
+
+  it('should import the macro module when metadata is not statically analysable', () => {
+    const page: NuxtPage = { path: '/', name: 'index', file: filePath }
+    Object.assign(page, getRouteMeta(`
+      <script setup>
+      definePageMeta({
+        layout: 'custom',
+      })
+      </script>
+      `, filePath))
+
+    const { imports } = normalizeRoutes([page], new Set(), {
+      clientComponentRuntime: '<client-component-runtime>',
+      serverComponentRuntime: '<server-component-runtime>',
+      overrideMeta: true,
+    })
+    expect(imports).toEqual(new Set([
+      'import { default as indexndqPXFtP262szLmLJV4PriPTgAg5k_7f05QyTfosBXQMeta } from "/app/pages/index.vue?macro=true";',
+    ]))
   })
 
   it('should produce valid route objects when used without extracted meta', () => {

--- a/packages/nuxt/test/page-metadata.test.ts
+++ b/packages/nuxt/test/page-metadata.test.ts
@@ -6,7 +6,7 @@ import { klona } from 'klona'
 import { parse as toAst } from 'acorn'
 
 import { PageMetaPlugin } from '../src/pages/plugins/page-meta.ts'
-import { augmentPages, getRouteMeta, normalizeRoutes } from '../src/pages/utils.ts'
+import { augmentPages, defaultExtractionKeys, getRouteMeta, normalizeRoutes } from '../src/pages/utils.ts'
 import type { NuxtPage } from '../schema.ts'
 
 const filePath = '/app/pages/index.vue'
@@ -1215,6 +1215,65 @@ definePageMeta({
       }
       // verify for valid JS
       expect(() => toAst(result!, { ecmaVersion: 'latest', sourceType: 'module' })).not.toThrow()
+    })
+  })
+
+  describe('agreement with extracted route meta', () => {
+    const extractionKeys = [...defaultExtractionKeys]
+
+    function macroModule (sfc: string, extractedKeys: string[]) {
+      const plugin = PageMetaPlugin({ extractedKeys }).raw({}, {} as any) as { transform: { handler: (code: string, id: string) => { code: string } | null } }
+      const res = compileScript(parse(sfc).descriptor, { id: 'component.vue' })
+      return plugin.transform.handler(res.content, 'component.vue?macro=true')?.code
+    }
+
+    it('should keep a computed key whose name collides with an extracted key', () => {
+      const sfc = `
+<script setup lang="ts">
+const name = 'title'
+definePageMeta({ [name]: 'some-title' })
+</script>
+      `
+      expect(macroModule(sfc, extractionKeys)).toContain('[name]: \'some-title\'')
+      expect(getRouteMeta(sfc, '/app/pages/computed.vue')).toEqual({
+        meta: { __nuxt_dynamic_meta_key: new Set(['meta']) },
+      })
+    })
+
+    it('should reshape an object layout even when `layout` is an extraction key', () => {
+      const sfc = `
+<script setup lang="ts">
+definePageMeta({ layout: { name: 'admin', props: { collapsed: true } } })
+</script>
+      `
+      const macro = macroModule(sfc, [...extractionKeys, 'layout'])
+      expect(macro).toContain('layout: \'admin\'')
+      expect(macro).toContain('layoutProps: { collapsed: true }')
+      expect(getRouteMeta(sfc, '/app/pages/layout.vue', new Set(['layout']))).toEqual({
+        meta: { __nuxt_dynamic_meta_key: new Set(['meta']) },
+      })
+    })
+
+    it('should strip a quoted key that is extracted into the route record', () => {
+      const sfc = `
+<script setup lang="ts">
+definePageMeta({ 'name': 'quoted-name' })
+</script>
+      `
+      expect(macroModule(sfc, extractionKeys)).not.toContain('quoted-name')
+      expect(getRouteMeta(sfc, '/app/pages/quoted.vue')).toEqual({ name: 'quoted-name' })
+    })
+
+    it('should keep a getter whose name collides with an extracted key', () => {
+      const sfc = `
+<script setup lang="ts">
+definePageMeta({ get name () { return 'from-getter' } })
+</script>
+      `
+      expect(macroModule(sfc, extractionKeys)).toContain('from-getter')
+      expect(getRouteMeta(sfc, '/app/pages/getter.vue')).toEqual({
+        meta: { __nuxt_dynamic_meta_key: new Set(['meta']) },
+      })
     })
   })
 })

--- a/packages/nuxt/test/page-metadata.test.ts
+++ b/packages/nuxt/test/page-metadata.test.ts
@@ -469,11 +469,11 @@ definePageMeta({ name: 'bar' })
     `)
   })
 
-  it('should mark metadata as dynamic when the macro is not called as a statement', () => {
+  it('should mark metadata as dynamic when the macro is not passed an object literal', () => {
     const meta = getRouteMeta(`
     <script setup>
     const meta = { name: 'some-custom-name' }
-    if (condition) { void definePageMeta(meta) }
+    definePageMeta(meta)
     </script>
     `, filePath)
 
@@ -486,6 +486,27 @@ definePageMeta({ name: 'bar' })
         },
       }
     `)
+  })
+
+  it('should extract metadata from a macro call that is not a statement', () => {
+    const meta = getRouteMeta(`
+    <script setup>
+    if (condition) { void definePageMeta({ name: 'some-custom-name' }) }
+    </script>
+    `, filePath)
+
+    expect(meta).toEqual({ name: 'some-custom-name' })
+  })
+
+  it('should not treat a mention of a macro name as a call', () => {
+    const meta = getRouteMeta(`
+    <script setup>
+    // definePageMeta({ name: 'commented-out' })
+    const doc = 'call definePageMeta to set page metadata'
+    </script>
+    `, filePath)
+
+    expect(meta).toEqual({})
   })
 })
 
@@ -1262,6 +1283,29 @@ definePageMeta({ 'name': 'quoted-name' })
       `
       expect(macroModule(sfc, extractionKeys)).not.toContain('quoted-name')
       expect(getRouteMeta(sfc, '/app/pages/quoted.vue')).toEqual({ name: 'quoted-name' })
+    })
+
+    it('should extract from a call the transform also strips, whatever its position', () => {
+      const sfc = `
+<script setup lang="ts">
+void definePageMeta({ name: 'voided-name' })
+</script>
+      `
+      expect(macroModule(sfc, extractionKeys)).not.toContain('voided-name')
+      expect(getRouteMeta(sfc, '/app/pages/voided.vue')).toEqual({ name: 'voided-name' })
+    })
+
+    it('should keep the macro module when the argument is not an object literal', () => {
+      const sfc = `
+<script setup lang="ts">
+const meta = { name: 'from-variable', title: 'hello' }
+definePageMeta(meta)
+</script>
+      `
+      expect(macroModule(sfc, extractionKeys)).toContain('const __nuxt_page_meta = meta')
+      expect(getRouteMeta(sfc, '/app/pages/variable.vue')).toEqual({
+        meta: { __nuxt_dynamic_meta_key: new Set(['meta']) },
+      })
     })
 
     it('should keep a getter whose name collides with an extracted key', () => {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

I started work on this originally as a performance improvement - to prevent having to pull in every single page (via macro transform) to render any page (the imports were always being rendered in `#build/routes.mjs`)

along the way, I discovered some correctness issues (for example, divergence between our static analysis and plugin transform), as well as some opportunities to give users better errors (e.g. detecting a `definePageMeta` macro inside a conditional, which can only indicate they have misunderstood the concept 

