### PR TITLE
fix(nuxt): settle asyncData status when bailing

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -964,6 +964,13 @@ function buildAsyncData<
       if (nuxtApp._asyncDataPromises[key]) {
         asyncData._abortController?.abort(new DOMException('AsyncData request cancelled by unmount', 'AbortError'))
         delete nuxtApp._asyncDataPromises[key]
+        // the rejection handler bails out once the promise is detached, so settle the state here
+        if (asyncData.status.value === 'pending') {
+          asyncData.status.value = 'idle'
+        }
+        if (pendingWhenIdle) {
+          asyncData.pending.value = false
+        }
       }
       // TODO: disable in v4 in favour of custom caching strategies
       if (purgeCachedData && !hasCustomGetCachedData) {

--- a/test/nuxt/use-async-data.test.ts
+++ b/test/nuxt/use-async-data.test.ts
@@ -836,6 +836,23 @@ describe('useAsyncData', () => {
     expect(nuxtApp._asyncDataPromises[key]).toBeUndefined()
   })
 
+  it('should settle status when unmounting mid-fetch with custom getCachedData', async () => {
+    const key = `settle-on-unmount-${++counter}`
+    const nuxtApp = useNuxtApp()
+    const scope = effectScope()
+    let res!: ReturnType<typeof useAsyncData>
+    scope.run(() => {
+      res = useAsyncData(key, () => new Promise<string>(() => {}), { getCachedData: () => undefined })
+    })
+    expect(res.status.value).toBe('pending')
+    scope.stop()
+    await nextTick()
+    await nextTick()
+    expect(res.status.value).toBe('idle')
+    expect(res.pending.value).toBe(false)
+    expect(nuxtApp._asyncData[key]?.status.value).toBe('idle')
+  })
+
   it('should be synced with useNuxtData', async () => {
     const { data: nuxtData } = useNuxtData('nuxtdata-sync')
     const promise = useAsyncData('nuxtdata-sync', () => Promise.resolve('test'), { default: () => 'default' })


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/35905

### 📚 Description

a regression from https://github.com/nuxt/nuxt/pull/35328, `status` was staying `pending` forever when we bailed on the fetch. this change resets the `status`/`pending` when we bail.