### PR TITLE
perf(vite): crawl client module graph when warming dev server

### DIFF
--- a/packages/schema/src/types/config.ts
+++ b/packages/schema/src/types/config.ts
@@ -122,6 +122,11 @@ export interface ViteConfig extends Omit<ViteUserConfig, 'publicDir'> {
 
   /**
    * Warmup vite entrypoint caches on dev startup.
+   *
+   * In dev mode Nuxt crawls the client entry's import graph once Nitro has built, transforming
+   * modules the browser is about to request. Set to `false` to skip this speculative work, which
+   * also disables Vite's own entry warmup.
+   * @default true
    */
   warmupEntry?: boolean
 

--- a/packages/vite/src/utils/warmup.test.ts
+++ b/packages/vite/src/utils/warmup.test.ts
@@ -1,0 +1,254 @@
+import type { IncomingMessage } from 'node:http'
+import { describe, expect, it, vi } from 'vitest'
+import type { DevEnvironment } from 'vite'
+import { isNavigationRequest, warmupViteServer } from './warmup.ts'
+
+const root = '/project'
+
+interface FakeModule {
+  url: string
+  imports: string[]
+}
+
+function createEnvironment (graph: Record<string, string[]>) {
+  const transformed: string[] = []
+  const modules = new Map<string, FakeModule & { transformResult: { code: string } | null }>()
+
+  const environment = {
+    moduleGraph: {
+      getModuleByUrl: (url: string) => {
+        const mod = modules.get(url)
+        if (!mod) { return Promise.resolve(undefined) }
+        return Promise.resolve({
+          transformResult: mod.transformResult,
+          importedModules: new Set(mod.imports.map(url => ({ url }))),
+        })
+      },
+    },
+    transformRequest: (url: string) => {
+      transformed.push(url)
+      modules.set(url, { url, imports: graph[url] || [], transformResult: { code: '' } })
+      return Promise.resolve({ code: '' })
+    },
+  } as unknown as DevEnvironment
+
+  for (const url of Object.keys(graph)) {
+    modules.set(url, { url, imports: graph[url]!, transformResult: null })
+  }
+
+  return { environment, transformed }
+}
+
+describe('warmupViteServer', () => {
+  it('should crawl the entry\'s transitive imports', async () => {
+    const { environment, transformed } = createEnvironment({
+      '/app/entry.js': ['/app/a.js', '/app/b.js'],
+      '/app/a.js': ['/app/c.js'],
+      '/app/b.js': ['/app/c.js'],
+      '/app/c.js': [],
+    })
+
+    const result = await warmupViteServer(environment, [`${root}/app/entry.js`], { root })
+
+    expect(transformed.sort()).toStrictEqual(['/app/a.js', '/app/b.js', '/app/c.js', '/app/entry.js'])
+    expect(result.modules).toBe(4)
+    expect(result.stopped).toBe(false)
+  })
+
+  it('should handle cycles and already-transformed modules', async () => {
+    const { environment, transformed } = createEnvironment({
+      '/app/entry.js': ['/app/a.js'],
+      '/app/a.js': ['/app/entry.js'],
+    })
+
+    await warmupViteServer(environment, [`${root}/app/entry.js`], { root })
+    await warmupViteServer(environment, [`${root}/app/entry.js`], { root })
+
+    expect(transformed).toStrictEqual(['/app/entry.js', '/app/a.js'])
+  })
+
+  it('should strip the base and vite url decorations', async () => {
+    const { environment, transformed } = createEnvironment({
+      '/app/entry.js': ['/base/app/a.js', '/base/@id/virtual:thing', '/base/app/b.js?import='],
+      '/app/a.js': [],
+      'virtual:thing': [],
+      '/app/b.js': [],
+    })
+
+    await warmupViteServer(environment, [`${root}/app/entry.js`], { root, base: '/base/' })
+
+    expect(transformed.sort()).toStrictEqual(['/app/a.js', '/app/b.js', '/app/entry.js', 'virtual:thing'])
+  })
+
+  it('should drop `import` without corrupting the remaining query', async () => {
+    const { environment, transformed } = createEnvironment({
+      '/app/entry.js': ['/app/a.js?import&t=1', '/app/b.js?import=&v=2', '/app/c.vue?vue&type=style&index=0&lang.css', '/app/d.js?'],
+      '/app/a.js?t=1': [],
+      '/app/b.js?v=2': [],
+      '/app/c.vue?vue&type=style&index=0&lang.css': [],
+      '/app/d.js': [],
+    })
+
+    await warmupViteServer(environment, [`${root}/app/entry.js`], { root })
+
+    expect(transformed.sort()).toStrictEqual([
+      '/app/a.js?t=1',
+      '/app/b.js?v=2',
+      '/app/c.vue?vue&type=style&index=0&lang.css',
+      '/app/d.js',
+      '/app/entry.js',
+    ])
+  })
+
+  it('should transform modules in parallel', async () => {
+    const { environment } = createEnvironment({
+      '/app/entry.js': ['/app/a.js', '/app/b.js', '/app/c.js', '/app/d.js'],
+      '/app/a.js': [],
+      '/app/b.js': [],
+      '/app/c.js': [],
+      '/app/d.js': [],
+    })
+
+    let active = 0
+    let maxActive = 0
+    const transformRequest = environment.transformRequest
+    vi.spyOn(environment, 'transformRequest').mockImplementation(async (url) => {
+      active++
+      maxActive = Math.max(maxActive, active)
+      await new Promise(resolve => setTimeout(resolve, 10))
+      active--
+      return transformRequest(url)
+    })
+
+    const result = await warmupViteServer(environment, [`${root}/app/entry.js`], { root, concurrency: 4 })
+
+    expect(maxActive).toBe(4)
+    expect(result.modules).toBe(5)
+  })
+
+  it('should idle while paused rather than transforming', async () => {
+    const { environment, transformed } = createEnvironment({
+      '/app/entry.js': ['/app/a.js'],
+      '/app/a.js': [],
+    })
+
+    let paused = true
+    const result = warmupViteServer(environment, [`${root}/app/entry.js`], {
+      root,
+      maxDuration: 5000,
+      shouldPause: () => paused,
+    })
+
+    await new Promise(resolve => setTimeout(resolve, 60))
+    expect(transformed).toStrictEqual([])
+
+    paused = false
+    expect((await result).stopped).toBe(false)
+    expect(transformed.sort()).toStrictEqual(['/app/a.js', '/app/entry.js'])
+  })
+
+  it('should not count already-transformed modules towards the module bound', async () => {
+    const { environment } = createEnvironment({
+      '/app/entry.js': ['/app/a.js'],
+      '/app/a.js': ['/app/b.js'],
+      '/app/b.js': [],
+    })
+
+    await warmupViteServer(environment, [`${root}/app/entry.js`], { root, maxModules: 1, concurrency: 1 })
+    const result = await warmupViteServer(environment, [`${root}/app/entry.js`], { root, maxModules: 1, concurrency: 1 })
+
+    expect(result.modules).toBe(1)
+    expect(result.visited).toBe(2)
+  })
+
+  it('should use an /@fs/ url for entries outside the root', async () => {
+    const { environment, transformed } = createEnvironment({ '/@fs/elsewhere/entry.js': [] })
+
+    await warmupViteServer(environment, ['/elsewhere/entry.js'], { root })
+
+    expect(transformed).toStrictEqual(['/@fs/elsewhere/entry.js'])
+  })
+
+  it('should stop at the module bound', async () => {
+    const { environment, transformed } = createEnvironment({
+      '/app/entry.js': ['/app/a.js', '/app/b.js', '/app/c.js'],
+      '/app/a.js': [],
+      '/app/b.js': [],
+      '/app/c.js': [],
+    })
+
+    const result = await warmupViteServer(environment, [`${root}/app/entry.js`], { root, maxModules: 2, concurrency: 1 })
+
+    expect(transformed.length).toBe(2)
+    expect(result.stopped).toBe(true)
+  })
+
+  it('should abandon the crawl when a request arrives', async () => {
+    const { environment, transformed } = createEnvironment({
+      '/app/entry.js': ['/app/a.js', '/app/b.js'],
+      '/app/a.js': [],
+      '/app/b.js': [],
+    })
+
+    let requested = false
+    const transformRequest = environment.transformRequest
+    vi.spyOn(environment, 'transformRequest').mockImplementation((url) => {
+      requested = true
+      return transformRequest(url)
+    })
+
+    const result = await warmupViteServer(environment, [`${root}/app/entry.js`], {
+      root,
+      concurrency: 1,
+      shouldStop: () => requested,
+    })
+
+    expect(transformed).toStrictEqual(['/app/entry.js'])
+    expect(result.stopped).toBe(true)
+  })
+
+  it('should not follow imports of css requests', async () => {
+    const { environment, transformed } = createEnvironment({
+      '/app/entry.js': ['/app/style.css'],
+      '/app/style.css': ['/app/nested.js'],
+      '/app/nested.js': [],
+    })
+
+    await warmupViteServer(environment, [`${root}/app/entry.js`], { root })
+
+    expect(transformed.sort()).toStrictEqual(['/app/entry.js', '/app/style.css'])
+  })
+
+  it('should survive a failing transform', async () => {
+    const { environment, transformed } = createEnvironment({
+      '/app/entry.js': ['/app/a.js', '/app/b.js'],
+      '/app/a.js': [],
+      '/app/b.js': [],
+    })
+    const transformRequest = environment.transformRequest
+    vi.spyOn(environment, 'transformRequest').mockImplementation((url) => {
+      if (url === '/app/a.js') { return Promise.reject(new Error('boom')) }
+      return transformRequest(url)
+    })
+
+    const result = await warmupViteServer(environment, [`${root}/app/entry.js`], { root })
+
+    expect(transformed).toContain('/app/b.js')
+    expect(result.stopped).toBe(false)
+  })
+})
+
+describe('isNavigationRequest', () => {
+  const request = (headers: Record<string, string>) => ({ headers } as unknown as IncomingMessage)
+
+  it.each([
+    [{ 'sec-fetch-mode': 'navigate', 'accept': '*/*' }, true],
+    [{ 'sec-fetch-mode': 'cors', 'accept': 'text/html' }, false],
+    [{ 'sec-fetch-mode': 'no-cors' }, false],
+    [{ accept: 'text/html,application/xhtml+xml' }, true],
+    [{ accept: '*/*' }, false],
+    [{}, false],
+  ])('should detect %o as %s', (headers, expected) => {
+    expect(isNavigationRequest(request(headers))).toBe(expected)
+  })
+})

--- a/packages/vite/src/utils/warmup.ts
+++ b/packages/vite/src/utils/warmup.ts
@@ -131,8 +131,8 @@ export async function warmupViteServer (
     try {
       mod = await environment.moduleGraph.getModuleByUrl(url)
       if (!mod?.transformResult) {
-        transformed++
         await environment.transformRequest(url)
+        transformed++
         mod = await environment.moduleGraph.getModuleByUrl(url)
       }
     } catch (error) {

--- a/packages/vite/src/utils/warmup.ts
+++ b/packages/vite/src/utils/warmup.ts
@@ -1,0 +1,180 @@
+import { isBuiltin } from 'node:module'
+import type { IncomingMessage } from 'node:http'
+import { performance } from 'node:perf_hooks'
+import { logger } from '@nuxt/kit'
+import { join, normalize, relative } from 'pathe'
+import { withoutBase } from 'ufo'
+import { isCSSRequest } from 'vite'
+import type { DevEnvironment } from 'vite'
+
+export interface WarmupOptions {
+  /** Vite `config.root`, used to turn absolute entry paths into dev server URLs. */
+  root: string
+  /** Vite `config.base`, stripped from module graph urls before transforming. */
+  base?: string
+  /** Stop the crawl after this many modules have been transformed. */
+  maxModules?: number
+  /** Stop the crawl after this many milliseconds. */
+  maxDuration?: number
+  /** Number of modules transformed in parallel. */
+  concurrency?: number
+  /** Called before each transform; return `true` to abandon the rest of the crawl. */
+  shouldStop?: () => boolean
+  /** Called before each transform; while `true` the crawl idles rather than transforming. */
+  shouldPause?: () => boolean
+}
+
+export interface WarmupResult {
+  /** Number of modules transformed; modules already in the graph do not count. */
+  modules: number
+  /** Number of module graph urls the crawl reached, transformed or not. */
+  visited: number
+  duration: number
+  stopped: boolean
+}
+
+const PAUSE_POLL_INTERVAL = 20
+
+/**
+ * Requests that will make the browser walk the module graph itself, at which point
+ * speculative transforms are pure contention for the same plugin containers.
+ */
+export function isNavigationRequest (req: IncomingMessage) {
+  const mode = req.headers['sec-fetch-mode']
+  if (mode) {
+    return mode === 'navigate'
+  }
+  return !!req.headers.accept?.includes('text/html')
+}
+
+// https://github.com/vitejs/vite/blob/main/packages/vite/src/node/server/warmup.ts#L62-L70
+function fileToUrl (file: string, root: string) {
+  const url = relative(root, file)
+  if (url[0] === '.') {
+    return join('/@fs/', normalize(file))
+  }
+  return '/' + normalize(url)
+}
+
+function normaliseURL (url: string, base: string) {
+  url = withoutBase(url, base)
+  if (url.startsWith('/@id/')) {
+    url = url.slice('/@id/'.length).replace('__x00__', '\0')
+  }
+  const queryIndex = url.indexOf('?')
+  if (queryIndex === -1) {
+    return url
+  }
+  // `?import` is added when the browser fetches a module, and would otherwise
+  // duplicate the entry we already hold for the bare url
+  const params = url.slice(queryIndex + 1).split('&').filter(param => param && param !== 'import' && param !== 'import=')
+  const path = url.slice(0, queryIndex)
+  return params.length ? `${path}?${params.join('&')}` : path
+}
+
+/**
+ * Transform the given entries and, unlike Vite's built-in warmup, keep following
+ * their imports through the module graph until it is exhausted or a bound is hit.
+ *
+ * Most of the transform cost of a Nuxt dev server's first page load is in transitive
+ * dependencies of the entry rather than in the entry itself, so warming only the
+ * listed files warms almost nothing.
+ */
+export async function warmupViteServer (
+  environment: DevEnvironment,
+  entries: string[],
+  options: WarmupOptions,
+): Promise<WarmupResult> {
+  const { root, base = '/', maxModules = Number.POSITIVE_INFINITY, maxDuration = Number.POSITIVE_INFINITY, concurrency = 4, shouldStop, shouldPause } = options
+
+  const start = performance.now()
+  const seen = new Set<string>()
+  const queue: string[] = []
+  let transformed = 0
+  let visited = 0
+  let stopped = false
+
+  // a worker with an empty queue can only exit once no other worker is still able
+  // to discover imports, so idle workers park here until woken by a state change
+  let active = 0
+  const waiters = new Set<() => void>()
+  const wake = () => {
+    for (const resolve of waiters) { resolve() }
+    waiters.clear()
+  }
+
+  const enqueue = (url: string) => {
+    const normalised = normaliseURL(url, base)
+    if (!normalised || seen.has(normalised) || isBuiltin(normalised)) { return }
+    seen.add(normalised)
+    queue.push(normalised)
+    wake()
+  }
+
+  for (const entry of entries) {
+    enqueue(fileToUrl(entry, root))
+  }
+
+  const isExhausted = () => {
+    if (stopped) { return true }
+    if (transformed >= maxModules || performance.now() - start > maxDuration || shouldStop?.()) {
+      stopped = true
+      wake()
+      return true
+    }
+    return false
+  }
+
+  const visit = async (url: string) => {
+    visited++
+    let mod
+    try {
+      mod = await environment.moduleGraph.getModuleByUrl(url)
+      if (!mod?.transformResult) {
+        transformed++
+        await environment.transformRequest(url)
+        mod = await environment.moduleGraph.getModuleByUrl(url)
+      }
+    } catch (error) {
+      logger.debug(`Vite warmup for ${url} failed with:`, error)
+      return
+    }
+
+    // CSS modules have no further imports to fetch over the network
+    if (isCSSRequest(url)) { return }
+
+    for (const dep of mod?.importedModules || []) {
+      enqueue(dep.url)
+    }
+  }
+
+  const worker = async () => {
+    while (!isExhausted()) {
+      if (shouldPause?.()) {
+        await new Promise(resolve => setTimeout(resolve, PAUSE_POLL_INTERVAL))
+        continue
+      }
+      if (!queue.length) {
+        if (!active) { break }
+        await new Promise<void>(resolve => waiters.add(resolve))
+        continue
+      }
+      const url = queue.shift()!
+      active++
+      try {
+        // yield between modules so an incoming request is never queued behind speculative work
+        await new Promise(resolve => setImmediate(resolve))
+        await visit(url)
+      } finally {
+        active--
+        wake()
+      }
+    }
+    // let any parked worker re-evaluate now that this one is gone
+    wake()
+  }
+
+  await Promise.all(Array.from({ length: concurrency }, () => worker()))
+
+  return { modules: transformed, visited, duration: performance.now() - start, stopped }
+}

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -1,9 +1,10 @@
 import { existsSync } from 'node:fs'
+import type { IncomingMessage, ServerResponse } from 'node:http'
 import { performance } from 'node:perf_hooks'
 import { createBuilder, createServer, mergeConfig } from 'vite'
 import type * as vite from 'vite'
 import { basename, dirname, join, resolve } from 'pathe'
-import type { NuxtBuilder, ViteConfig } from '@nuxt/schema'
+import type { Nuxt, NuxtBuilder, ViteConfig } from '@nuxt/schema'
 import { createIsIgnored, getLayerDirectories, logger, resolvePath, useNitro } from '@nuxt/kit'
 import type { PreRenderedAsset } from 'rolldown'
 import { sanitizeFilePath } from 'mlly'
@@ -42,6 +43,7 @@ import { ClientManifestPlugin } from './plugins/client-manifest.ts'
 import { ResolveDeepImportsPlugin } from './plugins/resolve-deep-imports.ts'
 import { ResolveExternalsPlugin } from './plugins/resolved-externals.ts'
 import { PerfPlugin } from './plugins/perf.ts'
+import { isNavigationRequest, warmupViteServer } from './utils/warmup.ts'
 
 export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
   const useAsyncEntry = nuxt.options.experimental.asyncEntry || nuxt.options.dev
@@ -142,14 +144,14 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
           consumer: 'client',
           keepProcessEnv: false,
           dev: {
-            warmup: [entry],
+            warmup: warmupEntries(nuxt, entry),
           },
           ...clientEnvironment(nuxt, entry),
         },
         ssr: {
           consumer: 'server',
           dev: {
-            warmup: [serverEntry],
+            warmup: warmupEntries(nuxt, serverEntry),
           },
           ...ssrEnvironment(nuxt, serverEntry),
         },
@@ -294,8 +296,62 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
     const server = await createServer(config)
     nuxt.hook('close', () => server.close())
     await server.environments.ssr.pluginContainer.buildStart({})
+    startClientWarmup(nuxt, server, entry)
   }, 'Vite dev server built')
   nuxt._perf?.endPhase('vite:dev-server')
+}
+
+const WARMUP_MAX_MODULES = 5000
+const WARMUP_MAX_DURATION = 20_000
+
+function warmupEntries (nuxt: Nuxt, entry: string) {
+  return nuxt.options.vite.warmupEntry === false ? [] : [entry]
+}
+
+function startClientWarmup (nuxt: Nuxt, server: vite.ViteDevServer, entry: string) {
+  if (nuxt.options.vite.warmupEntry === false) { return }
+
+  let stop = false
+  let inFlight = 0
+  const observer = {
+    route: '',
+    handle: (req: IncomingMessage, res: ServerResponse, next: (err?: unknown) => void) => {
+      if (isNavigationRequest(req)) {
+        stop = true
+      } else {
+        inFlight++
+        res.on('close', () => { inFlight-- })
+      }
+      next()
+    },
+  } as (typeof server.middlewares.stack)[number]
+  server.middlewares.stack.unshift(observer)
+
+  nuxt.hook('close', () => { stop = true })
+
+  const run = async () => {
+    try {
+      const { modules, visited, duration, stopped } = await warmupViteServer(server.environments.client as vite.DevEnvironment, [entry], {
+        root: server.config.root,
+        base: server.config.base,
+        maxModules: WARMUP_MAX_MODULES,
+        maxDuration: WARMUP_MAX_DURATION,
+        shouldStop: () => stop,
+        shouldPause: () => inFlight > 0,
+      })
+      logger.debug(`Vite client warmed up ${modules} of ${visited} modules in ${Math.round(duration)}ms${stopped ? ' (abandoned)' : ''}`)
+    } catch (error) {
+      logger.debug('Vite client warmup failed with:', error)
+    } finally {
+      const index = server.middlewares.stack.indexOf(observer)
+      if (index !== -1) {
+        server.middlewares.stack.splice(index, 1)
+      }
+    }
+  }
+
+  // we hook to avoid blocking nitro's build, and do not await crawl so we don't block the dev server
+  useNitro().hooks.hookOnce('compiled', () => { void run() })
 }
 
 async function withLogs (fn: () => Promise<unknown>, message: string, enabled = true) {

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -309,7 +309,7 @@ function warmupEntries (nuxt: Nuxt, entry: string) {
 }
 
 function startClientWarmup (nuxt: Nuxt, server: vite.ViteDevServer, entry: string) {
-  if (nuxt.options.vite.warmupEntry === false) { return }
+  if (nuxt.options.test || nuxt.options.vite.warmupEntry === false) { return }
 
   let stop = false
   let inFlight = 0


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

we've been back & forth on warming up entries and the difference it makes (if any)

I think part of the problem was how we were doing it, and the rest is _when_. it's very easy to block either nitro's build, or continue warming up (and therefore contending) after an actual request comes in from the browser.

this is an env-api-safe alternative way

here are my measurements:

---

> [!NOTE]
> `interactive` is `firstHtml + drain` measured within each run, so it is net of any extra time
spent before the first byte of HTML.

**Browser navigates the instant the server reports ready** (worst case for the crawl):

| | hello-world (155 modules) | 200 pages / 300 components (1155 modules) |
| --- | --- | --- |
| module graph drain | **-288 ms** | **-457 ms** |
| time to first HTML | +115 ms | +165 ms |
| **time to interactive** | **-174 ms** | **-342 ms** |

**Browser navigates 1 s later** (CLI hands over a URL, browser starts up, human reacts):

| | hello-world | 200 pages / 300 components |
| --- | --- | --- |
| module graph drain | **-295 ms** | **-795 ms** |
| time to first HTML | -159 ms | +58 ms |
| **time to interactive** | **-442 ms** | **-736 ms** |