### PR TITLE
perf(kit,nuxt): use lazy imports to improve parsing speed

### DIFF
--- a/packages/kit/src/module/define.ts
+++ b/packages/kit/src/module/define.ts
@@ -1,6 +1,5 @@
 import { performance } from 'node:perf_hooks'
 import { defu } from 'defu'
-import { applyDefaults } from 'untyped'
 import type { ModuleDefinition, ModuleOptions, ModuleSetupInstallResult, ModuleSetupReturn, Nuxt, NuxtModule, NuxtOptions, ResolvedModuleOptions } from '@nuxt/schema'
 import { logger } from '../logger.ts'
 import { tryUseNuxt, useNuxt } from '../context.ts'
@@ -69,6 +68,7 @@ function _defineNuxtModule<
     let options = defu(inlineOptions, nuxtConfigOptions, optionsDefaults)
 
     if (module.schema) {
+      const { applyDefaults } = await import('untyped')
       options = await applyDefaults(module.schema, options) as any
     }
 

--- a/packages/kit/src/module/install.ts
+++ b/packages/kit/src/module/install.ts
@@ -286,14 +286,13 @@ export function resolveModuleWithOptions (
 
 type Jiti = ReturnType<typeof import('jiti')['createJiti']>
 
-let _jitiCache: WeakMap<Nuxt, Jiti> | undefined
+let _jitiCache: WeakMap<Nuxt, Promise<Jiti>> | undefined
 
-async function getSharedJiti (nuxt: Nuxt): Promise<Jiti> {
+function getSharedJiti (nuxt: Nuxt): Promise<Jiti> {
   _jitiCache ||= new WeakMap()
   let jiti = _jitiCache.get(nuxt)
   if (!jiti) {
-    const { createJiti } = await import('jiti')
-    jiti = createJiti(nuxt.options.rootDir, { alias: nuxt.options.alias })
+    jiti = import('jiti').then(({ createJiti }) => createJiti(nuxt.options.rootDir, { alias: nuxt.options.alias }))
     _jitiCache.set(nuxt, jiti)
   }
   return jiti

--- a/packages/kit/src/module/install.ts
+++ b/packages/kit/src/module/install.ts
@@ -3,7 +3,6 @@ import { fileURLToPath } from 'node:url'
 import type { ModuleMeta, ModuleOptions, Nuxt, NuxtConfig, NuxtModule, NuxtOptions } from '@nuxt/schema'
 import { dirname, isAbsolute, join, resolve } from 'pathe'
 import { defu } from 'defu'
-import { createJiti } from 'jiti'
 import { lookupNodeModuleSubpath, parseNodeModulePath } from 'mlly'
 import { resolveModulePath, resolveModuleURL } from 'exsolve'
 import { isRelative } from 'ufo'
@@ -285,12 +284,15 @@ export function resolveModuleWithOptions (
   }
 }
 
-let _jitiCache: WeakMap<Nuxt, ReturnType<typeof createJiti>> | undefined
+type Jiti = ReturnType<typeof import('jiti')['createJiti']>
 
-function getSharedJiti (nuxt: Nuxt): ReturnType<typeof createJiti> {
+let _jitiCache: WeakMap<Nuxt, Jiti> | undefined
+
+async function getSharedJiti (nuxt: Nuxt): Promise<Jiti> {
   _jitiCache ||= new WeakMap()
   let jiti = _jitiCache.get(nuxt)
   if (!jiti) {
+    const { createJiti } = await import('jiti')
     jiti = createJiti(nuxt.options.rootDir, { alias: nuxt.options.alias })
     _jitiCache.set(nuxt, jiti)
   }
@@ -311,7 +313,7 @@ export async function loadNuxtModuleInstance (nuxtModule: string | NuxtModule, n
     throw kitDiagnostics.NUXT_B8015({ received: `${typeof nuxtModule} (${JSON.stringify(nuxtModule)})` })
   }
 
-  const jiti = getSharedJiti(nuxt)
+  const jiti = await getSharedJiti(nuxt)
 
   // Import if input is string
   nuxtModule = resolveAlias(nuxtModule, nuxt.options.alias)

--- a/packages/nuxt/src/app/plugins/dev-server-logs.ts
+++ b/packages/nuxt/src/app/plugins/dev-server-logs.ts
@@ -1,6 +1,4 @@
-import { createConsola } from 'consola'
 import type { LogObject } from 'consola'
-import { parse } from 'devalue'
 import type { ParsedTrace } from 'errx'
 
 import { h } from 'vue'
@@ -27,6 +25,7 @@ const plugin: Plugin & ObjectPlugin = defineNuxtPlugin(async (nuxtApp) => {
 
   // Show things in console
   if (devLogs !== 'silent') {
+    const { createConsola } = await import('consola')
     const logger = createConsola({
       formatOptions: {
         colors: true,
@@ -43,8 +42,11 @@ const plugin: Plugin & ObjectPlugin = defineNuxtPlugin(async (nuxtApp) => {
   if (typeof window !== 'undefined') {
     const nuxtLogsElement = document.querySelector(`[data-nuxt-logs="${nuxtApp._id}"]`)
     const content = nuxtLogsElement?.textContent
-    const logs = content ? parse(content, { ...devRevivers, ...nuxtApp._payloadRevivers }) as LogObject[] : []
-    await nuxtApp.hooks.callHook('dev:ssr-logs', logs)
+    if (content) {
+      const { parse } = await import('devalue')
+      const logs = parse(content, { ...devRevivers, ...nuxtApp._payloadRevivers }) as LogObject[]
+      await nuxtApp.hooks.callHook('dev:ssr-logs', logs)
+    }
   }
 })
 

--- a/packages/nuxt/src/core/schema.ts
+++ b/packages/nuxt/src/core/schema.ts
@@ -8,8 +8,8 @@ import { debounce } from 'perfect-debounce'
 import { configDiagnostics, createIsIgnored, createResolver, defineNuxtModule, directoryToURL, getAddDependencyCommand, getLayerDirectories, importModule } from '@nuxt/kit'
 import { generateTypes, resolveSchema as resolveUntypedSchema } from 'untyped'
 import type { Schema, SchemaDefinition } from 'untyped'
-import untypedPlugin from 'untyped/babel-plugin'
 import { createJiti } from 'jiti'
+import type { Jiti } from 'jiti'
 import { linkToAlias } from '../utils.ts'
 
 export default defineNuxtModule({
@@ -19,15 +19,23 @@ export default defineNuxtModule({
   async setup (_, nuxt) {
     const resolver = createResolver(import.meta.url)
 
-    // Initialize untyped/jiti loader
-    const _resolveSchema = createJiti(fileURLToPath(import.meta.url), {
-      fsCache: false,
-      transformOptions: {
-        babel: {
-          plugins: [untypedPlugin],
-        },
-      },
-    })
+    // `untyped/babel-plugin` pulls in the whole of `@babel/core`, so the loader is
+    // only created if a layer actually ships a `nuxt.schema.*` file.
+    let _resolveSchema: Jiti | undefined
+    async function getSchemaLoader () {
+      if (!_resolveSchema) {
+        const { default: untypedPlugin } = await import('untyped/babel-plugin')
+        _resolveSchema = createJiti(fileURLToPath(import.meta.url), {
+          fsCache: false,
+          transformOptions: {
+            babel: {
+              plugins: [untypedPlugin],
+            },
+          },
+        })
+      }
+      return _resolveSchema
+    }
 
     // Register module types
     nuxt.hook('prepare:types', async (ctx) => {
@@ -117,7 +125,7 @@ export default defineNuxtModule({
           let loadedConfig: SchemaDefinition
           try {
             // TODO: fix type for second argument of `import`
-            loadedConfig = await _resolveSchema.import(filePath, { default: true }) as SchemaDefinition
+            loadedConfig = await (await getSchemaLoader()).import(filePath, { default: true }) as SchemaDefinition
           } catch (err) {
             configDiagnostics.NUXT_B5005({ filePath: linkToAlias(filePath, nuxt), cause: err })
             continue

--- a/packages/nuxt/src/core/schema.ts
+++ b/packages/nuxt/src/core/schema.ts
@@ -21,19 +21,16 @@ export default defineNuxtModule({
 
     // `untyped/babel-plugin` pulls in the whole of `@babel/core`, so the loader is
     // only created if a layer actually ships a `nuxt.schema.*` file.
-    let _resolveSchema: Jiti | undefined
-    async function getSchemaLoader () {
-      if (!_resolveSchema) {
-        const { default: untypedPlugin } = await import('untyped/babel-plugin')
-        _resolveSchema = createJiti(fileURLToPath(import.meta.url), {
-          fsCache: false,
-          transformOptions: {
-            babel: {
-              plugins: [untypedPlugin],
-            },
+    let _resolveSchema: Promise<Jiti> | undefined
+    function getSchemaLoader () {
+      _resolveSchema ||= import('untyped/babel-plugin').then(({ default: untypedPlugin }) => createJiti(fileURLToPath(import.meta.url), {
+        fsCache: false,
+        transformOptions: {
+          babel: {
+            plugins: [untypedPlugin],
           },
-        })
-      }
+        },
+      }))
       return _resolveSchema
     }
 

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -5,7 +5,6 @@ import { dirname, join, relative, resolve } from 'pathe'
 import { genImport, genInlineTypeImport, genObjectFromRawEntries, genObjectKey, genString, genTypeImport } from 'knitwork'
 import { joinURL } from 'ufo'
 import { resolveModulePath } from 'exsolve'
-import { createRoutesContext, resolveOptions } from 'vue-router/unplugin'
 import type { EditableTreeNode, Options as TypedRouterOptions } from 'vue-router/unplugin'
 import type { Nitro, NitroRouteConfig } from 'nitro/types'
 import { defu } from 'defu'
@@ -394,6 +393,7 @@ export default defineNuxtModule({
         references.push({ path: declarationFile })
       })
 
+      const { createRoutesContext, resolveOptions } = await import('vue-router/unplugin')
       const context = createRoutesContext(resolveOptions(typedRouterOptions))
       await mkdir(dirname(declarationFile), { recursive: true })
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

noticed when doing some perf testing that the cost of importing `jiti` and `untyped/babel-plugin` are considerable in terms of parsing, when they might not be needed