### PR TITLE
fix(vite): resolve client manifest path from resolved config

### DIFF
--- a/packages/kit/src/diagnostics/bundler.ts
+++ b/packages/kit/src/diagnostics/bundler.ts
@@ -101,5 +101,15 @@ export const bundlerDiagnostics = /* #__PURE__ */ defineDiagnostics({
       fix: 'Externalize dependencies in the server build (`externals`) for better build performance.',
       docs: false,
     },
+    NUXT_B7020: {
+      why: 'The client build manifest is disabled, but Nuxt requires it to render the correct assets for each route.',
+      fix: 'Remove any `build.manifest: false` override from your `nuxt.config` `vite` options or from a Vite plugin `config`/`configEnvironment` hook.',
+      docs: false,
+    },
+    NUXT_B7021: {
+      why: (p: { manifestFile: string }) => `The client build manifest was expected at \`${p.manifestFile}\` but was not emitted by the client build.`,
+      fix: 'Check that no Vite plugin removes or renames the client build manifest in a `generateBundle`/`writeBundle` hook. If this happens with no such plugin, please report it at https://github.com/nuxt/nuxt/issues.',
+      docs: false,
+    },
   },
 })

--- a/packages/vite/src/plugins/client-manifest.ts
+++ b/packages/vite/src/plugins/client-manifest.ts
@@ -8,15 +8,17 @@ import { normalizeViteManifest, precomputeDependencies } from 'vue-bundle-render
 import { serialize } from 'seroval'
 import type { Manifest as RendererManifest } from 'vue-bundle-renderer'
 import type { Plugin, Manifest as ViteClientManifest } from 'vite'
-import { setBuildOutput } from '@nuxt/kit'
+import { bundlerDiagnostics, setBuildOutput } from '@nuxt/kit'
 import type { Nuxt } from '@nuxt/schema'
-import { resolveClientEntry } from '../utils/config.ts'
+import { resolveClientEntry, resolveClientManifestPath } from '../utils/config.ts'
 import { collectGlobalCss } from '../utils/css.ts'
 
 export function ClientManifestPlugin (nuxt: Nuxt): Plugin {
   let clientEntry: string
   let key: string
   let disableCssCodeSplit: boolean
+  let clientOutDir: string
+  let manifestFile: string
 
   let precomputedCode = 'export default undefined'
   // Default empty manifest so the build output is loadable before the real one is populated.
@@ -78,7 +80,7 @@ export function ClientManifestPlugin (nuxt: Nuxt): Plugin {
       order: 'post',
       handler (_options, bundle) {
         if (!envApi || nuxt.options.dev || this.environment?.name !== 'client') { return }
-        const asset = bundle['manifest.json']
+        const asset = bundle[relative(clientOutDir, manifestFile)]
         if (asset?.type === 'asset') {
           rawClientManifest = JSON.parse(asset.source.toString()) as ViteClientManifest
         }
@@ -88,6 +90,11 @@ export function ClientManifestPlugin (nuxt: Nuxt): Plugin {
       clientEntry = resolveClientEntry(config)
       key = relative(config.root, clientEntry)
       disableCssCodeSplit = config.build?.cssCodeSplit === false
+      if (!nuxt.options.dev) {
+        const clientBuild = config.environments.client?.build
+        clientOutDir = clientBuild?.outDir ?? resolve(nuxt.options.buildDir, 'dist/client')
+        manifestFile = resolveClientManifestPath(clientOutDir, clientBuild?.manifest)
+      }
     },
     async closeBundle () {
       // In env-API mode finalisation is triggered lazily by the provider
@@ -102,14 +109,13 @@ export function ClientManifestPlugin (nuxt: Nuxt): Plugin {
     // This is only used for ssr: false - when ssr is enabled we use vite-node runtime manifest
     const devClientManifest = buildDevClientManifest()
 
-    // Legacy reads the client `manifest.json` from disk, written by the time
-    // the ssr env's `closeBundle` runs. Env-API uses the in-memory capture
+    // Legacy reads the client manifest from disk, written by the time the ssr
+    // env's `closeBundle` runs. Env-API uses the in-memory capture
     // (`rawClientManifest`).
-    const manifestFile = resolve(nuxt.options.buildDir, 'dist/client', 'manifest.json')
     const clientManifest = nuxt.options.dev
       ? devClientManifest
       : envApi
-        ? (rawClientManifest ?? {})
+        ? (rawClientManifest ?? raiseMissingManifest())
         : JSON.parse(readFileSync(manifestFile, 'utf-8')) as ViteClientManifest
     const manifestEntries = Object.values(clientManifest)
 
@@ -147,10 +153,14 @@ export function ClientManifestPlugin (nuxt: Nuxt): Plugin {
         await writeFile(resolve(serverDist, 'client.precomputed.mjs'), precomputedCode, 'utf8')
       }
 
-      // The legacy build reads `manifest.json` from disk, so we can remove it once consumed.
+      // The legacy build reads the manifest from disk, so we can remove it once consumed.
       if (!envApi) {
         await rm(manifestFile, { force: true })
       }
     }
+  }
+
+  function raiseMissingManifest (): never {
+    throw bundlerDiagnostics.NUXT_B7021({ manifestFile })
   }
 }

--- a/packages/vite/src/plugins/client-manifest.ts
+++ b/packages/vite/src/plugins/client-manifest.ts
@@ -116,7 +116,7 @@ export function ClientManifestPlugin (nuxt: Nuxt): Plugin {
       ? devClientManifest
       : envApi
         ? (rawClientManifest ?? raiseMissingManifest())
-        : JSON.parse(readFileSync(manifestFile, 'utf-8')) as ViteClientManifest
+        : JSON.parse(readManifestFromDisk()) as ViteClientManifest
     const manifestEntries = Object.values(clientManifest)
 
     const buildAssetsDir = withTrailingSlash(withoutLeadingSlash(nuxt.options.app.buildAssetsDir))
@@ -157,6 +157,17 @@ export function ClientManifestPlugin (nuxt: Nuxt): Plugin {
       if (!envApi) {
         await rm(manifestFile, { force: true })
       }
+    }
+  }
+
+  function readManifestFromDisk (): string {
+    try {
+      return readFileSync(manifestFile, 'utf-8')
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        raiseMissingManifest()
+      }
+      throw error
     }
   }
 

--- a/packages/vite/src/plugins/client-manifest.ts
+++ b/packages/vite/src/plugins/client-manifest.ts
@@ -10,14 +10,14 @@ import type { Manifest as RendererManifest } from 'vue-bundle-renderer'
 import type { Plugin, Manifest as ViteClientManifest } from 'vite'
 import { bundlerDiagnostics, setBuildOutput } from '@nuxt/kit'
 import type { Nuxt } from '@nuxt/schema'
-import { resolveClientEntry, resolveClientManifestPath } from '../utils/config.ts'
+import { resolveClientEntry, resolveClientManifestFile } from '../utils/config.ts'
 import { collectGlobalCss } from '../utils/css.ts'
 
 export function ClientManifestPlugin (nuxt: Nuxt): Plugin {
   let clientEntry: string
   let key: string
   let disableCssCodeSplit: boolean
-  let clientOutDir: string
+  let manifestFileName: string
   let manifestFile: string
 
   let precomputedCode = 'export default undefined'
@@ -80,7 +80,7 @@ export function ClientManifestPlugin (nuxt: Nuxt): Plugin {
       order: 'post',
       handler (_options, bundle) {
         if (!envApi || nuxt.options.dev || this.environment?.name !== 'client') { return }
-        const asset = bundle[relative(clientOutDir, manifestFile)]
+        const asset = bundle[manifestFileName]
         if (asset?.type === 'asset') {
           rawClientManifest = JSON.parse(asset.source.toString()) as ViteClientManifest
         }
@@ -91,9 +91,9 @@ export function ClientManifestPlugin (nuxt: Nuxt): Plugin {
       key = relative(config.root, clientEntry)
       disableCssCodeSplit = config.build?.cssCodeSplit === false
       if (!nuxt.options.dev) {
-        const clientBuild = config.environments.client?.build
-        clientOutDir = clientBuild?.outDir ?? resolve(nuxt.options.buildDir, 'dist/client')
-        manifestFile = resolveClientManifestPath(clientOutDir, clientBuild?.manifest)
+        const clientBuild = config.environments.client?.build ?? config.build
+        manifestFileName = resolveClientManifestFile(clientBuild.manifest)
+        manifestFile = resolve(clientBuild.outDir, manifestFileName)
       }
     },
     async closeBundle () {

--- a/packages/vite/src/utils/config.ts
+++ b/packages/vite/src/utils/config.ts
@@ -1,5 +1,17 @@
 import type { ResolvedConfig } from 'vite'
+import { resolve } from 'pathe'
 import { bundlerDiagnostics } from '@nuxt/kit'
+
+/**
+ * Resolve the absolute path Vite writes the client build manifest to, honouring
+ * any `build.manifest` override from user config or a Vite plugin.
+ */
+export function resolveClientManifestPath (outDir: string, manifest: string | boolean | undefined) {
+  if (!manifest) {
+    throw bundlerDiagnostics.NUXT_B7020()
+  }
+  return resolve(outDir, manifest === true ? '.vite/manifest.json' : manifest)
+}
 
 export function resolveClientEntry (config: ResolvedConfig) {
   const input = config.environments.client?.build.rolldownOptions.input ?? config.build.rolldownOptions.input

--- a/packages/vite/src/utils/config.ts
+++ b/packages/vite/src/utils/config.ts
@@ -3,14 +3,22 @@ import { resolve } from 'pathe'
 import { bundlerDiagnostics } from '@nuxt/kit'
 
 /**
- * Resolve the absolute path Vite writes the client build manifest to, honouring
- * any `build.manifest` override from user config or a Vite plugin.
+ * Resolve the client build manifest file name, relative to the client `outDir`,
+ * honouring any `build.manifest` override from user config or a Vite plugin. This
+ * is also the key the manifest is emitted under in the client bundle.
  */
-export function resolveClientManifestPath (outDir: string, manifest: string | boolean | undefined) {
+export function resolveClientManifestFile (manifest: string | boolean | undefined) {
   if (!manifest) {
     throw bundlerDiagnostics.NUXT_B7020()
   }
-  return resolve(outDir, manifest === true ? '.vite/manifest.json' : manifest)
+  return manifest === true ? '.vite/manifest.json' : manifest
+}
+
+/**
+ * Resolve the absolute path Vite writes the client build manifest to.
+ */
+export function resolveClientManifestPath (outDir: string, manifest: string | boolean | undefined) {
+  return resolve(outDir, resolveClientManifestFile(manifest))
 }
 
 export function resolveClientEntry (config: ResolvedConfig) {

--- a/packages/vite/src/utils/config.ts
+++ b/packages/vite/src/utils/config.ts
@@ -1,5 +1,4 @@
 import type { ResolvedConfig } from 'vite'
-import { resolve } from 'pathe'
 import { bundlerDiagnostics } from '@nuxt/kit'
 
 /**
@@ -12,13 +11,6 @@ export function resolveClientManifestFile (manifest: string | boolean | undefine
     throw bundlerDiagnostics.NUXT_B7020()
   }
   return manifest === true ? '.vite/manifest.json' : manifest
-}
-
-/**
- * Resolve the absolute path Vite writes the client build manifest to.
- */
-export function resolveClientManifestPath (outDir: string, manifest: string | boolean | undefined) {
-  return resolve(outDir, resolveClientManifestFile(manifest))
 }
 
 export function resolveClientEntry (config: ResolvedConfig) {

--- a/packages/vite/test/client-manifest-path.test.ts
+++ b/packages/vite/test/client-manifest-path.test.ts
@@ -1,0 +1,87 @@
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { afterEach, describe, expect, it } from 'vitest'
+import { buildNuxt, loadNuxt } from '@nuxt/kit'
+import { join } from 'pathe'
+import type { NuxtConfig } from 'nuxt/schema'
+import type { Manifest } from 'vue-bundle-renderer'
+import type { Plugin } from 'vite'
+
+const tmpDir = fileURLToPath(new URL('./.tmp/client-manifest-path', import.meta.url))
+
+function overrideClientManifest (manifest: string | boolean): Plugin {
+  return {
+    name: 'test:client-manifest-override',
+    configEnvironment (name) {
+      if (name === 'client') {
+        return { build: { manifest } }
+      }
+    },
+  }
+}
+
+async function buildApp (overrides: NuxtConfig) {
+  await rm(tmpDir, { recursive: true, force: true })
+  await mkdir(join(tmpDir, 'app/components'), { recursive: true })
+  await writeFile(join(tmpDir, 'app/app.vue'), [
+    '<script setup>',
+    'const Lazy = defineAsyncComponent(() => import(\'./components/Lazy.vue\'))',
+    '</script>',
+    '',
+    '<template><div><Lazy /></div></template>',
+  ].join('\n'))
+  await writeFile(join(tmpDir, 'app/components/Lazy.vue'), [
+    '<template><p class="lazy">lazy</p></template>',
+    '',
+    '<style scoped>.lazy { color: rebeccapurple }</style>',
+  ].join('\n'))
+
+  const nuxt = await loadNuxt({
+    cwd: tmpDir,
+    ready: true,
+    dev: false,
+    overrides: {
+      ...overrides,
+      compatibilityDate: 'latest',
+      devtools: { enabled: false },
+      ssr: true,
+      pages: false,
+    },
+  })
+
+  let manifest: Manifest | undefined
+  nuxt.hook('build:manifest', (m) => { manifest = m })
+
+  try {
+    await buildNuxt(nuxt)
+  } finally {
+    await nuxt.close()
+  }
+
+  return manifest
+}
+
+// https://github.com/nuxt/nuxt/issues/35868
+describe('client manifest path overridden by a vite plugin', () => {
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it.each([false, true])('resolves the client manifest when a plugin sets `build.manifest: true` (`nitroViteEnvironment: %s`)', async (nitroViteEnvironment) => {
+    const manifest = await buildApp({
+      experimental: { nitroViteEnvironment },
+      vite: { plugins: [overrideClientManifest(true)] },
+    })
+
+    const entries = Object.values(manifest!)
+    expect(entries.length).toBeGreaterThan(1)
+    expect(entries.some(entry => entry.isEntry && entry.file?.endsWith('.js'))).toBe(true)
+    expect(entries.some(entry => entry.src?.endsWith('components/Lazy.vue'))).toBe(true)
+  }, 240 * 1000)
+
+  it('fails with `NUXT_B7020` when a plugin disables the client manifest', async () => {
+    await expect(buildApp({
+      vite: { plugins: [overrideClientManifest(false)] },
+    })).rejects.toMatchObject({ code: 'NUXT_B7020' })
+  }, 240 * 1000)
+})


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/35868

### 📚 Description

nuxt assumed that the vite manifest would be located in a single place but in fact this can be modified by plugins; this PR respects user's choice, and additionally errors if users disable it for whatever reason