### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -945,6 +945,7 @@ function buildAsyncData<
       if (nuxtApp._asyncDataPromises[key]) {
         asyncData._abortController?.abort(new DOMException('AsyncData request cancelled by unmount', 'AbortError'))
         delete nuxtApp._asyncDataPromises[key]
+        asyncData.status.value = 'idle'
       }
       // TODO: disable in v4 in favour of custom caching strategies
       if (purgeCachedData && !hasCustomGetCachedData) {

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -388,8 +388,8 @@ export const clientConfigTemplate: NuxtTemplate = {
     return [
       'export const useRuntimeConfig = () => ',
       (!nuxt.options.future.multiApp
-        ? 'window?.__NUXT__?.config || window?.useNuxtApp?.().payload?.config'
-        : `window?.__NUXT__?.[${appId}]?.config || window?.useNuxtApp?.(${appId}).payload?.config`)
+        ? 'typeof window !== \'undefined\' && (window.__NUXT__?.config || window.useNuxtApp?.().payload?.config)'
+        : `typeof window !== 'undefined' && (window.__NUXT__?.[${appId}]?.config || window.useNuxtApp?.(${appId}).payload?.config)`)
         || {},
     ].join('\n')
   },


### PR DESCRIPTION
**Problem**

When a component unmounts while `useAsyncData` is still fetching, `_off()` aborts the request and deletes `nuxtApp._asyncDataPromises[key]`, but `status` stays as `'pending'` forever.

The in-flight `.catch` handler checks `nuxtApp._asyncDataPromises[key] !== promise` as its first guard. After `_off()` deletes the entry, this guard evaluates to `undefined !== promise` = `true`, causing an early return before the `'idle'` status reset at line 913 is reached. The component is gone but the composable's status is stuck.

This is only visible when `getCachedData` is provided — the `clearNuxtDataByKey` purge that runs without it would otherwise mask the bug.

**Fix**

Reset `asyncData.status.value = 'idle'` immediately inside `_off()` after deleting the promise, mirroring the same pattern used in:
- Line 584 (the `enabled: false` abort path)  
- Line 913 (the user-abort path)

```diff
     asyncData._abortController?.abort(...)
     delete nuxtApp._asyncDataPromises[key]
+    asyncData.status.value = 'idle'
```

Refs #35905