### PR TITLE
fix(vite): start client warmup when nitro runs as a vite environment

### DIFF
--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -351,7 +351,11 @@ function startClientWarmup (nuxt: Nuxt, server: vite.ViteDevServer, entry: strin
   }
 
   // we hook to avoid blocking nitro's build, and do not await crawl so we don't block the dev server
-  useNitro().hooks.hookOnce('compiled', () => { void run() })
+  if (nuxt.options.experimental.nitroViteEnvironment) {
+    nuxt.hooks.hookOnce('build:done', () => { void run() })
+  } else {
+    useNitro().hooks.hookOnce('compiled', () => { void run() })
+  }
 }
 
 async function withLogs (fn: () => Promise<unknown>, message: string, enabled = true) {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this handles a missing piece in https://github.com/nuxt/nuxt/pull/35870 - to start warmup when we are using `nitroViteEnvironment`