### PR TITLE
fix(nuxt): set build outputs when restoring vue cache

### DIFF
--- a/packages/nuxt/src/core/cache.ts
+++ b/packages/nuxt/src/core/cache.ts
@@ -1,7 +1,7 @@
 import { mkdir, open, readFile, stat, unlink, writeFile } from 'node:fs/promises'
 import type { FileHandle } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
-import { buildDiagnostics, createIsIgnored } from '@nuxt/kit'
+import { buildDiagnostics, createIsIgnored, setBuildOutput } from '@nuxt/kit'
 import type { Nuxt, NuxtConfig, NuxtConfigLayer } from '@nuxt/schema'
 import { hash, serialize } from 'ohash'
 import { glob } from 'tinyglobby'
@@ -59,6 +59,13 @@ export async function getVueHash (nuxt: Nuxt) {
       const res = await restoreCacheFromFile(nuxt.options.buildDir, cacheFile)
       const elapsed = Date.now() - start
       if (res) {
+        // Vite is skipped on a cache hit, so re-point nuxt/* build outputs at
+        // the restored modules (same as packages/vite/src/manifest.ts does
+        // after a real client build).
+        const serverDist = resolve(nuxt.options.buildDir, 'dist/server')
+        setBuildOutput('clientManifest', () => `export { default } from ${JSON.stringify(resolve(serverDist, 'client.manifest.mjs'))}`)
+        setBuildOutput('clientPrecomputed', () => `export { default } from ${JSON.stringify(resolve(serverDist, 'client.precomputed.mjs'))}`)
+        setBuildOutput('serverEntry', () => `export { default } from ${JSON.stringify(resolve(serverDist, 'server.mjs'))}`)
         consola.success(`Restored Vue client and server builds from cache in \`${elapsed}ms\`.`)
       }
       return res

--- a/packages/nuxt/src/core/cache.ts
+++ b/packages/nuxt/src/core/cache.ts
@@ -2,7 +2,7 @@ import { mkdir, open, readFile, stat, unlink, writeFile } from 'node:fs/promises
 import type { FileHandle } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
 import { buildDiagnostics, createIsIgnored, setBuildOutput } from '@nuxt/kit'
-import type { Nuxt, NuxtConfig, NuxtConfigLayer } from '@nuxt/schema'
+import type { Nuxt, NuxtBuildOutputs, NuxtConfig, NuxtConfigLayer } from '@nuxt/schema'
 import { hash, serialize } from 'ohash'
 import { glob } from 'tinyglobby'
 import { consola } from 'consola'
@@ -45,6 +45,7 @@ export async function getVueHash (nuxt: Nuxt) {
     hash,
     async collectCache () {
       const start = Date.now()
+      await persistBuildOutputs(nuxt)
       await writeCache(nuxt.options.buildDir, nuxt.options.buildDir, cacheFile)
 
       // Cache buildId so it can be restored before modules are initialised on the next build
@@ -59,17 +60,36 @@ export async function getVueHash (nuxt: Nuxt) {
       const res = await restoreCacheFromFile(nuxt.options.buildDir, cacheFile)
       const elapsed = Date.now() - start
       if (res) {
-        // Vite is skipped on a cache hit, so re-point nuxt/* build outputs at
-        // the restored modules (same as packages/vite/src/manifest.ts does
-        // after a real client build).
-        const serverDist = resolve(nuxt.options.buildDir, 'dist/server')
-        setBuildOutput('clientManifest', () => `export { default } from ${JSON.stringify(resolve(serverDist, 'client.manifest.mjs'))}`)
-        setBuildOutput('clientPrecomputed', () => `export { default } from ${JSON.stringify(resolve(serverDist, 'client.precomputed.mjs'))}`)
-        setBuildOutput('serverEntry', () => `export { default } from ${JSON.stringify(resolve(serverDist, 'server.mjs'))}`)
+        await restoreBuildOutputs(nuxt)
         consola.success(`Restored Vue client and server builds from cache in \`${elapsed}ms\`.`)
       }
       return res
     },
+  }
+}
+
+const BUILD_OUTPUTS_FILE = 'build-outputs.json'
+
+/**
+ * The bundler is skipped entirely on a cache hit, so the `nuxt/*` build outputs
+ * it would normally provide are snapshotted into the cached build directory and
+ * replayed on restore.
+ */
+async function persistBuildOutputs (nuxt: Nuxt) {
+  const outputs: Partial<Record<keyof NuxtBuildOutputs, string>> = {}
+  for (const key of Object.keys(nuxt.buildOutputs) as Array<keyof NuxtBuildOutputs>) {
+    outputs[key] = String(await nuxt.buildOutputs[key]())
+  }
+  await writeFile(resolve(nuxt.options.buildDir, BUILD_OUTPUTS_FILE), JSON.stringify(outputs), 'utf8')
+}
+
+async function restoreBuildOutputs (nuxt: Nuxt) {
+  const file = resolve(nuxt.options.buildDir, BUILD_OUTPUTS_FILE)
+  if (!existsSync(file)) { return }
+  const outputs = JSON.parse(await readFile(file, 'utf8')) as Record<keyof NuxtBuildOutputs, string>
+  for (const key of Object.keys(outputs) as Array<keyof NuxtBuildOutputs>) {
+    const code = outputs[key]
+    setBuildOutput(key, () => code, nuxt)
   }
 }
 

--- a/packages/nuxt/test/cache.test.ts
+++ b/packages/nuxt/test/cache.test.ts
@@ -5,6 +5,15 @@ import { join } from 'pathe'
 import { findWorkspaceDir } from 'pkg-types'
 import { afterAll, beforeEach, describe, expect, it } from 'vitest'
 import { build, loadNuxt } from 'nuxt'
+import type { Nuxt, NuxtBuildOutputs } from '@nuxt/schema'
+
+async function resolveBuildOutputs (nuxt: Nuxt) {
+  const resolved: Partial<Record<keyof NuxtBuildOutputs, string>> = {}
+  for (const key of Object.keys(nuxt.buildOutputs) as Array<keyof NuxtBuildOutputs>) {
+    resolved[key] = String(await nuxt.buildOutputs[key]())
+  }
+  return resolved
+}
 
 describe('buildCache', { sequential: true, timeout: 120_000 }, async () => {
   const workspaceDir = await findWorkspaceDir()
@@ -103,6 +112,38 @@ describe('buildCache', { sequential: true, timeout: 120_000 }, async () => {
     await build(nuxt2)
 
     expect(buildDoneFired).toBe(true)
+  })
+
+  it('should restore build outputs on cache hit', async () => {
+    const rootDir = join(tmpDir, 'project')
+    await writeFile(join(rootDir, 'app.vue'), '<template><div class="box">hello</div></template><style scoped>.box { color: red }</style>')
+
+    const nuxt1 = await loadNuxt({
+      cwd: rootDir,
+      overrides: {
+        buildId: 'outputs-1',
+        experimental: { buildCache: true },
+        dev: false,
+        workspaceDir: tmpDir,
+      },
+    })
+    await build(nuxt1)
+    const expected = await resolveBuildOutputs(nuxt1)
+
+    const nuxt2 = await loadNuxt({
+      cwd: rootDir,
+      overrides: {
+        buildId: 'outputs-2',
+        experimental: { buildCache: true },
+        dev: false,
+        workspaceDir: tmpDir,
+      },
+    })
+    await build(nuxt2)
+
+    expect(await resolveBuildOutputs(nuxt2)).toStrictEqual(expected)
+    expect(expected.clientManifest).not.toBe('export default {}')
+    expect(expected.ssrStyles).not.toBe('export default {}')
   })
 
   it('should generate a new buildId when sources change', async () => {

--- a/packages/vite/src/plugins/client-manifest.ts
+++ b/packages/vite/src/plugins/client-manifest.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs'
-import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { rm } from 'node:fs/promises'
 
 import { relative, resolve } from 'pathe'
 import { withTrailingSlash, withoutLeadingSlash } from 'ufo'
@@ -140,13 +140,6 @@ export function ClientManifestPlugin (nuxt: Nuxt): Plugin {
     manifestCode = 'export default ' + serialize(manifest)
 
     if (!nuxt.options.dev) {
-      if (nuxt.options.experimental.buildCache) {
-        const serverDist = resolve(nuxt.options.buildDir, 'dist/server')
-        await mkdir(serverDist, { recursive: true })
-        await writeFile(resolve(serverDist, 'client.manifest.mjs'), manifestCode, 'utf8')
-        await writeFile(resolve(serverDist, 'client.precomputed.mjs'), precomputedCode, 'utf8')
-      }
-
       // The legacy build reads `manifest.json` from disk, so we can remove it once consumed.
       if (!envApi) {
         await rm(manifestFile, { force: true })


### PR DESCRIPTION
### 🔗 Linked issue

resolves #35894 

### 📚 Description

Hit this after upgrading to Nuxt `4.5.1` on a static site (`nuxt generate`, Cloudflare Pages, `experimental.buildCache: true`).

First generate is fine. Second one when restore cache and then prerender dies with:

    Either manifest or precomputed data must be provided

Same thing locally, not just on CF.
___
I aggressively questioned an LLM for way too long until it finally spit out a fix that both seemed to work and that I could actually understand the code diffs of. I'm not sure this is really where or how nuxt would want this fixed, but it got cached generates working for me again.

So hopefully this code actually helps y'all 🦆