### PR TITLE
fix(kit): clone resolved config with klona rather than klona/full

### DIFF
--- a/packages/kit/src/loader/config.ts
+++ b/packages/kit/src/loader/config.ts
@@ -7,7 +7,7 @@ import { loadConfig, setupDotenv } from 'c12'
 import type { NuxtConfig, NuxtOptions } from '@nuxt/schema'
 import { glob } from 'tinyglobby'
 import { createDefu, defu } from 'defu'
-import { klona } from 'klona/full'
+import { klona } from 'klona'
 import { diff } from 'ohash/utils'
 import { basename, dirname, join, normalize, relative, resolve } from 'pathe'
 import { resolveModuleURL } from 'exsolve'
@@ -167,6 +167,9 @@ export async function loadNuxtConfig (opts: LoadNuxtConfigOptions): Promise<Nuxt
     }),
   )
   const { configFile, layers = [], cwd, meta } = resolved
+  // Clone with `klona` rather than `klona/full`: jiti-imported JSON/CJS modules in user config
+  // carry a non-enumerable, self-referential `default` interop property, which `klona/full`
+  // would follow into infinite recursion.
   const nuxtConfig = klona(resolved.config)
 
   // Merge of the layers c12 produced, minus the synthetic layer it creates for `overrides`, so

--- a/packages/kit/test/load-nuxt-config.spec.ts
+++ b/packages/kit/test/load-nuxt-config.spec.ts
@@ -131,6 +131,25 @@ describe('loadNuxtConfig', () => {
     }
   })
 
+  it('should support jiti-imported JSON modules in build-time config', async () => {
+    // jiti gives JSON imports a non-enumerable, self-referential `default` interop
+    // property; cloning the config must not recurse into it (#35729 regression)
+    const tempDir = await mkdtemp(join(tmpdir(), 'nuxt-json-config-'))
+    await writeFile(join(tempDir, 'tsconfig.base.json'), JSON.stringify({ compilerOptions: { strict: true } }))
+    await writeFile(join(tempDir, 'nuxt.config.ts'), `import tsConfig from './tsconfig.base.json'
+
+    export default defineNuxtConfig({
+      nitro: { typescript: { tsConfig } },
+    })\n`)
+
+    try {
+      const config = await loadNuxtConfig({ cwd: tempDir })
+      expect(config.nitro.typescript?.tsConfig?.compilerOptions?.strict).toBe(true)
+    } finally {
+      await rm(tempDir, { recursive: true, force: true })
+    }
+  })
+
   describe('with .env file', () => {
     let tempDir: string
 


### PR DESCRIPTION
jiti gives JSON (and CJS) imports in nuxt.config a non-enumerable, self-referential `default` interop property. `klona/full` clones via `Object.getOwnPropertyNames`, follows that property and recurses until the stack overflows, so any config embedding a jiti-imported JSON module (e.g. a shared tsconfig preset passed to `nitro.typescript.tsConfig`) crashed `nuxt prepare` since the clone was introduced in #35729.

Plain `klona` copies only enumerable own properties, which is all the clone needs to protect layer configs from mutation, and matches the existing runtimeConfig clone in kit.

### 🔗 Linked issue

resolves #35913