### PR TITLE
refactor(nuxt): use `isReferenceIdentifier` in page-meta plugin

### DIFF
--- a/packages/nuxt/src/pages/plugins/page-meta.ts
+++ b/packages/nuxt/src/pages/plugins/page-meta.ts
@@ -3,7 +3,7 @@ import type { StaticImport } from 'mlly'
 import { findExports, findStaticImports, parseStaticImport } from 'mlly'
 import MagicString from 'magic-string'
 import { generateTransform, rolldownString } from 'rolldown-string'
-import { ScopeTracker, getUndeclaredIdentifiersInFunction, isBindingIdentifier, parseAndWalk, walk } from 'oxc-walker'
+import { ScopeTracker, getUndeclaredIdentifiersInFunction, isReferenceIdentifier, parseAndWalk, walk } from 'oxc-walker'
 import type { ScopeTrackerNode } from 'oxc-walker'
 
 import { pageDiagnostics } from '@nuxt/kit'
@@ -187,15 +187,28 @@ export const PageMetaPlugin = (options: PageMetaPluginOptions = {}) => createUnp
 
             for (const decl of scopeTrackerNode.variableNode.declarations) {
               if (!decl.init) { continue }
+
+              // `isReferenceIdentifier` cannot distinguish identifiers in destructured binding
+              // patterns (`({ foo }) => foo`) from references, and references to locals of
+              // functions within the initializer must not resolve to same-named declarations
+              // in the outer scope, so track the initializer's own scopes to filter them out
+              const initScopeTracker = new ScopeTracker({
+                preserveExitedScopes: true,
+              })
+              walk(decl.init, { scopeTracker: initScopeTracker })
+              initScopeTracker.freeze()
+
               walk(decl.init, {
+                scopeTracker: initScopeTracker,
                 enter: (node, parent) => {
                   if (node.type === 'AwaitExpression') {
                     const codeSnippet = code.slice(node.start, Math.min(node.end, node.start + 80))
                     throw pageDiagnostics.NUXT_B4002({ codeSnippet, offset: node.start })
                   }
                   if (
-                    isBindingIdentifier(node, parent)
+                    !isReferenceIdentifier(node, parent)
                   || node.type !== 'Identifier' // checking for `node.type` to narrow down the type
+                  || initScopeTracker.isDeclared(node.name)
                   ) { return }
 
                   addImportOrDeclaration(node.name, scopeTrackerNode)
@@ -292,7 +305,7 @@ export const PageMetaPlugin = (options: PageMetaPluginOptions = {}) => createUnp
               scopeTracker,
               enter (node, parent) {
                 if (
-                  isBindingIdentifier(node, parent)
+                  !isReferenceIdentifier(node, parent)
                 || node.type !== 'Identifier' // checking for `node.type` to narrow down the type
                 ) { return }
 

--- a/packages/nuxt/test/keyed-function-factories.test.ts
+++ b/packages/nuxt/test/keyed-function-factories.test.ts
@@ -512,7 +512,15 @@ describe('keyed function factories scan plugin', () => {
     export const useFetch = createUseFetch()
   `
     await callScanPlugin('fetch.ts', code, mockNuxt)
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot(`[]`)
+    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot(`
+      [
+        {
+          "argumentLength": 3,
+          "name": "useFetch",
+          "source": "fetch.ts",
+        },
+      ]
+    `)
   })
 
   it('should ignore type-modified specifier', async () => {
@@ -522,7 +530,15 @@ describe('keyed function factories scan plugin', () => {
     export const useFetch = createUseFetch()
   `
     await callScanPlugin('fetch.ts', code, mockNuxt)
-    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot(`[]`)
+    expect(mockNuxt.options.optimization.keyedComposables).toMatchInlineSnapshot(`
+      [
+        {
+          "argumentLength": 3,
+          "name": "useFetch",
+          "source": "fetch.ts",
+        },
+      ]
+    `)
   })
 
   it('should ignore type-only namespace import', async () => {

--- a/packages/nuxt/test/page-metadata.test.ts
+++ b/packages/nuxt/test/page-metadata.test.ts
@@ -1181,6 +1181,140 @@ const hoisted = ref('hoisted')
     `)
   })
 
+  it('should not hoist declarations shadowed by destructured bindings inside `definePageMeta`', () => {
+    const sfc = `
+<script setup lang="ts">
+const params = useShadowedParams()
+const query = useShadowedQuery()
+
+definePageMeta({
+  validate: ({ params }) => {
+    return params.id === 'test'
+  },
+  middleware: [
+    (to) => {
+      const { query } = to
+      return query.foo === 'bar'
+    },
+  ],
+})
+</script>
+      `
+    const res = compileScript(parse(sfc).descriptor, { id: 'component.vue' })
+    expect(transformPlugin.transform.handler(res.content, 'component.vue?macro=true')?.code).toMatchInlineSnapshot(`
+      "const __nuxt_page_meta = {
+        validate: ({ params }) => {
+          return params.id === 'test'
+        },
+        middleware: [
+          (to) => {
+            const { query } = to
+            return query.foo === 'bar'
+          },
+        ],
+      }
+      export default __nuxt_page_meta"
+    `)
+  })
+
+  it('should not hoist declarations shadowed by params and locals of functions in hoisted initializers', () => {
+    const sfc = `
+<script setup lang="ts">
+import { sep } from './utils'
+
+const spacer = useShadowedSpacer()
+const t = useShadowedT()
+
+const helper = ({ sep }, spacer) => sep + spacer
+const title = (() => { const t = 'hello'; return t })()
+
+definePageMeta({
+  validate: () => helper({ sep: 'x' }, '-') === title,
+})
+</script>
+      `
+    const res = compileScript(parse(sfc).descriptor, { id: 'component.vue' })
+    expect(transformPlugin.transform.handler(res.content, 'component.vue?macro=true')?.code).toMatchInlineSnapshot(`
+      "const helper = ({ sep }, spacer) => sep + spacer
+      const title = (() => { const t = 'hello'; return t })()
+      const __nuxt_page_meta = {
+        validate: () => helper({ sep: 'x' }, '-') === title,
+      }
+      export default __nuxt_page_meta"
+    `)
+  })
+
+  it('should hoist identifiers referenced as computed members and computed keys', () => {
+    const sfc = `
+<script setup lang="ts">
+const idx = 2
+const arr = [1, 2, 3]
+const key = 'foo'
+
+definePageMeta({
+  middleware: () => ({ [key]: arr[idx] }),
+})
+</script>
+      `
+    const res = compileScript(parse(sfc).descriptor, { id: 'component.vue' })
+    expect(transformPlugin.transform.handler(res.content, 'component.vue?macro=true')?.code).toMatchInlineSnapshot(`
+      "const idx = 2
+      const key = 'foo'
+      const arr = [1, 2, 3]
+      const __nuxt_page_meta = {
+        middleware: () => ({ [key]: arr[idx] }),
+      }
+      export default __nuxt_page_meta"
+    `)
+  })
+
+  it('should not treat statement labels as references', () => {
+    const sfc = `
+<script setup lang="ts">
+const outer = useShadowedOuter()
+
+definePageMeta({
+  middleware: () => {
+    outer: for (const x of [1]) { break outer }
+  },
+})
+</script>
+      `
+    const res = compileScript(parse(sfc).descriptor, { id: 'component.vue' })
+    expect(transformPlugin.transform.handler(res.content, 'component.vue?macro=true')?.code).toMatchInlineSnapshot(`
+      "const __nuxt_page_meta = {
+        middleware: () => {
+          outer: for (const x of [1]) { break outer }
+        },
+      }
+      export default __nuxt_page_meta"
+    `)
+  })
+
+  it('should not add imports or declarations for type-only references', () => {
+    const sfc = `
+<script setup lang="ts">
+import { validators } from './utils'
+import type { RouteThing } from './types'
+
+const helper = (route: RouteThing) => validators.isNumber(route.params.id)
+
+definePageMeta({
+  validate: (route: RouteThing) => helper(route),
+})
+</script>
+      `
+    const res = compileScript(parse(sfc).descriptor, { id: 'component.vue' })
+    expect(transformPlugin.transform.handler(res.content, 'component.vue?macro=true')?.code).toMatchInlineSnapshot(`
+      "import { validators } from './utils'
+      const helper = (route: RouteThing) => validators.isNumber(route.params.id)
+      const __nuxt_page_meta = {
+        validate: (route: RouteThing) => helper(route),
+      }
+      export default __nuxt_page_meta"
+    `)
+  })
+
   it('should transform layout written in object syntax', () => {
     const sfc = `
 <script setup lang="ts">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -473,8 +473,8 @@ catalogs:
       specifier: ^1.1.0
       version: 1.1.0
     oxc-walker:
-      specifier: ^1.0.0
-      version: 1.0.0
+      specifier: ^1.1.1
+      version: 1.1.1
     rolldown-string:
       specifier: ^0.3.1
       version: 0.3.1
@@ -1113,7 +1113,7 @@ importers:
         version: 6.0.2
       oxc-walker:
         specifier: catalog:vite
-        version: 1.0.0(@rspack/core@2.1.5(@swc/helpers@0.5.23))(esbuild@0.28.1)(oxc-parser@0.141.0)(rolldown@1.1.5)(rollup@4.62.3)(vite@8.1.5)(webpack@5.109.0(cssnano@8.0.2(postcss@8.5.23))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.23))
+        version: 1.1.1(@oxc-project/types@0.141.0)(oxc-parser@0.141.0)(rolldown@1.1.5)
       pathe:
         specifier: catalog:app-runtime
         version: 2.0.3
@@ -1183,7 +1183,7 @@ importers:
     devDependencies:
       '@nuxt/scripts':
         specifier: catalog:dev
-        version: 1.3.2(@rspack/core@2.1.5(@swc/helpers@0.5.23))(@unhead/vue@3.2.3(@rspack/core@2.1.5(@swc/helpers@0.5.23))(cac@7.0.0)(esbuild@0.28.1)(lightningcss@1.32.0)(rolldown@1.1.5)(rollup@4.62.3)(srvx@0.12.4)(typescript@6.0.3)(vite@8.1.5)(vue@3.5.40(typescript@6.0.3))(webpack@5.109.0(cssnano@8.0.2(postcss@8.5.23))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.23)))(db0@0.3.4)(esbuild@0.28.1)(ioredis@5.10.1(supports-color@10.2.2))(rolldown@1.1.5)(rollup@4.62.3)(typescript@6.0.3)(vite@8.1.5)(vue@3.5.40(typescript@6.0.3))(webpack@5.109.0(cssnano@8.0.2(postcss@8.5.23))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.23))
+        version: 1.3.2(@oxc-project/types@0.141.0)(@rspack/core@2.1.5(@swc/helpers@0.5.23))(@unhead/vue@3.2.3(@rspack/core@2.1.5(@swc/helpers@0.5.23))(cac@7.0.0)(esbuild@0.28.1)(lightningcss@1.32.0)(rolldown@1.1.5)(rollup@4.62.3)(srvx@0.12.4)(typescript@6.0.3)(vite@8.1.5)(vue@3.5.40(typescript@6.0.3))(webpack@5.109.0(cssnano@8.0.2(postcss@8.5.23))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.23)))(db0@0.3.4)(esbuild@0.28.1)(ioredis@5.10.1(supports-color@10.2.2))(rolldown@1.1.5)(rollup@4.62.3)(typescript@6.0.3)(vite@8.1.5)(vue@3.5.40(typescript@6.0.3))(webpack@5.109.0(cssnano@8.0.2(postcss@8.5.23))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.23))
       '@parcel/watcher':
         specifier: catalog:dev
         version: 2.6.0
@@ -8081,6 +8081,20 @@ packages:
       rolldown:
         optional: true
 
+  oxc-walker@1.1.1:
+    resolution: {integrity: sha512-Hwd7dq28zu/Er99+bpWp16CGwFrhyalJh0W3JOB7XpPvgWo3MqMi2ksWGKuzzA9zt50mJ2pIUwR5lpAdZ9ACNQ==}
+    peerDependencies:
+      '@oxc-project/types': '>=0.98.0'
+      oxc-parser: 0.141.0
+      rolldown: 1.1.5
+    peerDependenciesMeta:
+      '@oxc-project/types':
+        optional: true
+      oxc-parser:
+        optional: true
+      rolldown:
+        optional: true
+
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
@@ -11690,7 +11704,7 @@ snapshots:
       string-width: 4.2.3
       webpack: 5.109.0(cssnano@8.0.2(postcss@8.5.23))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.23)
 
-  '@nuxt/scripts@1.3.2(@rspack/core@2.1.5(@swc/helpers@0.5.23))(@unhead/vue@3.2.3(@rspack/core@2.1.5(@swc/helpers@0.5.23))(cac@7.0.0)(esbuild@0.28.1)(lightningcss@1.32.0)(rolldown@1.1.5)(rollup@4.62.3)(srvx@0.12.4)(typescript@6.0.3)(vite@8.1.5)(vue@3.5.40(typescript@6.0.3))(webpack@5.109.0(cssnano@8.0.2(postcss@8.5.23))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.23)))(db0@0.3.4)(esbuild@0.28.1)(ioredis@5.10.1(supports-color@10.2.2))(rolldown@1.1.5)(rollup@4.62.3)(typescript@6.0.3)(vite@8.1.5)(vue@3.5.40(typescript@6.0.3))(webpack@5.109.0(cssnano@8.0.2(postcss@8.5.23))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.23))':
+  '@nuxt/scripts@1.3.2(@oxc-project/types@0.141.0)(@rspack/core@2.1.5(@swc/helpers@0.5.23))(@unhead/vue@3.2.3(@rspack/core@2.1.5(@swc/helpers@0.5.23))(cac@7.0.0)(esbuild@0.28.1)(lightningcss@1.32.0)(rolldown@1.1.5)(rollup@4.62.3)(srvx@0.12.4)(typescript@6.0.3)(vite@8.1.5)(vue@3.5.40(typescript@6.0.3))(webpack@5.109.0(cssnano@8.0.2(postcss@8.5.23))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.23)))(db0@0.3.4)(esbuild@0.28.1)(ioredis@5.10.1(supports-color@10.2.2))(rolldown@1.1.5)(rollup@4.62.3)(typescript@6.0.3)(vite@8.1.5)(vue@3.5.40(typescript@6.0.3))(webpack@5.109.0(cssnano@8.0.2(postcss@8.5.23))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.23))':
     dependencies:
       '@nuxt/devtools-kit': 3.2.4(vite@8.1.5)
       '@vueuse/core': 14.3.0(vue@3.5.40(typescript@6.0.3))
@@ -11702,7 +11716,7 @@ snapshots:
       ofetch: 1.5.1
       ohash: 2.0.11
       oxc-parser: 0.141.0
-      oxc-walker: 1.0.0(@rspack/core@2.1.5(@swc/helpers@0.5.23))(esbuild@0.28.1)(oxc-parser@0.141.0)(rolldown@1.1.5)(rollup@4.62.3)(vite@8.1.5)(webpack@5.109.0(cssnano@8.0.2(postcss@8.5.23))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.23))
+      oxc-walker: 1.1.1(@oxc-project/types@0.141.0)(oxc-parser@0.141.0)(rolldown@1.1.5)
       pathe: 2.0.3
       pkg-types: 2.3.1
       sirv: 3.0.2
@@ -11725,6 +11739,7 @@ snapshots:
       - '@deno/kv'
       - '@farmfe/core'
       - '@netlify/blobs'
+      - '@oxc-project/types'
       - '@planetscale/database'
       - '@rspack/core'
       - '@upstash/redis'
@@ -17972,6 +17987,12 @@ snapshots:
       - unloader
       - vite
       - webpack
+
+  oxc-walker@1.1.1(@oxc-project/types@0.141.0)(oxc-parser@0.141.0)(rolldown@1.1.5):
+    optionalDependencies:
+      '@oxc-project/types': 0.141.0
+      oxc-parser: 0.141.0
+      rolldown: 1.1.5
 
   p-limit@3.1.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -55,6 +55,7 @@ minimumReleaseAgeExclude:
   - '@unhead/vue@3.2.1'
   - unhead@3.2.1
   - impound@1.1.6
+  - oxc-walker@1.1.1
 
 catalogs:
   # imported in the nuxt app runtime (packages/nuxt/src/app, head/runtime, pages/runtime)
@@ -104,7 +105,7 @@ catalogs:
   # vite/rolldown/oxc toolchain
   vite:
     magic-string: ^1.1.0
-    oxc-walker: ^1.0.0
+    oxc-walker: ^1.1.1
     # needs to match vite's own `~1.1.5` pin
     rolldown: ~1.1.5
     rolldown-string: ^0.3.1


### PR DESCRIPTION
### 📚 Description

this is a follow up on changes in `oxc-walker` described in https://github.com/oxc-project/oxc-walker/pull/344

it updates `oxc-walker` to include the latest bugfixes and also resolves some edge cases we've had with page meta extraction