### PR TITLE
perf(nuxt,kit): skip rewriting unchanged generated files

### DIFF
--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -623,14 +623,25 @@ export async function writeTypes (nuxt: Nuxt): Promise<void> {
 
   await fsp.mkdir(nuxt.options.buildDir, { recursive: true })
   await Promise.all([
-    fsp.writeFile(appTsConfigPath, JSON.stringify(tsConfig, null, 2)),
-    fsp.writeFile(legacyTsConfigPath, JSON.stringify(legacyTsConfig, null, 2)),
-    fsp.writeFile(nodeTsConfigPath, JSON.stringify(nodeTsConfig, null, 2)),
-    fsp.writeFile(sharedTsConfigPath, JSON.stringify(sharedTsConfig, null, 2)),
-    fsp.writeFile(declarationPath, declaration),
-    fsp.writeFile(nodeDeclarationPath, nodeDeclaration),
-    fsp.writeFile(sharedDeclarationPath, sharedDeclaration),
+    writeIfChanged(appTsConfigPath, JSON.stringify(tsConfig, null, 2)),
+    writeIfChanged(legacyTsConfigPath, JSON.stringify(legacyTsConfig, null, 2)),
+    writeIfChanged(nodeTsConfigPath, JSON.stringify(nodeTsConfig, null, 2)),
+    writeIfChanged(sharedTsConfigPath, JSON.stringify(sharedTsConfig, null, 2)),
+    writeIfChanged(declarationPath, declaration),
+    writeIfChanged(nodeDeclarationPath, nodeDeclaration),
+    writeIfChanged(sharedDeclarationPath, sharedDeclaration),
   ])
+}
+
+/**
+ * Types are regenerated on every start and are usually identical, so avoid
+ * touching the files: an unchanged mtime keeps editors and `tsc --watch` from
+ * redoing work they have already done.
+ */
+async function writeIfChanged (path: string, contents: string) {
+  const existing = await fsp.readFile(path, 'utf8').catch(() => undefined)
+  if (existing === contents) { return }
+  await fsp.writeFile(path, contents)
 }
 
 /**

--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -1,4 +1,4 @@
-import { promises as fsp, mkdirSync, writeFileSync } from 'node:fs'
+import { promises as fsp, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import process from 'node:process'
 import { performance } from 'node:perf_hooks'
 import { dirname, join, relative, resolve } from 'pathe'
@@ -96,7 +96,7 @@ export async function generateApp (nuxt: Nuxt, app: NuxtApp, options: { filter?:
       logger.info(`Compiled \`${template.filename}\` in ${compileTime}ms`)
     }
 
-    if (template.modified && template.write) {
+    if (template.modified && template.write && !matchesDisk(fullPath, contents)) {
       dirs.add(dirname(fullPath))
       writes.push(() => writeFileSync(fullPath, contents, 'utf8'))
       if (nuxt.options.debug && nuxt.options.debug.templates) {
@@ -119,6 +119,20 @@ export async function generateApp (nuxt: Nuxt, app: NuxtApp, options: { filter?:
 
   if (changedTemplates.length) {
     await nuxt.callHook('app:templatesGenerated', app, changedTemplates, options)
+  }
+}
+
+/**
+ * On a fresh start the in-memory comparison always reports a template as
+ * modified, so check the file we are about to overwrite: an unchanged
+ * `buildDir` keeps its mtimes stable for anything downstream that caches
+ * against them.
+ */
+function matchesDisk (path: string, contents: string) {
+  try {
+    return readFileSync(path, 'utf8') === contents
+  } catch {
+    return false
   }
 }
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

to avoid creating watch events, we only write template

this is worth it because most `write: true` templates are unchanged (e.g. they are type declarations) and this makes a particular difference when restarting the dev server