### PR TITLE
feat(nuxt): make file names clickable 🖱️

### DIFF
--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -90,6 +90,7 @@
     "@unhead/vue": "catalog:app-runtime",
     "@vue/shared": "catalog:app-runtime",
     "chokidar": "catalog:build",
+    "clickable-path": "catalog:build",
     "compatx": "catalog:build",
     "consola": "catalog:app-runtime",
     "cookie-es": "catalog:app-runtime",

--- a/packages/nuxt/src/compiler/module.ts
+++ b/packages/nuxt/src/compiler/module.ts
@@ -2,7 +2,7 @@ import { addBuildPlugin, buildDiagnostics, defineNuxtModule, resolveFiles, resol
 import type { CompilerScanDir, KeyedFunction, NuxtCompilerOptions } from '@nuxt/schema'
 import type { ScanPlugin, ScanPluginFilter } from './types.ts'
 import { resolve } from 'pathe'
-import { DECLARATION_EXTENSIONS, isDirectorySync, normalizeExtension, toArray } from '../utils.ts'
+import { DECLARATION_EXTENSIONS, isDirectorySync, linkToAlias, normalizeExtension, toArray } from '../utils.ts'
 import { createScanPluginContext, matchWithStringOrRegex } from './utils.ts'
 import { readFile } from 'node:fs/promises'
 import { KeyedFunctionFactoriesPlugin, KeyedFunctionFactoriesScanPlugin, scanFileForFactories } from './plugins/keyed-function-factories.ts'
@@ -124,11 +124,11 @@ export default defineNuxtModule<Partial<NuxtCompilerOptions>>({
             try {
               await plugin.scan.call(pluginScanThisContext, { id: filePath, code: contents, nuxt, autoImportsToSources })
             } catch (e) {
-              buildDiagnostics.NUXT_B1005({ plugin: plugin.name, file: filePath, cause: e })
+              buildDiagnostics.NUXT_B1005({ plugin: plugin.name, file: linkToAlias(filePath, nuxt), cause: e })
             }
           }))
         } catch (e) {
-          buildDiagnostics.NUXT_B1006({ file: filePath, cause: e })
+          buildDiagnostics.NUXT_B1006({ file: linkToAlias(filePath, nuxt), cause: e })
         }
       }
 

--- a/packages/nuxt/src/compiler/plugins/keyed-function-factories.ts
+++ b/packages/nuxt/src/compiler/plugins/keyed-function-factories.ts
@@ -1,6 +1,6 @@
 import { buildDiagnostics, resolveAlias } from '@nuxt/kit'
 import escapeRE from 'escape-string-regexp'
-import { JS_EXT_RE, MACRO_QUERY_RE, NUXT_LIB_RE, STYLE_QUERY_RE, logger, stripExtension } from '../../utils.ts'
+import { JS_EXT_RE, MACRO_QUERY_RE, NUXT_LIB_RE, STYLE_QUERY_RE, linkToAlias, logger, stripExtension } from '../../utils.ts'
 import type { ESTree } from 'rolldown/utils'
 import { isAbsolute, join, parse } from 'pathe'
 import { createUnplugin } from 'unplugin'
@@ -133,7 +133,7 @@ function createFactoryProcessor (
     for (const parsedFactoryCall of parsedFactoryCalls) {
       const factoryMeta = getFactoryByLocalName(parsedFactoryCall.factoryName)
       if (!factoryMeta) {
-        buildDiagnostics.NUXT_B1008({ function: parsedFactoryCall.functionName, file: filePath })
+        buildDiagnostics.NUXT_B1008({ function: parsedFactoryCall.functionName, file: linkToAlias(filePath) })
         continue
       }
 
@@ -211,7 +211,7 @@ function createFactoryProcessor (
         continue
       }
 
-      logger.debug(`[nuxt:compiler] The factory function \`${factoryMeta.name}\` used to create \`${parsedFactoryCall.functionName}\` in file \`${filePath}\` is not imported and is not in auto-imports. Skipping processing.`)
+      logger.debug(`[nuxt:compiler] The factory function \`${factoryMeta.name}\` used to create \`${parsedFactoryCall.functionName}\` in file \`${linkToAlias(filePath)}\` is not imported and is not in auto-imports. Skipping processing.`)
     }
   }
 

--- a/packages/nuxt/src/components/module.ts
+++ b/packages/nuxt/src/components/module.ts
@@ -4,7 +4,7 @@ import { addBuildPlugin, addImportsSources, addPluginTemplate, addTemplate, addT
 
 import { resolveModulePath } from 'exsolve'
 import { distDir } from '../dirs.ts'
-import { DECLARATION_EXTENSIONS, isDirectorySync, logger } from '../utils.ts'
+import { DECLARATION_EXTENSIONS, isDirectorySync, linkToAlias, logger } from '../utils.ts'
 import { lazyHydrationMacroPreset } from '../imports/presets.ts'
 import { componentNamesTemplate, componentsDeclarationTemplate, componentsIslandsTemplate, componentsMetadataTemplate, componentsPluginTemplate, componentsTypeTemplate } from './templates.ts'
 import { scanComponents } from './scan.ts'
@@ -99,7 +99,7 @@ export default defineNuxtModule<ComponentsOptions>({
 
         const present = isDirectorySync(dirPath)
         if (!present && !DEFAULT_COMPONENTS_DIRS_RE.test(dirOptions.path)) {
-          componentDiagnostics.NUXT_B3001({ dirPath })
+          componentDiagnostics.NUXT_B3001({ dirPath: linkToAlias(dirPath, nuxt) })
         }
 
         const inNodeModules = dirPath.includes('node_modules')
@@ -185,7 +185,7 @@ export default defineNuxtModule<ComponentsOptions>({
 
       const path = resolve(nuxt.options.srcDir, relativePath)
       if (componentDirs.some(dir => dir.path === path)) {
-        logger.info(`Directory \`${relativePath}/\` ${event === 'addDir' ? 'created' : 'removed'}`)
+        logger.info(`Directory \`${linkToAlias(path, nuxt)}/\` ${event === 'addDir' ? 'created' : 'removed'}`)
         return nuxt.callHook('restart')
       }
     })

--- a/packages/nuxt/src/components/plugins/islands-transform.ts
+++ b/packages/nuxt/src/components/plugins/islands-transform.ts
@@ -1,5 +1,6 @@
 import type { Component } from '@nuxt/schema'
 import { componentDiagnostics } from '@nuxt/kit'
+import { linkToAlias } from '../../utils.ts'
 import { createUnplugin } from 'unplugin'
 import { generateTransform, rolldownString } from 'rolldown-string'
 import { ELEMENT_NODE, parse, walk, walkSync } from 'ultrahtml'
@@ -193,9 +194,9 @@ export const IslandsTransformPlugin = (options: ServerOnlyComponentTransformPlug
 
         if (hasNuxtClient) {
           if (!options.selectiveClient) {
-            componentDiagnostics.NUXT_B3007({ file: id })
+            componentDiagnostics.NUXT_B3007({ file: linkToAlias(id) })
           } else if (!isVite) {
-            componentDiagnostics.NUXT_B3013({ file: id })
+            componentDiagnostics.NUXT_B3013({ file: linkToAlias(id) })
           }
         }
 

--- a/packages/nuxt/src/components/plugins/lazy-hydration-transform.ts
+++ b/packages/nuxt/src/components/plugins/lazy-hydration-transform.ts
@@ -6,7 +6,7 @@ import { componentDiagnostics, tryUseNuxt } from '@nuxt/kit'
 import { parse, walk } from 'ultrahtml'
 import { ScopeTracker, parseAndWalk } from 'oxc-walker'
 import { isVue } from '../../core/utils/index.ts'
-import { resolveToAlias } from '../../utils.ts'
+import { linkToAlias, offsetToPosition } from '../../utils.ts'
 import type { Component, ComponentsOptions } from 'nuxt/schema'
 
 interface LoaderOptions {
@@ -92,7 +92,7 @@ export const LazyHydrationTransformPlugin = (options: LoaderOptions) => createUn
               const prop = camelCase(isDynamic ? attr.slice(1) : attr)
               if (prop in hydrationStrategyMap) {
                 if (strategy) {
-                  componentDiagnostics.NUXT_B3005({ component: node.name, file: id })
+                  componentDiagnostics.NUXT_B3005({ component: node.name, file: linkToAlias(id, nuxt, offsetToPosition(code, node.loc[0].start + offset)) })
                 } else {
                   strategy = hydrationStrategyMap[prop as keyof typeof hydrationStrategyMap]
                 }
@@ -101,7 +101,7 @@ export const LazyHydrationTransformPlugin = (options: LoaderOptions) => createUn
 
             if (strategy && !/^(?:Lazy|lazy-)/.test(node.name)) {
               if (node.name !== 'template' && (nuxt?.options.dev || nuxt?.options.test)) {
-                const relativePath = resolveToAlias(id, nuxt)
+                const relativePath = linkToAlias(id, nuxt, offsetToPosition(code, node.loc[0].start + offset))
                 componentDiagnostics.NUXT_B3006({ component: node.name, file: relativePath, lazyName: `Lazy${pascalCase(node.name)}` })
               }
               return

--- a/packages/nuxt/src/components/plugins/loader.ts
+++ b/packages/nuxt/src/components/plugins/loader.ts
@@ -7,7 +7,7 @@ import { relative } from 'pathe'
 import { componentDiagnostics, tryUseNuxt } from '@nuxt/kit'
 import { QUOTE_RE, SX_RE, isVue } from '../../core/utils/index.ts'
 import { installNuxtModule } from '../../core/features.ts'
-import { resolveToAlias } from '../../utils.ts'
+import { linkToAlias } from '../../utils.ts'
 import type { Component, ComponentsOptions } from 'nuxt/schema'
 
 interface LoaderOptions {
@@ -68,7 +68,7 @@ export const LoaderPlugin = (options: LoaderOptions) => createUnplugin(() => {
           const internalInstall = ((component as any)._internal_install) as string
           if (internalInstall && nuxt?.options.test === false) {
             if (!nuxt.options.dev) {
-              throw componentDiagnostics.NUXT_B3004({ file: resolveToAlias(id, nuxt), component: component.pascalName, requiredModule: internalInstall })
+              throw componentDiagnostics.NUXT_B3004({ file: linkToAlias(id, nuxt), component: component.pascalName, requiredModule: internalInstall })
             }
             installNuxtModule(internalInstall)
           }

--- a/packages/nuxt/src/components/scan.ts
+++ b/packages/nuxt/src/components/scan.ts
@@ -6,7 +6,7 @@ import { componentDiagnostics, isIgnored, useNuxt } from '@nuxt/kit'
 import { withTrailingSlash } from 'ufo'
 
 import { QUOTE_RE, resolveComponentNameSegments } from '../core/utils/index.ts'
-import { resolveToAlias } from '../utils.ts'
+import { linkToAlias, resolveToAlias } from '../utils.ts'
 import type { Component, ComponentsDir } from 'nuxt/schema'
 
 const ISLAND_RE = /\.island(?:\.global)?$/
@@ -102,7 +102,7 @@ export async function scanComponents (dirs: ComponentsDir[], srcDir: string): Pr
       const pascalName = pascalCase(componentNameSegments)
 
       if (LAZY_COMPONENT_NAME_REGEX.test(pascalName)) {
-        componentDiagnostics.NUXT_B3009({ component: pascalName, filePath })
+        componentDiagnostics.NUXT_B3009({ component: pascalName, filePath: linkToAlias(filePath) })
       }
 
       if (resolvedNames.has(pascalName + suffix) || resolvedNames.has(pascalName)) {
@@ -142,7 +142,7 @@ export async function scanComponents (dirs: ComponentsDir[], srcDir: string): Pr
 
       // Ignore files like `~/components/index.vue` which end up not having a name at all
       if (!pascalName) {
-        componentDiagnostics.NUXT_B3010({ filePath: resolveToAlias(filePath) })
+        componentDiagnostics.NUXT_B3010({ filePath: linkToAlias(filePath) })
         continue
       }
 
@@ -182,7 +182,7 @@ export async function scanComponents (dirs: ComponentsDir[], srcDir: string): Pr
 }
 
 function warnAboutDuplicateComponent (componentName: string, filePath: string, duplicatePath: string) {
-  componentDiagnostics.NUXT_B3011({ component: componentName, filePath, duplicatePath })
+  componentDiagnostics.NUXT_B3011({ component: componentName, filePath: linkToAlias(filePath), duplicatePath: linkToAlias(duplicatePath) })
 }
 
 const LAZY_COMPONENT_NAME_REGEX = /^Lazy(?=[A-Z])/

--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -1,12 +1,12 @@
 import { promises as fsp, mkdirSync, writeFileSync } from 'node:fs'
 import process from 'node:process'
 import { performance } from 'node:perf_hooks'
-import { dirname, join, relative, resolve } from 'pathe'
+import { dirname, join, resolve } from 'pathe'
 import { defu } from 'defu'
 import { Diagnostic } from 'nostics'
 import { buildDiagnostics, findPath, getLayerDirectories, normalizePlugin, normalizeTemplate, pageDiagnostics, pluginDiagnostics, resolveFiles, resolvePath } from '@nuxt/kit'
 
-import { logger, resolveToAlias } from '../utils.ts'
+import { linkToAlias, logger } from '../utils.ts'
 import * as defaultTemplates from './templates.ts'
 import { getNameFromPath, hasSuffix, uniqueBy } from './utils/index.ts'
 import type { ExtractedPluginMeta, PluginBuildMode } from './plugins/plugin-metadata.ts'
@@ -93,14 +93,14 @@ export async function generateApp (nuxt: Nuxt, app: NuxtApp, options: { filter?:
     const compileTime = Math.round((perf * 100)) / 100
 
     if ((nuxt.options.debug && nuxt.options.debug.templates) || compileTime > 500) {
-      logger.info(`Compiled \`${template.filename}\` in ${compileTime}ms`)
+      logger.info(`Compiled \`${linkToAlias(fullPath, nuxt)}\` in ${compileTime}ms`)
     }
 
     if (template.modified && template.write) {
       dirs.add(dirname(fullPath))
       writes.push(() => writeFileSync(fullPath, contents, 'utf8'))
       if (nuxt.options.debug && nuxt.options.debug.templates) {
-        logger.info(`Writing \`${template.filename}\` to \`${fullPath}\``)
+        logger.info(`Writing \`${template.filename}\` to \`${linkToAlias(fullPath, nuxt)}\``)
       }
     }
   }
@@ -165,7 +165,7 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
       const name = getNameFromPath(file, dirs.appLayouts)
       if (!name) {
         // Ignore files like `~/layouts/index.vue` which end up not having a name at all
-        pageDiagnostics.NUXT_B4009({ file: resolveToAlias(file, nuxt) })
+        pageDiagnostics.NUXT_B4009({ file: linkToAlias(file, nuxt) })
         continue
       }
       layouts[name] ||= { name, file }
@@ -183,7 +183,7 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
       const name = getNameFromPath(file)
       if (!name) {
         // Ignore files like `~/middleware/index.vue` which end up not having a name at all
-        pageDiagnostics.NUXT_B4010({ file: resolveToAlias(file, nuxt) })
+        pageDiagnostics.NUXT_B4010({ file: linkToAlias(file, nuxt) })
         continue
       }
       middleware.push({ name, path: file, global: hasSuffix(file, '.global') })
@@ -266,7 +266,7 @@ export async function annotatePlugins (nuxt: Nuxt, plugins: NuxtPlugin[]): Promi
         ...plugin,
       })
     } catch (e) {
-      const relativePluginSrc = relative(nuxt.options.rootDir, plugin.src)
+      const relativePluginSrc = linkToAlias(plugin.src, nuxt)
       const code = e instanceof Error ? e.name : ''
       if (code === 'NUXT_B2001' || code === 'NUXT_B2002') {
         pluginDiagnostics.NUXT_B2010({ src: relativePluginSrc })

--- a/packages/nuxt/src/core/external-config-files.ts
+++ b/packages/nuxt/src/core/external-config-files.ts
@@ -1,5 +1,6 @@
 import { configDiagnostics, findPath } from '@nuxt/kit'
 import { basename } from 'pathe'
+import { link } from 'clickable-path'
 
 /**
  * Check for those external configuration files that are not compatible with Nuxt,
@@ -38,5 +39,5 @@ function checkPostCSSConfig () {
 
 async function checkConfigFileExistence (fileName: string, extensions: string[]) {
   const configFile = await findPath(fileName, { extensions }).catch(() => null)
-  return configFile ? basename(configFile) : undefined
+  return configFile ? link(configFile, { formatter: absolute => basename(absolute) }) : undefined
 }

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -22,6 +22,7 @@ import { coerce, satisfies } from 'verkit'
 import { hasTTY, isCI } from 'std-env'
 import { genImport, genString } from 'knitwork'
 import { resolveModulePath } from 'exsolve'
+import { link } from 'clickable-path'
 import type { Nuxt, NuxtHooks, NuxtModule, NuxtOptions } from 'nuxt/schema'
 
 import { installNuxtModule } from '../core/features.ts'
@@ -37,7 +38,7 @@ import { distDir, pkgDir } from '../dirs.ts'
 import { runtimeDependencies } from '../../meta.js'
 import pkg from '../../package.json' with { type: 'json' }
 import { scriptsStubsPreset } from '../imports/presets.ts'
-import { logger } from '../utils.ts'
+import { linkToAlias, logger } from '../utils.ts'
 import { installProxyDispatcher } from './utils/proxy.ts'
 import { createImportProtectionPatterns } from './plugins/import-protection.ts'
 import { UnctxTransformPlugin } from './plugins/unctx.ts'
@@ -843,14 +844,14 @@ export default defineNuxtPlugin({
 
     // Restart Nuxt when new `app/` dir is added
     if (event === 'addDir' && path === resolve(nuxt.options.srcDir, 'app')) {
-      logger.info(`\`${path}/\` ${event === 'addDir' ? 'created' : 'removed'}`)
+      logger.info(`\`${linkToAlias(path, nuxt)}/\` ${event === 'addDir' ? 'created' : 'removed'}`)
       return nuxt.callHook('restart', { hard: true })
     }
 
     // Core Nuxt files: app.vue, error.vue and app.config.ts
     const isFileChange = ['add', 'unlink'].includes(event)
     if (isFileChange && RESTART_RE.test(path)) {
-      logger.info(`\`${path}\` ${event === 'add' ? 'created' : 'removed'}`)
+      logger.info(`\`${linkToAlias(path, nuxt)}\` ${event === 'add' ? 'created' : 'removed'}`)
       return nuxt.callHook('restart')
     }
   })
@@ -1235,8 +1236,9 @@ function warnUnresolvableGlobalCss (nuxt: Nuxt) {
     if (typeof entry !== 'string') { continue }
 
     if (RELATIVE_CSS_ENTRY_RE.test(entry)) {
-      const asAlias = '~/' + relative(nuxt.options.srcDir, resolve(nuxt.options.rootDir, entry))
-      logger.warn(`\`css\` entries are resolved as module ids, not relative to \`nuxt.config\`. Replace \`${entry}\` with ${existsSync(resolve(nuxt.options.rootDir, entry)) ? `\`${asAlias}\`` : 'an aliased or absolute path'}.`)
+      const absolute = resolve(nuxt.options.rootDir, entry)
+      const asAlias = '~/' + relative(nuxt.options.srcDir, absolute)
+      logger.warn(`\`css\` entries are resolved as module ids, not relative to \`nuxt.config\`. Replace \`${entry}\` with ${existsSync(absolute) ? `\`${link(absolute, { formatter: () => asAlias })}\`` : 'an aliased or absolute path'}.`)
       continue
     }
 
@@ -1244,7 +1246,7 @@ function warnUnresolvableGlobalCss (nuxt: Nuxt) {
     // be resolved by builder-specific aliases, so neither can be checked here
     const resolved = resolveAlias(entry, nuxt.options.alias)
     if (isAbsolute(resolved) && !resolved.startsWith(nuxt.options.buildDir) && !existsSync(resolved)) {
-      logger.warn(`\`css\` entry \`${entry}\` could not be found${resolved === entry ? '' : ` (resolved to \`${resolved}\`)`}.`)
+      logger.warn(`\`css\` entry \`${entry}\` could not be found${resolved === entry ? '' : ` (resolved to \`${linkToAlias(resolved, nuxt)}\`)`}.`)
     }
   }
 }

--- a/packages/nuxt/src/core/perf.ts
+++ b/packages/nuxt/src/core/perf.ts
@@ -3,6 +3,7 @@ import process from 'node:process'
 import { mkdirSync, writeFileSync } from 'node:fs'
 import { join, relative } from 'pathe'
 import { consola } from 'consola'
+import { link } from 'clickable-path'
 import { colors } from 'consola/utils'
 import type { Hookable } from 'hookable'
 import type { NuxtHooks } from 'nuxt/schema'
@@ -699,9 +700,9 @@ export class NuxtPerfProfiler {
   writeReport (buildDir: string, options?: { quiet?: boolean }): string {
     const report = this.getReport()
     const reportPath = join(buildDir, 'perf-report.json')
-    const relativeReportPath = relative(process.cwd(), reportPath).replace(/^(?![^.]{1,2}\/)/, './')
+    const relativeReportPath = link(reportPath, { formatter: absolute => relative(process.cwd(), absolute).replace(/^(?![^.]{1,2}\/)/, './') })
     const tracePath = join(buildDir, 'perf-trace.json')
-    const relativeTracePath = relative(process.cwd(), tracePath).replace(/^(?![^.]{1,2}\/)/, './')
+    const relativeTracePath = link(tracePath, { formatter: absolute => relative(process.cwd(), absolute).replace(/^(?![^.]{1,2}\/)/, './') })
     try {
       mkdirSync(buildDir, { recursive: true })
       writeFileSync(reportPath, JSON.stringify(report, null, 2), 'utf-8')

--- a/packages/nuxt/src/core/plugins/plugin-metadata.ts
+++ b/packages/nuxt/src/core/plugins/plugin-metadata.ts
@@ -10,6 +10,7 @@ import type { NuxtAppLiterals, PluginMeta } from '../../app/types'
 import { parseAndWalk } from 'oxc-walker'
 import type { ESTree } from 'rolldown/utils'
 import { pluginDiagnostics } from '@nuxt/kit'
+import { linkToAlias } from '../../utils.ts'
 
 const internalOrderMap = {
   // -50: pre-all (nuxt)
@@ -163,7 +164,7 @@ export const RemovePluginMetadataPlugin = (nuxt: Nuxt, mode: PluginBuildMode) =>
       const filteredDependencies = pluginDependenciesByMode.get(nuxt)?.[mode]?.get(id)
 
       if (!code.trim()) {
-        pluginDiagnostics.NUXT_B2004({ src: plugin.src })
+        pluginDiagnostics.NUXT_B2004({ src: linkToAlias(plugin.src, nuxt) })
 
         return {
           code: 'export default () => {}',
@@ -174,7 +175,7 @@ export const RemovePluginMetadataPlugin = (nuxt: Nuxt, mode: PluginBuildMode) =>
       const exports = findExports(code)
       const defaultExport = exports.find(e => e.type === 'default' || e.names.includes('default'))
       if (!defaultExport) {
-        pluginDiagnostics.NUXT_B2005({ src: plugin.src })
+        pluginDiagnostics.NUXT_B2005({ src: linkToAlias(plugin.src, nuxt) })
         return {
           code: 'export default () => {}',
           map: null,
@@ -222,12 +223,12 @@ export const RemovePluginMetadataPlugin = (nuxt: Nuxt, mode: PluginBuildMode) =>
           }
         })
       } catch (e) {
-        pluginDiagnostics.NUXT_B2006({ src: plugin.src, cause: e })
+        pluginDiagnostics.NUXT_B2006({ src: linkToAlias(plugin.src, nuxt), cause: e })
         return
       }
 
       if (!wrapped) {
-        pluginDiagnostics.NUXT_B2007({ src: plugin.src })
+        pluginDiagnostics.NUXT_B2007({ src: linkToAlias(plugin.src, nuxt) })
       }
 
       return generateTransform(s, id)

--- a/packages/nuxt/src/core/schema.ts
+++ b/packages/nuxt/src/core/schema.ts
@@ -10,6 +10,7 @@ import { generateTypes, resolveSchema as resolveUntypedSchema } from 'untyped'
 import type { Schema, SchemaDefinition } from 'untyped'
 import untypedPlugin from 'untyped/babel-plugin'
 import { createJiti } from 'jiti'
+import { linkToAlias } from '../utils.ts'
 
 export default defineNuxtModule({
   meta: {
@@ -118,7 +119,7 @@ export default defineNuxtModule({
             // TODO: fix type for second argument of `import`
             loadedConfig = await _resolveSchema.import(filePath, { default: true }) as SchemaDefinition
           } catch (err) {
-            configDiagnostics.NUXT_B5005({ filePath, cause: err })
+            configDiagnostics.NUXT_B5005({ filePath: linkToAlias(filePath, nuxt), cause: err })
             continue
           }
           schemaDefs.push(loadedConfig)

--- a/packages/nuxt/src/head/plugins/unhead-imports.ts
+++ b/packages/nuxt/src/head/plugins/unhead-imports.ts
@@ -6,6 +6,7 @@ import { unheadVueComposablesImports } from '@unhead/vue'
 import { genImport } from 'knitwork'
 import { parseAndWalk } from 'oxc-walker'
 import { headDiagnostics } from '@nuxt/kit'
+import { link } from 'clickable-path'
 import { isJS, isVue } from '../../core/utils/index.ts'
 import { distDir } from '../../dirs.ts'
 
@@ -66,7 +67,7 @@ export const UnheadImportsPlugin = (options: UnheadImportsPluginOptions) => crea
         if (importsFromUnhead.length) {
           // warn if user has imported from @unhead/vue themselves
           if (!normalize(id).includes('node_modules')) {
-            headDiagnostics.NUXT_B6001({ module: UnheadVue, file: `./${relative(normalize(options.rootDir), normalize(id))}` })
+            headDiagnostics.NUXT_B6001({ module: UnheadVue, file: link(normalize(id), { cwd: options.rootDir, formatter: absolute => `./${relative(normalize(options.rootDir), absolute)}` }) })
           }
           s.prepend(`${genImport('#app/composables/head', toImports(importsFromUnhead))}\n`)
         }

--- a/packages/nuxt/src/imports/module.ts
+++ b/packages/nuxt/src/imports/module.ts
@@ -6,7 +6,7 @@ import { createUnimport, scanDirExports, toExports, toTypeDeclarationFile, toTyp
 import escapeRE from 'escape-string-regexp'
 import { resolveModulePath } from 'exsolve'
 
-import { isDirectory, logger, resolveToAlias } from '../utils.ts'
+import { isDirectory, linkToAlias, logger } from '../utils.ts'
 import { TransformPlugin } from './transform.ts'
 import { appCompatPresets, defaultPresets } from './presets.ts'
 import type { ImportsOptions, ResolvedNuxtTemplate } from 'nuxt/schema'
@@ -83,7 +83,7 @@ export default defineNuxtModule<Partial<ImportsOptions>>({
 
         const path = resolve(nuxt.options.srcDir, relativePath)
         if (composablesDirs.includes(path)) {
-          logger.info(`Directory \`${relativePath}/\` ${event === 'addDir' ? 'created' : 'removed'}`)
+          logger.info(`Directory \`${linkToAlias(path, nuxt)}/\` ${event === 'addDir' ? 'created' : 'removed'}`)
           return nuxt.callHook('restart')
         }
       })
@@ -168,7 +168,7 @@ export default defineNuxtModule<Partial<ImportsOptions>>({
           if (!nuxtImportSources.has(i.from)) {
             const value = i.as || i.name
             if (nuxtImports.has(value) && (!i.priority || i.priority >= 0 /* default priority */)) {
-              const relativePath = isAbsolute(i.from) ? `${resolveToAlias(i.from, nuxt)}` : i.from
+              const relativePath = isAbsolute(i.from) ? linkToAlias(i.from, nuxt) : i.from
               headDiagnostics.NUXT_B6002({ name: value, file: relativePath })
             }
           }

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -11,7 +11,7 @@ import type { Nitro, NitroRouteConfig } from 'nitro/types'
 import { defu } from 'defu'
 import { isEqual } from 'ohash'
 import { distDir } from '../dirs.ts'
-import { logger, toArray } from '../utils.ts'
+import { linkToAlias, logger, toArray } from '../utils.ts'
 import picomatch from 'picomatch'
 import { rou3PatternToURLPattern, vueRouterToRou3 } from 'unrouting'
 import { resolvePagesRoutes as _resolvePagesRoutes, augmentAndResolve, createPagesContext, normalizeRoutes, relativizeToParent, resolvePageMetaExtractionKeys, resolveRoutePaths, toRou3Patterns } from './utils.ts'
@@ -575,9 +575,9 @@ export default defineNuxtModule({
             warnedConflicts.add(key)
 
             pageDiagnostics.NUXT_B4015({
-              asset: relative(nuxt.options.rootDir, file),
+              asset: linkToAlias(file, nuxt),
               route,
-              page: page && relative(nuxt.options.rootDir, page),
+              page: page && linkToAlias(page, nuxt),
             })
           }
         }

--- a/packages/nuxt/src/pages/plugins/page-meta.ts
+++ b/packages/nuxt/src/pages/plugins/page-meta.ts
@@ -9,6 +9,7 @@ import type { ScopeTrackerNode } from 'oxc-walker'
 import { pageDiagnostics } from '@nuxt/kit'
 import { parseModuleId } from '../../core/utils/plugins.ts'
 import { classifyPageMetaProperty } from '../utils.ts'
+import { linkToAlias } from '../../utils.ts'
 import type { ESTree, ParserOptions } from 'rolldown/utils'
 
 interface PageMetaPluginOptions {
@@ -106,7 +107,7 @@ export const PageMetaPlugin = (options: PageMetaPluginOptions = {}) => createUnp
           if (!code) {
             s.append(options.dev ? (CODE_DEV_EMPTY + CODE_HMR) : CODE_EMPTY)
             const { pathname } = parseModuleId(id)
-            pageDiagnostics.NUXT_B4001({ pathname })
+            pageDiagnostics.NUXT_B4001({ pathname: linkToAlias(pathname) })
           } else {
             s.overwrite(0, code.length, options.dev ? (CODE_DEV_EMPTY + CODE_HMR) : CODE_EMPTY)
           }
@@ -333,7 +334,7 @@ export const PageMetaPlugin = (options: PageMetaPluginOptions = {}) => createUnp
         })
 
         if (instances > 1) {
-          throw pageDiagnostics.NUXT_B4003({ callCount: instances, file: id })
+          throw pageDiagnostics.NUXT_B4003({ callCount: instances, file: linkToAlias(id) })
         }
 
         if (!s.hasChanged() && !code.includes('__nuxt_page_meta')) {

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -14,7 +14,7 @@ import { addFile, buildTree, compileParsePath, removeFile, toVueRouter4 } from '
 import type { BuildTreeOptions, InputFile, RouteTree, VueRouterEmitOptions } from 'unrouting'
 
 import { getLoader } from '../core/utils/index.ts'
-import { logger, toArray } from '../utils.ts'
+import { linkToAlias, logger, offsetToPosition, toArray } from '../utils.ts'
 import type { NuxtPage } from 'nuxt/schema'
 
 // ---------------------------------------------------------------------------
@@ -48,7 +48,7 @@ export function createPagesContext (options: PagesContextOptions = {}): PagesCon
   }
   const emitOptions: VueRouterEmitOptions = {
     onDuplicateRouteName: (_name, file, existingFile) => {
-      pageDiagnostics.NUXT_B4004({ file, existingFile })
+      pageDiagnostics.NUXT_B4004({ file: linkToAlias(file), existingFile: linkToAlias(existingFile) })
     },
     attrs: { mode: modes },
   }
@@ -195,14 +195,18 @@ export async function augmentPages (routes: NuxtPage[], vfs: Record<string, stri
   return ctx.augmentedPages
 }
 
-const SFC_SCRIPT_RE = /<script(?=\s|>)(?<attrs>[^>]*)>(?<content>[\s\S]*?)<\/script\s*>/gi
+const SFC_SCRIPT_RE = /<script(?=\s|>)(?<attrs>[^>]*)>(?<content>[\s\S]*?)<\/script\s*>/dgi
 function extractScriptContent (sfc: string) {
-  const contents: Array<{ loader: 'tsx' | 'ts', code: string }> = []
+  const contents: Array<{ loader: 'tsx' | 'ts', code: string, offset: number }> = []
   for (const match of sfc.matchAll(SFC_SCRIPT_RE)) {
-    if (match?.groups?.content) {
+    const content = match?.groups?.content
+    if (content) {
+      const [contentStart] = match.indices!.groups!.content!
       contents.push({
-        loader: match.groups.attrs && /[tj]sx/.test(match.groups.attrs) ? 'tsx' : 'ts',
-        code: match.groups.content.trim(),
+        loader: match.groups!.attrs && /[tj]sx/.test(match.groups!.attrs) ? 'tsx' : 'ts',
+        code: content.trim(),
+        // offsets within the trimmed script block are reported against the whole SFC
+        offset: contentStart + content.length - content.trimStart().length,
       })
     }
   }
@@ -321,13 +325,14 @@ export function getRouteMeta (contents: string, absolutePath: string, extraExtra
   }
 
   const loader = getLoader(absolutePath)
-  const scriptBlocks = !loader ? null : loader === 'vue' ? extractScriptContent(contents) : [{ code: contents, loader }]
+  const scriptBlocks = !loader ? null : loader === 'vue' ? extractScriptContent(contents) : [{ code: contents, loader, offset: 0 }]
   if (!scriptBlocks) {
     extractCache[absolutePath] = {}
     return {}
   }
 
   const extractedData: Partial<Record<keyof NuxtPage, any>> = {}
+  const fileAt = (offset: number) => linkToAlias(absolutePath, undefined, offsetToPosition(contents, offset))
 
   const extractionKeys = resolvePageMetaExtractionKeys(extraExtractionKeys)
   const dynamicProperties = new Set<keyof NuxtPage>()
@@ -359,7 +364,7 @@ export function getRouteMeta (contents: string, absolutePath: string, extraExtra
       // top-level statement (nested in a condition, or used as an expression) does not mean what
       // it looks like it means.
       if (!topLevelCalls.has(node)) {
-        pageDiagnostics.NUXT_B4007({ fnName, file: absolutePath })
+        pageDiagnostics.NUXT_B4007({ fnName, file: fileAt(script.offset + node.start) })
       }
 
       // The macro transform reads the first call per macro (and errors on a second
@@ -370,7 +375,7 @@ export function getRouteMeta (contents: string, absolutePath: string, extraExtra
       const argument = unwrapStaticExpression(node.arguments[0])
 
       if (argument?.type !== 'ObjectExpression') {
-        pageDiagnostics.NUXT_B4005({ fnName, file: absolutePath, receivedType: String(argument?.type) })
+        pageDiagnostics.NUXT_B4005({ fnName, file: fileAt(script.offset + node.start), receivedType: String(argument?.type) })
         if (fnName === 'definePageMeta') {
           // The macro module resolves the object at runtime, so the route record cannot own it.
           dynamicProperties.add('meta')
@@ -381,7 +386,7 @@ export function getRouteMeta (contents: string, absolutePath: string, extraExtra
       if (fnName === 'defineRouteRules') {
         const { value, serializable } = isSerializable(argument)
         if (!serializable) {
-          pageDiagnostics.NUXT_B4006({ fnName, file: absolutePath })
+          pageDiagnostics.NUXT_B4006({ fnName, file: fileAt(script.offset + node.start) })
           continue
         }
 
@@ -409,7 +414,7 @@ export function getRouteMeta (contents: string, absolutePath: string, extraExtra
         if (!classification) { continue }
 
         if (classification.kind === 'dynamic') {
-          logger.debug(`Skipping extraction of \`${key}\` metadata as it is not JSON-serializable (reading \`${absolutePath}\`).`)
+          logger.debug(`Skipping extraction of \`${key}\` metadata as it is not JSON-serializable (reading \`${fileAt(script.offset + node.start)}\`).`)
           dynamicProperties.add(extraExtractionKeys.has(key) ? 'meta' : key)
           continue
         }

--- a/packages/nuxt/src/utils.ts
+++ b/packages/nuxt/src/utils.ts
@@ -1,6 +1,9 @@
 import { promises as fsp, statSync } from 'node:fs'
 import { tryUseNuxt, useLogger } from '@nuxt/kit'
+import { link } from 'clickable-path'
 import { reverseResolveAlias } from 'pathe/utils'
+
+import type { Nuxt } from '@nuxt/schema'
 
 /** @since 3.9.0 */
 export function toArray<T> (value: T | T[]): T[] {
@@ -69,4 +72,42 @@ export function resolveToAlias (path: string, nuxt = tryUseNuxt()) {
 const strippedAtAliases = {
   '@': '',
   '@@': '',
+}
+
+const QUERY_RE = /\?.*$/
+
+interface Position { line?: number, column?: number }
+
+/** Convert a 0-based offset within `code` into a 1-based line and column. */
+export function offsetToPosition (code: string, offset: number): Position {
+  let line = 1
+  let lineStart = 0
+  const end = Math.min(offset, code.length)
+  for (let i = 0; i < end; i++) {
+    if (code.charCodeAt(i) === 10 /* \n */) {
+      line++
+      lineStart = i + 1
+    }
+  }
+  return { line, column: end - lineStart + 1 }
+}
+
+/**
+ * Format `path` as its aliased form (`~/pages/index.vue`), wrapped in an OSC 8
+ * hyperlink so that supporting terminals can open the file at `line`/`column`.
+ *
+ * Aliased paths cannot be opened by clicking, and the hyperlink target is an
+ * absolute `file://` URL that isn't rendered, so the printed text is unchanged.
+ *
+ * Any module query (`?vue&type=template`) is dropped, as it is not part of the
+ * path on disk.
+ */
+export function linkToAlias (path: string, nuxt: Nuxt | null = tryUseNuxt(), position?: Position) {
+  return link(path.replace(QUERY_RE, ''), {
+    ...position,
+    cwd: nuxt?.options.rootDir,
+    // without a Nuxt instance there are no aliases to resolve against, so the
+    // default `cwd`-relative label applies
+    formatter: nuxt ? (absolute, line, column) => resolveToAlias(absolute, nuxt) + (line === undefined ? '' : `:${line}${column === undefined ? '' : `:${column}`}`) : undefined,
+  })
 }

--- a/packages/nuxt/test/page-metadata.test.ts
+++ b/packages/nuxt/test/page-metadata.test.ts
@@ -557,7 +557,7 @@ describe('page metadata macro position', () => {
     </script>
     `, '/app/pages/conditional.vue')
 
-    expect(warn).toHaveBeenCalledWith({ fnName: 'definePageMeta', file: '/app/pages/conditional.vue' })
+    expect(warn).toHaveBeenCalledWith({ fnName: 'definePageMeta', file: expect.stringMatching(/app\/pages\/conditional\.vue:4:7$/) })
   })
 
   it('should warn when a macro is used as an expression', () => {
@@ -567,7 +567,7 @@ describe('page metadata macro position', () => {
     </script>
     `, '/app/pages/expression.vue')
 
-    expect(warn).toHaveBeenCalledWith({ fnName: 'definePageMeta', file: '/app/pages/expression.vue' })
+    expect(warn).toHaveBeenCalledWith({ fnName: 'definePageMeta', file: expect.stringMatching(/app\/pages\/expression\.vue:3:10$/) })
   })
 
   it('should warn when a macro is called inside a function', () => {
@@ -579,7 +579,7 @@ describe('page metadata macro position', () => {
     </script>
     `, '/app/pages/nested.vue')
 
-    expect(warn).toHaveBeenCalledWith({ fnName: 'defineRouteRules', file: '/app/pages/nested.vue' })
+    expect(warn).toHaveBeenCalledWith({ fnName: 'defineRouteRules', file: expect.stringMatching(/app\/pages\/nested\.vue:4:7$/) })
   })
 })
 
@@ -770,7 +770,7 @@ describe('rewrite page meta', () => {
 </script>
       `
     const res = compileScript(parse(sfc).descriptor, { id: 'component.vue' })
-    expect(() => transformPlugin.transform.handler(res.content, 'component.vue?macro=true')).toThrowErrorMatchingInlineSnapshot(`[NUXT_B4003: \`definePageMeta()\` is called 2 times in \`component.vue?macro=true\`, but only one call is allowed.]`)
+    expect(() => transformPlugin.transform.handler(res.content, 'component.vue?macro=true')).toThrowErrorMatchingInlineSnapshot(`[NUXT_B4003: \`definePageMeta()\` is called 2 times in \`component.vue\`, but only one call is allowed.]`)
   })
 
   it('should extract metadata from vue components', () => {

--- a/packages/nuxt/test/utils.test.ts
+++ b/packages/nuxt/test/utils.test.ts
@@ -1,9 +1,10 @@
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
+import process from 'node:process'
 import { join } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
-import { isDirectory, isDirectorySync } from '../src/utils.ts'
+import { isDirectory, isDirectorySync, linkToAlias, offsetToPosition } from '../src/utils.ts'
 
 describe('isDirectorySync', () => {
   let dir: string
@@ -64,5 +65,29 @@ describe('isDirectory', () => {
 
   it('returns false when a path segment is a file, not a directory (ENOTDIR)', async () => {
     expect(await isDirectory(join(file, 'child'))).toBe(false)
+  })
+})
+
+describe('offsetToPosition', () => {
+  const code = 'first\nsecond\nthird'
+
+  it('returns a 1-based line and column', () => {
+    expect(offsetToPosition(code, 0)).toEqual({ line: 1, column: 1 })
+    expect(offsetToPosition(code, 6)).toEqual({ line: 2, column: 1 })
+    expect(offsetToPosition(code, 9)).toEqual({ line: 2, column: 4 })
+  })
+
+  it('clamps an offset beyond the end of the code', () => {
+    expect(offsetToPosition(code, code.length + 10)).toEqual({ line: 3, column: 6 })
+  })
+})
+
+describe('linkToAlias', () => {
+  it('labels a path with its cwd-relative form and position when there is no Nuxt instance', () => {
+    expect(linkToAlias(join(process.cwd(), 'app/pages/index.vue'), null, { line: 2, column: 4 })).toBe('app/pages/index.vue:2:4')
+  })
+
+  it('strips a module query', () => {
+    expect(linkToAlias(join(process.cwd(), 'app/pages/index.vue?macro=true'), null)).toBe('app/pages/index.vue')
   })
 })

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@nuxt/kit": "workspace:*",
     "@vitejs/plugin-vue": "catalog:vue",
+    "clickable-path": "catalog:build",
     "consola": "catalog:build",
     "defu": "catalog:build",
     "escape-string-regexp": "catalog:build",

--- a/packages/vite/src/plugins/optimize-deps-hint.ts
+++ b/packages/vite/src/plugins/optimize-deps-hint.ts
@@ -3,6 +3,7 @@ import type { Plugin } from 'vite'
 import type { Nuxt } from '@nuxt/schema'
 import { bundlerDiagnostics, logger } from '@nuxt/kit'
 import { colorize } from 'consola/utils'
+import { link } from 'clickable-path'
 
 export function formatIncludeSnippet (deps: string[], cjsDeps?: Set<string>): string {
   if (!deps.length) { return '[]' }
@@ -97,7 +98,7 @@ export function OptimizeDepsHintPlugin (nuxt: Nuxt): Plugin {
         const relativeImporters = new Map<string, string>()
         for (const dep of newDeps) {
           const imp = importerOf.get(dep)
-          if (imp) { relativeImporters.set(dep, './' + relative(rootDir, imp)) }
+          if (imp) { relativeImporters.set(dep, link(imp, { cwd: rootDir, formatter: absolute => './' + relative(rootDir, absolute) })) }
           importerOf.delete(dep)
         }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,9 @@ catalogs:
     chokidar:
       specifier: ^5.0.0
       version: 5.0.0
+    clickable-path:
+      specifier: ^0.0.1
+      version: 0.0.1
     compatx:
       specifier: ^0.2.0
       version: 0.2.0
@@ -1035,6 +1038,9 @@ importers:
       chokidar:
         specifier: catalog:build
         version: 5.0.0
+      clickable-path:
+        specifier: catalog:build
+        version: 0.0.1
       compatx:
         specifier: catalog:build
         version: 0.2.0
@@ -1554,6 +1560,9 @@ importers:
       '@vitejs/plugin-vue':
         specifier: catalog:vue
         version: 6.0.8(vite@8.1.5)(vue@3.5.40(typescript@7.0.2))
+      clickable-path:
+        specifier: catalog:build
+        version: 0.0.1
       consola:
         specifier: catalog:build
         version: 3.4.2
@@ -5681,6 +5690,10 @@ packages:
   cli-table3@0.6.5:
     resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
     engines: {node: 10.* || >= 12.*}
+
+  clickable-path@0.0.1:
+    resolution: {integrity: sha512-PkJJGbxFRoWoxyYImJPPyd/RW+aVe0HQVBPhbp2KUaYZdpVNcIopUcE9UmCNAwdbj9frP5SzundqaePJF4ZWrw==}
+    engines: {node: '>=22.1.0'}
 
   cliui@7.0.4:
     resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
@@ -14929,6 +14942,8 @@ snapshots:
       string-width: 4.2.3
     optionalDependencies:
       '@colors/colors': 1.5.0
+
+  clickable-path@0.0.1: {}
 
   cliui@7.0.4:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -145,6 +145,7 @@ catalogs:
     autoprefixer: ^10.5.4
     c12: ^3.3.4
     chokidar: ^5.0.0
+    clickable-path: ^0.0.1
     compatx: ^0.2.0
     consola: ^3.4.2
     cssnano: ^8.0.2


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this uses [clickable-path](https://github.com/danielroe/clickable-path) to add links to open files in an editor. (files are printed using nuxt aliases which means they often _wouldn't_ have opened previously.

example:

<img width="1544" height="640" alt="CleanShot 2026-07-30 at 09 21 22@2x" src="https://github.com/user-attachments/assets/3865614d-e3ef-4a15-9fe8-55373120ca5a" />

we also now track line/column in the page meta plugin so we can't link _directly_ to the line responsible for the warning...