### PR TITLE
perf(vite): skip html entry probes in bare-import resolver

### DIFF
--- a/packages/vite/src/plugins/resolve-deep-imports.ts
+++ b/packages/vite/src/plugins/resolve-deep-imports.ts
@@ -1,15 +1,19 @@
 import { parseNodeModulePath } from 'mlly'
 import { resolveModulePath } from 'exsolve'
-import { isAbsolute, normalize, resolve } from 'pathe'
+import { normalize, resolve } from 'pathe'
 import type { Environment, Plugin } from 'vite'
 import { directoryToURL, logger, resolveAlias } from '@nuxt/kit'
 import escapeRE from 'escape-string-regexp'
 import type { Nuxt } from '@nuxt/schema'
 
 const VIRTUAL_RE = /^\0?virtual:(?:nuxt:)?/
+const ABSOLUTE_RE = /^(?:[/\\](?![/\\])|[/\\]{2}(?!\.)|[A-Za-z]:[/\\])/
+const ABSOLUTE_OR_VIRTUAL_RE = /^(?:[/\\](?![/\\])|[/\\]{2}(?!\.)|[A-Za-z]:[/\\]|\0?virtual:)/
+const HTML_RE = /\.html(?:$|\?)/
 
 export function ResolveDeepImportsPlugin (nuxt: Nuxt): Plugin {
   const exclude: string[] = ['virtual:', '\0virtual:', '/__skip_vite', '@vitest/']
+  const EXCLUDE_RE = new RegExp('^(?:' + exclude.map(e => escapeRE(e)).join('|') + ')')
 
   const conditions: Record<string, undefined | string[]> = {}
 
@@ -34,15 +38,16 @@ export function ResolveDeepImportsPlugin (nuxt: Nuxt): Plugin {
     resolveId: {
       filter: {
         id: {
-          exclude: [
-            // absolute path
-            /^[/\\](?![/\\])|^[/\\]{2}(?!\.)|^[A-Z]:[/\\]/i,
-            ...exclude.map(e => new RegExp('^' + escapeRE(e))),
-          ],
+          exclude: [ABSOLUTE_RE, EXCLUDE_RE],
         },
       },
-      async handler (id, importer) {
-        if (!importer || (!isAbsolute(importer) && !VIRTUAL_RE.test(importer))) {
+      async handler (id, importer, options) {
+        // Vite probes `index.html` as a fallback entry when no input is configured; it is not a bare import
+        if (options.isEntry && HTML_RE.test(id)) {
+          return
+        }
+
+        if (!importer || !ABSOLUTE_OR_VIRTUAL_RE.test(importer)) {
           return
         }
 

--- a/packages/vite/src/plugins/resolve-deep-imports.ts
+++ b/packages/vite/src/plugins/resolve-deep-imports.ts
@@ -7,7 +7,7 @@ import escapeRE from 'escape-string-regexp'
 import type { Nuxt } from '@nuxt/schema'
 
 const VIRTUAL_RE = /^\0?virtual:(?:nuxt:)?/
-const ABSOLUTE_RE = /^(?:[/\\](?![/\\])|[/\\]{2}(?!\.)|[A-Za-z]:[/\\])/
+const ABSOLUTE_RE = /^(?:[/\\](?![/\\])|[/\\]{2}(?!\.)|[A-Z]:[/\\])/i
 const ABSOLUTE_OR_VIRTUAL_RE = /^(?:[/\\](?![/\\])|[/\\]{2}(?!\.)|[A-Za-z]:[/\\]|\0?virtual:)/
 const HTML_RE = /\.html(?:$|\?)/
 

--- a/packages/vite/test/resolve-deep-imports.test.ts
+++ b/packages/vite/test/resolve-deep-imports.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ResolveDeepImportsPlugin } from '../src/plugins/resolve-deep-imports.ts'
+
+vi.mock('@nuxt/kit', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@nuxt/kit')>()
+  return {
+    ...actual,
+    logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  }
+})
+
+const { logger } = await import('@nuxt/kit')
+
+function createNuxt () {
+  return {
+    options: {
+      dev: true,
+      alias: {},
+      appDir: '/project/app',
+      buildDir: '/project/.nuxt',
+      modulesDir: [],
+      build: { templates: [] },
+      experimental: {},
+    },
+  } as any
+}
+
+function createContext (resolved: { id: string } | null = null) {
+  return {
+    resolve: vi.fn().mockResolvedValue(resolved),
+    environment: { name: 'client', config: { mode: 'development', resolve: { conditions: [] } } },
+  }
+}
+
+function resolveId (context: ReturnType<typeof createContext>, id: string, importer?: string, options: { isEntry?: boolean } = {}) {
+  const plugin = ResolveDeepImportsPlugin(createNuxt()) as any
+  return plugin.resolveId.handler.call(context, id, importer, options)
+}
+
+function excluded (id: string) {
+  const plugin = ResolveDeepImportsPlugin(createNuxt()) as any
+  return plugin.resolveId.filter.id.exclude.some((re: RegExp) => re.test(id))
+}
+
+describe('ResolveDeepImportsPlugin', () => {
+  beforeEach(() => {
+    vi.mocked(logger.debug).mockClear()
+  })
+
+  it.each([
+    ['/project/app/app.vue', true],
+    ['C:\\project\\app\\app.vue', true],
+    ['virtual:nuxt:/project/.nuxt/routes.mjs', true],
+    ['\0virtual:nuxt:/project/.nuxt/routes.mjs', true],
+    ['/__skip_vite/foo', true],
+    ['@vitest/coverage-v8', true],
+    ['some-pkg/deep/import', false],
+    ['./relative.mjs', false],
+  ])('filters %s', (id, isExcluded) => {
+    expect(excluded(id)).toBe(isExcluded)
+  })
+
+  it.each(['index.html', 'index.html?html-proxy'])('skips %s entry probes', async (id) => {
+    const context = createContext()
+
+    await expect(resolveId(context, id, '/project/app/index.html', { isEntry: true })).resolves.toBeUndefined()
+    expect(context.resolve).not.toHaveBeenCalled()
+    expect(logger.debug).not.toHaveBeenCalled()
+  })
+
+  it('resolves bare entry specifiers', async () => {
+    const context = createContext({ id: '/project/node_modules/some-pkg/entry.mjs' })
+
+    await expect(resolveId(context, 'some-pkg/entry', '/project/app/entry.mjs', { isEntry: true })).resolves.toStrictEqual({ id: '/project/node_modules/some-pkg/entry.mjs' })
+    expect(context.resolve).toHaveBeenCalledWith('some-pkg/entry', '/project/app', { skipSelf: true })
+  })
+
+  it.each([
+    ['no importer', undefined],
+    ['a bare importer', 'some-other-pkg'],
+    ['a relative importer', './importer.mjs'],
+  ])('ignores ids with %s', async (_, importer) => {
+    const context = createContext()
+
+    await expect(resolveId(context, 'some-pkg', importer)).resolves.toBeUndefined()
+    expect(context.resolve).not.toHaveBeenCalled()
+  })
+
+  it('logs unresolved bare imports', async () => {
+    const context = createContext()
+
+    await expect(resolveId(context, 'does-not-exist', '/project/app/entry.mjs')).resolves.toBeNull()
+    expect(logger.debug).toHaveBeenCalledWith('Could not resolve id', 'does-not-exist', '/project/app/entry.mjs')
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/35904

### 📚 Description

this skips trying to resolve `index.html` (in vite 8.2) and also improves the exclude id filter by precompiling it (and dropping `isAbsolute` call)