### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/docs/4.api/4.commands/add.md
+++ b/docs/4.api/4.commands/add.md
@@ -4,7 +4,7 @@ description: "Scaffold an entity into your Nuxt application."
 links:
   - label: Source
     icon: i-simple-icons-github
-    to: https://github.com/nuxt/cli/blob/main/packages/nuxi/src/commands/add-template.ts
+    to: https://github.com/nuxt/cli/blob/main/packages/nuxt-cli/src/commands/add-template.ts
     size: xs
 ---
 

--- a/docs/4.api/4.commands/analyze.md
+++ b/docs/4.api/4.commands/analyze.md
@@ -4,7 +4,7 @@ description: "Analyze the production bundle or your Nuxt application."
 links:
   - label: Source
     icon: i-simple-icons-github
-    to: https://github.com/nuxt/cli/blob/main/packages/nuxi/src/commands/analyze.ts
+    to: https://github.com/nuxt/cli/blob/main/packages/nuxt-cli/src/commands/analyze.ts
     size: xs
 ---
 

--- a/docs/4.api/4.commands/build.md
+++ b/docs/4.api/4.commands/build.md
@@ -4,7 +4,7 @@ description: "Build your Nuxt application."
 links:
   - label: Source
     icon: i-simple-icons-github
-    to: https://github.com/nuxt/cli/blob/main/packages/nuxi/src/commands/build.ts
+    to: https://github.com/nuxt/cli/blob/main/packages/nuxt-cli/src/commands/build.ts
     size: xs
 ---
 

--- a/docs/4.api/4.commands/cleanup.md
+++ b/docs/4.api/4.commands/cleanup.md
@@ -4,7 +4,7 @@ description: 'Remove common generated Nuxt files and caches.'
 links:
   - label: Source
     icon: i-simple-icons-github
-    to: https://github.com/nuxt/cli/blob/main/packages/nuxi/src/commands/cleanup.ts
+    to: https://github.com/nuxt/cli/blob/main/packages/nuxt-cli/src/commands/cleanup.ts
     size: xs
 ---
 

--- a/docs/4.api/4.commands/dev.md
+++ b/docs/4.api/4.commands/dev.md
@@ -4,7 +4,7 @@ description: The dev command starts a development server with hot module replace
 links:
   - label: Source
     icon: i-simple-icons-github
-    to: https://github.com/nuxt/cli/blob/main/packages/nuxi/src/commands/dev.ts
+    to: https://github.com/nuxt/cli/blob/main/packages/nuxt-cli/src/commands/dev.ts
     size: xs
 ---
 

--- a/docs/4.api/4.commands/devtools.md
+++ b/docs/4.api/4.commands/devtools.md
@@ -4,7 +4,7 @@ description: The devtools command allows you to enable or disable Nuxt DevTools 
 links:
   - label: Source
     icon: i-simple-icons-github
-    to: https://github.com/nuxt/cli/blob/main/packages/nuxi/src/commands/devtools.ts
+    to: https://github.com/nuxt/cli/blob/main/packages/nuxt-cli/src/commands/devtools.ts
     size: xs
 ---
 

--- a/docs/4.api/4.commands/generate.md
+++ b/docs/4.api/4.commands/generate.md
@@ -4,7 +4,7 @@ description: Pre-renders every route of the application and stores the result in
 links:
   - label: Source
     icon: i-simple-icons-github
-    to: https://github.com/nuxt/cli/blob/main/packages/nuxi/src/commands/generate.ts
+    to: https://github.com/nuxt/cli/blob/main/packages/nuxt-cli/src/commands/generate.ts
     size: xs
 ---
 

--- a/docs/4.api/4.commands/info.md
+++ b/docs/4.api/4.commands/info.md
@@ -4,7 +4,7 @@ description: The info command logs information about the current or specified Nu
 links:
   - label: Source
     icon: i-simple-icons-github
-    to: https://github.com/nuxt/cli/blob/main/packages/nuxi/src/commands/info.ts
+    to: https://github.com/nuxt/cli/blob/main/packages/nuxt-cli/src/commands/info.ts
     size: xs
 ---
 

--- a/docs/4.api/4.commands/init.md
+++ b/docs/4.api/4.commands/init.md
@@ -4,7 +4,7 @@ description: The init command initializes a fresh Nuxt project.
 links:
   - label: Source
     icon: i-simple-icons-github
-    to: https://github.com/nuxt/cli/blob/main/packages/nuxi/src/commands/init.ts
+    to: https://github.com/nuxt/cli/blob/main/packages/nuxt-cli/src/commands/init.ts
     size: xs
 ---
 

--- a/docs/4.api/4.commands/module.md
+++ b/docs/4.api/4.commands/module.md
@@ -4,7 +4,7 @@ description: "Search and add modules to your Nuxt application with the command l
 links:
   - label: Source
     icon: i-simple-icons-github
-    to: https://github.com/nuxt/cli/tree/main/packages/nuxi/src/commands/module
+    to: https://github.com/nuxt/cli/tree/main/packages/nuxt-cli/src/commands/module
     size: xs
 ---
 

--- a/docs/4.api/4.commands/prepare.md
+++ b/docs/4.api/4.commands/prepare.md
@@ -4,7 +4,7 @@ description: The prepare command creates a .nuxt directory in your application a
 links:
   - label: Source
     icon: i-simple-icons-github
-    to: https://github.com/nuxt/cli/blob/main/packages/nuxi/src/commands/prepare.ts
+    to: https://github.com/nuxt/cli/blob/main/packages/nuxt-cli/src/commands/prepare.ts
     size: xs
 ---
 

--- a/docs/4.api/4.commands/preview.md
+++ b/docs/4.api/4.commands/preview.md
@@ -4,7 +4,7 @@ description: The preview command starts a server to preview your application aft
 links:
   - label: Source
     icon: i-simple-icons-github
-    to: https://github.com/nuxt/cli/blob/main/packages/nuxi/src/commands/preview.ts
+    to: https://github.com/nuxt/cli/blob/main/packages/nuxt-cli/src/commands/preview.ts
     size: xs
 ---
 

--- a/docs/4.api/4.commands/test.md
+++ b/docs/4.api/4.commands/test.md
@@ -4,7 +4,7 @@ description: The test command runs tests using @nuxt/test-utils.
 links:
   - label: Source
     icon: i-simple-icons-github
-    to: https://github.com/nuxt/cli/blob/main/packages/nuxi/src/commands/test.ts
+    to: https://github.com/nuxt/cli/blob/main/packages/nuxt-cli/src/commands/test.ts
     size: xs
 ---
 

--- a/docs/4.api/4.commands/typecheck.md
+++ b/docs/4.api/4.commands/typecheck.md
@@ -4,7 +4,7 @@ description: The typecheck command runs vue-tsc to check types throughout your a
 links:
   - label: Source
     icon: i-simple-icons-github
-    to: https://github.com/nuxt/cli/blob/main/packages/nuxi/src/commands/typecheck.ts
+    to: https://github.com/nuxt/cli/blob/main/packages/nuxt-cli/src/commands/typecheck.ts
     size: xs
 ---
 

--- a/docs/4.api/4.commands/upgrade.md
+++ b/docs/4.api/4.commands/upgrade.md
@@ -4,7 +4,7 @@ description: The upgrade command upgrades Nuxt to the latest version.
 links:
   - label: Source
     icon: i-simple-icons-github
-    to: https://github.com/nuxt/cli/blob/main/packages/nuxi/src/commands/upgrade.ts
+    to: https://github.com/nuxt/cli/blob/main/packages/nuxt-cli/src/commands/upgrade.ts
     size: xs
 ---
 


### PR DESCRIPTION
## Problem

All 15 command-reference pages under `docs/4.api/4.commands/` have a front-matter **Source** link pointing at `https://github.com/nuxt/cli/blob/main/packages/nuxi/src/commands/<cmd>.ts`. That path 404s — the `nuxi` package was renamed to `nuxt-cli`.

Example (`build.md` line 7): the stale link returns 404; `packages/nuxt-cli/src/commands/build.ts` returns 200.

Self-sourced docs drift (no linked issue).

## Triage / Root cause

The `nuxi` → `nuxt-cli` package rename in the `nuxt/cli` repo was not reflected in the Nuxt docs command-reference front-matter `links[].to` URLs. Every affected page uses the same stale path pattern.

## Fix

Replace `packages/nuxi/src/commands` → `packages/nuxt-cli/src/commands` in all 15 `docs/4.api/4.commands/*.md` files. Docs-only; no behavior change.

## Verification

- `python3 scripts/preflight_ship.py --repo nuxt/nuxt --branch main --file docs/4.api/4.commands/build.md --must-contain 'packages/nuxi/src/commands/build.ts' --must-not-contain 'packages/nuxt-cli/src/commands/build.ts'` → PREFLIGHT CLEAR before edit
- Manual HTTP check: stale `nuxi` path 404, corrected `nuxt-cli` path 200 on `nuxt/cli`
- `gh pr list --search "nuxi nuxt-cli"` → no open duplicate PRs touching these files

## Notes / Risks

- Scout-verified candidate from fleet recon ([EST-1639](/EST/issues/EST-1639) handoff); contention check clean.
- Secondary candidate (vue-router API link drift in other docs pages) intentionally deferred to a follow-up PR per same-repo gap policy.

Made with [Cursor](https://cursor.com)