### PR TITLE
docs: update .env provider reference from dotenv to c12

### DIFF
--- a/docs/2.directory-structure/2.env.md
+++ b/docs/2.directory-structure/2.env.md
@@ -11,7 +11,7 @@ This file should be added to your [`.gitignore`](/docs/4.x/directory-structure/g
 
 ## Dev, Build and Generate Time
 
-Nuxt CLI has built-in [dotenv](https://github.com/motdotla/dotenv) support in development mode and when running [`nuxt build`](/docs/4.x/api/commands/build) and [`nuxt generate`](/docs/4.x/api/commands/generate).
+Nuxt CLI has built-in `.env` support via [c12](https://github.com/unjs/c12) in development mode and when running [`nuxt build`](/docs/4.x/api/commands/build) and [`nuxt generate`](/docs/4.x/api/commands/generate).
 
 In addition to any process environment variables, if you have a `.env` file in your project root directory, it will be automatically loaded **at dev, build and generate time**. Any environment variables set there will be accessible within your `nuxt.config` file and modules.
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/35910

### 📚 Description

`dotenv` is an older implementation of `.env` that lacks some features like variable expansion (which was added in the same author's later `dotenvx`). Looking at the source of Nuxt, we actually [use `c12`](https://github.com/nuxt/nuxt/blob/7c38104c4c3769e27ec091727db7c6b3286d6586/packages/kit/src/loader/config.ts#L101), which *does* support those features.

Hopefully, this should prevent any future misunderstandings.