### PR TITLE
fix(kit): honour nested `apply` and `applyToEnvironment` in vite wrapper

### DIFF
--- a/packages/kit/src/build.ts
+++ b/packages/kit/src/build.ts
@@ -188,22 +188,13 @@ export function addVitePlugin (pluginOrGetter: Arrayable<VitePlugin> | (() => Th
 
     const environmentName = options.server === false ? 'client' : 'ssr'
     const pluginName = plugin.map(p => p.name).join('|')
-    // Vite only honours `apply` and nested `applyToEnvironment` for plugins it
-    // finds in the top-level array, so plugins we nest behind a wrapper have to
-    // be filtered here or dev-only plugins would leak into production builds.
-    const configEnv: ConfigEnv = {
-      command: nuxt.options.dev ? 'serve' : 'build',
-      mode: config.mode || nuxt.options.vite.mode || (nuxt.options.dev ? 'development' : 'production'),
-      isPreview: false,
-    }
-    const applicablePlugins = plugin.filter(p => p && (!p.apply || (typeof p.apply === 'function' ? p.apply(config, configEnv) : p.apply === configEnv.command))) as VitePlugin[]
     config.plugins.push({
       name: `${pluginName}:wrapper`,
       // isomorphic plugins are normally just added to plugins, so only force when `prepend` is set
       enforce: isIsomorphic ? (options?.prepend ? 'pre' : undefined) : (options?.prepend ? 'pre' : 'post'),
       applyToEnvironment (environment) {
         if (isIsomorphic ? environment.name === 'client' || environment.name === 'ssr' : environment.name === environmentName) {
-          return resolveNestedPlugins(applicablePlugins, environment)
+          return resolveNestedPlugins(plugin, config, environment, nuxt)
         }
       },
     })
@@ -226,24 +217,51 @@ export function addVitePlugin (pluginOrGetter: Arrayable<VitePlugin> | (() => Th
 
 type VitePluginEnvironment = Parameters<NonNullable<VitePlugin['applyToEnvironment']>>[0]
 
-async function resolveNestedPlugins (plugins: VitePlugin[], environment: VitePluginEnvironment): Promise<VitePlugin[]> {
+/**
+ * Vite only honours `apply` and `applyToEnvironment` for plugins it finds in the
+ * top-level plugin array, so plugins nested behind a wrapper have to be resolved
+ * by hand or (for example) dev-only plugins would leak into production builds.
+ */
+async function resolveNestedPlugins (plugins: VitePlugin[], config: ViteConfig, environment: VitePluginEnvironment, nuxt: Nuxt): Promise<VitePlugin[]> {
+  const configEnv = resolveConfigEnv(environment, config, nuxt)
+
   const resolved: VitePlugin[] = []
   for (const plugin of plugins) {
-    if (!plugin.applyToEnvironment) {
-      resolved.push(plugin)
+    const { apply, applyToEnvironment } = plugin
+    if (apply && (typeof apply === 'function' ? !apply(config, configEnv) : apply !== configEnv.command)) {
       continue
     }
-    const applied = await plugin.applyToEnvironment(environment)
-    if (!applied) {
-      continue
-    }
+    const applied = applyToEnvironment ? await applyToEnvironment(environment) : true
     if (applied === true) {
       resolved.push(plugin)
       continue
     }
-    resolved.push(...toArray(applied).flat().filter(Boolean) as VitePlugin[])
+    resolved.push(...await flattenPlugins(applied))
   }
   return resolved
+}
+
+/**
+ * `getTopLevelConfig` is only available from Vite 6, and kit is used with older
+ * versions of nuxt (and therefore vite), so fall back to what we can infer.
+ */
+function resolveConfigEnv (environment: VitePluginEnvironment, config: ViteConfig, nuxt: Nuxt): ConfigEnv {
+  const topLevelConfig = (environment as Partial<VitePluginEnvironment>).getTopLevelConfig?.() ?? environment.config as Partial<VitePluginEnvironment['config']> | undefined
+  return {
+    command: topLevelConfig?.command ?? (nuxt.options.dev ? 'serve' : 'build'),
+    mode: topLevelConfig?.mode ?? config.mode ?? nuxt.options.vite?.mode ?? (nuxt.options.dev ? 'development' : 'production'),
+  }
+}
+
+async function flattenPlugins (option: unknown): Promise<VitePlugin[]> {
+  const resolved = await option
+  if (!resolved) {
+    return []
+  }
+  if (Array.isArray(resolved)) {
+    return (await Promise.all(resolved.map(flattenPlugins))).flat()
+  }
+  return [resolved as VitePlugin]
 }
 
 interface AddBuildPluginFactory {

--- a/packages/kit/src/build.ts
+++ b/packages/kit/src/build.ts
@@ -1,5 +1,5 @@
 import type { Configuration as WebpackConfig, WebpackPluginInstance } from 'webpack'
-import type { UserConfig as ViteConfig, Plugin as VitePlugin } from 'vite'
+import type { ConfigEnv, UserConfig as ViteConfig, Plugin as VitePlugin } from 'vite'
 import type { Nuxt, NuxtBuildOutputs } from '@nuxt/schema'
 import { useNuxt } from './context.ts'
 import { toArray } from './utils.ts'
@@ -188,13 +188,22 @@ export function addVitePlugin (pluginOrGetter: Arrayable<VitePlugin> | (() => Th
 
     const environmentName = options.server === false ? 'client' : 'ssr'
     const pluginName = plugin.map(p => p.name).join('|')
+    // Vite only honours `apply` and nested `applyToEnvironment` for plugins it
+    // finds in the top-level array, so plugins we nest behind a wrapper have to
+    // be filtered here or dev-only plugins would leak into production builds.
+    const configEnv: ConfigEnv = {
+      command: nuxt.options.dev ? 'serve' : 'build',
+      mode: config.mode || nuxt.options.vite.mode || (nuxt.options.dev ? 'development' : 'production'),
+      isPreview: false,
+    }
+    const applicablePlugins = plugin.filter(p => p && (!p.apply || (typeof p.apply === 'function' ? p.apply(config, configEnv) : p.apply === configEnv.command))) as VitePlugin[]
     config.plugins.push({
       name: `${pluginName}:wrapper`,
       // isomorphic plugins are normally just added to plugins, so only force when `prepend` is set
       enforce: isIsomorphic ? (options?.prepend ? 'pre' : undefined) : (options?.prepend ? 'pre' : 'post'),
       applyToEnvironment (environment) {
         if (isIsomorphic ? environment.name === 'client' || environment.name === 'ssr' : environment.name === environmentName) {
-          return plugin
+          return resolveNestedPlugins(applicablePlugins, environment)
         }
       },
     })
@@ -213,6 +222,28 @@ export function addVitePlugin (pluginOrGetter: Arrayable<VitePlugin> | (() => Th
       config.plugins![method](...plugin)
     }
   })
+}
+
+type VitePluginEnvironment = Parameters<NonNullable<VitePlugin['applyToEnvironment']>>[0]
+
+async function resolveNestedPlugins (plugins: VitePlugin[], environment: VitePluginEnvironment): Promise<VitePlugin[]> {
+  const resolved: VitePlugin[] = []
+  for (const plugin of plugins) {
+    if (!plugin.applyToEnvironment) {
+      resolved.push(plugin)
+      continue
+    }
+    const applied = await plugin.applyToEnvironment(environment)
+    if (!applied) {
+      continue
+    }
+    if (applied === true) {
+      resolved.push(plugin)
+      continue
+    }
+    resolved.push(...toArray(applied).flat().filter(Boolean) as VitePlugin[])
+  }
+  return resolved
 }
 
 interface AddBuildPluginFactory {

--- a/packages/kit/test/build.test.ts
+++ b/packages/kit/test/build.test.ts
@@ -1,0 +1,65 @@
+import { createHooks } from 'hookable'
+import type { Nuxt } from 'nuxt/schema'
+import type { UserConfig as ViteConfig, Plugin as VitePlugin } from 'vite'
+import { describe, expect, it } from 'vitest'
+
+import { addVitePlugin } from '../src/build.ts'
+import { runWithNuxtContext } from '../src/context.ts'
+
+function createMockNuxt (dev: boolean) {
+  const hooks = createHooks()
+  return {
+    hooks,
+    hook: hooks.hook,
+    callHook: hooks.callHook,
+    options: {
+      dev,
+      build: false,
+      experimental: { nitroViteEnvironment: true },
+      vite: { mode: dev ? 'development' : 'production' },
+    },
+  } as unknown as Nuxt
+}
+
+async function resolveClientPlugins (nuxt: Nuxt, plugins: VitePlugin[]) {
+  const config: ViteConfig = { plugins: [], environments: { client: {}, ssr: {} } }
+  runWithNuxtContext(nuxt, () => addVitePlugin(plugins))
+  await nuxt.callHook('vite:extend', { config } as any)
+
+  const wrapper = config.plugins![0] as VitePlugin
+  const applied = await wrapper.applyToEnvironment!({ name: 'client' } as any)
+  return (Array.isArray(applied) ? applied : []).map(p => (p as VitePlugin).name)
+}
+
+describe('addVitePlugin', () => {
+  it('should filter nested dev-only plugins out of production builds', async () => {
+    const nuxt = createMockNuxt(false)
+    const names = await resolveClientPlugins(nuxt, [
+      { name: 'always' },
+      { name: 'serve-only', apply: 'serve' },
+      { name: 'build-only', apply: 'build' },
+      { name: 'fn-apply', apply: (_config, env) => env.command === 'build' },
+    ])
+    expect(names).toEqual(['always', 'build-only', 'fn-apply'])
+  })
+
+  it('should filter nested build-only plugins out of dev', async () => {
+    const nuxt = createMockNuxt(true)
+    const names = await resolveClientPlugins(nuxt, [
+      { name: 'always' },
+      { name: 'serve-only', apply: 'serve' },
+      { name: 'build-only', apply: 'build' },
+    ])
+    expect(names).toEqual(['always', 'serve-only'])
+  })
+
+  it('should respect a nested plugin own applyToEnvironment', async () => {
+    const nuxt = createMockNuxt(false)
+    const names = await resolveClientPlugins(nuxt, [
+      { name: 'ssr-only', applyToEnvironment: env => env.name === 'ssr' },
+      { name: 'client-only', applyToEnvironment: env => env.name === 'client' },
+      { name: 'replaced', applyToEnvironment: () => [{ name: 'replacement' }] },
+    ])
+    expect(names).toEqual(['client-only', 'replacement'])
+  })
+})

--- a/packages/kit/test/build.test.ts
+++ b/packages/kit/test/build.test.ts
@@ -21,13 +21,19 @@ function createMockNuxt (dev: boolean) {
   } as unknown as Nuxt
 }
 
-async function resolveClientPlugins (nuxt: Nuxt, plugins: VitePlugin[]) {
+async function resolveClientPlugins (nuxt: Nuxt, plugins: VitePlugin[], environment: Record<string, unknown> = {
+  name: 'client',
+  getTopLevelConfig: () => ({
+    command: nuxt.options.dev ? 'serve' : 'build',
+    mode: nuxt.options.dev ? 'development' : 'production',
+  }),
+}) {
   const config: ViteConfig = { plugins: [], environments: { client: {}, ssr: {} } }
   runWithNuxtContext(nuxt, () => addVitePlugin(plugins))
   await nuxt.callHook('vite:extend', { config } as any)
 
   const wrapper = config.plugins![0] as VitePlugin
-  const applied = await wrapper.applyToEnvironment!({ name: 'client' } as any)
+  const applied = await wrapper.applyToEnvironment!(environment as any)
   return (Array.isArray(applied) ? applied : []).map(p => (p as VitePlugin).name)
 }
 
@@ -61,5 +67,24 @@ describe('addVitePlugin', () => {
       { name: 'replaced', applyToEnvironment: () => [{ name: 'replacement' }] },
     ])
     expect(names).toEqual(['client-only', 'replacement'])
+  })
+
+  it('should infer the command when the environment predates `getTopLevelConfig`', async () => {
+    const nuxt = createMockNuxt(true)
+    const names = await resolveClientPlugins(nuxt, [
+      { name: 'always' },
+      { name: 'serve-only', apply: 'serve' },
+      { name: 'build-only', apply: 'build' },
+    ], { name: 'client' })
+    expect(names).toEqual(['always', 'serve-only'])
+  })
+
+  it('should resolve nested and async replacement plugins', async () => {
+    const nuxt = createMockNuxt(false)
+    const names = await resolveClientPlugins(nuxt, [
+      { name: 'deep', applyToEnvironment: () => [[{ name: 'nested' }], Promise.resolve({ name: 'async' })] as any },
+      { name: 'empty', applyToEnvironment: () => [null, undefined, false] as any },
+    ])
+    expect(names).toEqual(['nested', 'async'])
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

we create a wrapper plugin to make client/server plugins work with the environment api, but this was dropping `apply` and `applyToEnvironment`, which are only applied at the top level.