### PR TITLE
x

### DIFF
--- a/packages/vite/src/plugins/resolve-deep-imports.ts
+++ b/packages/vite/src/plugins/resolve-deep-imports.ts
@@ -41,8 +41,9 @@ export function ResolveDeepImportsPlugin (nuxt: Nuxt): Plugin {
           ],
         },
       },
-      async handler (id, importer) {
-        if (!importer || (!isAbsolute(importer) && !VIRTUAL_RE.test(importer))) {
+      async handler (id, importer, options) {
+        // let Vite resolve fallback entry probes (e.g. `index.html`) itself
+        if (options.isEntry || !importer || (!isAbsolute(importer) && !VIRTUAL_RE.test(importer))) {
           return
         }
 

--- a/packages/vite/test/resolve-deep-imports.test.ts
+++ b/packages/vite/test/resolve-deep-imports.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ResolveDeepImportsPlugin } from '../src/plugins/resolve-deep-imports.ts'
+
+vi.mock('@nuxt/kit', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@nuxt/kit')>()
+  return {
+    ...actual,
+    logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  }
+})
+
+const { logger } = await import('@nuxt/kit')
+
+function createNuxt () {
+  return {
+    options: {
+      dev: true,
+      alias: {},
+      appDir: '/project/app',
+      buildDir: '/project/.nuxt',
+      modulesDir: [],
+      build: { templates: [] },
+      experimental: {},
+    },
+  } as any
+}
+
+function createContext () {
+  return {
+    resolve: vi.fn().mockResolvedValue(null),
+    environment: { name: 'client', config: { mode: 'development', resolve: { conditions: [] } } },
+  }
+}
+
+describe('ResolveDeepImportsPlugin', () => {
+  beforeEach(() => {
+    vi.mocked(logger.debug).mockClear()
+  })
+
+  it('skips fallback entry probes such as index.html', async () => {
+    const plugin = ResolveDeepImportsPlugin(createNuxt()) as any
+    const context = createContext()
+
+    const result = await plugin.resolveId.handler.call(context, 'index.html', '/project/app/index.html', { isEntry: true })
+
+    expect(result).toBeUndefined()
+    expect(context.resolve).not.toHaveBeenCalled()
+    expect(logger.debug).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Since Vite 8.2, when no input is configured Vite probes `index.html` as the fallback entry for each environment. That probe reaches `nuxt:resolve-bare-imports`, which reads `index.html` as a bare specifier, fails to resolve it against the app directory, and prints a `Could not resolve id index.html` line in debug output. Entry points are not bare imports, so this skips them in the resolver and leaves the fallback entry for Vite to handle.

Refs #35904