### PR TITLE
docs(nuxt): expand vite/webpack config access examples

### DIFF
--- a/docs/1.getting-started/17.testing.md
+++ b/docs/1.getting-started/17.testing.md
@@ -658,6 +658,20 @@ If you prefer to use `@vue/test-utils` on its own for unit testing in Nuxt, and 
 
 Congratulations, you're all set to start unit testing with `@vue/test-utils` in Nuxt! Happy testing!
 
+## Third-Party Testing Integrations
+
+Tools such as [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/overview), [Vitest](https://vitest.dev/) with a custom dev server, [Histoire](https://histoire.dev/), or [Storybook](https://storybook.js.org/) sometimes need access to the Vite or webpack configuration Nuxt generates.
+
+Nuxt does not expose a standalone `getViteConfig` or `getWebpackConfig` API. Integrations can resolve the config programmatically with `@nuxt/kit` and build hooks instead.
+
+::important
+Reusing the client bundler config is usually enough for mounting components in a browser test runner, but it does not recreate the full Nuxt runtime (auto-imports, Nitro, server routes, and so on). Prefer [`@nuxt/test-utils`](/docs/4.x/getting-started/testing) when you need Nuxt-specific behavior. For SSR and server features, use [end-to-end testing](#end-to-end-testing).
+::
+
+::read-more{to="/docs/4.x/api/kit/examples#accessing-nuxt-vite-or-webpack-config"}
+See Kit examples for resolving Vite and webpack client config, including a Cypress setup snippet.
+::
+
 ## End-To-End Testing
 
 For end-to-end testing, we support [Vitest](https://github.com/vitest-dev/vitest), [Jest](https://jestjs.io), [Cucumber](https://cucumber.io/) and [Playwright](https://playwright.dev/) as test runners.

--- a/docs/1.getting-started/17.testing.md
+++ b/docs/1.getting-started/17.testing.md
@@ -654,6 +654,20 @@ If you prefer to use `@vue/test-utils` on its own for unit testing in Nuxt, and 
 
 Congratulations, you're all set to start unit testing with `@vue/test-utils` in Nuxt! Happy testing!
 
+## Third-Party Testing Integrations
+
+Tools such as [Cypress Component Testing](https://docs.cypress.io/guides/component-testing/overview), [Vitest](https://vitest.dev/) with a custom dev server, [Histoire](https://histoire.dev/), or [Storybook](https://storybook.js.org/) sometimes need access to the Vite or webpack configuration Nuxt generates.
+
+Nuxt does not expose a standalone `getViteConfig` or `getWebpackConfig` API. Integrations can resolve the config programmatically with `@nuxt/kit` and build hooks instead.
+
+::important
+Reusing the client bundler config is usually enough for mounting components in a browser test runner, but it does not recreate the full Nuxt runtime (auto-imports, Nitro, server routes, and so on). Prefer [`@nuxt/test-utils`](/docs/4.x/getting-started/testing) when you need Nuxt-specific behavior. For SSR and server features, use [end-to-end testing](#end-to-end-testing).
+::
+
+::read-more{to="/docs/4.x/api/kit/examples#accessing-nuxt-vite-or-webpack-config"}
+See Kit examples for resolving Vite and webpack client config, including a Cypress setup snippet.
+::
+
 ## End-To-End Testing
 
 For end-to-end testing, we support [Vitest](https://github.com/vitest-dev/vitest), [Jest](https://jestjs.io), [Cucumber](https://cucumber.io/) and [Playwright](https://playwright.dev/) as test runners.

--- a/docs/4.api/5.kit/16.examples.md
+++ b/docs/4.api/5.kit/16.examples.md
@@ -3,26 +3,52 @@ title: "Examples"
 description: Examples of Nuxt Kit utilities in use.
 ---
 
-## Accessing Nuxt Vite Config
+## Accessing Nuxt Vite or webpack Config
 
-If you are building an integration that needs access to the runtime Vite or webpack config that Nuxt uses, it is possible to extract this using Kit utilities.
+Nuxt does **not** ship a standalone exported function to retrieve the Vite or webpack client configuration (unlike Nuxt 2's `getWebpackConfig`). The bundler config is created as part of the Nuxt build pipeline.
 
-Some examples of projects doing this already:
+If you are building a third-party integration (for example Cypress Component Testing, Vitest, Histoire, or Storybook), you can extract the resolved config using Nuxt Kit and build hooks. Nuxt maintainers [document this pattern](https://github.com/nuxt/nuxt/issues/14534#issuecomment-1419025107) rather than adding a dedicated Kit utility to core.
 
-- [histoire](https://github.com/histoire-dev/histoire/blob/main/packages/histoire-plugin-nuxt/src/index.ts)
+### Limitations
+
+Bundler configuration alone is usually **not enough** to reproduce the full Nuxt runtime. Nuxt 3 is a full-stack framework with auto-imports, virtual modules, server isolation via [Nitro](https://nitro.build/), and other setup that lives outside the raw Vite or webpack config.
+
+For testing Nuxt components and composables inside the Nuxt pipeline, prefer [`@nuxt/test-utils`](/docs/4.x/getting-started/testing). Use the patterns below when you need to hand a Nuxt-resolved config to an external dev server.
+
+::read-more{to="/docs/4.x/getting-started/testing#third-party-testing-integrations"}
+See testing recommendations and when to reach for external tool configs.
+::
+
+### Existing Integrations
+
+These projects resolve Nuxt's Vite or webpack config today:
+
+- [histoire-plugin-nuxt](https://github.com/histoire-dev/histoire/blob/main/packages/histoire-plugin-nuxt/src/index.ts)
 - [nuxt-vitest](https://github.com/danielroe/nuxt-vitest/blob/main/packages/nuxt-vitest/src/config.ts)
 - [@storybook-vue/nuxt](https://github.com/storybook-vue/storybook-nuxt/blob/main/packages/storybook-nuxt/src/preset.ts)
 
-Here is a brief example of how you might access the Vite config from a project; you could implement a similar approach to get the webpack configuration.
+### Accessing the Vite Config
 
-```js
+Start a **fresh** Nuxt instance in a separate process, hook into config generation, then stop the build once you have the config. This pattern does not work reliably against an already-running Nuxt dev server because `vite:extendConfig` will have fired before your hook is registered.
+
+The example below loads Nuxt with `ssr: false`, waits for the **client** Vite config, and aborts the build with a sentinel error:
+
+```js [get-vite-config.mjs]
 import { buildNuxt, loadNuxt } from '@nuxt/kit'
 
 // https://github.com/nuxt/nuxt/issues/14534
-async function getViteConfig () {
-  const nuxt = await loadNuxt({ cwd: process.cwd(), dev: false, overrides: { ssr: false } })
+export async function getViteConfig () {
+  const nuxt = await loadNuxt({
+    cwd: process.cwd(),
+    dev: false,
+    overrides: { ssr: false },
+  })
+
   return new Promise((resolve, reject) => {
-    nuxt.hook('vite:extend', (config) => {
+    nuxt.hook('vite:extendConfig', (config, { isClient }) => {
+      if (!isClient) {
+        return
+      }
       resolve(config)
       throw new Error('_stop_')
     })
@@ -37,3 +63,63 @@ async function getViteConfig () {
 const viteConfig = await getViteConfig()
 console.log(viteConfig)
 ```
+
+You can pass the result to Cypress component testing:
+
+```ts [cypress.config.ts]
+import { defineConfig } from 'cypress'
+import { getViteConfig } from './get-vite-config.mjs'
+
+export default defineConfig({
+  component: {
+    devServer: {
+      framework: 'vue',
+      bundler: 'vite',
+      viteConfig: getViteConfig,
+    },
+  },
+})
+```
+
+::note
+In Nuxt 5+, `vite:extendConfig` and `vite:configResolved` operate on a shared configuration rather than separate client and server configs. See the [Nuxt 5 upgrade guide](/docs/4.x/getting-started/upgrade#migration-to-vite-environment-api) for migration details.
+::
+
+### Accessing the webpack Config
+
+If your project uses the webpack builder, use the `webpack:config` hook (or `rspack:config` with `@nuxt/rspack-builder`) in the same way:
+
+```js [get-webpack-config.mjs]
+import { buildNuxt, loadNuxt } from '@nuxt/kit'
+
+export async function getWebpackConfig () {
+  const nuxt = await loadNuxt({
+    cwd: process.cwd(),
+    dev: false,
+    overrides: { ssr: false },
+  })
+
+  const builder = nuxt.options.builder === '@nuxt/rspack-builder' ? 'rspack' : 'webpack'
+
+  return new Promise((resolve, reject) => {
+    nuxt.hook(`${builder}:config`, (webpackConfigs) => {
+      const clientConfig = webpackConfigs.find(config => config.name === 'client')
+      resolve(clientConfig ?? webpackConfigs[0])
+      throw new Error('_stop_')
+    })
+    buildNuxt(nuxt).catch((err) => {
+      if (!err.toString().includes('_stop_')) {
+        reject(err)
+      }
+    })
+  }).finally(() => nuxt.close())
+}
+```
+
+### Testing SSR Behavior
+
+Resolving the client bundler config covers client-side component mounting. Testing components that depend on SSR rendering, server routes, or Nitro behavior usually requires running Nuxt itself. Use [`@nuxt/test-utils` end-to-end helpers](/docs/4.x/getting-started/testing#end-to-end-testing) or full-stack test setups rather than only reusing the Vite or webpack config.
+
+::read-more{to="https://stackblitz.com/edit/nuxt-starter-yk8get?file=nuxt-vite-config.mjs"}
+See @pi0's StackBlitz POC for another Kit-based approach.
+::

--- a/docs/4.api/5.kit/16.examples.md
+++ b/docs/4.api/5.kit/16.examples.md
@@ -7,7 +7,7 @@ description: Examples of Nuxt Kit utilities in use.
 
 Nuxt does **not** ship a standalone exported function to retrieve the Vite or webpack client configuration (unlike Nuxt 2's `getWebpackConfig`). The bundler config is created as part of the Nuxt build pipeline.
 
-If you are building a third-party integration (for example Cypress Component Testing, Vitest, Histoire, or Storybook), you can extract the resolved config using Nuxt Kit and build hooks. Nuxt maintainers [document this pattern](https://github.com/nuxt/nuxt/issues/14534#issuecomment-1419025107) rather than adding a dedicated Kit utility to core.
+If you are building a third-party integration (for example Cypress Component Testing, Vitest, Histoire, or Storybook), you can extract the finalized Vite or webpack configuration using Nuxt Kit and build hooks. Nuxt maintainers [document this pattern](https://github.com/nuxt/nuxt/issues/14534#issuecomment-1419025107) rather than adding a dedicated Kit utility to core.
 
 ### Limitations
 
@@ -29,9 +29,9 @@ These projects resolve Nuxt's Vite or webpack config today:
 
 ### Accessing the Vite Config
 
-Start a **fresh** Nuxt instance in a separate process, hook into config generation, then stop the build once you have the config. This pattern does not work reliably against an already-running Nuxt dev server because `vite:extendConfig` will have fired before your hook is registered.
+Start a **fresh** Nuxt instance in a separate process, hook into config generation, then stop the build once you have the config. This pattern does not work reliably against an already-running Nuxt dev server because `vite:configResolved` will have fired before your hook is registered.
 
-The example below loads Nuxt with `ssr: false`, waits for the **client** Vite config, and aborts the build with a sentinel error:
+The example below loads Nuxt with `ssr: false`, captures the first finalized Vite config from `vite:configResolved`, and aborts the build with a sentinel error:
 
 ```js [get-vite-config.mjs]
 import { buildNuxt, loadNuxt } from '@nuxt/kit'
@@ -45,10 +45,7 @@ export async function getViteConfig () {
   })
 
   return new Promise((resolve, reject) => {
-    nuxt.hook('vite:extendConfig', (config, { isClient }) => {
-      if (!isClient) {
-        return
-      }
+    nuxt.hook('vite:configResolved', (config) => {
       resolve(config)
       throw new Error('_stop_')
     })
@@ -82,12 +79,12 @@ export default defineConfig({
 ```
 
 ::note
-In Nuxt 5+, `vite:extendConfig` and `vite:configResolved` operate on a shared configuration rather than separate client and server configs. See the [Nuxt 5 upgrade guide](/docs/4.x/getting-started/upgrade#migration-to-vite-environment-api) for migration details.
+With `ssr: false`, the first `vite:configResolved` emission is enough for a client-only integration. In Nuxt 5+, the hook receives the shared Vite configuration rather than separate client and server configs. See the [Nuxt 5 upgrade guide](/docs/4.x/getting-started/upgrade#migration-to-vite-environment-api) for migration details.
 ::
 
 ### Accessing the webpack Config
 
-If your project uses the webpack builder, use the `webpack:config` hook (or `rspack:config` with `@nuxt/rspack-builder`) in the same way:
+If your project uses the webpack builder, use the `webpack:configResolved` hook (or `rspack:configResolved` with `@nuxt/rspack-builder`) in the same way:
 
 ```js [get-webpack-config.mjs]
 import { buildNuxt, loadNuxt } from '@nuxt/kit'
@@ -102,9 +99,8 @@ export async function getWebpackConfig () {
   const builder = nuxt.options.builder === '@nuxt/rspack-builder' ? 'rspack' : 'webpack'
 
   return new Promise((resolve, reject) => {
-    nuxt.hook(`${builder}:config`, (webpackConfigs) => {
-      const clientConfig = webpackConfigs.find(config => config.name === 'client')
-      resolve(clientConfig ?? webpackConfigs[0])
+    nuxt.hook(`${builder}:configResolved`, (webpackConfigs) => {
+      resolve(webpackConfigs[0])
       throw new Error('_stop_')
     })
     buildNuxt(nuxt).catch((err) => {

--- a/docs/4.api/5.kit/16.examples.md
+++ b/docs/4.api/5.kit/16.examples.md
@@ -29,7 +29,7 @@ These projects resolve Nuxt's Vite or webpack config today:
 
 ### Accessing the Vite Config
 
-Start a **fresh** Nuxt instance in a separate process, hook into config generation, then stop the build once you have the config. This pattern does not work reliably against an already-running Nuxt dev server because `vite:configResolved` will have fired before your hook is registered.
+Start a **fresh** Nuxt instance, register your hook before configuration resolution, then stop the build once you have the config. This pattern does not work reliably against an already-running Nuxt dev server because `vite:configResolved` will have fired before your hook is registered.
 
 The example below loads Nuxt with `ssr: false`, captures the first finalized Vite config from `vite:configResolved`, and aborts the build with a sentinel error:
 
@@ -44,17 +44,29 @@ export async function getViteConfig () {
     overrides: { ssr: false },
   })
 
-  return new Promise((resolve, reject) => {
-    nuxt.hook('vite:configResolved', (config) => {
-      resolve(config)
-      throw new Error('_stop_')
-    })
-    buildNuxt(nuxt).catch((err) => {
-      if (!err.toString().includes('_stop_')) {
-        reject(err)
-      }
-    })
-  }).finally(() => nuxt.close())
+  let config
+  const abort = new Error('Nuxt Vite config extraction aborted')
+
+  nuxt.hook('vite:configResolved', (resolvedConfig) => {
+    config = resolvedConfig
+    throw abort
+  })
+
+  try {
+    await buildNuxt(nuxt)
+  } catch (err) {
+    if (err !== abort) {
+      throw err
+    }
+  } finally {
+    await nuxt.close()
+  }
+
+  if (!config) {
+    throw new Error('Failed to resolve Vite config')
+  }
+
+  return config
 }
 
 const viteConfig = await getViteConfig()
@@ -98,17 +110,29 @@ export async function getWebpackConfig () {
 
   const builder = nuxt.options.builder === '@nuxt/rspack-builder' ? 'rspack' : 'webpack'
 
-  return new Promise((resolve, reject) => {
-    nuxt.hook(`${builder}:configResolved`, (webpackConfigs) => {
-      resolve(webpackConfigs[0])
-      throw new Error('_stop_')
-    })
-    buildNuxt(nuxt).catch((err) => {
-      if (!err.toString().includes('_stop_')) {
-        reject(err)
-      }
-    })
-  }).finally(() => nuxt.close())
+  let config
+  const abort = new Error('Nuxt webpack config extraction aborted')
+
+  nuxt.hook(`${builder}:configResolved`, (webpackConfigs) => {
+    config = webpackConfigs[0]
+    throw abort
+  })
+
+  try {
+    await buildNuxt(nuxt)
+  } catch (err) {
+    if (err !== abort) {
+      throw err
+    }
+  } finally {
+    await nuxt.close()
+  }
+
+  if (!config) {
+    throw new Error('Failed to resolve webpack config')
+  }
+
+  return config
 }
 ```
 


### PR DESCRIPTION
### 🔗 Linked issue

Refs #14534

### 📚 Description

Nuxt 3 never shipped a standalone getViteConfig or getWebpackConfig export like Nuxt 2 did. Third-party tools still need the resolved client bundler config for Cypress, Vitest, Histoire, and similar setups.

I expanded the Kit examples page with Vite and webpack snippets, noted the limits of bundler-only reuse, and linked a new testing guide section that points integrators at @nuxt/test-utils when they need the full Nuxt runtime.