### PR TITLE
fix(nuxt): support options api in `v-for` islands transform

### DIFF
--- a/packages/nuxt/src/components/plugins/islands-transform.ts
+++ b/packages/nuxt/src/components/plugins/islands-transform.ts
@@ -2,7 +2,7 @@ import type { Component } from '@nuxt/schema'
 import { componentDiagnostics } from '@nuxt/kit'
 import { createUnplugin } from 'unplugin'
 import { generateTransform, rolldownString } from 'rolldown-string'
-import { ELEMENT_NODE, parse, walk } from 'ultrahtml'
+import { ELEMENT_NODE, parse, walk, walkSync } from 'ultrahtml'
 import { genObjectFromRawEntries, genString } from 'knitwork'
 import type { Plugin } from 'vite'
 import { normalize } from 'pathe'
@@ -23,8 +23,6 @@ interface ServerOnlyComponentTransformPluginOptions {
   selectiveClient?: boolean | 'deep'
 }
 
-const SCRIPT_RE_GLOBAL = /<script(?=[\s>])[^>]*>/gi
-const ATTR_RE = /([^\s=/>]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+)))?/g
 const HAS_SLOT_OR_CLIENT_RE = /<slot[^>]*>|nuxt-client/
 const HAS_VFOR_RE = /\sv-for=/
 const TEMPLATE_RE = /<template>[\s\S]*<\/template>/
@@ -54,12 +52,20 @@ function wrapWithVForDiv (code: string, vfor: string): string {
   return `<div v-for="${vfor}" style="display: contents;">${code}</div>`
 }
 
-function parseScriptAttributes (tag: string): Record<string, string> {
-  const attributes: Record<string, string> = {}
-  for (const match of tag.slice('<script'.length, -1).matchAll(ATTR_RE)) {
-    attributes[match[1]!.toLowerCase()] = match[2] ?? match[3] ?? match[4] ?? ''
-  }
-  return attributes
+interface ScriptBlock {
+  attributes: Record<string, string>
+  /** Offset just past the end of the opening `<script ...>` tag. */
+  contentStart: number
+}
+
+function findScriptBlocks (code: string): ScriptBlock[] {
+  const blocks: ScriptBlock[] = []
+  walkSync(parse(code), (node) => {
+    if (node.type === ELEMENT_NODE && node.name === 'script') {
+      blocks.push({ attributes: node.attributes, contentStart: node.loc[0].end })
+    }
+  })
+  return blocks
 }
 
 export const IslandsTransformPlugin = (options: ServerOnlyComponentTransformPluginOptions) => createUnplugin((_options, meta) => {
@@ -98,13 +104,13 @@ export const IslandsTransformPlugin = (options: ServerOnlyComponentTransformPlug
         // The injected helpers are referenced from the template, so they must be setup bindings:
         // adding them to a plain `<script>` leaves them in module scope only and the template
         // compiler resolves them off `_ctx` instead, which is `undefined` at render time.
-        const scriptTags = [...code.matchAll(SCRIPT_RE_GLOBAL)].map(match => ({ match, attributes: parseScriptAttributes(match[0]) }))
-        const setupTag = scriptTags.find(({ attributes }) => 'setup' in attributes)
-        if (setupTag) {
-          s.appendRight(setupTag.match.index + setupTag.match[0].length, IMPORT_CODE)
+        const scriptBlocks = findScriptBlocks(code)
+        const setupBlock = scriptBlocks.find(({ attributes }) => 'setup' in attributes)
+        if (setupBlock) {
+          s.appendRight(setupBlock.contentStart, IMPORT_CODE)
         } else {
           // `<script>` and `<script setup>` in one SFC must agree on `lang`.
-          const lang = scriptTags[0]?.attributes.lang
+          const lang = scriptBlocks[0]?.attributes.lang
           s.prepend(`<script setup${lang ? ` lang="${lang}"` : ''}>` + IMPORT_CODE + '</script>')
         }
 

--- a/packages/nuxt/src/components/plugins/islands-transform.ts
+++ b/packages/nuxt/src/components/plugins/islands-transform.ts
@@ -23,9 +23,8 @@ interface ServerOnlyComponentTransformPluginOptions {
   selectiveClient?: boolean | 'deep'
 }
 
-const SCRIPT_RE_GLOBAL = /<script[^>]*>/gi
-const ATTR_VALUE_RE = /=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/g
-const LANG_ATTR_RE = /\slang\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/i
+const SCRIPT_RE_GLOBAL = /<script(?=[\s>])[^>]*>/gi
+const ATTR_RE = /([^\s=/>]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+)))?/g
 const HAS_SLOT_OR_CLIENT_RE = /<slot[^>]*>|nuxt-client/
 const HAS_VFOR_RE = /\sv-for=/
 const TEMPLATE_RE = /<template>[\s\S]*<\/template>/
@@ -55,8 +54,12 @@ function wrapWithVForDiv (code: string, vfor: string): string {
   return `<div v-for="${vfor}" style="display: contents;">${code}</div>`
 }
 
-function isSetupScript (tag: string): boolean {
-  return /\bsetup\b/.test(tag.replace(ATTR_VALUE_RE, ''))
+function parseScriptAttributes (tag: string): Record<string, string> {
+  const attributes: Record<string, string> = {}
+  for (const match of tag.slice('<script'.length, -1).matchAll(ATTR_RE)) {
+    attributes[match[1]!.toLowerCase()] = match[2] ?? match[3] ?? match[4] ?? ''
+  }
+  return attributes
 }
 
 export const IslandsTransformPlugin = (options: ServerOnlyComponentTransformPluginOptions) => createUnplugin((_options, meta) => {
@@ -95,14 +98,14 @@ export const IslandsTransformPlugin = (options: ServerOnlyComponentTransformPlug
         // The injected helpers are referenced from the template, so they must be setup bindings:
         // adding them to a plain `<script>` leaves them in module scope only and the template
         // compiler resolves them off `_ctx` instead, which is `undefined` at render time.
-        const scriptTags = [...code.matchAll(SCRIPT_RE_GLOBAL)]
-        const setupTag = scriptTags.find(match => isSetupScript(match[0]))
+        const scriptTags = [...code.matchAll(SCRIPT_RE_GLOBAL)].map(match => ({ match, attributes: parseScriptAttributes(match[0]) }))
+        const setupTag = scriptTags.find(({ attributes }) => 'setup' in attributes)
         if (setupTag) {
-          s.appendRight(setupTag.index + setupTag[0].length, IMPORT_CODE)
+          s.appendRight(setupTag.match.index + setupTag.match[0].length, IMPORT_CODE)
         } else {
           // `<script>` and `<script setup>` in one SFC must agree on `lang`.
-          const lang = scriptTags[0]?.[0].match(LANG_ATTR_RE)?.[1]
-          s.prepend(`<script setup${lang ? ` lang=${lang}` : ''}>` + IMPORT_CODE + '</script>')
+          const lang = scriptTags[0]?.attributes.lang
+          s.prepend(`<script setup${lang ? ` lang="${lang}"` : ''}>` + IMPORT_CODE + '</script>')
         }
 
         let hasNuxtClient = false

--- a/packages/nuxt/src/components/plugins/islands-transform.ts
+++ b/packages/nuxt/src/components/plugins/islands-transform.ts
@@ -23,8 +23,9 @@ interface ServerOnlyComponentTransformPluginOptions {
   selectiveClient?: boolean | 'deep'
 }
 
-const SCRIPT_RE = /<script[^>]*>/i
 const SCRIPT_RE_GLOBAL = /<script[^>]*>/gi
+const ATTR_VALUE_RE = /=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/g
+const LANG_ATTR_RE = /\slang\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/i
 const HAS_SLOT_OR_CLIENT_RE = /<slot[^>]*>|nuxt-client/
 const HAS_VFOR_RE = /\sv-for=/
 const TEMPLATE_RE = /<template>[\s\S]*<\/template>/
@@ -52,6 +53,10 @@ function boundVForInTag (tag: string): string {
 function wrapWithVForDiv (code: string, vfor: string): string {
   // `vfor` is already passed through `boundVForExpression` by the caller.
   return `<div v-for="${vfor}" style="display: contents;">${code}</div>`
+}
+
+function isSetupScript (tag: string): boolean {
+  return /\bsetup\b/.test(tag.replace(ATTR_VALUE_RE, ''))
 }
 
 export const IslandsTransformPlugin = (options: ServerOnlyComponentTransformPluginOptions) => createUnplugin((_options, meta) => {
@@ -87,12 +92,17 @@ export const IslandsTransformPlugin = (options: ServerOnlyComponentTransformPlug
           return
         }
 
-        if (!SCRIPT_RE.test(code)) {
-          s.prepend('<script setup>' + IMPORT_CODE + '</script>')
+        // The injected helpers are referenced from the template, so they must be setup bindings:
+        // adding them to a plain `<script>` leaves them in module scope only and the template
+        // compiler resolves them off `_ctx` instead, which is `undefined` at render time.
+        const scriptTags = [...code.matchAll(SCRIPT_RE_GLOBAL)]
+        const setupTag = scriptTags.find(match => isSetupScript(match[0]))
+        if (setupTag) {
+          s.appendRight(setupTag.index + setupTag[0].length, IMPORT_CODE)
         } else {
-          for (const match of code.matchAll(SCRIPT_RE_GLOBAL)) {
-            s.appendRight(match.index + match[0].length, IMPORT_CODE)
-          }
+          // `<script>` and `<script setup>` in one SFC must agree on `lang`.
+          const lang = scriptTags[0]?.[0].match(LANG_ATTR_RE)?.[1]
+          s.prepend(`<script setup${lang ? ` lang=${lang}` : ''}>` + IMPORT_CODE + '</script>')
         }
 
         let hasNuxtClient = false

--- a/packages/nuxt/test/island-transform.test.ts
+++ b/packages/nuxt/test/island-transform.test.ts
@@ -166,6 +166,36 @@ defineProps<{ items: any[] }>()
       expect(result).toContain('v-for="(item, index) of __vforBound(items)"')
     })
 
+    it('injects helpers into a setup block when the SFC uses the Options API (#35876)', async () => {
+      const result = await viteTransform(`<template>
+  <div v-for="item in items" :key="item">{{ item }}</div>
+</template>
+<script lang="ts">
+export default {
+  props: { items: { type: Array, required: true } },
+}
+</script>
+`, 'hello.server.vue')
+      expect(result).toContain('<script setup lang="ts">')
+      expect(result).toContain('v-for="item in __vforBound(items)"')
+      expect(result.match(/vforBound as __vforBound/g)).toHaveLength(1)
+    })
+
+    it('injects helpers once when the SFC has both <script> and <script setup>', async () => {
+      const result = await viteTransform(`<template>
+  <div v-for="item in items" :key="item">{{ item }}</div>
+</template>
+<script lang="ts">
+export const foo = 'bar'
+</script>
+<script setup lang="ts">
+defineProps<{ items: any[] }>()
+</script>
+`, 'hello.server.vue')
+      expect(result.match(/vforBound as __vforBound/g)).toHaveLength(1)
+      expect(result).toContain(`<script setup lang="ts">\nimport { mergeProps as __mergeProps }`)
+    })
+
     it('bounds a v-for on a nuxt-client element', async () => {
       const result = await viteTransform(`<template>
   <HelloWorld v-for="n in count" :key="n" nuxt-client />

--- a/packages/nuxt/test/island-transform.test.ts
+++ b/packages/nuxt/test/island-transform.test.ts
@@ -196,6 +196,21 @@ defineProps<{ items: any[] }>()
       expect(result).toContain(`<script setup lang="ts">\nimport { mergeProps as __mergeProps }`)
     })
 
+    it('does not treat a non-setup script as a setup block', async () => {
+      const result = await viteTransform(`<template>
+  <div v-for="item in items" :key="item">{{ item }}</div>
+</template>
+<script lang="ts" data-setup="true">
+export default {
+  props: { items: { type: Array, required: true } },
+}
+</script>
+`, 'hello.server.vue')
+      expect(result).toContain('<script setup lang="ts">')
+      expect(result.match(/vforBound as __vforBound/g)).toHaveLength(1)
+      expect(result.indexOf('__vforBound')).toBeLessThan(result.indexOf('data-setup'))
+    })
+
     it('bounds a v-for on a nuxt-client element', async () => {
       const result = await viteTransform(`<template>
   <HelloWorld v-for="n in count" :key="n" nuxt-client />

--- a/packages/nuxt/test/island-transform.test.ts
+++ b/packages/nuxt/test/island-transform.test.ts
@@ -211,6 +211,23 @@ export default {
       expect(result.indexOf('__vforBound')).toBeLessThan(result.indexOf('data-setup'))
     })
 
+    it('ignores script openers inside comments and string literals', async () => {
+      const result = await viteTransform(`<template>
+  <div v-for="item in items" :key="item">{{ item }}</div>
+</template>
+<!-- <script setup> -->
+<script lang="ts">
+const example = '<script setup>'
+export default {
+  props: { items: { type: Array, required: true } },
+}
+</script>
+`, 'hello.server.vue')
+      expect(result).toContain('<script setup lang="ts">')
+      expect(result.match(/vforBound as __vforBound/g)).toHaveLength(1)
+      expect(result.indexOf('__vforBound')).toBeLessThan(result.indexOf('<!--'))
+    })
+
     it('bounds a v-for on a nuxt-client element', async () => {
       const result = await viteTransform(`<template>
   <HelloWorld v-for="n in count" :key="n" nuxt-client />


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/35876

### 📚 Description

the transform to protect `v-for` in islands from unbounded props didn't implement support for the options api - this adds it