### PR TITLE
feat(schema): enable nitro vite environment by default in v5

### DIFF
--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -302,19 +302,24 @@ export default defineResolvers({
      * Run Nitro as a Vite environment using the `nitro/vite` plugin instead of
      * Nitro's own Rolldown pipeline.
      *
+     * Enabled by default when `future.compatibilityVersion` is `5` or higher.
+     *
      * Only effective when using `@nuxt/vite-builder`.
      */
     nitroViteEnvironment: {
       $resolve: async (val, get) => {
-        if (val !== true) {
+        const enabled = typeof val === 'boolean' ? val : (await get('future.compatibilityVersion')) >= 5
+        if (!enabled) {
           return false
         }
         const builder = await get('builder')
         if (builder !== 'vite' && (builder as string) !== '@nuxt/vite-builder') {
-          console.warn('[nuxt] `experimental.nitroViteEnvironment` is only compatible with `@nuxt/vite-builder`. Disabling.')
+          if (val === true) {
+            console.warn('[nuxt] `experimental.nitroViteEnvironment` is only compatible with `@nuxt/vite-builder`. Disabling.')
+          }
           return false
         }
-        return val
+        return true
       },
     },
     asyncCallHook: {

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -302,14 +302,11 @@ export default defineResolvers({
      * Run Nitro as a Vite environment using the `nitro/vite` plugin instead of
      * Nitro's own Rolldown pipeline.
      *
-     * Enabled by default when `future.compatibilityVersion` is `5` or higher.
-     *
      * Only effective when using `@nuxt/vite-builder`.
      */
     nitroViteEnvironment: {
       $resolve: async (val, get) => {
-        const enabled = typeof val === 'boolean' ? val : (await get('future.compatibilityVersion')) >= 5
-        if (!enabled) {
+        if (val === false) {
           return false
         }
         const builder = await get('builder')

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1701,8 +1701,10 @@ export interface ConfigSchema {
      * Run Nitro as a Vite environment using the `nitro/vite` plugin instead of
      * Nitro's own Rolldown pipeline.
      *
+     * Enabled by default when `future.compatibilityVersion` is `5` or higher.
+     *
      * Only effective when using `@nuxt/vite-builder`.
-     * @default false
+     * @default true
      */
     nitroViteEnvironment: boolean
 

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1701,8 +1701,6 @@ export interface ConfigSchema {
      * Run Nitro as a Vite environment using the `nitro/vite` plugin instead of
      * Nitro's own Rolldown pipeline.
      *
-     * Enabled by default when `future.compatibilityVersion` is `5` or higher.
-     *
      * Only effective when using `@nuxt/vite-builder`.
      * @default true
      */

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -76,26 +76,25 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(rootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs'], serverDir, rootDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"273k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"265k"`)
 
     const packages = getVendorPackages(await glob(['_libs/**/*'], { cwd: serverDir }))
     expect(packages).toMatchInlineSnapshot(`
       [
-        "@unhead/vue+[...]",
+        "_vue/server-renderer+[...]",
         "defu",
         "devalue",
         "h3+rou3+srvx",
-        "nostics",
+        "hookable",
         "ocache+ohash",
         "ofetch",
-        "pathe",
         "scule",
         "ufo",
-        "unhead",
         "unstorage",
         "vue",
-        "vue-bundle-renderer",
-        "vue__server-renderer",
+        "vue__reactivity+vue__shared",
+        "vue__runtime-core",
+        "vue__runtime-dom",
       ]
     `)
   })
@@ -104,30 +103,26 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(pagesRootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs'], serverDir, pagesRootDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"348k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"311k"`)
 
     const packages = getVendorPackages(await glob(['_libs/**/*'], { cwd: serverDir }))
     expect(packages).toMatchInlineSnapshot(`
       [
-        "@unhead/vue+[...]",
+        "_vue/server-renderer+[...]",
         "defu",
-        "destr",
         "devalue",
         "h3+rou3+srvx",
-        "nostics",
+        "hookable",
         "ocache+ohash",
         "ofetch",
-        "pathe",
         "scule",
         "ufo",
-        "uncrypto",
-        "unhead",
         "unstorage",
         "vue",
-        "vue-bundle-renderer",
-        "vue-devtools-stub",
         "vue-router",
-        "vue__server-renderer",
+        "vue__reactivity+vue__shared",
+        "vue__runtime-core",
+        "vue__runtime-dom",
       ]
     `)
   })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,12 +1,25 @@
 import process from 'node:process'
 import { resolve } from 'pathe'
-import { defineVitestProject } from '@nuxt/test-utils/config'
+import { defineVitestProject as _defineVitestProject } from '@nuxt/test-utils/config'
 import { configDefaults, coverageConfigDefaults, defaultExclude, defineConfig } from 'vitest/config'
 import { isCI, isWindows } from 'std-env'
 import { getV8Flags } from '@codspeed/core'
 import codspeedPlugin from '@codspeed/vitest-plugin'
 import type { NuxtConfig } from 'nuxt/schema'
 import { defu } from 'defu'
+
+// TODO: fix upstream in nuxt/test-utils
+function defineVitestProject (config: Parameters<typeof _defineVitestProject>[0]) {
+  return _defineVitestProject(defu({
+    test: {
+      environmentOptions: {
+        nuxt: {
+          overrides: { experimental: { nitroViteEnvironment: false } } satisfies NuxtConfig,
+        },
+      },
+    },
+  }, config))
+}
 
 const commonSettings: NuxtConfig = {
   pages: true,
@@ -121,10 +134,6 @@ export default defineConfig({
           retry: isCI ? 2 : 0,
           benchmark: { include: [] },
           env: fixtureProjectEnv(entry),
-          // TODO: fix upstream in nitro
-          // `nitro/vite` keeps `RunnerManager` in process-global state, so all but
-          // one concurrent worker gets a 503: 'Vite environment "nitro" is unavailable'
-          ...(entry.builder === 'nitro-vite' ? { fileParallelism: false } : {}),
         },
       })),
       {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this enables the `nitro/vite` integration with the vite environment api as the default for nuxt v5

we may revert this before releasing v5 (cc: @pi0) but this enables us to test it more effectively beforehand