### PR TITLE
fix(nuxt): re-check for preview mode after prerendered page hydration

### DIFF
--- a/packages/nuxt/src/app/composables/preview.ts
+++ b/packages/nuxt/src/app/composables/preview.ts
@@ -1,6 +1,7 @@
 import { toRef, watch } from 'vue'
 import type { Ref } from 'vue'
 
+import { useNuxtApp } from '../nuxt'
 import { useState } from './state'
 import { refreshNuxtData } from './asyncData'
 import { useRoute, useRouter } from './router'
@@ -60,11 +61,25 @@ export function usePreviewMode<S extends EnteredState> (options: PreviewModeOpti
     preview.value._initialized = true
   }
 
-  if (!preview.value.enabled) {
-    const shouldEnable = options.shouldEnable ?? defaultShouldEnable
+  const shouldEnable = options.shouldEnable ?? defaultShouldEnable
+
+  function checkEnabled () {
+    if (preview.value.enabled) { return }
+
     const result = shouldEnable(preview.value.state)
 
     if (typeof result === 'boolean') { preview.value.enabled = result }
+  }
+
+  checkEnabled()
+
+  if (import.meta.client && !preview.value.enabled) {
+    const nuxtApp = useNuxtApp()
+    // on a prerendered page the real route (and its query) is only restored after hydration,
+    // so the query has to be re-checked once it is available (#35885)
+    if (nuxtApp['~restoreDeferredRoute']) {
+      nuxtApp.hooks.hookOnce('app:suspense:resolve', () => nuxtApp.runWithContext(checkEnabled))
+    }
   }
 
   watch(() => preview.value.enabled, (value) => {

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -714,6 +714,15 @@ describe('pages', () => {
 
     await page.close()
   })
+
+  it.skipIf(isDev)('enables preview mode on prerendered pages', async () => {
+    const { page } = await renderPage('/prerender/preview-mode?preview=true&token=hehe')
+
+    await page.waitForFunction(() => document.querySelector('#preview-enabled')?.textContent === 'true')
+    expect(await page.innerText('#preview-token')).toBe('hehe')
+
+    await page.close()
+  })
 })
 
 describe('nuxt composables', () => {

--- a/test/fixtures/basic/app/pages/prerender/preview-mode.vue
+++ b/test/fixtures/basic/app/pages/prerender/preview-mode.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+const { enabled, state } = usePreviewMode()
+</script>
+
+<template>
+  <div>
+    <span id="preview-enabled">{{ enabled }}</span>
+    <span id="preview-token">{{ state.token }}</span>
+  </div>
+</template>


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/35885

### 📚 Description

since we hydrate prerendered pages without a query string, preview mode wasn't properly detected for them.

this adds an additional check after hydration to check