### PR TITLE
perf(nuxt): reuse app and component scans for unchanged structures

### DIFF
--- a/packages/nuxt/src/components/module.ts
+++ b/packages/nuxt/src/components/module.ts
@@ -17,7 +17,7 @@ import { TreeShakeTemplatePlugin } from './plugins/tree-shake.ts'
 import { ComponentNamePlugin } from './plugins/component-names.ts'
 import { LazyHydrationTransformPlugin } from './plugins/lazy-hydration-transform.ts'
 import { LazyHydrationMacroTransformPlugin } from './plugins/lazy-hydration-macro-transform.ts'
-import type { Component, ComponentsDir, ComponentsOptions, NuxtPage } from 'nuxt/schema'
+import type { Component, ComponentsDir, ComponentsOptions, Nuxt, NuxtPage } from 'nuxt/schema'
 
 const isPureObjectOrString = (val: unknown): val is object | string => (!Array.isArray(val) && typeof val === 'object') || typeof val === 'string'
 const SLASH_SEPARATOR_RE = /[\\/]/
@@ -194,16 +194,15 @@ export default defineNuxtModule<ComponentsOptions>({
     const serverPlaceholderPath = await findPath(join(distDir, 'app/components/server-placeholder')) ?? join(distDir, 'app/components/server-placeholder')
 
     // Scan components and add to plugin
-    let scannedStructureVersion: number | undefined
+    const scannedStructureVersions = new WeakMap<Nuxt, number>()
     nuxt.hook('app:templates', async (app) => {
       // Component discovery depends only on which files exist, so it can be reused
       // until a file is added or removed.
       const structureVersion = getAppStructureVersion(nuxt)
-      if (nuxt.options.dev && context.components && scannedStructureVersion === structureVersion) {
+      if (nuxt.options.dev && context.components && scannedStructureVersions.get(nuxt) === structureVersion) {
         app.components = context.components
         return
       }
-      scannedStructureVersion = structureVersion
 
       const newComponents = await scanComponents(componentDirs, nuxt.options.srcDir!)
       await nuxt.callHook('components:extend', newComponents)
@@ -238,6 +237,7 @@ export default defineNuxtModule<ComponentsOptions>({
       }
       context.components = newComponents
       app.components = newComponents
+      scannedStructureVersions.set(nuxt, structureVersion)
     })
 
     nuxt.hook('prepare:types', ({ tsConfig }) => {

--- a/packages/nuxt/src/components/module.ts
+++ b/packages/nuxt/src/components/module.ts
@@ -8,6 +8,7 @@ import { DECLARATION_EXTENSIONS, isDirectorySync, linkToAlias, logger } from '..
 import { lazyHydrationMacroPreset } from '../imports/presets.ts'
 import { componentNamesTemplate, componentsDeclarationTemplate, componentsIslandsTemplate, componentsMetadataTemplate, componentsPluginTemplate, componentsTypeTemplate } from './templates.ts'
 import { scanComponents } from './scan.ts'
+import { getAppStructureVersion } from '../core/app.ts'
 
 import { LoaderPlugin } from './plugins/loader.ts'
 import { ComponentsChunkPlugin, IslandsTransformPlugin } from './plugins/islands-transform.ts'
@@ -193,7 +194,17 @@ export default defineNuxtModule<ComponentsOptions>({
     const serverPlaceholderPath = await findPath(join(distDir, 'app/components/server-placeholder')) ?? join(distDir, 'app/components/server-placeholder')
 
     // Scan components and add to plugin
+    let scannedStructureVersion: number | undefined
     nuxt.hook('app:templates', async (app) => {
+      // Component discovery depends only on which files exist, so it can be reused
+      // until a file is added or removed.
+      const structureVersion = getAppStructureVersion(nuxt)
+      if (nuxt.options.dev && context.components && scannedStructureVersion === structureVersion) {
+        app.components = context.components
+        return
+      }
+      scannedStructureVersion = structureVersion
+
       const newComponents = await scanComponents(componentDirs, nuxt.options.srcDir!)
       await nuxt.callHook('components:extend', newComponents)
       const modesByName = new Map<string, Set<string | undefined>>()

--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -23,6 +23,22 @@ export function createApp (nuxt: Nuxt, options: Partial<NuxtApp> = {}): NuxtApp 
   } as unknown as NuxtApp) as NuxtApp
 }
 
+const structureVersions = new WeakMap<Nuxt, number>()
+const resolvedStructureVersions = new WeakMap<NuxtApp, number>()
+
+/**
+ * Version of the app's file structure, bumped whenever a file is added to or removed
+ * from a watched directory. Scans whose result depends only on which files exist
+ * (layouts, middleware, plugins, components) can be reused while it is unchanged.
+ */
+export function getAppStructureVersion (nuxt: Nuxt): number {
+  return structureVersions.get(nuxt) ?? 0
+}
+
+export function invalidateAppStructure (nuxt: Nuxt): void {
+  structureVersions.set(nuxt, getAppStructureVersion(nuxt) + 1)
+}
+
 const postTemplates = new Set([
   defaultTemplates.clientPluginTemplate.filename,
   defaultTemplates.serverPluginTemplate.filename,
@@ -30,14 +46,17 @@ const postTemplates = new Set([
 ])
 
 export async function generateApp (nuxt: Nuxt, app: NuxtApp, options: { filter?: (template: ResolvedNuxtTemplate<any>) => boolean } = {}) {
+  const generateStart = performance.now()
   // Resolve app
   await resolveApp(nuxt, app)
+  const resolvedAt = performance.now()
 
   // User templates from options.build.templates
   app.templates = Object.values(defaultTemplates).concat(nuxt.options.build.templates) as NuxtTemplate[]
 
   // Extend templates with hook
   await nuxt.callHook('app:templates', app)
+  const scannedAt = performance.now()
 
   // Normalize templates
   app.templates = app.templates.map(tmpl => normalizeTemplate(tmpl, nuxt.options.buildDir))
@@ -117,6 +136,10 @@ export async function generateApp (nuxt: Nuxt, app: NuxtApp, options: { filter?:
     write()
   }
 
+  if (nuxt.options.debug && nuxt.options.debug.templates) {
+    logger.info(`Generated app in ${Math.round(performance.now() - generateStart)}ms (resolve ${Math.round(resolvedAt - generateStart)}ms, scan ${Math.round(scannedAt - resolvedAt)}ms, compile ${Math.round(performance.now() - scannedAt)}ms), ${changedTemplates.length} template(s) changed`)
+  }
+
   if (changedTemplates.length) {
     await nuxt.callHook('app:templatesGenerated', app, changedTemplates, options)
   }
@@ -155,6 +178,14 @@ async function compileTemplate<T> (template: NuxtTemplate<T>, ctx: { nuxt: Nuxt,
 }
 
 export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
+  // In dev, re-globbing every layer on each save is pure overhead unless a file has
+  // been added or removed since the last resolution.
+  if (nuxt.options.dev) {
+    const version = getAppStructureVersion(nuxt)
+    if (resolvedStructureVersions.get(app) === version) { return }
+    resolvedStructureVersions.set(app, version)
+  }
+
   // resolve layer
   const layerDirs = getLayerDirectories(nuxt)
   const reversedLayerDirs = layerDirs.toReversed()

--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -30,6 +30,10 @@ const resolvedStructureVersions = new WeakMap<NuxtApp, number>()
  * Version of the app's file structure, bumped whenever a file is added to or removed
  * from a watched directory. Scans whose result depends only on which files exist
  * (layouts, middleware, plugins, components) can be reused while it is unchanged.
+ *
+ * While it is unchanged, `app:resolve` and `components:extend` are not re-run in dev.
+ * Modules whose contributions depend on state other than the file tree should call
+ * `updateTemplates()` with no filter to force a full re-resolution.
  */
 export function getAppStructureVersion (nuxt: Nuxt): number {
   return structureVersions.get(nuxt) ?? 0
@@ -180,11 +184,8 @@ async function compileTemplate<T> (template: NuxtTemplate<T>, ctx: { nuxt: Nuxt,
 export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
   // In dev, re-globbing every layer on each save is pure overhead unless a file has
   // been added or removed since the last resolution.
-  if (nuxt.options.dev) {
-    const version = getAppStructureVersion(nuxt)
-    if (resolvedStructureVersions.get(app) === version) { return }
-    resolvedStructureVersions.set(app, version)
-  }
+  const version = getAppStructureVersion(nuxt)
+  if (nuxt.options.dev && resolvedStructureVersions.get(app) === version) { return }
 
   // resolve layer
   const layerDirs = getLayerDirectories(nuxt)
@@ -280,6 +281,10 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
   app.middleware = uniqueBy(await resolvePaths(nuxt, app.middleware, 'path'), 'name')
   app.plugins = uniqueBy(await resolvePaths(nuxt, app.plugins, 'src'), 'src')
   app.configs = [...new Set(app.configs)]
+
+  // committed only once resolution has fully succeeded, so a throwing `app:resolve`
+  // hook doesn't leave a partially resolved app cached for subsequent rebuilds
+  resolvedStructureVersions.set(app, version)
 }
 
 function resolvePaths<Item extends Record<string, any>> (nuxt: Nuxt, items: Item[], key: { [K in keyof Item]: Item[K] extends string ? K : never }[keyof Item]) {

--- a/packages/nuxt/src/core/builder.ts
+++ b/packages/nuxt/src/core/builder.ts
@@ -6,7 +6,7 @@ import { debounce } from 'perfect-debounce'
 import { dirname, join, normalize, relative, resolve } from 'pathe'
 
 import { isDirectory } from '../utils.ts'
-import { generateApp as _generateApp, createApp } from './app.ts'
+import { generateApp as _generateApp, createApp, invalidateAppStructure } from './app.ts'
 import { checkForExternalConfigurationFiles } from './external-config-files.ts'
 import { createChangedFileFilter } from './template-dependencies.ts'
 import { cleanupCaches, getVueHash } from './cache.ts'
@@ -46,6 +46,10 @@ export async function build (nuxt: Nuxt): Promise<void> {
       await Promise.allSettled(writes)
     })
     nuxt.hook('builder:watch', async (event, relativePath) => {
+      if (event !== 'change') {
+        invalidateAppStructure(nuxt)
+      }
+
       // Unset mainComponent and errorComponent if app or error component is changed
       if (event === 'add' || event === 'unlink') {
         const path = resolve(nuxt.options.srcDir, relativePath)
@@ -75,6 +79,8 @@ export async function build (nuxt: Nuxt): Promise<void> {
     nuxt.hook('builder:generateApp', (options) => {
       // Bypass debounce if we are selectively invalidating templates
       if (options) { return track(() => _generateApp(nuxt, app, options)) }
+      // An unfiltered request is a request to rebuild everything, including scans
+      invalidateAppStructure(nuxt)
       return track(() => generateApp())
     })
   }

--- a/packages/nuxt/test/app.test.ts
+++ b/packages/nuxt/test/app.test.ts
@@ -3,7 +3,7 @@ import { randomUUID } from 'node:crypto'
 import { afterAll, describe, expect, it, vi } from 'vitest'
 import { dirname, join, resolve } from 'pathe'
 import { findWorkspaceDir } from 'pkg-types'
-import { createApp, generateApp, resolveApp } from '../src/core/app.ts'
+import { createApp, generateApp, invalidateAppStructure, resolveApp } from '../src/core/app.ts'
 import { loadNuxt } from '../src/index.ts'
 
 const repoRoot = await findWorkspaceDir()
@@ -333,6 +333,64 @@ describe('resolveApp', () => {
 
     await nuxt.close()
     await rm(rootDir, { recursive: true, force: true })
+  })
+
+  it('reuses the previous resolution in dev until the app structure is invalidated', async () => {
+    const rootDir = resolve(repoRoot, 'node_modules/.fixture', randomUUID())
+    await mkdir(join(rootDir, 'app/layouts'), { recursive: true })
+    await writeFile(join(rootDir, 'nuxt.config.ts'), 'export default {}')
+    await writeFile(join(rootDir, 'app/layouts/default.vue'), '<template><div /></template>')
+
+    const nuxt = await loadNuxt({ cwd: rootDir, overrides: { dev: true } })
+    const app = createApp(nuxt)
+
+    let resolutions = 0
+    nuxt.hook('app:resolve', () => { resolutions++ })
+
+    try {
+      await resolveApp(nuxt, app)
+      expect(resolutions).toBe(1)
+
+      await resolveApp(nuxt, app)
+      expect(resolutions).toBe(1)
+
+      await writeFile(join(rootDir, 'app/layouts/other.vue'), '<template><div /></template>')
+      invalidateAppStructure(nuxt)
+
+      await resolveApp(nuxt, app)
+      expect(resolutions).toBe(2)
+      expect(Object.keys(app.layouts).sort()).toEqual(['default', 'other'])
+    } finally {
+      await nuxt.close()
+      await rm(rootDir, { recursive: true, force: true })
+    }
+  })
+
+  it('does not cache the resolution when it fails', async () => {
+    const rootDir = resolve(repoRoot, 'node_modules/.fixture', randomUUID())
+    await mkdir(rootDir, { recursive: true })
+    await writeFile(join(rootDir, 'nuxt.config.ts'), 'export default {}')
+
+    const nuxt = await loadNuxt({ cwd: rootDir, overrides: { dev: true } })
+    const app = createApp(nuxt)
+
+    let shouldThrow = true
+    let resolutions = 0
+    nuxt.hook('app:resolve', () => {
+      resolutions++
+      if (shouldThrow) { throw new Error('boom') }
+    })
+
+    try {
+      await expect(resolveApp(nuxt, app)).rejects.toThrow('boom')
+
+      shouldThrow = false
+      await resolveApp(nuxt, app)
+      expect(resolutions).toBe(2)
+    } finally {
+      await nuxt.close()
+      await rm(rootDir, { recursive: true, force: true })
+    }
   })
 })
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this is a nice performance improvement 🔥 

we can avoid globbing/scanning the app (via resolveApp) when files have been changed but not added/deleted