### PR TITLE
feat(nitro,nuxt,schema): let templates declare dependencies

### DIFF
--- a/docs/4.api/5.kit/10.templates.md
+++ b/docs/4.api/5.kit/10.templates.md
@@ -56,6 +56,7 @@ function addTemplate (template: NuxtTemplate | string): ResolvedNuxtTemplate
 | `options`     | `Options`                                                 | `false`  | Options to pass to the template.                                                                                                                                                 |
 | `getContents` | `(data: Options) => string \| Promise<string>`{lang="ts"} | `false`  | A function that will be called with the `options` object. It should return a string or a promise that resolves to a string. If `src` is provided, this function will be ignored. |
 | `write`       | `boolean`                                                 | `false`  | If set to `true`, the template will be written to the destination file. Otherwise, the template will be used only in virtual filesystem.                                         |
+| `dependsOn`   | `Array<'pages' \| 'plugins'> \| ((change: { event, path }, ctx: { nuxt, app, options }) => boolean)`{lang="ts"} | `false`  | The watched inputs the output of the template can depend on, beyond `nuxt.options` and the resolved structure of the app. Set to `[]` if the template never reads the contents of a watched file, so that Nuxt can skip recompiling it in dev mode when a file changes without any file being added or removed. List well-known keys if the template reads those sources, or pass a function to decide per change. A template that declares nothing is regenerated on every change. |
 
 ### Example
 
@@ -79,6 +80,47 @@ export default defineNuxtModule({
       getContents: () => 'export default ' + JSON.stringify({ globalMeta, mixinKey: 'setup' }),
     })
   },
+})
+```
+
+#### Skipping Regeneration in Development
+
+By default Nuxt recompiles a template on every watched file event, because it cannot know what
+the template reads. If your template is built only from configuration and from which files exist,
+declare that so Nuxt can leave it alone when a file is edited:
+
+```ts twoslash [module.ts]
+import { addTemplate, defineNuxtModule } from '@nuxt/kit'
+
+export default defineNuxtModule({
+  setup (options, nuxt) {
+    addTemplate({
+      filename: 'my-module/config.mjs',
+      dependsOn: [],
+      getContents: () => 'export default ' + JSON.stringify(options),
+    })
+  },
+})
+```
+
+If the template reads well-known sources, declare them by key:
+
+```ts
+addTemplate({
+  filename: 'my-module/routes.mjs',
+  dependsOn: ['pages'],
+  getContents: ({ app }) => generateRoutes(app.pages),
+})
+```
+
+And if it reads files Nuxt doesn't know about, say a set of YAML files you scan yourself, pass a
+function instead:
+
+```ts
+addTemplate({
+  filename: 'my-module/content.mjs',
+  dependsOn: ({ path }) => path.endsWith('.yaml'),
+  getContents: () => generateContents(),
 })
 ```
 

--- a/docs/4.api/5.kit/10.templates.md
+++ b/docs/4.api/5.kit/10.templates.md
@@ -85,7 +85,7 @@ export default defineNuxtModule({
 
 #### Skipping Regeneration in Development
 
-By default Nuxt recompiles a template on every watched file event, because it cannot know what
+By default, Nuxt recompiles a template on every watched file event because it cannot know what
 the template reads. If your template is built only from configuration and from which files exist,
 declare that so Nuxt can leave it alone when a file is edited:
 

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -380,6 +380,9 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
 
   addTemplate({
     filename: 'route-rules.mjs',
+    // `defineRouteRules` is extracted from page sources, so without it route rules come only
+    // from configuration
+    dependsOn: nuxt.options.experimental.inlineRouteRules ? ['pages'] : [],
     getContents () {
       if (!nuxt._nitro) {
         return `export default () => ({})`

--- a/packages/nitro-server/src/templates.ts
+++ b/packages/nitro-server/src/templates.ts
@@ -3,6 +3,7 @@ import { isAbsolute, join, relative } from 'pathe'
 
 export const nitroSchemaTemplate: NuxtTemplate = {
   filename: 'types/nitro-nuxt.d.ts',
+  dependsOn: [],
   async getContents ({ nuxt }) {
     const references = [] as TSReference[]
     const declarations = [] as string[]

--- a/packages/nuxt/src/components/module.ts
+++ b/packages/nuxt/src/components/module.ts
@@ -303,6 +303,7 @@ export default defineNuxtModule<ComponentsOptions>({
       } else {
         addTemplate({
           filename: 'component-chunk.mjs',
+          dependsOn: [],
           getContents: () => `export default {}`,
         })
       }

--- a/packages/nuxt/src/components/templates.ts
+++ b/packages/nuxt/src/components/templates.ts
@@ -34,6 +34,7 @@ export default defineNuxtPlugin({
 
 export const componentsPluginTemplate: NuxtPluginTemplate = {
   filename: 'components.plugin.mjs',
+  dependsOn: [],
   getContents ({ app }) {
     const lazyGlobalComponents = new Set<string>()
     const syncGlobalComponents = new Set<string>()
@@ -71,6 +72,7 @@ export default defineNuxtPlugin({
 
 export const componentNamesTemplate: NuxtTemplate = {
   filename: 'component-names.mjs',
+  dependsOn: [],
   getContents ({ app }) {
     const componentNames = new Set<string>()
     for (const c of app.components) {
@@ -84,6 +86,7 @@ export const componentNamesTemplate: NuxtTemplate = {
 
 export const componentsIslandsTemplate: NuxtTemplate = {
   filename: 'components.islands.mjs',
+  dependsOn: [],
   getContents ({ app, nuxt }) {
     if (!nuxt.options.experimental.componentIslands) {
       return 'export const islandComponents = Object.create(null)\nexport const pageIslandRoutes = Object.create(null)\nexport const providePageIslandDepth = () => {}'
@@ -217,6 +220,7 @@ type LazyComponent<T> = DefineComponent<HydrationStrategies, {}, {}, {}, {}, {},
 `
 export const componentsDeclarationTemplate = {
   filename: 'components.d.ts' as const,
+  dependsOn: [],
   write: true,
   getContents: ({ app, nuxt }) => {
     const componentTypes = resolveComponentTypes(app, nuxt.options.buildDir, nuxt.options.experimental.typescriptPlugin)
@@ -235,6 +239,7 @@ export const componentNames: string[]
 
 export const componentsTypeTemplate = {
   filename: 'types/components.d.ts' as const,
+  dependsOn: [],
   getContents: ({ app, nuxt }) => {
     const componentTypes = resolveComponentTypes(app, join(nuxt.options.buildDir, 'types'), nuxt.options.experimental.typescriptPlugin)
     const globalComponentNames = new Set<string>()
@@ -280,6 +285,7 @@ export {}
 
 export const componentsMetadataTemplate: NuxtTemplate = {
   filename: 'components.json',
+  dependsOn: [],
   write: true,
   getContents: ({ app }) => JSON.stringify(app.components, null, 2),
 }

--- a/packages/nuxt/src/core/builder.ts
+++ b/packages/nuxt/src/core/builder.ts
@@ -8,6 +8,7 @@ import { dirname, join, normalize, relative, resolve } from 'pathe'
 import { isDirectory } from '../utils.ts'
 import { generateApp as _generateApp, createApp } from './app.ts'
 import { checkForExternalConfigurationFiles } from './external-config-files.ts'
+import { createChangedFileFilter } from './template-dependencies.ts'
 import { cleanupCaches, getVueHash } from './cache.ts'
 import type { Nuxt, NuxtBuilder, NuxtHooks } from 'nuxt/schema'
 
@@ -62,6 +63,13 @@ export async function build (nuxt: Nuxt): Promise<void> {
       }
 
       // Recompile app templates
+      if (event === 'change' && app.templates.length) {
+        const filter = createChangedFileFilter(nuxt, app, resolve(nuxt.options.srcDir, relativePath))
+        if (!filter) { return }
+        await track(() => _generateApp(nuxt, app, { filter }))
+        return
+      }
+
       await track(() => generateApp())
     })
     nuxt.hook('builder:generateApp', (options) => {

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -248,6 +248,7 @@ async function initNuxt (nuxt: Nuxt) {
 
   addTypeTemplate({
     filename: 'types/nitro-layouts.d.ts',
+    dependsOn: [],
     getContents: ({ app }) => {
       return [
         `export type LayoutKey = ${Object.keys(app.layouts).map(name => genString(name)).join(' | ') || 'string'}`,
@@ -287,6 +288,7 @@ async function initNuxt (nuxt: Nuxt) {
       nuxt.options.typescript.hoist.push(environmentTypes)
       addTypeTemplate({
         filename: 'types/builder-env.d.ts',
+        dependsOn: [],
         getContents: () => genImport(environmentTypes),
       })
     }
@@ -803,6 +805,7 @@ async function initNuxt (nuxt: Nuxt) {
   if (nuxt.options.vue.config && Object.values(nuxt.options.vue.config).some(v => v !== null && v !== undefined)) {
     addPluginTemplate({
       filename: 'vue-app-config.mjs',
+      dependsOn: [],
       getContents: () => `
 import { defineNuxtPlugin } from '#app/nuxt'
 export default defineNuxtPlugin({

--- a/packages/nuxt/src/core/template-dependencies.ts
+++ b/packages/nuxt/src/core/template-dependencies.ts
@@ -1,8 +1,11 @@
+import { normalize } from 'pathe'
 import type { Nuxt, NuxtApp, NuxtPage, NuxtTemplateChange, NuxtTemplateDependency, ResolvedNuxtTemplate } from 'nuxt/schema'
+
+const isSamePath = (a: string | undefined, b: string) => !!a && (a === b || normalize(a) === b)
 
 function isPageFile (pages: NuxtPage[], path: string): boolean {
   for (const page of pages) {
-    if (page.file === path) { return true }
+    if (isSamePath(page.file, path)) { return true }
     if (page.children && isPageFile(page.children, path)) { return true }
   }
   return false
@@ -12,7 +15,7 @@ const dependencyMatchers: Record<NuxtTemplateDependency, (app: NuxtApp, path: st
   // `app.pages` is undefined for the whole session when the pages module is disabled, and adding
   // or removing a pages directory restarts Nuxt, so there is no page whose contents could matter
   pages: (app, path) => !!app.pages && isPageFile(app.pages, path),
-  plugins: (app, path) => app.plugins.some(plugin => plugin.src === path),
+  plugins: (app, path) => app.plugins.some(plugin => isSamePath(plugin.src, path)),
 }
 
 /**
@@ -35,7 +38,7 @@ export function createChangedFileFilter (nuxt: Nuxt, app: NuxtApp, path: string)
     }
     // a template read from disk depends on its own source and nothing else
     if (template.src) {
-      return template.src === path
+      return isSamePath(template.src, path)
     }
     return true
   }

--- a/packages/nuxt/src/core/template-dependencies.ts
+++ b/packages/nuxt/src/core/template-dependencies.ts
@@ -1,0 +1,46 @@
+import type { Nuxt, NuxtApp, NuxtPage, NuxtTemplateChange, NuxtTemplateDependency, ResolvedNuxtTemplate } from 'nuxt/schema'
+
+function isPageFile (pages: NuxtPage[], path: string): boolean {
+  for (const page of pages) {
+    if (page.file === path) { return true }
+    if (page.children && isPageFile(page.children, path)) { return true }
+  }
+  return false
+}
+
+const dependencyMatchers: Record<NuxtTemplateDependency, (app: NuxtApp, path: string) => boolean> = {
+  // `app.pages` is undefined for the whole session when the pages module is disabled, and adding
+  // or removing a pages directory restarts Nuxt, so there is no page whose contents could matter
+  pages: (app, path) => !!app.pages && isPageFile(app.pages, path),
+  plugins: (app, path) => app.plugins.some(plugin => plugin.src === path),
+}
+
+/**
+ * Build a `generateApp` filter for a `change` event on `path`, selecting the templates whose
+ * output could depend on that file, as declared by `dependsOn`. Returns `undefined` if no
+ * template can be affected, in which case regeneration can be skipped entirely.
+ *
+ * A template that declares nothing is regenerated, so a template Nuxt knows nothing about is
+ * never left stale.
+ */
+export function createChangedFileFilter (nuxt: Nuxt, app: NuxtApp, path: string): ((template: ResolvedNuxtTemplate<any>) => boolean) | undefined {
+  const change: NuxtTemplateChange = { event: 'change', path }
+  const filter = (template: ResolvedNuxtTemplate<any>) => {
+    const dependsOn = template.dependsOn
+    if (typeof dependsOn === 'function') {
+      return dependsOn(change, { nuxt, app, options: template.options })
+    }
+    if (dependsOn) {
+      return dependsOn.some(dependency => dependencyMatchers[dependency]?.(app, path))
+    }
+    // a template read from disk depends on its own source and nothing else
+    if (template.src) {
+      return template.src === path
+    }
+    return true
+  }
+
+  for (const template of app.templates) {
+    if (filter(template as ResolvedNuxtTemplate<any>)) { return filter }
+  }
+}

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -20,6 +20,7 @@ const defuPath = resolveModulePath('defu', { try: true, from: import.meta.url })
 
 export const vueShim: NuxtTemplate = {
   filename: 'types/vue-shim.d.ts',
+  dependsOn: [],
   getContents: ({ nuxt }) => {
     if (!nuxt.options.typescript.shim) {
       return ''
@@ -38,11 +39,13 @@ export const vueShim: NuxtTemplate = {
 // TODO: Use an alias
 export const appComponentTemplate: NuxtTemplate = {
   filename: 'app-component.mjs',
+  dependsOn: [],
   getContents: ctx => genExport(ctx.app.mainComponent!, ['default']),
 }
 // TODO: Use an alias
 export const rootComponentTemplate: NuxtTemplate = {
   filename: 'root-component.mjs',
+  dependsOn: [],
   // TODO: fix upstream in vite - this ensures that vite generates a module graph for islands
   // but should not be necessary (and has a warmup performance cost). See https://github.com/nuxt/nuxt/pull/24584.
   getContents: ctx => (ctx.nuxt.options.dev ? 'import \'#build/components.islands.mjs\';\n' : '') + genExport(ctx.app.rootComponent!, ['default']),
@@ -50,10 +53,12 @@ export const rootComponentTemplate: NuxtTemplate = {
 // TODO: Use an alias
 export const errorComponentTemplate: NuxtTemplate = {
   filename: 'error-component.mjs',
+  dependsOn: [],
   getContents: ctx => genExport(ctx.app.errorComponent!, ['default']),
 }
 export const islandRendererTemplate: NuxtTemplate = {
   filename: 'island-renderer.mjs',
+  dependsOn: [],
   getContents (ctx) {
     if (!shouldEnableComponentIslands(ctx.nuxt, ctx.app)) {
       return 'const IslandRenderer = () => null\nexport default IslandRenderer'
@@ -70,17 +75,20 @@ export const islandRendererTemplate: NuxtTemplate = {
 // TODO: Use an alias
 export const testComponentWrapperTemplate: NuxtTemplate = {
   filename: 'test-component-wrapper.mjs',
+  dependsOn: [],
   getContents: ctx => genExport(resolve(ctx.nuxt.options.appDir, 'components/test-component-wrapper'), ['default']),
 }
 
 export const cssTemplate: NuxtTemplate = {
   filename: 'css.mjs',
+  dependsOn: [],
   getContents: ctx => ctx.nuxt.options.css.map(i => genImport(i)).join('\n'),
 }
 
 const PLUGIN_TEMPLATE_RE = /_(?:45|46|47)/g
 export const clientPluginTemplate: NuxtTemplate = {
   filename: 'plugins.client.mjs',
+  dependsOn: ['plugins'],
   async getContents (ctx) {
     const allPlugins = await annotatePlugins(ctx.nuxt, ctx.app.plugins.filter(p => ctx.nuxt.options.dev || !p.mode || p.mode !== 'server'))
     const clientPlugins = sortPluginsByDependsOn(filterPluginDependencies(allPlugins.filter(p => !p.mode || p.mode !== 'server'), { warn: ctx.nuxt.options.dev, mode: 'client', allPlugins }))
@@ -103,6 +111,7 @@ export const clientPluginTemplate: NuxtTemplate = {
 
 export const serverPluginTemplate: NuxtTemplate = {
   filename: 'plugins.server.mjs',
+  dependsOn: ['plugins'],
   async getContents (ctx) {
     const allPlugins = await annotatePlugins(ctx.nuxt, ctx.app.plugins.filter(p => ctx.nuxt.options.dev || !p.mode || p.mode !== 'client'))
     const serverPlugins = sortPluginsByDependsOn(filterPluginDependencies(allPlugins.filter(p => !p.mode || p.mode !== 'client'), { warn: ctx.nuxt.options.dev, mode: 'server', allPlugins }))
@@ -127,6 +136,7 @@ const TS_RE = /\.[cm]?tsx?$/
 const JS_LETTER_RE = /\.(?<letter>[cm])?jsx?$/
 export const pluginsDeclaration: NuxtTemplate = {
   filename: 'types/plugins.d.ts',
+  dependsOn: ['plugins'],
   getContents: async ({ nuxt, app }) => {
     const EXTENSION_RE = new RegExp(`(?<=\\w)(${nuxt.options.extensions.map(e => escapeRE(e)).join('|')})$`, 'g')
 
@@ -195,6 +205,7 @@ const IMPORT_NAME_RE = /\.\w+$/
 const GIT_RE = /^git\+/
 export const schemaTemplate: NuxtTemplate = {
   filename: 'types/runtime-config.d.ts',
+  dependsOn: [],
   getContents: async ({ nuxt }) => {
     const privateRuntimeConfig = Object.create(null)
     for (const key in nuxt.options.runtimeConfig) {
@@ -239,6 +250,7 @@ export const schemaTemplate: NuxtTemplate = {
 }
 export const schemaNodeTemplate: NuxtTemplate = {
   filename: 'types/modules.d.ts',
+  dependsOn: [],
   getContents: ({ nuxt }) => {
     const relativeRoot = relative(resolve(nuxt.options.buildDir, 'types'), nuxt.options.rootDir)
     const getImportName = (name: string) => (name[0] === '.' ? './' + join(relativeRoot, name) : name).replace(IMPORT_NAME_RE, '')
@@ -331,6 +343,7 @@ export const schemaNodeTemplate: NuxtTemplate = {
 // Add layouts template
 export const layoutTemplate: NuxtTemplate = {
   filename: 'layouts.mjs',
+  dependsOn: [],
   getContents ({ app }) {
     const layoutsObject = genObjectFromRawEntries(Object.values(app.layouts).map(({ name, file }) => {
       return [name, `defineAsyncComponent(${genDynamicImport(file, { interopDefault: true })})`]
@@ -345,6 +358,7 @@ export const layoutTemplate: NuxtTemplate = {
 // Add middleware template
 export const middlewareTemplate: NuxtTemplate = {
   filename: 'middleware.mjs',
+  dependsOn: [],
   getContents ({ app, nuxt }) {
     const globalMiddleware = app.middleware.filter(mw => mw.global)
     const namedMiddleware = app.middleware.filter(mw => !mw.global)
@@ -383,6 +397,7 @@ export const middlewareTemplate: NuxtTemplate = {
 
 export const clientConfigTemplate: NuxtTemplate = {
   filename: 'nitro.client.mjs',
+  dependsOn: [],
   getContents: ({ nuxt }) => {
     const appId = JSON.stringify(nuxt.options.appId)
     return [
@@ -413,6 +428,7 @@ type MergedAppConfig<Resolved extends Record<string, unknown>, Custom extends Re
 
 export const appConfigDeclarationTemplate: NuxtTemplate = {
   filename: 'types/app.config.d.ts',
+  dependsOn: [],
   getContents ({ app, nuxt }) {
     const typesDir = join(nuxt.options.buildDir, 'types')
     const configPaths = app.configs.map(path => relative(typesDir, path).replace(EXTENSION_RE, ''))
@@ -445,6 +461,7 @@ declare module '@nuxt/schema' {
 // server programs (https://github.com/nuxt/nuxt/issues/34140).
 export const sharedAppConfigDeclarationTemplate: NuxtTemplate = {
   filename: 'types/shared-app.config.d.ts',
+  dependsOn: [],
   getContents ({ nuxt }) {
     return `
 import type { CustomAppConfig } from 'nuxt/schema'
@@ -464,6 +481,7 @@ declare module '@nuxt/schema' {
 
 export const appConfigTemplate: NuxtTemplate = {
   filename: 'app.config.mjs',
+  dependsOn: [],
   write: true,
   getContents ({ app, nuxt }) {
     return `
@@ -491,6 +509,7 @@ export default /*@__PURE__*/ defuFn(${app.configs.map((_id: string, index: numbe
 
 export const publicPathTemplate: NuxtTemplate = {
   filename: 'paths.mjs',
+  dependsOn: [],
   getContents ({ nuxt }) {
     return [
       'import { joinRelativeURL } from \'ufo\'',
@@ -522,6 +541,7 @@ export const publicPathTemplate: NuxtTemplate = {
 
 export const globalPolyfillsTemplate: NuxtTemplate = {
   filename: 'global-polyfills.mjs',
+  dependsOn: [],
   getContents () {
     // Node.js compatibility
     return `
@@ -533,6 +553,7 @@ if (!("global" in globalThis)) {
 
 export const dollarFetchTemplate: NuxtTemplate = {
   filename: 'fetch.server.mjs',
+  dependsOn: [],
   getContents () {
     return [
       'import { createFetch } from \'ofetch\'',
@@ -551,6 +572,7 @@ export const dollarFetchTemplate: NuxtTemplate = {
 
 export const dollarFetchClientTemplate: NuxtTemplate = {
   filename: 'fetch.client.mjs',
+  dependsOn: [],
   getContents () {
     return [
       'import { $fetch as _$fetch } from \'ofetch\'',
@@ -566,16 +588,19 @@ export const dollarFetchClientTemplate: NuxtTemplate = {
 // `ofetch` into bundles that never use `$fetch`.
 export const dollarFetchSetupServerTemplate: NuxtTemplate = {
   filename: 'fetch-setup.server.mjs',
+  dependsOn: [],
   getContents: () => 'import \'#build/fetch\'\n',
 }
 
 export const dollarFetchSetupClientTemplate: NuxtTemplate = {
   filename: 'fetch-setup.client.mjs',
+  dependsOn: [],
   getContents: () => 'export {}\n',
 }
 
 export const dollarFetchTypeTemplate: NuxtTemplate = {
   filename: 'fetch.d.ts',
+  dependsOn: [],
   getContents () {
     return 'export declare const $fetch: import(\'nitro/types\').$Fetch\n'
   },
@@ -598,6 +623,7 @@ function shouldEnableComponentIslands (nuxt: { options: NuxtOptions }, app: Nuxt
 // Allow direct access to specific exposed nuxt.config
 export const nuxtConfigTemplate: NuxtTemplate = {
   filename: 'nuxt.config.mjs',
+  dependsOn: ['plugins'],
   async getContents (ctx) {
     const annotatedPlugins = ctx.nuxt.options.dev || ctx.nuxt.options.test
       ? null
@@ -663,6 +689,7 @@ const TYPE_FILENAME_RE = /\.([cm])?[jt]s$/
 const DECLARATION_RE = /\.d\.[cm]?ts$/
 export const buildTypeTemplate: NuxtTemplate = {
   filename: 'types/build.d.ts',
+  dependsOn: [],
   getContents ({ app }) {
     let declarations = ''
 

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -623,7 +623,9 @@ function shouldEnableComponentIslands (nuxt: { options: NuxtOptions }, app: Nuxt
 // Allow direct access to specific exposed nuxt.config
 export const nuxtConfigTemplate: NuxtTemplate = {
   filename: 'nuxt.config.mjs',
-  dependsOn: ['plugins'],
+  // `payloadExtraction` below is derived from nitro route rules, and `defineRouteRules`
+  // (`experimental.inlineRouteRules`) extracts those from page sources
+  dependsOn: ['plugins', 'pages'],
   async getContents (ctx) {
     const annotatedPlugins = ctx.nuxt.options.dev || ctx.nuxt.options.test
       ? null

--- a/packages/nuxt/src/head/module.ts
+++ b/packages/nuxt/src/head/module.ts
@@ -102,6 +102,7 @@ export default defineNuxtModule<NuxtOptions['unhead']>({
 
     addTemplate({
       filename: 'unhead-options.mjs',
+      dependsOn: [],
       getContents () {
         const isV5 = nuxt.options.future.compatibilityVersion >= 5
 
@@ -140,6 +141,7 @@ export default defineNuxtModule<NuxtOptions['unhead']>({
 
     addTemplate({
       filename: 'unhead.config.mjs',
+      dependsOn: [],
       getContents () {
         return [
           `export const renderSSRHeadOptions = ${JSON.stringify(options.renderSSRHeadOptions || {})}`,

--- a/packages/nuxt/src/imports/module.ts
+++ b/packages/nuxt/src/imports/module.ts
@@ -119,6 +119,7 @@ export default defineNuxtModule<Partial<ImportsOptions>>({
     // Support for importing from '#imports'
     addTemplate({
       filename: 'imports.mjs',
+      dependsOn: [],
       getContents: async () => toExports(await ctx.getImports()) + '\nif (import.meta.dev) { console.warn("[nuxt] `#imports` should be transformed with real imports. There seems to be something wrong with the imports plugin.") }',
     })
     nuxt.options.alias['#imports'] = join(nuxt.options.buildDir, 'imports')
@@ -262,6 +263,7 @@ function addDeclarationTemplates (ctx: Pick<Unimport, 'getImports' | 'generateTy
 
   addTypeTemplate({
     filename: 'imports.d.ts',
+    dependsOn: [],
     getContents: async ({ nuxt }) => toExports(await ctx.getImports(), nuxt.options.buildDir, true, { declaration: true }),
   })
 
@@ -270,6 +272,7 @@ function addDeclarationTemplates (ctx: Pick<Unimport, 'getImports' | 'generateTy
 
   addTypeTemplate({
     filename: 'types/imports.d.ts',
+    dependsOn: [],
     getContents: async () => {
       const imports = await ctx.getImports()
       await cacheImportPaths(imports)
@@ -283,6 +286,7 @@ function addDeclarationTemplates (ctx: Pick<Unimport, 'getImports' | 'generateTy
 
   addTemplate({
     filename: 'types/shared-imports.d.ts',
+    dependsOn: [],
     getContents: async () => {
       if (!options.autoImport) {
         return GENERATED_BY_COMMENT + AUTO_IMPORTS_DISABLED_COMMENT

--- a/packages/nuxt/src/imports/module.ts
+++ b/packages/nuxt/src/imports/module.ts
@@ -135,7 +135,10 @@ export default defineNuxtModule<Partial<ImportsOptions>>({
 
     const priorities = getLayerDirectories(nuxt).map((dirs, i) => [dirs.app, -i] as const).sort(([a], [b]) => b.length - a.length)
 
-    const IMPORTS_TEMPLATE_RE = /\/imports\.(?:d\.ts|mjs)$/
+    // matches `imports.mjs`, `imports.d.ts`, `types/imports.d.ts` and `types/shared-imports.d.ts`;
+    // these templates render unimport state that this module refreshes itself, so they must all be
+    // caught by `regenerateImports` rather than relying on a full template regeneration
+    const IMPORTS_TEMPLATE_RE = /(?:^|\/)(?:shared-)?imports\.(?:d\.ts|mjs)$/
     function isImportsTemplate (template: ResolvedNuxtTemplate) {
       return IMPORTS_TEMPLATE_RE.test(template.filename)
     }

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -216,6 +216,7 @@ export default defineNuxtModule({
     // layouts can be used without pages (e.g. `<NuxtLayout>`), so always generate their types
     addTypeTemplate({
       filename: 'types/layouts.d.ts',
+      dependsOn: [],
       getContents: ({ app, nuxt }) => {
         // a path relative to the generated declaration keeps `buildDir` portable between machines
         const componentTypeHelpers = componentTypeHelpersPath
@@ -248,6 +249,7 @@ export default defineNuxtModule({
       addPlugin(resolve(distDir, 'app/plugins/router'))
       addTemplate({
         filename: 'pages.mjs',
+        dependsOn: [],
         getContents: () => [
           'export { useRoute } from \'#app/composables/router\'',
           'export const START_LOCATION = Symbol(\'router:start-location\')',
@@ -256,6 +258,7 @@ export default defineNuxtModule({
       // used by `<NuxtLink>`
       addTemplate({
         filename: 'router.options.mjs',
+        dependsOn: [],
         getContents: () => {
           return [
             'export const hashMode = false',
@@ -265,6 +268,7 @@ export default defineNuxtModule({
       })
       addTypeTemplate({
         filename: 'types/middleware.d.ts',
+        dependsOn: [],
         getContents: () => [
           'declare module \'nitro/types\' {',
           '  interface NitroRouteConfig {',
@@ -387,6 +391,7 @@ export default defineNuxtModule({
         const dts = await readFile(declarationFile, 'utf-8')
         addTemplate({
           filename: 'types/typed-router.d.ts',
+          dependsOn: [],
           getContents: () => dts,
         })
       }
@@ -705,6 +710,8 @@ export default defineNuxtModule({
     // Add routes template
     addTemplate({
       filename: 'routes.mjs',
+      // route metadata is extracted from page sources only when `scanPageMeta` is enabled
+      dependsOn: nuxt.options.experimental.scanPageMeta ? ['pages'] : [],
       getContents ({ app }) {
         if (!app.pages) { return ROUTES_HMR_CODE + 'export default []' }
         const { routes, imports } = normalizeRoutes(app.pages, new Set(), {
@@ -719,6 +726,7 @@ export default defineNuxtModule({
     // Add vue-router import for `<NuxtLayout>` integration
     addTemplate({
       filename: 'pages.mjs',
+      dependsOn: [],
       getContents: () => 'export { START_LOCATION, useRoute } from \'vue-router\'',
     })
 
@@ -729,6 +737,7 @@ export default defineNuxtModule({
     // Add router options template
     addTemplate({
       filename: 'router.options.mjs',
+      dependsOn: [],
       getContents: async ({ nuxt }) => {
         // Scan and register app/router.options files
         const routerOptionsFiles = await resolveRouterOptions(nuxt, builtInRouterOptions)
@@ -761,6 +770,7 @@ export default defineNuxtModule({
 
     addTypeTemplate({
       filename: 'types/middleware.d.ts',
+      dependsOn: [],
       getContents: ({ app }) => {
         const namedMiddleware = app.middleware.filter(mw => !mw.global)
         return [
@@ -777,6 +787,7 @@ export default defineNuxtModule({
 
     addTypeTemplate({
       filename: 'types/nitro-middleware.d.ts',
+      dependsOn: [],
       getContents: ({ app }) => {
         const namedMiddleware = app.middleware.filter(mw => !mw.global)
         return [
@@ -799,6 +810,7 @@ export default defineNuxtModule({
     if (nuxt.options.experimental.viewTransition) {
       addTypeTemplate({
         filename: 'types/view-transitions.d.ts',
+        dependsOn: [],
         getContents: () => {
           return [
             'import type { ViewTransitionPageOptions } from \'../types/config\'',

--- a/packages/nuxt/test/app.test.ts
+++ b/packages/nuxt/test/app.test.ts
@@ -58,6 +58,7 @@ describe('resolveApp', () => {
             "src": "<repoRoot>/packages/nuxt/src/app/plugins/revive-payload.server.ts",
           },
           {
+            "dependsOn": [],
             "filename": "components.plugin.mjs",
             "getContents": [Function],
             "mode": "all",

--- a/packages/nuxt/test/builder.test.ts
+++ b/packages/nuxt/test/builder.test.ts
@@ -1,7 +1,8 @@
 import { writeFileSync } from 'node:fs'
-import { mkdir, rm } from 'node:fs/promises'
+import { mkdir, rm, writeFile } from 'node:fs/promises'
 
 import type { FSWatcher } from 'vite'
+import type { ResolvedNuxtTemplate } from 'nuxt/schema'
 import { join, relative, resolve } from 'pathe'
 import { findWorkspaceDir } from 'pkg-types'
 import { afterAll, beforeEach, describe, expect, it } from 'vitest'
@@ -54,6 +55,42 @@ describe('builder:watch', { sequential: true }, async () => {
       'other',
       'test',
     ])
+  })
+
+  it('should only recompile templates that can be affected by a changed file', async () => {
+    const rootDir = join(tmpDir, 'project')
+    await mkdir(join(rootDir, 'app/pages'), { recursive: true })
+    await mkdir(join(rootDir, 'app/components'), { recursive: true })
+    await writeFile(join(rootDir, 'app/pages/index.vue'), '<template><div>index</div></template>')
+    await writeFile(join(rootDir, 'app/components/Foo.vue'), '<template><div>foo</div></template>')
+
+    const nuxt = await loadNuxt({
+      cwd: rootDir,
+      ready: true,
+      overrides: {
+        dev: true,
+        _prepare: true,
+        experimental: { watcher: 'chokidar' },
+      },
+    })
+
+    await build(nuxt)
+
+    let generations = 0
+    const selections: Array<string[] | undefined> = []
+    nuxt.hook('app:templates', () => { generations++ })
+    nuxt.hook('app:templatesGenerated', (app, _templates, options) => {
+      selections.push(options?.filter ? app.templates.filter(t => options.filter!(t as ResolvedNuxtTemplate<any>)).map(t => t.filename!).sort() : undefined)
+    })
+
+    await nuxt.callHook('builder:watch', 'change', 'components/Foo.vue')
+    expect.soft(generations).toBe(0)
+
+    await nuxt.callHook('builder:watch', 'change', 'pages/index.vue')
+    expect.soft(generations).toBe(1)
+    expect.soft(selections.every(selection => selection?.includes('routes.mjs'))).toBe(true)
+
+    await nuxt.close()
   })
 
   it('should restart Nuxt when a file is added with builder strategy', async () => {

--- a/packages/nuxt/test/builder.test.ts
+++ b/packages/nuxt/test/builder.test.ts
@@ -74,6 +74,15 @@ describe('builder:watch', { sequential: true }, async () => {
       },
     })
 
+    // `app:templatesGenerated` only fires when generated output differs, so without a template
+    // whose output actually changes the selection for a page change is never reported
+    let pageDependentOutput = 'initial'
+    nuxt.options.build.templates.push({
+      filename: 'test-page-dependent.mjs',
+      dependsOn: ['pages'],
+      getContents: () => `export default ${JSON.stringify(pageDependentOutput)}`,
+    })
+
     await build(nuxt)
 
     let generations = 0
@@ -85,10 +94,16 @@ describe('builder:watch', { sequential: true }, async () => {
 
     await nuxt.callHook('builder:watch', 'change', 'components/Foo.vue')
     expect.soft(generations).toBe(0)
+    expect.soft(selections).toStrictEqual([])
 
+    pageDependentOutput = 'changed'
     await nuxt.callHook('builder:watch', 'change', 'pages/index.vue')
-    expect.soft(generations).toBe(1)
-    expect.soft(selections.every(selection => selection?.includes('routes.mjs'))).toBe(true)
+    // regenerating a template whose output changed makes the imports module refresh its own
+    // templates in turn, so more than one generation can be recorded here
+    expect.soft(generations).toBeGreaterThan(0)
+    expect.soft(selections[0]).toContain('routes.mjs')
+    expect.soft(selections[0]).toContain('test-page-dependent.mjs')
+    expect.soft(selections[0]).not.toContain('components.plugin.mjs')
 
     await nuxt.close()
   })

--- a/packages/nuxt/test/builder.test.ts
+++ b/packages/nuxt/test/builder.test.ts
@@ -108,6 +108,69 @@ describe('builder:watch', { sequential: true }, async () => {
     await nuxt.close()
   })
 
+  it('should recompile templates affected by a change in a local layer', async () => {
+    const rootDir = join(tmpDir, 'project')
+    const layerDir = join(tmpDir, 'layer')
+    await mkdir(join(rootDir, 'app'), { recursive: true })
+    await mkdir(join(layerDir, 'app/pages'), { recursive: true })
+    await mkdir(join(layerDir, 'app/plugins'), { recursive: true })
+    await writeFile(join(layerDir, 'nuxt.config.ts'), 'export default defineNuxtConfig({})')
+    await writeFile(join(layerDir, 'app/pages/from-layer.vue'), '<template><div>layer</div></template>')
+    await writeFile(join(layerDir, 'app/plugins/from-layer.ts'), 'export default defineNuxtPlugin(() => {})')
+
+    const nuxt = await loadNuxt({
+      cwd: rootDir,
+      ready: true,
+      overrides: {
+        dev: true,
+        _prepare: true,
+        extends: [layerDir],
+        experimental: { watcher: 'chokidar' },
+      },
+    })
+
+    const layerPage = join(layerDir, 'app/pages/from-layer.vue')
+    const layerPlugin = join(layerDir, 'app/plugins/from-layer.ts')
+
+    await build(nuxt)
+
+    // the layer's files must be resolved under their own absolute paths for the filter to match
+    expect.soft(nuxt.apps.default!.pages?.map(p => p.file)).toContain(layerPage)
+    expect.soft(nuxt.apps.default!.plugins.map(p => p.src)).toContain(layerPlugin)
+
+    const selections: Array<string[] | undefined> = []
+    nuxt.hook('app:templatesGenerated', (app, _templates, options) => {
+      selections.push(options?.filter ? app.templates.filter(t => options.filter!(t as ResolvedNuxtTemplate<any>)).map(t => t.filename!).sort() : undefined)
+    })
+
+    let pageDependentOutput = 'initial'
+    let pluginDependentOutput = 'initial'
+    nuxt.options.build.templates.push(
+      {
+        filename: 'test-layer-page-dependent.mjs',
+        dependsOn: ['pages'],
+        getContents: () => `export default ${JSON.stringify(pageDependentOutput)}`,
+      },
+      {
+        filename: 'test-layer-plugin-dependent.mjs',
+        dependsOn: ['plugins'],
+        getContents: () => `export default ${JSON.stringify(pluginDependentOutput)}`,
+      },
+    )
+
+    pageDependentOutput = 'changed'
+    await nuxt.callHook('builder:watch', 'change', layerPage)
+    expect.soft(selections.at(-1)).toContain('test-layer-page-dependent.mjs')
+    expect.soft(selections.at(-1)).not.toContain('test-layer-plugin-dependent.mjs')
+
+    pluginDependentOutput = 'changed'
+    await nuxt.callHook('builder:watch', 'change', layerPlugin)
+    expect.soft(selections.at(-1)).toContain('test-layer-plugin-dependent.mjs')
+    expect.soft(selections.at(-1)).not.toContain('test-layer-page-dependent.mjs')
+
+    await nuxt.close()
+  })
+
   it('should restart Nuxt when a file is added with builder strategy', async () => {
     const rootDir = join(tmpDir, 'project')
     const nuxt = await loadNuxt({

--- a/packages/nuxt/test/template-dependencies.test.ts
+++ b/packages/nuxt/test/template-dependencies.test.ts
@@ -78,6 +78,24 @@ describe('createChangedFileFilter', () => {
     expect(select(app, '/src/components/Foo.vue')).toBeUndefined()
   })
 
+  it('matches platform-native paths against the normalised changed path', () => {
+    const app = createApp(
+      [
+        { filename: 'from-src.mjs', src: 'C:\\app\\some-template.mjs' },
+        { filename: 'routes.mjs', dependsOn: ['pages'] },
+        { filename: 'plugins.mjs', dependsOn: ['plugins'] },
+      ],
+      {
+        pages: [{ file: 'C:\\app\\pages\\index.vue' }] as NuxtApp['pages'],
+        plugins: [{ src: 'C:\\app\\plugins\\foo.ts' }],
+      },
+    )
+
+    expect(select(app, 'C:/app/some-template.mjs')).toStrictEqual(['from-src.mjs'])
+    expect(select(app, 'C:/app/pages/index.vue')).toStrictEqual(['routes.mjs'])
+    expect(select(app, 'C:/app/plugins/foo.ts')).toStrictEqual(['plugins.mjs'])
+  })
+
   it('regenerates a file-backed template only when its own source changes', () => {
     const app = createApp([
       { filename: 'from-src.mjs', src: '/src/some-template.mjs' },

--- a/packages/nuxt/test/template-dependencies.test.ts
+++ b/packages/nuxt/test/template-dependencies.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+import type { Nuxt, NuxtApp, ResolvedNuxtTemplate } from 'nuxt/schema'
+import { createChangedFileFilter } from '../src/core/template-dependencies.ts'
+
+const nuxt = {} as Nuxt
+
+function createApp (templates: Array<Partial<ResolvedNuxtTemplate<any>>>, overrides: Partial<NuxtApp> = {}) {
+  return {
+    plugins: [],
+    templates,
+    ...overrides,
+  } as unknown as NuxtApp
+}
+
+const select = (app: NuxtApp, path: string) => {
+  const filter = createChangedFileFilter(nuxt, app, path)
+  return filter ? app.templates.filter(t => filter(t as ResolvedNuxtTemplate<any>)).map(t => t.filename) : undefined
+}
+
+describe('createChangedFileFilter', () => {
+  it('skips regeneration when no template can be affected', () => {
+    const app = createApp([{ filename: 'a.mjs', dependsOn: [] }, { filename: 'b.mjs', dependsOn: [] }])
+    expect(createChangedFileFilter(nuxt, app, '/src/components/Foo.vue')).toBeUndefined()
+  })
+
+  it('regenerates templates that do not declare a dependency', () => {
+    const app = createApp([{ filename: 'a.mjs', dependsOn: [] }, { filename: 'my-module.mjs' }])
+    expect(select(app, '/src/components/Foo.vue')).toStrictEqual(['my-module.mjs'])
+  })
+
+  it('regenerates templates whose declared predicate matches the changed file', () => {
+    const app = createApp([
+      { filename: 'a.mjs', dependsOn: ({ path }) => path.endsWith('.yaml') },
+      { filename: 'b.mjs', dependsOn: [] },
+    ])
+
+    expect(select(app, '/src/content.yaml')).toStrictEqual(['a.mjs'])
+    expect(select(app, '/src/components/Foo.vue')).toBeUndefined()
+  })
+
+  it('passes the change and context to a declared predicate', () => {
+    const app = createApp([
+      { filename: 'a.mjs', options: { dir: '/src/plugins' }, dependsOn: (change, ctx: any) => change.event === 'change' && ctx.nuxt === nuxt && ctx.app === app && change.path.startsWith(ctx.options.dir) },
+    ])
+
+    expect(select(app, '/src/plugins/foo.ts')).toStrictEqual(['a.mjs'])
+    expect(select(app, '/src/components/Foo.vue')).toBeUndefined()
+  })
+
+  it('matches the `plugins` dependency against plugin sources', () => {
+    const app = createApp(
+      [{ filename: 'plugins.mjs', dependsOn: ['plugins'] }, { filename: 'a.mjs', dependsOn: [] }],
+      { plugins: [{ src: '/src/plugins/foo.ts' }] },
+    )
+
+    expect(select(app, '/src/plugins/foo.ts')).toStrictEqual(['plugins.mjs'])
+    expect(select(app, '/src/components/Foo.vue')).toBeUndefined()
+  })
+
+  it('matches the `pages` dependency against page sources, including nested pages', () => {
+    const app = createApp(
+      [{ filename: 'routes.mjs', dependsOn: ['pages'] }, { filename: 'a.mjs', dependsOn: [] }],
+      { pages: [{ file: '/src/pages/index.vue', children: [{ file: '/src/pages/nested.vue' }] }] as NuxtApp['pages'] },
+    )
+
+    expect(select(app, '/src/pages/index.vue')).toStrictEqual(['routes.mjs'])
+    expect(select(app, '/src/pages/nested.vue')).toStrictEqual(['routes.mjs'])
+    expect(select(app, '/src/components/Foo.vue')).toBeUndefined()
+  })
+
+  it('does not match the `pages` dependency when the pages module is disabled', () => {
+    const app = createApp([{ filename: 'route-rules.mjs', dependsOn: ['pages'] }])
+    expect(select(app, '/src/components/Foo.vue')).toBeUndefined()
+  })
+
+  it('does not match the `pages` dependency when every page has been removed', () => {
+    const app = createApp([{ filename: 'routes.mjs', dependsOn: ['pages'] }], { pages: [] })
+    expect(select(app, '/src/components/Foo.vue')).toBeUndefined()
+  })
+
+  it('regenerates a file-backed template only when its own source changes', () => {
+    const app = createApp([
+      { filename: 'from-src.mjs', src: '/src/some-template.mjs' },
+      { filename: 'a.mjs', dependsOn: [] },
+    ])
+
+    expect(select(app, '/src/some-template.mjs')).toStrictEqual(['from-src.mjs'])
+    expect(select(app, '/src/components/Foo.vue')).toBeUndefined()
+  })
+})

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -9,7 +9,7 @@ export type { GenerateAppOptions, HookResult, NuxtAnalyzeMeta, NuxtHookName, Nux
 export type { ImportsOptions } from './types/imports.ts'
 export type { AppHeadMetaObject, MetaObject, MetaObjectRaw } from './types/head.ts'
 export type { ModuleDefinition, ModuleDependencies, ModuleDependencyMeta, ModuleMeta, ModuleOptions, ModuleSetupInstallResult, ModuleSetupReturn, NuxtModule, ResolvedModuleOptions } from './types/module.ts'
-export type { Nuxt, NuxtApp, NuxtBuildOutputs, NuxtPlugin, NuxtPluginTemplate, NuxtTemplate, NuxtTypeTemplate, NuxtServerTemplate, ResolvedNuxtTemplate } from './types/nuxt.ts'
+export type { Nuxt, NuxtApp, NuxtBuildOutputs, NuxtPlugin, NuxtPluginTemplate, NuxtTemplate, NuxtTemplateChange, NuxtTemplateDependency, NuxtTypeTemplate, NuxtServerTemplate, ResolvedNuxtTemplate } from './types/nuxt.ts'
 export type { RouterConfig, RouterConfigSerializable, RouterOptions } from './types/router.ts'
 export type { ConfigSchema } from './types/schema.ts'
 export type { NuxtDebugContext, NuxtDebugOptions, NuxtDebugModuleMutationRecord } from './types/debug.ts'

--- a/packages/schema/src/types/nuxt.ts
+++ b/packages/schema/src/types/nuxt.ts
@@ -2,7 +2,7 @@ import type { AsyncLocalStorage } from 'node:async_hooks'
 import type { Hookable } from 'hookable'
 import type { Ignore } from 'ignore'
 import type { NuxtModule } from './module.ts'
-import type { NuxtHooks, NuxtLayout, NuxtMiddleware, NuxtPage } from './hooks.ts'
+import type { NuxtHooks, NuxtLayout, NuxtMiddleware, NuxtPage, WatchEvent } from './hooks.ts'
 import type { Component } from './components.ts'
 import type { NuxtOptions } from './config.ts'
 import type { NuxtDebugContext } from './debug.ts'
@@ -29,6 +29,21 @@ export interface NuxtPlugin {
 
 type TemplateDefaultOptions = Record<string, any>
 
+/**
+ * A well-known input a template can declare it depends on:
+ *
+ * - `'pages'`: the contents of the files backing `app.pages`
+ * - `'plugins'`: the contents of the files listed in `app.plugins`
+ */
+export type NuxtTemplateDependency = 'pages' | 'plugins'
+
+/** A watched file event that may require regenerating templates. */
+export interface NuxtTemplateChange {
+  event: WatchEvent
+  /** absolute path of the file the event was emitted for */
+  path: string
+}
+
 export interface NuxtTemplate<Options = TemplateDefaultOptions> {
   /** resolved output file path (generated) */
   dst?: string
@@ -43,6 +58,19 @@ export interface NuxtTemplate<Options = TemplateDefaultOptions> {
   getContents?: (data: { nuxt: Nuxt, app: NuxtApp, options: Options }) => string | Promise<string>
   /** Write to filesystem */
   write?: boolean
+  /**
+   * The watched inputs the output of this template can depend on, beyond `nuxt.options` and the
+   * resolved structure of the app (which files exist, and where).
+   *
+   * Set this to `[]` if the template never reads the contents of a watched file. In dev mode
+   * Nuxt then skips recompiling it when a file changes without any file being added or removed.
+   * List well-known keys (such as `'pages'` or `'plugins'`) if the template reads those sources,
+   * or pass a function to decide per change.
+   *
+   * A template that declares nothing is regenerated on every change, unless it has a `src`, in
+   * which case it is regenerated only when that source file changes.
+   */
+  dependsOn?: NuxtTemplateDependency[] | ((change: NuxtTemplateChange, ctx: { nuxt: Nuxt, app: NuxtApp, options: Options }) => boolean)
   /**
    * The source path of the template (to try resolving dependencies from).
    * @internal


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

templates are currently regenerated every time any file is added, deleted or modified

but plenty of templates don't need to be regenerated that often. for example, they only care whether a file exists, not what its contents are. in some cases they should only be generated _once_

this PR adds a new option when registering templates, allowing modules or Nuxt itself to specify what should invalidate a template and to skip core nuxt templates in the vast majority of cases.

---

### 📊 some numbers

I tested this with a fixture of 200 pages, 300 components, 20 composables, 1 plugin = 49 templates

## templates per event

| edited file  | templates regenerated | 
| ------------ | --------------------: |
| component    | **0 of 49** |
| composable   | **0 of 49** |
| page         | 1 of 49               |
| plugin       | 4 of 49               |

## `builder:watch` time

> [!NOTE]
> timings are the time for the `builder:watch` hook to settle, measured by calling `nuxt.callHook('builder:watch', event, path)` directly from a module once `build:done` fired.

| scenario                | base (ms) | new (ms) | median paired delta (ms) | reduction |
| ----------------------- | --------: | -------: | -----------------------: | --------: |
| change a component      |      36.4 |      0.6 |                     35.8 |       98% |
| change a page           |      43.2 |     33.4 |                      8.4 |       23% |
| change a plugin         |      37.0 |     30.4 |                      4.5 |       18% |
| add a page              |      64.8 |     70.4 |                     -3.6 |         – |
| delete a page           |      60.7 |     62.6 |                     -1.6 |         – |

add and delete are unchanged by design, so the small difference here is probably just noise

## apps with no pages directory

trying a second fixture with no `pages/`:

| scenario            | base (ms) | new (ms) | median paired delta (ms) | reduction |
| ------------------- | --------: | -------: | -----------------------: | --------: |
| change a component  |      35.5 |      0.6 |                     34.9 |       98% |
| change a composable |      41.9 |     28.5 |                     13.6 |       32% |
| change a plugin     |      33.3 |     30.1 |                      2.1 |       10% |

## end to end

here, we wrote a leaf component, then polled the SSR'd HTML for `/page` until the edit appeared:

| scenario           | base (ms) | new (ms) | median paired delta (ms) | reduction |
| ------------------ | --------: | -------: | -----------------------: | --------: |
| change a component |      69.3 |     54.7 |                     14.6 |       21% |

the savings was less because it included not just template regeneration but also vite's invalidation and rerender, but it was still 21% fastre than previously
